### PR TITLE
fix: initialize router=None before try block to prevent UnboundLocalError in error handler

### DIFF
--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -187,6 +187,7 @@ class AgentLoop:
                     )
                 )
 
+        router = None
         try:
             # 0. Injection scan for non-owner sources
             content = message.content
@@ -432,11 +433,12 @@ class AgentLoop:
                 )
             except Exception:
                 pass
-            # Kill the backend on error
-            try:
-                await router.stop()
-            except Exception:
-                pass
+            # Kill the backend on error (guard against router never being initialized)
+            if router is not None:
+                try:
+                    await router.stop()
+                except Exception:
+                    pass
 
             # Apply output redaction to exception messages
             error_msg = redact_output(f"An error occurred: {str(e)}")


### PR DESCRIPTION
## What does this PR do?
Fixes a latent UnboundLocalError in `_process_message_inner` (agents/loop.py). When any exception is raised before `router = self._get_router()` is reached, the error handler calls `await router.stop()` on an unbound variable. The resulting `UnboundLocalError` is silently swallowed, causing the backend process to never be properly terminated.


## Related Issue
Fixes #333

## Changes Made
- `src/pocketpaw/agents/loop.py`: Initialize `router = None` before the outer try block; guard `router.stop()` with `if router is not None:`

## How to Test
1. In agents/loop.py, temporarily add `raise RuntimeError("test")` at line 269 (before `router = self._get_router()`)
2. Run: uv run pocketpaw
3. Send any message via the web dashboard
4. Before fix: router.stop() silently raises UnboundLocalError — backend not cleaned up
5. After fix: error is logged cleanly, cleanup is skipped safely, no UnboundLocalError


## Evidence of Testing
# Before fix — server log shows RuntimeError, router.stop() silently fails:
ERROR    ❌ Error processing message: DEMO: simulated failure before router init

```
         Traceback (most recent call last):
           File "src/pocketpaw/agents/loop.py", line 269, in _process_message_inner
             raise RuntimeError("DEMO: simulated failure before router init")
         RuntimeError: DEMO: simulated failure before router init
```
UnboundLocalError on router.stop() swallowed silently — backend not stopped

After fix — same error logged, cleanup correctly skipped:
ERROR    ❌ Error processing message: DEMO: simulated failure before router init
         RuntimeError: DEMO: simulated failure before router init
router is None → if router is not None guard skips stop() safely ✓

## Checklist

- [x] I have run PocketPaw locally and tested my changes
- [x] This PR is linked to an existing issue
- [ ] I have added/updated tests if applicable
- [x] I have not made whitespace-only or typo-only changes
- [x] My code follows the existing style in the codebase
