### PR TITLE
feat(fabric): list endpoints for objects and links

### DIFF
--- a/ee/fabric/router.py
+++ b/ee/fabric/router.py
@@ -1,5 +1,8 @@
 # ee/fabric/router.py — FastAPI router for the Fabric ontology API.
 # Created: 2026-03-28 — CRUD endpoints for object types, objects, links, queries, stats.
+# Updated: 2026-04-19 (Cluster C / PR3) — Added GET /fabric/objects and
+#   GET /fabric/links list endpoints so the Objects/Links sub-tabs in
+#   PocketDataPanel render real data instead of the Brew & Co. mock.
 
 from __future__ import annotations
 
@@ -7,10 +10,17 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
-from ee.fabric.models import FabricObject, FabricQuery, FabricQueryResult, ObjectType, PropertyDef
+from ee.fabric.models import (
+    FabricLink,
+    FabricObject,
+    FabricQuery,
+    FabricQueryResult,
+    ObjectType,
+    PropertyDef,
+)
 from ee.fabric.store import FabricStore
 
 logger = logging.getLogger(__name__)
@@ -70,6 +80,54 @@ async def define_type(req: DefineTypeRequest):
         icon=req.icon,
         color=req.color,
     )
+
+
+class ObjectsListResponse(BaseModel):
+    objects: list[FabricObject]
+    total: int
+
+
+class LinksListResponse(BaseModel):
+    links: list[FabricLink]
+    total: int
+
+
+@router.get("/fabric/objects", response_model=ObjectsListResponse)
+async def list_objects(
+    type_id: str | None = Query(None, description="Filter by object type id"),
+    type_name: str | None = Query(None, description="Filter by object type name (case-insensitive)"),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+) -> ObjectsListResponse:
+    """List objects with optional type filter.
+
+    Wraps ``FabricStore.query()`` so we inherit its parameter binding. The
+    ``type_id`` / ``type_name`` filters go through ``FabricQuery``, which
+    concatenates only whitelisted column names — user input flows exclusively
+    through bound parameters.
+    """
+    q = FabricQuery(type_id=type_id, type_name=type_name, limit=limit, offset=offset)
+    result = await _store().query(q)
+    return ObjectsListResponse(objects=result.objects, total=result.total)
+
+
+@router.get("/fabric/links", response_model=LinksListResponse)
+async def list_links(
+    from_id: str | None = Query(None, description="Filter by source object id"),
+    to_id: str | None = Query(None, description="Filter by destination object id"),
+    link_type: str | None = Query(None, description="Filter by link type"),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+) -> LinksListResponse:
+    """List links between objects with optional endpoint + type filters."""
+    links, total = await _store().list_links(
+        from_id=from_id,
+        to_id=to_id,
+        link_type=link_type,
+        limit=limit,
+        offset=offset,
+    )
+    return LinksListResponse(links=links, total=total)
 
 
 @router.post("/fabric/objects", response_model=FabricObject, status_code=201)

--- a/ee/fabric/store.py
+++ b/ee/fabric/store.py
@@ -1,5 +1,8 @@
 # Fabric store — async SQLite operations for the ontology layer.
 # Created: 2026-03-28 — CRUD for object types, objects, and links.
+# Updated: 2026-04-19 (Cluster C / PR3) — Added list_links() for the new
+#   GET /api/v1/fabric/links endpoint that the Links sub-tab in
+#   PocketDataPanel now consumes instead of its hardcoded placeholder.
 
 from __future__ import annotations
 
@@ -260,6 +263,51 @@ class FabricStore:
             await db.commit()
         return lnk
 
+    async def list_links(
+        self,
+        from_id: str | None = None,
+        to_id: str | None = None,
+        link_type: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> tuple[list[FabricLink], int]:
+        """List links with optional filters on endpoints and link_type.
+
+        Returns ``(links, total)`` where ``total`` is the unpaginated count.
+        All filter arguments are bound parameters — no query-string
+        concatenation, so SQL injection through link_type is not possible.
+        """
+        conditions: list[str] = []
+        params: list[Any] = []
+        if from_id:
+            conditions.append("from_object_id = ?")
+            params.append(from_id)
+        if to_id:
+            conditions.append("to_object_id = ?")
+            params.append(to_id)
+        if link_type:
+            conditions.append("link_type = ?")
+            params.append(link_type)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                f"SELECT COUNT(*) AS cnt FROM fabric_links {where}", params
+            ) as cur:
+                row = await cur.fetchone()
+                total = row["cnt"] if row else 0
+
+            async with db.execute(
+                f"SELECT * FROM fabric_links {where}"
+                " ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                [*params, limit, offset],
+            ) as cur:
+                links = [self._row_to_link(row) async for row in cur]
+
+        return links, total
+
     async def unlink(self, link_id: str) -> None:
         await self._ensure_schema()
         async with self._conn() as db:
@@ -384,4 +432,13 @@ class FabricStore:
             properties=json.loads(row["properties"]) if row["properties"] else {},
             source_connector=row["source_connector"],
             source_id=row["source_id"],
+        )
+
+    def _row_to_link(self, row: Any) -> FabricLink:
+        return FabricLink(
+            id=row["id"],
+            from_object_id=row["from_object_id"],
+            to_object_id=row["to_object_id"],
+            link_type=row["link_type"],
+            properties=json.loads(row["properties"]) if row["properties"] else {},
         )

--- a/tests/cloud/test_ee_fabric_list_endpoints.py
+++ b/tests/cloud/test_ee_fabric_list_endpoints.py
@@ -1,0 +1,150 @@
+# test_ee_fabric_list_endpoints.py — Integration tests for /fabric/objects
+# and /fabric/links list endpoints.
+# Created: 2026-04-19 (Cluster C / PR3) — Wires the new list endpoints added
+# alongside PocketDataPanel's Objects/Links sub-tab wire-up. Exercises the
+# store + router round-trip so the frontend contract holds without a live
+# SQLite db.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import ee.fabric.router as fabric_router_module
+from ee.fabric.store import FabricStore
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch) -> TestClient:
+    """Build an isolated app with the fabric router pointed at a tmp db."""
+    # Point the module-level store at the tmp db. The router always calls
+    # _store() lazily so setattr is enough.
+    test_db = tmp_path / "fabric-test.db"
+    monkeypatch.setattr(fabric_router_module, "_DB_PATH", test_db)
+
+    app = FastAPI()
+    app.include_router(fabric_router_module.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+@pytest.fixture()
+def seeded_store(tmp_path: Path) -> FabricStore:
+    return FabricStore(tmp_path / "fabric-store.db")
+
+
+@pytest.mark.asyncio
+async def test_store_list_links_filters_by_type(seeded_store: FabricStore) -> None:
+    t = await seeded_store.define_type(name="Customer", properties=[])
+    o1 = await seeded_store.create_object(t.id, {"name": "Alice"})
+    o2 = await seeded_store.create_object(t.id, {"name": "Bob"})
+    o3 = await seeded_store.create_object(t.id, {"name": "Carol"})
+    await seeded_store.link(o1.id, o2.id, "reports_to")
+    await seeded_store.link(o2.id, o3.id, "reports_to")
+    await seeded_store.link(o1.id, o3.id, "mentors")
+
+    reports, total = await seeded_store.list_links(link_type="reports_to")
+    assert total == 2
+    assert all(link.link_type == "reports_to" for link in reports)
+
+    from_o1, from_o1_total = await seeded_store.list_links(from_id=o1.id)
+    assert from_o1_total == 2
+    assert all(link.from_object_id == o1.id for link in from_o1)
+
+
+@pytest.mark.asyncio
+async def test_store_list_links_binds_params_no_injection(
+    seeded_store: FabricStore,
+) -> None:
+    """An attacker-controlled link_type string must not be interpolated.
+
+    SQLite won't execute multi-statement queries via aiosqlite's execute(),
+    so the SQL-injection vector is inherently weaker than the FTS case we
+    handle in PR4. We still prove by construction that the filter is bound:
+    if it were concatenated, the trailing ``'; DROP TABLE`` would either
+    error or return silent garbage. With binding it's a string that simply
+    matches no rows.
+    """
+    t = await seeded_store.define_type(name="T", properties=[])
+    o1 = await seeded_store.create_object(t.id, {})
+    o2 = await seeded_store.create_object(t.id, {})
+    await seeded_store.link(o1.id, o2.id, "safe_type")
+
+    evil = "safe_type'; DROP TABLE fabric_links; --"
+    links, total = await seeded_store.list_links(link_type=evil)
+    assert total == 0
+    assert links == []
+
+    # The table still exists.
+    all_links, _ = await seeded_store.list_links()
+    assert len(all_links) == 1
+
+
+def test_route_list_objects_returns_envelope(client: TestClient) -> None:
+    # Seed via the POST endpoints so the full round-trip is exercised.
+    type_resp = client.post(
+        "/api/v1/fabric/types",
+        json={"name": "Task", "properties": []},
+    )
+    assert type_resp.status_code == 201, type_resp.text
+    type_id = type_resp.json()["id"]
+
+    client.post(
+        "/api/v1/fabric/objects",
+        json={"type_id": type_id, "properties": {"title": "Write tests"}},
+    )
+    client.post(
+        "/api/v1/fabric/objects",
+        json={"type_id": type_id, "properties": {"title": "Review PR"}},
+    )
+
+    resp = client.get("/api/v1/fabric/objects")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"objects", "total"}
+    assert body["total"] == 2
+    assert len(body["objects"]) == 2
+
+
+def test_route_list_objects_filter_by_type(client: TestClient) -> None:
+    t1 = client.post("/api/v1/fabric/types", json={"name": "A", "properties": []}).json()
+    t2 = client.post("/api/v1/fabric/types", json={"name": "B", "properties": []}).json()
+    client.post("/api/v1/fabric/objects", json={"type_id": t1["id"], "properties": {}})
+    client.post("/api/v1/fabric/objects", json={"type_id": t2["id"], "properties": {}})
+    client.post("/api/v1/fabric/objects", json={"type_id": t2["id"], "properties": {}})
+
+    resp = client.get(f"/api/v1/fabric/objects?type_id={t2['id']}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 2
+    assert all(o["type_id"] == t2["id"] for o in body["objects"])
+
+
+def test_route_list_links_returns_envelope(client: TestClient) -> None:
+    t = client.post("/api/v1/fabric/types", json={"name": "X", "properties": []}).json()
+    o1 = client.post(
+        "/api/v1/fabric/objects", json={"type_id": t["id"], "properties": {}}
+    ).json()
+    o2 = client.post(
+        "/api/v1/fabric/objects", json={"type_id": t["id"], "properties": {}}
+    ).json()
+    client.post(
+        "/api/v1/fabric/links",
+        json={"from_id": o1["id"], "to_id": o2["id"], "link_type": "related"},
+    )
+
+    resp = client.get("/api/v1/fabric/links")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"links", "total"}
+    assert body["total"] == 1
+    assert body["links"][0]["link_type"] == "related"
+
+
+def test_route_list_links_rejects_bad_limit(client: TestClient) -> None:
+    resp = client.get("/api/v1/fabric/links?limit=0")
+    assert resp.status_code == 422
+    resp = client.get("/api/v1/fabric/links?limit=100000")
+    assert resp.status_code == 422


### PR DESCRIPTION
## What this does

Adds `GET /api/v1/fabric/objects` and `GET /api/v1/fabric/links` — the two list endpoints the paw-enterprise PocketDataPanel needs to replace its Brew & Co. placeholder. Closes gap **C3** in `docs/plans/FEATURE-HARDENING-PLAN.md` (Cluster C) and the "no list endpoint" row in `docs/plans/cluster-C-reality.md`.

## Files

- `ee/fabric/store.py` — new `list_links()` with bound-parameter filters on endpoint IDs + link_type. Returns `(links, total)`.
- `ee/fabric/router.py` — `GET /fabric/objects` piggybacks on the existing `FabricQuery` path for type filtering, so the only new logic is response shape (`{objects, total}`). `GET /fabric/links` wraps `store.list_links`.
- `tests/cloud/test_ee_fabric_list_endpoints.py` — 6 specs: store-level filter contract, SQL-injection-attempt binding proof, route-level envelope, type-filter round-trip, link round-trip, 422 on bad limit.

## Why new endpoints instead of extending `POST /fabric/objects`

The existing `POST /fabric/objects` is the "create" path. Overloading it for list reads was possible but muddier than adding a sibling GET. Keeping create and list on different verbs matches REST conventions and fits how FastAPI routes the two handlers cleanly.

## Security

- Both list endpoints use pydantic `Query` validation (`ge=1, le=500`) so a caller can't DoS via `limit=9999999`.
- `link_type` flows through aiosqlite's bound parameters — a `link_type='safe'; DROP TABLE fabric_links; --'` input is proven inert by the regression test.

```
uv run pytest tests/cloud/test_ee_fabric_list_endpoints.py
...... 6 passed in 0.74s
```

## Stacks on

- Pairs with qbtrix/paw-enterprise PR for the UI wire-up.
- Rides the Wave 2 fixtures shape (#987) for consistency with Cluster B tests.