### PR TITLE
[FI] Fix missing agents, tasks, projects state in McEvents getState()

### DIFF
--- a/src/pocketpaw/frontend/js/features/mc-events.js
+++ b/src/pocketpaw/frontend/js/features/mc-events.js
@@ -24,6 +24,10 @@ window.PocketPaw.McEvents = {
                 loading: false,
                 stats: { total_agents: 0, active_tasks: 0, completed_today: 0, total_documents: 0 },
                 activities: [],
+                agents: [],
+                tasks: [],
+                projects: [],
+                runningTasks: {},
             }
         };
     },


### PR DESCRIPTION
Fixes #377

## Problem
Command Center shows "Failed to load Crew" error because McEvents getState() was missing initial state for agents, tasks, projects, and runningTasks.

## Fix
Added missing arrays to getState() in mc-events.js:
- agents: []
- tasks: []
- projects: []
- runningTasks: {}

## Testing
- OS: Windows 11
- Python: 3.12
- Reproduced the error, applied fix, verified Command Center loads without error