### PR TITLE
fix(client): use numeric version for MSI bundler compatibility

### DIFF
--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PocketPaw",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.1",
   "identifier": "com.pocketpaw.client",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
MSI bundler needs numeric-only pre-release identifiers. 0.1.0-alpha.2 broke Tauri builds on all platforms. Bumps to 0.1.1.