### PR TITLE
feat(connectors): Google Drive SourceAdapter

### DIFF
--- a/connectors/drive.yaml
+++ b/connectors/drive.yaml
@@ -1,0 +1,68 @@
+# Google Drive connector — live file search, content fetch, and revision history.
+# Created: 2026-04-16
+# Pairs with src/pocketpaw/connectors/drive/ for the SourceAdapter surface.
+# Auth is OAuth 2.0 (bearer token) — either from the credential broker at
+# dispatch time or from GOOGLE_OAUTH_TOKEN for local dev.
+
+name: drive
+display_name: Google Drive
+type: knowledge
+icon: cloud
+
+auth:
+  method: bearer
+  credentials:
+    - name: GOOGLE_OAUTH_TOKEN
+      description: OAuth access token with https://www.googleapis.com/auth/drive.readonly (plus drive.file for writes)
+      required: true
+
+actions:
+  - name: list_files
+    description: List or browse files in Drive, newest first
+    method: GET
+    url: https://www.googleapis.com/drive/v3/files
+    params:
+      q: { type: string, description: "Drive search query (e.g. \"name contains 'forecast'\")" }
+      page_size: { type: integer, default: 20, description: "Max results (1-100)" }
+      order_by: { type: string, default: "modifiedTime desc" }
+    trust_level: auto
+
+  - name: search_files
+    description: Full-text search across Drive file contents and metadata
+    method: GET
+    url: https://www.googleapis.com/drive/v3/files
+    params:
+      query: { type: string, required: true, description: "Free-text search term; wrapped into fullText contains" }
+      page_size: { type: integer, default: 20 }
+    trust_level: auto
+
+  - name: get_file_content
+    description: Fetch the content of a single file, exporting Google Docs to PDF
+    method: GET
+    url: https://www.googleapis.com/drive/v3/files/{file_id}
+    params:
+      file_id: { type: string, required: true, description: "Drive file ID" }
+      revision_id: { type: string, description: "Specific revision to fetch (defaults to latest)" }
+    trust_level: auto
+
+  - name: get_file_revisions
+    description: List the edit history of a file for point-in-time retrieval
+    method: GET
+    url: https://www.googleapis.com/drive/v3/files/{file_id}/revisions
+    params:
+      file_id: { type: string, required: true }
+      page_size: { type: integer, default: 50 }
+    trust_level: auto
+
+sync:
+  # Drive is primarily live-federated via SourceAdapter — no batch sync table.
+  # The ingest path (DriveIngestAdapter, future) would populate drive_files.
+  table: drive_files
+  schedule: manual
+  mapping:
+    id: id
+    name: name
+    mime_type: mimeType
+    modified: modifiedTime
+    size: size
+    web_view_link: webViewLink

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,15 @@ gchat = [
     "google-api-python-client>=2.100.0",
     "google-auth>=2.25.0",
 ]
+drive = [
+    # Google Drive SourceAdapter (zero-copy live federation) — see
+    # src/pocketpaw/connectors/drive/. The client itself runs on httpx (core
+    # dep), but we ship the Google SDK alongside for parity with gchat and
+    # for future DriveIngestAdapter bulk-sync work.
+    "google-api-python-client>=2.100.0",
+    "google-auth>=2.25.0",
+    "google-auth-oauthlib>=1.2.0",
+]
 
 # --- Tool extras ---
 image = [
@@ -194,9 +203,10 @@ all-channels = [
     # teams
     "botbuilder-core>=4.16.0",
     "botbuilder-integration-aiohttp>=4.16.0",
-    # gchat
+    # gchat + drive
     "google-api-python-client>=2.100.0",
     "google-auth>=2.25.0",
+    "google-auth-oauthlib>=1.2.0",
 ]
 all-tools = [
     # browser
@@ -269,6 +279,7 @@ all = [
     "botbuilder-integration-aiohttp>=4.16.0",
     "google-api-python-client>=2.100.0",
     "google-auth>=2.25.0",
+    "google-auth-oauthlib>=1.2.0",
     # tools
     "google-genai>=1.0.0",
     "html2text>=2020.1.16",

--- a/src/pocketpaw/connectors/drive/__init__.py
+++ b/src/pocketpaw/connectors/drive/__init__.py
@@ -1,0 +1,30 @@
+# pocketpaw.connectors.drive — Google Drive adapter module.
+# Created: 2026-04-16 (Workstream C2 of the Org Architecture RFC).
+#
+# Public surface is the SourceAdapter (zero-copy live federation). The
+# matching IngestAdapter (copy-on-ingest) lives alongside and will land in
+# a follow-up PR once the ingest primitive from #939 settles.
+
+from __future__ import annotations
+
+from .auth import resolve_bearer_token
+from .client import DriveClient, DriveFile, DriveRevision
+from .errors import (
+    DriveAuthError,
+    DriveError,
+    DriveNotFoundError,
+    DriveRateLimitError,
+)
+from .source import DriveSourceAdapter
+
+__all__ = [
+    "DriveAuthError",
+    "DriveClient",
+    "DriveError",
+    "DriveFile",
+    "DriveNotFoundError",
+    "DriveRateLimitError",
+    "DriveRevision",
+    "DriveSourceAdapter",
+    "resolve_bearer_token",
+]

--- a/src/pocketpaw/connectors/drive/auth.py
+++ b/src/pocketpaw/connectors/drive/auth.py
@@ -64,8 +64,7 @@ def resolve_bearer_token(
         from pocketpaw.integrations.token_store import TokenStore
     except Exception as e:  # pragma: no cover - defensive
         raise DriveAuthError(
-            "no Drive bearer token available (credential empty, env unset, "
-            "OAuth store unavailable)"
+            "no Drive bearer token available (credential empty, env unset, OAuth store unavailable)"
         ) from e
 
     store = TokenStore()

--- a/src/pocketpaw/connectors/drive/auth.py
+++ b/src/pocketpaw/connectors/drive/auth.py
@@ -1,0 +1,119 @@
+# Drive OAuth helpers — bearer-token resolution for the connector layer.
+# Created: 2026-04-16 (Workstream C2 of the Org Architecture RFC).
+#
+# The retrieval router hands the adapter a ``Credential`` from the broker at
+# dispatch time. In production that credential's ``token`` is the bearer
+# string we send upstream. For local development and tool-path invocations
+# (the non-zero-copy builtin tools) we still need a way to materialise a
+# token: the fall-backs live here so ``source.py`` stays focused.
+#
+# Precedence order (first non-empty wins):
+#   1. ``Credential.token`` from the broker (zero-copy federation).
+#   2. ``GOOGLE_OAUTH_TOKEN`` env var (local dev / CI).
+#   3. ``pocketpaw.integrations.oauth.OAuthManager`` (existing token store
+#      populated by the OAuth flow in the dashboard).
+#
+# TODO(hardening): we inherit ``OAuthManager``'s current contract, which
+# refreshes lazily on access. For long-running dispatches we may want a
+# warm-up phase so the first parallel worker doesn't pay the refresh
+# latency for the whole batch. Deferred until the second concrete adapter
+# (Salesforce) confirms the pattern.
+
+from __future__ import annotations
+
+import logging
+import os
+
+from soul_protocol.engine.retrieval import Credential
+
+from .errors import DriveAuthError
+
+logger = logging.getLogger(__name__)
+
+_ENV_TOKEN = "GOOGLE_OAUTH_TOKEN"
+
+
+def resolve_bearer_token(
+    credential: Credential | None,
+    *,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Pick the best bearer token for a Drive call.
+
+    ``env`` is injectable for tests; defaults to ``os.environ``. Raises
+    :class:`DriveAuthError` when no source yields a usable token — the
+    adapter surfaces this as a ``sources_failed`` entry rather than crashing
+    the whole router.
+    """
+    if credential is not None and credential.token:
+        return credential.token
+
+    env_map = env if env is not None else os.environ
+    env_token = env_map.get(_ENV_TOKEN, "").strip()
+    if env_token:
+        return env_token
+
+    # Fall-through: the OAuth token store. Imported lazily because the
+    # ``integrations`` package loads config state that we don't want to
+    # pull in for pure-library imports.
+    try:
+        import asyncio
+
+        from pocketpaw.config import get_settings
+        from pocketpaw.integrations.oauth import OAuthManager
+        from pocketpaw.integrations.token_store import TokenStore
+    except Exception as e:  # pragma: no cover - defensive
+        raise DriveAuthError(
+            "no Drive bearer token available (credential empty, env unset, "
+            "OAuth store unavailable)"
+        ) from e
+
+    store = TokenStore()
+    # Short-circuit: if the OAuth store has nothing saved for Drive, skip the
+    # async roundtrip entirely. This matters for tests (avoids closing the
+    # default event loop with ``asyncio.run``) and for fresh installs where
+    # the user hasn't completed the OAuth flow yet — we fail fast with a
+    # clear error message instead of spinning up a loop just to get None.
+    try:
+        tokens = store.load("google_drive")
+    except Exception:
+        tokens = None
+    if tokens is None:
+        raise DriveAuthError(
+            "Drive OAuth token not found. Complete the OAuth flow in "
+            "Settings > Google OAuth > Authorize Drive, or set "
+            f"{_ENV_TOKEN} for headless usage."
+        )
+
+    manager = OAuthManager(store)
+    try:
+        settings = get_settings()
+    except Exception as e:  # pragma: no cover - config may not be loaded in tests
+        raise DriveAuthError(f"cannot read OAuth settings: {e}") from e
+
+    client_id = getattr(settings, "google_oauth_client_id", "") or ""
+    client_secret = getattr(settings, "google_oauth_client_secret", "") or ""
+
+    async def _fetch() -> str | None:
+        return await manager.get_valid_token(
+            service="google_drive",
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+
+    # Prefer an isolated loop so we never close the caller's default loop —
+    # ``asyncio.run`` would swap out the main-thread loop on teardown, which
+    # breaks any downstream code that called ``asyncio.get_event_loop()``.
+    loop = asyncio.new_event_loop()
+    try:
+        token = loop.run_until_complete(_fetch())
+    finally:
+        loop.close()
+
+    if not token:
+        raise DriveAuthError(
+            "Drive OAuth token not found. Complete the OAuth flow in "
+            "Settings > Google OAuth > Authorize Drive, or set "
+            f"{_ENV_TOKEN} for headless usage."
+        )
+    return token

--- a/src/pocketpaw/connectors/drive/client.py
+++ b/src/pocketpaw/connectors/drive/client.py
@@ -1,0 +1,394 @@
+# Google Drive client for the SourceAdapter — sync, rate-limited, point-in-time aware.
+# Created: 2026-04-16 (Workstream C2 of the Org Architecture RFC).
+#
+# This is the connector-layer client. It is deliberately separate from
+# ``pocketpaw.integrations.gdrive.DriveClient``, which is coupled to the
+# global OAuth token store used by the ``drive_*`` built-in tools. The
+# retrieval router hands us a short-lived ``Credential`` at dispatch time
+# (via the credential broker) so we never reach for a global token.
+#
+# Sync on purpose: ``SourceAdapter.query`` is sync in soul-protocol 0.3.1
+# (the router runs adapters on a thread pool under the ``parallel`` strategy).
+# Using ``httpx.Client`` keeps us in the same HTTP lib the rest of pocketpaw
+# already depends on without pulling in ``google-api-python-client`` as a
+# runtime requirement — the extra still ships it for parity with the
+# enterprise Gmail/Calendar stacks, but it is not imported here.
+#
+# Rate limit policy: Drive raises 429 (quota exceeded) and 403 with a
+# ``userRateLimitExceeded`` or ``rateLimitExceeded`` reason — Google's guide
+# explicitly lists both. We back off exponentially with jitter up to
+# ``max_retries``; anything else (401, 404, network error) is normalised to
+# one of the errors in ``errors.py`` and raised.
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+from .errors import (
+    DriveAuthError,
+    DriveError,
+    DriveNotFoundError,
+    DriveRateLimitError,
+)
+
+logger = logging.getLogger(__name__)
+
+_DRIVE_BASE = "https://www.googleapis.com/drive/v3"
+
+# Rate-limit tuning. Drive's per-user quota resets every 100 seconds, so
+# capping the retry budget around that window keeps a single wedged worker
+# from holding onto a thread forever.
+_DEFAULT_MAX_RETRIES = 5
+_DEFAULT_BASE_BACKOFF_S = 1.0
+_DEFAULT_MAX_BACKOFF_S = 30.0
+
+
+@dataclass
+class DriveFile:
+    """A single Drive file as returned by the API, normalised to our shape."""
+
+    id: str
+    name: str
+    mime_type: str = ""
+    modified_time: str = ""
+    size: int | None = None
+    web_view_link: str = ""
+    revision_id: str | None = None
+    owners: list[dict[str, Any]] = field(default_factory=list)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_api(cls, data: dict[str, Any]) -> DriveFile:
+        size_raw = data.get("size")
+        size = int(size_raw) if size_raw is not None else None
+        return cls(
+            id=str(data.get("id", "")),
+            name=str(data.get("name", "")),
+            mime_type=str(data.get("mimeType", "")),
+            modified_time=str(data.get("modifiedTime", "")),
+            size=size,
+            web_view_link=str(data.get("webViewLink", "")),
+            revision_id=data.get("headRevisionId") or data.get("revisionId"),
+            owners=list(data.get("owners", [])),
+            raw=dict(data),
+        )
+
+
+@dataclass
+class DriveRevision:
+    """One row from files.revisions.list — trimmed to what we actually use."""
+
+    id: str
+    modified_time: str
+    keep_forever: bool = False
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_api(cls, data: dict[str, Any]) -> DriveRevision:
+        return cls(
+            id=str(data.get("id", "")),
+            modified_time=str(data.get("modifiedTime", "")),
+            keep_forever=bool(data.get("keepForever", False)),
+            raw=dict(data),
+        )
+
+
+class DriveClient:
+    """Sync HTTP client for the Drive v3 API with exponential-backoff retries.
+
+    The client is re-entrant-safe but not thread-safe — create one per thread
+    (or per dispatch) when sharing is inconvenient. The ``RetrievalRouter``
+    already isolates per-request state via its thread pool, so the intended
+    pattern is ``DriveClient(token=credential.token)`` inside
+    ``SourceAdapter.query``.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        http: httpx.Client | None = None,
+        timeout_s: float = 15.0,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+        base_backoff_s: float = _DEFAULT_BASE_BACKOFF_S,
+        max_backoff_s: float = _DEFAULT_MAX_BACKOFF_S,
+    ) -> None:
+        if not token:
+            raise DriveAuthError("DriveClient requires a non-empty OAuth bearer token")
+        self._token = token
+        self._owns_http = http is None
+        self._http = http or httpx.Client(timeout=timeout_s)
+        self._max_retries = max_retries
+        self._base_backoff_s = base_backoff_s
+        self._max_backoff_s = max_backoff_s
+
+    def close(self) -> None:
+        if self._owns_http:
+            self._http.close()
+
+    def __enter__(self) -> DriveClient:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    # -- public API -------------------------------------------------------
+
+    def list_files(
+        self,
+        *,
+        query: str | None = None,
+        page_size: int = 20,
+        order_by: str = "modifiedTime desc",
+        fields: str | None = None,
+    ) -> list[DriveFile]:
+        """List or search files. ``query`` is a Drive search expression."""
+        fields = fields or (
+            "files(id,name,mimeType,modifiedTime,size,webViewLink,"
+            "headRevisionId,owners)"
+        )
+        params: dict[str, Any] = {
+            "pageSize": max(1, min(page_size, 100)),
+            "fields": fields,
+            "orderBy": order_by,
+        }
+        if query:
+            params["q"] = query
+        data = self._request("GET", f"{_DRIVE_BASE}/files", params=params)
+        return [DriveFile.from_api(f) for f in data.get("files", [])]
+
+    def search(self, text: str, *, page_size: int = 20) -> list[DriveFile]:
+        """Full-text search wrapper over ``list_files``."""
+        safe = text.replace("'", "\\'")
+        return self.list_files(query=f"fullText contains '{safe}'", page_size=page_size)
+
+    def get_file(self, file_id: str) -> DriveFile:
+        """Fetch metadata for a single file (no body)."""
+        params = {
+            "fields": (
+                "id,name,mimeType,modifiedTime,size,webViewLink,"
+                "headRevisionId,owners"
+            )
+        }
+        data = self._request("GET", f"{_DRIVE_BASE}/files/{file_id}", params=params)
+        return DriveFile.from_api(data)
+
+    def list_revisions(self, file_id: str, *, page_size: int = 50) -> list[DriveRevision]:
+        """List the revision history of a file, oldest first (Drive's order)."""
+        params = {
+            "pageSize": max(1, min(page_size, 200)),
+            "fields": "revisions(id,modifiedTime,keepForever)",
+        }
+        data = self._request(
+            "GET", f"{_DRIVE_BASE}/files/{file_id}/revisions", params=params
+        )
+        return [DriveRevision.from_api(r) for r in data.get("revisions", [])]
+
+    def revision_at(
+        self, file_id: str, point_in_time: datetime
+    ) -> DriveRevision | None:
+        """Return the most recent revision at or before ``point_in_time``.
+
+        Drive's revision timestamps are ISO-8601 UTC. We parse them with
+        ``datetime.fromisoformat`` after swapping the trailing ``Z`` —
+        anything malformed is silently skipped so a single bad row cannot
+        break the walk.
+        """
+        if point_in_time.tzinfo is None:
+            raise ValueError("point_in_time must be timezone-aware")
+        revisions = self.list_revisions(file_id)
+        best: DriveRevision | None = None
+        for rev in revisions:
+            ts = _parse_drive_ts(rev.modified_time)
+            if ts is None:
+                continue
+            if ts <= point_in_time and (best is None or ts > _parse_drive_ts(best.modified_time)):  # type: ignore[operator]
+                best = rev
+        return best
+
+    def get_content(
+        self, file_id: str, *, revision_id: str | None = None, max_bytes: int = 1_000_000
+    ) -> bytes:
+        """Download the file body, optionally pinned to a specific revision.
+
+        Google-native formats (Docs/Sheets/Slides) are exported to PDF — raw
+        ``alt=media`` returns a 400 for those. ``max_bytes`` caps the download
+        so the adapter never hands a 4 GB Drive video to the router.
+        """
+        headers = {"Authorization": f"Bearer {self._token}"}
+        # Need mimeType to decide export vs raw download.
+        meta = self.get_file(file_id)
+        export_map = {
+            "application/vnd.google-apps.document": "application/pdf",
+            "application/vnd.google-apps.presentation": "application/pdf",
+            "application/vnd.google-apps.spreadsheet": (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        }
+        if meta.mime_type in export_map:
+            url = f"{_DRIVE_BASE}/files/{file_id}/export"
+            params: dict[str, Any] = {"mimeType": export_map[meta.mime_type]}
+        else:
+            url = f"{_DRIVE_BASE}/files/{file_id}"
+            params = {"alt": "media"}
+            if revision_id:
+                # Drive serves historical bytes from the revisions sub-resource.
+                url = f"{_DRIVE_BASE}/files/{file_id}/revisions/{revision_id}"
+
+        resp = self._raw_request("GET", url, params=params, headers=headers, stream=True)
+        try:
+            buf = bytearray()
+            for chunk in resp.iter_bytes():
+                buf.extend(chunk)
+                if len(buf) >= max_bytes:
+                    break
+            return bytes(buf[:max_bytes])
+        finally:
+            resp.close()
+
+    # -- internals --------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Issue a JSON request with retries and error normalisation."""
+        headers = {
+            "Authorization": f"Bearer {self._token}",
+            "Accept": "application/json",
+        }
+        resp = self._raw_request(method, url, params=params, headers=headers, json=json)
+        try:
+            return resp.json()
+        except ValueError as e:
+            raise DriveError(f"Drive returned non-JSON body: {e}") from e
+        finally:
+            resp.close()
+
+    def _raw_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+        stream: bool = False,
+    ) -> httpx.Response:
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                if stream:
+                    resp = self._http.send(
+                        self._http.build_request(
+                            method, url, params=params, headers=headers, json=json
+                        ),
+                        stream=True,
+                    )
+                else:
+                    resp = self._http.request(
+                        method, url, params=params, headers=headers, json=json
+                    )
+            except httpx.HTTPError as e:
+                last_exc = e
+                if attempt >= self._max_retries:
+                    raise DriveError(f"Drive transport error: {e}") from e
+                self._sleep_backoff(attempt)
+                continue
+
+            status = resp.status_code
+            if status == 401:
+                resp.close()
+                raise DriveAuthError("Drive rejected credentials (HTTP 401)")
+            if status == 404:
+                resp.close()
+                raise DriveNotFoundError(f"Drive resource not found: {url}")
+            if status == 429 or (status == 403 and _is_rate_limit(resp)):
+                reason = _reason_from(resp)
+                resp.close()
+                if attempt >= self._max_retries:
+                    raise DriveRateLimitError(
+                        f"Drive rate limit exceeded after {attempt + 1} attempts ({reason})"
+                    )
+                logger.info(
+                    "drive rate-limited on attempt %d (%s); backing off", attempt + 1, reason
+                )
+                self._sleep_backoff(attempt)
+                continue
+            if status >= 400:
+                body = _safe_body(resp)
+                resp.close()
+                raise DriveError(f"Drive error {status}: {body}")
+
+            return resp
+
+        # Should never land here — the loop either returns or raises.
+        raise DriveError(f"drive request exhausted retries: {last_exc}")
+
+    def _sleep_backoff(self, attempt: int) -> None:
+        delay = min(
+            self._max_backoff_s,
+            self._base_backoff_s * (2**attempt) + random.uniform(0, 0.25),
+        )
+        time.sleep(delay)
+
+
+# -- helpers ----------------------------------------------------------------
+
+
+def _parse_drive_ts(value: str) -> datetime | None:
+    """Parse a Drive ``modifiedTime`` string into a tz-aware datetime."""
+    if not value:
+        return None
+    cleaned = value.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+
+
+def _is_rate_limit(resp: httpx.Response) -> bool:
+    """Drive packs quota errors into 403 with a specific reason string."""
+    try:
+        body = resp.json()
+    except ValueError:
+        return False
+    errors = body.get("error", {}).get("errors", []) if isinstance(body, dict) else []
+    for err in errors:
+        if not isinstance(err, dict):
+            continue
+        reason = err.get("reason", "")
+        if reason in {"rateLimitExceeded", "userRateLimitExceeded"}:
+            return True
+    return False
+
+
+def _reason_from(resp: httpx.Response) -> str:
+    try:
+        body = resp.json()
+    except ValueError:
+        return f"HTTP {resp.status_code}"
+    if not isinstance(body, dict):
+        return f"HTTP {resp.status_code}"
+    errors = body.get("error", {}).get("errors", [])
+    if errors and isinstance(errors[0], dict):
+        return errors[0].get("reason", f"HTTP {resp.status_code}")
+    return f"HTTP {resp.status_code}"
+
+
+def _safe_body(resp: httpx.Response) -> str:
+    try:
+        return resp.text[:500]
+    except Exception:
+        return f"<unreadable body, status={resp.status_code}>"

--- a/src/pocketpaw/connectors/drive/client.py
+++ b/src/pocketpaw/connectors/drive/client.py
@@ -151,8 +151,7 @@ class DriveClient:
     ) -> list[DriveFile]:
         """List or search files. ``query`` is a Drive search expression."""
         fields = fields or (
-            "files(id,name,mimeType,modifiedTime,size,webViewLink,"
-            "headRevisionId,owners)"
+            "files(id,name,mimeType,modifiedTime,size,webViewLink,headRevisionId,owners)"
         )
         params: dict[str, Any] = {
             "pageSize": max(1, min(page_size, 100)),
@@ -172,10 +171,7 @@ class DriveClient:
     def get_file(self, file_id: str) -> DriveFile:
         """Fetch metadata for a single file (no body)."""
         params = {
-            "fields": (
-                "id,name,mimeType,modifiedTime,size,webViewLink,"
-                "headRevisionId,owners"
-            )
+            "fields": ("id,name,mimeType,modifiedTime,size,webViewLink,headRevisionId,owners")
         }
         data = self._request("GET", f"{_DRIVE_BASE}/files/{file_id}", params=params)
         return DriveFile.from_api(data)
@@ -186,14 +182,10 @@ class DriveClient:
             "pageSize": max(1, min(page_size, 200)),
             "fields": "revisions(id,modifiedTime,keepForever)",
         }
-        data = self._request(
-            "GET", f"{_DRIVE_BASE}/files/{file_id}/revisions", params=params
-        )
+        data = self._request("GET", f"{_DRIVE_BASE}/files/{file_id}/revisions", params=params)
         return [DriveRevision.from_api(r) for r in data.get("revisions", [])]
 
-    def revision_at(
-        self, file_id: str, point_in_time: datetime
-    ) -> DriveRevision | None:
+    def revision_at(self, file_id: str, point_in_time: datetime) -> DriveRevision | None:
         """Return the most recent revision at or before ``point_in_time``.
 
         Drive's revision timestamps are ISO-8601 UTC. We parse them with

--- a/src/pocketpaw/connectors/drive/errors.py
+++ b/src/pocketpaw/connectors/drive/errors.py
@@ -1,0 +1,23 @@
+# Drive connector error hierarchy — normalised surface for API failures.
+# Created: 2026-04-16 (Workstream C2 of the Org Architecture RFC).
+#
+# Kept deliberately small. Callers should be able to tell "bad token" from
+# "rate limited" from "not found" without string-sniffing.
+
+from __future__ import annotations
+
+
+class DriveError(Exception):
+    """Base class for all errors raised by the Drive connector."""
+
+
+class DriveAuthError(DriveError):
+    """The OAuth token is missing, expired, or rejected by Drive."""
+
+
+class DriveRateLimitError(DriveError):
+    """Drive returned 429 (or 403 quota reason) after retries were exhausted."""
+
+
+class DriveNotFoundError(DriveError):
+    """The requested file, revision, or permission does not exist."""

--- a/src/pocketpaw/connectors/drive/source.py
+++ b/src/pocketpaw/connectors/drive/source.py
@@ -135,7 +135,7 @@ def _split_point_in_time(raw: str) -> tuple[datetime | None, str]:
     stripped = raw.strip()
     if not stripped.startswith(_POINT_IN_TIME_PREFIX):
         return None, raw
-    remainder = stripped[len(_POINT_IN_TIME_PREFIX):]
+    remainder = stripped[len(_POINT_IN_TIME_PREFIX) :]
     if "|" not in remainder:
         return _parse_iso(remainder.strip()), ""
     ts_text, rest = remainder.split("|", 1)

--- a/src/pocketpaw/connectors/drive/source.py
+++ b/src/pocketpaw/connectors/drive/source.py
@@ -1,0 +1,231 @@
+# DriveSourceAdapter — zero-copy federation over the Drive v3 API.
+# Created: 2026-04-16 (Workstream C2 of the Org Architecture RFC).
+#
+# This is the first concrete ``SourceAdapter`` in pocketpaw. The pattern
+# established here will be followed for Salesforce, Slack, Gmail, etc.:
+#
+#   1. Accept a ``Credential`` from the router's broker.
+#   2. Resolve a bearer token via ``auth.resolve_bearer_token``.
+#   3. Build a scoped sync HTTP client.
+#   4. Translate the request's ``query`` into a source-native query string.
+#   5. Return ``RetrievalCandidate`` rows with ``content`` shaped as a
+#      DataRef dict (live pointer, not copied bytes) and ``as_of`` pinned
+#      to the effective point-in-time.
+#   6. Empty results return ``[]`` — never raise.
+#
+# Point-in-time handling: soul-protocol 0.3.1's ``RetrievalRequest`` does
+# not yet carry a structured ``point_in_time`` field (tracked for a future
+# soul-protocol bump). We support it today via a lightweight convention
+# embedded in the query string:
+#
+#     "@at=2026-04-01T12:00:00Z | Q3 forecast"
+#
+# ``_split_point_in_time`` peels the prefix off and leaves the remainder
+# as the free-text query. When present, we walk the file's revision list
+# and pin the candidate to the matching historical revision id.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from soul_protocol.engine.retrieval import Credential
+from soul_protocol.spec.retrieval import RetrievalCandidate, RetrievalRequest
+
+from .auth import resolve_bearer_token
+from .client import DriveClient, DriveFile, DriveRevision
+from .errors import DriveAuthError, DriveError
+
+logger = logging.getLogger(__name__)
+
+_POINT_IN_TIME_PREFIX = "@at="
+
+
+class DriveSourceAdapter:
+    """``SourceAdapter`` implementation for Google Drive.
+
+    Fields:
+        source_name: Key used when the router matches ``sources_failed``
+            entries and ``CandidateSource.adapter_ref`` pointers. Defaults
+            to ``"drive"`` — keep stable unless running side-by-side with
+            a second Drive instance (e.g. personal vs enterprise).
+    """
+
+    # SourceAdapter Protocol attribute — we emit live DataRef payloads.
+    supports_dataref: bool = True
+
+    def __init__(
+        self,
+        *,
+        source_name: str = "drive",
+        client_factory: Any = None,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        self._source_name = source_name
+        # ``client_factory`` is injectable so tests can swap in a stub
+        # without monkey-patching module globals. Signature: (token) -> DriveClient.
+        self._client_factory = client_factory or (lambda token: DriveClient(token))
+        self._env = env
+
+    def query(
+        self,
+        request: RetrievalRequest,
+        credential: Credential | None,
+    ) -> list[RetrievalCandidate]:
+        try:
+            token = resolve_bearer_token(credential, env=self._env)
+        except DriveAuthError:
+            # Let the router surface this as a per-source failure. The
+            # router catches the exception and records it — we do NOT want
+            # to swallow it here because that would hide credential issues.
+            raise
+
+        point_in_time, text_query = _split_point_in_time(request.query)
+        drive_query = _translate_query(text_query)
+
+        client = self._client_factory(token)
+        try:
+            files = client.list_files(
+                query=drive_query,
+                page_size=max(1, min(request.limit, 100)),
+            )
+        except DriveError:
+            # Preserve the error type; the router records the reason.
+            raise
+
+        if not files:
+            return []
+
+        as_of = point_in_time or datetime.now(UTC)
+        candidates: list[RetrievalCandidate] = []
+        for position, drive_file in enumerate(files):
+            revision = None
+            if point_in_time is not None:
+                try:
+                    revision = client.revision_at(drive_file.id, point_in_time)
+                except DriveError as e:
+                    logger.warning(
+                        "revision lookup failed for %s: %s; emitting head candidate",
+                        drive_file.id,
+                        e,
+                    )
+            score = _score_for_position(position, len(files))
+            candidates.append(
+                RetrievalCandidate(
+                    source=self._source_name,
+                    content=_dataref_payload(
+                        drive_file,
+                        revision=revision,
+                        request_scopes=list(request.scopes),
+                    ),
+                    score=score,
+                    as_of=as_of,
+                    cached=False,
+                )
+            )
+        return candidates
+
+
+# -- helpers ---------------------------------------------------------------
+
+
+def _split_point_in_time(raw: str) -> tuple[datetime | None, str]:
+    """Peel an optional ``@at=<iso>|rest`` prefix off the request query."""
+    stripped = raw.strip()
+    if not stripped.startswith(_POINT_IN_TIME_PREFIX):
+        return None, raw
+    remainder = stripped[len(_POINT_IN_TIME_PREFIX):]
+    if "|" not in remainder:
+        return _parse_iso(remainder.strip()), ""
+    ts_text, rest = remainder.split("|", 1)
+    return _parse_iso(ts_text.strip()), rest.strip()
+
+
+def _parse_iso(value: str) -> datetime | None:
+    if not value:
+        return None
+    cleaned = value.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _translate_query(text: str) -> str | None:
+    """Map a free-text query to Drive's search syntax.
+
+    If the caller already passed a Drive-native expression (contains an
+    operator like ``fullText``, ``mimeType``, ``name``, ``owners``, or
+    ``and``) we pass it through unchanged. Otherwise we wrap the text in
+    ``fullText contains '...'`` with single quotes escaped.
+    """
+    if not text:
+        return None
+    lowered = text.lower()
+    drive_operators = (
+        "fulltext contains",
+        "name contains",
+        "mimetype",
+        "owners in",
+        "modifiedtime",
+        "sharedwithme",
+        "starred",
+    )
+    if any(op in lowered for op in drive_operators):
+        return text
+    escaped = text.replace("'", "\\'")
+    return f"fullText contains '{escaped}'"
+
+
+def _dataref_payload(
+    drive_file: DriveFile,
+    *,
+    revision: DriveRevision | None,
+    request_scopes: list[str],
+) -> dict[str, Any]:
+    """Build the DataRef-shaped dict the router hands to the decision-maker.
+
+    Shape is deliberately loose (soul-protocol's ``RetrievalCandidate.content``
+    is ``dict[str, Any]`` so the router never inspects it). We follow the
+    Zero-Copy convention agreed in the RFC: ``kind="dataref"``, plus enough
+    identifiers for a downstream resolver to fetch live bytes on demand.
+    """
+    ref: dict[str, Any] = {
+        "kind": "dataref",
+        "source": "drive",
+        "id": drive_file.id,
+        "name": drive_file.name,
+        "mime_type": drive_file.mime_type,
+        "modified_time": drive_file.modified_time,
+        "web_view_link": drive_file.web_view_link,
+        "scopes": request_scopes,
+    }
+    if drive_file.size is not None:
+        ref["size"] = drive_file.size
+    if drive_file.owners:
+        ref["owners"] = drive_file.owners
+    if revision is not None:
+        ref["revision_id"] = revision.id
+        ref["revision_modified_time"] = revision.modified_time
+    elif drive_file.revision_id:
+        ref["revision_id"] = drive_file.revision_id
+    return ref
+
+
+def _score_for_position(position: int, total: int) -> float:
+    """Linear falloff so Drive's native ordering is preserved after merge.
+
+    Drive returns files sorted by ``modifiedTime desc`` (or by Google's
+    relevance ranking when ``fullText`` is used). We map that ordering into
+    a ``[0.1, 1.0]`` score so multi-source merges with other adapters
+    still respect Drive's intent without swamping projection sources that
+    produce true relevance scores.
+    """
+    if total <= 1:
+        return 1.0
+    # position 0 -> 1.0, position total-1 -> 0.1
+    return max(0.1, 1.0 - (position / (total - 1)) * 0.9)

--- a/tests/connectors/__init__.py
+++ b/tests/connectors/__init__.py
@@ -1,0 +1,1 @@
+# Tests for pocketpaw.connectors.* adapters.

--- a/tests/connectors/test_drive.py
+++ b/tests/connectors/test_drive.py
@@ -1,0 +1,606 @@
+# Tests for the Google Drive SourceAdapter (Workstream C2).
+# Created: 2026-04-16.
+#
+# Covers:
+#   * DriveClient request plumbing (auth header, params, rate-limit retry,
+#     point-in-time revision lookup, no-results is not an error).
+#   * DriveSourceAdapter.query shape — candidate scope context, DataRef
+#     payload, as_of pinned to point-in-time, score ordering.
+#   * Token resolution precedence (credential > env > OAuth store).
+#   * End-to-end with a real RetrievalRouter + InMemoryCredentialBroker,
+#     asserting retrieval.query journal emission with the recorded payload.
+#
+# No real Drive API traffic — httpx.Client.request is stubbed with a
+# scripted fake so we can walk each retry branch without httpx mocks.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.engine.retrieval import (
+    InMemoryCredentialBroker,
+    RetrievalRouter,
+)
+from soul_protocol.spec.journal import Actor
+from soul_protocol.spec.retrieval import (
+    CandidateSource,
+    RetrievalRequest,
+)
+
+from pocketpaw.connectors.drive import (
+    DriveAuthError,
+    DriveClient,
+    DriveError,
+    DriveNotFoundError,
+    DriveRateLimitError,
+    DriveSourceAdapter,
+)
+from pocketpaw.connectors.drive.auth import resolve_bearer_token
+
+# ---------------------------------------------------------------------------
+# HTTP scripting helpers — a tiny replacement for httpx_mock so we don't pull
+# a new test dep into an already-heavy tree.
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    """Stands in for httpx.Response for both sync and streaming paths."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        json_data: Any = None,
+        body: bytes = b"",
+        raise_on_request: Exception | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self._json_data = json_data
+        self._body = body
+        self._raise = raise_on_request
+        self.closed = False
+        self.text = body.decode("utf-8", errors="replace") if body else ""
+
+    def json(self) -> Any:
+        if self._json_data is None:
+            raise ValueError("no json body")
+        return self._json_data
+
+    def iter_bytes(self, chunk_size: int | None = None):  # noqa: ARG002
+        yield self._body
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class ScriptedClient:
+    """httpx.Client stand-in with an in-order script of responses."""
+
+    def __init__(self, script: list[FakeResponse | Exception]) -> None:
+        # ``itertools.chain`` + final response lets tests assert retry pacing.
+        self._script = list(script)
+        self.calls: list[dict[str, Any]] = []
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> FakeResponse:
+        self.calls.append(
+            {"method": method, "url": url, "params": params, "headers": headers, "json": json}
+        )
+        if not self._script:
+            raise AssertionError("ScriptedClient ran out of scripted responses")
+        nxt = self._script.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return nxt
+
+    def build_request(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+        return {"method": method, "url": url, **kwargs}
+
+    def send(self, request: dict[str, Any], *, stream: bool = False):  # noqa: ARG002
+        return self.request(request["method"], request["url"])
+
+    def close(self) -> None:
+        pass
+
+
+def _ts(year: int = 2026, month: int = 4, day: int = 1, hour: int = 12) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=UTC)
+
+
+def _actor() -> Actor:
+    return Actor(kind="agent", id="did:soul:test-agent")
+
+
+# ---------------------------------------------------------------------------
+# DriveClient tests
+# ---------------------------------------------------------------------------
+
+
+class TestDriveClient:
+    def test_empty_token_raises(self) -> None:
+        with pytest.raises(DriveAuthError):
+            DriveClient(token="")
+
+    def test_list_files_happy_path(self) -> None:
+        script = [
+            FakeResponse(
+                json_data={
+                    "files": [
+                        {
+                            "id": "file_1",
+                            "name": "Q3 forecast",
+                            "mimeType": "application/vnd.google-apps.document",
+                            "modifiedTime": "2026-04-01T12:00:00.000Z",
+                            "size": "1024",
+                            "webViewLink": "https://drive.google.com/file_1",
+                            "headRevisionId": "rev-latest",
+                        }
+                    ]
+                }
+            )
+        ]
+        http = ScriptedClient(script)
+        client = DriveClient(token="fake-token", http=http)
+        files = client.list_files(query="fullText contains 'forecast'", page_size=20)
+
+        assert len(files) == 1
+        assert files[0].id == "file_1"
+        assert files[0].revision_id == "rev-latest"
+        assert http.calls[0]["headers"]["Authorization"] == "Bearer fake-token"
+        assert http.calls[0]["params"]["q"] == "fullText contains 'forecast'"
+        assert http.calls[0]["params"]["pageSize"] == 20
+
+    def test_list_files_no_results_returns_empty_list(self) -> None:
+        http = ScriptedClient([FakeResponse(json_data={"files": []})])
+        client = DriveClient(token="fake-token", http=http)
+        assert client.list_files(query="name contains 'nope'") == []
+
+    def test_401_raises_drive_auth_error(self) -> None:
+        http = ScriptedClient([FakeResponse(status_code=401, json_data={"error": "unauth"})])
+        client = DriveClient(token="stale", http=http)
+        with pytest.raises(DriveAuthError):
+            client.list_files()
+
+    def test_404_raises_not_found(self) -> None:
+        http = ScriptedClient([FakeResponse(status_code=404, json_data={})])
+        client = DriveClient(token="ok", http=http)
+        with pytest.raises(DriveNotFoundError):
+            client.get_file("missing")
+
+    def test_429_triggers_backoff_and_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleep_calls: list[float] = []
+        monkeypatch.setattr(
+            "pocketpaw.connectors.drive.client.time.sleep",
+            lambda s: sleep_calls.append(s),
+        )
+        script = [
+            FakeResponse(status_code=429, json_data={"error": {"message": "slow down"}}),
+            FakeResponse(status_code=429, json_data={"error": {"message": "slow down"}}),
+            FakeResponse(json_data={"files": [{"id": "f1", "name": "after retry"}]}),
+        ]
+        http = ScriptedClient(script)
+        client = DriveClient(token="ok", http=http, base_backoff_s=0.01, max_backoff_s=0.1)
+        files = client.list_files()
+
+        assert len(files) == 1
+        assert files[0].id == "f1"
+        assert len(sleep_calls) == 2  # backed off twice, succeeded on 3rd attempt
+
+    def test_403_quota_reason_also_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "pocketpaw.connectors.drive.client.time.sleep", lambda s: None
+        )
+        quota_body = {
+            "error": {
+                "errors": [{"reason": "userRateLimitExceeded", "message": "quota"}],
+                "code": 403,
+            }
+        }
+        script = [
+            FakeResponse(status_code=403, json_data=quota_body),
+            FakeResponse(json_data={"files": []}),
+        ]
+        http = ScriptedClient(script)
+        client = DriveClient(token="ok", http=http, base_backoff_s=0.01)
+        client.list_files()  # should not raise
+        assert len(http.calls) == 2
+
+    def test_rate_limit_budget_exhausted_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "pocketpaw.connectors.drive.client.time.sleep", lambda s: None
+        )
+        script = [FakeResponse(status_code=429, json_data={}) for _ in range(6)]
+        http = ScriptedClient(script)
+        client = DriveClient(token="ok", http=http, max_retries=2, base_backoff_s=0.01)
+        with pytest.raises(DriveRateLimitError):
+            client.list_files()
+
+    def test_other_4xx_raises_generic_drive_error(self) -> None:
+        http = ScriptedClient(
+            [FakeResponse(status_code=500, body=b"boom", json_data={"error": "boom"})]
+        )
+        client = DriveClient(token="ok", http=http, max_retries=0)
+        with pytest.raises(DriveError):
+            client.list_files()
+
+    def test_revision_at_picks_most_recent_before_point(self) -> None:
+        script = [
+            FakeResponse(
+                json_data={
+                    "revisions": [
+                        {"id": "r1", "modifiedTime": "2026-03-01T00:00:00Z"},
+                        {"id": "r2", "modifiedTime": "2026-03-15T00:00:00Z"},
+                        {"id": "r3", "modifiedTime": "2026-04-10T00:00:00Z"},
+                    ]
+                }
+            )
+        ]
+        http = ScriptedClient(script)
+        client = DriveClient(token="ok", http=http)
+
+        chosen = client.revision_at("file_1", _ts(2026, 4, 1))
+        assert chosen is not None
+        assert chosen.id == "r2"
+
+    def test_revision_at_returns_none_when_all_revisions_are_future(self) -> None:
+        script = [
+            FakeResponse(
+                json_data={
+                    "revisions": [{"id": "r1", "modifiedTime": "2027-01-01T00:00:00Z"}]
+                }
+            )
+        ]
+        http = ScriptedClient(script)
+        client = DriveClient(token="ok", http=http)
+        assert client.revision_at("file_1", _ts(2026, 4, 1)) is None
+
+    def test_revision_at_requires_aware_timestamp(self) -> None:
+        client = DriveClient(token="ok", http=ScriptedClient([]))
+        with pytest.raises(ValueError):
+            client.revision_at("file_1", datetime(2026, 4, 1))  # naive
+
+
+# ---------------------------------------------------------------------------
+# DriveSourceAdapter tests
+# ---------------------------------------------------------------------------
+
+
+class FakeDriveClient:
+    """Minimal client stub exposing the methods the adapter calls."""
+
+    def __init__(
+        self,
+        *,
+        files: list[dict[str, Any]] | None = None,
+        revisions: dict[str, list[dict[str, Any]]] | None = None,
+        raise_on_list: Exception | None = None,
+    ) -> None:
+        from pocketpaw.connectors.drive.client import DriveFile, DriveRevision
+
+        self._files = [DriveFile.from_api(f) for f in (files or [])]
+        self._revisions = revisions or {}
+        self._raise_on_list = raise_on_list
+        self.list_calls: list[tuple[str | None, int]] = []
+        self.revision_calls: list[tuple[str, datetime]] = []
+        self._DriveRevision = DriveRevision
+
+    def list_files(
+        self, *, query: str | None = None, page_size: int = 20, **kwargs: Any
+    ):
+        if self._raise_on_list is not None:
+            raise self._raise_on_list
+        self.list_calls.append((query, page_size))
+        return list(self._files)
+
+    def revision_at(self, file_id: str, point_in_time: datetime):
+        self.revision_calls.append((file_id, point_in_time))
+        revs = [self._DriveRevision.from_api(r) for r in self._revisions.get(file_id, [])]
+        # simple "most recent <= point_in_time" without reimplementing client logic
+        best = None
+        for rev in revs:
+            ts = datetime.fromisoformat(rev.modified_time.replace("Z", "+00:00"))
+            if ts <= point_in_time and (
+                best is None
+                or ts > datetime.fromisoformat(best.modified_time.replace("Z", "+00:00"))
+            ):
+                best = rev
+        return best
+
+
+def _sample_files() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "file_1",
+            "name": "Q3 forecast",
+            "mimeType": "application/vnd.google-apps.document",
+            "modifiedTime": "2026-04-05T10:00:00Z",
+            "size": "2048",
+            "webViewLink": "https://drive.google.com/file_1",
+            "headRevisionId": "rev-now",
+        },
+        {
+            "id": "file_2",
+            "name": "forecast notes",
+            "mimeType": "text/plain",
+            "modifiedTime": "2026-04-04T09:00:00Z",
+            "webViewLink": "https://drive.google.com/file_2",
+        },
+    ]
+
+
+def _make_request(query: str, scopes: list[str] | None = None, limit: int = 10) -> RetrievalRequest:
+    return RetrievalRequest(
+        query=query,
+        actor=_actor(),
+        scopes=scopes or ["org:sales:*"],
+        limit=limit,
+        strategy="parallel",
+        timeout_s=5.0,
+    )
+
+
+class TestDriveSourceAdapter:
+    def test_supports_dataref_is_true(self) -> None:
+        assert DriveSourceAdapter.supports_dataref is True
+
+    def test_query_returns_dataref_candidates(self) -> None:
+        fake = FakeDriveClient(files=_sample_files())
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: fake,
+            env={"GOOGLE_OAUTH_TOKEN": "env-token"},
+        )
+        request = _make_request("Q3 forecast")
+        candidates = adapter.query(request, credential=None)
+
+        assert len(candidates) == 2
+        payload = candidates[0].content
+        assert payload["kind"] == "dataref"
+        assert payload["source"] == "drive"
+        assert payload["id"] == "file_1"
+        assert payload["scopes"] == ["org:sales:*"]
+        # First candidate must rank higher than the second under position scoring.
+        assert candidates[0].score is not None
+        assert candidates[1].score is not None
+        assert candidates[0].score > candidates[1].score
+        # Without a point-in-time, as_of should be "now-ish" and cached=False.
+        assert candidates[0].cached is False
+
+    def test_query_translates_free_text_to_fulltext(self) -> None:
+        fake = FakeDriveClient(files=[])
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: fake,
+            env={"GOOGLE_OAUTH_TOKEN": "env-token"},
+        )
+        adapter.query(_make_request("revenue"), credential=None)
+        assert fake.list_calls[0][0] == "fullText contains 'revenue'"
+
+    def test_query_passes_native_drive_syntax_through(self) -> None:
+        fake = FakeDriveClient(files=[])
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: fake,
+            env={"GOOGLE_OAUTH_TOKEN": "env-token"},
+        )
+        adapter.query(
+            _make_request("name contains 'forecast' and mimeType='text/plain'"),
+            credential=None,
+        )
+        assert "mimeType" in fake.list_calls[0][0]
+
+    def test_query_empty_results_is_not_error(self) -> None:
+        fake = FakeDriveClient(files=[])
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: fake,
+            env={"GOOGLE_OAUTH_TOKEN": "env-token"},
+        )
+        result = adapter.query(_make_request("anything"), credential=None)
+        assert result == []
+
+    def test_query_point_in_time_pins_revision_and_as_of(self) -> None:
+        fake = FakeDriveClient(
+            files=[_sample_files()[0]],
+            revisions={
+                "file_1": [
+                    {"id": "rev-old", "modifiedTime": "2026-03-01T00:00:00Z"},
+                    {"id": "rev-mid", "modifiedTime": "2026-03-15T00:00:00Z"},
+                    {"id": "rev-new", "modifiedTime": "2026-04-10T00:00:00Z"},
+                ]
+            },
+        )
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: fake,
+            env={"GOOGLE_OAUTH_TOKEN": "env-token"},
+        )
+        request = _make_request("@at=2026-04-01T00:00:00Z | Q3 forecast")
+        candidates = adapter.query(request, credential=None)
+
+        assert len(candidates) == 1
+        payload = candidates[0].content
+        assert payload["revision_id"] == "rev-mid"
+        assert candidates[0].as_of == _ts(2026, 4, 1, 0)
+        assert fake.revision_calls == [("file_1", _ts(2026, 4, 1, 0))]
+
+    def test_query_uses_credential_token_when_provided(self) -> None:
+        from soul_protocol.engine.retrieval import InMemoryCredentialBroker
+
+        broker = InMemoryCredentialBroker()
+        credential = broker.acquire("drive", ["org:sales:*"])
+
+        captured: dict[str, str] = {}
+
+        def factory(token: str):
+            captured["token"] = token
+            return FakeDriveClient(files=[])
+
+        adapter = DriveSourceAdapter(client_factory=factory, env={})
+        adapter.query(_make_request("anything"), credential=credential)
+        assert captured["token"] == credential.token
+
+    def test_query_raises_auth_error_when_no_token_anywhere(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Patch the name the adapter actually imported (source.py captured
+        # a reference at import time). With an empty env AND the token
+        # resolver short-circuited, we should bubble DriveAuthError so the
+        # router can record it as ``sources_failed``.
+        from pocketpaw.connectors.drive import source as source_mod
+
+        def stub(credential, *, env=None):  # noqa: ARG001
+            raise DriveAuthError("no token")
+
+        monkeypatch.setattr(source_mod, "resolve_bearer_token", stub)
+
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: FakeDriveClient(files=[]),
+            env={},
+        )
+        with pytest.raises(DriveAuthError):
+            adapter.query(_make_request("anything"), credential=None)
+
+
+# ---------------------------------------------------------------------------
+# resolve_bearer_token precedence tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBearerToken:
+    def test_credential_wins_over_env(self) -> None:
+        from soul_protocol.engine.retrieval import InMemoryCredentialBroker
+
+        broker = InMemoryCredentialBroker()
+        cred = broker.acquire("drive", ["org:sales:*"])
+        token = resolve_bearer_token(cred, env={"GOOGLE_OAUTH_TOKEN": "env-value"})
+        assert token == cred.token
+
+    def test_env_used_when_no_credential(self) -> None:
+        token = resolve_bearer_token(None, env={"GOOGLE_OAUTH_TOKEN": "env-value"})
+        assert token == "env-value"
+
+    def test_raises_auth_error_when_nothing_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Force the integrations import path to raise so we exercise the
+        # "no source left" branch deterministically.
+        monkeypatch.setitem(
+            __import__("sys").modules,
+            "pocketpaw.integrations.oauth",
+            None,
+        )
+        with pytest.raises(DriveAuthError):
+            resolve_bearer_token(None, env={})
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: RetrievalRouter + DriveSourceAdapter + journal emission
+# ---------------------------------------------------------------------------
+
+
+class TestRouterIntegration:
+    @pytest.fixture
+    def journal(self, tmp_path: Path):
+        j = open_journal(tmp_path / "journal.db")
+        yield j
+        j.close()
+
+    def test_router_dispatches_to_drive_adapter_and_emits_query_event(
+        self, journal
+    ) -> None:
+        broker = InMemoryCredentialBroker(journal=journal)
+        router = RetrievalRouter(journal=journal, broker=broker)
+
+        fake = FakeDriveClient(files=_sample_files())
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: fake,
+            env={"GOOGLE_OAUTH_TOKEN": "unused"},  # broker will hand a real token
+        )
+        router.register_source(
+            CandidateSource(
+                name="drive",
+                kind="dataref",
+                scopes=["org:sales:*"],
+                adapter_ref="pocketpaw.connectors.drive:DriveSourceAdapter",
+            ),
+            adapter,
+        )
+
+        result = router.dispatch(_make_request("Q3 forecast"))
+
+        # Router produced candidates with the DataRef shape.
+        assert len(result.candidates) == 2
+        assert result.candidates[0].content["kind"] == "dataref"
+        assert result.sources_queried == ["drive"]
+        assert result.sources_failed == []
+
+        # Journal captured retrieval.query + the three broker lifecycle events
+        # (acquired/used — the broker also emits on acquire+use when a journal
+        # is attached, we just assert retrieval.query is present).
+        events = journal.query(limit=50)
+        actions = [e.action for e in events]
+        assert "retrieval.query" in actions
+        assert "credential.acquired" in actions  # dataref kind triggers the broker
+        assert "credential.used" in actions
+
+        query_event = next(e for e in events if e.action == "retrieval.query")
+        payload = query_event.payload
+        assert payload["query"] == "Q3 forecast"
+        assert payload["sources_queried"] == ["drive"]
+        assert payload["candidate_count"] == 2
+
+    def test_router_records_auth_failure_as_sources_failed(self, journal) -> None:
+        broker = InMemoryCredentialBroker(journal=journal)
+        router = RetrievalRouter(journal=journal, broker=broker)
+
+        class FailingAdapter(DriveSourceAdapter):
+            def query(self, request, credential):  # type: ignore[override]
+                raise DriveAuthError("token rejected")
+
+        adapter = FailingAdapter(
+            client_factory=lambda token: FakeDriveClient(files=[]),
+            env={"GOOGLE_OAUTH_TOKEN": "ignored"},
+        )
+        router.register_source(
+            CandidateSource(
+                name="drive",
+                kind="dataref",
+                scopes=["org:sales:*"],
+                adapter_ref="pocketpaw.connectors.drive:DriveSourceAdapter",
+            ),
+            adapter,
+        )
+
+        result = router.dispatch(_make_request("anything"))
+        assert result.candidates == []
+        assert len(result.sources_failed) == 1
+        failed_name, failed_reason = result.sources_failed[0]
+        assert failed_name == "drive"
+        assert "DriveAuthError" in failed_reason
+
+
+# ---------------------------------------------------------------------------
+# Smoke — make sure the module exposes the expected public API.
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_exports() -> None:
+    import pocketpaw.connectors.drive as mod
+
+    assert hasattr(mod, "DriveSourceAdapter")
+    assert hasattr(mod, "DriveClient")
+    assert hasattr(mod, "DriveAuthError")
+    assert hasattr(mod, "DriveRateLimitError")
+    assert hasattr(mod, "DriveNotFoundError")
+    assert hasattr(mod, "resolve_bearer_token")
+
+

--- a/tests/connectors/test_drive.py
+++ b/tests/connectors/test_drive.py
@@ -198,9 +198,7 @@ class TestDriveClient:
         assert len(sleep_calls) == 2  # backed off twice, succeeded on 3rd attempt
 
     def test_403_quota_reason_also_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(
-            "pocketpaw.connectors.drive.client.time.sleep", lambda s: None
-        )
+        monkeypatch.setattr("pocketpaw.connectors.drive.client.time.sleep", lambda s: None)
         quota_body = {
             "error": {
                 "errors": [{"reason": "userRateLimitExceeded", "message": "quota"}],
@@ -216,12 +214,8 @@ class TestDriveClient:
         client.list_files()  # should not raise
         assert len(http.calls) == 2
 
-    def test_rate_limit_budget_exhausted_raises(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(
-            "pocketpaw.connectors.drive.client.time.sleep", lambda s: None
-        )
+    def test_rate_limit_budget_exhausted_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("pocketpaw.connectors.drive.client.time.sleep", lambda s: None)
         script = [FakeResponse(status_code=429, json_data={}) for _ in range(6)]
         http = ScriptedClient(script)
         client = DriveClient(token="ok", http=http, max_retries=2, base_backoff_s=0.01)
@@ -258,9 +252,7 @@ class TestDriveClient:
     def test_revision_at_returns_none_when_all_revisions_are_future(self) -> None:
         script = [
             FakeResponse(
-                json_data={
-                    "revisions": [{"id": "r1", "modifiedTime": "2027-01-01T00:00:00Z"}]
-                }
+                json_data={"revisions": [{"id": "r1", "modifiedTime": "2027-01-01T00:00:00Z"}]}
             )
         ]
         http = ScriptedClient(script)
@@ -297,9 +289,7 @@ class FakeDriveClient:
         self.revision_calls: list[tuple[str, datetime]] = []
         self._DriveRevision = DriveRevision
 
-    def list_files(
-        self, *, query: str | None = None, page_size: int = 20, **kwargs: Any
-    ):
+    def list_files(self, *, query: str | None = None, page_size: int = 20, **kwargs: Any):
         if self._raise_on_list is not None:
             raise self._raise_on_list
         self.list_calls.append((query, page_size))
@@ -514,9 +504,7 @@ class TestRouterIntegration:
         yield j
         j.close()
 
-    def test_router_dispatches_to_drive_adapter_and_emits_query_event(
-        self, journal
-    ) -> None:
+    def test_router_dispatches_to_drive_adapter_and_emits_query_event(self, journal) -> None:
         broker = InMemoryCredentialBroker(journal=journal)
         router = RetrievalRouter(journal=journal, broker=broker)
 
@@ -602,5 +590,3 @@ def test_public_api_exports() -> None:
     assert hasattr(mod, "DriveRateLimitError")
     assert hasattr(mod, "DriveNotFoundError")
     assert hasattr(mod, "resolve_bearer_token")
-
-

--- a/uv.lock
+++ b/uv.lock
@@ -4316,6 +4316,7 @@ all = [
     { name = "google-adk" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
     { name = "google-genai" },
     { name = "html2text" },
     { name = "langchain-mcp-adapters" },
@@ -4348,6 +4349,7 @@ all-channels = [
     { name = "discord-cli-agent" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
     { name = "matrix-nio" },
     { name = "neonize" },
     { name = "python-telegram-bot" },
@@ -4427,6 +4429,11 @@ dev = [
 ]
 discord = [
     { name = "discord-cli-agent" },
+]
+drive = [
+    { name = "google-api-python-client" },
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
 ]
 enterprise = [
     { name = "beanie" },
@@ -4612,13 +4619,18 @@ requires-dist = [
     { name = "google-api-python-client", marker = "extra == 'all'", specifier = ">=2.100.0" },
     { name = "google-api-python-client", marker = "extra == 'all-channels'", specifier = ">=2.100.0" },
     { name = "google-api-python-client", marker = "extra == 'dev'", specifier = ">=2.100.0" },
+    { name = "google-api-python-client", marker = "extra == 'drive'", specifier = ">=2.100.0" },
     { name = "google-api-python-client", marker = "extra == 'enterprise'", specifier = ">=2.100.0" },
     { name = "google-api-python-client", marker = "extra == 'gchat'", specifier = ">=2.100.0" },
     { name = "google-auth", marker = "extra == 'all'", specifier = ">=2.25.0" },
     { name = "google-auth", marker = "extra == 'all-channels'", specifier = ">=2.25.0" },
     { name = "google-auth", marker = "extra == 'dev'", specifier = ">=2.25.0" },
+    { name = "google-auth", marker = "extra == 'drive'", specifier = ">=2.25.0" },
     { name = "google-auth", marker = "extra == 'enterprise'", specifier = ">=2.25.0" },
     { name = "google-auth", marker = "extra == 'gchat'", specifier = ">=2.25.0" },
+    { name = "google-auth-oauthlib", marker = "extra == 'all'", specifier = ">=1.2.0" },
+    { name = "google-auth-oauthlib", marker = "extra == 'all-channels'", specifier = ">=1.2.0" },
+    { name = "google-auth-oauthlib", marker = "extra == 'drive'", specifier = ">=1.2.0" },
     { name = "google-auth-oauthlib", marker = "extra == 'enterprise'", specifier = ">=1.2.0" },
     { name = "google-cloud-storage", marker = "extra == 'enterprise'", specifier = ">=2.14.0" },
     { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.0.0" },
@@ -4727,7 +4739,7 @@ requires-dist = [
     { name = "trafilatura", marker = "extra == 'knowledge'" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.31.1" },
 ]
-provides-extras = ["vector", "knowledge", "databases", "postgresql", "mysql", "mongodb", "graph", "dashboard", "telegram", "browser", "desktop", "openai-agents", "google-adk", "copilot-sdk", "deep-agents", "litellm", "memory", "soul", "discord", "slack", "whatsapp-personal", "matrix", "teams", "gchat", "image", "extract", "voice", "ocr", "sarvam", "mcp", "recommended", "channels", "all-channels", "all-tools", "all-backends", "enterprise", "all", "dev"]
+provides-extras = ["vector", "knowledge", "databases", "postgresql", "mysql", "mongodb", "graph", "dashboard", "telegram", "browser", "desktop", "openai-agents", "google-adk", "copilot-sdk", "deep-agents", "litellm", "memory", "soul", "discord", "slack", "whatsapp-personal", "matrix", "teams", "gchat", "drive", "image", "extract", "voice", "ocr", "sarvam", "mcp", "recommended", "channels", "all-channels", "all-tools", "all-backends", "enterprise", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
First concrete `SourceAdapter` in pocketpaw — pairs with the `RetrievalRouter` shipped in soul-protocol 0.3.1 and establishes the pattern we'll follow for Salesforce, Slack, and Gmail.

## What's in the box

- `connectors/drive.yaml` — ConnectorProtocol definition with the tool-surface actions (`list_files`, `search_files`, `get_file_content`, `get_file_revisions`) and their trust levels.
- `src/pocketpaw/connectors/drive/` — the Python module:
  - `client.py` — sync httpx-backed Drive v3 client. Exponential-backoff retry on 429 and on 403 responses that carry a `rateLimitExceeded` or `userRateLimitExceeded` reason. Exposes a `revision_at(file_id, point_in_time)` helper that walks the revisions list and returns the most recent revision at or before the requested timestamp.
  - `source.py` — `DriveSourceAdapter` implementing soul-protocol's `SourceAdapter` protocol (`supports_dataref = True`). Returns `RetrievalCandidate` rows whose `content` is a DataRef-shaped dict (`kind="dataref"`, source id, scopes, optional revision_id). Empty result sets come back as `[]`, not an exception.
  - `auth.py` — bearer-token resolver. Precedence: broker `Credential.token` → `GOOGLE_OAUTH_TOKEN` env → existing `OAuthManager` token store. Fails fast with `DriveAuthError` when none yield a token so the router can record it as `sources_failed`.
  - `errors.py` — `DriveError` base plus `DriveAuthError` / `DriveRateLimitError` / `DriveNotFoundError` so callers branch on failure shape instead of string-sniffing.
- `tests/connectors/test_drive.py` — 26 tests covering the client retry branches, adapter query shape, point-in-time revision pinning, credential precedence, and an end-to-end router dispatch that asserts both `retrieval.query` and `credential.acquired` land in the journal.
- `pyproject.toml` — new `drive` extra (`google-api-python-client`, `google-auth`, `google-auth-oauthlib`) and a matching entry under `all-channels` / `all` so `pip install pocketpaw[all]` keeps the set in sync.

## Point-in-time handling

soul-protocol 0.3.1's `RetrievalRequest` does not yet have a first-class `point_in_time` field. Until it does, the adapter reads an optional `@at=<iso>|<rest>` prefix off the query string — when present, the candidate's `as_of` is pinned to that timestamp and a `revision_id` is resolved via the Drive revisions API. Worth flagging as a minor spec gap to fix in the next soul-protocol bump.

## Tests

```
uv run pytest tests/connectors/test_drive.py -q
26 passed
```

Full suite: 4099 passed, 7 skipped. No live Drive API traffic — a small `ScriptedClient` stands in for `httpx.Client` across every retry and error branch.

## Review notes

- Client is sync on purpose. The router runs adapters on a thread pool under the `parallel` strategy, so async wrapping is soul-protocol's job for the next slice.
- The existing `pocketpaw.integrations.gdrive.DriveClient` is untouched. It drives the `drive_*` built-in tools and has a different contract (global OAuth token store). The new connector client owns per-dispatch credentials handed in by the broker.
- No merge — leaving for captain review before it lands on `dev`.