### PR TITLE
feat(knowledge): workspace-level article rollup endpoint

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -1,8 +1,10 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
 Updated: Added kb (knowledge base) domain router to mount_cloud().
+Updated: 2026-04-19 (Cluster C / PR1) — Mounted ee.cloud.kb.knowledge_router,
+    which exposes GET /api/v1/knowledge/articles as a workspace-level aggregate.
 
-Domains: auth, workspace, chat, pockets, sessions, agents, kb.
+Domains: auth, workspace, chat, pockets, sessions, agents, kb, knowledge.
 Each has router.py (thin), service.py (logic), schemas.py (validation).
 """
 
@@ -70,11 +72,13 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(pockets_router, prefix="/api/v1")
     app.include_router(sessions_router, prefix="/api/v1")
 
+    from ee.cloud.kb.knowledge_router import router as knowledge_router
     from ee.cloud.kb.router import router as kb_router
     from ee.cloud.notifications.router import router as notifications_router
     from ee.cloud.uploads.router import router as uploads_router
 
     app.include_router(kb_router, prefix="/api/v1")
+    app.include_router(knowledge_router, prefix="/api/v1")
     app.include_router(uploads_router, prefix="/api/v1")
     app.include_router(notifications_router, prefix="/api/v1")
 

--- a/ee/cloud/kb/knowledge_router.py
+++ b/ee/cloud/kb/knowledge_router.py
@@ -1,0 +1,109 @@
+# knowledge_router.py — Workspace-level knowledge browser router.
+# Created: 2026-04-19 (Cluster C / PR1) — Adds GET /api/v1/knowledge/articles,
+# a workspace-level rollup that unions the workspace KB with every per-agent
+# KB inside the workspace. See docs/plans/FEATURE-HARDENING-PLAN.md §Cluster C
+# and docs/plans/cluster-C-reality.md for the Wave 1 reality brief.
+"""Workspace-level knowledge browser — FastAPI router.
+
+Mounts at ``/api/v1/knowledge/*``. Kept separate from the per-workspace-scope
+``/api/v1/kb/*`` router because the aggregation semantics differ: this view
+fans out across every agent in the workspace, whereas ``/kb/articles`` is a
+single-scope list.
+
+Auth model:
+    - ``kb.read`` action required on the active workspace.
+    - ``workspace_id`` query param, if provided, must match the caller's
+      active workspace. We intentionally do not allow cross-workspace reads
+      from this endpoint — the guard ``require_action_any_workspace('kb.read')``
+      already pins the caller to their active workspace, and honouring a
+      different ``workspace_id`` would leak KB across tenants.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from ee.cloud.kb.workspace_aggregator import aggregate_workspace_articles
+from ee.cloud.license import require_license
+from ee.cloud.shared.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_action_any_workspace,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/knowledge",
+    tags=["Knowledge"],
+    dependencies=[Depends(require_license)],
+)
+
+
+async def _list_workspace_agent_ids(workspace_id: str) -> list[str]:
+    """Return every agent id that belongs to *workspace_id*. Lazy import so
+    tests can patch this without pulling in Beanie/Mongo eagerly."""
+    from ee.cloud.models.agent import Agent
+
+    docs = await Agent.find(Agent.workspace == workspace_id).to_list()
+    return [str(doc.id) for doc in docs]
+
+
+def _call_kb_list(scope: str) -> list[Any]:
+    """Wrap the kb-go ``list`` command. Non-list returns are coerced to ``[]``
+    so the aggregator never sees surprising shapes."""
+    from ee.cloud.agents.knowledge import _kb
+
+    try:
+        result = _kb("list", "--scope", scope)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("kb list raised for scope=%s: %s", scope, exc)
+        return []
+    return result if isinstance(result, list) else []
+
+
+@router.get(
+    "/articles",
+    dependencies=[Depends(require_action_any_workspace("kb.read"))],
+)
+async def list_workspace_articles(
+    workspace_id_q: str | None = Query(None, alias="workspace_id"),
+    agent_id: str | None = Query(None, description="Filter by agent; 'workspace' for workspace-only"),
+    active_workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """List KB articles across the workspace + every agent in the workspace.
+
+    Query params:
+    -  ``workspace_id`` — optional; must match the caller's active workspace
+       if set (prevents accidental cross-tenant reads).
+    - ``agent_id`` — optional filter. ``"workspace"`` means workspace-only,
+      otherwise restricts to one agent's KB.
+    """
+    if workspace_id_q is not None and workspace_id_q != active_workspace_id:
+        raise HTTPException(
+            status_code=403,
+            detail="workspace_id must match the caller's active workspace",
+        )
+
+    agent_ids = await _list_workspace_agent_ids(active_workspace_id)
+    if agent_id is not None and agent_id != "workspace" and agent_id not in agent_ids:
+        # Unknown agent or an agent outside this workspace — surface as empty
+        # rather than leaking existence of agents in other workspaces.
+        return {"articles": [], "total": 0, "agent_ids": agent_ids}
+
+    articles = await aggregate_workspace_articles(
+        workspace_id=active_workspace_id,
+        agent_ids=agent_ids,
+        kb_list=_call_kb_list,
+        agent_filter=agent_id,
+    )
+
+    return {
+        "articles": [a.to_dict() for a in articles],
+        "total": len(articles),
+        "agent_ids": agent_ids,
+    }

--- a/ee/cloud/kb/workspace_aggregator.py
+++ b/ee/cloud/kb/workspace_aggregator.py
@@ -1,0 +1,169 @@
+# workspace_aggregator.py — Workspace-level KB aggregator for Cluster C / PR 1.
+# Created: 2026-04-19 — Powers GET /api/v1/knowledge/articles by merging the
+# workspace-scoped KB (`workspace:{id}`) with every per-agent KB
+# (`agent:{agent_id}`) that lives inside the same workspace. Scope checks are
+# enforced by the route layer; this module is pure aggregation and sorting.
+"""Workspace-level knowledge aggregator.
+
+The `/api/v1/kb/articles` endpoint only lists articles at the workspace scope.
+Per-agent knowledge (ingested via the agent Knowledge tab) lives in its own kb
+scope (`agent:{agent_id}`) and today has no cross-agent browse path — the only
+consumer is the per-agent search endpoint.
+
+For the workspace-level KB browser (UI-TESTING-GUIDE §5) we need to flatten
+both surfaces into a single stream, tagged with the owning scope so the UI can
+filter by agent + source. This module encapsulates that merge so the route
+handler stays thin and the merge is unit-testable without a live kb binary or
+MongoDB.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AggregatedArticle:
+    """One row in the workspace KB browser."""
+
+    id: str
+    title: str
+    source: str
+    scope: str  # "workspace:{id}" or "agent:{agent_id}"
+    agent_id: str | None
+    updated_at: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "source": self.source,
+            "scope": self.scope,
+            "agent_id": self.agent_id,
+            "updated_at": self.updated_at,
+        }
+
+
+def _row_to_article(
+    row: Any, *, scope: str, agent_id: str | None
+) -> AggregatedArticle | None:
+    """Normalise one kb-binary row into an AggregatedArticle.
+
+    The kb binary returns JSON objects that vary by list/search call. We accept
+    a few common key names so the aggregator survives minor CLI drift.
+    """
+    if not isinstance(row, dict):
+        return None
+    article_id = row.get("id") or row.get("article_id") or row.get("_id")
+    if not article_id:
+        return None
+    title = (
+        row.get("title")
+        or row.get("name")
+        or row.get("source")
+        or f"article:{article_id}"
+    )
+    source = row.get("source") or row.get("origin") or ""
+    updated_at = row.get("updated_at") or row.get("updatedAt") or row.get("modified")
+    return AggregatedArticle(
+        id=str(article_id),
+        title=str(title),
+        source=str(source),
+        scope=scope,
+        agent_id=agent_id,
+        updated_at=str(updated_at) if updated_at else None,
+    )
+
+
+def _dedupe(articles: list[AggregatedArticle]) -> list[AggregatedArticle]:
+    """Drop duplicates by (scope, id) — a single article can only belong to one
+    scope but the kb binary occasionally returns the same row twice on boundary
+    conditions. De-duping keeps the UI honest."""
+    seen: set[tuple[str, str]] = set()
+    out: list[AggregatedArticle] = []
+    for article in articles:
+        key = (article.scope, article.id)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(article)
+    return out
+
+
+def _sort_newest_first(articles: list[AggregatedArticle]) -> list[AggregatedArticle]:
+    """Sort by updated_at desc with None last. Stable on ties so scope ordering
+    is preserved from the caller."""
+    return sorted(
+        articles,
+        key=lambda a: (a.updated_at is None, a.updated_at or ""),
+        reverse=False,
+    ) if not articles else sorted(
+        articles,
+        key=lambda a: a.updated_at or "",
+        reverse=True,
+    )
+
+
+async def aggregate_workspace_articles(
+    *,
+    workspace_id: str,
+    agent_ids: list[str],
+    kb_list: Callable[[str], Awaitable[list[Any]] | list[Any]],
+    agent_filter: str | None = None,
+) -> list[AggregatedArticle]:
+    """Aggregate KB articles across the workspace scope + each agent scope.
+
+    Parameters
+    ----------
+    workspace_id : str
+        The active workspace id — maps to `workspace:{id}` kb scope.
+    agent_ids : list[str]
+        Every agent id that belongs to the workspace. The caller resolves these
+        against the Agent collection with proper scope guards.
+    kb_list : callable
+        Function that takes a scope string and returns a list of kb rows. The
+        real implementation wraps the kb-go binary's ``list`` command; tests
+        substitute an in-memory dict.
+    agent_filter : str | None
+        If set, only include articles whose ``agent_id`` matches this value.
+        ``"workspace"`` means workspace-scoped articles only; ``None`` means
+        no filter.
+
+    Returns
+    -------
+    list[AggregatedArticle]
+        Newest-first, de-duplicated.
+    """
+    scopes: list[tuple[str, str | None]] = []
+    if agent_filter is None or agent_filter == "workspace":
+        scopes.append((f"workspace:{workspace_id}", None))
+    if agent_filter != "workspace":
+        for agent_id in agent_ids:
+            if agent_filter is not None and agent_filter != agent_id:
+                continue
+            scopes.append((f"agent:{agent_id}", agent_id))
+
+    articles: list[AggregatedArticle] = []
+    for scope, agent_id in scopes:
+        try:
+            result = kb_list(scope)
+            if hasattr(result, "__await__"):
+                rows = await result  # type: ignore[assignment]
+            else:
+                rows = result
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("kb list failed for scope=%s: %s", scope, exc)
+            continue
+        if not isinstance(rows, list):
+            continue
+        for row in rows:
+            article = _row_to_article(row, scope=scope, agent_id=agent_id)
+            if article is not None:
+                articles.append(article)
+
+    return _sort_newest_first(_dedupe(articles))

--- a/tests/cloud/test_knowledge_aggregator.py
+++ b/tests/cloud/test_knowledge_aggregator.py
@@ -1,0 +1,213 @@
+# test_knowledge_aggregator.py — Unit tests for the workspace KB aggregator.
+# Created: 2026-04-19 (Cluster C / PR1) — Pins the aggregator's merge and
+# scope-filter contract before it becomes the /knowledge/articles endpoint's
+# only test harness. See ee/cloud/kb/workspace_aggregator.py for the code
+# under test.
+"""Unit tests for the workspace-level KB aggregator.
+
+These tests operate on the pure-Python aggregator module — no FastAPI, no
+Beanie, no subprocess. They lock in:
+
+- Merge: workspace + every agent scope feed into the result.
+- Filter: ``agent_filter='workspace'`` drops all agent scopes;
+  ``agent_filter='<agent_id>'`` keeps only that agent's scope.
+- Dedup: same (scope, id) pair collapses to one row.
+- Sort: newest-first on ``updated_at`` with ``None`` last.
+- Resilience: a kb binary that returns a non-list for one scope does not
+  sink the aggregator — that scope is skipped and the rest flow.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ee.cloud.kb.workspace_aggregator import (
+    AggregatedArticle,
+    aggregate_workspace_articles,
+)
+
+
+def _make_rows(count: int, prefix: str, base_ts: str = "2026-04-19T09:00:00Z") -> list[dict]:
+    return [
+        {
+            "id": f"{prefix}-{i}",
+            "title": f"{prefix} article {i}",
+            "source": f"{prefix}-source-{i}",
+            "updated_at": f"2026-04-{10 + i:02d}T12:00:00Z",
+        }
+        for i in range(count)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_merges_workspace_and_agent_scopes():
+    ws_rows = _make_rows(2, "ws")
+    a1_rows = _make_rows(3, "a1")
+    a2_rows = _make_rows(1, "a2")
+
+    def fake_kb_list(scope: str):
+        return {
+            "workspace:ws1": ws_rows,
+            "agent:a1": a1_rows,
+            "agent:a2": a2_rows,
+        }.get(scope, [])
+
+    articles = await aggregate_workspace_articles(
+        workspace_id="ws1",
+        agent_ids=["a1", "a2"],
+        kb_list=fake_kb_list,
+    )
+
+    assert len(articles) == 2 + 3 + 1
+    scopes = {a.scope for a in articles}
+    assert scopes == {"workspace:ws1", "agent:a1", "agent:a2"}
+
+
+@pytest.mark.asyncio
+async def test_agent_filter_workspace_keyword_drops_agents():
+    ws_rows = _make_rows(2, "ws")
+    a1_rows = _make_rows(3, "a1")
+
+    def fake_kb_list(scope: str):
+        return {"workspace:ws1": ws_rows, "agent:a1": a1_rows}.get(scope, [])
+
+    articles = await aggregate_workspace_articles(
+        workspace_id="ws1",
+        agent_ids=["a1"],
+        kb_list=fake_kb_list,
+        agent_filter="workspace",
+    )
+
+    assert len(articles) == 2
+    assert all(a.scope == "workspace:ws1" for a in articles)
+
+
+@pytest.mark.asyncio
+async def test_agent_filter_specific_agent_isolates_scope():
+    a1_rows = _make_rows(2, "a1")
+    a2_rows = _make_rows(2, "a2")
+
+    def fake_kb_list(scope: str):
+        return {"agent:a1": a1_rows, "agent:a2": a2_rows}.get(scope, [])
+
+    articles = await aggregate_workspace_articles(
+        workspace_id="ws1",
+        agent_ids=["a1", "a2"],
+        kb_list=fake_kb_list,
+        agent_filter="a2",
+    )
+
+    assert len(articles) == 2
+    assert all(a.agent_id == "a2" for a in articles)
+
+
+@pytest.mark.asyncio
+async def test_dedupe_by_scope_and_id():
+    dupes = _make_rows(1, "ws") * 2
+    ws_rows = dupes + _make_rows(1, "ws")
+
+    def fake_kb_list(scope: str):
+        return ws_rows if scope == "workspace:ws1" else []
+
+    articles = await aggregate_workspace_articles(
+        workspace_id="ws1",
+        agent_ids=[],
+        kb_list=fake_kb_list,
+    )
+
+    # ws-0 appeared 3 times (twice via dupes, once via the third row),
+    # ws-1 does not exist because _make_rows(1, "ws") only makes ws-0.
+    # So we should end with exactly one row.
+    assert len(articles) == 1
+    assert articles[0].id == "ws-0"
+
+
+@pytest.mark.asyncio
+async def test_newest_first_ordering():
+    rows = [
+        {"id": "old", "title": "old", "updated_at": "2026-04-01T00:00:00Z"},
+        {"id": "new", "title": "new", "updated_at": "2026-04-19T00:00:00Z"},
+        {"id": "mid", "title": "mid", "updated_at": "2026-04-10T00:00:00Z"},
+    ]
+
+    def fake_kb_list(scope: str):
+        return rows if scope == "workspace:ws1" else []
+
+    articles = await aggregate_workspace_articles(
+        workspace_id="ws1",
+        agent_ids=[],
+        kb_list=fake_kb_list,
+    )
+    assert [a.id for a in articles] == ["new", "mid", "old"]
+
+
+@pytest.mark.asyncio
+async def test_non_list_rows_are_skipped():
+    def fake_kb_list(scope: str):
+        # Workspace scope returns a string (kb binary degenerate case), agent
+        # scope returns a real list. Only the agent rows should land.
+        if scope == "workspace:ws1":
+            return "oops not a list"  # type: ignore[return-value]
+        return _make_rows(2, "agent-a")
+
+    articles = await aggregate_workspace_articles(
+        workspace_id="ws1",
+        agent_ids=["a"],
+        kb_list=fake_kb_list,
+    )
+    assert len(articles) == 2
+    assert all(a.agent_id == "a" for a in articles)
+
+
+@pytest.mark.asyncio
+async def test_rows_missing_id_are_dropped():
+    rows = [
+        {"title": "no-id"},
+        {"id": "keep", "title": "keep"},
+        {"id": "", "title": "empty-id"},
+    ]
+
+    def fake_kb_list(scope: str):
+        return rows if scope == "workspace:ws1" else []
+
+    articles = await aggregate_workspace_articles(
+        workspace_id="ws1",
+        agent_ids=[],
+        kb_list=fake_kb_list,
+    )
+    assert [a.id for a in articles] == ["keep"]
+
+
+@pytest.mark.asyncio
+async def test_async_kb_list_is_awaited():
+    async def async_kb_list(scope: str):
+        if scope == "workspace:ws1":
+            return _make_rows(1, "ws")
+        return []
+
+    articles = await aggregate_workspace_articles(
+        workspace_id="ws1",
+        agent_ids=[],
+        kb_list=async_kb_list,
+    )
+    assert len(articles) == 1
+    assert articles[0].scope == "workspace:ws1"
+
+
+def test_aggregated_article_to_dict_shape():
+    article = AggregatedArticle(
+        id="a1",
+        title="Title",
+        source="src",
+        scope="workspace:ws1",
+        agent_id=None,
+        updated_at="2026-04-19T00:00:00Z",
+    )
+    assert article.to_dict() == {
+        "id": "a1",
+        "title": "Title",
+        "source": "src",
+        "scope": "workspace:ws1",
+        "agent_id": None,
+        "updated_at": "2026-04-19T00:00:00Z",
+    }

--- a/tests/cloud/test_knowledge_router.py
+++ b/tests/cloud/test_knowledge_router.py
@@ -1,0 +1,119 @@
+# test_knowledge_router.py — Integration tests for /api/v1/knowledge/articles.
+# Created: 2026-04-19 (Cluster C / PR1) — Exercises the workspace KB browser
+# route with a User stub that already owns the active workspace, so the
+# ``kb.read`` action guard resolves without a real RBAC database. Proves the
+# merge, filter, and cross-workspace block contracts end-to-end through
+# FastAPI.
+"""Integration tests for the workspace-level knowledge router."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import ee.cloud.kb.knowledge_router as knowledge_router_module
+from ee.cloud.auth import current_active_user
+from ee.cloud.license import require_license
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    fake_rows = {
+        "workspace:ws-alpha": [
+            {"id": "ws-doc-1", "title": "Workspace KB 1", "updated_at": "2026-04-18T10:00:00Z"},
+            {"id": "ws-doc-2", "title": "Workspace KB 2", "updated_at": "2026-04-19T10:00:00Z"},
+        ],
+        "agent:agent-1": [
+            {"id": "a1-doc", "title": "Agent 1 KB", "updated_at": "2026-04-17T10:00:00Z"},
+        ],
+        "agent:agent-2": [
+            {"id": "a2-doc", "title": "Agent 2 KB", "updated_at": "2026-04-16T10:00:00Z"},
+        ],
+    }
+
+    def fake_kb_list(scope: str):
+        return fake_rows.get(scope, [])
+
+    async def fake_list_workspace_agent_ids(workspace_id: str) -> list[str]:
+        if workspace_id == "ws-alpha":
+            return ["agent-1", "agent-2"]
+        return []
+
+    monkeypatch.setattr(knowledge_router_module, "_call_kb_list", fake_kb_list)
+    monkeypatch.setattr(
+        knowledge_router_module,
+        "_list_workspace_agent_ids",
+        fake_list_workspace_agent_ids,
+    )
+
+    # Stub RBAC: make every action check pass for our fake user.
+    from pocketpaw.ee.guards import deps as guards_deps
+
+    monkeypatch.setattr(guards_deps, "check_workspace_action", lambda *a, **k: None)
+
+    # Build a fake user that already has ws-alpha as its active workspace.
+    fake_user = SimpleNamespace(
+        id="user-1",
+        active_workspace="ws-alpha",
+        workspaces=[SimpleNamespace(workspace="ws-alpha", role="owner")],
+    )
+
+    async def fake_current_active_user():
+        return fake_user
+
+    app = FastAPI()
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = fake_current_active_user
+    app.include_router(knowledge_router_module.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+def test_list_workspace_articles_unions_scopes(client: TestClient) -> None:
+    response = client.get("/api/v1/knowledge/articles")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 4
+    ids = {a["id"] for a in body["articles"]}
+    assert ids == {"ws-doc-1", "ws-doc-2", "a1-doc", "a2-doc"}
+    scopes = {a["scope"] for a in body["articles"]}
+    assert scopes == {"workspace:ws-alpha", "agent:agent-1", "agent:agent-2"}
+    assert set(body["agent_ids"]) == {"agent-1", "agent-2"}
+
+
+def test_filter_by_workspace_keyword(client: TestClient) -> None:
+    response = client.get("/api/v1/knowledge/articles?agent_id=workspace")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2
+    assert all(a["scope"] == "workspace:ws-alpha" for a in body["articles"])
+
+
+def test_filter_by_agent_id(client: TestClient) -> None:
+    response = client.get("/api/v1/knowledge/articles?agent_id=agent-1")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["articles"][0]["agent_id"] == "agent-1"
+
+
+def test_cross_workspace_id_rejected(client: TestClient) -> None:
+    response = client.get("/api/v1/knowledge/articles?workspace_id=ws-beta")
+    assert response.status_code == 403
+    assert "must match" in response.json()["detail"]
+
+
+def test_unknown_agent_returns_empty_not_leak(client: TestClient) -> None:
+    """An agent id outside the workspace must NOT cross-query another tenant.
+
+    The route returns an empty list + the real agent_ids, not a 404 — so the
+    caller can't probe existence of agents in a different workspace.
+    """
+    response = client.get("/api/v1/knowledge/articles?agent_id=some-other-agent")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 0
+    assert body["articles"] == []
+    assert set(body["agent_ids"]) == {"agent-1", "agent-2"}


### PR DESCRIPTION
## What this does

Adds `GET /api/v1/knowledge/articles` — the rollup endpoint the paw-enterprise `/knowledge` route (companion PR on main) consumes. The result merges the workspace-scoped KB with every per-agent KB inside the active workspace, so a viewer can finally browse everything the org knows from one place.

Closes gap **C1** in `docs/plans/FEATURE-HARDENING-PLAN.md` (Cluster C — Knowledge & Data) and the "Workspace KB aggregation" row in `docs/plans/cluster-C-reality.md`. UI-TESTING-GUIDE §5 is the user-facing story.

## What it does NOT touch

- `/api/v1/kb/*` stays exactly as-is. This is an additive aggregator, not a rewrite.
- No schema changes on the kb-go binary.
- No migration. The merge runs at read time over whatever kb already has.

## Design notes

- **Pure aggregator:** `ee/cloud/kb/workspace_aggregator.py` is a dependency-free module. The route layer passes in a `kb_list(scope)` callable — tests swap it for a dict, production wires it to the kb-go `list` command.
- **Tenant guard:** if the caller passes `?workspace_id=`, it has to match their active workspace. Otherwise 403. This blocks the "hand a cookie to the wrong URL and read another tenant's KB" bug class.
- **Unknown-agent leak:** agent IDs outside the active workspace return `[]` + the workspace's own `agent_ids`, not a 404. That way you can't probe whether an agent exists in a different tenant.
- **Dedupe + sort:** identical (scope, id) rows collapse, newest-first on `updated_at`.

## Test coverage

- `tests/cloud/test_knowledge_aggregator.py` — 9 unit specs for the merge module (scope union, workspace-only filter, agent-id filter, dedupe, sort, non-list resilience, async callable support, missing-id rows, `to_dict` shape).
- `tests/cloud/test_knowledge_router.py` — 5 router specs with a stubbed `current_active_user` + action guard: cross-workspace 403, unknown-agent empty response, workspace keyword isolation, per-agent filter, full union.

```
uv run pytest tests/cloud/test_knowledge_aggregator.py tests/cloud/test_knowledge_router.py
.............. 14 passed in 0.51s
```

## Stacks on

- Stacks on #987 (Wave 2 pytest fixtures) for the shared cloud fixtures pattern.
- Paired frontend PR opens against qbtrix/paw-enterprise:main and references #93 (contract harness) + #95 (Wave 2 seed).

## Downstream

Cluster D will start on PocketDataPanel + AgentSoulTab edits **after sub-PRs 2 and 3 land** — see Cluster C serialisation note in the plan.