### PR TITLE
chore: bump versions for release (python 0.4.8, client 0.1.0-alpha.2)

### DIFF
--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PocketPaw",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.2",
   "identifier": "com.pocketpaw.client",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
-# Updated: 2026-03-08 — Bump version to 0.4.7.
+# Updated: 2026-03-10 — Bump version to 0.4.8.
 [project]
 name = "pocketpaw"
-version = "0.4.7"
+version = "0.4.8"
 description = "The AI agent that runs on your laptop, not a datacenter. OpenClaw alternative with one-command install."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bumps for the upcoming release:
- Python package: 0.4.7 → 0.4.8
- Desktop client: 0.1.0 → 0.1.0-alpha.2