### PR TITLE
Sync correction-loop-soul + decision traces to dev

### DIFF
--- a/ee/instinct/__init__.py
+++ b/ee/instinct/__init__.py
@@ -22,6 +22,8 @@ from ee.instinct.models import (
     AuditEntry,
 )
 from ee.instinct.store import InstinctStore
+from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace, ToolCallRef
+from ee.instinct.trace_collector import TraceCollector
 
 __all__ = [
     "Action",
@@ -34,7 +36,11 @@ __all__ = [
     "AuditEntry",
     "Correction",
     "CorrectionPatch",
+    "FabricObjectSnapshot",
     "InstinctStore",
+    "ReasoningTrace",
+    "ToolCallRef",
+    "TraceCollector",
     "compute_patches",
     "summarize_correction",
 ]

--- a/ee/instinct/correction_soul_bridge.py
+++ b/ee/instinct/correction_soul_bridge.py
@@ -1,0 +1,151 @@
+# ee/instinct/correction_soul_bridge.py — Wires Corrections into soul-protocol.
+# Created: 2026-04-12 (Move 1 PR-B) — Turns each captured human edit into a soul
+# observation, and promotes repeated edits on the same field into a procedural
+# memory. No new soul primitive — uses soul.observe() + soul.remember() as-is.
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ee.instinct.correction import Correction, CorrectionPatch
+from ee.instinct.models import Action
+
+logger = logging.getLogger(__name__)
+
+_PROMOTION_THRESHOLD = 3  # Same path edited N times → procedural memory
+_PROCEDURAL_IMPORTANCE = 7
+_EPISODIC_IMPORTANCE = 5
+
+if TYPE_CHECKING:
+    from ee.instinct.store import InstinctStore  # noqa: F401
+
+
+class CorrectionSoulBridge:
+    """Connects captured Corrections to soul-protocol's learning hooks.
+
+    Call `record(correction, action)` right after persisting the Correction
+    in the store. The bridge:
+
+    - Always observes the edit as an Interaction so it enters the soul's
+      episodic tier with a recall-friendly summary.
+    - Counts how many times the same `path` has been edited in this pocket.
+      On the third match, synthesizes a short rule and stores it as a
+      procedural memory (importance 7).
+
+    The bridge degrades silently when the soul is not loaded — corrections
+    still persist to SQLite, and the agent tool can still read them back.
+    Nothing in the request path fails because soul is down.
+    """
+
+    def __init__(self, soul_manager: object, store: object) -> None:
+        self._soul_manager = soul_manager
+        self._store = store
+
+    async def record(self, correction: Correction, action: Action) -> None:
+        soul = self._get_soul()
+        if soul is None:
+            logger.debug("No active soul — correction recorded to store only")
+            return
+
+        await self._observe_correction(soul, correction, action)
+        await self._maybe_promote_to_procedural(soul, correction)
+
+    async def _observe_correction(
+        self, soul: object, correction: Correction, action: Action
+    ) -> None:
+        """Record the correction as an Interaction so it enters episodic memory."""
+        try:
+            from soul_protocol import Interaction
+
+            patches_text = "\n".join(
+                f"  - {p.path}: {self._fmt(p.before)} → {self._fmt(p.after)}"
+                for p in correction.patches
+            )
+            user_input = (
+                f"Correction on action '{action.title}' "
+                f"(pocket={correction.pocket_id}, actor={correction.actor})"
+            )
+            agent_output = (
+                f"Original recommendation: {action.recommendation or '(none)'}\n"
+                f"Edits applied by human:\n{patches_text}\n"
+                f"Summary: {correction.context_summary}"
+            )
+            await soul.observe(Interaction(user_input=user_input, agent_output=agent_output))
+            logger.info(
+                "Correction %s recorded to soul (action=%s, paths=%s)",
+                correction.id,
+                correction.action_id,
+                [p.path for p in correction.patches],
+            )
+        except Exception:
+            logger.exception("Failed to observe correction — continuing without soul record")
+
+    async def _maybe_promote_to_procedural(
+        self, soul: object, correction: Correction
+    ) -> None:
+        """When a path has been corrected _PROMOTION_THRESHOLD times, synthesize a rule."""
+        if not hasattr(soul, "remember"):
+            return
+
+        for patch in correction.patches:
+            try:
+                count = await self._store.count_corrections_by_path(
+                    pocket_id=correction.pocket_id,
+                    path=patch.path,
+                )
+            except Exception:
+                logger.debug("Failed to count corrections for path %s", patch.path)
+                continue
+
+            if count != _PROMOTION_THRESHOLD:
+                continue
+
+            rule = self._synthesize_rule(patch, correction)
+            try:
+                await soul.remember(
+                    content=rule,
+                    type="procedural",
+                    importance=_PROCEDURAL_IMPORTANCE,
+                )
+                logger.info(
+                    "Promoted to procedural after %dx '%s' corrections: %s",
+                    _PROMOTION_THRESHOLD,
+                    patch.path,
+                    rule,
+                )
+            except Exception:
+                logger.exception("Failed to persist procedural rule for path %s", patch.path)
+
+    def _get_soul(self) -> object | None:
+        """Resolve the active Soul, tolerating different manager shapes."""
+        manager = self._soul_manager
+        if manager is None:
+            return None
+        soul = getattr(manager, "soul", None)
+        return soul
+
+    @staticmethod
+    def _synthesize_rule(patch: CorrectionPatch, correction: Correction) -> str:
+        """Short natural-language rule — no LLM, deterministic."""
+        if patch.path.startswith("parameters."):
+            key = patch.path.split(".", 1)[1]
+            return (
+                f"For actions in pocket {correction.pocket_id}, "
+                f"{correction.actor} consistently sets {key} to "
+                f"{CorrectionSoulBridge._fmt(patch.after)} "
+                f"(changed from {CorrectionSoulBridge._fmt(patch.before)})."
+            )
+        return (
+            f"For actions in pocket {correction.pocket_id}, "
+            f"{correction.actor} consistently rewrites {patch.path} — "
+            f"most recent: {CorrectionSoulBridge._fmt(patch.before)} → "
+            f"{CorrectionSoulBridge._fmt(patch.after)}."
+        )
+
+    @staticmethod
+    def _fmt(value: object) -> str:
+        if value is None:
+            return "(none)"
+        s = str(value)
+        return s if len(s) <= 80 else s[:77] + "..."

--- a/ee/instinct/router.py
+++ b/ee/instinct/router.py
@@ -181,11 +181,27 @@ async def approve_action(action_id: str, req: ApproveRequest | None = None):
             )
             await store.record_correction(correction)
             await _persist_edits(store, after, edited_fields)
+            await _forward_to_soul(correction, after)
 
     approved = await store.approve(action_id, approver=req.approver)
     if not approved:
         raise HTTPException(404, "Action not found")
     return ApproveResponse(action=approved, correction=correction)
+
+
+async def _forward_to_soul(correction: Correction, action: Action) -> None:
+    """Hand off to the soul bridge — always best-effort, never breaks approval."""
+    try:
+        from ee.instinct.correction_soul_bridge import CorrectionSoulBridge
+        from pocketpaw.soul.manager import get_soul_manager
+
+        manager = get_soul_manager()
+        if manager is None:
+            return
+        bridge = CorrectionSoulBridge(soul_manager=manager, store=_store())
+        await bridge.record(correction, action)
+    except Exception:
+        logger.exception("Correction soul-bridge failed (non-fatal)")
 
 
 @router.post("/instinct/actions/{action_id}/reject", response_model=Action)

--- a/ee/instinct/store.py
+++ b/ee/instinct/store.py
@@ -25,6 +25,7 @@ from ee.instinct.models import (
     AuditCategory,
     AuditEntry,
 )
+from ee.instinct.trace import FabricObjectSnapshot
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS instinct_actions (
@@ -74,12 +75,23 @@ CREATE TABLE IF NOT EXISTS instinct_corrections (
     created_at TEXT DEFAULT (datetime('now'))
 );
 
+CREATE TABLE IF NOT EXISTS instinct_fabric_snapshots (
+    id TEXT PRIMARY KEY,
+    object_id TEXT NOT NULL,
+    audit_id TEXT NOT NULL,
+    object_type TEXT DEFAULT '',
+    snapshot TEXT DEFAULT '{}',
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
 CREATE INDEX IF NOT EXISTS idx_actions_pocket ON instinct_actions(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_actions_status ON instinct_actions(status);
 CREATE INDEX IF NOT EXISTS idx_audit_pocket ON instinct_audit(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON instinct_audit(timestamp);
 CREATE INDEX IF NOT EXISTS idx_corrections_pocket ON instinct_corrections(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_corrections_action ON instinct_corrections(action_id);
+CREATE INDEX IF NOT EXISTS idx_snapshots_audit ON instinct_fabric_snapshots(audit_id);
+CREATE INDEX IF NOT EXISTS idx_snapshots_object ON instinct_fabric_snapshots(object_id);
 """
 
 
@@ -462,6 +474,57 @@ class InstinctStore:
         corrections = await self.get_corrections_for_pocket(pocket_id, limit=1000)
         return sum(1 for c in corrections if any(p.path == path for p in c.patches))
 
+    # --- Fabric object snapshots (decision traces) ---
+
+    async def record_fabric_snapshot(self, snapshot: FabricObjectSnapshot) -> FabricObjectSnapshot:
+        """Persist a Fabric object snapshot keyed to the audit entry.
+
+        The snapshot preserves the object's state at decision time so later
+        queries can reproduce what the agent actually saw, even if the live
+        object has been updated since.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO instinct_fabric_snapshots"
+                " (id, object_id, audit_id, object_type, snapshot, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    snapshot.id,
+                    snapshot.object_id,
+                    snapshot.audit_id,
+                    snapshot.object_type,
+                    json.dumps(snapshot.snapshot),
+                    snapshot.created_at.isoformat(),
+                ),
+            )
+            await db.commit()
+        return snapshot
+
+    async def get_snapshots_for_audit(self, audit_id: str) -> list[FabricObjectSnapshot]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM instinct_fabric_snapshots WHERE audit_id = ?"
+                " ORDER BY created_at ASC",
+                (audit_id,),
+            ) as cur:
+                return [self._row_to_snapshot(row) async for row in cur]
+
+    async def get_snapshots_for_object(
+        self, object_id: str, limit: int = 100
+    ) -> list[FabricObjectSnapshot]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM instinct_fabric_snapshots WHERE object_id = ?"
+                " ORDER BY created_at DESC LIMIT ?",
+                (object_id, limit),
+            ) as cur:
+                return [self._row_to_snapshot(row) async for row in cur]
+
     # --- Helpers ---
 
     def _row_to_action(self, row: Any) -> Action:
@@ -509,5 +572,15 @@ class InstinctStore:
             patches=[CorrectionPatch.model_validate(p) for p in patches_raw],
             context_summary=row["context_summary"],
             action_title=row["action_title"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+    def _row_to_snapshot(self, row: Any) -> FabricObjectSnapshot:
+        return FabricObjectSnapshot(
+            id=row["id"],
+            object_id=row["object_id"],
+            audit_id=row["audit_id"],
+            object_type=row["object_type"] or "",
+            snapshot=json.loads(row["snapshot"]) if row["snapshot"] else {},
             created_at=datetime.fromisoformat(row["created_at"]),
         )

--- a/ee/instinct/trace.py
+++ b/ee/instinct/trace.py
@@ -1,0 +1,65 @@
+# ee/instinct/trace.py — Decision trace types for the Instinct pipeline.
+# Created: 2026-04-13 (Move 2 PR-A) — Captures the reasoning inputs behind each
+# proposed action so the audit log explains *why*, not just *what*. Paired with
+# TraceCollector (the bus-subscriber context manager) and FabricObjectSnapshot
+# (immutable rows that preserve referenced objects at decision time).
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from ee.fabric.models import _gen_id
+
+
+class ToolCallRef(BaseModel):
+    """One tool call captured during proposal reasoning.
+
+    Stored inside `ReasoningTrace.tool_calls`. `args_hash` is a stable fingerprint
+    of the invocation so repeated calls dedupe cleanly; `result_preview` is the
+    first 200 chars of the result string so a human can inspect the trace without
+    re-running the tool.
+    """
+
+    tool: str
+    args_hash: str
+    result_preview: str = ""
+    duration_ms: int = 0
+
+
+class ReasoningTrace(BaseModel):
+    """Full reasoning context that produced a proposed action.
+
+    Every decision that lands in `AuditEntry.context` under the key
+    `reasoning_trace` follows this schema. Reference fields hold IDs only —
+    hydrated content is resolved at read time via the `?hydrate=1` endpoint
+    (Move 2 PR-B).
+    """
+
+    fabric_queries: list[str] = Field(default_factory=list)
+    soul_memories: list[str] = Field(default_factory=list)
+    kb_articles: list[str] = Field(default_factory=list)
+    tool_calls: list[ToolCallRef] = Field(default_factory=list)
+    prompt_version: str = ""
+    backend: str = ""
+    model: str = ""
+    token_counts: dict[str, int] = Field(default_factory=dict)
+
+
+class FabricObjectSnapshot(BaseModel):
+    """An immutable snapshot of a Fabric object at the time a decision was made.
+
+    When the live object later changes (ownership transfer, status update,
+    anything), the trace still reproduces what the agent saw. Keyed by
+    (object_id, audit_id) so a single query can be referenced by many
+    decisions without duplication.
+    """
+
+    id: str = Field(default_factory=lambda: _gen_id("fos"))
+    object_id: str
+    audit_id: str
+    object_type: str = ""
+    snapshot: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=datetime.now)

--- a/ee/instinct/trace_collector.py
+++ b/ee/instinct/trace_collector.py
@@ -1,0 +1,152 @@
+# ee/instinct/trace_collector.py — Async context manager that captures reasoning
+# inputs for a single proposal.
+# Created: 2026-04-13 (Move 2 PR-A) — Subscribes to SystemEvents on the bus,
+# aggregates fabric_query / soul_recall / kb_inject / tool_start+tool_end events
+# into a ReasoningTrace, and exposes the finished trace for persistence by the
+# caller. No global state: a fresh collector per proposal keeps traces isolated.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from typing import Any
+
+from ee.instinct.trace import ReasoningTrace, ToolCallRef
+
+logger = logging.getLogger(__name__)
+
+_PREVIEW_CHARS = 200
+_TOOL_EVENT_START = "tool_start"
+_TOOL_EVENT_END = "tool_end"
+_TOOL_EVENT_RESULT = "tool_result"
+_FABRIC_EVENT = "fabric_query"
+_SOUL_EVENT = "soul_recall"
+_KB_EVENT = "kb_inject"
+
+
+class TraceCollector:
+    """Async context manager that captures reasoning events on the message bus.
+
+    Usage:
+        async with TraceCollector(bus) as trace:
+            action = await agent.propose(...)
+        # trace now holds the captured ReasoningTrace
+
+    The collector subscribes to `subscribe_system` on enter and unsubscribes on
+    exit — always, even if the body raises. It aggregates:
+
+    - Fabric queries (event_type="fabric_query", data["object_id"])
+    - Soul recalls (event_type="soul_recall", data["memory_id"])
+    - KB injections (event_type="kb_inject", data["article_id"])
+    - Tool calls (event_type="tool_start"/"tool_end" with matching tool name)
+
+    Unknown event types are ignored. Duplicate IDs within a single trace are
+    preserved in insertion order but the `fabric_queries` / `soul_memories` /
+    `kb_articles` lists are deduplicated on exit so the trace body stays
+    compact.
+    """
+
+    def __init__(
+        self,
+        bus: Any,
+        *,
+        prompt_version: str = "",
+        backend: str = "",
+        model: str = "",
+    ) -> None:
+        self._bus = bus
+        self.trace = ReasoningTrace(
+            prompt_version=prompt_version,
+            backend=backend,
+            model=model,
+        )
+        self._pending_tool_starts: dict[str, float] = {}
+        self._callback: Any = None
+
+    async def __aenter__(self) -> TraceCollector:
+        self._callback = self._on_event
+        self._bus.subscribe_system(self._callback)
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        if self._callback is not None:
+            try:
+                self._bus.unsubscribe_system(self._callback)
+            except Exception:
+                logger.debug("TraceCollector unsubscribe failed")
+            self._callback = None
+        # Deduplicate the reference lists while preserving insertion order.
+        self.trace.fabric_queries = _dedupe(self.trace.fabric_queries)
+        self.trace.soul_memories = _dedupe(self.trace.soul_memories)
+        self.trace.kb_articles = _dedupe(self.trace.kb_articles)
+
+    async def _on_event(self, event: Any) -> None:
+        event_type = getattr(event, "event_type", None)
+        data = getattr(event, "data", {}) or {}
+        if event_type == _FABRIC_EVENT:
+            oid = data.get("object_id")
+            if isinstance(oid, str):
+                self.trace.fabric_queries.append(oid)
+        elif event_type == _SOUL_EVENT:
+            mid = data.get("memory_id")
+            if isinstance(mid, str):
+                self.trace.soul_memories.append(mid)
+        elif event_type == _KB_EVENT:
+            aid = data.get("article_id")
+            if isinstance(aid, str):
+                self.trace.kb_articles.append(aid)
+        elif event_type == _TOOL_EVENT_START:
+            tool = data.get("tool")
+            if isinstance(tool, str):
+                self._pending_tool_starts[tool] = time.monotonic()
+        elif event_type in (_TOOL_EVENT_END, _TOOL_EVENT_RESULT):
+            self._record_tool_end(data)
+
+    def _record_tool_end(self, data: dict[str, Any]) -> None:
+        tool = data.get("tool")
+        if not isinstance(tool, str):
+            return
+        args = data.get("args", {})
+        result = data.get("result", "")
+        started = self._pending_tool_starts.pop(tool, None)
+        duration_ms = int((time.monotonic() - started) * 1000) if started is not None else 0
+
+        args_hash = _hash_args(args)
+        preview = str(result)
+        if len(preview) > _PREVIEW_CHARS:
+            preview = preview[:_PREVIEW_CHARS - 3] + "..."
+
+        # Dedupe identical tool+args pairs within a single trace.
+        for existing in self.trace.tool_calls:
+            if existing.tool == tool and existing.args_hash == args_hash:
+                return
+
+        self.trace.tool_calls.append(
+            ToolCallRef(
+                tool=tool,
+                args_hash=args_hash,
+                result_preview=preview,
+                duration_ms=duration_ms,
+            ),
+        )
+
+
+def _hash_args(args: Any) -> str:
+    try:
+        serialized = json.dumps(args, sort_keys=True, default=str)
+    except Exception:
+        serialized = str(args)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    """Dedupe while preserving the order of first appearance."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for v in values:
+        if v not in seen:
+            seen.add(v)
+            out.append(v)
+    return out

--- a/src/pocketpaw/tools/builtin/__init__.py
+++ b/src/pocketpaw/tools/builtin/__init__.py
@@ -92,6 +92,7 @@ try:
         FabricQueryTool,
         FabricStatsTool,
     )
+    from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
     from pocketpaw.tools.builtin.instinct_tools import (
         InstinctAuditTool,
         InstinctPendingTool,
@@ -105,6 +106,7 @@ try:
         InstinctProposeTool,
         InstinctPendingTool,
         InstinctAuditTool,
+        InstinctCorrectionsTool,
     ]
     _EE_NAMES = {cls.__name__: cls for cls in _EE_TOOLS}
 except ImportError:

--- a/src/pocketpaw/tools/builtin/instinct_corrections.py
+++ b/src/pocketpaw/tools/builtin/instinct_corrections.py
@@ -1,0 +1,112 @@
+# Instinct corrections tool — agent-facing surface for learned human edits.
+# Created: 2026-04-12 (Move 1 PR-B) — Lets an agent fetch recent corrections for
+# a pocket before proposing its next action, so past human edits shape the draft.
+# Pairs with the correction_soul_bridge, which also feeds the same signal into
+# soul-protocol's automatic memory injection when a soul is loaded.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw.tools.protocol import BaseTool
+
+logger = logging.getLogger(__name__)
+
+
+def _get_instinct_store():
+    """Lazy import — degrades gracefully when ee/ is not installed."""
+    try:
+        from ee.api import get_instinct_store
+
+        return get_instinct_store()
+    except ImportError:
+        return None
+
+
+class InstinctCorrectionsTool(BaseTool):
+    """Fetch recent human corrections on actions within a pocket."""
+
+    @property
+    def name(self) -> str:
+        return "instinct_corrections"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Fetch recent human edits (corrections) applied to previously proposed "
+            "actions in a pocket. Use this BEFORE proposing a new action so your "
+            "draft already matches the style and thresholds the user prefers — e.g. "
+            "if they consistently edit the greeting tone or cap a discount percentage, "
+            "match that pattern in the new proposal."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "high"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "pocket_id": {
+                    "type": "string",
+                    "description": "Pocket whose corrections you want to review",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max corrections to return (default: 10, max: 50)",
+                    "default": 10,
+                },
+            },
+            "required": ["pocket_id"],
+        }
+
+    async def execute(self, pocket_id: str, limit: int = 10) -> str:
+        store = _get_instinct_store()
+        if not store:
+            return "Instinct is not available (enterprise feature)."
+
+        try:
+            corrections = await store.get_corrections_for_pocket(
+                pocket_id=pocket_id,
+                limit=min(max(limit, 1), 50),
+            )
+        except Exception as exc:
+            logger.error("instinct_corrections lookup failed: %s", exc)
+            return f"Error loading corrections: {exc}"
+
+        if not corrections:
+            return (
+                f"No corrections captured yet for pocket {pocket_id}. "
+                "Propose freely — nothing to align with."
+            )
+
+        lines = [
+            f"{len(corrections)} recent correction(s) for pocket {pocket_id}:",
+            "",
+        ]
+        for c in corrections:
+            lines.append(f"- {c.action_title} (edited by {c.actor})")
+            lines.append(f"    Summary: {c.context_summary}")
+            for patch in c.patches[:5]:
+                before = _fmt(patch.before)
+                after = _fmt(patch.after)
+                lines.append(f"    {patch.path}: {before} → {after}")
+            if len(c.patches) > 5:
+                lines.append(f"    (+{len(c.patches) - 5} more field changes)")
+            lines.append("")
+
+        lines.append(
+            "When proposing your next action, pre-apply these patterns unless the "
+            "situation clearly calls for something different.",
+        )
+        return "\n".join(lines)
+
+
+def _fmt(value: object) -> str:
+    if value is None:
+        return "(none)"
+    s = str(value)
+    return s if len(s) <= 60 else s[:57] + "..."

--- a/tests/cloud/test_correction_soul_bridge.py
+++ b/tests/cloud/test_correction_soul_bridge.py
@@ -1,0 +1,333 @@
+# tests/cloud/test_correction_soul_bridge.py — Tests for the correction soul bridge
+# and the instinct_corrections agent tool (Move 1 PR-B).
+# Created: 2026-04-13 — Covers observe() call shape, 3x procedural promotion,
+# graceful degradation when no soul is loaded, and tool output formatting.
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ee.instinct.correction import Correction, CorrectionPatch
+from ee.instinct.correction_soul_bridge import CorrectionSoulBridge
+from ee.instinct.models import (
+    Action,
+    ActionCategory,
+    ActionPriority,
+    ActionTrigger,
+)
+from ee.instinct.store import InstinctStore
+
+
+@pytest.fixture(autouse=True)
+def _stub_soul_protocol(monkeypatch):
+    """Provide a minimal fake `soul_protocol` module when the real one is absent.
+
+    Production code imports `soul_protocol.Interaction` lazily inside the
+    bridge; the real package is an optional dep not installed in the base
+    dev env. A lightweight stub is sufficient to exercise the bridge's code
+    path without pulling in the full soul runtime.
+    """
+    if "soul_protocol" in sys.modules:
+        return
+
+    module = types.ModuleType("soul_protocol")
+
+    class _Interaction:
+        def __init__(self, user_input: str = "", agent_output: str = "", **kwargs):
+            self.user_input = user_input
+            self.agent_output = agent_output
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    module.Interaction = _Interaction  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "soul_protocol", module)
+
+
+def _trigger() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="claude", reason="test")
+
+
+def _action(**overrides) -> Action:
+    defaults: dict = {
+        "pocket_id": "pocket-1",
+        "title": "Send renewal outreach",
+        "description": "Two accounts up for renewal",
+        "recommendation": "Draft a formal nudge email",
+        "trigger": _trigger(),
+        "category": ActionCategory.WORKFLOW,
+        "priority": ActionPriority.MEDIUM,
+        "parameters": {"tone": "formal", "discount_pct": 20},
+    }
+    defaults.update(overrides)
+    return Action(**defaults)
+
+
+def _correction(
+    *,
+    action_id: str = "act-1",
+    patches: list[CorrectionPatch] | None = None,
+    pocket_id: str = "pocket-1",
+    actor: str = "user:priya",
+) -> Correction:
+    return Correction(
+        action_id=action_id,
+        pocket_id=pocket_id,
+        actor=actor,
+        patches=patches or [CorrectionPatch(path="title", before="A", after="B")],
+        context_summary="softened the greeting",
+        action_title="Send renewal outreach",
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "bridge_test.db")
+
+
+@pytest.fixture
+def fake_soul():
+    soul = MagicMock()
+    soul.observe = AsyncMock()
+    soul.remember = AsyncMock()
+    return soul
+
+
+@pytest.fixture
+def manager_with_soul(fake_soul):
+    manager = MagicMock()
+    manager.soul = fake_soul
+    return manager
+
+
+# ---------------------------------------------------------------------------
+# record() — observe path
+# ---------------------------------------------------------------------------
+
+
+class TestObserveCorrection:
+    @pytest.mark.asyncio
+    async def test_observe_called_once_per_correction(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+        await bridge.record(_correction(), _action())
+
+        assert fake_soul.observe.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_observe_payload_includes_summary_and_patches(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+        correction = _correction(
+            patches=[
+                CorrectionPatch(path="title", before="Formal", after="Casual"),
+                CorrectionPatch(path="parameters.discount_pct", before=20, after=15),
+            ],
+        )
+        await bridge.record(correction, _action())
+
+        (call,) = fake_soul.observe.await_args_list
+        interaction = call.args[0]
+        assert "pocket-1" in interaction.user_input
+        assert "user:priya" in interaction.user_input
+        assert "title" in interaction.agent_output
+        assert "parameters.discount_pct" in interaction.agent_output
+        assert "softened the greeting" in interaction.agent_output
+
+    @pytest.mark.asyncio
+    async def test_no_observe_when_soul_is_absent(self, store: InstinctStore) -> None:
+        manager = MagicMock()
+        manager.soul = None
+        bridge = CorrectionSoulBridge(soul_manager=manager, store=store)
+        # Should not raise, just no-op.
+        await bridge.record(_correction(), _action())
+
+    @pytest.mark.asyncio
+    async def test_observe_exception_is_swallowed(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        fake_soul.observe.side_effect = RuntimeError("soul went down")
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+        # Should not raise — approval flow must never break because soul is sick.
+        await bridge.record(_correction(), _action())
+
+
+# ---------------------------------------------------------------------------
+# Procedural promotion — 3x-same-path heuristic
+# ---------------------------------------------------------------------------
+
+
+class TestProceduralPromotion:
+    @pytest.mark.asyncio
+    async def test_promotes_on_third_same_path(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+
+        first = _correction(
+            action_id="act-a",
+            patches=[CorrectionPatch(path="parameters.tone", before="formal", after="casual")],
+        )
+        second = _correction(
+            action_id="act-b",
+            patches=[CorrectionPatch(path="parameters.tone", before="formal", after="casual")],
+        )
+        third = _correction(
+            action_id="act-c",
+            patches=[CorrectionPatch(path="parameters.tone", before="formal", after="casual")],
+        )
+
+        await store.record_correction(first)
+        await bridge.record(first, _action())
+        assert fake_soul.remember.await_count == 0
+
+        await store.record_correction(second)
+        await bridge.record(second, _action())
+        assert fake_soul.remember.await_count == 0
+
+        await store.record_correction(third)
+        await bridge.record(third, _action())
+        assert fake_soul.remember.await_count == 1
+
+        kwargs = fake_soul.remember.await_args.kwargs
+        assert kwargs["type"] == "procedural"
+        assert kwargs["importance"] == 7
+        assert "parameters.tone" in kwargs["content"] or "tone" in kwargs["content"]
+        assert "casual" in kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_does_not_re_promote_past_threshold(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+
+        for i in range(4):
+            correction = _correction(
+                action_id=f"act-{i}",
+                patches=[CorrectionPatch(path="title", before="A", after="B")],
+            )
+            await store.record_correction(correction)
+            await bridge.record(correction, _action())
+
+        # Promotion fires exactly once, when count hits the threshold.
+        assert fake_soul.remember.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_promotes_per_path_independently(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+
+        for i in range(3):
+            await store.record_correction(
+                _correction(
+                    action_id=f"title-{i}",
+                    patches=[CorrectionPatch(path="title", before="A", after="B")],
+                ),
+            )
+        for i in range(3):
+            await store.record_correction(
+                _correction(
+                    action_id=f"prio-{i}",
+                    patches=[CorrectionPatch(path="priority", before="medium", after="high")],
+                ),
+            )
+
+        await bridge.record(
+            _correction(
+                action_id="title-2",
+                patches=[CorrectionPatch(path="title", before="A", after="B")],
+            ),
+            _action(),
+        )
+        await bridge.record(
+            _correction(
+                action_id="prio-2",
+                patches=[CorrectionPatch(path="priority", before="medium", after="high")],
+            ),
+            _action(),
+        )
+
+        assert fake_soul.remember.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# InstinctCorrectionsTool — agent-facing shape
+# ---------------------------------------------------------------------------
+
+
+class TestInstinctCorrectionsTool:
+    @pytest.mark.asyncio
+    async def test_tool_returns_no_corrections_message_when_empty(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
+
+        empty_store = InstinctStore(tmp_path / "empty.db")
+        monkeypatch.setattr(
+            "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
+            lambda: empty_store,
+        )
+
+        tool = InstinctCorrectionsTool()
+        result = await tool.execute(pocket_id="pocket-1")
+        assert "No corrections captured" in result
+
+    @pytest.mark.asyncio
+    async def test_tool_formats_each_correction_with_patches(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
+
+        store = InstinctStore(tmp_path / "with_data.db")
+        await store.record_correction(
+            _correction(
+                action_id="act-x",
+                patches=[
+                    CorrectionPatch(path="title", before="Hi John", after="Hey J"),
+                    CorrectionPatch(path="parameters.discount_pct", before=20, after=15),
+                ],
+            ),
+        )
+        monkeypatch.setattr(
+            "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
+            lambda: store,
+        )
+
+        tool = InstinctCorrectionsTool()
+        result = await tool.execute(pocket_id="pocket-1")
+        assert "Send renewal outreach" in result
+        assert "user:priya" in result
+        assert "Hi John" in result
+        assert "Hey J" in result
+        assert "discount_pct" in result
+
+    @pytest.mark.asyncio
+    async def test_tool_returns_enterprise_missing_message_when_ee_unavailable(
+        self, monkeypatch
+    ) -> None:
+        from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
+
+        monkeypatch.setattr(
+            "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
+            lambda: None,
+        )
+
+        tool = InstinctCorrectionsTool()
+        result = await tool.execute(pocket_id="pocket-1")
+        assert "enterprise" in result.lower()
+
+    def test_tool_advertises_required_parameters(self) -> None:
+        from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
+
+        tool = InstinctCorrectionsTool()
+        assert tool.name == "instinct_corrections"
+        schema = tool.parameters
+        assert "pocket_id" in schema["properties"]
+        assert schema["required"] == ["pocket_id"]

--- a/tests/cloud/test_decision_traces.py
+++ b/tests/cloud/test_decision_traces.py
@@ -1,0 +1,307 @@
+# tests/cloud/test_decision_traces.py — Tests for ReasoningTrace + TraceCollector
+# + FabricObjectSnapshot store ops (Move 2 PR-A).
+# Created: 2026-04-13 — Locks the context-manager lifecycle, event aggregation
+# across fabric/soul/kb/tool-call event types, deduplication on exit, and the
+# SQLite persistence path for decision-time fabric snapshots.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ee.instinct.store import InstinctStore
+from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace, ToolCallRef
+from ee.instinct.trace_collector import TraceCollector
+
+# ---------------------------------------------------------------------------
+# Lightweight bus + event stand-ins (avoids pulling the real MessageBus)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeEvent:
+    event_type: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+class FakeBus:
+    """Minimal subscribe/unsubscribe interface matching MessageBus."""
+
+    def __init__(self) -> None:
+        self.subscribers: list[Any] = []
+
+    def subscribe_system(self, cb: Any) -> None:
+        self.subscribers.append(cb)
+
+    def unsubscribe_system(self, cb: Any) -> None:
+        if cb in self.subscribers:
+            self.subscribers.remove(cb)
+
+    async def publish(self, event: FakeEvent) -> None:
+        for cb in list(self.subscribers):
+            await cb(event)
+
+
+# ---------------------------------------------------------------------------
+# ReasoningTrace — shape
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningTraceModel:
+    def test_defaults_produce_empty_collections(self) -> None:
+        trace = ReasoningTrace()
+        assert trace.fabric_queries == []
+        assert trace.soul_memories == []
+        assert trace.kb_articles == []
+        assert trace.tool_calls == []
+        assert trace.token_counts == {}
+
+    def test_round_trip_serialization(self) -> None:
+        trace = ReasoningTrace(
+            fabric_queries=["obj_1", "obj_2"],
+            soul_memories=["mem_a"],
+            kb_articles=["kb_42"],
+            tool_calls=[ToolCallRef(tool="fabric_query", args_hash="abc", result_preview="...")],
+            prompt_version="v1",
+            backend="claude_agent_sdk",
+            model="claude-opus-4-6",
+            token_counts={"prompt": 120, "completion": 45},
+        )
+        restored = ReasoningTrace.model_validate(trace.model_dump())
+        assert restored == trace
+
+
+# ---------------------------------------------------------------------------
+# TraceCollector lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestCollectorLifecycle:
+    @pytest.mark.asyncio
+    async def test_subscribes_on_enter_and_unsubscribes_on_exit(self) -> None:
+        bus = FakeBus()
+        assert bus.subscribers == []
+
+        async with TraceCollector(bus):
+            assert len(bus.subscribers) == 1
+
+        assert bus.subscribers == []
+
+    @pytest.mark.asyncio
+    async def test_unsubscribes_even_when_body_raises(self) -> None:
+        bus = FakeBus()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            async with TraceCollector(bus):
+                raise RuntimeError("boom")
+
+        assert bus.subscribers == []
+
+    @pytest.mark.asyncio
+    async def test_carries_prompt_version_backend_and_model(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(
+            bus,
+            prompt_version="pv_123",
+            backend="claude_agent_sdk",
+            model="claude-opus-4-6",
+        ) as collector:
+            pass
+        assert collector.trace.prompt_version == "pv_123"
+        assert collector.trace.backend == "claude_agent_sdk"
+        assert collector.trace.model == "claude-opus-4-6"
+
+
+# ---------------------------------------------------------------------------
+# TraceCollector — event aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestCollectorAggregation:
+    @pytest.mark.asyncio
+    async def test_captures_fabric_queries(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("fabric_query", {"object_id": "obj_acme"}))
+            await bus.publish(FakeEvent("fabric_query", {"object_id": "obj_pricing"}))
+        assert collector.trace.fabric_queries == ["obj_acme", "obj_pricing"]
+
+    @pytest.mark.asyncio
+    async def test_captures_soul_memories(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("soul_recall", {"memory_id": "mem_1"}))
+            await bus.publish(FakeEvent("soul_recall", {"memory_id": "mem_2"}))
+        assert collector.trace.soul_memories == ["mem_1", "mem_2"]
+
+    @pytest.mark.asyncio
+    async def test_captures_kb_articles(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("kb_inject", {"article_id": "kb_pricing"}))
+        assert collector.trace.kb_articles == ["kb_pricing"]
+
+    @pytest.mark.asyncio
+    async def test_captures_tool_calls_with_duration(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_end",
+                    {"tool": "fabric_query", "args": {"q": "acme"}, "result": "1 row"},
+                ),
+            )
+        assert len(collector.trace.tool_calls) == 1
+        call = collector.trace.tool_calls[0]
+        assert call.tool == "fabric_query"
+        assert call.result_preview == "1 row"
+        assert call.args_hash  # non-empty
+        assert call.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_tool_result_alias_event_also_captured(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("tool_start", {"tool": "kb_search"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_result",
+                    {"tool": "kb_search", "args": {"q": "discount"}, "result": "ok"},
+                ),
+            )
+        assert len(collector.trace.tool_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_long_tool_result_is_truncated_with_ellipsis(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_end",
+                    {"tool": "fabric_query", "args": {}, "result": "x" * 500},
+                ),
+            )
+        preview = collector.trace.tool_calls[0].result_preview
+        assert len(preview) == 200
+        assert preview.endswith("...")
+
+    @pytest.mark.asyncio
+    async def test_duplicate_tool_calls_with_same_args_are_merged(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            for _ in range(3):
+                await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+                await bus.publish(
+                    FakeEvent(
+                        "tool_end",
+                        {"tool": "fabric_query", "args": {"q": "acme"}, "result": "ok"},
+                    ),
+                )
+        assert len(collector.trace.tool_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_tool_calls_with_different_args_are_kept_separate(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_end",
+                    {"tool": "fabric_query", "args": {"q": "acme"}, "result": "ok"},
+                ),
+            )
+            await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_end",
+                    {"tool": "fabric_query", "args": {"q": "beta"}, "result": "ok"},
+                ),
+            )
+        assert len(collector.trace.tool_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_reference_lists_are_deduplicated_on_exit(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("fabric_query", {"object_id": "obj_acme"}))
+            await bus.publish(FakeEvent("fabric_query", {"object_id": "obj_acme"}))
+            await bus.publish(FakeEvent("soul_recall", {"memory_id": "mem_1"}))
+            await bus.publish(FakeEvent("soul_recall", {"memory_id": "mem_1"}))
+        assert collector.trace.fabric_queries == ["obj_acme"]
+        assert collector.trace.soul_memories == ["mem_1"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_types_are_ignored(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("unknown_thing", {"object_id": "nope"}))
+            await bus.publish(FakeEvent("another_thing", {"data": 1}))
+        assert collector.trace.fabric_queries == []
+        assert collector.trace.tool_calls == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_event_data_is_skipped(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("fabric_query", {"object_id": 123}))
+            await bus.publish(FakeEvent("soul_recall", {}))
+            await bus.publish(FakeEvent("tool_end", {"args": {"q": "x"}}))
+        assert collector.trace.fabric_queries == []
+        assert collector.trace.soul_memories == []
+        assert collector.trace.tool_calls == []
+
+
+# ---------------------------------------------------------------------------
+# FabricObjectSnapshot store ops
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "trace_test.db")
+
+
+class TestFabricSnapshotStore:
+    @pytest.mark.asyncio
+    async def test_record_and_read_snapshot(self, store: InstinctStore) -> None:
+        snapshot = FabricObjectSnapshot(
+            object_id="obj_acme",
+            audit_id="aud_42",
+            object_type="Customer",
+            snapshot={"arr": 180000, "tier": "enterprise"},
+        )
+        saved = await store.record_fabric_snapshot(snapshot)
+        assert saved.id == snapshot.id
+
+        rows = await store.get_snapshots_for_audit("aud_42")
+        assert len(rows) == 1
+        assert rows[0].object_id == "obj_acme"
+        assert rows[0].snapshot["arr"] == 180000
+        assert rows[0].object_type == "Customer"
+
+    @pytest.mark.asyncio
+    async def test_snapshots_for_audit_orders_oldest_first(self, store: InstinctStore) -> None:
+        first = FabricObjectSnapshot(object_id="a", audit_id="aud_1")
+        second = FabricObjectSnapshot(object_id="b", audit_id="aud_1")
+        await store.record_fabric_snapshot(first)
+        await store.record_fabric_snapshot(second)
+
+        rows = await store.get_snapshots_for_audit("aud_1")
+        assert [r.object_id for r in rows] == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_snapshots_for_object_orders_newest_first(
+        self, store: InstinctStore
+    ) -> None:
+        older = FabricObjectSnapshot(object_id="obj_x", audit_id="aud_1")
+        newer = FabricObjectSnapshot(object_id="obj_x", audit_id="aud_2")
+        await store.record_fabric_snapshot(older)
+        await store.record_fabric_snapshot(newer)
+
+        rows = await store.get_snapshots_for_object("obj_x")
+        assert [r.audit_id for r in rows] == ["aud_2", "aud_1"]


### PR DESCRIPTION
## Summary
- Re-sync `feat/correction-loop-soul` into `dev` after the PR #929 / #930 chain
- Brings correction→soul bridge, `instinct_corrections` tool, and decision trace collector (ReasoningTrace + TraceCollector + fabric snapshots)

## Test plan
- [ ] `uv run pytest tests/cloud/test_correction_soul_bridge.py tests/cloud/test_decision_traces.py`
- [ ] `uv run ruff check . && uv run ruff format --check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)