### PR TITLE
feat(uploads): URL→disk-path resolver + chat wiring so agents see attached files

### DIFF
--- a/ee/cloud/uploads/resolver.py
+++ b/ee/cloud/uploads/resolver.py
@@ -1,0 +1,68 @@
+"""EE workspace-scoped upload URL resolver.
+
+Wraps :class:`pocketpaw.uploads.resolver.UploadResolver` semantics but looks
+up metadata in Mongo with workspace isolation. Cross-tenant lookups return
+``None`` (treated as "not found" — no leak of existence across workspaces).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ee.cloud.uploads.mongo_store import MongoFileStore
+from pocketpaw.uploads.adapter import StorageAdapter
+from pocketpaw.uploads.resolver import parse_upload_url
+
+
+class EEUploadResolver:
+    """Resolve upload URLs inside a single workspace."""
+
+    def __init__(self, adapter: StorageAdapter, meta: MongoFileStore) -> None:
+        self._adapter = adapter
+        self._meta = meta
+
+    async def resolve(self, url: str, workspace: str) -> Path | None:
+        file_id = parse_upload_url(url)
+        if file_id is None:
+            return None
+        rec = await self._meta.get_scoped(file_id, workspace=workspace)
+        if rec is None:
+            return None
+        return self._adapter.local_path(rec.storage_key)
+
+
+async def resolve_media_paths_scoped(
+    media: list[str],
+    *,
+    resolver: EEUploadResolver,
+    workspace: str,
+) -> list[str]:
+    """Async counterpart to :func:`pocketpaw.uploads.resolver.resolve_media_paths`.
+
+    Same semantics: upload URLs → local paths, unresolvable URLs dropped,
+    non-upload strings passed through.
+    """
+    out: list[str] = []
+    for entry in media:
+        fid = parse_upload_url(entry)
+        if fid is None:
+            out.append(entry)
+            continue
+        path = await resolver.resolve(entry, workspace=workspace)
+        if path is not None:
+            out.append(str(path))
+    return out
+
+
+def default_resolver() -> EEUploadResolver:
+    """Return the resolver wired to the EE /uploads singletons."""
+    from ee.cloud.uploads.router import _ADAPTER, _META
+
+    return EEUploadResolver(adapter=_ADAPTER, meta=_META)
+
+
+__all__ = [
+    "EEUploadResolver",
+    "default_resolver",
+    "resolve_media_paths_scoped",
+]

--- a/ee/cloud/uploads/resolver.py
+++ b/ee/cloud/uploads/resolver.py
@@ -7,11 +7,14 @@ up metadata in Mongo with workspace isolation. Cross-tenant lookups return
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from ee.cloud.uploads.mongo_store import MongoFileStore
 from pocketpaw.uploads.adapter import StorageAdapter
 from pocketpaw.uploads.resolver import parse_upload_url
+
+logger = logging.getLogger(__name__)
 
 
 class EEUploadResolver:
@@ -28,7 +31,19 @@ class EEUploadResolver:
         rec = await self._meta.get_scoped(file_id, workspace=workspace)
         if rec is None:
             return None
-        return self._adapter.local_path(rec.storage_key)
+        # Contain unexpected adapter failures (permission errors on the
+        # storage root, remount races, future remote adapters) so chat
+        # never crashes over a bad attachment — just drops the entry.
+        try:
+            return self._adapter.local_path(rec.storage_key)
+        except Exception:
+            logger.exception(
+                "upload adapter.local_path failed for file_id=%s storage_key=%s workspace=%s",
+                file_id,
+                rec.storage_key,
+                workspace,
+            )
+            return None
 
 
 async def resolve_media_paths_scoped(
@@ -49,8 +64,12 @@ async def resolve_media_paths_scoped(
             out.append(entry)
             continue
         path = await resolver.resolve(entry, workspace=workspace)
-        if path is not None:
-            out.append(str(path))
+        if path is None:
+            logger.warning(
+                "dropping unresolvable upload entry (workspace=%s): %s", workspace, entry
+            )
+            continue
+        out.append(str(path))
     return out
 
 

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -188,6 +188,7 @@ async def _send_message(chat_request: ChatRequest) -> str:
     """Publish an inbound message to the bus and return the chat_id."""
     from pocketpaw.bus import get_message_bus
     from pocketpaw.bus.events import Channel, InboundMessage
+    from pocketpaw.uploads.resolver import default_resolver, resolve_media_paths
 
     chat_id = _extract_chat_id(chat_request.session_id)
 
@@ -195,12 +196,16 @@ async def _send_message(chat_request: ChatRequest) -> str:
     if chat_request.file_context:
         meta["file_context"] = chat_request.file_context.model_dump(exclude_none=True)
 
+    # Resolve ``/api/v1/uploads/{id}`` URLs in ``media`` to local disk paths
+    # so the agent loop can hand them to the Read tool.
+    media = resolve_media_paths(chat_request.media or [], resolver=default_resolver())
+
     msg = InboundMessage(
         channel=Channel.WEBSOCKET,
         sender_id="api_client",
         chat_id=chat_id,
         content=chat_request.content,
-        media=chat_request.media,
+        media=media,
         metadata=meta,
     )
     bus = get_message_bus()

--- a/src/pocketpaw/uploads/adapter.py
+++ b/src/pocketpaw/uploads/adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Protocol
 
 
@@ -38,3 +39,11 @@ class StorageAdapter(Protocol):
 
     async def exists(self, key: str) -> bool:
         """Return whether ``key`` is currently stored."""
+
+    def local_path(self, key: str) -> Path | None:
+        """Return an absolute local path to the blob, or ``None`` if unsupported.
+
+        Lets the agent loop pass local files to built-in tools (e.g. Read)
+        without streaming through HTTP. Remote adapters (S3, GCS) return
+        ``None`` — the caller should fall back to streaming via ``open``.
+        """

--- a/src/pocketpaw/uploads/local.py
+++ b/src/pocketpaw/uploads/local.py
@@ -73,3 +73,10 @@ class LocalStorageAdapter(StorageAdapter):
     async def exists(self, key: str) -> bool:
         target = self._resolve(key)
         return target.exists()
+
+    def local_path(self, key: str) -> Path | None:
+        try:
+            target = self._resolve(key)
+        except AccessDenied:
+            return None
+        return target if target.exists() else None

--- a/src/pocketpaw/uploads/resolver.py
+++ b/src/pocketpaw/uploads/resolver.py
@@ -9,12 +9,15 @@ OSS-only — EE has its own workspace-scoped resolver alongside its Mongo store.
 
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
 from typing import Protocol
 
 from pocketpaw.uploads.adapter import StorageAdapter
 from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+
+logger = logging.getLogger(__name__)
 
 _UPLOAD_URL_RE = re.compile(r"^/api/v1/uploads/(?P<id>[A-Za-z0-9_-]+)$")
 
@@ -54,7 +57,18 @@ class UploadResolver:
         rec = self._meta.get(file_id)
         if rec is None:
             return None
-        return self._adapter.local_path(rec.storage_key)
+        # Contain unexpected adapter failures (permission errors on the
+        # storage root, remount races, future remote adapters) so chat
+        # never crashes over a bad attachment — just drops the entry.
+        try:
+            return self._adapter.local_path(rec.storage_key)
+        except Exception:
+            logger.exception(
+                "upload adapter.local_path failed for file_id=%s storage_key=%s",
+                file_id,
+                rec.storage_key,
+            )
+            return None
 
 
 def resolve_media_paths(
@@ -77,8 +91,14 @@ def resolve_media_paths(
             out.append(entry)
             continue
         path = resolver.resolve(entry)
-        if path is not None:
-            out.append(str(path))
+        if path is None:
+            # Upload-URL-shaped but unresolvable: record missing, record
+            # soft-deleted, blob gone, or adapter failure. Log so the next
+            # time a user says "the agent ignored my file" the trail is
+            # visible in server logs.
+            logger.warning("dropping unresolvable upload entry: %s", entry)
+            continue
+        out.append(str(path))
     return out
 
 

--- a/src/pocketpaw/uploads/resolver.py
+++ b/src/pocketpaw/uploads/resolver.py
@@ -1,0 +1,103 @@
+"""Turn an upload URL into a local disk path for the agent loop.
+
+The chat bridge receives media entries like ``/api/v1/uploads/{id}`` from the
+frontend. Agents consume local paths (Read tool, image blocks). This module
+bridges the two.
+
+OSS-only — EE has its own workspace-scoped resolver alongside its Mongo store.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Protocol
+
+from pocketpaw.uploads.adapter import StorageAdapter
+from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+
+_UPLOAD_URL_RE = re.compile(r"^/api/v1/uploads/(?P<id>[A-Za-z0-9_-]+)$")
+
+
+def parse_upload_url(url: str) -> str | None:
+    """Extract the file_id from an upload URL.
+
+    Returns ``None`` for anything that isn't a canonical upload URL:
+    disk paths, other API routes, blob URLs, empty strings, etc.
+    """
+    if not url:
+        return None
+    m = _UPLOAD_URL_RE.match(url)
+    return m.group("id") if m else None
+
+
+class _MetaReader(Protocol):
+    def get(self, file_id: str) -> FileRecord | None: ...
+
+
+class UploadResolver:
+    """Look up upload URLs in a metadata store and map to local disk paths.
+
+    Returns ``None`` for unresolvable URLs: unknown file_id, soft-deleted
+    records, blobs that have vanished from disk, or adapters that don't
+    support ``local_path`` (e.g. future S3 adapter).
+    """
+
+    def __init__(self, adapter: StorageAdapter, meta: _MetaReader) -> None:
+        self._adapter = adapter
+        self._meta = meta
+
+    def resolve(self, url: str) -> Path | None:
+        file_id = parse_upload_url(url)
+        if file_id is None:
+            return None
+        rec = self._meta.get(file_id)
+        if rec is None:
+            return None
+        return self._adapter.local_path(rec.storage_key)
+
+
+def resolve_media_paths(
+    media: list[str],
+    *,
+    resolver: UploadResolver,
+) -> list[str]:
+    """Map each media entry to a local path string.
+
+    - Upload URLs that resolve → absolute disk path as a string.
+    - Upload URLs that don't resolve → dropped silently (orphan/deleted).
+    - Non-upload strings (already local paths, opaque tokens) → passthrough.
+
+    Order is preserved; dropped unresolvable URLs do not leave gaps.
+    """
+    out: list[str] = []
+    for entry in media:
+        fid = parse_upload_url(entry)
+        if fid is None:
+            out.append(entry)
+            continue
+        path = resolver.resolve(entry)
+        if path is not None:
+            out.append(str(path))
+    return out
+
+
+def default_resolver() -> UploadResolver:
+    """Return the resolver wired to the OSS /uploads singletons.
+
+    Imported lazily so test code can stub the module-level singletons before
+    this is called.
+    """
+    from pocketpaw.api.v1.uploads import _ADAPTER, _META
+
+    return UploadResolver(adapter=_ADAPTER, meta=_META)
+
+
+# Keep JSONLFileStore importable for type-friendly call sites.
+__all__ = [
+    "UploadResolver",
+    "default_resolver",
+    "parse_upload_url",
+    "resolve_media_paths",
+    "JSONLFileStore",
+]

--- a/tests/cloud/uploads/conftest.py
+++ b/tests/cloud/uploads/conftest.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
 
 import pytest
+
+
+@pytest.fixture()
+def tmp_upload_root(tmp_path: Path) -> Path:
+    """Isolated storage root for each test."""
+    root = tmp_path / "uploads"
+    root.mkdir()
+    return root
 
 
 @pytest.fixture()

--- a/tests/cloud/uploads/test_resolver.py
+++ b/tests/cloud/uploads/test_resolver.py
@@ -1,0 +1,118 @@
+"""Tests for ee.cloud.uploads.resolver."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from ee.cloud.uploads.resolver import EEUploadResolver, resolve_media_paths_scoped
+from pocketpaw.uploads.file_store import FileRecord
+from pocketpaw.uploads.local import LocalStorageAdapter
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _stash(
+    tmp_upload_root: Path,
+    store,  # MongoFileStore
+    workspace: str,
+    data: bytes = b"hello",
+    filename: str = "x.txt",
+    mime: str = "text/plain",
+) -> tuple[FileRecord, Path]:
+    from datetime import UTC, datetime
+
+    file_id = uuid.uuid4().hex
+    storage_key = f"chat/202604/{file_id}.txt"
+    disk_path = tmp_upload_root / storage_key
+    disk_path.parent.mkdir(parents=True, exist_ok=True)
+    disk_path.write_bytes(data)
+    rec = FileRecord(
+        id=file_id,
+        storage_key=storage_key,
+        filename=filename,
+        mime=mime,
+        size=len(data),
+        owner_id="alice",
+        chat_id=None,
+        created=datetime.now(UTC),
+    )
+    await store.save_scoped(rec, workspace=workspace)
+    return rec, disk_path
+
+
+async def test_resolve_returns_disk_path_for_scoped_upload(
+    tmp_upload_root, store, beanie_upload_db
+):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    resolver = EEUploadResolver(adapter=adapter, meta=store)
+
+    rec, disk_path = await _stash(tmp_upload_root, store, workspace="ws-1")
+
+    resolved = await resolver.resolve(f"/api/v1/uploads/{rec.id}", workspace="ws-1")
+    assert resolved == disk_path
+
+
+async def test_resolve_enforces_workspace_isolation(tmp_upload_root, store, beanie_upload_db):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    resolver = EEUploadResolver(adapter=adapter, meta=store)
+
+    rec, _ = await _stash(tmp_upload_root, store, workspace="ws-1")
+
+    # Same id, different workspace → not found (not 403, returns None).
+    resolved = await resolver.resolve(f"/api/v1/uploads/{rec.id}", workspace="ws-other")
+    assert resolved is None
+
+
+async def test_resolve_returns_none_for_non_upload_url(tmp_upload_root, store, beanie_upload_db):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    resolver = EEUploadResolver(adapter=adapter, meta=store)
+
+    assert await resolver.resolve("/already/local.pdf", workspace="ws-1") is None
+    assert await resolver.resolve("/api/v1/files/abc", workspace="ws-1") is None
+
+
+async def test_resolve_returns_none_for_soft_deleted_upload(
+    tmp_upload_root, store, beanie_upload_db
+):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    resolver = EEUploadResolver(adapter=adapter, meta=store)
+
+    rec, _ = await _stash(tmp_upload_root, store, workspace="ws-1")
+    await store.soft_delete_scoped(rec.id, workspace="ws-1")
+
+    assert await resolver.resolve(f"/api/v1/uploads/{rec.id}", workspace="ws-1") is None
+
+
+async def test_resolve_returns_none_when_blob_missing_on_disk(
+    tmp_upload_root, store, beanie_upload_db
+):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    resolver = EEUploadResolver(adapter=adapter, meta=store)
+
+    rec, disk_path = await _stash(tmp_upload_root, store, workspace="ws-1")
+    disk_path.unlink()
+    assert await resolver.resolve(f"/api/v1/uploads/{rec.id}", workspace="ws-1") is None
+
+
+async def test_resolve_media_paths_scoped_mixes_pass_drop_resolve(
+    tmp_upload_root, store, beanie_upload_db
+):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    resolver = EEUploadResolver(adapter=adapter, meta=store)
+
+    rec, disk_path = await _stash(tmp_upload_root, store, workspace="ws-1")
+    ghost = "ghost0000000000000000000000000000"
+
+    result = await resolve_media_paths_scoped(
+        [
+            f"/api/v1/uploads/{rec.id}",
+            "/already/local/path.pdf",
+            f"/api/v1/uploads/{ghost}",
+        ],
+        resolver=resolver,
+        workspace="ws-1",
+    )
+    assert result == [str(disk_path), "/already/local/path.pdf"]

--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -183,3 +183,78 @@ class TestSSEFormat:
             data_str = data_line.split(":", 1)[1].strip()
             parsed = _json.loads(data_str)
             assert isinstance(parsed, dict), f"SSE data must be a JSON object, got: {type(parsed)}"
+
+
+class TestSendMessageResolvesMedia:
+    """_send_message must rewrite upload URLs to local paths before bus publish."""
+
+    @pytest.mark.asyncio
+    async def test_upload_urls_become_local_paths(self, tmp_path, monkeypatch):
+        import uuid
+        from datetime import UTC, datetime
+
+        from pocketpaw.api.v1.chat import _send_message
+        from pocketpaw.api.v1.schemas.chat import ChatRequest
+        from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+        from pocketpaw.uploads.local import LocalStorageAdapter
+        from pocketpaw.uploads.resolver import UploadResolver
+
+        # Stand up isolated adapter + meta store.
+        root = tmp_path / "uploads"
+        root.mkdir()
+        adapter = LocalStorageAdapter(root=root)
+        meta = JSONLFileStore(path=root / "_idx.jsonl")
+
+        # Stash a real blob + record.
+        fid = uuid.uuid4().hex
+        storage_key = f"chat/202604/{fid}.txt"
+        disk = root / storage_key
+        disk.parent.mkdir(parents=True, exist_ok=True)
+        disk.write_bytes(b"hello")
+        meta.save(
+            FileRecord(
+                id=fid,
+                storage_key=storage_key,
+                filename="x.txt",
+                mime="text/plain",
+                size=5,
+                owner_id="local",
+                chat_id=None,
+                created=datetime.now(UTC),
+            )
+        )
+
+        # Force chat._send_message's internal import to use our stub resolver.
+        from pocketpaw.uploads import resolver as resolver_mod
+
+        monkeypatch.setattr(
+            resolver_mod,
+            "default_resolver",
+            lambda: UploadResolver(adapter=adapter, meta=meta),
+        )
+
+        # Capture the InboundMessage that gets published.
+        captured: dict = {}
+
+        class _StubBus:
+            async def publish_inbound(self, msg):
+                captured["msg"] = msg
+
+        from pocketpaw import bus as bus_mod
+
+        monkeypatch.setattr(bus_mod, "get_message_bus", lambda: _StubBus())
+
+        req = ChatRequest(
+            content="look at this",
+            session_id="chat-1",
+            media=[
+                f"/api/v1/uploads/{fid}",
+                "/already/local/path.pdf",
+                "/api/v1/uploads/ghost0000000000000000000000000000",
+            ],
+        )
+        await _send_message(req)
+
+        msg = captured["msg"]
+        assert msg.content == "look at this"
+        assert msg.media == [str(disk), "/already/local/path.pdf"]

--- a/tests/uploads/test_resolver.py
+++ b/tests/uploads/test_resolver.py
@@ -1,0 +1,149 @@
+"""Tests for pocketpaw.uploads.resolver."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+from pocketpaw.uploads.local import LocalStorageAdapter
+from pocketpaw.uploads.resolver import (
+    UploadResolver,
+    parse_upload_url,
+    resolve_media_paths,
+)
+
+
+class TestParseUploadUrl:
+    def test_extracts_id_from_canonical_url(self) -> None:
+        fid = uuid.uuid4().hex
+        assert parse_upload_url(f"/api/v1/uploads/{fid}") == fid
+
+    def test_returns_none_for_non_upload_url(self) -> None:
+        assert parse_upload_url("/api/v1/files/abc") is None
+        assert parse_upload_url("https://example.com/x") is None
+
+    def test_returns_none_for_disk_path(self) -> None:
+        assert parse_upload_url("/home/user/image.png") is None
+        assert parse_upload_url("C:\\foo\\bar.pdf") is None
+
+    def test_parses_any_id_shaped_segment(self) -> None:
+        # parse is permissive; the metadata lookup decides validity.
+        assert parse_upload_url("/api/v1/uploads/abc") == "abc"
+        assert parse_upload_url("/api/v1/uploads/not-hex-chars") == "not-hex-chars"
+
+    def test_returns_none_for_url_with_trailing_slash_or_segment(self) -> None:
+        assert parse_upload_url("/api/v1/uploads/abc/") is None
+        assert parse_upload_url("/api/v1/uploads/abc/download") is None
+
+    def test_returns_none_for_empty_string(self) -> None:
+        assert parse_upload_url("") is None
+
+
+class TestUploadResolver:
+    @pytest.fixture()
+    def resolver(self, tmp_upload_root: Path) -> UploadResolver:
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+        return UploadResolver(adapter=adapter, meta=meta)
+
+    def _stash(
+        self,
+        tmp_upload_root: Path,
+        resolver: UploadResolver,
+        data: bytes = b"hello",
+        filename: str = "x.txt",
+        mime: str = "text/plain",
+    ) -> tuple[FileRecord, Path]:
+        """Put a blob on disk and register metadata. Returns (record, disk_path)."""
+        file_id = uuid.uuid4().hex
+        storage_key = f"chat/202604/{file_id}.txt"
+        disk_path = tmp_upload_root / storage_key
+        disk_path.parent.mkdir(parents=True, exist_ok=True)
+        disk_path.write_bytes(data)
+        rec = FileRecord(
+            id=file_id,
+            storage_key=storage_key,
+            filename=filename,
+            mime=mime,
+            size=len(data),
+            owner_id="local",
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+        resolver._meta.save(rec)
+        return rec, disk_path
+
+    def test_resolve_returns_disk_path_for_stored_upload(
+        self, tmp_upload_root: Path, resolver: UploadResolver
+    ) -> None:
+        rec, disk_path = self._stash(tmp_upload_root, resolver)
+        resolved = resolver.resolve(f"/api/v1/uploads/{rec.id}")
+        assert resolved == disk_path
+        assert resolved is not None
+        assert resolved.read_bytes() == b"hello"
+
+    def test_resolve_returns_none_for_missing_metadata(self, resolver: UploadResolver) -> None:
+        ghost = uuid.uuid4().hex
+        assert resolver.resolve(f"/api/v1/uploads/{ghost}") is None
+
+    def test_resolve_returns_none_when_blob_deleted_from_disk(
+        self, tmp_upload_root: Path, resolver: UploadResolver
+    ) -> None:
+        rec, disk_path = self._stash(tmp_upload_root, resolver)
+        disk_path.unlink()
+        assert resolver.resolve(f"/api/v1/uploads/{rec.id}") is None
+
+    def test_resolve_returns_none_for_non_upload_url(self, resolver: UploadResolver) -> None:
+        assert resolver.resolve("/api/v1/files/abc") is None
+        assert resolver.resolve("/already/local/path.txt") is None
+
+    def test_resolve_returns_none_for_soft_deleted_upload(
+        self, tmp_upload_root: Path, resolver: UploadResolver
+    ) -> None:
+        rec, _ = self._stash(tmp_upload_root, resolver)
+        resolver._meta.soft_delete(rec.id)
+        assert resolver.resolve(f"/api/v1/uploads/{rec.id}") is None
+
+
+class TestResolveMediaPaths:
+    @pytest.fixture()
+    def resolver(self, tmp_upload_root: Path) -> UploadResolver:
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+        return UploadResolver(adapter=adapter, meta=meta)
+
+    def test_mixed_paths_and_urls(self, tmp_upload_root: Path, resolver: UploadResolver) -> None:
+        file_id = uuid.uuid4().hex
+        storage_key = f"chat/202604/{file_id}.png"
+        disk_path = tmp_upload_root / storage_key
+        disk_path.parent.mkdir(parents=True, exist_ok=True)
+        disk_path.write_bytes(b"png")
+        rec = FileRecord(
+            id=file_id,
+            storage_key=storage_key,
+            filename="x.png",
+            mime="image/png",
+            size=3,
+            owner_id="local",
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+        resolver._meta.save(rec)
+
+        media_in = [
+            f"/api/v1/uploads/{file_id}",
+            "/already/local/path.pdf",  # passthrough
+            "/api/v1/uploads/ghost0000000000000000000000000000",  # unresolvable
+        ]
+        result = resolve_media_paths(media_in, resolver=resolver)
+        assert result == [
+            str(disk_path),
+            "/already/local/path.pdf",
+        ]
+
+    def test_empty_list(self, resolver: UploadResolver) -> None:
+        assert resolve_media_paths([], resolver=resolver) == []


### PR DESCRIPTION
## Summary

Closes the gap that blocks agents from actually seeing files the user attaches: the frontend sends `MediaAttachment.url = "/api/v1/uploads/{id}"`, the chat endpoint passes those strings into `InboundMessage.media`, and the agent loop at \`loop.py:669-671\` appends them as \`[Media files on disk: /api/v1/uploads/u1]\` — which the agent's Read tool cannot open. This PR wires a resolver so those URLs become real on-disk paths before the prompt is built.

Stacked on top of #965 (upload adapter) — set its base to \`ee\` once #965 merges.

## Changes

- \`StorageAdapter.local_path(key) -> Path | None\` — new protocol method. \`LocalStorageAdapter\` returns the resolved path when the blob exists; future S3 etc. returns \`None\` so callers can fall back to \`open()\`.
- \`pocketpaw/uploads/resolver.py\` — \`parse_upload_url\`, \`UploadResolver\`, \`resolve_media_paths\`. Unresolvable upload URLs are dropped; non-upload strings pass through.
- \`ee/cloud/uploads/resolver.py\` — workspace-scoped counterpart over MongoFileStore. Cross-tenant lookups return None (no existence leak across workspaces).
- \`api/v1/chat.py:_send_message\` — resolves \`ChatRequest.media\` before publishing the inbound message.
- Backward compatible: entries that aren't upload URLs (disk paths, opaque tokens) are passed through untouched.

## Agent pipeline after this PR

1. Frontend uploads → \`{ url: "/api/v1/uploads/u1", ... }\` in \`MediaAttachment\` (shipped in paw-enterprise PR #77).
2. \`POST /chat/stream\` \`ChatRequest.media = ["/api/v1/uploads/u1", ...]\`.
3. \`_send_message\` → \`resolve_media_paths\` → \`InboundMessage.media = ["/abs/path/to/blob", ...]\`.
4. \`AgentLoop\` already appends \`[Media files on disk: <path>]\` and the agent's Read tool opens it.

Image-native vision blocks (Claude / OpenAI / Gemini binary inputs) remain a separate improvement — for now, the agent sees the path and reads bytes.

## Test plan
- [x] \`tests/uploads/test_resolver.py\` — 13 unit tests, all green
- [x] \`tests/cloud/uploads/test_resolver.py\` — 6 EE tests including cross-tenant isolation
- [x] \`tests/test_api_chat.py::TestSendMessageResolvesMedia\` — integration test for \`_send_message\` resolution
- [x] \`uv run pytest tests/uploads/ tests/cloud/uploads/ tests/test_api_chat.py\` → 90 passed
- [x] \`uv run ruff check\`, \`uv run mypy\` on touched modules — green
- [ ] Manual smoke: start the backend, frontend paw-enterprise PR #77, attach an image, confirm the agent sees the file content