### PR TITLE
fix: make --version flag read dynamically from package metadata

### DIFF
--- a/src/pocketclaw/__main__.py
+++ b/src/pocketclaw/__main__.py
@@ -1,6 +1,7 @@
 """PocketPaw entry point.
 
 Changes:
+  - 2026-02-12: Fixed --version to read dynamically from package metadata.
   - 2026-02-06: Web dashboard is now the default mode (no flags needed).
   - 2026-02-06: Added --telegram flag for legacy Telegram-only mode.
   - 2026-02-06: Added --discord, --slack, --whatsapp CLI modes.
@@ -12,6 +13,7 @@ import argparse
 import asyncio
 import logging
 import webbrowser
+from importlib.metadata import version as get_version
 
 from pocketclaw.config import Settings, get_settings
 from pocketclaw.logging_setup import setup_logging
@@ -209,7 +211,9 @@ Examples:
     parser.add_argument(
         "--port", "-p", type=int, default=8888, help="Port for web server (default: 8888)"
     )
-    parser.add_argument("--version", "-v", action="version", version="%(prog)s 0.2.0")
+    parser.add_argument(
+        "--version", "-v", action="version", version=f"%(prog)s {get_version('pocketpaw')}"
+    )
 
     args = parser.parse_args()
     settings = get_settings()


### PR DESCRIPTION
## Summary

Fixes #35

The `--version` flag was hardcoded to `0.2.0`, but the actual version in `pyproject.toml` was `0.2.5`. This PR updates the version flag to read dynamically from package metadata using `importlib.metadata`.

## Changes

- Import `version` from `importlib.metadata` as `get_version`
- Update `--version` argument to use `get_version('pocketpaw')` instead of hardcoded string

## Testing

```bash
$ pocketpaw --version
pocketpaw 0.2.5
```

## Benefits

- Version only needs to be updated in one place (`pyproject.toml`)
- No more stale version strings in CLI output
- Follows Python packaging best practices