### PR TITLE
[F1] fix: return warning status for Windows health check skip (#783)

### DIFF
--- a/src/pocketpaw/health/checks/config.py
+++ b/src/pocketpaw/health/checks/config.py
@@ -77,9 +77,9 @@ def check_config_permissions() -> HealthCheckResult:
             check_id="config_permissions",
             name="Config Permissions",
             category="config",
-            status="ok",
+            status="warning",
             message="Permission check skipped on Windows",
-            fix_hint="",
+            fix_hint="Ensure your user profile is protected by a password.",
         )
 
     path = get_config_path()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -281,7 +281,10 @@ class TestCheckConfigPermissions:
         config_path.chmod(0o600)
         with patch(_P_CONFIG_PATH, return_value=config_path):
             r = check_config_permissions()
-            assert r.status == "ok"
+            if sys.platform == "win32":
+                assert r.status == "warning"
+            else:
+                assert r.status == "ok"
 
     @pytest.mark.skipif(
         sys.platform == "win32",


### PR DESCRIPTION
## What does this PR do?
Fixes a misleading health check status on Windows. Currently, the permission check is skipped on Windows but returns status="ok" (green check), which is misleading. This PR changes it to status="warning".

## Related Issue
Fixes #783 
## Changes Made
- `src/pocketpaw/health/checks/config.py`: Updated `check_config_permissions()` to return `status="warning"` on Windows.
- - `tests/test_health.py`: Updated existing tests to expect `warning` status when running on Windows.
## Checklist
- [x] PR targets `dev` branch
- [ ] - [x] Linked to #783 - [x] I have run PocketPaw locally and tested my changes
- [ ] - [x] Tests pass