### PR TITLE
F1: Fix Windows UnicodeDecodeError by enforcing UTF-8 in read_text() calls

### DIFF
--- a/tests/test_api_rate_limits.py
+++ b/tests/test_api_rate_limits.py
@@ -91,7 +91,7 @@ class TestAuditAPIEvents:
         # Verify written to file
         import json
 
-        lines = (tmp_path / "test_audit.jsonl").read_text().strip().split("\n")
+        lines = (tmp_path / "test_audit.jsonl").read_text(encoding="utf-8").strip().split("\n")
         assert len(lines) == 1
         entry = json.loads(lines[0])
         assert entry["action"] == "api_key_created"
@@ -111,7 +111,7 @@ class TestAuditAPIEvents:
 
         import json
 
-        lines = (tmp_path / "test_audit.jsonl").read_text().strip().split("\n")
+        lines = (tmp_path / "test_audit.jsonl").read_text(encoding="utf-8").strip().split("\n")
         entry = json.loads(lines[0])
         assert entry["action"] == "oauth_token"
         assert entry["context"]["scope"] == "chat sessions"
@@ -128,7 +128,7 @@ class TestAuditAPIEvents:
 
         import json
 
-        lines = (tmp_path / "test_audit.jsonl").read_text().strip().split("\n")
+        lines = (tmp_path / "test_audit.jsonl").read_text(encoding="utf-8").strip().split("\n")
         entry = json.loads(lines[0])
         assert entry["action"] == "api_key_revoked"
 

--- a/tests/test_api_v1_health.py
+++ b/tests/test_api_v1_health.py
@@ -128,7 +128,7 @@ class TestAuditLog:
             resp = client.delete("/api/v1/audit")
             assert resp.status_code == 200
             assert resp.json()["ok"] is True
-            assert Path(f.name).read_text() == ""
+            assert Path(f.name).read_text(encoding="utf-8") == ""
 
 
 class TestSecurityAudit:

--- a/tests/test_api_v1_identity.py
+++ b/tests/test_api_v1_identity.py
@@ -69,8 +69,8 @@ class TestSaveIdentity:
             assert "IDENTITY.md" in data["updated"]
             assert "SOUL.md" in data["updated"]
             identity_dir = Path(tmpdir) / "identity"
-            assert (identity_dir / "IDENTITY.md").read_text() == "Updated identity"
-            assert (identity_dir / "SOUL.md").read_text() == "Updated soul"
+            assert (identity_dir / "IDENTITY.md").read_text(encoding="utf-8") == "Updated identity"
+            assert (identity_dir / "SOUL.md").read_text(encoding="utf-8") == "Updated soul"
 
     @patch("pocketpaw.config.get_config_path")
     def test_save_partial_update(self, mock_config_path, client):

--- a/tests/test_channel_autostart.py
+++ b/tests/test_channel_autostart.py
@@ -178,6 +178,6 @@ def test_round_trip_save_load(tmp_path):
     config_path.write_text(json.dumps(save_dict))
 
     # Load back
-    data = json.loads(config_path.read_text())
+    data = json.loads(config_path.read_text(encoding="utf-8"))
     loaded = Settings(**data)
     assert loaded.channel_autostart == {"discord": False, "teams": True}

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -113,7 +113,7 @@ class TestSessionAliases:
     async def test_aliases_persist_to_disk(self):
         await self.store.set_session_alias("discord:123", "discord:123:abc")
         # Read the file directly
-        data = json.loads(self.store._aliases_path.read_text())
+        data = json.loads(self.store._aliases_path.read_text(encoding="utf-8"))
         assert data["discord:123"] == "discord:123:abc"
 
     async def test_get_session_keys_includes_alias_targets(self):
@@ -875,7 +875,7 @@ class TestSlackSlashCommands:
 
         from pocketpaw.bus.adapters import slack_adapter
 
-        source = ast.parse(Path(slack_adapter.__file__).read_text())
+        source = ast.parse(Path(slack_adapter.__file__).read_text(encoding="utf-8"))
 
         # Find the tuple of command names in the for loop
         expected = {

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -233,7 +233,7 @@ class TestTier2LLMSummary:
 
         assert "Fresh summary." in result[0]["content"]
         # Cache should be updated
-        cache = json.loads(cache_file.read_text())
+        cache = json.loads(cache_file.read_text(encoding="utf-8"))
         assert cache["watermark"] == 20
 
     async def test_no_sessions_path_falls_back(self):

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -309,7 +309,7 @@ async def test_file_memory_store_session_lock(tmp_path):
 
     # Verify session file is valid JSON with all 10 entries
     session_file = store._get_session_file(session_key)
-    data = json.loads(session_file.read_text())
+    data = json.loads(session_file.read_text(encoding="utf-8"))
     assert len(data) == 10
     contents = {item["content"] for item in data}
     assert contents == {f"message {i}" for i in range(10)}

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -237,7 +237,7 @@ class TestConfigSecretSeparation:
         )
         settings.save()
 
-        config_data = json.loads((env["tmp_path"] / "config.json").read_text())
+        config_data = json.loads((env["tmp_path"] / "config.json").read_text(encoding="utf-8"))
         assert "anthropic_api_key" not in config_data
         assert "openai_api_key" not in config_data
         assert "telegram_bot_token" not in config_data
@@ -259,7 +259,7 @@ class TestConfigSecretSeparation:
         )
         settings.save()
 
-        config_data = json.loads((env["tmp_path"] / "config.json").read_text())
+        config_data = json.loads((env["tmp_path"] / "config.json").read_text(encoding="utf-8"))
         assert config_data["agent_backend"] == "claude_agent_sdk"
         assert config_data["llm_provider"] == "anthropic"
 
@@ -376,7 +376,7 @@ class TestPlaintextMigration:
 
         Settings.load()
 
-        updated = json.loads((env["tmp_path"] / "config.json").read_text())
+        updated = json.loads((env["tmp_path"] / "config.json").read_text(encoding="utf-8"))
         # Keys remain in config.json as fallback (file is chmod 600)
         assert updated.get("telegram_bot_token") == "123:AAOldToken"
         assert updated.get("anthropic_api_key") == "sk-ant-old"

--- a/tests/test_frontend_syntax.py
+++ b/tests/test_frontend_syntax.py
@@ -67,7 +67,7 @@ class TestJavaScriptStructure:
     def test_app_defines_app_function(self):
         """Test that app.js defines the app() function for Alpine.js."""
         app_js = FRONTEND_DIR / "js" / "app.js"
-        content = app_js.read_text()
+        content = app_js.read_text(encoding="utf-8")
 
         assert "function app()" in content, "app.js should define app() function"
 
@@ -75,6 +75,6 @@ class TestJavaScriptStructure:
     def test_websocket_defines_manager(self):
         """Test that websocket.js defines WebSocket manager."""
         ws_js = FRONTEND_DIR / "js" / "websocket.js"
-        content = ws_js.read_text()
+        content = ws_js.read_text(encoding="utf-8")
 
         assert "WebSocket" in content, "websocket.js should use WebSocket"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -116,7 +116,7 @@ class TestErrorStore:
     def test_record_appends_valid_jsonl(self, store):
         store.record(message="error one")
         store.record(message="error two")
-        lines = store.path.read_text().strip().splitlines()
+        lines = store.path.read_text(encoding="utf-8").strip().splitlines()
         assert len(lines) == 2
         entry = json.loads(lines[0])
         assert entry["message"] == "error one"
@@ -159,7 +159,7 @@ class TestErrorStore:
             traceback="Traceback...",
             context={"project_id": "abc"},
         )
-        entry = json.loads(store.path.read_text().strip())
+        entry = json.loads(store.path.read_text(encoding="utf-8").strip())
         assert entry["source"] == "test.module"
         assert entry["severity"] == "warning"
         assert entry["traceback"] == "Traceback..."

--- a/tests/test_identity_api.py
+++ b/tests/test_identity_api.py
@@ -129,11 +129,11 @@ class TestSaveIdentity:
                 "INSTRUCTIONS.md",
                 "USER.md",
             }
-            assert (identity_dir / "IDENTITY.md").read_text() == "New identity"
-            assert (identity_dir / "SOUL.md").read_text() == "New soul"
-            assert (identity_dir / "STYLE.md").read_text() == "New style"
-            assert (identity_dir / "INSTRUCTIONS.md").read_text() == "New instructions"
-            assert (identity_dir / "USER.md").read_text() == "Name: Bob\nTimezone: EST"
+            assert (identity_dir / "IDENTITY.md").read_text(encoding="utf-8") == "New identity"
+            assert (identity_dir / "SOUL.md").read_text(encoding="utf-8") == "New soul"
+            assert (identity_dir / "STYLE.md").read_text(encoding="utf-8") == "New style"
+            assert (identity_dir / "INSTRUCTIONS.md").read_text(encoding="utf-8") == "New instructions"
+            assert (identity_dir / "USER.md").read_text(encoding="utf-8") == "Name: Bob\nTimezone: EST"
 
     async def test_partial_update(self):
         """PUT /api/identity with only user_file updates only that file."""
@@ -160,9 +160,9 @@ class TestSaveIdentity:
             assert result["ok"] is True
             assert result["updated"] == ["USER.md"]
             # Original identity untouched
-            assert (identity_dir / "IDENTITY.md").read_text() == "Original identity"
+            assert (identity_dir / "IDENTITY.md").read_text(encoding="utf-8") == "Original identity"
             # User file updated
-            assert (identity_dir / "USER.md").read_text() == "Name: Updated"
+            assert (identity_dir / "USER.md").read_text(encoding="utf-8") == "Name: Updated"
 
     async def test_ignores_non_string_values(self):
         """PUT /api/identity ignores non-string values."""
@@ -203,7 +203,7 @@ class TestSaveIdentity:
                 result = await save_identity(request)
 
             assert result["ok"] is True
-            assert (base / "identity" / "USER.md").read_text() == "Name: New User"
+            assert (base / "identity" / "USER.md").read_text(encoding="utf-8") == "Name: New User"
 
     async def test_ignores_unknown_keys(self):
         """PUT /api/identity ignores keys not in the file_map."""

--- a/tests/test_launcher_autostart.py
+++ b/tests/test_launcher_autostart.py
@@ -136,7 +136,7 @@ class TestLinuxAutoStart:
     def test_enable_creates_desktop_file(self):
         assert self.mgr.enable()
         assert self.desktop_path.exists()
-        content = self.desktop_path.read_text()
+        content = self.desktop_path.read_text(encoding="utf-8")
         assert "[Desktop Entry]" in content
         assert "PocketPaw" in content
         assert "Type=Application" in content

--- a/tests/test_mem0_store.py
+++ b/tests/test_mem0_store.py
@@ -642,7 +642,7 @@ class TestMemorySettings:
         with patch("pocketpaw.config.get_config_path", return_value=config_path):
             settings.save()
 
-        saved = json.loads(config_path.read_text())
+        saved = json.loads(config_path.read_text(encoding="utf-8"))
         assert saved["memory_backend"] == "mem0"
         assert saved["mem0_llm_provider"] == "ollama"
         assert saved["mem0_auto_learn"] is False

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -83,7 +83,7 @@ class TestFileMemoryStore:
 
         # Check file was created
         assert memory_store.long_term_file.exists()
-        content = memory_store.long_term_file.read_text()
+        content = memory_store.long_term_file.read_text(encoding="utf-8")
         assert "User prefers dark mode" in content
 
     @pytest.mark.asyncio

--- a/tests/test_memory_isolation.py
+++ b/tests/test_memory_isolation.py
@@ -87,7 +87,7 @@ class TestFileStoreUserScoping:
         )
         await store.save(entry)
         assert store.long_term_file.exists()
-        assert "Owner fact" in store.long_term_file.read_text()
+        assert "Owner fact" in store.long_term_file.read_text(encoding="utf-8")
 
     async def test_save_long_term_scoped_user(self, tmp_path):
         store = FileMemoryStore(base_path=tmp_path)
@@ -101,10 +101,10 @@ class TestFileStoreUserScoping:
         await store.save(entry)
         user_file = tmp_path / "users" / "abc123" / "MEMORY.md"
         assert user_file.exists()
-        assert "Stranger fact" in user_file.read_text()
+        assert "Stranger fact" in user_file.read_text(encoding="utf-8")
         # Root MEMORY.md should NOT contain it
         if store.long_term_file.exists():
-            assert "Stranger fact" not in store.long_term_file.read_text()
+            assert "Stranger fact" not in store.long_term_file.read_text(encoding="utf-8")
 
     async def test_get_by_type_scoped(self, tmp_path):
         store = FileMemoryStore(base_path=tmp_path)

--- a/tests/test_memory_tools.py
+++ b/tests/test_memory_tools.py
@@ -285,7 +285,7 @@ class TestSessionListAPI:
         for session_file in sorted(
             sessions_path.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True
         ):
-            data = json.loads(session_file.read_text())
+            data = json.loads(session_file.read_text(encoding="utf-8"))
             if data:
                 first_msg = data[0]
                 last_msg = data[-1]
@@ -341,7 +341,7 @@ class TestSessionListAPI:
         sessions = []
         for session_file in sessions_dir.glob("*.json"):
             try:
-                data = json.loads(session_file.read_text())
+                data = json.loads(session_file.read_text(encoding="utf-8"))
                 if data:
                     sessions.append({"id": session_file.stem})
             except json.JSONDecodeError:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -12,7 +12,7 @@ PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 
 def _load_pyproject() -> dict:
-    return tomllib.loads(PYPROJECT.read_text())
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
 
 
 # ---------------------------------------------------------------------------
@@ -90,7 +90,7 @@ def test_version_consistency():
     pyproject_version = data["project"]["version"]
 
     main_path = Path(__file__).resolve().parent.parent / "src" / "pocketpaw" / "__main__.py"
-    main_text = main_path.read_text()
+    main_text = main_path.read_text(encoding="utf-8")
 
     # Either the version string is hardcoded and matches pyproject.toml,
     # or __main__.py uses dynamic version via importlib.metadata.version()

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -49,7 +49,7 @@ def test_token_generation(mock_config):
     assert token is not None
     assert len(token) > 20  # UUID length
     assert token_path.exists()
-    assert token_path.read_text() == token
+    assert token_path.read_text(encoding="utf-8") == token
 
 
 def test_auth_middleware_deny():

--- a/tests/test_skill_gen.py
+++ b/tests/test_skill_gen.py
@@ -66,7 +66,7 @@ class TestCreateSkillTool:
         skill_file = temp_skills_dir / "test-skill" / "SKILL.md"
         assert skill_file.exists()
 
-        content = skill_file.read_text()
+        content = skill_file.read_text(encoding="utf-8")
         assert "---" in content
         assert "name: test-skill" in content
         assert "description: A test skill" in content
@@ -86,7 +86,7 @@ class TestCreateSkillTool:
             )
 
         assert "created successfully" in result
-        content = (temp_skills_dir / "code-review" / "SKILL.md").read_text()
+        content = (temp_skills_dir / "code-review" / "SKILL.md").read_text(encoding="utf-8")
         assert "allowed-tools:" in content
         assert "  - read_file" in content
         assert "  - shell" in content
@@ -104,7 +104,7 @@ class TestCreateSkillTool:
             )
 
         assert "created successfully" in result
-        content = (temp_skills_dir / "internal-skill" / "SKILL.md").read_text()
+        content = (temp_skills_dir / "internal-skill" / "SKILL.md").read_text(encoding="utf-8")
         assert "user-invocable: false" in content
 
     async def test_invalid_skill_name_rejected(self, tool):
@@ -134,7 +134,7 @@ class TestCreateSkillTool:
         assert "Error" in result
         assert "already exists" in result
         # Original content preserved
-        assert (skill_dir / "SKILL.md").read_text() == "existing content"
+        assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == "existing content"
 
     @patch("pocketpaw.tools.builtin.skill_gen._get_skills_dir")
     async def test_skill_loader_reload_called(self, mock_dir, tool, temp_skills_dir):
@@ -161,7 +161,7 @@ class TestCreateSkillTool:
                 instructions="Instruction body here.",
             )
 
-        content = (temp_skills_dir / "fmt-test" / "SKILL.md").read_text()
+        content = (temp_skills_dir / "fmt-test" / "SKILL.md").read_text(encoding="utf-8")
         # Check frontmatter delimiters
         parts = content.split("---")
         assert len(parts) >= 3  # before, frontmatter, after

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -76,7 +76,7 @@ class TestCheckForUpdates:
 
         cache_file = tmp_path / CACHE_FILENAME
         assert cache_file.exists()
-        cache = json.loads(cache_file.read_text())
+        cache = json.loads(cache_file.read_text(encoding="utf-8"))
         assert "ts" in cache
         assert cache["latest"] == "0.4.1"
 
@@ -274,7 +274,7 @@ class TestVersionSeen:
 
         mark_version_seen("0.4.2", tmp_path)
 
-        cache = json.loads(cache_file.read_text())
+        cache = json.loads(cache_file.read_text(encoding="utf-8"))
         assert cache["ts"] == 12345
         assert cache["latest"] == "0.5.0"
         assert cache["last_seen_version"] == "0.4.2"

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -45,7 +45,7 @@ class TestUserProfile:
         DefaultBootstrapProvider(base_path=temp_identity_path)
         user_file = temp_identity_path / "USER.md"
         assert user_file.exists()
-        content = user_file.read_text()
+        content = user_file.read_text(encoding="utf-8")
         assert "# User Profile" in content
         assert "Name:" in content
         assert "Timezone:" in content
@@ -54,7 +54,7 @@ class TestUserProfile:
         # Pre-create USER.md with custom content
         (temp_identity_path / "USER.md").write_text("Name: Bob")
         DefaultBootstrapProvider(base_path=temp_identity_path)
-        content = (temp_identity_path / "USER.md").read_text()
+        content = (temp_identity_path / "USER.md").read_text(encoding="utf-8")
         assert content == "Name: Bob"
 
     async def test_user_profile_loaded_into_context(self, temp_identity_path):


### PR DESCRIPTION
Fixes #363

Adds encoding="utf-8" to read_text() usages across the test suite to resolve Windows UnicodeDecodeError issues.

Includes test_skill_gen.py and other files reading project source, memory, identity, and markdown files.

No unrelated changes included.