### PR TITLE
fix(security): authenticate WebSocket scopes in AuthMiddleware

### DIFF
--- a/src/pocketpaw/dashboard_auth.py
+++ b/src/pocketpaw/dashboard_auth.py
@@ -131,24 +131,132 @@ async def verify_token(
 
 
 # ---------------------------------------------------------------------------
-# HTTP auth middleware (registered by dashboard.py via app.add_middleware)
+# WebSocket scope authentication (used by AuthMiddleware — issue #883)
+# ---------------------------------------------------------------------------
+
+
+def _ws_scope_auth_ok(scope: dict) -> bool:
+    """Return True if the raw ASGI WebSocket *scope* carries valid auth.
+
+    Checks — in order — query-string ``token`` param, ``Cookie`` header
+    (``pocketpaw_session``), ``Authorization: Bearer …`` header,
+    ``Sec-WebSocket-Protocol`` header, and genuine-localhost bypass.
+
+    This runs *before* the WebSocket upgrade completes so that
+    unauthenticated connections are rejected immediately.
+    """
+    from urllib.parse import parse_qs
+
+    current_token = get_access_token()
+
+    # --- helpers -----------------------------------------------------------
+
+    def _tok_ok(t: str | None) -> bool:
+        if not t:
+            return False
+        if hmac.compare_digest(t, current_token):
+            return True
+        if ":" in t and verify_session_token(t, current_token):
+            return True
+        if t.startswith("pp_") and not t.startswith("ppat_"):
+            try:
+                from pocketpaw.api.api_keys import get_api_key_manager
+
+                if get_api_key_manager().verify(t) is not None:
+                    return True
+            except Exception:
+                pass
+        if t.startswith("ppat_"):
+            try:
+                from pocketpaw.api.oauth2.server import get_oauth_server
+
+                if get_oauth_server().verify_access_token(t) is not None:
+                    return True
+            except Exception:
+                pass
+        return False
+
+    # --- extract headers as a dict (lower-cased keys) ----------------------
+    headers: dict[str, str] = {}
+    for raw_name, raw_val in scope.get("headers", []):
+        headers[raw_name.decode("latin-1").lower()] = raw_val.decode("latin-1")
+
+    # 1. Query-string token
+    qs = scope.get("query_string", b"").decode("latin-1")
+    params = parse_qs(qs)
+    token_vals = params.get("token", [])
+    if token_vals and _tok_ok(token_vals[0]):
+        return True
+
+    # 2. HTTP-only session cookie
+    cookie_header = headers.get("cookie", "")
+    for morsel in cookie_header.split(";"):
+        morsel = morsel.strip()
+        if morsel.startswith("pocketpaw_session="):
+            cookie_token = morsel.split("=", 1)[1]
+            if _tok_ok(cookie_token):
+                return True
+
+    # 3. Authorization header
+    auth_header = headers.get("authorization", "")
+    if auth_header.startswith("Bearer "):
+        bearer = auth_header.removeprefix("Bearer ").strip()
+        if _tok_ok(bearer):
+            return True
+
+    # 4. Sec-WebSocket-Protocol (browser clients)
+    protocols = headers.get("sec-websocket-protocol", "")
+    for proto in protocols.split(","):
+        candidate = proto.strip()
+        if candidate and _tok_ok(candidate):
+            return True
+
+    # 5. Genuine localhost bypass
+    class _ScopeProxy:
+        """Minimal object satisfying ``_is_genuine_localhost`` expectations."""
+
+        def __init__(self, s, h):
+            self.client = type("C", (), {"host": s.get("client", ("", 0))[0]})()
+            self.headers = h
+
+    if _is_genuine_localhost(_ScopeProxy(scope, headers)):
+        return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Auth middleware (registered by dashboard.py via app.add_middleware)
 # ---------------------------------------------------------------------------
 
 
 class AuthMiddleware:
-    """Pure ASGI middleware — explicitly passes WebSocket through.
+    """Pure ASGI middleware with auth checks for both HTTP and WebSocket scopes.
 
     Using a raw ASGI class instead of ``BaseHTTPMiddleware`` avoids known
     issues with Starlette's ``@app.middleware("http")`` blocking WebSocket
     connections in certain middleware stack configurations.
+
+    WebSocket connections are authenticated at the middleware level as a
+    defence-in-depth measure (see issue #883).  Individual WebSocket
+    handlers may perform additional checks, but any *new* WebSocket route
+    is now protected by default.
     """
 
     def __init__(self, app):
         self.app = app
 
     async def __call__(self, scope, receive, send):
+        if scope["type"] == "websocket":
+            if not _ws_scope_auth_ok(scope):
+                # Reject before the upgrade completes.
+                await receive()  # consume websocket.connect
+                await send({"type": "websocket.close", "code": 4003})
+                return
+            await self.app(scope, receive, send)
+            return
         if scope["type"] != "http":
-            # WebSocket / lifespan — pass through immediately
+            # lifespan — pass through immediately
             await self.app(scope, receive, send)
             return
         # HTTP — run the auth dispatch
@@ -208,9 +316,8 @@ async def _auth_dispatch(request: Request) -> Response | None:
     exempt_paths = [
         "/static",
         "/favicon.ico",
-        "/ws",  # WebSocket handles its own auth in dashboard_ws.py
-        "/v1/ws",  # v1 WebSocket (short path) — same handler, same auth
-        "/api/v1/ws",  # v1 WebSocket — same handler, same auth
+        # NOTE: /ws, /v1/ws, /api/v1/ws are no longer exempted here — WebSocket
+        # scopes are now authenticated at the middleware level (issue #883).
         "/api/auth/login",
         "/api/v1/auth/login",
         "/api/v1/docs",

--- a/tests/test_dashboard_security.py
+++ b/tests/test_dashboard_security.py
@@ -512,3 +512,165 @@ class TestLoginRateLimit:
         req = self._make_request("/static/some-asset.js", method="GET")
         await _auth_dispatch(req)
         mock_auth_limiter.check.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Issue #883 — WebSocket middleware auth (defence-in-depth)
+# ---------------------------------------------------------------------------
+
+
+class TestWebSocketMiddlewareAuth:
+    """AuthMiddleware must authenticate WebSocket scopes *before* the upgrade
+    completes, so that any new WebSocket route is protected by default (issue #883).
+    """
+
+    def _ws_scope(
+        self,
+        path: str = "/ws",
+        query_string: str = "",
+        headers: dict[str, str] | None = None,
+        client: tuple[str, int] = ("10.0.0.1", 12345),
+    ) -> dict:
+        raw_headers = []
+        for k, v in (headers or {}).items():
+            raw_headers.append((k.lower().encode(), v.encode()))
+        return {
+            "type": "websocket",
+            "path": path,
+            "query_string": query_string.encode(),
+            "headers": raw_headers,
+            "client": client,
+        }
+
+    @patch("pocketpaw.dashboard_auth.get_access_token", return_value="tok-secret")
+    @patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=False)
+    def test_ws_no_token_rejected(self, mock_local, mock_token):
+        from pocketpaw.dashboard_auth import _ws_scope_auth_ok
+
+        scope = self._ws_scope()
+        assert _ws_scope_auth_ok(scope) is False
+
+    @patch("pocketpaw.dashboard_auth.get_access_token", return_value="tok-secret")
+    @patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=False)
+    def test_ws_valid_query_token(self, mock_local, mock_token):
+        from pocketpaw.dashboard_auth import _ws_scope_auth_ok
+
+        scope = self._ws_scope(query_string="token=tok-secret")
+        assert _ws_scope_auth_ok(scope) is True
+
+    @patch("pocketpaw.dashboard_auth.get_access_token", return_value="tok-secret")
+    @patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=False)
+    def test_ws_invalid_query_token(self, mock_local, mock_token):
+        from pocketpaw.dashboard_auth import _ws_scope_auth_ok
+
+        scope = self._ws_scope(query_string="token=wrong")
+        assert _ws_scope_auth_ok(scope) is False
+
+    @patch("pocketpaw.dashboard_auth.get_access_token", return_value="tok-secret")
+    @patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=False)
+    def test_ws_valid_cookie(self, mock_local, mock_token):
+        from pocketpaw.dashboard_auth import _ws_scope_auth_ok
+
+        scope = self._ws_scope(headers={"cookie": "pocketpaw_session=tok-secret"})
+        assert _ws_scope_auth_ok(scope) is True
+
+    @patch("pocketpaw.dashboard_auth.get_access_token", return_value="tok-secret")
+    @patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=False)
+    def test_ws_valid_bearer_header(self, mock_local, mock_token):
+        from pocketpaw.dashboard_auth import _ws_scope_auth_ok
+
+        scope = self._ws_scope(headers={"authorization": "Bearer tok-secret"})
+        assert _ws_scope_auth_ok(scope) is True
+
+    @patch("pocketpaw.dashboard_auth.get_access_token", return_value="tok-secret")
+    @patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=False)
+    def test_ws_valid_session_token(self, mock_local, mock_token):
+        from pocketpaw.dashboard_auth import _ws_scope_auth_ok
+
+        session = create_session_token("tok-secret", ttl_hours=1)
+        scope = self._ws_scope(query_string=f"token={session}")
+        assert _ws_scope_auth_ok(scope) is True
+
+    @patch("pocketpaw.dashboard_auth.get_access_token", return_value="tok-secret")
+    @patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=True)
+    def test_ws_localhost_bypass(self, mock_local, mock_token):
+        from pocketpaw.dashboard_auth import _ws_scope_auth_ok
+
+        scope = self._ws_scope(client=("127.0.0.1", 9999))
+        assert _ws_scope_auth_ok(scope) is True
+
+    @patch("pocketpaw.dashboard_auth.get_access_token", return_value="tok-secret")
+    @patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=False)
+    def test_ws_sec_websocket_protocol(self, mock_local, mock_token):
+        from pocketpaw.dashboard_auth import _ws_scope_auth_ok
+
+        scope = self._ws_scope(headers={"sec-websocket-protocol": "tok-secret"})
+        assert _ws_scope_auth_ok(scope) is True
+
+    @patch("pocketpaw.dashboard_auth.get_access_token", return_value="tok-secret")
+    @patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=False)
+    async def test_middleware_closes_unauthenticated_ws(self, mock_local, mock_token):
+        """AuthMiddleware must send websocket.close for unauthenticated WS."""
+        from pocketpaw.dashboard_auth import AuthMiddleware
+
+        downstream_called = False
+
+        async def downstream_app(scope, receive, send):
+            nonlocal downstream_called
+            downstream_called = True
+
+        middleware = AuthMiddleware(downstream_app)
+        scope = self._ws_scope()
+        messages_sent = []
+
+        async def receive():
+            return {"type": "websocket.connect"}
+
+        async def send(msg):
+            messages_sent.append(msg)
+
+        await middleware(scope, receive, send)
+        assert not downstream_called
+        assert len(messages_sent) == 1
+        assert messages_sent[0]["type"] == "websocket.close"
+        assert messages_sent[0]["code"] == 4003
+
+    @patch("pocketpaw.dashboard_auth.get_access_token", return_value="tok-secret")
+    @patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=False)
+    async def test_middleware_passes_authenticated_ws(self, mock_local, mock_token):
+        """AuthMiddleware must pass authenticated WS to downstream app."""
+        from pocketpaw.dashboard_auth import AuthMiddleware
+
+        downstream_called = False
+
+        async def downstream_app(scope, receive, send):
+            nonlocal downstream_called
+            downstream_called = True
+
+        middleware = AuthMiddleware(downstream_app)
+        scope = self._ws_scope(query_string="token=tok-secret")
+
+        async def receive():
+            return {"type": "websocket.connect"}
+
+        async def send(msg):
+            pass
+
+        await middleware(scope, receive, send)
+        assert downstream_called
+
+    async def test_middleware_passes_lifespan_through(self):
+        """Lifespan scopes must always pass through without auth."""
+        from pocketpaw.dashboard_auth import AuthMiddleware
+
+        downstream_called = False
+
+        async def downstream_app(scope, receive, send):
+            nonlocal downstream_called
+            downstream_called = True
+
+        middleware = AuthMiddleware(downstream_app)
+        scope = {"type": "lifespan"}
+
+        await middleware(scope, None, None)
+        assert downstream_called


### PR DESCRIPTION
## What does this PR do?

Adds a defence-in-depth authentication check for WebSocket connections at the ASGI middleware level. Previously `AuthMiddleware` passed every non-HTTP scope (i.e., WebSocket) straight through to the downstream app with no auth check, meaning any new WebSocket route was unauthenticated by default and a single bug in `dashboard_ws.py` left the entire WebSocket surface unprotected with no fallback.

## Related Issue

Fixes #883

## Changes Made

- `src/pocketpaw/dashboard_auth.py`:
  - Added `_ws_scope_auth_ok()` — validates a raw ASGI WebSocket scope **before the upgrade completes**. Checks (in order): query-string `token`, `pocketpaw_session` cookie, `Authorization: Bearer` header, `Sec-WebSocket-Protocol` header, and genuine-localhost bypass. Supports master tokens, HMAC session tokens (`expires:hmac`), API keys (`pp_*`), and OAuth2 tokens (`ppat_*`).
  - Updated `AuthMiddleware.__call__` to branch on `scope["type"] == "websocket"` and call `_ws_scope_auth_ok()`. Unauthenticated connections are closed with code `4003` before the upgrade completes. `lifespan` scopes still pass through unconditionally.
  - Removed `/ws`, `/v1/ws`, `/api/v1/ws` entries from the `_auth_dispatch` exempt list — WebSocket scopes no longer reach `_auth_dispatch`.
- `tests/test_dashboard_security.py`:
  - Added `TestWebSocketMiddlewareAuth` with 11 tests.

## How to Test

1. Install dependencies: `uv sync --dev`
2. Run the new test class directly:
   ```
   uv run pytest tests/test_dashboard_security.py::TestWebSocketMiddlewareAuth -v
   ```
3. Run the full security test file to check for regressions:
   ```
   uv run pytest tests/test_dashboard_security.py -v
   ```
4. Run all non-e2e tests:
   ```
   uv run pytest --ignore=tests/e2e
   ```

## Evidence of Testing

```
tests/test_dashboard_security.py::TestWebSocketMiddlewareAuth::test_ws_no_token_rejected PASSED [ 78%]
tests/test_dashboard_security.py::TestWebSocketMiddlewareAuth::test_ws_valid_query_token PASSED [ 80%]
tests/test_dashboard_security.py::TestWebSocketMiddlewareAuth::test_ws_invalid_query_token PASSED [ 82%]
tests/test_dashboard_security.py::TestWebSocketMiddlewareAuth::test_ws_valid_cookie PASSED [ 85%]
tests/test_dashboard_security.py::TestWebSocketMiddlewareAuth::test_ws_valid_bearer_header PASSED [ 87%]
tests/test_dashboard_security.py::TestWebSocketMiddlewareAuth::test_ws_valid_session_token PASSED [ 89%]
tests/test_dashboard_security.py::TestWebSocketMiddlewareAuth::test_ws_localhost_bypass PASSED [ 91%]
tests/test_dashboard_security.py::TestWebSocketMiddlewareAuth::test_ws_sec_websocket_protocol PASSED [ 93%]
tests/test_dashboard_security.py::TestWebSocketMiddlewareAuth::test_middleware_closes_unauthenticated_ws PASSED [ 95%]
tests/test_dashboard_security.py::TestWebSocketMiddlewareAuth::test_middleware_passes_authenticated_ws PASSED [ 97%]
tests/test_dashboard_security.py::TestWebSocketMiddlewareAuth::test_middleware_passes_lifespan_through PASSED [100%]

============================== 47 passed in 1.23s ==============================

$ uv run ruff check .
All checks passed!
```

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff