### PR TITLE
docs: add API key setup guide to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ python -m pocketpaw
 ```
 
 > [!TIP]
-> **First Run:** After opening the dashboard, the system health may show **UNHEALTHY** — this is expected until at least one model provider is configured. The app itself is running correctly; only AI features are disabled. See [Setting up your first API key](#-setting-up-your-first-api-key), or [use Ollama for free local inference](#features).
+> **First Run:** After opening the dashboard, the system health may show **UNHEALTHY**. This is expected until at least one model provider is configured. The app itself is running correctly; only AI features are disabled. See [Setting up your first API key](#api-key-setup), or [use Ollama for free local inference](#features).
 
 > **Note:** Some features (browser automation, shell tools) work best under WSL2. Native Windows support covers the web dashboard and all LLM chat features.
 
@@ -223,16 +223,21 @@ Agent-created files appear in `./workspace/` on the host. Optional profiles: `--
 
 The web dashboard opens at `http://localhost:8888`. From there you can connect Discord, Slack, WhatsApp, or Telegram.
 
+<a id="api-key-setup"></a>
+
 ### 🔑 Setting up your first API key
 
-If the dashboard shows **UNHEALTHY** on first run, PocketPaw is usually installed correctly — you just need to configure at least one model provider (API key or local provider).
+If the dashboard shows **UNHEALTHY** on first run, PocketPaw is usually installed correctly. You just need to configure at least one model provider (API key or local provider).
 
 1. Open **Settings > API Keys** in the dashboard.
 2. Add a key for at least one provider:
    - Anthropic: [console.anthropic.com/settings/keys](https://console.anthropic.com/settings/keys)
    - OpenAI: [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
-   - Google API Key (Gemini): [aistudio.google.com/apikey](https://aistudio.google.com/apikey)
+   - Google Gemini: [aistudio.google.com/apikey](https://aistudio.google.com/apikey)
 3. Save settings and retry your chat.
+
+> [!TIP]
+> **Power users / Docker / headless:** You can also set API keys via environment variables instead of the dashboard. Use `POCKETPAW_ANTHROPIC_API_KEY`, `POCKETPAW_OPENAI_API_KEY`, or `POCKETPAW_GOOGLE_API_KEY`. See [Configuration](#configuration) for the full list.
 
 Prefer a free local option? Use Ollama instead (see [Features](#features) and [Configuration](#configuration)).
 


### PR DESCRIPTION
## Summary
- Add a new **Setting up your first API key** subsection under README Quick Start.
- Explain that **UNHEALTHY** on first run usually means no provider key is configured yet.
- Provide direct links for Anthropic, OpenAI, and Gemini keys, plus a note about Ollama as a free local alternative.

Closes #414

## Validation
- uv run ruff check .
- uv run pytest --ignore=tests/e2e