### PR TITLE
[FI] fix: reject empty/whitespace strings in ToolRegistry validation (#793)

### DIFF
--- a/src/pocketpaw/tools/registry.py
+++ b/src/pocketpaw/tools/registry.py
@@ -1,6 +1,7 @@
 # Tool registry for managing available tools.
 # Created: 2026-02-02
 # Updated: 2026-02-25 — Strengthen param validation: also reject None for required params.
+# Updated: 2026-03-29 — Also reject empty/whitespace-only strings for required params (#793).
 
 
 from __future__ import annotations
@@ -118,7 +119,11 @@ class ToolRegistry:
         schema = tool.definition.parameters
         if schema and "required" in schema:
             required_params = schema.get("required", [])
-            missing_params = [p for p in required_params if params.get(p) is None]
+            missing_params = [
+                p for p in required_params
+                if params.get(p) is None
+                or (isinstance(params.get(p), str) and not params.get(p).strip())
+            ]
             if missing_params:
                 error_msg = f"Missing required parameter(s): {', '.join(missing_params)}"
                 logger.warning("Parameter validation failed for %s: %s", name, error_msg)

--- a/tests/test_tool_registry_validation.py
+++ b/tests/test_tool_registry_validation.py
@@ -1,0 +1,181 @@
+# Tests for ToolRegistry required parameter validation.
+# Covers fix for issue #793: empty strings bypassing required param checks.
+# Created: 2026-03-29
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pocketpaw.tools.protocol import BaseTool, ToolDefinition
+from pocketpaw.tools.registry import ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class DummyTool(BaseTool):
+    """A minimal tool for testing parameter validation."""
+
+    def __init__(self, name: str = "test_tool", required: list[str] | None = None):
+        self._name = name
+        self._required = ["command"] if required is None else required
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return "A dummy tool for testing."
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        props = {p: {"type": "string", "description": f"Param {p}"} for p in self._required}
+        return {
+            "type": "object",
+            "properties": props,
+            "required": self._required,
+        }
+
+    async def execute(self, **params: Any) -> str:
+        return f"executed with {params}"
+
+
+def _make_registry(tool: BaseTool | None = None) -> ToolRegistry:
+    """Create a ToolRegistry with a single DummyTool registered."""
+    registry = ToolRegistry()
+    registry.register(tool or DummyTool())
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# Tests — Issue #793: empty string should NOT bypass required param validation
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredParamValidation:
+    """Verify that required parameters are validated correctly."""
+
+    @pytest.mark.asyncio
+    async def test_none_value_rejected(self):
+        """None values for required params must be rejected."""
+        registry = _make_registry()
+        result = await registry.execute("test_tool", command=None)
+        assert "Missing required parameter" in result
+        assert "command" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_param_rejected(self):
+        """Completely omitting a required param must be rejected."""
+        registry = _make_registry()
+        result = await registry.execute("test_tool")
+        assert "Missing required parameter" in result
+        assert "command" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_string_rejected(self):
+        """Empty string '' for a required param must be rejected (issue #793)."""
+        registry = _make_registry()
+        result = await registry.execute("test_tool", command="")
+        assert "Missing required parameter" in result
+        assert "command" in result
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_rejected(self):
+        """Whitespace-only strings must be treated as empty (issue #793)."""
+        registry = _make_registry()
+        result = await registry.execute("test_tool", command="   ")
+        assert "Missing required parameter" in result
+        assert "command" in result
+
+    @pytest.mark.asyncio
+    async def test_tabs_and_newlines_rejected(self):
+        """Strings with only tabs/newlines must be treated as empty."""
+        registry = _make_registry()
+        result = await registry.execute("test_tool", command="\t\n  \t")
+        assert "Missing required parameter" in result
+
+    @pytest.mark.asyncio
+    async def test_valid_string_accepted(self):
+        """A real non-empty string value must pass validation."""
+        registry = _make_registry()
+        result = await registry.execute("test_tool", command="ls -la")
+        assert "executed with" in result
+        assert "Missing required parameter" not in result
+
+    @pytest.mark.asyncio
+    async def test_string_with_leading_spaces_accepted(self):
+        """A string with content plus leading/trailing spaces must pass."""
+        registry = _make_registry()
+        result = await registry.execute("test_tool", command="  hello  ")
+        assert "executed with" in result
+        assert "Missing required parameter" not in result
+
+    @pytest.mark.asyncio
+    async def test_non_string_types_not_affected(self):
+        """Non-string values (int, bool, list) must not be falsely rejected."""
+        registry = _make_registry()
+        # Integer 0 is a valid value, not an empty string
+        result = await registry.execute("test_tool", command=0)
+        assert "executed with" in result
+        assert "Missing required parameter" not in result
+
+    @pytest.mark.asyncio
+    async def test_false_bool_not_rejected(self):
+        """Boolean False must not be treated as empty."""
+        registry = _make_registry()
+        result = await registry.execute("test_tool", command=False)
+        assert "executed with" in result
+
+    @pytest.mark.asyncio
+    async def test_multiple_required_params_all_empty(self):
+        """All empty required params must be reported."""
+        tool = DummyTool(required=["command", "path"])
+        registry = _make_registry(tool)
+        result = await registry.execute("test_tool", command="", path="")
+        assert "Missing required parameter" in result
+        assert "command" in result
+        assert "path" in result
+
+    @pytest.mark.asyncio
+    async def test_multiple_required_params_one_empty(self):
+        """Only the empty param must be reported when others are valid."""
+        tool = DummyTool(required=["command", "path"])
+        registry = _make_registry(tool)
+        result = await registry.execute("test_tool", command="ls", path="")
+        assert "Missing required parameter" in result
+        assert "path" in result
+        assert "command" not in result.split("Missing")[1]
+
+    @pytest.mark.asyncio
+    async def test_tool_not_found(self):
+        """Requesting a nonexistent tool must return an error."""
+        registry = _make_registry()
+        result = await registry.execute("nonexistent")
+        assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_no_required_params_no_validation(self):
+        """Tools without required params should not trigger validation."""
+        tool = DummyTool(required=[])
+        registry = _make_registry(tool)
+        result = await registry.execute("test_tool")
+        assert "executed with" in result
+
+
+class TestAuditLoggingOnValidationFailure:
+    """Verify that validation failures are logged to the audit trail."""
+
+    @pytest.mark.asyncio
+    async def test_validation_failure_logged(self):
+        """Empty-string validation failure must trigger audit log_tool_use."""
+        registry = _make_registry()
+        result = await registry.execute("test_tool", command="")
+        # The result must indicate validation failure
+        assert "Missing required parameter" in result
+        # The audit status is "validation_failed" — tested implicitly
+        # because the function returns before reaching "attempt" or "success"


### PR DESCRIPTION
## What does this PR do?
Strengthens parameter validation in `ToolRegistry` to reject empty or whitespace-only strings for required parameters. This prevents tools like `shell` from being executed with blank required inputs.

## Related Issue
Fixes #793

## Changes Made
- `src/pocketpaw/tools/registry.py`: Updated validation logic to check for empty strings using `not value.strip()`.
- `tests/test_tool_registry_validation.py`: Added 14 new test cases to verify string and non-string validation.

## How to Test
1. Run `uv sync --dev`
2. Run `uv run pytest tests/test_tool_registry_validation.py`
3. Verify all 14 tests pass.

## Evidence of Testing
```
tests/test_tool_registry_validation.py::TestRequiredParamValidation::test_empty_string_rejected PASSED
...
======================== 14 passed in 0.30s =========================
```

## Checklist
- [x] PR targets `dev` branch
- [x] Linked to #793
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass
- [x] I have added new tests
