### PR TITLE
[FI] fix: empty string bypasses required parameter validation in ToolRegistry

### DIFF
--- a/src/pocketpaw/tools/registry.py
+++ b/src/pocketpaw/tools/registry.py
@@ -118,7 +118,10 @@ class ToolRegistry:
         schema = tool.definition.parameters
         if schema and "required" in schema:
             required_params = schema.get("required", [])
-            missing_params = [p for p in required_params if params.get(p) is None]
+            missing_params = [
+                p for p in required_params
+                if params.get(p) is None or params.get(p) == ""
+            ]
             if missing_params:
                 error_msg = f"Missing required parameter(s): {', '.join(missing_params)}"
                 logger.warning("Parameter validation failed for %s: %s", name, error_msg)


### PR DESCRIPTION
Fixes #793

## What this fixes
In `tools/registry.py`, the required parameter validation used `is None` 
to detect missing params. An empty string `""` is not `None`, so it passed 
the check silently — allowing tools to execute with blank required parameters.

## Change
```python
# Before
missing_params = [p for p in required_params if params.get(p) is None]

# After
missing_params = [
    p for p in required_params
    if params.get(p) is None or params.get(p) == ""
]
```

## Impact
Tools with required string parameters can no longer be called with empty 
strings. The validation now correctly treats `""` as missing.