### PR TITLE
docs: add playwright install step to fix e2e fixture 'page' not found errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,11 @@ PocketPaw is a self-hosted AI agent that runs locally and is controlled via Tele
 # Install dev dependencies
 uv sync --dev
 
+# Install Playwright browsers (required for e2e tests in tests/e2e/)
+uv run playwright install
+# On Windows if the above fails (uv trampoline error), use:
+# .venv\Scripts\python -m playwright install
+
 # Run the app (web dashboard is the default — auto-starts all configured adapters)
 uv run pocketpaw
 
@@ -34,13 +39,19 @@ uv run pocketpaw --discord --slack
 uv run pocketpaw --dev
 
 # Run all tests
-uv run pytest
+uv run python -m pytest
+
+# Run unit tests only (excludes e2e — no browser required)
+uv run python -m pytest --ignore=tests/e2e
+
+# Run e2e tests only (requires: uv run playwright install first)
+uv run python -m pytest tests/e2e/ -v
 
 # Run a single test file
-uv run pytest tests/test_bus.py
+uv run python -m pytest tests/test_bus.py
 
 # Run a specific test
-uv run pytest tests/test_bus.py::test_publish_subscribe -v
+uv run python -m pytest tests/test_bus.py::test_publish_subscribe -v
 
 # Lint
 uv run ruff check .

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -6,8 +6,13 @@
 # - Browser configuration
 # - Test isolation
 #
-# Run with: pytest tests/e2e/ -v
-# Run headed (see browser): pytest tests/e2e/ -v --headed
+# Prerequisites (one-time setup):
+#   uv sync --dev
+#   uv run playwright install
+#
+# Run with: uv run python -m pytest tests/e2e/ -v
+# Run headed (see browser): uv run python -m pytest tests/e2e/ -v --headed
+# Run unit tests only (no browser needed): uv run python -m pytest --ignore=tests/e2e
 
 import os
 import socket


### PR DESCRIPTION
## What does this PR do?

Documents the required `playwright install` step that was missing from the setup instructions. Without it, all 25 e2e tests fail immediately with `fixture 'page' not found` on a fresh clone. Also fixes `uv run pytest` → `uv run python -m pytest` which hits a uv trampoline error on Windows.

## Related Issue

Fixes #326

## Changes Made

- `CLAUDE.md`: Add `uv run playwright install` step after `uv sync --dev`, add Windows fallback (`.venv\Scripts\python -m playwright install`), fix `uv run pytest` → `uv run python -m pytest`, add separate unit-only and e2e-only test commands
- `tests/e2e/conftest.py`: Update header comment with prerequisites and correct run commands

## How to Test

1. Fresh clone the repo and run `uv sync --dev` (do NOT run `playwright install` yet)
2. Run `uv run python -m pytest tests/e2e/ -v` — all 25 tests should error with `fixture 'page' not found`
3. Run `.venv\Scripts\python -m playwright install` (Windows) or `uv run playwright install` (Linux/Mac)
4. Run `uv run python -m pytest tests/e2e/ -v` again — tests should now run (no more fixture errors)

## Evidence of Testing

Before fix (no playwright install):
ERRORS
fixture 'page' not found
available fixtures: anyio_backend, anyio_backend_options, browser,
browser_context_args, browser_name, browser_type, dashboard_port,
dashboard_server, dashboard_url, event_loop, is_chromium, is_firefox,
is_webkit, launch_browser_args, pytestconfig
25 errors

After running .venv\Scripts\python -m playwright install:
tests/e2e/test_chat.py::test_page_loads PASSED
tests/e2e/test_chat.py::test_sidebar_toggle PASSED
... (9 passed, remaining failures are pre-existing stale selectors)


## Checklist

- [x] I have run PocketPaw locally and tested my changes
- [x] This PR is linked to an existing issue
- [x] I have added/updated tests if applicable
- [x] I have not made whitespace-only or typo-only changes
- [x] My code follows the existing style in the codebase