### PR TITLE
fix(ci): remove conflicting apt package for Linux Tauri build

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -67,7 +67,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
             patchelf \


### PR DESCRIPTION
## Summary

Remove `libappindicator3-dev` which conflicts with `libayatana-appindicator3-dev` on Ubuntu 22.04, causing the Linux Tauri build to fail with `unmet dependencies`.

One-line fix. The ayatana version is the modern replacement and is all that's needed.

## Context

Second alpha build: macOS (both) and Windows passed, Linux failed on apt install.