### PR TITLE
[FI]docs: add python -m fallback run instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ pocketpaw
 ```
 > 💡 If the `pocketpaw` command is not recognized, you can run:
 >
- ```bash
- python -m pocketpaw
- ```
+> ```bash
+> python -m pocketpaw
+> ```
 >
 > This works even if your PATH is not configured.
 **Or use the automated install script:**


### PR DESCRIPTION
What does this PR do?
Adds a fallback instruction for running PocketPaw using `python -m pocketpaw` in case the `pocketpaw` command is not recognized.

Changes Made
Updated README.md
Added fallback command instruction for better usability

### Linked Issue

Fixes #0

### Testing

Tested locally:

```bash
python -m pocketpaw
```

The command runs successfully even if the `pocketpaw` command is not recognized.
