### PR TITLE
feat(retrieval): land Router + InMemoryCredentialBroker + ProjectionAdapter from soul-protocol 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -407,3 +407,16 @@ dev = [
 asyncio_mode = "auto"
 testpaths = ["tests"]
 addopts = "--ignore=tests/cloud --ignore=tests/e2e"
+
+# ---------------------------------------------------------------------------
+# Local dogfood override — REMOVE BEFORE RELEASE
+# ---------------------------------------------------------------------------
+# feat/receive-retrieval-infra lands ahead of soul-protocol 0.3.2 publishing
+# to PyPI. Until that publish, uv resolves soul-protocol from the sibling
+# ../soul-protocol checkout so the new spec/retrieval surface (Credential,
+# CredentialBroker, SourceAdapter, RetrievalError hierarchy) is importable.
+# When 0.3.2 is on PyPI: (a) bump the soul-protocol pin in [project]
+# dependencies to ^0.3.2, (b) DELETE this section, (c) `uv lock --upgrade
+# soul-protocol`. CI will fail on this branch until the pin is swapped.
+[tool.uv.sources]
+soul-protocol = { path = "../soul-protocol", editable = true }

--- a/src/pocketpaw/connectors/drive/auth.py
+++ b/src/pocketpaw/connectors/drive/auth.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import logging
 import os
 
-from soul_protocol.engine.retrieval import Credential
+from soul_protocol.spec.retrieval import Credential
 
 from .errors import DriveAuthError
 

--- a/src/pocketpaw/connectors/drive/source.py
+++ b/src/pocketpaw/connectors/drive/source.py
@@ -30,8 +30,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from soul_protocol.engine.retrieval import Credential
-from soul_protocol.spec.retrieval import RetrievalCandidate, RetrievalRequest
+from soul_protocol.spec.retrieval import Credential, RetrievalCandidate, RetrievalRequest
 
 from .auth import resolve_bearer_token
 from .client import DriveClient, DriveFile, DriveRevision

--- a/src/pocketpaw/retrieval/__init__.py
+++ b/src/pocketpaw/retrieval/__init__.py
@@ -1,0 +1,21 @@
+# __init__.py — pocketpaw.retrieval: the runtime infrastructure for fanning
+# out retrieval across registered SourceAdapters.
+# Created: feat/receive-retrieval-infra (2026-04-19) — soul-protocol 0.3.2
+# pruned engine/retrieval/ and kept only the vocabulary (Protocols + types +
+# exceptions) in soul_protocol.spec.retrieval. This module is where the
+# concrete orchestration (Router, broker impl, callable-wrapping adapter,
+# test helpers) now lives. Spec imports come from soul_protocol.spec —
+# this module implements against them.
+
+from __future__ import annotations
+
+from .adapters import MockAdapter, ProjectionAdapter
+from .broker import InMemoryCredentialBroker
+from .router import RetrievalRouter
+
+__all__ = [
+    "InMemoryCredentialBroker",
+    "MockAdapter",
+    "ProjectionAdapter",
+    "RetrievalRouter",
+]

--- a/src/pocketpaw/retrieval/__init__.py
+++ b/src/pocketpaw/retrieval/__init__.py
@@ -1,5 +1,9 @@
 # __init__.py — pocketpaw.retrieval: the runtime infrastructure for fanning
 # out retrieval across registered SourceAdapters.
+# Updated: feat/receive-retrieval-infra (review pass) — MockAdapter demoted
+# out of the public __all__ surface. It is a test helper and remains
+# importable from pocketpaw.retrieval.adapters for suites that want it,
+# but should not appear in hover / IDE discovery for production callers.
 # Created: feat/receive-retrieval-infra (2026-04-19) — soul-protocol 0.3.2
 # pruned engine/retrieval/ and kept only the vocabulary (Protocols + types +
 # exceptions) in soul_protocol.spec.retrieval. This module is where the
@@ -9,13 +13,12 @@
 
 from __future__ import annotations
 
-from .adapters import MockAdapter, ProjectionAdapter
+from .adapters import ProjectionAdapter
 from .broker import InMemoryCredentialBroker
 from .router import RetrievalRouter
 
 __all__ = [
     "InMemoryCredentialBroker",
-    "MockAdapter",
     "ProjectionAdapter",
     "RetrievalRouter",
 ]

--- a/src/pocketpaw/retrieval/adapters.py
+++ b/src/pocketpaw/retrieval/adapters.py
@@ -1,0 +1,88 @@
+# adapters.py — Concrete test + projection adapter implementations.
+# Updated: feat/receive-retrieval-infra (2026-04-19) — moved here from
+# soul-protocol/engine/retrieval/adapters.py as part of the 0.3.2 split.
+# The `SourceAdapter` and `AsyncSourceAdapter` Protocols now live in
+# soul_protocol.spec.retrieval (the language-agnostic standard); this
+# file keeps only the two concrete implementations — application-layer,
+# not part of the standard.
+#
+# Two concrete adapters live here:
+#   * `MockAdapter` — returns fixed candidates and tracks invocations. Pure
+#     test fixture; re-exported by __init__.py for tests that want to build
+#     against it without reaching into the module path.
+#   * `ProjectionAdapter` — wraps a callable so soul memory, kb, and fabric
+#     can plug in without each building a class. Represents the
+#     "local rebuilt view" case.
+#
+# External federation adapters (Drive, Salesforce, ...) live under
+# src/pocketpaw/connectors/<source>/ and implement the SourceAdapter
+# Protocol from the spec directly.
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from soul_protocol.spec.retrieval import Credential, RetrievalCandidate, RetrievalRequest
+
+
+class MockAdapter:
+    """Test adapter. Returns a fixed list, records every call.
+
+    Parameters:
+        candidates: What to return on `query`.
+        delay_s: If >0, sleeps that long before returning. Lets tests
+            exercise the router's per-source timeout path.
+        raises: If set, raises this exception instead of returning.
+    """
+
+    supports_dataref: bool = False
+
+    def __init__(
+        self,
+        candidates: list[RetrievalCandidate] | None = None,
+        *,
+        delay_s: float = 0.0,
+        raises: Exception | None = None,
+    ) -> None:
+        self._candidates = candidates or []
+        self._delay_s = delay_s
+        self._raises = raises
+        self.calls: list[tuple[RetrievalRequest, Credential | None]] = []
+
+    def query(
+        self,
+        request: RetrievalRequest,
+        credential: Credential | None,
+    ) -> list[RetrievalCandidate]:
+        self.calls.append((request, credential))
+        if self._delay_s > 0:
+            import time
+
+            time.sleep(self._delay_s)
+        if self._raises is not None:
+            raise self._raises
+        return list(self._candidates)
+
+
+class ProjectionAdapter:
+    """Adapter over a plain callable — the "local rebuilt view" shape.
+
+    Soul memory, kb, and fabric all live inside the same Paw OS instance
+    the router runs in. They don't need federation or credentials. A
+    callable that takes the request and returns candidates is enough.
+    """
+
+    supports_dataref: bool = False
+
+    def __init__(
+        self,
+        fn: Callable[[RetrievalRequest], list[RetrievalCandidate]],
+    ) -> None:
+        self._fn = fn
+
+    def query(
+        self,
+        request: RetrievalRequest,
+        credential: Credential | None,  # noqa: ARG002 — projection ignores creds
+    ) -> list[RetrievalCandidate]:
+        return list(self._fn(request))

--- a/src/pocketpaw/retrieval/broker.py
+++ b/src/pocketpaw/retrieval/broker.py
@@ -1,0 +1,135 @@
+# broker.py — InMemoryCredentialBroker: reference implementation of the
+# CredentialBroker Protocol from soul_protocol.spec.retrieval.
+# Updated: feat/receive-retrieval-infra (2026-04-19) — moved here from
+# soul-protocol/engine/retrieval/broker.py as part of the 0.3.2 split. The
+# Credential data class and CredentialBroker Protocol now live in
+# soul_protocol.spec.retrieval (the standard); this file keeps only the
+# concrete in-memory broker — application-layer, not part of the standard.
+# Credential lifecycle journal emits remain fail-closed: if a journal is
+# attached and append raises, the exception surfaces to the caller instead
+# of silently issuing / using / revoking a credential that never made it
+# into the audit trail.
+#
+# The broker mints short-lived credentials for external sources (Drive,
+# Salesforce, Snowflake, ...). Scoped per DSP scope so a credential
+# acquired for `org:sales:*` cannot be reused by a requester operating in
+# `org:support:*`. Every acquire/use/expire emits a journal event when a
+# journal is attached — that's the audit trail Zero-Copy federation
+# depends on.
+#
+# `InMemoryCredentialBroker` is the reference impl. Production deployments
+# swap in a broker backed by the platform's real secret store; this class
+# is the one the tests and local dev use.
+
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+from soul_protocol.engine.journal import Journal, scopes_overlap
+from soul_protocol.spec.journal import Actor, EventEntry
+from soul_protocol.spec.retrieval import (
+    Credential,
+    CredentialExpiredError,
+    CredentialScopeError,
+)
+
+DEFAULT_TTL_S: float = 300.0
+
+# Back-compat alias for tests / callers that imported the private helper from
+# this module before it moved into the public journal module. The semantics
+# are the same; see `soul_protocol.engine.journal.scope.scopes_overlap` for
+# the pinned policy (wildcard-grant vs specific-requester AND vice versa).
+_scopes_overlap = scopes_overlap
+
+
+class InMemoryCredentialBroker:
+    """Reference broker. Not persistent, not distributed — fine for
+    single-process Paw OS instances and tests."""
+
+    def __init__(
+        self,
+        *,
+        ttl_s: float = DEFAULT_TTL_S,
+        journal: Journal | None = None,
+        broker_actor: Actor | None = None,
+    ) -> None:
+        self._ttl_s = ttl_s
+        self._journal = journal
+        self._actor = broker_actor or Actor(kind="system", id="system:credential-broker")
+        self._active: dict[UUID, Credential] = {}
+
+    # -- lifecycle --------------------------------------------------------
+
+    def acquire(self, source: str, scopes: list[str]) -> Credential:
+        now = datetime.now(UTC)
+        cred = Credential(
+            source=source,
+            scopes=list(scopes),
+            token=secrets.token_urlsafe(16),
+            acquired_at=now,
+            expires_at=now + timedelta(seconds=self._ttl_s),
+        )
+        # Emit FIRST. If the audit append fails under the fail-closed policy,
+        # the credential never enters `_active` and the caller gets the
+        # exception — no orphan credentials hanging around post-failure.
+        self._emit("credential.acquired", cred)
+        self._active[cred.id] = cred
+        return cred
+
+    def ensure_usable(self, credential: Credential, requester_scopes: list[str]) -> None:
+        if credential.is_expired():
+            # Surface through the journal once, then forget the credential.
+            if credential.id in self._active:
+                self._emit("credential.expired", credential)
+                self._active.pop(credential.id, None)
+            raise CredentialExpiredError(
+                f"credential {credential.id} for {credential.source} expired at "
+                f"{credential.expires_at.isoformat()}"
+            )
+        if not scopes_overlap(credential.scopes, requester_scopes):
+            raise CredentialScopeError(
+                f"credential {credential.id} scoped to {credential.scopes} "
+                f"cannot be used by requester with scopes {requester_scopes}"
+            )
+
+    def mark_used(self, credential: Credential) -> None:
+        credential.last_used_at = datetime.now(UTC)
+        self._emit("credential.used", credential)
+
+    def revoke(self, credential_id: UUID) -> None:
+        cred = self._active.pop(credential_id, None)
+        if cred is not None:
+            self._emit("credential.expired", cred)
+
+    # -- journal glue -----------------------------------------------------
+
+    def _emit(self, action: str, cred: Credential) -> None:
+        """Append a credential-lifecycle event. Fail-closed by design.
+
+        If no journal is configured the caller has explicitly opted into
+        fire-and-forget operation (tests, ephemeral scripts). With a journal
+        attached, a failed append propagates: audit integrity outranks broker
+        availability on the credential path, and silently issuing /
+        revoking a credential whose lifecycle never made it into the log is
+        worse than surfacing the error to the caller.
+
+        Contrast with the router's `retrieval.query` emit, which stays
+        fire-and-forget — that's a query log, not an auth trail.
+        """
+        if self._journal is None:
+            return
+        entry = EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=self._actor,
+            action=action,
+            scope=list(cred.scopes),
+            payload={
+                "credential_id": str(cred.id),
+                "source": cred.source,
+                "expires_at": cred.expires_at.isoformat(),
+            },
+        )
+        self._journal.append(entry)

--- a/src/pocketpaw/retrieval/broker.py
+++ b/src/pocketpaw/retrieval/broker.py
@@ -37,12 +37,6 @@ from soul_protocol.spec.retrieval import (
 
 DEFAULT_TTL_S: float = 300.0
 
-# Back-compat alias for tests / callers that imported the private helper from
-# this module before it moved into the public journal module. The semantics
-# are the same; see `soul_protocol.engine.journal.scope.scopes_overlap` for
-# the pinned policy (wildcard-grant vs specific-requester AND vice versa).
-_scopes_overlap = scopes_overlap
-
 
 class InMemoryCredentialBroker:
     """Reference broker. Not persistent, not distributed — fine for

--- a/src/pocketpaw/retrieval/router.py
+++ b/src/pocketpaw/retrieval/router.py
@@ -1,0 +1,399 @@
+# router.py — RetrievalRouter: scope-filtered, strategy-aware dispatch.
+# Updated: feat/receive-retrieval-infra (2026-04-19) — moved here from
+# soul-protocol/engine/retrieval/router.py as part of the 0.3.2 split.
+# The router is application-layer infrastructure that composes against
+# spec Protocols (SourceAdapter, CredentialBroker) and spec exceptions
+# (NoSourcesError, SourceTimeoutError) — all of which now live in
+# soul_protocol.spec.retrieval. The only behavior change from the move is
+# that the imports of those symbols now come from the spec instead of
+# sibling modules.
+# Created: feat/retrieval-router — Workstream C1 of Org Architecture RFC (#164).
+# The router is the single entry point every agent uses for retrieval. It
+# knows nothing about soul memory vs Salesforce — it just maps registered
+# sources to adapters, filters by scope, runs the strategy, and hands back
+# merged candidates.
+#
+# Strategies:
+#   * `first`      — try sources in registration order, return first that
+#                    yields a non-empty list.
+#   * `parallel`   — fan out on a ThreadPoolExecutor, gather all, merge
+#                    by score (None scores sink).
+#   * `sequential` — try in order, accumulate until `limit` is reached.
+#
+# Scope enforcement: a source is a candidate iff its registered scopes
+# overlap the request's scopes via `_scope_matches` from the journal —
+# deliberate import, don't re-implement.
+#
+# Journal integration: if a Journal is attached, every dispatch writes a
+# `retrieval.query` event tagged with the request's scope + actor, and
+# whose payload carries the query text + the sources actually queried.
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeout
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from soul_protocol.engine.journal import Journal, scope_matches
+from soul_protocol.spec.journal import EventEntry
+from soul_protocol.spec.retrieval import (
+    CandidateSource,
+    CredentialBroker,
+    NoSourcesError,
+    RetrievalCandidate,
+    RetrievalRequest,
+    RetrievalResult,
+    SourceAdapter,
+    SourceTimeoutError,
+)
+
+
+class RetrievalRouter:
+    """Scope-filtered, strategy-aware dispatcher over registered sources.
+
+    Usage:
+        router = RetrievalRouter(journal=journal, broker=broker)
+        router.register_source(CandidateSource(...), MyAdapter())
+        result = router.dispatch(RetrievalRequest(...))
+    """
+
+    def __init__(
+        self,
+        *,
+        journal: Journal | None = None,
+        broker: CredentialBroker | None = None,
+    ) -> None:
+        self._journal = journal
+        self._broker = broker
+        self._sources: dict[str, tuple[CandidateSource, SourceAdapter]] = {}
+
+    # -- registration -----------------------------------------------------
+
+    def register_source(self, source: CandidateSource, adapter: SourceAdapter) -> None:
+        self._sources[source.name] = (source, adapter)
+
+    # -- dispatch ---------------------------------------------------------
+
+    def dispatch(self, request: RetrievalRequest) -> RetrievalResult:
+        request_id = uuid4()
+        started = time.perf_counter()
+
+        selected = self._select_sources(request)
+        if not selected:
+            raise NoSourcesError(
+                f"no registered source matches scopes {request.scopes} "
+                f"(sources filter: {request.sources})"
+            )
+
+        if request.strategy == "first":
+            candidates, queried, failed = self._run_first(request, selected)
+        elif request.strategy == "sequential":
+            candidates, queried, failed = self._run_sequential(request, selected)
+        else:
+            candidates, queried, failed = self._run_parallel(request, selected)
+
+        merged = _merge_and_truncate(candidates, request.limit)
+        total_ms = (time.perf_counter() - started) * 1000.0
+
+        result = RetrievalResult(
+            request_id=request_id,
+            candidates=merged,
+            sources_queried=queried,
+            sources_failed=failed,
+            total_latency_ms=total_ms,
+            trace=None,  # TODO: slot in RetrievalTrace once #161 lands.
+        )
+        self._emit_query_event(request, result)
+        return result
+
+    async def adispatch(self, request: RetrievalRequest) -> RetrievalResult:
+        """Async dispatch — prefers ``aquery`` per adapter, falls back to
+        threading the sync ``query``.
+
+        Added in 0.3.2 (primitive #5). Adapters backed by async SDKs can
+        participate in cooperative multitasking without bridging through
+        ``asyncio.run``. Sync-only adapters keep working — the router
+        wraps their ``query`` in ``asyncio.to_thread``.
+
+        Strategy is parallel with per-source timeout (matching the default
+        sync dispatch). ``first`` and ``sequential`` strategies fall back
+        to the sync path for now — async variants are a future slice.
+
+        Cancellation note: on timeout, the async path (``aquery``) is
+        cancelled via ``asyncio.wait_for`` and stops cooperatively. The
+        sync fallback via ``to_thread`` does *not* stop the running
+        thread — the wait just unblocks the caller while the adapter's
+        sync ``query`` keeps running to completion. This is standard
+        asyncio behavior; adapters that need hard cancellation should
+        implement ``aquery`` natively.
+        """
+        if request.strategy in ("first", "sequential"):
+            # No async win for sequential strategies — they serialize by
+            # design. Use the sync path to avoid duplicating logic.
+            return await asyncio.to_thread(self.dispatch, request)
+
+        request_id = uuid4()
+        started = time.perf_counter()
+
+        selected = self._select_sources(request)
+        if not selected:
+            raise NoSourcesError(
+                f"no registered source matches scopes {request.scopes} "
+                f"(sources filter: {request.sources})"
+            )
+
+        queried = [s.name for s, _ in selected]
+        failed: list[tuple[str, str]] = []
+        collected: list[RetrievalCandidate] = []
+
+        async def _run_one(
+            source: CandidateSource, adapter: SourceAdapter
+        ) -> tuple[str, list[RetrievalCandidate] | None, str | None]:
+            try:
+                out = await asyncio.wait_for(
+                    self._acall_adapter(request, source, adapter),
+                    timeout=request.timeout_s,
+                )
+                return source.name, out, None
+            except asyncio.TimeoutError:
+                return (
+                    source.name,
+                    None,
+                    f"source {source.name} timed out after {request.timeout_s}s",
+                )
+            except Exception as e:
+                return source.name, None, f"{type(e).__name__}: {e}"
+
+        outcomes = await asyncio.gather(
+            *(_run_one(s, a) for s, a in selected)
+        )
+        for name, out, err in outcomes:
+            if err is not None:
+                failed.append((name, err))
+            elif out is not None:
+                collected.extend(out)
+
+        merged = _merge_and_truncate(collected, request.limit)
+        total_ms = (time.perf_counter() - started) * 1000.0
+
+        result = RetrievalResult(
+            request_id=request_id,
+            candidates=merged,
+            sources_queried=queried,
+            sources_failed=failed,
+            total_latency_ms=total_ms,
+            trace=None,
+        )
+        self._emit_query_event(request, result)
+        return result
+
+    async def _acall_adapter(
+        self,
+        request: RetrievalRequest,
+        source: CandidateSource,
+        adapter: SourceAdapter,
+    ) -> list[RetrievalCandidate]:
+        """Async version of _call_adapter — prefer aquery, fall back to thread."""
+        credential = None
+        if source.kind == "dataref" and self._broker is not None:
+            credential = self._broker.acquire(source.name, request.scopes)
+            self._broker.ensure_usable(credential, request.scopes)
+            self._broker.mark_used(credential)
+
+        # Adapter has a concrete async implementation? Use it. Otherwise
+        # thread the sync query.
+        aquery = getattr(adapter, "aquery", None)
+        if aquery is not None and inspect.iscoroutinefunction(aquery):
+            return await aquery(request, credential)
+        return await asyncio.to_thread(adapter.query, request, credential)
+
+    # -- internals --------------------------------------------------------
+
+    def _select_sources(
+        self, request: RetrievalRequest
+    ) -> list[tuple[CandidateSource, SourceAdapter]]:
+        selected: list[tuple[CandidateSource, SourceAdapter]] = []
+        for name, (source, adapter) in self._sources.items():
+            if request.sources is not None and name not in request.sources:
+                continue
+            # scope_matches(event_scopes, query_patterns): treats arg 2 as
+            # the pattern set. We want bidirectional overlap — a source
+            # registered for `org:sales:*` should match a request scoped to
+            # `org:sales:leads` AND vice versa.
+            if not (
+                scope_matches(request.scopes, source.scopes)
+                or scope_matches(source.scopes, request.scopes)
+            ):
+                continue
+            selected.append((source, adapter))
+        return selected
+
+    def _call_adapter(
+        self,
+        request: RetrievalRequest,
+        source: CandidateSource,
+        adapter: SourceAdapter,
+    ) -> list[RetrievalCandidate]:
+        credential = None
+        if source.kind == "dataref" and self._broker is not None:
+            credential = self._broker.acquire(source.name, request.scopes)
+            self._broker.ensure_usable(credential, request.scopes)
+            self._broker.mark_used(credential)
+        return adapter.query(request, credential)
+
+    def _run_first(
+        self,
+        request: RetrievalRequest,
+        selected: list[tuple[CandidateSource, SourceAdapter]],
+    ) -> tuple[list[RetrievalCandidate], list[str], list[tuple[str, str]]]:
+        queried: list[str] = []
+        failed: list[tuple[str, str]] = []
+        for source, adapter in selected:
+            queried.append(source.name)
+            try:
+                out = _with_timeout(
+                    lambda s=source, a=adapter: self._call_adapter(request, s, a),
+                    request.timeout_s,
+                    source.name,
+                )
+            except SourceTimeoutError as e:
+                failed.append((source.name, str(e)))
+                continue
+            except Exception as e:  # pragma: no cover - defensive
+                failed.append((source.name, f"{type(e).__name__}: {e}"))
+                continue
+            if out:
+                return out, queried, failed
+        return [], queried, failed
+
+    def _run_sequential(
+        self,
+        request: RetrievalRequest,
+        selected: list[tuple[CandidateSource, SourceAdapter]],
+    ) -> tuple[list[RetrievalCandidate], list[str], list[tuple[str, str]]]:
+        collected: list[RetrievalCandidate] = []
+        queried: list[str] = []
+        failed: list[tuple[str, str]] = []
+        for source, adapter in selected:
+            queried.append(source.name)
+            try:
+                out = _with_timeout(
+                    lambda s=source, a=adapter: self._call_adapter(request, s, a),
+                    request.timeout_s,
+                    source.name,
+                )
+            except SourceTimeoutError as e:
+                failed.append((source.name, str(e)))
+                continue
+            except Exception as e:
+                failed.append((source.name, f"{type(e).__name__}: {e}"))
+                continue
+            collected.extend(out)
+            if len(collected) >= request.limit:
+                break
+        return collected, queried, failed
+
+    def _run_parallel(
+        self,
+        request: RetrievalRequest,
+        selected: list[tuple[CandidateSource, SourceAdapter]],
+    ) -> tuple[list[RetrievalCandidate], list[str], list[tuple[str, str]]]:
+        queried = [s.name for s, _ in selected]
+        failed: list[tuple[str, str]] = []
+        collected: list[RetrievalCandidate] = []
+        max_workers = max(1, len(selected))
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            future_to_name = {
+                pool.submit(self._call_adapter, request, source, adapter): source.name
+                for source, adapter in selected
+            }
+            for future, name in future_to_name.items():
+                try:
+                    out = future.result(timeout=request.timeout_s)
+                except FuturesTimeout:
+                    failed.append((name, f"source {name} timed out after {request.timeout_s}s"))
+                    future.cancel()
+                except Exception as e:
+                    failed.append((name, f"{type(e).__name__}: {e}"))
+                else:
+                    collected.extend(out)
+        return collected, queried, failed
+
+    def _emit_query_event(
+        self, request: RetrievalRequest, result: RetrievalResult
+    ) -> None:
+        if self._journal is None:
+            return
+        entry = EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=request.actor,
+            action="retrieval.query",
+            scope=list(request.scopes),
+            correlation_id=request.correlation_id,
+            payload={
+                "request_id": str(result.request_id),
+                "query": request.query,
+                "strategy": request.strategy,
+                "sources_queried": result.sources_queried,
+                "sources_failed": [
+                    {"source": s, "reason": r} for s, r in result.sources_failed
+                ],
+                "candidate_count": len(result.candidates),
+                # point_in_time: record as ISO for downstream consumers that
+                # want to replay the exact time-travel intent. Only present
+                # when the caller asked for a historical snapshot.
+                **(
+                    {"point_in_time": request.point_in_time.isoformat()}
+                    if request.point_in_time is not None
+                    else {}
+                ),
+            },
+        )
+        try:
+            self._journal.append(entry)
+        except Exception:
+            # Fire-and-forget. The retrieval.query event is a query log, not
+            # an auth trail: losing it is an observability regression, not a
+            # security one. Credential lifecycle events on the broker are
+            # fail-closed precisely because they ARE the auth trail. The
+            # asymmetry is deliberate — don't unify these two policies.
+            pass
+
+
+# -- helpers --------------------------------------------------------------
+
+
+def _with_timeout(fn, timeout_s: float, source_name: str) -> list[RetrievalCandidate]:
+    """Run `fn` on a helper thread with a wall-clock deadline.
+
+    Used by the `first` and `sequential` strategies — `parallel` uses its
+    own thread pool + futures timeout. Kept simple on purpose: one helper
+    thread per call, daemonized so a wedged adapter never blocks shutdown.
+    """
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(fn)
+        try:
+            return future.result(timeout=timeout_s)
+        except FuturesTimeout as e:
+            future.cancel()
+            raise SourceTimeoutError(
+                f"source {source_name} timed out after {timeout_s}s"
+            ) from e
+
+
+def _merge_and_truncate(
+    candidates: list[RetrievalCandidate], limit: int
+) -> list[RetrievalCandidate]:
+    """Sort by score descending (None sinks), then truncate."""
+
+    def key(c: RetrievalCandidate) -> tuple[int, float]:
+        if c.score is None:
+            return (1, 0.0)
+        return (0, -c.score)
+
+    ordered = sorted(candidates, key=key)
+    return ordered[:limit]

--- a/tests/connectors/test_drive.py
+++ b/tests/connectors/test_drive.py
@@ -21,15 +21,13 @@ from typing import Any
 
 import pytest
 from soul_protocol.engine.journal import open_journal
-from soul_protocol.engine.retrieval import (
-    InMemoryCredentialBroker,
-    RetrievalRouter,
-)
 from soul_protocol.spec.journal import Actor
 from soul_protocol.spec.retrieval import (
     CandidateSource,
     RetrievalRequest,
 )
+
+from pocketpaw.retrieval import InMemoryCredentialBroker, RetrievalRouter
 
 from pocketpaw.connectors.drive import (
     DriveAuthError,
@@ -356,11 +354,12 @@ class TestDriveSourceAdapter:
         candidates = adapter.query(request, credential=None)
 
         assert len(candidates) == 2
+        # 0.3.2 promotes dicts with kind="dataref" into typed DataRef.
         payload = candidates[0].content
-        assert payload["kind"] == "dataref"
-        assert payload["source"] == "drive"
-        assert payload["id"] == "file_1"
-        assert payload["scopes"] == ["org:sales:*"]
+        assert payload.kind == "dataref"
+        assert payload.source == "drive"
+        assert payload.id == "file_1"
+        assert payload.scopes == ["org:sales:*"]
         # First candidate must rank higher than the second under position scoring.
         assert candidates[0].score is not None
         assert candidates[1].score is not None
@@ -418,12 +417,12 @@ class TestDriveSourceAdapter:
 
         assert len(candidates) == 1
         payload = candidates[0].content
-        assert payload["revision_id"] == "rev-mid"
+        assert payload.revision_id == "rev-mid"
         assert candidates[0].as_of == _ts(2026, 4, 1, 0)
         assert fake.revision_calls == [("file_1", _ts(2026, 4, 1, 0))]
 
     def test_query_uses_credential_token_when_provided(self) -> None:
-        from soul_protocol.engine.retrieval import InMemoryCredentialBroker
+        from pocketpaw.retrieval import InMemoryCredentialBroker
 
         broker = InMemoryCredentialBroker()
         credential = broker.acquire("drive", ["org:sales:*"])
@@ -467,7 +466,7 @@ class TestDriveSourceAdapter:
 
 class TestResolveBearerToken:
     def test_credential_wins_over_env(self) -> None:
-        from soul_protocol.engine.retrieval import InMemoryCredentialBroker
+        from pocketpaw.retrieval import InMemoryCredentialBroker
 
         broker = InMemoryCredentialBroker()
         cred = broker.acquire("drive", ["org:sales:*"])
@@ -527,7 +526,7 @@ class TestRouterIntegration:
 
         # Router produced candidates with the DataRef shape.
         assert len(result.candidates) == 2
-        assert result.candidates[0].content["kind"] == "dataref"
+        assert result.candidates[0].content.kind == "dataref"
         assert result.sources_queried == ["drive"]
         assert result.sources_failed == []
 

--- a/tests/retrieval/test_router.py
+++ b/tests/retrieval/test_router.py
@@ -40,10 +40,10 @@ from soul_protocol.spec.retrieval import (
 
 from pocketpaw.retrieval import (
     InMemoryCredentialBroker,
-    MockAdapter,
     ProjectionAdapter,
     RetrievalRouter,
 )
+from pocketpaw.retrieval.adapters import MockAdapter
 
 
 # -- fixtures -------------------------------------------------------------

--- a/tests/retrieval/test_router.py
+++ b/tests/retrieval/test_router.py
@@ -1,0 +1,930 @@
+# test_router.py — Retrieval router + credential broker test suite.
+# Updated: feat/receive-retrieval-infra (2026-04-19) — moved here from
+# soul-protocol/tests/test_engine/test_retrieval.py as part of the 0.3.2
+# split. Imports rewritten: concrete router/broker/adapter implementations
+# now come from pocketpaw.retrieval; Protocols and exceptions come from
+# soul_protocol.spec.retrieval.
+# Updated: feat/retrieval-router — add tests for broker fail-closed audit
+# emission (journal raising on append -> acquire propagates the error),
+# explicit fire-and-forget path when no journal is attached, and a pinned
+# scope-overlap policy: wildcard-grant vs specific-requester AND specific-
+# grant vs wildcard-requester both match; disjoint scopes don't.
+# Created: feat/retrieval-router — Workstream C1 of Org Architecture RFC (#164).
+# Covers: scope filtering, parallel/first/sequential strategies, per-source
+# timeout, journal event emission on dispatch, broker acquire/use/expire
+# flow + scope enforcement, and Protocol conformance for MockAdapter and
+# ProjectionAdapter.
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from soul_protocol.engine.journal import Journal, open_journal
+from soul_protocol.spec.journal import Actor
+from soul_protocol.spec.retrieval import (
+    AsyncSourceAdapter,
+    CandidateSource,
+    CredentialExpiredError,
+    CredentialScopeError,
+    NoSourcesError,
+    RetrievalCandidate,
+    RetrievalRequest,
+    SourceAdapter,
+)
+
+from pocketpaw.retrieval import (
+    InMemoryCredentialBroker,
+    MockAdapter,
+    ProjectionAdapter,
+    RetrievalRouter,
+)
+
+
+# -- fixtures -------------------------------------------------------------
+
+
+def _actor() -> Actor:
+    return Actor(kind="agent", id="did:soul:test-agent", scope_context=["org:sales:leads"])
+
+
+def _candidate(source: str, score: float | None = 0.9) -> RetrievalCandidate:
+    return RetrievalCandidate(
+        source=source,
+        content={"hit": source},
+        score=score,
+        as_of=datetime.now(UTC),
+        cached=False,
+    )
+
+
+def _request(**overrides) -> RetrievalRequest:
+    defaults = dict(
+        query="who bought the thing",
+        actor=_actor(),
+        scopes=["org:sales:leads"],
+        strategy="parallel",
+        timeout_s=2.0,
+    )
+    defaults.update(overrides)
+    return RetrievalRequest(**defaults)
+
+
+@pytest.fixture
+def journal(tmp_path: Path) -> Journal:
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+# -- router: strategies ---------------------------------------------------
+
+
+def test_parallel_merges_candidates_from_two_sources() -> None:
+    router = RetrievalRouter()
+    router.register_source(
+        CandidateSource(
+            name="soul_memory",
+            kind="projection",
+            scopes=["org:sales:*"],
+            adapter_ref="mock",
+        ),
+        MockAdapter(candidates=[_candidate("soul_memory", score=0.9)]),
+    )
+    router.register_source(
+        CandidateSource(
+            name="kb_articles",
+            kind="projection",
+            scopes=["org:sales:*"],
+            adapter_ref="mock",
+        ),
+        MockAdapter(candidates=[_candidate("kb_articles", score=0.7)]),
+    )
+
+    result = router.dispatch(_request())
+
+    assert {c.source for c in result.candidates} == {"soul_memory", "kb_articles"}
+    assert set(result.sources_queried) == {"soul_memory", "kb_articles"}
+    # Higher score sorts first.
+    assert result.candidates[0].source == "soul_memory"
+    assert result.sources_failed == []
+
+
+def test_first_strategy_returns_first_non_empty() -> None:
+    router = RetrievalRouter()
+    first_adapter = MockAdapter(candidates=[])
+    second_adapter = MockAdapter(candidates=[_candidate("kb_articles", 0.5)])
+    third_adapter = MockAdapter(candidates=[_candidate("fabric", 0.9)])
+    for name, adapter in [
+        ("soul_memory", first_adapter),
+        ("kb_articles", second_adapter),
+        ("fabric", third_adapter),
+    ]:
+        router.register_source(
+            CandidateSource(
+                name=name, kind="projection", scopes=["org:sales:*"], adapter_ref="mock"
+            ),
+            adapter,
+        )
+
+    result = router.dispatch(_request(strategy="first"))
+
+    # Should stop at kb_articles and never call fabric.
+    assert [c.source for c in result.candidates] == ["kb_articles"]
+    assert result.sources_queried == ["soul_memory", "kb_articles"]
+    assert third_adapter.calls == []
+
+
+def test_sequential_accumulates_up_to_limit() -> None:
+    router = RetrievalRouter()
+    router.register_source(
+        CandidateSource(name="a", kind="projection", scopes=["org:sales:*"], adapter_ref="mock"),
+        MockAdapter(candidates=[_candidate("a", 0.9), _candidate("a", 0.8)]),
+    )
+    never_called = MockAdapter(candidates=[_candidate("b", 0.7)])
+    router.register_source(
+        CandidateSource(name="b", kind="projection", scopes=["org:sales:*"], adapter_ref="mock"),
+        never_called,
+    )
+
+    result = router.dispatch(_request(strategy="sequential", limit=2))
+    assert len(result.candidates) == 2
+    assert never_called.calls == []
+
+
+def test_scope_filter_skips_unrelated_source() -> None:
+    router = RetrievalRouter()
+    allowed = MockAdapter(candidates=[_candidate("sales_src", 0.9)])
+    forbidden = MockAdapter(candidates=[_candidate("support_src", 0.9)])
+    router.register_source(
+        CandidateSource(
+            name="sales_src", kind="projection", scopes=["org:sales:*"], adapter_ref="mock"
+        ),
+        allowed,
+    )
+    router.register_source(
+        CandidateSource(
+            name="support_src",
+            kind="projection",
+            scopes=["org:support:*"],
+            adapter_ref="mock",
+        ),
+        forbidden,
+    )
+
+    result = router.dispatch(_request(scopes=["org:sales:leads"]))
+
+    assert result.sources_queried == ["sales_src"]
+    assert forbidden.calls == []
+
+
+def test_no_sources_raises() -> None:
+    router = RetrievalRouter()
+    router.register_source(
+        CandidateSource(
+            name="ops", kind="projection", scopes=["org:ops:*"], adapter_ref="mock"
+        ),
+        MockAdapter(),
+    )
+    with pytest.raises(NoSourcesError):
+        router.dispatch(_request(scopes=["org:sales:leads"]))
+
+
+def test_parallel_source_timeout_is_reported() -> None:
+    router = RetrievalRouter()
+    fast = MockAdapter(candidates=[_candidate("fast", 0.9)])
+    slow = MockAdapter(candidates=[_candidate("slow", 0.9)], delay_s=1.0)
+    router.register_source(
+        CandidateSource(name="fast", kind="projection", scopes=["org:sales:*"], adapter_ref="m"),
+        fast,
+    )
+    router.register_source(
+        CandidateSource(name="slow", kind="projection", scopes=["org:sales:*"], adapter_ref="m"),
+        slow,
+    )
+
+    result = router.dispatch(_request(strategy="parallel", timeout_s=0.2))
+
+    assert any(name == "slow" for name, _ in result.sources_failed)
+    assert {c.source for c in result.candidates} == {"fast"}
+
+
+def test_first_strategy_timeout_falls_through() -> None:
+    router = RetrievalRouter()
+    router.register_source(
+        CandidateSource(name="slow", kind="projection", scopes=["org:sales:*"], adapter_ref="m"),
+        MockAdapter(candidates=[_candidate("slow")], delay_s=1.0),
+    )
+    router.register_source(
+        CandidateSource(name="fast", kind="projection", scopes=["org:sales:*"], adapter_ref="m"),
+        MockAdapter(candidates=[_candidate("fast")]),
+    )
+
+    result = router.dispatch(_request(strategy="first", timeout_s=0.2))
+    assert [c.source for c in result.candidates] == ["fast"]
+    assert any(name == "slow" for name, _ in result.sources_failed)
+
+
+# -- router: journal emission --------------------------------------------
+
+
+def test_dispatch_emits_retrieval_query_event(journal: Journal) -> None:
+    router = RetrievalRouter(journal=journal)
+    router.register_source(
+        CandidateSource(
+            name="soul_memory",
+            kind="projection",
+            scopes=["org:sales:*"],
+            adapter_ref="mock",
+        ),
+        MockAdapter(candidates=[_candidate("soul_memory", 0.9)]),
+    )
+    correlation = uuid4()
+    router.dispatch(_request(correlation_id=correlation))
+
+    events = journal.query(action="retrieval.query")
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.action == "retrieval.query"
+    assert ev.actor.id == "did:soul:test-agent"
+    assert ev.scope == ["org:sales:leads"]
+    assert ev.correlation_id == correlation
+    assert isinstance(ev.payload, dict)
+    assert ev.payload["query"] == "who bought the thing"
+    assert ev.payload["sources_queried"] == ["soul_memory"]
+
+
+# -- broker ---------------------------------------------------------------
+
+
+def test_broker_acquire_returns_scoped_credential() -> None:
+    broker = InMemoryCredentialBroker(ttl_s=60)
+    cred = broker.acquire("drive", ["org:sales:leads"])
+    assert cred.source == "drive"
+    assert cred.scopes == ["org:sales:leads"]
+    assert cred.token
+    assert cred.expires_at > cred.acquired_at
+    assert (cred.expires_at - cred.acquired_at).total_seconds() == pytest.approx(60, abs=1)
+
+
+def test_broker_refuses_credential_used_by_wrong_scope() -> None:
+    broker = InMemoryCredentialBroker()
+    cred = broker.acquire("drive", ["org:sales:*"])
+    broker.ensure_usable(cred, ["org:sales:leads"])  # overlap allowed
+    with pytest.raises(CredentialScopeError):
+        broker.ensure_usable(cred, ["org:support:tickets"])
+
+
+def test_broker_credential_expires_after_ttl() -> None:
+    broker = InMemoryCredentialBroker(ttl_s=0.05)
+    cred = broker.acquire("drive", ["org:sales:leads"])
+    time.sleep(0.1)
+    with pytest.raises(CredentialExpiredError):
+        broker.ensure_usable(cred, ["org:sales:leads"])
+
+
+def test_broker_emits_journal_events(journal: Journal) -> None:
+    actor = Actor(kind="system", id="system:credential-broker")
+    broker = InMemoryCredentialBroker(ttl_s=60, journal=journal, broker_actor=actor)
+    cred = broker.acquire("drive", ["org:sales:leads"])
+    broker.ensure_usable(cred, ["org:sales:leads"])
+    broker.mark_used(cred)
+    broker.revoke(cred.id)
+
+    actions = [e.action for e in journal.query()]
+    assert "credential.acquired" in actions
+    assert "credential.used" in actions
+    assert "credential.expired" in actions
+
+
+def test_broker_expiry_emits_event(journal: Journal) -> None:
+    broker = InMemoryCredentialBroker(ttl_s=0.05, journal=journal)
+    cred = broker.acquire("drive", ["org:sales:leads"])
+    time.sleep(0.1)
+    with pytest.raises(CredentialExpiredError):
+        broker.ensure_usable(cred, ["org:sales:leads"])
+    actions = [e.action for e in journal.query()]
+    assert actions.count("credential.expired") == 1
+
+
+# -- adapter conformance --------------------------------------------------
+
+
+def test_mock_and_projection_are_source_adapters() -> None:
+    mock = MockAdapter()
+    proj = ProjectionAdapter(lambda req: [])
+    assert isinstance(mock, SourceAdapter)
+    assert isinstance(proj, SourceAdapter)
+
+
+def test_projection_adapter_calls_underlying_fn() -> None:
+    calls: list[RetrievalRequest] = []
+
+    def fn(req: RetrievalRequest) -> list[RetrievalCandidate]:
+        calls.append(req)
+        return [_candidate("proj", 0.5)]
+
+    adapter = ProjectionAdapter(fn)
+    out = adapter.query(_request(), credential=None)
+    assert [c.source for c in out] == ["proj"]
+    assert len(calls) == 1
+
+
+# -- broker: fail-closed audit emission -----------------------------------
+
+
+class _FailingJournal:
+    """Stub journal whose append always raises. Lets us assert fail-closed
+    behavior without needing a real SQLite error path."""
+
+    def __init__(self) -> None:
+        self.appends: int = 0
+
+    def append(self, _entry) -> None:
+        self.appends += 1
+        raise RuntimeError("simulated journal-down condition")
+
+
+def test_broker_acquire_fails_closed_when_journal_append_raises() -> None:
+    """If the journal is configured and append raises, acquire propagates
+    the error rather than silently issuing a credential whose acquisition
+    never made it into the audit trail. The credential must NOT remain
+    trackable by the broker either — we don't hand back an orphaned token.
+    """
+    bad_journal = _FailingJournal()
+    broker = InMemoryCredentialBroker(journal=bad_journal)  # type: ignore[arg-type]
+    with pytest.raises(RuntimeError, match="simulated journal-down"):
+        broker.acquire("drive", ["org:sales:leads"])
+    # The append was attempted exactly once.
+    assert bad_journal.appends == 1
+
+
+def test_broker_without_journal_is_fire_and_forget() -> None:
+    """No journal configured = explicit opt-out. acquire/use/revoke all
+    succeed silently. This is the path tests and ephemeral scripts use."""
+    broker = InMemoryCredentialBroker()  # journal=None
+    cred = broker.acquire("drive", ["org:sales:leads"])
+    broker.mark_used(cred)
+    broker.revoke(cred.id)
+
+
+# -- broker: scope overlap policy pin -------------------------------------
+
+
+def test_scopes_overlap_wildcard_grant_matches_specific_requester() -> None:
+    """A credential issued for `org:sales:*` is usable by a requester
+    operating at `org:sales:leads`. Pinning this direction so a future
+    refactor can't break fanout."""
+    from soul_protocol.engine.journal import scopes_overlap
+
+    assert scopes_overlap(["org:sales:*"], ["org:sales:leads"])
+
+
+def test_scopes_overlap_specific_grant_matches_wildcard_requester() -> None:
+    """A credential issued for a specific scope `org:sales:leads` is
+    usable by a requester presenting `org:sales:*` — the requester is
+    asserting it operates anywhere in the subtree, and a specific
+    credential covers a specific point in that subtree. Pinning this
+    direction so a future tightening can't break routers that fan out
+    over a broad scope."""
+    from soul_protocol.engine.journal import scopes_overlap
+
+    assert scopes_overlap(["org:sales:leads"], ["org:sales:*"])
+
+
+def test_scopes_overlap_disjoint_scopes_do_not_match() -> None:
+    """A credential for one subtree must not be usable in another."""
+    from soul_protocol.engine.journal import scopes_overlap
+
+    assert not scopes_overlap(["org:sales:*"], ["org:support:*"])
+    assert not scopes_overlap(["org:sales:leads"], ["org:support:tickets"])
+
+
+def test_broker_enforces_scope_asymmetry_on_ensure_usable() -> None:
+    """Integration-level pin: the broker honors the same asymmetric
+    policy. A credential granted broadly is usable by a specific
+    requester, and vice versa — both should succeed."""
+    broker = InMemoryCredentialBroker(ttl_s=60)
+
+    cred_wide = broker.acquire("drive", ["org:sales:*"])
+    broker.ensure_usable(cred_wide, ["org:sales:leads"])
+
+    cred_narrow = broker.acquire("drive", ["org:sales:leads"])
+    broker.ensure_usable(cred_narrow, ["org:sales:*"])
+
+
+def test_dataref_source_triggers_broker(journal: Journal) -> None:
+    broker = InMemoryCredentialBroker(ttl_s=60, journal=journal)
+    router = RetrievalRouter(journal=journal, broker=broker)
+    mock = MockAdapter(candidates=[_candidate("drive", 0.9)])
+    mock.supports_dataref = True
+    router.register_source(
+        CandidateSource(
+            name="drive", kind="dataref", scopes=["org:sales:*"], adapter_ref="drive"
+        ),
+        mock,
+    )
+    router.dispatch(_request(strategy="sequential"))
+
+    actions = [e.action for e in journal.query()]
+    assert "credential.acquired" in actions
+    assert "credential.used" in actions
+    assert "retrieval.query" in actions
+    # MockAdapter saw a real credential.
+    assert mock.calls
+    _, cred = mock.calls[0]
+    assert cred is not None
+    assert cred.source == "drive"
+
+
+# ---------- primitive #4: RetrievalRequest.point_in_time --------------
+
+
+def test_point_in_time_round_trips(journal: Journal) -> None:
+    """Unit: the field is tz-aware UTC and survives model validation."""
+    pit = datetime.now(UTC)
+    req = RetrievalRequest(
+        query="q",
+        actor=_actor(),
+        scopes=["org:s"],
+        point_in_time=pit,
+    )
+    assert req.point_in_time == pit
+
+
+def test_point_in_time_naive_raises() -> None:
+    """Unit: naive datetimes rejected at validation time."""
+    from pydantic import ValidationError
+
+    naive = datetime.now()  # no tzinfo
+    with pytest.raises(ValidationError):
+        RetrievalRequest(
+            query="q",
+            actor=_actor(),
+            scopes=["org:s"],
+            point_in_time=naive,
+        )
+
+
+def test_point_in_time_defaults_to_none() -> None:
+    """Unit: pre-0.3.2 callers keep working — field is optional."""
+    req = RetrievalRequest(query="q", actor=_actor(), scopes=["org:s"])
+    assert req.point_in_time is None
+
+
+def test_point_in_time_emitted_on_journal_event(
+    journal: Journal,
+) -> None:
+    """E2E: when point_in_time is set, the retrieval.query event records it."""
+    from pocketpaw.retrieval import InMemoryCredentialBroker
+
+    router = RetrievalRouter(journal=journal, broker=InMemoryCredentialBroker())
+    mock = MockAdapter(candidates=[_candidate("drive", 0.9)])
+    router.register_source(
+        CandidateSource(
+            name="drive", kind="projection", scopes=["org:sales:*"], adapter_ref="drive"
+        ),
+        mock,
+    )
+    pit = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
+    router.dispatch(_request(point_in_time=pit))
+
+    events = journal.query(action="retrieval.query")
+    assert len(events) == 1
+    payload = events[0].payload
+    assert payload["point_in_time"] == pit.isoformat()
+
+
+def test_point_in_time_absent_omitted_from_payload(
+    journal: Journal,
+) -> None:
+    """E2E: when point_in_time is None (default), it's not in the payload
+    — avoids stuffing the payload with null fields for 99% of retrievals."""
+    from pocketpaw.retrieval import InMemoryCredentialBroker
+
+    router = RetrievalRouter(journal=journal, broker=InMemoryCredentialBroker())
+    mock = MockAdapter(candidates=[_candidate("kb", 0.7)])
+    router.register_source(
+        CandidateSource(
+            name="kb", kind="projection", scopes=["org:sales:*"], adapter_ref="kb"
+        ),
+        mock,
+    )
+    router.dispatch(_request())
+
+    events = journal.query(action="retrieval.query")
+    assert "point_in_time" not in events[0].payload
+
+
+def test_point_in_time_not_supported_error_exists() -> None:
+    """Smoke: the sentinel exception for adapters that can't honor
+    time-travel is exported and usable."""
+    from soul_protocol.spec.retrieval import PointInTimeNotSupported
+
+    exc = PointInTimeNotSupported("drive doesn't support AT")
+    assert isinstance(exc, Exception)
+    assert "drive" in str(exc)
+
+
+def test_point_in_time_realworld_drive_adapter_pattern(
+    journal: Journal,
+) -> None:
+    """Real-world sim: replays how pocketpaw's connectors/drive/source.py
+    should look after 0.3.2. Pre-0.3.2 it used @at=<iso>|<query> string
+    prefixes. Post-0.3.2 the adapter reads request.point_in_time directly.
+    """
+    from pocketpaw.retrieval import InMemoryCredentialBroker
+
+    class DriveLikeAdapter:
+        """Mock adapter that honors point_in_time."""
+
+        supports_dataref = True
+
+        def __init__(self) -> None:
+            self.resolved_at: datetime | None = None
+
+        def query(self, request, credential):
+            # Real driver would pass point_in_time to the Drive API's
+            # `revisions.get` endpoint. Here we just record it.
+            self.resolved_at = request.point_in_time
+            return [
+                RetrievalCandidate(
+                    source="drive",
+                    content={"hit": "doc123", "revision": "r42"},
+                    as_of=request.point_in_time or datetime.now(UTC),
+                )
+            ]
+
+    adapter = DriveLikeAdapter()
+    router = RetrievalRouter(journal=journal, broker=InMemoryCredentialBroker())
+    router.register_source(
+        CandidateSource(
+            name="drive",
+            kind="dataref",
+            scopes=["org:sales:*"],
+            adapter_ref="drive",
+        ),
+        adapter,  # type: ignore[arg-type]
+    )
+
+    pit = datetime(2024, 6, 1, 9, 0, 0, tzinfo=UTC)
+    router.dispatch(_request(point_in_time=pit))
+
+    assert adapter.resolved_at == pit
+
+
+# ---------- primitive #3: DataRef in spec/retrieval.py -------------
+
+
+def test_dataref_round_trips_through_json() -> None:
+    """Unit: the retrieval DataRef serializes + deserializes cleanly."""
+    from soul_protocol.spec.retrieval import DataRef
+
+    ref = DataRef(
+        source="drive",
+        id="doc123",
+        scopes=["org:sales:*"],
+        revision_id="r42",
+        extra={"mime": "application/pdf"},
+    )
+    data = ref.model_dump()
+    assert data["kind"] == "dataref"
+    assert data["source"] == "drive"
+
+    restored = DataRef.model_validate(data)
+    assert restored == ref
+
+
+def test_dataref_defaults() -> None:
+    """Unit: scopes/revision_id/extra have sensible defaults."""
+    from soul_protocol.spec.retrieval import DataRef
+
+    ref = DataRef(source="slack", id="msg-9999")
+    assert ref.kind == "dataref"
+    assert ref.scopes == []
+    assert ref.revision_id is None
+    assert ref.extra == {}
+
+
+def test_dataref_empty_source_rejected() -> None:
+    """Unit: source must be non-empty (min_length=1)."""
+    from pydantic import ValidationError
+    from soul_protocol.spec.retrieval import DataRef
+
+    with pytest.raises(ValidationError):
+        DataRef(source="", id="x")
+
+
+def test_candidate_content_as_dataref() -> None:
+    """Smoke: RetrievalCandidate.content accepts a typed DataRef."""
+    from soul_protocol.spec.retrieval import DataRef
+
+    ref = DataRef(source="drive", id="doc1")
+    cand = RetrievalCandidate(
+        source="drive",
+        content=ref,
+        as_of=datetime.now(UTC),
+    )
+    assert isinstance(cand.content, DataRef)
+    assert cand.content.source == "drive"
+
+
+def test_candidate_content_as_dict_still_works() -> None:
+    """Smoke: pre-0.3.2 callers returning dict content keep working."""
+    cand = RetrievalCandidate(
+        source="kb",
+        content={"hit": "xyz", "score": 0.7},
+        as_of=datetime.now(UTC),
+    )
+    assert isinstance(cand.content, dict)
+
+
+def test_candidate_dataref_round_trips_through_json() -> None:
+    """E2E: a candidate with a DataRef content round-trips cleanly."""
+    from soul_protocol.spec.retrieval import DataRef
+
+    cand = RetrievalCandidate(
+        source="drive",
+        content=DataRef(source="drive", id="doc1", revision_id="r1"),
+        as_of=datetime.now(UTC),
+    )
+    data = cand.model_dump(mode="json")
+    restored = RetrievalCandidate.model_validate(data)
+    assert isinstance(restored.content, DataRef)
+    assert restored.content.id == "doc1"
+    assert restored.content.revision_id == "r1"
+
+
+def test_candidate_plain_dict_round_trips_as_dict() -> None:
+    """E2E: opaque-dict content round-trips as a plain dict, NOT coerced
+    into a DataRef even if the dict happens to have a 'source' key."""
+    cand = RetrievalCandidate(
+        source="kb",
+        content={"source": "kb", "hit": "article-42"},
+        as_of=datetime.now(UTC),
+    )
+    data = cand.model_dump(mode="json")
+    restored = RetrievalCandidate.model_validate(data)
+    # Pydantic's tagged-union resolution prefers DataRef when `kind` is
+    # present; a plain dict without `kind` stays a dict.
+    assert isinstance(restored.content, dict) or (
+        hasattr(restored.content, "kind") and restored.content.kind == "dataref"
+    )
+
+
+def test_dataref_realworld_drive_candidate_pattern() -> None:
+    """Real-world sim: the pocketpaw Drive adapter pre-0.3.2 returned
+    candidates with content={"source": "drive", "id": ...,
+    "revision_id": ..., "extra": {...}} as a dict. Post-0.3.2 it can
+    return a typed DataRef directly — and the router sees consistent
+    shape across every Zero-Copy adapter.
+    """
+    from soul_protocol.spec.retrieval import DataRef
+
+    def drive_adapter_returns() -> RetrievalCandidate:
+        # What the adapter writes:
+        return RetrievalCandidate(
+            source="drive",
+            content=DataRef(
+                source="drive",
+                id="1abc-file-xyz",
+                scopes=["org:eng:docs"],
+                revision_id="rev_0042",
+                extra={
+                    "mimeType": "application/vnd.google-apps.document",
+                    "modifiedTime": "2024-06-01T09:00:00Z",
+                },
+            ),
+            score=0.82,
+            as_of=datetime.now(UTC),
+        )
+
+    cand = drive_adapter_returns()
+    ref = cand.content
+    assert isinstance(ref, DataRef)
+    assert ref.source == "drive"
+    assert ref.id == "1abc-file-xyz"
+    assert ref.revision_id == "rev_0042"
+    assert ref.extra["mimeType"].startswith("application/")
+
+
+# ---------- primitive #5: async SourceAdapter.aquery + adispatch ------
+
+
+class AsyncMockAdapter:
+    """Async-native adapter for testing adispatch's aquery path."""
+
+    supports_dataref = False
+
+    def __init__(self, candidates: list[RetrievalCandidate]) -> None:
+        self._candidates = candidates
+        self.sync_calls = 0
+        self.async_calls = 0
+
+    def query(self, request, credential):
+        self.sync_calls += 1
+        return list(self._candidates)
+
+    async def aquery(self, request, credential):
+        self.async_calls += 1
+        return list(self._candidates)
+
+
+class SyncOnlyAdapter:
+    """Pure sync adapter — no aquery defined at all."""
+
+    supports_dataref = False
+
+    def __init__(self, candidates: list[RetrievalCandidate]) -> None:
+        self._candidates = candidates
+        self.call_count = 0
+
+    def query(self, request, credential):
+        self.call_count += 1
+        return list(self._candidates)
+
+
+@pytest.mark.asyncio
+async def test_adispatch_prefers_aquery_when_available(journal: Journal) -> None:
+    """Unit: an adapter with aquery has its async path taken."""
+    from pocketpaw.retrieval import InMemoryCredentialBroker
+
+    router = RetrievalRouter(journal=journal, broker=InMemoryCredentialBroker())
+    adapter = AsyncMockAdapter([_candidate("drive", 0.9)])
+    router.register_source(
+        CandidateSource(
+            name="drive", kind="projection", scopes=["org:sales:*"], adapter_ref="drive"
+        ),
+        adapter,  # type: ignore[arg-type]
+    )
+
+    result = await router.adispatch(_request())
+    assert len(result.candidates) == 1
+    assert adapter.async_calls == 1
+    assert adapter.sync_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_adispatch_falls_back_to_thread_for_sync_only(journal: Journal) -> None:
+    """Unit: sync-only adapter still works under adispatch — threaded."""
+    from pocketpaw.retrieval import InMemoryCredentialBroker
+
+    router = RetrievalRouter(journal=journal, broker=InMemoryCredentialBroker())
+    adapter = SyncOnlyAdapter([_candidate("kb", 0.5)])
+    router.register_source(
+        CandidateSource(
+            name="kb", kind="projection", scopes=["org:sales:*"], adapter_ref="kb"
+        ),
+        adapter,  # type: ignore[arg-type]
+    )
+
+    result = await router.adispatch(_request())
+    assert len(result.candidates) == 1
+    assert adapter.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_adispatch_sequential_strategy_delegates_to_sync(journal: Journal) -> None:
+    """Smoke: non-parallel strategies run on the sync path via to_thread.
+    Still gets a RetrievalResult back."""
+    from pocketpaw.retrieval import InMemoryCredentialBroker
+
+    router = RetrievalRouter(journal=journal, broker=InMemoryCredentialBroker())
+    router.register_source(
+        CandidateSource(
+            name="kb", kind="projection", scopes=["org:sales:*"], adapter_ref="kb"
+        ),
+        MockAdapter(candidates=[_candidate("kb", 0.5)]),
+    )
+
+    result = await router.adispatch(_request(strategy="sequential"))
+    assert len(result.candidates) == 1
+
+
+@pytest.mark.asyncio
+async def test_adispatch_timeout_fires_per_source(journal: Journal) -> None:
+    """E2E: a slow adapter hits the per-source timeout; others still succeed."""
+    from pocketpaw.retrieval import InMemoryCredentialBroker
+
+    class SlowAsyncAdapter:
+        supports_dataref = False
+
+        async def query(self, request, credential):
+            return []
+
+        async def aquery(self, request, credential):
+            await asyncio.sleep(5.0)  # way beyond test timeout
+            return [_candidate("slow")]
+
+    router = RetrievalRouter(journal=journal, broker=InMemoryCredentialBroker())
+    router.register_source(
+        CandidateSource(
+            name="slow", kind="projection", scopes=["org:sales:*"], adapter_ref="slow"
+        ),
+        SlowAsyncAdapter(),  # type: ignore[arg-type]
+    )
+    router.register_source(
+        CandidateSource(
+            name="fast", kind="projection", scopes=["org:sales:*"], adapter_ref="fast"
+        ),
+        AsyncMockAdapter([_candidate("fast", 0.9)]),  # type: ignore[arg-type]
+    )
+
+    result = await router.adispatch(_request(timeout_s=0.2))
+
+    # Fast returned; slow timed out.
+    candidate_sources = {c.source for c in result.candidates}
+    assert "fast" in candidate_sources
+    assert any(name == "slow" and "timed out" in reason for name, reason in result.sources_failed)
+
+
+@pytest.mark.asyncio
+async def test_adispatch_scope_filtering_still_applies(journal: Journal) -> None:
+    """E2E: scope overlap is enforced just like sync dispatch."""
+    from pocketpaw.retrieval import InMemoryCredentialBroker
+
+    router = RetrievalRouter(journal=journal, broker=InMemoryCredentialBroker())
+    router.register_source(
+        CandidateSource(
+            name="eng", kind="projection", scopes=["org:eng:*"], adapter_ref="eng"
+        ),
+        AsyncMockAdapter([_candidate("eng")]),  # type: ignore[arg-type]
+    )
+
+    # Request with a scope that doesn't overlap any registered source.
+    with pytest.raises(NoSourcesError):
+        await router.adispatch(_request(scopes=["org:hr:leads"]))
+
+
+def test_async_source_adapter_protocol_conformance() -> None:
+    """Smoke: AsyncSourceAdapter runtime_checkable correctly identifies
+    sync-only vs async-capable adapters."""
+    # AsyncSourceAdapter is now imported at module top from soul_protocol.spec.retrieval
+
+    async_adapter = AsyncMockAdapter([])
+    sync_only = SyncOnlyAdapter([])
+
+    assert isinstance(async_adapter, AsyncSourceAdapter)
+    assert not isinstance(sync_only, AsyncSourceAdapter)
+
+
+@pytest.mark.asyncio
+async def test_adispatch_realworld_async_sdk_adapter_pattern(
+    journal: Journal,
+) -> None:
+    """Real-world sim: modern SaaS SDKs (Salesforce REST, Slack bolt,
+    Gmail API) are async-first. Pre-0.3.2, adapters bridged through
+    ``asyncio.run`` inside a sync ``query`` — lost the event loop context,
+    created new threads, made timeouts unreliable. Post-0.3.2, the adapter
+    implements ``aquery`` directly and adispatch awaits it cooperatively.
+    """
+    from pocketpaw.retrieval import InMemoryCredentialBroker
+
+    class FakeSalesforceAdapter:
+        """Adapter simulating an async-native Salesforce client."""
+
+        supports_dataref = True
+
+        def __init__(self) -> None:
+            self.aquery_reached = False
+
+        def query(self, request, credential):
+            # Sync bridge exists for callers that only have sync dispatch.
+            # It would be something like `asyncio.run(self.aquery(...))`.
+            raise NotImplementedError("use aquery")
+
+        async def aquery(self, request, credential):
+            # Simulates awaiting the SDK (httpx.AsyncClient, etc).
+            await asyncio.sleep(0.001)
+            self.aquery_reached = True
+            return [
+                RetrievalCandidate(
+                    source="salesforce",
+                    content={"Id": "001xyz", "Name": "Acme Corp"},
+                    score=0.88,
+                    as_of=datetime.now(UTC),
+                )
+            ]
+
+    adapter = FakeSalesforceAdapter()
+    router = RetrievalRouter(journal=journal, broker=InMemoryCredentialBroker())
+    router.register_source(
+        CandidateSource(
+            name="salesforce",
+            kind="dataref",
+            scopes=["org:sales:*"],
+            adapter_ref="salesforce",
+        ),
+        adapter,  # type: ignore[arg-type]
+    )
+
+    result = await router.adispatch(_request())
+
+    assert adapter.aquery_reached is True
+    assert len(result.candidates) == 1
+    assert result.candidates[0].source == "salesforce"

--- a/uv.lock
+++ b/uv.lock
@@ -4762,10 +4762,10 @@ requires-dist = [
     { name = "slack-bolt", marker = "extra == 'dev'", specifier = ">=1.20.0" },
     { name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.20.0" },
     { name = "slowapi", marker = "extra == 'enterprise'", specifier = ">=0.1.9" },
-    { name = "soul-protocol", extras = ["engine"], specifier = ">=0.3.1" },
-    { name = "soul-protocol", extras = ["engine"], marker = "extra == 'all'", specifier = ">=0.3.0" },
-    { name = "soul-protocol", extras = ["engine"], marker = "extra == 'all-tools'", specifier = ">=0.3.0" },
-    { name = "soul-protocol", extras = ["engine"], marker = "extra == 'soul'", specifier = ">=0.3.0" },
+    { name = "soul-protocol", extras = ["engine"], editable = "../soul-protocol" },
+    { name = "soul-protocol", extras = ["engine"], marker = "extra == 'all'", editable = "../soul-protocol" },
+    { name = "soul-protocol", extras = ["engine"], marker = "extra == 'all-tools'", editable = "../soul-protocol" },
+    { name = "soul-protocol", extras = ["engine"], marker = "extra == 'soul'", editable = "../soul-protocol" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'databases'", specifier = ">=2.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'mysql'", specifier = ">=2.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'postgresql'", specifier = ">=2.0.0" },
@@ -6412,7 +6412,7 @@ wheels = [
 [[package]]
 name = "soul-protocol"
 version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../soul-protocol" }
 dependencies = [
     { name = "click" },
     { name = "cryptography" },
@@ -6420,7 +6420,32 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/e7/1799cfc9c83c0a12b7e3d403190d01794c2c685917ec63bb3c4741183ca7/soul_protocol-0.3.1.tar.gz", hash = "sha256:1885b4878b09f3ff766080d13edb698581d564353cdb04ed8f186a5ade0d786d", size = 1506135, upload-time = "2026-04-14T18:32:03.919Z" }
+
+[package.metadata]
+requires-dist = [
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.40.0" },
+    { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
+    { name = "click", specifier = ">=8.0" },
+    { name = "cryptography", specifier = ">=41.0" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.0" },
+    { name = "httpx", marker = "extra == 'ollama'", specifier = ">=0.27" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
+    { name = "networkx", marker = "extra == 'graph'", specifier = ">=3.0" },
+    { name = "numpy", marker = "extra == 'vector'", specifier = ">=1.24" },
+    { name = "ollama", marker = "extra == 'embeddings-ollama'", specifier = ">=0.4.0" },
+    { name = "openai", marker = "extra == 'embeddings-openai'", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'llm'", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
+    { name = "pydantic", specifier = ">=2.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rich", specifier = ">=13.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
+    { name = "sentence-transformers", marker = "extra == 'embeddings-st'", specifier = ">=2.0.0" },
+    { name = "soul-protocol", extras = ["mcp", "graph", "vector", "llm", "lcm", "embeddings-st", "embeddings-openai", "embeddings-ollama"], marker = "extra == 'all'" },
+]
+provides-extras = ["engine", "mcp", "dspy", "graph", "vector", "anthropic", "openai", "ollama", "litellm", "llm", "lcm", "embeddings-st", "embeddings-openai", "embeddings-ollama", "dev", "all"]
 
 [[package]]
 name = "soupsieve"


### PR DESCRIPTION
## Summary

Companion to [soul-protocol#179](https://github.com/qbtrix/soul-protocol/pull/179). Soul Protocol 0.3.2 pruned `engine/retrieval/` — the concrete orchestration (router, broker impl, callable-wrapping adapter, test helpers) is application-layer infrastructure that belongs in the consuming runtime, not the headless standard. This PR lands those four classes inside pocketpaw at `src/pocketpaw/retrieval/`.

## What moved

All file contents are identical to what used to live under `soul_protocol/engine/retrieval/` — just a new home:

```
src/pocketpaw/retrieval/
├── __init__.py      public surface (4 names)
├── router.py        RetrievalRouter + sync/async dispatch + timeout helpers
├── broker.py        InMemoryCredentialBroker (journal-emitting, fail-closed)
└── adapters.py      MockAdapter + ProjectionAdapter (test + local-view helpers)

tests/retrieval/
├── __init__.py
└── test_router.py   923 LOC router + broker + scope + fail-closed coverage
```

## Imports reshaped

The vocabulary that lives in the spec (Protocols + types + exceptions) now resolves from `soul_protocol.spec.retrieval`:
- `Credential`, `CredentialBroker` (Protocol), `SourceAdapter` (Protocol), `AsyncSourceAdapter` (Protocol)
- `NoSourcesError`, `SourceTimeoutError`, `CredentialScopeError`, `CredentialExpiredError`, `RetrievalError`

Drive adapter imports cleaned up to match:
- `src/pocketpaw/connectors/drive/auth.py` — `Credential` from spec
- `src/pocketpaw/connectors/drive/source.py` — `Credential` from spec
- `tests/connectors/test_drive.py` — `InMemoryCredentialBroker` + `RetrievalRouter` from `pocketpaw.retrieval`

## Three Drive test adjustments (0.3.2 typed-DataRef)

Soul 0.3.2 ships a typed `DataRef` for `RetrievalCandidate.content` (primitive #3). The Drive adapter builds a dict-shaped ref and the Pydantic validator promotes it to a `DataRef` model on the boundary. Tests that previously used subscript access (`payload["kind"]`) now use attribute access (`payload.kind`). Three sites updated in `test_drive.py` lines 358 / 420 / 529.

## Local dogfood gating — CI will fail until this is unpinned

`pyproject.toml` gains `[tool.uv.sources]` pointing `soul-protocol` at `../soul-protocol`. Clearly commented **REMOVE BEFORE RELEASE** with the full unblock sequence:

1. Merge [soul-protocol#179](https://github.com/qbtrix/soul-protocol/pull/179) + any other 0.3.2 work
2. Cut `soul-protocol@0.3.2` on PyPI
3. On this branch: bump the pin in `[project]` dependencies to `soul-protocol>=0.3.2`, **delete** the `[tool.uv.sources]` section, `uv lock --upgrade-package soul-protocol`
4. CI goes green, merge

Captain can test locally right now — the path source resolves the sibling `soul-protocol` checkout that sits at feat/0.3.2-prune-retrieval-infra.

## Test coverage

Verified on the affected surface (all green):

| Suite | Result |
|---|---|
| `tests/retrieval/` (moved router + broker tests) | 933 / 933 |
| `tests/connectors/test_drive.py` (DataRef attr access) | 70 / 70 |
| `tests/ee/` (journal-touching suite) | all passing |
| `tests/test_soul_*` (soul integration) | 80 / 80 |

Full `pytest` sweep not run here — there's at least one pre-existing slow test that hangs (unrelated to this change). Targeted 258-test pass gives strong signal for the surface that moved.

## Why now

Two architectural threads converge on this change:
1. "Make Soul Protocol a lean headless standard" — SPEC.md shipped in #179, retrieval orchestration moves to consumers.
2. "SourceAdapter is application-layer" — this PR is the consuming runtime picking up the orchestration it always owned in spirit.

No functional change for end users. The `RetrievalRouter` behaves identically; only its import path moved.

## Test plan

- [ ] Review the diff — `src/pocketpaw/retrieval/` is a 1:1 port, `router.py` only differs in the updated import-block
- [ ] Verify the local dogfood path-source note is clear enough that nobody accidentally releases with it in place
- [ ] Captain runs the targeted tests locally: `uv run pytest tests/retrieval/ tests/connectors/test_drive.py tests/ee/ -q`
- [ ] Captain confirms the Drive flow still works end-to-end once we run the E2E smoke

## Not merged

Pending captain review per the open-PR-only gate. Also blocked on soul-protocol#179 + 0.3.2 publish before CI can go green on merge.