### PR TITLE
fix(chat): forward channel attachments into agent prompt

### DIFF
--- a/ee/cloud/chat/message_service.py
+++ b/ee/cloud/chat/message_service.py
@@ -1,6 +1,9 @@
 # Refactored: Split from service.py — contains MessageService class and message-related
 # helper functions. Added create_agent_message() static method for use by agent_bridge
 # instead of creating Message documents directly.
+# 2026-04-19: ``message.sent`` event now carries ``attachments`` so agent_bridge
+# can surface filename/mime/size into the channel agent prompt (fixes silent
+# attachment drop on the channel path — DM path already had this).
 
 """Chat domain — message business logic (CRUD, reactions, threads, pins, search)."""
 
@@ -195,6 +198,12 @@ class MessageService:
                 "sender_type": "user",
                 "content": body.content,
                 "mentions": body.mentions,
+                # Attachments ride on the event so ``agent_bridge`` can inject
+                # filename / mime / size into the agent prompt. Mirrors the DM
+                # path's file-awareness contract; raw dicts match
+                # ``body.attachments``'s shape and downstream handlers no-op on
+                # unknown keys.
+                "attachments": body.attachments,
                 "workspace_id": group.workspace,
                 **reply_meta,
             },

--- a/ee/cloud/shared/agent_bridge.py
+++ b/ee/cloud/shared/agent_bridge.py
@@ -1,7 +1,12 @@
 """Bridge between cloud chat events and the PocketPaw agent pool.
 
-Changes: Replaced inline pocket creation with PocketService.create_from_ripple_spec()
-to reduce coupling. Pocket creation logic now lives in the pockets domain.
+Changes:
+- 2026-04-19: Forward ``Message.attachments`` through ``on_message_for_agents``
+  and ``_run_agent_response`` so channel agents see filename/mime/size context.
+  Matches the DM path's shape (``Attached files:`` block appended to the user
+  prompt before ``pool.run``); keeps ``pool.run``'s signature unchanged.
+- Replaced inline pocket creation with PocketService.create_from_ripple_spec()
+  to reduce coupling. Pocket creation logic now lives in the pockets domain.
 
 Responsibilities (focused orchestrator):
 1. Checks each agent's respond_mode (silent, auto, mention_only, smart)
@@ -70,6 +75,10 @@ async def _dispatch_agent_responses(data: dict) -> None:
     content = data.get("content", "")
     mentions = data.get("mentions", [])
     workspace_id = data.get("workspace_id", "")
+    # Attachments ride the ``message.sent`` payload so channel agents see the
+    # same filename/mime/size context DM agents already get. Defaults to ``[]``
+    # so emit sites that don't populate it (legacy or test) stay compatible.
+    attachments = data.get("attachments", []) or []
     # Reply metadata — used to skip ``auto``-mode agents when the message is
     # a directed reply to another human (or to a different agent). Absent
     # for top-level messages.
@@ -121,6 +130,7 @@ async def _dispatch_agent_responses(data: dict) -> None:
                     workspace_id=workspace_id,
                     user_message=content,
                     group_members=group.members,
+                    attachments=attachments,
                 )
             )
 
@@ -226,19 +236,77 @@ async def _smart_relevance_check(agent_id: str, content: str) -> bool:
         return False
 
 
+def _format_bytes(n: int | None) -> str:
+    """Compact human-readable byte size (``12.3 KB``).
+
+    Mirrors the helper used on the DM path so channel prompts render file
+    sizes the same way. ``None`` / unknown returns an empty string.
+    """
+    if not isinstance(n, int) or n < 0:
+        return ""
+    units = ("B", "KB", "MB", "GB", "TB")
+    size = float(n)
+    for unit in units:
+        if size < 1024 or unit == units[-1]:
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return ""
+
+
+def _augment_message_with_attachments(
+    content: str, attachments: list[dict] | None
+) -> str:
+    """Append an ``Attached files`` block to ``content`` so agents see context.
+
+    Attachment dicts come off the ``message.sent`` event payload. Each entry
+    is permissive: ``name``, ``url``, ``meta.mime``, ``meta.size``. Missing
+    fields degrade gracefully — an attachment with only a name still shows up,
+    which is better than silently dropping it like the pre-fix behavior did.
+    """
+    if not attachments:
+        return content
+    lines: list[str] = []
+    for att in attachments:
+        if not isinstance(att, dict):
+            continue
+        name = att.get("name") or "file"
+        meta = att.get("meta") or {}
+        mime = meta.get("mime") or att.get("type") or "application/octet-stream"
+        size_str = _format_bytes(meta.get("size"))
+        url = att.get("url", "")
+        meta_suffix = f", {size_str}" if size_str else ""
+        location = f" at {url}" if url else ""
+        lines.append(f"- {name} ({mime}{meta_suffix}){location}")
+    if not lines:
+        return content
+    return f"{content}\n\nAttached files:\n" + "\n".join(lines)
+
+
 async def _run_agent_response(
     agent_id: str,
     group_id: str,
     workspace_id: str,
     user_message: str,
     group_members: list[str],
+    attachments: list[dict] | None = None,
 ) -> None:
-    """Run an agent's response and stream it to the group."""
+    """Run an agent's response and stream it to the group.
+
+    ``attachments`` carries the triggering user message's files (shape matches
+    ``ee.cloud.models.message.Attachment``: ``type``, ``url``, ``name``,
+    ``meta``). They're formatted into ``user_message`` before ``pool.run`` so
+    the agent sees filename/mime/size the same way it does on the DM path.
+    """
     from ee.cloud.models.message import Attachment, Message
     from pocketpaw.agents.pool import get_agent_pool
 
     pool = get_agent_pool()
     session_key = f"cloud:{group_id}:{agent_id}"
+
+    # Match the DM path's shape (``src/pocketpaw/agents/loop.py``) — append an
+    # "Attached files" block to the prompt so agents can reason about channel
+    # uploads. Kept inline so ``pool.run``'s signature stays untouched.
+    user_message = _augment_message_with_attachments(user_message, attachments)
 
     logger.info("Agent bridge: running response for agent %s in group %s", agent_id, group_id)
 

--- a/tests/cloud/shared/test_agent_bridge_attachments.py
+++ b/tests/cloud/shared/test_agent_bridge_attachments.py
@@ -1,0 +1,136 @@
+"""Regression test: channel agent bridge forwards attachments to pool.run.
+
+Created 2026-04-19: guards against the silent attachment-drop bug where
+``_run_agent_response`` never surfaced ``Message.attachments`` into the agent
+prompt. The DM path formats file metadata into the user content as
+``Attached files:\\n- <name> (<mime>, <size>) at <url>`` lines; the channel
+path must match that shape so agents in groups see the same file context DM
+users already get.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class _AsyncIter:
+    """Minimal async iterator that yields a done event, then stops."""
+
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._events:
+            raise StopAsyncIteration
+        return self._events.pop(0)
+
+
+def _done_event():
+    return SimpleNamespace(type="done", content="", metadata={})
+
+
+@pytest.mark.asyncio
+async def test_run_agent_response_forwards_attachments_to_pool_run():
+    """Channel agent bridge must forward Message.attachments into pool.run.
+
+    Before the fix, ``on_message_for_agents`` and ``_run_agent_response``
+    ignored ``data["attachments"]``, so ``pool.run`` received only the bare
+    text. The agent then had no filename/mime/size context for files the user
+    shared in a channel. After the fix, the attachments travel through to the
+    prompt using the same shape the DM path uses.
+    """
+    from ee.cloud.shared import agent_bridge
+
+    # Stub agent instance returned by pool.get
+    instance = SimpleNamespace(agent_name="Test Agent")
+
+    pool = MagicMock()
+    pool.get = AsyncMock(return_value=instance)
+    captured: dict = {}
+
+    async def fake_run(agent_id, user_message, session_key, history=None, knowledge_context=""):
+        captured["agent_id"] = agent_id
+        captured["user_message"] = user_message
+        captured["session_key"] = session_key
+        captured["history"] = history
+        captured["knowledge_context"] = knowledge_context
+        # Yield only ``done`` — ``full_text`` stays empty so the bridge's
+        # ``if not full_text.strip(): return`` short-circuits before the Mongo
+        # persistence branch (which would need Beanie initialized to execute
+        # ``Message(...)``). Keeps the test at unit-scope while still capturing
+        # what we care about: the prompt handed to ``pool.run``.
+        yield _done_event()
+
+    pool.run = fake_run
+    pool.observe = AsyncMock()
+
+    # Mongo Message.find(...).sort(...).limit(...).to_list() — return no history
+    # so the bridge doesn't try to talk to a real database.
+    to_list_mock = AsyncMock(return_value=[])
+    limit_mock = MagicMock()
+    limit_mock.to_list = to_list_mock
+    sort_mock = MagicMock()
+    sort_mock.limit = MagicMock(return_value=limit_mock)
+    find_mock = MagicMock()
+    find_mock.sort = MagicMock(return_value=sort_mock)
+
+    from ee.cloud.models.message import Message as _RealMessage
+
+    # Beanie isn't initialized in unit tests, so ``Message.group`` / etc. raise
+    # AttributeError. Stamp the class attributes Beanie would otherwise provide
+    # for query-builder expressions. They're MagicMocks that no-op on `==`.
+    _patched_attrs = {"group": MagicMock(), "deleted": MagicMock(), "createdAt": MagicMock()}
+
+    # Patch class-level ``find`` so the history query returns [] without a DB.
+    # Patch ``Message.insert`` so the agent-message persistence step no-ops.
+    attachments_in = [
+        {
+            "type": "image",
+            "url": "/api/v1/uploads/abc123",
+            "name": "diagram.png",
+            "meta": {"mime": "image/png", "size": 48_000, "id": "abc123"},
+        },
+    ]
+
+    with (
+        patch("ee.cloud.shared.agent_bridge.emit", new=AsyncMock()),
+        patch.multiple(_RealMessage, create=True, **_patched_attrs),
+        patch.object(_RealMessage, "find", MagicMock(return_value=find_mock)),
+        patch.object(_RealMessage, "insert", new=AsyncMock(return_value=None)),
+        patch(
+            "pocketpaw.agents.pool.get_agent_pool",
+            return_value=pool,
+        ),
+        patch(
+            "ee.cloud.agents.knowledge.KnowledgeService.search_context",
+            new=AsyncMock(return_value=""),
+        ),
+    ):
+        await agent_bridge._run_agent_response(
+            agent_id="agent-1",
+            group_id="group-1",
+            workspace_id="ws-1",
+            user_message="what's in this file?",
+            group_members=["user-1"],
+            attachments=attachments_in,
+        )
+
+    # The bridge must have called pool.run with a prompt that carries the
+    # file-awareness block (filename / mime / size). Matching the DM shape
+    # lets agents reason about channel attachments the same way they already
+    # do for DMs.
+    assert "user_message" in captured, "pool.run was never invoked"
+    augmented = captured["user_message"]
+    assert "diagram.png" in augmented, f"filename missing from prompt: {augmented!r}"
+    assert "image/png" in augmented, f"mime missing from prompt: {augmented!r}"
+    # The DM path renders size via a human-readable helper (_format_bytes).
+    # Size presence is the contract; exact formatting is incidental.
+    assert "Attached" in augmented or "attached" in augmented, (
+        f"no attachment header in prompt: {augmented!r}"
+    )


### PR DESCRIPTION
## Summary

Channel agents were missing the filename/mime/size block that DM agents already get from PR #969. Drop a PDF in a group chat and the agent answered as if no file existed.

The `message.sent` event payload didn't carry attachments, and `_run_agent_response` had no attachments parameter. So they never reached the prompt passed to `pool.run`.

## What changed

- `ee/cloud/chat/message_service.py`: include `body.attachments` in the `message.sent` emit. Additive change. Existing subscribers ignore unknown keys.
- `ee/cloud/shared/agent_bridge.py`: `_dispatch_agent_responses` now reads `data["attachments"]` and passes it to `_run_agent_response`, which appends an `Attached files:` block to the user prompt before calling `pool.run`. Shape matches the DM path in `src/pocketpaw/agents/loop.py` (filename, mime, readable size, URL).
- `pool.run`'s signature is unchanged.

## Test plan

- [x] New test `tests/cloud/shared/test_agent_bridge_attachments.py` fails on pre-fix code with `TypeError: _run_agent_response() got an unexpected keyword argument 'attachments'` and passes on this branch.
- [x] `uv run pytest tests/cloud/shared/ tests/cloud/chat/`: passing tests stay green. Two pre-existing failures on other files are unrelated (hardcoded Windows path; audit export matcher).
- [ ] Manual smoke: drop a file into a group with an auto-mode agent and check the reply references the filename or type.