### PR TITLE
[FI] Fix silent failure in load_reminders when JSON is corruptedFix silent failure in load_reminders by adding error logging and back…

### DIFF
--- a/src/pocketpaw/scheduler.py
+++ b/src/pocketpaw/scheduler.py
@@ -46,8 +46,17 @@ def load_reminders() -> list[dict]:
         try:
             data = json.loads(path.read_text())
             return data.get("reminders", [])
-        except Exception:
-            pass
+        except Exception as e:
+            logger.error(f"Failed to load reminders: {e}")
+
+            # Backup corrupted file
+            backup_path = path.with_suffix(".backup.json")
+            try:
+                path.rename(backup_path)
+                logger.warning(f"Corrupted reminders file backed up to {backup_path}")
+            except Exception as backup_error:
+                logger.error(f"Failed to backup corrupted file: {backup_error}")
+
     return []
 
 

--- a/tests/test_reminders_load.py
+++ b/tests/test_reminders_load.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+from pocketpaw.scheduler import load_reminders
+
+
+def test_load_reminders_with_corrupted_file(tmp_path, monkeypatch):
+    # Create fake .pocketpaw directory
+    fake_home = tmp_path
+    config_dir = fake_home / ".pocketpaw"
+    config_dir.mkdir()
+
+    # Create corrupted reminders.json
+    reminders_file = config_dir / "reminders.json"
+    reminders_file.write_text("{ invalid json")
+
+    # Monkeypatch Path.home() to use temp directory
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+
+    # Run function
+    result = load_reminders()
+
+    # Assert safe fallback
+    assert result == []
+
+    # Assert backup created
+    backup_file = config_dir / "reminders.backup.json"
+    assert backup_file.exists()


### PR DESCRIPTION
## Problem
`load_reminders()` silently ignores errors when the reminders.json file is corrupted due to a broad exception handler:

except Exception:
    pass

This can lead to silent data loss and makes debugging difficult.

## Solution
- Added error logging when JSON parsing fails
- Implemented automatic backup of corrupted reminders file
- Preserved safe fallback behavior (returns empty list)

## Changes
- Updated `load_reminders()` to log errors and create `.backup.json`
- Added unit test to verify behavior with corrupted JSON

## Test
- Added test: `test_load_reminders_with_corrupted_file`
- Verified:
  - Function returns `[]`
  - Backup file is created

## Impact
Improves reliability and prevents silent data loss when reminders file is corrupted.