### PR TITLE
Persist reasoning traces and hydrate audit entries

### DIFF
--- a/ee/instinct/router.py
+++ b/ee/instinct/router.py
@@ -6,6 +6,11 @@
 #   When present, the server diffs the stored proposal against the edits, persists
 #   a Correction, then approves. GET /instinct/corrections exposes corrections
 #   scoped to a pocket or an action so the UI and agents can read them back.
+# Updated: 2026-04-13 (Move 2 PR-B) — POST /instinct/actions accepts an optional
+#   reasoning_trace + fabric_snapshots body so callers (and the agent tool) can
+#   attach decision inputs at propose time. GET /instinct/audit/{id}?hydrate=1
+#   returns the audit entry with the trace's referenced IDs expanded into Fabric
+#   object snapshots, making the "Why?" drawer possible in the UI.
 
 from __future__ import annotations
 
@@ -29,6 +34,7 @@ from ee.instinct.models import (
     ActionTrigger,
     AuditEntry,
 )
+from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +61,21 @@ class ProposeRequest(BaseModel):
     category: ActionCategory = ActionCategory.WORKFLOW
     priority: ActionPriority = ActionPriority.MEDIUM
     parameters: dict[str, Any] = {}
+    reasoning_trace: ReasoningTrace | None = Field(
+        default=None,
+        description=(
+            "Optional decision trace: which Fabric objects / soul memories / "
+            "KB articles / tool calls the agent consumed to produce this proposal. "
+            "Persisted into the audit entry so the Why? drawer can expand it."
+        ),
+    )
+    fabric_snapshots: list[FabricObjectSnapshot] = Field(
+        default_factory=list,
+        description=(
+            "Optional snapshots of the Fabric objects referenced in the trace, "
+            "captured at decision time so later live mutations don't erase the reasoning."
+        ),
+    )
 
 
 class RejectRequest(BaseModel):
@@ -113,7 +134,12 @@ class CorrectionsListResponse(BaseModel):
 
 @router.post("/instinct/actions", response_model=Action, status_code=201)
 async def propose_action(req: ProposeRequest):
-    """Propose a new action for human approval."""
+    """Propose a new action for human approval.
+
+    Optional `reasoning_trace` and `fabric_snapshots` let callers attach the
+    agent's decision inputs at propose time. They are persisted into the
+    resulting audit row for later hydration via `/audit/{id}?hydrate=1`.
+    """
     return await _store().propose(
         pocket_id=req.pocket_id,
         title=req.title,
@@ -123,6 +149,8 @@ async def propose_action(req: ProposeRequest):
         category=req.category,
         priority=req.priority,
         parameters=req.parameters,
+        reasoning_trace=req.reasoning_trace,
+        fabric_snapshots=list(req.fabric_snapshots) if req.fabric_snapshots else None,
     )
 
 
@@ -321,6 +349,95 @@ async def query_audit(
         limit=limit,
     )
     return AuditListResponse(entries=entries, total=len(entries))
+
+
+class HydratedAuditEntry(BaseModel):
+    """Audit entry with referenced IDs expanded for the Why? drawer."""
+
+    entry: AuditEntry
+    reasoning_trace: ReasoningTrace | None = None
+    fabric_snapshots: list[FabricObjectSnapshot] = Field(default_factory=list)
+    fabric_current: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Live Fabric objects referenced in the trace (current state).",
+    )
+
+
+@router.get("/instinct/audit/{audit_id}", response_model=HydratedAuditEntry)
+async def get_audit_entry(
+    audit_id: str,
+    hydrate: int = Query(0, description="Pass 1 to expand referenced IDs"),
+):
+    """Fetch a single audit entry, optionally hydrated with referenced content.
+
+    When `hydrate=1`, the response carries:
+    - the decoded `reasoning_trace` (if stored)
+    - `fabric_snapshots` — immutable snapshots captured at decision time
+    - `fabric_current` — live state of the referenced objects (so a reviewer
+      can compare what the agent saw against what the object is now)
+    """
+    store = _store()
+    entries = await store.query_audit(limit=1000)
+    entry = next((e for e in entries if e.id == audit_id), None)
+    if entry is None:
+        raise HTTPException(404, "Audit entry not found")
+
+    trace = _decode_trace(entry)
+    if not hydrate:
+        return HydratedAuditEntry(entry=entry, reasoning_trace=trace)
+
+    snapshots: list[FabricObjectSnapshot] = []
+    current: list[dict[str, Any]] = []
+    if trace is not None:
+        snapshots = await store.get_snapshots_for_audit(audit_id)
+        current = await _fetch_current_fabric(trace.fabric_queries)
+
+    return HydratedAuditEntry(
+        entry=entry,
+        reasoning_trace=trace,
+        fabric_snapshots=snapshots,
+        fabric_current=current,
+    )
+
+
+def _decode_trace(entry: AuditEntry) -> ReasoningTrace | None:
+    raw = (entry.context or {}).get("reasoning_trace")
+    if not raw:
+        return None
+    try:
+        return ReasoningTrace.model_validate(raw)
+    except Exception:
+        logger.debug("Failed to decode reasoning_trace on audit %s", entry.id)
+        return None
+
+
+async def _fetch_current_fabric(object_ids: list[str]) -> list[dict[str, Any]]:
+    """Look up live Fabric objects by ID, tolerating a missing ee module."""
+    if not object_ids:
+        return []
+    try:
+        from ee.api import get_fabric_store
+
+        fabric = get_fabric_store()
+    except ImportError:
+        return []
+
+    results: list[dict[str, Any]] = []
+    for oid in object_ids:
+        try:
+            obj = await fabric.get_object(oid)
+        except Exception:
+            obj = None
+        if obj is None:
+            continue
+        results.append(
+            {
+                "object_id": oid,
+                "type_name": getattr(obj, "type_name", ""),
+                "properties": getattr(obj, "properties", {}),
+            },
+        )
+    return results
 
 
 @router.get("/instinct/audit/export")

--- a/ee/instinct/store.py
+++ b/ee/instinct/store.py
@@ -4,6 +4,10 @@
 # Updated: 2026-04-12 (Move 1 PR-A) — Corrections table + record_correction() and
 #   get_corrections*() methods for the correction loop. Human edits between
 #   proposal and approval land here, then feed soul-protocol on next proposal.
+# Updated: 2026-04-13 (Move 2 PR-A/B) — instinct_fabric_snapshots table +
+#   record_fabric_snapshot/get_snapshots_*. propose() now accepts optional
+#   reasoning_trace and fabric_snapshots, persisting the trace as JSON inside
+#   AuditEntry.context["reasoning_trace"] and keying snapshots to the audit row.
 
 from __future__ import annotations
 
@@ -25,7 +29,7 @@ from ee.instinct.models import (
     AuditCategory,
     AuditEntry,
 )
-from ee.instinct.trace import FabricObjectSnapshot
+from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS instinct_actions (
@@ -127,6 +131,8 @@ class InstinctStore:
         priority: ActionPriority = ActionPriority.MEDIUM,
         parameters: dict[str, Any] | None = None,
         context: ActionContext | None = None,
+        reasoning_trace: ReasoningTrace | None = None,
+        fabric_snapshots: list[FabricObjectSnapshot] | None = None,
     ) -> Action:
         action = Action(
             pocket_id=pocket_id,
@@ -163,14 +169,25 @@ class InstinctStore:
             )
             await db.commit()
 
-        await self._log(
+        audit_context: dict[str, Any] = {}
+        if reasoning_trace is not None:
+            audit_context["reasoning_trace"] = reasoning_trace.model_dump(mode="json")
+
+        audit_entry = await self._log(
             action_id=action.id,
             pocket_id=pocket_id,
             actor=f"{trigger.type}:{trigger.source}",
             event="action_proposed",
             description=f"Proposed: {title}",
             ai_recommendation=recommendation,
+            context=audit_context,
         )
+
+        if fabric_snapshots:
+            for snapshot in fabric_snapshots:
+                snapshot.audit_id = audit_entry.id
+                await self.record_fabric_snapshot(snapshot)
+
         return action
 
     async def approve(self, action_id: str, approver: str = "user") -> Action | None:

--- a/src/pocketpaw/tools/builtin/fabric_tools.py
+++ b/src/pocketpaw/tools/builtin/fabric_tools.py
@@ -19,6 +19,26 @@ def _get_fabric_store():
         return None
 
 
+async def _emit_trace_events(event_type: str, entries: list[dict[str, Any]]) -> None:
+    """Publish one SystemEvent per entry so TraceCollector can aggregate them.
+
+    Silent in the common case — the message bus only has subscribers when a
+    proposal is actively being traced. Any failure is swallowed so tool calls
+    never break because telemetry is sick.
+    """
+    if not entries:
+        return
+    try:
+        from pocketpaw.bus import get_message_bus
+        from pocketpaw.bus.events import SystemEvent
+
+        bus = get_message_bus()
+        for entry in entries:
+            await bus.publish_system(SystemEvent(event_type=event_type, data=entry))
+    except Exception:
+        logger.debug("Trace event emission skipped (event_type=%s)", event_type)
+
+
 class FabricQueryTool(BaseTool):
     """Query objects in the Fabric ontology."""
 
@@ -84,6 +104,15 @@ class FabricQueryTool(BaseTool):
                     link_type=link_type,
                     limit=min(limit, 50),
                 )
+            )
+
+            # Emit a trace event per object so decision-time snapshots can
+            # capture what this query actually returned. The collector is only
+            # active when an InstinctProposeTool wraps the reasoning, so this
+            # is a no-op in all other contexts.
+            await _emit_trace_events(
+                "fabric_query",
+                [{"object_id": obj.id, "object_type": obj.type_name} for obj in result.objects],
             )
 
             if not result.objects:

--- a/tests/cloud/test_decision_traces_wiring.py
+++ b/tests/cloud/test_decision_traces_wiring.py
@@ -1,0 +1,256 @@
+# tests/cloud/test_decision_traces_wiring.py — Integration tests for PR-B.
+# Created: 2026-04-13 — Verifies that propose() accepts and persists a trace,
+# that fabric snapshots are keyed to the audit row, and that the hydration
+# endpoint expands referenced IDs correctly with hydrate=0 / hydrate=1.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ee.instinct.models import ActionTrigger
+from ee.instinct.router import router
+from ee.instinct.store import InstinctStore
+from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace, ToolCallRef
+
+
+def _trigger() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="claude", reason="unit test")
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "traces_wiring.db")
+
+
+@pytest.fixture
+def app_with_store(tmp_path: Path):
+    app = FastAPI()
+    app.include_router(router)
+    store = InstinctStore(tmp_path / "router_traces.db")
+    with patch("ee.instinct.router._store", return_value=store):
+        yield app, store
+
+
+@pytest.fixture
+def client(app_with_store):
+    app, _ = app_with_store
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Store-level wiring
+# ---------------------------------------------------------------------------
+
+
+class TestProposeWithTrace:
+    @pytest.mark.asyncio
+    async def test_reasoning_trace_lands_in_audit_context(
+        self, store: InstinctStore
+    ) -> None:
+        trace = ReasoningTrace(
+            fabric_queries=["obj_acme"],
+            soul_memories=["mem_q4_pricing"],
+            kb_articles=["kb_discount_policy"],
+            tool_calls=[ToolCallRef(tool="kb_search", args_hash="abc", result_preview="…")],
+            prompt_version="v1",
+            backend="claude_agent_sdk",
+            model="claude-opus-4-6",
+        )
+        await store.propose(
+            pocket_id="pocket-1",
+            title="Offer renewal discount",
+            description="Acme up for renewal",
+            recommendation="Offer 25%",
+            trigger=_trigger(),
+            reasoning_trace=trace,
+        )
+
+        entries = await store.query_audit(pocket_id="pocket-1")
+        proposed = [e for e in entries if e.event == "action_proposed"]
+        assert len(proposed) == 1
+        decoded = ReasoningTrace.model_validate(
+            proposed[0].context["reasoning_trace"],
+        )
+        assert decoded.fabric_queries == ["obj_acme"]
+        assert decoded.soul_memories == ["mem_q4_pricing"]
+        assert decoded.backend == "claude_agent_sdk"
+
+    @pytest.mark.asyncio
+    async def test_fabric_snapshots_are_keyed_to_the_audit_row(
+        self, store: InstinctStore
+    ) -> None:
+        snapshots = [
+            FabricObjectSnapshot(
+                object_id="obj_acme",
+                audit_id="will-be-overwritten",
+                object_type="Customer",
+                snapshot={"arr": 180000},
+            ),
+            FabricObjectSnapshot(
+                object_id="obj_snowflake",
+                audit_id="will-be-overwritten",
+                object_type="Competitor",
+                snapshot={"last_seen": "Q4"},
+            ),
+        ]
+        await store.propose(
+            pocket_id="pocket-1",
+            title="Offer renewal discount",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+            reasoning_trace=ReasoningTrace(fabric_queries=["obj_acme", "obj_snowflake"]),
+            fabric_snapshots=snapshots,
+        )
+
+        entries = await store.query_audit(pocket_id="pocket-1")
+        proposed = next(e for e in entries if e.event == "action_proposed")
+        saved = await store.get_snapshots_for_audit(proposed.id)
+        assert {s.object_id for s in saved} == {"obj_acme", "obj_snowflake"}
+        for snap in saved:
+            assert snap.audit_id == proposed.id
+
+    @pytest.mark.asyncio
+    async def test_propose_without_trace_still_works(self, store: InstinctStore) -> None:
+        """Trace is optional — legacy callers keep working."""
+        await store.propose(
+            pocket_id="pocket-1",
+            title="No trace",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+        )
+        entries = await store.query_audit(pocket_id="pocket-1")
+        proposed = next(e for e in entries if e.event == "action_proposed")
+        assert "reasoning_trace" not in (proposed.context or {})
+
+
+# ---------------------------------------------------------------------------
+# Router-level wiring
+# ---------------------------------------------------------------------------
+
+
+class TestProposeEndpointWithTrace:
+    def test_endpoint_accepts_and_persists_trace_and_snapshots(
+        self, app_with_store, client: TestClient
+    ) -> None:
+        _, store = app_with_store
+        payload = {
+            "pocket_id": "pocket-1",
+            "title": "Offer renewal discount",
+            "description": "Acme up for renewal",
+            "recommendation": "Offer 25%",
+            "priority": "high",
+            "trigger": {
+                "type": "agent",
+                "source": "claude",
+                "reason": "renewal sequence",
+            },
+            "reasoning_trace": {
+                "fabric_queries": ["obj_acme"],
+                "soul_memories": [],
+                "kb_articles": ["kb_pricing"],
+                "tool_calls": [],
+                "prompt_version": "v1",
+                "backend": "claude_agent_sdk",
+                "model": "claude-opus-4-6",
+            },
+            "fabric_snapshots": [
+                {
+                    "object_id": "obj_acme",
+                    "audit_id": "placeholder",
+                    "object_type": "Customer",
+                    "snapshot": {"arr": 180000},
+                },
+            ],
+        }
+        res = client.post("/instinct/actions", json=payload)
+        assert res.status_code == 201
+        assert res.json()["title"] == "Offer renewal discount"
+        assert res.json()["priority"] == "high"
+
+
+class TestHydrationEndpoint:
+    @pytest.mark.asyncio
+    async def test_hydrate_zero_returns_decoded_trace_without_expansion(
+        self, app_with_store, client: TestClient
+    ) -> None:
+        _, store = app_with_store
+        await store.propose(
+            pocket_id="pocket-1",
+            title="Offer renewal discount",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+            reasoning_trace=ReasoningTrace(fabric_queries=["obj_acme"]),
+        )
+        entries = await store.query_audit(pocket_id="pocket-1")
+        proposed = next(e for e in entries if e.event == "action_proposed")
+
+        res = client.get(f"/instinct/audit/{proposed.id}")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["entry"]["id"] == proposed.id
+        assert body["reasoning_trace"]["fabric_queries"] == ["obj_acme"]
+        assert body["fabric_snapshots"] == []
+        assert body["fabric_current"] == []
+
+    @pytest.mark.asyncio
+    async def test_hydrate_one_returns_snapshots(
+        self, app_with_store, client: TestClient
+    ) -> None:
+        _, store = app_with_store
+        await store.propose(
+            pocket_id="pocket-1",
+            title="Offer renewal discount",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+            reasoning_trace=ReasoningTrace(fabric_queries=["obj_acme"]),
+            fabric_snapshots=[
+                FabricObjectSnapshot(
+                    object_id="obj_acme",
+                    audit_id="will-be-replaced",
+                    object_type="Customer",
+                    snapshot={"arr": 180000},
+                ),
+            ],
+        )
+        entries = await store.query_audit(pocket_id="pocket-1")
+        proposed = next(e for e in entries if e.event == "action_proposed")
+
+        res = client.get(f"/instinct/audit/{proposed.id}?hydrate=1")
+        assert res.status_code == 200
+        body = res.json()
+        assert len(body["fabric_snapshots"]) == 1
+        assert body["fabric_snapshots"][0]["object_id"] == "obj_acme"
+        assert body["fabric_snapshots"][0]["snapshot"]["arr"] == 180000
+
+    def test_hydrate_unknown_audit_returns_404(self, client: TestClient) -> None:
+        res = client.get("/instinct/audit/aud_does_not_exist")
+        assert res.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_audit_entry_without_trace_hydrates_empty(
+        self, app_with_store, client: TestClient
+    ) -> None:
+        _, store = app_with_store
+        await store.propose(
+            pocket_id="pocket-1",
+            title="No trace",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+        )
+        entries = await store.query_audit(pocket_id="pocket-1")
+        proposed = next(e for e in entries if e.event == "action_proposed")
+        res = client.get(f"/instinct/audit/{proposed.id}?hydrate=1")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["reasoning_trace"] is None
+        assert body["fabric_snapshots"] == []


### PR DESCRIPTION
## Why

PR-A ([#930](https://github.com/pocketpaw/pocketpaw/pull/930)) landed the data types. This PR wires them into the proposal path and adds the read endpoint the UI will consume.

Stacks on `feat/decision-traces-models`.

## What's in this PR

### Store
- `InstinctStore.propose()` now takes optional `reasoning_trace` and `fabric_snapshots` kwargs.
- Trace is serialized into `AuditEntry.context["reasoning_trace"]` when present.
- Snapshots are persisted via `record_fabric_snapshot()` with their `audit_id` rewritten to the freshly created audit row — callers don't need to know the audit ID ahead of time.

### Router
- `POST /instinct/actions` accepts `reasoning_trace` and `fabric_snapshots` on the body so direct HTTP callers (and the agent tool) can attach decision inputs at propose time.
- **`GET /instinct/audit/{id}`** is the new read endpoint.
  - `hydrate=0` (default): entry + decoded trace if stored.
  - `hydrate=1`: also expands referenced Fabric IDs into immutable snapshots (captured at decision time) and live state (current object). Reviewers can compare what the agent saw against what the object looks like now.
- `HydratedAuditEntry` response: `{ entry, reasoning_trace, fabric_snapshots, fabric_current }`.
- `fabric_current` is best-effort; if ee/ isn't installed or an object was deleted, its entry is omitted.

### FabricQueryTool
- Emits `SystemEvent(event_type="fabric_query", data={"object_id": ..., "object_type": ...})` for each returned object.
- When a `TraceCollector` is active (agent-loop wiring — follow-up), these land in the trace automatically.
- In every other context it's a no-op; any failure is logged at debug and swallowed so tool calls never break because telemetry is sick.

## Test plan

- [x] 8 new tests in `tests/cloud/test_decision_traces_wiring.py`:
  - `propose()` with trace — lands in audit context
  - `propose()` with snapshots — re-keyed to audit row
  - `propose()` without trace — legacy callers still work
  - `POST /instinct/actions` — accepts both fields
  - `hydrate=0` — decoded trace, no expansion
  - `hydrate=1` — snapshots returned
  - unknown audit ID → 404
  - audit entry without trace → hydrates empty
- [x] `uv run pytest` — 3991 passed
- [x] `uv run ruff check` — clean

## Follow-ups

- **Agent-loop integration** — wrap `instinct_propose` and the agent turn in a `TraceCollector` so fabric/soul/kb events that happen during reasoning are captured automatically. Deferred to a follow-up PR to keep this one surgical.
- **PR-C** (paw-enterprise) — Why? drawer in `AuditLogPanel` consuming this endpoint.

## Context

Design doc: `paw-enterprise/docs/enterprise/DECISION-TRACES.md`.