### PR TITLE
Shared pytest fixtures for ee tests (Wave 2 minimal)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -400,6 +400,7 @@ dev = [
     "mypy>=1.8.0",
     "pytest-playwright>=0.7.2",
     "mongomock-motor>=0.0.36",
+    "moto[s3]>=5.0.0",
     "types-aiofiles>=25.1.0.20260409",
 ]
 

--- a/tests/ee/conftest.py
+++ b/tests/ee/conftest.py
@@ -1,0 +1,365 @@
+# tests/ee/conftest.py — Shared pytest fixtures for ee/cloud integration tests.
+# Created: 2026-04-19 (Wave 2.2 / feat/wave-2-pytest-fixtures-v2)
+#
+# Minimal slice of the Wave 2 hardening plan. Three callable factories
+# (``user_token_pair``, ``workspace_factory``, ``seeded_channel``) plus the
+# supporting scaffolding (mongomock-motor db, mounted FastAPI, httpx client,
+# moto s3). Composes on the existing ``mongomock-motor`` primitive already in
+# use under ``tests/cloud/chat/conftest.py`` — no new Mongo infrastructure.
+#
+# Deferred to later waves:
+#   * ``fleet_installed_org`` — Wave 3 Cluster D
+#   * ``drive_connected_pocket`` — Wave 3 Cluster C
+#   * The full seed set from Appendix B — Wave 2.1
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib.util
+import json
+import os
+import uuid
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+
+def _require_enterprise() -> None:
+    """Skip the calling fixture if the ee/cloud dependencies are missing.
+
+    The fixtures in this module mount the real ee/cloud router tree, which
+    pulls in ``beanie``, ``motor``, ``fastapi-users``, etc. Those only land
+    when the ``enterprise`` extra is installed (``uv sync --extra enterprise``
+    or the package ``[enterprise]`` install). When they're missing we emit
+    a ``skip`` rather than an ``ImportError`` so the rest of the ``tests/ee/``
+    suite keeps collecting.
+    """
+
+    for module in ("beanie", "motor", "mongomock_motor"):
+        if importlib.util.find_spec(module) is None:
+            pytest.skip(
+                f"Shared ee fixtures require the '{module}' module "
+                "(install with: uv sync --extra enterprise).",
+                allow_module_level=False,
+            )
+
+
+def _require_moto() -> None:
+    """Skip if moto isn't on the path. moto is declared under the ``dev``
+    dependency group, so plain ``uv sync --dev`` should satisfy it; this
+    guard exists for environments that bootstrap a subset of the dev deps.
+    """
+
+    if importlib.util.find_spec("moto") is None:
+        pytest.skip(
+            "mock_s3 fixture requires the 'moto' module (install with: uv sync --dev).",
+            allow_module_level=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# License env + session-scoped AWS creds
+# ---------------------------------------------------------------------------
+
+
+def _make_license_key(secret: str = "test-secret") -> str:
+    """Mint a valid HMAC-signed license key for the license middleware."""
+
+    from datetime import datetime, timedelta
+
+    payload = {
+        "org": "test-org",
+        "plan": "enterprise",
+        "seats": 100,
+        "exp": (datetime.now(tz=None) + timedelta(days=365)).strftime("%Y-%m-%d"),
+    }
+    payload_str = json.dumps(payload)
+    sig = hashlib.sha256(f"{secret}:{payload_str}".encode()).hexdigest()
+    raw = f"{payload_str}.{sig}"
+    return base64.b64encode(raw.encode()).decode()
+
+
+@pytest.fixture(scope="session")
+def _license_env_vars() -> dict[str, str]:
+    """Build the env var dict once per session — values never change."""
+
+    secret = "test-secret"
+    return {
+        "POCKETPAW_LICENSE_KEY": _make_license_key(secret),
+        "POCKETPAW_LICENSE_SECRET": secret,
+        "AUTH_SECRET": "test-auth-secret-for-ee-shared-fixtures",
+        # moto/boto3 reads these — dummy values are fine, the mock intercepts.
+        "AWS_ACCESS_KEY_ID": "testing",
+        "AWS_SECRET_ACCESS_KEY": "testing",
+        "AWS_SESSION_TOKEN": "testing",
+        "AWS_DEFAULT_REGION": "us-east-1",
+    }
+
+
+@pytest.fixture()
+def license_env(_license_env_vars: dict[str, str]):
+    """Inject license + AWS creds into the process env for the duration of
+    the test. Also flushes the license module's lru-style cache so the new
+    key takes effect on the next request.
+    """
+
+    with patch.dict(os.environ, _license_env_vars):
+        import ee.cloud.license as lic_mod
+
+        lic_mod._cached_license = None
+        lic_mod._license_error = None
+        yield _license_env_vars
+        lic_mod._cached_license = None
+        lic_mod._license_error = None
+
+
+# ---------------------------------------------------------------------------
+# Mongo isolation — composes on the existing ``mongomock-motor`` primitive
+# used by ``tests/cloud/chat/conftest.py`` / ``tests/cloud/memory/conftest.py``.
+#
+# Each test gets its own uniquely-named in-memory database, so teardown is
+# implicit (the client goes out of scope when the fixture unwinds). No real
+# MongoDB service is required.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def beanie_test_db():
+    """Initialise Beanie against a fresh mongomock-motor database.
+
+    Beanie >=1.26 calls ``database.list_collection_names`` with
+    ``authorizedCollections`` / ``nameOnly``; mongomock-motor's stub rejects
+    unknown kwargs. Wrap the method to drop them, mirroring the shim in
+    ``tests/cloud/chat/conftest.py``.
+    """
+
+    _require_enterprise()
+
+    from beanie import init_beanie
+    from mongomock_motor import AsyncMongoMockClient
+
+    from ee.cloud.memory.documents import MemoryFactDoc
+    from ee.cloud.models import ALL_DOCUMENTS
+
+    db_name = f"test_ee_shared_{uuid.uuid4().hex[:8]}"
+    client = AsyncMongoMockClient()
+    db = client[db_name]
+
+    original = db.list_collection_names
+
+    async def _safe_list_collection_names(*_args: Any, **_kwargs: Any) -> list[str]:
+        return await original()
+
+    db.list_collection_names = _safe_list_collection_names  # type: ignore[method-assign]
+
+    await init_beanie(database=db, document_models=[*ALL_DOCUMENTS, MemoryFactDoc])
+    yield db
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app + httpx client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def app(license_env, beanie_test_db) -> FastAPI:
+    """Mount the ee/cloud router tree onto a fresh FastAPI app.
+
+    The agent pool start/stop coroutines are replaced with no-op mocks so the
+    app can boot without a running backend. ``beanie_test_db`` runs first so
+    every route hits an initialised in-memory database.
+    """
+
+    _require_enterprise()
+
+    from ee.cloud import mount_cloud
+
+    test_app = FastAPI()
+
+    mock_pool = MagicMock()
+    mock_pool.start = AsyncMock()
+    mock_pool.stop = AsyncMock()
+
+    with patch("pocketpaw.agents.pool.get_agent_pool", return_value=mock_pool):
+        mount_cloud(test_app)
+
+    return test_app
+
+
+@pytest.fixture()
+async def http(app: FastAPI) -> AsyncIterator[AsyncClient]:
+    """httpx.AsyncClient bound to the in-process ASGI app."""
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Shared factory fixtures
+# ---------------------------------------------------------------------------
+
+
+UserTokenPair = Callable[..., Awaitable[dict[str, Any]]]
+WorkspaceFactory = Callable[..., Awaitable[str]]
+SeededChannel = Callable[..., Awaitable[tuple[str, list[str]]]]
+
+
+@pytest.fixture()
+def user_token_pair(http: AsyncClient) -> UserTokenPair:
+    """Callable that registers + logs in a fresh user.
+
+    Returns a dict with keys: ``user_id``, ``email``, ``token``, ``headers``.
+    Tests can call it multiple times to get independent users — each invocation
+    produces a unique email, so no cleanup is required (the per-test
+    mongomock database is thrown away at teardown).
+    """
+
+    async def _factory(email: str | None = None, password: str = "Password1!") -> dict[str, Any]:
+        email = email or f"ee-fixture-{uuid.uuid4().hex[:8]}@test.example"
+
+        reg = await http.post(
+            "/api/v1/auth/register",
+            json={
+                "email": email,
+                "password": password,
+                "full_name": "EE Fixture User",
+            },
+        )
+        assert reg.status_code == 201, f"register failed: {reg.status_code} {reg.text}"
+        user = reg.json()
+
+        login = await http.post(
+            "/api/v1/auth/bearer/login",
+            data={"username": email, "password": password},
+        )
+        assert login.status_code == 200, f"login failed: {login.status_code} {login.text}"
+        token = login.json()["access_token"]
+
+        return {
+            "user_id": user["id"],
+            "email": email,
+            "token": token,
+            "headers": {"Authorization": f"Bearer {token}"},
+        }
+
+    return _factory
+
+
+@pytest.fixture()
+def workspace_factory(http: AsyncClient) -> WorkspaceFactory:
+    """Callable that creates a workspace owned by the given user and sets it
+    as their active workspace. Returns the workspace id.
+
+    Teardown is implicit — the mongomock database is dropped when
+    ``beanie_test_db`` unwinds at the end of the test.
+    """
+
+    async def _factory(
+        user: dict[str, Any],
+        *,
+        name: str = "Shared Fixture Workspace",
+        slug: str | None = None,
+        activate: bool = True,
+    ) -> str:
+        slug = slug or f"ws-{uuid.uuid4().hex[:8]}"
+
+        resp = await http.post(
+            "/api/v1/workspaces",
+            json={"name": name, "slug": slug},
+            headers=user["headers"],
+        )
+        assert resp.status_code == 200, f"create workspace failed: {resp.status_code} {resp.text}"
+        workspace_id: str = resp.json()["_id"]
+
+        if activate:
+            act = await http.post(
+                "/api/v1/auth/set-active-workspace",
+                json={"workspace_id": workspace_id},
+                headers=user["headers"],
+            )
+            assert act.status_code == 200, (
+                f"activate workspace failed: {act.status_code} {act.text}"
+            )
+
+        return workspace_id
+
+    return _factory
+
+
+@pytest.fixture()
+def seeded_channel(http: AsyncClient) -> SeededChannel:
+    """Callable that creates a chat channel (group) in the caller's active
+    workspace and seeds it with ``count`` text messages.
+
+    Channels and groups are the same concept in ee/cloud — the route tree
+    exposes them under ``/api/v1/chat/groups``. Returns
+    ``(channel_id, [message_ids])`` so tests can round-trip against either.
+    """
+
+    async def _factory(
+        user: dict[str, Any],
+        *,
+        name: str | None = None,
+        count: int = 3,
+    ) -> tuple[str, list[str]]:
+        name = name or f"channel-{uuid.uuid4().hex[:6]}"
+
+        create = await http.post(
+            "/api/v1/chat/groups",
+            json={"name": name},
+            headers=user["headers"],
+        )
+        assert create.status_code == 200, (
+            f"create channel failed: {create.status_code} {create.text}"
+        )
+        channel_id: str = create.json()["_id"]
+
+        message_ids: list[str] = []
+        for i in range(count):
+            resp = await http.post(
+                f"/api/v1/chat/groups/{channel_id}/messages",
+                json={"content": f"seed message {i}"},
+                headers=user["headers"],
+            )
+            assert resp.status_code == 200, (
+                f"send message {i} failed: {resp.status_code} {resp.text}"
+            )
+            message_ids.append(resp.json()["_id"])
+
+        return channel_id, message_ids
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# S3 mock — session-scoped moto. Keeps the AWS SDK wire off-network for every
+# test that touches uploads, without the cost of re-initialising the moto
+# backend on every function. Tests should use uniquely-named buckets.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def mock_s3(_license_env_vars: dict[str, str]):
+    """Session-scoped AWS mock via moto 5's unified ``mock_aws`` decorator.
+
+    Yields a ready-to-use boto3 S3 client bound to the in-memory backend.
+    AWS credentials are injected via ``_license_env_vars`` so the boto3
+    client can authenticate even when the host has no real creds.
+    """
+
+    _require_moto()
+
+    import boto3
+    from moto import mock_aws
+
+    with patch.dict(os.environ, _license_env_vars), mock_aws():
+        client = boto3.client("s3", region_name=_license_env_vars["AWS_DEFAULT_REGION"])
+        yield client

--- a/tests/ee/test_shared_fixtures.py
+++ b/tests/ee/test_shared_fixtures.py
@@ -1,0 +1,112 @@
+# tests/ee/test_shared_fixtures.py — Smoke tests for the Wave 2 shared fixtures.
+# Created: 2026-04-19 (Wave 2.2 / feat/wave-2-pytest-fixtures-v2)
+#
+# Each test below exercises exactly one of the three callable factories
+# defined in ``tests/ee/conftest.py``. They prove the fixture wires a
+# mongomock-motor db through a mounted ee/cloud FastAPI and that the
+# round-trip flows (register -> login, create workspace, create channel,
+# post messages) work end-to-end. A fourth test verifies the session-scoped
+# ``mock_s3`` fixture can perform a basic put/get against the in-memory moto
+# backend.
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_workspace_factory_creates_and_cleans_up(
+    http: AsyncClient,
+    user_token_pair,
+    workspace_factory,
+) -> None:
+    """A workspace minted by ``workspace_factory`` should be reachable via the
+    GET route and linked as the caller's active workspace.
+
+    Teardown is implicit — the mongomock-motor database is thrown away when
+    ``beanie_test_db`` unwinds. We assert the workspace exists during the
+    test so a regression in the factory (e.g. failing to persist) shows up
+    as an immediate 404 rather than a silent drift on the next wave's tests.
+    """
+
+    user = await user_token_pair()
+    ws_id = await workspace_factory(user)
+
+    # Reachable by id — returned payload matches the factory's output.
+    resp = await http.get(f"/api/v1/workspaces/{ws_id}", headers=user["headers"])
+    assert resp.status_code == 200
+    assert resp.json()["_id"] == ws_id
+
+    # Activated for the caller — set-active-workspace is implicit in the factory.
+    me = await http.get("/api/v1/auth/me", headers=user["headers"])
+    assert me.status_code == 200
+    assert me.json().get("active_workspace") == ws_id or me.json().get("activeWorkspace") == ws_id
+
+
+@pytest.mark.asyncio
+async def test_user_token_pair_returns_usable_token(
+    http: AsyncClient,
+    user_token_pair,
+) -> None:
+    """The bearer token produced by ``user_token_pair`` must unlock the
+    authenticated ``/auth/me`` endpoint and echo back the same email/user
+    that the factory claims to have registered.
+    """
+
+    user = await user_token_pair()
+
+    resp = await http.get("/api/v1/auth/me", headers=user["headers"])
+    assert resp.status_code == 200
+
+    profile = resp.json()
+    assert profile["email"] == user["email"]
+    assert profile["id"] == user["user_id"]
+
+
+@pytest.mark.asyncio
+async def test_seeded_channel_has_expected_messages(
+    http: AsyncClient,
+    user_token_pair,
+    workspace_factory,
+    seeded_channel,
+) -> None:
+    """Seeding five messages should round-trip: GET on the channel's messages
+    endpoint must return five items whose ids match the ones the factory
+    reported creating (order-insensitive).
+    """
+
+    user = await user_token_pair()
+    await workspace_factory(user)
+    channel_id, message_ids = await seeded_channel(user, count=5)
+
+    assert len(message_ids) == 5
+
+    resp = await http.get(
+        f"/api/v1/chat/groups/{channel_id}/messages",
+        headers=user["headers"],
+    )
+    assert resp.status_code == 200
+
+    payload = resp.json()
+    items = payload["items"] if isinstance(payload, dict) else payload
+    returned_ids = {item["_id"] for item in items}
+    assert returned_ids == set(message_ids)
+
+
+def test_mock_s3_put_and_get_roundtrip(mock_s3) -> None:
+    """Sanity-check the session-scoped ``mock_s3`` fixture — put an object,
+    get it back, and confirm the payload matches. This only proves moto is
+    wired in; the upload adapter tests that actually consume the mock live
+    under ``tests/uploads/`` and are out of scope for this slice.
+    """
+
+    import uuid
+
+    bucket = f"shared-fixture-{uuid.uuid4().hex[:8]}"
+    mock_s3.create_bucket(Bucket=bucket)
+
+    mock_s3.put_object(Bucket=bucket, Key="hello.txt", Body=b"wave-2-fixtures")
+
+    obj = mock_s3.get_object(Bucket=bucket, Key="hello.txt")
+    assert obj["Body"].read() == b"wave-2-fixtures"

--- a/uv.lock
+++ b/uv.lock
@@ -3428,6 +3428,32 @@ wheels = [
 ]
 
 [[package]]
+name = "moto"
+version = "5.1.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/3d/1765accbf753dc1ae52f26a2e2ed2881d78c2eb9322c178e45312472e4a0/moto-5.1.22.tar.gz", hash = "sha256:e5b2c378296e4da50ce5a3c355a1743c8d6d396ea41122f5bb2a40f9b9a8cc0e", size = 8547792, upload-time = "2026-03-08T21:06:43.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/4f/8812a01e3e0bd6be3e13b90432fb5c696af9a720af3f00e6eba5ad748345/moto-5.1.22-py3-none-any.whl", hash = "sha256:d9f20ae3cf29c44f93c1f8f06c8f48d5560e5dc027816ef1d0d2059741ffcfbe", size = 6617400, upload-time = "2026-03-08T21:06:41.093Z" },
+]
+
+[package.optional-dependencies]
+s3 = [
+    { name = "py-partiql-parser" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "motor"
 version = "3.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4583,6 +4609,7 @@ dev = [
     { name = "mcp" },
     { name = "mem0ai" },
     { name = "mongomock-motor" },
+    { name = "moto", extra = ["s3"] },
     { name = "mypy" },
     { name = "neonize" },
     { name = "ollama" },
@@ -4792,6 +4819,7 @@ dev = [
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mongomock-motor", specifier = ">=0.0.36" },
+    { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "mypy", specifier = ">=1.8.0" },
     { name = "neonize", specifier = ">=0.3.14" },
     { name = "ollama", specifier = ">=0.6.1" },
@@ -5008,6 +5036,15 @@ argon2 = [
 ]
 bcrypt = [
     { name = "bcrypt" },
+]
+
+[[package]]
+name = "py-partiql-parser"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
 ]
 
 [[package]]
@@ -6137,6 +6174,20 @@ wheels = [
 ]
 
 [[package]]
+name = "responses"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b4/b7e040379838cc71bf5aabdb26998dfbe5ee73904c92c1c161faf5de8866/responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4", size = 81303, upload-time = "2026-02-19T14:38:05.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/7f73d05b556da048923e31a0cc878f03be7c5425ed1f268082255c75d872/responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37", size = 35099, upload-time = "2026-02-19T14:38:03.847Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -7070,6 +7121,18 @@ wheels = [
 ]
 
 [[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
 name = "wrapt"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -7154,6 +7217,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this is

A minimal slice of the Wave 2 hardening plan. Three callable factories plus the scaffolding to make them work, added to `tests/ee/conftest.py`:

- `user_token_pair` — registers a user and returns `(user_id, email, token, headers)`
- `workspace_factory` — creates a workspace owned by the given user and activates it
- `seeded_channel` — creates a chat channel (group) and sends `count` messages, default 3

Plus a session-scoped `mock_s3` fixture backed by moto 5.

## Why it looks the way it does

The existing `tests/cloud/chat/conftest.py` already wires `mongomock-motor` + `init_beanie` + a uuid database name for every test. Rather than duplicate that, the new fixtures compose on top of it: each test gets its own in-memory database, so teardown is implicit when the fixture unwinds. No real MongoDB needed.

moto was not already a dependency, so `moto[s3]>=5.0.0` is added under the `dev` group. The fixture uses moto 5's unified `mock_aws` context manager.

If the `enterprise` extra isn't installed, the factory fixtures emit `pytest.skip` rather than failing on import, so the rest of `tests/ee/` continues to collect in environments that only have the core deps.

## Out of scope

These land in Wave 3 clusters that actually consume them:

- `fleet_installed_org` — Cluster D
- `drive_connected_pocket` — Cluster C

The full Appendix B seed set belongs to Wave 2.1.

## Verification

```
$ uv run pytest tests/ee/test_shared_fixtures.py -v
...
4 passed, 12 warnings in 1.92s
```

`tests/ee/` in full: 112 passed (109 pre-existing + 4 new). No new failures in adjacent subsets (`tests/cloud/`, `tests/uploads/`, `tests/connectors/`, `tests/v1/`) beyond the pre-existing baseline.

## Test plan

- [ ] `uv run pytest tests/ee/test_shared_fixtures.py -v` passes
- [ ] `uv run pytest tests/ee/ -q` shows 112 passed
- [ ] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py` shows no regressions in the non-ignored suite