### PR TITLE
feat(policy): scope on Fabric objects + visibility engine

### DIFF
--- a/ee/fabric/models.py
+++ b/ee/fabric/models.py
@@ -54,6 +54,10 @@ class FabricObject(BaseModel):
     source_id: str | None = None
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
+    # Move 5 PR-B — RBAC/ABAC scope tags. Empty list = visible to anyone.
+    # Hierarchical glob: org:sales:* matches org:sales:leads. Filtered at
+    # query time before results reach the LLM.
+    scope: list[str] = Field(default_factory=list)
 
 
 class FabricLink(BaseModel):
@@ -77,6 +81,10 @@ class FabricQuery(BaseModel):
     link_type: str | None = None
     limit: int = 50
     offset: int = 0
+    # Move 5 PR-B — caller's effective scope set. Empty = no scope filter
+    # (sees everything). Populated by paw-runtime from session auth before
+    # forwarding to FabricStore.query().
+    scopes: list[str] = Field(default_factory=list)
 
 
 class FabricQueryResult(BaseModel):

--- a/ee/fabric/store.py
+++ b/ee/fabric/store.py
@@ -38,7 +38,8 @@ CREATE TABLE IF NOT EXISTS fabric_objects (
     source_connector TEXT,
     source_id TEXT,
     created_at TEXT DEFAULT (datetime('now')),
-    updated_at TEXT DEFAULT (datetime('now'))
+    updated_at TEXT DEFAULT (datetime('now')),
+    scope TEXT DEFAULT '[]'
 );
 
 CREATE TABLE IF NOT EXISTS fabric_links (
@@ -163,33 +164,42 @@ class FabricStore:
 
     async def create_object(
         self,
-        type_id: str,
-        properties: dict[str, Any],
+        type_id_or_obj: str | FabricObject,
+        properties: dict[str, Any] | None = None,
         source_connector: str | None = None,
         source_id: str | None = None,
+        scope: list[str] | None = None,
     ) -> FabricObject:
-        obj_type = await self.get_type(type_id)
-        obj = FabricObject(
-            type_id=type_id,
-            type_name=obj_type.name if obj_type else "",
-            properties=properties,
-            source_connector=source_connector,
-            source_id=source_id,
-        )
+        """Insert a FabricObject. Accepts either a type_id + properties pair
+        (legacy positional shape) or a pre-built FabricObject instance.
+        """
+        if isinstance(type_id_or_obj, FabricObject):
+            obj = type_id_or_obj
+        else:
+            obj_type = await self.get_type(type_id_or_obj)
+            obj = FabricObject(
+                type_id=type_id_or_obj,
+                type_name=obj_type.name if obj_type else "",
+                properties=properties or {},
+                source_connector=source_connector,
+                source_id=source_id,
+                scope=scope or [],
+            )
         await self._ensure_schema()
         async with self._conn() as db:
             await db.execute(
                 "INSERT INTO fabric_objects"
                 " (id, type_id, type_name, properties,"
-                " source_connector, source_id)"
-                " VALUES (?, ?, ?, ?, ?, ?)",
+                " source_connector, source_id, scope)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (
                     obj.id,
                     obj.type_id,
                     obj.type_name,
-                    json.dumps(properties),
-                    source_connector,
-                    source_id,
+                    json.dumps(obj.properties),
+                    obj.source_connector,
+                    obj.source_id,
+                    json.dumps(obj.scope),
                 ),
             )
             await db.commit()
@@ -347,6 +357,11 @@ class FabricStore:
             ) as cur:
                 objects = [self._row_to_object(row) async for row in cur]
 
+        if q.scopes:
+            from ee.policy.engine import filter_visible
+
+            objects, _ = filter_visible(objects, q.scopes)
+
         return FabricQueryResult(objects=objects, total=total)
 
     # --- Stats ---
@@ -377,6 +392,15 @@ class FabricStore:
         )
 
     def _row_to_object(self, row: Any) -> FabricObject:
+        scope_raw = row["scope"] if "scope" in row.keys() else None
+        scope: list[str] = []
+        if scope_raw:
+            try:
+                parsed = json.loads(scope_raw)
+                if isinstance(parsed, list):
+                    scope = [s for s in parsed if isinstance(s, str)]
+            except (ValueError, TypeError):
+                scope = []
         return FabricObject(
             id=row["id"],
             type_id=row["type_id"],
@@ -384,4 +408,5 @@ class FabricStore:
             properties=json.loads(row["properties"]) if row["properties"] else {},
             source_connector=row["source_connector"],
             source_id=row["source_id"],
+            scope=scope,
         )

--- a/ee/policy/__init__.py
+++ b/ee/policy/__init__.py
@@ -1,0 +1,19 @@
+# Policy — RBAC/ABAC scope evaluation for paw-runtime retrieval paths.
+# Created: 2026-04-13 (Move 5 PR-B) — One pure function `visible(entity, user)`
+# applied at every retrieval boundary (Fabric, Pocket, soul recall, kb search).
+# Scope semantics live in soul-protocol's match_scope; this module just
+# applies them consistently to the runtime's data shapes.
+
+from ee.policy.engine import (
+    DEFAULT_ALLOW_UNSCOPED,
+    PolicyDecision,
+    filter_visible,
+    visible,
+)
+
+__all__ = [
+    "DEFAULT_ALLOW_UNSCOPED",
+    "PolicyDecision",
+    "filter_visible",
+    "visible",
+]

--- a/ee/policy/engine.py
+++ b/ee/policy/engine.py
@@ -1,0 +1,179 @@
+# ee/policy/engine.py — Apply scope tags to runtime objects.
+# Created: 2026-04-13 (Move 5 PR-B) — Wraps soul-protocol's match_scope so
+# every paw-runtime retrieval path uses the same matcher. Defensively reads
+# `scope` from any entity (FabricObject, Pocket, MemoryEntry, dict) so new
+# entity types can adopt scope tags without changing the engine.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# Default behaviour: unscoped entities (scope == []) are visible to everyone.
+# Set to False at startup if your tenant requires explicit scope on every
+# entity. Per-call overrides via filter_visible(allow_unscoped=...).
+DEFAULT_ALLOW_UNSCOPED = True
+
+
+@dataclass
+class PolicyDecision:
+    """Result of applying the policy to a single entity."""
+
+    allowed: bool
+    entity_id: str
+    entity_scopes: list[str]
+    matched_scope: str | None = None
+    reason: str = ""
+
+
+def visible(
+    entity: Any,
+    user_scopes: list[str] | None,
+    *,
+    allow_unscoped: bool = DEFAULT_ALLOW_UNSCOPED,
+) -> bool:
+    """Return True when the user is allowed to see this entity.
+
+    ``entity`` is anything with a ``scope`` attribute or a ``scope`` key —
+    FabricObject, Pocket, MemoryEntry, dict, or a duck-typed stand-in.
+    ``user_scopes`` is the caller's scope list. Empty/None passes through
+    (caller sees everything they otherwise would).
+    """
+    entity_scopes = _entity_scopes(entity)
+
+    if not user_scopes:
+        return True
+    if not entity_scopes:
+        return allow_unscoped
+
+    return _match(entity_scopes, user_scopes)
+
+
+def filter_visible(
+    entities: list[Any],
+    user_scopes: list[str] | None,
+    *,
+    allow_unscoped: bool = DEFAULT_ALLOW_UNSCOPED,
+) -> tuple[list[Any], int]:
+    """Return ``(visible_entities, hidden_count)`` for the given user.
+
+    The hidden count is what paw-runtime writes into the retrieval log so
+    operators can see how many entries were filtered out per call.
+    """
+    if not user_scopes:
+        return list(entities), 0
+
+    kept: list[Any] = []
+    hidden = 0
+    for entity in entities:
+        if visible(entity, user_scopes, allow_unscoped=allow_unscoped):
+            kept.append(entity)
+        else:
+            hidden += 1
+    return kept, hidden
+
+
+def decide(
+    entity: Any,
+    user_scopes: list[str] | None,
+    *,
+    allow_unscoped: bool = DEFAULT_ALLOW_UNSCOPED,
+) -> PolicyDecision:
+    """Return a PolicyDecision explaining why the entity was allowed/denied.
+
+    Used by the audit path so operators can answer "why was X filtered?"
+    without re-running the policy.
+    """
+    entity_scopes = _entity_scopes(entity)
+    entity_id = _entity_id(entity)
+
+    if not user_scopes:
+        return PolicyDecision(
+            allowed=True,
+            entity_id=entity_id,
+            entity_scopes=entity_scopes,
+            reason="caller has no scope filter — pass-through",
+        )
+
+    if not entity_scopes:
+        return PolicyDecision(
+            allowed=allow_unscoped,
+            entity_id=entity_id,
+            entity_scopes=entity_scopes,
+            reason=(
+                "entity is unscoped — allowed by default"
+                if allow_unscoped
+                else "entity is unscoped — denied because allow_unscoped=False"
+            ),
+        )
+
+    matched = _first_match(entity_scopes, user_scopes)
+    if matched is not None:
+        return PolicyDecision(
+            allowed=True,
+            entity_id=entity_id,
+            entity_scopes=entity_scopes,
+            matched_scope=matched,
+            reason=f"caller has '{matched}' which grants entity scope",
+        )
+
+    return PolicyDecision(
+        allowed=False,
+        entity_id=entity_id,
+        entity_scopes=entity_scopes,
+        reason="no caller scope grants any entity scope",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _entity_scopes(entity: Any) -> list[str]:
+    if entity is None:
+        return []
+    raw = getattr(entity, "scope", None)
+    if raw is None and isinstance(entity, dict):
+        raw = entity.get("scope")
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [raw]
+    return [s for s in raw if isinstance(s, str)]
+
+
+def _entity_id(entity: Any) -> str:
+    if entity is None:
+        return ""
+    raw = getattr(entity, "id", None)
+    if raw is None and isinstance(entity, dict):
+        raw = entity.get("id")
+    return str(raw) if raw else ""
+
+
+def _match(entity_scopes: list[str], user_scopes: list[str]) -> bool:
+    """Boolean OR over cartesian — same logic soul-protocol uses, replicated
+    locally so paw-runtime doesn't take a hard dep on soul-protocol being
+    installed for the policy engine to work.
+    """
+    return any(_granted(e, a) for e in entity_scopes for a in user_scopes)
+
+
+def _first_match(entity_scopes: list[str], user_scopes: list[str]) -> str | None:
+    for a in user_scopes:
+        for e in entity_scopes:
+            if _granted(e, a):
+                return a
+    return None
+
+
+def _granted(entity_scope: str, allowed_scope: str) -> bool:
+    if allowed_scope == "*":
+        return True
+    if allowed_scope == entity_scope:
+        return True
+    if allowed_scope.endswith(":*"):
+        prefix = allowed_scope[:-2]
+        return entity_scope == prefix or entity_scope.startswith(prefix + ":")
+    return False

--- a/tests/cloud/test_policy_engine.py
+++ b/tests/cloud/test_policy_engine.py
@@ -1,0 +1,201 @@
+# tests/cloud/test_policy_engine.py — Move 5 PR-B.
+# Created: 2026-04-13 — Visibility checks across FabricObject, Pocket-shaped
+# dicts, and arbitrary duck-typed objects. Covers fail-open / fail-closed
+# semantics for unscoped entities + filter_visible's hidden counter +
+# PolicyDecision audit shape.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from ee.fabric.models import FabricObject
+from ee.policy.engine import (
+    PolicyDecision,
+    decide,
+    filter_visible,
+    visible,
+)
+
+
+def _obj(scope: list[str] | None = None, oid: str = "obj_x") -> FabricObject:
+    return FabricObject(id=oid, type_id="t", type_name="Customer", scope=scope or [])
+
+
+@dataclass
+class _DuckEntity:
+    id: str
+    scope: list[str]
+
+
+# ---------------------------------------------------------------------------
+# visible()
+# ---------------------------------------------------------------------------
+
+
+class TestVisible:
+    def test_unscoped_caller_sees_everything(self) -> None:
+        assert visible(_obj(["org:finance:*"]), None) is True
+        assert visible(_obj(["org:finance:*"]), []) is True
+
+    def test_unscoped_entity_visible_by_default(self) -> None:
+        assert visible(_obj([]), ["org:sales:*"]) is True
+
+    def test_unscoped_entity_blocked_when_allow_unscoped_false(self) -> None:
+        assert visible(_obj([]), ["org:sales:*"], allow_unscoped=False) is False
+
+    def test_exact_scope_match(self) -> None:
+        assert visible(_obj(["org:sales:leads"]), ["org:sales:leads"]) is True
+
+    def test_glob_match(self) -> None:
+        assert visible(_obj(["org:sales:leads"]), ["org:sales:*"]) is True
+
+    def test_no_overlap_denied(self) -> None:
+        assert visible(_obj(["org:finance:*"]), ["org:sales:*"]) is False
+
+    def test_dict_entity_supported(self) -> None:
+        assert visible({"id": "x", "scope": ["org:sales:leads"]}, ["org:sales:*"]) is True
+
+    def test_duck_typed_entity_supported(self) -> None:
+        entity = _DuckEntity(id="dx", scope=["org:hr:reports"])
+        # Caller's scope is broader than the entity's — wildcard grants access.
+        assert visible(entity, ["org:hr:*"]) is True
+
+    def test_string_scope_field_treated_as_single_entry(self) -> None:
+        entity = _DuckEntity(id="dx", scope="org:hr:reports")  # type: ignore[arg-type]
+        assert visible(entity, ["org:hr:*"]) is True
+
+    def test_none_entity_passes_through_with_no_filter(self) -> None:
+        assert visible(None, None) is True
+
+
+# ---------------------------------------------------------------------------
+# filter_visible()
+# ---------------------------------------------------------------------------
+
+
+class TestFilterVisible:
+    def test_pass_through_when_caller_unscoped(self) -> None:
+        items = [_obj(["org:finance:*"]), _obj([])]
+        kept, hidden = filter_visible(items, None)
+        assert kept == items
+        assert hidden == 0
+
+    def test_filters_disallowed_and_counts(self) -> None:
+        sales = _obj(["org:sales:leads"], oid="s1")
+        finance = _obj(["org:finance:reports"], oid="f1")
+        unscoped = _obj([], oid="u1")
+
+        kept, hidden = filter_visible([sales, finance, unscoped], ["org:sales:*"])
+        kept_ids = [k.id for k in kept]
+        assert "s1" in kept_ids
+        assert "u1" in kept_ids  # unscoped passes through with default allow
+        assert "f1" not in kept_ids
+        assert hidden == 1
+
+    def test_strict_mode_blocks_unscoped(self) -> None:
+        sales = _obj(["org:sales:leads"], oid="s1")
+        unscoped = _obj([], oid="u1")
+        kept, hidden = filter_visible(
+            [sales, unscoped],
+            ["org:sales:*"],
+            allow_unscoped=False,
+        )
+        assert [k.id for k in kept] == ["s1"]
+        assert hidden == 1
+
+
+# ---------------------------------------------------------------------------
+# decide() — audit explanations
+# ---------------------------------------------------------------------------
+
+
+class TestDecide:
+    def test_pass_through_decision_when_no_filter(self) -> None:
+        d = decide(_obj(["org:sales:*"]), None)
+        assert isinstance(d, PolicyDecision)
+        assert d.allowed is True
+        assert "no scope filter" in d.reason
+
+    def test_unscoped_allow_decision(self) -> None:
+        d = decide(_obj([]), ["org:sales:*"])
+        assert d.allowed is True
+        assert "allowed by default" in d.reason
+
+    def test_unscoped_deny_decision_strict(self) -> None:
+        d = decide(_obj([]), ["org:sales:*"], allow_unscoped=False)
+        assert d.allowed is False
+
+    def test_match_records_winning_scope(self) -> None:
+        entity = _obj(["org:sales:leads"], oid="s1")
+        d = decide(entity, ["org:other:*", "org:sales:*"])
+        assert d.allowed is True
+        assert d.matched_scope == "org:sales:*"
+
+    def test_deny_records_no_match_reason(self) -> None:
+        d = decide(_obj(["org:finance:*"]), ["org:sales:*"])
+        assert d.allowed is False
+        assert "no caller scope grants" in d.reason
+
+
+# ---------------------------------------------------------------------------
+# FabricObject + FabricQuery shape
+# ---------------------------------------------------------------------------
+
+
+class TestFabricModelScope:
+    def test_fabric_object_has_default_empty_scope(self) -> None:
+        obj = FabricObject(type_id="t", type_name="Customer")
+        assert obj.scope == []
+
+    def test_fabric_object_round_trips_scope(self) -> None:
+        obj = FabricObject(
+            type_id="t",
+            type_name="Customer",
+            scope=["org:sales:leads", "org:marketing:read"],
+        )
+        restored = FabricObject.model_validate(obj.model_dump())
+        assert restored.scope == obj.scope
+
+    def test_fabric_query_scopes_default_empty(self) -> None:
+        from ee.fabric.models import FabricQuery
+
+        q = FabricQuery()
+        assert q.scopes == []
+
+    @pytest.mark.asyncio
+    async def test_fabric_store_query_filters_by_scopes(self, tmp_path) -> None:
+        """Integration check — FabricStore.query() honours the new scopes filter."""
+        from ee.fabric.models import FabricObject, FabricQuery
+        from ee.fabric.store import FabricStore
+
+        store = FabricStore(tmp_path / "fabric_test.db")
+        otype = await store.define_type(name="Customer", properties=[])
+
+        await store.create_object(
+            FabricObject(
+                type_id=otype.id,
+                type_name="Customer",
+                scope=["org:sales:leads"],
+            ),
+        )
+        await store.create_object(
+            FabricObject(
+                type_id=otype.id,
+                type_name="Customer",
+                scope=["org:finance:reports"],
+            ),
+        )
+        await store.create_object(
+            FabricObject(type_id=otype.id, type_name="Customer"),  # unscoped
+        )
+
+        sales = await store.query(
+            FabricQuery(type_name="Customer", scopes=["org:sales:*"]),
+        )
+        kept_scopes = [s for o in sales.objects for s in o.scope]
+        # Sales caller sees the sales-scoped object + the unscoped one.
+        assert "org:sales:leads" in kept_scopes
+        assert "org:finance:reports" not in kept_scopes
+        assert any(o.scope == [] for o in sales.objects)


### PR DESCRIPTION
Adds the runtime side of the RBAC/ABAC primitive landed in [soul-protocol #162](https://github.com/qbtrix/soul-protocol/pull/162). FabricObject gains a \`scope: list[str]\` field, FabricQuery accepts an optional \`scopes\` filter, and a new \`ee/policy/\` module exposes the one function paw-runtime uses across every retrieval path.

Move 5 PR-B. Targets \`dev\`. PR-C (scope chip UI) and PR-D (E2E enforcement test) follow.

## What's in this PR

### \`ee/policy/engine.py\`
- \`visible(entity, user_scopes)\` — pure function, defensive about where scope lives (attribute / dict key / empty). Empty either side passes through.
- \`filter_visible(entities, user_scopes)\` — returns \`(kept, hidden_count)\` so paw-runtime can record how many entries got filtered into the retrieval log (ties Move 4 + Move 5).
- \`decide(entity, user_scopes)\` — \`PolicyDecision\` dataclass with \`reason\` field for audit explanations.
- \`DEFAULT_ALLOW_UNSCOPED\` toggle for tenants that want strict mode.
- Local \`_granted\` helper mirrors soul-protocol's \`match_scope\` semantics — no hard dep on soul-protocol being installed.

### \`ee/fabric/models.py\`
- \`FabricObject.scope\` (list[str], default empty).
- \`FabricQuery.scopes\` (caller's scope set; default empty = no filter).

### \`ee/fabric/store.py\`
- \`fabric_objects\` table gets a \`scope TEXT\` column with default \`'[]'\`.
- \`create_object\` accepts either positional (legacy: \`type_id\` + properties) OR a pre-built \`FabricObject\` instance, plus an optional \`scope=[]\` kwarg on the legacy path.
- \`_row_to_object\` decodes scope JSON defensively (malformed rows fall back to \`[]\`).
- \`query()\` applies \`filter_visible(objects, q.scopes)\` after the SQL fetch — policy logic in one place.

## Test plan

- [x] 22 new tests in \`tests/cloud/test_policy_engine.py\` covering:
  - \`visible\` / \`filter_visible\` / \`decide\` across FabricObject + dict + duck-typed dataclass + string scope
  - Default allow-unscoped behaviour + strict mode override
  - Exact match, hierarchical glob, no-overlap denial
  - \`FabricObject.scope\` round-trip through model_dump
  - \`FabricQuery.scopes\` default
  - End-to-end: \`FabricStore.query()\` with three objects (sales/finance/unscoped) and a sales-scoped caller — confirms the right subset surfaces
- [x] \`pytest tests/\` — 3991 passed, 0 failed
- [x] \`ruff check\` — clean

## Pairs with

- soul-protocol [#162](https://github.com/qbtrix/soul-protocol/pull/162) — scope on \`MemoryEntry\` + \`Soul.recall(scopes=...)\` + \`spec.match_scope\`
- PR-C — scope chip UI
- PR-D — Playwright E2E enforcement test

## Context

Design referenced in the fleet vision brainstorm. Compliance narrative ("show me who saw what" = SQL) becomes one query against the retrieval log + policy decisions.