### PR TITLE
[FI] Fix missing .uv\bin in PATH refresh for Windows installer

### DIFF
--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -187,7 +187,7 @@ if (Get-Command uv -ErrorAction SilentlyContinue) {
     Write-Step "Installing uv (fast Python package manager)..."
     try {
         Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression 2>$null
-        $env:PATH = "$env:USERPROFILE\.local\bin;$env:USERPROFILE\.cargo\bin;$env:PATH"
+        $env:PATH = "$env:USERPROFILE\.local\bin;$env:USERPROFILE\.cargo\bin;$env:USERPROFILE.uv\bin;$env:PATH"
         if (Get-Command uv -ErrorAction SilentlyContinue) {
             $uvAvailable = $true
             Write-Ok "uv installed"


### PR DESCRIPTION
Added missing $env:USERPROFILE\.uv\bin to second PATH refresh block so uv command is detected correctly after installation.

## What does this PR do?

## Related Issue
Fixes # 295

## Changes Made
- installer/install.ps1 : Added missing $env:USERPROFILE\.uv\bin to second PATH refresh block

## How to Test
1. Run installer/install.ps1 on Windows
2. Verify uv command is detected after PATH refresh
3. Confirm installation proceeds without fallback


## Checklist

- [ ] I have run PocketPaw locally and tested my changes
- [x] This PR is linked to an existing issue
- [ ] I have added/updated tests if applicable
- [x] I have not made whitespace-only or typo-only changes
- [x] My code follows the existing style in the codebase
