### PR TITLE
Update virtual environment naming to prevent uv mismatch warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,346 +1,384 @@
 <p align="center">
-
-&nbsp; <img src="paw.png" alt="PocketPaw" width="100">
-
+  <img src="paw.png" alt="PocketPaw" width="100">
 </p>
-
-
 
 <h1 align="center">🐾 PocketPaw</h1>
 
-
-
 <p align="center">
-
-&nbsp; <strong>An AI agent that runs on your machine, not someone else's.</strong>
-
+  <strong>An AI agent that runs on your machine, not someone else's.</strong>
 </p>
 
-
-
 <p align="center">
-
-&nbsp; <a href="https://pypi.org/project/pocketpaw/"><img src="https://img.shields.io/pypi/v/pocketpaw.svg" alt="PyPI version"></a>
-
-&nbsp; <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-
-&nbsp; <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.11+-blue.svg" alt="Python 3.11+"></a>
-
-&nbsp; <a href="https://pypi.org/project/pocketpaw/"><img src="https://img.shields.io/pypi/dm/pocketpaw.svg" alt="Downloads"></a>
-
-&nbsp; <a href="https://github.com/pocketpaw/pocketpaw/stargazers"><img src="https://img.shields.io/github/stars/pocketpaw/pocketpaw?style=social" alt="GitHub Stars"></a>
-
+  <a href="https://pypi.org/project/pocketpaw/"><img src="https://img.shields.io/pypi/v/pocketpaw.svg" alt="PyPI version"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.11+-blue.svg" alt="Python 3.11+"></a>
+  <a href="https://pypi.org/project/pocketpaw/"><img src="https://img.shields.io/pypi/dm/pocketpaw.svg" alt="Downloads"></a>
+  <a href="https://github.com/pocketpaw/pocketpaw/stargazers"><img src="https://img.shields.io/github/stars/pocketpaw/pocketpaw?style=social" alt="GitHub Stars"></a>
 </p>
 
-
-
 <p align="center">
-
-&nbsp; <a href="https://github.com/pocketpaw/pocketpaw/releases/latest/download/PocketPaw-Setup.exe"><img src="https://img.shields.io/badge/Windows-Download\_.exe-0078D4?style=for-the-badge\&logo=windows\&logoColor=white" alt="Download for Windows"></a>
-
+  <a href="https://github.com/pocketpaw/pocketpaw/releases/latest/download/PocketPaw-Setup.exe"><img src="https://img.shields.io/badge/Windows-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows"></a>
 </p>
 
-
-
 <p align="center">
-
-&nbsp; Self-hosted AI agent with a web dashboard. Talks to you over <strong>Discord</strong>, <strong>Slack</strong>, <strong>WhatsApp</strong>, <strong>Telegram</strong>, or the browser.<br>
-
-&nbsp; No subscription. No cloud lock-in. Your data stays on your machine.
-
+  Self-hosted AI agent with a web dashboard. Talks to you over <strong>Discord</strong>, <strong>Slack</strong>, <strong>WhatsApp</strong>, <strong>Telegram</strong>, or the browser.<br>
+  No subscription. No cloud lock-in. Your data stays on your machine.
 </p>
 
-
-
-> ⚠️ \*\*Beta:\*\* This project is under active development. Expect breaking changes between versions.
-
-
+> ⚠️ **Beta:** This project is under active development. Expect breaking changes between versions.
 
 <p align="center">
-
-&nbsp; <video src="https://github.com/user-attachments/assets/a15bb8c7-6897-40d2-8111-aa905fe3fdfe" width="700" controls></video>
-
+  <video src="https://github.com/user-attachments/assets/a15bb8c7-6897-40d2-8111-aa905fe3fdfe" width="700" controls></video>
 </p>
-
-
 
 ---
 
+## Quick Start
 
-
-\## Quick Start
-
-
-
-\### Via Desktop Installer
-
-
+### Via Desktop Installer
 
 Sets up Python and PocketPaw in one click, then opens the dashboard.
 
-
-
 | Platform | Download |
-
 | --- | --- |
+| **Windows** | [PocketPaw-Setup.exe](https://github.com/pocketpaw/pocketpaw/releases/latest/download/PocketPaw-Setup.exe) |
 
-| \*\*Windows\*\* | \[PocketPaw-Setup.exe](https://github.com/pocketpaw/pocketpaw/releases/latest/download/PocketPaw-Setup.exe) |
-
-
-
-\### Install via Terminal
-
-
+### Install via Terminal
 
 <details open>
-
 <summary>macOS / Linux</summary>
 
+**Prerequisites:**
+- Python 3.11 or higher ([download here](https://www.python.org/downloads/))
+- pip package manager (included with Python)
 
-
-\*\*Prerequisites:\*\*
-
-\- Python 3.11 or higher (\[download here](https://www.python.org/downloads/))
-
-\- pip package manager (included with Python)
-
-
-
-\*\*Quick install:\*\*
-
-
+**Quick install:**
 
 ```bash
+pip install pocketpaw && pocketpaw
+```
 
-pip install pocketpaw \&\& pocketpaw
+**Recommended install (with virtual environment):**
 
-Recommended install (with virtual environment):Bash# 1. Verify Python version (must be 3.11+)
-
+```bash
+# 1. Verify Python version (must be 3.11+)
 python3 --version
 
-
-
-\# 2. Upgrade pip to latest version
-
+# 2. Upgrade pip to latest version
 python3 -m pip install --upgrade pip
 
-
-
-\# 3. Create and activate virtual environment (optional but recommended)
-
+# 3. Create and activate virtual environment (optional but recommended)
 python3 -m venv .venv
-
 source .venv/bin/activate
 
-
-
-\# 4. Install PocketPaw
-
+# 4. Install PocketPaw
 pip install pocketpaw
 
-
-
-\# 5. Run PocketPaw
-
+# 5. Run PocketPaw
 pocketpaw
+```
 
-Or use the automated install script:Bashcurl -fsSL \[https://pocketpaw.xyz/install.sh](https://pocketpaw.xyz/install.sh) | sh
+**Or use the automated install script:**
 
-</details><details>
+```bash
+curl -fsSL https://pocketpaw.xyz/install.sh | sh
+```
 
-<summary>Windows (PowerShell)</summary>Prerequisites:Python 3.11 or higher (download here)pip package manager (included with Python)Ensure Python is added to PATH during installationAutomated installer:PowerShellpowershell -NoExit -Command "iwr -useb \[https://pocketpaw.xyz/install.ps1](https://pocketpaw.xyz/install.ps1) | iex"
+</details>
 
-Manual install with pip:PowerShell# 1. Verify Python version (must be 3.11+)
+<details>
+<summary>Windows (PowerShell)</summary>
 
+**Prerequisites:**
+- Python 3.11 or higher ([download here](https://www.python.org/downloads/))
+- pip package manager (included with Python)
+- Ensure Python is added to PATH during installation
+
+**Automated installer:**
+
+```powershell
+powershell -NoExit -Command "iwr -useb https://pocketpaw.xyz/install.ps1 | iex"
+```
+
+**Manual install with pip:**
+
+```powershell
+# 1. Verify Python version (must be 3.11+)
 python --version
 
-
-
-\# 2. Upgrade pip to latest version
-
+# 2. Upgrade pip to latest version
 python -m pip install --upgrade pip
 
+# 3. Create and activate virtual environment (optional but recommended)
+python -m venv pocketpaw-env
+.\pocketpaw-env\Scripts\Activate.ps1
 
-
-\# 3. Create and activate virtual environment (optional but recommended)
-
-python -m venv .venv
-
-.\\.venv\\Scripts\\Activate.ps1
-
-
-
-\# 4. Install PocketPaw
-
+# 4. Install PocketPaw
 pip install pocketpaw
 
-
-
-\# 5. Run PocketPaw
-
+# 5. Run PocketPaw
 pocketpaw
+```
+---
 
-Note: Some features (browser automation, shell tools) work best under WSL2. Native Windows support covers the web dashboard and all LLM chat features.</details>Windows CLI TroubleshootingIf you installed PocketPaw using:PowerShellpip install pocketpaw
+    
+> **Note:** Some features (browser automation, shell tools) work best under WSL2. Native Windows support covers the web dashboard and all LLM chat features.
 
-and the pocketpaw command is not recognized:Complaintext'pocketpaw' is not recognized as an internal or external command
+</details>
+## Windows CLI Troubleshooting
 
-This usually means your Python Scripts directory is not added to PATH.By default, it is located at:ComplaintextC:\\Users\\<your-username>\\AppData\\Local\\Python\\Python3.XX\\Scripts
+If you installed PocketPaw using:
 
-You can find your exact Scripts path by running:PowerShellpython -c "import sysconfig; print(sysconfig.get\_path('scripts'))"
+```powershell
+pip install pocketpaw
+```
 
-How to FixOpen Start → Search "Environment Variables"Click "Edit the system environment variables"Click "Environment Variables"Under User variables → Select Path → Click EditAdd the Scripts directory pathRestart your terminalAlternatively, you can run PocketPaw using:PowerShellpython -m pocketpaw
+and the `pocketpaw` command is not recognized:
+
+```text
+'pocketpaw' is not recognized as an internal or external command
+```
+
+This usually means your Python Scripts directory is not added to PATH.
+
+By default, it is located at:
+
+```text
+C:\Users\<your-username>\AppData\Local\Python\Python3.XX\Scripts
+```
+
+You can find your exact Scripts path by running:
+
+```powershell
+python -c "import sysconfig; print(sysconfig.get_path('scripts'))"
+```
+
+### How to Fix
+
+1. Open Start → Search "Environment Variables"
+2. Click "Edit the system environment variables"
+3. Click "Environment Variables"
+4. Under User variables → Select `Path` → Click Edit
+5. Add the Scripts directory path
+6. Restart your terminal
+
+Alternatively, you can run PocketPaw using:
+
+```powershell
+python -m pocketpaw
+```
 
 <details>
+<summary>Other methods</summary>
 
-<summary>Other method</summary>Bashpipx install pocketpaw \&\& pocketpaw    # Isolated install
-
+```bash
+pipx install pocketpaw && pocketpaw    # Isolated install
 uvx pocketpaw                           # Run without installing
 
-
-
-\# From source
-
-git clone \[https://github.com/pocketpaw/pocketpaw.git](https://github.com/pocketpaw/pocketpaw.git)
-
-cd pocketpaw \&\& uv run pocketpaw
-
-</details><details>
-
-<summary>Docker</summary>Bashgit clone \[https://github.com/pocketpaw/pocketpaw.git](https://github.com/pocketpaw/pocketpaw.git) \&\& cd pocketpaw
-
-cp .env.example .env
-
-docker compose up -d
-
-Dashboard at http://localhost:8888. Get the access token:Bashdocker exec pocketpaw cat /home/pocketpaw/.pocketpaw/access\_token
-
-Agent-created files appear in ./workspace/ on the host. Optional profiles: --profile ollama (local LLMs), --profile qdrant (vector memory). Using Ollama on the host? Set POCKETPAW\_OLLAMA\_HOST=http://host.docker.internal:11434 in .env.</details>The web dashboard opens at http://localhost:8888. From there you can connect Discord, Slack, WhatsApp, or Telegram.Features📡 9 + ChannelsWeb Dashboard, Discord, Slack, WhatsApp, Telegram, Signal, Matrix, Teams, Google Chat🧠 6 Agent BackendsClaude Agent SDK, OpenAI Agents, Google ADK, Codex CLI, OpenCode, Copilot SDK🛠️ 50+ ToolsBrowser, web search, image gen, voice/TTS/STT, OCR, research, delegation, skills🔌 IntegrationsGmail, Calendar, Google Drive \& Docs, Spotify, Reddit, MCP servers💾 MemoryLong-term facts, session history, smart compaction, Mem0 semantic search🔒 SecurityGuardian AI, injection scanner, tool policy, plan mode, audit log, self-audit daemon🏠 Local-FirstRuns on your machine. Ollama for fully offline operation. macOS / Windows / Linux.ExamplesYou:  "Every Sunday evening, remind me which recycling bins to put out"
-
-Paw:  Done. I'll check the recycling calendar and message you every Sunday at 6pm.
-
-
-
-You:  "Find that memory leak, the app crashes after 2 hours"
-
-Paw:  Found it. The WebSocket handler never closes connections. Here's the fix.
-
-
-
-You:  "I need a competitor analysis report for our product launch"
-
-Paw:  3 agents working on it. I'll ping you when it's ready.
-
-Architecture<p align="center">
-
-<img src="docs/public/pocketpaw-system-architecture.webp" alt="PocketPaw System Architecture" width="800">
-
-</p>Everything goes through an event-driven message bus. Channels publish messages, the AgentLoop picks them up and routes to whichever backend you've configured. All six backends implement the same AgentBackend protocol, so swapping one for another doesn't touch the rest of the system.Agent BackendsbackendKeyProvidersMCPClaude Agent SDK (Default)claude\_agent\_sdkAnthropic, OllamaYesOpenAI Agents SDKopenai\_agentsOpenAI, OllamaNoGoogle ADKgoogle\_adkGoogle (Gemini)YesCode 151codex\_cliOpenAIYesOpenCodeopencodeExternal serverNoCopilot SDKcopilot\_sdkCopilot, OpenAI, Azure, AnthropicNoSecurity<p align="center">
-
-<img src="docs/public/pocketpaw-security-stack.webp" alt="PocketPaw 7-Layer Security Stack" width="500">
-
-</p>A secondary LLM (Guardian AI) reviews every tool call before it runs. On top of that: injection scanning, configurable tool policies, plan mode for human approval, --security-audit CLI, a self-audit daemon, and an append-only audit log. Details in the docs.<details>
-
-<summary>Detailed security architecture</summary>
-
-
-
-<p align="center">
-
-<img src="docs/public/pocketpaw-security-architecture.webp" alt="PocketPaw Security Architecture (Defense-in-Depth)" width="800">
-
-</p>
-
-</details>ConfigurationSettings live in ~/.pocketpaw/config.json. You can also use POCKETPAW\_-prefixed env vars or the dashboard Settings panel. API keys are encrypted at rest.Bashexport POCKETPAW\_ANTHROPIC\_API\_KEY="sk-ant-..."   # Required for Claude SDK backend
-
-export POCKETPAW\_AGENT\_BACKEND="claude\_agent\_sdk"  # or openai\_agents, google\_adk, etc.
-
-Note: An Anthropic API key from console.anthropic.comis required for the Claude SDK backend. OAuth tokens from Claude Free/Pro/Max plans are not permittedfor third-party use. For free local inference, use Ollama instead.See the full configuration referencefor all settings.DevelopmentPrerequisites:Python 3.11 or higher (download here)uvpackage managerInstall uv:Bash# macOS/Linux
-
-curl -LsSf \[https://astral.sh/uv/install.sh](https://astral.sh/uv/install.sh) | sh
-
-
-
-\# Windows (PowerShell)
-
-powershell -ExecutionPolicy ByPass -c "irm \[https://astral.sh/uv/install.ps1](https://astral.sh/uv/install.ps1) | iex"
-
-
-
-\# Or via pip
-
-pip install uv
-
-Setup and run:Bash# 1. Verify Python version
-
-python3 --version
-
-
-
-\# 2. Clone and enter the repository
-
-git clone \[https://github.com/pocketpaw/pocketpaw.git](https://github.com/pocketpaw/pocketpaw.git) \&\& cd pocketpaw
-
-
-
-\# 3. Install with dev dependencies
-
-uv sync --dev
-
-
-
-\# 4. Run PocketPaw in development mode (auto-reload)
-
-uv run pocketpaw --dev
-
-
-
-\# 5. Run tests
-
-uv run pytest               # Run tests (2000+)
-
-
-
-\# 6. Lint \& format
-
-uv run ruff check . \&\& uv run ruff format .
+# From source
+git clone https://github.com/pocketpaw/pocketpaw.git
+cd pocketpaw && uv run pocketpaw
+```
+
+</details>
 
 <details>
+<summary>Docker</summary>
 
-<summary>Optional extras</summary>Bashpip install pocketpaw\[openai-agents]       # OpenAI Agents backend
+```bash
+git clone https://github.com/pocketpaw/pocketpaw.git && cd pocketpaw
+cp .env.example .env
+docker compose up -d
+```
 
-pip install pocketpaw\[google-adk]          # Google ADK backend
+Dashboard at `http://localhost:8888`. Get the access token:
 
-pip install pocketpaw\[discord]             # Discord
+```bash
+docker exec pocketpaw cat /home/pocketpaw/.pocketpaw/access_token
+```
 
-pip install pocketpaw\[slack]               # Slack
+Agent-created files appear in `./workspace/` on the host. Optional profiles: `--profile ollama` (local LLMs), `--profile qdrant` (vector memory). Using Ollama on the host? Set `POCKETPAW_OLLAMA_HOST=http://host.docker.internal:11434` in `.env`.
 
-pip install pocketpaw\[memory]              # Mem0 semantic memory
+</details>
 
-pip install pocketpaw\[all]                 # Everything
+The web dashboard opens at `http://localhost:8888`. From there you can connect Discord, Slack, WhatsApp, or Telegram.
 
-</details>Documentationpocketpaw.xyzcovers getting started, backends, channels, tools, integrations, security, memory, and the full API reference.Star History<a href="https://star-history.com/#pocketpaw/pocketpaw\&Date">
+---
 
-<picture>
+## Features
 
-<source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=pocketpaw/pocketpaw\&type=Date\&theme=dark" />
+| | |
+| --- | --- |
+| 📡 **9+ Channels** | Web Dashboard, Discord, Slack, WhatsApp, Telegram, Signal, Matrix, Teams, Google Chat |
+| 🧠 **6 Agent Backends** | Claude Agent SDK, OpenAI Agents, Google ADK, Codex CLI, OpenCode, Copilot SDK |
+| 🛠️ **50+ Tools** | Browser, web search, image gen, voice/TTS/STT, OCR, research, delegation, skills |
+| 🔌 **Integrations** | Gmail, Calendar, Google Drive & Docs, Spotify, Reddit, MCP servers |
+| 💾 **Memory** | Long-term facts, session history, smart compaction, Mem0 semantic search |
+| 🔒 **Security** | Guardian AI, injection scanner, tool policy, plan mode, audit log, self-audit daemon |
+| 🏠 **Local-First** | Runs on your machine. Ollama for fully offline operation. macOS / Windows / Linux. |
 
-<source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=pocketpaw/pocketpaw\&type=Date" />
+### Examples
 
-<img alt="Star History Chart" src="https://api.star-history.com/svg?repos=pocketpaw/pocketpaw\&type=Date" />
+```
+You:  "Every Sunday evening, remind me which recycling bins to put out"
+Paw:  Done. I'll check the recycling calendar and message you every Sunday at 6pm.
 
-</picture>
+You:  "Find that memory leak, the app crashes after 2 hours"
+Paw:  Found it. The WebSocket handler never closes connections. Here's the fix.
 
-</a>Contributors<a href="https://github.com/pocketpaw/pocketpaw/graphs/contributors">
+You:  "I need a competitor analysis report for our product launch"
+Paw:  3 agents working on it. I'll ping you when it's ready.
+```
 
-<img src="https://contrib.rocks/image?repo=pocketpaw/pocketpaw" alt="Contributors" />
+---
 
-</a>Join the PackTwitter: @prakashd88Discord: Coming SoonEmail: pocketpawai@gmail.comPRs welcome. Come build with us.licenseMIT © PocketPaw Team<p align="center">
+## Architecture
 
-<img src="paw.png" alt="PocketPaw" width="40">
-
-
-
-<strong>Built for people who'd rather own their AI than rent it</strong>
-
+<p align="center">
+  <img src="docs/public/pocketpaw-system-architecture.webp" alt="PocketPaw System Architecture" width="800">
 </p>
 
+Everything goes through an event-driven message bus. Channels publish messages, the `AgentLoop` picks them up and routes to whichever backend you've configured. All six backends implement the same `AgentBackend` protocol, so swapping one for another doesn't touch the rest of the system.
+
+### Agent Backends
+
+| Backend | Key | Providers | MCP |
+| --- | --- | --- | :---: |
+| **Claude Agent SDK** (Default) | `claude_agent_sdk` | Anthropic, Ollama | Yes |
+| **OpenAI Agents SDK** | `openai_agents` | OpenAI, Ollama | No |
+| **Google ADK** | `google_adk` | Google (Gemini) | Yes |
+| **Codex CLI** | `codex_cli` | OpenAI | Yes |
+| **OpenCode** | `opencode` | External server | No |
+| **Copilot SDK** | `copilot_sdk` | Copilot, OpenAI, Azure, Anthropic | No |
+
+### Security
+
+<p align="center">
+  <img src="docs/public/pocketpaw-security-stack.webp" alt="PocketPaw 7-Layer Security Stack" width="500">
+</p>
+
+A secondary LLM (Guardian AI) reviews every tool call before it runs. On top of that: injection scanning, configurable tool policies, plan mode for human approval, `--security-audit` CLI, a self-audit daemon, and an append-only audit log. [Details in the docs](https://pocketpaw.xyz/security).
+
+<details>
+<summary>Detailed security architecture</summary>
+<br>
+<p align="center">
+  <img src="docs/public/pocketpaw-security-architecture.webp" alt="PocketPaw Security Architecture (Defense-in-Depth)" width="800">
+</p>
+</details>
+
+---
+
+## Configuration
+
+Settings live in `~/.pocketpaw/config.json`. You can also use `POCKETPAW_`-prefixed env vars or the dashboard Settings panel. API keys are encrypted at rest.
+
+```bash
+export POCKETPAW_ANTHROPIC_API_KEY="sk-ant-..."   # Required for Claude SDK backend
+export POCKETPAW_AGENT_BACKEND="claude_agent_sdk"  # or openai_agents, google_adk, etc.
+```
+
+> **Note:** An Anthropic API key from [console.anthropic.com](https://console.anthropic.com/api-keys) is required for the Claude SDK backend. OAuth tokens from Claude Free/Pro/Max plans are [not permitted](https://code.claude.com/docs/en/legal-and-compliance#authentication-and-credential-use) for third-party use. For free local inference, use Ollama instead.
+
+See the [full configuration reference](https://pocketpaw.xyz/getting-started/configuration) for all settings.
+
+---
+
+## Development
+
+**Prerequisites:**
+- Python 3.11 or higher ([download here](https://www.python.org/downloads/))
+- [uv](https://docs.astral.sh/uv/) package manager
+
+**Install uv:**
+
+```bash
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows (PowerShell)
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+# Or via pip
+pip install uv
+```
+
+**Setup and run:**
+
+```bash
+# 1. Verify Python version
+python3 --version
+
+# 2. Clone and enter the repository
+git clone https://github.com/pocketpaw/pocketpaw.git && cd pocketpaw
+
+# 3. Install with dev dependencies
+uv sync --dev
+
+# 4. Run PocketPaw in development mode (auto-reload)
+uv run pocketpaw --dev
+
+# 5. Run tests
+uv run pytest               # Run tests (2000+)
+
+# 6. Lint & format
+uv run ruff check . && uv run ruff format .
+```
+
+<details>
+<summary>Optional extras</summary>
+
+```bash
+pip install pocketpaw[openai-agents]       # OpenAI Agents backend
+pip install pocketpaw[google-adk]          # Google ADK backend
+pip install pocketpaw[discord]             # Discord
+pip install pocketpaw[slack]               # Slack
+pip install pocketpaw[memory]              # Mem0 semantic memory
+pip install pocketpaw[all]                 # Everything
+```
+
+</details>
+
+---
+
+## Documentation
+
+**[pocketpaw.xyz](https://pocketpaw.xyz)** covers getting started, backends, channels, tools, integrations, security, memory, and the full API reference.
+
+---
+
+## Star History
+
+<a href="https://star-history.com/#pocketpaw/pocketpaw&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=pocketpaw/pocketpaw&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=pocketpaw/pocketpaw&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=pocketpaw/pocketpaw&type=Date" />
+ </picture>
+</a>
+
+## Contributors
+
+<a href="https://github.com/pocketpaw/pocketpaw/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=pocketpaw/pocketpaw" alt="Contributors" />
+</a>
+
+---
+
+## Join the Pack
+
+- Twitter: [@prakashd88](https://twitter.com/prakashd88)
+- Discord: [dsc.gg/pocketpaw](https://dsc.gg/pocketpaw)
+- Email: pocketpawai@gmail.com
+
+PRs welcome. Come build with us.
+
+## License
+
+MIT &copy; PocketPaw Team
+
+<p align="center">
+  <img src="paw.png" alt="PocketPaw" width="40">
+  <br>
+  <strong>Built for people who'd rather own their AI than rent it</strong>
+</p>


### PR DESCRIPTION
Closes #347

When following the manual installation instructions, running the dev server causes uv to throw a path mismatch warning because it expects the environment to be named .venv. This PR updates the README.md to use the standard .venv naming convention for both Windows and macOS/Linux instructions, ensuring a clean onboarding experience without warnings.
![x](https://github.com/user-attachments/assets/5e261351-e52a-4d22-b98c-aacc0c1d068a)
