### PR TITLE
[FI] Add Windows Quick Start installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,23 @@
 
 ```bash
 curl -fsSL https://pocketpaw.xyz/install.sh | sh
+
+### Windows
+
+The above command uses `sh` which is not available on Windows.
+
+Use:
+
+```bash
+pip install pocketpaw
+pocketpaw
 ```
 
-Or install directly:
+If the command is not found after installation, restart the terminal and run again.
+
+
+Or install directly (cross-platform):
+
 
 ```bash
 pip install pocketpaw && pocketpaw


### PR DESCRIPTION
## Problem
The Quick Start command uses:

curl -fsSL https://pocketpaw.xyz/install.sh | sh

This fails on Windows because `sh` is not available, causing users to think installation is broken.

## What I did
Added a dedicated Windows installation section and clarified cross-platform instructions.

## Result
Windows users can now successfully install using:

pip install pocketpaw
pocketpaw

## Why this matters
Prevents onboarding drop-off for Windows users and improves first-time setup experience.
