### PR TITLE
feat(ee-retrieval): retrieval log + graduation as journal projection

### DIFF
--- a/ee/retrieval/__init__.py
+++ b/ee/retrieval/__init__.py
@@ -1,0 +1,61 @@
+# ee/retrieval/__init__.py — Retrieval log + graduation as a journal projection.
+# Created: 2026-04-16 (feat/retrieval-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Supersedes the side-channel design in held PRs
+# #936 (JSONL retrieval sink) and #937 (graduation policy over that JSONL).
+# Both targeted the same problem — an observable retrieval trail + access-
+# count graduation — with a separate `~/.pocketpaw/retrieval.jsonl` file
+# and its own mutex. The org journal is now the source of truth, so the
+# JSONL sink is retired and the domain logic re-lands here as a projection
+# over the journal's ``retrieval.query`` + ``graduation.applied`` events.
+#
+# What we re-export: the store (write path), the projection (read path),
+# the policy (graduation decisions), plus the canonical action names and
+# payload builders for callers that want to emit events out of band.
+
+from ee.retrieval.events import (
+    ACTION_GRADUATION_APPLIED,
+    ACTION_RETRIEVAL_QUERY,
+    ALL_RETRIEVAL_ACTIONS,
+    graduation_applied_payload,
+    retrieval_query_payload,
+)
+from ee.retrieval.policy import (
+    DEFAULT_EPISODIC_THRESHOLD,
+    DEFAULT_SEMANTIC_THRESHOLD,
+    DEFAULT_WINDOW_DAYS,
+    GraduationDecision,
+    GraduationKind,
+    GraduationReport,
+    apply_decisions,
+    scan_for_graduations,
+)
+from ee.retrieval.projection import (
+    GraduationStateRow,
+    RetrievalProjection,
+    RetrievalView,
+)
+from ee.retrieval.store import RetrievalJournalStore
+
+__all__ = [
+    # Actions + payload builders.
+    "ACTION_RETRIEVAL_QUERY",
+    "ACTION_GRADUATION_APPLIED",
+    "ALL_RETRIEVAL_ACTIONS",
+    "retrieval_query_payload",
+    "graduation_applied_payload",
+    # Write path.
+    "RetrievalJournalStore",
+    # Read path.
+    "RetrievalProjection",
+    "RetrievalView",
+    "GraduationStateRow",
+    # Graduation policy.
+    "GraduationDecision",
+    "GraduationKind",
+    "GraduationReport",
+    "DEFAULT_WINDOW_DAYS",
+    "DEFAULT_EPISODIC_THRESHOLD",
+    "DEFAULT_SEMANTIC_THRESHOLD",
+    "scan_for_graduations",
+    "apply_decisions",
+]

--- a/ee/retrieval/events.py
+++ b/ee/retrieval/events.py
@@ -1,0 +1,129 @@
+# ee/retrieval/events.py — Canonical event payloads for the retrieval projection.
+# Created: 2026-04-16 (feat/retrieval-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Carries #936's intent (capture retrieval traces
+# in an append-only log) and #937's intent (graduation decisions written
+# durably) onto the org journal. The action names come from soul-protocol's
+# v0.3.1 catalog — ``retrieval.query`` is the event soul-protocol's own
+# RetrievalRouter already emits, ``graduation.applied`` is listed there too
+# even though no upstream writer exists yet.
+#
+# Payload shapes:
+#   - ``retrieval.query`` — we keep the v0.3.1 base keys (``request_id``,
+#     ``query``, ``strategy``, ``sources_queried``, ``sources_failed``,
+#     ``candidate_count``) and extend with pocketpaw-specific context the
+#     graduation projection needs (full candidate list with tier + score,
+#     picked IDs, pocket, latency). Downstream readers that only know the
+#     base keys still work — additive fields, no breaking rename.
+#   - ``graduation.applied`` — no upstream writer shipped with v0.3.1, so
+#     this is the first concrete shape. Mirrors #937's GraduationDecision
+#     so the projection can reconstruct decisions without a second table.
+#
+# Scope lives on ``EventEntry.scope`` (the journal column), NOT inside the
+# payload. Same rule as ee/fabric/events.py — scope is the journal's
+# canonical filter and duplicating it in the payload invites drift.
+
+from __future__ import annotations
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Action names — from soul-protocol v0.3.1 ACTION_CATALOG. Pinned as
+# constants so the projection + policy can both reach them without another
+# module path.
+# ---------------------------------------------------------------------------
+
+ACTION_RETRIEVAL_QUERY = "retrieval.query"
+ACTION_GRADUATION_APPLIED = "graduation.applied"
+
+ALL_RETRIEVAL_ACTIONS = (
+    ACTION_RETRIEVAL_QUERY,
+    ACTION_GRADUATION_APPLIED,
+)
+
+
+# ---------------------------------------------------------------------------
+# Payload builders — tiny module-level functions, same pattern as
+# ee/fabric/events.py. Kept boring on purpose so migrations and out-of-band
+# emitters (soul-protocol's own router, for instance) produce identical
+# dicts to what the projection expects.
+# ---------------------------------------------------------------------------
+
+
+def retrieval_query_payload(
+    *,
+    request_id: str,
+    query: str,
+    strategy: str = "parallel",
+    sources_queried: list[str] | None = None,
+    sources_failed: list[dict[str, Any]] | None = None,
+    candidates: list[dict[str, Any]] | None = None,
+    picked: list[str] | None = None,
+    latency_ms: int = 0,
+    pocket_id: str | None = None,
+    trace_id: str | None = None,
+) -> dict[str, Any]:
+    """Payload for ``retrieval.query`` events.
+
+    Base keys (``request_id``, ``query``, ``strategy``, ``sources_queried``,
+    ``sources_failed``, ``candidate_count``) match what soul-protocol's own
+    RetrievalRouter emits — so callers replaying a journal written by the
+    engine get the same shape regardless of who wrote the entry.
+
+    The extra keys (``candidates``, ``picked``, ``latency_ms``, ``pocket_id``,
+    ``trace_id``) are additive — pocketpaw's graduation projection needs the
+    per-candidate tier + score to count accesses, and the operator UI wants
+    to see what was actually picked. Consumers that only know the base
+    shape simply ignore the extra keys.
+
+    Each entry in ``candidates`` is a small dict — ``{"id", "source",
+    "score", "tier"?}`` — not a Pydantic model so the projection survives
+    soul-protocol refactors without a migration.
+    """
+
+    candidates = list(candidates or [])
+    return {
+        "request_id": request_id,
+        "query": query,
+        "strategy": strategy,
+        "sources_queried": list(sources_queried or []),
+        "sources_failed": list(sources_failed or []),
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+        "picked": list(picked or []),
+        "latency_ms": latency_ms,
+        "pocket_id": pocket_id,
+        "trace_id": trace_id,
+    }
+
+
+def graduation_applied_payload(
+    *,
+    memory_id: str,
+    kind: str,
+    access_count: int,
+    window_days: int,
+    from_tier: str | None,
+    to_tier: str,
+    pocket_id: str | None = None,
+    reason: str = "",
+) -> dict[str, Any]:
+    """Payload for ``graduation.applied`` events.
+
+    One event per decision. The projection walks these to reconstruct a
+    per-memory graduation history — which memories graduated, to what
+    tier, how many accesses triggered the promotion. Apply-or-propose is
+    recorded on the EventEntry's ``actor`` (``system:graduation`` for the
+    scheduler, a real actor when a human pushes the button) rather than
+    inside the payload.
+    """
+
+    return {
+        "memory_id": memory_id,
+        "kind": kind,
+        "access_count": access_count,
+        "window_days": window_days,
+        "from_tier": from_tier,
+        "to_tier": to_tier,
+        "pocket_id": pocket_id,
+        "reason": reason,
+    }

--- a/ee/retrieval/policy.py
+++ b/ee/retrieval/policy.py
@@ -1,0 +1,367 @@
+# ee/retrieval/policy.py — Graduation policy over the journal-backed projection.
+# Created: 2026-04-16 (feat/retrieval-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Ports #937's access-count graduation logic
+# from a JSONL scan onto a projection scan. Every numeric threshold and
+# decision rule from #937 is preserved verbatim — only the input source
+# changes (projection rows instead of RetrievalLogEntry rows) and the
+# output emission goes through ``RetrievalJournalStore.log_graduation``
+# instead of mutating a JSONL file.
+#
+# Why keep #937's rules verbatim? Because the thresholds were tuned for
+# feel ("accessed 10x in a month = episodic graduates to semantic") and
+# the refactor isn't the place to re-tune. A follow-up slice can make
+# them configurable per pocket.
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+from ee.retrieval.projection import RetrievalProjection
+from ee.retrieval.store import RetrievalJournalStore
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tuning defaults — carried verbatim from #937 so the runtime behaviour
+# stays identical after the refactor. Override via scan_for_graduations
+# kwargs when a pocket needs a different cadence.
+# ---------------------------------------------------------------------------
+
+DEFAULT_WINDOW_DAYS = 30
+DEFAULT_EPISODIC_THRESHOLD = 10
+DEFAULT_SEMANTIC_THRESHOLD = 50
+
+
+GraduationKind = Literal[
+    "episodic_to_semantic",
+    "semantic_to_core",
+    "promote_procedural",
+]
+
+
+@dataclass
+class GraduationDecision:
+    """One proposed tier change. The scan emits these; the apply path turns
+    them into ``graduation.applied`` events on the journal.
+
+    Mirrors the shape from #937 so downstream consumers (widget
+    graduation, soul-protocol's own memory.graduated listeners) don't
+    need to learn a new dataclass.
+    """
+
+    memory_id: str
+    kind: GraduationKind
+    access_count: int
+    window_days: int
+    from_tier: str | None
+    to_tier: str
+    actor: str = ""
+    pocket_id: str | None = None
+    reason: str = ""
+
+    def short(self) -> str:
+        """One-line summary for terminal output / operator dashboards."""
+
+        from_label = self.from_tier or "?"
+        return (
+            f"[{self.kind}] {self.memory_id} {from_label}->{self.to_tier} "
+            f"({self.access_count} accesses in {self.window_days}d)"
+        )
+
+
+@dataclass
+class GraduationReport:
+    """Output of one scan — decisions + scan metadata."""
+
+    decisions: list[GraduationDecision] = field(default_factory=list)
+    scanned_retrievals: int = 0
+    window_days: int = DEFAULT_WINDOW_DAYS
+    dry_run: bool = True
+    generated_at: datetime = field(default_factory=datetime.now)
+
+
+# ---------------------------------------------------------------------------
+# Scan — counts per-memory accesses off the projection and emits decisions.
+# ---------------------------------------------------------------------------
+
+
+def scan_for_graduations(
+    projection: RetrievalProjection,
+    *,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    episodic_threshold: int = DEFAULT_EPISODIC_THRESHOLD,
+    semantic_threshold: int = DEFAULT_SEMANTIC_THRESHOLD,
+    actor_id: str | None = None,
+    pocket_id: str | None = None,
+    scope: str | None = None,
+    dry_run: bool = True,
+) -> GraduationReport:
+    """Walk the projection's retrievals in the last ``window_days`` and
+    return a report of memories that crossed an access threshold.
+
+    ``actor_id`` / ``pocket_id`` / ``scope`` narrow the scan the same way
+    #937's scan accepted filters — so an operator can ask "which memories
+    have been accessed enough by user:priya in pocket-1 to graduate?"
+    without scanning the whole org's history.
+
+    This path never writes; apply() does. Matches #937's original dry-
+    run-by-default contract so an operator can review the report before
+    committing the tier change.
+    """
+
+    # EventEntry.ts is tz-aware UTC per the journal spec, so compute the
+    # cutoff in UTC too. Using a naive datetime here would TypeError on
+    # the comparison below the first time a real journal entry flows in.
+    since = datetime.now(UTC) - timedelta(days=window_days)
+    rows = projection.recent_retrievals(
+        scope=scope,
+        actor_id=actor_id,
+        pocket_id=pocket_id,
+        limit=0,  # 0 == all, see projection.recent_retrievals limit contract
+    )
+    # recent_retrievals returns newest-first; cap by time window here so the
+    # projection doesn't have to grow a since= filter. Defensive: coerce
+    # naive ts values to UTC so the comparison stays well-defined when a
+    # shim adapter emits a naive datetime.
+    rows = [r for r in rows if _ensure_aware(r.ts) >= since]
+
+    counts: Counter[str] = Counter()
+    contexts: dict[str, dict[str, Any]] = {}
+
+    for view in rows:
+        for candidate in view.candidates:
+            if not isinstance(candidate, dict):
+                continue
+            mid = candidate.get("id")
+            if not isinstance(mid, str) or not mid:
+                continue
+            counts[mid] += 1
+            ctx = contexts.setdefault(
+                mid,
+                {
+                    "tier": candidate.get("tier"),
+                    "actor": view.actor_id,
+                    "pocket_id": view.pocket_id,
+                },
+            )
+            if candidate.get("tier"):
+                ctx["tier"] = candidate["tier"]
+
+    decisions: list[GraduationDecision] = []
+    for mid, count in counts.most_common():
+        ctx = contexts.get(mid, {})
+        decision = _decide(
+            memory_id=mid,
+            count=count,
+            from_tier=ctx.get("tier"),
+            actor=ctx.get("actor", "") or "",
+            pocket_id=ctx.get("pocket_id"),
+            episodic_threshold=episodic_threshold,
+            semantic_threshold=semantic_threshold,
+            window_days=window_days,
+        )
+        if decision is not None:
+            decisions.append(decision)
+
+    return GraduationReport(
+        decisions=decisions,
+        scanned_retrievals=len(rows),
+        window_days=window_days,
+        dry_run=dry_run,
+    )
+
+
+def _decide(
+    *,
+    memory_id: str,
+    count: int,
+    from_tier: str | None,
+    actor: str,
+    pocket_id: str | None,
+    episodic_threshold: int,
+    semantic_threshold: int,
+    window_days: int,
+) -> GraduationDecision | None:
+    """Threshold check — ported verbatim from #937.
+
+    Empty tier is treated as episodic because soul-protocol defaults
+    interaction-derived memories to episodic and the retrieval log
+    doesn't always carry tier on every candidate.
+    """
+
+    tier = (from_tier or "").lower()
+
+    if tier in {"episodic", ""} and count >= episodic_threshold:
+        return GraduationDecision(
+            memory_id=memory_id,
+            actor=actor,
+            pocket_id=pocket_id,
+            kind="episodic_to_semantic",
+            access_count=count,
+            window_days=window_days,
+            from_tier=from_tier or "episodic",
+            to_tier="semantic",
+            reason=(
+                f"Accessed {count}x in last {window_days} days (threshold {episodic_threshold})."
+            ),
+        )
+
+    if tier == "semantic" and count >= semantic_threshold:
+        return GraduationDecision(
+            memory_id=memory_id,
+            actor=actor,
+            pocket_id=pocket_id,
+            kind="semantic_to_core",
+            access_count=count,
+            window_days=window_days,
+            from_tier="semantic",
+            to_tier="core",
+            reason=(
+                f"Accessed {count}x in last {window_days} days (threshold {semantic_threshold})."
+            ),
+        )
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Apply — turns GraduationDecisions into graduation.applied events + fires
+# the optional soul.remember path from #937.
+# ---------------------------------------------------------------------------
+
+
+async def apply_decisions(
+    decisions: list[GraduationDecision],
+    store: RetrievalJournalStore,
+    *,
+    scope: list[str],
+    soul: Any = None,
+    correlation_id: Any = None,
+) -> list[GraduationDecision]:
+    """Emit a ``graduation.applied`` event for each decision, optionally
+    mutating the soul. Returns the subset that completed without error.
+
+    This is the journal-backed replacement for #937's ``apply_decisions``.
+    The soul-side mutation is still best-effort — graduation must never
+    break the runtime, so per-decision failures are logged and skipped.
+    The journal event is written regardless of whether soul.remember
+    succeeded; operators can retry the soul step separately without
+    double-counting the journal entry.
+    """
+
+    if not decisions:
+        return []
+
+    _require_scope(scope)
+
+    applied: list[GraduationDecision] = []
+    for decision in decisions:
+        try:
+            await store.log_graduation(
+                scope=scope,
+                memory_id=decision.memory_id,
+                kind=decision.kind,
+                access_count=decision.access_count,
+                window_days=decision.window_days,
+                from_tier=decision.from_tier,
+                to_tier=decision.to_tier,
+                pocket_id=decision.pocket_id,
+                reason=decision.reason,
+                correlation_id=correlation_id,
+            )
+        except Exception:
+            logger.exception("Graduation apply: journal emit failed for %s", decision.memory_id)
+            continue
+
+        if soul is not None and hasattr(soul, "remember") and hasattr(soul, "recall"):
+            try:
+                await _mutate_soul(soul, decision)
+            except Exception:
+                logger.exception(
+                    "Graduation apply: soul mutation failed for %s", decision.memory_id
+                )
+                # Journal event already written — don't drop the decision
+                # from applied() just because the soul side failed. The
+                # journal is the source of truth; the soul copy is a cache.
+
+        applied.append(decision)
+    return applied
+
+
+async def _mutate_soul(soul: Any, decision: GraduationDecision) -> None:
+    """Mirror #937's soul.remember() call so the in-memory soul reflects
+    the new tier. Kept as a separate helper so apply_decisions() can
+    short-circuit on import / attribute gaps without nesting try/except.
+    """
+
+    content = await _lookup_memory_content(soul, decision.memory_id)
+    if not content:
+        logger.debug("Graduation apply: memory %s not found in soul", decision.memory_id)
+        return
+
+    target_type = _resolve_tier(decision.to_tier)
+    await soul.remember(
+        content=f"[graduated:{decision.kind}] {content}",
+        type=target_type,
+        importance=8 if decision.to_tier == "core" else 7,
+    )
+
+
+def _resolve_tier(tier: str):
+    """Translate a tier name to soul-protocol's MemoryType enum, falling
+    back to the raw string when soul-protocol isn't importable (common in
+    test contexts that mock the soul interface).
+    """
+
+    try:
+        from soul_protocol.runtime.types import MemoryType
+    except ImportError:
+        return tier
+
+    try:
+        return MemoryType(tier)
+    except ValueError:
+        return MemoryType.SEMANTIC
+
+
+async def _lookup_memory_content(soul: Any, memory_id: str) -> str:
+    """Best-effort lookup — soul-protocol doesn't expose get-by-id on the
+    soul manager yet. Pull a wide recall and match by id. Identical to the
+    #937 helper.
+    """
+
+    try:
+        memories = await soul.recall("", limit=500)
+    except Exception:
+        return ""
+    for entry in memories:
+        if getattr(entry, "id", None) == memory_id:
+            return getattr(entry, "content", "")
+    return ""
+
+
+def _require_scope(scope: list[str]) -> None:
+    if not scope:
+        raise ValueError(
+            "apply_decisions requires a non-empty scope — the journal "
+            "invariant refuses events with scope=[]."
+        )
+
+
+def _ensure_aware(ts: datetime) -> datetime:
+    """Promote a naive datetime to UTC for comparison.
+
+    The journal spec always emits tz-aware ``EventEntry.ts`` values, but
+    the projection's defensive parser can fall back to ``datetime.now()``
+    (naive) when a malformed ts slips in. Treat those as UTC rather than
+    crashing the scan.
+    """
+
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=UTC)
+    return ts

--- a/ee/retrieval/projection.py
+++ b/ee/retrieval/projection.py
@@ -1,0 +1,389 @@
+# ee/retrieval/projection.py — In-memory projection over retrieval + graduation events.
+# Created: 2026-04-16 (feat/retrieval-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Carries the read side of #936 (recent
+# retrievals with filters) and #937 (graduation state per memory) as a
+# replay over the org journal instead of a separate JSONL file. Same
+# shape as ee/fabric/projection.py — ``rebuild(journal, since_seq)`` +
+# incremental ``apply(entry)`` + filtered query methods.
+#
+# Two logical views live in one projection because they share the same
+# event stream:
+#   - RetrievalView: last-N retrievals, filterable by scope / correlation_id
+#     / actor / pocket. This is what #936's GET /retrieval/log wanted.
+#   - GraduationStateRow: one row per memory_id summarising the most-recent
+#     graduation decision. This is what #937's scan wrote into a separate
+#     JSONL. Rebuilt by folding every ``graduation.applied`` event.
+#
+# Keeping both in one projection means one replay pass does both, which
+# matches how soul-protocol exposes the journal today (``replay_from``
+# iterates the whole stream; ``query(action=...)`` filters by exact
+# match, no globs — see the task constraint).
+
+from __future__ import annotations
+
+import logging
+from bisect import insort
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from soul_protocol.engine.journal import Journal
+from soul_protocol.spec.journal import EventEntry
+
+from ee.fabric.policy import filter_visible
+from ee.retrieval.events import (
+    ACTION_GRADUATION_APPLIED,
+    ACTION_RETRIEVAL_QUERY,
+    ALL_RETRIEVAL_ACTIONS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public row shapes — stable dataclasses the router serialises. Kept as
+# dataclasses rather than Pydantic so the projection has no runtime import
+# cost from the model machinery on hot paths.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RetrievalView:
+    """One projected retrieval — a single ``retrieval.query`` event after replay.
+
+    ``scope`` and ``correlation_id`` are lifted off the EventEntry so the
+    view carries everything the router needs without re-reading the
+    journal. ``actor_id`` flattens the ``Actor`` to a string for JSON.
+    """
+
+    request_id: str
+    query: str
+    actor_id: str
+    actor_kind: str
+    scope: list[str]
+    correlation_id: str | None
+    ts: datetime
+    strategy: str
+    sources_queried: list[str]
+    sources_failed: list[dict[str, Any]]
+    candidate_count: int
+    candidates: list[dict[str, Any]]
+    picked: list[str]
+    latency_ms: int
+    pocket_id: str | None
+    trace_id: str | None
+    seq: int
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "request_id": self.request_id,
+            "query": self.query,
+            "actor_id": self.actor_id,
+            "actor_kind": self.actor_kind,
+            "scope": list(self.scope),
+            "correlation_id": self.correlation_id,
+            "ts": self.ts.isoformat(),
+            "strategy": self.strategy,
+            "sources_queried": list(self.sources_queried),
+            "sources_failed": list(self.sources_failed),
+            "candidate_count": self.candidate_count,
+            "candidates": list(self.candidates),
+            "picked": list(self.picked),
+            "latency_ms": self.latency_ms,
+            "pocket_id": self.pocket_id,
+            "trace_id": self.trace_id,
+            "seq": self.seq,
+        }
+
+
+@dataclass
+class GraduationStateRow:
+    """Most-recent graduation decision for one memory_id.
+
+    The projection keeps only the latest tier per memory — a repeat
+    graduation overwrites the row. The full history is still on the
+    journal for anyone who needs the audit trail (``journal.query(action=
+    "graduation.applied", correlation_id=...)``).
+    """
+
+    memory_id: str
+    current_tier: str
+    previous_tier: str | None
+    kind: str
+    access_count: int
+    window_days: int
+    pocket_id: str | None
+    scope: list[str]
+    reason: str
+    applied_at: datetime
+    seq: int
+
+
+# ---------------------------------------------------------------------------
+# Internal storage dataclasses — not exposed.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _RetrievalRow:
+    """Internal projection row for retrievals.
+
+    Retrievals are kept in insertion order; the list is cheap to slice for
+    "recent N" queries. A sorted-by-seq insert is used so out-of-order
+    replays (unusual but possible on a merged journal) still land in seq
+    order in the view.
+    """
+
+    view: RetrievalView
+
+    def __lt__(self, other: _RetrievalRow) -> bool:
+        return self.view.seq < other.view.seq
+
+
+class RetrievalProjection:
+    """Rebuilds + serves read views for retrieval + graduation events.
+
+    One instance per process; rebuild is O(events) so operators can drop
+    and rebuild if they suspect drift. No persistence — the projection is
+    a pure fold over the journal.
+    """
+
+    def __init__(self, *, max_retrievals: int = 10_000) -> None:
+        self._retrievals: list[_RetrievalRow] = []
+        self._graduation: dict[str, GraduationStateRow] = {}
+        self._cursor: int = 0
+        # Soft cap — stops a busy org's projection from eating a lot of
+        # RAM. Once the cap is hit we evict oldest-first. Callers who want
+        # full history should read the journal directly.
+        self._max = max_retrievals
+
+    # -- Build / rebuild ----------------------------------------------------
+
+    def rebuild(self, journal: Journal, *, since_seq: int = 0) -> int:
+        """Replay the journal from ``since_seq`` (0 = genesis), applying
+        every retrieval + graduation event. Returns the number of events
+        applied. When ``since_seq == 0`` the projection wipes its state
+        first so the rebuild is a true reset.
+        """
+
+        if since_seq == 0:
+            self._retrievals.clear()
+            self._graduation.clear()
+            self._cursor = 0
+
+        applied = 0
+        for entry in journal.replay_from(since_seq):
+            if entry.action not in ALL_RETRIEVAL_ACTIONS:
+                continue
+            self.apply(entry)
+            applied += 1
+        return applied
+
+    # -- Incremental apply --------------------------------------------------
+
+    def apply(self, entry: EventEntry) -> None:
+        """Fold a single event into the projection."""
+
+        if entry.action not in ALL_RETRIEVAL_ACTIONS:
+            return
+
+        payload: dict[str, Any] = dict(entry.payload) if isinstance(entry.payload, dict) else {}
+        seq = getattr(entry, "seq", None) or 0
+        if seq > self._cursor:
+            self._cursor = seq
+
+        if entry.action == ACTION_RETRIEVAL_QUERY:
+            self._apply_retrieval(entry, payload, seq)
+        elif entry.action == ACTION_GRADUATION_APPLIED:
+            self._apply_graduation(entry, payload, seq)
+
+    def _apply_retrieval(
+        self,
+        entry: EventEntry,
+        payload: dict[str, Any],
+        seq: int,
+    ) -> None:
+        view = RetrievalView(
+            request_id=str(payload.get("request_id") or entry.id),
+            query=str(payload.get("query", "")),
+            actor_id=str(entry.actor.id),
+            actor_kind=str(entry.actor.kind),
+            scope=list(entry.scope),
+            correlation_id=_uuid_to_str(entry.correlation_id),
+            ts=_as_datetime(entry.ts),
+            strategy=str(payload.get("strategy", "")),
+            sources_queried=list(payload.get("sources_queried") or []),
+            sources_failed=list(payload.get("sources_failed") or []),
+            candidate_count=int(payload.get("candidate_count", 0) or 0),
+            candidates=list(payload.get("candidates") or []),
+            picked=list(payload.get("picked") or []),
+            latency_ms=int(payload.get("latency_ms", 0) or 0),
+            pocket_id=_none_or_str(payload.get("pocket_id")),
+            trace_id=_none_or_str(payload.get("trace_id")),
+            seq=seq,
+        )
+        insort(self._retrievals, _RetrievalRow(view=view))
+        # Evict oldest once we pass the cap — keep the tail (newest).
+        if len(self._retrievals) > self._max:
+            overflow = len(self._retrievals) - self._max
+            del self._retrievals[:overflow]
+
+    def _apply_graduation(
+        self,
+        entry: EventEntry,
+        payload: dict[str, Any],
+        seq: int,
+    ) -> None:
+        memory_id = payload.get("memory_id")
+        if not isinstance(memory_id, str) or not memory_id:
+            logger.warning("Retrieval projection: graduation event missing memory_id")
+            return
+        row = GraduationStateRow(
+            memory_id=memory_id,
+            current_tier=str(payload.get("to_tier", "")),
+            previous_tier=_none_or_str(payload.get("from_tier")),
+            kind=str(payload.get("kind", "")),
+            access_count=int(payload.get("access_count", 0) or 0),
+            window_days=int(payload.get("window_days", 0) or 0),
+            pocket_id=_none_or_str(payload.get("pocket_id")),
+            scope=list(entry.scope),
+            reason=str(payload.get("reason", "")),
+            applied_at=_as_datetime(entry.ts),
+            seq=seq,
+        )
+        self._graduation[memory_id] = row
+
+    # -- Retrieval queries --------------------------------------------------
+
+    def recent_retrievals(
+        self,
+        *,
+        scope: str | None = None,
+        actor_id: str | None = None,
+        pocket_id: str | None = None,
+        limit: int = 20,
+        requester_scopes: list[str] | None = None,
+    ) -> list[RetrievalView]:
+        """Return the most-recent retrievals, newest-first, with optional
+        filters. Scope filtering runs via ee.fabric.policy.filter_visible so
+        the containment rules (``org:*`` matches ``org:sales`` and vice
+        versa) stay identical to Fabric's — no divergent semantics between
+        the two projections.
+        """
+
+        rows = [row.view for row in self._retrievals]
+
+        if scope:
+            rows = [r for r in rows if scope in r.scope]
+        if actor_id:
+            rows = [r for r in rows if r.actor_id == actor_id]
+        if pocket_id:
+            rows = [r for r in rows if r.pocket_id == pocket_id]
+
+        if requester_scopes:
+            visible, _hidden = filter_visible(rows, requester_scopes)
+            rows = list(visible)
+
+        # Newest first, cap at limit.
+        rows.sort(key=lambda v: v.seq, reverse=True)
+        if limit > 0:
+            rows = rows[:limit]
+        return rows
+
+    def retrievals_by_correlation(
+        self,
+        correlation_id: str,
+        *,
+        requester_scopes: list[str] | None = None,
+    ) -> list[RetrievalView]:
+        """All retrievals sharing one correlation_id — the "session" view.
+
+        Ordered oldest-first so a UI can render a chronological trail of
+        what the agent asked during one run.
+        """
+
+        rows = [row.view for row in self._retrievals if row.view.correlation_id == correlation_id]
+        if requester_scopes:
+            visible, _hidden = filter_visible(rows, requester_scopes)
+            rows = list(visible)
+        rows.sort(key=lambda v: v.seq)
+        return rows
+
+    # -- Graduation queries --------------------------------------------------
+
+    def graduation_state(
+        self,
+        *,
+        memory_id: str | None = None,
+        requester_scopes: list[str] | None = None,
+    ) -> list[GraduationStateRow]:
+        """Current graduation state — one row per memory_id.
+
+        Passing ``memory_id`` returns a single-row list (or empty) for the
+        common "what tier is this memory at?" probe.
+        """
+
+        if memory_id is not None:
+            row = self._graduation.get(memory_id)
+            rows = [row] if row else []
+        else:
+            rows = list(self._graduation.values())
+
+        if requester_scopes:
+            visible, _hidden = filter_visible(rows, requester_scopes)
+            rows = list(visible)
+
+        rows.sort(key=lambda r: r.seq, reverse=True)
+        return rows
+
+    # -- Diagnostics --------------------------------------------------------
+
+    @property
+    def cursor(self) -> int:
+        """Latest seq the projection has seen. Persist this to skip ahead
+        on restart.
+        """
+
+        return self._cursor
+
+    def size(self) -> dict[str, int]:
+        """Quick counters for the /retrieval/stats endpoint."""
+
+        return {
+            "retrievals": len(self._retrievals),
+            "graduations": len(self._graduation),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _as_datetime(ts: Any) -> datetime:
+    if isinstance(ts, datetime):
+        return ts
+    try:
+        return datetime.fromisoformat(str(ts))
+    except (TypeError, ValueError):
+        return datetime.now()
+
+
+def _uuid_to_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, UUID):
+        return str(value)
+    try:
+        return str(value)
+    except Exception:  # noqa: BLE001 — defensive only.
+        return None
+
+
+def _none_or_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and not value:
+        return None
+    return str(value)

--- a/ee/retrieval/router.py
+++ b/ee/retrieval/router.py
@@ -1,0 +1,288 @@
+# ee/retrieval/router.py — REST surface for the retrieval + graduation projection.
+# Created: 2026-04-16 (feat/retrieval-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Carries the intent of #936's retrieval log
+# endpoints + #937's graduation endpoints onto the journal-backed
+# projection. Reads are the projection; writes happen either via
+# soul-protocol's own RetrievalRouter (which emits ``retrieval.query``
+# directly) or via ``RetrievalJournalStore.log_retrieval`` from a
+# pocketpaw caller. Nothing in this router writes retrievals.
+#
+# The router owns a process-scoped store + projection warmed from the
+# org journal on first request. That follows the fleet router's pattern:
+# one ``Depends(get_journal)`` per request, the store itself is cached
+# so the projection doesn't rebuild on every call.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from soul_protocol.engine.journal import Journal
+
+from ee.journal_dep import get_journal
+from ee.retrieval.policy import (
+    DEFAULT_EPISODIC_THRESHOLD,
+    DEFAULT_SEMANTIC_THRESHOLD,
+    DEFAULT_WINDOW_DAYS,
+    GraduationDecision,
+    scan_for_graduations,
+)
+from ee.retrieval.store import RetrievalJournalStore
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Retrieval"])
+
+
+# ---------------------------------------------------------------------------
+# Response envelopes — small Pydantic shells so the OpenAPI schema documents
+# every field. Keeping them here (not in projection.py) matches how other
+# ee/ routers segregate HTTP types from the pure-Python model layer.
+# ---------------------------------------------------------------------------
+
+
+class RetrievalEntryResponse(BaseModel):
+    """One retrieval row as rendered by the REST surface."""
+
+    request_id: str
+    query: str
+    actor_id: str
+    actor_kind: str
+    scope: list[str]
+    correlation_id: str | None
+    ts: str
+    strategy: str
+    sources_queried: list[str]
+    sources_failed: list[dict[str, Any]]
+    candidate_count: int
+    candidates: list[dict[str, Any]]
+    picked: list[str]
+    latency_ms: int
+    pocket_id: str | None
+    trace_id: str | None
+    seq: int
+
+
+class RecentRetrievalsResponse(BaseModel):
+    """Envelope for ``GET /retrieval/recent`` — leaves room for pagination
+    metadata without breaking clients later.
+    """
+
+    entries: list[RetrievalEntryResponse]
+    total: int
+
+
+class GraduationStateResponse(BaseModel):
+    memory_id: str
+    current_tier: str
+    previous_tier: str | None
+    kind: str
+    access_count: int
+    window_days: int
+    pocket_id: str | None
+    scope: list[str]
+    reason: str
+    applied_at: str
+    seq: int
+
+
+class GraduationStateListResponse(BaseModel):
+    entries: list[GraduationStateResponse]
+    total: int
+
+
+class ScanRequest(BaseModel):
+    """Body for ``POST /graduation/scan``."""
+
+    window_days: int = DEFAULT_WINDOW_DAYS
+    episodic_threshold: int = DEFAULT_EPISODIC_THRESHOLD
+    semantic_threshold: int = DEFAULT_SEMANTIC_THRESHOLD
+    actor_id: str | None = None
+    pocket_id: str | None = None
+    scope: str | None = None
+
+
+class ScanResponse(BaseModel):
+    """Flat projection of GraduationReport for HTTP — dataclasses don't
+    serialise directly through FastAPI without a response_model shim.
+    """
+
+    decisions: list[GraduationDecision]
+    scanned_retrievals: int
+    window_days: int
+    dry_run: bool
+    generated_at: str
+
+
+# ---------------------------------------------------------------------------
+# Store caching — the projection is expensive to rebuild, cheap to query.
+# One instance per (Journal) keeps the rebuild cost to O(1) in the amortised
+# case and O(events) on cold start. Tests can reset this via
+# ``_cached_store.cache_clear()`` or by overriding ``get_journal``.
+# ---------------------------------------------------------------------------
+
+
+def _get_store(journal: Journal) -> RetrievalJournalStore:
+    """Return a warmed store for ``journal`` — one instance per Journal id.
+
+    First call on a given journal warms the projection with
+    ``store.bootstrap()``. Subsequent calls return the cached instance
+    unchanged; incremental apply() on every new write keeps it current.
+    """
+
+    key = id(journal)
+    cached = _STORE_CACHE.get(key)
+    if cached is not None:
+        return cached
+    store = RetrievalJournalStore(journal)
+    store.bootstrap()
+    _STORE_CACHE[key] = store
+    return store
+
+
+_STORE_CACHE: dict[int, RetrievalJournalStore] = {}
+
+
+def reset_store_cache() -> None:
+    """Drop every cached store — for tests that need a clean projection."""
+
+    _STORE_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/retrieval/recent", response_model=RecentRetrievalsResponse)
+async def recent_retrievals(
+    scope: str | None = Query(None, description="Filter to retrievals tagged with this scope"),
+    actor_id: str | None = Query(None, description="Filter by actor id (e.g. 'user:priya')"),
+    pocket_id: str | None = Query(None, description="Filter by pocket id"),
+    limit: int = Query(20, ge=1, le=500),
+    journal: Journal = Depends(get_journal),
+) -> RecentRetrievalsResponse:
+    """Return the most-recent retrievals from the projection — newest first.
+
+    The journal's event log is the source of truth; this endpoint serves
+    an in-memory fold of the ``retrieval.query`` stream. Identical data
+    shape to what #936's GET /retrieval/log returned, minus the
+    since/until time filters (use correlation_id for session-scoped
+    lookups or rebuild with ``scope=...`` for tenant-scoped views).
+    """
+
+    store = _get_store(journal)
+    rows = store.projection.recent_retrievals(
+        scope=scope,
+        actor_id=actor_id,
+        pocket_id=pocket_id,
+        limit=limit,
+    )
+    return RecentRetrievalsResponse(
+        entries=[RetrievalEntryResponse(**_view_to_dict(r)) for r in rows],
+        total=len(rows),
+    )
+
+
+@router.get("/retrieval/session/{correlation_id}", response_model=RecentRetrievalsResponse)
+async def retrievals_in_session(
+    correlation_id: str,
+    journal: Journal = Depends(get_journal),
+) -> RecentRetrievalsResponse:
+    """All retrievals sharing one correlation_id — the "what did the
+    agent ask during this run" view. Ordered oldest-first.
+
+    Returns 404 when no retrievals match — lets a UI distinguish between
+    "session didn't exist" and "session had nothing in the projection
+    yet" with a straightforward status code.
+    """
+
+    store = _get_store(journal)
+    rows = store.projection.retrievals_by_correlation(correlation_id)
+    if not rows:
+        raise HTTPException(status_code=404, detail="No retrievals for correlation_id")
+    return RecentRetrievalsResponse(
+        entries=[RetrievalEntryResponse(**_view_to_dict(r)) for r in rows],
+        total=len(rows),
+    )
+
+
+@router.get("/graduation/state", response_model=GraduationStateListResponse)
+async def graduation_state(
+    memory_id: str | None = Query(None, description="Return state for one memory_id"),
+    journal: Journal = Depends(get_journal),
+) -> GraduationStateListResponse:
+    """Current graduation state — most-recent ``graduation.applied`` event
+    per memory_id. Omitting ``memory_id`` returns the full set.
+    """
+
+    store = _get_store(journal)
+    rows = store.projection.graduation_state(memory_id=memory_id)
+    return GraduationStateListResponse(
+        entries=[
+            GraduationStateResponse(
+                memory_id=r.memory_id,
+                current_tier=r.current_tier,
+                previous_tier=r.previous_tier,
+                kind=r.kind,
+                access_count=r.access_count,
+                window_days=r.window_days,
+                pocket_id=r.pocket_id,
+                scope=list(r.scope),
+                reason=r.reason,
+                applied_at=r.applied_at.isoformat(),
+                seq=r.seq,
+            )
+            for r in rows
+        ],
+        total=len(rows),
+    )
+
+
+@router.post("/graduation/scan", response_model=ScanResponse)
+async def run_graduation_scan(
+    req: ScanRequest | None = None,
+    journal: Journal = Depends(get_journal),
+) -> ScanResponse:
+    """Dry-run the graduation policy over the projection and return the
+    proposed decisions. Does NOT emit events — the apply path is a
+    separate step that callers opt into explicitly, matching #937's
+    dry-run-by-default contract.
+    """
+
+    req = req or ScanRequest()
+    store = _get_store(journal)
+    report = scan_for_graduations(
+        store.projection,
+        window_days=req.window_days,
+        episodic_threshold=req.episodic_threshold,
+        semantic_threshold=req.semantic_threshold,
+        actor_id=req.actor_id,
+        pocket_id=req.pocket_id,
+        scope=req.scope,
+        dry_run=True,
+    )
+    return ScanResponse(
+        decisions=list(report.decisions),
+        scanned_retrievals=report.scanned_retrievals,
+        window_days=report.window_days,
+        dry_run=report.dry_run,
+        generated_at=report.generated_at.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _view_to_dict(view: Any) -> dict[str, Any]:
+    """RetrievalView.as_dict() emits ISO-timestamp strings for ``ts`` so the
+    Pydantic response model serialises cleanly. This wrapper exists so the
+    router stays agnostic to whether the projection returned a dataclass
+    or something else in the future.
+    """
+
+    return view.as_dict()

--- a/ee/retrieval/store.py
+++ b/ee/retrieval/store.py
@@ -1,0 +1,214 @@
+# ee/retrieval/store.py — Journal-backed write path for retrieval + graduation.
+# Created: 2026-04-16 (feat/retrieval-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Replaces the JSONL sink from #936 (file at
+# ``~/.pocketpaw/retrieval.jsonl`` with an asyncio.Lock around writes) and
+# the apply-side of #937's graduation policy (which wrote decisions into
+# the same JSONL). Both land on the org journal now — one append-only log
+# instead of a side-channel file, and write serialization is inherited
+# from SQLite's WAL + transaction semantics rather than from a per-
+# process asyncio lock that didn't protect against multi-process anyway.
+#
+# The store is small on purpose. It:
+#   - emits ``retrieval.query`` events when a retrieval happens
+#   - emits ``graduation.applied`` events when a graduation decision fires
+#   - folds each emitted event into a shared RetrievalProjection so
+#     reads are consistent without waiting for a rebuild
+#
+# Everything else (policy decisions, REST surface, soul mutations) lives
+# in policy.py / router.py so the store has no dependencies on the UI
+# layer or on soul-protocol beyond the journal primitive.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from soul_protocol.engine.journal import Journal
+from soul_protocol.spec.journal import Actor, EventEntry
+
+from ee.retrieval.events import (
+    ACTION_GRADUATION_APPLIED,
+    ACTION_RETRIEVAL_QUERY,
+    graduation_applied_payload,
+    retrieval_query_payload,
+)
+from ee.retrieval.projection import RetrievalProjection
+
+_SYSTEM_RETRIEVAL_ACTOR_ID = "system:retrieval"
+_SYSTEM_GRADUATION_ACTOR_ID = "system:graduation"
+
+
+class RetrievalJournalStore:
+    """Journal-backed emitter for retrieval + graduation events.
+
+    Wiring:
+
+        from ee.journal_dep import get_journal
+        journal = get_journal()
+        store = RetrievalJournalStore(journal)
+        store.bootstrap()
+        await store.log_retrieval(request, result, actor=..., scope=["org:sales"])
+    """
+
+    def __init__(
+        self,
+        journal: Journal,
+        *,
+        projection: RetrievalProjection | None = None,
+        default_retrieval_actor: Actor | None = None,
+        default_graduation_actor: Actor | None = None,
+    ) -> None:
+        self._journal = journal
+        self._projection = projection or RetrievalProjection()
+        self._default_retrieval_actor = default_retrieval_actor or Actor(
+            kind="system",
+            id=_SYSTEM_RETRIEVAL_ACTOR_ID,
+            scope_context=[],
+        )
+        self._default_graduation_actor = default_graduation_actor or Actor(
+            kind="system",
+            id=_SYSTEM_GRADUATION_ACTOR_ID,
+            scope_context=[],
+        )
+
+    # -- Bootstrap ----------------------------------------------------------
+
+    def bootstrap(self, *, since_seq: int = 0) -> int:
+        """Warm the projection from the journal. Returns the number of
+        events applied. Call once at process start.
+        """
+
+        return self._projection.rebuild(self._journal, since_seq=since_seq)
+
+    @property
+    def projection(self) -> RetrievalProjection:
+        return self._projection
+
+    # -- Writes -------------------------------------------------------------
+
+    async def log_retrieval(
+        self,
+        *,
+        scope: list[str],
+        query: str,
+        request_id: str | None = None,
+        strategy: str = "parallel",
+        sources_queried: list[str] | None = None,
+        sources_failed: list[dict[str, Any]] | None = None,
+        candidates: list[dict[str, Any]] | None = None,
+        picked: list[str] | None = None,
+        latency_ms: int = 0,
+        pocket_id: str | None = None,
+        trace_id: str | None = None,
+        actor: Actor | None = None,
+        correlation_id: UUID | None = None,
+    ) -> EventEntry:
+        """Emit one ``retrieval.query`` event and fold it into the projection.
+
+        ``scope`` is required — the journal's EventEntry invariant rejects
+        an empty scope list. Callers that don't have a scope for their
+        retrieval (rare; the retrieval router always knows one) should
+        make that explicit at the call site rather than having the store
+        fabricate an empty list.
+        """
+
+        _require_scope(scope)
+
+        payload = retrieval_query_payload(
+            request_id=request_id or str(uuid4()),
+            query=query,
+            strategy=strategy,
+            sources_queried=sources_queried,
+            sources_failed=sources_failed,
+            candidates=candidates,
+            picked=picked,
+            latency_ms=latency_ms,
+            pocket_id=pocket_id,
+            trace_id=trace_id,
+        )
+        entry = self._build_entry(
+            action=ACTION_RETRIEVAL_QUERY,
+            scope=scope,
+            actor=actor or self._default_retrieval_actor,
+            correlation_id=correlation_id,
+            payload=payload,
+        )
+        self._journal.append(entry)
+        self._projection.apply(entry)
+        return entry
+
+    async def log_graduation(
+        self,
+        *,
+        scope: list[str],
+        memory_id: str,
+        kind: str,
+        access_count: int,
+        window_days: int,
+        from_tier: str | None,
+        to_tier: str,
+        pocket_id: str | None = None,
+        reason: str = "",
+        actor: Actor | None = None,
+        correlation_id: UUID | None = None,
+    ) -> EventEntry:
+        """Emit one ``graduation.applied`` event + fold it into the projection.
+
+        Graduation decisions are one-event-per-promotion. Replaying the
+        stream gives you the full history; the projection keeps only the
+        most-recent decision per memory_id (see
+        RetrievalProjection._apply_graduation).
+        """
+
+        _require_scope(scope)
+
+        payload = graduation_applied_payload(
+            memory_id=memory_id,
+            kind=kind,
+            access_count=access_count,
+            window_days=window_days,
+            from_tier=from_tier,
+            to_tier=to_tier,
+            pocket_id=pocket_id,
+            reason=reason,
+        )
+        entry = self._build_entry(
+            action=ACTION_GRADUATION_APPLIED,
+            scope=scope,
+            actor=actor or self._default_graduation_actor,
+            correlation_id=correlation_id,
+            payload=payload,
+        )
+        self._journal.append(entry)
+        self._projection.apply(entry)
+        return entry
+
+    # -- Internals ----------------------------------------------------------
+
+    def _build_entry(
+        self,
+        *,
+        action: str,
+        scope: list[str],
+        actor: Actor,
+        correlation_id: UUID | None,
+        payload: dict[str, Any],
+    ) -> EventEntry:
+        return EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=actor,
+            action=action,
+            scope=list(scope),
+            correlation_id=correlation_id,
+            payload=payload,
+        )
+
+
+def _require_scope(scope: list[str]) -> None:
+    if not scope:
+        raise ValueError(
+            "RetrievalJournalStore requires a non-empty scope on every write — "
+            "the journal invariant refuses events with scope=[]."
+        )

--- a/src/pocketpaw/api/v1/__init__.py
+++ b/src/pocketpaw/api/v1/__init__.py
@@ -4,6 +4,9 @@
 # Updated: 2026-04-16 (feat/fleet-rest-router) — Added Fleet router so
 #   paw-enterprise's InstallFleetPanel can call GET /api/v1/fleet/templates
 #   and POST /api/v1/fleet/install against a running pocketpaw instance.
+# Updated: 2026-04-16 (feat/retrieval-journal-projection) — Added the
+#   Retrieval router so UIs can surface the journal-backed retrieval +
+#   graduation projection (supersedes held PRs #936 / #937).
 #
 # mount_v1_routers(app) registers all domain routers at /api/v1/ (canonical).
 # Existing dashboard.py endpoints at /api/ remain as backward-compat aliases.
@@ -58,6 +61,7 @@ _EE_ROUTERS: list[tuple[str, str, str]] = [
     ("ee.fabric.router", "router", "Fabric"),
     ("ee.fleet.router", "router", "Fleet"),
     ("ee.instinct.router", "router", "Instinct"),
+    ("ee.retrieval.router", "router", "Retrieval"),
     ("pocketpaw.ee.automations.router", "router", "Automations"),
 ]
 

--- a/tests/ee/test_retrieval_journal.py
+++ b/tests/ee/test_retrieval_journal.py
@@ -1,0 +1,608 @@
+# tests/ee/test_retrieval_journal.py — Coverage for the retrieval + graduation
+# journal projection.
+# Created: 2026-04-16 (feat/retrieval-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Supersedes the held PRs #936 (JSONL retrieval
+# sink) and #937 (graduation policy over that JSONL).
+#
+# These tests pin the invariants the projection-based design is supposed to
+# hold. If any regress we've silently recreated the bugs that held those PRs:
+#   1. Write path — ``log_retrieval`` / ``log_graduation`` emit the expected
+#      journal events with the full payload shape.
+#   2. Scope filter — ``recent_retrievals(scope=...)`` returns only
+#      scope-matching events; cross-scope readers see an empty list.
+#   3. Correlation view — ``retrievals_by_correlation`` groups events from
+#      one run chronologically.
+#   4. Graduation projection — N retrievals of the same candidate cross the
+#      threshold + emit a decision; applying the decision writes a
+#      ``graduation.applied`` event visible via the projection.
+#   5. Projection rebuild on empty journal returns empty state (no crash).
+#   6. Incremental apply — projection state after one incremental event
+#      equals the rebuild-from-scratch state.
+#   7. REST router — GET /retrieval/recent returns the expected envelope,
+#      GET /graduation/state returns the current per-memory decisions.
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.spec.journal import Actor
+
+from ee.journal_dep import get_journal, reset_journal_cache
+from ee.retrieval.events import (
+    ACTION_GRADUATION_APPLIED,
+    ACTION_RETRIEVAL_QUERY,
+)
+from ee.retrieval.policy import (
+    DEFAULT_EPISODIC_THRESHOLD,
+    DEFAULT_SEMANTIC_THRESHOLD,
+    apply_decisions,
+    scan_for_graduations,
+)
+from ee.retrieval.projection import RetrievalProjection
+from ee.retrieval.router import reset_store_cache, router
+from ee.retrieval.store import RetrievalJournalStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_caches():
+    """Reset both journal + store caches between tests.
+
+    The journal dep has an ``lru_cache`` and the router caches one store
+    per Journal id; without resets, a prior test's state leaks forward.
+    """
+
+    reset_journal_cache()
+    reset_store_cache()
+    yield
+    reset_journal_cache()
+    reset_store_cache()
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+@pytest.fixture
+def store(journal) -> RetrievalJournalStore:
+    s = RetrievalJournalStore(journal)
+    s.bootstrap()
+    return s
+
+
+def _candidate(
+    memory_id: str,
+    *,
+    source: str = "soul",
+    tier: str = "episodic",
+    score: float = 0.5,
+) -> dict:
+    return {"id": memory_id, "source": source, "tier": tier, "score": score}
+
+
+# ---------------------------------------------------------------------------
+# 1. Write path — events land on the journal with the expected payload.
+# ---------------------------------------------------------------------------
+
+
+class TestWritePath:
+    @pytest.mark.asyncio
+    async def test_log_retrieval_emits_event_with_full_payload(
+        self,
+        store: RetrievalJournalStore,
+        journal,
+    ) -> None:
+        """One log_retrieval call should surface as exactly one
+        ``retrieval.query`` event with every field propagated into the
+        journal payload — nothing dropped, nothing fabricated."""
+
+        actor = Actor(kind="user", id="user:priya", scope_context=["org:sales:*"])
+        await store.log_retrieval(
+            scope=["org:sales:leads"],
+            query="renewal discount",
+            strategy="parallel",
+            sources_queried=["soul", "kb"],
+            candidates=[_candidate("mem_x")],
+            picked=["mem_x"],
+            latency_ms=12,
+            pocket_id="pocket-1",
+            actor=actor,
+        )
+
+        events = journal.query(action=ACTION_RETRIEVAL_QUERY)
+        assert len(events) == 1
+        event = events[0]
+        assert event.actor.id == "user:priya"
+        assert list(event.scope) == ["org:sales:leads"]
+        assert event.payload["query"] == "renewal discount"
+        assert event.payload["strategy"] == "parallel"
+        assert event.payload["sources_queried"] == ["soul", "kb"]
+        assert event.payload["candidate_count"] == 1
+        assert event.payload["candidates"][0]["id"] == "mem_x"
+        assert event.payload["picked"] == ["mem_x"]
+        assert event.payload["latency_ms"] == 12
+        assert event.payload["pocket_id"] == "pocket-1"
+
+    @pytest.mark.asyncio
+    async def test_log_graduation_emits_event_with_decision_shape(
+        self,
+        store: RetrievalJournalStore,
+        journal,
+    ) -> None:
+        await store.log_graduation(
+            scope=["org:sales:leads"],
+            memory_id="mem_x",
+            kind="episodic_to_semantic",
+            access_count=12,
+            window_days=30,
+            from_tier="episodic",
+            to_tier="semantic",
+            pocket_id="pocket-1",
+            reason="threshold crossed",
+        )
+
+        events = journal.query(action=ACTION_GRADUATION_APPLIED)
+        assert len(events) == 1
+        payload = events[0].payload
+        assert payload["memory_id"] == "mem_x"
+        assert payload["kind"] == "episodic_to_semantic"
+        assert payload["access_count"] == 12
+        assert payload["from_tier"] == "episodic"
+        assert payload["to_tier"] == "semantic"
+
+    @pytest.mark.asyncio
+    async def test_log_retrieval_rejects_empty_scope(
+        self,
+        store: RetrievalJournalStore,
+    ) -> None:
+        """The journal's EventEntry refuses scope=[]. Surface the
+        violation at the store boundary so the caller sees a clear
+        pocketpaw error instead of a pydantic validator trace."""
+
+        with pytest.raises(ValueError, match="non-empty scope"):
+            await store.log_retrieval(scope=[], query="x")
+
+    @pytest.mark.asyncio
+    async def test_log_graduation_rejects_empty_scope(
+        self,
+        store: RetrievalJournalStore,
+    ) -> None:
+        with pytest.raises(ValueError, match="non-empty scope"):
+            await store.log_graduation(
+                scope=[],
+                memory_id="mem_x",
+                kind="episodic_to_semantic",
+                access_count=12,
+                window_days=30,
+                from_tier="episodic",
+                to_tier="semantic",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 2. Scope-filtered recent retrievals.
+# ---------------------------------------------------------------------------
+
+
+class TestScopeFilter:
+    @pytest.mark.asyncio
+    async def test_recent_retrievals_filtered_by_scope(
+        self,
+        store: RetrievalJournalStore,
+    ) -> None:
+        """recent_retrievals(scope=X) returns only entries tagged with
+        exactly that scope on the event."""
+
+        await store.log_retrieval(
+            scope=["org:sales:leads"],
+            query="sales q",
+            candidates=[_candidate("mem_a")],
+        )
+        await store.log_retrieval(
+            scope=["org:finance:reports"],
+            query="finance q",
+            candidates=[_candidate("mem_b")],
+        )
+
+        sales = store.projection.recent_retrievals(scope="org:sales:leads")
+        assert len(sales) == 1
+        assert sales[0].query == "sales q"
+
+        finance = store.projection.recent_retrievals(scope="org:finance:reports")
+        assert len(finance) == 1
+        assert finance[0].query == "finance q"
+
+    @pytest.mark.asyncio
+    async def test_recent_retrievals_filtered_by_actor(
+        self,
+        store: RetrievalJournalStore,
+    ) -> None:
+        await store.log_retrieval(
+            scope=["org:sales:leads"],
+            query="q1",
+            actor=Actor(kind="user", id="user:priya"),
+        )
+        await store.log_retrieval(
+            scope=["org:sales:leads"],
+            query="q2",
+            actor=Actor(kind="user", id="user:maya"),
+        )
+
+        priya = store.projection.recent_retrievals(actor_id="user:priya")
+        assert len(priya) == 1
+        assert priya[0].query == "q1"
+
+    @pytest.mark.asyncio
+    async def test_recent_retrievals_applies_requester_scope_containment(
+        self,
+        store: RetrievalJournalStore,
+    ) -> None:
+        """A caller scoped to ``org:sales:*`` sees their own events and
+        nothing from ``org:finance:*``. Uses the same policy engine as
+        Fabric so the containment rules stay identical."""
+
+        await store.log_retrieval(
+            scope=["org:sales:leads"],
+            query="sales",
+            candidates=[_candidate("mem_a")],
+        )
+        await store.log_retrieval(
+            scope=["org:finance:reports"],
+            query="finance",
+            candidates=[_candidate("mem_b")],
+        )
+
+        visible = store.projection.recent_retrievals(
+            requester_scopes=["org:sales:*"],
+        )
+        assert len(visible) == 1
+        assert visible[0].query == "sales"
+
+
+# ---------------------------------------------------------------------------
+# 3. Correlation view — retrievals in one "session".
+# ---------------------------------------------------------------------------
+
+
+class TestCorrelationView:
+    @pytest.mark.asyncio
+    async def test_retrievals_by_correlation_returns_events_in_order(
+        self,
+        store: RetrievalJournalStore,
+    ) -> None:
+        cid = uuid4()
+        await store.log_retrieval(
+            scope=["org:sales:leads"],
+            query="first",
+            correlation_id=cid,
+        )
+        await store.log_retrieval(
+            scope=["org:sales:leads"],
+            query="second",
+            correlation_id=cid,
+        )
+        await store.log_retrieval(
+            scope=["org:sales:leads"],
+            query="other session",
+            correlation_id=uuid4(),
+        )
+
+        rows = store.projection.retrievals_by_correlation(str(cid))
+        assert [r.query for r in rows] == ["first", "second"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Graduation policy + apply over the projection.
+# ---------------------------------------------------------------------------
+
+
+class TestGraduationPolicy:
+    @pytest.mark.asyncio
+    async def test_threshold_crosses_produces_decision(
+        self,
+        store: RetrievalJournalStore,
+    ) -> None:
+        """N retrievals (N == episodic threshold) where every trace lists
+        the same memory_id as a candidate should produce one
+        episodic→semantic decision. Ported from #937."""
+
+        for _ in range(DEFAULT_EPISODIC_THRESHOLD):
+            await store.log_retrieval(
+                scope=["org:sales:leads"],
+                query="q",
+                candidates=[_candidate("mem_hot")],
+            )
+
+        report = scan_for_graduations(store.projection)
+        assert len(report.decisions) == 1
+        d = report.decisions[0]
+        assert d.memory_id == "mem_hot"
+        assert d.kind == "episodic_to_semantic"
+        assert d.access_count == DEFAULT_EPISODIC_THRESHOLD
+        assert d.from_tier == "episodic"
+        assert d.to_tier == "semantic"
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_yields_no_decision(
+        self,
+        store: RetrievalJournalStore,
+    ) -> None:
+        for _ in range(DEFAULT_EPISODIC_THRESHOLD - 1):
+            await store.log_retrieval(
+                scope=["org:sales:leads"],
+                query="q",
+                candidates=[_candidate("mem_cold")],
+            )
+        report = scan_for_graduations(store.projection)
+        assert report.decisions == []
+
+    @pytest.mark.asyncio
+    async def test_semantic_threshold_promotes_to_core(
+        self,
+        store: RetrievalJournalStore,
+    ) -> None:
+        for _ in range(DEFAULT_SEMANTIC_THRESHOLD):
+            await store.log_retrieval(
+                scope=["org:sales:leads"],
+                query="q",
+                candidates=[_candidate("mem_core", tier="semantic")],
+            )
+        report = scan_for_graduations(store.projection)
+        decisions = [d for d in report.decisions if d.memory_id == "mem_core"]
+        assert len(decisions) == 1
+        assert decisions[0].kind == "semantic_to_core"
+
+    @pytest.mark.asyncio
+    async def test_apply_decisions_emits_graduation_event(
+        self,
+        store: RetrievalJournalStore,
+    ) -> None:
+        """apply_decisions should write one ``graduation.applied`` event
+        per decision and surface the result in the projection's
+        ``graduation_state`` view."""
+
+        for _ in range(DEFAULT_EPISODIC_THRESHOLD):
+            await store.log_retrieval(
+                scope=["org:sales:leads"],
+                query="q",
+                candidates=[_candidate("mem_hot")],
+            )
+
+        report = scan_for_graduations(store.projection)
+        applied = await apply_decisions(
+            report.decisions,
+            store,
+            scope=["org:sales:leads"],
+        )
+        assert len(applied) == len(report.decisions) == 1
+
+        state = store.projection.graduation_state()
+        assert len(state) == 1
+        assert state[0].memory_id == "mem_hot"
+        assert state[0].current_tier == "semantic"
+        assert state[0].previous_tier == "episodic"
+
+    @pytest.mark.asyncio
+    async def test_apply_decisions_skipped_when_soul_missing(
+        self,
+        store: RetrievalJournalStore,
+    ) -> None:
+        """Journal emission must succeed even when no soul is supplied —
+        the soul mutation is best-effort per #937."""
+
+        from ee.retrieval.policy import GraduationDecision
+
+        decision = GraduationDecision(
+            memory_id="mem_manual",
+            kind="episodic_to_semantic",
+            access_count=15,
+            window_days=30,
+            from_tier="episodic",
+            to_tier="semantic",
+        )
+        applied = await apply_decisions(
+            [decision],
+            store,
+            scope=["org:sales:leads"],
+            soul=None,
+        )
+        assert len(applied) == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Empty journal rebuild — no crash.
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyJournalRebuild:
+    def test_rebuild_on_empty_journal_returns_zero(self, journal) -> None:
+        projection = RetrievalProjection()
+        applied = projection.rebuild(journal)
+        assert applied == 0
+        assert projection.size() == {"retrievals": 0, "graduations": 0}
+        assert projection.recent_retrievals() == []
+        assert projection.graduation_state() == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Incremental apply == rebuild-from-scratch.
+# ---------------------------------------------------------------------------
+
+
+class TestIncrementalEqualsRebuild:
+    @pytest.mark.asyncio
+    async def test_projection_state_matches_after_cold_rebuild(
+        self,
+        journal,
+    ) -> None:
+        """Writing a sequence of events via the store (which folds
+        incrementally) should produce identical projection state to
+        dropping the projection and replaying from genesis."""
+
+        live = RetrievalJournalStore(journal)
+        live.bootstrap()
+
+        for i in range(5):
+            await live.log_retrieval(
+                scope=["org:sales:leads"],
+                query=f"q{i}",
+                candidates=[_candidate(f"mem_{i}")],
+            )
+        await live.log_graduation(
+            scope=["org:sales:leads"],
+            memory_id="mem_0",
+            kind="episodic_to_semantic",
+            access_count=11,
+            window_days=30,
+            from_tier="episodic",
+            to_tier="semantic",
+        )
+
+        live_retr = {v.query for v in live.projection.recent_retrievals(limit=100)}
+        live_grad = {r.memory_id for r in live.projection.graduation_state()}
+
+        cold = RetrievalJournalStore(journal, projection=RetrievalProjection())
+        applied = cold.bootstrap()
+        assert applied == 6  # 5 retrievals + 1 graduation
+
+        cold_retr = {v.query for v in cold.projection.recent_retrievals(limit=100)}
+        cold_grad = {r.memory_id for r in cold.projection.graduation_state()}
+
+        assert cold_retr == live_retr
+        assert cold_grad == live_grad
+
+
+# ---------------------------------------------------------------------------
+# 7. REST router — the UI-facing contract.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> FastAPI:
+    """FastAPI app with the retrieval router + get_journal overridden to
+    a tmp-path journal. Matches the fleet router's dep-override pattern.
+    """
+
+    a = FastAPI()
+    a.include_router(router)
+    journal_path = tmp_path / "router_journal.db"
+    a.dependency_overrides[get_journal] = lambda: open_journal(journal_path)
+    return a
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+class TestRouter:
+    def test_recent_returns_empty_envelope_on_cold_journal(
+        self,
+        client: TestClient,
+    ) -> None:
+        res = client.get("/retrieval/recent")
+        assert res.status_code == 200
+        body = res.json()
+        assert body == {"entries": [], "total": 0}
+
+    def test_recent_shows_retrievals_after_direct_write(
+        self,
+        client: TestClient,
+        app: FastAPI,
+    ) -> None:
+        """Seed the journal via get_journal()'s override, then GET
+        /retrieval/recent — the warmed store should pick up the event on
+        first call via bootstrap()."""
+
+        # Write directly to the journal the override hands out.
+        journal = app.dependency_overrides[get_journal]()
+        seed_store = RetrievalJournalStore(journal)
+        import asyncio
+
+        asyncio.run(
+            seed_store.log_retrieval(
+                scope=["org:sales:leads"],
+                query="recent q",
+                candidates=[_candidate("mem_x")],
+            )
+        )
+
+        res = client.get("/retrieval/recent?limit=10")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] == 1
+        assert body["entries"][0]["query"] == "recent q"
+        assert body["entries"][0]["scope"] == ["org:sales:leads"]
+
+    def test_recent_filters_by_scope_query_param(
+        self,
+        client: TestClient,
+        app: FastAPI,
+    ) -> None:
+        journal = app.dependency_overrides[get_journal]()
+        seed_store = RetrievalJournalStore(journal)
+        import asyncio
+
+        asyncio.run(
+            seed_store.log_retrieval(
+                scope=["org:sales:leads"],
+                query="sales",
+            )
+        )
+        asyncio.run(
+            seed_store.log_retrieval(
+                scope=["org:finance:reports"],
+                query="finance",
+            )
+        )
+
+        res = client.get("/retrieval/recent?scope=org%3Asales%3Aleads")
+        body = res.json()
+        assert body["total"] == 1
+        assert body["entries"][0]["query"] == "sales"
+
+    def test_session_endpoint_returns_404_when_missing(
+        self,
+        client: TestClient,
+    ) -> None:
+        res = client.get(f"/retrieval/session/{uuid4()}")
+        assert res.status_code == 404
+
+    def test_graduation_state_endpoint_lists_current_decisions(
+        self,
+        client: TestClient,
+        app: FastAPI,
+    ) -> None:
+        journal = app.dependency_overrides[get_journal]()
+        seed_store = RetrievalJournalStore(journal)
+        import asyncio
+
+        asyncio.run(
+            seed_store.log_graduation(
+                scope=["org:sales:leads"],
+                memory_id="mem_hot",
+                kind="episodic_to_semantic",
+                access_count=12,
+                window_days=30,
+                from_tier="episodic",
+                to_tier="semantic",
+            )
+        )
+
+        res = client.get("/graduation/state")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] == 1
+        assert body["entries"][0]["memory_id"] == "mem_hot"
+        assert body["entries"][0]["current_tier"] == "semantic"


### PR DESCRIPTION
## What

Carries the intent of the held PRs #936 (JSONL retrieval sink) and #937 (graduation policy over that JSONL) onto the org journal. Both were held because the side-channel `~/.pocketpaw/retrieval.jsonl` file became redundant once the journal took over as source of truth. Both come back as projections over the `retrieval.query` + `graduation.applied` events that soul-protocol v0.3.1 already lists in the action catalog.

Mirrors the file layout established by #953's Fabric projection:

| File | Role |
|---|---|
| `ee/retrieval/events.py` | Action names + payload builders |
| `ee/retrieval/store.py` | `log_retrieval()` / `log_graduation()` write path |
| `ee/retrieval/projection.py` | Rebuild + incremental apply + views |
| `ee/retrieval/policy.py` | #937's thresholds + decision rules ported verbatim |
| `ee/retrieval/router.py` | REST surface on `/api/v1/` |

## Endpoints

- `GET /api/v1/retrieval/recent?scope=&actor_id=&pocket_id=&limit=` — newest-first view of the `retrieval.query` stream
- `GET /api/v1/retrieval/session/{correlation_id}` — all retrievals in one run, chronological
- `GET /api/v1/graduation/state?memory_id=` — most-recent graduation decision per memory
- `POST /api/v1/graduation/scan` — dry-run policy scan, returns proposed decisions

## What's ported verbatim vs rewritten

**Ported verbatim from #937**: threshold constants (10 / 50 / 30-day window), tier-progression rules (episodic→semantic→core), apply-decisions contract (best-effort soul mutation, journal event written regardless), the `GraduationDecision` shape.

**Rewritten**: the input (projection rows, not `RetrievalLogEntry` rows), the output (`graduation.applied` events on the journal, not a JSONL line). The per-process asyncio mutex from #936 is retired — SQLite WAL + transaction semantics handle write serialization now.

## Domain events

`retrieval.query` is already in the soul-protocol v0.3.1 catalog and emitted by soul-protocol's own `RetrievalRouter`. The base payload shape (`request_id`, `query`, `strategy`, `sources_queried`, `sources_failed`, `candidate_count`) was too lean for graduation — the projection needs per-candidate `id` + `tier` to count accesses. Extended the payload additively with `candidates`, `picked`, `latency_ms`, `pocket_id`, `trace_id`. Consumers that only know the base keys still work unchanged.

`graduation.applied` is in the catalog but had no upstream writer, so this PR lands the first concrete payload shape — mirrors `GraduationDecision` so downstream listeners (`memory.graduated` subscribers, widget graduation) don't need a second dataclass.

## Tests

`tests/ee/test_retrieval_journal.py` — 20 tests, 7 classes:
- Write path: full-payload emission, scope-required invariant on both event types
- Scope filter: exact-scope filter, actor filter, requester-scope containment (shared with Fabric)
- Correlation view: `/retrieval/session/{cid}` grouping in chronological order
- Graduation policy: threshold crosses, below-threshold silence, semantic→core, apply emits journal events, apply survives missing soul
- Empty journal rebuild: no crash, empty state
- Incremental == rebuild: live projection state matches cold-replay state after mixed writes
- REST router: empty envelope, filters, 404 on missing correlation, graduation state surfacing

All 20 new tests pass. Pre-existing failures in `test_api_chat`, `test_audit`, `test_deep_work_v2` reproduce on baseline `ee` — not introduced by this PR.

## Supersedes

Closes the design intent of #936 and #937. Leaving both open so captain decides after this merges. Unblocks #941 / #942 (widget graduation) and #69 / #74 (retrieval + graduation UIs in paw-enterprise) — they can now read the projection via REST instead of parsing the retired JSONL.

## Soul-protocol gaps noted

- `Journal.query(action=...)` is exact-match only; no prefix globbing. Worked around by pinning two action names (`retrieval.query`, `graduation.applied`). If more domain actions land we may want a `journal.query(action_prefix=...)` helper — candidate for #48 / #49.
- `soul.get_by_id(memory_id)` still not exposed; `apply_decisions` falls back to a wide recall + in-memory filter, same as #937. Flagging on the v0.3.2/0.4.0 list.