### PR TITLE
fix: add gt=0/ge=0 constraints to numeric settings in config.py (#629)

### DIFF
--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -378,13 +378,13 @@ class Settings(BaseSettings):
 
     # Session History Compaction
     compaction_recent_window: int = Field(
-        default=10, description="Number of recent messages to keep verbatim"
+        default=10, gt=0, description="Number of recent messages to keep verbatim"
     )
     compaction_char_budget: int = Field(
-        default=8000, description="Max total chars for compacted history"
+        default=8000, gt=0, description="Max total chars for compacted history"
     )
     compaction_summary_chars: int = Field(
-        default=150, description="Max chars per older message one-liner extract"
+        default=150, gt=0, description="Max chars per older message one-liner extract"
     )
     compaction_llm_summarize: bool = Field(
         default=False, description="Use Haiku to summarize older messages (opt-in)"
@@ -486,7 +486,9 @@ class Settings(BaseSettings):
         description="Allow unauthenticated localhost access (disable for non-CF proxies)",
     )
     session_token_ttl_hours: int = Field(
-        default=24, description="TTL in hours for HMAC session tokens issued via /api/auth/session"
+        default=24,
+        gt=0,
+        description="TTL in hours for HMAC session tokens issued via /api/auth/session",
     )
     api_cors_allowed_origins: list[str] = Field(
         default_factory=list,
@@ -494,6 +496,7 @@ class Settings(BaseSettings):
     )
     api_rate_limit_per_key: int = Field(
         default=60,
+        gt=0,
         description="Max requests per minute per API key (token-bucket capacity)",
     )
     file_jail_path: Path = Field(
@@ -713,7 +716,7 @@ class Settings(BaseSettings):
         default="", description="Custom media download dir (default: ~/.pocketpaw/media/)"
     )
     media_max_file_size_mb: int = Field(
-        default=50, description="Max media file size in MB (0 = unlimited)"
+        default=50, ge=0, description="Max media file size in MB (0 = unlimited)"
     )
 
     # UX
@@ -730,7 +733,7 @@ class Settings(BaseSettings):
 
     # Concurrency
     max_concurrent_conversations: int = Field(
-        default=5, description="Max parallel conversations processed simultaneously"
+        default=5, gt=0, description="Max parallel conversations processed simultaneously"
     )
 
     def save(self) -> None:

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,6 +1,11 @@
-"""Tests for config.py API key validation."""
+"""Tests for config.py API key validation and numeric field constraints."""
 
-from pocketpaw.config import validate_api_key
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from pocketpaw.config import Settings, validate_api_key
 
 
 class TestValidateApiKey:
@@ -158,3 +163,132 @@ class TestValidateApiKey:
         assert len(result) == 2
         assert isinstance(result[0], bool)
         assert isinstance(result[1], str)
+
+
+class TestNumericFieldConstraints:
+    """Tests for gt/ge constraints on numeric settings in Settings (issue #629)."""
+
+    # ─── compaction_recent_window ───────────────────────────────────────────
+
+    def test_compaction_recent_window_zero_rejected(self):
+        """compaction_recent_window=0 must raise a ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(compaction_recent_window=0)
+
+    def test_compaction_recent_window_negative_rejected(self):
+        """compaction_recent_window=-1 must raise a ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(compaction_recent_window=-1)
+
+    def test_compaction_recent_window_positive_accepted(self):
+        """compaction_recent_window=1 must be accepted."""
+        s = Settings(compaction_recent_window=1)
+        assert s.compaction_recent_window == 1
+
+    # ─── compaction_char_budget ─────────────────────────────────────────────
+
+    def test_compaction_char_budget_zero_rejected(self):
+        """compaction_char_budget=0 must raise a ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(compaction_char_budget=0)
+
+    def test_compaction_char_budget_negative_rejected(self):
+        """compaction_char_budget=-100 must raise a ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(compaction_char_budget=-100)
+
+    def test_compaction_char_budget_positive_accepted(self):
+        """compaction_char_budget=1 must be accepted."""
+        s = Settings(compaction_char_budget=1)
+        assert s.compaction_char_budget == 1
+
+    # ─── compaction_summary_chars ───────────────────────────────────────────
+
+    def test_compaction_summary_chars_zero_rejected(self):
+        """compaction_summary_chars=0 must raise a ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(compaction_summary_chars=0)
+
+    def test_compaction_summary_chars_negative_rejected(self):
+        """compaction_summary_chars=-5 must raise a ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(compaction_summary_chars=-5)
+
+    def test_compaction_summary_chars_positive_accepted(self):
+        """compaction_summary_chars=1 must be accepted."""
+        s = Settings(compaction_summary_chars=1)
+        assert s.compaction_summary_chars == 1
+
+    # ─── session_token_ttl_hours ────────────────────────────────────────────
+
+    def test_session_token_ttl_hours_zero_rejected(self):
+        """session_token_ttl_hours=0 must raise a ValidationError.
+
+        Zero TTL means all session tokens are immediately expired.
+        """
+        with pytest.raises(ValidationError):
+            Settings(session_token_ttl_hours=0)
+
+    def test_session_token_ttl_hours_negative_rejected(self):
+        """session_token_ttl_hours=-1 must raise a ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(session_token_ttl_hours=-1)
+
+    def test_session_token_ttl_hours_positive_accepted(self):
+        """session_token_ttl_hours=1 must be accepted."""
+        s = Settings(session_token_ttl_hours=1)
+        assert s.session_token_ttl_hours == 1
+
+    # ─── api_rate_limit_per_key ─────────────────────────────────────────────
+
+    def test_api_rate_limit_per_key_zero_rejected(self):
+        """api_rate_limit_per_key=0 must raise a ValidationError.
+
+        Zero capacity causes the rate limiter to reject every request.
+        """
+        with pytest.raises(ValidationError):
+            Settings(api_rate_limit_per_key=0)
+
+    def test_api_rate_limit_per_key_negative_rejected(self):
+        """api_rate_limit_per_key=-10 must raise a ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(api_rate_limit_per_key=-10)
+
+    def test_api_rate_limit_per_key_positive_accepted(self):
+        """api_rate_limit_per_key=1 must be accepted."""
+        s = Settings(api_rate_limit_per_key=1)
+        assert s.api_rate_limit_per_key == 1
+
+    # ─── media_max_file_size_mb ─────────────────────────────────────────────
+
+    def test_media_max_file_size_mb_zero_accepted(self):
+        """media_max_file_size_mb=0 must be accepted (documented as unlimited)."""
+        s = Settings(media_max_file_size_mb=0)
+        assert s.media_max_file_size_mb == 0
+
+    def test_media_max_file_size_mb_negative_rejected(self):
+        """media_max_file_size_mb=-1 must raise a ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(media_max_file_size_mb=-1)
+
+    def test_media_max_file_size_mb_positive_accepted(self):
+        """media_max_file_size_mb=100 must be accepted."""
+        s = Settings(media_max_file_size_mb=100)
+        assert s.media_max_file_size_mb == 100
+
+    # ─── max_concurrent_conversations ───────────────────────────────────────
+
+    def test_max_concurrent_conversations_zero_rejected(self):
+        """max_concurrent_conversations=0 must raise a ValidationError (zero limit deadlocks)."""
+        with pytest.raises(ValidationError):
+            Settings(max_concurrent_conversations=0)
+
+    def test_max_concurrent_conversations_negative_rejected(self):
+        """max_concurrent_conversations=-3 must raise a ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(max_concurrent_conversations=-3)
+
+    def test_max_concurrent_conversations_positive_accepted(self):
+        """max_concurrent_conversations=1 must be accepted."""
+        s = Settings(max_concurrent_conversations=1)
+        assert s.max_concurrent_conversations == 1


### PR DESCRIPTION
## What does this PR do?

Seven `int` fields in `config.py` had no lower-bound constraint, so Pydantic silently accepted `0` and negative values. This caused hard-to-diagnose runtime failures (empty compacted history, immediately-expired session tokens, a rate limiter that rejects every request, etc.). Adding `gt=0` / `ge=0` to the Pydantic `Field()` calls makes Pydantic raise a clear `ValidationError` at startup instead.

## Related Issue

Fixes #629

## Changes Made

- `src/pocketpaw/config.py`: added `gt=0` to `compaction_recent_window`, `compaction_char_budget`, `compaction_summary_chars`, `session_token_ttl_hours`, `api_rate_limit_per_key`, and `max_concurrent_conversations`; added `ge=0` to `media_max_file_size_mb` (0 is documented as "unlimited" so it must remain valid).
- `tests/test_config_validation.py`: added `TestNumericFieldConstraints` class with 21 tests covering zero, negative, and positive values for every constrained field; also added `from __future__ import annotations` and updated imports.

## How to Test

1. Run the test file:
   ```
   uv run pytest tests/test_config_validation.py -v
   ```
2. Verify all 43 tests pass.
3. Optionally try setting e.g. `POCKETPAW_API_RATE_LIMIT_PER_KEY=0` and running `uv run pocketpaw` — it should fail with a `ValidationError` on startup rather than silently accepting the bad value.

## Evidence of Testing

```
tests/test_config_validation.py::TestNumericFieldConstraints::test_compaction_recent_window_zero_rejected PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_compaction_recent_window_negative_rejected PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_compaction_recent_window_positive_accepted PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_compaction_char_budget_zero_rejected PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_compaction_char_budget_negative_rejected PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_compaction_char_budget_positive_accepted PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_compaction_summary_chars_zero_rejected PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_compaction_summary_chars_negative_rejected PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_compaction_summary_chars_positive_accepted PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_session_token_ttl_hours_zero_rejected PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_session_token_ttl_hours_negative_rejected PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_session_token_ttl_hours_positive_accepted PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_api_rate_limit_per_key_zero_rejected PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_api_rate_limit_per_key_negative_rejected PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_api_rate_limit_per_key_positive_accepted PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_media_max_file_size_mb_zero_accepted PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_media_max_file_size_mb_negative_rejected PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_media_max_file_size_mb_positive_accepted PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_max_concurrent_conversations_zero_rejected PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_max_concurrent_conversations_negative_rejected PASSED
tests/test_config_validation.py::TestNumericFieldConstraints::test_max_concurrent_conversations_positive_accepted PASSED
============================== 43 passed in 0.10s ==============================
```

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff