### PR TITLE
fix(codex_cli): increase subprocess buffer limit to prevent chunk parsing errors

### DIFF
--- a/src/pocketpaw/agents/codex_cli.py
+++ b/src/pocketpaw/agents/codex_cli.py
@@ -358,7 +358,10 @@ class CodexCLIBackend:
             yield AgentEvent(type="done", content="")
 
         except (asyncio.LimitOverrunError, asyncio.IncompleteReadError) as e:
-            logger.warning("Codex CLI output exceeded buffer limit, skipping event: %s", e)
+            logger.warning("Codex CLI session terminated: stdout buffer exceeded: %s", e)
+            self._process = None
+            yield AgentEvent(type="error", content="Codex CLI output exceeded buffer limit")
+            yield AgentEvent(type="done", content="")
         except Exception as e:
             logger.error("Codex CLI error: %s", e)
             yield AgentEvent(type="error", content=f"Codex CLI error: {e}")

--- a/tests/test_codex_cli_backend.py
+++ b/tests/test_codex_cli_backend.py
@@ -846,8 +846,11 @@ class TestCodexCLIBufferLimit:
             async for event in backend.run("test"):
                 events.append(event)
 
-        # Should not crash; the session completes without raising
-        assert len(events) >= 0  # no exception was raised
+        # Should not crash; yields error + done instead of raising
+        error_events = [e for e in events if e.type == "error"]
+        assert len(error_events) == 1
+        assert "buffer limit" in error_events[0].content
+        assert events[-1].type == "done"
 
 
 class TestCodexCLIRegistry:


### PR DESCRIPTION
## Summary
- Increases the asyncio subprocess stdout buffer from 64 KiB (default) to 10 MiB, fixing `LimitOverrunError` when Codex CLI emits large NDJSON events (e.g., Playwright MCP tool results, large code completions)
- Adds graceful handling for `LimitOverrunError` and `IncompleteReadError` so the session logs a warning instead of crashing
- Adds 4 new tests covering buffer limit propagation, large MCP output parsing, and overrun recovery

Fixes #601

## Test plan
- [x] `uv run pytest tests/test_codex_cli_backend.py` - all 39 tests pass
- [x] `uv run ruff check` - no lint issues
- [x] Manual test with Codex CLI + Playwright MCP (requires Codex CLI + OpenAI key)