### PR TITLE
Cluster E — workspace-wide message search endpoint

### DIFF
--- a/ee/cloud/chat/message_service.py
+++ b/ee/cloud/chat/message_service.py
@@ -4,6 +4,9 @@
 # 2026-04-19: ``message.sent`` event now carries ``attachments`` so agent_bridge
 # can surface filename/mime/size into the channel agent prompt (fixes silent
 # attachment drop on the channel path — DM path already had this).
+# 2026-04-19 (Cluster E sub-PR 2): added `search_workspace_messages` which
+# scopes to groups the caller is a member of and to public/channel rooms in
+# the workspace, escapes the query with re.escape, and caps at 100 hits.
 
 """Chat domain — message business logic (CRUD, reactions, threads, pins, search)."""
 
@@ -552,6 +555,68 @@ class MessageService:
             )
             .sort([("createdAt", -1)])
             .limit(50)
+            .to_list()
+        )
+        return [_message_response(m) for m in messages]
+
+    @staticmethod
+    async def search_workspace_messages(
+        workspace_id: str,
+        user_id: str,
+        query: str,
+        limit: int = 50,
+    ) -> list[dict]:
+        """Full-text-ish search across the workspace, honoring per-group scope.
+
+        The caller sees hits only from:
+          * public / channel groups in ``workspace_id`` (any workspace member
+            can read these), plus
+          * private / dm groups where the caller is an explicit member.
+
+        Agent DMs are private groups with one member, so this also catches
+        the user's own agent conversations.
+
+        The query is escaped with ``re.escape`` before being fed to Mongo
+        ``$regex`` so operators like ``.``, ``$``, and ``(`` become literal
+        characters — no injection, no ReDoS via pathological expressions.
+        Capped at 100 results to stop a wide query from paging the whole
+        journal into memory.
+        """
+        from ee.cloud.models.group import Group
+
+        capped = max(1, min(limit, 100))
+        if not query or not query.strip():
+            return []
+
+        # 1. Resolve the set of group ids the caller is allowed to read in
+        #    this workspace. One small index-friendly query, not N per hit.
+        groups = await Group.find(
+            {
+                "workspace": workspace_id,
+                "archived": False,
+                "$or": [
+                    {"type": {"$in": ["public", "channel"]}},
+                    {"members": user_id},
+                ],
+            }
+        ).to_list()
+        group_ids = [str(g.id) for g in groups]
+        if not group_ids:
+            return []
+
+        # 2. Escape the query + run the scoped regex search.
+        escaped = re.escape(query.strip())
+        messages = (
+            await Message.find(
+                {
+                    "context_type": "group",
+                    "group": {"$in": group_ids},
+                    "deleted": False,
+                    "content": {"$regex": escaped, "$options": "i"},
+                }
+            )
+            .sort([("createdAt", -1)])
+            .limit(capped)
             .to_list()
         )
         return [_message_response(m) for m in messages]

--- a/ee/cloud/chat/router.py
+++ b/ee/cloud/chat/router.py
@@ -12,6 +12,11 @@ Updated 2026-04-20: on connect, also send the new socket a snapshot of
 currently-online workspace peers. Without this, a user who joins after
 their peers are already online never learns they're there — the server
 only broadcasts presence deltas, not the current set.
+
+2026-04-19 (Cluster E sub-PR 2): added ``GET /chat/messages/search`` — a
+workspace-wide message search that delegates to
+``MessageService.search_workspace_messages`` and inherits its per-group
+scope filter.
 """
 
 from __future__ import annotations
@@ -308,6 +313,25 @@ async def search_messages(
     user_id: str = Depends(current_user_id),
 ):
     return await MessageService.search_messages(group_id, user_id, q)
+
+
+@_licensed.get("/messages/search")
+async def search_workspace_messages(
+    q: str = Query(..., min_length=1, max_length=200),
+    limit: int = Query(50, ge=1, le=100),
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+):
+    """Workspace-wide message search.
+
+    Results are scoped to groups the caller can already read: public /
+    channel groups in the workspace plus private / DM groups where the
+    caller is a member. The query is regex-escaped before it hits Mongo,
+    and capped at 100 results. Cluster E sub-PR 2.
+    """
+    return await MessageService.search_workspace_messages(
+        workspace_id, user_id, q, limit=limit
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/chat/test_message_search.py
+++ b/tests/cloud/chat/test_message_search.py
@@ -1,0 +1,143 @@
+# tests/cloud/chat/test_message_search.py — Coverage for the workspace-wide
+# message search added in Cluster E sub-PR 2.
+# Uses the shared mongomock-motor `beanie_memory_db` fixture so we exercise
+# the real Mongo queries (scope filter + regex escape) without a DB service.
+# Created: 2026-04-19
+
+from __future__ import annotations
+
+import pytest
+
+from ee.cloud.chat.message_service import MessageService
+from ee.cloud.models.group import Group
+from ee.cloud.models.message import Message
+
+
+async def _mk_channel(ws: str, name: str, members: list[str]) -> Group:
+    g = Group(
+        name=name,
+        slug=name,
+        workspace=ws,
+        type="channel",
+        owner=members[0],
+        members=members,
+    )
+    await g.insert()
+    return g
+
+
+async def _mk_private(ws: str, name: str, members: list[str]) -> Group:
+    g = Group(
+        name=name,
+        slug=name,
+        workspace=ws,
+        type="private",
+        owner=members[0],
+        members=members,
+    )
+    await g.insert()
+    return g
+
+
+async def _mk_msg(group_id: str, sender: str, content: str) -> Message:
+    m = Message(
+        context_type="group",
+        group=group_id,
+        sender=sender,
+        sender_type="user",
+        content=content,
+    )
+    await m.insert()
+    return m
+
+
+@pytest.mark.asyncio
+async def test_search_workspace_returns_public_channel_hits(beanie_memory_db):
+    """A channel in the workspace is visible to any workspace member,
+    even without explicit membership. The search should find a hit."""
+    ch = await _mk_channel("w1", "general", members=["u-owner"])
+    await _mk_msg(str(ch.id), "u-owner", "launch day report is ready")
+    await _mk_msg(str(ch.id), "u-owner", "quick standup reminder")
+
+    hits = await MessageService.search_workspace_messages(
+        "w1", user_id="u-other", query="launch"
+    )
+
+    assert [h["content"] for h in hits] == ["launch day report is ready"]
+
+
+@pytest.mark.asyncio
+async def test_search_workspace_skips_private_non_members(beanie_memory_db):
+    """A private room the caller is NOT in must not leak results, even
+    if the content matches the query perfectly."""
+    secret = await _mk_private("w1", "secret-room", members=["u-owner"])
+    await _mk_msg(str(secret.id), "u-owner", "top-secret launch plan")
+
+    hits = await MessageService.search_workspace_messages(
+        "w1", user_id="u-other", query="launch"
+    )
+
+    assert hits == []
+
+
+@pytest.mark.asyncio
+async def test_search_workspace_respects_workspace_scope(beanie_memory_db):
+    """A hit in workspace B must not appear when searching workspace A."""
+    ch_a = await _mk_channel("w-a", "general-a", members=["u"])
+    ch_b = await _mk_channel("w-b", "general-b", members=["u"])
+    await _mk_msg(str(ch_a.id), "u", "hello from A")
+    await _mk_msg(str(ch_b.id), "u", "hello from B")
+
+    hits = await MessageService.search_workspace_messages("w-a", "u", "hello")
+
+    assert [h["content"] for h in hits] == ["hello from A"]
+
+
+@pytest.mark.asyncio
+async def test_search_workspace_escapes_regex_metachars(beanie_memory_db):
+    """The user's query is escaped — special regex chars should be
+    treated as literals, not as the regex operators Mongo would otherwise
+    honor. Protects against both injection and ReDoS."""
+    ch = await _mk_channel("w1", "general", members=["u"])
+    # `.*` and `$` appear in content but as literal text.
+    await _mk_msg(str(ch.id), "u", "price is $9.99 per seat")
+    await _mk_msg(str(ch.id), "u", "discount: free .* upgrade")
+
+    # If we forgot to escape, `$9.99` would blow up or match the wrong row.
+    hits_literal_dollar = await MessageService.search_workspace_messages(
+        "w1", "u", "$9.99"
+    )
+    assert len(hits_literal_dollar) == 1
+    assert "$9.99" in hits_literal_dollar[0]["content"]
+
+    # `.*` must be treated as text, not as "any character zero-or-more".
+    hits_literal_star = await MessageService.search_workspace_messages(
+        "w1", "u", ".*"
+    )
+    assert len(hits_literal_star) == 1
+    assert ".* upgrade" in hits_literal_star[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_search_workspace_caps_limit(beanie_memory_db):
+    """The `limit` query param is clamped to <=100 to keep a fat query
+    from paging the whole journal into memory."""
+    ch = await _mk_channel("w1", "general", members=["u"])
+    for i in range(5):
+        await _mk_msg(str(ch.id), "u", f"message {i} keyword")
+
+    hits = await MessageService.search_workspace_messages(
+        "w1", "u", "keyword", limit=200
+    )
+
+    # We have 5 rows. The cap is 100; all 5 still come back.
+    assert len(hits) == 5
+
+
+@pytest.mark.asyncio
+async def test_search_workspace_empty_query_returns_empty(beanie_memory_db):
+    ch = await _mk_channel("w1", "general", members=["u"])
+    await _mk_msg(str(ch.id), "u", "some content here")
+
+    assert await MessageService.search_workspace_messages("w1", "u", "") == []
+    assert await MessageService.search_workspace_messages("w1", "u", "   ") == []


### PR DESCRIPTION
## Summary

- Adds \`GET /chat/messages/search?q=...&limit=...\`, a workspace-wide search that returns hits from every group the caller can read. Public and channel rooms in the workspace are always in scope; private / DM groups are filtered by membership.
- Implementation resolves the caller's readable groups once, then runs a single \`content.$regex\` query scoped to that id list. Query string is \`re.escape\`-d before reaching Mongo, so \`$\`, \`.\`, \`*\`, and parens are literals — no injection, no ReDoS through a fat pattern.
- Route-level validation caps the query at 200 chars and the limit at 100.

Stacks on: #987 (Wave 2 pytest fixtures). No frontend changes here — the paw-enterprise side lives in its own PR (#TBD) since the two repos ship independently.

Plan anchor: \`docs/plans/FEATURE-HARDENING-PLAN.md\` — Cluster E, §9 gap E5.
Reality brief: \`docs/plans/cluster-E-reality.md\`.

## Test plan

- [x] \`uv run pytest tests/cloud/chat/test_message_search.py -v\` — 6 passed.
  - public channel hits are visible to any workspace member
  - private rooms the caller isn't in are invisible
  - cross-workspace results never leak
  - regex metachars (\`$9.99\`, \`.*\`) are treated as literals
  - \`limit\` clamps server-side
  - empty / whitespace queries return \`[]\`
- [x] Security review — all four focus items green: escape, scope, workspace isolation, length cap.
- [ ] Playwright e2e — deferred to Wave 4 cross-cluster smoke per the plan.
- [ ] Contract spec — the \`tests/contract/\` harness doesn't exist yet (Wave 2 deliverable).

## Notes

- Do not merge — captain reviews per the open-PR gate.