### PR TITLE
[FI]Trigger docs deploy on installer script changes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - "docs/**"
+      - "installer/**"
   pull_request:
     branches: [main]
     paths:
       - "docs/**"
+      - "installer/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Closes #198

This PR ensures docs deployment also runs when installer scripts are changed.

## Problem
Installer scripts are copied into docs output, but workflow path filters did not include installer directory changes.  
That could cause published install assets/docs to lag behind source updates.

## Root Cause
Docs deploy workflow triggers only watched docs paths.

## Changes Made
- Updated docs deploy workflow trigger paths to include installer directory changes.

## Validation
Verified workflow file changes are minimal and trigger scope now includes installer updates.

## Risk
Low. Only CI workflow trigger paths were changed.