### PR TITLE
fix: close IP detection socket via context manager to prevent resource leak

### DIFF
--- a/src/pocketpaw/api/serve.py
+++ b/src/pocketpaw/api/serve.py
@@ -146,10 +146,9 @@ def run_api_server(
         import socket
 
         try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            s.connect(("8.8.8.8", 80))
-            local_ip = s.getsockname()[0]
-            s.close()
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+                s.connect(("8.8.8.8", 80))
+                local_ip = s.getsockname()[0]
         except Exception:
             local_ip = "<your-server-ip>"
         print(f"\n\U0001f310 API docs: http://{local_ip}:{port}/api/v1/docs")

--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -1679,10 +1679,9 @@ def run_dashboard(
             import socket
 
             try:
-                s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                s.connect(("8.8.8.8", 80))
-                local_ip = s.getsockname()[0]
-                s.close()
+                with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+                    s.connect(("8.8.8.8", 80))
+                    local_ip = s.getsockname()[0]
             except Exception:
                 local_ip = "<your-server-ip>"
             print(f"\n🌐 Open http://{local_ip}:{port} in your browser")

--- a/tests/test_api_serve.py
+++ b/tests/test_api_serve.py
@@ -1,6 +1,7 @@
 """Tests for the ``pocketpaw serve`` API-only server."""
 
-from unittest.mock import patch
+import socket
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -174,3 +175,128 @@ class TestServeCommand:
         assert args.command == "serve"
         assert args.host == "0.0.0.0"
         assert args.port == 9000
+
+
+# ---------------------------------------------------------------------------
+# Socket resource safety (issue #608)
+# ---------------------------------------------------------------------------
+
+
+class TestSocketResourceSafety:
+    """Verify the local-IP detection socket is always closed — even on error.
+
+    Regression tests for the resource leak reported in issue #608:
+    s.close() was only called on the happy path, leaving the socket open
+    whenever connect() or getsockname() raised an exception.
+    """
+
+    def _make_mock_socket(self) -> MagicMock:
+        """Return a MagicMock that looks enough like a socket.socket."""
+        sock = MagicMock(spec=socket.socket)
+        # Make it usable as a context manager (__enter__ returns itself,
+        # __exit__ calls close — same as the real socket implementation).
+        sock.__enter__ = MagicMock(return_value=sock)
+        sock.__exit__ = MagicMock(return_value=False)
+        return sock
+
+    def test_serve_socket_closed_on_success(self):
+        """Socket must be closed after successful IP detection."""
+        mock_sock = self._make_mock_socket()
+        mock_sock.getsockname.return_value = ("192.168.1.100", 0)
+
+        with (
+            patch("socket.socket", return_value=mock_sock),
+            patch("uvicorn.run"),
+        ):
+            from pocketpaw.api.serve import run_api_server
+
+            run_api_server(host="0.0.0.0", port=9999)
+
+        # __exit__ is how the context manager closes the socket
+        mock_sock.__exit__.assert_called_once()
+
+    def test_serve_socket_closed_on_connect_error(self):
+        """Socket must be closed even when connect() raises."""
+        mock_sock = self._make_mock_socket()
+        mock_sock.connect.side_effect = OSError("Network unreachable")
+
+        with (
+            patch("socket.socket", return_value=mock_sock),
+            patch("uvicorn.run"),
+        ):
+            from pocketpaw.api.serve import run_api_server
+
+            # Should not raise — falls back to placeholder IP
+            run_api_server(host="0.0.0.0", port=9999)
+
+        mock_sock.__exit__.assert_called_once()
+
+    def test_serve_socket_closed_on_getsockname_error(self):
+        """Socket must be closed even when getsockname() raises."""
+        mock_sock = self._make_mock_socket()
+        mock_sock.getsockname.side_effect = OSError("Socket error")
+
+        with (
+            patch("socket.socket", return_value=mock_sock),
+            patch("uvicorn.run"),
+        ):
+            from pocketpaw.api.serve import run_api_server
+
+            run_api_server(host="0.0.0.0", port=9999)
+
+        mock_sock.__exit__.assert_called_once()
+
+    def test_serve_fallback_ip_used_on_error(self):
+        """When socket raises, the fallback placeholder should be printed."""
+        mock_sock = self._make_mock_socket()
+        mock_sock.connect.side_effect = OSError("Network unreachable")
+
+        with (
+            patch("socket.socket", return_value=mock_sock),
+            patch("uvicorn.run"),
+            patch("builtins.print") as mock_print,
+        ):
+            from pocketpaw.api.serve import run_api_server
+
+            run_api_server(host="0.0.0.0", port=9999)
+
+        printed = " ".join(str(c) for call in mock_print.call_args_list for c in call.args)
+        assert "<your-server-ip>" in printed
+
+    def test_dashboard_socket_closed_on_connect_error(self):
+        """dashboard.py IP detection socket must be closed even when connect() raises."""
+        mock_sock = self._make_mock_socket()
+        mock_sock.connect.side_effect = OSError("Network unreachable")
+
+        mock_uv_server = MagicMock()
+        mock_uv_server.run = MagicMock()  # no-op so the loop exits
+
+        with (
+            patch("socket.socket", return_value=mock_sock),
+            patch("pocketpaw.dashboard.uvicorn.Config", return_value=MagicMock()),
+            patch("pocketpaw.dashboard.uvicorn.Server", return_value=mock_uv_server),
+        ):
+            from pocketpaw.dashboard import run_dashboard
+
+            run_dashboard(host="0.0.0.0", port=9999, open_browser=False)
+
+        mock_sock.__exit__.assert_called_once()
+
+    def test_dashboard_socket_closed_on_success(self):
+        """dashboard.py IP detection socket must be closed on the happy path."""
+        mock_sock = self._make_mock_socket()
+        mock_sock.getsockname.return_value = ("10.0.0.1", 0)
+
+        mock_uv_server = MagicMock()
+        mock_uv_server.run = MagicMock()
+
+        with (
+            patch("socket.socket", return_value=mock_sock),
+            patch("pocketpaw.dashboard.uvicorn.Config", return_value=MagicMock()),
+            patch("pocketpaw.dashboard.uvicorn.Server", return_value=mock_uv_server),
+        ):
+            from pocketpaw.dashboard import run_dashboard
+
+            run_dashboard(host="0.0.0.0", port=9999, open_browser=False)
+
+        mock_sock.__exit__.assert_called_once()


### PR DESCRIPTION
Fixes #608

## What does this PR do?

Both `run_api_server()` in `api/serve.py` and `run_dashboard()` in `dashboard.py` detected the local IP address by creating a UDP socket, but only called `s.close()` on the happy path. Any exception raised by `s.connect()` or `s.getsockname()` would skip `s.close()`, leaking one file descriptor per failed attempt. On long-running or frequently-restarting servers this accumulates until the OS FD limit (~1 024) is hit and new sockets can no longer be created.

The fix replaces the manual `s.close()` call with Python's `with socket.socket(...) as s:` context manager, which guarantees the socket is closed on both the success and exception paths.

## Related Issue

Fixes #608

## Changes Made

- `src/pocketpaw/api/serve.py`: replace manual `s.close()` with context manager in `run_api_server()`
- `src/pocketpaw/dashboard.py`: same fix in `run_dashboard()`
- `tests/test_api_serve.py`: add `TestSocketResourceSafety` class with 6 regression tests

## Evidence of Testing

```
uv run pytest tests/test_api_serve.py -v
# 23 passed

uv run pytest --ignore=tests/e2e -q
# 3157 passed, 1 skipped
```

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Added regression tests
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff