### PR TITLE
fix(security): implement file jail for OCR/STT and stabilize agent loop

### DIFF
--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -493,9 +493,13 @@ class AgentLoop:
             )
             try:
                 async for event in run_iter:
-                    etype = event.type
-                    econtent = event.content
-                    meta = event.metadata or {}
+                    etype = getattr(event, 'type', None) or (event.get('type') if isinstance(event, dict) else None)
+                    econtent = getattr(event, 'content', None) or (event.get('content', '') if isinstance(event, dict) else '')
+                    meta = getattr(event, 'metadata', None) or (event.get('metadata') if isinstance(event, dict) else None) or {}
+
+                    if not etype:
+                        logger.warning("Received malformed agent event (no type): %s", event)
+                        continue
 
                     if etype == "message":
                         full_response += econtent

--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -493,9 +493,17 @@ class AgentLoop:
             )
             try:
                 async for event in run_iter:
-                    etype = getattr(event, 'type', None) or (event.get('type') if isinstance(event, dict) else None)
-                    econtent = getattr(event, 'content', None) or (event.get('content', '') if isinstance(event, dict) else '')
-                    meta = getattr(event, 'metadata', None) or (event.get('metadata') if isinstance(event, dict) else None) or {}
+                    etype = getattr(event, "type", None) or (
+                        event.get("type") if isinstance(event, dict) else None
+                    )
+                    econtent = getattr(event, "content", None) or (
+                        event.get("content", "") if isinstance(event, dict) else ""
+                    )
+                    meta = (
+                        getattr(event, "metadata", None)
+                        or (event.get("metadata") if isinstance(event, dict) else None)
+                        or {}
+                    )
 
                     if not etype:
                         logger.warning("Received malformed agent event (no type): %s", event)

--- a/src/pocketpaw/tools/builtin/desktop.py
+++ b/src/pocketpaw/tools/builtin/desktop.py
@@ -21,76 +21,9 @@ class ScreenshotTool(BaseTool):
         if not img_bytes:
             return "Error: Failed to take screenshot (display might be unavailable)."
 
-        # For now, return a message indicating success.
-        # In a real multimodal agent, we'd attach the image to the message.
-        # But for text-based Loop, we might need a way to pass binary data.
-        # The MessageBus supports metadata.
-        # For now, let's return a special string or handle it via a side channel?
-        # Actually, let's return a description.
-        # But wait, the USER wants to SEE it.
-        # The TelegramAdapter can handle 'image' content if we structure
-        # the OutboundMessage correctly.
-        # But the tool returns a string.
-        # Let's return the base64 string and let the Loop/Adapter handle it?
-        # Or save to a temp file and return the path?
-        # Saving to file is safer for text-only LLMs.
-
-        # Let's save to a temp file in the jail if possible, or just return "Buffered".
-        # Re-reading `bot_gateway.py`: it uses `reply_photo(photo=img_bytes)`.
-
-        # Strategy: The Tool execution returns a text summary.
-        # BUT, we want the side effect of sending the image.
-        # The AgentLoop publishes OutboundMessage.
-        # If the Tool can "emit" a message to the bus, that would be ideal.
-        # But Tools are passive.
-
-        # Alternative: Tool saves file to
-        # `desktop/screenshot_<timestamp>.png` in the Memory/File store,
-        # and returns "Screenshot saved to ...".
-        # Then the user can ask "Send me that file".
-
-        # OR: We encode it in the text result using a special tag? <image_base64>...</image_base64>?
-        # This is getting complex for a "simplified" tool system.
-
-        # Simple approach for now:
-        # Return base64 string. The LLM won't like it.
-        # Let's just return "Screenshot taken." and maybe we improve
-        # the system to support binary blobs later?
-        # The USER specifically wants the existing features.
-
-        # Let's use a Hack for Phase 2:
-        # The tool returns "Screenshot taken."
-        # BUT, we cheat and use the `loop` context? No.
-
-        # Let's look at `AgentLoop`. It publishes `tool_result` event.
-        # Maybe we can publish a separate event?
-
-        # Actually, `tool_use` event in loop:
-        # await self.bus.publish_system(SystemEvent(event_type="tool_use", ... result=result))
-
-        # If we return a massive base64 string, it will clog the logs/memory.
-
-        return (
-            "[Screenshot capture functionality is active but image"
-            " routing to chat is pending implementation in Phase 2B]"
-        )
-
-        # Wait, I am implementing Phase 2B NOW.
-        # I should simply allow the tool to return a special result
-        # that the Agent Loop can interpret?
-        # No, AgentLoop is generic.
-
-        # Best approach: Save to `file_jail/screenshots/`
-        # and return the path.
-        # The Agent can then use `ReadFile` or we rely on the Adapter to detecting "File paths"?
-
-        # Let's stick to the prompt: `AgentLoop` orchestration.
-        # If I return a path, the user can say "Download <path>"
-        # (if we implement Download tool or file serving).
-        # Telegram Adapter can potentially treat paths as files to upload?
-
-        # Let's stick to "saving to file" as the most robust "Agentic" way.
-        # It persists the data.
+        # Save screenshot to file jail for retrieval.
+        # The agent can deliver it via deliver_artifact or the user can
+        # download it from the Files panel in the dashboard.
 
         from datetime import datetime
 

--- a/src/pocketpaw/tools/builtin/ocr.py
+++ b/src/pocketpaw/tools/builtin/ocr.py
@@ -10,6 +10,7 @@ from typing import Any
 import httpx
 
 from pocketpaw.config import get_config_dir, get_settings
+from pocketpaw.tools.fetch import is_safe_path
 from pocketpaw.tools.protocol import BaseTool
 
 logger = logging.getLogger(__name__)
@@ -85,7 +86,13 @@ class OCRTool(BaseTool):
     ) -> str:
         settings = get_settings()
 
-        image_file = Path(image_path).expanduser()
+        image_file = Path(image_path).expanduser().resolve()
+
+        # Security: check file jail
+        jail = get_settings().file_jail_path.resolve()
+        if not is_safe_path(image_file, jail):
+            return self._error(f"Access denied: {image_path} is outside allowed directory")
+
         if not image_file.exists():
             return self._error(f"File not found: {image_file}")
 

--- a/src/pocketpaw/tools/builtin/stt.py
+++ b/src/pocketpaw/tools/builtin/stt.py
@@ -10,6 +10,7 @@ from typing import Any
 import httpx
 
 from pocketpaw.config import get_config_dir, get_settings
+from pocketpaw.tools.fetch import is_safe_path
 from pocketpaw.tools.protocol import BaseTool
 
 logger = logging.getLogger(__name__)
@@ -74,7 +75,13 @@ class SpeechToTextTool(BaseTool):
     async def execute(
         self, audio_file: str, language: str | None = None, mode: str | None = None
     ) -> str:
-        audio_path = Path(audio_file).expanduser()
+        audio_path = Path(audio_file).expanduser().resolve()
+
+        # Security: check file jail
+        jail = get_settings().file_jail_path.resolve()
+        if not is_safe_path(audio_path, jail):
+            return self._error(f"Access denied: {audio_file} is outside allowed directory")
+
         if not audio_path.exists():
             return self._error(f"Audio file not found: {audio_path}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,26 @@
 """Pytest configuration."""
 
+import asyncio
+import sys
 from unittest.mock import patch
 
 import pytest
 
 from pocketpaw.security.audit import AuditLogger
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _setup_asyncio_child_watcher():
+    """Attach a child watcher so subprocess-based tests don't crash.
+
+    On Python < 3.12 the default child watcher requires attachment to
+    the running event loop.  On 3.12+ child watchers were removed, so
+    this is a no-op.
+    """
+    if sys.version_info < (3, 12) and hasattr(asyncio, "ThreadedChildWatcher"):
+        watcher = asyncio.ThreadedChildWatcher()
+        asyncio.set_child_watcher(watcher)
+    yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -167,11 +167,12 @@ class TestAgentRouter:
 
         assert AgentRouter is not None
 
-    def test_router_defaults_to_claude_agent_sdk(self):
+    def test_router_defaults_to_claude_agent_sdk(self, monkeypatch):
         from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
         from pocketpaw.agents.router import AgentRouter
 
-        settings = Settings()
+        monkeypatch.delenv("POCKETPAW_AGENT_BACKEND", raising=False)
+        settings = Settings(_env_file=None)
         router = AgentRouter(settings)
         assert router._backend is not None
         assert isinstance(router._backend, ClaudeSDKBackend)
@@ -210,10 +211,11 @@ class TestAgentRouter:
         router = AgentRouter(settings)
         assert isinstance(router._backend, ClaudeSDKBackend)
 
-    def test_router_get_backend_info(self):
+    def test_router_get_backend_info(self, monkeypatch):
         from pocketpaw.agents.router import AgentRouter
 
-        router = AgentRouter(Settings())
+        monkeypatch.delenv("POCKETPAW_AGENT_BACKEND", raising=False)
+        router = AgentRouter(Settings(_env_file=None))
         info = router.get_backend_info()
         assert info is not None
         assert info.name == "claude_agent_sdk"
@@ -251,17 +253,19 @@ class TestAgentRouter:
 class TestClaudeSDKCliAuth:
     """Bug reproduction: PocketPaw requires API key even when Claude CLI is authenticated."""
 
-    def test_auto_resolve_no_key_gives_ollama(self):
+    def test_auto_resolve_no_key_gives_ollama(self, monkeypatch):
         from pocketpaw.llm.client import resolve_llm_client
 
-        settings = Settings()
+        monkeypatch.delenv("POCKETPAW_LLM_PROVIDER", raising=False)
+        settings = Settings(_env_file=None)
         llm = resolve_llm_client(settings)
         assert llm.provider == "ollama"
 
-    def test_force_anthropic_no_key_returns_anthropic(self):
+    def test_force_anthropic_no_key_returns_anthropic(self, monkeypatch):
         from pocketpaw.llm.client import resolve_llm_client
 
-        settings = Settings()
+        monkeypatch.delenv("POCKETPAW_LLM_PROVIDER", raising=False)
+        settings = Settings(_env_file=None)
         llm = resolve_llm_client(settings, force_provider="anthropic")
         assert llm.provider == "anthropic"
         assert llm.api_key is None
@@ -278,14 +282,17 @@ class TestClaudeSDKCliAuth:
         assert llm.to_sdk_env() == {}
 
     @pytest.mark.asyncio
-    async def test_claude_sdk_run_resolves_anthropic_not_ollama(self):
+    async def test_claude_sdk_run_resolves_anthropic_not_ollama(self, monkeypatch):
         """run() should resolve to anthropic, not fall to ollama."""
         from unittest.mock import patch
 
         from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
         from pocketpaw.llm.client import resolve_llm_client as real_resolve
 
-        settings = Settings(agent_backend="claude_agent_sdk", smart_routing_enabled=False)
+        monkeypatch.delenv("POCKETPAW_LLM_PROVIDER", raising=False)
+        settings = Settings(
+            _env_file=None, agent_backend="claude_agent_sdk", smart_routing_enabled=False
+        )
         with patch("shutil.which", return_value="/usr/bin/claude"):
             sdk = ClaudeSDKBackend(settings)
 

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -37,11 +37,15 @@ class TestOCRToolSchema:
 
 
 @pytest.fixture
-def _mock_settings():
+def _mock_settings(tmp_path):
     settings = MagicMock()
     settings.openai_api_key = "test-key"
     settings.ocr_provider = "openai"
-    with patch("pocketpaw.tools.builtin.ocr.get_settings", return_value=settings):
+    settings.file_jail_path = tmp_path
+    with (
+        patch("pocketpaw.tools.builtin.ocr.get_settings", return_value=settings),
+        patch("pocketpaw.tools.builtin.ocr.is_safe_path", return_value=True),
+    ):
         yield settings
 
 
@@ -52,6 +56,25 @@ async def test_ocr_file_not_found(_mock_settings):
     result = await tool.execute(image_path="/nonexistent/image.png")
     assert result.startswith("Error:")
     assert "not found" in result
+
+
+async def test_ocr_file_jail_rejects_outside_path(tmp_path):
+    """Files outside the jail directory must be rejected."""
+    from pocketpaw.tools.builtin.ocr import OCRTool
+
+    tool = OCRTool()
+    jail = tmp_path / "jail"
+    jail.mkdir()
+    outside = tmp_path / "outside.png"
+    outside.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+
+    settings = MagicMock()
+    settings.file_jail_path = jail
+    with patch("pocketpaw.tools.builtin.ocr.get_settings", return_value=settings):
+        result = await tool.execute(image_path=str(outside))
+
+    assert result.startswith("Error:")
+    assert "Access denied" in result or "outside" in result
 
 
 async def test_ocr_unsupported_format(_mock_settings, tmp_path):
@@ -133,7 +156,11 @@ async def test_ocr_no_api_key_no_tesseract(tmp_path):
     settings = MagicMock()
     settings.openai_api_key = None
     settings.ocr_provider = "openai"
-    with patch("pocketpaw.tools.builtin.ocr.get_settings", return_value=settings):
+    settings.file_jail_path = tmp_path
+    with (
+        patch("pocketpaw.tools.builtin.ocr.get_settings", return_value=settings),
+        patch("pocketpaw.tools.builtin.ocr.is_safe_path", return_value=True),
+    ):
         # Mock pytesseract as not installed
         with patch.dict("sys.modules", {"pytesseract": None}):
             result = await tool.execute(image_path=str(img))

--- a/tests/test_sarvam.py
+++ b/tests/test_sarvam.py
@@ -23,6 +23,8 @@ def _mock_settings(**overrides):
         "openai_api_key": "test-openai-key",
         "elevenlabs_api_key": None,
         "stt_model": "whisper-1",
+        # file_jail_path is expected to be overridden per-test via tmp_path
+        "file_jail_path": None,
     }
     defaults.update(overrides)
     m = MagicMock()
@@ -256,9 +258,12 @@ class TestSarvamSTT:
 
         return SpeechToTextTool()
 
+    @patch("pocketpaw.tools.builtin.stt.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.stt.get_settings")
-    async def test_no_api_key_returns_error(self, mock_gs, tmp_path):
-        mock_gs.return_value = _mock_settings(sarvam_api_key=None, stt_provider="sarvam")
+    async def test_no_api_key_returns_error(self, mock_gs, _safe, tmp_path):
+        mock_gs.return_value = _mock_settings(
+            sarvam_api_key=None, stt_provider="sarvam", file_jail_path=tmp_path
+        )
         audio_file = tmp_path / "test.wav"
         audio_file.write_bytes(b"\x00" * 100)
         tool = self._make_tool()
@@ -266,18 +271,22 @@ class TestSarvamSTT:
         assert "error" in result.lower()
         assert "SARVAM_API_KEY" in result
 
+    @patch("pocketpaw.tools.builtin.stt.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.stt.get_settings")
-    async def test_file_not_found(self, mock_gs):
-        mock_gs.return_value = _mock_settings(stt_provider="sarvam")
+    async def test_file_not_found(self, mock_gs, _safe):
+        from pathlib import Path
+
+        mock_gs.return_value = _mock_settings(stt_provider="sarvam", file_jail_path=Path("/tmp"))
         tool = self._make_tool()
         result = await tool.execute(audio_file="/nonexistent/file.wav")
         assert "error" in result.lower()
         assert "not found" in result.lower()
 
+    @patch("pocketpaw.tools.builtin.stt.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.stt._get_transcripts_dir")
     @patch("pocketpaw.tools.builtin.stt.get_settings")
-    async def test_success_mock(self, mock_gs, mock_tdir, tmp_path):
-        mock_gs.return_value = _mock_settings(stt_provider="sarvam")
+    async def test_success_mock(self, mock_gs, mock_tdir, _safe, tmp_path):
+        mock_gs.return_value = _mock_settings(stt_provider="sarvam", file_jail_path=tmp_path)
         mock_tdir.return_value = tmp_path
 
         audio_file = tmp_path / "test.wav"
@@ -301,10 +310,11 @@ class TestSarvamSTT:
 
         assert "यह एक टेस्ट है" in result
 
+    @patch("pocketpaw.tools.builtin.stt.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.stt._get_transcripts_dir")
     @patch("pocketpaw.tools.builtin.stt.get_settings")
-    async def test_mode_translit(self, mock_gs, mock_tdir, tmp_path):
-        mock_gs.return_value = _mock_settings(stt_provider="sarvam")
+    async def test_mode_translit(self, mock_gs, mock_tdir, _safe, tmp_path):
+        mock_gs.return_value = _mock_settings(stt_provider="sarvam", file_jail_path=tmp_path)
         mock_tdir.return_value = tmp_path
 
         audio_file = tmp_path / "test.wav"
@@ -330,9 +340,10 @@ class TestSarvamSTT:
         assert "yeh ek test hai" in result
         assert "mode=translit" in result
 
+    @patch("pocketpaw.tools.builtin.stt.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.stt.get_settings")
-    async def test_stt_http_error(self, mock_gs, tmp_path):
-        mock_gs.return_value = _mock_settings(stt_provider="sarvam")
+    async def test_stt_http_error(self, mock_gs, _safe, tmp_path):
+        mock_gs.return_value = _mock_settings(stt_provider="sarvam", file_jail_path=tmp_path)
 
         audio_file = tmp_path / "test.wav"
         audio_file.write_bytes(b"\x00" * 100)
@@ -359,9 +370,10 @@ class TestSarvamSTT:
         assert "error" in result.lower()
         assert "429" in result
 
+    @patch("pocketpaw.tools.builtin.stt.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.stt.get_settings")
-    async def test_no_speech_detected(self, mock_gs, tmp_path):
-        mock_gs.return_value = _mock_settings(stt_provider="sarvam")
+    async def test_no_speech_detected(self, mock_gs, _safe, tmp_path):
+        mock_gs.return_value = _mock_settings(stt_provider="sarvam", file_jail_path=tmp_path)
 
         audio_file = tmp_path / "silence.wav"
         audio_file.write_bytes(b"\x00" * 100)
@@ -383,9 +395,10 @@ class TestSarvamSTT:
 
         assert "no speech" in result.lower()
 
+    @patch("pocketpaw.tools.builtin.stt.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.stt.get_settings")
-    async def test_unknown_provider_error(self, mock_gs, tmp_path):
-        mock_gs.return_value = _mock_settings(stt_provider="invalid")
+    async def test_unknown_provider_error(self, mock_gs, _safe, tmp_path):
+        mock_gs.return_value = _mock_settings(stt_provider="invalid", file_jail_path=tmp_path)
         audio_file = tmp_path / "test.wav"
         audio_file.write_bytes(b"\x00" * 100)
         tool = self._make_tool()
@@ -407,9 +420,12 @@ class TestSarvamOCR:
 
         return OCRTool()
 
+    @patch("pocketpaw.tools.builtin.ocr.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.ocr.get_settings")
-    async def test_no_api_key_returns_error(self, mock_gs, tmp_path):
-        mock_gs.return_value = _mock_settings(sarvam_api_key=None, ocr_provider="sarvam")
+    async def test_no_api_key_returns_error(self, mock_gs, _safe, tmp_path):
+        mock_gs.return_value = _mock_settings(
+            sarvam_api_key=None, ocr_provider="sarvam", file_jail_path=tmp_path
+        )
         img = tmp_path / "test.png"
         img.write_bytes(b"\x89PNG" + b"\x00" * 100)
         tool = self._make_tool()
@@ -417,17 +433,21 @@ class TestSarvamOCR:
         assert "error" in result.lower()
         assert "SARVAM_API_KEY" in result
 
+    @patch("pocketpaw.tools.builtin.ocr.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.ocr.get_settings")
-    async def test_file_not_found(self, mock_gs):
-        mock_gs.return_value = _mock_settings(ocr_provider="sarvam")
+    async def test_file_not_found(self, mock_gs, _safe):
+        from pathlib import Path
+
+        mock_gs.return_value = _mock_settings(ocr_provider="sarvam", file_jail_path=Path("/tmp"))
         tool = self._make_tool()
         result = await tool.execute(image_path="/nonexistent/file.png")
         assert "error" in result.lower()
         assert "not found" in result.lower()
 
+    @patch("pocketpaw.tools.builtin.ocr.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.ocr.get_settings")
-    async def test_unsupported_format(self, mock_gs, tmp_path):
-        mock_gs.return_value = _mock_settings(ocr_provider="sarvam")
+    async def test_unsupported_format(self, mock_gs, _safe, tmp_path):
+        mock_gs.return_value = _mock_settings(ocr_provider="sarvam", file_jail_path=tmp_path)
         f = tmp_path / "test.xyz"
         f.write_bytes(b"\x00" * 100)
         tool = self._make_tool()
@@ -435,10 +455,11 @@ class TestSarvamOCR:
         assert "error" in result.lower()
         assert "unsupported" in result.lower()
 
+    @patch("pocketpaw.tools.builtin.ocr.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.ocr._get_ocr_output_dir")
     @patch("pocketpaw.tools.builtin.ocr.get_settings")
-    async def test_success_mock(self, mock_gs, mock_odir, tmp_path):
-        mock_gs.return_value = _mock_settings(ocr_provider="sarvam")
+    async def test_success_mock(self, mock_gs, mock_odir, _safe, tmp_path):
+        mock_gs.return_value = _mock_settings(ocr_provider="sarvam", file_jail_path=tmp_path)
         ocr_out = tmp_path / "ocr_out"
         ocr_out.mkdir()
         mock_odir.return_value = ocr_out
@@ -467,10 +488,11 @@ class TestSarvamOCR:
         assert "Extracted text here" in result
         assert "document.png" in result
 
+    @patch("pocketpaw.tools.builtin.ocr.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.ocr._get_ocr_output_dir")
     @patch("pocketpaw.tools.builtin.ocr.get_settings")
-    async def test_pdf_support(self, mock_gs, mock_odir, tmp_path):
-        mock_gs.return_value = _mock_settings(ocr_provider="sarvam")
+    async def test_pdf_support(self, mock_gs, mock_odir, _safe, tmp_path):
+        mock_gs.return_value = _mock_settings(ocr_provider="sarvam", file_jail_path=tmp_path)
         ocr_out = tmp_path / "ocr_out"
         ocr_out.mkdir()
         mock_odir.return_value = ocr_out
@@ -492,10 +514,11 @@ class TestSarvamOCR:
 
         assert "PDF text content" in result
 
+    @patch("pocketpaw.tools.builtin.ocr.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.ocr.get_settings")
-    async def test_openai_rejects_pdf(self, mock_gs, tmp_path):
+    async def test_openai_rejects_pdf(self, mock_gs, _safe, tmp_path):
         """OpenAI Vision does not support PDF — should return helpful error."""
-        mock_gs.return_value = _mock_settings(ocr_provider="openai")
+        mock_gs.return_value = _mock_settings(ocr_provider="openai", file_jail_path=tmp_path)
         pdf = tmp_path / "test.pdf"
         pdf.write_bytes(b"%PDF" + b"\x00" * 100)
         tool = self._make_tool()
@@ -503,9 +526,10 @@ class TestSarvamOCR:
         assert "error" in result.lower()
         assert "sarvam" in result.lower()
 
+    @patch("pocketpaw.tools.builtin.ocr.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.ocr.get_settings")
-    async def test_sdk_not_installed(self, mock_gs, tmp_path):
-        mock_gs.return_value = _mock_settings(ocr_provider="sarvam")
+    async def test_sdk_not_installed(self, mock_gs, _safe, tmp_path):
+        mock_gs.return_value = _mock_settings(ocr_provider="sarvam", file_jail_path=tmp_path)
         img = tmp_path / "test.png"
         img.write_bytes(b"\x89PNG" + b"\x00" * 100)
         tool = self._make_tool()
@@ -514,9 +538,10 @@ class TestSarvamOCR:
             result = await tool.execute(image_path=str(img))
         assert "error" in result.lower()
 
+    @patch("pocketpaw.tools.builtin.ocr.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.ocr.get_settings")
-    async def test_no_text_detected(self, mock_gs, tmp_path):
-        mock_gs.return_value = _mock_settings(ocr_provider="sarvam")
+    async def test_no_text_detected(self, mock_gs, _safe, tmp_path):
+        mock_gs.return_value = _mock_settings(ocr_provider="sarvam", file_jail_path=tmp_path)
         ocr_out = tmp_path / "ocr_out"
         ocr_out.mkdir()
 
@@ -536,9 +561,10 @@ class TestSarvamOCR:
 
         assert "no text" in result.lower()
 
+    @patch("pocketpaw.tools.builtin.ocr.is_safe_path", return_value=True)
     @patch("pocketpaw.tools.builtin.ocr.get_settings")
-    async def test_unknown_provider_error(self, mock_gs, tmp_path):
-        mock_gs.return_value = _mock_settings(ocr_provider="invalid")
+    async def test_unknown_provider_error(self, mock_gs, _safe, tmp_path):
+        mock_gs.return_value = _mock_settings(ocr_provider="invalid", file_jail_path=tmp_path)
         img = tmp_path / "test.png"
         img.write_bytes(b"\x89PNG" + b"\x00" * 100)
         tool = self._make_tool()

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -38,12 +38,16 @@ class TestSpeechToTextToolSchema:
 
 
 @pytest.fixture
-def _mock_settings():
+def _mock_settings(tmp_path):
     settings = MagicMock()
     settings.openai_api_key = "test-key"
     settings.stt_model = "whisper-1"
     settings.stt_provider = "openai"
-    with patch("pocketpaw.tools.builtin.stt.get_settings", return_value=settings):
+    settings.file_jail_path = tmp_path
+    with (
+        patch("pocketpaw.tools.builtin.stt.get_settings", return_value=settings),
+        patch("pocketpaw.tools.builtin.stt.is_safe_path", return_value=True),
+    ):
         yield settings
 
 
@@ -56,10 +60,33 @@ async def test_stt_no_api_key(tmp_path):
     settings = MagicMock()
     settings.openai_api_key = None
     settings.stt_provider = "openai"
-    with patch("pocketpaw.tools.builtin.stt.get_settings", return_value=settings):
+    settings.file_jail_path = tmp_path
+    with (
+        patch("pocketpaw.tools.builtin.stt.get_settings", return_value=settings),
+        patch("pocketpaw.tools.builtin.stt.is_safe_path", return_value=True),
+    ):
         result = await tool.execute(audio_file=str(audio_file))
     assert result.startswith("Error:")
     assert "API key" in result
+
+
+async def test_stt_file_jail_rejects_outside_path(tmp_path):
+    """Files outside the jail directory must be rejected."""
+    from pocketpaw.tools.builtin.stt import SpeechToTextTool
+
+    tool = SpeechToTextTool()
+    jail = tmp_path / "jail"
+    jail.mkdir()
+    outside = tmp_path / "outside.mp3"
+    outside.write_bytes(b"\x00" * 100)
+
+    settings = MagicMock()
+    settings.file_jail_path = jail
+    with patch("pocketpaw.tools.builtin.stt.get_settings", return_value=settings):
+        result = await tool.execute(audio_file=str(outside))
+
+    assert result.startswith("Error:")
+    assert "Access denied" in result or "outside" in result
 
 
 async def test_stt_file_not_found(_mock_settings):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -146,7 +146,8 @@ class TestConfig:
 
         monkeypatch.delenv("POCKETPAW_LLM_PROVIDER", raising=False)
         monkeypatch.delenv("POCKETPAW_OLLAMA_HOST", raising=False)
-        settings = Settings()
+        monkeypatch.delenv("POCKETPAW_AGENT_BACKEND", raising=False)
+        settings = Settings(_env_file=None)
 
         assert settings.agent_backend == "claude_agent_sdk"  # New default
         assert settings.llm_provider == "auto"


### PR DESCRIPTION
## What does this PR do?

This PR implements critical security hardening and stability fixes identified during a runtime audit. It enforces the file sandbox (jail) for media tools to prevent path traversal and introduces defensive event handling in the agent loop to prevent crashes from malformed API responses.

## Related Issue

Fixes #944 

## Changes Made

- src/pocketpaw/tools/builtin/ocr.py: Added is_safe_path validation to prevent unauthorized file access.
 
- src/pocketpaw/tools/builtin/stt.py: Added is_safe_path validation to prevent unauthorized file access.
 
- src/pocketpaw/agents/loop.py: Implemented getattr with dictionary fallback for streaming events to prevent AttributeError.
 
- src/pocketpaw/tools/builtin/desktop.py: Removed unreachable return statement and legacy comments to restore screenshot functionality.
 
- tests/conftest.py: Added session-scoped asyncio child watcher fixture for test suite compatibility on Unix systems.
 

## How to Test

- Run uv run pocketpaw --dev.
 
- Ask the agent to OCR a file outside the jail (e.g., /etc/passwd). Verify it returns an "Access denied" error.
 
- Trigger a screenshot capture and verify the file is correctly saved to ~/.pocketpaw/jail/screenshots/.
 
- Run the test suite: uv run pytest --ignore=tests/e2e.
 

## Evidence of Testing
All modified files pass ruff check.
Security validation correctly blocks path traversal in OCR/STT modules.
Agent loop successfully handles raw dictionary events without silent crashes.
Checklist Instructions

Once you paste this, make sure to manually click the checkboxes in the preview or add an x inside the brackets like this: [x].

[x] PR targets dev branch (Crucial, as noted in the header)

[x] Linked to an existing issue

[x] Tests pass

[x] Linting passes

[x] No secrets or credentials in the diff (Double-check that .env wasn't added!)