### PR TITLE
[FIRST] Remove deprecated pocketpaw_native backend from insatller options

### DIFF
--- a/installer/installer.py
+++ b/installer/installer.py
@@ -211,7 +211,6 @@ FEATURE_GROUPS: dict[str, list[tuple[str, str]]] = {
 
 BACKENDS = {
     "claude_agent_sdk": "Claude Agent SDK (recommended)",
-    "pocketpaw_native": "PocketPaw Native (Anthropic + Open Interpreter)",
     "open_interpreter": "Open Interpreter (Experimental — Ollama/OpenAI/Anthropic)",
 }
 
@@ -1207,7 +1206,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--backend",
-        choices=["claude_agent_sdk", "pocketpaw_native", "open_interpreter"],
+        choices=["claude_agent_sdk", "open_interpreter"],
         default=None,
         help="Agent backend (non-interactive)",
     )


### PR DESCRIPTION
## What does this PR do?

This PR removes the deprecated `pocketpaw_native` backend from the installer options and CLI backend selection.

## Related Issue

Fixes #255

## Changes Made

- `installer/installer.py`:  
  - Removed `pocketpaw_native` from `BACKENDS` dictionary.  
  - Removed `pocketpaw_native` from CLI backend selection choices.  
  - Kept legacy mapping intact in registry for backward compatibility.

## How to Test

1. Run the installer CLI.
2. Verify that `pocketpaw_native` no longer appears as a selectable backend.
3. Confirm that other backends (e.g., `claude_agent_sdk`, `open_interpreter`) are unaffected.

## Evidence of Testing

Manual verification completed locally.  
`pocketpaw_native` no longer appears in installer backend options.

## Checklist

-  I have tested my changes locally
-  This PR is linked to an existing issue
-  I have not made whitespace-only or typo-only changes
- My code follows the existing style in the codebase

