### PR TITLE
[FI] Fix invalid OpenAI tool schema by preserving empty properties in tool_bridge

### DIFF
--- a/src/pocketpaw/agents/tool_bridge.py
+++ b/src/pocketpaw/agents/tool_bridge.py
@@ -126,14 +126,21 @@ def build_openai_function_tools(settings: Any, backend: str = "openai_agents") -
 
         defn = tool.definition
 
-        # Sanitize JSON schema: strict providers (e.g. Groq) reject schemas
-        # where 'required' is present but 'properties' is empty or missing.
+        # Sanitize JSON schema for OpenAI Agents SDK.
+        #
+        # OpenAI requires `{"type":"object"}` schemas to include a `properties` key,
+        # even when the tool takes no arguments (so we must keep `properties: {}`).
+        #
+        # Some strict providers reject schemas where `required` is present but empty
+        # while `properties` is empty/missing. For compatibility we only remove
+        # empty `required`, but we never remove `properties`.
         params_schema = dict(defn.parameters) if defn.parameters else {"type": "object"}
-        props = params_schema.get("properties")
-        if not props and "required" in params_schema:
+        params_schema.setdefault("type", "object")
+        params_schema.setdefault("properties", {})
+
+        # If `required` exists but is empty, remove it (tool takes no required args).
+        if "required" in params_schema and not params_schema.get("required"):
             params_schema.pop("required")
-        if not props and "properties" in params_schema:
-            params_schema.pop("properties")
 
         ft = FunctionTool(
             name=defn.name,

--- a/src/pocketpaw/tools/builtin/gmail.py
+++ b/src/pocketpaw/tools/builtin/gmail.py
@@ -189,7 +189,9 @@ class GmailListLabelsTool(BaseTool):
 
     @property
     def parameters(self) -> dict[str, Any]:
-        return {"type": "object", "properties": {}}
+        # OpenAI tool schema validation expects an object schema to include `properties`.
+        # This tool takes no arguments, so `properties` is intentionally empty.
+        return {"type": "object", "properties": {}, "required": []}
 
     async def execute(self) -> str:
         from pocketpaw.integrations.gmail import GmailClient


### PR DESCRIPTION
## Summary

Fixes an issue where tool schemas with empty `"properties": {}` were being transformed into invalid schemas for OpenAI Agents.

## Root Cause

In `tool_bridge.py`, empty `"properties"` fields were removed:

```python
if not props and "properties" in params_schema:
    params_schema.pop("properties")
    
    This resulted in:

{ "type": "object" }

which is rejected by OpenAI.

Fix
Preserve "properties": {} for all object schemas
Only remove "required" if empty
Ensure compatibility with OpenAI function schema requirements
Additional Changes

Updated gmail_list_labels tool to explicitly define:

{ "type": "object", "properties": {}, "required": [] }
Impact
Fixes OpenAI Agents backend failures
Restores functionality for argument-less tools
Testing
Verified locally via uv run pocketpaw --dev
Ran tests: 21 passed