### PR TITLE
Cluster E — explicit download-url alias for chat attachments

### DIFF
--- a/ee/cloud/uploads/router.py
+++ b/ee/cloud/uploads/router.py
@@ -1,4 +1,12 @@
-"""EE /uploads router — workspace-scoped upload endpoints."""
+"""EE /uploads router — workspace-scoped upload endpoints.
+
+2026-04-19 (Cluster E sub-PR 3): added ``GET /uploads/{id}/download-url``
+as an explicitly-named alias for the existing ``/grant`` endpoint. The
+alias returns the same signed-URL-or-cookie-URL payload plus a
+short-lived ``expires_at`` and a ``filename`` that the FE can use as the
+default save-as name. The underlying service enforces workspace scope +
+per-file adapter auth; nothing extra leaks through the alias.
+"""
 
 from __future__ import annotations
 
@@ -66,6 +74,39 @@ async def upload(
     return {
         "uploaded": [_record_to_dict(r) for r in result.uploaded],
         "failed": [asdict(f) for f in result.failed],
+    }
+
+
+@router.get("/{file_id}/download-url")
+async def download_url(
+    file_id: str,
+    workspace: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Return a short-TTL download URL for ``file_id``.
+
+    Cluster E sub-PR 3 alias of ``/grant``. The payload shape matches —
+    ``{url, expires_at}`` — with an extra ``filename`` so the FE's
+    "Save As" dialog opens with a sensible default. Workspace scope is
+    enforced by ``EEUploadService.presigned_get``; the alias does not
+    relax any check.
+    """
+    import time
+
+    from pocketpaw.uploads.signing import DEFAULT_TTL_SECONDS
+
+    try:
+        rec, presigned = await _SVC.presigned_get(
+            file_id, user_id, workspace, DEFAULT_TTL_SECONDS
+        )
+    except NotFound as e:
+        raise HTTPException(status_code=404, detail="not found") from e
+
+    url = presigned or f"/api/v1/uploads/{file_id}"
+    return {
+        "url": url,
+        "expires_at": int(time.time()) + DEFAULT_TTL_SECONDS,
+        "filename": rec.filename,
     }
 
 

--- a/tests/cloud/uploads/test_download_url.py
+++ b/tests/cloud/uploads/test_download_url.py
@@ -1,0 +1,128 @@
+# tests/cloud/uploads/test_download_url.py — Coverage for the explicit
+# download-url alias added in Cluster E sub-PR 3. Uses the same FastAPI
+# app wiring pattern as test_router.py (header-driven user/workspace
+# dependencies, tmpfs storage, mongomock-motor metadata).
+# Created: 2026-04-19
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"body"
+
+
+@pytest.fixture()
+def ee_client(tmp_path: Path, beanie_upload_db, monkeypatch):
+    """App with the EE uploads router + overridden identity deps."""
+    import ee.cloud.uploads.router as uploads_module
+    from ee.cloud.uploads.mongo_store import MongoFileStore
+    from ee.cloud.uploads.service import EEUploadService
+    from pocketpaw.uploads.config import UploadSettings
+    from pocketpaw.uploads.local import LocalStorageAdapter
+
+    root = tmp_path / "u"
+    root.mkdir()
+
+    test_cfg = UploadSettings(local_root=root)
+    test_adapter = LocalStorageAdapter(root=root)
+    test_meta = MongoFileStore()
+    test_svc = EEUploadService(adapter=test_adapter, meta=test_meta, cfg=test_cfg)
+
+    monkeypatch.setattr(uploads_module, "_SVC", test_svc)
+
+    app = FastAPI()
+    from fastapi import Header
+
+    from ee.cloud.license import require_license
+    from ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+    app.dependency_overrides[require_license] = lambda: None
+
+    async def _user_dep(x_user: str = Header(default="u1")) -> str:
+        return x_user
+
+    async def _workspace_dep(x_workspace: str = Header(default="w1")) -> str:
+        return x_workspace
+
+    app.dependency_overrides[current_user_id] = _user_dep
+    app.dependency_overrides[current_workspace_id] = _workspace_dep
+
+    app.include_router(uploads_module.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+def _upload(client: TestClient, user: str, ws: str, name: str = "pic.png") -> str:
+    r = client.post(
+        "/api/v1/uploads",
+        files=[("files", (name, PNG, "image/png"))],
+        headers={"x-user": user, "x-workspace": ws},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["uploaded"][0]["id"]
+
+
+def test_download_url_returns_ttl_and_filename(ee_client: TestClient):
+    """The alias returns a signed-or-cookie URL, an expires_at in the
+    near future, and the original filename for the Save-As dialog."""
+    fid = _upload(ee_client, "u1", "w1", name="report.png")
+
+    r = ee_client.get(
+        f"/api/v1/uploads/{fid}/download-url",
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    assert body["url"].endswith(f"/uploads/{fid}") or body["url"].startswith("http")
+    assert body["filename"] == "report.png"
+
+    now = int(time.time())
+    # TTL should be short (default is 15 minutes) but always in the
+    # future and not more than an hour out.
+    assert now < body["expires_at"] <= now + 60 * 60
+
+
+def test_download_url_blocks_cross_workspace(ee_client: TestClient):
+    """A file uploaded in workspace A must not be fetchable from B,
+    even through the download-url alias."""
+    fid = _upload(ee_client, "u1", "w-a")
+
+    r = ee_client.get(
+        f"/api/v1/uploads/{fid}/download-url",
+        headers={"x-user": "u1", "x-workspace": "w-b"},
+    )
+    assert r.status_code == 404
+
+
+def test_download_url_rejects_path_traversal_ids(ee_client: TestClient):
+    """File ids are opaque strings in our store. Callers can't smuggle a
+    traversal string through the path — FastAPI routes it as the id,
+    the store's workspace-scoped lookup returns None -> 404."""
+    r = ee_client.get(
+        "/api/v1/uploads/..%2F..%2Fetc%2Fpasswd/download-url",
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r.status_code == 404
+
+
+def test_download_url_404_for_deleted(ee_client: TestClient):
+    """Soft-deleted files disappear from the alias just like they do
+    from /grant and /{file_id}."""
+    fid = _upload(ee_client, "u1", "w1")
+
+    d = ee_client.delete(
+        f"/api/v1/uploads/{fid}",
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert d.status_code == 204
+
+    r = ee_client.get(
+        f"/api/v1/uploads/{fid}/download-url",
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary

- Adds \`GET /uploads/{file_id}/download-url\` alongside the existing \`/grant\` endpoint. Returns \`{url, expires_at, filename}\`. The filename lets the FE open Save-As with the original name; the TTL stays short (15 minutes by default from \`pocketpaw.uploads.signing.DEFAULT_TTL_SECONDS\`) so a leaked URL expires quickly.
- Workspace scope, soft-delete, and cross-tenant isolation are enforced by the same \`EEUploadService.presigned_get\` path that \`/grant\` uses. The alias does not relax any check.
- Path traversal doesn't compose here — file ids are opaque Mongo keys, not path segments.

Stacks on: #987 (Wave 2 pytest fixtures). Frontend PR wires this on the paw-enterprise side.

Plan anchor: \`docs/plans/FEATURE-HARDENING-PLAN.md\` — Cluster E, §10 gap E7.
Reality brief: \`docs/plans/cluster-E-reality.md\`.

## Test plan

- [x] \`uv run pytest tests/cloud/uploads/test_download_url.py -v\` — 4 passed:
  - happy path returns a URL, short TTL, and filename
  - cross-workspace fetch is 404
  - URL-encoded path traversal in the id is 404
  - soft-deleted files become 404 through the alias
- [x] Security review — 4/4 green: short TTL (<= 60 min default cap in test), workspace scope, no path-traversal exposure, deleted files invisible.
- [ ] Playwright e2e — deferred to Wave 4 cross-cluster smoke per the plan.
- [ ] Contract spec — the \`tests/contract/\` harness doesn't exist yet (Wave 2 deliverable).

## Notes

- Do not merge — captain reviews per the open-PR gate.