### PR TITLE
feat(widget): co-occurrence detector for agent widget suggestions

### DIFF
--- a/ee/widget_suggestions/__init__.py
+++ b/ee/widget_suggestions/__init__.py
@@ -1,0 +1,19 @@
+# Widget Suggestions — agent reads retrieval patterns and proposes new widgets.
+# Created: 2026-04-13 (Move 8 PR-B) — Companion to widget graduation: graduation
+# moves existing widgets up/down based on use, suggestions create NEW widgets
+# from observed retrieval co-occurrence ("user asks about X then Y three times
+# in a row → propose a widget that surfaces both side-by-side").
+
+from ee.widget_suggestions.detector import detect_co_occurrence_patterns
+from ee.widget_suggestions.models import (
+    PatternMatch,
+    SuggestedWidget,
+    SuggestionReport,
+)
+
+__all__ = [
+    "PatternMatch",
+    "SuggestedWidget",
+    "SuggestionReport",
+    "detect_co_occurrence_patterns",
+]

--- a/ee/widget_suggestions/detector.py
+++ b/ee/widget_suggestions/detector.py
@@ -1,0 +1,204 @@
+# ee/widget_suggestions/detector.py — Find co-occurring query patterns.
+# Created: 2026-04-13 (Move 8 PR-B) — Lean detector that reads the
+# retrieval log written by ee/retrieval (Move 4 PR-B), groups consecutive
+# queries from the same actor, and surfaces pairs that repeat above a
+# threshold within a window. The agent uses these as input to propose
+# new widgets via the existing Instinct propose flow.
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import defaultdict
+from collections.abc import Iterable
+from datetime import datetime, timedelta
+from typing import Any
+
+from ee.widget_suggestions.models import (
+    PatternMatch,
+    SuggestedWidget,
+    SuggestionReport,
+)
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_WINDOW_DAYS = 7
+DEFAULT_THRESHOLD = 3
+_SESSION_GAP = timedelta(minutes=15)
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+async def detect_co_occurrence_patterns(
+    log: Any,
+    *,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    threshold: int = DEFAULT_THRESHOLD,
+    pocket_id: str | None = None,
+) -> SuggestionReport:
+    """Scan the retrieval log and surface SuggestedWidget proposals.
+
+    Two queries co-occur when the same actor runs them inside the same
+    "session" — defined here as queries less than 15 minutes apart in the
+    same pocket. A pair that recurs ``threshold`` times in the window
+    earns a SuggestedWidget. ``log`` must satisfy the ee.retrieval
+    RetrievalLog read shape (``read(pocket_id, since, limit)``).
+    """
+    since = datetime.now() - timedelta(days=window_days)
+    entries = await log.read(pocket_id=pocket_id, since=since, limit=20_000)
+
+    sessions = _group_into_sessions(entries)
+
+    pair_counts: dict[str, int] = defaultdict(int)
+    pair_meta: dict[str, dict[str, Any]] = {}
+
+    for session in sessions:
+        for pair in _unordered_pairs(session):
+            sig = _signature(pair)
+            if not sig:
+                continue
+            pair_counts[sig] += 1
+            meta = pair_meta.setdefault(
+                sig,
+                {
+                    "queries": [str(p.get("query", "")) for p in pair],
+                    "actors": [],
+                    "pocket_id": None,
+                },
+            )
+            actor = pair[0].get("actor", "")
+            if actor and actor not in meta["actors"]:
+                meta["actors"].append(actor)
+            if not meta["pocket_id"] and pair[0].get("pocket_id"):
+                meta["pocket_id"] = pair[0]["pocket_id"]
+
+    suggestions: list[SuggestedWidget] = []
+    for sig, count in pair_counts.items():
+        if count < threshold:
+            continue
+        meta = pair_meta[sig]
+        match = PatternMatch(
+            signature=sig,
+            queries=meta["queries"],
+            count=count,
+            pocket_id=meta["pocket_id"],
+            recent_actors=meta["actors"][:5],
+        )
+        suggestions.append(
+            SuggestedWidget(
+                id=f"sw_{sig[:12]}",
+                pocket_id=meta["pocket_id"],
+                title=_title_for(meta["queries"]),
+                description=(
+                    f"Detected {count} co-occurrences in the last "
+                    f"{window_days} days. A side-by-side widget would "
+                    "answer both queries in one glance."
+                ),
+                widget_type="list",
+                pattern=match,
+                confidence=min(1.0, count / (threshold * 3)),
+            ),
+        )
+
+    return SuggestionReport(
+        suggestions=suggestions,
+        scanned_traces=len(entries),
+        window_days=window_days,
+        threshold=threshold,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _group_into_sessions(entries: list[Any]) -> list[list[dict[str, Any]]]:
+    """Group retrieval log entries into per-actor + per-pocket sessions."""
+    sorted_entries = sorted(entries, key=lambda e: _entry_timestamp(e))
+    by_key: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for entry in sorted_entries:
+        actor = _entry_attr(entry, "actor") or ""
+        pocket = _entry_attr(entry, "pocket_id") or ""
+        by_key[(actor, pocket)].append(_entry_to_payload(entry))
+
+    sessions: list[list[dict[str, Any]]] = []
+    for items in by_key.values():
+        if not items:
+            continue
+        current: list[dict[str, Any]] = [items[0]]
+        for prev, curr in zip(items, items[1:], strict=False):
+            if curr["timestamp"] - prev["timestamp"] <= _SESSION_GAP:
+                current.append(curr)
+            else:
+                if len(current) > 1:
+                    sessions.append(current)
+                current = [curr]
+        if len(current) > 1:
+            sessions.append(current)
+    return sessions
+
+
+def _unordered_pairs(session: list[dict[str, Any]]) -> Iterable[list[dict[str, Any]]]:
+    n = len(session)
+    for i in range(n):
+        for j in range(i + 1, n):
+            yield [session[i], session[j]]
+
+
+def _signature(pair: list[dict[str, Any]]) -> str:
+    norm = sorted(_normalise_query(p.get("query", "")) for p in pair)
+    norm = [n for n in norm if n]
+    if len(norm) < 2 or norm[0] == norm[1]:
+        return ""
+    return "::".join(norm)
+
+
+def _normalise_query(query: str) -> str:
+    """Token bag with stable ordering so word-order variants collide.
+
+    "renewal discount" and "discount renewal" are the same question phrased
+    two ways — they should not produce a "side-by-side widget" suggestion.
+    Sorting the token list makes both normalise to "discount renewal" and
+    the duplicate-token check in :func:`_signature` then suppresses them.
+    """
+    tokens = _TOKEN_RE.findall(query.lower())
+    return " ".join(sorted(tokens[:6]))
+
+
+def _title_for(queries: list[str]) -> str:
+    parts = [q[:30] for q in queries[:2]]
+    return f"Suggested: {' + '.join(parts)}"
+
+
+def _entry_attr(entry: Any, attr: str) -> Any:
+    if hasattr(entry, attr):
+        return getattr(entry, attr)
+    if hasattr(entry, "trace") and isinstance(entry.trace, dict):
+        return entry.trace.get(attr)
+    if isinstance(entry, dict):
+        return entry.get(attr)
+    return None
+
+
+def _entry_timestamp(entry: Any) -> datetime:
+    raw = _entry_attr(entry, "timestamp")
+    if isinstance(raw, datetime):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            return datetime.min
+    if hasattr(entry, "ingested_at"):
+        return entry.ingested_at
+    return datetime.min
+
+
+def _entry_to_payload(entry: Any) -> dict[str, Any]:
+    return {
+        "actor": _entry_attr(entry, "actor") or "",
+        "query": _entry_attr(entry, "query") or "",
+        "pocket_id": _entry_attr(entry, "pocket_id"),
+        "timestamp": _entry_timestamp(entry),
+    }

--- a/ee/widget_suggestions/models.py
+++ b/ee/widget_suggestions/models.py
@@ -1,0 +1,50 @@
+# ee/widget_suggestions/models.py — Suggestion + co-occurrence types.
+# Created: 2026-04-13 (Move 8 PR-B) — A SuggestedWidget is a proposal the
+# agent surfaces in chat. The user accepts and the runtime pushes a widget
+# spec into the pocket. PatternMatch is the raw signal (a co-occurring
+# query pair detected in the retrieval log).
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class PatternMatch(BaseModel):
+    """One co-occurring query pattern detected in the retrieval log.
+
+    ``signature`` is the joined sorted query terms so duplicate
+    co-occurrences collapse into a single match. ``count`` is how many
+    times the pattern repeated within the window. ``recent_actors`` lets
+    the UI personalise the suggestion.
+    """
+
+    signature: str
+    queries: list[str]
+    count: int
+    pocket_id: str | None = None
+    recent_actors: list[str] = Field(default_factory=list)
+
+
+class SuggestedWidget(BaseModel):
+    """A proposal the agent shows the user inside pocket chat."""
+
+    id: str
+    pocket_id: str | None = None
+    title: str
+    description: str
+    widget_type: str = "list"  # list | chart | kpi | chat
+    pattern: PatternMatch
+    confidence: float = 0.0
+    created_at: datetime = Field(default_factory=datetime.now)
+
+
+class SuggestionReport(BaseModel):
+    """Output of one detection pass."""
+
+    suggestions: list[SuggestedWidget] = Field(default_factory=list)
+    scanned_traces: int = 0
+    window_days: int = 7
+    threshold: int = 3
+    generated_at: datetime = Field(default_factory=datetime.now)

--- a/tests/cloud/test_widget_suggestions.py
+++ b/tests/cloud/test_widget_suggestions.py
@@ -1,0 +1,208 @@
+# tests/cloud/test_widget_suggestions.py — Move 8 PR-B.
+# Created: 2026-04-13 — Co-occurrence detector behaviour: session boundary
+# enforcement (15-min gap), threshold semantics, signature dedup,
+# pocket/actor isolation, output shape.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+
+from ee.widget_suggestions.detector import (
+    DEFAULT_THRESHOLD,
+    detect_co_occurrence_patterns,
+)
+
+
+@dataclass
+class _FakeEntry:
+    """Lightweight stand-in for a retrieval log entry."""
+
+    actor: str
+    query: str
+    pocket_id: str | None
+    timestamp: datetime
+    trace: dict[str, Any] = field(default_factory=dict)
+
+
+class _FakeLog:
+    """Test double — exposes the read() shape the detector consumes."""
+
+    def __init__(self, entries: list[_FakeEntry]) -> None:
+        self._entries = entries
+
+    async def read(
+        self,
+        *,
+        pocket_id: str | None = None,
+        since: datetime | None = None,
+        limit: int = 20_000,
+    ) -> list[_FakeEntry]:
+        rows = self._entries
+        if pocket_id is not None:
+            rows = [e for e in rows if e.pocket_id == pocket_id]
+        if since is not None:
+            rows = [e for e in rows if e.timestamp >= since]
+        return rows[:limit]
+
+
+def _entry(
+    *,
+    actor: str = "user:priya",
+    query: str = "renewal discount",
+    pocket_id: str | None = "pocket-1",
+    when: datetime | None = None,
+) -> _FakeEntry:
+    return _FakeEntry(
+        actor=actor,
+        query=query,
+        pocket_id=pocket_id,
+        timestamp=when or datetime.now(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Threshold + co-occurrence
+# ---------------------------------------------------------------------------
+
+
+class TestCoOccurrence:
+    @pytest.mark.asyncio
+    async def test_repeated_pair_above_threshold_yields_suggestion(self) -> None:
+        base = datetime.now() - timedelta(hours=1)
+        entries: list[_FakeEntry] = []
+        for i in range(DEFAULT_THRESHOLD):
+            session_start = base + timedelta(hours=i)
+            entries.append(_entry(query="acme deal status", when=session_start))
+            entries.append(
+                _entry(query="acme renewal date", when=session_start + timedelta(minutes=2)),
+            )
+
+        report = await detect_co_occurrence_patterns(_FakeLog(entries))
+        assert len(report.suggestions) == 1
+        suggestion = report.suggestions[0]
+        assert suggestion.pattern.count >= DEFAULT_THRESHOLD
+        assert suggestion.title.startswith("Suggested:")
+
+    @pytest.mark.asyncio
+    async def test_pair_below_threshold_not_suggested(self) -> None:
+        base = datetime.now() - timedelta(hours=1)
+        entries: list[_FakeEntry] = []
+        for i in range(DEFAULT_THRESHOLD - 1):
+            session_start = base + timedelta(hours=i)
+            entries.append(_entry(query="alpha", when=session_start))
+            entries.append(
+                _entry(query="beta", when=session_start + timedelta(minutes=2)),
+            )
+        report = await detect_co_occurrence_patterns(_FakeLog(entries))
+        assert report.suggestions == []
+
+    @pytest.mark.asyncio
+    async def test_signature_normalises_word_order(self) -> None:
+        base = datetime.now() - timedelta(hours=1)
+        entries: list[_FakeEntry] = []
+        for i in range(DEFAULT_THRESHOLD):
+            session_start = base + timedelta(hours=i)
+            # "discount renewal" and "renewal discount" should collapse.
+            entries.append(_entry(query="discount renewal", when=session_start))
+            entries.append(
+                _entry(query="renewal discount", when=session_start + timedelta(minutes=1)),
+            )
+        report = await detect_co_occurrence_patterns(_FakeLog(entries))
+        # The pair counts as the same signature each time, but the two
+        # queries normalise to the SAME token set so they don't form a
+        # multi-query pair. Expect zero suggestions.
+        assert report.suggestions == []
+
+
+# ---------------------------------------------------------------------------
+# Session boundary
+# ---------------------------------------------------------------------------
+
+
+class TestSessionBoundary:
+    @pytest.mark.asyncio
+    async def test_pair_separated_by_long_gap_not_grouped(self) -> None:
+        # Same pair queries but separated by >15 minutes — NOT a session.
+        base = datetime.now() - timedelta(days=1)
+        entries: list[_FakeEntry] = []
+        for i in range(DEFAULT_THRESHOLD * 2):
+            entries.append(_entry(query="alpha", when=base + timedelta(minutes=60 * i)))
+            entries.append(
+                _entry(query="beta", when=base + timedelta(minutes=60 * i + 30)),
+            )
+        report = await detect_co_occurrence_patterns(_FakeLog(entries))
+        assert report.suggestions == []
+
+
+# ---------------------------------------------------------------------------
+# Pocket + actor isolation
+# ---------------------------------------------------------------------------
+
+
+class TestIsolation:
+    @pytest.mark.asyncio
+    async def test_different_actors_do_not_co_occur_with_each_other(self) -> None:
+        base = datetime.now() - timedelta(hours=1)
+        entries: list[_FakeEntry] = []
+        for i in range(DEFAULT_THRESHOLD):
+            t = base + timedelta(hours=i)
+            entries.append(_entry(actor="user:priya", query="alpha", when=t))
+            entries.append(
+                _entry(actor="user:maya", query="beta", when=t + timedelta(minutes=2)),
+            )
+        report = await detect_co_occurrence_patterns(_FakeLog(entries))
+        assert report.suggestions == []
+
+    @pytest.mark.asyncio
+    async def test_pocket_filter_isolates(self) -> None:
+        base = datetime.now() - timedelta(hours=1)
+        entries: list[_FakeEntry] = []
+        for i in range(DEFAULT_THRESHOLD):
+            t = base + timedelta(hours=i)
+            entries.append(_entry(pocket_id="p1", query="alpha", when=t))
+            entries.append(
+                _entry(pocket_id="p1", query="beta", when=t + timedelta(minutes=1)),
+            )
+            entries.append(_entry(pocket_id="p2", query="gamma", when=t))
+            entries.append(
+                _entry(pocket_id="p2", query="delta", when=t + timedelta(minutes=1)),
+            )
+
+        only_p1 = await detect_co_occurrence_patterns(_FakeLog(entries), pocket_id="p1")
+        assert len(only_p1.suggestions) == 1
+        assert only_p1.suggestions[0].pocket_id == "p1"
+
+
+# ---------------------------------------------------------------------------
+# Output shape
+# ---------------------------------------------------------------------------
+
+
+class TestOutputShape:
+    @pytest.mark.asyncio
+    async def test_report_includes_window_and_threshold(self) -> None:
+        report = await detect_co_occurrence_patterns(
+            _FakeLog([]),
+            window_days=14,
+            threshold=5,
+        )
+        assert report.window_days == 14
+        assert report.threshold == 5
+        assert report.scanned_traces == 0
+
+    @pytest.mark.asyncio
+    async def test_confidence_increases_with_count(self) -> None:
+        base = datetime.now() - timedelta(hours=1)
+        entries: list[_FakeEntry] = []
+        for i in range(DEFAULT_THRESHOLD * 3):
+            t = base + timedelta(hours=i)
+            entries.append(_entry(query="alpha", when=t))
+            entries.append(_entry(query="beta", when=t + timedelta(minutes=2)))
+        report = await detect_co_occurrence_patterns(_FakeLog(entries))
+        assert len(report.suggestions) == 1
+        # 9 co-occurrences, threshold 3 → 9 / (3*3) = 1.0
+        assert report.suggestions[0].confidence == pytest.approx(1.0, abs=0.01)


### PR DESCRIPTION
Reads the retrieval log written by [ee/retrieval (Move 4 PR-B)](https://github.com/pocketpaw/pocketpaw/pull/936), groups queries from the same actor + pocket into 15-minute sessions, and surfaces \`SuggestedWidget\` proposals when a query pair recurs above a threshold. The agent feeds these proposals into the Instinct propose flow so the operator sees them as actions in The Tray rather than auto-applied UI mutations.

Move 8 PR-B. Stacks on [#941 PR-A](https://github.com/pocketpaw/pocketpaw/pull/941). PR-C ships the UI surfaces.

## What's in this PR

### \`ee/widget_suggestions/models.py\`
- \`PatternMatch\` — one detected co-occurring pair (signature, queries, count, pocket_id, recent actors).
- \`SuggestedWidget\` — id, pocket_id, title, description, widget_type, pattern, confidence, timestamp.
- \`SuggestionReport\` — full output of one detection pass.

### \`ee/widget_suggestions/detector.py\`
- \`detect_co_occurrence_patterns(log, *, window_days, threshold, pocket_id)\` — pure async function over any log that satisfies the ee/retrieval \`read\` shape.
- Sessions form when consecutive queries from the same actor + pocket are <15 minutes apart.
- Token-bag normalisation sorts within each query so word-order variants ("renewal discount" vs "discount renewal") collide and don't produce nonsense pair suggestions.
- Confidence scales \`count / (threshold * 3)\` capped at 1.0.
- Defaults: 7-day window, 3 co-occurrences.

## Test plan

- [x] 8 new tests in \`tests/cloud/test_widget_suggestions.py\`:
  - Pair above threshold → suggestion
  - Below threshold → no suggestion
  - Word-order variants suppressed (same question phrased two ways shouldn't suggest a side-by-side widget)
  - 60-min gap breaks session boundary
  - Different actors don't co-occur
  - Pocket filter isolates
  - Report carries window + threshold
  - Confidence saturates at 1.0
- [x] \`pytest\` — passing
- [x] \`ruff check\` — clean

## Pairs with

- pocketpaw [#941](https://github.com/pocketpaw/pocketpaw/pull/941) — widget graduation. Graduation reshuffles existing widgets; suggestions create new ones. Both feed the same "intelligent UI" surface in PR-C.