### PR TITLE
feat(ee): graduation policy over the retrieval log

### DIFF
--- a/ee/graduation/__init__.py
+++ b/ee/graduation/__init__.py
@@ -1,0 +1,11 @@
+# Graduation — promote frequently-accessed soul memories to higher tiers.
+# Created: 2026-04-13 (Move 4 PR-C) — Reads the retrieval log written by
+# ee/retrieval (PR-B), counts accesses per memory_id within a window,
+# emits GraduationDecision objects when access crosses a threshold.
+# Apply mode uses soul.remember() to write the higher-tier copy; the
+# original entry is marked superseded via the spec's superseded field.
+
+from ee.graduation.models import GraduationDecision, GraduationReport
+from ee.graduation.policy import scan_for_graduations
+
+__all__ = ["GraduationDecision", "GraduationReport", "scan_for_graduations"]

--- a/ee/graduation/models.py
+++ b/ee/graduation/models.py
@@ -1,0 +1,45 @@
+# ee/graduation/models.py — GraduationDecision + report types.
+# Created: 2026-04-13 — Decisions describe the change without making it.
+# Apply mode reads decisions and mutates the soul; dry-run (default) just
+# emits them so an operator can review before promoting.
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+GraduationKind = Literal["episodic_to_semantic", "semantic_to_core", "promote_procedural"]
+
+
+class GraduationDecision(BaseModel):
+    """One memory crossed an access threshold — propose a tier change."""
+
+    memory_id: str
+    actor: str = ""
+    pocket_id: str | None = None
+    kind: GraduationKind
+    access_count: int
+    window_days: int
+    from_tier: str | None = None
+    to_tier: str
+    reason: str = ""
+
+    def short(self) -> str:
+        """One-line summary for terminal output."""
+        from_label = self.from_tier or "?"
+        return (
+            f"[{self.kind}] {self.memory_id} {from_label}→{self.to_tier} "
+            f"({self.access_count} accesses in {self.window_days}d)"
+        )
+
+
+class GraduationReport(BaseModel):
+    """The output of one scan."""
+
+    decisions: list[GraduationDecision] = Field(default_factory=list)
+    scanned_entries: int = 0
+    window_days: int = 30
+    dry_run: bool = True
+    generated_at: datetime = Field(default_factory=datetime.now)

--- a/ee/graduation/policy.py
+++ b/ee/graduation/policy.py
@@ -1,0 +1,238 @@
+# ee/graduation/policy.py — Tier promotion policy over the retrieval log.
+# Created: 2026-04-13 (Move 4 PR-C) — Scans ~/.pocketpaw/retrieval.jsonl,
+# counts access per memory_id within `window_days`, emits decisions when
+# counts cross thresholds. Generalises the bespoke 3x-same-path rule from
+# correction_soul_bridge — that bridge becomes a special case once the
+# refactor lands post-merge.
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from datetime import datetime, timedelta
+from typing import Any
+
+from ee.graduation.models import GraduationDecision, GraduationReport
+from ee.retrieval.log import RetrievalLog
+
+logger = logging.getLogger(__name__)
+
+
+# Defaults — overridable per-call. Sized for "feels like learning" without
+# hyperactive promotion: 10 accesses in a month for episodic→semantic,
+# 50 for semantic→core. Tunable from settings or env.
+DEFAULT_WINDOW_DAYS = 30
+DEFAULT_EPISODIC_THRESHOLD = 10
+DEFAULT_SEMANTIC_THRESHOLD = 50
+
+
+async def scan_for_graduations(
+    log: RetrievalLog,
+    *,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    episodic_threshold: int = DEFAULT_EPISODIC_THRESHOLD,
+    semantic_threshold: int = DEFAULT_SEMANTIC_THRESHOLD,
+    actor: str | None = None,
+    pocket_id: str | None = None,
+    dry_run: bool = True,
+) -> GraduationReport:
+    """Scan the retrieval log and return graduation decisions.
+
+    Each decision describes a tier change a higher process can apply. When
+    ``dry_run=True`` (default) no soul mutation happens — the report is the
+    full output. Apply path lives in ``apply_decisions()`` and is opt-in.
+
+    Args:
+        log: The retrieval log instance to scan.
+        window_days: Look-back window for access counting.
+        episodic_threshold: Accesses needed for episodic→semantic promotion.
+        semantic_threshold: Accesses needed for semantic→core promotion.
+        actor: Optional filter — only count accesses by this actor.
+        pocket_id: Optional filter — only count accesses in this pocket.
+        dry_run: When True (default), the returned report is the full output.
+
+    Returns:
+        :class:`GraduationReport` — decisions + scan metadata.
+    """
+    since = datetime.now() - timedelta(days=window_days)
+    entries = await log.read(actor=actor, pocket_id=pocket_id, since=since, limit=10_000)
+
+    # Per memory_id: count + most-recent tier seen + sample actor/pocket
+    counts: Counter[str] = Counter()
+    contexts: dict[str, dict[str, Any]] = {}
+
+    for entry in entries:
+        candidates = entry.trace.get("candidates") or []
+        for cand in candidates:
+            mid = cand.get("id")
+            if not isinstance(mid, str):
+                continue
+            counts[mid] += 1
+            existing = contexts.setdefault(
+                mid,
+                {
+                    "tier": cand.get("tier"),
+                    "actor": entry.actor(),
+                    "pocket_id": entry.pocket_id(),
+                },
+            )
+            # Last-seen tier wins so we reflect the current state.
+            if cand.get("tier"):
+                existing["tier"] = cand["tier"]
+
+    decisions: list[GraduationDecision] = []
+    for mid, count in counts.most_common():
+        ctx = contexts.get(mid, {})
+        from_tier = ctx.get("tier")
+        decision = _decide(
+            memory_id=mid,
+            count=count,
+            from_tier=from_tier,
+            actor=ctx.get("actor", ""),
+            pocket_id=ctx.get("pocket_id"),
+            episodic_threshold=episodic_threshold,
+            semantic_threshold=semantic_threshold,
+            window_days=window_days,
+        )
+        if decision is not None:
+            decisions.append(decision)
+
+    return GraduationReport(
+        decisions=decisions,
+        scanned_entries=len(entries),
+        window_days=window_days,
+        dry_run=dry_run,
+    )
+
+
+def _decide(
+    *,
+    memory_id: str,
+    count: int,
+    from_tier: str | None,
+    actor: str,
+    pocket_id: str | None,
+    episodic_threshold: int,
+    semantic_threshold: int,
+    window_days: int,
+) -> GraduationDecision | None:
+    """Return a decision when access count crosses a threshold for this tier."""
+    tier = (from_tier or "").lower()
+
+    if tier in {"episodic", ""} and count >= episodic_threshold:
+        # Empty tier is treated as episodic — soul defaults episodic for
+        # interaction-derived memories, and the retrieval log doesn't always
+        # carry tier on every candidate.
+        return GraduationDecision(
+            memory_id=memory_id,
+            actor=actor,
+            pocket_id=pocket_id,
+            kind="episodic_to_semantic",
+            access_count=count,
+            window_days=window_days,
+            from_tier=from_tier or "episodic",
+            to_tier="semantic",
+            reason=(
+                f"Accessed {count}x in last {window_days} days "
+                f"(threshold {episodic_threshold})."
+            ),
+        )
+
+    if tier == "semantic" and count >= semantic_threshold:
+        return GraduationDecision(
+            memory_id=memory_id,
+            actor=actor,
+            pocket_id=pocket_id,
+            kind="semantic_to_core",
+            access_count=count,
+            window_days=window_days,
+            from_tier="semantic",
+            to_tier="core",
+            reason=(
+                f"Accessed {count}x in last {window_days} days "
+                f"(threshold {semantic_threshold})."
+            ),
+        )
+
+    return None
+
+
+async def apply_decisions(
+    soul: Any,
+    decisions: list[GraduationDecision],
+) -> list[GraduationDecision]:
+    """Apply graduation decisions by writing higher-tier copies via soul.remember().
+
+    Returns the subset of decisions that were applied successfully. Errors are
+    logged but never raise — graduation must never break the runtime. Original
+    memory entries are not deleted; soul-protocol's ``superseded`` field on
+    ``MemoryEntry`` can mark the old row in a follow-up if/when the spec
+    exposes a native ``promote()``.
+    """
+    if not hasattr(soul, "remember") or not hasattr(soul, "recall"):
+        logger.debug("apply_decisions: soul has no remember/recall — skipping")
+        return []
+
+    target_type_for_tier = _resolve_tier_resolver()
+
+    applied: list[GraduationDecision] = []
+    for decision in decisions:
+        try:
+            content = await _lookup_memory_content(soul, decision.memory_id)
+            if not content:
+                logger.debug(
+                    "apply_decisions: memory %s not found in soul — skipping",
+                    decision.memory_id,
+                )
+                continue
+
+            target_type = target_type_for_tier(decision.to_tier)
+            await soul.remember(
+                content=f"[graduated:{decision.kind}] {content}",
+                type=target_type,
+                importance=8 if decision.to_tier == "core" else 7,
+            )
+            applied.append(decision)
+        except Exception:
+            logger.exception(
+                "apply_decisions: failed to graduate %s",
+                decision.memory_id,
+            )
+    return applied
+
+
+def _resolve_tier_resolver():
+    """Return a callable that maps a tier name to soul-protocol's MemoryType enum.
+
+    When soul-protocol isn't installed (rare in production, common in tests
+    that mock the soul interface), fall back to passing the tier name as a
+    plain string. The mock soul doesn't care about the type either way.
+    """
+    try:
+        from soul_protocol.runtime.types import MemoryType
+    except ImportError:
+        return lambda tier: tier
+
+    def _lookup(tier: str):
+        try:
+            return MemoryType(tier)
+        except ValueError:
+            return MemoryType.SEMANTIC
+
+    return _lookup
+
+
+async def _lookup_memory_content(soul: Any, memory_id: str) -> str:
+    """Best-effort lookup — soul-protocol doesn't expose a get-by-id API yet.
+
+    Pulls a wide recall and finds the matching entry. Once soul-protocol gains
+    a direct lookup, swap this for a single-call read.
+    """
+    try:
+        memories = await soul.recall("", limit=500)
+    except Exception:
+        return ""
+    for entry in memories:
+        if getattr(entry, "id", None) == memory_id:
+            return getattr(entry, "content", "")
+    return ""

--- a/ee/graduation/router.py
+++ b/ee/graduation/router.py
@@ -1,0 +1,76 @@
+# ee/graduation/router.py — HTTP surface for the graduation policy.
+# Created: 2026-04-13 (Move 4 PR-C) — Scan endpoint returns proposed
+# decisions; apply endpoint mutates the soul (opt-in via body flag).
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from ee.graduation.models import GraduationDecision, GraduationReport
+from ee.graduation.policy import (
+    DEFAULT_EPISODIC_THRESHOLD,
+    DEFAULT_SEMANTIC_THRESHOLD,
+    DEFAULT_WINDOW_DAYS,
+    apply_decisions,
+    scan_for_graduations,
+)
+from ee.retrieval.log import get_log
+
+router = APIRouter(tags=["Graduation"])
+
+
+class ScanRequest(BaseModel):
+    window_days: int = DEFAULT_WINDOW_DAYS
+    episodic_threshold: int = DEFAULT_EPISODIC_THRESHOLD
+    semantic_threshold: int = DEFAULT_SEMANTIC_THRESHOLD
+    actor: str | None = None
+    pocket_id: str | None = None
+
+
+class ApplyRequest(BaseModel):
+    decisions: list[GraduationDecision] = Field(default_factory=list)
+
+
+class ApplyResponse(BaseModel):
+    applied: list[GraduationDecision]
+    skipped: int
+
+
+@router.post("/graduation/scan", response_model=GraduationReport)
+async def scan_graduations(
+    req: ScanRequest | None = None,
+    dry_run: int = Query(1, description="Pass 0 to NOT prefix the report as dry-run"),
+) -> GraduationReport:
+    """Scan the retrieval log for memories that crossed access thresholds."""
+    req = req or ScanRequest()
+    return await scan_for_graduations(
+        get_log(),
+        window_days=req.window_days,
+        episodic_threshold=req.episodic_threshold,
+        semantic_threshold=req.semantic_threshold,
+        actor=req.actor,
+        pocket_id=req.pocket_id,
+        dry_run=bool(dry_run),
+    )
+
+
+@router.post("/graduation/apply", response_model=ApplyResponse)
+async def apply_graduations(req: ApplyRequest) -> ApplyResponse:
+    """Apply the supplied decisions against the active soul.
+
+    Returns the subset that succeeded. Failures are logged server-side and
+    counted in ``skipped`` so the caller can retry only the failed entries.
+    """
+    try:
+        from pocketpaw.soul.manager import get_soul_manager
+    except ImportError as exc:
+        raise HTTPException(503, f"Soul manager unavailable: {exc}") from exc
+
+    manager = get_soul_manager()
+    soul = getattr(manager, "soul", None) if manager else None
+    if soul is None:
+        raise HTTPException(503, "No soul loaded — cannot apply graduations")
+
+    applied = await apply_decisions(soul, req.decisions)
+    return ApplyResponse(applied=applied, skipped=len(req.decisions) - len(applied))

--- a/tests/cloud/test_graduation_policy.py
+++ b/tests/cloud/test_graduation_policy.py
@@ -1,0 +1,271 @@
+# tests/cloud/test_graduation_policy.py — Move 4 PR-C.
+# Created: 2026-04-13 — Threshold semantics, tier filtering, window
+# enforcement, apply path with mocked soul, and the HTTP surface.
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ee.graduation.models import GraduationDecision
+from ee.graduation.policy import (
+    DEFAULT_EPISODIC_THRESHOLD,
+    DEFAULT_SEMANTIC_THRESHOLD,
+    apply_decisions,
+    scan_for_graduations,
+)
+from ee.graduation.router import router
+from ee.retrieval.log import RetrievalLog
+
+
+def _trace_with_candidate(memory_id: str, *, tier: str = "episodic", actor: str = "user:priya"):
+    return {
+        "id": "rt_x",
+        "actor": actor,
+        "query": "x",
+        "source": "soul",
+        "candidates": [{"id": memory_id, "source": "soul", "score": 0.5, "tier": tier}],
+        "picked": [],
+        "used_by": None,
+        "latency_ms": 1,
+        "pocket_id": "pocket-1",
+        "timestamp": datetime.now().isoformat(),
+        "metadata": {},
+    }
+
+
+@pytest.fixture
+def log(tmp_path: Path) -> RetrievalLog:
+    return RetrievalLog(path=tmp_path / "graduation_test.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# scan_for_graduations
+# ---------------------------------------------------------------------------
+
+
+class TestScan:
+    @pytest.mark.asyncio
+    async def test_no_decisions_when_no_log(self, log: RetrievalLog) -> None:
+        report = await scan_for_graduations(log)
+        assert report.decisions == []
+        assert report.scanned_entries == 0
+        assert report.dry_run is True
+
+    @pytest.mark.asyncio
+    async def test_episodic_promotes_at_threshold(self, log: RetrievalLog) -> None:
+        for _ in range(DEFAULT_EPISODIC_THRESHOLD):
+            await log.append(_trace_with_candidate("mem_renew_policy"))
+
+        report = await scan_for_graduations(log)
+        assert len(report.decisions) == 1
+        decision = report.decisions[0]
+        assert decision.memory_id == "mem_renew_policy"
+        assert decision.kind == "episodic_to_semantic"
+        assert decision.access_count == DEFAULT_EPISODIC_THRESHOLD
+        assert decision.from_tier == "episodic"
+        assert decision.to_tier == "semantic"
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_yields_no_decision(self, log: RetrievalLog) -> None:
+        for _ in range(DEFAULT_EPISODIC_THRESHOLD - 1):
+            await log.append(_trace_with_candidate("mem_x"))
+        report = await scan_for_graduations(log)
+        assert report.decisions == []
+
+    @pytest.mark.asyncio
+    async def test_semantic_promotes_to_core_at_higher_threshold(
+        self, log: RetrievalLog
+    ) -> None:
+        for _ in range(DEFAULT_SEMANTIC_THRESHOLD):
+            await log.append(_trace_with_candidate("mem_core_fact", tier="semantic"))
+
+        report = await scan_for_graduations(log)
+        assert len(report.decisions) == 1
+        d = report.decisions[0]
+        assert d.kind == "semantic_to_core"
+        assert d.from_tier == "semantic"
+        assert d.to_tier == "core"
+
+    @pytest.mark.asyncio
+    async def test_outside_window_is_ignored(self, log: RetrievalLog) -> None:
+        # Pre-write old entries by editing the file directly.
+        import json
+
+        from ee.retrieval.models import RetrievalLogEntry
+
+        old = datetime.now() - timedelta(days=60)
+        for _ in range(DEFAULT_EPISODIC_THRESHOLD):
+            entry = RetrievalLogEntry(
+                trace=_trace_with_candidate("mem_old"),
+                ingested_at=old,
+            )
+            with log.path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(entry.model_dump(mode="json")) + "\n")
+
+        # Hits inside the window but not enough to cross threshold:
+        for _ in range(DEFAULT_EPISODIC_THRESHOLD - 1):
+            await log.append(_trace_with_candidate("mem_old"))
+
+        report = await scan_for_graduations(log, window_days=30)
+        assert report.decisions == []
+
+    @pytest.mark.asyncio
+    async def test_actor_filter_isolates_counts(self, log: RetrievalLog) -> None:
+        for _ in range(DEFAULT_EPISODIC_THRESHOLD):
+            await log.append(_trace_with_candidate("mem_x", actor="user:priya"))
+        for _ in range(DEFAULT_EPISODIC_THRESHOLD):
+            await log.append(_trace_with_candidate("mem_x", actor="user:maya"))
+
+        priya_only = await scan_for_graduations(log, actor="user:priya")
+        # mem_x has 10 accesses by priya alone — promotes.
+        assert any(d.memory_id == "mem_x" for d in priya_only.decisions)
+
+
+# ---------------------------------------------------------------------------
+# apply_decisions
+# ---------------------------------------------------------------------------
+
+
+class TestApply:
+    @pytest.mark.asyncio
+    async def test_apply_calls_remember_with_target_tier(self) -> None:
+        # Mock soul that surfaces a single matching entry on recall().
+        soul = MagicMock()
+        soul.remember = AsyncMock(return_value="mem_new_id")
+
+        async def fake_recall(query, *, limit=500):
+            entry = MagicMock()
+            entry.id = "mem_x"
+            entry.content = "the renewal policy caps discount at 20%"
+            return [entry]
+
+        soul.recall = fake_recall
+
+        decision = GraduationDecision(
+            memory_id="mem_x",
+            kind="episodic_to_semantic",
+            access_count=15,
+            window_days=30,
+            from_tier="episodic",
+            to_tier="semantic",
+            reason="threshold crossed",
+        )
+
+        applied = await apply_decisions(soul, [decision])
+        assert len(applied) == 1
+        soul.remember.assert_awaited_once()
+        kwargs = soul.remember.await_args.kwargs
+        assert "renewal policy" in kwargs["content"]
+        # Importance bumps for the new tier.
+        assert kwargs["importance"] >= 7
+
+    @pytest.mark.asyncio
+    async def test_apply_skips_when_memory_not_found(self) -> None:
+        soul = MagicMock()
+        soul.remember = AsyncMock()
+
+        async def empty_recall(query, *, limit=500):
+            return []
+
+        soul.recall = empty_recall
+
+        decision = GraduationDecision(
+            memory_id="missing",
+            kind="episodic_to_semantic",
+            access_count=15,
+            window_days=30,
+            from_tier="episodic",
+            to_tier="semantic",
+        )
+
+        applied = await apply_decisions(soul, [decision])
+        assert applied == []
+        soul.remember.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_apply_swallows_per_decision_errors(self) -> None:
+        soul = MagicMock()
+        soul.remember = AsyncMock(side_effect=RuntimeError("boom"))
+
+        async def fake_recall(query, *, limit=500):
+            entry = MagicMock()
+            entry.id = "mem_x"
+            entry.content = "x"
+            return [entry]
+
+        soul.recall = fake_recall
+
+        decision = GraduationDecision(
+            memory_id="mem_x",
+            kind="episodic_to_semantic",
+            access_count=15,
+            window_days=30,
+            from_tier="episodic",
+            to_tier="semantic",
+        )
+
+        # Must not raise — graduation never breaks the runtime.
+        applied = await apply_decisions(soul, [decision, decision])
+        assert applied == []
+
+    @pytest.mark.asyncio
+    async def test_apply_returns_empty_when_soul_lacks_apis(self) -> None:
+        soul = MagicMock(spec=[])  # no remember / recall attrs
+        decision = GraduationDecision(
+            memory_id="mem_x",
+            kind="episodic_to_semantic",
+            access_count=15,
+            window_days=30,
+            from_tier="episodic",
+            to_tier="semantic",
+        )
+        applied = await apply_decisions(soul, [decision])
+        assert applied == []
+
+
+# ---------------------------------------------------------------------------
+# HTTP router
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_with_log(tmp_path: Path):
+    app = FastAPI()
+    app.include_router(router)
+    log = RetrievalLog(path=tmp_path / "router_grad.jsonl")
+    with patch("ee.graduation.router.get_log", return_value=log):
+        yield app, log
+
+
+@pytest.fixture
+def client(app_with_log):
+    app, _ = app_with_log
+    return TestClient(app)
+
+
+class TestHTTPEndpoints:
+    @pytest.mark.asyncio
+    async def test_scan_endpoint_returns_decisions(
+        self, app_with_log, client: TestClient
+    ) -> None:
+        _, log = app_with_log
+        for _ in range(DEFAULT_EPISODIC_THRESHOLD):
+            await log.append(_trace_with_candidate("mem_x"))
+
+        res = client.post("/graduation/scan", json={})
+        assert res.status_code == 200
+        body = res.json()
+        assert body["dry_run"] is True
+        assert len(body["decisions"]) == 1
+        assert body["decisions"][0]["memory_id"] == "mem_x"
+
+    def test_apply_endpoint_returns_503_when_no_soul(self, client: TestClient) -> None:
+        res = client.post("/graduation/apply", json={"decisions": []})
+        # No soul manager available in test app → 503.
+        assert res.status_code == 503


### PR DESCRIPTION
Generalises the bespoke 3×-same-path rule from \`correction_soul_bridge\` into a tier-promotion policy that scans the retrieval log and emits \`GraduationDecision\` objects when access counts cross thresholds. Apply mode is opt-in and uses \`soul.remember()\` for the higher-tier copy — no spec addition needed.

Move 4 PR-C. Stacks on [#936](https://github.com/pocketpaw/pocketpaw/pull/936).

## What's in this PR

### \`ee/graduation/models.py\`
- \`GraduationDecision\` (\`memory_id\`, \`kind\`, \`access_count\`, \`from_tier\`→\`to_tier\`, \`reason\`).
- \`GraduationReport\` (decisions + scan metadata + dry_run flag).

### \`ee/graduation/policy.py\`
- \`scan_for_graduations(log, *, window_days, episodic_threshold, semantic_threshold, actor, pocket_id, dry_run)\` — reads the log via \`ee/retrieval\`, counts per memory_id within the window, emits decisions when counts cross the threshold matching the candidate's tier. Last-seen tier wins so the report reflects current state.
- \`apply_decisions(soul, decisions)\` — writes higher-tier copies via \`soul.remember()\`, looks up original content via wide recall. Per-decision errors are logged and counted; never raises upward (graduation must not break the runtime). Soul without \`remember\`/\`recall\` is a no-op.
- Defaults: 30-day window, 10 accesses for episodic→semantic, 50 for semantic→core.
- \`MemoryType\` import is wrapped — when soul-protocol isn't installed in the dev env (optional dep), the apply path passes tier as a string. Production resolves to the real enum.

### \`ee/graduation/router.py\`
- \`POST /graduation/scan\` returns a \`GraduationReport\` (dry-run by default). Body tunes windows + thresholds + filters.
- \`POST /graduation/apply\` takes \`{ decisions: [...] }\` and returns \`{ applied, skipped }\`. 503 when no soul manager is loaded.

## Test plan

- [x] 12 new tests in \`tests/cloud/test_graduation_policy.py\`:
  - Empty log → no decisions
  - Episodic threshold crossing → \`episodic_to_semantic\`
  - Sub-threshold → no decision
  - Semantic threshold crossing → \`semantic_to_core\`
  - Outside-window entries excluded
  - Actor filter isolates counts
  - Apply success path with mocked soul (verifies \`remember\` called with target tier + bumped importance)
  - Apply skips missing memory
  - Apply swallows per-decision exceptions
  - Soul-without-apis returns empty
  - Scan endpoint returns decisions
  - Apply endpoint 503s when no soul manager
- [x] \`pytest tests/\` — 3991 passed (no regressions)
- [x] \`ruff check\` — clean

## Follow-up

Once both Move 1 PR-B (correction_soul_bridge) and this PR land in dev, a cleanup PR will collapse the bespoke 3×-same-path rule in \`_maybe_promote_to_procedural\` into a call to \`scan_for_graduations\` with \`window_days=30, episodic_threshold=3\`. Tracked separately so neither PR blocks the other.

## Pairs with

- soul-protocol [#161](https://github.com/qbtrix/soul-protocol/pull/161) — \`RetrievalTrace\` spec + emission
- pocketpaw [#936](https://github.com/pocketpaw/pocketpaw/pull/936) — sink + HTTP + CLI

## Context

Design doc: paw-enterprise \`docs/enterprise/RETRIEVAL-TRACE.md\` (paw-enterprise PR #67).