### PR TITLE
[FIRST] Improve LLM backend error handling with user-friendly messages

### DIFF
--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -730,7 +730,47 @@ class ClaudeAgentSDK:
                     ),
                 )
             else:
-                yield AgentEvent(type="error", content=llm.format_api_error(e))
+                error_text = error_msg.lower()
+
+                if (
+                    "authentication" in error_text
+                    or "api key" in error_text
+                    or "not configured" in error_text
+                ):
+                    friendly = (
+                        "❌ Authentication failed.\n\n"
+                        "Please check your API key in Settings → API Keys."
+                    )
+
+                elif "connection" in error_text or "unreachable" in error_text:
+                    friendly = (
+                        "🌐 Cannot connect to the LLM backend.\n\n"
+                        "Please check:\n"
+                        "- Your internet connection\n"
+                        "- If Ollama is running (ollama serve)\n"
+                        "- If the backend service is reachable"
+                    )
+
+                elif "timeout" in error_text:
+                    friendly = (
+                        "⏳ The request timed out.\n\n"
+                        "Please try again."
+                    )
+
+                elif "rate limit" in error_text:
+                    friendly = (
+                        "🚦 Rate limit exceeded.\n\n"
+                        "Please wait a moment and try again."
+                    )
+
+                else:
+                    friendly = (
+                        "⚠️ The LLM backend is currently unavailable.\n\n"
+                        "Please check your configuration in Settings."
+                    )
+
+                yield AgentEvent(type="error", content=friendly)
+
 
     async def stop(self) -> None:
         """Stop the agent execution."""


### PR DESCRIPTION
## What does this PR do?

Improves LLM backend error handling by converting backend exceptions into user-friendly chat messages instead of exposing raw Python tracebacks.

Previously, when an LLM backend (Claude, Ollama, etc.) failed due to authentication errors, connection issues, timeouts, or rate limits, users could see raw or confusing error output. This PR ensures clear, actionable messages are shown instead.

## Related Issue

Fixes #34 

## Changes Made

- src/pocketpaw/agents/loop.py:
  - Added centralized `_format_friendly_error()` helper
  - Improved `TimeoutError` handling
  - Ensured no raw traceback reaches the UI

- src/pocketpaw/agents/claude_sdk.py:
  - Added structured exception handling for:
    - Authentication errors
    - Connection errors
    - Timeout errors
    - Rate limit errors
  - Emits clean `AgentEvent(type="error")` messages instead of raw exceptions

## How to Test

1. Run PocketPaw locally.
2. Misconfigure or disable an LLM backend (e.g., remove API key or stop Ollama).
3. Send a message in the UI.
4. Confirm that a friendly error message appears instead of a raw Python traceback.

## Evidence of Testing

Tested locally by disabling backend services.

Observed behavior:
- UI displayed a friendly timeout/error message.
- No Python traceback appeared in the chat.
- Full exception details remained available in server logs.

## Checklist

- [x] I have run PocketPaw locally and tested my changes
- [x] This PR is linked to an existing issue
- [ ] I have added/updated tests if applicable
- [x] I have not made whitespace-only or typo-only changes
- [x] My code follows the existing style in the codebase