### PR TITLE
chore: fix version to 0.4.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pocketpaw"
-version = "0.5.0"
+version = "0.4.4"
 description = "The AI agent that runs on your laptop, not a datacenter. OpenClaw alternative with one-command install."
 readme = "README.md"
 license = "MIT"

--- a/src/pocketpaw/__init__.py
+++ b/src/pocketpaw/__init__.py
@@ -1,3 +1,3 @@
 """PocketPaw - The AI agent that runs on your laptop, not a datacenter."""
 
-__version__ = "0.5.0"
+__version__ = "0.4.4"


### PR DESCRIPTION
## Summary

Fix version from 0.5.0 back to 0.4.4 for this patch release.

## Test Plan

- [x] `pyproject.toml` and `__init__.py` both set to 0.4.4