### PR TITLE
[FI] fix: add consistent error handling for Get-Command in Windows installer

### DIFF
--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -176,7 +176,7 @@ if (-not $Python) {
 }
 
 $pyVer = Get-PythonFullVersion $Python
-$pyPath = if ($Python -eq "py -3") { (Get-Command py).Source } else { (Get-Command $Python -ErrorAction SilentlyContinue).Source }
+$pyPath = if ($Python -eq "py -3") { (Get-Command py -ErrorAction SilentlyContinue).Source } else { (Get-Command $Python -ErrorAction SilentlyContinue).Source }
 Write-Step "Python:  $pyVer ($pyPath)"
 
 # ── Ensure uv is available ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes inconsistent error handling in the Windows PowerShell installer that could cause installation failures in edge cases.

Closes #425

## Changes

- Added `-ErrorAction SilentlyContinue` to `Get-Command py` call on line 179 of `installer/install.ps1`
- Ensures consistent error handling in both branches of the conditional
- Prevents terminating errors when py command lookup fails

## Technical Details

**Problem:** Line 179 had asymmetric error handling:
```powershell
# Before (buggy):
$pyPath = if ($Python -eq "py -3") { 
    (Get-Command py).Source                                      # ❌ Missing error handling
} else { 
    (Get-Command $Python -ErrorAction SilentlyContinue).Source  # ✅ Correct
}

Solution:
# After (fixed):
$pyPath = if ($Python -eq "py -3") { 
    (Get-Command py -ErrorAction SilentlyContinue).Source       # ✅ Now consistent
} else { 
    (Get-Command $Python -ErrorAction SilentlyContinue).Source  # ✅ Already correct
}