### PR TITLE
[FIRST] Add session export functionality (JSON & Markdown)

### DIFF
--- a/src/pocketclaw/frontend/templates/components/chat.html
+++ b/src/pocketclaw/frontend/templates/components/chat.html
@@ -19,6 +19,7 @@
 -->
 <!-- Chat View -->
 <!-- Added explicit min-height-0 to allow flex child to shrink properly -->
+<!-- Chat View -->
 <div
   class="flex-1 flex flex-col pt-16 md:pt-20 overflow-hidden min-h-0"
   x-show="view === 'chat'"
@@ -28,7 +29,6 @@
     x-ref="messages"
   >
     <template x-for="(msg, index) in messages" :key="index">
-      <!-- Message Item -->
       <div
         class="flex flex-col gap-1 max-w-[85%] md:max-w-[70%] min-w-0"
         :class="[msg.role === 'user' ? 'self-end items-end' : 'self-start items-start', msg.isNew === true ? 'animate-[messageSlide_0.3s_ease-out]' : '']"
@@ -79,10 +79,9 @@
         <span class="animate-pulse font-bold" aria-label="Streaming in progress">▌</span>
       </div>
       <div class="flex gap-2 items-center px-1 opacity-70">
-        <span
-          class="text-[11px] md:text-xs font-semibold text-[var(--text-secondary)]"
-          >PocketPaw</span
-        >
+        <span class="text-[11px] md:text-xs font-semibold text-[var(--text-secondary)]">
+          PocketPaw
+        </span>
         <span
           class="text-[10px] md:text-[11px] text-[var(--text-tertiary)]"
           x-text="currentTime()"
@@ -91,15 +90,47 @@
     </div>
   </div>
 
-  <!-- Input Area — flex child, gradient fade, safe-area inset -->
+  <!-- Input Area -->
   <div class="shrink-0 relative z-20">
     <div class="absolute inset-x-0 -top-8 h-8 bg-gradient-to-t from-black to-transparent pointer-events-none"></div>
-    <div class="bg-black px-3 md:px-8 pb-2 md:pb-4 pt-1" style="padding-bottom: max(0.5rem, env(safe-area-inset-bottom))">
+
+    <!-- Added relative here for export positioning -->
+    <div
+      class="bg-black px-3 md:px-8 pb-2 md:pb-4 pt-1 relative"
+      style="padding-bottom: max(0.5rem, env(safe-area-inset-bottom))"
+    >
+
+      <!--  Export Buttons  -->
+      <div
+        class="absolute right-3 md:right-8 -top-10 flex items-center gap-2"
+        x-show="currentSessionId && !isStreaming"
+      >
+        <button
+          type="button"
+          class="text-xs px-3 py-1.5 rounded-full bg-[var(--card-bg)] border border-[var(--glass-border)] hover:bg-white/5 transition"
+          @click="exportSession('md')"
+          aria-label="Export session as Markdown"
+        >
+          Export MD
+        </button>
+
+        <button
+          type="button"
+          class="text-xs px-3 py-1.5 rounded-full bg-[var(--card-bg)] border border-[var(--glass-border)] hover:bg-white/5 transition"
+          @click="exportSession('json')"
+          aria-label="Export session as JSON"
+        >
+          Export JSON
+        </button>
+      </div>
+
+      <!-- EXISTING FORM  -->
       <form
         class="relative flex items-center bg-[#2c2c2e]/90 backdrop-blur-xl border border-[var(--glass-border)] rounded-[24px] shadow-2xl transition-all focus-within:ring-1 focus-within:ring-white/20 focus-within:bg-[#323234]"
         @submit.prevent="sendMessage()"
       >
-        <!-- Agent Mode Toggle (inside pill) -->
+
+        <!-- Agent Mode Toggle -->
         <label class="relative w-[36px] h-[20px] cursor-pointer ml-4 shrink-0" aria-label="Agent mode">
           <input
             type="checkbox"
@@ -114,6 +145,7 @@
             class="absolute left-0.5 top-0.5 w-[16px] h-[16px] bg-white rounded-full shadow-[0_1px_3px_rgba(0,0,0,0.2)] transition-transform duration-300 peer-checked:translate-x-[16px]"
           ></span>
         </label>
+
         <div class="w-px h-5 bg-white/10 mx-2 shrink-0"></div>
 
         <input
@@ -124,6 +156,7 @@
           :disabled="isStreaming"
           aria-label="Chat message input"
         />
+
         <button
           type="submit"
           class="absolute right-2 top-1/2 -translate-y-1/2 w-8 h-8 md:w-9 md:h-9 bg-[var(--accent-color)] hover:bg-[var(--accent-hover)] text-white rounded-full flex items-center justify-center transition-all disabled:opacity-50 disabled:cursor-not-allowed shadow-lg hover:shadow-[0_0_15px_rgba(10,132,255,0.4)] hover:scale-105 active:scale-95"


### PR DESCRIPTION
🚀 [FIRST] Add Session Export Feature

Overview

This PR adds export functionality for conversation sessions, allowing users to download their chat history in JSON or Markdown format.

What’s Included
Backend

Added GET /api/sessions/{session_id}/export

Supports:

?format=json → Full session data with metadata

?format=md → Clean transcript (user/assistant only)

Sets Content-Disposition: attachment for browser download

Frontend

Added Export buttons in chat UI

Implemented exportSession() in sessions.js

Handles file download via Blob API

Why This Matters

Users can now:

Backup their sessions

Share conversations

Analyze chat logs externally

Closes #37 