### PR TITLE
fix(ci): skip PyPI publish on client-v* release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
 # Publish to PyPI when a release is created
 # Changes: Initial creation for PyPI publishing
+# Updated: skip client-v* release tags (desktop releases), only run on v* backend tags
 
 name: Publish to PyPI
 
@@ -12,6 +13,7 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || !startsWith(github.ref, 'refs/tags/client-') }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The PyPI publish workflow was firing on every release, including desktop client releases (`client-v*` tags). This caused a spurious failure on the `client-v0.1.4` release since there's no new Python package to publish.

Added an `if` condition to the `build` job that skips the workflow when the release tag starts with `client-`. Manual `workflow_dispatch` runs are always allowed through.