### PR TITLE
fix: Windows stability - cross-platform MCP stdio + Bun crash auto-retry

### DIFF
--- a/src/pocketpaw/mcp/discord_server.py
+++ b/src/pocketpaw/mcp/discord_server.py
@@ -338,27 +338,30 @@ async def _handle_request(request: dict) -> dict:
     }
 
 
+async def _read_stdin(loop: asyncio.AbstractEventLoop) -> bytes:
+    """Read a line from stdin in a thread (works on all platforms)."""
+    return await loop.run_in_executor(None, sys.stdin.buffer.readline)
+
+
+async def _read_exact(loop: asyncio.AbstractEventLoop, n: int) -> bytes:
+    """Read exactly n bytes from stdin in a thread (works on all platforms)."""
+    return await loop.run_in_executor(None, sys.stdin.buffer.read, n)
+
+
 async def main():
     """Run the MCP server on stdio."""
-    reader = asyncio.StreamReader()
-    protocol = asyncio.StreamReaderProtocol(reader)
-    await asyncio.get_event_loop().connect_read_pipe(lambda: protocol, sys.stdin.buffer)
-
-    writer_transport, writer_protocol = await asyncio.get_event_loop().connect_write_pipe(
-        asyncio.streams.FlowControlMixin, sys.stdout.buffer
-    )
-    writer = asyncio.StreamWriter(writer_transport, writer_protocol, None, asyncio.get_event_loop())
+    loop = asyncio.get_event_loop()
 
     while True:
-        header = await reader.readline()
+        header = await _read_stdin(loop)
         if not header:
             break
 
         header_str = header.decode().strip()
         if header_str.startswith("Content-Length:"):
             content_length = int(header_str.split(":")[1].strip())
-            await reader.readline()  # empty line
-            body = await reader.readexactly(content_length)
+            await _read_stdin(loop)  # empty line
+            body = await _read_exact(loop, content_length)
             request = json.loads(body.decode())
 
             response = await _handle_request(request)
@@ -367,8 +370,8 @@ async def main():
 
             response_bytes = json.dumps(response).encode()
             out = f"Content-Length: {len(response_bytes)}\r\n\r\n".encode() + response_bytes
-            writer.write(out)
-            await writer.drain()
+            sys.stdout.buffer.write(out)
+            sys.stdout.buffer.flush()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Discord MCP server**: Replace Unix-only `connect_read_pipe`/`connect_write_pipe` with thread-based `run_in_executor` reads and direct `sys.stdout.buffer.write`. Fixes the `pocketpaw-discord` MCP server crashing on startup because the Windows `ProactorEventLoop` does not support pipe-based async streams.
- **Claude SDK backend**: Auto-detect Bun runtime panics ("switch on corrupt value", exit code 3) and retry the query once with a fresh subprocess. This is a known Bun bug on Windows under memory pressure during long sessions.

## Test plan
- [ ] Start the Discord adapter on Windows and verify the MCP server starts without crashing
- [ ] Verify MCP tool calls (e.g. `discord_send_message`) still work end-to-end
- [ ] Trigger a long Claude SDK session and confirm auto-retry fires on Bun crash
- [ ] Confirm no regression on Linux/macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)