### PR TITLE
[FI] Fix README virtual environment setup issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 .venv/
 venv/
 ENV/
+pocketpaw-env
 
 # UV
 .uv/

--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ pip install pocketpaw
 pocketpaw
 ```
 
+### ⚠️ Virtual Environment Issue (Important)
+
+In some environments, running PocketPaw inside a virtual environment may result in a runtime error:
+
+
+This is likely caused by incompatible versions of dependencies (e.g., Jinja2 / Starlette) being installed inside the virtual environment.
+
+#### ✅ Workarounds:
+
+- Run PocketPaw using system Python instead of a virtual environment:
+  ```bash
+  pip install pocketpaw
+  pocketpaw
+
+  Or ensure compatible dependency versions:
+  pip install "jinja2>=3.1.2,<3.2" "starlette>=0.27,<0.28"
+
 **Or use the automated install script:**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ python3 --version
 # 2. Upgrade pip to latest version
 python3 -m pip install --upgrade pip
 
-# 3. Create and activate virtual environment (optional but recommended)
+# 3. Create and activate virtual environment (recommended)
 python3 -m venv pocketpaw-env
 source pocketpaw-env/bin/activate
 
@@ -85,26 +85,13 @@ pocketpaw
 ```
 
 ### ⚠️ Virtual Environment Issue (Important)
+If you're running PocketPaw **v0.4.15 or earlier** inside a virtual environment, you may encounter a `500 Internal Server Error` with `TypeError: unhashable type: 'dict'` when opening the dashboard.
 
-In some environments, running PocketPaw inside a virtual environment may result in a runtime error:
+**Cause:** Starlette 1.0.0 removed the old `TemplateResponse(name, context)` API. A fresh virtual environment resolves the latest Starlette (1.0+), which exposed this incompatibility.
 
-
-This is likely caused by incompatible versions of dependencies (e.g., Jinja2 / Starlette) being installed inside the virtual environment.
-
-#### ✅ Workarounds:
-
-- Run PocketPaw using system Python instead of a virtual environment:
-  ```bash
-  pip install pocketpaw
-  pocketpaw
-
-  Or ensure compatible dependency versions:
-  pip install "jinja2>=3.1.2,<3.2" "starlette>=0.27,<0.28"
-
-**Or use the automated install script:**
-
+**Fix:** This has been resolved in the current version. Ensure you are running the latest PocketPaw:
 ```bash
-curl -fsSL https://pocketpaw.xyz/install.sh | sh
+pip install --upgrade pocketpaw
 ```
 
 </details>

--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -115,7 +115,13 @@ FRONTEND_DIR = Path(__file__).parent / "frontend"
 TEMPLATES_DIR = FRONTEND_DIR / "templates"
 
 # Initialize Templates
-templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+from jinja2 import Environment, FileSystemLoader
+jinja_env = Environment(
+    loader=FileSystemLoader(str(TEMPLATES_DIR)),
+    cache_size=0,  # Disable template caching for development; set to a positive int for production)
+    )
+templates = Jinja2Templates(env=jinja_env)
+templates.env.globals.clear() # Clear default globals to prevent accidental access to unsafe functions like `open`
 
 # Create FastAPI app
 app = FastAPI(
@@ -909,16 +915,16 @@ async def get_version_info():
     info = await check_for_updates_async(current, get_config_dir())
     return info or {"current": current, "latest": current, "update_available": False}
 
-
+from fastapi import HTMLResponse
 @app.get("/")
 async def index(request: Request):
     """Serve the main dashboard page."""
     from importlib.metadata import version as get_version
 
-    return templates.TemplateResponse(
-        "base.html",
-        {"request": request, "v": _static_version(), "app_version": get_version("pocketpaw")},
-    )
+    template = templates.get_template("base.html")
+    html = template.render(request=request, v=str(_static_version()), app_version=str(get_version("pocketpaw"))) 
+    return HTMLResponse(content=html, status_code=200)
+    
 
 
 # NOTE: Session token exchange, cookie login/logout, QR code, and token

--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -115,13 +115,7 @@ FRONTEND_DIR = Path(__file__).parent / "frontend"
 TEMPLATES_DIR = FRONTEND_DIR / "templates"
 
 # Initialize Templates
-from jinja2 import Environment, FileSystemLoader
-jinja_env = Environment(
-    loader=FileSystemLoader(str(TEMPLATES_DIR)),
-    cache_size=0,  # Disable template caching for development; set to a positive int for production)
-    )
-templates = Jinja2Templates(env=jinja_env)
-templates.env.globals.clear() # Clear default globals to prevent accidental access to unsafe functions like `open`
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 # Create FastAPI app
 app = FastAPI(
@@ -915,16 +909,17 @@ async def get_version_info():
     info = await check_for_updates_async(current, get_config_dir())
     return info or {"current": current, "latest": current, "update_available": False}
 
-from fastapi import HTMLResponse
+
 @app.get("/")
 async def index(request: Request):
     """Serve the main dashboard page."""
     from importlib.metadata import version as get_version
 
-    template = templates.get_template("base.html")
-    html = template.render(request=request, v=str(_static_version()), app_version=str(get_version("pocketpaw"))) 
-    return HTMLResponse(content=html, status_code=200)
-    
+    return templates.TemplateResponse(
+        request,
+        "base.html",
+        {"v": _static_version(), "app_version": get_version("pocketpaw")},
+    )
 
 
 # NOTE: Session token exchange, cookie login/logout, QR code, and token

--- a/src/pocketpaw/frontend/templates/base.html
+++ b/src/pocketpaw/frontend/templates/base.html
@@ -122,7 +122,7 @@
       }
     </style>
   </head>
-  <body class="loading flex h-screen overflow-hidden bg-[var(--bg-color)] text-[var(--text-primary)]" x-data="{ ...app(), sidebarOpen: false }" x-init="init()">
+  <body class="loading flex h-screen overflow-hidden bg-(--bg-color) text-(--text-primary)" x-data="Object.assign({}, app(), { sidebarOpen: false })" x-init="init()">
 
     <!-- Preloader (visible immediately, hidden once app is ready) -->
     <div id="preloader">


### PR DESCRIPTION
Fixes #839 

### Issue
Running PocketPaw inside a virtual environment (as per README instructions) causes a dashboard crash with:
TypeError: unhashable type: 'dict'

### Cause
Likely due to dependency incompatibility inside virtual environments.

### Fix
- Added warning in README, at lines of '87 - 102'
- Provided workaround instructions

### Impact
Improves onboarding experience and prevents confusion, while saving time for new users / beginners.