### PR TITLE
Fix pocket context injection — restore session continuity

### DIFF
--- a/src/pocketpaw/bootstrap/context_builder.py
+++ b/src/pocketpaw/bootstrap/context_builder.py
@@ -180,7 +180,20 @@ class AgentContextBuilder:
 
         # 4c. Inject pocket creation context (from pocket chat endpoint)
         if metadata and metadata.get("pocket_system_context"):
-            parts.append(metadata["pocket_system_context"])
+            blocks.append(("pocket_context", _Priority.HIGH, metadata["pocket_system_context"]))
+
+        # 4d. Inject current pocket info so the AI knows what pocket is open
+        if metadata and metadata.get("pocket_context"):
+            import json
+            pc = metadata["pocket_context"]
+            pocket_tag = (
+                f"\n<current-pocket>\n"
+                f"id: {pc.get('id', 'unknown')}\n"
+                f"name: {pc.get('name', 'Untitled')}\n"
+                f"widgets: {json.dumps(pc.get('widgets', []))}\n"
+                f"</current-pocket>\n"
+            )
+            blocks.append(("current_pocket", _Priority.HIGH, pocket_tag))
 
         # 5. Inject session key for session management tools
         if session_key:


### PR DESCRIPTION
## Problem

Pocket chat was broken in two ways:

1. **NameError crash** — `context_builder.py:183` used `parts.append()` but the variable was renamed to `blocks` during a priority-based prompt assembly refactor. Every pocket chat message silently crashed the system prompt builder, so the AI never received pocket creation instructions (UISpec formats, layout system, etc.)

2. **No current pocket awareness** — The frontend sends `pocket_context` (pocket ID, name, widgets) on every message via the `pocketChat()` API. The backend stored it in metadata but never injected it into the system prompt. The AI couldn't answer "what's this pocket about?" or know which pocket to modify.

## Fix

- Changed `parts.append()` to `blocks.append(("pocket_context", _Priority.HIGH, ...))` to match the priority-block pattern
- Added `<current-pocket>` tag injection into the system prompt with the pocket's ID, name, and widget list — matching what the pocket system prompt teaches the AI to look for

## Test plan
- [x] Prompt "what's this pocket about?" now returns pocket-specific info
- [x] Follow-up edits ("add a chart widget") correctly target the open pocket
- [x] New pocket creation still works (UISpec, flat widgets, multi-pane)