### PR TITLE
fix(llm-router): detect and route all LLM providers correctly

### DIFF
--- a/src/pocketpaw/llm/client.py
+++ b/src/pocketpaw/llm/client.py
@@ -177,6 +177,14 @@ def resolve_llm_client(
             provider = "anthropic"
         elif settings.openai_api_key:
             provider = "openai"
+        elif settings.google_api_key:
+            provider = "gemini"
+        elif settings.openrouter_api_key:
+            provider = "openrouter"
+        elif settings.openai_compatible_base_url and settings.openai_compatible_api_key:
+            provider = "openai_compatible"
+        elif settings.litellm_api_key:
+            provider = "litellm"
         else:
             provider = "ollama"
 

--- a/src/pocketpaw/llm/router.py
+++ b/src/pocketpaw/llm/router.py
@@ -62,14 +62,43 @@ class LLMRouter:
                 return "anthropic"
             return None
 
-        # Auto mode - try in order: Ollama → OpenAI → Anthropic
+        if provider == "openai_compatible":
+            if self.settings.openai_compatible_base_url:
+                return "openai_compatible"
+            return None
+
+        if provider == "openrouter":
+            if self.settings.openrouter_api_key or self.settings.openai_compatible_api_key:
+                return "openrouter"
+            return None
+
+        if provider == "gemini":
+            if self.settings.google_api_key:
+                return "gemini"
+            return None
+
+        if provider == "litellm":
+            # LiteLLM proxy may not require a key; presence of the provider
+            # setting is sufficient (proxy URL defaults to localhost:4000).
+            return "litellm"
+
+        # Auto mode - try in order: Anthropic → OpenAI → Gemini →
+        # OpenRouter → OpenAI-compatible → LiteLLM → Ollama
         if provider == "auto":
-            if await self._check_ollama():
-                return "ollama"
-            if self.settings.openai_api_key:
-                return "openai"
             if self.settings.anthropic_api_key:
                 return "anthropic"
+            if self.settings.openai_api_key:
+                return "openai"
+            if self.settings.google_api_key:
+                return "gemini"
+            if self.settings.openrouter_api_key:
+                return "openrouter"
+            if self.settings.openai_compatible_base_url and self.settings.openai_compatible_api_key:
+                return "openai_compatible"
+            if self.settings.litellm_api_key:
+                return "litellm"
+            if await self._check_ollama():
+                return "ollama"
 
         return None
 
@@ -84,7 +113,11 @@ class LLMRouter:
                 "Options:\n"
                 "• Install [Ollama](https://ollama.ai) and run `ollama run llama3.2`\n"
                 "• Add OpenAI API key in ⚙️ Settings\n"
-                "• Add Anthropic API key in ⚙️ Settings"
+                "• Add Anthropic API key in ⚙️ Settings\n"
+                "• Add Google API key in ⚙️ Settings (Gemini)\n"
+                "• Add OpenRouter API key in ⚙️ Settings\n"
+                "• Configure an OpenAI-compatible endpoint in ⚙️ Settings\n"
+                "• Configure a LiteLLM proxy in ⚙️ Settings"
             )
 
         self.conversation_history.append({"role": "user", "content": message})
@@ -96,6 +129,13 @@ class LLMRouter:
                 response = await self._chat_openai(message)
             elif self._available_backend == "anthropic":
                 response = await self._chat_anthropic(message)
+            elif self._available_backend in (
+                "openai_compatible",
+                "openrouter",
+                "gemini",
+                "litellm",
+            ):
+                response = await self._chat_openai_compat(self._available_backend)
             else:
                 response = "Unknown backend"
 
@@ -166,6 +206,38 @@ class LLMRouter:
             logger.warning("Anthropic returned an empty content list; returning fallback response")
             return "I'm sorry, I received an empty response. Please try again."
         return response.content[0].text
+
+    async def _chat_openai_compat(self, provider: str) -> str:
+        """Chat via an OpenAI-compatible provider (openai_compatible, openrouter, gemini, litellm).
+
+        Uses ``resolve_llm_client`` to build a correctly configured
+        ``AsyncOpenAI`` client for the given provider.
+        """
+        from pocketpaw.llm.client import resolve_llm_client
+
+        llm = resolve_llm_client(self.settings, force_provider=provider)
+        client = llm.create_openai_client()
+
+        response = await client.chat.completions.create(
+            model=llm.model,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are PocketPaw, a helpful AI assistant"
+                        " running locally on the user's machine."
+                    ),
+                },
+                *self.conversation_history,
+            ],
+        )
+
+        if not response.choices:
+            logger.warning(
+                "%s returned an empty choices list; returning fallback response", provider
+            )
+            return "I'm sorry, I received an empty response. Please try again."
+        return response.choices[0].message.content
 
     def clear_history(self) -> None:
         """Clear conversation history."""

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -200,3 +200,174 @@ class TestChatFallbackIntegration:
             result = await router.chat("ping")
 
         assert result == FALLBACK
+
+
+# ---------------------------------------------------------------------------
+# Provider detection (issue #795)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectBackendProviders:
+    """_detect_backend must recognise all supported providers."""
+
+    async def test_detect_openai_compatible(self):
+        settings = Settings(
+            llm_provider="openai_compatible",
+            openai_compatible_base_url="http://localhost:8000/v1",
+            openai_compatible_api_key="sk-test",
+        )
+        router = LLMRouter(settings)
+        assert await router._detect_backend() == "openai_compatible"
+
+    async def test_detect_openai_compatible_missing_url(self):
+        settings = Settings(
+            llm_provider="openai_compatible",
+            openai_compatible_base_url="",
+        )
+        router = LLMRouter(settings)
+        assert await router._detect_backend() is None
+
+    async def test_detect_openrouter(self):
+        settings = Settings(
+            llm_provider="openrouter",
+            openrouter_api_key="sk-or-v1-test",
+        )
+        router = LLMRouter(settings)
+        assert await router._detect_backend() == "openrouter"
+
+    async def test_detect_openrouter_fallback_to_compat_key(self):
+        settings = Settings(
+            llm_provider="openrouter",
+            openrouter_api_key=None,
+            openai_compatible_api_key="sk-compat",
+        )
+        router = LLMRouter(settings)
+        assert await router._detect_backend() == "openrouter"
+
+    async def test_detect_openrouter_missing_keys(self):
+        settings = Settings(
+            llm_provider="openrouter",
+            openrouter_api_key=None,
+            openai_compatible_api_key=None,
+        )
+        router = LLMRouter(settings)
+        assert await router._detect_backend() is None
+
+    async def test_detect_gemini(self):
+        settings = Settings(
+            llm_provider="gemini",
+            google_api_key="AIza-test",
+        )
+        router = LLMRouter(settings)
+        assert await router._detect_backend() == "gemini"
+
+    async def test_detect_gemini_missing_key(self):
+        settings = Settings(
+            llm_provider="gemini",
+            google_api_key=None,
+        )
+        router = LLMRouter(settings)
+        assert await router._detect_backend() is None
+
+    async def test_detect_litellm(self):
+        settings = Settings(llm_provider="litellm")
+        router = LLMRouter(settings)
+        assert await router._detect_backend() == "litellm"
+
+    async def test_auto_selects_gemini_over_ollama(self):
+        """Auto mode should prefer Gemini (cloud) over Ollama when key is set."""
+        settings = Settings(
+            llm_provider="auto",
+            anthropic_api_key=None,
+            openai_api_key=None,
+            google_api_key="AIza-test",
+        )
+        router = LLMRouter(settings)
+        assert await router._detect_backend() == "gemini"
+
+    async def test_auto_selects_openrouter_when_key_set(self):
+        settings = Settings(
+            llm_provider="auto",
+            anthropic_api_key=None,
+            openai_api_key=None,
+            google_api_key=None,
+            openrouter_api_key="sk-or-v1-test",
+        )
+        router = LLMRouter(settings)
+        assert await router._detect_backend() == "openrouter"
+
+    async def test_auto_selects_litellm_when_key_set(self):
+        settings = Settings(
+            llm_provider="auto",
+            anthropic_api_key=None,
+            openai_api_key=None,
+            google_api_key=None,
+            openrouter_api_key=None,
+            openai_compatible_base_url="",
+            litellm_api_key="sk-litellm-test",
+        )
+        router = LLMRouter(settings)
+        assert await router._detect_backend() == "litellm"
+
+
+# ---------------------------------------------------------------------------
+# chat() routing for OpenAI-compatible providers (issue #795)
+# ---------------------------------------------------------------------------
+
+
+class TestChatOpenAICompatProviders:
+    """chat() must route openai_compatible / openrouter / gemini / litellm
+    through _chat_openai_compat and return the model response."""
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["openai_compatible", "openrouter", "gemini", "litellm"],
+    )
+    async def test_chat_routes_to_openai_compat(self, provider):
+        settings = Settings(llm_provider=provider)
+        router = LLMRouter(settings)
+        router._available_backend = provider
+
+        mock_message = MagicMock()
+        mock_message.content = "Hello from provider!"
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        mock_llm = MagicMock()
+        mock_llm.model = "test-model"
+        mock_llm.create_openai_client.return_value = mock_client
+
+        with patch("pocketpaw.llm.client.resolve_llm_client", return_value=mock_llm):
+            result = await router.chat("hi")
+
+        assert result == "Hello from provider!"
+        mock_llm.create_openai_client.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["openai_compatible", "openrouter", "gemini", "litellm"],
+    )
+    async def test_chat_openai_compat_empty_response(self, provider):
+        settings = Settings(llm_provider=provider)
+        router = LLMRouter(settings)
+        router._available_backend = provider
+
+        mock_response = MagicMock()
+        mock_response.choices = []
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        mock_llm = MagicMock()
+        mock_llm.model = "test-model"
+        mock_llm.create_openai_client.return_value = mock_client
+
+        with patch("pocketpaw.llm.client.resolve_llm_client", return_value=mock_llm):
+            result = await router.chat("hi")
+
+        assert result == FALLBACK


### PR DESCRIPTION
## fix: LLMRouter fails to detect and route multiple LLM providers (#795)

### Summary

`LLMRouter` only handled 3 providers (`ollama`, `openai`, `anthropic`), returning "No LLM backend available" for `openai_compatible`, `openrouter`, `gemini`, and `litellm`. The `auto` mode also only tried those 3 in a suboptimal order (Ollama first instead of cloud APIs).

This PR extends `LLMRouter` and `resolve_llm_client()` to correctly detect and route all supported providers.

Closes #795

---

### Changes

#### `src/pocketpaw/llm/router.py`

- **`_detect_backend()`** — Added detection for:
  - `openai_compatible` — requires `openai_compatible_base_url` to be set
  - `openrouter` — requires `openrouter_api_key` or `openai_compatible_api_key`
  - `gemini` — requires `google_api_key`
  - `litellm` — always available (proxy may not require a key)
- **`auto` mode** — Reordered priority to: Anthropic → OpenAI → Gemini → OpenRouter → OpenAI-compatible → LiteLLM → Ollama (cloud APIs first, local fallback last)
- **`chat()`** — Routes the 4 new providers to the new `_chat_openai_compat()` method
- **`_chat_openai_compat()`** — New method that uses `resolve_llm_client()` + `create_openai_client()` to build a correctly-configured OpenAI-compatible client for any of these providers
- Updated the "No backend available" error message to list all provider options

#### `src/pocketpaw/llm/client.py`

- **`resolve_llm_client()` `auto` mode** — Extended with the same provider cascade (gemini, openrouter, openai_compatible, litellm) to match the router

#### `tests/test_llm_router.py`

- **`TestDetectBackendProviders`** — 11 new tests covering detection of each new provider, missing-credential rejection, and auto-mode priority
- **`TestChatOpenAICompatProviders`** — 8 new parametrized tests covering successful routing and empty-response fallback for all 4 providers

---

### How it works

All 4 new providers support the OpenAI chat completions API, so they share a single `_chat_openai_compat()` method. This method delegates to the existing `resolve_llm_client()` → `LLMClient.create_openai_client()` pipeline, which already knows how to configure each provider's base URL, API key, and model via the provider adapter registry (`llm/providers/`).

---

### Testing

All 27 tests pass (8 existing + 19 new):

```
uv run pytest tests/test_llm_router.py -v
```

---

### Checklist

- [x] Branch is based on `dev` (not `main`)
- [x] PR targets the `dev` branch
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No secrets or credentials in the diff
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] No new config fields or secret fields added
- [x] No new optional dependencies added
