### PR TITLE
fix(client): fix Linux Tauri build — lifetime and unused var

### DIFF
--- a/client/src-tauri/src/commands.rs
+++ b/client/src-tauri/src/commands.rs
@@ -1,6 +1,7 @@
 // Tauri IPC commands for the PocketPaw desktop client.
 // Updated: 2026-03-09 — Fix cross-platform build: use #[cfg(windows)] for
 //   Windows-specific process creation flags instead of cfg!(windows) runtime check.
+//   Prefix unused `profile` param with underscore to suppress warning.
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::net::TcpStream;
@@ -93,7 +94,7 @@ pub struct InstallProgress {
 /// Install PocketPaw by spawning a non-interactive installer process.
 /// Streams stdout line-by-line via "install-progress" events.
 #[tauri::command]
-pub async fn install_pocketpaw(app: AppHandle, profile: String) -> Result<bool, String> {
+pub async fn install_pocketpaw(app: AppHandle, _profile: String) -> Result<bool, String> {
     let child = if cfg!(windows) {
         Command::new("powershell")
             .args([

--- a/client/src-tauri/src/fs_commands.rs
+++ b/client/src-tauri/src/fs_commands.rs
@@ -436,12 +436,13 @@ pub fn fs_open_in_terminal(path: String) -> Result<(), String> {
 
     #[cfg(target_os = "linux")]
     {
+        let xterm_cmd = format!("cd '{}' && $SHELL", dir_str);
         let terminals = [
             ("x-terminal-emulator", vec!["--working-directory", &dir_str]),
             ("gnome-terminal", vec!["--working-directory", &dir_str]),
             ("konsole", vec!["--workdir", &dir_str]),
             ("xfce4-terminal", vec!["--working-directory", &dir_str]),
-            ("xterm", vec!["-e", &format!("cd '{}' && $SHELL", dir_str)]),
+            ("xterm", vec!["-e", xterm_cmd.as_str()]),
         ];
         let mut launched = false;
         for (cmd, args) in &terminals {


### PR DESCRIPTION
## Summary

- **fs_commands.rs:444** — `format!()` created a temporary `String` borrowed as `&str` in an array literal, causing `error[E0716]: temporary value dropped while borrowed`. Fixed by binding to a `let xterm_cmd` variable first.
- **commands.rs** — Prefixed unused `profile` parameter with underscore to suppress compiler warning.

These two issues were the last blockers for the Linux (`ubuntu-22.04`) build in the `client-v0.1.0-alpha.1` release workflow. macOS (arm64 + x86_64) and Windows builds already pass.

## Test plan

- [ ] Linux build passes in CI (`publish-client` workflow)
- [ ] macOS and Windows builds still pass (no regressions)