### PR TITLE
chore(client): bump desktop version to 0.1.4

### DIFF
--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PocketPaw",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "com.pocketpaw.client",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Bumps the Tauri desktop client version from 0.1.4 to 0.1.4 to cut a new desktop release.

No code changes — version bump only. Once merged to main, tag `client-v0.1.4` to trigger the build workflow and generate binaries for all platforms (macOS arm64/x64, Windows exe/msi, Linux AppImage/deb/rpm).

**Why:** Users downloading the latest release (`v0.4.15`) see no binaries. The desktop binaries live on separate `client-v*` tags. Cutting `client-v0.1.4` makes it easy to find platform binaries alongside the latest backend.