### PR TITLE
fix: resolve NameError in auto-learn, broken settings reload, and pla…

### DIFF
--- a/src/pocketclaw/agents/loop.py
+++ b/src/pocketclaw/agents/loop.py
@@ -400,7 +400,7 @@ class AgentLoop:
                     self.settings.memory_backend == "mem0" and self.settings.mem0_auto_learn
                 ) or (self.settings.memory_backend == "file" and self.settings.file_auto_learn)
                 if should_auto_learn:
-                    asyncio.create_task(
+                    t = asyncio.create_task(
                         self._auto_learn(
                             message.content,
                             full_response,


### PR DESCRIPTION
…intext secret leakage

- agents/loop.py: assign create_task() return to variable 't' — previously caused NameError on every auto-learn call, silently breaking memory learning
- config.py: replace @lru_cache with manual cache for get_settings() — force_reload=True was broken because lru_cache cached (True,) and (False,) as separate keys, so subsequent get_settings() still returned stale values
- config.py: strip plaintext secrets from config.json after migrating them to the encrypted credential store — previously left API keys in cleartext