### PR TITLE
docs: document Playwright browser installation for e2e tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,12 @@ uv run pocketpaw --discord --slack
 # Run in development mode (auto-reload on file changes)
 uv run pocketpaw --dev
 
-# Run all tests
-uv run pytest
+# Run all tests (unit)
+uv run pytest tests/ --ignore=tests/e2e
+
+# Run e2e tests (requires Playwright browsers to be installed first)
+uv run playwright install
+uv run pytest tests/e2e/ -v
 
 # Run a single test file
 uv run pytest tests/test_bus.py

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -6,6 +6,9 @@
 # - Browser configuration
 # - Test isolation
 #
+# Prerequisites:
+#   uv run playwright install   # download browser binaries (one-time)
+#
 # Run with: pytest tests/e2e/ -v
 # Run headed (see browser): pytest tests/e2e/ -v --headed
 


### PR DESCRIPTION
Fixes #326

## Problem

The e2e test suite requires Playwright browser binaries (`playwright install`) but this prerequisite isn't documented anywhere. All 25 e2e tests fail with `fixture 'page' not found` for new contributors.

## Changes

1. **CLAUDE.md**: Split test commands into unit vs e2e, added `uv run playwright install` prerequisite
2. **tests/e2e/conftest.py**: Added prerequisite note to file header