### PR TITLE
fix: remove soul-protocol from PyPI extras (v0.4.6 hotfix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
-# Updated: 2026-03-03 — Bump version to 0.4.6, remove soul-protocol from PyPI extras (not on PyPI yet).
+# Updated: 2026-03-03 — Bump version to 0.4.5.1, remove soul-protocol from PyPI extras (not on PyPI yet).
 [project]
 name = "pocketpaw"
-version = "0.4.6"
+version = "0.4.5.1"
 description = "The AI agent that runs on your laptop, not a datacenter. OpenClaw alternative with one-command install."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## What broke

`pip install pocketpaw[paw]` and `pip install pocketpaw[soul]` hard-fail for all users with:

```
ERROR: Could not find a version that satisfies the requirement soul-protocol>=0.2.0
ERROR: No matching distribution found for soul-protocol>=0.2.0
```

This shipped in v0.4.5 when the paw module was included. soul-protocol isn't on PyPI yet so pip can't resolve the dependency.

Base `pip install pocketpaw` was not affected.

## Fix

Removed `soul-protocol>=0.2.0` from the `[soul]` optional extra. Left a comment pointing to the manual git install for users who want soul features.

The paw CLI already handles this gracefully — `_check_soul_protocol()` in cli.py catches the missing import at runtime and shows a clear error, so no code changes needed beyond pyproject.toml.

## Testing

Reproduced the error locally with a clean uninstall, confirmed fix resolves it.

## After merge

Create GitHub release `v0.4.6` to trigger the publish workflow → PyPI update.