### PR TITLE
[FI] Docs: Improve troubleshooting section for installation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,26 @@ The web dashboard opens at `http://localhost:8888`. From there you can connect D
 
 ---
 
+
+## 🛠️ Troubleshooting
+
+If you encounter issues during installation, check these common solutions:
+
+- **Python/pip not found:** Ensure Python 3.11+ is installed and added to your system **PATH**. On Windows, try using `python -m pip` if `pip` isn't recognized.
+- **Virtual Environments:** We recommend using a venv to avoid conflicts:
+  ```bash
+  python -m venv .venv
+  source .venv/bin/activate  # macOS/Linux
+  .venv\Scripts\activate     # Windows
+  ```
+- **Upgrade pip:** `python -m pip install --upgrade pip`
+- **Clean Reinstall:** `pip uninstall pocketpaw && pip install pocketpaw[all]`
+- **PATH Issues:** If the `pocketpaw` command isn't found after install, you can always run it via `python -m pocketpaw`.
+
+For more detailed guidance, see the [Full Installation Guide](https://docs.pocketpaw.xyz/getting-started/installation#troubleshooting).
+
+---
+
 ## Features
 
 | | |

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -158,6 +158,61 @@ docker compose up -d
 
 The image includes all extras, Playwright Chromium, and OCR support. See the [Docker deployment guide](/deployment/docker) for optional Ollama/Qdrant services and configuration details.
 
+## Troubleshooting
+
+### Common Installation Issues
+
+#### 1. Python or pip not found
+PocketPaw requires **Python 3.11** or higher.
+- Verify your version: `python --version` or `python3 --version`
+- If you see `command not found`, ensure Python is installed and added to your system's **PATH**.
+- On **Windows**, if `pip` is not recognized, try using `python -m pip` instead.
+
+#### 2. Virtual Environment Setup
+To avoid dependency conflicts, we recommend using a virtual environment:
+```bash
+# Create a virtual environment
+python -m venv .venv
+
+# Activate it
+# Windows:
+.venv\Scripts\activate
+# macOS/Linux:
+source .venv/bin/activate
+```
+
+#### 3. Upgrading pip
+Old versions of `pip` can cause installation failures with modern packages. Update it using:
+```bash
+python -m pip install --upgrade pip
+```
+
+#### 4. Dependency Errors
+If you encounter errors during installation:
+- Ensure you have a stable internet connection.
+- Try a clean reinstall:
+  ```bash
+  pip uninstall pocketpaw
+  pip install pocketpaw[all]
+  ```
+- If using the `[browser]` extra, ensure Playwright dependencies are installed:
+  ```bash
+  playwright install chromium
+  ```
+
+#### 5. PATH Configuration (Windows)
+If you've installed PocketPaw but the `pocketpaw` command still isn't found:
+- Python's `Scripts` folder might not be in your PATH.
+- You can always run it via Python: `python -m pocketpaw`
+
+### Verification Commands
+Use these commands to confirm your environment is ready:
+```bash
+python --version      # Should be 3.11.x or higher
+pip --version         # Verifies pip is working
+pocketpaw --version   # Verifies PocketPaw installation
+```
+
 ## Verify Installation
 
 ```bash

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -22,7 +22,7 @@ On **Windows PowerShell**, use:
 powershell -NoExit -Command "iwr -useb https://pocketpaw.xyz/install.ps1 | iex"
 ```
 
-**Tip:** If the install command fails, make sure Python 3.11+ is installed and available in your system PATH.
+**Tip:** If the install command fails, make sure Python 3.11+ is installed and available in your system PATH. See the [Troubleshooting Guide](/getting-started/installation#troubleshooting) for help.
 
 
 ## Step 2: Set Your API Key


### PR DESCRIPTION
## What does this PR do?

This PR improves the troubleshooting section in the installation documentation.  
It clarifies installation steps, fixes formatting issues, and adds clearer guidance for users facing installation errors.

## Related Issue

Fixes #330 

## Changes Made

<!-- List the specific files changed and what was modified in each. -->

- `README.md`: improved installation troubleshooting clarity and formatting  
- `docs/getting-started/installation.mdx`: refined installation steps and command formatting  
- `docs/getting-started/quick-start.mdx`: added clearer instructions and troubleshooting hints  

## How to Test

1. Open the documentation locally using this command
```
cd docs
npx --yes @litodocs/cli dev -i .
```
2. Navigate to the installation and quick-start sections.
3. Verify the troubleshooting steps are clear and formatted correctly.
4. Confirm commands display properly in terminal blocks.

## Evidence of Testing

<!-- Paste terminal output, test results, or screenshots proving you tested locally. -->

```
┌   Lito - Dev Server 
│
◇  Using template: /Users/paramkhodiyar/.lito/templates/Lito-docs-lito-astro-template-main
│
◇  Project scaffolded
│
◇  Using framework: astro
│
◇  Project prepared (dependencies installed, docs synced, navigation generated)
│
◇  Configuration generated
│
●  Watching for file changes...
│
◇  Dev Server ─────────────────────────────────────────╮
│                                                      │
│  Starting astro dev server at http://localhost:4321  │
│                                                      │
├──────────────────────────────────────────────────────╯

> astro-docs-template@1.0.0 astro /Users/paramkhodiyar/.lito/dev-project
> astro dev --port 4321

14:36:46 [astro-mermaid] Setting up Mermaid integration
14:36:46 [astro-mermaid] Existing rehype plugins:
14:36:46 [astro-mermaid] Enabling ELK support
14:36:46 [types] Generated 0ms
14:36:46 [content] Syncing content
14:36:46 [content] Synced content

 astro  v5.17.2 ready in 2119 ms

┃ Local    http://localhost:4321/
┃ Network  use --host to expose

14:36:46 watching for file changes...
```
<img width="1512" height="949" alt="Screenshot 2026-02-25 at 14 38 06" src="https://github.com/user-attachments/assets/67ae2199-45d7-4317-a318-814c95c70855" />
<img width="1512" height="949" alt="Screenshot 2026-02-25 at 14 38 11" src="https://github.com/user-attachments/assets/bf77b87e-e340-4027-a290-9cbbe263b591" />
<img width="1536" height="977" alt="Screenshot 2026-02-25 at 14 38 41" src="https://github.com/user-attachments/assets/c4eaad26-5c02-47d0-8dd1-3b6f0f571d38" />

## Checklist

- [ ✓] I have run PocketPaw locally and tested my changes
- [ ✓] This PR is linked to an existing issue
- [ ] I have added/updated tests if applicable
- [✓ ] I have not made whitespace-only or typo-only changes
- [ ✓] My code follows the existing style in the codebase
