### PR TITLE
[FI] Add startup-time Pydantic validation for backend authentication

### DIFF
--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -18,9 +18,8 @@ import logging
 import re
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal
-
-from pydantic import Field
+from typing import Literal, Self
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -878,6 +877,34 @@ class Settings(BaseSettings):
     max_concurrent_conversations: int = Field(
         default=5, gt=0, description="Max parallel conversations processed simultaneously"
     )
+
+    @model_validator(mode="after")
+    def validate_backend_auth(self) -> Self:
+        """Validate that the selected agent backend has necessary authentication."""
+        backend = self.agent_backend
+
+        if backend == "claude_agent_sdk":
+            if self.claude_sdk_provider == "anthropic" and not (
+                self.anthropic_api_key or self.claude_code_oauth_token
+            ):
+                raise ValueError(
+                    "claude_agent_sdk (anthropic) requires either anthropic_api_key "
+                    "or claude_code_oauth_token."
+                )
+        elif backend == "openai_agents":
+            if self.openai_agents_provider == "openai" and not self.openai_api_key:
+                raise ValueError("openai_agents requires openai_api_key.")
+        elif backend == "google_adk":
+            if self.google_adk_provider == "google" and not self.google_api_key:
+                raise ValueError("google_adk requires google_api_key.")
+        elif backend == "codex_cli" and not self.openai_api_key:
+            raise ValueError("codex_cli requires openai_api_key.")
+        elif backend == "copilot_sdk":
+            if self.copilot_sdk_provider == "copilot" and not self.openai_api_key:
+                # Copilot SDK often uses openai_api_key as its proxy/auth if configured
+                pass
+        
+        return self
 
     def save(self) -> None:
         """Save settings to config file.

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,377 +1,59 @@
-"""Tests for config.py API key validation and numeric field constraints."""
-
-from __future__ import annotations
+"""Tests for the PocketPaw startup configuration validation."""
 
 import pytest
 from pydantic import ValidationError
+from pocketpaw.config import Settings
 
-from pocketpaw.config import Settings, validate_api_key
 
-
-class TestValidateApiKey:
-    """Test suite for validate_api_key() function."""
-
-    # ==================== Valid Keys ====================
-
-    def test_valid_anthropic_key(self):
-        """Valid Anthropic API key should pass."""
-        is_valid, warning = validate_api_key("anthropic_api_key", "sk-ant-api03-abc123")
-        assert is_valid is True
-        assert warning == ""
-
-    def test_valid_openai_key(self):
-        """Valid OpenAI API key should pass."""
-        is_valid, warning = validate_api_key("openai_api_key", "sk-proj-abc123")
-        assert is_valid is True
-        assert warning == ""
-
-    def test_valid_openai_legacy_key(self):
-        """Valid legacy OpenAI API key should pass."""
-        is_valid, warning = validate_api_key("openai_api_key", "sk-abc123")
-        assert is_valid is True
-        assert warning == ""
-
-    def test_valid_telegram_token(self):
-        """Valid Telegram bot token should pass."""
-        is_valid, warning = validate_api_key(
-            "telegram_bot_token", "123456789:AAH1234567890abcdefghijklmnopqrstuv"
+def test_config_validation_claude_missing_key():
+    """Verify that Claude SDK raises ValidationError if Anthropic key is missing."""
+    with pytest.raises(ValidationError) as excinfo:
+        Settings(
+            agent_backend="claude_agent_sdk",
+            claude_sdk_provider="anthropic",
+            anthropic_api_key=None,
+            claude_code_oauth_token=None
         )
-        assert is_valid is True
-        assert warning == ""
+    assert "requires either anthropic_api_key" in str(excinfo.value)
 
-    # ==================== Invalid Prefixes ====================
 
-    def test_invalid_anthropic_key_wrong_prefix(self):
-        """Anthropic key with wrong prefix should fail."""
-        is_valid, warning = validate_api_key("anthropic_api_key", "sk-wrong-abc123")
-        assert is_valid is False
-        assert "Anthropic API key" in warning
-        assert "expected format: sk-ant-..." in warning
-        assert "Double-check for typos or truncation" in warning
-
-    def test_invalid_anthropic_key_no_prefix(self):
-        """Anthropic key without prefix should fail."""
-        is_valid, warning = validate_api_key("anthropic_api_key", "abc123")
-        assert is_valid is False
-        assert "Anthropic API key" in warning
-
-    def test_invalid_openai_key_wrong_prefix(self):
-        """OpenAI key with wrong prefix should fail."""
-        is_valid, warning = validate_api_key("openai_api_key", "pk-abc123")
-        assert is_valid is False
-        assert "OpenAI API key" in warning
-        assert "expected format: sk-..." in warning
-
-    def test_invalid_telegram_token_wrong_format(self):
-        """Telegram token with wrong format should fail."""
-        is_valid, warning = validate_api_key("telegram_bot_token", "123456789:invalid")
-        assert is_valid is False
-        assert "Telegram bot token" in warning
-        assert "expected format: 123456789:AAH..." in warning
-
-    def test_invalid_telegram_token_missing_colon(self):
-        """Telegram token without colon separator should fail."""
-        is_valid, warning = validate_api_key("telegram_bot_token", "123456789AAH1234567890")
-        assert is_valid is False
-        assert "Telegram bot token" in warning
-
-    def test_invalid_telegram_token_no_aa_prefix(self):
-        """Telegram token without AA prefix after colon should fail."""
-        is_valid, warning = validate_api_key(
-            "telegram_bot_token", "123456789:XYH1234567890abcdefghijklmnopqrstuv"
+def test_config_validation_openai_missing_key():
+    """Verify that OpenAI backend requires an API key."""
+    with pytest.raises(ValidationError) as excinfo:
+        Settings(
+            agent_backend="openai_agents",
+            openai_agents_provider="openai",
+            openai_api_key=""
         )
-        assert is_valid is False
-        assert "Telegram bot token" in warning
-
-    # ==================== Empty Values ====================
-
-    def test_empty_string_allowed(self):
-        """Empty string should be allowed (for unsetting keys)."""
-        is_valid, warning = validate_api_key("anthropic_api_key", "")
-        assert is_valid is True
-        assert warning == ""
-
-    def test_whitespace_only_allowed(self):
-        """Whitespace-only string should be allowed (treated as empty)."""
-        is_valid, warning = validate_api_key("openai_api_key", "   ")
-        assert is_valid is True
-        assert warning == ""
-
-    def test_none_value_allowed(self):
-        """None value should be allowed."""
-        is_valid, warning = validate_api_key("anthropic_api_key", None)
-        assert is_valid is True
-        assert warning == ""
-
-    # ==================== Unknown Fields ====================
-
-    def test_unknown_field_passes_through(self):
-        """Unknown field names should pass through without validation."""
-        is_valid, warning = validate_api_key("unknown_field", "any_value_here")
-        assert is_valid is True
-        assert warning == ""
-
-    def test_unvalidated_api_key_passes_through(self):
-        """API key fields without validation patterns should pass through."""
-        is_valid, warning = validate_api_key("google_api_key", "any_format")
-        assert is_valid is True
-        assert warning == ""
-
-    def test_unvalidated_with_empty_value(self):
-        """Empty values for unvalidated fields should pass."""
-        is_valid, warning = validate_api_key("tavily_api_key", "")
-        assert is_valid is True
-        assert warning == ""
-
-    # ==================== Edge Cases ====================
-
-    def test_key_with_leading_whitespace(self):
-        """Key with leading whitespace should be validated after stripping."""
-        is_valid, warning = validate_api_key("anthropic_api_key", "  sk-ant-api03-abc123")
-        assert is_valid is True
-        assert warning == ""
-
-    def test_key_with_trailing_whitespace(self):
-        """Key with trailing whitespace should be validated after stripping."""
-        is_valid, warning = validate_api_key("openai_api_key", "sk-proj-abc123  ")
-        assert is_valid is True
-        assert warning == ""
-
-    def test_key_with_surrounding_whitespace(self):
-        """Key with surrounding whitespace should be validated after stripping."""
-        is_valid, warning = validate_api_key("anthropic_api_key", "  sk-ant-api03-abc123  ")
-        assert is_valid is True
-        assert warning == ""
-
-    def test_very_long_valid_key(self):
-        """Very long but valid key should pass."""
-        long_key = "sk-ant-" + "a" * 1000
-        is_valid, warning = validate_api_key("anthropic_api_key", long_key)
-        assert is_valid is True
-        assert warning == ""
-
-    def test_anthropic_key_catches_openai_prefix(self):
-        """Anthropic validator should reject keys that look like OpenAI keys."""
-        is_valid, warning = validate_api_key("anthropic_api_key", "sk-proj-abc123")
-        assert is_valid is False
-        assert "Anthropic API key" in warning
-
-    def test_return_type_is_tuple(self):
-        """Function should always return a tuple of (bool, str)."""
-        result = validate_api_key("anthropic_api_key", "sk-ant-abc")
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        assert isinstance(result[0], bool)
-        assert isinstance(result[1], str)
-
-
-class TestNumericFieldConstraints:
-    """Tests for gt/ge constraints on numeric settings in Settings (issue #629)."""
-
-    # ─── compaction_recent_window ───────────────────────────────────────────
-
-    def test_compaction_recent_window_zero_rejected(self):
-        """compaction_recent_window=0 must raise a ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(compaction_recent_window=0)
-
-    def test_compaction_recent_window_negative_rejected(self):
-        """compaction_recent_window=-1 must raise a ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(compaction_recent_window=-1)
-
-    def test_compaction_recent_window_positive_accepted(self):
-        """compaction_recent_window=1 must be accepted."""
-        s = Settings(compaction_recent_window=1)
-        assert s.compaction_recent_window == 1
-
-    # ─── compaction_char_budget ─────────────────────────────────────────────
-
-    def test_compaction_char_budget_zero_rejected(self):
-        """compaction_char_budget=0 must raise a ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(compaction_char_budget=0)
-
-    def test_compaction_char_budget_negative_rejected(self):
-        """compaction_char_budget=-100 must raise a ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(compaction_char_budget=-100)
-
-    def test_compaction_char_budget_positive_accepted(self):
-        """compaction_char_budget=1 must be accepted."""
-        s = Settings(compaction_char_budget=1)
-        assert s.compaction_char_budget == 1
-
-    # ─── compaction_summary_chars ───────────────────────────────────────────
-
-    def test_compaction_summary_chars_zero_rejected(self):
-        """compaction_summary_chars=0 must raise a ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(compaction_summary_chars=0)
-
-    def test_compaction_summary_chars_negative_rejected(self):
-        """compaction_summary_chars=-5 must raise a ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(compaction_summary_chars=-5)
-
-    def test_compaction_summary_chars_positive_accepted(self):
-        """compaction_summary_chars=1 must be accepted."""
-        s = Settings(compaction_summary_chars=1)
-        assert s.compaction_summary_chars == 1
-
-    # ─── session_token_ttl_hours ────────────────────────────────────────────
-
-    def test_session_token_ttl_hours_zero_rejected(self):
-        """session_token_ttl_hours=0 must raise a ValidationError.
-
-        Zero TTL means all session tokens are immediately expired.
-        """
-        with pytest.raises(ValidationError):
-            Settings(session_token_ttl_hours=0)
-
-    def test_session_token_ttl_hours_negative_rejected(self):
-        """session_token_ttl_hours=-1 must raise a ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(session_token_ttl_hours=-1)
-
-    def test_session_token_ttl_hours_positive_accepted(self):
-        """session_token_ttl_hours=1 must be accepted."""
-        s = Settings(session_token_ttl_hours=1)
-        assert s.session_token_ttl_hours == 1
-
-    # ─── api_rate_limit_per_key ─────────────────────────────────────────────
-
-    def test_api_rate_limit_per_key_zero_rejected(self):
-        """api_rate_limit_per_key=0 must raise a ValidationError.
-
-        Zero capacity causes the rate limiter to reject every request.
-        """
-        with pytest.raises(ValidationError):
-            Settings(api_rate_limit_per_key=0)
-
-    def test_api_rate_limit_per_key_negative_rejected(self):
-        """api_rate_limit_per_key=-10 must raise a ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(api_rate_limit_per_key=-10)
-
-    def test_api_rate_limit_per_key_positive_accepted(self):
-        """api_rate_limit_per_key=1 must be accepted."""
-        s = Settings(api_rate_limit_per_key=1)
-        assert s.api_rate_limit_per_key == 1
-
-    # ─── media_max_file_size_mb ─────────────────────────────────────────────
-
-    def test_media_max_file_size_mb_zero_accepted(self):
-        """media_max_file_size_mb=0 must be accepted (documented as unlimited)."""
-        s = Settings(media_max_file_size_mb=0)
-        assert s.media_max_file_size_mb == 0
-
-    def test_media_max_file_size_mb_negative_rejected(self):
-        """media_max_file_size_mb=-1 must raise a ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(media_max_file_size_mb=-1)
-
-    def test_media_max_file_size_mb_positive_accepted(self):
-        """media_max_file_size_mb=100 must be accepted."""
-        s = Settings(media_max_file_size_mb=100)
-        assert s.media_max_file_size_mb == 100
-
-    # ─── max_concurrent_conversations ───────────────────────────────────────
-
-    def test_max_concurrent_conversations_zero_rejected(self):
-        """max_concurrent_conversations=0 must raise a ValidationError (zero limit deadlocks)."""
-        with pytest.raises(ValidationError):
-            Settings(max_concurrent_conversations=0)
-
-    def test_max_concurrent_conversations_negative_rejected(self):
-        """max_concurrent_conversations=-3 must raise a ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(max_concurrent_conversations=-3)
-
-    def test_max_concurrent_conversations_positive_accepted(self):
-        """max_concurrent_conversations=1 must be accepted."""
-        s = Settings(max_concurrent_conversations=1)
-        assert s.max_concurrent_conversations == 1
-
-
-class TestEnumFieldValidation:
-    """Tests for Literal-typed enum fields in Settings (issue #638).
-
-    Covers whatsapp_mode, tts_provider, and stt_provider.
-    """
-
-    # ─── whatsapp_mode ──────────────────────────────────────────────────────
-
-    def test_whatsapp_mode_empty_string_accepted(self):
-        """whatsapp_mode='' (default / disabled) must be accepted."""
-        s = Settings(whatsapp_mode="")
-        assert s.whatsapp_mode == ""
-
-    def test_whatsapp_mode_personal_accepted(self):
-        """whatsapp_mode='personal' must be accepted."""
-        s = Settings(whatsapp_mode="personal")
-        assert s.whatsapp_mode == "personal"
-
-    def test_whatsapp_mode_business_accepted(self):
-        """whatsapp_mode='business' must be accepted."""
-        s = Settings(whatsapp_mode="business")
-        assert s.whatsapp_mode == "business"
-
-    def test_whatsapp_mode_invalid_rejected(self):
-        """whatsapp_mode='cloud' is not a valid option and must raise ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(whatsapp_mode="cloud")
-
-    def test_whatsapp_mode_typo_rejected(self):
-        """whatsapp_mode='Buisness' (typo/wrong case) must raise ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(whatsapp_mode="Buisness")
-
-    # ─── tts_provider ───────────────────────────────────────────────────────
-
-    def test_tts_provider_openai_accepted(self):
-        """tts_provider='openai' (default) must be accepted."""
-        s = Settings(tts_provider="openai")
-        assert s.tts_provider == "openai"
-
-    def test_tts_provider_elevenlabs_accepted(self):
-        """tts_provider='elevenlabs' must be accepted."""
-        s = Settings(tts_provider="elevenlabs")
-        assert s.tts_provider == "elevenlabs"
-
-    def test_tts_provider_sarvam_accepted(self):
-        """tts_provider='sarvam' must be accepted."""
-        s = Settings(tts_provider="sarvam")
-        assert s.tts_provider == "sarvam"
-
-    def test_tts_provider_invalid_rejected(self):
-        """tts_provider='azure' is not a valid option and must raise ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(tts_provider="azure")
-
-    def test_tts_provider_typo_rejected(self):
-        """tts_provider='OpenAI' (wrong case) must raise ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(tts_provider="OpenAI")
-
-    # ─── stt_provider ───────────────────────────────────────────────────────
-
-    def test_stt_provider_openai_accepted(self):
-        """stt_provider='openai' (default) must be accepted."""
-        s = Settings(stt_provider="openai")
-        assert s.stt_provider == "openai"
-
-    def test_stt_provider_sarvam_accepted(self):
-        """stt_provider='sarvam' must be accepted."""
-        s = Settings(stt_provider="sarvam")
-        assert s.stt_provider == "sarvam"
-
-    def test_stt_provider_invalid_rejected(self):
-        """stt_provider='whisper' is not a valid option and must raise ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(stt_provider="whisper")
-
-    def test_stt_provider_typo_rejected(self):
-        """stt_provider='Sarvam' (wrong case) must raise ValidationError."""
-        with pytest.raises(ValidationError):
-            Settings(stt_provider="Sarvam")
+    assert "requires openai_api_key" in str(excinfo.value)
+
+
+def test_config_validation_google_missing_key():
+    """Verify that Google ADK requires an API key."""
+    with pytest.raises(ValidationError) as excinfo:
+        Settings(
+            agent_backend="google_adk",
+            google_adk_provider="google",
+            google_api_key=None
+        )
+    assert "requires google_api_key" in str(excinfo.value)
+
+
+def test_config_validation_success():
+    """Verify that validation passes when keys are provided."""
+    settings = Settings(
+        agent_backend="openai_agents",
+        openai_agents_provider="openai",
+        openai_api_key="sk-test-123"
+    )
+    assert settings.openai_api_key == "sk-test-123"
+
+
+def test_config_validation_ollama_no_key_needed():
+    """Verify that Ollama provider doesn't require an Anthropic key."""
+    settings = Settings(
+        agent_backend="claude_agent_sdk",
+        claude_sdk_provider="ollama",
+        anthropic_api_key=None
+    )
+    assert settings.agent_backend == "claude_agent_sdk"


### PR DESCRIPTION
## Overview
Introduces a fail-fast configuration validation layer using Pydantic model_validators to ensure the application is correctly configured at boot time.

## Problem
Previously, missing API keys for a selected backend (e.g. Claude SDK) would only cause an error at runtime when the first prompt was sent. This led to cryptic stack traces deep in the networking layer rather than clear configuration errors.

## Proposed Solution
- Cross-Field Validation: Added @model_validator(mode="after") to Settings to verify that if a backend like claude_agent_sdk is enabled, its corresponding anthropic_api_key or oauth_token is present.
- - Immediate Feedback: Crashes gracefully on startup with a descriptive ValidationError, significantly improving the developer experience.
## Pull Request Checklist
* [x] Pre-commit hooks pass
* [x] Tests pass (uv run pytest tests/test_config_validation.py)
