### PR TITLE
Fix/telegram paw command

### DIFF
--- a/src/pocketpaw/agents/tool_bridge.py
+++ b/src/pocketpaw/agents/tool_bridge.py
@@ -23,7 +23,7 @@ import logging
 from typing import Any
 
 from pocketpaw.tools.policy import ToolPolicy
-from pocketpaw.tools.protocol import BaseTool
+from pocketpaw.tools.protocol import BaseTool, normalize_schema
 from pocketpaw.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
@@ -126,14 +126,8 @@ def build_openai_function_tools(settings: Any, backend: str = "openai_agents") -
 
         defn = tool.definition
 
-        # Sanitize JSON schema: strict providers (e.g. Groq) reject schemas
-        # where 'required' is present but 'properties' is empty or missing.
-        params_schema = dict(defn.parameters) if defn.parameters else {"type": "object"}
-        props = params_schema.get("properties")
-        if not props and "required" in params_schema:
-            params_schema.pop("required")
-        if not props and "properties" in params_schema:
-            params_schema.pop("properties")
+        # Reuse the shared schema normalizer so zero-arg tools survive strict OpenAI validation.
+        params_schema = normalize_schema(defn.parameters or {"type": "object"})
 
         ft = FunctionTool(
             name=defn.name,

--- a/src/pocketpaw/bus/adapters/telegram_adapter.py
+++ b/src/pocketpaw/bus/adapters/telegram_adapter.py
@@ -72,6 +72,7 @@ class TelegramAdapter(BaseChannelAdapter):
         # Add Handlers
         self.app.add_handler(CommandHandler("start", self._handle_start))
         _cmds = (
+            "paw",
             "new",
             "sessions",
             "resume",
@@ -87,7 +88,8 @@ class TelegramAdapter(BaseChannelAdapter):
             "kill",
         )
         for cmd_name in _cmds:
-            self.app.add_handler(CommandHandler(cmd_name, self._handle_command))
+            handler = self._handle_paw if cmd_name == "paw" else self._handle_command
+            self.app.add_handler(CommandHandler(cmd_name, handler))
         media_filter = (
             filters.PHOTO
             | filters.Document.ALL
@@ -113,6 +115,7 @@ class TelegramAdapter(BaseChannelAdapter):
 
             await self.app.bot.set_my_commands(
                 [
+                    BotCommand("paw", "Send a message to PocketPaw"),
                     BotCommand("new", "Start a fresh conversation"),
                     BotCommand("sessions", "List your conversation sessions"),
                     BotCommand("resume", "Resume a previous session"),
@@ -421,6 +424,35 @@ class TelegramAdapter(BaseChannelAdapter):
             sender_id=str(user_id),
             chat_id=chat_id,
             content=text,
+            metadata={"username": update.effective_user.username},
+        )
+        await self._publish_inbound(msg)
+
+    async def _handle_paw(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle /paw by forwarding only its message body to the agent."""
+        if not update.effective_user or not update.message:
+            return
+
+        user_id = update.effective_user.id
+        if self.allowed_user_id and user_id != self.allowed_user_id:
+            return
+
+        content = " ".join(getattr(context, "args", [])).strip()
+        if not content:
+            await update.message.reply_text("Usage: /paw <message>")
+            return
+
+        base_chat_id = str(update.effective_chat.id)
+        topic_id = getattr(update.message, "message_thread_id", None)
+        chat_id = f"{base_chat_id}:topic:{topic_id}" if topic_id else base_chat_id
+
+        await self._send_typing_indicator(chat_id)
+
+        msg = InboundMessage(
+            channel=Channel.TELEGRAM,
+            sender_id=str(user_id),
+            chat_id=chat_id,
+            content=content,
             metadata={"username": update.effective_user.username},
         )
         await self._publish_inbound(msg)

--- a/src/pocketpaw/tools/protocol.py
+++ b/src/pocketpaw/tools/protocol.py
@@ -7,6 +7,18 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 
 
+def normalize_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Normalize JSON schema for strict OpenAI-style function validators."""
+    schema = dict(schema)
+    if schema.get("type") == "object":
+        # Zero-arg tools still need an explicit object shape for strict validators.
+        schema.setdefault("properties", {})
+        if not schema["properties"]:
+            # Keep the schema callable with no inputs instead of emitting an invalid object schema.
+            schema["required"] = []
+    return schema
+
+
 @dataclass
 class ToolDefinition:
     """Tool definition for LLM function calling."""
@@ -23,7 +35,8 @@ class ToolDefinition:
             "function": {
                 "name": self.name,
                 "description": self.description,
-                "parameters": self.parameters,
+                # OpenAI-style backends are stricter than Anthropic about empty object schemas.
+                "parameters": normalize_schema(self.parameters),
             },
         }
 

--- a/tests/test_paw_tools.py
+++ b/tests/test_paw_tools.py
@@ -351,3 +351,14 @@ class TestToolDefinitions:
         assert schema["type"] == "function"
         assert "function" in schema
         assert schema["function"]["name"] == "soul_remember"
+
+    def test_openai_schema_normalizes_zero_arg_tools(self, mock_soul):
+        tool = SoulStatusTool(mock_soul)
+        schema = tool.definition.to_openai_schema()
+
+        # Shared OpenAI schema formatting should normalize zero-arg tools at the definition layer.
+        assert schema["function"]["parameters"] == {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -345,6 +345,53 @@ class TestMessageUpdate:
         call_kwargs = adapter_with_app.app.bot.edit_message_text.call_args[1]
         assert call_kwargs["chat_id"] == "-100123"
 
+ 
+class TestTelegramCommands:
+    async def test_handle_paw_forwards_message_body(self, adapter):
+        adapter._publish_inbound = AsyncMock()
+        adapter._send_typing_indicator = AsyncMock()
+
+        update = MagicMock()
+        update.effective_user.id = 12345
+        update.effective_user.username = "alice"
+        update.effective_chat.id = 67890
+        update.message = MagicMock()
+        update.message.message_thread_id = None
+        update.message.reply_text = AsyncMock()
+
+        context = MagicMock()
+        context.args = ["hello", "there"]
+
+        await adapter._handle_paw(update, context)
+
+        adapter._send_typing_indicator.assert_awaited_once_with("67890")
+        update.message.reply_text.assert_not_called()
+
+        published = adapter._publish_inbound.await_args.args[0]
+        assert published.channel == Channel.TELEGRAM
+        assert published.sender_id == "12345"
+        assert published.chat_id == "67890"
+        assert published.content == "hello there"
+        assert published.metadata["username"] == "alice"
+
+    async def test_handle_paw_requires_message_body(self, adapter):
+        adapter._publish_inbound = AsyncMock()
+        adapter._send_typing_indicator = AsyncMock()
+
+        update = MagicMock()
+        update.effective_user.id = 12345
+        update.message = MagicMock()
+        update.message.reply_text = AsyncMock()
+
+        context = MagicMock()
+        context.args = []
+
+        await adapter._handle_paw(update, context)
+
+        adapter._send_typing_indicator.assert_not_called()
+        adapter._publish_inbound.assert_not_called()
+        update.message.reply_text.assert_awaited_once_with("Usage: /paw <message>")
+
 
 class TestVoiceMediaRouting:
     def test_is_voice_media_false_without_metadata(self):

--- a/tests/test_tool_bridge.py
+++ b/tests/test_tool_bridge.py
@@ -147,6 +147,30 @@ class TestBuildOpenAIFunctionTools:
             # Only remember and recall should pass minimal profile
             assert len(result) == 2
 
+    @patch("pocketpaw.agents.tool_bridge._instantiate_all_tools")
+    def test_normalizes_empty_object_schema_for_openai_tools(self, mock_instantiate):
+        """Zero-arg tools keep an explicit empty object schema for strict providers."""
+        mock_tool = MagicMock()
+        mock_tool.name = "gmail_list_labels"
+        mock_tool.definition.name = "gmail_list_labels"
+        mock_tool.definition.description = "List Gmail labels"
+        mock_tool.definition.parameters = {"type": "object", "properties": {}}
+        mock_instantiate.return_value = [mock_tool]
+
+        mock_ft_cls = MagicMock()
+        with patch.dict("sys.modules", {"agents": MagicMock(FunctionTool=mock_ft_cls)}):
+            from pocketpaw.agents.tool_bridge import build_openai_function_tools
+
+            build_openai_function_tools(Settings())
+
+        kwargs = mock_ft_cls.call_args.kwargs
+        # The bridge should preserve an explicit empty object schema for zero-arg tools.
+        assert kwargs["params_json_schema"] == {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+
 
 class TestMakeInvokeCallback:
     @pytest.mark.asyncio


### PR DESCRIPTION

this pr depends on this pr:  #741 (the openai won't send respone, more details on this pr)
## What does this PR do?

Implements a dedicated handler for the /paw command in the Telegram adapter.

Currently, /paw is listed in /help but does not function. This PR ensures that /paw <message> behaves like a normal chat message by stripping the command prefix and forwarding only the message body to the agent.

## Related Issue

Fixes #759

## Changes Made
in telegram_adapter.py:
Added _handle_paw() to process /paw messages by stripping the command prefix and forwarding clean input to the agent. Also handles empty input with a usage message.
 in test_telegram_adapter.py:
Added/updated tests to verify /paw behavior and ensure correct message handling.

## How to Test

<!-- Step-by-step instructions for a reviewer to verify your changes work. -->

1.uv run pocketpaw
2.Connect Telegram bot
3.Send /paw hello → should respond like hello
4.Send /paw → should return usage message
5.Send normal message (hello) → should still work

## Evidence of Testing
<img width="1536" height="331" alt="testpaw" src="https://github.com/user-attachments/assets/80a0c5cb-96f1-4ddc-903a-3d49b7bfeca9" />

<img width="1079" height="893" alt="pawfix" src="https://github.com/user-attachments/assets/8d97992e-1e8e-4359-b9a2-f5d350fffe6d" />



## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff
