### PR TITLE
feat(connectors): IngestAdapter alias + IngestACL for source-side scope inheritance

### DIFF
--- a/src/pocketpaw/connectors/__init__.py
+++ b/src/pocketpaw/connectors/__init__.py
@@ -7,6 +7,8 @@ from pocketpaw.connectors.protocol import (
     ActionSchema,
     ConnectionResult,
     ConnectorProtocol,
+    IngestACL,
+    IngestAdapter,
     SyncResult,
 )
 from pocketpaw.connectors.registry import ConnectorRegistry
@@ -16,6 +18,8 @@ __all__ = [
     "ConnectionResult",
     "ActionSchema",
     "ActionResult",
+    "IngestACL",
+    "IngestAdapter",
     "SyncResult",
     "ConnectorRegistry",
 ]

--- a/src/pocketpaw/connectors/protocol.py
+++ b/src/pocketpaw/connectors/protocol.py
@@ -1,5 +1,10 @@
 # ConnectorProtocol — interface for all data source adapters.
 # Created: 2026-03-27 — Protocol-based, async, adapter-agnostic.
+# Updated: 2026-04-13 (Move 7 PR-A) — Added IngestACL + IngestAdapter
+#   alias so the ingest side of the protocol carries source-side ACLs
+#   into Fabric. Adapters that emit documents tagged with inherited
+#   scope keep org permissions intact end-to-end (a private Slack
+#   channel's messages stay private inside Single Brain).
 
 from __future__ import annotations
 
@@ -70,6 +75,29 @@ class SyncResult:
     duration_ms: float = 0
 
 
+@dataclass
+class IngestACL:
+    """Source-side access control list inherited into Single Brain.
+
+    When an adapter pulls a document from a tenant system that already has
+    ACLs (a private Slack channel, a HubSpot deal restricted to one team,
+    a Notion page shared with a sub-list), the adapter reports those ACLs
+    here so paw-runtime tags the resulting Fabric object with the matching
+    scope tags before it lands. The brain inherits the source's permissions
+    instead of flattening them to "everyone with access to the connector."
+
+    Empty fields are intentional defaults — most ingests are global to the
+    pocket and need no per-record scoping. When ``scope`` is non-empty,
+    the runtime applies it as the Fabric object's ``scope`` list verbatim;
+    when ``visibility`` is set, callers can also surface a UI label.
+    """
+
+    scope: list[str] = field(default_factory=list)
+    visibility: str = ""  # "public" | "private" | "members" | "owner"
+    source_principal: str = ""  # The original ACL holder, e.g. "channel:#founders"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
 class ConnectorProtocol(Protocol):
     """Interface for all connector adapters.
 
@@ -111,4 +139,28 @@ class ConnectorProtocol(Protocol):
 
     async def schema(self) -> dict[str, Any]:
         """Return data schema for pocket.db table mapping."""
+        ...
+
+
+class IngestAdapter(ConnectorProtocol, Protocol):
+    """A connector that pulls data INTO Paw OS (vs sending it out).
+
+    Same surface as :class:`ConnectorProtocol` plus :meth:`permissions`,
+    which reports the ACLs of records the adapter can ingest. Existing
+    REST + DB + file connectors satisfy this protocol once they implement
+    permissions(); the alias makes the intent explicit at type-check time
+    and lets the fleet template runtime (PR-B) discover ACL-aware
+    connectors without sniffing for the method.
+    """
+
+    async def permissions(
+        self, pocket_id: str, record_id: str | None = None
+    ) -> IngestACL:
+        """Report source-side ACLs for the next ingest.
+
+        ``record_id`` may be ``None`` for connector-wide defaults (e.g. a
+        Stripe-account-wide read scope). When present, returns the ACLs
+        for one specific record so per-document scoping works for systems
+        like Slack channels or HubSpot deal-team membership.
+        """
         ...

--- a/src/pocketpaw/connectors/protocol.py
+++ b/src/pocketpaw/connectors/protocol.py
@@ -153,9 +153,7 @@ class IngestAdapter(ConnectorProtocol, Protocol):
     connectors without sniffing for the method.
     """
 
-    async def permissions(
-        self, pocket_id: str, record_id: str | None = None
-    ) -> IngestACL:
+    async def permissions(self, pocket_id: str, record_id: str | None = None) -> IngestACL:
         """Report source-side ACLs for the next ingest.
 
         ``record_id`` may be ``None`` for connector-wide defaults (e.g. a

--- a/tests/test_ingest_adapter.py
+++ b/tests/test_ingest_adapter.py
@@ -24,7 +24,6 @@ from pocketpaw.connectors import (
 )
 from pocketpaw.connectors.protocol import ConnectorStatus
 
-
 # ---------------------------------------------------------------------------
 # IngestACL dataclass
 # ---------------------------------------------------------------------------

--- a/tests/test_ingest_adapter.py
+++ b/tests/test_ingest_adapter.py
@@ -89,9 +89,7 @@ class FakeIngestAdapter:
     async def schema(self) -> dict[str, Any]:
         return {"messages": {"text": "string"}}
 
-    async def permissions(
-        self, pocket_id: str, record_id: str | None = None
-    ) -> IngestACL:
+    async def permissions(self, pocket_id: str, record_id: str | None = None) -> IngestACL:
         self.permissions_calls.append((pocket_id, record_id))
         if record_id and record_id.startswith("private_"):
             return IngestACL(

--- a/tests/test_ingest_adapter.py
+++ b/tests/test_ingest_adapter.py
@@ -1,0 +1,191 @@
+"""Tests for the IngestAdapter alias + IngestACL dataclass (Move 7 PR-A).
+
+Created: 2026-04-13 — Wire-shape tests + a duck-typed adapter that
+implements both ConnectorProtocol and the new permissions() method.
+The fleet template runtime (PR-B) discovers ACL-aware connectors by
+checking for the permissions() method, which this test pins as the
+contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pocketpaw.connectors import (
+    ActionResult,
+    ActionSchema,
+    ConnectionResult,
+    ConnectorProtocol,
+    IngestACL,
+    IngestAdapter,
+    SyncResult,
+)
+from pocketpaw.connectors.protocol import ConnectorStatus
+
+
+# ---------------------------------------------------------------------------
+# IngestACL dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestIngestACL:
+    def test_defaults_are_empty(self) -> None:
+        acl = IngestACL()
+        assert acl.scope == []
+        assert acl.visibility == ""
+        assert acl.source_principal == ""
+        assert acl.metadata == {}
+
+    def test_carries_scope_list_into_fabric(self) -> None:
+        acl = IngestACL(
+            scope=["org:sales:leads"],
+            visibility="members",
+            source_principal="hubspot:deal-team:42",
+        )
+        assert acl.scope == ["org:sales:leads"]
+        assert acl.visibility == "members"
+        assert acl.source_principal == "hubspot:deal-team:42"
+
+    def test_metadata_is_open_dict(self) -> None:
+        acl = IngestACL(metadata={"channel_type": "private", "guests_excluded": True})
+        assert acl.metadata["channel_type"] == "private"
+        assert acl.metadata["guests_excluded"] is True
+
+
+# ---------------------------------------------------------------------------
+# IngestAdapter contract — duck-typed implementation
+# ---------------------------------------------------------------------------
+
+
+class FakeIngestAdapter:
+    """Reference implementation that satisfies IngestAdapter at runtime."""
+
+    name = "fake_slack"
+    display_name = "Fake Slack"
+
+    def __init__(self) -> None:
+        self.permissions_calls: list[tuple[str, str | None]] = []
+
+    async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        return ConnectionResult(
+            success=True,
+            connector_name=self.name,
+            status=ConnectorStatus.CONNECTED,
+        )
+
+    async def disconnect(self, pocket_id: str) -> bool:
+        return True
+
+    async def actions(self) -> list[ActionSchema]:
+        return [ActionSchema(name="list_messages", description="List channel messages")]
+
+    async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
+        return ActionResult(success=True, data={"messages": []})
+
+    async def sync(self, pocket_id: str) -> SyncResult:
+        return SyncResult(success=True, connector_name=self.name)
+
+    async def schema(self) -> dict[str, Any]:
+        return {"messages": {"text": "string"}}
+
+    async def permissions(
+        self, pocket_id: str, record_id: str | None = None
+    ) -> IngestACL:
+        self.permissions_calls.append((pocket_id, record_id))
+        if record_id and record_id.startswith("private_"):
+            return IngestACL(
+                scope=["org:engineering:eyes-only"],
+                visibility="private",
+                source_principal=f"slack:channel:{record_id}",
+            )
+        return IngestACL(scope=["org:public:*"], visibility="public")
+
+
+class TestIngestAdapterContract:
+    def test_fake_adapter_satisfies_connector_protocol(self) -> None:
+        adapter = FakeIngestAdapter()
+        # Runtime isinstance check on Protocol with @runtime_checkable would
+        # work, but ConnectorProtocol isn't decorated. Structural check via
+        # attribute presence is the documented pattern in the codebase.
+        assert hasattr(adapter, "connect")
+        assert hasattr(adapter, "execute")
+        assert hasattr(adapter, "sync")
+        assert hasattr(adapter, "schema")
+
+    def test_fake_adapter_exposes_permissions_method(self) -> None:
+        adapter = FakeIngestAdapter()
+        assert callable(getattr(adapter, "permissions", None))
+
+    @pytest.mark.asyncio
+    async def test_permissions_default_returns_public_scope(self) -> None:
+        adapter = FakeIngestAdapter()
+        acl = await adapter.permissions("pocket-1")
+        assert "org:public:*" in acl.scope
+        assert acl.visibility == "public"
+
+    @pytest.mark.asyncio
+    async def test_permissions_per_record_returns_private_scope(self) -> None:
+        adapter = FakeIngestAdapter()
+        acl = await adapter.permissions("pocket-1", record_id="private_founders")
+        assert "org:engineering:eyes-only" in acl.scope
+        assert acl.visibility == "private"
+        assert "private_founders" in acl.source_principal
+
+    @pytest.mark.asyncio
+    async def test_permissions_call_records_pocket_and_record_args(self) -> None:
+        adapter = FakeIngestAdapter()
+        await adapter.permissions("pocket-1", record_id="msg_42")
+        await adapter.permissions("pocket-2")
+        assert adapter.permissions_calls == [("pocket-1", "msg_42"), ("pocket-2", None)]
+
+
+# ---------------------------------------------------------------------------
+# Public exports
+# ---------------------------------------------------------------------------
+
+
+class TestPublicExports:
+    def test_ingest_adapter_re_exported(self) -> None:
+        from pocketpaw.connectors import IngestAdapter as RexportedAdapter
+        from pocketpaw.connectors.protocol import IngestAdapter as DirectAdapter
+
+        assert RexportedAdapter is DirectAdapter
+
+    def test_ingest_acl_re_exported(self) -> None:
+        from pocketpaw.connectors import IngestACL as RexportedACL
+        from pocketpaw.connectors.protocol import IngestACL as DirectACL
+
+        assert RexportedACL is DirectACL
+
+
+# ---------------------------------------------------------------------------
+# Static check — IngestAdapter type alias keeps ConnectorProtocol surface
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_adapter_protocol_extends_connector_protocol() -> None:
+    """IngestAdapter should not lose any ConnectorProtocol methods."""
+    connector_methods = {
+        "connect",
+        "disconnect",
+        "actions",
+        "execute",
+        "sync",
+        "schema",
+    }
+    ingest_methods = {
+        "connect",
+        "disconnect",
+        "actions",
+        "execute",
+        "sync",
+        "schema",
+        "permissions",
+    }
+    # Inspect the Protocol classes to be sure.
+    for method in connector_methods:
+        assert hasattr(ConnectorProtocol, method)
+    for method in ingest_methods:
+        assert hasattr(IngestAdapter, method)


### PR DESCRIPTION
Adds the lean ingest-side primitive sketched in the fleet platform brainstorm. \`ConnectorProtocol\` stays as-is for the existing 9 adapters; a new \`IngestAdapter\` Protocol extends it with one method (\`permissions\`) that reports source-side ACLs so paw-runtime tags ingested Fabric objects with the inherited scope before they land.

The result: a private Slack channel's messages stay private inside Single Brain without flattening permissions to "anyone with the connector."

Move 7 PR-A. PR-B adds the fleet template runtime that discovers \`IngestAdapter\` implementations and wires the install flow.

## What's in this PR

### \`src/pocketpaw/connectors/protocol.py\`
- \`IngestACL\` dataclass — \`scope\` (list[str]), \`visibility\`, \`source_principal\`, open \`metadata\` dict. Empty defaults so legacy adapters that don't care about per-record scope are unaffected.
- \`IngestAdapter\` Protocol — extends \`ConnectorProtocol\` with a single \`permissions(pocket_id, record_id=None) -> IngestACL\` method.
  - \`record_id=None\` → connector-wide defaults (a Stripe-account-wide read scope).
  - Named \`record_id\` → per-document ACLs for systems like Slack channels or HubSpot deal-team membership.

### \`src/pocketpaw/connectors/__init__.py\`
- Re-exports \`IngestACL\` + \`IngestAdapter\` alongside the existing public surface.

## Test plan

- [x] 11 new tests in \`tests/test_ingest_adapter.py\`:
  - \`IngestACL\` defaults, scope passthrough, open metadata
  - Reference duck-typed \`FakeIngestAdapter\` implementing both protocols
  - Default \`permissions\` returns public scope when \`record_id\` is None
  - Per-record \`permissions\` returns private scope for \`private_*\` ids
  - \`permissions\` records the call args (pocket_id + record_id) so PR-B's installer can verify ACL inheritance
  - Public re-exports point at the same objects
  - Static check: \`IngestAdapter\` exposes every \`ConnectorProtocol\` method + \`permissions\`
- [x] \`pytest\` — passing
- [x] \`ruff check\` — clean

## Pairs with

- pocketpaw [#938](https://github.com/pocketpaw/pocketpaw/pull/938) — \`ee/policy\` engine. \`IngestACL.scope\` feeds straight into \`FabricObject.scope\`, then \`ee/policy.filter_visible\` applies \`match_scope\` at retrieval time. End-to-end: a private Slack channel ingested by a SlackIngestAdapter lands tagged \`org:eng:eyes-only\` and only callers granted that scope ever see those messages.

## Follow-ups

- Update existing 9 connectors to implement \`permissions()\` — non-breaking; defaults to "no per-record ACL" if missing.
- PR-B (next): fleet template runtime + paw fleet install CLI.
- PR-C: Install Fleet UI flow.