### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pocketpaw"
-version = "0.4.3"
+version = "0.5.0"
 description = "The AI agent that runs on your laptop, not a datacenter. OpenClaw alternative with one-command install."
 readme = "README.md"
 license = "MIT"

--- a/src/pocketpaw/__init__.py
+++ b/src/pocketpaw/__init__.py
@@ -1,3 +1,3 @@
 """PocketPaw - The AI agent that runs on your laptop, not a datacenter."""
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"


### PR DESCRIPTION
## Summary

- Bump version from 0.4.3 to 0.5.0 for the minor release
- Fix version mismatch between `pyproject.toml` (was 0.4.3) and `__init__.py` (was 0.4.2)

## Test Plan

- [x] Version string updated in both `pyproject.toml` and `src/pocketpaw/__init__.py`
- [x] No other hardcoded version references in source