### PR TITLE
[FI] fix: normalize CPU/RAM/Disk fallback display to use '—' instead of raw string

### DIFF
--- a/src/pocketpaw/frontend/templates/components/sidebar.html
+++ b/src/pocketpaw/frontend/templates/components/sidebar.html
@@ -392,15 +392,15 @@
       <div class="grid grid-cols-4 gap-1 mt-2 px-1 py-2 bg-black/20 rounded-lg">
         <div class="text-center">
           <div class="text-[10px] text-white/30">CPU</div>
-          <div class="text-[11px] font-mono text-white/70" x-text="typeof status.cpu === 'number' ? status.cpu + '%' : status.cpu"></div>
+          <div class="text-[11px] font-mono text-white/70" x-text="typeof status.cpu === 'number' ? status.cpu + '%' : '—'"></div>
         </div>
         <div class="text-center">
           <div class="text-[10px] text-white/30">RAM</div>
-          <div class="text-[11px] font-mono text-white/70" x-text="typeof status.ram === 'number' ? status.ram + '%' : status.ram"></div>
+          <div class="text-[11px] font-mono text-white/70" x-text="typeof status.ram === 'number' ? status.ram + '%' : '—'"></div>
         </div>
         <div class="text-center">
           <div class="text-[10px] text-white/30">Disk</div>
-          <div class="text-[11px] font-mono text-white/70" x-text="typeof status.disk === 'number' ? status.disk + '%' : status.disk"></div>
+          <div class="text-[11px] font-mono text-white/70" x-text="typeof status.disk === 'number' ? status.disk + '%' : '—'"></div>
         </div>
         <div class="text-center">
           <div class="text-[10px] text-white/30">Bat</div>


### PR DESCRIPTION
## What does this PR do?
Normalizes the fallback display for CPU, RAM, and Disk status widgets in the sidebar to show '—' instead of the raw string '...' during loading.

## Related Issue
Fixes #816

## Changes Made
- `src/pocketpaw/frontend/templates/components/sidebar.html`: Changed fallback from raw variable to '—' for CPU, RAM, and Disk widgets

## How to Test
1. Run `uv run pocketpaw --dev`
2. Open dashboard at localhost:8888
3. Check CPU/RAM/Disk widgets during initial load
4. Should show '—' instead of '...'

## Evidence of Testing
Tested locally on Windows — widgets show '—' consistently.

## Checklist
- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff