### PR TITLE
fix(config): use Literal types for whatsapp_mode, tts_provider, stt_provider

### DIFF
--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,7 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-03-16: Use Literal types for whatsapp_mode, tts_provider, stt_provider (#638).
   - 2026-02-17: Added health_check_on_startup field for Health Engine.
   - 2026-02-14: Add migration warning for old ~/.pocketclaw/ config dir and POCKETCLAW_ env vars.
   - 2026-02-06: Secrets stored encrypted via CredentialStore; auto-migrate plaintext keys.
@@ -10,11 +11,14 @@ Changes:
   - 2026-02-02: claude_agent_sdk is now RECOMMENDED (uses official SDK).
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import re
 from functools import lru_cache
 from pathlib import Path
+from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -147,7 +151,7 @@ def get_token_path() -> Path:
 _TELEGRAM_BOT_TOKEN_RE = re.compile(r"^\d+:[A-Za-z0-9_-]+$")
 
 
-def validate_api_keys(settings: "Settings") -> list[str]:
+def validate_api_keys(settings: Settings) -> list[str]:
     """Validate **all** API keys on a :class:`Settings` instance (batch, loose).
 
     Uses simple prefix checks (not the strict regexes in :func:`validate_api_key`)
@@ -439,7 +443,7 @@ class Settings(BaseSettings):
     )
 
     # WhatsApp
-    whatsapp_mode: str = Field(
+    whatsapp_mode: Literal["", "personal", "business"] = Field(
         default="",
         description="WhatsApp mode: 'personal' (QR scan via neonize) or 'business' (Cloud API)",
     )
@@ -596,14 +600,16 @@ class Settings(BaseSettings):
     )
 
     # Voice/TTS
-    tts_provider: str = Field(
+    tts_provider: Literal["openai", "elevenlabs", "sarvam"] = Field(
         default="openai", description="TTS provider: 'openai', 'elevenlabs', or 'sarvam'"
     )
     elevenlabs_api_key: str | None = Field(default=None, description="ElevenLabs API key for TTS")
     tts_voice: str = Field(
         default="alloy", description="TTS voice name (OpenAI: alloy/echo/fable/onyx/nova/shimmer)"
     )
-    stt_provider: str = Field(default="openai", description="STT provider: 'openai' or 'sarvam'")
+    stt_provider: Literal["openai", "sarvam"] = Field(
+        default="openai", description="STT provider: 'openai' or 'sarvam'"
+    )
     stt_model: str = Field(default="whisper-1", description="OpenAI Whisper model for STT")
 
     # OCR
@@ -828,7 +834,7 @@ class Settings(BaseSettings):
         _chmod_safe(config_path, 0o600)
 
     @classmethod
-    def load(cls) -> "Settings":
+    def load(cls) -> Settings:
         """Load settings from config file + encrypted credential store."""
         from pocketpaw.credentials import SECRET_FIELDS, get_credential_store
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -292,3 +292,86 @@ class TestNumericFieldConstraints:
         """max_concurrent_conversations=1 must be accepted."""
         s = Settings(max_concurrent_conversations=1)
         assert s.max_concurrent_conversations == 1
+
+
+class TestEnumFieldValidation:
+    """Tests for Literal-typed enum fields in Settings (issue #638).
+
+    Covers whatsapp_mode, tts_provider, and stt_provider.
+    """
+
+    # ─── whatsapp_mode ──────────────────────────────────────────────────────
+
+    def test_whatsapp_mode_empty_string_accepted(self):
+        """whatsapp_mode='' (default / disabled) must be accepted."""
+        s = Settings(whatsapp_mode="")
+        assert s.whatsapp_mode == ""
+
+    def test_whatsapp_mode_personal_accepted(self):
+        """whatsapp_mode='personal' must be accepted."""
+        s = Settings(whatsapp_mode="personal")
+        assert s.whatsapp_mode == "personal"
+
+    def test_whatsapp_mode_business_accepted(self):
+        """whatsapp_mode='business' must be accepted."""
+        s = Settings(whatsapp_mode="business")
+        assert s.whatsapp_mode == "business"
+
+    def test_whatsapp_mode_invalid_rejected(self):
+        """whatsapp_mode='cloud' is not a valid option and must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(whatsapp_mode="cloud")
+
+    def test_whatsapp_mode_typo_rejected(self):
+        """whatsapp_mode='Buisness' (typo/wrong case) must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(whatsapp_mode="Buisness")
+
+    # ─── tts_provider ───────────────────────────────────────────────────────
+
+    def test_tts_provider_openai_accepted(self):
+        """tts_provider='openai' (default) must be accepted."""
+        s = Settings(tts_provider="openai")
+        assert s.tts_provider == "openai"
+
+    def test_tts_provider_elevenlabs_accepted(self):
+        """tts_provider='elevenlabs' must be accepted."""
+        s = Settings(tts_provider="elevenlabs")
+        assert s.tts_provider == "elevenlabs"
+
+    def test_tts_provider_sarvam_accepted(self):
+        """tts_provider='sarvam' must be accepted."""
+        s = Settings(tts_provider="sarvam")
+        assert s.tts_provider == "sarvam"
+
+    def test_tts_provider_invalid_rejected(self):
+        """tts_provider='azure' is not a valid option and must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(tts_provider="azure")
+
+    def test_tts_provider_typo_rejected(self):
+        """tts_provider='OpenAI' (wrong case) must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(tts_provider="OpenAI")
+
+    # ─── stt_provider ───────────────────────────────────────────────────────
+
+    def test_stt_provider_openai_accepted(self):
+        """stt_provider='openai' (default) must be accepted."""
+        s = Settings(stt_provider="openai")
+        assert s.stt_provider == "openai"
+
+    def test_stt_provider_sarvam_accepted(self):
+        """stt_provider='sarvam' must be accepted."""
+        s = Settings(stt_provider="sarvam")
+        assert s.stt_provider == "sarvam"
+
+    def test_stt_provider_invalid_rejected(self):
+        """stt_provider='whisper' is not a valid option and must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(stt_provider="whisper")
+
+    def test_stt_provider_typo_rejected(self):
+        """stt_provider='Sarvam' (wrong case) must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(stt_provider="Sarvam")


### PR DESCRIPTION
## What does this PR do?

`whatsapp_mode`, `tts_provider`, and `stt_provider` in `config.py` were declared as bare `str` fields, so Pydantic accepted any arbitrary value at settings-load time. This change narrows each field to a `Literal` type so misconfiguration is caught immediately with a clear `ValidationError` rather than silently propagating into adapter or TTS code.

## Related Issue

Fixes #638

## Changes Made

- `src/pocketpaw/config.py`:
  - Add `from __future__ import annotations` (required by project style guide)
  - Add `from typing import Literal`
  - `whatsapp_mode: str` → `whatsapp_mode: Literal["", "personal", "business"]`
  - `tts_provider: str` → `tts_provider: Literal["openai", "elevenlabs", "sarvam"]`
  - `stt_provider: str` → `stt_provider: Literal["openai", "sarvam"]`
  - Fix two pre-existing `UP037` ruff warnings (unnecessary quoted forward references)
- `tests/test_config_validation.py`:
  - Add `TestEnumFieldValidation` class with 14 tests covering all valid values and invalid/typo values for each field

## How to Test

1. Install dependencies: `uv sync --dev`
2. Run the new tests: `uv run pytest tests/test_config_validation.py::TestEnumFieldValidation -v`
3. Verify that setting an invalid value raises a `ValidationError`:
   ```python
   from pocketpaw.config import Settings
   from pydantic import ValidationError
   try:
       Settings(whatsapp_mode="cloud")
   except ValidationError as e:
       print(e)  # clear error pointing at whatsapp_mode
   ```

## Evidence of Testing

```
tests/test_config_validation.py::TestEnumFieldValidation::test_whatsapp_mode_empty_string_accepted PASSED
tests/test_config_validation.py::TestEnumFieldValidation::test_whatsapp_mode_personal_accepted PASSED
tests/test_config_validation.py::TestEnumFieldValidation::test_whatsapp_mode_business_accepted PASSED
tests/test_config_validation.py::TestEnumFieldValidation::test_whatsapp_mode_invalid_rejected PASSED
tests/test_config_validation.py::TestEnumFieldValidation::test_whatsapp_mode_typo_rejected PASSED
tests/test_config_validation.py::TestEnumFieldValidation::test_tts_provider_openai_accepted PASSED
tests/test_config_validation.py::TestEnumFieldValidation::test_tts_provider_elevenlabs_accepted PASSED
tests/test_config_validation.py::TestEnumFieldValidation::test_tts_provider_sarvam_accepted PASSED
tests/test_config_validation.py::TestEnumFieldValidation::test_tts_provider_invalid_rejected PASSED
tests/test_config_validation.py::TestEnumFieldValidation::test_tts_provider_typo_rejected PASSED
tests/test_config_validation.py::TestEnumFieldValidation::test_stt_provider_openai_accepted PASSED
tests/test_config_validation.py::TestEnumFieldValidation::test_stt_provider_sarvam_accepted PASSED
tests/test_config_validation.py::TestEnumFieldValidation::test_stt_provider_invalid_rejected PASSED
tests/test_config_validation.py::TestEnumFieldValidation::test_stt_provider_typo_rejected PASSED

============================== 57 passed in 0.14s ==============================
```

Full suite also ran clean via pre-commit on push (ruff + ruff-format + pytest all passed).

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff