### PR TITLE
docs: add troubleshooting guide and link from installation

### DIFF
--- a/documentation/guides/installation.md
+++ b/documentation/guides/installation.md
@@ -75,4 +75,4 @@ No sudo required on macOS. On Linux, system package installs (apt/dnf) may promp
 
 ## Common Issues
 
-For detailed solutions, see the Troubleshooting Guide.
+For detailed solutions, see the [Troubleshooting Guide](troubleshooting.md).

--- a/documentation/guides/troubleshooting.md
+++ b/documentation/guides/troubleshooting.md
@@ -1,4 +1,4 @@
-# Troubleshooting Guide
+# 🛠 Troubleshooting Guide
 
 This guide addresses common installation and runtime issues encountered while setting up and running PocketPaw.
 
@@ -8,46 +8,73 @@ This guide addresses common installation and runtime issues encountered while se
 
 If you see output like:
 
+```text
 🌐 Open http://127.0.0.1:8888 in your browser
+```
 
 But the dashboard does not load:
 
-### Check the following:
+### ✅ Check the Following
 
 1. Ensure you are visiting the exact URL shown in the terminal.
 2. If running with:
-   pocketpaw --host 0.0.0.0
 
-   Access using:
-   http://localhost:8888
-   or
-   http://<your-local-ip>:8888
+```bash
+pocketpaw --host 0.0.0.0
+```
+
+Access using:
+
+```text
+http://localhost:8888
+```
+
+or
+
+```text
+http://<your-local-ip>:8888
+```
 
 3. Confirm no firewall or antivirus is blocking the port.
 4. If using Docker, ensure ports are mapped correctly:
-   docker run -p 8888:8888 pocketpaw
+
+```bash
+docker run -p 8888:8888 pocketpaw
+```
 
 ---
 
 ## 2. Address Already in Use
 
 Error example:
+
+```text
 OSError: [Errno 98] Address already in use
+```
 
 This means another application is already using the selected port.
 
-### Solution:
+### ✅ Solution
 
 Run on a different port:
+
+```bash
 pocketpaw --port 8890
+```
 
 Or find the process using the port:
 
-macOS / Linux:
-lsof -i :8888
+**macOS / Linux**
 
-Windows:
+```bash
+lsof -i :8888
+```
+
+**Windows**
+
+```powershell
 netstat -ano | findstr :8888
+```
 
 Terminate the process or choose another port.
 
@@ -56,20 +83,32 @@ Terminate the process or choose another port.
 ## 3. Missing Environment Variables
 
 Error example:
-ValueError: Missing required environment variable: POCKETPAW_OPENAI_API_KEY
 
-### Solution:
+```text
+ValueError: Missing required environment variable: POCKETPAW_OPENAI_API_KEY
+```
+
+### ✅ Solution
 
 Set required environment variables before running the application.
 
-Windows (CMD):
+**Windows (CMD)**
+
+```cmd
 set POCKETPAW_OPENAI_API_KEY=your_key_here
+```
 
-Windows (PowerShell):
+**Windows (PowerShell)**
+
+```powershell
 $env:POCKETPAW_OPENAI_API_KEY="your_key_here"
+```
 
-macOS / Linux:
+**macOS / Linux**
+
+```bash
 export POCKETPAW_OPENAI_API_KEY=your_key_here
+```
 
 Restart the terminal after setting variables.
 
@@ -78,32 +117,70 @@ Restart the terminal after setting variables.
 ## 4. Headless Server Binding to 0.0.0.0
 
 If you see:
+
+```text
 Headless server detected — binding to 0.0.0.0
+```
 
 This means the server is accessible on all network interfaces.
 
 Access the app using:
+
+```text
 http://localhost:8888
+```
+
 or
+
+```text
 http://<your-machine-ip>:8888
+```
 
 If you want local-only access:
+
+```bash
 pocketpaw --host 127.0.0.1
+```
 
 ---
 
 ## 5. Python Version Issues
 
-Check version:
+PocketPaw requires **Python 3.11 or higher**.
+
+### 🔎 Check Your Version
+
+```bash
 python --version
+```
 
-Ensure Python 3.x is installed.
+or
 
-If dependencies fail to install, recreate your virtual environment:
+```bash
+python3 --version
+```
 
-python -m venv venv
-source venv/bin/activate  (macOS/Linux)
-venv\Scripts\activate     (Windows)
+If your version is below 3.11, install Python 3.11+ from:
+
+https://www.python.org/downloads/
+
+### 🔄 Recreate Virtual Environment (If Dependencies Fail)
+
+```bash
+python -m venv .venv
+```
+
+**macOS / Linux**
+
+```bash
+source .venv/bin/activate
+```
+
+**Windows**
+
+```powershell
+.venv\Scripts\Activate.ps1
+```
 
 Then reinstall dependencies.
 
@@ -112,26 +189,41 @@ Then reinstall dependencies.
 ## 6. uv Command Not Found
 
 Error:
+
+```text
 uv: command not found
+```
 
-Install uv:
-pip install uv
+### ✅ Official Installation (Recommended)
 
-Verify:
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Restart your terminal and verify:
+
+```bash
 uv --version
+```
 
-If still not recognized, ensure your Python Scripts directory is added to your system PATH.
+### ⚠ Alternative (Works but Not Official)
+
+```bash
+pip install uv
+```
+
+If still not recognized, ensure your Python Scripts directory is added to your system `PATH`.
 
 ---
 
-## Reporting Issues
+## 📌 Reporting Issues
 
 If problems persist, open a GitHub issue and include:
 
 - Operating system
-- Python version
+- Python version (exact version, must be 3.11+)
 - Exact command used to start PocketPaw
-- Full error message
-- Screenshot or terminal logs
+- Full error message (copy-paste preferred)
+- Screenshot or terminal logs (if applicable)
 
 Providing complete information helps maintainers reproduce and resolve the issue efficiently.


### PR DESCRIPTION
This PR introduces a new troubleshooting guide under documentation/guides/.

The guide covers common installation and runtime issues including:

- Port conflicts
- Missing environment variables
- Python version issues
- uv not installed
- Docker port binding
- Dashboard accessibility issues

Additionally, a link to the troubleshooting guide has been added
to installation.md for better discoverability.

This improves developer onboarding and documentation clarity.
