### PR TITLE
docs: update README download links to desktop v0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.2/PocketPaw_0.1.2_x64-setup.exe"><img src="https://img.shields.io/badge/Windows-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows"></a>
-  <a href="https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.2/PocketPaw_0.1.2_aarch64.dmg"><img src="https://img.shields.io/badge/macOS-Download_.dmg-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS"></a>
-  <a href="https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.2/PocketPaw_0.1.2_amd64.AppImage"><img src="https://img.shields.io/badge/Linux-Download_.AppImage-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download for Linux"></a>
+  <a href="https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.3/PocketPaw_0.1.3_x64-setup.exe"><img src="https://img.shields.io/badge/Windows-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows"></a>
+  <a href="https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.3/PocketPaw_0.1.3_aarch64.dmg"><img src="https://img.shields.io/badge/macOS-Download_.dmg-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS"></a>
+  <a href="https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.3/PocketPaw_0.1.3_amd64.AppImage"><img src="https://img.shields.io/badge/Linux-Download_.AppImage-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download for Linux"></a>
 </p>
 
 <p align="center">
@@ -43,11 +43,11 @@ Download the native desktop app. It bundles the backend installer and provides a
 
 | Platform | Download |
 | --- | --- |
-| **Windows** | [PocketPaw_0.1.2_x64-setup.exe](https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.2/PocketPaw_0.1.2_x64-setup.exe) |
-| **macOS (Apple Silicon)** | [PocketPaw_0.1.2_aarch64.dmg](https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.2/PocketPaw_0.1.2_aarch64.dmg) |
-| **macOS (Intel)** | [PocketPaw_0.1.2_x64.dmg](https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.2/PocketPaw_0.1.2_x64.dmg) |
-| **Linux (.deb)** | [PocketPaw_0.1.2_amd64.deb](https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.2/PocketPaw_0.1.2_amd64.deb) |
-| **Linux (.AppImage)** | [PocketPaw_0.1.2_amd64.AppImage](https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.2/PocketPaw_0.1.2_amd64.AppImage) |
+| **Windows** | [PocketPaw_0.1.3_x64-setup.exe](https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.3/PocketPaw_0.1.3_x64-setup.exe) |
+| **macOS (Apple Silicon)** | [PocketPaw_0.1.3_aarch64.dmg](https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.3/PocketPaw_0.1.3_aarch64.dmg) |
+| **macOS (Intel)** | [PocketPaw_0.1.3_x64.dmg](https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.3/PocketPaw_0.1.3_x64.dmg) |
+| **Linux (.deb)** | [PocketPaw_0.1.3_amd64.deb](https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.3/PocketPaw_0.1.3_amd64.deb) |
+| **Linux (.AppImage)** | [PocketPaw_0.1.3_amd64.AppImage](https://github.com/pocketpaw/pocketpaw/releases/download/client-v0.1.3/PocketPaw_0.1.3_amd64.AppImage) |
 
 ### Install via Terminal
 


### PR DESCRIPTION
## Summary

- Update all desktop download links in README.md from v0.1.2 to v0.1.3
- Covers badge links, download table, and all platform-specific file references

## Test plan

- [x] No remaining v0.1.2 references in README.md
- [x] All links point to valid assets on the client-v0.1.3 release