### PR TITLE
Fix/csp xss protection

### DIFF
--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -148,6 +148,10 @@ _EXTRA_ORIGINS = list(set(_BUILTIN_ORIGINS + _custom_origins))
 @app.middleware("http")
 async def security_headers_middleware(request: Request, call_next):
     """Add security headers to all responses."""
+    import secrets
+    nonce = secrets.token_urlsafe(16)
+    request.state.csp_nonce = nonce
+
     response = await call_next(request)
 
     # Allow the file-content endpoint to be embedded in same-origin iframes
@@ -161,10 +165,10 @@ async def security_headers_middleware(request: Request, call_next):
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
-    # CSP: allow self + CDN + inline styles/scripts (required by Alpine.js/UnoCSS)
+    # CSP: allow self + CDN + strictly nonced scripts (Alpine evaluates allowed via unsafe-eval)
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; "
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval' "
+        f"script-src 'self' 'nonce-{nonce}' 'unsafe-eval' "
         "https://cdn.jsdelivr.net https://unpkg.com; "
         "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; "
         "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; "

--- a/src/pocketpaw/frontend/templates/base.html
+++ b/src/pocketpaw/frontend/templates/base.html
@@ -38,7 +38,7 @@
     <link rel="stylesheet" href="/static/css/styles.css?v={{ v }}" />
 
     <!-- UnoCSS Runtime (utilities alongside custom CSS) -->
-    <script>
+    <script nonce="{{ request.state.csp_nonce }}">
       window.__unocss = {
         theme: {
           colors: {
@@ -312,7 +312,7 @@
     <script src="/static/js/app.js?v={{ v }}"></script>
 
     <!-- Initialize Lucide icons + dismiss preloader -->
-    <script>
+    <script nonce="{{ request.state.csp_nonce }}">
       // Initial render
       document.addEventListener('DOMContentLoaded', () => {
         lucide.createIcons();

--- a/src/pocketpaw/frontend/templates/components/modals/plan_approval.html
+++ b/src/pocketpaw/frontend/templates/components/modals/plan_approval.html
@@ -11,10 +11,10 @@
     </div>
 
     <div class="modal-footer" style="display:flex;gap:10px;justify-content:flex-end;padding-top:12px;border-top:1px solid var(--border-color, #333)">
-      <button onclick="PlanMode.reject()" class="btn btn-secondary" style="padding:8px 20px">
+      <button @click="PlanMode.reject()" class="btn btn-secondary" style="padding:8px 20px">
         Reject
       </button>
-      <button onclick="PlanMode.approve()" class="btn btn-primary" style="padding:8px 20px;background:var(--accent-color, #4CAF50);color:#fff;border:none;border-radius:6px;cursor:pointer">
+      <button @click="PlanMode.approve()" class="btn btn-primary" style="padding:8px 20px;background:var(--accent-color, #4CAF50);color:#fff;border:none;border-radius:6px;cursor:pointer">
         Approve
       </button>
     </div>

--- a/tests/test_a2a_server.py
+++ b/tests/test_a2a_server.py
@@ -636,7 +636,7 @@ class TestTasksSend:
         await _load()
 
         params = _make_send_params()
-        resp = await client.post("/a2a/tasks/send", content=params.model_dump_json())
+        resp = await client.post("/a2a/tasks/send", json=params.model_dump(mode='json'))
         assert resp.status_code == 200
         data = resp.json()
         assert data["id"] == "test-task-001"
@@ -661,7 +661,7 @@ class TestTasksSend:
         await _load()
 
         params = _make_send_params(task_id="artifact-test")
-        resp = await client.post("/a2a/tasks/send", content=params.model_dump_json())
+        resp = await client.post("/a2a/tasks/send", json=params.model_dump(mode='json'))
         data = resp.json()
         assert len(data["artifacts"]) == 1
         assert data["artifacts"][0]["name"] == "response"
@@ -684,7 +684,7 @@ class TestTasksSend:
         await _load()
 
         params = _make_send_params()
-        resp = await client.post("/a2a/tasks/send", content=params.model_dump_json())
+        resp = await client.post("/a2a/tasks/send", json=params.model_dump(mode='json'))
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"]["state"] == TaskState.FAILED
@@ -712,7 +712,7 @@ class TestTasksSend:
         await _load()
 
         params = _make_send_params()
-        resp = await client.post("/a2a/tasks/send", content=params.model_dump_json())
+        resp = await client.post("/a2a/tasks/send", json=params.model_dump(mode='json'))
         data = resp.json()
         assert len(data["history"]) >= 2
         assert data["history"][0]["role"] == "user"
@@ -822,7 +822,7 @@ class TestTasksSendStream:
         params = _make_send_params(task_id="stream-task")
 
         async with client.stream(
-            "POST", "/a2a/tasks/send/stream", content=params.model_dump_json()
+            "POST", "/a2a/tasks/send/stream", json=params.model_dump(mode='json')
         ) as resp:
             assert resp.status_code == 200
             assert "text/event-stream" in resp.headers.get("content-type", "")
@@ -846,7 +846,7 @@ class TestTasksSendStream:
         await _load()
         params = _make_send_params(task_id="sse-val")
         async with client.stream(
-            "POST", "/a2a/tasks/send/stream", content=params.model_dump_json()
+            "POST", "/a2a/tasks/send/stream", json=params.model_dump(mode='json')
         ) as resp:
             raw = await resp.aread()
             raw = raw.decode()
@@ -885,7 +885,7 @@ class TestTasksSendStream:
         await _load()
         params = _make_send_params(task_id="final-test")
         async with client.stream(
-            "POST", "/a2a/tasks/send/stream", content=params.model_dump_json()
+            "POST", "/a2a/tasks/send/stream", json=params.model_dump(mode='json')
         ) as resp:
             raw = await resp.aread()
             raw = raw.decode()
@@ -916,7 +916,7 @@ class TestTasksSendStream:
         await _load()
         params = _make_send_params(task_id="artifact-stream")
         async with client.stream(
-            "POST", "/a2a/tasks/send/stream", content=params.model_dump_json()
+            "POST", "/a2a/tasks/send/stream", json=params.model_dump(mode='json')
         ) as resp:
             raw = await resp.aread()
             raw = raw.decode()


### PR DESCRIPTION
### What problem does this solve?
The current `Content-Security-Policy` header explicitly allowed `unsafe-inline` in its `script-src` directive (added to support Alpine.js/UnoCSS initialization). By allowing this, the CSP's primary defense-in-depth against XSS execution was nullified. An attacker who managed to inject a malicious `<script>` tag or HTML payload could achieve arbitrary execution because the policy whitelisted all inline scripts globally.

### How does this solve it?
Instead of adding heavy Node.js built-step refactors for UnoCSS (which would disrupt the Python-focused dev workflow for this dashboard), this PR implements a native, zero-dependency **dynamic CSP nonce** solution:
1. The FastAPI middleware now dynamically generates a secure 16-byte cryptographic nonce using Python's built-in `secrets` module for every incoming request.
2. The `Content-Security-Policy` header was updated to replace `'unsafe-inline'` with the strict `'nonce-<dynamic>'` value, maintaining `'unsafe-eval'` for Alpine.js bindings.
3. The nonce is injected securely into the `base.html` Jinja2 template and attached *only* to the authorized inline `<script>` tags used to initialize UnoCSS and Lucide icons.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Security patch
