### PR TITLE
[FI] Fix: Prevent E2E test failures by skipping without full environment setup

### DIFF
--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -7,7 +7,17 @@
 # Run with: pytest tests/e2e/ -v --headed (to see browser)
 # Run headless: pytest tests/e2e/ -v
 
+import pytest
+import os
+
+# Skip entire module BEFORE anything else
+if not os.environ.get("RUN_E2E"):
+    pytest.skip("E2E tests require full environment setup", allow_module_level=True)
+
+pytest.importorskip("playwright.sync_api")
+
 from playwright.sync_api import Page, expect
+
 
 
 class TestDashboardLoads:

--- a/tests/e2e/test_deep_work_e2e.py
+++ b/tests/e2e/test_deep_work_e2e.py
@@ -15,12 +15,17 @@
 #   6. Output chaining: task output stored on task.output field
 #   7. Cancel rejection: completed/cancelled projects can't be cancelled again
 #   8. PawKit YAML round-trip through real file system
+import pytest
+import os
+
+# Skip entire module unless explicitly enabled
+if not os.environ.get("RUN_E2E"):
+    pytest.skip("E2E tests require full environment setup", allow_module_level=True)
 
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
-import pytest
 from fastapi import FastAPI
 
 from pocketpaw.deep_work.api import router as deep_work_router

--- a/tests/e2e/test_security.py
+++ b/tests/e2e/test_security.py
@@ -10,8 +10,16 @@
 # Run with: pytest tests/e2e/test_security.py -v --headed
 
 
-from playwright.sync_api import Page, expect
+import pytest
+import os
 
+# Skip entire module BEFORE anything else
+if not os.environ.get("RUN_E2E"):
+    pytest.skip("E2E tests require full environment setup", allow_module_level=True)
+
+pytest.importorskip("playwright.sync_api")
+
+from playwright.sync_api import Page, expect
 
 class TestWebSocketAuth:
     """Tests for WebSocket authentication via first message."""


### PR DESCRIPTION
E2E tests currently fail in environments where the full setup (browser, server, or runtime dependencies) is not available.

This PR ensures that E2E tests are skipped by default unless explicitly enabled via the RUN_E2E environment variable.

Fixes #715

Key changes:
- Added module-level skip guard in all E2E test files
- Ensures tests do not fail during collection or execution in minimal environments
- Maintains ability to run E2E tests when full setup is available

This improves test stability and prevents false negatives during development and CI.