### PR TITLE
[FI] Implement structured logging with latency tracking and metadata-…

### DIFF
--- a/src/pocketpaw/agents/router.py
+++ b/src/pocketpaw/agents/router.py
@@ -6,6 +6,7 @@ backends if the primary backend fails.
 """
 
 import logging
+import time
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -101,6 +102,10 @@ class AgentRouter:
 
         # Primary backend (streaming, no buffering, no error-event fallback)
         if self._backend is not None:
+            backend_name = self._active_backend_name or "unknown"
+            logger.info("Starting primary backend: %s", backend_name, 
+                        extra={"event": "backend_start", "backend": backend_name, "is_primary": True})
+            start_time = time.perf_counter()
             try:
                 async for event in self._backend.run(
                     message,
@@ -111,14 +116,21 @@ class AgentRouter:
                     yield event
 
                     if event.type == "done":
+                        latency_ms = (time.perf_counter() - start_time) * 1000
+                        logger.info("Primary backend '%s' completed successfully", backend_name,
+                                    extra={"event": "backend_success", "backend": backend_name, 
+                                           "latency_ms": latency_ms, "is_primary": True})
                         return
 
             except Exception as exc:
+                latency_ms = (time.perf_counter() - start_time) * 1000
                 last_error = str(exc)
                 logger.warning(
                     "Primary backend '%s' failed: %s",
-                    self._active_backend_name,
+                    backend_name,
                     exc,
+                    extra={"event": "backend_failure", "backend": backend_name, 
+                           "error": last_error, "latency_ms": latency_ms, "is_primary": True}
                 )
 
         # Fallback backends
@@ -126,10 +138,13 @@ class AgentRouter:
             backend = self._get_fallback_backend(backend_name)
 
             if backend is None:
-                logger.warning("Fallback backend '%s' unavailable", backend_name)
+                logger.warning("Fallback backend '%s' unavailable", backend_name,
+                               extra={"event": "backend_unavailable", "backend": backend_name})
                 continue
 
-            logger.info("Attempting fallback backend: %s", backend_name)
+            logger.info("Attempting fallback backend: %s", backend_name,
+                        extra={"event": "backend_start", "backend": backend_name, "is_primary": False})
+            start_time = time.perf_counter()
 
             try:
                 async for event in backend.run(
@@ -141,14 +156,21 @@ class AgentRouter:
                     yield event
 
                     if event.type == "done":
+                        latency_ms = (time.perf_counter() - start_time) * 1000
+                        logger.info("Fallback backend '%s' completed successfully", backend_name,
+                                    extra={"event": "backend_success", "backend": backend_name, 
+                                           "latency_ms": latency_ms, "is_primary": False})
                         return
 
             except Exception as exc:
+                latency_ms = (time.perf_counter() - start_time) * 1000
                 last_error = str(exc)
                 logger.warning(
                     "Fallback backend '%s' failed: %s",
                     backend_name,
                     exc,
+                    extra={"event": "backend_failure", "backend": backend_name, 
+                           "error": last_error, "latency_ms": latency_ms, "is_primary": False}
                 )
 
         # All backends failed

--- a/tests/test_structured_logging.py
+++ b/tests/test_structured_logging.py
@@ -1,0 +1,118 @@
+"""Tests for structured logging in AgentRouter."""
+
+import asyncio
+import logging
+import time
+from collections.abc import AsyncIterator
+from unittest.mock import patch
+
+import pytest
+
+from pocketpaw.agents.protocol import AgentEvent
+from pocketpaw.agents.router import AgentRouter
+
+
+class MockSettings:
+    """Minimal settings mock."""
+    def __init__(self):
+        self.agent_backend = "mock_primary"
+        self.fallback_backends = ["mock_fallback"]
+
+
+class MockBackend:
+    """A backend that yields events with a small delay."""
+    def __init__(self, name: str):
+        self.name = name
+
+    async def run(self, *args, **kwargs) -> AsyncIterator[AgentEvent]:
+        # Simulate some processing time
+        await asyncio.sleep(0.1)
+        yield AgentEvent(type="message", content=f"Hello from {self.name}")
+        yield AgentEvent(type="done", content="")
+
+    async def stop(self):
+        pass
+
+    @classmethod
+    def info(cls):
+        from pocketpaw.agents.backend import BackendInfo
+        return BackendInfo(name="mock", display_name="Mock Backend")
+
+
+@pytest.mark.asyncio
+async def test_router_structured_logging_success(caplog):
+    """Verify that successful backend runs produce structured logs with latency."""
+    caplog.set_level(logging.INFO)
+    settings = MockSettings()
+
+    primary = MockBackend("primary")
+    fallback = MockBackend("fallback")
+
+    def mock_get_backend(name):
+        if name == "mock_primary": return lambda s: primary
+        if name == "mock_fallback": return lambda s: fallback
+        return None
+
+    with patch("pocketpaw.agents.router.get_backend_class", side_effect=mock_get_backend):
+        router = AgentRouter(settings)
+        # Manually set primary backend because initialization in __init__ is complex to mock
+        router._backend = primary
+        router._active_backend_name = "mock_primary"
+
+        async for _ in router.run("test"):
+            pass
+
+        # Check log records
+        log_records = [r for r in caplog.records if r.name == "pocketpaw.agents.router"]
+        
+        # 1. Start log
+        start_logs = [r for r in log_records if getattr(r, "event", None) == "backend_start"]
+        assert len(start_logs) >= 1
+        assert start_logs[0].backend == "mock_primary"
+        assert start_logs[0].is_primary is True
+
+        # 2. Success log
+        success_logs = [r for r in log_records if getattr(r, "event", None) == "backend_success"]
+        assert len(success_logs) == 1
+        assert success_logs[0].backend == "mock_primary"
+        # Latency should be at least 100ms (0.1s sleep)
+        assert success_logs[0].latency_ms >= 100
+        assert success_logs[0].is_primary is True
+
+
+@pytest.mark.asyncio
+async def test_router_structured_logging_failure(caplog):
+    """Verify that failed backend runs produce structured logs with error and latency."""
+    caplog.set_level(logging.WARNING)
+    settings = MockSettings()
+
+    class FailingBackend(MockBackend):
+        async def run(self, *args, **kwargs) -> AsyncIterator[AgentEvent]:
+            await asyncio.sleep(0.05)
+            if False: yield AgentEvent(type="message", content="never")
+            raise RuntimeError("Backend exploded")
+
+    primary = FailingBackend("primary")
+    fallback = MockBackend("fallback")
+
+    def mock_get_backend(name):
+        if name == "mock_primary": return lambda s: primary
+        if name == "mock_fallback": return lambda s: fallback
+        return None
+
+    with patch("pocketpaw.agents.router.get_backend_class", side_effect=mock_get_backend):
+        router = AgentRouter(settings)
+        router._backend = primary
+        router._active_backend_name = "mock_primary"
+
+        # It should fall back to the fallback backend
+        async for _ in router.run("test"):
+            pass
+
+        # Check failure log for primary
+        failure_logs = [r for r in caplog.records if getattr(r, "event", None) == "backend_failure"]
+        assert len(failure_logs) == 1
+        assert failure_logs[0].backend == "mock_primary"
+        assert "exploded" in failure_logs[0].error
+        assert failure_logs[0].latency_ms >= 50
+        assert failure_logs[0].is_primary is True


### PR DESCRIPTION
## Overview
Standardizes logging across the AgentRouter to include structured metadata and precise latency metrics, making PocketPaw production-ready for observability stacks.

## Problem
Existing logs were mostly free-text strings. This made it impossible to programmatically track which backends were failing most often or determine the latency impact of fallback chains in tools like Datadog or ELK.

## Proposed Solution
- Metadata Injection: Standardized all critical router logs to use the extra={} field containing event, backend, and is_primary attributes.
- - Latency Tracking: Integrated time.perf_counter() to calculate and log the exact latency_ms for every successful or failed backend execution.
## Pull Request Checklist
* [x] Pre-commit hooks pass
* [x] Tests pass (uv run pytest tests/test_structured_logging.py)
