### PR TITLE
feat: Paw-to-Paw Phase 1 -- update check + announcement system

### DIFF
--- a/docs/public/latest.json
+++ b/docs/public/latest.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.4.8",
+  "announcement": "",
+  "urgency": "info",
+  "url": ""
+}

--- a/src/pocketpaw/__main__.py
+++ b/src/pocketpaw/__main__.py
@@ -214,10 +214,13 @@ Examples:
     def _bg_update_check() -> None:
         try:
             from pocketpaw.config import get_config_dir
-            from pocketpaw.update_check import check_for_updates, print_styled_update_notice
+            from pocketpaw.update_check import (
+                check_for_updates_full,
+                print_styled_update_notice,
+            )
 
-            update_info = check_for_updates(get_version("pocketpaw"), get_config_dir())
-            if update_info and update_info.get("update_available"):
+            update_info = check_for_updates_full(get_version("pocketpaw"), get_config_dir())
+            if update_info.get("update_available") or update_info.get("announcement"):
                 print_styled_update_notice(update_info)
         except Exception:
             pass  # Update check failure never interrupts startup

--- a/src/pocketpaw/api/v1/__init__.py
+++ b/src/pocketpaw/api/v1/__init__.py
@@ -40,6 +40,7 @@ _V1_ROUTERS: list[tuple[str, str, str]] = [
     ("pocketpaw.api.v1.events", "router", "Events"),
     ("pocketpaw.api.v1.kits", "router", "Kits"),
     ("pocketpaw.api.v1.metrics", "router", "Metrics"),
+    ("pocketpaw.api.v1.updates", "router", "Updates"),
 ]
 
 

--- a/src/pocketpaw/api/v1/updates.py
+++ b/src/pocketpaw/api/v1/updates.py
@@ -1,0 +1,49 @@
+# Updates router — version check, announcements, banner dismiss (Paw-to-Paw Phase 1).
+# Created: 2026-03-11
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Request
+
+from pocketpaw.api.v1.schemas.common import OkResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Updates"])
+
+
+@router.get("/updates")
+async def get_update_info():
+    """Return current version, update availability, and announcements.
+
+    Combines PyPI version check (24h cache) with latest.json announcements
+    (1h cache) into a single response. Fields:
+
+    - ``current`` / ``latest`` / ``update_available`` — version info
+    - ``announcement`` / ``urgency`` / ``announcement_url`` — from latest.json
+    """
+    from importlib.metadata import version as get_version
+
+    from pocketpaw.config import get_config_dir
+    from pocketpaw.update_check import check_for_updates_full
+
+    current = get_version("pocketpaw")
+    return check_for_updates_full(current, get_config_dir())
+
+
+@router.post("/updates/dismiss", response_model=OkResponse)
+async def dismiss_update_banner(request: Request):
+    """Record that the user dismissed the update banner for a specific version.
+
+    Expects JSON body: ``{"version": "0.5.0"}``
+    """
+    from pocketpaw.config import get_config_dir
+    from pocketpaw.update_check import mark_version_seen
+
+    body = await request.json()
+    version = body.get("version", "")
+    if version:
+        mark_version_seen(version, get_config_dir())
+    return OkResponse()

--- a/src/pocketpaw/bootstrap/context_builder.py
+++ b/src/pocketpaw/bootstrap/context_builder.py
@@ -1,6 +1,7 @@
 """
 Builder for assembling the full agent context.
 Created: 2026-02-02
+Updated: 2026-03-11 - Paw-to-Paw Phase 1: inject update/announcement context into system prompt
 Updated: 2026-03-10 - AGENTS.md injection: read project-specific constraints from target repos
 Updated: 2026-03-09 - Sanitize file_context paths before injecting into system prompt
 Updated: 2026-02-17 - Inject health state into system prompt when degraded/unhealthy
@@ -20,6 +21,52 @@ from pocketpaw.bus.format import CHANNEL_FORMAT_HINTS
 from pocketpaw.memory.manager import MemoryManager, get_memory_manager
 
 logger = logging.getLogger(__name__)
+
+
+def _build_update_context(update_info: dict) -> str:
+    """Build a system prompt block for update/announcement awareness.
+
+    Returns empty string when there's nothing to communicate.
+    When an update or announcement exists, returns a contextual block that lets
+    the agent weave the information into conversation naturally, rather than
+    relying on traditional banners or popups (Paw-to-Paw Phase 1).
+    """
+    has_update = update_info.get("update_available")
+    announcement = update_info.get("announcement", "")
+
+    if not has_update and not announcement:
+        return ""
+
+    lines = ["# Available Update"]
+
+    if has_update:
+        current = update_info.get("current", "?")
+        latest = update_info.get("latest", "?")
+        lines.append(f"A newer version of PocketPaw is available: v{current} -> v{latest}.")
+        lines.append("Upgrade command: pip install --upgrade pocketpaw")
+
+    if announcement:
+        urgency = update_info.get("urgency", "info")
+        if urgency == "critical":
+            lines.append(f"CRITICAL announcement: {announcement}")
+        elif urgency == "warning":
+            lines.append(f"Important: {announcement}")
+        else:
+            lines.append(f"Announcement: {announcement}")
+
+    url = update_info.get("announcement_url", "")
+    if url:
+        lines.append(f"More details: {url}")
+
+    lines.append("")
+    lines.append(
+        "You may mention this naturally when relevant (e.g. if the user hits a bug "
+        "that was fixed, or asks about new features). Do not interrupt unrelated "
+        "conversations with update notices. For critical announcements, proactively "
+        "inform the user at the first opportunity."
+    )
+
+    return "\n".join(lines)
 
 
 class AgentContextBuilder:
@@ -148,7 +195,21 @@ class AgentContextBuilder:
         except Exception as exc:  # noqa: BLE001
             logger.debug("Health engine failure (non-fatal, skipping health block): %s", exc)
 
-        # 8. Inject AGENTS.md constraints from the target repo
+        # 8. Inject update/announcement awareness (Paw-to-Paw Phase 1)
+        try:
+            from importlib.metadata import version as _get_version
+
+            from pocketpaw.config import get_config_dir
+            from pocketpaw.update_check import check_for_updates_full
+
+            update_info = check_for_updates_full(_get_version("pocketpaw"), get_config_dir())
+            update_block = _build_update_context(update_info)
+            if update_block:
+                parts.append(update_block)
+        except Exception:
+            pass  # Update context failure never breaks prompt building
+
+        # 9. Inject AGENTS.md constraints from the target repo
         if agents_md_dir:
             try:
                 from pocketpaw.agents_md import AgentsMdLoader

--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -882,15 +882,33 @@ def _static_version() -> str:
 
 @app.get("/api/version")
 async def get_version_info():
-    """Return current version and update availability."""
+    """Return current version, update availability, and announcements.
+
+    Backward-compat alias for /api/v1/updates.
+    """
     from importlib.metadata import version as get_version
 
     from pocketpaw.config import get_config_dir
-    from pocketpaw.update_check import check_for_updates
+    from pocketpaw.update_check import check_for_updates_full
 
     current = get_version("pocketpaw")
-    info = check_for_updates(current, get_config_dir())
-    return info or {"current": current, "latest": current, "update_available": False}
+    return check_for_updates_full(current, get_config_dir())
+
+
+@app.post("/api/version/dismiss")
+async def dismiss_version_banner(request: Request):
+    """Record that the user dismissed the update banner for a specific version.
+
+    Backward-compat alias for /api/v1/updates/dismiss.
+    """
+    from pocketpaw.config import get_config_dir
+    from pocketpaw.update_check import mark_version_seen
+
+    body = await request.json()
+    version = body.get("version", "")
+    if version:
+        mark_version_seen(version, get_config_dir())
+    return {"ok": True}
 
 
 @app.get("/")

--- a/src/pocketpaw/dashboard_lifecycle.py
+++ b/src/pocketpaw/dashboard_lifecycle.py
@@ -200,6 +200,50 @@ async def startup_event(
             except Exception as e:
                 logger.warning("Failed to auto-start webhook adapter: %s", e)
 
+    # One-time admin DM: notify configured channels about available updates (Paw-to-Paw Phase 1)
+    try:
+        from importlib.metadata import version as get_version
+
+        from pocketpaw.config import get_config_dir
+        from pocketpaw.update_check import (
+            check_for_updates_full,
+            format_admin_update_message,
+            get_last_notified_version,
+            mark_version_notified,
+        )
+
+        config_dir = get_config_dir()
+        current = get_version("pocketpaw")
+        update_info = check_for_updates_full(current, config_dir)
+
+        if update_info.get("update_available"):
+            latest = update_info["latest"]
+            last_notified = get_last_notified_version(config_dir)
+            if last_notified != latest:
+                # Send one-time DM to all configured notification channels
+
+                async def _send_admin_update_dm():
+                    try:
+                        # Small delay so channel adapters finish connecting
+                        await asyncio.sleep(10)
+                        from pocketpaw.bus.notifier import notify
+
+                        msg = format_admin_update_message(update_info)
+                        sent = await notify(msg)
+                        if sent > 0:
+                            mark_version_notified(latest, config_dir)
+                            logger.info(
+                                "Sent update notification (v%s) to %d channel(s)",
+                                latest,
+                                sent,
+                            )
+                    except Exception as e:
+                        logger.debug("Failed to send admin update DM: %s", e)
+
+                asyncio.create_task(_send_admin_update_dm())
+    except Exception:
+        logger.debug("Update notification check failed", exc_info=True)
+
     # Ensure project directories exist for all Deep Work projects
     try:
         from pocketpaw.mission_control.manager import get_mission_control_manager

--- a/src/pocketpaw/frontend/js/app.js
+++ b/src/pocketpaw/frontend/js/app.js
@@ -31,6 +31,10 @@ function app() {
         appVersion: '',
         latestVersion: '',
         updateAvailable: false,
+        announcement: '',
+        announcementUrgency: 'info',
+        announcementUrl: '',
+        updateBannerDismissed: false,
 
         // View state
         view: 'chat',
@@ -351,17 +355,40 @@ function app() {
         },
 
         /**
-         * Check PyPI for newer version via /api/version endpoint.
+         * Check for newer version + announcements via /api/v1/updates endpoint.
          */
         async checkForUpdates() {
             try {
-                const resp = await fetch('/api/version');
+                const resp = await fetch('/api/v1/updates');
                 if (!resp.ok) return;
                 const data = await resp.json();
                 this.appVersion = data.current || '';
                 this.latestVersion = data.latest || '';
                 this.updateAvailable = !!data.update_available;
+                this.announcement = data.announcement || '';
+                this.announcementUrgency = data.urgency || 'info';
+                this.announcementUrl = data.announcement_url || '';
+
+                // Check if this version's banner was already dismissed
+                const dismissedVersion = localStorage.getItem('pocketpaw_dismissed_update');
+                if (dismissedVersion === this.latestVersion && !this.announcement) {
+                    this.updateBannerDismissed = true;
+                }
             } catch (e) { /* silent */ }
+        },
+
+        /**
+         * Dismiss the update banner and persist the choice.
+         */
+        dismissUpdateBanner() {
+            this.updateBannerDismissed = true;
+            localStorage.setItem('pocketpaw_dismissed_update', this.latestVersion);
+            // Notify backend so mark_version_seen is recorded
+            fetch('/api/v1/updates/dismiss', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ version: this.latestVersion }),
+            }).catch(() => {});
         },
 
         /**

--- a/src/pocketpaw/frontend/templates/base.html
+++ b/src/pocketpaw/frontend/templates/base.html
@@ -165,6 +165,77 @@
 
     <!-- Main Content -->
     <main class="flex-1 flex flex-col relative bg-[radial-gradient(circle_at_50%_30%,#1c1c1e_0%,#000000_100%)] overflow-hidden w-full">
+
+      <!-- Update / Announcement Banner (Paw-to-Paw Phase 1) -->
+      <div
+        x-show="(updateAvailable || announcement) && !updateBannerDismissed"
+        x-transition:enter="transition ease-out duration-300"
+        x-transition:enter-start="opacity-0 -translate-y-2"
+        x-transition:enter-end="opacity-100 translate-y-0"
+        x-transition:leave="transition ease-in duration-200"
+        x-transition:leave-start="opacity-100 translate-y-0"
+        x-transition:leave-end="opacity-0 -translate-y-2"
+        class="relative z-20 mx-4 md:mx-8 mt-3 rounded-xl border backdrop-blur-md px-4 py-3 flex items-start gap-3 shadow-lg"
+        :class="{
+          'bg-amber-500/10 border-amber-500/20': announcementUrgency === 'warning',
+          'bg-red-500/10 border-red-500/20': announcementUrgency === 'critical',
+          'bg-blue-500/10 border-blue-500/20': announcementUrgency === 'info' || !announcementUrgency,
+        }"
+      >
+        <!-- Icon -->
+        <div class="flex-shrink-0 mt-0.5">
+          <template x-if="announcementUrgency === 'critical'">
+            <i data-lucide="alert-triangle" class="w-5 h-5 text-red-400"></i>
+          </template>
+          <template x-if="announcementUrgency === 'warning'">
+            <i data-lucide="alert-circle" class="w-5 h-5 text-amber-400"></i>
+          </template>
+          <template x-if="announcementUrgency !== 'critical' && announcementUrgency !== 'warning'">
+            <i data-lucide="arrow-up-circle" class="w-5 h-5 text-blue-400"></i>
+          </template>
+        </div>
+
+        <!-- Content -->
+        <div class="flex-1 min-w-0">
+          <template x-if="updateAvailable">
+            <p class="text-sm font-medium text-white/90">
+              Update available: <span class="font-mono text-white/60" x-text="appVersion"></span>
+              <span class="text-white/40 mx-1">&rarr;</span>
+              <span class="font-mono text-green-400" x-text="latestVersion"></span>
+            </p>
+          </template>
+          <template x-if="announcement">
+            <p class="text-sm text-white/70 mt-1" x-text="announcement"></p>
+          </template>
+          <div class="flex items-center gap-3 mt-2">
+            <template x-if="announcementUrl">
+              <a :href="announcementUrl" target="_blank" rel="noopener"
+                 class="text-xs text-blue-400 hover:text-blue-300 underline underline-offset-2">
+                Learn more
+              </a>
+            </template>
+            <template x-if="updateAvailable">
+              <a href="https://github.com/pocketpaw/pocketpaw/releases" target="_blank" rel="noopener"
+                 class="text-xs text-white/40 hover:text-white/60 underline underline-offset-2">
+                Release notes
+              </a>
+            </template>
+            <template x-if="updateAvailable">
+              <span class="text-xs font-mono text-white/30">pip install --upgrade pocketpaw</span>
+            </template>
+          </div>
+        </div>
+
+        <!-- Dismiss button -->
+        <button
+          @click="dismissUpdateBanner()"
+          class="flex-shrink-0 p-1 rounded-lg text-white/30 hover:text-white/60 hover:bg-white/5 transition-colors"
+          title="Dismiss"
+        >
+          <i data-lucide="x" class="w-4 h-4"></i>
+        </button>
+      </div>
+
       <!-- Top Bar -->
       <header class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-4 md:px-8 py-4 bg-gradient-to-b from-black/40 to-transparent pointer-events-none">
         

--- a/src/pocketpaw/update_check.py
+++ b/src/pocketpaw/update_check.py
@@ -1,10 +1,13 @@
-"""Startup version check against PyPI + release notes fetching.
+"""Startup version check against PyPI + latest.json announcements + release notes.
 
 Changes:
+  - 2026-03-11: Phase 1 Paw-to-Paw: added latest.json announcement fetching, admin DM
+    notification, and dashboard banner support (issue #573).
   - 2026-02-18: Added styled CLI update box, release notes fetching, version seen tracking.
   - 2026-02-16: Initial implementation. Checks PyPI daily, caches result, prints update notice.
 
-Checks once per 24 hours whether a newer version of pocketpaw exists on PyPI.
+Checks once per 24 hours whether a newer version of pocketpaw exists on PyPI,
+and fetches announcements from a hosted latest.json endpoint.
 Cache stored in ~/.pocketpaw/.update_check so the result is shared between
 CLI launches and the dashboard API.
 """
@@ -21,8 +24,11 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 PYPI_URL = "https://pypi.org/pypi/pocketpaw/json"
+LATEST_JSON_URL = "https://pocketpaw.github.io/pocketpaw/latest.json"
 CACHE_FILENAME = ".update_check"
 CACHE_TTL = 86400  # 24 hours
+ANNOUNCEMENT_CACHE_FILENAME = ".announcement_cache"
+ANNOUNCEMENT_CACHE_TTL = 3600  # 1 hour — announcements refresh more often
 REQUEST_TIMEOUT = 2  # seconds
 
 RELEASE_NOTES_CACHE_DIR = ".release_notes_cache"
@@ -88,6 +94,105 @@ def check_for_updates(current_version: str, config_dir: Path) -> dict | None:
 
 
 # ---------------------------------------------------------------------------
+# latest.json announcement fetching (Paw-to-Paw Phase 1)
+# ---------------------------------------------------------------------------
+
+
+def fetch_latest_json(config_dir: Path) -> dict | None:
+    """Fetch the hosted latest.json for version + announcements.
+
+    Expected schema::
+
+        {
+          "version": "0.4.9",
+          "announcement": "Optional message to display to all users",
+          "urgency": "info",        // "info" | "warning" | "critical"
+          "url": "https://..."      // optional link for more details
+        }
+
+    Uses a 1-hour cache. Returns the parsed dict or None on error.
+    Never raises.
+    """
+    try:
+        cache_file = config_dir / ANNOUNCEMENT_CACHE_FILENAME
+        now = time.time()
+
+        # Try cache first
+        if cache_file.exists():
+            try:
+                cached = json.loads(cache_file.read_text())
+                if now - cached.get("ts", 0) < ANNOUNCEMENT_CACHE_TTL:
+                    return cached.get("data")
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+        url = os.environ.get("POCKETPAW_LATEST_JSON_URL", LATEST_JSON_URL)
+        req = urllib.request.Request(url, headers={"User-Agent": "pocketpaw"})
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+            data = json.loads(resp.read())
+
+        # Validate minimum fields
+        if not isinstance(data, dict) or "version" not in data:
+            logger.debug("latest.json missing 'version' field")
+            return None
+
+        result = {
+            "version": data["version"],
+            "announcement": data.get("announcement", ""),
+            "urgency": data.get("urgency", "info"),
+            "url": data.get("url", ""),
+        }
+
+        # Write cache
+        config_dir.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(json.dumps({"ts": now, "data": result}))
+
+        return result
+    except Exception:
+        logger.debug("Failed to fetch latest.json", exc_info=True)
+        return None
+
+
+def check_for_updates_full(current_version: str, config_dir: Path) -> dict:
+    """Combined update check: PyPI version + latest.json announcements.
+
+    Returns a dict with:
+      - current, latest, update_available (from PyPI check)
+      - announcement, urgency, announcement_url (from latest.json)
+
+    Always returns a dict (never None). Errors in either source are isolated.
+    """
+    # Base version info from PyPI
+    pypi_info = check_for_updates(current_version, config_dir)
+    result = pypi_info or {
+        "current": current_version,
+        "latest": current_version,
+        "update_available": False,
+    }
+
+    # Merge latest.json announcement data
+    latest_json = fetch_latest_json(config_dir)
+    if latest_json:
+        # latest.json version takes precedence if newer than PyPI
+        lj_version = latest_json["version"]
+        if _parse_version(lj_version) > _parse_version(result["latest"]):
+            result["latest"] = lj_version
+            result["update_available"] = _parse_version(lj_version) > _parse_version(
+                current_version
+            )
+
+        result["announcement"] = latest_json.get("announcement", "")
+        result["urgency"] = latest_json.get("urgency", "info")
+        result["announcement_url"] = latest_json.get("url", "")
+    else:
+        result["announcement"] = ""
+        result["urgency"] = "info"
+        result["announcement_url"] = ""
+
+    return result
+
+
+# ---------------------------------------------------------------------------
 # CLI styled update notice
 # ---------------------------------------------------------------------------
 
@@ -109,18 +214,22 @@ def print_styled_update_notice(info: dict) -> None:
     Uses box-drawing characters, ANSI colors, and writes to stderr so it
     doesn't pollute piped output. Auto-suppressed in CI, non-TTY, or when
     POCKETPAW_NO_UPDATE_CHECK is set.
+
+    Supports announcement text from latest.json (Paw-to-Paw Phase 1).
     """
     if _should_suppress_notice():
         return
 
     current = info["current"]
     latest = info["latest"]
+    announcement = info.get("announcement", "")
 
     # ANSI color codes
     YELLOW = "\033[33m"
     GREEN = "\033[32m"
     DIM = "\033[2m"
     BOLD = "\033[1m"
+    CYAN = "\033[36m"
     RESET = "\033[0m"
 
     changelog_url = "github.com/pocketpaw/pocketpaw/releases"
@@ -145,9 +254,25 @@ def print_styled_update_notice(info: dict) -> None:
         f"{YELLOW}\u2502{RESET}{empty_inner}{YELLOW}\u2502{RESET}",
         f"{YELLOW}\u2502{RESET}{changelog_line}{' ' * (box_width - 52)}{YELLOW}\u2502{RESET}",
         f"{YELLOW}\u2502{RESET}{upgrade_line}{' ' * (box_width - 46)}{YELLOW}\u2502{RESET}",
-        f"{YELLOW}\u2502{RESET}{empty_inner}{YELLOW}\u2502{RESET}",
-        f"{YELLOW}\u2514{border_h}\u2518{RESET}",
     ]
+
+    # Add announcement line if present
+    if announcement:
+        lines.append(f"{YELLOW}\u2502{RESET}{empty_inner}{YELLOW}\u2502{RESET}")
+        # Wrap announcement to fit in box (max ~54 chars per line)
+        max_text_width = box_width - 6  # 3 indent + 3 padding
+        for i in range(0, len(announcement), max_text_width):
+            chunk = announcement[i : i + max_text_width]
+            padded = f"   {CYAN}{chunk}{RESET}"
+            pad_right = box_width - len(chunk) - 3
+            lines.append(f"{YELLOW}\u2502{RESET}{padded}{' ' * pad_right}{YELLOW}\u2502{RESET}")
+
+    lines.extend(
+        [
+            f"{YELLOW}\u2502{RESET}{empty_inner}{YELLOW}\u2502{RESET}",
+            f"{YELLOW}\u2514{border_h}\u2518{RESET}",
+        ]
+    )
 
     sys.stderr.write("\n" + "\n".join(lines) + "\n\n")
 
@@ -241,3 +366,49 @@ def mark_version_seen(version: str, config_dir: Path) -> None:
         cache_file.write_text(json.dumps(cache))
     except OSError:
         logger.debug("Failed to mark version %s as seen", version, exc_info=True)
+
+
+def get_last_notified_version(config_dir: Path) -> str | None:
+    """Read last_notified_version (for admin DM dedup) from the cache file."""
+    try:
+        cache_file = config_dir / CACHE_FILENAME
+        if cache_file.exists():
+            cache = json.loads(cache_file.read_text())
+            return cache.get("last_notified_version")
+    except (json.JSONDecodeError, ValueError, OSError):
+        pass
+    return None
+
+
+def mark_version_notified(version: str, config_dir: Path) -> None:
+    """Record that admin DM was sent for this version, preventing duplicate notifications."""
+    try:
+        cache_file = config_dir / CACHE_FILENAME
+        cache = {}
+        if cache_file.exists():
+            try:
+                cache = json.loads(cache_file.read_text())
+            except (json.JSONDecodeError, ValueError):
+                pass
+        cache["last_notified_version"] = version
+        config_dir.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(json.dumps(cache))
+    except OSError:
+        logger.debug("Failed to mark version %s as notified", version, exc_info=True)
+
+
+def format_admin_update_message(info: dict) -> str:
+    """Format a concise update notification message for admin DMs."""
+    current = info.get("current", "?")
+    latest = info.get("latest", "?")
+    announcement = info.get("announcement", "")
+
+    lines = [f"PocketPaw update available: v{current} -> v{latest}"]
+
+    if announcement:
+        lines.append(f"\n{announcement}")
+
+    lines.append("\nUpgrade: pip install --upgrade pocketpaw")
+    lines.append("Release notes: github.com/pocketpaw/pocketpaw/releases")
+
+    return "\n".join(lines)

--- a/tests/test_api_cors.py
+++ b/tests/test_api_cors.py
@@ -24,7 +24,7 @@ class TestV1RouterRegistration:
 
     def test_v1_routers_count(self):
         """Verify total number of registered routers."""
-        assert len(_V1_ROUTERS) == 23
+        assert len(_V1_ROUTERS) == 24
 
     def test_mount_v1_routers_succeeds(self):
         """mount_v1_routers should not raise on a real FastAPI app."""

--- a/tests/test_api_v1_updates.py
+++ b/tests/test_api_v1_updates.py
@@ -1,0 +1,119 @@
+# Tests for API v1 updates router (Paw-to-Paw Phase 1).
+# Created: 2026-03-11
+
+import json
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from pocketpaw.api.v1.updates import router
+
+
+@pytest.fixture
+def test_app():
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    return app
+
+
+@pytest.fixture
+def client(test_app):
+    return TestClient(test_app)
+
+
+class TestGetUpdateInfo:
+    """Tests for GET /api/v1/updates."""
+
+    @patch("pocketpaw.config.get_config_dir")
+    @patch("pocketpaw.update_check.check_for_updates_full")
+    def test_returns_update_info(self, mock_full, mock_config_dir, client, tmp_path):
+        mock_config_dir.return_value = tmp_path
+        mock_full.return_value = {
+            "current": "0.4.8",
+            "latest": "0.5.0",
+            "update_available": True,
+            "announcement": "",
+            "urgency": "info",
+            "announcement_url": "",
+        }
+
+        resp = client.get("/api/v1/updates")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["current"] == "0.4.8"
+        assert data["latest"] == "0.5.0"
+        assert data["update_available"] is True
+        assert "announcement" in data
+        assert "urgency" in data
+        assert "announcement_url" in data
+
+    @patch("pocketpaw.config.get_config_dir")
+    @patch("pocketpaw.update_check.check_for_updates_full")
+    def test_no_update_available(self, mock_full, mock_config_dir, client, tmp_path):
+        mock_config_dir.return_value = tmp_path
+        mock_full.return_value = {
+            "current": "0.5.0",
+            "latest": "0.5.0",
+            "update_available": False,
+            "announcement": "",
+            "urgency": "info",
+            "announcement_url": "",
+        }
+
+        resp = client.get("/api/v1/updates")
+        assert resp.status_code == 200
+        assert resp.json()["update_available"] is False
+
+    @patch("pocketpaw.config.get_config_dir")
+    @patch("pocketpaw.update_check.check_for_updates_full")
+    def test_includes_announcement(self, mock_full, mock_config_dir, client, tmp_path):
+        mock_config_dir.return_value = tmp_path
+        mock_full.return_value = {
+            "current": "0.4.8",
+            "latest": "0.5.0",
+            "update_available": True,
+            "announcement": "Security patch!",
+            "urgency": "critical",
+            "announcement_url": "https://example.com/security",
+        }
+
+        resp = client.get("/api/v1/updates")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["announcement"] == "Security patch!"
+        assert data["urgency"] == "critical"
+        assert data["announcement_url"] == "https://example.com/security"
+
+
+class TestDismissUpdateBanner:
+    """Tests for POST /api/v1/updates/dismiss."""
+
+    @patch("pocketpaw.config.get_config_dir")
+    def test_dismiss_records_version(self, mock_config_dir, client, tmp_path):
+        mock_config_dir.return_value = tmp_path
+
+        resp = client.post(
+            "/api/v1/updates/dismiss",
+            json={"version": "0.5.0"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+        # Verify it was written to cache
+        cache = json.loads((tmp_path / ".update_check").read_text())
+        assert cache["last_seen_version"] == "0.5.0"
+
+    @patch("pocketpaw.config.get_config_dir")
+    def test_dismiss_empty_version_is_noop(self, mock_config_dir, client, tmp_path):
+        mock_config_dir.return_value = tmp_path
+
+        resp = client.post(
+            "/api/v1/updates/dismiss",
+            json={"version": ""},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        # No cache file created
+        assert not (tmp_path / ".update_check").exists()

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -11,6 +11,7 @@ import json
 import time
 from unittest.mock import patch
 
+from pocketpaw.bootstrap.context_builder import _build_update_context
 from pocketpaw.update_check import (
     ANNOUNCEMENT_CACHE_FILENAME,
     CACHE_FILENAME,
@@ -537,3 +538,104 @@ class TestStyledNoticeWithAnnouncement:
         captured = capsys.readouterr()
         assert "Bug fixes for memory hang" in captured.err
         assert "0.5.0" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Agent context injection (Paw-to-Paw Phase 1 — AI-native delivery)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUpdateContext:
+    """Tests for the system prompt injection block."""
+
+    def test_empty_when_no_update_and_no_announcement(self):
+        info = {
+            "current": "0.4.8",
+            "latest": "0.4.8",
+            "update_available": False,
+            "announcement": "",
+        }
+        assert _build_update_context(info) == ""
+
+    def test_includes_version_when_update_available(self):
+        info = {
+            "current": "0.4.8",
+            "latest": "0.5.0",
+            "update_available": True,
+            "announcement": "",
+        }
+        block = _build_update_context(info)
+        assert "# Available Update" in block
+        assert "v0.4.8 -> v0.5.0" in block
+        assert "pip install --upgrade pocketpaw" in block
+        assert "mention this naturally" in block
+
+    def test_includes_announcement_without_update(self):
+        info = {
+            "current": "0.4.8",
+            "latest": "0.4.8",
+            "update_available": False,
+            "announcement": "Maintenance window tonight",
+        }
+        block = _build_update_context(info)
+        assert "# Available Update" in block
+        assert "Maintenance window tonight" in block
+        # No version line since there's no update
+        assert "v0.4.8 -> v0.4.8" not in block
+
+    def test_critical_urgency_prefix(self):
+        info = {
+            "current": "0.4.8",
+            "latest": "0.5.0",
+            "update_available": True,
+            "announcement": "Security fix",
+            "urgency": "critical",
+        }
+        block = _build_update_context(info)
+        assert "CRITICAL announcement: Security fix" in block
+        assert "proactively inform the user" in block
+
+    def test_warning_urgency_prefix(self):
+        info = {
+            "current": "0.4.8",
+            "latest": "0.5.0",
+            "update_available": True,
+            "announcement": "Breaking change",
+            "urgency": "warning",
+        }
+        block = _build_update_context(info)
+        assert "Important: Breaking change" in block
+
+    def test_info_urgency_prefix(self):
+        info = {
+            "current": "0.4.8",
+            "latest": "0.5.0",
+            "update_available": True,
+            "announcement": "New feature",
+            "urgency": "info",
+        }
+        block = _build_update_context(info)
+        assert "Announcement: New feature" in block
+
+    def test_includes_url_when_present(self):
+        info = {
+            "current": "0.4.8",
+            "latest": "0.5.0",
+            "update_available": True,
+            "announcement": "Details at link",
+            "announcement_url": "https://example.com/update",
+        }
+        block = _build_update_context(info)
+        assert "https://example.com/update" in block
+
+    def test_behavioral_guidance_present(self):
+        """The block tells the agent how to use the info."""
+        info = {
+            "current": "0.4.8",
+            "latest": "0.5.0",
+            "update_available": True,
+            "announcement": "",
+        }
+        block = _build_update_context(info)
+        assert "Do not interrupt unrelated conversations" in block
+        assert "mention this naturally" in block

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,6 +1,8 @@
 """Tests for update_check module.
 
 Changes:
+  - 2026-03-11: Added tests for Paw-to-Paw Phase 1: fetch_latest_json,
+    check_for_updates_full, admin notification helpers, announcement in CLI notice.
   - 2026-02-18: Added TestStyledUpdateNotice, TestFetchReleaseNotes, TestVersionSeen.
   - 2026-02-16: Initial tests for PyPI version check with caching.
 """
@@ -10,13 +12,19 @@ import time
 from unittest.mock import patch
 
 from pocketpaw.update_check import (
+    ANNOUNCEMENT_CACHE_FILENAME,
     CACHE_FILENAME,
     CACHE_TTL,
     RELEASE_NOTES_CACHE_DIR,
     _parse_version,
     check_for_updates,
+    check_for_updates_full,
+    fetch_latest_json,
     fetch_release_notes,
+    format_admin_update_message,
+    get_last_notified_version,
     get_last_seen_version,
+    mark_version_notified,
     mark_version_seen,
     print_styled_update_notice,
     print_update_notice,
@@ -284,3 +292,248 @@ class TestVersionSeen:
         mark_version_seen("0.4.1", tmp_path)
         mark_version_seen("0.4.2", tmp_path)
         assert get_last_seen_version(tmp_path) == "0.4.2"
+
+
+# ---------------------------------------------------------------------------
+# Paw-to-Paw Phase 1 tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchLatestJson:
+    def test_fetch_and_cache(self, tmp_path):
+        """Fetches latest.json and caches the result."""
+        payload = json.dumps(
+            {
+                "version": "0.5.0",
+                "announcement": "New feature!",
+                "urgency": "info",
+                "url": "https://example.com",
+            }
+        ).encode()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = lambda s: s
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            mock_urlopen.return_value.read.return_value = payload
+
+            result = fetch_latest_json(tmp_path)
+
+        assert result is not None
+        assert result["version"] == "0.5.0"
+        assert result["announcement"] == "New feature!"
+        assert result["urgency"] == "info"
+        assert result["url"] == "https://example.com"
+
+        # Cache written
+        cache_file = tmp_path / ANNOUNCEMENT_CACHE_FILENAME
+        assert cache_file.exists()
+
+    def test_uses_cached_data(self, tmp_path):
+        """Returns cached data without fetching."""
+        cache_file = tmp_path / ANNOUNCEMENT_CACHE_FILENAME
+        cached = {
+            "ts": time.time(),
+            "data": {
+                "version": "0.5.0",
+                "announcement": "cached msg",
+                "urgency": "warning",
+                "url": "",
+            },
+        }
+        cache_file.write_text(json.dumps(cached))
+
+        result = fetch_latest_json(tmp_path)
+        assert result is not None
+        assert result["announcement"] == "cached msg"
+        assert result["urgency"] == "warning"
+
+    def test_returns_none_on_network_error(self, tmp_path):
+        """Network errors return None."""
+        with patch("urllib.request.urlopen", side_effect=Exception("no network")):
+            result = fetch_latest_json(tmp_path)
+        assert result is None
+
+    def test_returns_none_on_missing_version_field(self, tmp_path):
+        """Rejects payloads without a version field."""
+        payload = json.dumps({"announcement": "hello"}).encode()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = lambda s: s
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            mock_urlopen.return_value.read.return_value = payload
+
+            result = fetch_latest_json(tmp_path)
+        assert result is None
+
+    def test_defaults_missing_optional_fields(self, tmp_path):
+        """Optional fields default to empty strings."""
+        payload = json.dumps({"version": "0.5.0"}).encode()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value.__enter__ = lambda s: s
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            mock_urlopen.return_value.read.return_value = payload
+
+            result = fetch_latest_json(tmp_path)
+
+        assert result is not None
+        assert result["announcement"] == ""
+        assert result["urgency"] == "info"
+        assert result["url"] == ""
+
+
+class TestCheckForUpdatesFull:
+    def test_merges_pypi_and_latest_json(self, tmp_path):
+        """Combines PyPI version info with latest.json announcements."""
+        # Seed PyPI cache
+        cache_file = tmp_path / CACHE_FILENAME
+        cache_file.write_text(json.dumps({"ts": time.time(), "latest": "0.5.0"}))
+
+        # Seed announcement cache
+        ann_cache = tmp_path / ANNOUNCEMENT_CACHE_FILENAME
+        ann_cache.write_text(
+            json.dumps(
+                {
+                    "ts": time.time(),
+                    "data": {
+                        "version": "0.5.0",
+                        "announcement": "Big update!",
+                        "urgency": "warning",
+                        "url": "https://example.com/update",
+                    },
+                }
+            )
+        )
+
+        result = check_for_updates_full("0.4.8", tmp_path)
+
+        assert result["current"] == "0.4.8"
+        assert result["latest"] == "0.5.0"
+        assert result["update_available"] is True
+        assert result["announcement"] == "Big update!"
+        assert result["urgency"] == "warning"
+        assert result["announcement_url"] == "https://example.com/update"
+
+    def test_latest_json_version_takes_precedence(self, tmp_path):
+        """latest.json version overrides PyPI if newer."""
+        # PyPI says 0.5.0
+        cache_file = tmp_path / CACHE_FILENAME
+        cache_file.write_text(json.dumps({"ts": time.time(), "latest": "0.5.0"}))
+
+        # latest.json says 0.5.1
+        ann_cache = tmp_path / ANNOUNCEMENT_CACHE_FILENAME
+        ann_cache.write_text(
+            json.dumps(
+                {
+                    "ts": time.time(),
+                    "data": {"version": "0.5.1", "announcement": "", "urgency": "info", "url": ""},
+                }
+            )
+        )
+
+        result = check_for_updates_full("0.4.8", tmp_path)
+        assert result["latest"] == "0.5.1"
+
+    def test_works_without_latest_json(self, tmp_path):
+        """Falls back gracefully when latest.json is unavailable."""
+        cache_file = tmp_path / CACHE_FILENAME
+        cache_file.write_text(json.dumps({"ts": time.time(), "latest": "0.5.0"}))
+
+        result = check_for_updates_full("0.4.8", tmp_path)
+
+        assert result["update_available"] is True
+        assert result["announcement"] == ""
+        assert result["urgency"] == "info"
+        assert result["announcement_url"] == ""
+
+    def test_announcement_only_no_update(self, tmp_path):
+        """Announcement can exist even when version is current."""
+        cache_file = tmp_path / CACHE_FILENAME
+        cache_file.write_text(json.dumps({"ts": time.time(), "latest": "0.4.8"}))
+
+        ann_cache = tmp_path / ANNOUNCEMENT_CACHE_FILENAME
+        ann_cache.write_text(
+            json.dumps(
+                {
+                    "ts": time.time(),
+                    "data": {
+                        "version": "0.4.8",
+                        "announcement": "Maintenance window tonight",
+                        "urgency": "info",
+                        "url": "",
+                    },
+                }
+            )
+        )
+
+        result = check_for_updates_full("0.4.8", tmp_path)
+        assert result["update_available"] is False
+        assert result["announcement"] == "Maintenance window tonight"
+
+
+class TestVersionNotified:
+    def test_initial_none(self, tmp_path):
+        """No notification record initially."""
+        assert get_last_notified_version(tmp_path) is None
+
+    def test_mark_and_get(self, tmp_path):
+        """Mark a version as notified, then retrieve it."""
+        mark_version_notified("0.5.0", tmp_path)
+        assert get_last_notified_version(tmp_path) == "0.5.0"
+
+    def test_preserves_existing_cache(self, tmp_path):
+        """Notification record doesn't destroy other cache fields."""
+        cache_file = tmp_path / CACHE_FILENAME
+        cache_file.write_text(json.dumps({"ts": 12345, "latest": "0.5.0"}))
+
+        mark_version_notified("0.5.0", tmp_path)
+
+        cache = json.loads(cache_file.read_text(encoding="utf-8"))
+        assert cache["ts"] == 12345
+        assert cache["latest"] == "0.5.0"
+        assert cache["last_notified_version"] == "0.5.0"
+
+    def test_updates_existing_notified(self, tmp_path):
+        """Updating last_notified_version overwrites old value."""
+        mark_version_notified("0.4.9", tmp_path)
+        mark_version_notified("0.5.0", tmp_path)
+        assert get_last_notified_version(tmp_path) == "0.5.0"
+
+
+class TestFormatAdminUpdateMessage:
+    def test_basic_message(self):
+        info = {"current": "0.4.8", "latest": "0.5.0"}
+        msg = format_admin_update_message(info)
+        assert "v0.4.8 -> v0.5.0" in msg
+        assert "pip install --upgrade pocketpaw" in msg
+        assert "Release notes" in msg
+
+    def test_includes_announcement(self):
+        info = {
+            "current": "0.4.8",
+            "latest": "0.5.0",
+            "announcement": "Critical security fix",
+        }
+        msg = format_admin_update_message(info)
+        assert "Critical security fix" in msg
+
+    def test_no_announcement(self):
+        info = {"current": "0.4.8", "latest": "0.5.0", "announcement": ""}
+        msg = format_admin_update_message(info)
+        assert "v0.4.8 -> v0.5.0" in msg
+
+
+class TestStyledNoticeWithAnnouncement:
+    def test_includes_announcement_text(self, capsys):
+        """Announcement text is shown in the CLI box."""
+        info = {
+            "current": "0.4.8",
+            "latest": "0.5.0",
+            "announcement": "Bug fixes for memory hang",
+        }
+        with (
+            patch("sys.stderr.isatty", return_value=True),
+            patch("pocketpaw.update_check.os.environ.get", return_value=None),
+        ):
+            print_styled_update_notice(info)
+        captured = capsys.readouterr()
+        assert "Bug fixes for memory hang" in captured.err
+        assert "0.5.0" in captured.err


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the Paw-to-Paw AI-native update and communication system from #573.

The core idea: instead of traditional notification patterns (banners, popups, email blasts), **the agent itself is the messenger**. Update and announcement info is injected into the agent's system prompt so it can mention them naturally in conversation, like "that memory issue you hit last week? Fixed in the latest update."

### AI-native delivery (the key differentiator)

- **Agent context injection**: Update/announcement data from `latest.json` is injected into the system prompt via `_build_update_context()` in the context builder pipeline
- The agent is instructed to weave updates naturally into conversation when relevant
- Critical announcements trigger proactive notification; info-level updates only surface when contextually appropriate (e.g. user hits a bug that was fixed)
- This bridges directly toward Phase 2's fully context-aware conversational delivery

### Infrastructure

- **`latest.json` announcement system**: Hosted JSON file (GitHub Pages) lets us broadcast messages to all PocketPaw instances without a new release. 1-hour cache, URL overridable via `POCKETPAW_LATEST_JSON_URL` env var
- **Combined update check** (`check_for_updates_full`): Merges PyPI version data (24h cache) with `latest.json` announcements (1h cache). `latest.json` version takes precedence if newer
- **v1 API endpoints**: `GET /api/v1/updates` and `POST /api/v1/updates/dismiss`. Legacy `/api/version` kept as backward-compat alias

### Fallback channels (for when users aren't chatting)

- **Dashboard banner**: Dismissible banner at the top of the dashboard, color-coded by urgency (blue/amber/red). Dismiss persisted to localStorage + backend
- **Enhanced CLI notice**: ANSI box now includes announcement text. Triggers on announcement-only too
- **One-time admin DM**: On startup, sends update notification to configured `notification_channels` (Telegram, Discord, Slack, etc.). Deduped per version

## Files changed

| File | What |
|---|---|
| `src/pocketpaw/bootstrap/context_builder.py` | Agent system prompt injection (`_build_update_context`) |
| `src/pocketpaw/update_check.py` | `fetch_latest_json`, `check_for_updates_full`, notification helpers |
| `src/pocketpaw/api/v1/updates.py` | New v1 router (GET + POST) |
| `src/pocketpaw/api/v1/__init__.py` | Router registration |
| `src/pocketpaw/dashboard.py` | Legacy endpoints with compat notes |
| `src/pocketpaw/dashboard_lifecycle.py` | Admin DM on startup |
| `src/pocketpaw/__main__.py` | CLI uses `check_for_updates_full` |
| `src/pocketpaw/frontend/js/app.js` | Banner state, v1 endpoints, dismiss logic |
| `src/pocketpaw/frontend/templates/base.html` | Banner HTML component |
| `docs/public/latest.json` | Deployable announcement file |
| `tests/test_update_check.py` | 25 new tests (context injection + update logic) |
| `tests/test_api_v1_updates.py` | 5 new v1 API tests |

## Test plan

- [x] All 53 update-related tests pass (23 existing + 30 new)
- [ ] Manual: chat with the agent when an update is available, verify it can mention the update naturally
- [ ] Manual: verify agent does NOT interrupt unrelated conversations with update notices
- [ ] Manual: set a critical announcement, verify agent proactively informs user
- [ ] Manual: start dashboard, verify banner appears when update is available
- [ ] Manual: dismiss banner, reload page, confirm it stays dismissed
- [ ] Manual: configure `notification_channels`, restart, verify admin DM sent once
- [ ] Manual: verify CLI ANSI box shows announcement text

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)