### PR TITLE
feat(claude-sdk): add model selection dropdown with friendly aliases

### DIFF
--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -107,8 +107,11 @@ class Settings(BaseSettings):
         description="Provider for Claude SDK: 'anthropic', 'ollama', or 'openai_compatible'",
     )
     claude_sdk_model: str = Field(
-        default="",
-        description="Model for Claude SDK backend (empty = let Claude Code auto-select)",
+        default="sonnet",
+        description=(
+            "Model alias for Claude SDK backend: "
+            "sonnet, opus, haiku, sonnet[1m], opusplan, or a raw model ID"
+        ),
     )
     claude_sdk_max_turns: int = Field(
         default=100,
@@ -144,9 +147,7 @@ class Settings(BaseSettings):
     )
 
     # Codex CLI Settings
-    codex_cli_model: str = Field(
-        default="gpt-5.3-codex", description="Model for Codex CLI backend"
-    )
+    codex_cli_model: str = Field(default="gpt-5.3-codex", description="Model for Codex CLI backend")
     codex_cli_max_turns: int = Field(
         default=100, description="Max turns per query in Codex CLI backend (0 = unlimited)"
     )
@@ -203,9 +204,7 @@ class Settings(BaseSettings):
     openai_api_key: str | None = Field(default=None, description="OpenAI API key")
     openai_model: str = Field(default="gpt-5.2", description="OpenAI model to use")
     anthropic_api_key: str | None = Field(default=None, description="Anthropic API key")
-    anthropic_model: str = Field(
-        default="claude-sonnet-4-6", description="Anthropic model to use"
-    )
+    anthropic_model: str = Field(default="claude-sonnet-4-6", description="Anthropic model to use")
 
     # Memory Backend
     memory_backend: str = Field(

--- a/src/pocketpaw/frontend/js/app.js
+++ b/src/pocketpaw/frontend/js/app.js
@@ -73,7 +73,8 @@ function app() {
         // Settings
         settings: {
             agentBackend: 'claude_agent_sdk',
-            claudeSdkModel: '',
+            claudeSdkModel: 'sonnet',
+            claudeSdkCustomModel: '',
             claudeSdkMaxTurns: 0,
             openaiAgentsModel: '',
             openaiAgentsMaxTurns: 0,

--- a/src/pocketpaw/frontend/templates/components/modals/settings.html
+++ b/src/pocketpaw/frontend/templates/components/modals/settings.html
@@ -394,23 +394,70 @@
                 />
               </div>
             </div>
-            <!-- Model override (Anthropic) -->
-            <div class="flex flex-col gap-1" x-show="settings.claudeSdkProvider === 'anthropic'">
-              <label
-                class="text-[12px] font-medium text-[var(--text-secondary)]"
-                >Model Override</label
-              >
-              <input
-                type="text"
-                x-model="settings.claudeSdkModel"
-                @change="saveSettings()"
-                placeholder="auto (recommended)"
-                class="w-full bg-black/30 border border-[var(--glass-border)] rounded-[10px] py-2 px-3 text-[13px] text-white focus:outline-none focus:border-[var(--accent-color)] focus:bg-black/40 transition-all placeholder-white/40"
-              />
-              <small class="text-white/50 text-[11px]"
-                >Leave empty to let Claude Code auto-select the best
-                model</small
-              >
+            <!-- Model selection (Anthropic) -->
+            <div
+              class="flex flex-col gap-1"
+              x-show="settings.claudeSdkProvider === 'anthropic'"
+              x-init="
+                const known = ['sonnet','opus','haiku','sonnet[1m]','opusplan',''];
+                if (settings.claudeSdkModel && !known.includes(settings.claudeSdkModel)) {
+                  claudeSdkCustomModel = settings.claudeSdkModel;
+                  settings.claudeSdkModel = '__custom__';
+                }
+              "
+            >
+              <label class="text-[12px] font-medium text-[var(--text-secondary)]">Model</label>
+              <div class="relative">
+                <select
+                  x-model="settings.claudeSdkModel"
+                  @change="
+                    if (settings.claudeSdkModel === '__custom__') {
+                      if (claudeSdkCustomModel) saveSettings();
+                    } else {
+                      claudeSdkCustomModel = '';
+                      saveSettings();
+                    }
+                  "
+                  class="w-full appearance-none bg-black/30 border border-[var(--glass-border)] rounded-[10px] py-2 px-3 text-[13px] text-white focus:outline-none focus:border-[var(--accent-color)] focus:bg-black/40 transition-all"
+                >
+                  <option value="sonnet">Sonnet (Default)</option>
+                  <option value="opus">Opus</option>
+                  <option value="haiku">Haiku</option>
+                  <option value="sonnet[1m]">Sonnet 1M</option>
+                  <option value="opusplan">OpusPlan</option>
+                  <option value="__custom__">Other...</option>
+                </select>
+                <div class="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none opacity-50">
+                  <i data-lucide="chevron-down" class="w-3.5 h-3.5"></i>
+                </div>
+              </div>
+              <!-- Custom model text input (shown only when "Other" is selected) -->
+              <template x-if="settings.claudeSdkModel === '__custom__'">
+                <input
+                  type="text"
+                  x-model="claudeSdkCustomModel"
+                  @change="
+                    if (claudeSdkCustomModel.trim()) {
+                      settings.claudeSdkModel = claudeSdkCustomModel.trim();
+                      saveSettings();
+                      $nextTick(() => { settings.claudeSdkModel = '__custom__'; });
+                    }
+                  "
+                  placeholder="e.g. claude-sonnet-4-6"
+                  class="w-full bg-black/30 border border-[var(--glass-border)] rounded-[10px] py-2 px-3 text-[13px] text-white focus:outline-none focus:border-[var(--accent-color)] focus:bg-black/40 transition-all placeholder-white/40 mt-1"
+                />
+              </template>
+              <small class="text-white/50 text-[11px]">
+                <template x-if="settings.claudeSdkModel === 'opusplan'">
+                  <span>Uses Opus for plan-mode, Sonnet otherwise</span>
+                </template>
+                <template x-if="settings.claudeSdkModel === 'sonnet[1m]'">
+                  <span>Sonnet with 1M token extended context</span>
+                </template>
+                <template x-if="settings.claudeSdkModel !== 'opusplan' && settings.claudeSdkModel !== 'sonnet[1m]' && settings.claudeSdkModel !== '__custom__'">
+                  <span>Select a Claude model or choose "Other" for a custom model ID</span>
+                </template>
+              </small>
             </div>
             <div class="flex flex-col gap-1">
               <label

--- a/tests/test_claude_sdk_aliases.py
+++ b/tests/test_claude_sdk_aliases.py
@@ -1,0 +1,81 @@
+"""Tests for Claude SDK model alias resolution."""
+
+import pytest
+
+from pocketpaw.agents.claude_sdk import (
+    _CLAUDE_MODEL_IDS,
+    _LONG_CONTEXT_ALIASES,
+    resolve_claude_model,
+)
+
+
+class TestResolveClaude:
+    """resolve_claude_model() — alias → (model_id, extended_context)."""
+
+    def test_sonnet_alias(self):
+        model, ext = resolve_claude_model("sonnet")
+        assert model == "claude-sonnet-4-6"
+        assert ext is False
+
+    def test_opus_alias(self):
+        model, ext = resolve_claude_model("opus")
+        assert model == "claude-opus-4-6"
+        assert ext is False
+
+    def test_haiku_alias(self):
+        model, ext = resolve_claude_model("haiku")
+        assert model == "claude-haiku-4-5-20251001"
+        assert ext is False
+
+    def test_sonnet_1m_alias(self):
+        model, ext = resolve_claude_model("sonnet[1m]")
+        assert model == "claude-sonnet-4-6"
+        assert ext is True
+
+    def test_opusplan_plan_mode_true(self):
+        model, ext = resolve_claude_model("opusplan", plan_mode=True)
+        assert model == "claude-opus-4-6"
+        assert ext is False
+
+    def test_opusplan_plan_mode_false(self):
+        model, ext = resolve_claude_model("opusplan", plan_mode=False)
+        assert model == "claude-sonnet-4-6"
+        assert ext is False
+
+    def test_case_insensitive(self):
+        for variant in ("Sonnet", "SONNET", "sOnNeT"):
+            model, _ = resolve_claude_model(variant)
+            assert model == "claude-sonnet-4-6", f"Failed for {variant!r}"
+
+    def test_raw_model_id_passthrough(self):
+        raw = "claude-sonnet-4-6"
+        model, ext = resolve_claude_model(raw)
+        assert model == raw
+        assert ext is False
+
+    def test_unknown_alias_passthrough(self):
+        model, ext = resolve_claude_model("my-custom-model-v2")
+        assert model == "my-custom-model-v2"
+        assert ext is False
+
+    def test_empty_string(self):
+        model, ext = resolve_claude_model("")
+        assert model == ""
+        assert ext is False
+
+    def test_whitespace_only(self):
+        model, ext = resolve_claude_model("   ")
+        assert model == ""
+        assert ext is False
+
+    def test_whitespace_stripped(self):
+        model, _ = resolve_claude_model("  sonnet  ")
+        assert model == "claude-sonnet-4-6"
+
+    def test_long_context_aliases_frozenset(self):
+        assert isinstance(_LONG_CONTEXT_ALIASES, frozenset)
+        assert "sonnet[1m]" in _LONG_CONTEXT_ALIASES
+
+    def test_all_aliases_present(self):
+        expected = {"sonnet", "opus", "haiku", "sonnet[1m]", "opusplan"}
+        assert expected == set(_CLAUDE_MODEL_IDS.keys())


### PR DESCRIPTION
## Summary
- Adds a model dropdown with friendly aliases (Sonnet, Opus, Haiku, Sonnet 1M, OpusPlan, Other) to the Claude SDK backend settings, replacing the raw text input
- Defaults to `sonnet` instead of empty (CLI auto-select)
- Adds `resolve_claude_model()` alias resolver that maps friendly names to model IDs, with case-insensitive matching and raw model ID passthrough
- Includes 14 unit tests for alias resolution

Closes #132

## Test plan
- [x] `uv run pytest tests/test_claude_sdk_aliases.py -v` — 14/14 pass
- [x] `uv run pytest tests/test_model_router.py -v` — 17/17 pass
- [x] `uv run pytest --ignore=tests/e2e -q` — 2266/2266 pass
- [x] `uv run ruff check` — clean
- [x] Manual: start dashboard, open Settings > General, verify dropdown with all 6 options
- [x] Manual: select "Other" and verify custom text input appears
- [x] Manual: refresh page and verify stored selection persists


https://github.com/user-attachments/assets/fbd78526-eaf4-49cc-931a-d4ee2e221144


