### PR TITLE
fix: log and preserve corrupted reminders.json instead of silently dropping data (#659)

### DIFF
--- a/src/pocketpaw/scheduler.py
+++ b/src/pocketpaw/scheduler.py
@@ -47,7 +47,17 @@ def load_reminders() -> list[dict]:
             data = json.loads(path.read_text())
             return data.get("reminders", [])
         except Exception:
-            pass
+            logger.warning(
+                "Failed to load reminders from %s — file may be corrupted. "
+                "Backing up to %s.bak and starting with empty reminders.",
+                path,
+                path,
+                exc_info=True,
+            )
+            try:
+                path.rename(path.with_suffix(".json.bak"))
+            except Exception:
+                logger.debug("Failed to back up corrupted reminders file", exc_info=True)
     return []
 
 


### PR DESCRIPTION
## Summary

Fixes silent data-loss bug in `scheduler.py` where a corrupted `reminders.json` would cause all saved reminders to be silently destroyed on restart with no log, no warning, and no recovery path.

Closes #659

---

## What was wrong

`load_reminders()` used a bare `except Exception: pass` when JSON parsing failed. This silently returned an empty list, after which `save_reminders([])` was immediately called — permanently overwriting the corrupted file with an empty reminders list. No log entry, no warning, no way for the user to know what happened.

## What was changed

`src/pocketpaw/scheduler.py` — `load_reminders()`:

| Before | After |
|---|---|
| `except Exception: pass` | Logs a `WARNING` with full stack trace |
| File silently overwritten | Corrupted file renamed to `reminders.json.bak` |
| No recovery possible | User can manually inspect/restore the `.bak` file |

If the rename itself fails, that is also caught and logged at `DEBUG` level.

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .` — all checks passed)
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff