### PR TITLE
Improve Windows uv installation error messaging with manual fallback

### DIFF
--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -128,8 +128,16 @@ if (-not $Python) {
                 Write-Ok "uv installed"
             }
         } catch {
-            Write-Warn "Could not install uv automatically."
-        }
+    Write-Warn "Could not install uv automatically."
+
+    Write-Host ""
+    Write-Host "Manual installation instructions for Windows:" -ForegroundColor Yellow
+    Write-Host "1. Run this command in PowerShell:" -ForegroundColor Yellow
+    Write-Host '   irm https://astral.sh/uv/install.ps1 | iex'
+    Write-Host ""
+    Write-Host "2. Restart your PowerShell after installation." -ForegroundColor Yellow
+    Write-Host "3. Then re-run this installer." -ForegroundColor Yellow
+}
     }
 
     if ($uvAvailable) {


### PR DESCRIPTION
## Summary

Improves the Windows installer experience by enhancing the error message shown when `uv` installation fails.

Instead of only displaying a generic warning, this update provides clear manual installation instructions for Windows users, including:

- Direct PowerShell command to install `uv`
- Instruction to restart PowerShell
- Guidance to re-run the installer

This improves user experience and reduces confusion during setup.

---

## Changes Made

- **installer/install.ps1**
  - Enhanced the `catch` block for `uv` installation failure.
  - Added manual fallback instructions for Windows users.
  - Maintained existing logic and flow.

---

## How to Test

1. Run the Windows installer (`install.ps1`) on a system without `uv`.
2. Simulate a failed `uv` installation.
3. Verify that manual installation instructions are clearly displayed.

---

## Checklist

- [x] I have tested the changes locally
- [x] No existing logic was broken
- [x] This change only improves user messaging