### PR TITLE
[FI] Improve Windows installation troubleshooting for PATH issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,25 @@ If you installed PocketPaw using:
 ```powershell
 pip install pocketpaw
 ```
+**Common Windows Issue**
 
-and the `pocketpaw` command is not recognized:
+After installing PocketPaw using `pip install pocketpaw`, some Windows users may see:
 
-```text
-'pocketpaw' is not recognized as an internal or external command
 ```
+'pocketpaw' is not recognized as the name of a cmdlet
+```
+
+This usually happens because the Python **Scripts directory is not included in the system PATH**.
+
+You can still run PocketPaw using:
+
+```powershell
+python -m pocketpaw
+```
+
+If this works, it confirms that the issue is related to the PATH configuration.
+
+
 
 This usually means your Python Scripts directory is not added to PATH.
 


### PR DESCRIPTION
<!-- Updated: 2026-02-26 — Added branch/issue warnings, tightened checklist. -->

> **Before opening this PR:**
> - Does it target `dev`? PRs against `main` are auto-closed.
> - Is there a linked issue? PRs without one will be closed.
> - Did you read [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md)?

## What does this PR do?

Improves the Windows CLI troubleshooting section in the README.

Some Windows users encounter the error `'pocketpaw' is not recognized as the name of a cmdlet` after installing with `pip install pocketpaw` because the Python Scripts directory is not in PATH.

This PR adds clearer guidance explaining the cause and suggests using `python -m pocketpaw` as a temporary workaround.

## Related Issue

Fixes #434 

<!-- List the specific files changed and what was modified in each. -->

## Changes Made

- `README.md`: Improved the Windows CLI troubleshooting section
- Added explanation for the PATH issue after installing with `pip install pocketpaw`
- Added guidance to run `python -m pocketpaw` as a workaround

## How to Test

1. Install PocketPaw using:
   pip install pocketpaw

2. Open PowerShell on Windows.

3. Run:
   pocketpaw

4. If the Python Scripts directory is not in PATH, the command may not be recognized.

5. Run:
   python -m pocketpaw

6. Verify that the PocketPaw dashboard starts at http://localhost:8888.

## Evidence of Testing

<img width="1453" height="672" alt="image" src="https://github.com/user-attachments/assets/176c688e-e893-4906-b4f6-f6fa5674a846" />


## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes.
- [ ] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff
