### PR TITLE
feat(pockets): YAML layout export and user-defined templates

### DIFF
--- a/ee/cloud/pockets/layouts.py
+++ b/ee/cloud/pockets/layouts.py
@@ -1,0 +1,176 @@
+# ee/cloud/pockets/layouts.py — YAML layout export + user-defined pocket templates.
+# Created: 2026-04-19 (Cluster B Sub-PR #3) — Backs two new endpoints on the
+# pockets router:
+#
+#   - POST /api/v1/pockets/{id}/export-layout  → serialise a pocket's ripple
+#     spec as a YAML document the operator can copy, share, or save.
+#   - POST /api/v1/pockets/templates           → accept a user-defined YAML
+#     template and register it under the caller's workspace so it shows up
+#     in PocketTemplates's new "My templates" category.
+#   - GET  /api/v1/pockets/templates?workspace_id=... → list the
+#     workspace's user templates.
+#
+# The export side is pure — given a Pocket, we canonicalise its ripple spec
+# and emit YAML. No side effects, no persistence required.
+#
+# The template store is deliberately in-process + workspace-keyed. This is a
+# minimum-viable surface for the demo-readiness push in
+# FEATURE-HARDENING-PLAN.md; Wave 4 / Cluster G can bolt persistence on
+# behind the same protocol without changing the REST contract. The brief
+# calls this out as green-field work — no prior backend surface exists,
+# and this is the cleanest way to land the write + read shape now.
+#
+# YAML: lazy-imported via PyYAML (same pattern as ee/fleet/installer.py),
+# avoiding a new top-level dependency. safe_load + safe_dump keep the
+# surface free of Python-object injection.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# In-process user-template store.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class UserPocketTemplate:
+    """One user-defined template row. Keyed by id within a workspace."""
+
+    id: str
+    workspace_id: str
+    owner_id: str
+    name: str
+    description: str
+    category: str
+    spec: dict[str, Any]
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "workspace_id": self.workspace_id,
+            "owner_id": self.owner_id,
+            "name": self.name,
+            "description": self.description,
+            "category": self.category,
+            "spec": self.spec,
+            "created_at": self.created_at.isoformat(),
+        }
+
+
+class UserTemplateStore:
+    """In-process workspace-scoped template registry.
+
+    Thread-safe for the single-process dev + test setup. Mongo-backed
+    persistence follows in a later PR — the REST contract stays stable.
+    """
+
+    def __init__(self) -> None:
+        self._rows: dict[tuple[str, str], UserPocketTemplate] = {}
+
+    def save(self, template: UserPocketTemplate) -> UserPocketTemplate:
+        self._rows[(template.workspace_id, template.id)] = template
+        return template
+
+    def list_for_workspace(self, workspace_id: str) -> list[UserPocketTemplate]:
+        return [t for (w, _), t in self._rows.items() if w == workspace_id]
+
+    def get(self, workspace_id: str, template_id: str) -> UserPocketTemplate | None:
+        return self._rows.get((workspace_id, template_id))
+
+    def reset(self) -> None:
+        """Drop every row — for tests."""
+
+        self._rows.clear()
+
+
+_store = UserTemplateStore()
+
+
+def get_user_template_store() -> UserTemplateStore:
+    """FastAPI dependency accessor so tests can swap the store under test."""
+
+    return _store
+
+
+def reset_user_template_store() -> None:
+    """Test-only convenience: forget every stored template."""
+
+    _store.reset()
+
+
+# ---------------------------------------------------------------------------
+# YAML helpers.
+# ---------------------------------------------------------------------------
+
+
+def export_layout_yaml(
+    *,
+    pocket_id: str,
+    name: str,
+    description: str,
+    category: str,
+    ripple_spec: dict[str, Any] | None,
+    widgets: list[dict[str, Any]],
+) -> str:
+    """Serialise a pocket's layout as a YAML document.
+
+    The output is deterministic (``sort_keys=True``) so the same pocket
+    produces byte-identical YAML across runs — the test suite diffs two
+    exports and expects a round-trip. ``ripple_spec`` takes precedence
+    over the flat ``widgets`` list when both are present: modern pockets
+    store the canonical layout inside rippleSpec; the widgets column is
+    a legacy mirror.
+    """
+
+    import yaml  # lazy, matches ee/fleet/installer.py
+
+    body: dict[str, Any] = {
+        "apiVersion": "pocketpaw.io/v1",
+        "kind": "PocketLayout",
+        "metadata": {
+            "sourcePocketId": pocket_id,
+            "name": name,
+            "description": description,
+            "category": category,
+            "exportedAt": datetime.now(UTC).isoformat(),
+        },
+        "spec": ripple_spec or {"widgets": list(widgets or [])},
+    }
+    return yaml.safe_dump(body, sort_keys=True, default_flow_style=False)
+
+
+def parse_layout_yaml(yaml_text: str) -> dict[str, Any]:
+    """Parse a user-supplied YAML template into the template spec body.
+
+    Raises ``ValueError`` when the document is malformed or missing the
+    ``kind: PocketLayout`` / ``spec`` combo the exporter produces. The
+    error string is safe to return to the caller — it does not leak
+    filesystem paths or Python internals.
+    """
+
+    import yaml
+
+    try:
+        parsed = yaml.safe_load(yaml_text) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML: {exc}") from exc
+
+    if not isinstance(parsed, dict):
+        raise ValueError("Template YAML must resolve to a mapping, not a scalar or list")
+    if parsed.get("kind") and parsed.get("kind") != "PocketLayout":
+        raise ValueError(
+            f"Unsupported template kind {parsed.get('kind')!r}; expected 'PocketLayout'",
+        )
+    spec = parsed.get("spec")
+    if not isinstance(spec, dict):
+        raise ValueError("Template YAML must carry a 'spec' mapping")
+
+    return spec

--- a/ee/cloud/pockets/router.py
+++ b/ee/cloud/pockets/router.py
@@ -1,11 +1,33 @@
-"""Pockets domain — FastAPI router."""
+"""Pockets domain — FastAPI router.
+
+Updated: 2026-04-19 (Cluster B Sub-PR #3) — Added three new routes that
+close UI-TESTING-GUIDE §11 gap B5 (no widget layout save/share):
+
+    POST /pockets/{id}/export-layout   — return the pocket's layout as YAML
+    POST /pockets/templates            — save a YAML template to "My templates"
+    GET  /pockets/templates            — list the workspace's user templates
+
+The YAML + in-process store live in ee.cloud.pockets.layouts. Export is
+pure. Template storage is workspace-scoped and in-process for now; the
+REST contract matches the MongoDB-backed version that Wave 4 will ship.
+"""
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
 from starlette.responses import Response
 
 from ee.cloud.license import require_license
+from ee.cloud.pockets.layouts import (
+    UserPocketTemplate,
+    UserTemplateStore,
+    export_layout_yaml,
+    get_user_template_store,
+    parse_layout_yaml,
+)
 from ee.cloud.pockets.schemas import (
     AddCollaboratorRequest,
     AddWidgetRequest,
@@ -25,6 +47,128 @@ from ee.cloud.shared.deps import (
 )
 
 router = APIRouter(prefix="/pockets", tags=["Pockets"], dependencies=[Depends(require_license)])
+
+
+# ---------------------------------------------------------------------------
+# Layout export + user templates — Cluster B Sub-PR #3.
+# ---------------------------------------------------------------------------
+
+
+class ExportLayoutRequest(BaseModel):
+    """Optional overrides on the metadata block of the exported YAML.
+
+    The pocket's own name / description / category seed the defaults —
+    the override fields let the operator ship the template under a
+    different display name without renaming the source pocket. Empty
+    fields fall back to the pocket's values.
+    """
+
+    name: str | None = None
+    description: str | None = None
+    category: str | None = None
+
+
+class ExportLayoutResponse(BaseModel):
+    pocket_id: str
+    yaml: str
+
+
+class CreateTemplateRequest(BaseModel):
+    """Body for POST /pockets/templates.
+
+    ``yaml_source`` is the YAML a previous /export-layout call produced
+    or a hand-authored equivalent. ``name`` / ``description`` /
+    ``category`` are required on the template row even when the YAML
+    carries them — the store indexes on those fields for the gallery.
+    """
+
+    name: str = Field(min_length=1, max_length=100)
+    description: str = ""
+    category: str = "custom"
+    yaml_source: str = Field(min_length=1)
+
+
+class UserTemplateResponse(BaseModel):
+    id: str
+    workspace_id: str
+    owner_id: str
+    name: str
+    description: str
+    category: str
+    spec: dict
+    created_at: str
+
+
+@router.post("/{pocket_id}/export-layout", response_model=ExportLayoutResponse)
+async def export_layout(
+    pocket_id: str,
+    body: ExportLayoutRequest | None = None,
+    user_id: str = Depends(current_user_id),
+) -> ExportLayoutResponse:
+    """Serialise this pocket's layout as YAML.
+
+    Read-only, safe on any pocket the caller can fetch. The YAML is
+    deterministic (sort_keys=True) so a round-trip save-then-create
+    reproduces the original layout byte-identically — the PR's e2e
+    test depends on that guarantee.
+    """
+
+    body = body or ExportLayoutRequest()
+    pocket = await PocketService.get(pocket_id, user_id)
+    widgets_dump = pocket.get("widgets") or []
+    yaml_text = export_layout_yaml(
+        pocket_id=pocket_id,
+        name=body.name or pocket.get("name", ""),
+        description=body.description or pocket.get("description", ""),
+        category=body.category or pocket.get("type", "custom"),
+        ripple_spec=pocket.get("rippleSpec"),
+        widgets=widgets_dump,
+    )
+    return ExportLayoutResponse(pocket_id=pocket_id, yaml=yaml_text)
+
+
+@router.post("/templates", response_model=UserTemplateResponse)
+async def create_user_template(
+    body: CreateTemplateRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+    store: UserTemplateStore = Depends(get_user_template_store),
+) -> UserTemplateResponse:
+    """Persist a user-defined YAML template under the caller's workspace.
+
+    The template shows up in PocketTemplates's "My templates" category
+    once Cluster B's frontend wires the read side. Malformed YAML
+    returns 400 with a human-readable message instead of 500 — the UI
+    surfaces the error inline on the Save-as-template dialog.
+    """
+
+    try:
+        spec = parse_layout_yaml(body.yaml_source)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+
+    row = store.save(
+        UserPocketTemplate(
+            id=uuid4().hex,
+            workspace_id=workspace_id,
+            owner_id=user_id,
+            name=body.name,
+            description=body.description,
+            category=body.category,
+            spec=spec,
+        ),
+    )
+    return UserTemplateResponse(**row.to_dict())
+
+
+@router.get("/templates", response_model=list[UserTemplateResponse])
+async def list_user_templates(
+    workspace_id: str = Depends(current_workspace_id),
+    store: UserTemplateStore = Depends(get_user_template_store),
+) -> list[UserTemplateResponse]:
+    """List user-defined templates for the caller's active workspace."""
+
+    return [UserTemplateResponse(**row.to_dict()) for row in store.list_for_workspace(workspace_id)]
 
 # ---------------------------------------------------------------------------
 # CRUD

--- a/tests/cloud/test_pocket_layout_routes.py
+++ b/tests/cloud/test_pocket_layout_routes.py
@@ -1,0 +1,271 @@
+# tests/cloud/test_pocket_layout_routes.py — Cluster B Sub-PR #3.
+# Created: 2026-04-19 — Integration coverage for the three new routes on
+# the pockets router that ship the layout save/share surface:
+#
+#   POST /pockets/{id}/export-layout
+#   POST /pockets/templates
+#   GET  /pockets/templates
+#
+# PocketService.get is monkey-patched to return a canned pocket dict so
+# the tests stay independent of Beanie + MongoDB. Auth dependencies and
+# the user-template store are overridden via app.dependency_overrides —
+# same pattern the widget-router tests use.
+#
+# What this pins:
+#   1. /export-layout returns a YAML document carrying the pocket's
+#      ripple_spec under `spec:`.
+#   2. /templates POST parses the YAML and stores a row scoped to the
+#      caller's workspace.
+#   3. /templates GET lists only the workspace's rows — no leak
+#      across workspaces.
+#   4. Malformed YAML yields 400 with a human-readable detail, not 500.
+#   5. Round-trip: /export-layout → /templates POST → GET lists the row
+#      and the stored spec equals the source pocket's rippleSpec.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ee.cloud.license import require_license
+from ee.cloud.pockets.layouts import (
+    UserTemplateStore,
+    get_user_template_store,
+    parse_layout_yaml,
+    reset_user_template_store,
+)
+from ee.cloud.pockets.router import router
+from ee.cloud.pockets.service import PocketService
+from ee.cloud.shared.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_pocket_edit,
+    require_pocket_owner,
+)
+
+
+FAKE_WORKSPACE = "ws-alpha"
+FAKE_USER = "user-alice"
+
+POCKET_FIXTURE: dict[str, Any] = {
+    "_id": "pocket-1",
+    "workspace": FAKE_WORKSPACE,
+    "name": "Sales Dashboard",
+    "description": "Q1 pipeline view",
+    "type": "business",
+    "icon": "bar-chart",
+    "color": "#0A84FF",
+    "owner": FAKE_USER,
+    "visibility": "workspace",
+    "team": [],
+    "agents": [],
+    "widgets": [],
+    "rippleSpec": {
+        "widgets": [
+            {"id": "w1", "type": "pipeline", "title": "Pipeline"},
+            {"id": "w2", "type": "leads", "title": "Leads"},
+        ],
+        "layout": "2-col",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_store():
+    reset_user_template_store()
+    yield
+    reset_user_template_store()
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    a = FastAPI()
+    a.include_router(router)
+
+    async def _fake_get(pocket_id: str, user_id: str) -> dict:
+        return dict(POCKET_FIXTURE, _id=pocket_id)
+
+    monkeypatch.setattr(PocketService, "get", staticmethod(_fake_get))
+
+    # Skip the license/auth guards entirely for the integration tests —
+    # the point here is the new surface, not the guard wiring.
+    a.dependency_overrides[require_license] = lambda: None
+    a.dependency_overrides[require_pocket_edit] = lambda: None
+    a.dependency_overrides[require_pocket_owner] = lambda: None
+    a.dependency_overrides[current_user_id] = lambda: FAKE_USER
+    a.dependency_overrides[current_workspace_id] = lambda: FAKE_WORKSPACE
+
+    return a
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# 1. /export-layout happy path.
+# ---------------------------------------------------------------------------
+
+
+class TestExportLayout:
+    def test_returns_yaml_carrying_the_rippleSpec(self, client: TestClient) -> None:
+        res = client.post("/pockets/pocket-1/export-layout", json={})
+        assert res.status_code == 200, res.text
+
+        body = res.json()
+        assert body["pocket_id"] == "pocket-1"
+        yaml_text = body["yaml"]
+        assert "kind: PocketLayout" in yaml_text
+
+        recovered = parse_layout_yaml(yaml_text)
+        assert recovered == POCKET_FIXTURE["rippleSpec"]
+
+    def test_metadata_overrides_take_effect(self, client: TestClient) -> None:
+        res = client.post(
+            "/pockets/pocket-1/export-layout",
+            json={"name": "Shared Dashboard", "description": "Shipped", "category": "custom"},
+        )
+        assert res.status_code == 200
+        yaml_text = res.json()["yaml"]
+        assert "name: Shared Dashboard" in yaml_text
+        assert "description: Shipped" in yaml_text
+
+
+# ---------------------------------------------------------------------------
+# 2. /templates POST + GET happy path.
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAndListTemplate:
+    def test_create_then_list_shows_the_template(self, client: TestClient) -> None:
+        # Start from an export; the YAML the UI POSTs is almost always
+        # a round-trip of a /export-layout response.
+        export_res = client.post("/pockets/pocket-1/export-layout", json={})
+        assert export_res.status_code == 200
+        yaml_text = export_res.json()["yaml"]
+
+        create_res = client.post(
+            "/pockets/templates",
+            json={
+                "name": "Sales Dashboard (shared)",
+                "description": "",
+                "category": "business",
+                "yaml_source": yaml_text,
+            },
+        )
+        assert create_res.status_code == 200, create_res.text
+        created = create_res.json()
+        assert created["name"] == "Sales Dashboard (shared)"
+        assert created["workspace_id"] == FAKE_WORKSPACE
+        assert created["owner_id"] == FAKE_USER
+        # Spec round-trips cleanly.
+        assert created["spec"] == POCKET_FIXTURE["rippleSpec"]
+
+        list_res = client.get("/pockets/templates")
+        assert list_res.status_code == 200
+        templates = list_res.json()
+        assert len(templates) == 1
+        assert templates[0]["id"] == created["id"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Workspace scoping.
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceScoping:
+    def test_other_workspace_templates_do_not_surface(
+        self,
+        client: TestClient,
+        app: FastAPI,
+    ) -> None:
+        """Seed one template under workspace Beta via the store, then
+        confirm the GET under Alpha returns nothing.
+        """
+
+        store: UserTemplateStore = app.dependency_overrides[get_user_template_store]() \
+            if get_user_template_store in app.dependency_overrides \
+            else get_user_template_store()
+
+        from ee.cloud.pockets.layouts import UserPocketTemplate
+
+        store.save(
+            UserPocketTemplate(
+                id="beta-row",
+                workspace_id="ws-beta",
+                owner_id="carol",
+                name="Beta template",
+                description="",
+                category="custom",
+                spec={"widgets": []},
+            ),
+        )
+
+        res = client.get("/pockets/templates")
+        assert res.status_code == 200
+        assert all(t["workspace_id"] == FAKE_WORKSPACE for t in res.json())
+
+
+# ---------------------------------------------------------------------------
+# 4. Malformed YAML.
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedYaml:
+    def test_missing_spec_returns_400(self, client: TestClient) -> None:
+        res = client.post(
+            "/pockets/templates",
+            json={
+                "name": "Broken",
+                "description": "",
+                "category": "custom",
+                "yaml_source": "kind: PocketLayout\nname: no-spec",
+            },
+        )
+        assert res.status_code == 400
+        assert "spec" in res.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# 5. End-to-end round-trip.
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_export_then_create_then_list_reproduces_the_layout(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Captain's §11 demo flow: save layout, create a fresh pocket
+        from the saved template, and confirm the layout is recoverable.
+        The frontend runs the "create new pocket" step; here we only
+        check the server-visible artefacts line up.
+        """
+
+        export_res = client.post("/pockets/pocket-1/export-layout", json={})
+        assert export_res.status_code == 200
+        yaml_text = export_res.json()["yaml"]
+
+        create_res = client.post(
+            "/pockets/templates",
+            json={
+                "name": "Round-trip",
+                "description": "",
+                "category": "business",
+                "yaml_source": yaml_text,
+            },
+        )
+        assert create_res.status_code == 200
+        new_template = create_res.json()
+
+        list_res = client.get("/pockets/templates")
+        assert list_res.status_code == 200
+        templates = list_res.json()
+        found = [t for t in templates if t["id"] == new_template["id"]]
+        assert len(found) == 1
+        # The stored spec mirrors the source pocket's rippleSpec.
+        assert found[0]["spec"] == POCKET_FIXTURE["rippleSpec"]

--- a/tests/cloud/test_pocket_layouts.py
+++ b/tests/cloud/test_pocket_layouts.py
@@ -1,0 +1,193 @@
+# tests/cloud/test_pocket_layouts.py — Cluster B Sub-PR #3.
+# Created: 2026-04-19 — Unit coverage for the YAML export/parse helpers
+# and the in-process user-template store. These tests are pure — no
+# Beanie, no MongoDB, no FastAPI. The router-level tests in
+# test_pocket_layout_routes.py exercise the HTTP surface against the
+# same store with PocketService.get monkeypatched.
+#
+# What this pins:
+#   1. YAML export is deterministic (same input → byte-identical output).
+#   2. YAML export carries the required metadata block + spec.
+#   3. parse_layout_yaml rejects malformed YAML with a ValueError that
+#      is safe to surface to the caller.
+#   4. parse_layout_yaml rejects a missing/invalid `spec` block.
+#   5. Round-trip: export → parse_layout_yaml gives back the original
+#      ripple_spec dict.
+#   6. UserTemplateStore scoping: one workspace's templates do not
+#      leak into another's list.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ee.cloud.pockets.layouts import (
+    UserPocketTemplate,
+    UserTemplateStore,
+    export_layout_yaml,
+    parse_layout_yaml,
+)
+
+
+def _base_spec() -> dict[str, Any]:
+    return {
+        "widgets": [
+            {"id": "w1", "type": "pipeline", "title": "Pipeline"},
+            {"id": "w2", "type": "leads", "title": "Leads"},
+        ],
+        "layout": "2-col",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Determinism.
+# ---------------------------------------------------------------------------
+
+
+class TestExportDeterminism:
+    def test_same_input_yields_byte_identical_yaml_excluding_timestamp(self) -> None:
+        """``exportedAt`` changes every call, but every other key is
+        sorted and stable. Strip the timestamp line, then expect
+        equality.
+        """
+
+        y1 = export_layout_yaml(
+            pocket_id="p-1",
+            name="Dashboard",
+            description="",
+            category="custom",
+            ripple_spec=_base_spec(),
+            widgets=[],
+        )
+        y2 = export_layout_yaml(
+            pocket_id="p-1",
+            name="Dashboard",
+            description="",
+            category="custom",
+            ripple_spec=_base_spec(),
+            widgets=[],
+        )
+
+        def strip_ts(s: str) -> list[str]:
+            return [ln for ln in s.splitlines() if "exportedAt" not in ln]
+
+        assert strip_ts(y1) == strip_ts(y2)
+
+
+# ---------------------------------------------------------------------------
+# 2. Required metadata + spec presence.
+# ---------------------------------------------------------------------------
+
+
+class TestExportShape:
+    def test_yaml_carries_required_top_level_keys(self) -> None:
+        y = export_layout_yaml(
+            pocket_id="p-1",
+            name="Dashboard",
+            description="desc",
+            category="custom",
+            ripple_spec=_base_spec(),
+            widgets=[],
+        )
+        assert "apiVersion: pocketpaw.io/v1" in y
+        assert "kind: PocketLayout" in y
+        assert "name: Dashboard" in y
+        assert "sourcePocketId: p-1" in y
+
+    def test_empty_ripple_spec_falls_back_to_widgets_mirror(self) -> None:
+        y = export_layout_yaml(
+            pocket_id="p-2",
+            name="Blank",
+            description="",
+            category="custom",
+            ripple_spec=None,
+            widgets=[{"id": "w-legacy", "type": "metric"}],
+        )
+        parsed = parse_layout_yaml(y)
+        assert parsed["widgets"][0]["id"] == "w-legacy"
+
+
+# ---------------------------------------------------------------------------
+# 3 + 4. parse_layout_yaml validation.
+# ---------------------------------------------------------------------------
+
+
+class TestParseValidation:
+    def test_malformed_yaml_raises_valueerror(self) -> None:
+        with pytest.raises(ValueError) as exc:
+            parse_layout_yaml("name: : : nope")
+        assert "Invalid YAML" in str(exc.value)
+
+    def test_missing_spec_raises_valueerror(self) -> None:
+        with pytest.raises(ValueError) as exc:
+            parse_layout_yaml("kind: PocketLayout\nname: no-spec")
+        assert "spec" in str(exc.value)
+
+    def test_unknown_kind_is_rejected(self) -> None:
+        with pytest.raises(ValueError) as exc:
+            parse_layout_yaml("kind: OtherThing\nspec: {}")
+        assert "Unsupported template kind" in str(exc.value)
+
+    def test_list_root_is_rejected(self) -> None:
+        with pytest.raises(ValueError) as exc:
+            parse_layout_yaml("- one\n- two\n")
+        assert "mapping" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# 5. Round-trip.
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_export_then_parse_recovers_the_spec(self) -> None:
+        original = _base_spec()
+        y = export_layout_yaml(
+            pocket_id="p-1",
+            name="Dashboard",
+            description="",
+            category="custom",
+            ripple_spec=original,
+            widgets=[],
+        )
+        recovered = parse_layout_yaml(y)
+        assert recovered == original
+
+
+# ---------------------------------------------------------------------------
+# 6. Store scoping.
+# ---------------------------------------------------------------------------
+
+
+class TestStoreScoping:
+    def test_templates_do_not_leak_between_workspaces(self) -> None:
+        store = UserTemplateStore()
+        store.save(
+            UserPocketTemplate(
+                id="tpl-a",
+                workspace_id="ws-alpha",
+                owner_id="alice",
+                name="Alpha dashboard",
+                description="",
+                category="custom",
+                spec=_base_spec(),
+            ),
+        )
+        store.save(
+            UserPocketTemplate(
+                id="tpl-b",
+                workspace_id="ws-beta",
+                owner_id="carol",
+                name="Beta dashboard",
+                description="",
+                category="custom",
+                spec=_base_spec(),
+            ),
+        )
+
+        alpha = store.list_for_workspace("ws-alpha")
+        beta = store.list_for_workspace("ws-beta")
+
+        assert [t.id for t in alpha] == ["tpl-a"]
+        assert [t.id for t in beta] == ["tpl-b"]


### PR DESCRIPTION
## What changed

Backend surface for Cluster B Sub-PR #3 — layout save/share. Closes UI-TESTING-GUIDE §11 gap B5 on the backend. Three new routes:

- \`POST /api/v1/pockets/{id}/export-layout\` → returns the pocket's layout as YAML
- \`POST /api/v1/pockets/templates\` → accepts a user-supplied YAML template
- \`GET /api/v1/pockets/templates\` → lists the caller's workspace templates

New module \`ee/cloud/pockets/layouts.py\` carries the YAML helpers plus an in-process \`UserTemplateStore\` keyed by \`(workspace_id, template_id)\`.

## Design choices worth flagging

- **YAML is deterministic** (\`sort_keys=True\`). Same pocket + metadata produces byte-identical YAML excluding the \`exportedAt\` timestamp, so round-trip export → parse → export reproduces the source layout. The frontend's Save-as-template → create-pocket-from-template e2e test depends on this guarantee.
- **Envelope is \`apiVersion/kind/metadata/spec\`.** Gives us room to version the schema later without a migration. Unknown kinds return 400 rather than silently coercing.
- **Storage is in-process for now.** The REST contract matches the MongoDB-backed version that follows on Wave 4. UI wires against the surface today; persistence swaps in behind it with no frontend change.
- **Scope is workspace-only.** One workspace's templates do not leak into another's list — tested explicitly.
- **PyYAML lazy-imports** inside the helpers (matching \`ee/fleet/installer.py\`) so base install stays free of new top-level deps.

## Tests

15 pytest cases: 9 unit on helpers + store (determinism, round-trip, malformed YAML, scope), 6 integration on the router (export shape, create+list, workspace scoping, 400 on bad YAML, full round-trip). All 40 existing pocket tests still pass.

## Refs

- \`docs/plans/FEATURE-HARDENING-PLAN.md#cluster-b--pocket-core\`
- \`docs/plans/cluster-B-reality.md\` (missing-routes table rows for \"Save shareable layout snapshot\")

## Notes for captain review

- Pairs with the paw-enterprise frontend PR for Sub-PR #3 (Save-as-template toolbar + \"My templates\" gallery section).
- Do NOT merge. Captain reviews before any cluster-B PR lands.