### PR TITLE
fix: reject empty and whitespace-only strings in ToolRegistry required param validation

### DIFF
--- a/src/pocketpaw/tools/registry.py
+++ b/src/pocketpaw/tools/registry.py
@@ -118,7 +118,12 @@ class ToolRegistry:
         schema = tool.definition.parameters
         if schema and "required" in schema:
             required_params = schema.get("required", [])
-            missing_params = [p for p in required_params if params.get(p) is None]
+            missing_params = [
+                p
+                for p in required_params
+                if params.get(p) is None
+                or (isinstance(params.get(p), str) and not params[p].strip())
+            ]
             if missing_params:
                 error_msg = f"Missing required parameter(s): {', '.join(missing_params)}"
                 logger.warning("Parameter validation failed for %s: %s", name, error_msg)


### PR DESCRIPTION
## Summary

- `ToolRegistry.execute()` checked required parameters for `None` only (#793)
- Passing `""` or `"   "` for a required parameter silently bypassed validation and let the tool execute with a blank value — producing cryptic errors deep inside the tool rather than a clear message at the call site
- One-line fix: extend the existing comprehension to also reject `str` values that are empty after `.strip()`

## Changes

**`src/pocketpaw/tools/registry.py`** — line 121

```python
# Before
missing_params = [p for p in required_params if params.get(p) is None]

# After
missing_params = [
    p
    for p in required_params
    if params.get(p) is None
    or (isinstance(params.get(p), str) and not params[p].strip())
]
```

Non-string types (`int`, `bool`, `list`, `dict`, …) are unaffected — `0`, `False`, and `[]` still pass through as legitimate values.

## Test plan

- [ ] Call a tool with a required `str` param set to `""` → returns `Error: Tool '...' Missing required parameter(s): ...`
- [ ] Call a tool with a required `str` param set to `"   "` → same error
- [ ] Call a tool with a required `int` param set to `0` → passes validation (not falsely flagged)
- [ ] `uv run pytest --ignore=tests/e2e` passes

Fixes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)