### PR TITLE
Fix/installer cli choices

### DIFF
--- a/installer/installer.py
+++ b/installer/installer.py
@@ -1258,13 +1258,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--backend",
-        choices=["claude_agent_sdk", "pocketpaw_native", "open_interpreter"],
+        choices=list(BACKENDS.keys()),
         default=None,
         help="Agent backend (non-interactive)",
     )
     parser.add_argument(
         "--llm-provider",
-        choices=["anthropic", "openai", "ollama", "auto"],
+        choices=list(LLM_PROVIDERS.keys()),
         default=None,
         help="LLM provider (non-interactive)",
     )


### PR DESCRIPTION
## What does this PR do?

The `--backend` and `--llm-provider` flags in `build_parser()` had hardcoded choices lists that were out of sync with the `BACKENDS` and `LLM_PROVIDERS` dicts. This caused argparse to reject valid options like `openai_agents` and `gemini`, breaking all non-interactive and CI installs that use those backends.

## Related Issue

Fixes #727

## Changes Made

- `installer/installer.py`: replaced hardcoded `choices=["claude_agent_sdk", "pocketpaw_native", "open_interpreter"]` with `choices=list(BACKENDS.keys())`
- `installer/installer.py`: replaced hardcoded `choices=["anthropic", "openai", "ollama", "auto"]` with `choices=list(LLM_PROVIDERS.keys())`

## How to Test

1. Run `python installer.py --non-interactive --backend openai_agents --llm-provider auto`
2. Run `python installer.py --non-interactive --backend google_adk --llm-provider gemini`
3. Both commands should proceed without argparse errors (previously they crashed)

## Evidence of Testing

$ python installer/installer.py --non-interactive --backend openai_agents --llm-provider gemini

Successfully installed pocketpaw and dependencies.
Installing Playwright browsers...
Installation cancelled.

No argparse error — fix confirmed working.
Before fix: error: argument --backend: invalid choice: 'openai_agents'
After fix: installer accepts openai_agents and gemini without errors.


## Checklist
- [x] PR targets `dev` branch (not `main`)
- [ ] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [ ] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff