### PR TITLE
feat(a2a): A2A server protocol endpoints - Phase 1

### DIFF
--- a/src/pocketpaw/a2a/__init__.py
+++ b/src/pocketpaw/a2a/__init__.py
@@ -1,0 +1,5 @@
+# Agent-to-Agent (A2A) Protocol support for PocketPaw.
+#
+# Phase 1 — A2A Server: exposes PocketPaw as a remote A2A-compatible agent.
+# Phase 2 — A2A Client: allows PocketPaw to delegate tasks to external agents.
+# Phase 3 — A2A Registry: multi-agent orchestration and dashboard UI.

--- a/src/pocketpaw/a2a/models.py
+++ b/src/pocketpaw/a2a/models.py
@@ -1,0 +1,89 @@
+# A2A Protocol — Pydantic models for request/response payloads.
+#
+# Follows the A2A Protocol specification:
+# https://google.github.io/A2A/specification/
+#
+# Task lifecycle: submitted → working → completed | failed | canceled
+# Supports text and tool-call content parts.
+
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class TaskState(enum.StrEnum):
+    """A2A task lifecycle states."""
+
+    SUBMITTED = "submitted"
+    WORKING = "working"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELED = "canceled"
+    INPUT_REQUIRED = "input_required"
+
+
+class TextPart(BaseModel):
+    """A plain-text content part."""
+
+    type: str = "text"
+    text: str
+
+
+class A2AMessage(BaseModel):
+    """A single message in an A2A task conversation."""
+
+    role: str  # "user" | "agent"
+    parts: list[TextPart]
+
+
+class TaskStatus(BaseModel):
+    """Current status of a task."""
+
+    state: TaskState
+    message: A2AMessage | None = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(tz=UTC))
+
+
+class Task(BaseModel):
+    """An A2A task resource."""
+
+    id: str
+    session_id: str | None = None
+    status: TaskStatus
+    history: list[A2AMessage] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class TaskSendParams(BaseModel):
+    """Parameters for tasks/send."""
+
+    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    session_id: str | None = None
+    message: A2AMessage
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentCapabilities(BaseModel):
+    """Agent capability flags advertised in the agent card."""
+
+    streaming: bool = True
+    push_notifications: bool = False
+    state_transition_history: bool = True
+
+
+class AgentCard(BaseModel):
+    """A2A Agent Card — advertised at /.well-known/agent.json."""
+
+    name: str
+    description: str
+    url: str
+    version: str
+    capabilities: AgentCapabilities = Field(default_factory=AgentCapabilities)
+    skills: list[dict[str, Any]] = Field(default_factory=list)
+    default_input_modes: list[str] = Field(default=["text"])
+    default_output_modes: list[str] = Field(default=["text"])

--- a/src/pocketpaw/a2a/server.py
+++ b/src/pocketpaw/a2a/server.py
@@ -1,0 +1,545 @@
+# A2A Protocol — Server implementation for PocketPaw.
+#
+# Phase 1: Exposes PocketPaw as an A2A-compatible agent.
+#
+# Endpoints:
+#   GET  /.well-known/agent.json  — Agent Card (capability manifest)
+#   POST /a2a/tasks/send          — Submit a task (returns task JSON)
+#   POST /a2a/tasks/send/stream   — Submit a task; SSE response stream
+#   GET  /a2a/tasks/{task_id}     — Poll task status
+#   POST /a2a/tasks/{task_id}/cancel — Cancel an in-flight task
+#
+# All task processing is routed through the existing PocketPaw AgentLoop
+# via the internal message bus (same path as REST /api/v1/chat).
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import UTC, datetime
+from importlib.metadata import version as _pkg_version
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from pocketpaw.a2a.models import (
+    A2AMessage,
+    AgentCapabilities,
+    AgentCard,
+    Task,
+    TaskSendParams,
+    TaskState,
+    TaskStatus,
+    TextPart,
+)
+from pocketpaw.api.deps import require_scope
+from pocketpaw.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# In-memory task store (sufficient for single-process; Phase 3 may persist)
+# ---------------------------------------------------------------------------
+_MAX_TASKS = 1000
+# TODO(Phase 3): replace with a distributed store for multi-worker support
+_tasks: dict[str, Task] = {}
+_cancel_events: dict[str, asyncio.Event] = {}  # task_id → cancellation flag
+
+
+def _store_task(task: Task) -> None:
+    """Store a task and prune old tasks to prevent memory leaks."""
+    if len(_tasks) >= _MAX_TASKS:
+        terminal = {TaskState.COMPLETED, TaskState.FAILED, TaskState.CANCELED}
+        evict_id = next(
+            (tid for tid, t in _tasks.items() if t.status.state in terminal),
+            next(iter(_tasks)),  # fallback: evict oldest if all are active
+        )
+        _tasks.pop(evict_id, None)
+        _cancel_events.pop(evict_id, None)
+    _tasks[task.id] = task
+
+
+# ---------------------------------------------------------------------------
+# Routers
+# ---------------------------------------------------------------------------
+
+
+def _check_a2a_enabled() -> None:
+    if not get_settings().a2a_enabled:
+        raise HTTPException(status_code=403, detail="A2A protocol is disabled on this agent.")
+
+
+# The agent-card route lives at the well-known path (outside /api prefix)
+well_known_router = APIRouter(
+    tags=["A2A"], dependencies=[Depends(_check_a2a_enabled), Depends(require_scope("chat"))]
+)
+
+# Task endpoints live under /a2a
+tasks_router = APIRouter(
+    prefix="/a2a/tasks",
+    tags=["A2A"],
+    dependencies=[Depends(_check_a2a_enabled), Depends(require_scope("chat"))],
+)
+
+
+# ---------------------------------------------------------------------------
+# Agent Card helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_agent_card(base_url: str) -> AgentCard:
+    """Build an A2A-compliant Agent Card from current PocketPaw config."""
+    # Advertise a skill per enabled tool profile group
+    skills: list[dict[str, Any]] = [
+        {
+            "id": "general-assistant",
+            "name": "General Assistant",
+            "description": (
+                "Answer questions, run shell commands, search the web, manage files, "
+                "read/send email, control Spotify, and more."
+            ),
+            "input_modes": ["text"],
+            "output_modes": ["text"],
+        }
+    ]
+
+    try:
+        paw_version = _pkg_version("pocketpaw")
+    except Exception:
+        paw_version = "unknown"
+
+    return AgentCard(
+        name="PocketPaw",
+        description=(
+            "Self-hosted, modular AI agent. "
+            "Runs locally with 60+ built-in tools across productivity, coding, and research."
+        ),
+        url=base_url,
+        version=paw_version,
+        capabilities=AgentCapabilities(
+            streaming=True,
+            push_notifications=False,
+            state_transition_history=True,
+        ),
+        skills=skills,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal: bridge A2A task to AgentLoop via message bus
+# ---------------------------------------------------------------------------
+
+
+class _A2ASessionBridge:
+    """Bridges the message bus outbound stream to an asyncio Queue for A2A SSE.
+
+    Mirrors the pattern in ``api/v1/chat.py::_APISessionBridge``.
+    """
+
+    def __init__(self, chat_id: str):
+        self.chat_id = chat_id
+        self.queue: asyncio.Queue = asyncio.Queue()
+        self._outbound_cb = None
+        self._system_cb = None
+
+    async def start(self) -> None:
+        from pocketpaw.bus import get_message_bus
+        from pocketpaw.bus.events import Channel, OutboundMessage, SystemEvent
+
+        bus = get_message_bus()
+
+        async def _on_outbound(msg: OutboundMessage) -> None:
+            if msg.chat_id != self.chat_id:
+                return
+            if msg.is_stream_chunk:
+                await self.queue.put({"type": "chunk", "content": msg.content})
+            elif msg.is_stream_end:
+                await self.queue.put({"type": "stream_end"})
+            else:
+                await self.queue.put({"type": "chunk", "content": msg.content})
+
+        async def _on_system(evt: SystemEvent) -> None:
+            data = evt.data or {}
+            sk = data.get("session_key", "")
+            if not sk or not sk.endswith(f":{self.chat_id}"):
+                return
+            if evt.event_type == "error":
+                await self.queue.put({"type": "error", "message": data.get("message", "")})
+
+        self._outbound_cb = _on_outbound
+        self._system_cb = _on_system
+        bus.subscribe_outbound(Channel.WEBSOCKET, _on_outbound)
+        bus.subscribe_system(_on_system)
+
+    async def stop(self) -> None:
+        from pocketpaw.bus import get_message_bus
+        from pocketpaw.bus.events import Channel
+
+        bus = get_message_bus()
+        if self._outbound_cb:
+            bus.unsubscribe_outbound(Channel.WEBSOCKET, self._outbound_cb)
+        if self._system_cb:
+            bus.unsubscribe_system(self._system_cb)
+
+
+async def _dispatch_to_agent(task_id: str, message: A2AMessage) -> str:
+    """Publish an inbound message onto the bus and return the chat_id."""
+    from pocketpaw.bus import get_message_bus
+    from pocketpaw.bus.events import Channel, InboundMessage
+
+    # Use task_id as the stable chat_id so session context is maintained
+    chat_id = f"a2a:{task_id}"
+    text = " ".join(part.text for part in message.parts if part.type == "text")
+
+    msg = InboundMessage(
+        channel=Channel.WEBSOCKET,
+        sender_id="a2a_client",
+        chat_id=chat_id,
+        content=text,
+        metadata={"source": "a2a_protocol", "task_id": task_id},
+    )
+    bus = get_message_bus()
+    await bus.publish_inbound(msg)
+    return chat_id
+
+
+# ---------------------------------------------------------------------------
+# Endpoint: Agent Card
+# ---------------------------------------------------------------------------
+
+
+@well_known_router.get("/.well-known/agent.json", response_class=JSONResponse)
+async def get_agent_card(request: Request):
+    """Return the A2A Agent Card describing PocketPaw's capabilities.
+
+    External agents discover this endpoint first when initiating A2A sessions.
+    """
+    base_url = str(request.base_url).rstrip("/")
+    card = _build_agent_card(base_url)
+    return JSONResponse(content=card.model_dump(mode="json"))
+
+
+# ---------------------------------------------------------------------------
+# Endpoint: tasks/send (non-streaming)
+# ---------------------------------------------------------------------------
+
+
+@tasks_router.post("/send", response_model=Task)
+async def tasks_send(params: TaskSendParams):
+    """Submit a task to PocketPaw and wait for the completed response.
+
+    The task is routed through the internal AgentLoop. Completes when the
+    agent signals ``stream_end`` or on a 120-second timeout.
+    """
+    task_id = params.id  # always set: default_factory in TaskSendParams guarantees this
+    chat_id = f"a2a:{task_id}"
+
+    # Create cancel event so tasks_cancel can interrupt even non-streaming tasks
+    cancel_event = asyncio.Event()
+    _cancel_events[task_id] = cancel_event
+
+    # Record initial task state
+    task = Task(
+        id=task_id,
+        session_id=params.session_id,
+        status=TaskStatus(state=TaskState.SUBMITTED),
+        history=[params.message],
+        metadata=params.metadata,
+    )
+    _store_task(task)
+
+    bridge = _A2ASessionBridge(chat_id)
+    await bridge.start()
+
+    # Transition: submitted → working
+    task.status = TaskStatus(state=TaskState.WORKING)
+
+    try:
+        await _dispatch_to_agent(task_id, params.message)
+
+        # Collect chunks until stream_end, error, or cancellation.
+        # Use asyncio.wait so a cancel_event.wait() future can race against
+        # bridge.queue.get() — this makes cancellation work for sync tasks too.
+        cancel_fut = asyncio.ensure_future(cancel_event.wait())
+        content_parts: list[str] = []
+        done = False
+        while not done:
+            get_fut = asyncio.ensure_future(bridge.queue.get())
+            try:
+                finished, _ = await asyncio.wait(
+                    {get_fut, cancel_fut},
+                    timeout=120,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            except Exception:
+                finished = set()
+
+            if not finished:  # timeout
+                get_fut.cancel()
+                cancel_fut.cancel()
+                task.status = TaskStatus(
+                    state=TaskState.FAILED,
+                    message=A2AMessage(
+                        role="agent",
+                        parts=[TextPart(text="Task timed out after 120 seconds.")],
+                    ),
+                )
+                return task
+
+            if cancel_fut in finished:  # cancellation requested
+                get_fut.cancel()
+                task.status = TaskStatus(state=TaskState.CANCELED)
+                return task
+
+            # get_fut completed — process the event
+            event = get_fut.result()
+            if event["type"] == "chunk":
+                content_parts.append(event.get("content", ""))
+            elif event["type"] == "stream_end":
+                done = True
+                cancel_fut.cancel()
+            elif event["type"] == "error":
+                cancel_fut.cancel()
+                task.status = TaskStatus(
+                    state=TaskState.FAILED,
+                    message=A2AMessage(
+                        role="agent",
+                        parts=[TextPart(text=event.get("message", "Agent error"))],
+                    ),
+                )
+                return task
+
+        # Build completion response
+        agent_reply = A2AMessage(
+            role="agent",
+            parts=[TextPart(text="".join(content_parts))],
+        )
+        task.status = TaskStatus(state=TaskState.COMPLETED, message=agent_reply)
+        task.history.append(agent_reply)
+        return task
+
+    finally:
+        await bridge.stop()
+        _cancel_events.pop(task_id, None)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint: tasks/send/stream (SSE streaming)
+# ---------------------------------------------------------------------------
+
+
+@tasks_router.post("/send/stream")
+async def tasks_send_stream(params: TaskSendParams):
+    """Submit a task and receive an SSE stream of state-update events.
+
+    Each SSE event carries a JSON-encoded ``TaskStatus`` update:
+    - ``submitted``  — initial acknowledgment
+    - ``working``    — agent began processing, with delta content parts
+    - ``completed``  — final message and task result
+    - ``failed``     — unrecoverable error
+    """
+    task_id = params.id  # always set: default_factory in TaskSendParams guarantees this
+    chat_id = f"a2a:{task_id}"
+
+    cancel_event = asyncio.Event()
+    _cancel_events[task_id] = cancel_event
+
+    task = Task(
+        id=task_id,
+        session_id=params.session_id,
+        status=TaskStatus(state=TaskState.SUBMITTED),
+        history=[params.message],
+        metadata=params.metadata,
+    )
+    _store_task(task)
+
+    bridge = _A2ASessionBridge(chat_id)
+    await bridge.start()
+    await _dispatch_to_agent(task_id, params.message)
+
+    async def _event_generator():
+        try:
+            # Submitted acknowledgment
+            submitted_status = TaskStatus(state=TaskState.SUBMITTED)
+            yield _format_sse(
+                "task_status_update",
+                {
+                    "id": task_id,
+                    "status": submitted_status.model_dump(mode="json"),
+                    "final": False,
+                },
+            )
+
+            # Working notification
+            working_status = TaskStatus(state=TaskState.WORKING)
+            _tasks[task_id].status = working_status
+            yield _format_sse(
+                "task_status_update",
+                {
+                    "id": task_id,
+                    "status": working_status.model_dump(mode="json"),
+                    "final": False,
+                },
+            )
+
+            # Stream content chunks as working updates
+            accumulated: list[str] = []
+            max_duration = 120.0
+            elapsed = 0.0
+            while not cancel_event.is_set():
+                if elapsed >= max_duration:
+                    agent_reply = A2AMessage(
+                        role="agent",
+                        parts=[TextPart(text="Task timed out after 120 seconds.")],
+                    )
+                    failed_status = TaskStatus(state=TaskState.FAILED, message=agent_reply)
+                    _tasks[task_id].status = failed_status
+                    yield _format_sse(
+                        "task_status_update",
+                        {
+                            "id": task_id,
+                            "status": failed_status.model_dump(mode="json"),
+                            "final": True,
+                        },
+                    )
+                    break
+
+                try:
+                    event = await asyncio.wait_for(bridge.queue.get(), timeout=1.0)
+                except TimeoutError:
+                    elapsed += 1.0
+                    continue
+
+                if event["type"] == "chunk":
+                    chunk_text = event.get("content", "")
+                    accumulated.append(chunk_text)
+                    delta_msg = A2AMessage(role="agent", parts=[TextPart(text=chunk_text)])
+                    chunk_status = TaskStatus(state=TaskState.WORKING, message=delta_msg)
+                    yield _format_sse(
+                        "task_status_update",
+                        {
+                            "id": task_id,
+                            "status": chunk_status.model_dump(mode="json"),
+                            "final": False,
+                        },
+                    )
+
+                elif event["type"] == "stream_end":
+                    full_text = "".join(accumulated)
+                    agent_reply = A2AMessage(role="agent", parts=[TextPart(text=full_text)])
+                    completed_status = TaskStatus(state=TaskState.COMPLETED, message=agent_reply)
+                    _tasks[task_id].status = completed_status
+                    _tasks[task_id].history.append(agent_reply)
+                    yield _format_sse(
+                        "task_status_update",
+                        {
+                            "id": task_id,
+                            "status": completed_status.model_dump(mode="json"),
+                            "final": True,
+                        },
+                    )
+                    break
+
+                elif event["type"] == "error":
+                    agent_reply = A2AMessage(
+                        role="agent",
+                        parts=[TextPart(text=event.get("message", "Agent error"))],
+                    )
+                    failed_status = TaskStatus(state=TaskState.FAILED, message=agent_reply)
+                    _tasks[task_id].status = failed_status
+                    yield _format_sse(
+                        "task_status_update",
+                        {
+                            "id": task_id,
+                            "status": failed_status.model_dump(mode="json"),
+                            "final": True,
+                        },
+                    )
+                    break
+
+        except asyncio.CancelledError:
+            pass  # client disconnected, finally block handles cleanup
+        finally:
+            await bridge.stop()
+            _cancel_events.pop(task_id, None)
+
+    return StreamingResponse(
+        _event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoint: tasks/{task_id} (GET — poll)
+# ---------------------------------------------------------------------------
+
+
+@tasks_router.get("/{task_id}", response_model=Task)
+async def tasks_get(task_id: str):
+    """Poll the current status of a previously submitted task."""
+    task = _tasks.get(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
+    return task
+
+
+# ---------------------------------------------------------------------------
+# Endpoint: tasks/{task_id}/cancel
+# ---------------------------------------------------------------------------
+
+
+@tasks_router.post("/{task_id}/cancel")
+async def tasks_cancel(task_id: str):
+    """Request cancellation of an in-flight task."""
+    task = _tasks.get(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
+
+    cancel_event = _cancel_events.get(task_id)
+    if cancel_event:
+        cancel_event.set()
+
+    task.status = TaskStatus(
+        state=TaskState.CANCELED,
+        timestamp=datetime.now(tz=UTC),
+    )
+    return {"id": task_id, "status": "canceled"}
+
+
+# ---------------------------------------------------------------------------
+# SSE helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_sse(event: str, data: dict) -> str:
+    """Format a single SSE message frame."""
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Router registration helper
+# ---------------------------------------------------------------------------
+
+
+def register_routes(app) -> None:
+    """Mount all A2A routers onto *app*.
+
+    Called during dashboard startup. Keeps dashboard.py free of A2A-specific
+    import details and makes it easy for maintainers to see what gets exposed.
+
+    Routes added:
+      GET  /.well-known/agent.json     — Agent Card capability manifest
+      POST /a2a/tasks/send             — Submit task (blocking)
+      POST /a2a/tasks/send/stream      — Submit task (SSE streaming)
+      GET  /a2a/tasks/{task_id}        — Poll task status
+      POST /a2a/tasks/{task_id}/cancel — Cancel task
+    """
+    app.include_router(well_known_router)
+    app.include_router(tasks_router)

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -695,6 +695,12 @@ class Settings(BaseSettings):
     web_host: str = Field(default="127.0.0.1", description="Web server host")
     web_port: int = Field(default=8888, description="Web server port")
 
+    # A2A Protocol
+    a2a_enabled: bool = Field(
+        default=False,
+        description="Enable the A2A Protocol remote endpoints (allow external delegates)",
+    )
+
     # MCP OAuth
     mcp_client_metadata_url: str = Field(
         default="",

--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -191,6 +191,14 @@ app.include_router(deep_work_router, prefix="/api/deep-work")
 # Mount API v1 routers at /api/v1/ (canonical) — see api/v1/__init__.py
 mount_v1_routers(app)
 
+# Mount A2A Protocol routers (agent card + task endpoints) — see a2a/server.py
+try:
+    from pocketpaw.a2a.server import register_routes as _a2a_register_routes
+
+    _a2a_register_routes(app)
+except Exception as _a2a_exc:
+    logger.warning("A2A Protocol unavailable — skipping router mount: %s", _a2a_exc)
+
 # Mount channel management router (webhooks, extras, channel status/toggle)
 app.include_router(channels_router)
 

--- a/tests/test_a2a_server.py
+++ b/tests/test_a2a_server.py
@@ -1,0 +1,462 @@
+# Tests for A2A Protocol — Phase 1: Server implementation.
+# Created: 2026-03-07
+#
+# Covers:
+#  - Agent Card structure and required fields
+#  - POST /a2a/tasks/send (non-streaming, mocked AgentLoop)
+#  - GET  /a2a/tasks/{task_id} polling
+#  - POST /a2a/tasks/{task_id}/cancel
+#  - POST /a2a/tasks/send/stream (SSE format validation)
+#  - Model validation: TaskState enum, TextPart, A2AMessage
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from pocketpaw.a2a.models import (
+    A2AMessage,
+    AgentCard,
+    Task,
+    TaskSendParams,
+    TaskState,
+    TaskStatus,
+    TextPart,
+)
+from pocketpaw.a2a.server import (
+    _A2ASessionBridge,
+    _cancel_events,
+    _check_a2a_enabled,
+    _format_sse,
+    _tasks,
+    tasks_router,
+    well_known_router,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def test_app():
+    """Minimal FastAPI app with both A2A routers mounted."""
+    from fastapi import Request
+
+    app = FastAPI()
+    app.dependency_overrides[_check_a2a_enabled] = lambda: None
+
+    # A cleaner approach for tests is to inject a dummy API key state that passes.
+    # However, since require_scope just checks request.state:
+    @app.middleware("http")
+    async def mock_auth_middleware(request: Request, call_next):
+        class MockAPIKey:
+            scopes = ["chat", "admin"]
+
+        request.state.api_key = MockAPIKey()
+        return await call_next(request)
+
+    app.include_router(well_known_router)
+    app.include_router(tasks_router)
+    return app
+
+
+@pytest_asyncio.fixture
+async def client(test_app):
+    transport = ASGITransport(app=test_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.fixture(autouse=True)
+def clear_task_store():
+    """Isolate the in-memory task store between tests."""
+    _tasks.clear()
+    _cancel_events.clear()
+    yield
+    _tasks.clear()
+    _cancel_events.clear()
+
+
+def _make_send_params(text: str = "Hello PocketPaw", task_id: str = "test-task-001"):
+    return TaskSendParams(
+        id=task_id,
+        message=A2AMessage(role="user", parts=[TextPart(text=text)]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: Pydantic Models
+# ---------------------------------------------------------------------------
+
+
+class TestModels:
+    def test_task_state_values(self):
+        assert TaskState.SUBMITTED == "submitted"
+        assert TaskState.WORKING == "working"
+        assert TaskState.COMPLETED == "completed"
+        assert TaskState.FAILED == "failed"
+        assert TaskState.CANCELED == "canceled"
+
+    def test_text_part_defaults(self):
+        part = TextPart(text="hello")
+        assert part.type == "text"
+        assert part.text == "hello"
+
+    def test_a2a_message_serialization(self):
+        msg = A2AMessage(role="agent", parts=[TextPart(text="hi")])
+        data = msg.model_dump()
+        assert data["role"] == "agent"
+        assert data["parts"][0]["text"] == "hi"
+
+    def test_agent_card_defaults(self):
+        card = AgentCard(
+            name="Test", description="Desc", url="http://localhost:8888", version="1.0"
+        )
+        assert card.capabilities.streaming is True
+        assert card.default_input_modes == ["text"]
+        assert card.default_output_modes == ["text"]
+
+    def test_task_send_params_auto_id(self):
+        params = TaskSendParams(message=A2AMessage(role="user", parts=[TextPart(text="test")]))
+        assert params.id  # auto-generated
+
+    def test_task_status_default_timestamp(self):
+        status = TaskStatus(state=TaskState.SUBMITTED)
+        assert status.timestamp is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /.well-known/agent.json
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCard:
+    @pytest.mark.asyncio
+    async def test_agent_card_returns_200(self, client):
+        resp = await client.get("/.well-known/agent.json")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_agent_card_content_type(self, client):
+        resp = await client.get("/.well-known/agent.json")
+        assert "application/json" in resp.headers.get("content-type", "")
+
+    @pytest.mark.asyncio
+    async def test_agent_card_required_fields(self, client):
+        resp = await client.get("/.well-known/agent.json")
+        data = resp.json()
+        assert "name" in data
+        assert "description" in data
+        assert "url" in data
+        assert "version" in data
+        assert "capabilities" in data
+        assert "skills" in data
+
+    @pytest.mark.asyncio
+    async def test_agent_card_name(self, client):
+        resp = await client.get("/.well-known/agent.json")
+        assert resp.json()["name"] == "PocketPaw"
+
+    @pytest.mark.asyncio
+    async def test_agent_card_capabilities_streaming(self, client):
+        resp = await client.get("/.well-known/agent.json")
+        caps = resp.json()["capabilities"]
+        assert caps["streaming"] is True
+
+    @pytest.mark.asyncio
+    async def test_agent_card_skills_list(self, client):
+        resp = await client.get("/.well-known/agent.json")
+        skills = resp.json()["skills"]
+        assert isinstance(skills, list)
+        assert len(skills) >= 1
+        skill = skills[0]
+        assert "id" in skill
+        assert "name" in skill
+        assert "description" in skill
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /a2a/tasks/send (non-streaming)
+# ---------------------------------------------------------------------------
+
+
+class TestTasksSend:
+    @patch("pocketpaw.a2a.server._dispatch_to_agent")
+    @patch("pocketpaw.a2a.server._A2ASessionBridge")
+    async def test_send_returns_completed_task(self, mock_bridge_cls, mock_dispatch, client):
+        bridge = MagicMock()
+        q = asyncio.Queue()
+        bridge.queue = q
+        bridge.start = AsyncMock()
+        bridge.stop = AsyncMock()
+        mock_bridge_cls.return_value = bridge
+        mock_dispatch.return_value = "a2a:test-task-001"
+
+        async def _load():
+            await q.put({"type": "chunk", "content": "Here is the answer."})
+            await q.put({"type": "stream_end"})
+
+        await _load()
+
+        params = _make_send_params()
+        resp = await client.post("/a2a/tasks/send", content=params.model_dump_json())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == "test-task-001"
+        assert data["status"]["state"] == TaskState.COMPLETED
+        assert "Here is the answer." in data["status"]["message"]["parts"][0]["text"]
+
+    @patch("pocketpaw.a2a.server._dispatch_to_agent")
+    @patch("pocketpaw.a2a.server._A2ASessionBridge")
+    async def test_send_failed_on_error_event(self, mock_bridge_cls, mock_dispatch, client):
+        bridge = MagicMock()
+        q = asyncio.Queue()
+        bridge.queue = q
+        bridge.start = AsyncMock()
+        bridge.stop = AsyncMock()
+        mock_bridge_cls.return_value = bridge
+        mock_dispatch.return_value = "a2a:test-task-001"
+
+        async def _load():
+            await q.put({"type": "error", "message": "Something went wrong"})
+
+        await _load()
+
+        params = _make_send_params()
+        resp = await client.post("/a2a/tasks/send", content=params.model_dump_json())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"]["state"] == TaskState.FAILED
+
+    @pytest.mark.asyncio
+    async def test_send_invalid_body_returns_422(self, client):
+        resp = await client.post("/a2a/tasks/send", json={"bad": "body"})
+        assert resp.status_code == 422
+
+    @patch("pocketpaw.a2a.server._dispatch_to_agent")
+    @patch("pocketpaw.a2a.server._A2ASessionBridge")
+    async def test_send_stores_task_history(self, mock_bridge_cls, mock_dispatch, client):
+        bridge = MagicMock()
+        q = asyncio.Queue()
+        bridge.queue = q
+        bridge.start = AsyncMock()
+        bridge.stop = AsyncMock()
+        mock_bridge_cls.return_value = bridge
+        mock_dispatch.return_value = "a2a:test-task-001"
+
+        async def _load():
+            await q.put({"type": "chunk", "content": "Done."})
+            await q.put({"type": "stream_end"})
+
+        await _load()
+
+        params = _make_send_params()
+        resp = await client.post("/a2a/tasks/send", content=params.model_dump_json())
+        data = resp.json()
+        # history should include the original user message + agent reply
+        assert len(data["history"]) >= 2
+        assert data["history"][0]["role"] == "user"
+        assert data["history"][-1]["role"] == "agent"
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /a2a/tasks/{task_id}
+# ---------------------------------------------------------------------------
+
+
+class TestTasksGet:
+    @pytest.mark.asyncio
+    async def test_get_task_not_found(self, client):
+        resp = await client.get("/a2a/tasks/nonexistent-id")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_task_found(self, client):
+        # Pre-seed the store
+        task = Task(
+            id="known-task",
+            status=TaskStatus(state=TaskState.WORKING),
+        )
+        _tasks["known-task"] = task
+
+        resp = await client.get("/a2a/tasks/known-task")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == "known-task"
+        assert data["status"]["state"] == TaskState.WORKING
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /a2a/tasks/{task_id}/cancel
+# ---------------------------------------------------------------------------
+
+
+class TestTasksCancel:
+    @pytest.mark.asyncio
+    async def test_cancel_nonexistent_task(self, client):
+        resp = await client.post("/a2a/tasks/ghost-task/cancel")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_cancel_sets_state(self, client):
+        task = Task(
+            id="cancel-me",
+            status=TaskStatus(state=TaskState.WORKING),
+        )
+        _tasks["cancel-me"] = task
+        cancel_evt = asyncio.Event()
+        _cancel_events["cancel-me"] = cancel_evt
+
+        resp = await client.post("/a2a/tasks/cancel-me/cancel")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "canceled"
+        assert _tasks["cancel-me"].status.state == TaskState.CANCELED
+        assert cancel_evt.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /a2a/tasks/send/stream (SSE)
+# ---------------------------------------------------------------------------
+
+
+class TestTasksSendStream:
+    @patch("pocketpaw.a2a.server._dispatch_to_agent")
+    @patch("pocketpaw.a2a.server._A2ASessionBridge")
+    async def test_stream_returns_sse_content_type(self, mock_bridge_cls, mock_dispatch, client):
+        bridge = MagicMock()
+        q = asyncio.Queue()
+        bridge.queue = q
+        bridge.start = AsyncMock()
+        bridge.stop = AsyncMock()
+        mock_bridge_cls.return_value = bridge
+        mock_dispatch.return_value = "a2a:stream-task"
+
+        async def _load():
+            await q.put({"type": "chunk", "content": "Streaming..."})
+            await q.put({"type": "stream_end"})
+
+        await _load()
+        params = _make_send_params(task_id="stream-task")
+
+        async with client.stream(
+            "POST", "/a2a/tasks/send/stream", content=params.model_dump_json()
+        ) as resp:
+            assert resp.status_code == 200
+            assert "text/event-stream" in resp.headers.get("content-type", "")
+
+    @patch("pocketpaw.a2a.server._dispatch_to_agent")
+    @patch("pocketpaw.a2a.server._A2ASessionBridge")
+    async def test_stream_sse_events_valid_format(self, mock_bridge_cls, mock_dispatch, client):
+        """Each SSE event must follow: event: <type>\\ndata: <json>\\n\\n"""
+        bridge = MagicMock()
+        q = asyncio.Queue()
+        bridge.queue = q
+        bridge.start = AsyncMock()
+        bridge.stop = AsyncMock()
+        mock_bridge_cls.return_value = bridge
+        mock_dispatch.return_value = "a2a:sse-val"
+
+        async def _load():
+            await q.put({"type": "chunk", "content": "partial answer"})
+            await q.put({"type": "stream_end"})
+
+        await _load()
+        params = _make_send_params(task_id="sse-val")
+        async with client.stream(
+            "POST", "/a2a/tasks/send/stream", content=params.model_dump_json()
+        ) as resp:
+            raw = await resp.aread()
+            raw = raw.decode()
+
+        events = [e.strip() for e in raw.split("\n\n") if e.strip()]
+        assert len(events) >= 2
+
+        for block in events:
+            lines = block.split("\n")
+            event_line = next((line for line in lines if line.startswith("event:")), None)
+            data_line = next((line for line in lines if line.startswith("data:")), None)
+            assert event_line is not None, f"Missing 'event:' in: {block!r}"
+            assert data_line is not None, f"Missing 'data:' in: {block!r}"
+            data_str = data_line.split(":", 1)[1].strip()
+            parsed = json.loads(data_str)
+            assert "id" in parsed
+            assert "status" in parsed
+
+    @patch("pocketpaw.a2a.server._dispatch_to_agent")
+    @patch("pocketpaw.a2a.server._A2ASessionBridge")
+    async def test_stream_final_event_has_completed_state(
+        self, mock_bridge_cls, mock_dispatch, client
+    ):
+        bridge = MagicMock()
+        q = asyncio.Queue()
+        bridge.queue = q
+        bridge.start = AsyncMock()
+        bridge.stop = AsyncMock()
+        mock_bridge_cls.return_value = bridge
+        mock_dispatch.return_value = "a2a:final-test"
+
+        async def _load():
+            await q.put({"type": "chunk", "content": "Final answer."})
+            await q.put({"type": "stream_end"})
+
+        await _load()
+        params = _make_send_params(task_id="final-test")
+        async with client.stream(
+            "POST", "/a2a/tasks/send/stream", content=params.model_dump_json()
+        ) as resp:
+            raw = await resp.aread()
+            raw = raw.decode()
+
+        events = [e.strip() for e in raw.split("\n\n") if e.strip()]
+        final = events[-1]
+        data_line = next(line for line in final.split("\n") if line.startswith("data:"))
+        parsed = json.loads(data_line.split(":", 1)[1].strip())
+        assert parsed["final"] is True
+        assert parsed["status"]["state"] == TaskState.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Tests: SSE format helper
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSSE:
+    def test_format_sse_basic(self):
+        result = _format_sse("test_event", {"key": "value"})
+        assert result.startswith("event: test_event\n")
+        assert "data:" in result
+        assert result.endswith("\n\n")
+
+    def test_format_sse_json_valid(self):
+        result = _format_sse("update", {"id": "t1", "status": "working"})
+        data_line = [line for line in result.split("\n") if line.startswith("data:")][0]
+        parsed = json.loads(data_line.split(":", 1)[1].strip())
+        assert parsed["id"] == "t1"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _A2ASessionBridge
+# ---------------------------------------------------------------------------
+
+
+class TestA2ASessionBridge:
+    @pytest.mark.asyncio
+    async def test_bridge_creation(self):
+        bridge = _A2ASessionBridge("chat-abc")
+        assert bridge.chat_id == "chat-abc"
+        assert isinstance(bridge.queue, asyncio.Queue)
+
+    @pytest.mark.asyncio
+    async def test_bridge_queue_chunk(self):
+        bridge = _A2ASessionBridge("x")
+        await bridge.queue.put({"type": "chunk", "content": "hello"})
+        item = await bridge.queue.get()
+        assert item["type"] == "chunk"
+        assert item["content"] == "hello"

--- a/tests/test_headless_permissions.py
+++ b/tests/test_headless_permissions.py
@@ -128,6 +128,7 @@ class TestToolExecutionInSubprocess:
                 **dict(__import__("os").environ),
                 "HOME": str(tmp_path),  # Isolate from real config
                 "USERPROFILE": str(tmp_path),  # Windows compat
+                "PYTHONIOENCODING": "utf-8",
             },
         )
 
@@ -140,6 +141,7 @@ class TestToolExecutionInSubprocess:
             **dict(__import__("os").environ),
             "HOME": str(tmp_path),
             "USERPROFILE": str(tmp_path),
+            "PYTHONIOENCODING": "utf-8",
         }
 
         # Save
@@ -195,6 +197,7 @@ class TestToolExecutionInSubprocess:
                     **dict(__import__("os").environ),
                     "HOME": str(tmp_path),
                     "USERPROFILE": str(tmp_path),
+                    "PYTHONIOENCODING": "utf-8",
                 },
             )
             # Should complete without timeout


### PR DESCRIPTION
## Summary

- Implements Phase 1 of #450, exposing PocketPaw as an A2A-compatible remote agent
- Adds `src/pocketpaw/a2a/` package with Pydantic models, FastAPI routers, and SSE streaming
- Agent Card served at `/.well-known/agent.json` for agent discovery
- Task endpoints: submit (blocking + SSE), poll, and cancel with full lifecycle management
- All task I/O routes through the existing AgentLoop message bus
- 27 tests covering all endpoints, models, and SSE formatting

## Changes

- `src/pocketpaw/a2a/__init__.py` - Package scaffold
- `src/pocketpaw/a2a/models.py` - Pydantic models (TaskState, Task, AgentCard, etc.)
- `src/pocketpaw/a2a/server.py` - FastAPI routers for agent card, task submit/poll/cancel
- `src/pocketpaw/dashboard.py` - Mount A2A routers on app startup
- `src/pocketpaw/config.py` - A2A config fields
- `tests/test_a2a_server.py` - 27 tests

## How to Test

```bash
# Run tests
uv run pytest tests/test_a2a_server.py -v

# Manual verification
uv run pocketpaw
curl http://localhost:8888/.well-known/agent.json
curl -X POST http://localhost:8888/a2a/tasks/send \
  -H "Content-Type: application/json" \
  -d '{"message": {"role": "user", "parts": [{"type": "text", "text": "Hello"}]}}'
```

## Test plan
- [x] All 27 A2A server tests pass
- [ ] Manual test: agent card endpoint returns valid JSON
- [ ] Manual test: task submit and poll lifecycle works end-to-end
- [ ] Manual test: SSE streaming returns properly formatted events

Based on PR #500 by @Vedant-Baldwa

🤖 Generated with [Claude Code](https://claude.com/claude-code)