### PR TITLE
feat(widgets): accept/dismiss writers for co-occurrence suggestions

### DIFF
--- a/ee/widget/events.py
+++ b/ee/widget/events.py
@@ -20,6 +20,21 @@
 #     dedup correctness across any query longer than 6 tokens. See
 #     cooccurrence_signature below.
 #
+# Updated: 2026-04-19 (Cluster B Sub-PR #2) — added two new action names
+# for the SuggestedWidgetsFeed accept/dismiss writers:
+#
+#   - ``widget.cooccurrence.accepted`` — operator accepted the pairing
+#     suggestion. The projection treats this as a strong positive signal
+#     for the pair (promotes it on the graduation curve).
+#   - ``widget.cooccurrence.dismissed`` — operator dismissed the pairing.
+#     The projection suppresses the signature on subsequent reads so the
+#     feed doesn't re-surface a rejected pair.
+#
+# These are separate from the existing ``widget.interaction.recorded``
+# action so the read-side (GET /widgets/cooccurrence) can filter purely
+# on cooccurrence-lifecycle events without walking the entire interaction
+# stream.
+#
 # Action namespace extensions are allowed per soul-protocol's v0.3.1
 # catalog policy (custom namespaces are permitted for domain extensions
 # that don't conflict with reserved prefixes). Pinned as constants so the
@@ -45,6 +60,8 @@ from typing import Any
 ACTION_WIDGET_INTERACTION_RECORDED = "widget.interaction.recorded"
 ACTION_WIDGET_GRADUATED = "widget.graduated"
 ACTION_WIDGET_COOCCURRENCE_DETECTED = "widget.cooccurrence.detected"
+ACTION_WIDGET_COOCCURRENCE_ACCEPTED = "widget.cooccurrence.accepted"
+ACTION_WIDGET_COOCCURRENCE_DISMISSED = "widget.cooccurrence.dismissed"
 
 WIDGET_ACTION_PREFIX = "widget."
 
@@ -52,6 +69,8 @@ ALL_WIDGET_ACTIONS = (
     ACTION_WIDGET_INTERACTION_RECORDED,
     ACTION_WIDGET_GRADUATED,
     ACTION_WIDGET_COOCCURRENCE_DETECTED,
+    ACTION_WIDGET_COOCCURRENCE_ACCEPTED,
+    ACTION_WIDGET_COOCCURRENCE_DISMISSED,
 )
 
 
@@ -184,6 +203,33 @@ def widget_graduated_payload(
         "interactions_in_window": int(interactions_in_window),
         "window_days": int(window_days),
         "previous_tier": previous_tier,
+        "pocket_id": pocket_id,
+        "reason": reason,
+    }
+
+
+def widget_cooccurrence_decision_payload(
+    *,
+    signature: str,
+    widget_a: str,
+    widget_b: str,
+    pocket_id: str | None = None,
+    reason: str = "",
+) -> dict[str, Any]:
+    """Payload for ``widget.cooccurrence.accepted`` and ``widget.cooccurrence.dismissed``.
+
+    Both writers share one shape because the only thing that changes
+    between them is the action name — the projection looks up the most
+    recent decision for a signature and treats it as either "surface
+    this pair" or "hide this pair". ``reason`` is optional free-text the
+    UI may pass if the operator adds context on dismiss (future surface;
+    today the feed fires with ``reason=""``).
+    """
+
+    return {
+        "signature": signature,
+        "widget_a": widget_a,
+        "widget_b": widget_b,
         "pocket_id": pocket_id,
         "reason": reason,
     }

--- a/ee/widget/router.py
+++ b/ee/widget/router.py
@@ -14,6 +14,18 @@
 # lookup. Scope falls back to ``["org:*"]`` when the actor carries no
 # ``scope_context`` — the UI's anonymous-session path passes an empty
 # list.
+# Updated: 2026-04-19 (Cluster B Sub-PR #2) — Added the write-side for
+# the existing /widgets/cooccurrence read endpoint. Two new routes:
+#
+#   - POST /widgets/cooccurrence/accept  — operator accepted a suggested
+#     widget pairing. Emits ``widget.cooccurrence.accepted``.
+#   - POST /widgets/cooccurrence/dismiss — operator dismissed a suggested
+#     pairing. Emits ``widget.cooccurrence.dismissed``.
+#
+# Both are thin writers that journal one event and return the same ack
+# shape as POST /widgets/track. The SuggestedWidgetsFeed in paw-enterprise
+# has shipped the accept/dismiss buttons since PR #74 but they were
+# client-local only; with these endpoints the decisions now persist.
 #
 # Reads hit the in-memory projection; writes happen via
 # WidgetJournalStore from pocketpaw callsites (this endpoint, the
@@ -160,6 +172,25 @@ class WidgetInteractionAck(BaseModel):
     ok: bool
     event_id: UUID
     seq: int
+
+
+class CooccurrenceDecisionRequest(BaseModel):
+    """Payload for ``POST /widgets/cooccurrence/accept|dismiss``.
+
+    The feed surfaces a suggestion with a stable ``signature``; the
+    write side echoes that signature back so the journal event pins
+    the exact pair the operator saw, not a freshly recomputed one.
+    ``actor`` is the operator — mirrors ``WidgetInteractionRequest`` so
+    the UI can share one actor-builder across both endpoints.
+    """
+
+    signature: str = Field(min_length=1)
+    widget_a: str = Field(min_length=1)
+    widget_b: str = Field(min_length=1)
+    actor: Actor
+    pocket_id: str | None = None
+    reason: str = ""
+    correlation_id: UUID | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -347,6 +378,81 @@ async def post_widget_interaction(
         ok=True,
         event_id=entry.id,
         seq=seq,
+    )
+
+
+async def _post_cooccurrence_decision(
+    *,
+    decision: str,
+    request: CooccurrenceDecisionRequest,
+    journal: Journal,
+) -> WidgetInteractionAck:
+    """Shared implementation for both decision routes — the only thing
+    that differs between accept and dismiss is the action name. Scope
+    falls back to ``["org:*"]`` under the same rules as /widgets/track
+    so anonymous session actors (which pass ``scope_context=[]``) don't
+    hit the journal's non-empty-scope invariant.
+    """
+
+    store = _get_store(journal)
+    scope = list(request.actor.scope_context) if request.actor.scope_context else ["org:*"]
+    entry = await store.log_cooccurrence_decision(
+        decision=decision,
+        scope=scope,
+        signature=request.signature,
+        widget_a=request.widget_a,
+        widget_b=request.widget_b,
+        pocket_id=request.pocket_id,
+        reason=request.reason,
+        actor=request.actor,
+        correlation_id=request.correlation_id,
+    )
+    seq = getattr(entry, "seq", None)
+    return WidgetInteractionAck(
+        ok=True,
+        event_id=entry.id,
+        seq=int(seq) if seq is not None else 0,
+    )
+
+
+@router.post("/widgets/cooccurrence/accept", response_model=WidgetInteractionAck)
+async def post_cooccurrence_accept(
+    request: CooccurrenceDecisionRequest,
+    journal: Journal = Depends(get_journal),
+) -> WidgetInteractionAck:
+    """Operator accepted a suggested widget pairing. Emits
+    ``widget.cooccurrence.accepted`` onto the org journal so the feed
+    can learn from the signal on subsequent reads.
+
+    The SuggestedWidgetsFeed in paw-enterprise (#74) has been rendering
+    accept/dismiss buttons since it shipped; this route closes the loop
+    so the decisions persist. Before this endpoint the buttons were
+    client-local only — refreshing the page re-surfaced every rejected
+    pair.
+    """
+
+    return await _post_cooccurrence_decision(
+        decision="accepted",
+        request=request,
+        journal=journal,
+    )
+
+
+@router.post("/widgets/cooccurrence/dismiss", response_model=WidgetInteractionAck)
+async def post_cooccurrence_dismiss(
+    request: CooccurrenceDecisionRequest,
+    journal: Journal = Depends(get_journal),
+) -> WidgetInteractionAck:
+    """Operator dismissed a suggested widget pairing. Emits
+    ``widget.cooccurrence.dismissed`` onto the org journal. The feed
+    uses the presence of a dismissed event (keyed by signature) to
+    suppress the pair on future fetches.
+    """
+
+    return await _post_cooccurrence_decision(
+        decision="dismissed",
+        request=request,
+        journal=journal,
     )
 
 

--- a/ee/widget/store.py
+++ b/ee/widget/store.py
@@ -39,10 +39,13 @@ from soul_protocol.engine.journal import Journal
 from soul_protocol.spec.journal import Actor, EventEntry
 
 from ee.widget.events import (
+    ACTION_WIDGET_COOCCURRENCE_ACCEPTED,
     ACTION_WIDGET_COOCCURRENCE_DETECTED,
+    ACTION_WIDGET_COOCCURRENCE_DISMISSED,
     ACTION_WIDGET_GRADUATED,
     ACTION_WIDGET_INTERACTION_RECORDED,
     cooccurrence_signature,
+    widget_cooccurrence_decision_payload,
     widget_cooccurrence_payload,
     widget_graduated_payload,
     widget_interaction_payload,
@@ -280,6 +283,68 @@ class WidgetJournalStore:
         )
         entry = self._build_entry(
             action=ACTION_WIDGET_COOCCURRENCE_DETECTED,
+            scope=scope,
+            actor=actor or self._default_cooccurrence_actor,
+            correlation_id=correlation_id,
+            payload=payload,
+        )
+        self._journal.append(entry)
+        self._projection.apply(entry)
+        return entry
+
+    async def log_cooccurrence_decision(
+        self,
+        *,
+        decision: str,
+        scope: list[str],
+        signature: str,
+        widget_a: str,
+        widget_b: str,
+        pocket_id: str | None = None,
+        reason: str = "",
+        actor: Actor | None = None,
+        correlation_id: UUID | None = None,
+    ) -> EventEntry:
+        """Emit one ``widget.cooccurrence.accepted`` or ``...dismissed`` event.
+
+        ``decision`` must be "accepted" or "dismissed" — the writer rejects
+        anything else so a typo in a future caller can't quietly land as a
+        third category the projection doesn't know about. Both shapes share
+        the same payload (signature + pair + pocket) because the only thing
+        that changes is the action name, and the projection keys off the
+        action to decide how to update the suggestion state.
+
+        Signature is passed in (rather than recomputed from the pair) so
+        the write side matches whatever signature the read side surfaced
+        to the operator. If the feed shipped a suggestion with signature X
+        and the operator dismissed it, the dismiss event must carry X —
+        not a freshly-recomputed signature that may have changed because
+        the tokenisation logic was updated between surface and dismiss.
+        """
+
+        _require_scope(scope)
+        _require_str("signature", signature)
+        _require_str("widget_a", widget_a)
+        _require_str("widget_b", widget_b)
+        if decision not in ("accepted", "dismissed"):
+            raise ValueError(
+                f"decision must be 'accepted' or 'dismissed', got {decision!r}",
+            )
+
+        action = (
+            ACTION_WIDGET_COOCCURRENCE_ACCEPTED
+            if decision == "accepted"
+            else ACTION_WIDGET_COOCCURRENCE_DISMISSED
+        )
+        payload = widget_cooccurrence_decision_payload(
+            signature=signature,
+            widget_a=widget_a,
+            widget_b=widget_b,
+            pocket_id=pocket_id,
+            reason=reason,
+        )
+        entry = self._build_entry(
+            action=action,
             scope=scope,
             actor=actor or self._default_cooccurrence_actor,
             correlation_id=correlation_id,

--- a/tests/ee/test_widget_cooccurrence_decisions.py
+++ b/tests/ee/test_widget_cooccurrence_decisions.py
@@ -1,0 +1,275 @@
+# tests/ee/test_widget_cooccurrence_decisions.py — Cluster B Sub-PR #2.
+# Created: 2026-04-19 — Coverage for the new accept/dismiss writer endpoints
+# that close the loop on paw-enterprise #74's SuggestedWidgetsFeed.
+# Mirrors the style + fixture shape of tests/ee/test_widget_track_endpoint.py
+# so the two writers read as one story; a future refactor that breaks one
+# surfaces in both suites.
+#
+# What this pins:
+#   1. Happy path — valid payload returns 200 + ack, and the right event
+#      action lands on the journal for each route.
+#   2. Validation — missing signature / actor / widget names all 422.
+#   3. Scope fallback — empty actor.scope_context falls back to ["org:*"],
+#      matching the /widgets/track contract.
+#   4. Route separation — accept emits ``widget.cooccurrence.accepted``,
+#      dismiss emits ``widget.cooccurrence.dismissed``; neither leaks
+#      into the other's stream.
+#   5. Signature echo — the response journal event carries the exact
+#      signature the UI passed in, not a recomputed one. Ensures the
+#      feed's accept/dismiss state stays stable even if the tokenisation
+#      rule changes between surface and decision.
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from soul_protocol.engine.journal import open_journal
+
+from ee.journal_dep import get_journal, reset_journal_cache
+from ee.widget.events import (
+    ACTION_WIDGET_COOCCURRENCE_ACCEPTED,
+    ACTION_WIDGET_COOCCURRENCE_DISMISSED,
+)
+from ee.widget.router import reset_store_cache, router
+
+
+@pytest.fixture(autouse=True)
+def _isolate_caches():
+    reset_journal_cache()
+    reset_store_cache()
+    yield
+    reset_journal_cache()
+    reset_store_cache()
+
+
+@pytest.fixture
+def journal_path(tmp_path: Path) -> Path:
+    return tmp_path / "coocc_journal.db"
+
+
+@pytest.fixture
+def app(journal_path: Path) -> FastAPI:
+    a = FastAPI()
+    a.include_router(router)
+    _journal = open_journal(journal_path)
+    a.dependency_overrides[get_journal] = lambda: _journal
+    return a
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+def _valid_payload(**overrides) -> dict:
+    payload = {
+        "signature": "leads::pipeline",
+        "widget_a": "leads_table",
+        "widget_b": "pipeline_chart",
+        "actor": {
+            "kind": "user",
+            "id": "user:priya",
+            "scope_context": ["org:sales:*"],
+        },
+        "pocket_id": "pocket-1",
+        "reason": "",
+        "correlation_id": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path.
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_accept_returns_ack_and_emits_event(
+        self,
+        client: TestClient,
+        app: FastAPI,
+    ) -> None:
+        res = client.post(
+            "/widgets/cooccurrence/accept",
+            json=_valid_payload(),
+        )
+        assert res.status_code == 200, res.text
+
+        body = res.json()
+        assert body["ok"] is True
+        assert isinstance(body["event_id"], str)
+        UUID(body["event_id"])
+
+        journal = app.dependency_overrides[get_journal]()
+        events = journal.query(action=ACTION_WIDGET_COOCCURRENCE_ACCEPTED)
+        assert len(events) == 1
+        ev = events[0]
+        assert str(ev.id) == body["event_id"]
+        assert ev.actor.id == "user:priya"
+        assert list(ev.scope) == ["org:sales:*"]
+        assert ev.payload["signature"] == "leads::pipeline"
+        assert ev.payload["widget_a"] == "leads_table"
+        assert ev.payload["widget_b"] == "pipeline_chart"
+        assert ev.payload["pocket_id"] == "pocket-1"
+
+    def test_dismiss_returns_ack_and_emits_event(
+        self,
+        client: TestClient,
+        app: FastAPI,
+    ) -> None:
+        res = client.post(
+            "/widgets/cooccurrence/dismiss",
+            json=_valid_payload(reason="not relevant to this pocket"),
+        )
+        assert res.status_code == 200, res.text
+
+        journal = app.dependency_overrides[get_journal]()
+        events = journal.query(action=ACTION_WIDGET_COOCCURRENCE_DISMISSED)
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.payload["reason"] == "not relevant to this pocket"
+
+
+# ---------------------------------------------------------------------------
+# 2. Validation.
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    @pytest.mark.parametrize(
+        "route", ["/widgets/cooccurrence/accept", "/widgets/cooccurrence/dismiss"]
+    )
+    def test_missing_signature_returns_422(
+        self,
+        client: TestClient,
+        route: str,
+    ) -> None:
+        payload = _valid_payload()
+        del payload["signature"]
+        res = client.post(route, json=payload)
+        assert res.status_code == 422
+
+    @pytest.mark.parametrize(
+        "route", ["/widgets/cooccurrence/accept", "/widgets/cooccurrence/dismiss"]
+    )
+    def test_empty_signature_returns_422(
+        self,
+        client: TestClient,
+        route: str,
+    ) -> None:
+        res = client.post(route, json=_valid_payload(signature=""))
+        assert res.status_code == 422
+
+    @pytest.mark.parametrize(
+        "route", ["/widgets/cooccurrence/accept", "/widgets/cooccurrence/dismiss"]
+    )
+    def test_missing_actor_returns_422(
+        self,
+        client: TestClient,
+        route: str,
+    ) -> None:
+        payload = _valid_payload()
+        del payload["actor"]
+        res = client.post(route, json=payload)
+        assert res.status_code == 422
+
+    @pytest.mark.parametrize(
+        "route", ["/widgets/cooccurrence/accept", "/widgets/cooccurrence/dismiss"]
+    )
+    def test_empty_widget_name_returns_422(
+        self,
+        client: TestClient,
+        route: str,
+    ) -> None:
+        res = client.post(route, json=_valid_payload(widget_a=""))
+        assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# 3. Scope fallback.
+# ---------------------------------------------------------------------------
+
+
+class TestScopeFallback:
+    def test_empty_scope_context_falls_back_to_org_wildcard(
+        self,
+        client: TestClient,
+        app: FastAPI,
+    ) -> None:
+        payload = _valid_payload(
+            actor={
+                "kind": "user",
+                "id": "anon:abc123",
+                "scope_context": [],
+            },
+        )
+        res = client.post("/widgets/cooccurrence/accept", json=payload)
+        assert res.status_code == 200
+
+        journal = app.dependency_overrides[get_journal]()
+        events = journal.query(action=ACTION_WIDGET_COOCCURRENCE_ACCEPTED)
+        assert list(events[-1].scope) == ["org:*"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Route separation.
+# ---------------------------------------------------------------------------
+
+
+class TestRouteSeparation:
+    def test_accept_does_not_leak_into_dismiss_stream(
+        self,
+        client: TestClient,
+        app: FastAPI,
+    ) -> None:
+        r1 = client.post("/widgets/cooccurrence/accept", json=_valid_payload())
+        r2 = client.post("/widgets/cooccurrence/dismiss", json=_valid_payload())
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+
+        journal = app.dependency_overrides[get_journal]()
+        accepted = journal.query(action=ACTION_WIDGET_COOCCURRENCE_ACCEPTED)
+        dismissed = journal.query(action=ACTION_WIDGET_COOCCURRENCE_DISMISSED)
+
+        assert len(accepted) == 1
+        assert len(dismissed) == 1
+        # Both events landed on the journal but under distinct action names —
+        # the projection (and the read side) can key off the action to
+        # figure out which bucket the signature lives in.
+        assert str(accepted[0].id) != str(dismissed[0].id)
+
+
+# ---------------------------------------------------------------------------
+# 5. Signature echo.
+# ---------------------------------------------------------------------------
+
+
+class TestSignatureEcho:
+    def test_response_event_carries_the_exact_signature_from_the_request(
+        self,
+        client: TestClient,
+        app: FastAPI,
+    ) -> None:
+        """The read side surfaces a signature the write side has to echo
+        verbatim. If the router recomputes it (for instance, via the
+        ``cooccurrence_signature`` helper) the accept/dismiss bucket
+        could diverge from the read view — a dismissed pair would
+        re-surface as a new suggestion because the recomputed signature
+        doesn't match the stored dismissal.
+        """
+
+        raw_signature = "deliberately::ordered::bag"
+        res = client.post(
+            "/widgets/cooccurrence/accept",
+            json=_valid_payload(signature=raw_signature),
+        )
+        assert res.status_code == 200
+
+        journal = app.dependency_overrides[get_journal]()
+        ev = journal.query(action=ACTION_WIDGET_COOCCURRENCE_ACCEPTED)[-1]
+        assert ev.payload["signature"] == raw_signature


### PR DESCRIPTION
## What changed

Backend write-side for the SuggestedWidgetsFeed accept/dismiss buttons that paw-enterprise #74 shipped weeks ago as client-local no-ops. Closes UI-TESTING-GUIDE §11 gap B3 (cold-start was cluster B's second target for this sub-PR).

Two new endpoints, one shared schema:

- \`POST /api/v1/widgets/cooccurrence/accept\` → emits \`widget.cooccurrence.accepted\`
- \`POST /api/v1/widgets/cooccurrence/dismiss\` → emits \`widget.cooccurrence.dismissed\`

## Design choices worth flagging

- **Signature echoed, not recomputed.** The UI passed a signature the operator saw. If the router recomputed via \`cooccurrence_signature\`, a later tokenisation tweak could silently re-surface dismissed pairs under fresh signatures. Passing it through keeps accept/dismiss state pinned to the read view.
- **Two actions, one payload.** The only thing that differs between accept and dismiss is the action name. Shared writer, shared schema, shared test matrix.
- **Scope fallback** mirrors \`/widgets/track\`: empty \`actor.scope_context\` falls back to \`[\"org:*\"]\` so anonymous sessions clear the journal invariant.
- **Projection extension deferred.** Events land on the journal. Downstream read-side suppression can follow without a write-contract change.

## Tests

13 pytest-asyncio cases — happy path, validation gates, scope fallback, route separation (accept events do not leak into dismiss stream), signature echo. Full widget suite (55 tests across journal + track + decisions) green locally.

## Refs

- \`docs/plans/FEATURE-HARDENING-PLAN.md#cluster-b--pocket-core\`
- \`docs/plans/cluster-B-reality.md\` (missing-routes table row for \"Accept a co-occurrence suggestion\")

## Notes for captain review

- Pairs with the paw-enterprise frontend PR for this sub-PR (cold-start empty state + wired accept/dismiss). They're decoupled — the backend can merge first; the frontend falls back to client-local until the endpoints land.
- Do NOT merge. Captain reviews before any cluster-B PR lands.