### PR TITLE
[FI] fix: use AsyncMock for neonize preflight test to avoid real network call

### DIFF
--- a/tests/test_neonize_adapter.py
+++ b/tests/test_neonize_adapter.py
@@ -294,6 +294,7 @@ async def test_bus_integration(bus):
 
 async def test_preflight_check_passes_when_reachable():
     """Preflight check succeeds when the host is reachable."""
-    with patch("pocketpaw.bus.adapters.neonize_adapter._tcp_probe", return_value=None):
+    with patch("pocketpaw.bus.adapters.neonize_adapter._tcp_probe", new_callable=AsyncMock):
+
         # Should not raise
         await NeonizeAdapter._preflight_connectivity_check()


### PR DESCRIPTION
## What does this PR do?
Fixes a test that was making real network calls to web.whatsapp.com:443 during testing.

## Related Issue
Fixes #821

## Changes Made
- `tests/test_neonize_adapter.py`: Changed `return_value=None` to `new_callable=AsyncMock` for patching `_tcp_probe` since it is an async function

## How to Test
1. Run `uv run pytest tests/test_neonize_adapter.py::test_preflight_check_passes_when_reachable -v`
2. Test should pass without any network access

## Evidence of Testing
Before: FAILED — ConnectionError: Cannot reach web.whatsapp.com:443
After:  PASSED in 0.25s — no network call made

## Checklist
- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff 
<img width="1466" height="375" alt="image" src="https://github.com/user-attachments/assets/b0fdae5a-2f1b-4bf8-8093-ec27a81ce7ca" />

<img width="1696" height="781" alt="image" src="https://github.com/user-attachments/assets/b7a71d94-0623-4875-8d9c-5aa1c9e3d78b" />
