### PR TITLE
fix: correct hatchling wheel build configuration for src-layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,10 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/pocketpaw"]
+only-include = ["src/pocketpaw"]
+
+[tool.hatch.build.targets.wheel.sources]
+"src" = ""
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary

Fixes #284

This PR corrects the hatchling wheel build configuration to properly handle the src-layout directory structure. The previous configuration was causing `ModuleNotFoundError: No module named 'pocketpaw'` after pip installation.

## Changes

- Changed `packages = ["src/pocketpaw"]` to use `only-include` with source remapping
- Added `[tool.hatch.build.targets.wheel.sources]` section that maps `"src" = ""`
- This ensures the pocketpaw module is installed at the correct import path

## Root Cause

The previous `packages` directive didn't properly remap the src directory structure in the wheel, causing the module to be installed in an incorrect location where Python couldn't import it.

## Testing

- ✅ Built the wheel using `python3 -m build`
- ✅ Verified wheel contents show correct structure (`pocketpaw/` not `src/pocketpaw/`)
- ✅ Installed in clean virtual environment
- ✅ Confirmed `pocketpaw` command works (`pocketpaw --version`)
- ✅ Confirmed module import works (`import pocketpaw`)
- ✅ Linting passes (`uv run ruff check .`)

## Checklist

- [x] Branch is based on `dev` (not `main`)
- [x] PR targets the `dev` branch
- [x] Linting passes (`uv run ruff check .`)
- [x] No secrets or credentials in the diff
- [x] Tested wheel installation in clean environment