### PR TITLE
feat(ee): get_journal FastAPI dep + migrate fleet router onto it

### DIFF
--- a/ee/fleet/router.py
+++ b/ee/fleet/router.py
@@ -7,20 +7,22 @@
 # ``/api/v1``, giving ``/api/v1/fleet/templates`` and
 # ``/api/v1/fleet/install``.
 #
-# Journal emission is opt-in per request. When ``journal=true`` the
-# router lazily opens a local SQLite journal at
-# ``~/.pocketpaw/journal/fleet.db`` so every install is observable even
-# without an org-scoped journal wiring. The heavier per-org Journal
-# dependency-injection can supersede this later without breaking callers.
+# Updated: 2026-04-16 (feat/ee-journal-dep) — dropped the local
+# ``~/.pocketpaw/journal/fleet.db`` in favour of the shared
+# ``ee.journal_dep.get_journal`` FastAPI dependency. Now every ee/ route
+# writes into the same org journal (SOUL_DATA_DIR or ~/.soul/), so the
+# audit trail is no longer split across two SQLite files. The request
+# body flag ``journal`` still defaults to True; setting it False opts
+# out and passes ``None`` into ``install_fleet`` unchanged.
 
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+from soul_protocol.engine.journal import Journal
 
 from ee.fleet import (
     FleetInstallReport,
@@ -29,13 +31,11 @@ from ee.fleet import (
     list_bundled_fleets,
     load_fleet,
 )
+from ee.journal_dep import get_journal
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/fleet", tags=["Fleet"])
-
-
-_DEFAULT_JOURNAL_PATH = Path.home() / ".pocketpaw" / "journal" / "fleet.db"
 
 
 # ---------------------------------------------------------------------------
@@ -102,31 +102,6 @@ def _load_all_bundled() -> list[FleetTemplate]:
     return templates
 
 
-def _open_default_journal() -> Any | None:
-    """Open (or create) the default fleet journal at the canonical path.
-
-    Returns ``None`` when soul-protocol is not installed or the journal
-    cannot be opened — the installer tolerates a missing journal and
-    the request still succeeds.
-    """
-
-    try:
-        from soul_protocol.engine.journal import open_journal
-    except ImportError:
-        logger.warning(
-            "Fleet install: soul-protocol not available, skipping journal emission. "
-            "Install `pocketpaw[soul]` or pass journal=false to silence this.",
-        )
-        return None
-
-    try:
-        _DEFAULT_JOURNAL_PATH.parent.mkdir(parents=True, exist_ok=True)
-        return open_journal(_DEFAULT_JOURNAL_PATH)
-    except Exception:  # noqa: BLE001 — observability only.
-        logger.exception("Fleet install: failed to open default journal")
-        return None
-
-
 def _resolve_actor(spec: ActorSpec | None) -> Any | None:
     """Translate an ``ActorSpec`` payload to a soul-protocol Actor.
 
@@ -163,14 +138,19 @@ async def get_templates() -> FleetTemplatesResponse:
 
 
 @router.post("/install", response_model=FleetInstallReport)
-async def post_install(req: InstallFleetRequest) -> FleetInstallReport:
+async def post_install(
+    req: InstallFleetRequest,
+    journal: Journal = Depends(get_journal),
+) -> FleetInstallReport:
     """Install a bundled fleet by name.
 
     Resolves ``template_name`` via ``load_fleet()``, installs it, and
     returns the ``FleetInstallReport`` verbatim. Unknown names return
-    404 with a clear message. When ``journal=true`` the installer
-    emits the correlated ``fleet.install.started`` /
-    ``agent.spawned`` / ``fleet.installed`` event trio.
+    404 with a clear message. When ``journal=true`` (the default) the
+    installer receives the org's canonical Journal and emits the
+    correlated ``fleet.install.started`` / ``agent.spawned`` /
+    ``fleet.installed`` event trio; ``journal=false`` forwards ``None``
+    so the installer skips emission.
     """
 
     try:
@@ -187,20 +167,10 @@ async def post_install(req: InstallFleetRequest) -> FleetInstallReport:
             detail=f"Failed to load fleet template: {exc}",
         ) from exc
 
-    journal = _open_default_journal() if req.journal else None
     actor = _resolve_actor(req.actor)
+    effective_journal: Journal | None = journal if req.journal else None
 
-    try:
-        report = await install_fleet(fleet, journal=journal, actor=actor)
-    finally:
-        # open_journal returns a resource with a close() method on the
-        # SQLite backend. Closing keeps the per-request writer from
-        # leaking file handles under load.
-        close = getattr(journal, "close", None)
-        if callable(close):
-            try:
-                close()
-            except Exception:  # noqa: BLE001 — best-effort cleanup.
-                logger.debug("Fleet install: journal close failed", exc_info=True)
-
-    return report
+    # Journal lifetime is managed by the dependency (process-scoped
+    # singleton via lru_cache) — no per-request close, that would defeat
+    # the cache and churn SQLite connections under load.
+    return await install_fleet(fleet, journal=effective_journal, actor=actor)

--- a/ee/journal_dep.py
+++ b/ee/journal_dep.py
@@ -1,0 +1,63 @@
+# ee/journal_dep.py — Org-level Journal FastAPI dependency for ee/ routers.
+# Created: 2026-04-16 (feat/ee-journal-dep) — #948's fleet router opened a
+# second SQLite journal at ~/.pocketpaw/journal/fleet.db so it could emit
+# the correlated install trio without a wired org journal. That works but
+# splits the audit trail across two files. This module is the shared
+# dependency every ee/ route should use instead: one Journal per process,
+# rooted at the canonical org data dir (SOUL_DATA_DIR or ~/.soul/), so the
+# whole org shares one append-only event log.
+#
+# SQLite WAL is concurrent-safe at the file level, but re-opening on every
+# request still pays the connection + pragma cost. ``@lru_cache`` keeps one
+# Python instance alive for the life of the process. Tests that need a
+# disposable journal should use FastAPI's ``app.dependency_overrides``
+# pattern instead of mutating the cache — ``reset_journal_cache()`` is
+# offered only as a belt-and-braces escape hatch for unit-level coverage.
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+
+from soul_protocol.engine.journal import Journal, open_journal
+
+
+def _org_data_dir() -> Path:
+    """Resolve the canonical org data directory.
+
+    ``SOUL_DATA_DIR`` wins when set — that's how operators point an
+    install at a custom volume. Falls back to ``~/.soul/`` which matches
+    the default soul-protocol engine layout.
+    """
+
+    env = os.environ.get("SOUL_DATA_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".soul"
+
+
+@lru_cache(maxsize=1)
+def _cached_journal() -> Journal:
+    """Open the org journal once per process and reuse it thereafter."""
+
+    data_dir = _org_data_dir()
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return open_journal(data_dir / "journal.db")
+
+
+def get_journal() -> Journal:
+    """FastAPI dependency returning the org's canonical Journal.
+
+    Pair with ``Depends(get_journal)`` in route signatures. Tests should
+    override via ``app.dependency_overrides[get_journal] = ...`` rather
+    than touching ``_cached_journal`` directly.
+    """
+
+    return _cached_journal()
+
+
+def reset_journal_cache() -> None:
+    """Drop the cached Journal instance — for tests that need isolation."""
+
+    _cached_journal.cache_clear()

--- a/tests/ee/test_fleet_router.py
+++ b/tests/ee/test_fleet_router.py
@@ -5,9 +5,18 @@
 # name, emit journal events when opted in, 404 on unknown template,
 # 422 on a malformed body.
 #
+# Updated: 2026-04-16 (feat/ee-journal-dep) — swapped the
+# ``_open_default_journal`` patch for FastAPI's ``dependency_overrides``
+# so tests exercise the same ``get_journal`` seam production uses.
+# The override points at a ``tmp_path`` SQLite file so tests never
+# touch the real ``~/.soul/`` dir. ``journal=false`` is now verified by
+# inspecting the ``install_fleet`` call signature instead of asserting
+# the dep was never called (it's always resolved; the router decides
+# whether to forward it).
+#
 # Mocks the soul-protocol + connector + pocket factories out at the
 # ee.fleet.router seam so these tests stay hermetic — no filesystem
-# journal writes, no mongo, no soul-protocol runtime.
+# journal writes to the real data dir, no mongo, no soul-protocol runtime.
 
 from __future__ import annotations
 
@@ -22,6 +31,7 @@ from soul_protocol.engine.journal import open_journal
 
 from ee.fleet import FleetTemplate
 from ee.fleet.router import router
+from ee.journal_dep import get_journal, reset_journal_cache
 
 # ---------------------------------------------------------------------------
 # Fixtures — app, client, and a fake fleet factory stack so we never boot
@@ -29,10 +39,42 @@ from ee.fleet.router import router
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _isolate_journal_cache():
+    """Drop any Journal cached by a previous test before/after each run.
+
+    The dep's ``lru_cache`` is module-global, so without a reset an open
+    handle from an earlier test could leak into the next one and mask
+    override bugs.
+    """
+
+    reset_journal_cache()
+    yield
+    reset_journal_cache()
+
+
 @pytest.fixture
-def app() -> FastAPI:
+def journal_path(tmp_path: Path) -> Path:
+    """A disposable SQLite path the tests' ``get_journal`` override
+    points at. Shared between the override factory and the read helper.
+    """
+
+    return tmp_path / "router_journal.db"
+
+
+@pytest.fixture
+def app(journal_path: Path) -> FastAPI:
+    """FastAPI app with the fleet router mounted + ``get_journal``
+    overridden to write into a tmp-path journal.
+
+    Using ``dependency_overrides`` is the canonical FastAPI pattern for
+    swapping collaborators in tests — it exercises the real Depends
+    wiring instead of monkey-patching an internal helper.
+    """
+
     a = FastAPI()
     a.include_router(router)
+    a.dependency_overrides[get_journal] = lambda: open_journal(journal_path)
     return a
 
 
@@ -75,25 +117,6 @@ def patch_install_fleet(fake_soul_factory):
 
     with patch("ee.fleet.router.install_fleet", side_effect=_wrapped) as mock:
         yield mock
-
-
-@pytest.fixture
-def journal_path(tmp_path: Path):
-    """Redirect ``_open_default_journal`` to a disposable SQLite path.
-
-    The router opens (and closes) the journal per request — mirroring
-    production where each install is an isolated HTTP round-trip. The
-    fixture itself yields the path so tests can re-open a read handle
-    after the request completes.
-    """
-
-    path = tmp_path / "router_journal.db"
-
-    def _factory() -> Any:
-        return open_journal(path)
-
-    with patch("ee.fleet.router._open_default_journal", side_effect=_factory):
-        yield path
 
 
 @pytest.fixture
@@ -217,13 +240,13 @@ class TestInstallFleet:
         self,
         client: TestClient,
         patch_install_fleet,
-        journal_path,
         read_journal,
     ) -> None:
-        """``journal=true`` wires the default journal into the installer
-        and yields the canonical ``fleet.install.started`` /
+        """``journal=true`` hands the shared org Journal into the
+        installer and yields the canonical ``fleet.install.started`` /
         ``agent.spawned`` / ``fleet.installed`` trio sharing one
-        correlation id.
+        correlation id. Under the dependency override the journal lives
+        at ``tmp_path``, so we can re-open it for read assertions.
         """
 
         resp = client.post(
@@ -242,23 +265,25 @@ class TestInstallFleet:
         corr_ids = {e.correlation_id for e in events}
         assert len(corr_ids) == 1
 
-    def test_install_without_journal_does_not_open_one(
+    def test_install_without_journal_forwards_none(
         self,
         client: TestClient,
         patch_install_fleet,
     ) -> None:
-        """``journal=false`` must not even attempt to open the default
-        journal — keeps the router silent when callers opt out.
+        """``journal=false`` must forward ``None`` into ``install_fleet``.
+        The dep itself is still resolved (FastAPI has no graceful way to
+        skip it), but the router is responsible for the opt-out.
         """
 
-        with patch("ee.fleet.router._open_default_journal") as opener:
-            resp = client.post(
-                "/fleet/install",
-                json={"template_name": "sales-fleet", "journal": False},
-            )
-
+        resp = client.post(
+            "/fleet/install",
+            json={"template_name": "sales-fleet", "journal": False},
+        )
         assert resp.status_code == 200
-        opener.assert_not_called()
+
+        assert patch_install_fleet.call_count == 1
+        kwargs = patch_install_fleet.call_args.kwargs
+        assert kwargs["journal"] is None
 
     def test_unknown_template_returns_404(self, client: TestClient) -> None:
         """Missing templates surface as 404 with a message that names the
@@ -284,7 +309,6 @@ class TestInstallFleet:
         self,
         client: TestClient,
         patch_install_fleet,
-        journal_path,
         read_journal,
     ) -> None:
         """When the caller supplies an ActorSpec it reaches the journal

--- a/tests/ee/test_journal_dep.py
+++ b/tests/ee/test_journal_dep.py
@@ -1,0 +1,85 @@
+# tests/ee/test_journal_dep.py — Coverage for the shared ``get_journal``
+# FastAPI dependency shipped in feat/ee-journal-dep.
+# Created: 2026-04-16 — Pins three contracts the rest of ee/ depends on:
+# the dep returns a real ``Journal`` instance, successive calls hit the
+# cache (one Journal per process), and ``SOUL_DATA_DIR`` is honored as
+# the override knob operators use to pin the data dir to a custom volume.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from soul_protocol.engine.journal import Journal
+
+from ee.journal_dep import _org_data_dir, get_journal, reset_journal_cache
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Each test gets a disposable ``SOUL_DATA_DIR`` + a clean cache.
+
+    The lru_cache is module-global, so without the reset a stale instance
+    from a previous test would mask env-var changes in the next one.
+    """
+
+    monkeypatch.setenv("SOUL_DATA_DIR", str(tmp_path))
+    reset_journal_cache()
+    yield
+    reset_journal_cache()
+
+
+class TestGetJournal:
+    def test_returns_journal_instance(self) -> None:
+        """The dep returns a ready-to-use ``Journal`` rooted at the org
+        data dir. Callers should be able to ``append()`` immediately.
+        """
+
+        journal = get_journal()
+        assert isinstance(journal, Journal)
+
+    def test_is_cached_across_calls(self) -> None:
+        """Two calls inside one process return the exact same instance —
+        re-opening SQLite on every request would churn file handles and
+        defeat the point of the dependency.
+        """
+
+        first = get_journal()
+        second = get_journal()
+        assert first is second
+
+    def test_honors_soul_data_dir_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """``SOUL_DATA_DIR`` overrides the default ``~/.soul/`` location
+        so operators can point an install at any volume without editing
+        code. The override must be live — not frozen at import time.
+        """
+
+        custom = tmp_path / "custom-soul-data"
+        monkeypatch.setenv("SOUL_DATA_DIR", str(custom))
+        reset_journal_cache()
+
+        resolved = _org_data_dir()
+        assert resolved == custom
+
+        # Opening the journal creates the dir + the sqlite file, proving
+        # the env var flowed all the way through.
+        journal = get_journal()
+        assert isinstance(journal, Journal)
+        assert (custom / "journal.db").exists()
+
+
+class TestResetJournalCache:
+    def test_drops_cached_instance(self) -> None:
+        """``reset_journal_cache()`` is the escape hatch for tests that
+        need a fresh Journal. After reset the next ``get_journal()``
+        call must return a new instance, not the stale one.
+        """
+
+        first = get_journal()
+        reset_journal_cache()
+        second = get_journal()
+        assert first is not second


### PR DESCRIPTION
## Why

#948 landed the fleet REST router with a local workaround. With no shared DI for the org journal, the router opened its own SQLite at `~/.pocketpaw/journal/fleet.db` so the `fleet.install.started` / `agent.spawned` / `fleet.installed` trio had somewhere to land.

That works, but it splits the audit trail. Every new ee/ route that emits journal events would end up doing the same dance — opening its own file, closing it per request, picking a path — and an org ends up with N journals instead of one. The right shape is one Journal per process, rooted at the org data dir, injected via a shared dependency.

## What

- `ee/journal_dep.py` — `get_journal()` returns a process-scoped Journal opened at `SOUL_DATA_DIR` (or `~/.soul/`). Cached via `lru_cache` so the connection + pragmas aren't re-run on every request. `reset_journal_cache()` is offered for test isolation.
- `ee/fleet/router.py` — drops the local `_open_default_journal` + the per-request `close()`. The install endpoint now takes `journal: Journal = Depends(get_journal)`. The request body's `journal=false` opt-out still works: it forwards `None` into `install_fleet` so the installer skips emission.
- Tests — 3 new on `test_journal_dep.py` (instance shape, cache identity, `SOUL_DATA_DIR` override). `test_fleet_router.py` migrated off the `_open_default_journal` monkeypatch to FastAPI's `dependency_overrides`, pointing the dep at a `tmp_path` journal so tests never write to real `~/.soul/`.

## Behaviour changes

None observable to the caller beyond the storage location. The endpoint contract (`template_name`, `journal`, `actor`) is unchanged. `journal=true` still emits the canonical trio; `journal=false` still skips. The only user-visible difference is that events now land in the org journal at `~/.soul/journal.db` instead of a fleet-specific file.

## Follow-ups

- Every future ee/ route that needs to emit journal events should use `Depends(get_journal)` rather than opening its own file. Audited the tree — fleet was the only route doing this, so there's nothing else to migrate today.
- The `lru_cache` is a process-local singleton. Multi-process workers (gunicorn with `--workers > 1`) will each hold their own writer handle. SQLite WAL handles that safely, but if we ever outgrow SQLite's writer concurrency, the dep is the one seam to swap.

## Test plan

- [x] `uv run pytest tests/ee/ -xvs` — 27 passed (12 pre-existing + 8 router + 4 new dep tests, with the router suite migrated to `dependency_overrides`)
- [x] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py` — 4073 passed, 7 skipped, zero regressions
- [x] `uv run ruff check` + `uv run ruff format` — clean