### PR TITLE
feat: add Output Files panel to Deep Work project view

### DIFF
--- a/src/pocketpaw/frontend/js/features/file-browser.js
+++ b/src/pocketpaw/frontend/js/features/file-browser.js
@@ -2,8 +2,8 @@
  * PocketPaw - File Browser Feature Module
  *
  * Created: 2026-02-05
- * Updated: 2026-02-12 — handleFiles routes sidebar_* context responses to
- *   ProjectBrowser.handleSidebarFiles() instead of updating modal state.
+ * Updated: 2026-02-16 — handleFiles routes output_* context responses to
+ *   handleOutputFiles() for the Deep Work project Output Files panel.
  *
  * Contains file browser modal functionality:
  * - Directory navigation
@@ -40,6 +40,11 @@ window.PocketPaw.FileBrowser = {
                 // Route sidebar file tree responses to ProjectBrowser
                 if (data.context && data.context.startsWith('sidebar_')) {
                     this.handleSidebarFiles(data);
+                    return;
+                }
+                // Route output file responses to Deep Work Output Files panel
+                if (data.context && data.context.startsWith('output_')) {
+                    this.handleOutputFiles(data);
                     return;
                 }
 

--- a/src/pocketpaw/frontend/templates/components/missions/deep-work-projects.html
+++ b/src/pocketpaw/frontend/templates/components/missions/deep-work-projects.html
@@ -2,15 +2,14 @@
   PocketPaw - Deep Work Projects Component
 
   Created: 2026-02-12
-  Updated: 2026-02-12 — Bumped contrast on all low-visibility elements:
-    phase headers, chevrons, blocker/blocks icons, estimated time, hover
-    actions, toolbar counts, sidebar meta, timestamps, expanded row labels.
-    Base: /20→/40, /25→/45, /30→/50. Hover bg /[0.03]→/[0.06].
-    Phase separators get stronger bg and borders.
+  Updated: 2026-02-16 — Added Output Files panel to right sidebar between
+    PRD Document and Timestamps. Displays project output files using the
+    existing WebSocket browse command with output_ context prefix.
+    Auto-loads on project select; collapsible, starts expanded.
 
   Layout:
     No project selected → Left: project cards, Right: placeholder
-    Project selected    → Left: task breakdown (level-grouped), Right: project meta
+    Project selected    → Left: task breakdown (level-grouped), Right: project meta + output files
 -->
 
 <!-- Left: Main Panel -->
@@ -654,6 +653,55 @@
                 </button>
                 <div x-ref="prdContent" class="hidden flex-1 overflow-y-auto px-4 pb-4">
                     <div class="prose prose-invert prose-xs text-xs text-white/60 leading-relaxed" x-html="typeof marked !== 'undefined' ? DOMPurify.sanitize(marked.parse(missionControl.projectPrd?.content || '')) : (missionControl.projectPrd?.content || '')"></div>
+                </div>
+            </div>
+
+            <!-- Output Files -->
+            <div class="border-t border-white/8">
+                <button
+                    class="w-full flex items-center justify-between px-4 py-3 text-[10px] text-white/55 uppercase tracking-wider font-semibold hover:bg-white/[0.06] transition-all"
+                    @click="missionControl._outputExpanded = !missionControl._outputExpanded; if (missionControl._outputExpanded && missionControl.projectOutputFiles.length === 0 && !missionControl.projectOutputLoading) loadProjectOutputFiles()"
+                >
+                    <span class="flex items-center gap-1.5">
+                        <i data-lucide="folder-open" class="w-3 h-3"></i>
+                        Output Files
+                        <span x-show="missionControl.selectedProject.file_count" class="text-white/30 normal-case" x-text="missionControl.selectedProject.file_count + ' files'"></span>
+                    </span>
+                    <i data-lucide="chevron-down" class="w-3 h-3 transition-transform" :class="missionControl._outputExpanded && 'rotate-180'"></i>
+                </button>
+
+                <div x-show="missionControl._outputExpanded" x-transition class="px-4 pb-3 space-y-0.5">
+                    <!-- Loading -->
+                    <div x-show="missionControl.projectOutputLoading" class="py-3 text-center">
+                        <i data-lucide="loader" class="w-4 h-4 animate-spin text-white/30 inline-block"></i>
+                    </div>
+
+                    <!-- File list -->
+                    <template x-for="file in missionControl.projectOutputFiles" :key="file.name">
+                        <button
+                            class="w-full flex items-center gap-2 px-2 py-1.5 rounded text-left hover:bg-white/5 transition-colors group"
+                            @click="openOutputFile(file)"
+                        >
+                            <i :data-lucide="file.isDir ? 'folder' : 'file-code'" class="w-3.5 h-3.5 text-white/40 shrink-0"></i>
+                            <span class="text-xs text-white/70 truncate" x-text="file.name"></span>
+                            <span x-show="!file.isDir" class="ml-auto text-[10px] text-white/30 shrink-0" x-text="file.size"></span>
+                        </button>
+                    </template>
+
+                    <!-- Empty state -->
+                    <p x-show="!missionControl.projectOutputLoading && missionControl.projectOutputFiles.length === 0" class="text-[10px] text-white/30 py-2 text-center">
+                        No files yet
+                    </p>
+
+                    <!-- Open folder button -->
+                    <button
+                        x-show="missionControl.projectOutputFiles.length > 0"
+                        class="w-full mt-1 px-2 py-1.5 text-[10px] text-white/40 hover:text-white/60 hover:bg-white/5 rounded transition-colors flex items-center justify-center gap-1"
+                        @click="fileLoading = true; fileError = null; files = []; filePath = missionControl.selectedProject.folder_path; socket.send('browse', { path: missionControl.selectedProject.folder_path }); showFileBrowser = true"
+                    >
+                        <i data-lucide="external-link" class="w-3 h-3"></i>
+                        Open in File Browser
+                    </button>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

- Adds an **Output Files** collapsible panel to the Deep Work project right sidebar (between PRD Document and Timestamps)
- Enriches the `/api/deep-work/projects/{id}/plan` response with `folder_path` and `file_count` so the frontend can browse project output
- Reuses the existing WebSocket `browse` command with a new `output_` context prefix (follows the established `sidebar_` pattern in file-browser.js)
- Auto-loads files when a project is selected; clicking files/folders opens the File Browser modal

## Test plan

- [x] Create a Deep Work project that generates output files
- [x] Select the project — Output Files section should appear in right sidebar with file list
- [ ] Click a folder in the output list — opens file browser modal at that path
- [ ] Click "Open in File Browser" — opens the full file browser at the project root directory
- [ ] Project with no files — shows "No files yet" empty state
- [ ] Toggle the Output Files section collapsed/expanded
- [ ] Run tests: `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py -q` (1820 passing)