### PR TITLE
fix(ci): use pull_request_target so label/comment writes work from fo…

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -1,9 +1,10 @@
 # PR quality gate — enforces contribution standards and security checks.
 # Updated: 2026-03-05 — Fixed duplicate const bug, added security scan, dependency alerts, sensitive file alerts, PR size gate.
+# Updated: 2026-03-06 — Switch to pull_request_target so GITHUB_TOKEN has write access for fork PRs (label/comment writes).
 name: PR Quality Gate
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
@@ -281,6 +282,7 @@ jobs:
       - name: Checkout PR code
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Get changed files


### PR DESCRIPTION
…rk PRs

The pr-quality-gate workflow used the pull_request trigger, which gives the GITHUB_TOKEN read-only access to the base repository when the PR comes from a fork. This caused a 403 HttpError on any write operation (addLabels, createComment, pulls.update) for all fork-originated PRs.

Switch to pull_request_target, which runs the workflow from the base repo's code and grants the GITHUB_TOKEN full write access regardless of whether the PR is from a fork or not.

For the security-scan job that checks out code, explicitly pin the checkout ref to github.event.pull_request.head.sha so the scan targets the actual PR changes (not the base branch). This is safe because the scan only runs grep over files, it never executes PR code.

Fixes the 403 Resource not accessible by integration error reported by fork contributors when the quality gate attempts to add labels.

