### PR TITLE
fix(uploads): resolve media URLs from EE Mongo when OSS JSONL misses

### DIFF
--- a/ee/cloud/uploads/mongo_store.py
+++ b/ee/cloud/uploads/mongo_store.py
@@ -30,6 +30,24 @@ class MongoFileStore:
             FileUpload.workspace == workspace,
             FileUpload.deleted_at == None,  # noqa: E711 beanie needs literal None
         )
+        return self._to_record(doc)
+
+    async def get_unscoped(self, file_id: str) -> FileRecord | None:
+        """Find a live record by file_id without workspace filter.
+
+        Intended for call sites that lack tenant context (e.g. the OSS chat
+        bridge in single-user self-hosted deployments). Multi-tenant cloud
+        chat flows should use ``get_scoped`` with an authenticated workspace
+        and never call this.
+        """
+        doc = await FileUpload.find_one(
+            FileUpload.file_id == file_id,
+            FileUpload.deleted_at == None,  # noqa: E711
+        )
+        return self._to_record(doc)
+
+    @staticmethod
+    def _to_record(doc: FileUpload | None) -> FileRecord | None:
         if doc is None:
             return None
         return FileRecord(

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -188,7 +188,7 @@ async def _send_message(chat_request: ChatRequest) -> str:
     """Publish an inbound message to the bus and return the chat_id."""
     from pocketpaw.bus import get_message_bus
     from pocketpaw.bus.events import Channel, InboundMessage
-    from pocketpaw.uploads.resolver import default_resolver, resolve_media_paths
+    from pocketpaw.uploads.resolver import resolve_media_paths_any
 
     chat_id = _extract_chat_id(chat_request.session_id)
 
@@ -197,8 +197,10 @@ async def _send_message(chat_request: ChatRequest) -> str:
         meta["file_context"] = chat_request.file_context.model_dump(exclude_none=True)
 
     # Resolve ``/api/v1/uploads/{id}`` URLs in ``media`` to local disk paths
-    # so the agent loop can hand them to the Read tool.
-    media = resolve_media_paths(chat_request.media or [], resolver=default_resolver())
+    # so the agent loop can hand them to the Read tool. Falls back to the EE
+    # Mongo store when OSS JSONL misses — common in self-hosted EE where
+    # uploads go through the workspace-scoped router but chat is OSS.
+    media = await resolve_media_paths_any(chat_request.media or [])
 
     msg = InboundMessage(
         channel=Channel.WEBSOCKET,

--- a/src/pocketpaw/uploads/resolver.py
+++ b/src/pocketpaw/uploads/resolver.py
@@ -113,11 +113,71 @@ def default_resolver() -> UploadResolver:
     return UploadResolver(adapter=_ADAPTER, meta=_META)
 
 
+async def _resolve_via_ee_mongo(file_id: str) -> Path | None:
+    """Fallback: look up ``file_id`` in the EE Mongo store with no workspace
+    filter. Returns ``None`` if EE isn't installed or Mongo can't reach the id.
+
+    Intended for single-user self-hosted deployments where the EE router is
+    mounted (uploads land in Mongo) but chat still goes through the OSS
+    endpoint. Multi-tenant cloud chat should route through EE with explicit
+    workspace context instead of calling this.
+    """
+    try:
+        from ee.cloud.uploads.router import _ADAPTER as EE_ADAPTER
+        from ee.cloud.uploads.router import _META as EE_META
+    except Exception:
+        return None
+
+    try:
+        rec = await EE_META.get_unscoped(file_id)
+    except Exception:
+        logger.exception("EE mongo lookup failed for file_id=%s", file_id)
+        return None
+    if rec is None:
+        return None
+    try:
+        return EE_ADAPTER.local_path(rec.storage_key)
+    except Exception:
+        logger.exception(
+            "EE adapter.local_path failed for file_id=%s storage_key=%s",
+            file_id,
+            rec.storage_key,
+        )
+        return None
+
+
+async def resolve_media_paths_any(media: list[str]) -> list[str]:
+    """Async counterpart to :func:`resolve_media_paths` that falls back to
+    the EE Mongo store when the OSS JSONL lookup misses.
+
+    Covers the common self-hosted EE case: uploads go through the EE
+    workspace-scoped router (Mongo), but chat still goes through the OSS
+    `/chat/stream` endpoint (no auth context). Without this fallback, the
+    agent would never see files uploaded via the EE path.
+    """
+    resolver = default_resolver()
+    out: list[str] = []
+    for entry in media:
+        fid = parse_upload_url(entry)
+        if fid is None:
+            out.append(entry)
+            continue
+        path = resolver.resolve(entry)
+        if path is None:
+            path = await _resolve_via_ee_mongo(fid)
+        if path is None:
+            logger.warning("dropping unresolvable upload entry: %s", entry)
+            continue
+        out.append(str(path))
+    return out
+
+
 # Keep JSONLFileStore importable for type-friendly call sites.
 __all__ = [
     "UploadResolver",
     "default_resolver",
     "parse_upload_url",
     "resolve_media_paths",
+    "resolve_media_paths_any",
     "JSONLFileStore",
 ]

--- a/tests/cloud/uploads/test_resolver_fallback.py
+++ b/tests/cloud/uploads/test_resolver_fallback.py
@@ -1,0 +1,139 @@
+"""Tests for the OSS→EE Mongo fallback in ``resolve_media_paths_any``.
+
+Scenario: uploads go through the EE router (workspace-scoped Mongo) but
+chat still goes through the OSS ``/chat/stream`` endpoint. Without fallback
+the OSS JSONL lookup misses every EE upload.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+from pocketpaw.uploads.local import LocalStorageAdapter
+from pocketpaw.uploads.resolver import resolve_media_paths_any
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_fallback_resolves_from_ee_mongo_when_oss_misses(
+    tmp_upload_root: Path, store, beanie_upload_db
+):
+    """File in Mongo but not JSONL still resolves via the fallback path."""
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    oss_meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+
+    # Stash only in Mongo (simulates upload via EE router).
+    file_id = uuid.uuid4().hex
+    storage_key = f"chat/202604/{file_id}.png"
+    disk = tmp_upload_root / storage_key
+    disk.parent.mkdir(parents=True, exist_ok=True)
+    disk.write_bytes(b"pngbytes")
+    await store.save_scoped(
+        FileRecord(
+            id=file_id,
+            storage_key=storage_key,
+            filename="x.png",
+            mime="image/png",
+            size=8,
+            owner_id="u1",
+            chat_id="__paw-runtime-dm__",
+            created=datetime.now(UTC),
+        ),
+        workspace="ws-1",
+    )
+
+    # Stub OSS + EE module-level singletons for the resolver.
+    with (
+        patch("pocketpaw.api.v1.uploads._ADAPTER", adapter),
+        patch("pocketpaw.api.v1.uploads._META", oss_meta),
+        patch("ee.cloud.uploads.router._ADAPTER", adapter),
+        patch("ee.cloud.uploads.router._META", store),
+    ):
+        result = await resolve_media_paths_any([f"/api/v1/uploads/{file_id}"])
+
+    assert result == [str(disk)]
+
+
+async def test_fallback_returns_none_when_neither_store_has_id(
+    tmp_upload_root: Path, store, beanie_upload_db
+):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    oss_meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+    ghost_url = "/api/v1/uploads/ghost0000000000000000000000000000"
+
+    with (
+        patch("pocketpaw.api.v1.uploads._ADAPTER", adapter),
+        patch("pocketpaw.api.v1.uploads._META", oss_meta),
+        patch("ee.cloud.uploads.router._ADAPTER", adapter),
+        patch("ee.cloud.uploads.router._META", store),
+    ):
+        result = await resolve_media_paths_any([ghost_url])
+
+    assert result == []
+
+
+async def test_fallback_ignores_soft_deleted_ee_record(
+    tmp_upload_root: Path, store, beanie_upload_db
+):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    oss_meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+
+    file_id = uuid.uuid4().hex
+    storage_key = f"chat/202604/{file_id}.png"
+    disk = tmp_upload_root / storage_key
+    disk.parent.mkdir(parents=True, exist_ok=True)
+    disk.write_bytes(b"x")
+    await store.save_scoped(
+        FileRecord(
+            id=file_id,
+            storage_key=storage_key,
+            filename="x.png",
+            mime="image/png",
+            size=1,
+            owner_id="u1",
+            chat_id=None,
+            created=datetime.now(UTC),
+        ),
+        workspace="ws-1",
+    )
+    await store.soft_delete_scoped(file_id, workspace="ws-1")
+
+    with (
+        patch("pocketpaw.api.v1.uploads._ADAPTER", adapter),
+        patch("pocketpaw.api.v1.uploads._META", oss_meta),
+        patch("ee.cloud.uploads.router._ADAPTER", adapter),
+        patch("ee.cloud.uploads.router._META", store),
+    ):
+        result = await resolve_media_paths_any([f"/api/v1/uploads/{file_id}"])
+
+    assert result == []
+
+
+async def test_get_unscoped_returns_record_across_workspaces(
+    tmp_upload_root: Path, store, beanie_upload_db
+):
+    """``get_unscoped`` finds a file_id regardless of workspace."""
+    file_id = uuid.uuid4().hex
+    await store.save_scoped(
+        FileRecord(
+            id=file_id,
+            storage_key=f"chat/202604/{file_id}.txt",
+            filename="x.txt",
+            mime="text/plain",
+            size=1,
+            owner_id="u1",
+            chat_id=None,
+            created=datetime.now(UTC),
+        ),
+        workspace="ws-private",
+    )
+
+    found = await store.get_unscoped(file_id)
+    assert found is not None
+    assert found.id == file_id


### PR DESCRIPTION
## Problem

Uploads in self-hosted EE flow through the workspace-scoped `ee.cloud.uploads.router` (writes to MongoDB), but chat still goes through the OSS `POST /api/v1/chat/stream` endpoint (no auth, no workspace context). The resolver merged in #967 only reads the OSS `JSONLFileStore`, so every EE-backed upload gets silently dropped before reaching the agent loop.

**Concrete repro:** user uploads a screenshot via `ChatInput` → Mongo has the record (`file_uploads` collection) → user sends chat with the returned URL → resolver's JSONL lookup misses → `logger.warning("dropping unresolvable upload entry: ...")` → agent gets `InboundMessage.media = []` → agent responds "you didn't attach an image."

## Fix

- `MongoFileStore.get_unscoped(file_id)` — find a live record by id without workspace filter. Documented as for single-user self-hosted use; multi-tenant cloud chat should continue to use `get_scoped` with an authenticated workspace.
- `pocketpaw.uploads.resolver.resolve_media_paths_any(media)` — async chain: try OSS JSONL first; on miss, fall back to EE Mongo; on double miss, drop with a warning log. EE is imported lazily so pure-OSS installs stay unaffected.
- `api/v1/chat.py:_send_message` awaits the async chain.

## Test plan
- [x] `tests/cloud/uploads/test_resolver_fallback.py` — 4 new tests (fallback hit, double-miss drop, soft-delete respected, workspace-less get)
- [x] `pytest tests/uploads/ tests/cloud/uploads/ tests/test_api_chat.py` → 74 passed
- [x] Ruff + mypy clean on touched files (pre-existing mypy noise in `chat.py:170-171` is unrelated)

## Known limits

`get_unscoped` ignores tenant isolation — acceptable here because the OSS chat endpoint has no auth context to check a workspace against, and the file_id is a 128-bit random UUID (not guessable). A proper multi-tenant fix is to route chat through a workspace-aware EE endpoint; that's a larger refactor outside this hotfix.