### PR TITLE
[FIRST] Issue #104 : Add loading screen to prevent flash-of-unstyled-content

### DIFF
--- a/src/pocketclaw/frontend/css/styles.css
+++ b/src/pocketclaw/frontend/css/styles.css
@@ -7,6 +7,65 @@
    - Cleaned up redundant custom classes.
    ===================================================== */
 
+/* =====================================================
+   Loading Screen (prevents FOUC)
+   ===================================================== */
+.paw-content { 
+  opacity: 0; 
+  transition: opacity 0.25s ease-in-out;
+  display: flex;
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+body.ready .paw-content { opacity: 1; }
+body.ready #paw-loader { opacity: 0; pointer-events: none; }
+
+#paw-loader {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at 50% 30%, #1C1C1E 0%, #000000 100%);
+  transition: opacity 0.3s ease-out;
+}
+
+.paw-spinner {
+  width: 48px;
+  height: 48px;
+  position: relative;
+  animation: paw-pulse 1.4s ease-in-out infinite;
+}
+.paw-spinner svg {
+  width: 100%;
+  height: 100%;
+}
+@keyframes paw-pulse {
+  0%,
+    100% {
+      transform: scale(1);
+      opacity: 0.8;
+    }
+  
+    50% {
+      transform: scale(1.1);
+      opacity: 1;
+    }
+}
+
+.paw-loader-text {
+  margin-top: 16px;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: rgba(235, 235, 245, 0.6);
+  letter-spacing: 0.02em;
+}
+
 :root {
   /* Apple-inspired Dark Palette (Used by UnoCSS variables and remaining custom CSS) */
   --bg-color: #000000;

--- a/src/pocketclaw/frontend/templates/base.html
+++ b/src/pocketclaw/frontend/templates/base.html
@@ -30,6 +30,9 @@
       rel="icon"
       href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='15' fill='%230A84FF'/><g transform='translate(4,4)' fill='none' stroke='%23fff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><circle cx='11' cy='4' r='2'/><circle cx='3' cy='7' r='2'/><circle cx='19' cy='7' r='2'/><circle cx='7' cy='19' r='2'/><circle cx='15' cy='19' r='2'/><path d='M8 14v.5a2 2 0 0 0 2 2h2a2 2 0 0 0 2-2V14a4 4 0 0 0-6 0z'/></g></svg>"
     />
+    
+    <!-- Critical: dark background to prevent white flash before CSS loads -->
+    <style>html,body{background:#000}</style>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
@@ -74,6 +77,27 @@
   </head>
   <body x-data="{ ...app(), sidebarOpen: false }" x-init="init()" class="flex h-screen overflow-hidden bg-[var(--bg-color)] text-[var(--text-primary)]">
     
+    <!-- Loading Screen (prevents FOUC) -->
+    <div id="paw-loader">
+      <div class="paw-spinner">
+        <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="16" cy="16" r="15" fill="#0A84FF"/>
+          <g transform="translate(4,4)" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="4" r="2"/>
+            <circle cx="3" cy="7" r="2"/>
+            <circle cx="19" cy="7" r="2"/>
+            <circle cx="7" cy="19" r="2"/>
+            <circle cx="15" cy="19" r="2"/>
+            <path d="M8 14v.5a2 2 0 0 0 2 2h2a2 2 0 0 0 2-2V14a4 4 0 0 0-6 0z"/>
+          </g>
+        </svg>
+      </div>
+      <div class="paw-loader-text">Loading PocketPaw...</div>
+    </div>
+    
+    <!-- Main App Content (hidden until ready) -->
+    <div class="paw-content">
+
     <!-- Mobile Sidebar Overlay -->
     <div 
         x-show="sidebarOpen" 
@@ -184,6 +208,8 @@
 
     <!-- Toast Container -->
     <div class="toast-container" x-ref="toasts"></div>
+    
+    </div><!-- /paw-content -->
 
     <!-- Scripts (cache-busted via ?v= hash) -->
     <script src="/static/js/state.js?v={{ v }}"></script>
@@ -208,11 +234,20 @@
     <!-- Main app (assembles features) -->
     <script src="/static/js/app.js?v={{ v }}"></script>
 
-    <!-- Initialize Lucide icons -->
+    <!-- Initialize Lucide icons and hide loader -->
     <script>
-      // Initial render
+      // Initial render and hide loader
       document.addEventListener('DOMContentLoaded', () => {
         lucide.createIcons();
+        
+        // Show content and hide loader via CSS transition
+        document.body.classList.add('ready');
+        
+        // Remove loader from DOM after transition completes
+        setTimeout(() => {
+          const loader = document.getElementById('paw-loader');
+          if (loader) loader.remove();
+        }, 350);
       });
 
       // Debounced refresh for dynamic content

--- a/src/pocketclaw/frontend/templates/components/chat.html
+++ b/src/pocketclaw/frontend/templates/components/chat.html
@@ -27,6 +27,21 @@
     class="messages flex-1 flex flex-col gap-2.5 overflow-y-auto p-4 md:p-8 pb-8 min-h-0"
     x-ref="messages"
   >
+    <!-- Empty state: welcome message for new chats with no history -->
+    <div
+      x-show="messages.length === 0 && !isStreaming"
+      class="flex-1 flex items-center justify-center text-center text-[var(--text-secondary)] px-4"
+    >
+      <div class="max-w-md space-y-1.5">
+        <div class="text-sm md:text-base font-semibold">
+          Welcome to PocketPaw
+        </div>
+        <div class="text-xs md:text-sm text-[var(--text-tertiary)]">
+          This is a new chat. Ask your first question to get started.
+        </div>
+      </div>
+    </div>
+
     <template x-for="(msg, index) in messages" :key="index">
       <!-- Message Item -->
       <div

--- a/src/pocketclaw/frontend/templates/components/sidebar.html
+++ b/src/pocketclaw/frontend/templates/components/sidebar.html
@@ -353,7 +353,7 @@
         <button class="flex items-center gap-2 px-2 py-1.5 rounded-lg text-xs text-white/60 hover:text-white hover:bg-white/5 transition-colors" @click="openSettings(); sidebarOpen = false">
           <i data-lucide="settings" class="w-3.5 h-3.5"></i> Settings
         </button>
-        <button class="flex items-center gap-2 px-2 py-1.5 rounded-lg text-xs text-[var(--danger-color)] hover:bg-[var(--danger-color)]/10 transition-colors" @click="runTool('panic'); sidebarOpen = false">
+        <button class="flex items-center gap-2 px-2 py-1.5 rounded-lg text-xs text-[var(--danger-color)] hover:text-black hover:bg-[var(--danger-color)]/10 transition-colors" @click="runTool('panic'); sidebarOpen = false">
           <i data-lucide="octagon-x" class="w-3.5 h-3.5"></i> Panic
         </button>
       </div>

--- a/uv.lock
+++ b/uv.lock
@@ -2820,7 +2820,7 @@ wheels = [
 
 [[package]]
 name = "pocketpaw"
-version = "0.2.5"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION

### **Summary**

Add a themed loading overlay to prevent flash-of-unstyled-content (FOUC) and improve first-render UX.

### **Reasons**

On page refresh the UI briefly showed a white/unstyled flash before CSS/JS finished loading. This patch ensures a smooth dark-themed startup and provides a friendly empty-chat state.

### **Changes**

- Added loading-screen styles and animations (style.css).
- Injected critical inline background, loader markup, and DOM logic to reveal content after resources load (base.html).
- Added an empty-state welcome message for new chats (chat.html).
- Improved panic button hover contrast in the sidebar (sidebar.html).

<img width="1470" height="956" alt="Screenshot 2026-02-14 at 2 13 20 PM" src="https://github.com/user-attachments/assets/4c9d8017-473c-4585-836a-7b64820a72c1" />
