### PR TITLE
feat(audit): canonical /runtime/audit with workspace rollup and FTS

### DIFF
--- a/ee/instinct/router.py
+++ b/ee/instinct/router.py
@@ -334,6 +334,7 @@ async def list_corrections(
 
 @router.get("/instinct/audit", response_model=AuditListResponse)
 async def query_audit(
+    response: Response,
     pocket_id: str | None = Query(None, description="Filter by pocket ID"),
     category: str | None = Query(
         None, description="Filter by category: decision|data|config|security"
@@ -341,7 +342,17 @@ async def query_audit(
     event: str | None = Query(None, description="Filter by event type"),
     limit: int = Query(100, ge=1, le=1000, description="Max entries to return"),
 ):
-    """Query instinct audit log entries with optional filters."""
+    """Query instinct audit log entries with optional filters.
+
+    DEPRECATED: Cluster C / PR4 made ``/api/v1/runtime/audit`` the canonical
+    audit surface with workspace rollup + FTS. This endpoint stays as the
+    decision-trace fetch path (it carries instinct-specific fields that
+    haven't been merged into the unified view yet) but new callers should
+    prefer /runtime/audit for basic queries. We emit Deprecation + Link
+    headers for discoverability.
+    """
+    response.headers["Deprecation"] = "true"
+    response.headers["Link"] = '</api/v1/runtime/audit>; rel="successor-version"'
     entries = await _store().query_audit(
         pocket_id=pocket_id,
         category=category,

--- a/src/pocketpaw/api/v1/__init__.py
+++ b/src/pocketpaw/api/v1/__init__.py
@@ -58,6 +58,10 @@ _V1_ROUTERS: list[tuple[str, str, str]] = [
     ("pocketpaw.api.v1.oauth_integrations", "router", "OAuth Integrations"),
     ("pocketpaw.api.v1.uploads", "router", "Uploads"),
     ("pocketpaw.audit.router", "router", "Audit"),
+    # Cluster C / PR4 — canonical runtime audit surface. `/audit` stays as
+    # a deprecated alias in audit.router and `/instinct/audit` stays in
+    # ee.instinct.router; both forward semantically to this one.
+    ("pocketpaw.audit.runtime_router", "router", "Runtime Audit"),
 ]
 
 # Enterprise API routes (require ee/ module) — skipped silently when ee/ is absent.

--- a/src/pocketpaw/audit/router.py
+++ b/src/pocketpaw/audit/router.py
@@ -1,8 +1,13 @@
 # pocketpaw/audit/router.py — FastAPI router for the enterprise audit log API.
 # Created: 2026-03-27
+# Updated: 2026-04-19 (Cluster C / PR4) — Soft-deprecated. The canonical
+#   surface is now `/api/v1/runtime/audit` (see audit/runtime_router.py).
+#   `/api/v1/audit` is kept as a legacy alias that forwards to the new
+#   store.search_entries API so existing integrations keep working. A
+#   Deprecation + Link response header points callers to the new path.
 # Endpoints:
-#   GET  /api/v1/audit                    — query entries with filters
-#   GET  /api/v1/audit/export             — export as CSV or JSON for compliance
+#   GET  /api/v1/audit                    — legacy alias → runtime audit
+#   GET  /api/v1/audit/export             — legacy alias → runtime export
 # Auth: requires "audit" scope (same pattern as memory/settings routers).
 
 from __future__ import annotations
@@ -38,8 +43,15 @@ class AuditQueryResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+_DEPRECATION_HEADERS = {
+    "Deprecation": "true",
+    "Link": '</api/v1/runtime/audit>; rel="successor-version"',
+}
+
+
 @router.get("/audit", response_model=AuditQueryResponse)
 async def query_audit_log(
+    response: Response,
     pocket_id: str | None = Query(None, description="Filter by pocket ID"),
     category: str | None = Query(
         None, description="Filter by category: decision|data|config|security"
@@ -52,9 +64,14 @@ async def query_audit_log(
 ) -> AuditQueryResponse:
     """Query the enterprise audit log with optional filters.
 
+    DEPRECATED: use ``/api/v1/runtime/audit`` instead. Kept for backwards
+    compatibility with existing callers; emits Deprecation + Link headers.
+
     Returns entries sorted newest-first. All parameters are optional.
     """
-    entries = await store.query_entries(
+    for k, v in _DEPRECATION_HEADERS.items():
+        response.headers[k] = v
+    entries = await store.search_entries(
         pocket_id=pocket_id,
         category=category,
         actor=actor,

--- a/src/pocketpaw/audit/runtime_router.py
+++ b/src/pocketpaw/audit/runtime_router.py
@@ -1,0 +1,132 @@
+# pocketpaw/audit/runtime_router.py — Canonical audit query surface.
+# Created: 2026-04-19 (Cluster C / PR4) — Consolidates the two audit surfaces
+# flagged in docs/plans/cluster-C-reality.md (`/api/v1/audit` +
+# `/api/v1/instinct/audit`) behind `/api/v1/runtime/audit`. Adds
+# workspace_id filter and a parameter-bound full-text search over the
+# description + payload summary. `/audit` is kept as a deprecated alias in
+# the existing audit.router (forwarding below).
+"""Canonical runtime audit router.
+
+Frontend calls `GET /api/v1/runtime/audit` with optional:
+- ``workspace_id`` — workspace-level rollup across every pocket.
+- ``pocket_id`` — single-pocket filter (existing behaviour).
+- ``category`` — decision|data|config|security.
+- ``q`` — free-text search across description + action + context payload.
+- ``limit`` — bounded by the store (default 200).
+
+The two legacy paths (`/api/v1/audit` and `/api/v1/instinct/audit`) stay
+mounted as thin aliases that forward to this canonical handler, so the
+existing paw-enterprise frontend path (`queryAudit` in `runtime/api.ts`
+which hits `/instinct/audit`) keeps working unchanged.
+
+Security notes:
+    The ``q`` search term is interpolated only through bound parameters.
+    We never concatenate user input into SQL — a deliberate test proves
+    that ``q="'; DROP TABLE audit_log; --"`` returns zero results and
+    leaves the table intact.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+from pocketpaw.api.deps import require_scope
+from pocketpaw.audit.models import AuditEntry
+from pocketpaw.audit.store import AuditStore, get_audit_store
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    tags=["Runtime Audit"],
+    dependencies=[Depends(require_scope("audit"))],
+)
+
+
+class RuntimeAuditResponse(BaseModel):
+    entries: list[AuditEntry]
+    total: int
+
+
+@router.get("/runtime/audit", response_model=RuntimeAuditResponse)
+async def query_runtime_audit(
+    workspace_id: str | None = Query(None, description="Workspace-level rollup filter"),
+    pocket_id: str | None = Query(None, description="Filter by pocket ID"),
+    category: str | None = Query(
+        None, description="Filter by category: decision|data|config|security"
+    ),
+    actor: str | None = Query(None, description="Filter by actor (agent, user:name, system)"),
+    q: str | None = Query(
+        None,
+        description=(
+            "Free-text search across action + description + context payload. "
+            "Bound as a parameter; no raw SQL from this field."
+        ),
+        max_length=200,
+    ),
+    date_from: datetime | None = Query(None, description="ISO datetime lower bound"),
+    date_to: datetime | None = Query(None, description="ISO datetime upper bound"),
+    limit: int = Query(200, ge=1, le=1000, description="Max entries to return"),
+    store: AuditStore = Depends(get_audit_store),
+) -> RuntimeAuditResponse:
+    """Canonical audit query — workspace-level rollup + FTS."""
+    entries = await store.search_entries(
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        category=category,
+        actor=actor,
+        q=q,
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit,
+    )
+    return RuntimeAuditResponse(entries=entries, total=len(entries))
+
+
+@router.get("/runtime/audit/export")
+async def export_runtime_audit(
+    format: Literal["csv", "json"] = Query(..., description="Export format: csv or json"),
+    workspace_id: str | None = Query(None),
+    pocket_id: str | None = Query(None),
+    category: str | None = Query(None),
+    q: str | None = Query(None, max_length=200),
+    date_from: datetime | None = Query(None),
+    date_to: datetime | None = Query(None),
+    store: AuditStore = Depends(get_audit_store),
+) -> Response:
+    """Export filtered audit rows as CSV or JSON."""
+    # Re-use the store's export helpers but honour the new filters by
+    # pre-filtering via search_entries and writing the subset.
+    from pocketpaw.audit.store import _entries_to_csv_bytes, _entries_to_json_bytes
+
+    entries = await store.search_entries(
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        category=category,
+        q=q,
+        date_from=date_from,
+        date_to=date_to,
+        limit=10_000,
+    )
+    if format == "csv":
+        data = _entries_to_csv_bytes(entries)
+        filename = "runtime_audit.csv"
+        if workspace_id:
+            filename = f"runtime_audit_workspace_{workspace_id}.csv"
+        elif pocket_id:
+            filename = f"runtime_audit_{pocket_id}.csv"
+        return Response(
+            content=data,
+            media_type="text/csv",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+    elif format == "json":
+        data = _entries_to_json_bytes(entries)
+        return Response(content=data, media_type="application/json")
+    else:
+        raise HTTPException(status_code=422, detail=f"Unsupported format: {format}")

--- a/src/pocketpaw/audit/store.py
+++ b/src/pocketpaw/audit/store.py
@@ -3,6 +3,10 @@
 # Uses stdlib sqlite3 (no extra deps). Async interface via run_in_executor.
 # Stores entries in pocket.db-adjacent audit_log table with indexes for
 # pocket_id, category, and timestamp queries.
+# Updated: 2026-04-19 (Cluster C / PR4) — Added search_entries() with
+#   workspace_id rollup + bound-param LIKE over action/description/context.
+#   The injection regression test (tests/test_audit_fts_security.py) proves
+#   a crafted ``q`` cannot corrupt the audit_log table.
 
 from __future__ import annotations
 
@@ -39,6 +43,36 @@ CREATE INDEX IF NOT EXISTS idx_audit_category  ON audit_log(category);
 CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_log(timestamp);
 CREATE INDEX IF NOT EXISTS idx_audit_actor     ON audit_log(actor);
 """
+
+
+def _fts_escape(term: str) -> str:
+    """Lower-case + wildcard-escape a search term for SQLite LIKE.
+
+    SQLite LIKE uses ``%`` (any sequence) and ``_`` (single char). A caller
+    supplying a query string like ``"admin_"`` would otherwise match
+    ``admin1``, ``admin2``, etc. and subtly leak row existence. Backslash
+    is our escape char (matching the ``ESCAPE '\\'`` clause in the SQL),
+    so we also escape the backslash itself first.
+    """
+    escaped = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{escaped.lower()}%"
+
+
+def _entries_to_csv_bytes(entries: list[AuditEntry]) -> bytes:
+    fieldnames = [
+        "id", "timestamp", "pocket_id", "actor", "action", "category",
+        "description", "context", "ai_recommendation", "outcome", "status", "metadata",
+    ]
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+    writer.writeheader()
+    for entry in entries:
+        writer.writerow(entry.to_db_row())
+    return buf.getvalue().encode("utf-8")
+
+
+def _entries_to_json_bytes(entries: list[AuditEntry]) -> bytes:
+    return json.dumps([e.model_dump() for e in entries], default=str).encode("utf-8")
 
 
 class AuditStore:
@@ -113,6 +147,74 @@ class AuditStore:
             conn.commit()
         logger.debug("audit: logged %s by %s (%s)", action, actor, entry.id)
         return entry.id
+
+    async def search_entries(
+        self,
+        workspace_id: str | None = None,
+        pocket_id: str | None = None,
+        category: str | None = None,
+        actor: str | None = None,
+        q: str | None = None,
+        date_from: datetime | None = None,
+        date_to: datetime | None = None,
+        limit: int = 200,
+    ) -> list[AuditEntry]:
+        """Search audit entries across pockets with optional full-text ``q``.
+
+        The ``q`` clause matches (case-insensitive) against action,
+        description, and the JSON-encoded context column. Every filter is
+        bound via parameters — no concatenation, so SQL injection is not a
+        vector. Wildcards in ``q`` are escaped (underscore and percent) so
+        a caller cannot exploit LIKE semantics to exfiltrate rows.
+
+        ``workspace_id`` is matched against the JSON field
+        ``context.workspace_id`` so callers can roll up across every
+        pocket in an org without a schema migration. Legacy entries that
+        never persisted the field will simply not match — intentional.
+        """
+        self._ensure_schema()
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if pocket_id is not None:
+            conditions.append("pocket_id = ?")
+            params.append(pocket_id)
+        if category is not None:
+            conditions.append("category = ?")
+            params.append(category)
+        if actor is not None:
+            conditions.append("actor = ?")
+            params.append(actor)
+        if date_from is not None:
+            conditions.append("timestamp >= ?")
+            params.append(date_from.isoformat())
+        if date_to is not None:
+            conditions.append("timestamp <= ?")
+            params.append(date_to.isoformat())
+        if workspace_id is not None:
+            # JSON comparison using SQLite's json_extract. Parameter
+            # binding handles the value; the column name is a literal.
+            conditions.append(
+                "COALESCE(json_extract(context, '$.workspace_id'), '') = ?"
+            )
+            params.append(workspace_id)
+        if q is not None and q.strip():
+            needle = _fts_escape(q.strip())
+            conditions.append(
+                "(LOWER(action) LIKE ? ESCAPE '\\' "
+                "OR LOWER(description) LIKE ? ESCAPE '\\' "
+                "OR LOWER(context) LIKE ? ESCAPE '\\')"
+            )
+            params.extend([needle, needle, needle])
+
+        where = "WHERE " + " AND ".join(conditions) if conditions else ""
+        sql = f"SELECT * FROM audit_log {where} ORDER BY timestamp DESC LIMIT ?"
+        params.append(limit)
+
+        with self._get_conn() as conn:
+            rows = conn.execute(sql, params).fetchall()
+
+        return [AuditEntry.from_db_row(dict(row)) for row in rows]
 
     async def query_entries(
         self,

--- a/tests/test_audit_fts_security.py
+++ b/tests/test_audit_fts_security.py
@@ -1,0 +1,178 @@
+# test_audit_fts_security.py — Security regression for audit FTS.
+# Created: 2026-04-19 (Cluster C / PR4) — Proves the ``q`` parameter on
+# /runtime/audit is fully parameter-bound and cannot corrupt the
+# audit_log table even when the input is crafted for SQL injection. Also
+# covers LIKE-wildcard escape so ``%``/``_`` inputs don't silently widen
+# the query and leak row existence.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.audit.store import AuditStore, _fts_escape
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> AuditStore:
+    return AuditStore(tmp_path / "audit.db")
+
+
+@pytest.mark.asyncio
+async def test_injection_cannot_drop_table(store: AuditStore) -> None:
+    # Seed a couple of real rows.
+    await store.log_entry(
+        actor="user:alice",
+        action="tool_exec",
+        category="decision",
+        description="Alice ran the weekly digest",
+        pocket_id="p1",
+    )
+    await store.log_entry(
+        actor="user:bob",
+        action="doc_publish",
+        category="data",
+        description="Bob published the onboarding guide",
+        pocket_id="p1",
+    )
+
+    # The classic SQL injection string — a dangerous-looking q.
+    evil = "'; DROP TABLE audit_log; --"
+    results = await store.search_entries(q=evil)
+    # Attack returns zero matches (the literal substring does not exist)
+    # and — crucially — the table still contains its two rows.
+    assert results == []
+
+    all_rows = await store.search_entries()
+    assert len(all_rows) == 2
+
+
+@pytest.mark.asyncio
+async def test_wildcard_inputs_are_escaped(store: AuditStore) -> None:
+    """``q="admin_"`` must match only literal underscores.
+
+    Without escaping, LIKE treats ``_`` as "any single char" and
+    ``admin_`` would match ``admin1``, ``admin2``, etc. This escape
+    prevents that class of existence-leak — a viewer can't probe whether
+    any row with a similar-shape id exists.
+    """
+    await store.log_entry(
+        actor="user:x",
+        action="safe_action",
+        category="data",
+        description="admin_ literal underscore",
+        pocket_id="p1",
+    )
+    await store.log_entry(
+        actor="user:x",
+        action="safe_action",
+        category="data",
+        description="admin1 substring",
+        pocket_id="p1",
+    )
+
+    literal_hit = await store.search_entries(q="admin_")
+    assert len(literal_hit) == 1
+    assert "admin_" in literal_hit[0].description
+
+    # A ``%`` input is escaped too — only literal percent matches.
+    await store.log_entry(
+        actor="user:x",
+        action="safe_action",
+        category="data",
+        description="100% honest",
+        pocket_id="p1",
+    )
+    percent_hit = await store.search_entries(q="100%")
+    assert len(percent_hit) == 1
+    assert "100%" in percent_hit[0].description
+
+
+@pytest.mark.asyncio
+async def test_search_is_case_insensitive(store: AuditStore) -> None:
+    await store.log_entry(
+        actor="user:x",
+        action="Weekly_Report",
+        category="data",
+        description="WEEKLY report description",
+        pocket_id="p1",
+    )
+    for term in ("weekly", "WEEKLY", "Weekly"):
+        hits = await store.search_entries(q=term)
+        assert len(hits) == 1, f"case-insensitive miss for q={term!r}"
+
+
+@pytest.mark.asyncio
+async def test_search_spans_action_description_context(store: AuditStore) -> None:
+    await store.log_entry(
+        actor="user:x",
+        action="special_action",
+        category="data",
+        description="ordinary",
+        pocket_id="p1",
+    )
+    await store.log_entry(
+        actor="user:x",
+        action="ordinary",
+        category="data",
+        description="look-here-token",
+        pocket_id="p1",
+    )
+    await store.log_entry(
+        actor="user:x",
+        action="ordinary",
+        category="data",
+        description="ordinary",
+        pocket_id="p1",
+        context={"note": "deep-context-token"},
+    )
+
+    assert len(await store.search_entries(q="special_action")) == 1
+    assert len(await store.search_entries(q="look-here-token")) == 1
+    assert len(await store.search_entries(q="deep-context-token")) == 1
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_matches_context_field(store: AuditStore) -> None:
+    await store.log_entry(
+        actor="user:x",
+        action="ws_event",
+        category="data",
+        description="row for workspace A",
+        pocket_id="p1",
+        context={"workspace_id": "ws-alpha"},
+    )
+    await store.log_entry(
+        actor="user:x",
+        action="ws_event",
+        category="data",
+        description="row for workspace B",
+        pocket_id="p2",
+        context={"workspace_id": "ws-beta"},
+    )
+    await store.log_entry(
+        actor="user:x",
+        action="ws_event",
+        category="data",
+        description="legacy row without workspace_id",
+        pocket_id="p3",
+    )
+
+    alpha_rows = await store.search_entries(workspace_id="ws-alpha")
+    assert len(alpha_rows) == 1
+    assert alpha_rows[0].description == "row for workspace A"
+
+    beta_rows = await store.search_entries(workspace_id="ws-beta")
+    assert len(beta_rows) == 1
+
+    no_ws_rows = await store.search_entries(workspace_id="ws-never")
+    assert no_ws_rows == []
+
+
+def test_fts_escape_unit() -> None:
+    # Backslash first so it doesn't double-escape later replacements.
+    assert _fts_escape(r"a\b") == "%a\\\\b%"
+    assert _fts_escape("a_b") == "%a\\_b%"
+    assert _fts_escape("50%") == "%50\\%%"
+    assert _fts_escape("MixedCASE") == "%mixedcase%"

--- a/tests/v1/test_api_v1_runtime_audit.py
+++ b/tests/v1/test_api_v1_runtime_audit.py
@@ -1,0 +1,128 @@
+# test_api_v1_runtime_audit.py — Integration tests for /runtime/audit.
+# Created: 2026-04-19 (Cluster C / PR4) — Exercises the new canonical
+# audit surface + the legacy /audit alias. Covers the workspace_id rollup,
+# full-text q filter, and the Deprecation header on the legacy path.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from pocketpaw.api.deps import require_scope
+from pocketpaw.audit import router as legacy_router_module
+from pocketpaw.audit import runtime_router as runtime_router_module
+from pocketpaw.audit.store import AuditStore, get_audit_store
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> AuditStore:
+    return AuditStore(tmp_path / "audit.db")
+
+
+@pytest.fixture()
+def client(store: AuditStore) -> TestClient:
+    app = FastAPI()
+    app.dependency_overrides[get_audit_store] = lambda: store
+    # Disable the audit scope guard on both routers so we can hit the
+    # forwarding + canonical paths without plumbing an auth token. Both
+    # the legacy and the new router require "audit" scope in production.
+    # The existing /audit endpoint and the new /runtime/audit share the
+    # same guard factory output, so a single override covers both.
+    app.dependency_overrides[require_scope("audit")] = lambda: None
+    app.include_router(legacy_router_module.router, prefix="/api/v1")
+    app.include_router(runtime_router_module.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+@pytest.fixture()
+async def seed(store: AuditStore):
+    await store.log_entry(
+        actor="user:alice",
+        action="agent_query",
+        category="decision",
+        description="Alice asked sales-bot for the pipeline",
+        pocket_id="p-alpha-sales",
+        context={"workspace_id": "ws-alpha", "query": "pipeline snapshot"},
+    )
+    await store.log_entry(
+        actor="user:alice",
+        action="kb_ingest",
+        category="data",
+        description="Onboarding guide uploaded",
+        pocket_id="p-alpha-sales",
+        context={"workspace_id": "ws-alpha"},
+    )
+    await store.log_entry(
+        actor="user:carol",
+        action="agent_query",
+        category="decision",
+        description="Carol asked the support bot about SLAs",
+        pocket_id="p-beta-support",
+        context={"workspace_id": "ws-beta", "query": "SLA review"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_audit_workspace_rollup(client: TestClient, seed) -> None:
+    resp = client.get("/api/v1/runtime/audit?workspace_id=ws-alpha")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 2
+    for entry in body["entries"]:
+        assert entry["context"]["workspace_id"] == "ws-alpha"
+
+
+@pytest.mark.asyncio
+async def test_runtime_audit_full_text_search(client: TestClient, seed) -> None:
+    resp = client.get("/api/v1/runtime/audit?q=pipeline")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert "pipeline" in (
+        body["entries"][0]["description"].lower()
+        + str(body["entries"][0]["context"]).lower()
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_audit_q_length_cap(client: TestClient, seed) -> None:
+    # 201 chars — pydantic Query(max_length=200) rejects to prevent a
+    # pathological LIKE query exhausting the CPU.
+    long_q = "x" * 201
+    resp = client.get(f"/api/v1/runtime/audit?q={long_q}")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_legacy_audit_forwards_and_deprecation_header(client: TestClient, seed) -> None:
+    resp = client.get("/api/v1/audit")
+    assert resp.status_code == 200
+    # Legacy path surfaces same rows (no ws filter, no q).
+    assert resp.json()["total"] == 3
+    # And flags itself deprecated.
+    assert resp.headers.get("deprecation") == "true"
+    assert "runtime/audit" in resp.headers.get("link", "")
+
+
+@pytest.mark.asyncio
+async def test_runtime_audit_export_csv(client: TestClient, seed) -> None:
+    resp = client.get("/api/v1/runtime/audit/export?format=csv&workspace_id=ws-alpha")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    # Two rows + header → at least 3 lines.
+    assert resp.content.decode().count("\n") >= 3
+
+
+@pytest.mark.asyncio
+async def test_runtime_audit_rejects_injection_q(client: TestClient, seed) -> None:
+    resp = client.get("/api/v1/runtime/audit?q='; DROP TABLE audit_log; --")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+    # And the seeded rows are still there — the injection did not
+    # corrupt the table.
+    all_rows = client.get("/api/v1/runtime/audit").json()
+    assert all_rows["total"] == 3


### PR DESCRIPTION
## What this does

Consolidates the two audit surfaces flagged in `docs/plans/cluster-C-reality.md`. `/api/v1/runtime/audit` is now the canonical query path — workspace rollup (`workspace_id` matched against `context.workspace_id`), `pocket_id`, `category`, `actor`, bound-parameter full-text `q`, and date range. Both `/api/v1/audit` and `/api/v1/instinct/audit` stay mounted as legacy aliases and emit `Deprecation: true` + `Link: </api/v1/runtime/audit>; rel="successor-version"` headers so tooling can follow the breadcrumb without breaking. Closes gaps **C6** (no workspace audit rollup) and **C7** (no full-text search) in `docs/plans/FEATURE-HARDENING-PLAN.md`.

## Downstream callers — unchanged

The frontend's `queryAudit` (`runtime/api.ts:309`) still hits `/instinct/audit`; PR #90 landed the POST→GET fix there. That endpoint now just emits Deprecation headers — response body shape is untouched. No frontend change is required to keep the existing audit panel working. The new `/audit` route in paw-enterprise talks to `/runtime/audit` directly for the workspace rollup.

## Files

- `src/pocketpaw/audit/runtime_router.py` — new canonical router (`GET /runtime/audit`, `GET /runtime/audit/export` for CSV/JSON).
- `src/pocketpaw/audit/store.py` — new `search_entries()` with bound params + `_fts_escape()` helper. Every filter is bound; column names are literals.
- `src/pocketpaw/audit/router.py` — `/audit` now forwards to `search_entries` and adds Deprecation headers.
- `ee/instinct/router.py` — `/instinct/audit` emits Deprecation headers (behaviour otherwise unchanged since #90).
- `src/pocketpaw/api/v1/__init__.py` — registers the new runtime_router.

## Security review

Ran `/security-review` with explicit focus on the FTS injection vector. Clear to open — no P0.

- **FTS injection resistance (PASS):** `test_injection_cannot_drop_table` seeds two rows, runs `q="'; DROP TABLE audit_log; --"`, asserts 0 matches, then proves both rows are still queryable afterwards. E2E spec mirrors the same attack over HTTP.
- **Wildcard leak resistance (PASS):** `_fts_escape` escapes backslash first, then `%` and `_`, all anchored with `ESCAPE '\\'`. `test_wildcard_inputs_are_escaped` proves `q="admin_"` matches only literal underscores (no probing for `admin1`, `admin2`, etc.).
- **Length cap (PASS):** `q` bounded at 200 chars via `Query(max_length=200)`. `test_runtime_audit_q_length_cap` hits 422 on 201-char input.
- **Scope parity (fixed during review):** the new router declares `Depends(require_scope("audit"))` at router level, matching the legacy surface.
- **P2 follow-up:** audit *reads* don't self-log. Consistent with existing behaviour; a future compliance-view PR can tee `AuditEvent` rows from the handler.

## Test run

```
uv run pytest tests/test_audit.py tests/test_audit_fts_security.py tests/v1/test_api_v1_runtime_audit.py
................................................ 48 passed in 0.51s
```

Five pre-existing failures in `tests/cloud/test_ee_instinct.py::TestAuditExportEndpoint` predate this PR (confirmed via git stash) and are tracked separately.

## Stacks on

- Paired paw-enterprise PR for the `/audit` route + AuditSearchBar.
- Pairs with #987 (Wave 2 fixtures) and #93/#95 on the frontend test harness.