### PR TITLE
fix(ci): remove duplicate const declaration in PR quality gate

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -1,4 +1,5 @@
 # PR quality gate — enforces contribution standards automatically.
+# Updated: 2026-03-05 — Fix duplicate `const base` declaration that crashed the gate on every PR.
 # Updated: 2026-02-26 — Added branch enforcement, cosmetic PR detection, size labels, reopen guard.
 name: PR Quality Gate
 
@@ -32,7 +33,6 @@ jobs:
             const deletions = pr.deletions || 0;
             const changedFiles = pr.changed_files || 0;
 
-            const base = pr.base.ref;
             const issues = [];
             const warnings = [];
             const MARKER = '<!-- pr-quality-gate -->';


### PR DESCRIPTION
## Summary

One-line fix — `const base` was declared twice in the quality gate script, which threw a `SyntaxError` in the V8 runtime and silently killed the entire job on every PR.

This meant:
- The branch enforcement check (blocking non-maintainer PRs to `main`) never fired
- The `needs-work` label was incorrectly applied to PRs (including #443)
- The quality gate comment was never posted (404 on PATCH because the comment didn't exist)

## What changed

Removed the duplicate `const base = pr.base.ref;` on line 35 of `.github/workflows/pr-quality-gate.yml`. The first declaration on line 30 is sufficient.

## Test plan

- [ ] Open a test PR and verify the quality gate job passes (no SyntaxError)
- [ ] Verify the quality gate comment is posted correctly

Blocking #443 (release PR) — needs to land on dev first so the release merge includes the fix.