### PR TITLE
[FIRST]Implement keyboard shortcuts for the dashboard

### DIFF
--- a/src/pocketclaw/frontend/js/app.js
+++ b/src/pocketclaw/frontend/js/app.js
@@ -23,7 +23,8 @@ function app() {
         ...window.PocketPaw.Transparency.getState(),
         ...window.PocketPaw.RemoteAccess.getState(),
         ...window.PocketPaw.MissionControl.getState(),
-        ...window.PocketPaw.Channels.getState()
+        ...window.PocketPaw.Channels.getState(),
+        ...window.PocketPaw.KeyboardShortcuts.getState()
     };
 
     // Assemble feature methods
@@ -36,7 +37,8 @@ function app() {
         ...window.PocketPaw.Transparency.getMethods(),
         ...window.PocketPaw.RemoteAccess.getMethods(),
         ...window.PocketPaw.MissionControl.getMethods(),
-        ...window.PocketPaw.Channels.getMethods()
+        ...window.PocketPaw.Channels.getMethods(),
+        ...window.PocketPaw.KeyboardShortcuts.getMethods()
     };
 
     return {
@@ -121,6 +123,9 @@ function app() {
 
             // Register event handlers first
             this.setupSocketHandlers();
+
+            // Setup keyboard shortcuts
+            this.setupKeyboardShortcuts();
 
             // Connect WebSocket (singleton - will only connect once)
             socket.connect();

--- a/src/pocketclaw/frontend/js/features/keyboard-shortcuts.js
+++ b/src/pocketclaw/frontend/js/features/keyboard-shortcuts.js
@@ -1,0 +1,98 @@
+window.PocketPaw = window.PocketPaw || {};
+
+window.PocketPaw.KeyboardShortcuts = {
+    getState() {
+        return {
+            showKeyboardHelp: false
+        };
+    },
+
+    getMethods() {
+        return {
+            setupKeyboardShortcuts() {
+                window.addEventListener('keydown', (event) => this.handleKeyboardShortcut(event));
+            },
+
+            handleKeyboardShortcut(event) {
+                const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+                const isModifierPressed = isMac ? event.metaKey : event.ctrlKey;
+                const isTyping = this.isTypingContext();
+
+                if (event.key === 'Escape') {
+                    event.preventDefault();
+                    this.closeAnyModal();
+                    return;
+                }
+
+                if (isTyping && event.key !== 'Escape') {
+                    return;
+                }
+
+                if (isModifierPressed && event.key === 'k') {
+                    event.preventDefault();
+                    this.focusChatInput();
+                } else if (isModifierPressed && event.key === 'n') {
+                    event.preventDefault();
+                    this.newConversation();
+                } else if (isModifierPressed && event.key === ',') {
+                    event.preventDefault();
+                    this.showSettings = true;
+                } else if (isModifierPressed && event.key === '/') {
+                    event.preventDefault();
+                    this.toggleKeyboardHelp();
+                } else if (isModifierPressed && event.shiftKey && event.key === 'A') {
+                    event.preventDefault();
+                    this.view = 'activity';
+                }
+            },
+
+            isTypingContext() {
+                const activeElement = document.activeElement;
+                return activeElement.tagName === 'INPUT' || 
+                       activeElement.tagName === 'TEXTAREA' ||
+                       activeElement.isContentEditable;
+            },
+
+            getModifierKey() {
+                const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+                return isMac ? '⌘' : 'Ctrl';
+            },
+
+            toggleKeyboardHelp() {
+                this.showKeyboardHelp = !this.showKeyboardHelp;
+            },
+
+            focusChatInput() {
+                const chatInput = document.getElementById('chatInput');
+                if (chatInput) {
+                    chatInput.focus();
+                    chatInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
+            },
+
+            newConversation() {
+                this.messages = [];
+                this.isStreaming = false;
+                this.streamingContent = '';
+                this.streamingMessageId = null;
+                this.log('Started new conversation', 'info');
+                this.showToast('New conversation started', 'success');
+            },
+
+            closeAnyModal() {
+                this.showSettings = false;
+                this.showKeyboardHelp = false;
+                this.showFileBrowser = false;
+                this.showReminders = false;
+                this.showIntentions = false;
+                this.showSkills = false;
+                this.showIdentity = false;
+                this.showMemory = false;
+                this.showAudit = false;
+                this.showRemote = false;
+                this.showChannels = false;
+                this.showScreenshot = false;
+            }
+        };
+    }
+};

--- a/src/pocketclaw/frontend/templates/base.html
+++ b/src/pocketclaw/frontend/templates/base.html
@@ -179,6 +179,7 @@
     <script src="/static/js/features/remote-access.js"></script>
     <script src="/static/js/features/mission-control.js"></script>
     <script src="/static/js/features/channels.js"></script>
+    <script src="/static/js/features/keyboard-shortcuts.js"></script>
     <!-- Main app (assembles features) -->
     <script src="/static/js/app.js"></script>
 

--- a/src/pocketclaw/frontend/templates/components/chat.html
+++ b/src/pocketclaw/frontend/templates/components/chat.html
@@ -50,6 +50,7 @@
 <div class="absolute bottom-4 left-3 right-3 md:bottom-8 md:left-[10%] md:right-[10%] z-20">
     <form class="relative flex items-center bg-[#2c2c2e]/90 backdrop-blur-xl border border-[var(--glass-border)] rounded-[24px] shadow-2xl transition-all focus-within:ring-1 focus-within:ring-white/20 focus-within:bg-[#323234]" @submit.prevent="sendMessage()">
     <input
+        id="chatInput"
         type="text"
         class="w-full bg-transparent border-none text-[15px] text-white placeholder-white/30 px-5 py-4 pr-14 rounded-[24px] focus:outline-none focus:ring-0"
         placeholder="Type a message..."

--- a/src/pocketclaw/frontend/templates/components/modals.html
+++ b/src/pocketclaw/frontend/templates/components/modals.html
@@ -20,3 +20,4 @@
 {% include "components/modals/audit.html" %}
 {% include "components/modals/remote.html" %}
 {% include "components/modals/channels.html" %}
+{% include "components/modals/keyboard-shortcuts.html" %}

--- a/src/pocketclaw/frontend/templates/components/modals/keyboard-shortcuts.html
+++ b/src/pocketclaw/frontend/templates/components/modals/keyboard-shortcuts.html
@@ -1,0 +1,93 @@
+<!-- Keyboard Shortcuts Help Modal -->
+<div
+class="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 backdrop-blur-md p-4"
+x-show="showKeyboardHelp"
+x-transition.opacity
+@click.self="showKeyboardHelp = false"
+>
+<div class="w-full max-w-[550px] bg-[#1c1c1e]/95 backdrop-blur-xl border border-[var(--glass-border)] rounded-[20px] shadow-2xl animate-[modalPop_0.25s_ease-out] overflow-hidden" @click.stop>
+    <div class="flex items-center justify-between px-6 py-5 border-b border-[var(--glass-border)]">
+    <h2 class="text-[17px] font-semibold">Keyboard Shortcuts</h2>
+    <button class="p-2 -mr-2 text-[var(--text-secondary)] hover:text-white hover:bg-white/10 rounded-lg transition-colors" @click="showKeyboardHelp = false">
+        <i data-lucide="x" class="w-5 h-5"></i>
+    </button>
+    </div>
+    
+    <div class="p-6 space-y-6">
+    <!-- General Section -->
+    <div>
+        <h3 class="text-[13px] font-semibold text-[var(--text-secondary)] mb-3 uppercase tracking-wide">General</h3>
+        <div class="space-y-2">
+        <div class="flex items-center justify-between py-2">
+            <span class="text-[14px] text-white/90">Focus chat input</span>
+            <div class="flex items-center gap-1">
+            <kbd class="px-2 py-1 bg-black/40 border border-white/10 rounded text-[12px] font-medium text-white/80" x-text="getModifierKey()"></kbd>
+            <span class="text-white/40">+</span>
+            <kbd class="px-2 py-1 bg-black/40 border border-white/10 rounded text-[12px] font-medium text-white/80">K</kbd>
+            </div>
+        </div>
+        <div class="flex items-center justify-between py-2">
+            <span class="text-[14px] text-white/90">New conversation</span>
+            <div class="flex items-center gap-1">
+            <kbd class="px-2 py-1 bg-black/40 border border-white/10 rounded text-[12px] font-medium text-white/80" x-text="getModifierKey()"></kbd>
+            <span class="text-white/40">+</span>
+            <kbd class="px-2 py-1 bg-black/40 border border-white/10 rounded text-[12px] font-medium text-white/80">N</kbd>
+            </div>
+        </div>
+        <div class="flex items-center justify-between py-2">
+            <span class="text-[14px] text-white/90">Settings</span>
+            <div class="flex items-center gap-1">
+            <kbd class="px-2 py-1 bg-black/40 border border-white/10 rounded text-[12px] font-medium text-white/80" x-text="getModifierKey()"></kbd>
+            <span class="text-white/40">+</span>
+            <kbd class="px-2 py-1 bg-black/40 border border-white/10 rounded text-[12px] font-medium text-white/80">,</kbd>
+            </div>
+        </div>
+        <div class="flex items-center justify-between py-2">
+            <span class="text-[14px] text-white/90">Show this help</span>
+            <div class="flex items-center gap-1">
+            <kbd class="px-2 py-1 bg-black/40 border border-white/10 rounded text-[12px] font-medium text-white/80" x-text="getModifierKey()"></kbd>
+            <span class="text-white/40">+</span>
+            <kbd class="px-2 py-1 bg-black/40 border border-white/10 rounded text-[12px] font-medium text-white/80">/</kbd>
+            </div>
+        </div>
+        </div>
+    </div>
+
+    <!-- Navigation Section -->
+    <div>
+        <h3 class="text-[13px] font-semibold text-[var(--text-secondary)] mb-3 uppercase tracking-wide">Navigation</h3>
+        <div class="space-y-2">
+        <div class="flex items-center justify-between py-2">
+            <span class="text-[14px] text-white/90">Toggle activity panel</span>
+            <div class="flex items-center gap-1">
+            <kbd class="px-2 py-1 bg-black/40 border border-white/10 rounded text-[12px] font-medium text-white/80" x-text="getModifierKey()"></kbd>
+            <span class="text-white/40">+</span>
+            <kbd class="px-2 py-1 bg-black/40 border border-white/10 rounded text-[12px] font-medium text-white/80">Shift</kbd>
+            <span class="text-white/40">+</span>
+            <kbd class="px-2 py-1 bg-black/40 border border-white/10 rounded text-[12px] font-medium text-white/80">A</kbd>
+            </div>
+        </div>
+        </div>
+    </div>
+
+    <!-- Other Section -->
+    <div>
+        <h3 class="text-[13px] font-semibold text-[var(--text-secondary)] mb-3 uppercase tracking-wide">Other</h3>
+        <div class="space-y-2">
+        <div class="flex items-center justify-between py-2">
+            <span class="text-[14px] text-white/90">Close modal</span>
+            <kbd class="px-3 py-1 bg-black/40 border border-white/10 rounded text-[12px] font-medium text-white/80">Escape</kbd>
+        </div>
+        </div>
+    </div>
+
+    <!-- Footer tip -->
+    <div class="pt-4 border-t border-white/5">
+        <p class="text-[12px] text-white/40 text-center">
+        <i data-lucide="info" class="w-3 h-3 inline-block align-middle mr-1"></i>
+        Shortcuts are disabled while typing in input fields
+        </p>
+    </div>
+    </div>
+</div>
+</div>


### PR DESCRIPTION
-Implemented global keyboard shortcuts:

1. Ctrl/Cmd + K — Focus chat input / command palette
2. Ctrl/Cmd + N — New conversation
3. Ctrl/Cmd + , — Open settings
4. Ctrl/Cmd + / — Show shortcuts help
5. Escape — Close modal/sheet
6. Ctrl/Cmd + Shift + A — Toggle activity panel