### PR TITLE
[FI] Fix: Make Telegram token validation consistent across codebase

### DIFF
--- a/src/pocketpaw/dashboard_channels.py
+++ b/src/pocketpaw/dashboard_channels.py
@@ -582,8 +582,11 @@ async def _validate_channel_tokens(channel: str, config: dict) -> str | None:
 
     elif channel == "telegram":
         bot_token = config.get("bot_token", "")
-        if bot_token and ":" not in bot_token:
-            return "Invalid Telegram bot token. It should be in the format '123456:ABC-DEF...'."
+        if bot_token:
+            # Telegram tokens: numeric_id:alphanumeric_secret format
+            telegram_token_pattern = re.compile(r'^\d+:[A-Za-z0-9_-]+$')
+            if not telegram_token_pattern.match(bot_token):
+                return "Invalid Telegram bot token. Expected format: numeric_id:alphanumeric_secret"
 
     return None
 


### PR DESCRIPTION
## Issue
Telegram bot token validation was inconsistent between config.py (using regex) and dashboard_channels.py (using simple colon check), causing users to get different validation results depending on where they enter tokens.

## Fix
- Replace simple colon check in dashboard_channels.py with proper regex pattern
- Use same validation pattern as config.py: `^\d+:[A-Za-z0-9_-]+$`
- Update error message to be more specific about expected format
- Ensures consistent validation behavior across all token entry points

## Testing
- Tested with invalid tokens (no colon, wrong characters, non-numeric ID) - correctly rejected
- Tested with valid format tokens (numeric_id:alphanumeric_secret) - correctly accepted
- Verified validation now matches behavior in config.py

## Result
Users now receive consistent token validation regardless of where they enter Telegram bot tokens, improving user experience and reducing confusion.