### PR TITLE
fix: treat missing API key as DEGRADED with onboarding guidance

### DIFF
--- a/src/pocketpaw/api/v1/schemas/health.py
+++ b/src/pocketpaw/api/v1/schemas/health.py
@@ -10,6 +10,7 @@ class HealthSummary(BaseModel):
     """Health engine summary."""
 
     status: str = "unknown"
+    message: str | None = None
     check_count: int = 0
     issues: list[dict] = []
     error: str | None = None

--- a/src/pocketpaw/frontend/js/features/health.js
+++ b/src/pocketpaw/frontend/js/features/health.js
@@ -24,6 +24,7 @@ window.PocketPaw.Health = {
     getState() {
         return {
             healthStatus: 'unknown',   // 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
+            healthMessage: null,       // onboarding message when degraded (e.g. API key missing)
             healthIssues: [],           // HealthCheckResult[] (non-ok only)
             healthErrors: [],           // ErrorStore entries
             showHealthModal: false,
@@ -71,6 +72,7 @@ window.PocketPaw.Health = {
                     })
                     .then(data => {
                         this.healthStatus = data.status || 'unknown';
+                        this.healthMessage = data.message || null;
                         this.healthIssues = data.issues || [];
                         this.healthLastCheck = data.last_check;
                         this.healthLoading = false;
@@ -133,6 +135,7 @@ window.PocketPaw.Health = {
                     })
                     .then(data => {
                         this.healthStatus = data.status || 'unknown';
+                        this.healthMessage = data.message || null;
                         this.healthIssues = data.issues || [];
                         this.healthLastCheck = data.last_check;
                         this.healthLoading = false;
@@ -198,6 +201,7 @@ window.PocketPaw.Health = {
             handleHealthUpdate(data) {
                 if (data && data.data) {
                     this.healthStatus = data.data.status || 'unknown';
+                    this.healthMessage = data.data.message || null;
                     this.healthIssues = data.data.issues || [];
                     this.healthLastCheck = data.data.last_check;
 

--- a/src/pocketpaw/frontend/templates/components/modals/health.html
+++ b/src/pocketpaw/frontend/templates/components/modals/health.html
@@ -70,6 +70,13 @@
 
     <!-- Content -->
     <div class="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+      <!-- Onboarding message when degraded (e.g. API key missing) -->
+      <div
+          x-show="healthStatus === 'degraded' && (healthMessage || (healthIssues && healthIssues.some(i => i.check_id === 'api_key_primary')))"
+          class="rounded-lg px-4 py-3 bg-amber-500/10 border border-amber-500/30 text-amber-200/90 text-sm"
+      >
+        <span x-text="healthMessage || 'System is running. Add your API key to enable AI features.'"></span>
+      </div>
       <!-- Last check timestamp -->
       <div x-show="healthLastCheck" class="text-[11px] text-white/30">
         Last checked: <span x-text="healthLastCheck ? healthLastCheck.substring(0, 19).replace('T', ' ') + ' UTC' : 'never'"></span>

--- a/src/pocketpaw/frontend/templates/components/sidebar.html
+++ b/src/pocketpaw/frontend/templates/components/sidebar.html
@@ -40,7 +40,7 @@
             'bg-white/20': !healthStatus || healthStatus === 'unknown'
         }"
         @click="openHealthPanel(); sidebarOpen = false"
-        :title="'System: ' + (healthStatus || 'unknown')"
+        :title="healthStatus === 'degraded' && healthMessage ? healthMessage : ('System: ' + (healthStatus || 'unknown'))"
     ></button>
     <button class="ml-auto md:hidden" @click="sidebarOpen = false">
         <i data-lucide="x" class="w-5 h-5 text-white/50"></i>

--- a/src/pocketpaw/health/checks.py
+++ b/src/pocketpaw/health/checks.py
@@ -197,7 +197,7 @@ def check_api_key_primary() -> HealthCheckResult:
             check_id="api_key_primary",
             name="Primary API Key",
             category="config",
-            status="critical",
+            status="warning",
             message=(
                 "No Anthropic API key found — required for Claude SDK backend. "
                 "OAuth tokens from Free/Pro/Max plans are not permitted for third-party use."
@@ -232,7 +232,7 @@ def check_api_key_primary() -> HealthCheckResult:
             check_id="api_key_primary",
             name="Primary API Key",
             category="config",
-            status="critical",
+            status="warning",
             message="No Google API key found for Google ADK backend",
             fix_hint=(
                 "Set your Google API key in Settings > API Keys, or set GOOGLE_API_KEY env var."
@@ -256,7 +256,7 @@ def check_api_key_primary() -> HealthCheckResult:
             check_id="api_key_primary",
             name="Primary API Key",
             category="config",
-            status="critical",
+            status="warning",
             message="No OpenAI API key found for OpenAI Agents backend",
             fix_hint=(
                 "Set your OpenAI API key in Settings > API Keys, or set OPENAI_API_KEY env var."
@@ -604,7 +604,7 @@ async def check_llm_reachable() -> HealthCheckResult:
                     check_id="llm_reachable",
                     name="LLM Reachable",
                     category="connectivity",
-                    status="critical",
+                    status="warning",
                     message="No API key to test connectivity",
                     fix_hint="Set your Anthropic API key first.",
                 )
@@ -669,7 +669,7 @@ async def check_llm_reachable() -> HealthCheckResult:
                     check_id="llm_reachable",
                     name="LLM Reachable",
                     category="connectivity",
-                    status="critical",
+                    status="warning",
                     message="No Google API key to test connectivity",
                     fix_hint="Set your Google API key first.",
                 )
@@ -728,7 +728,7 @@ async def check_llm_reachable() -> HealthCheckResult:
                     check_id="llm_reachable",
                     name="LLM Reachable",
                     category="connectivity",
-                    status="critical",
+                    status="warning",
                     message="No OpenAI API key to test connectivity",
                     fix_hint="Set your OpenAI API key first.",
                 )

--- a/src/pocketpaw/health/engine.py
+++ b/src/pocketpaw/health/engine.py
@@ -115,8 +115,17 @@ class HealthEngine:
     def summary(self) -> dict:
         """Compact dict for API/WebSocket."""
         issues = [r.to_dict() for r in self._results if r.status != "ok"]
+        status = self.overall_status
+        message = None
+        if status == "degraded":
+            api_key_issues = [
+                r for r in self._results if r.check_id == "api_key_primary" and r.status != "ok"
+            ]
+            if api_key_issues:
+                message = "System running, but AI features disabled. Please add API key."
         return {
-            "status": self.overall_status,
+            "status": status,
+            "message": message,
             "check_count": len(self._results),
             "issues": issues,
             "last_check": self._last_check,

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -319,7 +319,7 @@ class TestCheckApiKeyPrimary:
             patch.dict("os.environ", {}, clear=True),
         ):
             r = check_api_key_primary()
-            assert r.status == "critical"
+            assert r.status == "warning"
 
     def test_claude_sdk_env_var(self):
         settings = self._mock_settings(anthropic_api_key="")
@@ -359,7 +359,7 @@ class TestCheckApiKeyPrimary:
             patch.dict("os.environ", {}, clear=True),
         ):
             r = check_api_key_primary()
-            assert r.status == "critical"
+            assert r.status == "warning"
 
     def test_openai_agents_with_key(self):
         settings = self._mock_settings(agent_backend="openai_agents", openai_api_key="sk-test")
@@ -545,7 +545,7 @@ class TestCheckLlmReachable:
             patch.dict("os.environ", {}, clear=True),
         ):
             r = await check_llm_reachable()
-            assert r.status == "critical"
+            assert r.status == "warning"
             assert "No API key" in r.message
 
     @pytest.mark.asyncio
@@ -610,7 +610,7 @@ class TestCheckVersionUpdate:
 
 class TestCheckRegistries:
     def test_startup_checks_count(self):
-        assert len(STARTUP_CHECKS) == 11  # 10 original + version_update
+        assert len(STARTUP_CHECKS) == 12  # 10 original + version_update + gws_binary
 
     def test_connectivity_checks_count(self):
         assert len(CONNECTIVITY_CHECKS) == 1
@@ -655,10 +655,37 @@ class TestHealthEngine:
             patch("importlib.util.find_spec", return_value=MagicMock()),
         ):
             results = engine.run_startup_checks()
-            assert len(results) == 11  # 10 original + version_update
+            assert len(results) == 12  # 10 original + version_update + gws_binary
             # All should be ok with valid config + key
             statuses = {r.status for r in results}
             assert "critical" not in statuses
+
+    def test_missing_api_key_degraded_with_onboarding_message(self, engine, tmp_path):
+        """When API key is missing, health is DEGRADED and summary contains onboarding guidance."""
+        config_path = tmp_path / "config.json"
+        config_path.write_text('{"agent_backend": "claude_agent_sdk"}')
+        config_path.chmod(0o600)
+
+        settings = MagicMock()
+        settings.agent_backend = "claude_agent_sdk"
+        settings.anthropic_api_key = ""
+        settings.openai_api_key = ""
+        settings.google_api_key = ""
+        settings.llm_provider = "auto"
+
+        with (
+            patch(_P_CONFIG_PATH, return_value=config_path),
+            patch(_P_CONFIG_DIR, return_value=tmp_path),
+            patch(_P_SETTINGS, return_value=settings),
+            patch("importlib.util.find_spec", return_value=MagicMock()),
+        ):
+            engine.run_startup_checks()
+
+        assert engine.overall_status == "degraded"
+        s = engine.summary
+        assert s["status"] == "degraded"
+        assert s["message"] is not None
+        assert "add API key" in s["message"].lower() or "api key" in s["message"].lower()
 
     def test_overall_status_unhealthy(self, engine):
         engine._results = [
@@ -701,6 +728,26 @@ class TestHealthEngine:
         s = engine.summary
         assert s["status"] == "healthy"
         assert s["issues"] == []
+
+    def test_summary_degraded_api_key_message(self, engine):
+        """When degraded due to api_key_primary, summary includes onboarding message."""
+        engine._results = [
+            HealthCheckResult("config_exists", "Config", "config", "ok", "ok", ""),
+            HealthCheckResult(
+                "api_key_primary",
+                "Primary API Key",
+                "config",
+                "warning",
+                "No Anthropic API key found",
+                "Add key in Settings",
+            ),
+        ]
+        engine._last_check = "2026-01-01T00:00:00"
+        s = engine.summary
+        assert s["status"] == "degraded"
+        assert s["message"] == "System running, but AI features disabled. Please add API key."
+        assert len(s["issues"]) == 1
+        assert s["issues"][0]["check_id"] == "api_key_primary"
 
     def test_health_prompt_section_healthy(self, engine):
         engine._results = [


### PR DESCRIPTION
## Summary
Replaces #397 with a clean rebase on current `dev`. The original PR by @yuktaa123 had accumulated 22 commits with merge conflicts across 126 files (mostly unrelated formatting/lint changes from other PRs). This PR preserves the core fix in a single clean commit.

**What changed:**
- `check_api_key_primary` returns `warning` instead of `critical` when API key is missing
- `check_llm_reachable` returns `warning` (not `critical`) when no API key available
- `HealthEngine.summary` includes an onboarding `message` field when degraded due to missing key
- `HealthSummary` Pydantic schema gains optional `message` field
- Dashboard health modal shows amber onboarding banner when degraded
- Sidebar health dot tooltip shows the onboarding message
- Tests updated to expect `warning` + 2 new tests verify onboarding message

**Result:** System shows **DEGRADED** instead of **UNHEALTHY** when API key is missing. Users see clear guidance to add their key.

Based on work by @yuktaa123 in #397.
Fixes #359

## Test plan
- [x] `test_claude_sdk_no_key` — expects `warning` (was `critical`)
- [x] `test_google_adk_no_key` — expects `warning` (was `critical`)
- [x] `test_no_api_key` (llm_reachable) — expects `warning` (was `critical`)
- [x] `test_missing_api_key_degraded_with_onboarding_message` — full engine integration
- [x] `test_summary_degraded_api_key_message` — verifies message text
- [x] All 99 health tests pass