### PR TITLE
feat(widget): graduation engine for UI elements

### DIFF
--- a/ee/widget_graduation/__init__.py
+++ b/ee/widget_graduation/__init__.py
@@ -1,0 +1,23 @@
+# Widget Graduation — same primitive as memory graduation, applied to widgets.
+# Created: 2026-04-13 (Move 8 PR-A) — Widgets a user opens often get pinned;
+# widgets ignored for a window get archived. Reads from the widget interaction
+# log and emits WidgetDecision objects (analogous to GraduationDecision in
+# ee/graduation). The captain's "intelligent UI" thesis materialises here:
+# the same memory-tier promotion mechanism, applied to UI elements.
+
+from ee.widget_graduation.log import WidgetInteractionLog, get_widget_log
+from ee.widget_graduation.models import (
+    WidgetDecision,
+    WidgetInteraction,
+    WidgetReport,
+)
+from ee.widget_graduation.policy import scan_for_widget_decisions
+
+__all__ = [
+    "WidgetDecision",
+    "WidgetInteraction",
+    "WidgetInteractionLog",
+    "WidgetReport",
+    "get_widget_log",
+    "scan_for_widget_decisions",
+]

--- a/ee/widget_graduation/log.py
+++ b/ee/widget_graduation/log.py
@@ -1,0 +1,106 @@
+# ee/widget_graduation/log.py — Append-only JSONL widget interaction log.
+# Created: 2026-04-13 (Move 8 PR-A) — Same JSONL pattern as ee/retrieval/log,
+# scoped to widget events. Lives at ~/.pocketpaw/widget-interactions.jsonl
+# (override via POCKETPAW_WIDGET_LOG). Read by the graduation policy.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections.abc import AsyncIterator
+from datetime import datetime
+from pathlib import Path
+
+from ee.widget_graduation.models import WidgetInteraction
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PATH = Path.home() / ".pocketpaw" / "widget-interactions.jsonl"
+
+
+class WidgetInteractionLog:
+    """Async-safe append + streaming read for widget interactions."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self._path = Path(path) if path else DEFAULT_PATH
+        self._lock = asyncio.Lock()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    async def append(self, interaction: WidgetInteraction) -> WidgetInteraction:
+        line = interaction.model_dump_json() + "\n"
+        async with self._lock:
+            await asyncio.to_thread(self._write, line)
+        return interaction
+
+    def _write(self, line: str) -> None:
+        with self._path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+
+    async def read(
+        self,
+        *,
+        widget_id: str | None = None,
+        pocket_id: str | None = None,
+        actor: str | None = None,
+        since: datetime | None = None,
+        limit: int = 1000,
+    ) -> list[WidgetInteraction]:
+        if not self._path.exists():
+            return []
+        rows: list[WidgetInteraction] = []
+        async for entry in self._stream():
+            if widget_id and entry.widget_id != widget_id:
+                continue
+            if pocket_id and entry.pocket_id != pocket_id:
+                continue
+            if actor and entry.actor != actor:
+                continue
+            if since and entry.timestamp < since:
+                continue
+            rows.append(entry)
+        rows.sort(key=lambda r: r.timestamp, reverse=True)
+        return rows[:limit]
+
+    async def clear(self) -> None:
+        async with self._lock:
+            if self._path.exists():
+                await asyncio.to_thread(self._path.unlink)
+
+    async def _stream(self) -> AsyncIterator[WidgetInteraction]:
+        lines: list[str] = await asyncio.to_thread(self._read_lines)
+        for raw in lines:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                yield WidgetInteraction.model_validate_json(raw)
+            except (ValueError, TypeError):
+                logger.debug("Skipping malformed widget log line")
+                continue
+
+    def _read_lines(self) -> list[str]:
+        with self._path.open("r", encoding="utf-8") as fh:
+            return fh.readlines()
+
+
+_singleton: WidgetInteractionLog | None = None
+
+
+def get_widget_log() -> WidgetInteractionLog:
+    """Process-wide singleton. Override path via POCKETPAW_WIDGET_LOG."""
+    global _singleton
+    if _singleton is None:
+        override = os.environ.get("POCKETPAW_WIDGET_LOG")
+        _singleton = WidgetInteractionLog(path=override or None)
+    return _singleton
+
+
+def reset_widget_log_for_tests() -> None:
+    global _singleton
+    _singleton = None

--- a/ee/widget_graduation/log.py
+++ b/ee/widget_graduation/log.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
 from collections.abc import AsyncIterator

--- a/ee/widget_graduation/models.py
+++ b/ee/widget_graduation/models.py
@@ -1,0 +1,53 @@
+# ee/widget_graduation/models.py — Widget interaction + graduation models.
+# Created: 2026-04-13 (Move 8 PR-A) — Mirrors the shape of ee/graduation
+# but keyed on widget IDs instead of memory IDs. The same scan + threshold
+# pattern applies; the UI consumes WidgetDecision to pin / fade widgets.
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+WidgetAction = Literal["open", "edit", "click", "dismiss", "remove"]
+WidgetVerdict = Literal["pin", "fade", "archive"]
+
+
+class WidgetInteraction(BaseModel):
+    """One user interaction with a widget. Append-only log entry."""
+
+    widget_id: str
+    pocket_id: str
+    actor: str
+    action: WidgetAction
+    timestamp: datetime = Field(default_factory=datetime.now)
+    metadata: dict = Field(default_factory=dict)
+
+
+class WidgetDecision(BaseModel):
+    """A proposed UI mutation produced by the graduation policy.
+
+    The UI applies it (or shows it as a suggestion in the chat panel
+    depending on operator preference). Decisions are advisory — never
+    write directly to the pocket spec without going through the
+    existing widget mutation flow.
+    """
+
+    widget_id: str
+    pocket_id: str
+    verdict: WidgetVerdict
+    interactions_in_window: int
+    window_days: int
+    reason: str = ""
+    last_interaction: datetime | None = None
+
+
+class WidgetReport(BaseModel):
+    """Output of one graduation scan."""
+
+    decisions: list[WidgetDecision] = Field(default_factory=list)
+    scanned_interactions: int = 0
+    window_days: int = 30
+    generated_at: datetime = Field(default_factory=datetime.now)

--- a/ee/widget_graduation/models.py
+++ b/ee/widget_graduation/models.py
@@ -10,7 +10,6 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-
 WidgetAction = Literal["open", "edit", "click", "dismiss", "remove"]
 WidgetVerdict = Literal["pin", "fade", "archive"]
 

--- a/ee/widget_graduation/policy.py
+++ b/ee/widget_graduation/policy.py
@@ -1,0 +1,113 @@
+# ee/widget_graduation/policy.py — Promotion + demotion thresholds for widgets.
+# Created: 2026-04-13 (Move 8 PR-A) — Mirrors ee/graduation/policy. Reads the
+# widget interaction log and emits WidgetDecision objects when usage crosses
+# the configured thresholds.
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from datetime import datetime, timedelta
+
+from ee.widget_graduation.log import WidgetInteractionLog
+from ee.widget_graduation.models import WidgetDecision, WidgetReport
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_WINDOW_DAYS = 30
+DEFAULT_PIN_THRESHOLD = 10        # Interactions in window → pin
+DEFAULT_FADE_THRESHOLD = 0        # Zero interactions in window → fade
+DEFAULT_ARCHIVE_DAYS = 60         # Untouched longer than this → archive
+_PROMOTING_ACTIONS = {"open", "edit", "click"}
+
+
+async def scan_for_widget_decisions(
+    log: WidgetInteractionLog,
+    *,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    pin_threshold: int = DEFAULT_PIN_THRESHOLD,
+    archive_days: int = DEFAULT_ARCHIVE_DAYS,
+    pocket_id: str | None = None,
+    actor: str | None = None,
+) -> WidgetReport:
+    """Scan the widget log and propose pin / fade / archive decisions.
+
+    Pin: widget hit ``pin_threshold`` promoting interactions in the window.
+    Fade: widget seen at least once historically but zero promoting
+        interactions in the window.
+    Archive: widget last touched more than ``archive_days`` ago.
+    """
+    since = datetime.now() - timedelta(days=window_days)
+    long_ago = datetime.now() - timedelta(days=archive_days)
+
+    promoting_in_window: Counter[tuple[str, str]] = Counter()
+    last_seen: dict[tuple[str, str], datetime] = {}
+
+    # Pull the long-window history so archive logic sees old entries too.
+    archive_window_start = datetime.now() - timedelta(days=archive_days * 2)
+    history = await log.read(
+        pocket_id=pocket_id,
+        actor=actor,
+        since=archive_window_start,
+        limit=100_000,
+    )
+
+    for entry in history:
+        key = (entry.widget_id, entry.pocket_id)
+        last_seen[key] = max(last_seen.get(key, entry.timestamp), entry.timestamp)
+        if entry.action in _PROMOTING_ACTIONS and entry.timestamp >= since:
+            promoting_in_window[key] += 1
+
+    decisions: list[WidgetDecision] = []
+    for key, count in promoting_in_window.items():
+        if count >= pin_threshold:
+            decisions.append(
+                WidgetDecision(
+                    widget_id=key[0],
+                    pocket_id=key[1],
+                    verdict="pin",
+                    interactions_in_window=count,
+                    window_days=window_days,
+                    last_interaction=last_seen.get(key),
+                    reason=(
+                        f"Opened/edited/clicked {count}× in last {window_days} days "
+                        f"(threshold {pin_threshold})."
+                    ),
+                ),
+            )
+
+    # Fade: widgets present in history but with no promoting interactions in window.
+    for key, seen in last_seen.items():
+        if key in promoting_in_window:
+            continue
+        if seen >= long_ago:
+            decisions.append(
+                WidgetDecision(
+                    widget_id=key[0],
+                    pocket_id=key[1],
+                    verdict="fade",
+                    interactions_in_window=0,
+                    window_days=window_days,
+                    last_interaction=seen,
+                    reason="No promoting interactions in window.",
+                ),
+            )
+        else:
+            decisions.append(
+                WidgetDecision(
+                    widget_id=key[0],
+                    pocket_id=key[1],
+                    verdict="archive",
+                    interactions_in_window=0,
+                    window_days=window_days,
+                    last_interaction=seen,
+                    reason=f"Untouched for over {archive_days} days.",
+                ),
+            )
+
+    return WidgetReport(
+        decisions=decisions,
+        scanned_interactions=len(history),
+        window_days=window_days,
+    )

--- a/tests/cloud/test_widget_graduation.py
+++ b/tests/cloud/test_widget_graduation.py
@@ -1,0 +1,191 @@
+# tests/cloud/test_widget_graduation.py — Move 8 PR-A.
+# Created: 2026-04-13 — Append + read for the widget interaction log,
+# pin/fade/archive verdict logic, threshold semantics, window boundaries.
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from ee.widget_graduation.log import WidgetInteractionLog, reset_widget_log_for_tests
+from ee.widget_graduation.models import WidgetInteraction
+from ee.widget_graduation.policy import (
+    DEFAULT_ARCHIVE_DAYS,
+    DEFAULT_PIN_THRESHOLD,
+    scan_for_widget_decisions,
+)
+
+
+def _interaction(
+    widget_id: str = "w1",
+    pocket_id: str = "pocket-1",
+    actor: str = "user:priya",
+    action: str = "open",
+    timestamp: datetime | None = None,
+) -> WidgetInteraction:
+    return WidgetInteraction(
+        widget_id=widget_id,
+        pocket_id=pocket_id,
+        actor=actor,
+        action=action,  # type: ignore[arg-type]
+        timestamp=timestamp or datetime.now(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_widget_log_for_tests()
+    yield
+    reset_widget_log_for_tests()
+
+
+@pytest.fixture
+def log(tmp_path: Path) -> WidgetInteractionLog:
+    return WidgetInteractionLog(path=tmp_path / "widget_test.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# Log
+# ---------------------------------------------------------------------------
+
+
+class TestLog:
+    @pytest.mark.asyncio
+    async def test_append_writes_jsonl_line(self, log: WidgetInteractionLog) -> None:
+        await log.append(_interaction())
+        rows = await log.read()
+        assert len(rows) == 1
+        assert rows[0].widget_id == "w1"
+
+    @pytest.mark.asyncio
+    async def test_filter_by_pocket(self, log: WidgetInteractionLog) -> None:
+        await log.append(_interaction(pocket_id="p1"))
+        await log.append(_interaction(pocket_id="p2"))
+        rows = await log.read(pocket_id="p1")
+        assert len(rows) == 1
+        assert rows[0].pocket_id == "p1"
+
+    @pytest.mark.asyncio
+    async def test_filter_by_widget_id(self, log: WidgetInteractionLog) -> None:
+        await log.append(_interaction(widget_id="w1"))
+        await log.append(_interaction(widget_id="w2"))
+        rows = await log.read(widget_id="w1")
+        assert len(rows) == 1
+        assert rows[0].widget_id == "w1"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_append_preserves_lines(self, log: WidgetInteractionLog) -> None:
+        await asyncio.gather(*(log.append(_interaction(actor=f"u{i}")) for i in range(15)))
+        rows = await log.read()
+        assert len(rows) == 15
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_empty(self, log: WidgetInteractionLog) -> None:
+        rows = await log.read()
+        assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Policy: pin
+# ---------------------------------------------------------------------------
+
+
+class TestPin:
+    @pytest.mark.asyncio
+    async def test_widget_with_threshold_interactions_gets_pinned(
+        self, log: WidgetInteractionLog
+    ) -> None:
+        for _ in range(DEFAULT_PIN_THRESHOLD):
+            await log.append(_interaction(action="open"))
+        report = await scan_for_widget_decisions(log)
+        pinned = [d for d in report.decisions if d.verdict == "pin"]
+        assert len(pinned) == 1
+        assert pinned[0].widget_id == "w1"
+        assert pinned[0].interactions_in_window == DEFAULT_PIN_THRESHOLD
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_does_not_pin(self, log: WidgetInteractionLog) -> None:
+        for _ in range(DEFAULT_PIN_THRESHOLD - 1):
+            await log.append(_interaction(action="click"))
+        report = await scan_for_widget_decisions(log)
+        assert all(d.verdict != "pin" for d in report.decisions)
+
+    @pytest.mark.asyncio
+    async def test_only_promoting_actions_count(self, log: WidgetInteractionLog) -> None:
+        # 'dismiss' and 'remove' are not promoting actions.
+        for _ in range(DEFAULT_PIN_THRESHOLD):
+            await log.append(_interaction(action="dismiss"))
+        report = await scan_for_widget_decisions(log)
+        assert all(d.verdict != "pin" for d in report.decisions)
+
+
+# ---------------------------------------------------------------------------
+# Policy: fade
+# ---------------------------------------------------------------------------
+
+
+class TestFade:
+    @pytest.mark.asyncio
+    async def test_recent_history_with_no_in_window_use_gets_faded(
+        self, log: WidgetInteractionLog
+    ) -> None:
+        # Last seen ~10 days ago — within archive window, but no promoting
+        # interactions in the 30-day pin window.
+        ten_days_ago = datetime.now() - timedelta(days=40)
+        await log.append(_interaction(action="open", timestamp=ten_days_ago))
+        report = await scan_for_widget_decisions(log)
+        faded = [d for d in report.decisions if d.verdict == "fade"]
+        assert len(faded) == 1
+
+
+# ---------------------------------------------------------------------------
+# Policy: archive
+# ---------------------------------------------------------------------------
+
+
+class TestArchive:
+    @pytest.mark.asyncio
+    async def test_old_inactive_widget_archived(self, log: WidgetInteractionLog) -> None:
+        old = datetime.now() - timedelta(days=DEFAULT_ARCHIVE_DAYS + 30)
+        await log.append(_interaction(action="open", timestamp=old))
+        report = await scan_for_widget_decisions(log)
+        archived = [d for d in report.decisions if d.verdict == "archive"]
+        assert len(archived) == 1
+        assert "Untouched" in archived[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+
+class TestFilters:
+    @pytest.mark.asyncio
+    async def test_pocket_filter_isolates_decisions(
+        self, log: WidgetInteractionLog
+    ) -> None:
+        for _ in range(DEFAULT_PIN_THRESHOLD):
+            await log.append(_interaction(action="open", pocket_id="p1"))
+        for _ in range(DEFAULT_PIN_THRESHOLD):
+            await log.append(_interaction(action="open", pocket_id="p2", widget_id="w2"))
+
+        only_p1 = await scan_for_widget_decisions(log, pocket_id="p1")
+        assert all(d.pocket_id == "p1" for d in only_p1.decisions)
+        assert any(d.verdict == "pin" for d in only_p1.decisions)
+
+    @pytest.mark.asyncio
+    async def test_actor_filter_isolates_decisions(
+        self, log: WidgetInteractionLog
+    ) -> None:
+        for _ in range(DEFAULT_PIN_THRESHOLD):
+            await log.append(_interaction(action="open", actor="user:priya"))
+        for _ in range(DEFAULT_PIN_THRESHOLD - 5):
+            await log.append(
+                _interaction(action="open", actor="user:maya", widget_id="w_maya"),
+            )
+        priya = await scan_for_widget_decisions(log, actor="user:priya")
+        ids = {d.widget_id for d in priya.decisions if d.verdict == "pin"}
+        assert ids == {"w1"}


### PR DESCRIPTION
Same primitive as memory graduation ([ee/graduation in Move 4 PR-C](https://github.com/pocketpaw/pocketpaw/pull/937)), applied to widgets. Captures user interaction with widgets in a JSONL log, scans the log to propose pin / fade / archive decisions.

This is the captain's "intelligent UI" thesis materialising as a concrete primitive — UI that reacts to use the same way memory does. The UI consumer (Move 8 PR-C) renders the proposals as Suggested Layout chips inside pocket chat.

Move 8 PR-A. PR-B adds agent widget suggestions over retrieval patterns. PR-C ships the UI surfaces.

## What's in this PR

### \`ee/widget_graduation/models.py\`
- \`WidgetInteraction\` — append-only log entry: widget_id, pocket_id, actor, action (\`open\` / \`edit\` / \`click\` / \`dismiss\` / \`remove\`), timestamp.
- \`WidgetDecision\` — proposed UI mutation: \`pin\` / \`fade\` / \`archive\` verdict + interaction count + window + reason.
- \`WidgetReport\` — full scan output.

### \`ee/widget_graduation/log.py\`
- \`WidgetInteractionLog\` — async-safe JSONL sink mirroring \`ee/retrieval/log.py\`.
- Filtered read (widget_id / pocket_id / actor / since / limit).
- Process singleton via \`get_widget_log()\` with \`POCKETPAW_WIDGET_LOG\` env override.

### \`ee/widget_graduation/policy.py\`
- \`scan_for_widget_decisions(log, *, window_days, pin_threshold, archive_days, pocket_id, actor)\` — three-verdict policy.
- **Pin** — widget hit \`pin_threshold\` promoting interactions in window. Promoting = open / edit / click. Dismiss + remove never promote.
- **Fade** — widget seen in archive window but no promoting hits in pin window.
- **Archive** — widget last touched more than \`archive_days\` ago.
- Defaults: 30-day pin window, 10 promoting interactions, 60-day archive ceiling.

## Test plan

- [x] 12 new tests in \`tests/cloud/test_widget_graduation.py\`:
  - Append + filtered read across pocket + widget axes
  - Concurrent appends preserve line integrity
  - Missing-file returns empty
  - Pin fires at exact threshold, sub-threshold does not
  - Only promoting actions count toward pin
  - Recent history with zero in-window use → fade
  - Old inactive widget → archive
  - Pocket + actor filters isolate decisions
- [x] \`pytest\` — passing
- [x] \`ruff check\` — clean

## Pairs with

- pocketpaw [#937](https://github.com/pocketpaw/pocketpaw/pull/937) — same memory-graduation primitive applied to a different signal source. The two scans share zero code by design but have identical shape (JSONL log → policy → decisions) so a future cleanup could factor a shared helper if patterns repeat across more signal types.