### PR TITLE
[FI] Avoid import-time writes during dashboard setup

### DIFF
--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -124,23 +124,38 @@ def _warn_old_config() -> None:
         )
 
 
-def get_config_dir() -> Path:
-    """Get the config directory, creating if needed."""
+def get_config_dir(create: bool = True) -> Path:
+    """Get the config directory.
+
+    Args:
+        create: When True, create the directory if needed. Read-only code paths
+            should pass False so importing or loading settings does not mutate
+            the user's home directory.
+    """
     config_dir = Path.home() / ".pocketpaw"
-    config_dir.mkdir(exist_ok=True)
-    _chmod_safe(config_dir, 0o700)
+    if create:
+        config_dir.mkdir(exist_ok=True)
+        _chmod_safe(config_dir, 0o700)
     _warn_old_config()
     return config_dir
 
 
-def get_config_path() -> Path:
+def _resolve_config_dir(*, create: bool) -> Path:
+    """Call ``get_config_dir`` while tolerating older no-arg monkeypatches in tests."""
+    try:
+        return get_config_dir(create=create)
+    except TypeError:
+        return get_config_dir()
+
+
+def get_config_path(create: bool = True) -> Path:
     """Get the config file path."""
-    return get_config_dir() / "config.json"
+    return _resolve_config_dir(create=create) / "config.json"
 
 
-def get_token_path() -> Path:
+def get_token_path(create: bool = True) -> Path:
     """Get the access token file path."""
-    return get_config_dir() / "access_token"
+    return _resolve_config_dir(create=create) / "access_token"
 
 
 # Telegram bot token format: numeric id + colon + alphanumeric secret
@@ -744,7 +759,7 @@ class Settings(BaseSettings):
         # Run one-time migration from plaintext config
         _migrate_plaintext_keys()
 
-        config_path = get_config_path()
+        config_path = get_config_path(create=False)
         data: dict = {}
         if config_path.exists():
             try:
@@ -804,25 +819,22 @@ def regenerate_token() -> str:
     return token
 
 
-# Flag file to avoid re-running migration on every load
-_MIGRATION_DONE_PATH: Path | None = None
-
-
 def _migrate_plaintext_keys() -> None:
-    """One-time migration: move plaintext API keys from config.json to encrypted store."""
+    """Best-effort migration from plaintext config.json to encrypted secrets."""
     from pocketpaw.credentials import SECRET_FIELDS, get_credential_store
 
-    global _MIGRATION_DONE_PATH  # noqa: PLW0603
-    if _MIGRATION_DONE_PATH is None:
-        _MIGRATION_DONE_PATH = get_config_dir() / ".secrets_migrated"
-
-    if _MIGRATION_DONE_PATH.exists():
+    migration_done_path = _resolve_config_dir(create=False) / ".secrets_migrated"
+    if migration_done_path.exists():
         return
 
-    config_path = get_config_path()
+    config_path = get_config_path(create=False)
     if not config_path.exists():
         # No config yet — nothing to migrate
-        _MIGRATION_DONE_PATH.write_text("1")
+        try:
+            migration_done_path.write_text("1")
+            _chmod_safe(migration_done_path, 0o600)
+        except OSError:
+            logger.debug("Skipping migration marker write in read-only config dir", exc_info=True)
         return
 
     try:
@@ -830,17 +842,23 @@ def _migrate_plaintext_keys() -> None:
     except (json.JSONDecodeError, Exception):
         return
 
-    store = get_credential_store()
-    migrated_count = 0
-
-    for field in SECRET_FIELDS:
-        value = data.get(field)
-        if value and isinstance(value, str):
-            store.set(field, value)
-            migrated_count += 1
+    try:
+        store = get_credential_store()
+        migrated_count = 0
+        for field in SECRET_FIELDS:
+            value = data.get(field)
+            if value and isinstance(value, str):
+                store.set(field, value)
+                migrated_count += 1
+    except Exception:
+        logger.debug("Skipping plaintext key migration in read-only config dir", exc_info=True)
+        return
 
     if migrated_count:
         logger.info("Copied %d secret(s) from config to encrypted store.", migrated_count)
 
-    _MIGRATION_DONE_PATH.write_text("1")
-    _chmod_safe(_MIGRATION_DONE_PATH, 0o600)
+    try:
+        migration_done_path.write_text("1")
+        _chmod_safe(migration_done_path, 0o600)
+    except OSError:
+        logger.debug("Skipping migration marker write in read-only config dir", exc_info=True)

--- a/src/pocketpaw/dashboard_state.py
+++ b/src/pocketpaw/dashboard_state.py
@@ -21,7 +21,32 @@ except ImportError:
 # ── Singletons ──────────────────────────────────────────────────────────────
 
 ws_adapter = WebSocketAdapter()
-agent_loop = AgentLoop()
+
+
+class _LazyAgentLoopProxy:
+    """Instantiate the dashboard agent loop only when code actually uses it."""
+
+    def __init__(self):
+        object.__setattr__(self, "_loop", None)
+
+    def _get_loop(self) -> AgentLoop:
+        loop = object.__getattribute__(self, "_loop")
+        if loop is None:
+            loop = AgentLoop()
+            object.__setattr__(self, "_loop", loop)
+        return loop
+
+    def __getattr__(self, name: str):
+        return getattr(self._get_loop(), name)
+
+    def __setattr__(self, name: str, value):
+        if name == "_loop":
+            object.__setattr__(self, name, value)
+            return
+        setattr(self._get_loop(), name, value)
+
+
+agent_loop = _LazyAgentLoopProxy()
 
 # Wire up the agent loop so /kill can cancel in-flight sessions
 _get_cmd_handler().set_agent_loop(agent_loop)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -212,8 +212,7 @@ class TestConfigSecretSeparation:
         test_store = CredentialStore(config_dir=tmp_path)
 
         original_fn = cfg.get_config_dir
-        cfg.get_config_dir = lambda: tmp_path
-        cfg._MIGRATION_DONE_PATH = None
+        cfg.get_config_dir = lambda *args, **kwargs: tmp_path
 
         # Mark migration as done so it doesn't interfere
         (tmp_path / ".secrets_migrated").write_text("1")
@@ -387,8 +386,7 @@ class TestPlaintextMigration:
         test_store = CredentialStore(config_dir=tmp_path)
 
         original_fn = cfg.get_config_dir
-        cfg.get_config_dir = lambda: tmp_path
-        cfg._MIGRATION_DONE_PATH = None  # Force re-check
+        cfg.get_config_dir = lambda *args, **kwargs: tmp_path
 
         with patch.object(creds, "get_credential_store", return_value=test_store):
             yield {
@@ -450,7 +448,6 @@ class TestPlaintextMigration:
 
     def test_migration_runs_only_once(self, env):
         """If the flag file exists, migration should not re-run."""
-        import pocketpaw.config as cfg
         from pocketpaw.config import Settings
 
         # Write config with plaintext key
@@ -459,7 +456,6 @@ class TestPlaintextMigration:
 
         # Pre-set the flag
         (env["tmp_path"] / ".secrets_migrated").write_text("1")
-        cfg._MIGRATION_DONE_PATH = env["tmp_path"] / ".secrets_migrated"
 
         Settings.load()
 

--- a/tests/test_import_side_effects.py
+++ b/tests/test_import_side_effects.py
@@ -1,0 +1,78 @@
+"""Regression tests for import-time filesystem side effects."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Read-only HOME simulation relies on POSIX chmod semantics",
+)
+
+
+def _run_in_read_only_home(tmp_path, code: str) -> subprocess.CompletedProcess[str]:
+    home = tmp_path / "home"
+    home.mkdir()
+    home.chmod(stat.S_IREAD | stat.S_IEXEC)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
+
+    pythonpath = env.get("PYTHONPATH")
+    repo_src = str((REPO_ROOT / "src").resolve())
+    env["PYTHONPATH"] = repo_src if not pythonpath else os.pathsep.join([repo_src, pythonpath])
+
+    try:
+        return subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(REPO_ROOT),
+            check=False,
+        )
+    finally:
+        home.chmod(stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC)
+
+
+def test_settings_load_does_not_require_writable_home(tmp_path):
+    result = _run_in_read_only_home(
+        tmp_path,
+        "from pocketpaw.config import Settings; Settings.load(); print('ok')",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+    assert not (tmp_path / "home" / ".pocketpaw").exists()
+
+
+def test_create_api_app_does_not_require_writable_home(tmp_path):
+    result = _run_in_read_only_home(
+        tmp_path,
+        "from pocketpaw.api.serve import create_api_app; create_api_app(); print('ok')",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+    assert not (tmp_path / "home" / ".pocketpaw").exists()
+
+
+def test_dashboard_import_does_not_require_writable_home(tmp_path):
+    result = _run_in_read_only_home(
+        tmp_path,
+        "import pocketpaw.dashboard; print('ok')",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+    assert not (tmp_path / "home" / ".pocketpaw").exists()


### PR DESCRIPTION
## What does this PR do?

Prevents dashboard-related read paths from writing to ~/.pocketpaw during import or app creation. This fixes PermissionError failures in read-only homes, sandboxed CI, and other restricted environments before PocketPaw startup has even begun.

## Related Issue

Fixes #592

## Changes Made

- src/pocketpaw/config.py: allow config-path helpers to read without creating ~/.pocketpaw, and make plaintext-key migration best-effort on read-only homes
- src/pocketpaw/dashboard_state.py: replace eager AgentLoop singleton construction with a lazy proxy so importing dashboard modules does not initialize memory/config state
- tests/test_import_side_effects.py: add subprocess regressions for Settings.load(), create_api_app(), and import pocketpaw.dashboard under a non-writable HOME
- tests/test_credentials.py: update config-dir monkeypatches to stay compatible with the non-creating read path

## How to Test

1. Use a non-writable HOME and run python -c "import pocketpaw.dashboard"
2. Use a non-writable HOME and run python -c "from pocketpaw.api.serve import create_api_app; create_api_app()"
3. Verify both commands succeed and do not create ~/.pocketpaw
4. Run the updated regression tests

## Evidence of Testing

```
./.venv/bin/python -m ruff check src/pocketpaw/config.py src/pocketpaw/dashboard_state.py tests/test_credentials.py tests/test_import_side_effects.py
All checks passed!

HOME=$(pwd)/.home ./.venv/bin/python -m pytest -q tests/test_import_side_effects.py tests/test_credentials.py tests/test_api_serve.py tests/test_api_v1_channels.py
75 passed, 64 warnings in 9.24s

HOME=$(pwd)/.home ./.venv/bin/python -m pytest -q tests --ignore=tests/e2e --ignore=tests/test_launcher_server.py --ignore=tests/test_neonize_adapter.py --ignore=tests/test_teams_adapter.py --ignore=tests/test_tools.py --ignore=tests/test_tools_sysinfo.py
2918 passed, 26 skipped, 68 warnings in 35.67s
```

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [ ] I have run PocketPaw locally and tested my changes
- [ ] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [ ] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff
