### PR TITLE
fix: backup encrypted secrets when machine identity changes

### DIFF
--- a/src/pocketpaw/credentials.py
+++ b/src/pocketpaw/credentials.py
@@ -166,11 +166,22 @@ class CredentialStore:
             decrypted = fernet.decrypt(encrypted)
             self._cache = json.loads(decrypted)
         except (InvalidToken, json.JSONDecodeError, Exception) as exc:
-            logger.warning(
-                "Failed to decrypt secrets.enc (machine changed? corrupted?): %s. "
-                "Starting with empty credential store.",
-                exc,
-            )
+            backup_path = self._secrets_path.with_name(self._secrets_path.name + ".bak")
+            try:
+                self._secrets_path.replace(backup_path)
+                logger.warning(
+                    "Failed to decrypt secrets.enc (did your machine name or username change?).\n"
+                    "Your previous credentials have been locked to protect them and safely backed up to:\n"
+                    "  %s\n"
+                    "If you restore your previous machine identity (hostname/username), you can "
+                    "rename this backup file back to 'secrets.enc' to recover your secrets.\n"
+                    "Starting with a new, empty credential store. Error: %s",
+                    backup_path, exc
+                )
+            except OSError as mv_exc:
+                logger.error("Failed to back up unreadable secrets.enc: %s", mv_exc)
+                logger.warning("Starting with empty credential store.")
+            
             self._cache = {}
 
         return self._cache


### PR DESCRIPTION
### Description
This addresses a critical data loss bug where renaming my computer caused `secrets.enc` to be completely overwritten with an empty dictionary. 

Instead of silently erasing the secrets when `InvalidToken` is caught (caused by a mismatched `machine_identity`), this fix renames the broken file to `secrets.enc.bak` and logs a verbose warning. It maintains the original security intent (stolen files still cannot be decrypted) while preventing accidental data loss for legitimate users.
