### PR TITLE
fix: guard LLMRouter against empty LLM response (IndexError)

### DIFF
--- a/src/pocketpaw/llm/router.py
+++ b/src/pocketpaw/llm/router.py
@@ -10,6 +10,8 @@ Limitations:
   - Unbounded conversation history (call clear_history() to reset)
 """
 
+from __future__ import annotations
+
 import logging
 
 import httpx
@@ -139,6 +141,9 @@ class LLMRouter:
             ],
         )
 
+        if not response.choices:
+            logger.warning("OpenAI returned an empty choices list; returning fallback response")
+            return "I'm sorry, I received an empty response. Please try again."
         return response.choices[0].message.content
 
     async def _chat_anthropic(self, message: str) -> str:
@@ -157,6 +162,9 @@ class LLMRouter:
             messages=self.conversation_history,
         )
 
+        if not response.content:
+            logger.warning("Anthropic returned an empty content list; returning fallback response")
+            return "I'm sorry, I received an empty response. Please try again."
         return response.content[0].text
 
     def clear_history(self) -> None:

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -1,0 +1,202 @@
+"""Tests for LLMRouter empty-response handling (issue #664).
+
+Verifies that LLMRouter._chat_openai and LLMRouter._chat_anthropic
+return a safe fallback string instead of raising IndexError when the
+upstream LLM API returns an empty choices/content list.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pocketpaw.config import Settings
+from pocketpaw.llm.router import LLMRouter
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FALLBACK = "I'm sorry, I received an empty response. Please try again."
+
+
+def _make_router(provider: str = "openai") -> LLMRouter:
+    settings = Settings(
+        llm_provider=provider,
+        openai_api_key="sk-test",
+        anthropic_api_key="sk-ant-test",
+    )
+    router = LLMRouter(settings)
+    return router
+
+
+# ---------------------------------------------------------------------------
+# OpenAI path
+# ---------------------------------------------------------------------------
+
+
+class TestChatOpenAIEmptyResponse:
+    async def test_empty_choices_returns_fallback(self):
+        """IndexError must NOT be raised; fallback text is returned instead."""
+        router = _make_router("openai")
+        router._available_backend = "openai"
+
+        mock_response = MagicMock()
+        mock_response.choices = []
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        # AsyncOpenAI is imported lazily inside _chat_openai — patch at source
+        with patch("openai.AsyncOpenAI", return_value=mock_client):
+            result = await router._chat_openai("hello")
+
+        assert result == FALLBACK
+
+    async def test_empty_choices_does_not_raise(self):
+        """Regression: confirm no IndexError propagates to the caller."""
+        router = _make_router("openai")
+        router._available_backend = "openai"
+
+        mock_response = MagicMock()
+        mock_response.choices = []
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        with patch("openai.AsyncOpenAI", return_value=mock_client):
+            try:
+                await router._chat_openai("hello")
+            except IndexError:
+                pytest.fail("_chat_openai raised IndexError on empty choices")
+
+    async def test_normal_response_still_works(self):
+        """Non-empty choices returns the expected content."""
+        router = _make_router("openai")
+        router._available_backend = "openai"
+
+        mock_message = MagicMock()
+        mock_message.content = "Hello, world!"
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        with patch("openai.AsyncOpenAI", return_value=mock_client):
+            result = await router._chat_openai("hello")
+
+        assert result == "Hello, world!"
+
+
+# ---------------------------------------------------------------------------
+# Anthropic path
+# ---------------------------------------------------------------------------
+
+
+class TestChatAnthropicEmptyResponse:
+    async def test_empty_content_returns_fallback(self):
+        """IndexError must NOT be raised; fallback text is returned instead."""
+        router = _make_router("anthropic")
+        router._available_backend = "anthropic"
+
+        mock_response = MagicMock()
+        mock_response.content = []
+
+        mock_anthropic_client = AsyncMock()
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        mock_llm = MagicMock()
+        mock_llm.create_anthropic_client.return_value = mock_anthropic_client
+
+        # resolve_llm_client is imported lazily inside _chat_anthropic — patch at source
+        with patch("pocketpaw.llm.client.resolve_llm_client", return_value=mock_llm):
+            result = await router._chat_anthropic("hello")
+
+        assert result == FALLBACK
+
+    async def test_empty_content_does_not_raise(self):
+        """Regression: confirm no IndexError propagates to the caller."""
+        router = _make_router("anthropic")
+        router._available_backend = "anthropic"
+
+        mock_response = MagicMock()
+        mock_response.content = []
+
+        mock_anthropic_client = AsyncMock()
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        mock_llm = MagicMock()
+        mock_llm.create_anthropic_client.return_value = mock_anthropic_client
+
+        with patch("pocketpaw.llm.client.resolve_llm_client", return_value=mock_llm):
+            try:
+                await router._chat_anthropic("hello")
+            except IndexError:
+                pytest.fail("_chat_anthropic raised IndexError on empty content")
+
+    async def test_normal_response_still_works(self):
+        """Non-empty content returns the expected text."""
+        router = _make_router("anthropic")
+        router._available_backend = "anthropic"
+
+        mock_block = MagicMock()
+        mock_block.text = "Hi there!"
+        mock_response = MagicMock()
+        mock_response.content = [mock_block]
+
+        mock_anthropic_client = AsyncMock()
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        mock_llm = MagicMock()
+        mock_llm.create_anthropic_client.return_value = mock_anthropic_client
+
+        with patch("pocketpaw.llm.client.resolve_llm_client", return_value=mock_llm):
+            result = await router._chat_anthropic("hello")
+
+        assert result == "Hi there!"
+
+
+# ---------------------------------------------------------------------------
+# Integration: chat() surface
+# ---------------------------------------------------------------------------
+
+
+class TestChatFallbackIntegration:
+    async def test_chat_openai_empty_response_returns_fallback(self):
+        """End-to-end: chat() surfaces the fallback when OpenAI returns empty."""
+        router = _make_router("openai")
+        router._available_backend = "openai"
+
+        mock_response = MagicMock()
+        mock_response.choices = []
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        with patch("openai.AsyncOpenAI", return_value=mock_client):
+            result = await router.chat("ping")
+
+        assert result == FALLBACK
+
+    async def test_chat_anthropic_empty_response_returns_fallback(self):
+        """End-to-end: chat() surfaces the fallback when Anthropic returns empty."""
+        router = _make_router("anthropic")
+        router._available_backend = "anthropic"
+
+        mock_response = MagicMock()
+        mock_response.content = []
+
+        mock_anthropic_client = AsyncMock()
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        mock_llm = MagicMock()
+        mock_llm.create_anthropic_client.return_value = mock_anthropic_client
+
+        with patch("pocketpaw.llm.client.resolve_llm_client", return_value=mock_llm):
+            result = await router.chat("ping")
+
+        assert result == FALLBACK


### PR DESCRIPTION
## What does this PR do?

Guards `LLMRouter._chat_openai` and `LLMRouter._chat_anthropic` against an `IndexError` that occurs when the upstream LLM API returns an empty response list. Instead of crashing, the router now logs a warning and returns a safe fallback message to the caller.

## Related Issue

Fixes #664

## Changes Made

- `src/pocketpaw/llm/router.py`: Added empty-list guards before indexing `response.choices[0]` (OpenAI) and `response.content[0]` (Anthropic). Both paths log a `WARNING` and return `"I'm sorry, I received an empty response. Please try again."` when the list is empty. Also added `from __future__ import annotations` per project style.
- `tests/test_llm_router.py`: New test file with 8 tests covering — empty choices/content returns the fallback string, empty response does not raise `IndexError`, normal non-empty responses still return the expected content, and end-to-end `chat()` surface for both providers.

## How to Test

1. `uv sync --dev`
2. `uv run pytest tests/test_llm_router.py -v` — all 8 tests should pass
3. To reproduce the original crash manually:
   ```python
   from unittest.mock import MagicMock, AsyncMock
   from pocketpaw.config import Settings
   from pocketpaw.llm.router import LLMRouter
   import asyncio

   router = LLMRouter(Settings())
   router._available_backend = "openai"

   # Before fix: IndexError. After fix: safe fallback string.
   mock_resp = MagicMock(); mock_resp.choices = []
   # (patch openai.AsyncOpenAI appropriately and call _chat_openai)
   ```

## Evidence of Testing

```
$ uv run pytest tests/test_llm_router.py -v
============================= test session starts ==============================
collected 8 items

tests/test_llm_router.py::TestChatOpenAIEmptyResponse::test_empty_choices_returns_fallback PASSED
tests/test_llm_router.py::TestChatOpenAIEmptyResponse::test_empty_choices_does_not_raise PASSED
tests/test_llm_router.py::TestChatOpenAIEmptyResponse::test_normal_response_still_works PASSED
tests/test_llm_router.py::TestChatAnthropicEmptyResponse::test_empty_content_returns_fallback PASSED
tests/test_llm_router.py::TestChatAnthropicEmptyResponse::test_empty_content_does_not_raise PASSED
tests/test_llm_router.py::TestChatAnthropicEmptyResponse::test_normal_response_still_works PASSED
tests/test_llm_router.py::TestChatFallbackIntegration::test_chat_openai_empty_response_returns_fallback PASSED
tests/test_llm_router.py::TestChatFallbackIntegration::test_chat_anthropic_empty_response_returns_fallback PASSED
============================== 8 passed in 0.25s ==============================

$ uv run pytest --ignore=tests/e2e -q
3285 passed, 19 skipped, 89 warnings in 29.15s

$ uv run ruff check .
(no output — clean)
```

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff
