### PR TITLE
feat(ee): retrieval log sink + HTTP + CLI

### DIFF
--- a/ee/retrieval/__init__.py
+++ b/ee/retrieval/__init__.py
@@ -1,0 +1,8 @@
+# Retrieval log — paw-runtime sink for RetrievalTrace events from soul + kb + skills.
+# Created: 2026-04-13 (Move 4 PR-B) — JSONL appender, filtered reader, HTTP endpoint,
+# CLI tail. Consumers: graduation policy (PR-C), Why? drawer (PR-D), compliance export.
+
+from ee.retrieval.log import RetrievalLog, get_log
+from ee.retrieval.models import RetrievalLogEntry
+
+__all__ = ["RetrievalLog", "RetrievalLogEntry", "get_log"]

--- a/ee/retrieval/log.py
+++ b/ee/retrieval/log.py
@@ -1,0 +1,172 @@
+# ee/retrieval/log.py — Async-safe JSONL sink + filtered reader.
+# Created: 2026-04-13 (Move 4 PR-B) — Append-only file at
+# ~/.pocketpaw/retrieval.jsonl. Reads stream the file with optional filters.
+# Once line counts cross 10K-100K, swap the reader for an SQLite FTS index.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections.abc import AsyncIterator
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ee.retrieval.models import RetrievalLogEntry
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PATH = Path.home() / ".pocketpaw" / "retrieval.jsonl"
+
+
+class RetrievalLog:
+    """Async-safe JSONL sink for RetrievalTrace events.
+
+    Single-process serialisation via an asyncio.Lock — protects against
+    interleaved writes from concurrent recall callers in the same runtime.
+    Cross-process safety is intentionally NOT provided here (run paw-runtime
+    once per host); add file-locking later if multi-process emerges.
+    """
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self._path = Path(path) if path else DEFAULT_PATH
+        self._lock = asyncio.Lock()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    async def append(
+        self,
+        trace: Any,
+        *,
+        session_id: str | None = None,
+    ) -> RetrievalLogEntry:
+        """Append a trace to the log. ``trace`` may be a Pydantic model or a dict."""
+        trace_dict: dict[str, Any]
+        if hasattr(trace, "model_dump"):
+            trace_dict = trace.model_dump(mode="json")
+        elif isinstance(trace, dict):
+            trace_dict = trace
+        else:
+            raise TypeError(f"Unsupported trace type: {type(trace).__name__}")
+
+        entry = RetrievalLogEntry(trace=trace_dict, session_id=session_id)
+        line = entry.model_dump_json() + "\n"
+
+        async with self._lock:
+            await asyncio.to_thread(self._write, line)
+        return entry
+
+    def _write(self, line: str) -> None:
+        with self._path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+
+    async def read(
+        self,
+        *,
+        actor: str | None = None,
+        source: str | None = None,
+        pocket_id: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 100,
+    ) -> list[RetrievalLogEntry]:
+        """Filtered read of the log. Returns newest-first up to ``limit`` rows."""
+        rows: list[RetrievalLogEntry] = []
+        if not self._path.exists():
+            return rows
+        async for entry in self._stream():
+            if not _matches(entry, actor, source, pocket_id, since, until):
+                continue
+            rows.append(entry)
+        rows.sort(key=lambda e: e.ingested_at, reverse=True)
+        return rows[:limit]
+
+    async def tail(self, n: int = 20) -> list[RetrievalLogEntry]:
+        """Return the last ``n`` entries — newest last (terminal-friendly)."""
+        rows = await self.read(limit=max(n, 1))
+        rows.reverse()
+        return rows
+
+    async def stats(self) -> dict[str, int]:
+        """Quick counters for ops dashboards."""
+        if not self._path.exists():
+            return {"total": 0, "actors": 0, "pockets": 0}
+        actors: set[str] = set()
+        pockets: set[str] = set()
+        total = 0
+        async for entry in self._stream():
+            total += 1
+            if entry.actor():
+                actors.add(entry.actor())
+            if entry.pocket_id():
+                pockets.add(entry.pocket_id() or "")
+        return {"total": total, "actors": len(actors), "pockets": len(pockets)}
+
+    async def clear(self) -> None:
+        """Truncate the log file. Used by tests; no production callers."""
+        async with self._lock:
+            if self._path.exists():
+                await asyncio.to_thread(self._path.unlink)
+
+    async def _stream(self) -> AsyncIterator[RetrievalLogEntry]:
+        """Yield entries one at a time. Tolerant of malformed lines."""
+        # Read in a worker thread to keep the event loop free.
+        lines: list[str] = await asyncio.to_thread(self._read_lines)
+        for raw in lines:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                payload = json.loads(raw)
+                yield RetrievalLogEntry.model_validate(payload)
+            except (ValueError, TypeError):
+                logger.debug("Skipping malformed retrieval log line")
+                continue
+
+    def _read_lines(self) -> list[str]:
+        with self._path.open("r", encoding="utf-8") as fh:
+            return fh.readlines()
+
+
+def _matches(
+    entry: RetrievalLogEntry,
+    actor: str | None,
+    source: str | None,
+    pocket_id: str | None,
+    since: datetime | None,
+    until: datetime | None,
+) -> bool:
+    if actor and entry.actor() != actor:
+        return False
+    if source and entry.source() != source:
+        return False
+    if pocket_id and entry.pocket_id() != pocket_id:
+        return False
+    if since and entry.ingested_at < since:
+        return False
+    if until and entry.ingested_at > until:
+        return False
+    return True
+
+
+_singleton: RetrievalLog | None = None
+
+
+def get_log() -> RetrievalLog:
+    """Process-wide singleton sink. Override the path via POCKETPAW_RETRIEVAL_LOG."""
+    global _singleton
+    if _singleton is None:
+        override = os.environ.get("POCKETPAW_RETRIEVAL_LOG")
+        _singleton = RetrievalLog(path=override or None)
+    return _singleton
+
+
+def reset_log_for_tests() -> None:
+    """Reset the singleton so tests can substitute paths cleanly."""
+    global _singleton
+    _singleton = None

--- a/ee/retrieval/models.py
+++ b/ee/retrieval/models.py
@@ -1,0 +1,53 @@
+# ee/retrieval/models.py — RetrievalLogEntry: the on-disk shape of one trace.
+# Created: 2026-04-13 — Wraps the soul-protocol RetrievalTrace with the small
+# amount of paw-runtime context the trace itself doesn't carry (host process,
+# session, ingestion timestamp). Lean — no inheritance, just a thin wrapper.
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+# Re-export for callers that already have a RetrievalTrace in hand.
+try:
+    from soul_protocol.spec.retrieval import RetrievalCandidate, RetrievalTrace
+except ImportError:  # pragma: no cover — soul-protocol is required at runtime
+    RetrievalTrace = None  # type: ignore[assignment]
+    RetrievalCandidate = None  # type: ignore[assignment]
+
+
+class RetrievalLogEntry(BaseModel):
+    """One JSON line in ~/.pocketpaw/retrieval.jsonl.
+
+    The trace itself is the soul-protocol primitive. The wrapper adds the
+    paw-runtime context fields that aren't part of the portable spec — the
+    process that wrote the trace, the session it belonged to, and the
+    ingest timestamp. Append-only; never mutated after write.
+    """
+
+    trace: dict[str, Any]
+    ingested_at: datetime = Field(default_factory=datetime.now)
+    process: str = "paw-runtime"
+    session_id: str | None = None
+
+    def trace_id(self) -> str:
+        return str(self.trace.get("id", ""))
+
+    def actor(self) -> str:
+        return str(self.trace.get("actor", ""))
+
+    def source(self) -> str:
+        return str(self.trace.get("source", ""))
+
+    def query(self) -> str:
+        return str(self.trace.get("query", ""))
+
+    def pocket_id(self) -> str | None:
+        value = self.trace.get("pocket_id")
+        return str(value) if value else None
+
+    def candidate_ids(self) -> list[str]:
+        candidates = self.trace.get("candidates") or []
+        return [str(c.get("id")) for c in candidates if c.get("id")]

--- a/ee/retrieval/router.py
+++ b/ee/retrieval/router.py
@@ -1,0 +1,54 @@
+# ee/retrieval/router.py — HTTP surface for the retrieval log.
+# Created: 2026-04-13 (Move 4 PR-B) — GET /retrieval/log with filters,
+# GET /retrieval/stats. Read-only — writes happen via the in-process sink.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel
+
+from ee.retrieval.log import get_log
+from ee.retrieval.models import RetrievalLogEntry
+
+router = APIRouter(tags=["Retrieval"])
+
+
+class RetrievalLogResponse(BaseModel):
+    entries: list[RetrievalLogEntry]
+    total: int
+
+
+class RetrievalStatsResponse(BaseModel):
+    total: int
+    actors: int
+    pockets: int
+
+
+@router.get("/retrieval/log", response_model=RetrievalLogResponse)
+async def list_retrieval_log(
+    actor: str | None = Query(None, description="Filter by actor (e.g. 'user:sarah@co')"),
+    source: str | None = Query(None, description="Filter by source (soul|kb|skill|fabric)"),
+    pocket_id: str | None = Query(None, description="Filter by pocket"),
+    since: datetime | None = Query(None, description="Only entries on/after this timestamp"),
+    until: datetime | None = Query(None, description="Only entries on/before this timestamp"),
+    limit: int = Query(100, ge=1, le=1000),
+) -> RetrievalLogResponse:
+    """Read the retrieval log with optional filters. Newest first."""
+    entries = await get_log().read(
+        actor=actor,
+        source=source,
+        pocket_id=pocket_id,
+        since=since,
+        until=until,
+        limit=limit,
+    )
+    return RetrievalLogResponse(entries=entries, total=len(entries))
+
+
+@router.get("/retrieval/stats", response_model=RetrievalStatsResponse)
+async def retrieval_stats() -> RetrievalStatsResponse:
+    """Summary counters across the full log."""
+    stats = await get_log().stats()
+    return RetrievalStatsResponse(**stats)

--- a/src/pocketpaw/__main__.py
+++ b/src/pocketpaw/__main__.py
@@ -96,6 +96,7 @@ _EARLY_COMMANDS = {
     "config",
     "errors",
     "logs",
+    "retrieval",
 }
 
 
@@ -174,6 +175,18 @@ def _handle_early_command(args) -> int | None:
         return run_logs_cmd(
             limit=getattr(args, "limit", 50),
             follow=getattr(args, "follow", False),
+            as_json=getattr(args, "json", False),
+        )
+
+    if cmd == "retrieval":
+        from pocketpaw.cli.retrieval import run_retrieval_cmd
+
+        return run_retrieval_cmd(
+            action=getattr(args, "subaction", None),
+            limit=getattr(args, "limit", 20),
+            actor=getattr(args, "actor", None),
+            source=getattr(args, "source", None),
+            pocket_id=getattr(args, "pocket_id", None),
             as_json=getattr(args, "json", False),
         )
 
@@ -328,6 +341,7 @@ Examples:
             "config",
             "errors",
             "logs",
+            "retrieval",
         ],
         help="Subcommand to run",
     )
@@ -347,6 +361,15 @@ Examples:
         help="Limit number of results (for errors, logs, sessions, memory)",
     )
     parser.add_argument("--follow", action="store_true", help="Tail mode (for logs)")
+    parser.add_argument("--actor", type=str, default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--source", type=str, default=None, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--pocket-id",
+        dest="pocket_id",
+        type=str,
+        default=None,
+        help=argparse.SUPPRESS,
+    )
 
     return parser
 
@@ -383,6 +406,8 @@ def _resolve_subargs(args) -> None:
             args.key = subargs[1]
         if len(subargs) > 2:
             args.value = subargs[2]
+    elif cmd == "retrieval" and subargs:
+        args.subaction = subargs[0]
 
     if args.limit is None:
         defaults = {"errors": 20, "logs": 50, "sessions": 20, "memory": 10}

--- a/src/pocketpaw/cli/retrieval.py
+++ b/src/pocketpaw/cli/retrieval.py
@@ -1,0 +1,109 @@
+# pocketpaw/cli/retrieval.py — `pocketpaw retrieval tail|stats` (Move 4 PR-B).
+# Created: 2026-04-13 — Terminal view over ~/.pocketpaw/retrieval.jsonl. Read
+# only; the sink writes from the in-process runtime hooks.
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from pocketpaw.cli.utils import BOLD, DIM, GREEN, RESET, YELLOW, output_json, print_header
+
+
+def run_retrieval_cmd(
+    action: str | None = None,
+    limit: int = 20,
+    actor: str | None = None,
+    source: str | None = None,
+    pocket_id: str | None = None,
+    as_json: bool = False,
+) -> int:
+    """Read the retrieval log from the terminal.
+
+    ``action`` is the subcommand: ``tail`` (default) or ``stats``.
+    """
+    return asyncio.run(_run(action, limit, actor, source, pocket_id, as_json))
+
+
+async def _run(
+    action: str | None,
+    limit: int,
+    actor: str | None,
+    source: str | None,
+    pocket_id: str | None,
+    as_json: bool,
+) -> int:
+    try:
+        from ee.retrieval.log import get_log
+    except ImportError:
+        print(f"{YELLOW}Retrieval log not available — enterprise feature.{RESET}")
+        return 1
+
+    log = get_log()
+    sub = (action or "tail").lower()
+
+    if sub == "stats":
+        stats = await log.stats()
+        if as_json:
+            output_json(stats)
+        else:
+            print_header("Retrieval Log Stats")
+            print(f"  Total entries:  {BOLD}{stats['total']}{RESET}")
+            print(f"  Distinct actors:  {BOLD}{stats['actors']}{RESET}")
+            print(f"  Distinct pockets: {BOLD}{stats['pockets']}{RESET}\n")
+        return 0
+
+    if sub != "tail":
+        print(f"{YELLOW}Unknown subcommand: {sub} (try 'tail' or 'stats').{RESET}")
+        return 1
+
+    rows = await log.read(actor=actor, source=source, pocket_id=pocket_id, limit=limit)
+
+    if as_json:
+        output_json([_row_to_payload(r) for r in rows])
+        return 0
+
+    title = "Recent Retrievals"
+    filters: list[str] = []
+    if actor:
+        filters.append(f"actor={actor}")
+    if source:
+        filters.append(f"source={source}")
+    if pocket_id:
+        filters.append(f"pocket={pocket_id}")
+    if filters:
+        title += f" ({', '.join(filters)})"
+    print_header(title)
+
+    if not rows:
+        print(f"  {DIM}No retrievals match.{RESET}\n")
+        return 0
+
+    # Reverse to newest-last so the terminal feels like `tail -f`.
+    for entry in reversed(rows):
+        trace = entry.trace
+        ts = entry.ingested_at.isoformat(timespec="seconds")
+        actor_label = trace.get("actor", "unknown")
+        src = trace.get("source", "?")
+        query = trace.get("query", "")
+        n_candidates = len(trace.get("candidates") or [])
+        latency = trace.get("latency_ms", 0)
+
+        print(
+            f"  {DIM}{ts}{RESET} "
+            f"{GREEN}{src}{RESET} "
+            f"{BOLD}{actor_label}{RESET} "
+            f"q={query!r} "
+            f"candidates={n_candidates} "
+            f"latency={latency}ms",
+        )
+    print()
+    return 0
+
+
+def _row_to_payload(entry: Any) -> dict[str, Any]:
+    return {
+        "trace": entry.trace,
+        "ingested_at": entry.ingested_at.isoformat(),
+        "session_id": entry.session_id,
+    }

--- a/tests/cloud/test_retrieval_log.py
+++ b/tests/cloud/test_retrieval_log.py
@@ -1,0 +1,276 @@
+# tests/cloud/test_retrieval_log.py — Sink + reader + HTTP for Move 4 PR-B.
+# Created: 2026-04-13 — Async-safe append, filter correctness, malformed-line
+# tolerance, stats, HTTP wrapping.
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ee.retrieval.log import RetrievalLog, get_log, reset_log_for_tests
+from ee.retrieval.router import router
+
+
+def _trace(
+    *,
+    actor: str = "user:priya",
+    source: str = "soul",
+    query: str = "renewal discount",
+    pocket_id: str | None = "pocket-1",
+    candidates: list[dict] | None = None,
+) -> dict:
+    return {
+        "id": "rt_" + actor[:6],
+        "actor": actor,
+        "query": query,
+        "source": source,
+        "candidates": candidates or [{"id": "m1", "source": source, "score": 0.9}],
+        "picked": [],
+        "used_by": None,
+        "latency_ms": 12,
+        "pocket_id": pocket_id,
+        "timestamp": datetime.now().isoformat(),
+        "metadata": {},
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_log_for_tests()
+    yield
+    reset_log_for_tests()
+
+
+@pytest.fixture
+def log(tmp_path: Path) -> RetrievalLog:
+    return RetrievalLog(path=tmp_path / "retrieval_test.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# Sink
+# ---------------------------------------------------------------------------
+
+
+class TestSink:
+    @pytest.mark.asyncio
+    async def test_append_writes_jsonl_line(self, log: RetrievalLog) -> None:
+        entry = await log.append(_trace())
+        assert entry.actor() == "user:priya"
+
+        contents = log.path.read_text(encoding="utf-8").splitlines()
+        assert len(contents) == 1
+        parsed = json.loads(contents[0])
+        assert parsed["trace"]["query"] == "renewal discount"
+
+    @pytest.mark.asyncio
+    async def test_append_accepts_pydantic_trace(self, log: RetrievalLog) -> None:
+        try:
+            from soul_protocol.spec.retrieval import RetrievalCandidate, RetrievalTrace
+        except ImportError:
+            pytest.skip("soul_protocol not installed in dev env (optional dep)")
+
+        trace = RetrievalTrace(
+            actor="user:maya",
+            query="oat milk",
+            candidates=[RetrievalCandidate(id="m1", score=0.5)],
+        )
+        entry = await log.append(trace)
+        assert entry.actor() == "user:maya"
+        assert entry.candidate_ids() == ["m1"]
+
+    @pytest.mark.asyncio
+    async def test_append_rejects_unknown_type(self, log: RetrievalLog) -> None:
+        with pytest.raises(TypeError):
+            await log.append("not a trace")
+
+    @pytest.mark.asyncio
+    async def test_concurrent_appends_preserve_line_integrity(self, log: RetrievalLog) -> None:
+        await asyncio.gather(*(log.append(_trace(actor=f"user:{i}")) for i in range(20)))
+        lines = log.path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 20
+        # Every line must be valid JSON.
+        for line in lines:
+            json.loads(line)
+
+
+# ---------------------------------------------------------------------------
+# Reader
+# ---------------------------------------------------------------------------
+
+
+class TestReader:
+    @pytest.mark.asyncio
+    async def test_filter_by_actor(self, log: RetrievalLog) -> None:
+        await log.append(_trace(actor="user:priya"))
+        await log.append(_trace(actor="user:maya"))
+        await log.append(_trace(actor="user:priya"))
+
+        rows = await log.read(actor="user:priya")
+        assert len(rows) == 2
+        assert all(r.actor() == "user:priya" for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_filter_by_source(self, log: RetrievalLog) -> None:
+        await log.append(_trace(source="soul"))
+        await log.append(_trace(source="kb"))
+        rows = await log.read(source="kb")
+        assert len(rows) == 1
+        assert rows[0].source() == "kb"
+
+    @pytest.mark.asyncio
+    async def test_filter_by_pocket_id(self, log: RetrievalLog) -> None:
+        await log.append(_trace(pocket_id="pocket-1"))
+        await log.append(_trace(pocket_id="pocket-2"))
+        rows = await log.read(pocket_id="pocket-1")
+        assert len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_filter_by_time_window(self, log: RetrievalLog) -> None:
+        await log.append(_trace(actor="user:old"))
+        cutoff = datetime.now() + timedelta(milliseconds=10)
+        await asyncio.sleep(0.05)
+        await log.append(_trace(actor="user:new"))
+
+        recent = await log.read(since=cutoff)
+        assert len(recent) == 1
+        assert recent[0].actor() == "user:new"
+
+    @pytest.mark.asyncio
+    async def test_results_are_newest_first(self, log: RetrievalLog) -> None:
+        await log.append(_trace(actor="user:a"))
+        await asyncio.sleep(0.01)
+        await log.append(_trace(actor="user:b"))
+        rows = await log.read()
+        assert rows[0].actor() == "user:b"
+        assert rows[1].actor() == "user:a"
+
+    @pytest.mark.asyncio
+    async def test_limit_caps_results(self, log: RetrievalLog) -> None:
+        for i in range(5):
+            await log.append(_trace(actor=f"user:{i}"))
+        rows = await log.read(limit=2)
+        assert len(rows) == 2
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_empty(self, log: RetrievalLog) -> None:
+        rows = await log.read()
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_lines_are_skipped(self, log: RetrievalLog) -> None:
+        await log.append(_trace(actor="user:good"))
+        # Inject a malformed line directly.
+        with log.path.open("a", encoding="utf-8") as fh:
+            fh.write("not json at all\n")
+            fh.write('{"trace": "incomplete"\n')
+        await log.append(_trace(actor="user:also_good"))
+
+        rows = await log.read()
+        assert len(rows) == 2
+        assert {r.actor() for r in rows} == {"user:good", "user:also_good"}
+
+
+class TestTail:
+    @pytest.mark.asyncio
+    async def test_tail_returns_newest_last(self, log: RetrievalLog) -> None:
+        for i in range(5):
+            await log.append(_trace(actor=f"user:{i}"))
+            await asyncio.sleep(0.005)
+        tailed = await log.tail(n=3)
+        assert [t.actor() for t in tailed] == ["user:2", "user:3", "user:4"]
+
+
+class TestStats:
+    @pytest.mark.asyncio
+    async def test_stats_counts_actors_and_pockets(self, log: RetrievalLog) -> None:
+        await log.append(_trace(actor="user:a", pocket_id="pocket-1"))
+        await log.append(_trace(actor="user:a", pocket_id="pocket-2"))
+        await log.append(_trace(actor="user:b", pocket_id="pocket-1"))
+        stats = await log.stats()
+        assert stats == {"total": 3, "actors": 2, "pockets": 2}
+
+    @pytest.mark.asyncio
+    async def test_stats_on_empty_log(self, log: RetrievalLog) -> None:
+        stats = await log.stats()
+        assert stats == {"total": 0, "actors": 0, "pockets": 0}
+
+
+# ---------------------------------------------------------------------------
+# Singleton + env override
+# ---------------------------------------------------------------------------
+
+
+class TestSingleton:
+    def test_get_log_returns_same_instance(self) -> None:
+        a = get_log()
+        b = get_log()
+        assert a is b
+
+    def test_env_override_path(self, tmp_path: Path, monkeypatch) -> None:
+        custom = tmp_path / "custom_retrieval.jsonl"
+        monkeypatch.setenv("POCKETPAW_RETRIEVAL_LOG", str(custom))
+        reset_log_for_tests()
+        log = get_log()
+        assert log.path == custom
+
+
+# ---------------------------------------------------------------------------
+# HTTP router
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_with_log(tmp_path: Path):
+    app = FastAPI()
+    app.include_router(router)
+    log = RetrievalLog(path=tmp_path / "router_test.jsonl")
+    with patch("ee.retrieval.router.get_log", return_value=log):
+        yield app, log
+
+
+@pytest.fixture
+def client(app_with_log):
+    app, _ = app_with_log
+    return TestClient(app)
+
+
+class TestHTTPEndpoints:
+    @pytest.mark.asyncio
+    async def test_log_endpoint_returns_envelope(self, app_with_log, client: TestClient) -> None:
+        _, log = app_with_log
+        await log.append(_trace())
+
+        res = client.get("/retrieval/log")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] == 1
+        assert body["entries"][0]["trace"]["query"] == "renewal discount"
+
+    @pytest.mark.asyncio
+    async def test_log_endpoint_passes_filters(self, app_with_log, client: TestClient) -> None:
+        _, log = app_with_log
+        await log.append(_trace(actor="user:a"))
+        await log.append(_trace(actor="user:b"))
+
+        res = client.get("/retrieval/log?actor=user%3Ab")
+        body = res.json()
+        assert body["total"] == 1
+        assert body["entries"][0]["trace"]["actor"] == "user:b"
+
+    @pytest.mark.asyncio
+    async def test_stats_endpoint(self, app_with_log, client: TestClient) -> None:
+        _, log = app_with_log
+        await log.append(_trace(actor="user:a"))
+        await log.append(_trace(actor="user:b"))
+
+        res = client.get("/retrieval/stats")
+        assert res.status_code == 200
+        body = res.json()
+        assert body == {"total": 2, "actors": 2, "pockets": 1}


### PR DESCRIPTION
The companion runtime layer for soul-protocol's `RetrievalTrace` primitive ([soul-protocol #161](https://github.com/qbtrix/soul-protocol/pull/161)). Provides one place where every recall / search / match writes a receipt, plus the three reads off that file: HTTP, CLI, and the upcoming graduation policy + Why? drawer.

Move 4 PR-B. Targets `dev`. PR-C (graduation) and PR-D (UI) follow.

## What's in this PR

### \`ee/retrieval/log.py\`
- \`RetrievalLog\` — async-safe JSONL sink at \`~/.pocketpaw/retrieval.jsonl\` (override via \`POCKETPAW_RETRIEVAL_LOG\`). \`asyncio.Lock\` around appends serialises concurrent writers in-process. Cross-process safety intentionally out of scope until multi-process surfaces.
- \`read()\` — actor / source / pocket_id / since / until / limit filters, newest-first, malformed-line tolerant, missing-file safe.
- \`tail()\` reverses for terminal display. \`stats()\` for ops counters. \`clear()\` is test-only.
- Process singleton via \`get_log()\` + \`reset_log_for_tests()\`.

### \`ee/retrieval/models.py\`
- \`RetrievalLogEntry\` wraps the raw \`RetrievalTrace\` dict with paw-runtime context (ingestion timestamp, process tag, optional session id).
- Convenience accessors (\`actor()\`, \`source()\`, \`query()\`, \`pocket_id()\`, \`candidate_ids()\`) save callers from re-deserialising the embedded dict.

### \`ee/retrieval/router.py\`
- \`GET /retrieval/log\` — same filter set as the sink + \`limit\` (1-1000). Returns \`{ entries, total }\`.
- \`GET /retrieval/stats\` — \`{ total, actors, pockets }\`.

### \`pocketpaw retrieval\` CLI
- \`pocketpaw retrieval tail [--actor X] [--source Y] [--pocket-id Z] [--limit N] [--json]\` — newest-last terminal view.
- \`pocketpaw retrieval stats [--json]\` — counters.
- Registered as an early command alongside \`errors\` / \`logs\`.

## Test plan

- [x] 19 new tests in \`tests/cloud/test_retrieval_log.py\`:
  - Append path (dict + Pydantic + bad input)
  - 20-way concurrent appends preserving line integrity
  - Every filter axis (actor / source / pocket_id / time window)
  - Malformed-line tolerance
  - Missing-file safety
  - Tail ordering
  - Stats counters on empty + populated log
  - Singleton + env-var override
  - HTTP envelope, filter passthrough, stats endpoint
- [x] \`pytest tests/\` — 3991 passed (no regressions)
- [x] \`ruff check\` — clean
- [x] Smoke-tested \`uv run pocketpaw retrieval stats\`

## Pairs with

- [soul-protocol #161](https://github.com/qbtrix/soul-protocol/pull/161) — spec + emission
- PR-C (graduation policy) — reads this log
- PR-D (Why? drawer fourth tab) — surfaces traces inline

## Context

Design doc: paw-enterprise \`docs/enterprise/RETRIEVAL-TRACE.md\` (paw-enterprise PR #67).