### PR TITLE
feat(fleet): REST router for templates + install endpoints

### DIFF
--- a/ee/fleet/router.py
+++ b/ee/fleet/router.py
@@ -1,0 +1,206 @@
+# ee/fleet/router.py — REST surface for the fleet install subsystem.
+# Created: 2026-04-16 (feat/fleet-rest-router) — Exposes the Python
+# primitives shipped in the fleet installer + journal-emission patches so
+# paw-enterprise's InstallFleetPanel can list bundled templates and
+# trigger an install over HTTP. Matches the existing ee router pattern:
+# internal ``prefix="/fleet"`` + registered via _EE_ROUTERS at
+# ``/api/v1``, giving ``/api/v1/fleet/templates`` and
+# ``/api/v1/fleet/install``.
+#
+# Journal emission is opt-in per request. When ``journal=true`` the
+# router lazily opens a local SQLite journal at
+# ``~/.pocketpaw/journal/fleet.db`` so every install is observable even
+# without an org-scoped journal wiring. The heavier per-org Journal
+# dependency-injection can supersede this later without breaking callers.
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from ee.fleet import (
+    FleetInstallReport,
+    FleetTemplate,
+    install_fleet,
+    list_bundled_fleets,
+    load_fleet,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/fleet", tags=["Fleet"])
+
+
+_DEFAULT_JOURNAL_PATH = Path.home() / ".pocketpaw" / "journal" / "fleet.db"
+
+
+# ---------------------------------------------------------------------------
+# Request / response envelopes
+# ---------------------------------------------------------------------------
+
+
+class FleetTemplatesResponse(BaseModel):
+    """List response for ``GET /fleet/templates``.
+
+    Wraps the templates in a top-level envelope so the payload has space
+    for future pagination / total counts without a breaking change.
+    """
+
+    templates: list[FleetTemplate]
+    total: int
+
+
+class ActorSpec(BaseModel):
+    """Optional caller identity forwarded to the journal on install.
+
+    When omitted the installer's built-in ``system:fleet-installer``
+    actor is recorded instead. Keeps the router stateless while still
+    letting richer clients (paw-enterprise) attribute installs to the
+    logged-in operator.
+    """
+
+    kind: str = "user"
+    id: str
+    scope_context: list[str] = Field(default_factory=list)
+
+
+class InstallFleetRequest(BaseModel):
+    """Body for ``POST /fleet/install``.
+
+    ``journal`` opts into the v0.3.1 correlated-event trio. ``actor``
+    lets a caller attribute the install to a specific identity.
+    """
+
+    template_name: str
+    journal: bool = True
+    actor: ActorSpec | None = None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — isolated so tests can patch them without touching
+# the filesystem or soul-protocol internals.
+# ---------------------------------------------------------------------------
+
+
+def _load_all_bundled() -> list[FleetTemplate]:
+    """Resolve every bundled fleet name to a full FleetTemplate.
+
+    Templates that fail to parse are skipped with a warning — one bad
+    template shouldn't sink the whole list endpoint for every caller.
+    """
+
+    templates: list[FleetTemplate] = []
+    for name in list_bundled_fleets():
+        try:
+            templates.append(load_fleet(name))
+        except Exception as exc:  # noqa: BLE001 — observability only.
+            logger.warning("Skipping bundled fleet %s: %s", name, exc)
+    return templates
+
+
+def _open_default_journal() -> Any | None:
+    """Open (or create) the default fleet journal at the canonical path.
+
+    Returns ``None`` when soul-protocol is not installed or the journal
+    cannot be opened — the installer tolerates a missing journal and
+    the request still succeeds.
+    """
+
+    try:
+        from soul_protocol.engine.journal import open_journal
+    except ImportError:
+        logger.warning(
+            "Fleet install: soul-protocol not available, skipping journal emission. "
+            "Install `pocketpaw[soul]` or pass journal=false to silence this.",
+        )
+        return None
+
+    try:
+        _DEFAULT_JOURNAL_PATH.parent.mkdir(parents=True, exist_ok=True)
+        return open_journal(_DEFAULT_JOURNAL_PATH)
+    except Exception:  # noqa: BLE001 — observability only.
+        logger.exception("Fleet install: failed to open default journal")
+        return None
+
+
+def _resolve_actor(spec: ActorSpec | None) -> Any | None:
+    """Translate an ``ActorSpec`` payload to a soul-protocol Actor.
+
+    Returns ``None`` when no spec was supplied so the installer's
+    default system actor is used instead.
+    """
+
+    if spec is None:
+        return None
+    try:
+        from soul_protocol.spec.journal import Actor
+    except ImportError:
+        return None
+    return Actor(kind=spec.kind, id=spec.id, scope_context=list(spec.scope_context))
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/templates", response_model=FleetTemplatesResponse)
+async def get_templates() -> FleetTemplatesResponse:
+    """Return every bundled fleet template the server knows about.
+
+    This is what paw-enterprise's InstallFleetPanel calls on mount to
+    populate its picker. Each entry is the full ``FleetTemplate`` so
+    the UI can show description, connectors, widgets, and scopes
+    without a second round-trip.
+    """
+
+    templates = _load_all_bundled()
+    return FleetTemplatesResponse(templates=templates, total=len(templates))
+
+
+@router.post("/install", response_model=FleetInstallReport)
+async def post_install(req: InstallFleetRequest) -> FleetInstallReport:
+    """Install a bundled fleet by name.
+
+    Resolves ``template_name`` via ``load_fleet()``, installs it, and
+    returns the ``FleetInstallReport`` verbatim. Unknown names return
+    404 with a clear message. When ``journal=true`` the installer
+    emits the correlated ``fleet.install.started`` /
+    ``agent.spawned`` / ``fleet.installed`` event trio.
+    """
+
+    try:
+        fleet = load_fleet(req.template_name)
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Fleet template '{req.template_name}' not found",
+        ) from None
+    except Exception as exc:
+        logger.exception("Fleet install: failed to load template %s", req.template_name)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Failed to load fleet template: {exc}",
+        ) from exc
+
+    journal = _open_default_journal() if req.journal else None
+    actor = _resolve_actor(req.actor)
+
+    try:
+        report = await install_fleet(fleet, journal=journal, actor=actor)
+    finally:
+        # open_journal returns a resource with a close() method on the
+        # SQLite backend. Closing keeps the per-request writer from
+        # leaking file handles under load.
+        close = getattr(journal, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:  # noqa: BLE001 — best-effort cleanup.
+                logger.debug("Fleet install: journal close failed", exc_info=True)
+
+    return report

--- a/src/pocketpaw/api/v1/__init__.py
+++ b/src/pocketpaw/api/v1/__init__.py
@@ -1,6 +1,9 @@
 # API v1 router aggregation.
 # Created: 2026-02-20
 # Updated: 2026-03-30 — Added Automations router (enterprise, rule-based pocket automations).
+# Updated: 2026-04-16 (feat/fleet-rest-router) — Added Fleet router so
+#   paw-enterprise's InstallFleetPanel can call GET /api/v1/fleet/templates
+#   and POST /api/v1/fleet/install against a running pocketpaw instance.
 #
 # mount_v1_routers(app) registers all domain routers at /api/v1/ (canonical).
 # Existing dashboard.py endpoints at /api/ remain as backward-compat aliases.
@@ -53,6 +56,7 @@ _V1_ROUTERS: list[tuple[str, str, str]] = [
 # Enterprise API routes (require ee/ module) — skipped silently when ee/ is absent.
 _EE_ROUTERS: list[tuple[str, str, str]] = [
     ("ee.fabric.router", "router", "Fabric"),
+    ("ee.fleet.router", "router", "Fleet"),
     ("ee.instinct.router", "router", "Instinct"),
     ("pocketpaw.ee.automations.router", "router", "Automations"),
 ]

--- a/tests/ee/test_fleet_router.py
+++ b/tests/ee/test_fleet_router.py
@@ -1,0 +1,343 @@
+# tests/ee/test_fleet_router.py — FastAPI TestClient coverage for the
+# fleet REST router shipped in feat/fleet-rest-router.
+# Created: 2026-04-16 — Asserts the router's contract with the
+# paw-enterprise InstallFleetPanel: list bundled templates, install by
+# name, emit journal events when opted in, 404 on unknown template,
+# 422 on a malformed body.
+#
+# Mocks the soul-protocol + connector + pocket factories out at the
+# ee.fleet.router seam so these tests stay hermetic — no filesystem
+# journal writes, no mongo, no soul-protocol runtime.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from soul_protocol.engine.journal import open_journal
+
+from ee.fleet import FleetTemplate
+from ee.fleet.router import router
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — app, client, and a fake fleet factory stack so we never boot
+# a real soul runtime inside the test suite.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    a = FastAPI()
+    a.include_router(router)
+    return a
+
+
+@pytest.fixture
+def fake_soul_factory():
+    """Return a ``SoulFactory``-shaped double.
+
+    The installer duck-types on ``load_bundled(name)`` + ``from_template``
+    so we only need those two methods. The soul object itself needs a
+    ``did`` and ``name`` — the installer's ``_agent_spawned_payload``
+    reads them into the journal event.
+    """
+
+    factory = MagicMock()
+    template = MagicMock()
+    template.name = "Arrow"
+    factory.load_bundled = MagicMock(return_value=template)
+
+    soul = MagicMock()
+    soul.did = "did:soul:fake-sales-fleet"
+    soul.name = "Arrow"
+    factory.from_template = AsyncMock(return_value=soul)
+    return factory
+
+
+@pytest.fixture
+def patch_install_fleet(fake_soul_factory):
+    """Replace ``ee.fleet.router.install_fleet`` with a version that
+    always hands the fake soul factory to the real installer.
+
+    This keeps journal wiring + report shape real (the tests assert
+    on them) without requiring a real SoulFactory on the import path.
+    """
+
+    from ee.fleet import install_fleet as real_install
+
+    async def _wrapped(fleet, **kwargs):
+        kwargs.setdefault("soul_factory", fake_soul_factory)
+        return await real_install(fleet, **kwargs)
+
+    with patch("ee.fleet.router.install_fleet", side_effect=_wrapped) as mock:
+        yield mock
+
+
+@pytest.fixture
+def journal_path(tmp_path: Path):
+    """Redirect ``_open_default_journal`` to a disposable SQLite path.
+
+    The router opens (and closes) the journal per request — mirroring
+    production where each install is an isolated HTTP round-trip. The
+    fixture itself yields the path so tests can re-open a read handle
+    after the request completes.
+    """
+
+    path = tmp_path / "router_journal.db"
+
+    def _factory() -> Any:
+        return open_journal(path)
+
+    with patch("ee.fleet.router._open_default_journal", side_effect=_factory):
+        yield path
+
+
+@pytest.fixture
+def read_journal(journal_path: Path):
+    """Expose a helper that re-opens the journal for read assertions
+    after the install request has closed its own writer handle.
+    """
+
+    def _read() -> list:
+        reader = open_journal(journal_path)
+        try:
+            return reader.query(limit=100)
+        finally:
+            reader.close()
+
+    return _read
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# GET /fleet/templates
+# ---------------------------------------------------------------------------
+
+
+class TestGetTemplates:
+    def test_returns_bundled_templates_envelope(self, client: TestClient) -> None:
+        """The list endpoint returns the canonical envelope shape with at
+        least one bundled template — currently ``sales-fleet`` ships with
+        the package; any additions should keep the count >= 1.
+        """
+
+        resp = client.get("/fleet/templates")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "templates" in body
+        assert "total" in body
+        assert body["total"] == len(body["templates"])
+        assert body["total"] >= 1
+
+    def test_templates_have_full_shape(self, client: TestClient) -> None:
+        """Every entry validates as a FleetTemplate so the UI can render
+        description + connectors + widgets without a second round-trip.
+        """
+
+        resp = client.get("/fleet/templates")
+        assert resp.status_code == 200
+        for entry in resp.json()["templates"]:
+            parsed = FleetTemplate.model_validate(entry)
+            assert parsed.name
+            assert parsed.soul_template
+            assert parsed.pocket_name
+
+    def test_sales_fleet_is_present(self, client: TestClient) -> None:
+        """``sales-fleet`` is the canonical reference fleet — its presence
+        is a regression guard if the bundled directory moves.
+        """
+
+        resp = client.get("/fleet/templates")
+        names = [t["name"] for t in resp.json()["templates"]]
+        assert "sales-fleet" in names
+
+    def test_bad_template_is_skipped(self, client: TestClient, monkeypatch) -> None:
+        """A single bad template can't take down the list endpoint — it
+        is logged and skipped while the rest still render.
+        """
+
+        def _explode(name: str) -> FleetTemplate:
+            if name == "broken":
+                raise ValueError("simulated parse error")
+            return FleetTemplate(
+                name=name,
+                soul_template="arrow",
+                pocket_name="Pipeline",
+            )
+
+        monkeypatch.setattr(
+            "ee.fleet.router.list_bundled_fleets",
+            lambda: ["broken", "ok"],
+        )
+        monkeypatch.setattr("ee.fleet.router.load_fleet", _explode)
+
+        resp = client.get("/fleet/templates")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["templates"][0]["name"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# POST /fleet/install — happy path, journal opt-in, 404, 422.
+# ---------------------------------------------------------------------------
+
+
+class TestInstallFleet:
+    def test_installs_known_template_and_returns_report(
+        self,
+        client: TestClient,
+        patch_install_fleet,
+    ) -> None:
+        """``sales-fleet`` installs end-to-end against fake factories and
+        the router returns the serialized ``FleetInstallReport``. The
+        report's ``soul_id`` tracks the fake soul from the factory.
+        """
+
+        resp = client.post(
+            "/fleet/install",
+            json={"template_name": "sales-fleet", "journal": False},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["fleet"] == "sales-fleet"
+        assert body["soul_id"] == "did:soul:fake-sales-fleet"
+        assert isinstance(body["steps"], list)
+        assert body["steps"], "install report should record at least one step"
+
+    def test_install_with_journal_emits_correlated_events(
+        self,
+        client: TestClient,
+        patch_install_fleet,
+        journal_path,
+        read_journal,
+    ) -> None:
+        """``journal=true`` wires the default journal into the installer
+        and yields the canonical ``fleet.install.started`` /
+        ``agent.spawned`` / ``fleet.installed`` trio sharing one
+        correlation id.
+        """
+
+        resp = client.post(
+            "/fleet/install",
+            json={"template_name": "sales-fleet", "journal": True},
+        )
+        assert resp.status_code == 200
+
+        events = read_journal()
+        actions = [e.action for e in events]
+        assert actions == [
+            "fleet.install.started",
+            "agent.spawned",
+            "fleet.installed",
+        ]
+        corr_ids = {e.correlation_id for e in events}
+        assert len(corr_ids) == 1
+
+    def test_install_without_journal_does_not_open_one(
+        self,
+        client: TestClient,
+        patch_install_fleet,
+    ) -> None:
+        """``journal=false`` must not even attempt to open the default
+        journal — keeps the router silent when callers opt out.
+        """
+
+        with patch("ee.fleet.router._open_default_journal") as opener:
+            resp = client.post(
+                "/fleet/install",
+                json={"template_name": "sales-fleet", "journal": False},
+            )
+
+        assert resp.status_code == 200
+        opener.assert_not_called()
+
+    def test_unknown_template_returns_404(self, client: TestClient) -> None:
+        """Missing templates surface as 404 with a message that names the
+        offending ``template_name``.
+        """
+
+        resp = client.post(
+            "/fleet/install",
+            json={"template_name": "does-not-exist", "journal": False},
+        )
+        assert resp.status_code == 404
+        assert "does-not-exist" in resp.json()["detail"]
+
+    def test_malformed_body_returns_422(self, client: TestClient) -> None:
+        """Missing required ``template_name`` field must fail validation
+        before the installer is even considered.
+        """
+
+        resp = client.post("/fleet/install", json={})
+        assert resp.status_code == 422
+
+    def test_actor_spec_is_forwarded_to_installer(
+        self,
+        client: TestClient,
+        patch_install_fleet,
+        journal_path,
+        read_journal,
+    ) -> None:
+        """When the caller supplies an ActorSpec it reaches the journal
+        events as the authoring actor instead of the fallback
+        ``system:fleet-installer`` identity.
+        """
+
+        resp = client.post(
+            "/fleet/install",
+            json={
+                "template_name": "sales-fleet",
+                "journal": True,
+                "actor": {
+                    "kind": "user",
+                    "id": "user-123",
+                    "scope_context": ["org:sales:*"],
+                },
+            },
+        )
+        assert resp.status_code == 200
+
+        events = read_journal()
+        assert events, "journal should have captured events"
+        for event in events:
+            assert event.actor.kind == "user"
+            assert event.actor.id == "user-123"
+
+
+# ---------------------------------------------------------------------------
+# Response shape — a smoke test to keep Pydantic warnings out of the logs
+# when FastAPI serializes the install report.
+# ---------------------------------------------------------------------------
+
+
+class TestResponseShape:
+    def test_install_report_serializes_without_warnings(
+        self,
+        client: TestClient,
+        patch_install_fleet,
+        recwarn: Any,
+    ) -> None:
+        """Serialising the install report must not raise PydanticSerializationUnexpectedValue
+        or similar warnings — the router's response_model is the canonical
+        ``FleetInstallReport`` so downstream TypeScript clients can rely on it.
+        """
+
+        resp = client.post(
+            "/fleet/install",
+            json={"template_name": "sales-fleet", "journal": False},
+        )
+        assert resp.status_code == 200
+        pydantic_warnings = [
+            w for w in recwarn.list if "pydantic" in str(w.category).lower()
+        ]
+        assert not pydantic_warnings, [str(w) for w in pydantic_warnings]

--- a/tests/ee/test_fleet_router.py
+++ b/tests/ee/test_fleet_router.py
@@ -23,7 +23,6 @@ from soul_protocol.engine.journal import open_journal
 from ee.fleet import FleetTemplate
 from ee.fleet.router import router
 
-
 # ---------------------------------------------------------------------------
 # Fixtures — app, client, and a fake fleet factory stack so we never boot
 # a real soul runtime inside the test suite.
@@ -337,7 +336,5 @@ class TestResponseShape:
             json={"template_name": "sales-fleet", "journal": False},
         )
         assert resp.status_code == 200
-        pydantic_warnings = [
-            w for w in recwarn.list if "pydantic" in str(w.category).lower()
-        ]
+        pydantic_warnings = [w for w in recwarn.list if "pydantic" in str(w.category).lower()]
         assert not pydantic_warnings, [str(w) for w in pydantic_warnings]


### PR DESCRIPTION
## Why

#940 shipped the Python primitives for fleet installs (`install_fleet`, `load_fleet`, `list_bundled_fleets`) and #947 wired the correlated journal trio. paw-enterprise's `InstallFleetPanel` already calls `GET /fleet/templates` and `POST /fleet/install`, but nothing on the server answered — every call got a 404.

This PR adds the FastAPI surface so the panel can actually list and install bundled fleets against a running pocketpaw.

## What ships

- `ee/fleet/router.py` — `APIRouter(prefix="/fleet")`, registered in `_EE_ROUTERS` so it mounts at `/api/v1/fleet` alongside Fabric, Instinct, and Automations.

**Endpoints**

- `GET /api/v1/fleet/templates` — returns `{templates: FleetTemplate[], total: int}`. Each entry is the full template (description, soul template, pocket, widgets, connectors, scopes) so the UI renders without a second round-trip. A template that fails to parse is logged and skipped — one bad YAML doesn't sink the list.
- `POST /api/v1/fleet/install` — body `{template_name, journal=true, actor?}`. Returns `FleetInstallReport`. Unknown template → 404. Missing `template_name` → 422. `journal=true` lazily opens `~/.pocketpaw/journal/fleet.db` and feeds it to the installer so the `fleet.install.started` / `agent.spawned` / `fleet.installed` trio lands. `actor` lets a caller attribute the install to the logged-in operator; when omitted, the installer's `system:fleet-installer` identity is used.

## Journal wiring — opt-in default rather than DI

There is no `get_journal` dependency anywhere in ee/ today. Rather than invent a new cross-cutting primitive for a wiring PR, this router opens a local SQLite journal at the canonical pocketpaw path when `journal=true`. Org-scoped journal DI can supersede this later without changing the HTTP contract. Flagged in the router docstring.

## SSE streaming — deferred

The task brief called the `/fleet/install/{correlation_id}/events` stream optional. It stays optional because `soul_protocol.engine.journal` exposes `append` + `query` but no subscription hook — a live tail would need new primitives (pub/sub on the journal or a polling adapter on the router). Neither fits in a wiring PR. Follow-up.

## Tests

11 new tests at `tests/ee/test_fleet_router.py` using `TestClient` — the same pattern as the existing instinct / paw-print router tests:

- `GET /fleet/templates` returns the envelope with at least one entry.
- Every entry validates as a `FleetTemplate`.
- `sales-fleet` is present (regression guard for the bundled directory).
- A broken template is skipped.
- `POST /fleet/install` with `sales-fleet` installs and returns the report.
- `journal=true` emits the canonical trio under one correlation id.
- `journal=false` never even opens the default journal.
- Unknown template → 404 with the offending name in the detail.
- Missing `template_name` → 422.
- `actor` payload reaches the journal as the authoring actor.
- Install report serialises without Pydantic warnings.

Full suite: `4069 passed, 7 skipped` in 71s.

## Notes for reviewers

- Router follows the `automations` / `instinct` internal-`prefix` style (not the cloud domain auth-gated style) — this tier doesn't need MongoDB or session auth.
- Only `sales-fleet` is currently bundled; the task brief's Arrow/Flash/Cyborg/Analyst count was stale so the list test asserts `>= 1` rather than pinning a number.
- The journal handle is opened fresh per request and closed in a `finally` so high-throughput installs don't leak SQLite writers.

## Test plan

- [x] `uv run pytest tests/ee/ -v` — 23 passed
- [x] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py` — 4069 passed
- [ ] Manual: start a dashboard, hit `GET /api/v1/fleet/templates`, confirm `sales-fleet` comes back with full shape
- [ ] Manual: `POST /api/v1/fleet/install` with `{"template_name":"sales-fleet","journal":true}`, inspect `~/.pocketpaw/journal/fleet.db` for the trio
- [ ] paw-enterprise #73 (InstallFleetPanel) against this branch