### PR TITLE
chore: bump version to 0.4.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Updated: 2026-03-03 — Bump version to 0.4.5.1, remove soul-protocol from PyPI extras (not on PyPI yet).
 [project]
 name = "pocketpaw"
-version = "0.4.5.1"
+version = "0.4.6"
 description = "The AI agent that runs on your laptop, not a datacenter. OpenClaw alternative with one-command install."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump for the v0.4.6 release.