### PR TITLE
fix(health): guard non-string values in check_api_key_format

### DIFF
--- a/src/pocketpaw/health/checks.py
+++ b/src/pocketpaw/health/checks.py
@@ -311,7 +311,7 @@ def check_api_key_format() -> HealthCheckResult:
     for field_name, validator in _API_KEY_PATTERNS.items():
         value = getattr(settings, field_name, None)
         pattern = validator["pattern"]
-        if value and not pattern.match(value):
+        if value and isinstance(value, str) and not pattern.match(value):
             warnings.append(f"{field_name} doesn't match expected format ({pattern.pattern})")
 
     if warnings:


### PR DESCRIPTION
## What

One-line fix in `health/checks.py`. The `check_api_key_format()` function iterates over `_API_KEY_PATTERNS` and runs a regex against each key value. If a test uses `MagicMock()` for settings and doesn't explicitly set every field in `_API_KEY_PATTERNS`, `getattr` returns a MagicMock object. That object is truthy, so the `if value` check passes, and `pattern.match(value)` blows up with `TypeError: expected string or bytes-like object`.

Added `isinstance(value, str)` guard before the regex call.

## Why now

The health check refactor in the PR #394 fix commit added `telegram_bot_token` to `_API_KEY_PATTERNS`, but the existing `TestCheckApiKeyFormat` tests only set `anthropic_api_key` and `openai_api_key` on the mock. Third field → MagicMock attribute → crash. 3 tests started failing.

## Tests

```
tests/test_health.py::TestCheckApiKeyFormat::test_valid_anthropic_key PASSED
tests/test_health.py::TestCheckApiKeyFormat::test_invalid_anthropic_key_format PASSED
tests/test_health.py::TestCheckApiKeyFormat::test_no_keys_is_ok PASSED
```

Full run: 2472 passed, 1 skipped, 1 pre-existing failure (`test_authorize_invalid_scope`).