### PR TITLE
fix(config): add enum validation for whatsapp_mode and tts_provider

### DIFF
--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -15,6 +15,7 @@ import logging
 import re
 from functools import lru_cache
 from pathlib import Path
+from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -439,10 +440,10 @@ class Settings(BaseSettings):
     )
 
     # WhatsApp
-    whatsapp_mode: str = Field(
-        default="",
-        description="WhatsApp mode: 'personal' (QR scan via neonize) or 'business' (Cloud API)",
-    )
+    whatsapp_mode: Literal["", "personal", "business"] = Field(
+    default="",
+    description="WhatsApp mode: 'personal' (QR scan via neonize) or 'business' (Cloud API)",
+)
     whatsapp_neonize_db: str = Field(
         default="",
         description="Path to neonize SQLite credential store",
@@ -593,9 +594,9 @@ class Settings(BaseSettings):
     )
 
     # Voice/TTS
-    tts_provider: str = Field(
-        default="openai", description="TTS provider: 'openai', 'elevenlabs', or 'sarvam'"
-    )
+    tts_provider: Literal["openai", "elevenlabs", "sarvam"] = Field(
+    default="openai", description="TTS provider: 'openai', 'elevenlabs', or 'sarvam'"
+)
     elevenlabs_api_key: str | None = Field(default=None, description="ElevenLabs API key for TTS")
     tts_voice: str = Field(
         default="alloy", description="TTS voice name (OpenAI: alloy/echo/fable/onyx/nova/shimmer)"

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -158,3 +158,60 @@ class TestValidateApiKey:
         assert len(result) == 2
         assert isinstance(result[0], bool)
         assert isinstance(result[1], str)
+        
+class TestEnumValidation:
+    """Tests for enum validation on whatsapp_mode and tts_provider — issue #638."""
+
+    def test_valid_whatsapp_mode_personal(self):
+        """whatsapp_mode='personal' should be accepted."""
+        from pocketpaw.config import Settings
+        s = Settings(whatsapp_mode="personal")
+        assert s.whatsapp_mode == "personal"
+
+    def test_valid_whatsapp_mode_business(self):
+        """whatsapp_mode='business' should be accepted."""
+        from pocketpaw.config import Settings
+        s = Settings(whatsapp_mode="business")
+        assert s.whatsapp_mode == "business"
+
+    def test_valid_whatsapp_mode_empty(self):
+        """whatsapp_mode='' (default) should be accepted."""
+        from pocketpaw.config import Settings
+        s = Settings(whatsapp_mode="")
+        assert s.whatsapp_mode == ""
+
+    def test_invalid_whatsapp_mode_raises(self):
+        """whatsapp_mode with invalid value should raise ValidationError."""
+        import pytest
+        from pydantic import ValidationError
+
+        from pocketpaw.config import Settings
+        with pytest.raises(ValidationError):
+            Settings(whatsapp_mode="invalid_mode")
+
+    def test_valid_tts_provider_openai(self):
+        """tts_provider='openai' should be accepted."""
+        from pocketpaw.config import Settings
+        s = Settings(tts_provider="openai")
+        assert s.tts_provider == "openai"
+
+    def test_valid_tts_provider_elevenlabs(self):
+        """tts_provider='elevenlabs' should be accepted."""
+        from pocketpaw.config import Settings
+        s = Settings(tts_provider="elevenlabs")
+        assert s.tts_provider == "elevenlabs"
+
+    def test_valid_tts_provider_sarvam(self):
+        """tts_provider='sarvam' should be accepted."""
+        from pocketpaw.config import Settings
+        s = Settings(tts_provider="sarvam")
+        assert s.tts_provider == "sarvam"
+
+    def test_invalid_tts_provider_raises(self):
+        """tts_provider with invalid value should raise ValidationError."""
+        import pytest
+        from pydantic import ValidationError
+
+        from pocketpaw.config import Settings
+        with pytest.raises(ValidationError):
+            Settings(tts_provider="invalid_provider")


### PR DESCRIPTION
## What does this PR do?

Adds enum validation for whatsapp_mode and tts_provider fields in the Settings config. Previously, invalid values were accepted silently and could misconfigure the app at runtime. Now a ValidationError is raised immediately on startup if an unsupported value is provided.

## Related Issue

Fixes #638

## Changes Made

src/pocketpaw/config.py: Replaced plain str types with Literal enums for whatsapp_mode ("personal", "business", "") and tts_provider ("openai", "elevenlabs", "sarvam")
tests/test_config_validation.py: Added TestEnumValidation class with 8 tests covering valid and invalid values for both fields

## How to Test

1. git checkout fix/enum-validation-whatsapp-tts
2. uv sync --dev
3. uv run pytest tests/test_config_validation.py -v

## Evidence of Testing

```
tests/test_config_validation.py::TestValidateApiKey::test_valid_anthropic_key PASSED                            [  3%]
tests/test_config_validation.py::TestValidateApiKey::test_valid_openai_key PASSED                               [  6%]
tests/test_config_validation.py::TestValidateApiKey::test_valid_openai_legacy_key PASSED                        [ 10%]
tests/test_config_validation.py::TestValidateApiKey::test_valid_telegram_token PASSED                           [ 13%]
tests/test_config_validation.py::TestValidateApiKey::test_invalid_anthropic_key_wrong_prefix PASSED             [ 16%]
tests/test_config_validation.py::TestValidateApiKey::test_invalid_anthropic_key_no_prefix PASSED                [ 20%]
tests/test_config_validation.py::TestValidateApiKey::test_invalid_openai_key_wrong_prefix PASSED                [ 23%]
tests/test_config_validation.py::TestValidateApiKey::test_invalid_telegram_token_wrong_format PASSED            [ 26%]
tests/test_config_validation.py::TestValidateApiKey::test_invalid_telegram_token_missing_colon PASSED           [ 30%]
tests/test_config_validation.py::TestValidateApiKey::test_invalid_telegram_token_no_aa_prefix PASSED            [ 33%]
tests/test_config_validation.py::TestValidateApiKey::test_empty_string_allowed PASSED                           [ 36%]
tests/test_config_validation.py::TestValidateApiKey::test_whitespace_only_allowed PASSED                        [ 40%]
tests/test_config_validation.py::TestValidateApiKey::test_none_value_allowed PASSED                             [ 43%]
tests/test_config_validation.py::TestValidateApiKey::test_unknown_field_passes_through PASSED                   [ 46%]
tests/test_config_validation.py::TestValidateApiKey::test_unvalidated_api_key_passes_through PASSED             [ 50%]
tests/test_config_validation.py::TestValidateApiKey::test_unvalidated_with_empty_value PASSED                   [ 53%]
tests/test_config_validation.py::TestValidateApiKey::test_key_with_leading_whitespace PASSED                    [ 56%]
tests/test_config_validation.py::TestValidateApiKey::test_key_with_trailing_whitespace PASSED                   [ 60%]
tests/test_config_validation.py::TestValidateApiKey::test_key_with_surrounding_whitespace PASSED                [ 63%]
tests/test_config_validation.py::TestValidateApiKey::test_very_long_valid_key PASSED                            [ 66%]
tests/test_config_validation.py::TestValidateApiKey::test_anthropic_key_catches_openai_prefix PASSED            [ 70%]
tests/test_config_validation.py::TestValidateApiKey::test_return_type_is_tuple PASSED                           [ 73%]
tests/test_config_validation.py::TestEnumValidation::test_valid_whatsapp_mode_personal PASSED                   [ 76%]
tests/test_config_validation.py::TestEnumValidation::test_valid_whatsapp_mode_business PASSED                   [ 80%]
tests/test_config_validation.py::TestEnumValidation::test_valid_whatsapp_mode_empty PASSED                      [ 83%]
tests/test_config_validation.py::TestEnumValidation::test_invalid_whatsapp_mode_raises PASSED                   [ 86%]
tests/test_config_validation.py::TestEnumValidation::test_valid_tts_provider_openai PASSED                      [ 90%]
tests/test_config_validation.py::TestEnumValidation::test_valid_tts_provider_elevenlabs PASSED                  [ 93%]
tests/test_config_validation.py::TestEnumValidation::test_valid_tts_provider_sarvam PASSED                      [ 96%]
tests/test_config_validation.py::TestEnumValidation::test_invalid_tts_provider_raises PASSED                    [100%]

30 passed in 0.56s 
```

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff
