### PR TITLE
fix: add per-tool execution timeout to prevent hung agent sessions (#…

### DIFF
--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -354,6 +354,10 @@ class Settings(BaseSettings):
     tools_deny: list[str] = Field(
         default_factory=list, description="Explicit tool deny list (highest priority)"
     )
+    tool_timeout: int = Field(
+        default=120,
+        description="Per-tool execution timeout in seconds (0 = no timeout)",
+    )
 
     # Discord
     discord_bot_token: str | None = Field(default=None, description="Discord bot token")

--- a/src/pocketpaw/tools/registry.py
+++ b/src/pocketpaw/tools/registry.py
@@ -1,16 +1,21 @@
 # Tool registry for managing available tools.
 # Created: 2026-02-02
+# Updated: 2026-03-07 — Add per-tool execution timeout (Issue #494).
 # Updated: 2026-02-25 — Strengthen param validation: also reject None for required params.
 
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
 from pocketpaw.security import AuditSeverity, get_audit_logger
+from pocketpaw.security.audit import AuditEvent
 from pocketpaw.tools.policy import ToolPolicy
 from pocketpaw.tools.protocol import ToolProtocol
+
+DEFAULT_TOOL_TIMEOUT = 60  # seconds
 
 logger = logging.getLogger(__name__)
 
@@ -125,9 +130,18 @@ class ToolRegistry:
 
         audit.log_tool_use(name, params, severity=severity, status="attempt")
 
+        # Per-tool timeout (Issue #494): use per-tool attribute if set,
+        # otherwise fall back to configurable global setting, then default.
+        from pocketpaw.config import get_settings
+
+        global_timeout = get_settings().tool_timeout
+        timeout = getattr(tool, "timeout", global_timeout or DEFAULT_TOOL_TIMEOUT)
+        if global_timeout == 0:
+            timeout = None  # 0 = no timeout (opt-out)
+
         try:
             logger.debug(f"🔧 Executing {name} with {params}")
-            result = await tool.execute(**params)
+            result = await asyncio.wait_for(tool.execute(**params), timeout=timeout)
 
             # Audit Log: Success
             # We don't log full result content in audit to avoid PII, usually
@@ -136,7 +150,6 @@ class ToolRegistry:
 
             # Injection scan on tool results (e.g. web content)
             try:
-                from pocketpaw.config import get_settings
                 from pocketpaw.security.injection_scanner import get_injection_scanner
 
                 settings = get_settings()
@@ -152,14 +165,25 @@ class ToolRegistry:
             log_result = result[:200] + "..." if len(result) > 200 else result
             logger.debug(f"🔧 {name} result: {log_result}")
             return result
-        except Exception as e:
-            # Audit Log: Error
-            from pocketpaw.security.audit import AuditEvent
-            from pocketpaw.security.audit import AuditSeverity as AS
-
+        except TimeoutError:
             audit.log(
                 AuditEvent.create(
-                    severity=AS.WARNING,
+                    severity=AuditSeverity.WARNING,
+                    actor="agent",
+                    action="tool_timeout",
+                    target=name,
+                    status="timeout",
+                    timeout_seconds=timeout,
+                    params=params,
+                )
+            )
+            logger.error("🔧 %s timed out after %ds", name, timeout)
+            return f"Error: Tool '{name}' timed out after {timeout}s"
+        except Exception as e:
+            # Audit Log: Error
+            audit.log(
+                AuditEvent.create(
+                    severity=AuditSeverity.WARNING,
                     actor="agent",
                     action="tool_error",
                     target=name,

--- a/tests/test_tool_timeout.py
+++ b/tests/test_tool_timeout.py
@@ -1,0 +1,107 @@
+# Tests for per-tool execution timeout (Issue #494).
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pocketpaw.tools.protocol import BaseTool
+
+# ---------- Helpers ----------
+
+
+class FastTool(BaseTool):
+    """A tool that returns immediately."""
+
+    @property
+    def name(self) -> str:
+        return "fast_tool"
+
+    @property
+    def description(self) -> str:
+        return "Returns instantly"
+
+    async def execute(self, **params) -> str:
+        return "done"
+
+
+class SlowTool(BaseTool):
+    """A tool that hangs longer than the timeout."""
+
+    @property
+    def name(self) -> str:
+        return "slow_tool"
+
+    @property
+    def description(self) -> str:
+        return "Hangs forever"
+
+    async def execute(self, **params) -> str:
+        await asyncio.sleep(999)
+        return "never"
+
+
+# ---------- Fixtures ----------
+
+
+def _make_mock_settings(timeout: int = 1) -> MagicMock:
+    """Create a mock settings object with the given tool_timeout."""
+    mock = MagicMock()
+    mock.tool_timeout = timeout
+    mock.injection_scan_enabled = False
+    return mock
+
+
+@pytest.fixture
+def mock_audit():
+    """Patch the audit logger where registry.py calls it."""
+    mock = MagicMock()
+    # Patch at the call site in registry, not at the definition site
+    with patch("pocketpaw.tools.registry.get_audit_logger", return_value=mock):
+        yield mock
+
+
+# ---------- Tests ----------
+
+
+async def test_fast_tool_succeeds_with_timeout(mock_audit):
+    """A fast tool should complete normally when timeout is set."""
+    from pocketpaw.tools.registry import ToolRegistry
+
+    with patch("pocketpaw.config.get_settings", return_value=_make_mock_settings(1)):
+        registry = ToolRegistry()
+        registry.register(FastTool())
+        result = await registry.execute("fast_tool")
+
+    assert result == "done"
+
+
+async def test_slow_tool_times_out(mock_audit):
+    """A tool that exceeds the timeout should be cancelled and return an error."""
+    from pocketpaw.tools.registry import ToolRegistry
+
+    with patch("pocketpaw.config.get_settings", return_value=_make_mock_settings(1)):
+        registry = ToolRegistry()
+        registry.register(SlowTool())
+        result = await registry.execute("slow_tool")
+
+    assert "timed out" in result
+    assert "1s" in result
+
+    # Verify audit log was called with timeout status
+    mock_audit.log.assert_called()
+    audit_event = mock_audit.log.call_args[0][0]
+    assert audit_event.status == "timeout"
+    assert audit_event.action == "tool_timeout"
+
+
+async def test_no_timeout_when_zero(mock_audit):
+    """Setting tool_timeout=0 should disable the timeout (fast tool completes)."""
+    from pocketpaw.tools.registry import ToolRegistry
+
+    with patch("pocketpaw.config.get_settings", return_value=_make_mock_settings(0)):
+        registry = ToolRegistry()
+        registry.register(FastTool())
+        result = await registry.execute("fast_tool")
+
+    assert result == "done"


### PR DESCRIPTION
…494)

<!-- Updated: 2026-02-26 — Added branch/issue warnings, tightened checklist. -->

> **Before opening this PR:**
> - Does it target `dev`? PRs against `main` are auto-closed.
> - Is there a linked issue? PRs without one will be closed.
> - Did you read [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md)?

## What does this PR do?

Adds a configurable per-tool execution timeout to ToolRegistry.execute(). Previously, a stuck tool (e.g. hitting an unresponsive HTTP endpoint) would block the agent session indefinitely with no way to recover. Now, tool calls are wrapped with asyncio.wait_for() and cancelled after the timeout (default: 120s), with the event logged to the audit trail.

## Related Issue


Fixes #494 

## Changes Made


src/pocketpaw/config.py
: Added tool_timeout setting (default 120s, POCKETPAW_TOOL_TIMEOUT env var, 0 = disabled)

src/pocketpaw/tools/registry.py
: Wrapped tool.execute() with asyncio.wait_for(), added audit logging for timeouts with status="timeout", moved 

AuditEvent
 import to top-level

tests/test_tool_timeout.py
: [NEW] 3 tests covering fast tool success, slow tool timeout + audit, and timeout=0 disabling

## How to Test

<!-- Step-by-step instructions for a reviewer to verify your changes work. -->

1. uv run ruff check src/pocketpaw/tools/registry.py src/pocketpaw/config.py
2. uv run pytest tests/test_tool_timeout.py -v

## Evidence of Testing

tests/test_tool_timeout.py::test_fast_tool_succeeds_with_timeout PASSED
tests/test_tool_timeout.py::test_slow_tool_times_out PASSED
tests/test_tool_timeout.py::test_no_timeout_when_zero PASSED
======================== 3 passed in 1.83s =========================
ruff check: All checks passed!

<img width="982" height="128" alt="image" src="https://github.com/user-attachments/assets/82ffd529-34b8-4355-a651-6dbc0c6fab70" />


## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff
