### PR TITLE
ReasoningTrace + TraceCollector + fabric snapshots

### DIFF
--- a/ee/instinct/__init__.py
+++ b/ee/instinct/__init__.py
@@ -22,6 +22,8 @@ from ee.instinct.models import (
     AuditEntry,
 )
 from ee.instinct.store import InstinctStore
+from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace, ToolCallRef
+from ee.instinct.trace_collector import TraceCollector
 
 __all__ = [
     "Action",
@@ -34,7 +36,11 @@ __all__ = [
     "AuditEntry",
     "Correction",
     "CorrectionPatch",
+    "FabricObjectSnapshot",
     "InstinctStore",
+    "ReasoningTrace",
+    "ToolCallRef",
+    "TraceCollector",
     "compute_patches",
     "summarize_correction",
 ]

--- a/ee/instinct/store.py
+++ b/ee/instinct/store.py
@@ -25,6 +25,7 @@ from ee.instinct.models import (
     AuditCategory,
     AuditEntry,
 )
+from ee.instinct.trace import FabricObjectSnapshot
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS instinct_actions (
@@ -74,12 +75,23 @@ CREATE TABLE IF NOT EXISTS instinct_corrections (
     created_at TEXT DEFAULT (datetime('now'))
 );
 
+CREATE TABLE IF NOT EXISTS instinct_fabric_snapshots (
+    id TEXT PRIMARY KEY,
+    object_id TEXT NOT NULL,
+    audit_id TEXT NOT NULL,
+    object_type TEXT DEFAULT '',
+    snapshot TEXT DEFAULT '{}',
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
 CREATE INDEX IF NOT EXISTS idx_actions_pocket ON instinct_actions(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_actions_status ON instinct_actions(status);
 CREATE INDEX IF NOT EXISTS idx_audit_pocket ON instinct_audit(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON instinct_audit(timestamp);
 CREATE INDEX IF NOT EXISTS idx_corrections_pocket ON instinct_corrections(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_corrections_action ON instinct_corrections(action_id);
+CREATE INDEX IF NOT EXISTS idx_snapshots_audit ON instinct_fabric_snapshots(audit_id);
+CREATE INDEX IF NOT EXISTS idx_snapshots_object ON instinct_fabric_snapshots(object_id);
 """
 
 
@@ -462,6 +474,57 @@ class InstinctStore:
         corrections = await self.get_corrections_for_pocket(pocket_id, limit=1000)
         return sum(1 for c in corrections if any(p.path == path for p in c.patches))
 
+    # --- Fabric object snapshots (decision traces) ---
+
+    async def record_fabric_snapshot(self, snapshot: FabricObjectSnapshot) -> FabricObjectSnapshot:
+        """Persist a Fabric object snapshot keyed to the audit entry.
+
+        The snapshot preserves the object's state at decision time so later
+        queries can reproduce what the agent actually saw, even if the live
+        object has been updated since.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO instinct_fabric_snapshots"
+                " (id, object_id, audit_id, object_type, snapshot, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    snapshot.id,
+                    snapshot.object_id,
+                    snapshot.audit_id,
+                    snapshot.object_type,
+                    json.dumps(snapshot.snapshot),
+                    snapshot.created_at.isoformat(),
+                ),
+            )
+            await db.commit()
+        return snapshot
+
+    async def get_snapshots_for_audit(self, audit_id: str) -> list[FabricObjectSnapshot]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM instinct_fabric_snapshots WHERE audit_id = ?"
+                " ORDER BY created_at ASC",
+                (audit_id,),
+            ) as cur:
+                return [self._row_to_snapshot(row) async for row in cur]
+
+    async def get_snapshots_for_object(
+        self, object_id: str, limit: int = 100
+    ) -> list[FabricObjectSnapshot]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM instinct_fabric_snapshots WHERE object_id = ?"
+                " ORDER BY created_at DESC LIMIT ?",
+                (object_id, limit),
+            ) as cur:
+                return [self._row_to_snapshot(row) async for row in cur]
+
     # --- Helpers ---
 
     def _row_to_action(self, row: Any) -> Action:
@@ -509,5 +572,15 @@ class InstinctStore:
             patches=[CorrectionPatch.model_validate(p) for p in patches_raw],
             context_summary=row["context_summary"],
             action_title=row["action_title"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+    def _row_to_snapshot(self, row: Any) -> FabricObjectSnapshot:
+        return FabricObjectSnapshot(
+            id=row["id"],
+            object_id=row["object_id"],
+            audit_id=row["audit_id"],
+            object_type=row["object_type"] or "",
+            snapshot=json.loads(row["snapshot"]) if row["snapshot"] else {},
             created_at=datetime.fromisoformat(row["created_at"]),
         )

--- a/ee/instinct/trace.py
+++ b/ee/instinct/trace.py
@@ -1,0 +1,65 @@
+# ee/instinct/trace.py — Decision trace types for the Instinct pipeline.
+# Created: 2026-04-13 (Move 2 PR-A) — Captures the reasoning inputs behind each
+# proposed action so the audit log explains *why*, not just *what*. Paired with
+# TraceCollector (the bus-subscriber context manager) and FabricObjectSnapshot
+# (immutable rows that preserve referenced objects at decision time).
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from ee.fabric.models import _gen_id
+
+
+class ToolCallRef(BaseModel):
+    """One tool call captured during proposal reasoning.
+
+    Stored inside `ReasoningTrace.tool_calls`. `args_hash` is a stable fingerprint
+    of the invocation so repeated calls dedupe cleanly; `result_preview` is the
+    first 200 chars of the result string so a human can inspect the trace without
+    re-running the tool.
+    """
+
+    tool: str
+    args_hash: str
+    result_preview: str = ""
+    duration_ms: int = 0
+
+
+class ReasoningTrace(BaseModel):
+    """Full reasoning context that produced a proposed action.
+
+    Every decision that lands in `AuditEntry.context` under the key
+    `reasoning_trace` follows this schema. Reference fields hold IDs only —
+    hydrated content is resolved at read time via the `?hydrate=1` endpoint
+    (Move 2 PR-B).
+    """
+
+    fabric_queries: list[str] = Field(default_factory=list)
+    soul_memories: list[str] = Field(default_factory=list)
+    kb_articles: list[str] = Field(default_factory=list)
+    tool_calls: list[ToolCallRef] = Field(default_factory=list)
+    prompt_version: str = ""
+    backend: str = ""
+    model: str = ""
+    token_counts: dict[str, int] = Field(default_factory=dict)
+
+
+class FabricObjectSnapshot(BaseModel):
+    """An immutable snapshot of a Fabric object at the time a decision was made.
+
+    When the live object later changes (ownership transfer, status update,
+    anything), the trace still reproduces what the agent saw. Keyed by
+    (object_id, audit_id) so a single query can be referenced by many
+    decisions without duplication.
+    """
+
+    id: str = Field(default_factory=lambda: _gen_id("fos"))
+    object_id: str
+    audit_id: str
+    object_type: str = ""
+    snapshot: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=datetime.now)

--- a/ee/instinct/trace_collector.py
+++ b/ee/instinct/trace_collector.py
@@ -1,0 +1,152 @@
+# ee/instinct/trace_collector.py — Async context manager that captures reasoning
+# inputs for a single proposal.
+# Created: 2026-04-13 (Move 2 PR-A) — Subscribes to SystemEvents on the bus,
+# aggregates fabric_query / soul_recall / kb_inject / tool_start+tool_end events
+# into a ReasoningTrace, and exposes the finished trace for persistence by the
+# caller. No global state: a fresh collector per proposal keeps traces isolated.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from typing import Any
+
+from ee.instinct.trace import ReasoningTrace, ToolCallRef
+
+logger = logging.getLogger(__name__)
+
+_PREVIEW_CHARS = 200
+_TOOL_EVENT_START = "tool_start"
+_TOOL_EVENT_END = "tool_end"
+_TOOL_EVENT_RESULT = "tool_result"
+_FABRIC_EVENT = "fabric_query"
+_SOUL_EVENT = "soul_recall"
+_KB_EVENT = "kb_inject"
+
+
+class TraceCollector:
+    """Async context manager that captures reasoning events on the message bus.
+
+    Usage:
+        async with TraceCollector(bus) as trace:
+            action = await agent.propose(...)
+        # trace now holds the captured ReasoningTrace
+
+    The collector subscribes to `subscribe_system` on enter and unsubscribes on
+    exit — always, even if the body raises. It aggregates:
+
+    - Fabric queries (event_type="fabric_query", data["object_id"])
+    - Soul recalls (event_type="soul_recall", data["memory_id"])
+    - KB injections (event_type="kb_inject", data["article_id"])
+    - Tool calls (event_type="tool_start"/"tool_end" with matching tool name)
+
+    Unknown event types are ignored. Duplicate IDs within a single trace are
+    preserved in insertion order but the `fabric_queries` / `soul_memories` /
+    `kb_articles` lists are deduplicated on exit so the trace body stays
+    compact.
+    """
+
+    def __init__(
+        self,
+        bus: Any,
+        *,
+        prompt_version: str = "",
+        backend: str = "",
+        model: str = "",
+    ) -> None:
+        self._bus = bus
+        self.trace = ReasoningTrace(
+            prompt_version=prompt_version,
+            backend=backend,
+            model=model,
+        )
+        self._pending_tool_starts: dict[str, float] = {}
+        self._callback: Any = None
+
+    async def __aenter__(self) -> TraceCollector:
+        self._callback = self._on_event
+        self._bus.subscribe_system(self._callback)
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        if self._callback is not None:
+            try:
+                self._bus.unsubscribe_system(self._callback)
+            except Exception:
+                logger.debug("TraceCollector unsubscribe failed")
+            self._callback = None
+        # Deduplicate the reference lists while preserving insertion order.
+        self.trace.fabric_queries = _dedupe(self.trace.fabric_queries)
+        self.trace.soul_memories = _dedupe(self.trace.soul_memories)
+        self.trace.kb_articles = _dedupe(self.trace.kb_articles)
+
+    async def _on_event(self, event: Any) -> None:
+        event_type = getattr(event, "event_type", None)
+        data = getattr(event, "data", {}) or {}
+        if event_type == _FABRIC_EVENT:
+            oid = data.get("object_id")
+            if isinstance(oid, str):
+                self.trace.fabric_queries.append(oid)
+        elif event_type == _SOUL_EVENT:
+            mid = data.get("memory_id")
+            if isinstance(mid, str):
+                self.trace.soul_memories.append(mid)
+        elif event_type == _KB_EVENT:
+            aid = data.get("article_id")
+            if isinstance(aid, str):
+                self.trace.kb_articles.append(aid)
+        elif event_type == _TOOL_EVENT_START:
+            tool = data.get("tool")
+            if isinstance(tool, str):
+                self._pending_tool_starts[tool] = time.monotonic()
+        elif event_type in (_TOOL_EVENT_END, _TOOL_EVENT_RESULT):
+            self._record_tool_end(data)
+
+    def _record_tool_end(self, data: dict[str, Any]) -> None:
+        tool = data.get("tool")
+        if not isinstance(tool, str):
+            return
+        args = data.get("args", {})
+        result = data.get("result", "")
+        started = self._pending_tool_starts.pop(tool, None)
+        duration_ms = int((time.monotonic() - started) * 1000) if started is not None else 0
+
+        args_hash = _hash_args(args)
+        preview = str(result)
+        if len(preview) > _PREVIEW_CHARS:
+            preview = preview[:_PREVIEW_CHARS - 3] + "..."
+
+        # Dedupe identical tool+args pairs within a single trace.
+        for existing in self.trace.tool_calls:
+            if existing.tool == tool and existing.args_hash == args_hash:
+                return
+
+        self.trace.tool_calls.append(
+            ToolCallRef(
+                tool=tool,
+                args_hash=args_hash,
+                result_preview=preview,
+                duration_ms=duration_ms,
+            ),
+        )
+
+
+def _hash_args(args: Any) -> str:
+    try:
+        serialized = json.dumps(args, sort_keys=True, default=str)
+    except Exception:
+        serialized = str(args)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    """Dedupe while preserving the order of first appearance."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for v in values:
+        if v not in seen:
+            seen.add(v)
+            out.append(v)
+    return out

--- a/tests/cloud/test_decision_traces.py
+++ b/tests/cloud/test_decision_traces.py
@@ -1,0 +1,307 @@
+# tests/cloud/test_decision_traces.py — Tests for ReasoningTrace + TraceCollector
+# + FabricObjectSnapshot store ops (Move 2 PR-A).
+# Created: 2026-04-13 — Locks the context-manager lifecycle, event aggregation
+# across fabric/soul/kb/tool-call event types, deduplication on exit, and the
+# SQLite persistence path for decision-time fabric snapshots.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ee.instinct.store import InstinctStore
+from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace, ToolCallRef
+from ee.instinct.trace_collector import TraceCollector
+
+# ---------------------------------------------------------------------------
+# Lightweight bus + event stand-ins (avoids pulling the real MessageBus)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeEvent:
+    event_type: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+class FakeBus:
+    """Minimal subscribe/unsubscribe interface matching MessageBus."""
+
+    def __init__(self) -> None:
+        self.subscribers: list[Any] = []
+
+    def subscribe_system(self, cb: Any) -> None:
+        self.subscribers.append(cb)
+
+    def unsubscribe_system(self, cb: Any) -> None:
+        if cb in self.subscribers:
+            self.subscribers.remove(cb)
+
+    async def publish(self, event: FakeEvent) -> None:
+        for cb in list(self.subscribers):
+            await cb(event)
+
+
+# ---------------------------------------------------------------------------
+# ReasoningTrace — shape
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningTraceModel:
+    def test_defaults_produce_empty_collections(self) -> None:
+        trace = ReasoningTrace()
+        assert trace.fabric_queries == []
+        assert trace.soul_memories == []
+        assert trace.kb_articles == []
+        assert trace.tool_calls == []
+        assert trace.token_counts == {}
+
+    def test_round_trip_serialization(self) -> None:
+        trace = ReasoningTrace(
+            fabric_queries=["obj_1", "obj_2"],
+            soul_memories=["mem_a"],
+            kb_articles=["kb_42"],
+            tool_calls=[ToolCallRef(tool="fabric_query", args_hash="abc", result_preview="...")],
+            prompt_version="v1",
+            backend="claude_agent_sdk",
+            model="claude-opus-4-6",
+            token_counts={"prompt": 120, "completion": 45},
+        )
+        restored = ReasoningTrace.model_validate(trace.model_dump())
+        assert restored == trace
+
+
+# ---------------------------------------------------------------------------
+# TraceCollector lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestCollectorLifecycle:
+    @pytest.mark.asyncio
+    async def test_subscribes_on_enter_and_unsubscribes_on_exit(self) -> None:
+        bus = FakeBus()
+        assert bus.subscribers == []
+
+        async with TraceCollector(bus):
+            assert len(bus.subscribers) == 1
+
+        assert bus.subscribers == []
+
+    @pytest.mark.asyncio
+    async def test_unsubscribes_even_when_body_raises(self) -> None:
+        bus = FakeBus()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            async with TraceCollector(bus):
+                raise RuntimeError("boom")
+
+        assert bus.subscribers == []
+
+    @pytest.mark.asyncio
+    async def test_carries_prompt_version_backend_and_model(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(
+            bus,
+            prompt_version="pv_123",
+            backend="claude_agent_sdk",
+            model="claude-opus-4-6",
+        ) as collector:
+            pass
+        assert collector.trace.prompt_version == "pv_123"
+        assert collector.trace.backend == "claude_agent_sdk"
+        assert collector.trace.model == "claude-opus-4-6"
+
+
+# ---------------------------------------------------------------------------
+# TraceCollector — event aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestCollectorAggregation:
+    @pytest.mark.asyncio
+    async def test_captures_fabric_queries(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("fabric_query", {"object_id": "obj_acme"}))
+            await bus.publish(FakeEvent("fabric_query", {"object_id": "obj_pricing"}))
+        assert collector.trace.fabric_queries == ["obj_acme", "obj_pricing"]
+
+    @pytest.mark.asyncio
+    async def test_captures_soul_memories(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("soul_recall", {"memory_id": "mem_1"}))
+            await bus.publish(FakeEvent("soul_recall", {"memory_id": "mem_2"}))
+        assert collector.trace.soul_memories == ["mem_1", "mem_2"]
+
+    @pytest.mark.asyncio
+    async def test_captures_kb_articles(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("kb_inject", {"article_id": "kb_pricing"}))
+        assert collector.trace.kb_articles == ["kb_pricing"]
+
+    @pytest.mark.asyncio
+    async def test_captures_tool_calls_with_duration(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_end",
+                    {"tool": "fabric_query", "args": {"q": "acme"}, "result": "1 row"},
+                ),
+            )
+        assert len(collector.trace.tool_calls) == 1
+        call = collector.trace.tool_calls[0]
+        assert call.tool == "fabric_query"
+        assert call.result_preview == "1 row"
+        assert call.args_hash  # non-empty
+        assert call.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_tool_result_alias_event_also_captured(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("tool_start", {"tool": "kb_search"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_result",
+                    {"tool": "kb_search", "args": {"q": "discount"}, "result": "ok"},
+                ),
+            )
+        assert len(collector.trace.tool_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_long_tool_result_is_truncated_with_ellipsis(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_end",
+                    {"tool": "fabric_query", "args": {}, "result": "x" * 500},
+                ),
+            )
+        preview = collector.trace.tool_calls[0].result_preview
+        assert len(preview) == 200
+        assert preview.endswith("...")
+
+    @pytest.mark.asyncio
+    async def test_duplicate_tool_calls_with_same_args_are_merged(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            for _ in range(3):
+                await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+                await bus.publish(
+                    FakeEvent(
+                        "tool_end",
+                        {"tool": "fabric_query", "args": {"q": "acme"}, "result": "ok"},
+                    ),
+                )
+        assert len(collector.trace.tool_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_tool_calls_with_different_args_are_kept_separate(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_end",
+                    {"tool": "fabric_query", "args": {"q": "acme"}, "result": "ok"},
+                ),
+            )
+            await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_end",
+                    {"tool": "fabric_query", "args": {"q": "beta"}, "result": "ok"},
+                ),
+            )
+        assert len(collector.trace.tool_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_reference_lists_are_deduplicated_on_exit(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("fabric_query", {"object_id": "obj_acme"}))
+            await bus.publish(FakeEvent("fabric_query", {"object_id": "obj_acme"}))
+            await bus.publish(FakeEvent("soul_recall", {"memory_id": "mem_1"}))
+            await bus.publish(FakeEvent("soul_recall", {"memory_id": "mem_1"}))
+        assert collector.trace.fabric_queries == ["obj_acme"]
+        assert collector.trace.soul_memories == ["mem_1"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_types_are_ignored(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("unknown_thing", {"object_id": "nope"}))
+            await bus.publish(FakeEvent("another_thing", {"data": 1}))
+        assert collector.trace.fabric_queries == []
+        assert collector.trace.tool_calls == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_event_data_is_skipped(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("fabric_query", {"object_id": 123}))
+            await bus.publish(FakeEvent("soul_recall", {}))
+            await bus.publish(FakeEvent("tool_end", {"args": {"q": "x"}}))
+        assert collector.trace.fabric_queries == []
+        assert collector.trace.soul_memories == []
+        assert collector.trace.tool_calls == []
+
+
+# ---------------------------------------------------------------------------
+# FabricObjectSnapshot store ops
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "trace_test.db")
+
+
+class TestFabricSnapshotStore:
+    @pytest.mark.asyncio
+    async def test_record_and_read_snapshot(self, store: InstinctStore) -> None:
+        snapshot = FabricObjectSnapshot(
+            object_id="obj_acme",
+            audit_id="aud_42",
+            object_type="Customer",
+            snapshot={"arr": 180000, "tier": "enterprise"},
+        )
+        saved = await store.record_fabric_snapshot(snapshot)
+        assert saved.id == snapshot.id
+
+        rows = await store.get_snapshots_for_audit("aud_42")
+        assert len(rows) == 1
+        assert rows[0].object_id == "obj_acme"
+        assert rows[0].snapshot["arr"] == 180000
+        assert rows[0].object_type == "Customer"
+
+    @pytest.mark.asyncio
+    async def test_snapshots_for_audit_orders_oldest_first(self, store: InstinctStore) -> None:
+        first = FabricObjectSnapshot(object_id="a", audit_id="aud_1")
+        second = FabricObjectSnapshot(object_id="b", audit_id="aud_1")
+        await store.record_fabric_snapshot(first)
+        await store.record_fabric_snapshot(second)
+
+        rows = await store.get_snapshots_for_audit("aud_1")
+        assert [r.object_id for r in rows] == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_snapshots_for_object_orders_newest_first(
+        self, store: InstinctStore
+    ) -> None:
+        older = FabricObjectSnapshot(object_id="obj_x", audit_id="aud_1")
+        newer = FabricObjectSnapshot(object_id="obj_x", audit_id="aud_2")
+        await store.record_fabric_snapshot(older)
+        await store.record_fabric_snapshot(newer)
+
+        rows = await store.get_snapshots_for_object("obj_x")
+        assert [r.audit_id for r in rows] == ["aud_2", "aud_1"]


### PR DESCRIPTION
## Why

The audit log already records that a decision happened — actor, event, timestamp. It never recorded *why*. This PR lays the foundation so every proposal carries its reasoning context.

Stacks on `feat/correction-loop-soul` ([#929](https://github.com/pocketpaw/pocketpaw/pull/929)) to keep the diff clean. First of three PRs that land Move 2 (Decision Traces).

## What's in this PR

### `ee/instinct/trace.py`
- `ToolCallRef` — tool invocation captured during reasoning: tool name, stable args fingerprint, 200-char result preview, duration. Hash lets repeated calls dedupe without losing the first result.
- `ReasoningTrace` — the top-level structure stored inside `AuditEntry.context["reasoning_trace"]`. Holds referenced `fabric_query` / `soul_recall` / `kb_article` IDs, `tool_calls`, and prompt version + backend + model.
- `FabricObjectSnapshot` — immutable snapshot of a Fabric object at decision time, keyed by `(object_id, audit_id)`. The trace stores IDs; the snapshot lets a compliance reviewer reproduce inputs three months later.

### `ee/instinct/trace_collector.py`
- `TraceCollector` async context manager (will wrap `instinct_propose` in PR-B). Subscribes to `SystemEvent`s on enter, aggregates `fabric_query` / `soul_recall` / `kb_inject` / `tool_start` / `tool_end` (or `tool_result`), unsubscribes on exit — even when the body raises.
- Tool calls deduped on `(tool, args_hash)`. Reference lists deduped on exit, preserving first-seen order.
- Unknown types and malformed payloads are silently ignored. The collector never fails the surrounding proposal.

### `InstinctStore`
- `record_fabric_snapshot` / `get_snapshots_for_audit` / `get_snapshots_for_object`.
- New `instinct_fabric_snapshots` SQLite table, indexed on both `audit_id` and `object_id`.

## Test plan

- [x] 19 new tests in `tests/cloud/test_decision_traces.py`:
  - model round-trip
  - subscribe/unsubscribe on enter + exit (including exception path)
  - every event-type branch (`fabric_query`, `soul_recall`, `kb_inject`, `tool_start`+`tool_end`, `tool_result` alias)
  - tool-call dedup and 200-char truncation
  - malformed-event tolerance
  - snapshot read paths (audit-scoped ordered oldest-first, object-scoped newest-first)
- [x] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py` — 3991 passed
- [x] `uv run ruff check` — clean

## Follow-ups

- **PR-B** — Wrap `instinct_propose` agent tool with `TraceCollector`, serialize trace into `AuditEntry.context.reasoning_trace` at proposal time, snapshot referenced Fabric objects, and add `GET /instinct/audit/{id}?hydrate=1` for the UI.
- **PR-C** (paw-enterprise) — Why? drawer in `AuditLogPanel` with Data / Memory / Knowledge tabs.

## Context

Design doc: `paw-enterprise/docs/enterprise/DECISION-TRACES.md`.