### PR TITLE
[FI] fix: implement port fallback for Windows and update README curl …

### DIFF
--- a/src/pocketpaw/__main__.py
+++ b/src/pocketpaw/__main__.py
@@ -731,7 +731,17 @@ Examples:
             asyncio.run(run_multi_channel_mode(settings, args))
         else:
             # Default: web dashboard (also handles --web flag)
-            run_dashboard_mode(settings, host, args.port, dev=args.dev)
+            from pocketpaw.web_server import find_available_port
+            try:
+                # Automatically find a free port if the default 8888 is taken
+                final_port = find_available_port(args.port)
+                if final_port != args.port:
+                    logger.warning(f"⚠️ Port {args.port} was busy. Using {final_port} instead.")
+                
+                run_dashboard_mode(settings, host, final_port, dev=args.dev)
+            except OSError:
+                logger.error(f"❌ Could not find any available ports starting from {args.port}.")
+                sys.exit(1)
     except KeyboardInterrupt:
         logger.info("👋 PocketPaw stopped.")
     finally:


### PR DESCRIPTION
## What does this PR do?
This PR prevents the application from crashing on Windows systems when the default port (8888) is already occupied. It also updates the README to provide the correct command escaping for Windows Command Prompt users.

## Related Issue
Fixes #217

## Changes Made
- `src/pocketpaw/__main__.py`: Added `find_available_port` logic to catch `OSError` and fall back to an open port.
- `README.md`: Updated installation instructions with `^` escaping for multi-line curl commands in CMD.

## How to Test
1. Run another service on port 8888 (e.g., `python -m http.server 8888`).
2. Run `pocketpaw` in the terminal.
3. Verify the app successfully starts on 8889 instead of crashing with `WinError 10048`.

## Checklist
- [x] I have run PocketPaw locally and tested my changes
- [x] This PR is linked to an existing issue
- [x] I have not made whitespace-only or typo-only changes
- [x] My code follows the existing style in the codebase