### PR TITLE
feat(chat): inline quoted replies — drop thread panel

### DIFF
--- a/ee/cloud/chat/message_service.py
+++ b/ee/cloud/chat/message_service.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import asyncio
-
 import logging
 import re
 from datetime import UTC, datetime
@@ -25,9 +24,9 @@ from ee.cloud.chat.schemas import (
     EditMessageRequest,
     SendMessageRequest,
 )
+from ee.cloud.chat.unread_service import UnreadService
 from ee.cloud.models.message import Attachment, Mention, Message, Reaction
 from ee.cloud.models.notification import NotificationSource
-from ee.cloud.chat.unread_service import UnreadService
 from ee.cloud.notifications.service import NotificationService
 from ee.cloud.realtime.emit import emit
 from ee.cloud.realtime.events import (
@@ -36,7 +35,6 @@ from ee.cloud.realtime.events import (
     MessageNew,
     MessageReaction,
     MessageSent,
-    ThreadReply,
     UnreadUpdate,
 )
 from ee.cloud.shared.errors import Forbidden, NotFound
@@ -51,8 +49,38 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _message_response(msg: Message) -> dict:
-    """Convert a Message document to a frontend-compatible dict."""
+_REPLY_PREVIEW_CHARS = 140
+
+
+def _reply_preview(parent: Message | None) -> dict | None:
+    """Build a small preview payload for an inline reply quote.
+
+    Rendered as the small quote bubble above a reply message. We keep the
+    text short so history payloads don't balloon for channels with lots
+    of replies. ``None`` when the parent is missing or soft-deleted — the
+    FE falls back to a "message deleted" placeholder.
+    """
+    if parent is None or parent.deleted:
+        return None
+    snippet = (parent.content or "")[:_REPLY_PREVIEW_CHARS]
+    return {
+        "id": str(parent.id),
+        "content": snippet,
+        "sender": parent.sender,
+        "senderType": parent.sender_type,
+        "agent": parent.agent,
+    }
+
+
+def _message_response(msg: Message, *, parent: Message | None = None) -> dict:
+    """Convert a Message document to a frontend-compatible dict.
+
+    When ``parent`` is supplied (because the caller already fetched it,
+    or prefetched a batch for a list view), a ``replyPreview`` field is
+    included so the FE can render the inline quote without a second
+    fetch. For replies where the parent isn't resolvable (deleted, or
+    caller chose not to fetch), ``replyPreview`` is ``None``.
+    """
     return {
         "_id": str(msg.id),
         "group": msg.group,
@@ -62,6 +90,7 @@ def _message_response(msg: Message) -> dict:
         "content": msg.content,
         "mentions": [m.model_dump() for m in msg.mentions],
         "replyTo": msg.reply_to,
+        "replyPreview": _reply_preview(parent) if msg.reply_to else None,
         "threadCount": msg.thread_count,
         "attachments": [a.model_dump() for a in msg.attachments],
         "reactions": [r.model_dump() for r in msg.reactions],
@@ -126,19 +155,24 @@ class MessageService:
         group.message_count += 1
         await group.save()
 
+        # Resolve the reply parent once so we can both embed a preview in
+        # the response and keep replies rendering inline in the main feed.
+        # The previous implementation also bumped ``parent.thread_count``
+        # and emitted a ``ThreadReply`` event — we've moved to inline
+        # quoted replies (Telegram-style), so neither is needed: the
+        # parent's counter isn't displayed anywhere and the reply fans out
+        # via ``MessageNew`` like any other message.
+        parent: Message | None = None
         if body.reply_to:
             try:
-                from beanie import PydanticObjectId
                 parent_id = PydanticObjectId(body.reply_to)
                 parent = await Message.find_one({"_id": parent_id, "context_type": "group"})
-                if parent is not None:
-                    parent.thread_count = (parent.thread_count or 0) + 1
-                    await parent.save()
             except Exception:
-                # Bad reply_to — skip bump; main send already succeeded
-                pass
+                # Bad reply_to — the reply still sends; FE will render it
+                # without a quote bubble.
+                parent = None
 
-        response = _message_response(msg)
+        response = _message_response(msg, parent=parent)
 
         await event_bus.emit(
             "message.sent",
@@ -155,11 +189,10 @@ class MessageService:
 
         # Realtime fan-out: message.new to the group (sender excluded via
         # AudienceResolver reading data["sender"]), message.sent ack to the
-        # sender only (keyed by data["sender_id"]).
-        if body.reply_to:
-            await emit(ThreadReply(data={**response, "group_id": group_id, "root_message_id": body.reply_to}))
-        else:
-            await emit(MessageNew(data={**response, "group_id": group_id}))
+        # sender only (keyed by data["sender_id"]). Inline replies share
+        # the same ``MessageNew`` channel as top-level messages — the quote
+        # bubble is rendered client-side from ``replyPreview``.
+        await emit(MessageNew(data={**response, "group_id": group_id}))
         await emit(MessageSent(data={**response, "group_id": group_id, "sender_id": user_id}))
 
         # Unread badge sync — every non-sender member receives a delta so their
@@ -406,7 +439,24 @@ class MessageService:
         if has_more:
             messages = messages[:limit]
 
-        items = [_message_response(m) for m in messages]
+        # Batch-fetch parents for any replies in this page so ``replyPreview``
+        # lands on each reply without an N+1 round-trip. Missing parents are
+        # tolerated — the FE falls back to a "message unavailable" bubble.
+        parent_ids = {m.reply_to for m in messages if m.reply_to}
+        parents_by_id: dict[str, Message] = {}
+        if parent_ids:
+            try:
+                oids = [PydanticObjectId(pid) for pid in parent_ids if pid]
+            except Exception:
+                oids = []
+            if oids:
+                parent_docs = await Message.find({"_id": {"$in": oids}}).to_list()
+                parents_by_id = {str(p.id): p for p in parent_docs}
+
+        items = [
+            _message_response(m, parent=parents_by_id.get(m.reply_to) if m.reply_to else None)
+            for m in messages
+        ]
 
         next_cursor: str | None = None
         if has_more and messages:

--- a/ee/cloud/shared/agent_bridge.py
+++ b/ee/cloud/shared/agent_bridge.py
@@ -336,13 +336,18 @@ async def _run_agent_response(
     )
     await msg.insert()
 
-    # Broadcast final message
+    # Broadcast final message. ``temp_message_id`` is echoed from the
+    # matching ``stream_start`` so the FE can precisely replace the
+    # streaming placeholder — without it, a group with two agents
+    # responding concurrently would race on a startsWith('agent-stream-')
+    # lookup and finalize the wrong row.
     await emit(
         AgentStreamEnd(
             data={
                 "group_id": group_id,
                 "agent_id": agent_id,
                 "message_id": str(msg.id),
+                "temp_message_id": temp_msg_id,
                 "content": full_text,
                 "ripple_spec": ripple_spec,
                 "pocket_id": pocket_id,

--- a/tests/cloud/chat/test_message_emits.py
+++ b/tests/cloud/chat/test_message_emits.py
@@ -394,14 +394,15 @@ async def test_send_message_emits_unread_update_for_non_senders():
 
 
 @pytest.mark.asyncio
-async def test_send_reply_bumps_thread_count_on_parent():
-    """A message with reply_to set increments the parent message's thread_count."""
+async def test_send_reply_does_not_bump_thread_count():
+    """Inline-quoted replies replaced threads: parent.thread_count stays
+    untouched so we don't do a pointless parent write on every reply."""
     from types import SimpleNamespace
 
     from ee.cloud.chat.message_service import MessageService
     from ee.cloud.chat.schemas import SendMessageRequest
 
-    recorded, fake_emit = _capture_emits()
+    _recorded, fake_emit = _capture_emits()
     group = _fake_group(owner="sender", members=["sender", "u2"])
 
     parent = SimpleNamespace(id="parent1", thread_count=0, save=AsyncMock())
@@ -424,12 +425,14 @@ async def test_send_reply_bumps_thread_count_on_parent():
             SendMessageRequest(content="a reply", reply_to="507f1f77bcf86cd799439011"),
         )
 
-    assert parent.thread_count == 1
-    parent.save.assert_awaited_once()
+    assert parent.thread_count == 0
+    parent.save.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_send_reply_emits_thread_reply_not_message_new():
+async def test_send_reply_emits_message_new_not_thread_reply():
+    """Inline replies fan out via MessageNew; no ThreadReply event fires
+    because we no longer render a separate thread panel."""
     from types import SimpleNamespace
 
     from ee.cloud.chat.message_service import MessageService
@@ -460,6 +463,5 @@ async def test_send_reply_emits_thread_reply_not_message_new():
 
     threads = [e for e in recorded if isinstance(e, ThreadReply)]
     news = [e for e in recorded if isinstance(e, MessageNew)]
-    assert len(threads) == 1
-    assert threads[0].data.get("root_message_id") == "507f1f77bcf86cd799439011"
-    assert len(news) == 0  # no MessageNew on replies
+    assert len(threads) == 0
+    assert len(news) == 1


### PR DESCRIPTION
## Summary

Replaces the side-panel thread UI with Telegram-style inline quoted replies.

- `MessageService.send_message` resolves the reply parent once, attaches a compact `replyPreview` ({id, content[:140], sender, senderType, agent}) to the response, and emits `MessageNew` for fan-out instead of `ThreadReply`.
- `list_messages` batch-fetches parents for the current page (one `{_id: {\$in: [...]}}` round-trip) so history loads include `replyPreview` without N+1.
- Dropped the `parent.thread_count` bump — nothing renders it anymore.
- Kept `reply_to` on `Message`, `thread_count` on the model, `get_thread` endpoint, and the `ThreadReply` event class for legacy compatibility. They're off the hot path.

## Test plan

- [x] `uv run pytest tests/cloud/chat/` — 51 passed (includes rewritten `test_send_reply_does_not_bump_thread_count` and `test_send_reply_emits_message_new_not_thread_reply`)
- [ ] Reviewer: post a reply from the FE, verify the quote bubble renders from the initial response (no extra fetch) and on history reload

## Paired with

Frontend: https://github.com/qbtrix/paw-enterprise/pull/new/feat/inline-replies — drops the thread panel and renders inline quote bubbles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)