### PR TITLE
Fix lint errors in test files from PR #571

### DIFF
--- a/tests/test_headless_permissions.py
+++ b/tests/test_headless_permissions.py
@@ -82,9 +82,9 @@ class TestHeadlessPermissionMode:
     def test_no_conditional_bypass_in_options_build(self):
         """Verify the options_kwargs assignment is unconditional by checking
         that 'permission_mode' appears exactly once and not inside an if block."""
-        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
-
         import inspect
+
+        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
 
         source = inspect.getsource(ClaudeSDKBackend.run)
 

--- a/tests/test_integration_headless.py
+++ b/tests/test_integration_headless.py
@@ -23,7 +23,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
@@ -156,9 +155,9 @@ class TestServerStartup:
         Marked @pytest.mark.integration — skipped in CI by default.
         Requires all dashboard dependencies to be installed.
         """
-        import httpx
-        from fastapi.testclient import TestClient
         from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
 
         from pocketpaw.dashboard import app
 
@@ -321,7 +320,7 @@ class TestHeadlessChannelToolAccess:
         permission_line = None
         for line in lines:
             stripped = line.strip()
-            if 'permission_mode' in stripped and '=' in stripped and 'bypassPermissions' in stripped:
+            if all(k in stripped for k in ('permission_mode', '=', 'bypassPermissions')):
                 permission_line = stripped
                 break
 
@@ -554,7 +553,7 @@ class TestToolExecutionTimeout:
 
         try:
             await asyncio.wait_for(run_all(), timeout=5.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(
                 "Concurrent tool calls timed out after 5s — "
                 "possible event loop starvation from a blocking tool call."


### PR DESCRIPTION
## Summary

Fixes 6 ruff lint errors introduced in #571:
- Import sorting (I001) in both test files
- Unused `httpx` import (F401)
- Line too long (E501) — refactored with `all()`
- `asyncio.TimeoutError` → `TimeoutError` (UP041)

## Test plan
- [x] `ruff check` passes
- [x] All tests still pass