### PR TITLE
Fix cloud module bootstrap — seed workspace + mount in dashboard

### DIFF
--- a/ee/cloud/auth/__init__.py
+++ b/ee/cloud/auth/__init__.py
@@ -13,6 +13,7 @@ from ee.cloud.auth.core import (  # noqa: F401
     UserCreate,
     UserManager,
     seed_admin,
+    seed_workspace,
     SECRET,
     TOKEN_LIFETIME,
 )

--- a/ee/cloud/auth/core.py
+++ b/ee/cloud/auth/core.py
@@ -1,5 +1,8 @@
 """Enterprise auth — fastapi-users with JWT cookie + bearer transport.
 
+Changes: Added seed_workspace() to auto-create default workspace + General group
+on first boot, so admin can immediately use the app after seeding.
+
 Provides:
 - POST /auth/register — sign up with email + password
 - POST /auth/login — sign in, returns JWT cookie + token
@@ -8,6 +11,7 @@ Provides:
 - PATCH /auth/me — update profile
 
 Admin seeding: call seed_admin() on startup to ensure a default admin exists.
+Workspace seeding: call seed_workspace() after seed_admin() to bootstrap first workspace.
 """
 
 from __future__ import annotations
@@ -30,6 +34,7 @@ from fastapi_users import schemas as fastapi_users_schemas
 from pydantic import BaseModel
 
 from ee.cloud.models.user import OAuthAccount, User, WorkspaceMembership
+from ee.cloud.models.workspace import Workspace, WorkspaceSettings
 
 logger = logging.getLogger(__name__)
 
@@ -168,4 +173,81 @@ async def seed_admin(
         return await User.find_one(User.email == email)
     except Exception as exc:
         logger.error("Failed to seed admin: %s", exc)
+        return None
+
+
+async def seed_workspace(admin: User | None = None) -> Workspace | None:
+    """Create a default workspace and General chat group if none exist.
+
+    Called after seed_admin() on startup. Skips if any workspace already exists.
+    """
+    from datetime import UTC, datetime
+
+    if admin is None:
+        admin = await User.find_one(User.is_superuser == True)  # noqa: E712
+        if not admin:
+            logger.debug("No admin user found — skipping workspace seed")
+            return None
+
+    # Skip if admin already has a workspace
+    if admin.workspaces:
+        logger.debug("Admin already has workspace(s) — skipping seed")
+        return None
+
+    # Also skip if any workspace exists at all
+    existing = await Workspace.find_one()
+    if existing:
+        logger.debug("Workspace already exists — skipping seed")
+        return None
+
+    ws_name = os.environ.get("DEFAULT_WORKSPACE_NAME", "PocketPaw")
+    ws_slug = os.environ.get("DEFAULT_WORKSPACE_SLUG", "pocketpaw")
+
+    try:
+        ws = Workspace(
+            name=ws_name,
+            slug=ws_slug,
+            owner=str(admin.id),
+            plan="enterprise",
+            seats=50,
+            settings=WorkspaceSettings(),
+        )
+        await ws.insert()
+
+        admin.workspaces.append(
+            WorkspaceMembership(
+                workspace=str(ws.id),
+                role="owner",
+                joined_at=datetime.now(UTC),
+            )
+        )
+        admin.active_workspace = str(ws.id)
+        await admin.save()
+
+        logger.info(
+            "Default workspace created: %s (slug: %s, id: %s)",
+            ws_name, ws_slug, ws.id,
+        )
+
+        # Create a default "General" chat group
+        try:
+            from ee.cloud.models.group import Group
+
+            group = Group(
+                workspace=str(ws.id),
+                name="General",
+                slug="general",
+                description="Default channel for team discussion",
+                type="public",
+                owner=str(admin.id),
+                members=[str(admin.id)],
+            )
+            await group.insert()
+            logger.info("Default 'General' group created in workspace %s", ws_name)
+        except Exception as exc:
+            logger.warning("Failed to create default group (non-fatal): %s", exc)
+
+        return ws
+    except Exception as exc:
+        logger.error("Failed to seed workspace: %s", exc)
         return None

--- a/src/pocketpaw/api/serve.py
+++ b/src/pocketpaw/api/serve.py
@@ -69,8 +69,9 @@ def create_api_app():
     try:
         from ee.cloud import mount_cloud
         mount_cloud(app)
-    except ImportError:
-        pass
+        logger.info("Enterprise cloud module mounted successfully")
+    except ImportError as exc:
+        logger.debug("Enterprise cloud module not available: %s", exc)
     except Exception:
         logger.warning("Cloud module mount failed", exc_info=True)
 

--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -189,6 +189,16 @@ app.include_router(mission_control_router, prefix="/api/mission-control")
 
 app.include_router(deep_work_router, prefix="/api/deep-work")
 
+# Mount enterprise cloud module FIRST (takes priority over core v1 routers)
+try:
+    from ee.cloud import mount_cloud
+    mount_cloud(app)
+    logger.info("Enterprise cloud module mounted successfully")
+except ImportError as exc:
+    logger.debug("Enterprise cloud module not available: %s", exc)
+except Exception:
+    logger.warning("Cloud module mount failed", exc_info=True)
+
 # Mount API v1 routers at /api/v1/ (canonical) — see api/v1/__init__.py
 mount_v1_routers(app)
 

--- a/src/pocketpaw/dashboard_lifecycle.py
+++ b/src/pocketpaw/dashboard_lifecycle.py
@@ -179,9 +179,10 @@ async def startup_event(
 
         mongo_uri = os.environ.get("CLOUD_MONGODB_URI", "mongodb://localhost:27017/paw-enterprise")
         await init_cloud_db(mongo_uri)
-        # Seed default admin user
-        from ee.cloud.auth import seed_admin
-        await seed_admin()
+        # Seed default admin user and workspace
+        from ee.cloud.auth.core import seed_admin, seed_workspace
+        admin = await seed_admin()
+        await seed_workspace(admin)
     except ImportError:
         logger.debug("Enterprise cloud module not available — skipping MongoDB init")
     except Exception as exc:


### PR DESCRIPTION
## What broke

Fresh installs with the ee/cloud module couldn't get past the login screen. Three compounding issues:

1. **Cloud routes never mounted in dashboard mode** — `mount_cloud()` was only called in `serve.py` (API-only mode), but `uv run pocketpaw` uses `dashboard.py`. All `/api/v1/auth/*`, `/api/v1/workspaces`, `/api/v1/chat/*` endpoints returned 404.

2. **No workspace after seeding** — `seed_admin()` created the admin user but never created a workspace. Every cloud endpoint requires `current_workspace_id`, so the admin could log in but immediately hit "No active workspace" on every request.

3. **Silent failures** — `ImportError` was caught with bare `pass`, hiding the fact that enterprise deps weren't installed or the module failed to load.

## What this fixes

- Mount `ee.cloud` routes in `dashboard.py` before v1 routers (same pattern as `serve.py`)
- Add `seed_workspace()` that runs after `seed_admin()` on startup:
  - Creates default "PocketPaw" workspace (enterprise plan, 50 seats)
  - Sets admin as owner with `active_workspace` linked
  - Creates default "General" public chat group
  - Fully idempotent — skips if workspace already exists
  - Workspace name/slug configurable via `DEFAULT_WORKSPACE_NAME` / `DEFAULT_WORKSPACE_SLUG` env vars
- Better logging: cloud mount success/failure now visible in startup output

## Test plan

- [ ] Drop MongoDB (`mongosh --eval "use paw-enterprise; db.dropDatabase()"`)
- [ ] Run `uv sync --extra enterprise` then `uv run pocketpaw`
- [ ] Verify startup logs show "Enterprise cloud module mounted successfully"
- [ ] `POST /api/v1/auth/bearer/login` with admin credentials returns JWT
- [ ] `GET /api/v1/auth/me` shows `activeWorkspace` populated
- [ ] `GET /api/v1/workspaces` returns the seeded workspace
- [ ] `GET /api/v1/chat/groups` returns the "General" group
- [ ] Restart server — verify seeding is skipped (idempotent)