### PR TITLE
feat(adk): enable JSON Schema feature for function tools and MCP tools

### DIFF
--- a/src/pocketpaw/agents/google_adk.py
+++ b/src/pocketpaw/agents/google_adk.py
@@ -75,6 +75,15 @@ class GoogleADKBackend:
             logger.warning("Google ADK not installed -- pip install 'pocketpaw[google-adk]'")
             return
 
+        # JSON Schema declarations for ADK function tools and MCP tools.
+        try:
+            from google.adk.features import FeatureName, override_feature_enabled
+
+            override_feature_enabled(FeatureName.JSON_SCHEMA_FOR_FUNC_DECL, True)
+            logger.info("Enabled ADK feature JSON_SCHEMA_FOR_FUNC_DECL")
+        except Exception as exc:
+            logger.debug("Could not enable ADK JSON schema feature flag: %s", exc)
+
         from pocketpaw.llm.providers import get_adapter
 
         provider = self.settings.google_adk_provider


### PR DESCRIPTION


## What does this PR do?

<!-- Describe the change in 2-3 sentences. What problem does it solve? -->
Enable ADK JSON-schema declaration mode to avoid ADK's legacy Schema conversion errors (fixes KeyError: 'anyOf').
Toggles JSON_SCHEMA_FOR_FUNC_DECL at backend init so ADK/MCP tools use parameters_json_schema.
Improves robustness of Google ADK integration and prevents runtime tool-schema crashes.

## Related Issue

<!-- Link the issue this PR addresses. PRs without a linked issue will be closed. -->

Fixes #764 

## Changes Made

<!-- List the specific files changed and what was modified in each. -->
- `src/pocketpaw/agents/google_adk.py : JSON_SCHEMA_FOR_FUNC_DECL`


## How to Test

<!-- Step-by-step instructions for a reviewer to verify your changes work. -->

1. Install any MCP server and connect to it
2. choose Goggle ADK from setting
3. ask any question

## Evidence of Testing

<!-- Paste terminal output, test results, or screenshots proving you tested locally. -->
<img width="1166" height="671" alt="image" src="https://github.com/user-attachments/assets/9c063f27-5c61-4850-82f1-1673d08bd1d8" />

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff
