### PR TITLE
[FI] Add global execution timeouts and cancellation handling to AgentRouter

### DIFF
--- a/src/pocketpaw/agents/router.py
+++ b/src/pocketpaw/agents/router.py
@@ -5,6 +5,7 @@ configured agent backend. Supports optional user-configured fallback
 backends if the primary backend fails.
 """
 
+import asyncio
 import logging
 from collections.abc import AsyncIterator
 from typing import Any
@@ -99,57 +100,68 @@ class AgentRouter:
 
         last_error: str | None = None
 
-        # Primary backend (streaming, no buffering, no error-event fallback)
-        if self._backend is not None:
-            try:
-                async for event in self._backend.run(
-                    message,
-                    system_prompt=system_prompt,
-                    history=history,
-                    session_key=session_key,
-                ):
-                    yield event
+        # Core routing loop with global execution timeout
+        try:
+            async with asyncio.timeout(self.settings.agent_execution_timeout_seconds):
+                # Primary backend (streaming, no buffering, no error-event fallback)
+                if self._backend is not None:
+                    try:
+                        async for event in self._backend.run(
+                            message,
+                            system_prompt=system_prompt,
+                            history=history,
+                            session_key=session_key,
+                        ):
+                            yield event
 
-                    if event.type == "done":
-                        return
+                            if event.type == "done":
+                                return
 
-            except Exception as exc:
-                last_error = str(exc)
-                logger.warning(
-                    "Primary backend '%s' failed: %s",
-                    self._active_backend_name,
-                    exc,
-                )
+                    except Exception as exc:
+                        last_error = str(exc)
+                        logger.warning(
+                            "Primary backend '%s' failed: %s",
+                            self._active_backend_name,
+                            exc,
+                        )
 
-        # Fallback backends
-        for backend_name in self._fallback_backends:
-            backend = self._get_fallback_backend(backend_name)
+                # Fallback backends
+                for backend_name in self._fallback_backends:
+                    backend = self._get_fallback_backend(backend_name)
 
-            if backend is None:
-                logger.warning("Fallback backend '%s' unavailable", backend_name)
-                continue
+                    if backend is None:
+                        logger.warning("Fallback backend '%s' unavailable", backend_name)
+                        continue
 
-            logger.info("Attempting fallback backend: %s", backend_name)
+                    logger.info("Attempting fallback backend: %s", backend_name)
 
-            try:
-                async for event in backend.run(
-                    message,
-                    system_prompt=system_prompt,
-                    history=history,
-                    session_key=session_key,
-                ):
-                    yield event
+                    try:
+                        async for event in backend.run(
+                            message,
+                            system_prompt=system_prompt,
+                            history=history,
+                            session_key=session_key,
+                        ):
+                            yield event
 
-                    if event.type == "done":
-                        return
+                            if event.type == "done":
+                                return
 
-            except Exception as exc:
-                last_error = str(exc)
-                logger.warning(
-                    "Fallback backend '%s' failed: %s",
-                    backend_name,
-                    exc,
-                )
+                    except Exception as exc:
+                        last_error = str(exc)
+                        logger.warning(
+                            "Fallback backend '%s' failed: %s",
+                            backend_name,
+                            exc,
+                        )
+        except TimeoutError:
+            logger.warning("Agent execution timed out after %ds",
+                           self.settings.agent_execution_timeout_seconds)
+            yield AgentEvent(
+                type="error",
+                content=f"Agent execution timed out after {self.settings.agent_execution_timeout_seconds} seconds."
+            )
+            return
 
         # All backends failed
         yield AgentEvent(

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -200,6 +200,11 @@ class Settings(BaseSettings):
         default_factory=list,
         description=("Ordered list of fallback backends to try if the primary backend fails"),
     )
+    agent_execution_timeout_seconds: int = Field(
+        default=300,
+        gt=0,
+        description="Global timeout in seconds for a single agent execution (run) call.",
+    )
 
     # Claude Agent SDK Settings
     claude_sdk_provider: str = Field(

--- a/tests/test_router_timeouts.py
+++ b/tests/test_router_timeouts.py
@@ -1,0 +1,89 @@
+"""Tests for the Agent Router execution timeouts."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pocketpaw.agents.protocol import AgentEvent
+from pocketpaw.agents.router import AgentRouter
+
+
+class MockSettings:
+    """Minimal settings mock."""
+    def __init__(self, timeout: int = 1):
+        self.agent_backend = "mock_backend"
+        self.fallback_backends = []
+        self.agent_execution_timeout_seconds = timeout
+
+
+class MockHangingBackend:
+    """A backend that sleeps longer than the timeout."""
+    def __init__(self, settings):
+        self.settings = settings
+
+    async def run(self, *args, **kwargs) -> AsyncIterator[AgentEvent]:
+        yield AgentEvent(type="thinking", content="I am thinking...")
+        await asyncio.sleep(5)  # Sleep longer than the 1s timeout
+        yield AgentEvent(type="message", content="I finished!")
+        yield AgentEvent(type="done", content="")
+
+    async def stop(self):
+        pass
+
+    @classmethod
+    def info(cls):
+        from pocketpaw.agents.backend import BackendInfo
+        return BackendInfo(name="mock", display_name="Mock Hanging Backend")
+
+
+@pytest.mark.asyncio
+async def test_router_execution_timeout():
+    """Verify that the router terminates and yields an error on timeout."""
+    settings = MockSettings(timeout=1)
+    
+    # Mock the registry to return our hanging backend
+    with patch("pocketpaw.agents.router.get_backend_class", return_value=MockHangingBackend):
+        router = AgentRouter(settings)
+        
+        events = []
+        async for event in router.run("Hello"):
+            events.append(event)
+            
+        # Expectation:
+        # 1. "thinking" event from backend
+        # 2. "error" event from router's timeout catch
+        # 3. "done" event (not yielded by timeout catch itself, but maybe by the final router yield)
+        
+        # Check that we got the timeout error
+        error_events = [e for e in events if e.type == "error"]
+        assert len(error_events) == 1
+        assert "timed out" in error_events[0].content
+        
+        # Check that the "message" event was never reached
+        message_contents = [e.content for e in events if e.type == "message"]
+        assert "I finished!" not in message_contents
+
+
+@pytest.mark.asyncio
+async def test_router_no_timeout_on_fast_backend():
+    """Verify that the router finishes normally if the backend is fast."""
+    settings = MockSettings(timeout=2)
+    
+    class MockFastBackend(MockHangingBackend):
+        async def run(self, *args, **kwargs) -> AsyncIterator[AgentEvent]:
+            yield AgentEvent(type="message", content="Fast response")
+            yield AgentEvent(type="done", content="")
+
+    with patch("pocketpaw.agents.router.get_backend_class", return_value=MockFastBackend):
+        router = AgentRouter(settings)
+        events = []
+        async for event in router.run("Hello"):
+            events.append(event)
+            
+        assert any(e.type == "done" for e in events)
+        assert not any(e.type == "error" for e in events)
+        assert events[0].content == "Fast response"


### PR DESCRIPTION
## Overview
Implements a hard global timeout for the AgentRouter to prevent Zombie Requests and ensure resource availability during long-running or stalled operations.

## Problem
Without a global execution timeout, a hanging LLM provider, a slow third-party tool, or an infinite generation loop could block an execution thread/session indefinitely. This leads to leaked resources and poor UX in the dashboard.

## Proposed Solution
- Asyncio Timeout Integration: Wrapped the entire AgentRouter.run generator pipeline in a configurable asyncio.timeout context.
- - Graceful Error Recovery: Intercepts TimeoutError to yield a clean AgentEvent(type="error") to the user before closing the backend stream.
## Pull Request Checklist
* [x] Pre-commit hooks pass
* [x] Tests pass (uv run pytest tests/test_router_timeouts.py)
* [x] New config field agent_execution_timeout_seconds added to Settings
