### PR TITLE
Cluster E — unified workspace files endpoint

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -72,6 +72,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(pockets_router, prefix="/api/v1")
     app.include_router(sessions_router, prefix="/api/v1")
 
+    from ee.cloud.files.router import router as files_router
     from ee.cloud.kb.knowledge_router import router as knowledge_router
     from ee.cloud.kb.router import router as kb_router
     from ee.cloud.notifications.router import router as notifications_router
@@ -82,6 +83,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(knowledge_router, prefix="/api/v1")
     app.include_router(uploads_router, prefix="/api/v1")
     app.include_router(notifications_router, prefix="/api/v1")
+    app.include_router(files_router, prefix="/api/v1")
     # paw_print lives outside ee/cloud/ but is mounted alongside the cloud
     # routers so the admin UI (paw-enterprise /pockets/<id> Paw Print tab) can
     # reach /api/v1/paw-print/* without a second app setup entry point.

--- a/ee/cloud/files/__init__.py
+++ b/ee/cloud/files/__init__.py
@@ -1,0 +1,3 @@
+# ee/cloud/files/__init__.py — Unified workspace files API.
+# Created: 2026-04-19 — Cluster E sub-PR 4 (UI-TESTING-GUIDE §14 gap E8/E9).
+from ee.cloud.files.router import router  # noqa: F401

--- a/ee/cloud/files/router.py
+++ b/ee/cloud/files/router.py
@@ -1,0 +1,77 @@
+"""EE /files router — unified workspace files listing.
+
+Returns a single list that the paw-enterprise FilesPanel renders without
+knowing which origin each row came from. Today the listing merges chat
+S3 uploads with a (stubbed) Drive branch; local filesystem entries stay
+client-side because the server has no canonical copy of the user's
+workspace directory.
+
+Created: 2026-04-19 — Cluster E sub-PR 4 (UI-TESTING-GUIDE §14 gap E8/E9).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+
+from ee.cloud.files.service import UnifiedFilesService
+from ee.cloud.license import require_license
+from ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+router = APIRouter(
+    prefix="/files",
+    tags=["Files"],
+    dependencies=[Depends(require_license)],
+)
+
+_SVC = UnifiedFilesService()
+
+
+@router.get("")
+async def list_files(
+    workspace_id: str | None = Query(None),
+    source: Literal["chat", "local", "drive"] | None = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+    user_id: str = Depends(current_user_id),
+    current_workspace: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """List files in the caller's current workspace.
+
+    ``workspace_id`` is accepted for explicitness but must match the
+    caller's current workspace — cross-workspace listing is rejected.
+    """
+    if workspace_id and workspace_id != current_workspace:
+        return JSONResponse(
+            status_code=403,
+            content={
+                "detail": "workspace.mismatch",
+                "message": "Cannot list files outside your current workspace.",
+            },
+        )
+
+    files, warnings = await _SVC.list_unified(
+        current_workspace, source=source, limit=limit
+    )
+
+    return JSONResponse(
+        content={
+            "workspace_id": current_workspace,
+            "source": source or "all",
+            "files": [
+                {
+                    "id": f.id,
+                    "source": f.source,
+                    "filename": f.filename,
+                    "mime": f.mime,
+                    "size": f.size,
+                    "url": f.url,
+                    "created": f.created.isoformat() if f.created else None,
+                    "chat_id": f.chat_id,
+                }
+                for f in files
+            ],
+            "warnings": warnings,
+        }
+    )

--- a/ee/cloud/files/service.py
+++ b/ee/cloud/files/service.py
@@ -1,0 +1,142 @@
+"""Unified files service — merges chat S3 uploads, local workspace dir,
+and (stubbed for now) Drive-synced files into one list the FE Files
+panel can render.
+
+Cluster E sub-PR 4. The Drive branch returns an empty list today;
+Cluster C owns the connector-status endpoint that will tell us which
+pockets have a connected Drive account. Once that lands we can fan a
+Drive listing in here without changing the response shape the FE already
+consumes. See ``docs/plans/cluster-E-reality.md`` for the handshake.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+from ee.cloud.uploads.mongo_store import MongoFileStore
+
+logger = logging.getLogger(__name__)
+
+
+FileSource = Literal["chat", "local", "drive"]
+
+
+@dataclass
+class UnifiedFile:
+    """Row in the unified Files listing. Shape is shared across sources."""
+
+    id: str
+    source: FileSource
+    filename: str
+    mime: str | None
+    size: int | None
+    url: str | None  # None for local fs (FE uses Tauri for those)
+    created: datetime | None
+    chat_id: str | None = None
+
+
+def _dedupe(files: list[UnifiedFile]) -> list[UnifiedFile]:
+    """Drop later duplicates keyed on ``(filename, size, mime)``.
+
+    The same file that lives in both the Drive mirror and a chat upload
+    would otherwise show up twice in the panel. We keep the first hit
+    (which is the newest because we sort before dedupe).
+    """
+    seen: set[tuple[str, int | None, str | None]] = set()
+    out: list[UnifiedFile] = []
+    for f in files:
+        key = (f.filename, f.size, f.mime)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(f)
+    return out
+
+
+class UnifiedFilesService:
+    """Stateless façade that pulls each source and merges the results."""
+
+    def __init__(self, uploads: MongoFileStore | None = None) -> None:
+        self._uploads = uploads or MongoFileStore()
+
+    async def list_chat_uploads(
+        self, workspace_id: str, *, limit: int
+    ) -> list[UnifiedFile]:
+        records = await self._uploads.list_by_workspace(workspace_id, limit=limit)
+        return [
+            UnifiedFile(
+                id=rec.id,
+                source="chat",
+                filename=rec.filename,
+                mime=rec.mime,
+                size=rec.size,
+                url=f"/api/v1/uploads/{rec.id}",
+                created=rec.created,
+                chat_id=rec.chat_id,
+            )
+            for rec in records
+        ]
+
+    async def list_drive(
+        self, workspace_id: str, *, limit: int
+    ) -> list[UnifiedFile]:
+        """Drive source — stubbed until Cluster C lands connector status.
+
+        Returns an empty list and logs at debug level. The FE handles an
+        empty Drive branch gracefully (no empty-state surprise).
+        """
+        logger.debug(
+            "Drive source for workspace %s not yet wired (Cluster C dep)",
+            workspace_id,
+        )
+        return []
+
+    async def list_unified(
+        self,
+        workspace_id: str,
+        *,
+        source: FileSource | None,
+        limit: int,
+    ) -> tuple[list[UnifiedFile], list[str]]:
+        """Return (files, warnings).
+
+        ``source`` is optional — omit for "everything we can reach". When
+        a specific source is requested, only that source is queried.
+        """
+        per_source = max(1, min(limit, 500))
+        warnings: list[str] = []
+        merged: list[UnifiedFile] = []
+
+        if source in (None, "chat"):
+            merged.extend(await self.list_chat_uploads(workspace_id, limit=per_source))
+
+        if source in (None, "drive"):
+            drive_hits = await self.list_drive(workspace_id, limit=per_source)
+            merged.extend(drive_hits)
+            if not drive_hits:
+                # Visible to the FE so it can render a "connect Drive" hint.
+                warnings.append(
+                    "drive.not_connected: Drive source is not wired yet; "
+                    "see Cluster C connector-status endpoint."
+                )
+
+        # Local filesystem is addressed by the FE's Tauri bridge (no
+        # single authoritative path on the server). The unified endpoint
+        # only reports remote-sourced files; the FE merges its local
+        # listing in-client. Flag the intent so the panel's filter chips
+        # still read meaningfully.
+        if source == "local":
+            warnings.append(
+                "local.client_only: Local files are enumerated by the "
+                "Tauri filesystem bridge; the server does not keep a "
+                "canonical copy."
+            )
+
+        # Dedupe once after all sources are merged. Sort newest first.
+        merged.sort(key=lambda f: f.created or datetime.min, reverse=True)
+        merged = _dedupe(merged)
+
+        return merged[:limit], warnings

--- a/ee/cloud/uploads/mongo_store.py
+++ b/ee/cloud/uploads/mongo_store.py
@@ -1,4 +1,10 @@
-"""Mongo-backed metadata store, workspace-scoped."""
+"""Mongo-backed metadata store, workspace-scoped.
+
+2026-04-19 (Cluster E sub-PR 4): added ``list_by_workspace`` so the
+unified files endpoint can pull chat-sourced uploads alongside local
+filesystem entries. Soft-deleted rows are skipped. Results are capped
+to keep the unified list cheap.
+"""
 
 from __future__ import annotations
 
@@ -60,6 +66,34 @@ class MongoFileStore:
             chat_id=doc.chat_id,
             created=doc.createdAt or datetime.now(UTC),
         )
+
+    async def list_by_workspace(
+        self,
+        workspace: str,
+        *,
+        limit: int = 200,
+        chat_id: str | None = None,
+    ) -> list[FileRecord]:
+        """Return live (non-deleted) file records in a workspace.
+
+        Newest first. When ``chat_id`` is supplied, narrow further to the
+        uploads that originated in that chat. The workspace filter always
+        applies — cross-workspace bleed is not allowed through this API.
+        """
+        capped = max(1, min(limit, 500))
+        query: dict = {
+            "workspace": workspace,
+            "deleted_at": None,
+        }
+        if chat_id:
+            query["chat_id"] = chat_id
+        docs = (
+            await FileUpload.find(query)
+            .sort([("createdAt", -1)])
+            .limit(capped)
+            .to_list()
+        )
+        return [r for r in (self._to_record(d) for d in docs) if r is not None]
 
     async def soft_delete_scoped(self, file_id: str, workspace: str) -> None:
         doc = await FileUpload.find_one(

--- a/tests/cloud/files/test_unified_list.py
+++ b/tests/cloud/files/test_unified_list.py
@@ -1,0 +1,144 @@
+# tests/cloud/files/test_unified_list.py — Coverage for the unified
+# files service + mongo_store listing added in Cluster E sub-PR 4.
+# Exercises workspace scope, dedupe, drive-stub warning, and limit cap.
+# Created: 2026-04-19
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from beanie import init_beanie
+from mongomock_motor import AsyncMongoMockClient
+
+from ee.cloud.files.service import UnifiedFile, UnifiedFilesService, _dedupe
+from ee.cloud.uploads.models import FileUpload
+from ee.cloud.uploads.mongo_store import MongoFileStore
+from pocketpaw.uploads.file_store import FileRecord
+
+
+@pytest.fixture()
+async def beanie_files_db():
+    db_name = f"test_files_{uuid.uuid4().hex[:8]}"
+    client = AsyncMongoMockClient()
+    db = client[db_name]
+    original = db.list_collection_names
+
+    async def _safe(*_a, **_kw):
+        return await original()
+
+    db.list_collection_names = _safe  # type: ignore[method-assign]
+
+    await init_beanie(database=db, document_models=[FileUpload])
+    yield db
+
+
+async def _seed_upload(workspace: str, *, name: str, chat_id: str | None = None) -> None:
+    store = MongoFileStore()
+    rec = FileRecord(
+        id=uuid.uuid4().hex,
+        storage_key=f"keys/{uuid.uuid4().hex}",
+        filename=name,
+        mime="text/plain",
+        size=123,
+        owner_id="u1",
+        chat_id=chat_id,
+        created=datetime.now(),
+    )
+    await store.save_scoped(rec, workspace=workspace)
+
+
+@pytest.mark.asyncio
+async def test_list_by_workspace_returns_rows(beanie_files_db):
+    await _seed_upload("w1", name="a.pdf")
+    await _seed_upload("w1", name="b.pdf")
+
+    store = MongoFileStore()
+    rows = await store.list_by_workspace("w1", limit=50)
+
+    assert {r.filename for r in rows} == {"a.pdf", "b.pdf"}
+
+
+@pytest.mark.asyncio
+async def test_list_by_workspace_skips_other_workspaces(beanie_files_db):
+    """Cross-workspace isolation — a file in workspace A never surfaces
+    through a listing against workspace B, even for the same caller."""
+    await _seed_upload("w-a", name="A-file.pdf")
+    await _seed_upload("w-b", name="B-file.pdf")
+
+    store = MongoFileStore()
+    rows = await store.list_by_workspace("w-a", limit=50)
+
+    assert [r.filename for r in rows] == ["A-file.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_list_by_workspace_soft_delete_is_hidden(beanie_files_db):
+    await _seed_upload("w1", name="keep.pdf")
+    await _seed_upload("w1", name="gone.pdf")
+    # Soft-delete one row directly on the doc for speed.
+    doc = await FileUpload.find_one(FileUpload.filename == "gone.pdf")
+    assert doc is not None
+    doc.deleted_at = datetime.now()
+    await doc.save()
+
+    rows = await MongoFileStore().list_by_workspace("w1", limit=50)
+    assert [r.filename for r in rows] == ["keep.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_unified_list_includes_chat_and_drive_warning(beanie_files_db):
+    await _seed_upload("w1", name="chat-attachment.pdf")
+
+    svc = UnifiedFilesService()
+    files, warnings = await svc.list_unified("w1", source=None, limit=50)
+
+    assert [f.source for f in files] == ["chat"]
+    assert [f.filename for f in files] == ["chat-attachment.pdf"]
+    # Drive branch is stubbed — the service flags it so the FE can
+    # render a "connect Drive" nudge without guessing.
+    assert any("drive.not_connected" in w for w in warnings)
+
+
+@pytest.mark.asyncio
+async def test_unified_list_chat_only_has_no_drive_warning(beanie_files_db):
+    await _seed_upload("w1", name="a.pdf")
+
+    svc = UnifiedFilesService()
+    files, warnings = await svc.list_unified("w1", source="chat", limit=50)
+
+    assert len(files) == 1
+    assert warnings == []
+
+
+@pytest.mark.asyncio
+async def test_unified_list_local_source_warns_client_only(beanie_files_db):
+    svc = UnifiedFilesService()
+    files, warnings = await svc.list_unified("w1", source="local", limit=50)
+
+    assert files == []
+    assert any("local.client_only" in w for w in warnings)
+
+
+def test_dedupe_keeps_first_occurrence():
+    now = datetime.now()
+    rows = [
+        UnifiedFile(id="a", source="chat", filename="a.pdf", mime="x", size=100, url="u", created=now),
+        UnifiedFile(id="b", source="drive", filename="a.pdf", mime="x", size=100, url="u2", created=now),
+        UnifiedFile(id="c", source="chat", filename="b.pdf", mime="x", size=200, url="u", created=now),
+    ]
+
+    out = _dedupe(rows)
+    assert [r.id for r in out] == ["a", "c"]
+
+
+@pytest.mark.asyncio
+async def test_unified_list_respects_limit_cap(beanie_files_db):
+    for i in range(6):
+        await _seed_upload("w1", name=f"f{i}.pdf")
+
+    svc = UnifiedFilesService()
+    files, _ = await svc.list_unified("w1", source="chat", limit=3)
+    assert len(files) == 3


### PR DESCRIPTION
## Summary

- Adds \`GET /api/v1/files\` with a new \`UnifiedFilesService\` that merges chat S3 uploads today and leaves a graceful stub for Drive until Cluster C's connector-status ships.
- Adds \`MongoFileStore.list_by_workspace\` with workspace scope, soft-delete skip, and a 500-row cap.
- Response shape is \`{workspace_id, source, files[], warnings[]}\`. Each row carries \`{id, source, filename, mime, size, url, created, chat_id}\`. A \`workspace_id\` query param is accepted but must match the caller's current workspace — cross-workspace asks are 403.
- Drive is not wired yet; the service returns a \`drive.not_connected\` warning the FE surfaces as a hint. Handshake to \`/connectors/google_drive/status\` drops in when Cluster C lands without touching this shape.

Stacks on: #987 (Wave 2 pytest fixtures). Soft-depends on Cluster C's connector-status endpoint for the Drive branch — stubbed until that merges.

Plan anchor: \`docs/plans/FEATURE-HARDENING-PLAN.md\` — Cluster E, §14 gaps E8 and E9.
Reality brief: \`docs/plans/cluster-E-reality.md\`.

## Test plan

- [x] \`uv run pytest tests/cloud/files/test_unified_list.py -v\` — 8 passed:
  - basic listing
  - cross-workspace isolation
  - soft-delete hidden
  - default merge flags drive as not-connected
  - chat-only filter returns no drive warning
  - local-only filter returns the client-only note
  - dedupe keeps first of \`(filename, size, mime)\`
  - limit cap honoured
- [x] Security review — 3/3 focus items green: cross-workspace isolation tested at store + service + router; Drive branch returns nothing so cred-leak isn't possible; request \`workspace_id\` mismatch is 403.
- [ ] Playwright e2e — deferred to Wave 4 cross-cluster smoke per the plan.
- [ ] Contract spec — the \`tests/contract/\` harness doesn't exist yet (Wave 2 deliverable).

## Notes

- Do not merge — captain reviews per the open-PR gate.