### PR TITLE
[FI] fix: install.ps1 missing .uv\bin in PATH and install.sh drops cache headers

### DIFF
--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -187,7 +187,7 @@ if (Get-Command uv -ErrorAction SilentlyContinue) {
     Write-Step "Installing uv (fast Python package manager)..."
     try {
         Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression 2>$null
-        $env:PATH = "$env:USERPROFILE\.local\bin;$env:USERPROFILE\.cargo\bin;$env:PATH"
+        $env:PATH = "$env:USERPROFILE\.local\bin;$env:USERPROFILE\.cargo\bin;$env:USERPROFILE\.uv\bin;$env:PATH"
         if (Get-Command uv -ErrorAction SilentlyContinue) {
             $uvAvailable = $true
             Write-Ok "uv installed"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -220,21 +220,13 @@ else
     INSTALLER="$TMPDIR/pocketpaw_installer.py"
     NEED_CLEANUP=1
 
-    INSTALLER_URL="${POCKETPAW_INSTALLER_URL:-https://raw.githubusercontent.com/pocketpaw/pocketpaw/main/installer/installer.py}"
-
-    if command -v curl >/dev/null 2>&1; then
-        DOWNLOAD="curl -fsSL"
-    elif command -v wget >/dev/null 2>&1; then
-        DOWNLOAD="wget -qO-"
-    else
-        printf '\033[31mError:\033[0m Neither curl nor wget found.\n'
-        exit 1
-    fi
+    # Reuse INSTALLER_URL, FALLBACK_URL, and DOWNLOAD defined at the top of
+    # the script. The originals include cache-busting headers (Cache-Control /
+    # --no-cache) which are important behind corporate proxies and CDNs.
 
     printf '  Downloading installer...\n'
     if ! $DOWNLOAD "$INSTALLER_URL" > "$INSTALLER" 2>/dev/null; then
         printf '\033[33mWarn:\033[0m Primary download failed, trying fallback...\n'
-        FALLBACK_URL="https://raw.githubusercontent.com/pocketpaw/pocketpaw/dev/installer/installer.py"
         if ! $DOWNLOAD "$FALLBACK_URL" > "$INSTALLER" 2>/dev/null; then
             printf '\033[31mError:\033[0m Could not download installer.\n'
             printf '       Try manually: %s\n' "$INSTALLER_URL"


### PR DESCRIPTION
Fixes #XXX

## Problem

Two bugs in the installation scripts:

1. **install.ps1 (Windows)**: The second uv PATH refresh (line 190) is missing
   `$env:USERPROFILE\.uv\bin`, while the first refresh (line 125) correctly
   includes it. If uv installs to `.uv\bin`, the second attempt to locate uv
   fails silently.

2. **install.sh (macOS/Linux)**: The `DOWNLOAD` helper is redefined at line 225
   without the `Cache-Control:no-cache` / `--no-cache` headers from the original
   definition (lines 30-33). This means `installer.py` downloads could receive
   stale cached versions from CDNs or corporate proxies. `INSTALLER_URL` and
   `FALLBACK_URL` were also redundantly redefined with the same values already
   set at lines 39-40.

## Changes

- **install.ps1**: Add `$env:USERPROFILE\.uv\bin` to the second PATH refresh
  (line 190) to match the first (line 125)
- **install.sh**: Remove redundant `DOWNLOAD`, `INSTALLER_URL`, and
  `FALLBACK_URL` redefinitions — reuse the originals defined at the top of the
  script that include cache-busting headers

## How I found this

Compared the two PATH refresh blocks in `install.ps1` (lines 125 vs 190) and
noticed `.uv\bin` was missing from the second one. For `install.sh`, traced the
`DOWNLOAD` variable from its initial definition (line 30) through its
redefinition (line 225) and noticed the cache headers were dropped.