### PR TITLE
[F1] Fix windows installation instructions for curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@
 ```bash
 curl -fsSL https://pocketpaw.xyz/install.sh | sh
 ```
+### Windows Users
+
+The above command works on macOS and Linux.
+
+On Windows PowerShell, use:
+
+```bash
+pip install pocketpaw
+pocketpaw
+```
+
+Alternatively, use Git Bash if you prefer the curl installation method.
 
 Or install directly:
 


### PR DESCRIPTION
## Fix Windows Installation Issue

The quick start command using `curl | sh` does not work on Windows PowerShell 
since `sh` is not available by default.

This PR:
- Clarifies that the curl command is for macOS/Linux
- Adds Windows-specific installation instructions using pip
- Improves cross-platform documentation clarity

This aligns the README with the project's cross-platform claim.