### PR TITLE
Inject kb-go articles into agent context alongside soul memories

### DIFF
--- a/src/pocketpaw/bootstrap/context_builder.py
+++ b/src/pocketpaw/bootstrap/context_builder.py
@@ -1,6 +1,7 @@
 """
 Builder for assembling the full agent context.
 Created: 2026-02-02
+Updated: 2026-04-08 - kb injection: query kb-go (github.com/qbtrix/kb-go) for structured knowledge alongside soul memories
 Updated: 2026-04-01 - Context window budget tracking: priority-based injection with per-block caps
 Updated: 2026-03-10 - AGENTS.md injection: read project-specific constraints from target repos
 Updated: 2026-03-09 - Sanitize file_context paths before injecting into system prompt
@@ -38,6 +39,7 @@ _INJECTION_CAPS: dict[str, int | None] = {
     "identity": None,  # Critical — never capped
     "instructions": None,  # Critical — never capped
     "memory_context": 4000,
+    "kb_context": 3000,
     "sender_block": 500,
     "channel_hints": 500,
     "channel_instructions": 1000,
@@ -100,18 +102,24 @@ class AgentContextBuilder:
         """
         blocks: list[tuple[str, _Priority, str]] = []
 
-        # 1. Load static identity + memory context concurrently (independent I/O)
+        # 1. Load static identity, memory context, and kb context concurrently
+        # (independent I/O — identity is a function call, memory hits disk/vector db,
+        # kb shells out to a subprocess). asyncio.gather keeps the critical path fast.
         if include_memory:
             if user_query:
                 memory_coro = self.memory.get_semantic_context(user_query, sender_id=sender_id)
             else:
                 memory_coro = self.memory.get_context_for_agent(sender_id=sender_id)
-            context, memory_context = await asyncio.gather(
+            context, memory_context, kb_context = await asyncio.gather(
                 self.bootstrap.get_context(),
                 memory_coro,
+                self._get_kb_context(user_query),
             )
         else:
-            context = await self.bootstrap.get_context()
+            context, kb_context = await asyncio.gather(
+                self.bootstrap.get_context(),
+                self._get_kb_context(user_query),
+            )
             memory_context = ""
 
         base_prompt = context.to_system_prompt()
@@ -131,6 +139,19 @@ class AgentContextBuilder:
                 "do NOT call recall unless you need something not listed here)\n" + memory_context
             )
             blocks.append(("memory_context", _Priority.HIGH, mem_block))
+
+        # 2b. Inject kb (knowledge base) context — structured articles from source files
+        # This runs alongside soul memory: soul handles "what we discussed", kb handles
+        # "what the code currently says". The two complement each other, so we inject
+        # both when available. See https://github.com/qbtrix/kb-go for the kb tool.
+        if kb_context:
+            kb_block = (
+                "\n# Knowledge Base (relevant articles from the project wiki)\n"
+                "These are compiled from source files. Use them for implementation "
+                "details and current-state facts. Use soul_recall for past decisions "
+                "and conversation history.\n\n" + kb_context
+            )
+            blocks.append(("kb_context", _Priority.HIGH, kb_block))
 
         # 3. Inject sender identity block
         if sender_id:
@@ -317,6 +338,65 @@ class AgentContextBuilder:
             remaining -= len(content)
 
         return "\n\n".join(result_parts)
+
+    @staticmethod
+    async def _get_kb_context(user_query: str | None) -> str:
+        """Fetch relevant articles from the kb-go CLI.
+
+        Uses `kb search <query> --scope <scope> --context` to get pre-formatted
+        text ready for prompt injection. Runs the kb binary as a subprocess so
+        kb stays a standalone tool and paw-runtime never takes a hard dependency
+        on it.
+
+        Returns empty string on any failure (missing binary, missing scope,
+        empty query, timeout, non-zero exit). Failures never break prompt
+        building — kb is a nice-to-have, not a critical path.
+        """
+        if not user_query:
+            return ""
+
+        from pocketpaw.config import get_settings
+
+        settings = get_settings()
+        scope = (settings.kb_scope or "").strip()
+        if not scope:
+            return ""
+
+        binary = settings.kb_binary or "kb"
+        limit = str(settings.kb_limit or 3)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                binary,
+                "search",
+                user_query,
+                "--scope",
+                scope,
+                "--context",
+                "--limit",
+                limit,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=3.0)
+            except TimeoutError:
+                proc.kill()
+                await proc.wait()
+                logger.debug("kb context fetch timed out after 3s")
+                return ""
+        except FileNotFoundError:
+            logger.debug("kb binary not found at %s — skipping kb injection", binary)
+            return ""
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("kb context fetch failed (non-fatal): %s", exc)
+            return ""
+
+        if proc.returncode != 0:
+            return ""
+
+        output = stdout.decode("utf-8", errors="replace").strip()
+        return output
 
     @staticmethod
     def _load_channel_instructions(channel: Channel) -> str:

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -866,6 +866,22 @@ class Settings(BaseSettings):
             "auto_regen: passive energy recovery rate."
         ),
     )
+    kb_scope: str = Field(
+        default="",
+        description=(
+            "Knowledge base scope to query via the `kb` CLI (github.com/qbtrix/kb-go). "
+            "When set and the kb binary is on PATH, relevant articles are injected "
+            "into the agent system prompt alongside soul memories. Empty = disabled."
+        ),
+    )
+    kb_binary: str = Field(
+        default="kb",
+        description="Path to the kb binary (default: `kb` on PATH)",
+    )
+    kb_limit: int = Field(
+        default=3,
+        description="Number of top articles to inject from kb search (default: 3)",
+    )
 
     notification_channels: list[str] = Field(
         default_factory=list,

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -158,3 +158,80 @@ class TestAssembleWithBudget:
         assert "sender" in result
         assert "session" in result
         assert "files" in result
+
+
+class TestKbContext:
+    """Unit tests for kb (knowledge base) context injection via the kb-go CLI."""
+
+    async def test_empty_query_returns_empty(self):
+        """No user query means nothing to search, so kb injection is skipped."""
+        result = await AgentContextBuilder._get_kb_context(None)
+        assert result == ""
+
+        result = await AgentContextBuilder._get_kb_context("")
+        assert result == ""
+
+    async def test_empty_scope_returns_empty(self, monkeypatch):
+        """If kb_scope is not configured, kb injection is a no-op."""
+        from unittest.mock import MagicMock
+
+        import pocketpaw.bootstrap.context_builder as ctx_mod
+
+        settings = MagicMock()
+        settings.kb_scope = ""
+        settings.kb_binary = "kb"
+        settings.kb_limit = 3
+        monkeypatch.setattr("pocketpaw.config.get_settings", lambda: settings)
+
+        result = await ctx_mod.AgentContextBuilder._get_kb_context("authentication")
+        assert result == ""
+
+    async def test_missing_binary_returns_empty(self, monkeypatch):
+        """If the kb binary isn't found, failure is silent — empty string returned."""
+        from unittest.mock import MagicMock
+
+        import pocketpaw.bootstrap.context_builder as ctx_mod
+
+        settings = MagicMock()
+        settings.kb_scope = "test-scope"
+        settings.kb_binary = "/nonexistent/kb-binary-that-does-not-exist"
+        settings.kb_limit = 3
+        monkeypatch.setattr("pocketpaw.config.get_settings", lambda: settings)
+
+        result = await ctx_mod.AgentContextBuilder._get_kb_context("authentication")
+        assert result == ""
+
+    async def test_successful_kb_fetch(self, monkeypatch):
+        """When kb returns output, the stdout text is injected verbatim."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        import pocketpaw.bootstrap.context_builder as ctx_mod
+
+        settings = MagicMock()
+        settings.kb_scope = "test-scope"
+        settings.kb_binary = "kb"
+        settings.kb_limit = 3
+        monkeypatch.setattr("pocketpaw.config.get_settings", lambda: settings)
+
+        # Fake the subprocess
+        fake_proc = MagicMock()
+        fake_proc.returncode = 0
+        fake_proc.communicate = AsyncMock(
+            return_value=(b"## Article 1\nauth module details\n", b"")
+        )
+
+        async def fake_create_subprocess_exec(*args, **kwargs):
+            return fake_proc
+
+        monkeypatch.setattr(
+            "asyncio.create_subprocess_exec", fake_create_subprocess_exec
+        )
+
+        result = await ctx_mod.AgentContextBuilder._get_kb_context("auth")
+        assert "auth module details" in result
+
+    def test_kb_context_has_injection_cap(self):
+        """kb_context should have a reasonable cap to avoid blowing the context window."""
+        cap = _INJECTION_CAPS.get("kb_context")
+        assert cap is not None
+        assert 1000 <= cap <= 5000  # sanity range


### PR DESCRIPTION
## What

When the `kb` CLI (github.com/qbtrix/kb-go) is on PATH and `POCKETPAW_KB_SCOPE` is set, the context builder now fetches relevant articles via subprocess and injects them into the system prompt as a new `kb_context` block. Runs in parallel with memory via `asyncio.gather` so it stays off the critical path.

## Why

Soul handles "what did we discuss before" (episodic memory). kb handles "what does the code look like now" (compiled source articles). Both matter on every agent request — past decisions alongside current implementation. This wires them together in the existing context builder pipeline without coupling either tool.

## How

Three new settings:
- `POCKETPAW_KB_SCOPE` — scope name for kb search (empty = disabled, acts as the kill switch)
- `POCKETPAW_KB_BINARY` — path to kb binary (default `kb`)
- `POCKETPAW_KB_LIMIT` — top N articles to inject (default 3)

New async helper `AgentContextBuilder._get_kb_context(user_query)` shells out to `kb search <query> --scope <scope> --context --limit N`. The result is injected as a HIGH priority block with a 3000 char cap, after the identity and memory blocks.

Failure modes are all silent — missing binary, missing scope, timeout (3s hard cap), non-zero exit. kb is a nice-to-have, not a critical path. Prompt building never breaks because kb is unavailable.

## Why not tightly integrate

kb-go stays a standalone 6MB binary. paw-runtime never imports it. The subprocess call is ~50 lines in one file. Either tool can evolve independently — swap kb-go for something else, or run it on a different host, without touching this code.

See the kb-go README's "Pairing with Soul Protocol" section for the broader pattern and workflow examples.

## Note on the old branch

There's an existing `feat/kb-context-injection` branch from April that uses the old Python `knowledge-base` package. That's a different approach — direct import vs subprocess. That branch should probably be closed or rebased onto this one since kb-go replaces the Python package.

## Test plan

- [x] 5 new unit tests (empty query, empty scope, missing binary, successful fetch, injection cap sanity)
- [x] `pytest tests/test_context_budget.py` — 15/15 passing
- [x] Manual verification: no regressions in existing context assembly tests