### PR TITLE
Paw Print backend — models + async SQLite store

### DIFF
--- a/ee/paw_print/__init__.py
+++ b/ee/paw_print/__init__.py
@@ -1,0 +1,23 @@
+# Paw Print — embeddable customer-facing widget layer for Paw OS.
+# Created: 2026-04-13 (Move 3 PR-A) — The full-stack decision loop Palantir
+# cannot offer: customer interactions on a Paw Print widget flow back into
+# a Pocket in real time, Instinct nudges the owner, approved actions feed
+# back to the widget. This module is the backend side of that loop.
+
+from ee.paw_print.models import (
+    PawPrintBlock,
+    PawPrintEvent,
+    PawPrintEventMapping,
+    PawPrintSpec,
+    PawPrintWidget,
+)
+from ee.paw_print.store import PawPrintStore
+
+__all__ = [
+    "PawPrintBlock",
+    "PawPrintEvent",
+    "PawPrintEventMapping",
+    "PawPrintSpec",
+    "PawPrintStore",
+    "PawPrintWidget",
+]

--- a/ee/paw_print/models.py
+++ b/ee/paw_print/models.py
@@ -1,0 +1,195 @@
+# ee/paw_print/models.py — Pydantic models for the Paw Print widget layer.
+# Created: 2026-04-13 (Move 3 PR-A) — Minimal, secure-by-design render vocabulary
+# (text / image / list / button / form / divider). No raw HTML, no script
+# injection paths. The widget.js bundle consumes PawPrintSpec; the backend
+# consumes PawPrintEvent on the ingest side.
+
+from __future__ import annotations
+
+import secrets
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+from ee.fabric.models import _gen_id
+
+_MAX_BLOCKS_PER_SPEC = 64
+_MAX_ITEMS_PER_LIST = 50
+_MAX_DOMAINS_PER_WIDGET = 20
+_MAX_PAYLOAD_BYTES = 4 * 1024  # 4KB cap matches the planning doc
+_MAX_SPEC_BYTES = 64 * 1024
+
+
+def _gen_token() -> str:
+    """Per-widget scoped access token — URL-safe, rotatable."""
+    return f"pp_tok_{secrets.token_urlsafe(32)}"
+
+
+# ---------------------------------------------------------------------------
+# Render blocks (tagged union via `type`)
+# ---------------------------------------------------------------------------
+
+
+class PawPrintAction(BaseModel):
+    """An outbound event the widget should post when the block is activated."""
+
+    event: str
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class PawPrintListItem(BaseModel):
+    title: str
+    meta: str = ""
+    action: PawPrintAction | None = None
+    disabled: bool = False
+
+
+class PawPrintFormField(BaseModel):
+    name: str
+    label: str = ""
+    type: Literal["text", "email", "number", "textarea"] = "text"
+    placeholder: str = ""
+    required: bool = False
+
+
+class PawPrintBlock(BaseModel):
+    """Minimal render primitive shared with the widget bundle.
+
+    `type` drives how the bundle renders the block. Every block-specific field
+    is optional at the schema level — the renderer only reads fields relevant
+    to the active type. Anything else is ignored, so forward-compatible spec
+    additions don't break older widget builds.
+    """
+
+    type: Literal["text", "image", "list", "button", "form", "divider"]
+
+    # text
+    content: str = ""
+    style: Literal["body", "heading", "muted"] = "body"
+
+    # image
+    src: str = ""
+    alt: str = ""
+
+    # list
+    items: list[PawPrintListItem] = Field(default_factory=list)
+
+    # button
+    label: str = ""
+    href: str = ""
+    action: PawPrintAction | None = None
+
+    # form
+    fields: list[PawPrintFormField] = Field(default_factory=list)
+    submit_event: str = ""
+
+    @field_validator("items")
+    @classmethod
+    def _cap_list(cls, value: list[PawPrintListItem]) -> list[PawPrintListItem]:
+        if len(value) > _MAX_ITEMS_PER_LIST:
+            raise ValueError(f"list block accepts at most {_MAX_ITEMS_PER_LIST} items")
+        return value
+
+
+class PawPrintSpec(BaseModel):
+    """The payload the widget fetches and renders."""
+
+    widget_id: str
+    pocket_id: str
+    layout: Literal["vertical", "horizontal", "grid"] = "vertical"
+    theme: dict[str, str] = Field(default_factory=dict)
+    blocks: list[PawPrintBlock] = Field(default_factory=list)
+
+    @field_validator("blocks")
+    @classmethod
+    def _cap_blocks(cls, value: list[PawPrintBlock]) -> list[PawPrintBlock]:
+        if len(value) > _MAX_BLOCKS_PER_SPEC:
+            raise ValueError(f"spec accepts at most {_MAX_BLOCKS_PER_SPEC} blocks")
+        return value
+
+
+# ---------------------------------------------------------------------------
+# Widget + Event domain
+# ---------------------------------------------------------------------------
+
+
+class PawPrintEventMapping(BaseModel):
+    """How an inbound widget event turns into a Fabric object.
+
+    `creates` is the Fabric object type; `fields` values follow `{{ placeholder }}`
+    interpolation against the event payload and metadata (`customer_ref`, `timestamp`).
+    """
+
+    creates: str
+    fields: dict[str, str] = Field(default_factory=dict)
+
+
+class PawPrintWidget(BaseModel):
+    id: str = Field(default_factory=lambda: _gen_id("pp"))
+    pocket_id: str
+    owner: str
+    name: str = ""
+    spec: PawPrintSpec
+    allowed_domains: list[str] = Field(default_factory=list)
+    access_token: str = Field(default_factory=_gen_token)
+    rate_limit_per_min: int = 60
+    per_customer_limit_per_min: int = 10
+    event_mapping: dict[str, PawPrintEventMapping] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+    @field_validator("allowed_domains")
+    @classmethod
+    def _cap_domains(cls, value: list[str]) -> list[str]:
+        if len(value) > _MAX_DOMAINS_PER_WIDGET:
+            raise ValueError(f"allowed_domains accepts at most {_MAX_DOMAINS_PER_WIDGET} entries")
+        cleaned: list[str] = []
+        for domain in value:
+            d = domain.strip().lower()
+            if d and d not in cleaned:
+                cleaned.append(d)
+        return cleaned
+
+    @field_validator("rate_limit_per_min", "per_customer_limit_per_min")
+    @classmethod
+    def _positive_rate(cls, value: int) -> int:
+        if value < 1:
+            raise ValueError("rate limits must be >= 1")
+        return value
+
+
+class PawPrintEvent(BaseModel):
+    """One inbound signal from a rendered widget."""
+
+    widget_id: str
+    type: str
+    payload: dict[str, Any] = Field(default_factory=dict)
+    customer_ref: str
+    timestamp: datetime = Field(default_factory=datetime.now)
+
+    def payload_size(self) -> int:
+        import json as _json
+
+        try:
+            return len(_json.dumps(self.payload).encode("utf-8"))
+        except Exception:
+            return _MAX_PAYLOAD_BYTES + 1
+
+    @field_validator("type")
+    @classmethod
+    def _non_empty_type(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("event type is required")
+        return value.strip()
+
+
+# ---------------------------------------------------------------------------
+# Limit constants — re-exported so the ingest layer (PR-B) reads the same values.
+# ---------------------------------------------------------------------------
+
+MAX_BLOCKS_PER_SPEC = _MAX_BLOCKS_PER_SPEC
+MAX_ITEMS_PER_LIST = _MAX_ITEMS_PER_LIST
+MAX_DOMAINS_PER_WIDGET = _MAX_DOMAINS_PER_WIDGET
+MAX_PAYLOAD_BYTES = _MAX_PAYLOAD_BYTES
+MAX_SPEC_BYTES = _MAX_SPEC_BYTES

--- a/ee/paw_print/store.py
+++ b/ee/paw_print/store.py
@@ -1,0 +1,276 @@
+# ee/paw_print/store.py — Async SQLite store for Paw Print widgets and events.
+# Created: 2026-04-13 (Move 3 PR-A) — CRUD for PawPrintWidget + append-only
+# PawPrintEvent log. Token rotation invalidates any cached copies. Event ingest
+# + rate-limit logic lives in PR-B; this module only handles persistence.
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+from ee.paw_print.models import PawPrintEvent, PawPrintSpec, PawPrintWidget, _gen_token
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS paw_print_widgets (
+    id TEXT PRIMARY KEY,
+    pocket_id TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    name TEXT DEFAULT '',
+    spec TEXT NOT NULL,
+    allowed_domains TEXT DEFAULT '[]',
+    access_token TEXT NOT NULL,
+    rate_limit_per_min INTEGER DEFAULT 60,
+    per_customer_limit_per_min INTEGER DEFAULT 10,
+    event_mapping TEXT DEFAULT '{}',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS paw_print_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    widget_id TEXT NOT NULL,
+    type TEXT NOT NULL,
+    payload TEXT DEFAULT '{}',
+    customer_ref TEXT NOT NULL,
+    timestamp TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_pp_widgets_pocket ON paw_print_widgets(pocket_id);
+CREATE INDEX IF NOT EXISTS idx_pp_widgets_owner ON paw_print_widgets(owner);
+CREATE INDEX IF NOT EXISTS idx_pp_events_widget_ts
+    ON paw_print_events(widget_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_pp_events_customer
+    ON paw_print_events(widget_id, customer_ref);
+"""
+
+
+class PawPrintStore:
+    """Async SQLite store — same shape as InstinctStore so the wiring is familiar."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._initialized = False
+
+    async def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        async with aiosqlite.connect(self._db_path) as db:
+            await db.executescript(SCHEMA_SQL)
+            await db.commit()
+        self._initialized = True
+
+    def _conn(self) -> aiosqlite.Connection:
+        return aiosqlite.connect(self._db_path)
+
+    # ---------------- Widgets ----------------
+
+    async def create_widget(self, widget: PawPrintWidget) -> PawPrintWidget:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO paw_print_widgets"
+                " (id, pocket_id, owner, name, spec, allowed_domains,"
+                " access_token, rate_limit_per_min, per_customer_limit_per_min,"
+                " event_mapping, created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    widget.id,
+                    widget.pocket_id,
+                    widget.owner,
+                    widget.name,
+                    widget.spec.model_dump_json(),
+                    json.dumps(widget.allowed_domains),
+                    widget.access_token,
+                    widget.rate_limit_per_min,
+                    widget.per_customer_limit_per_min,
+                    json.dumps(
+                        {k: v.model_dump() for k, v in widget.event_mapping.items()},
+                    ),
+                    widget.created_at.isoformat(),
+                    widget.updated_at.isoformat(),
+                ),
+            )
+            await db.commit()
+        return widget
+
+    async def get_widget(self, widget_id: str) -> PawPrintWidget | None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM paw_print_widgets WHERE id = ?", (widget_id,),
+            ) as cur:
+                row = await cur.fetchone()
+                return self._row_to_widget(row) if row else None
+
+    async def list_widgets(
+        self, pocket_id: str | None = None, owner: str | None = None, limit: int = 100
+    ) -> list[PawPrintWidget]:
+        conditions: list[str] = []
+        params: list[Any] = []
+        if pocket_id:
+            conditions.append("pocket_id = ?")
+            params.append(pocket_id)
+        if owner:
+            conditions.append("owner = ?")
+            params.append(owner)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        params.append(limit)
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                f"SELECT * FROM paw_print_widgets {where} ORDER BY created_at DESC LIMIT ?",
+                params,
+            ) as cur:
+                return [self._row_to_widget(row) async for row in cur]
+
+    async def update_spec(
+        self, widget_id: str, spec: PawPrintSpec
+    ) -> PawPrintWidget | None:
+        existing = await self.get_widget(widget_id)
+        if existing is None:
+            return None
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE paw_print_widgets SET spec = ?, updated_at = ? WHERE id = ?",
+                (spec.model_dump_json(), datetime.now().isoformat(), widget_id),
+            )
+            await db.commit()
+        return await self.get_widget(widget_id)
+
+    async def rotate_token(self, widget_id: str) -> PawPrintWidget | None:
+        existing = await self.get_widget(widget_id)
+        if existing is None:
+            return None
+        new_token = _gen_token()
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE paw_print_widgets SET access_token = ?, updated_at = ? WHERE id = ?",
+                (new_token, datetime.now().isoformat(), widget_id),
+            )
+            await db.commit()
+        return await self.get_widget(widget_id)
+
+    async def delete_widget(self, widget_id: str) -> bool:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            cur = await db.execute(
+                "DELETE FROM paw_print_widgets WHERE id = ?", (widget_id,),
+            )
+            await db.commit()
+            return (cur.rowcount or 0) > 0
+
+    # ---------------- Events ----------------
+
+    async def record_event(self, event: PawPrintEvent) -> PawPrintEvent:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO paw_print_events"
+                " (widget_id, type, payload, customer_ref, timestamp)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (
+                    event.widget_id,
+                    event.type,
+                    json.dumps(event.payload),
+                    event.customer_ref,
+                    event.timestamp.isoformat(),
+                ),
+            )
+            await db.commit()
+        return event
+
+    async def recent_events(
+        self, widget_id: str, limit: int = 100
+    ) -> list[PawPrintEvent]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM paw_print_events WHERE widget_id = ?"
+                " ORDER BY timestamp DESC LIMIT ?",
+                (widget_id, limit),
+            ) as cur:
+                return [self._row_to_event(row) async for row in cur]
+
+    async def count_events_since(
+        self,
+        widget_id: str,
+        since: datetime,
+        customer_ref: str | None = None,
+    ) -> int:
+        """Count events in the last window — backs the rate limiter."""
+        await self._ensure_schema()
+        conditions = ["widget_id = ?", "timestamp >= ?"]
+        params: list[Any] = [widget_id, since.isoformat()]
+        if customer_ref is not None:
+            conditions.append("customer_ref = ?")
+            params.append(customer_ref)
+        async with self._conn() as db:
+            async with db.execute(
+                f"SELECT COUNT(*) FROM paw_print_events WHERE {' AND '.join(conditions)}",
+                params,
+            ) as cur:
+                row = await cur.fetchone()
+                return row[0] if row else 0
+
+    async def within_rate_limit(
+        self,
+        widget_id: str,
+        *,
+        overall_per_min: int,
+        per_customer_per_min: int,
+        customer_ref: str,
+        now: datetime | None = None,
+    ) -> bool:
+        """Return True if the next event from `customer_ref` should be accepted."""
+        now = now or datetime.now()
+        window_start = now - timedelta(minutes=1)
+        total = await self.count_events_since(widget_id, window_start)
+        if total >= overall_per_min:
+            return False
+        per_customer = await self.count_events_since(
+            widget_id, window_start, customer_ref=customer_ref,
+        )
+        return per_customer < per_customer_per_min
+
+    # ---------------- Helpers ----------------
+
+    def _row_to_widget(self, row: Any) -> PawPrintWidget:
+        from ee.paw_print.models import PawPrintEventMapping
+
+        raw_domains = json.loads(row["allowed_domains"]) if row["allowed_domains"] else []
+        raw_mapping = json.loads(row["event_mapping"]) if row["event_mapping"] else {}
+        mapping = {k: PawPrintEventMapping.model_validate(v) for k, v in raw_mapping.items()}
+        spec = PawPrintSpec.model_validate_json(row["spec"])
+        return PawPrintWidget(
+            id=row["id"],
+            pocket_id=row["pocket_id"],
+            owner=row["owner"],
+            name=row["name"] or "",
+            spec=spec,
+            allowed_domains=raw_domains,
+            access_token=row["access_token"],
+            rate_limit_per_min=row["rate_limit_per_min"],
+            per_customer_limit_per_min=row["per_customer_limit_per_min"],
+            event_mapping=mapping,
+            created_at=datetime.fromisoformat(row["created_at"]),
+            updated_at=datetime.fromisoformat(row["updated_at"]),
+        )
+
+    def _row_to_event(self, row: Any) -> PawPrintEvent:
+        return PawPrintEvent(
+            widget_id=row["widget_id"],
+            type=row["type"],
+            payload=json.loads(row["payload"]) if row["payload"] else {},
+            customer_ref=row["customer_ref"],
+            timestamp=datetime.fromisoformat(row["timestamp"]),
+        )

--- a/tests/cloud/test_paw_print_backend.py
+++ b/tests/cloud/test_paw_print_backend.py
@@ -1,0 +1,301 @@
+# tests/cloud/test_paw_print_backend.py — PR-A: Paw Print models + store.
+# Created: 2026-04-13 — Covers validation caps, domain normalization, token
+# rotation, event persistence, and the rate-limit primitives used by PR-B.
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from ee.paw_print.models import (
+    MAX_BLOCKS_PER_SPEC,
+    MAX_DOMAINS_PER_WIDGET,
+    MAX_ITEMS_PER_LIST,
+    PawPrintAction,
+    PawPrintBlock,
+    PawPrintEvent,
+    PawPrintEventMapping,
+    PawPrintListItem,
+    PawPrintSpec,
+    PawPrintWidget,
+)
+from ee.paw_print.store import PawPrintStore
+
+
+def _spec(widget_id: str = "pp_test") -> PawPrintSpec:
+    return PawPrintSpec(
+        widget_id=widget_id,
+        pocket_id="pocket-1",
+        blocks=[
+            PawPrintBlock(type="text", content="Today's menu", style="heading"),
+            PawPrintBlock(
+                type="list",
+                items=[
+                    PawPrintListItem(
+                        title="Oat Milk Latte",
+                        meta="$5 — 34 in stock",
+                        action=PawPrintAction(event="order_click", payload={"item": "oat_latte"}),
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def _widget(**overrides) -> PawPrintWidget:
+    defaults = {
+        "pocket_id": "pocket-1",
+        "owner": "user:maya",
+        "name": "Brew & Co Menu",
+        "spec": _spec(),
+        "allowed_domains": ["brewco.com"],
+        "event_mapping": {
+            "order_click": PawPrintEventMapping(
+                creates="Order",
+                fields={"item": "{{ payload.item }}", "customer_ref": "{{ customer_ref }}"},
+            ),
+        },
+    }
+    defaults.update(overrides)
+    return PawPrintWidget(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Model validation
+# ---------------------------------------------------------------------------
+
+
+class TestBlockCaps:
+    def test_list_block_accepts_up_to_the_cap(self) -> None:
+        items = [PawPrintListItem(title=f"Item {i}") for i in range(MAX_ITEMS_PER_LIST)]
+        block = PawPrintBlock(type="list", items=items)
+        assert len(block.items) == MAX_ITEMS_PER_LIST
+
+    def test_list_block_rejects_past_the_cap(self) -> None:
+        items = [PawPrintListItem(title=f"Item {i}") for i in range(MAX_ITEMS_PER_LIST + 1)]
+        with pytest.raises(ValueError, match="list block accepts at most"):
+            PawPrintBlock(type="list", items=items)
+
+    def test_spec_rejects_too_many_blocks(self) -> None:
+        blocks = [PawPrintBlock(type="divider") for _ in range(MAX_BLOCKS_PER_SPEC + 1)]
+        with pytest.raises(ValueError, match="spec accepts at most"):
+            PawPrintSpec(widget_id="pp_x", pocket_id="p", blocks=blocks)
+
+
+class TestWidgetValidation:
+    def test_allowed_domains_are_lowercased_and_deduped(self) -> None:
+        widget = _widget(allowed_domains=["BrewCo.com", "brewco.com", " shop.brewco.com "])
+        assert widget.allowed_domains == ["brewco.com", "shop.brewco.com"]
+
+    def test_allowed_domains_cap_enforced(self) -> None:
+        domains = [f"site{i}.example" for i in range(MAX_DOMAINS_PER_WIDGET + 1)]
+        with pytest.raises(ValueError, match="allowed_domains accepts at most"):
+            _widget(allowed_domains=domains)
+
+    def test_rate_limit_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="rate limits must be"):
+            _widget(rate_limit_per_min=0)
+        with pytest.raises(ValueError, match="rate limits must be"):
+            _widget(per_customer_limit_per_min=-1)
+
+    def test_access_token_is_generated_and_prefixed(self) -> None:
+        widget = _widget()
+        assert widget.access_token.startswith("pp_tok_")
+        assert len(widget.access_token) > len("pp_tok_") + 20
+
+
+class TestEventValidation:
+    def test_empty_type_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="event type is required"):
+            PawPrintEvent(widget_id="pp_x", type="  ", customer_ref="abc")
+
+    def test_type_is_stripped(self) -> None:
+        event = PawPrintEvent(widget_id="pp_x", type=" order_click ", customer_ref="abc")
+        assert event.type == "order_click"
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> PawPrintStore:
+    return PawPrintStore(tmp_path / "paw_print.db")
+
+
+class TestWidgetCRUD:
+    @pytest.mark.asyncio
+    async def test_create_and_fetch_widget(self, store: PawPrintStore) -> None:
+        widget = await store.create_widget(_widget())
+        fetched = await store.get_widget(widget.id)
+        assert fetched is not None
+        assert fetched.owner == "user:maya"
+        assert fetched.allowed_domains == ["brewco.com"]
+        assert "order_click" in fetched.event_mapping
+        assert fetched.event_mapping["order_click"].creates == "Order"
+
+    @pytest.mark.asyncio
+    async def test_list_filters_by_pocket_and_owner(self, store: PawPrintStore) -> None:
+        await store.create_widget(_widget(pocket_id="pocket-1", owner="user:maya"))
+        await store.create_widget(_widget(pocket_id="pocket-2", owner="user:priya"))
+
+        by_pocket = await store.list_widgets(pocket_id="pocket-1")
+        assert len(by_pocket) == 1
+        assert by_pocket[0].pocket_id == "pocket-1"
+
+        by_owner = await store.list_widgets(owner="user:priya")
+        assert len(by_owner) == 1
+        assert by_owner[0].owner == "user:priya"
+
+    @pytest.mark.asyncio
+    async def test_update_spec_replaces_blocks(self, store: PawPrintStore) -> None:
+        widget = await store.create_widget(_widget())
+        new_spec = PawPrintSpec(
+            widget_id=widget.id,
+            pocket_id=widget.pocket_id,
+            blocks=[PawPrintBlock(type="text", content="Closed today")],
+        )
+        updated = await store.update_spec(widget.id, new_spec)
+        assert updated is not None
+        assert len(updated.spec.blocks) == 1
+        assert updated.spec.blocks[0].content == "Closed today"
+
+    @pytest.mark.asyncio
+    async def test_rotate_token_invalidates_old_token(self, store: PawPrintStore) -> None:
+        widget = await store.create_widget(_widget())
+        original = widget.access_token
+        rotated = await store.rotate_token(widget.id)
+        assert rotated is not None
+        assert rotated.access_token != original
+        assert rotated.access_token.startswith("pp_tok_")
+
+    @pytest.mark.asyncio
+    async def test_delete_widget_returns_true_then_false(self, store: PawPrintStore) -> None:
+        widget = await store.create_widget(_widget())
+        assert await store.delete_widget(widget.id) is True
+        assert await store.delete_widget(widget.id) is False
+        assert await store.get_widget(widget.id) is None
+
+    @pytest.mark.asyncio
+    async def test_update_missing_widget_returns_none(self, store: PawPrintStore) -> None:
+        result = await store.update_spec("does_not_exist", _spec())
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Event log + rate limit
+# ---------------------------------------------------------------------------
+
+
+class TestEventStore:
+    @pytest.mark.asyncio
+    async def test_events_are_listed_newest_first(self, store: PawPrintStore) -> None:
+        widget = await store.create_widget(_widget())
+        now = datetime.now()
+        await store.record_event(
+            PawPrintEvent(
+                widget_id=widget.id,
+                type="order_click",
+                customer_ref="cust_a",
+                timestamp=now - timedelta(minutes=5),
+            ),
+        )
+        await store.record_event(
+            PawPrintEvent(
+                widget_id=widget.id,
+                type="order_click",
+                customer_ref="cust_b",
+                timestamp=now,
+            ),
+        )
+        events = await store.recent_events(widget.id)
+        assert len(events) == 2
+        assert events[0].customer_ref == "cust_b"
+        assert events[1].customer_ref == "cust_a"
+
+    @pytest.mark.asyncio
+    async def test_count_events_since_respects_window(self, store: PawPrintStore) -> None:
+        widget = await store.create_widget(_widget())
+        now = datetime.now()
+        await store.record_event(
+            PawPrintEvent(
+                widget_id=widget.id,
+                type="order_click",
+                customer_ref="cust_a",
+                timestamp=now - timedelta(minutes=5),
+            ),
+        )
+        await store.record_event(
+            PawPrintEvent(
+                widget_id=widget.id,
+                type="order_click",
+                customer_ref="cust_a",
+                timestamp=now - timedelta(seconds=20),
+            ),
+        )
+
+        assert await store.count_events_since(widget.id, now - timedelta(minutes=1)) == 1
+        assert await store.count_events_since(widget.id, now - timedelta(minutes=10)) == 2
+
+    @pytest.mark.asyncio
+    async def test_within_rate_limit_enforces_overall_and_per_customer(
+        self, store: PawPrintStore
+    ) -> None:
+        widget = await store.create_widget(_widget())
+        now = datetime.now()
+        for i in range(3):
+            await store.record_event(
+                PawPrintEvent(
+                    widget_id=widget.id,
+                    type="order_click",
+                    customer_ref="cust_a",
+                    timestamp=now - timedelta(seconds=10 * i),
+                ),
+            )
+
+        # Overall cap 5, per-customer cap 3 — cust_a is at the per-customer ceiling.
+        allowed = await store.within_rate_limit(
+            widget.id,
+            overall_per_min=5,
+            per_customer_per_min=3,
+            customer_ref="cust_a",
+            now=now,
+        )
+        assert allowed is False
+
+        # cust_b has no prior events — still accepted.
+        allowed_other = await store.within_rate_limit(
+            widget.id,
+            overall_per_min=5,
+            per_customer_per_min=3,
+            customer_ref="cust_b",
+            now=now,
+        )
+        assert allowed_other is True
+
+    @pytest.mark.asyncio
+    async def test_within_rate_limit_respects_overall_ceiling(
+        self, store: PawPrintStore
+    ) -> None:
+        widget = await store.create_widget(_widget())
+        now = datetime.now()
+        for i in range(5):
+            await store.record_event(
+                PawPrintEvent(
+                    widget_id=widget.id,
+                    type="order_click",
+                    customer_ref=f"cust_{i}",
+                    timestamp=now - timedelta(seconds=5),
+                ),
+            )
+        allowed = await store.within_rate_limit(
+            widget.id,
+            overall_per_min=5,
+            per_customer_per_min=10,
+            customer_ref="cust_new",
+            now=now,
+        )
+        assert allowed is False


### PR DESCRIPTION
## Why

Kicks off Move 3 — the customer-facing widget. Palantir's decision loop ends at the operator. Paw OS closes the loop to the customer: events on a brand-embedded widget flow into a Pocket, Instinct nudges the owner, the approved action flows back to the widget. This PR is the backend foundation of that loop.

Stacks on `feat/decision-traces-wiring` (pocketpaw #931).

## What's in this PR

### `ee/paw_print/models.py`
- `PawPrintBlock` — tagged-union render primitive: `text` / `image` / `list` / `button` / `form` / `divider`. No raw HTML, no arbitrary JS. Forward-compatible.
- `PawPrintSpec` — what the widget bundle renders. `<= 64 blocks per spec`, `<= 50 items per list`.
- `PawPrintWidget` — owner-facing model. Validators lowercase + dedupe `allowed_domains` (cap 20), enforce positive rate limits, and mint per-widget tokens via `secrets`.
- `PawPrintEvent` — inbound signal. Type required + stripped. `payload_size()` helps PR-B enforce the 4 KB cap.
- `PawPrintEventMapping` — how a widget event becomes a Fabric object (template interpolation lives in PR-B).

### `ee/paw_print/store.py`
- Async SQLite tables for widgets + events, matching `InstinctStore`'s shape.
- Indexes on `(widget_id, timestamp DESC)` and `(widget_id, customer_ref)` — keeps PR-B's rate limiter cheap.
- CRUD + `update_spec` + `rotate_token` (mints a fresh `pp_tok_…`).
- Append-only event log with `recent_events`, `count_events_since`, and the composite `within_rate_limit(overall_per_min, per_customer_per_min, customer_ref)` primitive.

## Test plan

- [x] 19 tests in `tests/cloud/test_paw_print_backend.py`:
  - block + spec caps enforced
  - domain normalization + dedup + cap
  - rate-limit + token validation
  - CRUD round-trip including update_spec, rotate_token, delete idempotency
  - event ordering, window counting
  - overall-vs-per-customer rate-limit interaction
- [x] `uv run pytest` — 3991 passed
- [x] `uv run ruff check` — clean

## Follow-ups

- **PR-B** — HTTP router (`GET /paw-print/spec/{id}`, WS `/paw-print/ws/{id}`, `POST /paw-print/events/{id}`), domain/origin enforcement, Guardian hook, event → Fabric mapping.
- **PR-C** — `paw-print-widget` vanilla JS bundle (new repo).
- **PR-D** — `PawPrintPanel.svelte` in paw-enterprise.

## Context

Design doc: `paw-enterprise/docs/enterprise/PAW-PRINT-MVP.md`.