### PR TITLE
Add automations engine — rules, store, trigger evaluator

### DIFF
--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,0 +1,146 @@
+# Connectors — Data Source Integration
+
+Connectors bring external data into PocketPaw Pockets. Each service is defined in a YAML file — the engine reads the definition and handles auth, execution, and sync.
+
+## Quick Start
+
+```bash
+# List available connectors
+paw connectors list
+
+# Connect Stripe to a pocket
+paw connect stripe --pocket "My Business"
+
+# Check connection status
+paw connectors status
+```
+
+## How It Works
+
+```
+Your Service (Stripe, Shopify, CSV, etc.)
+    ↓
+Connector YAML (defines endpoints, auth, sync)
+    ↓
+DirectREST Engine (reads YAML, makes API calls)
+    ↓
+pocket.db (data lands in SQLite tables)
+    ↓
+Pocket widgets auto-update with fresh data
+```
+
+## Writing a Connector YAML
+
+Each connector is a YAML file in `connectors/`. Here's the structure:
+
+```yaml
+# connectors/my_service.yaml
+name: my_service
+display_name: My Service
+type: payment                     # category for grouping
+icon: credit-card                 # lucide icon name
+
+auth:
+  method: api_key                 # api_key | oauth | basic | bearer | none
+  credentials:
+    - name: MY_API_KEY
+      description: API key from My Service dashboard
+      required: true
+
+actions:
+  - name: list_items
+    description: Get all items
+    method: GET
+    url: https://api.myservice.com/v1/items
+    params:
+      limit: { type: integer, default: 10 }
+      status: { type: string, enum: [active, archived] }
+    trust_level: auto             # auto | confirm | restricted
+
+  - name: create_item
+    description: Create a new item
+    method: POST
+    url: https://api.myservice.com/v1/items
+    body:
+      name: { type: string, required: true }
+      price: { type: number }
+    trust_level: confirm          # requires user approval
+
+sync:
+  table: my_service_items         # target table in pocket.db
+  schedule: every_15m             # polling interval
+  mapping:                        # field mapping
+    id: id
+    name: name
+    price: price
+    created: created_at
+```
+
+## Auth Methods
+
+| Method | When to Use | Example |
+|--------|-------------|---------|
+| `api_key` | Service provides a static API key | Stripe, Tavily |
+| `oauth` | Service uses OAuth 2.0 flow | Google, Spotify |
+| `bearer` | Token-based auth (API key in Authorization header) | Generic REST APIs |
+| `basic` | Username + password auth | Legacy APIs |
+| `none` | Public API, no auth needed | Reddit (read-only) |
+
+## Trust Levels
+
+Each action has a trust level that controls how much human oversight the agent needs:
+
+| Level | Behavior | Use For |
+|-------|----------|---------|
+| `auto` | Agent executes without asking | Read-only operations (list, search) |
+| `confirm` | Agent asks user before executing | Write operations (create, update, delete) |
+| `restricted` | Requires admin approval | Destructive or financial operations |
+
+## Using with Existing Integrations
+
+PocketPaw already has built-in integrations for Google Workspace, Spotify, and Reddit. These work as **agent tools** (one-off actions via chat). Connectors add **continuous data sync** on top:
+
+| Integration | As Tool (built-in) | As Connector (YAML) |
+|-------------|-------------------|---------------------|
+| Gmail | "Search my emails for invoices" → one-off result | Sync inbox every 15m → `gmail_messages` table → Pocket widget |
+| Google Calendar | "Create a meeting tomorrow" → done | Sync events daily → `calendar_events` table → schedule widget |
+| Stripe | (not built-in yet) | Sync invoices → `stripe_invoices` table → revenue dashboard |
+| CSV | (not built-in yet) | Import file → custom table → data visualization |
+
+Tools and connectors complement each other. Tools are for actions. Connectors are for data.
+
+## Built-in Connectors
+
+| Connector | File | Auth | Syncs |
+|-----------|------|------|-------|
+| **Stripe** | `connectors/stripe.yaml` | API key | Invoices, customers |
+| **CSV Import** | `connectors/csv.yaml` | None | Any CSV/Excel file |
+| **REST API** | `connectors/rest_generic.yaml` | Bearer token | Any REST endpoint |
+
+## Architecture
+
+```
+ConnectorProtocol (Python async interface)
+│
+├── DirectRESTAdapter     ← YAML-defined REST APIs (primary)
+├── ComposioAdapter       ← 250+ apps with managed OAuth (planned)
+└── CuratedMCPAdapter     ← Whitelisted MCP servers (planned)
+```
+
+The `ConnectorRegistry` auto-discovers YAML files from the `connectors/` directory and manages adapter instances per pocket.
+
+## Adding a New Connector
+
+1. Create `connectors/your_service.yaml` following the schema above
+2. Test it: `paw connect your_service --pocket "Test"`
+3. The agent can now use it: "Connect my Shopify to this pocket"
+
+That's it. No Python code needed — just YAML.
+
+## Security
+
+- Credentials are never stored in YAML files or pocket.db
+- Auth tokens flow through the credential store (Infisical planned)
+- Each pocket has isolated connector access
+- Trust levels enforce human oversight for write operations
+- All connector actions are logged to the audit trail

--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,0 +1,27 @@
+Functional Source License, Version 1.1, Apache 2.0 Future License
+
+Licensor:  Qbtrix Inc.
+Software:  PocketPaw Enterprise Extensions
+
+Use Limitation:
+You may use this software for any purpose except competing with
+PocketPaw or offering it as a managed service.
+
+Change Date: Four years from the date the software is released.
+Change License: Apache License, Version 2.0
+
+For full FSL terms, see: https://fsl.software/
+
+---
+
+The code in this directory (ee/) is licensed separately from the
+rest of the PocketPaw repository, which is under the Apache 2.0 license.
+
+Enterprise features include:
+- Fabric (ontology layer)
+- Instinct (decision pipeline)
+- Automations (triggers and schedules)
+- Audit (enhanced compliance logging)
+
+These features require a PocketPaw Enterprise license for production use.
+After the Change Date, this code converts to Apache 2.0.

--- a/ee/__init__.py
+++ b/ee/__init__.py
@@ -1,0 +1,9 @@
+# PocketPaw Enterprise Extensions (ee/)
+# Licensed under FSL 1.1 — see ee/LICENSE
+# These features require a PocketPaw Enterprise license for production use.
+#
+# Modules:
+#   fabric/    — Ontology layer (objects, links, properties)
+#   instinct/  — Decision pipeline (actions, approvals, audit)
+#   automations/ — Time/data triggers
+#   audit/     — Enhanced compliance logging

--- a/ee/audit/__init__.py
+++ b/ee/audit/__init__.py
@@ -1,0 +1,4 @@
+# Audit — enhanced compliance logging for Paw OS.
+# Created: 2026-03-28 — Placeholder for future implementation.
+# Extends instinct's audit log with export formats, retention policies,
+# and compliance reporting (SOC2, GDPR).

--- a/ee/automations/__init__.py
+++ b/ee/automations/__init__.py
@@ -1,0 +1,12 @@
+# Automations — time/data triggers for Paw OS.
+# Created: 2026-03-28
+
+from ee.automations.models import AutomationRule, TriggerType
+from ee.automations.store import AutomationsStore
+from ee.automations.evaluator import check_all_rules, evaluate_threshold, evaluate_schedule, evaluate_data_change, evaluate_event
+
+__all__ = [
+    "AutomationRule", "TriggerType", "AutomationsStore",
+    "check_all_rules", "evaluate_threshold", "evaluate_schedule",
+    "evaluate_data_change", "evaluate_event",
+]

--- a/ee/automations/evaluator.py
+++ b/ee/automations/evaluator.py
@@ -1,0 +1,130 @@
+# automations/evaluator.py — Trigger evaluation logic.
+# Created: 2026-03-28 — Checks if rules should fire based on conditions.
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from ee.automations.models import AutomationRule, TriggerType
+
+if TYPE_CHECKING:
+    from ee.fabric.store import FabricStore
+
+
+_OPERATORS = {
+    "lt": lambda a, b: a < b,
+    "gt": lambda a, b: a > b,
+    "eq": lambda a, b: a == b,
+    "gte": lambda a, b: a >= b,
+    "lte": lambda a, b: a <= b,
+    "ne": lambda a, b: a != b,
+}
+
+
+async def evaluate_threshold(rule: AutomationRule, fabric_store: "FabricStore") -> bool:
+    """Check if any Fabric object of the configured type has a property crossing the threshold."""
+    cfg = rule.trigger_config
+    object_type = cfg.get("object_type")
+    prop_name = cfg.get("property")
+    operator = cfg.get("operator", "lt")
+    threshold_value = cfg.get("value")
+
+    if not object_type or not prop_name or threshold_value is None:
+        return False
+
+    op_fn = _OPERATORS.get(operator)
+    if op_fn is None:
+        return False
+
+    from ee.fabric.models import FabricQuery
+    result = await fabric_store.query(FabricQuery(type_name=object_type, limit=1000))
+
+    for obj in result.objects:
+        raw = obj.properties.get(prop_name)
+        if raw is None:
+            continue
+        try:
+            if op_fn(float(raw), float(threshold_value)):
+                return True
+        except (TypeError, ValueError):
+            if operator == "eq" and str(raw) == str(threshold_value):
+                return True
+    return False
+
+
+def evaluate_schedule(rule: AutomationRule, now: datetime | None = None) -> bool:
+    """Check if cron expression matches current time. Requires croniter."""
+    cron_expr = rule.trigger_config.get("cron")
+    if not cron_expr:
+        return False
+    if now is None:
+        now = datetime.now()
+    now_minute = now.replace(second=0, microsecond=0)
+    try:
+        from croniter import croniter
+        return bool(croniter.match(cron_expr, now_minute))
+    except (ImportError, Exception):
+        return False
+
+
+def evaluate_data_change(rule: AutomationRule, event: dict[str, Any]) -> bool:
+    """Check if an incoming data event matches the rule."""
+    cfg = rule.trigger_config
+    expected_type = cfg.get("object_type")
+    expected_op = cfg.get("on")
+    if not expected_type:
+        return False
+
+    actual_type = event.get("object_type") or event.get("type")
+    actual_op = event.get("on") or event.get("operation") or event.get("event")
+
+    if not actual_type or expected_type.lower() != actual_type.lower():
+        return False
+    if expected_op and actual_op and expected_op.lower() != actual_op.lower():
+        return False
+    return True
+
+
+def evaluate_event(rule: AutomationRule, event: dict[str, Any]) -> bool:
+    """Check if a system event matches the rule."""
+    cfg = rule.trigger_config
+    expected_name = cfg.get("event_name")
+    expected_connector = cfg.get("connector")
+    if not expected_name:
+        return False
+
+    actual_name = event.get("event_name") or event.get("name")
+    if not actual_name or expected_name.lower() != actual_name.lower():
+        return False
+
+    if expected_connector:
+        actual_connector = event.get("connector")
+        if not actual_connector or expected_connector.lower() != actual_connector.lower():
+            return False
+    return True
+
+
+async def check_all_rules(
+    rules: list[AutomationRule],
+    fabric_store: "FabricStore | None" = None,
+    event: dict[str, Any] | None = None,
+    now: datetime | None = None,
+) -> list[AutomationRule]:
+    """Evaluate all enabled rules and return those that should fire."""
+    should_fire: list[AutomationRule] = []
+    for rule in rules:
+        if not rule.enabled:
+            continue
+        fired = False
+        if rule.trigger_type == TriggerType.SCHEDULE:
+            fired = evaluate_schedule(rule, now=now)
+        elif rule.trigger_type == TriggerType.THRESHOLD and fabric_store:
+            fired = await evaluate_threshold(rule, fabric_store)
+        elif rule.trigger_type == TriggerType.DATA_CHANGE and event:
+            fired = evaluate_data_change(rule, event)
+        elif rule.trigger_type == TriggerType.EVENT and event:
+            fired = evaluate_event(rule, event)
+        if fired:
+            should_fire.append(rule)
+    return should_fire

--- a/ee/automations/models.py
+++ b/ee/automations/models.py
@@ -1,0 +1,43 @@
+# automations/models.py — AutomationRule and TriggerType models.
+# Created: 2026-03-28
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from ee.fabric.models import _gen_id
+
+
+class TriggerType(StrEnum):
+    SCHEDULE = "schedule"
+    DATA_CHANGE = "data_change"
+    THRESHOLD = "threshold"
+    EVENT = "event"
+
+
+class AutomationRule(BaseModel):
+    """A rule that triggers an action when conditions are met.
+
+    trigger_config examples:
+      schedule:     {"cron": "0 9 * * MON"}
+      threshold:    {"object_type": "Inventory", "property": "quantity", "operator": "lt", "value": 10}
+      data_change:  {"object_type": "Order", "on": "create"}
+      event:        {"event_name": "connector_synced", "connector": "stripe"}
+    """
+
+    id: str = Field(default_factory=lambda: _gen_id("rul"))
+    pocket_id: str
+    name: str
+    description: str = ""
+    enabled: bool = True
+    trigger_type: TriggerType
+    trigger_config: dict[str, Any] = Field(default_factory=dict)
+    action_template: dict[str, Any] = Field(default_factory=dict)
+    last_fired: datetime | None = None
+    fire_count: int = 0
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)

--- a/ee/automations/store.py
+++ b/ee/automations/store.py
@@ -1,0 +1,162 @@
+# automations/store.py — Async SQLite store for automation rules.
+# Created: 2026-03-28
+
+from __future__ import annotations
+
+import json
+import aiosqlite
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ee.automations.models import AutomationRule, TriggerType
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS automation_rules (
+    id TEXT PRIMARY KEY,
+    pocket_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    enabled INTEGER DEFAULT 1,
+    trigger_type TEXT NOT NULL,
+    trigger_config TEXT DEFAULT '{}',
+    action_template TEXT DEFAULT '{}',
+    last_fired TEXT,
+    fire_count INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_rules_pocket ON automation_rules(pocket_id);
+CREATE INDEX IF NOT EXISTS idx_rules_enabled ON automation_rules(enabled);
+"""
+
+
+class AutomationsStore:
+    """Async SQLite store for automation rules."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._initialized = False
+
+    async def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        async with aiosqlite.connect(self._db_path) as db:
+            await db.executescript(SCHEMA_SQL)
+            await db.commit()
+        self._initialized = True
+
+    def _conn(self) -> aiosqlite.Connection:
+        return aiosqlite.connect(self._db_path)
+
+    async def create_rule(
+        self, pocket_id: str, name: str, trigger_type: TriggerType,
+        trigger_config: dict[str, Any], action_template: dict[str, Any],
+        description: str = "", enabled: bool = True,
+    ) -> AutomationRule:
+        rule = AutomationRule(
+            pocket_id=pocket_id, name=name, description=description,
+            enabled=enabled, trigger_type=trigger_type,
+            trigger_config=trigger_config, action_template=action_template,
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO automation_rules (id, pocket_id, name, description, enabled, trigger_type, trigger_config, action_template) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (rule.id, pocket_id, name, description, 1 if enabled else 0,
+                 trigger_type.value, json.dumps(trigger_config), json.dumps(action_template)),
+            )
+            await db.commit()
+        return rule
+
+    async def get_rule(self, rule_id: str) -> AutomationRule | None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM automation_rules WHERE id = ?", (rule_id,)) as cur:
+                row = await cur.fetchone()
+                return self._row_to_rule(row) if row else None
+
+    async def list_rules(self, pocket_id: str | None = None, enabled_only: bool = False) -> list[AutomationRule]:
+        conditions: list[str] = []
+        params: list[Any] = []
+        if pocket_id:
+            conditions.append("pocket_id = ?")
+            params.append(pocket_id)
+        if enabled_only:
+            conditions.append("enabled = 1")
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(f"SELECT * FROM automation_rules {where} ORDER BY created_at DESC", params) as cur:
+                return [self._row_to_rule(row) async for row in cur]
+
+    async def update_rule(self, rule_id: str, **fields: Any) -> AutomationRule | None:
+        rule = await self.get_rule(rule_id)
+        if not rule:
+            return None
+
+        sets = ["updated_at = datetime('now')"]
+        params: list[Any] = []
+        for k, v in fields.items():
+            if v is not None:
+                if k in ("trigger_config", "action_template"):
+                    sets.append(f"{k} = ?")
+                    params.append(json.dumps(v))
+                elif k == "enabled":
+                    sets.append("enabled = ?")
+                    params.append(1 if v else 0)
+                else:
+                    sets.append(f"{k} = ?")
+                    params.append(v)
+        params.append(rule_id)
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(f"UPDATE automation_rules SET {', '.join(sets)} WHERE id = ?", params)
+            await db.commit()
+        return await self.get_rule(rule_id)
+
+    async def delete_rule(self, rule_id: str) -> bool:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            cursor = await db.execute("DELETE FROM automation_rules WHERE id = ?", (rule_id,))
+            await db.commit()
+            return cursor.rowcount > 0
+
+    async def enable_rule(self, rule_id: str) -> AutomationRule | None:
+        return await self.update_rule(rule_id, enabled=True)
+
+    async def disable_rule(self, rule_id: str) -> AutomationRule | None:
+        return await self.update_rule(rule_id, enabled=False)
+
+    async def mark_fired(self, rule_id: str) -> AutomationRule | None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE automation_rules SET last_fired = datetime('now'), fire_count = fire_count + 1, updated_at = datetime('now') WHERE id = ?",
+                (rule_id,),
+            )
+            await db.commit()
+        return await self.get_rule(rule_id)
+
+    def _row_to_rule(self, row: Any) -> AutomationRule:
+        last_fired = None
+        if row["last_fired"]:
+            try:
+                last_fired = datetime.fromisoformat(row["last_fired"])
+            except ValueError:
+                pass
+        return AutomationRule(
+            id=row["id"], pocket_id=row["pocket_id"], name=row["name"],
+            description=row["description"] or "", enabled=bool(row["enabled"]),
+            trigger_type=TriggerType(row["trigger_type"]),
+            trigger_config=json.loads(row["trigger_config"]) if row["trigger_config"] else {},
+            action_template=json.loads(row["action_template"]) if row["action_template"] else {},
+            last_fired=last_fired, fire_count=row["fire_count"] or 0,
+        )

--- a/ee/fabric/__init__.py
+++ b/ee/fabric/__init__.py
@@ -1,0 +1,16 @@
+# Fabric — lightweight ontology layer for Paw OS.
+# Created: 2026-03-28 — Objects, links, properties in SQLite.
+# Maps raw data into typed business objects with relationships
+# so agents can reason across data.
+
+from ee.fabric.models import FabricLink, FabricObject, FabricQuery, ObjectType, PropertyDef
+from ee.fabric.store import FabricStore
+
+__all__ = [
+    "ObjectType",
+    "PropertyDef",
+    "FabricObject",
+    "FabricLink",
+    "FabricQuery",
+    "FabricStore",
+]

--- a/ee/fabric/models.py
+++ b/ee/fabric/models.py
@@ -1,0 +1,78 @@
+# Fabric data models — Pydantic models for the ontology layer.
+# Created: 2026-03-28
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+def _gen_id(prefix: str) -> str:
+    import time, random, string
+    ts = hex(int(time.time() * 1000))[2:]
+    rand = ''.join(random.choices(string.ascii_lowercase + string.digits, k=4))
+    return f"{prefix}-{ts}-{rand}"
+
+
+class PropertyDef(BaseModel):
+    """Definition of a property on an object type."""
+    name: str
+    type: str = "string"  # string, number, boolean, date, enum
+    required: bool = False
+    description: str = ""
+    enum_values: list[str] | None = None
+    default: Any = None
+
+
+class ObjectType(BaseModel):
+    """Defines a category of business objects (Customer, Order, Product)."""
+    id: str = Field(default_factory=lambda: _gen_id("ot"))
+    name: str
+    description: str = ""
+    icon: str = "box"
+    color: str = "#0A84FF"
+    properties: list[PropertyDef] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
+class FabricObject(BaseModel):
+    """An instance of an ObjectType."""
+    id: str = Field(default_factory=lambda: _gen_id("obj"))
+    type_id: str
+    type_name: str = ""
+    properties: dict[str, Any] = Field(default_factory=dict)
+    source_connector: str | None = None
+    source_id: str | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
+class FabricLink(BaseModel):
+    """A directional relationship between two objects."""
+    id: str = Field(default_factory=lambda: _gen_id("lnk"))
+    from_object_id: str
+    to_object_id: str
+    link_type: str  # "has_orders", "belongs_to", "purchased"
+    properties: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=datetime.now)
+
+
+class FabricQuery(BaseModel):
+    """Query parameters for finding objects."""
+    type_name: str | None = None
+    type_id: str | None = None
+    filters: dict[str, Any] = Field(default_factory=dict)
+    linked_to: str | None = None
+    link_type: str | None = None
+    limit: int = 50
+    offset: int = 0
+
+
+class FabricQueryResult(BaseModel):
+    """Result of a fabric query."""
+    objects: list[FabricObject]
+    total: int
+    links: list[FabricLink] = Field(default_factory=list)

--- a/ee/fabric/store.py
+++ b/ee/fabric/store.py
@@ -1,0 +1,328 @@
+# Fabric store — async SQLite operations for the ontology layer.
+# Created: 2026-03-28 — CRUD for object types, objects, and links.
+
+from __future__ import annotations
+
+import json
+import aiosqlite
+from pathlib import Path
+from typing import Any
+
+from ee.fabric.models import (
+    FabricLink,
+    FabricObject,
+    FabricQuery,
+    FabricQueryResult,
+    ObjectType,
+    PropertyDef,
+    _gen_id,
+)
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS fabric_object_types (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    icon TEXT DEFAULT 'box',
+    color TEXT DEFAULT '#0A84FF',
+    properties_schema TEXT DEFAULT '[]',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS fabric_objects (
+    id TEXT PRIMARY KEY,
+    type_id TEXT NOT NULL REFERENCES fabric_object_types(id),
+    type_name TEXT DEFAULT '',
+    properties TEXT NOT NULL DEFAULT '{}',
+    source_connector TEXT,
+    source_id TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS fabric_links (
+    id TEXT PRIMARY KEY,
+    from_object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    to_object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    link_type TEXT NOT NULL,
+    properties TEXT DEFAULT '{}',
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_objects_type ON fabric_objects(type_id);
+CREATE INDEX IF NOT EXISTS idx_objects_source ON fabric_objects(source_connector, source_id);
+CREATE INDEX IF NOT EXISTS idx_links_from ON fabric_links(from_object_id);
+CREATE INDEX IF NOT EXISTS idx_links_to ON fabric_links(to_object_id);
+CREATE INDEX IF NOT EXISTS idx_links_type ON fabric_links(link_type);
+"""
+
+
+class FabricStore:
+    """Async SQLite store for Fabric ontology data."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._initialized = False
+
+    async def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        async with aiosqlite.connect(self._db_path) as db:
+            await db.executescript(SCHEMA_SQL)
+            await db.commit()
+        self._initialized = True
+
+    def _conn(self) -> aiosqlite.Connection:
+        """Return a new connection context manager. Use with `async with`."""
+        return aiosqlite.connect(self._db_path)
+
+    # --- Object Types ---
+
+    async def define_type(
+        self, name: str, properties: list[PropertyDef],
+        description: str = "", icon: str = "box", color: str = "#0A84FF",
+    ) -> ObjectType:
+        obj_type = ObjectType(
+            name=name, description=description, icon=icon, color=color,
+            properties=properties,
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO fabric_object_types (id, name, description, icon, color, properties_schema) VALUES (?, ?, ?, ?, ?, ?)",
+                (obj_type.id, obj_type.name, obj_type.description, obj_type.icon, obj_type.color,
+                 json.dumps([p.model_dump() for p in properties])),
+            )
+            await db.commit()
+        return obj_type
+
+    async def get_type(self, type_id: str) -> ObjectType | None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM fabric_object_types WHERE id = ?", (type_id,)) as cur:
+                row = await cur.fetchone()
+                if not row:
+                    return None
+                return self._row_to_type(row)
+
+    async def get_type_by_name(self, name: str) -> ObjectType | None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM fabric_object_types WHERE LOWER(name) = LOWER(?)", (name,)
+            ) as cur:
+                row = await cur.fetchone()
+                if not row:
+                    return None
+                return self._row_to_type(row)
+
+    async def list_types(self) -> list[ObjectType]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM fabric_object_types ORDER BY name") as cur:
+                return [self._row_to_type(row) async for row in cur]
+
+    async def remove_type(self, type_id: str) -> None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            # Cascade: delete links involving objects of this type, then objects, then type
+            await db.execute(
+                "DELETE FROM fabric_links WHERE from_object_id IN (SELECT id FROM fabric_objects WHERE type_id = ?) "
+                "OR to_object_id IN (SELECT id FROM fabric_objects WHERE type_id = ?)",
+                (type_id, type_id),
+            )
+            await db.execute("DELETE FROM fabric_objects WHERE type_id = ?", (type_id,))
+            await db.execute("DELETE FROM fabric_object_types WHERE id = ?", (type_id,))
+            await db.commit()
+
+    # --- Objects ---
+
+    async def create_object(
+        self, type_id: str, properties: dict[str, Any],
+        source_connector: str | None = None, source_id: str | None = None,
+    ) -> FabricObject:
+        obj_type = await self.get_type(type_id)
+        obj = FabricObject(
+            type_id=type_id,
+            type_name=obj_type.name if obj_type else "",
+            properties=properties,
+            source_connector=source_connector,
+            source_id=source_id,
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO fabric_objects (id, type_id, type_name, properties, source_connector, source_id) VALUES (?, ?, ?, ?, ?, ?)",
+                (obj.id, obj.type_id, obj.type_name, json.dumps(properties), source_connector, source_id),
+            )
+            await db.commit()
+        return obj
+
+    async def get_object(self, obj_id: str) -> FabricObject | None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM fabric_objects WHERE id = ?", (obj_id,)) as cur:
+                row = await cur.fetchone()
+                if not row:
+                    return None
+                return self._row_to_object(row)
+
+    async def update_object(self, obj_id: str, properties: dict[str, Any]) -> FabricObject | None:
+        existing = await self.get_object(obj_id)
+        if not existing:
+            return None
+        merged = {**existing.properties, **properties}
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE fabric_objects SET properties = ?, updated_at = datetime('now') WHERE id = ?",
+                (json.dumps(merged), obj_id),
+            )
+            await db.commit()
+        return await self.get_object(obj_id)
+
+    async def remove_object(self, obj_id: str) -> None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "DELETE FROM fabric_links WHERE from_object_id = ? OR to_object_id = ?",
+                (obj_id, obj_id),
+            )
+            await db.execute("DELETE FROM fabric_objects WHERE id = ?", (obj_id,))
+            await db.commit()
+
+    # --- Links ---
+
+    async def link(self, from_id: str, to_id: str, link_type: str,
+                   properties: dict[str, Any] | None = None) -> FabricLink:
+        lnk = FabricLink(
+            from_object_id=from_id, to_object_id=to_id,
+            link_type=link_type, properties=properties or {},
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO fabric_links (id, from_object_id, to_object_id, link_type, properties) VALUES (?, ?, ?, ?, ?)",
+                (lnk.id, lnk.from_object_id, lnk.to_object_id, lnk.link_type, json.dumps(lnk.properties)),
+            )
+            await db.commit()
+        return lnk
+
+    async def unlink(self, link_id: str) -> None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute("DELETE FROM fabric_links WHERE id = ?", (link_id,))
+            await db.commit()
+
+    async def get_linked_objects(self, obj_id: str, link_type: str | None = None) -> list[FabricObject]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            if link_type:
+                query = (
+                    "SELECT o.* FROM fabric_objects o JOIN fabric_links l "
+                    "ON (o.id = l.to_object_id AND l.from_object_id = ?) "
+                    "OR (o.id = l.from_object_id AND l.to_object_id = ?) "
+                    "WHERE l.link_type = ?"
+                )
+                params = (obj_id, obj_id, link_type)
+            else:
+                query = (
+                    "SELECT o.* FROM fabric_objects o JOIN fabric_links l "
+                    "ON (o.id = l.to_object_id AND l.from_object_id = ?) "
+                    "OR (o.id = l.from_object_id AND l.to_object_id = ?)"
+                )
+                params = (obj_id, obj_id)
+            async with db.execute(query, params) as cur:
+                return [self._row_to_object(row) async for row in cur]
+
+    # --- Query ---
+
+    async def query(self, q: FabricQuery) -> FabricQueryResult:
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if q.type_id:
+            conditions.append("o.type_id = ?")
+            params.append(q.type_id)
+        elif q.type_name:
+            conditions.append("LOWER(o.type_name) = LOWER(?)")
+            params.append(q.type_name)
+
+        if q.linked_to:
+            if q.link_type:
+                link_cond = (
+                    "o.id IN ("
+                    "SELECT to_object_id FROM fabric_links WHERE from_object_id = ? AND link_type = ? "
+                    "UNION "
+                    "SELECT from_object_id FROM fabric_links WHERE to_object_id = ? AND link_type = ?"
+                    ")"
+                )
+                conditions.append(link_cond)
+                params.extend([q.linked_to, q.link_type, q.linked_to, q.link_type])
+            else:
+                link_cond = (
+                    "o.id IN ("
+                    "SELECT to_object_id FROM fabric_links WHERE from_object_id = ? "
+                    "UNION "
+                    "SELECT from_object_id FROM fabric_links WHERE to_object_id = ?"
+                    ")"
+                )
+                conditions.append(link_cond)
+                params.extend([q.linked_to, q.linked_to])
+
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            # Count
+            async with db.execute(f"SELECT COUNT(*) as cnt FROM fabric_objects o {where}", params) as cur:
+                row = await cur.fetchone()
+                total = row["cnt"] if row else 0
+
+            # Fetch
+            async with db.execute(
+                f"SELECT o.* FROM fabric_objects o {where} ORDER BY o.created_at DESC LIMIT ? OFFSET ?",
+                [*params, q.limit, q.offset],
+            ) as cur:
+                objects = [self._row_to_object(row) async for row in cur]
+
+        return FabricQueryResult(objects=objects, total=total)
+
+    # --- Stats ---
+
+    async def stats(self) -> dict[str, int]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            types = await db.execute_fetchall("SELECT COUNT(*) FROM fabric_object_types")
+            objects = await db.execute_fetchall("SELECT COUNT(*) FROM fabric_objects")
+            links = await db.execute_fetchall("SELECT COUNT(*) FROM fabric_links")
+            return {
+                "types": types[0][0] if types else 0,
+                "objects": objects[0][0] if objects else 0,
+                "links": links[0][0] if links else 0,
+            }
+
+    # --- Helpers ---
+
+    def _row_to_type(self, row: Any) -> ObjectType:
+        props_raw = json.loads(row["properties_schema"]) if row["properties_schema"] else []
+        return ObjectType(
+            id=row["id"], name=row["name"], description=row["description"] or "",
+            icon=row["icon"] or "box", color=row["color"] or "#0A84FF",
+            properties=[PropertyDef(**p) for p in props_raw],
+        )
+
+    def _row_to_object(self, row: Any) -> FabricObject:
+        return FabricObject(
+            id=row["id"], type_id=row["type_id"], type_name=row["type_name"] or "",
+            properties=json.loads(row["properties"]) if row["properties"] else {},
+            source_connector=row["source_connector"], source_id=row["source_id"],
+        )

--- a/ee/instinct/__init__.py
+++ b/ee/instinct/__init__.py
@@ -1,0 +1,14 @@
+# Instinct — decision pipeline for Paw OS.
+# Created: 2026-03-28 — Actions, approvals, audit log.
+# The decision loop: Agent proposes → Human approves → Action executes → Feedback captured.
+
+from ee.instinct.models import Action, ActionTrigger, ActionContext, AuditEntry
+from ee.instinct.store import InstinctStore
+
+__all__ = [
+    "Action",
+    "ActionTrigger",
+    "ActionContext",
+    "AuditEntry",
+    "InstinctStore",
+]

--- a/ee/instinct/models.py
+++ b/ee/instinct/models.py
@@ -1,0 +1,95 @@
+# Instinct data models — decision pipeline types.
+# Created: 2026-03-28
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from ee.fabric.models import _gen_id
+
+
+class ActionStatus(StrEnum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    EXECUTED = "executed"
+    FAILED = "failed"
+
+
+class ActionPriority(StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ActionCategory(StrEnum):
+    DATA = "data"
+    ALERT = "alert"
+    WORKFLOW = "workflow"
+    CONFIG = "config"
+    EXTERNAL = "external"
+
+
+class ActionTrigger(BaseModel):
+    """What triggered an action."""
+    type: str  # "agent", "automation", "user", "connector"
+    source: str  # agent name, rule ID, user ID, connector name
+    reason: str
+
+
+class ActionContext(BaseModel):
+    """Data context for a decision."""
+    object_ids: list[str] = Field(default_factory=list)
+    connector_data: dict[str, Any] = Field(default_factory=dict)
+    metrics: dict[str, float] = Field(default_factory=dict)
+    notes: str = ""
+
+
+class Action(BaseModel):
+    """A proposed action from the agent, waiting for approval."""
+    id: str = Field(default_factory=lambda: _gen_id("act"))
+    pocket_id: str
+    title: str
+    description: str
+    category: ActionCategory = ActionCategory.WORKFLOW
+    status: ActionStatus = ActionStatus.PENDING
+    priority: ActionPriority = ActionPriority.MEDIUM
+    trigger: ActionTrigger
+    recommendation: str
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    context: ActionContext = Field(default_factory=ActionContext)
+    outcome: str | None = None
+    error: str | None = None
+    approved_by: str | None = None
+    approved_at: datetime | None = None
+    rejected_reason: str | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+    executed_at: datetime | None = None
+
+
+class AuditCategory(StrEnum):
+    DECISION = "decision"
+    DATA = "data"
+    CONFIG = "config"
+    SECURITY = "security"
+
+
+class AuditEntry(BaseModel):
+    """An audit log entry for every decision."""
+    id: str = Field(default_factory=lambda: _gen_id("aud"))
+    action_id: str | None = None
+    pocket_id: str | None = None
+    timestamp: datetime = Field(default_factory=datetime.now)
+    actor: str  # "agent:claude", "user:prakash", "system"
+    event: str  # "action_proposed", "action_approved", etc.
+    category: AuditCategory = AuditCategory.DECISION
+    description: str
+    context: dict[str, Any] = Field(default_factory=dict)
+    ai_recommendation: str | None = None
+    outcome: str | None = None

--- a/ee/instinct/store.py
+++ b/ee/instinct/store.py
@@ -1,0 +1,315 @@
+# Instinct store — async SQLite operations for the decision pipeline.
+# Created: 2026-03-28 — Action lifecycle + audit log.
+
+from __future__ import annotations
+
+import json
+import aiosqlite
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ee.instinct.models import (
+    Action,
+    ActionCategory,
+    ActionContext,
+    ActionPriority,
+    ActionStatus,
+    ActionTrigger,
+    AuditCategory,
+    AuditEntry,
+    _gen_id,
+)
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS instinct_actions (
+    id TEXT PRIMARY KEY,
+    pocket_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    category TEXT DEFAULT 'workflow',
+    status TEXT DEFAULT 'pending',
+    priority TEXT DEFAULT 'medium',
+    trigger TEXT NOT NULL,
+    recommendation TEXT DEFAULT '',
+    parameters TEXT DEFAULT '{}',
+    context TEXT DEFAULT '{}',
+    outcome TEXT,
+    error TEXT,
+    approved_by TEXT,
+    approved_at TEXT,
+    rejected_reason TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    executed_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS instinct_audit (
+    id TEXT PRIMARY KEY,
+    action_id TEXT,
+    pocket_id TEXT,
+    timestamp TEXT DEFAULT (datetime('now')),
+    actor TEXT NOT NULL,
+    event TEXT NOT NULL,
+    category TEXT DEFAULT 'decision',
+    description TEXT NOT NULL,
+    context TEXT DEFAULT '{}',
+    ai_recommendation TEXT,
+    outcome TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_actions_pocket ON instinct_actions(pocket_id);
+CREATE INDEX IF NOT EXISTS idx_actions_status ON instinct_actions(status);
+CREATE INDEX IF NOT EXISTS idx_audit_pocket ON instinct_audit(pocket_id);
+CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON instinct_audit(timestamp);
+"""
+
+
+class InstinctStore:
+    """Async SQLite store for the decision pipeline."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._initialized = False
+
+    async def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        async with aiosqlite.connect(self._db_path) as db:
+            await db.executescript(SCHEMA_SQL)
+            await db.commit()
+        self._initialized = True
+
+    def _conn(self) -> aiosqlite.Connection:
+        """Return a new connection context manager."""
+        return aiosqlite.connect(self._db_path)
+
+    # --- Actions ---
+
+    async def propose(
+        self, pocket_id: str, title: str, description: str,
+        recommendation: str, trigger: ActionTrigger,
+        category: ActionCategory = ActionCategory.WORKFLOW,
+        priority: ActionPriority = ActionPriority.MEDIUM,
+        parameters: dict[str, Any] | None = None,
+        context: ActionContext | None = None,
+    ) -> Action:
+        action = Action(
+            pocket_id=pocket_id, title=title, description=description,
+            recommendation=recommendation, trigger=trigger,
+            category=category, priority=priority,
+            parameters=parameters or {}, context=context or ActionContext(),
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO instinct_actions (id, pocket_id, title, description, category, status, priority, trigger, recommendation, parameters, context) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (action.id, pocket_id, title, description, action.category.value,
+                 action.status.value, action.priority.value,
+                 action.trigger.model_dump_json(), recommendation,
+                 json.dumps(parameters or {}), action.context.model_dump_json()),
+            )
+            await db.commit()
+
+        await self._log(
+            action_id=action.id, pocket_id=pocket_id,
+            actor=f"{trigger.type}:{trigger.source}",
+            event="action_proposed",
+            description=f"Proposed: {title}",
+            ai_recommendation=recommendation,
+        )
+        return action
+
+    async def approve(self, action_id: str, approver: str = "user") -> Action | None:
+        return await self._update_status(
+            action_id, ActionStatus.APPROVED,
+            approved_by=approver, approved_at=datetime.now().isoformat(),
+            event="action_approved", actor=approver,
+        )
+
+    async def reject(self, action_id: str, reason: str = "", rejector: str = "user") -> Action | None:
+        return await self._update_status(
+            action_id, ActionStatus.REJECTED,
+            rejected_reason=reason,
+            event="action_rejected", actor=rejector,
+            extra_desc=f" — {reason}" if reason else "",
+        )
+
+    async def mark_executed(self, action_id: str, outcome: str | None = None) -> Action | None:
+        return await self._update_status(
+            action_id, ActionStatus.EXECUTED,
+            outcome=outcome, executed_at=datetime.now().isoformat(),
+            event="action_executed", actor="system",
+        )
+
+    async def mark_failed(self, action_id: str, error: str) -> Action | None:
+        return await self._update_status(
+            action_id, ActionStatus.FAILED,
+            error=error,
+            event="action_failed", actor="system",
+            extra_desc=f" — {error}",
+        )
+
+    async def _update_status(
+        self, action_id: str, status: ActionStatus, *,
+        event: str, actor: str, extra_desc: str = "", **fields: Any,
+    ) -> Action | None:
+        action = await self.get_action(action_id)
+        if not action:
+            return None
+
+        sets = ["status = ?", "updated_at = datetime('now')"]
+        params: list[Any] = [status.value]
+        for k, v in fields.items():
+            if v is not None:
+                sets.append(f"{k} = ?")
+                params.append(v)
+        params.append(action_id)
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                f"UPDATE instinct_actions SET {', '.join(sets)} WHERE id = ?", params
+            )
+            await db.commit()
+
+        await self._log(
+            action_id=action_id, pocket_id=action.pocket_id,
+            actor=actor, event=event,
+            description=f"{event.replace('_', ' ').title()}: {action.title}{extra_desc}",
+        )
+        return await self.get_action(action_id)
+
+    async def get_action(self, action_id: str) -> Action | None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM instinct_actions WHERE id = ?", (action_id,)) as cur:
+                row = await cur.fetchone()
+                return self._row_to_action(row) if row else None
+
+    async def pending(self, pocket_id: str | None = None) -> list[Action]:
+        return await self._query_actions(status=ActionStatus.PENDING, pocket_id=pocket_id)
+
+    async def pending_count(self, pocket_id: str | None = None) -> int:
+        cond = "WHERE status = 'pending'"
+        params: list[Any] = []
+        if pocket_id:
+            cond += " AND pocket_id = ?"
+            params.append(pocket_id)
+        await self._ensure_schema()
+        async with self._conn() as db:
+            async with db.execute(f"SELECT COUNT(*) FROM instinct_actions {cond}", params) as cur:
+                row = await cur.fetchone()
+                return row[0] if row else 0
+
+    async def for_pocket(self, pocket_id: str) -> list[Action]:
+        return await self._query_actions(pocket_id=pocket_id)
+
+    async def _query_actions(
+        self, status: ActionStatus | None = None, pocket_id: str | None = None,
+    ) -> list[Action]:
+        conditions: list[str] = []
+        params: list[Any] = []
+        if status:
+            conditions.append("status = ?")
+            params.append(status.value)
+        if pocket_id:
+            conditions.append("pocket_id = ?")
+            params.append(pocket_id)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                f"SELECT * FROM instinct_actions {where} ORDER BY created_at DESC", params
+            ) as cur:
+                return [self._row_to_action(row) async for row in cur]
+
+    # --- Audit Log ---
+
+    async def _log(self, *, actor: str, event: str, description: str,
+                   action_id: str | None = None, pocket_id: str | None = None,
+                   category: AuditCategory = AuditCategory.DECISION,
+                   context: dict[str, Any] | None = None,
+                   ai_recommendation: str | None = None, outcome: str | None = None) -> AuditEntry:
+        entry = AuditEntry(
+            action_id=action_id, pocket_id=pocket_id, actor=actor,
+            event=event, category=category, description=description,
+            context=context or {}, ai_recommendation=ai_recommendation, outcome=outcome,
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO instinct_audit (id, action_id, pocket_id, actor, event, category, description, context, ai_recommendation, outcome) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (entry.id, entry.action_id, entry.pocket_id, entry.actor, entry.event,
+                 entry.category.value, entry.description, json.dumps(entry.context),
+                 entry.ai_recommendation, entry.outcome),
+            )
+            await db.commit()
+        return entry
+
+    async def log(self, *, actor: str, event: str, description: str, **kwargs: Any) -> AuditEntry:
+        """Public audit log method for non-action events."""
+        return await self._log(actor=actor, event=event, description=description, **kwargs)
+
+    async def query_audit(
+        self, pocket_id: str | None = None, category: str | None = None,
+        event: str | None = None, limit: int = 100,
+    ) -> list[AuditEntry]:
+        conditions: list[str] = []
+        params: list[Any] = []
+        if pocket_id:
+            conditions.append("pocket_id = ?")
+            params.append(pocket_id)
+        if category:
+            conditions.append("category = ?")
+            params.append(category)
+        if event:
+            conditions.append("event = ?")
+            params.append(event)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        params.append(limit)
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                f"SELECT * FROM instinct_audit {where} ORDER BY timestamp DESC LIMIT ?", params
+            ) as cur:
+                return [self._row_to_audit(row) async for row in cur]
+
+    async def export_audit(self, pocket_id: str | None = None) -> str:
+        entries = await self.query_audit(pocket_id=pocket_id, limit=10000)
+        return json.dumps([e.model_dump(mode="json") for e in entries], indent=2)
+
+    # --- Helpers ---
+
+    def _row_to_action(self, row: Any) -> Action:
+        return Action(
+            id=row["id"], pocket_id=row["pocket_id"], title=row["title"],
+            description=row["description"] or "",
+            category=ActionCategory(row["category"]),
+            status=ActionStatus(row["status"]),
+            priority=ActionPriority(row["priority"]),
+            trigger=ActionTrigger.model_validate_json(row["trigger"]),
+            recommendation=row["recommendation"] or "",
+            parameters=json.loads(row["parameters"]) if row["parameters"] else {},
+            context=ActionContext.model_validate_json(row["context"]) if row["context"] else ActionContext(),
+            outcome=row["outcome"], error=row["error"],
+            approved_by=row["approved_by"], rejected_reason=row["rejected_reason"],
+        )
+
+    def _row_to_audit(self, row: Any) -> AuditEntry:
+        return AuditEntry(
+            id=row["id"], action_id=row["action_id"], pocket_id=row["pocket_id"],
+            actor=row["actor"], event=row["event"],
+            category=AuditCategory(row["category"]),
+            description=row["description"],
+            context=json.loads(row["context"]) if row["context"] else {},
+            ai_recommendation=row["ai_recommendation"], outcome=row["outcome"],
+        )

--- a/tests/test_ee_automations.py
+++ b/tests/test_ee_automations.py
@@ -1,0 +1,161 @@
+# Tests for ee/automations — rules, store, evaluator.
+# Created: 2026-03-28
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ee.automations.models import AutomationRule, TriggerType
+from ee.automations.store import AutomationsStore
+from ee.automations.evaluator import (
+    check_all_rules, evaluate_data_change, evaluate_event,
+    evaluate_schedule, evaluate_threshold,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> AutomationsStore:
+    return AutomationsStore(tmp_path / "test.db")
+
+
+def _mock_fabric(objects: list[dict]) -> Any:
+    from ee.fabric.models import FabricObject, FabricQueryResult
+    objs = [FabricObject(type_id="t1", type_name="Inventory", properties=p) for p in objects]
+    mock = MagicMock()
+    mock.query = AsyncMock(return_value=FabricQueryResult(objects=objs, total=len(objs)))
+    return mock
+
+
+# --- Store ---
+
+class TestStore:
+    @pytest.mark.asyncio
+    async def test_create_and_get(self, store):
+        rule = await store.create_rule("p1", "Low stock", TriggerType.THRESHOLD,
+            {"object_type": "Inventory", "property": "qty", "operator": "lt", "value": 10}, {})
+        assert rule.id.startswith("rul-")
+        fetched = await store.get_rule(rule.id)
+        assert fetched is not None
+        assert fetched.name == "Low stock"
+
+    @pytest.mark.asyncio
+    async def test_list_filter(self, store):
+        await store.create_rule("p1", "A", TriggerType.SCHEDULE, {"cron": "* * * * *"}, {})
+        await store.create_rule("p2", "B", TriggerType.SCHEDULE, {"cron": "* * * * *"}, {})
+        assert len(await store.list_rules(pocket_id="p1")) == 1
+
+    @pytest.mark.asyncio
+    async def test_enable_disable(self, store):
+        rule = await store.create_rule("p1", "X", TriggerType.EVENT, {}, {})
+        disabled = await store.disable_rule(rule.id)
+        assert disabled is not None and not disabled.enabled
+        enabled = await store.enable_rule(rule.id)
+        assert enabled is not None and enabled.enabled
+
+    @pytest.mark.asyncio
+    async def test_mark_fired(self, store):
+        rule = await store.create_rule("p1", "X", TriggerType.EVENT, {}, {})
+        fired = await store.mark_fired(rule.id)
+        assert fired is not None and fired.fire_count == 1 and fired.last_fired is not None
+        fired2 = await store.mark_fired(rule.id)
+        assert fired2 is not None and fired2.fire_count == 2
+
+    @pytest.mark.asyncio
+    async def test_delete(self, store):
+        rule = await store.create_rule("p1", "X", TriggerType.EVENT, {}, {})
+        assert await store.delete_rule(rule.id) is True
+        assert await store.get_rule(rule.id) is None
+        assert await store.delete_rule("ghost") is False
+
+
+# --- Evaluator ---
+
+class TestThreshold:
+    @pytest.mark.asyncio
+    async def test_lt_fires(self):
+        assert await evaluate_threshold(
+            AutomationRule(pocket_id="p1", name="t", trigger_type=TriggerType.THRESHOLD,
+                trigger_config={"object_type": "Inventory", "property": "qty", "operator": "lt", "value": 10},
+                action_template={}),
+            _mock_fabric([{"qty": 5}]),
+        ) is True
+
+    @pytest.mark.asyncio
+    async def test_lt_no_fire(self):
+        assert await evaluate_threshold(
+            AutomationRule(pocket_id="p1", name="t", trigger_type=TriggerType.THRESHOLD,
+                trigger_config={"object_type": "Inventory", "property": "qty", "operator": "lt", "value": 10},
+                action_template={}),
+            _mock_fabric([{"qty": 15}]),
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_gt_fires(self):
+        assert await evaluate_threshold(
+            AutomationRule(pocket_id="p1", name="t", trigger_type=TriggerType.THRESHOLD,
+                trigger_config={"object_type": "Inventory", "property": "qty", "operator": "gt", "value": 50},
+                action_template={}),
+            _mock_fabric([{"qty": 100}]),
+        ) is True
+
+    @pytest.mark.asyncio
+    async def test_missing_config(self):
+        assert await evaluate_threshold(
+            AutomationRule(pocket_id="p1", name="t", trigger_type=TriggerType.THRESHOLD,
+                trigger_config={}, action_template={}),
+            _mock_fabric([{"qty": 5}]),
+        ) is False
+
+
+class TestDataChange:
+    def test_fires(self):
+        rule = AutomationRule(pocket_id="p1", name="t", trigger_type=TriggerType.DATA_CHANGE,
+            trigger_config={"object_type": "Order", "on": "create"}, action_template={})
+        assert evaluate_data_change(rule, {"object_type": "Order", "on": "create"}) is True
+
+    def test_wrong_type(self):
+        rule = AutomationRule(pocket_id="p1", name="t", trigger_type=TriggerType.DATA_CHANGE,
+            trigger_config={"object_type": "Order", "on": "create"}, action_template={})
+        assert evaluate_data_change(rule, {"object_type": "Invoice", "on": "create"}) is False
+
+
+class TestEvent:
+    def test_fires(self):
+        rule = AutomationRule(pocket_id="p1", name="t", trigger_type=TriggerType.EVENT,
+            trigger_config={"event_name": "connector_synced", "connector": "stripe"}, action_template={})
+        assert evaluate_event(rule, {"event_name": "connector_synced", "connector": "stripe"}) is True
+
+    def test_wrong_connector(self):
+        rule = AutomationRule(pocket_id="p1", name="t", trigger_type=TriggerType.EVENT,
+            trigger_config={"event_name": "connector_synced", "connector": "stripe"}, action_template={})
+        assert evaluate_event(rule, {"event_name": "connector_synced", "connector": "shopify"}) is False
+
+
+class TestCheckAllRules:
+    @pytest.mark.asyncio
+    async def test_threshold_fires(self):
+        rule = AutomationRule(pocket_id="p1", name="t", trigger_type=TriggerType.THRESHOLD,
+            trigger_config={"object_type": "Inv", "property": "qty", "operator": "lt", "value": 10},
+            action_template={})
+        fired = await check_all_rules([rule], fabric_store=_mock_fabric([{"qty": 3}]))
+        assert len(fired) == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_disabled(self):
+        rule = AutomationRule(pocket_id="p1", name="t", trigger_type=TriggerType.THRESHOLD,
+            trigger_config={"object_type": "Inv", "property": "qty", "operator": "lt", "value": 10},
+            action_template={}, enabled=False)
+        fired = await check_all_rules([rule], fabric_store=_mock_fabric([{"qty": 3}]))
+        assert len(fired) == 0
+
+    @pytest.mark.asyncio
+    async def test_data_change_fires(self):
+        rule = AutomationRule(pocket_id="p1", name="t", trigger_type=TriggerType.DATA_CHANGE,
+            trigger_config={"object_type": "Order", "on": "create"}, action_template={})
+        fired = await check_all_rules([rule], event={"object_type": "Order", "on": "create"})
+        assert len(fired) == 1

--- a/tests/test_ee_fabric.py
+++ b/tests/test_ee_fabric.py
@@ -1,0 +1,172 @@
+# Tests for ee/fabric — ontology store (SQLite).
+# Created: 2026-03-28
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ee.fabric.models import PropertyDef, FabricQuery
+from ee.fabric.store import FabricStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> FabricStore:
+    return FabricStore(tmp_path / "test.db")
+
+
+class TestObjectTypes:
+    @pytest.mark.asyncio
+    async def test_define_and_get(self, store: FabricStore) -> None:
+        t = await store.define_type(
+            name="Customer",
+            properties=[
+                PropertyDef(name="name", type="string", required=True),
+                PropertyDef(name="email", type="string"),
+                PropertyDef(name="revenue", type="number"),
+            ],
+            icon="user", color="#FF6B35",
+        )
+        assert t.id.startswith("ot-")
+        assert t.name == "Customer"
+
+        fetched = await store.get_type(t.id)
+        assert fetched is not None
+        assert fetched.name == "Customer"
+        assert len(fetched.properties) == 3
+
+    @pytest.mark.asyncio
+    async def test_get_by_name(self, store: FabricStore) -> None:
+        await store.define_type(name="Order", properties=[])
+        found = await store.get_type_by_name("order")
+        assert found is not None
+        assert found.name == "Order"
+
+    @pytest.mark.asyncio
+    async def test_list_types(self, store: FabricStore) -> None:
+        await store.define_type(name="A", properties=[])
+        await store.define_type(name="B", properties=[])
+        types = await store.list_types()
+        assert len(types) == 2
+
+    @pytest.mark.asyncio
+    async def test_remove_cascades(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Product", properties=[])
+        o1 = await store.create_object(t.id, {"name": "Widget"})
+        o2 = await store.create_object(t.id, {"name": "Gadget"})
+        await store.link(o1.id, o2.id, "related")
+
+        await store.remove_type(t.id)
+        types = await store.list_types()
+        assert len(types) == 0
+        result = await store.query(FabricQuery())
+        assert result.total == 0
+
+
+class TestObjects:
+    @pytest.mark.asyncio
+    async def test_create_and_get(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Customer", properties=[])
+        obj = await store.create_object(t.id, {"name": "Acme", "email": "hi@acme.com"})
+        assert obj.id.startswith("obj-")
+        assert obj.type_name == "Customer"
+
+        fetched = await store.get_object(obj.id)
+        assert fetched is not None
+        assert fetched.properties["name"] == "Acme"
+
+    @pytest.mark.asyncio
+    async def test_update(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Customer", properties=[])
+        obj = await store.create_object(t.id, {"name": "Acme", "revenue": 50000})
+        updated = await store.update_object(obj.id, {"revenue": 75000})
+        assert updated is not None
+        assert updated.properties["revenue"] == 75000
+        assert updated.properties["name"] == "Acme"
+
+    @pytest.mark.asyncio
+    async def test_source_tracking(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Invoice", properties=[])
+        obj = await store.create_object(t.id, {"amount": 100}, source_connector="stripe", source_id="inv_123")
+        assert obj.source_connector == "stripe"
+        assert obj.source_id == "inv_123"
+
+    @pytest.mark.asyncio
+    async def test_remove(self, store: FabricStore) -> None:
+        t = await store.define_type(name="X", properties=[])
+        obj = await store.create_object(t.id, {})
+        await store.remove_object(obj.id)
+        assert await store.get_object(obj.id) is None
+
+
+class TestLinks:
+    @pytest.mark.asyncio
+    async def test_link_and_traverse(self, store: FabricStore) -> None:
+        ct = await store.define_type(name="Customer", properties=[])
+        ot = await store.define_type(name="Order", properties=[])
+
+        cust = await store.create_object(ct.id, {"name": "Acme"})
+        o1 = await store.create_object(ot.id, {"amount": 100})
+        o2 = await store.create_object(ot.id, {"amount": 200})
+
+        await store.link(cust.id, o1.id, "has_order")
+        await store.link(cust.id, o2.id, "has_order")
+
+        linked = await store.get_linked_objects(cust.id, "has_order")
+        assert len(linked) == 2
+
+    @pytest.mark.asyncio
+    async def test_unlink(self, store: FabricStore) -> None:
+        t = await store.define_type(name="X", properties=[])
+        a = await store.create_object(t.id, {})
+        b = await store.create_object(t.id, {})
+        lnk = await store.link(a.id, b.id, "r")
+        await store.unlink(lnk.id)
+        linked = await store.get_linked_objects(a.id)
+        assert len(linked) == 0
+
+
+class TestQuery:
+    @pytest.mark.asyncio
+    async def test_by_type_name(self, store: FabricStore) -> None:
+        ct = await store.define_type(name="Customer", properties=[])
+        ot = await store.define_type(name="Order", properties=[])
+        await store.create_object(ct.id, {"name": "A"})
+        await store.create_object(ct.id, {"name": "B"})
+        await store.create_object(ot.id, {"amount": 100})
+
+        result = await store.query(FabricQuery(type_name="Customer"))
+        assert result.total == 2
+
+    @pytest.mark.asyncio
+    async def test_by_linked(self, store: FabricStore) -> None:
+        ct = await store.define_type(name="Customer", properties=[])
+        ot = await store.define_type(name="Order", properties=[])
+        cust = await store.create_object(ct.id, {"name": "Acme"})
+        o1 = await store.create_object(ot.id, {"amount": 100})
+        await store.create_object(ot.id, {"amount": 200})  # not linked
+        await store.link(cust.id, o1.id, "has_order")
+
+        result = await store.query(FabricQuery(linked_to=cust.id, link_type="has_order"))
+        assert result.total == 1
+
+    @pytest.mark.asyncio
+    async def test_pagination(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Item", properties=[])
+        for i in range(10):
+            await store.create_object(t.id, {"idx": i})
+
+        r1 = await store.query(FabricQuery(type_name="Item", limit=3, offset=0))
+        assert len(r1.objects) == 3
+        assert r1.total == 10
+
+    @pytest.mark.asyncio
+    async def test_stats(self, store: FabricStore) -> None:
+        t = await store.define_type(name="X", properties=[])
+        a = await store.create_object(t.id, {})
+        b = await store.create_object(t.id, {})
+        await store.link(a.id, b.id, "r")
+        s = await store.stats()
+        assert s == {"types": 1, "objects": 2, "links": 1}

--- a/tests/test_ee_instinct.py
+++ b/tests/test_ee_instinct.py
@@ -1,0 +1,134 @@
+# Tests for ee/instinct — decision pipeline store (SQLite).
+# Created: 2026-03-28
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ee.instinct.models import ActionTrigger, ActionContext
+from ee.instinct.store import InstinctStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "test.db")
+
+
+def trigger(source: str = "claude") -> ActionTrigger:
+    return ActionTrigger(type="agent", source=source, reason="test")
+
+
+class TestActionLifecycle:
+    @pytest.mark.asyncio
+    async def test_propose(self, store: InstinctStore) -> None:
+        action = await store.propose(
+            pocket_id="p1", title="Reorder inventory",
+            description="Stock at 4 units", recommendation="Order 20 units",
+            trigger=trigger(),
+        )
+        assert action.id.startswith("act-")
+        assert action.status.value == "pending"
+
+    @pytest.mark.asyncio
+    async def test_approve(self, store: InstinctStore) -> None:
+        action = await store.propose(
+            pocket_id="p1", title="Test", description="",
+            recommendation="Do it", trigger=trigger(),
+        )
+        approved = await store.approve(action.id, "user:prakash")
+        assert approved is not None
+        assert approved.status.value == "approved"
+        assert approved.approved_by == "user:prakash"
+
+    @pytest.mark.asyncio
+    async def test_reject(self, store: InstinctStore) -> None:
+        action = await store.propose(
+            pocket_id="p1", title="Test", description="",
+            recommendation="Do it", trigger=trigger(),
+        )
+        rejected = await store.reject(action.id, "Not needed")
+        assert rejected is not None
+        assert rejected.status.value == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_execute(self, store: InstinctStore) -> None:
+        action = await store.propose(
+            pocket_id="p1", title="Test", description="",
+            recommendation="Do it", trigger=trigger(),
+        )
+        await store.approve(action.id)
+        executed = await store.mark_executed(action.id, "Done successfully")
+        assert executed is not None
+        assert executed.status.value == "executed"
+        assert executed.outcome == "Done successfully"
+
+    @pytest.mark.asyncio
+    async def test_fail(self, store: InstinctStore) -> None:
+        action = await store.propose(
+            pocket_id="p1", title="Test", description="",
+            recommendation="Do it", trigger=trigger(),
+        )
+        failed = await store.mark_failed(action.id, "API error")
+        assert failed is not None
+        assert failed.status.value == "failed"
+        assert failed.error == "API error"
+
+
+class TestQueries:
+    @pytest.mark.asyncio
+    async def test_pending(self, store: InstinctStore) -> None:
+        await store.propose(pocket_id="p1", title="A", description="", recommendation="", trigger=trigger())
+        await store.propose(pocket_id="p1", title="B", description="", recommendation="", trigger=trigger())
+        pending = await store.pending()
+        assert len(pending) == 2
+
+    @pytest.mark.asyncio
+    async def test_pending_count(self, store: InstinctStore) -> None:
+        a = await store.propose(pocket_id="p1", title="A", description="", recommendation="", trigger=trigger())
+        await store.propose(pocket_id="p1", title="B", description="", recommendation="", trigger=trigger())
+        await store.approve(a.id)
+        count = await store.pending_count()
+        assert count == 1
+
+    @pytest.mark.asyncio
+    async def test_for_pocket(self, store: InstinctStore) -> None:
+        await store.propose(pocket_id="p1", title="A", description="", recommendation="", trigger=trigger())
+        await store.propose(pocket_id="p2", title="B", description="", recommendation="", trigger=trigger())
+        p1_actions = await store.for_pocket("p1")
+        assert len(p1_actions) == 1
+
+
+class TestAuditLog:
+    @pytest.mark.asyncio
+    async def test_auto_logs_lifecycle(self, store: InstinctStore) -> None:
+        action = await store.propose(
+            pocket_id="p1", title="Test action", description="",
+            recommendation="Do it", trigger=trigger(),
+        )
+        await store.approve(action.id)
+        await store.mark_executed(action.id, "Done")
+
+        entries = await store.query_audit(pocket_id="p1")
+        events = [e.event for e in entries]
+        assert "action_proposed" in events
+        assert "action_approved" in events
+        assert "action_executed" in events
+
+    @pytest.mark.asyncio
+    async def test_manual_log(self, store: InstinctStore) -> None:
+        await store.log(
+            actor="system", event="connector_synced",
+            description="Stripe synced 42 records", pocket_id="p1",
+        )
+        entries = await store.query_audit(event="connector_synced")
+        assert len(entries) == 1
+
+    @pytest.mark.asyncio
+    async def test_export(self, store: InstinctStore) -> None:
+        await store.log(actor="system", event="test", description="Test", pocket_id="p1")
+        exported = await store.export_audit("p1")
+        import json
+        parsed = json.loads(exported)
+        assert len(parsed) == 1


### PR DESCRIPTION
## Summary

Automations engine for the ee/ enterprise layer. Time/data-based triggers that fire actions in the Instinct decision pipeline.

## What's included

| File | Purpose |
|------|---------|
| `ee/automations/models.py` | AutomationRule, TriggerType (schedule, threshold, data_change, event) |
| `ee/automations/store.py` | Async SQLite CRUD, enable/disable, fire tracking |
| `ee/automations/evaluator.py` | Trigger evaluation for all 4 types + batch check_all_rules() |
| `tests/test_ee_automations.py` | 16 tests |

## Trigger types

| Type | Config | Example |
|------|--------|---------|
| `schedule` | `{"cron": "0 9 * * MON"}` | "Every Monday at 9am" |
| `threshold` | `{"object_type": "Inventory", "property": "qty", "operator": "lt", "value": 10}` | "When stock drops below 10" |
| `data_change` | `{"object_type": "Order", "on": "create"}` | "When a new order is created" |
| `event` | `{"event_name": "connector_synced", "connector": "stripe"}` | "When Stripe data syncs" |

## Test plan

- [x] 16/16 tests passing
- [ ] Add scheduler daemon that calls check_all_rules() periodically (future)
- [ ] Add automations REST API endpoints (future)