### PR TITLE
[FI]Fix outdated dashboard port in getting-started pages

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -167,7 +167,7 @@ pocketpaw
 uv run pocketpaw
 ```
 
-The web dashboard will start at `http://localhost:8000`. Open it in your browser to verify everything is working.
+The web dashboard will start at `http://localhost:8888`. Open it in your browser to verify everything is working.
 
 ## Next Steps
 

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -31,7 +31,7 @@ export POCKETPAW_ANTHROPIC_API_KEY="sk-ant-your-key-here"
 pocketpaw
 ```
 
-This starts the **web dashboard** at `http://localhost:8000`. Open it in your browser.
+This starts the **web dashboard** at `http://localhost:8888`. Open it in your browser.
 
 ## Step 4: Chat
 


### PR DESCRIPTION
## Summary
Closes #197

This PR updates outdated dashboard port references in getting-started documentation to match the current runtime default.

## Problem
Some getting-started docs referenced `http://localhost:8000`, while the current runtime default is `8888`.  
This can make new users think startup failed when opening the wrong URL.

## Changes Made
- Updated dashboard URL in `docs/getting-started/quick-start.mdx` from `8000` to `8888`
- Updated dashboard URL in `docs/getting-started/installation.mdx` from `8000` to `8888`

## Verification
- Confirmed runtime default in `src/pocketpaw/config.py` is `web_port = 8888`
- Verified both affected getting-started pages now reference `http://localhost:8888`

## Risk
Low. Documentation-only change with no runtime code changes.