### PR TITLE
Modify existing pockets instead of creating duplicates

### DIFF
--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -178,11 +178,54 @@ async def _create_pocket_and_session(spec: dict, session_key: str) -> str | None
         return None
 
 
+async def _update_pocket(spec: dict) -> str | None:
+    """Update an existing pocket's rippleSpec in MongoDB. Returns pocket _id or None."""
+    try:
+        from ee.cloud.models.user import User
+        from ee.cloud.pockets.schemas import UpdatePocketRequest
+        from ee.cloud.pockets.service import PocketService
+
+        # Extract pocket_id from the spec's lifecycle.id
+        pocket_id = spec.get("lifecycle", {}).get("id", "")
+        if not pocket_id:
+            pocket_id = spec.get("metadata", {}).get("pocket_id", "")
+        if not pocket_id:
+            logger.warning("Cannot update pocket — no pocket_id in spec")
+            return None
+
+        # Find the cloud pocket by lifecycle.id match
+        from ee.cloud.models.pocket import Pocket
+
+        pocket = await Pocket.find_one({"rippleSpec.lifecycle.id": pocket_id})
+        if not pocket:
+            logger.warning("Pocket with lifecycle.id=%s not found, falling back to create", pocket_id)
+            return None
+        cloud_id = str(pocket.id)
+
+        user = await User.find_one()
+        user_id = str(user.id) if user else ""
+
+        await PocketService.update(
+            cloud_id,
+            user_id,
+            UpdatePocketRequest(
+                name=spec.get("title") or spec.get("name"),
+                description=spec.get("description"),
+                rippleSpec=spec,
+            ),
+        )
+        logger.info("Updated pocket %s (lifecycle.id=%s) in MongoDB", cloud_id, pocket_id)
+        return cloud_id
+    except Exception:
+        logger.warning("Failed to update pocket in MongoDB", exc_info=True)
+        return None
+
+
 async def _publish_pocket_event(bus: "MessageBus", content: str, session_key: str) -> None:
     """Detect pocket event JSON in tool output and publish a dedicated SystemEvent.
 
     Pocket tools return output as: ``{json}\\n\\nhuman message``.
-    The JSON block has a ``pocket_event`` key (``"created"`` or ``"mutation"``).
+    The JSON block has a ``pocket_event`` key (``"created"``, ``"updated"``, or ``"mutation"``).
     """
     # Fast path: skip content that can't contain a pocket event.
     if '"pocket_event"' not in content:
@@ -207,6 +250,19 @@ async def _publish_pocket_event(bus: "MessageBus", content: str, session_key: st
         await bus.publish_system(
             SystemEvent(
                 event_type="pocket_created",
+                data={
+                    "spec": spec,
+                    "session_key": session_key,
+                    "pocket_cloud_id": pocket_cloud_id,
+                },
+            )
+        )
+    elif evt_type == "updated":
+        # Update existing pocket in MongoDB
+        pocket_cloud_id = await _update_pocket(spec)
+        await bus.publish_system(
+            SystemEvent(
+                event_type="pocket_updated",
                 data={
                     "spec": spec,
                     "session_key": session_key,

--- a/src/pocketpaw/api/v1/pockets.py
+++ b/src/pocketpaw/api/v1/pockets.py
@@ -246,16 +246,20 @@ Colors: #30D158 (green), #FF453A (red), #FF9F0A (orange),
 #0A84FF (blue), #BF5AF2 (purple), #5E5CE6 (indigo).
 
 MODIFYING EXISTING POCKETS:
-When a <current-pocket> tag is present in the user message, you are editing that pocket.
+When a <current-pocket> tag is present, you are editing that pocket — NOT creating a new one.
+- To CHANGE LAYOUT or redesign the pocket: call create_pocket with pocket_id set to the id from
+  <current-pocket>. This UPDATES the existing pocket in place. Example:
+  echo '{"pocket_id":"<id>","title":"...","ui":{...}}' \
+  | python -m pocketpaw.tools.cli create_pocket
+  (use 'ui' for UISpec, 'widgets' for flat dashboard, 'panes'+'layout' for multi-pane)
 - To ADD a widget:
   echo '{"pocket_id":"<id>","widget":{...}}' \
   | python -m pocketpaw.tools.cli add_widget
 - To REMOVE a widget:
   echo '{"pocket_id":"<id>","widget_id":"<wid>"}' \
   | python -m pocketpaw.tools.cli remove_widget
-- To RECREATE the entire pocket: echo '{"title":...}' | python -m pocketpaw.tools.cli create_pocket
-  (use 'ui' for UISpec, 'widgets' for flat dashboard, 'panes'+'layout' for multi-pane)
 - The pocket id and widget ids are provided in the <current-pocket> tag.
+- ALWAYS pass pocket_id when modifying. If you omit it, a duplicate pocket will be created.
 - Do NOT use HTTP/curl/fetch — only use the CLI bridge commands above.
 </pocket-creation-context>
 

--- a/src/pocketpaw/tools/builtin/pocket.py
+++ b/src/pocketpaw/tools/builtin/pocket.py
@@ -339,6 +339,13 @@ class CreatePocketTool(BaseTool):
                         "required": ["type", "title", "data"],
                     },
                 },
+                "pocket_id": {
+                    "type": "string",
+                    "description": (
+                        "Pass an existing pocket ID to update it instead of creating a new one. "
+                        "Get this from the <current-pocket> tag when modifying an open pocket."
+                    ),
+                },
             },
             "required": ["title", "description", "category"],
         }
@@ -355,12 +362,15 @@ class CreatePocketTool(BaseTool):
         color: str = "#0A84FF",
         columns: int = 3,
         name: str = "",
+        pocket_id: str = "",
         **kwargs: Any,
     ) -> str:
         """Build and return a pocket spec as JSON."""
         import uuid
 
-        pocket_id = f"ai-{uuid.uuid4().hex[:8]}"
+        is_update = bool(pocket_id)
+        if not pocket_id:
+            pocket_id = f"ai-{uuid.uuid4().hex[:8]}"
         pocket_title = title or name or "Untitled Pocket"
 
         metadata = {
@@ -383,8 +393,10 @@ class CreatePocketTool(BaseTool):
                     "panes": valid_panes,
                     "metadata": metadata,
                 }
-                event_payload = json.dumps({"pocket_event": "created", "spec": spec})
-                msg = f"Created pocket **{pocket_title}** ({len(valid_panes)} panes)."
+                evt = "updated" if is_update else "created"
+                event_payload = json.dumps({"pocket_event": evt, "spec": spec})
+                verb = "Updated" if is_update else "Created"
+                msg = f"{verb} pocket **{pocket_title}** ({len(valid_panes)} panes)."
                 return f"{event_payload}\n\n{msg}"
 
         # ── UISpec v1.0 path: nested component tree ──
@@ -399,8 +411,10 @@ class CreatePocketTool(BaseTool):
             }
             if layout:
                 spec["layout"] = layout
-            event_payload = json.dumps({"pocket_event": "created", "spec": spec})
-            msg = f"Created pocket **{pocket_title}** (UISpec)."
+            evt = "updated" if is_update else "created"
+            event_payload = json.dumps({"pocket_event": evt, "spec": spec})
+            verb = "Updated" if is_update else "Created"
+            msg = f"{verb} pocket **{pocket_title}** (UISpec)."
             return f"{event_payload}\n\n{msg}"
 
         # ── Flat widgets path: UniversalSpec v2.0 dashboard ──
@@ -464,8 +478,10 @@ class CreatePocketTool(BaseTool):
         # Return structured JSON (first block) + human message (second block).
         # The AgentLoop detects the pocket_event key and publishes a dedicated
         # SystemEvent so the SSE handler receives it without regex/markers.
-        event_payload = json.dumps({"pocket_event": "created", "spec": spec})
-        msg = f"Created pocket **{pocket_title}** with {len(built_widgets)} widgets."
+        evt = "updated" if is_update else "created"
+        event_payload = json.dumps({"pocket_event": evt, "spec": spec})
+        verb = "Updated" if is_update else "Created"
+        msg = f"{verb} pocket **{pocket_title}** with {len(built_widgets)} widgets."
         return f"{event_payload}\n\n{msg}"
 
 


### PR DESCRIPTION
## Summary

When a user opens a pocket and asks the agent to change its layout, the agent now updates the existing pocket instead of creating a new one with mock data.

**Root cause:** `CreatePocketTool` always generated a new UUID and `_create_pocket_and_session()` always inserted. The agent knew which pocket was open (via `<current-pocket>` tag) but had no tool path to update it.

**Changes:**

- `CreatePocketTool` now accepts optional `pocket_id` parameter. When provided, reuses the ID and emits `"updated"` event instead of `"created"`
- New `_update_pocket()` function in agent loop handles `"updated"` events by calling `PocketService.update()` with the new rippleSpec
- System prompt updated to teach the agent: "when `<current-pocket>` is present, pass its `pocket_id` to `create_pocket` to update in place"
- Frontend counterpart in paw-enterprise#61 handles `pocket_updated` SSE events

## Test plan

- [x] 37/37 pocket tool tests passing
- [ ] Open existing pocket, ask agent to change layout — verify same pocket ID, no duplicate
- [ ] New pocket creation still works (no pocket_id = new UUID as before)
- [ ] Widget add/remove mutations unaffected