### PR TITLE
fix(client): numeric version 0.1.1 for MSI bundler

### DIFF
--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PocketPaw",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.1",
   "identifier": "com.pocketpaw.client",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Cherry-pick of #561. MSI bundler needs numeric-only versions — 0.1.0-alpha.2 broke all Tauri builds.