### PR TITLE
[FI] fix: correct invalid tool trust levels, fetch.py crash, and PII scanner gaps

### DIFF
--- a/src/pocketpaw/security/pii.py
+++ b/src/pocketpaw/security/pii.py
@@ -23,6 +23,8 @@ class PIIType(StrEnum):
     CREDIT_CARD = "credit_card"
     IP_ADDRESS = "ip_address"
     DATE_OF_BIRTH = "date_of_birth"
+    PASSPORT = "passport"
+    BANK_ACCOUNT = "bank_account"
 
 
 class PIIAction(StrEnum):
@@ -70,6 +72,10 @@ class PIIScanResult:
 _PII_PATTERNS: list[tuple[str, PIIType, int]] = [
     # SSN: 123-45-6789 (dashed format only — bare 9-digit has too many false positives)
     (r"\b\d{3}-\d{2}-\d{4}\b", PIIType.SSN, 0),
+    # SSN: 123 45 6789 (space-separated)
+    (r"\b\d{3}\s\d{2}\s\d{4}\b", PIIType.SSN, 0),
+    # SSN: contextual bare 9-digit (requires keyword nearby)
+    (r"(?:ssn|social security)\s*(?:number|num|no|#)?[\s:]*\b\d{9}\b", PIIType.SSN, re.IGNORECASE),
     # Email addresses
     (r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b", PIIType.EMAIL, 0),
     # US phone: (555) 123-4567, 555-123-4567, 555.123.4567, +1 555-123-4567
@@ -96,6 +102,14 @@ _PII_PATTERNS: list[tuple[str, PIIType, int]] = [
         PIIType.DATE_OF_BIRTH,
         re.IGNORECASE,
     ),
+    # Passport number (contextual — requires "passport" keyword)
+    (
+        r"(?:passport)\s*(?:number|num|no|#)?[\s:]*\b[A-Z0-9]{6,9}\b",
+        PIIType.PASSPORT,
+        re.IGNORECASE,
+    ),
+    # IBAN (2-letter country code + 2 check digits + up to 30 alphanumeric)
+    (r"\b[A-Z]{2}\d{2}[A-Z0-9]{4,30}\b", PIIType.BANK_ACCOUNT, 0),
 ]
 
 _COMPILED_PII: list[tuple[re.Pattern, PIIType]] = [

--- a/src/pocketpaw/tools/builtin/pip_install.py
+++ b/src/pocketpaw/tools/builtin/pip_install.py
@@ -37,7 +37,7 @@ class InstallPackageTool(BaseTool):
 
     @property
     def trust_level(self) -> str:
-        return "elevated"
+        return "high"
 
     @property
     def parameters(self) -> dict[str, Any]:

--- a/src/pocketpaw/tools/builtin/python_exec.py
+++ b/src/pocketpaw/tools/builtin/python_exec.py
@@ -28,7 +28,7 @@ class RunPythonTool(BaseTool):
 
     @property
     def trust_level(self) -> str:
-        return "elevated"
+        return "critical"
 
     @property
     def parameters(self) -> dict[str, Any]:

--- a/src/pocketpaw/tools/fetch.py
+++ b/src/pocketpaw/tools/fetch.py
@@ -21,6 +21,9 @@ def is_safe_path(path: Path, jail: Path) -> bool:
 
 def get_directory_keyboard(path: Path, jail: Path | None = None) -> InlineKeyboardMarkup:
     """Generate inline keyboard for directory contents."""
+    if InlineKeyboardMarkup is None:
+        return None
+
     if jail is None:
         jail = Path.home()
 

--- a/tests/test_install_package.py
+++ b/tests/test_install_package.py
@@ -257,7 +257,7 @@ def test_install_package_definition():
     defn = tool.definition
 
     assert defn.name == "install_package"
-    assert defn.trust_level == "elevated"
+    assert defn.trust_level == "high"
 
     props = defn.parameters["properties"]
     assert "package" in props

--- a/tests/test_run_python.py
+++ b/tests/test_run_python.py
@@ -211,7 +211,7 @@ def test_run_python_definition():
     defn = tool.definition
 
     assert defn.name == "run_python"
-    assert defn.trust_level == "elevated"
+    assert defn.trust_level == "critical"
 
     props = defn.parameters["properties"]
     assert "code" in props


### PR DESCRIPTION
# PR Description

## Title
[FI] fix: correct invalid tool trust levels, fetch.py crash, and PII scanner gaps

## Body

### Problem

Three independent issues found during codebase analysis:

**1. Invalid `trust_level="elevated"` on `RunPythonTool` and `InstallPackageTool`**

Both tools return `trust_level = "elevated"`, which is not a recognized trust level. The tool system only recognizes `standard`, `high`, and `critical`. In `tools/registry.py`, the trust-to-audit-severity mapping falls through to the `else` branch for unrecognized levels:

```python
# tools/registry.py lines 109-115
if t_level == "critical":
    severity = AuditSeverity.CRITICAL
elif t_level == "high":
    severity = AuditSeverity.WARNING
else:
    severity = AuditSeverity.INFO  # ← "elevated" falls here
```

This means arbitrary Python code execution (`run_python`) and package installation (`install_package`) are audited at `INFO` severity — the same as safe read-only tools.

**2. `get_directory_keyboard()` crashes when `python-telegram-bot` is not installed**

`tools/fetch.py` conditionally imports `InlineKeyboardMarkup`, setting it to `None` when unavailable. But `get_directory_keyboard()` calls `InlineKeyboardMarkup(buttons)` unconditionally, causing `TypeError: 'NoneType' object is not callable` in non-Telegram deployments.

**3. PII scanner misses common patterns**

The PII scanner (`security/pii.py`) only detects dashed SSNs (`123-45-6789`). It misses space-separated SSNs (`123 45 6789`), contextual bare 9-digit SSNs, passport numbers, and IBANs.

### Solution

**1. Trust levels**: Changed `RunPythonTool.trust_level` to `"critical"` (arbitrary code execution, same as `ShellTool`) and `InstallPackageTool.trust_level` to `"high"` (has Guardian + regex validation guardrails). Updated corresponding test assertions.

**2. Fetch crash**: Added early return guard `if InlineKeyboardMarkup is None: return None` at the top of `get_directory_keyboard()`.

**3. PII patterns**: Added `PASSPORT` and `BANK_ACCOUNT` to `PIIType` enum. Added 4 new regex patterns:
- SSN space-separated: `\b\d{3}\s\d{2}\s\d{4}\b`
- SSN contextual bare 9-digit (requires keyword like "SSN" or "social security")
- Passport number (contextual, requires "passport" keyword)
- IBAN (2-letter country code + 2 check digits + alphanumeric body)

### Files Changed

| File | Change |
|---|---|
| `src/pocketpaw/tools/builtin/python_exec.py` | `trust_level`: `"elevated"` → `"critical"` |
| `src/pocketpaw/tools/builtin/pip_install.py` | `trust_level`: `"elevated"` → `"high"` |
| `src/pocketpaw/tools/fetch.py` | Guard `get_directory_keyboard()` for missing telegram |
| `src/pocketpaw/security/pii.py` | Add 2 enum values + 4 regex patterns |
| `tests/test_run_python.py` | Update trust_level assertion |
| `tests/test_install_package.py` | Update trust_level assertion |

### Testing

```
3,211 passed, 39 failed (all pre-existing missing-dep issues), 46 skipped
```

- All 53 directly affected tests pass
- `test_tools.py::TestFetchTool::test_handle_path_directory` — was failing, now passes
- Zero regressions introduced (39 failures are all pre-existing: missing playwright/sarvamai/psutil/aiohttp)
- Ruff lint: all checks passed
- Ruff format: all files already formatted

### Checklist

- [x] Code follows project conventions
- [x] Tests updated for changed behavior
- [x] No new dependencies introduced
- [x] Backward compatible
- [x] Ruff lint passes
- [x] Ruff format passes
