### PR TITLE
[FI] Fix stale identity cache when file mtime is unchanged on Windows

### DIFF
--- a/src/pocketpaw/bootstrap/default_provider.py
+++ b/src/pocketpaw/bootstrap/default_provider.py
@@ -17,20 +17,22 @@ logger = logging.getLogger(__name__)
 class _IdentityCache:
     content: str
     mtime: float
+    size: int = 0
 
 
 _identity_file_cache: dict[str, _IdentityCache] = {}
 
-
 def _read_identity_file(path: Path, strip: bool = False) -> str:
     """Read an identity file; return cached content when mtime is unchanged."""
     try:
-        mtime = path.stat().st_mtime
+        stat = path.stat()
+        mtime = stat.st_mtime
+        size = stat.st_size
     except FileNotFoundError:
         return ""
     key = str(path)
     cached = _identity_file_cache.get(key)
-    if cached and cached.mtime == mtime:
+    if cached and cached.mtime == mtime and cached.size == size:
         return cached.content
     raw = path.read_bytes()
     content = raw.decode("utf-8", errors="replace").replace("\r\n", "\n")
@@ -38,9 +40,8 @@ def _read_identity_file(path: Path, strip: bool = False) -> str:
         logger.warning("File %s contains non-UTF-8 bytes (replaced with placeholders)", path)
     if strip:
         content = content.strip()
-    _identity_file_cache[key] = _IdentityCache(content=content, mtime=mtime)
+    _identity_file_cache[key] = _IdentityCache(content=content, mtime=mtime, size=size)
     return content
-
 
 _DEFAULT_INSTRUCTIONS = """\
 ## PocketPaw Tools


### PR DESCRIPTION
… Windows

<!-- Updated: 2026-02-26 — Added branch/issue warnings, tightened checklist. -->

> **Before opening this PR:**
> - Does it target `dev`? PRs against `main` are auto-closed.
> - Is there a linked issue? PRs without one will be closed.
> - Did you read [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md)?

## What does this PR do?
Fixes stale identity file cache on Windows. When a file is 
rewritten within the same clock tick, st_mtime stays identical. 
Added size field to _IdentityCache so cache invalidates when 
either m-time OR file size changes.  Fixes #789->

## Related Issue

<!-- Link the issue this PR addresses. PRs without a linked issue will be closed. -->

Fixes #

## Changes Made
- src/pocketpaw/bootstrap/default_provider.py: Added size: int 
  to _IdentityCache dataclass. Cache now checks both mtime and 
  size before returning cached content.

- `file_path`: description of change

## How to Test
uv run pytest tests/test_identity_api.py -v
All 14 tests pass including test_saved_instructions_in_system_prompt.

1.
2.
3.

## Evidence of Testing

<!-- Paste terminal output, test results, or screenshots proving you tested locally. -->

```
paste output here
```

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff
