### PR TITLE
chore: sync dev → ee (post-v0.3.1 integration work)

### DIFF
--- a/connectors/drive.yaml
+++ b/connectors/drive.yaml
@@ -1,0 +1,68 @@
+# Google Drive connector — live file search, content fetch, and revision history.
+# Created: 2026-04-16
+# Pairs with src/pocketpaw/connectors/drive/ for the SourceAdapter surface.
+# Auth is OAuth 2.0 (bearer token) — either from the credential broker at
+# dispatch time or from GOOGLE_OAUTH_TOKEN for local dev.
+
+name: drive
+display_name: Google Drive
+type: knowledge
+icon: cloud
+
+auth:
+  method: bearer
+  credentials:
+    - name: GOOGLE_OAUTH_TOKEN
+      description: OAuth access token with https://www.googleapis.com/auth/drive.readonly (plus drive.file for writes)
+      required: true
+
+actions:
+  - name: list_files
+    description: List or browse files in Drive, newest first
+    method: GET
+    url: https://www.googleapis.com/drive/v3/files
+    params:
+      q: { type: string, description: "Drive search query (e.g. \"name contains 'forecast'\")" }
+      page_size: { type: integer, default: 20, description: "Max results (1-100)" }
+      order_by: { type: string, default: "modifiedTime desc" }
+    trust_level: auto
+
+  - name: search_files
+    description: Full-text search across Drive file contents and metadata
+    method: GET
+    url: https://www.googleapis.com/drive/v3/files
+    params:
+      query: { type: string, required: true, description: "Free-text search term; wrapped into fullText contains" }
+      page_size: { type: integer, default: 20 }
+    trust_level: auto
+
+  - name: get_file_content
+    description: Fetch the content of a single file, exporting Google Docs to PDF
+    method: GET
+    url: https://www.googleapis.com/drive/v3/files/{file_id}
+    params:
+      file_id: { type: string, required: true, description: "Drive file ID" }
+      revision_id: { type: string, description: "Specific revision to fetch (defaults to latest)" }
+    trust_level: auto
+
+  - name: get_file_revisions
+    description: List the edit history of a file for point-in-time retrieval
+    method: GET
+    url: https://www.googleapis.com/drive/v3/files/{file_id}/revisions
+    params:
+      file_id: { type: string, required: true }
+      page_size: { type: integer, default: 50 }
+    trust_level: auto
+
+sync:
+  # Drive is primarily live-federated via SourceAdapter — no batch sync table.
+  # The ingest path (DriveIngestAdapter, future) would populate drive_files.
+  table: drive_files
+  schedule: manual
+  mapping:
+    id: id
+    name: name
+    mime_type: mimeType
+    modified: modifiedTime
+    size: size
+    web_view_link: webViewLink

--- a/ee/fleet/__init__.py
+++ b/ee/fleet/__init__.py
@@ -1,0 +1,25 @@
+# Fleet — installable bundles of soul + pocket + connectors + scopes.
+# Created: 2026-04-13 (Move 7 PR-B) — A FleetTemplate is a YAML manifest
+# that a non-technical operator can install with one command. Reads the
+# manifest, creates the soul (via SoulFactory.from_template), creates the
+# pocket, registers the listed connectors, and seeds scope tags. Outputs
+# an InstallReport so the UI/CLI can show what landed and what failed.
+
+from ee.fleet.installer import (
+    FleetInstallReport,
+    FleetInstallStep,
+    install_fleet,
+    list_bundled_fleets,
+    load_fleet,
+)
+from ee.fleet.models import FleetConnector, FleetTemplate
+
+__all__ = [
+    "FleetConnector",
+    "FleetInstallReport",
+    "FleetInstallStep",
+    "FleetTemplate",
+    "install_fleet",
+    "list_bundled_fleets",
+    "load_fleet",
+]

--- a/ee/fleet/installer.py
+++ b/ee/fleet/installer.py
@@ -6,14 +6,23 @@
 # Updated: 2026-04-16 — PyYAML import-error message now points at
 # `pocketpaw[soul]` (the pocketpaw extra that pulls PyYAML in via
 # soul-protocol[engine]) instead of the transitive package name.
+# Updated: 2026-04-16 (feat/fleet-journal-emission) — install_fleet now
+# accepts an optional Journal + Actor and emits a correlated trio of events
+# on every run: one `fleet.install.started` (extension namespace), one
+# canonical `agent.spawned` per soul created, and one `fleet.installed`
+# summary at the end. The journal parameter is opt-in so existing callers
+# (tests, CLI without an org) keep working unchanged. Emission errors are
+# logged and swallowed — the journal is observability, not control flow.
 
 from __future__ import annotations
 
 import json
 import logging
 import time
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+from uuid import UUID, uuid4
 
 from ee.fleet.models import (
     FleetConnector,
@@ -22,7 +31,14 @@ from ee.fleet.models import (
     FleetTemplate,
 )
 
+if TYPE_CHECKING:
+    from soul_protocol.engine.journal import Journal
+    from soul_protocol.spec.journal import Actor
+
 logger = logging.getLogger(__name__)
+
+
+_SYSTEM_INSTALLER_ACTOR_ID = "system:fleet-installer"
 
 
 _BUNDLED_DIR = Path(__file__).parent.parent.parent / "src" / "pocketpaw" / "fleet_templates"
@@ -73,19 +89,66 @@ async def install_fleet(
     soul_factory: Any | None = None,
     connector_registry: Any | None = None,
     pocket_creator: Any | None = None,
+    journal: Journal | None = None,
+    actor: Actor | None = None,
 ) -> FleetInstallReport:
     """Install a fleet by orchestrating soul + pocket + connector creation.
 
     Each external dependency is injectable so tests can substitute fakes.
     Production callers pass the real SoulFactory, ConnectorRegistry, and
     pocket service; install_fleet itself remains a pure orchestrator.
+
+    When a ``journal`` is supplied, the installer emits a correlated event
+    trio for the run:
+
+    * ``fleet.install.started`` (extension namespace) when the run begins.
+    * ``agent.spawned`` (canonical namespace) for each soul created.
+    * ``fleet.installed`` (extension namespace) only when the soul step
+      succeeded — a partial install stops at the step boundary and leaves
+      no terminal event, so projections and UI tailers can see the gap.
+
+    All three events share a single ``correlation_id`` (generated per run)
+    and carry the fleet's declared ``scopes`` verbatim. If ``actor`` is
+    omitted, a ``system:fleet-installer`` actor is recorded so events are
+    attributable without an org root soul present.
+
+    Journal errors are logged and swallowed. The installer's return value
+    is the existing :class:`FleetInstallReport` regardless of emission.
     """
     report = FleetInstallReport(fleet=fleet.name)
 
+    correlation_id = uuid4()
+    scope = _resolve_scope(fleet)
+    resolved_actor = actor if actor is not None else _default_system_actor(scope)
+
+    _emit(
+        journal,
+        action="fleet.install.started",
+        actor=resolved_actor,
+        scope=scope,
+        correlation_id=correlation_id,
+        payload={
+            "fleet": fleet.name,
+            "version": fleet.version,
+            "soul_template": fleet.soul_template,
+        },
+    )
+
     soul = await _step_create_soul(report, fleet, soul_factory)
     if soul is None:
+        # Partial install: no agent.spawned, no fleet.installed. The
+        # report itself already shows the failed step.
         return report
     report.soul_id = getattr(soul, "did", None) or getattr(soul, "name", None)
+
+    _emit(
+        journal,
+        action="agent.spawned",
+        actor=resolved_actor,
+        scope=scope,
+        correlation_id=correlation_id,
+        payload=_agent_spawned_payload(fleet, soul),
+    )
 
     pocket = await _step_create_pocket(report, fleet, pocket_creator)
     if pocket is not None:
@@ -93,7 +156,100 @@ async def install_fleet(
 
     await _step_register_connectors(report, fleet, connector_registry)
 
+    _emit(
+        journal,
+        action="fleet.installed",
+        actor=resolved_actor,
+        scope=scope,
+        correlation_id=correlation_id,
+        payload={
+            "fleet": fleet.name,
+            "soul_id": report.soul_id,
+            "pocket_id": report.pocket_id,
+            "succeeded": report.succeeded(),
+            "step_count": len(report.steps),
+            "failed_steps": [s.name for s in report.failed_steps()],
+        },
+    )
+
     return report
+
+
+# ---------------------------------------------------------------------------
+# Journal helpers — all tolerant of a None journal so production callers can
+# opt in without branching at every call site.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_scope(fleet: FleetTemplate) -> list[str]:
+    """Pick the scope for journal events. Fall back to a fleet-qualified tag
+    so the EventEntry's non-empty scope invariant holds even when a template
+    author forgot to declare scopes.
+    """
+    if fleet.scopes:
+        return list(fleet.scopes)
+    return [f"fleet:{fleet.name}"]
+
+
+def _default_system_actor(scope: list[str]) -> Actor:
+    """Build the ``system:fleet-installer`` actor used when a caller does
+    not supply a root/admin actor. Scope context mirrors the event scope so
+    later audits can see the permissions the installer was acting under.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    return Actor(kind="system", id=_SYSTEM_INSTALLER_ACTOR_ID, scope_context=list(scope))
+
+
+def _agent_spawned_payload(fleet: FleetTemplate, soul: Any) -> dict[str, Any]:
+    """Assemble the canonical ``agent.spawned`` payload. The soul object is
+    duck-typed — the fleet installer accepts any factory that returns
+    something with ``did`` and/or ``name`` attributes, so we mirror that here.
+    """
+    did = getattr(soul, "did", None)
+    name = getattr(soul, "name", None)
+    return {
+        "soul_id": did or name,
+        "did": did,
+        "name": name,
+        "archetype": fleet.soul_template,
+        "fleet": fleet.name,
+    }
+
+
+def _emit(
+    journal: Journal | None,
+    *,
+    action: str,
+    actor: Actor,
+    scope: list[str],
+    correlation_id: UUID,
+    payload: dict[str, Any],
+) -> None:
+    """Append one event to the journal, swallowing and logging any failure.
+
+    The installer's job is to install — journal emission is a side channel
+    for observability. A broken journal must not translate into a broken
+    install, so every failure mode (import, validation, backend I/O) is
+    logged at warning level and discarded.
+    """
+    if journal is None:
+        return
+    try:
+        from soul_protocol.spec.journal import EventEntry
+
+        entry = EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=actor,
+            action=action,
+            scope=list(scope),
+            correlation_id=correlation_id,
+            payload=payload,
+        )
+        journal.append(entry)
+    except Exception as exc:  # noqa: BLE001 — see docstring.
+        logger.warning("Fleet install: journal emission for %s failed: %s", action, exc)
 
 
 async def _step_create_soul(

--- a/ee/fleet/installer.py
+++ b/ee/fleet/installer.py
@@ -1,0 +1,245 @@
+# ee/fleet/installer.py — Read a FleetTemplate manifest, install the bundle.
+# Created: 2026-04-13 (Move 7 PR-B) — Pure orchestration. Uses existing
+# primitives (SoulFactory, ConnectorRegistry, Pocket service) and does not
+# introduce new runtime concepts. Each install step is independently
+# reported so partial failures are observable.
+# Updated: 2026-04-16 — PyYAML import-error message now points at
+# `pocketpaw[soul]` (the pocketpaw extra that pulls PyYAML in via
+# soul-protocol[engine]) instead of the transitive package name.
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+from ee.fleet.models import (
+    FleetConnector,
+    FleetInstallReport,
+    FleetInstallStep,
+    FleetTemplate,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_BUNDLED_DIR = Path(__file__).parent.parent.parent / "src" / "pocketpaw" / "fleet_templates"
+
+
+def list_bundled_fleets() -> list[str]:
+    """Return the names of bundled fleet templates on disk."""
+    if not _BUNDLED_DIR.exists():
+        return []
+    return sorted(p.stem for p in _BUNDLED_DIR.glob("*.yaml"))
+
+
+def load_fleet(path_or_name: str | Path) -> FleetTemplate:
+    """Load a FleetTemplate from a YAML/JSON file or a bundled name.
+
+    If the argument is one of the bundled fleet names, resolves to the
+    packaged YAML. Otherwise treats it as a filesystem path.
+    """
+    if isinstance(path_or_name, str):
+        bundled = _BUNDLED_DIR / f"{path_or_name}.yaml"
+        if bundled.exists():
+            return _load_from_path(bundled)
+    p = Path(path_or_name)
+    if not p.exists():
+        raise FileNotFoundError(f"Fleet template not found: {path_or_name}")
+    return _load_from_path(p)
+
+
+def _load_from_path(path: Path) -> FleetTemplate:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        try:
+            import yaml
+        except ImportError as exc:
+            raise ImportError(
+                "PyYAML is required to load fleet templates. "
+                "Install with `pip install pocketpaw[soul]`."
+            ) from exc
+        data = yaml.safe_load(text) or {}
+    else:
+        data = json.loads(text)
+    return FleetTemplate.model_validate(data)
+
+
+async def install_fleet(
+    fleet: FleetTemplate,
+    *,
+    soul_factory: Any | None = None,
+    connector_registry: Any | None = None,
+    pocket_creator: Any | None = None,
+) -> FleetInstallReport:
+    """Install a fleet by orchestrating soul + pocket + connector creation.
+
+    Each external dependency is injectable so tests can substitute fakes.
+    Production callers pass the real SoulFactory, ConnectorRegistry, and
+    pocket service; install_fleet itself remains a pure orchestrator.
+    """
+    report = FleetInstallReport(fleet=fleet.name)
+
+    soul = await _step_create_soul(report, fleet, soul_factory)
+    if soul is None:
+        return report
+    report.soul_id = getattr(soul, "did", None) or getattr(soul, "name", None)
+
+    pocket = await _step_create_pocket(report, fleet, pocket_creator)
+    if pocket is not None:
+        report.pocket_id = getattr(pocket, "id", None) or getattr(pocket, "_id", None)
+
+    await _step_register_connectors(report, fleet, connector_registry)
+
+    return report
+
+
+async def _step_create_soul(
+    report: FleetInstallReport,
+    fleet: FleetTemplate,
+    soul_factory: Any | None,
+) -> Any | None:
+    start = time.monotonic()
+    try:
+        if soul_factory is None:
+            from soul_protocol.runtime.templates import SoulFactory
+
+            soul_factory = SoulFactory
+
+        template = soul_factory.load_bundled(fleet.soul_template)
+        soul_name = fleet.soul_name or template.name
+        soul = await soul_factory.from_template(template, name=soul_name)
+        report.steps.append(
+            FleetInstallStep(
+                name=f"create_soul:{template.name}",
+                status="succeeded",
+                detail=f"Created soul '{soul_name}' from template '{template.name}'",
+                duration_ms=int((time.monotonic() - start) * 1000),
+            ),
+        )
+        return soul
+    except Exception as exc:
+        logger.exception("Fleet install: soul creation failed")
+        report.steps.append(
+            FleetInstallStep(
+                name=f"create_soul:{fleet.soul_template}",
+                status="failed",
+                detail=str(exc),
+                duration_ms=int((time.monotonic() - start) * 1000),
+            ),
+        )
+        return None
+
+
+async def _step_create_pocket(
+    report: FleetInstallReport,
+    fleet: FleetTemplate,
+    pocket_creator: Any | None,
+) -> Any | None:
+    start = time.monotonic()
+    if pocket_creator is None:
+        # Pocket creation hooks into ee/cloud/pockets which is mongo-backed
+        # and not always available in the test/standalone path. Skip cleanly.
+        report.steps.append(
+            FleetInstallStep(
+                name=f"create_pocket:{fleet.pocket_name}",
+                status="skipped",
+                detail="Pocket creator not provided (cloud module not loaded)",
+                duration_ms=int((time.monotonic() - start) * 1000),
+            ),
+        )
+        return None
+
+    try:
+        pocket = await pocket_creator(
+            name=fleet.pocket_name,
+            description=fleet.pocket_description,
+            widgets=fleet.pocket_widgets,
+            scope=list(fleet.scopes),
+        )
+        report.steps.append(
+            FleetInstallStep(
+                name=f"create_pocket:{fleet.pocket_name}",
+                status="succeeded",
+                detail=f"Created pocket '{fleet.pocket_name}'",
+                duration_ms=int((time.monotonic() - start) * 1000),
+            ),
+        )
+        return pocket
+    except Exception as exc:
+        logger.exception("Fleet install: pocket creation failed")
+        report.steps.append(
+            FleetInstallStep(
+                name=f"create_pocket:{fleet.pocket_name}",
+                status="failed",
+                detail=str(exc),
+                duration_ms=int((time.monotonic() - start) * 1000),
+            ),
+        )
+        return None
+
+
+async def _step_register_connectors(
+    report: FleetInstallReport,
+    fleet: FleetTemplate,
+    connector_registry: Any | None,
+) -> None:
+    if not fleet.connectors:
+        return
+
+    if connector_registry is None:
+        # Same pattern as pocket creation — caller must provide the registry.
+        for conn in fleet.connectors:
+            report.steps.append(
+                FleetInstallStep(
+                    name=f"connect:{conn.name}",
+                    status="skipped",
+                    detail="Connector registry not provided",
+                ),
+            )
+        return
+
+    for conn in fleet.connectors:
+        await _register_one_connector(report, conn, connector_registry)
+
+
+async def _register_one_connector(
+    report: FleetInstallReport,
+    conn: FleetConnector,
+    registry: Any,
+) -> None:
+    start = time.monotonic()
+    try:
+        if not registry.has(conn.name):
+            status = "skipped" if conn.optional else "failed"
+            report.steps.append(
+                FleetInstallStep(
+                    name=f"connect:{conn.name}",
+                    status=status,
+                    detail=f"Connector '{conn.name}' not registered",
+                    duration_ms=int((time.monotonic() - start) * 1000),
+                ),
+            )
+            return
+
+        await registry.connect(conn.name, conn.config)
+        report.steps.append(
+            FleetInstallStep(
+                name=f"connect:{conn.name}",
+                status="succeeded",
+                detail=f"Connected '{conn.name}'",
+                duration_ms=int((time.monotonic() - start) * 1000),
+            ),
+        )
+    except Exception as exc:
+        logger.exception("Fleet install: connector %s failed", conn.name)
+        report.steps.append(
+            FleetInstallStep(
+                name=f"connect:{conn.name}",
+                status="failed",
+                detail=str(exc),
+                duration_ms=int((time.monotonic() - start) * 1000),
+            ),
+        )

--- a/ee/fleet/models.py
+++ b/ee/fleet/models.py
@@ -1,0 +1,64 @@
+# ee/fleet/models.py — FleetTemplate manifest + install report types.
+# Created: 2026-04-13 (Move 7 PR-B) — A fleet is a thin orchestration over
+# primitives that already exist (soul template, pocket, connectors, scope).
+# No new runtime concepts; the manifest just names them in one place so a
+# non-technical operator can install the whole bundle in one step.
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class FleetConnector(BaseModel):
+    """One connector to register when the fleet is installed."""
+
+    name: str
+    config: dict[str, Any] = Field(default_factory=dict)
+    optional: bool = False  # Skip silently if the connector module is missing.
+
+
+class FleetTemplate(BaseModel):
+    """An installable bundle of soul + pocket + connectors + scopes."""
+
+    name: str
+    display_name: str = ""
+    description: str = ""
+    version: str = "0.1.0"
+    soul_template: str  # Bundled soul template name (arrow / flash / cyborg / analyst)
+    soul_name: str = ""  # Override; defaults to template's name
+    pocket_name: str  # Pocket created at install time
+    pocket_description: str = ""
+    pocket_widgets: list[dict[str, Any]] = Field(default_factory=list)
+    connectors: list[FleetConnector] = Field(default_factory=list)
+    scopes: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class FleetInstallStep(BaseModel):
+    """One step in the install pipeline. Reports succeeded / skipped / failed
+    so the UI can show partial progress without re-running the whole install.
+    """
+
+    name: str
+    status: Literal["succeeded", "skipped", "failed"]
+    detail: str = ""
+    duration_ms: int = 0
+
+
+class FleetInstallReport(BaseModel):
+    """Full report of an install run."""
+
+    fleet: str
+    installed_at: datetime = Field(default_factory=datetime.now)
+    steps: list[FleetInstallStep] = Field(default_factory=list)
+    soul_id: str | None = None
+    pocket_id: str | None = None
+
+    def succeeded(self) -> bool:
+        return all(step.status != "failed" for step in self.steps)
+
+    def failed_steps(self) -> list[FleetInstallStep]:
+        return [s for s in self.steps if s.status == "failed"]

--- a/ee/fleet/router.py
+++ b/ee/fleet/router.py
@@ -7,20 +7,22 @@
 # ``/api/v1``, giving ``/api/v1/fleet/templates`` and
 # ``/api/v1/fleet/install``.
 #
-# Journal emission is opt-in per request. When ``journal=true`` the
-# router lazily opens a local SQLite journal at
-# ``~/.pocketpaw/journal/fleet.db`` so every install is observable even
-# without an org-scoped journal wiring. The heavier per-org Journal
-# dependency-injection can supersede this later without breaking callers.
+# Updated: 2026-04-16 (feat/ee-journal-dep) — dropped the local
+# ``~/.pocketpaw/journal/fleet.db`` in favour of the shared
+# ``ee.journal_dep.get_journal`` FastAPI dependency. Now every ee/ route
+# writes into the same org journal (SOUL_DATA_DIR or ~/.soul/), so the
+# audit trail is no longer split across two SQLite files. The request
+# body flag ``journal`` still defaults to True; setting it False opts
+# out and passes ``None`` into ``install_fleet`` unchanged.
 
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+from soul_protocol.engine.journal import Journal
 
 from ee.fleet import (
     FleetInstallReport,
@@ -29,13 +31,11 @@ from ee.fleet import (
     list_bundled_fleets,
     load_fleet,
 )
+from ee.journal_dep import get_journal
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/fleet", tags=["Fleet"])
-
-
-_DEFAULT_JOURNAL_PATH = Path.home() / ".pocketpaw" / "journal" / "fleet.db"
 
 
 # ---------------------------------------------------------------------------
@@ -102,31 +102,6 @@ def _load_all_bundled() -> list[FleetTemplate]:
     return templates
 
 
-def _open_default_journal() -> Any | None:
-    """Open (or create) the default fleet journal at the canonical path.
-
-    Returns ``None`` when soul-protocol is not installed or the journal
-    cannot be opened — the installer tolerates a missing journal and
-    the request still succeeds.
-    """
-
-    try:
-        from soul_protocol.engine.journal import open_journal
-    except ImportError:
-        logger.warning(
-            "Fleet install: soul-protocol not available, skipping journal emission. "
-            "Install `pocketpaw[soul]` or pass journal=false to silence this.",
-        )
-        return None
-
-    try:
-        _DEFAULT_JOURNAL_PATH.parent.mkdir(parents=True, exist_ok=True)
-        return open_journal(_DEFAULT_JOURNAL_PATH)
-    except Exception:  # noqa: BLE001 — observability only.
-        logger.exception("Fleet install: failed to open default journal")
-        return None
-
-
 def _resolve_actor(spec: ActorSpec | None) -> Any | None:
     """Translate an ``ActorSpec`` payload to a soul-protocol Actor.
 
@@ -163,14 +138,19 @@ async def get_templates() -> FleetTemplatesResponse:
 
 
 @router.post("/install", response_model=FleetInstallReport)
-async def post_install(req: InstallFleetRequest) -> FleetInstallReport:
+async def post_install(
+    req: InstallFleetRequest,
+    journal: Journal = Depends(get_journal),
+) -> FleetInstallReport:
     """Install a bundled fleet by name.
 
     Resolves ``template_name`` via ``load_fleet()``, installs it, and
     returns the ``FleetInstallReport`` verbatim. Unknown names return
-    404 with a clear message. When ``journal=true`` the installer
-    emits the correlated ``fleet.install.started`` /
-    ``agent.spawned`` / ``fleet.installed`` event trio.
+    404 with a clear message. When ``journal=true`` (the default) the
+    installer receives the org's canonical Journal and emits the
+    correlated ``fleet.install.started`` / ``agent.spawned`` /
+    ``fleet.installed`` event trio; ``journal=false`` forwards ``None``
+    so the installer skips emission.
     """
 
     try:
@@ -187,20 +167,10 @@ async def post_install(req: InstallFleetRequest) -> FleetInstallReport:
             detail=f"Failed to load fleet template: {exc}",
         ) from exc
 
-    journal = _open_default_journal() if req.journal else None
     actor = _resolve_actor(req.actor)
+    effective_journal: Journal | None = journal if req.journal else None
 
-    try:
-        report = await install_fleet(fleet, journal=journal, actor=actor)
-    finally:
-        # open_journal returns a resource with a close() method on the
-        # SQLite backend. Closing keeps the per-request writer from
-        # leaking file handles under load.
-        close = getattr(journal, "close", None)
-        if callable(close):
-            try:
-                close()
-            except Exception:  # noqa: BLE001 — best-effort cleanup.
-                logger.debug("Fleet install: journal close failed", exc_info=True)
-
-    return report
+    # Journal lifetime is managed by the dependency (process-scoped
+    # singleton via lru_cache) — no per-request close, that would defeat
+    # the cache and churn SQLite connections under load.
+    return await install_fleet(fleet, journal=effective_journal, actor=actor)

--- a/ee/fleet/router.py
+++ b/ee/fleet/router.py
@@ -1,0 +1,206 @@
+# ee/fleet/router.py — REST surface for the fleet install subsystem.
+# Created: 2026-04-16 (feat/fleet-rest-router) — Exposes the Python
+# primitives shipped in the fleet installer + journal-emission patches so
+# paw-enterprise's InstallFleetPanel can list bundled templates and
+# trigger an install over HTTP. Matches the existing ee router pattern:
+# internal ``prefix="/fleet"`` + registered via _EE_ROUTERS at
+# ``/api/v1``, giving ``/api/v1/fleet/templates`` and
+# ``/api/v1/fleet/install``.
+#
+# Journal emission is opt-in per request. When ``journal=true`` the
+# router lazily opens a local SQLite journal at
+# ``~/.pocketpaw/journal/fleet.db`` so every install is observable even
+# without an org-scoped journal wiring. The heavier per-org Journal
+# dependency-injection can supersede this later without breaking callers.
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from ee.fleet import (
+    FleetInstallReport,
+    FleetTemplate,
+    install_fleet,
+    list_bundled_fleets,
+    load_fleet,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/fleet", tags=["Fleet"])
+
+
+_DEFAULT_JOURNAL_PATH = Path.home() / ".pocketpaw" / "journal" / "fleet.db"
+
+
+# ---------------------------------------------------------------------------
+# Request / response envelopes
+# ---------------------------------------------------------------------------
+
+
+class FleetTemplatesResponse(BaseModel):
+    """List response for ``GET /fleet/templates``.
+
+    Wraps the templates in a top-level envelope so the payload has space
+    for future pagination / total counts without a breaking change.
+    """
+
+    templates: list[FleetTemplate]
+    total: int
+
+
+class ActorSpec(BaseModel):
+    """Optional caller identity forwarded to the journal on install.
+
+    When omitted the installer's built-in ``system:fleet-installer``
+    actor is recorded instead. Keeps the router stateless while still
+    letting richer clients (paw-enterprise) attribute installs to the
+    logged-in operator.
+    """
+
+    kind: str = "user"
+    id: str
+    scope_context: list[str] = Field(default_factory=list)
+
+
+class InstallFleetRequest(BaseModel):
+    """Body for ``POST /fleet/install``.
+
+    ``journal`` opts into the v0.3.1 correlated-event trio. ``actor``
+    lets a caller attribute the install to a specific identity.
+    """
+
+    template_name: str
+    journal: bool = True
+    actor: ActorSpec | None = None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — isolated so tests can patch them without touching
+# the filesystem or soul-protocol internals.
+# ---------------------------------------------------------------------------
+
+
+def _load_all_bundled() -> list[FleetTemplate]:
+    """Resolve every bundled fleet name to a full FleetTemplate.
+
+    Templates that fail to parse are skipped with a warning — one bad
+    template shouldn't sink the whole list endpoint for every caller.
+    """
+
+    templates: list[FleetTemplate] = []
+    for name in list_bundled_fleets():
+        try:
+            templates.append(load_fleet(name))
+        except Exception as exc:  # noqa: BLE001 — observability only.
+            logger.warning("Skipping bundled fleet %s: %s", name, exc)
+    return templates
+
+
+def _open_default_journal() -> Any | None:
+    """Open (or create) the default fleet journal at the canonical path.
+
+    Returns ``None`` when soul-protocol is not installed or the journal
+    cannot be opened — the installer tolerates a missing journal and
+    the request still succeeds.
+    """
+
+    try:
+        from soul_protocol.engine.journal import open_journal
+    except ImportError:
+        logger.warning(
+            "Fleet install: soul-protocol not available, skipping journal emission. "
+            "Install `pocketpaw[soul]` or pass journal=false to silence this.",
+        )
+        return None
+
+    try:
+        _DEFAULT_JOURNAL_PATH.parent.mkdir(parents=True, exist_ok=True)
+        return open_journal(_DEFAULT_JOURNAL_PATH)
+    except Exception:  # noqa: BLE001 — observability only.
+        logger.exception("Fleet install: failed to open default journal")
+        return None
+
+
+def _resolve_actor(spec: ActorSpec | None) -> Any | None:
+    """Translate an ``ActorSpec`` payload to a soul-protocol Actor.
+
+    Returns ``None`` when no spec was supplied so the installer's
+    default system actor is used instead.
+    """
+
+    if spec is None:
+        return None
+    try:
+        from soul_protocol.spec.journal import Actor
+    except ImportError:
+        return None
+    return Actor(kind=spec.kind, id=spec.id, scope_context=list(spec.scope_context))
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/templates", response_model=FleetTemplatesResponse)
+async def get_templates() -> FleetTemplatesResponse:
+    """Return every bundled fleet template the server knows about.
+
+    This is what paw-enterprise's InstallFleetPanel calls on mount to
+    populate its picker. Each entry is the full ``FleetTemplate`` so
+    the UI can show description, connectors, widgets, and scopes
+    without a second round-trip.
+    """
+
+    templates = _load_all_bundled()
+    return FleetTemplatesResponse(templates=templates, total=len(templates))
+
+
+@router.post("/install", response_model=FleetInstallReport)
+async def post_install(req: InstallFleetRequest) -> FleetInstallReport:
+    """Install a bundled fleet by name.
+
+    Resolves ``template_name`` via ``load_fleet()``, installs it, and
+    returns the ``FleetInstallReport`` verbatim. Unknown names return
+    404 with a clear message. When ``journal=true`` the installer
+    emits the correlated ``fleet.install.started`` /
+    ``agent.spawned`` / ``fleet.installed`` event trio.
+    """
+
+    try:
+        fleet = load_fleet(req.template_name)
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Fleet template '{req.template_name}' not found",
+        ) from None
+    except Exception as exc:
+        logger.exception("Fleet install: failed to load template %s", req.template_name)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Failed to load fleet template: {exc}",
+        ) from exc
+
+    journal = _open_default_journal() if req.journal else None
+    actor = _resolve_actor(req.actor)
+
+    try:
+        report = await install_fleet(fleet, journal=journal, actor=actor)
+    finally:
+        # open_journal returns a resource with a close() method on the
+        # SQLite backend. Closing keeps the per-request writer from
+        # leaking file handles under load.
+        close = getattr(journal, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:  # noqa: BLE001 — best-effort cleanup.
+                logger.debug("Fleet install: journal close failed", exc_info=True)
+
+    return report

--- a/ee/journal_dep.py
+++ b/ee/journal_dep.py
@@ -1,0 +1,63 @@
+# ee/journal_dep.py — Org-level Journal FastAPI dependency for ee/ routers.
+# Created: 2026-04-16 (feat/ee-journal-dep) — #948's fleet router opened a
+# second SQLite journal at ~/.pocketpaw/journal/fleet.db so it could emit
+# the correlated install trio without a wired org journal. That works but
+# splits the audit trail across two files. This module is the shared
+# dependency every ee/ route should use instead: one Journal per process,
+# rooted at the canonical org data dir (SOUL_DATA_DIR or ~/.soul/), so the
+# whole org shares one append-only event log.
+#
+# SQLite WAL is concurrent-safe at the file level, but re-opening on every
+# request still pays the connection + pragma cost. ``@lru_cache`` keeps one
+# Python instance alive for the life of the process. Tests that need a
+# disposable journal should use FastAPI's ``app.dependency_overrides``
+# pattern instead of mutating the cache — ``reset_journal_cache()`` is
+# offered only as a belt-and-braces escape hatch for unit-level coverage.
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+
+from soul_protocol.engine.journal import Journal, open_journal
+
+
+def _org_data_dir() -> Path:
+    """Resolve the canonical org data directory.
+
+    ``SOUL_DATA_DIR`` wins when set — that's how operators point an
+    install at a custom volume. Falls back to ``~/.soul/`` which matches
+    the default soul-protocol engine layout.
+    """
+
+    env = os.environ.get("SOUL_DATA_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".soul"
+
+
+@lru_cache(maxsize=1)
+def _cached_journal() -> Journal:
+    """Open the org journal once per process and reuse it thereafter."""
+
+    data_dir = _org_data_dir()
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return open_journal(data_dir / "journal.db")
+
+
+def get_journal() -> Journal:
+    """FastAPI dependency returning the org's canonical Journal.
+
+    Pair with ``Depends(get_journal)`` in route signatures. Tests should
+    override via ``app.dependency_overrides[get_journal] = ...`` rather
+    than touching ``_cached_journal`` directly.
+    """
+
+    return _cached_journal()
+
+
+def reset_journal_cache() -> None:
+    """Drop the cached Journal instance — for tests that need isolation."""
+
+    _cached_journal.cache_clear()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,11 @@ dependencies = [
     "cryptography>=46.0.0",
     # Image basics
     "pillow>=10.0.0",
+    # Soul Protocol — runtime imports from soul_protocol.spec.journal and
+    # soul_protocol.engine.journal for fleet installer event emission (#947).
+    # Promoted from optional extra to base dep in v0.3.1 integration work;
+    # the runtime now takes a hard dependency on the journal primitives.
+    "soul-protocol[engine]>=0.3.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,15 @@ gchat = [
     "google-api-python-client>=2.100.0",
     "google-auth>=2.25.0",
 ]
+drive = [
+    # Google Drive SourceAdapter (zero-copy live federation) — see
+    # src/pocketpaw/connectors/drive/. The client itself runs on httpx (core
+    # dep), but we ship the Google SDK alongside for parity with gchat and
+    # for future DriveIngestAdapter bulk-sync work.
+    "google-api-python-client>=2.100.0",
+    "google-auth>=2.25.0",
+    "google-auth-oauthlib>=1.2.0",
+]
 
 # --- Tool extras ---
 image = [
@@ -194,9 +203,10 @@ all-channels = [
     # teams
     "botbuilder-core>=4.16.0",
     "botbuilder-integration-aiohttp>=4.16.0",
-    # gchat
+    # gchat + drive
     "google-api-python-client>=2.100.0",
     "google-auth>=2.25.0",
+    "google-auth-oauthlib>=1.2.0",
 ]
 all-tools = [
     # browser
@@ -269,6 +279,7 @@ all = [
     "botbuilder-integration-aiohttp>=4.16.0",
     "google-api-python-client>=2.100.0",
     "google-auth>=2.25.0",
+    "google-auth-oauthlib>=1.2.0",
     # tools
     "google-genai>=1.0.0",
     "html2text>=2020.1.16",

--- a/src/pocketpaw/api/v1/__init__.py
+++ b/src/pocketpaw/api/v1/__init__.py
@@ -1,6 +1,9 @@
 # API v1 router aggregation.
 # Created: 2026-02-20
 # Updated: 2026-03-30 — Added Automations router (enterprise, rule-based pocket automations).
+# Updated: 2026-04-16 (feat/fleet-rest-router) — Added Fleet router so
+#   paw-enterprise's InstallFleetPanel can call GET /api/v1/fleet/templates
+#   and POST /api/v1/fleet/install against a running pocketpaw instance.
 #
 # mount_v1_routers(app) registers all domain routers at /api/v1/ (canonical).
 # Existing dashboard.py endpoints at /api/ remain as backward-compat aliases.
@@ -53,6 +56,7 @@ _V1_ROUTERS: list[tuple[str, str, str]] = [
 # Enterprise API routes (require ee/ module) — skipped silently when ee/ is absent.
 _EE_ROUTERS: list[tuple[str, str, str]] = [
     ("ee.fabric.router", "router", "Fabric"),
+    ("ee.fleet.router", "router", "Fleet"),
     ("ee.instinct.router", "router", "Instinct"),
     ("pocketpaw.ee.automations.router", "router", "Automations"),
 ]

--- a/src/pocketpaw/api/v1/pockets.py
+++ b/src/pocketpaw/api/v1/pockets.py
@@ -1,7 +1,8 @@
 # Pocket chat router — dedicated endpoint for pocket creation.
-# Updated: 2026-04-01 — _prepare_pocket_spec now handles UISpec v1.0, multi-pane specs,
-#   and flat widget specs. System prompt teaches all three formats with UISpec as default.
-#   Debug logging added to trace pocket event pipeline.
+# Updated: 2026-04-12 — Added dynamic Ripple widget knowledge injection via kb-go.
+#   _get_ripple_widget_context() searches the 'ripple' kb scope for widget docs
+#   relevant to the user's request. Results are appended to the static pocket system
+#   context so agents get deep, targeted knowledge about the widgets they need.
 
 from __future__ import annotations
 
@@ -29,6 +30,66 @@ _WS_PREFIX = "websocket_"
 
 # Match the JSON arg passed to create_pocket in a Bash command (legacy fallback)
 _CREATE_POCKET_RE = re.compile(r"create_pocket\s+'(.*?)'", re.DOTALL)
+
+_RIPPLE_KB_SCOPE = "ripple"
+_RIPPLE_KB_LIMIT = 3
+
+
+async def _get_ripple_widget_context(user_message: str) -> str:
+    """Search the 'ripple' kb scope for widget docs relevant to the user's request.
+
+    Returns pre-formatted markdown articles about the specific Ripple widgets
+    the agent will need. Falls back to empty string on any failure — this is
+    a nice-to-have enhancement, never a blocker.
+    """
+    if not user_message:
+        return ""
+
+    from pocketpaw.config import get_settings
+
+    settings = get_settings()
+    binary = settings.kb_binary or "kb"
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            binary,
+            "search",
+            user_message,
+            "--scope",
+            _RIPPLE_KB_SCOPE,
+            "--context",
+            "--limit",
+            str(_RIPPLE_KB_LIMIT),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=3.0)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return ""
+    except FileNotFoundError:
+        logger.debug("kb binary not found — skipping ripple widget context")
+        return ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+    if proc.returncode != 0:
+        return ""
+
+    output = stdout.decode("utf-8", errors="replace").strip()
+    if not output:
+        return ""
+
+    return (
+        "\n\n<ripple-widget-reference>\n"
+        "The following Ripple widget documentation is relevant to this request. "
+        "Use these props, types, and examples when building the UI spec.\n\n"
+        + output
+        + "\n</ripple-widget-reference>"
+    )
+
 
 _POCKET_SYSTEM_CONTEXT = """\
 <pocket-creation-context>
@@ -553,10 +614,17 @@ async def pocket_chat_stream(body: ChatRequest):
     chat_id = _extract_chat_id(body.session_id)
     safe_key = _to_safe_key(chat_id)
 
-    # Build metadata with pocket context if provided
+    # Fetch relevant Ripple widget docs in parallel (non-blocking, ~10ms)
+    widget_context = await _get_ripple_widget_context(body.content)
+
+    # Build metadata with pocket context — static rules + dynamic widget knowledge
+    pocket_ctx = _POCKET_SYSTEM_CONTEXT
+    if widget_context:
+        pocket_ctx += widget_context
+
     meta: dict = {
         "source": "pocket_chat",
-        "pocket_system_context": _POCKET_SYSTEM_CONTEXT,
+        "pocket_system_context": pocket_ctx,
     }
     if body.pocket_context:
         meta["pocket_context"] = body.pocket_context.model_dump(exclude_none=True)

--- a/src/pocketpaw/connectors/__init__.py
+++ b/src/pocketpaw/connectors/__init__.py
@@ -7,6 +7,8 @@ from pocketpaw.connectors.protocol import (
     ActionSchema,
     ConnectionResult,
     ConnectorProtocol,
+    IngestACL,
+    IngestAdapter,
     SyncResult,
 )
 from pocketpaw.connectors.registry import ConnectorRegistry
@@ -16,6 +18,8 @@ __all__ = [
     "ConnectionResult",
     "ActionSchema",
     "ActionResult",
+    "IngestACL",
+    "IngestAdapter",
     "SyncResult",
     "ConnectorRegistry",
 ]

--- a/src/pocketpaw/connectors/drive/__init__.py
+++ b/src/pocketpaw/connectors/drive/__init__.py
@@ -1,0 +1,30 @@
+# pocketpaw.connectors.drive — Google Drive adapter module.
+# Created: 2026-04-16 (Workstream C2 of the Org Architecture RFC).
+#
+# Public surface is the SourceAdapter (zero-copy live federation). The
+# matching IngestAdapter (copy-on-ingest) lives alongside and will land in
+# a follow-up PR once the ingest primitive from #939 settles.
+
+from __future__ import annotations
+
+from .auth import resolve_bearer_token
+from .client import DriveClient, DriveFile, DriveRevision
+from .errors import (
+    DriveAuthError,
+    DriveError,
+    DriveNotFoundError,
+    DriveRateLimitError,
+)
+from .source import DriveSourceAdapter
+
+__all__ = [
+    "DriveAuthError",
+    "DriveClient",
+    "DriveError",
+    "DriveFile",
+    "DriveNotFoundError",
+    "DriveRateLimitError",
+    "DriveRevision",
+    "DriveSourceAdapter",
+    "resolve_bearer_token",
+]

--- a/src/pocketpaw/connectors/drive/auth.py
+++ b/src/pocketpaw/connectors/drive/auth.py
@@ -1,0 +1,118 @@
+# Drive OAuth helpers — bearer-token resolution for the connector layer.
+# Created: 2026-04-16 (Workstream C2 of the Org Architecture RFC).
+#
+# The retrieval router hands the adapter a ``Credential`` from the broker at
+# dispatch time. In production that credential's ``token`` is the bearer
+# string we send upstream. For local development and tool-path invocations
+# (the non-zero-copy builtin tools) we still need a way to materialise a
+# token: the fall-backs live here so ``source.py`` stays focused.
+#
+# Precedence order (first non-empty wins):
+#   1. ``Credential.token`` from the broker (zero-copy federation).
+#   2. ``GOOGLE_OAUTH_TOKEN`` env var (local dev / CI).
+#   3. ``pocketpaw.integrations.oauth.OAuthManager`` (existing token store
+#      populated by the OAuth flow in the dashboard).
+#
+# TODO(hardening): we inherit ``OAuthManager``'s current contract, which
+# refreshes lazily on access. For long-running dispatches we may want a
+# warm-up phase so the first parallel worker doesn't pay the refresh
+# latency for the whole batch. Deferred until the second concrete adapter
+# (Salesforce) confirms the pattern.
+
+from __future__ import annotations
+
+import logging
+import os
+
+from soul_protocol.engine.retrieval import Credential
+
+from .errors import DriveAuthError
+
+logger = logging.getLogger(__name__)
+
+_ENV_TOKEN = "GOOGLE_OAUTH_TOKEN"
+
+
+def resolve_bearer_token(
+    credential: Credential | None,
+    *,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Pick the best bearer token for a Drive call.
+
+    ``env`` is injectable for tests; defaults to ``os.environ``. Raises
+    :class:`DriveAuthError` when no source yields a usable token — the
+    adapter surfaces this as a ``sources_failed`` entry rather than crashing
+    the whole router.
+    """
+    if credential is not None and credential.token:
+        return credential.token
+
+    env_map = env if env is not None else os.environ
+    env_token = env_map.get(_ENV_TOKEN, "").strip()
+    if env_token:
+        return env_token
+
+    # Fall-through: the OAuth token store. Imported lazily because the
+    # ``integrations`` package loads config state that we don't want to
+    # pull in for pure-library imports.
+    try:
+        import asyncio
+
+        from pocketpaw.config import get_settings
+        from pocketpaw.integrations.oauth import OAuthManager
+        from pocketpaw.integrations.token_store import TokenStore
+    except Exception as e:  # pragma: no cover - defensive
+        raise DriveAuthError(
+            "no Drive bearer token available (credential empty, env unset, OAuth store unavailable)"
+        ) from e
+
+    store = TokenStore()
+    # Short-circuit: if the OAuth store has nothing saved for Drive, skip the
+    # async roundtrip entirely. This matters for tests (avoids closing the
+    # default event loop with ``asyncio.run``) and for fresh installs where
+    # the user hasn't completed the OAuth flow yet — we fail fast with a
+    # clear error message instead of spinning up a loop just to get None.
+    try:
+        tokens = store.load("google_drive")
+    except Exception:
+        tokens = None
+    if tokens is None:
+        raise DriveAuthError(
+            "Drive OAuth token not found. Complete the OAuth flow in "
+            "Settings > Google OAuth > Authorize Drive, or set "
+            f"{_ENV_TOKEN} for headless usage."
+        )
+
+    manager = OAuthManager(store)
+    try:
+        settings = get_settings()
+    except Exception as e:  # pragma: no cover - config may not be loaded in tests
+        raise DriveAuthError(f"cannot read OAuth settings: {e}") from e
+
+    client_id = getattr(settings, "google_oauth_client_id", "") or ""
+    client_secret = getattr(settings, "google_oauth_client_secret", "") or ""
+
+    async def _fetch() -> str | None:
+        return await manager.get_valid_token(
+            service="google_drive",
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+
+    # Prefer an isolated loop so we never close the caller's default loop —
+    # ``asyncio.run`` would swap out the main-thread loop on teardown, which
+    # breaks any downstream code that called ``asyncio.get_event_loop()``.
+    loop = asyncio.new_event_loop()
+    try:
+        token = loop.run_until_complete(_fetch())
+    finally:
+        loop.close()
+
+    if not token:
+        raise DriveAuthError(
+            "Drive OAuth token not found. Complete the OAuth flow in "
+            "Settings > Google OAuth > Authorize Drive, or set "
+            f"{_ENV_TOKEN} for headless usage."
+        )
+    return token

--- a/src/pocketpaw/connectors/drive/client.py
+++ b/src/pocketpaw/connectors/drive/client.py
@@ -1,0 +1,386 @@
+# Google Drive client for the SourceAdapter — sync, rate-limited, point-in-time aware.
+# Created: 2026-04-16 (Workstream C2 of the Org Architecture RFC).
+#
+# This is the connector-layer client. It is deliberately separate from
+# ``pocketpaw.integrations.gdrive.DriveClient``, which is coupled to the
+# global OAuth token store used by the ``drive_*`` built-in tools. The
+# retrieval router hands us a short-lived ``Credential`` at dispatch time
+# (via the credential broker) so we never reach for a global token.
+#
+# Sync on purpose: ``SourceAdapter.query`` is sync in soul-protocol 0.3.1
+# (the router runs adapters on a thread pool under the ``parallel`` strategy).
+# Using ``httpx.Client`` keeps us in the same HTTP lib the rest of pocketpaw
+# already depends on without pulling in ``google-api-python-client`` as a
+# runtime requirement — the extra still ships it for parity with the
+# enterprise Gmail/Calendar stacks, but it is not imported here.
+#
+# Rate limit policy: Drive raises 429 (quota exceeded) and 403 with a
+# ``userRateLimitExceeded`` or ``rateLimitExceeded`` reason — Google's guide
+# explicitly lists both. We back off exponentially with jitter up to
+# ``max_retries``; anything else (401, 404, network error) is normalised to
+# one of the errors in ``errors.py`` and raised.
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+from .errors import (
+    DriveAuthError,
+    DriveError,
+    DriveNotFoundError,
+    DriveRateLimitError,
+)
+
+logger = logging.getLogger(__name__)
+
+_DRIVE_BASE = "https://www.googleapis.com/drive/v3"
+
+# Rate-limit tuning. Drive's per-user quota resets every 100 seconds, so
+# capping the retry budget around that window keeps a single wedged worker
+# from holding onto a thread forever.
+_DEFAULT_MAX_RETRIES = 5
+_DEFAULT_BASE_BACKOFF_S = 1.0
+_DEFAULT_MAX_BACKOFF_S = 30.0
+
+
+@dataclass
+class DriveFile:
+    """A single Drive file as returned by the API, normalised to our shape."""
+
+    id: str
+    name: str
+    mime_type: str = ""
+    modified_time: str = ""
+    size: int | None = None
+    web_view_link: str = ""
+    revision_id: str | None = None
+    owners: list[dict[str, Any]] = field(default_factory=list)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_api(cls, data: dict[str, Any]) -> DriveFile:
+        size_raw = data.get("size")
+        size = int(size_raw) if size_raw is not None else None
+        return cls(
+            id=str(data.get("id", "")),
+            name=str(data.get("name", "")),
+            mime_type=str(data.get("mimeType", "")),
+            modified_time=str(data.get("modifiedTime", "")),
+            size=size,
+            web_view_link=str(data.get("webViewLink", "")),
+            revision_id=data.get("headRevisionId") or data.get("revisionId"),
+            owners=list(data.get("owners", [])),
+            raw=dict(data),
+        )
+
+
+@dataclass
+class DriveRevision:
+    """One row from files.revisions.list — trimmed to what we actually use."""
+
+    id: str
+    modified_time: str
+    keep_forever: bool = False
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_api(cls, data: dict[str, Any]) -> DriveRevision:
+        return cls(
+            id=str(data.get("id", "")),
+            modified_time=str(data.get("modifiedTime", "")),
+            keep_forever=bool(data.get("keepForever", False)),
+            raw=dict(data),
+        )
+
+
+class DriveClient:
+    """Sync HTTP client for the Drive v3 API with exponential-backoff retries.
+
+    The client is re-entrant-safe but not thread-safe — create one per thread
+    (or per dispatch) when sharing is inconvenient. The ``RetrievalRouter``
+    already isolates per-request state via its thread pool, so the intended
+    pattern is ``DriveClient(token=credential.token)`` inside
+    ``SourceAdapter.query``.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        http: httpx.Client | None = None,
+        timeout_s: float = 15.0,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+        base_backoff_s: float = _DEFAULT_BASE_BACKOFF_S,
+        max_backoff_s: float = _DEFAULT_MAX_BACKOFF_S,
+    ) -> None:
+        if not token:
+            raise DriveAuthError("DriveClient requires a non-empty OAuth bearer token")
+        self._token = token
+        self._owns_http = http is None
+        self._http = http or httpx.Client(timeout=timeout_s)
+        self._max_retries = max_retries
+        self._base_backoff_s = base_backoff_s
+        self._max_backoff_s = max_backoff_s
+
+    def close(self) -> None:
+        if self._owns_http:
+            self._http.close()
+
+    def __enter__(self) -> DriveClient:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    # -- public API -------------------------------------------------------
+
+    def list_files(
+        self,
+        *,
+        query: str | None = None,
+        page_size: int = 20,
+        order_by: str = "modifiedTime desc",
+        fields: str | None = None,
+    ) -> list[DriveFile]:
+        """List or search files. ``query`` is a Drive search expression."""
+        fields = fields or (
+            "files(id,name,mimeType,modifiedTime,size,webViewLink,headRevisionId,owners)"
+        )
+        params: dict[str, Any] = {
+            "pageSize": max(1, min(page_size, 100)),
+            "fields": fields,
+            "orderBy": order_by,
+        }
+        if query:
+            params["q"] = query
+        data = self._request("GET", f"{_DRIVE_BASE}/files", params=params)
+        return [DriveFile.from_api(f) for f in data.get("files", [])]
+
+    def search(self, text: str, *, page_size: int = 20) -> list[DriveFile]:
+        """Full-text search wrapper over ``list_files``."""
+        safe = text.replace("'", "\\'")
+        return self.list_files(query=f"fullText contains '{safe}'", page_size=page_size)
+
+    def get_file(self, file_id: str) -> DriveFile:
+        """Fetch metadata for a single file (no body)."""
+        params = {
+            "fields": ("id,name,mimeType,modifiedTime,size,webViewLink,headRevisionId,owners")
+        }
+        data = self._request("GET", f"{_DRIVE_BASE}/files/{file_id}", params=params)
+        return DriveFile.from_api(data)
+
+    def list_revisions(self, file_id: str, *, page_size: int = 50) -> list[DriveRevision]:
+        """List the revision history of a file, oldest first (Drive's order)."""
+        params = {
+            "pageSize": max(1, min(page_size, 200)),
+            "fields": "revisions(id,modifiedTime,keepForever)",
+        }
+        data = self._request("GET", f"{_DRIVE_BASE}/files/{file_id}/revisions", params=params)
+        return [DriveRevision.from_api(r) for r in data.get("revisions", [])]
+
+    def revision_at(self, file_id: str, point_in_time: datetime) -> DriveRevision | None:
+        """Return the most recent revision at or before ``point_in_time``.
+
+        Drive's revision timestamps are ISO-8601 UTC. We parse them with
+        ``datetime.fromisoformat`` after swapping the trailing ``Z`` —
+        anything malformed is silently skipped so a single bad row cannot
+        break the walk.
+        """
+        if point_in_time.tzinfo is None:
+            raise ValueError("point_in_time must be timezone-aware")
+        revisions = self.list_revisions(file_id)
+        best: DriveRevision | None = None
+        for rev in revisions:
+            ts = _parse_drive_ts(rev.modified_time)
+            if ts is None:
+                continue
+            if ts <= point_in_time and (best is None or ts > _parse_drive_ts(best.modified_time)):  # type: ignore[operator]
+                best = rev
+        return best
+
+    def get_content(
+        self, file_id: str, *, revision_id: str | None = None, max_bytes: int = 1_000_000
+    ) -> bytes:
+        """Download the file body, optionally pinned to a specific revision.
+
+        Google-native formats (Docs/Sheets/Slides) are exported to PDF — raw
+        ``alt=media`` returns a 400 for those. ``max_bytes`` caps the download
+        so the adapter never hands a 4 GB Drive video to the router.
+        """
+        headers = {"Authorization": f"Bearer {self._token}"}
+        # Need mimeType to decide export vs raw download.
+        meta = self.get_file(file_id)
+        export_map = {
+            "application/vnd.google-apps.document": "application/pdf",
+            "application/vnd.google-apps.presentation": "application/pdf",
+            "application/vnd.google-apps.spreadsheet": (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        }
+        if meta.mime_type in export_map:
+            url = f"{_DRIVE_BASE}/files/{file_id}/export"
+            params: dict[str, Any] = {"mimeType": export_map[meta.mime_type]}
+        else:
+            url = f"{_DRIVE_BASE}/files/{file_id}"
+            params = {"alt": "media"}
+            if revision_id:
+                # Drive serves historical bytes from the revisions sub-resource.
+                url = f"{_DRIVE_BASE}/files/{file_id}/revisions/{revision_id}"
+
+        resp = self._raw_request("GET", url, params=params, headers=headers, stream=True)
+        try:
+            buf = bytearray()
+            for chunk in resp.iter_bytes():
+                buf.extend(chunk)
+                if len(buf) >= max_bytes:
+                    break
+            return bytes(buf[:max_bytes])
+        finally:
+            resp.close()
+
+    # -- internals --------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Issue a JSON request with retries and error normalisation."""
+        headers = {
+            "Authorization": f"Bearer {self._token}",
+            "Accept": "application/json",
+        }
+        resp = self._raw_request(method, url, params=params, headers=headers, json=json)
+        try:
+            return resp.json()
+        except ValueError as e:
+            raise DriveError(f"Drive returned non-JSON body: {e}") from e
+        finally:
+            resp.close()
+
+    def _raw_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+        stream: bool = False,
+    ) -> httpx.Response:
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                if stream:
+                    resp = self._http.send(
+                        self._http.build_request(
+                            method, url, params=params, headers=headers, json=json
+                        ),
+                        stream=True,
+                    )
+                else:
+                    resp = self._http.request(
+                        method, url, params=params, headers=headers, json=json
+                    )
+            except httpx.HTTPError as e:
+                last_exc = e
+                if attempt >= self._max_retries:
+                    raise DriveError(f"Drive transport error: {e}") from e
+                self._sleep_backoff(attempt)
+                continue
+
+            status = resp.status_code
+            if status == 401:
+                resp.close()
+                raise DriveAuthError("Drive rejected credentials (HTTP 401)")
+            if status == 404:
+                resp.close()
+                raise DriveNotFoundError(f"Drive resource not found: {url}")
+            if status == 429 or (status == 403 and _is_rate_limit(resp)):
+                reason = _reason_from(resp)
+                resp.close()
+                if attempt >= self._max_retries:
+                    raise DriveRateLimitError(
+                        f"Drive rate limit exceeded after {attempt + 1} attempts ({reason})"
+                    )
+                logger.info(
+                    "drive rate-limited on attempt %d (%s); backing off", attempt + 1, reason
+                )
+                self._sleep_backoff(attempt)
+                continue
+            if status >= 400:
+                body = _safe_body(resp)
+                resp.close()
+                raise DriveError(f"Drive error {status}: {body}")
+
+            return resp
+
+        # Should never land here — the loop either returns or raises.
+        raise DriveError(f"drive request exhausted retries: {last_exc}")
+
+    def _sleep_backoff(self, attempt: int) -> None:
+        delay = min(
+            self._max_backoff_s,
+            self._base_backoff_s * (2**attempt) + random.uniform(0, 0.25),
+        )
+        time.sleep(delay)
+
+
+# -- helpers ----------------------------------------------------------------
+
+
+def _parse_drive_ts(value: str) -> datetime | None:
+    """Parse a Drive ``modifiedTime`` string into a tz-aware datetime."""
+    if not value:
+        return None
+    cleaned = value.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+
+
+def _is_rate_limit(resp: httpx.Response) -> bool:
+    """Drive packs quota errors into 403 with a specific reason string."""
+    try:
+        body = resp.json()
+    except ValueError:
+        return False
+    errors = body.get("error", {}).get("errors", []) if isinstance(body, dict) else []
+    for err in errors:
+        if not isinstance(err, dict):
+            continue
+        reason = err.get("reason", "")
+        if reason in {"rateLimitExceeded", "userRateLimitExceeded"}:
+            return True
+    return False
+
+
+def _reason_from(resp: httpx.Response) -> str:
+    try:
+        body = resp.json()
+    except ValueError:
+        return f"HTTP {resp.status_code}"
+    if not isinstance(body, dict):
+        return f"HTTP {resp.status_code}"
+    errors = body.get("error", {}).get("errors", [])
+    if errors and isinstance(errors[0], dict):
+        return errors[0].get("reason", f"HTTP {resp.status_code}")
+    return f"HTTP {resp.status_code}"
+
+
+def _safe_body(resp: httpx.Response) -> str:
+    try:
+        return resp.text[:500]
+    except Exception:
+        return f"<unreadable body, status={resp.status_code}>"

--- a/src/pocketpaw/connectors/drive/errors.py
+++ b/src/pocketpaw/connectors/drive/errors.py
@@ -1,0 +1,23 @@
+# Drive connector error hierarchy — normalised surface for API failures.
+# Created: 2026-04-16 (Workstream C2 of the Org Architecture RFC).
+#
+# Kept deliberately small. Callers should be able to tell "bad token" from
+# "rate limited" from "not found" without string-sniffing.
+
+from __future__ import annotations
+
+
+class DriveError(Exception):
+    """Base class for all errors raised by the Drive connector."""
+
+
+class DriveAuthError(DriveError):
+    """The OAuth token is missing, expired, or rejected by Drive."""
+
+
+class DriveRateLimitError(DriveError):
+    """Drive returned 429 (or 403 quota reason) after retries were exhausted."""
+
+
+class DriveNotFoundError(DriveError):
+    """The requested file, revision, or permission does not exist."""

--- a/src/pocketpaw/connectors/drive/source.py
+++ b/src/pocketpaw/connectors/drive/source.py
@@ -1,0 +1,231 @@
+# DriveSourceAdapter — zero-copy federation over the Drive v3 API.
+# Created: 2026-04-16 (Workstream C2 of the Org Architecture RFC).
+#
+# This is the first concrete ``SourceAdapter`` in pocketpaw. The pattern
+# established here will be followed for Salesforce, Slack, Gmail, etc.:
+#
+#   1. Accept a ``Credential`` from the router's broker.
+#   2. Resolve a bearer token via ``auth.resolve_bearer_token``.
+#   3. Build a scoped sync HTTP client.
+#   4. Translate the request's ``query`` into a source-native query string.
+#   5. Return ``RetrievalCandidate`` rows with ``content`` shaped as a
+#      DataRef dict (live pointer, not copied bytes) and ``as_of`` pinned
+#      to the effective point-in-time.
+#   6. Empty results return ``[]`` — never raise.
+#
+# Point-in-time handling: soul-protocol 0.3.1's ``RetrievalRequest`` does
+# not yet carry a structured ``point_in_time`` field (tracked for a future
+# soul-protocol bump). We support it today via a lightweight convention
+# embedded in the query string:
+#
+#     "@at=2026-04-01T12:00:00Z | Q3 forecast"
+#
+# ``_split_point_in_time`` peels the prefix off and leaves the remainder
+# as the free-text query. When present, we walk the file's revision list
+# and pin the candidate to the matching historical revision id.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from soul_protocol.engine.retrieval import Credential
+from soul_protocol.spec.retrieval import RetrievalCandidate, RetrievalRequest
+
+from .auth import resolve_bearer_token
+from .client import DriveClient, DriveFile, DriveRevision
+from .errors import DriveAuthError, DriveError
+
+logger = logging.getLogger(__name__)
+
+_POINT_IN_TIME_PREFIX = "@at="
+
+
+class DriveSourceAdapter:
+    """``SourceAdapter`` implementation for Google Drive.
+
+    Fields:
+        source_name: Key used when the router matches ``sources_failed``
+            entries and ``CandidateSource.adapter_ref`` pointers. Defaults
+            to ``"drive"`` — keep stable unless running side-by-side with
+            a second Drive instance (e.g. personal vs enterprise).
+    """
+
+    # SourceAdapter Protocol attribute — we emit live DataRef payloads.
+    supports_dataref: bool = True
+
+    def __init__(
+        self,
+        *,
+        source_name: str = "drive",
+        client_factory: Any = None,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        self._source_name = source_name
+        # ``client_factory`` is injectable so tests can swap in a stub
+        # without monkey-patching module globals. Signature: (token) -> DriveClient.
+        self._client_factory = client_factory or (lambda token: DriveClient(token))
+        self._env = env
+
+    def query(
+        self,
+        request: RetrievalRequest,
+        credential: Credential | None,
+    ) -> list[RetrievalCandidate]:
+        try:
+            token = resolve_bearer_token(credential, env=self._env)
+        except DriveAuthError:
+            # Let the router surface this as a per-source failure. The
+            # router catches the exception and records it — we do NOT want
+            # to swallow it here because that would hide credential issues.
+            raise
+
+        point_in_time, text_query = _split_point_in_time(request.query)
+        drive_query = _translate_query(text_query)
+
+        client = self._client_factory(token)
+        try:
+            files = client.list_files(
+                query=drive_query,
+                page_size=max(1, min(request.limit, 100)),
+            )
+        except DriveError:
+            # Preserve the error type; the router records the reason.
+            raise
+
+        if not files:
+            return []
+
+        as_of = point_in_time or datetime.now(UTC)
+        candidates: list[RetrievalCandidate] = []
+        for position, drive_file in enumerate(files):
+            revision = None
+            if point_in_time is not None:
+                try:
+                    revision = client.revision_at(drive_file.id, point_in_time)
+                except DriveError as e:
+                    logger.warning(
+                        "revision lookup failed for %s: %s; emitting head candidate",
+                        drive_file.id,
+                        e,
+                    )
+            score = _score_for_position(position, len(files))
+            candidates.append(
+                RetrievalCandidate(
+                    source=self._source_name,
+                    content=_dataref_payload(
+                        drive_file,
+                        revision=revision,
+                        request_scopes=list(request.scopes),
+                    ),
+                    score=score,
+                    as_of=as_of,
+                    cached=False,
+                )
+            )
+        return candidates
+
+
+# -- helpers ---------------------------------------------------------------
+
+
+def _split_point_in_time(raw: str) -> tuple[datetime | None, str]:
+    """Peel an optional ``@at=<iso>|rest`` prefix off the request query."""
+    stripped = raw.strip()
+    if not stripped.startswith(_POINT_IN_TIME_PREFIX):
+        return None, raw
+    remainder = stripped[len(_POINT_IN_TIME_PREFIX) :]
+    if "|" not in remainder:
+        return _parse_iso(remainder.strip()), ""
+    ts_text, rest = remainder.split("|", 1)
+    return _parse_iso(ts_text.strip()), rest.strip()
+
+
+def _parse_iso(value: str) -> datetime | None:
+    if not value:
+        return None
+    cleaned = value.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _translate_query(text: str) -> str | None:
+    """Map a free-text query to Drive's search syntax.
+
+    If the caller already passed a Drive-native expression (contains an
+    operator like ``fullText``, ``mimeType``, ``name``, ``owners``, or
+    ``and``) we pass it through unchanged. Otherwise we wrap the text in
+    ``fullText contains '...'`` with single quotes escaped.
+    """
+    if not text:
+        return None
+    lowered = text.lower()
+    drive_operators = (
+        "fulltext contains",
+        "name contains",
+        "mimetype",
+        "owners in",
+        "modifiedtime",
+        "sharedwithme",
+        "starred",
+    )
+    if any(op in lowered for op in drive_operators):
+        return text
+    escaped = text.replace("'", "\\'")
+    return f"fullText contains '{escaped}'"
+
+
+def _dataref_payload(
+    drive_file: DriveFile,
+    *,
+    revision: DriveRevision | None,
+    request_scopes: list[str],
+) -> dict[str, Any]:
+    """Build the DataRef-shaped dict the router hands to the decision-maker.
+
+    Shape is deliberately loose (soul-protocol's ``RetrievalCandidate.content``
+    is ``dict[str, Any]`` so the router never inspects it). We follow the
+    Zero-Copy convention agreed in the RFC: ``kind="dataref"``, plus enough
+    identifiers for a downstream resolver to fetch live bytes on demand.
+    """
+    ref: dict[str, Any] = {
+        "kind": "dataref",
+        "source": "drive",
+        "id": drive_file.id,
+        "name": drive_file.name,
+        "mime_type": drive_file.mime_type,
+        "modified_time": drive_file.modified_time,
+        "web_view_link": drive_file.web_view_link,
+        "scopes": request_scopes,
+    }
+    if drive_file.size is not None:
+        ref["size"] = drive_file.size
+    if drive_file.owners:
+        ref["owners"] = drive_file.owners
+    if revision is not None:
+        ref["revision_id"] = revision.id
+        ref["revision_modified_time"] = revision.modified_time
+    elif drive_file.revision_id:
+        ref["revision_id"] = drive_file.revision_id
+    return ref
+
+
+def _score_for_position(position: int, total: int) -> float:
+    """Linear falloff so Drive's native ordering is preserved after merge.
+
+    Drive returns files sorted by ``modifiedTime desc`` (or by Google's
+    relevance ranking when ``fullText`` is used). We map that ordering into
+    a ``[0.1, 1.0]`` score so multi-source merges with other adapters
+    still respect Drive's intent without swamping projection sources that
+    produce true relevance scores.
+    """
+    if total <= 1:
+        return 1.0
+    # position 0 -> 1.0, position total-1 -> 0.1
+    return max(0.1, 1.0 - (position / (total - 1)) * 0.9)

--- a/src/pocketpaw/connectors/protocol.py
+++ b/src/pocketpaw/connectors/protocol.py
@@ -1,5 +1,10 @@
 # ConnectorProtocol — interface for all data source adapters.
 # Created: 2026-03-27 — Protocol-based, async, adapter-agnostic.
+# Updated: 2026-04-13 (Move 7 PR-A) — Added IngestACL + IngestAdapter
+#   alias so the ingest side of the protocol carries source-side ACLs
+#   into Fabric. Adapters that emit documents tagged with inherited
+#   scope keep org permissions intact end-to-end (a private Slack
+#   channel's messages stay private inside Single Brain).
 
 from __future__ import annotations
 
@@ -70,6 +75,29 @@ class SyncResult:
     duration_ms: float = 0
 
 
+@dataclass
+class IngestACL:
+    """Source-side access control list inherited into Single Brain.
+
+    When an adapter pulls a document from a tenant system that already has
+    ACLs (a private Slack channel, a HubSpot deal restricted to one team,
+    a Notion page shared with a sub-list), the adapter reports those ACLs
+    here so paw-runtime tags the resulting Fabric object with the matching
+    scope tags before it lands. The brain inherits the source's permissions
+    instead of flattening them to "everyone with access to the connector."
+
+    Empty fields are intentional defaults — most ingests are global to the
+    pocket and need no per-record scoping. When ``scope`` is non-empty,
+    the runtime applies it as the Fabric object's ``scope`` list verbatim;
+    when ``visibility`` is set, callers can also surface a UI label.
+    """
+
+    scope: list[str] = field(default_factory=list)
+    visibility: str = ""  # "public" | "private" | "members" | "owner"
+    source_principal: str = ""  # The original ACL holder, e.g. "channel:#founders"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
 class ConnectorProtocol(Protocol):
     """Interface for all connector adapters.
 
@@ -111,4 +139,26 @@ class ConnectorProtocol(Protocol):
 
     async def schema(self) -> dict[str, Any]:
         """Return data schema for pocket.db table mapping."""
+        ...
+
+
+class IngestAdapter(ConnectorProtocol, Protocol):
+    """A connector that pulls data INTO Paw OS (vs sending it out).
+
+    Same surface as :class:`ConnectorProtocol` plus :meth:`permissions`,
+    which reports the ACLs of records the adapter can ingest. Existing
+    REST + DB + file connectors satisfy this protocol once they implement
+    permissions(); the alias makes the intent explicit at type-check time
+    and lets the fleet template runtime (PR-B) discover ACL-aware
+    connectors without sniffing for the method.
+    """
+
+    async def permissions(self, pocket_id: str, record_id: str | None = None) -> IngestACL:
+        """Report source-side ACLs for the next ingest.
+
+        ``record_id`` may be ``None`` for connector-wide defaults (e.g. a
+        Stripe-account-wide read scope). When present, returns the ACLs
+        for one specific record so per-document scoping works for systems
+        like Slack channels or HubSpot deal-team membership.
+        """
         ...

--- a/src/pocketpaw/fleet_templates/sales-fleet.yaml
+++ b/src/pocketpaw/fleet_templates/sales-fleet.yaml
@@ -1,0 +1,56 @@
+# Sales Fleet — Arrow + a sales pipeline pocket + the connectors a 40-person
+# SaaS sales org would use. The first reference fleet, intentionally minimal
+# so the install flow is testable end-to-end without setting up fifteen
+# external services.
+
+name: sales-fleet
+display_name: Sales Fleet
+description: |
+  Arrow soul + sales pipeline pocket + HubSpot + Gong connectors. The
+  default scope is org:sales:* so any reps already given that scope see
+  the fleet's data immediately; admins can narrow individual records via
+  the per-record ACLs the connectors report back.
+version: 0.1.0
+
+soul_template: arrow
+soul_name: Arrow
+
+pocket_name: Pipeline
+pocket_description: Live deal pipeline + outreach drafts.
+
+pocket_widgets:
+  - id: hot_leads
+    type: list
+    title: Hot Leads
+    source: fabric:Lead
+    limit: 10
+  - id: pipeline_summary
+    type: kpi
+    title: Pipeline This Week
+    source: fabric:Deal:summary
+  - id: arrow_chat
+    type: chat
+    title: Talk to Arrow
+    agent: arrow
+
+connectors:
+  - name: hubspot
+    optional: true
+    config:
+      poll_minutes: 15
+  - name: gong
+    optional: true
+    config:
+      poll_minutes: 30
+
+scopes:
+  - org:sales:*
+
+metadata:
+  recommended_tools:
+    - instinct_propose
+    - instinct_corrections
+    - fabric_query
+  industry_fit:
+    - saas
+    - mid_market_b2b

--- a/tests/cloud/test_fleet_installer.py
+++ b/tests/cloud/test_fleet_installer.py
@@ -1,0 +1,287 @@
+# tests/cloud/test_fleet_installer.py — Move 7 PR-B.
+# Created: 2026-04-13 — Manifest loader, install orchestration with mocked
+# soul/connector/pocket dependencies, partial-failure reporting, bundled
+# Sales Fleet contract, and the install report shape.
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ee.fleet import (
+    FleetConnector,
+    FleetInstallReport,
+    FleetTemplate,
+    install_fleet,
+    list_bundled_fleets,
+    load_fleet,
+)
+
+# ---------------------------------------------------------------------------
+# Manifest loader
+# ---------------------------------------------------------------------------
+
+
+class TestLoader:
+    def test_loads_yaml_manifest(self, tmp_path: Path) -> None:
+        path = tmp_path / "custom.yaml"
+        path.write_text(
+            textwrap.dedent(
+                """
+                name: custom-fleet
+                soul_template: arrow
+                pocket_name: Custom Pocket
+                scopes:
+                  - org:sales:*
+                """,
+            ).strip(),
+            encoding="utf-8",
+        )
+        fleet = load_fleet(path)
+        assert fleet.name == "custom-fleet"
+        assert fleet.soul_template == "arrow"
+        assert fleet.scopes == ["org:sales:*"]
+
+    def test_loads_json_manifest(self, tmp_path: Path) -> None:
+        path = tmp_path / "custom.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "name": "json-fleet",
+                    "soul_template": "flash",
+                    "pocket_name": "JSON Pocket",
+                }
+            ),
+            encoding="utf-8",
+        )
+        fleet = load_fleet(path)
+        assert fleet.name == "json-fleet"
+
+    def test_loads_bundled_by_name(self) -> None:
+        names = list_bundled_fleets()
+        if not names:
+            pytest.skip("No bundled fleets available")
+        fleet = load_fleet(names[0])
+        assert isinstance(fleet, FleetTemplate)
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_fleet(tmp_path / "nope.yaml")
+
+
+# ---------------------------------------------------------------------------
+# install_fleet — orchestration
+# ---------------------------------------------------------------------------
+
+
+def _basic_fleet(**overrides) -> FleetTemplate:
+    defaults = {
+        "name": "sales-fleet",
+        "soul_template": "arrow",
+        "pocket_name": "Pipeline",
+        "pocket_description": "Live pipeline",
+        "scopes": ["org:sales:*"],
+    }
+    defaults.update(overrides)
+    return FleetTemplate(**defaults)
+
+
+def _fake_factory(soul_template_name: str = "arrow"):
+    """Return an object that quacks like SoulFactory — load_bundled + from_template."""
+    factory = MagicMock()
+
+    template = MagicMock()
+    template.name = soul_template_name.capitalize()
+    factory.load_bundled = MagicMock(return_value=template)
+
+    soul = MagicMock()
+    soul.did = "did:soul:fake-1"
+    soul.name = template.name
+    factory.from_template = AsyncMock(return_value=soul)
+    return factory, soul
+
+
+@pytest.fixture
+def fake_pocket_creator():
+    pocket = MagicMock()
+    pocket.id = "pocket_fake_1"
+    creator = AsyncMock(return_value=pocket)
+    return creator, pocket
+
+
+@pytest.fixture
+def fake_registry():
+    registry = MagicMock()
+    registry.has = MagicMock(return_value=True)
+    registry.connect = AsyncMock(return_value=True)
+    return registry
+
+
+class TestInstallOrchestration:
+    @pytest.mark.asyncio
+    async def test_install_creates_soul_pocket_and_connectors(
+        self, fake_pocket_creator, fake_registry
+    ) -> None:
+        factory, soul = _fake_factory()
+        creator, pocket = fake_pocket_creator
+
+        fleet = _basic_fleet(
+            connectors=[FleetConnector(name="hubspot", config={"poll_minutes": 15})],
+        )
+        report = await install_fleet(
+            fleet,
+            soul_factory=factory,
+            connector_registry=fake_registry,
+            pocket_creator=creator,
+        )
+
+        assert report.succeeded()
+        assert report.soul_id == "did:soul:fake-1"
+        assert report.pocket_id == "pocket_fake_1"
+        statuses = [step.status for step in report.steps]
+        assert "succeeded" in statuses
+        assert all(s != "failed" for s in statuses)
+
+    @pytest.mark.asyncio
+    async def test_install_skips_pocket_when_creator_missing(self) -> None:
+        factory, _ = _fake_factory()
+        report = await install_fleet(
+            _basic_fleet(),
+            soul_factory=factory,
+            connector_registry=None,
+            pocket_creator=None,
+        )
+        skipped = [s for s in report.steps if s.status == "skipped"]
+        assert any("create_pocket" in s.name for s in skipped)
+        assert report.pocket_id is None
+
+    @pytest.mark.asyncio
+    async def test_install_marks_optional_missing_connector_as_skipped(
+        self, fake_pocket_creator
+    ) -> None:
+        factory, _ = _fake_factory()
+        creator, _ = fake_pocket_creator
+        registry = MagicMock()
+        registry.has = MagicMock(return_value=False)
+
+        fleet = _basic_fleet(
+            connectors=[FleetConnector(name="missing-connector", optional=True)],
+        )
+        report = await install_fleet(
+            fleet,
+            soul_factory=factory,
+            connector_registry=registry,
+            pocket_creator=creator,
+        )
+        connector_step = next(s for s in report.steps if "missing-connector" in s.name)
+        assert connector_step.status == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_install_marks_required_missing_connector_as_failed(
+        self, fake_pocket_creator
+    ) -> None:
+        factory, _ = _fake_factory()
+        creator, _ = fake_pocket_creator
+        registry = MagicMock()
+        registry.has = MagicMock(return_value=False)
+
+        fleet = _basic_fleet(
+            connectors=[FleetConnector(name="critical-connector", optional=False)],
+        )
+        report = await install_fleet(
+            fleet,
+            soul_factory=factory,
+            connector_registry=registry,
+            pocket_creator=creator,
+        )
+        assert not report.succeeded()
+        failed = report.failed_steps()
+        assert len(failed) == 1
+        assert "critical-connector" in failed[0].name
+
+    @pytest.mark.asyncio
+    async def test_install_swallows_per_step_exceptions(self, fake_pocket_creator) -> None:
+        factory, _ = _fake_factory()
+        creator, _ = fake_pocket_creator
+        registry = MagicMock()
+        registry.has = MagicMock(return_value=True)
+        registry.connect = AsyncMock(side_effect=RuntimeError("network down"))
+
+        fleet = _basic_fleet(connectors=[FleetConnector(name="hubspot")])
+        report = await install_fleet(
+            fleet,
+            soul_factory=factory,
+            connector_registry=registry,
+            pocket_creator=creator,
+        )
+        failed = report.failed_steps()
+        assert len(failed) == 1
+        assert "network down" in failed[0].detail
+
+    @pytest.mark.asyncio
+    async def test_install_returns_early_on_soul_failure(self) -> None:
+        factory = MagicMock()
+        factory.load_bundled = MagicMock(side_effect=FileNotFoundError("template missing"))
+
+        fleet = _basic_fleet()
+        report = await install_fleet(fleet, soul_factory=factory)
+        assert not report.succeeded()
+        assert report.soul_id is None
+        # Pocket + connector steps shouldn't even appear.
+        assert all("create_pocket" not in s.name for s in report.steps)
+
+
+# ---------------------------------------------------------------------------
+# Bundled Sales Fleet — contract check
+# ---------------------------------------------------------------------------
+
+
+class TestSalesFleetBundle:
+    def test_sales_fleet_is_bundled(self) -> None:
+        names = list_bundled_fleets()
+        assert "sales-fleet" in names
+
+    def test_sales_fleet_has_arrow_soul_and_sales_scope(self) -> None:
+        fleet = load_fleet("sales-fleet")
+        assert fleet.soul_template == "arrow"
+        assert "org:sales:*" in fleet.scopes
+
+    def test_sales_fleet_lists_widgets_and_connectors(self) -> None:
+        fleet = load_fleet("sales-fleet")
+        assert len(fleet.pocket_widgets) >= 2
+        assert any(c.name == "hubspot" for c in fleet.connectors)
+        assert all(c.optional for c in fleet.connectors), (
+            "All Sales Fleet connectors should be optional so the demo install "
+            "works without external API keys."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Report shape
+# ---------------------------------------------------------------------------
+
+
+class TestInstallReport:
+    def test_succeeded_when_no_failed_steps(self) -> None:
+        report = FleetInstallReport(fleet="x")
+        assert report.succeeded()
+
+    def test_failed_steps_filters(self) -> None:
+        from ee.fleet.models import FleetInstallStep
+
+        report = FleetInstallReport(
+            fleet="x",
+            steps=[
+                FleetInstallStep(name="a", status="succeeded"),
+                FleetInstallStep(name="b", status="failed"),
+                FleetInstallStep(name="c", status="skipped"),
+            ],
+        )
+        failed = report.failed_steps()
+        assert len(failed) == 1
+        assert failed[0].name == "b"
+        assert not report.succeeded()

--- a/tests/connectors/__init__.py
+++ b/tests/connectors/__init__.py
@@ -1,0 +1,1 @@
+# Tests for pocketpaw.connectors.* adapters.

--- a/tests/connectors/test_drive.py
+++ b/tests/connectors/test_drive.py
@@ -1,0 +1,592 @@
+# Tests for the Google Drive SourceAdapter (Workstream C2).
+# Created: 2026-04-16.
+#
+# Covers:
+#   * DriveClient request plumbing (auth header, params, rate-limit retry,
+#     point-in-time revision lookup, no-results is not an error).
+#   * DriveSourceAdapter.query shape — candidate scope context, DataRef
+#     payload, as_of pinned to point-in-time, score ordering.
+#   * Token resolution precedence (credential > env > OAuth store).
+#   * End-to-end with a real RetrievalRouter + InMemoryCredentialBroker,
+#     asserting retrieval.query journal emission with the recorded payload.
+#
+# No real Drive API traffic — httpx.Client.request is stubbed with a
+# scripted fake so we can walk each retry branch without httpx mocks.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.engine.retrieval import (
+    InMemoryCredentialBroker,
+    RetrievalRouter,
+)
+from soul_protocol.spec.journal import Actor
+from soul_protocol.spec.retrieval import (
+    CandidateSource,
+    RetrievalRequest,
+)
+
+from pocketpaw.connectors.drive import (
+    DriveAuthError,
+    DriveClient,
+    DriveError,
+    DriveNotFoundError,
+    DriveRateLimitError,
+    DriveSourceAdapter,
+)
+from pocketpaw.connectors.drive.auth import resolve_bearer_token
+
+# ---------------------------------------------------------------------------
+# HTTP scripting helpers — a tiny replacement for httpx_mock so we don't pull
+# a new test dep into an already-heavy tree.
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    """Stands in for httpx.Response for both sync and streaming paths."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        json_data: Any = None,
+        body: bytes = b"",
+        raise_on_request: Exception | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self._json_data = json_data
+        self._body = body
+        self._raise = raise_on_request
+        self.closed = False
+        self.text = body.decode("utf-8", errors="replace") if body else ""
+
+    def json(self) -> Any:
+        if self._json_data is None:
+            raise ValueError("no json body")
+        return self._json_data
+
+    def iter_bytes(self, chunk_size: int | None = None):  # noqa: ARG002
+        yield self._body
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class ScriptedClient:
+    """httpx.Client stand-in with an in-order script of responses."""
+
+    def __init__(self, script: list[FakeResponse | Exception]) -> None:
+        # ``itertools.chain`` + final response lets tests assert retry pacing.
+        self._script = list(script)
+        self.calls: list[dict[str, Any]] = []
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> FakeResponse:
+        self.calls.append(
+            {"method": method, "url": url, "params": params, "headers": headers, "json": json}
+        )
+        if not self._script:
+            raise AssertionError("ScriptedClient ran out of scripted responses")
+        nxt = self._script.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return nxt
+
+    def build_request(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+        return {"method": method, "url": url, **kwargs}
+
+    def send(self, request: dict[str, Any], *, stream: bool = False):  # noqa: ARG002
+        return self.request(request["method"], request["url"])
+
+    def close(self) -> None:
+        pass
+
+
+def _ts(year: int = 2026, month: int = 4, day: int = 1, hour: int = 12) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=UTC)
+
+
+def _actor() -> Actor:
+    return Actor(kind="agent", id="did:soul:test-agent")
+
+
+# ---------------------------------------------------------------------------
+# DriveClient tests
+# ---------------------------------------------------------------------------
+
+
+class TestDriveClient:
+    def test_empty_token_raises(self) -> None:
+        with pytest.raises(DriveAuthError):
+            DriveClient(token="")
+
+    def test_list_files_happy_path(self) -> None:
+        script = [
+            FakeResponse(
+                json_data={
+                    "files": [
+                        {
+                            "id": "file_1",
+                            "name": "Q3 forecast",
+                            "mimeType": "application/vnd.google-apps.document",
+                            "modifiedTime": "2026-04-01T12:00:00.000Z",
+                            "size": "1024",
+                            "webViewLink": "https://drive.google.com/file_1",
+                            "headRevisionId": "rev-latest",
+                        }
+                    ]
+                }
+            )
+        ]
+        http = ScriptedClient(script)
+        client = DriveClient(token="fake-token", http=http)
+        files = client.list_files(query="fullText contains 'forecast'", page_size=20)
+
+        assert len(files) == 1
+        assert files[0].id == "file_1"
+        assert files[0].revision_id == "rev-latest"
+        assert http.calls[0]["headers"]["Authorization"] == "Bearer fake-token"
+        assert http.calls[0]["params"]["q"] == "fullText contains 'forecast'"
+        assert http.calls[0]["params"]["pageSize"] == 20
+
+    def test_list_files_no_results_returns_empty_list(self) -> None:
+        http = ScriptedClient([FakeResponse(json_data={"files": []})])
+        client = DriveClient(token="fake-token", http=http)
+        assert client.list_files(query="name contains 'nope'") == []
+
+    def test_401_raises_drive_auth_error(self) -> None:
+        http = ScriptedClient([FakeResponse(status_code=401, json_data={"error": "unauth"})])
+        client = DriveClient(token="stale", http=http)
+        with pytest.raises(DriveAuthError):
+            client.list_files()
+
+    def test_404_raises_not_found(self) -> None:
+        http = ScriptedClient([FakeResponse(status_code=404, json_data={})])
+        client = DriveClient(token="ok", http=http)
+        with pytest.raises(DriveNotFoundError):
+            client.get_file("missing")
+
+    def test_429_triggers_backoff_and_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleep_calls: list[float] = []
+        monkeypatch.setattr(
+            "pocketpaw.connectors.drive.client.time.sleep",
+            lambda s: sleep_calls.append(s),
+        )
+        script = [
+            FakeResponse(status_code=429, json_data={"error": {"message": "slow down"}}),
+            FakeResponse(status_code=429, json_data={"error": {"message": "slow down"}}),
+            FakeResponse(json_data={"files": [{"id": "f1", "name": "after retry"}]}),
+        ]
+        http = ScriptedClient(script)
+        client = DriveClient(token="ok", http=http, base_backoff_s=0.01, max_backoff_s=0.1)
+        files = client.list_files()
+
+        assert len(files) == 1
+        assert files[0].id == "f1"
+        assert len(sleep_calls) == 2  # backed off twice, succeeded on 3rd attempt
+
+    def test_403_quota_reason_also_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("pocketpaw.connectors.drive.client.time.sleep", lambda s: None)
+        quota_body = {
+            "error": {
+                "errors": [{"reason": "userRateLimitExceeded", "message": "quota"}],
+                "code": 403,
+            }
+        }
+        script = [
+            FakeResponse(status_code=403, json_data=quota_body),
+            FakeResponse(json_data={"files": []}),
+        ]
+        http = ScriptedClient(script)
+        client = DriveClient(token="ok", http=http, base_backoff_s=0.01)
+        client.list_files()  # should not raise
+        assert len(http.calls) == 2
+
+    def test_rate_limit_budget_exhausted_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("pocketpaw.connectors.drive.client.time.sleep", lambda s: None)
+        script = [FakeResponse(status_code=429, json_data={}) for _ in range(6)]
+        http = ScriptedClient(script)
+        client = DriveClient(token="ok", http=http, max_retries=2, base_backoff_s=0.01)
+        with pytest.raises(DriveRateLimitError):
+            client.list_files()
+
+    def test_other_4xx_raises_generic_drive_error(self) -> None:
+        http = ScriptedClient(
+            [FakeResponse(status_code=500, body=b"boom", json_data={"error": "boom"})]
+        )
+        client = DriveClient(token="ok", http=http, max_retries=0)
+        with pytest.raises(DriveError):
+            client.list_files()
+
+    def test_revision_at_picks_most_recent_before_point(self) -> None:
+        script = [
+            FakeResponse(
+                json_data={
+                    "revisions": [
+                        {"id": "r1", "modifiedTime": "2026-03-01T00:00:00Z"},
+                        {"id": "r2", "modifiedTime": "2026-03-15T00:00:00Z"},
+                        {"id": "r3", "modifiedTime": "2026-04-10T00:00:00Z"},
+                    ]
+                }
+            )
+        ]
+        http = ScriptedClient(script)
+        client = DriveClient(token="ok", http=http)
+
+        chosen = client.revision_at("file_1", _ts(2026, 4, 1))
+        assert chosen is not None
+        assert chosen.id == "r2"
+
+    def test_revision_at_returns_none_when_all_revisions_are_future(self) -> None:
+        script = [
+            FakeResponse(
+                json_data={"revisions": [{"id": "r1", "modifiedTime": "2027-01-01T00:00:00Z"}]}
+            )
+        ]
+        http = ScriptedClient(script)
+        client = DriveClient(token="ok", http=http)
+        assert client.revision_at("file_1", _ts(2026, 4, 1)) is None
+
+    def test_revision_at_requires_aware_timestamp(self) -> None:
+        client = DriveClient(token="ok", http=ScriptedClient([]))
+        with pytest.raises(ValueError):
+            client.revision_at("file_1", datetime(2026, 4, 1))  # naive
+
+
+# ---------------------------------------------------------------------------
+# DriveSourceAdapter tests
+# ---------------------------------------------------------------------------
+
+
+class FakeDriveClient:
+    """Minimal client stub exposing the methods the adapter calls."""
+
+    def __init__(
+        self,
+        *,
+        files: list[dict[str, Any]] | None = None,
+        revisions: dict[str, list[dict[str, Any]]] | None = None,
+        raise_on_list: Exception | None = None,
+    ) -> None:
+        from pocketpaw.connectors.drive.client import DriveFile, DriveRevision
+
+        self._files = [DriveFile.from_api(f) for f in (files or [])]
+        self._revisions = revisions or {}
+        self._raise_on_list = raise_on_list
+        self.list_calls: list[tuple[str | None, int]] = []
+        self.revision_calls: list[tuple[str, datetime]] = []
+        self._DriveRevision = DriveRevision
+
+    def list_files(self, *, query: str | None = None, page_size: int = 20, **kwargs: Any):
+        if self._raise_on_list is not None:
+            raise self._raise_on_list
+        self.list_calls.append((query, page_size))
+        return list(self._files)
+
+    def revision_at(self, file_id: str, point_in_time: datetime):
+        self.revision_calls.append((file_id, point_in_time))
+        revs = [self._DriveRevision.from_api(r) for r in self._revisions.get(file_id, [])]
+        # simple "most recent <= point_in_time" without reimplementing client logic
+        best = None
+        for rev in revs:
+            ts = datetime.fromisoformat(rev.modified_time.replace("Z", "+00:00"))
+            if ts <= point_in_time and (
+                best is None
+                or ts > datetime.fromisoformat(best.modified_time.replace("Z", "+00:00"))
+            ):
+                best = rev
+        return best
+
+
+def _sample_files() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "file_1",
+            "name": "Q3 forecast",
+            "mimeType": "application/vnd.google-apps.document",
+            "modifiedTime": "2026-04-05T10:00:00Z",
+            "size": "2048",
+            "webViewLink": "https://drive.google.com/file_1",
+            "headRevisionId": "rev-now",
+        },
+        {
+            "id": "file_2",
+            "name": "forecast notes",
+            "mimeType": "text/plain",
+            "modifiedTime": "2026-04-04T09:00:00Z",
+            "webViewLink": "https://drive.google.com/file_2",
+        },
+    ]
+
+
+def _make_request(query: str, scopes: list[str] | None = None, limit: int = 10) -> RetrievalRequest:
+    return RetrievalRequest(
+        query=query,
+        actor=_actor(),
+        scopes=scopes or ["org:sales:*"],
+        limit=limit,
+        strategy="parallel",
+        timeout_s=5.0,
+    )
+
+
+class TestDriveSourceAdapter:
+    def test_supports_dataref_is_true(self) -> None:
+        assert DriveSourceAdapter.supports_dataref is True
+
+    def test_query_returns_dataref_candidates(self) -> None:
+        fake = FakeDriveClient(files=_sample_files())
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: fake,
+            env={"GOOGLE_OAUTH_TOKEN": "env-token"},
+        )
+        request = _make_request("Q3 forecast")
+        candidates = adapter.query(request, credential=None)
+
+        assert len(candidates) == 2
+        payload = candidates[0].content
+        assert payload["kind"] == "dataref"
+        assert payload["source"] == "drive"
+        assert payload["id"] == "file_1"
+        assert payload["scopes"] == ["org:sales:*"]
+        # First candidate must rank higher than the second under position scoring.
+        assert candidates[0].score is not None
+        assert candidates[1].score is not None
+        assert candidates[0].score > candidates[1].score
+        # Without a point-in-time, as_of should be "now-ish" and cached=False.
+        assert candidates[0].cached is False
+
+    def test_query_translates_free_text_to_fulltext(self) -> None:
+        fake = FakeDriveClient(files=[])
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: fake,
+            env={"GOOGLE_OAUTH_TOKEN": "env-token"},
+        )
+        adapter.query(_make_request("revenue"), credential=None)
+        assert fake.list_calls[0][0] == "fullText contains 'revenue'"
+
+    def test_query_passes_native_drive_syntax_through(self) -> None:
+        fake = FakeDriveClient(files=[])
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: fake,
+            env={"GOOGLE_OAUTH_TOKEN": "env-token"},
+        )
+        adapter.query(
+            _make_request("name contains 'forecast' and mimeType='text/plain'"),
+            credential=None,
+        )
+        assert "mimeType" in fake.list_calls[0][0]
+
+    def test_query_empty_results_is_not_error(self) -> None:
+        fake = FakeDriveClient(files=[])
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: fake,
+            env={"GOOGLE_OAUTH_TOKEN": "env-token"},
+        )
+        result = adapter.query(_make_request("anything"), credential=None)
+        assert result == []
+
+    def test_query_point_in_time_pins_revision_and_as_of(self) -> None:
+        fake = FakeDriveClient(
+            files=[_sample_files()[0]],
+            revisions={
+                "file_1": [
+                    {"id": "rev-old", "modifiedTime": "2026-03-01T00:00:00Z"},
+                    {"id": "rev-mid", "modifiedTime": "2026-03-15T00:00:00Z"},
+                    {"id": "rev-new", "modifiedTime": "2026-04-10T00:00:00Z"},
+                ]
+            },
+        )
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: fake,
+            env={"GOOGLE_OAUTH_TOKEN": "env-token"},
+        )
+        request = _make_request("@at=2026-04-01T00:00:00Z | Q3 forecast")
+        candidates = adapter.query(request, credential=None)
+
+        assert len(candidates) == 1
+        payload = candidates[0].content
+        assert payload["revision_id"] == "rev-mid"
+        assert candidates[0].as_of == _ts(2026, 4, 1, 0)
+        assert fake.revision_calls == [("file_1", _ts(2026, 4, 1, 0))]
+
+    def test_query_uses_credential_token_when_provided(self) -> None:
+        from soul_protocol.engine.retrieval import InMemoryCredentialBroker
+
+        broker = InMemoryCredentialBroker()
+        credential = broker.acquire("drive", ["org:sales:*"])
+
+        captured: dict[str, str] = {}
+
+        def factory(token: str):
+            captured["token"] = token
+            return FakeDriveClient(files=[])
+
+        adapter = DriveSourceAdapter(client_factory=factory, env={})
+        adapter.query(_make_request("anything"), credential=credential)
+        assert captured["token"] == credential.token
+
+    def test_query_raises_auth_error_when_no_token_anywhere(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Patch the name the adapter actually imported (source.py captured
+        # a reference at import time). With an empty env AND the token
+        # resolver short-circuited, we should bubble DriveAuthError so the
+        # router can record it as ``sources_failed``.
+        from pocketpaw.connectors.drive import source as source_mod
+
+        def stub(credential, *, env=None):  # noqa: ARG001
+            raise DriveAuthError("no token")
+
+        monkeypatch.setattr(source_mod, "resolve_bearer_token", stub)
+
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: FakeDriveClient(files=[]),
+            env={},
+        )
+        with pytest.raises(DriveAuthError):
+            adapter.query(_make_request("anything"), credential=None)
+
+
+# ---------------------------------------------------------------------------
+# resolve_bearer_token precedence tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBearerToken:
+    def test_credential_wins_over_env(self) -> None:
+        from soul_protocol.engine.retrieval import InMemoryCredentialBroker
+
+        broker = InMemoryCredentialBroker()
+        cred = broker.acquire("drive", ["org:sales:*"])
+        token = resolve_bearer_token(cred, env={"GOOGLE_OAUTH_TOKEN": "env-value"})
+        assert token == cred.token
+
+    def test_env_used_when_no_credential(self) -> None:
+        token = resolve_bearer_token(None, env={"GOOGLE_OAUTH_TOKEN": "env-value"})
+        assert token == "env-value"
+
+    def test_raises_auth_error_when_nothing_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Force the integrations import path to raise so we exercise the
+        # "no source left" branch deterministically.
+        monkeypatch.setitem(
+            __import__("sys").modules,
+            "pocketpaw.integrations.oauth",
+            None,
+        )
+        with pytest.raises(DriveAuthError):
+            resolve_bearer_token(None, env={})
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: RetrievalRouter + DriveSourceAdapter + journal emission
+# ---------------------------------------------------------------------------
+
+
+class TestRouterIntegration:
+    @pytest.fixture
+    def journal(self, tmp_path: Path):
+        j = open_journal(tmp_path / "journal.db")
+        yield j
+        j.close()
+
+    def test_router_dispatches_to_drive_adapter_and_emits_query_event(self, journal) -> None:
+        broker = InMemoryCredentialBroker(journal=journal)
+        router = RetrievalRouter(journal=journal, broker=broker)
+
+        fake = FakeDriveClient(files=_sample_files())
+        adapter = DriveSourceAdapter(
+            client_factory=lambda token: fake,
+            env={"GOOGLE_OAUTH_TOKEN": "unused"},  # broker will hand a real token
+        )
+        router.register_source(
+            CandidateSource(
+                name="drive",
+                kind="dataref",
+                scopes=["org:sales:*"],
+                adapter_ref="pocketpaw.connectors.drive:DriveSourceAdapter",
+            ),
+            adapter,
+        )
+
+        result = router.dispatch(_make_request("Q3 forecast"))
+
+        # Router produced candidates with the DataRef shape.
+        assert len(result.candidates) == 2
+        assert result.candidates[0].content["kind"] == "dataref"
+        assert result.sources_queried == ["drive"]
+        assert result.sources_failed == []
+
+        # Journal captured retrieval.query + the three broker lifecycle events
+        # (acquired/used — the broker also emits on acquire+use when a journal
+        # is attached, we just assert retrieval.query is present).
+        events = journal.query(limit=50)
+        actions = [e.action for e in events]
+        assert "retrieval.query" in actions
+        assert "credential.acquired" in actions  # dataref kind triggers the broker
+        assert "credential.used" in actions
+
+        query_event = next(e for e in events if e.action == "retrieval.query")
+        payload = query_event.payload
+        assert payload["query"] == "Q3 forecast"
+        assert payload["sources_queried"] == ["drive"]
+        assert payload["candidate_count"] == 2
+
+    def test_router_records_auth_failure_as_sources_failed(self, journal) -> None:
+        broker = InMemoryCredentialBroker(journal=journal)
+        router = RetrievalRouter(journal=journal, broker=broker)
+
+        class FailingAdapter(DriveSourceAdapter):
+            def query(self, request, credential):  # type: ignore[override]
+                raise DriveAuthError("token rejected")
+
+        adapter = FailingAdapter(
+            client_factory=lambda token: FakeDriveClient(files=[]),
+            env={"GOOGLE_OAUTH_TOKEN": "ignored"},
+        )
+        router.register_source(
+            CandidateSource(
+                name="drive",
+                kind="dataref",
+                scopes=["org:sales:*"],
+                adapter_ref="pocketpaw.connectors.drive:DriveSourceAdapter",
+            ),
+            adapter,
+        )
+
+        result = router.dispatch(_make_request("anything"))
+        assert result.candidates == []
+        assert len(result.sources_failed) == 1
+        failed_name, failed_reason = result.sources_failed[0]
+        assert failed_name == "drive"
+        assert "DriveAuthError" in failed_reason
+
+
+# ---------------------------------------------------------------------------
+# Smoke — make sure the module exposes the expected public API.
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_exports() -> None:
+    import pocketpaw.connectors.drive as mod
+
+    assert hasattr(mod, "DriveSourceAdapter")
+    assert hasattr(mod, "DriveClient")
+    assert hasattr(mod, "DriveAuthError")
+    assert hasattr(mod, "DriveRateLimitError")
+    assert hasattr(mod, "DriveNotFoundError")
+    assert hasattr(mod, "resolve_bearer_token")

--- a/tests/ee/__init__.py
+++ b/tests/ee/__init__.py
@@ -1,0 +1,3 @@
+# tests/ee/__init__.py — Test package for ee/ subsystems.
+# Created: 2026-04-16 (feat/fleet-journal-emission) — marks the tests/ee
+# directory as a package so pytest can import fixtures across ee tests.

--- a/tests/ee/test_fleet_journal_emission.py
+++ b/tests/ee/test_fleet_journal_emission.py
@@ -1,0 +1,356 @@
+# tests/ee/test_fleet_journal_emission.py — Verify fleet installer emits
+# correlated journal events (fleet.install.started, agent.spawned per soul,
+# fleet.installed summary) when a Journal is passed; stays silent when it
+# isn't; and suppresses the terminal fleet.installed event on partial
+# install so projections never see a completion marker without the work.
+# Created: 2026-04-16 (feat/fleet-journal-emission).
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.spec.journal import Actor
+
+from ee.fleet import FleetConnector, FleetTemplate, install_fleet
+
+# ---------------------------------------------------------------------------
+# Fixtures — parallel the existing test_fleet_installer.py shape so both
+# suites exercise install_fleet through the same factory contract.
+# ---------------------------------------------------------------------------
+
+
+def _basic_fleet(**overrides) -> FleetTemplate:
+    defaults = {
+        "name": "sales-fleet",
+        "soul_template": "arrow",
+        "pocket_name": "Pipeline",
+        "pocket_description": "Live pipeline",
+        "scopes": ["org:sales:*"],
+    }
+    defaults.update(overrides)
+    return FleetTemplate(**defaults)
+
+
+def _fake_factory(*, soul_did: str = "did:soul:fake-1", template_name: str = "Arrow"):
+    factory = MagicMock()
+
+    template = MagicMock()
+    template.name = template_name
+    factory.load_bundled = MagicMock(return_value=template)
+
+    soul = MagicMock()
+    soul.did = soul_did
+    soul.name = template_name
+    factory.from_template = AsyncMock(return_value=soul)
+    return factory, soul
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+@pytest.fixture
+def fake_pocket_creator():
+    pocket = MagicMock()
+    pocket.id = "pocket_fake_1"
+    return AsyncMock(return_value=pocket)
+
+
+@pytest.fixture
+def fake_registry():
+    registry = MagicMock()
+    registry.has = MagicMock(return_value=True)
+    registry.connect = AsyncMock(return_value=True)
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# Happy path — journal supplied, install succeeds end-to-end.
+# ---------------------------------------------------------------------------
+
+
+class TestEmissionHappyPath:
+    @pytest.mark.asyncio
+    async def test_emits_started_spawned_installed_in_order(
+        self, journal, fake_pocket_creator, fake_registry
+    ) -> None:
+        factory, _ = _fake_factory()
+
+        fleet = _basic_fleet(
+            connectors=[FleetConnector(name="hubspot", config={"poll_minutes": 15})],
+        )
+        report = await install_fleet(
+            fleet,
+            soul_factory=factory,
+            connector_registry=fake_registry,
+            pocket_creator=fake_pocket_creator,
+            journal=journal,
+        )
+
+        assert report.succeeded()
+
+        events = journal.query(limit=100)
+        actions = [e.action for e in events]
+        assert actions == [
+            "fleet.install.started",
+            "agent.spawned",
+            "fleet.installed",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_all_events_share_one_correlation_id(self, journal, fake_pocket_creator) -> None:
+        factory, _ = _fake_factory()
+
+        await install_fleet(
+            _basic_fleet(),
+            soul_factory=factory,
+            pocket_creator=fake_pocket_creator,
+            journal=journal,
+        )
+
+        events = journal.query(limit=100)
+        corr_ids = {e.correlation_id for e in events}
+        assert len(events) == 3
+        assert len(corr_ids) == 1
+        assert next(iter(corr_ids)) is not None
+
+    @pytest.mark.asyncio
+    async def test_events_carry_declared_fleet_scope(self, journal, fake_pocket_creator) -> None:
+        factory, _ = _fake_factory()
+        fleet = _basic_fleet(scopes=["org:sales:*", "team:ae"])
+
+        await install_fleet(
+            fleet,
+            soul_factory=factory,
+            pocket_creator=fake_pocket_creator,
+            journal=journal,
+        )
+
+        events = journal.query(limit=100)
+        for event in events:
+            assert event.scope == ["org:sales:*", "team:ae"]
+
+    @pytest.mark.asyncio
+    async def test_agent_spawned_payload_has_canonical_fields(
+        self, journal, fake_pocket_creator
+    ) -> None:
+        factory, soul = _fake_factory(soul_did="did:soul:arrow-42", template_name="Arrow")
+
+        await install_fleet(
+            _basic_fleet(),
+            soul_factory=factory,
+            pocket_creator=fake_pocket_creator,
+            journal=journal,
+        )
+
+        spawned = [e for e in journal.query(limit=100) if e.action == "agent.spawned"]
+        assert len(spawned) == 1
+        payload = spawned[0].payload
+        assert isinstance(payload, dict)
+        assert payload["did"] == "did:soul:arrow-42"
+        assert payload["soul_id"] == "did:soul:arrow-42"
+        assert payload["archetype"] == "arrow"
+        assert payload["fleet"] == "sales-fleet"
+        assert payload["name"] == "Arrow"
+
+    @pytest.mark.asyncio
+    async def test_default_actor_is_system_fleet_installer(
+        self, journal, fake_pocket_creator
+    ) -> None:
+        factory, _ = _fake_factory()
+
+        await install_fleet(
+            _basic_fleet(),
+            soul_factory=factory,
+            pocket_creator=fake_pocket_creator,
+            journal=journal,
+        )
+
+        # SQLite backend persists actor kind + id (not scope_context — that
+        # is a known backend-level projection, not a spec loss). Asserting
+        # only the fields that round-trip keeps this test aligned with the
+        # journal's storage contract.
+        for event in journal.query(limit=100):
+            assert event.actor.kind == "system"
+            assert event.actor.id == "system:fleet-installer"
+
+    @pytest.mark.asyncio
+    async def test_explicit_root_actor_is_recorded_on_every_event(
+        self, journal, fake_pocket_creator
+    ) -> None:
+        factory, _ = _fake_factory()
+        root_actor = Actor(
+            kind="root",
+            id="did:soul:root-01",
+            scope_context=["org:*"],
+        )
+
+        await install_fleet(
+            _basic_fleet(),
+            soul_factory=factory,
+            pocket_creator=fake_pocket_creator,
+            journal=journal,
+            actor=root_actor,
+        )
+
+        for event in journal.query(limit=100):
+            assert event.actor.kind == "root"
+            assert event.actor.id == "did:soul:root-01"
+
+    @pytest.mark.asyncio
+    async def test_fleet_installed_payload_summarises_outcome(
+        self, journal, fake_pocket_creator, fake_registry
+    ) -> None:
+        factory, _ = _fake_factory()
+        fleet = _basic_fleet(
+            connectors=[FleetConnector(name="hubspot")],
+        )
+
+        await install_fleet(
+            fleet,
+            soul_factory=factory,
+            connector_registry=fake_registry,
+            pocket_creator=fake_pocket_creator,
+            journal=journal,
+        )
+
+        terminal = [e for e in journal.query(limit=100) if e.action == "fleet.installed"]
+        assert len(terminal) == 1
+        payload = terminal[0].payload
+        assert payload["fleet"] == "sales-fleet"
+        assert payload["soul_id"] == "did:soul:fake-1"
+        assert payload["pocket_id"] == "pocket_fake_1"
+        assert payload["succeeded"] is True
+        assert payload["step_count"] >= 1
+        assert payload["failed_steps"] == []
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility — no journal means no emission + no failure.
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompat:
+    @pytest.mark.asyncio
+    async def test_install_without_journal_still_works(self, fake_pocket_creator) -> None:
+        factory, _ = _fake_factory()
+
+        report = await install_fleet(
+            _basic_fleet(),
+            soul_factory=factory,
+            pocket_creator=fake_pocket_creator,
+            # journal omitted entirely
+        )
+
+        assert report.succeeded()
+        assert report.soul_id == "did:soul:fake-1"
+
+    @pytest.mark.asyncio
+    async def test_install_with_journal_none_emits_nothing(
+        self, tmp_path: Path, fake_pocket_creator
+    ) -> None:
+        # Open a second, unrelated journal and confirm the installer call
+        # below does not touch it. This is the backward-compat guarantee
+        # for callers that pass journal=None explicitly.
+        unrelated = open_journal(tmp_path / "unrelated.db")
+        try:
+            factory, _ = _fake_factory()
+            await install_fleet(
+                _basic_fleet(),
+                soul_factory=factory,
+                pocket_creator=fake_pocket_creator,
+                journal=None,
+            )
+            assert unrelated.query(limit=100) == []
+        finally:
+            unrelated.close()
+
+
+# ---------------------------------------------------------------------------
+# Partial install — soul step fails, no terminal fleet.installed event.
+# ---------------------------------------------------------------------------
+
+
+class TestPartialInstall:
+    @pytest.mark.asyncio
+    async def test_soul_failure_emits_started_only_no_terminal(self, journal) -> None:
+        factory = MagicMock()
+        factory.load_bundled = MagicMock(side_effect=FileNotFoundError("template missing"))
+
+        report = await install_fleet(
+            _basic_fleet(),
+            soul_factory=factory,
+            journal=journal,
+        )
+
+        assert not report.succeeded()
+        events = journal.query(limit=100)
+        actions = [e.action for e in events]
+        assert actions == ["fleet.install.started"]
+        # No agent.spawned, no fleet.installed — projections and UI
+        # tailers should never see a completion marker for a run that
+        # never produced a soul.
+        assert "agent.spawned" not in actions
+        assert "fleet.installed" not in actions
+
+    @pytest.mark.asyncio
+    async def test_connector_failure_still_emits_terminal_event(
+        self, journal, fake_pocket_creator
+    ) -> None:
+        # Soul creation succeeded, so the install run did produce a soul.
+        # A downstream connector failure shouldn't suppress the terminal
+        # event — the caller already sees it in report.failed_steps and
+        # the journal payload reflects it too.
+        factory, _ = _fake_factory()
+        registry = MagicMock()
+        registry.has = MagicMock(return_value=True)
+        registry.connect = AsyncMock(side_effect=RuntimeError("network down"))
+
+        fleet = _basic_fleet(connectors=[FleetConnector(name="hubspot")])
+        report = await install_fleet(
+            fleet,
+            soul_factory=factory,
+            connector_registry=registry,
+            pocket_creator=fake_pocket_creator,
+            journal=journal,
+        )
+
+        assert not report.succeeded()
+        events = journal.query(limit=100)
+        actions = [e.action for e in events]
+        assert "fleet.install.started" in actions
+        assert "agent.spawned" in actions
+        assert "fleet.installed" in actions
+
+        terminal = next(e for e in events if e.action == "fleet.installed")
+        assert terminal.payload["succeeded"] is False
+        assert "connect:hubspot" in terminal.payload["failed_steps"]
+
+
+# ---------------------------------------------------------------------------
+# Scope fallback — when a fleet declares no scopes the installer still
+# needs to produce a non-empty scope list (EventEntry invariant).
+# ---------------------------------------------------------------------------
+
+
+class TestScopeFallback:
+    @pytest.mark.asyncio
+    async def test_empty_scopes_fall_back_to_fleet_tag(self, journal, fake_pocket_creator) -> None:
+        factory, _ = _fake_factory()
+        fleet = _basic_fleet(scopes=[])
+
+        await install_fleet(
+            fleet,
+            soul_factory=factory,
+            pocket_creator=fake_pocket_creator,
+            journal=journal,
+        )
+
+        for event in journal.query(limit=100):
+            assert event.scope == ["fleet:sales-fleet"]

--- a/tests/ee/test_fleet_router.py
+++ b/tests/ee/test_fleet_router.py
@@ -5,9 +5,18 @@
 # name, emit journal events when opted in, 404 on unknown template,
 # 422 on a malformed body.
 #
+# Updated: 2026-04-16 (feat/ee-journal-dep) — swapped the
+# ``_open_default_journal`` patch for FastAPI's ``dependency_overrides``
+# so tests exercise the same ``get_journal`` seam production uses.
+# The override points at a ``tmp_path`` SQLite file so tests never
+# touch the real ``~/.soul/`` dir. ``journal=false`` is now verified by
+# inspecting the ``install_fleet`` call signature instead of asserting
+# the dep was never called (it's always resolved; the router decides
+# whether to forward it).
+#
 # Mocks the soul-protocol + connector + pocket factories out at the
 # ee.fleet.router seam so these tests stay hermetic — no filesystem
-# journal writes, no mongo, no soul-protocol runtime.
+# journal writes to the real data dir, no mongo, no soul-protocol runtime.
 
 from __future__ import annotations
 
@@ -22,6 +31,7 @@ from soul_protocol.engine.journal import open_journal
 
 from ee.fleet import FleetTemplate
 from ee.fleet.router import router
+from ee.journal_dep import get_journal, reset_journal_cache
 
 # ---------------------------------------------------------------------------
 # Fixtures — app, client, and a fake fleet factory stack so we never boot
@@ -29,10 +39,42 @@ from ee.fleet.router import router
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _isolate_journal_cache():
+    """Drop any Journal cached by a previous test before/after each run.
+
+    The dep's ``lru_cache`` is module-global, so without a reset an open
+    handle from an earlier test could leak into the next one and mask
+    override bugs.
+    """
+
+    reset_journal_cache()
+    yield
+    reset_journal_cache()
+
+
 @pytest.fixture
-def app() -> FastAPI:
+def journal_path(tmp_path: Path) -> Path:
+    """A disposable SQLite path the tests' ``get_journal`` override
+    points at. Shared between the override factory and the read helper.
+    """
+
+    return tmp_path / "router_journal.db"
+
+
+@pytest.fixture
+def app(journal_path: Path) -> FastAPI:
+    """FastAPI app with the fleet router mounted + ``get_journal``
+    overridden to write into a tmp-path journal.
+
+    Using ``dependency_overrides`` is the canonical FastAPI pattern for
+    swapping collaborators in tests — it exercises the real Depends
+    wiring instead of monkey-patching an internal helper.
+    """
+
     a = FastAPI()
     a.include_router(router)
+    a.dependency_overrides[get_journal] = lambda: open_journal(journal_path)
     return a
 
 
@@ -75,25 +117,6 @@ def patch_install_fleet(fake_soul_factory):
 
     with patch("ee.fleet.router.install_fleet", side_effect=_wrapped) as mock:
         yield mock
-
-
-@pytest.fixture
-def journal_path(tmp_path: Path):
-    """Redirect ``_open_default_journal`` to a disposable SQLite path.
-
-    The router opens (and closes) the journal per request — mirroring
-    production where each install is an isolated HTTP round-trip. The
-    fixture itself yields the path so tests can re-open a read handle
-    after the request completes.
-    """
-
-    path = tmp_path / "router_journal.db"
-
-    def _factory() -> Any:
-        return open_journal(path)
-
-    with patch("ee.fleet.router._open_default_journal", side_effect=_factory):
-        yield path
 
 
 @pytest.fixture
@@ -217,13 +240,13 @@ class TestInstallFleet:
         self,
         client: TestClient,
         patch_install_fleet,
-        journal_path,
         read_journal,
     ) -> None:
-        """``journal=true`` wires the default journal into the installer
-        and yields the canonical ``fleet.install.started`` /
+        """``journal=true`` hands the shared org Journal into the
+        installer and yields the canonical ``fleet.install.started`` /
         ``agent.spawned`` / ``fleet.installed`` trio sharing one
-        correlation id.
+        correlation id. Under the dependency override the journal lives
+        at ``tmp_path``, so we can re-open it for read assertions.
         """
 
         resp = client.post(
@@ -242,23 +265,25 @@ class TestInstallFleet:
         corr_ids = {e.correlation_id for e in events}
         assert len(corr_ids) == 1
 
-    def test_install_without_journal_does_not_open_one(
+    def test_install_without_journal_forwards_none(
         self,
         client: TestClient,
         patch_install_fleet,
     ) -> None:
-        """``journal=false`` must not even attempt to open the default
-        journal — keeps the router silent when callers opt out.
+        """``journal=false`` must forward ``None`` into ``install_fleet``.
+        The dep itself is still resolved (FastAPI has no graceful way to
+        skip it), but the router is responsible for the opt-out.
         """
 
-        with patch("ee.fleet.router._open_default_journal") as opener:
-            resp = client.post(
-                "/fleet/install",
-                json={"template_name": "sales-fleet", "journal": False},
-            )
-
+        resp = client.post(
+            "/fleet/install",
+            json={"template_name": "sales-fleet", "journal": False},
+        )
         assert resp.status_code == 200
-        opener.assert_not_called()
+
+        assert patch_install_fleet.call_count == 1
+        kwargs = patch_install_fleet.call_args.kwargs
+        assert kwargs["journal"] is None
 
     def test_unknown_template_returns_404(self, client: TestClient) -> None:
         """Missing templates surface as 404 with a message that names the
@@ -284,7 +309,6 @@ class TestInstallFleet:
         self,
         client: TestClient,
         patch_install_fleet,
-        journal_path,
         read_journal,
     ) -> None:
         """When the caller supplies an ActorSpec it reaches the journal

--- a/tests/ee/test_fleet_router.py
+++ b/tests/ee/test_fleet_router.py
@@ -1,0 +1,340 @@
+# tests/ee/test_fleet_router.py — FastAPI TestClient coverage for the
+# fleet REST router shipped in feat/fleet-rest-router.
+# Created: 2026-04-16 — Asserts the router's contract with the
+# paw-enterprise InstallFleetPanel: list bundled templates, install by
+# name, emit journal events when opted in, 404 on unknown template,
+# 422 on a malformed body.
+#
+# Mocks the soul-protocol + connector + pocket factories out at the
+# ee.fleet.router seam so these tests stay hermetic — no filesystem
+# journal writes, no mongo, no soul-protocol runtime.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from soul_protocol.engine.journal import open_journal
+
+from ee.fleet import FleetTemplate
+from ee.fleet.router import router
+
+# ---------------------------------------------------------------------------
+# Fixtures — app, client, and a fake fleet factory stack so we never boot
+# a real soul runtime inside the test suite.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    a = FastAPI()
+    a.include_router(router)
+    return a
+
+
+@pytest.fixture
+def fake_soul_factory():
+    """Return a ``SoulFactory``-shaped double.
+
+    The installer duck-types on ``load_bundled(name)`` + ``from_template``
+    so we only need those two methods. The soul object itself needs a
+    ``did`` and ``name`` — the installer's ``_agent_spawned_payload``
+    reads them into the journal event.
+    """
+
+    factory = MagicMock()
+    template = MagicMock()
+    template.name = "Arrow"
+    factory.load_bundled = MagicMock(return_value=template)
+
+    soul = MagicMock()
+    soul.did = "did:soul:fake-sales-fleet"
+    soul.name = "Arrow"
+    factory.from_template = AsyncMock(return_value=soul)
+    return factory
+
+
+@pytest.fixture
+def patch_install_fleet(fake_soul_factory):
+    """Replace ``ee.fleet.router.install_fleet`` with a version that
+    always hands the fake soul factory to the real installer.
+
+    This keeps journal wiring + report shape real (the tests assert
+    on them) without requiring a real SoulFactory on the import path.
+    """
+
+    from ee.fleet import install_fleet as real_install
+
+    async def _wrapped(fleet, **kwargs):
+        kwargs.setdefault("soul_factory", fake_soul_factory)
+        return await real_install(fleet, **kwargs)
+
+    with patch("ee.fleet.router.install_fleet", side_effect=_wrapped) as mock:
+        yield mock
+
+
+@pytest.fixture
+def journal_path(tmp_path: Path):
+    """Redirect ``_open_default_journal`` to a disposable SQLite path.
+
+    The router opens (and closes) the journal per request — mirroring
+    production where each install is an isolated HTTP round-trip. The
+    fixture itself yields the path so tests can re-open a read handle
+    after the request completes.
+    """
+
+    path = tmp_path / "router_journal.db"
+
+    def _factory() -> Any:
+        return open_journal(path)
+
+    with patch("ee.fleet.router._open_default_journal", side_effect=_factory):
+        yield path
+
+
+@pytest.fixture
+def read_journal(journal_path: Path):
+    """Expose a helper that re-opens the journal for read assertions
+    after the install request has closed its own writer handle.
+    """
+
+    def _read() -> list:
+        reader = open_journal(journal_path)
+        try:
+            return reader.query(limit=100)
+        finally:
+            reader.close()
+
+    return _read
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# GET /fleet/templates
+# ---------------------------------------------------------------------------
+
+
+class TestGetTemplates:
+    def test_returns_bundled_templates_envelope(self, client: TestClient) -> None:
+        """The list endpoint returns the canonical envelope shape with at
+        least one bundled template — currently ``sales-fleet`` ships with
+        the package; any additions should keep the count >= 1.
+        """
+
+        resp = client.get("/fleet/templates")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "templates" in body
+        assert "total" in body
+        assert body["total"] == len(body["templates"])
+        assert body["total"] >= 1
+
+    def test_templates_have_full_shape(self, client: TestClient) -> None:
+        """Every entry validates as a FleetTemplate so the UI can render
+        description + connectors + widgets without a second round-trip.
+        """
+
+        resp = client.get("/fleet/templates")
+        assert resp.status_code == 200
+        for entry in resp.json()["templates"]:
+            parsed = FleetTemplate.model_validate(entry)
+            assert parsed.name
+            assert parsed.soul_template
+            assert parsed.pocket_name
+
+    def test_sales_fleet_is_present(self, client: TestClient) -> None:
+        """``sales-fleet`` is the canonical reference fleet — its presence
+        is a regression guard if the bundled directory moves.
+        """
+
+        resp = client.get("/fleet/templates")
+        names = [t["name"] for t in resp.json()["templates"]]
+        assert "sales-fleet" in names
+
+    def test_bad_template_is_skipped(self, client: TestClient, monkeypatch) -> None:
+        """A single bad template can't take down the list endpoint — it
+        is logged and skipped while the rest still render.
+        """
+
+        def _explode(name: str) -> FleetTemplate:
+            if name == "broken":
+                raise ValueError("simulated parse error")
+            return FleetTemplate(
+                name=name,
+                soul_template="arrow",
+                pocket_name="Pipeline",
+            )
+
+        monkeypatch.setattr(
+            "ee.fleet.router.list_bundled_fleets",
+            lambda: ["broken", "ok"],
+        )
+        monkeypatch.setattr("ee.fleet.router.load_fleet", _explode)
+
+        resp = client.get("/fleet/templates")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["templates"][0]["name"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# POST /fleet/install — happy path, journal opt-in, 404, 422.
+# ---------------------------------------------------------------------------
+
+
+class TestInstallFleet:
+    def test_installs_known_template_and_returns_report(
+        self,
+        client: TestClient,
+        patch_install_fleet,
+    ) -> None:
+        """``sales-fleet`` installs end-to-end against fake factories and
+        the router returns the serialized ``FleetInstallReport``. The
+        report's ``soul_id`` tracks the fake soul from the factory.
+        """
+
+        resp = client.post(
+            "/fleet/install",
+            json={"template_name": "sales-fleet", "journal": False},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["fleet"] == "sales-fleet"
+        assert body["soul_id"] == "did:soul:fake-sales-fleet"
+        assert isinstance(body["steps"], list)
+        assert body["steps"], "install report should record at least one step"
+
+    def test_install_with_journal_emits_correlated_events(
+        self,
+        client: TestClient,
+        patch_install_fleet,
+        journal_path,
+        read_journal,
+    ) -> None:
+        """``journal=true`` wires the default journal into the installer
+        and yields the canonical ``fleet.install.started`` /
+        ``agent.spawned`` / ``fleet.installed`` trio sharing one
+        correlation id.
+        """
+
+        resp = client.post(
+            "/fleet/install",
+            json={"template_name": "sales-fleet", "journal": True},
+        )
+        assert resp.status_code == 200
+
+        events = read_journal()
+        actions = [e.action for e in events]
+        assert actions == [
+            "fleet.install.started",
+            "agent.spawned",
+            "fleet.installed",
+        ]
+        corr_ids = {e.correlation_id for e in events}
+        assert len(corr_ids) == 1
+
+    def test_install_without_journal_does_not_open_one(
+        self,
+        client: TestClient,
+        patch_install_fleet,
+    ) -> None:
+        """``journal=false`` must not even attempt to open the default
+        journal — keeps the router silent when callers opt out.
+        """
+
+        with patch("ee.fleet.router._open_default_journal") as opener:
+            resp = client.post(
+                "/fleet/install",
+                json={"template_name": "sales-fleet", "journal": False},
+            )
+
+        assert resp.status_code == 200
+        opener.assert_not_called()
+
+    def test_unknown_template_returns_404(self, client: TestClient) -> None:
+        """Missing templates surface as 404 with a message that names the
+        offending ``template_name``.
+        """
+
+        resp = client.post(
+            "/fleet/install",
+            json={"template_name": "does-not-exist", "journal": False},
+        )
+        assert resp.status_code == 404
+        assert "does-not-exist" in resp.json()["detail"]
+
+    def test_malformed_body_returns_422(self, client: TestClient) -> None:
+        """Missing required ``template_name`` field must fail validation
+        before the installer is even considered.
+        """
+
+        resp = client.post("/fleet/install", json={})
+        assert resp.status_code == 422
+
+    def test_actor_spec_is_forwarded_to_installer(
+        self,
+        client: TestClient,
+        patch_install_fleet,
+        journal_path,
+        read_journal,
+    ) -> None:
+        """When the caller supplies an ActorSpec it reaches the journal
+        events as the authoring actor instead of the fallback
+        ``system:fleet-installer`` identity.
+        """
+
+        resp = client.post(
+            "/fleet/install",
+            json={
+                "template_name": "sales-fleet",
+                "journal": True,
+                "actor": {
+                    "kind": "user",
+                    "id": "user-123",
+                    "scope_context": ["org:sales:*"],
+                },
+            },
+        )
+        assert resp.status_code == 200
+
+        events = read_journal()
+        assert events, "journal should have captured events"
+        for event in events:
+            assert event.actor.kind == "user"
+            assert event.actor.id == "user-123"
+
+
+# ---------------------------------------------------------------------------
+# Response shape — a smoke test to keep Pydantic warnings out of the logs
+# when FastAPI serializes the install report.
+# ---------------------------------------------------------------------------
+
+
+class TestResponseShape:
+    def test_install_report_serializes_without_warnings(
+        self,
+        client: TestClient,
+        patch_install_fleet,
+        recwarn: Any,
+    ) -> None:
+        """Serialising the install report must not raise PydanticSerializationUnexpectedValue
+        or similar warnings — the router's response_model is the canonical
+        ``FleetInstallReport`` so downstream TypeScript clients can rely on it.
+        """
+
+        resp = client.post(
+            "/fleet/install",
+            json={"template_name": "sales-fleet", "journal": False},
+        )
+        assert resp.status_code == 200
+        pydantic_warnings = [w for w in recwarn.list if "pydantic" in str(w.category).lower()]
+        assert not pydantic_warnings, [str(w) for w in pydantic_warnings]

--- a/tests/ee/test_journal_dep.py
+++ b/tests/ee/test_journal_dep.py
@@ -1,0 +1,85 @@
+# tests/ee/test_journal_dep.py — Coverage for the shared ``get_journal``
+# FastAPI dependency shipped in feat/ee-journal-dep.
+# Created: 2026-04-16 — Pins three contracts the rest of ee/ depends on:
+# the dep returns a real ``Journal`` instance, successive calls hit the
+# cache (one Journal per process), and ``SOUL_DATA_DIR`` is honored as
+# the override knob operators use to pin the data dir to a custom volume.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from soul_protocol.engine.journal import Journal
+
+from ee.journal_dep import _org_data_dir, get_journal, reset_journal_cache
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Each test gets a disposable ``SOUL_DATA_DIR`` + a clean cache.
+
+    The lru_cache is module-global, so without the reset a stale instance
+    from a previous test would mask env-var changes in the next one.
+    """
+
+    monkeypatch.setenv("SOUL_DATA_DIR", str(tmp_path))
+    reset_journal_cache()
+    yield
+    reset_journal_cache()
+
+
+class TestGetJournal:
+    def test_returns_journal_instance(self) -> None:
+        """The dep returns a ready-to-use ``Journal`` rooted at the org
+        data dir. Callers should be able to ``append()`` immediately.
+        """
+
+        journal = get_journal()
+        assert isinstance(journal, Journal)
+
+    def test_is_cached_across_calls(self) -> None:
+        """Two calls inside one process return the exact same instance —
+        re-opening SQLite on every request would churn file handles and
+        defeat the point of the dependency.
+        """
+
+        first = get_journal()
+        second = get_journal()
+        assert first is second
+
+    def test_honors_soul_data_dir_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """``SOUL_DATA_DIR`` overrides the default ``~/.soul/`` location
+        so operators can point an install at any volume without editing
+        code. The override must be live — not frozen at import time.
+        """
+
+        custom = tmp_path / "custom-soul-data"
+        monkeypatch.setenv("SOUL_DATA_DIR", str(custom))
+        reset_journal_cache()
+
+        resolved = _org_data_dir()
+        assert resolved == custom
+
+        # Opening the journal creates the dir + the sqlite file, proving
+        # the env var flowed all the way through.
+        journal = get_journal()
+        assert isinstance(journal, Journal)
+        assert (custom / "journal.db").exists()
+
+
+class TestResetJournalCache:
+    def test_drops_cached_instance(self) -> None:
+        """``reset_journal_cache()`` is the escape hatch for tests that
+        need a fresh Journal. After reset the next ``get_journal()``
+        call must return a new instance, not the stale one.
+        """
+
+        first = get_journal()
+        reset_journal_cache()
+        second = get_journal()
+        assert first is not second

--- a/tests/test_ingest_adapter.py
+++ b/tests/test_ingest_adapter.py
@@ -1,0 +1,188 @@
+"""Tests for the IngestAdapter alias + IngestACL dataclass (Move 7 PR-A).
+
+Created: 2026-04-13 — Wire-shape tests + a duck-typed adapter that
+implements both ConnectorProtocol and the new permissions() method.
+The fleet template runtime (PR-B) discovers ACL-aware connectors by
+checking for the permissions() method, which this test pins as the
+contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pocketpaw.connectors import (
+    ActionResult,
+    ActionSchema,
+    ConnectionResult,
+    ConnectorProtocol,
+    IngestACL,
+    IngestAdapter,
+    SyncResult,
+)
+from pocketpaw.connectors.protocol import ConnectorStatus
+
+# ---------------------------------------------------------------------------
+# IngestACL dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestIngestACL:
+    def test_defaults_are_empty(self) -> None:
+        acl = IngestACL()
+        assert acl.scope == []
+        assert acl.visibility == ""
+        assert acl.source_principal == ""
+        assert acl.metadata == {}
+
+    def test_carries_scope_list_into_fabric(self) -> None:
+        acl = IngestACL(
+            scope=["org:sales:leads"],
+            visibility="members",
+            source_principal="hubspot:deal-team:42",
+        )
+        assert acl.scope == ["org:sales:leads"]
+        assert acl.visibility == "members"
+        assert acl.source_principal == "hubspot:deal-team:42"
+
+    def test_metadata_is_open_dict(self) -> None:
+        acl = IngestACL(metadata={"channel_type": "private", "guests_excluded": True})
+        assert acl.metadata["channel_type"] == "private"
+        assert acl.metadata["guests_excluded"] is True
+
+
+# ---------------------------------------------------------------------------
+# IngestAdapter contract — duck-typed implementation
+# ---------------------------------------------------------------------------
+
+
+class FakeIngestAdapter:
+    """Reference implementation that satisfies IngestAdapter at runtime."""
+
+    name = "fake_slack"
+    display_name = "Fake Slack"
+
+    def __init__(self) -> None:
+        self.permissions_calls: list[tuple[str, str | None]] = []
+
+    async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        return ConnectionResult(
+            success=True,
+            connector_name=self.name,
+            status=ConnectorStatus.CONNECTED,
+        )
+
+    async def disconnect(self, pocket_id: str) -> bool:
+        return True
+
+    async def actions(self) -> list[ActionSchema]:
+        return [ActionSchema(name="list_messages", description="List channel messages")]
+
+    async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
+        return ActionResult(success=True, data={"messages": []})
+
+    async def sync(self, pocket_id: str) -> SyncResult:
+        return SyncResult(success=True, connector_name=self.name)
+
+    async def schema(self) -> dict[str, Any]:
+        return {"messages": {"text": "string"}}
+
+    async def permissions(self, pocket_id: str, record_id: str | None = None) -> IngestACL:
+        self.permissions_calls.append((pocket_id, record_id))
+        if record_id and record_id.startswith("private_"):
+            return IngestACL(
+                scope=["org:engineering:eyes-only"],
+                visibility="private",
+                source_principal=f"slack:channel:{record_id}",
+            )
+        return IngestACL(scope=["org:public:*"], visibility="public")
+
+
+class TestIngestAdapterContract:
+    def test_fake_adapter_satisfies_connector_protocol(self) -> None:
+        adapter = FakeIngestAdapter()
+        # Runtime isinstance check on Protocol with @runtime_checkable would
+        # work, but ConnectorProtocol isn't decorated. Structural check via
+        # attribute presence is the documented pattern in the codebase.
+        assert hasattr(adapter, "connect")
+        assert hasattr(adapter, "execute")
+        assert hasattr(adapter, "sync")
+        assert hasattr(adapter, "schema")
+
+    def test_fake_adapter_exposes_permissions_method(self) -> None:
+        adapter = FakeIngestAdapter()
+        assert callable(getattr(adapter, "permissions", None))
+
+    @pytest.mark.asyncio
+    async def test_permissions_default_returns_public_scope(self) -> None:
+        adapter = FakeIngestAdapter()
+        acl = await adapter.permissions("pocket-1")
+        assert "org:public:*" in acl.scope
+        assert acl.visibility == "public"
+
+    @pytest.mark.asyncio
+    async def test_permissions_per_record_returns_private_scope(self) -> None:
+        adapter = FakeIngestAdapter()
+        acl = await adapter.permissions("pocket-1", record_id="private_founders")
+        assert "org:engineering:eyes-only" in acl.scope
+        assert acl.visibility == "private"
+        assert "private_founders" in acl.source_principal
+
+    @pytest.mark.asyncio
+    async def test_permissions_call_records_pocket_and_record_args(self) -> None:
+        adapter = FakeIngestAdapter()
+        await adapter.permissions("pocket-1", record_id="msg_42")
+        await adapter.permissions("pocket-2")
+        assert adapter.permissions_calls == [("pocket-1", "msg_42"), ("pocket-2", None)]
+
+
+# ---------------------------------------------------------------------------
+# Public exports
+# ---------------------------------------------------------------------------
+
+
+class TestPublicExports:
+    def test_ingest_adapter_re_exported(self) -> None:
+        from pocketpaw.connectors import IngestAdapter as RexportedAdapter
+        from pocketpaw.connectors.protocol import IngestAdapter as DirectAdapter
+
+        assert RexportedAdapter is DirectAdapter
+
+    def test_ingest_acl_re_exported(self) -> None:
+        from pocketpaw.connectors import IngestACL as RexportedACL
+        from pocketpaw.connectors.protocol import IngestACL as DirectACL
+
+        assert RexportedACL is DirectACL
+
+
+# ---------------------------------------------------------------------------
+# Static check — IngestAdapter type alias keeps ConnectorProtocol surface
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_adapter_protocol_extends_connector_protocol() -> None:
+    """IngestAdapter should not lose any ConnectorProtocol methods."""
+    connector_methods = {
+        "connect",
+        "disconnect",
+        "actions",
+        "execute",
+        "sync",
+        "schema",
+    }
+    ingest_methods = {
+        "connect",
+        "disconnect",
+        "actions",
+        "execute",
+        "sync",
+        "schema",
+        "permissions",
+    }
+    # Inspect the Protocol classes to be sure.
+    for method in connector_methods:
+        assert hasattr(ConnectorProtocol, method)
+    for method in ingest_methods:
+        assert hasattr(IngestAdapter, method)

--- a/tests/test_integration_headless.py
+++ b/tests/test_integration_headless.py
@@ -188,6 +188,22 @@ class TestToolBridgeCompleteness:
     to invoke the tools via subprocess.
     """
 
+    @pytest.fixture(autouse=True)
+    def _reset_soul(self):
+        """Reset the soul manager singleton before each test.
+
+        `_instantiate_all_tools` strips `remember/recall/forget` when a soul
+        manager is active (soul_remember/soul_recall supersede them). A prior
+        test in the suite may leave a SoulManager installed globally; without
+        this reset the memory-tool assertions below fail non-deterministically
+        depending on test order. Mirrors the pattern in test_soul_v024_smoke.py.
+        """
+        from pocketpaw.soul.manager import _reset_manager
+
+        _reset_manager()
+        yield
+        _reset_manager()
+
     # All backends that go through _instantiate_all_tools()
     _ALL_BACKENDS = [
         "openai_agents",

--- a/tests/test_soul_manager.py
+++ b/tests/test_soul_manager.py
@@ -70,15 +70,21 @@ class TestSoulManager:
         await mgr.initialize()
         await mgr.observe("Hello", "Hi there!")
 
-    async def test_get_tools_returns_six(self, soul_settings):
+    async def test_get_tools_exposes_core_soul_tools(self, soul_settings):
+        """SoulManager exposes at least the six core tools pocketpaw depends on.
+
+        Subset-check (renamed from the old exact-6 variant) so soul-protocol
+        can add new tools without breaking this contract. v0.3.1 ships three
+        extras (soul_forget, soul_core_memory, soul_context) on top of the
+        original six; the test now proves the core six are always present.
+        """
         from pocketpaw.soul.manager import SoulManager
 
         mgr = SoulManager(soul_settings)
         await mgr.initialize()
         tools = mgr.get_tools()
-        assert len(tools) == 6
         names = {t.name for t in tools}
-        assert names == {
+        required = {
             "soul_remember",
             "soul_recall",
             "soul_edit_core",
@@ -86,6 +92,8 @@ class TestSoulManager:
             "soul_evaluate",
             "soul_reload",
         }
+        missing = required - names
+        assert not missing, f"SoulManager missing core tools: {missing}"
 
     async def test_corrupt_soul_file_falls_back_to_birth(self, soul_settings, tmp_path):
         from pocketpaw.soul.manager import SoulManager

--- a/uv.lock
+++ b/uv.lock
@@ -4301,6 +4301,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "qrcode", extra = ["pil"] },
     { name = "rich" },
+    { name = "soul-protocol" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -4331,7 +4332,7 @@ all = [
     { name = "python-telegram-bot" },
     { name = "sarvamai" },
     { name = "slack-bolt" },
-    { name = "soul-protocol", extra = ["engine"] },
+    { name = "soul-protocol" },
 ]
 all-backends = [
     { name = "deepagents" },
@@ -4365,7 +4366,7 @@ all-tools = [
     { name = "pyautogui" },
     { name = "pytesseract" },
     { name = "sarvamai" },
-    { name = "soul-protocol", extra = ["engine"] },
+    { name = "soul-protocol" },
 ]
 browser = [
     { name = "playwright" },
@@ -4508,7 +4509,7 @@ slack = [
     { name = "slack-bolt" },
 ]
 soul = [
-    { name = "soul-protocol", extra = ["engine"] },
+    { name = "soul-protocol" },
 ]
 teams = [
     { name = "botbuilder-core" },
@@ -4716,6 +4717,7 @@ requires-dist = [
     { name = "slack-bolt", marker = "extra == 'dev'", specifier = ">=1.20.0" },
     { name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.20.0" },
     { name = "slowapi", marker = "extra == 'enterprise'", specifier = ">=0.1.9" },
+    { name = "soul-protocol", extras = ["engine"], specifier = ">=0.3.1" },
     { name = "soul-protocol", extras = ["engine"], marker = "extra == 'all'", specifier = ">=0.2.9" },
     { name = "soul-protocol", extras = ["engine"], marker = "extra == 'all-tools'", specifier = ">=0.2.9" },
     { name = "soul-protocol", extras = ["engine"], marker = "extra == 'soul'", specifier = ">=0.2.9" },
@@ -6353,23 +6355,16 @@ wheels = [
 
 [[package]]
 name = "soul-protocol"
-version = "0.2.9"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0a/7b6ea4f8903edad06ad73d2280bee3c1a387821ea90d38186ab9ac5d2d50/soul_protocol-0.2.9.tar.gz", hash = "sha256:7e8a6ec7179694a465fd1cb17f9db6af73a5426d6d3a3bf1e4a33495a687fb37", size = 1232417, upload-time = "2026-03-29T10:43:25.293Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/13/8ea72d17a23848e04ae46834895d2ee4dd4c59b42cf586fc9da0443d3eed/soul_protocol-0.2.9-py3-none-any.whl", hash = "sha256:82199de3114d5ceb5084e23dc6d253bb48032ba9fc3ced4ea2956fb1abec6e22", size = 266368, upload-time = "2026-03-29T10:43:24.046Z" },
-]
-
-[package.optional-dependencies]
-engine = [
     { name = "click" },
     { name = "cryptography" },
+    { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/e7/1799cfc9c83c0a12b7e3d403190d01794c2c685917ec63bb3c4741183ca7/soul_protocol-0.3.1.tar.gz", hash = "sha256:1885b4878b09f3ff766080d13edb698581d564353cdb04ed8f186a5ade0d786d", size = 1506135, upload-time = "2026-04-14T18:32:03.919Z" }
 
 [[package]]
 name = "soupsieve"

--- a/uv.lock
+++ b/uv.lock
@@ -4316,6 +4316,7 @@ all = [
     { name = "google-adk" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
     { name = "google-genai" },
     { name = "html2text" },
     { name = "langchain-mcp-adapters" },
@@ -4348,6 +4349,7 @@ all-channels = [
     { name = "discord-cli-agent" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
     { name = "matrix-nio" },
     { name = "neonize" },
     { name = "python-telegram-bot" },
@@ -4427,6 +4429,11 @@ dev = [
 ]
 discord = [
     { name = "discord-cli-agent" },
+]
+drive = [
+    { name = "google-api-python-client" },
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
 ]
 enterprise = [
     { name = "beanie" },
@@ -4612,13 +4619,18 @@ requires-dist = [
     { name = "google-api-python-client", marker = "extra == 'all'", specifier = ">=2.100.0" },
     { name = "google-api-python-client", marker = "extra == 'all-channels'", specifier = ">=2.100.0" },
     { name = "google-api-python-client", marker = "extra == 'dev'", specifier = ">=2.100.0" },
+    { name = "google-api-python-client", marker = "extra == 'drive'", specifier = ">=2.100.0" },
     { name = "google-api-python-client", marker = "extra == 'enterprise'", specifier = ">=2.100.0" },
     { name = "google-api-python-client", marker = "extra == 'gchat'", specifier = ">=2.100.0" },
     { name = "google-auth", marker = "extra == 'all'", specifier = ">=2.25.0" },
     { name = "google-auth", marker = "extra == 'all-channels'", specifier = ">=2.25.0" },
     { name = "google-auth", marker = "extra == 'dev'", specifier = ">=2.25.0" },
+    { name = "google-auth", marker = "extra == 'drive'", specifier = ">=2.25.0" },
     { name = "google-auth", marker = "extra == 'enterprise'", specifier = ">=2.25.0" },
     { name = "google-auth", marker = "extra == 'gchat'", specifier = ">=2.25.0" },
+    { name = "google-auth-oauthlib", marker = "extra == 'all'", specifier = ">=1.2.0" },
+    { name = "google-auth-oauthlib", marker = "extra == 'all-channels'", specifier = ">=1.2.0" },
+    { name = "google-auth-oauthlib", marker = "extra == 'drive'", specifier = ">=1.2.0" },
     { name = "google-auth-oauthlib", marker = "extra == 'enterprise'", specifier = ">=1.2.0" },
     { name = "google-cloud-storage", marker = "extra == 'enterprise'", specifier = ">=2.14.0" },
     { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.0.0" },
@@ -4727,7 +4739,7 @@ requires-dist = [
     { name = "trafilatura", marker = "extra == 'knowledge'" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.31.1" },
 ]
-provides-extras = ["vector", "knowledge", "databases", "postgresql", "mysql", "mongodb", "graph", "dashboard", "telegram", "browser", "desktop", "openai-agents", "google-adk", "copilot-sdk", "deep-agents", "litellm", "memory", "soul", "discord", "slack", "whatsapp-personal", "matrix", "teams", "gchat", "image", "extract", "voice", "ocr", "sarvam", "mcp", "recommended", "channels", "all-channels", "all-tools", "all-backends", "enterprise", "all", "dev"]
+provides-extras = ["vector", "knowledge", "databases", "postgresql", "mysql", "mongodb", "graph", "dashboard", "telegram", "browser", "desktop", "openai-agents", "google-adk", "copilot-sdk", "deep-agents", "litellm", "memory", "soul", "discord", "slack", "whatsapp-personal", "matrix", "teams", "gchat", "drive", "image", "extract", "voice", "ocr", "sarvam", "mcp", "recommended", "channels", "all-channels", "all-tools", "all-backends", "enterprise", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Brings 7 integration PRs from dev onto ee so enterprise testing runs against one consolidated base.

## What's synced

| PR (on dev) | What it ships |
|---|---|
| #927 | Ripple widget docs via kb-go (read-side kb integration) |
| #939 | IngestAdapter + IngestACL base for connectors |
| #940 | Fleet bundle runtime + Sales Fleet template |
| #947 | Fleet installer journal emission (agent.spawned + fleet.install.started + fleet.installed) |
| #948 | Fleet REST router — /api/v1/fleet/templates + /install |
| #949 | get_journal FastAPI dep + fleet router migration onto it |
| #950 | Google Drive SourceAdapter (first zero-copy federation source) |

Plus the soul-protocol base-dep promotion (was [engine] extra, now soul-protocol[engine]>=0.3.1 in base deps) and two test fixes that surfaced when soul became resolvable in CI (autouse _reset_manager fixture for TestToolBridgeCompleteness, subset-check for soul manager tool count).

## Conflict resolution

- `uv.lock` regenerated to pick soul-protocol 0.3.1 (matches the new base dep). Everything else auto-merged cleanly — ee's existing ee-cloud work (workspace RBAC, avatars, paw-print) sits alongside the new ee/fleet/ and ee/journal_dep.py without overlap.

## Tests

- Full suite: 4099 passed, 7 skipped
- ee suite specifically: all green (fleet router 11 tests, journal dep 4 tests, fleet install 12 tests)

## Why ee not dev

Enterprise integration testing happens on ee. Keeping dev and ee in sync on these primitives means Wave 3 rewrites can target ee directly without each one needing its own dev-ee sync.