### PR TITLE
[FI] Fix Windows installer source parity and align install docs

### DIFF
--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -35,8 +35,8 @@ export POCKETPAW_OLLAMA_HOST="http://localhost:11434"
 export POCKETPAW_OLLAMA_MODEL="qwen2.5:7b"
 
 # Web Dashboard
-export POCKETPAW_DASHBOARD_PORT=8000
-export POCKETPAW_DASHBOARD_HOST="0.0.0.0"
+export POCKETPAW_WEB_PORT=8888
+export POCKETPAW_WEB_HOST="0.0.0.0"
 
 # Telegram
 export POCKETPAW_TELEGRAM_TOKEN="your-bot-token"

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -167,7 +167,7 @@ pocketpaw
 uv run pocketpaw
 ```
 
-The web dashboard will start at `http://localhost:8000`. Open it in your browser to verify everything is working.
+The web dashboard will start at `http://localhost:8888`. Open it in your browser to verify everything is working.
 
 ## Next Steps
 

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -16,6 +16,12 @@ This guide gets you from zero to a working AI agent in under 5 minutes.
 ```bash
 curl -fsSL https://pocketpaw.xyz/install.sh | sh
 ```
+On **Windows PowerShell**, use:
+
+```powershell
+powershell -NoExit -Command "iwr -useb https://pocketpaw.xyz/install.ps1 | iex"
+```
+
 **Tip:** If the install command fails, make sure Python 3.11+ is installed and available in your system PATH.
 
 
@@ -31,7 +37,7 @@ export POCKETPAW_ANTHROPIC_API_KEY="sk-ant-your-key-here"
 pocketpaw
 ```
 
-This starts the **web dashboard** at `http://localhost:8000`. Open it in your browser.
+This starts the **web dashboard** at `http://localhost:8888`. Open it in your browser.
 
 ## Step 4: Chat
 

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -239,7 +239,7 @@ Write-Step "Launching interactive installer..."
 Write-Host ""
 
 # ── Run installer ──────────────────────────────────────────────────────
-$extraFlags = @("--from-git")
+$extraFlags = @()
 if ($uvAvailable) { $extraFlags += "--uv-available" }
 if ($NonInteractive) { $extraFlags += "--non-interactive" }
 if ($Profile -ne "recommended") { $extraFlags += "--profile"; $extraFlags += $Profile }


### PR DESCRIPTION
## Summary
Closes #196

This PR fixes a Windows installer parity issue and updates related getting-started docs for consistency.

## Problem
Windows installer flow was forcing a GitHub-source install path, which differed from the default installer behavior on other platforms.  
Some setup docs also had drifted defaults/instructions, causing confusion for new users.

## Root Cause
- Windows bootstrap script passed a forced git-source flag.
- Documentation values/instructions were not fully aligned with current runtime/config behavior.

## Changes Made
- Removed forced git-source behavior from Windows installer bootstrap flow.
- Updated Quick Start with explicit Windows PowerShell install command.
- Updated getting-started docs to match current dashboard defaults and config naming.

## Validation
I validated the change set locally by reviewing the diff and ensuring issue-specific file scope only.

## Risk
Low to medium. Changes are narrowly scoped to installer bootstrap arguments and documentation consistency.