### PR TITLE
chore: bump version to 0.4.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
-# Updated: 2026-03-11 — Hotfix 0.4.9: fix tool permissions hanging on messaging channels.
+# Updated: 2026-03-17 — Release 0.4.10: Soul Protocol, agent primitives, Discord overhaul, LiteLLM.
 [project]
 name = "pocketpaw"
-version = "0.4.9"
+version = "0.4.10"
 description = "The AI agent that runs on your laptop, not a datacenter. OpenClaw alternative with one-command install."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` version from 0.4.9 to 0.4.10 for the PyPI release

## Test plan

- [x] Version string updated in pyproject.toml
- [ ] PyPI upload succeeds after merge