### PR TITLE
feat(uploads): S3 adapter + signed grant URLs + memory dedup

### DIFF
--- a/docs/plans/2026-04-16-upload-adapter-design.md
+++ b/docs/plans/2026-04-16-upload-adapter-design.md
@@ -1,0 +1,332 @@
+# Upload Adapter Service — Design
+
+**Date:** 2026-04-16
+**Scope:** Chat file uploads, shared adapter across OSS and EE tiers, local-disk backend now, S3 later
+**Status:** Approved — ready for implementation plan
+
+## Goal
+
+Add a file upload service used by chat attachments. Ship a clean `StorageAdapter` abstraction so later work (S3, Azure Blob, etc.) swaps implementations without touching call sites. Support bulk uploads from day one to match the chat input's multi-attachment UX.
+
+## Scope decisions
+
+- **Use case**: chat attachments only. Existing ad-hoc upload surfaces (avatar, knowledge ingestion, soul imports) are out of scope — they can migrate to this adapter later.
+- **Tiering**: both OSS and EE share the core adapter/service; each tier has its own router + metadata store.
+  - OSS: single-user, local disk, JSONL metadata.
+  - EE: multi-tenant, local-now / S3-later, Mongo metadata.
+- **Access model**: auth-scoped opaque `file_id`. Clients never see the storage key. `GET /uploads/{id}` streams bytes after permission check.
+- **Lifecycle**: persistent. Soft-delete on `DELETE`. Cascade from chat/message deletion is the chat code's problem, not the adapter's.
+- **Out-of-scope for this PR**: AV/malware scanning, presigned URLs, cross-region replication, CDN, background cleanup of orphans, migration of existing avatar/KB uploads.
+
+## Key constants
+
+- `max_file_bytes = 25 MiB`
+- `max_files_per_batch = 50` (matches ChatInput attachment cap)
+- `allowed_mimes` — images (png/jpeg/webp/gif), pdf, plain text + markdown + csv, common source files, docx/xlsx. Configurable via env.
+- Disallowed by design: `.html`, `.svg`, `.xml`, `.js`, executables, archives.
+
+## Architecture
+
+```
+src/pocketpaw/uploads/                     ← OSS core (shared)
+├── __init__.py
+├── adapter.py         StorageAdapter protocol + StoredObject
+├── local.py           LocalStorageAdapter (aiofiles, atomic writes)
+├── errors.py          UploadError / TooLarge / UnsupportedMime / NotFound / AccessDenied
+├── keys.py            new_storage_key(kind, ext) → "{kind}/{yyyymm}/{uuid}{ext}"
+├── service.py         UploadService: validate → put → persist metadata
+├── config.py          size/mime limits, local root, batch cap
+└── file_store.py      OSS JSONL metadata store
+
+src/pocketpaw/api/v1/uploads.py           ← OSS router
+  POST   /uploads       multipart (files: list) → { uploaded, failed }
+  GET    /uploads/{id}  auth check → stream bytes
+  DELETE /uploads/{id}  owner check → adapter.delete + soft-delete metadata
+
+ee/cloud/uploads/
+├── __init__.py
+├── models.py          FileUpload Beanie Document (Mongo)
+├── service.py         EEUploadService — workspace scoping + RBAC
+└── router.py          EE /uploads router (workspace-scoped deps)
+```
+
+**Principles**
+
+- Adapter is dumb bytes-in/bytes-out keyed by string. No metadata, no auth, no mime logic.
+- Metadata lives in the service layer. Different stores per tier (JSONL in OSS, Mongo in EE).
+- Adapter wiring via config, not a plugin loader. `settings.upload_adapter = "local"` (default). S3 added as a branch in one factory when it lands.
+- Storage keys are opaque and never exposed via API. Clients see only `file_id`. That keeps local/S3 interchangeable.
+
+## Components
+
+### `adapter.py`
+
+```python
+@dataclass(frozen=True)
+class StoredObject:
+    key: str
+    size: int
+    mime: str
+
+class StorageAdapter(Protocol):
+    async def put(self, key: str, stream: AsyncIterator[bytes], mime: str) -> StoredObject: ...
+    async def open(self, key: str) -> AsyncIterator[bytes]: ...
+    async def delete(self, key: str) -> None: ...
+    async def exists(self, key: str) -> bool: ...
+```
+
+Streaming from day one so the S3 swap doesn't change the contract.
+
+### `local.py`
+
+`LocalStorageAdapter(root: Path)`. Writes to `root / key`. Creates parent dirs on `put`. Atomic: stream to `.tmp`, `os.replace` on completion. `delete` is idempotent. Asserts `key` resolves inside `root` after normalization (defense-in-depth).
+
+### `keys.py`
+
+```python
+def new_storage_key(kind: str = "chat", ext: str = "") -> str
+```
+
+Returns `"{kind}/{yyyymm}/{uuid4hex}{ext}"`. `ext` is sanitized: lowercase, alphanumeric, capped at 8 chars.
+
+### `errors.py`
+
+`UploadError` base + subclasses: `TooLarge`, `UnsupportedMime`, `EmptyFile`, `NotFound`, `AccessDenied`, `StorageFailure`. Router maps each to an HTTP status.
+
+### `config.py`
+
+```python
+@dataclass
+class UploadSettings:
+    max_file_bytes: int = 25 * 1024 * 1024
+    max_files_per_batch: int = 50
+    allowed_mimes: frozenset[str] = <sensible defaults>
+    local_root: Path = Path.home() / ".pocketpaw" / "uploads"
+```
+
+Populated from `POCKETPAW_UPLOAD_*` env + JSON config.
+
+### `service.py`
+
+```python
+@dataclass
+class FileRecord:
+    id: str; filename: str; mime: str; size: int
+    url: str; created: datetime
+    owner_id: str; chat_id: str | None; storage_key: str
+
+@dataclass
+class FailedUpload:
+    filename: str
+    reason: str                              # human-readable
+    code: Literal["too_large", "unsupported_mime", "empty", "storage_error"]
+
+@dataclass
+class BulkUploadResult:
+    uploaded: list[FileRecord]
+    failed: list[FailedUpload]
+
+class UploadService:
+    def __init__(self, adapter: StorageAdapter, meta: MetadataStore, cfg: UploadSettings)
+    async def upload(self, file: UploadFile, owner_id: str, chat_id: str | None) -> FileRecord
+    async def upload_many(
+        self, files: list[UploadFile], owner_id: str, chat_id: str | None,
+    ) -> BulkUploadResult
+    async def stream(self, file_id: str, requester_id: str) -> tuple[FileRecord, AsyncIterator[bytes]]
+    async def delete(self, file_id: str, requester_id: str) -> None
+```
+
+`upload_many` iterates files; per-file errors accumulate into `failed[]` — they do not abort the batch. `upload` is thin sugar over `upload_many`.
+
+### OSS `MetadataStore` (`file_store.py`)
+
+JSONL at `~/.pocketpaw/uploads/_index.jsonl`. Append on create, append tombstone on delete. Load-all-on-startup into in-memory dict. Corrupt lines are skipped with a warning.
+
+### EE `FileUpload` Beanie Document (`ee/cloud/uploads/models.py`)
+
+```python
+class FileUpload(TimestampedDocument):
+    file_id: Indexed(str, unique=True)
+    storage_key: str
+    filename: str
+    mime: str
+    size: int
+    workspace: Indexed(str)
+    owner: str
+    chat_id: Indexed(str) | None = None
+    deleted_at: datetime | None = None
+
+    class Settings:
+        name = "file_uploads"
+        indexes = [
+            [("workspace", 1), ("chat_id", 1), ("createdAt", -1)],
+            [("workspace", 1), ("owner", 1), ("createdAt", -1)],
+        ]
+```
+
+### EE `EEUploadService`
+
+Extends `UploadService`. Injects `workspace_id` and enforces tenant isolation on every read/delete. Cross-workspace access returns `NotFound` (not `AccessDenied`) to avoid leaking existence.
+
+### Routers
+
+`POST /uploads` (multipart form, `files: list[UploadFile]`, optional `chat_id`) — always returns 200 with `{uploaded, failed}`. 400 only for malformed requests (empty batch, > `max_files_per_batch`).
+
+`GET /uploads/{id}` — `StreamingResponse` with `Content-Disposition: inline` for inline-safe mimes, `attachment` for everything else.
+
+`DELETE /uploads/{id}` — owner-only (OSS); owner or workspace admin (EE). Idempotent.
+
+## Data flow
+
+**Upload single file**
+```
+client multipart
+  → router: auth → UploadFile + chat_id (form)
+  → service.upload(file, owner_id, chat_id)  # wraps upload_many([file])
+      1. size check (mid-stream counter; reject > cap)
+      2. mime check (magic-byte sniff on first 512 bytes; trust bytes over header)
+      3. ext = mime→extension map
+      4. key = new_storage_key("chat", ext)
+      5. adapter.put(key, stream, mime) → StoredObject
+      6. file_id = uuid4().hex
+      7. meta.save(FileRecord(...))
+  → { uploaded: [record], failed: [] }
+```
+
+**Bulk upload**
+
+Same endpoint. For each file, independent validation + adapter call. Per-file failures land in `failed[]`; successful files still persist. No two-phase commit — partial success is explicit in the response and the chat UI renders accordingly.
+
+**Download**
+```
+router: auth → requester_id
+  → service.stream(file_id, requester_id)
+      1. record = meta.get(file_id) or raise NotFound
+      2. access check (OSS: owner match; EE: workspace match + (chat-member OR owner))
+      3. return (record, adapter.open(record.storage_key))
+  → StreamingResponse(iterator, mime=record.mime, headers={"Content-Disposition": ...})
+```
+
+**Delete**
+```
+router: auth → requester_id
+  → service.delete(file_id, requester_id)
+      1. record = meta.get(file_id) or raise NotFound
+      2. access check (owner, or workspace admin in EE)
+      3. adapter.delete(record.storage_key)  # idempotent
+      4. meta.soft_delete(file_id)  # sets deleted_at; record retained for audit
+```
+
+**Adapter invariants**
+
+- `storage_key` is opaque; clients never see it. `file_id` is the stable external handle.
+- Adapter has no auth knowledge. Permission is enforced in the service.
+- `put` must be atomic from the caller's perspective. Partial `.tmp` files on failure are adapter-local cleanup.
+
+## Error handling
+
+**Validation (4xx)**
+- Size > cap → `TooLarge` (413 on single-file; `failed[]` entry with `code: "too_large"` in bulk)
+- Disallowed mime → `UnsupportedMime` (415 / `code: "unsupported_mime"`)
+- Empty file → `EmptyFile` (400 / `code: "empty"`)
+- Filename with path separators → sanitized to basename; never used in storage key
+- Empty batch or batch > `max_files_per_batch` → 400 (whole request rejected before any file is processed)
+
+**Access (4xx)**
+- Unauthenticated `GET` → 401
+- Wrong workspace (EE) → 404 (not 403; don't leak existence)
+- Not a chat member (EE) → 404
+- Deleted record → 404 (not 410)
+
+**Adapter (5xx)**
+- Disk-full / IOError on `put` → `StorageFailure` (507 single / `code: "storage_error"` bulk). Metadata NOT saved — service is transactional at the adapter level.
+- Orphaned metadata (key missing at stream time) → 500 + warning log. Record kept for cleanup.
+- Delete of missing key → idempotent; metadata still soft-deleted.
+
+**Security**
+- Trust bytes, not client-declared `Content-Type`. Magic-byte sniff decides the canonical mime.
+- `Content-Disposition: inline` only for images, pdf, plain text. Everything else gets `attachment`.
+- Explicitly disallowed: `.html`, `.svg`, `.js`, `.xml`. No in-origin HTML/SVG rendering from user uploads.
+- Path traversal: keys are generated server-side; adapter double-checks `root` containment after resolving the key.
+- Size-limit spoof: `Content-Length` is never trusted; bytes are counted as they stream into the adapter.
+
+**Races**
+- Concurrent uploads of the same filename: each gets unique `file_id` + random `storage_key`. No collision possible.
+- Delete during in-flight download: stream holds an OS file handle and continues. On Windows, `os.remove` on an open handle raises; wrap in try/except and defer to cleanup.
+- Crash mid-upload: `.tmp` files orphaned; cleanup job (out of scope) handles eventually.
+
+**Metadata store**
+- OSS JSONL corruption: skip bad line, warn, continue.
+- JSONL/Mongo write failure after a successful adapter `put`: record the adapter blob as orphaned; raise 500.
+
+## Testing
+
+**Unit — adapter** (`tests/uploads/test_local_adapter.py`)
+- `put` writes correct bytes, returns `StoredObject` with matching size
+- `put` creates missing parent dirs
+- `put` atomic: mid-stream failure leaves no file at `key`, only `.tmp` (or nothing) — no partial read possible
+- `open` streams; raises `NotFound` on missing key
+- `delete` idempotent; path-traversal key → `AccessDenied`
+- `exists` returns correct boolean
+
+**Unit — keys** (`tests/uploads/test_keys.py`)
+- Shape `{kind}/{yyyymm}/{hex32}{ext}`
+- Extension sanitization: strips non-alphanumeric, lowercases, 8-char cap
+- 1000 calls → 1000 unique keys
+
+**Unit — service** (`tests/uploads/test_service.py`) against fake adapter + fake meta
+- Happy path single and bulk
+- Bulk partial-success: 1 good + 1 oversize + 1 bad-mime → `uploaded=1, failed=2` with distinct `code`s
+- Empty batch → 400
+- Batch > `max_files_per_batch` → 400 (reject before any processing)
+- Magic-byte sniff overrides misdeclared `Content-Type`
+- Empty file → `EmptyFile`
+- `stream` with wrong owner → `NotFound` (not `AccessDenied`)
+- `delete` idempotent
+- Adapter `put` failure → meta NOT saved (transactional)
+
+**Unit — OSS metadata store** (`tests/uploads/test_file_store.py`)
+- Save → get roundtrip
+- Soft-delete → `get` returns `None`
+- Corrupt JSONL line skipped, valid lines loaded
+- Cold start reload matches prior state
+
+**Unit — EE Mongo store** (`tests/cloud/uploads/test_mongo_store.py`) against mongomock-motor
+- Workspace isolation (wrong workspace → `None`)
+- Chat-scoped listing
+- Index shape
+
+**Integration — routers** (`tests/uploads/test_router.py`, `tests/cloud/uploads/test_router.py`)
+- `POST /uploads` multipart round-trip: upload → download same bytes
+- Bulk: 3 files, one each of (good, too-large, bad-mime) → 200 with mixed response
+- `GET` unauthenticated → 401; cross-workspace (EE) → 404
+- `DELETE` non-owner → 404
+- `Content-Disposition` `inline` for images; `attachment` for docx
+
+**Contract test** — one parametrized suite any `StorageAdapter` must pass. Future `S3StorageAdapter` reuses the same tests with its own fixture.
+
+**Out of scope**
+- Load/performance tests (no SLA yet)
+- Malware scanning (hook point documented only)
+- Concurrency stress (rely on uvicorn defaults)
+
+**Manual verification before merge**
+- [ ] Upload 24 MiB file succeeds; 26 MiB fails with 413 (or `too_large` in bulk)
+- [ ] Bulk upload 3 files (one oversize) → 200 with 2 `uploaded`, 1 `failed`
+- [ ] End-to-end from ChatInput once frontend is wired (follow-up PR)
+- [ ] `~/.pocketpaw/uploads/chat/{yyyymm}/` contains the blob
+- [ ] Backend restart preserves uploads + metadata (OSS JSONL reload)
+- [ ] EE: upload under workspace A → user in workspace B gets 404
+
+## Dependencies
+
+- Add: `aiofiles` (atomic async disk I/O)
+- Add: `python-magic` OR manual magic-byte sniffing (prefer manual for no system-lib dep)
+- Reuse: FastAPI `UploadFile`, Beanie (EE only)
+- No new deps for S3 yet — added when S3 adapter lands
+
+## Open items for implementation plan
+
+- Exact mime allowlist list (compile default from the chat input accepts)
+- Whether OSS serves files via FastAPI static mount OR always through `/uploads/{id}` — default to always-through-router for consistency with EE
+- Where to bolt the `on_put` hook for future AV scanning (list of async callbacks on `LocalStorageAdapter`? Middleware on service? Defer to implementation)

--- a/docs/plans/2026-04-16-upload-adapter.md
+++ b/docs/plans/2026-04-16-upload-adapter.md
@@ -1,0 +1,2255 @@
+# Upload Adapter Service Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a file upload service with a pluggable `StorageAdapter` abstraction, local-disk backend, and both OSS + EE routers for chat attachments. Support bulk uploads (up to 50 files per request) from day one.
+
+**Architecture:** Small core protocol + local impl in `src/pocketpaw/uploads/`. The `UploadService` validates (size, mime, magic-byte sniff), generates opaque storage keys, writes via the adapter, persists metadata in a tier-specific store (JSONL for OSS, Mongo for EE). Routers in `src/pocketpaw/api/v1/uploads.py` (OSS) and `ee/cloud/uploads/router.py` (EE, workspace-scoped).
+
+**Tech Stack:** Python 3.11+, FastAPI, Pydantic, Beanie (EE), `aiofiles` (new dep), pytest + pytest-asyncio, mongomock-motor (EE tests).
+
+---
+
+## Design reference
+
+See `docs/plans/2026-04-16-upload-adapter-design.md` for the full design, scope decisions, access model, and rationale.
+
+## File inventory
+
+**Create (OSS core):**
+- `src/pocketpaw/uploads/__init__.py`
+- `src/pocketpaw/uploads/adapter.py`
+- `src/pocketpaw/uploads/local.py`
+- `src/pocketpaw/uploads/keys.py`
+- `src/pocketpaw/uploads/errors.py`
+- `src/pocketpaw/uploads/config.py`
+- `src/pocketpaw/uploads/file_store.py`
+- `src/pocketpaw/uploads/service.py`
+- `src/pocketpaw/api/v1/uploads.py`
+
+**Create (EE):**
+- `ee/cloud/uploads/__init__.py`
+- `ee/cloud/uploads/models.py`
+- `ee/cloud/uploads/service.py`
+- `ee/cloud/uploads/router.py`
+
+**Create (tests):**
+- `tests/uploads/__init__.py`
+- `tests/uploads/conftest.py`
+- `tests/uploads/test_keys.py`
+- `tests/uploads/test_errors.py`
+- `tests/uploads/test_local_adapter.py`
+- `tests/uploads/test_file_store.py`
+- `tests/uploads/test_service.py`
+- `tests/uploads/test_router.py`
+- `tests/cloud/uploads/__init__.py`
+- `tests/cloud/uploads/test_mongo_store.py`
+- `tests/cloud/uploads/test_service.py`
+- `tests/cloud/uploads/test_router.py`
+
+**Modify:**
+- `pyproject.toml` — add `aiofiles>=23.2` to main deps
+- `src/pocketpaw/api/v1/__init__.py` — register uploads router
+- `ee/cloud/models/__init__.py` — append `FileUpload` to `ALL_DOCUMENTS`
+- `ee/cloud/__init__.py` or wherever EE routers register — mount EE uploads router
+
+## Command reference (run from `D:/paw/backend`)
+
+| Purpose | Command |
+|---|---|
+| Install deps | `uv sync --dev` |
+| Add aiofiles | `uv add aiofiles` |
+| Run a single test file | `uv run pytest tests/uploads/test_keys.py -v` |
+| Run all upload tests | `uv run pytest tests/uploads/ tests/cloud/uploads/ -v` |
+| Run full fast suite | `uv run pytest --ignore=tests/e2e` |
+| Lint + format | `uv run ruff check . && uv run ruff format .` |
+| Type check | `uv run mypy .` |
+
+---
+
+## Task 1: Add `aiofiles` dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+
+**Step 1: Install**
+
+Run: `uv add aiofiles`
+Expected: `aiofiles` added to `[project].dependencies`, `uv.lock` updated.
+
+**Step 2: Verify import**
+
+Run: `uv run python -c "import aiofiles; print(aiofiles.__version__)"`
+Expected: prints a version (>= 23.2).
+
+**Step 3: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "chore: add aiofiles for async file I/O in upload adapter"
+```
+
+---
+
+## Task 2: `uploads/errors.py` — error hierarchy
+
+**Files:**
+- Create: `src/pocketpaw/uploads/__init__.py` (empty)
+- Create: `src/pocketpaw/uploads/errors.py`
+- Create: `tests/uploads/__init__.py` (empty)
+- Create: `tests/uploads/test_errors.py`
+
+**Step 1: Write failing tests**
+
+`tests/uploads/test_errors.py`:
+
+```python
+from pocketpaw.uploads.errors import (
+    AccessDenied,
+    EmptyFile,
+    NotFound,
+    StorageFailure,
+    TooLarge,
+    UnsupportedMime,
+    UploadError,
+)
+
+
+def test_all_errors_inherit_upload_error():
+    for cls in (TooLarge, UnsupportedMime, EmptyFile, NotFound, AccessDenied, StorageFailure):
+        assert issubclass(cls, UploadError)
+
+
+def test_errors_carry_code_attribute():
+    assert TooLarge("25mb").code == "too_large"
+    assert UnsupportedMime("image/tiff").code == "unsupported_mime"
+    assert EmptyFile().code == "empty"
+    assert NotFound().code == "not_found"
+    assert AccessDenied().code == "access_denied"
+    assert StorageFailure("disk full").code == "storage_error"
+
+
+def test_upload_error_preserves_message():
+    err = TooLarge("file is 40MB")
+    assert str(err) == "file is 40MB"
+```
+
+**Step 2: Run — expect fail**
+
+Run: `uv run pytest tests/uploads/test_errors.py -v`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+`src/pocketpaw/uploads/errors.py`:
+
+```python
+"""Error hierarchy for the upload adapter."""
+
+from __future__ import annotations
+
+
+class UploadError(Exception):
+    """Base class for all upload-related errors."""
+
+    code: str = "upload_error"
+
+
+class TooLarge(UploadError):
+    code = "too_large"
+
+
+class UnsupportedMime(UploadError):
+    code = "unsupported_mime"
+
+
+class EmptyFile(UploadError):
+    code = "empty"
+
+    def __init__(self, message: str = "file is empty") -> None:
+        super().__init__(message)
+
+
+class NotFound(UploadError):
+    code = "not_found"
+
+    def __init__(self, message: str = "not found") -> None:
+        super().__init__(message)
+
+
+class AccessDenied(UploadError):
+    code = "access_denied"
+
+    def __init__(self, message: str = "access denied") -> None:
+        super().__init__(message)
+
+
+class StorageFailure(UploadError):
+    code = "storage_error"
+```
+
+**Step 4: Run — expect pass**
+
+Run: `uv run pytest tests/uploads/test_errors.py -v`
+Expected: PASS, 3/3 tests green.
+
+**Step 5: Commit**
+
+```bash
+git add src/pocketpaw/uploads/__init__.py src/pocketpaw/uploads/errors.py tests/uploads/__init__.py tests/uploads/test_errors.py
+git commit -m "feat(uploads): add error hierarchy with per-class codes"
+```
+
+---
+
+## Task 3: `uploads/keys.py` — storage key generation
+
+**Files:**
+- Create: `src/pocketpaw/uploads/keys.py`
+- Create: `tests/uploads/test_keys.py`
+
+**Step 1: Write failing tests**
+
+`tests/uploads/test_keys.py`:
+
+```python
+import re
+
+from pocketpaw.uploads.keys import new_storage_key, sanitize_ext
+
+
+def test_new_storage_key_shape():
+    key = new_storage_key("chat", ".png")
+    assert re.match(r"^chat/\d{6}/[a-f0-9]{32}\.png$", key), key
+
+
+def test_default_kind_is_chat():
+    key = new_storage_key(ext=".pdf")
+    assert key.startswith("chat/")
+
+
+def test_no_ext_produces_key_without_extension():
+    key = new_storage_key("chat", "")
+    assert re.match(r"^chat/\d{6}/[a-f0-9]{32}$", key)
+
+
+def test_1000_keys_are_unique():
+    keys = {new_storage_key("chat", ".bin") for _ in range(1000)}
+    assert len(keys) == 1000
+
+
+def test_sanitize_ext_lowercases():
+    assert sanitize_ext(".PNG") == ".png"
+
+
+def test_sanitize_ext_strips_non_alnum():
+    assert sanitize_ext(".p!ng") == ".png"
+
+
+def test_sanitize_ext_caps_length():
+    assert sanitize_ext(".abcdefghijklmno") == ".abcdefgh"  # 8 chars max
+
+
+def test_sanitize_ext_empty_returns_empty():
+    assert sanitize_ext("") == ""
+    assert sanitize_ext(".") == ""
+
+
+def test_sanitize_ext_adds_leading_dot():
+    assert sanitize_ext("png") == ".png"
+```
+
+**Step 2: Run — expect fail**
+
+Run: `uv run pytest tests/uploads/test_keys.py -v`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+`src/pocketpaw/uploads/keys.py`:
+
+```python
+"""Storage-key generation for uploads.
+
+Keys are opaque to external callers and namespaced by "kind" + a yyyymm bucket.
+The UUID4 hex tail guarantees uniqueness.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import UTC, datetime
+
+_EXT_RE = re.compile(r"[^a-z0-9]")
+_MAX_EXT_LEN = 8
+
+
+def sanitize_ext(ext: str) -> str:
+    """Normalize a file extension to ``.{alnum,<=8}`` or empty."""
+    if not ext:
+        return ""
+    tail = ext.lstrip(".").lower()
+    tail = _EXT_RE.sub("", tail)[:_MAX_EXT_LEN]
+    return f".{tail}" if tail else ""
+
+
+def new_storage_key(kind: str = "chat", ext: str = "") -> str:
+    """Return a fresh unique storage key ``{kind}/{yyyymm}/{uuid32}{ext}``."""
+    yyyymm = datetime.now(UTC).strftime("%Y%m")
+    safe_ext = sanitize_ext(ext)
+    return f"{kind}/{yyyymm}/{uuid.uuid4().hex}{safe_ext}"
+```
+
+**Step 4: Run — expect pass**
+
+Run: `uv run pytest tests/uploads/test_keys.py -v`
+Expected: PASS, 9/9 tests green.
+
+**Step 5: Commit**
+
+```bash
+git add src/pocketpaw/uploads/keys.py tests/uploads/test_keys.py
+git commit -m "feat(uploads): storage key generator with safe extension sanitization"
+```
+
+---
+
+## Task 4: `uploads/config.py` — upload settings
+
+**Files:**
+- Create: `src/pocketpaw/uploads/config.py`
+
+No tests needed — this is config data. Exercised via `test_service.py`.
+
+**Step 1: Implement**
+
+`src/pocketpaw/uploads/config.py`:
+
+```python
+"""Upload configuration — size limits, mime allowlist, storage root."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Mimes safe to render inline (images, pdf, plain text). Everything else gets
+# Content-Disposition: attachment to avoid in-origin HTML/SVG tricks.
+INLINE_MIMES: frozenset[str] = frozenset({
+    "image/png", "image/jpeg", "image/gif", "image/webp",
+    "application/pdf",
+    "text/plain", "text/markdown", "text/csv",
+})
+
+DEFAULT_ALLOWED_MIMES: frozenset[str] = frozenset({
+    # Images
+    "image/png", "image/jpeg", "image/gif", "image/webp",
+    # Documents
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # .docx
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",         # .xlsx
+    # Text / code
+    "text/plain", "text/markdown", "text/csv",
+    "application/json",
+})
+
+
+@dataclass
+class UploadSettings:
+    """Static configuration for the upload pipeline."""
+
+    max_file_bytes: int = 25 * 1024 * 1024          # 25 MiB
+    max_files_per_batch: int = 50
+    allowed_mimes: frozenset[str] = field(default_factory=lambda: DEFAULT_ALLOWED_MIMES)
+    local_root: Path = field(default_factory=lambda: Path.home() / ".pocketpaw" / "uploads")
+
+
+_MIME_TO_EXT: dict[str, str] = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "application/pdf": ".pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+    "text/plain": ".txt",
+    "text/markdown": ".md",
+    "text/csv": ".csv",
+    "application/json": ".json",
+}
+
+
+def extension_for(mime: str) -> str:
+    """Map a canonical mime type to a file extension. Returns ``""`` if unknown."""
+    return _MIME_TO_EXT.get(mime, "")
+```
+
+**Step 2: Verify import**
+
+Run: `uv run python -c "from pocketpaw.uploads.config import UploadSettings, extension_for; print(extension_for('image/png'))"`
+Expected: prints `.png`.
+
+**Step 3: Commit**
+
+```bash
+git add src/pocketpaw/uploads/config.py
+git commit -m "feat(uploads): static config — size caps, mime allowlist, local root"
+```
+
+---
+
+## Task 5: `uploads/adapter.py` — `StorageAdapter` protocol
+
+**Files:**
+- Create: `src/pocketpaw/uploads/adapter.py`
+
+**Step 1: Implement**
+
+`src/pocketpaw/uploads/adapter.py`:
+
+```python
+"""StorageAdapter protocol — the swap point for local, S3, etc."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class StoredObject:
+    """Return value of ``StorageAdapter.put``."""
+
+    key: str
+    size: int
+    mime: str
+
+
+class StorageAdapter(Protocol):
+    """Abstract byte storage. Knows nothing about metadata, auth, or mime logic.
+
+    Implementations must be safe to call from asyncio contexts.
+    """
+
+    async def put(
+        self, key: str, stream: AsyncIterator[bytes], mime: str
+    ) -> StoredObject:
+        """Persist ``stream`` at ``key``. Returns the canonical ``StoredObject``."""
+
+    async def open(self, key: str) -> AsyncIterator[bytes]:  # pragma: no cover
+        """Yield the stored bytes in chunks. Raises ``NotFound`` if missing."""
+
+    async def delete(self, key: str) -> None:
+        """Remove ``key`` if present. Idempotent."""
+
+    async def exists(self, key: str) -> bool:
+        """Return whether ``key`` is currently stored."""
+```
+
+**Step 2: Verify import**
+
+Run: `uv run python -c "from pocketpaw.uploads.adapter import StorageAdapter, StoredObject; print(StoredObject(key='k', size=0, mime='t'))"`
+Expected: prints the `StoredObject(...)` repr.
+
+**Step 3: Commit**
+
+```bash
+git add src/pocketpaw/uploads/adapter.py
+git commit -m "feat(uploads): StorageAdapter protocol + StoredObject"
+```
+
+---
+
+## Task 6: `uploads/local.py` — `LocalStorageAdapter`
+
+**Files:**
+- Create: `src/pocketpaw/uploads/local.py`
+- Create: `tests/uploads/conftest.py`
+- Create: `tests/uploads/test_local_adapter.py`
+
+**Step 1: Write the conftest + failing tests**
+
+`tests/uploads/conftest.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def tmp_upload_root(tmp_path: Path) -> Path:
+    """Isolated root for each test."""
+    root = tmp_path / "uploads"
+    root.mkdir()
+    return root
+```
+
+`tests/uploads/test_local_adapter.py`:
+
+```python
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.uploads.errors import AccessDenied, NotFound, StorageFailure
+from pocketpaw.uploads.local import LocalStorageAdapter
+
+
+async def _astream(chunks: list[bytes]) -> AsyncIterator[bytes]:
+    for c in chunks:
+        yield c
+
+
+class TestLocalStorageAdapter:
+    async def test_put_writes_bytes_and_returns_size(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        obj = await adapter.put("chat/202604/abc.png", _astream([b"hello"]), "image/png")
+        assert obj.key == "chat/202604/abc.png"
+        assert obj.size == 5
+        assert obj.mime == "image/png"
+        assert (tmp_upload_root / "chat" / "202604" / "abc.png").read_bytes() == b"hello"
+
+    async def test_put_creates_parent_dirs(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        await adapter.put("a/b/c/d.bin", _astream([b"x"]), "application/octet-stream")
+        assert (tmp_upload_root / "a" / "b" / "c" / "d.bin").exists()
+
+    async def test_put_concatenates_chunks(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        obj = await adapter.put("k/file.bin", _astream([b"foo", b"bar", b"baz"]), "application/octet-stream")
+        assert obj.size == 9
+        assert (tmp_upload_root / "k/file.bin").read_bytes() == b"foobarbaz"
+
+    async def test_put_atomic_no_partial_on_stream_error(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+
+        async def bad_stream() -> AsyncIterator[bytes]:
+            yield b"part1"
+            raise RuntimeError("boom")
+
+        with pytest.raises(StorageFailure):
+            await adapter.put("k/file.bin", bad_stream(), "application/octet-stream")
+
+        # Final file must NOT exist
+        assert not (tmp_upload_root / "k" / "file.bin").exists()
+
+    async def test_open_streams_bytes(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        await adapter.put("k/file.bin", _astream([b"hello world"]), "application/octet-stream")
+        chunks: list[bytes] = [c async for c in adapter.open("k/file.bin")]
+        assert b"".join(chunks) == b"hello world"
+
+    async def test_open_missing_raises_not_found(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        with pytest.raises(NotFound):
+            _ = [c async for c in adapter.open("nope")]
+
+    async def test_delete_idempotent(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        await adapter.put("k/file.bin", _astream([b"x"]), "application/octet-stream")
+        await adapter.delete("k/file.bin")
+        await adapter.delete("k/file.bin")  # second call: no error
+        assert not (tmp_upload_root / "k" / "file.bin").exists()
+
+    async def test_exists_true_after_put(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        assert await adapter.exists("k/file.bin") is False
+        await adapter.put("k/file.bin", _astream([b"x"]), "application/octet-stream")
+        assert await adapter.exists("k/file.bin") is True
+
+    async def test_put_rejects_path_traversal_key(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        with pytest.raises(AccessDenied):
+            await adapter.put("../../evil.bin", _astream([b"x"]), "application/octet-stream")
+
+    async def test_open_rejects_path_traversal_key(self, tmp_upload_root: Path):
+        adapter = LocalStorageAdapter(root=tmp_upload_root)
+        with pytest.raises(AccessDenied):
+            _ = [c async for c in adapter.open("../outside.bin")]
+```
+
+**Step 2: Run — expect fail**
+
+Run: `uv run pytest tests/uploads/test_local_adapter.py -v`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+`src/pocketpaw/uploads/local.py`:
+
+```python
+"""Local-disk StorageAdapter backed by aiofiles."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import aiofiles
+import aiofiles.os
+
+from pocketpaw.uploads.adapter import StorageAdapter, StoredObject
+from pocketpaw.uploads.errors import AccessDenied, NotFound, StorageFailure
+
+_CHUNK_SIZE = 64 * 1024
+
+
+class LocalStorageAdapter(StorageAdapter):
+    """Store blobs under ``root``. Atomic writes via .tmp + rename.
+
+    Rejects keys that would escape ``root`` after normalization.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self._root = root.resolve()
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def _resolve(self, key: str) -> Path:
+        target = (self._root / key).resolve()
+        try:
+            target.relative_to(self._root)
+        except ValueError as exc:
+            raise AccessDenied(f"key escapes storage root: {key!r}") from exc
+        return target
+
+    async def put(
+        self, key: str, stream: AsyncIterator[bytes], mime: str
+    ) -> StoredObject:
+        final = self._resolve(key)
+        final.parent.mkdir(parents=True, exist_ok=True)
+        tmp = final.with_name(final.name + ".tmp")
+        size = 0
+        try:
+            async with aiofiles.open(tmp, "wb") as fh:
+                async for chunk in stream:
+                    await fh.write(chunk)
+                    size += len(chunk)
+            await aiofiles.os.replace(str(tmp), str(final))
+        except Exception as exc:
+            # Best-effort cleanup of the partial .tmp
+            try:
+                await aiofiles.os.remove(str(tmp))
+            except FileNotFoundError:
+                pass
+            raise StorageFailure(str(exc)) from exc
+        return StoredObject(key=key, size=size, mime=mime)
+
+    async def open(self, key: str) -> AsyncIterator[bytes]:
+        target = self._resolve(key)
+        if not target.exists():
+            raise NotFound(f"missing: {key}")
+        async with aiofiles.open(target, "rb") as fh:
+            while True:
+                chunk = await fh.read(_CHUNK_SIZE)
+                if not chunk:
+                    break
+                yield chunk
+
+    async def delete(self, key: str) -> None:
+        target = self._resolve(key)
+        try:
+            await aiofiles.os.remove(str(target))
+        except FileNotFoundError:
+            pass
+
+    async def exists(self, key: str) -> bool:
+        target = self._resolve(key)
+        return target.exists()
+```
+
+**Step 4: Run — expect pass**
+
+Run: `uv run pytest tests/uploads/test_local_adapter.py -v`
+Expected: PASS, 10/10 tests green.
+
+**Step 5: Commit**
+
+```bash
+git add src/pocketpaw/uploads/local.py tests/uploads/conftest.py tests/uploads/test_local_adapter.py
+git commit -m "feat(uploads): LocalStorageAdapter with atomic writes + path safety"
+```
+
+---
+
+## Task 7: `uploads/file_store.py` — OSS JSONL metadata store
+
+**Files:**
+- Create: `src/pocketpaw/uploads/file_store.py`
+- Create: `tests/uploads/test_file_store.py`
+
+**Step 1: Write failing tests**
+
+`tests/uploads/test_file_store.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+
+
+def _record(file_id: str = "f1", **overrides) -> FileRecord:
+    defaults = {
+        "id": file_id,
+        "storage_key": "chat/202604/abc.png",
+        "filename": "cat.png",
+        "mime": "image/png",
+        "size": 1234,
+        "owner_id": "user-1",
+        "chat_id": "chat-1",
+        "created": datetime(2026, 4, 16, 12, 0, tzinfo=UTC),
+    }
+    defaults.update(overrides)
+    return FileRecord(**defaults)
+
+
+class TestJSONLFileStore:
+    def test_save_then_get_roundtrip(self, tmp_path: Path):
+        store = JSONLFileStore(path=tmp_path / "idx.jsonl")
+        store.save(_record())
+        got = store.get("f1")
+        assert got is not None
+        assert got.filename == "cat.png"
+        assert got.size == 1234
+
+    def test_get_missing_returns_none(self, tmp_path: Path):
+        store = JSONLFileStore(path=tmp_path / "idx.jsonl")
+        assert store.get("nope") is None
+
+    def test_soft_delete_hides_from_get(self, tmp_path: Path):
+        store = JSONLFileStore(path=tmp_path / "idx.jsonl")
+        store.save(_record())
+        store.soft_delete("f1")
+        assert store.get("f1") is None
+
+    def test_cold_reload_preserves_state(self, tmp_path: Path):
+        path = tmp_path / "idx.jsonl"
+        s1 = JSONLFileStore(path=path)
+        s1.save(_record("a"))
+        s1.save(_record("b", filename="b.png"))
+        s1.soft_delete("a")
+
+        s2 = JSONLFileStore(path=path)  # reload
+        assert s2.get("a") is None
+        assert s2.get("b") is not None
+        assert s2.get("b").filename == "b.png"
+
+    def test_corrupt_line_is_skipped(self, tmp_path: Path):
+        path = tmp_path / "idx.jsonl"
+        path.write_text('{"op": "save", "record": {"id": "a", "storage_key": "k", "filename": "a", '
+                        '"mime": "text/plain", "size": 1, "owner_id": "u", "chat_id": null, '
+                        '"created": "2026-04-16T12:00:00+00:00"}}\n'
+                        'THIS IS NOT JSON\n'
+                        '{"op": "save", "record": {"id": "b", "storage_key": "k2", "filename": "b", '
+                        '"mime": "text/plain", "size": 1, "owner_id": "u", "chat_id": null, '
+                        '"created": "2026-04-16T12:00:00+00:00"}}\n',
+                        encoding="utf-8")
+        store = JSONLFileStore(path=path)
+        assert store.get("a") is not None
+        assert store.get("b") is not None
+```
+
+**Step 2: Run — expect fail**
+
+Run: `uv run pytest tests/uploads/test_file_store.py -v`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+`src/pocketpaw/uploads/file_store.py`:
+
+```python
+"""OSS metadata store — append-only JSONL keyed by file_id."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from threading import Lock
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FileRecord:
+    id: str
+    storage_key: str
+    filename: str
+    mime: str
+    size: int
+    owner_id: str
+    chat_id: str | None
+    created: datetime
+
+
+class JSONLFileStore:
+    """Append-only JSONL store with in-memory cache.
+
+    Each line is either:
+      - ``{"op": "save",   "record": {...FileRecord...}}``
+      - ``{"op": "delete", "id": "<file_id>"}``
+
+    Deleted records are hidden from ``get`` but the historical line stays in
+    the file for audit.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._records: dict[str, FileRecord] = {}
+        self._deleted: set[str] = set()
+        self._lock = Lock()
+        self._reload()
+
+    def _reload(self) -> None:
+        if not self._path.exists():
+            return
+        for line in self._path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("skipping corrupt upload-index line: %r", line[:120])
+                continue
+            op = row.get("op")
+            if op == "save":
+                rec = row.get("record") or {}
+                try:
+                    rec["created"] = datetime.fromisoformat(rec["created"])
+                    self._records[rec["id"]] = FileRecord(**rec)
+                except (KeyError, TypeError, ValueError):
+                    logger.warning("skipping malformed record line: %r", line[:120])
+            elif op == "delete":
+                fid = row.get("id")
+                if isinstance(fid, str):
+                    self._deleted.add(fid)
+
+    def _append(self, line: dict) -> None:
+        with self._lock:
+            with self._path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(line, default=_json_default) + "\n")
+
+    def save(self, record: FileRecord) -> None:
+        self._records[record.id] = record
+        self._deleted.discard(record.id)
+        self._append({"op": "save", "record": asdict(record)})
+
+    def get(self, file_id: str) -> FileRecord | None:
+        if file_id in self._deleted:
+            return None
+        return self._records.get(file_id)
+
+    def soft_delete(self, file_id: str) -> None:
+        self._deleted.add(file_id)
+        self._append({"op": "delete", "id": file_id, "at": datetime.now(UTC).isoformat()})
+
+
+def _json_default(value: object) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    raise TypeError(f"cannot serialize {type(value)}")
+```
+
+**Step 4: Run — expect pass**
+
+Run: `uv run pytest tests/uploads/test_file_store.py -v`
+Expected: PASS, 5/5 tests green.
+
+**Step 5: Commit**
+
+```bash
+git add src/pocketpaw/uploads/file_store.py tests/uploads/test_file_store.py
+git commit -m "feat(uploads): JSONL metadata store with soft-delete and corruption tolerance"
+```
+
+---
+
+## Task 8: `uploads/service.py` — validation + orchestration
+
+**Files:**
+- Create: `src/pocketpaw/uploads/service.py`
+- Create: `tests/uploads/test_service.py`
+
+**Step 1: Write failing tests**
+
+`tests/uploads/test_service.py`:
+
+```python
+from __future__ import annotations
+
+import io
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import UploadFile
+
+from pocketpaw.uploads.adapter import StorageAdapter, StoredObject
+from pocketpaw.uploads.config import UploadSettings
+from pocketpaw.uploads.errors import (
+    AccessDenied,
+    EmptyFile,
+    NotFound,
+    TooLarge,
+    UnsupportedMime,
+)
+from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+from pocketpaw.uploads.service import UploadService
+
+
+# --- Fake adapter --------------------------------------------------------
+
+class _FakeAdapter(StorageAdapter):
+    def __init__(self) -> None:
+        self.blobs: dict[str, bytes] = {}
+
+    async def put(self, key, stream, mime):
+        data = b""
+        async for chunk in stream:
+            data += chunk
+        self.blobs[key] = data
+        return StoredObject(key=key, size=len(data), mime=mime)
+
+    async def open(self, key):
+        if key not in self.blobs:
+            raise NotFound()
+        yield self.blobs[key]
+
+    async def delete(self, key):
+        self.blobs.pop(key, None)
+
+    async def exists(self, key):
+        return key in self.blobs
+
+
+# --- Helpers -------------------------------------------------------------
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n" + b"rest"
+JPEG_MAGIC = b"\xff\xd8\xff\xe0" + b"rest"
+
+def _upload(content: bytes, filename: str, content_type: str) -> UploadFile:
+    return UploadFile(
+        file=io.BytesIO(content),
+        filename=filename,
+        headers={"content-type": content_type},  # type: ignore[arg-type]
+    )
+
+
+@pytest.fixture()
+def service(tmp_path: Path):
+    adapter = _FakeAdapter()
+    meta = JSONLFileStore(path=tmp_path / "idx.jsonl")
+    cfg = UploadSettings(local_root=tmp_path)
+    return UploadService(adapter=adapter, meta=meta, cfg=cfg), adapter, meta
+
+
+# --- Tests ---------------------------------------------------------------
+
+class TestUploadServiceSingle:
+    async def test_happy_path_returns_record(self, service):
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "cat.png", "image/png")
+        rec = await svc.upload(file, owner_id="u1", chat_id="c1")
+        assert rec.filename == "cat.png"
+        assert rec.mime == "image/png"
+        assert rec.size == len(PNG_MAGIC)
+        assert rec.owner_id == "u1"
+        assert rec.chat_id == "c1"
+        assert rec.id
+
+    async def test_rejects_oversize(self, service):
+        svc, _, _ = service
+        svc._cfg = UploadSettings(max_file_bytes=10, local_root=svc._cfg.local_root)
+        file = _upload(b"x" * 100, "big.bin", "application/octet-stream")
+        with pytest.raises(TooLarge):
+            await svc.upload(file, owner_id="u1", chat_id=None)
+
+    async def test_rejects_disallowed_mime(self, service):
+        svc, _, _ = service
+        file = _upload(b"<svg/>", "x.svg", "image/svg+xml")
+        with pytest.raises(UnsupportedMime):
+            await svc.upload(file, owner_id="u1", chat_id=None)
+
+    async def test_rejects_empty_file(self, service):
+        svc, _, _ = service
+        file = _upload(b"", "empty.txt", "text/plain")
+        with pytest.raises(EmptyFile):
+            await svc.upload(file, owner_id="u1", chat_id=None)
+
+    async def test_magic_byte_sniff_overrides_content_type(self, service):
+        # Client claims image/jpeg but bytes are PNG; saved mime should be image/png.
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "x.jpg", "image/jpeg")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        assert rec.mime == "image/png"
+
+    async def test_filename_with_path_separators_sanitized(self, service):
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "../evil.png", "image/png")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        assert rec.filename == "evil.png"
+
+
+class TestUploadServiceBulk:
+    async def test_all_succeed(self, service):
+        svc, _, _ = service
+        files = [
+            _upload(PNG_MAGIC, "a.png", "image/png"),
+            _upload(JPEG_MAGIC, "b.jpg", "image/jpeg"),
+            _upload(b"hi", "c.txt", "text/plain"),
+        ]
+        result = await svc.upload_many(files, owner_id="u1", chat_id=None)
+        assert len(result.uploaded) == 3
+        assert len(result.failed) == 0
+
+    async def test_partial_failure(self, service):
+        svc, _, _ = service
+        svc._cfg = UploadSettings(max_file_bytes=100, local_root=svc._cfg.local_root)
+        files = [
+            _upload(PNG_MAGIC, "good.png", "image/png"),
+            _upload(b"x" * 500, "big.bin", "application/octet-stream"),
+            _upload(b"<svg/>", "bad.svg", "image/svg+xml"),
+        ]
+        result = await svc.upload_many(files, owner_id="u1", chat_id=None)
+        assert len(result.uploaded) == 1
+        assert result.uploaded[0].filename == "good.png"
+        assert len(result.failed) == 2
+        codes = {f.code for f in result.failed}
+        assert codes == {"too_large", "unsupported_mime"}
+
+    async def test_empty_batch_raises_too_large(self, service):
+        svc, _, _ = service
+        with pytest.raises(ValueError, match="empty"):
+            await svc.upload_many([], owner_id="u1", chat_id=None)
+
+    async def test_batch_over_cap_raises(self, service):
+        svc, _, _ = service
+        svc._cfg = UploadSettings(max_files_per_batch=2, local_root=svc._cfg.local_root)
+        files = [_upload(PNG_MAGIC, f"{i}.png", "image/png") for i in range(3)]
+        with pytest.raises(ValueError, match="too many"):
+            await svc.upload_many(files, owner_id="u1", chat_id=None)
+
+
+class TestStreamAndDelete:
+    async def test_stream_happy_path(self, service):
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "cat.png", "image/png")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        got_rec, it = await svc.stream(rec.id, requester_id="u1")
+        chunks = [c async for c in it]
+        assert b"".join(chunks) == PNG_MAGIC
+        assert got_rec.id == rec.id
+
+    async def test_stream_wrong_owner_returns_not_found(self, service):
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "cat.png", "image/png")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        with pytest.raises(NotFound):
+            await svc.stream(rec.id, requester_id="someone-else")
+
+    async def test_stream_missing_raises_not_found(self, service):
+        svc, _, _ = service
+        with pytest.raises(NotFound):
+            await svc.stream("nope", requester_id="u1")
+
+    async def test_delete_owner_succeeds_idempotent(self, service):
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "cat.png", "image/png")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        await svc.delete(rec.id, requester_id="u1")
+        with pytest.raises(NotFound):
+            await svc.stream(rec.id, requester_id="u1")
+        # Second delete: not found (already soft-deleted)
+        with pytest.raises(NotFound):
+            await svc.delete(rec.id, requester_id="u1")
+
+    async def test_delete_non_owner_raises_not_found(self, service):
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "cat.png", "image/png")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        with pytest.raises(NotFound):
+            await svc.delete(rec.id, requester_id="someone-else")
+```
+
+**Step 2: Run — expect fail**
+
+Run: `uv run pytest tests/uploads/test_service.py -v`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+`src/pocketpaw/uploads/service.py`:
+
+```python
+"""UploadService — validates, stores, and persists metadata."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+from fastapi import UploadFile
+
+from pocketpaw.uploads.adapter import StorageAdapter
+from pocketpaw.uploads.config import UploadSettings, extension_for
+from pocketpaw.uploads.errors import (
+    AccessDenied,
+    EmptyFile,
+    NotFound,
+    StorageFailure,
+    TooLarge,
+    UnsupportedMime,
+    UploadError,
+)
+from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
+from pocketpaw.uploads.keys import new_storage_key
+
+_SNIFF_BYTES = 512
+
+
+# --- Magic-byte sniff ----------------------------------------------------
+
+def _sniff_mime(head: bytes, fallback: str) -> str:
+    if head.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if head.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if head.startswith(b"GIF87a") or head.startswith(b"GIF89a"):
+        return "image/gif"
+    if head.startswith(b"RIFF") and head[8:12] == b"WEBP":
+        return "image/webp"
+    if head.startswith(b"%PDF-"):
+        return "application/pdf"
+    if head.startswith(b"PK\x03\x04"):
+        # ZIP container — docx/xlsx both use this. Keep fallback if it matches.
+        if fallback in (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ):
+            return fallback
+    return fallback
+
+
+# --- Public types --------------------------------------------------------
+
+FailCode = Literal["too_large", "unsupported_mime", "empty", "storage_error"]
+
+
+@dataclass
+class FailedUpload:
+    filename: str
+    reason: str
+    code: FailCode
+
+
+@dataclass
+class BulkUploadResult:
+    uploaded: list[FileRecord]
+    failed: list[FailedUpload]
+
+
+# --- Service -------------------------------------------------------------
+
+class UploadService:
+    def __init__(
+        self,
+        adapter: StorageAdapter,
+        meta: JSONLFileStore,
+        cfg: UploadSettings,
+    ) -> None:
+        self._adapter = adapter
+        self._meta = meta
+        self._cfg = cfg
+
+    async def upload(
+        self, file: UploadFile, owner_id: str, chat_id: str | None
+    ) -> FileRecord:
+        result = await self.upload_many([file], owner_id, chat_id)
+        if result.failed:
+            f = result.failed[0]
+            _raise(f.code, f.reason)
+        return result.uploaded[0]
+
+    async def upload_many(
+        self, files: list[UploadFile], owner_id: str, chat_id: str | None,
+    ) -> BulkUploadResult:
+        if not files:
+            raise ValueError("empty upload batch")
+        if len(files) > self._cfg.max_files_per_batch:
+            raise ValueError(
+                f"too many files: {len(files)} > {self._cfg.max_files_per_batch}"
+            )
+
+        uploaded: list[FileRecord] = []
+        failed: list[FailedUpload] = []
+
+        for file in files:
+            try:
+                rec = await self._upload_one(file, owner_id, chat_id)
+                uploaded.append(rec)
+            except TooLarge as e:
+                failed.append(FailedUpload(filename=_basename(file.filename), reason=str(e), code="too_large"))
+            except UnsupportedMime as e:
+                failed.append(FailedUpload(filename=_basename(file.filename), reason=str(e), code="unsupported_mime"))
+            except EmptyFile as e:
+                failed.append(FailedUpload(filename=_basename(file.filename), reason=str(e), code="empty"))
+            except StorageFailure as e:
+                failed.append(FailedUpload(filename=_basename(file.filename), reason=str(e), code="storage_error"))
+
+        return BulkUploadResult(uploaded=uploaded, failed=failed)
+
+    async def _upload_one(
+        self, file: UploadFile, owner_id: str, chat_id: str | None,
+    ) -> FileRecord:
+        head = await file.read(_SNIFF_BYTES)
+        if not head:
+            raise EmptyFile()
+
+        mime = _sniff_mime(head, file.content_type or "application/octet-stream")
+        if mime not in self._cfg.allowed_mimes:
+            raise UnsupportedMime(f"mime not allowed: {mime}")
+
+        ext = extension_for(mime)
+        key = new_storage_key("chat", ext)
+
+        # Stream the rest while counting size; raise TooLarge mid-stream
+        cap = self._cfg.max_file_bytes
+        first = head
+
+        async def _body() -> AsyncIterator[bytes]:
+            nonlocal_size = {"n": len(first)}
+            if nonlocal_size["n"] > cap:
+                raise TooLarge(f"file exceeds {cap} bytes")
+            yield first
+            while True:
+                chunk = await file.read(64 * 1024)
+                if not chunk:
+                    break
+                nonlocal_size["n"] += len(chunk)
+                if nonlocal_size["n"] > cap:
+                    raise TooLarge(f"file exceeds {cap} bytes")
+                yield chunk
+
+        obj = await self._adapter.put(key, _body(), mime)
+
+        file_id = uuid.uuid4().hex
+        filename = _basename(file.filename) or "upload"
+        record = FileRecord(
+            id=file_id,
+            storage_key=obj.key,
+            filename=filename,
+            mime=obj.mime,
+            size=obj.size,
+            owner_id=owner_id,
+            chat_id=chat_id,
+            created=datetime.now(UTC),
+        )
+        self._meta.save(record)
+        return record
+
+    async def stream(
+        self, file_id: str, requester_id: str
+    ) -> tuple[FileRecord, AsyncIterator[bytes]]:
+        rec = self._meta.get(file_id)
+        if rec is None:
+            raise NotFound()
+        if rec.owner_id != requester_id:
+            raise NotFound()  # 404-not-403 to avoid leaking existence
+        return rec, self._adapter.open(rec.storage_key)
+
+    async def delete(self, file_id: str, requester_id: str) -> None:
+        rec = self._meta.get(file_id)
+        if rec is None:
+            raise NotFound()
+        if rec.owner_id != requester_id:
+            raise NotFound()
+        await self._adapter.delete(rec.storage_key)
+        self._meta.soft_delete(file_id)
+
+
+# --- Helpers -------------------------------------------------------------
+
+def _basename(name: str | None) -> str:
+    if not name:
+        return ""
+    return os.path.basename(name.replace("\\", "/"))
+
+
+def _raise(code: FailCode, reason: str) -> None:
+    mapping: dict[FailCode, type[UploadError]] = {
+        "too_large": TooLarge,
+        "unsupported_mime": UnsupportedMime,
+        "empty": EmptyFile,
+        "storage_error": StorageFailure,
+    }
+    raise mapping[code](reason)
+```
+
+**Step 4: Run — expect pass**
+
+Run: `uv run pytest tests/uploads/test_service.py -v`
+Expected: PASS, all tests green (15+ tests across the 3 classes).
+
+**Step 5: Commit**
+
+```bash
+git add src/pocketpaw/uploads/service.py tests/uploads/test_service.py
+git commit -m "feat(uploads): UploadService with validation, magic-byte sniff, bulk, soft-delete"
+```
+
+---
+
+## Task 9: `api/v1/uploads.py` — OSS router
+
+**Files:**
+- Create: `src/pocketpaw/api/v1/uploads.py`
+- Modify: `src/pocketpaw/api/v1/__init__.py`
+- Create: `tests/uploads/test_router.py`
+
+**Step 1: Write failing tests**
+
+`tests/uploads/test_router.py`:
+
+```python
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from pocketpaw.api.v1.uploads import make_router
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"body"
+
+
+@pytest.fixture()
+def client(tmp_path: Path) -> TestClient:
+    app = FastAPI()
+    # Stub auth: requester_id comes from a header for testing
+    async def _fake_requester(x_user: str = "u1") -> str:
+        return x_user
+
+    app.include_router(
+        make_router(upload_root=tmp_path / "u", index_path=tmp_path / "u/_idx.jsonl",
+                    requester_dep=_fake_requester),
+        prefix="/api/v1",
+    )
+    return TestClient(app)
+
+
+def test_upload_single_roundtrip(client: TestClient):
+    r = client.post(
+        "/api/v1/uploads",
+        files=[("files", ("cat.png", PNG, "image/png"))],
+        headers={"x-user": "u1"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["uploaded"]) == 1
+    assert data["uploaded"][0]["filename"] == "cat.png"
+    assert data["uploaded"][0]["mime"] == "image/png"
+    fid = data["uploaded"][0]["id"]
+
+    r2 = client.get(f"/api/v1/uploads/{fid}", headers={"x-user": "u1"})
+    assert r2.status_code == 200
+    assert r2.content == PNG
+    assert r2.headers["content-type"].startswith("image/png")
+    assert "inline" in r2.headers["content-disposition"]
+
+
+def test_bulk_upload_partial_success(client: TestClient):
+    r = client.post(
+        "/api/v1/uploads",
+        files=[
+            ("files", ("good.png", PNG, "image/png")),
+            ("files", ("bad.svg", b"<svg/>", "image/svg+xml")),
+        ],
+        headers={"x-user": "u1"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["uploaded"]) == 1
+    assert len(data["failed"]) == 1
+    assert data["failed"][0]["code"] == "unsupported_mime"
+
+
+def test_download_wrong_user_is_not_found(client: TestClient):
+    r = client.post(
+        "/api/v1/uploads",
+        files=[("files", ("cat.png", PNG, "image/png"))],
+        headers={"x-user": "alice"},
+    )
+    fid = r.json()["uploaded"][0]["id"]
+
+    r2 = client.get(f"/api/v1/uploads/{fid}", headers={"x-user": "bob"})
+    assert r2.status_code == 404
+
+
+def test_delete_owner_then_get_not_found(client: TestClient):
+    r = client.post(
+        "/api/v1/uploads",
+        files=[("files", ("cat.png", PNG, "image/png"))],
+        headers={"x-user": "u1"},
+    )
+    fid = r.json()["uploaded"][0]["id"]
+
+    r2 = client.delete(f"/api/v1/uploads/{fid}", headers={"x-user": "u1"})
+    assert r2.status_code == 204
+
+    r3 = client.get(f"/api/v1/uploads/{fid}", headers={"x-user": "u1"})
+    assert r3.status_code == 404
+
+
+def test_empty_batch_is_400(client: TestClient):
+    r = client.post("/api/v1/uploads", headers={"x-user": "u1"})
+    assert r.status_code == 400
+
+
+def test_docx_gets_attachment_disposition(client: TestClient):
+    # ZIP magic (docx container). With the officedocument mime, sniff keeps it.
+    docx = b"PK\x03\x04" + b"rest"
+    r = client.post(
+        "/api/v1/uploads",
+        files=[("files", ("doc.docx", docx,
+                          "application/vnd.openxmlformats-officedocument.wordprocessingml.document"))],
+        headers={"x-user": "u1"},
+    )
+    fid = r.json()["uploaded"][0]["id"]
+    r2 = client.get(f"/api/v1/uploads/{fid}", headers={"x-user": "u1"})
+    assert r2.status_code == 200
+    assert "attachment" in r2.headers["content-disposition"]
+```
+
+**Step 2: Run — expect fail**
+
+Run: `uv run pytest tests/uploads/test_router.py -v`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+`src/pocketpaw/api/v1/uploads.py`:
+
+```python
+"""OSS uploads router — /uploads POST/GET/DELETE."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import asdict
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Response,
+    UploadFile,
+    status,
+)
+from fastapi.responses import StreamingResponse
+
+from pocketpaw.uploads.config import INLINE_MIMES, UploadSettings
+from pocketpaw.uploads.errors import (
+    EmptyFile,
+    NotFound,
+    TooLarge,
+    UnsupportedMime,
+    UploadError,
+)
+from pocketpaw.uploads.file_store import JSONLFileStore
+from pocketpaw.uploads.local import LocalStorageAdapter
+from pocketpaw.uploads.service import UploadService
+
+
+def make_router(
+    upload_root: Path,
+    index_path: Path,
+    requester_dep: Callable[..., Awaitable[str]],
+    cfg: UploadSettings | None = None,
+) -> APIRouter:
+    """Build the uploads router.
+
+    ``requester_dep`` is a FastAPI dependency returning the authenticated user
+    id. Caller plugs in their app-specific auth here.
+    """
+    cfg = cfg or UploadSettings(local_root=upload_root)
+    adapter = LocalStorageAdapter(root=upload_root)
+    meta = JSONLFileStore(path=index_path)
+    service = UploadService(adapter=adapter, meta=meta, cfg=cfg)
+
+    router = APIRouter(prefix="/uploads", tags=["Uploads"])
+
+    @router.post("")
+    async def upload(
+        files: Annotated[list[UploadFile], File(...)],
+        chat_id: Annotated[str | None, Form()] = None,
+        requester_id: str = Depends(requester_dep),
+    ) -> dict:
+        try:
+            result = await service.upload_many(files, requester_id, chat_id)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
+        return {
+            "uploaded": [_record_to_dict(r) for r in result.uploaded],
+            "failed": [asdict(f) for f in result.failed],
+        }
+
+    @router.get("/{file_id}")
+    async def download(
+        file_id: str, requester_id: str = Depends(requester_dep),
+    ) -> StreamingResponse:
+        try:
+            rec, it = await service.stream(file_id, requester_id)
+        except NotFound as e:
+            raise HTTPException(status_code=404, detail="not found") from e
+        disposition = "inline" if rec.mime in INLINE_MIMES else "attachment"
+        return StreamingResponse(
+            it,
+            media_type=rec.mime,
+            headers={
+                "Content-Disposition": f'{disposition}; filename="{rec.filename}"',
+            },
+        )
+
+    @router.delete("/{file_id}", status_code=204)
+    async def delete(
+        file_id: str, requester_id: str = Depends(requester_dep),
+    ) -> Response:
+        try:
+            await service.delete(file_id, requester_id)
+        except NotFound as e:
+            raise HTTPException(status_code=404, detail="not found") from e
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    return router
+
+
+def _record_to_dict(rec) -> dict:
+    return {
+        "id": rec.id,
+        "filename": rec.filename,
+        "mime": rec.mime,
+        "size": rec.size,
+        "url": f"/api/v1/uploads/{rec.id}",
+        "created": rec.created.isoformat(),
+    }
+```
+
+**Step 4: Register in the v1 app**
+
+Edit `src/pocketpaw/api/v1/__init__.py`. Find where other routers are included (e.g. `router.include_router(sessions.router)`). Add:
+
+```python
+from pathlib import Path
+from pocketpaw.api.v1 import uploads as _uploads
+from pocketpaw.api.deps import require_scope  # or whatever auth dep is used elsewhere
+
+# After the existing routers block:
+async def _upload_requester(user_id: str = Depends(require_scope("uploads"))) -> str:
+    return user_id  # replace with however v1 obtains the user id
+
+router.include_router(
+    _uploads.make_router(
+        upload_root=Path.home() / ".pocketpaw" / "uploads",
+        index_path=Path.home() / ".pocketpaw" / "uploads" / "_idx.jsonl",
+        requester_dep=_upload_requester,
+    )
+)
+```
+
+**If uncertain about the exact auth pattern** in the v1 app, STOP and flag as NEEDS_CONTEXT — the right pattern is whatever `sessions.py` or `chat.py` uses for `user_id`. Do not invent an auth path.
+
+**Step 5: Run — expect pass**
+
+Run: `uv run pytest tests/uploads/test_router.py -v`
+Expected: PASS.
+
+**Step 6: Run full upload suite**
+
+Run: `uv run pytest tests/uploads/ -v`
+Expected: all green across Tasks 2–9.
+
+**Step 7: Commit**
+
+```bash
+git add src/pocketpaw/api/v1/uploads.py src/pocketpaw/api/v1/__init__.py tests/uploads/test_router.py
+git commit -m "feat(uploads): OSS /uploads router with single + bulk + stream + delete"
+```
+
+---
+
+## Task 10: EE `FileUpload` Beanie document
+
+**Files:**
+- Create: `ee/cloud/uploads/__init__.py` (empty)
+- Create: `ee/cloud/uploads/models.py`
+- Modify: `ee/cloud/models/__init__.py` — append `FileUpload` to `ALL_DOCUMENTS`
+- Create: `tests/cloud/uploads/__init__.py` (empty)
+
+**Step 1: Read the existing pattern**
+
+Read `ee/cloud/models/session.py` and `ee/cloud/models/__init__.py` so the new document follows the same shape (TimestampedDocument base, Indexed, alias/populate_by_name settings, indexes list).
+
+**Step 2: Implement**
+
+`ee/cloud/uploads/models.py`:
+
+```python
+"""EE FileUpload document — Mongo metadata for uploaded blobs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from beanie import Indexed
+from pydantic import Field
+
+from ee.cloud.models.base import TimestampedDocument
+
+
+class FileUpload(TimestampedDocument):
+    """Metadata for one uploaded file. Blob bytes live in the StorageAdapter."""
+
+    file_id: Indexed(str, unique=True)  # type: ignore[valid-type]
+    storage_key: str
+    filename: str
+    mime: str
+    size: int
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    owner: str
+    chat_id: Indexed(str) | None = None  # type: ignore[valid-type]
+    deleted_at: datetime | None = None
+
+    class Settings:
+        name = "file_uploads"
+        indexes = [
+            [("workspace", 1), ("chat_id", 1), ("createdAt", -1)],
+            [("workspace", 1), ("owner", 1), ("createdAt", -1)],
+        ]
+```
+
+Append to `ee/cloud/models/__init__.py` the `FileUpload` import and include in `ALL_DOCUMENTS` tuple.
+
+**Step 3: Verify imports**
+
+Run: `uv run python -c "from ee.cloud.uploads.models import FileUpload; from ee.cloud.models import ALL_DOCUMENTS; print(FileUpload in ALL_DOCUMENTS)"`
+Expected: `True`.
+
+**Step 4: Commit**
+
+```bash
+git add ee/cloud/uploads/__init__.py ee/cloud/uploads/models.py ee/cloud/models/__init__.py tests/cloud/uploads/__init__.py
+git commit -m "feat(ee-uploads): FileUpload Beanie document + ALL_DOCUMENTS registration"
+```
+
+---
+
+## Task 11: EE `MongoFileStore` — metadata persistence
+
+**Files:**
+- Create: `ee/cloud/uploads/mongo_store.py`
+- Create: `tests/cloud/uploads/conftest.py` (Beanie fixture)
+- Create: `tests/cloud/uploads/test_mongo_store.py`
+
+**Step 1: Write the Beanie fixture**
+
+`tests/cloud/uploads/conftest.py`:
+
+```python
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+@pytest.fixture()
+async def beanie_upload_db():
+    from beanie import init_beanie
+    from mongomock_motor import AsyncMongoMockClient
+
+    from ee.cloud.uploads.models import FileUpload
+
+    db_name = f"test_uploads_{uuid.uuid4().hex[:8]}"
+    client = AsyncMongoMockClient()
+    db = client[db_name]
+
+    original = db.list_collection_names
+
+    async def _safe(*_a, **_kw):
+        return await original()
+
+    db.list_collection_names = _safe  # type: ignore[method-assign]
+
+    await init_beanie(database=db, document_models=[FileUpload])
+    yield db
+
+
+@pytest.fixture()
+async def store(beanie_upload_db):
+    from ee.cloud.uploads.mongo_store import MongoFileStore
+    return MongoFileStore()
+```
+
+**Step 2: Write failing tests**
+
+`tests/cloud/uploads/test_mongo_store.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.asyncio
+
+
+def _record(**overrides) -> FileRecord:
+    defaults = {
+        "id": "f1",
+        "storage_key": "chat/202604/aaa.png",
+        "filename": "cat.png",
+        "mime": "image/png",
+        "size": 1,
+        "owner_id": "u1",
+        "chat_id": "c1",
+        "created": datetime.now(UTC),
+    }
+    defaults.update(overrides)
+    return FileRecord(**defaults)
+
+
+class TestMongoFileStore:
+    async def test_save_then_get(self, store):
+        await store.save_scoped(_record(), workspace="w1")
+        got = await store.get_scoped("f1", workspace="w1")
+        assert got is not None
+        assert got.filename == "cat.png"
+
+    async def test_cross_workspace_get_returns_none(self, store):
+        await store.save_scoped(_record(), workspace="w1")
+        assert await store.get_scoped("f1", workspace="w2") is None
+
+    async def test_soft_delete_hides(self, store):
+        await store.save_scoped(_record(), workspace="w1")
+        await store.soft_delete_scoped("f1", workspace="w1")
+        assert await store.get_scoped("f1", workspace="w1") is None
+```
+
+**Step 3: Run — expect fail**
+
+Run: `uv run pytest tests/cloud/uploads/test_mongo_store.py -v`
+Expected: FAIL — module not found.
+
+**Step 4: Implement**
+
+`ee/cloud/uploads/mongo_store.py`:
+
+```python
+"""Mongo-backed metadata store, workspace-scoped."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from ee.cloud.uploads.models import FileUpload
+from pocketpaw.uploads.file_store import FileRecord
+
+
+class MongoFileStore:
+    """Workspace-scoped metadata store for EE uploads."""
+
+    async def save_scoped(self, record: FileRecord, workspace: str) -> None:
+        doc = FileUpload(
+            file_id=record.id,
+            storage_key=record.storage_key,
+            filename=record.filename,
+            mime=record.mime,
+            size=record.size,
+            workspace=workspace,
+            owner=record.owner_id,
+            chat_id=record.chat_id,
+        )
+        await doc.insert()
+
+    async def get_scoped(self, file_id: str, workspace: str) -> FileRecord | None:
+        doc = await FileUpload.find_one(
+            FileUpload.file_id == file_id,
+            FileUpload.workspace == workspace,
+            FileUpload.deleted_at == None,  # noqa: E711 beanie needs literal
+        )
+        if doc is None:
+            return None
+        return FileRecord(
+            id=doc.file_id,
+            storage_key=doc.storage_key,
+            filename=doc.filename,
+            mime=doc.mime,
+            size=doc.size,
+            owner_id=doc.owner,
+            chat_id=doc.chat_id,
+            created=doc.createdAt or datetime.now(UTC),
+        )
+
+    async def soft_delete_scoped(self, file_id: str, workspace: str) -> None:
+        doc = await FileUpload.find_one(
+            FileUpload.file_id == file_id,
+            FileUpload.workspace == workspace,
+        )
+        if doc is None:
+            return
+        doc.deleted_at = datetime.now(UTC)
+        await doc.save()
+```
+
+**Step 5: Run — expect pass**
+
+Run: `uv run pytest tests/cloud/uploads/test_mongo_store.py -v`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add ee/cloud/uploads/mongo_store.py tests/cloud/uploads/conftest.py tests/cloud/uploads/test_mongo_store.py
+git commit -m "feat(ee-uploads): MongoFileStore with workspace-scoped reads"
+```
+
+---
+
+## Task 12: EE `EEUploadService` — workspace-scoped wrapper
+
+**Files:**
+- Create: `ee/cloud/uploads/service.py`
+- Create: `tests/cloud/uploads/test_service.py`
+
+**Step 1: Write failing tests**
+
+`tests/cloud/uploads/test_service.py`:
+
+```python
+from __future__ import annotations
+
+import io
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from fastapi import UploadFile
+
+from pocketpaw.uploads.adapter import StorageAdapter, StoredObject
+from pocketpaw.uploads.config import UploadSettings
+from pocketpaw.uploads.errors import NotFound
+
+pytestmark = pytest.mark.asyncio
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"rest"
+
+
+class _MemAdapter(StorageAdapter):
+    def __init__(self) -> None:
+        self.blobs: dict[str, bytes] = {}
+
+    async def put(self, key, stream, mime):
+        buf = b""
+        async for c in stream:
+            buf += c
+        self.blobs[key] = buf
+        return StoredObject(key=key, size=len(buf), mime=mime)
+
+    async def open(self, key):
+        if key not in self.blobs:
+            raise NotFound()
+        yield self.blobs[key]
+
+    async def delete(self, key):
+        self.blobs.pop(key, None)
+
+    async def exists(self, key):
+        return key in self.blobs
+
+
+def _upload(content: bytes, filename: str, mime: str) -> UploadFile:
+    return UploadFile(
+        file=io.BytesIO(content),
+        filename=filename,
+        headers={"content-type": mime},  # type: ignore[arg-type]
+    )
+
+
+class TestEEUploadService:
+    async def test_upload_stores_record_in_workspace(self, store, tmp_path: Path):
+        from ee.cloud.uploads.service import EEUploadService
+
+        svc = EEUploadService(
+            adapter=_MemAdapter(), meta=store, cfg=UploadSettings(local_root=tmp_path),
+        )
+        rec = await svc.upload(_upload(PNG, "cat.png", "image/png"),
+                               owner_id="u1", chat_id="c1", workspace="w1")
+        assert rec.owner_id == "u1"
+        got = await store.get_scoped(rec.id, workspace="w1")
+        assert got is not None
+
+    async def test_stream_enforces_workspace(self, store, tmp_path: Path):
+        from ee.cloud.uploads.service import EEUploadService
+
+        svc = EEUploadService(
+            adapter=_MemAdapter(), meta=store, cfg=UploadSettings(local_root=tmp_path),
+        )
+        rec = await svc.upload(_upload(PNG, "cat.png", "image/png"),
+                               owner_id="u1", chat_id="c1", workspace="w1")
+        with pytest.raises(NotFound):
+            await svc.stream(rec.id, requester_id="u1", workspace="w2")
+```
+
+**Step 2: Run — expect fail**
+
+Run: `uv run pytest tests/cloud/uploads/test_service.py -v`
+Expected: FAIL.
+
+**Step 3: Implement**
+
+`ee/cloud/uploads/service.py`:
+
+```python
+"""EEUploadService — workspace-scoped upload pipeline."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+from fastapi import UploadFile
+
+from ee.cloud.uploads.mongo_store import MongoFileStore
+from pocketpaw.uploads.adapter import StorageAdapter
+from pocketpaw.uploads.config import UploadSettings
+from pocketpaw.uploads.errors import NotFound
+from pocketpaw.uploads.file_store import FileRecord
+from pocketpaw.uploads.service import (
+    BulkUploadResult,
+    UploadService,
+)
+
+
+class EEUploadService:
+    """Thin adapter around UploadService that plumbs workspace through.
+
+    Not a subclass — wrapping lets us keep the OSS UploadService's metadata
+    parameter typed as JSONLFileStore while the EE variant uses Mongo.
+    """
+
+    def __init__(
+        self,
+        adapter: StorageAdapter,
+        meta: MongoFileStore,
+        cfg: UploadSettings,
+    ) -> None:
+        self._adapter = adapter
+        self._meta = meta
+        self._cfg = cfg
+        # Reuse OSS validation + magic sniff via a stub meta that we never write to
+        self._oss = UploadService(
+            adapter=adapter,
+            meta=_NullMeta(),  # validation only; we persist via Mongo below
+            cfg=cfg,
+        )
+
+    async def upload(
+        self, file: UploadFile, owner_id: str, chat_id: str | None, workspace: str,
+    ) -> FileRecord:
+        result = await self.upload_many([file], owner_id, chat_id, workspace)
+        if result.failed:
+            # Mirror OSS single-upload behavior
+            from pocketpaw.uploads.service import _raise
+            f = result.failed[0]
+            _raise(f.code, f.reason)
+        return result.uploaded[0]
+
+    async def upload_many(
+        self, files: list[UploadFile], owner_id: str, chat_id: str | None, workspace: str,
+    ) -> BulkUploadResult:
+        # Delegate validation + adapter write, then re-persist in Mongo
+        result = await self._oss.upload_many(files, owner_id, chat_id)
+        # _NullMeta ate the saves; re-save to Mongo with workspace
+        for rec in result.uploaded:
+            await self._meta.save_scoped(rec, workspace=workspace)
+        return result
+
+    async def stream(
+        self, file_id: str, requester_id: str, workspace: str,
+    ) -> tuple[FileRecord, AsyncIterator[bytes]]:
+        rec = await self._meta.get_scoped(file_id, workspace=workspace)
+        if rec is None:
+            raise NotFound()
+        if rec.owner_id != requester_id:
+            # v1 access: owner only. Chat-member check is a follow-up.
+            raise NotFound()
+        return rec, self._adapter.open(rec.storage_key)
+
+    async def delete(
+        self, file_id: str, requester_id: str, workspace: str,
+    ) -> None:
+        rec = await self._meta.get_scoped(file_id, workspace=workspace)
+        if rec is None:
+            raise NotFound()
+        if rec.owner_id != requester_id:
+            raise NotFound()
+        await self._adapter.delete(rec.storage_key)
+        await self._meta.soft_delete_scoped(file_id, workspace=workspace)
+
+
+class _NullMeta:
+    """Stub JSONLFileStore interface — swallows saves (EE persists in Mongo)."""
+
+    def save(self, record: FileRecord) -> None:
+        pass
+
+    def get(self, file_id: str):
+        return None
+
+    def soft_delete(self, file_id: str) -> None:
+        pass
+```
+
+**Step 4: Run — expect pass**
+
+Run: `uv run pytest tests/cloud/uploads/test_service.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add ee/cloud/uploads/service.py tests/cloud/uploads/test_service.py
+git commit -m "feat(ee-uploads): EEUploadService with workspace-scoped reads + writes"
+```
+
+---
+
+## Task 13: EE uploads router
+
+**Files:**
+- Create: `ee/cloud/uploads/router.py`
+- Create: `tests/cloud/uploads/test_router.py`
+- Modify: wherever EE routers are mounted (check `ee/cloud/__init__.py` or the main EE app builder)
+
+**Step 1: Read the pattern**
+
+Read `ee/cloud/sessions/router.py` to see how EE routers obtain `workspace_id` + `user_id` (via `current_workspace_id`, `current_user_id` deps). The uploads router must use the same.
+
+**Step 2: Write failing tests**
+
+`tests/cloud/uploads/test_router.py`: mirror the OSS router tests, but with a fake `current_workspace_id` + `current_user_id` dependency set. Include:
+
+- happy-path upload + download round-trip in workspace w1
+- cross-workspace GET returns 404 (user in w2 tries to read w1's upload)
+- bulk partial success
+- DELETE by owner in right workspace → 204
+
+(Full test file ~100 lines; model closely on `tests/cloud/uploads/conftest.py` + the OSS router test.)
+
+**Step 3: Implement**
+
+`ee/cloud/uploads/router.py` — mirror OSS shape but with workspace dep injection. Wire:
+- `adapter = LocalStorageAdapter(root=workspace_root(workspace_id))` lazily per request (or pass in a factory that knows the workspace)
+- Actually cleaner: one global adapter rooted at `~/.pocketpaw/uploads`, and EE storage keys are prefixed with workspace: e.g. key = `"{workspace}/chat/{yyyymm}/{uuid}{ext}"`. That matches the design doc.
+
+```python
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile, status
+from fastapi.responses import StreamingResponse
+
+from ee.cloud.license import require_license
+from ee.cloud.shared.deps import current_user_id, current_workspace_id
+from ee.cloud.uploads.mongo_store import MongoFileStore
+from ee.cloud.uploads.service import EEUploadService
+from pocketpaw.uploads.config import INLINE_MIMES, UploadSettings
+from pocketpaw.uploads.errors import NotFound
+from pocketpaw.uploads.local import LocalStorageAdapter
+
+router = APIRouter(prefix="/uploads", tags=["Uploads"], dependencies=[Depends(require_license)])
+
+# Single shared adapter + store. EE service prefixes keys with workspace.
+_ROOT = Path.home() / ".pocketpaw" / "uploads"
+_ADAPTER = LocalStorageAdapter(root=_ROOT)
+_META = MongoFileStore()
+_CFG = UploadSettings(local_root=_ROOT)
+_SVC = EEUploadService(adapter=_ADAPTER, meta=_META, cfg=_CFG)
+
+
+@router.post("")
+async def upload(
+    files: Annotated[list[UploadFile], File(...)],
+    chat_id: Annotated[str | None, Form()] = None,
+    workspace: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    try:
+        result = await _SVC.upload_many(files, user_id, chat_id, workspace)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return {
+        "uploaded": [
+            {
+                "id": r.id, "filename": r.filename, "mime": r.mime, "size": r.size,
+                "url": f"/api/v1/uploads/{r.id}", "created": r.created.isoformat(),
+            } for r in result.uploaded
+        ],
+        "failed": [asdict(f) for f in result.failed],
+    }
+
+
+@router.get("/{file_id}")
+async def download(
+    file_id: str,
+    workspace: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> StreamingResponse:
+    try:
+        rec, it = await _SVC.stream(file_id, user_id, workspace)
+    except NotFound as e:
+        raise HTTPException(status_code=404, detail="not found") from e
+    disposition = "inline" if rec.mime in INLINE_MIMES else "attachment"
+    return StreamingResponse(
+        it, media_type=rec.mime,
+        headers={"Content-Disposition": f'{disposition}; filename="{rec.filename}"'},
+    )
+
+
+@router.delete("/{file_id}", status_code=204)
+async def delete_upload(
+    file_id: str,
+    workspace: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> Response:
+    try:
+        await _SVC.delete(file_id, user_id, workspace)
+    except NotFound as e:
+        raise HTTPException(status_code=404, detail="not found") from e
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+```
+
+**Step 4: Mount the router in EE app**
+
+Find the EE router aggregator (search `from ee.cloud.sessions import router as sessions_router` or similar). Add the uploads router alongside:
+
+```python
+from ee.cloud.uploads.router import router as uploads_router
+app.include_router(uploads_router, prefix="/api/v1")
+```
+
+Exact file depends on EE's app composition — mirror whatever pattern `sessions_router` uses.
+
+**Step 5: Run — expect pass**
+
+Run: `uv run pytest tests/cloud/uploads/test_router.py -v`
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add ee/cloud/uploads/router.py tests/cloud/uploads/test_router.py <app-mount-file>
+git commit -m "feat(ee-uploads): workspace-scoped /uploads router mounted in EE app"
+```
+
+---
+
+## Task 14: Full verification + manual checklist
+
+**Step 1: Lint + format**
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+Expected: no issues in new files.
+
+**Step 2: Type check**
+
+Run: `uv run mypy src/pocketpaw/uploads ee/cloud/uploads`
+Expected: no errors in new modules.
+
+**Step 3: Full fast test suite**
+
+Run: `uv run pytest --ignore=tests/e2e -q`
+Expected: all green (new upload suite + no regressions).
+
+**Step 4: Manual smoke**
+
+Start the app: `uv run pocketpaw --dev`
+
+With `curl` or HTTPie, exercise:
+- [ ] Single PNG upload → 200 with `uploaded[0]`
+- [ ] Download same file → matching bytes, `Content-Disposition: inline`
+- [ ] Upload 26 MiB file → `failed[0].code == "too_large"`
+- [ ] Upload `.html` → `failed[0].code == "unsupported_mime"`
+- [ ] Upload 3 files (1 good + 1 oversize + 1 bad-mime) → `uploaded=1, failed=2`
+- [ ] Delete → 204; subsequent GET → 404
+- [ ] Restart backend → previously uploaded file still downloadable
+- [ ] Blob path is `~/.pocketpaw/uploads/chat/{yyyymm}/...` on disk
+
+**Step 5: Final commit if any polish**
+
+```bash
+git add -u
+git commit -m "chore(uploads): polish after manual verification"
+```
+
+---
+
+## Open items (out of this PR, log for follow-up)
+
+- Frontend integration: wire `ChatInput.svelte` to `POST /api/v1/uploads` and surface upload progress / failure reasons in the attachment chips.
+- Chat-member access check on EE downloads (currently owner-only; group members can't fetch each other's attachments yet).
+- S3 adapter (`ee/cloud/uploads/s3.py`) — additive; no change to OSS or service surface. Reuse `test_local_adapter.py` contract tests via parametrization.
+- Cleanup job: scan for `.tmp` orphans older than 1h; scan metadata for records whose blob is missing.
+- `on_put` hook on `LocalStorageAdapter` for future AV/malware scanning.
+- Migrate existing ad-hoc upload sites (avatar, knowledge, soul imports) to `UploadService`.
+
+---
+
+## Plan complete
+
+Plan saved to `docs/plans/2026-04-16-upload-adapter.md`.
+
+Two execution options:
+
+1. **Subagent-Driven (this session)** — I dispatch a fresh subagent per task, review between tasks.
+2. **Parallel Session (separate)** — open a new Claude Code session with `superpowers:executing-plans`.
+
+Which approach?

--- a/docs/plans/2026-04-18-realtime-ws-design.md
+++ b/docs/plans/2026-04-18-realtime-ws-design.md
@@ -1,0 +1,369 @@
+# Global Realtime over `/ws/cloud` — Design
+
+**Date:** 2026-04-18
+**Scope:** EE cloud (`ee/cloud/` backend + paw-enterprise client). Eliminate the "refresh after every step" UX by emitting WebSocket events for every server-side mutation across groups, workspaces, messages, presence, files, sessions, agent activity, and notifications.
+**Status:** Approved — ready for implementation plan
+
+## Goal
+
+Every mutation the user or the server makes to chat-related state should appear in every relevant client in realtime, without a page refresh. Reuse the existing `/ws/cloud` endpoint and `ConnectionManager`; add a thin event-bus abstraction so future multi-instance deployments swap to Redis pub/sub without touching call sites.
+
+## Scope decisions
+
+- **Tier**: EE only. OSS dashboard already has its own per-chat WebSocket and is out of scope.
+- **Transport**: one native WebSocket per user tab at `/ws/cloud?token=<JWT>`. Retire `socket.io-client` usage (`core/shared/socket.ts`, `core/notifications/socket.ts`).
+- **Catch-up model**: reconcile-on-reconnect. WS delivers live events only; on `open` the client re-fetches authoritative state via existing REST. No event log, no resume cursors.
+- **Topology**: `EventBus` protocol. `InProcessBus` is the default (single FastAPI process). `RedisBus` added behind `POCKETPAW_REALTIME_BUS=redis` for multi-instance. Call sites don't change.
+- **Subscription model (hybrid)**:
+  - User-scoped events auto-deliver to all of a user's connected sockets based on server-known membership (workspaces, groups).
+  - Room-local high-frequency events (`typing.*`, `read.ack`-derived `message.read`) require explicit `room.join` per focused group.
+- **Transactional boundary**: emit after DB commit, never inside. WS fanout failures never abort a mutation.
+
+## Architecture
+
+```
+FastAPI process (ee/cloud)
+  Service layer (group, message, workspace, invite, session, upload, agent)
+      │
+      │  await emit(event)
+      ▼
+  ┌──────────────┐      ┌──────────────────┐
+  │  EventBus    │────▶ │ InProcessBus     │  (default)
+  │  (Protocol)  │      └──────────────────┘
+  │              │      ┌──────────────────┐
+  │              │────▶ │ RedisBus         │ ── pub/sub ──▶ other instances
+  └──────┬───────┘      └──────────────────┘
+         │
+         ▼
+  AudienceResolver (event → list[user_id])
+         │
+         ▼
+  ConnectionManager.send_to_user   (existing)
+         │
+         ▼
+  /ws/cloud?token=JWT
+
+paw-enterprise client
+  ├── RealtimeClient singleton (/ws/cloud)
+  ├── dispatcher → handlers/{group,workspace,message,...}.ts
+  ├── store reconcilers (upsert/patch/remove by id)
+  └── room.join for typing + read.ack only
+```
+
+### Principles
+
+- **Services emit, routers don't.** A mutation that runs via REST today and via an agent tool tomorrow fires the same event from the same line.
+- **Audience resolution in one place.** One `AudienceResolver.audience(event)` function, one branch per event type. Call sites stay one line.
+- **Client is dumb.** Receive, dispatch, mutate store by id. No ordering logic, no dedupe — stores are idempotent.
+- **Reconnect = refetch + buffered flush.** On `open`, buffer incoming events for 200 ms, fire REST refetches for the mounted screens, replace store contents, flush buffer. Late duplicates are no-ops.
+
+## Files touched
+
+```
+ee/cloud/realtime/
+├── __init__.py
+├── bus.py              EventBus protocol + InProcessBus + get_bus() factory
+├── redis_bus.py        RedisBus (loaded only when POCKETPAW_REALTIME_BUS=redis)
+├── events.py           Typed Event dataclasses for all surfaces
+├── audience.py         AudienceResolver (event → user_ids) with 2s TTL cache
+└── emit.py             Thin facade: async def emit(event) -> None
+
+ee/cloud/chat/ws.py     ConnectionManager untouched; InProcessBus wraps it
+ee/cloud/chat/group_service.py       emit() after mutations
+ee/cloud/chat/message_service.py     emit() after mutations
+ee/cloud/workspace/service.py        emit() after mutations
+ee/cloud/sessions/service.py         emit() after mutations
+ee/cloud/uploads/service.py (EE)     emit() on put/delete with chat_id
+ee/cloud/shared/agent_bridge.py      refactor: replace ws_manager.broadcast_to_group with emit()
+
+paw-enterprise/src/lib/core/realtime/
+├── client.ts           RealtimeClient singleton (replaces core/chat/socket.ts)
+├── dispatcher.ts       type → handler map
+├── reconcile.ts        post-reconnect refetch orchestrator
+└── handlers/
+    ├── group.ts
+    ├── workspace.ts
+    ├── message.ts
+    ├── presence.ts
+    ├── session.ts
+    ├── file.ts
+    ├── agent.ts
+    └── notification.ts
+```
+
+Deleted:
+- `paw-enterprise/src/lib/core/shared/socket.ts`
+- `paw-enterprise/src/lib/core/notifications/socket.ts`
+- `paw-enterprise/src/lib/core/chat/socket.ts` (folded into `realtime/client.ts`)
+- `socket.io-client` dependency
+
+## Event catalog
+
+All events: `{type, data, ts}`. Audience resolved server-side by `AudienceResolver`.
+
+### Workspace
+| type | audience | payload |
+|---|---|---|
+| `workspace.updated` | members | `{workspace_id, name, icon, ...}` |
+| `workspace.deleted` | members | `{workspace_id}` |
+| `workspace.member_added` | members + new user | `{workspace_id, user_id, role}` |
+| `workspace.member_removed` | remaining + removed user | `{workspace_id, user_id}` |
+| `workspace.member_role` | members | `{workspace_id, user_id, role}` |
+| `workspace.invite.created` | admins + invitee (if registered) | `{workspace_id, invite_id, email}` |
+| `workspace.invite.accepted` | admins + invitee | `{workspace_id, invite_id, user_id}` |
+| `workspace.invite.revoked` | admins + invitee | `{workspace_id, invite_id}` |
+
+### Groups
+| type | audience | payload |
+|---|---|---|
+| `group.created` | new members | full `GroupResponse` |
+| `group.updated` | members | `{group_id, name, icon, color, type, archived}` |
+| `group.deleted` | last-known members | `{group_id}` |
+| `group.member_added` | members + added user | `{group_id, user_id, role}` |
+| `group.member_removed` | remaining + removed user | `{group_id, user_id}` |
+| `group.member_role` | members | `{group_id, user_id, role}` |
+| `group.agent_added` / `_removed` / `_updated` | members | `{group_id, agent_id, ...}` |
+| `group.pinned` / `group.unpinned` | members | `{group_id, message_id}` |
+
+### Messages
+| type | audience | payload |
+|---|---|---|
+| `message.new` | members (exc. sender) | `MessageResponse` |
+| `message.sent` | sender only | `MessageResponse` |
+| `message.edited` | members | `MessageResponse` |
+| `message.deleted` | members | `{group_id, message_id}` |
+| `message.reaction.added` / `_removed` | members | `{group_id, message_id, emoji, user_id}` |
+| `message.read` | members (room-joined) | `{group_id, user_id, up_to_message_id}` |
+| `group.unread_delta` | specific user | `{group_id, unread}` |
+
+### Presence
+| type | audience | payload |
+|---|---|---|
+| `presence.online` | workspace peers | `{user_id, workspaces: [...]}` |
+| `presence.offline` | workspace peers | `{user_id}` (after 30s grace — infra exists) |
+| `typing.start` / `typing.stop` | room-joined group members | `{group_id, user_id}` |
+
+### Files (EE upload service, chat-scoped only)
+| type | audience | payload |
+|---|---|---|
+| `file.ready` | chat members | `{group_id, file_id, filename, mime, size, url}` |
+| `file.deleted` | chat members | `{group_id, file_id}` |
+
+### Sessions / DMs
+| type | audience | payload |
+|---|---|---|
+| `session.created` | both participants | `{session_id, agent_id, peer_id}` |
+| `session.updated` | participants | `{session_id, last_message_at, last_message_preview}` |
+| `session.deleted` | participants | `{session_id}` |
+
+### Agent activity (`agent_bridge` — already emits, now through `emit()`)
+| type | audience | payload |
+|---|---|---|
+| `agent.thinking` | members | `{group_id, agent_id}` |
+| `agent.tool_start` | members | `{group_id, agent_id, tool, args_preview}` |
+| `agent.tool_result` | members | `{group_id, agent_id, tool, ok, summary}` |
+| `agent.error` | members | `{group_id, agent_id, error}` |
+| `agent.stream_chunk` | members | `{group_id, message_id, chunk}` |
+| `agent.stream_end` | members | `{group_id, message_id}` |
+
+### Notifications (unified feed)
+| type | audience | payload |
+|---|---|---|
+| `notification.new` | specific user | `{id, kind, source_id, preview, created_at}` |
+| `notification.read` | user's other tabs | `{id}` |
+| `notification.cleared` | user's other tabs | `{}` |
+
+Derived server-side by listening on `message.new` (mentions), `message.reaction.added` (reactions to your message), and `workspace.invite.created`. Persisted in a new `notifications` Beanie collection.
+
+## Client wiring
+
+### RealtimeClient
+
+```ts
+class RealtimeClient {
+  private ws: WebSocket | null = null;
+  private state: 'idle' | 'connecting' | 'open' | 'reconnecting' = 'idle';
+  private backoff = 1000;          // 1s → 2s → 4s → ... cap 30s with ±20% jitter
+  private buffer: Event[] = [];
+  private currentRoom: string | null = null;
+
+  connect(token: string): void
+  disconnect(): void
+  joinRoom(groupId: string): void
+  leaveRoom(groupId: string): void
+  send(type: string, data: object): void     // typing.start/stop, read.ack
+}
+```
+
+Singleton exported from `core/realtime/client.ts`, mounted once in the root layout.
+
+### Reconnect + reconcile
+
+On every `open` (first connect AND reconnect):
+
+1. Start 200 ms buffer window — events queued, not dispatched.
+2. Fire REST refetches in parallel for mounted screens:
+   - Always: `GET /workspaces`, `GET /workspaces/{current}/members`, `GET /groups`, `GET /notifications?unread=true`
+   - Current group view: `GET /groups/{id}`, `GET /groups/{id}/messages?cursor=last_seen_id`
+   - Current DM view: `GET /sessions/{id}`, `GET /sessions/{id}/messages?cursor=last_seen_id`
+3. Replace store contents (set-by-id is idempotent).
+4. Flush `buffer` through the dispatcher. Late duplicates are no-ops.
+5. `joinRoom(currentGroupId)` if a room view is mounted.
+
+### Dispatcher
+
+```ts
+const handlers: Record<string, (data: any) => void> = {
+  'group.created':            groupHandlers.onCreated,
+  'group.updated':            groupHandlers.onUpdated,
+  'group.member_added':       groupHandlers.onMemberAdded,
+  'workspace.invite.created': workspaceHandlers.onInviteCreated,
+  'message.new':              messageHandlers.onNew,
+  // one entry per event type
+};
+
+export function dispatch(event: {type: string; data: any}) {
+  handlers[event.type]?.(event.data);
+}
+```
+
+### Store pattern
+
+Every store exposes `upsert(item)`, `patch(id, fields)`, `remove(id)`. Handlers call these by id; order-independence is a property, not a contract.
+
+### Room join
+
+- Enter group/DM view → `{type: "room.join", group_id}`.
+- Leave view → `{type: "room.leave", group_id}`.
+- Server tracks `socket → current_room`. `typing.*` and `message.read` only fan out to members currently joined to the room. All other events still use `user_id` fanout regardless.
+
+## Server-side emit wiring
+
+### Facade
+
+```python
+# ee/cloud/realtime/emit.py
+from ee.cloud.realtime.bus import get_bus
+from ee.cloud.realtime.events import Event
+
+async def emit(event: Event) -> None:
+    await get_bus().publish(event)
+```
+
+### Call sites
+
+| Service | Method | Event(s) |
+|---|---|---|
+| `GroupService` | `create_group` | `group.created` |
+| | `update_group` | `group.updated` |
+| | `delete_group` | `group.deleted` |
+| | `add_members` | `group.member_added` (batched one per user_id) |
+| | `remove_member` | `group.member_removed` |
+| | `update_member_role` | `group.member_role` |
+| | `add_agent` / `remove_agent` / `update_agent` | `group.agent_added/removed/updated` |
+| | `pin_message` / `unpin_message` | `group.pinned/unpinned` |
+| `MessageService` | `send_message` | `message.new` + `message.sent` + derived `notification.new` (mentions) + per-recipient `group.unread_delta` |
+| | `edit_message` | `message.edited` |
+| | `delete_message` | `message.deleted` |
+| | `react` / `unreact` | `message.reaction.*` + derived `notification.new` if target != actor |
+| | `mark_read` (new) | `message.read` + `group.unread_delta` to reader |
+| `WorkspaceService` | `update` / `delete` | `workspace.updated/deleted` |
+| | `add_member` / `remove_member` / `set_role` | `workspace.member_*` |
+| | `create_invite` / `accept_invite` / `revoke_invite` | `workspace.invite.*` |
+| `SessionService` | `get_or_create` (only when created) | `session.created` |
+| | hook on DM message | `session.updated` |
+| | `delete_session` | `session.deleted` |
+| `EEUploadService` | `upload` with `chat_id` | `file.ready` |
+| | `delete` | `file.deleted` |
+| `agent_bridge` | existing hooks | keep events; route through `emit()` |
+
+### AudienceResolver (sketch)
+
+One branch per event type. Caches `_group_member_ids` and `_workspace_member_ids` with 2s TTL keyed by id. Invalidate on membership mutation.
+
+### EventBus
+
+```python
+class EventBus(Protocol):
+    async def publish(self, event: Event) -> None: ...
+
+class InProcessBus:
+    def __init__(self, resolver, conn_manager): ...
+    async def publish(self, event):
+        for uid in await self._resolver.audience(event):
+            await self._conn.send_to_user(uid, WsOutbound(type=event.type, data=event.data))
+
+class RedisBus:
+    # publish → Redis PUBLISH on channel "realtime:events" with msgpack/json payload
+    # background task on start → SUBSCRIBE; on message, fan out to local sockets
+    # reconnects with exponential backoff
+```
+
+Factory reads `POCKETPAW_REALTIME_BUS` (`inprocess` default, `redis` opt-in).
+
+### Transactional boundary
+
+```python
+await group.save()
+await emit(GroupCreated(...))  # errors swallowed + logged; never aborts the mutation
+```
+
+Emit runs after commit. Failures are logged, not raised — the user's next reconnect refetch re-synchronizes state.
+
+## Error handling
+
+- Fanout exception on a single socket → disconnect it (existing `send_to_user` already handles dead sockets).
+- Audience resolution DB error → log, skip that event; client reconciles on next mutation or reconnect.
+- Redis down (RedisBus) → log + retry connect; client still has its local socket open, just sees delayed events. REST stays fully functional.
+- Client missed events (tab asleep) → reconnect triggers reconcile. Zero data loss for *state*; transient events (typing, tool_start) are lost by design.
+
+## Testing
+
+### Backend
+
+- **Unit — `AudienceResolver`** (`tests/cloud/realtime/test_audience.py`): correct user_ids per event type; removed-member events include removed user; cache invalidation on membership change.
+- **Unit — `InProcessBus`** (`tests/cloud/realtime/test_bus.py`): publish calls send_to_user for every audience member; exceptions isolated per handler.
+- **Unit — `RedisBus`** (`tests/cloud/realtime/test_redis_bus.py`, fakeredis): cross-instance fanout; ordering per publisher; reconnect after broker drop.
+- **Integration — emit sites** (`tests/cloud/chat/test_group_emits.py`, `test_workspace_emits.py`, `test_session_emits.py`, `test_upload_emits.py`): call each service method with a bus spy; assert expected event + audience.
+- **Integration — end-to-end** (`tests/cloud/realtime/test_e2e.py`): two TestClient WS connections; verify group.created/member_added/invite flows reach the right users within 500 ms.
+
+### Client
+
+- `dispatcher.test.ts`: unknown types no-op.
+- `reconcile.test.ts`: buffer → refetch → flush ordering; duplicate events idempotent.
+- `client.test.ts`: exponential backoff with jitter; resubscribe current room on reconnect.
+
+### Manual verification before merge
+
+- [ ] Two tabs: A creates group including B → B sidebar updates without refresh.
+- [ ] Invite non-member → invitee receives invite card; accepting removes it from admin's pending list live.
+- [ ] Remove user from group → their open group view closes.
+- [ ] Force-disconnect socket for 20s, make 3 mutations, reconnect → UI reconciles to server state.
+- [ ] With `POCKETPAW_REALTIME_BUS=redis` across two backend instances: mutation on A fans out to user connected on B.
+- [ ] Kill Redis: client still sees REST working; on Redis recovery, realtime resumes.
+
+## Rollout
+
+1. Ship infra only: `ee/cloud/realtime/` package with `InProcessBus` + `emit()`. Behavior unchanged.
+2. Refactor `agent_bridge.py` to use `emit()` — canary. All existing tests still pass.
+3. Add group + workspace + session + file + notification emits one service at a time, each with emit-site tests.
+4. Client: add handlers + reconcile behind `VITE_REALTIME_V2=true`.
+5. Flip the flag, delete socket.io files and `socket.io-client` dep.
+6. Follow-up PR: `RedisBus` + cross-instance tests, gated on `POCKETPAW_REALTIME_BUS=redis`.
+
+## Out of scope
+
+- Event log / resume cursors — reconcile-on-reconnect covers the UX.
+- Message delivery receipts beyond `read.ack`.
+- E2E encryption of event payloads.
+- Cross-workspace notifications.
+- Typing-storm rate limiting (add later if measured).
+- OSS dashboard realtime — separate surface, untouched.
+- paw-runtime DM routing — untouched; `agent_bridge` rides the same bus after refactor.
+
+## Open items for implementation plan
+
+- Concrete `notifications` Beanie collection shape (fields, indexes).
+- Exact `room.join` protocol wire format (reuse `WsInbound` with new `type` values vs. separate envelope).
+- Whether `agent.stream_chunk` should go on a separate high-volume channel in the future (not needed for (a) topology).
+- Feature flag lifecycle — keep `VITE_REALTIME_V2` for one release or flip atomically.

--- a/docs/plans/2026-04-18-realtime-ws.md
+++ b/docs/plans/2026-04-18-realtime-ws.md
@@ -1,0 +1,1144 @@
+# Global Realtime `/ws/cloud` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Emit WebSocket events for every EE mutation so the paw-enterprise client never needs a refresh to see group, workspace, message, presence, file, session, agent, or notification changes.
+
+**Architecture:** Services call a single `emit(event)` facade after each successful mutation. A pluggable `EventBus` (in-process default, Redis optional) resolves audience via a central `AudienceResolver` and fans out through the existing `ConnectionManager` on `/ws/cloud`. Client runs one `RealtimeClient` singleton, dispatches events to store reconcilers, and refetches on reconnect instead of replaying a log.
+
+**Tech Stack:** FastAPI, Beanie (MongoDB), Pydantic, SvelteKit 2 + Svelte 5 runes, Vitest, pytest + pytest-asyncio, fakeredis, redis.asyncio.
+
+**Design source:** `docs/plans/2026-04-18-realtime-ws-design.md`
+
+---
+
+## Phase 1 — Event bus infra
+
+### Task 1: Scaffold `ee/cloud/realtime/` package
+
+**Files:**
+- Create: `ee/cloud/realtime/__init__.py`
+- Create: `ee/cloud/realtime/events.py`
+- Create: `ee/cloud/realtime/bus.py`
+- Create: `ee/cloud/realtime/audience.py`
+- Create: `ee/cloud/realtime/emit.py`
+- Test: `tests/cloud/realtime/__init__.py`
+- Test: `tests/cloud/realtime/test_events.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/cloud/realtime/test_events.py
+from ee.cloud.realtime.events import Event, GroupCreated
+
+def test_event_has_type_data_ts():
+    ev = Event(type="x.y", data={"a": 1})
+    assert ev.type == "x.y"
+    assert ev.data == {"a": 1}
+    assert ev.ts is not None  # defaults to now()
+
+def test_typed_event_subclass_sets_type():
+    ev = GroupCreated(data={"group_id": "g1", "member_ids": ["u1"]})
+    assert ev.type == "group.created"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/cloud/realtime/test_events.py -v`
+Expected: FAIL — import error.
+
+**Step 3: Implement `events.py`**
+
+```python
+# ee/cloud/realtime/events.py
+from __future__ import annotations
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import ClassVar
+
+@dataclass
+class Event:
+    type: str
+    data: dict
+    ts: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def __post_init__(self):
+        cls_type = getattr(type(self), "EVENT_TYPE", None)
+        if cls_type:
+            self.type = cls_type
+
+@dataclass
+class GroupCreated(Event):
+    EVENT_TYPE: ClassVar[str] = "group.created"
+    type: str = "group.created"
+
+# (one class per type in the design's event catalog — use the catalog as the source of truth)
+```
+
+Implement one class per event listed in the design's event catalog (workspace.*, group.*, message.*, presence.*, file.*, session.*, agent.*, notification.*). Keep it mechanical — name, `EVENT_TYPE`, nothing else.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/cloud/realtime/test_events.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add ee/cloud/realtime/__init__.py ee/cloud/realtime/events.py tests/cloud/realtime/
+git commit -m "feat(realtime): add typed Event dataclasses for all surfaces"
+```
+
+---
+
+### Task 2: `AudienceResolver` with per-event branches
+
+**Files:**
+- Modify: `ee/cloud/realtime/audience.py`
+- Test: `tests/cloud/realtime/test_audience.py`
+
+**Step 1: Write failing tests**
+
+```python
+# tests/cloud/realtime/test_audience.py
+import pytest
+from ee.cloud.realtime.audience import AudienceResolver
+from ee.cloud.realtime.events import (
+    GroupCreated, GroupMemberRemoved, MessageNew, MessageSent,
+    WorkspaceInviteCreated, SessionCreated, NotificationNew,
+)
+
+@pytest.mark.asyncio
+async def test_group_created_returns_member_ids():
+    r = AudienceResolver(group_members=lambda gid: ["u1","u2","u3"])
+    ev = GroupCreated(data={"group_id":"g1","member_ids":["u1","u2","u3"]})
+    assert set(await r.audience(ev)) == {"u1","u2","u3"}
+
+@pytest.mark.asyncio
+async def test_member_removed_includes_removed_user():
+    r = AudienceResolver(group_members=lambda gid: ["u1","u2"])
+    ev = GroupMemberRemoved(data={"group_id":"g1","user_id":"u3"})
+    assert set(await r.audience(ev)) == {"u1","u2","u3"}
+
+@pytest.mark.asyncio
+async def test_message_sent_only_to_sender():
+    r = AudienceResolver()
+    ev = MessageSent(data={"group_id":"g1","sender_id":"u1"})
+    assert await r.audience(ev) == ["u1"]
+```
+
+Run: `uv run pytest tests/cloud/realtime/test_audience.py -v`
+Expected: FAIL.
+
+**Step 2: Implement `AudienceResolver`**
+
+```python
+# ee/cloud/realtime/audience.py
+from __future__ import annotations
+import time
+from typing import Callable, Awaitable
+from ee.cloud.realtime.events import Event
+
+class AudienceResolver:
+    def __init__(
+        self,
+        group_members: Callable[[str], Awaitable[list[str]]] | None = None,
+        workspace_members: Callable[[str], Awaitable[list[str]]] | None = None,
+        workspace_admins: Callable[[str], Awaitable[list[str]]] | None = None,
+        workspace_peers: Callable[[str], Awaitable[list[str]]] | None = None,
+    ):
+        self._group_members = group_members
+        self._workspace_members = workspace_members
+        self._workspace_admins = workspace_admins
+        self._workspace_peers = workspace_peers
+        self._cache: dict[tuple[str,str], tuple[float, list[str]]] = {}
+
+    async def _cached(self, kind: str, key: str, fn) -> list[str]:
+        now = time.monotonic()
+        entry = self._cache.get((kind, key))
+        if entry and now - entry[0] < 2.0:
+            return entry[1]
+        value = await fn(key)
+        self._cache[(kind, key)] = (now, value)
+        return value
+
+    def invalidate_group(self, group_id: str) -> None:
+        self._cache.pop(("group", group_id), None)
+
+    def invalidate_workspace(self, workspace_id: str) -> None:
+        self._cache.pop(("workspace", workspace_id), None)
+        self._cache.pop(("workspace_admins", workspace_id), None)
+
+    async def audience(self, event: Event) -> list[str]:
+        d = event.data
+        t = event.type
+        # ... branches per design
+```
+
+Implement all branches from the design's AudienceResolver sketch. Add branches until every event type in `events.py` is covered (test coverage check in Task 3).
+
+**Step 3: Run tests to verify pass**
+
+Run: `uv run pytest tests/cloud/realtime/test_audience.py -v`
+Expected: PASS (all three).
+
+**Step 4: Commit**
+
+```bash
+git add ee/cloud/realtime/audience.py tests/cloud/realtime/test_audience.py
+git commit -m "feat(realtime): add AudienceResolver with 2s TTL cache"
+```
+
+---
+
+### Task 3: Audience coverage sanity test
+
+**Files:**
+- Test: `tests/cloud/realtime/test_audience_coverage.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/cloud/realtime/test_audience_coverage.py
+import inspect
+import pytest
+from ee.cloud.realtime import events as ev_mod
+from ee.cloud.realtime.audience import AudienceResolver
+from ee.cloud.realtime.events import Event
+
+@pytest.mark.asyncio
+async def test_every_event_type_is_resolved():
+    """Every Event subclass must have a branch in AudienceResolver.audience."""
+    r = AudienceResolver(
+        group_members=lambda g: [],
+        workspace_members=lambda w: [],
+        workspace_admins=lambda w: [],
+        workspace_peers=lambda u: [],
+    )
+    subclasses = [
+        c for _, c in inspect.getmembers(ev_mod, inspect.isclass)
+        if issubclass(c, Event) and c is not Event
+    ]
+    assert subclasses, "no typed events defined"
+    for cls in subclasses:
+        # Minimal payload with common keys; resolver must not KeyError.
+        ev = cls(data={
+            "group_id":"g","user_id":"u","sender_id":"u","peer_id":"p",
+            "workspace_id":"w","invite_id":"i","member_ids":["u"],
+            "message_id":"m","emoji":"x","file_id":"f",
+        })
+        result = await r.audience(ev)
+        assert isinstance(result, list), f"{cls.__name__}: expected list, got {type(result)}"
+```
+
+**Step 2: Run test; fix any uncovered branches**
+
+Run: `uv run pytest tests/cloud/realtime/test_audience_coverage.py -v`
+If any event type errors or returns non-list, add its branch to `audience.py`.
+
+**Step 3: Commit**
+
+```bash
+git add tests/cloud/realtime/test_audience_coverage.py ee/cloud/realtime/audience.py
+git commit -m "test(realtime): enforce AudienceResolver covers every Event type"
+```
+
+---
+
+### Task 4: `EventBus` protocol + `InProcessBus`
+
+**Files:**
+- Modify: `ee/cloud/realtime/bus.py`
+- Test: `tests/cloud/realtime/test_bus.py`
+
+**Step 1: Write failing tests**
+
+```python
+# tests/cloud/realtime/test_bus.py
+import pytest
+from unittest.mock import AsyncMock
+from ee.cloud.realtime.bus import InProcessBus
+from ee.cloud.realtime.audience import AudienceResolver
+from ee.cloud.realtime.events import GroupCreated
+
+@pytest.mark.asyncio
+async def test_inprocess_bus_fans_out_to_resolved_audience():
+    resolver = AudienceResolver(group_members=AsyncMock(return_value=["u1","u2"]))
+    conn = AsyncMock()
+    bus = InProcessBus(resolver=resolver, conn_manager=conn)
+    ev = GroupCreated(data={"group_id":"g1","member_ids":["u1","u2"]})
+
+    await bus.publish(ev)
+
+    assert conn.send_to_user.await_count == 2
+    sent_users = {call.args[0] for call in conn.send_to_user.await_args_list}
+    assert sent_users == {"u1","u2"}
+
+@pytest.mark.asyncio
+async def test_inprocess_bus_isolates_handler_exceptions():
+    resolver = AudienceResolver(group_members=AsyncMock(return_value=["u1","u2","u3"]))
+    conn = AsyncMock()
+    # Fail on middle recipient
+    conn.send_to_user.side_effect = [None, RuntimeError("dead socket"), None]
+    bus = InProcessBus(resolver=resolver, conn_manager=conn)
+    await bus.publish(GroupCreated(data={"group_id":"g1","member_ids":["u1","u2","u3"]}))
+    # u3 still got it
+    assert conn.send_to_user.await_count == 3
+```
+
+Run: `uv run pytest tests/cloud/realtime/test_bus.py -v` → FAIL.
+
+**Step 2: Implement `bus.py`**
+
+```python
+# ee/cloud/realtime/bus.py
+from __future__ import annotations
+import logging
+from typing import Protocol
+from ee.cloud.chat.schemas import WsOutbound
+from ee.cloud.realtime.audience import AudienceResolver
+from ee.cloud.realtime.events import Event
+
+logger = logging.getLogger(__name__)
+
+class EventBus(Protocol):
+    async def publish(self, event: Event) -> None: ...
+
+class InProcessBus:
+    def __init__(self, resolver: AudienceResolver, conn_manager) -> None:
+        self._resolver = resolver
+        self._conn = conn_manager
+
+    async def publish(self, event: Event) -> None:
+        try:
+            audience = await self._resolver.audience(event)
+        except Exception:
+            logger.exception("audience resolution failed for %s", event.type)
+            return
+        payload = WsOutbound(type=event.type, data=event.data)
+        for uid in audience:
+            try:
+                await self._conn.send_to_user(uid, payload)
+            except Exception:
+                logger.warning("ws send failed for user=%s event=%s", uid, event.type)
+
+_bus: EventBus | None = None
+
+def set_bus(bus: EventBus) -> None:
+    global _bus
+    _bus = bus
+
+def get_bus() -> EventBus:
+    assert _bus is not None, "EventBus not initialized"
+    return _bus
+```
+
+**Step 3: Verify tests pass**
+
+Run: `uv run pytest tests/cloud/realtime/test_bus.py -v` → PASS.
+
+**Step 4: Commit**
+
+```bash
+git add ee/cloud/realtime/bus.py tests/cloud/realtime/test_bus.py
+git commit -m "feat(realtime): add EventBus protocol and InProcessBus"
+```
+
+---
+
+### Task 5: `emit()` facade
+
+**Files:**
+- Modify: `ee/cloud/realtime/emit.py`
+- Test: `tests/cloud/realtime/test_emit.py`
+
+**Step 1: Write failing test**
+
+```python
+# tests/cloud/realtime/test_emit.py
+import pytest
+from unittest.mock import AsyncMock
+from ee.cloud.realtime.bus import set_bus
+from ee.cloud.realtime.emit import emit
+from ee.cloud.realtime.events import GroupCreated
+
+@pytest.mark.asyncio
+async def test_emit_delegates_to_bus():
+    bus = AsyncMock()
+    set_bus(bus)
+    ev = GroupCreated(data={"group_id":"g","member_ids":[]})
+    await emit(ev)
+    bus.publish.assert_awaited_once_with(ev)
+```
+
+Run: `uv run pytest tests/cloud/realtime/test_emit.py -v` → FAIL.
+
+**Step 2: Implement `emit.py`**
+
+```python
+# ee/cloud/realtime/emit.py
+from ee.cloud.realtime.bus import get_bus
+from ee.cloud.realtime.events import Event
+
+async def emit(event: Event) -> None:
+    try:
+        await get_bus().publish(event)
+    except Exception:
+        import logging
+        logging.getLogger(__name__).exception("emit failed for %s", event.type)
+```
+
+**Step 3: Verify**
+
+Run: `uv run pytest tests/cloud/realtime/test_emit.py -v` → PASS.
+
+**Step 4: Commit**
+
+```bash
+git add ee/cloud/realtime/emit.py tests/cloud/realtime/test_emit.py
+git commit -m "feat(realtime): add emit() facade"
+```
+
+---
+
+### Task 6: Wire bus into cloud startup
+
+**Files:**
+- Modify: `ee/cloud/__init__.py` (wherever cloud app startup lives — grep for `ConnectionManager` or `manager = ConnectionManager()`)
+- Modify: `src/pocketpaw/dashboard_lifecycle.py` if cloud bus init belongs in startup hooks
+- Test: `tests/cloud/realtime/test_wiring.py`
+
+**Step 1: Write failing test**
+
+```python
+# tests/cloud/realtime/test_wiring.py
+from ee.cloud.realtime.bus import get_bus, _bus
+from ee.cloud import init_realtime  # will define in step 2
+
+def test_init_realtime_sets_inprocess_bus_by_default(monkeypatch):
+    monkeypatch.delenv("POCKETPAW_REALTIME_BUS", raising=False)
+    init_realtime()
+    assert type(get_bus()).__name__ == "InProcessBus"
+```
+
+Run: `uv run pytest tests/cloud/realtime/test_wiring.py -v` → FAIL.
+
+**Step 2: Implement `init_realtime()` in `ee/cloud/__init__.py`**
+
+```python
+# ee/cloud/__init__.py (add)
+import os
+from ee.cloud.chat.ws import manager as _conn_manager
+from ee.cloud.realtime.audience import AudienceResolver
+from ee.cloud.realtime.bus import InProcessBus, set_bus
+
+def init_realtime() -> None:
+    from ee.cloud.chat.group_service import GroupService
+    from ee.cloud.workspace.service import WorkspaceService
+
+    resolver = AudienceResolver(
+        group_members=GroupService.list_member_ids,       # async (group_id) -> list[str]
+        workspace_members=WorkspaceService.list_member_ids,
+        workspace_admins=WorkspaceService.list_admin_ids,
+        workspace_peers=WorkspaceService.list_peers,
+    )
+    mode = os.environ.get("POCKETPAW_REALTIME_BUS", "inprocess")
+    if mode == "redis":
+        from ee.cloud.realtime.redis_bus import RedisBus
+        set_bus(RedisBus(resolver=resolver, conn_manager=_conn_manager))
+    else:
+        set_bus(InProcessBus(resolver=resolver, conn_manager=_conn_manager))
+```
+
+Add required helper methods on services — use `list_member_ids` style async classmethods that return `list[str]`. Implement using Beanie `find` projection.
+
+Call `init_realtime()` from the cloud startup path (look for existing `@app.on_event("startup")` or equivalent).
+
+**Step 3: Verify**
+
+Run: `uv run pytest tests/cloud/realtime/test_wiring.py -v` → PASS.
+
+**Step 4: Commit**
+
+```bash
+git add ee/cloud/__init__.py ee/cloud/realtime/
+git commit -m "feat(realtime): wire EventBus into cloud startup"
+```
+
+---
+
+## Phase 2 — Canary: refactor `agent_bridge` to use `emit()`
+
+### Task 7: Replace direct `ws_manager.broadcast_to_group` calls with `emit()`
+
+**Files:**
+- Modify: `ee/cloud/shared/agent_bridge.py:221-360` (the five existing broadcast sites)
+- Test: `tests/cloud/shared/test_agent_bridge_emits.py`
+
+**Step 1: Write failing test**
+
+```python
+# tests/cloud/shared/test_agent_bridge_emits.py
+import pytest
+from unittest.mock import AsyncMock, patch
+from ee.cloud.shared.agent_bridge import broadcast_agent_thinking  # or whatever the fn names are
+
+@pytest.mark.asyncio
+async def test_agent_thinking_fires_emit():
+    with patch("ee.cloud.shared.agent_bridge.emit", new=AsyncMock()) as m_emit:
+        await broadcast_agent_thinking(group_id="g1", agent_id="a1")
+        m_emit.assert_awaited_once()
+        ev = m_emit.await_args.args[0]
+        assert ev.type == "agent.thinking"
+        assert ev.data["group_id"] == "g1"
+        assert ev.data["agent_id"] == "a1"
+```
+
+Write one test per current broadcast site in `agent_bridge.py`.
+
+Run: `uv run pytest tests/cloud/shared/test_agent_bridge_emits.py -v` → FAIL.
+
+**Step 2: Refactor `agent_bridge.py`**
+
+Replace every `await ws_manager.broadcast_to_group(group_id, member_ids, WsOutbound(type=X, data=Y))` with `await emit(EventClass(data=Y))`. Delete the manual member-id lookups — the resolver owns that.
+
+**Step 3: Run existing agent-bridge tests + new tests**
+
+Run:
+- `uv run pytest tests/cloud/shared/ -v`
+- `uv run pytest tests/cloud/ -v --ignore=tests/e2e`
+
+Expected: all pass. Existing agent integration tests continue to work because events still reach the same clients — just via the bus.
+
+**Step 4: Commit**
+
+```bash
+git add ee/cloud/shared/agent_bridge.py tests/cloud/shared/test_agent_bridge_emits.py
+git commit -m "refactor(realtime): route agent_bridge through emit() canary"
+```
+
+---
+
+## Phase 3 — Route existing message + typing emits through the bus
+
+### Task 8: Refactor `MessageService` to emit through bus
+
+**Files:**
+- Modify: `ee/cloud/chat/message_service.py` (and wherever `message.new` / `message.edited` / `message.deleted` / `message.reaction.*` are currently broadcast — `ee/cloud/chat/router.py:463-610` per design exploration)
+- Test: `tests/cloud/chat/test_message_emits.py`
+
+**Step 1: Write failing test**
+
+```python
+# tests/cloud/chat/test_message_emits.py
+import pytest
+from unittest.mock import AsyncMock, patch
+
+@pytest.mark.asyncio
+async def test_send_message_emits_message_new_and_sent(group_fixture, user_fixture):
+    from ee.cloud.chat.message_service import MessageService
+    from ee.cloud.chat.schemas import SendMessageRequest
+    with patch("ee.cloud.chat.message_service.emit", new=AsyncMock()) as m_emit:
+        body = SendMessageRequest(content="hi")
+        await MessageService.send_message(group_fixture.id, user_fixture.id, body)
+
+    types = [c.args[0].type for c in m_emit.await_args_list]
+    assert "message.new" in types
+    assert "message.sent" in types
+```
+
+Add tests for edit/delete/react/unreact.
+
+Run → FAIL.
+
+**Step 2: Refactor**
+
+1. Move the existing `manager.broadcast_to_group` / `manager.send_to_user` calls out of `chat/router.py` and into `MessageService` methods.
+2. Replace with `emit(MessageNew(...))`, `emit(MessageSent(...))`, etc.
+3. Keep the router thin — just: validate → call service → return.
+
+**Step 3: Run tests**
+
+Run: `uv run pytest tests/cloud/chat/ -v`
+Expected: all pass. Existing end-to-end message tests should be unchanged.
+
+**Step 4: Commit**
+
+```bash
+git add ee/cloud/chat/message_service.py ee/cloud/chat/router.py tests/cloud/chat/test_message_emits.py
+git commit -m "refactor(realtime): route message events through bus"
+```
+
+---
+
+### Task 9: Move typing / read.ack handlers through bus
+
+**Files:**
+- Modify: `ee/cloud/chat/router.py` (`_ws_typing`, `_ws_read_ack`)
+- Test: `tests/cloud/chat/test_typing_emits.py`
+
+**Step 1: Test**
+
+```python
+@pytest.mark.asyncio
+async def test_typing_start_emits_to_room_joined_members_only():
+    # Details: two users joined room, one not joined → only joined user receives
+    ...
+
+@pytest.mark.asyncio
+async def test_read_ack_emits_message_read():
+    ...
+```
+
+**Step 2: Refactor**
+
+Introduce room-scoped routing in `ConnectionManager`:
+- Add `join_room(ws, group_id)` / `leave_room(ws)` / `send_to_room_members(group_id, members, event)` where members intersect only sockets whose `current_room == group_id`.
+- `emit()` for `typing.*` / `message.read` calls a new `ConnectionManager.send_room(...)` instead of fanout by user_id.
+- Alternative: `AudienceResolver` returns `(user_ids, room_id)`; bus consults manager. Simpler: route room-scoped events via a distinct bus method `publish_room(event, group_id)`.
+
+**Step 3: Tests pass.**
+
+Run: `uv run pytest tests/cloud/chat/test_typing_emits.py -v` → PASS.
+
+**Step 4: Commit**
+
+```bash
+git commit -m "feat(realtime): room-scoped fanout for typing + read.ack"
+```
+
+---
+
+## Phase 4 — Group emits
+
+### Task 10: Emit from `GroupService.create_group`
+
+**Files:**
+- Modify: `ee/cloud/chat/group_service.py`
+- Test: `tests/cloud/chat/test_group_emits.py`
+
+**Step 1: Test**
+
+```python
+@pytest.mark.asyncio
+async def test_create_group_emits_group_created(user_fixture):
+    from ee.cloud.chat.group_service import GroupService
+    from ee.cloud.chat.schemas import CreateGroupRequest
+    with patch("ee.cloud.chat.group_service.emit", new=AsyncMock()) as m_emit:
+        body = CreateGroupRequest(name="test", member_ids=["u2","u3"])
+        g = await GroupService.create_group("workspace1", user_fixture.id, body)
+    m_emit.assert_awaited()
+    ev = m_emit.await_args_list[0].args[0]
+    assert ev.type == "group.created"
+    assert set(ev.data["member_ids"]) >= {user_fixture.id, "u2", "u3"}
+```
+
+Run → FAIL.
+
+**Step 2: Implement**
+
+Add `await emit(GroupCreated(data={...}))` after the `await group.insert()` in `GroupService.create_group`.
+
+**Step 3: Pass.** Commit.
+
+```bash
+git commit -m "feat(realtime): emit group.created"
+```
+
+---
+
+### Task 11: Emit group.updated / group.deleted
+
+Mirror of Task 10 for `update_group` and `delete_group`. One commit per event to keep diffs small.
+
+**Commits:**
+- `feat(realtime): emit group.updated`
+- `feat(realtime): emit group.deleted`
+
+---
+
+### Task 12: Emit group.member_added / _removed / _role
+
+**Files:**
+- Modify: `ee/cloud/chat/group_service.py`
+- Test: extend `tests/cloud/chat/test_group_emits.py`
+
+For `add_members`, emit one `GroupMemberAdded` per new user_id so each audience resolution is correct (the new user receives it; existing members also do). After commit, call `resolver.invalidate_group(group_id)` so the cached member list refreshes.
+
+Same pattern for `remove_member` (emit before resolver cache refresh so the removed user is still in the audience — or pass their id explicitly via the event payload, which the resolver branch already handles).
+
+**Commits (one each):**
+- `feat(realtime): emit group.member_added`
+- `feat(realtime): emit group.member_removed`
+- `feat(realtime): emit group.member_role`
+
+---
+
+### Task 13: Emit group.agent_* and group.pinned / unpinned
+
+Mechanical repetition of Task 10 for each method. One commit each.
+
+---
+
+## Phase 5 — Workspace emits
+
+### Task 14: Emit workspace.updated / deleted / member_* / invite.*
+
+**Files:**
+- Modify: `ee/cloud/workspace/service.py`
+- Test: `tests/cloud/workspace/test_workspace_emits.py`
+
+One test + one emit per mutation. One commit each. Follow Task 10's pattern.
+
+After membership mutations: `resolver.invalidate_workspace(workspace_id)`.
+
+---
+
+## Phase 6 — Session / DM emits
+
+### Task 15: Emit session.created / updated / deleted
+
+**Files:**
+- Modify: `ee/cloud/sessions/service.py`
+- Test: `tests/cloud/sessions/test_session_emits.py`
+
+`session.created` only fires when `get_or_create` actually creates — not on retrieval. `session.updated` fires as a side effect of DM message send (call from `MessageService` when group is a DM type).
+
+**Commits:**
+- `feat(realtime): emit session.created on DM creation`
+- `feat(realtime): emit session.updated on DM message`
+- `feat(realtime): emit session.deleted`
+
+---
+
+## Phase 7 — Upload emits
+
+### Task 16: Emit file.ready / file.deleted from EE upload service
+
+**Files:**
+- Modify: `ee/cloud/uploads/service.py`
+- Test: `tests/cloud/uploads/test_upload_emits.py`
+
+Emit `file.ready` from `EEUploadService.upload` when `chat_id` is set (no emit for avatar/KB uploads — those are out of scope).
+
+**Commits:**
+- `feat(realtime): emit file.ready`
+- `feat(realtime): emit file.deleted`
+
+---
+
+## Phase 8 — Notifications (derived)
+
+### Task 17: `notifications` Beanie collection
+
+**Files:**
+- Create: `ee/cloud/notifications/__init__.py`
+- Create: `ee/cloud/notifications/models.py`
+- Create: `ee/cloud/notifications/service.py`
+- Create: `ee/cloud/notifications/router.py`
+- Test: `tests/cloud/notifications/test_models.py`
+
+```python
+# ee/cloud/notifications/models.py
+class Notification(TimestampedDocument):
+    user_id: Indexed(str)
+    kind: Literal["mention","reaction","invite","dm"]
+    source_id: str          # message_id or invite_id
+    preview: str
+    read_at: datetime | None = None
+
+    class Settings:
+        name = "notifications"
+        indexes = [[("user_id", 1), ("read_at", 1), ("createdAt", -1)]]
+```
+
+Add REST endpoints:
+- `GET /notifications?unread=true` — paginated
+- `POST /notifications/{id}/read`
+- `POST /notifications/clear`
+
+**Commit:** `feat(notifications): add Notification model + REST`
+
+---
+
+### Task 18: Derive notifications from message events
+
+**Files:**
+- Modify: `ee/cloud/chat/message_service.py`
+- Test: `tests/cloud/notifications/test_derived.py`
+
+On `send_message`: for each mention in `body.mentions`, create a `Notification(kind="mention")` and emit `notification.new` with its payload. Audience = `[user_id]`.
+
+On `react`: if target message sender != reactor, create `Notification(kind="reaction")`, emit.
+
+Keep derivation inside the service — don't subscribe to bus events; it's simpler, and the bus is fanout-only.
+
+**Commits:**
+- `feat(notifications): derive mention notifications from message.new`
+- `feat(notifications): derive reaction notifications from message.react`
+- `feat(notifications): derive invite notifications from workspace.invite.created`
+
+---
+
+## Phase 9 — Client: RealtimeClient + reconcile
+
+### Task 19: Scaffold `core/realtime/` module
+
+**Files:**
+- Create: `paw-enterprise/src/lib/core/realtime/client.ts`
+- Create: `paw-enterprise/src/lib/core/realtime/dispatcher.ts`
+- Create: `paw-enterprise/src/lib/core/realtime/reconcile.ts`
+- Create: `paw-enterprise/src/lib/core/realtime/types.ts`
+- Test: `paw-enterprise/src/lib/core/realtime/__tests__/client.test.ts`
+
+**Step 1: Write failing test**
+
+```ts
+// __tests__/client.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RealtimeClient } from '../client';
+
+describe('RealtimeClient', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (globalThis as any).WebSocket = vi.fn(() => ({
+      send: vi.fn(), close: vi.fn(),
+      addEventListener: vi.fn(), removeEventListener: vi.fn(),
+    }));
+  });
+
+  it('opens a socket to /ws/cloud with token', () => {
+    const c = new RealtimeClient('ws://x');
+    c.connect('jwt123');
+    expect((globalThis as any).WebSocket).toHaveBeenCalledWith(
+      'ws://x/ws/cloud?token=jwt123'
+    );
+  });
+
+  it('backs off exponentially on close', async () => {
+    const c = new RealtimeClient('ws://x');
+    c.connect('t');
+    // simulate close event → expect next connect after 1s
+    const ws = (globalThis as any).WebSocket.mock.results[0].value;
+    ws.onclose?.({});
+    vi.advanceTimersByTime(1000);
+    expect((globalThis as any).WebSocket).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+Run: `bun run test src/lib/core/realtime/__tests__/client.test.ts` → FAIL.
+
+**Step 2: Implement `RealtimeClient`**
+
+```ts
+// client.ts
+export class RealtimeClient {
+  private ws: WebSocket | null = null;
+  private state: 'idle' | 'connecting' | 'open' | 'reconnecting' = 'idle';
+  private backoff = 1000;
+  private buffer: any[] = [];
+  private currentRoom: string | null = null;
+  private token: string | null = null;
+
+  constructor(private baseUrl: string, private onOpen?: () => void) {}
+
+  connect(token: string): void {
+    this.token = token;
+    this.state = 'connecting';
+    this.ws = new WebSocket(`${this.baseUrl}/ws/cloud?token=${encodeURIComponent(token)}`);
+    this.ws.onopen = () => this.handleOpen();
+    this.ws.onclose = () => this.handleClose();
+    this.ws.onmessage = (e) => this.handleMessage(e);
+    this.ws.onerror = () => {};
+  }
+
+  private handleOpen() {
+    this.state = 'open';
+    this.backoff = 1000;
+    this.onOpen?.();
+  }
+
+  private handleClose() {
+    if (this.state === 'idle') return;
+    this.state = 'reconnecting';
+    const jitter = Math.random() * 0.4 - 0.2;
+    const delay = Math.min(30000, this.backoff * (1 + jitter));
+    setTimeout(() => { if (this.token) this.connect(this.token); }, delay);
+    this.backoff = Math.min(30000, this.backoff * 2);
+  }
+
+  private handleMessage(e: MessageEvent) { /* fill in Task 20 */ }
+
+  joinRoom(groupId: string) {
+    this.currentRoom = groupId;
+    this.ws?.send(JSON.stringify({ type: 'room.join', group_id: groupId }));
+  }
+  leaveRoom(groupId: string) {
+    if (this.currentRoom === groupId) this.currentRoom = null;
+    this.ws?.send(JSON.stringify({ type: 'room.leave', group_id: groupId }));
+  }
+  send(type: string, data: object) {
+    this.ws?.send(JSON.stringify({ type, ...data }));
+  }
+  disconnect() { this.state = 'idle'; this.ws?.close(); }
+}
+```
+
+**Step 3: Pass.** Commit.
+
+```bash
+git add paw-enterprise/src/lib/core/realtime/
+git commit -m "feat(realtime): scaffold RealtimeClient with backoff"
+```
+
+---
+
+### Task 20: Dispatcher + buffer/flush
+
+**Files:**
+- Modify: `paw-enterprise/src/lib/core/realtime/dispatcher.ts`
+- Modify: `paw-enterprise/src/lib/core/realtime/client.ts` (handleMessage)
+- Test: `paw-enterprise/src/lib/core/realtime/__tests__/dispatcher.test.ts`
+
+**Step 1: Test**
+
+```ts
+it('unknown event types are no-op', () => {
+  const fn = vi.fn();
+  const dispatcher = new Dispatcher({ 'known.event': fn });
+  dispatcher.dispatch({ type: 'unknown.event', data: {} });
+  expect(fn).not.toHaveBeenCalled();
+});
+
+it('events during buffer window are flushed after close', () => {
+  const fn = vi.fn();
+  const dispatcher = new Dispatcher({ 'x.y': fn });
+  dispatcher.openBuffer();
+  dispatcher.dispatch({ type: 'x.y', data: 1 });
+  expect(fn).not.toHaveBeenCalled();
+  dispatcher.closeBuffer();
+  expect(fn).toHaveBeenCalledWith(1);
+});
+```
+
+**Step 2: Implement**, wire `handleMessage` to route through dispatcher (buffer if open, dispatch otherwise).
+
+**Step 3: Pass.** Commit.
+
+---
+
+### Task 21: Reconcile orchestrator
+
+**Files:**
+- Modify: `paw-enterprise/src/lib/core/realtime/reconcile.ts`
+- Test: `paw-enterprise/src/lib/core/realtime/__tests__/reconcile.test.ts`
+
+**Step 1: Test**
+
+```ts
+it('buffer → refetch → flush in order; duplicate events are idempotent', async () => {
+  const store = { upsert: vi.fn(), map: new Map() };
+  const fetcher = vi.fn().mockResolvedValue([{id:'g1',name:'g'}]);
+  const reconciler = new Reconciler({ groups: { fetch: fetcher, store } });
+
+  reconciler.openBuffer();
+  reconciler.handleEvent({ type: 'group.updated', data: { group_id: 'g1', name: 'new' } });
+  await reconciler.reconcile();
+  reconciler.flushBuffer();
+
+  // First the refetch set 'g', then flush applied 'new' → final is 'new'
+  expect(store.upsert).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'new' }));
+});
+```
+
+**Step 2: Implement** — `reconcile()` runs REST refetches in parallel, calls `store.replace(items)` per surface, then `flushBuffer()`.
+
+**Step 3: Commit.**
+
+```bash
+git commit -m "feat(realtime): reconcile on reconnect with buffered flush"
+```
+
+---
+
+## Phase 10 — Client handlers
+
+### Task 22: Store reconciliation helpers
+
+**Files:**
+- Modify: every store in `paw-enterprise/src/lib/stores/` that holds chat state (`chat.svelte.ts` and friends)
+- Add to each: `upsert(item)`, `patch(id, fields)`, `remove(id)`, `replace(items)`.
+- Test: smoke tests per store
+
+**Commit:** `refactor(stores): add by-id reconciliation helpers`
+
+---
+
+### Task 23-30: Per-surface handlers
+
+One task per handler file. Pattern:
+
+```ts
+// handlers/group.ts
+import { stores } from '$lib/stores';
+
+export const groupHandlers = {
+  onCreated: (data: any) => stores.groups.upsert(data),
+  onUpdated: (data: any) => stores.groups.patch(data.group_id, data),
+  onDeleted: (data: any) => {
+    stores.groups.remove(data.group_id);
+    if (stores.chat.currentGroupId === data.group_id) stores.chat.currentGroupId = null;
+  },
+  onMemberAdded: (data: any) => stores.groups.patchMember(data.group_id, data.user_id, { role: data.role }),
+  onMemberRemoved: (data: any) => stores.groups.removeMember(data.group_id, data.user_id),
+  // ...
+};
+```
+
+Register each in `dispatcher.ts`'s handler map.
+
+**Commits (one per surface):**
+- `feat(realtime): group handlers`
+- `feat(realtime): workspace handlers`
+- `feat(realtime): message handlers`
+- `feat(realtime): presence handlers`
+- `feat(realtime): session handlers`
+- `feat(realtime): file handlers`
+- `feat(realtime): agent handlers`
+- `feat(realtime): notification handlers`
+
+---
+
+### Task 31: Mount RealtimeClient in root layout + feature flag
+
+**Files:**
+- Modify: `paw-enterprise/src/routes/+layout.svelte`
+- Modify: `paw-enterprise/.env.example` (add `VITE_REALTIME_V2=false`)
+
+Behind `import.meta.env.VITE_REALTIME_V2 === 'true'`, wire `realtime.connect(token)` on mount + `disconnect()` on unmount. Else keep existing `core/chat/socket.ts` path.
+
+**Commit:** `feat(realtime): mount RealtimeClient behind VITE_REALTIME_V2 flag`
+
+---
+
+## Phase 11 — Cutover
+
+### Task 32: Flip flag + delete socket.io
+
+**Files:**
+- Modify: `paw-enterprise/src/routes/+layout.svelte` (remove flag check)
+- Delete: `paw-enterprise/src/lib/core/shared/socket.ts`
+- Delete: `paw-enterprise/src/lib/core/notifications/socket.ts`
+- Delete: `paw-enterprise/src/lib/core/chat/socket.ts`
+- Modify: `paw-enterprise/package.json` (remove `socket.io-client`)
+
+Run: `bun install && bun run check && bun run test`
+
+**Manual verification:**
+
+- [ ] Two tabs, create group with other user → instant sidebar update on both.
+- [ ] Invite non-member → appears without refresh, acceptance clears admin's pending list.
+- [ ] Remove user from group → their group view closes.
+- [ ] 20-second disconnect + 3 mutations + reconnect → UI reconciles.
+
+**Commit:** `feat(realtime): cutover to /ws/cloud; delete socket.io`
+
+---
+
+## Phase 12 — Redis bus (follow-up PR)
+
+### Task 33: `RedisBus` implementation
+
+**Files:**
+- Create: `ee/cloud/realtime/redis_bus.py`
+- Test: `tests/cloud/realtime/test_redis_bus.py` (fakeredis)
+
+**Step 1: Test**
+
+```python
+@pytest.mark.asyncio
+async def test_redis_bus_cross_instance_fanout(fakeredis_factory):
+    r1 = fakeredis_factory()
+    r2 = fakeredis_factory()  # same backing store
+    conn_a = AsyncMock()
+    conn_b = AsyncMock()
+    bus_a = RedisBus(redis=r1, resolver=resolver_a, conn_manager=conn_a)
+    bus_b = RedisBus(redis=r2, resolver=resolver_b, conn_manager=conn_b)
+    await bus_a.start()
+    await bus_b.start()
+
+    await bus_a.publish(GroupCreated(data={"group_id":"g","member_ids":["u1"]}))
+    await asyncio.sleep(0.05)
+
+    # Both instances fanned out to their local sockets
+    assert conn_a.send_to_user.await_count == 1
+    assert conn_b.send_to_user.await_count == 1
+```
+
+**Step 2: Implement**
+
+```python
+# ee/cloud/realtime/redis_bus.py
+class RedisBus:
+    CHANNEL = "pocketpaw:realtime"
+
+    def __init__(self, redis, resolver, conn_manager):
+        self._redis = redis
+        self._resolver = resolver
+        self._conn = conn_manager
+        self._task = None
+
+    async def start(self):
+        self._task = asyncio.create_task(self._subscribe_loop())
+
+    async def publish(self, event):
+        payload = json.dumps({"type": event.type, "data": event.data})
+        await self._redis.publish(self.CHANNEL, payload)
+
+    async def _subscribe_loop(self):
+        pubsub = self._redis.pubsub()
+        await pubsub.subscribe(self.CHANNEL)
+        async for message in pubsub.listen():
+            if message["type"] != "message": continue
+            raw = json.loads(message["data"])
+            event = Event(type=raw["type"], data=raw["data"])
+            audience = await self._resolver.audience(event)
+            payload = WsOutbound(type=event.type, data=event.data)
+            for uid in audience:
+                try: await self._conn.send_to_user(uid, payload)
+                except Exception: pass
+```
+
+**Step 3: Pass.** Commit.
+
+```bash
+git commit -m "feat(realtime): Redis-backed EventBus for multi-instance"
+```
+
+---
+
+### Task 34: Document `POCKETPAW_REALTIME_BUS`
+
+**Files:**
+- Modify: `docs/deployment/` (add a realtime-scaling page if absent)
+- Modify: `README.md` (env-var table if present)
+
+**Commit:** `docs(realtime): document Redis bus and multi-instance scaling`
+
+---
+
+## Verification checklist
+
+Before declaring done:
+
+- [ ] `uv run pytest --ignore=tests/e2e` — all green
+- [ ] `uv run ruff check . && uv run ruff format --check .`
+- [ ] `uv run mypy .`
+- [ ] `cd paw-enterprise && bun run check && bun run test`
+- [ ] All manual checks in Task 32 pass.
+- [ ] `docs/wiki/` rebuilt (post-commit hook).
+
+---
+
+**Total task count:** ~34 tasks across 12 phases. Phases 1-8 land independently. Phase 9-11 land as a second PR once backend emits are live. Phase 12 is a follow-up.

--- a/ee/cloud/SPEC-rbac.md
+++ b/ee/cloud/SPEC-rbac.md
@@ -1,0 +1,249 @@
+# Spec: Workspace RBAC Consolidation
+
+## Objective
+
+Consolidate the two parallel RBAC implementations in the backend into a single, route-level enforced authorization system covering every resource in the cloud module: workspaces, chat groups, messages, pockets, agents, sessions, KB, invites, and billing.
+
+Today the cloud module has two RBAC frameworks (`src/pocketpaw/ee/guards/` newer, `ee/cloud/shared/` legacy) with duplicated enums, and permission checks are scattered inside service methods rather than declared on routes. Group roles are effectively binary (owner vs. member) despite a `member_roles` dict already being present. The goal is one framework, one enforcement pattern, and a documented action matrix — so that every protected operation has exactly one place where its access rule is defined.
+
+**Target users:** Backend engineers working in `ee/cloud/`; frontend engineers who need stable `Forbidden.code` values to key UI state off of.
+
+**Success looks like:**
+- All cloud routes enforce authorization via FastAPI dependencies, not via ad-hoc checks inside services.
+- `ee/cloud/shared/permissions.py` and `ee/cloud/shared/deps.py:require_role` are deleted; all callers migrated to `src/pocketpaw/ee/guards/`.
+- Groups support a 3-tier role model (OWNER > ADMIN > MEMBER) with per-member override via `Group.member_roles`.
+- Every `Forbidden` raised has a stable machine-readable `code` listed in the action matrix.
+- A role × action matrix test exists and passes, covering every row in the matrix below.
+
+## Tech Stack
+
+- Python 3.11+, FastAPI, Beanie (MongoDB ODM), fastapi-users
+- Pytest with `asyncio_mode = "auto"`
+- Ruff (line-length 100, E/F/I/UP), mypy
+- Existing deps — no new dependencies
+
+## Commands
+
+```bash
+# From D:\paw\backend
+uv sync --dev
+
+# Run cloud RBAC tests only
+uv run pytest tests/cloud/test_ee_guards.py tests/cloud/test_permissions.py -v
+
+# Run full cloud suite
+uv run pytest tests/cloud -v
+
+# Run full test suite (excluding e2e)
+uv run pytest --ignore=tests/e2e
+
+# Lint + format
+uv run ruff check ee/cloud src/pocketpaw/ee/guards tests/cloud
+uv run ruff format ee/cloud src/pocketpaw/ee/guards tests/cloud
+
+# Type check
+uv run mypy src/pocketpaw/ee/guards ee/cloud
+
+# Rebuild KB wiki after changes
+kb build ./ee/cloud --scope paw-cloud --output docs/wiki/
+```
+
+## Project Structure
+
+```
+src/pocketpaw/ee/guards/           # Canonical RBAC framework (keep)
+  rbac.py                          # WorkspaceRole, PocketAccess enums + check_* functions
+  policy.py                        # PolicyContext, PolicyResult, Forbidden
+  abac.py                          # Plan features, ACTION_ROLES, tool limits, agent ceiling
+  deps.py                          # require_role, require_pocket_access, require_policy,
+                                   #   require_plan_feature, require_group_role (NEW)
+  actions.py                       # NEW — single source of truth for action → (role, code) mapping
+  audit.py                         # NEW — helper: log_denial(), log_privileged_action()
+
+ee/cloud/
+  shared/
+    errors.py                      # CloudError hierarchy (keep)
+    permissions.py                 # DELETE after migration
+    deps.py                        # Keep current_user; DELETE local require_role
+  workspace/router.py              # Add Depends(require_role(ADMIN)) etc. to routes
+  workspace/service.py             # Remove inline role checks (move to router deps)
+  chat/router.py                   # Add Depends(require_group_role(...)) to routes
+  chat/group_service.py            # Remove inline _require_group_admin etc.
+  pockets/router.py                # Add Depends(require_pocket_access(...)) to routes
+  agents/router.py                 # Add Depends + plan/ceiling checks
+  sessions/router.py               # Add deps
+  kb/router.py                     # Add deps
+  models/group.py                  # Extend MemberRole to include "admin" tier
+
+tests/cloud/
+  test_ee_guards.py                # Unit tests for enums + check functions (extend)
+  test_permissions.py              # DELETE (duplicates test_ee_guards)
+  test_rbac_matrix.py              # NEW — parametrized (role, action, resource) → allow/deny
+  test_rbac_routes.py              # NEW — integration tests hitting real routers
+
+docs/wiki/                         # Auto-regenerated via kb build
+SPEC-rbac.md                       # This file (ee/cloud/SPEC-rbac.md)
+```
+
+## Code Style
+
+**Route-level enforcement — the target pattern:**
+
+```python
+# ee/cloud/workspace/router.py
+from pocketpaw.ee.guards.deps import require_role
+from pocketpaw.ee.guards.rbac import WorkspaceRole
+
+@router.patch("/workspaces/{workspace_id}")
+async def update_workspace(
+    workspace_id: str,
+    payload: WorkspaceUpdate,
+    _: User = Depends(require_role(WorkspaceRole.ADMIN)),
+    service: WorkspaceService = Depends(get_workspace_service),
+) -> WorkspaceRead:
+    return await service.update(workspace_id, payload)
+
+
+@router.delete("/workspaces/{workspace_id}")
+async def delete_workspace(
+    workspace_id: str,
+    _: User = Depends(require_role(WorkspaceRole.OWNER)),
+    service: WorkspaceService = Depends(get_workspace_service),
+) -> None:
+    await service.delete(workspace_id)
+```
+
+**Service stays auth-agnostic:**
+
+```python
+# ee/cloud/workspace/service.py — AFTER
+async def update(self, workspace_id: str, payload: WorkspaceUpdate) -> Workspace:
+    ws = await self._get(workspace_id)
+    ws.apply(payload)
+    await ws.save()
+    return ws
+# No role checks here — the route dependency already enforced it.
+```
+
+**Denials use stable codes:**
+
+```python
+# pocketpaw/ee/guards/actions.py
+ACTIONS: dict[str, ActionRule] = {
+    "workspace.update":          ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    "workspace.delete":          ActionRule(WorkspaceRole.OWNER, "workspace.insufficient_role"),
+    "workspace.member.remove":   ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    "group.post":                ActionRule(GroupRole.MEMBER,    "group.view_only"),
+    "group.admin":               ActionRule(GroupRole.ADMIN,     "group.not_admin"),
+    "group.delete":              ActionRule(GroupRole.OWNER,     "group.not_owner"),
+    "pocket.read":               ActionRule(PocketAccess.VIEW,   "pocket.access_denied"),
+    "pocket.edit":               ActionRule(PocketAccess.EDIT,   "pocket.access_denied"),
+    "pocket.share":              ActionRule(PocketAccess.OWNER,  "pocket.not_owner"),
+    "agent.create":              ActionRule(WorkspaceRole.MEMBER,"agent.ceiling_exceeded"),
+    "billing.manage":            ActionRule(WorkspaceRole.OWNER, "billing.owner_only"),
+    # ... full matrix below
+}
+```
+
+**Naming:** snake_case for functions, PascalCase for classes, `SCREAMING_SNAKE` for action codes in dotted form (`resource.reason`). Dependency factories return callables, named `require_*`.
+
+## Action Matrix
+
+Authoritative source: `src/pocketpaw/ee/guards/actions.py`. Tests iterate this dict.
+
+| Resource | Action | Min Role | Deny Code |
+|---|---|---|---|
+| Workspace | view | MEMBER | `workspace.not_member` |
+| Workspace | update settings | ADMIN | `workspace.insufficient_role` |
+| Workspace | delete | OWNER | `workspace.insufficient_role` |
+| Workspace | transfer ownership | OWNER | `workspace.insufficient_role` |
+| Workspace | invite member | ADMIN | `workspace.insufficient_role` |
+| Workspace | remove member | ADMIN | `workspace.insufficient_role` |
+| Workspace | change member role | ADMIN (cannot promote ≥ self) | `workspace.insufficient_role` / `workspace.cannot_promote_above_self` |
+| Workspace | demote owner | — | `workspace.cannot_demote_owner` |
+| Group | view | MEMBER (ws) + group member | `group.not_member` |
+| Group | create | MEMBER (ws) | `workspace.insufficient_role` |
+| Group | post message | GROUP_MEMBER (not view-only) | `group.view_only` |
+| Group | edit group / add admin | GROUP_ADMIN | `group.not_admin` |
+| Group | delete | GROUP_OWNER | `group.not_owner` |
+| Group | transfer ownership | GROUP_OWNER | `group.not_owner` |
+| Message | edit (own) | author | `message.not_author` |
+| Message | delete (any) | GROUP_ADMIN | `group.not_admin` |
+| Pocket | read | VIEW+ | `pocket.access_denied` |
+| Pocket | comment | COMMENT+ | `pocket.access_denied` |
+| Pocket | edit | EDIT+ | `pocket.access_denied` |
+| Pocket | share / delete | OWNER | `pocket.not_owner` |
+| Agent | run | MEMBER | `workspace.insufficient_role` |
+| Agent | create | MEMBER + plan + ceiling | `agent.ceiling_exceeded` / `plan.feature_denied` |
+| Agent | edit / delete | ADMIN or agent.owner | `agent.not_owner` |
+| Session | read (own) | author | `session.not_owner` |
+| Session | read (any in ws) | ADMIN | `workspace.insufficient_role` |
+| KB | read | MEMBER | `workspace.insufficient_role` |
+| KB | write | MEMBER | `workspace.insufficient_role` |
+| Invite | create | ADMIN | `workspace.insufficient_role` |
+| Invite | revoke | ADMIN | `workspace.insufficient_role` |
+| Billing | view | ADMIN | `billing.admin_only` |
+| Billing | manage | OWNER | `billing.owner_only` |
+
+## Testing Strategy
+
+- **Framework:** pytest + pytest-asyncio (auto mode), existing fixtures in `tests/cloud/conftest.py`.
+- **Unit tests** (`test_ee_guards.py`): role comparisons, `check_workspace_role`, `check_pocket_access`, agent-ceiling, plan-feature gates.
+- **Matrix test** (`test_rbac_matrix.py` — NEW): `@pytest.mark.parametrize` over every entry in `ACTIONS`; for each row iterate all roles and assert allow/deny and exact `code`.
+- **Route integration tests** (`test_rbac_routes.py` — NEW): spin up the FastAPI app with test DB; for each protected route, call it as OWNER/ADMIN/MEMBER/non-member and assert 200 / 403 + `code`. Fixture factory: `authed_client(role)`.
+- **Coverage target:** every `ACTIONS` row exercised at least once in positive (allow) and negative (deny) direction. Enforced by a meta-test that diffs `ACTIONS.keys()` against covered actions.
+- **No mocks for DB** — use an in-memory/real Mongo test instance per existing `tests/cloud` convention.
+
+## Boundaries
+
+**Always:**
+- Declare permission rules at the route layer via `Depends(require_*)`.
+- Register every new guarded action in `ACTIONS` with a stable `code`; add a matrix test row.
+- Raise `Forbidden(code=...)` — never a bare `HTTPException(403)`.
+- Log privileged actions (role change, invite accept, billing change, workspace delete) and every denial to the audit log.
+- Run `ruff check`, `ruff format`, `mypy`, and the cloud test suite before considering a change done.
+- Update `docs/wiki/` by rebuilding KB when cloud modules change.
+
+**Ask first:**
+- Adding any new dependency.
+- Schema changes to `User`, `Workspace`, `Group`, `Pocket`, `Agent` (beyond extending `MemberRole` enum values).
+- Introducing custom roles or org-level hierarchies.
+- Changing any existing `Forbidden.code` string (frontend consumes these).
+- Touching billing / plan-gate logic.
+- Deleting `ee/cloud/shared/permissions.py` (confirm all callers migrated first).
+
+**Never:**
+- Put auth logic inside service methods. Services are auth-agnostic.
+- Bypass `require_*` with inline `if user.role != "admin"` checks.
+- Return 404 to mask a 403 (leaks no less info than 403 does in this system — consistency matters).
+- Silently widen a role's permissions without adding a matrix test row.
+- Remove or disable audit logging for denials.
+- Commit secrets; modify `vendor/` or fastapi-users internals.
+
+## Success Criteria
+
+1. `rg "ee.cloud.shared.permissions|ee.cloud.shared.deps.require_role" src ee` returns no hits.
+2. `rg "if .*\.role" ee/cloud --type py` returns only model/schema field access, no authorization branching.
+3. Every route in `ee/cloud/*/router.py` that mutates or reads non-public data has a `Depends(require_*)` in its signature.
+4. `uv run pytest tests/cloud` passes with the new matrix + route tests.
+5. Meta-test confirms every key in `ACTIONS` has at least one allow and one deny test.
+6. `uv run mypy src/pocketpaw/ee/guards ee/cloud` passes.
+7. Docs wiki regenerated; a new `docs/wiki/rbac-overview.md` describes the model and action matrix.
+
+## Open Questions
+
+1. **Group admin tier storage:** extend `MemberRole` literal to `"owner" | "admin" | "edit" | "view"`, or split into two fields (`role` + `access_level`)? Leaning toward single field with 4 values — simpler.
+2. **Workspace owner uniqueness:** should `WorkspaceRole.OWNER` be limited to exactly one user (transfer-only) or allow multiple? Today it's singular via `Workspace.owner: str`; keeping that assumption.
+3. **Self-service role change:** can a user leave a workspace (remove themselves)? Proposed yes, except the sole OWNER must transfer first.
+4. **Agent-as-actor:** when an agent performs an action on behalf of a user, does the ceiling check happen at invocation time, creation time, or both? `abac.py` currently implies creation-time; confirm that's sufficient.
+
+## Phased Rollout
+
+1. **Phase 1 — Foundation:** Add `actions.py`, `audit.py`, `require_group_role` dep. Write matrix test that initially xfails for unmigrated routes.
+2. **Phase 2 — Migrate workspace routes:** Move all `check_workspace_role` calls out of `workspace/service.py` into `workspace/router.py` deps. Green the matrix for workspace rows.
+3. **Phase 3 — Migrate chat/group routes:** Extend `MemberRole`, introduce `GroupRole` enum, migrate `group_service.py` checks out to router. Green group rows.
+4. **Phase 4 — Migrate pockets, agents, sessions, KB, invites, billing.**
+5. **Phase 5 — Delete legacy:** Remove `ee/cloud/shared/permissions.py` + legacy `require_role`. Remove `tests/cloud/test_permissions.py`. Final grep verification per Success Criteria.
+6. **Phase 6 — Docs:** KB rebuild, add `docs/wiki/rbac-overview.md`.
+
+Each phase ends with: matrix test green for its scope, `ruff` + `mypy` clean, PR reviewed.

--- a/ee/cloud/auth/__init__.py
+++ b/ee/cloud/auth/__init__.py
@@ -14,7 +14,9 @@ from ee.cloud.auth.core import (  # noqa: F401
     get_jwt_strategy,
     get_user_db,
     get_user_manager,
+    ensure_default_agent_all_workspaces,
     seed_admin,
+    seed_default_agent,
     seed_workspace,
 )
 from ee.cloud.auth.router import router  # noqa: F401

--- a/ee/cloud/auth/core.py
+++ b/ee/cloud/auth/core.py
@@ -265,6 +265,24 @@ async def seed_workspace(admin: User | None = None) -> Workspace | None:
         return None
 
 
+async def ensure_default_agent_all_workspaces() -> int:
+    """Back-fill the pocketpaw agent for every existing workspace.
+
+    ``seed_workspace`` only runs on fresh installs — workspaces that predate
+    agent seeding never got one. Call this on every boot so the DM target
+    exists regardless of install age. Returns the count seeded this run.
+    """
+    seeded = 0
+    async for ws in Workspace.find_all():
+        try:
+            agent = await seed_default_agent(str(ws.id), str(ws.owner))
+            if agent is not None:
+                seeded += 1
+        except Exception as exc:
+            logger.warning("Failed to back-fill pocketpaw agent for ws=%s: %s", ws.id, exc)
+    return seeded
+
+
 async def seed_default_agent(workspace_id: str, owner_id: str) -> Agent | None:  # noqa: F821
     """Create the default "pocketpaw" Agent for a workspace if missing.
 

--- a/ee/cloud/memory/mongo_store.py
+++ b/ee/cloud/memory/mongo_store.py
@@ -137,6 +137,17 @@ class MongoMemoryStore:
             # (instead of `role`) would render every message as the user.
             sender_type = "agent" if role == "assistant" else "user"
             normalized_key = _normalize_session_key(entry.session_key)
+
+            # Dedup against chat_persistence: the chat endpoint persists the
+            # user message (with attachments) the moment it arrives, and the
+            # agent loop also calls us with the same content for context.
+            # Without this check both land as separate Message rows and the
+            # UI renders the user's send twice on reload. Window is 30s so
+            # normal re-sends of identical text still persist.
+            existing = await _find_recent_twin(normalized_key, role, entry.content)
+            if existing is not None:
+                return str(existing.id)
+
             workspace_id = await _resolve_session_workspace(normalized_key, entry)
             msg = Message(
                 context_type="pocket",
@@ -366,6 +377,43 @@ class MongoMemoryStore:
             filters["user_id"] = user_id
         facts = await MemoryFactDoc.find(filters).sort("-createdAt").limit(limit).to_list()
         return [_fact_to_entry(f) for f in facts]
+
+
+# Window for treating an existing Message as a duplicate of the current
+# write. Sized to comfortably cover the save_user_message → memory.add_to_session
+# race (same request, same event loop) while still letting an actual user
+# resend of the identical text through.
+_DEDUP_WINDOW_SECONDS = 30
+
+
+async def _find_recent_twin(
+    session_key: str,
+    role: str,
+    content: str,
+) -> Message | None:
+    """Return an existing Message row with the same content written recently.
+
+    Guards against the dual-write case where the chat endpoint persists the
+    message once (with attachments) and the agent loop then calls us with
+    the same content for agent-context memory. The first writer wins —
+    attachments and ordering on the canonical record are preserved.
+    """
+    from datetime import timedelta
+
+    cutoff = datetime.now(UTC) - timedelta(seconds=_DEDUP_WINDOW_SECONDS)
+    try:
+        return await Message.find_one(
+            {
+                "context_type": "pocket",
+                "session_key": session_key,
+                "role": role,
+                "content": content,
+                "createdAt": {"$gte": cutoff},
+            }
+        )
+    except Exception:
+        logger.exception("memory dedup lookup failed for session=%s", session_key)
+        return None
 
 
 async def _resolve_session_workspace(session_key: str, entry: MemoryEntry) -> str | None:

--- a/ee/cloud/memory/mongo_store.py
+++ b/ee/cloud/memory/mongo_store.py
@@ -29,7 +29,7 @@ from beanie import PydanticObjectId
 from bson.errors import InvalidId
 
 from ee.cloud.memory.documents import MemoryFactDoc
-from ee.cloud.models.message import Message
+from ee.cloud.models.message import Attachment, Message
 from ee.cloud.models.session import Session
 from pocketpaw.memory.protocol import MemoryEntry, MemoryType  # type: ignore[import-untyped]
 
@@ -138,15 +138,28 @@ class MongoMemoryStore:
             sender_type = "agent" if role == "assistant" else "user"
             normalized_key = _normalize_session_key(entry.session_key)
 
-            # Dedup against chat_persistence: the chat endpoint persists the
-            # user message (with attachments) the moment it arrives, and the
-            # agent loop also calls us with the same content for context.
-            # Without this check both land as separate Message rows and the
-            # UI renders the user's send twice on reload. Window is 30s so
-            # normal re-sends of identical text still persist.
+            # Dedup against a same-turn re-write. The main duplicate source
+            # (chat_persistence writing in parallel) is gone — we now own
+            # the single write path — but keep this guard so agent-loop
+            # retries of identical content don't land twice.
             existing = await _find_recent_twin(normalized_key, role, entry.content)
             if existing is not None:
                 return str(existing.id)
+
+            # Attachments ride on the InboundMessage metadata from
+            # /chat/stream so we can persist them on the same Message row
+            # instead of double-writing. Malformed entries are skipped but
+            # don't abort the save — the text content still gets through.
+            attachment_docs: list[Attachment] = []
+            raw_attachments = (entry.metadata or {}).get("attachments") or []
+            if isinstance(raw_attachments, list):
+                for a in raw_attachments:
+                    if not isinstance(a, dict):
+                        continue
+                    try:
+                        attachment_docs.append(Attachment(**a))
+                    except Exception:
+                        logger.warning("skipping malformed attachment on pocket message: %r", a)
 
             workspace_id = await _resolve_session_workspace(normalized_key, entry)
             msg = Message(
@@ -156,6 +169,7 @@ class MongoMemoryStore:
                 sender_type=sender_type,
                 content=entry.content,
                 workspace_id=workspace_id,
+                attachments=attachment_docs,
             )
             await msg.insert()
             return str(msg.id)

--- a/ee/cloud/memory/mongo_store.py
+++ b/ee/cloud/memory/mongo_store.py
@@ -394,10 +394,11 @@ class MongoMemoryStore:
 
 
 # Window for treating an existing Message as a duplicate of the current
-# write. Sized to comfortably cover the save_user_message → memory.add_to_session
-# race (same request, same event loop) while still letting an actual user
-# resend of the identical text through.
-_DEDUP_WINDOW_SECONDS = 30
+# write. The dual-write race (chat endpoint + agent loop both saving) is
+# synchronous in the same request, so 5s is plenty — and short enough that a
+# real user sending back-to-back "ok" messages doesn't see one silently
+# swallowed.
+_DEDUP_WINDOW_SECONDS = 5
 
 
 async def _find_recent_twin(
@@ -407,10 +408,12 @@ async def _find_recent_twin(
 ) -> Message | None:
     """Return an existing Message row with the same content written recently.
 
-    Guards against the dual-write case where the chat endpoint persists the
-    message once (with attachments) and the agent loop then calls us with
-    the same content for agent-context memory. The first writer wins —
-    attachments and ordering on the canonical record are preserved.
+    Covers the synchronous in-request race where the chat endpoint persists
+    the message once (with attachments) and the agent loop's
+    ``memory.add_to_session`` then calls us with the same content for
+    agent-context memory. The first writer wins — attachments and ordering
+    on the canonical record are preserved. Legitimate back-to-back resends
+    of the same short text (``"ok"``) fall outside the 5s window.
     """
     from datetime import timedelta
 

--- a/ee/cloud/shared/chat_persistence.py
+++ b/ee/cloud/shared/chat_persistence.py
@@ -25,10 +25,25 @@ from datetime import UTC, datetime
 logger = logging.getLogger(__name__)
 
 # In-memory cache of session metadata so we don't re-query Mongo on every
-# message. Keyed by chat_id (== Session.sessionId).
+# message. Keyed by the normalized chat_id (== Session.sessionId).
 _session_cache: dict[str, dict] = {}
 # Accumulate streaming chunks per chat until stream_end.
 _stream_buffers: dict[str, str] = {}
+
+# Channel label prefixed onto raw bus chat_ids to match Session.sessionId
+# and the key that MongoMemoryStore writes via `_normalize_session_key`.
+# The /chat/stream router strips "websocket_" from incoming session ids
+# before publishing to the bus; we re-add it here so all three storage
+# paths (Session docs, memory-stored messages, attachment-stored messages)
+# agree on a single session_key format.
+_WS_SAFE_PREFIX = "websocket_"
+
+
+def _safe_chat_id(chat_id: str) -> str:
+    """Return the underscore-prefixed form used across Mongo."""
+    if chat_id.startswith(_WS_SAFE_PREFIX):
+        return chat_id
+    return f"{_WS_SAFE_PREFIX}{chat_id}"
 
 
 def register_chat_persistence() -> None:
@@ -54,14 +69,21 @@ async def save_user_message(
     content: str,
     attachments: list[dict] | None = None,
 ) -> None:
-    """Persist a user chat message. ``chat_id`` must be the Session.sessionId.
+    """Persist a user chat message.
+
+    ``chat_id`` may be either the raw bus chat_id (``"522bd857d048"``) or
+    the already-prefixed ``Session.sessionId`` form
+    (``"websocket_522bd857d048"``) — we normalize internally so the message
+    ``session_key`` matches both ``Session.sessionId`` and the format that
+    ``MongoMemoryStore`` uses for agent-memory rows.
 
     ``attachments``, when present, is a list of Attachment-shaped dicts
     (``{type, url, name, meta}``). They are stored on the Message doc so
     reloaded history shows the uploaded files.
     """
     try:
-        ctx = await _resolve_session_context(chat_id)
+        safe_id = _safe_chat_id(chat_id)
+        ctx = await _resolve_session_context(safe_id)
         if not ctx:
             logger.warning("no session context for chat_id=%s — user message dropped", chat_id)
             return
@@ -79,7 +101,11 @@ async def save_user_message(
 async def _on_outbound_message(message) -> None:
     """Accumulate agent stream chunks and save final message to MongoDB."""
     try:
-        chat_id = message.chat_id
+        # Bus messages carry the raw chat_id (stripped of any safe-key prefix
+        # by /chat/stream). Normalize to the underscore form so the resulting
+        # ``session_key`` matches Session.sessionId and the format written by
+        # MongoMemoryStore for agent-memory rows.
+        chat_id = _safe_chat_id(message.chat_id)
 
         if message.is_stream_chunk:
             _stream_buffers[chat_id] = _stream_buffers.get(chat_id, "") + (message.content or "")
@@ -132,9 +158,11 @@ async def _resolve_session_context(chat_id: str) -> dict | None:
 
     from ee.cloud.models.session import Session
 
+    # Callers in this module pre-normalize to the underscore form, so the
+    # Session.sessionId lookup is a direct hit for any session created by
+    # POST /sessions or the auto-create fallback below.
     session = await Session.find_one(Session.sessionId == chat_id)
     if session is None:
-        # Auto-create a pocket session so messages have a key.
         session = await _auto_create_pocket_session(chat_id)
         if session is None:
             return None

--- a/ee/cloud/uploads/router.py
+++ b/ee/cloud/uploads/router.py
@@ -24,12 +24,12 @@ from ee.cloud.uploads.mongo_store import MongoFileStore
 from ee.cloud.uploads.service import EEUploadService
 from pocketpaw.uploads.config import INLINE_MIMES, UploadSettings
 from pocketpaw.uploads.errors import NotFound
-from pocketpaw.uploads.local import LocalStorageAdapter
+from pocketpaw.uploads.factory import build_adapter
 
 # Module-level singletons — one adapter + store per process
 _ROOT = Path.home() / ".pocketpaw" / "uploads"
 _CFG = UploadSettings(local_root=_ROOT)
-_ADAPTER = LocalStorageAdapter(root=_ROOT)
+_ADAPTER = build_adapter(_ROOT)
 _META = MongoFileStore()
 _SVC = EEUploadService(adapter=_ADAPTER, meta=_META, cfg=_CFG)
 
@@ -65,6 +65,42 @@ async def upload(
     return {
         "uploaded": [_record_to_dict(r) for r in result.uploaded],
         "failed": [asdict(f) for f in result.failed],
+    }
+
+
+@router.get("/{file_id}/grant")
+async def grant(
+    file_id: str,
+    workspace: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Mint a short-lived signed URL for ``file_id``.
+
+    Returns the storage adapter's presigned URL when available (S3 and
+    friends), otherwise an HMAC-signed proxy URL through this service.
+    """
+    import time
+
+    from ee.cloud.auth import SECRET
+    from pocketpaw.uploads.signing import DEFAULT_TTL_SECONDS, sign_grant
+
+    try:
+        _rec, presigned = await _SVC.presigned_get(
+            file_id, user_id, workspace, DEFAULT_TTL_SECONDS
+        )
+    except NotFound as e:
+        raise HTTPException(status_code=404, detail="not found") from e
+
+    if presigned:
+        return {
+            "url": presigned,
+            "expires_at": int(time.time()) + DEFAULT_TTL_SECONDS,
+        }
+
+    token, expires_at = sign_grant(file_id, SECRET)
+    return {
+        "url": f"/api/v1/uploads/{file_id}?t={token}",
+        "expires_at": expires_at,
     }
 
 

--- a/ee/cloud/uploads/router.py
+++ b/ee/cloud/uploads/router.py
@@ -74,15 +74,24 @@ async def grant(
     workspace: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
 ) -> dict:
-    """Mint a short-lived signed URL for ``file_id``.
+    """Mint a short-lived download URL for ``file_id``.
 
     Returns the storage adapter's presigned URL when available (S3 and
-    friends), otherwise an HMAC-signed proxy URL through this service.
+    friends). Otherwise returns the authenticated cloud download URL —
+    the paw-enterprise browser attaches ``paw_auth`` cookies via
+    ``withCredentials`` so ``<img src>`` / ``<a href download>`` work
+    directly without a Bearer header.
+
+    HMAC-signed ``?t=`` grants are intentionally NOT used here: the EE
+    download route at ``GET /uploads/{id}`` requires ``current_active_user``
+    (JWT), and the OSS dashboard auth middleware verifies HMAC with its
+    own master token, not EE's ``SECRET``. Embedding these URLs in
+    cookie-less contexts (mobile webviews, cross-origin embeds) requires
+    S3 presigning — use that adapter for production.
     """
     import time
 
-    from ee.cloud.auth import SECRET
-    from pocketpaw.uploads.signing import DEFAULT_TTL_SECONDS, sign_grant
+    from pocketpaw.uploads.signing import DEFAULT_TTL_SECONDS
 
     try:
         _rec, presigned = await _SVC.presigned_get(
@@ -97,10 +106,9 @@ async def grant(
             "expires_at": int(time.time()) + DEFAULT_TTL_SECONDS,
         }
 
-    token, expires_at = sign_grant(file_id, SECRET)
     return {
-        "url": f"/api/v1/uploads/{file_id}?t={token}",
-        "expires_at": expires_at,
+        "url": f"/api/v1/uploads/{file_id}",
+        "expires_at": int(time.time()) + DEFAULT_TTL_SECONDS,
     }
 
 

--- a/ee/cloud/uploads/service.py
+++ b/ee/cloud/uploads/service.py
@@ -91,6 +91,21 @@ class EEUploadService:
             raise NotFound()
         return rec, self._adapter.open(rec.storage_key)
 
+    async def presigned_get(
+        self,
+        file_id: str,
+        requester_id: str,
+        workspace: str,
+        ttl_seconds: int,
+    ) -> tuple[FileRecord, str | None]:
+        rec = await self._meta.get_scoped(file_id, workspace=workspace)
+        if rec is None:
+            raise NotFound()
+        if rec.owner_id != requester_id:
+            raise NotFound()
+        url = await self._adapter.presigned_get(rec.storage_key, ttl_seconds)
+        return rec, url
+
     async def delete(
         self,
         file_id: str,

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -217,7 +217,11 @@ async def _send_message(chat_request: ChatRequest) -> str:
 
     # Persistence-friendly Attachment payloads for Mongo history. Kept on the
     # original upload URL (not the resolved disk path) so the FE can <img
-    # src> the stored message on reload without server-side rewriting.
+    # src> the stored message on reload without server-side rewriting. These
+    # travel through ``meta["attachments"]`` so the single write path in
+    # ``MongoMemoryStore.save`` owns persistence — writing directly from
+    # here AND letting MongoMemoryStore write from the agent-loop path
+    # produced two user rows per send (one with attachments, one without).
     attachments: list[dict] = []
     for original_url, r in zip(chat_request.media or [], resolved, strict=False):
         if r.record is None:
@@ -239,6 +243,8 @@ async def _send_message(chat_request: ChatRequest) -> str:
                 },
             }
         )
+    if attachments:
+        meta["attachments"] = attachments
 
     msg = InboundMessage(
         channel=Channel.WEBSOCKET,
@@ -250,17 +256,6 @@ async def _send_message(chat_request: ChatRequest) -> str:
     )
     bus = get_message_bus()
     await bus.publish_inbound(msg)
-
-    # Persist the user message with attachments to Mongo so reloaded history
-    # shows uploads. Isolated import so OSS (no EE) deployments don't fail.
-    try:
-        from ee.cloud.shared.chat_persistence import save_user_message
-
-        await save_user_message(chat_id, chat_request.content, attachments=attachments or None)
-    except ImportError:
-        pass
-    except Exception:
-        logger.exception("chat_persistence.save_user_message failed")
 
     return chat_id
 

--- a/src/pocketpaw/api/v1/schemas/chat.py
+++ b/src/pocketpaw/api/v1/schemas/chat.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class FileContext(BaseModel):
@@ -29,21 +29,30 @@ class PocketContext(BaseModel):
 
 
 class ChatRequest(BaseModel):
-    """Send a message for processing."""
+    """Send a message for processing.
+
+    Accepts both snake_case and camelCase keys on the wire so the FE can
+    post ``sessionId``/``agentId`` without silently losing the value —
+    Pydantic defaults to dropping unknown fields, which previously caused
+    every ``sessionId: "websocket_xxx"`` payload to be treated as a brand
+    new chat with a freshly generated id.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
 
     content: str = Field(..., min_length=1, max_length=100000)
-    session_id: str | None = None
+    session_id: str | None = Field(default=None, alias="sessionId")
     media: list[str] = []
-    file_context: FileContext | None = None
-    pocket_context: PocketContext | None = None
+    file_context: FileContext | None = Field(default=None, alias="fileContext")
+    pocket_context: PocketContext | None = Field(default=None, alias="pocketContext")
 
     # Enterprise overrides (all optional, ignored in community mode)
-    agent_id: str | None = None
-    workspace_id: str | None = None
-    system_prompt: str | None = None
+    agent_id: str | None = Field(default=None, alias="agentId")
+    workspace_id: str | None = Field(default=None, alias="workspaceId")
+    system_prompt: str | None = Field(default=None, alias="systemPrompt")
     model: str | None = None
     tools: list[str] | None = None
-    soul_path: str | None = None
+    soul_path: str | None = Field(default=None, alias="soulPath")
     channel: str | None = None  # "enterprise" for NestJS requests
 
 

--- a/src/pocketpaw/api/v1/uploads.py
+++ b/src/pocketpaw/api/v1/uploads.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from dataclasses import asdict
 from pathlib import Path
 from typing import Annotated
@@ -19,18 +20,20 @@ from fastapi import (
 from fastapi.responses import StreamingResponse
 
 from pocketpaw.api.deps import require_scope
+from pocketpaw.dashboard_auth import get_access_token
 from pocketpaw.uploads.config import INLINE_MIMES, UploadSettings
 from pocketpaw.uploads.errors import NotFound
+from pocketpaw.uploads.factory import build_adapter
 from pocketpaw.uploads.file_store import JSONLFileStore
-from pocketpaw.uploads.local import LocalStorageAdapter
 from pocketpaw.uploads.service import UploadService
+from pocketpaw.uploads.signing import DEFAULT_TTL_SECONDS, sign_grant
 
 _OWNER = "local"  # OSS is single-user; all uploads are "owned" by the local user.
 
 _ROOT = Path.home() / ".pocketpaw" / "uploads"
 _INDEX = _ROOT / "_idx.jsonl"
 _CFG = UploadSettings(local_root=_ROOT)
-_ADAPTER = LocalStorageAdapter(root=_ROOT)
+_ADAPTER = build_adapter(_ROOT)
 _META = JSONLFileStore(path=_INDEX)
 _SVC = UploadService(adapter=_ADAPTER, meta=_META, cfg=_CFG)
 
@@ -68,8 +71,45 @@ async def upload(
     }
 
 
+@router.get("/{file_id}/grant")
+async def grant(file_id: str) -> dict:
+    """Mint a short-lived signed URL for ``file_id``.
+
+    Two signing paths, adapter-driven:
+
+    1. If the configured storage adapter can sign (S3 and friends), return
+       the adapter's presigned URL — the browser fetches bytes directly
+       from object storage, bypassing the app server.
+    2. Otherwise, return an HMAC-signed proxy URL routed through this
+       service's ``GET /uploads/{id}?t=...`` endpoint. Lets local-disk
+       deployments still power ``<img src>`` and ``<a download>``.
+    """
+    try:
+        _rec, presigned = await _SVC.presigned_get(
+            file_id, requester_id=_OWNER, ttl_seconds=DEFAULT_TTL_SECONDS
+        )
+    except NotFound as e:
+        raise HTTPException(status_code=404, detail="not found") from e
+
+    if presigned:
+        return {
+            "url": presigned,
+            "expires_at": int(time.time()) + DEFAULT_TTL_SECONDS,
+        }
+
+    token, expires_at = sign_grant(file_id, get_access_token())
+    return {
+        "url": f"/api/v1/uploads/{file_id}?t={token}",
+        "expires_at": expires_at,
+    }
+
+
 @router.get("/{file_id}")
-async def download(file_id: str) -> StreamingResponse:
+async def download(file_id: str, t: str | None = None) -> StreamingResponse:
+    # ``t`` is accepted purely so FastAPI ignores it (the signature is verified
+    # by middleware before this handler runs). Keeping it in the signature
+    # also documents the public contract.
+    _ = t
     try:
         rec, it = await _SVC.stream(file_id, requester_id=_OWNER)
     except NotFound as e:

--- a/src/pocketpaw/bus/adapters/websocket_adapter.py
+++ b/src/pocketpaw/bus/adapters/websocket_adapter.py
@@ -133,18 +133,10 @@ class WebSocketAdapter(BaseChannelAdapter):
                     pass
 
             await self._publish_inbound(message)
-
-            # Persist user message to MongoDB (cloud persistence bridge).
-            # Log at WARNING so silent persistence failures are visible in
-            # dev when users report "my messages aren't saving".
-            try:
-                from ee.cloud.shared.chat_persistence import save_user_message
-
-                await save_user_message(chat_id, content)
-            except ImportError:
-                logger.warning("ee/cloud chat_persistence unavailable — user message not saved")
-            except Exception:
-                logger.exception("Failed to persist user message via ee/cloud")
+            # Persistence is owned by MongoMemoryStore via the agent loop's
+            # ``memory.add_to_session`` call — calling save_user_message
+            # here produced a second Message row per send (one with and one
+            # without attachments).
         # Other actions (settings, tools) handled separately
 
     async def send(self, message: OutboundMessage) -> None:

--- a/src/pocketpaw/dashboard_auth.py
+++ b/src/pocketpaw/dashboard_auth.py
@@ -11,6 +11,7 @@ Extracted from dashboard.py — contains:
 import hmac
 import io
 import logging
+import re
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
@@ -20,6 +21,22 @@ from pocketpaw.dashboard_state import _LOCALHOST_ADDRS, _PROXY_HEADERS
 from pocketpaw.security.rate_limiter import api_limiter, auth_limiter
 from pocketpaw.security.session_tokens import create_session_token, verify_session_token
 from pocketpaw.tunnel import get_tunnel_manager
+from pocketpaw.uploads.signing import verify_grant
+
+# Matches `/api/v1/uploads/{file_id}` — not `/grant` and not root. Used to
+# scope the signed-grant bypass so it can't be used to reach any other route.
+_UPLOAD_GET_PATH = re.compile(r"^/api/v1/uploads/(?P<id>[A-Za-z0-9_-]+)$")
+
+
+def _verify_upload_grant(request: Request, secret: str) -> bool:
+    """True if ``request`` carries a valid ``?t=`` grant for its path's file."""
+    m = _UPLOAD_GET_PATH.match(request.url.path)
+    if not m:
+        return False
+    token = request.query_params.get("t")
+    if not token:
+        return False
+    return verify_grant(m.group("id"), token, secret)
 
 logger = logging.getLogger(__name__)
 
@@ -464,6 +481,14 @@ async def _auth_dispatch(request: Request) -> Response | None:
     # 6. Allow genuine localhost (not tunneled proxies)
     if not is_valid and _is_genuine_localhost(request):
         is_valid = True
+
+    # 7. Short-lived signed grant for uploaded files.
+    # Minted by the authed ``/uploads/{id}/grant`` endpoint; lets the bytes be
+    # loaded from ``<img src>`` / ``<a href download>`` where a Bearer header
+    # cannot be attached. Scope: GETs only, path-bound, 5-minute TTL by default.
+    if not is_valid and request.method == "GET":
+        if _verify_upload_grant(request, current_token):
+            is_valid = True
 
     # Allow frontend assets (/, /static/*, /uploads/*) through for SPA bootstrap.
     if (

--- a/src/pocketpaw/dashboard_lifecycle.py
+++ b/src/pocketpaw/dashboard_lifecycle.py
@@ -182,10 +182,16 @@ async def startup_event(
         mongo_uri = os.environ.get("CLOUD_MONGODB_URI", "mongodb://localhost:27017/paw-enterprise")
         await init_cloud_db(mongo_uri)
         # Seed default admin user and workspace
-        from ee.cloud.auth.core import seed_admin, seed_workspace
+        from ee.cloud.auth.core import (
+            ensure_default_agent_all_workspaces,
+            seed_admin,
+            seed_workspace,
+        )
 
         admin = await seed_admin()
         await seed_workspace(admin)
+        # Back-fill the pocketpaw agent for workspaces that predate agent seeding.
+        await ensure_default_agent_all_workspaces()
     except ImportError:
         logger.debug("Enterprise cloud module not available — skipping MongoDB init")
     except Exception as exc:

--- a/src/pocketpaw/uploads/adapter.py
+++ b/src/pocketpaw/uploads/adapter.py
@@ -47,3 +47,12 @@ class StorageAdapter(Protocol):
         without streaming through HTTP. Remote adapters (S3, GCS) return
         ``None`` — the caller should fall back to streaming via ``open``.
         """
+
+    async def presigned_get(self, key: str, ttl_seconds: int) -> str | None:
+        """Return a time-limited public URL for reading ``key``.
+
+        Adapters that natively support presigning (S3, GCS) return an
+        absolute URL the browser can fetch without an Authorization header.
+        Adapters that don't (local disk) return ``None``; the caller should
+        fall back to its own signing scheme.
+        """

--- a/src/pocketpaw/uploads/factory.py
+++ b/src/pocketpaw/uploads/factory.py
@@ -1,0 +1,61 @@
+"""Pick a StorageAdapter based on environment.
+
+Selection is env-driven rather than config-driven so deployments can swap
+backends without editing the JSON config file:
+
+- ``POCKETPAW_UPLOAD_ADAPTER=local`` (default) — on-disk storage
+- ``POCKETPAW_UPLOAD_ADAPTER=s3`` — S3 or any S3-compatible endpoint
+
+S3 mode reads the same env vars that interacly-backend uses, so a single
+deployment can point both services at the same bucket:
+
+    S3_ENDPOINT             (optional — omit for AWS public S3)
+    S3_REGION
+    S3_ACCESS_KEY_ID
+    S3_SECRET_ACCESS_KEY
+    S3_PRIVATE_BUCKET       (required in s3 mode)
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from pocketpaw.uploads.adapter import StorageAdapter
+from pocketpaw.uploads.local import LocalStorageAdapter
+
+
+def build_adapter(local_root: Path) -> StorageAdapter:
+    """Return the configured adapter. Defaults to local-disk."""
+    # Routers instantiate adapters at module import time, which happens before
+    # the dashboard lifecycle loads .env. Call ``load_dotenv`` defensively so
+    # S3_* / POCKETPAW_UPLOAD_ADAPTER are visible here regardless of order.
+    # ``load_dotenv`` is idempotent and won't override vars already in env.
+    try:  # pragma: no cover — trivial guard
+        from dotenv import load_dotenv
+
+        load_dotenv()
+    except ImportError:
+        pass
+
+    kind = os.environ.get("POCKETPAW_UPLOAD_ADAPTER", "local").strip().lower()
+    if kind == "s3":
+        return _build_s3()
+    return LocalStorageAdapter(root=local_root)
+
+
+def _build_s3() -> StorageAdapter:
+    from pocketpaw.uploads.s3 import S3StorageAdapter
+
+    bucket = os.environ.get("S3_PRIVATE_BUCKET") or os.environ.get("S3_BUCKET")
+    if not bucket:
+        raise RuntimeError(
+            "POCKETPAW_UPLOAD_ADAPTER=s3 requires S3_PRIVATE_BUCKET to be set"
+        )
+    return S3StorageAdapter(
+        bucket=bucket,
+        region=os.environ.get("S3_REGION") or None,
+        endpoint_url=os.environ.get("S3_ENDPOINT") or None,
+        access_key_id=os.environ.get("S3_ACCESS_KEY_ID") or None,
+        secret_access_key=os.environ.get("S3_SECRET_ACCESS_KEY") or None,
+    )

--- a/src/pocketpaw/uploads/local.py
+++ b/src/pocketpaw/uploads/local.py
@@ -80,3 +80,8 @@ class LocalStorageAdapter(StorageAdapter):
         except AccessDenied:
             return None
         return target if target.exists() else None
+
+    async def presigned_get(self, key: str, ttl_seconds: int) -> str | None:
+        # Local disk can't mint a public URL. Callers fall back to the
+        # HMAC-signed ``/uploads/{id}?t=...`` proxy.
+        return None

--- a/src/pocketpaw/uploads/resolver.py
+++ b/src/pocketpaw/uploads/resolver.py
@@ -15,7 +15,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
+import aiofiles
+import aiofiles.os
+
 from pocketpaw.uploads.adapter import StorageAdapter
+from pocketpaw.uploads.config import extension_for
 from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
 
 
@@ -185,6 +189,10 @@ async def resolve_media_with_records(media: list[str]) -> list[ResolvedMedia]:
     - Non-upload string (already a path / opaque token) → ``ResolvedMedia(str, None)``
     - Upload URL that resolves nowhere → dropped with a warning log
 
+    When the storage adapter doesn't expose a local path (S3 et al.), the
+    blob is streamed to a local cache file so the agent loop gets a real
+    path to read from. Repeat lookups for the same file hit the cache.
+
     Callers that only want the paths can use :func:`resolve_media_paths_any`.
     """
     resolver = default_resolver()
@@ -195,19 +203,82 @@ async def resolve_media_with_records(media: list[str]) -> list[ResolvedMedia]:
             out.append(ResolvedMedia(path=entry, record=None))
             continue
 
-        # Try OSS first.
-        path = resolver.resolve(entry)
-        rec: FileRecord | None = None
-        if path is not None:
-            rec = resolver._meta.get(fid)
-        else:
-            path, rec = await _resolve_via_ee_mongo(fid)
+        # Locate the metadata record — OSS JSONL first, then EE Mongo.
+        rec = resolver._meta.get(fid)
+        adapter: StorageAdapter = resolver._adapter
+        if rec is None:
+            ee_path, ee_rec = await _resolve_via_ee_mongo(fid)
+            if ee_rec is not None:
+                rec = ee_rec
+                from ee.cloud.uploads.router import _ADAPTER as EE_ADAPTER
 
-        if path is None:
+                adapter = EE_ADAPTER
+                # EE's LocalStorageAdapter may have given us a local path already.
+                if ee_path is not None:
+                    out.append(ResolvedMedia(path=str(ee_path), record=rec))
+                    continue
+
+        if rec is None:
             logger.warning("dropping unresolvable upload entry: %s", entry)
             continue
-        out.append(ResolvedMedia(path=str(path), record=rec))
+
+        # Prefer a native local path (LocalStorageAdapter). Otherwise stream
+        # the remote blob to the local cache so the agent loop can read it.
+        try:
+            local = adapter.local_path(rec.storage_key)
+        except Exception:
+            logger.exception("adapter.local_path failed for file_id=%s", fid)
+            local = None
+
+        if local is None:
+            local = await _materialize_remote(adapter, rec)
+
+        if local is None:
+            logger.warning("dropping unresolvable upload entry: %s", entry)
+            continue
+        out.append(ResolvedMedia(path=str(local), record=rec))
     return out
+
+
+_REMOTE_CACHE_DIR = Path.home() / ".pocketpaw" / "uploads" / "_remote_cache"
+
+
+async def _materialize_remote(adapter: StorageAdapter, rec: FileRecord) -> Path | None:
+    """Stream a remote blob into the local cache and return its path.
+
+    The cache is keyed by ``file_id`` so repeat calls reuse the download.
+    Agents can pass the returned path to Read / image tools without caring
+    that the original bytes live in S3.
+    """
+    try:
+        await aiofiles.os.makedirs(str(_REMOTE_CACHE_DIR), exist_ok=True)
+    except Exception:
+        logger.exception("failed to create remote upload cache dir")
+        return None
+
+    ext = extension_for(rec.mime)
+    target = _REMOTE_CACHE_DIR / f"{rec.id}{ext}"
+    if target.exists():
+        return target
+
+    tmp = target.with_suffix(target.suffix + ".part")
+    try:
+        async with aiofiles.open(tmp, "wb") as fh:
+            async for chunk in adapter.open(rec.storage_key):
+                await fh.write(chunk)
+        await aiofiles.os.replace(str(tmp), str(target))
+    except Exception:
+        logger.exception(
+            "failed to materialize remote blob file_id=%s storage_key=%s",
+            rec.id,
+            rec.storage_key,
+        )
+        try:
+            await aiofiles.os.remove(str(tmp))
+        except FileNotFoundError:
+            pass
+        return None
+    return target
 
 
 # Keep JSONLFileStore importable for type-friendly call sites.

--- a/src/pocketpaw/uploads/resolver.py
+++ b/src/pocketpaw/uploads/resolver.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import re
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
@@ -261,7 +262,11 @@ async def _materialize_remote(adapter: StorageAdapter, rec: FileRecord) -> Path 
     if target.exists():
         return target
 
-    tmp = target.with_suffix(target.suffix + ".part")
+    # Unique .part suffix so two concurrent calls for the same file_id don't
+    # race each other into the same tmp path (POSIX silently interleaves,
+    # Windows blocks the second open). The first one to os.replace wins and
+    # the loser is cleaned up in the except branch.
+    tmp = target.with_suffix(f"{target.suffix}.{uuid.uuid4().hex}.part")
     try:
         async with aiofiles.open(tmp, "wb") as fh:
             async for chunk in adapter.open(rec.storage_key):

--- a/src/pocketpaw/uploads/s3.py
+++ b/src/pocketpaw/uploads/s3.py
@@ -1,0 +1,150 @@
+"""S3-backed StorageAdapter.
+
+Targets any S3-compatible endpoint (AWS S3, MinIO, Cloudflare R2, Wasabi, ...).
+Uses boto3 under ``asyncio.to_thread`` — it's sync-only, so we push calls off
+the event loop. The throughput cost is negligible for chat-sized uploads; in
+exchange we avoid pulling in aioboto3 (which still depends on boto3).
+
+Credentials are shared with interacly-backend's file storage module — same
+env var names (``S3_ENDPOINT``, ``S3_REGION``, ``S3_ACCESS_KEY_ID``,
+``S3_SECRET_ACCESS_KEY``, ``S3_PRIVATE_BUCKET``) so one deployment can point
+both services at the same bucket.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+from pocketpaw.uploads.adapter import StorageAdapter, StoredObject
+from pocketpaw.uploads.errors import NotFound, StorageFailure
+
+_CHUNK_SIZE = 64 * 1024
+
+
+class S3StorageAdapter(StorageAdapter):
+    """Store blobs in an S3 bucket.
+
+    ``endpoint_url`` defaults to AWS public S3 when unset. Pass a custom
+    endpoint for MinIO / R2 / self-hosted S3.
+    """
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        region: str | None = None,
+        endpoint_url: str | None = None,
+        access_key_id: str | None = None,
+        secret_access_key: str | None = None,
+    ) -> None:
+        try:
+            import boto3
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "boto3 is required for S3 uploads — install the `enterprise` "
+                "extra or add boto3 to your environment."
+            ) from exc
+
+        if not bucket:
+            raise ValueError("S3StorageAdapter requires a bucket name")
+
+        self._bucket = bucket
+        self._client = boto3.client(
+            "s3",
+            region_name=region,
+            endpoint_url=endpoint_url,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+        )
+
+    async def put(self, key: str, stream: AsyncIterator[bytes], mime: str) -> StoredObject:
+        # boto3 expects a seekable file-like object. Upload sizes are already
+        # bounded by the service-layer cap (25 MiB default), so buffering in
+        # memory is fine — swap to multipart_upload later if caps grow.
+        buf = io.BytesIO()
+        size = 0
+        try:
+            async for chunk in stream:
+                buf.write(chunk)
+                size += len(chunk)
+        except Exception as exc:  # propagate TooLarge etc. untouched
+            raise exc
+        buf.seek(0)
+
+        try:
+            await asyncio.to_thread(
+                self._client.put_object,
+                Bucket=self._bucket,
+                Key=key,
+                Body=buf,
+                ContentType=mime,
+            )
+        except Exception as exc:
+            raise StorageFailure(str(exc)) from exc
+        return StoredObject(key=key, size=size, mime=mime)
+
+    async def open(self, key: str) -> AsyncIterator[bytes]:
+        try:
+            obj = await asyncio.to_thread(
+                self._client.get_object, Bucket=self._bucket, Key=key
+            )
+        except Exception as exc:
+            if _is_missing_key(exc):
+                raise NotFound(f"missing: {key}") from exc
+            raise StorageFailure(str(exc)) from exc
+
+        body = obj["Body"]
+        try:
+            while True:
+                chunk = await asyncio.to_thread(body.read, _CHUNK_SIZE)
+                if not chunk:
+                    break
+                yield chunk
+        finally:
+            await asyncio.to_thread(body.close)
+
+    async def delete(self, key: str) -> None:
+        try:
+            await asyncio.to_thread(
+                self._client.delete_object, Bucket=self._bucket, Key=key
+            )
+        except Exception as exc:
+            if _is_missing_key(exc):
+                return
+            raise StorageFailure(str(exc)) from exc
+
+    async def exists(self, key: str) -> bool:
+        try:
+            await asyncio.to_thread(
+                self._client.head_object, Bucket=self._bucket, Key=key
+            )
+            return True
+        except Exception:
+            return False
+
+    def local_path(self, key: str) -> Path | None:
+        return None
+
+    async def presigned_get(self, key: str, ttl_seconds: int) -> str | None:
+        try:
+            return await asyncio.to_thread(
+                self._client.generate_presigned_url,
+                "get_object",
+                Params={"Bucket": self._bucket, "Key": key},
+                ExpiresIn=int(ttl_seconds),
+            )
+        except Exception:
+            return None
+
+
+def _is_missing_key(exc: Exception) -> bool:
+    """True if ``exc`` looks like an S3 404. Keeps the module importable even
+    when botocore isn't installed (the protocol check is duck-typed)."""
+    response = getattr(exc, "response", None)
+    if not isinstance(response, dict):
+        return False
+    code = response.get("Error", {}).get("Code", "")
+    return code in ("NoSuchKey", "404", "NotFound")

--- a/src/pocketpaw/uploads/s3.py
+++ b/src/pocketpaw/uploads/s3.py
@@ -15,13 +15,21 @@ from __future__ import annotations
 
 import asyncio
 import io
+import logging
 from collections.abc import AsyncIterator
 from pathlib import Path
 
 from pocketpaw.uploads.adapter import StorageAdapter, StoredObject
 from pocketpaw.uploads.errors import NotFound, StorageFailure
 
+logger = logging.getLogger(__name__)
+
 _CHUNK_SIZE = 64 * 1024
+# Above this, in-memory buffering in put() starts eating real RAM. Chat
+# attachments default to 25 MiB, so 64 MiB gives headroom without surprise
+# OOM. If max_file_bytes is raised past this, switch to multipart_upload
+# instead of buffering the whole body.
+_MEM_BUFFER_WARN_BYTES = 64 * 1024 * 1024
 
 
 class S3StorageAdapter(StorageAdapter):
@@ -66,12 +74,16 @@ class S3StorageAdapter(StorageAdapter):
         # memory is fine — swap to multipart_upload later if caps grow.
         buf = io.BytesIO()
         size = 0
-        try:
-            async for chunk in stream:
-                buf.write(chunk)
-                size += len(chunk)
-        except Exception as exc:  # propagate TooLarge etc. untouched
-            raise exc
+        async for chunk in stream:
+            buf.write(chunk)
+            size += len(chunk)
+        if size > _MEM_BUFFER_WARN_BYTES:
+            logger.warning(
+                "S3 put buffering %d bytes in memory for key=%s — "
+                "consider multipart_upload if max_file_bytes was raised",
+                size,
+                key,
+            )
         buf.seek(0)
 
         try:

--- a/src/pocketpaw/uploads/service.py
+++ b/src/pocketpaw/uploads/service.py
@@ -194,6 +194,22 @@ class UploadService:
             raise NotFound()
         return rec, self._adapter.open(rec.storage_key)
 
+    async def presigned_get(
+        self, file_id: str, requester_id: str, ttl_seconds: int
+    ) -> tuple[FileRecord, str | None]:
+        """Return (record, presigned_url_or_None) for ``file_id``.
+
+        Delegates to the adapter's ``presigned_get``. Callers that get ``None``
+        should fall back to their own signing scheme (e.g. HMAC proxy URL).
+        """
+        rec = self._meta.get(file_id)
+        if rec is None:
+            raise NotFound()
+        if rec.owner_id != requester_id:
+            raise NotFound()
+        url = await self._adapter.presigned_get(rec.storage_key, ttl_seconds)
+        return rec, url
+
     async def delete(self, file_id: str, requester_id: str) -> None:
         rec = self._meta.get(file_id)
         if rec is None:

--- a/src/pocketpaw/uploads/signing.py
+++ b/src/pocketpaw/uploads/signing.py
@@ -1,0 +1,54 @@
+"""HMAC-signed short-lived grant tokens for upload access.
+
+A grant binds ``(file_id, expires_unix)`` with an HMAC signature. Clients mint
+grants via an authenticated ``GET /uploads/{id}/grant`` endpoint, then open
+the bytes via ``GET /uploads/{id}?t={token}`` — no Authorization header
+required. That makes signed URLs usable from raw ``<img src>`` / ``<a href
+download>`` attributes, which can't carry a Bearer token.
+
+Token format on the wire: ``{expires_unix}.{hex_hmac}``.
+Signed message: ``{file_id}:{expires_unix}``.
+
+The caller supplies the signing secret so OSS can use the master access token
+and EE can use its JWT signing secret without coupling this module to either.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+
+__all__ = ["DEFAULT_TTL_SECONDS", "sign_grant", "verify_grant"]
+
+DEFAULT_TTL_SECONDS = 300  # 5 minutes — balance between replay risk and UX
+
+
+def sign_grant(
+    file_id: str,
+    secret: str,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+) -> tuple[str, int]:
+    """Mint a grant token for ``file_id``. Returns ``(token, expires_unix)``."""
+    expires = int(time.time()) + int(ttl_seconds)
+    sig = _sign(secret, f"{file_id}:{expires}")
+    return f"{expires}.{sig}", expires
+
+
+def verify_grant(file_id: str, token: str, secret: str) -> bool:
+    """Return True if ``token`` is a live grant for ``file_id``."""
+    if not token or "." not in token:
+        return False
+    expires_str, sig = token.split(".", 1)
+    try:
+        expires = int(expires_str)
+    except ValueError:
+        return False
+    if time.time() > expires:
+        return False
+    expected = _sign(secret, f"{file_id}:{expires}")
+    return hmac.compare_digest(sig, expected)
+
+
+def _sign(secret: str, message: str) -> str:
+    return hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()

--- a/tests/cloud/memory/test_dedup.py
+++ b/tests/cloud/memory/test_dedup.py
@@ -1,0 +1,60 @@
+"""MongoMemoryStore de-duplication against the chat_persistence write path.
+
+The chat endpoint persists the user message the moment it arrives (with
+attachments). The agent loop subsequently calls ``memory.add_to_session``
+with the same content to seed context for the model. Without dedup both
+rows end up in Mongo and the UI renders the user's send twice on reload.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from pocketpaw.memory.protocol import MemoryEntry, MemoryType
+
+
+def _entry(session_key: str, role: str, content: str) -> MemoryEntry:
+    return MemoryEntry(
+        id="",
+        type=MemoryType.SESSION,
+        content=content,
+        role=role,
+        session_key=session_key,
+    )
+
+
+class TestDedup:
+    async def test_second_save_with_same_content_reuses_existing_id(self, store):
+        key = f"sess-{uuid.uuid4().hex[:8]}"
+
+        first_id = await store.save(_entry(key, "user", "hello there"))
+        # Re-saving the identical (session, role, content) within the dedup
+        # window must return the SAME id — i.e. no second row was inserted.
+        second_id = await store.save(_entry(key, "user", "hello there"))
+
+        assert first_id == second_id
+
+    async def test_different_content_is_not_deduped(self, store):
+        key = f"sess-{uuid.uuid4().hex[:8]}"
+
+        first_id = await store.save(_entry(key, "user", "first"))
+        second_id = await store.save(_entry(key, "user", "second"))
+
+        assert first_id != second_id
+
+    async def test_different_session_is_not_deduped(self, store):
+        key_a = f"sess-a-{uuid.uuid4().hex[:8]}"
+        key_b = f"sess-b-{uuid.uuid4().hex[:8]}"
+
+        first_id = await store.save(_entry(key_a, "user", "hello"))
+        second_id = await store.save(_entry(key_b, "user", "hello"))
+
+        assert first_id != second_id
+
+    async def test_different_role_is_not_deduped(self, store):
+        key = f"sess-{uuid.uuid4().hex[:8]}"
+
+        user_id = await store.save(_entry(key, "user", "ping"))
+        asst_id = await store.save(_entry(key, "assistant", "ping"))
+
+        assert user_id != asst_id

--- a/tests/cloud/test_agent_seed_and_dm_persistence.py
+++ b/tests/cloud/test_agent_seed_and_dm_persistence.py
@@ -78,6 +78,41 @@ class TestSeedDefaultAgent:
         assert a1.workspace != a2.workspace
 
 
+class TestEnsureDefaultAgentBackfill:
+    async def test_backfills_existing_workspaces(self, beanie_db) -> None:
+        from ee.cloud.auth.core import ensure_default_agent_all_workspaces
+        from ee.cloud.models.agent import Agent
+        from ee.cloud.models.workspace import Workspace, WorkspaceSettings
+
+        ws1 = Workspace(name="A", slug="a", owner="u-1", settings=WorkspaceSettings())
+        ws2 = Workspace(name="B", slug="b", owner="u-2", settings=WorkspaceSettings())
+        await ws1.insert()
+        await ws2.insert()
+
+        seeded = await ensure_default_agent_all_workspaces()
+        assert seeded == 2
+
+        a1 = await Agent.find_one(Agent.workspace == str(ws1.id), Agent.slug == "pocketpaw")
+        a2 = await Agent.find_one(Agent.workspace == str(ws2.id), Agent.slug == "pocketpaw")
+        assert a1 is not None and a2 is not None
+        assert a1.owner == "u-1"
+        assert a2.owner == "u-2"
+
+    async def test_backfill_is_idempotent(self, beanie_db) -> None:
+        from ee.cloud.auth.core import ensure_default_agent_all_workspaces
+        from ee.cloud.models.agent import Agent
+        from ee.cloud.models.workspace import Workspace, WorkspaceSettings
+
+        ws = Workspace(name="A", slug="a", owner="u-1", settings=WorkspaceSettings())
+        await ws.insert()
+
+        await ensure_default_agent_all_workspaces()
+        await ensure_default_agent_all_workspaces()
+
+        count = await Agent.find(Agent.workspace == str(ws.id), Agent.slug == "pocketpaw").count()
+        assert count == 1
+
+
 class TestSaveUserMessageAttachments:
     async def _session(self, beanie_db, chat_id: str = "sess-1") -> None:
         """Make a pocket session + workspace-bearing user so auto-create works."""
@@ -113,7 +148,7 @@ class TestSaveUserMessageAttachments:
         from ee.cloud.shared.chat_persistence import _session_cache, save_user_message
 
         _session_cache.clear()
-        await self._session(beanie_db)
+        await self._session(beanie_db, chat_id="websocket_sess-1")
 
         attachments = [
             {
@@ -123,11 +158,11 @@ class TestSaveUserMessageAttachments:
                 "meta": {"mime": "image/png", "size": 414255, "id": "abc123"},
             }
         ]
-        await save_user_message("sess-1", "look at this", attachments=attachments)
+        await save_user_message("websocket_sess-1", "look at this", attachments=attachments)
 
         msg = await Message.find_one(
             Message.context_type == "pocket",
-            Message.session_key == "sess-1",
+            Message.session_key == "websocket_sess-1",
         )
         assert msg is not None
         assert msg.content == "look at this"
@@ -144,14 +179,167 @@ class TestSaveUserMessageAttachments:
         from ee.cloud.shared.chat_persistence import _session_cache, save_user_message
 
         _session_cache.clear()
-        await self._session(beanie_db, chat_id="sess-plain")
+        await self._session(beanie_db, chat_id="websocket_sess-plain")
 
-        await save_user_message("sess-plain", "hi")
+        await save_user_message("websocket_sess-plain", "hi")
 
         msg = await Message.find_one(
             Message.context_type == "pocket",
-            Message.session_key == "sess-plain",
+            Message.session_key == "websocket_sess-plain",
         )
+        assert msg is not None
+        assert msg.attachments == []
+
+    async def test_bare_chat_id_normalizes_to_prefixed_session(self, beanie_db) -> None:
+        """``/chat/stream`` strips the ``websocket_`` prefix before writing
+        and ``MongoMemoryStore`` normalizes the bus-form ``"websocket:..."``
+        to ``"websocket_..."`` — ``save_user_message`` must match the latter
+        so the user and assistant messages share a single ``session_key``.
+        """
+        from ee.cloud.models.message import Message
+        from ee.cloud.models.session import Session
+        from ee.cloud.shared.chat_persistence import _session_cache, save_user_message
+
+        _session_cache.clear()
+        # Create the session as POST /sessions would — with the prefixed form.
+        await self._session(beanie_db, chat_id="prefixed-stub")
+        existing = await Session.find_one(Session.sessionId == "prefixed-stub")
+        assert existing is not None
+        existing.sessionId = "websocket_abc123"
+        await existing.save()
+
+        # Client sends "websocket_abc123"; router strips to "abc123" before
+        # calling save_user_message.
+        await save_user_message("abc123", "hello via stripped id")
+
+        # The message should land on the pre-existing prefixed session.
+        msg = await Message.find_one(
+            Message.context_type == "pocket",
+            Message.session_key == "websocket_abc123",
+        )
+        assert msg is not None
+        assert msg.content == "hello via stripped id"
+
+        # And no shadow session with the bare id should have been created.
+        shadow = await Session.find_one(Session.sessionId == "abc123")
+        assert shadow is None
+
+    async def test_already_prefixed_chat_id_is_idempotent(self, beanie_db) -> None:
+        """Callers that already pass the safe-key form must not be prefixed
+        a second time (``websocket_websocket_...``)."""
+        from ee.cloud.models.message import Message
+        from ee.cloud.models.session import Session
+        from ee.cloud.shared.chat_persistence import _session_cache, save_user_message
+
+        _session_cache.clear()
+        await self._session(beanie_db, chat_id="prefixed-stub")
+        existing = await Session.find_one(Session.sessionId == "prefixed-stub")
+        assert existing is not None
+        existing.sessionId = "websocket_xyz789"
+        await existing.save()
+
+        await save_user_message("websocket_xyz789", "already prefixed")
+
+        msg = await Message.find_one(
+            Message.context_type == "pocket",
+            Message.session_key == "websocket_xyz789",
+        )
+        assert msg is not None
+        # Guard against accidental double-prefixing.
+        doubled = await Message.find_one(Message.session_key == "websocket_websocket_xyz789")
+        assert doubled is None
+
+
+class TestMongoMemoryStoreAttachments:
+    """The canonical user-message write path since we removed the duplicate
+    ``chat_persistence.save_user_message`` call out of ``/chat/stream``.
+    Attachments arrive via ``entry.metadata["attachments"]`` (piped through
+    InboundMessage → agent loop → memory), and MongoMemoryStore persists
+    them on the same row as the content — not a second row."""
+
+    async def _session(self, workspace_id: str = "ws-1") -> str:
+        from ee.cloud.models.session import Session
+        from ee.cloud.models.user import User, WorkspaceMembership
+
+        user = User(
+            email="m@example.com",
+            hashed_password="x",
+            is_active=True,
+            is_verified=True,
+            name="m",
+            workspaces=[WorkspaceMembership(workspace=workspace_id, role="owner")],
+        )
+        await user.insert()
+        session = Session(
+            sessionId="websocket_mm-1",
+            context_type="pocket",
+            workspace=workspace_id,
+            owner=str(user.id),
+            title="Chat",
+        )
+        await session.insert()
+        return str(user.id)
+
+    async def test_attachments_from_metadata_persist_on_single_row(self, beanie_db) -> None:
+        from ee.cloud.memory.mongo_store import MongoMemoryStore
+        from ee.cloud.models.message import Message
+        from pocketpaw.memory.protocol import MemoryEntry, MemoryType
+
+        await self._session()
+
+        store = MongoMemoryStore()
+        entry = MemoryEntry(
+            id="",
+            type=MemoryType.SESSION,
+            content="What do you see in this image?",
+            role="user",
+            session_key="websocket:mm-1",
+            metadata={
+                "attachments": [
+                    {
+                        "type": "image",
+                        "url": "/api/v1/uploads/abc",
+                        "name": "chart.png",
+                        "meta": {"mime": "image/png", "size": 137747, "id": "abc"},
+                    }
+                ]
+            },
+        )
+        await store.save(entry)
+
+        rows = await Message.find(
+            Message.context_type == "pocket",
+            Message.session_key == "websocket_mm-1",
+        ).to_list()
+        assert len(rows) == 1, f"expected a single message row, got {len(rows)}"
+        [msg] = rows
+        assert msg.content == "What do you see in this image?"
+        assert len(msg.attachments) == 1
+        att = msg.attachments[0]
+        assert att.type == "image"
+        assert att.url == "/api/v1/uploads/abc"
+        assert att.name == "chart.png"
+        assert att.meta["size"] == 137747
+
+    async def test_no_attachments_key_yields_empty_list(self, beanie_db) -> None:
+        from ee.cloud.memory.mongo_store import MongoMemoryStore
+        from ee.cloud.models.message import Message
+        from pocketpaw.memory.protocol import MemoryEntry, MemoryType
+
+        await self._session()
+
+        store = MongoMemoryStore()
+        entry = MemoryEntry(
+            id="",
+            type=MemoryType.SESSION,
+            content="just text",
+            role="user",
+            session_key="websocket:mm-1",
+            metadata={},
+        )
+        await store.save(entry)
+
+        msg = await Message.find_one(Message.session_key == "websocket_mm-1")
         assert msg is not None
         assert msg.attachments == []
 

--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -297,3 +297,29 @@ class TestSendMessageResolvesMedia:
         assert msg.media == ["/already/here.pdf"]
         # Passthrough entries yield no media_info; key should be absent.
         assert "media_info" not in msg.metadata
+
+
+class TestChatRequestAliases:
+    """Frontends (paw-enterprise) post camelCase keys. Without an alias config
+    Pydantic silently drops ``sessionId`` / ``agentId`` — this causes every
+    request to be treated as a new conversation and the server spawns a fresh
+    chat id. These tests pin the alias behaviour so the regression stays dead.
+    """
+
+    def test_camelcase_session_id_binds(self):
+        from pocketpaw.api.v1.schemas.chat import ChatRequest
+
+        req = ChatRequest.model_validate({"content": "hi", "sessionId": "websocket_abc"})
+        assert req.session_id == "websocket_abc"
+
+    def test_snake_case_session_id_still_binds(self):
+        from pocketpaw.api.v1.schemas.chat import ChatRequest
+
+        req = ChatRequest.model_validate({"content": "hi", "session_id": "websocket_abc"})
+        assert req.session_id == "websocket_abc"
+
+    def test_camelcase_agent_id_binds(self):
+        from pocketpaw.api.v1.schemas.chat import ChatRequest
+
+        req = ChatRequest.model_validate({"content": "hi", "agentId": "agent-123"})
+        assert req.agent_id == "agent-123"

--- a/tests/uploads/test_factory.py
+++ b/tests/uploads/test_factory.py
@@ -1,0 +1,70 @@
+"""Tests for the upload adapter factory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.uploads.factory import build_adapter
+from pocketpaw.uploads.local import LocalStorageAdapter
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Stub out the factory's defensive ``load_dotenv`` so tests don't see
+    S3 config leaking in from the dev machine's ``.env``. Also clear the
+    upload-related env vars so each test starts from a clean slate.
+    """
+    import pocketpaw.uploads.factory as factory_module
+
+    # load_dotenv is imported lazily inside build_adapter; patch the symbol
+    # in dotenv itself so the lazy import inside the factory is a no-op.
+    try:
+        import dotenv
+
+        monkeypatch.setattr(dotenv, "load_dotenv", lambda *a, **kw: False)
+    except ImportError:
+        pass
+    _ = factory_module  # keep the import live so monkeypatch has scope
+    for var in (
+        "POCKETPAW_UPLOAD_ADAPTER",
+        "S3_PRIVATE_BUCKET",
+        "S3_BUCKET",
+        "S3_REGION",
+        "S3_ENDPOINT",
+        "S3_ACCESS_KEY_ID",
+        "S3_SECRET_ACCESS_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_defaults_to_local(tmp_path: Path):
+    adapter = build_adapter(tmp_path)
+    assert isinstance(adapter, LocalStorageAdapter)
+
+
+def test_explicit_local(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+    adapter = build_adapter(tmp_path)
+    assert isinstance(adapter, LocalStorageAdapter)
+
+
+def test_s3_requires_bucket(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "s3")
+    with pytest.raises(RuntimeError, match="S3_PRIVATE_BUCKET"):
+        build_adapter(tmp_path)
+
+
+def test_s3_mode_builds_s3_adapter(tmp_path: Path, monkeypatch):
+    # Skip if boto3 isn't available (OSS installs without enterprise extra).
+    pytest.importorskip("boto3")
+    from pocketpaw.uploads.s3 import S3StorageAdapter
+
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "s3")
+    monkeypatch.setenv("S3_PRIVATE_BUCKET", "test-bucket")
+    monkeypatch.setenv("S3_REGION", "us-east-1")
+    monkeypatch.setenv("S3_ACCESS_KEY_ID", "AKIA_TEST")
+    monkeypatch.setenv("S3_SECRET_ACCESS_KEY", "test-secret")
+    adapter = build_adapter(tmp_path)
+    assert isinstance(adapter, S3StorageAdapter)

--- a/tests/uploads/test_router.py
+++ b/tests/uploads/test_router.py
@@ -89,6 +89,73 @@ def test_get_missing_id_is_404(client: TestClient):
     assert r.status_code == 404
 
 
+def test_grant_returns_signed_url_that_fetches_bytes(client: TestClient, monkeypatch):
+    # Pin the master token so the grant's HMAC key is deterministic for the
+    # duration of the test. The dashboard middleware reads ``get_access_token``
+    # from the same module, so stubbing it in both call sites keeps the
+    # token-signing key and the verifier aligned.
+    from pocketpaw import dashboard_auth
+    from pocketpaw.api.v1 import uploads as uploads_module
+
+    monkeypatch.setattr(uploads_module, "get_access_token", lambda: "test-secret")
+    monkeypatch.setattr(dashboard_auth, "get_access_token", lambda: "test-secret")
+
+    r = client.post(
+        "/api/v1/uploads",
+        files=[("files", ("cat.png", PNG, "image/png"))],
+    )
+    fid = r.json()["uploaded"][0]["id"]
+
+    g = client.get(f"/api/v1/uploads/{fid}/grant")
+    assert g.status_code == 200
+    body = g.json()
+    assert body["url"].startswith(f"/api/v1/uploads/{fid}?t=")
+    assert body["expires_at"] > 0
+
+    # The signed URL fetches bytes. The isolated TestClient app doesn't mount
+    # AuthMiddleware, so middleware-level signature verification is exercised
+    # separately in test_signing.py — here we just confirm the handler honors
+    # the token query param without erroring.
+    r2 = client.get(body["url"])
+    assert r2.status_code == 200
+    assert r2.content == PNG
+
+
+def test_grant_missing_file_is_404(client: TestClient):
+    r = client.get("/api/v1/uploads/does-not-exist/grant")
+    assert r.status_code == 404
+
+
+def test_grant_returns_adapter_presigned_url_when_available(
+    client: TestClient, monkeypatch
+):
+    """When the storage adapter returns a presigned URL (S3/GCS), the grant
+    endpoint proxies it verbatim — no HMAC fallback, no signature query param.
+    """
+    from pocketpaw.api.v1 import uploads as uploads_module
+
+    r = client.post(
+        "/api/v1/uploads",
+        files=[("files", ("cat.png", PNG, "image/png"))],
+    )
+    fid = r.json()["uploaded"][0]["id"]
+
+    async def fake_presigned(self, file_id, requester_id, ttl_seconds):
+        rec = self._meta.get(file_id)
+        return rec, f"https://s3.example.com/bucket/{rec.storage_key}?X-Amz-Signature=abc"
+
+    monkeypatch.setattr(
+        type(uploads_module._SVC), "presigned_get", fake_presigned
+    )
+
+    g = client.get(f"/api/v1/uploads/{fid}/grant")
+    assert g.status_code == 200
+    body = g.json()
+    assert body["url"].startswith("https://s3.example.com/bucket/")
+    assert "X-Amz-Signature" in body["url"]
+    assert body["expires_at"] > 0
+
+
 def test_docx_gets_attachment_disposition(client: TestClient):
     docx = b"PK\x03\x04" + b"rest"
     r = client.post(

--- a/tests/uploads/test_s3_adapter.py
+++ b/tests/uploads/test_s3_adapter.py
@@ -1,0 +1,139 @@
+"""Unit tests for S3StorageAdapter.
+
+Mocks the boto3 client directly rather than spinning up moto — the adapter's
+job is to translate the Protocol methods into the right boto calls, plus
+exception mapping. Integration coverage against real S3 is out of scope.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("boto3")
+
+from pocketpaw.uploads.errors import NotFound, StorageFailure  # noqa: E402
+from pocketpaw.uploads.s3 import S3StorageAdapter  # noqa: E402
+
+
+def _make_adapter(client: MagicMock) -> S3StorageAdapter:
+    adapter = S3StorageAdapter.__new__(S3StorageAdapter)
+    adapter._bucket = "test-bucket"  # type: ignore[attr-defined]
+    adapter._client = client  # type: ignore[attr-defined]
+    return adapter
+
+
+async def _collect(gen):
+    return b"".join([chunk async for chunk in gen])
+
+
+async def _aiter(chunks):
+    for c in chunks:
+        yield c
+
+
+async def test_put_uploads_full_body_and_returns_metadata():
+    client = MagicMock()
+    adapter = _make_adapter(client)
+
+    obj = await adapter.put("chat/2026-04/abcd.png", _aiter([b"hello", b" world"]), "image/png")
+
+    assert obj.key == "chat/2026-04/abcd.png"
+    assert obj.size == 11
+    assert obj.mime == "image/png"
+    client.put_object.assert_called_once()
+    kwargs = client.put_object.call_args.kwargs
+    assert kwargs["Bucket"] == "test-bucket"
+    assert kwargs["Key"] == "chat/2026-04/abcd.png"
+    assert kwargs["ContentType"] == "image/png"
+    # Body is the buffered BytesIO; read it back to verify bytes.
+    assert kwargs["Body"].getvalue() == b"hello world"
+
+
+async def test_put_wraps_client_errors_as_storage_failure():
+    client = MagicMock()
+    client.put_object.side_effect = RuntimeError("boom")
+    adapter = _make_adapter(client)
+
+    with pytest.raises(StorageFailure, match="boom"):
+        await adapter.put("k", _aiter([b"x"]), "text/plain")
+
+
+async def test_open_streams_chunks():
+    client = MagicMock()
+    body = MagicMock()
+    body.read.side_effect = [b"abc", b"def", b""]
+    client.get_object.return_value = {"Body": body}
+    adapter = _make_adapter(client)
+
+    data = await _collect(adapter.open("k"))
+
+    assert data == b"abcdef"
+    body.close.assert_called_once()
+
+
+async def test_open_missing_key_raises_not_found():
+    class _ClientError(Exception):
+        def __init__(self):
+            super().__init__("nope")
+            self.response = {"Error": {"Code": "NoSuchKey"}}
+
+    client = MagicMock()
+    client.get_object.side_effect = _ClientError()
+    adapter = _make_adapter(client)
+
+    with pytest.raises(NotFound):
+        await _collect(adapter.open("missing"))
+
+
+async def test_delete_is_idempotent_on_missing():
+    class _ClientError(Exception):
+        def __init__(self):
+            super().__init__("nope")
+            self.response = {"Error": {"Code": "NoSuchKey"}}
+
+    client = MagicMock()
+    client.delete_object.side_effect = _ClientError()
+    adapter = _make_adapter(client)
+
+    # Should not raise.
+    await adapter.delete("missing")
+
+
+async def test_exists_true_and_false():
+    client = MagicMock()
+    client.head_object.return_value = {}
+    adapter = _make_adapter(client)
+    assert await adapter.exists("k") is True
+
+    client.head_object.side_effect = RuntimeError("404")
+    assert await adapter.exists("k") is False
+
+
+async def test_presigned_get_returns_url():
+    client = MagicMock()
+    client.generate_presigned_url.return_value = "https://s3.example.com/signed"
+    adapter = _make_adapter(client)
+
+    url = await adapter.presigned_get("k", 300)
+
+    assert url == "https://s3.example.com/signed"
+    client.generate_presigned_url.assert_called_once_with(
+        "get_object",
+        Params={"Bucket": "test-bucket", "Key": "k"},
+        ExpiresIn=300,
+    )
+
+
+async def test_presigned_get_swallows_errors():
+    client = MagicMock()
+    client.generate_presigned_url.side_effect = RuntimeError("boom")
+    adapter = _make_adapter(client)
+
+    assert await adapter.presigned_get("k", 300) is None
+
+
+def test_local_path_returns_none():
+    adapter = _make_adapter(MagicMock())
+    assert adapter.local_path("any") is None

--- a/tests/uploads/test_signing.py
+++ b/tests/uploads/test_signing.py
@@ -1,0 +1,42 @@
+"""Unit tests for upload grant signing."""
+
+from __future__ import annotations
+
+import time
+
+from pocketpaw.uploads.signing import sign_grant, verify_grant
+
+
+def test_sign_and_verify_roundtrip():
+    token, exp = sign_grant("file-1", "secret")
+    assert verify_grant("file-1", token, "secret")
+    assert exp > int(time.time())
+
+
+def test_reject_wrong_file_id():
+    token, _ = sign_grant("file-1", "secret")
+    assert not verify_grant("file-2", token, "secret")
+
+
+def test_reject_wrong_secret():
+    token, _ = sign_grant("file-1", "secret")
+    assert not verify_grant("file-1", token, "other")
+
+
+def test_reject_malformed_token():
+    assert not verify_grant("file-1", "not-a-token", "secret")
+    assert not verify_grant("file-1", "", "secret")
+    assert not verify_grant("file-1", "abc.def.ghi", "secret")
+    assert not verify_grant("file-1", "notanumber.deadbeef", "secret")
+
+
+def test_reject_expired():
+    token, _ = sign_grant("file-1", "secret", ttl_seconds=-1)
+    assert not verify_grant("file-1", token, "secret")
+
+
+def test_sig_not_stripped_across_file_ids():
+    # Two files share the same exp but produce distinct signatures.
+    t1, _ = sign_grant("file-1", "secret", ttl_seconds=60)
+    t2, _ = sign_grant("file-2", "secret", ttl_seconds=60)
+    assert t1 != t2


### PR DESCRIPTION
## Summary

- Adds an **S3 StorageAdapter** (reuses interacly-backend's `S3_*` env names) and a factory (`POCKETPAW_UPLOAD_ADAPTER=s3|local`) so uploads can land in object storage without changing call sites.
- Adds **signed grant URLs** so `<img src>` and `<a download>` work against auth-gated uploads: `/uploads/{id}/grant` returns the adapter's native presigned URL (S3) when available, else an HMAC-signed proxy URL through this service.
- Resolver now **materializes remote blobs** to a local cache so the agent loop keeps receiving a real disk path even when bytes live in S3.
- Fixes a pre-existing **dual-write** that duplicated the user's message on reload: `MongoMemoryStore.save` now skips inserts inside a 30s window when `chat_persistence` has already persisted the same `(session_key, role, content)`.

## Test plan

- [x] `tests/uploads/test_signing.py` — HMAC token sign/verify, expiry, wrong file/secret, malformed tokens
- [x] `tests/uploads/test_s3_adapter.py` — put / open / delete / exists / presigned_get against a mocked boto client
- [x] `tests/uploads/test_factory.py` — env-driven adapter selection + missing-bucket guard
- [x] `tests/uploads/test_router.py` — grant endpoint: HMAC fallback path + adapter-native presigned URL path
- [x] `tests/cloud/memory/test_dedup.py` — dedup window respects content / session / role boundaries
- [x] Full upload + memory + chat persistence suites green locally (124 passing on the affected surface)
- [ ] Manual: set `POCKETPAW_UPLOAD_ADAPTER=s3` + S3 creds, upload an image, verify the frontend's `/grant` call returns an `https://…?X-Amz-Signature=…` URL and the image renders without an `Authorization` header
- [ ] Manual: send a DM with an attachment; refresh; assert the user message appears exactly once with the attachment still attached

## Notes

- Local disk mode remains the default — S3 is opt-in via env.
- Boto3 is already in the `enterprise` extra; no new dependencies.
- The design doc (`docs/plans/2026-04-16-upload-adapter.md`) pre-dated this branch and is committed here as the canonical scope for this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)