### PR TITLE
Add ConnectorProtocol — YAML-driven data source integration

### DIFF
--- a/connectors/csv.yaml
+++ b/connectors/csv.yaml
@@ -1,0 +1,31 @@
+# CSV connector — import local CSV/Excel files into pocket.db.
+# Created: 2026-03-27
+
+name: csv
+display_name: CSV Import
+type: file
+icon: file-spreadsheet
+auth:
+  method: none
+  credentials: []
+
+actions:
+  - name: import_file
+    description: Import a CSV or Excel file into a pocket table
+    method: LOCAL
+    params:
+      file_path: { type: string, required: true, description: "Path to CSV/Excel file" }
+      table_name: { type: string, description: "Target table name (defaults to filename)" }
+      delimiter: { type: string, default: "," }
+      has_header: { type: boolean, default: true }
+    trust_level: auto
+
+  - name: list_tables
+    description: List imported tables in this pocket
+    method: LOCAL
+    trust_level: auto
+
+sync:
+  table: null
+  schedule: manual
+  mapping: {}

--- a/connectors/rest_generic.yaml
+++ b/connectors/rest_generic.yaml
@@ -1,0 +1,39 @@
+# Generic REST connector — connect any REST API with user-defined endpoints.
+# Created: 2026-03-27
+
+name: rest_generic
+display_name: REST API
+type: api
+icon: globe
+auth:
+  method: bearer
+  credentials:
+    - name: API_TOKEN
+      description: Bearer token or API key
+      required: false
+    - name: BASE_URL
+      description: Base URL for the API (e.g. https://api.example.com)
+      required: true
+
+actions:
+  - name: get_endpoint
+    description: Make a GET request to any endpoint
+    method: GET
+    params:
+      path: { type: string, required: true, description: "API path (e.g. /users)" }
+      query: { type: object, description: "Query parameters" }
+    trust_level: auto
+
+  - name: post_endpoint
+    description: Make a POST request to any endpoint
+    method: POST
+    params:
+      path: { type: string, required: true }
+    body:
+      data: { type: object, description: "Request body" }
+    trust_level: confirm
+
+sync:
+  table: api_data
+  schedule: manual
+  mapping: {}

--- a/connectors/stripe.yaml
+++ b/connectors/stripe.yaml
@@ -1,0 +1,50 @@
+# Stripe connector — payment data integration.
+# Created: 2026-03-27
+
+name: stripe
+display_name: Stripe
+type: payment
+icon: credit-card
+auth:
+  method: api_key
+  credentials:
+    - name: STRIPE_API_KEY
+      description: Stripe secret key (sk_...)
+      required: true
+
+actions:
+  - name: list_invoices
+    description: List recent invoices
+    method: GET
+    url: https://api.stripe.com/v1/invoices
+    params:
+      limit: { type: integer, default: 10 }
+      status: { type: string, enum: [draft, open, paid, void] }
+    trust_level: auto
+
+  - name: list_customers
+    description: List customers
+    method: GET
+    url: https://api.stripe.com/v1/customers
+    params:
+      limit: { type: integer, default: 10 }
+    trust_level: auto
+
+  - name: create_invoice
+    description: Create a new invoice
+    method: POST
+    url: https://api.stripe.com/v1/invoices
+    body:
+      customer: { type: string, required: true }
+      description: { type: string }
+    trust_level: confirm
+
+sync:
+  table: stripe_invoices
+  schedule: every_15m
+  mapping:
+    id: id
+    amount: amount_due
+    status: status
+    customer: customer
+    created: created

--- a/src/pocketpaw/connectors/__init__.py
+++ b/src/pocketpaw/connectors/__init__.py
@@ -1,0 +1,21 @@
+# Connectors — data integration layer for Paw OS.
+# Created: 2026-03-27 — Multi-adapter facade for external data sources.
+# DirectREST (YAML-defined) is the primary adapter. Composio/MCP are fallbacks.
+
+from pocketpaw.connectors.protocol import (
+    ActionResult,
+    ActionSchema,
+    ConnectionResult,
+    ConnectorProtocol,
+    SyncResult,
+)
+from pocketpaw.connectors.registry import ConnectorRegistry
+
+__all__ = [
+    "ConnectorProtocol",
+    "ConnectionResult",
+    "ActionSchema",
+    "ActionResult",
+    "SyncResult",
+    "ConnectorRegistry",
+]

--- a/src/pocketpaw/connectors/protocol.py
+++ b/src/pocketpaw/connectors/protocol.py
@@ -1,0 +1,108 @@
+# ConnectorProtocol — interface for all data source adapters.
+# Created: 2026-03-27 — Protocol-based, async, adapter-agnostic.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Protocol
+
+
+class ConnectorStatus(StrEnum):
+    """Connection status."""
+    DISCONNECTED = "disconnected"
+    CONNECTED = "connected"
+    SYNCING = "syncing"
+    ERROR = "error"
+
+
+class TrustLevel(StrEnum):
+    """How much human oversight this action needs."""
+    AUTO = "auto"          # Agent can execute without asking
+    CONFIRM = "confirm"    # Agent must ask user first
+    RESTRICTED = "restricted"  # Requires admin approval
+
+
+@dataclass
+class ConnectionResult:
+    """Result of a connect() call."""
+    success: bool
+    connector_name: str
+    status: ConnectorStatus = ConnectorStatus.DISCONNECTED
+    message: str = ""
+    tables_created: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ActionSchema:
+    """Schema for a single connector action."""
+    name: str
+    description: str = ""
+    method: str = "GET"
+    parameters: dict[str, Any] = field(default_factory=dict)
+    trust_level: TrustLevel = TrustLevel.CONFIRM
+
+
+@dataclass
+class ActionResult:
+    """Result of executing a connector action."""
+    success: bool
+    data: Any = None
+    error: str | None = None
+    records_affected: int = 0
+
+
+@dataclass
+class SyncResult:
+    """Result of syncing data from a connector."""
+    success: bool
+    connector_name: str
+    records_synced: int = 0
+    records_updated: int = 0
+    records_deleted: int = 0
+    error: str | None = None
+    duration_ms: float = 0
+
+
+class ConnectorProtocol(Protocol):
+    """Interface for all connector adapters.
+
+    Implementations:
+    - DirectRESTAdapter: YAML-defined REST API connectors
+    - ComposioAdapter: 250+ apps with managed OAuth (future)
+    - CuratedMCPAdapter: Whitelisted MCP servers (future)
+    """
+
+    @property
+    def name(self) -> str:
+        """Connector name (e.g. 'stripe', 'csv')."""
+        ...
+
+    @property
+    def display_name(self) -> str:
+        """Human-readable name (e.g. 'Stripe', 'CSV Import')."""
+        ...
+
+    async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        """Authenticate and establish connection to this data source."""
+        ...
+
+    async def disconnect(self, pocket_id: str) -> bool:
+        """Disconnect from this data source."""
+        ...
+
+    async def actions(self) -> list[ActionSchema]:
+        """Return available actions for this connector."""
+        ...
+
+    async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
+        """Execute a specific action (e.g. list_invoices, create_invoice)."""
+        ...
+
+    async def sync(self, pocket_id: str) -> SyncResult:
+        """Pull latest data into pocket.db."""
+        ...
+
+    async def schema(self) -> dict[str, Any]:
+        """Return data schema for pocket.db table mapping."""
+        ...

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -1,0 +1,97 @@
+# Connector registry — discovers and manages available connectors.
+# Created: 2026-03-27 — Scans connectors/ dir for YAML definitions.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pocketpaw.connectors.protocol import ConnectorStatus
+from pocketpaw.connectors.yaml_engine import ConnectorDef, DirectRESTAdapter, parse_connector_yaml
+
+
+class ConnectorRegistry:
+    """Discovers available connectors and manages instances per pocket."""
+
+    def __init__(self, connectors_dir: Path | None = None) -> None:
+        self._connectors_dir = connectors_dir or Path("connectors")
+        self._definitions: dict[str, ConnectorDef] = {}
+        self._instances: dict[str, DirectRESTAdapter] = {}  # key = "{pocket_id}:{connector_name}"
+        self._scan()
+
+    def _scan(self) -> None:
+        """Scan connectors directory for YAML definitions."""
+        if not self._connectors_dir.exists():
+            return
+        for path in sorted(self._connectors_dir.glob("*.yaml")):
+            try:
+                defn = parse_connector_yaml(path)
+                self._definitions[defn.name] = defn
+            except Exception:
+                pass  # Skip malformed YAMLs
+
+    @property
+    def available(self) -> list[dict[str, str]]:
+        """List all available connector definitions."""
+        return [
+            {
+                "name": d.name,
+                "display_name": d.display_name,
+                "type": d.type,
+                "icon": d.icon,
+            }
+            for d in self._definitions.values()
+        ]
+
+    def get_definition(self, name: str) -> ConnectorDef | None:
+        """Get a connector definition by name."""
+        return self._definitions.get(name)
+
+    def get_adapter(self, pocket_id: str, connector_name: str) -> DirectRESTAdapter | None:
+        """Get an active adapter instance for a pocket+connector."""
+        key = f"{pocket_id}:{connector_name}"
+        return self._instances.get(key)
+
+    async def connect(self, pocket_id: str, connector_name: str, config: dict[str, Any]) -> Any:
+        """Create and connect a connector adapter for a pocket."""
+        defn = self._definitions.get(connector_name)
+        if not defn:
+            return None
+
+        adapter = DirectRESTAdapter(defn)
+        result = await adapter.connect(pocket_id, config)
+
+        if result.success:
+            key = f"{pocket_id}:{connector_name}"
+            self._instances[key] = adapter
+
+        return result
+
+    async def disconnect(self, pocket_id: str, connector_name: str) -> bool:
+        """Disconnect a connector from a pocket."""
+        key = f"{pocket_id}:{connector_name}"
+        adapter = self._instances.get(key)
+        if not adapter:
+            return False
+        await adapter.disconnect(pocket_id)
+        del self._instances[key]
+        return True
+
+    def status(self, pocket_id: str) -> list[dict[str, Any]]:
+        """Get connection status for all connectors in a pocket."""
+        results = []
+        for name, defn in self._definitions.items():
+            key = f"{pocket_id}:{name}"
+            adapter = self._instances.get(key)
+            results.append({
+                "name": name,
+                "display_name": defn.display_name,
+                "icon": defn.icon,
+                "status": ConnectorStatus.CONNECTED if adapter else ConnectorStatus.DISCONNECTED,
+            })
+        return results
+
+    def reload(self) -> None:
+        """Re-scan the connectors directory."""
+        self._definitions.clear()
+        self._scan()

--- a/src/pocketpaw/connectors/yaml_engine.py
+++ b/src/pocketpaw/connectors/yaml_engine.py
@@ -1,0 +1,172 @@
+# DirectREST YAML engine — reads connector YAML definitions and executes REST actions.
+# Created: 2026-03-27 — Primary adapter. One YAML per service.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from pocketpaw.connectors.protocol import (
+    ActionResult,
+    ActionSchema,
+    ConnectionResult,
+    ConnectorStatus,
+    SyncResult,
+    TrustLevel,
+)
+
+
+@dataclass
+class ConnectorDef:
+    """Parsed connector YAML definition."""
+    name: str
+    display_name: str
+    type: str = "generic"
+    icon: str = "plug"
+    auth: dict[str, Any] = field(default_factory=dict)
+    actions: list[dict[str, Any]] = field(default_factory=list)
+    sync: dict[str, Any] = field(default_factory=dict)
+
+
+def parse_connector_yaml(path: Path) -> ConnectorDef:
+    """Parse a connector YAML file into a ConnectorDef."""
+    with open(path) as f:
+        raw = yaml.safe_load(f)
+
+    return ConnectorDef(
+        name=raw.get("name", path.stem),
+        display_name=raw.get("display_name", raw.get("name", path.stem)),
+        type=raw.get("type", "generic"),
+        icon=raw.get("icon", "plug"),
+        auth=raw.get("auth", {}),
+        actions=raw.get("actions", []),
+        sync=raw.get("sync", {}),
+    )
+
+
+class DirectRESTAdapter:
+    """Connector adapter that reads YAML definitions and executes REST actions.
+
+    Each YAML file defines one service (Stripe, Square, etc.) with:
+    - auth config (api_key, oauth, basic, bearer)
+    - actions (REST endpoints with params and response schemas)
+    - sync config (table mapping, schedule)
+    """
+
+    def __init__(self, definition: ConnectorDef) -> None:
+        self._def = definition
+        self._credentials: dict[str, str] = {}
+        self._connected = False
+
+    @property
+    def name(self) -> str:
+        return self._def.name
+
+    @property
+    def display_name(self) -> str:
+        return self._def.display_name
+
+    async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        """Store credentials and mark as connected."""
+        # Extract credentials from config
+        for cred in self._def.auth.get("credentials", []):
+            key = cred["name"]
+            if key in config:
+                self._credentials[key] = config[key]
+            elif cred.get("required", False):
+                return ConnectionResult(
+                    success=False,
+                    connector_name=self.name,
+                    status=ConnectorStatus.ERROR,
+                    message=f"Missing required credential: {key}",
+                )
+
+        self._connected = True
+        tables = []
+        if self._def.sync.get("table"):
+            tables.append(self._def.sync["table"])
+
+        return ConnectionResult(
+            success=True,
+            connector_name=self.name,
+            status=ConnectorStatus.CONNECTED,
+            message=f"Connected to {self.display_name}",
+            tables_created=tables,
+        )
+
+    async def disconnect(self, pocket_id: str) -> bool:
+        self._credentials.clear()
+        self._connected = False
+        return True
+
+    async def actions(self) -> list[ActionSchema]:
+        """Convert YAML action definitions to ActionSchema list."""
+        schemas = []
+        for act in self._def.actions:
+            params = {}
+            for key, val in act.get("params", {}).items():
+                params[key] = val
+            for key, val in act.get("body", {}).items():
+                params[key] = val
+
+            schemas.append(ActionSchema(
+                name=act["name"],
+                description=act.get("description", ""),
+                method=act.get("method", "GET"),
+                parameters=params,
+                trust_level=TrustLevel(act.get("trust_level", "confirm")),
+            ))
+        return schemas
+
+    async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
+        """Execute a REST action. In production this would make HTTP calls."""
+        if not self._connected:
+            return ActionResult(success=False, error="Not connected")
+
+        # Find the action definition
+        act_def = None
+        for a in self._def.actions:
+            if a["name"] == action:
+                act_def = a
+                break
+
+        if not act_def:
+            return ActionResult(success=False, error=f"Unknown action: {action}")
+
+        # In a real implementation, this would:
+        # 1. Build the URL with params
+        # 2. Add auth headers from self._credentials
+        # 3. Make the HTTP request
+        # 4. Parse and return the response
+        # For now, return a placeholder indicating the action would be called
+        return ActionResult(
+            success=True,
+            data={"action": action, "method": act_def.get("method", "GET"), "params": params},
+            records_affected=0,
+        )
+
+    async def sync(self, pocket_id: str) -> SyncResult:
+        """Sync data from the external service into pocket.db."""
+        if not self._connected:
+            return SyncResult(success=False, connector_name=self.name, error="Not connected")
+
+        if not self._def.sync:
+            return SyncResult(success=False, connector_name=self.name, error="No sync config")
+
+        # In production: call the list action, map response to pocket.db table
+        return SyncResult(
+            success=True,
+            connector_name=self.name,
+            records_synced=0,
+        )
+
+    async def schema(self) -> dict[str, Any]:
+        """Return the sync table schema."""
+        return {
+            "table": self._def.sync.get("table", f"{self.name}_data"),
+            "mapping": self._def.sync.get("mapping", {}),
+            "schedule": self._def.sync.get("schedule", "manual"),
+        }

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,0 +1,160 @@
+# Tests for ConnectorProtocol — YAML parsing, registry, adapter lifecycle.
+# Created: 2026-03-27
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.connectors.protocol import ConnectorStatus, TrustLevel
+from pocketpaw.connectors.yaml_engine import DirectRESTAdapter, parse_connector_yaml
+from pocketpaw.connectors.registry import ConnectorRegistry
+
+
+CONNECTORS_DIR = Path(__file__).parent.parent / "connectors"
+
+
+class TestYAMLParsing:
+    """Test parsing connector YAML definitions."""
+
+    def test_parse_stripe_yaml(self) -> None:
+        defn = parse_connector_yaml(CONNECTORS_DIR / "stripe.yaml")
+        assert defn.name == "stripe"
+        assert defn.display_name == "Stripe"
+        assert defn.type == "payment"
+        assert defn.icon == "credit-card"
+        assert len(defn.actions) == 3
+        assert defn.auth["method"] == "api_key"
+
+    def test_parse_csv_yaml(self) -> None:
+        defn = parse_connector_yaml(CONNECTORS_DIR / "csv.yaml")
+        assert defn.name == "csv"
+        assert defn.auth["method"] == "none"
+        assert len(defn.actions) == 2
+
+    def test_parse_generic_rest_yaml(self) -> None:
+        defn = parse_connector_yaml(CONNECTORS_DIR / "rest_generic.yaml")
+        assert defn.name == "rest_generic"
+        assert defn.display_name == "REST API"
+
+    def test_action_schemas(self) -> None:
+        defn = parse_connector_yaml(CONNECTORS_DIR / "stripe.yaml")
+        # create_invoice should have trust_level: confirm
+        create = next(a for a in defn.actions if a["name"] == "create_invoice")
+        assert create["trust_level"] == "confirm"
+
+    def test_sync_config(self) -> None:
+        defn = parse_connector_yaml(CONNECTORS_DIR / "stripe.yaml")
+        assert defn.sync["table"] == "stripe_invoices"
+        assert defn.sync["schedule"] == "every_15m"
+        assert "amount" in defn.sync["mapping"]
+
+
+class TestDirectRESTAdapter:
+    """Test the DirectREST adapter lifecycle."""
+
+    @pytest.fixture
+    def stripe_adapter(self) -> DirectRESTAdapter:
+        defn = parse_connector_yaml(CONNECTORS_DIR / "stripe.yaml")
+        return DirectRESTAdapter(defn)
+
+    @pytest.mark.asyncio
+    async def test_connect_success(self, stripe_adapter: DirectRESTAdapter) -> None:
+        result = await stripe_adapter.connect("pocket-1", {"STRIPE_API_KEY": "sk_test_123"})
+        assert result.success is True
+        assert result.status == ConnectorStatus.CONNECTED
+        assert "stripe_invoices" in result.tables_created
+
+    @pytest.mark.asyncio
+    async def test_connect_missing_credential(self, stripe_adapter: DirectRESTAdapter) -> None:
+        result = await stripe_adapter.connect("pocket-1", {})
+        assert result.success is False
+        assert "STRIPE_API_KEY" in result.message
+
+    @pytest.mark.asyncio
+    async def test_list_actions(self, stripe_adapter: DirectRESTAdapter) -> None:
+        actions = await stripe_adapter.actions()
+        assert len(actions) == 3
+        names = [a.name for a in actions]
+        assert "list_invoices" in names
+        assert "create_invoice" in names
+
+        create = next(a for a in actions if a.name == "create_invoice")
+        assert create.trust_level == TrustLevel.CONFIRM
+
+    @pytest.mark.asyncio
+    async def test_execute_not_connected(self, stripe_adapter: DirectRESTAdapter) -> None:
+        result = await stripe_adapter.execute("list_invoices", {})
+        assert result.success is False
+        assert result.error == "Not connected"
+
+    @pytest.mark.asyncio
+    async def test_execute_connected(self, stripe_adapter: DirectRESTAdapter) -> None:
+        await stripe_adapter.connect("pocket-1", {"STRIPE_API_KEY": "sk_test_123"})
+        result = await stripe_adapter.execute("list_invoices", {"limit": 5})
+        assert result.success is True
+        assert result.data["action"] == "list_invoices"
+
+    @pytest.mark.asyncio
+    async def test_execute_unknown_action(self, stripe_adapter: DirectRESTAdapter) -> None:
+        await stripe_adapter.connect("pocket-1", {"STRIPE_API_KEY": "sk_test_123"})
+        result = await stripe_adapter.execute("nonexistent", {})
+        assert result.success is False
+        assert "Unknown action" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_disconnect(self, stripe_adapter: DirectRESTAdapter) -> None:
+        await stripe_adapter.connect("pocket-1", {"STRIPE_API_KEY": "sk_test_123"})
+        await stripe_adapter.disconnect("pocket-1")
+        result = await stripe_adapter.execute("list_invoices", {})
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_schema(self, stripe_adapter: DirectRESTAdapter) -> None:
+        schema = await stripe_adapter.schema()
+        assert schema["table"] == "stripe_invoices"
+        assert schema["schedule"] == "every_15m"
+
+
+class TestConnectorRegistry:
+    """Test connector discovery and management."""
+
+    def test_scan_connectors(self) -> None:
+        registry = ConnectorRegistry(CONNECTORS_DIR)
+        available = registry.available
+        names = [c["name"] for c in available]
+        assert "stripe" in names
+        assert "csv" in names
+        assert "rest_generic" in names
+
+    def test_get_definition(self) -> None:
+        registry = ConnectorRegistry(CONNECTORS_DIR)
+        defn = registry.get_definition("stripe")
+        assert defn is not None
+        assert defn.display_name == "Stripe"
+
+    @pytest.mark.asyncio
+    async def test_connect_and_status(self) -> None:
+        registry = ConnectorRegistry(CONNECTORS_DIR)
+        result = await registry.connect("pocket-1", "stripe", {"STRIPE_API_KEY": "sk_test_123"})
+        assert result.success is True
+
+        status = registry.status("pocket-1")
+        stripe_status = next(s for s in status if s["name"] == "stripe")
+        assert stripe_status["status"] == ConnectorStatus.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_disconnect(self) -> None:
+        registry = ConnectorRegistry(CONNECTORS_DIR)
+        await registry.connect("pocket-1", "stripe", {"STRIPE_API_KEY": "sk_test_123"})
+        success = await registry.disconnect("pocket-1", "stripe")
+        assert success is True
+
+        adapter = registry.get_adapter("pocket-1", "stripe")
+        assert adapter is None
+
+    def test_nonexistent_connector(self) -> None:
+        registry = ConnectorRegistry(CONNECTORS_DIR)
+        defn = registry.get_definition("nonexistent")
+        assert defn is None


### PR DESCRIPTION
## Summary

ConnectorProtocol is the data integration layer for Paw OS. Each external service (Stripe, CSV, REST API) is defined in a YAML file. The YAML engine reads definitions and executes REST actions with trust levels (auto/confirm/restricted).

## What's included

| File | Purpose |
|------|---------|
| `src/pocketpaw/connectors/protocol.py` | Protocol interface + result models |
| `src/pocketpaw/connectors/yaml_engine.py` | YAML parser + DirectRESTAdapter |
| `src/pocketpaw/connectors/registry.py` | Auto-discovery, per-pocket management |
| `connectors/stripe.yaml` | Stripe connector (invoices, customers) |
| `connectors/csv.yaml` | CSV file import |
| `connectors/rest_generic.yaml` | Generic REST API |
| `tests/test_connectors.py` | 18 tests |

## Architecture

```
ConnectorProtocol (async interface)
├── DirectRESTAdapter  ← YAML-defined, this PR
├── ComposioAdapter    ← 250+ apps (Phase 2)
└── CuratedMCPAdapter  ← Whitelisted MCP (Phase 2)
```

## Test plan

- [x] 18/18 tests passing
- [ ] Wire to `paw connect` CLI command (future PR)
- [ ] Add HTTP execution with httpx (future PR)
- [ ] Infisical credential storage (future PR)