### PR TITLE
fix: correct parameter validation in tool registry

### DIFF
--- a/src/pocketpaw/tools/registry.py
+++ b/src/pocketpaw/tools/registry.py
@@ -118,7 +118,7 @@ class ToolRegistry:
         schema = tool.definition.parameters
         if schema and "required" in schema:
             required_params = schema.get("required", [])
-            missing_params = [p for p in required_params if params.get(p) is None]
+            missing_params = [p for p in required_params if p not in params]
             if missing_params:
                 error_msg = f"Missing required parameter(s): {', '.join(missing_params)}"
                 logger.warning("Parameter validation failed for %s: %s", name, error_msg)


### PR DESCRIPTION
Fix parameter validation logic that incorrectly treated missing parameters the same as parameters explicitly set to None.

Changed from `params.get(p) is None` to `p not in params` to properly check for parameter presence rather than value truthiness.

This fix:
- Distinguishes between missing keys and keys with None values
- Allows tools to receive None values if explicitly provided
- More accurately validates required parameter presence

Impact: Low - tightens validation correctness without breaking existing behavior since most tools don't accept None values.

Addresses a subtle logic bug where the validation layer checks parameter values instead of checking parameter existence.

<!-- Updated: 2026-02-26 — Added branch/issue warnings, tightened checklist. -->

> **Before opening this PR:**
> - Does it target `dev`? PRs against `main` are auto-closed.
> - Is there a linked issue? PRs without one will be closed.
> - Did you read [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md)?

## What does this PR do?

Fixes a logic bug in the tool registry's parameter validation at `src/pocketpaw/tools/registry.py:121` that cannot distinguish between missing parameters and parameters explicitly set to `None`. The current implementation uses `params.get(p) is None` which returns `None` for both scenarios, causing the validation to incorrectly reject parameters that are present but have `None` values. This PR changes the check to `p not in params` to properly validate parameter **presence** rather than parameter **values**.

## Related Issue

<!-- Link the issue this PR addresses. PRs without a linked issue will be closed. -->

Fixes #757

## Changes Made

<!-- List the specific files changed and what was modified in each. -->

- `src/pocketpaw/tools/registry.py`: Changed line 121 from `missing_params = [p for p in required_params if params.get(p) is None]` to `missing_params = [p for p in required_params if p not in params]` to correctly check for parameter key presence using the `in` operator instead of checking parameter values.

## How to Test

<!-- Step-by-step instructions for a reviewer to verify your changes work. -->

1. Run the existing tool protocol test suite to verify no regressions:
   ```bash
   uv run pytest tests/test_tools_protocol.py -v
2. Test with a tool that has required parameters - verify missing parameters are caught:
   ```bash
       # This should fail validation (missing 'count' parameter)
        await registry.execute("test_tool", text="hello")
3. Test with explicit None value - verify it passes validation:
   ```bash
        # This should now pass validation (key exists, even with None value)
          await registry.execute("test_tool", text="hello", count=None)
4. Run the full test suite (excluding e2e):
    ```bash
         uv run pytest --ignore=tests/e2e
## Evidence of Testing

<!-- Paste terminal output, test results, or screenshots proving you tested locally. -->

```
============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /Users/niksmac/Desktop/internship/pocketpaw/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/niksmac/Desktop/internship/pocketpaw
configfile: pyproject.toml
plugins: anyio-4.12.1, playwright-0.7.2, langsmith-0.7.20, asyncio-1.3.0, base-url-2.1.0
asyncio: mode=Mode.AUTO, debug=False
collecting ... collected 12 items

tests/test_tools_protocol.py::TestToolRegistry::test_register_and_get PASSED [  8%]
tests/test_tools_protocol.py::TestToolRegistry::test_unregister PASSED   [ 16%]
tests/test_tools_protocol.py::TestToolRegistry::test_get_definitions PASSED [ 25%]
tests/test_tools_protocol.py::TestToolRegistry::test_execute PASSED      [ 33%]
tests/test_tools_protocol.py::TestToolRegistry::test_execute_missing PASSED [ 41%]
tests/test_tools_protocol.py::TestShellTool::test_execute_simple PASSED  [ 50%]
tests/test_tools_protocol.py::TestShellTool::test_security_check PASSED  [ 58%]
tests/test_tools_protocol.py::TestShellTool::test_timeout PASSED         [ 66%]
tests/test_tools_protocol.py::TestFilesystemTools::test_write_and_read PASSED [ 75%]
tests/test_tools_protocol.py::TestFilesystemTools::test_jail_break_attempt PASSED [ 83%]
tests/test_tools_protocol.py::TestFilesystemTools::test_jail_prefix_bypass_blocked PASSED [ 91%]
tests/test_tools_protocol.py::TestFilesystemTools::test_list_dir PASSED  [100%]

============================== 12 passed in 1.31s
==============================
```

## Checklist

 PR targets dev branch (not main)
 Linked to an existing issue (#757)
 I have run PocketPaw locally and tested my changes
 Tests pass (uv run pytest --ignore=tests/e2e)
 Linting passes (uv run ruff check .)
 I have added/updated tests if applicable
 No unrelated changes bundled in this PR
 No secrets or credentials in the diff
