### PR TITLE
fix(guardian): handle empty API response with fail-closed default

### DIFF
--- a/src/pocketpaw/security/guardian.py
+++ b/src/pocketpaw/security/guardian.py
@@ -118,12 +118,6 @@ Respond with valid JSON only:
                 messages=[{"role": "user", "content": f"Command: {command}"}],
             )
             if not response.content:
-                logger.warning(
-                    "Guardian received empty response from API — defaulting to DANGEROUS"
-                )
-                return False, "Guardian received empty API response (fail-closed)"
-
-            if not response.content:
                 self._audit.log(
                     AuditEvent.create(
                         severity=AuditSeverity.ALERT,
@@ -134,6 +128,9 @@ Respond with valid JSON only:
                         reason="Empty safety response",
                         command=command,
                     )
+                )
+                logger.warning(
+                    "Guardian received empty response from API - defaulting to DANGEROUS"
                 )
                 return False, "Guardian received empty response from API, defaulting to block"
 

--- a/tests/test_guardian.py
+++ b/tests/test_guardian.py
@@ -1,4 +1,4 @@
-"""Tests for GuardianAgent — security/guardian.py"""
+"""Tests for GuardianAgent - security/guardian.py"""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -19,7 +19,7 @@ def guardian():
 
 
 class TestGuardianEmptyResponse:
-    """Tests for fix: issue #636 — empty API response causes IndexError."""
+    """Tests for fix: issue #636 - empty API response causes IndexError."""
 
     @pytest.mark.asyncio
     async def test_empty_content_returns_dangerous(self, guardian):


### PR DESCRIPTION
## What does this PR do?

`Guardian.check_command()` accessed `response.content[0].text` without
checking if the content list was empty. When the Anthropic API returns
an empty content list (transient error, content filtering, etc.) this
raised an `IndexError`, bypassing the safety check entirely.

Fix adds an explicit guard that defaults to DANGEROUS (fail-closed)
when an empty response is received, logging a warning.

## Related Issue

Fixes #636

## Changes Made

- `src/pocketpaw/security/guardian.py`: added empty content guard before
  accessing `response.content[0].text`
- `tests/test_guardian.py`: new test file with 4 tests covering empty
  response handling and regression tests for normal safe/dangerous responses

## How to Test

1. Run `uv run pytest tests/test_guardian.py -v`
2. All 4 tests should pass

## Evidence of Testing

collected 4 items

tests/test_guardian.py::TestGuardianEmptyResponse::test_empty_content_returns_dangerous PASSED                [ 25%]
tests/test_guardian.py::TestGuardianEmptyResponse::test_empty_content_does_not_raise PASSED                   [ 50%]
tests/test_guardian.py::TestGuardianEmptyResponse::test_valid_safe_response_still_works PASSED                [ 75%]
tests/test_guardian.py::TestGuardianEmptyResponse::test_valid_dangerous_response_still_blocked PASSED         [100%]

4 passed in 0.31s

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest tests/test_guardian.py -v`)
- [x] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff