### PR TITLE
Route captured corrections into soul + expose a read tool

### DIFF
--- a/ee/instinct/correction_soul_bridge.py
+++ b/ee/instinct/correction_soul_bridge.py
@@ -1,0 +1,151 @@
+# ee/instinct/correction_soul_bridge.py — Wires Corrections into soul-protocol.
+# Created: 2026-04-12 (Move 1 PR-B) — Turns each captured human edit into a soul
+# observation, and promotes repeated edits on the same field into a procedural
+# memory. No new soul primitive — uses soul.observe() + soul.remember() as-is.
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ee.instinct.correction import Correction, CorrectionPatch
+from ee.instinct.models import Action
+
+logger = logging.getLogger(__name__)
+
+_PROMOTION_THRESHOLD = 3  # Same path edited N times → procedural memory
+_PROCEDURAL_IMPORTANCE = 7
+_EPISODIC_IMPORTANCE = 5
+
+if TYPE_CHECKING:
+    from ee.instinct.store import InstinctStore  # noqa: F401
+
+
+class CorrectionSoulBridge:
+    """Connects captured Corrections to soul-protocol's learning hooks.
+
+    Call `record(correction, action)` right after persisting the Correction
+    in the store. The bridge:
+
+    - Always observes the edit as an Interaction so it enters the soul's
+      episodic tier with a recall-friendly summary.
+    - Counts how many times the same `path` has been edited in this pocket.
+      On the third match, synthesizes a short rule and stores it as a
+      procedural memory (importance 7).
+
+    The bridge degrades silently when the soul is not loaded — corrections
+    still persist to SQLite, and the agent tool can still read them back.
+    Nothing in the request path fails because soul is down.
+    """
+
+    def __init__(self, soul_manager: object, store: object) -> None:
+        self._soul_manager = soul_manager
+        self._store = store
+
+    async def record(self, correction: Correction, action: Action) -> None:
+        soul = self._get_soul()
+        if soul is None:
+            logger.debug("No active soul — correction recorded to store only")
+            return
+
+        await self._observe_correction(soul, correction, action)
+        await self._maybe_promote_to_procedural(soul, correction)
+
+    async def _observe_correction(
+        self, soul: object, correction: Correction, action: Action
+    ) -> None:
+        """Record the correction as an Interaction so it enters episodic memory."""
+        try:
+            from soul_protocol import Interaction
+
+            patches_text = "\n".join(
+                f"  - {p.path}: {self._fmt(p.before)} → {self._fmt(p.after)}"
+                for p in correction.patches
+            )
+            user_input = (
+                f"Correction on action '{action.title}' "
+                f"(pocket={correction.pocket_id}, actor={correction.actor})"
+            )
+            agent_output = (
+                f"Original recommendation: {action.recommendation or '(none)'}\n"
+                f"Edits applied by human:\n{patches_text}\n"
+                f"Summary: {correction.context_summary}"
+            )
+            await soul.observe(Interaction(user_input=user_input, agent_output=agent_output))
+            logger.info(
+                "Correction %s recorded to soul (action=%s, paths=%s)",
+                correction.id,
+                correction.action_id,
+                [p.path for p in correction.patches],
+            )
+        except Exception:
+            logger.exception("Failed to observe correction — continuing without soul record")
+
+    async def _maybe_promote_to_procedural(
+        self, soul: object, correction: Correction
+    ) -> None:
+        """When a path has been corrected _PROMOTION_THRESHOLD times, synthesize a rule."""
+        if not hasattr(soul, "remember"):
+            return
+
+        for patch in correction.patches:
+            try:
+                count = await self._store.count_corrections_by_path(
+                    pocket_id=correction.pocket_id,
+                    path=patch.path,
+                )
+            except Exception:
+                logger.debug("Failed to count corrections for path %s", patch.path)
+                continue
+
+            if count != _PROMOTION_THRESHOLD:
+                continue
+
+            rule = self._synthesize_rule(patch, correction)
+            try:
+                await soul.remember(
+                    content=rule,
+                    type="procedural",
+                    importance=_PROCEDURAL_IMPORTANCE,
+                )
+                logger.info(
+                    "Promoted to procedural after %dx '%s' corrections: %s",
+                    _PROMOTION_THRESHOLD,
+                    patch.path,
+                    rule,
+                )
+            except Exception:
+                logger.exception("Failed to persist procedural rule for path %s", patch.path)
+
+    def _get_soul(self) -> object | None:
+        """Resolve the active Soul, tolerating different manager shapes."""
+        manager = self._soul_manager
+        if manager is None:
+            return None
+        soul = getattr(manager, "soul", None)
+        return soul
+
+    @staticmethod
+    def _synthesize_rule(patch: CorrectionPatch, correction: Correction) -> str:
+        """Short natural-language rule — no LLM, deterministic."""
+        if patch.path.startswith("parameters."):
+            key = patch.path.split(".", 1)[1]
+            return (
+                f"For actions in pocket {correction.pocket_id}, "
+                f"{correction.actor} consistently sets {key} to "
+                f"{CorrectionSoulBridge._fmt(patch.after)} "
+                f"(changed from {CorrectionSoulBridge._fmt(patch.before)})."
+            )
+        return (
+            f"For actions in pocket {correction.pocket_id}, "
+            f"{correction.actor} consistently rewrites {patch.path} — "
+            f"most recent: {CorrectionSoulBridge._fmt(patch.before)} → "
+            f"{CorrectionSoulBridge._fmt(patch.after)}."
+        )
+
+    @staticmethod
+    def _fmt(value: object) -> str:
+        if value is None:
+            return "(none)"
+        s = str(value)
+        return s if len(s) <= 80 else s[:77] + "..."

--- a/ee/instinct/router.py
+++ b/ee/instinct/router.py
@@ -181,11 +181,27 @@ async def approve_action(action_id: str, req: ApproveRequest | None = None):
             )
             await store.record_correction(correction)
             await _persist_edits(store, after, edited_fields)
+            await _forward_to_soul(correction, after)
 
     approved = await store.approve(action_id, approver=req.approver)
     if not approved:
         raise HTTPException(404, "Action not found")
     return ApproveResponse(action=approved, correction=correction)
+
+
+async def _forward_to_soul(correction: Correction, action: Action) -> None:
+    """Hand off to the soul bridge — always best-effort, never breaks approval."""
+    try:
+        from ee.instinct.correction_soul_bridge import CorrectionSoulBridge
+        from pocketpaw.soul.manager import get_soul_manager
+
+        manager = get_soul_manager()
+        if manager is None:
+            return
+        bridge = CorrectionSoulBridge(soul_manager=manager, store=_store())
+        await bridge.record(correction, action)
+    except Exception:
+        logger.exception("Correction soul-bridge failed (non-fatal)")
 
 
 @router.post("/instinct/actions/{action_id}/reject", response_model=Action)

--- a/src/pocketpaw/tools/builtin/__init__.py
+++ b/src/pocketpaw/tools/builtin/__init__.py
@@ -92,6 +92,7 @@ try:
         FabricQueryTool,
         FabricStatsTool,
     )
+    from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
     from pocketpaw.tools.builtin.instinct_tools import (
         InstinctAuditTool,
         InstinctPendingTool,
@@ -105,6 +106,7 @@ try:
         InstinctProposeTool,
         InstinctPendingTool,
         InstinctAuditTool,
+        InstinctCorrectionsTool,
     ]
     _EE_NAMES = {cls.__name__: cls for cls in _EE_TOOLS}
 except ImportError:

--- a/src/pocketpaw/tools/builtin/instinct_corrections.py
+++ b/src/pocketpaw/tools/builtin/instinct_corrections.py
@@ -1,0 +1,112 @@
+# Instinct corrections tool — agent-facing surface for learned human edits.
+# Created: 2026-04-12 (Move 1 PR-B) — Lets an agent fetch recent corrections for
+# a pocket before proposing its next action, so past human edits shape the draft.
+# Pairs with the correction_soul_bridge, which also feeds the same signal into
+# soul-protocol's automatic memory injection when a soul is loaded.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw.tools.protocol import BaseTool
+
+logger = logging.getLogger(__name__)
+
+
+def _get_instinct_store():
+    """Lazy import — degrades gracefully when ee/ is not installed."""
+    try:
+        from ee.api import get_instinct_store
+
+        return get_instinct_store()
+    except ImportError:
+        return None
+
+
+class InstinctCorrectionsTool(BaseTool):
+    """Fetch recent human corrections on actions within a pocket."""
+
+    @property
+    def name(self) -> str:
+        return "instinct_corrections"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Fetch recent human edits (corrections) applied to previously proposed "
+            "actions in a pocket. Use this BEFORE proposing a new action so your "
+            "draft already matches the style and thresholds the user prefers — e.g. "
+            "if they consistently edit the greeting tone or cap a discount percentage, "
+            "match that pattern in the new proposal."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "high"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "pocket_id": {
+                    "type": "string",
+                    "description": "Pocket whose corrections you want to review",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max corrections to return (default: 10, max: 50)",
+                    "default": 10,
+                },
+            },
+            "required": ["pocket_id"],
+        }
+
+    async def execute(self, pocket_id: str, limit: int = 10) -> str:
+        store = _get_instinct_store()
+        if not store:
+            return "Instinct is not available (enterprise feature)."
+
+        try:
+            corrections = await store.get_corrections_for_pocket(
+                pocket_id=pocket_id,
+                limit=min(max(limit, 1), 50),
+            )
+        except Exception as exc:
+            logger.error("instinct_corrections lookup failed: %s", exc)
+            return f"Error loading corrections: {exc}"
+
+        if not corrections:
+            return (
+                f"No corrections captured yet for pocket {pocket_id}. "
+                "Propose freely — nothing to align with."
+            )
+
+        lines = [
+            f"{len(corrections)} recent correction(s) for pocket {pocket_id}:",
+            "",
+        ]
+        for c in corrections:
+            lines.append(f"- {c.action_title} (edited by {c.actor})")
+            lines.append(f"    Summary: {c.context_summary}")
+            for patch in c.patches[:5]:
+                before = _fmt(patch.before)
+                after = _fmt(patch.after)
+                lines.append(f"    {patch.path}: {before} → {after}")
+            if len(c.patches) > 5:
+                lines.append(f"    (+{len(c.patches) - 5} more field changes)")
+            lines.append("")
+
+        lines.append(
+            "When proposing your next action, pre-apply these patterns unless the "
+            "situation clearly calls for something different.",
+        )
+        return "\n".join(lines)
+
+
+def _fmt(value: object) -> str:
+    if value is None:
+        return "(none)"
+    s = str(value)
+    return s if len(s) <= 60 else s[:57] + "..."

--- a/tests/cloud/test_correction_soul_bridge.py
+++ b/tests/cloud/test_correction_soul_bridge.py
@@ -1,0 +1,333 @@
+# tests/cloud/test_correction_soul_bridge.py — Tests for the correction soul bridge
+# and the instinct_corrections agent tool (Move 1 PR-B).
+# Created: 2026-04-13 — Covers observe() call shape, 3x procedural promotion,
+# graceful degradation when no soul is loaded, and tool output formatting.
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ee.instinct.correction import Correction, CorrectionPatch
+from ee.instinct.correction_soul_bridge import CorrectionSoulBridge
+from ee.instinct.models import (
+    Action,
+    ActionCategory,
+    ActionPriority,
+    ActionTrigger,
+)
+from ee.instinct.store import InstinctStore
+
+
+@pytest.fixture(autouse=True)
+def _stub_soul_protocol(monkeypatch):
+    """Provide a minimal fake `soul_protocol` module when the real one is absent.
+
+    Production code imports `soul_protocol.Interaction` lazily inside the
+    bridge; the real package is an optional dep not installed in the base
+    dev env. A lightweight stub is sufficient to exercise the bridge's code
+    path without pulling in the full soul runtime.
+    """
+    if "soul_protocol" in sys.modules:
+        return
+
+    module = types.ModuleType("soul_protocol")
+
+    class _Interaction:
+        def __init__(self, user_input: str = "", agent_output: str = "", **kwargs):
+            self.user_input = user_input
+            self.agent_output = agent_output
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    module.Interaction = _Interaction  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "soul_protocol", module)
+
+
+def _trigger() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="claude", reason="test")
+
+
+def _action(**overrides) -> Action:
+    defaults: dict = {
+        "pocket_id": "pocket-1",
+        "title": "Send renewal outreach",
+        "description": "Two accounts up for renewal",
+        "recommendation": "Draft a formal nudge email",
+        "trigger": _trigger(),
+        "category": ActionCategory.WORKFLOW,
+        "priority": ActionPriority.MEDIUM,
+        "parameters": {"tone": "formal", "discount_pct": 20},
+    }
+    defaults.update(overrides)
+    return Action(**defaults)
+
+
+def _correction(
+    *,
+    action_id: str = "act-1",
+    patches: list[CorrectionPatch] | None = None,
+    pocket_id: str = "pocket-1",
+    actor: str = "user:priya",
+) -> Correction:
+    return Correction(
+        action_id=action_id,
+        pocket_id=pocket_id,
+        actor=actor,
+        patches=patches or [CorrectionPatch(path="title", before="A", after="B")],
+        context_summary="softened the greeting",
+        action_title="Send renewal outreach",
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "bridge_test.db")
+
+
+@pytest.fixture
+def fake_soul():
+    soul = MagicMock()
+    soul.observe = AsyncMock()
+    soul.remember = AsyncMock()
+    return soul
+
+
+@pytest.fixture
+def manager_with_soul(fake_soul):
+    manager = MagicMock()
+    manager.soul = fake_soul
+    return manager
+
+
+# ---------------------------------------------------------------------------
+# record() — observe path
+# ---------------------------------------------------------------------------
+
+
+class TestObserveCorrection:
+    @pytest.mark.asyncio
+    async def test_observe_called_once_per_correction(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+        await bridge.record(_correction(), _action())
+
+        assert fake_soul.observe.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_observe_payload_includes_summary_and_patches(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+        correction = _correction(
+            patches=[
+                CorrectionPatch(path="title", before="Formal", after="Casual"),
+                CorrectionPatch(path="parameters.discount_pct", before=20, after=15),
+            ],
+        )
+        await bridge.record(correction, _action())
+
+        (call,) = fake_soul.observe.await_args_list
+        interaction = call.args[0]
+        assert "pocket-1" in interaction.user_input
+        assert "user:priya" in interaction.user_input
+        assert "title" in interaction.agent_output
+        assert "parameters.discount_pct" in interaction.agent_output
+        assert "softened the greeting" in interaction.agent_output
+
+    @pytest.mark.asyncio
+    async def test_no_observe_when_soul_is_absent(self, store: InstinctStore) -> None:
+        manager = MagicMock()
+        manager.soul = None
+        bridge = CorrectionSoulBridge(soul_manager=manager, store=store)
+        # Should not raise, just no-op.
+        await bridge.record(_correction(), _action())
+
+    @pytest.mark.asyncio
+    async def test_observe_exception_is_swallowed(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        fake_soul.observe.side_effect = RuntimeError("soul went down")
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+        # Should not raise — approval flow must never break because soul is sick.
+        await bridge.record(_correction(), _action())
+
+
+# ---------------------------------------------------------------------------
+# Procedural promotion — 3x-same-path heuristic
+# ---------------------------------------------------------------------------
+
+
+class TestProceduralPromotion:
+    @pytest.mark.asyncio
+    async def test_promotes_on_third_same_path(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+
+        first = _correction(
+            action_id="act-a",
+            patches=[CorrectionPatch(path="parameters.tone", before="formal", after="casual")],
+        )
+        second = _correction(
+            action_id="act-b",
+            patches=[CorrectionPatch(path="parameters.tone", before="formal", after="casual")],
+        )
+        third = _correction(
+            action_id="act-c",
+            patches=[CorrectionPatch(path="parameters.tone", before="formal", after="casual")],
+        )
+
+        await store.record_correction(first)
+        await bridge.record(first, _action())
+        assert fake_soul.remember.await_count == 0
+
+        await store.record_correction(second)
+        await bridge.record(second, _action())
+        assert fake_soul.remember.await_count == 0
+
+        await store.record_correction(third)
+        await bridge.record(third, _action())
+        assert fake_soul.remember.await_count == 1
+
+        kwargs = fake_soul.remember.await_args.kwargs
+        assert kwargs["type"] == "procedural"
+        assert kwargs["importance"] == 7
+        assert "parameters.tone" in kwargs["content"] or "tone" in kwargs["content"]
+        assert "casual" in kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_does_not_re_promote_past_threshold(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+
+        for i in range(4):
+            correction = _correction(
+                action_id=f"act-{i}",
+                patches=[CorrectionPatch(path="title", before="A", after="B")],
+            )
+            await store.record_correction(correction)
+            await bridge.record(correction, _action())
+
+        # Promotion fires exactly once, when count hits the threshold.
+        assert fake_soul.remember.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_promotes_per_path_independently(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+
+        for i in range(3):
+            await store.record_correction(
+                _correction(
+                    action_id=f"title-{i}",
+                    patches=[CorrectionPatch(path="title", before="A", after="B")],
+                ),
+            )
+        for i in range(3):
+            await store.record_correction(
+                _correction(
+                    action_id=f"prio-{i}",
+                    patches=[CorrectionPatch(path="priority", before="medium", after="high")],
+                ),
+            )
+
+        await bridge.record(
+            _correction(
+                action_id="title-2",
+                patches=[CorrectionPatch(path="title", before="A", after="B")],
+            ),
+            _action(),
+        )
+        await bridge.record(
+            _correction(
+                action_id="prio-2",
+                patches=[CorrectionPatch(path="priority", before="medium", after="high")],
+            ),
+            _action(),
+        )
+
+        assert fake_soul.remember.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# InstinctCorrectionsTool — agent-facing shape
+# ---------------------------------------------------------------------------
+
+
+class TestInstinctCorrectionsTool:
+    @pytest.mark.asyncio
+    async def test_tool_returns_no_corrections_message_when_empty(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
+
+        empty_store = InstinctStore(tmp_path / "empty.db")
+        monkeypatch.setattr(
+            "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
+            lambda: empty_store,
+        )
+
+        tool = InstinctCorrectionsTool()
+        result = await tool.execute(pocket_id="pocket-1")
+        assert "No corrections captured" in result
+
+    @pytest.mark.asyncio
+    async def test_tool_formats_each_correction_with_patches(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
+
+        store = InstinctStore(tmp_path / "with_data.db")
+        await store.record_correction(
+            _correction(
+                action_id="act-x",
+                patches=[
+                    CorrectionPatch(path="title", before="Hi John", after="Hey J"),
+                    CorrectionPatch(path="parameters.discount_pct", before=20, after=15),
+                ],
+            ),
+        )
+        monkeypatch.setattr(
+            "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
+            lambda: store,
+        )
+
+        tool = InstinctCorrectionsTool()
+        result = await tool.execute(pocket_id="pocket-1")
+        assert "Send renewal outreach" in result
+        assert "user:priya" in result
+        assert "Hi John" in result
+        assert "Hey J" in result
+        assert "discount_pct" in result
+
+    @pytest.mark.asyncio
+    async def test_tool_returns_enterprise_missing_message_when_ee_unavailable(
+        self, monkeypatch
+    ) -> None:
+        from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
+
+        monkeypatch.setattr(
+            "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
+            lambda: None,
+        )
+
+        tool = InstinctCorrectionsTool()
+        result = await tool.execute(pocket_id="pocket-1")
+        assert "enterprise" in result.lower()
+
+    def test_tool_advertises_required_parameters(self) -> None:
+        from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
+
+        tool = InstinctCorrectionsTool()
+        assert tool.name == "instinct_corrections"
+        schema = tool.parameters
+        assert "pocket_id" in schema["properties"]
+        assert schema["required"] == ["pocket_id"]


### PR DESCRIPTION
## Why

Part two of the correction loop. [PR #928](https://github.com/pocketpaw/pocketpaw/pull/928) captured the diff between proposal and approval; this PR feeds that signal into soul-protocol and makes it available to the agent on the next draft.

Stacks on top of `feat/correction-loop-models` — ready to merge into `dev` once PR-A lands.

## What's in this PR

### `ee/instinct/correction_soul_bridge.py` (new)
- `CorrectionSoulBridge.record(correction, action)` observes the edit as a soul `Interaction` with the full patch list in `agent_output` — enters the episodic tier with a recall-friendly body.
- Counts how many times the same `path` has been edited in this pocket. On the **third match**, synthesizes a short deterministic rule (no LLM call on the hot path) and stores it as a procedural memory at importance 7.
- Degrades silently when the soul is absent, or when any step of the soul handoff raises. Approval must never fail because the soul is sick. Corrections still persist to SQLite either way.

### `ee/instinct/router.py`
- `/approve` forwards to the bridge after `record_correction` succeeds. Best-effort, never blocks the response.

### `src/pocketpaw/tools/builtin/instinct_corrections.py` (new)
- New `instinct_corrections` agent tool. The agent calls it with a `pocket_id` before proposing a new action and gets back a formatted list of recent edits with patch paths. Pre-applying those patterns is the whole point — the draft reflects the user's history before it reaches the Tray.
- Registered alongside `instinct_propose` / `instinct_pending` / `instinct_audit` in the enterprise tool block. All 7 agent backends pick it up.

## Test plan

- [x] 11 new tests in `tests/cloud/test_correction_soul_bridge.py`:
  - observe payload shape (summary + patches in agent_output)
  - 3x-same-path promotion fires exactly once
  - promotion tracks different paths independently
  - graceful no-soul degradation
  - observe exception is swallowed
  - tool empty state, populated state, ee-missing message, parameter schema
- [x] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py` — 3991 passed, 0 failed
- [x] `uv run ruff check` — clean
- [x] Optional `soul_protocol` dep stubbed via autouse fixture so tests run in the base dev env

## Note on context injection

The original plan called for a `context_builder.py` step 4f to auto-inject corrections. We skipped it this PR because soul-protocol's existing `SoulBootstrapProvider` already pulls in the episodic memories we wrote via `soul.observe()`, and the `instinct_corrections` tool provides an explicit fallback when soul isn't loaded. Adding a third injection path would duplicate the signal and couple `context_builder` to the instinct store unnecessarily.

## Follow-ups

- **PR-C** (paw-enterprise) — Edit & Approve UI + `api.ts` type refresh for the new `ApproveResponse` shape.

## Context

Design doc: `paw-enterprise/docs/enterprise/CORRECTION-LOOP.md`.