### PR TITLE
fix(chat): silence WS disconnect race noise in cloud socket

### DIFF
--- a/ee/cloud/chat/router.py
+++ b/ee/cloud/chat/router.py
@@ -467,6 +467,13 @@ async def websocket_endpoint(websocket: WebSocket, token: str = Query(...)):
 
     except WebSocketDisconnect:
         pass
+    except RuntimeError as e:
+        # Starlette raises RuntimeError("WebSocket is not connected...") when
+        # receive_text() is called after the socket already transitioned to
+        # DISCONNECTED (e.g. a concurrent send/recv consumed the disconnect
+        # frame). Treat as a normal disconnect.
+        if "not connected" not in str(e).lower():
+            logger.exception("WebSocket error for user=%s", user_id)
     except Exception:
         logger.exception("WebSocket error for user=%s", user_id)
     finally:


### PR DESCRIPTION
Starlette's `websocket.receive_text()` can raise a bare `RuntimeError('WebSocket is not connected...')` during a client-disconnect race. The existing `Exception` fallback turned every clean close into `logger.exception` noise. Match on the 'not connected' substring and treat as a quiet disconnect; everything else still goes to `logger.exception`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)