### PR TITLE
[FI] fix: replace deprecated on_event with lifespan context manager

### DIFF
--- a/src/pocketpaw/api/serve.py
+++ b/src/pocketpaw/api/serve.py
@@ -16,11 +16,21 @@ logger = logging.getLogger(__name__)
 
 def create_api_app():
     """Build a FastAPI application with v1 API routers and WebSocket."""
+    from contextlib import asynccontextmanager
+
     from fastapi import FastAPI, Query, WebSocket
     from fastapi.middleware.cors import CORSMiddleware
 
     from pocketpaw.api.v1 import mount_v1_routers
     from pocketpaw.config import Settings, get_access_token
+
+    @asynccontextmanager
+    async def _lifespan(app: FastAPI):
+        from pocketpaw.dashboard_lifecycle import shutdown_event, startup_event
+
+        await startup_event()
+        yield
+        await shutdown_event()
 
     app = FastAPI(
         title="PocketPaw API",
@@ -29,6 +39,7 @@ def create_api_app():
         docs_url="/api/v1/docs",
         redoc_url="/api/v1/redoc",
         openapi_url="/api/v1/openapi.json",
+        lifespan=_lifespan,
     )
 
     # --- Middleware (order matters: last added = outermost = runs first) --
@@ -113,19 +124,6 @@ def create_api_app():
     ):
         """WebSocket v1 short path — for clients using /v1/ws."""
         await _handle_ws(websocket, token, resume_session)
-
-    # --- Lifecycle events -----------------------------------------------
-    @app.on_event("startup")
-    async def startup():
-        from pocketpaw.dashboard_lifecycle import startup_event
-
-        await startup_event()
-
-    @app.on_event("shutdown")
-    async def shutdown():
-        from pocketpaw.dashboard_lifecycle import shutdown_event
-
-        await shutdown_event()
 
     return app
 

--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -29,6 +29,7 @@ import base64
 import io
 import json
 import logging
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 try:
@@ -118,6 +119,13 @@ TEMPLATES_DIR = FRONTEND_DIR / "templates"
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 # Create FastAPI app
+@asynccontextmanager
+async def _lifespan(app: "FastAPI"):
+    await _startup_event(_start_channel_adapter_fn=_start_channel_adapter)
+    yield
+    await _shutdown_event(_stop_channel_adapter_fn=_stop_channel_adapter)
+
+
 app = FastAPI(
     title="PocketPaw API",
     description="Self-hosted AI agent — REST API for external clients and the web dashboard.",
@@ -125,6 +133,7 @@ app = FastAPI(
     docs_url="/api/v1/docs",
     redoc_url="/api/v1/redoc",
     openapi_url="/api/v1/openapi.json",
+    lifespan=_lifespan,
 )
 
 # CORS — localhost + Cloudflare tunnel + Tauri desktop + custom origins from config
@@ -218,16 +227,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-
-@app.on_event("startup")
-async def startup_event():
-    await _startup_event(_start_channel_adapter_fn=_start_channel_adapter)
-
-
-@app.on_event("shutdown")
-async def shutdown_event():
-    await _shutdown_event(_stop_channel_adapter_fn=_stop_channel_adapter)
 
 
 # ==================== MCP Server API ====================


### PR DESCRIPTION
## Summary

- `@app.on_event("startup/shutdown")` was deprecated in FastAPI v0.93 and emits `DeprecationWarning` on every server start and test run (#807, #808)
- Both `dashboard.py` and `api/serve.py` used the old pattern
- Migrate to the modern `asynccontextmanager` lifespan approach, passing `lifespan=` directly to `FastAPI(...)` — the canonical fix described in the FastAPI docs

## Changes

- `src/pocketpaw/dashboard.py`: add `asynccontextmanager` import, define `_lifespan` before `app = FastAPI(...)`, add `lifespan=_lifespan`, remove the two `@app.on_event` functions
- `src/pocketpaw/api/serve.py`: same pattern inside `create_api_app()` — `_lifespan` is defined as a nested function so it can close over the lifecycle imports already present

No behaviour change; startup and shutdown hooks fire in identical order.

## Test plan

- [ ] `uv run pocketpaw` — no `DeprecationWarning` about `on_event` in output
- [ ] `uv run pytest --ignore=tests/e2e` — no `DeprecationWarning` in test output, all existing tests pass
- [ ] `pocketpaw serve` (API-only mode) — server starts and shuts down cleanly

Closes #807
Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)