### PR TITLE
[FI] Add Windows venv activation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ python3 -m pip install --upgrade pip
 python3 -m venv pocketpaw-env
 source pocketpaw-env/bin/activate
 
+# On Linux/macOS:
+source pocketpaw-env/bin/activate
+
+# On Windows:
+pocketpaw-env\Scripts\activate
+
 # 4. Install PocketPaw
 pip install pocketpaw
 


### PR DESCRIPTION
> **Before opening this PR:**
> - Does it target `dev`? PRs against `main` are auto-closed.
> - Is there a linked issue? PRs without one will be closed.
> - Did you read [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md)?

## What does this PR do?

The `README.md` currently only lists the virtual environment activation command for Linux/macOS (`source pocketpaw-env/bin/activate`). This PR adds the correct activation command for Windows to prevent setup friction for new contributors.

## Related Issue

Fixes #686

## Changes Made

- `README.md`: Added Windows venv activation instructions (`pocketpaw-env\Scripts\activate`) to the Recommended install section.

## How to Test

1. Open a Windows command prompt.
2. Run `python -m venv pocketpaw-env` to create the environment.
3. Run `pocketpaw-env\Scripts\activate` to verify it successfully activates.

## Evidence of Testing

```text
C:\Users\acer\Desktop\pocketpaw>pocketpaw-env\Scripts\activate
(pocketpaw-env) C:\Users\acer\Desktop\pocketpaw>
```

## Checklist

- [x] PR targets dev branch (not main)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (uv run pytest --ignore=tests/e2e)
- [x] Linting passes (uv run ruff check .)
- [ ] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff
