### PR TITLE
feat(health): add version update check + --doctor CLI

### DIFF
--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -1323,9 +1323,7 @@ async def install_extras(request: Request):
     # Clear cached adapter module so _start_channel_adapter can re-import fresh
     import sys
 
-    adapter_modules = [
-        k for k in sys.modules if k.startswith("pocketpaw.bus.adapters.")
-    ]
+    adapter_modules = [k for k in sys.modules if k.startswith("pocketpaw.bus.adapters.")]
     for mod in adapter_modules:
         del sys.modules[mod]
 

--- a/src/pocketpaw/frontend/templates/components/modals/health.html
+++ b/src/pocketpaw/frontend/templates/components/modals/health.html
@@ -1,6 +1,8 @@
 <!--
   Health Engine Modal — system diagnostics and error log.
   Created: 2026-02-17
+  Updated: 2026-02-18
+    - Show version number badge in header (next to status badge)
   Updated: 2026-02-17
     - Added "Fix Issues" button (sends issues to agent via chat)
     - Added "Clear Log" button to clear resolved errors
@@ -36,6 +38,9 @@
                 'bg-white/10 text-white/40 border border-white/10': !healthStatus || healthStatus === 'unknown'
             }"
             x-text="(healthStatus || 'unknown').toUpperCase()"
+        ></span>
+        <span class="px-2 py-0.5 text-[10px] font-mono text-white/30 bg-white/5 rounded-full"
+              x-text="'v' + (appVersion || '...')"
         ></span>
       </div>
       <div class="flex items-center gap-2">

--- a/src/pocketpaw/frontend/templates/components/sidebar.html
+++ b/src/pocketpaw/frontend/templates/components/sidebar.html
@@ -1,7 +1,10 @@
 <!--
   PocketPaw Dashboard - Sidebar Component
 
-  Updated: 2026-02-17
+  Updated: 2026-02-18
+  - Version footer: update available now links to health modal (doctor integration)
+
+  Previous: 2026-02-17
   - Added health indicator dot next to Beta badge (green/yellow/red pulsing)
   - Added Health button in Tools & Config grid
 
@@ -410,7 +413,7 @@
         <div class="text-[10px] text-white/30 font-mono">
           v<span x-text="appVersion || '...'"></span>
           <template x-if="updateAvailable">
-            <span class="text-amber-400 ml-1">
+            <span class="text-amber-400 ml-1 cursor-pointer" @click="openHealthPanel()">
               &rarr; <span x-text="latestVersion"></span> available
             </span>
           </template>
@@ -418,7 +421,7 @@
         <a href="https://github.com/pocketpaw/pocketpaw/releases"
            target="_blank" rel="noopener"
            class="text-[10px] text-white/20 hover:text-white/50 transition-colors">
-          Get release updates
+          Release notes
         </a>
       </div>
     </div>

--- a/src/pocketpaw/health/checks.py
+++ b/src/pocketpaw/health/checks.py
@@ -1,5 +1,6 @@
 # Health check functions — pure Python, no LLM.
 # Created: 2026-02-17
+# Updated: 2026-02-18 — added check_version_update (PyPI version check via update_check module).
 # Updated: 2026-02-17 — fix check_secrets_encrypted: was doing json.loads() on
 #   Fernet-encrypted bytes (always fails). Now checks for Fernet token signature.
 # Each check returns a HealthCheckResult dataclass.
@@ -654,6 +655,63 @@ async def check_llm_reachable() -> HealthCheckResult:
 
 
 # =============================================================================
+# Update checks (sync, uses cached PyPI data — 2s timeout max)
+# =============================================================================
+
+
+def check_version_update() -> HealthCheckResult:
+    """Check if a newer version of PocketPaw is available on PyPI."""
+    try:
+        from importlib.metadata import version as get_version
+
+        from pocketpaw.config import get_config_dir
+        from pocketpaw.update_check import check_for_updates
+
+        current = get_version("pocketpaw")
+        config_dir = get_config_dir()
+        info = check_for_updates(current, config_dir)
+
+        if info is None:
+            return HealthCheckResult(
+                check_id="version_update",
+                name="Version Update",
+                category="updates",
+                status="ok",
+                message=f"Running v{current} (update check unavailable)",
+                fix_hint="",
+            )
+
+        if info.get("update_available"):
+            latest = info["latest"]
+            return HealthCheckResult(
+                check_id="version_update",
+                name="Version Update",
+                category="updates",
+                status="warning",
+                message=f"Update available: v{current} \u2192 v{latest}",
+                fix_hint=f"Run: pip install --upgrade pocketpaw  |  Changelog: github.com/pocketpaw/pocketpaw/releases/tag/v{latest}",
+            )
+
+        return HealthCheckResult(
+            check_id="version_update",
+            name="Version Update",
+            category="updates",
+            status="ok",
+            message=f"Running v{current} (latest)",
+            fix_hint="",
+        )
+    except Exception as e:
+        return HealthCheckResult(
+            check_id="version_update",
+            name="Version Update",
+            category="updates",
+            status="ok",
+            message=f"Could not check version: {e}",
+            fix_hint="",
+        )
+
+
+# =============================================================================
 # Check registry
 # =============================================================================
 
@@ -669,6 +727,7 @@ STARTUP_CHECKS = [
     check_disk_space,
     check_audit_log_writable,
     check_memory_dir_accessible,
+    check_version_update,
 ]
 
 # Async checks (run in background, may be slow)

--- a/src/pocketpaw/health/playbooks.py
+++ b/src/pocketpaw/health/playbooks.py
@@ -1,5 +1,6 @@
 # Repair playbooks — pure data mapping check_id to diagnostic info.
 # Created: 2026-02-17
+# Updated: 2026-02-18 — added version_update playbook.
 # Used by config_doctor tool and health modal UI.
 
 from __future__ import annotations
@@ -98,6 +99,19 @@ PLAYBOOKS: dict[str, dict] = {
         "fix_steps": [
             "Open Settings > API Keys in the dashboard and save",
             "This automatically encrypts all secret fields",
+        ],
+        "auto_fixable": False,
+    },
+    "version_update": {
+        "symptom": "Running an outdated version — may miss bug fixes and new features",
+        "causes": [
+            "PocketPaw was installed a while ago and not updated",
+            "Auto-update is not configured",
+        ],
+        "fix_steps": [
+            "Run: pip install --upgrade pocketpaw",
+            "Check release notes at github.com/pocketpaw/pocketpaw/releases",
+            "Restart PocketPaw after upgrading",
         ],
         "auto_fixable": False,
     },

--- a/src/pocketpaw/update_check.py
+++ b/src/pocketpaw/update_check.py
@@ -1,6 +1,7 @@
-"""Startup version check against PyPI.
+"""Startup version check against PyPI + release notes fetching.
 
 Changes:
+  - 2026-02-18: Added styled CLI update box, release notes fetching, version seen tracking.
   - 2026-02-16: Initial implementation. Checks PyPI daily, caches result, prints update notice.
 
 Checks once per 24 hours whether a newer version of pocketpaw exists on PyPI.
@@ -10,6 +11,8 @@ CLI launches and the dashboard API.
 
 import json
 import logging
+import os
+import sys
 import time
 import urllib.request
 from pathlib import Path
@@ -20,6 +23,10 @@ PYPI_URL = "https://pypi.org/pypi/pocketpaw/json"
 CACHE_FILENAME = ".update_check"
 CACHE_TTL = 86400  # 24 hours
 REQUEST_TIMEOUT = 2  # seconds
+
+RELEASE_NOTES_CACHE_DIR = ".release_notes_cache"
+RELEASE_NOTES_TTL = 3600  # 1 hour
+GITHUB_API_URL = "https://api.github.com/repos/pocketpaw/pocketpaw/releases/tags/v{version}"
 
 
 def _parse_version(v: str) -> tuple[int, ...]:
@@ -72,10 +79,157 @@ def check_for_updates(current_version: str, config_dir: Path) -> dict | None:
         return None
 
 
-def print_update_notice(info: dict) -> None:
-    """Print a one-line update notice to the terminal."""
+# ---------------------------------------------------------------------------
+# CLI styled update notice
+# ---------------------------------------------------------------------------
+
+
+def _should_suppress_notice() -> bool:
+    """Check if the update notice should be suppressed."""
+    if os.environ.get("POCKETPAW_NO_UPDATE_CHECK"):
+        return True
+    if os.environ.get("CI"):
+        return True
+    if not sys.stderr.isatty():
+        return True
+    return False
+
+
+def print_styled_update_notice(info: dict) -> None:
+    """Print a styled, can't-miss update box to stderr.
+
+    Uses box-drawing characters, ANSI colors, and writes to stderr so it
+    doesn't pollute piped output. Auto-suppressed in CI, non-TTY, or when
+    POCKETPAW_NO_UPDATE_CHECK is set.
+    """
+    if _should_suppress_notice():
+        return
+
     current = info["current"]
     latest = info["latest"]
-    print(
-        f"\n  Update available: {current} \u2192 {latest} \u2014 pip install --upgrade pocketpaw\n"
+
+    # ANSI color codes
+    YELLOW = "\033[33m"
+    GREEN = "\033[32m"
+    DIM = "\033[2m"
+    BOLD = "\033[1m"
+    RESET = "\033[0m"
+
+    changelog_url = "github.com/pocketpaw/pocketpaw/releases"
+    upgrade_cmd = "pip install --upgrade pocketpaw"
+
+    # Build the content lines (without borders) to measure width
+    title_line = (
+        f"   {BOLD}Update available!{RESET}  {current} {YELLOW}\u2192{RESET} {GREEN}{latest}{RESET}"
     )
+    changelog_line = f"   {DIM}Changelog:{RESET} {changelog_url}"
+    upgrade_line = f"   {DIM}Run:{RESET}       {upgrade_cmd}"
+
+    # Fixed box width (60 chars inner)
+    box_width = 60
+    border_h = "\u2500" * box_width
+    empty_inner = " " * box_width
+
+    lines = [
+        f"{YELLOW}\u250c{border_h}\u2510{RESET}",
+        f"{YELLOW}\u2502{RESET}{empty_inner}{YELLOW}\u2502{RESET}",
+        f"{YELLOW}\u2502{RESET}{title_line}{' ' * 6}{YELLOW}\u2502{RESET}",
+        f"{YELLOW}\u2502{RESET}{empty_inner}{YELLOW}\u2502{RESET}",
+        f"{YELLOW}\u2502{RESET}{changelog_line}{' ' * (box_width - 52)}{YELLOW}\u2502{RESET}",
+        f"{YELLOW}\u2502{RESET}{upgrade_line}{' ' * (box_width - 46)}{YELLOW}\u2502{RESET}",
+        f"{YELLOW}\u2502{RESET}{empty_inner}{YELLOW}\u2502{RESET}",
+        f"{YELLOW}\u2514{border_h}\u2518{RESET}",
+    ]
+
+    sys.stderr.write("\n" + "\n".join(lines) + "\n\n")
+
+
+def print_update_notice(info: dict) -> None:
+    """Deprecated: use print_styled_update_notice instead.
+
+    Delegates to styled version for backward compatibility.
+    """
+    print_styled_update_notice(info)
+
+
+# ---------------------------------------------------------------------------
+# Release notes fetching + version seen tracking
+# ---------------------------------------------------------------------------
+
+
+def fetch_release_notes(version: str, config_dir: Path) -> dict | None:
+    """Fetch release notes from GitHub for a specific version.
+
+    Returns {version, body, html_url, published_at, name} or None on error.
+    Uses per-version cache files with 1h TTL in config_dir/.release_notes_cache/.
+    """
+    try:
+        cache_dir = config_dir / RELEASE_NOTES_CACHE_DIR
+        cache_file = cache_dir / f"v{version}.json"
+        now = time.time()
+
+        # Try cache first
+        if cache_file.exists():
+            try:
+                cached = json.loads(cache_file.read_text())
+                if now - cached.get("ts", 0) < RELEASE_NOTES_TTL:
+                    return cached.get("data")
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+        # Fetch from GitHub
+        url = GITHUB_API_URL.format(version=version)
+        req = urllib.request.Request(
+            url, headers={"Accept": "application/vnd.github.v3+json", "User-Agent": "pocketpaw"}
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            release = json.loads(resp.read())
+
+        data = {
+            "version": version,
+            "body": release.get("body", ""),
+            "html_url": release.get("html_url", ""),
+            "published_at": release.get("published_at", ""),
+            "name": release.get("name", f"v{version}"),
+        }
+
+        # Write cache
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(json.dumps({"ts": now, "data": data}))
+
+        return data
+    except Exception:
+        logger.debug("Failed to fetch release notes for v%s", version, exc_info=True)
+        return None
+
+
+def get_last_seen_version(config_dir: Path) -> str | None:
+    """Read last_seen_version from the update check cache file."""
+    try:
+        cache_file = config_dir / CACHE_FILENAME
+        if cache_file.exists():
+            cache = json.loads(cache_file.read_text())
+            return cache.get("last_seen_version")
+    except (json.JSONDecodeError, ValueError, OSError):
+        pass
+    return None
+
+
+def mark_version_seen(version: str, config_dir: Path) -> None:
+    """Write last_seen_version into the update check cache file.
+
+    Preserves existing cache fields (ts, latest) and adds/updates last_seen_version.
+    """
+    try:
+        cache_file = config_dir / CACHE_FILENAME
+        cache = {}
+        if cache_file.exists():
+            try:
+                cache = json.loads(cache_file.read_text())
+            except (json.JSONDecodeError, ValueError):
+                pass
+        cache["last_seen_version"] = version
+        config_dir.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(json.dumps(cache))
+    except OSError:
+        logger.debug("Failed to mark version %s as seen", version, exc_info=True)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,5 +1,6 @@
 # Tests for the Health Engine (health/store.py, checks.py, engine.py, playbooks.py, tools)
 # Created: 2026-02-17
+# Updated: 2026-02-18 — added TestCheckVersionUpdate, updated registry count for version check.
 # Updated: 2026-02-17 — Phase 2: added ContextHub health_status integration tests
 # Covers: ErrorStore, HealthCheckResult, individual checks, HealthEngine,
 #         playbook diagnostics, health agent tools, ContextHub health_status source.
@@ -25,6 +26,7 @@ from pocketpaw.health.checks import (
     check_llm_reachable,
     check_memory_dir_accessible,
     check_secrets_encrypted,
+    check_version_update,
 )
 from pocketpaw.health.engine import HealthEngine
 from pocketpaw.health.playbooks import PLAYBOOKS, diagnose_config
@@ -545,9 +547,53 @@ class TestCheckLlmReachable:
 # =============================================================================
 
 
+class TestCheckVersionUpdate:
+    """Tests for check_version_update health check."""
+
+    _P_GET_VERSION = "importlib.metadata.version"
+    _P_UPDATE_CHECK = "pocketpaw.update_check.check_for_updates"
+
+    def test_returns_ok_when_current(self, tmp_path):
+        """No update available returns ok status."""
+        update_info = {"current": "0.4.2", "latest": "0.4.2", "update_available": False}
+        with (
+            patch(self._P_GET_VERSION, return_value="0.4.2"),
+            patch(_P_CONFIG_DIR, return_value=tmp_path),
+            patch(self._P_UPDATE_CHECK, return_value=update_info),
+        ):
+            result = check_version_update()
+        assert result.status == "ok"
+        assert result.check_id == "version_update"
+        assert "latest" in result.message
+
+    def test_returns_warning_when_update_available(self, tmp_path):
+        """Update available returns warning status with upgrade hint."""
+        update_info = {"current": "0.4.1", "latest": "0.4.2", "update_available": True}
+        with (
+            patch(self._P_GET_VERSION, return_value="0.4.1"),
+            patch(_P_CONFIG_DIR, return_value=tmp_path),
+            patch(self._P_UPDATE_CHECK, return_value=update_info),
+        ):
+            result = check_version_update()
+        assert result.status == "warning"
+        assert "0.4.2" in result.message
+        assert "pip install --upgrade pocketpaw" in result.fix_hint
+
+    def test_returns_ok_on_check_failure(self, tmp_path):
+        """When update check fails (None), returns ok (no false alarm)."""
+        with (
+            patch(self._P_GET_VERSION, return_value="0.4.2"),
+            patch(_P_CONFIG_DIR, return_value=tmp_path),
+            patch(self._P_UPDATE_CHECK, return_value=None),
+        ):
+            result = check_version_update()
+        assert result.status == "ok"
+        assert "unavailable" in result.message
+
+
 class TestCheckRegistries:
     def test_startup_checks_count(self):
-        assert len(STARTUP_CHECKS) == 10
+        assert len(STARTUP_CHECKS) == 11  # 10 original + version_update
 
     def test_connectivity_checks_count(self):
         assert len(CONNECTIVITY_CHECKS) == 1
@@ -592,7 +638,7 @@ class TestHealthEngine:
             patch("importlib.util.find_spec", return_value=MagicMock()),
         ):
             results = engine.run_startup_checks()
-            assert len(results) == 10
+            assert len(results) == 11  # 10 original + version_update
             # All should be ok with valid config + key
             statuses = {r.status for r in results}
             assert "critical" not in statuses
@@ -764,6 +810,7 @@ class TestPlaybooks:
             "disk_space",
             "config_permissions",
             "secrets_encrypted",
+            "version_update",
         }
         assert set(PLAYBOOKS.keys()) == expected
 

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,6 +1,7 @@
 """Tests for update_check module.
 
 Changes:
+  - 2026-02-18: Added TestStyledUpdateNotice, TestFetchReleaseNotes, TestVersionSeen.
   - 2026-02-16: Initial tests for PyPI version check with caching.
 """
 
@@ -11,8 +12,13 @@ from unittest.mock import patch
 from pocketpaw.update_check import (
     CACHE_FILENAME,
     CACHE_TTL,
+    RELEASE_NOTES_CACHE_DIR,
     _parse_version,
     check_for_updates,
+    fetch_release_notes,
+    get_last_seen_version,
+    mark_version_seen,
+    print_styled_update_notice,
     print_update_notice,
 )
 
@@ -129,8 +135,152 @@ class TestCheckForUpdates:
 
 class TestPrintUpdateNotice:
     def test_prints_notice(self, capsys):
+        """Legacy print_update_notice delegates to styled version (suppressed in non-TTY tests)."""
+        # In test env, stderr is not a TTY so styled notice is suppressed.
+        # Just verify it doesn't crash.
         print_update_notice({"current": "0.4.0", "latest": "0.4.1"})
+
+
+class TestStyledUpdateNotice:
+    def test_outputs_to_stderr_when_tty(self, capsys):
+        """Styled notice writes box-drawing chars to stderr when TTY is available."""
+        info = {"current": "0.4.1", "latest": "0.5.0"}
+        with (
+            patch("sys.stderr.isatty", return_value=True),
+            patch("pocketpaw.update_check.os.environ.get", return_value=None),
+        ):
+            print_styled_update_notice(info)
         captured = capsys.readouterr()
-        assert "0.4.0" in captured.out
-        assert "0.4.1" in captured.out
-        assert "pip install --upgrade pocketpaw" in captured.out
+        assert "\u250c" in captured.err  # box-drawing top-left corner
+        assert "\u2514" in captured.err  # box-drawing bottom-left corner
+        assert "0.5.0" in captured.err
+        assert "0.4.1" in captured.err
+        assert "pip install --upgrade pocketpaw" in captured.err
+
+    def test_suppressed_in_ci(self, capsys):
+        """No output when CI env var is set."""
+        info = {"current": "0.4.1", "latest": "0.5.0"}
+        with (
+            patch("sys.stderr.isatty", return_value=True),
+            patch.dict("os.environ", {"CI": "true"}, clear=False),
+        ):
+            print_styled_update_notice(info)
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_suppressed_when_not_tty(self, capsys):
+        """No output when stderr is not a TTY."""
+        info = {"current": "0.4.1", "latest": "0.5.0"}
+        with patch("sys.stderr.isatty", return_value=False):
+            print_styled_update_notice(info)
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_suppressed_by_env_var(self, capsys):
+        """No output when POCKETPAW_NO_UPDATE_CHECK is set."""
+        info = {"current": "0.4.1", "latest": "0.5.0"}
+        with (
+            patch("sys.stderr.isatty", return_value=True),
+            patch.dict("os.environ", {"POCKETPAW_NO_UPDATE_CHECK": "1"}, clear=False),
+        ):
+            print_styled_update_notice(info)
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_contains_box_drawing_chars(self, capsys):
+        """Output includes all four box corners."""
+        info = {"current": "0.4.1", "latest": "0.5.0"}
+        with (
+            patch("sys.stderr.isatty", return_value=True),
+            patch("pocketpaw.update_check.os.environ.get", return_value=None),
+        ):
+            print_styled_update_notice(info)
+        captured = capsys.readouterr()
+        for char in ["\u250c", "\u2510", "\u2514", "\u2518", "\u2500"]:
+            assert char in captured.err
+
+
+class TestFetchReleaseNotes:
+    def test_fetch_and_cache(self, tmp_path):
+        """Fetches from GitHub and caches the result."""
+        release_data = json.dumps(
+            {
+                "body": "## Changes\n- Fixed stuff",
+                "html_url": "https://github.com/pocketpaw/pocketpaw/releases/tag/v0.4.2",
+                "published_at": "2026-02-16T00:00:00Z",
+                "name": "v0.4.2",
+            }
+        ).encode()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = lambda s: s
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            mock_urlopen.return_value.read.return_value = release_data
+
+            result = fetch_release_notes("0.4.2", tmp_path)
+
+        assert result is not None
+        assert result["version"] == "0.4.2"
+        assert "Fixed stuff" in result["body"]
+        assert result["name"] == "v0.4.2"
+
+        # Verify cache was written
+        cache_file = tmp_path / RELEASE_NOTES_CACHE_DIR / "v0.4.2.json"
+        assert cache_file.exists()
+
+    def test_uses_cached_notes(self, tmp_path):
+        """Returns cached notes without hitting GitHub."""
+        cache_dir = tmp_path / RELEASE_NOTES_CACHE_DIR
+        cache_dir.mkdir(parents=True)
+        cached = {
+            "ts": time.time(),
+            "data": {
+                "version": "0.4.2",
+                "body": "cached notes",
+                "html_url": "https://example.com",
+                "published_at": "2026-02-16T00:00:00Z",
+                "name": "v0.4.2",
+            },
+        }
+        (cache_dir / "v0.4.2.json").write_text(json.dumps(cached))
+
+        # No mock — would fail if it tried to fetch
+        result = fetch_release_notes("0.4.2", tmp_path)
+
+        assert result is not None
+        assert result["body"] == "cached notes"
+
+    def test_returns_none_on_network_error(self, tmp_path):
+        """Network errors return None, never raise."""
+        with patch("urllib.request.urlopen", side_effect=Exception("no network")):
+            result = fetch_release_notes("0.4.2", tmp_path)
+        assert result is None
+
+
+class TestVersionSeen:
+    def test_initial_none(self, tmp_path):
+        """When no cache exists, returns None."""
+        assert get_last_seen_version(tmp_path) is None
+
+    def test_mark_and_get(self, tmp_path):
+        """Mark a version as seen, then retrieve it."""
+        mark_version_seen("0.4.2", tmp_path)
+        assert get_last_seen_version(tmp_path) == "0.4.2"
+
+    def test_preserves_existing_cache(self, tmp_path):
+        """Marking version seen doesn't destroy existing cache fields."""
+        cache_file = tmp_path / CACHE_FILENAME
+        cache_file.write_text(json.dumps({"ts": 12345, "latest": "0.5.0"}))
+
+        mark_version_seen("0.4.2", tmp_path)
+
+        cache = json.loads(cache_file.read_text())
+        assert cache["ts"] == 12345
+        assert cache["latest"] == "0.5.0"
+        assert cache["last_seen_version"] == "0.4.2"
+
+    def test_updates_existing_seen(self, tmp_path):
+        """Updating last_seen_version overwrites old value."""
+        mark_version_seen("0.4.1", tmp_path)
+        mark_version_seen("0.4.2", tmp_path)
+        assert get_last_seen_version(tmp_path) == "0.4.2"


### PR DESCRIPTION
## Summary
- `pocketpaw --doctor` CLI command: runs all health checks, prints a categorized diagnostic report
- Version updates are now a health engine check instead of separate UI. Health dot turns yellow when outdated
- Styled CLI update notice (ANSI box on stderr at startup, suppressed in CI and non-TTY)
- Version badge in health modal header
- 15 new tests for styled notices, release notes caching, version tracking, and health check integration

## Details
Users on older versions had no idea updates existed. The old system printed one line that blended into startup noise, and the sidebar footer was 10px text nobody noticed.

The doctor handles this now. `pocketpaw --doctor` runs all 11 startup checks plus connectivity, groups results by category (Config, Storage, Updates, Connectivity), and prints fix hints for anything wrong. Version checking is just another health check. When an update is available, the health dot goes yellow and the modal shows details with an upgrade command.

Terminal users also get a styled box on stderr when an update is available. Writes to stderr so piped output stays clean. Auto-suppressed in CI, non-TTY, and when `POCKETPAW_NO_UPDATE_CHECK` is set.

## Test plan
- [ ] Run `pocketpaw --doctor`, verify categorized output
- [ ] Temporarily set version to "0.0.1", run app, verify styled CLI box appears
- [ ] Open dashboard, check health modal shows version badge
- [ ] Verify health dot turns yellow when update is available