### PR TITLE
fix(cloud): add group.joined so new members see the group without refresh

### DIFF
--- a/ee/cloud/chat/group_service.py
+++ b/ee/cloud/chat/group_service.py
@@ -26,6 +26,7 @@ from ee.cloud.realtime.events import (
     GroupAgentRemoved,
     GroupAgentUpdated,
     GroupCreated,
+    GroupJoined,
     GroupMemberAdded,
     GroupMemberRemoved,
     GroupMemberRole,
@@ -341,6 +342,11 @@ class GroupService:
             await emit(
                 GroupMemberAdded(data={"group_id": group_id, "user_id": user_id, "role": "edit"})
             )
+            # The joining user has no local record of this group yet — a
+            # ``group.joined`` (audience = just them) hydrates the room in their
+            # sidebar so they don't have to refresh to see it.
+            resp = await _group_response(group)
+            await emit(GroupJoined(data={**resp, "member_ids": [user_id]}))
             get_resolver().invalidate_group(group_id)
 
     @staticmethod
@@ -400,6 +406,11 @@ class GroupService:
                 )
             )
         if newly_added:
+            # Newly-added members have no local record of this group yet — a
+            # ``group.joined`` (audience = just the new ids) hydrates the room
+            # in their sidebars so they don't have to refresh to see it.
+            resp = await _group_response(group)
+            await emit(GroupJoined(data={**resp, "member_ids": newly_added}))
             get_resolver().invalidate_group(group_id)
 
         return newly_added

--- a/ee/cloud/chat/router.py
+++ b/ee/cloud/chat/router.py
@@ -124,11 +124,6 @@ async def add_members(
     user_id: str = Depends(current_user_id),
 ):
     added = await GroupService.add_members(group_id, user_id, body.user_ids, body.role)
-    await _broadcast_members_event(
-        group_id,
-        "members.added",
-        {"group_id": group_id, "user_ids": added, "role": body.role},
-    )
     return {"ok": True, "added": added}
 
 
@@ -143,11 +138,6 @@ async def remove_member(
     user_id: str = Depends(current_user_id),
 ):
     await GroupService.remove_member(group_id, user_id, target_user_id)
-    await _broadcast_members_event(
-        group_id,
-        "members.removed",
-        {"group_id": group_id, "user_id": target_user_id},
-    )
 
 
 @_licensed.patch(
@@ -161,11 +151,6 @@ async def update_member_role(
     user_id: str = Depends(current_user_id),
 ):
     new_role = await GroupService.set_member_role(group_id, user_id, target_user_id, body.role)
-    await _broadcast_members_event(
-        group_id,
-        "members.role_changed",
-        {"group_id": group_id, "user_id": target_user_id, "role": new_role},
-    )
     return {"ok": True, "role": new_role}
 
 
@@ -341,26 +326,6 @@ router.include_router(_licensed)
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-async def _broadcast_members_event(group_id: str, event_type: str, data: dict) -> None:
-    """Broadcast a member/role change to all current group members.
-
-    Loads the group freshly so the broadcast reflects post-mutation membership
-    (a removed user, for example, no longer receives the event).
-    """
-    from beanie import PydanticObjectId
-
-    from ee.cloud.models.group import Group
-
-    group = await Group.get(PydanticObjectId(group_id))
-    if not group:
-        return
-    await manager.broadcast_to_group(
-        group_id,
-        group.members,
-        WsOutbound(type=event_type, data=data),
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/ee/cloud/realtime/audience.py
+++ b/ee/cloud/realtime/audience.py
@@ -91,6 +91,11 @@ class AudienceResolver:
         if t == "group.member_removed":
             members = await self._group(d["group_id"])
             return list({*members, d["user_id"]})
+        if t == "group.joined":
+            # Scoped hydration event: audience is exactly the new user(s)
+            # carried in ``member_ids``. Existing members already have the
+            # room and receive ``group.member_added`` instead.
+            return list(d.get("member_ids", []))
         if t == "group.unread_delta":
             return [d["user_id"]]
 

--- a/ee/cloud/realtime/events.py
+++ b/ee/cloud/realtime/events.py
@@ -80,6 +80,18 @@ class GroupMemberAdded(Event):
 
 
 @dataclass
+class GroupJoined(Event):
+    """Full group payload delivered only to a newly-added user.
+
+    Lets the recipient's sidebar insert the room without a manual refresh.
+    Existing members don't need this (they already have the room); they
+    receive ``GroupMemberAdded`` instead.
+    """
+
+    EVENT_TYPE: ClassVar[str] = "group.joined"
+
+
+@dataclass
 class GroupMemberRemoved(Event):
     EVENT_TYPE: ClassVar[str] = "group.member_removed"
 

--- a/tests/cloud/chat/test_group_emits.py
+++ b/tests/cloud/chat/test_group_emits.py
@@ -18,6 +18,7 @@ from ee.cloud.realtime.events import (
     GroupAgentRemoved,
     GroupAgentUpdated,
     GroupCreated,
+    GroupJoined,
     GroupMemberAdded,
     GroupMemberRemoved,
     GroupMemberRole,
@@ -186,6 +187,7 @@ async def test_join_group_emits_member_added_and_invalidates_cache():
 
     with (
         patch("ee.cloud.chat.group_service.emit", new=fake_emit),
+        patch("ee.cloud.chat.group_service._group_response", new=_fake_group_response),
         patch(
             "ee.cloud.chat.group_service._get_group_or_404",
             new=AsyncMock(return_value=group),
@@ -197,6 +199,12 @@ async def test_join_group_emits_member_added_and_invalidates_cache():
     events = [e for e in recorded if isinstance(e, GroupMemberAdded)]
     assert len(events) == 1
     assert events[0].data == {"group_id": "g1", "user_id": "u2", "role": "edit"}
+    # group.joined — audience scoped to the joining user so their sidebar
+    # hydrates the room without a manual refresh.
+    joined = [e for e in recorded if isinstance(e, GroupJoined)]
+    assert len(joined) == 1
+    assert joined[0].data["member_ids"] == ["u2"]
+    assert joined[0].data["_id"] == "g1"
     resolver_mock.invalidate_group.assert_called_once_with("g1")
 
 
@@ -266,6 +274,7 @@ async def test_add_members_emits_one_event_per_newly_added_user():
 
     with (
         patch("ee.cloud.chat.group_service.emit", new=fake_emit),
+        patch("ee.cloud.chat.group_service._group_response", new=_fake_group_response),
         patch(
             "ee.cloud.chat.group_service._get_group_or_404",
             new=AsyncMock(return_value=group),
@@ -281,6 +290,12 @@ async def test_add_members_emits_one_event_per_newly_added_user():
     for ev in events:
         assert ev.data["group_id"] == "g1"
         assert ev.data["role"] == "edit"
+    # One group.joined scoped to the newly-added user ids so their sidebars
+    # hydrate the room without refreshing.
+    joined = [e for e in recorded if isinstance(e, GroupJoined)]
+    assert len(joined) == 1
+    assert joined[0].data["member_ids"] == ["u2", "u3", "u4"]
+    assert joined[0].data["_id"] == "g1"
     resolver_mock.invalidate_group.assert_called_once_with("g1")
 
 


### PR DESCRIPTION
## Summary
- Introduce scoped ``group.joined`` event carrying the full populated group payload
- ``GroupService.add_members`` + ``join_group`` emit it targeting only newly-added users so their sidebars hydrate live (existing members keep getting ``group.member_added`` only)
- Drop the dead ``_broadcast_members_event`` helper in ``chat/router.py`` — it broadcast ``members.added``/``members.removed``/``members.role_changed``, names no frontend listens for, duplicating what the realtime bus already emits

## Why
Adding a user to a group correctly fired ``group.member_added`` to the new user, but their frontend had no room to mutate yet — the room only materializes on a full groups refresh — so the sidebar silently stayed empty until the user hit reload. ``group.joined`` delivers the whole group payload (members, agents, metadata) only to the people who need it.

## Test plan
- [x] ``uv run pytest tests/cloud/chat/ tests/cloud/realtime/`` — 63 passed
- [ ] Add a user to a private group; their sidebar shows the room without a refresh
- [ ] Existing members still see ``group.member_added`` and update their member list in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)