### PR TITLE
feat(agents): per-agent AgentLoop for cloud-defined agents

### DIFF
--- a/ee/cloud/shared/agent_bridge.py
+++ b/ee/cloud/shared/agent_bridge.py
@@ -32,21 +32,44 @@ from ee.cloud.shared.events import event_bus
 logger = logging.getLogger(__name__)
 
 
+_background_tasks: set[asyncio.Task] = set()
+
+
 async def on_message_for_agents(data: dict) -> None:
-    """Handle message.sent event — check if any agents should respond."""
+    """Handle message.sent event — check if any agents should respond.
+
+    Dispatches all the actual work (respond-mode checks, smart-mode LLM
+    calls, ``_run_agent_response``) to a background task so the ``event_bus``
+    emitter — which is awaited on the group-chat send path — returns
+    immediately. Before this, a ``smart``-mode agent blocked the
+    ``MessageSent`` realtime broadcast for the full duration of a Haiku
+    relevance-check call (5–10s), making the sender wait seconds to see
+    their own message ack.
+    """
     group_id = data.get("group_id")
-    sender_id = data.get("sender_id")
     sender_type = data.get("sender_type", "user")
     content = data.get("content", "")
-    mentions = data.get("mentions", [])
-    workspace_id = data.get("workspace_id", "")
 
     if not group_id or not content:
         return
-
-    # Don't respond to agent messages (prevent loops)
     if sender_type == "agent":
+        # Don't respond to agent messages (prevent loops)
         return
+
+    task = asyncio.create_task(_dispatch_agent_responses(data))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+async def _dispatch_agent_responses(data: dict) -> None:
+    """Background worker for ``on_message_for_agents`` — does the actual
+    respond-mode evaluation and per-agent response spawning. Runs
+    detached from the emitter's await chain."""
+    group_id = data.get("group_id")
+    sender_id = data.get("sender_id")
+    content = data.get("content", "")
+    mentions = data.get("mentions", [])
+    workspace_id = data.get("workspace_id", "")
 
     logger.info("Agent bridge: message in group %s from %s: %s", group_id, sender_id, content[:50])
 

--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -284,11 +284,57 @@ class AgentLoop:
     openai_agents, google_adk, codex_cli, opencode, or copilot_sdk).
     """
 
-    def __init__(self):
-        self.settings = get_settings()
+    def __init__(
+        self,
+        agent_id: str | None = None,
+        agent_config: dict | None = None,
+        agent_name: str | None = None,
+    ):
+        """Build a loop, optionally scoped to a cloud Agent.
+
+        When ``agent_id`` is set, the loop uses a
+        :class:`CloudAgentBootstrapProvider` keyed by the agent's config so
+        the identity block in the system prompt matches the selected agent.
+        Per-agent backend overrides (``config.backend``, ``config.model``)
+        are applied when present. Per-agent loops are *not* bus consumers —
+        they're invoked directly via :meth:`process_message` so multiple
+        loops can coexist without racing each other for InboundMessages.
+        """
+        self.agent_id = agent_id
+        self.agent_config = agent_config or {}
+        self.agent_name = agent_name
+
+        base_settings = get_settings()
+        # Per-agent overrides: backend + model come from the agent doc.
+        if agent_id and self.agent_config:
+            overrides: dict = {}
+            be = (self.agent_config.get("backend") or "").strip()
+            mdl = (self.agent_config.get("model") or "").strip()
+            if be:
+                overrides["agent_backend"] = be
+            if mdl:
+                # Applies to the Anthropic provider — other providers read
+                # their own model fields from settings, so this is a
+                # best-effort override aligned with today's default backend.
+                overrides["anthropic_model"] = mdl
+            self.settings = (
+                base_settings.model_copy(update=overrides) if overrides else base_settings
+            )
+        else:
+            self.settings = base_settings
+
         self.bus = get_message_bus()
         self.memory = get_memory_manager()
         self.context_builder = AgentContextBuilder(memory_manager=self.memory)
+
+        # Point the context builder at a per-agent bootstrap when scoped.
+        if agent_id:
+            from pocketpaw.bootstrap.cloud_agent_provider import CloudAgentBootstrapProvider
+
+            self.context_builder.bootstrap = CloudAgentBootstrapProvider(
+                agent_name=agent_name or "Agent",
+                agent_config=self.agent_config,
+            )
 
         # Agent Router handles backend selection
         self._router: AgentRouter | None = None
@@ -311,12 +357,41 @@ class AgentLoop:
         self._running = False
 
     def _get_router(self) -> AgentRouter:
-        """Get or create the agent router (lazy initialization)."""
+        """Get or create the agent router (lazy initialization).
+
+        Per-agent loops honour their captured ``self.settings`` (which
+        already carries the agent's backend/model overrides) so we don't
+        reload from disk and clobber them on first router access.
+        """
         if self._router is None:
-            # Reload settings to pick up any changes
-            settings = Settings.load()
-            self._router = AgentRouter(settings)
+            if self.agent_id:
+                self._router = AgentRouter(self.settings)
+            else:
+                # Default loop: reload settings to pick up config changes.
+                self._router = AgentRouter(Settings.load())
         return self._router
+
+    async def process_message(self, message: InboundMessage) -> None:
+        """Public entry point — run the full processing pipeline on one
+        message without going through the bus consumer.
+
+        The default loop consumes InboundMessages from the bus in
+        ``_loop()``; per-agent loops skip that and are invoked directly
+        from the HTTP handler so multiple loops never race for messages.
+        Outbound events still go through the bus so SSE bridges and
+        other subscribers keep working unchanged.
+        """
+        session_key = message.session_key
+        task = asyncio.create_task(self._process_message(message))
+        self._background_tasks.add(task)
+        self._active_tasks[session_key] = task
+
+        def _on_done(t: asyncio.Task, key: str = session_key) -> None:
+            self._background_tasks.discard(t)
+            if self._active_tasks.get(key) is t:
+                self._active_tasks.pop(key, None)
+
+        task.add_done_callback(_on_done)
 
     async def start(self) -> None:
         """Start the agent loop."""

--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -1121,9 +1121,14 @@ class AgentLoop:
                 # Skip auto-learn on cancelled responses — partial data is unreliable.
                 # Also skip when soul is active — soul.observe() + reflect() handles
                 # fact extraction and memory consolidation, so auto_learn would duplicate.
+                # Per-agent loops share the global memory store with every other
+                # agent, so extracted facts would contaminate the default agent's
+                # identity context. Skip auto-learn for per-agent loops until we
+                # have per-agent namespaced fact storage.
                 should_auto_learn = (
                     not cancelled
                     and self._soul_manager is None
+                    and self.agent_id is None
                     and (
                         (self.settings.memory_backend == "mem0" and self.settings.mem0_auto_learn)
                         or (

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -354,14 +354,14 @@ async def chat_stream(body: ChatRequest):
         # stream — otherwise we'd kill a task that's just finishing up
         # memory storage for the previous (completed) message.
         try:
-            from pocketpaw.dashboard_state import _agent_loops, agent_loop
+            from pocketpaw.dashboard_state import agent_loop, iter_per_agent_loops
 
             session_key = f"websocket:{chat_id}"
             # Try the default loop first, then every per-agent loop — only
             # one of them owns the task. ``cancel_task`` is a no-op when
             # the key is unknown, so this is safe.
             agent_loop.cancel_task(session_key)
-            for loop in list(_agent_loops.values()):
+            for loop in iter_per_agent_loops():
                 loop.cancel_task(session_key)
         except Exception:
             logger.debug("Could not cancel stale agent task", exc_info=True)
@@ -441,7 +441,7 @@ async def chat_stop(session_id: str = ""):
 
     # Also cancel the agent loop's processing task
     try:
-        from pocketpaw.dashboard_state import _agent_loops, agent_loop
+        from pocketpaw.dashboard_state import agent_loop, iter_per_agent_loops
 
         # Derive chat_id from whatever format was given
         raw = session_id
@@ -449,7 +449,7 @@ async def chat_stop(session_id: str = ""):
             raw = raw[len(_WS_PREFIX) :]
         session_key = f"websocket:{raw}"
         agent_loop.cancel_task(session_key)
-        for loop in list(_agent_loops.values()):
+        for loop in iter_per_agent_loops():
             loop.cancel_task(session_key)
     except Exception:
         pass

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -184,9 +184,11 @@ class _APISessionBridge:
             bus.unsubscribe_system(self._system_cb)
 
 
-async def _send_message(chat_request: ChatRequest) -> str:
-    """Publish an inbound message to the bus and return the chat_id."""
-    from pocketpaw.bus import get_message_bus
+async def _build_inbound_message(chat_request: ChatRequest):
+    """Build an InboundMessage for ``chat_request`` — shared by the bus
+    dispatch path (default loop) and the direct-call path (per-agent loop).
+    Returns ``(chat_id, InboundMessage)``.
+    """
     from pocketpaw.bus.events import Channel, InboundMessage
     from pocketpaw.uploads.resolver import resolve_media_with_records
 
@@ -195,6 +197,8 @@ async def _send_message(chat_request: ChatRequest) -> str:
     meta: dict = {"source": "rest_api"}
     if chat_request.file_context:
         meta["file_context"] = chat_request.file_context.model_dump(exclude_none=True)
+    if chat_request.agent_id:
+        meta["agent_id"] = chat_request.agent_id
 
     # Resolve ``/api/v1/uploads/{id}`` URLs to (path, FileRecord) pairs so the
     # agent prompt can carry filename / mime / size, not just a bare disk path.
@@ -254,9 +258,36 @@ async def _send_message(chat_request: ChatRequest) -> str:
         media=media,
         metadata=meta,
     )
+    return chat_id, msg
+
+
+async def _send_message(chat_request: ChatRequest) -> str:
+    """Dispatch the message to the default loop (via bus) or to a per-agent
+    loop directly when ``chat_request.agent_id`` is set.
+
+    Per-agent loops bypass the bus consumer to avoid racing with the
+    default loop for InboundMessages. Outbound events still flow through
+    the bus so the SSE bridge sees them unchanged.
+    """
+    from pocketpaw.bus import get_message_bus
+
+    chat_id, msg = await _build_inbound_message(chat_request)
+
+    if chat_request.agent_id:
+        try:
+            from pocketpaw.dashboard_state import get_agent_loop_for
+
+            loop = await get_agent_loop_for(chat_request.agent_id)
+            await loop.process_message(msg)
+            return chat_id
+        except Exception:
+            logger.exception(
+                "per-agent dispatch failed for agent %s; falling back to bus",
+                chat_request.agent_id,
+            )
+
     bus = get_message_bus()
     await bus.publish_inbound(msg)
-
     return chat_id
 
 
@@ -273,6 +304,7 @@ async def chat_send(body: ChatRequest):
             session_id=chat_id,
             media=body.media,
             file_context=body.file_context,
+            agent_id=body.agent_id,
         )
     )
 
@@ -322,10 +354,15 @@ async def chat_stream(body: ChatRequest):
         # stream — otherwise we'd kill a task that's just finishing up
         # memory storage for the previous (completed) message.
         try:
-            from pocketpaw.dashboard_state import agent_loop
+            from pocketpaw.dashboard_state import _agent_loops, agent_loop
 
             session_key = f"websocket:{chat_id}"
+            # Try the default loop first, then every per-agent loop — only
+            # one of them owns the task. ``cancel_task`` is a no-op when
+            # the key is unknown, so this is safe.
             agent_loop.cancel_task(session_key)
+            for loop in list(_agent_loops.values()):
+                loop.cancel_task(session_key)
         except Exception:
             logger.debug("Could not cancel stale agent task", exc_info=True)
 
@@ -353,6 +390,7 @@ async def chat_stream(body: ChatRequest):
             session_id=chat_id,
             media=body.media,
             file_context=body.file_context,
+            agent_id=body.agent_id,
         )
     )
 
@@ -403,13 +441,16 @@ async def chat_stop(session_id: str = ""):
 
     # Also cancel the agent loop's processing task
     try:
-        from pocketpaw.dashboard_state import agent_loop
+        from pocketpaw.dashboard_state import _agent_loops, agent_loop
 
         # Derive chat_id from whatever format was given
         raw = session_id
         if raw.startswith(_WS_PREFIX):
             raw = raw[len(_WS_PREFIX) :]
-        agent_loop.cancel_task(f"websocket:{raw}")
+        session_key = f"websocket:{raw}"
+        agent_loop.cancel_task(session_key)
+        for loop in list(_agent_loops.values()):
+            loop.cancel_task(session_key)
     except Exception:
         pass
 

--- a/src/pocketpaw/bootstrap/cloud_agent_provider.py
+++ b/src/pocketpaw/bootstrap/cloud_agent_provider.py
@@ -1,0 +1,51 @@
+"""Bootstrap provider for cloud-defined agents.
+
+The default provider assembles identity/style/instructions from the OSS
+config (IDENTITY.md, USER.md, etc.). Cloud agents live in MongoDB with
+their own ``soul_persona`` + ``system_prompt`` + archetype/values, and
+should present that as the identity block for per-agent AgentLoops.
+"""
+
+from __future__ import annotations
+
+from pocketpaw.bootstrap.protocol import BootstrapContext, BootstrapProviderProtocol
+
+
+class CloudAgentBootstrapProvider(BootstrapProviderProtocol):
+    """Build a BootstrapContext from a cloud Agent.config dict."""
+
+    def __init__(self, agent_name: str, agent_config: dict) -> None:
+        self.agent_name = agent_name
+        self.agent_config = agent_config or {}
+
+    async def get_context(self) -> BootstrapContext:
+        cfg = self.agent_config
+        persona = (cfg.get("soul_persona") or "").strip()
+        system_prompt = (cfg.get("system_prompt") or "").strip()
+        archetype = (cfg.get("soul_archetype") or "").strip()
+        values = cfg.get("soul_values") or []
+
+        # Identity = the "who are you" block. Prefer an explicit system_prompt
+        # if set, otherwise fall back to the soul persona. Both together when
+        # the user configured both (system_prompt as extra directive).
+        identity_parts: list[str] = []
+        if persona:
+            identity_parts.append(persona)
+        if system_prompt and system_prompt != persona:
+            identity_parts.append(system_prompt)
+        identity = "\n\n".join(identity_parts) or f"You are {self.agent_name}."
+
+        soul_parts: list[str] = []
+        if archetype:
+            soul_parts.append(f"Archetype: {archetype}")
+        if values and isinstance(values, list):
+            soul_parts.append("Core values: " + ", ".join(str(v) for v in values))
+        soul = "\n".join(soul_parts)
+
+        return BootstrapContext(
+            name=self.agent_name,
+            identity=identity,
+            soul=soul,
+            style="",
+            instructions="",
+        )

--- a/src/pocketpaw/dashboard_state.py
+++ b/src/pocketpaw/dashboard_state.py
@@ -28,6 +28,46 @@ status_tracker = StatusTracker()
 # Wire up the agent loop so /kill can cancel in-flight sessions
 _get_cmd_handler().set_agent_loop(agent_loop)
 
+# Per-agent AgentLoop registry — cached on first use, keyed by cloud agent id.
+# These loops don't consume from the bus (unlike the default ``agent_loop``);
+# they're invoked directly via ``process_message`` from the /chat/stream
+# handler when a request targets a specific cloud agent.
+_agent_loops: dict[str, AgentLoop] = {}
+_agent_loops_lock = asyncio.Lock()
+
+
+async def get_agent_loop_for(agent_id: str) -> AgentLoop:
+    """Fetch-or-build the per-agent AgentLoop for ``agent_id``.
+
+    Falls back to the default singleton loop when the agent doc can't be
+    loaded (e.g. Beanie/Mongo not initialised) so callers never hit a
+    hard failure — the default loop will still produce *some* response,
+    just without the per-agent persona/backend override.
+    """
+    if agent_id in _agent_loops:
+        return _agent_loops[agent_id]
+
+    async with _agent_loops_lock:
+        if agent_id in _agent_loops:
+            return _agent_loops[agent_id]
+        try:
+            from beanie import PydanticObjectId
+
+            from ee.cloud.models.agent import Agent
+
+            doc = await Agent.get(PydanticObjectId(agent_id))
+            if doc is None:
+                return agent_loop
+            loop = AgentLoop(
+                agent_id=agent_id,
+                agent_name=doc.name,
+                agent_config=dict(doc.config or {}),
+            )
+        except Exception:
+            return agent_loop
+        _agent_loops[agent_id] = loop
+        return loop
+
 # Retain active_connections for legacy broadcasts until fully migrated
 active_connections: list[WebSocket] = []
 

--- a/src/pocketpaw/dashboard_state.py
+++ b/src/pocketpaw/dashboard_state.py
@@ -6,6 +6,7 @@ sub-modules (channels, auth, lifecycle, ws) need access to the same globals.
 
 import asyncio
 import importlib
+from typing import Any
 
 from pocketpaw.agents.loop import AgentLoop
 from pocketpaw.bus.adapters.websocket_adapter import WebSocketAdapter
@@ -32,7 +33,21 @@ _get_cmd_handler().set_agent_loop(agent_loop)
 # These loops don't consume from the bus (unlike the default ``agent_loop``);
 # they're invoked directly via ``process_message`` from the /chat/stream
 # handler when a request targets a specific cloud agent.
-_agent_loops: dict[str, AgentLoop] = {}
+#
+# Values hold the AgentLoop plus the Agent doc's ``updatedAt`` at build time
+# so we can detect staleness and rebuild when the operator edits the agent
+# in Mongo. A sentinel ``_NOT_FOUND`` is cached for agent ids whose doc
+# lookup returned ``None`` — avoids pounding Mongo with Agent.get() on every
+# message for a deleted agent.
+
+
+class _NotFound:
+    """Sentinel entry for agent ids that don't resolve to a Mongo doc."""
+
+
+_NOT_FOUND = _NotFound()
+_agent_loops: dict[str, AgentLoop | _NotFound] = {}
+_agent_loop_stamps: dict[str, Any] = {}  # agent_id -> Agent.updatedAt snapshot
 _agent_loops_lock = asyncio.Lock()
 
 
@@ -40,33 +55,63 @@ async def get_agent_loop_for(agent_id: str) -> AgentLoop:
     """Fetch-or-build the per-agent AgentLoop for ``agent_id``.
 
     Falls back to the default singleton loop when the agent doc can't be
-    loaded (e.g. Beanie/Mongo not initialised) so callers never hit a
-    hard failure — the default loop will still produce *some* response,
-    just without the per-agent persona/backend override.
+    loaded (e.g. Beanie/Mongo not initialised, or the id doesn't exist)
+    so callers never hit a hard failure — the default loop will still
+    produce *some* response, just without the per-agent persona/backend
+    override.
+
+    Cache invalidation mirrors ``AgentPool``: when the Agent doc's
+    ``updatedAt`` advances past the value we stored at build time, the
+    cached loop is discarded and rebuilt. Negative results (doc missing)
+    are cached as ``_NOT_FOUND`` to keep repeated lookups out of Mongo.
     """
-    if agent_id in _agent_loops:
-        return _agent_loops[agent_id]
+    from beanie import PydanticObjectId
+
+    from ee.cloud.models.agent import Agent
 
     async with _agent_loops_lock:
-        if agent_id in _agent_loops:
-            return _agent_loops[agent_id]
         try:
-            from beanie import PydanticObjectId
-
-            from ee.cloud.models.agent import Agent
-
             doc = await Agent.get(PydanticObjectId(agent_id))
-            if doc is None:
-                return agent_loop
-            loop = AgentLoop(
-                agent_id=agent_id,
-                agent_name=doc.name,
-                agent_config=dict(doc.config or {}),
-            )
         except Exception:
+            # Transient DB error — don't poison the cache; use the default
+            # loop for this request and retry lookup on the next one.
             return agent_loop
+
+        if doc is None:
+            _agent_loops[agent_id] = _NOT_FOUND
+            _agent_loop_stamps.pop(agent_id, None)
+            return agent_loop
+
+        cached = _agent_loops.get(agent_id)
+        stamp = _agent_loop_stamps.get(agent_id)
+        fresh = (
+            isinstance(cached, AgentLoop)
+            and stamp is not None
+            and doc.updatedAt is not None
+            and doc.updatedAt <= stamp
+        )
+        if fresh:
+            return cached  # type: ignore[return-value]
+
+        loop = AgentLoop(
+            agent_id=agent_id,
+            agent_name=doc.name,
+            agent_config=dict(doc.config or {}),
+        )
         _agent_loops[agent_id] = loop
+        _agent_loop_stamps[agent_id] = doc.updatedAt
         return loop
+
+
+def iter_per_agent_loops() -> list[AgentLoop]:
+    """Snapshot of live per-agent loops for cross-loop ops (cancel, stop).
+
+    Skips the ``_NOT_FOUND`` sentinel so callers only ever see real loops.
+    Reads the dict synchronously — safe under asyncio's single-threaded
+    scheduling, and avoids forcing every caller to hold ``_agent_loops_lock``
+    for a read-only snapshot.
+    """
+    return [v for v in _agent_loops.values() if isinstance(v, AgentLoop)]
 
 # Retain active_connections for legacy broadcasts until fully migrated
 active_connections: list[WebSocket] = []


### PR DESCRIPTION
## Summary

- `/chat/stream` now routes through a per-agent `AgentLoop` when a cloud `agent_id` is supplied, so the response matches the selected agent's persona / backend / model instead of falling through to the default PocketPaw loop.
- New `CloudAgentBootstrapProvider` builds `BootstrapContext` from `Agent.config` (soul_persona, system_prompt, archetype, values).
- New `dashboard_state.get_agent_loop_for(agent_id)` registry; falls back to the default singleton on failure so callers never hard-fail.

## Why

Non-pocketpaw agent DMs were all answered by the default PocketPaw identity/backend, regardless of which agent the user selected, because OSS `/chat/stream` accepted `agent_id` in the schema but dropped it before dispatch. The short-term fix (a `system_prompt_override` shim in `context_builder`) covered the persona gap but left backend/model and future per-agent hooks (soul, KB) unaddressed.

## Architecture

- Per-agent loops are **not** bus consumers — they're invoked directly via the new public `AgentLoop.process_message()` so multiple loops can coexist without racing for `InboundMessage`s. The default loop still consumes the bus.
- Outbound events still flow through the bus, so the SSE bridge and every other subscriber work unchanged.
- `_send_message` split into `_build_inbound_message` + dispatch (direct-call vs. bus publish).
- `chat_stop` and the stale-stream cancel walk all loops (default + per-agent) before giving up on a `cancel_task` lookup.
- The earlier `system_prompt_override` shim in `context_builder.build_system_prompt` is reverted — superseded by the per-agent bootstrap.

## Gaps still open (deferred)

- Per-agent **soul**: scoped loops skip `SoulManager` init; adding per-agent `.soul` paths is a follow-up.
- Per-agent **KnowledgeService** injection: `search_context(agent_id, query)` isn't wired into the per-agent system prompt yet. Planned as a `metadata.knowledge_context` block the context builder picks up.
- Per-agent loop **eviction**: registry grows unbounded. Fine for now (small agent count), needs LRU similar to `AgentPool` at scale.

`AgentPool` is untouched — it's still used by the ee cloud group-chat `agent_bridge` for `_run_agent_response`. Unifying the two paths onto this loop is a later migration.

## Test plan

- [x] `uv run pytest tests/test_agent_loop.py tests/test_concurrency.py` — 28 passed
- [x] Manual: send to non-pocketpaw agent DM, verify reply matches the agent's `soul_persona`
- [x] Manual: send to pocketpaw DM, verify no regression (default loop path)
- [ ] Reviewer: exercise `chat_stop` mid-stream on a per-agent session

🤖 Generated with [Claude Code](https://claude.com/claude-code)