### PR TITLE
Prevent combining --telegram with other channel flags

### DIFF
--- a/src/pocketpaw/__main__.py
+++ b/src/pocketpaw/__main__.py
@@ -174,7 +174,19 @@ Examples:
     )
 
     args = parser.parse_args()
+    # Prevent mixing Telegram mode with other channel flags
+channel_flags = [
+    args.discord,
+    args.slack,
+    args.whatsapp,
+    args.signal,
+    args.matrix,
+    args.teams,
+    args.gchat,
+]
 
+if args.telegram and any(channel_flags):
+    parser.error("--telegram cannot be combined with other channel flags")
     # Fail fast if optional deps are missing for the chosen mode
     _check_extras_installed(args)
 


### PR DESCRIPTION
Adds CLI validation to prevent --telegram from being used together with other channel flags such as --discord or --slack. This avoids conflicting runtime modes.

<!-- Updated: 2026-02-26 — Added branch/issue warnings, tightened checklist. -->

> **Before opening this PR:**
> - Does it target `dev`? PRs against `main` are auto-closed.
> - Is there a linked issue? PRs without one will be closed.
> - Did you read [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md)?

## What does this PR do?

<!-- Describe the change in 2-3 sentences. What problem does it solve? -->

## Related Issue

<!-- Link the issue this PR addresses. PRs without a linked issue will be closed. -->

Fixes #

## Changes Made

<!-- List the specific files changed and what was modified in each. -->

- `file_path`: description of change

## How to Test

<!-- Step-by-step instructions for a reviewer to verify your changes work. -->

1.
2.
3.

## Evidence of Testing

<!-- Paste terminal output, test results, or screenshots proving you tested locally. -->

```
paste output here
```

## Checklist

- [ ] PR targets `dev` branch (not `main`)
- [ ] Linked to an existing issue
- [ ] I have run PocketPaw locally and tested my changes
- [ ] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] I have added/updated tests if applicable
- [ ] No unrelated changes bundled in this PR
- [ ] No secrets or credentials in the diff
