### PR TITLE
Configurable cheaper model for soul cognitive processing

### DIFF
--- a/ee/cloud/pockets/schemas.py
+++ b/ee/cloud/pockets/schemas.py
@@ -1,4 +1,9 @@
-"""Pockets domain — request/response schemas."""
+"""Pockets domain — request/response schemas.
+
+Changes: Added agents, rippleSpec (aliased), and widgets fields to CreatePocketRequest
+so the frontend can pass the full pocket spec on creation instead of requiring
+separate follow-up calls.
+"""
 
 from __future__ import annotations
 
@@ -16,7 +21,9 @@ class CreatePocketRequest(BaseModel):
     color: str = ""
     visibility: str = Field(default="private", pattern="^(private|workspace|public)$")
     session_id: str | None = Field(default=None, alias="sessionId")
+    agents: list[str] = Field(default_factory=list)  # Agent IDs to assign
     ripple_spec: dict | None = Field(default=None, alias="rippleSpec")
+    widgets: list[dict] = Field(default_factory=list)  # Initial widget definitions
 
     model_config = {"populate_by_name": True}
 

--- a/ee/cloud/pockets/service.py
+++ b/ee/cloud/pockets/service.py
@@ -80,7 +80,23 @@ class PocketService:
     async def create(
         workspace_id: str, user_id: str, body: CreatePocketRequest
     ) -> dict:
-        """Create a pocket. Optionally link an existing session."""
+        """Create a pocket with optional agents, widgets, and rippleSpec."""
+        # Build initial widgets from request body
+        initial_widgets: list[Widget] = []
+        for w in body.widgets:
+            initial_widgets.append(Widget(
+                name=w.get("name", "Widget"),
+                type=w.get("type", "custom"),
+                icon=w.get("icon", ""),
+                color=w.get("color", ""),
+                span=w.get("span", "col-span-1"),
+                dataSourceType=w.get("dataSourceType", w.get("data_source_type", "static")),
+                config=w.get("config", {}),
+                props=w.get("props", {}),
+                data=w.get("data"),
+                assignedAgent=w.get("assignedAgent", w.get("assigned_agent")),
+            ))
+
         pocket = Pocket(
             workspace=workspace_id,
             name=body.name,
@@ -90,6 +106,8 @@ class PocketService:
             color=body.color,
             owner=user_id,
             visibility=body.visibility,
+            agents=body.agents,
+            widgets=initial_widgets,
             rippleSpec=normalize_ripple_spec(body.ripple_spec) if body.ripple_spec else None,
         )
         await pocket.insert()

--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -243,7 +243,9 @@ class AgentLoop:
                 engine = PocketPawCognitiveEngine(
                     backend_provider=lambda: (
                         self._get_router()._backend if self._router is not None else None
-                    )
+                    ),
+                    model=settings.soul_cognitive_model,
+                    api_key=settings.anthropic_api_key or "",
                 )
 
                 self._soul_manager = SoulManager(settings)

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,7 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-04-04: Added soul_cognitive_model setting for cheaper cognitive processing.
   - 2026-03-16: Use Literal types for whatsapp_mode, tts_provider, stt_provider (#638).
   - 2026-02-17: Added health_check_on_startup field for Health Engine.
   - 2026-02-14: Add migration warning for old ~/.pocketclaw/ config dir and POCKETCLAW_ env vars.
@@ -848,6 +849,15 @@ class Settings(BaseSettings):
             "mood_inertia: resistance to mood change (0-1). "
             "tired_threshold: energy level that triggers fatigue. "
             "auto_regen: passive energy recovery rate."
+        ),
+    )
+
+    soul_cognitive_model: str = Field(
+        default="",
+        description=(
+            "Model to use for soul cognitive processing (sentiment, significance, "
+            "fact/entity extraction). Empty = use main agent backend. Set to a cheaper "
+            "model like 'claude-haiku-4-5-20251001' to reduce cost. Requires anthropic SDK."
         ),
     )
 

--- a/src/pocketpaw/soul/cognitive.py
+++ b/src/pocketpaw/soul/cognitive.py
@@ -1,7 +1,14 @@
 """PocketPaw CognitiveEngine bridge.
 
-Routes soul cognitive tasks to PocketPaw's active agent backend.
-No extra API key — uses the same LLM powering the conversation.
+Routes soul cognitive tasks to PocketPaw's active agent backend,
+or to a cheaper dedicated model via the Anthropic SDK when configured.
+
+Changes:
+  - 2026-04-04: Added optional `model` parameter for direct Anthropic API calls.
+    When `model` is set (e.g. "claude-haiku-4-5-20251001"), bypasses the main
+    backend and calls the Anthropic Messages API directly, reducing cost for
+    the 5-6 cognitive calls per user message. Falls back to main backend on
+    any failure or if the anthropic SDK is unavailable.
 
 Created: feat/pocketpaw-cognitive-engine
 - PocketPawCognitiveEngine implements the CognitiveEngine protocol
@@ -13,6 +20,7 @@ Created: feat/pocketpaw-cognitive-engine
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -47,6 +55,11 @@ class PocketPawCognitiveEngine:
     the same LLM for cognitive tasks (significance, fact extraction,
     reflection, sentiment) that drives the main conversation.
 
+    When ``model`` is provided, uses a direct Anthropic SDK call with that
+    model instead of routing through the main backend. This allows using a
+    cheaper model (e.g. Haiku) for the high-volume cognitive pipeline while
+    keeping the main conversation on a stronger model (e.g. Sonnet).
+
     The backend is resolved lazily via `backend_provider` so this engine
     can be created before the AgentRouter is initialised (which happens on
     the first in-bound message, after soul initialisation).
@@ -54,29 +67,74 @@ class PocketPawCognitiveEngine:
     Args:
         backend_provider: A zero-arg callable that returns the active
             AgentBackend instance, or None if no backend is ready yet.
+        model: Optional model name for direct Anthropic API calls.
+            Empty string or None means use the main backend.
+        api_key: Optional Anthropic API key. Falls back to ANTHROPIC_API_KEY env var.
     """
 
-    def __init__(self, backend_provider: Callable[[], AgentBackend | None]) -> None:
+    def __init__(
+        self,
+        backend_provider: Callable[[], AgentBackend | None],
+        model: str = "",
+        api_key: str | None = None,
+    ) -> None:
         self._backend_provider = backend_provider
+        self._model = model or ""
+        self._api_key = api_key
+        self._anthropic_client: Any | None = None  # Lazy-initialized
+
+    def _get_anthropic_client(self) -> Any | None:
+        """Lazily initialize and return the Anthropic async client.
+
+        Returns None if the SDK is not installed or no API key is available.
+        """
+        if self._anthropic_client is not None:
+            return self._anthropic_client
+
+        try:
+            import anthropic
+        except ImportError:
+            logger.warning(
+                "anthropic SDK not installed — soul_cognitive_model requires it. "
+                "Falling back to main backend."
+            )
+            return None
+
+        key = self._api_key or os.environ.get("ANTHROPIC_API_KEY", "")
+        if not key:
+            logger.warning(
+                "No Anthropic API key available for soul cognitive model. "
+                "Falling back to main backend."
+            )
+            return None
+
+        self._anthropic_client = anthropic.AsyncAnthropic(api_key=key)
+        return self._anthropic_client
 
     # ------------------------------------------------------------------
     # CognitiveEngine protocol
     # ------------------------------------------------------------------
 
     async def think(self, prompt: str) -> str:
-        """Send a prompt to the active backend and return the full response.
+        """Send a prompt to the configured model and return the full response.
 
-        Streams events from `backend.run()` and concatenates the content
-        from all message-type events.  Returns an empty string on any
-        failure so the soul falls back to heuristics gracefully.
+        When a dedicated cognitive model is configured, tries the direct
+        Anthropic API first. Falls back to the main backend on any failure.
 
         Args:
             prompt: The cognitive task prompt (contains a [TASK:xxx] marker
                 and structured input as formatted by soul-protocol's CognitiveProcessor).
 
         Returns:
-            The concatenated text response from the backend, or "" on failure.
+            The concatenated text response, or "" on failure.
         """
+        # Try the dedicated cognitive model first
+        if self._model:
+            result = await self._think_direct(prompt)
+            if result is not None:
+                return result
+            # Fall through to backend on failure
+
         backend = self._backend_provider()
         if backend is None:
             logger.debug("PocketPawCognitiveEngine.think(): no backend available, returning empty")
@@ -92,7 +150,42 @@ class PocketPawCognitiveEngine:
             return ""
 
     # ------------------------------------------------------------------
-    # Internal helpers
+    # Direct Anthropic API path (cheaper model)
+    # ------------------------------------------------------------------
+
+    async def _think_direct(self, prompt: str) -> str | None:
+        """Call the Anthropic Messages API directly with the configured model.
+
+        Returns the response text on success, or None to signal fallback
+        to the main backend.
+        """
+        client = self._get_anthropic_client()
+        if client is None:
+            return None
+
+        try:
+            response = await client.messages.create(
+                model=self._model,
+                max_tokens=1024,
+                system=_COGNITIVE_SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            # Extract text from the response content blocks
+            text_parts = []
+            for block in response.content:
+                if hasattr(block, "text"):
+                    text_parts.append(block.text)
+            return "".join(text_parts).strip()
+        except Exception:
+            logger.warning(
+                "Direct Anthropic call failed (model=%s), falling back to main backend",
+                self._model,
+                exc_info=True,
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # Main backend path (streaming)
     # ------------------------------------------------------------------
 
     async def _stream_to_text(self, backend: Any, prompt: str) -> str:


### PR DESCRIPTION
## Problem

The soul's cognitive pipeline runs 5-6 sequential LLM calls per user message (sentiment, significance, fact extraction, entity extraction, self-model update), all routed through the main conversation model (e.g. Sonnet). This is expensive for background processing that doesn't need the strongest model.

## Solution

New `soul_cognitive_model` config setting that routes cognitive calls to a cheaper model via direct Anthropic API.

```bash
pocketpaw config set soul_cognitive_model claude-haiku-4-5-20251001
```

### How it works

- `PocketPawCognitiveEngine` now accepts optional `model` and `api_key` params
- When `model` is set, tries direct `anthropic.AsyncAnthropic().messages.create()` first
- Falls back to main backend on any failure (SDK missing, API error, etc.)
- Lazy client initialization — no overhead when not configured
- Empty string (default) = use main backend, same as before

### Files changed

- `config.py` — `soul_cognitive_model` setting with `POCKETPAW_` env prefix
- `soul/cognitive.py` — Direct Anthropic API path with fallback
- `agents/loop.py` — Wires config into engine constructor

## Test plan

- [ ] Default behavior unchanged (empty model = main backend)
- [ ] Set `soul_cognitive_model` to Haiku — verify cognitive calls use Haiku
- [ ] Remove anthropic SDK — verify graceful fallback to main backend
- [ ] Invalid API key — verify fallback to main backend