### PR TITLE
feat(security): dashboard security hardening

### DIFF
--- a/src/pocketclaw/config.py
+++ b/src/pocketclaw/config.py
@@ -208,6 +208,13 @@ class Settings(BaseSettings):
     bypass_permissions: bool = Field(
         default=False, description="Skip permission prompts for agent actions (use with caution)"
     )
+    localhost_auth_bypass: bool = Field(
+        default=True,
+        description="Allow unauthenticated localhost access (disable for non-CF proxies)",
+    )
+    session_token_ttl_hours: int = Field(
+        default=24, description="TTL in hours for HMAC session tokens issued via /api/auth/session"
+    )
     file_jail_path: Path = Field(
         default_factory=Path.home, description="Root path for file operations"
     )
@@ -426,6 +433,8 @@ class Settings(BaseSettings):
             "injection_scan_enabled": self.injection_scan_enabled,
             "injection_scan_llm": self.injection_scan_llm,
             "injection_scan_llm_model": self.injection_scan_llm_model,
+            "localhost_auth_bypass": self.localhost_auth_bypass,
+            "session_token_ttl_hours": self.session_token_ttl_hours,
             # Smart routing
             "smart_routing_enabled": self.smart_routing_enabled,
             "model_tier_simple": self.model_tier_simple,

--- a/src/pocketclaw/frontend/js/websocket.js
+++ b/src/pocketclaw/frontend/js/websocket.js
@@ -29,12 +29,13 @@ class PocketPawSocket {
 
         this.isConnecting = true;
         const token = localStorage.getItem('pocketpaw_token');
-        let url = `ws://${window.location.host}/ws`;
+        const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        let url = `${wsProtocol}//${window.location.host}/ws`;
         const params = [];
         if (token) params.push(`token=${token}`);
         if (resumeSessionId) params.push(`resume_session=${resumeSessionId}`);
         if (params.length > 0) url += '?' + params.join('&');
-        console.log('[WS] Connecting to', `ws://${window.location.host}/ws...`);
+        console.log('[WS] Connecting to', `${wsProtocol}//${window.location.host}/ws...`);
 
         this.ws = new WebSocket(url);
 

--- a/src/pocketclaw/security/rate_limiter.py
+++ b/src/pocketclaw/security/rate_limiter.py
@@ -1,0 +1,84 @@
+"""In-memory token-bucket rate limiter for the web dashboard.
+
+Three pre-configured tiers:
+  - api:  10 req/s, burst 30  (general API endpoints)
+  - auth:  1 req/s, burst  5  (token/QR endpoints)
+  - ws:    2 conn/s, burst  5  (WebSocket connections)
+
+No external dependencies — pure stdlib.
+"""
+
+import time
+
+__all__ = [
+    "RateLimiter",
+    "api_limiter",
+    "auth_limiter",
+    "ws_limiter",
+    "cleanup_all",
+]
+
+
+class _Bucket:
+    """A single token bucket for one client."""
+
+    __slots__ = ("tokens", "last_refill")
+
+    def __init__(self, capacity: float, now: float):
+        self.tokens: float = capacity
+        self.last_refill: float = now
+
+
+class RateLimiter:
+    """Token-bucket rate limiter keyed by client identifier (IP address).
+
+    Parameters
+    ----------
+    rate : float
+        Tokens added per second.
+    capacity : int
+        Maximum burst size (bucket capacity).
+    """
+
+    def __init__(self, rate: float, capacity: int):
+        self.rate = rate
+        self.capacity = capacity
+        self._buckets: dict[str, _Bucket] = {}
+
+    def allow(self, key: str) -> bool:
+        """Return True if the request is allowed, consuming one token."""
+        now = time.monotonic()
+
+        if key not in self._buckets:
+            self._buckets[key] = _Bucket(self.capacity, now)
+
+        bucket = self._buckets[key]
+
+        # Refill tokens since last check
+        elapsed = now - bucket.last_refill
+        bucket.tokens = min(self.capacity, bucket.tokens + elapsed * self.rate)
+        bucket.last_refill = now
+
+        if bucket.tokens >= 1.0:
+            bucket.tokens -= 1.0
+            return True
+        return False
+
+    def cleanup(self, max_age: float = 3600.0) -> int:
+        """Remove stale entries older than *max_age* seconds. Returns count removed."""
+        now = time.monotonic()
+        stale = [k for k, b in self._buckets.items() if now - b.last_refill > max_age]
+        for k in stale:
+            del self._buckets[k]
+        return len(stale)
+
+
+# Pre-configured limiter instances
+api_limiter = RateLimiter(rate=10.0, capacity=30)
+auth_limiter = RateLimiter(rate=1.0, capacity=5)
+ws_limiter = RateLimiter(rate=2.0, capacity=5)
+
+
+def cleanup_all() -> int:
+    """Run cleanup on all global limiters. Returns total entries removed."""
+    return api_limiter.cleanup() + auth_limiter.cleanup() + ws_limiter.cleanup()

--- a/src/pocketclaw/security/session_tokens.py
+++ b/src/pocketclaw/security/session_tokens.py
@@ -1,0 +1,47 @@
+"""HMAC-based stateless session tokens with TTL.
+
+Token format: ``{expires_unix}:{hex_hmac}``
+
+The master access token is used as the HMAC key so that regenerating the
+master token instantly invalidates all outstanding session tokens — no
+server-side session store required.
+"""
+
+import hashlib
+import hmac
+import time
+
+__all__ = ["create_session_token", "verify_session_token"]
+
+
+def create_session_token(master_token: str, ttl_hours: int = 24) -> str:
+    """Issue a session token that expires after *ttl_hours*.
+
+    Returns a string of the form ``{expires_unix}:{hex_hmac}``.
+    """
+    expires = int(time.time()) + ttl_hours * 3600
+    sig = _sign(master_token, str(expires))
+    return f"{expires}:{sig}"
+
+
+def verify_session_token(token: str, master_token: str) -> bool:
+    """Verify a session token. Returns True if valid and not expired."""
+    parts = token.split(":", 1)
+    if len(parts) != 2:
+        return False
+
+    expires_str, sig = parts
+    try:
+        expires = int(expires_str)
+    except ValueError:
+        return False
+
+    if time.time() > expires:
+        return False
+
+    expected = _sign(master_token, expires_str)
+    return hmac.compare_digest(sig, expected)
+
+
+def _sign(key: str, message: str) -> str:
+    return hmac.new(key.encode(), message.encode(), hashlib.sha256).hexdigest()

--- a/tests/test_dashboard_security.py
+++ b/tests/test_dashboard_security.py
@@ -1,0 +1,311 @@
+"""Tests for dashboard security hardening.
+
+Covers:
+  - Tunnel auth bypass fix (_is_genuine_localhost)
+  - Rate limiting (burst, refill, 429 responses, per-IP isolation)
+  - Session tokens (create, verify, expired, tampered, master regen)
+  - Security headers
+  - CORS rejection of non-matching origins
+  - WebSocket tunnel auth
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pocketclaw.security.rate_limiter import RateLimiter
+from pocketclaw.security.session_tokens import create_session_token, verify_session_token
+
+
+class TestRateLimiter:
+    def test_allows_within_capacity(self):
+        rl = RateLimiter(rate=10.0, capacity=5)
+        for _ in range(5):
+            assert rl.allow("client1") is True
+
+    def test_rejects_over_capacity(self):
+        rl = RateLimiter(rate=10.0, capacity=3)
+        for _ in range(3):
+            rl.allow("client1")
+        assert rl.allow("client1") is False
+
+    def test_refills_over_time(self):
+        rl = RateLimiter(rate=1000.0, capacity=1)
+        assert rl.allow("a") is True
+        assert rl.allow("a") is False
+        # Simulate time passing by manipulating last_refill
+        rl._buckets["a"].last_refill -= 1.0  # 1 second ago
+        assert rl.allow("a") is True
+
+    def test_per_ip_isolation(self):
+        rl = RateLimiter(rate=10.0, capacity=1)
+        assert rl.allow("ip1") is True
+        assert rl.allow("ip1") is False
+        # Different IP still has tokens
+        assert rl.allow("ip2") is True
+
+    def test_cleanup_removes_stale(self):
+        rl = RateLimiter(rate=10.0, capacity=5)
+        rl.allow("old")
+        rl._buckets["old"].last_refill -= 7200  # 2 hours ago
+        rl.allow("recent")
+        removed = rl.cleanup(max_age=3600)
+        assert removed == 1
+        assert "old" not in rl._buckets
+        assert "recent" in rl._buckets
+
+    def test_cleanup_keeps_active(self):
+        rl = RateLimiter(rate=10.0, capacity=5)
+        rl.allow("active")
+        removed = rl.cleanup(max_age=3600)
+        assert removed == 0
+
+
+class TestSessionTokens:
+    def test_create_and_verify(self):
+        master = "test-master-token-1234"
+        token = create_session_token(master, ttl_hours=1)
+        assert ":" in token
+        assert verify_session_token(token, master) is True
+
+    def test_expired_token_rejected(self):
+        master = "test-master-token"
+        token = create_session_token(master, ttl_hours=1)  # noqa: F841
+        # Build an expired token with correct HMAC
+        expired_ts = str(int(time.time()) - 100)
+        # Re-sign with correct HMAC for the expired timestamp
+        from pocketclaw.security.session_tokens import _sign
+
+        sig = _sign(master, expired_ts)
+        expired_token = f"{expired_ts}:{sig}"
+        assert verify_session_token(expired_token, master) is False
+
+    def test_tampered_token_rejected(self):
+        master = "test-master-token"
+        token = create_session_token(master, ttl_hours=1)
+        # Tamper with the HMAC
+        parts = token.split(":", 1)
+        tampered = f"{parts[0]}:{'0' * 64}"
+        assert verify_session_token(tampered, master) is False
+
+    def test_wrong_master_rejects(self):
+        master = "original-master"
+        token = create_session_token(master, ttl_hours=1)
+        assert verify_session_token(token, "different-master") is False
+
+    def test_invalid_format_rejected(self):
+        assert verify_session_token("no-colon-here", "master") is False
+        assert verify_session_token("", "master") is False
+        assert verify_session_token("abc:def", "master") is False
+
+    def test_master_regeneration_invalidates(self):
+        master1 = "master-v1"
+        token = create_session_token(master1, ttl_hours=24)
+        assert verify_session_token(token, master1) is True
+        # After master regen, old session tokens are invalid
+        master2 = "master-v2"
+        assert verify_session_token(token, master2) is False
+
+
+# ---------------------------------------------------------------------------
+# _is_genuine_localhost tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsGenuineLocalhost:
+    """Test the _is_genuine_localhost helper function."""
+
+    def _make_request(self, host="127.0.0.1", headers=None):
+        """Create a mock request with given client host and headers."""
+        req = MagicMock()
+        req.client = MagicMock()
+        req.client.host = host
+        req.headers = headers or {}
+        return req
+
+    @patch("pocketclaw.dashboard.Settings")
+    @patch("pocketclaw.dashboard.get_tunnel_manager")
+    def test_genuine_localhost_no_tunnel(self, mock_tunnel_fn, mock_settings_cls):
+        from pocketclaw.dashboard import _is_genuine_localhost
+
+        settings = MagicMock()
+        settings.localhost_auth_bypass = True
+        mock_settings_cls.load.return_value = settings
+
+        tunnel = MagicMock()
+        tunnel.get_status.return_value = {"active": False}
+        mock_tunnel_fn.return_value = tunnel
+
+        req = self._make_request("127.0.0.1")
+        assert _is_genuine_localhost(req) is True
+
+    @patch("pocketclaw.dashboard.Settings")
+    @patch("pocketclaw.dashboard.get_tunnel_manager")
+    def test_tunneled_request_blocked(self, mock_tunnel_fn, mock_settings_cls):
+        from pocketclaw.dashboard import _is_genuine_localhost
+
+        settings = MagicMock()
+        settings.localhost_auth_bypass = True
+        mock_settings_cls.load.return_value = settings
+
+        tunnel = MagicMock()
+        tunnel.get_status.return_value = {"active": True}
+        mock_tunnel_fn.return_value = tunnel
+
+        # Request comes from localhost but has Cf-Connecting-Ip header (tunnel proxy)
+        req = self._make_request("127.0.0.1", headers={"cf-connecting-ip": "1.2.3.4"})
+        assert _is_genuine_localhost(req) is False
+
+    @patch("pocketclaw.dashboard.Settings")
+    @patch("pocketclaw.dashboard.get_tunnel_manager")
+    def test_tunneled_request_x_forwarded_for(self, mock_tunnel_fn, mock_settings_cls):
+        from pocketclaw.dashboard import _is_genuine_localhost
+
+        settings = MagicMock()
+        settings.localhost_auth_bypass = True
+        mock_settings_cls.load.return_value = settings
+
+        tunnel = MagicMock()
+        tunnel.get_status.return_value = {"active": True}
+        mock_tunnel_fn.return_value = tunnel
+
+        req = self._make_request("127.0.0.1", headers={"x-forwarded-for": "5.6.7.8"})
+        assert _is_genuine_localhost(req) is False
+
+    @patch("pocketclaw.dashboard.Settings")
+    @patch("pocketclaw.dashboard.get_tunnel_manager")
+    def test_genuine_localhost_with_active_tunnel_no_proxy_headers(
+        self, mock_tunnel_fn, mock_settings_cls
+    ):
+        """Genuine localhost browser while tunnel is active — no proxy headers."""
+        from pocketclaw.dashboard import _is_genuine_localhost
+
+        settings = MagicMock()
+        settings.localhost_auth_bypass = True
+        mock_settings_cls.load.return_value = settings
+
+        tunnel = MagicMock()
+        tunnel.get_status.return_value = {"active": True}
+        mock_tunnel_fn.return_value = tunnel
+
+        req = self._make_request("127.0.0.1", headers={})
+        assert _is_genuine_localhost(req) is True
+
+    @patch("pocketclaw.dashboard.Settings")
+    @patch("pocketclaw.dashboard.get_tunnel_manager")
+    def test_bypass_disabled(self, mock_tunnel_fn, mock_settings_cls):
+        from pocketclaw.dashboard import _is_genuine_localhost
+
+        settings = MagicMock()
+        settings.localhost_auth_bypass = False
+        mock_settings_cls.load.return_value = settings
+
+        req = self._make_request("127.0.0.1")
+        assert _is_genuine_localhost(req) is False
+
+    @patch("pocketclaw.dashboard.Settings")
+    @patch("pocketclaw.dashboard.get_tunnel_manager")
+    def test_non_localhost_rejected(self, mock_tunnel_fn, mock_settings_cls):
+        from pocketclaw.dashboard import _is_genuine_localhost
+
+        settings = MagicMock()
+        settings.localhost_auth_bypass = True
+        mock_settings_cls.load.return_value = settings
+
+        req = self._make_request("192.168.1.5")
+        assert _is_genuine_localhost(req) is False
+
+    @patch("pocketclaw.dashboard.Settings")
+    @patch("pocketclaw.dashboard.get_tunnel_manager")
+    def test_ipv6_localhost(self, mock_tunnel_fn, mock_settings_cls):
+        from pocketclaw.dashboard import _is_genuine_localhost
+
+        settings = MagicMock()
+        settings.localhost_auth_bypass = True
+        mock_settings_cls.load.return_value = settings
+
+        tunnel = MagicMock()
+        tunnel.get_status.return_value = {"active": False}
+        mock_tunnel_fn.return_value = tunnel
+
+        req = self._make_request("::1")
+        assert _is_genuine_localhost(req) is True
+
+
+# ---------------------------------------------------------------------------
+# Dashboard integration tests (auth middleware, headers, CORS, session exchange)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def test_client():
+    """Create a FastAPI TestClient for the dashboard app."""
+    from starlette.testclient import TestClient
+
+    from pocketclaw.dashboard import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestSecurityHeaders:
+    def test_headers_present(self, test_client):
+        resp = test_client.get("/")
+        assert resp.headers.get("X-Frame-Options") == "DENY"
+        assert resp.headers.get("X-Content-Type-Options") == "nosniff"
+        assert resp.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        assert "camera=()" in resp.headers.get("Permissions-Policy", "")
+        assert "default-src 'self'" in resp.headers.get("Content-Security-Policy", "")
+
+    def test_hsts_only_on_https(self, test_client):
+        # Regular HTTP request — no HSTS
+        resp = test_client.get("/")
+        assert "Strict-Transport-Security" not in resp.headers
+
+
+class TestSessionTokenEndpoint:
+    @patch("pocketclaw.dashboard.get_access_token", return_value="master-abc")
+    @patch("pocketclaw.dashboard.Settings")
+    @patch("pocketclaw.dashboard._is_genuine_localhost", return_value=True)
+    def test_exchange_valid_master(self, mock_local, mock_settings_cls, mock_token, test_client):
+        settings = MagicMock()
+        settings.session_token_ttl_hours = 24
+        mock_settings_cls.load.return_value = settings
+
+        resp = test_client.post(
+            "/api/auth/session",
+            headers={"Authorization": "Bearer master-abc"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "session_token" in data
+        assert ":" in data["session_token"]
+        assert data["expires_in_hours"] == 24
+
+    @patch("pocketclaw.dashboard.get_access_token", return_value="master-abc")
+    @patch("pocketclaw.dashboard._is_genuine_localhost", return_value=True)
+    def test_exchange_invalid_master(self, mock_local, mock_token, test_client):
+        resp = test_client.post(
+            "/api/auth/session",
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+        assert resp.status_code == 401
+
+
+class TestAuthMiddlewareSessionToken:
+    @patch("pocketclaw.dashboard.get_access_token", return_value="master-xyz")
+    @patch("pocketclaw.dashboard._is_genuine_localhost", return_value=False)
+    def test_session_token_accepted(self, mock_local, mock_token, test_client):
+        session = create_session_token("master-xyz", ttl_hours=1)
+        resp = test_client.get(
+            "/api/channels/status",
+            headers={"Authorization": f"Bearer {session}"},
+        )
+        # Should not be 401 (may be other status depending on channel state)
+        assert resp.status_code != 401
+
+    @patch("pocketclaw.dashboard.get_access_token", return_value="master-xyz")
+    @patch("pocketclaw.dashboard._is_genuine_localhost", return_value=False)
+    def test_no_token_rejected(self, mock_local, mock_token, test_client):
+        resp = test_client.get("/api/channels/status")
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary

- **Fix critical tunnel auth bypass (P0)**: Cloudflare-proxied requests via `localhost` no longer bypass authentication. New `_is_genuine_localhost()` helper detects proxy headers (`Cf-Connecting-Ip`, `X-Forwarded-For`) when the tunnel is active and rejects them. Configurable via `localhost_auth_bypass` setting.
- **Fix CORS (P1)**: Replace wildcard `allow_origins=["*"]` with regex matching only `localhost` and `*.trycloudflare.com` subdomains. Restrict allowed methods and headers.
- **Fix WebSocket protocol (P1)**: Auto-detect `wss://` vs `ws://` based on page protocol, fixing connections over HTTPS tunnels.
- **Add security headers (P2)**: New middleware adds `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Content-Security-Policy`, `Referrer-Policy`, `Permissions-Policy`, and `HSTS` (HTTPS only).
- **Add rate limiting (P2)**: Token-bucket rate limiter with 3 tiers (API: 10/s, Auth: 1/s, WS: 2/s). Returns 429 / WS close 4029 when exceeded. Hourly cleanup task.
- **Add HMAC session tokens (P3)**: Stateless `{expires}:{hmac_sha256}` tokens via `POST /api/auth/session`. Master token exchange on first visit; regenerating master invalidates all sessions.

## Test plan

- [x] `uv run pytest tests/test_dashboard_security.py -v` — 25 new tests all pass
- [x] `uv run pytest --ignore=tests/e2e` — 1167 passed, 2 pre-existing failures only
- [x] `uv run ruff check` — no new lint violations
- [x] Manual: start dashboard, confirm localhost works without token
- [x] Manual: start tunnel, confirm trycloudflare URL requires token on `/api/*`
- [x] Manual: confirm `wss://` connection over tunnel in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)