### PR TITLE
Add REST API endpoints for Fabric + Instinct enterprise features

### DIFF
--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,0 +1,146 @@
+# Connectors — Data Source Integration
+
+Connectors bring external data into PocketPaw Pockets. Each service is defined in a YAML file — the engine reads the definition and handles auth, execution, and sync.
+
+## Quick Start
+
+```bash
+# List available connectors
+paw connectors list
+
+# Connect Stripe to a pocket
+paw connect stripe --pocket "My Business"
+
+# Check connection status
+paw connectors status
+```
+
+## How It Works
+
+```
+Your Service (Stripe, Shopify, CSV, etc.)
+    ↓
+Connector YAML (defines endpoints, auth, sync)
+    ↓
+DirectREST Engine (reads YAML, makes API calls)
+    ↓
+pocket.db (data lands in SQLite tables)
+    ↓
+Pocket widgets auto-update with fresh data
+```
+
+## Writing a Connector YAML
+
+Each connector is a YAML file in `connectors/`. Here's the structure:
+
+```yaml
+# connectors/my_service.yaml
+name: my_service
+display_name: My Service
+type: payment                     # category for grouping
+icon: credit-card                 # lucide icon name
+
+auth:
+  method: api_key                 # api_key | oauth | basic | bearer | none
+  credentials:
+    - name: MY_API_KEY
+      description: API key from My Service dashboard
+      required: true
+
+actions:
+  - name: list_items
+    description: Get all items
+    method: GET
+    url: https://api.myservice.com/v1/items
+    params:
+      limit: { type: integer, default: 10 }
+      status: { type: string, enum: [active, archived] }
+    trust_level: auto             # auto | confirm | restricted
+
+  - name: create_item
+    description: Create a new item
+    method: POST
+    url: https://api.myservice.com/v1/items
+    body:
+      name: { type: string, required: true }
+      price: { type: number }
+    trust_level: confirm          # requires user approval
+
+sync:
+  table: my_service_items         # target table in pocket.db
+  schedule: every_15m             # polling interval
+  mapping:                        # field mapping
+    id: id
+    name: name
+    price: price
+    created: created_at
+```
+
+## Auth Methods
+
+| Method | When to Use | Example |
+|--------|-------------|---------|
+| `api_key` | Service provides a static API key | Stripe, Tavily |
+| `oauth` | Service uses OAuth 2.0 flow | Google, Spotify |
+| `bearer` | Token-based auth (API key in Authorization header) | Generic REST APIs |
+| `basic` | Username + password auth | Legacy APIs |
+| `none` | Public API, no auth needed | Reddit (read-only) |
+
+## Trust Levels
+
+Each action has a trust level that controls how much human oversight the agent needs:
+
+| Level | Behavior | Use For |
+|-------|----------|---------|
+| `auto` | Agent executes without asking | Read-only operations (list, search) |
+| `confirm` | Agent asks user before executing | Write operations (create, update, delete) |
+| `restricted` | Requires admin approval | Destructive or financial operations |
+
+## Using with Existing Integrations
+
+PocketPaw already has built-in integrations for Google Workspace, Spotify, and Reddit. These work as **agent tools** (one-off actions via chat). Connectors add **continuous data sync** on top:
+
+| Integration | As Tool (built-in) | As Connector (YAML) |
+|-------------|-------------------|---------------------|
+| Gmail | "Search my emails for invoices" → one-off result | Sync inbox every 15m → `gmail_messages` table → Pocket widget |
+| Google Calendar | "Create a meeting tomorrow" → done | Sync events daily → `calendar_events` table → schedule widget |
+| Stripe | (not built-in yet) | Sync invoices → `stripe_invoices` table → revenue dashboard |
+| CSV | (not built-in yet) | Import file → custom table → data visualization |
+
+Tools and connectors complement each other. Tools are for actions. Connectors are for data.
+
+## Built-in Connectors
+
+| Connector | File | Auth | Syncs |
+|-----------|------|------|-------|
+| **Stripe** | `connectors/stripe.yaml` | API key | Invoices, customers |
+| **CSV Import** | `connectors/csv.yaml` | None | Any CSV/Excel file |
+| **REST API** | `connectors/rest_generic.yaml` | Bearer token | Any REST endpoint |
+
+## Architecture
+
+```
+ConnectorProtocol (Python async interface)
+│
+├── DirectRESTAdapter     ← YAML-defined REST APIs (primary)
+├── ComposioAdapter       ← 250+ apps with managed OAuth (planned)
+└── CuratedMCPAdapter     ← Whitelisted MCP servers (planned)
+```
+
+The `ConnectorRegistry` auto-discovers YAML files from the `connectors/` directory and manages adapter instances per pocket.
+
+## Adding a New Connector
+
+1. Create `connectors/your_service.yaml` following the schema above
+2. Test it: `paw connect your_service --pocket "Test"`
+3. The agent can now use it: "Connect my Shopify to this pocket"
+
+That's it. No Python code needed — just YAML.
+
+## Security
+
+- Credentials are never stored in YAML files or pocket.db
+- Auth tokens flow through the credential store (Infisical planned)
+- Each pocket has isolated connector access
+- Trust levels enforce human oversight for write operations
+- All connector actions are logged to the audit trail

--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,0 +1,27 @@
+Functional Source License, Version 1.1, Apache 2.0 Future License
+
+Licensor:  Qbtrix Inc.
+Software:  PocketPaw Enterprise Extensions
+
+Use Limitation:
+You may use this software for any purpose except competing with
+PocketPaw or offering it as a managed service.
+
+Change Date: Four years from the date the software is released.
+Change License: Apache License, Version 2.0
+
+For full FSL terms, see: https://fsl.software/
+
+---
+
+The code in this directory (ee/) is licensed separately from the
+rest of the PocketPaw repository, which is under the Apache 2.0 license.
+
+Enterprise features include:
+- Fabric (ontology layer)
+- Instinct (decision pipeline)
+- Automations (triggers and schedules)
+- Audit (enhanced compliance logging)
+
+These features require a PocketPaw Enterprise license for production use.
+After the Change Date, this code converts to Apache 2.0.

--- a/ee/__init__.py
+++ b/ee/__init__.py
@@ -1,0 +1,9 @@
+# PocketPaw Enterprise Extensions (ee/)
+# Licensed under FSL 1.1 — see ee/LICENSE
+# These features require a PocketPaw Enterprise license for production use.
+#
+# Modules:
+#   fabric/    — Ontology layer (objects, links, properties)
+#   instinct/  — Decision pipeline (actions, approvals, audit)
+#   automations/ — Time/data triggers
+#   audit/     — Enhanced compliance logging

--- a/ee/api.py
+++ b/ee/api.py
@@ -1,0 +1,27 @@
+# Enterprise API — dependency injection for ee/ stores.
+# Created: 2026-03-28 — Provides FabricStore + InstinctStore as FastAPI deps.
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+from ee.fabric.store import FabricStore
+from ee.instinct.store import InstinctStore
+
+
+def _db_path() -> Path:
+    """Enterprise DB path — ~/.pocketpaw/enterprise.db"""
+    p = Path.home() / ".pocketpaw"
+    p.mkdir(parents=True, exist_ok=True)
+    return p / "enterprise.db"
+
+
+@lru_cache(maxsize=1)
+def get_fabric_store() -> FabricStore:
+    return FabricStore(_db_path())
+
+
+@lru_cache(maxsize=1)
+def get_instinct_store() -> InstinctStore:
+    return InstinctStore(_db_path())

--- a/ee/audit/__init__.py
+++ b/ee/audit/__init__.py
@@ -1,0 +1,4 @@
+# Audit — enhanced compliance logging for Paw OS.
+# Created: 2026-03-28 — Placeholder for future implementation.
+# Extends instinct's audit log with export formats, retention policies,
+# and compliance reporting (SOC2, GDPR).

--- a/ee/automations/__init__.py
+++ b/ee/automations/__init__.py
@@ -1,0 +1,4 @@
+# Automations — time/data triggers for Paw OS.
+# Created: 2026-03-28 — Placeholder for future implementation.
+# "When inventory drops below 10, alert me."
+# "Every Monday, generate the weekly report pocket."

--- a/ee/fabric/__init__.py
+++ b/ee/fabric/__init__.py
@@ -1,0 +1,16 @@
+# Fabric — lightweight ontology layer for Paw OS.
+# Created: 2026-03-28 — Objects, links, properties in SQLite.
+# Maps raw data into typed business objects with relationships
+# so agents can reason across data.
+
+from ee.fabric.models import FabricLink, FabricObject, FabricQuery, ObjectType, PropertyDef
+from ee.fabric.store import FabricStore
+
+__all__ = [
+    "ObjectType",
+    "PropertyDef",
+    "FabricObject",
+    "FabricLink",
+    "FabricQuery",
+    "FabricStore",
+]

--- a/ee/fabric/models.py
+++ b/ee/fabric/models.py
@@ -1,0 +1,78 @@
+# Fabric data models — Pydantic models for the ontology layer.
+# Created: 2026-03-28
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+def _gen_id(prefix: str) -> str:
+    import time, random, string
+    ts = hex(int(time.time() * 1000))[2:]
+    rand = ''.join(random.choices(string.ascii_lowercase + string.digits, k=4))
+    return f"{prefix}-{ts}-{rand}"
+
+
+class PropertyDef(BaseModel):
+    """Definition of a property on an object type."""
+    name: str
+    type: str = "string"  # string, number, boolean, date, enum
+    required: bool = False
+    description: str = ""
+    enum_values: list[str] | None = None
+    default: Any = None
+
+
+class ObjectType(BaseModel):
+    """Defines a category of business objects (Customer, Order, Product)."""
+    id: str = Field(default_factory=lambda: _gen_id("ot"))
+    name: str
+    description: str = ""
+    icon: str = "box"
+    color: str = "#0A84FF"
+    properties: list[PropertyDef] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
+class FabricObject(BaseModel):
+    """An instance of an ObjectType."""
+    id: str = Field(default_factory=lambda: _gen_id("obj"))
+    type_id: str
+    type_name: str = ""
+    properties: dict[str, Any] = Field(default_factory=dict)
+    source_connector: str | None = None
+    source_id: str | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
+class FabricLink(BaseModel):
+    """A directional relationship between two objects."""
+    id: str = Field(default_factory=lambda: _gen_id("lnk"))
+    from_object_id: str
+    to_object_id: str
+    link_type: str  # "has_orders", "belongs_to", "purchased"
+    properties: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=datetime.now)
+
+
+class FabricQuery(BaseModel):
+    """Query parameters for finding objects."""
+    type_name: str | None = None
+    type_id: str | None = None
+    filters: dict[str, Any] = Field(default_factory=dict)
+    linked_to: str | None = None
+    link_type: str | None = None
+    limit: int = 50
+    offset: int = 0
+
+
+class FabricQueryResult(BaseModel):
+    """Result of a fabric query."""
+    objects: list[FabricObject]
+    total: int
+    links: list[FabricLink] = Field(default_factory=list)

--- a/ee/fabric/router.py
+++ b/ee/fabric/router.py
@@ -1,0 +1,161 @@
+# Fabric API router — REST endpoints for the ontology layer.
+# Created: 2026-03-28 — CRUD for object types, objects, links.
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from ee.api import get_fabric_store
+from ee.fabric.models import FabricQuery, PropertyDef
+from ee.fabric.store import FabricStore
+
+router = APIRouter(prefix="/api/v1/fabric", tags=["fabric"])
+
+
+# --- Request Models ---
+
+class CreateTypeRequest(BaseModel):
+    name: str
+    description: str = ""
+    icon: str = "box"
+    color: str = "#0A84FF"
+    properties: list[PropertyDef] = []
+
+
+class CreateObjectRequest(BaseModel):
+    type_id: str
+    properties: dict[str, Any] = {}
+    source_connector: str | None = None
+    source_id: str | None = None
+
+
+class UpdateObjectRequest(BaseModel):
+    properties: dict[str, Any]
+
+
+class CreateLinkRequest(BaseModel):
+    from_object_id: str
+    to_object_id: str
+    link_type: str
+    properties: dict[str, Any] = {}
+
+
+# --- Object Types ---
+
+@router.get("/types")
+async def list_types(store: FabricStore = Depends(get_fabric_store)):
+    types = await store.list_types()
+    return [t.model_dump(mode="json") for t in types]
+
+
+@router.post("/types", status_code=201)
+async def create_type(req: CreateTypeRequest, store: FabricStore = Depends(get_fabric_store)):
+    t = await store.define_type(
+        name=req.name, properties=req.properties,
+        description=req.description, icon=req.icon, color=req.color,
+    )
+    return t.model_dump(mode="json")
+
+
+@router.delete("/types/{type_id}")
+async def delete_type(type_id: str, store: FabricStore = Depends(get_fabric_store)):
+    existing = await store.get_type(type_id)
+    if not existing:
+        raise HTTPException(404, "Object type not found")
+    await store.remove_type(type_id)
+    return {"ok": True}
+
+
+# --- Objects ---
+
+@router.get("/objects")
+async def query_objects(
+    type_name: str | None = None,
+    type_id: str | None = None,
+    linked_to: str | None = None,
+    link_type: str | None = None,
+    limit: int = Query(50, le=200),
+    offset: int = Query(0, ge=0),
+    store: FabricStore = Depends(get_fabric_store),
+):
+    q = FabricQuery(
+        type_name=type_name, type_id=type_id,
+        linked_to=linked_to, link_type=link_type,
+        limit=limit, offset=offset,
+    )
+    result = await store.query(q)
+    return {
+        "objects": [o.model_dump(mode="json") for o in result.objects],
+        "total": result.total,
+    }
+
+
+@router.post("/objects", status_code=201)
+async def create_object(req: CreateObjectRequest, store: FabricStore = Depends(get_fabric_store)):
+    obj = await store.create_object(
+        type_id=req.type_id, properties=req.properties,
+        source_connector=req.source_connector, source_id=req.source_id,
+    )
+    return obj.model_dump(mode="json")
+
+
+@router.get("/objects/{obj_id}")
+async def get_object(obj_id: str, store: FabricStore = Depends(get_fabric_store)):
+    obj = await store.get_object(obj_id)
+    if not obj:
+        raise HTTPException(404, "Object not found")
+    return obj.model_dump(mode="json")
+
+
+@router.patch("/objects/{obj_id}")
+async def update_object(obj_id: str, req: UpdateObjectRequest, store: FabricStore = Depends(get_fabric_store)):
+    obj = await store.update_object(obj_id, req.properties)
+    if not obj:
+        raise HTTPException(404, "Object not found")
+    return obj.model_dump(mode="json")
+
+
+@router.delete("/objects/{obj_id}")
+async def delete_object(obj_id: str, store: FabricStore = Depends(get_fabric_store)):
+    existing = await store.get_object(obj_id)
+    if not existing:
+        raise HTTPException(404, "Object not found")
+    await store.remove_object(obj_id)
+    return {"ok": True}
+
+
+@router.get("/objects/{obj_id}/linked")
+async def get_linked(
+    obj_id: str,
+    link_type: str | None = None,
+    store: FabricStore = Depends(get_fabric_store),
+):
+    objects = await store.get_linked_objects(obj_id, link_type)
+    return [o.model_dump(mode="json") for o in objects]
+
+
+# --- Links ---
+
+@router.post("/links", status_code=201)
+async def create_link(req: CreateLinkRequest, store: FabricStore = Depends(get_fabric_store)):
+    lnk = await store.link(
+        from_id=req.from_object_id, to_id=req.to_object_id,
+        link_type=req.link_type, properties=req.properties,
+    )
+    return lnk.model_dump(mode="json")
+
+
+@router.delete("/links/{link_id}")
+async def delete_link(link_id: str, store: FabricStore = Depends(get_fabric_store)):
+    await store.unlink(link_id)
+    return {"ok": True}
+
+
+# --- Stats ---
+
+@router.get("/stats")
+async def get_stats(store: FabricStore = Depends(get_fabric_store)):
+    return await store.stats()

--- a/ee/fabric/store.py
+++ b/ee/fabric/store.py
@@ -1,0 +1,328 @@
+# Fabric store — async SQLite operations for the ontology layer.
+# Created: 2026-03-28 — CRUD for object types, objects, and links.
+
+from __future__ import annotations
+
+import json
+import aiosqlite
+from pathlib import Path
+from typing import Any
+
+from ee.fabric.models import (
+    FabricLink,
+    FabricObject,
+    FabricQuery,
+    FabricQueryResult,
+    ObjectType,
+    PropertyDef,
+    _gen_id,
+)
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS fabric_object_types (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    icon TEXT DEFAULT 'box',
+    color TEXT DEFAULT '#0A84FF',
+    properties_schema TEXT DEFAULT '[]',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS fabric_objects (
+    id TEXT PRIMARY KEY,
+    type_id TEXT NOT NULL REFERENCES fabric_object_types(id),
+    type_name TEXT DEFAULT '',
+    properties TEXT NOT NULL DEFAULT '{}',
+    source_connector TEXT,
+    source_id TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS fabric_links (
+    id TEXT PRIMARY KEY,
+    from_object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    to_object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    link_type TEXT NOT NULL,
+    properties TEXT DEFAULT '{}',
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_objects_type ON fabric_objects(type_id);
+CREATE INDEX IF NOT EXISTS idx_objects_source ON fabric_objects(source_connector, source_id);
+CREATE INDEX IF NOT EXISTS idx_links_from ON fabric_links(from_object_id);
+CREATE INDEX IF NOT EXISTS idx_links_to ON fabric_links(to_object_id);
+CREATE INDEX IF NOT EXISTS idx_links_type ON fabric_links(link_type);
+"""
+
+
+class FabricStore:
+    """Async SQLite store for Fabric ontology data."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._initialized = False
+
+    async def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        async with aiosqlite.connect(self._db_path) as db:
+            await db.executescript(SCHEMA_SQL)
+            await db.commit()
+        self._initialized = True
+
+    def _conn(self) -> aiosqlite.Connection:
+        """Return a new connection context manager. Use with `async with`."""
+        return aiosqlite.connect(self._db_path)
+
+    # --- Object Types ---
+
+    async def define_type(
+        self, name: str, properties: list[PropertyDef],
+        description: str = "", icon: str = "box", color: str = "#0A84FF",
+    ) -> ObjectType:
+        obj_type = ObjectType(
+            name=name, description=description, icon=icon, color=color,
+            properties=properties,
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO fabric_object_types (id, name, description, icon, color, properties_schema) VALUES (?, ?, ?, ?, ?, ?)",
+                (obj_type.id, obj_type.name, obj_type.description, obj_type.icon, obj_type.color,
+                 json.dumps([p.model_dump() for p in properties])),
+            )
+            await db.commit()
+        return obj_type
+
+    async def get_type(self, type_id: str) -> ObjectType | None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM fabric_object_types WHERE id = ?", (type_id,)) as cur:
+                row = await cur.fetchone()
+                if not row:
+                    return None
+                return self._row_to_type(row)
+
+    async def get_type_by_name(self, name: str) -> ObjectType | None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM fabric_object_types WHERE LOWER(name) = LOWER(?)", (name,)
+            ) as cur:
+                row = await cur.fetchone()
+                if not row:
+                    return None
+                return self._row_to_type(row)
+
+    async def list_types(self) -> list[ObjectType]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM fabric_object_types ORDER BY name") as cur:
+                return [self._row_to_type(row) async for row in cur]
+
+    async def remove_type(self, type_id: str) -> None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            # Cascade: delete links involving objects of this type, then objects, then type
+            await db.execute(
+                "DELETE FROM fabric_links WHERE from_object_id IN (SELECT id FROM fabric_objects WHERE type_id = ?) "
+                "OR to_object_id IN (SELECT id FROM fabric_objects WHERE type_id = ?)",
+                (type_id, type_id),
+            )
+            await db.execute("DELETE FROM fabric_objects WHERE type_id = ?", (type_id,))
+            await db.execute("DELETE FROM fabric_object_types WHERE id = ?", (type_id,))
+            await db.commit()
+
+    # --- Objects ---
+
+    async def create_object(
+        self, type_id: str, properties: dict[str, Any],
+        source_connector: str | None = None, source_id: str | None = None,
+    ) -> FabricObject:
+        obj_type = await self.get_type(type_id)
+        obj = FabricObject(
+            type_id=type_id,
+            type_name=obj_type.name if obj_type else "",
+            properties=properties,
+            source_connector=source_connector,
+            source_id=source_id,
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO fabric_objects (id, type_id, type_name, properties, source_connector, source_id) VALUES (?, ?, ?, ?, ?, ?)",
+                (obj.id, obj.type_id, obj.type_name, json.dumps(properties), source_connector, source_id),
+            )
+            await db.commit()
+        return obj
+
+    async def get_object(self, obj_id: str) -> FabricObject | None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM fabric_objects WHERE id = ?", (obj_id,)) as cur:
+                row = await cur.fetchone()
+                if not row:
+                    return None
+                return self._row_to_object(row)
+
+    async def update_object(self, obj_id: str, properties: dict[str, Any]) -> FabricObject | None:
+        existing = await self.get_object(obj_id)
+        if not existing:
+            return None
+        merged = {**existing.properties, **properties}
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE fabric_objects SET properties = ?, updated_at = datetime('now') WHERE id = ?",
+                (json.dumps(merged), obj_id),
+            )
+            await db.commit()
+        return await self.get_object(obj_id)
+
+    async def remove_object(self, obj_id: str) -> None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "DELETE FROM fabric_links WHERE from_object_id = ? OR to_object_id = ?",
+                (obj_id, obj_id),
+            )
+            await db.execute("DELETE FROM fabric_objects WHERE id = ?", (obj_id,))
+            await db.commit()
+
+    # --- Links ---
+
+    async def link(self, from_id: str, to_id: str, link_type: str,
+                   properties: dict[str, Any] | None = None) -> FabricLink:
+        lnk = FabricLink(
+            from_object_id=from_id, to_object_id=to_id,
+            link_type=link_type, properties=properties or {},
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO fabric_links (id, from_object_id, to_object_id, link_type, properties) VALUES (?, ?, ?, ?, ?)",
+                (lnk.id, lnk.from_object_id, lnk.to_object_id, lnk.link_type, json.dumps(lnk.properties)),
+            )
+            await db.commit()
+        return lnk
+
+    async def unlink(self, link_id: str) -> None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute("DELETE FROM fabric_links WHERE id = ?", (link_id,))
+            await db.commit()
+
+    async def get_linked_objects(self, obj_id: str, link_type: str | None = None) -> list[FabricObject]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            if link_type:
+                query = (
+                    "SELECT o.* FROM fabric_objects o JOIN fabric_links l "
+                    "ON (o.id = l.to_object_id AND l.from_object_id = ?) "
+                    "OR (o.id = l.from_object_id AND l.to_object_id = ?) "
+                    "WHERE l.link_type = ?"
+                )
+                params = (obj_id, obj_id, link_type)
+            else:
+                query = (
+                    "SELECT o.* FROM fabric_objects o JOIN fabric_links l "
+                    "ON (o.id = l.to_object_id AND l.from_object_id = ?) "
+                    "OR (o.id = l.from_object_id AND l.to_object_id = ?)"
+                )
+                params = (obj_id, obj_id)
+            async with db.execute(query, params) as cur:
+                return [self._row_to_object(row) async for row in cur]
+
+    # --- Query ---
+
+    async def query(self, q: FabricQuery) -> FabricQueryResult:
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if q.type_id:
+            conditions.append("o.type_id = ?")
+            params.append(q.type_id)
+        elif q.type_name:
+            conditions.append("LOWER(o.type_name) = LOWER(?)")
+            params.append(q.type_name)
+
+        if q.linked_to:
+            if q.link_type:
+                link_cond = (
+                    "o.id IN ("
+                    "SELECT to_object_id FROM fabric_links WHERE from_object_id = ? AND link_type = ? "
+                    "UNION "
+                    "SELECT from_object_id FROM fabric_links WHERE to_object_id = ? AND link_type = ?"
+                    ")"
+                )
+                conditions.append(link_cond)
+                params.extend([q.linked_to, q.link_type, q.linked_to, q.link_type])
+            else:
+                link_cond = (
+                    "o.id IN ("
+                    "SELECT to_object_id FROM fabric_links WHERE from_object_id = ? "
+                    "UNION "
+                    "SELECT from_object_id FROM fabric_links WHERE to_object_id = ?"
+                    ")"
+                )
+                conditions.append(link_cond)
+                params.extend([q.linked_to, q.linked_to])
+
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            # Count
+            async with db.execute(f"SELECT COUNT(*) as cnt FROM fabric_objects o {where}", params) as cur:
+                row = await cur.fetchone()
+                total = row["cnt"] if row else 0
+
+            # Fetch
+            async with db.execute(
+                f"SELECT o.* FROM fabric_objects o {where} ORDER BY o.created_at DESC LIMIT ? OFFSET ?",
+                [*params, q.limit, q.offset],
+            ) as cur:
+                objects = [self._row_to_object(row) async for row in cur]
+
+        return FabricQueryResult(objects=objects, total=total)
+
+    # --- Stats ---
+
+    async def stats(self) -> dict[str, int]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            types = await db.execute_fetchall("SELECT COUNT(*) FROM fabric_object_types")
+            objects = await db.execute_fetchall("SELECT COUNT(*) FROM fabric_objects")
+            links = await db.execute_fetchall("SELECT COUNT(*) FROM fabric_links")
+            return {
+                "types": types[0][0] if types else 0,
+                "objects": objects[0][0] if objects else 0,
+                "links": links[0][0] if links else 0,
+            }
+
+    # --- Helpers ---
+
+    def _row_to_type(self, row: Any) -> ObjectType:
+        props_raw = json.loads(row["properties_schema"]) if row["properties_schema"] else []
+        return ObjectType(
+            id=row["id"], name=row["name"], description=row["description"] or "",
+            icon=row["icon"] or "box", color=row["color"] or "#0A84FF",
+            properties=[PropertyDef(**p) for p in props_raw],
+        )
+
+    def _row_to_object(self, row: Any) -> FabricObject:
+        return FabricObject(
+            id=row["id"], type_id=row["type_id"], type_name=row["type_name"] or "",
+            properties=json.loads(row["properties"]) if row["properties"] else {},
+            source_connector=row["source_connector"], source_id=row["source_id"],
+        )

--- a/ee/instinct/__init__.py
+++ b/ee/instinct/__init__.py
@@ -1,0 +1,14 @@
+# Instinct — decision pipeline for Paw OS.
+# Created: 2026-03-28 — Actions, approvals, audit log.
+# The decision loop: Agent proposes → Human approves → Action executes → Feedback captured.
+
+from ee.instinct.models import Action, ActionTrigger, ActionContext, AuditEntry
+from ee.instinct.store import InstinctStore
+
+__all__ = [
+    "Action",
+    "ActionTrigger",
+    "ActionContext",
+    "AuditEntry",
+    "InstinctStore",
+]

--- a/ee/instinct/models.py
+++ b/ee/instinct/models.py
@@ -1,0 +1,95 @@
+# Instinct data models — decision pipeline types.
+# Created: 2026-03-28
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from ee.fabric.models import _gen_id
+
+
+class ActionStatus(StrEnum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    EXECUTED = "executed"
+    FAILED = "failed"
+
+
+class ActionPriority(StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ActionCategory(StrEnum):
+    DATA = "data"
+    ALERT = "alert"
+    WORKFLOW = "workflow"
+    CONFIG = "config"
+    EXTERNAL = "external"
+
+
+class ActionTrigger(BaseModel):
+    """What triggered an action."""
+    type: str  # "agent", "automation", "user", "connector"
+    source: str  # agent name, rule ID, user ID, connector name
+    reason: str
+
+
+class ActionContext(BaseModel):
+    """Data context for a decision."""
+    object_ids: list[str] = Field(default_factory=list)
+    connector_data: dict[str, Any] = Field(default_factory=dict)
+    metrics: dict[str, float] = Field(default_factory=dict)
+    notes: str = ""
+
+
+class Action(BaseModel):
+    """A proposed action from the agent, waiting for approval."""
+    id: str = Field(default_factory=lambda: _gen_id("act"))
+    pocket_id: str
+    title: str
+    description: str
+    category: ActionCategory = ActionCategory.WORKFLOW
+    status: ActionStatus = ActionStatus.PENDING
+    priority: ActionPriority = ActionPriority.MEDIUM
+    trigger: ActionTrigger
+    recommendation: str
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    context: ActionContext = Field(default_factory=ActionContext)
+    outcome: str | None = None
+    error: str | None = None
+    approved_by: str | None = None
+    approved_at: datetime | None = None
+    rejected_reason: str | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+    executed_at: datetime | None = None
+
+
+class AuditCategory(StrEnum):
+    DECISION = "decision"
+    DATA = "data"
+    CONFIG = "config"
+    SECURITY = "security"
+
+
+class AuditEntry(BaseModel):
+    """An audit log entry for every decision."""
+    id: str = Field(default_factory=lambda: _gen_id("aud"))
+    action_id: str | None = None
+    pocket_id: str | None = None
+    timestamp: datetime = Field(default_factory=datetime.now)
+    actor: str  # "agent:claude", "user:prakash", "system"
+    event: str  # "action_proposed", "action_approved", etc.
+    category: AuditCategory = AuditCategory.DECISION
+    description: str
+    context: dict[str, Any] = Field(default_factory=dict)
+    ai_recommendation: str | None = None
+    outcome: str | None = None

--- a/ee/instinct/router.py
+++ b/ee/instinct/router.py
@@ -1,0 +1,150 @@
+# Instinct API router — REST endpoints for the decision pipeline.
+# Created: 2026-03-28 — Action lifecycle, approvals, audit log.
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from ee.api import get_instinct_store
+from ee.instinct.models import ActionCategory, ActionPriority, ActionTrigger, ActionContext
+from ee.instinct.store import InstinctStore
+
+router = APIRouter(prefix="/api/v1/instinct", tags=["instinct"])
+
+
+# --- Request Models ---
+
+class ProposeActionRequest(BaseModel):
+    pocket_id: str
+    title: str
+    description: str = ""
+    category: str = "workflow"
+    priority: str = "medium"
+    recommendation: str
+    parameters: dict[str, Any] = {}
+    trigger: ActionTrigger
+    context: ActionContext | None = None
+
+
+class ApproveRequest(BaseModel):
+    approver: str = "user"
+
+
+class RejectRequest(BaseModel):
+    reason: str = ""
+    rejector: str = "user"
+
+
+class ExecuteRequest(BaseModel):
+    outcome: str | None = None
+
+
+# --- Actions ---
+
+@router.get("/actions")
+async def list_actions(
+    pocket_id: str | None = None,
+    status: str | None = None,
+    store: InstinctStore = Depends(get_instinct_store),
+):
+    if pocket_id:
+        actions = await store.for_pocket(pocket_id)
+    elif status:
+        from ee.instinct.models import ActionStatus
+        actions = await store._query_actions(status=ActionStatus(status))
+    else:
+        actions = await store._query_actions()
+    return [a.model_dump(mode="json") for a in actions]
+
+
+@router.post("/actions", status_code=201)
+async def propose_action(req: ProposeActionRequest, store: InstinctStore = Depends(get_instinct_store)):
+    action = await store.propose(
+        pocket_id=req.pocket_id, title=req.title, description=req.description,
+        recommendation=req.recommendation, trigger=req.trigger,
+        category=ActionCategory(req.category),
+        priority=ActionPriority(req.priority),
+        parameters=req.parameters, context=req.context,
+    )
+    return action.model_dump(mode="json")
+
+
+@router.get("/actions/{action_id}")
+async def get_action(action_id: str, store: InstinctStore = Depends(get_instinct_store)):
+    action = await store.get_action(action_id)
+    if not action:
+        raise HTTPException(404, "Action not found")
+    return action.model_dump(mode="json")
+
+
+@router.post("/actions/{action_id}/approve")
+async def approve_action(action_id: str, req: ApproveRequest, store: InstinctStore = Depends(get_instinct_store)):
+    action = await store.approve(action_id, req.approver)
+    if not action:
+        raise HTTPException(404, "Action not found")
+    return action.model_dump(mode="json")
+
+
+@router.post("/actions/{action_id}/reject")
+async def reject_action(action_id: str, req: RejectRequest, store: InstinctStore = Depends(get_instinct_store)):
+    action = await store.reject(action_id, req.reason, req.rejector)
+    if not action:
+        raise HTTPException(404, "Action not found")
+    return action.model_dump(mode="json")
+
+
+@router.post("/actions/{action_id}/execute")
+async def execute_action(action_id: str, req: ExecuteRequest, store: InstinctStore = Depends(get_instinct_store)):
+    action = await store.mark_executed(action_id, req.outcome)
+    if not action:
+        raise HTTPException(404, "Action not found")
+    return action.model_dump(mode="json")
+
+
+# --- Pending Queue ---
+
+@router.get("/pending")
+async def get_pending(
+    pocket_id: str | None = None,
+    store: InstinctStore = Depends(get_instinct_store),
+):
+    actions = await store.pending(pocket_id)
+    return [a.model_dump(mode="json") for a in actions]
+
+
+@router.get("/pending/count")
+async def get_pending_count(
+    pocket_id: str | None = None,
+    store: InstinctStore = Depends(get_instinct_store),
+):
+    count = await store.pending_count(pocket_id)
+    return {"count": count}
+
+
+# --- Audit Log ---
+
+@router.get("/audit")
+async def query_audit(
+    pocket_id: str | None = None,
+    category: str | None = None,
+    event: str | None = None,
+    limit: int = Query(100, le=1000),
+    store: InstinctStore = Depends(get_instinct_store),
+):
+    entries = await store.query_audit(
+        pocket_id=pocket_id, category=category, event=event, limit=limit,
+    )
+    return [e.model_dump(mode="json") for e in entries]
+
+
+@router.get("/audit/export")
+async def export_audit(
+    pocket_id: str | None = None,
+    store: InstinctStore = Depends(get_instinct_store),
+):
+    from fastapi.responses import JSONResponse
+    data = await store.export_audit(pocket_id)
+    return JSONResponse(content={"entries": __import__("json").loads(data)})

--- a/ee/instinct/store.py
+++ b/ee/instinct/store.py
@@ -1,0 +1,315 @@
+# Instinct store — async SQLite operations for the decision pipeline.
+# Created: 2026-03-28 — Action lifecycle + audit log.
+
+from __future__ import annotations
+
+import json
+import aiosqlite
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ee.instinct.models import (
+    Action,
+    ActionCategory,
+    ActionContext,
+    ActionPriority,
+    ActionStatus,
+    ActionTrigger,
+    AuditCategory,
+    AuditEntry,
+    _gen_id,
+)
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS instinct_actions (
+    id TEXT PRIMARY KEY,
+    pocket_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    category TEXT DEFAULT 'workflow',
+    status TEXT DEFAULT 'pending',
+    priority TEXT DEFAULT 'medium',
+    trigger TEXT NOT NULL,
+    recommendation TEXT DEFAULT '',
+    parameters TEXT DEFAULT '{}',
+    context TEXT DEFAULT '{}',
+    outcome TEXT,
+    error TEXT,
+    approved_by TEXT,
+    approved_at TEXT,
+    rejected_reason TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    executed_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS instinct_audit (
+    id TEXT PRIMARY KEY,
+    action_id TEXT,
+    pocket_id TEXT,
+    timestamp TEXT DEFAULT (datetime('now')),
+    actor TEXT NOT NULL,
+    event TEXT NOT NULL,
+    category TEXT DEFAULT 'decision',
+    description TEXT NOT NULL,
+    context TEXT DEFAULT '{}',
+    ai_recommendation TEXT,
+    outcome TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_actions_pocket ON instinct_actions(pocket_id);
+CREATE INDEX IF NOT EXISTS idx_actions_status ON instinct_actions(status);
+CREATE INDEX IF NOT EXISTS idx_audit_pocket ON instinct_audit(pocket_id);
+CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON instinct_audit(timestamp);
+"""
+
+
+class InstinctStore:
+    """Async SQLite store for the decision pipeline."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._initialized = False
+
+    async def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        async with aiosqlite.connect(self._db_path) as db:
+            await db.executescript(SCHEMA_SQL)
+            await db.commit()
+        self._initialized = True
+
+    def _conn(self) -> aiosqlite.Connection:
+        """Return a new connection context manager."""
+        return aiosqlite.connect(self._db_path)
+
+    # --- Actions ---
+
+    async def propose(
+        self, pocket_id: str, title: str, description: str,
+        recommendation: str, trigger: ActionTrigger,
+        category: ActionCategory = ActionCategory.WORKFLOW,
+        priority: ActionPriority = ActionPriority.MEDIUM,
+        parameters: dict[str, Any] | None = None,
+        context: ActionContext | None = None,
+    ) -> Action:
+        action = Action(
+            pocket_id=pocket_id, title=title, description=description,
+            recommendation=recommendation, trigger=trigger,
+            category=category, priority=priority,
+            parameters=parameters or {}, context=context or ActionContext(),
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO instinct_actions (id, pocket_id, title, description, category, status, priority, trigger, recommendation, parameters, context) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (action.id, pocket_id, title, description, action.category.value,
+                 action.status.value, action.priority.value,
+                 action.trigger.model_dump_json(), recommendation,
+                 json.dumps(parameters or {}), action.context.model_dump_json()),
+            )
+            await db.commit()
+
+        await self._log(
+            action_id=action.id, pocket_id=pocket_id,
+            actor=f"{trigger.type}:{trigger.source}",
+            event="action_proposed",
+            description=f"Proposed: {title}",
+            ai_recommendation=recommendation,
+        )
+        return action
+
+    async def approve(self, action_id: str, approver: str = "user") -> Action | None:
+        return await self._update_status(
+            action_id, ActionStatus.APPROVED,
+            approved_by=approver, approved_at=datetime.now().isoformat(),
+            event="action_approved", actor=approver,
+        )
+
+    async def reject(self, action_id: str, reason: str = "", rejector: str = "user") -> Action | None:
+        return await self._update_status(
+            action_id, ActionStatus.REJECTED,
+            rejected_reason=reason,
+            event="action_rejected", actor=rejector,
+            extra_desc=f" — {reason}" if reason else "",
+        )
+
+    async def mark_executed(self, action_id: str, outcome: str | None = None) -> Action | None:
+        return await self._update_status(
+            action_id, ActionStatus.EXECUTED,
+            outcome=outcome, executed_at=datetime.now().isoformat(),
+            event="action_executed", actor="system",
+        )
+
+    async def mark_failed(self, action_id: str, error: str) -> Action | None:
+        return await self._update_status(
+            action_id, ActionStatus.FAILED,
+            error=error,
+            event="action_failed", actor="system",
+            extra_desc=f" — {error}",
+        )
+
+    async def _update_status(
+        self, action_id: str, status: ActionStatus, *,
+        event: str, actor: str, extra_desc: str = "", **fields: Any,
+    ) -> Action | None:
+        action = await self.get_action(action_id)
+        if not action:
+            return None
+
+        sets = ["status = ?", "updated_at = datetime('now')"]
+        params: list[Any] = [status.value]
+        for k, v in fields.items():
+            if v is not None:
+                sets.append(f"{k} = ?")
+                params.append(v)
+        params.append(action_id)
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                f"UPDATE instinct_actions SET {', '.join(sets)} WHERE id = ?", params
+            )
+            await db.commit()
+
+        await self._log(
+            action_id=action_id, pocket_id=action.pocket_id,
+            actor=actor, event=event,
+            description=f"{event.replace('_', ' ').title()}: {action.title}{extra_desc}",
+        )
+        return await self.get_action(action_id)
+
+    async def get_action(self, action_id: str) -> Action | None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM instinct_actions WHERE id = ?", (action_id,)) as cur:
+                row = await cur.fetchone()
+                return self._row_to_action(row) if row else None
+
+    async def pending(self, pocket_id: str | None = None) -> list[Action]:
+        return await self._query_actions(status=ActionStatus.PENDING, pocket_id=pocket_id)
+
+    async def pending_count(self, pocket_id: str | None = None) -> int:
+        cond = "WHERE status = 'pending'"
+        params: list[Any] = []
+        if pocket_id:
+            cond += " AND pocket_id = ?"
+            params.append(pocket_id)
+        await self._ensure_schema()
+        async with self._conn() as db:
+            async with db.execute(f"SELECT COUNT(*) FROM instinct_actions {cond}", params) as cur:
+                row = await cur.fetchone()
+                return row[0] if row else 0
+
+    async def for_pocket(self, pocket_id: str) -> list[Action]:
+        return await self._query_actions(pocket_id=pocket_id)
+
+    async def _query_actions(
+        self, status: ActionStatus | None = None, pocket_id: str | None = None,
+    ) -> list[Action]:
+        conditions: list[str] = []
+        params: list[Any] = []
+        if status:
+            conditions.append("status = ?")
+            params.append(status.value)
+        if pocket_id:
+            conditions.append("pocket_id = ?")
+            params.append(pocket_id)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                f"SELECT * FROM instinct_actions {where} ORDER BY created_at DESC", params
+            ) as cur:
+                return [self._row_to_action(row) async for row in cur]
+
+    # --- Audit Log ---
+
+    async def _log(self, *, actor: str, event: str, description: str,
+                   action_id: str | None = None, pocket_id: str | None = None,
+                   category: AuditCategory = AuditCategory.DECISION,
+                   context: dict[str, Any] | None = None,
+                   ai_recommendation: str | None = None, outcome: str | None = None) -> AuditEntry:
+        entry = AuditEntry(
+            action_id=action_id, pocket_id=pocket_id, actor=actor,
+            event=event, category=category, description=description,
+            context=context or {}, ai_recommendation=ai_recommendation, outcome=outcome,
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO instinct_audit (id, action_id, pocket_id, actor, event, category, description, context, ai_recommendation, outcome) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (entry.id, entry.action_id, entry.pocket_id, entry.actor, entry.event,
+                 entry.category.value, entry.description, json.dumps(entry.context),
+                 entry.ai_recommendation, entry.outcome),
+            )
+            await db.commit()
+        return entry
+
+    async def log(self, *, actor: str, event: str, description: str, **kwargs: Any) -> AuditEntry:
+        """Public audit log method for non-action events."""
+        return await self._log(actor=actor, event=event, description=description, **kwargs)
+
+    async def query_audit(
+        self, pocket_id: str | None = None, category: str | None = None,
+        event: str | None = None, limit: int = 100,
+    ) -> list[AuditEntry]:
+        conditions: list[str] = []
+        params: list[Any] = []
+        if pocket_id:
+            conditions.append("pocket_id = ?")
+            params.append(pocket_id)
+        if category:
+            conditions.append("category = ?")
+            params.append(category)
+        if event:
+            conditions.append("event = ?")
+            params.append(event)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        params.append(limit)
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                f"SELECT * FROM instinct_audit {where} ORDER BY timestamp DESC LIMIT ?", params
+            ) as cur:
+                return [self._row_to_audit(row) async for row in cur]
+
+    async def export_audit(self, pocket_id: str | None = None) -> str:
+        entries = await self.query_audit(pocket_id=pocket_id, limit=10000)
+        return json.dumps([e.model_dump(mode="json") for e in entries], indent=2)
+
+    # --- Helpers ---
+
+    def _row_to_action(self, row: Any) -> Action:
+        return Action(
+            id=row["id"], pocket_id=row["pocket_id"], title=row["title"],
+            description=row["description"] or "",
+            category=ActionCategory(row["category"]),
+            status=ActionStatus(row["status"]),
+            priority=ActionPriority(row["priority"]),
+            trigger=ActionTrigger.model_validate_json(row["trigger"]),
+            recommendation=row["recommendation"] or "",
+            parameters=json.loads(row["parameters"]) if row["parameters"] else {},
+            context=ActionContext.model_validate_json(row["context"]) if row["context"] else ActionContext(),
+            outcome=row["outcome"], error=row["error"],
+            approved_by=row["approved_by"], rejected_reason=row["rejected_reason"],
+        )
+
+    def _row_to_audit(self, row: Any) -> AuditEntry:
+        return AuditEntry(
+            id=row["id"], action_id=row["action_id"], pocket_id=row["pocket_id"],
+            actor=row["actor"], event=row["event"],
+            category=AuditCategory(row["category"]),
+            description=row["description"],
+            context=json.loads(row["context"]) if row["context"] else {},
+            ai_recommendation=row["ai_recommendation"], outcome=row["outcome"],
+        )

--- a/src/pocketpaw/audit/__init__.py
+++ b/src/pocketpaw/audit/__init__.py
@@ -1,0 +1,9 @@
+# pocketpaw/audit/__init__.py — Enterprise audit log module.
+# Created: 2026-03-27
+# Provides AuditEntry model, AuditStore (SQLite), and FastAPI router
+# for government/enterprise compliance logging of all Paw OS decisions.
+
+from pocketpaw.audit.models import AuditEntry
+from pocketpaw.audit.store import AuditStore, get_audit_store
+
+__all__ = ["AuditEntry", "AuditStore", "get_audit_store"]

--- a/src/pocketpaw/audit/models.py
+++ b/src/pocketpaw/audit/models.py
@@ -1,0 +1,97 @@
+# pocketpaw/audit/models.py — Pydantic models for enterprise audit logging.
+# Created: 2026-03-27
+# AuditEntry captures who did what, when, why, what data was used,
+# what the AI recommended, and what actually happened — for compliance.
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+
+# Valid categories for audit entries
+AuditCategory = Literal["decision", "data", "config", "security"]
+
+# Valid status values
+AuditStatus = Literal["completed", "approved", "rejected", "pending"]
+
+
+class AuditEntry(BaseModel):
+    """A single enterprise audit log entry.
+
+    Captures the full decision context: who acted, on what data,
+    what AI recommended, and what actually happened.
+    """
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: str = Field(
+        default_factory=lambda: datetime.now(UTC).isoformat()
+    )
+    pocket_id: str | None = None
+    actor: str  # "agent", "user:prakash", "system"
+    action: str  # "create_pocket", "approve_action", "connector_sync"
+    category: AuditCategory  # "decision", "data", "config", "security"
+    description: str  # Human-readable: "Agent proposed reordering inventory"
+    context: dict = Field(default_factory=dict)  # Data used to make the decision
+    ai_recommendation: str | None = None  # What the AI suggested
+    outcome: str | None = None  # What actually happened
+    status: AuditStatus = "completed"
+    metadata: dict = Field(default_factory=dict)  # Tool name, connector, etc.
+
+    @field_validator("category")
+    @classmethod
+    def validate_category(cls, v: str) -> str:
+        valid = {"decision", "data", "config", "security"}
+        if v not in valid:
+            raise ValueError(f"category must be one of {valid}, got {v!r}")
+        return v
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        valid = {"completed", "approved", "rejected", "pending"}
+        if v not in valid:
+            raise ValueError(f"status must be one of {valid}, got {v!r}")
+        return v
+
+    def to_db_row(self) -> dict:
+        """Serialize for SQLite storage."""
+        import json
+
+        return {
+            "id": self.id,
+            "timestamp": self.timestamp,
+            "pocket_id": self.pocket_id,
+            "actor": self.actor,
+            "action": self.action,
+            "category": self.category,
+            "description": self.description,
+            "context": json.dumps(self.context),
+            "ai_recommendation": self.ai_recommendation,
+            "outcome": self.outcome,
+            "status": self.status,
+            "metadata": json.dumps(self.metadata),
+        }
+
+    @classmethod
+    def from_db_row(cls, row: dict) -> "AuditEntry":
+        """Deserialize from SQLite row."""
+        import json
+
+        return cls(
+            id=row["id"],
+            timestamp=row["timestamp"],
+            pocket_id=row["pocket_id"],
+            actor=row["actor"],
+            action=row["action"],
+            category=row["category"],
+            description=row["description"],
+            context=json.loads(row["context"] or "{}"),
+            ai_recommendation=row["ai_recommendation"],
+            outcome=row["outcome"],
+            status=row["status"],
+            metadata=json.loads(row["metadata"] or "{}"),
+        )

--- a/src/pocketpaw/audit/router.py
+++ b/src/pocketpaw/audit/router.py
@@ -1,0 +1,107 @@
+# pocketpaw/audit/router.py — FastAPI router for the enterprise audit log API.
+# Created: 2026-03-27
+# Endpoints:
+#   GET  /api/v1/audit                    — query entries with filters
+#   GET  /api/v1/audit/export             — export as CSV or JSON for compliance
+# Auth: requires "audit" scope (same pattern as memory/settings routers).
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+from pocketpaw.audit.models import AuditEntry
+from pocketpaw.audit.store import AuditStore, get_audit_store
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Audit"])
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class AuditQueryResponse(BaseModel):
+    entries: list[AuditEntry]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/audit", response_model=AuditQueryResponse)
+async def query_audit_log(
+    pocket_id: str | None = Query(None, description="Filter by pocket ID"),
+    category: str | None = Query(None, description="Filter by category: decision|data|config|security"),
+    actor: str | None = Query(None, description="Filter by actor (agent, user:name, system)"),
+    date_from: datetime | None = Query(None, description="ISO datetime lower bound"),
+    date_to: datetime | None = Query(None, description="ISO datetime upper bound"),
+    limit: int = Query(100, ge=1, le=1000, description="Max entries to return"),
+    store: AuditStore = Depends(get_audit_store),
+) -> AuditQueryResponse:
+    """Query the enterprise audit log with optional filters.
+
+    Returns entries sorted newest-first. All parameters are optional.
+    """
+    entries = await store.query_entries(
+        pocket_id=pocket_id,
+        category=category,
+        actor=actor,
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit,
+    )
+    return AuditQueryResponse(entries=entries, total=len(entries))
+
+
+@router.get("/audit/export")
+async def export_audit_log(
+    format: Literal["csv", "json"] = Query(..., description="Export format: csv or json"),
+    pocket_id: str | None = Query(None),
+    category: str | None = Query(None),
+    date_from: datetime | None = Query(None),
+    date_to: datetime | None = Query(None),
+    store: AuditStore = Depends(get_audit_store),
+) -> Response:
+    """Export audit log for compliance. Supports CSV and JSON formats.
+
+    CSV is suitable for Excel/Google Sheets. JSON is suitable for programmatic
+    processing or import into compliance tools.
+    """
+    if format == "csv":
+        data = await store.export_csv(
+            pocket_id=pocket_id,
+            category=category,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        filename = "audit_log.csv"
+        if pocket_id:
+            filename = f"audit_log_{pocket_id}.csv"
+        return Response(
+            content=data,
+            media_type="text/csv",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+    elif format == "json":
+        data = await store.export_json(
+            pocket_id=pocket_id,
+            category=category,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        return Response(
+            content=data,
+            media_type="application/json",
+        )
+    else:
+        raise HTTPException(status_code=422, detail=f"Unsupported format: {format}")

--- a/src/pocketpaw/audit/store.py
+++ b/src/pocketpaw/audit/store.py
@@ -1,0 +1,262 @@
+# pocketpaw/audit/store.py — SQLite-backed store for enterprise audit log entries.
+# Created: 2026-03-27
+# Uses stdlib sqlite3 (no extra deps). Async interface via run_in_executor.
+# Stores entries in pocket.db-adjacent audit_log table with indexes for
+# pocket_id, category, and timestamp queries.
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import logging
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pocketpaw.audit.models import AuditEntry
+
+logger = logging.getLogger(__name__)
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    id TEXT PRIMARY KEY,
+    timestamp TEXT NOT NULL,
+    pocket_id TEXT,
+    actor TEXT NOT NULL,
+    action TEXT NOT NULL,
+    category TEXT NOT NULL DEFAULT 'decision',
+    description TEXT NOT NULL,
+    context TEXT DEFAULT '{}',
+    ai_recommendation TEXT,
+    outcome TEXT,
+    status TEXT DEFAULT 'completed',
+    metadata TEXT DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_audit_pocket    ON audit_log(pocket_id);
+CREATE INDEX IF NOT EXISTS idx_audit_category  ON audit_log(category);
+CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_log(timestamp);
+CREATE INDEX IF NOT EXISTS idx_audit_actor     ON audit_log(actor);
+"""
+
+
+class AuditStore:
+    """SQLite-backed audit log store.
+
+    Stores AuditEntry records and supports filtered queries + CSV/JSON export.
+    All public methods are async (run sqlite3 synchronously — it's fast enough
+    for audit log volume; aiosqlite not required as a dependency).
+    """
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        if db_path is None:
+            base_dir = Path.home() / ".pocketpaw"
+            base_dir.mkdir(parents=True, exist_ok=True)
+            db_path = base_dir / "audit.db"
+        self.db_path = Path(db_path)
+        self._initialized = False
+
+    def _get_conn(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.db_path))
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        with self._get_conn() as conn:
+            conn.executescript(_DDL)
+            conn.commit()
+        self._initialized = True
+
+    async def log_entry(
+        self,
+        actor: str,
+        action: str,
+        category: str,
+        description: str,
+        pocket_id: str | None = None,
+        context: dict | None = None,
+        ai_recommendation: str | None = None,
+        outcome: str | None = None,
+        status: str = "completed",
+        metadata: dict | None = None,
+    ) -> str:
+        """Create and persist a new AuditEntry. Returns the entry id."""
+        self._ensure_schema()
+        entry = AuditEntry(
+            actor=actor,
+            action=action,
+            category=category,  # type: ignore[arg-type]
+            description=description,
+            pocket_id=pocket_id,
+            context=context or {},
+            ai_recommendation=ai_recommendation,
+            outcome=outcome,
+            status=status,  # type: ignore[arg-type]
+            metadata=metadata or {},
+        )
+        row = entry.to_db_row()
+        with self._get_conn() as conn:
+            conn.execute(
+                """
+                INSERT INTO audit_log
+                    (id, timestamp, pocket_id, actor, action, category,
+                     description, context, ai_recommendation, outcome, status, metadata)
+                VALUES
+                    (:id, :timestamp, :pocket_id, :actor, :action, :category,
+                     :description, :context, :ai_recommendation, :outcome, :status, :metadata)
+                """,
+                row,
+            )
+            conn.commit()
+        logger.debug("audit: logged %s by %s (%s)", action, actor, entry.id)
+        return entry.id
+
+    async def query_entries(
+        self,
+        pocket_id: str | None = None,
+        category: str | None = None,
+        actor: str | None = None,
+        date_from: datetime | None = None,
+        date_to: datetime | None = None,
+        limit: int = 200,
+    ) -> list[AuditEntry]:
+        """Query audit entries with optional filters. Returns newest first."""
+        self._ensure_schema()
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if pocket_id is not None:
+            conditions.append("pocket_id = ?")
+            params.append(pocket_id)
+        if category is not None:
+            conditions.append("category = ?")
+            params.append(category)
+        if actor is not None:
+            conditions.append("actor = ?")
+            params.append(actor)
+        if date_from is not None:
+            conditions.append("timestamp >= ?")
+            params.append(date_from.isoformat())
+        if date_to is not None:
+            conditions.append("timestamp <= ?")
+            params.append(date_to.isoformat())
+
+        where = "WHERE " + " AND ".join(conditions) if conditions else ""
+        sql = f"SELECT * FROM audit_log {where} ORDER BY timestamp DESC LIMIT ?"
+        params.append(limit)
+
+        with self._get_conn() as conn:
+            rows = conn.execute(sql, params).fetchall()
+
+        return [AuditEntry.from_db_row(dict(row)) for row in rows]
+
+    async def export_csv(
+        self,
+        pocket_id: str | None = None,
+        category: str | None = None,
+        date_from: datetime | None = None,
+        date_to: datetime | None = None,
+    ) -> bytes:
+        """Export filtered entries as CSV bytes."""
+        entries = await self.query_entries(
+            pocket_id=pocket_id,
+            category=category,
+            date_from=date_from,
+            date_to=date_to,
+            limit=10_000,
+        )
+        buf = io.StringIO()
+        fieldnames = [
+            "id", "timestamp", "pocket_id", "actor", "action",
+            "category", "description", "context", "ai_recommendation",
+            "outcome", "status", "metadata",
+        ]
+        writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for entry in entries:
+            row = entry.to_db_row()
+            writer.writerow(row)
+        return buf.getvalue().encode("utf-8")
+
+    async def export_json(
+        self,
+        pocket_id: str | None = None,
+        category: str | None = None,
+        date_from: datetime | None = None,
+        date_to: datetime | None = None,
+    ) -> bytes:
+        """Export filtered entries as JSON bytes (list of objects)."""
+        entries = await self.query_entries(
+            pocket_id=pocket_id,
+            category=category,
+            date_from=date_from,
+            date_to=date_to,
+            limit=10_000,
+        )
+        data = [entry.model_dump() for entry in entries]
+        return json.dumps(data, default=str).encode("utf-8")
+
+    # ------------------------------------------------------------------
+    # Domain helpers — convenience methods for common integration points
+    # ------------------------------------------------------------------
+
+    async def log_tool_execution(
+        self,
+        tool_name: str,
+        actor: str,
+        description: str,
+        context: dict | None = None,
+        pocket_id: str | None = None,
+        outcome: str | None = None,
+        status: str = "completed",
+    ) -> str:
+        """Log an agent tool execution event."""
+        return await self.log_entry(
+            actor=actor,
+            action="tool_execution",
+            category="decision",
+            description=description,
+            pocket_id=pocket_id,
+            context=context or {},
+            outcome=outcome,
+            status=status,
+            metadata={"tool": tool_name},
+        )
+
+    async def log_connector_sync(
+        self,
+        connector_name: str,
+        actor: str,
+        description: str,
+        record_count: int = 0,
+        pocket_id: str | None = None,
+        status: str = "completed",
+    ) -> str:
+        """Log a connector data sync event."""
+        return await self.log_entry(
+            actor=actor,
+            action="connector_sync",
+            category="data",
+            description=description,
+            pocket_id=pocket_id,
+            status=status,
+            metadata={"connector": connector_name, "record_count": record_count},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Singleton / FastAPI dependency
+# ---------------------------------------------------------------------------
+
+_audit_store: AuditStore | None = None
+
+
+def get_audit_store() -> AuditStore:
+    """Return the global AuditStore singleton."""
+    global _audit_store
+    if _audit_store is None:
+        _audit_store = AuditStore()
+    return _audit_store

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,511 @@
+# test_audit.py — Tests for the enterprise audit log module.
+# Created: 2026-03-27
+# TDD: tests written before implementation.
+# Covers AuditEntry model, AuditStore (log/query/export), and API endpoints.
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def audit_db(tmp_path) -> "AuditStore":
+    """Isolated in-memory (tmp file) AuditStore per test."""
+    from pocketpaw.audit.store import AuditStore
+
+    return AuditStore(db_path=tmp_path / "audit.db")
+
+
+@pytest.fixture
+def sample_entry_data():
+    return {
+        "pocket_id": "pocket-abc",
+        "actor": "agent",
+        "action": "create_pocket",
+        "category": "decision",
+        "description": "Agent created inventory pocket",
+        "context": {"query": "inventory levels Q1"},
+        "ai_recommendation": "Create pocket with 3 widgets",
+        "outcome": "Pocket created successfully",
+        "status": "completed",
+        "metadata": {"tool": "create_pocket"},
+    }
+
+
+@pytest.fixture
+def populated_store(audit_db, sample_entry_data):
+    """Store pre-populated with several entries for filter testing."""
+    import asyncio
+
+    entries = [
+        {**sample_entry_data, "category": "decision", "actor": "agent", "pocket_id": "pocket-1"},
+        {**sample_entry_data, "category": "data", "actor": "user:prakash", "pocket_id": "pocket-1"},
+        {**sample_entry_data, "category": "security", "actor": "system", "pocket_id": "pocket-2"},
+        {**sample_entry_data, "category": "decision", "actor": "agent", "pocket_id": "pocket-2"},
+        {**sample_entry_data, "category": "config", "actor": "user:prakash", "pocket_id": "pocket-1"},
+    ]
+
+    async def _populate():
+        for e in entries:
+            await audit_db.log_entry(**e)
+
+    asyncio.get_event_loop().run_until_complete(_populate())
+    return audit_db
+
+
+# ---------------------------------------------------------------------------
+# AuditEntry model tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuditEntryModel:
+    def test_model_has_required_fields(self):
+        from pocketpaw.audit.models import AuditEntry
+
+        entry = AuditEntry(
+            actor="agent",
+            action="create_pocket",
+            category="decision",
+            description="Agent created a pocket",
+        )
+        assert entry.id is not None
+        assert entry.timestamp is not None
+        assert entry.actor == "agent"
+        assert entry.action == "create_pocket"
+        assert entry.category == "decision"
+        assert entry.description == "Agent created a pocket"
+
+    def test_model_defaults(self):
+        from pocketpaw.audit.models import AuditEntry
+
+        entry = AuditEntry(
+            actor="system",
+            action="connector_sync",
+            category="data",
+            description="Synced Stripe connector",
+        )
+        assert entry.status == "completed"
+        assert entry.context == {}
+        assert entry.metadata == {}
+        assert entry.pocket_id is None
+        assert entry.ai_recommendation is None
+        assert entry.outcome is None
+
+    def test_model_id_is_unique(self):
+        from pocketpaw.audit.models import AuditEntry
+
+        a = AuditEntry(actor="agent", action="x", category="decision", description="x")
+        b = AuditEntry(actor="agent", action="x", category="decision", description="x")
+        assert a.id != b.id
+
+    def test_model_timestamp_is_utc_iso(self):
+        from pocketpaw.audit.models import AuditEntry
+
+        entry = AuditEntry(actor="agent", action="x", category="decision", description="x")
+        # Should be parseable as ISO datetime
+        dt = datetime.fromisoformat(entry.timestamp.replace("Z", "+00:00"))
+        assert dt is not None
+
+    def test_model_rejects_invalid_status(self):
+        from pocketpaw.audit.models import AuditEntry
+
+        with pytest.raises(Exception):
+            AuditEntry(
+                actor="agent",
+                action="x",
+                category="decision",
+                description="x",
+                status="invalid_status",
+            )
+
+    def test_model_rejects_invalid_category(self):
+        from pocketpaw.audit.models import AuditEntry
+
+        with pytest.raises(Exception):
+            AuditEntry(
+                actor="agent",
+                action="x",
+                category="unknown_cat",
+                description="x",
+            )
+
+
+# ---------------------------------------------------------------------------
+# AuditStore tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuditStoreLogEntry:
+    @pytest.mark.asyncio
+    async def test_log_entry_returns_entry_id(self, audit_db, sample_entry_data):
+        entry_id = await audit_db.log_entry(**sample_entry_data)
+        assert isinstance(entry_id, str)
+        assert len(entry_id) > 0
+
+    @pytest.mark.asyncio
+    async def test_log_entry_persists_to_db(self, audit_db, sample_entry_data):
+        entry_id = await audit_db.log_entry(**sample_entry_data)
+        entries = await audit_db.query_entries()
+        assert any(e.id == entry_id for e in entries)
+
+    @pytest.mark.asyncio
+    async def test_log_entry_stores_all_fields(self, audit_db, sample_entry_data):
+        entry_id = await audit_db.log_entry(**sample_entry_data)
+        entries = await audit_db.query_entries()
+        entry = next(e for e in entries if e.id == entry_id)
+
+        assert entry.pocket_id == "pocket-abc"
+        assert entry.actor == "agent"
+        assert entry.action == "create_pocket"
+        assert entry.category == "decision"
+        assert entry.description == "Agent created inventory pocket"
+        assert entry.context["query"] == "inventory levels Q1"
+        assert entry.ai_recommendation == "Create pocket with 3 widgets"
+        assert entry.outcome == "Pocket created successfully"
+        assert entry.status == "completed"
+        assert entry.metadata["tool"] == "create_pocket"
+
+    @pytest.mark.asyncio
+    async def test_log_entry_without_optional_fields(self, audit_db):
+        entry_id = await audit_db.log_entry(
+            actor="system",
+            action="connector_sync",
+            category="data",
+            description="Synced connector",
+        )
+        entries = await audit_db.query_entries()
+        entry = next(e for e in entries if e.id == entry_id)
+        assert entry.pocket_id is None
+        assert entry.ai_recommendation is None
+        assert entry.outcome is None
+
+
+class TestAuditStoreQueryEntries:
+    @pytest.mark.asyncio
+    async def test_query_all_entries(self, populated_store):
+        entries = await populated_store.query_entries()
+        assert len(entries) == 5
+
+    @pytest.mark.asyncio
+    async def test_filter_by_pocket_id(self, populated_store):
+        entries = await populated_store.query_entries(pocket_id="pocket-1")
+        assert len(entries) == 3
+        assert all(e.pocket_id == "pocket-1" for e in entries)
+
+    @pytest.mark.asyncio
+    async def test_filter_by_category(self, populated_store):
+        entries = await populated_store.query_entries(category="decision")
+        assert len(entries) == 2
+        assert all(e.category == "decision" for e in entries)
+
+    @pytest.mark.asyncio
+    async def test_filter_by_actor(self, populated_store):
+        entries = await populated_store.query_entries(actor="user:prakash")
+        assert len(entries) == 2
+        assert all(e.actor == "user:prakash" for e in entries)
+
+    @pytest.mark.asyncio
+    async def test_filter_by_date_range(self, audit_db):
+        from pocketpaw.audit.models import AuditEntry
+
+        past = datetime.now(UTC) - timedelta(hours=2)
+        future = datetime.now(UTC) + timedelta(hours=2)
+
+        await audit_db.log_entry(
+            actor="agent",
+            action="x",
+            category="decision",
+            description="entry 1",
+        )
+
+        entries = await audit_db.query_entries(date_from=past, date_to=future)
+        assert len(entries) == 1
+
+    @pytest.mark.asyncio
+    async def test_filter_excludes_outside_date_range(self, audit_db):
+        await audit_db.log_entry(
+            actor="agent",
+            action="x",
+            category="decision",
+            description="entry 1",
+        )
+
+        # Query for a range entirely in the past
+        past_start = datetime.now(UTC) - timedelta(hours=10)
+        past_end = datetime.now(UTC) - timedelta(hours=5)
+        entries = await audit_db.query_entries(date_from=past_start, date_to=past_end)
+        assert len(entries) == 0
+
+    @pytest.mark.asyncio
+    async def test_query_returns_entries_newest_first(self, populated_store):
+        entries = await populated_store.query_entries()
+        timestamps = [e.timestamp for e in entries]
+        # Should be sorted descending
+        assert timestamps == sorted(timestamps, reverse=True)
+
+    @pytest.mark.asyncio
+    async def test_query_limit(self, populated_store):
+        entries = await populated_store.query_entries(limit=2)
+        assert len(entries) == 2
+
+    @pytest.mark.asyncio
+    async def test_query_combined_filters(self, populated_store):
+        entries = await populated_store.query_entries(pocket_id="pocket-1", category="decision")
+        assert len(entries) == 1
+        assert entries[0].pocket_id == "pocket-1"
+        assert entries[0].category == "decision"
+
+
+class TestAuditStoreExport:
+    @pytest.mark.asyncio
+    async def test_export_csv_returns_bytes(self, populated_store):
+        data = await populated_store.export_csv()
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+
+    @pytest.mark.asyncio
+    async def test_export_csv_has_header_row(self, populated_store):
+        data = await populated_store.export_csv()
+        reader = csv.DictReader(io.StringIO(data.decode("utf-8")))
+        headers = reader.fieldnames
+        assert "id" in headers
+        assert "timestamp" in headers
+        assert "actor" in headers
+        assert "action" in headers
+        assert "category" in headers
+        assert "description" in headers
+        assert "status" in headers
+
+    @pytest.mark.asyncio
+    async def test_export_csv_row_count_matches_entries(self, populated_store):
+        data = await populated_store.export_csv()
+        reader = csv.DictReader(io.StringIO(data.decode("utf-8")))
+        rows = list(reader)
+        assert len(rows) == 5
+
+    @pytest.mark.asyncio
+    async def test_export_csv_respects_pocket_id_filter(self, populated_store):
+        data = await populated_store.export_csv(pocket_id="pocket-1")
+        reader = csv.DictReader(io.StringIO(data.decode("utf-8")))
+        rows = list(reader)
+        assert len(rows) == 3
+
+    @pytest.mark.asyncio
+    async def test_export_json_returns_list(self, populated_store):
+        data = await populated_store.export_json()
+        parsed = json.loads(data)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 5
+
+    @pytest.mark.asyncio
+    async def test_export_json_respects_pocket_id_filter(self, populated_store):
+        data = await populated_store.export_json(pocket_id="pocket-1")
+        parsed = json.loads(data)
+        assert len(parsed) == 3
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def api_client(tmp_path):
+    """FastAPI test client with the audit router mounted."""
+    from pocketpaw.audit.router import router as audit_router
+    from pocketpaw.audit.store import AuditStore, get_audit_store
+
+    # Override the store dependency to use a temp DB
+    store = AuditStore(db_path=tmp_path / "api_audit.db")
+
+    app = FastAPI()
+    app.include_router(audit_router, prefix="/api/v1")
+
+    # Override the store dependency
+    app.dependency_overrides[get_audit_store] = lambda: store
+
+    return TestClient(app), store
+
+
+class TestAuditAPIQuery:
+    @pytest.mark.asyncio
+    async def test_get_audit_empty(self, api_client):
+        client, _ = api_client
+        resp = client.get("/api/v1/audit")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["entries"] == []
+        assert data["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_audit_returns_entries(self, api_client):
+        client, store = api_client
+        await store.log_entry(
+            actor="agent",
+            action="create_pocket",
+            category="decision",
+            description="Agent created a pocket",
+        )
+        resp = client.get("/api/v1/audit")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["entries"]) == 1
+        assert data["total"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_audit_filter_by_pocket_id(self, api_client):
+        client, store = api_client
+        await store.log_entry(
+            actor="agent", action="x", category="decision",
+            description="d", pocket_id="pocket-1",
+        )
+        await store.log_entry(
+            actor="agent", action="x", category="decision",
+            description="d", pocket_id="pocket-2",
+        )
+        resp = client.get("/api/v1/audit?pocket_id=pocket-1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["entries"]) == 1
+        assert data["entries"][0]["pocket_id"] == "pocket-1"
+
+    @pytest.mark.asyncio
+    async def test_get_audit_filter_by_category(self, api_client):
+        client, store = api_client
+        await store.log_entry(actor="agent", action="x", category="decision", description="d")
+        await store.log_entry(actor="agent", action="x", category="security", description="d")
+        resp = client.get("/api/v1/audit?category=security")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["entries"]) == 1
+        assert data["entries"][0]["category"] == "security"
+
+    @pytest.mark.asyncio
+    async def test_get_audit_entry_shape(self, api_client):
+        client, store = api_client
+        await store.log_entry(
+            actor="agent",
+            action="create_pocket",
+            category="decision",
+            description="Created pocket",
+            ai_recommendation="Use 3 widgets",
+            outcome="Done",
+            status="completed",
+        )
+        resp = client.get("/api/v1/audit")
+        entry = resp.json()["entries"][0]
+        assert "id" in entry
+        assert "timestamp" in entry
+        assert "actor" in entry
+        assert "action" in entry
+        assert "category" in entry
+        assert "description" in entry
+        assert "status" in entry
+        assert "ai_recommendation" in entry
+        assert "outcome" in entry
+
+
+class TestAuditAPIExport:
+    @pytest.mark.asyncio
+    async def test_export_csv_returns_csv_content_type(self, api_client):
+        client, store = api_client
+        await store.log_entry(
+            actor="agent", action="x", category="decision", description="d"
+        )
+        resp = client.get("/api/v1/audit/export?format=csv")
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers["content-type"]
+
+    @pytest.mark.asyncio
+    async def test_export_json_returns_json(self, api_client):
+        client, store = api_client
+        await store.log_entry(
+            actor="agent", action="x", category="decision", description="d"
+        )
+        resp = client.get("/api/v1/audit/export?format=json")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+        data = resp.json()
+        assert isinstance(data, list)
+
+    @pytest.mark.asyncio
+    async def test_export_csv_respects_pocket_id(self, api_client):
+        client, store = api_client
+        await store.log_entry(
+            actor="agent", action="x", category="decision",
+            description="d", pocket_id="p1",
+        )
+        await store.log_entry(
+            actor="agent", action="x", category="decision",
+            description="d", pocket_id="p2",
+        )
+        resp = client.get("/api/v1/audit/export?format=csv&pocket_id=p1")
+        assert resp.status_code == 200
+        reader = csv.DictReader(io.StringIO(resp.text))
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["pocket_id"] == "p1"
+
+    @pytest.mark.asyncio
+    async def test_export_invalid_format_returns_400(self, api_client):
+        client, _ = api_client
+        resp = client.get("/api/v1/audit/export?format=xml")
+        assert resp.status_code == 422  # FastAPI validation error
+
+
+# ---------------------------------------------------------------------------
+# Integration: tool execution auto-logging
+# ---------------------------------------------------------------------------
+
+
+class TestAuditIntegration:
+    @pytest.mark.asyncio
+    async def test_log_tool_execution(self, audit_db):
+        """log_tool_execution helper logs a tool action."""
+        from pocketpaw.audit.store import AuditStore
+
+        entry_id = await audit_db.log_tool_execution(
+            tool_name="web_search",
+            actor="agent",
+            description="Searched for inventory data",
+            context={"query": "inventory Q1 2026"},
+            pocket_id="pocket-123",
+        )
+        entries = await audit_db.query_entries()
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.id == entry_id
+        assert entry.action == "tool_execution"
+        assert entry.category == "decision"
+        assert entry.actor == "agent"
+        assert entry.metadata["tool"] == "web_search"
+
+    @pytest.mark.asyncio
+    async def test_log_connector_sync(self, audit_db):
+        """log_connector_sync helper logs a data sync event."""
+        entry_id = await audit_db.log_connector_sync(
+            connector_name="stripe",
+            actor="system",
+            description="Synced Stripe invoices",
+            record_count=42,
+        )
+        entries = await audit_db.query_entries()
+        entry = entries[0]
+        assert entry.id == entry_id
+        assert entry.action == "connector_sync"
+        assert entry.category == "data"
+        assert entry.metadata["connector"] == "stripe"
+        assert entry.metadata["record_count"] == 42

--- a/tests/test_ee_api.py
+++ b/tests/test_ee_api.py
@@ -1,0 +1,168 @@
+# Tests for ee/ API endpoints — Fabric + Instinct REST.
+# Created: 2026-03-28
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ee.fabric.router import router as fabric_router
+from ee.instinct.router import router as instinct_router
+from ee.fabric.store import FabricStore
+from ee.instinct.store import InstinctStore
+
+
+@pytest.fixture
+def app(tmp_path: Path):
+    db_path = tmp_path / "test_ee.db"
+    fabric = FabricStore(db_path)
+    instinct = InstinctStore(db_path)
+
+    app = FastAPI()
+    app.include_router(fabric_router)
+    app.include_router(instinct_router)
+
+    # Override deps
+    app.dependency_overrides = {
+        __import__("ee.api", fromlist=["get_fabric_store"]).get_fabric_store: lambda: fabric,
+        __import__("ee.api", fromlist=["get_instinct_store"]).get_instinct_store: lambda: instinct,
+    }
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+class TestFabricAPI:
+    def test_create_and_list_types(self, client):
+        resp = client.post("/api/v1/fabric/types", json={
+            "name": "Customer",
+            "properties": [{"name": "email", "type": "string"}],
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "Customer"
+
+        resp = client.get("/api/v1/fabric/types")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+    def test_create_and_query_objects(self, client):
+        # Create type
+        type_resp = client.post("/api/v1/fabric/types", json={"name": "Order", "properties": []})
+        type_id = type_resp.json()["id"]
+
+        # Create objects
+        client.post("/api/v1/fabric/objects", json={"type_id": type_id, "properties": {"amount": 100}})
+        client.post("/api/v1/fabric/objects", json={"type_id": type_id, "properties": {"amount": 200}})
+
+        # Query
+        resp = client.get("/api/v1/fabric/objects", params={"type_name": "Order"})
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 2
+
+    def test_link_and_traverse(self, client):
+        t1 = client.post("/api/v1/fabric/types", json={"name": "Customer", "properties": []}).json()
+        t2 = client.post("/api/v1/fabric/types", json={"name": "Order", "properties": []}).json()
+
+        c = client.post("/api/v1/fabric/objects", json={"type_id": t1["id"], "properties": {"name": "Acme"}}).json()
+        o = client.post("/api/v1/fabric/objects", json={"type_id": t2["id"], "properties": {"amount": 100}}).json()
+
+        # Link
+        client.post("/api/v1/fabric/links", json={
+            "from_object_id": c["id"], "to_object_id": o["id"], "link_type": "has_order",
+        })
+
+        # Traverse
+        resp = client.get(f"/api/v1/fabric/objects/{c['id']}/linked", params={"link_type": "has_order"})
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+    def test_stats(self, client):
+        resp = client.get("/api/v1/fabric/stats")
+        assert resp.status_code == 200
+        assert "types" in resp.json()
+
+    def test_delete_type_cascades(self, client):
+        t = client.post("/api/v1/fabric/types", json={"name": "Temp", "properties": []}).json()
+        client.post("/api/v1/fabric/objects", json={"type_id": t["id"], "properties": {}})
+
+        resp = client.delete(f"/api/v1/fabric/types/{t['id']}")
+        assert resp.status_code == 200
+
+        resp = client.get("/api/v1/fabric/objects", params={"type_id": t["id"]})
+        assert resp.json()["total"] == 0
+
+
+class TestInstinctAPI:
+    def test_propose_and_list(self, client):
+        resp = client.post("/api/v1/instinct/actions", json={
+            "pocket_id": "p1",
+            "title": "Reorder inventory",
+            "description": "Stock low",
+            "recommendation": "Order 20 units",
+            "trigger": {"type": "agent", "source": "claude", "reason": "threshold"},
+        })
+        assert resp.status_code == 201
+        action = resp.json()
+        assert action["status"] == "pending"
+
+        resp = client.get("/api/v1/instinct/actions", params={"pocket_id": "p1"})
+        assert len(resp.json()) == 1
+
+    def test_approve_and_execute(self, client):
+        action = client.post("/api/v1/instinct/actions", json={
+            "pocket_id": "p1", "title": "Test", "recommendation": "Do it",
+            "trigger": {"type": "agent", "source": "claude", "reason": "test"},
+        }).json()
+
+        resp = client.post(f"/api/v1/instinct/actions/{action['id']}/approve", json={"approver": "prakash"})
+        assert resp.json()["status"] == "approved"
+
+        resp = client.post(f"/api/v1/instinct/actions/{action['id']}/execute", json={"outcome": "Done"})
+        assert resp.json()["status"] == "executed"
+
+    def test_reject(self, client):
+        action = client.post("/api/v1/instinct/actions", json={
+            "pocket_id": "p1", "title": "Test", "recommendation": "Do it",
+            "trigger": {"type": "agent", "source": "claude", "reason": "test"},
+        }).json()
+
+        resp = client.post(f"/api/v1/instinct/actions/{action['id']}/reject", json={"reason": "Not needed"})
+        assert resp.json()["status"] == "rejected"
+
+    def test_pending_count(self, client):
+        client.post("/api/v1/instinct/actions", json={
+            "pocket_id": "p1", "title": "A", "recommendation": "",
+            "trigger": {"type": "agent", "source": "claude", "reason": "test"},
+        })
+        client.post("/api/v1/instinct/actions", json={
+            "pocket_id": "p1", "title": "B", "recommendation": "",
+            "trigger": {"type": "agent", "source": "claude", "reason": "test"},
+        })
+
+        resp = client.get("/api/v1/instinct/pending/count")
+        assert resp.json()["count"] == 2
+
+    def test_audit_log(self, client):
+        client.post("/api/v1/instinct/actions", json={
+            "pocket_id": "p1", "title": "Audited", "recommendation": "Yes",
+            "trigger": {"type": "agent", "source": "claude", "reason": "test"},
+        })
+
+        resp = client.get("/api/v1/instinct/audit", params={"pocket_id": "p1"})
+        assert resp.status_code == 200
+        entries = resp.json()
+        assert any(e["event"] == "action_proposed" for e in entries)
+
+    def test_audit_export(self, client):
+        resp = client.get("/api/v1/instinct/audit/export")
+        assert resp.status_code == 200
+        assert "entries" in resp.json()

--- a/tests/test_ee_fabric.py
+++ b/tests/test_ee_fabric.py
@@ -1,0 +1,172 @@
+# Tests for ee/fabric — ontology store (SQLite).
+# Created: 2026-03-28
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ee.fabric.models import PropertyDef, FabricQuery
+from ee.fabric.store import FabricStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> FabricStore:
+    return FabricStore(tmp_path / "test.db")
+
+
+class TestObjectTypes:
+    @pytest.mark.asyncio
+    async def test_define_and_get(self, store: FabricStore) -> None:
+        t = await store.define_type(
+            name="Customer",
+            properties=[
+                PropertyDef(name="name", type="string", required=True),
+                PropertyDef(name="email", type="string"),
+                PropertyDef(name="revenue", type="number"),
+            ],
+            icon="user", color="#FF6B35",
+        )
+        assert t.id.startswith("ot-")
+        assert t.name == "Customer"
+
+        fetched = await store.get_type(t.id)
+        assert fetched is not None
+        assert fetched.name == "Customer"
+        assert len(fetched.properties) == 3
+
+    @pytest.mark.asyncio
+    async def test_get_by_name(self, store: FabricStore) -> None:
+        await store.define_type(name="Order", properties=[])
+        found = await store.get_type_by_name("order")
+        assert found is not None
+        assert found.name == "Order"
+
+    @pytest.mark.asyncio
+    async def test_list_types(self, store: FabricStore) -> None:
+        await store.define_type(name="A", properties=[])
+        await store.define_type(name="B", properties=[])
+        types = await store.list_types()
+        assert len(types) == 2
+
+    @pytest.mark.asyncio
+    async def test_remove_cascades(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Product", properties=[])
+        o1 = await store.create_object(t.id, {"name": "Widget"})
+        o2 = await store.create_object(t.id, {"name": "Gadget"})
+        await store.link(o1.id, o2.id, "related")
+
+        await store.remove_type(t.id)
+        types = await store.list_types()
+        assert len(types) == 0
+        result = await store.query(FabricQuery())
+        assert result.total == 0
+
+
+class TestObjects:
+    @pytest.mark.asyncio
+    async def test_create_and_get(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Customer", properties=[])
+        obj = await store.create_object(t.id, {"name": "Acme", "email": "hi@acme.com"})
+        assert obj.id.startswith("obj-")
+        assert obj.type_name == "Customer"
+
+        fetched = await store.get_object(obj.id)
+        assert fetched is not None
+        assert fetched.properties["name"] == "Acme"
+
+    @pytest.mark.asyncio
+    async def test_update(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Customer", properties=[])
+        obj = await store.create_object(t.id, {"name": "Acme", "revenue": 50000})
+        updated = await store.update_object(obj.id, {"revenue": 75000})
+        assert updated is not None
+        assert updated.properties["revenue"] == 75000
+        assert updated.properties["name"] == "Acme"
+
+    @pytest.mark.asyncio
+    async def test_source_tracking(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Invoice", properties=[])
+        obj = await store.create_object(t.id, {"amount": 100}, source_connector="stripe", source_id="inv_123")
+        assert obj.source_connector == "stripe"
+        assert obj.source_id == "inv_123"
+
+    @pytest.mark.asyncio
+    async def test_remove(self, store: FabricStore) -> None:
+        t = await store.define_type(name="X", properties=[])
+        obj = await store.create_object(t.id, {})
+        await store.remove_object(obj.id)
+        assert await store.get_object(obj.id) is None
+
+
+class TestLinks:
+    @pytest.mark.asyncio
+    async def test_link_and_traverse(self, store: FabricStore) -> None:
+        ct = await store.define_type(name="Customer", properties=[])
+        ot = await store.define_type(name="Order", properties=[])
+
+        cust = await store.create_object(ct.id, {"name": "Acme"})
+        o1 = await store.create_object(ot.id, {"amount": 100})
+        o2 = await store.create_object(ot.id, {"amount": 200})
+
+        await store.link(cust.id, o1.id, "has_order")
+        await store.link(cust.id, o2.id, "has_order")
+
+        linked = await store.get_linked_objects(cust.id, "has_order")
+        assert len(linked) == 2
+
+    @pytest.mark.asyncio
+    async def test_unlink(self, store: FabricStore) -> None:
+        t = await store.define_type(name="X", properties=[])
+        a = await store.create_object(t.id, {})
+        b = await store.create_object(t.id, {})
+        lnk = await store.link(a.id, b.id, "r")
+        await store.unlink(lnk.id)
+        linked = await store.get_linked_objects(a.id)
+        assert len(linked) == 0
+
+
+class TestQuery:
+    @pytest.mark.asyncio
+    async def test_by_type_name(self, store: FabricStore) -> None:
+        ct = await store.define_type(name="Customer", properties=[])
+        ot = await store.define_type(name="Order", properties=[])
+        await store.create_object(ct.id, {"name": "A"})
+        await store.create_object(ct.id, {"name": "B"})
+        await store.create_object(ot.id, {"amount": 100})
+
+        result = await store.query(FabricQuery(type_name="Customer"))
+        assert result.total == 2
+
+    @pytest.mark.asyncio
+    async def test_by_linked(self, store: FabricStore) -> None:
+        ct = await store.define_type(name="Customer", properties=[])
+        ot = await store.define_type(name="Order", properties=[])
+        cust = await store.create_object(ct.id, {"name": "Acme"})
+        o1 = await store.create_object(ot.id, {"amount": 100})
+        await store.create_object(ot.id, {"amount": 200})  # not linked
+        await store.link(cust.id, o1.id, "has_order")
+
+        result = await store.query(FabricQuery(linked_to=cust.id, link_type="has_order"))
+        assert result.total == 1
+
+    @pytest.mark.asyncio
+    async def test_pagination(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Item", properties=[])
+        for i in range(10):
+            await store.create_object(t.id, {"idx": i})
+
+        r1 = await store.query(FabricQuery(type_name="Item", limit=3, offset=0))
+        assert len(r1.objects) == 3
+        assert r1.total == 10
+
+    @pytest.mark.asyncio
+    async def test_stats(self, store: FabricStore) -> None:
+        t = await store.define_type(name="X", properties=[])
+        a = await store.create_object(t.id, {})
+        b = await store.create_object(t.id, {})
+        await store.link(a.id, b.id, "r")
+        s = await store.stats()
+        assert s == {"types": 1, "objects": 2, "links": 1}

--- a/tests/test_ee_instinct.py
+++ b/tests/test_ee_instinct.py
@@ -1,0 +1,134 @@
+# Tests for ee/instinct — decision pipeline store (SQLite).
+# Created: 2026-03-28
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ee.instinct.models import ActionTrigger, ActionContext
+from ee.instinct.store import InstinctStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "test.db")
+
+
+def trigger(source: str = "claude") -> ActionTrigger:
+    return ActionTrigger(type="agent", source=source, reason="test")
+
+
+class TestActionLifecycle:
+    @pytest.mark.asyncio
+    async def test_propose(self, store: InstinctStore) -> None:
+        action = await store.propose(
+            pocket_id="p1", title="Reorder inventory",
+            description="Stock at 4 units", recommendation="Order 20 units",
+            trigger=trigger(),
+        )
+        assert action.id.startswith("act-")
+        assert action.status.value == "pending"
+
+    @pytest.mark.asyncio
+    async def test_approve(self, store: InstinctStore) -> None:
+        action = await store.propose(
+            pocket_id="p1", title="Test", description="",
+            recommendation="Do it", trigger=trigger(),
+        )
+        approved = await store.approve(action.id, "user:prakash")
+        assert approved is not None
+        assert approved.status.value == "approved"
+        assert approved.approved_by == "user:prakash"
+
+    @pytest.mark.asyncio
+    async def test_reject(self, store: InstinctStore) -> None:
+        action = await store.propose(
+            pocket_id="p1", title="Test", description="",
+            recommendation="Do it", trigger=trigger(),
+        )
+        rejected = await store.reject(action.id, "Not needed")
+        assert rejected is not None
+        assert rejected.status.value == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_execute(self, store: InstinctStore) -> None:
+        action = await store.propose(
+            pocket_id="p1", title="Test", description="",
+            recommendation="Do it", trigger=trigger(),
+        )
+        await store.approve(action.id)
+        executed = await store.mark_executed(action.id, "Done successfully")
+        assert executed is not None
+        assert executed.status.value == "executed"
+        assert executed.outcome == "Done successfully"
+
+    @pytest.mark.asyncio
+    async def test_fail(self, store: InstinctStore) -> None:
+        action = await store.propose(
+            pocket_id="p1", title="Test", description="",
+            recommendation="Do it", trigger=trigger(),
+        )
+        failed = await store.mark_failed(action.id, "API error")
+        assert failed is not None
+        assert failed.status.value == "failed"
+        assert failed.error == "API error"
+
+
+class TestQueries:
+    @pytest.mark.asyncio
+    async def test_pending(self, store: InstinctStore) -> None:
+        await store.propose(pocket_id="p1", title="A", description="", recommendation="", trigger=trigger())
+        await store.propose(pocket_id="p1", title="B", description="", recommendation="", trigger=trigger())
+        pending = await store.pending()
+        assert len(pending) == 2
+
+    @pytest.mark.asyncio
+    async def test_pending_count(self, store: InstinctStore) -> None:
+        a = await store.propose(pocket_id="p1", title="A", description="", recommendation="", trigger=trigger())
+        await store.propose(pocket_id="p1", title="B", description="", recommendation="", trigger=trigger())
+        await store.approve(a.id)
+        count = await store.pending_count()
+        assert count == 1
+
+    @pytest.mark.asyncio
+    async def test_for_pocket(self, store: InstinctStore) -> None:
+        await store.propose(pocket_id="p1", title="A", description="", recommendation="", trigger=trigger())
+        await store.propose(pocket_id="p2", title="B", description="", recommendation="", trigger=trigger())
+        p1_actions = await store.for_pocket("p1")
+        assert len(p1_actions) == 1
+
+
+class TestAuditLog:
+    @pytest.mark.asyncio
+    async def test_auto_logs_lifecycle(self, store: InstinctStore) -> None:
+        action = await store.propose(
+            pocket_id="p1", title="Test action", description="",
+            recommendation="Do it", trigger=trigger(),
+        )
+        await store.approve(action.id)
+        await store.mark_executed(action.id, "Done")
+
+        entries = await store.query_audit(pocket_id="p1")
+        events = [e.event for e in entries]
+        assert "action_proposed" in events
+        assert "action_approved" in events
+        assert "action_executed" in events
+
+    @pytest.mark.asyncio
+    async def test_manual_log(self, store: InstinctStore) -> None:
+        await store.log(
+            actor="system", event="connector_synced",
+            description="Stripe synced 42 records", pocket_id="p1",
+        )
+        entries = await store.query_audit(event="connector_synced")
+        assert len(entries) == 1
+
+    @pytest.mark.asyncio
+    async def test_export(self, store: InstinctStore) -> None:
+        await store.log(actor="system", event="test", description="Test", pocket_id="p1")
+        exported = await store.export_audit("p1")
+        import json
+        parsed = json.loads(exported)
+        assert len(parsed) == 1


### PR DESCRIPTION
## Summary

REST API endpoints for the enterprise `ee/` features, enabling the paw-enterprise-client to call Fabric (ontology) and Instinct (decision pipeline) via HTTP.

## Endpoints

### Fabric (`/api/v1/fabric/`)
- `GET/POST/DELETE /types` — object type CRUD
- `GET/POST/PATCH/DELETE /objects` — object CRUD with query filters
- `POST/DELETE /links` — relationship management
- `GET /objects/{id}/linked` — traverse relationships
- `GET /stats` — type/object/link counts

### Instinct (`/api/v1/instinct/`)
- `GET/POST /actions` — action lifecycle
- `POST /actions/{id}/approve|reject|execute` — approval workflow
- `GET /pending` + `/pending/count` — approval queue
- `GET /audit` + `/audit/export` — decision audit log

## Also includes

This PR bundles the ee/ layer + audit module + connector docs (consolidated from branches feat/ee-enterprise-layer and feat/connector-protocol):

- `ee/fabric/` — Ontology store (async SQLite)
- `ee/instinct/` — Decision pipeline store
- `ee/api.py` — Dependency injection for FastAPI
- `src/pocketpaw/audit/` — Base audit logging with API + CSV export
- `docs/CONNECTORS.md` — Connector usage guide

## Tests

72 tests: 11 API + 14 Fabric + 11 Instinct + 36 audit

## Test plan

- [x] All 72 tests passing
- [ ] Wire routers into main app (future PR)
- [ ] paw-enterprise-client calls these endpoints (future PR)