### PR TITLE
fix: resolve session lock TOCTOU race and register injection scanner …

### DIFF
--- a/src/pocketclaw/security/injection_scanner.py
+++ b/src/pocketclaw/security/injection_scanner.py
@@ -246,4 +246,12 @@ def get_injection_scanner() -> InjectionScanner:
     global _scanner
     if _scanner is None:
         _scanner = InjectionScanner()
+
+        from pocketclaw.lifecycle import register
+
+        def _reset() -> None:
+            global _scanner
+            _scanner = None
+
+        register("injection_scanner", reset=_reset)
     return _scanner


### PR DESCRIPTION
…lifecycle

- agents/loop.py: replace check-then-create pattern with dict.setdefault() for atomic session lock creation — prevents duplicate locks when two coroutines process messages for the same session simultaneously. Also removes racy lock cleanup that could delete a lock while another coroutine was about to acquire it.
- security/injection_scanner.py: register InjectionScanner singleton with the lifecycle system so it properly resets during tests and hot-reloads, consistent with every other singleton (MessageBus, ReminderScheduler, TunnelManager, AnalyticsCollector).