### PR TITLE
feat: startup version check + dashboard update notice

### DIFF
--- a/src/pocketpaw/__main__.py
+++ b/src/pocketpaw/__main__.py
@@ -1,6 +1,7 @@
 """PocketPaw entry point.
 
 Changes:
+  - 2026-02-16: Add startup version check against PyPI (cached daily, silent on error).
   - 2026-02-14: Dashboard deps moved to core — `pip install pocketpaw` just works.
   - 2026-02-12: Fixed --version to read dynamically from package metadata.
   - 2026-02-06: Web dashboard is now the default mode (no flags needed).
@@ -563,6 +564,14 @@ Examples:
     _check_extras_installed(args)
 
     settings = get_settings()
+
+    # Check for updates (cached daily, silent on error)
+    from pocketpaw.config import get_config_dir
+    from pocketpaw.update_check import check_for_updates, print_update_notice
+
+    update_info = check_for_updates(get_version("pocketpaw"), get_config_dir())
+    if update_info and update_info.get("update_available"):
+        print_update_notice(update_info)
 
     # Resolve host: explicit flag > config > auto-detect
     if args.host is not None:

--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -1618,10 +1618,28 @@ def _static_version() -> str:
     return hashlib.md5("|".join(mtimes).encode()).hexdigest()[:8]
 
 
+@app.get("/api/version")
+async def get_version_info():
+    """Return current version and update availability."""
+    from importlib.metadata import version as get_version
+
+    from pocketpaw.config import get_config_dir
+    from pocketpaw.update_check import check_for_updates
+
+    current = get_version("pocketpaw")
+    info = check_for_updates(current, get_config_dir())
+    return info or {"current": current, "latest": current, "update_available": False}
+
+
 @app.get("/")
 async def index(request: Request):
     """Serve the main dashboard page."""
-    return templates.TemplateResponse("base.html", {"request": request, "v": _static_version()})
+    from importlib.metadata import version as get_version
+
+    return templates.TemplateResponse(
+        "base.html",
+        {"request": request, "v": _static_version(), "app_version": get_version("pocketpaw")},
+    )
 
 
 # ==================== Auth Middleware ====================

--- a/src/pocketpaw/frontend/js/app.js
+++ b/src/pocketpaw/frontend/js/app.js
@@ -23,6 +23,11 @@ function app() {
     return {
         // ==================== Core State ====================
 
+        // Version & updates
+        appVersion: '',
+        latestVersion: '',
+        updateAvailable: false,
+
         // View state
         view: 'chat',
         showSettings: false,
@@ -284,6 +289,9 @@ function app() {
                 }
             });
 
+            // Check for version updates
+            this.checkForUpdates();
+
             // Initialize hash-based URL routing
             this.initHashRouter();
 
@@ -291,6 +299,20 @@ function app() {
             this.$nextTick(() => {
                 if (window.refreshIcons) window.refreshIcons();
             });
+        },
+
+        /**
+         * Check PyPI for newer version via /api/version endpoint.
+         */
+        async checkForUpdates() {
+            try {
+                const resp = await fetch('/api/version');
+                if (!resp.ok) return;
+                const data = await resp.json();
+                this.appVersion = data.current || '';
+                this.latestVersion = data.latest || '';
+                this.updateAvailable = !!data.update_available;
+            } catch (e) { /* silent */ }
         },
 
         /**

--- a/src/pocketpaw/frontend/templates/components/sidebar.html
+++ b/src/pocketpaw/frontend/templates/components/sidebar.html
@@ -377,6 +377,23 @@
           <div class="text-[11px] font-mono text-white/70" x-text="typeof status.battery === 'number' ? status.battery + '%' : status.battery"></div>
         </div>
       </div>
+
+      <!-- Version & Updates -->
+      <div class="mt-2 px-2 py-1.5 text-center space-y-0.5">
+        <div class="text-[10px] text-white/30 font-mono">
+          v<span x-text="appVersion || '...'"></span>
+          <template x-if="updateAvailable">
+            <span class="text-amber-400 ml-1">
+              &rarr; <span x-text="latestVersion"></span> available
+            </span>
+          </template>
+        </div>
+        <a href="https://github.com/pocketpaw/pocketpaw/releases"
+           target="_blank" rel="noopener"
+           class="text-[10px] text-white/20 hover:text-white/50 transition-colors">
+          Get release updates
+        </a>
+      </div>
     </div>
   </div>
 </aside>

--- a/src/pocketpaw/update_check.py
+++ b/src/pocketpaw/update_check.py
@@ -1,0 +1,81 @@
+"""Startup version check against PyPI.
+
+Changes:
+  - 2026-02-16: Initial implementation. Checks PyPI daily, caches result, prints update notice.
+
+Checks once per 24 hours whether a newer version of pocketpaw exists on PyPI.
+Cache stored in ~/.pocketpaw/.update_check so the result is shared between
+CLI launches and the dashboard API.
+"""
+
+import json
+import logging
+import time
+import urllib.request
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+PYPI_URL = "https://pypi.org/pypi/pocketpaw/json"
+CACHE_FILENAME = ".update_check"
+CACHE_TTL = 86400  # 24 hours
+REQUEST_TIMEOUT = 2  # seconds
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse '0.4.1' into (0, 4, 1)."""
+    return tuple(int(x) for x in v.strip().split("."))
+
+
+def check_for_updates(current_version: str, config_dir: Path) -> dict | None:
+    """Check PyPI for a newer version. Returns version info dict or None on error.
+
+    Uses a daily cache file to avoid hitting PyPI on every launch.
+    Never raises — all errors are caught and logged at debug level.
+    """
+    try:
+        cache_file = config_dir / CACHE_FILENAME
+        now = time.time()
+
+        # Try cache first
+        if cache_file.exists():
+            try:
+                cache = json.loads(cache_file.read_text())
+                if now - cache.get("ts", 0) < CACHE_TTL:
+                    latest = cache.get("latest", current_version)
+                    return {
+                        "current": current_version,
+                        "latest": latest,
+                        "update_available": _parse_version(latest)
+                        > _parse_version(current_version),
+                    }
+            except (json.JSONDecodeError, ValueError):
+                pass  # Corrupted cache, re-fetch
+
+        # Fetch from PyPI
+        req = urllib.request.Request(PYPI_URL, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+            data = json.loads(resp.read())
+        latest = data["info"]["version"]
+
+        # Write cache
+        config_dir.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(json.dumps({"ts": now, "latest": latest}))
+
+        return {
+            "current": current_version,
+            "latest": latest,
+            "update_available": _parse_version(latest) > _parse_version(current_version),
+        }
+    except Exception:
+        logger.debug("Update check failed (network or parse error)", exc_info=True)
+        return None
+
+
+def print_update_notice(info: dict) -> None:
+    """Print a one-line update notice to the terminal."""
+    current = info["current"]
+    latest = info["latest"]
+    print(
+        f"\n  Update available: {current} \u2192 {latest} \u2014 pip install --upgrade pocketpaw\n"
+    )

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,136 @@
+"""Tests for update_check module.
+
+Changes:
+  - 2026-02-16: Initial tests for PyPI version check with caching.
+"""
+
+import json
+import time
+from unittest.mock import patch
+
+from pocketpaw.update_check import (
+    CACHE_FILENAME,
+    CACHE_TTL,
+    _parse_version,
+    check_for_updates,
+    print_update_notice,
+)
+
+
+class TestParseVersion:
+    def test_simple(self):
+        assert _parse_version("0.4.1") == (0, 4, 1)
+
+    def test_major(self):
+        assert _parse_version("1.0.0") == (1, 0, 0)
+
+    def test_two_digit(self):
+        assert _parse_version("0.12.3") == (0, 12, 3)
+
+
+class TestCheckForUpdates:
+    def test_returns_no_update_when_current(self, tmp_path):
+        """When PyPI returns same version, update_available is False."""
+        pypi_response = json.dumps({"info": {"version": "0.4.1"}}).encode()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = lambda s: s
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            mock_urlopen.return_value.read.return_value = pypi_response
+
+            result = check_for_updates("0.4.1", tmp_path)
+
+        assert result is not None
+        assert result["current"] == "0.4.1"
+        assert result["latest"] == "0.4.1"
+        assert result["update_available"] is False
+
+    def test_returns_update_when_behind(self, tmp_path):
+        """When PyPI has newer version, update_available is True."""
+        pypi_response = json.dumps({"info": {"version": "0.5.0"}}).encode()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = lambda s: s
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            mock_urlopen.return_value.read.return_value = pypi_response
+
+            result = check_for_updates("0.4.1", tmp_path)
+
+        assert result is not None
+        assert result["update_available"] is True
+        assert result["latest"] == "0.5.0"
+
+    def test_writes_cache_file(self, tmp_path):
+        """After a successful check, cache file should exist."""
+        pypi_response = json.dumps({"info": {"version": "0.4.1"}}).encode()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = lambda s: s
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            mock_urlopen.return_value.read.return_value = pypi_response
+
+            check_for_updates("0.4.1", tmp_path)
+
+        cache_file = tmp_path / CACHE_FILENAME
+        assert cache_file.exists()
+        cache = json.loads(cache_file.read_text())
+        assert "ts" in cache
+        assert cache["latest"] == "0.4.1"
+
+    def test_uses_fresh_cache(self, tmp_path):
+        """When cache is fresh, doesn't hit PyPI."""
+        cache_file = tmp_path / CACHE_FILENAME
+        cache_file.write_text(json.dumps({"ts": time.time(), "latest": "0.5.0"}))
+
+        # No mock needed — if it tries to hit PyPI it would fail
+        result = check_for_updates("0.4.1", tmp_path)
+
+        assert result is not None
+        assert result["update_available"] is True
+        assert result["latest"] == "0.5.0"
+
+    def test_ignores_stale_cache(self, tmp_path):
+        """When cache is older than TTL, re-fetches from PyPI."""
+        cache_file = tmp_path / CACHE_FILENAME
+        stale_ts = time.time() - CACHE_TTL - 100
+        cache_file.write_text(json.dumps({"ts": stale_ts, "latest": "0.3.0"}))
+
+        pypi_response = json.dumps({"info": {"version": "0.4.1"}}).encode()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = lambda s: s
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            mock_urlopen.return_value.read.return_value = pypi_response
+
+            result = check_for_updates("0.4.1", tmp_path)
+
+        assert result is not None
+        assert result["latest"] == "0.4.1"  # Updated from stale 0.3.0
+
+    def test_returns_none_on_network_error(self, tmp_path):
+        """Network errors return None, never raise."""
+        with patch("urllib.request.urlopen", side_effect=Exception("no network")):
+            result = check_for_updates("0.4.1", tmp_path)
+
+        assert result is None
+
+    def test_handles_corrupted_cache(self, tmp_path):
+        """Corrupted cache file doesn't crash, re-fetches."""
+        cache_file = tmp_path / CACHE_FILENAME
+        cache_file.write_text("not json{{{")
+
+        pypi_response = json.dumps({"info": {"version": "0.4.1"}}).encode()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = lambda s: s
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            mock_urlopen.return_value.read.return_value = pypi_response
+
+            result = check_for_updates("0.4.1", tmp_path)
+
+        assert result is not None
+        assert result["current"] == "0.4.1"
+
+
+class TestPrintUpdateNotice:
+    def test_prints_notice(self, capsys):
+        print_update_notice({"current": "0.4.0", "latest": "0.4.1"})
+        captured = capsys.readouterr()
+        assert "0.4.0" in captured.out
+        assert "0.4.1" in captured.out
+        assert "pip install --upgrade pocketpaw" in captured.out


### PR DESCRIPTION
## Summary

- **Startup version check**: On every launch, checks PyPI for a newer version. Cached for 24 hours so it only hits the network once per day. Prints a one-liner if behind:
  ```
  Update available: 0.4.1 → 0.4.2 — pip install --upgrade pocketpaw
  ```
- **Dashboard `/api/version` endpoint**: Returns `{current, latest, update_available}` from the same cache
- **Sidebar version footer**: Current version display, amber banner when an update exists, "Get release updates" link pointing to GitHub releases

## How it works

New `src/pocketpaw/update_check.py` handles the check. Stdlib only (`urllib.request`), no new deps. Cache lives at `~/.pocketpaw/.update_check` as JSON with a timestamp and the latest version string. 2-second timeout on the PyPI request, fails silently on any error.

The CLI calls it right after loading settings, before picking a mode. The dashboard exposes it via `GET /api/version` and fetches it on page load to show the version in the sidebar footer.

## Files changed (6)

| File | What changed |
|------|-------------|
| `src/pocketpaw/update_check.py` | New — PyPI check + cache logic |
| `src/pocketpaw/__main__.py` | Version check call after settings load |
| `src/pocketpaw/dashboard.py` | `/api/version` endpoint + `app_version` template var |
| `frontend/js/app.js` | Version state + `checkForUpdates()` fetch |
| `frontend/templates/components/sidebar.html` | Version display, update banner, releases link |
| `tests/test_update_check.py` | 11 unit tests |

## Test plan

- [x] `uv run pytest tests/test_update_check.py` — 11 passed
- [x] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py` — no regressions
- [ ] Launch `uv run pocketpaw`, confirm version check runs without blocking startup
- [ ] Open dashboard, confirm sidebar shows version + "Get release updates" link
- [ ] Hit `localhost:8888/api/version`, confirm JSON response