### PR TITLE
[FI] Fix missing WebSocket routes in dashboard for frontend connection

### DIFF
--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -1079,13 +1079,12 @@ async def get_telegram_pairing_status():
     return {"paired": paired, "user_id": user_id}
 
 
-@app.websocket("/ws")
-async def websocket_endpoint(
+async def _handle_dashboard_ws(
     websocket: WebSocket,
-    token: str | None = Query(None),
-    resume_session: str | None = Query(None),
+    token: str | None,
+    resume_session: str | None,
 ):
-    """WebSocket endpoint — delegates to dashboard_ws.websocket_handler()."""
+    """Shared WebSocket handler for /ws and /api/v1/ws."""
     from pocketpaw.dashboard_ws import websocket_handler
 
     await websocket_handler(
@@ -1095,6 +1094,36 @@ async def websocket_endpoint(
         _is_genuine_localhost_fn=_is_genuine_localhost,
         _get_access_token_fn=get_access_token,
     )
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(
+    websocket: WebSocket,
+    token: str | None = Query(None),
+    resume_session: str | None = Query(None),
+):
+    """WebSocket endpoint — delegates to dashboard_ws.websocket_handler()."""
+    await _handle_dashboard_ws(websocket, token, resume_session)
+
+
+@app.websocket("/api/v1/ws")
+async def websocket_v1_endpoint(
+    websocket: WebSocket,
+    token: str | None = Query(None),
+    resume_session: str | None = Query(None),
+):
+    """WebSocket v1 endpoint — matches client's API_PREFIX + /ws path."""
+    await _handle_dashboard_ws(websocket, token, resume_session)
+
+
+@app.websocket("/v1/ws")
+async def websocket_v1_short_endpoint(
+    websocket: WebSocket,
+    token: str | None = Query(None),
+    resume_session: str | None = Query(None),
+):
+    """WebSocket v1 short path — for clients using /v1/ws."""
+    await _handle_dashboard_ws(websocket, token, resume_session)
 
 
 # ==================== Transparency APIs ====================


### PR DESCRIPTION
## What does this PR do?

The SvelteKit desktop client connects to the backend WebSocket endpoint at:

`ws://localhost:8888/api/v1/ws`

However, the dashboard server only exposed the `/ws` WebSocket route. The `/api/v1/ws` route existed in `serve.py` (API-only mode) but was missing from `dashboard.py`.

Because of this mismatch, WebSocket upgrade requests from the frontend returned **HTTP 403**, preventing the frontend client from connecting during local development.

This PR adds the missing routes `/api/v1/ws` and `/v1/ws` in `dashboard.py`, delegating them to the same handler used by `/ws`.

---

## Related Issue

Fixes #<issue-number>

---

## Changes Made

* `src/pocketpaw/dashboard.py`: Added missing WebSocket routes `/api/v1/ws` and `/v1/ws` and delegated them to the existing `/ws` handler.

---

## How to Test

1. Start backend:

```
uv run pocketpaw --dev
```

2. Start frontend:

```
cd client
bun run dev
```

3. Open the frontend dashboard.

4. Verify that the frontend successfully establishes a WebSocket connection with the backend.

---

## Evidence of Testing

Backend and frontend were run locally to reproduce the issue.

Example logs:

```
INFO: 127.0.0.1 "GET /api/mission-control/notifications HTTP/1.1" 200 OK
vite v6.4.1 ready in ~1095 ms
Local: http://localhost:1420/
```

Before the fix, the frontend attempted to connect to:

`ws://localhost:8888/api/v1/ws`

and received **HTTP 403** because the route was not registered in `dashboard.py`.

After adding the routes `/api/v1/ws` and `/v1/ws`, the frontend successfully connects to the backend WebSocket.

---

## Checklist

* [x] PR targets `dev` branch (not `main`)
* [x] Linked to an existing issue
* [x] I have run PocketPaw locally and tested my changes
* [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
* [x] Linting passes (`uv run ruff check .`)
* [ ] I have added/updated tests if applicable
* [x] No unrelated changes bundled in this PR
* [x] No secrets or credentials in the diff

Fixes #610
