### PR TITLE
chore(client): bump desktop version to 0.1.3

### DIFF
--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PocketPaw",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "com.pocketpaw.client",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

- Bump desktop client version from 0.1.2 to 0.1.3 in tauri.conf.json for the new desktop release

## Test plan

- [x] Version string updated in tauri.conf.json