### PR TITLE
[FI] fix(docs): Move Windows uv PATH warning before install command to prevent CommandNotFoundException on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ See the [full configuration reference](https://pocketpaw.xyz/getting-started/con
 
 **Install uv:**
 
+> [!WARNING]
+> **Windows users:** You must **open a new terminal window** after running the install script below before `uv` will be recognized. The installer updates your PATH, but this change does not apply to your current terminal session — running `uv` immediately after install will give a `CommandNotFoundException` error.
 ```bash
 # macOS/Linux
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -306,17 +308,12 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 pip install uv
 ```
 
-> **Windows Note:** After installing `uv` via the PowerShell script, you may need to **restart your terminal** for the `uv` command to be recognized. The installer adds `uv` to `C:\Users\<your-username>\.local\bin` and updates your PATH, but the current session won't reflect this change until you open a new terminal window.
->
-> If you want to use `uv` immediately without restarting, run:
+> [!TIP]
+> **Windows:** To use `uv` immediately without opening a new terminal, run:
 > ```powershell
 > $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
 > ```
->
-> Verify the installation:
-> ```powershell
-> uv --version
-> ```
+> Then verify the installation: `uv --version`
 
 **Setup and run:**
 


### PR DESCRIPTION
## What does this PR fix?

Fixes #478

## Problem

In the **Development > Install uv** section of the README, the Windows warning about restarting the terminal appears **after** the PowerShell install command block.

Users follow the README top-to-bottom:
1. Run the PowerShell install script ✅
2. Immediately run `uv --version` or `uv run pocketpaw` in the **same terminal** ❌
3. Hit this error:
```
uv : The term 'uv' is not recognized as the name of a cmdlet, function,
script file, or operable program.
+ CategoryInfo : ObjectNotFound: (uv:String) [], CommandNotFoundException
+ FullyQualifiedErrorId : CommandNotFoundException
```

The fix is simply opening a new terminal — but the warning explaining this comes too late.

## Fix

- Moved the warning **above** the install command as a `[!WARNING]` admonition so users see it before running anything
- Replaced the plain `> Note` below with a `[!TIP]` admonition for the immediate PATH workaround

## Screenshots

<!-- Attach your two screenshots here — drag and drop them in -->

**Before fix — error in same terminal after install:**
[attach Screenshot_2026-03-05_123707.png here]

**After fix — works in new terminal:**
[attach Screenshot_2026-03-05_123736.png here]

## Testing
- [x] README renders correctly on GitHub
- [x] Warning now visible BEFORE any command is run
- [x] No code changes — documentation only
- [x] Manually reproduced the bug on Windows 11 PowerShell
<img width="347" height="44" alt="Screenshot 2026-03-05 123736" src="https://github.com/user-attachments/assets/8fae8796-7bd7-4614-97fa-4d50270384c1" />
<img width="1095" height="155" alt="Screenshot 2026-03-05 123707" src="https://github.com/user-attachments/assets/bd89371c-7b71-4eb2-880d-6676529c8aad" />
