### PR TITLE
Add validate_api_key function for API key validations

### DIFF
--- a/src/pocketclaw/config.py
+++ b/src/pocketclaw/config.py
@@ -607,6 +607,31 @@ def regenerate_token() -> str:
     _chmod_safe(token_path, 0o600)
     return token
 
+def validate_api_key(provider: str, api_key: str | None) -> bool:
+    """
+    Validate API key format based on provider.
+    """
+
+    if not api_key or not isinstance(api_key, str):
+        return False
+
+    api_key = api_key.strip()
+
+    if provider.lower() == "openai":
+        return api_key.startswith("sk-")
+
+    if provider.lower() == "anthropic":
+        return api_key.startswith("sk-ant-")
+
+    if provider.lower() == "telegram":
+        # Telegram bot tokens
+        return ":" in api_key and len(api_key.split(":")[0]) > 5
+
+    if provider.lower() == "tavily":
+        return api_key.startswith("tvly-")
+
+    return False
+
 
 # Flag file to avoid re-running migration on every load
 _MIGRATION_DONE_PATH: Path | None = None


### PR DESCRIPTION
## What does this PR do?

This PR adds a new `validate_api_key()` function in `src/pocketclaw/config.py`.
The function validates API key formats for supported providers before they are used in the application.

It currently supports validation for **OpenAI, Anthropic, Telegram, and Tavily** by checking their expected key prefixes or token format.

---

## Related Issue

Fixes #33

---

## Changes Made

* `src/pocketclaw/config.py`: Added `validate_api_key()` function to validate API key formats for:

  * OpenAI (`sk-`)
  * Anthropic (`sk-ant-`)
  * Telegram (bot token format `number:token`)
  * Tavily (`tvly-`)

---

## How to Test

1. Run the project locally.
2. Import and call the `validate_api_key()` function with different provider names and API keys.
3. Verify that valid keys return `True` and invalid keys return `False`.

Example cases:

* `validate_api_key("openai", "sk-test123")` → True
* `validate_api_key("anthropic", "sk-ant-test123")` → True
* `validate_api_key("tavily", "tvly-test123")` → True
* `validate_api_key("telegram", "123456789:ABCDEF")` → True
* `validate_api_key("openai", "invalidkey")` → False

---

## Evidence of Testing

```
validate_api_key("openai", "sk-test123") -> True
validate_api_key("anthropic", "sk-ant-test123") -> True
validate_api_key("tavily", "tvly-test123") -> True
validate_api_key("telegram", "123456789:ABCDEF") -> True
validate_api_key("openai", "invalidkey") -> False
```

---

## Checklist

* [x] PR targets `dev` branch (not `main`)
* [x] Linked to an existing issue
* [x] I have run PocketPaw locally and tested my changes
* [ ] Tests pass (`uv run pytest --ignore=tests/e2e`)
* [ ] Linting passes (`uv run ruff check .`)
* [ ] I have added/updated tests if applicable
* [x] No unrelated changes bundled in this PR
* [x] No secrets or credentials in the diff
