### PR TITLE
feat(agent): inject filename/mime/size into prompt so agents know what's attached

### DIFF
--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -264,6 +264,17 @@ def _strip_tts_links(text: str) -> str:
     return text.strip()
 
 
+def _format_bytes(n: int) -> str:
+    """Human-readable byte size (e.g. ``414.7 KB``) for prompt injection."""
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    if n < 1024 * 1024 * 1024:
+        return f"{n / (1024 * 1024):.1f} MB"
+    return f"{n / (1024 * 1024 * 1024):.1f} GB"
+
+
 class AgentLoop:
     """
     Main agent execution loop.
@@ -667,8 +678,26 @@ class AgentLoop:
                 Path(p).suffix.lower() in _AUDIO_EXTS for p in (message.media or [])
             )
             if message.media:
-                paths_info = ", ".join(message.media)
-                content += f"\n[Media files on disk: {paths_info}]"
+                # Prefer the richer form when the chat bridge populated metadata
+                # (filename + mime + size per path). The plain path list is still
+                # a correct fallback — e.g. Telegram / Discord / WhatsApp adapters
+                # that don't produce upload records will drop in here.
+                media_info = (message.metadata or {}).get("media_info") or []
+                if media_info:
+                    lines = []
+                    for info in media_info:
+                        filename = info.get("filename") or Path(info.get("path", "")).name or "file"
+                        mime = info.get("mime") or "application/octet-stream"
+                        size = info.get("size")
+                        size_str = _format_bytes(size) if isinstance(size, int) else ""
+                        meta_suffix = f", {size_str}" if size_str else ""
+                        lines.append(
+                            f"- {filename} ({mime}{meta_suffix}) at {info.get('path', '')}"
+                        )
+                    content += "\n\nAttached files:\n" + "\n".join(lines)
+                else:
+                    paths_info = ", ".join(message.media)
+                    content += f"\n[Media files on disk: {paths_info}]"
 
             # 2. Build system prompt + session history concurrently (independent I/O)
             sender_id = message.sender_id

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -188,7 +188,7 @@ async def _send_message(chat_request: ChatRequest) -> str:
     """Publish an inbound message to the bus and return the chat_id."""
     from pocketpaw.bus import get_message_bus
     from pocketpaw.bus.events import Channel, InboundMessage
-    from pocketpaw.uploads.resolver import resolve_media_paths_any
+    from pocketpaw.uploads.resolver import resolve_media_with_records
 
     chat_id = _extract_chat_id(chat_request.session_id)
 
@@ -196,11 +196,24 @@ async def _send_message(chat_request: ChatRequest) -> str:
     if chat_request.file_context:
         meta["file_context"] = chat_request.file_context.model_dump(exclude_none=True)
 
-    # Resolve ``/api/v1/uploads/{id}`` URLs in ``media`` to local disk paths
-    # so the agent loop can hand them to the Read tool. Falls back to the EE
-    # Mongo store when OSS JSONL misses — common in self-hosted EE where
-    # uploads go through the workspace-scoped router but chat is OSS.
-    media = await resolve_media_paths_any(chat_request.media or [])
+    # Resolve ``/api/v1/uploads/{id}`` URLs to (path, FileRecord) pairs so the
+    # agent prompt can carry filename / mime / size, not just a bare disk path.
+    # Falls back to the EE Mongo store when OSS JSONL misses — common in
+    # self-hosted EE where uploads go through the workspace-scoped router.
+    resolved = await resolve_media_with_records(chat_request.media or [])
+    media = [r.path for r in resolved]
+    media_info = [
+        {
+            "path": r.path,
+            "filename": r.record.filename,
+            "mime": r.record.mime,
+            "size": r.record.size,
+        }
+        for r in resolved
+        if r.record is not None
+    ]
+    if media_info:
+        meta["media_info"] = media_info
 
     msg = InboundMessage(
         channel=Channel.WEBSOCKET,

--- a/src/pocketpaw/uploads/resolver.py
+++ b/src/pocketpaw/uploads/resolver.py
@@ -11,11 +11,29 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
 from pocketpaw.uploads.adapter import StorageAdapter
 from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+
+
+@dataclass(frozen=True)
+class ResolvedMedia:
+    """One entry of the resolved media list.
+
+    ``path`` is the string the agent loop will inject into the prompt
+    (absolute disk path for resolved upload URLs, original string for
+    passthroughs). ``record`` carries the metadata when the entry was
+    resolved from an upload store — used to build the richer prompt
+    block (filename, mime, size). ``None`` for passthroughs / non-upload
+    entries where we don't know the metadata.
+    """
+
+    path: str
+    record: FileRecord | None
+
 
 logger = logging.getLogger(__name__)
 
@@ -113,9 +131,12 @@ def default_resolver() -> UploadResolver:
     return UploadResolver(adapter=_ADAPTER, meta=_META)
 
 
-async def _resolve_via_ee_mongo(file_id: str) -> Path | None:
+async def _resolve_via_ee_mongo(
+    file_id: str,
+) -> tuple[Path | None, FileRecord | None]:
     """Fallback: look up ``file_id`` in the EE Mongo store with no workspace
-    filter. Returns ``None`` if EE isn't installed or Mongo can't reach the id.
+    filter. Returns ``(None, None)`` if EE isn't installed or Mongo can't
+    reach the id.
 
     Intended for single-user self-hosted deployments where the EE router is
     mounted (uploads land in Mongo) but chat still goes through the OSS
@@ -126,58 +147,77 @@ async def _resolve_via_ee_mongo(file_id: str) -> Path | None:
         from ee.cloud.uploads.router import _ADAPTER as EE_ADAPTER
         from ee.cloud.uploads.router import _META as EE_META
     except Exception:
-        return None
+        return None, None
 
     try:
         rec = await EE_META.get_unscoped(file_id)
     except Exception:
         logger.exception("EE mongo lookup failed for file_id=%s", file_id)
-        return None
+        return None, None
     if rec is None:
-        return None
+        return None, None
     try:
-        return EE_ADAPTER.local_path(rec.storage_key)
+        return EE_ADAPTER.local_path(rec.storage_key), rec
     except Exception:
         logger.exception(
             "EE adapter.local_path failed for file_id=%s storage_key=%s",
             file_id,
             rec.storage_key,
         )
-        return None
+        return None, rec
 
 
 async def resolve_media_paths_any(media: list[str]) -> list[str]:
     """Async counterpart to :func:`resolve_media_paths` that falls back to
-    the EE Mongo store when the OSS JSONL lookup misses.
+    the EE Mongo store when the OSS JSONL lookup misses. Returns only the
+    path strings; use :func:`resolve_media_with_records` when callers need
+    per-entry metadata (filename / mime / size) for richer prompts.
+    """
+    resolved = await resolve_media_with_records(media)
+    return [r.path for r in resolved]
 
-    Covers the common self-hosted EE case: uploads go through the EE
-    workspace-scoped router (Mongo), but chat still goes through the OSS
-    `/chat/stream` endpoint (no auth context). Without this fallback, the
-    agent would never see files uploaded via the EE path.
+
+async def resolve_media_with_records(media: list[str]) -> list[ResolvedMedia]:
+    """Return path + FileRecord pairs for each resolvable media entry.
+
+    - Upload URL that resolves via OSS JSONL → ``ResolvedMedia(path, rec)``
+    - Upload URL that resolves via EE Mongo fallback → ``ResolvedMedia(path, rec)``
+    - Non-upload string (already a path / opaque token) → ``ResolvedMedia(str, None)``
+    - Upload URL that resolves nowhere → dropped with a warning log
+
+    Callers that only want the paths can use :func:`resolve_media_paths_any`.
     """
     resolver = default_resolver()
-    out: list[str] = []
+    out: list[ResolvedMedia] = []
     for entry in media:
         fid = parse_upload_url(entry)
         if fid is None:
-            out.append(entry)
+            out.append(ResolvedMedia(path=entry, record=None))
             continue
+
+        # Try OSS first.
         path = resolver.resolve(entry)
-        if path is None:
-            path = await _resolve_via_ee_mongo(fid)
+        rec: FileRecord | None = None
+        if path is not None:
+            rec = resolver._meta.get(fid)
+        else:
+            path, rec = await _resolve_via_ee_mongo(fid)
+
         if path is None:
             logger.warning("dropping unresolvable upload entry: %s", entry)
             continue
-        out.append(str(path))
+        out.append(ResolvedMedia(path=str(path), record=rec))
     return out
 
 
 # Keep JSONLFileStore importable for type-friendly call sites.
 __all__ = [
+    "JSONLFileStore",
+    "ResolvedMedia",
     "UploadResolver",
     "default_resolver",
     "parse_upload_url",
     "resolve_media_paths",
     "resolve_media_paths_any",
-    "JSONLFileStore",
+    "resolve_media_with_records",
 ]

--- a/tests/test_agent_loop_media.py
+++ b/tests/test_agent_loop_media.py
@@ -1,0 +1,25 @@
+"""Tests for the media prompt helpers in pocketpaw.agents.loop."""
+
+from __future__ import annotations
+
+from pocketpaw.agents.loop import _format_bytes
+
+
+class TestFormatBytes:
+    def test_under_1kb_shows_bytes(self) -> None:
+        assert _format_bytes(0) == "0 B"
+        assert _format_bytes(1) == "1 B"
+        assert _format_bytes(1023) == "1023 B"
+
+    def test_kb_range(self) -> None:
+        assert _format_bytes(1024) == "1.0 KB"
+        assert _format_bytes(414255) == "404.5 KB"
+        assert _format_bytes(1024 * 1024 - 1) == "1024.0 KB"
+
+    def test_mb_range(self) -> None:
+        assert _format_bytes(1024 * 1024) == "1.0 MB"
+        assert _format_bytes(5_242_880) == "5.0 MB"
+
+    def test_gb_range(self) -> None:
+        assert _format_bytes(1024 * 1024 * 1024) == "1.0 GB"
+        assert _format_bytes(2 * 1024 * 1024 * 1024) == "2.0 GB"

--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -258,3 +258,42 @@ class TestSendMessageResolvesMedia:
         msg = captured["msg"]
         assert msg.content == "look at this"
         assert msg.media == [str(disk), "/already/local/path.pdf"]
+
+        # media_info should carry the FileRecord metadata only for resolved
+        # upload entries (not the passthrough "/already/local/path.pdf").
+        info = msg.metadata.get("media_info")
+        assert isinstance(info, list)
+        assert len(info) == 1
+        assert info[0] == {
+            "path": str(disk),
+            "filename": "x.txt",
+            "mime": "text/plain",
+            "size": 5,
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_media_info_when_no_upload_urls(self, tmp_path, monkeypatch):
+        from pocketpaw.api.v1.chat import _send_message
+        from pocketpaw.api.v1.schemas.chat import ChatRequest
+
+        captured: dict = {}
+
+        class _StubBus:
+            async def publish_inbound(self, msg):
+                captured["msg"] = msg
+
+        from pocketpaw import bus as bus_mod
+
+        monkeypatch.setattr(bus_mod, "get_message_bus", lambda: _StubBus())
+
+        req = ChatRequest(
+            content="plain text",
+            session_id="chat-2",
+            media=["/already/here.pdf"],
+        )
+        await _send_message(req)
+
+        msg = captured["msg"]
+        assert msg.media == ["/already/here.pdf"]
+        # Passthrough entries yield no media_info; key should be absent.
+        assert "media_info" not in msg.metadata

--- a/tests/uploads/test_resolver.py
+++ b/tests/uploads/test_resolver.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
 from pocketpaw.uploads.local import LocalStorageAdapter
 from pocketpaw.uploads.resolver import (
+    ResolvedMedia,
     UploadResolver,
     parse_upload_url,
     resolve_media_paths,
+    resolve_media_with_records,
 )
 
 
@@ -147,3 +150,71 @@ class TestResolveMediaPaths:
 
     def test_empty_list(self, resolver: UploadResolver) -> None:
         assert resolve_media_paths([], resolver=resolver) == []
+
+
+class TestResolveMediaWithRecords:
+    """Async version that returns path + FileRecord for prompt enrichment."""
+
+    @pytest.mark.asyncio
+    async def test_oss_hit_yields_record(self, tmp_upload_root: Path) -> None:
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+
+        file_id = uuid.uuid4().hex
+        storage_key = f"chat/202604/{file_id}.png"
+        disk = tmp_upload_root / storage_key
+        disk.parent.mkdir(parents=True, exist_ok=True)
+        disk.write_bytes(b"bytes")
+        rec = FileRecord(
+            id=file_id,
+            storage_key=storage_key,
+            filename="screenshot.png",
+            mime="image/png",
+            size=5,
+            owner_id="local",
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+        meta.save(rec)
+
+        with (
+            patch("pocketpaw.api.v1.uploads._ADAPTER", adapter),
+            patch("pocketpaw.api.v1.uploads._META", meta),
+        ):
+            result = await resolve_media_with_records([f"/api/v1/uploads/{file_id}"])
+
+        assert len(result) == 1
+        assert isinstance(result[0], ResolvedMedia)
+        assert result[0].path == str(disk)
+        assert result[0].record is not None
+        assert result[0].record.filename == "screenshot.png"
+        assert result[0].record.mime == "image/png"
+        assert result[0].record.size == 5
+
+    @pytest.mark.asyncio
+    async def test_passthrough_entry_has_none_record(self, tmp_upload_root: Path) -> None:
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+
+        with (
+            patch("pocketpaw.api.v1.uploads._ADAPTER", adapter),
+            patch("pocketpaw.api.v1.uploads._META", meta),
+        ):
+            result = await resolve_media_with_records(["/already/local/path.pdf"])
+
+        assert result == [ResolvedMedia(path="/already/local/path.pdf", record=None)]
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_upload_url_dropped(self, tmp_upload_root: Path) -> None:
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+
+        with (
+            patch("pocketpaw.api.v1.uploads._ADAPTER", adapter),
+            patch("pocketpaw.api.v1.uploads._META", meta),
+        ):
+            result = await resolve_media_with_records(
+                ["/api/v1/uploads/ghost0000000000000000000000000000"]
+            )
+
+        assert result == []


### PR DESCRIPTION
## Summary

Before this PR the agent prompt injected \`[Media files on disk: /abs/chat/202604/abc.png]\` — a storage-key path the model had to Read just to learn what kind of file it got. Now:

\`\`\`
Attached files:
- screenshot.png (image/png, 404.5 KB) at /abs/chat/202604/abc.png
\`\`\`

The agent sees filename + mime + size up front and can decide whether to Read (text/code), treat as an image, or ignore — without opening the bytes first.

## Changes

- \`pocketpaw/uploads/resolver.py\` gets a \`ResolvedMedia(path, record)\` dataclass and \`resolve_media_with_records\` that yields path + FileRecord pairs. Passthrough entries (non-upload strings) get \`record=None\`.
- \`api/v1/chat.py:_send_message\` uses the richer form to populate \`InboundMessage.metadata[\"media_info\"]\` — list of \`{path, filename, mime, size}\` dicts, one per resolved upload.
- \`agents/loop.py\` renders the richer block when \`media_info\` is present and falls back to the old plain-path line when it isn't — so adapters that don't know about uploads (Telegram/Discord/Slack/WhatsApp) keep their existing behavior.
- \`_format_bytes\` helper for human-readable sizes in the prompt.

## Test plan
- [x] \`tests/uploads/test_resolver.py\` — 3 new tests: OSS hit yields record, passthrough has \`None\` record, unresolvable drops.
- [x] \`tests/test_api_chat.py\` — 1 new test confirming \`media_info\` populated for resolved URLs and absent for passthroughs.
- [x] \`tests/test_agent_loop_media.py\` — 4 tests for the size formatter (B / KB / MB / GB).
- [x] \`pytest tests/uploads/ tests/cloud/uploads/ tests/test_api_chat.py tests/test_agent_loop_media.py\` → 102 passed.
- [x] Ruff + mypy clean on touched files.

## Not in scope
- Native vision blocks for Claude / OpenAI / Gemini (per-backend work).
- Persisting \`attachments\` on the \`Message\` doc so reloaded history shows them — follow-up on the feat/ee-mongo-memory-backend track.