### PR TITLE
[FI] Ensure valid object schema for tools without properties

### DIFF
--- a/src/pocketpaw/agents/tool_bridge.py
+++ b/src/pocketpaw/agents/tool_bridge.py
@@ -23,7 +23,7 @@ import logging
 from typing import Any
 
 from pocketpaw.tools.policy import ToolPolicy
-from pocketpaw.tools.protocol import BaseTool
+from pocketpaw.tools.protocol import BaseTool, normalize_schema
 from pocketpaw.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
@@ -126,14 +126,8 @@ def build_openai_function_tools(settings: Any, backend: str = "openai_agents") -
 
         defn = tool.definition
 
-        # Sanitize JSON schema: strict providers (e.g. Groq) reject schemas
-        # where 'required' is present but 'properties' is empty or missing.
-        params_schema = dict(defn.parameters) if defn.parameters else {"type": "object"}
-        props = params_schema.get("properties")
-        if not props and "required" in params_schema:
-            params_schema.pop("required")
-        if not props and "properties" in params_schema:
-            params_schema.pop("properties")
+        # Reuse the shared schema normalizer so zero-arg tools survive strict OpenAI validation.
+        params_schema = normalize_schema(defn.parameters or {"type": "object"})
 
         ft = FunctionTool(
             name=defn.name,

--- a/src/pocketpaw/tools/protocol.py
+++ b/src/pocketpaw/tools/protocol.py
@@ -7,6 +7,18 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 
 
+def normalize_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Normalize JSON schema for strict OpenAI-style function validators."""
+    schema = dict(schema)
+    if schema.get("type") == "object":
+        # Zero-arg tools still need an explicit object shape for strict validators.
+        schema.setdefault("properties", {})
+        if not schema["properties"]:
+            # Keep the schema callable with no inputs instead of emitting an invalid object schema.
+            schema["required"] = []
+    return schema
+
+
 @dataclass
 class ToolDefinition:
     """Tool definition for LLM function calling."""
@@ -23,7 +35,8 @@ class ToolDefinition:
             "function": {
                 "name": self.name,
                 "description": self.description,
-                "parameters": self.parameters,
+                # OpenAI-style backends are stricter than Anthropic about empty object schemas.
+                "parameters": normalize_schema(self.parameters),
             },
         }
 

--- a/tests/test_paw_tools.py
+++ b/tests/test_paw_tools.py
@@ -351,3 +351,14 @@ class TestToolDefinitions:
         assert schema["type"] == "function"
         assert "function" in schema
         assert schema["function"]["name"] == "soul_remember"
+
+    def test_openai_schema_normalizes_zero_arg_tools(self, mock_soul):
+        tool = SoulStatusTool(mock_soul)
+        schema = tool.definition.to_openai_schema()
+
+        # Shared OpenAI schema formatting should normalize zero-arg tools at the definition layer.
+        assert schema["function"]["parameters"] == {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }

--- a/tests/test_tool_bridge.py
+++ b/tests/test_tool_bridge.py
@@ -147,6 +147,30 @@ class TestBuildOpenAIFunctionTools:
             # Only remember and recall should pass minimal profile
             assert len(result) == 2
 
+    @patch("pocketpaw.agents.tool_bridge._instantiate_all_tools")
+    def test_normalizes_empty_object_schema_for_openai_tools(self, mock_instantiate):
+        """Zero-arg tools keep an explicit empty object schema for strict providers."""
+        mock_tool = MagicMock()
+        mock_tool.name = "gmail_list_labels"
+        mock_tool.definition.name = "gmail_list_labels"
+        mock_tool.definition.description = "List Gmail labels"
+        mock_tool.definition.parameters = {"type": "object", "properties": {}}
+        mock_instantiate.return_value = [mock_tool]
+
+        mock_ft_cls = MagicMock()
+        with patch.dict("sys.modules", {"agents": MagicMock(FunctionTool=mock_ft_cls)}):
+            from pocketpaw.agents.tool_bridge import build_openai_function_tools
+
+            build_openai_function_tools(Settings())
+
+        kwargs = mock_ft_cls.call_args.kwargs
+        # The bridge should preserve an explicit empty object schema for zero-arg tools.
+        assert kwargs["params_json_schema"] == {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+
 
 class TestMakeInvokeCallback:
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes OpenAI-compatible function schema generation for zero-argument tools.

PocketPaw was stripping empty `properties` from object schemas, which caused strict providers like OpenAI/OpenRouter to reject tools (e.g., `gmail_list_labels`) with the error: `object schema missing properties`.

---

## Related Issue

Fixes #739

---

## Changes Made

- `src/pocketpaw/tools/protocol.py`:
  - Added `normalize_schema()` to ensure object schemas always include `properties`
  - Ensured zero-argument schemas explicitly define `"required": []`
  - Updated `ToolDefinition.to_openai_schema()` to apply normalization

- `src/pocketpaw/agents/tool_bridge.py`:
  - Replaced ad hoc schema sanitization with shared `normalize_schema()` when building OpenAI `FunctionTool` schemas

- `tests/test_tool_bridge.py`:
  - Added regression tests for zero-argument tool schemas in the OpenAI Agents bridge

- `tests/test_paw_tools.py`:
  - Added regression tests for schema normalization at the `ToolDefinition` level

---

## How to Test

1. Run `uv sync --dev`
2. Start PocketPaw with the `openai_agents` backend
3. Configure:
   - Provider: OpenRouter
   - Model: `openai/gpt-4o-mini`
4. Trigger a request that uses a zero-argument tool (e.g., `gmail_list_labels`)
5. Verify that the request succeeds without schema validation errors
6. Run tests:

---

## Evidence of Testing

<img width="1322" height="303" alt="tests" src="https://github.com/user-attachments/assets/1afffb44-ba9a-4e36-b31f-1ad3c2baa29a" />


<img width="1895" height="1007" alt="fix" src="https://github.com/user-attachments/assets/15e4671d-5f3c-4bdd-8dc7-ae5c2affbc01" />

---

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff
