### PR TITLE
docs: update docs URL from docs.pocketpaw.xyz to pocketpaw.xyz

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Everything goes through an event-driven message bus. Channels publish messages, 
   <img src="docs/public/pocketpaw-security-stack.webp" alt="PocketPaw 7-Layer Security Stack" width="500">
 </p>
 
-A secondary LLM (Guardian AI) reviews every tool call before it runs. On top of that: injection scanning, configurable tool policies, plan mode for human approval, `--security-audit` CLI, a self-audit daemon, and an append-only audit log. [Details in the docs](https://docs.pocketpaw.xyz/security).
+A secondary LLM (Guardian AI) reviews every tool call before it runs. On top of that: injection scanning, configurable tool policies, plan mode for human approval, `--security-audit` CLI, a self-audit daemon, and an append-only audit log. [Details in the docs](https://pocketpaw.xyz/security).
 
 <details>
 <summary>Detailed security architecture</summary>
@@ -280,7 +280,7 @@ export POCKETPAW_AGENT_BACKEND="claude_agent_sdk"  # or openai_agents, google_ad
 
 > **Note:** An Anthropic API key from [console.anthropic.com](https://console.anthropic.com/api-keys) is required for the Claude SDK backend. OAuth tokens from Claude Free/Pro/Max plans are [not permitted](https://code.claude.com/docs/en/legal-and-compliance#authentication-and-credential-use) for third-party use. For free local inference, use Ollama instead.
 
-See the [full configuration reference](https://docs.pocketpaw.xyz/getting-started/configuration) for all settings.
+See the [full configuration reference](https://pocketpaw.xyz/getting-started/configuration) for all settings.
 
 ---
 
@@ -343,7 +343,7 @@ pip install pocketpaw[all]                 # Everything
 
 ## Documentation
 
-**[docs.pocketpaw.xyz](https://docs.pocketpaw.xyz)** covers getting started, backends, channels, tools, integrations, security, memory, and the full API reference.
+**[pocketpaw.xyz](https://pocketpaw.xyz)** covers getting started, backends, channels, tools, integrations, security, memory, and the full API reference.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 The official documentation for [PocketPaw](https://github.com/pocketpaw/pocketpaw) — a self-hosted AI agent controlled via Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Teams, Google Chat, or a web dashboard.
 
-**Live site:** [docs.pocketpaw.xyz](https://docs.pocketpaw.xyz)
+**Live site:** [pocketpaw.xyz](https://pocketpaw.xyz)
 
 ## Stack
 

--- a/docs/integrations/mcp-servers.mdx
+++ b/docs/integrations/mcp-servers.mdx
@@ -148,14 +148,14 @@ The solution is CIMD: you host a small JSON file at a publicly accessible URL, a
 2. Set the URL in PocketPaw's config:
 
 ```bash
-export POCKETPAW_MCP_CLIENT_METADATA_URL="https://docs.pocketpaw.xyz/mcp-client.json"
+export POCKETPAW_MCP_CLIENT_METADATA_URL="https://pocketpaw.xyz/mcp-client.json"
 ```
 
 Or set it in `~/.pocketpaw/config.json`:
 
 ```json
 {
-  "mcp_client_metadata_url": "https://docs.pocketpaw.xyz/mcp-client.json"
+  "mcp_client_metadata_url": "https://pocketpaw.xyz/mcp-client.json"
 }
 ```
 


### PR DESCRIPTION
## Summary
- Update all documentation URLs from `docs.pocketpaw.xyz` to `pocketpaw.xyz` across README, docs README, and MCP servers integration guide
- The documentation site has moved from the `docs` subdomain to the root domain

## Files changed
- `README.md` — 3 URL references updated
- `docs/README.md` — live site link updated
- `docs/integrations/mcp-servers.mdx` — CIMD example URLs updated

## Test plan
- [x] Verify links resolve correctly to the new domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)