### PR TITLE
[FI] Clarify uv installation and fix Windows command not recognized.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,16 @@ See the [full configuration reference](https://docs.pocketpaw.xyz/getting-starte
 
 ```bash
 git clone https://github.com/pocketpaw/pocketpaw.git && cd pocketpaw
-uv sync --dev               # Install with dev deps
-uv run pocketpaw --dev      # Dashboard with auto-reload
+
+# Install uv if not already installed
+pip install uv
+
+# On Windows, if uv is not recognized, use:
+# python -m uv sync --dev
+# python -m uv run pocketpaw --dev
+
+uv sync --dev
+uv run pocketpaw --dev
 uv run pytest               # Run tests (2000+)
 uv run ruff check . && uv run ruff format .  # Lint & format
 ```


### PR DESCRIPTION
## What does this PR do?

This PR fixes a Windows installation issue where the `uv` command is not recognized when following the Development setup instructions in the README.

It adds clarification on installing `uv` and provides a fallback using `python -m uv` for Windows environments where the `uv` executable is not added to PATH automatically.

This improves cross-platform compatibility and helps developers successfully set up PocketPaw from source on Windows.

## Related Issue

Fixes #269 

## Changes Made

- `README.md`: Added instructions to install `uv` using pip if not already installed
- `README.md`: Added Windows fallback commands using `python -m uv`
- `README.md`: Improved clarity of Development setup instructions

## How to Test

1. Clone the repository
2. Install uv using: `pip install uv`
3. Run: `python -m uv sync --dev`
4. Run: `python -m uv run pocketpaw --dev`
5. Verify the dashboard starts without errors

## Evidence of Testing
![Bug_reporting2](https://github.com/user-attachments/assets/f1440e55-3dc2-4e8e-9120-cd5911e426fa)


## Checklist

- [x] I have run PocketPaw locally and tested my changes
- [x] This PR is linked to an existing issue
- [ ] I have added/updated tests if applicable
- [x] I have not made whitespace-only or typo-only changes
- [x] My code follows the existing style in the codebase