### PR TITLE
fix(security): remove session_secret from /setup JSON response

### DIFF
--- a/src/pocketpaw/web_server.py
+++ b/src/pocketpaw/web_server.py
@@ -385,7 +385,12 @@ def create_app(settings: Settings) -> FastAPI:
 
             _temp_bot_app = app
 
-            return {"qr_url": qr_data, "session_secret": _session_secret}
+            # Return only the QR image data — never expose the session_secret
+            # in the HTTP response body. The secret is embedded inside the QR
+            # code URL and must stay server-side; returning it here would let
+            # any JS running on the page (or anyone reading DevTools) steal the
+            # Telegram pairing token before the legitimate user scans it.
+            return {"qr_url": qr_data}
 
         except Exception as e:
             logger.error(f"Setup failed: {e}")


### PR DESCRIPTION
## What does this PR do?

[web_server.py](cci:7://file:///C:/Users/prajw/OneDrive/Desktop/PocketPaw/pocketpaw-repo/src/pocketpaw/web_server.py:0:0-0:0) was returning the Telegram pairing secret directly in the HTTP JSON response alongside the QR image. The secret is embedded inside the QR code URL and must stay server-side — exposing it in the response body leaks it to browser DevTools, XSS scripts, network observers, and server access logs.

## Related Issue

Fixes #<!-- add issue number if one exists, or remove this line -->

## Changes Made

- [src/pocketpaw/web_server.py](cci:7://file:///C:/Users/prajw/OneDrive/Desktop/PocketPaw/pocketpaw-repo/src/pocketpaw/web_server.py:0:0-0:0): Removed `session_secret` from the `/setup` endpoint's JSON response. The response now returns only `{"qr_url": qr_data}`. The secret remains server-side in the `_session_secret` global and is already embedded inside the QR image.

## How to Test

1. Run PocketPaw and open the Telegram setup page in the dashboard.
2. Enter a valid bot token and submit.
3. Open Chrome DevTools → Network → find the POST `/setup` response.
4. Verify the response body contains only `{"qr_url": "data:image/png;..."}` and **does not** contain a `session_secret` field.
5. Confirm the QR code still renders and can be scanned to complete pairing.

## Evidence of Testing

**Before (vulnerable):**
```json
{
  "qr_url": "data:image/png;base64,...",
  "session_secret": "abc123xyz..."
}