### PR TITLE
Capture corrections between proposal and approval

### DIFF
--- a/ee/instinct/__init__.py
+++ b/ee/instinct/__init__.py
@@ -1,8 +1,16 @@
 # Instinct — decision pipeline for Paw OS.
 # Created: 2026-03-28 — Actions, approvals, audit log.
 # Updated: 2026-03-30 — Exported ActionStatus, ActionCategory, ActionPriority, AuditCategory.
-# The decision loop: Agent proposes -> Human approves -> Action executes -> Feedback captured.
+# Updated: 2026-04-12 (Move 1 PR-A) — Exported Correction, CorrectionPatch, compute_patches.
+# The decision loop: Agent proposes -> Human approves (optionally edits) ->
+# Action executes -> Correction captured -> Soul learns.
 
+from ee.instinct.correction import (
+    Correction,
+    CorrectionPatch,
+    compute_patches,
+    summarize_correction,
+)
 from ee.instinct.models import (
     Action,
     ActionCategory,
@@ -24,5 +32,9 @@ __all__ = [
     "ActionTrigger",
     "AuditCategory",
     "AuditEntry",
+    "Correction",
+    "CorrectionPatch",
     "InstinctStore",
+    "compute_patches",
+    "summarize_correction",
 ]

--- a/ee/instinct/correction.py
+++ b/ee/instinct/correction.py
@@ -1,0 +1,101 @@
+# ee/instinct/correction.py — Correction Loop data types.
+# Created: 2026-04-12 (Move 1 PR-A) — Captures the diff between what the agent
+# proposed and what the human approved so it can be used as a learning signal.
+# Pairs with soul-protocol to form the correction loop: proposal → edit → soul
+# remembers → next proposal improves.
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from ee.fabric.models import _gen_id
+from ee.instinct.models import Action
+
+_CORRECTABLE_SCALAR_FIELDS: tuple[str, ...] = (
+    "title",
+    "description",
+    "recommendation",
+    "category",
+    "priority",
+)
+
+
+class CorrectionPatch(BaseModel):
+    """One field-level change between the proposed and approved action."""
+
+    path: str
+    before: Any
+    after: Any
+
+
+class Correction(BaseModel):
+    """Captured when a human edits an Action before approving it.
+
+    Stored alongside the approval and later consumed by soul-protocol's
+    `observe()` + `recall()` to bias future proposals toward the actor's
+    preferred shape.
+    """
+
+    id: str = Field(default_factory=lambda: _gen_id("cor"))
+    action_id: str
+    pocket_id: str
+    actor: str
+    patches: list[CorrectionPatch]
+    context_summary: str
+    action_title: str
+    created_at: datetime = Field(default_factory=datetime.now)
+
+
+def compute_patches(before: Action, after: Action) -> list[CorrectionPatch]:
+    """Diff two Action snapshots and return the list of field changes.
+
+    Only fields a human would meaningfully edit are compared:
+    title/description/recommendation/category/priority as flat scalars, and
+    the top-level keys of `parameters` (path = "parameters.<key>").
+
+    `context` is intentionally skipped — it holds reasoning metadata, not
+    action content, and will be captured separately by the decision-trace
+    collector (Move 2).
+    """
+    patches: list[CorrectionPatch] = []
+
+    for field in _CORRECTABLE_SCALAR_FIELDS:
+        b = getattr(before, field)
+        a = getattr(after, field)
+        if _normalize(b) != _normalize(a):
+            patches.append(CorrectionPatch(path=field, before=_normalize(b), after=_normalize(a)))
+
+    before_params = before.parameters or {}
+    after_params = after.parameters or {}
+    for key in sorted(set(before_params) | set(after_params)):
+        b_val = before_params.get(key)
+        a_val = after_params.get(key)
+        if b_val != a_val:
+            patches.append(
+                CorrectionPatch(path=f"parameters.{key}", before=b_val, after=a_val),
+            )
+
+    return patches
+
+
+def summarize_correction(action: Action, patches: list[CorrectionPatch]) -> str:
+    """Short natural-language summary used as a recall key by soul-protocol.
+
+    Kept deliberately terse and deterministic — no LLM call on the hot path.
+    Format: "<title> — edited <N> field(s): <path1>, <path2>, ..."
+    """
+    if not patches:
+        return f"{action.title} — approved without edits"
+    fields = ", ".join(p.path for p in patches[:5])
+    more = f" (+{len(patches) - 5} more)" if len(patches) > 5 else ""
+    return f"{action.title} — edited {len(patches)} field(s): {fields}{more}"
+
+
+def _normalize(value: Any) -> Any:
+    """Convert enums to their string values so patches serialize cleanly."""
+    if hasattr(value, "value"):
+        return value.value
+    return value

--- a/ee/instinct/router.py
+++ b/ee/instinct/router.py
@@ -2,6 +2,10 @@
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
 # Updated: 2026-03-30 — Added GET /instinct/actions (list all with status filter),
 #   GET /instinct/audit/export (JSON export), switched to singleton from ee.api.
+# Updated: 2026-04-12 (Move 1 PR-A) — /approve now accepts optional edited fields.
+#   When present, the server diffs the stored proposal against the edits, persists
+#   a Correction, then approves. GET /instinct/corrections exposes corrections
+#   scoped to a pocket or an action so the UI and agents can read them back.
 
 from __future__ import annotations
 
@@ -10,8 +14,13 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
+from ee.instinct.correction import (
+    Correction,
+    compute_patches,
+    summarize_correction,
+)
 from ee.instinct.models import (
     Action,
     ActionCategory,
@@ -52,6 +61,23 @@ class RejectRequest(BaseModel):
     reason: str = ""
 
 
+class ApproveRequest(BaseModel):
+    """Optional edits and approver metadata for an approval.
+
+    When any of `title`, `description`, `recommendation`, `category`, `priority`,
+    or `parameters` differ from the stored proposal, the server computes a
+    Correction before approving. Omit the fields to approve unchanged.
+    """
+
+    approver: str = "user"
+    title: str | None = None
+    description: str | None = None
+    recommendation: str | None = None
+    category: ActionCategory | None = None
+    priority: ActionPriority | None = None
+    parameters: dict[str, Any] | None = None
+
+
 # ---------------------------------------------------------------------------
 # Response schemas
 # ---------------------------------------------------------------------------
@@ -64,6 +90,19 @@ class ActionsListResponse(BaseModel):
 
 class AuditListResponse(BaseModel):
     entries: list[AuditEntry]
+    total: int
+
+
+class ApproveResponse(BaseModel):
+    action: Action
+    correction: Correction | None = Field(
+        default=None,
+        description="Present when the approver edited the proposal before approving.",
+    )
+
+
+class CorrectionsListResponse(BaseModel):
+    corrections: list[Correction]
     total: int
 
 
@@ -112,13 +151,41 @@ async def list_actions(
     return ActionsListResponse(actions=actions, total=len(actions))
 
 
-@router.post("/instinct/actions/{action_id}/approve", response_model=Action)
-async def approve_action(action_id: str):
-    """Approve a pending action."""
-    action = await _store().approve(action_id)
-    if not action:
+@router.post("/instinct/actions/{action_id}/approve", response_model=ApproveResponse)
+async def approve_action(action_id: str, req: ApproveRequest | None = None):
+    """Approve a pending action, optionally with edits.
+
+    If the request body carries edits, the server diffs the stored proposal
+    against the incoming shape and persists a Correction alongside the
+    approval. Callers that want to approve unchanged can POST with no body.
+    """
+    store = _store()
+    before = await store.get_action(action_id)
+    if not before:
         raise HTTPException(404, "Action not found")
-    return action
+
+    req = req or ApproveRequest()
+    after, edited_fields = _apply_edits(before, req)
+
+    correction: Correction | None = None
+    if edited_fields:
+        patches = compute_patches(before, after)
+        if patches:
+            correction = Correction(
+                action_id=before.id,
+                pocket_id=before.pocket_id,
+                actor=req.approver,
+                patches=patches,
+                context_summary=summarize_correction(before, patches),
+                action_title=before.title,
+            )
+            await store.record_correction(correction)
+            await _persist_edits(store, after, edited_fields)
+
+    approved = await store.approve(action_id, approver=req.approver)
+    if not approved:
+        raise HTTPException(404, "Action not found")
+    return ApproveResponse(action=approved, correction=correction)
 
 
 @router.post("/instinct/actions/{action_id}/reject", response_model=Action)
@@ -129,6 +196,91 @@ async def reject_action(action_id: str, req: RejectRequest | None = None):
     if not action:
         raise HTTPException(404, "Action not found")
     return action
+
+
+def _apply_edits(before: Action, req: ApproveRequest) -> tuple[Action, set[str]]:
+    """Return a copy of `before` with any non-null fields from `req` applied.
+
+    Also returns the set of field names that were actually changed so the
+    caller can decide whether to persist them back to the store.
+    """
+    edited: set[str] = set()
+    update: dict[str, Any] = {}
+    for field in ("title", "description", "recommendation", "category", "priority"):
+        incoming = getattr(req, field)
+        if incoming is not None and incoming != getattr(before, field):
+            update[field] = incoming
+            edited.add(field)
+    if req.parameters is not None and req.parameters != before.parameters:
+        update["parameters"] = req.parameters
+        edited.add("parameters")
+    return before.model_copy(update=update), edited
+
+
+async def _persist_edits(store: Any, action: Action, edited: set[str]) -> None:
+    """Persist the human edits back to the store before the approve update.
+
+    Approval itself touches `status` and `approved_*` so we only write the
+    content fields that actually changed — no redundant updates.
+    """
+    import aiosqlite
+
+    assignments: list[str] = []
+    params: list[Any] = []
+    if "title" in edited:
+        assignments.append("title = ?")
+        params.append(action.title)
+    if "description" in edited:
+        assignments.append("description = ?")
+        params.append(action.description)
+    if "recommendation" in edited:
+        assignments.append("recommendation = ?")
+        params.append(action.recommendation)
+    if "category" in edited:
+        assignments.append("category = ?")
+        params.append(action.category.value)
+    if "priority" in edited:
+        assignments.append("priority = ?")
+        params.append(action.priority.value)
+    if "parameters" in edited:
+        import json as _json
+
+        assignments.append("parameters = ?")
+        params.append(_json.dumps(action.parameters))
+
+    if not assignments:
+        return
+
+    assignments.append("updated_at = datetime('now')")
+    params.append(action.id)
+    async with aiosqlite.connect(store._db_path) as db:
+        await db.execute(
+            f"UPDATE instinct_actions SET {', '.join(assignments)} WHERE id = ?",
+            params,
+        )
+        await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Correction endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/instinct/corrections", response_model=CorrectionsListResponse)
+async def list_corrections(
+    pocket_id: str | None = Query(None, description="Filter by pocket ID"),
+    action_id: str | None = Query(None, description="Filter by action ID"),
+    limit: int = Query(100, ge=1, le=500),
+):
+    """List corrections captured when humans edited proposed actions."""
+    store = _store()
+    if action_id:
+        corrections = await store.get_corrections_for_action(action_id)
+    elif pocket_id:
+        corrections = await store.get_corrections_for_pocket(pocket_id, limit=limit)
+    else:
+        raise HTTPException(400, "Provide pocket_id or action_id")
+    return CorrectionsListResponse(corrections=corrections, total=len(corrections))
 
 
 # ---------------------------------------------------------------------------

--- a/ee/instinct/store.py
+++ b/ee/instinct/store.py
@@ -445,15 +445,12 @@ class InstinctStore:
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
-                "SELECT * FROM instinct_corrections"
-                " WHERE action_id = ? ORDER BY created_at DESC",
+                "SELECT * FROM instinct_corrections WHERE action_id = ? ORDER BY created_at DESC",
                 (action_id,),
             ) as cur:
                 return [self._row_to_correction(row) async for row in cur]
 
-    async def count_corrections_by_path(
-        self, pocket_id: str, path: str
-    ) -> int:
+    async def count_corrections_by_path(self, pocket_id: str, path: str) -> int:
         """Return how many corrections on this pocket touched a given path.
 
         Used by the soul bridge to decide when to promote a pattern from

--- a/ee/instinct/store.py
+++ b/ee/instinct/store.py
@@ -1,6 +1,9 @@
 # Instinct store — async SQLite operations for the decision pipeline.
 # Created: 2026-03-28 — Action lifecycle + audit log.
 # Updated: 2026-03-30 — Added limit param to _query_actions, list_actions() public method.
+# Updated: 2026-04-12 (Move 1 PR-A) — Corrections table + record_correction() and
+#   get_corrections*() methods for the correction loop. Human edits between
+#   proposal and approval land here, then feed soul-protocol on next proposal.
 
 from __future__ import annotations
 
@@ -11,6 +14,7 @@ from typing import Any
 
 import aiosqlite
 
+from ee.instinct.correction import Correction, CorrectionPatch
 from ee.instinct.models import (
     Action,
     ActionCategory,
@@ -59,10 +63,23 @@ CREATE TABLE IF NOT EXISTS instinct_audit (
     outcome TEXT
 );
 
+CREATE TABLE IF NOT EXISTS instinct_corrections (
+    id TEXT PRIMARY KEY,
+    action_id TEXT NOT NULL,
+    pocket_id TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    patches TEXT NOT NULL,
+    context_summary TEXT NOT NULL,
+    action_title TEXT NOT NULL,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
 CREATE INDEX IF NOT EXISTS idx_actions_pocket ON instinct_actions(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_actions_status ON instinct_actions(status);
 CREATE INDEX IF NOT EXISTS idx_audit_pocket ON instinct_audit(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON instinct_audit(timestamp);
+CREATE INDEX IF NOT EXISTS idx_corrections_pocket ON instinct_corrections(pocket_id);
+CREATE INDEX IF NOT EXISTS idx_corrections_action ON instinct_corrections(action_id);
 """
 
 
@@ -372,6 +389,79 @@ class InstinctStore:
         entries = await self.query_audit(pocket_id=pocket_id, limit=10000)
         return json.dumps([e.model_dump(mode="json") for e in entries], indent=2)
 
+    # --- Corrections ---
+
+    async def record_correction(self, correction: Correction) -> Correction:
+        """Persist a Correction and log the event to the audit table."""
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO instinct_corrections"
+                " (id, action_id, pocket_id, actor, patches,"
+                " context_summary, action_title, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    correction.id,
+                    correction.action_id,
+                    correction.pocket_id,
+                    correction.actor,
+                    json.dumps([p.model_dump(mode="json") for p in correction.patches]),
+                    correction.context_summary,
+                    correction.action_title,
+                    correction.created_at.isoformat(),
+                ),
+            )
+            await db.commit()
+
+        await self._log(
+            action_id=correction.action_id,
+            pocket_id=correction.pocket_id,
+            actor=correction.actor,
+            event="correction_captured",
+            description=correction.context_summary,
+            context={
+                "correction_id": correction.id,
+                "patch_count": len(correction.patches),
+                "paths": [p.path for p in correction.patches],
+            },
+        )
+        return correction
+
+    async def get_corrections_for_pocket(
+        self, pocket_id: str, limit: int = 100
+    ) -> list[Correction]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM instinct_corrections"
+                " WHERE pocket_id = ? ORDER BY created_at DESC LIMIT ?",
+                (pocket_id, limit),
+            ) as cur:
+                return [self._row_to_correction(row) async for row in cur]
+
+    async def get_corrections_for_action(self, action_id: str) -> list[Correction]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM instinct_corrections"
+                " WHERE action_id = ? ORDER BY created_at DESC",
+                (action_id,),
+            ) as cur:
+                return [self._row_to_correction(row) async for row in cur]
+
+    async def count_corrections_by_path(
+        self, pocket_id: str, path: str
+    ) -> int:
+        """Return how many corrections on this pocket touched a given path.
+
+        Used by the soul bridge to decide when to promote a pattern from
+        episodic to procedural (the 3x-same-path heuristic).
+        """
+        corrections = await self.get_corrections_for_pocket(pocket_id, limit=1000)
+        return sum(1 for c in corrections if any(p.path == path for p in c.patches))
+
     # --- Helpers ---
 
     def _row_to_action(self, row: Any) -> Action:
@@ -407,4 +497,17 @@ class InstinctStore:
             context=json.loads(row["context"]) if row["context"] else {},
             ai_recommendation=row["ai_recommendation"],
             outcome=row["outcome"],
+        )
+
+    def _row_to_correction(self, row: Any) -> Correction:
+        patches_raw = json.loads(row["patches"]) if row["patches"] else []
+        return Correction(
+            id=row["id"],
+            action_id=row["action_id"],
+            pocket_id=row["pocket_id"],
+            actor=row["actor"],
+            patches=[CorrectionPatch.model_validate(p) for p in patches_raw],
+            context_summary=row["context_summary"],
+            action_title=row["action_title"],
+            created_at=datetime.fromisoformat(row["created_at"]),
         )

--- a/tests/cloud/test_ee_correction.py
+++ b/tests/cloud/test_ee_correction.py
@@ -129,17 +129,13 @@ class TestSummarizeCorrection:
         assert "Send renewal outreach" in summary
 
     def test_summary_names_each_patched_field_up_to_five(self) -> None:
-        patches = [
-            CorrectionPatch(path=f"parameters.f{i}", before=1, after=2) for i in range(5)
-        ]
+        patches = [CorrectionPatch(path=f"parameters.f{i}", before=1, after=2) for i in range(5)]
         summary = summarize_correction(_action(), patches)
         for i in range(5):
             assert f"parameters.f{i}" in summary
 
     def test_more_than_five_patches_appends_overflow_counter(self) -> None:
-        patches = [
-            CorrectionPatch(path=f"parameters.f{i}", before=1, after=2) for i in range(8)
-        ]
+        patches = [CorrectionPatch(path=f"parameters.f{i}", before=1, after=2) for i in range(8)]
         summary = summarize_correction(_action(), patches)
         assert "(+3 more)" in summary
 
@@ -170,8 +166,7 @@ def correction_for(store: InstinctStore):
             action_id=action_id,
             pocket_id=pocket_id,
             actor=actor,
-            patches=patches
-            or [CorrectionPatch(path="title", before="Old", after="New")],
+            patches=patches or [CorrectionPatch(path="title", before="Old", after="New")],
             context_summary="edited the greeting tone",
             action_title=title,
         )
@@ -233,9 +228,7 @@ class TestCorrectionStore:
         assert corrections[1].action_id == "act-a"
 
     @pytest.mark.asyncio
-    async def test_count_corrections_by_path(
-        self, store: InstinctStore, correction_for
-    ) -> None:
+    async def test_count_corrections_by_path(self, store: InstinctStore, correction_for) -> None:
         await store.record_correction(
             correction_for(
                 action_id="act-1",

--- a/tests/cloud/test_ee_correction.py
+++ b/tests/cloud/test_ee_correction.py
@@ -1,0 +1,402 @@
+# tests/cloud/test_ee_correction.py — Tests for the Correction Loop (Move 1 PR-A).
+# Created: 2026-04-12 — Unit coverage for compute_patches + summarize_correction,
+# store-level record_correction + query helpers, and the /approve endpoint behavior
+# across unedited, edited, and edge-case bodies.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ee.instinct.correction import (
+    Correction,
+    CorrectionPatch,
+    compute_patches,
+    summarize_correction,
+)
+from ee.instinct.models import (
+    Action,
+    ActionCategory,
+    ActionPriority,
+    ActionStatus,
+    ActionTrigger,
+)
+from ee.instinct.router import router
+from ee.instinct.store import InstinctStore
+
+
+def _trigger() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="claude", reason="unit test")
+
+
+def _action(**overrides) -> Action:
+    defaults: dict = {
+        "pocket_id": "pocket-1",
+        "title": "Send renewal outreach",
+        "description": "Three accounts up for renewal this month",
+        "recommendation": "Draft a friendly nudge email",
+        "trigger": _trigger(),
+        "category": ActionCategory.WORKFLOW,
+        "priority": ActionPriority.MEDIUM,
+        "parameters": {"tone": "formal", "discount_pct": 20},
+    }
+    defaults.update(overrides)
+    return Action(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# compute_patches — field-level diff logic
+# ---------------------------------------------------------------------------
+
+
+class TestComputePatches:
+    def test_identical_actions_produce_no_patches(self) -> None:
+        before = _action()
+        after = before.model_copy()
+        assert compute_patches(before, after) == []
+
+    def test_scalar_field_change_is_captured(self) -> None:
+        before = _action(title="Send renewal outreach")
+        after = before.model_copy(update={"title": "Quick renewal nudge"})
+        patches = compute_patches(before, after)
+        assert len(patches) == 1
+        assert patches[0].path == "title"
+        assert patches[0].before == "Send renewal outreach"
+        assert patches[0].after == "Quick renewal nudge"
+
+    def test_enum_fields_normalize_to_string_values(self) -> None:
+        before = _action(priority=ActionPriority.MEDIUM)
+        after = before.model_copy(update={"priority": ActionPriority.HIGH})
+        patches = compute_patches(before, after)
+        assert len(patches) == 1
+        assert patches[0].path == "priority"
+        assert patches[0].before == "medium"
+        assert patches[0].after == "high"
+
+    def test_parameters_diff_uses_dotted_path(self) -> None:
+        before = _action(parameters={"tone": "formal", "discount_pct": 20})
+        after = before.model_copy(
+            update={"parameters": {"tone": "casual", "discount_pct": 15}},
+        )
+        paths = {p.path for p in compute_patches(before, after)}
+        assert paths == {"parameters.tone", "parameters.discount_pct"}
+
+    def test_parameter_added_and_removed_both_captured(self) -> None:
+        before = _action(parameters={"tone": "formal"})
+        after = before.model_copy(update={"parameters": {"discount_pct": 15}})
+        patches = compute_patches(before, after)
+        paths = {p.path for p in patches}
+        assert paths == {"parameters.tone", "parameters.discount_pct"}
+        by_path = {p.path: p for p in patches}
+        assert by_path["parameters.tone"].after is None
+        assert by_path["parameters.discount_pct"].before is None
+
+    def test_context_field_is_ignored(self) -> None:
+        """Context carries reasoning metadata, not action content — skip it."""
+        before = _action()
+        after = before.model_copy(update={"context": before.context.model_copy()})
+        # Even if context were different, compute_patches should ignore it.
+        assert compute_patches(before, after) == []
+
+    def test_multiple_unrelated_fields_return_multiple_patches(self) -> None:
+        before = _action()
+        after = before.model_copy(
+            update={
+                "title": "New title",
+                "description": "New desc",
+                "priority": ActionPriority.HIGH,
+                "parameters": {"tone": "casual", "discount_pct": 20},
+            },
+        )
+        patches = compute_patches(before, after)
+        paths = {p.path for p in patches}
+        assert paths == {"title", "description", "priority", "parameters.tone"}
+
+
+# ---------------------------------------------------------------------------
+# summarize_correction — deterministic recall-key formatting
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizeCorrection:
+    def test_zero_patches_returns_approved_without_edits(self) -> None:
+        summary = summarize_correction(_action(), [])
+        assert "approved without edits" in summary
+        assert "Send renewal outreach" in summary
+
+    def test_summary_names_each_patched_field_up_to_five(self) -> None:
+        patches = [
+            CorrectionPatch(path=f"parameters.f{i}", before=1, after=2) for i in range(5)
+        ]
+        summary = summarize_correction(_action(), patches)
+        for i in range(5):
+            assert f"parameters.f{i}" in summary
+
+    def test_more_than_five_patches_appends_overflow_counter(self) -> None:
+        patches = [
+            CorrectionPatch(path=f"parameters.f{i}", before=1, after=2) for i in range(8)
+        ]
+        summary = summarize_correction(_action(), patches)
+        assert "(+3 more)" in summary
+
+
+# ---------------------------------------------------------------------------
+# InstinctStore — corrections CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "correction_test.db")
+
+
+@pytest.fixture
+def correction_for(store: InstinctStore):
+    """Factory: build a Correction wired to a concrete pocket/action pair."""
+
+    def _make(
+        *,
+        pocket_id: str = "pocket-1",
+        action_id: str = "act-123",
+        actor: str = "user:priya",
+        patches: list[CorrectionPatch] | None = None,
+        title: str = "Send renewal outreach",
+    ) -> Correction:
+        return Correction(
+            action_id=action_id,
+            pocket_id=pocket_id,
+            actor=actor,
+            patches=patches
+            or [CorrectionPatch(path="title", before="Old", after="New")],
+            context_summary="edited the greeting tone",
+            action_title=title,
+        )
+
+    return _make
+
+
+class TestCorrectionStore:
+    @pytest.mark.asyncio
+    async def test_record_correction_persists_the_row(
+        self, store: InstinctStore, correction_for
+    ) -> None:
+        correction = correction_for()
+        await store.record_correction(correction)
+
+        saved = await store.get_corrections_for_action("act-123")
+        assert len(saved) == 1
+        assert saved[0].id == correction.id
+        assert saved[0].patches[0].path == "title"
+
+    @pytest.mark.asyncio
+    async def test_record_correction_writes_audit_entry(
+        self, store: InstinctStore, correction_for
+    ) -> None:
+        correction = correction_for()
+        await store.record_correction(correction)
+
+        audit = await store.query_audit(pocket_id="pocket-1")
+        events = [e.event for e in audit]
+        assert "correction_captured" in events
+        captured = next(e for e in audit if e.event == "correction_captured")
+        assert captured.context["correction_id"] == correction.id
+        assert captured.context["patch_count"] == 1
+        assert captured.context["paths"] == ["title"]
+
+    @pytest.mark.asyncio
+    async def test_get_corrections_for_pocket_filters_by_pocket(
+        self, store: InstinctStore, correction_for
+    ) -> None:
+        await store.record_correction(correction_for(pocket_id="pocket-1"))
+        await store.record_correction(correction_for(pocket_id="pocket-2"))
+
+        only = await store.get_corrections_for_pocket("pocket-1")
+        assert len(only) == 1
+        assert only[0].pocket_id == "pocket-1"
+
+    @pytest.mark.asyncio
+    async def test_get_corrections_orders_newest_first(
+        self, store: InstinctStore, correction_for
+    ) -> None:
+        first = correction_for(action_id="act-a")
+        second = correction_for(action_id="act-b")
+        await store.record_correction(first)
+        await store.record_correction(second)
+
+        corrections = await store.get_corrections_for_pocket("pocket-1")
+        assert len(corrections) == 2
+        assert corrections[0].action_id == "act-b"
+        assert corrections[1].action_id == "act-a"
+
+    @pytest.mark.asyncio
+    async def test_count_corrections_by_path(
+        self, store: InstinctStore, correction_for
+    ) -> None:
+        await store.record_correction(
+            correction_for(
+                action_id="act-1",
+                patches=[CorrectionPatch(path="title", before="A", after="B")],
+            ),
+        )
+        await store.record_correction(
+            correction_for(
+                action_id="act-2",
+                patches=[CorrectionPatch(path="title", before="C", after="D")],
+            ),
+        )
+        await store.record_correction(
+            correction_for(
+                action_id="act-3",
+                patches=[
+                    CorrectionPatch(path="parameters.tone", before="formal", after="casual"),
+                ],
+            ),
+        )
+
+        assert await store.count_corrections_by_path("pocket-1", "title") == 2
+        assert await store.count_corrections_by_path("pocket-1", "parameters.tone") == 1
+        assert await store.count_corrections_by_path("pocket-1", "description") == 0
+
+
+# ---------------------------------------------------------------------------
+# /approve endpoint — integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_with_store(tmp_path: Path):
+    app = FastAPI()
+    app.include_router(router)
+    store = InstinctStore(tmp_path / "router_correction.db")
+    with patch("ee.instinct.router._store", return_value=store):
+        yield app, store
+
+
+@pytest.fixture
+def client(app_with_store):
+    app, _ = app_with_store
+    return TestClient(app)
+
+
+class TestApproveEndpoint:
+    @pytest.mark.asyncio
+    async def test_approve_unchanged_returns_no_correction(
+        self, app_with_store, client: TestClient
+    ) -> None:
+        _, store = app_with_store
+        action = await store.propose(
+            pocket_id="pocket-1",
+            title="Send renewal outreach",
+            description="",
+            recommendation="Draft nudge",
+            trigger=_trigger(),
+        )
+
+        res = client.post(f"/instinct/actions/{action.id}/approve")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["action"]["status"] == "approved"
+        assert body["correction"] is None
+
+    @pytest.mark.asyncio
+    async def test_approve_with_edits_captures_correction(
+        self, app_with_store, client: TestClient
+    ) -> None:
+        _, store = app_with_store
+        action = await store.propose(
+            pocket_id="pocket-1",
+            title="Send renewal outreach",
+            description="Three accounts up for renewal",
+            recommendation="Formal email",
+            trigger=_trigger(),
+            priority=ActionPriority.MEDIUM,
+            parameters={"tone": "formal", "discount_pct": 20},
+        )
+
+        res = client.post(
+            f"/instinct/actions/{action.id}/approve",
+            json={
+                "approver": "user:priya",
+                "title": "Quick renewal nudge",
+                "priority": "high",
+                "parameters": {"tone": "casual", "discount_pct": 15},
+            },
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["action"]["status"] == "approved"
+        assert body["correction"] is not None
+        paths = {p["path"] for p in body["correction"]["patches"]}
+        assert paths == {"title", "priority", "parameters.tone", "parameters.discount_pct"}
+
+        saved = await store.get_action(action.id)
+        assert saved.title == "Quick renewal nudge"
+        assert saved.priority == ActionPriority.HIGH
+        assert saved.parameters["tone"] == "casual"
+        assert saved.status == ActionStatus.APPROVED
+
+    @pytest.mark.asyncio
+    async def test_approve_with_equal_body_treats_as_unchanged(
+        self, app_with_store, client: TestClient
+    ) -> None:
+        """Approve body can carry identical fields — no correction should be stored."""
+        _, store = app_with_store
+        action = await store.propose(
+            pocket_id="pocket-1",
+            title="Send renewal outreach",
+            description="desc",
+            recommendation="rec",
+            trigger=_trigger(),
+        )
+
+        res = client.post(
+            f"/instinct/actions/{action.id}/approve",
+            json={"approver": "user:priya", "title": action.title},
+        )
+        assert res.status_code == 200
+        assert res.json()["correction"] is None
+
+        corrections = await store.get_corrections_for_action(action.id)
+        assert corrections == []
+
+    def test_approve_unknown_action_returns_404(self, client: TestClient) -> None:
+        res = client.post("/instinct/actions/does-not-exist/approve")
+        assert res.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /corrections endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestCorrectionsEndpoint:
+    @pytest.mark.asyncio
+    async def test_list_by_pocket_returns_corrections(
+        self, app_with_store, client: TestClient
+    ) -> None:
+        _, store = app_with_store
+        action = await store.propose(
+            pocket_id="pocket-1",
+            title="Old",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+        )
+        client.post(
+            f"/instinct/actions/{action.id}/approve",
+            json={"approver": "user:priya", "title": "New"},
+        )
+
+        res = client.get("/instinct/corrections?pocket_id=pocket-1")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] == 1
+        assert body["corrections"][0]["patches"][0]["path"] == "title"
+
+    def test_list_without_filters_returns_400(self, client: TestClient) -> None:
+        res = client.get("/instinct/corrections")
+        assert res.status_code == 400

--- a/tests/cloud/test_ee_instinct.py
+++ b/tests/cloud/test_ee_instinct.py
@@ -852,8 +852,10 @@ class TestApproveEndpoint:
         approve_resp = client.post(f"/instinct/actions/{action_id}/approve")
         assert approve_resp.status_code == 200
         data = approve_resp.json()
-        assert data["status"] == "approved"
-        assert data["id"] == action_id
+        # Response shape now wraps the action + optional correction (Move 1 PR-A).
+        assert data["action"]["status"] == "approved"
+        assert data["action"]["id"] == action_id
+        assert data["correction"] is None
 
     def test_approve_removes_from_pending(self, client: TestClient) -> None:
         propose_resp = client.post("/instinct/actions", json=PROPOSE_PAYLOAD)
@@ -1017,7 +1019,7 @@ class TestFullLifecycle:
         # Step 3: approve
         approve_resp = client.post(f"/instinct/actions/{action_id}/approve")
         assert approve_resp.status_code == 200
-        assert approve_resp.json()["status"] == "approved"
+        assert approve_resp.json()["action"]["status"] == "approved"
 
         # Step 4: no longer in pending
         pending_resp_after = client.get("/instinct/actions/pending")


### PR DESCRIPTION
## Why

The Instinct pipeline already captured what the agent proposed and what the human ultimately decided. It did not capture the delta between them — the edits a rep made to a draft before hitting approve. That delta is the single cheapest learning signal we have, and it was being discarded every time.

This PR lands the first part of the Correction Loop: the data model, storage, and endpoint surface. PR-B will wire the captured corrections into soul-protocol so the agent learns from them on the next proposal. PR-C (paw-enterprise) adds the Edit & Approve UI.

## What's in this PR

### `ee/instinct/correction.py` (new)
- `CorrectionPatch` and `Correction` Pydantic models.
- `compute_patches(before, after)` structural diff across fields a human would actually edit: `title`, `description`, `recommendation`, `category`, `priority`, and the top-level keys of `parameters`. `context` is intentionally skipped — it's reasoning metadata, not action content, and will be handled by the Move 2 decision-trace collector.
- `summarize_correction(action, patches)` formats a deterministic, LLM-free recall key for the soul bridge to consume in PR-B.

### `ee/instinct/store.py`
- New `instinct_corrections` SQLite table with indexes on `pocket_id` and `action_id`.
- `record_correction()` persists the row and logs a `correction_captured` audit event carrying the patch paths.
- `get_corrections_for_pocket` / `get_corrections_for_action` / `count_corrections_by_path` read paths.

### `ee/instinct/router.py`
- `POST /instinct/actions/{id}/approve` accepts an optional `ApproveRequest` body with edited fields. When edits differ from the stored proposal, the server diffs the two, persists a `Correction`, and writes the edits back to the action before transitioning its status to approved.
- Response is now `ApproveResponse { action, correction | null }` so callers always know whether learning was captured. No-body POST still approves unchanged.
- `GET /instinct/corrections?pocket_id=...|action_id=...` exposes captured deltas for the UI and the agent tool in PR-B.

## Test plan

- [x] `uv run pytest tests/cloud/test_ee_correction.py` — 21 new tests, all passing
- [x] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py` — 3991 passed, 0 failed
- [x] `uv run ruff check ee/instinct/ tests/cloud/test_ee_correction.py` — clean

## Follow-ups

- **PR-B** (this workstream) — soul bridge + `instinct_corrections` agent tool + `context_builder` hook so past edits shape the next proposal.
- **PR-C** (paw-enterprise) — Edit & Approve UI. Will also update `src/lib/core/runtime/api.ts` to consume the new `ApproveResponse` shape (existing callers only use the returned object at runtime for optimistic updates; types need refresh).

## Context

Design doc: `paw-enterprise/docs/enterprise/CORRECTION-LOOP.md`.