### PR TITLE
fix(chat): auto-mode agents skip replies directed at other parties

### DIFF
--- a/ee/cloud/chat/message_service.py
+++ b/ee/cloud/chat/message_service.py
@@ -174,6 +174,18 @@ class MessageService:
 
         response = _message_response(msg, parent=parent)
 
+        # Thread reply-target metadata into the event so the agent bridge can
+        # decide whether an ``auto``-mode agent should respond. A reply aimed
+        # at a human is a directed side-conversation and shouldn't summon
+        # auto agents; a reply aimed at an agent is a follow-up and should
+        # go through the normal respond-mode logic.
+        reply_meta: dict = {}
+        if body.reply_to:
+            reply_meta["reply_to"] = body.reply_to
+            if parent is not None:
+                reply_meta["reply_to_sender_type"] = parent.sender_type
+                reply_meta["reply_to_agent_id"] = parent.agent
+
         await event_bus.emit(
             "message.sent",
             {
@@ -184,6 +196,7 @@ class MessageService:
                 "content": body.content,
                 "mentions": body.mentions,
                 "workspace_id": group.workspace,
+                **reply_meta,
             },
         )
 

--- a/ee/cloud/shared/agent_bridge.py
+++ b/ee/cloud/shared/agent_bridge.py
@@ -70,6 +70,12 @@ async def _dispatch_agent_responses(data: dict) -> None:
     content = data.get("content", "")
     mentions = data.get("mentions", [])
     workspace_id = data.get("workspace_id", "")
+    # Reply metadata — used to skip ``auto``-mode agents when the message is
+    # a directed reply to another human (or to a different agent). Absent
+    # for top-level messages.
+    reply_to = data.get("reply_to")
+    reply_to_sender_type = data.get("reply_to_sender_type")
+    reply_to_agent_id = data.get("reply_to_agent_id")
 
     logger.info("Agent bridge: message in group %s from %s: %s", group_id, sender_id, content[:50])
 
@@ -93,7 +99,14 @@ async def _dispatch_agent_responses(data: dict) -> None:
     )
 
     for group_agent in group.agents:
-        should = await _should_agent_respond(group_agent, content, mentions)
+        should = await _should_agent_respond(
+            group_agent,
+            content,
+            mentions,
+            reply_to=reply_to,
+            reply_to_sender_type=reply_to_sender_type,
+            reply_to_agent_id=reply_to_agent_id,
+        )
         logger.info(
             "Agent bridge: agent %s respond_mode=%s should_respond=%s",
             group_agent.agent,
@@ -112,7 +125,15 @@ async def _dispatch_agent_responses(data: dict) -> None:
             )
 
 
-async def _should_agent_respond(group_agent: Any, content: str, mentions: list) -> bool:
+async def _should_agent_respond(
+    group_agent: Any,
+    content: str,
+    mentions: list,
+    *,
+    reply_to: str | None = None,
+    reply_to_sender_type: str | None = None,
+    reply_to_agent_id: str | None = None,
+) -> bool:
     """Determine if an agent should respond.
 
     Precedence:
@@ -121,7 +142,15 @@ async def _should_agent_respond(group_agent: Any, content: str, mentions: list) 
        agents respond. Non-mentioned agents — even those on ``auto`` — stay
        quiet so multiple auto agents don't all answer when the user is
        clearly addressing one.
-    3. With no agent mentions, fall back to per-agent mode:
+    3. If the message is a reply aimed at someone else, no agent chimes in
+       unless it was specifically mentioned (handled in step 2):
+       - Reply to a human → nobody auto-responds; the message is a directed
+         side-conversation between two users.
+       - Reply to a *different* agent → that agent's turn, not ours.
+       - Reply to *this* agent → fall through to the normal mode checks so
+         a follow-up actually gets answered.
+    4. With no agent mentions and no directed reply, fall back to per-agent
+       mode:
        - ``auto`` → respond
        - ``mention_only`` → don't respond
        - ``smart`` → ask a cheap LLM whether this agent is relevant
@@ -134,6 +163,13 @@ async def _should_agent_respond(group_agent: Any, content: str, mentions: list) 
     agent_mentions = [m for m in mentions if m.get("type") == "agent"]
     if agent_mentions:
         return any(m.get("id") == group_agent.agent for m in agent_mentions)
+
+    # Directed reply handling — see docstring step 3.
+    if reply_to:
+        if reply_to_sender_type == "user":
+            return False
+        if reply_to_sender_type == "agent" and reply_to_agent_id != group_agent.agent:
+            return False
 
     if mode == "auto":
         return True

--- a/tests/cloud/chat/test_message_emits.py
+++ b/tests/cloud/chat/test_message_emits.py
@@ -405,7 +405,13 @@ async def test_send_reply_does_not_bump_thread_count():
     _recorded, fake_emit = _capture_emits()
     group = _fake_group(owner="sender", members=["sender", "u2"])
 
-    parent = SimpleNamespace(id="parent1", thread_count=0, save=AsyncMock())
+    parent = SimpleNamespace(
+        id="parent1",
+        thread_count=0,
+        sender_type="user",
+        agent=None,
+        save=AsyncMock(),
+    )
     fake_msg_ns = SimpleNamespace(id="reply1", createdAt=None, insert=AsyncMock())
 
     fake_message_class = MagicMock(return_value=fake_msg_ns)
@@ -441,7 +447,13 @@ async def test_send_reply_emits_message_new_not_thread_reply():
 
     recorded, fake_emit = _capture_emits()
     group = _fake_group(owner="sender", members=["sender"])
-    parent = SimpleNamespace(id="parent1", thread_count=0, save=AsyncMock())
+    parent = SimpleNamespace(
+        id="parent1",
+        thread_count=0,
+        sender_type="user",
+        agent=None,
+        save=AsyncMock(),
+    )
     fake_msg_ns = SimpleNamespace(id="r1", createdAt=None, insert=AsyncMock(), thread_count=0)
 
     fake_message_class = MagicMock(return_value=fake_msg_ns)


### PR DESCRIPTION
## The bug

In a channel with an \`auto\`-mode agent, replying to a human message triggered the agent to respond — even though the user wasn't addressing the agent. Every reply now summons the agent.

## Root cause

\`_should_agent_respond\` treated every non-agent message as a candidate for auto-mode response. It didn't look at \`reply_to\` at all, so replies directed at another user were indistinguishable from open messages.

## Fix

Thread reply-target metadata through the pipeline:

- \`send_message\` adds \`reply_to_sender_type\` + \`reply_to_agent_id\` to the \`message.sent\` event (from the parent we already fetch for \`replyPreview\`).
- \`_dispatch_agent_responses\` extracts them and passes through.
- \`_should_agent_respond\` skips for directed replies:
  - Reply to a human → no auto-response
  - Reply to a *different* agent → not this agent's turn
  - Reply to *this* agent → fall through to mode checks so follow-ups still get answered
  - @-mentions still win over all of the above (unchanged)

## Test plan

- [x] \`uv run pytest tests/cloud/chat/\` — 51 passed (adjusted mocks for new parent attrs)
- [ ] Reviewer: in a channel with auto-mode agent, reply to a human — agent should stay quiet; reply to the agent — agent should answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)