### PR TITLE
feat: add paw module — Click CLI + soul-protocol integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
+# Updated: 2026-03-02 — Added click dep, soul optional dep, paw composite extra, paw script entry.
 [project]
 name = "pocketpaw"
 version = "0.4.4"
@@ -52,6 +53,7 @@ dependencies = [
     "python-multipart>=0.0.22",
     # Logging & CLI
     "rich>=13.0.0",
+    "click>=8.0",
     # Scheduling
     "apscheduler>=3.10.0",
     "python-dateutil>=2.8.0",
@@ -132,6 +134,9 @@ sarvam = [
 mcp = [
     "mcp>=1.0.0",
 ]
+soul = [
+    "soul-protocol>=0.2.0",
+]
 
 # --- Composite extras ---
 recommended = [
@@ -149,6 +154,10 @@ all-tools = [
 all-backends = [
     "pocketpaw[openai-agents,google-adk,copilot-sdk]",
 ]
+paw = [
+    "pocketpaw[soul]",
+    "click>=8.0",
+]
 all = [
     "pocketpaw[recommended,all-channels,all-tools,all-backends]",
 ]
@@ -163,6 +172,7 @@ dev = [
 
 [project.scripts]
 pocketpaw = "pocketpaw.__main__:main"
+paw = "pocketpaw.paw.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/pocketpaw/pocketpaw"

--- a/src/pocketpaw/paw/__init__.py
+++ b/src/pocketpaw/paw/__init__.py
@@ -1,0 +1,7 @@
+# Paw module — lightweight CLI entry point for PocketPaw with soul-protocol integration.
+# Created: 2026-03-02
+# Provides: PawConfig, SoulBridge, SoulBootstrapProvider, soul tools, CLI commands.
+
+from pocketpaw.paw.config import PawConfig
+
+__all__ = ["PawConfig"]

--- a/src/pocketpaw/paw/agent.py
+++ b/src/pocketpaw/paw/agent.py
@@ -1,0 +1,98 @@
+# Paw agent factory — wires Soul, bootstrap provider, tools, and registry together.
+# Created: 2026-03-02
+# get_paw_agent() returns a configured agent context ready to run.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pocketpaw.paw.config import PawConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _require_soul_protocol() -> None:
+    """Raise a helpful error if soul-protocol is not installed."""
+    try:
+        import soul_protocol  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "soul-protocol is required for paw. Install it with:\n"
+            "  pip install pocketpaw[soul]\n"
+            "  # or\n"
+            "  pip install soul-protocol"
+        ) from None
+
+
+@dataclass
+class PawAgent:
+    """Container for a wired-up paw agent."""
+
+    soul: Any  # Soul instance
+    bridge: Any  # SoulBridge
+    bootstrap_provider: Any  # SoulBootstrapProvider
+    registry: Any  # ToolRegistry
+    config: PawConfig
+
+
+async def get_paw_agent(project_root: Path | None = None) -> PawAgent:
+    """Wire everything together and return a configured paw agent.
+
+    1. Load PawConfig from project directory
+    2. Awaken or birth a Soul
+    3. Create SoulBootstrapProvider
+    4. Create ToolRegistry with soul tools
+    5. Return PawAgent ready to run
+    """
+    _require_soul_protocol()
+
+    from soul_protocol import Soul
+
+    from pocketpaw.paw.soul_bridge import SoulBootstrapProvider, SoulBridge
+    from pocketpaw.paw.tools import (
+        SoulEditCoreTool,
+        SoulRecallTool,
+        SoulRememberTool,
+        SoulStatusTool,
+    )
+    from pocketpaw.tools.registry import ToolRegistry
+
+    config = PawConfig.load(project_root)
+
+    # Ensure .paw directory exists
+    config.paw_dir.mkdir(parents=True, exist_ok=True)
+
+    # Awaken existing soul or birth a new one
+    soul_path = config.soul_path or config.default_soul_path
+    if soul_path.exists():
+        logger.info("Awakening soul from %s", soul_path)
+        soul = await Soul.awaken(soul_path)
+    else:
+        logger.info("Birthing new soul: %s", config.soul_name)
+        soul = await Soul.birth(
+            name=config.soul_name,
+            archetype="Project Assistant",
+            persona=f"I am {config.soul_name}, the resident AI for this project.",
+        )
+
+    # Wire up bridge and bootstrap
+    bridge = SoulBridge(soul)
+    bootstrap_provider = SoulBootstrapProvider(soul)
+
+    # Create tool registry with soul tools
+    registry = ToolRegistry()
+    registry.register(SoulRememberTool(soul))
+    registry.register(SoulRecallTool(soul))
+    registry.register(SoulEditCoreTool(soul))
+    registry.register(SoulStatusTool(soul))
+
+    return PawAgent(
+        soul=soul,
+        bridge=bridge,
+        bootstrap_provider=bootstrap_provider,
+        registry=registry,
+        config=config,
+    )

--- a/src/pocketpaw/paw/cli.py
+++ b/src/pocketpaw/paw/cli.py
@@ -1,0 +1,541 @@
+# Paw CLI — Click-based universal entry point for PocketPaw with soul-protocol.
+# Created: 2026-03-02
+# Updated: 2026-03-02 — Fixed _print() call without args in doctor command.
+# Commands: init, ask, chat, serve, status, doctor, os, channels.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+import click
+
+logger = logging.getLogger(__name__)
+
+
+def _run_async(coro):
+    """Bridge sync Click commands to async internals."""
+    return asyncio.run(coro)
+
+
+def _get_console():
+    """Lazy-import rich Console."""
+    try:
+        from rich.console import Console
+
+        return Console()
+    except ImportError:
+        return None
+
+
+def _print(message: str, style: str | None = None) -> None:
+    """Print with rich if available, plain otherwise."""
+    console = _get_console()
+    if console and style:
+        console.print(message, style=style)
+    elif console:
+        console.print(message)
+    else:
+        click.echo(message)
+
+
+def _check_soul_protocol() -> bool:
+    """Check if soul-protocol is installed."""
+    try:
+        import soul_protocol  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Main group
+# ---------------------------------------------------------------------------
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+@click.version_option(package_name="pocketpaw", prog_name="paw")
+def main(ctx: click.Context) -> None:
+    """paw — your AI companion that lives in your project."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+# ---------------------------------------------------------------------------
+# paw init
+# ---------------------------------------------------------------------------
+
+@main.command()
+@click.option("--name", "-n", default=None, help="Name for the soul (default: Paw)")
+@click.option("--provider", "-p", default=None, help="LLM provider: claude, openai, ollama, none")
+@click.option("--scan/--no-scan", default=True, help="Scan project on init (default: yes)")
+def init(name: str | None, provider: str | None, scan: bool) -> None:
+    """Initialize paw in the current project directory."""
+    if not _check_soul_protocol():
+        _print(
+            "soul-protocol is not installed. Install with:\n"
+            "  pip install pocketpaw[soul]",
+            style="bold red",
+        )
+        raise SystemExit(1)
+
+    _run_async(_init_async(name, provider, scan))
+
+
+async def _init_async(name: str | None, provider: str | None, scan: bool) -> None:
+    """Async implementation of paw init."""
+    import os
+
+    from pocketpaw.paw.config import PawConfig
+
+    project_root = Path.cwd()
+    config = PawConfig.load(project_root)
+
+    if name:
+        config.soul_name = name
+    if provider:
+        config.provider = provider
+
+    # Ensure .paw directory
+    config.paw_dir.mkdir(parents=True, exist_ok=True)
+
+    _print(f"\nInitializing paw in {project_root}", style="bold cyan")
+    _print(f"  Soul name: {config.soul_name}", style="dim")
+    _print(f"  Provider:  {config.provider}", style="dim")
+
+    # Birth the soul
+    from soul_protocol import Soul
+
+    soul_path = config.soul_path or config.default_soul_path
+    if soul_path.exists():
+        _print(f"\n  Soul already exists at {soul_path}", style="yellow")
+        soul = await Soul.awaken(soul_path)
+    else:
+        _print(f"\n  Birthing soul: {config.soul_name}...", style="green")
+        soul = await Soul.birth(
+            name=config.soul_name,
+            archetype="Project Assistant",
+            persona=f"I am {config.soul_name}, the resident AI for this project.",
+        )
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        await soul.save(soul_path)
+        _print(f"  Soul saved to {soul_path}", style="green")
+
+    # Write paw.yaml config
+    yaml_path = project_root / "paw.yaml"
+    if not yaml_path.exists():
+        yaml_content = (
+            f"# Paw configuration\n"
+            f"soul_name: {config.soul_name}\n"
+            f"provider: {config.provider}\n"
+            f"soul_path: {soul_path}\n"
+        )
+        yaml_path.write_text(yaml_content)
+        _print(f"  Config written to {yaml_path}", style="green")
+
+    # Scan project
+    if scan:
+        _print("\n  Scanning project...", style="cyan")
+        from pocketpaw.paw.scan import heuristic_scan
+
+        await heuristic_scan(project_root, soul)
+        await soul.save(soul_path)
+        _print("  Scan complete. Soul updated with project knowledge.", style="green")
+
+    _print("\n  paw is ready. Try: paw ask 'what is this project?'\n", style="bold green")
+
+
+# ---------------------------------------------------------------------------
+# paw ask
+# ---------------------------------------------------------------------------
+
+@main.command()
+@click.argument("question")
+def ask(question: str) -> None:
+    """Ask paw a one-shot question about your project."""
+    if not _check_soul_protocol():
+        _print("soul-protocol is not installed. Run: pip install pocketpaw[soul]", style="red")
+        raise SystemExit(1)
+
+    _run_async(_ask_async(question))
+
+
+async def _ask_async(question: str) -> None:
+    """Async implementation of paw ask."""
+    from pocketpaw.paw.agent import get_paw_agent
+
+    try:
+        agent = await get_paw_agent()
+    except Exception as e:
+        _print(f"Failed to initialize paw: {e}", style="red")
+        _print("Run 'paw init' first to set up your project.", style="dim")
+        raise SystemExit(1)
+
+    # Recall relevant memories
+    memories = await agent.bridge.recall(question, limit=5)
+    context_parts = []
+    if memories:
+        context_parts.append("Relevant memories:\n" + "\n".join(f"- {m}" for m in memories))
+
+    # Get bootstrap context
+    bootstrap = await agent.bootstrap_provider.get_context()
+    system_prompt = bootstrap.to_system_prompt()
+
+    if context_parts:
+        system_prompt += "\n\n" + "\n".join(context_parts)
+
+    # For now, print the system prompt context and note that full agent routing
+    # requires provider-specific wiring
+    _print(f"\n[{agent.config.soul_name}]", style="bold cyan")
+
+    if agent.config.provider == "none":
+        _print(
+            "Provider is set to 'none'. Showing recalled memories only:\n",
+            style="dim",
+        )
+        if memories:
+            for m in memories:
+                _print(f"  - {m}")
+        else:
+            _print("  No relevant memories found. Run 'paw init --scan' first.", style="dim")
+        return
+
+    # Use PocketPaw's agent router for the actual query
+    try:
+        from pocketpaw.agents.router import AgentRouter
+        from pocketpaw.config import get_settings
+
+        settings = get_settings()
+        router = AgentRouter(settings)
+
+        response_parts: list[str] = []
+        async for event in router.run(question, system_prompt=system_prompt):
+            if event.type in ("text", "response"):
+                response_parts.append(event.content)
+            elif event.type == "error":
+                _print(f"Error: {event.content}", style="red")
+
+        if response_parts:
+            _print("".join(response_parts))
+
+        # Observe the interaction
+        full_response = "".join(response_parts)
+        if full_response:
+            await agent.bridge.observe(question, full_response)
+            await agent.soul.save(agent.config.soul_path or agent.config.default_soul_path)
+    except Exception as e:
+        _print(f"Agent error: {e}", style="red")
+        _print("Falling back to memory recall only.", style="dim")
+        if memories:
+            for m in memories:
+                _print(f"  - {m}")
+
+
+# ---------------------------------------------------------------------------
+# paw chat
+# ---------------------------------------------------------------------------
+
+@main.command()
+def chat() -> None:
+    """Start an interactive chat session with paw."""
+    if not _check_soul_protocol():
+        _print("soul-protocol is not installed. Run: pip install pocketpaw[soul]", style="red")
+        raise SystemExit(1)
+
+    _run_async(_chat_async())
+
+
+async def _chat_async() -> None:
+    """Async implementation of paw chat REPL."""
+    from pocketpaw.paw.agent import get_paw_agent
+
+    try:
+        agent = await get_paw_agent()
+    except Exception as e:
+        _print(f"Failed to initialize paw: {e}", style="red")
+        _print("Run 'paw init' first.", style="dim")
+        raise SystemExit(1)
+
+    _print(f"\n  Chat with {agent.config.soul_name} (type 'exit' or Ctrl+C to quit)\n",
+           style="bold cyan")
+
+    try:
+        from pocketpaw.agents.router import AgentRouter
+        from pocketpaw.config import get_settings
+
+        settings = get_settings()
+        router = AgentRouter(settings)
+    except Exception:
+        router = None
+
+    soul_path = agent.config.soul_path or agent.config.default_soul_path
+
+    while True:
+        try:
+            user_input = input("you> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            _print("\nGoodbye!", style="dim")
+            break
+
+        if not user_input:
+            continue
+        if user_input.lower() in ("exit", "quit", "bye"):
+            _print("Goodbye!", style="dim")
+            break
+
+        # Recall context
+        memories = await agent.bridge.recall(user_input, limit=5)
+        bootstrap = await agent.bootstrap_provider.get_context()
+        system_prompt = bootstrap.to_system_prompt()
+
+        if memories:
+            system_prompt += (
+                "\n\nRelevant memories:\n" + "\n".join(f"- {m}" for m in memories)
+            )
+
+        if router:
+            response_parts: list[str] = []
+            async for event in router.run(user_input, system_prompt=system_prompt):
+                if event.type in ("text", "response"):
+                    response_parts.append(event.content)
+                    # Stream to terminal
+                    sys.stdout.write(event.content)
+                    sys.stdout.flush()
+                elif event.type == "error":
+                    _print(f"\nError: {event.content}", style="red")
+
+            print()  # newline after streamed response
+            full_response = "".join(response_parts)
+            if full_response:
+                await agent.bridge.observe(user_input, full_response)
+        else:
+            _print("(No agent backend available — showing memories only)", style="dim")
+            if memories:
+                for m in memories:
+                    _print(f"  - {m}")
+            else:
+                _print("  No relevant memories found.", style="dim")
+
+    # Save soul state on exit
+    try:
+        await agent.soul.save(soul_path)
+        _print("Soul state saved.", style="dim")
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# paw serve
+# ---------------------------------------------------------------------------
+
+@main.command()
+@click.option("--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1)")
+@click.option("--port", "-p", default=8888, type=int, help="Port to bind (default: 8888)")
+def serve(host: str, port: int) -> None:
+    """Start MCP server (placeholder — full implementation coming soon)."""
+    _print(f"MCP server placeholder — would bind to {host}:{port}", style="yellow")
+    _print("Full MCP server integration coming in a future release.", style="dim")
+
+
+# ---------------------------------------------------------------------------
+# paw status
+# ---------------------------------------------------------------------------
+
+@main.command()
+def status() -> None:
+    """Show the soul's current state and project info."""
+    if not _check_soul_protocol():
+        _print("soul-protocol is not installed.", style="red")
+        raise SystemExit(1)
+
+    _run_async(_status_async())
+
+
+async def _status_async() -> None:
+    """Async implementation of paw status."""
+    from pocketpaw.paw.agent import get_paw_agent
+
+    try:
+        agent = await get_paw_agent()
+    except Exception as e:
+        _print(f"Not initialized: {e}", style="red")
+        _print("Run 'paw init' first.", style="dim")
+        raise SystemExit(1)
+
+    config = agent.config
+    soul = agent.soul
+    state = soul.state
+
+    _print(f"\n  paw status", style="bold cyan")
+    _print(f"  {'─' * 40}")
+    _print(f"  Soul:     {config.soul_name}")
+    _print(f"  Provider: {config.provider}")
+    _print(f"  Project:  {config.project_root}")
+
+    if hasattr(state, "mood"):
+        _print(f"  Mood:     {state.mood}")
+    if hasattr(state, "energy"):
+        _print(f"  Energy:   {state.energy}")
+    if hasattr(state, "social_battery"):
+        _print(f"  Social:   {state.social_battery}")
+
+    # Show active domains
+    if hasattr(soul, "self_model") and soul.self_model:
+        try:
+            images = soul.self_model.get_active_self_images(limit=5)
+            if images:
+                _print(f"\n  Active domains:")
+                for img in images:
+                    _print(f"    - {img.domain} (confidence: {img.confidence})")
+        except Exception:
+            pass
+
+    _print()
+
+
+# ---------------------------------------------------------------------------
+# paw doctor
+# ---------------------------------------------------------------------------
+
+@main.command()
+def doctor() -> None:
+    """Run health checks for paw and PocketPaw."""
+    _print("\n  paw doctor", style="bold cyan")
+    _print(f"  {'─' * 40}")
+
+    # Check soul-protocol
+    if _check_soul_protocol():
+        _print("  [OK]   soul-protocol installed", style="green")
+    else:
+        _print("  [FAIL] soul-protocol not installed", style="red")
+        _print("         pip install pocketpaw[soul]", style="dim")
+
+    # Check click
+    _print("  [OK]   click installed", style="green")
+
+    # Check rich
+    try:
+        import rich  # noqa: F401
+
+        _print("  [OK]   rich installed", style="green")
+    except ImportError:
+        _print("  [WARN] rich not installed (plain output)", style="yellow")
+
+    # Check .paw directory
+    paw_dir = Path.cwd() / ".paw"
+    if paw_dir.exists():
+        _print(f"  [OK]   .paw directory exists", style="green")
+    else:
+        _print("  [WARN] .paw directory not found — run 'paw init'", style="yellow")
+
+    # Check paw.yaml
+    yaml_path = Path.cwd() / "paw.yaml"
+    if yaml_path.exists():
+        _print(f"  [OK]   paw.yaml found", style="green")
+    else:
+        _print("  [WARN] paw.yaml not found — run 'paw init'", style="yellow")
+
+    # Check soul file
+    from pocketpaw.paw.config import PawConfig
+
+    config = PawConfig.load()
+    soul_path = config.soul_path or config.default_soul_path
+    if soul_path.exists():
+        _print(f"  [OK]   Soul file: {soul_path}", style="green")
+    else:
+        _print(f"  [WARN] No soul file at {soul_path}", style="yellow")
+
+    # Delegate to PocketPaw's health engine
+    try:
+        from pocketpaw.health import get_health_engine
+
+        engine = get_health_engine()
+        results = engine.run_startup_checks()
+        for r in results:
+            if r.status == "ok":
+                _print(f"  [OK]   {r.name}: {r.message}", style="green")
+            elif r.status == "warning":
+                _print(f"  [WARN] {r.name}: {r.message}", style="yellow")
+            else:
+                _print(f"  [FAIL] {r.name}: {r.message}", style="red")
+    except Exception:
+        _print("  [WARN] Could not run PocketPaw health checks", style="yellow")
+
+    _print("")
+
+
+# ---------------------------------------------------------------------------
+# paw os
+# ---------------------------------------------------------------------------
+
+@main.command(name="os")
+@click.option("--port", "-p", default=8888, type=int, help="Dashboard port (default: 8888)")
+@click.option("--dev", is_flag=True, help="Development mode with auto-reload")
+def launch_os(port: int, dev: bool) -> None:
+    """Launch the full PocketPaw dashboard."""
+    _print("Launching PocketPaw dashboard...", style="bold cyan")
+    try:
+        from pocketpaw.dashboard import run_dashboard
+
+        run_dashboard(host="127.0.0.1", port=port, open_browser=True, dev=dev)
+    except ImportError as e:
+        _print(f"Dashboard unavailable: {e}", style="red")
+    except KeyboardInterrupt:
+        _print("Dashboard stopped.", style="dim")
+
+
+# ---------------------------------------------------------------------------
+# paw channels
+# ---------------------------------------------------------------------------
+
+@main.command()
+@click.option("--telegram", is_flag=True, help="Start Telegram adapter")
+@click.option("--slack", is_flag=True, help="Start Slack adapter")
+@click.option("--discord", is_flag=True, help="Start Discord adapter")
+def channels(telegram: bool, slack: bool, discord: bool) -> None:
+    """Run headless channel adapters."""
+    if not any([telegram, slack, discord]):
+        _print("Specify at least one channel: --telegram, --slack, --discord", style="yellow")
+        raise SystemExit(1)
+
+    _print("Starting headless channels...", style="bold cyan")
+
+    try:
+        from pocketpaw.config import get_settings
+
+        settings = get_settings()
+
+        # Build a mock args namespace for the headless runner
+        class _Args:
+            pass
+
+        args = _Args()
+        args.telegram = telegram
+        args.slack = slack
+        args.discord = discord
+        args.whatsapp = False
+        args.signal = False
+        args.matrix = False
+        args.teams = False
+        args.gchat = False
+
+        if telegram and not any([slack, discord]):
+            from pocketpaw.headless import run_telegram_mode
+
+            _run_async(run_telegram_mode(settings))
+        else:
+            from pocketpaw.headless import run_multi_channel_mode
+
+            _run_async(run_multi_channel_mode(settings, args))
+    except ImportError as e:
+        _print(f"Missing dependency: {e}", style="red")
+        _print("Install channel extras: pip install pocketpaw[telegram,discord,slack]", style="dim")
+    except KeyboardInterrupt:
+        _print("Channels stopped.", style="dim")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pocketpaw/paw/config.py
+++ b/src/pocketpaw/paw/config.py
@@ -1,0 +1,78 @@
+# Paw configuration — reads paw.yaml from project root.
+# Created: 2026-03-02
+# Supports env vars PAW_PROVIDER, PAW_SOUL_PATH for overrides.
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class PawConfig:
+    """Configuration for a paw instance in a project directory."""
+
+    project_root: Path
+    soul_name: str = "Paw"
+    soul_path: Path | None = None
+    provider: str = "claude"  # claude, openai, ollama, none
+
+    @classmethod
+    def load(cls, project_root: Path | None = None) -> PawConfig:
+        """Load config from paw.yaml in project_root, with env var overrides."""
+        root = project_root or Path.cwd()
+        config_file = root / "paw.yaml"
+
+        data: dict[str, Any] = {}
+        if config_file.exists():
+            data = _load_yaml(config_file)
+
+        # Env var overrides
+        provider = os.environ.get("PAW_PROVIDER", data.get("provider", "claude"))
+        soul_path_str = os.environ.get("PAW_SOUL_PATH", data.get("soul_path"))
+        soul_path = Path(soul_path_str) if soul_path_str else None
+        soul_name = data.get("soul_name", data.get("name", "Paw"))
+
+        return cls(
+            project_root=root,
+            soul_name=soul_name,
+            soul_path=soul_path,
+            provider=provider,
+        )
+
+    @property
+    def default_soul_path(self) -> Path:
+        """Default location for the .soul file in the project."""
+        return self.project_root / ".paw" / f"{self.soul_name.lower()}.soul"
+
+    @property
+    def paw_dir(self) -> Path:
+        """The .paw directory in the project root."""
+        return self.project_root / ".paw"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load YAML file, falling back to basic parsing if PyYAML unavailable."""
+    try:
+        import yaml
+
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+    except ImportError:
+        # Minimal key: value parser for simple configs
+        result: dict[str, Any] = {}
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if ":" in line:
+                    key, _, value = line.partition(":")
+                    value = value.strip().strip("\"'")
+                    if value.lower() in ("null", "~", ""):
+                        result[key.strip()] = None
+                    else:
+                        result[key.strip()] = value
+        return result

--- a/src/pocketpaw/paw/scan.py
+++ b/src/pocketpaw/paw/scan.py
@@ -1,0 +1,125 @@
+# Project scanning — learns about a project via agent or heuristic fallback.
+# Created: 2026-03-02
+# SCAN_PROMPT template, run_agent_scan(), heuristic_scan().
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from soul_protocol import Soul
+
+logger = logging.getLogger(__name__)
+
+SCAN_PROMPT = """You are scanning a new project to learn about it. Your job is to understand:
+1. What language/framework this project uses
+2. What the project does (purpose)
+3. How to build/run/test it
+4. Key files and directory structure
+5. Any notable patterns or conventions
+
+Use the file reading tools to examine:
+- README.md or README files
+- pyproject.toml, package.json, Cargo.toml, go.mod (build configs)
+- Top-level source files and directory names
+- .env.example or similar config templates (DO NOT read .env itself)
+
+For each important fact you discover, use the soul_remember tool to store it.
+Be thorough but efficient — focus on the most important structural facts.
+
+Project root: {project_path}
+"""
+
+
+async def run_agent_scan(soul: Soul, project_path: Path, provider: str) -> None:
+    """Run a full agent-powered scan of the project.
+
+    Uses the configured LLM provider to intelligently scan the project,
+    reading files and storing discoveries in the soul's memory.
+    """
+    from pocketpaw.paw.tools import SoulRememberTool, SoulRecallTool
+
+    prompt = SCAN_PROMPT.format(project_path=project_path)
+
+    # For now, delegate to heuristic scan + remember.
+    # Full agent-powered scan requires wiring AgentRouter which is a bigger lift.
+    # This is the recommended path for v1 — do the heuristic scan and store results.
+    logger.info("Running heuristic project scan (agent scan coming in next version)")
+    await heuristic_scan(project_path, soul)
+
+
+async def heuristic_scan(project_path: Path, soul: Soul) -> None:
+    """Offline fallback that reads common project files and stores facts.
+
+    Examines README, pyproject.toml, package.json, and .env.example
+    to bootstrap the soul's knowledge about the project.
+    """
+    facts: list[str] = []
+
+    # README
+    for readme_name in ("README.md", "README.rst", "README.txt", "README"):
+        readme_path = project_path / readme_name
+        if readme_path.exists():
+            content = readme_path.read_text(errors="replace")[:2000]
+            facts.append(f"Project README ({readme_name}):\n{content}")
+            break
+
+    # pyproject.toml
+    pyproject = project_path / "pyproject.toml"
+    if pyproject.exists():
+        content = pyproject.read_text(errors="replace")[:1500]
+        facts.append(f"Python project config (pyproject.toml):\n{content}")
+
+    # package.json
+    pkg_json = project_path / "package.json"
+    if pkg_json.exists():
+        content = pkg_json.read_text(errors="replace")[:1500]
+        facts.append(f"Node.js project config (package.json):\n{content}")
+
+    # Cargo.toml
+    cargo = project_path / "Cargo.toml"
+    if cargo.exists():
+        content = cargo.read_text(errors="replace")[:1500]
+        facts.append(f"Rust project config (Cargo.toml):\n{content}")
+
+    # go.mod
+    gomod = project_path / "go.mod"
+    if gomod.exists():
+        content = gomod.read_text(errors="replace")[:500]
+        facts.append(f"Go module config (go.mod):\n{content}")
+
+    # .env.example (safe to read — no secrets)
+    env_example = project_path / ".env.example"
+    if env_example.exists():
+        content = env_example.read_text(errors="replace")[:500]
+        var_names = [
+            line.split("=")[0].strip()
+            for line in content.splitlines()
+            if "=" in line and not line.strip().startswith("#")
+        ]
+        if var_names:
+            facts.append(f"Environment variables used: {', '.join(var_names)}")
+
+    # Directory structure (top-level only)
+    try:
+        entries = sorted(p.name for p in project_path.iterdir() if not p.name.startswith("."))
+        dirs = [e for e in entries if (project_path / e).is_dir()]
+        files = [e for e in entries if (project_path / e).is_file()]
+        facts.append(
+            f"Top-level directories: {', '.join(dirs[:20])}\n"
+            f"Top-level files: {', '.join(files[:20])}"
+        )
+    except OSError:
+        pass
+
+    # Store each fact in the soul
+    for fact in facts:
+        importance = 8 if "README" in fact or "project config" in fact else 6
+        try:
+            await soul.remember(fact, importance=importance)
+        except Exception as e:
+            logger.warning("Failed to store scan fact: %s", e)
+
+    logger.info("Heuristic scan complete — stored %d facts", len(facts))

--- a/src/pocketpaw/paw/soul_bridge.py
+++ b/src/pocketpaw/paw/soul_bridge.py
@@ -1,0 +1,79 @@
+# Soul bridge — connects soul-protocol into PocketPaw's bootstrap and agent loop.
+# Created: 2026-03-02
+# SoulBootstrapProvider implements BootstrapProviderProtocol.
+# SoulBridge provides high-level observe/recall for the agent loop.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pocketpaw.bootstrap.protocol import BootstrapContext
+
+if TYPE_CHECKING:
+    from soul_protocol import Soul
+
+
+class SoulBootstrapProvider:
+    """Wraps a Soul into PocketPaw's BootstrapProviderProtocol.
+
+    Maps the soul's system prompt, personality, and memories into
+    the BootstrapContext fields that AgentContextBuilder consumes.
+    """
+
+    def __init__(self, soul: Soul) -> None:
+        self._soul = soul
+
+    async def get_context(self) -> BootstrapContext:
+        """Build BootstrapContext from the soul's current state."""
+        soul = self._soul
+        system_prompt = soul.to_system_prompt()
+
+        # Extract personality and mood for style hints
+        state = soul.state
+        mood_hint = f"Current mood: {state.mood}" if hasattr(state, "mood") else ""
+        energy_hint = f"Energy: {state.energy}" if hasattr(state, "energy") else ""
+        style_parts = [s for s in [mood_hint, energy_hint] if s]
+
+        # Pull active self-images for knowledge context
+        knowledge: list[str] = []
+        if hasattr(soul, "self_model") and soul.self_model:
+            try:
+                images = soul.self_model.get_active_self_images(limit=5)
+                for img in images:
+                    knowledge.append(f"[{img.domain}] confidence={img.confidence}")
+            except Exception:
+                pass
+
+        return BootstrapContext(
+            name=soul.name if hasattr(soul, "name") else "Paw",
+            identity=system_prompt,
+            soul="I am a persistent AI companion powered by soul-protocol.",
+            style="; ".join(style_parts) if style_parts else "Helpful and attentive.",
+            knowledge=knowledge,
+        )
+
+
+class SoulBridge:
+    """High-level bridge for observe/recall in the agent loop."""
+
+    def __init__(self, soul: Soul) -> None:
+        self._soul = soul
+
+    async def observe(self, user_input: str, agent_output: str) -> None:
+        """Record an interaction for the soul to learn from."""
+        try:
+            from soul_protocol import Interaction
+
+            await self._soul.observe(
+                Interaction(user_input=user_input, agent_output=agent_output)
+            )
+        except Exception:
+            pass  # Observation failure should never break the agent loop
+
+    async def recall(self, query: str, limit: int = 5) -> list[str]:
+        """Search soul memories and return content strings."""
+        try:
+            memories = await self._soul.recall(query, limit=limit)
+            return [m.content for m in memories]
+        except Exception:
+            return []

--- a/src/pocketpaw/paw/tools.py
+++ b/src/pocketpaw/paw/tools.py
@@ -1,0 +1,224 @@
+# Soul tools — four BaseTool implementations for soul-protocol integration.
+# Created: 2026-03-02
+# SoulRememberTool, SoulRecallTool, SoulEditCoreTool, SoulStatusTool.
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from pocketpaw.tools.protocol import BaseTool
+
+if TYPE_CHECKING:
+    from soul_protocol import Soul
+
+
+class SoulRememberTool(BaseTool):
+    """Store memories via soul.remember()."""
+
+    def __init__(self, soul: Soul) -> None:
+        self._soul = soul
+
+    @property
+    def name(self) -> str:
+        return "soul_remember"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Store a memory in the soul's persistent memory. Use this to remember "
+            "facts about the project, user preferences, or important context that "
+            "should persist across sessions."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": "The information to remember (be specific and clear)",
+                },
+                "importance": {
+                    "type": "integer",
+                    "description": "Importance level from 1 (trivial) to 10 (critical). Default: 5",
+                    "minimum": 1,
+                    "maximum": 10,
+                },
+            },
+            "required": ["content"],
+        }
+
+    async def execute(self, content: str, importance: int = 5, **kwargs: Any) -> str:
+        try:
+            await self._soul.remember(content, importance=importance)
+            return self._success(
+                f"Remembered (importance={importance}): "
+                f"{content[:100]}{'...' if len(content) > 100 else ''}"
+            )
+        except Exception as e:
+            return self._error(f"Failed to store memory: {e}")
+
+
+class SoulRecallTool(BaseTool):
+    """Search memories via soul.recall()."""
+
+    def __init__(self, soul: Soul) -> None:
+        self._soul = soul
+
+    @property
+    def name(self) -> str:
+        return "soul_recall"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search the soul's persistent memories. Returns relevant memories "
+            "matching the query, ordered by relevance."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "What to search for in memories",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of memories to return (default: 5)",
+                    "minimum": 1,
+                    "maximum": 20,
+                },
+            },
+            "required": ["query"],
+        }
+
+    async def execute(self, query: str, limit: int = 5, **kwargs: Any) -> str:
+        try:
+            memories = await self._soul.recall(query, limit=limit)
+            if not memories:
+                return f"No memories found matching: {query}"
+
+            lines = [f"Found {len(memories)} memories:\n"]
+            for i, m in enumerate(memories, 1):
+                emotion = f" ({m.emotion})" if hasattr(m, "emotion") and m.emotion else ""
+                lines.append(f"{i}. [{m.importance}] {m.content[:200]}{emotion}")
+
+            return "\n".join(lines)
+        except Exception as e:
+            return self._error(f"Failed to search memories: {e}")
+
+
+class SoulEditCoreTool(BaseTool):
+    """Edit persona/human core memory via soul.edit_core_memory()."""
+
+    def __init__(self, soul: Soul) -> None:
+        self._soul = soul
+
+    @property
+    def name(self) -> str:
+        return "soul_edit_core"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Edit the soul's core memory — the persistent persona and human descriptions. "
+            "Use this to update who the agent is (persona) or who the user is (human)."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "persona": {
+                    "type": "string",
+                    "description": "Updated persona description for the agent",
+                },
+                "human": {
+                    "type": "string",
+                    "description": "Updated description of the human user",
+                },
+            },
+            "required": [],
+        }
+
+    async def execute(
+        self, persona: str | None = None, human: str | None = None, **kwargs: Any
+    ) -> str:
+        if not persona and not human:
+            return self._error("Provide at least one of 'persona' or 'human' to edit.")
+
+        try:
+            edit_args: dict[str, str] = {}
+            if persona:
+                edit_args["persona"] = persona
+            if human:
+                edit_args["human"] = human
+
+            await self._soul.edit_core_memory(**edit_args)
+
+            updated = ", ".join(f"{k}" for k in edit_args)
+            return self._success(f"Core memory updated: {updated}")
+        except Exception as e:
+            return self._error(f"Failed to edit core memory: {e}")
+
+
+class SoulStatusTool(BaseTool):
+    """Check soul state, mood, energy, and active domains."""
+
+    def __init__(self, soul: Soul) -> None:
+        self._soul = soul
+
+    @property
+    def name(self) -> str:
+        return "soul_status"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Check the soul's current state including mood, energy level, "
+            "social battery, and active knowledge domains."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        try:
+            state = self._soul.state
+            status: dict[str, Any] = {}
+
+            if hasattr(state, "mood"):
+                status["mood"] = state.mood
+            if hasattr(state, "energy"):
+                status["energy"] = state.energy
+            if hasattr(state, "social_battery"):
+                status["social_battery"] = state.social_battery
+
+            # Active self-image domains
+            if hasattr(self._soul, "self_model") and self._soul.self_model:
+                try:
+                    images = self._soul.self_model.get_active_self_images(limit=5)
+                    status["domains"] = [
+                        {"domain": img.domain, "confidence": img.confidence}
+                        for img in images
+                    ]
+                except Exception:
+                    pass
+
+            if not status:
+                return "Soul state: active (no detailed state available)"
+
+            return json.dumps(status, indent=2, default=str)
+        except Exception as e:
+            return self._error(f"Failed to get soul status: {e}")

--- a/tests/test_paw_bridge.py
+++ b/tests/test_paw_bridge.py
@@ -1,0 +1,237 @@
+# Tests for paw module SoulBootstrapProvider and SoulBridge.
+# Created: 2026-03-02
+# Covers: get_context() returns BootstrapContext, SoulBridge.observe() and recall()
+#         behaviour, and error-swallowing guarantees.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pocketpaw.bootstrap.protocol import BootstrapContext
+from pocketpaw.paw.soul_bridge import SoulBootstrapProvider, SoulBridge
+
+
+# ---------------------------------------------------------------------------
+# Shared soul fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_soul():
+    soul = MagicMock()
+    soul.name = "TestSoul"
+    soul.to_system_prompt.return_value = "I am TestSoul."
+    soul.state = MagicMock(mood="curious", energy=85, social_battery=90)
+    soul.self_model = None
+    soul.remember = AsyncMock(return_value="mem_123")
+    soul.recall = AsyncMock(
+        return_value=[MagicMock(content="fact about project", importance=7, emotion=None)]
+    )
+    soul.observe = AsyncMock()
+    soul.edit_core_memory = AsyncMock()
+    soul.save = AsyncMock()
+    return soul
+
+
+# ---------------------------------------------------------------------------
+# SoulBootstrapProvider
+# ---------------------------------------------------------------------------
+
+
+class TestSoulBootstrapProvider:
+    @pytest.mark.asyncio
+    async def test_get_context_returns_bootstrap_context(self, mock_soul):
+        provider = SoulBootstrapProvider(mock_soul)
+
+        ctx = await provider.get_context()
+
+        assert isinstance(ctx, BootstrapContext)
+
+    @pytest.mark.asyncio
+    async def test_get_context_uses_soul_name(self, mock_soul):
+        provider = SoulBootstrapProvider(mock_soul)
+
+        ctx = await provider.get_context()
+
+        assert ctx.name == "TestSoul"
+
+    @pytest.mark.asyncio
+    async def test_get_context_uses_system_prompt_as_identity(self, mock_soul):
+        provider = SoulBootstrapProvider(mock_soul)
+
+        ctx = await provider.get_context()
+
+        assert ctx.identity == "I am TestSoul."
+
+    @pytest.mark.asyncio
+    async def test_get_context_includes_mood_in_style(self, mock_soul):
+        provider = SoulBootstrapProvider(mock_soul)
+
+        ctx = await provider.get_context()
+
+        assert "curious" in ctx.style
+
+    @pytest.mark.asyncio
+    async def test_get_context_includes_energy_in_style(self, mock_soul):
+        provider = SoulBootstrapProvider(mock_soul)
+
+        ctx = await provider.get_context()
+
+        assert "85" in ctx.style
+
+    @pytest.mark.asyncio
+    async def test_get_context_default_style_when_no_state_attrs(self):
+        soul = MagicMock()
+        soul.name = "Bare"
+        soul.to_system_prompt.return_value = "Bare soul."
+        soul.state = MagicMock(spec=[])  # no mood/energy attrs
+        soul.self_model = None
+        provider = SoulBootstrapProvider(soul)
+
+        ctx = await provider.get_context()
+
+        assert ctx.style != ""  # falls back to default
+
+    @pytest.mark.asyncio
+    async def test_get_context_includes_self_image_domains(self, mock_soul):
+        img = MagicMock(domain="Python", confidence=0.9)
+        self_model = MagicMock()
+        self_model.get_active_self_images.return_value = [img]
+        mock_soul.self_model = self_model
+        provider = SoulBootstrapProvider(mock_soul)
+
+        ctx = await provider.get_context()
+
+        assert any("Python" in k for k in ctx.knowledge)
+
+    @pytest.mark.asyncio
+    async def test_get_context_survives_self_model_exception(self, mock_soul):
+        self_model = MagicMock()
+        self_model.get_active_self_images.side_effect = RuntimeError("model error")
+        mock_soul.self_model = self_model
+        provider = SoulBootstrapProvider(mock_soul)
+
+        # Should not raise
+        ctx = await provider.get_context()
+
+        assert isinstance(ctx, BootstrapContext)
+        assert ctx.knowledge == []
+
+    @pytest.mark.asyncio
+    async def test_get_context_soul_string_present(self, mock_soul):
+        provider = SoulBootstrapProvider(mock_soul)
+
+        ctx = await provider.get_context()
+
+        assert "soul-protocol" in ctx.soul
+
+    @pytest.mark.asyncio
+    async def test_get_context_to_system_prompt_runs_without_error(self, mock_soul):
+        provider = SoulBootstrapProvider(mock_soul)
+
+        ctx = await provider.get_context()
+        prompt = ctx.to_system_prompt()
+
+        assert "TestSoul" in prompt
+
+
+# ---------------------------------------------------------------------------
+# SoulBridge
+# ---------------------------------------------------------------------------
+
+
+class TestSoulBridgeObserve:
+    @pytest.mark.asyncio
+    async def test_observe_calls_soul_observe(self, mock_soul):
+        """SoulBridge.observe() should call soul.observe() with an Interaction."""
+        bridge = SoulBridge(mock_soul)
+
+        # Patch Interaction so soul_protocol need not be installed
+        mock_interaction_cls = MagicMock()
+        mock_interaction_instance = MagicMock()
+        mock_interaction_cls.return_value = mock_interaction_instance
+
+        with patch("pocketpaw.paw.soul_bridge.Interaction", mock_interaction_cls, create=True):
+            with patch.dict("sys.modules", {"soul_protocol": MagicMock(Interaction=mock_interaction_cls)}):
+                await bridge.observe("Hello", "Hi there")
+
+        mock_soul.observe.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_observe_swallows_import_error(self, mock_soul):
+        """If soul_protocol is not installed, observe() must not raise."""
+        bridge = SoulBridge(mock_soul)
+
+        with patch.dict("sys.modules", {"soul_protocol": None}):
+            # Should complete silently even without soul_protocol
+            await bridge.observe("user says hi", "agent says hi back")
+
+    @pytest.mark.asyncio
+    async def test_observe_swallows_soul_exception(self, mock_soul):
+        """Any exception from soul.observe() must not propagate."""
+        mock_soul.observe = AsyncMock(side_effect=RuntimeError("disk error"))
+        bridge = SoulBridge(mock_soul)
+
+        mock_interaction_cls = MagicMock()
+        with patch.dict("sys.modules", {"soul_protocol": MagicMock(Interaction=mock_interaction_cls)}):
+            # Should complete silently
+            await bridge.observe("input", "output")
+
+
+class TestSoulBridgeRecall:
+    @pytest.mark.asyncio
+    async def test_recall_returns_content_strings(self, mock_soul):
+        bridge = SoulBridge(mock_soul)
+
+        results = await bridge.recall("project language")
+
+        assert results == ["fact about project"]
+
+    @pytest.mark.asyncio
+    async def test_recall_uses_limit_param(self, mock_soul):
+        bridge = SoulBridge(mock_soul)
+
+        await bridge.recall("query", limit=3)
+
+        mock_soul.recall.assert_awaited_once_with("query", limit=3)
+
+    @pytest.mark.asyncio
+    async def test_recall_default_limit_is_5(self, mock_soul):
+        bridge = SoulBridge(mock_soul)
+
+        await bridge.recall("query")
+
+        mock_soul.recall.assert_awaited_once_with("query", limit=5)
+
+    @pytest.mark.asyncio
+    async def test_recall_returns_empty_list_on_exception(self, mock_soul):
+        mock_soul.recall = AsyncMock(side_effect=RuntimeError("timeout"))
+        bridge = SoulBridge(mock_soul)
+
+        results = await bridge.recall("anything")
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_recall_returns_empty_list_when_soul_recall_returns_empty(self, mock_soul):
+        mock_soul.recall = AsyncMock(return_value=[])
+        bridge = SoulBridge(mock_soul)
+
+        results = await bridge.recall("anything")
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_recall_extracts_content_attribute_from_memories(self, mock_soul):
+        memories = [
+            MagicMock(content="first fact"),
+            MagicMock(content="second fact"),
+        ]
+        mock_soul.recall = AsyncMock(return_value=memories)
+        bridge = SoulBridge(mock_soul)
+
+        results = await bridge.recall("test")
+
+        assert results == ["first fact", "second fact"]

--- a/tests/test_paw_cli.py
+++ b/tests/test_paw_cli.py
@@ -1,0 +1,228 @@
+# Tests for paw module CLI commands.
+# Created: 2026-03-02
+# Covers: main help, init (mocked soul-protocol), doctor, channels validation,
+#         version option, serve placeholder. Uses Click's CliRunner throughout.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from pocketpaw.paw.cli import main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_mock_soul():
+    soul = MagicMock()
+    soul.name = "Paw"
+    soul.to_system_prompt.return_value = "I am Paw."
+    soul.state = MagicMock(mood="curious", energy=85, social_battery=90)
+    soul.self_model = None
+    soul.remember = AsyncMock()
+    soul.recall = AsyncMock(return_value=[])
+    soul.observe = AsyncMock()
+    soul.edit_core_memory = AsyncMock()
+    soul.save = AsyncMock()
+    soul.export = AsyncMock()
+    return soul
+
+
+# ---------------------------------------------------------------------------
+# main group
+# ---------------------------------------------------------------------------
+
+
+class TestMainGroup:
+    def test_main_shows_help_with_no_subcommand(self):
+        runner = CliRunner()
+        result = runner.invoke(main, [])
+
+        assert result.exit_code == 0
+        assert "paw" in result.output.lower()
+
+    def test_help_flag_exits_zero(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+
+        assert result.exit_code == 0
+
+    def test_version_option_outputs_version(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["--version"])
+
+        # Should mention 'paw' in version string
+        assert result.exit_code == 0
+        assert "paw" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# paw init
+# ---------------------------------------------------------------------------
+
+
+class TestInitCommand:
+    def test_init_fails_gracefully_when_soul_protocol_missing(self, tmp_path):
+        runner = CliRunner()
+
+        with patch("pocketpaw.paw.cli._check_soul_protocol", return_value=False):
+            result = runner.invoke(main, ["init"], catch_exceptions=False)
+
+        assert result.exit_code != 0
+        assert "soul-protocol" in result.output.lower()
+
+    def test_init_with_mocked_async_impl(self, tmp_path):
+        runner = CliRunner()
+
+        with (
+            patch("pocketpaw.paw.cli._check_soul_protocol", return_value=True),
+            patch("pocketpaw.paw.cli._init_async", new_callable=AsyncMock) as mock_init,
+        ):
+            result = runner.invoke(
+                main, ["init", "--no-scan"], catch_exceptions=False
+            )
+
+        assert result.exit_code == 0
+        mock_init.assert_awaited_once()
+
+    def test_init_name_option_passed_through(self, tmp_path):
+        runner = CliRunner()
+
+        with (
+            patch("pocketpaw.paw.cli._check_soul_protocol", return_value=True),
+            patch("pocketpaw.paw.cli._init_async", new_callable=AsyncMock) as mock_init,
+        ):
+            result = runner.invoke(
+                main, ["init", "--name", "Buddy", "--no-scan"], catch_exceptions=False
+            )
+
+        assert result.exit_code == 0
+        # _init_async called with name="Buddy"
+        _, kwargs = mock_init.call_args
+        assert kwargs.get("name") == "Buddy" or mock_init.call_args.args[0] == "Buddy"
+
+    def test_init_provider_option_accepted(self, tmp_path):
+        runner = CliRunner()
+
+        with (
+            patch("pocketpaw.paw.cli._check_soul_protocol", return_value=True),
+            patch("pocketpaw.paw.cli._init_async", new_callable=AsyncMock),
+        ):
+            result = runner.invoke(
+                main, ["init", "--provider", "ollama", "--no-scan"], catch_exceptions=False
+            )
+
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# paw doctor
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorCommand:
+    def test_doctor_runs_without_error(self, tmp_path):
+        runner = CliRunner()
+
+        # Run inside tmp_path so .paw and paw.yaml are absent (WARN is fine)
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            with patch("pocketpaw.paw.cli._check_soul_protocol", return_value=True):
+                result = runner.invoke(main, ["doctor"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+
+    def test_doctor_reports_soul_protocol_ok_when_installed(self, tmp_path):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            with patch("pocketpaw.paw.cli._check_soul_protocol", return_value=True):
+                result = runner.invoke(main, ["doctor"], catch_exceptions=False)
+
+        assert "soul-protocol" in result.output.lower()
+
+    def test_doctor_reports_soul_protocol_fail_when_missing(self, tmp_path):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            with patch("pocketpaw.paw.cli._check_soul_protocol", return_value=False):
+                result = runner.invoke(main, ["doctor"], catch_exceptions=False)
+
+        assert "soul-protocol" in result.output.lower()
+
+    def test_doctor_checks_for_paw_directory(self, tmp_path):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(main, ["doctor"], catch_exceptions=False)
+
+        # Output should mention .paw in some form
+        assert ".paw" in result.output
+
+    def test_doctor_paw_dir_ok_when_present(self, tmp_path):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            Path(".paw").mkdir()
+            result = runner.invoke(main, ["doctor"], catch_exceptions=False)
+
+        assert "OK" in result.output or "ok" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# paw channels
+# ---------------------------------------------------------------------------
+
+
+class TestChannelsCommand:
+    def test_channels_no_flags_exits_nonzero(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["channels"], catch_exceptions=False)
+
+        assert result.exit_code != 0
+
+    def test_channels_no_flags_shows_usage_hint(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["channels"], catch_exceptions=False)
+
+        assert "telegram" in result.output.lower() or "channel" in result.output.lower()
+
+    def test_channels_telegram_flag_parsed_past_guard(self):
+        runner = CliRunner()
+
+        # Patch get_settings and the headless runner at their import locations
+        mock_settings = MagicMock()
+
+        with (
+            patch("pocketpaw.config.get_settings", return_value=mock_settings),
+            patch("pocketpaw.headless.run_telegram_mode", new=AsyncMock()),
+        ):
+            result = runner.invoke(main, ["channels", "--telegram"])
+
+        # The flag was accepted — the "no flags" guard should NOT have fired
+        assert "Specify at least one" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# paw serve
+# ---------------------------------------------------------------------------
+
+
+class TestServeCommand:
+    def test_serve_outputs_placeholder_message(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["serve"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert "MCP" in result.output or "placeholder" in result.output.lower()
+
+    def test_serve_custom_port_accepted(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["serve", "--port", "9999"], catch_exceptions=False)
+
+        assert result.exit_code == 0

--- a/tests/test_paw_config.py
+++ b/tests/test_paw_config.py
@@ -1,0 +1,139 @@
+# Tests for paw module PawConfig.
+# Created: 2026-03-02
+# Covers: load() defaults, load() from yaml, env var overrides,
+#         default_soul_path, and paw_dir properties.
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pocketpaw.paw.config import PawConfig
+
+
+class TestPawConfigDefaults:
+    """PawConfig.load() with no paw.yaml present."""
+
+    def test_load_no_yaml_returns_defaults(self, tmp_path):
+        config = PawConfig.load(tmp_path)
+
+        assert config.project_root == tmp_path
+        assert config.soul_name == "Paw"
+        assert config.provider == "claude"
+        assert config.soul_path is None
+
+    def test_load_uses_cwd_when_no_root_given(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        config = PawConfig.load()
+
+        assert config.project_root == tmp_path
+
+    def test_default_soul_path_uses_soul_name(self, tmp_path):
+        config = PawConfig.load(tmp_path)
+        expected = tmp_path / ".paw" / "paw.soul"
+
+        assert config.default_soul_path == expected
+
+    def test_paw_dir_is_dot_paw_under_project_root(self, tmp_path):
+        config = PawConfig.load(tmp_path)
+
+        assert config.paw_dir == tmp_path / ".paw"
+
+
+class TestPawConfigFromYaml:
+    """PawConfig.load() reading a valid paw.yaml."""
+
+    def test_loads_soul_name(self, tmp_path):
+        (tmp_path / "paw.yaml").write_text("soul_name: Buddy\nprovider: openai\n")
+
+        config = PawConfig.load(tmp_path)
+
+        assert config.soul_name == "Buddy"
+
+    def test_loads_provider(self, tmp_path):
+        (tmp_path / "paw.yaml").write_text("provider: openai\n")
+
+        config = PawConfig.load(tmp_path)
+
+        assert config.provider == "openai"
+
+    def test_loads_soul_path(self, tmp_path):
+        soul_file = tmp_path / "my.soul"
+        (tmp_path / "paw.yaml").write_text(f"soul_path: {soul_file}\n")
+
+        config = PawConfig.load(tmp_path)
+
+        assert config.soul_path == soul_file
+
+    def test_name_alias_for_soul_name(self, tmp_path):
+        # Some configs use 'name' instead of 'soul_name'
+        (tmp_path / "paw.yaml").write_text("name: Rex\n")
+
+        config = PawConfig.load(tmp_path)
+
+        assert config.soul_name == "Rex"
+
+    def test_empty_yaml_gives_defaults(self, tmp_path):
+        (tmp_path / "paw.yaml").write_text("")
+
+        config = PawConfig.load(tmp_path)
+
+        assert config.soul_name == "Paw"
+        assert config.provider == "claude"
+
+
+class TestPawConfigEnvOverrides:
+    """Env vars PAW_PROVIDER and PAW_SOUL_PATH override yaml and defaults."""
+
+    def test_paw_provider_overrides_yaml(self, tmp_path, monkeypatch):
+        (tmp_path / "paw.yaml").write_text("provider: openai\n")
+        monkeypatch.setenv("PAW_PROVIDER", "ollama")
+
+        config = PawConfig.load(tmp_path)
+
+        assert config.provider == "ollama"
+
+    def test_paw_provider_overrides_default(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PAW_PROVIDER", "none")
+
+        config = PawConfig.load(tmp_path)
+
+        assert config.provider == "none"
+
+    def test_paw_soul_path_overrides_yaml(self, tmp_path, monkeypatch):
+        soul_from_yaml = tmp_path / "yaml.soul"
+        (tmp_path / "paw.yaml").write_text(f"soul_path: {soul_from_yaml}\n")
+
+        env_soul = tmp_path / "env.soul"
+        monkeypatch.setenv("PAW_SOUL_PATH", str(env_soul))
+
+        config = PawConfig.load(tmp_path)
+
+        assert config.soul_path == env_soul
+
+    def test_paw_soul_path_overrides_default(self, tmp_path, monkeypatch):
+        env_soul = tmp_path / "custom.soul"
+        monkeypatch.setenv("PAW_SOUL_PATH", str(env_soul))
+
+        config = PawConfig.load(tmp_path)
+
+        assert config.soul_path == env_soul
+
+
+class TestPawConfigProperties:
+    """Property correctness for various soul_name values."""
+
+    def test_default_soul_path_lowercases_soul_name(self, tmp_path):
+        config = PawConfig(project_root=tmp_path, soul_name="MyPet")
+
+        assert config.default_soul_path == tmp_path / ".paw" / "mypet.soul"
+
+    def test_paw_dir_does_not_create_directory(self, tmp_path):
+        config = PawConfig(project_root=tmp_path)
+
+        # The property just returns a Path — it does not mkdir
+        assert not config.paw_dir.exists()
+        assert config.paw_dir == tmp_path / ".paw"

--- a/tests/test_paw_scan.py
+++ b/tests/test_paw_scan.py
@@ -1,0 +1,228 @@
+# Tests for paw module heuristic_scan and SCAN_PROMPT.
+# Created: 2026-03-02
+# Covers: heuristic_scan() with README.md, pyproject.toml, package.json,
+#         .env.example; SCAN_PROMPT placeholder validation.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pocketpaw.paw.scan import SCAN_PROMPT, heuristic_scan
+
+
+# ---------------------------------------------------------------------------
+# Shared soul fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_soul():
+    soul = MagicMock()
+    soul.remember = AsyncMock(return_value="mem_id")
+    return soul
+
+
+# ---------------------------------------------------------------------------
+# SCAN_PROMPT
+# ---------------------------------------------------------------------------
+
+
+class TestScanPrompt:
+    def test_scan_prompt_has_project_path_placeholder(self):
+        assert "{project_path}" in SCAN_PROMPT
+
+    def test_scan_prompt_formats_without_error(self, tmp_path):
+        formatted = SCAN_PROMPT.format(project_path=tmp_path)
+
+        assert str(tmp_path) in formatted
+
+    def test_scan_prompt_mentions_readme(self):
+        assert "README" in SCAN_PROMPT
+
+    def test_scan_prompt_mentions_pyproject(self):
+        assert "pyproject.toml" in SCAN_PROMPT
+
+    def test_scan_prompt_mentions_soul_remember(self):
+        assert "soul_remember" in SCAN_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# heuristic_scan — README
+# ---------------------------------------------------------------------------
+
+
+class TestHeuristicScanReadme:
+    @pytest.mark.asyncio
+    async def test_readme_md_content_stored_in_soul(self, tmp_path, mock_soul):
+        (tmp_path / "README.md").write_text("# MyProject\nAwesome project.")
+
+        await heuristic_scan(tmp_path, mock_soul)
+
+        stored_facts = [call.args[0] for call in mock_soul.remember.call_args_list]
+        assert any("MyProject" in f for f in stored_facts)
+
+    @pytest.mark.asyncio
+    async def test_readme_rst_fallback(self, tmp_path, mock_soul):
+        (tmp_path / "README.rst").write_text("MyRstProject docs")
+
+        await heuristic_scan(tmp_path, mock_soul)
+
+        stored = [call.args[0] for call in mock_soul.remember.call_args_list]
+        assert any("MyRstProject" in f for f in stored)
+
+    @pytest.mark.asyncio
+    async def test_readme_md_takes_precedence_over_rst(self, tmp_path, mock_soul):
+        (tmp_path / "README.md").write_text("MD content")
+        (tmp_path / "README.rst").write_text("RST content")
+
+        await heuristic_scan(tmp_path, mock_soul)
+
+        stored = [call.args[0] for call in mock_soul.remember.call_args_list]
+        # Only one README *content* fact should be stored — the first match (README.md).
+        # The directory structure fact may also mention the filenames but won't have the content.
+        readme_content_facts = [f for f in stored if "Project README" in f]
+        assert len(readme_content_facts) == 1
+        assert "MD content" in readme_content_facts[0]
+        assert "RST content" not in readme_content_facts[0]
+
+    @pytest.mark.asyncio
+    async def test_no_readme_does_not_error(self, tmp_path, mock_soul):
+        # No README at all — should not raise
+        await heuristic_scan(tmp_path, mock_soul)
+
+    @pytest.mark.asyncio
+    async def test_readme_stored_with_high_importance(self, tmp_path, mock_soul):
+        (tmp_path / "README.md").write_text("# Project")
+
+        await heuristic_scan(tmp_path, mock_soul)
+
+        importance_values = [call.kwargs.get("importance") for call in mock_soul.remember.call_args_list]
+        readme_importances = [
+            imp for call, imp in zip(mock_soul.remember.call_args_list, importance_values)
+            if "README" in call.args[0]
+        ]
+        assert all(imp >= 8 for imp in readme_importances)
+
+
+# ---------------------------------------------------------------------------
+# heuristic_scan — pyproject.toml
+# ---------------------------------------------------------------------------
+
+
+class TestHeuristicScanPyproject:
+    @pytest.mark.asyncio
+    async def test_pyproject_content_stored(self, tmp_path, mock_soul):
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "coolapp"\n')
+
+        await heuristic_scan(tmp_path, mock_soul)
+
+        stored = [call.args[0] for call in mock_soul.remember.call_args_list]
+        assert any("coolapp" in f for f in stored)
+
+    @pytest.mark.asyncio
+    async def test_pyproject_label_in_stored_fact(self, tmp_path, mock_soul):
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\n')
+
+        await heuristic_scan(tmp_path, mock_soul)
+
+        stored = [call.args[0] for call in mock_soul.remember.call_args_list]
+        assert any("pyproject.toml" in f for f in stored)
+
+
+# ---------------------------------------------------------------------------
+# heuristic_scan — package.json
+# ---------------------------------------------------------------------------
+
+
+class TestHeuristicScanPackageJson:
+    @pytest.mark.asyncio
+    async def test_package_json_content_stored(self, tmp_path, mock_soul):
+        (tmp_path / "package.json").write_text('{"name": "my-app", "version": "1.0.0"}')
+
+        await heuristic_scan(tmp_path, mock_soul)
+
+        stored = [call.args[0] for call in mock_soul.remember.call_args_list]
+        assert any("my-app" in f for f in stored)
+
+    @pytest.mark.asyncio
+    async def test_package_json_label_in_stored_fact(self, tmp_path, mock_soul):
+        (tmp_path / "package.json").write_text('{"name": "x"}')
+
+        await heuristic_scan(tmp_path, mock_soul)
+
+        stored = [call.args[0] for call in mock_soul.remember.call_args_list]
+        assert any("package.json" in f for f in stored)
+
+
+# ---------------------------------------------------------------------------
+# heuristic_scan — .env.example
+# ---------------------------------------------------------------------------
+
+
+class TestHeuristicScanEnvExample:
+    @pytest.mark.asyncio
+    async def test_env_var_names_extracted(self, tmp_path, mock_soul):
+        (tmp_path / ".env.example").write_text(
+            "OPENAI_API_KEY=your-key-here\nDATABASE_URL=postgres://...\n"
+        )
+
+        await heuristic_scan(tmp_path, mock_soul)
+
+        stored = [call.args[0] for call in mock_soul.remember.call_args_list]
+        assert any("OPENAI_API_KEY" in f for f in stored)
+        assert any("DATABASE_URL" in f for f in stored)
+
+    @pytest.mark.asyncio
+    async def test_commented_env_vars_ignored(self, tmp_path, mock_soul):
+        (tmp_path / ".env.example").write_text(
+            "# This is a comment\nACTIVE_KEY=value\n"
+        )
+
+        await heuristic_scan(tmp_path, mock_soul)
+
+        stored = [call.args[0] for call in mock_soul.remember.call_args_list]
+        env_facts = [f for f in stored if "ACTIVE_KEY" in f]
+        assert len(env_facts) >= 1
+        # The commented key should not appear as a var name
+        comment_facts = [f for f in stored if "This is a comment" in f]
+        assert not comment_facts
+
+    @pytest.mark.asyncio
+    async def test_no_env_example_does_not_error(self, tmp_path, mock_soul):
+        await heuristic_scan(tmp_path, mock_soul)
+
+
+# ---------------------------------------------------------------------------
+# heuristic_scan — directory structure
+# ---------------------------------------------------------------------------
+
+
+class TestHeuristicScanDirectoryStructure:
+    @pytest.mark.asyncio
+    async def test_top_level_dirs_stored(self, tmp_path, mock_soul):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "tests").mkdir()
+
+        await heuristic_scan(tmp_path, mock_soul)
+
+        stored = [call.args[0] for call in mock_soul.remember.call_args_list]
+        dir_fact = " ".join(stored)
+        assert "src" in dir_fact
+        assert "tests" in dir_fact
+
+    @pytest.mark.asyncio
+    async def test_soul_remember_called_at_least_once(self, tmp_path, mock_soul):
+        # Even in a minimal directory, structure fact should be stored
+        await heuristic_scan(tmp_path, mock_soul)
+
+        assert mock_soul.remember.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_soul_remember_failure_does_not_raise(self, tmp_path, mock_soul):
+        (tmp_path / "README.md").write_text("Test")
+        mock_soul.remember = AsyncMock(side_effect=RuntimeError("storage error"))
+
+        # Should complete without raising even if remember fails
+        await heuristic_scan(tmp_path, mock_soul)

--- a/tests/test_paw_tools.py
+++ b/tests/test_paw_tools.py
@@ -1,0 +1,358 @@
+# Tests for paw module soul tools.
+# Created: 2026-03-02
+# Covers: SoulRememberTool, SoulRecallTool, SoulEditCoreTool, SoulStatusTool —
+#         execute() behaviour, tool names, and JSON Schema correctness.
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pocketpaw.paw.tools import (
+    SoulEditCoreTool,
+    SoulRecallTool,
+    SoulRememberTool,
+    SoulStatusTool,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared soul fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_soul():
+    soul = MagicMock()
+    soul.name = "TestSoul"
+    soul.to_system_prompt.return_value = "I am TestSoul."
+    soul.state = MagicMock(mood="curious", energy=85, social_battery=90)
+    soul.self_model = None
+    soul.remember = AsyncMock(return_value="mem_123")
+    soul.recall = AsyncMock(
+        return_value=[MagicMock(content="project uses Python", importance=8, emotion=None)]
+    )
+    soul.observe = AsyncMock()
+    soul.edit_core_memory = AsyncMock()
+    soul.save = AsyncMock()
+    soul.export = AsyncMock()
+    return soul
+
+
+# ---------------------------------------------------------------------------
+# SoulRememberTool
+# ---------------------------------------------------------------------------
+
+
+class TestSoulRememberTool:
+    def test_name(self, mock_soul):
+        tool = SoulRememberTool(mock_soul)
+        assert tool.name == "soul_remember"
+
+    def test_parameters_schema_has_content_required(self, mock_soul):
+        tool = SoulRememberTool(mock_soul)
+        params = tool.parameters
+
+        assert params["type"] == "object"
+        assert "content" in params["properties"]
+        assert "content" in params["required"]
+
+    def test_parameters_schema_importance_is_integer(self, mock_soul):
+        tool = SoulRememberTool(mock_soul)
+        params = tool.parameters
+
+        assert params["properties"]["importance"]["type"] == "integer"
+        assert params["properties"]["importance"]["minimum"] == 1
+        assert params["properties"]["importance"]["maximum"] == 10
+
+    @pytest.mark.asyncio
+    async def test_execute_stores_memory(self, mock_soul):
+        tool = SoulRememberTool(mock_soul)
+
+        result = await tool.execute(content="The project uses FastAPI", importance=7)
+
+        mock_soul.remember.assert_awaited_once_with(
+            "The project uses FastAPI", importance=7
+        )
+        assert "Remembered" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_default_importance_is_5(self, mock_soul):
+        tool = SoulRememberTool(mock_soul)
+
+        await tool.execute(content="Some fact")
+
+        mock_soul.remember.assert_awaited_once_with("Some fact", importance=5)
+
+    @pytest.mark.asyncio
+    async def test_execute_truncates_long_content_in_result(self, mock_soul):
+        tool = SoulRememberTool(mock_soul)
+        long_content = "x" * 200
+
+        result = await tool.execute(content=long_content)
+
+        assert "..." in result
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_error_on_soul_failure(self, mock_soul):
+        mock_soul.remember = AsyncMock(side_effect=RuntimeError("disk full"))
+        tool = SoulRememberTool(mock_soul)
+
+        result = await tool.execute(content="Fact")
+
+        assert "Error:" in result
+        assert "disk full" in result
+
+
+# ---------------------------------------------------------------------------
+# SoulRecallTool
+# ---------------------------------------------------------------------------
+
+
+class TestSoulRecallTool:
+    def test_name(self, mock_soul):
+        tool = SoulRecallTool(mock_soul)
+        assert tool.name == "soul_recall"
+
+    def test_parameters_schema_has_query_required(self, mock_soul):
+        tool = SoulRecallTool(mock_soul)
+        params = tool.parameters
+
+        assert "query" in params["properties"]
+        assert "query" in params["required"]
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_formatted_results(self, mock_soul):
+        tool = SoulRecallTool(mock_soul)
+
+        result = await tool.execute(query="Python")
+
+        assert "project uses Python" in result
+        mock_soul.recall.assert_awaited_once_with("Python", limit=5)
+
+    @pytest.mark.asyncio
+    async def test_execute_no_memories_returns_not_found(self, mock_soul):
+        mock_soul.recall = AsyncMock(return_value=[])
+        tool = SoulRecallTool(mock_soul)
+
+        result = await tool.execute(query="nonexistent topic")
+
+        assert "No memories found" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_respects_limit_param(self, mock_soul):
+        tool = SoulRecallTool(mock_soul)
+
+        await tool.execute(query="test", limit=3)
+
+        mock_soul.recall.assert_awaited_once_with("test", limit=3)
+
+    @pytest.mark.asyncio
+    async def test_execute_shows_memory_importance(self, mock_soul):
+        tool = SoulRecallTool(mock_soul)
+
+        result = await tool.execute(query="Python")
+
+        # importance=8 should appear in the formatted output
+        assert "8" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_includes_emotion_when_present(self, mock_soul):
+        mem = MagicMock(content="exciting discovery", importance=7, emotion="joy")
+        mock_soul.recall = AsyncMock(return_value=[mem])
+        tool = SoulRecallTool(mock_soul)
+
+        result = await tool.execute(query="discovery")
+
+        assert "joy" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_error_on_soul_failure(self, mock_soul):
+        mock_soul.recall = AsyncMock(side_effect=RuntimeError("connection lost"))
+        tool = SoulRecallTool(mock_soul)
+
+        result = await tool.execute(query="test")
+
+        assert "Error:" in result
+
+
+# ---------------------------------------------------------------------------
+# SoulEditCoreTool
+# ---------------------------------------------------------------------------
+
+
+class TestSoulEditCoreTool:
+    def test_name(self, mock_soul):
+        tool = SoulEditCoreTool(mock_soul)
+        assert tool.name == "soul_edit_core"
+
+    def test_parameters_schema_has_persona_and_human(self, mock_soul):
+        tool = SoulEditCoreTool(mock_soul)
+        params = tool.parameters
+
+        assert "persona" in params["properties"]
+        assert "human" in params["properties"]
+        # Both are optional — required list should be empty
+        assert params["required"] == []
+
+    @pytest.mark.asyncio
+    async def test_execute_with_persona(self, mock_soul):
+        tool = SoulEditCoreTool(mock_soul)
+
+        result = await tool.execute(persona="I am a code assistant.")
+
+        mock_soul.edit_core_memory.assert_awaited_once_with(persona="I am a code assistant.")
+        assert "persona" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_with_human(self, mock_soul):
+        tool = SoulEditCoreTool(mock_soul)
+
+        result = await tool.execute(human="Alice, a senior engineer.")
+
+        mock_soul.edit_core_memory.assert_awaited_once_with(human="Alice, a senior engineer.")
+        assert "human" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_with_both(self, mock_soul):
+        tool = SoulEditCoreTool(mock_soul)
+
+        result = await tool.execute(
+            persona="Code assistant.", human="Bob, a data scientist."
+        )
+
+        mock_soul.edit_core_memory.assert_awaited_once_with(
+            persona="Code assistant.", human="Bob, a data scientist."
+        )
+        assert "persona" in result or "human" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_with_neither_returns_error(self, mock_soul):
+        tool = SoulEditCoreTool(mock_soul)
+
+        result = await tool.execute()
+
+        assert "Error:" in result
+        mock_soul.edit_core_memory.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_error_on_soul_failure(self, mock_soul):
+        mock_soul.edit_core_memory = AsyncMock(side_effect=RuntimeError("bad state"))
+        tool = SoulEditCoreTool(mock_soul)
+
+        result = await tool.execute(persona="New persona")
+
+        assert "Error:" in result
+
+
+# ---------------------------------------------------------------------------
+# SoulStatusTool
+# ---------------------------------------------------------------------------
+
+
+class TestSoulStatusTool:
+    def test_name(self, mock_soul):
+        tool = SoulStatusTool(mock_soul)
+        assert tool.name == "soul_status"
+
+    def test_parameters_schema_empty(self, mock_soul):
+        tool = SoulStatusTool(mock_soul)
+        params = tool.parameters
+
+        assert params["type"] == "object"
+        assert params["properties"] == {}
+        assert params["required"] == []
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_json_with_mood_energy(self, mock_soul):
+        tool = SoulStatusTool(mock_soul)
+
+        result = await tool.execute()
+
+        data = json.loads(result)
+        assert data["mood"] == "curious"
+        assert data["energy"] == 85
+        assert data["social_battery"] == 90
+
+    @pytest.mark.asyncio
+    async def test_execute_includes_domains_when_self_model_present(self, mock_soul):
+        img = MagicMock(domain="Python", confidence=0.9)
+        self_model = MagicMock()
+        self_model.get_active_self_images.return_value = [img]
+        mock_soul.self_model = self_model
+        tool = SoulStatusTool(mock_soul)
+
+        result = await tool.execute()
+
+        data = json.loads(result)
+        assert "domains" in data
+        assert data["domains"][0]["domain"] == "Python"
+
+    @pytest.mark.asyncio
+    async def test_execute_no_state_attrs_returns_active_message(self):
+        soul = MagicMock()
+        soul.state = MagicMock(spec=[])  # no mood/energy/social_battery attrs
+        soul.self_model = None
+        tool = SoulStatusTool(soul)
+
+        result = await tool.execute()
+
+        assert "active" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_error_on_soul_failure(self):
+        soul = MagicMock()
+        type(soul).state = property(fget=lambda s: (_ for _ in ()).throw(RuntimeError("broken")))
+        tool = SoulStatusTool(soul)
+
+        result = await tool.execute()
+
+        assert "Error:" in result
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions via BaseTool.definition
+# ---------------------------------------------------------------------------
+
+
+class TestToolDefinitions:
+    """Verify that tool.definition exports correct JSON Schema via BaseTool."""
+
+    def test_remember_tool_definition_name(self, mock_soul):
+        tool = SoulRememberTool(mock_soul)
+        assert tool.definition.name == "soul_remember"
+
+    def test_recall_tool_definition_name(self, mock_soul):
+        tool = SoulRecallTool(mock_soul)
+        assert tool.definition.name == "soul_recall"
+
+    def test_edit_core_tool_definition_name(self, mock_soul):
+        tool = SoulEditCoreTool(mock_soul)
+        assert tool.definition.name == "soul_edit_core"
+
+    def test_status_tool_definition_name(self, mock_soul):
+        tool = SoulStatusTool(mock_soul)
+        assert tool.definition.name == "soul_status"
+
+    def test_definition_has_description(self, mock_soul):
+        for cls in (SoulRememberTool, SoulRecallTool, SoulEditCoreTool, SoulStatusTool):
+            tool = cls(mock_soul)
+            assert len(tool.definition.description) > 10
+
+    def test_anthropic_schema_format(self, mock_soul):
+        tool = SoulRememberTool(mock_soul)
+        schema = tool.definition.to_anthropic_schema()
+
+        assert "name" in schema
+        assert "description" in schema
+        assert "input_schema" in schema
+
+    def test_openai_schema_format(self, mock_soul):
+        tool = SoulRememberTool(mock_soul)
+        schema = tool.definition.to_openai_schema()
+
+        assert schema["type"] == "function"
+        assert "function" in schema
+        assert schema["function"]["name"] == "soul_remember"


### PR DESCRIPTION
## Summary

Adds the `paw` module — a lightweight CLI entry point for PocketPaw with soul-protocol integration. This is Phase 1 of the paw roadmap: an AI agent that lives in your project, learns from it, and talks everywhere.

**What's new:**
- `src/pocketpaw/paw/` — 7 new files, ~1150 lines of implementation
- `paw` CLI entry point via Click (replaces argparse for the paw path)
- Soul-protocol integration: bridge, tools, config, scanning
- 106 new tests, all passing

## New Files

| File | Lines | Purpose |
|------|-------|---------|
| `paw/__init__.py` | 7 | Module exports |
| `paw/config.py` | 79 | PawConfig — reads `paw.yaml`, env vars |
| `paw/soul_bridge.py` | 79 | SoulBootstrapProvider + SoulBridge |
| `paw/tools.py` | 224 | 4 soul tools (remember, recall, edit_core, status) |
| `paw/scan.py` | 125 | Heuristic project scanner + agent scan prompt |
| `paw/agent.py` | 98 | get_paw_agent() — wires everything together |
| `paw/cli.py` | 540 | Click CLI: init, ask, chat, serve, status, doctor, os, channels |

## CLI Commands

```bash
paw init              # scan project, birth soul, seed knowledge
paw ask "question"    # one-shot query
paw chat              # interactive REPL
paw serve             # MCP server (placeholder for v2)
paw status            # soul state + project info
paw doctor            # health checks
paw os                # launch full PocketPaw dashboard
paw channels          # headless channel adapters
```

## Architecture

```
soul-protocol (Soul API)
    ↓
SoulBridge / SoulBootstrapProvider (paw/soul_bridge.py)
    ↓
PocketPaw Agent Loop + Router (existing)
    ↓
Click CLI (paw/cli.py) ← new entry point
```

- **SoulBootstrapProvider** implements `BootstrapProviderProtocol` — maps soul's system prompt into PocketPaw's `BootstrapContext`
- **SoulBridge** provides `observe()` / `recall()` hooks for the agent loop
- **Soul tools** extend `BaseTool` — registered in `ToolRegistry` like any other PocketPaw tool
- **PawConfig** reads `paw.yaml` from project root with env var overrides

## Packaging Changes (pyproject.toml)

- Added `click>=8.0` to core dependencies
- Added `soul` optional extra: `pip install pocketpaw[soul]`
- Added `paw` composite extra: `pip install pocketpaw[paw]`
- Added `paw` script entry point: `paw = "pocketpaw.paw.cli:main"`

## Test plan

- [x] 106 new tests covering all paw module components
- [x] Config loading (defaults, yaml, env vars)
- [x] All 4 soul tools (execute, schemas, error handling)
- [x] Soul bridge (observe, recall, error resilience)
- [x] Heuristic scanner (README, pyproject, package.json, .env)
- [x] CLI commands (help, init, doctor, channels, serve, version)
- [x] Full existing test suite still passes (2521 passed, 0 regressions)