### PR TITLE
[FIRST] Add ChatAction.TYPING support to Telegram adapter

### DIFF
--- a/src/pocketpaw/bus/adapters/telegram_adapter.py
+++ b/src/pocketpaw/bus/adapters/telegram_adapter.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any
 
 try:
-    from telegram import Update
+    from telegram import Update, ChatAction
     from telegram.ext import (
         Application,
         CommandHandler,
@@ -219,7 +219,9 @@ class TelegramAdapter(BaseChannelAdapter):
 
         if chat_id not in self._buffers:
             # Send initial message (topic-aware)
-            real_chat_id, topic_id = self._parse_chat_id(chat_id)
+            real_chat_id, topic_id = self._parse_chat_id(chat_id) # Parse chat_id here to use for send_chat_action
+            await self.app.bot.send_chat_action(chat_id=real_chat_id, action=ChatAction.TYPING)
+            # Send initial message (topic-aware)
             send_kwargs: dict[str, Any] = {"chat_id": real_chat_id, "text": "🧠 ..."}
             if topic_id is not None:
                 send_kwargs["message_thread_id"] = topic_id


### PR DESCRIPTION

Added "ChatAction.TYPING" support to the Telegram Adapter to improve UX during streamed responses.

# Changes
* Sends typing indicator before first streamed chunk.
* Keeps buffered message updates.
* Preserves topic-aware chat handling.

This improves responsiveness perception for Telegram users.