### PR TITLE
fix: handle non-UTF-8 bytes in identity files

### DIFF
--- a/src/pocketpaw/bootstrap/default_provider.py
+++ b/src/pocketpaw/bootstrap/default_provider.py
@@ -29,7 +29,7 @@ def _read_identity_file(path: Path, strip: bool = False) -> str:
     cached = _identity_file_cache.get(key)
     if cached and cached.mtime == mtime:
         return cached.content
-    content = path.read_text(encoding="utf-8")
+    content = path.read_text(encoding="utf-8", errors="replace")
     if strip:
         content = content.strip()
     _identity_file_cache[key] = _IdentityCache(content=content, mtime=mtime)


### PR DESCRIPTION
## Summary

- Fixes a `UnicodeDecodeError` crash on `GET /api/identity` when `INSTRUCTIONS.md` contains non-UTF-8 bytes (e.g. Windows-1252 em dashes, byte `0x97`)
- Adds `errors="replace"` to `_read_identity_file()` so invalid bytes are replaced with the Unicode replacement character instead of raising an exception

## Test plan

- [x] Create an `INSTRUCTIONS.md` with Windows-1252 encoded characters (em dashes, smart quotes, etc.)
- [x] Verify `GET /api/identity` returns 200 instead of 500
- [x] Confirm the response content is intact with replacement characters where needed