### PR TITLE
perf: run update check in daemon thread to avoid blocking startup

### DIFF
--- a/src/pocketpaw/__main__.py
+++ b/src/pocketpaw/__main__.py
@@ -189,13 +189,22 @@ Examples:
         except Exception:
             pass  # Health engine failure never blocks startup
 
-    # Check for updates (cached daily, silent on error)
-    from pocketpaw.config import get_config_dir
-    from pocketpaw.update_check import check_for_updates, print_styled_update_notice
+    # Check for updates in background thread to avoid blocking startup
+    # (cold start or stale cache triggers a sync HTTP request to PyPI)
+    import threading
 
-    update_info = check_for_updates(get_version("pocketpaw"), get_config_dir())
-    if update_info and update_info.get("update_available"):
-        print_styled_update_notice(update_info)
+    def _bg_update_check() -> None:
+        try:
+            from pocketpaw.config import get_config_dir
+            from pocketpaw.update_check import check_for_updates, print_styled_update_notice
+
+            update_info = check_for_updates(get_version("pocketpaw"), get_config_dir())
+            if update_info and update_info.get("update_available"):
+                print_styled_update_notice(update_info)
+        except Exception:
+            pass  # Update check failure never interrupts startup
+
+    threading.Thread(target=_bg_update_check, daemon=True).start()
 
     # Resolve host: explicit flag > config > auto-detect
     if args.host is not None:


### PR DESCRIPTION
On cold start or stale cache, check_for_updates() made a sync HTTP request to PyPI (up to 2s) inline in the CLI startup path, blocking the event loop before the server could bind.

Move the check-and-print block into a daemon=True background thread so startup is not blocked. check_for_updates() itself is unchanged - dashboard.py and health/checks.py callers are unaffected.

