### PR TITLE
[FI] Fixed installation errors for backend agents and playwright

### DIFF
--- a/installer/installer.py
+++ b/installer/installer.py
@@ -859,6 +859,7 @@ class PackageInstaller:
         return str(candidate) if candidate.exists() else sys.executable
 
     def install_playwright(self) -> bool:
+        """Install Playwright browsers."""
         py = self._uv_tool_python()
         # Check if playwright package is importable in the uv tool venv
         try:
@@ -869,7 +870,11 @@ class PackageInstaller:
                 console.print("[dim]  Playwright package missing — installing into venv...[/dim]")
             else:
                 print("  Playwright package missing — installing into venv...")
-            if not self._run_cmd([py, "-m", "pip", "install", "playwright"]):
+            if shutil.which("uv"):
+                install_cmd = [py, "-m", "uv", "pip", "install", "playwright"]
+            else:
+                install_cmd = [py, "-m", "pip", "install", "playwright"]
+            if not self._run_cmd(install_cmd):
                 return False
 
         # Install browser binaries


### PR DESCRIPTION
Fix 1: Installation failing because a dependency, tiktoken is hardcoded to download the version 0.7.0. The launcher's bootstrap.py already has the fix, it writes an overrides file to loosen tiktoken==0.7.0 to tiktoken>=0.7.0. The same in needed to be done in installer.py. Fix 2: Playwright browser installation was searching for playwright in system Python packages. If not only available in venv, the installation failed. Added a validation script for checking availability of playwright and default to uv venv with a fallback to system. If not available, install playwright first then browser.