### PR TITLE
feat(ee): seed pocketpaw agent + persist DM attachments end-to-end

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -39,8 +39,10 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(sessions_router, prefix="/api/v1")
 
     from ee.cloud.kb.router import router as kb_router
+    from ee.cloud.uploads.router import router as uploads_router
 
     app.include_router(kb_router, prefix="/api/v1")
+    app.include_router(uploads_router, prefix="/api/v1")
 
     # User search endpoint — used by group settings, pocket sharing
     from ee.cloud.models.user import User as UserModel

--- a/ee/cloud/auth/core.py
+++ b/ee/cloud/auth/core.py
@@ -251,7 +251,55 @@ async def seed_workspace(admin: User | None = None) -> Workspace | None:
         except Exception as exc:
             logger.warning("Failed to create default group (non-fatal): %s", exc)
 
+        # Seed the default "pocketpaw" agent — the agent that users DM
+        # through the runtime SSE chat endpoint. Gives DMs a stable
+        # identity so sessions can be keyed by agent_id.
+        try:
+            await seed_default_agent(str(ws.id), str(admin.id))
+        except Exception as exc:
+            logger.warning("Failed to seed default agent (non-fatal): %s", exc)
+
         return ws
     except Exception as exc:
         logger.error("Failed to seed workspace: %s", exc)
         return None
+
+
+async def seed_default_agent(workspace_id: str, owner_id: str) -> Agent | None:  # noqa: F821
+    """Create the default "pocketpaw" Agent for a workspace if missing.
+
+    The frontend uses this agent's id as the DM room identifier (replacing
+    the legacy ``__paw-runtime-dm__`` sentinel), and Session docs for DMs
+    carry ``agent=<this agent's id>`` so per-agent history works.
+
+    Idempotent: returns the existing agent if one with slug="pocketpaw"
+    already exists in the workspace.
+    """
+    from ee.cloud.models.agent import Agent, AgentConfig
+
+    existing = await Agent.find_one(Agent.workspace == workspace_id, Agent.slug == "pocketpaw")
+    if existing is not None:
+        return existing
+
+    agent = Agent(
+        workspace=workspace_id,
+        name="PocketPaw",
+        slug="pocketpaw",
+        avatar="",
+        owner=owner_id,
+        visibility="workspace",
+        config=AgentConfig(
+            system_prompt=(
+                "You are PocketPaw — the default assistant in this workspace. "
+                "Help the user with their tasks. Be concise, accurate, and honest."
+            ),
+            soul_persona="PocketPaw",
+        ),
+    )
+    await agent.insert()
+    logger.info(
+        "Default 'pocketpaw' agent seeded in workspace %s (id: %s)",
+        workspace_id,
+        agent.id,
+    )
+    return agent

--- a/ee/cloud/models/__init__.py
+++ b/ee/cloud/models/__init__.py
@@ -13,7 +13,18 @@ from ee.cloud.models.pocket import Pocket, Widget, WidgetPosition
 from ee.cloud.models.session import Session
 from ee.cloud.models.user import OAuthAccount, User, WorkspaceMembership
 from ee.cloud.models.workspace import Workspace, WorkspaceSettings
-from ee.cloud.uploads.models import FileUpload
+
+# Lazy import to avoid circular imports
+FileUpload: type = None  # type: ignore[assignment]
+
+
+def _ensure_file_upload():
+    global FileUpload
+    if FileUpload is None:
+        from ee.cloud.uploads.models import FileUpload as _FileUpload
+
+        FileUpload = _FileUpload
+    return FileUpload
 
 __all__ = [
     "Agent",
@@ -43,17 +54,55 @@ __all__ = [
     "WorkspaceSettings",
 ]
 
-ALL_DOCUMENTS = [
-    User,
-    Agent,
-    Pocket,
-    Session,
-    Comment,
-    Notification,
-    FileObj,
-    FileUpload,
-    Workspace,
-    Invite,
-    Group,
-    Message,
-]
+def get_all_documents():
+    """Get all Beanie documents, with lazy FileUpload loading."""
+    _ensure_file_upload()
+    return [
+        User,
+        Agent,
+        Pocket,
+        Session,
+        Comment,
+        Notification,
+        FileObj,
+        FileUpload,
+        Workspace,
+        Invite,
+        Group,
+        Message,
+    ]
+
+
+# For backward compat, expose as lazy-loading list
+class _LazyAllDocuments(list):
+    """Lazy-loads ALL_DOCUMENTS on first access."""
+
+    def __init__(self):
+        super().__init__()
+        self._loaded = False
+
+    def _ensure_loaded(self):
+        if not self._loaded:
+            docs = get_all_documents()
+            self.clear()
+            self.extend(docs)
+            self._loaded = True
+
+    def __getitem__(self, index):
+        self._ensure_loaded()
+        return super().__getitem__(index)
+
+    def __iter__(self):
+        self._ensure_loaded()
+        return super().__iter__()
+
+    def __len__(self):
+        self._ensure_loaded()
+        return super().__len__()
+
+    def __contains__(self, item):
+        self._ensure_loaded()
+        return super().__contains__(item)
+
+
+ALL_DOCUMENTS = _LazyAllDocuments()

--- a/ee/cloud/models/__init__.py
+++ b/ee/cloud/models/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     "CommentAuthor",
     "CommentTarget",
     "FileObj",
+    "FileUpload",
     "Group",
     "GroupAgent",
     "Invite",
@@ -41,16 +42,64 @@ __all__ = [
     "WorkspaceSettings",
 ]
 
-ALL_DOCUMENTS = [
-    User,
-    Agent,
-    Pocket,
-    Session,
-    Comment,
-    Notification,
-    FileObj,
-    Workspace,
-    Invite,
-    Group,
-    Message,
-]
+_ALL_DOCUMENTS_CACHE = None
+
+
+def get_all_documents():
+    """Lazy load ALL_DOCUMENTS to avoid circular imports."""
+    global _ALL_DOCUMENTS_CACHE
+    if _ALL_DOCUMENTS_CACHE is not None:
+        return _ALL_DOCUMENTS_CACHE
+
+    from ee.cloud.uploads.models import FileUpload
+
+    _ALL_DOCUMENTS_CACHE = [
+        User,
+        Agent,
+        Pocket,
+        Session,
+        Comment,
+        Notification,
+        FileObj,
+        FileUpload,
+        Workspace,
+        Invite,
+        Group,
+        Message,
+    ]
+    return _ALL_DOCUMENTS_CACHE
+
+
+# For backward compatibility, expose as property that auto-calls get_all_documents()
+class _AllDocumentsProxy(list):
+    """Proxy that lazily loads ALL_DOCUMENTS."""
+
+    def __init__(self):
+        super().__init__()
+        self._loaded = False
+
+    def _ensure_loaded(self):
+        if not self._loaded:
+            docs = get_all_documents()
+            self.clear()
+            self.extend(docs)
+            self._loaded = True
+
+    def __getitem__(self, index):
+        self._ensure_loaded()
+        return super().__getitem__(index)
+
+    def __iter__(self):
+        self._ensure_loaded()
+        return super().__iter__()
+
+    def __len__(self):
+        self._ensure_loaded()
+        return super().__len__()
+
+    def __contains__(self, item):
+        self._ensure_loaded()
+        return super().__contains__(item)
+
+
+ALL_DOCUMENTS = _AllDocumentsProxy()

--- a/ee/cloud/models/__init__.py
+++ b/ee/cloud/models/__init__.py
@@ -13,6 +13,7 @@ from ee.cloud.models.pocket import Pocket, Widget, WidgetPosition
 from ee.cloud.models.session import Session
 from ee.cloud.models.user import OAuthAccount, User, WorkspaceMembership
 from ee.cloud.models.workspace import Workspace, WorkspaceSettings
+from ee.cloud.uploads.models import FileUpload
 
 __all__ = [
     "Agent",
@@ -42,64 +43,17 @@ __all__ = [
     "WorkspaceSettings",
 ]
 
-_ALL_DOCUMENTS_CACHE = None
-
-
-def get_all_documents():
-    """Lazy load ALL_DOCUMENTS to avoid circular imports."""
-    global _ALL_DOCUMENTS_CACHE
-    if _ALL_DOCUMENTS_CACHE is not None:
-        return _ALL_DOCUMENTS_CACHE
-
-    from ee.cloud.uploads.models import FileUpload
-
-    _ALL_DOCUMENTS_CACHE = [
-        User,
-        Agent,
-        Pocket,
-        Session,
-        Comment,
-        Notification,
-        FileObj,
-        FileUpload,
-        Workspace,
-        Invite,
-        Group,
-        Message,
-    ]
-    return _ALL_DOCUMENTS_CACHE
-
-
-# For backward compatibility, expose as property that auto-calls get_all_documents()
-class _AllDocumentsProxy(list):
-    """Proxy that lazily loads ALL_DOCUMENTS."""
-
-    def __init__(self):
-        super().__init__()
-        self._loaded = False
-
-    def _ensure_loaded(self):
-        if not self._loaded:
-            docs = get_all_documents()
-            self.clear()
-            self.extend(docs)
-            self._loaded = True
-
-    def __getitem__(self, index):
-        self._ensure_loaded()
-        return super().__getitem__(index)
-
-    def __iter__(self):
-        self._ensure_loaded()
-        return super().__iter__()
-
-    def __len__(self):
-        self._ensure_loaded()
-        return super().__len__()
-
-    def __contains__(self, item):
-        self._ensure_loaded()
-        return super().__contains__(item)
-
-
-ALL_DOCUMENTS = _AllDocumentsProxy()
+ALL_DOCUMENTS = [
+    User,
+    Agent,
+    Pocket,
+    Session,
+    Comment,
+    Notification,
+    FileObj,
+    FileUpload,
+    Workspace,
+    Invite,
+    Group,
+    Message,
+]

--- a/ee/cloud/sessions/router.py
+++ b/ee/cloud/sessions/router.py
@@ -35,9 +35,14 @@ async def create_session(
 
 @router.get("", dependencies=[Depends(require_action_any_workspace("session.read_own"))])
 async def list_sessions(
+    agent_id: str | None = None,
     workspace_id: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
 ) -> list[dict]:
+    """List the user's sessions. ``?agent_id=X`` filters to DM sessions for
+    that agent (used by the frontend to resolve the DM room)."""
+    if agent_id:
+        return await SessionService.list_by_agent(workspace_id, user_id, agent_id)
     return await SessionService.list_sessions(workspace_id, user_id)
 
 

--- a/ee/cloud/sessions/service.py
+++ b/ee/cloud/sessions/service.py
@@ -97,6 +97,29 @@ class SessionService:
         return [_session_response(s) for s in sessions]
 
     @staticmethod
+    async def list_by_agent(
+        workspace_id: str,
+        user_id: str,
+        agent_id: str,
+    ) -> list[dict]:
+        """List a user's DM sessions for a specific agent, newest first.
+
+        Used by the frontend to resolve the DM room for an agent — pick the
+        most-recent session to resume, or show the full list for history.
+        """
+        sessions = (
+            await Session.find(
+                Session.workspace == workspace_id,
+                Session.owner == user_id,
+                Session.agent == agent_id,
+                Session.deleted_at == None,  # noqa: E711
+            )
+            .sort(-Session.lastActivity)
+            .to_list()
+        )
+        return [_session_response(s) for s in sessions]
+
+    @staticmethod
     async def get(session_id: str, user_id: str) -> dict:
         session = await SessionService._get_session(session_id, user_id)
         return _session_response(session)
@@ -190,6 +213,7 @@ class SessionService:
                         "sender": m.sender,
                         "senderType": m.sender_type,
                         "createdAt": m.createdAt.isoformat() if m.createdAt else None,
+                        "attachments": [a.model_dump() for a in (m.attachments or [])],
                     }
                     for m in messages
                 ]
@@ -211,6 +235,7 @@ class SessionService:
                     "sender": m.sender,
                     "senderType": m.sender_type,
                     "createdAt": m.createdAt.isoformat() if m.createdAt else None,
+                    "attachments": [a.model_dump() for a in (m.attachments or [])],
                 }
                 for m in messages
             ]

--- a/ee/cloud/shared/chat_persistence.py
+++ b/ee/cloud/shared/chat_persistence.py
@@ -49,14 +49,29 @@ def register_chat_persistence() -> None:
         logger.exception("Failed to register chat persistence")
 
 
-async def save_user_message(chat_id: str, content: str) -> None:
-    """Persist a user chat message. ``chat_id`` must be the Session.sessionId."""
+async def save_user_message(
+    chat_id: str,
+    content: str,
+    attachments: list[dict] | None = None,
+) -> None:
+    """Persist a user chat message. ``chat_id`` must be the Session.sessionId.
+
+    ``attachments``, when present, is a list of Attachment-shaped dicts
+    (``{type, url, name, meta}``). They are stored on the Message doc so
+    reloaded history shows the uploaded files.
+    """
     try:
         ctx = await _resolve_session_context(chat_id)
         if not ctx:
             logger.warning("no session context for chat_id=%s — user message dropped", chat_id)
             return
-        await _write_message(ctx, role="user", content=content, sender_type="user")
+        await _write_message(
+            ctx,
+            role="user",
+            content=content,
+            sender_type="user",
+            attachments=attachments,
+        )
     except Exception:
         logger.exception("Failed to persist user message")
 
@@ -77,13 +92,9 @@ async def _on_outbound_message(message) -> None:
 
             ctx = await _resolve_session_context(chat_id)
             if not ctx:
-                logger.warning(
-                    "no session context for chat_id=%s — agent message dropped", chat_id
-                )
+                logger.warning("no session context for chat_id=%s — agent message dropped", chat_id)
                 return
-            await _write_message(
-                ctx, role="assistant", content=full_text, sender_type="agent"
-            )
+            await _write_message(ctx, role="assistant", content=full_text, sender_type="agent")
             return
 
         # Non-streaming content accumulation
@@ -172,10 +183,27 @@ async def _auto_create_pocket_session(chat_id: str):
     return session
 
 
-async def _write_message(ctx: dict, *, role: str, content: str, sender_type: str) -> None:
+async def _write_message(
+    ctx: dict,
+    *,
+    role: str,
+    content: str,
+    sender_type: str,
+    attachments: list[dict] | None = None,
+) -> None:
     """Insert a Message in the right context and touch the Session."""
-    from ee.cloud.models.message import Message
+    from ee.cloud.models.message import Attachment, Message
     from ee.cloud.models.session import Session
+
+    # Coerce incoming dicts to the Attachment document model so Beanie
+    # doesn't try to persist raw dicts.
+    attachment_docs: list[Attachment] = []
+    if attachments:
+        for a in attachments:
+            try:
+                attachment_docs.append(Attachment(**a))
+            except Exception:
+                logger.warning("skipping malformed attachment on user message: %r", a)
 
     if ctx["is_group"]:
         msg = Message(
@@ -184,6 +212,7 @@ async def _write_message(ctx: dict, *, role: str, content: str, sender_type: str
             sender=ctx["owner"] if sender_type == "user" else None,
             sender_type=sender_type,
             content=content,
+            attachments=attachment_docs,
         )
     else:
         msg = Message(
@@ -193,6 +222,7 @@ async def _write_message(ctx: dict, *, role: str, content: str, sender_type: str
             sender=ctx["owner"] if sender_type == "user" else None,
             sender_type=sender_type,
             content=content,
+            attachments=attachment_docs,
         )
     await msg.insert()
 

--- a/ee/cloud/uploads/models.py
+++ b/ee/cloud/uploads/models.py
@@ -1,0 +1,35 @@
+"""EE FileUpload document — Mongo metadata for blobs stored via StorageAdapter."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from beanie import Indexed
+
+from ee.cloud.models.base import TimestampedDocument
+
+
+class FileUpload(TimestampedDocument):
+    """Metadata for one uploaded file. Blob bytes live in the StorageAdapter.
+
+    Distinct from ``ee.cloud.models.file.FileObj`` (pre-signed URL storage):
+    ``FileUpload`` is the adapter-backed path for chat attachments, with
+    workspace scoping and soft-delete.
+    """
+
+    file_id: Indexed(str, unique=True)  # type: ignore[valid-type]
+    storage_key: str
+    filename: str
+    mime: str
+    size: int
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    owner: str
+    chat_id: Indexed(str) | None = None  # type: ignore[valid-type]
+    deleted_at: datetime | None = None
+
+    class Settings:
+        name = "file_uploads"
+        indexes = [
+            [("workspace", 1), ("chat_id", 1), ("createdAt", -1)],
+            [("workspace", 1), ("owner", 1), ("createdAt", -1)],
+        ]

--- a/ee/cloud/uploads/mongo_store.py
+++ b/ee/cloud/uploads/mongo_store.py
@@ -1,0 +1,54 @@
+"""Mongo-backed metadata store, workspace-scoped."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from ee.cloud.uploads.models import FileUpload
+from pocketpaw.uploads.file_store import FileRecord
+
+
+class MongoFileStore:
+    """Workspace-scoped metadata store for EE uploads."""
+
+    async def save_scoped(self, record: FileRecord, workspace: str) -> None:
+        doc = FileUpload(
+            file_id=record.id,
+            storage_key=record.storage_key,
+            filename=record.filename,
+            mime=record.mime,
+            size=record.size,
+            workspace=workspace,
+            owner=record.owner_id,
+            chat_id=record.chat_id,
+        )
+        await doc.insert()
+
+    async def get_scoped(self, file_id: str, workspace: str) -> FileRecord | None:
+        doc = await FileUpload.find_one(
+            FileUpload.file_id == file_id,
+            FileUpload.workspace == workspace,
+            FileUpload.deleted_at == None,  # noqa: E711 beanie needs literal None
+        )
+        if doc is None:
+            return None
+        return FileRecord(
+            id=doc.file_id,
+            storage_key=doc.storage_key,
+            filename=doc.filename,
+            mime=doc.mime,
+            size=doc.size,
+            owner_id=doc.owner,
+            chat_id=doc.chat_id,
+            created=doc.createdAt or datetime.now(UTC),
+        )
+
+    async def soft_delete_scoped(self, file_id: str, workspace: str) -> None:
+        doc = await FileUpload.find_one(
+            FileUpload.file_id == file_id,
+            FileUpload.workspace == workspace,
+        )
+        if doc is None:
+            return
+        doc.deleted_at = datetime.now(UTC)
+        await doc.save()

--- a/ee/cloud/uploads/mongo_store.py
+++ b/ee/cloud/uploads/mongo_store.py
@@ -30,6 +30,24 @@ class MongoFileStore:
             FileUpload.workspace == workspace,
             FileUpload.deleted_at == None,  # noqa: E711 beanie needs literal None
         )
+        return self._to_record(doc)
+
+    async def get_unscoped(self, file_id: str) -> FileRecord | None:
+        """Find a live record by file_id without workspace filter.
+
+        Intended for call sites that lack tenant context (e.g. the OSS chat
+        bridge in single-user self-hosted deployments). Multi-tenant cloud
+        chat flows should use ``get_scoped`` with an authenticated workspace
+        and never call this.
+        """
+        doc = await FileUpload.find_one(
+            FileUpload.file_id == file_id,
+            FileUpload.deleted_at == None,  # noqa: E711
+        )
+        return self._to_record(doc)
+
+    @staticmethod
+    def _to_record(doc: FileUpload | None) -> FileRecord | None:
         if doc is None:
             return None
         return FileRecord(

--- a/ee/cloud/uploads/resolver.py
+++ b/ee/cloud/uploads/resolver.py
@@ -1,0 +1,68 @@
+"""EE workspace-scoped upload URL resolver.
+
+Wraps :class:`pocketpaw.uploads.resolver.UploadResolver` semantics but looks
+up metadata in Mongo with workspace isolation. Cross-tenant lookups return
+``None`` (treated as "not found" — no leak of existence across workspaces).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ee.cloud.uploads.mongo_store import MongoFileStore
+from pocketpaw.uploads.adapter import StorageAdapter
+from pocketpaw.uploads.resolver import parse_upload_url
+
+
+class EEUploadResolver:
+    """Resolve upload URLs inside a single workspace."""
+
+    def __init__(self, adapter: StorageAdapter, meta: MongoFileStore) -> None:
+        self._adapter = adapter
+        self._meta = meta
+
+    async def resolve(self, url: str, workspace: str) -> Path | None:
+        file_id = parse_upload_url(url)
+        if file_id is None:
+            return None
+        rec = await self._meta.get_scoped(file_id, workspace=workspace)
+        if rec is None:
+            return None
+        return self._adapter.local_path(rec.storage_key)
+
+
+async def resolve_media_paths_scoped(
+    media: list[str],
+    *,
+    resolver: EEUploadResolver,
+    workspace: str,
+) -> list[str]:
+    """Async counterpart to :func:`pocketpaw.uploads.resolver.resolve_media_paths`.
+
+    Same semantics: upload URLs → local paths, unresolvable URLs dropped,
+    non-upload strings passed through.
+    """
+    out: list[str] = []
+    for entry in media:
+        fid = parse_upload_url(entry)
+        if fid is None:
+            out.append(entry)
+            continue
+        path = await resolver.resolve(entry, workspace=workspace)
+        if path is not None:
+            out.append(str(path))
+    return out
+
+
+def default_resolver() -> EEUploadResolver:
+    """Return the resolver wired to the EE /uploads singletons."""
+    from ee.cloud.uploads.router import _ADAPTER, _META
+
+    return EEUploadResolver(adapter=_ADAPTER, meta=_META)
+
+
+__all__ = [
+    "EEUploadResolver",
+    "default_resolver",
+    "resolve_media_paths_scoped",
+]

--- a/ee/cloud/uploads/resolver.py
+++ b/ee/cloud/uploads/resolver.py
@@ -7,11 +7,14 @@ up metadata in Mongo with workspace isolation. Cross-tenant lookups return
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from ee.cloud.uploads.mongo_store import MongoFileStore
 from pocketpaw.uploads.adapter import StorageAdapter
 from pocketpaw.uploads.resolver import parse_upload_url
+
+logger = logging.getLogger(__name__)
 
 
 class EEUploadResolver:
@@ -28,7 +31,19 @@ class EEUploadResolver:
         rec = await self._meta.get_scoped(file_id, workspace=workspace)
         if rec is None:
             return None
-        return self._adapter.local_path(rec.storage_key)
+        # Contain unexpected adapter failures (permission errors on the
+        # storage root, remount races, future remote adapters) so chat
+        # never crashes over a bad attachment — just drops the entry.
+        try:
+            return self._adapter.local_path(rec.storage_key)
+        except Exception:
+            logger.exception(
+                "upload adapter.local_path failed for file_id=%s storage_key=%s workspace=%s",
+                file_id,
+                rec.storage_key,
+                workspace,
+            )
+            return None
 
 
 async def resolve_media_paths_scoped(
@@ -49,8 +64,12 @@ async def resolve_media_paths_scoped(
             out.append(entry)
             continue
         path = await resolver.resolve(entry, workspace=workspace)
-        if path is not None:
-            out.append(str(path))
+        if path is None:
+            logger.warning(
+                "dropping unresolvable upload entry (workspace=%s): %s", workspace, entry
+            )
+            continue
+        out.append(str(path))
     return out
 
 

--- a/ee/cloud/uploads/router.py
+++ b/ee/cloud/uploads/router.py
@@ -82,7 +82,10 @@ async def download(
     return StreamingResponse(
         it,
         media_type=rec.mime,
-        headers={"Content-Disposition": f'{disposition}; filename="{rec.filename}"'},
+        headers={
+            "Content-Disposition": f'{disposition}; filename="{rec.filename}"',
+            "X-Content-Type-Options": "nosniff",
+        },
     )
 
 

--- a/ee/cloud/uploads/router.py
+++ b/ee/cloud/uploads/router.py
@@ -1,0 +1,99 @@
+"""EE /uploads router — workspace-scoped upload endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Response,
+    UploadFile,
+    status,
+)
+from fastapi.responses import StreamingResponse
+
+from ee.cloud.license import require_license
+from ee.cloud.shared.deps import current_user_id, current_workspace_id
+from ee.cloud.uploads.mongo_store import MongoFileStore
+from ee.cloud.uploads.service import EEUploadService
+from pocketpaw.uploads.config import INLINE_MIMES, UploadSettings
+from pocketpaw.uploads.errors import NotFound
+from pocketpaw.uploads.local import LocalStorageAdapter
+
+# Module-level singletons — one adapter + store per process
+_ROOT = Path.home() / ".pocketpaw" / "uploads"
+_CFG = UploadSettings(local_root=_ROOT)
+_ADAPTER = LocalStorageAdapter(root=_ROOT)
+_META = MongoFileStore()
+_SVC = EEUploadService(adapter=_ADAPTER, meta=_META, cfg=_CFG)
+
+router = APIRouter(
+    prefix="/uploads",
+    tags=["Uploads"],
+    dependencies=[Depends(require_license)],
+)
+
+
+def _record_to_dict(rec) -> dict:
+    return {
+        "id": rec.id,
+        "filename": rec.filename,
+        "mime": rec.mime,
+        "size": rec.size,
+        "url": f"/api/v1/uploads/{rec.id}",
+        "created": rec.created.isoformat(),
+    }
+
+
+@router.post("")
+async def upload(
+    files: Annotated[list[UploadFile], File(...)],
+    chat_id: Annotated[str | None, Form()] = None,
+    workspace: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    try:
+        result = await _SVC.upload_many(files, user_id, chat_id, workspace)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return {
+        "uploaded": [_record_to_dict(r) for r in result.uploaded],
+        "failed": [asdict(f) for f in result.failed],
+    }
+
+
+@router.get("/{file_id}")
+async def download(
+    file_id: str,
+    workspace: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> StreamingResponse:
+    try:
+        rec, it = await _SVC.stream(file_id, user_id, workspace)
+    except NotFound as e:
+        raise HTTPException(status_code=404, detail="not found") from e
+    disposition = "inline" if rec.mime in INLINE_MIMES else "attachment"
+    return StreamingResponse(
+        it,
+        media_type=rec.mime,
+        headers={"Content-Disposition": f'{disposition}; filename="{rec.filename}"'},
+    )
+
+
+@router.delete("/{file_id}", status_code=204)
+async def delete_upload(
+    file_id: str,
+    workspace: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> Response:
+    try:
+        await _SVC.delete(file_id, user_id, workspace)
+    except NotFound as e:
+        raise HTTPException(status_code=404, detail="not found") from e
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/ee/cloud/uploads/service.py
+++ b/ee/cloud/uploads/service.py
@@ -1,0 +1,92 @@
+"""EEUploadService — workspace-scoped upload pipeline on top of the OSS service."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from fastapi import UploadFile
+
+from ee.cloud.uploads.mongo_store import MongoFileStore
+from pocketpaw.uploads.adapter import StorageAdapter
+from pocketpaw.uploads.config import UploadSettings
+from pocketpaw.uploads.errors import NotFound
+from pocketpaw.uploads.file_store import FileRecord
+from pocketpaw.uploads.service import (
+    BulkUploadResult,
+    UploadService,
+    _raise,
+)
+
+
+class _NullMeta:
+    """Stub JSONLFileStore — validates but doesn't persist (EE uses Mongo)."""
+
+    def save(self, record: FileRecord) -> None:
+        pass
+
+    def get(self, file_id: str) -> FileRecord | None:
+        return None
+
+    def soft_delete(self, file_id: str) -> None:
+        pass
+
+
+class EEUploadService:
+    """Workspace-scoped upload pipeline.
+
+    Wraps the OSS ``UploadService`` for validation + magic-byte sniff + adapter
+    writes, then persists metadata to Mongo with workspace scoping.
+    """
+
+    def __init__(
+        self,
+        adapter: StorageAdapter,
+        meta: MongoFileStore,
+        cfg: UploadSettings,
+    ) -> None:
+        self._adapter = adapter
+        self._meta = meta
+        self._cfg = cfg
+        # Use a null meta under OSS service so we control Mongo writes here
+        self._oss = UploadService(adapter=adapter, meta=_NullMeta(), cfg=cfg)  # type: ignore[arg-type]
+
+    async def upload(
+        self, file: UploadFile, owner_id: str, chat_id: str | None, workspace: str,
+    ) -> FileRecord:
+        result = await self.upload_many([file], owner_id, chat_id, workspace)
+        if result.failed:
+            f = result.failed[0]
+            _raise(f.code, f.reason)
+        return result.uploaded[0]
+
+    async def upload_many(
+        self, files: list[UploadFile], owner_id: str, chat_id: str | None, workspace: str,
+    ) -> BulkUploadResult:
+        # Delegate validation + adapter writes; metadata is discarded inside OSS
+        result = await self._oss.upload_many(files, owner_id, chat_id)
+        # Persist each successful record in Mongo with workspace scoping
+        for rec in result.uploaded:
+            await self._meta.save_scoped(rec, workspace=workspace)
+        return result
+
+    async def stream(
+        self, file_id: str, requester_id: str, workspace: str,
+    ) -> tuple[FileRecord, AsyncIterator[bytes]]:
+        rec = await self._meta.get_scoped(file_id, workspace=workspace)
+        if rec is None:
+            raise NotFound()
+        if rec.owner_id != requester_id:
+            # v1: owner-only. Chat-member check is a follow-up.
+            raise NotFound()
+        return rec, self._adapter.open(rec.storage_key)
+
+    async def delete(
+        self, file_id: str, requester_id: str, workspace: str,
+    ) -> None:
+        rec = await self._meta.get_scoped(file_id, workspace=workspace)
+        if rec is None:
+            raise NotFound()
+        if rec.owner_id != requester_id:
+            raise NotFound()
+        await self._adapter.delete(rec.storage_key)
+        await self._meta.soft_delete_scoped(file_id, workspace=workspace)

--- a/ee/cloud/uploads/service.py
+++ b/ee/cloud/uploads/service.py
@@ -102,5 +102,8 @@ class EEUploadService:
             raise NotFound()
         if rec.owner_id != requester_id:
             raise NotFound()
-        await self._adapter.delete(rec.storage_key)
+        # Mark deleted in Mongo first — if the adapter call fails, the record
+        # stays tombstoned and the blob becomes an orphan (picked up by a
+        # future cleanup job) rather than silently surviving visibility.
         await self._meta.soft_delete_scoped(file_id, workspace=workspace)
+        await self._adapter.delete(rec.storage_key)

--- a/ee/cloud/uploads/service.py
+++ b/ee/cloud/uploads/service.py
@@ -51,7 +51,11 @@ class EEUploadService:
         self._oss = UploadService(adapter=adapter, meta=_NullMeta(), cfg=cfg)  # type: ignore[arg-type]
 
     async def upload(
-        self, file: UploadFile, owner_id: str, chat_id: str | None, workspace: str,
+        self,
+        file: UploadFile,
+        owner_id: str,
+        chat_id: str | None,
+        workspace: str,
     ) -> FileRecord:
         result = await self.upload_many([file], owner_id, chat_id, workspace)
         if result.failed:
@@ -60,7 +64,11 @@ class EEUploadService:
         return result.uploaded[0]
 
     async def upload_many(
-        self, files: list[UploadFile], owner_id: str, chat_id: str | None, workspace: str,
+        self,
+        files: list[UploadFile],
+        owner_id: str,
+        chat_id: str | None,
+        workspace: str,
     ) -> BulkUploadResult:
         # Delegate validation + adapter writes; metadata is discarded inside OSS
         result = await self._oss.upload_many(files, owner_id, chat_id)
@@ -70,7 +78,10 @@ class EEUploadService:
         return result
 
     async def stream(
-        self, file_id: str, requester_id: str, workspace: str,
+        self,
+        file_id: str,
+        requester_id: str,
+        workspace: str,
     ) -> tuple[FileRecord, AsyncIterator[bytes]]:
         rec = await self._meta.get_scoped(file_id, workspace=workspace)
         if rec is None:
@@ -81,7 +92,10 @@ class EEUploadService:
         return rec, self._adapter.open(rec.storage_key)
 
     async def delete(
-        self, file_id: str, requester_id: str, workspace: str,
+        self,
+        file_id: str,
+        requester_id: str,
+        workspace: str,
     ) -> None:
         rec = await self._meta.get_scoped(file_id, workspace=workspace)
         if rec is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -399,6 +399,7 @@ dev = [
     "ruff>=0.4.0",
     "mypy>=1.8.0",
     "pytest-playwright>=0.7.2",
+    "types-aiofiles>=25.1.0.20260409",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
     "pydantic-settings>=2.1.0",
     # HTTP client (used everywhere)
     "httpx>=0.26.0",
+    # Async file I/O
+    "aiofiles>=23.2.0",
     # LLM Clients
     "openai>=1.60.0",
     "anthropic>=0.45.0",

--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -264,6 +264,17 @@ def _strip_tts_links(text: str) -> str:
     return text.strip()
 
 
+def _format_bytes(n: int) -> str:
+    """Human-readable byte size (e.g. ``414.7 KB``) for prompt injection."""
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    if n < 1024 * 1024 * 1024:
+        return f"{n / (1024 * 1024):.1f} MB"
+    return f"{n / (1024 * 1024 * 1024):.1f} GB"
+
+
 class AgentLoop:
     """
     Main agent execution loop.
@@ -667,8 +678,26 @@ class AgentLoop:
                 Path(p).suffix.lower() in _AUDIO_EXTS for p in (message.media or [])
             )
             if message.media:
-                paths_info = ", ".join(message.media)
-                content += f"\n[Media files on disk: {paths_info}]"
+                # Prefer the richer form when the chat bridge populated metadata
+                # (filename + mime + size per path). The plain path list is still
+                # a correct fallback — e.g. Telegram / Discord / WhatsApp adapters
+                # that don't produce upload records will drop in here.
+                media_info = (message.metadata or {}).get("media_info") or []
+                if media_info:
+                    lines = []
+                    for info in media_info:
+                        filename = info.get("filename") or Path(info.get("path", "")).name or "file"
+                        mime = info.get("mime") or "application/octet-stream"
+                        size = info.get("size")
+                        size_str = _format_bytes(size) if isinstance(size, int) else ""
+                        meta_suffix = f", {size_str}" if size_str else ""
+                        lines.append(
+                            f"- {filename} ({mime}{meta_suffix}) at {info.get('path', '')}"
+                        )
+                    content += "\n\nAttached files:\n" + "\n".join(lines)
+                else:
+                    paths_info = ", ".join(message.media)
+                    content += f"\n[Media files on disk: {paths_info}]"
 
             # 2. Build system prompt + session history concurrently (independent I/O)
             sender_id = message.sender_id

--- a/src/pocketpaw/api/v1/__init__.py
+++ b/src/pocketpaw/api/v1/__init__.py
@@ -56,6 +56,7 @@ _V1_ROUTERS: list[tuple[str, str, str]] = [
     ("pocketpaw.api.v1.connectors", "router", "Connectors"),
     ("pocketpaw.api.v1.tools", "router", "Tools"),
     ("pocketpaw.api.v1.oauth_integrations", "router", "OAuth Integrations"),
+    ("pocketpaw.api.v1.uploads", "router", "Uploads"),
     ("pocketpaw.audit.router", "router", "Audit"),
 ]
 

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -215,6 +215,31 @@ async def _send_message(chat_request: ChatRequest) -> str:
     if media_info:
         meta["media_info"] = media_info
 
+    # Persistence-friendly Attachment payloads for Mongo history. Kept on the
+    # original upload URL (not the resolved disk path) so the FE can <img
+    # src> the stored message on reload without server-side rewriting.
+    attachments: list[dict] = []
+    for original_url, r in zip(chat_request.media or [], resolved, strict=False):
+        if r.record is None:
+            continue
+        kind = (
+            "image"
+            if r.record.mime.startswith("image/")
+            else ("audio" if r.record.mime.startswith("audio/") else "file")
+        )
+        attachments.append(
+            {
+                "type": kind,
+                "url": original_url,
+                "name": r.record.filename,
+                "meta": {
+                    "mime": r.record.mime,
+                    "size": r.record.size,
+                    "id": r.record.id,
+                },
+            }
+        )
+
     msg = InboundMessage(
         channel=Channel.WEBSOCKET,
         sender_id="api_client",
@@ -225,6 +250,18 @@ async def _send_message(chat_request: ChatRequest) -> str:
     )
     bus = get_message_bus()
     await bus.publish_inbound(msg)
+
+    # Persist the user message with attachments to Mongo so reloaded history
+    # shows uploads. Isolated import so OSS (no EE) deployments don't fail.
+    try:
+        from ee.cloud.shared.chat_persistence import save_user_message
+
+        await save_user_message(chat_id, chat_request.content, attachments=attachments or None)
+    except ImportError:
+        pass
+    except Exception:
+        logger.exception("chat_persistence.save_user_message failed")
+
     return chat_id
 
 

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -188,7 +188,7 @@ async def _send_message(chat_request: ChatRequest) -> str:
     """Publish an inbound message to the bus and return the chat_id."""
     from pocketpaw.bus import get_message_bus
     from pocketpaw.bus.events import Channel, InboundMessage
-    from pocketpaw.uploads.resolver import default_resolver, resolve_media_paths
+    from pocketpaw.uploads.resolver import resolve_media_paths_any
 
     chat_id = _extract_chat_id(chat_request.session_id)
 
@@ -197,8 +197,10 @@ async def _send_message(chat_request: ChatRequest) -> str:
         meta["file_context"] = chat_request.file_context.model_dump(exclude_none=True)
 
     # Resolve ``/api/v1/uploads/{id}`` URLs in ``media`` to local disk paths
-    # so the agent loop can hand them to the Read tool.
-    media = resolve_media_paths(chat_request.media or [], resolver=default_resolver())
+    # so the agent loop can hand them to the Read tool. Falls back to the EE
+    # Mongo store when OSS JSONL misses — common in self-hosted EE where
+    # uploads go through the workspace-scoped router but chat is OSS.
+    media = await resolve_media_paths_any(chat_request.media or [])
 
     msg = InboundMessage(
         channel=Channel.WEBSOCKET,

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -188,7 +188,7 @@ async def _send_message(chat_request: ChatRequest) -> str:
     """Publish an inbound message to the bus and return the chat_id."""
     from pocketpaw.bus import get_message_bus
     from pocketpaw.bus.events import Channel, InboundMessage
-    from pocketpaw.uploads.resolver import resolve_media_paths_any
+    from pocketpaw.uploads.resolver import resolve_media_with_records
 
     chat_id = _extract_chat_id(chat_request.session_id)
 
@@ -196,11 +196,24 @@ async def _send_message(chat_request: ChatRequest) -> str:
     if chat_request.file_context:
         meta["file_context"] = chat_request.file_context.model_dump(exclude_none=True)
 
-    # Resolve ``/api/v1/uploads/{id}`` URLs in ``media`` to local disk paths
-    # so the agent loop can hand them to the Read tool. Falls back to the EE
-    # Mongo store when OSS JSONL misses — common in self-hosted EE where
-    # uploads go through the workspace-scoped router but chat is OSS.
-    media = await resolve_media_paths_any(chat_request.media or [])
+    # Resolve ``/api/v1/uploads/{id}`` URLs to (path, FileRecord) pairs so the
+    # agent prompt can carry filename / mime / size, not just a bare disk path.
+    # Falls back to the EE Mongo store when OSS JSONL misses — common in
+    # self-hosted EE where uploads go through the workspace-scoped router.
+    resolved = await resolve_media_with_records(chat_request.media or [])
+    media = [r.path for r in resolved]
+    media_info = [
+        {
+            "path": r.path,
+            "filename": r.record.filename,
+            "mime": r.record.mime,
+            "size": r.record.size,
+        }
+        for r in resolved
+        if r.record is not None
+    ]
+    if media_info:
+        meta["media_info"] = media_info
 
     msg = InboundMessage(
         channel=Channel.WEBSOCKET,

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -188,6 +188,7 @@ async def _send_message(chat_request: ChatRequest) -> str:
     """Publish an inbound message to the bus and return the chat_id."""
     from pocketpaw.bus import get_message_bus
     from pocketpaw.bus.events import Channel, InboundMessage
+    from pocketpaw.uploads.resolver import default_resolver, resolve_media_paths
 
     chat_id = _extract_chat_id(chat_request.session_id)
 
@@ -195,12 +196,16 @@ async def _send_message(chat_request: ChatRequest) -> str:
     if chat_request.file_context:
         meta["file_context"] = chat_request.file_context.model_dump(exclude_none=True)
 
+    # Resolve ``/api/v1/uploads/{id}`` URLs in ``media`` to local disk paths
+    # so the agent loop can hand them to the Read tool.
+    media = resolve_media_paths(chat_request.media or [], resolver=default_resolver())
+
     msg = InboundMessage(
         channel=Channel.WEBSOCKET,
         sender_id="api_client",
         chat_id=chat_id,
         content=chat_request.content,
-        media=chat_request.media,
+        media=media,
         metadata=meta,
     )
     bus = get_message_bus()

--- a/src/pocketpaw/api/v1/uploads.py
+++ b/src/pocketpaw/api/v1/uploads.py
@@ -1,0 +1,91 @@
+"""OSS /uploads router — POST (single + bulk), GET (stream), DELETE."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Response,
+    UploadFile,
+    status,
+)
+from fastapi.responses import StreamingResponse
+
+from pocketpaw.api.deps import require_scope
+from pocketpaw.uploads.config import INLINE_MIMES, UploadSettings
+from pocketpaw.uploads.errors import NotFound
+from pocketpaw.uploads.file_store import JSONLFileStore
+from pocketpaw.uploads.local import LocalStorageAdapter
+from pocketpaw.uploads.service import UploadService
+
+_OWNER = "local"  # OSS is single-user; all uploads are "owned" by the local user.
+
+_ROOT = Path.home() / ".pocketpaw" / "uploads"
+_INDEX = _ROOT / "_idx.jsonl"
+_CFG = UploadSettings(local_root=_ROOT)
+_ADAPTER = LocalStorageAdapter(root=_ROOT)
+_META = JSONLFileStore(path=_INDEX)
+_SVC = UploadService(adapter=_ADAPTER, meta=_META, cfg=_CFG)
+
+router = APIRouter(
+    prefix="/uploads",
+    tags=["Uploads"],
+    dependencies=[Depends(require_scope("uploads"))],
+)
+
+
+def _record_to_dict(rec) -> dict:
+    return {
+        "id": rec.id,
+        "filename": rec.filename,
+        "mime": rec.mime,
+        "size": rec.size,
+        "url": f"/api/v1/uploads/{rec.id}",
+        "created": rec.created.isoformat(),
+    }
+
+
+@router.post("")
+async def upload(
+    files: Annotated[list[UploadFile], File(...)],
+    chat_id: Annotated[str | None, Form()] = None,
+) -> dict:
+    try:
+        result = await _SVC.upload_many(files, owner_id=_OWNER, chat_id=chat_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    return {
+        "uploaded": [_record_to_dict(r) for r in result.uploaded],
+        "failed": [asdict(f) for f in result.failed],
+    }
+
+
+@router.get("/{file_id}")
+async def download(file_id: str) -> StreamingResponse:
+    try:
+        rec, it = await _SVC.stream(file_id, requester_id=_OWNER)
+    except NotFound as e:
+        raise HTTPException(status_code=404, detail="not found") from e
+    disposition = "inline" if rec.mime in INLINE_MIMES else "attachment"
+    return StreamingResponse(
+        it,
+        media_type=rec.mime,
+        headers={"Content-Disposition": f'{disposition}; filename="{rec.filename}"'},
+    )
+
+
+@router.delete("/{file_id}", status_code=204)
+async def delete_upload(file_id: str) -> Response:
+    try:
+        await _SVC.delete(file_id, requester_id=_OWNER)
+    except NotFound as e:
+        raise HTTPException(status_code=404, detail="not found") from e
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/pocketpaw/api/v1/uploads.py
+++ b/src/pocketpaw/api/v1/uploads.py
@@ -78,7 +78,13 @@ async def download(file_id: str) -> StreamingResponse:
     return StreamingResponse(
         it,
         media_type=rec.mime,
-        headers={"Content-Disposition": f'{disposition}; filename="{rec.filename}"'},
+        headers={
+            "Content-Disposition": f'{disposition}; filename="{rec.filename}"',
+            # Prevent browsers from MIME-sniffing past the declared type.
+            # Defense-in-depth against content-type confusion for uploads that
+            # are labeled as text/* but hold unexpected bytes.
+            "X-Content-Type-Options": "nosniff",
+        },
     )
 
 

--- a/src/pocketpaw/uploads/adapter.py
+++ b/src/pocketpaw/uploads/adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Protocol
 
 
@@ -38,3 +39,11 @@ class StorageAdapter(Protocol):
 
     async def exists(self, key: str) -> bool:
         """Return whether ``key`` is currently stored."""
+
+    def local_path(self, key: str) -> Path | None:
+        """Return an absolute local path to the blob, or ``None`` if unsupported.
+
+        Lets the agent loop pass local files to built-in tools (e.g. Read)
+        without streaming through HTTP. Remote adapters (S3, GCS) return
+        ``None`` — the caller should fall back to streaming via ``open``.
+        """

--- a/src/pocketpaw/uploads/adapter.py
+++ b/src/pocketpaw/uploads/adapter.py
@@ -22,13 +22,16 @@ class StorageAdapter(Protocol):
     Implementations must be safe to call from asyncio contexts.
     """
 
-    async def put(
-        self, key: str, stream: AsyncIterator[bytes], mime: str
-    ) -> StoredObject:
+    async def put(self, key: str, stream: AsyncIterator[bytes], mime: str) -> StoredObject:
         """Persist ``stream`` at ``key``. Returns the canonical ``StoredObject``."""
 
-    async def open(self, key: str) -> AsyncIterator[bytes]:  # pragma: no cover
-        """Yield the stored bytes in chunks. Raises ``NotFound`` if missing."""
+    def open(self, key: str) -> AsyncIterator[bytes]:  # pragma: no cover
+        """Yield the stored bytes in chunks. Raises ``NotFound`` if missing.
+
+        Note: not ``async def`` — implementations are async generator
+        functions (``async def`` + ``yield``), which Python types as
+        ``AsyncIterator[bytes]`` when called (no ``await`` on the call).
+        """
 
     async def delete(self, key: str) -> None:
         """Remove ``key`` if present. Idempotent."""

--- a/src/pocketpaw/uploads/adapter.py
+++ b/src/pocketpaw/uploads/adapter.py
@@ -1,0 +1,37 @@
+"""StorageAdapter protocol — the swap point for local, S3, etc."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class StoredObject:
+    """Return value of ``StorageAdapter.put``."""
+
+    key: str
+    size: int
+    mime: str
+
+
+class StorageAdapter(Protocol):
+    """Abstract byte storage. Knows nothing about metadata, auth, or mime logic.
+
+    Implementations must be safe to call from asyncio contexts.
+    """
+
+    async def put(
+        self, key: str, stream: AsyncIterator[bytes], mime: str
+    ) -> StoredObject:
+        """Persist ``stream`` at ``key``. Returns the canonical ``StoredObject``."""
+
+    async def open(self, key: str) -> AsyncIterator[bytes]:  # pragma: no cover
+        """Yield the stored bytes in chunks. Raises ``NotFound`` if missing."""
+
+    async def delete(self, key: str) -> None:
+        """Remove ``key`` if present. Idempotent."""
+
+    async def exists(self, key: str) -> bool:
+        """Return whether ``key`` is currently stored."""

--- a/src/pocketpaw/uploads/config.py
+++ b/src/pocketpaw/uploads/config.py
@@ -1,0 +1,56 @@
+"""Upload configuration — size limits, mime allowlist, storage root."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Mimes safe to render inline (images, pdf, plain text). Everything else gets
+# Content-Disposition: attachment to avoid in-origin HTML/SVG tricks.
+INLINE_MIMES: frozenset[str] = frozenset({
+    "image/png", "image/jpeg", "image/gif", "image/webp",
+    "application/pdf",
+    "text/plain", "text/markdown", "text/csv",
+})
+
+DEFAULT_ALLOWED_MIMES: frozenset[str] = frozenset({
+    # Images
+    "image/png", "image/jpeg", "image/gif", "image/webp",
+    # Documents
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # .docx
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",         # .xlsx
+    # Text / code
+    "text/plain", "text/markdown", "text/csv",
+    "application/json",
+})
+
+
+@dataclass
+class UploadSettings:
+    """Static configuration for the upload pipeline."""
+
+    max_file_bytes: int = 25 * 1024 * 1024          # 25 MiB
+    max_files_per_batch: int = 50
+    allowed_mimes: frozenset[str] = field(default_factory=lambda: DEFAULT_ALLOWED_MIMES)
+    local_root: Path = field(default_factory=lambda: Path.home() / ".pocketpaw" / "uploads")
+
+
+_MIME_TO_EXT: dict[str, str] = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "application/pdf": ".pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+    "text/plain": ".txt",
+    "text/markdown": ".md",
+    "text/csv": ".csv",
+    "application/json": ".json",
+}
+
+
+def extension_for(mime: str) -> str:
+    """Map a canonical mime type to a file extension. Returns ``""`` if unknown."""
+    return _MIME_TO_EXT.get(mime, "")

--- a/src/pocketpaw/uploads/config.py
+++ b/src/pocketpaw/uploads/config.py
@@ -7,30 +7,44 @@ from pathlib import Path
 
 # Mimes safe to render inline (images, pdf, plain text). Everything else gets
 # Content-Disposition: attachment to avoid in-origin HTML/SVG tricks.
-INLINE_MIMES: frozenset[str] = frozenset({
-    "image/png", "image/jpeg", "image/gif", "image/webp",
-    "application/pdf",
-    "text/plain", "text/markdown", "text/csv",
-})
+INLINE_MIMES: frozenset[str] = frozenset(
+    {
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "application/pdf",
+        "text/plain",
+        "text/markdown",
+        "text/csv",
+    }
+)
 
-DEFAULT_ALLOWED_MIMES: frozenset[str] = frozenset({
-    # Images
-    "image/png", "image/jpeg", "image/gif", "image/webp",
-    # Documents
-    "application/pdf",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # .docx
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",         # .xlsx
-    # Text / code
-    "text/plain", "text/markdown", "text/csv",
-    "application/json",
-})
+DEFAULT_ALLOWED_MIMES: frozenset[str] = frozenset(
+    {
+        # Images
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        # Documents
+        "application/pdf",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # .docx
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",  # .xlsx
+        # Text / code
+        "text/plain",
+        "text/markdown",
+        "text/csv",
+        "application/json",
+    }
+)
 
 
 @dataclass
 class UploadSettings:
     """Static configuration for the upload pipeline."""
 
-    max_file_bytes: int = 25 * 1024 * 1024          # 25 MiB
+    max_file_bytes: int = 25 * 1024 * 1024  # 25 MiB
     max_files_per_batch: int = 50
     allowed_mimes: frozenset[str] = field(default_factory=lambda: DEFAULT_ALLOWED_MIMES)
     local_root: Path = field(default_factory=lambda: Path.home() / ".pocketpaw" / "uploads")

--- a/src/pocketpaw/uploads/errors.py
+++ b/src/pocketpaw/uploads/errors.py
@@ -1,0 +1,42 @@
+"""Error hierarchy for the upload adapter."""
+
+from __future__ import annotations
+
+
+class UploadError(Exception):
+    """Base class for all upload-related errors."""
+
+    code: str = "upload_error"
+
+
+class TooLarge(UploadError):
+    code = "too_large"
+
+
+class UnsupportedMime(UploadError):
+    code = "unsupported_mime"
+
+
+class EmptyFile(UploadError):
+    code = "empty"
+
+    def __init__(self, message: str = "file is empty") -> None:
+        super().__init__(message)
+
+
+class NotFound(UploadError):
+    code = "not_found"
+
+    def __init__(self, message: str = "not found") -> None:
+        super().__init__(message)
+
+
+class AccessDenied(UploadError):
+    code = "access_denied"
+
+    def __init__(self, message: str = "access denied") -> None:
+        super().__init__(message)
+
+
+class StorageFailure(UploadError):
+    code = "storage_error"

--- a/src/pocketpaw/uploads/file_store.py
+++ b/src/pocketpaw/uploads/file_store.py
@@ -1,0 +1,93 @@
+"""OSS metadata store — append-only JSONL keyed by file_id."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from threading import Lock
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FileRecord:
+    id: str
+    storage_key: str
+    filename: str
+    mime: str
+    size: int
+    owner_id: str
+    chat_id: str | None
+    created: datetime
+
+
+class JSONLFileStore:
+    """Append-only JSONL store with in-memory cache.
+
+    Each line is either:
+      - ``{"op": "save",   "record": {...FileRecord...}}``
+      - ``{"op": "delete", "id": "<file_id>"}``
+
+    Deleted records are hidden from ``get`` but the historical line stays in
+    the file for audit.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._records: dict[str, FileRecord] = {}
+        self._deleted: set[str] = set()
+        self._lock = Lock()
+        self._reload()
+
+    def _reload(self) -> None:
+        if not self._path.exists():
+            return
+        for line in self._path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("skipping corrupt upload-index line: %r", line[:120])
+                continue
+            op = row.get("op")
+            if op == "save":
+                rec = row.get("record") or {}
+                try:
+                    rec["created"] = datetime.fromisoformat(rec["created"])
+                    self._records[rec["id"]] = FileRecord(**rec)
+                except (KeyError, TypeError, ValueError):
+                    logger.warning("skipping malformed record line: %r", line[:120])
+            elif op == "delete":
+                fid = row.get("id")
+                if isinstance(fid, str):
+                    self._deleted.add(fid)
+
+    def _append(self, line: dict) -> None:
+        with self._lock:
+            with self._path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(line, default=_json_default) + "\n")
+
+    def save(self, record: FileRecord) -> None:
+        self._records[record.id] = record
+        self._deleted.discard(record.id)
+        self._append({"op": "save", "record": asdict(record)})
+
+    def get(self, file_id: str) -> FileRecord | None:
+        if file_id in self._deleted:
+            return None
+        return self._records.get(file_id)
+
+    def soft_delete(self, file_id: str) -> None:
+        self._deleted.add(file_id)
+        self._append({"op": "delete", "id": file_id, "at": datetime.now(UTC).isoformat()})
+
+
+def _json_default(value: object) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    raise TypeError(f"cannot serialize {type(value)}")

--- a/src/pocketpaw/uploads/keys.py
+++ b/src/pocketpaw/uploads/keys.py
@@ -1,0 +1,30 @@
+"""Storage-key generation for uploads.
+
+Keys are opaque to external callers and namespaced by "kind" + a yyyymm bucket.
+The UUID4 hex tail guarantees uniqueness.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import UTC, datetime
+
+_EXT_RE = re.compile(r"[^a-z0-9]")
+_MAX_EXT_LEN = 8
+
+
+def sanitize_ext(ext: str) -> str:
+    """Normalize a file extension to ``.{alnum,<=8}`` or empty."""
+    if not ext:
+        return ""
+    tail = ext.lstrip(".").lower()
+    tail = _EXT_RE.sub("", tail)[:_MAX_EXT_LEN]
+    return f".{tail}" if tail else ""
+
+
+def new_storage_key(kind: str = "chat", ext: str = "") -> str:
+    """Return a fresh unique storage key ``{kind}/{yyyymm}/{uuid32}{ext}``."""
+    yyyymm = datetime.now(UTC).strftime("%Y%m")
+    safe_ext = sanitize_ext(ext)
+    return f"{kind}/{yyyymm}/{uuid.uuid4().hex}{safe_ext}"

--- a/src/pocketpaw/uploads/local.py
+++ b/src/pocketpaw/uploads/local.py
@@ -32,9 +32,7 @@ class LocalStorageAdapter(StorageAdapter):
             raise AccessDenied(f"key escapes storage root: {key!r}") from exc
         return target
 
-    async def put(
-        self, key: str, stream: AsyncIterator[bytes], mime: str
-    ) -> StoredObject:
+    async def put(self, key: str, stream: AsyncIterator[bytes], mime: str) -> StoredObject:
         final = self._resolve(key)
         final.parent.mkdir(parents=True, exist_ok=True)
         tmp = final.with_name(final.name + ".tmp")

--- a/src/pocketpaw/uploads/local.py
+++ b/src/pocketpaw/uploads/local.py
@@ -73,3 +73,10 @@ class LocalStorageAdapter(StorageAdapter):
     async def exists(self, key: str) -> bool:
         target = self._resolve(key)
         return target.exists()
+
+    def local_path(self, key: str) -> Path | None:
+        try:
+            target = self._resolve(key)
+        except AccessDenied:
+            return None
+        return target if target.exists() else None

--- a/src/pocketpaw/uploads/local.py
+++ b/src/pocketpaw/uploads/local.py
@@ -1,0 +1,77 @@
+"""Local-disk StorageAdapter backed by aiofiles."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import aiofiles
+import aiofiles.os
+
+from pocketpaw.uploads.adapter import StorageAdapter, StoredObject
+from pocketpaw.uploads.errors import AccessDenied, NotFound, StorageFailure
+
+_CHUNK_SIZE = 64 * 1024
+
+
+class LocalStorageAdapter(StorageAdapter):
+    """Store blobs under ``root``. Atomic writes via .tmp + rename.
+
+    Rejects keys that would escape ``root`` after normalization.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self._root = root.resolve()
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def _resolve(self, key: str) -> Path:
+        target = (self._root / key).resolve()
+        try:
+            target.relative_to(self._root)
+        except ValueError as exc:
+            raise AccessDenied(f"key escapes storage root: {key!r}") from exc
+        return target
+
+    async def put(
+        self, key: str, stream: AsyncIterator[bytes], mime: str
+    ) -> StoredObject:
+        final = self._resolve(key)
+        final.parent.mkdir(parents=True, exist_ok=True)
+        tmp = final.with_name(final.name + ".tmp")
+        size = 0
+        try:
+            async with aiofiles.open(tmp, "wb") as fh:
+                async for chunk in stream:
+                    await fh.write(chunk)
+                    size += len(chunk)
+            await aiofiles.os.replace(str(tmp), str(final))
+        except Exception as exc:
+            # Best-effort cleanup of the partial .tmp
+            try:
+                await aiofiles.os.remove(str(tmp))
+            except FileNotFoundError:
+                pass
+            raise StorageFailure(str(exc)) from exc
+        return StoredObject(key=key, size=size, mime=mime)
+
+    async def open(self, key: str) -> AsyncIterator[bytes]:
+        target = self._resolve(key)
+        if not target.exists():
+            raise NotFound(f"missing: {key}")
+        async with aiofiles.open(target, "rb") as fh:
+            while True:
+                chunk = await fh.read(_CHUNK_SIZE)
+                if not chunk:
+                    break
+                yield chunk
+
+    async def delete(self, key: str) -> None:
+        target = self._resolve(key)
+        try:
+            await aiofiles.os.remove(str(target))
+        except FileNotFoundError:
+            pass
+
+    async def exists(self, key: str) -> bool:
+        target = self._resolve(key)
+        return target.exists()

--- a/src/pocketpaw/uploads/resolver.py
+++ b/src/pocketpaw/uploads/resolver.py
@@ -9,12 +9,15 @@ OSS-only — EE has its own workspace-scoped resolver alongside its Mongo store.
 
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
 from typing import Protocol
 
 from pocketpaw.uploads.adapter import StorageAdapter
 from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+
+logger = logging.getLogger(__name__)
 
 _UPLOAD_URL_RE = re.compile(r"^/api/v1/uploads/(?P<id>[A-Za-z0-9_-]+)$")
 
@@ -54,7 +57,18 @@ class UploadResolver:
         rec = self._meta.get(file_id)
         if rec is None:
             return None
-        return self._adapter.local_path(rec.storage_key)
+        # Contain unexpected adapter failures (permission errors on the
+        # storage root, remount races, future remote adapters) so chat
+        # never crashes over a bad attachment — just drops the entry.
+        try:
+            return self._adapter.local_path(rec.storage_key)
+        except Exception:
+            logger.exception(
+                "upload adapter.local_path failed for file_id=%s storage_key=%s",
+                file_id,
+                rec.storage_key,
+            )
+            return None
 
 
 def resolve_media_paths(
@@ -77,8 +91,14 @@ def resolve_media_paths(
             out.append(entry)
             continue
         path = resolver.resolve(entry)
-        if path is not None:
-            out.append(str(path))
+        if path is None:
+            # Upload-URL-shaped but unresolvable: record missing, record
+            # soft-deleted, blob gone, or adapter failure. Log so the next
+            # time a user says "the agent ignored my file" the trail is
+            # visible in server logs.
+            logger.warning("dropping unresolvable upload entry: %s", entry)
+            continue
+        out.append(str(path))
     return out
 
 

--- a/src/pocketpaw/uploads/resolver.py
+++ b/src/pocketpaw/uploads/resolver.py
@@ -113,11 +113,71 @@ def default_resolver() -> UploadResolver:
     return UploadResolver(adapter=_ADAPTER, meta=_META)
 
 
+async def _resolve_via_ee_mongo(file_id: str) -> Path | None:
+    """Fallback: look up ``file_id`` in the EE Mongo store with no workspace
+    filter. Returns ``None`` if EE isn't installed or Mongo can't reach the id.
+
+    Intended for single-user self-hosted deployments where the EE router is
+    mounted (uploads land in Mongo) but chat still goes through the OSS
+    endpoint. Multi-tenant cloud chat should route through EE with explicit
+    workspace context instead of calling this.
+    """
+    try:
+        from ee.cloud.uploads.router import _ADAPTER as EE_ADAPTER
+        from ee.cloud.uploads.router import _META as EE_META
+    except Exception:
+        return None
+
+    try:
+        rec = await EE_META.get_unscoped(file_id)
+    except Exception:
+        logger.exception("EE mongo lookup failed for file_id=%s", file_id)
+        return None
+    if rec is None:
+        return None
+    try:
+        return EE_ADAPTER.local_path(rec.storage_key)
+    except Exception:
+        logger.exception(
+            "EE adapter.local_path failed for file_id=%s storage_key=%s",
+            file_id,
+            rec.storage_key,
+        )
+        return None
+
+
+async def resolve_media_paths_any(media: list[str]) -> list[str]:
+    """Async counterpart to :func:`resolve_media_paths` that falls back to
+    the EE Mongo store when the OSS JSONL lookup misses.
+
+    Covers the common self-hosted EE case: uploads go through the EE
+    workspace-scoped router (Mongo), but chat still goes through the OSS
+    `/chat/stream` endpoint (no auth context). Without this fallback, the
+    agent would never see files uploaded via the EE path.
+    """
+    resolver = default_resolver()
+    out: list[str] = []
+    for entry in media:
+        fid = parse_upload_url(entry)
+        if fid is None:
+            out.append(entry)
+            continue
+        path = resolver.resolve(entry)
+        if path is None:
+            path = await _resolve_via_ee_mongo(fid)
+        if path is None:
+            logger.warning("dropping unresolvable upload entry: %s", entry)
+            continue
+        out.append(str(path))
+    return out
+
+
 # Keep JSONLFileStore importable for type-friendly call sites.
 __all__ = [
     "UploadResolver",
     "default_resolver",
     "parse_upload_url",
     "resolve_media_paths",
+    "resolve_media_paths_any",
     "JSONLFileStore",
 ]

--- a/src/pocketpaw/uploads/resolver.py
+++ b/src/pocketpaw/uploads/resolver.py
@@ -11,11 +11,29 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
 from pocketpaw.uploads.adapter import StorageAdapter
 from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+
+
+@dataclass(frozen=True)
+class ResolvedMedia:
+    """One entry of the resolved media list.
+
+    ``path`` is the string the agent loop will inject into the prompt
+    (absolute disk path for resolved upload URLs, original string for
+    passthroughs). ``record`` carries the metadata when the entry was
+    resolved from an upload store — used to build the richer prompt
+    block (filename, mime, size). ``None`` for passthroughs / non-upload
+    entries where we don't know the metadata.
+    """
+
+    path: str
+    record: FileRecord | None
+
 
 logger = logging.getLogger(__name__)
 
@@ -113,9 +131,12 @@ def default_resolver() -> UploadResolver:
     return UploadResolver(adapter=_ADAPTER, meta=_META)
 
 
-async def _resolve_via_ee_mongo(file_id: str) -> Path | None:
+async def _resolve_via_ee_mongo(
+    file_id: str,
+) -> tuple[Path | None, FileRecord | None]:
     """Fallback: look up ``file_id`` in the EE Mongo store with no workspace
-    filter. Returns ``None`` if EE isn't installed or Mongo can't reach the id.
+    filter. Returns ``(None, None)`` if EE isn't installed or Mongo can't
+    reach the id.
 
     Intended for single-user self-hosted deployments where the EE router is
     mounted (uploads land in Mongo) but chat still goes through the OSS
@@ -126,58 +147,77 @@ async def _resolve_via_ee_mongo(file_id: str) -> Path | None:
         from ee.cloud.uploads.router import _ADAPTER as EE_ADAPTER
         from ee.cloud.uploads.router import _META as EE_META
     except Exception:
-        return None
+        return None, None
 
     try:
         rec = await EE_META.get_unscoped(file_id)
     except Exception:
         logger.exception("EE mongo lookup failed for file_id=%s", file_id)
-        return None
+        return None, None
     if rec is None:
-        return None
+        return None, None
     try:
-        return EE_ADAPTER.local_path(rec.storage_key)
+        return EE_ADAPTER.local_path(rec.storage_key), rec
     except Exception:
         logger.exception(
             "EE adapter.local_path failed for file_id=%s storage_key=%s",
             file_id,
             rec.storage_key,
         )
-        return None
+        return None, rec
 
 
 async def resolve_media_paths_any(media: list[str]) -> list[str]:
     """Async counterpart to :func:`resolve_media_paths` that falls back to
-    the EE Mongo store when the OSS JSONL lookup misses.
+    the EE Mongo store when the OSS JSONL lookup misses. Returns only the
+    path strings; use :func:`resolve_media_with_records` when callers need
+    per-entry metadata (filename / mime / size) for richer prompts.
+    """
+    resolved = await resolve_media_with_records(media)
+    return [r.path for r in resolved]
 
-    Covers the common self-hosted EE case: uploads go through the EE
-    workspace-scoped router (Mongo), but chat still goes through the OSS
-    `/chat/stream` endpoint (no auth context). Without this fallback, the
-    agent would never see files uploaded via the EE path.
+
+async def resolve_media_with_records(media: list[str]) -> list[ResolvedMedia]:
+    """Return path + FileRecord pairs for each resolvable media entry.
+
+    - Upload URL that resolves via OSS JSONL → ``ResolvedMedia(path, rec)``
+    - Upload URL that resolves via EE Mongo fallback → ``ResolvedMedia(path, rec)``
+    - Non-upload string (already a path / opaque token) → ``ResolvedMedia(str, None)``
+    - Upload URL that resolves nowhere → dropped with a warning log
+
+    Callers that only want the paths can use :func:`resolve_media_paths_any`.
     """
     resolver = default_resolver()
-    out: list[str] = []
+    out: list[ResolvedMedia] = []
     for entry in media:
         fid = parse_upload_url(entry)
         if fid is None:
-            out.append(entry)
+            out.append(ResolvedMedia(path=entry, record=None))
             continue
+
+        # Try OSS first.
         path = resolver.resolve(entry)
-        if path is None:
-            path = await _resolve_via_ee_mongo(fid)
+        rec: FileRecord | None = None
+        if path is not None:
+            rec = resolver._meta.get(fid)
+        else:
+            path, rec = await _resolve_via_ee_mongo(fid)
+
         if path is None:
             logger.warning("dropping unresolvable upload entry: %s", entry)
             continue
-        out.append(str(path))
+        out.append(ResolvedMedia(path=str(path), record=rec))
     return out
 
 
 # Keep JSONLFileStore importable for type-friendly call sites.
 __all__ = [
+    "JSONLFileStore",
+    "ResolvedMedia",
     "UploadResolver",
     "default_resolver",
     "parse_upload_url",
     "resolve_media_paths",
     "resolve_media_paths_any",
-    "JSONLFileStore",
+    "resolve_media_with_records",
 ]

--- a/src/pocketpaw/uploads/resolver.py
+++ b/src/pocketpaw/uploads/resolver.py
@@ -1,0 +1,103 @@
+"""Turn an upload URL into a local disk path for the agent loop.
+
+The chat bridge receives media entries like ``/api/v1/uploads/{id}`` from the
+frontend. Agents consume local paths (Read tool, image blocks). This module
+bridges the two.
+
+OSS-only — EE has its own workspace-scoped resolver alongside its Mongo store.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Protocol
+
+from pocketpaw.uploads.adapter import StorageAdapter
+from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+
+_UPLOAD_URL_RE = re.compile(r"^/api/v1/uploads/(?P<id>[A-Za-z0-9_-]+)$")
+
+
+def parse_upload_url(url: str) -> str | None:
+    """Extract the file_id from an upload URL.
+
+    Returns ``None`` for anything that isn't a canonical upload URL:
+    disk paths, other API routes, blob URLs, empty strings, etc.
+    """
+    if not url:
+        return None
+    m = _UPLOAD_URL_RE.match(url)
+    return m.group("id") if m else None
+
+
+class _MetaReader(Protocol):
+    def get(self, file_id: str) -> FileRecord | None: ...
+
+
+class UploadResolver:
+    """Look up upload URLs in a metadata store and map to local disk paths.
+
+    Returns ``None`` for unresolvable URLs: unknown file_id, soft-deleted
+    records, blobs that have vanished from disk, or adapters that don't
+    support ``local_path`` (e.g. future S3 adapter).
+    """
+
+    def __init__(self, adapter: StorageAdapter, meta: _MetaReader) -> None:
+        self._adapter = adapter
+        self._meta = meta
+
+    def resolve(self, url: str) -> Path | None:
+        file_id = parse_upload_url(url)
+        if file_id is None:
+            return None
+        rec = self._meta.get(file_id)
+        if rec is None:
+            return None
+        return self._adapter.local_path(rec.storage_key)
+
+
+def resolve_media_paths(
+    media: list[str],
+    *,
+    resolver: UploadResolver,
+) -> list[str]:
+    """Map each media entry to a local path string.
+
+    - Upload URLs that resolve → absolute disk path as a string.
+    - Upload URLs that don't resolve → dropped silently (orphan/deleted).
+    - Non-upload strings (already local paths, opaque tokens) → passthrough.
+
+    Order is preserved; dropped unresolvable URLs do not leave gaps.
+    """
+    out: list[str] = []
+    for entry in media:
+        fid = parse_upload_url(entry)
+        if fid is None:
+            out.append(entry)
+            continue
+        path = resolver.resolve(entry)
+        if path is not None:
+            out.append(str(path))
+    return out
+
+
+def default_resolver() -> UploadResolver:
+    """Return the resolver wired to the OSS /uploads singletons.
+
+    Imported lazily so test code can stub the module-level singletons before
+    this is called.
+    """
+    from pocketpaw.api.v1.uploads import _ADAPTER, _META
+
+    return UploadResolver(adapter=_ADAPTER, meta=_META)
+
+
+# Keep JSONLFileStore importable for type-friendly call sites.
+__all__ = [
+    "UploadResolver",
+    "default_resolver",
+    "parse_upload_url",
+    "resolve_media_paths",
+    "JSONLFileStore",
+]

--- a/src/pocketpaw/uploads/service.py
+++ b/src/pocketpaw/uploads/service.py
@@ -1,0 +1,206 @@
+"""UploadService — validates, stores, and persists metadata."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+from fastapi import UploadFile
+
+from pocketpaw.uploads.adapter import StorageAdapter
+from pocketpaw.uploads.config import UploadSettings, extension_for
+from pocketpaw.uploads.errors import (
+    EmptyFile,
+    NotFound,
+    StorageFailure,
+    TooLarge,
+    UnsupportedMime,
+    UploadError,
+)
+from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+from pocketpaw.uploads.keys import new_storage_key
+
+_SNIFF_BYTES = 512
+
+
+def _sniff_mime(head: bytes, fallback: str) -> str:
+    if head.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if head.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if head.startswith(b"GIF87a") or head.startswith(b"GIF89a"):
+        return "image/gif"
+    if head.startswith(b"RIFF") and head[8:12] == b"WEBP":
+        return "image/webp"
+    if head.startswith(b"%PDF-"):
+        return "application/pdf"
+    if head.startswith(b"PK\x03\x04"):
+        # ZIP container — docx/xlsx both use this. Keep fallback if it matches.
+        if fallback in (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ):
+            return fallback
+    return fallback
+
+
+FailCode = Literal["too_large", "unsupported_mime", "empty", "storage_error"]
+
+
+@dataclass
+class FailedUpload:
+    filename: str
+    reason: str
+    code: FailCode
+
+
+@dataclass
+class BulkUploadResult:
+    uploaded: list[FileRecord]
+    failed: list[FailedUpload]
+
+
+class UploadService:
+    def __init__(
+        self,
+        adapter: StorageAdapter,
+        meta: JSONLFileStore,
+        cfg: UploadSettings,
+    ) -> None:
+        self._adapter = adapter
+        self._meta = meta
+        self._cfg = cfg
+
+    async def upload(
+        self, file: UploadFile, owner_id: str, chat_id: str | None
+    ) -> FileRecord:
+        result = await self.upload_many([file], owner_id, chat_id)
+        if result.failed:
+            f = result.failed[0]
+            _raise(f.code, f.reason)
+        return result.uploaded[0]
+
+    async def upload_many(
+        self, files: list[UploadFile], owner_id: str, chat_id: str | None,
+    ) -> BulkUploadResult:
+        if not files:
+            raise ValueError("empty upload batch")
+        if len(files) > self._cfg.max_files_per_batch:
+            raise ValueError(
+                f"too many files: {len(files)} > {self._cfg.max_files_per_batch}"
+            )
+
+        uploaded: list[FileRecord] = []
+        failed: list[FailedUpload] = []
+
+        for file in files:
+            try:
+                rec = await self._upload_one(file, owner_id, chat_id)
+                uploaded.append(rec)
+            except TooLarge as e:
+                failed.append(FailedUpload(filename=_basename(file.filename), reason=str(e), code="too_large"))
+            except UnsupportedMime as e:
+                failed.append(FailedUpload(filename=_basename(file.filename), reason=str(e), code="unsupported_mime"))
+            except EmptyFile as e:
+                failed.append(FailedUpload(filename=_basename(file.filename), reason=str(e), code="empty"))
+            except StorageFailure as e:
+                failed.append(FailedUpload(filename=_basename(file.filename), reason=str(e), code="storage_error"))
+
+        return BulkUploadResult(uploaded=uploaded, failed=failed)
+
+    async def _upload_one(
+        self, file: UploadFile, owner_id: str, chat_id: str | None,
+    ) -> FileRecord:
+        head = await file.read(_SNIFF_BYTES)
+        if not head:
+            raise EmptyFile()
+
+        # Size-check the head first so TooLarge beats UnsupportedMime when both apply.
+        cap = self._cfg.max_file_bytes
+        if len(head) > cap:
+            raise TooLarge(f"file exceeds {cap} bytes")
+
+        mime = _sniff_mime(head, file.content_type or "application/octet-stream")
+        if mime not in self._cfg.allowed_mimes:
+            raise UnsupportedMime(f"mime not allowed: {mime}")
+
+        ext = extension_for(mime)
+        key = new_storage_key("chat", ext)
+
+        first = head
+
+        async def _body() -> AsyncIterator[bytes]:
+            size = len(first)
+            if size > cap:
+                raise TooLarge(f"file exceeds {cap} bytes")
+            yield first
+            while True:
+                chunk = await file.read(64 * 1024)
+                if not chunk:
+                    break
+                size += len(chunk)
+                if size > cap:
+                    raise TooLarge(f"file exceeds {cap} bytes")
+                yield chunk
+
+        try:
+            obj = await self._adapter.put(key, _body(), mime)
+        except StorageFailure as e:
+            # Check if the root cause was our TooLarge (wrapped by LocalStorageAdapter)
+            if isinstance(e.__cause__, TooLarge):
+                raise e.__cause__
+            raise
+
+        file_id = uuid.uuid4().hex
+        filename = _basename(file.filename) or "upload"
+        record = FileRecord(
+            id=file_id,
+            storage_key=obj.key,
+            filename=filename,
+            mime=obj.mime,
+            size=obj.size,
+            owner_id=owner_id,
+            chat_id=chat_id,
+            created=datetime.now(UTC),
+        )
+        self._meta.save(record)
+        return record
+
+    async def stream(
+        self, file_id: str, requester_id: str
+    ) -> tuple[FileRecord, AsyncIterator[bytes]]:
+        rec = self._meta.get(file_id)
+        if rec is None:
+            raise NotFound()
+        if rec.owner_id != requester_id:
+            raise NotFound()
+        return rec, self._adapter.open(rec.storage_key)
+
+    async def delete(self, file_id: str, requester_id: str) -> None:
+        rec = self._meta.get(file_id)
+        if rec is None:
+            raise NotFound()
+        if rec.owner_id != requester_id:
+            raise NotFound()
+        await self._adapter.delete(rec.storage_key)
+        self._meta.soft_delete(file_id)
+
+
+def _basename(name: str | None) -> str:
+    if not name:
+        return ""
+    return os.path.basename(name.replace("\\", "/"))
+
+
+def _raise(code: FailCode, reason: str) -> None:
+    mapping: dict[FailCode, type[UploadError]] = {
+        "too_large": TooLarge,
+        "unsupported_mime": UnsupportedMime,
+        "empty": EmptyFile,
+        "storage_error": StorageFailure,
+    }
+    raise mapping[code](reason)

--- a/src/pocketpaw/uploads/service.py
+++ b/src/pocketpaw/uploads/service.py
@@ -75,9 +75,7 @@ class UploadService:
         self._meta = meta
         self._cfg = cfg
 
-    async def upload(
-        self, file: UploadFile, owner_id: str, chat_id: str | None
-    ) -> FileRecord:
+    async def upload(self, file: UploadFile, owner_id: str, chat_id: str | None) -> FileRecord:
         result = await self.upload_many([file], owner_id, chat_id)
         if result.failed:
             f = result.failed[0]
@@ -85,14 +83,15 @@ class UploadService:
         return result.uploaded[0]
 
     async def upload_many(
-        self, files: list[UploadFile], owner_id: str, chat_id: str | None,
+        self,
+        files: list[UploadFile],
+        owner_id: str,
+        chat_id: str | None,
     ) -> BulkUploadResult:
         if not files:
             raise ValueError("empty upload batch")
         if len(files) > self._cfg.max_files_per_batch:
-            raise ValueError(
-                f"too many files: {len(files)} > {self._cfg.max_files_per_batch}"
-            )
+            raise ValueError(f"too many files: {len(files)} > {self._cfg.max_files_per_batch}")
 
         uploaded: list[FileRecord] = []
         failed: list[FailedUpload] = []
@@ -102,18 +101,33 @@ class UploadService:
                 rec = await self._upload_one(file, owner_id, chat_id)
                 uploaded.append(rec)
             except TooLarge as e:
-                failed.append(FailedUpload(filename=_basename(file.filename), reason=str(e), code="too_large"))
+                failed.append(
+                    FailedUpload(filename=_basename(file.filename), reason=str(e), code="too_large")
+                )
             except UnsupportedMime as e:
-                failed.append(FailedUpload(filename=_basename(file.filename), reason=str(e), code="unsupported_mime"))
+                failed.append(
+                    FailedUpload(
+                        filename=_basename(file.filename), reason=str(e), code="unsupported_mime"
+                    )
+                )
             except EmptyFile as e:
-                failed.append(FailedUpload(filename=_basename(file.filename), reason=str(e), code="empty"))
+                failed.append(
+                    FailedUpload(filename=_basename(file.filename), reason=str(e), code="empty")
+                )
             except StorageFailure as e:
-                failed.append(FailedUpload(filename=_basename(file.filename), reason=str(e), code="storage_error"))
+                failed.append(
+                    FailedUpload(
+                        filename=_basename(file.filename), reason=str(e), code="storage_error"
+                    )
+                )
 
         return BulkUploadResult(uploaded=uploaded, failed=failed)
 
     async def _upload_one(
-        self, file: UploadFile, owner_id: str, chat_id: str | None,
+        self,
+        file: UploadFile,
+        owner_id: str,
+        chat_id: str | None,
     ) -> FileRecord:
         head = await file.read(_SNIFF_BYTES)
         if not head:

--- a/src/pocketpaw/uploads/service.py
+++ b/src/pocketpaw/uploads/service.py
@@ -200,8 +200,10 @@ class UploadService:
             raise NotFound()
         if rec.owner_id != requester_id:
             raise NotFound()
-        await self._adapter.delete(rec.storage_key)
+        # Tombstone metadata before unlinking the blob so a mid-op crash
+        # leaves an orphan blob (cleanable) rather than a dangling record.
         self._meta.soft_delete(file_id)
+        await self._adapter.delete(rec.storage_key)
 
 
 def _basename(name: str | None) -> str:

--- a/tests/cloud/test_agent_seed_and_dm_persistence.py
+++ b/tests/cloud/test_agent_seed_and_dm_persistence.py
@@ -1,0 +1,266 @@
+"""Tests for the pocketpaw agent seed + DM chat persistence with attachments.
+
+Covers:
+- ``seed_default_agent`` is idempotent and creates the expected Agent.
+- ``save_user_message(chat_id, content, attachments=...)`` persists
+  attachments on the Message doc.
+- ``SessionService.get_history`` returns attachments per message.
+- ``SessionService.list_by_agent`` filters to sessions for a given agent.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture()
+async def beanie_db():
+    """Isolated Beanie session for these tests (all EE documents registered)."""
+    from beanie import init_beanie
+    from mongomock_motor import AsyncMongoMockClient
+
+    from ee.cloud.models import ALL_DOCUMENTS
+
+    db_name = f"test_agent_seed_{uuid.uuid4().hex[:8]}"
+    client = AsyncMongoMockClient()
+    db = client[db_name]
+
+    original = db.list_collection_names
+
+    async def _safe(*_a, **_kw):
+        return await original()
+
+    db.list_collection_names = _safe  # type: ignore[method-assign]
+
+    await init_beanie(database=db, document_models=list(ALL_DOCUMENTS))
+    yield db
+
+
+class TestSeedDefaultAgent:
+    async def test_creates_agent_with_pocketpaw_slug(self, beanie_db) -> None:
+        from ee.cloud.auth.core import seed_default_agent
+        from ee.cloud.models.agent import Agent
+
+        agent = await seed_default_agent(workspace_id="ws-1", owner_id="user-1")
+        assert agent is not None
+        assert agent.slug == "pocketpaw"
+        assert agent.workspace == "ws-1"
+        assert agent.owner == "user-1"
+
+        # Confirm persisted
+        found = await Agent.find_one(Agent.workspace == "ws-1", Agent.slug == "pocketpaw")
+        assert found is not None
+
+    async def test_is_idempotent(self, beanie_db) -> None:
+        from ee.cloud.auth.core import seed_default_agent
+        from ee.cloud.models.agent import Agent
+
+        first = await seed_default_agent("ws-1", "user-1")
+        second = await seed_default_agent("ws-1", "user-1")
+        assert first is not None and second is not None
+        assert first.id == second.id
+
+        # Still only one agent for this workspace.
+        count = await Agent.find(Agent.workspace == "ws-1", Agent.slug == "pocketpaw").count()
+        assert count == 1
+
+    async def test_per_workspace_agents(self, beanie_db) -> None:
+        from ee.cloud.auth.core import seed_default_agent
+
+        a1 = await seed_default_agent("ws-1", "user-1")
+        a2 = await seed_default_agent("ws-2", "user-1")
+        assert a1 is not None and a2 is not None
+        assert a1.id != a2.id
+        assert a1.workspace != a2.workspace
+
+
+class TestSaveUserMessageAttachments:
+    async def _session(self, beanie_db, chat_id: str = "sess-1") -> None:
+        """Make a pocket session + workspace-bearing user so auto-create works."""
+        from ee.cloud.models.session import Session
+        from ee.cloud.models.user import User, WorkspaceMembership
+
+        user = User(
+            email="u@example.com",
+            hashed_password="x",
+            is_active=True,
+            is_verified=True,
+            is_superuser=True,
+            name="u",
+            workspaces=[
+                WorkspaceMembership(
+                    workspace="ws-1",
+                    role="owner",
+                )
+            ],
+        )
+        await user.insert()
+        session = Session(
+            sessionId=chat_id,
+            context_type="pocket",
+            workspace="ws-1",
+            owner=str(user.id),
+            title="Chat",
+        )
+        await session.insert()
+
+    async def test_attachments_persist_on_message(self, beanie_db) -> None:
+        from ee.cloud.models.message import Message
+        from ee.cloud.shared.chat_persistence import _session_cache, save_user_message
+
+        _session_cache.clear()
+        await self._session(beanie_db)
+
+        attachments = [
+            {
+                "type": "image",
+                "url": "/api/v1/uploads/abc123",
+                "name": "screenshot.png",
+                "meta": {"mime": "image/png", "size": 414255, "id": "abc123"},
+            }
+        ]
+        await save_user_message("sess-1", "look at this", attachments=attachments)
+
+        msg = await Message.find_one(
+            Message.context_type == "pocket",
+            Message.session_key == "sess-1",
+        )
+        assert msg is not None
+        assert msg.content == "look at this"
+        assert len(msg.attachments) == 1
+        att = msg.attachments[0]
+        assert att.type == "image"
+        assert att.url == "/api/v1/uploads/abc123"
+        assert att.name == "screenshot.png"
+        assert att.meta["mime"] == "image/png"
+        assert att.meta["size"] == 414255
+
+    async def test_attachments_none_is_no_op(self, beanie_db) -> None:
+        from ee.cloud.models.message import Message
+        from ee.cloud.shared.chat_persistence import _session_cache, save_user_message
+
+        _session_cache.clear()
+        await self._session(beanie_db, chat_id="sess-plain")
+
+        await save_user_message("sess-plain", "hi")
+
+        msg = await Message.find_one(
+            Message.context_type == "pocket",
+            Message.session_key == "sess-plain",
+        )
+        assert msg is not None
+        assert msg.attachments == []
+
+
+class TestHistoryReturnsAttachments:
+    async def test_pocket_history_exposes_attachments(self, beanie_db) -> None:
+        from ee.cloud.models.message import Attachment, Message
+        from ee.cloud.models.session import Session
+        from ee.cloud.models.user import User, WorkspaceMembership
+        from ee.cloud.sessions.service import SessionService
+
+        user = User(
+            email="u2@example.com",
+            hashed_password="x",
+            is_active=True,
+            is_verified=True,
+            is_superuser=False,
+            name="u2",
+            workspaces=[WorkspaceMembership(workspace="ws-1", role="member")],
+        )
+        await user.insert()
+        session = Session(
+            sessionId="hist-1",
+            context_type="pocket",
+            workspace="ws-1",
+            owner=str(user.id),
+            title="Chat",
+        )
+        await session.insert()
+
+        msg = Message(
+            context_type="pocket",
+            session_key="hist-1",
+            role="user",
+            sender=str(user.id),
+            sender_type="user",
+            content="hi",
+            attachments=[
+                Attachment(
+                    type="image",
+                    url="/api/v1/uploads/xyz",
+                    name="pic.png",
+                    meta={"mime": "image/png", "size": 100},
+                )
+            ],
+        )
+        await msg.insert()
+
+        result = await SessionService.get_history("hist-1", str(user.id))
+        messages = result["messages"]
+        assert len(messages) == 1
+        assert "attachments" in messages[0]
+        assert len(messages[0]["attachments"]) == 1
+        assert messages[0]["attachments"][0]["url"] == "/api/v1/uploads/xyz"
+        assert messages[0]["attachments"][0]["name"] == "pic.png"
+
+
+class TestListByAgent:
+    async def test_filters_sessions_to_given_agent(self, beanie_db) -> None:
+        from ee.cloud.models.session import Session
+        from ee.cloud.sessions.service import SessionService
+
+        s_match = Session(
+            sessionId="s1",
+            context_type="pocket",
+            workspace="ws-1",
+            owner="user-1",
+            agent="agent-A",
+            title="match",
+        )
+        s_other = Session(
+            sessionId="s2",
+            context_type="pocket",
+            workspace="ws-1",
+            owner="user-1",
+            agent="agent-B",
+            title="other",
+        )
+        s_no_agent = Session(
+            sessionId="s3",
+            context_type="pocket",
+            workspace="ws-1",
+            owner="user-1",
+            title="no agent",
+        )
+        for s in (s_match, s_other, s_no_agent):
+            await s.insert()
+
+        found = await SessionService.list_by_agent("ws-1", "user-1", "agent-A")
+        assert len(found) == 1
+        assert found[0]["sessionId"] == "s1"
+        assert found[0]["agent"] == "agent-A"
+
+    async def test_respects_soft_delete(self, beanie_db) -> None:
+        from datetime import UTC, datetime
+
+        from ee.cloud.models.session import Session
+        from ee.cloud.sessions.service import SessionService
+
+        deleted = Session(
+            sessionId="s-dead",
+            context_type="pocket",
+            workspace="ws-1",
+            owner="user-1",
+            agent="agent-A",
+            title="deleted",
+            deleted_at=datetime.now(UTC),
+        )
+        await deleted.insert()
+
+        found = await SessionService.list_by_agent("ws-1", "user-1", "agent-A")
+        assert found == []

--- a/tests/cloud/uploads/conftest.py
+++ b/tests/cloud/uploads/conftest.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
 
 import pytest
+
+
+@pytest.fixture()
+def tmp_upload_root(tmp_path: Path) -> Path:
+    """Isolated storage root for each test."""
+    root = tmp_path / "uploads"
+    root.mkdir()
+    return root
 
 
 @pytest.fixture()

--- a/tests/cloud/uploads/conftest.py
+++ b/tests/cloud/uploads/conftest.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+@pytest.fixture()
+async def beanie_upload_db():
+    from beanie import init_beanie
+    from mongomock_motor import AsyncMongoMockClient
+
+    db_name = f"test_uploads_{uuid.uuid4().hex[:8]}"
+    client = AsyncMongoMockClient()
+    db = client[db_name]
+
+    original = db.list_collection_names
+
+    async def _safe(*_a, **_kw):
+        return await original()
+
+    db.list_collection_names = _safe  # type: ignore[method-assign]
+
+    # Import after db creation to avoid circular imports
+    from ee.cloud.uploads.models import FileUpload
+
+    await init_beanie(database=db, document_models=[FileUpload])
+    yield db
+
+
+@pytest.fixture()
+async def store(beanie_upload_db):
+    from ee.cloud.uploads.mongo_store import MongoFileStore
+    return MongoFileStore()

--- a/tests/cloud/uploads/conftest.py
+++ b/tests/cloud/uploads/conftest.py
@@ -31,4 +31,5 @@ async def beanie_upload_db():
 @pytest.fixture()
 async def store(beanie_upload_db):
     from ee.cloud.uploads.mongo_store import MongoFileStore
+
     return MongoFileStore()

--- a/tests/cloud/uploads/test_mongo_store.py
+++ b/tests/cloud/uploads/test_mongo_store.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.asyncio
+
+
+def _record(**overrides) -> FileRecord:
+    defaults = {
+        "id": "f1",
+        "storage_key": "chat/202604/aaa.png",
+        "filename": "cat.png",
+        "mime": "image/png",
+        "size": 1,
+        "owner_id": "u1",
+        "chat_id": "c1",
+        "created": datetime.now(UTC),
+    }
+    defaults.update(overrides)
+    return FileRecord(**defaults)
+
+
+class TestMongoFileStore:
+    async def test_save_then_get(self, store):
+        await store.save_scoped(_record(), workspace="w1")
+        got = await store.get_scoped("f1", workspace="w1")
+        assert got is not None
+        assert got.filename == "cat.png"
+
+    async def test_cross_workspace_get_returns_none(self, store):
+        await store.save_scoped(_record(), workspace="w1")
+        assert await store.get_scoped("f1", workspace="w2") is None
+
+    async def test_soft_delete_hides(self, store):
+        await store.save_scoped(_record(), workspace="w1")
+        await store.soft_delete_scoped("f1", workspace="w1")
+        assert await store.get_scoped("f1", workspace="w1") is None
+
+    async def test_get_missing_returns_none(self, store):
+        assert await store.get_scoped("nope", workspace="w1") is None

--- a/tests/cloud/uploads/test_resolver.py
+++ b/tests/cloud/uploads/test_resolver.py
@@ -1,0 +1,118 @@
+"""Tests for ee.cloud.uploads.resolver."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from ee.cloud.uploads.resolver import EEUploadResolver, resolve_media_paths_scoped
+from pocketpaw.uploads.file_store import FileRecord
+from pocketpaw.uploads.local import LocalStorageAdapter
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _stash(
+    tmp_upload_root: Path,
+    store,  # MongoFileStore
+    workspace: str,
+    data: bytes = b"hello",
+    filename: str = "x.txt",
+    mime: str = "text/plain",
+) -> tuple[FileRecord, Path]:
+    from datetime import UTC, datetime
+
+    file_id = uuid.uuid4().hex
+    storage_key = f"chat/202604/{file_id}.txt"
+    disk_path = tmp_upload_root / storage_key
+    disk_path.parent.mkdir(parents=True, exist_ok=True)
+    disk_path.write_bytes(data)
+    rec = FileRecord(
+        id=file_id,
+        storage_key=storage_key,
+        filename=filename,
+        mime=mime,
+        size=len(data),
+        owner_id="alice",
+        chat_id=None,
+        created=datetime.now(UTC),
+    )
+    await store.save_scoped(rec, workspace=workspace)
+    return rec, disk_path
+
+
+async def test_resolve_returns_disk_path_for_scoped_upload(
+    tmp_upload_root, store, beanie_upload_db
+):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    resolver = EEUploadResolver(adapter=adapter, meta=store)
+
+    rec, disk_path = await _stash(tmp_upload_root, store, workspace="ws-1")
+
+    resolved = await resolver.resolve(f"/api/v1/uploads/{rec.id}", workspace="ws-1")
+    assert resolved == disk_path
+
+
+async def test_resolve_enforces_workspace_isolation(tmp_upload_root, store, beanie_upload_db):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    resolver = EEUploadResolver(adapter=adapter, meta=store)
+
+    rec, _ = await _stash(tmp_upload_root, store, workspace="ws-1")
+
+    # Same id, different workspace → not found (not 403, returns None).
+    resolved = await resolver.resolve(f"/api/v1/uploads/{rec.id}", workspace="ws-other")
+    assert resolved is None
+
+
+async def test_resolve_returns_none_for_non_upload_url(tmp_upload_root, store, beanie_upload_db):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    resolver = EEUploadResolver(adapter=adapter, meta=store)
+
+    assert await resolver.resolve("/already/local.pdf", workspace="ws-1") is None
+    assert await resolver.resolve("/api/v1/files/abc", workspace="ws-1") is None
+
+
+async def test_resolve_returns_none_for_soft_deleted_upload(
+    tmp_upload_root, store, beanie_upload_db
+):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    resolver = EEUploadResolver(adapter=adapter, meta=store)
+
+    rec, _ = await _stash(tmp_upload_root, store, workspace="ws-1")
+    await store.soft_delete_scoped(rec.id, workspace="ws-1")
+
+    assert await resolver.resolve(f"/api/v1/uploads/{rec.id}", workspace="ws-1") is None
+
+
+async def test_resolve_returns_none_when_blob_missing_on_disk(
+    tmp_upload_root, store, beanie_upload_db
+):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    resolver = EEUploadResolver(adapter=adapter, meta=store)
+
+    rec, disk_path = await _stash(tmp_upload_root, store, workspace="ws-1")
+    disk_path.unlink()
+    assert await resolver.resolve(f"/api/v1/uploads/{rec.id}", workspace="ws-1") is None
+
+
+async def test_resolve_media_paths_scoped_mixes_pass_drop_resolve(
+    tmp_upload_root, store, beanie_upload_db
+):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    resolver = EEUploadResolver(adapter=adapter, meta=store)
+
+    rec, disk_path = await _stash(tmp_upload_root, store, workspace="ws-1")
+    ghost = "ghost0000000000000000000000000000"
+
+    result = await resolve_media_paths_scoped(
+        [
+            f"/api/v1/uploads/{rec.id}",
+            "/already/local/path.pdf",
+            f"/api/v1/uploads/{ghost}",
+        ],
+        resolver=resolver,
+        workspace="ws-1",
+    )
+    assert result == [str(disk_path), "/already/local/path.pdf"]

--- a/tests/cloud/uploads/test_resolver_fallback.py
+++ b/tests/cloud/uploads/test_resolver_fallback.py
@@ -1,0 +1,139 @@
+"""Tests for the OSS→EE Mongo fallback in ``resolve_media_paths_any``.
+
+Scenario: uploads go through the EE router (workspace-scoped Mongo) but
+chat still goes through the OSS ``/chat/stream`` endpoint. Without fallback
+the OSS JSONL lookup misses every EE upload.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+from pocketpaw.uploads.local import LocalStorageAdapter
+from pocketpaw.uploads.resolver import resolve_media_paths_any
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_fallback_resolves_from_ee_mongo_when_oss_misses(
+    tmp_upload_root: Path, store, beanie_upload_db
+):
+    """File in Mongo but not JSONL still resolves via the fallback path."""
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    oss_meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+
+    # Stash only in Mongo (simulates upload via EE router).
+    file_id = uuid.uuid4().hex
+    storage_key = f"chat/202604/{file_id}.png"
+    disk = tmp_upload_root / storage_key
+    disk.parent.mkdir(parents=True, exist_ok=True)
+    disk.write_bytes(b"pngbytes")
+    await store.save_scoped(
+        FileRecord(
+            id=file_id,
+            storage_key=storage_key,
+            filename="x.png",
+            mime="image/png",
+            size=8,
+            owner_id="u1",
+            chat_id="__paw-runtime-dm__",
+            created=datetime.now(UTC),
+        ),
+        workspace="ws-1",
+    )
+
+    # Stub OSS + EE module-level singletons for the resolver.
+    with (
+        patch("pocketpaw.api.v1.uploads._ADAPTER", adapter),
+        patch("pocketpaw.api.v1.uploads._META", oss_meta),
+        patch("ee.cloud.uploads.router._ADAPTER", adapter),
+        patch("ee.cloud.uploads.router._META", store),
+    ):
+        result = await resolve_media_paths_any([f"/api/v1/uploads/{file_id}"])
+
+    assert result == [str(disk)]
+
+
+async def test_fallback_returns_none_when_neither_store_has_id(
+    tmp_upload_root: Path, store, beanie_upload_db
+):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    oss_meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+    ghost_url = "/api/v1/uploads/ghost0000000000000000000000000000"
+
+    with (
+        patch("pocketpaw.api.v1.uploads._ADAPTER", adapter),
+        patch("pocketpaw.api.v1.uploads._META", oss_meta),
+        patch("ee.cloud.uploads.router._ADAPTER", adapter),
+        patch("ee.cloud.uploads.router._META", store),
+    ):
+        result = await resolve_media_paths_any([ghost_url])
+
+    assert result == []
+
+
+async def test_fallback_ignores_soft_deleted_ee_record(
+    tmp_upload_root: Path, store, beanie_upload_db
+):
+    adapter = LocalStorageAdapter(root=tmp_upload_root)
+    oss_meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+
+    file_id = uuid.uuid4().hex
+    storage_key = f"chat/202604/{file_id}.png"
+    disk = tmp_upload_root / storage_key
+    disk.parent.mkdir(parents=True, exist_ok=True)
+    disk.write_bytes(b"x")
+    await store.save_scoped(
+        FileRecord(
+            id=file_id,
+            storage_key=storage_key,
+            filename="x.png",
+            mime="image/png",
+            size=1,
+            owner_id="u1",
+            chat_id=None,
+            created=datetime.now(UTC),
+        ),
+        workspace="ws-1",
+    )
+    await store.soft_delete_scoped(file_id, workspace="ws-1")
+
+    with (
+        patch("pocketpaw.api.v1.uploads._ADAPTER", adapter),
+        patch("pocketpaw.api.v1.uploads._META", oss_meta),
+        patch("ee.cloud.uploads.router._ADAPTER", adapter),
+        patch("ee.cloud.uploads.router._META", store),
+    ):
+        result = await resolve_media_paths_any([f"/api/v1/uploads/{file_id}"])
+
+    assert result == []
+
+
+async def test_get_unscoped_returns_record_across_workspaces(
+    tmp_upload_root: Path, store, beanie_upload_db
+):
+    """``get_unscoped`` finds a file_id regardless of workspace."""
+    file_id = uuid.uuid4().hex
+    await store.save_scoped(
+        FileRecord(
+            id=file_id,
+            storage_key=f"chat/202604/{file_id}.txt",
+            filename="x.txt",
+            mime="text/plain",
+            size=1,
+            owner_id="u1",
+            chat_id=None,
+            created=datetime.now(UTC),
+        ),
+        workspace="ws-private",
+    )
+
+    found = await store.get_unscoped(file_id)
+    assert found is not None
+    assert found.id == file_id

--- a/tests/cloud/uploads/test_router.py
+++ b/tests/cloud/uploads/test_router.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"body"
+
+
+@pytest.fixture()
+def ee_client(tmp_path: Path, beanie_upload_db, monkeypatch):
+    """Build an app with the EE uploads router pointed at a tmp dir and fake deps."""
+    import ee.cloud.uploads.router as uploads_module
+    from ee.cloud.uploads.mongo_store import MongoFileStore
+    from ee.cloud.uploads.service import EEUploadService
+    from pocketpaw.uploads.config import UploadSettings
+    from pocketpaw.uploads.local import LocalStorageAdapter
+
+    root = tmp_path / "u"
+    root.mkdir()
+
+    test_cfg = UploadSettings(local_root=root)
+    test_adapter = LocalStorageAdapter(root=root)
+    test_meta = MongoFileStore()
+    test_svc = EEUploadService(adapter=test_adapter, meta=test_meta, cfg=test_cfg)
+
+    monkeypatch.setattr(uploads_module, "_SVC", test_svc)
+
+    app = FastAPI()
+    # Override the license + identity dependencies so tests don't need auth plumbing.
+    from ee.cloud.license import require_license
+    from ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+    app.dependency_overrides[require_license] = lambda: None
+
+    # Dynamic user/workspace per-request via headers so we can test isolation.
+    from fastapi import Header
+
+    async def _user_dep(x_user: str = Header(default="u1")) -> str:
+        return x_user
+
+    async def _workspace_dep(x_workspace: str = Header(default="w1")) -> str:
+        return x_workspace
+
+    app.dependency_overrides[current_user_id] = _user_dep
+    app.dependency_overrides[current_workspace_id] = _workspace_dep
+
+    app.include_router(uploads_module.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+def _post_png(client: TestClient, user: str, ws: str, filename: str = "cat.png"):
+    return client.post(
+        "/api/v1/uploads",
+        files=[("files", (filename, PNG, "image/png"))],
+        headers={"x-user": user, "x-workspace": ws},
+    )
+
+
+def test_upload_roundtrip(ee_client: TestClient):
+    r = _post_png(ee_client, "u1", "w1")
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert len(data["uploaded"]) == 1
+    fid = data["uploaded"][0]["id"]
+
+    r2 = ee_client.get(
+        f"/api/v1/uploads/{fid}", headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r2.status_code == 200
+    assert r2.content == PNG
+    assert "inline" in r2.headers["content-disposition"]
+
+
+def test_cross_workspace_get_is_404(ee_client: TestClient):
+    r = _post_png(ee_client, "u1", "w1")
+    fid = r.json()["uploaded"][0]["id"]
+
+    r2 = ee_client.get(
+        f"/api/v1/uploads/{fid}", headers={"x-user": "u1", "x-workspace": "w2"},
+    )
+    assert r2.status_code == 404
+
+
+def test_cross_user_same_workspace_is_404(ee_client: TestClient):
+    r = _post_png(ee_client, "alice", "w1")
+    fid = r.json()["uploaded"][0]["id"]
+
+    r2 = ee_client.get(
+        f"/api/v1/uploads/{fid}", headers={"x-user": "bob", "x-workspace": "w1"},
+    )
+    assert r2.status_code == 404  # owner-only in v1
+
+
+def test_delete_then_get_is_404(ee_client: TestClient):
+    r = _post_png(ee_client, "u1", "w1")
+    fid = r.json()["uploaded"][0]["id"]
+
+    r2 = ee_client.delete(
+        f"/api/v1/uploads/{fid}", headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r2.status_code == 204
+
+    r3 = ee_client.get(
+        f"/api/v1/uploads/{fid}", headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r3.status_code == 404
+
+
+def test_bulk_partial_success(ee_client: TestClient):
+    r = ee_client.post(
+        "/api/v1/uploads",
+        files=[
+            ("files", ("good.png", PNG, "image/png")),
+            ("files", ("bad.svg", b"<svg/>", "image/svg+xml")),
+        ],
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["uploaded"]) == 1
+    assert len(data["failed"]) == 1
+    assert data["failed"][0]["code"] == "unsupported_mime"

--- a/tests/cloud/uploads/test_router.py
+++ b/tests/cloud/uploads/test_router.py
@@ -67,7 +67,8 @@ def test_upload_roundtrip(ee_client: TestClient):
     fid = data["uploaded"][0]["id"]
 
     r2 = ee_client.get(
-        f"/api/v1/uploads/{fid}", headers={"x-user": "u1", "x-workspace": "w1"},
+        f"/api/v1/uploads/{fid}",
+        headers={"x-user": "u1", "x-workspace": "w1"},
     )
     assert r2.status_code == 200
     assert r2.content == PNG
@@ -79,7 +80,8 @@ def test_cross_workspace_get_is_404(ee_client: TestClient):
     fid = r.json()["uploaded"][0]["id"]
 
     r2 = ee_client.get(
-        f"/api/v1/uploads/{fid}", headers={"x-user": "u1", "x-workspace": "w2"},
+        f"/api/v1/uploads/{fid}",
+        headers={"x-user": "u1", "x-workspace": "w2"},
     )
     assert r2.status_code == 404
 
@@ -89,7 +91,8 @@ def test_cross_user_same_workspace_is_404(ee_client: TestClient):
     fid = r.json()["uploaded"][0]["id"]
 
     r2 = ee_client.get(
-        f"/api/v1/uploads/{fid}", headers={"x-user": "bob", "x-workspace": "w1"},
+        f"/api/v1/uploads/{fid}",
+        headers={"x-user": "bob", "x-workspace": "w1"},
     )
     assert r2.status_code == 404  # owner-only in v1
 
@@ -99,12 +102,14 @@ def test_delete_then_get_is_404(ee_client: TestClient):
     fid = r.json()["uploaded"][0]["id"]
 
     r2 = ee_client.delete(
-        f"/api/v1/uploads/{fid}", headers={"x-user": "u1", "x-workspace": "w1"},
+        f"/api/v1/uploads/{fid}",
+        headers={"x-user": "u1", "x-workspace": "w1"},
     )
     assert r2.status_code == 204
 
     r3 = ee_client.get(
-        f"/api/v1/uploads/{fid}", headers={"x-user": "u1", "x-workspace": "w1"},
+        f"/api/v1/uploads/{fid}",
+        headers={"x-user": "u1", "x-workspace": "w1"},
     )
     assert r3.status_code == 404
 

--- a/tests/cloud/uploads/test_service.py
+++ b/tests/cloud/uploads/test_service.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import io
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from fastapi import UploadFile
+
+from pocketpaw.uploads.adapter import StorageAdapter, StoredObject
+from pocketpaw.uploads.config import UploadSettings
+from pocketpaw.uploads.errors import NotFound
+
+pytestmark = pytest.mark.asyncio
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"rest"
+
+
+class _MemAdapter(StorageAdapter):
+    def __init__(self) -> None:
+        self.blobs: dict[str, bytes] = {}
+
+    async def put(self, key, stream, mime):
+        buf = b""
+        async for c in stream:
+            buf += c
+        self.blobs[key] = buf
+        return StoredObject(key=key, size=len(buf), mime=mime)
+
+    async def open(self, key):
+        if key not in self.blobs:
+            raise NotFound()
+        yield self.blobs[key]
+
+    async def delete(self, key):
+        self.blobs.pop(key, None)
+
+    async def exists(self, key):
+        return key in self.blobs
+
+
+def _upload(content: bytes, filename: str, mime: str) -> UploadFile:
+    return UploadFile(
+        file=io.BytesIO(content),
+        filename=filename,
+        headers={"content-type": mime},  # type: ignore[arg-type]
+    )
+
+
+class TestEEUploadService:
+    async def test_upload_stores_record_in_workspace(self, store, tmp_path: Path):
+        from ee.cloud.uploads.service import EEUploadService
+
+        svc = EEUploadService(
+            adapter=_MemAdapter(), meta=store, cfg=UploadSettings(local_root=tmp_path),
+        )
+        rec = await svc.upload(_upload(PNG, "cat.png", "image/png"),
+                               owner_id="u1", chat_id="c1", workspace="w1")
+        assert rec.owner_id == "u1"
+        got = await store.get_scoped(rec.id, workspace="w1")
+        assert got is not None
+
+    async def test_stream_enforces_workspace(self, store, tmp_path: Path):
+        from ee.cloud.uploads.service import EEUploadService
+
+        svc = EEUploadService(
+            adapter=_MemAdapter(), meta=store, cfg=UploadSettings(local_root=tmp_path),
+        )
+        rec = await svc.upload(_upload(PNG, "cat.png", "image/png"),
+                               owner_id="u1", chat_id="c1", workspace="w1")
+        with pytest.raises(NotFound):
+            await svc.stream(rec.id, requester_id="u1", workspace="w2")
+
+    async def test_stream_happy_path(self, store, tmp_path: Path):
+        from ee.cloud.uploads.service import EEUploadService
+
+        adapter = _MemAdapter()
+        svc = EEUploadService(
+            adapter=adapter, meta=store, cfg=UploadSettings(local_root=tmp_path),
+        )
+        rec = await svc.upload(_upload(PNG, "cat.png", "image/png"),
+                               owner_id="u1", chat_id="c1", workspace="w1")
+        got_rec, it = await svc.stream(rec.id, requester_id="u1", workspace="w1")
+        chunks = [c async for c in it]
+        assert b"".join(chunks) == PNG
+        assert got_rec.id == rec.id
+
+    async def test_delete_owner_in_workspace(self, store, tmp_path: Path):
+        from ee.cloud.uploads.service import EEUploadService
+
+        svc = EEUploadService(
+            adapter=_MemAdapter(), meta=store, cfg=UploadSettings(local_root=tmp_path),
+        )
+        rec = await svc.upload(_upload(PNG, "cat.png", "image/png"),
+                               owner_id="u1", chat_id="c1", workspace="w1")
+        await svc.delete(rec.id, requester_id="u1", workspace="w1")
+        with pytest.raises(NotFound):
+            await svc.stream(rec.id, requester_id="u1", workspace="w1")
+
+    async def test_bulk_upload(self, store, tmp_path: Path):
+        from ee.cloud.uploads.service import EEUploadService
+
+        svc = EEUploadService(
+            adapter=_MemAdapter(), meta=store, cfg=UploadSettings(local_root=tmp_path),
+        )
+        files = [
+            _upload(PNG, "a.png", "image/png"),
+            _upload(PNG, "b.png", "image/png"),
+        ]
+        result = await svc.upload_many(files, owner_id="u1", chat_id=None, workspace="w1")
+        assert len(result.uploaded) == 2
+        assert len(result.failed) == 0
+        # Both persisted in Mongo under workspace
+        for rec in result.uploaded:
+            got = await store.get_scoped(rec.id, workspace="w1")
+            assert got is not None

--- a/tests/cloud/uploads/test_service.py
+++ b/tests/cloud/uploads/test_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
@@ -52,10 +51,13 @@ class TestEEUploadService:
         from ee.cloud.uploads.service import EEUploadService
 
         svc = EEUploadService(
-            adapter=_MemAdapter(), meta=store, cfg=UploadSettings(local_root=tmp_path),
+            adapter=_MemAdapter(),
+            meta=store,
+            cfg=UploadSettings(local_root=tmp_path),
         )
-        rec = await svc.upload(_upload(PNG, "cat.png", "image/png"),
-                               owner_id="u1", chat_id="c1", workspace="w1")
+        rec = await svc.upload(
+            _upload(PNG, "cat.png", "image/png"), owner_id="u1", chat_id="c1", workspace="w1"
+        )
         assert rec.owner_id == "u1"
         got = await store.get_scoped(rec.id, workspace="w1")
         assert got is not None
@@ -64,10 +66,13 @@ class TestEEUploadService:
         from ee.cloud.uploads.service import EEUploadService
 
         svc = EEUploadService(
-            adapter=_MemAdapter(), meta=store, cfg=UploadSettings(local_root=tmp_path),
+            adapter=_MemAdapter(),
+            meta=store,
+            cfg=UploadSettings(local_root=tmp_path),
         )
-        rec = await svc.upload(_upload(PNG, "cat.png", "image/png"),
-                               owner_id="u1", chat_id="c1", workspace="w1")
+        rec = await svc.upload(
+            _upload(PNG, "cat.png", "image/png"), owner_id="u1", chat_id="c1", workspace="w1"
+        )
         with pytest.raises(NotFound):
             await svc.stream(rec.id, requester_id="u1", workspace="w2")
 
@@ -76,10 +81,13 @@ class TestEEUploadService:
 
         adapter = _MemAdapter()
         svc = EEUploadService(
-            adapter=adapter, meta=store, cfg=UploadSettings(local_root=tmp_path),
+            adapter=adapter,
+            meta=store,
+            cfg=UploadSettings(local_root=tmp_path),
         )
-        rec = await svc.upload(_upload(PNG, "cat.png", "image/png"),
-                               owner_id="u1", chat_id="c1", workspace="w1")
+        rec = await svc.upload(
+            _upload(PNG, "cat.png", "image/png"), owner_id="u1", chat_id="c1", workspace="w1"
+        )
         got_rec, it = await svc.stream(rec.id, requester_id="u1", workspace="w1")
         chunks = [c async for c in it]
         assert b"".join(chunks) == PNG
@@ -89,10 +97,13 @@ class TestEEUploadService:
         from ee.cloud.uploads.service import EEUploadService
 
         svc = EEUploadService(
-            adapter=_MemAdapter(), meta=store, cfg=UploadSettings(local_root=tmp_path),
+            adapter=_MemAdapter(),
+            meta=store,
+            cfg=UploadSettings(local_root=tmp_path),
         )
-        rec = await svc.upload(_upload(PNG, "cat.png", "image/png"),
-                               owner_id="u1", chat_id="c1", workspace="w1")
+        rec = await svc.upload(
+            _upload(PNG, "cat.png", "image/png"), owner_id="u1", chat_id="c1", workspace="w1"
+        )
         await svc.delete(rec.id, requester_id="u1", workspace="w1")
         with pytest.raises(NotFound):
             await svc.stream(rec.id, requester_id="u1", workspace="w1")
@@ -101,7 +112,9 @@ class TestEEUploadService:
         from ee.cloud.uploads.service import EEUploadService
 
         svc = EEUploadService(
-            adapter=_MemAdapter(), meta=store, cfg=UploadSettings(local_root=tmp_path),
+            adapter=_MemAdapter(),
+            meta=store,
+            cfg=UploadSettings(local_root=tmp_path),
         )
         files = [
             _upload(PNG, "a.png", "image/png"),

--- a/tests/test_agent_loop_media.py
+++ b/tests/test_agent_loop_media.py
@@ -1,0 +1,25 @@
+"""Tests for the media prompt helpers in pocketpaw.agents.loop."""
+
+from __future__ import annotations
+
+from pocketpaw.agents.loop import _format_bytes
+
+
+class TestFormatBytes:
+    def test_under_1kb_shows_bytes(self) -> None:
+        assert _format_bytes(0) == "0 B"
+        assert _format_bytes(1) == "1 B"
+        assert _format_bytes(1023) == "1023 B"
+
+    def test_kb_range(self) -> None:
+        assert _format_bytes(1024) == "1.0 KB"
+        assert _format_bytes(414255) == "404.5 KB"
+        assert _format_bytes(1024 * 1024 - 1) == "1024.0 KB"
+
+    def test_mb_range(self) -> None:
+        assert _format_bytes(1024 * 1024) == "1.0 MB"
+        assert _format_bytes(5_242_880) == "5.0 MB"
+
+    def test_gb_range(self) -> None:
+        assert _format_bytes(1024 * 1024 * 1024) == "1.0 GB"
+        assert _format_bytes(2 * 1024 * 1024 * 1024) == "2.0 GB"

--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -183,3 +183,78 @@ class TestSSEFormat:
             data_str = data_line.split(":", 1)[1].strip()
             parsed = _json.loads(data_str)
             assert isinstance(parsed, dict), f"SSE data must be a JSON object, got: {type(parsed)}"
+
+
+class TestSendMessageResolvesMedia:
+    """_send_message must rewrite upload URLs to local paths before bus publish."""
+
+    @pytest.mark.asyncio
+    async def test_upload_urls_become_local_paths(self, tmp_path, monkeypatch):
+        import uuid
+        from datetime import UTC, datetime
+
+        from pocketpaw.api.v1.chat import _send_message
+        from pocketpaw.api.v1.schemas.chat import ChatRequest
+        from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+        from pocketpaw.uploads.local import LocalStorageAdapter
+        from pocketpaw.uploads.resolver import UploadResolver
+
+        # Stand up isolated adapter + meta store.
+        root = tmp_path / "uploads"
+        root.mkdir()
+        adapter = LocalStorageAdapter(root=root)
+        meta = JSONLFileStore(path=root / "_idx.jsonl")
+
+        # Stash a real blob + record.
+        fid = uuid.uuid4().hex
+        storage_key = f"chat/202604/{fid}.txt"
+        disk = root / storage_key
+        disk.parent.mkdir(parents=True, exist_ok=True)
+        disk.write_bytes(b"hello")
+        meta.save(
+            FileRecord(
+                id=fid,
+                storage_key=storage_key,
+                filename="x.txt",
+                mime="text/plain",
+                size=5,
+                owner_id="local",
+                chat_id=None,
+                created=datetime.now(UTC),
+            )
+        )
+
+        # Force chat._send_message's internal import to use our stub resolver.
+        from pocketpaw.uploads import resolver as resolver_mod
+
+        monkeypatch.setattr(
+            resolver_mod,
+            "default_resolver",
+            lambda: UploadResolver(adapter=adapter, meta=meta),
+        )
+
+        # Capture the InboundMessage that gets published.
+        captured: dict = {}
+
+        class _StubBus:
+            async def publish_inbound(self, msg):
+                captured["msg"] = msg
+
+        from pocketpaw import bus as bus_mod
+
+        monkeypatch.setattr(bus_mod, "get_message_bus", lambda: _StubBus())
+
+        req = ChatRequest(
+            content="look at this",
+            session_id="chat-1",
+            media=[
+                f"/api/v1/uploads/{fid}",
+                "/already/local/path.pdf",
+                "/api/v1/uploads/ghost0000000000000000000000000000",
+            ],
+        )
+        await _send_message(req)
+
+        msg = captured["msg"]
+        assert msg.content == "look at this"
+        assert msg.media == [str(disk), "/already/local/path.pdf"]

--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -258,3 +258,42 @@ class TestSendMessageResolvesMedia:
         msg = captured["msg"]
         assert msg.content == "look at this"
         assert msg.media == [str(disk), "/already/local/path.pdf"]
+
+        # media_info should carry the FileRecord metadata only for resolved
+        # upload entries (not the passthrough "/already/local/path.pdf").
+        info = msg.metadata.get("media_info")
+        assert isinstance(info, list)
+        assert len(info) == 1
+        assert info[0] == {
+            "path": str(disk),
+            "filename": "x.txt",
+            "mime": "text/plain",
+            "size": 5,
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_media_info_when_no_upload_urls(self, tmp_path, monkeypatch):
+        from pocketpaw.api.v1.chat import _send_message
+        from pocketpaw.api.v1.schemas.chat import ChatRequest
+
+        captured: dict = {}
+
+        class _StubBus:
+            async def publish_inbound(self, msg):
+                captured["msg"] = msg
+
+        from pocketpaw import bus as bus_mod
+
+        monkeypatch.setattr(bus_mod, "get_message_bus", lambda: _StubBus())
+
+        req = ChatRequest(
+            content="plain text",
+            session_id="chat-2",
+            media=["/already/here.pdf"],
+        )
+        await _send_message(req)
+
+        msg = captured["msg"]
+        assert msg.media == ["/already/here.pdf"]
+        # Passthrough entries yield no media_info; key should be absent.
+        assert "media_info" not in msg.metadata

--- a/tests/uploads/conftest.py
+++ b/tests/uploads/conftest.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def tmp_upload_root(tmp_path: Path) -> Path:
+    """Isolated root for each test."""
+    root = tmp_path / "uploads"
+    root.mkdir()
+    return root

--- a/tests/uploads/test_errors.py
+++ b/tests/uploads/test_errors.py
@@ -1,0 +1,28 @@
+from pocketpaw.uploads.errors import (
+    AccessDenied,
+    EmptyFile,
+    NotFound,
+    StorageFailure,
+    TooLarge,
+    UnsupportedMime,
+    UploadError,
+)
+
+
+def test_all_errors_inherit_upload_error():
+    for cls in (TooLarge, UnsupportedMime, EmptyFile, NotFound, AccessDenied, StorageFailure):
+        assert issubclass(cls, UploadError)
+
+
+def test_errors_carry_code_attribute():
+    assert TooLarge("25mb").code == "too_large"
+    assert UnsupportedMime("image/tiff").code == "unsupported_mime"
+    assert EmptyFile().code == "empty"
+    assert NotFound().code == "not_found"
+    assert AccessDenied().code == "access_denied"
+    assert StorageFailure("disk full").code == "storage_error"
+
+
+def test_upload_error_preserves_message():
+    err = TooLarge("file is 40MB")
+    assert str(err) == "file is 40MB"

--- a/tests/uploads/test_file_store.py
+++ b/tests/uploads/test_file_store.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+
+
+def _record(file_id: str = "f1", **overrides) -> FileRecord:
+    defaults = {
+        "id": file_id,
+        "storage_key": "chat/202604/abc.png",
+        "filename": "cat.png",
+        "mime": "image/png",
+        "size": 1234,
+        "owner_id": "user-1",
+        "chat_id": "chat-1",
+        "created": datetime(2026, 4, 16, 12, 0, tzinfo=UTC),
+    }
+    defaults.update(overrides)
+    return FileRecord(**defaults)
+
+
+class TestJSONLFileStore:
+    def test_save_then_get_roundtrip(self, tmp_path: Path):
+        store = JSONLFileStore(path=tmp_path / "idx.jsonl")
+        store.save(_record())
+        got = store.get("f1")
+        assert got is not None
+        assert got.filename == "cat.png"
+        assert got.size == 1234
+
+    def test_get_missing_returns_none(self, tmp_path: Path):
+        store = JSONLFileStore(path=tmp_path / "idx.jsonl")
+        assert store.get("nope") is None
+
+    def test_soft_delete_hides_from_get(self, tmp_path: Path):
+        store = JSONLFileStore(path=tmp_path / "idx.jsonl")
+        store.save(_record())
+        store.soft_delete("f1")
+        assert store.get("f1") is None
+
+    def test_cold_reload_preserves_state(self, tmp_path: Path):
+        path = tmp_path / "idx.jsonl"
+        s1 = JSONLFileStore(path=path)
+        s1.save(_record("a"))
+        s1.save(_record("b", filename="b.png"))
+        s1.soft_delete("a")
+
+        s2 = JSONLFileStore(path=path)  # reload
+        assert s2.get("a") is None
+        assert s2.get("b") is not None
+        assert s2.get("b").filename == "b.png"
+
+    def test_corrupt_line_is_skipped(self, tmp_path: Path):
+        path = tmp_path / "idx.jsonl"
+        path.write_text('{"op": "save", "record": {"id": "a", "storage_key": "k", "filename": "a", '
+                        '"mime": "text/plain", "size": 1, "owner_id": "u", "chat_id": null, '
+                        '"created": "2026-04-16T12:00:00+00:00"}}\n'
+                        'THIS IS NOT JSON\n'
+                        '{"op": "save", "record": {"id": "b", "storage_key": "k2", "filename": "b", '
+                        '"mime": "text/plain", "size": 1, "owner_id": "u", "chat_id": null, '
+                        '"created": "2026-04-16T12:00:00+00:00"}}\n',
+                        encoding="utf-8")
+        store = JSONLFileStore(path=path)
+        assert store.get("a") is not None
+        assert store.get("b") is not None

--- a/tests/uploads/test_file_store.py
+++ b/tests/uploads/test_file_store.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 
-import pytest
-
 from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
 
 
@@ -56,14 +54,16 @@ class TestJSONLFileStore:
 
     def test_corrupt_line_is_skipped(self, tmp_path: Path):
         path = tmp_path / "idx.jsonl"
-        path.write_text('{"op": "save", "record": {"id": "a", "storage_key": "k", "filename": "a", '
-                        '"mime": "text/plain", "size": 1, "owner_id": "u", "chat_id": null, '
-                        '"created": "2026-04-16T12:00:00+00:00"}}\n'
-                        'THIS IS NOT JSON\n'
-                        '{"op": "save", "record": {"id": "b", "storage_key": "k2", "filename": "b", '
-                        '"mime": "text/plain", "size": 1, "owner_id": "u", "chat_id": null, '
-                        '"created": "2026-04-16T12:00:00+00:00"}}\n',
-                        encoding="utf-8")
+        path.write_text(
+            '{"op": "save", "record": {"id": "a", "storage_key": "k", "filename": "a", '
+            '"mime": "text/plain", "size": 1, "owner_id": "u", "chat_id": null, '
+            '"created": "2026-04-16T12:00:00+00:00"}}\n'
+            "THIS IS NOT JSON\n"
+            '{"op": "save", "record": {"id": "b", "storage_key": "k2", "filename": "b", '
+            '"mime": "text/plain", "size": 1, "owner_id": "u", "chat_id": null, '
+            '"created": "2026-04-16T12:00:00+00:00"}}\n',
+            encoding="utf-8",
+        )
         store = JSONLFileStore(path=path)
         assert store.get("a") is not None
         assert store.get("b") is not None

--- a/tests/uploads/test_keys.py
+++ b/tests/uploads/test_keys.py
@@ -1,0 +1,44 @@
+import re
+
+from pocketpaw.uploads.keys import new_storage_key, sanitize_ext
+
+
+def test_new_storage_key_shape():
+    key = new_storage_key("chat", ".png")
+    assert re.match(r"^chat/\d{6}/[a-f0-9]{32}\.png$", key), key
+
+
+def test_default_kind_is_chat():
+    key = new_storage_key(ext=".pdf")
+    assert key.startswith("chat/")
+
+
+def test_no_ext_produces_key_without_extension():
+    key = new_storage_key("chat", "")
+    assert re.match(r"^chat/\d{6}/[a-f0-9]{32}$", key)
+
+
+def test_1000_keys_are_unique():
+    keys = {new_storage_key("chat", ".bin") for _ in range(1000)}
+    assert len(keys) == 1000
+
+
+def test_sanitize_ext_lowercases():
+    assert sanitize_ext(".PNG") == ".png"
+
+
+def test_sanitize_ext_strips_non_alnum():
+    assert sanitize_ext(".p!ng") == ".png"
+
+
+def test_sanitize_ext_caps_length():
+    assert sanitize_ext(".abcdefghijklmno") == ".abcdefgh"  # 8 chars max
+
+
+def test_sanitize_ext_empty_returns_empty():
+    assert sanitize_ext("") == ""
+    assert sanitize_ext(".") == ""
+
+
+def test_sanitize_ext_adds_leading_dot():
+    assert sanitize_ext("png") == ".png"

--- a/tests/uploads/test_local_adapter.py
+++ b/tests/uploads/test_local_adapter.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.uploads.errors import AccessDenied, NotFound, StorageFailure
+from pocketpaw.uploads.local import LocalStorageAdapter
+
+
+async def _astream(chunks: list[bytes]) -> AsyncIterator[bytes]:
+    for c in chunks:
+        yield c
+
+
+class TestLocalStorageAdapter:
+    async def test_put_writes_bytes_and_returns_size(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        obj = await adapter.put("chat/202604/abc.png", _astream([b"hello"]), "image/png")
+        assert obj.key == "chat/202604/abc.png"
+        assert obj.size == 5
+        assert obj.mime == "image/png"
+        assert (tmp_upload_root / "chat" / "202604" / "abc.png").read_bytes() == b"hello"
+
+    async def test_put_creates_parent_dirs(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        await adapter.put("a/b/c/d.bin", _astream([b"x"]), "application/octet-stream")
+        assert (tmp_upload_root / "a" / "b" / "c" / "d.bin").exists()
+
+    async def test_put_concatenates_chunks(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        obj = await adapter.put("k/file.bin", _astream([b"foo", b"bar", b"baz"]), "application/octet-stream")
+        assert obj.size == 9
+        assert (tmp_upload_root / "k/file.bin").read_bytes() == b"foobarbaz"
+
+    async def test_put_atomic_no_partial_on_stream_error(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+
+        async def bad_stream() -> AsyncIterator[bytes]:
+            yield b"part1"
+            raise RuntimeError("boom")
+
+        with pytest.raises(StorageFailure):
+            await adapter.put("k/file.bin", bad_stream(), "application/octet-stream")
+
+        # Final file must NOT exist
+        assert not (tmp_upload_root / "k" / "file.bin").exists()
+
+    async def test_open_streams_bytes(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        await adapter.put("k/file.bin", _astream([b"hello world"]), "application/octet-stream")
+        chunks: list[bytes] = [c async for c in adapter.open("k/file.bin")]
+        assert b"".join(chunks) == b"hello world"
+
+    async def test_open_missing_raises_not_found(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        with pytest.raises(NotFound):
+            _ = [c async for c in adapter.open("nope")]
+
+    async def test_delete_idempotent(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        await adapter.put("k/file.bin", _astream([b"x"]), "application/octet-stream")
+        await adapter.delete("k/file.bin")
+        await adapter.delete("k/file.bin")  # second call: no error
+        assert not (tmp_upload_root / "k" / "file.bin").exists()
+
+    async def test_exists_true_after_put(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        assert await adapter.exists("k/file.bin") is False
+        await adapter.put("k/file.bin", _astream([b"x"]), "application/octet-stream")
+        assert await adapter.exists("k/file.bin") is True
+
+    async def test_put_rejects_path_traversal_key(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        with pytest.raises(AccessDenied):
+            await adapter.put("../../evil.bin", _astream([b"x"]), "application/octet-stream")
+
+    async def test_open_rejects_path_traversal_key(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        with pytest.raises(AccessDenied):
+            _ = [c async for c in adapter.open("../outside.bin")]

--- a/tests/uploads/test_local_adapter.py
+++ b/tests/uploads/test_local_adapter.py
@@ -30,7 +30,9 @@ class TestLocalStorageAdapter:
 
     async def test_put_concatenates_chunks(self, tmp_upload_root: Path):
         adapter = LocalStorageAdapter(root=tmp_upload_root)
-        obj = await adapter.put("k/file.bin", _astream([b"foo", b"bar", b"baz"]), "application/octet-stream")
+        obj = await adapter.put(
+            "k/file.bin", _astream([b"foo", b"bar", b"baz"]), "application/octet-stream"
+        )
         assert obj.size == 9
         assert (tmp_upload_root / "k/file.bin").read_bytes() == b"foobarbaz"
 

--- a/tests/uploads/test_resolver.py
+++ b/tests/uploads/test_resolver.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
 from pocketpaw.uploads.local import LocalStorageAdapter
 from pocketpaw.uploads.resolver import (
+    ResolvedMedia,
     UploadResolver,
     parse_upload_url,
     resolve_media_paths,
+    resolve_media_with_records,
 )
 
 
@@ -147,3 +150,71 @@ class TestResolveMediaPaths:
 
     def test_empty_list(self, resolver: UploadResolver) -> None:
         assert resolve_media_paths([], resolver=resolver) == []
+
+
+class TestResolveMediaWithRecords:
+    """Async version that returns path + FileRecord for prompt enrichment."""
+
+    @pytest.mark.asyncio
+    async def test_oss_hit_yields_record(self, tmp_upload_root: Path) -> None:
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+
+        file_id = uuid.uuid4().hex
+        storage_key = f"chat/202604/{file_id}.png"
+        disk = tmp_upload_root / storage_key
+        disk.parent.mkdir(parents=True, exist_ok=True)
+        disk.write_bytes(b"bytes")
+        rec = FileRecord(
+            id=file_id,
+            storage_key=storage_key,
+            filename="screenshot.png",
+            mime="image/png",
+            size=5,
+            owner_id="local",
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+        meta.save(rec)
+
+        with (
+            patch("pocketpaw.api.v1.uploads._ADAPTER", adapter),
+            patch("pocketpaw.api.v1.uploads._META", meta),
+        ):
+            result = await resolve_media_with_records([f"/api/v1/uploads/{file_id}"])
+
+        assert len(result) == 1
+        assert isinstance(result[0], ResolvedMedia)
+        assert result[0].path == str(disk)
+        assert result[0].record is not None
+        assert result[0].record.filename == "screenshot.png"
+        assert result[0].record.mime == "image/png"
+        assert result[0].record.size == 5
+
+    @pytest.mark.asyncio
+    async def test_passthrough_entry_has_none_record(self, tmp_upload_root: Path) -> None:
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+
+        with (
+            patch("pocketpaw.api.v1.uploads._ADAPTER", adapter),
+            patch("pocketpaw.api.v1.uploads._META", meta),
+        ):
+            result = await resolve_media_with_records(["/already/local/path.pdf"])
+
+        assert result == [ResolvedMedia(path="/already/local/path.pdf", record=None)]
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_upload_url_dropped(self, tmp_upload_root: Path) -> None:
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+
+        with (
+            patch("pocketpaw.api.v1.uploads._ADAPTER", adapter),
+            patch("pocketpaw.api.v1.uploads._META", meta),
+        ):
+            result = await resolve_media_with_records(
+                ["/api/v1/uploads/ghost0000000000000000000000000000"]
+            )
+
+        assert result == []

--- a/tests/uploads/test_resolver.py
+++ b/tests/uploads/test_resolver.py
@@ -1,0 +1,149 @@
+"""Tests for pocketpaw.uploads.resolver."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+from pocketpaw.uploads.local import LocalStorageAdapter
+from pocketpaw.uploads.resolver import (
+    UploadResolver,
+    parse_upload_url,
+    resolve_media_paths,
+)
+
+
+class TestParseUploadUrl:
+    def test_extracts_id_from_canonical_url(self) -> None:
+        fid = uuid.uuid4().hex
+        assert parse_upload_url(f"/api/v1/uploads/{fid}") == fid
+
+    def test_returns_none_for_non_upload_url(self) -> None:
+        assert parse_upload_url("/api/v1/files/abc") is None
+        assert parse_upload_url("https://example.com/x") is None
+
+    def test_returns_none_for_disk_path(self) -> None:
+        assert parse_upload_url("/home/user/image.png") is None
+        assert parse_upload_url("C:\\foo\\bar.pdf") is None
+
+    def test_parses_any_id_shaped_segment(self) -> None:
+        # parse is permissive; the metadata lookup decides validity.
+        assert parse_upload_url("/api/v1/uploads/abc") == "abc"
+        assert parse_upload_url("/api/v1/uploads/not-hex-chars") == "not-hex-chars"
+
+    def test_returns_none_for_url_with_trailing_slash_or_segment(self) -> None:
+        assert parse_upload_url("/api/v1/uploads/abc/") is None
+        assert parse_upload_url("/api/v1/uploads/abc/download") is None
+
+    def test_returns_none_for_empty_string(self) -> None:
+        assert parse_upload_url("") is None
+
+
+class TestUploadResolver:
+    @pytest.fixture()
+    def resolver(self, tmp_upload_root: Path) -> UploadResolver:
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+        return UploadResolver(adapter=adapter, meta=meta)
+
+    def _stash(
+        self,
+        tmp_upload_root: Path,
+        resolver: UploadResolver,
+        data: bytes = b"hello",
+        filename: str = "x.txt",
+        mime: str = "text/plain",
+    ) -> tuple[FileRecord, Path]:
+        """Put a blob on disk and register metadata. Returns (record, disk_path)."""
+        file_id = uuid.uuid4().hex
+        storage_key = f"chat/202604/{file_id}.txt"
+        disk_path = tmp_upload_root / storage_key
+        disk_path.parent.mkdir(parents=True, exist_ok=True)
+        disk_path.write_bytes(data)
+        rec = FileRecord(
+            id=file_id,
+            storage_key=storage_key,
+            filename=filename,
+            mime=mime,
+            size=len(data),
+            owner_id="local",
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+        resolver._meta.save(rec)
+        return rec, disk_path
+
+    def test_resolve_returns_disk_path_for_stored_upload(
+        self, tmp_upload_root: Path, resolver: UploadResolver
+    ) -> None:
+        rec, disk_path = self._stash(tmp_upload_root, resolver)
+        resolved = resolver.resolve(f"/api/v1/uploads/{rec.id}")
+        assert resolved == disk_path
+        assert resolved is not None
+        assert resolved.read_bytes() == b"hello"
+
+    def test_resolve_returns_none_for_missing_metadata(self, resolver: UploadResolver) -> None:
+        ghost = uuid.uuid4().hex
+        assert resolver.resolve(f"/api/v1/uploads/{ghost}") is None
+
+    def test_resolve_returns_none_when_blob_deleted_from_disk(
+        self, tmp_upload_root: Path, resolver: UploadResolver
+    ) -> None:
+        rec, disk_path = self._stash(tmp_upload_root, resolver)
+        disk_path.unlink()
+        assert resolver.resolve(f"/api/v1/uploads/{rec.id}") is None
+
+    def test_resolve_returns_none_for_non_upload_url(self, resolver: UploadResolver) -> None:
+        assert resolver.resolve("/api/v1/files/abc") is None
+        assert resolver.resolve("/already/local/path.txt") is None
+
+    def test_resolve_returns_none_for_soft_deleted_upload(
+        self, tmp_upload_root: Path, resolver: UploadResolver
+    ) -> None:
+        rec, _ = self._stash(tmp_upload_root, resolver)
+        resolver._meta.soft_delete(rec.id)
+        assert resolver.resolve(f"/api/v1/uploads/{rec.id}") is None
+
+
+class TestResolveMediaPaths:
+    @pytest.fixture()
+    def resolver(self, tmp_upload_root: Path) -> UploadResolver:
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        meta = JSONLFileStore(path=tmp_upload_root / "_idx.jsonl")
+        return UploadResolver(adapter=adapter, meta=meta)
+
+    def test_mixed_paths_and_urls(self, tmp_upload_root: Path, resolver: UploadResolver) -> None:
+        file_id = uuid.uuid4().hex
+        storage_key = f"chat/202604/{file_id}.png"
+        disk_path = tmp_upload_root / storage_key
+        disk_path.parent.mkdir(parents=True, exist_ok=True)
+        disk_path.write_bytes(b"png")
+        rec = FileRecord(
+            id=file_id,
+            storage_key=storage_key,
+            filename="x.png",
+            mime="image/png",
+            size=3,
+            owner_id="local",
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+        resolver._meta.save(rec)
+
+        media_in = [
+            f"/api/v1/uploads/{file_id}",
+            "/already/local/path.pdf",  # passthrough
+            "/api/v1/uploads/ghost0000000000000000000000000000",  # unresolvable
+        ]
+        result = resolve_media_paths(media_in, resolver=resolver)
+        assert result == [
+            str(disk_path),
+            "/already/local/path.pdf",
+        ]
+
+    def test_empty_list(self, resolver: UploadResolver) -> None:
+        assert resolve_media_paths([], resolver=resolver) == []

--- a/tests/uploads/test_router.py
+++ b/tests/uploads/test_router.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 from fastapi import FastAPI
@@ -14,17 +13,16 @@ PNG = b"\x89PNG\r\n\x1a\n" + b"body"
 def client(tmp_path: Path, monkeypatch):
     """Build an app with the uploads router pointed at a tmp dir."""
     # Patch module-level globals BEFORE importing the router
-    import pocketpaw.uploads.config as cfg
     import pocketpaw.api.v1.uploads as uploads_module
 
     root = tmp_path / "u"
     root.mkdir()
 
     # Rebuild module-level service against tmp dirs
-    from pocketpaw.uploads.local import LocalStorageAdapter
-    from pocketpaw.uploads.file_store import JSONLFileStore
-    from pocketpaw.uploads.service import UploadService
     from pocketpaw.uploads.config import UploadSettings
+    from pocketpaw.uploads.file_store import JSONLFileStore
+    from pocketpaw.uploads.local import LocalStorageAdapter
+    from pocketpaw.uploads.service import UploadService
 
     test_cfg = UploadSettings(local_root=root)
     test_adapter = LocalStorageAdapter(root=root)
@@ -95,11 +93,16 @@ def test_docx_gets_attachment_disposition(client: TestClient):
     docx = b"PK\x03\x04" + b"rest"
     r = client.post(
         "/api/v1/uploads",
-        files=[("files", (
-            "doc.docx",
-            docx,
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        ))],
+        files=[
+            (
+                "files",
+                (
+                    "doc.docx",
+                    docx,
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                ),
+            )
+        ],
     )
     fid = r.json()["uploaded"][0]["id"]
     r2 = client.get(f"/api/v1/uploads/{fid}")

--- a/tests/uploads/test_router.py
+++ b/tests/uploads/test_router.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"body"
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch):
+    """Build an app with the uploads router pointed at a tmp dir."""
+    # Patch module-level globals BEFORE importing the router
+    import pocketpaw.uploads.config as cfg
+    import pocketpaw.api.v1.uploads as uploads_module
+
+    root = tmp_path / "u"
+    root.mkdir()
+
+    # Rebuild module-level service against tmp dirs
+    from pocketpaw.uploads.local import LocalStorageAdapter
+    from pocketpaw.uploads.file_store import JSONLFileStore
+    from pocketpaw.uploads.service import UploadService
+    from pocketpaw.uploads.config import UploadSettings
+
+    test_cfg = UploadSettings(local_root=root)
+    test_adapter = LocalStorageAdapter(root=root)
+    test_meta = JSONLFileStore(path=root / "_idx.jsonl")
+    test_svc = UploadService(adapter=test_adapter, meta=test_meta, cfg=test_cfg)
+
+    monkeypatch.setattr(uploads_module, "_SVC", test_svc)
+
+    app = FastAPI()
+    app.include_router(uploads_module.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+def test_upload_single_roundtrip(client: TestClient):
+    r = client.post(
+        "/api/v1/uploads",
+        files=[("files", ("cat.png", PNG, "image/png"))],
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert len(data["uploaded"]) == 1
+    assert data["uploaded"][0]["filename"] == "cat.png"
+    assert data["uploaded"][0]["mime"] == "image/png"
+    fid = data["uploaded"][0]["id"]
+
+    r2 = client.get(f"/api/v1/uploads/{fid}")
+    assert r2.status_code == 200
+    assert r2.content == PNG
+    assert r2.headers["content-type"].startswith("image/png")
+    assert "inline" in r2.headers["content-disposition"]
+
+
+def test_bulk_upload_partial_success(client: TestClient):
+    r = client.post(
+        "/api/v1/uploads",
+        files=[
+            ("files", ("good.png", PNG, "image/png")),
+            ("files", ("bad.svg", b"<svg/>", "image/svg+xml")),
+        ],
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["uploaded"]) == 1
+    assert len(data["failed"]) == 1
+    assert data["failed"][0]["code"] == "unsupported_mime"
+
+
+def test_delete_then_get_not_found(client: TestClient):
+    r = client.post(
+        "/api/v1/uploads",
+        files=[("files", ("cat.png", PNG, "image/png"))],
+    )
+    fid = r.json()["uploaded"][0]["id"]
+
+    r2 = client.delete(f"/api/v1/uploads/{fid}")
+    assert r2.status_code == 204
+
+    r3 = client.get(f"/api/v1/uploads/{fid}")
+    assert r3.status_code == 404
+
+
+def test_get_missing_id_is_404(client: TestClient):
+    r = client.get("/api/v1/uploads/nope")
+    assert r.status_code == 404
+
+
+def test_docx_gets_attachment_disposition(client: TestClient):
+    docx = b"PK\x03\x04" + b"rest"
+    r = client.post(
+        "/api/v1/uploads",
+        files=[("files", (
+            "doc.docx",
+            docx,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ))],
+    )
+    fid = r.json()["uploaded"][0]["id"]
+    r2 = client.get(f"/api/v1/uploads/{fid}")
+    assert r2.status_code == 200
+    assert "attachment" in r2.headers["content-disposition"]

--- a/tests/uploads/test_service.py
+++ b/tests/uploads/test_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
@@ -18,8 +17,8 @@ from pocketpaw.uploads.errors import (
 from pocketpaw.uploads.file_store import JSONLFileStore
 from pocketpaw.uploads.service import UploadService
 
-
 # --- Fake adapter --------------------------------------------------------
+
 
 class _FakeAdapter(StorageAdapter):
     def __init__(self) -> None:
@@ -67,6 +66,7 @@ def service(tmp_path: Path):
 
 
 # --- Tests ---------------------------------------------------------------
+
 
 class TestUploadServiceSingle:
     async def test_happy_path_returns_record(self, service):

--- a/tests/uploads/test_service.py
+++ b/tests/uploads/test_service.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import io
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from fastapi import UploadFile
+
+from pocketpaw.uploads.adapter import StorageAdapter, StoredObject
+from pocketpaw.uploads.config import UploadSettings
+from pocketpaw.uploads.errors import (
+    EmptyFile,
+    NotFound,
+    TooLarge,
+    UnsupportedMime,
+)
+from pocketpaw.uploads.file_store import JSONLFileStore
+from pocketpaw.uploads.service import UploadService
+
+
+# --- Fake adapter --------------------------------------------------------
+
+class _FakeAdapter(StorageAdapter):
+    def __init__(self) -> None:
+        self.blobs: dict[str, bytes] = {}
+
+    async def put(self, key, stream, mime):
+        data = b""
+        async for chunk in stream:
+            data += chunk
+        self.blobs[key] = data
+        return StoredObject(key=key, size=len(data), mime=mime)
+
+    async def open(self, key):
+        if key not in self.blobs:
+            raise NotFound()
+        yield self.blobs[key]
+
+    async def delete(self, key):
+        self.blobs.pop(key, None)
+
+    async def exists(self, key):
+        return key in self.blobs
+
+
+# --- Helpers -------------------------------------------------------------
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n" + b"rest"
+JPEG_MAGIC = b"\xff\xd8\xff\xe0" + b"rest"
+
+
+def _upload(content: bytes, filename: str, content_type: str) -> UploadFile:
+    return UploadFile(
+        file=io.BytesIO(content),
+        filename=filename,
+        headers={"content-type": content_type},  # type: ignore[arg-type]
+    )
+
+
+@pytest.fixture()
+def service(tmp_path: Path):
+    adapter = _FakeAdapter()
+    meta = JSONLFileStore(path=tmp_path / "idx.jsonl")
+    cfg = UploadSettings(local_root=tmp_path)
+    return UploadService(adapter=adapter, meta=meta, cfg=cfg), adapter, meta
+
+
+# --- Tests ---------------------------------------------------------------
+
+class TestUploadServiceSingle:
+    async def test_happy_path_returns_record(self, service):
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "cat.png", "image/png")
+        rec = await svc.upload(file, owner_id="u1", chat_id="c1")
+        assert rec.filename == "cat.png"
+        assert rec.mime == "image/png"
+        assert rec.size == len(PNG_MAGIC)
+        assert rec.owner_id == "u1"
+        assert rec.chat_id == "c1"
+        assert rec.id
+
+    async def test_rejects_oversize(self, service):
+        svc, _, _ = service
+        svc._cfg = UploadSettings(max_file_bytes=10, local_root=svc._cfg.local_root)
+        file = _upload(b"x" * 100, "big.bin", "application/octet-stream")
+        with pytest.raises(TooLarge):
+            await svc.upload(file, owner_id="u1", chat_id=None)
+
+    async def test_rejects_disallowed_mime(self, service):
+        svc, _, _ = service
+        file = _upload(b"<svg/>", "x.svg", "image/svg+xml")
+        with pytest.raises(UnsupportedMime):
+            await svc.upload(file, owner_id="u1", chat_id=None)
+
+    async def test_rejects_empty_file(self, service):
+        svc, _, _ = service
+        file = _upload(b"", "empty.txt", "text/plain")
+        with pytest.raises(EmptyFile):
+            await svc.upload(file, owner_id="u1", chat_id=None)
+
+    async def test_magic_byte_sniff_overrides_content_type(self, service):
+        # Client claims image/jpeg but bytes are PNG; saved mime should be image/png.
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "x.jpg", "image/jpeg")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        assert rec.mime == "image/png"
+
+    async def test_filename_with_path_separators_sanitized(self, service):
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "../evil.png", "image/png")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        assert rec.filename == "evil.png"
+
+
+class TestUploadServiceBulk:
+    async def test_all_succeed(self, service):
+        svc, _, _ = service
+        files = [
+            _upload(PNG_MAGIC, "a.png", "image/png"),
+            _upload(JPEG_MAGIC, "b.jpg", "image/jpeg"),
+            _upload(b"hi", "c.txt", "text/plain"),
+        ]
+        result = await svc.upload_many(files, owner_id="u1", chat_id=None)
+        assert len(result.uploaded) == 3
+        assert len(result.failed) == 0
+
+    async def test_partial_failure(self, service):
+        svc, _, _ = service
+        svc._cfg = UploadSettings(max_file_bytes=100, local_root=svc._cfg.local_root)
+        files = [
+            _upload(PNG_MAGIC, "good.png", "image/png"),
+            _upload(b"x" * 500, "big.bin", "application/octet-stream"),
+            _upload(b"<svg/>", "bad.svg", "image/svg+xml"),
+        ]
+        result = await svc.upload_many(files, owner_id="u1", chat_id=None)
+        assert len(result.uploaded) == 1
+        assert result.uploaded[0].filename == "good.png"
+        assert len(result.failed) == 2
+        codes = {f.code for f in result.failed}
+        assert codes == {"too_large", "unsupported_mime"}
+
+    async def test_empty_batch_raises(self, service):
+        svc, _, _ = service
+        with pytest.raises(ValueError, match="empty"):
+            await svc.upload_many([], owner_id="u1", chat_id=None)
+
+    async def test_batch_over_cap_raises(self, service):
+        svc, _, _ = service
+        svc._cfg = UploadSettings(max_files_per_batch=2, local_root=svc._cfg.local_root)
+        files = [_upload(PNG_MAGIC, f"{i}.png", "image/png") for i in range(3)]
+        with pytest.raises(ValueError, match="too many"):
+            await svc.upload_many(files, owner_id="u1", chat_id=None)
+
+
+class TestStreamAndDelete:
+    async def test_stream_happy_path(self, service):
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "cat.png", "image/png")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        got_rec, it = await svc.stream(rec.id, requester_id="u1")
+        chunks = [c async for c in it]
+        assert b"".join(chunks) == PNG_MAGIC
+        assert got_rec.id == rec.id
+
+    async def test_stream_wrong_owner_returns_not_found(self, service):
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "cat.png", "image/png")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        with pytest.raises(NotFound):
+            await svc.stream(rec.id, requester_id="someone-else")
+
+    async def test_stream_missing_raises_not_found(self, service):
+        svc, _, _ = service
+        with pytest.raises(NotFound):
+            await svc.stream("nope", requester_id="u1")
+
+    async def test_delete_owner_succeeds_idempotent(self, service):
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "cat.png", "image/png")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        await svc.delete(rec.id, requester_id="u1")
+        with pytest.raises(NotFound):
+            await svc.stream(rec.id, requester_id="u1")
+        with pytest.raises(NotFound):
+            await svc.delete(rec.id, requester_id="u1")
+
+    async def test_delete_non_owner_raises_not_found(self, service):
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "cat.png", "image/png")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        with pytest.raises(NotFound):
+            await svc.delete(rec.id, requester_id="someone-else")

--- a/uv.lock
+++ b/uv.lock
@@ -4285,6 +4285,7 @@ name = "pocketpaw"
 version = "0.4.16"
 source = { editable = "." }
 dependencies = [
+    { name = "aiofiles" },
     { name = "anthropic" },
     { name = "apscheduler" },
     { name = "claude-agent-sdk" },
@@ -4569,10 +4570,12 @@ dev = [
     { name = "ruff" },
     { name = "sarvamai" },
     { name = "slack-bolt" },
+    { name = "types-aiofiles" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles", specifier = ">=23.2.0" },
     { name = "aiomysql", marker = "extra == 'databases'", specifier = ">=0.2.0" },
     { name = "aiomysql", marker = "extra == 'mysql'", specifier = ">=0.2.0" },
     { name = "aiosqlite", marker = "extra == 'databases'", specifier = ">=0.20.0" },
@@ -4775,6 +4778,7 @@ dev = [
     { name = "ruff", specifier = ">=0.4.0" },
     { name = "sarvamai", specifier = ">=0.1.25" },
     { name = "slack-bolt", specifier = ">=1.20.0" },
+    { name = "types-aiofiles", specifier = ">=25.1.0.20260409" },
 ]
 
 [[package]]
@@ -6658,6 +6662,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-aiofiles"
+version = "25.1.0.20260409"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/66/9e62a2692792bc96c0f423f478149f4a7b84720704c546c8960b0a047c89/types_aiofiles-25.1.0.20260409.tar.gz", hash = "sha256:49e67d72bdcf9fe406f5815758a78dc34a1249bb5aa2adba78a80aec0a775435", size = 14812, upload-time = "2026-04-09T04:22:35.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/d0/28236f869ba4dfb223ecdbc267eb2bdb634b81a561dd992230a4f9ec48fa/types_aiofiles-25.1.0.20260409-py3-none-any.whl", hash = "sha256:923fedb532c772cc0f62e0ce4282725afa82ca5b41cabd9857f06b55e5eee8de", size = 14372, upload-time = "2026-04-09T04:22:34.328Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Uploaded images vanished from the DM bubble on browser refresh. Root cause — surfaced by @prakash — is that the runtime ""pocketpaw"" agent isn't a registered Agent doc. That leaves DMs without a stable identity: each reload spins up a new session_id, messages get orphaned, and (even if they didn't) the persistence bridge never wrote attachments in the first place.

## What

1. **Seed pocketpaw as a proper Agent on workspace bootstrap.** ``seed_default_agent(workspace, owner)`` — idempotent, creates slug=""pocketpaw"" with a sensible default system prompt. Called from ``seed_workspace`` alongside the ""General"" group.
2. **Persist attachments on user messages.** ``save_user_message(chat_id, content, attachments=None)`` and ``_write_message`` accept an optional list of Attachment-shaped dicts and coerce to the ``Attachment`` document model before inserting.
3. **Call the persistence bridge from the SSE chat path.** ``api/v1/chat.py:_send_message`` builds Attachment payloads from the resolved uploads (URL kept as-is so the FE can ``<img src>`` directly on reload) and invokes ``save_user_message`` after publishing to the bus. EE import is guarded so pure-OSS deployments still work.
4. **Expose attachments in history.** ``SessionService.get_history`` now emits ``attachments`` in each message dict (group + pocket contexts), unblocking the FE's existing bubble rendering on refresh.
5. **``GET /sessions?agent_id=X``** — ``SessionService.list_by_agent`` helper + query-param filter so the FE can find the DM room for a specific agent (replaces the legacy ``__paw-runtime-dm__`` sentinel flow).

## Tests

``pytest tests/cloud/test_agent_seed_and_dm_persistence.py -q`` — 8 passing:
- Seed creates the right Agent, is idempotent, one per workspace
- ``save_user_message`` with attachments → they land on the Message doc
- ``save_user_message`` with no attachments → empty list (no breakage)
- History dict includes ``attachments``
- ``list_by_agent`` filters correctly and respects soft-delete

## Follow-up (separate PR)

Frontend: replace ``FALLBACK_ROOM_ID = '__paw-runtime-dm__'`` with the seeded pocketpaw agent's id; resolve DM room via ``GET /sessions?agent_id=X``; load history through the sessions API so refresh renders thumbnails from the persisted ``attachments`` field.