### PR TITLE
fix(memory): deduplicate soul and regular memory

### DIFF
--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -771,10 +771,18 @@ class AgentLoop:
                 )
 
                 # 6. Auto-learn: extract facts from conversation (non-blocking)
-                # Skip auto-learn on cancelled responses — partial data is unreliable
-                should_auto_learn = not cancelled and (
-                    (self.settings.memory_backend == "mem0" and self.settings.mem0_auto_learn)
-                    or (self.settings.memory_backend == "file" and self.settings.file_auto_learn)
+                # Skip auto-learn on cancelled responses — partial data is unreliable.
+                # Also skip when soul is active — soul.observe() + reflect() handles
+                # fact extraction and memory consolidation, so auto_learn would duplicate.
+                should_auto_learn = (
+                    not cancelled
+                    and self._soul_manager is None
+                    and (
+                        (self.settings.memory_backend == "mem0" and self.settings.mem0_auto_learn)
+                        or (
+                            self.settings.memory_backend == "file" and self.settings.file_auto_learn
+                        )
+                    )
                 )
                 if should_auto_learn:
                     t = asyncio.create_task(

--- a/src/pocketpaw/agents/tool_bridge.py
+++ b/src/pocketpaw/agents/tool_bridge.py
@@ -73,12 +73,14 @@ def _instantiate_all_tools(backend: str = "claude_agent_sdk") -> list[BaseTool]:
         except Exception as exc:
             logger.debug("Skipping tool %s: %s", class_name, exc)
 
-    # Inject soul tools if soul is active
+    # Inject soul tools if soul is active — and exclude regular memory tools
+    # to avoid overlap (soul_remember/soul_recall supersede remember/recall/forget).
     try:
         from pocketpaw.soul.manager import get_soul_manager
 
         soul_mgr = get_soul_manager()
         if soul_mgr is not None:
+            tools = [t for t in tools if t.name not in ("remember", "recall", "forget")]
             tools.extend(soul_mgr.get_tools())
     except Exception:
         pass  # Soul not available

--- a/src/pocketpaw/bootstrap/context_builder.py
+++ b/src/pocketpaw/bootstrap/context_builder.py
@@ -78,7 +78,14 @@ class AgentContextBuilder:
         parts = [base_prompt]
 
         # 2. Inject memory context (scoped to sender)
-        if include_memory and memory_context:
+        # When soul is active, soul's bootstrap provider already handles persistent
+        # memory (identity, personality, knowledge domains). Skip regular long-term
+        # memory injection to avoid duplication — the agent should use soul_recall
+        # for fact retrieval instead. Session history is still managed by regular memory.
+        from pocketpaw.paw.soul_bridge import SoulBootstrapProvider
+
+        soul_active = isinstance(self.bootstrap, SoulBootstrapProvider)
+        if include_memory and memory_context and not soul_active:
             parts.append(
                 "\n# Memory Context (already loaded — use this directly, "
                 "do NOT call recall unless you need something not listed here)\n" + memory_context


### PR DESCRIPTION
## Summary

When `soul_enabled=true`, both memory systems were running in parallel, causing overlap:

- **Duplicate tools**: Both `remember`/`recall`/`forget` and `soul_remember`/`soul_recall` existed, forcing the agent to guess which to use
- **Duplicate fact extraction**: Both `_auto_learn()` and `soul.observe()` + `reflect()` fired after every response, storing the same facts in two places
- **Wasted context window**: Both regular long-term memory AND soul identity/knowledge were injected into the system prompt

## Changes

Three surgical fixes (3 files, ~15 lines changed):

- **`tool_bridge.py`**: Exclude `remember`, `recall`, `forget` from tool registry when soul is active. Soul tools (`soul_remember`, `soul_recall`) supersede them with richer features (importance scoring, emotional context, consolidation).
- **`loop.py`**: Skip `_auto_learn()` when soul is active. Soul's `observe()` + `reflect()` pipeline already handles fact extraction from conversations.
- **`context_builder.py`**: Skip long-term memory injection into system prompt when `SoulBootstrapProvider` is active. Soul's bootstrap already injects identity, personality, mood, energy, and knowledge domains.

## What stays unchanged

- **Session history** (`add_to_session`, `get_compacted_history`, all session tools) still uses regular memory, since soul doesn't handle sessions
- **When `soul_enabled=false`**, all behavior is identical to before, zero code path changes

## Test plan

- [x] Full test suite passes (3556 passed, 0 failed)
- [x] Soul integration tests pass (tool injection, bootstrap, lifecycle)
- [x] Soul manager tests pass (observe, reflect, tools, dirty tracking)
- [x] Agent loop tests pass
- [x] No regressions in memory, tool policy, or injection scanner tests
