### PR TITLE
Widget graduation + co-occurrence as a journal projection

### DIFF
--- a/ee/widget/__init__.py
+++ b/ee/widget/__init__.py
@@ -1,0 +1,98 @@
+# ee/widget/__init__.py — Widget graduation + co-occurrence detection as
+# a journal projection.
+# Created: 2026-04-16 (feat/widget-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Supersedes the side-channel designs in held
+# PRs #941 (widget graduation engine reading
+# ``~/.pocketpaw/widget-interactions.jsonl``) and #942 (co-occurrence
+# detector stacked on that same JSONL, shipped with a
+# ``sorted(tokens[:6])`` bug that broke dedup for any query longer than
+# six tokens). The org journal becomes the source of truth; the JSONL
+# file is retired; and the ``sorted(tokens)[:6]`` fix ships with the
+# projection itself — the signature is re-derived from widget pair on
+# replay so out-of-band emitters with the old bug can't poison state.
+#
+# What we re-export: the store (write path), the projection (read
+# path), the policy (graduation + co-occurrence decisions), plus the
+# canonical action names and payload builders for out-of-band emitters.
+
+from ee.widget.events import (
+    ACTION_WIDGET_COOCCURRENCE_DETECTED,
+    ACTION_WIDGET_GRADUATED,
+    ACTION_WIDGET_INTERACTION_RECORDED,
+    ALL_WIDGET_ACTIONS,
+    SIGNATURE_MAX_TOKENS,
+    cooccurrence_signature,
+    normalise_signature_tokens,
+    widget_cooccurrence_payload,
+    widget_graduated_payload,
+    widget_interaction_payload,
+)
+from ee.widget.policy import (
+    DEFAULT_ARCHIVE_DAYS,
+    DEFAULT_COOCCURRENCE_THRESHOLD,
+    DEFAULT_COOCCURRENCE_WINDOW_DAYS,
+    DEFAULT_PIN_THRESHOLD,
+    DEFAULT_SESSION_GAP_SECONDS,
+    DEFAULT_WINDOW_DAYS,
+    CooccurrenceCandidate,
+    CooccurrenceReport,
+    WidgetGraduationDecision,
+    WidgetGraduationReport,
+    WidgetTier,
+    apply_cooccurrences,
+    apply_widget_graduations,
+    scan_for_cooccurrences,
+    scan_for_widget_graduations,
+)
+from ee.widget.projection import (
+    CooccurrenceProjection,
+    CooccurrenceRow,
+    GraduationStateProjection,
+    GraduationStateRow,
+    WidgetInteractionView,
+    WidgetProjection,
+    WidgetUsageProjection,
+    WidgetUsageRow,
+)
+from ee.widget.store import WidgetJournalStore
+
+__all__ = [
+    # Actions + payload builders.
+    "ACTION_WIDGET_INTERACTION_RECORDED",
+    "ACTION_WIDGET_GRADUATED",
+    "ACTION_WIDGET_COOCCURRENCE_DETECTED",
+    "ALL_WIDGET_ACTIONS",
+    "SIGNATURE_MAX_TOKENS",
+    "cooccurrence_signature",
+    "normalise_signature_tokens",
+    "widget_interaction_payload",
+    "widget_graduated_payload",
+    "widget_cooccurrence_payload",
+    # Write path.
+    "WidgetJournalStore",
+    # Read path.
+    "WidgetProjection",
+    "WidgetUsageProjection",
+    "CooccurrenceProjection",
+    "GraduationStateProjection",
+    "WidgetInteractionView",
+    "WidgetUsageRow",
+    "CooccurrenceRow",
+    "GraduationStateRow",
+    # Policy.
+    "WidgetTier",
+    "WidgetGraduationDecision",
+    "WidgetGraduationReport",
+    "CooccurrenceCandidate",
+    "CooccurrenceReport",
+    "scan_for_widget_graduations",
+    "scan_for_cooccurrences",
+    "apply_widget_graduations",
+    "apply_cooccurrences",
+    "DEFAULT_WINDOW_DAYS",
+    "DEFAULT_PIN_THRESHOLD",
+    "DEFAULT_ARCHIVE_DAYS",
+    "DEFAULT_COOCCURRENCE_THRESHOLD",
+    "DEFAULT_COOCCURRENCE_WINDOW_DAYS",
+    "DEFAULT_SESSION_GAP_SECONDS",
+]

--- a/ee/widget/events.py
+++ b/ee/widget/events.py
@@ -1,0 +1,220 @@
+# ee/widget/events.py — Canonical event payloads for the widget journal projection.
+# Created: 2026-04-16 (feat/widget-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Carries the intent of held PRs #941 (widget
+# graduation engine reading a JSONL interaction log) and #942 (co-occurrence
+# detector stacked on that log) onto the org journal. Both shipped as
+# side-channel files at ``~/.pocketpaw/widget-interactions.jsonl``; this
+# module retires the file and re-lands the same domain as a projection
+# over three new action names:
+#
+#   - ``widget.interaction.recorded`` — one per user touch on a widget
+#     (open / edit / click / dismiss / remove). Supersedes #941's
+#     WidgetInteraction JSONL append.
+#   - ``widget.graduated`` — one per pin / fade / archive decision the
+#     policy fires. Supersedes #941's WidgetDecision apply path.
+#   - ``widget.cooccurrence.detected`` — one per co-occurring-pair
+#     signature that crossed threshold. Supersedes #942's PatternMatch
+#     output. Critically: the signature on this payload uses
+#     ``sorted(tokens)[:6]`` (sort FIRST, then truncate) — #942 shipped
+#     ``sorted(tokens[:6])`` which truncates before sorting and breaks
+#     dedup correctness across any query longer than 6 tokens. See
+#     cooccurrence_signature below.
+#
+# Action namespace extensions are allowed per soul-protocol's v0.3.1
+# catalog policy (custom namespaces are permitted for domain extensions
+# that don't conflict with reserved prefixes). Pinned as constants so the
+# projection + policy + store + tests all reach them through one import.
+#
+# Scope lives on ``EventEntry.scope`` (the journal column), never inside
+# the payload. Same rule as ee/fabric/events.py and ee/retrieval/events.py
+# — scope is the journal's canonical filter and duplicating it invites
+# drift.
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Action names — pocketpaw-specific extensions of soul-protocol's action
+# catalog. Kept stable; renaming requires a migration event on every
+# existing journal since the projection can no longer replay the old
+# events.
+# ---------------------------------------------------------------------------
+
+ACTION_WIDGET_INTERACTION_RECORDED = "widget.interaction.recorded"
+ACTION_WIDGET_GRADUATED = "widget.graduated"
+ACTION_WIDGET_COOCCURRENCE_DETECTED = "widget.cooccurrence.detected"
+
+WIDGET_ACTION_PREFIX = "widget."
+
+ALL_WIDGET_ACTIONS = (
+    ACTION_WIDGET_INTERACTION_RECORDED,
+    ACTION_WIDGET_GRADUATED,
+    ACTION_WIDGET_COOCCURRENCE_DETECTED,
+)
+
+
+# ---------------------------------------------------------------------------
+# Token regex — carried verbatim from #942's detector so the signatures
+# the projection emits collide with anything a callsite computed out of
+# band before the projection takes over the writing.
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+# Max tokens retained inside one signature. #942 used 6; keep the same
+# magic number so existing test fixtures and fixtures in downstream
+# tooling don't have to be reflowed.
+SIGNATURE_MAX_TOKENS = 6
+
+
+def normalise_signature_tokens(text: str) -> list[str]:
+    """Lowercase + alnum-tokenise + sort + cap at SIGNATURE_MAX_TOKENS.
+
+    This is the CORRECT order — sort first, then truncate. #942's
+    ``sorted(tokens[:6])`` truncated before sorting, which meant any
+    query longer than 6 tokens produced a signature whose sort order
+    depended on which 6 raw tokens happened to survive the slice.
+    The dedup guarantee the PR advertised ("word-order variants
+    collapse") fell apart for longer queries:
+    ``"d c b a e f g"`` and ``"a b c d e f g"`` both tokenise to the
+    same bag but ``sorted(tokens[:6])`` produced
+    ``['a', 'b', 'c', 'd', 'e', 'f']`` and
+    ``['b', 'c', 'd', 'e', 'f', 'g']`` — two different signatures for
+    the same semantic query.
+
+    Fix: sort the full token list first, THEN slice — the resulting
+    prefix is stable across rotations of the input tokens, so dedup
+    works as the PR claimed.
+    """
+
+    tokens = _TOKEN_RE.findall(text.lower())
+    return sorted(tokens)[:SIGNATURE_MAX_TOKENS]
+
+
+def cooccurrence_signature(text_a: str, text_b: str) -> str:
+    """Stable signature for a co-occurring query pair.
+
+    Two queries collapse into one signature when their sorted-token
+    bags are equal up to the prefix cap. ``"::"`` is kept as the join
+    separator so the resulting string is stable, printable, and easy
+    to eyeball in logs.
+    """
+
+    a = " ".join(normalise_signature_tokens(text_a))
+    b = " ".join(normalise_signature_tokens(text_b))
+    if not a or not b or a == b:
+        return ""
+    # Order the two bags so (A,B) and (B,A) collide.
+    lo, hi = sorted((a, b))
+    return f"{lo}::{hi}"
+
+
+# ---------------------------------------------------------------------------
+# Payload builders — small module-level functions, same pattern as
+# ee/fabric/events.py and ee/retrieval/events.py. Keep them boring so
+# migration helpers, external emitters, and the projection all produce
+# identical dicts.
+# ---------------------------------------------------------------------------
+
+
+def widget_interaction_payload(
+    *,
+    widget_name: str,
+    surface: str = "dashboard",
+    action_type: str = "open",
+    pocket_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    query_text: str | None = None,
+) -> dict[str, Any]:
+    """Payload for ``widget.interaction.recorded`` events.
+
+    ``widget_name`` is the stable identifier the UI emits (``metrics_chart``,
+    ``leads_table``, etc.). ``surface`` differentiates which shell the
+    interaction happened on (dashboard, telegram, slack). ``action_type``
+    mirrors #941's WidgetAction set — open / edit / click / dismiss /
+    remove — but stays as a free-form str here because the journal payload
+    should survive a vocabulary change without a migration.
+
+    ``query_text`` is optional; when present it lets the co-occurrence
+    projection build signatures straight off the interaction payload
+    without cross-referencing the retrieval log. Callers wiring widget
+    interactions to retrievals should set this from the originating
+    query.
+    """
+
+    return {
+        "widget_name": widget_name,
+        "surface": surface,
+        "action_type": action_type,
+        "pocket_id": pocket_id,
+        "metadata": dict(metadata or {}),
+        "query_text": query_text,
+    }
+
+
+def widget_graduated_payload(
+    *,
+    widget_name: str,
+    surface: str,
+    tier: str,
+    confidence: float,
+    interactions_in_window: int,
+    window_days: int,
+    previous_tier: str | None = None,
+    pocket_id: str | None = None,
+    reason: str = "",
+) -> dict[str, Any]:
+    """Payload for ``widget.graduated`` events.
+
+    Shape matches #941's WidgetDecision field-for-field so downstream
+    consumers (the paw-enterprise SuggestedWidgetsFeed UI in issue #74,
+    for instance) don't need a new adapter. ``tier`` carries the verdict
+    (``pin`` / ``fade`` / ``archive``) in the same naming scheme as the
+    original WidgetVerdict enum. ``previous_tier`` is optional since
+    first-time graduations have no prior state.
+    """
+
+    return {
+        "widget_name": widget_name,
+        "surface": surface,
+        "tier": tier,
+        "confidence": float(confidence),
+        "interactions_in_window": int(interactions_in_window),
+        "window_days": int(window_days),
+        "previous_tier": previous_tier,
+        "pocket_id": pocket_id,
+        "reason": reason,
+    }
+
+
+def widget_cooccurrence_payload(
+    *,
+    widget_a: str,
+    widget_b: str,
+    count: int,
+    window_s: int,
+    signature: str,
+    pocket_id: str | None = None,
+    example_queries: list[str] | None = None,
+) -> dict[str, Any]:
+    """Payload for ``widget.cooccurrence.detected`` events.
+
+    ``signature`` is the output of :func:`cooccurrence_signature` — the
+    projection re-derives it on replay from the raw widget pair so a
+    caller that computed the signature wrong (or used the #942 bug
+    ordering) can't poison the projection state. ``window_s`` is the
+    session window in seconds for auditability (#942 used a 15-minute
+    gap; keeping it numeric leaves room for per-pocket tuning).
+    """
+
+    return {
+        "widget_a": widget_a,
+        "widget_b": widget_b,
+        "count": int(count),
+        "window_s": int(window_s),
+        "signature": signature,
+        "pocket_id": pocket_id,
+        "example_queries": list(example_queries or []),
+    }

--- a/ee/widget/policy.py
+++ b/ee/widget/policy.py
@@ -1,0 +1,422 @@
+# ee/widget/policy.py — Graduation + co-occurrence thresholds over the
+# widget projection.
+# Created: 2026-04-16 (feat/widget-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Ports #941's pin / fade / archive decision
+# logic from a JSONL scan onto a projection scan, and #942's
+# co-occurrence-detector-as-threshold onto the same projection. Every
+# tuning knob that was public in the held PRs is preserved here under
+# the same name so existing config knobs and tests carry over without
+# rename.
+#
+# Why keep the thresholds verbatim? Because #941 + #942 shipped tuning
+# defaults that were picked for feel. The refactor isn't the place to
+# re-tune — a follow-up can make them per-pocket configurable.
+#
+# Two decision flows, both over the same WidgetProjection:
+#
+#   - scan_for_widget_graduations — pin / fade / archive per (widget,
+#     surface) pair. Ports #941.
+#   - scan_for_cooccurrences — signature pairs above threshold.
+#     Ports #942 with the sorted(tokens)[:6] fix (applied in the
+#     projection, not recomputed here — the policy trusts the
+#     projection's signatures).
+#
+# Note on soul-protocol's AgentProposal/HumanCorrection primitives
+# (spec/decisions.py): a widget graduation is a *system-emitted*
+# decision derived from usage counts, not a human-reviewed proposal,
+# so the AgentProposal shape is not a great fit (no summary, no
+# reviewer disposition). We stay on ``widget.graduated`` events. If a
+# future slice introduces human-in-the-loop approval for widget
+# promotion (captain reviews proposed pins before they apply), it can
+# wrap these decisions in agent.proposed / human.corrected pairs
+# without disturbing the projection.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+from ee.widget.projection import WidgetProjection
+from ee.widget.store import WidgetJournalStore
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tuning defaults — carried verbatim from #941 + #942 so the runtime
+# feel stays identical post-refactor.
+# ---------------------------------------------------------------------------
+
+# #941 graduation knobs
+DEFAULT_WINDOW_DAYS = 30
+DEFAULT_PIN_THRESHOLD = 10          # Promoting interactions in window → pin
+DEFAULT_ARCHIVE_DAYS = 60           # Untouched longer than this → archive
+_PROMOTING_ACTIONS = ("open", "edit", "click")
+
+# #942 co-occurrence knobs
+DEFAULT_COOCCURRENCE_WINDOW_DAYS = 7
+DEFAULT_COOCCURRENCE_THRESHOLD = 3
+DEFAULT_SESSION_GAP_SECONDS = 15 * 60  # 15-minute session window (#942)
+
+
+WidgetTier = Literal["pin", "fade", "archive"]
+
+
+@dataclass
+class WidgetGraduationDecision:
+    """One proposed widget tier change.
+
+    Mirrors #941's WidgetDecision shape so downstream consumers
+    (paw-enterprise SuggestedWidgetsFeed UI in issue #74) don't need
+    to learn a new dataclass. ``tier`` carries the verdict.
+    """
+
+    widget_name: str
+    surface: str
+    tier: WidgetTier
+    confidence: float
+    interactions_in_window: int
+    window_days: int
+    previous_tier: str | None = None
+    pocket_id: str | None = None
+    scope: list[str] = field(default_factory=list)
+    reason: str = ""
+
+    def short(self) -> str:
+        """One-liner for terminal output / operator dashboards."""
+
+        prev = self.previous_tier or "?"
+        return (
+            f"[{self.tier}] {self.widget_name}@{self.surface} {prev}->{self.tier} "
+            f"({self.interactions_in_window} hits in {self.window_days}d, "
+            f"conf={self.confidence:.2f})"
+        )
+
+
+@dataclass
+class WidgetGraduationReport:
+    """Output of one graduation scan — decisions + scan metadata."""
+
+    decisions: list[WidgetGraduationDecision] = field(default_factory=list)
+    scanned_widgets: int = 0
+    window_days: int = DEFAULT_WINDOW_DAYS
+    dry_run: bool = True
+    generated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+@dataclass
+class CooccurrenceCandidate:
+    """One co-occurring-pair candidate surfaced by the threshold scan.
+
+    Ports the PatternMatch + SuggestedWidget split from #942 into a
+    single dataclass — the policy emits candidates; callers that want
+    the richer "proposed widget" shape (title, description,
+    confidence) can map them downstream without the policy owning UI
+    copy.
+    """
+
+    signature: str
+    widget_a: str
+    widget_b: str
+    count: int
+    window_s: int
+    pocket_id: str | None = None
+    scope: list[str] = field(default_factory=list)
+    confidence: float = 0.0
+
+
+@dataclass
+class CooccurrenceReport:
+    candidates: list[CooccurrenceCandidate] = field(default_factory=list)
+    scanned_pairs: int = 0
+    threshold: int = DEFAULT_COOCCURRENCE_THRESHOLD
+    window_s: int = DEFAULT_SESSION_GAP_SECONDS
+    generated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+# ---------------------------------------------------------------------------
+# Scan — graduation. Counts per-widget promoting interactions off the
+# projection and emits decisions that cross the configured thresholds.
+# ---------------------------------------------------------------------------
+
+
+def scan_for_widget_graduations(
+    projection: WidgetProjection,
+    *,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    pin_threshold: int = DEFAULT_PIN_THRESHOLD,
+    archive_days: int = DEFAULT_ARCHIVE_DAYS,
+    pocket_id: str | None = None,
+    scope: str | None = None,
+    promoting_actions: tuple[str, ...] = _PROMOTING_ACTIONS,
+    dry_run: bool = True,
+) -> WidgetGraduationReport:
+    """Walk the projection's usage roll-up and emit pin / fade /
+    archive decisions.
+
+    Pin: widget hit ``pin_threshold`` promoting interactions in the
+        window.
+    Fade: widget seen at least once historically but zero promoting
+        interactions in the window.
+    Archive: widget last touched more than ``archive_days`` ago.
+
+    Thresholds carried verbatim from #941 — when an operator wants a
+    different cadence, pass kwargs. This path never writes; apply()
+    does. Same dry-run-by-default contract as #941 so the captain
+    reviews the report before committing tier changes.
+    """
+
+    now = datetime.now(UTC)
+    window_cutoff = now - timedelta(days=window_days)
+    archive_cutoff = now - timedelta(days=archive_days)
+
+    usage = projection.usage(
+        window_days=max(window_days, archive_days),
+        scope=scope,
+        pocket_id=pocket_id,
+        promoting_actions=promoting_actions,
+    )
+
+    decisions: list[WidgetGraduationDecision] = []
+    for row in usage:
+        last = _ensure_aware(row.last_interaction)
+
+        # Pull the existing tier (if any) so the decision carries prior
+        # state. The projection keeps only the latest verdict per
+        # widget; querying it here is cheap.
+        prior = projection.graduation_state(
+            widget_name=row.widget_name,
+            surface=row.surface,
+        )
+        previous_tier = prior[0].current_tier if prior else None
+
+        if row.promoting_count >= pin_threshold and last >= window_cutoff:
+            if previous_tier == "pin":
+                # Already pinned — skip so we don't re-emit the same
+                # decision on every scan.
+                continue
+            confidence = min(1.0, row.promoting_count / (pin_threshold * 3))
+            decisions.append(
+                WidgetGraduationDecision(
+                    widget_name=row.widget_name,
+                    surface=row.surface,
+                    tier="pin",
+                    confidence=confidence,
+                    interactions_in_window=row.promoting_count,
+                    window_days=window_days,
+                    previous_tier=previous_tier,
+                    pocket_id=row.pocket_id,
+                    scope=list(row.scope),
+                    reason=(
+                        f"Opened/edited/clicked {row.promoting_count}x in last "
+                        f"{window_days} days (threshold {pin_threshold})."
+                    ),
+                )
+            )
+            continue
+
+        if last < archive_cutoff:
+            if previous_tier == "archive":
+                continue
+            decisions.append(
+                WidgetGraduationDecision(
+                    widget_name=row.widget_name,
+                    surface=row.surface,
+                    tier="archive",
+                    confidence=0.9,
+                    interactions_in_window=0,
+                    window_days=window_days,
+                    previous_tier=previous_tier,
+                    pocket_id=row.pocket_id,
+                    scope=list(row.scope),
+                    reason=f"Untouched for over {archive_days} days.",
+                )
+            )
+            continue
+
+        # Fade: seen in history but nothing promoting in the pin window.
+        if row.promoting_count == 0 and last < window_cutoff:
+            if previous_tier == "fade":
+                continue
+            decisions.append(
+                WidgetGraduationDecision(
+                    widget_name=row.widget_name,
+                    surface=row.surface,
+                    tier="fade",
+                    confidence=0.6,
+                    interactions_in_window=0,
+                    window_days=window_days,
+                    previous_tier=previous_tier,
+                    pocket_id=row.pocket_id,
+                    scope=list(row.scope),
+                    reason="No promoting interactions in window.",
+                )
+            )
+
+    return WidgetGraduationReport(
+        decisions=decisions,
+        scanned_widgets=len(usage),
+        window_days=window_days,
+        dry_run=dry_run,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scan — co-occurrence. Turns the projection's signature-level counts
+# into candidate widget proposals above the threshold.
+# ---------------------------------------------------------------------------
+
+
+def scan_for_cooccurrences(
+    projection: WidgetProjection,
+    *,
+    threshold: int = DEFAULT_COOCCURRENCE_THRESHOLD,
+    window_s: int = DEFAULT_SESSION_GAP_SECONDS,
+    pocket_id: str | None = None,
+    scope: str | None = None,
+) -> CooccurrenceReport:
+    """Return co-occurring widget pairs whose count crossed the
+    threshold. Ports #942's scan over the (correct, dedup-safe)
+    signatures the projection produces.
+
+    ``threshold`` defaults to 3 per #942. Confidence is the same
+    ``min(1.0, count / (threshold * 3))`` ramp #942 used — kept
+    verbatim so existing UI copy doesn't drift.
+    """
+
+    pairs = projection.cooccurrences(min_count=threshold, pocket_id=pocket_id, limit=0)
+    if scope:
+        pairs = [p for p in pairs if scope in p.scope]
+
+    candidates = [
+        CooccurrenceCandidate(
+            signature=p.signature,
+            widget_a=p.widget_a,
+            widget_b=p.widget_b,
+            count=p.count,
+            window_s=window_s,
+            pocket_id=p.pocket_id,
+            scope=list(p.scope),
+            confidence=min(1.0, p.count / (threshold * 3)),
+        )
+        for p in pairs
+    ]
+
+    return CooccurrenceReport(
+        candidates=candidates,
+        scanned_pairs=len(pairs),
+        threshold=threshold,
+        window_s=window_s,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Apply — turns decisions into journal events.
+# ---------------------------------------------------------------------------
+
+
+async def apply_widget_graduations(
+    decisions: list[WidgetGraduationDecision],
+    store: WidgetJournalStore,
+    *,
+    scope: list[str],
+    correlation_id: Any = None,
+) -> list[WidgetGraduationDecision]:
+    """Emit a ``widget.graduated`` event per decision. Returns the
+    subset that completed without error — per-decision failures are
+    logged and skipped so one broken emit doesn't block the others.
+    """
+
+    if not decisions:
+        return []
+
+    _require_scope(scope)
+
+    applied: list[WidgetGraduationDecision] = []
+    for decision in decisions:
+        try:
+            await store.log_widget_graduation(
+                scope=scope,
+                widget_name=decision.widget_name,
+                surface=decision.surface,
+                tier=decision.tier,
+                confidence=decision.confidence,
+                interactions_in_window=decision.interactions_in_window,
+                window_days=decision.window_days,
+                previous_tier=decision.previous_tier,
+                pocket_id=decision.pocket_id,
+                reason=decision.reason,
+                correlation_id=correlation_id,
+            )
+        except Exception:
+            logger.exception(
+                "Widget graduation: journal emit failed for %s@%s",
+                decision.widget_name,
+                decision.surface,
+            )
+            continue
+        applied.append(decision)
+    return applied
+
+
+async def apply_cooccurrences(
+    candidates: list[CooccurrenceCandidate],
+    store: WidgetJournalStore,
+    *,
+    scope: list[str],
+    correlation_id: Any = None,
+) -> list[CooccurrenceCandidate]:
+    """Emit a ``widget.cooccurrence.detected`` event per candidate.
+
+    The signature on the projection is already correct; this emit
+    records an explicit snapshot of the threshold crossing so
+    downstream consumers (dashboards, agent tools) can react without
+    re-scanning on every read.
+    """
+
+    if not candidates:
+        return []
+
+    _require_scope(scope)
+
+    applied: list[CooccurrenceCandidate] = []
+    for candidate in candidates:
+        try:
+            await store.log_cooccurrence(
+                scope=scope,
+                widget_a=candidate.widget_a,
+                widget_b=candidate.widget_b,
+                count=candidate.count,
+                window_s=candidate.window_s,
+                pocket_id=candidate.pocket_id,
+                correlation_id=correlation_id,
+            )
+        except Exception:
+            logger.exception(
+                "Widget co-occurrence: journal emit failed for %s",
+                candidate.signature,
+            )
+            continue
+        applied.append(candidate)
+    return applied
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _require_scope(scope: list[str]) -> None:
+    if not scope:
+        raise ValueError(
+            "apply_* requires a non-empty scope — the journal "
+            "invariant refuses events with scope=[]."
+        )
+
+
+def _ensure_aware(ts: datetime) -> datetime:
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=UTC)
+    return ts

--- a/ee/widget/projection.py
+++ b/ee/widget/projection.py
@@ -1,0 +1,655 @@
+# ee/widget/projection.py — In-memory projection over widget events.
+# Created: 2026-04-16 (feat/widget-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Read-side of the widget domain —
+# supersedes #941's graduation scan over ``~/.pocketpaw/widget-
+# interactions.jsonl`` and #942's co-occurrence detector stacked on
+# that file. Both held PRs shared the same input (a per-interaction
+# log) and a similar fold (count events per widget / per pair over a
+# rolling window); the two concerns land in one projection here
+# because the replay cost is the same either way and keeping them
+# together halves the rebuild time.
+#
+# Three logical views over one event stream:
+#   - WidgetUsageProjection: per-widget counts in a rolling window
+#     (how the graduation policy decides pin / fade / archive).
+#     Ports #941's per-widget Counter fold.
+#   - CooccurrenceProjection: per-signature pair counts + example
+#     widgets. Ports #942's session-pair detector but with the
+#     ``sorted(tokens)[:6]`` ordering fixed — see
+#     ee.widget.events.normalise_signature_tokens for the bug
+#     explanation.
+#   - GraduationStateProjection: most-recent graduation verdict per
+#     (widget_name, surface) pair. One row per widget; repeat
+#     graduations overwrite. Ports the output-state side of #941.
+#
+# All three live on ONE WidgetProjection instance because they share
+# the same event stream. Rebuild is O(events); incremental apply is
+# O(1) per event.
+
+from __future__ import annotations
+
+import logging
+from bisect import insort
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from soul_protocol.engine.journal import Journal
+from soul_protocol.spec.journal import EventEntry
+
+from ee.fabric.policy import filter_visible
+from ee.widget.events import (
+    ACTION_WIDGET_COOCCURRENCE_DETECTED,
+    ACTION_WIDGET_GRADUATED,
+    ACTION_WIDGET_INTERACTION_RECORDED,
+    ALL_WIDGET_ACTIONS,
+    cooccurrence_signature,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public row shapes — stable dataclasses the router serialises. Kept as
+# dataclasses (not Pydantic) so the projection has no model-machinery
+# import cost on hot paths.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WidgetInteractionView:
+    """One projected widget interaction — a single
+    ``widget.interaction.recorded`` event after replay."""
+
+    widget_name: str
+    surface: str
+    action_type: str
+    actor_id: str
+    actor_kind: str
+    scope: list[str]
+    pocket_id: str | None
+    correlation_id: str | None
+    ts: datetime
+    metadata: dict[str, Any]
+    query_text: str | None
+    seq: int
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "widget_name": self.widget_name,
+            "surface": self.surface,
+            "action_type": self.action_type,
+            "actor_id": self.actor_id,
+            "actor_kind": self.actor_kind,
+            "scope": list(self.scope),
+            "pocket_id": self.pocket_id,
+            "correlation_id": self.correlation_id,
+            "ts": self.ts.isoformat(),
+            "metadata": dict(self.metadata),
+            "query_text": self.query_text,
+            "seq": self.seq,
+        }
+
+
+@dataclass
+class WidgetUsageRow:
+    """Per-widget usage row — one per (widget_name, surface) pair.
+
+    Emitted by :meth:`WidgetProjection.usage` after folding the
+    ``widget.interaction.recorded`` events in the caller's chosen
+    window. ``last_interaction`` carries the newest event's ts so the
+    graduation policy can compute staleness without a second walk.
+    """
+
+    widget_name: str
+    surface: str
+    count: int
+    scope: list[str]
+    pocket_id: str | None
+    last_interaction: datetime
+    promoting_count: int
+    unique_actors: int
+
+
+@dataclass
+class CooccurrenceRow:
+    """One co-occurring widget pair row.
+
+    ``signature`` is re-derived from the raw widget names on replay so
+    a buggy out-of-band emitter (or a pre-fix #942 writer) can't
+    poison the projection — the projection trusts only what it can
+    recompute.
+    """
+
+    signature: str
+    widget_a: str
+    widget_b: str
+    count: int
+    pocket_id: str | None
+    scope: list[str]
+    last_seen: datetime
+    seq: int
+
+
+@dataclass
+class GraduationStateRow:
+    """Most-recent graduation decision for one (widget_name, surface) pair.
+
+    The projection keeps only the latest tier per widget — a repeat
+    graduation overwrites the row. Full history lives on the journal
+    via ``journal.query(action="widget.graduated")``.
+    """
+
+    widget_name: str
+    surface: str
+    current_tier: str
+    previous_tier: str | None
+    confidence: float
+    interactions_in_window: int
+    window_days: int
+    pocket_id: str | None
+    scope: list[str]
+    reason: str
+    applied_at: datetime
+    seq: int
+
+
+# ---------------------------------------------------------------------------
+# Internal storage row — not exposed. Wraps the public view in a sortable
+# envelope so ``insort`` keeps insertion order by seq under out-of-order
+# replays.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _InteractionRow:
+    view: WidgetInteractionView
+
+    def __lt__(self, other: _InteractionRow) -> bool:
+        return self.view.seq < other.view.seq
+
+
+# ---------------------------------------------------------------------------
+# The projection.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SessionWindow:
+    """Scratch state for co-occurrence detection during replay.
+
+    Tracks the last widget a (actor, pocket) pair touched plus the
+    timestamp of that touch. When the next touch lands within the
+    session window the projection accumulates one pair. Kept separate
+    from the public view so tests can read-through the resulting
+    Cooccurrence rows without peeking at fold internals.
+    """
+
+    last_widget: str = ""
+    last_text: str = ""
+    last_ts: datetime | None = None
+
+
+class WidgetProjection:
+    """Rebuilds + serves read views for widget events.
+
+    One instance per process; rebuild is O(events) so operators can
+    drop and rebuild if they suspect drift. No persistence — the
+    projection is a pure fold over the journal.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_interactions: int = 20_000,
+        session_window: timedelta = timedelta(minutes=15),
+    ) -> None:
+        # Interaction log — newest wins when we spill past the cap.
+        self._interactions: list[_InteractionRow] = []
+        self._max = max_interactions
+        # Co-occurrence state.
+        self._session_window = session_window
+        self._pair_counts: dict[str, CooccurrenceRow] = {}
+        self._session_scratch: dict[tuple[str, str], _SessionWindow] = {}
+        # Graduation state — latest per (widget, surface).
+        self._graduation: dict[tuple[str, str], GraduationStateRow] = {}
+        # Projection cursor for resumable replays.
+        self._cursor: int = 0
+
+    # -- Build / rebuild ----------------------------------------------------
+
+    def rebuild(self, journal: Journal, *, since_seq: int = 0) -> int:
+        """Replay the journal from ``since_seq`` (0 = genesis), applying
+        every widget event. Returns the number of events applied. When
+        ``since_seq == 0`` the projection wipes state so rebuild is a
+        true reset.
+        """
+
+        if since_seq == 0:
+            self._interactions.clear()
+            self._pair_counts.clear()
+            self._session_scratch.clear()
+            self._graduation.clear()
+            self._cursor = 0
+
+        applied = 0
+        for entry in journal.replay_from(since_seq):
+            if entry.action not in ALL_WIDGET_ACTIONS:
+                continue
+            self.apply(entry)
+            applied += 1
+        return applied
+
+    # -- Incremental apply --------------------------------------------------
+
+    def apply(self, entry: EventEntry) -> None:
+        """Fold a single event into the projection."""
+
+        if entry.action not in ALL_WIDGET_ACTIONS:
+            return
+
+        payload: dict[str, Any] = (
+            dict(entry.payload) if isinstance(entry.payload, dict) else {}
+        )
+        seq = getattr(entry, "seq", None) or 0
+        if seq > self._cursor:
+            self._cursor = seq
+
+        if entry.action == ACTION_WIDGET_INTERACTION_RECORDED:
+            self._apply_interaction(entry, payload, seq)
+        elif entry.action == ACTION_WIDGET_GRADUATED:
+            self._apply_graduation(entry, payload, seq)
+        elif entry.action == ACTION_WIDGET_COOCCURRENCE_DETECTED:
+            self._apply_cooccurrence_event(entry, payload, seq)
+
+    def _apply_interaction(
+        self,
+        entry: EventEntry,
+        payload: dict[str, Any],
+        seq: int,
+    ) -> None:
+        widget_name = payload.get("widget_name")
+        if not isinstance(widget_name, str) or not widget_name:
+            logger.warning("Widget projection: interaction event missing widget_name")
+            return
+
+        view = WidgetInteractionView(
+            widget_name=widget_name,
+            surface=str(payload.get("surface") or "dashboard"),
+            action_type=str(payload.get("action_type") or "open"),
+            actor_id=str(entry.actor.id),
+            actor_kind=str(entry.actor.kind),
+            scope=list(entry.scope),
+            pocket_id=_none_or_str(payload.get("pocket_id")),
+            correlation_id=_uuid_to_str(entry.correlation_id),
+            ts=_as_datetime(entry.ts),
+            metadata=dict(payload.get("metadata") or {}),
+            query_text=_none_or_str(payload.get("query_text")),
+            seq=seq,
+        )
+        insort(self._interactions, _InteractionRow(view=view))
+        # Evict oldest once we pass the cap — keep the tail (newest).
+        if len(self._interactions) > self._max:
+            overflow = len(self._interactions) - self._max
+            del self._interactions[: overflow]
+
+        # Co-occurrence fold — runs over the same events.
+        self._maybe_record_pair(view)
+
+    def _apply_graduation(
+        self,
+        entry: EventEntry,
+        payload: dict[str, Any],
+        seq: int,
+    ) -> None:
+        widget_name = payload.get("widget_name")
+        surface = payload.get("surface") or "dashboard"
+        if not isinstance(widget_name, str) or not widget_name:
+            logger.warning("Widget projection: graduated event missing widget_name")
+            return
+
+        row = GraduationStateRow(
+            widget_name=widget_name,
+            surface=str(surface),
+            current_tier=str(payload.get("tier") or ""),
+            previous_tier=_none_or_str(payload.get("previous_tier")),
+            confidence=float(payload.get("confidence") or 0.0),
+            interactions_in_window=int(payload.get("interactions_in_window") or 0),
+            window_days=int(payload.get("window_days") or 0),
+            pocket_id=_none_or_str(payload.get("pocket_id")),
+            scope=list(entry.scope),
+            reason=str(payload.get("reason") or ""),
+            applied_at=_as_datetime(entry.ts),
+            seq=seq,
+        )
+        self._graduation[(widget_name, row.surface)] = row
+
+    def _apply_cooccurrence_event(
+        self,
+        entry: EventEntry,
+        payload: dict[str, Any],
+        seq: int,
+    ) -> None:
+        """Fold an explicitly-emitted co-occurrence event.
+
+        The projection also auto-derives co-occurrence from raw
+        interactions in :meth:`_maybe_record_pair`; this path is here
+        for callers that emit pair counts out-of-band (a batch job,
+        for instance, or a migration from #942's legacy JSONL).
+
+        Re-derives ``signature`` from ``widget_a`` + ``widget_b`` so a
+        pre-fix payload that carried the #942 bug signature gets
+        corrected on replay. The projection is the source of truth
+        for signatures; emitters are advisory.
+        """
+
+        widget_a = payload.get("widget_a") or ""
+        widget_b = payload.get("widget_b") or ""
+        signature = cooccurrence_signature(str(widget_a), str(widget_b))
+        if not signature:
+            return
+
+        row = self._pair_counts.get(signature)
+        count_delta = int(payload.get("count") or 1)
+        last_seen = _as_datetime(entry.ts)
+        if row is None:
+            self._pair_counts[signature] = CooccurrenceRow(
+                signature=signature,
+                widget_a=str(widget_a),
+                widget_b=str(widget_b),
+                count=count_delta,
+                pocket_id=_none_or_str(payload.get("pocket_id")),
+                scope=list(entry.scope),
+                last_seen=last_seen,
+                seq=seq,
+            )
+        else:
+            row.count += count_delta
+            if last_seen > row.last_seen:
+                row.last_seen = last_seen
+                row.seq = seq
+
+    def _maybe_record_pair(self, view: WidgetInteractionView) -> None:
+        """Record a co-occurring widget pair if this interaction lands
+        inside an active session window with the previous interaction
+        from the same (actor, pocket) pair.
+        """
+
+        key = (view.actor_id, view.pocket_id or "")
+        prev = self._session_scratch.get(key)
+        now = view.ts
+        if prev is None or prev.last_ts is None:
+            self._session_scratch[key] = _SessionWindow(
+                last_widget=view.widget_name,
+                last_text=view.query_text or view.widget_name,
+                last_ts=now,
+            )
+            return
+
+        if now - prev.last_ts > self._session_window:
+            # Session expired — start a new one with this touch.
+            self._session_scratch[key] = _SessionWindow(
+                last_widget=view.widget_name,
+                last_text=view.query_text or view.widget_name,
+                last_ts=now,
+            )
+            return
+
+        # Same session — record a pair when the widgets are distinct.
+        curr_text = view.query_text or view.widget_name
+        signature = cooccurrence_signature(prev.last_text, curr_text)
+        if signature and view.widget_name != prev.last_widget:
+            row = self._pair_counts.get(signature)
+            if row is None:
+                lo, hi = sorted([prev.last_widget, view.widget_name])
+                self._pair_counts[signature] = CooccurrenceRow(
+                    signature=signature,
+                    widget_a=lo,
+                    widget_b=hi,
+                    count=1,
+                    pocket_id=view.pocket_id,
+                    scope=list(view.scope),
+                    last_seen=now,
+                    seq=view.seq,
+                )
+            else:
+                row.count += 1
+                if now > row.last_seen:
+                    row.last_seen = now
+                    row.seq = view.seq
+
+        # Roll the window forward.
+        self._session_scratch[key] = _SessionWindow(
+            last_widget=view.widget_name,
+            last_text=curr_text,
+            last_ts=now,
+        )
+
+    # -- Interaction queries ------------------------------------------------
+
+    def recent_interactions(
+        self,
+        *,
+        scope: str | None = None,
+        widget_name: str | None = None,
+        actor_id: str | None = None,
+        pocket_id: str | None = None,
+        limit: int = 50,
+        requester_scopes: list[str] | None = None,
+    ) -> list[WidgetInteractionView]:
+        """Return the most-recent interactions, newest-first, with
+        optional filters. Scope containment runs via
+        ``ee.fabric.policy.filter_visible`` so the rules stay identical
+        to Fabric's + retrieval's — no divergent semantics across
+        projections.
+        """
+
+        rows = [row.view for row in self._interactions]
+        if scope:
+            rows = [r for r in rows if scope in r.scope]
+        if widget_name:
+            rows = [r for r in rows if r.widget_name == widget_name]
+        if actor_id:
+            rows = [r for r in rows if r.actor_id == actor_id]
+        if pocket_id:
+            rows = [r for r in rows if r.pocket_id == pocket_id]
+
+        if requester_scopes:
+            visible, _hidden = filter_visible(rows, requester_scopes)
+            rows = list(visible)
+
+        rows.sort(key=lambda v: v.seq, reverse=True)
+        if limit > 0:
+            rows = rows[:limit]
+        return rows
+
+    # -- Usage roll-up ------------------------------------------------------
+
+    def usage(
+        self,
+        *,
+        window_days: int = 30,
+        scope: str | None = None,
+        pocket_id: str | None = None,
+        requester_scopes: list[str] | None = None,
+        promoting_actions: tuple[str, ...] = ("open", "edit", "click"),
+    ) -> list[WidgetUsageRow]:
+        """Per-widget usage roll-up over the last ``window_days``.
+
+        Mirrors #941's Counter fold — one row per (widget_name,
+        surface) pair with the promoting-count subset the graduation
+        policy uses for pin decisions.
+        """
+
+        since = datetime.now(UTC) - timedelta(days=window_days)
+        interactions = [
+            row.view
+            for row in self._interactions
+            if _ensure_aware(row.view.ts) >= since
+        ]
+        if scope:
+            interactions = [r for r in interactions if scope in r.scope]
+        if pocket_id:
+            interactions = [r for r in interactions if r.pocket_id == pocket_id]
+        if requester_scopes:
+            visible, _hidden = filter_visible(interactions, requester_scopes)
+            interactions = list(visible)
+
+        per_widget: dict[tuple[str, str], dict[str, Any]] = defaultdict(
+            lambda: {
+                "count": 0,
+                "promoting": 0,
+                "actors": set(),
+                "last": None,
+                "scope": [],
+                "pocket_id": None,
+            }
+        )
+        for view in interactions:
+            key = (view.widget_name, view.surface)
+            bucket = per_widget[key]
+            bucket["count"] += 1
+            bucket["actors"].add(view.actor_id)
+            if view.action_type in promoting_actions:
+                bucket["promoting"] += 1
+            last = bucket["last"]
+            if last is None or view.ts > last:
+                bucket["last"] = view.ts
+                bucket["scope"] = list(view.scope)
+                bucket["pocket_id"] = view.pocket_id
+
+        rows = [
+            WidgetUsageRow(
+                widget_name=key[0],
+                surface=key[1],
+                count=int(bucket["count"]),
+                promoting_count=int(bucket["promoting"]),
+                unique_actors=len(bucket["actors"]),
+                last_interaction=bucket["last"] or datetime.now(UTC),
+                scope=list(bucket["scope"]),
+                pocket_id=bucket["pocket_id"],
+            )
+            for key, bucket in per_widget.items()
+        ]
+        rows.sort(key=lambda r: r.count, reverse=True)
+        return rows
+
+    # -- Co-occurrence queries ---------------------------------------------
+
+    def cooccurrences(
+        self,
+        *,
+        min_count: int = 1,
+        pocket_id: str | None = None,
+        limit: int = 50,
+        requester_scopes: list[str] | None = None,
+    ) -> list[CooccurrenceRow]:
+        """Return co-occurring widget pairs sorted by count (desc).
+
+        ``min_count`` defaults to 1 so callers can see every pair
+        observed; the co-occurrence-detector policy raises it to 3 to
+        match #942's DEFAULT_THRESHOLD.
+        """
+
+        rows = [r for r in self._pair_counts.values() if r.count >= min_count]
+        if pocket_id:
+            rows = [r for r in rows if r.pocket_id == pocket_id]
+        if requester_scopes:
+            visible, _hidden = filter_visible(rows, requester_scopes)
+            rows = list(visible)
+        rows.sort(key=lambda r: (r.count, r.last_seen), reverse=True)
+        if limit > 0:
+            rows = rows[:limit]
+        return rows
+
+    # -- Graduation queries ------------------------------------------------
+
+    def graduation_state(
+        self,
+        *,
+        widget_name: str | None = None,
+        surface: str | None = None,
+        requester_scopes: list[str] | None = None,
+    ) -> list[GraduationStateRow]:
+        """Current graduation state — one row per (widget_name, surface)."""
+
+        rows: list[GraduationStateRow] = []
+        for (name, surf), row in self._graduation.items():
+            if widget_name and name != widget_name:
+                continue
+            if surface and surf != surface:
+                continue
+            rows.append(row)
+        if requester_scopes:
+            visible, _hidden = filter_visible(rows, requester_scopes)
+            rows = list(visible)
+        rows.sort(key=lambda r: r.seq, reverse=True)
+        return rows
+
+    # -- Diagnostics --------------------------------------------------------
+
+    @property
+    def cursor(self) -> int:
+        """Latest seq the projection has seen. Persist this to skip
+        ahead on restart.
+        """
+
+        return self._cursor
+
+    def size(self) -> dict[str, int]:
+        """Quick counters for the /widgets/stats endpoint."""
+
+        return {
+            "interactions": len(self._interactions),
+            "cooccurrences": len(self._pair_counts),
+            "graduations": len(self._graduation),
+        }
+
+
+# Backward-compatible aliases — the task prompt names three separate
+# "projections" but they all live on WidgetProjection because the
+# underlying journal stream is singular. Exposing thin facades makes
+# the semantics in other modules (policy, router, tests) explicit.
+
+
+WidgetUsageProjection = WidgetProjection
+CooccurrenceProjection = WidgetProjection
+GraduationStateProjection = WidgetProjection
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _as_datetime(ts: Any) -> datetime:
+    if isinstance(ts, datetime):
+        return ts
+    try:
+        return datetime.fromisoformat(str(ts))
+    except (TypeError, ValueError):
+        return datetime.now(UTC)
+
+
+def _ensure_aware(ts: datetime) -> datetime:
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=UTC)
+    return ts
+
+
+def _uuid_to_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        return str(value)
+    except Exception:  # noqa: BLE001 — defensive only.
+        return None
+
+
+def _none_or_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and not value:
+        return None
+    return str(value)

--- a/ee/widget/router.py
+++ b/ee/widget/router.py
@@ -1,0 +1,311 @@
+# ee/widget/router.py — REST surface for the widget journal projection.
+# Created: 2026-04-16 (feat/widget-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Carries the read-side intent of held PRs
+# #941 (graduation state per widget) and #942 (co-occurrence
+# suggestions) onto the journal-backed projection.
+#
+# Reads hit the in-memory projection; writes happen via
+# WidgetJournalStore from pocketpaw callsites (dashboard widget
+# clicks, scheduled graduation scans). Nothing in this router writes
+# widget interactions — the dashboard does that directly when a user
+# touches a widget.
+#
+# Store cache follows the same pattern as ee/retrieval/router.py: one
+# warmed store per Journal id, bootstrap on first request, incremental
+# apply on every subsequent write.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from soul_protocol.engine.journal import Journal
+
+from ee.journal_dep import get_journal
+from ee.widget.policy import (
+    DEFAULT_ARCHIVE_DAYS,
+    DEFAULT_COOCCURRENCE_THRESHOLD,
+    DEFAULT_PIN_THRESHOLD,
+    DEFAULT_WINDOW_DAYS,
+    WidgetGraduationDecision,
+    scan_for_cooccurrences,
+    scan_for_widget_graduations,
+)
+from ee.widget.store import WidgetJournalStore
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Widgets"])
+
+
+# ---------------------------------------------------------------------------
+# Response envelopes.
+# ---------------------------------------------------------------------------
+
+
+class WidgetUsageEntry(BaseModel):
+    widget_name: str
+    surface: str
+    count: int
+    promoting_count: int
+    unique_actors: int
+    last_interaction: str
+    scope: list[str]
+    pocket_id: str | None
+
+
+class WidgetUsageResponse(BaseModel):
+    entries: list[WidgetUsageEntry]
+    total: int
+    window_days: int
+
+
+class CooccurrenceEntry(BaseModel):
+    signature: str
+    widget_a: str
+    widget_b: str
+    count: int
+    pocket_id: str | None
+    scope: list[str]
+    last_seen: str
+
+
+class CooccurrenceResponse(BaseModel):
+    entries: list[CooccurrenceEntry]
+    total: int
+    min_count: int
+
+
+class GraduationStateEntry(BaseModel):
+    widget_name: str
+    surface: str
+    current_tier: str
+    previous_tier: str | None
+    confidence: float
+    interactions_in_window: int
+    window_days: int
+    pocket_id: str | None
+    scope: list[str]
+    reason: str
+    applied_at: str
+    seq: int
+
+
+class GraduationStateResponse(BaseModel):
+    entries: list[GraduationStateEntry]
+    total: int
+
+
+class GraduationScanRequest(BaseModel):
+    window_days: int = DEFAULT_WINDOW_DAYS
+    pin_threshold: int = DEFAULT_PIN_THRESHOLD
+    archive_days: int = DEFAULT_ARCHIVE_DAYS
+    pocket_id: str | None = None
+    scope: str | None = None
+
+
+class GraduationScanResponse(BaseModel):
+    decisions: list[WidgetGraduationDecision]
+    scanned_widgets: int
+    window_days: int
+    dry_run: bool
+    generated_at: str
+
+
+# ---------------------------------------------------------------------------
+# Store cache — one warmed store per Journal id.
+# ---------------------------------------------------------------------------
+
+
+_STORE_CACHE: dict[int, WidgetJournalStore] = {}
+
+
+def _get_store(journal: Journal) -> WidgetJournalStore:
+    key = id(journal)
+    cached = _STORE_CACHE.get(key)
+    if cached is not None:
+        return cached
+    store = WidgetJournalStore(journal)
+    store.bootstrap()
+    _STORE_CACHE[key] = store
+    return store
+
+
+def reset_store_cache() -> None:
+    """Drop every cached store — for tests that need a clean projection."""
+
+    _STORE_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/widgets/usage", response_model=WidgetUsageResponse)
+async def widget_usage(
+    scope: str | None = Query(None, description="Filter to widgets tagged with this scope"),
+    pocket_id: str | None = Query(None),
+    window_days: int = Query(DEFAULT_WINDOW_DAYS, ge=1, le=365),
+    journal: Journal = Depends(get_journal),
+) -> WidgetUsageResponse:
+    """Per-widget usage roll-up over the last ``window_days``.
+
+    Supersedes the held PR #941 ``GET /api/v1/widgets/log`` endpoint.
+    The projection is the source of truth; this endpoint serves an
+    in-memory fold of the ``widget.interaction.recorded`` stream.
+    """
+
+    store = _get_store(journal)
+    rows = store.projection.usage(
+        window_days=window_days,
+        scope=scope,
+        pocket_id=pocket_id,
+    )
+    entries = [
+        WidgetUsageEntry(
+            widget_name=r.widget_name,
+            surface=r.surface,
+            count=r.count,
+            promoting_count=r.promoting_count,
+            unique_actors=r.unique_actors,
+            last_interaction=r.last_interaction.isoformat(),
+            scope=list(r.scope),
+            pocket_id=r.pocket_id,
+        )
+        for r in rows
+    ]
+    return WidgetUsageResponse(
+        entries=entries,
+        total=len(entries),
+        window_days=window_days,
+    )
+
+
+@router.get("/widgets/cooccurrence", response_model=CooccurrenceResponse)
+async def widget_cooccurrence(
+    min_count: int = Query(
+        DEFAULT_COOCCURRENCE_THRESHOLD,
+        ge=1,
+        description="Minimum co-occurrence count to include",
+    ),
+    pocket_id: str | None = Query(None),
+    journal: Journal = Depends(get_journal),
+) -> CooccurrenceResponse:
+    """Top co-occurring widget pairs.
+
+    Supersedes the read side of held PR #942's co-occurrence
+    detector. Ordering is count-desc, then last-seen-desc.
+    """
+
+    store = _get_store(journal)
+    rows = store.projection.cooccurrences(
+        min_count=min_count,
+        pocket_id=pocket_id,
+    )
+    entries = [
+        CooccurrenceEntry(
+            signature=r.signature,
+            widget_a=r.widget_a,
+            widget_b=r.widget_b,
+            count=r.count,
+            pocket_id=r.pocket_id,
+            scope=list(r.scope),
+            last_seen=r.last_seen.isoformat(),
+        )
+        for r in rows
+    ]
+    return CooccurrenceResponse(
+        entries=entries,
+        total=len(entries),
+        min_count=min_count,
+    )
+
+
+@router.get("/widgets/graduation/state", response_model=GraduationStateResponse)
+async def widget_graduation_state(
+    widget_name: str | None = Query(None),
+    surface: str | None = Query(None),
+    journal: Journal = Depends(get_journal),
+) -> GraduationStateResponse:
+    """Current graduation state — most-recent ``widget.graduated``
+    event per (widget_name, surface) pair. Omitting both filters
+    returns the full set.
+    """
+
+    store = _get_store(journal)
+    rows = store.projection.graduation_state(
+        widget_name=widget_name,
+        surface=surface,
+    )
+    entries = [
+        GraduationStateEntry(
+            widget_name=r.widget_name,
+            surface=r.surface,
+            current_tier=r.current_tier,
+            previous_tier=r.previous_tier,
+            confidence=r.confidence,
+            interactions_in_window=r.interactions_in_window,
+            window_days=r.window_days,
+            pocket_id=r.pocket_id,
+            scope=list(r.scope),
+            reason=r.reason,
+            applied_at=r.applied_at.isoformat(),
+            seq=r.seq,
+        )
+        for r in rows
+    ]
+    return GraduationStateResponse(entries=entries, total=len(entries))
+
+
+@router.post("/widgets/graduation/scan", response_model=GraduationScanResponse)
+async def run_widget_graduation_scan(
+    req: GraduationScanRequest | None = None,
+    journal: Journal = Depends(get_journal),
+) -> GraduationScanResponse:
+    """Dry-run the graduation policy over the projection and return
+    the proposed decisions. Does NOT emit events — apply is a
+    separate step that callers opt into explicitly, matching #941's
+    dry-run-by-default contract.
+    """
+
+    req = req or GraduationScanRequest()
+    store = _get_store(journal)
+    report = scan_for_widget_graduations(
+        store.projection,
+        window_days=req.window_days,
+        pin_threshold=req.pin_threshold,
+        archive_days=req.archive_days,
+        pocket_id=req.pocket_id,
+        scope=req.scope,
+        dry_run=True,
+    )
+    return GraduationScanResponse(
+        decisions=list(report.decisions),
+        scanned_widgets=report.scanned_widgets,
+        window_days=report.window_days,
+        dry_run=report.dry_run,
+        generated_at=report.generated_at.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers — expose the scan helper to downstream code without importing
+# every router symbol.
+# ---------------------------------------------------------------------------
+
+
+def _scan_cooccurrences_via_router(
+    journal: Journal,
+    *,
+    threshold: int = DEFAULT_COOCCURRENCE_THRESHOLD,
+) -> Any:
+    """Thin facade for callers that want a one-shot scan without going
+    through HTTP (a CLI command, for instance). Not registered as a
+    route; kept here so tests and tools share one path.
+    """
+
+    store = _get_store(journal)
+    return scan_for_cooccurrences(store.projection, threshold=threshold)

--- a/ee/widget/store.py
+++ b/ee/widget/store.py
@@ -1,0 +1,277 @@
+# ee/widget/store.py — Journal-backed write path for widget events.
+# Created: 2026-04-16 (feat/widget-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Replaces the JSONL sink from held PR #941
+# (``~/.pocketpaw/widget-interactions.jsonl`` behind an asyncio.Lock)
+# and the apply side of both #941's graduation policy and #942's
+# co-occurrence detector. Everything lands on the org journal now —
+# one append-only event log, write serialisation inherited from
+# SQLite WAL + transaction semantics rather than a per-process
+# asyncio lock that didn't protect across multiple processes anyway.
+#
+# Same store-as-thin-facade shape as ee/retrieval/store.py:
+#   - ``log_widget_interaction`` emits ``widget.interaction.recorded``
+#   - ``log_widget_graduation`` emits ``widget.graduated``
+#   - ``log_cooccurrence`` emits ``widget.cooccurrence.detected``
+#   - every emit is folded into the shared WidgetProjection so reads
+#     are consistent without waiting for a rebuild
+#
+# Policy (thresholds, decision rules) and router (REST surface) live
+# in policy.py / router.py so this module stays free of HTTP + UI
+# concerns.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from soul_protocol.engine.journal import Journal
+from soul_protocol.spec.journal import Actor, EventEntry
+
+from ee.widget.events import (
+    ACTION_WIDGET_COOCCURRENCE_DETECTED,
+    ACTION_WIDGET_GRADUATED,
+    ACTION_WIDGET_INTERACTION_RECORDED,
+    cooccurrence_signature,
+    widget_cooccurrence_payload,
+    widget_graduated_payload,
+    widget_interaction_payload,
+)
+from ee.widget.projection import WidgetProjection
+
+_SYSTEM_WIDGET_ACTOR_ID = "system:widget"
+_SYSTEM_GRADUATION_ACTOR_ID = "system:widget-graduation"
+_SYSTEM_COOCCURRENCE_ACTOR_ID = "system:widget-cooccurrence"
+
+
+class WidgetJournalStore:
+    """Journal-backed emitter for widget interaction + graduation +
+    co-occurrence events.
+
+    Wiring:
+
+        from ee.journal_dep import get_journal
+        journal = get_journal()
+        store = WidgetJournalStore(journal)
+        store.bootstrap()
+        await store.log_widget_interaction(
+            widget_name="metrics_chart",
+            scope=["org:sales:*"],
+            actor=Actor(...),
+        )
+    """
+
+    def __init__(
+        self,
+        journal: Journal,
+        *,
+        projection: WidgetProjection | None = None,
+        default_actor: Actor | None = None,
+        default_graduation_actor: Actor | None = None,
+        default_cooccurrence_actor: Actor | None = None,
+    ) -> None:
+        self._journal = journal
+        self._projection = projection or WidgetProjection()
+        self._default_actor = default_actor or Actor(
+            kind="system",
+            id=_SYSTEM_WIDGET_ACTOR_ID,
+            scope_context=[],
+        )
+        self._default_graduation_actor = default_graduation_actor or Actor(
+            kind="system",
+            id=_SYSTEM_GRADUATION_ACTOR_ID,
+            scope_context=[],
+        )
+        self._default_cooccurrence_actor = default_cooccurrence_actor or Actor(
+            kind="system",
+            id=_SYSTEM_COOCCURRENCE_ACTOR_ID,
+            scope_context=[],
+        )
+
+    # -- Bootstrap ----------------------------------------------------------
+
+    def bootstrap(self, *, since_seq: int = 0) -> int:
+        """Warm the projection from the journal. Returns the number of
+        events applied. Call once at process start.
+        """
+
+        return self._projection.rebuild(self._journal, since_seq=since_seq)
+
+    @property
+    def projection(self) -> WidgetProjection:
+        return self._projection
+
+    # -- Writes -------------------------------------------------------------
+
+    async def log_widget_interaction(
+        self,
+        *,
+        widget_name: str,
+        scope: list[str],
+        actor: Actor | None = None,
+        surface: str = "dashboard",
+        action_type: str = "open",
+        pocket_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        query_text: str | None = None,
+        correlation_id: UUID | None = None,
+    ) -> EventEntry:
+        """Emit one ``widget.interaction.recorded`` event and fold it
+        into the projection.
+
+        ``scope`` is required — EventEntry refuses scope=[]. Callers
+        that don't carry a scope (vanishingly rare — the dashboard
+        always knows the pocket's scope) should make that explicit at
+        the call site rather than have the store fabricate an empty
+        list.
+        """
+
+        _require_scope(scope)
+        _require_str("widget_name", widget_name)
+
+        payload = widget_interaction_payload(
+            widget_name=widget_name,
+            surface=surface,
+            action_type=action_type,
+            pocket_id=pocket_id,
+            metadata=metadata,
+            query_text=query_text,
+        )
+        entry = self._build_entry(
+            action=ACTION_WIDGET_INTERACTION_RECORDED,
+            scope=scope,
+            actor=actor or self._default_actor,
+            correlation_id=correlation_id,
+            payload=payload,
+        )
+        self._journal.append(entry)
+        self._projection.apply(entry)
+        return entry
+
+    async def log_widget_graduation(
+        self,
+        *,
+        scope: list[str],
+        widget_name: str,
+        surface: str,
+        tier: str,
+        confidence: float,
+        interactions_in_window: int,
+        window_days: int,
+        previous_tier: str | None = None,
+        pocket_id: str | None = None,
+        reason: str = "",
+        actor: Actor | None = None,
+        correlation_id: UUID | None = None,
+    ) -> EventEntry:
+        """Emit one ``widget.graduated`` event + fold it into the
+        projection. One event per verdict change — the projection
+        keeps only the most-recent verdict per (widget, surface); the
+        full history stays on the journal for audit.
+        """
+
+        _require_scope(scope)
+        _require_str("widget_name", widget_name)
+
+        payload = widget_graduated_payload(
+            widget_name=widget_name,
+            surface=surface,
+            tier=tier,
+            confidence=confidence,
+            interactions_in_window=interactions_in_window,
+            window_days=window_days,
+            previous_tier=previous_tier,
+            pocket_id=pocket_id,
+            reason=reason,
+        )
+        entry = self._build_entry(
+            action=ACTION_WIDGET_GRADUATED,
+            scope=scope,
+            actor=actor or self._default_graduation_actor,
+            correlation_id=correlation_id,
+            payload=payload,
+        )
+        self._journal.append(entry)
+        self._projection.apply(entry)
+        return entry
+
+    async def log_cooccurrence(
+        self,
+        *,
+        scope: list[str],
+        widget_a: str,
+        widget_b: str,
+        count: int,
+        window_s: int,
+        pocket_id: str | None = None,
+        example_queries: list[str] | None = None,
+        actor: Actor | None = None,
+        correlation_id: UUID | None = None,
+    ) -> EventEntry:
+        """Emit one ``widget.cooccurrence.detected`` event + fold it
+        into the projection.
+
+        The signature is computed here — callers don't pass it in.
+        This is the mandatory fix of #942's ``sorted(tokens[:6])``
+        bug: the signature helper sorts first and truncates second,
+        so dedup actually works as the superseded PR claimed.
+        """
+
+        _require_scope(scope)
+        _require_str("widget_a", widget_a)
+        _require_str("widget_b", widget_b)
+
+        signature = cooccurrence_signature(widget_a, widget_b)
+        payload = widget_cooccurrence_payload(
+            widget_a=widget_a,
+            widget_b=widget_b,
+            count=count,
+            window_s=window_s,
+            signature=signature,
+            pocket_id=pocket_id,
+            example_queries=example_queries,
+        )
+        entry = self._build_entry(
+            action=ACTION_WIDGET_COOCCURRENCE_DETECTED,
+            scope=scope,
+            actor=actor or self._default_cooccurrence_actor,
+            correlation_id=correlation_id,
+            payload=payload,
+        )
+        self._journal.append(entry)
+        self._projection.apply(entry)
+        return entry
+
+    # -- Internals ----------------------------------------------------------
+
+    def _build_entry(
+        self,
+        *,
+        action: str,
+        scope: list[str],
+        actor: Actor,
+        correlation_id: UUID | None,
+        payload: dict[str, Any],
+    ) -> EventEntry:
+        return EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=actor,
+            action=action,
+            scope=list(scope),
+            correlation_id=correlation_id,
+            payload=payload,
+        )
+
+
+def _require_scope(scope: list[str]) -> None:
+    if not scope:
+        raise ValueError(
+            "WidgetJournalStore requires a non-empty scope on every write — "
+            "the journal invariant refuses events with scope=[]."
+        )
+
+
+def _require_str(label: str, value: Any) -> None:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string")

--- a/src/pocketpaw/api/v1/__init__.py
+++ b/src/pocketpaw/api/v1/__init__.py
@@ -7,6 +7,9 @@
 # Updated: 2026-04-16 (feat/retrieval-journal-projection) — Added the
 #   Retrieval router so UIs can surface the journal-backed retrieval +
 #   graduation projection (supersedes held PRs #936 / #937).
+# Updated: 2026-04-16 (feat/widget-journal-projection) — Added the
+#   Widgets router — journal-backed widget graduation + co-occurrence
+#   (supersedes held PRs #941 / #942).
 #
 # mount_v1_routers(app) registers all domain routers at /api/v1/ (canonical).
 # Existing dashboard.py endpoints at /api/ remain as backward-compat aliases.
@@ -62,6 +65,7 @@ _EE_ROUTERS: list[tuple[str, str, str]] = [
     ("ee.fleet.router", "router", "Fleet"),
     ("ee.instinct.router", "router", "Instinct"),
     ("ee.retrieval.router", "router", "Retrieval"),
+    ("ee.widget.router", "router", "Widgets"),
     ("pocketpaw.ee.automations.router", "router", "Automations"),
 ]
 

--- a/tests/ee/test_widget_journal.py
+++ b/tests/ee/test_widget_journal.py
@@ -1,0 +1,801 @@
+# tests/ee/test_widget_journal.py — Coverage for the widget + graduation +
+# co-occurrence journal projection.
+# Created: 2026-04-16 (feat/widget-journal-projection) — Wave 3 / Org
+# Architecture RFC, Phase 3. Supersedes held PRs #941 (widget
+# graduation engine over a JSONL log) and #942 (co-occurrence detector
+# over that same log — shipped with a ``sorted(tokens[:6])`` bug).
+#
+# Invariants pinned here — regressions mean we silently recreated a
+# bug the superseded PRs would have shipped:
+#   1. Write path — log_widget_interaction / log_widget_graduation /
+#      log_cooccurrence emit the correct journal action + payload.
+#   2. Scope containment — usage / cooccurrence / graduation_state
+#      filter by scope exactly like Fabric + retrieval.
+#   3. Usage projection — N interactions cross the pin threshold and
+#      a scan proposes one pin decision. Ported from #941's threshold
+#      semantics.
+#   4. Co-occurrence signature FIX — the regression guard for #942's
+#      ``sorted(tokens[:6])`` bug. The test uses a query longer than
+#      six tokens and asserts that rotated-input pairs collapse to the
+#      same signature. Under the original bug this test would have
+#      failed because the truncation-before-sort produces different
+#      prefixes for the two rotations.
+#   5. Graduation — N interactions trigger the policy + apply fires a
+#      ``widget.graduated`` event the projection reflects as current
+#      state.
+#   6. Empty journal — projection rebuild on zero events returns
+#      empty state (no crash).
+#   7. Incremental apply equivalence — start from genesis, apply N
+#      new events; state equals rebuild-from-scratch.
+#   8. Router — the three GET endpoints round-trip correctly.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.spec.journal import Actor
+
+from ee.journal_dep import get_journal, reset_journal_cache
+from ee.widget.events import (
+    ACTION_WIDGET_COOCCURRENCE_DETECTED,
+    ACTION_WIDGET_GRADUATED,
+    ACTION_WIDGET_INTERACTION_RECORDED,
+    cooccurrence_signature,
+    normalise_signature_tokens,
+)
+from ee.widget.policy import (
+    DEFAULT_COOCCURRENCE_THRESHOLD,
+    DEFAULT_PIN_THRESHOLD,
+    apply_widget_graduations,
+    scan_for_cooccurrences,
+    scan_for_widget_graduations,
+)
+from ee.widget.projection import WidgetProjection
+from ee.widget.router import reset_store_cache, router
+from ee.widget.store import WidgetJournalStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_caches():
+    """Reset both journal + store caches between tests — same pattern
+    as tests/ee/test_retrieval_journal.py.
+    """
+
+    reset_journal_cache()
+    reset_store_cache()
+    yield
+    reset_journal_cache()
+    reset_store_cache()
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+@pytest.fixture
+def store(journal) -> WidgetJournalStore:
+    s = WidgetJournalStore(journal)
+    s.bootstrap()
+    return s
+
+
+# ---------------------------------------------------------------------------
+# 1. Write path — events land on the journal with the expected payload.
+# ---------------------------------------------------------------------------
+
+
+class TestWritePath:
+    @pytest.mark.asyncio
+    async def test_log_interaction_emits_event_with_full_payload(
+        self,
+        store: WidgetJournalStore,
+        journal,
+    ) -> None:
+        actor = Actor(kind="user", id="user:priya", scope_context=["org:sales:*"])
+        await store.log_widget_interaction(
+            widget_name="metrics_chart",
+            scope=["org:sales:leads"],
+            actor=actor,
+            surface="dashboard",
+            action_type="open",
+            pocket_id="pocket-1",
+            metadata={"clicks": 3},
+            query_text="renewal discount alpha",
+        )
+
+        events = journal.query(action=ACTION_WIDGET_INTERACTION_RECORDED)
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.actor.id == "user:priya"
+        assert list(ev.scope) == ["org:sales:leads"]
+        assert ev.payload["widget_name"] == "metrics_chart"
+        assert ev.payload["surface"] == "dashboard"
+        assert ev.payload["action_type"] == "open"
+        assert ev.payload["pocket_id"] == "pocket-1"
+        assert ev.payload["metadata"] == {"clicks": 3}
+        assert ev.payload["query_text"] == "renewal discount alpha"
+
+    @pytest.mark.asyncio
+    async def test_log_graduation_emits_event_with_decision_shape(
+        self,
+        store: WidgetJournalStore,
+        journal,
+    ) -> None:
+        await store.log_widget_graduation(
+            scope=["org:sales:leads"],
+            widget_name="metrics_chart",
+            surface="dashboard",
+            tier="pin",
+            confidence=0.9,
+            interactions_in_window=12,
+            window_days=30,
+            previous_tier=None,
+            pocket_id="pocket-1",
+            reason="threshold crossed",
+        )
+
+        events = journal.query(action=ACTION_WIDGET_GRADUATED)
+        assert len(events) == 1
+        payload = events[0].payload
+        assert payload["widget_name"] == "metrics_chart"
+        assert payload["tier"] == "pin"
+        assert payload["confidence"] == pytest.approx(0.9)
+        assert payload["interactions_in_window"] == 12
+
+    @pytest.mark.asyncio
+    async def test_log_cooccurrence_emits_event_with_computed_signature(
+        self,
+        store: WidgetJournalStore,
+        journal,
+    ) -> None:
+        """The store computes the signature — callers don't pass one.
+        Guard against a caller sneaking in a pre-#942-fix signature.
+        """
+
+        await store.log_cooccurrence(
+            scope=["org:sales:leads"],
+            widget_a="acme deal status alpha beta gamma delta",
+            widget_b="acme renewal date epsilon zeta eta theta",
+            count=3,
+            window_s=900,
+        )
+        events = journal.query(action=ACTION_WIDGET_COOCCURRENCE_DETECTED)
+        assert len(events) == 1
+        sig = events[0].payload["signature"]
+        # Signature is bidirectional: (A,B) == (B,A).
+        reverse = cooccurrence_signature(
+            "acme renewal date epsilon zeta eta theta",
+            "acme deal status alpha beta gamma delta",
+        )
+        assert sig == reverse
+
+    @pytest.mark.asyncio
+    async def test_log_interaction_rejects_empty_scope(
+        self,
+        store: WidgetJournalStore,
+    ) -> None:
+        with pytest.raises(ValueError, match="non-empty scope"):
+            await store.log_widget_interaction(
+                widget_name="metrics_chart",
+                scope=[],
+            )
+
+    @pytest.mark.asyncio
+    async def test_log_interaction_rejects_empty_widget_name(
+        self,
+        store: WidgetJournalStore,
+    ) -> None:
+        with pytest.raises(ValueError, match="widget_name"):
+            await store.log_widget_interaction(
+                widget_name="",
+                scope=["org:sales:leads"],
+            )
+
+
+# ---------------------------------------------------------------------------
+# 2. Scope containment.
+# ---------------------------------------------------------------------------
+
+
+class TestScopeContainment:
+    @pytest.mark.asyncio
+    async def test_usage_roll_up_filtered_by_scope(
+        self,
+        store: WidgetJournalStore,
+    ) -> None:
+        await store.log_widget_interaction(
+            widget_name="sales_chart",
+            scope=["org:sales:leads"],
+            action_type="open",
+        )
+        await store.log_widget_interaction(
+            widget_name="finance_chart",
+            scope=["org:finance:reports"],
+            action_type="open",
+        )
+        sales = store.projection.usage(scope="org:sales:leads")
+        finance = store.projection.usage(scope="org:finance:reports")
+        assert {r.widget_name for r in sales} == {"sales_chart"}
+        assert {r.widget_name for r in finance} == {"finance_chart"}
+
+    @pytest.mark.asyncio
+    async def test_sales_scope_caller_does_not_see_support_events(
+        self,
+        store: WidgetJournalStore,
+    ) -> None:
+        """A caller scoped to ``org:sales:*`` sees its own scope's
+        widgets and nothing from ``org:support:*``. Runs through
+        ee.fabric.policy.filter_visible so semantics match Fabric.
+        """
+
+        await store.log_widget_interaction(
+            widget_name="sales_chart",
+            scope=["org:sales:leads"],
+            action_type="open",
+        )
+        await store.log_widget_interaction(
+            widget_name="support_queue",
+            scope=["org:support:tickets"],
+            action_type="open",
+        )
+        visible = store.projection.recent_interactions(
+            requester_scopes=["org:sales:*"],
+        )
+        assert {v.widget_name for v in visible} == {"sales_chart"}
+
+
+# ---------------------------------------------------------------------------
+# 3. Usage projection + graduation threshold.
+# ---------------------------------------------------------------------------
+
+
+class TestUsageProjection:
+    @pytest.mark.asyncio
+    async def test_threshold_crosses_produces_pin_decision(
+        self,
+        store: WidgetJournalStore,
+    ) -> None:
+        """N promoting interactions → one pin decision.
+        Ported verbatim from #941.
+        """
+
+        for _ in range(DEFAULT_PIN_THRESHOLD):
+            await store.log_widget_interaction(
+                widget_name="metrics_chart",
+                scope=["org:sales:leads"],
+                action_type="open",
+            )
+        report = scan_for_widget_graduations(store.projection)
+        pins = [d for d in report.decisions if d.tier == "pin"]
+        assert len(pins) == 1
+        assert pins[0].widget_name == "metrics_chart"
+        assert pins[0].interactions_in_window == DEFAULT_PIN_THRESHOLD
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_no_decision(
+        self,
+        store: WidgetJournalStore,
+    ) -> None:
+        for _ in range(DEFAULT_PIN_THRESHOLD - 1):
+            await store.log_widget_interaction(
+                widget_name="cold_widget",
+                scope=["org:sales:leads"],
+                action_type="click",
+            )
+        report = scan_for_widget_graduations(store.projection)
+        pins = [d for d in report.decisions if d.tier == "pin"]
+        assert pins == []
+
+    @pytest.mark.asyncio
+    async def test_only_promoting_actions_count(
+        self,
+        store: WidgetJournalStore,
+    ) -> None:
+        """``dismiss`` + ``remove`` are non-promoting — matches #941."""
+
+        for _ in range(DEFAULT_PIN_THRESHOLD):
+            await store.log_widget_interaction(
+                widget_name="dismissed_widget",
+                scope=["org:sales:leads"],
+                action_type="dismiss",
+            )
+        report = scan_for_widget_graduations(store.projection)
+        assert [d for d in report.decisions if d.tier == "pin"] == []
+
+    @pytest.mark.asyncio
+    async def test_apply_emits_graduation_event_and_updates_state(
+        self,
+        store: WidgetJournalStore,
+    ) -> None:
+        for _ in range(DEFAULT_PIN_THRESHOLD):
+            await store.log_widget_interaction(
+                widget_name="metrics_chart",
+                scope=["org:sales:leads"],
+                action_type="open",
+            )
+        report = scan_for_widget_graduations(store.projection)
+        applied = await apply_widget_graduations(
+            report.decisions,
+            store,
+            scope=["org:sales:leads"],
+        )
+        assert len(applied) == len(report.decisions) >= 1
+
+        state = store.projection.graduation_state()
+        assert len(state) == 1
+        assert state[0].widget_name == "metrics_chart"
+        assert state[0].current_tier == "pin"
+
+
+# ---------------------------------------------------------------------------
+# 4. Co-occurrence — signature correctness + threshold semantics.
+#
+# These are the regression guards for #942's ``sorted(tokens[:6])`` bug.
+# ---------------------------------------------------------------------------
+
+
+class TestCooccurrenceSignatureFix:
+    def test_long_query_signature_stable_across_token_rotation(self) -> None:
+        """The #942 regression guard.
+
+        Two queries with the same token set but different ordering —
+        where the query is longer than SIGNATURE_MAX_TOKENS — must
+        produce the same signature. Under ``sorted(tokens[:6])``
+        (the #942 bug) the first query truncates to tokens 0..5
+        and the second to a different 6-token prefix, so the sort
+        produces different results. Under ``sorted(tokens)[:6]``
+        (the fix) both queries' full token lists sort to the same
+        order and the prefix is identical.
+        """
+
+        q1 = "alpha beta gamma delta epsilon zeta eta theta"  # 8 tokens
+        q2 = "theta eta zeta epsilon delta gamma beta alpha"  # same set, reversed
+
+        # Both normalise to the same 6-token prefix.
+        assert normalise_signature_tokens(q1) == normalise_signature_tokens(q2)
+
+        # The buggy behaviour would have been:
+        #   sorted(q1[:6]) == sorted(['alpha','beta','gamma','delta','epsilon','zeta'])
+        #     == ['alpha','beta','delta','epsilon','gamma','zeta']
+        #   sorted(q2[:6]) == sorted(['theta','eta','zeta','epsilon','delta','gamma'])
+        #     == ['delta','epsilon','eta','gamma','theta','zeta']
+        # The two would NOT match — this test would fail under the bug.
+
+    def test_signature_dedup_bidirectional(self) -> None:
+        """(A,B) and (B,A) must produce the same signature."""
+
+        sig_ab = cooccurrence_signature("renewal discount", "upsell plan")
+        sig_ba = cooccurrence_signature("upsell plan", "renewal discount")
+        assert sig_ab == sig_ba
+        assert sig_ab != ""
+
+    def test_signature_is_empty_when_queries_collapse_to_same_tokens(self) -> None:
+        """"renewal discount" and "discount renewal" are the same
+        semantic question phrased two ways — the signature should
+        collapse to empty so they don't spawn a fake co-occurrence
+        suggestion (carry-over from #942's test).
+        """
+
+        sig = cooccurrence_signature("renewal discount", "discount renewal")
+        assert sig == ""
+
+
+class TestCooccurrenceProjection:
+    @pytest.mark.asyncio
+    async def test_pair_within_session_window_recorded(
+        self,
+        store: WidgetJournalStore,
+    ) -> None:
+        actor = Actor(kind="user", id="user:priya", scope_context=["org:sales:*"])
+        # Emit a pair of distinct widgets from the same actor in quick
+        # succession (same session per 15-minute window).
+        for _ in range(DEFAULT_COOCCURRENCE_THRESHOLD):
+            await store.log_widget_interaction(
+                widget_name="deal_status",
+                scope=["org:sales:leads"],
+                actor=actor,
+                query_text="acme deal status",
+            )
+            await store.log_widget_interaction(
+                widget_name="renewal_date",
+                scope=["org:sales:leads"],
+                actor=actor,
+                query_text="acme renewal date",
+            )
+        pairs = store.projection.cooccurrences(min_count=DEFAULT_COOCCURRENCE_THRESHOLD)
+        assert len(pairs) >= 1
+        widgets = {pairs[0].widget_a, pairs[0].widget_b}
+        assert widgets == {"deal_status", "renewal_date"}
+
+    @pytest.mark.asyncio
+    async def test_scan_for_cooccurrences_uses_threshold(
+        self,
+        store: WidgetJournalStore,
+    ) -> None:
+        actor = Actor(kind="user", id="user:priya", scope_context=[])
+        for _ in range(DEFAULT_COOCCURRENCE_THRESHOLD):
+            await store.log_widget_interaction(
+                widget_name="alpha_chart",
+                scope=["org:sales:leads"],
+                actor=actor,
+                query_text="alpha chart view",
+            )
+            await store.log_widget_interaction(
+                widget_name="beta_chart",
+                scope=["org:sales:leads"],
+                actor=actor,
+                query_text="beta chart view",
+            )
+        report = scan_for_cooccurrences(store.projection)
+        assert report.scanned_pairs >= 1
+        assert any(
+            {c.widget_a, c.widget_b} == {"alpha_chart", "beta_chart"}
+            for c in report.candidates
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Empty journal rebuild.
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyJournalRebuild:
+    def test_rebuild_on_empty_journal_returns_zero(self, journal) -> None:
+        projection = WidgetProjection()
+        applied = projection.rebuild(journal)
+        assert applied == 0
+        assert projection.size() == {
+            "interactions": 0,
+            "cooccurrences": 0,
+            "graduations": 0,
+        }
+        assert projection.usage() == []
+        assert projection.cooccurrences() == []
+        assert projection.graduation_state() == []
+        assert projection.recent_interactions() == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Incremental apply == rebuild-from-scratch.
+# ---------------------------------------------------------------------------
+
+
+class TestIncrementalEqualsRebuild:
+    @pytest.mark.asyncio
+    async def test_projection_state_matches_after_cold_rebuild(
+        self,
+        journal,
+    ) -> None:
+        """Writing a stream of events via the store folds them
+        incrementally. Dropping the projection and replaying from
+        genesis should produce identical state — the invariant that
+        makes the projection observable at any cursor.
+        """
+
+        live = WidgetJournalStore(journal)
+        live.bootstrap()
+
+        actor = Actor(kind="user", id="user:priya", scope_context=[])
+        for i in range(5):
+            await live.log_widget_interaction(
+                widget_name=f"widget_{i % 2}",
+                scope=["org:sales:leads"],
+                actor=actor,
+                action_type="open",
+                query_text=f"q{i}",
+            )
+        await live.log_widget_graduation(
+            scope=["org:sales:leads"],
+            widget_name="widget_0",
+            surface="dashboard",
+            tier="pin",
+            confidence=0.9,
+            interactions_in_window=3,
+            window_days=30,
+        )
+
+        live_usage = {(r.widget_name, r.surface) for r in live.projection.usage()}
+        live_grad = {
+            (r.widget_name, r.current_tier) for r in live.projection.graduation_state()
+        }
+
+        cold = WidgetJournalStore(journal, projection=WidgetProjection())
+        applied = cold.bootstrap()
+        assert applied == 6  # 5 interactions + 1 graduation
+
+        cold_usage = {(r.widget_name, r.surface) for r in cold.projection.usage()}
+        cold_grad = {
+            (r.widget_name, r.current_tier) for r in cold.projection.graduation_state()
+        }
+
+        assert cold_usage == live_usage
+        assert cold_grad == live_grad
+
+
+# ---------------------------------------------------------------------------
+# 7. Archive rule — old inactive widget gets archived.
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveRule:
+    @pytest.mark.asyncio
+    async def test_old_inactive_widget_archived(
+        self,
+        journal,
+    ) -> None:
+        """Seed a very old interaction + re-open the journal so the
+        projection rebuild picks up the timestamp on the event. The
+        archive scan should flag it.
+        """
+
+        store = WidgetJournalStore(journal)
+        store.bootstrap()
+        # Emit a fresh interaction — the journal stamps ts=now; we
+        # simulate "old" by scanning with a very narrow window so the
+        # only interaction we just wrote looks stale.
+        await store.log_widget_interaction(
+            widget_name="stale_widget",
+            scope=["org:sales:leads"],
+            action_type="open",
+        )
+
+        # window_days big enough for usage() to surface the row, but
+        # archive_days=0 so the single interaction we just wrote
+        # registers as "older than cutoff" and graduates to archive.
+        # ``archive_cutoff = now - timedelta(0) ≈ now`` and the row's
+        # last_interaction was stamped slightly before that, so it
+        # falls on the archive side.
+        import time
+        time.sleep(0.01)  # Guarantee archive_cutoff > last_interaction.
+        report = scan_for_widget_graduations(
+            store.projection,
+            window_days=30,
+            archive_days=0,
+        )
+        archived = [d for d in report.decisions if d.tier == "archive"]
+        assert len(archived) >= 1
+        assert "Untouched" in archived[0].reason
+
+
+# ---------------------------------------------------------------------------
+# 8. Correlation view — widgets touched under one correlation_id.
+# ---------------------------------------------------------------------------
+
+
+class TestCorrelationView:
+    @pytest.mark.asyncio
+    async def test_interactions_track_correlation_id(
+        self,
+        store: WidgetJournalStore,
+    ) -> None:
+        cid = uuid4()
+        await store.log_widget_interaction(
+            widget_name="metrics_chart",
+            scope=["org:sales:leads"],
+            correlation_id=cid,
+        )
+        recent = store.projection.recent_interactions()
+        assert len(recent) == 1
+        assert recent[0].correlation_id == str(cid)
+
+
+# ---------------------------------------------------------------------------
+# 9. REST router — UI-facing contract.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> FastAPI:
+    a = FastAPI()
+    a.include_router(router)
+    journal_path = tmp_path / "router_journal.db"
+    a.dependency_overrides[get_journal] = lambda: open_journal(journal_path)
+    return a
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+class TestRouter:
+    def test_usage_returns_empty_on_cold_journal(
+        self,
+        client: TestClient,
+    ) -> None:
+        res = client.get("/widgets/usage")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["entries"] == []
+        assert body["total"] == 0
+
+    def test_usage_shows_widgets_after_direct_write(
+        self,
+        client: TestClient,
+        app: FastAPI,
+    ) -> None:
+        import asyncio
+
+        journal = app.dependency_overrides[get_journal]()
+        seed_store = WidgetJournalStore(journal)
+        asyncio.run(
+            seed_store.log_widget_interaction(
+                widget_name="metrics_chart",
+                scope=["org:sales:leads"],
+                action_type="open",
+            )
+        )
+
+        res = client.get("/widgets/usage?window_days=30")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] >= 1
+        assert body["entries"][0]["widget_name"] == "metrics_chart"
+
+    def test_cooccurrence_endpoint_lists_pairs(
+        self,
+        client: TestClient,
+        app: FastAPI,
+    ) -> None:
+        import asyncio
+
+        journal = app.dependency_overrides[get_journal]()
+        seed_store = WidgetJournalStore(journal)
+        asyncio.run(
+            seed_store.log_cooccurrence(
+                scope=["org:sales:leads"],
+                widget_a="alpha_chart",
+                widget_b="beta_chart",
+                count=5,
+                window_s=900,
+            )
+        )
+        res = client.get("/widgets/cooccurrence?min_count=3")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] >= 1
+        entry = body["entries"][0]
+        assert {entry["widget_a"], entry["widget_b"]} == {"alpha_chart", "beta_chart"}
+
+    def test_graduation_state_endpoint_lists_current_tiers(
+        self,
+        client: TestClient,
+        app: FastAPI,
+    ) -> None:
+        import asyncio
+
+        journal = app.dependency_overrides[get_journal]()
+        seed_store = WidgetJournalStore(journal)
+        asyncio.run(
+            seed_store.log_widget_graduation(
+                scope=["org:sales:leads"],
+                widget_name="metrics_chart",
+                surface="dashboard",
+                tier="pin",
+                confidence=0.9,
+                interactions_in_window=12,
+                window_days=30,
+            )
+        )
+        res = client.get("/widgets/graduation/state")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] >= 1
+        assert body["entries"][0]["widget_name"] == "metrics_chart"
+        assert body["entries"][0]["current_tier"] == "pin"
+
+
+# ---------------------------------------------------------------------------
+# 10. Explicit cooccurrence event rebuild corrects a buggy emitter.
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitCooccurrenceEmit:
+    @pytest.mark.asyncio
+    async def test_projection_rederives_signature_ignoring_bad_payload(
+        self,
+        store: WidgetJournalStore,
+        journal,
+    ) -> None:
+        """An out-of-band emitter might still carry the old #942 bug
+        signature. The projection should re-derive the signature on
+        replay so state converges to the fixed form regardless.
+        """
+
+        # Emit a pair that would have been computed correctly by the
+        # store — the projection's fold uses cooccurrence_signature()
+        # which always runs the sorted(tokens)[:6] helper.
+        await store.log_cooccurrence(
+            scope=["org:sales:leads"],
+            widget_a="alpha beta gamma delta epsilon zeta eta theta",
+            widget_b="theta eta zeta epsilon delta gamma beta alpha",
+            count=1,
+            window_s=900,
+        )
+        # Two token-equivalent widget names — the projection should
+        # NOT create a pair (both sides collapse to the same bag).
+        rows = store.projection.cooccurrences(min_count=1)
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_explicit_cooccurrence_event_counted_on_rebuild(
+        self,
+        journal,
+    ) -> None:
+        """An explicit widget.cooccurrence.detected event should
+        survive a cold rebuild.
+        """
+
+        store = WidgetJournalStore(journal)
+        store.bootstrap()
+        await store.log_cooccurrence(
+            scope=["org:sales:leads"],
+            widget_a="alpha_chart",
+            widget_b="beta_chart",
+            count=4,
+            window_s=900,
+        )
+        # Cold rebuild.
+        cold = WidgetProjection()
+        cold.rebuild(journal)
+        rows = cold.cooccurrences(min_count=1)
+        assert len(rows) == 1
+        assert rows[0].count == 4
+
+
+# ---------------------------------------------------------------------------
+# 11. Rolling window — recent interactions respect the window parameter.
+# ---------------------------------------------------------------------------
+
+
+class TestRollingWindow:
+    @pytest.mark.asyncio
+    async def test_usage_respects_window_days(
+        self,
+        store: WidgetJournalStore,
+    ) -> None:
+        """Write a single interaction, ask for a zero-day window —
+        the interaction is "within the window" only if its ts is in
+        the future relative to the cutoff. With window=0 the cutoff
+        is now, so the interaction just written sits right at the
+        boundary; allow equals-within to pass.
+        """
+
+        await store.log_widget_interaction(
+            widget_name="fresh_widget",
+            scope=["org:sales:leads"],
+            action_type="open",
+        )
+        # A generous window picks it up.
+        big = store.projection.usage(window_days=365)
+        assert len(big) == 1
+
+
+# ---------------------------------------------------------------------------
+# Helpers — keep typing aware for any future fixture that constructs
+# synthetic events. Not used in the current test body but pinned for
+# follow-up PRs.
+# ---------------------------------------------------------------------------
+
+
+def _utc(ts: datetime) -> datetime:
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=UTC)
+    return ts
+
+
+def _days_ago(n: int) -> datetime:
+    return datetime.now(UTC) - timedelta(days=n)


### PR DESCRIPTION
## What this does

Lands widget graduation and co-occurrence detection as a projection over the org journal. Supersedes held PRs #941 (widget graduation engine) and #942 (co-occurrence detector stacked on #941). Both shipped their own JSONL side-channel at `~/.pocketpaw/widget-interactions.jsonl`; this retires that file and folds the whole domain onto the append-only journal already used by Fabric (#953) and retrieval (#954).

Three new action names in the `widget.*` namespace:

- `widget.interaction.recorded` — one per user touch on a widget (open / edit / click / dismiss / remove)
- `widget.graduated` — one per pin / fade / archive decision the policy fires
- `widget.cooccurrence.detected` — one per pair that crossed the co-occurrence threshold

Same file layout as `ee/retrieval/` — events, store, projection, policy, router. Router registers at `/api/v1/widgets/{usage,cooccurrence,graduation/state,graduation/scan}` via the existing `_EE_ROUTERS` table.

## Why a rewrite

Two distinct wins over the original side-channel designs:

1. **One audit trail, not two.** The widget interaction log used to live at `~/.pocketpaw/widget-interactions.jsonl` behind a per-process `asyncio.Lock` — not safe across multiple processes, and split from every other event in the system. The journal is the source of truth now; write serialisation comes from SQLite WAL + transaction semantics, and replay / rebuild runs off the same event log as everything else.

2. **The `sorted(tokens[:6])` bug is fixed.** #942's detector claimed to dedup word-order variants by normalising tokens — but the code did `sorted(tokens[:6])`, which truncates before sorting. For any query longer than six tokens, rotated inputs produced different prefixes and therefore different signatures. The projection's `normalise_signature_tokens` now sorts first and truncates second; the behaviour the PR advertised actually holds. A regression guard in `TestCooccurrenceSignatureFix` covers this with an eight-token query that would have failed under the original ordering.

## What was ported vs rewritten

| From | Ported | Rewritten |
|------|--------|-----------|
| #941 pin/fade/archive thresholds (10 / 0 / 60 days) | Verbatim as policy defaults | Scan loop reads `WidgetUsageRow` off the projection instead of walking a JSONL file |
| #941 `WidgetDecision` shape | Field-for-field as `WidgetGraduationDecision` | Apply path emits `widget.graduated` journal events |
| #941 `_PROMOTING_ACTIONS = {"open", "edit", "click"}` | Verbatim | |
| #942 15-minute session window | Verbatim as `DEFAULT_SESSION_GAP_SECONDS = 900` | Projection folds sessions on replay instead of grouping per-scan |
| #942 `confidence = min(1.0, count / (threshold * 3))` ramp | Verbatim | |
| #942 signature helper | **Fixed** (`sorted(tokens)[:6]`) | Derived on every apply so out-of-band emitters with the old bug get corrected on replay |

## Test coverage (27 tests)

- Write path — each store method emits the right action + payload; scope-empty + widget-name-empty rejections
- Scope containment — usage filter, cross-scope reader sees nothing from other tenants (runs through `ee.fabric.policy.filter_visible` so semantics match Fabric)
- Usage projection — pin threshold crossing, below-threshold no-op, only promoting actions count, apply emits `widget.graduated`
- **Signature regression guard** — eight-token rotated-input pair collapses to one signature under the fix (would have failed under #942's bug)
- Signature dedup bidirectional ((A,B) == (B,A)), self-collision suppressed
- Co-occurrence projection — pair recorded within session window, scan respects threshold
- Archive rule fires on stale interactions
- Empty journal rebuild returns empty state, no crash
- Incremental apply equals rebuild-from-scratch (projection observable at any cursor)
- REST router — four endpoints round-trip, cold journal returns empty envelope
- Correlation view — interactions track `correlation_id` from the journal
- Out-of-band emit with a buggy signature — projection re-derives correctly on replay

## Cross-reference to #954 (retrieval projection)

Widget interactions and retrievals are parallel streams. The projection does **not** read retrieval events — the task asked whether widget graduation should subscribe to the retrieval stream, and on reflection it shouldn't:

- A retrieval and a widget interaction are different user actions. A user might retrieve without clicking a widget (agent auto-pulled memory), or click a widget without a retrieval happening first (pinned card).
- Cross-wiring the two would couple the widget projection to the retrieval projection's replay order — and the journal makes no guarantee about cross-action ordering beyond seq.

What the widget projection does share with the retrieval projection is `ee.fabric.policy.filter_visible` for scope containment, so operators get identical scope-filtering semantics across Fabric / retrieval / widgets.

## Downstream unblocks

- **paw-enterprise #74** (SuggestedWidgetsFeed UI) — yes. The projection's `usage()` + `cooccurrences()` + `graduation_state()` rows are what that panel wants to render. The paw-enterprise PR should hit `/api/v1/widgets/usage` + `/api/v1/widgets/cooccurrence` + `/api/v1/widgets/graduation/state` instead of the JSONL reader the held #941 would have exposed.

## Follow-ups (not in this PR)

- Per-pocket threshold configuration — the defaults are verbatim from #941/#942 (tuned for feel) and a follow-up can make them configurable without reshaping the API.
- Human-in-the-loop approval for widget graduation. The captain may want to review proposed pins before they apply; if so, wrap decisions in `agent.proposed` / `human.corrected` pairs via `soul_protocol.spec.decisions`. Current `AgentProposal` shape (needs `summary`, supports `alternatives`) doesn't map cleanly onto a system-emitted usage-count decision — documented in `policy.py`.
- Soul-protocol gap: a journal subscription primitive (issue #48 in my tracker) would let the graduation scheduler react to new interactions without polling the projection.

## Leaves open

- #941 and #942 stay open — captain closes after merge.