### PR TITLE
Sync paw-print ingest + decision trace wiring to dev

### DIFF
--- a/ee/instinct/__init__.py
+++ b/ee/instinct/__init__.py
@@ -22,6 +22,8 @@ from ee.instinct.models import (
     AuditEntry,
 )
 from ee.instinct.store import InstinctStore
+from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace, ToolCallRef
+from ee.instinct.trace_collector import TraceCollector
 
 __all__ = [
     "Action",
@@ -34,7 +36,11 @@ __all__ = [
     "AuditEntry",
     "Correction",
     "CorrectionPatch",
+    "FabricObjectSnapshot",
     "InstinctStore",
+    "ReasoningTrace",
+    "ToolCallRef",
+    "TraceCollector",
     "compute_patches",
     "summarize_correction",
 ]

--- a/ee/instinct/correction_soul_bridge.py
+++ b/ee/instinct/correction_soul_bridge.py
@@ -1,0 +1,151 @@
+# ee/instinct/correction_soul_bridge.py — Wires Corrections into soul-protocol.
+# Created: 2026-04-12 (Move 1 PR-B) — Turns each captured human edit into a soul
+# observation, and promotes repeated edits on the same field into a procedural
+# memory. No new soul primitive — uses soul.observe() + soul.remember() as-is.
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ee.instinct.correction import Correction, CorrectionPatch
+from ee.instinct.models import Action
+
+logger = logging.getLogger(__name__)
+
+_PROMOTION_THRESHOLD = 3  # Same path edited N times → procedural memory
+_PROCEDURAL_IMPORTANCE = 7
+_EPISODIC_IMPORTANCE = 5
+
+if TYPE_CHECKING:
+    from ee.instinct.store import InstinctStore  # noqa: F401
+
+
+class CorrectionSoulBridge:
+    """Connects captured Corrections to soul-protocol's learning hooks.
+
+    Call `record(correction, action)` right after persisting the Correction
+    in the store. The bridge:
+
+    - Always observes the edit as an Interaction so it enters the soul's
+      episodic tier with a recall-friendly summary.
+    - Counts how many times the same `path` has been edited in this pocket.
+      On the third match, synthesizes a short rule and stores it as a
+      procedural memory (importance 7).
+
+    The bridge degrades silently when the soul is not loaded — corrections
+    still persist to SQLite, and the agent tool can still read them back.
+    Nothing in the request path fails because soul is down.
+    """
+
+    def __init__(self, soul_manager: object, store: object) -> None:
+        self._soul_manager = soul_manager
+        self._store = store
+
+    async def record(self, correction: Correction, action: Action) -> None:
+        soul = self._get_soul()
+        if soul is None:
+            logger.debug("No active soul — correction recorded to store only")
+            return
+
+        await self._observe_correction(soul, correction, action)
+        await self._maybe_promote_to_procedural(soul, correction)
+
+    async def _observe_correction(
+        self, soul: object, correction: Correction, action: Action
+    ) -> None:
+        """Record the correction as an Interaction so it enters episodic memory."""
+        try:
+            from soul_protocol import Interaction
+
+            patches_text = "\n".join(
+                f"  - {p.path}: {self._fmt(p.before)} → {self._fmt(p.after)}"
+                for p in correction.patches
+            )
+            user_input = (
+                f"Correction on action '{action.title}' "
+                f"(pocket={correction.pocket_id}, actor={correction.actor})"
+            )
+            agent_output = (
+                f"Original recommendation: {action.recommendation or '(none)'}\n"
+                f"Edits applied by human:\n{patches_text}\n"
+                f"Summary: {correction.context_summary}"
+            )
+            await soul.observe(Interaction(user_input=user_input, agent_output=agent_output))
+            logger.info(
+                "Correction %s recorded to soul (action=%s, paths=%s)",
+                correction.id,
+                correction.action_id,
+                [p.path for p in correction.patches],
+            )
+        except Exception:
+            logger.exception("Failed to observe correction — continuing without soul record")
+
+    async def _maybe_promote_to_procedural(
+        self, soul: object, correction: Correction
+    ) -> None:
+        """When a path has been corrected _PROMOTION_THRESHOLD times, synthesize a rule."""
+        if not hasattr(soul, "remember"):
+            return
+
+        for patch in correction.patches:
+            try:
+                count = await self._store.count_corrections_by_path(
+                    pocket_id=correction.pocket_id,
+                    path=patch.path,
+                )
+            except Exception:
+                logger.debug("Failed to count corrections for path %s", patch.path)
+                continue
+
+            if count != _PROMOTION_THRESHOLD:
+                continue
+
+            rule = self._synthesize_rule(patch, correction)
+            try:
+                await soul.remember(
+                    content=rule,
+                    type="procedural",
+                    importance=_PROCEDURAL_IMPORTANCE,
+                )
+                logger.info(
+                    "Promoted to procedural after %dx '%s' corrections: %s",
+                    _PROMOTION_THRESHOLD,
+                    patch.path,
+                    rule,
+                )
+            except Exception:
+                logger.exception("Failed to persist procedural rule for path %s", patch.path)
+
+    def _get_soul(self) -> object | None:
+        """Resolve the active Soul, tolerating different manager shapes."""
+        manager = self._soul_manager
+        if manager is None:
+            return None
+        soul = getattr(manager, "soul", None)
+        return soul
+
+    @staticmethod
+    def _synthesize_rule(patch: CorrectionPatch, correction: Correction) -> str:
+        """Short natural-language rule — no LLM, deterministic."""
+        if patch.path.startswith("parameters."):
+            key = patch.path.split(".", 1)[1]
+            return (
+                f"For actions in pocket {correction.pocket_id}, "
+                f"{correction.actor} consistently sets {key} to "
+                f"{CorrectionSoulBridge._fmt(patch.after)} "
+                f"(changed from {CorrectionSoulBridge._fmt(patch.before)})."
+            )
+        return (
+            f"For actions in pocket {correction.pocket_id}, "
+            f"{correction.actor} consistently rewrites {patch.path} — "
+            f"most recent: {CorrectionSoulBridge._fmt(patch.before)} → "
+            f"{CorrectionSoulBridge._fmt(patch.after)}."
+        )
+
+    @staticmethod
+    def _fmt(value: object) -> str:
+        if value is None:
+            return "(none)"
+        s = str(value)
+        return s if len(s) <= 80 else s[:77] + "..."

--- a/ee/instinct/correction_soul_bridge.py
+++ b/ee/instinct/correction_soul_bridge.py
@@ -81,9 +81,7 @@ class CorrectionSoulBridge:
         except Exception:
             logger.exception("Failed to observe correction — continuing without soul record")
 
-    async def _maybe_promote_to_procedural(
-        self, soul: object, correction: Correction
-    ) -> None:
+    async def _maybe_promote_to_procedural(self, soul: object, correction: Correction) -> None:
         """When a path has been corrected _PROMOTION_THRESHOLD times, synthesize a rule."""
         if not hasattr(soul, "remember"):
             return

--- a/ee/instinct/router.py
+++ b/ee/instinct/router.py
@@ -181,11 +181,27 @@ async def approve_action(action_id: str, req: ApproveRequest | None = None):
             )
             await store.record_correction(correction)
             await _persist_edits(store, after, edited_fields)
+            await _forward_to_soul(correction, after)
 
     approved = await store.approve(action_id, approver=req.approver)
     if not approved:
         raise HTTPException(404, "Action not found")
     return ApproveResponse(action=approved, correction=correction)
+
+
+async def _forward_to_soul(correction: Correction, action: Action) -> None:
+    """Hand off to the soul bridge — always best-effort, never breaks approval."""
+    try:
+        from ee.instinct.correction_soul_bridge import CorrectionSoulBridge
+        from pocketpaw.soul.manager import get_soul_manager
+
+        manager = get_soul_manager()
+        if manager is None:
+            return
+        bridge = CorrectionSoulBridge(soul_manager=manager, store=_store())
+        await bridge.record(correction, action)
+    except Exception:
+        logger.exception("Correction soul-bridge failed (non-fatal)")
 
 
 @router.post("/instinct/actions/{action_id}/reject", response_model=Action)

--- a/ee/instinct/router.py
+++ b/ee/instinct/router.py
@@ -6,6 +6,11 @@
 #   When present, the server diffs the stored proposal against the edits, persists
 #   a Correction, then approves. GET /instinct/corrections exposes corrections
 #   scoped to a pocket or an action so the UI and agents can read them back.
+# Updated: 2026-04-13 (Move 2 PR-B) — POST /instinct/actions accepts an optional
+#   reasoning_trace + fabric_snapshots body so callers (and the agent tool) can
+#   attach decision inputs at propose time. GET /instinct/audit/{id}?hydrate=1
+#   returns the audit entry with the trace's referenced IDs expanded into Fabric
+#   object snapshots, making the "Why?" drawer possible in the UI.
 
 from __future__ import annotations
 
@@ -29,6 +34,7 @@ from ee.instinct.models import (
     ActionTrigger,
     AuditEntry,
 )
+from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +61,21 @@ class ProposeRequest(BaseModel):
     category: ActionCategory = ActionCategory.WORKFLOW
     priority: ActionPriority = ActionPriority.MEDIUM
     parameters: dict[str, Any] = {}
+    reasoning_trace: ReasoningTrace | None = Field(
+        default=None,
+        description=(
+            "Optional decision trace: which Fabric objects / soul memories / "
+            "KB articles / tool calls the agent consumed to produce this proposal. "
+            "Persisted into the audit entry so the Why? drawer can expand it."
+        ),
+    )
+    fabric_snapshots: list[FabricObjectSnapshot] = Field(
+        default_factory=list,
+        description=(
+            "Optional snapshots of the Fabric objects referenced in the trace, "
+            "captured at decision time so later live mutations don't erase the reasoning."
+        ),
+    )
 
 
 class RejectRequest(BaseModel):
@@ -113,7 +134,12 @@ class CorrectionsListResponse(BaseModel):
 
 @router.post("/instinct/actions", response_model=Action, status_code=201)
 async def propose_action(req: ProposeRequest):
-    """Propose a new action for human approval."""
+    """Propose a new action for human approval.
+
+    Optional `reasoning_trace` and `fabric_snapshots` let callers attach the
+    agent's decision inputs at propose time. They are persisted into the
+    resulting audit row for later hydration via `/audit/{id}?hydrate=1`.
+    """
     return await _store().propose(
         pocket_id=req.pocket_id,
         title=req.title,
@@ -123,6 +149,8 @@ async def propose_action(req: ProposeRequest):
         category=req.category,
         priority=req.priority,
         parameters=req.parameters,
+        reasoning_trace=req.reasoning_trace,
+        fabric_snapshots=list(req.fabric_snapshots) if req.fabric_snapshots else None,
     )
 
 
@@ -321,6 +349,95 @@ async def query_audit(
         limit=limit,
     )
     return AuditListResponse(entries=entries, total=len(entries))
+
+
+class HydratedAuditEntry(BaseModel):
+    """Audit entry with referenced IDs expanded for the Why? drawer."""
+
+    entry: AuditEntry
+    reasoning_trace: ReasoningTrace | None = None
+    fabric_snapshots: list[FabricObjectSnapshot] = Field(default_factory=list)
+    fabric_current: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Live Fabric objects referenced in the trace (current state).",
+    )
+
+
+@router.get("/instinct/audit/{audit_id}", response_model=HydratedAuditEntry)
+async def get_audit_entry(
+    audit_id: str,
+    hydrate: int = Query(0, description="Pass 1 to expand referenced IDs"),
+):
+    """Fetch a single audit entry, optionally hydrated with referenced content.
+
+    When `hydrate=1`, the response carries:
+    - the decoded `reasoning_trace` (if stored)
+    - `fabric_snapshots` — immutable snapshots captured at decision time
+    - `fabric_current` — live state of the referenced objects (so a reviewer
+      can compare what the agent saw against what the object is now)
+    """
+    store = _store()
+    entries = await store.query_audit(limit=1000)
+    entry = next((e for e in entries if e.id == audit_id), None)
+    if entry is None:
+        raise HTTPException(404, "Audit entry not found")
+
+    trace = _decode_trace(entry)
+    if not hydrate:
+        return HydratedAuditEntry(entry=entry, reasoning_trace=trace)
+
+    snapshots: list[FabricObjectSnapshot] = []
+    current: list[dict[str, Any]] = []
+    if trace is not None:
+        snapshots = await store.get_snapshots_for_audit(audit_id)
+        current = await _fetch_current_fabric(trace.fabric_queries)
+
+    return HydratedAuditEntry(
+        entry=entry,
+        reasoning_trace=trace,
+        fabric_snapshots=snapshots,
+        fabric_current=current,
+    )
+
+
+def _decode_trace(entry: AuditEntry) -> ReasoningTrace | None:
+    raw = (entry.context or {}).get("reasoning_trace")
+    if not raw:
+        return None
+    try:
+        return ReasoningTrace.model_validate(raw)
+    except Exception:
+        logger.debug("Failed to decode reasoning_trace on audit %s", entry.id)
+        return None
+
+
+async def _fetch_current_fabric(object_ids: list[str]) -> list[dict[str, Any]]:
+    """Look up live Fabric objects by ID, tolerating a missing ee module."""
+    if not object_ids:
+        return []
+    try:
+        from ee.api import get_fabric_store
+
+        fabric = get_fabric_store()
+    except ImportError:
+        return []
+
+    results: list[dict[str, Any]] = []
+    for oid in object_ids:
+        try:
+            obj = await fabric.get_object(oid)
+        except Exception:
+            obj = None
+        if obj is None:
+            continue
+        results.append(
+            {
+                "object_id": oid,
+                "type_name": getattr(obj, "type_name", ""),
+                "properties": getattr(obj, "properties", {}),
+            },
+        )
+    return results
 
 
 @router.get("/instinct/audit/export")

--- a/ee/instinct/store.py
+++ b/ee/instinct/store.py
@@ -4,6 +4,10 @@
 # Updated: 2026-04-12 (Move 1 PR-A) — Corrections table + record_correction() and
 #   get_corrections*() methods for the correction loop. Human edits between
 #   proposal and approval land here, then feed soul-protocol on next proposal.
+# Updated: 2026-04-13 (Move 2 PR-A/B) — instinct_fabric_snapshots table +
+#   record_fabric_snapshot/get_snapshots_*. propose() now accepts optional
+#   reasoning_trace and fabric_snapshots, persisting the trace as JSON inside
+#   AuditEntry.context["reasoning_trace"] and keying snapshots to the audit row.
 
 from __future__ import annotations
 
@@ -25,7 +29,7 @@ from ee.instinct.models import (
     AuditCategory,
     AuditEntry,
 )
-from ee.instinct.trace import FabricObjectSnapshot
+from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS instinct_actions (
@@ -127,6 +131,8 @@ class InstinctStore:
         priority: ActionPriority = ActionPriority.MEDIUM,
         parameters: dict[str, Any] | None = None,
         context: ActionContext | None = None,
+        reasoning_trace: ReasoningTrace | None = None,
+        fabric_snapshots: list[FabricObjectSnapshot] | None = None,
     ) -> Action:
         action = Action(
             pocket_id=pocket_id,
@@ -163,14 +169,25 @@ class InstinctStore:
             )
             await db.commit()
 
-        await self._log(
+        audit_context: dict[str, Any] = {}
+        if reasoning_trace is not None:
+            audit_context["reasoning_trace"] = reasoning_trace.model_dump(mode="json")
+
+        audit_entry = await self._log(
             action_id=action.id,
             pocket_id=pocket_id,
             actor=f"{trigger.type}:{trigger.source}",
             event="action_proposed",
             description=f"Proposed: {title}",
             ai_recommendation=recommendation,
+            context=audit_context,
         )
+
+        if fabric_snapshots:
+            for snapshot in fabric_snapshots:
+                snapshot.audit_id = audit_entry.id
+                await self.record_fabric_snapshot(snapshot)
+
         return action
 
     async def approve(self, action_id: str, approver: str = "user") -> Action | None:

--- a/ee/instinct/store.py
+++ b/ee/instinct/store.py
@@ -25,6 +25,7 @@ from ee.instinct.models import (
     AuditCategory,
     AuditEntry,
 )
+from ee.instinct.trace import FabricObjectSnapshot
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS instinct_actions (
@@ -74,12 +75,23 @@ CREATE TABLE IF NOT EXISTS instinct_corrections (
     created_at TEXT DEFAULT (datetime('now'))
 );
 
+CREATE TABLE IF NOT EXISTS instinct_fabric_snapshots (
+    id TEXT PRIMARY KEY,
+    object_id TEXT NOT NULL,
+    audit_id TEXT NOT NULL,
+    object_type TEXT DEFAULT '',
+    snapshot TEXT DEFAULT '{}',
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
 CREATE INDEX IF NOT EXISTS idx_actions_pocket ON instinct_actions(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_actions_status ON instinct_actions(status);
 CREATE INDEX IF NOT EXISTS idx_audit_pocket ON instinct_audit(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON instinct_audit(timestamp);
 CREATE INDEX IF NOT EXISTS idx_corrections_pocket ON instinct_corrections(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_corrections_action ON instinct_corrections(action_id);
+CREATE INDEX IF NOT EXISTS idx_snapshots_audit ON instinct_fabric_snapshots(audit_id);
+CREATE INDEX IF NOT EXISTS idx_snapshots_object ON instinct_fabric_snapshots(object_id);
 """
 
 
@@ -462,6 +474,57 @@ class InstinctStore:
         corrections = await self.get_corrections_for_pocket(pocket_id, limit=1000)
         return sum(1 for c in corrections if any(p.path == path for p in c.patches))
 
+    # --- Fabric object snapshots (decision traces) ---
+
+    async def record_fabric_snapshot(self, snapshot: FabricObjectSnapshot) -> FabricObjectSnapshot:
+        """Persist a Fabric object snapshot keyed to the audit entry.
+
+        The snapshot preserves the object's state at decision time so later
+        queries can reproduce what the agent actually saw, even if the live
+        object has been updated since.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO instinct_fabric_snapshots"
+                " (id, object_id, audit_id, object_type, snapshot, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    snapshot.id,
+                    snapshot.object_id,
+                    snapshot.audit_id,
+                    snapshot.object_type,
+                    json.dumps(snapshot.snapshot),
+                    snapshot.created_at.isoformat(),
+                ),
+            )
+            await db.commit()
+        return snapshot
+
+    async def get_snapshots_for_audit(self, audit_id: str) -> list[FabricObjectSnapshot]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM instinct_fabric_snapshots WHERE audit_id = ?"
+                " ORDER BY created_at ASC",
+                (audit_id,),
+            ) as cur:
+                return [self._row_to_snapshot(row) async for row in cur]
+
+    async def get_snapshots_for_object(
+        self, object_id: str, limit: int = 100
+    ) -> list[FabricObjectSnapshot]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM instinct_fabric_snapshots WHERE object_id = ?"
+                " ORDER BY created_at DESC LIMIT ?",
+                (object_id, limit),
+            ) as cur:
+                return [self._row_to_snapshot(row) async for row in cur]
+
     # --- Helpers ---
 
     def _row_to_action(self, row: Any) -> Action:
@@ -509,5 +572,15 @@ class InstinctStore:
             patches=[CorrectionPatch.model_validate(p) for p in patches_raw],
             context_summary=row["context_summary"],
             action_title=row["action_title"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+    def _row_to_snapshot(self, row: Any) -> FabricObjectSnapshot:
+        return FabricObjectSnapshot(
+            id=row["id"],
+            object_id=row["object_id"],
+            audit_id=row["audit_id"],
+            object_type=row["object_type"] or "",
+            snapshot=json.loads(row["snapshot"]) if row["snapshot"] else {},
             created_at=datetime.fromisoformat(row["created_at"]),
         )

--- a/ee/instinct/trace.py
+++ b/ee/instinct/trace.py
@@ -1,0 +1,65 @@
+# ee/instinct/trace.py — Decision trace types for the Instinct pipeline.
+# Created: 2026-04-13 (Move 2 PR-A) — Captures the reasoning inputs behind each
+# proposed action so the audit log explains *why*, not just *what*. Paired with
+# TraceCollector (the bus-subscriber context manager) and FabricObjectSnapshot
+# (immutable rows that preserve referenced objects at decision time).
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from ee.fabric.models import _gen_id
+
+
+class ToolCallRef(BaseModel):
+    """One tool call captured during proposal reasoning.
+
+    Stored inside `ReasoningTrace.tool_calls`. `args_hash` is a stable fingerprint
+    of the invocation so repeated calls dedupe cleanly; `result_preview` is the
+    first 200 chars of the result string so a human can inspect the trace without
+    re-running the tool.
+    """
+
+    tool: str
+    args_hash: str
+    result_preview: str = ""
+    duration_ms: int = 0
+
+
+class ReasoningTrace(BaseModel):
+    """Full reasoning context that produced a proposed action.
+
+    Every decision that lands in `AuditEntry.context` under the key
+    `reasoning_trace` follows this schema. Reference fields hold IDs only —
+    hydrated content is resolved at read time via the `?hydrate=1` endpoint
+    (Move 2 PR-B).
+    """
+
+    fabric_queries: list[str] = Field(default_factory=list)
+    soul_memories: list[str] = Field(default_factory=list)
+    kb_articles: list[str] = Field(default_factory=list)
+    tool_calls: list[ToolCallRef] = Field(default_factory=list)
+    prompt_version: str = ""
+    backend: str = ""
+    model: str = ""
+    token_counts: dict[str, int] = Field(default_factory=dict)
+
+
+class FabricObjectSnapshot(BaseModel):
+    """An immutable snapshot of a Fabric object at the time a decision was made.
+
+    When the live object later changes (ownership transfer, status update,
+    anything), the trace still reproduces what the agent saw. Keyed by
+    (object_id, audit_id) so a single query can be referenced by many
+    decisions without duplication.
+    """
+
+    id: str = Field(default_factory=lambda: _gen_id("fos"))
+    object_id: str
+    audit_id: str
+    object_type: str = ""
+    snapshot: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=datetime.now)

--- a/ee/instinct/trace_collector.py
+++ b/ee/instinct/trace_collector.py
@@ -1,0 +1,152 @@
+# ee/instinct/trace_collector.py — Async context manager that captures reasoning
+# inputs for a single proposal.
+# Created: 2026-04-13 (Move 2 PR-A) — Subscribes to SystemEvents on the bus,
+# aggregates fabric_query / soul_recall / kb_inject / tool_start+tool_end events
+# into a ReasoningTrace, and exposes the finished trace for persistence by the
+# caller. No global state: a fresh collector per proposal keeps traces isolated.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from typing import Any
+
+from ee.instinct.trace import ReasoningTrace, ToolCallRef
+
+logger = logging.getLogger(__name__)
+
+_PREVIEW_CHARS = 200
+_TOOL_EVENT_START = "tool_start"
+_TOOL_EVENT_END = "tool_end"
+_TOOL_EVENT_RESULT = "tool_result"
+_FABRIC_EVENT = "fabric_query"
+_SOUL_EVENT = "soul_recall"
+_KB_EVENT = "kb_inject"
+
+
+class TraceCollector:
+    """Async context manager that captures reasoning events on the message bus.
+
+    Usage:
+        async with TraceCollector(bus) as trace:
+            action = await agent.propose(...)
+        # trace now holds the captured ReasoningTrace
+
+    The collector subscribes to `subscribe_system` on enter and unsubscribes on
+    exit — always, even if the body raises. It aggregates:
+
+    - Fabric queries (event_type="fabric_query", data["object_id"])
+    - Soul recalls (event_type="soul_recall", data["memory_id"])
+    - KB injections (event_type="kb_inject", data["article_id"])
+    - Tool calls (event_type="tool_start"/"tool_end" with matching tool name)
+
+    Unknown event types are ignored. Duplicate IDs within a single trace are
+    preserved in insertion order but the `fabric_queries` / `soul_memories` /
+    `kb_articles` lists are deduplicated on exit so the trace body stays
+    compact.
+    """
+
+    def __init__(
+        self,
+        bus: Any,
+        *,
+        prompt_version: str = "",
+        backend: str = "",
+        model: str = "",
+    ) -> None:
+        self._bus = bus
+        self.trace = ReasoningTrace(
+            prompt_version=prompt_version,
+            backend=backend,
+            model=model,
+        )
+        self._pending_tool_starts: dict[str, float] = {}
+        self._callback: Any = None
+
+    async def __aenter__(self) -> TraceCollector:
+        self._callback = self._on_event
+        self._bus.subscribe_system(self._callback)
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        if self._callback is not None:
+            try:
+                self._bus.unsubscribe_system(self._callback)
+            except Exception:
+                logger.debug("TraceCollector unsubscribe failed")
+            self._callback = None
+        # Deduplicate the reference lists while preserving insertion order.
+        self.trace.fabric_queries = _dedupe(self.trace.fabric_queries)
+        self.trace.soul_memories = _dedupe(self.trace.soul_memories)
+        self.trace.kb_articles = _dedupe(self.trace.kb_articles)
+
+    async def _on_event(self, event: Any) -> None:
+        event_type = getattr(event, "event_type", None)
+        data = getattr(event, "data", {}) or {}
+        if event_type == _FABRIC_EVENT:
+            oid = data.get("object_id")
+            if isinstance(oid, str):
+                self.trace.fabric_queries.append(oid)
+        elif event_type == _SOUL_EVENT:
+            mid = data.get("memory_id")
+            if isinstance(mid, str):
+                self.trace.soul_memories.append(mid)
+        elif event_type == _KB_EVENT:
+            aid = data.get("article_id")
+            if isinstance(aid, str):
+                self.trace.kb_articles.append(aid)
+        elif event_type == _TOOL_EVENT_START:
+            tool = data.get("tool")
+            if isinstance(tool, str):
+                self._pending_tool_starts[tool] = time.monotonic()
+        elif event_type in (_TOOL_EVENT_END, _TOOL_EVENT_RESULT):
+            self._record_tool_end(data)
+
+    def _record_tool_end(self, data: dict[str, Any]) -> None:
+        tool = data.get("tool")
+        if not isinstance(tool, str):
+            return
+        args = data.get("args", {})
+        result = data.get("result", "")
+        started = self._pending_tool_starts.pop(tool, None)
+        duration_ms = int((time.monotonic() - started) * 1000) if started is not None else 0
+
+        args_hash = _hash_args(args)
+        preview = str(result)
+        if len(preview) > _PREVIEW_CHARS:
+            preview = preview[:_PREVIEW_CHARS - 3] + "..."
+
+        # Dedupe identical tool+args pairs within a single trace.
+        for existing in self.trace.tool_calls:
+            if existing.tool == tool and existing.args_hash == args_hash:
+                return
+
+        self.trace.tool_calls.append(
+            ToolCallRef(
+                tool=tool,
+                args_hash=args_hash,
+                result_preview=preview,
+                duration_ms=duration_ms,
+            ),
+        )
+
+
+def _hash_args(args: Any) -> str:
+    try:
+        serialized = json.dumps(args, sort_keys=True, default=str)
+    except Exception:
+        serialized = str(args)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    """Dedupe while preserving the order of first appearance."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for v in values:
+        if v not in seen:
+            seen.add(v)
+            out.append(v)
+    return out

--- a/ee/instinct/trace_collector.py
+++ b/ee/instinct/trace_collector.py
@@ -116,7 +116,7 @@ class TraceCollector:
         args_hash = _hash_args(args)
         preview = str(result)
         if len(preview) > _PREVIEW_CHARS:
-            preview = preview[:_PREVIEW_CHARS - 3] + "..."
+            preview = preview[: _PREVIEW_CHARS - 3] + "..."
 
         # Dedupe identical tool+args pairs within a single trace.
         for existing in self.trace.tool_calls:

--- a/ee/paw_print/__init__.py
+++ b/ee/paw_print/__init__.py
@@ -1,0 +1,23 @@
+# Paw Print — embeddable customer-facing widget layer for Paw OS.
+# Created: 2026-04-13 (Move 3 PR-A) — The full-stack decision loop Palantir
+# cannot offer: customer interactions on a Paw Print widget flow back into
+# a Pocket in real time, Instinct nudges the owner, approved actions feed
+# back to the widget. This module is the backend side of that loop.
+
+from ee.paw_print.models import (
+    PawPrintBlock,
+    PawPrintEvent,
+    PawPrintEventMapping,
+    PawPrintSpec,
+    PawPrintWidget,
+)
+from ee.paw_print.store import PawPrintStore
+
+__all__ = [
+    "PawPrintBlock",
+    "PawPrintEvent",
+    "PawPrintEventMapping",
+    "PawPrintSpec",
+    "PawPrintStore",
+    "PawPrintWidget",
+]

--- a/ee/paw_print/models.py
+++ b/ee/paw_print/models.py
@@ -1,0 +1,195 @@
+# ee/paw_print/models.py — Pydantic models for the Paw Print widget layer.
+# Created: 2026-04-13 (Move 3 PR-A) — Minimal, secure-by-design render vocabulary
+# (text / image / list / button / form / divider). No raw HTML, no script
+# injection paths. The widget.js bundle consumes PawPrintSpec; the backend
+# consumes PawPrintEvent on the ingest side.
+
+from __future__ import annotations
+
+import secrets
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+from ee.fabric.models import _gen_id
+
+_MAX_BLOCKS_PER_SPEC = 64
+_MAX_ITEMS_PER_LIST = 50
+_MAX_DOMAINS_PER_WIDGET = 20
+_MAX_PAYLOAD_BYTES = 4 * 1024  # 4KB cap matches the planning doc
+_MAX_SPEC_BYTES = 64 * 1024
+
+
+def _gen_token() -> str:
+    """Per-widget scoped access token — URL-safe, rotatable."""
+    return f"pp_tok_{secrets.token_urlsafe(32)}"
+
+
+# ---------------------------------------------------------------------------
+# Render blocks (tagged union via `type`)
+# ---------------------------------------------------------------------------
+
+
+class PawPrintAction(BaseModel):
+    """An outbound event the widget should post when the block is activated."""
+
+    event: str
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class PawPrintListItem(BaseModel):
+    title: str
+    meta: str = ""
+    action: PawPrintAction | None = None
+    disabled: bool = False
+
+
+class PawPrintFormField(BaseModel):
+    name: str
+    label: str = ""
+    type: Literal["text", "email", "number", "textarea"] = "text"
+    placeholder: str = ""
+    required: bool = False
+
+
+class PawPrintBlock(BaseModel):
+    """Minimal render primitive shared with the widget bundle.
+
+    `type` drives how the bundle renders the block. Every block-specific field
+    is optional at the schema level — the renderer only reads fields relevant
+    to the active type. Anything else is ignored, so forward-compatible spec
+    additions don't break older widget builds.
+    """
+
+    type: Literal["text", "image", "list", "button", "form", "divider"]
+
+    # text
+    content: str = ""
+    style: Literal["body", "heading", "muted"] = "body"
+
+    # image
+    src: str = ""
+    alt: str = ""
+
+    # list
+    items: list[PawPrintListItem] = Field(default_factory=list)
+
+    # button
+    label: str = ""
+    href: str = ""
+    action: PawPrintAction | None = None
+
+    # form
+    fields: list[PawPrintFormField] = Field(default_factory=list)
+    submit_event: str = ""
+
+    @field_validator("items")
+    @classmethod
+    def _cap_list(cls, value: list[PawPrintListItem]) -> list[PawPrintListItem]:
+        if len(value) > _MAX_ITEMS_PER_LIST:
+            raise ValueError(f"list block accepts at most {_MAX_ITEMS_PER_LIST} items")
+        return value
+
+
+class PawPrintSpec(BaseModel):
+    """The payload the widget fetches and renders."""
+
+    widget_id: str
+    pocket_id: str
+    layout: Literal["vertical", "horizontal", "grid"] = "vertical"
+    theme: dict[str, str] = Field(default_factory=dict)
+    blocks: list[PawPrintBlock] = Field(default_factory=list)
+
+    @field_validator("blocks")
+    @classmethod
+    def _cap_blocks(cls, value: list[PawPrintBlock]) -> list[PawPrintBlock]:
+        if len(value) > _MAX_BLOCKS_PER_SPEC:
+            raise ValueError(f"spec accepts at most {_MAX_BLOCKS_PER_SPEC} blocks")
+        return value
+
+
+# ---------------------------------------------------------------------------
+# Widget + Event domain
+# ---------------------------------------------------------------------------
+
+
+class PawPrintEventMapping(BaseModel):
+    """How an inbound widget event turns into a Fabric object.
+
+    `creates` is the Fabric object type; `fields` values follow `{{ placeholder }}`
+    interpolation against the event payload and metadata (`customer_ref`, `timestamp`).
+    """
+
+    creates: str
+    fields: dict[str, str] = Field(default_factory=dict)
+
+
+class PawPrintWidget(BaseModel):
+    id: str = Field(default_factory=lambda: _gen_id("pp"))
+    pocket_id: str
+    owner: str
+    name: str = ""
+    spec: PawPrintSpec
+    allowed_domains: list[str] = Field(default_factory=list)
+    access_token: str = Field(default_factory=_gen_token)
+    rate_limit_per_min: int = 60
+    per_customer_limit_per_min: int = 10
+    event_mapping: dict[str, PawPrintEventMapping] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+    @field_validator("allowed_domains")
+    @classmethod
+    def _cap_domains(cls, value: list[str]) -> list[str]:
+        if len(value) > _MAX_DOMAINS_PER_WIDGET:
+            raise ValueError(f"allowed_domains accepts at most {_MAX_DOMAINS_PER_WIDGET} entries")
+        cleaned: list[str] = []
+        for domain in value:
+            d = domain.strip().lower()
+            if d and d not in cleaned:
+                cleaned.append(d)
+        return cleaned
+
+    @field_validator("rate_limit_per_min", "per_customer_limit_per_min")
+    @classmethod
+    def _positive_rate(cls, value: int) -> int:
+        if value < 1:
+            raise ValueError("rate limits must be >= 1")
+        return value
+
+
+class PawPrintEvent(BaseModel):
+    """One inbound signal from a rendered widget."""
+
+    widget_id: str
+    type: str
+    payload: dict[str, Any] = Field(default_factory=dict)
+    customer_ref: str
+    timestamp: datetime = Field(default_factory=datetime.now)
+
+    def payload_size(self) -> int:
+        import json as _json
+
+        try:
+            return len(_json.dumps(self.payload).encode("utf-8"))
+        except Exception:
+            return _MAX_PAYLOAD_BYTES + 1
+
+    @field_validator("type")
+    @classmethod
+    def _non_empty_type(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("event type is required")
+        return value.strip()
+
+
+# ---------------------------------------------------------------------------
+# Limit constants — re-exported so the ingest layer (PR-B) reads the same values.
+# ---------------------------------------------------------------------------
+
+MAX_BLOCKS_PER_SPEC = _MAX_BLOCKS_PER_SPEC
+MAX_ITEMS_PER_LIST = _MAX_ITEMS_PER_LIST
+MAX_DOMAINS_PER_WIDGET = _MAX_DOMAINS_PER_WIDGET
+MAX_PAYLOAD_BYTES = _MAX_PAYLOAD_BYTES
+MAX_SPEC_BYTES = _MAX_SPEC_BYTES

--- a/ee/paw_print/router.py
+++ b/ee/paw_print/router.py
@@ -1,0 +1,389 @@
+# ee/paw_print/router.py — HTTP surface for the Paw Print widget layer.
+# Created: 2026-04-13 (Move 3 PR-B) — Spec serving (public, CORS-gated),
+# widget CRUD (owner-authed via access_token), event ingest (rate-limited,
+# domain-enforced, Guardian-screened, Fabric-mapped). The widget.js bundle
+# built in PR-C consumes these endpoints.
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from fastapi import APIRouter, Header, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from ee.paw_print.models import (
+    MAX_PAYLOAD_BYTES,
+    PawPrintEvent,
+    PawPrintEventMapping,
+    PawPrintSpec,
+    PawPrintWidget,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["PawPrint"])
+
+_PLACEHOLDER_RE = re.compile(r"\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}")
+
+
+def _store():
+    from ee.api import get_paw_print_store
+
+    return get_paw_print_store()
+
+
+def _require_owner_token(widget: PawPrintWidget, header_token: str | None) -> None:
+    if not header_token or header_token != widget.access_token:
+        raise HTTPException(status_code=401, detail="Invalid or missing access token")
+
+
+def _origin_allowed(widget: PawPrintWidget, origin: str | None) -> bool:
+    """Match an inbound Origin header against the widget's allowed_domains.
+
+    Empty `allowed_domains` disables the check — useful for local demos but
+    must be set in production. The match is host-only so ports and paths don't
+    matter: `https://brewco.com:443/menu` matches `brewco.com`.
+    """
+    if not widget.allowed_domains:
+        return True
+    if not origin:
+        return False
+    host = origin.strip().lower()
+    if "://" in host:
+        host = host.split("://", 1)[1]
+    host = host.split("/", 1)[0]
+    host = host.split(":", 1)[0]
+    return host in widget.allowed_domains
+
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+
+class CreateWidgetRequest(BaseModel):
+    pocket_id: str
+    owner: str
+    name: str = ""
+    spec: PawPrintSpec
+    allowed_domains: list[str] = Field(default_factory=list)
+    rate_limit_per_min: int = 60
+    per_customer_limit_per_min: int = 10
+    event_mapping: dict[str, PawPrintEventMapping] = Field(default_factory=dict)
+
+
+class WidgetListResponse(BaseModel):
+    widgets: list[PawPrintWidget]
+    total: int
+
+
+class EventIngestResponse(BaseModel):
+    accepted: bool
+    event: PawPrintEvent | None = None
+    fabric_object_id: str | None = None
+    reason: str | None = None
+
+
+class EventsListResponse(BaseModel):
+    events: list[PawPrintEvent]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# Owner-authed CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.post("/paw-print/widgets", response_model=PawPrintWidget, status_code=201)
+async def create_widget(req: CreateWidgetRequest) -> PawPrintWidget:
+    widget = PawPrintWidget(
+        pocket_id=req.pocket_id,
+        owner=req.owner,
+        name=req.name,
+        spec=req.spec,
+        allowed_domains=req.allowed_domains,
+        rate_limit_per_min=req.rate_limit_per_min,
+        per_customer_limit_per_min=req.per_customer_limit_per_min,
+        event_mapping=req.event_mapping,
+    )
+    return await _store().create_widget(widget)
+
+
+@router.get("/paw-print/widgets", response_model=WidgetListResponse)
+async def list_widgets(
+    pocket_id: str | None = Query(None),
+    owner: str | None = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+) -> WidgetListResponse:
+    widgets = await _store().list_widgets(pocket_id=pocket_id, owner=owner, limit=limit)
+    return WidgetListResponse(widgets=widgets, total=len(widgets))
+
+
+@router.get("/paw-print/widgets/{widget_id}", response_model=PawPrintWidget)
+async def get_widget(
+    widget_id: str,
+    x_paw_print_token: str | None = Header(default=None, alias="X-Paw-Print-Token"),
+) -> PawPrintWidget:
+    widget = await _store().get_widget(widget_id)
+    if widget is None:
+        raise HTTPException(404, "Widget not found")
+    _require_owner_token(widget, x_paw_print_token)
+    return widget
+
+
+@router.patch("/paw-print/widgets/{widget_id}/spec", response_model=PawPrintWidget)
+async def update_spec(
+    widget_id: str,
+    spec: PawPrintSpec,
+    x_paw_print_token: str | None = Header(default=None, alias="X-Paw-Print-Token"),
+) -> PawPrintWidget:
+    widget = await _store().get_widget(widget_id)
+    if widget is None:
+        raise HTTPException(404, "Widget not found")
+    _require_owner_token(widget, x_paw_print_token)
+    updated = await _store().update_spec(widget_id, spec)
+    if updated is None:
+        raise HTTPException(404, "Widget not found")
+    return updated
+
+
+@router.post("/paw-print/widgets/{widget_id}/rotate-token", response_model=PawPrintWidget)
+async def rotate_token(
+    widget_id: str,
+    x_paw_print_token: str | None = Header(default=None, alias="X-Paw-Print-Token"),
+) -> PawPrintWidget:
+    widget = await _store().get_widget(widget_id)
+    if widget is None:
+        raise HTTPException(404, "Widget not found")
+    _require_owner_token(widget, x_paw_print_token)
+    rotated = await _store().rotate_token(widget_id)
+    if rotated is None:
+        raise HTTPException(404, "Widget not found")
+    return rotated
+
+
+@router.delete("/paw-print/widgets/{widget_id}", status_code=204)
+async def delete_widget(
+    widget_id: str,
+    x_paw_print_token: str | None = Header(default=None, alias="X-Paw-Print-Token"),
+) -> None:
+    widget = await _store().get_widget(widget_id)
+    if widget is None:
+        raise HTTPException(404, "Widget not found")
+    _require_owner_token(widget, x_paw_print_token)
+    await _store().delete_widget(widget_id)
+
+
+@router.get("/paw-print/widgets/{widget_id}/events", response_model=EventsListResponse)
+async def list_events(
+    widget_id: str,
+    limit: int = Query(100, ge=1, le=500),
+    x_paw_print_token: str | None = Header(default=None, alias="X-Paw-Print-Token"),
+) -> EventsListResponse:
+    widget = await _store().get_widget(widget_id)
+    if widget is None:
+        raise HTTPException(404, "Widget not found")
+    _require_owner_token(widget, x_paw_print_token)
+    events = await _store().recent_events(widget_id, limit=limit)
+    return EventsListResponse(events=events, total=len(events))
+
+
+# ---------------------------------------------------------------------------
+# Public spec serving (CORS-enforced)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/paw-print/spec/{widget_id}")
+async def get_spec(
+    widget_id: str,
+    request: Request,
+) -> JSONResponse:
+    """Public spec endpoint consumed by the widget.js bundle.
+
+    CORS is enforced per-widget: the response carries
+    `Access-Control-Allow-Origin` set to the inbound Origin only when it
+    matches the widget's allowlist. Any other origin gets a 403 — browsers
+    would block the fetch anyway, but failing explicitly makes misconfigs
+    loud instead of silent.
+    """
+    widget = await _store().get_widget(widget_id)
+    if widget is None:
+        raise HTTPException(404, "Widget not found")
+
+    origin = request.headers.get("origin")
+    if not _origin_allowed(widget, origin):
+        raise HTTPException(403, "Origin not allowed for this widget")
+
+    headers: dict[str, str] = {}
+    if origin:
+        headers["Access-Control-Allow-Origin"] = origin
+        headers["Vary"] = "Origin"
+    return JSONResponse(widget.spec.model_dump(), headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# Event ingest
+# ---------------------------------------------------------------------------
+
+
+class IngestPayload(BaseModel):
+    type: str
+    payload: dict[str, Any] = Field(default_factory=dict)
+    customer_ref: str
+
+
+@router.post("/paw-print/events/{widget_id}", response_model=EventIngestResponse)
+async def ingest_event(
+    widget_id: str,
+    body: IngestPayload,
+    request: Request,
+) -> EventIngestResponse:
+    """Inbound customer event.
+
+    Enforces (in order):
+    1. Widget exists.
+    2. Origin is on the widget's allowlist.
+    3. Payload size is under MAX_PAYLOAD_BYTES.
+    4. Rate limits (overall + per customer_ref).
+    5. Guardian screens the payload (input sanitization layer — degrades
+       cleanly when ee/ lacks the guardian backend).
+    After that, the event is persisted and — if the widget has a matching
+    `event_mapping` — a Fabric object is created.
+    """
+    store = _store()
+    widget = await store.get_widget(widget_id)
+    if widget is None:
+        raise HTTPException(404, "Widget not found")
+
+    origin = request.headers.get("origin")
+    if not _origin_allowed(widget, origin):
+        raise HTTPException(403, "Origin not allowed for this widget")
+
+    event = PawPrintEvent(
+        widget_id=widget_id,
+        type=body.type,
+        payload=body.payload,
+        customer_ref=body.customer_ref,
+    )
+
+    if event.payload_size() > MAX_PAYLOAD_BYTES:
+        raise HTTPException(413, "Payload exceeds 4KB cap")
+
+    ok = await store.within_rate_limit(
+        widget_id,
+        overall_per_min=widget.rate_limit_per_min,
+        per_customer_per_min=widget.per_customer_limit_per_min,
+        customer_ref=event.customer_ref,
+    )
+    if not ok:
+        raise HTTPException(429, "Rate limit exceeded")
+
+    if not await _pass_through_guardian(event):
+        return EventIngestResponse(accepted=False, reason="guardian_rejected")
+
+    await store.record_event(event)
+    fabric_object_id = await _apply_event_mapping(widget, event)
+
+    return EventIngestResponse(
+        accepted=True,
+        event=event,
+        fabric_object_id=fabric_object_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _pass_through_guardian(event: PawPrintEvent) -> bool:
+    """Best-effort Guardian screen — tolerant when the security stack is absent."""
+    try:
+        from pocketpaw.security.guardian import GuardianProtocol, get_guardian
+    except Exception:
+        return True
+
+    try:
+        guardian: GuardianProtocol = get_guardian()
+    except Exception:
+        return True
+
+    payload = json.dumps(event.payload, default=str)
+    check = getattr(guardian, "check_input", None)
+    if check is None:
+        return True
+    try:
+        verdict = await check(payload)
+    except Exception:
+        logger.debug("Guardian check raised; accepting event by default")
+        return True
+    if isinstance(verdict, bool):
+        return verdict
+    # Guardian may return a richer dataclass; accept when no `blocked` attr.
+    return not getattr(verdict, "blocked", False)
+
+
+async def _apply_event_mapping(
+    widget: PawPrintWidget, event: PawPrintEvent
+) -> str | None:
+    """Turn a PawPrintEvent into a Fabric object when a mapping exists."""
+    mapping = widget.event_mapping.get(event.type)
+    if mapping is None:
+        return None
+
+    try:
+        from ee.api import get_fabric_store
+        from ee.fabric.models import FabricObject
+    except ImportError:
+        return None
+
+    fabric = get_fabric_store()
+    if fabric is None:
+        return None
+
+    context = {"payload": event.payload, "customer_ref": event.customer_ref}
+    properties = {k: _interpolate(v, context) for k, v in mapping.fields.items()}
+    try:
+        obj = FabricObject(
+            type_name=mapping.creates,
+            properties=properties,
+            source_connector="paw_print",
+            source_id=widget.id,
+        )
+        created = await fabric.create_object(obj)
+        return getattr(created, "id", None)
+    except Exception:
+        logger.exception("Failed to create Fabric object from paw-print event")
+        return None
+
+
+def _interpolate(template: str, context: dict[str, Any]) -> Any:
+    """Resolve `{{ a.b }}` placeholders against the context dict.
+
+    If the entire template is a single placeholder (`{{ payload.item }}`), the
+    raw value is returned (preserving non-string types). Mixed strings fall back
+    to stringified substitution.
+    """
+    full_match = re.fullmatch(r"\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}", template)
+    if full_match:
+        return _lookup(full_match.group(1), context)
+
+    def _replace(m: re.Match[str]) -> str:
+        val = _lookup(m.group(1), context)
+        return "" if val is None else str(val)
+
+    return _PLACEHOLDER_RE.sub(_replace, template)
+
+
+def _lookup(path: str, context: dict[str, Any]) -> Any:
+    cur: Any = context
+    for part in path.split("."):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return None
+    return cur

--- a/ee/paw_print/router.py
+++ b/ee/paw_print/router.py
@@ -327,9 +327,7 @@ async def _pass_through_guardian(event: PawPrintEvent) -> bool:
     return not getattr(verdict, "blocked", False)
 
 
-async def _apply_event_mapping(
-    widget: PawPrintWidget, event: PawPrintEvent
-) -> str | None:
+async def _apply_event_mapping(widget: PawPrintWidget, event: PawPrintEvent) -> str | None:
     """Turn a PawPrintEvent into a Fabric object when a mapping exists."""
     mapping = widget.event_mapping.get(event.type)
     if mapping is None:

--- a/ee/paw_print/store.py
+++ b/ee/paw_print/store.py
@@ -1,0 +1,276 @@
+# ee/paw_print/store.py — Async SQLite store for Paw Print widgets and events.
+# Created: 2026-04-13 (Move 3 PR-A) — CRUD for PawPrintWidget + append-only
+# PawPrintEvent log. Token rotation invalidates any cached copies. Event ingest
+# + rate-limit logic lives in PR-B; this module only handles persistence.
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+from ee.paw_print.models import PawPrintEvent, PawPrintSpec, PawPrintWidget, _gen_token
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS paw_print_widgets (
+    id TEXT PRIMARY KEY,
+    pocket_id TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    name TEXT DEFAULT '',
+    spec TEXT NOT NULL,
+    allowed_domains TEXT DEFAULT '[]',
+    access_token TEXT NOT NULL,
+    rate_limit_per_min INTEGER DEFAULT 60,
+    per_customer_limit_per_min INTEGER DEFAULT 10,
+    event_mapping TEXT DEFAULT '{}',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS paw_print_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    widget_id TEXT NOT NULL,
+    type TEXT NOT NULL,
+    payload TEXT DEFAULT '{}',
+    customer_ref TEXT NOT NULL,
+    timestamp TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_pp_widgets_pocket ON paw_print_widgets(pocket_id);
+CREATE INDEX IF NOT EXISTS idx_pp_widgets_owner ON paw_print_widgets(owner);
+CREATE INDEX IF NOT EXISTS idx_pp_events_widget_ts
+    ON paw_print_events(widget_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_pp_events_customer
+    ON paw_print_events(widget_id, customer_ref);
+"""
+
+
+class PawPrintStore:
+    """Async SQLite store — same shape as InstinctStore so the wiring is familiar."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._initialized = False
+
+    async def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        async with aiosqlite.connect(self._db_path) as db:
+            await db.executescript(SCHEMA_SQL)
+            await db.commit()
+        self._initialized = True
+
+    def _conn(self) -> aiosqlite.Connection:
+        return aiosqlite.connect(self._db_path)
+
+    # ---------------- Widgets ----------------
+
+    async def create_widget(self, widget: PawPrintWidget) -> PawPrintWidget:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO paw_print_widgets"
+                " (id, pocket_id, owner, name, spec, allowed_domains,"
+                " access_token, rate_limit_per_min, per_customer_limit_per_min,"
+                " event_mapping, created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    widget.id,
+                    widget.pocket_id,
+                    widget.owner,
+                    widget.name,
+                    widget.spec.model_dump_json(),
+                    json.dumps(widget.allowed_domains),
+                    widget.access_token,
+                    widget.rate_limit_per_min,
+                    widget.per_customer_limit_per_min,
+                    json.dumps(
+                        {k: v.model_dump() for k, v in widget.event_mapping.items()},
+                    ),
+                    widget.created_at.isoformat(),
+                    widget.updated_at.isoformat(),
+                ),
+            )
+            await db.commit()
+        return widget
+
+    async def get_widget(self, widget_id: str) -> PawPrintWidget | None:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM paw_print_widgets WHERE id = ?", (widget_id,),
+            ) as cur:
+                row = await cur.fetchone()
+                return self._row_to_widget(row) if row else None
+
+    async def list_widgets(
+        self, pocket_id: str | None = None, owner: str | None = None, limit: int = 100
+    ) -> list[PawPrintWidget]:
+        conditions: list[str] = []
+        params: list[Any] = []
+        if pocket_id:
+            conditions.append("pocket_id = ?")
+            params.append(pocket_id)
+        if owner:
+            conditions.append("owner = ?")
+            params.append(owner)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        params.append(limit)
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                f"SELECT * FROM paw_print_widgets {where} ORDER BY created_at DESC LIMIT ?",
+                params,
+            ) as cur:
+                return [self._row_to_widget(row) async for row in cur]
+
+    async def update_spec(
+        self, widget_id: str, spec: PawPrintSpec
+    ) -> PawPrintWidget | None:
+        existing = await self.get_widget(widget_id)
+        if existing is None:
+            return None
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE paw_print_widgets SET spec = ?, updated_at = ? WHERE id = ?",
+                (spec.model_dump_json(), datetime.now().isoformat(), widget_id),
+            )
+            await db.commit()
+        return await self.get_widget(widget_id)
+
+    async def rotate_token(self, widget_id: str) -> PawPrintWidget | None:
+        existing = await self.get_widget(widget_id)
+        if existing is None:
+            return None
+        new_token = _gen_token()
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE paw_print_widgets SET access_token = ?, updated_at = ? WHERE id = ?",
+                (new_token, datetime.now().isoformat(), widget_id),
+            )
+            await db.commit()
+        return await self.get_widget(widget_id)
+
+    async def delete_widget(self, widget_id: str) -> bool:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            cur = await db.execute(
+                "DELETE FROM paw_print_widgets WHERE id = ?", (widget_id,),
+            )
+            await db.commit()
+            return (cur.rowcount or 0) > 0
+
+    # ---------------- Events ----------------
+
+    async def record_event(self, event: PawPrintEvent) -> PawPrintEvent:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO paw_print_events"
+                " (widget_id, type, payload, customer_ref, timestamp)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (
+                    event.widget_id,
+                    event.type,
+                    json.dumps(event.payload),
+                    event.customer_ref,
+                    event.timestamp.isoformat(),
+                ),
+            )
+            await db.commit()
+        return event
+
+    async def recent_events(
+        self, widget_id: str, limit: int = 100
+    ) -> list[PawPrintEvent]:
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM paw_print_events WHERE widget_id = ?"
+                " ORDER BY timestamp DESC LIMIT ?",
+                (widget_id, limit),
+            ) as cur:
+                return [self._row_to_event(row) async for row in cur]
+
+    async def count_events_since(
+        self,
+        widget_id: str,
+        since: datetime,
+        customer_ref: str | None = None,
+    ) -> int:
+        """Count events in the last window — backs the rate limiter."""
+        await self._ensure_schema()
+        conditions = ["widget_id = ?", "timestamp >= ?"]
+        params: list[Any] = [widget_id, since.isoformat()]
+        if customer_ref is not None:
+            conditions.append("customer_ref = ?")
+            params.append(customer_ref)
+        async with self._conn() as db:
+            async with db.execute(
+                f"SELECT COUNT(*) FROM paw_print_events WHERE {' AND '.join(conditions)}",
+                params,
+            ) as cur:
+                row = await cur.fetchone()
+                return row[0] if row else 0
+
+    async def within_rate_limit(
+        self,
+        widget_id: str,
+        *,
+        overall_per_min: int,
+        per_customer_per_min: int,
+        customer_ref: str,
+        now: datetime | None = None,
+    ) -> bool:
+        """Return True if the next event from `customer_ref` should be accepted."""
+        now = now or datetime.now()
+        window_start = now - timedelta(minutes=1)
+        total = await self.count_events_since(widget_id, window_start)
+        if total >= overall_per_min:
+            return False
+        per_customer = await self.count_events_since(
+            widget_id, window_start, customer_ref=customer_ref,
+        )
+        return per_customer < per_customer_per_min
+
+    # ---------------- Helpers ----------------
+
+    def _row_to_widget(self, row: Any) -> PawPrintWidget:
+        from ee.paw_print.models import PawPrintEventMapping
+
+        raw_domains = json.loads(row["allowed_domains"]) if row["allowed_domains"] else []
+        raw_mapping = json.loads(row["event_mapping"]) if row["event_mapping"] else {}
+        mapping = {k: PawPrintEventMapping.model_validate(v) for k, v in raw_mapping.items()}
+        spec = PawPrintSpec.model_validate_json(row["spec"])
+        return PawPrintWidget(
+            id=row["id"],
+            pocket_id=row["pocket_id"],
+            owner=row["owner"],
+            name=row["name"] or "",
+            spec=spec,
+            allowed_domains=raw_domains,
+            access_token=row["access_token"],
+            rate_limit_per_min=row["rate_limit_per_min"],
+            per_customer_limit_per_min=row["per_customer_limit_per_min"],
+            event_mapping=mapping,
+            created_at=datetime.fromisoformat(row["created_at"]),
+            updated_at=datetime.fromisoformat(row["updated_at"]),
+        )
+
+    def _row_to_event(self, row: Any) -> PawPrintEvent:
+        return PawPrintEvent(
+            widget_id=row["widget_id"],
+            type=row["type"],
+            payload=json.loads(row["payload"]) if row["payload"] else {},
+            customer_ref=row["customer_ref"],
+            timestamp=datetime.fromisoformat(row["timestamp"]),
+        )

--- a/ee/paw_print/store.py
+++ b/ee/paw_print/store.py
@@ -102,7 +102,8 @@ class PawPrintStore:
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
-                "SELECT * FROM paw_print_widgets WHERE id = ?", (widget_id,),
+                "SELECT * FROM paw_print_widgets WHERE id = ?",
+                (widget_id,),
             ) as cur:
                 row = await cur.fetchone()
                 return self._row_to_widget(row) if row else None
@@ -130,9 +131,7 @@ class PawPrintStore:
             ) as cur:
                 return [self._row_to_widget(row) async for row in cur]
 
-    async def update_spec(
-        self, widget_id: str, spec: PawPrintSpec
-    ) -> PawPrintWidget | None:
+    async def update_spec(self, widget_id: str, spec: PawPrintSpec) -> PawPrintWidget | None:
         existing = await self.get_widget(widget_id)
         if existing is None:
             return None
@@ -163,7 +162,8 @@ class PawPrintStore:
         await self._ensure_schema()
         async with self._conn() as db:
             cur = await db.execute(
-                "DELETE FROM paw_print_widgets WHERE id = ?", (widget_id,),
+                "DELETE FROM paw_print_widgets WHERE id = ?",
+                (widget_id,),
             )
             await db.commit()
             return (cur.rowcount or 0) > 0
@@ -188,9 +188,7 @@ class PawPrintStore:
             await db.commit()
         return event
 
-    async def recent_events(
-        self, widget_id: str, limit: int = 100
-    ) -> list[PawPrintEvent]:
+    async def recent_events(self, widget_id: str, limit: int = 100) -> list[PawPrintEvent]:
         await self._ensure_schema()
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
@@ -238,7 +236,9 @@ class PawPrintStore:
         if total >= overall_per_min:
             return False
         per_customer = await self.count_events_since(
-            widget_id, window_start, customer_ref=customer_ref,
+            widget_id,
+            window_start,
+            customer_ref=customer_ref,
         )
         return per_customer < per_customer_per_min
 

--- a/src/pocketpaw/tools/builtin/__init__.py
+++ b/src/pocketpaw/tools/builtin/__init__.py
@@ -92,6 +92,7 @@ try:
         FabricQueryTool,
         FabricStatsTool,
     )
+    from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
     from pocketpaw.tools.builtin.instinct_tools import (
         InstinctAuditTool,
         InstinctPendingTool,
@@ -105,6 +106,7 @@ try:
         InstinctProposeTool,
         InstinctPendingTool,
         InstinctAuditTool,
+        InstinctCorrectionsTool,
     ]
     _EE_NAMES = {cls.__name__: cls for cls in _EE_TOOLS}
 except ImportError:

--- a/src/pocketpaw/tools/builtin/fabric_tools.py
+++ b/src/pocketpaw/tools/builtin/fabric_tools.py
@@ -19,6 +19,26 @@ def _get_fabric_store():
         return None
 
 
+async def _emit_trace_events(event_type: str, entries: list[dict[str, Any]]) -> None:
+    """Publish one SystemEvent per entry so TraceCollector can aggregate them.
+
+    Silent in the common case — the message bus only has subscribers when a
+    proposal is actively being traced. Any failure is swallowed so tool calls
+    never break because telemetry is sick.
+    """
+    if not entries:
+        return
+    try:
+        from pocketpaw.bus import get_message_bus
+        from pocketpaw.bus.events import SystemEvent
+
+        bus = get_message_bus()
+        for entry in entries:
+            await bus.publish_system(SystemEvent(event_type=event_type, data=entry))
+    except Exception:
+        logger.debug("Trace event emission skipped (event_type=%s)", event_type)
+
+
 class FabricQueryTool(BaseTool):
     """Query objects in the Fabric ontology."""
 
@@ -84,6 +104,15 @@ class FabricQueryTool(BaseTool):
                     link_type=link_type,
                     limit=min(limit, 50),
                 )
+            )
+
+            # Emit a trace event per object so decision-time snapshots can
+            # capture what this query actually returned. The collector is only
+            # active when an InstinctProposeTool wraps the reasoning, so this
+            # is a no-op in all other contexts.
+            await _emit_trace_events(
+                "fabric_query",
+                [{"object_id": obj.id, "object_type": obj.type_name} for obj in result.objects],
             )
 
             if not result.objects:

--- a/src/pocketpaw/tools/builtin/instinct_corrections.py
+++ b/src/pocketpaw/tools/builtin/instinct_corrections.py
@@ -1,0 +1,112 @@
+# Instinct corrections tool — agent-facing surface for learned human edits.
+# Created: 2026-04-12 (Move 1 PR-B) — Lets an agent fetch recent corrections for
+# a pocket before proposing its next action, so past human edits shape the draft.
+# Pairs with the correction_soul_bridge, which also feeds the same signal into
+# soul-protocol's automatic memory injection when a soul is loaded.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw.tools.protocol import BaseTool
+
+logger = logging.getLogger(__name__)
+
+
+def _get_instinct_store():
+    """Lazy import — degrades gracefully when ee/ is not installed."""
+    try:
+        from ee.api import get_instinct_store
+
+        return get_instinct_store()
+    except ImportError:
+        return None
+
+
+class InstinctCorrectionsTool(BaseTool):
+    """Fetch recent human corrections on actions within a pocket."""
+
+    @property
+    def name(self) -> str:
+        return "instinct_corrections"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Fetch recent human edits (corrections) applied to previously proposed "
+            "actions in a pocket. Use this BEFORE proposing a new action so your "
+            "draft already matches the style and thresholds the user prefers — e.g. "
+            "if they consistently edit the greeting tone or cap a discount percentage, "
+            "match that pattern in the new proposal."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "high"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "pocket_id": {
+                    "type": "string",
+                    "description": "Pocket whose corrections you want to review",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max corrections to return (default: 10, max: 50)",
+                    "default": 10,
+                },
+            },
+            "required": ["pocket_id"],
+        }
+
+    async def execute(self, pocket_id: str, limit: int = 10) -> str:
+        store = _get_instinct_store()
+        if not store:
+            return "Instinct is not available (enterprise feature)."
+
+        try:
+            corrections = await store.get_corrections_for_pocket(
+                pocket_id=pocket_id,
+                limit=min(max(limit, 1), 50),
+            )
+        except Exception as exc:
+            logger.error("instinct_corrections lookup failed: %s", exc)
+            return f"Error loading corrections: {exc}"
+
+        if not corrections:
+            return (
+                f"No corrections captured yet for pocket {pocket_id}. "
+                "Propose freely — nothing to align with."
+            )
+
+        lines = [
+            f"{len(corrections)} recent correction(s) for pocket {pocket_id}:",
+            "",
+        ]
+        for c in corrections:
+            lines.append(f"- {c.action_title} (edited by {c.actor})")
+            lines.append(f"    Summary: {c.context_summary}")
+            for patch in c.patches[:5]:
+                before = _fmt(patch.before)
+                after = _fmt(patch.after)
+                lines.append(f"    {patch.path}: {before} → {after}")
+            if len(c.patches) > 5:
+                lines.append(f"    (+{len(c.patches) - 5} more field changes)")
+            lines.append("")
+
+        lines.append(
+            "When proposing your next action, pre-apply these patterns unless the "
+            "situation clearly calls for something different.",
+        )
+        return "\n".join(lines)
+
+
+def _fmt(value: object) -> str:
+    if value is None:
+        return "(none)"
+    s = str(value)
+    return s if len(s) <= 60 else s[:57] + "..."

--- a/tests/cloud/test_correction_soul_bridge.py
+++ b/tests/cloud/test_correction_soul_bridge.py
@@ -1,0 +1,333 @@
+# tests/cloud/test_correction_soul_bridge.py — Tests for the correction soul bridge
+# and the instinct_corrections agent tool (Move 1 PR-B).
+# Created: 2026-04-13 — Covers observe() call shape, 3x procedural promotion,
+# graceful degradation when no soul is loaded, and tool output formatting.
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ee.instinct.correction import Correction, CorrectionPatch
+from ee.instinct.correction_soul_bridge import CorrectionSoulBridge
+from ee.instinct.models import (
+    Action,
+    ActionCategory,
+    ActionPriority,
+    ActionTrigger,
+)
+from ee.instinct.store import InstinctStore
+
+
+@pytest.fixture(autouse=True)
+def _stub_soul_protocol(monkeypatch):
+    """Provide a minimal fake `soul_protocol` module when the real one is absent.
+
+    Production code imports `soul_protocol.Interaction` lazily inside the
+    bridge; the real package is an optional dep not installed in the base
+    dev env. A lightweight stub is sufficient to exercise the bridge's code
+    path without pulling in the full soul runtime.
+    """
+    if "soul_protocol" in sys.modules:
+        return
+
+    module = types.ModuleType("soul_protocol")
+
+    class _Interaction:
+        def __init__(self, user_input: str = "", agent_output: str = "", **kwargs):
+            self.user_input = user_input
+            self.agent_output = agent_output
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    module.Interaction = _Interaction  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "soul_protocol", module)
+
+
+def _trigger() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="claude", reason="test")
+
+
+def _action(**overrides) -> Action:
+    defaults: dict = {
+        "pocket_id": "pocket-1",
+        "title": "Send renewal outreach",
+        "description": "Two accounts up for renewal",
+        "recommendation": "Draft a formal nudge email",
+        "trigger": _trigger(),
+        "category": ActionCategory.WORKFLOW,
+        "priority": ActionPriority.MEDIUM,
+        "parameters": {"tone": "formal", "discount_pct": 20},
+    }
+    defaults.update(overrides)
+    return Action(**defaults)
+
+
+def _correction(
+    *,
+    action_id: str = "act-1",
+    patches: list[CorrectionPatch] | None = None,
+    pocket_id: str = "pocket-1",
+    actor: str = "user:priya",
+) -> Correction:
+    return Correction(
+        action_id=action_id,
+        pocket_id=pocket_id,
+        actor=actor,
+        patches=patches or [CorrectionPatch(path="title", before="A", after="B")],
+        context_summary="softened the greeting",
+        action_title="Send renewal outreach",
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "bridge_test.db")
+
+
+@pytest.fixture
+def fake_soul():
+    soul = MagicMock()
+    soul.observe = AsyncMock()
+    soul.remember = AsyncMock()
+    return soul
+
+
+@pytest.fixture
+def manager_with_soul(fake_soul):
+    manager = MagicMock()
+    manager.soul = fake_soul
+    return manager
+
+
+# ---------------------------------------------------------------------------
+# record() — observe path
+# ---------------------------------------------------------------------------
+
+
+class TestObserveCorrection:
+    @pytest.mark.asyncio
+    async def test_observe_called_once_per_correction(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+        await bridge.record(_correction(), _action())
+
+        assert fake_soul.observe.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_observe_payload_includes_summary_and_patches(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+        correction = _correction(
+            patches=[
+                CorrectionPatch(path="title", before="Formal", after="Casual"),
+                CorrectionPatch(path="parameters.discount_pct", before=20, after=15),
+            ],
+        )
+        await bridge.record(correction, _action())
+
+        (call,) = fake_soul.observe.await_args_list
+        interaction = call.args[0]
+        assert "pocket-1" in interaction.user_input
+        assert "user:priya" in interaction.user_input
+        assert "title" in interaction.agent_output
+        assert "parameters.discount_pct" in interaction.agent_output
+        assert "softened the greeting" in interaction.agent_output
+
+    @pytest.mark.asyncio
+    async def test_no_observe_when_soul_is_absent(self, store: InstinctStore) -> None:
+        manager = MagicMock()
+        manager.soul = None
+        bridge = CorrectionSoulBridge(soul_manager=manager, store=store)
+        # Should not raise, just no-op.
+        await bridge.record(_correction(), _action())
+
+    @pytest.mark.asyncio
+    async def test_observe_exception_is_swallowed(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        fake_soul.observe.side_effect = RuntimeError("soul went down")
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+        # Should not raise — approval flow must never break because soul is sick.
+        await bridge.record(_correction(), _action())
+
+
+# ---------------------------------------------------------------------------
+# Procedural promotion — 3x-same-path heuristic
+# ---------------------------------------------------------------------------
+
+
+class TestProceduralPromotion:
+    @pytest.mark.asyncio
+    async def test_promotes_on_third_same_path(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+
+        first = _correction(
+            action_id="act-a",
+            patches=[CorrectionPatch(path="parameters.tone", before="formal", after="casual")],
+        )
+        second = _correction(
+            action_id="act-b",
+            patches=[CorrectionPatch(path="parameters.tone", before="formal", after="casual")],
+        )
+        third = _correction(
+            action_id="act-c",
+            patches=[CorrectionPatch(path="parameters.tone", before="formal", after="casual")],
+        )
+
+        await store.record_correction(first)
+        await bridge.record(first, _action())
+        assert fake_soul.remember.await_count == 0
+
+        await store.record_correction(second)
+        await bridge.record(second, _action())
+        assert fake_soul.remember.await_count == 0
+
+        await store.record_correction(third)
+        await bridge.record(third, _action())
+        assert fake_soul.remember.await_count == 1
+
+        kwargs = fake_soul.remember.await_args.kwargs
+        assert kwargs["type"] == "procedural"
+        assert kwargs["importance"] == 7
+        assert "parameters.tone" in kwargs["content"] or "tone" in kwargs["content"]
+        assert "casual" in kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_does_not_re_promote_past_threshold(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+
+        for i in range(4):
+            correction = _correction(
+                action_id=f"act-{i}",
+                patches=[CorrectionPatch(path="title", before="A", after="B")],
+            )
+            await store.record_correction(correction)
+            await bridge.record(correction, _action())
+
+        # Promotion fires exactly once, when count hits the threshold.
+        assert fake_soul.remember.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_promotes_per_path_independently(
+        self, manager_with_soul, fake_soul, store: InstinctStore
+    ) -> None:
+        bridge = CorrectionSoulBridge(soul_manager=manager_with_soul, store=store)
+
+        for i in range(3):
+            await store.record_correction(
+                _correction(
+                    action_id=f"title-{i}",
+                    patches=[CorrectionPatch(path="title", before="A", after="B")],
+                ),
+            )
+        for i in range(3):
+            await store.record_correction(
+                _correction(
+                    action_id=f"prio-{i}",
+                    patches=[CorrectionPatch(path="priority", before="medium", after="high")],
+                ),
+            )
+
+        await bridge.record(
+            _correction(
+                action_id="title-2",
+                patches=[CorrectionPatch(path="title", before="A", after="B")],
+            ),
+            _action(),
+        )
+        await bridge.record(
+            _correction(
+                action_id="prio-2",
+                patches=[CorrectionPatch(path="priority", before="medium", after="high")],
+            ),
+            _action(),
+        )
+
+        assert fake_soul.remember.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# InstinctCorrectionsTool — agent-facing shape
+# ---------------------------------------------------------------------------
+
+
+class TestInstinctCorrectionsTool:
+    @pytest.mark.asyncio
+    async def test_tool_returns_no_corrections_message_when_empty(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
+
+        empty_store = InstinctStore(tmp_path / "empty.db")
+        monkeypatch.setattr(
+            "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
+            lambda: empty_store,
+        )
+
+        tool = InstinctCorrectionsTool()
+        result = await tool.execute(pocket_id="pocket-1")
+        assert "No corrections captured" in result
+
+    @pytest.mark.asyncio
+    async def test_tool_formats_each_correction_with_patches(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
+
+        store = InstinctStore(tmp_path / "with_data.db")
+        await store.record_correction(
+            _correction(
+                action_id="act-x",
+                patches=[
+                    CorrectionPatch(path="title", before="Hi John", after="Hey J"),
+                    CorrectionPatch(path="parameters.discount_pct", before=20, after=15),
+                ],
+            ),
+        )
+        monkeypatch.setattr(
+            "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
+            lambda: store,
+        )
+
+        tool = InstinctCorrectionsTool()
+        result = await tool.execute(pocket_id="pocket-1")
+        assert "Send renewal outreach" in result
+        assert "user:priya" in result
+        assert "Hi John" in result
+        assert "Hey J" in result
+        assert "discount_pct" in result
+
+    @pytest.mark.asyncio
+    async def test_tool_returns_enterprise_missing_message_when_ee_unavailable(
+        self, monkeypatch
+    ) -> None:
+        from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
+
+        monkeypatch.setattr(
+            "pocketpaw.tools.builtin.instinct_corrections._get_instinct_store",
+            lambda: None,
+        )
+
+        tool = InstinctCorrectionsTool()
+        result = await tool.execute(pocket_id="pocket-1")
+        assert "enterprise" in result.lower()
+
+    def test_tool_advertises_required_parameters(self) -> None:
+        from pocketpaw.tools.builtin.instinct_corrections import InstinctCorrectionsTool
+
+        tool = InstinctCorrectionsTool()
+        assert tool.name == "instinct_corrections"
+        schema = tool.parameters
+        assert "pocket_id" in schema["properties"]
+        assert schema["required"] == ["pocket_id"]

--- a/tests/cloud/test_decision_traces.py
+++ b/tests/cloud/test_decision_traces.py
@@ -1,0 +1,307 @@
+# tests/cloud/test_decision_traces.py — Tests for ReasoningTrace + TraceCollector
+# + FabricObjectSnapshot store ops (Move 2 PR-A).
+# Created: 2026-04-13 — Locks the context-manager lifecycle, event aggregation
+# across fabric/soul/kb/tool-call event types, deduplication on exit, and the
+# SQLite persistence path for decision-time fabric snapshots.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ee.instinct.store import InstinctStore
+from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace, ToolCallRef
+from ee.instinct.trace_collector import TraceCollector
+
+# ---------------------------------------------------------------------------
+# Lightweight bus + event stand-ins (avoids pulling the real MessageBus)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeEvent:
+    event_type: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+class FakeBus:
+    """Minimal subscribe/unsubscribe interface matching MessageBus."""
+
+    def __init__(self) -> None:
+        self.subscribers: list[Any] = []
+
+    def subscribe_system(self, cb: Any) -> None:
+        self.subscribers.append(cb)
+
+    def unsubscribe_system(self, cb: Any) -> None:
+        if cb in self.subscribers:
+            self.subscribers.remove(cb)
+
+    async def publish(self, event: FakeEvent) -> None:
+        for cb in list(self.subscribers):
+            await cb(event)
+
+
+# ---------------------------------------------------------------------------
+# ReasoningTrace — shape
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningTraceModel:
+    def test_defaults_produce_empty_collections(self) -> None:
+        trace = ReasoningTrace()
+        assert trace.fabric_queries == []
+        assert trace.soul_memories == []
+        assert trace.kb_articles == []
+        assert trace.tool_calls == []
+        assert trace.token_counts == {}
+
+    def test_round_trip_serialization(self) -> None:
+        trace = ReasoningTrace(
+            fabric_queries=["obj_1", "obj_2"],
+            soul_memories=["mem_a"],
+            kb_articles=["kb_42"],
+            tool_calls=[ToolCallRef(tool="fabric_query", args_hash="abc", result_preview="...")],
+            prompt_version="v1",
+            backend="claude_agent_sdk",
+            model="claude-opus-4-6",
+            token_counts={"prompt": 120, "completion": 45},
+        )
+        restored = ReasoningTrace.model_validate(trace.model_dump())
+        assert restored == trace
+
+
+# ---------------------------------------------------------------------------
+# TraceCollector lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestCollectorLifecycle:
+    @pytest.mark.asyncio
+    async def test_subscribes_on_enter_and_unsubscribes_on_exit(self) -> None:
+        bus = FakeBus()
+        assert bus.subscribers == []
+
+        async with TraceCollector(bus):
+            assert len(bus.subscribers) == 1
+
+        assert bus.subscribers == []
+
+    @pytest.mark.asyncio
+    async def test_unsubscribes_even_when_body_raises(self) -> None:
+        bus = FakeBus()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            async with TraceCollector(bus):
+                raise RuntimeError("boom")
+
+        assert bus.subscribers == []
+
+    @pytest.mark.asyncio
+    async def test_carries_prompt_version_backend_and_model(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(
+            bus,
+            prompt_version="pv_123",
+            backend="claude_agent_sdk",
+            model="claude-opus-4-6",
+        ) as collector:
+            pass
+        assert collector.trace.prompt_version == "pv_123"
+        assert collector.trace.backend == "claude_agent_sdk"
+        assert collector.trace.model == "claude-opus-4-6"
+
+
+# ---------------------------------------------------------------------------
+# TraceCollector — event aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestCollectorAggregation:
+    @pytest.mark.asyncio
+    async def test_captures_fabric_queries(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("fabric_query", {"object_id": "obj_acme"}))
+            await bus.publish(FakeEvent("fabric_query", {"object_id": "obj_pricing"}))
+        assert collector.trace.fabric_queries == ["obj_acme", "obj_pricing"]
+
+    @pytest.mark.asyncio
+    async def test_captures_soul_memories(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("soul_recall", {"memory_id": "mem_1"}))
+            await bus.publish(FakeEvent("soul_recall", {"memory_id": "mem_2"}))
+        assert collector.trace.soul_memories == ["mem_1", "mem_2"]
+
+    @pytest.mark.asyncio
+    async def test_captures_kb_articles(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("kb_inject", {"article_id": "kb_pricing"}))
+        assert collector.trace.kb_articles == ["kb_pricing"]
+
+    @pytest.mark.asyncio
+    async def test_captures_tool_calls_with_duration(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_end",
+                    {"tool": "fabric_query", "args": {"q": "acme"}, "result": "1 row"},
+                ),
+            )
+        assert len(collector.trace.tool_calls) == 1
+        call = collector.trace.tool_calls[0]
+        assert call.tool == "fabric_query"
+        assert call.result_preview == "1 row"
+        assert call.args_hash  # non-empty
+        assert call.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_tool_result_alias_event_also_captured(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("tool_start", {"tool": "kb_search"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_result",
+                    {"tool": "kb_search", "args": {"q": "discount"}, "result": "ok"},
+                ),
+            )
+        assert len(collector.trace.tool_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_long_tool_result_is_truncated_with_ellipsis(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_end",
+                    {"tool": "fabric_query", "args": {}, "result": "x" * 500},
+                ),
+            )
+        preview = collector.trace.tool_calls[0].result_preview
+        assert len(preview) == 200
+        assert preview.endswith("...")
+
+    @pytest.mark.asyncio
+    async def test_duplicate_tool_calls_with_same_args_are_merged(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            for _ in range(3):
+                await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+                await bus.publish(
+                    FakeEvent(
+                        "tool_end",
+                        {"tool": "fabric_query", "args": {"q": "acme"}, "result": "ok"},
+                    ),
+                )
+        assert len(collector.trace.tool_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_tool_calls_with_different_args_are_kept_separate(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_end",
+                    {"tool": "fabric_query", "args": {"q": "acme"}, "result": "ok"},
+                ),
+            )
+            await bus.publish(FakeEvent("tool_start", {"tool": "fabric_query"}))
+            await bus.publish(
+                FakeEvent(
+                    "tool_end",
+                    {"tool": "fabric_query", "args": {"q": "beta"}, "result": "ok"},
+                ),
+            )
+        assert len(collector.trace.tool_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_reference_lists_are_deduplicated_on_exit(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("fabric_query", {"object_id": "obj_acme"}))
+            await bus.publish(FakeEvent("fabric_query", {"object_id": "obj_acme"}))
+            await bus.publish(FakeEvent("soul_recall", {"memory_id": "mem_1"}))
+            await bus.publish(FakeEvent("soul_recall", {"memory_id": "mem_1"}))
+        assert collector.trace.fabric_queries == ["obj_acme"]
+        assert collector.trace.soul_memories == ["mem_1"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_types_are_ignored(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("unknown_thing", {"object_id": "nope"}))
+            await bus.publish(FakeEvent("another_thing", {"data": 1}))
+        assert collector.trace.fabric_queries == []
+        assert collector.trace.tool_calls == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_event_data_is_skipped(self) -> None:
+        bus = FakeBus()
+        async with TraceCollector(bus) as collector:
+            await bus.publish(FakeEvent("fabric_query", {"object_id": 123}))
+            await bus.publish(FakeEvent("soul_recall", {}))
+            await bus.publish(FakeEvent("tool_end", {"args": {"q": "x"}}))
+        assert collector.trace.fabric_queries == []
+        assert collector.trace.soul_memories == []
+        assert collector.trace.tool_calls == []
+
+
+# ---------------------------------------------------------------------------
+# FabricObjectSnapshot store ops
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "trace_test.db")
+
+
+class TestFabricSnapshotStore:
+    @pytest.mark.asyncio
+    async def test_record_and_read_snapshot(self, store: InstinctStore) -> None:
+        snapshot = FabricObjectSnapshot(
+            object_id="obj_acme",
+            audit_id="aud_42",
+            object_type="Customer",
+            snapshot={"arr": 180000, "tier": "enterprise"},
+        )
+        saved = await store.record_fabric_snapshot(snapshot)
+        assert saved.id == snapshot.id
+
+        rows = await store.get_snapshots_for_audit("aud_42")
+        assert len(rows) == 1
+        assert rows[0].object_id == "obj_acme"
+        assert rows[0].snapshot["arr"] == 180000
+        assert rows[0].object_type == "Customer"
+
+    @pytest.mark.asyncio
+    async def test_snapshots_for_audit_orders_oldest_first(self, store: InstinctStore) -> None:
+        first = FabricObjectSnapshot(object_id="a", audit_id="aud_1")
+        second = FabricObjectSnapshot(object_id="b", audit_id="aud_1")
+        await store.record_fabric_snapshot(first)
+        await store.record_fabric_snapshot(second)
+
+        rows = await store.get_snapshots_for_audit("aud_1")
+        assert [r.object_id for r in rows] == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_snapshots_for_object_orders_newest_first(
+        self, store: InstinctStore
+    ) -> None:
+        older = FabricObjectSnapshot(object_id="obj_x", audit_id="aud_1")
+        newer = FabricObjectSnapshot(object_id="obj_x", audit_id="aud_2")
+        await store.record_fabric_snapshot(older)
+        await store.record_fabric_snapshot(newer)
+
+        rows = await store.get_snapshots_for_object("obj_x")
+        assert [r.audit_id for r in rows] == ["aud_2", "aud_1"]

--- a/tests/cloud/test_decision_traces.py
+++ b/tests/cloud/test_decision_traces.py
@@ -295,9 +295,7 @@ class TestFabricSnapshotStore:
         assert [r.object_id for r in rows] == ["a", "b"]
 
     @pytest.mark.asyncio
-    async def test_snapshots_for_object_orders_newest_first(
-        self, store: InstinctStore
-    ) -> None:
+    async def test_snapshots_for_object_orders_newest_first(self, store: InstinctStore) -> None:
         older = FabricObjectSnapshot(object_id="obj_x", audit_id="aud_1")
         newer = FabricObjectSnapshot(object_id="obj_x", audit_id="aud_2")
         await store.record_fabric_snapshot(older)

--- a/tests/cloud/test_decision_traces_wiring.py
+++ b/tests/cloud/test_decision_traces_wiring.py
@@ -1,0 +1,256 @@
+# tests/cloud/test_decision_traces_wiring.py — Integration tests for PR-B.
+# Created: 2026-04-13 — Verifies that propose() accepts and persists a trace,
+# that fabric snapshots are keyed to the audit row, and that the hydration
+# endpoint expands referenced IDs correctly with hydrate=0 / hydrate=1.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ee.instinct.models import ActionTrigger
+from ee.instinct.router import router
+from ee.instinct.store import InstinctStore
+from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace, ToolCallRef
+
+
+def _trigger() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="claude", reason="unit test")
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "traces_wiring.db")
+
+
+@pytest.fixture
+def app_with_store(tmp_path: Path):
+    app = FastAPI()
+    app.include_router(router)
+    store = InstinctStore(tmp_path / "router_traces.db")
+    with patch("ee.instinct.router._store", return_value=store):
+        yield app, store
+
+
+@pytest.fixture
+def client(app_with_store):
+    app, _ = app_with_store
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Store-level wiring
+# ---------------------------------------------------------------------------
+
+
+class TestProposeWithTrace:
+    @pytest.mark.asyncio
+    async def test_reasoning_trace_lands_in_audit_context(
+        self, store: InstinctStore
+    ) -> None:
+        trace = ReasoningTrace(
+            fabric_queries=["obj_acme"],
+            soul_memories=["mem_q4_pricing"],
+            kb_articles=["kb_discount_policy"],
+            tool_calls=[ToolCallRef(tool="kb_search", args_hash="abc", result_preview="…")],
+            prompt_version="v1",
+            backend="claude_agent_sdk",
+            model="claude-opus-4-6",
+        )
+        await store.propose(
+            pocket_id="pocket-1",
+            title="Offer renewal discount",
+            description="Acme up for renewal",
+            recommendation="Offer 25%",
+            trigger=_trigger(),
+            reasoning_trace=trace,
+        )
+
+        entries = await store.query_audit(pocket_id="pocket-1")
+        proposed = [e for e in entries if e.event == "action_proposed"]
+        assert len(proposed) == 1
+        decoded = ReasoningTrace.model_validate(
+            proposed[0].context["reasoning_trace"],
+        )
+        assert decoded.fabric_queries == ["obj_acme"]
+        assert decoded.soul_memories == ["mem_q4_pricing"]
+        assert decoded.backend == "claude_agent_sdk"
+
+    @pytest.mark.asyncio
+    async def test_fabric_snapshots_are_keyed_to_the_audit_row(
+        self, store: InstinctStore
+    ) -> None:
+        snapshots = [
+            FabricObjectSnapshot(
+                object_id="obj_acme",
+                audit_id="will-be-overwritten",
+                object_type="Customer",
+                snapshot={"arr": 180000},
+            ),
+            FabricObjectSnapshot(
+                object_id="obj_snowflake",
+                audit_id="will-be-overwritten",
+                object_type="Competitor",
+                snapshot={"last_seen": "Q4"},
+            ),
+        ]
+        await store.propose(
+            pocket_id="pocket-1",
+            title="Offer renewal discount",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+            reasoning_trace=ReasoningTrace(fabric_queries=["obj_acme", "obj_snowflake"]),
+            fabric_snapshots=snapshots,
+        )
+
+        entries = await store.query_audit(pocket_id="pocket-1")
+        proposed = next(e for e in entries if e.event == "action_proposed")
+        saved = await store.get_snapshots_for_audit(proposed.id)
+        assert {s.object_id for s in saved} == {"obj_acme", "obj_snowflake"}
+        for snap in saved:
+            assert snap.audit_id == proposed.id
+
+    @pytest.mark.asyncio
+    async def test_propose_without_trace_still_works(self, store: InstinctStore) -> None:
+        """Trace is optional — legacy callers keep working."""
+        await store.propose(
+            pocket_id="pocket-1",
+            title="No trace",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+        )
+        entries = await store.query_audit(pocket_id="pocket-1")
+        proposed = next(e for e in entries if e.event == "action_proposed")
+        assert "reasoning_trace" not in (proposed.context or {})
+
+
+# ---------------------------------------------------------------------------
+# Router-level wiring
+# ---------------------------------------------------------------------------
+
+
+class TestProposeEndpointWithTrace:
+    def test_endpoint_accepts_and_persists_trace_and_snapshots(
+        self, app_with_store, client: TestClient
+    ) -> None:
+        _, store = app_with_store
+        payload = {
+            "pocket_id": "pocket-1",
+            "title": "Offer renewal discount",
+            "description": "Acme up for renewal",
+            "recommendation": "Offer 25%",
+            "priority": "high",
+            "trigger": {
+                "type": "agent",
+                "source": "claude",
+                "reason": "renewal sequence",
+            },
+            "reasoning_trace": {
+                "fabric_queries": ["obj_acme"],
+                "soul_memories": [],
+                "kb_articles": ["kb_pricing"],
+                "tool_calls": [],
+                "prompt_version": "v1",
+                "backend": "claude_agent_sdk",
+                "model": "claude-opus-4-6",
+            },
+            "fabric_snapshots": [
+                {
+                    "object_id": "obj_acme",
+                    "audit_id": "placeholder",
+                    "object_type": "Customer",
+                    "snapshot": {"arr": 180000},
+                },
+            ],
+        }
+        res = client.post("/instinct/actions", json=payload)
+        assert res.status_code == 201
+        assert res.json()["title"] == "Offer renewal discount"
+        assert res.json()["priority"] == "high"
+
+
+class TestHydrationEndpoint:
+    @pytest.mark.asyncio
+    async def test_hydrate_zero_returns_decoded_trace_without_expansion(
+        self, app_with_store, client: TestClient
+    ) -> None:
+        _, store = app_with_store
+        await store.propose(
+            pocket_id="pocket-1",
+            title="Offer renewal discount",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+            reasoning_trace=ReasoningTrace(fabric_queries=["obj_acme"]),
+        )
+        entries = await store.query_audit(pocket_id="pocket-1")
+        proposed = next(e for e in entries if e.event == "action_proposed")
+
+        res = client.get(f"/instinct/audit/{proposed.id}")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["entry"]["id"] == proposed.id
+        assert body["reasoning_trace"]["fabric_queries"] == ["obj_acme"]
+        assert body["fabric_snapshots"] == []
+        assert body["fabric_current"] == []
+
+    @pytest.mark.asyncio
+    async def test_hydrate_one_returns_snapshots(
+        self, app_with_store, client: TestClient
+    ) -> None:
+        _, store = app_with_store
+        await store.propose(
+            pocket_id="pocket-1",
+            title="Offer renewal discount",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+            reasoning_trace=ReasoningTrace(fabric_queries=["obj_acme"]),
+            fabric_snapshots=[
+                FabricObjectSnapshot(
+                    object_id="obj_acme",
+                    audit_id="will-be-replaced",
+                    object_type="Customer",
+                    snapshot={"arr": 180000},
+                ),
+            ],
+        )
+        entries = await store.query_audit(pocket_id="pocket-1")
+        proposed = next(e for e in entries if e.event == "action_proposed")
+
+        res = client.get(f"/instinct/audit/{proposed.id}?hydrate=1")
+        assert res.status_code == 200
+        body = res.json()
+        assert len(body["fabric_snapshots"]) == 1
+        assert body["fabric_snapshots"][0]["object_id"] == "obj_acme"
+        assert body["fabric_snapshots"][0]["snapshot"]["arr"] == 180000
+
+    def test_hydrate_unknown_audit_returns_404(self, client: TestClient) -> None:
+        res = client.get("/instinct/audit/aud_does_not_exist")
+        assert res.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_audit_entry_without_trace_hydrates_empty(
+        self, app_with_store, client: TestClient
+    ) -> None:
+        _, store = app_with_store
+        await store.propose(
+            pocket_id="pocket-1",
+            title="No trace",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+        )
+        entries = await store.query_audit(pocket_id="pocket-1")
+        proposed = next(e for e in entries if e.event == "action_proposed")
+        res = client.get(f"/instinct/audit/{proposed.id}?hydrate=1")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["reasoning_trace"] is None
+        assert body["fabric_snapshots"] == []

--- a/tests/cloud/test_decision_traces_wiring.py
+++ b/tests/cloud/test_decision_traces_wiring.py
@@ -49,9 +49,7 @@ def client(app_with_store):
 
 class TestProposeWithTrace:
     @pytest.mark.asyncio
-    async def test_reasoning_trace_lands_in_audit_context(
-        self, store: InstinctStore
-    ) -> None:
+    async def test_reasoning_trace_lands_in_audit_context(self, store: InstinctStore) -> None:
         trace = ReasoningTrace(
             fabric_queries=["obj_acme"],
             soul_memories=["mem_q4_pricing"],
@@ -81,9 +79,7 @@ class TestProposeWithTrace:
         assert decoded.backend == "claude_agent_sdk"
 
     @pytest.mark.asyncio
-    async def test_fabric_snapshots_are_keyed_to_the_audit_row(
-        self, store: InstinctStore
-    ) -> None:
+    async def test_fabric_snapshots_are_keyed_to_the_audit_row(self, store: InstinctStore) -> None:
         snapshots = [
             FabricObjectSnapshot(
                 object_id="obj_acme",
@@ -201,9 +197,7 @@ class TestHydrationEndpoint:
         assert body["fabric_current"] == []
 
     @pytest.mark.asyncio
-    async def test_hydrate_one_returns_snapshots(
-        self, app_with_store, client: TestClient
-    ) -> None:
+    async def test_hydrate_one_returns_snapshots(self, app_with_store, client: TestClient) -> None:
         _, store = app_with_store
         await store.propose(
             pocket_id="pocket-1",

--- a/tests/cloud/test_paw_print_backend.py
+++ b/tests/cloud/test_paw_print_backend.py
@@ -1,0 +1,301 @@
+# tests/cloud/test_paw_print_backend.py — PR-A: Paw Print models + store.
+# Created: 2026-04-13 — Covers validation caps, domain normalization, token
+# rotation, event persistence, and the rate-limit primitives used by PR-B.
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from ee.paw_print.models import (
+    MAX_BLOCKS_PER_SPEC,
+    MAX_DOMAINS_PER_WIDGET,
+    MAX_ITEMS_PER_LIST,
+    PawPrintAction,
+    PawPrintBlock,
+    PawPrintEvent,
+    PawPrintEventMapping,
+    PawPrintListItem,
+    PawPrintSpec,
+    PawPrintWidget,
+)
+from ee.paw_print.store import PawPrintStore
+
+
+def _spec(widget_id: str = "pp_test") -> PawPrintSpec:
+    return PawPrintSpec(
+        widget_id=widget_id,
+        pocket_id="pocket-1",
+        blocks=[
+            PawPrintBlock(type="text", content="Today's menu", style="heading"),
+            PawPrintBlock(
+                type="list",
+                items=[
+                    PawPrintListItem(
+                        title="Oat Milk Latte",
+                        meta="$5 — 34 in stock",
+                        action=PawPrintAction(event="order_click", payload={"item": "oat_latte"}),
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def _widget(**overrides) -> PawPrintWidget:
+    defaults = {
+        "pocket_id": "pocket-1",
+        "owner": "user:maya",
+        "name": "Brew & Co Menu",
+        "spec": _spec(),
+        "allowed_domains": ["brewco.com"],
+        "event_mapping": {
+            "order_click": PawPrintEventMapping(
+                creates="Order",
+                fields={"item": "{{ payload.item }}", "customer_ref": "{{ customer_ref }}"},
+            ),
+        },
+    }
+    defaults.update(overrides)
+    return PawPrintWidget(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Model validation
+# ---------------------------------------------------------------------------
+
+
+class TestBlockCaps:
+    def test_list_block_accepts_up_to_the_cap(self) -> None:
+        items = [PawPrintListItem(title=f"Item {i}") for i in range(MAX_ITEMS_PER_LIST)]
+        block = PawPrintBlock(type="list", items=items)
+        assert len(block.items) == MAX_ITEMS_PER_LIST
+
+    def test_list_block_rejects_past_the_cap(self) -> None:
+        items = [PawPrintListItem(title=f"Item {i}") for i in range(MAX_ITEMS_PER_LIST + 1)]
+        with pytest.raises(ValueError, match="list block accepts at most"):
+            PawPrintBlock(type="list", items=items)
+
+    def test_spec_rejects_too_many_blocks(self) -> None:
+        blocks = [PawPrintBlock(type="divider") for _ in range(MAX_BLOCKS_PER_SPEC + 1)]
+        with pytest.raises(ValueError, match="spec accepts at most"):
+            PawPrintSpec(widget_id="pp_x", pocket_id="p", blocks=blocks)
+
+
+class TestWidgetValidation:
+    def test_allowed_domains_are_lowercased_and_deduped(self) -> None:
+        widget = _widget(allowed_domains=["BrewCo.com", "brewco.com", " shop.brewco.com "])
+        assert widget.allowed_domains == ["brewco.com", "shop.brewco.com"]
+
+    def test_allowed_domains_cap_enforced(self) -> None:
+        domains = [f"site{i}.example" for i in range(MAX_DOMAINS_PER_WIDGET + 1)]
+        with pytest.raises(ValueError, match="allowed_domains accepts at most"):
+            _widget(allowed_domains=domains)
+
+    def test_rate_limit_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="rate limits must be"):
+            _widget(rate_limit_per_min=0)
+        with pytest.raises(ValueError, match="rate limits must be"):
+            _widget(per_customer_limit_per_min=-1)
+
+    def test_access_token_is_generated_and_prefixed(self) -> None:
+        widget = _widget()
+        assert widget.access_token.startswith("pp_tok_")
+        assert len(widget.access_token) > len("pp_tok_") + 20
+
+
+class TestEventValidation:
+    def test_empty_type_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="event type is required"):
+            PawPrintEvent(widget_id="pp_x", type="  ", customer_ref="abc")
+
+    def test_type_is_stripped(self) -> None:
+        event = PawPrintEvent(widget_id="pp_x", type=" order_click ", customer_ref="abc")
+        assert event.type == "order_click"
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> PawPrintStore:
+    return PawPrintStore(tmp_path / "paw_print.db")
+
+
+class TestWidgetCRUD:
+    @pytest.mark.asyncio
+    async def test_create_and_fetch_widget(self, store: PawPrintStore) -> None:
+        widget = await store.create_widget(_widget())
+        fetched = await store.get_widget(widget.id)
+        assert fetched is not None
+        assert fetched.owner == "user:maya"
+        assert fetched.allowed_domains == ["brewco.com"]
+        assert "order_click" in fetched.event_mapping
+        assert fetched.event_mapping["order_click"].creates == "Order"
+
+    @pytest.mark.asyncio
+    async def test_list_filters_by_pocket_and_owner(self, store: PawPrintStore) -> None:
+        await store.create_widget(_widget(pocket_id="pocket-1", owner="user:maya"))
+        await store.create_widget(_widget(pocket_id="pocket-2", owner="user:priya"))
+
+        by_pocket = await store.list_widgets(pocket_id="pocket-1")
+        assert len(by_pocket) == 1
+        assert by_pocket[0].pocket_id == "pocket-1"
+
+        by_owner = await store.list_widgets(owner="user:priya")
+        assert len(by_owner) == 1
+        assert by_owner[0].owner == "user:priya"
+
+    @pytest.mark.asyncio
+    async def test_update_spec_replaces_blocks(self, store: PawPrintStore) -> None:
+        widget = await store.create_widget(_widget())
+        new_spec = PawPrintSpec(
+            widget_id=widget.id,
+            pocket_id=widget.pocket_id,
+            blocks=[PawPrintBlock(type="text", content="Closed today")],
+        )
+        updated = await store.update_spec(widget.id, new_spec)
+        assert updated is not None
+        assert len(updated.spec.blocks) == 1
+        assert updated.spec.blocks[0].content == "Closed today"
+
+    @pytest.mark.asyncio
+    async def test_rotate_token_invalidates_old_token(self, store: PawPrintStore) -> None:
+        widget = await store.create_widget(_widget())
+        original = widget.access_token
+        rotated = await store.rotate_token(widget.id)
+        assert rotated is not None
+        assert rotated.access_token != original
+        assert rotated.access_token.startswith("pp_tok_")
+
+    @pytest.mark.asyncio
+    async def test_delete_widget_returns_true_then_false(self, store: PawPrintStore) -> None:
+        widget = await store.create_widget(_widget())
+        assert await store.delete_widget(widget.id) is True
+        assert await store.delete_widget(widget.id) is False
+        assert await store.get_widget(widget.id) is None
+
+    @pytest.mark.asyncio
+    async def test_update_missing_widget_returns_none(self, store: PawPrintStore) -> None:
+        result = await store.update_spec("does_not_exist", _spec())
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Event log + rate limit
+# ---------------------------------------------------------------------------
+
+
+class TestEventStore:
+    @pytest.mark.asyncio
+    async def test_events_are_listed_newest_first(self, store: PawPrintStore) -> None:
+        widget = await store.create_widget(_widget())
+        now = datetime.now()
+        await store.record_event(
+            PawPrintEvent(
+                widget_id=widget.id,
+                type="order_click",
+                customer_ref="cust_a",
+                timestamp=now - timedelta(minutes=5),
+            ),
+        )
+        await store.record_event(
+            PawPrintEvent(
+                widget_id=widget.id,
+                type="order_click",
+                customer_ref="cust_b",
+                timestamp=now,
+            ),
+        )
+        events = await store.recent_events(widget.id)
+        assert len(events) == 2
+        assert events[0].customer_ref == "cust_b"
+        assert events[1].customer_ref == "cust_a"
+
+    @pytest.mark.asyncio
+    async def test_count_events_since_respects_window(self, store: PawPrintStore) -> None:
+        widget = await store.create_widget(_widget())
+        now = datetime.now()
+        await store.record_event(
+            PawPrintEvent(
+                widget_id=widget.id,
+                type="order_click",
+                customer_ref="cust_a",
+                timestamp=now - timedelta(minutes=5),
+            ),
+        )
+        await store.record_event(
+            PawPrintEvent(
+                widget_id=widget.id,
+                type="order_click",
+                customer_ref="cust_a",
+                timestamp=now - timedelta(seconds=20),
+            ),
+        )
+
+        assert await store.count_events_since(widget.id, now - timedelta(minutes=1)) == 1
+        assert await store.count_events_since(widget.id, now - timedelta(minutes=10)) == 2
+
+    @pytest.mark.asyncio
+    async def test_within_rate_limit_enforces_overall_and_per_customer(
+        self, store: PawPrintStore
+    ) -> None:
+        widget = await store.create_widget(_widget())
+        now = datetime.now()
+        for i in range(3):
+            await store.record_event(
+                PawPrintEvent(
+                    widget_id=widget.id,
+                    type="order_click",
+                    customer_ref="cust_a",
+                    timestamp=now - timedelta(seconds=10 * i),
+                ),
+            )
+
+        # Overall cap 5, per-customer cap 3 — cust_a is at the per-customer ceiling.
+        allowed = await store.within_rate_limit(
+            widget.id,
+            overall_per_min=5,
+            per_customer_per_min=3,
+            customer_ref="cust_a",
+            now=now,
+        )
+        assert allowed is False
+
+        # cust_b has no prior events — still accepted.
+        allowed_other = await store.within_rate_limit(
+            widget.id,
+            overall_per_min=5,
+            per_customer_per_min=3,
+            customer_ref="cust_b",
+            now=now,
+        )
+        assert allowed_other is True
+
+    @pytest.mark.asyncio
+    async def test_within_rate_limit_respects_overall_ceiling(
+        self, store: PawPrintStore
+    ) -> None:
+        widget = await store.create_widget(_widget())
+        now = datetime.now()
+        for i in range(5):
+            await store.record_event(
+                PawPrintEvent(
+                    widget_id=widget.id,
+                    type="order_click",
+                    customer_ref=f"cust_{i}",
+                    timestamp=now - timedelta(seconds=5),
+                ),
+            )
+        allowed = await store.within_rate_limit(
+            widget.id,
+            overall_per_min=5,
+            per_customer_per_min=10,
+            customer_ref="cust_new",
+            now=now,
+        )
+        assert allowed is False

--- a/tests/cloud/test_paw_print_backend.py
+++ b/tests/cloud/test_paw_print_backend.py
@@ -277,9 +277,7 @@ class TestEventStore:
         assert allowed_other is True
 
     @pytest.mark.asyncio
-    async def test_within_rate_limit_respects_overall_ceiling(
-        self, store: PawPrintStore
-    ) -> None:
+    async def test_within_rate_limit_respects_overall_ceiling(self, store: PawPrintStore) -> None:
         widget = await store.create_widget(_widget())
         now = datetime.now()
         for i in range(5):

--- a/tests/cloud/test_paw_print_ingest.py
+++ b/tests/cloud/test_paw_print_ingest.py
@@ -1,0 +1,340 @@
+# tests/cloud/test_paw_print_ingest.py — PR-B: HTTP surface + event ingest.
+# Created: 2026-04-13 — Covers spec serving (CORS), owner-authed CRUD, event
+# ingest with origin + payload-size + rate-limit + mapping-to-Fabric logic.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ee.paw_print.models import (
+    MAX_PAYLOAD_BYTES,
+    PawPrintBlock,
+    PawPrintSpec,
+)
+from ee.paw_print.router import router
+from ee.paw_print.store import PawPrintStore
+
+
+def _spec(widget_id: str = "pp_test", pocket_id: str = "pocket-1") -> PawPrintSpec:
+    return PawPrintSpec(
+        widget_id=widget_id,
+        pocket_id=pocket_id,
+        blocks=[PawPrintBlock(type="text", content="Hi from Brew & Co")],
+    )
+
+
+def _widget_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "pocket_id": "pocket-1",
+        "owner": "user:maya",
+        "name": "Brew & Co Menu",
+        "spec": _spec().model_dump(),
+        "allowed_domains": ["brewco.com"],
+        "rate_limit_per_min": 5,
+        "per_customer_limit_per_min": 3,
+        "event_mapping": {
+            "order_click": {
+                "creates": "Order",
+                "fields": {"item": "{{ payload.item }}", "buyer": "{{ customer_ref }}"},
+            },
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture
+def app_with_store(tmp_path: Path):
+    app = FastAPI()
+    app.include_router(router)
+    store = PawPrintStore(tmp_path / "paw_print_router.db")
+    with patch("ee.paw_print.router._store", return_value=store):
+        yield app, store
+
+
+@pytest.fixture
+def client(app_with_store):
+    app, _ = app_with_store
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Widget CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestWidgetCRUDEndpoints:
+    def test_create_widget_returns_shape(self, client: TestClient) -> None:
+        res = client.post("/paw-print/widgets", json=_widget_payload())
+        assert res.status_code == 201
+        body = res.json()
+        assert body["pocket_id"] == "pocket-1"
+        assert body["access_token"].startswith("pp_tok_")
+        assert body["allowed_domains"] == ["brewco.com"]
+
+    def test_get_widget_requires_token(self, client: TestClient) -> None:
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+        res = client.get(f"/paw-print/widgets/{created['id']}")
+        assert res.status_code == 401
+
+    def test_get_widget_with_valid_token(self, client: TestClient) -> None:
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+        res = client.get(
+            f"/paw-print/widgets/{created['id']}",
+            headers={"X-Paw-Print-Token": created["access_token"]},
+        )
+        assert res.status_code == 200
+        assert res.json()["id"] == created["id"]
+
+    def test_rotate_token_changes_value(self, client: TestClient) -> None:
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+        res = client.post(
+            f"/paw-print/widgets/{created['id']}/rotate-token",
+            headers={"X-Paw-Print-Token": created["access_token"]},
+        )
+        assert res.status_code == 200
+        assert res.json()["access_token"] != created["access_token"]
+
+    def test_delete_widget(self, client: TestClient) -> None:
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+        res = client.delete(
+            f"/paw-print/widgets/{created['id']}",
+            headers={"X-Paw-Print-Token": created["access_token"]},
+        )
+        assert res.status_code == 204
+        res2 = client.get(
+            f"/paw-print/widgets/{created['id']}",
+            headers={"X-Paw-Print-Token": created["access_token"]},
+        )
+        assert res2.status_code == 404
+
+    def test_list_events_requires_token(self, client: TestClient) -> None:
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+        unauthed = client.get(f"/paw-print/widgets/{created['id']}/events")
+        assert unauthed.status_code == 401
+        authed = client.get(
+            f"/paw-print/widgets/{created['id']}/events",
+            headers={"X-Paw-Print-Token": created["access_token"]},
+        )
+        assert authed.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Public spec serving
+# ---------------------------------------------------------------------------
+
+
+class TestSpecEndpoint:
+    def test_allowed_origin_gets_spec_with_cors_headers(self, client: TestClient) -> None:
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+        res = client.get(
+            f"/paw-print/spec/{created['id']}",
+            headers={"Origin": "https://brewco.com"},
+        )
+        assert res.status_code == 200
+        assert res.headers["access-control-allow-origin"] == "https://brewco.com"
+        assert "origin" in res.headers.get("vary", "").lower()
+
+    def test_disallowed_origin_is_rejected(self, client: TestClient) -> None:
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+        res = client.get(
+            f"/paw-print/spec/{created['id']}",
+            headers={"Origin": "https://evil.example"},
+        )
+        assert res.status_code == 403
+
+    def test_missing_origin_is_rejected_when_allowlist_set(self, client: TestClient) -> None:
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+        res = client.get(f"/paw-print/spec/{created['id']}")
+        assert res.status_code == 403
+
+    def test_empty_allowlist_allows_any_origin(self, client: TestClient) -> None:
+        created = client.post(
+            "/paw-print/widgets", json=_widget_payload(allowed_domains=[]),
+        ).json()
+        res = client.get(
+            f"/paw-print/spec/{created['id']}",
+            headers={"Origin": "https://anywhere.example"},
+        )
+        assert res.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Event ingest
+# ---------------------------------------------------------------------------
+
+
+class TestEventIngest:
+    def test_ingest_happy_path_records_event(
+        self, app_with_store, client: TestClient
+    ) -> None:
+        _, store = app_with_store
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+
+        res = client.post(
+            f"/paw-print/events/{created['id']}",
+            json={
+                "type": "order_click",
+                "payload": {"item": "oat_latte"},
+                "customer_ref": "cust_hash_abc",
+            },
+            headers={"Origin": "https://brewco.com"},
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["accepted"] is True
+        assert body["event"]["type"] == "order_click"
+
+    def test_disallowed_origin_is_rejected(self, client: TestClient) -> None:
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+        res = client.post(
+            f"/paw-print/events/{created['id']}",
+            json={"type": "order_click", "payload": {}, "customer_ref": "abc"},
+            headers={"Origin": "https://evil.example"},
+        )
+        assert res.status_code == 403
+
+    def test_oversized_payload_is_rejected(self, client: TestClient) -> None:
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+        big_payload = {"blob": "x" * (MAX_PAYLOAD_BYTES + 50)}
+        res = client.post(
+            f"/paw-print/events/{created['id']}",
+            json={"type": "order_click", "payload": big_payload, "customer_ref": "abc"},
+            headers={"Origin": "https://brewco.com"},
+        )
+        assert res.status_code == 413
+
+    def test_rate_limit_per_customer_fires(self, client: TestClient) -> None:
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+        # per_customer_limit_per_min=3 in payload — fourth call from same
+        # customer should 429.
+        for _ in range(3):
+            ok = client.post(
+                f"/paw-print/events/{created['id']}",
+                json={
+                    "type": "order_click",
+                    "payload": {"item": "oat_latte"},
+                    "customer_ref": "cust_a",
+                },
+                headers={"Origin": "https://brewco.com"},
+            )
+            assert ok.status_code == 200
+        blocked = client.post(
+            f"/paw-print/events/{created['id']}",
+            json={
+                "type": "order_click",
+                "payload": {"item": "oat_latte"},
+                "customer_ref": "cust_a",
+            },
+            headers={"Origin": "https://brewco.com"},
+        )
+        assert blocked.status_code == 429
+
+    def test_guardian_rejection_marks_event_not_accepted(
+        self, app_with_store, client: TestClient, monkeypatch
+    ) -> None:
+        async def blocker(payload: str) -> bool:
+            return False
+
+        monkeypatch.setattr(
+            "ee.paw_print.router._pass_through_guardian", AsyncMock(return_value=False),
+        )
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+        res = client.post(
+            f"/paw-print/events/{created['id']}",
+            json={"type": "order_click", "payload": {}, "customer_ref": "abc"},
+            headers={"Origin": "https://brewco.com"},
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["accepted"] is False
+        assert body["reason"] == "guardian_rejected"
+
+    def test_event_mapping_creates_fabric_object(
+        self, client: TestClient, monkeypatch
+    ) -> None:
+        fabric = MagicMock()
+        created_obj = MagicMock()
+        created_obj.id = "obj_created_123"
+        fabric.create_object = AsyncMock(return_value=created_obj)
+
+        class _FakeFabricObject:
+            def __init__(self, **kwargs):
+                for k, v in kwargs.items():
+                    setattr(self, k, v)
+
+        import sys
+        import types
+
+        fake_api = types.ModuleType("ee.api")
+        fake_api.get_fabric_store = lambda: fabric  # type: ignore[attr-defined]
+
+        fake_fabric_models = types.ModuleType("ee.fabric.models")
+        fake_fabric_models.FabricObject = _FakeFabricObject  # type: ignore[attr-defined]
+        fake_fabric_models._gen_id = lambda prefix="x": f"{prefix}_fake"  # type: ignore[attr-defined]
+
+        monkeypatch.setitem(sys.modules, "ee.api", fake_api)
+        # ee.fabric.models is already a real module — only patch create_object
+        # via monkeypatching the router's _apply_event_mapping import path.
+        from ee.paw_print import router as ppr
+
+        async def fake_apply(widget, event):
+            props = {
+                "item": event.payload.get("item"),
+                "buyer": event.customer_ref,
+            }
+            obj = fabric.create_object(
+                _FakeFabricObject(
+                    type_name="Order", properties=props, source_connector="paw_print",
+                ),
+            )
+            awaited = await obj if hasattr(obj, "__await__") else obj
+            return getattr(awaited, "id", None)
+
+        monkeypatch.setattr(ppr, "_apply_event_mapping", fake_apply)
+
+        created = client.post("/paw-print/widgets", json=_widget_payload()).json()
+        res = client.post(
+            f"/paw-print/events/{created['id']}",
+            json={
+                "type": "order_click",
+                "payload": {"item": "oat_latte"},
+                "customer_ref": "cust_a",
+            },
+            headers={"Origin": "https://brewco.com"},
+        )
+        assert res.status_code == 200
+        assert res.json()["fabric_object_id"] == "obj_created_123"
+
+
+# ---------------------------------------------------------------------------
+# _interpolate helper behavior
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolate:
+    def test_full_placeholder_returns_raw_value(self) -> None:
+        from ee.paw_print.router import _interpolate
+
+        assert _interpolate("{{ payload.count }}", {"payload": {"count": 42}}) == 42
+
+    def test_mixed_string_stringifies(self) -> None:
+        from ee.paw_print.router import _interpolate
+
+        out = _interpolate(
+            "Order {{ payload.item }} for {{ customer_ref }}",
+            {"payload": {"item": "latte"}, "customer_ref": "cust_a"},
+        )
+        assert out == "Order latte for cust_a"
+
+    def test_missing_path_resolves_to_empty_string_in_mixed_mode(self) -> None:
+        from ee.paw_print.router import _interpolate
+
+        out = _interpolate("Hi {{ payload.name }}!", {"payload": {}})
+        assert out == "Hi !"

--- a/tests/cloud/test_paw_print_ingest.py
+++ b/tests/cloud/test_paw_print_ingest.py
@@ -156,7 +156,8 @@ class TestSpecEndpoint:
 
     def test_empty_allowlist_allows_any_origin(self, client: TestClient) -> None:
         created = client.post(
-            "/paw-print/widgets", json=_widget_payload(allowed_domains=[]),
+            "/paw-print/widgets",
+            json=_widget_payload(allowed_domains=[]),
         ).json()
         res = client.get(
             f"/paw-print/spec/{created['id']}",
@@ -171,9 +172,7 @@ class TestSpecEndpoint:
 
 
 class TestEventIngest:
-    def test_ingest_happy_path_records_event(
-        self, app_with_store, client: TestClient
-    ) -> None:
+    def test_ingest_happy_path_records_event(self, app_with_store, client: TestClient) -> None:
         _, store = app_with_store
         created = client.post("/paw-print/widgets", json=_widget_payload()).json()
 
@@ -243,7 +242,8 @@ class TestEventIngest:
             return False
 
         monkeypatch.setattr(
-            "ee.paw_print.router._pass_through_guardian", AsyncMock(return_value=False),
+            "ee.paw_print.router._pass_through_guardian",
+            AsyncMock(return_value=False),
         )
         created = client.post("/paw-print/widgets", json=_widget_payload()).json()
         res = client.post(
@@ -256,9 +256,7 @@ class TestEventIngest:
         assert body["accepted"] is False
         assert body["reason"] == "guardian_rejected"
 
-    def test_event_mapping_creates_fabric_object(
-        self, client: TestClient, monkeypatch
-    ) -> None:
+    def test_event_mapping_creates_fabric_object(self, client: TestClient, monkeypatch) -> None:
         fabric = MagicMock()
         created_obj = MagicMock()
         created_obj.id = "obj_created_123"
@@ -291,7 +289,9 @@ class TestEventIngest:
             }
             obj = fabric.create_object(
                 _FakeFabricObject(
-                    type_name="Order", properties=props, source_connector="paw_print",
+                    type_name="Order",
+                    properties=props,
+                    source_connector="paw_print",
                 ),
             )
             awaited = await obj if hasattr(obj, "__await__") else obj


### PR DESCRIPTION
## Summary
- Re-sync `feat/paw-print-ingest` into `dev` after the #929/#930/#933 chain
- Brings Paw Print backend (models, async SQLite store) and HTTP ingest surface with Fabric event mapping
- Also pulls in decision trace persistence/wiring and correction→soul bridge from upstream branches

## Test plan
- [ ] `uv run pytest tests/cloud/test_paw_print_backend.py tests/cloud/test_paw_print_ingest.py tests/cloud/test_decision_traces.py tests/cloud/test_decision_traces_wiring.py tests/cloud/test_correction_soul_bridge.py`
- [ ] `uv run ruff check . && uv run ruff format --check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)