### PR TITLE
hotfix(chat): smart-mode agents stalling group sends 5–10s

### DIFF
--- a/ee/cloud/shared/agent_bridge.py
+++ b/ee/cloud/shared/agent_bridge.py
@@ -32,21 +32,44 @@ from ee.cloud.shared.events import event_bus
 logger = logging.getLogger(__name__)
 
 
+_background_tasks: set[asyncio.Task] = set()
+
+
 async def on_message_for_agents(data: dict) -> None:
-    """Handle message.sent event — check if any agents should respond."""
+    """Handle message.sent event — check if any agents should respond.
+
+    Dispatches all the actual work (respond-mode checks, smart-mode LLM
+    calls, ``_run_agent_response``) to a background task so the ``event_bus``
+    emitter — which is awaited on the group-chat send path — returns
+    immediately. Before this, a ``smart``-mode agent blocked the
+    ``MessageSent`` realtime broadcast for the full duration of a Haiku
+    relevance-check call (5–10s), making the sender wait seconds to see
+    their own message ack.
+    """
     group_id = data.get("group_id")
-    sender_id = data.get("sender_id")
     sender_type = data.get("sender_type", "user")
     content = data.get("content", "")
-    mentions = data.get("mentions", [])
-    workspace_id = data.get("workspace_id", "")
 
     if not group_id or not content:
         return
-
-    # Don't respond to agent messages (prevent loops)
     if sender_type == "agent":
+        # Don't respond to agent messages (prevent loops)
         return
+
+    task = asyncio.create_task(_dispatch_agent_responses(data))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+async def _dispatch_agent_responses(data: dict) -> None:
+    """Background worker for ``on_message_for_agents`` — does the actual
+    respond-mode evaluation and per-agent response spawning. Runs
+    detached from the emitter's await chain."""
+    group_id = data.get("group_id")
+    sender_id = data.get("sender_id")
+    content = data.get("content", "")
+    mentions = data.get("mentions", [])
+    workspace_id = data.get("workspace_id", "")
 
     logger.info("Agent bridge: message in group %s from %s: %s", group_id, sender_id, content[:50])
 


### PR DESCRIPTION
## The bug

Group sends into a channel that has a \`smart\`-mode agent stall for 5–10 seconds. The sender's own \`message.sent\` ack AND the \`message.new\` broadcast to other members are both delayed by the full duration of a Haiku LLM relevance-check call.

## Root cause

\`MessageService.send_message\` awaits \`event_bus.emit('message.sent')\` on the hot path. \`agent_bridge.on_message_for_agents\` is subscribed to that event and the handler serially awaits \`_should_agent_respond\` for each attached agent. For \`smart\` mode, that function awaits \`_smart_relevance_check\` — an LLM round-trip to Haiku.

So:

\`\`\`
send_message
  └── event_bus.emit("message.sent")   ← awaited
         └── on_message_for_agents     ← awaited
              └── _should_agent_respond
                   └── _smart_relevance_check  ← 5–10s LLM call
  then: emit(MessageNew), emit(MessageSent)
\`\`\`

Everyone sees the message late.

## Fix

\`on_message_for_agents\` now spawns \`_dispatch_agent_responses\` as a background task and returns immediately. The emitter unblocks, the realtime fan-out fires on time, and smart-mode evaluation + \`_run_agent_response\` spawning continues detached from the request.

Also cherry-picked from PR #977 — but split out here as a standalone hotfix since the underlying issue is production-blocking and PR #977 carries a much larger change (per-agent AgentLoop).

## Test plan

- [x] \`uv run pytest tests/cloud/chat/\` — 51 passed (unchanged)
- [ ] Reviewer: in a channel with a \`smart\`-mode agent, confirm the sender's WS \`message.sent\` ack returns inside ~100ms and other members see \`message.new\` immediately (rather than after the Haiku call completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)