### PR TITLE
Pocket journal SSE stream for the Ripple graph

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -3,6 +3,9 @@
 Updated: Added kb (knowledge base) domain router to mount_cloud().
 Updated: 2026-04-19 (Cluster C / PR1) — Mounted ee.cloud.kb.knowledge_router,
     which exposes GET /api/v1/knowledge/articles as a workspace-level aggregate.
+Updated: 2026-04-19 (Cluster B) — Added pocket journal SSE stream router to
+    mount_cloud() — feeds the RippleGraphWidget with a live, pocket-scoped
+    slice of the org journal.
 
 Domains: auth, workspace, chat, pockets, sessions, agents, kb, knowledge.
 Each has router.py (thin), service.py (logic), schemas.py (validation).
@@ -73,6 +76,17 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(sessions_router, prefix="/api/v1")
 
     from ee.cloud.kb.knowledge_router import router as knowledge_router
+
+    # Pocket journal SSE stream — feeds the RippleGraphWidget (Cluster B §11).
+    # Lives alongside pockets_router rather than inside it so the main pocket
+    # CRUD router stays focused on documents while the stream has its own
+    # lifecycle (long-lived connection, polling loop, separate error paths).
+    from ee.cloud.pockets.journal_stream_router import (
+        router as pockets_journal_stream_router,
+    )
+
+    app.include_router(pockets_journal_stream_router, prefix="/api/v1")
+
     from ee.cloud.kb.router import router as kb_router
     from ee.cloud.notifications.router import router as notifications_router
     from ee.cloud.uploads.router import router as uploads_router

--- a/ee/cloud/pockets/journal_stream_router.py
+++ b/ee/cloud/pockets/journal_stream_router.py
@@ -1,0 +1,267 @@
+# ee/cloud/pockets/journal_stream_router.py — SSE feed for pocket-scoped journal events.
+# Created: 2026-04-19 (Cluster B / Wave 3 §11 — RippleGraphWidget)
+# Serves a live stream of org journal events filtered to a single pocket so the
+# frontend RippleGraphWidget can render the pocket's decision + retrieval + tool
+# trace as a live causation graph. The filter matches on either
+# ``payload.pocket_id == pocket_id`` (the dominant convention used by ee.widget
+# and ee.retrieval stores) or a scope entry of the form ``pocket:<id>`` (so
+# callers who tag scope rather than payload still show up without a catalog
+# rewrite). The stream replays events from ``since_seq`` for reconnects and
+# polls every ``POLL_INTERVAL_SEC`` for new entries.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+from soul_protocol.engine.journal import Journal
+from soul_protocol.spec.journal import DataRef, EventEntry
+
+from ee.cloud.license import require_license
+from ee.cloud.shared.deps import require_pocket_edit
+from ee.journal_dep import get_journal
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/pockets",
+    tags=["Pockets", "Journal"],
+    dependencies=[Depends(require_license)],
+)
+
+# Cadence balances responsiveness (RippleGraphWidget spec asks for <2s node
+# visibility) against SQLite read churn. 500ms keeps perceived latency below
+# the ask while adding ≤2 QPS/connection on the WAL reader. The heartbeat
+# matches the chat SSE convention (events.py) so intermediaries do not close
+# the stream on idle.
+POLL_INTERVAL_SEC = 0.5
+HEARTBEAT_SEC = 30.0
+INITIAL_BACKLOG_LIMIT = 200  # safety cap on first-connect replay
+
+
+def _entry_matches_pocket(entry: EventEntry, pocket_id: str) -> bool:
+    """Return True when an event belongs to the given pocket.
+
+    Two sources of truth are in play today:
+
+    * ``payload.pocket_id`` — how ``ee/widget/store.py`` and
+      ``ee/retrieval/store.py`` tag the pocket on every event.
+    * ``scope`` entry equal to ``pocket:<id>`` — proposed namespace for
+      callers that prefer scope tagging over payload fields.
+
+    Accept either so future writers do not have to coordinate with the
+    stream route. The payload check short-circuits when the payload is a
+    :class:`DataRef` (Zero-Copy external data); those events carry scope
+    only.
+    """
+    scope_match = f"pocket:{pocket_id}"
+    if scope_match in entry.scope:
+        return True
+    payload = entry.payload
+    if isinstance(payload, DataRef):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    value = payload.get("pocket_id")
+    return isinstance(value, str) and value == pocket_id
+
+
+def _encode_entry(entry: EventEntry, *, seq: int) -> str:
+    """Shape one :class:`EventEntry` into the SSE frame the RippleGraphWidget
+    reader consumes. Kept deterministic so contract tests can diff against a
+    frozen snapshot.
+    """
+    payload_obj: Any
+    payload = entry.payload
+    if isinstance(payload, DataRef):
+        payload_obj = {"__dataref__": True, **payload.model_dump(mode="json")}
+    else:
+        payload_obj = dict(payload)
+
+    data = {
+        "id": str(entry.id),
+        "seq": seq,
+        "ts": entry.ts.isoformat(),
+        "action": entry.action,
+        "actor": {
+            "kind": entry.actor.kind,
+            "id": entry.actor.id,
+        },
+        "scope": list(entry.scope),
+        "causation_id": str(entry.causation_id) if entry.causation_id else None,
+        "correlation_id": str(entry.correlation_id) if entry.correlation_id else None,
+        "payload": payload_obj,
+    }
+    return f"event: journal\ndata: {json.dumps(data)}\n\n"
+
+
+def _drain_since(
+    journal: Journal, pocket_id: str, since_seq: int
+) -> tuple[list[tuple[int, EventEntry]], int]:
+    """Pull every pocket-matched entry strictly greater than ``since_seq``.
+
+    Returns a pair of ``(matched, last_observed_seq)`` so the caller can
+    advance its cursor even when all new entries were filtered out — that
+    keeps the next poll from re-walking the same prefix. Replay is bounded
+    by :data:`INITIAL_BACKLOG_LIMIT` so a very old cursor does not produce
+    an unbounded burst on first connect.
+
+    ``since_seq == -1`` is the cold-start sentinel — it asks for the entire
+    backlog (up to :data:`INITIAL_BACKLOG_LIMIT`) without skipping seq 0.
+    The backend assigns seqs starting at 0, so a naive ``since_seq + 1``
+    start would drop the very first event of a freshly created pocket.
+
+    The function reaches into ``journal._backend`` deliberately: the public
+    ``Journal.query`` API flattens seq away, and the installed soul-protocol
+    version (0.3.1) does not populate ``EventEntry.seq`` on the round-tripped
+    entry. Keeping the seq cursor hand-in-hand with the row iterator is the
+    only way today to stream with a resumable cursor.
+    """
+    matched: list[tuple[int, EventEntry]] = []
+    last_seq = since_seq
+
+    backend = journal._backend  # type: ignore[attr-defined]
+    tail = backend.last_entry()
+    if tail is None:
+        return matched, since_seq
+    _, tail_seq = tail
+    if tail_seq <= since_seq:
+        return matched, tail_seq
+
+    # Cold start (since_seq == -1): read from the top of the available
+    # window so seq=0 is included. Warm start: skip what we already saw.
+    if since_seq < 0:
+        start = max(0, tail_seq - INITIAL_BACKLOG_LIMIT + 1)
+    else:
+        start = since_seq + 1
+    cur = backend._conn.execute(  # type: ignore[attr-defined]
+        "SELECT * FROM events WHERE seq >= ? ORDER BY seq ASC", (start,)
+    )
+    for row in cur:
+        entry, seq = backend._row_to_entry(row)  # type: ignore[attr-defined]
+        last_seq = seq
+        if _entry_matches_pocket(entry, pocket_id):
+            matched.append((seq, entry))
+
+    return matched, last_seq
+
+
+@router.get("/{pocket_id}/journal/stream")
+async def stream_pocket_journal(
+    pocket_id: str,
+    since_seq: int = Query(
+        default=-1,
+        ge=-1,
+        description=(
+            "Resume cursor. ``-1`` (the default) asks for the whole recent "
+            "backlog (cold-start). Pass the ``seq`` of the last event the "
+            "client already rendered to resume strictly after it — used by "
+            "EventSource reconnects so the widget never double-renders a "
+            "node."
+        ),
+    ),
+    max_idle_polls: int | None = Query(
+        default=None,
+        ge=1,
+        description=(
+            "Debug/test hook — close the stream after this many idle polls "
+            "(polls that yielded zero matched events). Production clients "
+            "connect via EventSource and never pass this so the stream runs "
+            "for the life of the page."
+        ),
+    ),
+    journal: Journal = Depends(get_journal),
+    _user=Depends(require_pocket_edit),
+) -> StreamingResponse:
+    """Subscribe to the pocket's journal as a live SSE stream.
+
+    Emits three event types:
+
+    * ``connected`` — initial handshake with the server-observed ``last_seq``
+      so the client can pin its cursor without reading stale data.
+    * ``journal`` — one per matched :class:`EventEntry`, newest-to-oldest
+      after the initial backlog flushes, then strictly increasing thereafter.
+    * ``: keepalive`` comments every :data:`HEARTBEAT_SEC` seconds so proxies
+      do not tear down the connection on idle.
+
+    The route is read-only — it does not mutate the journal. Scope enforcement
+    runs through ``require_pocket_edit`` (the same guard the PATCH route uses)
+    so only authorised pocket members receive events.
+    """
+
+    cancel_event = asyncio.Event()
+
+    async def _event_generator():
+        nonlocal_since = since_seq
+        idle_polls = 0
+        try:
+            # Seed the client with the current cursor so a disconnect +
+            # reconnect can resume without a SQL count.
+            backend = journal._backend  # type: ignore[attr-defined]
+            tail = backend.last_entry()
+            tail_seq = tail[1] if tail else 0
+            handshake = {"last_seq": tail_seq, "pocket_id": pocket_id}
+            yield f"event: connected\ndata: {json.dumps(handshake)}\n\n"
+
+            # Flush the backlog up front so the widget renders immediately on
+            # mount instead of waiting for the next event.
+            matched, nonlocal_since = _drain_since(journal, pocket_id, nonlocal_since)
+            for seq, entry in matched:
+                yield _encode_entry(entry, seq=seq)
+
+            last_heartbeat = datetime.now(UTC)
+
+            while not cancel_event.is_set():
+                await asyncio.sleep(POLL_INTERVAL_SEC)
+
+                matched, nonlocal_since = _drain_since(
+                    journal, pocket_id, nonlocal_since
+                )
+                for seq, entry in matched:
+                    yield _encode_entry(entry, seq=seq)
+
+                if max_idle_polls is not None:
+                    if matched:
+                        idle_polls = 0
+                    else:
+                        idle_polls += 1
+                        if idle_polls >= max_idle_polls:
+                            # Emit a terminal frame so the client can
+                            # distinguish "backlog drained" from "connection
+                            # dropped". Matches the Fleet router convention
+                            # of always framing terminal state explicitly.
+                            yield "event: closed\ndata: {\"reason\": \"idle\"}\n\n"
+                            return
+
+                # Keepalive comment keeps intermediaries happy when the
+                # pocket is idle.
+                now = datetime.now(UTC)
+                if (now - last_heartbeat).total_seconds() >= HEARTBEAT_SEC:
+                    yield ": keepalive\n\n"
+                    last_heartbeat = now
+
+        except asyncio.CancelledError:
+            # The client disconnected — propagate so FastAPI can clean up
+            # without producing a 500.
+            raise
+        except Exception:  # pragma: no cover — defensive
+            logger.exception(
+                "pocket journal stream failed for pocket_id=%s", pocket_id
+            )
+            raise
+
+    return StreamingResponse(
+        _event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            # Disable nginx buffering so frames flush in real time.
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/tests/ee/test_pocket_journal_stream.py
+++ b/tests/ee/test_pocket_journal_stream.py
@@ -1,0 +1,364 @@
+# tests/ee/test_pocket_journal_stream.py — FastAPI TestClient coverage for the
+# pocket journal SSE router shipped in feat/cluster-b-ripple-journal-stream.
+# Created: 2026-04-19 — Cluster B / Wave 3 §11 — RippleGraphWidget. Pins the
+# route's contract with the frontend widget: (1) filters the shared org journal
+# down to events that carry ``payload.pocket_id`` equal to the path pocket, or
+# a scope entry ``pocket:<id>``; (2) emits one ``event: journal`` SSE frame per
+# match, JSON-encoded with the shape the widget reader consumes; (3) respects
+# the ``since_seq`` cursor so reconnects do not replay the whole backlog; (4)
+# leaks no events from other pockets.
+#
+# Auth + pocket access are stubbed by overriding ``require_pocket_edit`` — the
+# real dep reads from beanie/Mongo. These are route-contract tests, not end-to-
+# end scope tests; Cluster B security-auditor covers the access-control matrix.
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.spec.journal import Actor, EventEntry
+
+from ee.cloud.license import require_license
+from ee.cloud.pockets.journal_stream_router import (
+    router,
+    _entry_matches_pocket,
+)
+from ee.cloud.shared.deps import require_pocket_edit
+from ee.journal_dep import get_journal, reset_journal_cache
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_journal_cache() -> None:
+    """Clear the module-level journal cache between tests.
+
+    Tests override ``get_journal`` via ``dependency_overrides`` but a stale
+    cached instance from a sibling test could leak through if the override
+    resolves early. The fixture is belt-and-braces.
+    """
+
+    reset_journal_cache()
+    yield
+    reset_journal_cache()
+
+
+@pytest.fixture
+def journal_path(tmp_path: Path) -> Path:
+    """A disposable SQLite file the override points at."""
+
+    return tmp_path / "pocket_journal_stream.db"
+
+
+@pytest.fixture
+def app(journal_path: Path) -> FastAPI:
+    """FastAPI app with the stream router + deps overridden.
+
+    ``require_pocket_edit`` is replaced with a no-op that accepts every
+    caller, and ``require_license`` short-circuits the same way. Tests that
+    want to exercise the 403 path can override these back in-line.
+    """
+
+    a = FastAPI()
+    a.include_router(router, prefix="/api/v1")
+    a.dependency_overrides[get_journal] = lambda: open_journal(journal_path)
+    a.dependency_overrides[require_pocket_edit] = lambda pocket_id: None
+    a.dependency_overrides[require_license] = lambda: None
+    return a
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+def _append(
+    journal, *, action: str, pocket_id: str | None, scope: list[str] | None = None
+) -> int:
+    """Append one event to the test journal and return its seq.
+
+    Takes a kwargs-only shape so tests read more like specs than scratch
+    snippets — the shape mirrors how ``ee/widget/store.py`` builds entries.
+    The installed soul-protocol (0.3.1) ``Journal.append`` returns None, so
+    we read seq from the backend tail after the write. That matches how
+    :func:`_drain_since` in the router resolves seqs.
+    """
+
+    entry = EventEntry(
+        id=uuid4(),
+        ts=datetime.now(UTC),
+        actor=Actor(kind="system", id="system:test", scope_context=[]),
+        action=action,
+        scope=scope or ["org:test"],
+        payload={"pocket_id": pocket_id} if pocket_id else {},
+    )
+    journal.append(entry)
+    tail = journal._backend.last_entry()
+    assert tail is not None
+    _, seq = tail
+    return seq
+
+
+def _read_sse_frames(response_text: str) -> list[dict]:
+    """Parse the SSE body into a list of ``{event, data}`` dicts.
+
+    The route emits one ``event: <name>\\ndata: <json>\\n\\n`` block per
+    entry. Keepalive comments (``: keepalive\\n\\n``) are discarded so
+    assertions can focus on business events.
+    """
+
+    frames: list[dict] = []
+    for block in response_text.split("\n\n"):
+        if not block.strip() or block.strip().startswith(":"):
+            continue
+        event = None
+        data = None
+        for line in block.splitlines():
+            if line.startswith("event:"):
+                event = line[len("event:"):].strip()
+            elif line.startswith("data:"):
+                data = line[len("data:"):].strip()
+        if event is not None and data is not None:
+            frames.append({"event": event, "data": json.loads(data)})
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# Unit-level — filter predicate
+# ---------------------------------------------------------------------------
+
+
+class TestEntryMatchesPocket:
+    def test_matches_by_payload_pocket_id(self) -> None:
+        """Events whose ``payload.pocket_id`` equals the path arg are
+        included. This is the dominant convention used by the widget and
+        retrieval stores today.
+        """
+
+        entry = EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=Actor(kind="system", id="system:t", scope_context=[]),
+            action="widget.interaction.recorded",
+            scope=["org:test"],
+            payload={"pocket_id": "p-target"},
+        )
+        assert _entry_matches_pocket(entry, "p-target") is True
+        assert _entry_matches_pocket(entry, "p-other") is False
+
+    def test_matches_by_scope_pocket_prefix(self) -> None:
+        """A scope entry of the form ``pocket:<id>`` also counts as a
+        match so future writers can tag scope instead of payload without
+        a stream-route change.
+        """
+
+        entry = EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=Actor(kind="system", id="system:t", scope_context=[]),
+            action="retrieval.query",
+            scope=["org:test", "pocket:p-target"],
+            payload={},
+        )
+        assert _entry_matches_pocket(entry, "p-target") is True
+
+    def test_does_not_match_dataref_payload(self) -> None:
+        """Zero-Copy DataRef payloads carry no ``pocket_id`` — matching
+        should rely on scope alone, not crash on the non-dict payload.
+        """
+
+        from soul_protocol.spec.journal import DataRef
+
+        entry = EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=Actor(kind="system", id="system:t", scope_context=[]),
+            action="dataref.resolved",
+            scope=["org:test"],
+            payload=DataRef(
+                source="salesforce",
+                query="SELECT Id FROM Opp",
+                point_in_time=datetime.now(UTC),
+            ),
+        )
+        assert _entry_matches_pocket(entry, "p-target") is False
+
+
+# ---------------------------------------------------------------------------
+# Route-level — SSE frame shape + filtering
+# ---------------------------------------------------------------------------
+
+
+class TestStreamPocketJournal:
+    def test_emits_connected_handshake_with_last_seq(
+        self, client: TestClient, journal_path: Path
+    ) -> None:
+        """The first SSE frame is the ``connected`` handshake so the
+        widget can pin its resume cursor before the first journal frame.
+        """
+
+        journal = open_journal(journal_path)
+        _append(journal, action="widget.interaction.recorded", pocket_id="p-1")
+        journal.close()
+
+        body = _drain_stream(client, "/api/v1/pockets/p-1/journal/stream")
+        frames = _read_sse_frames(body)
+        assert frames[0]["event"] == "connected"
+        assert frames[0]["data"]["pocket_id"] == "p-1"
+        # SQLite backend assigns seq starting at 0 for the first event. The
+        # handshake just has to echo whatever the backend sees — assert
+        # non-negative rather than hard-coding 1 so a future seq-from-1
+        # migration would not flake this test.
+        assert frames[0]["data"]["last_seq"] >= 0
+
+    def test_emits_backlog_for_matching_events_only(
+        self, client: TestClient, journal_path: Path
+    ) -> None:
+        """Only events that match the path pocket_id are streamed —
+        cross-pocket leakage would be a scope bug.
+        """
+
+        journal = open_journal(journal_path)
+        _append(journal, action="widget.interaction.recorded", pocket_id="p-target")
+        _append(journal, action="widget.interaction.recorded", pocket_id="p-other")
+        _append(journal, action="retrieval.query", pocket_id="p-target")
+        journal.close()
+
+        body = _drain_stream(client, "/api/v1/pockets/p-target/journal/stream")
+        frames = _read_sse_frames(body)
+        journal_frames = [f for f in frames if f["event"] == "journal"]
+        assert len(journal_frames) == 2
+        for f in journal_frames:
+            assert f["data"]["payload"]["pocket_id"] == "p-target"
+
+    def test_respects_since_seq_cursor(
+        self, client: TestClient, journal_path: Path
+    ) -> None:
+        """``since_seq`` skips events whose seq is ``<=`` the cursor so
+        reconnects do not replay the whole backlog.
+        """
+
+        journal = open_journal(journal_path)
+        seq_a = _append(journal, action="agent.proposed", pocket_id="p-1")
+        seq_b = _append(journal, action="human.corrected", pocket_id="p-1")
+        journal.close()
+
+        body = _drain_stream(
+            client,
+            "/api/v1/pockets/p-1/journal/stream",
+            params={"since_seq": seq_a},
+        )
+        frames = _read_sse_frames(body)
+        journal_frames = [f for f in frames if f["event"] == "journal"]
+        seqs = [f["data"]["seq"] for f in journal_frames]
+        assert seq_b in seqs
+        assert seq_a not in seqs
+
+    def test_frame_carries_widget_contract_fields(
+        self, client: TestClient, journal_path: Path
+    ) -> None:
+        """The JSON payload of each ``journal`` frame matches the shape
+        the RippleGraphWidget reader expects — ``id``, ``seq``, ``ts``,
+        ``action``, ``actor``, ``scope``, ``correlation_id``,
+        ``causation_id``, ``payload``.
+        """
+
+        journal = open_journal(journal_path)
+        _append(journal, action="retrieval.query", pocket_id="p-1")
+        journal.close()
+
+        body = _drain_stream(client, "/api/v1/pockets/p-1/journal/stream")
+        frames = _read_sse_frames(body)
+        journal_frames = [f for f in frames if f["event"] == "journal"]
+        assert journal_frames, "expected at least one journal frame"
+        data = journal_frames[0]["data"]
+        assert set(data.keys()) == {
+            "id",
+            "seq",
+            "ts",
+            "action",
+            "actor",
+            "scope",
+            "causation_id",
+            "correlation_id",
+            "payload",
+        }
+        assert data["actor"] == {"kind": "system", "id": "system:test"}
+
+    def test_empty_pocket_still_emits_connected(
+        self, client: TestClient, journal_path: Path
+    ) -> None:
+        """A pocket with zero journal events still receives the
+        ``connected`` handshake so the widget can render the cold-start
+        empty state instead of hanging.
+        """
+
+        # Write an unrelated event so the journal file exists.
+        journal = open_journal(journal_path)
+        _append(journal, action="widget.interaction.recorded", pocket_id="p-other")
+        journal.close()
+
+        body = _drain_stream(client, "/api/v1/pockets/p-empty/journal/stream")
+        frames = _read_sse_frames(body)
+        assert any(f["event"] == "connected" for f in frames)
+        assert [f for f in frames if f["event"] == "journal"] == []
+
+    def test_stream_closes_on_max_idle_polls(
+        self, client: TestClient, journal_path: Path
+    ) -> None:
+        """The ``max_idle_polls`` debug knob short-circuits the long-poll
+        loop so the stream terminates with a ``closed`` frame once the
+        backlog has drained. Without it, the connection would stay open
+        for the life of the page — useful in prod, catastrophic in a
+        synchronous TestClient.
+        """
+
+        journal = open_journal(journal_path)
+        _append(journal, action="agent.proposed", pocket_id="p-1")
+        journal.close()
+
+        body = _drain_stream(client, "/api/v1/pockets/p-1/journal/stream")
+        frames = _read_sse_frames(body)
+        assert any(f["event"] == "closed" for f in frames)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _drain_stream(
+    client: TestClient,
+    path: str,
+    *,
+    params: dict[str, object] | None = None,
+    max_idle_polls: int = 1,
+) -> str:
+    """Drive the SSE endpoint to completion by asking the server to close
+    the stream after ``max_idle_polls`` idle polls, then return the full
+    response body.
+
+    Without the ``max_idle_polls`` debug knob the route would hold the
+    connection open for the life of the page and ``TestClient.stream``
+    would hang forever — FastAPI's sync TestClient does not surface the
+    same cancellation signals that a real ASGI transport would.
+    """
+
+    full_params: dict[str, object] = {"max_idle_polls": max_idle_polls}
+    if params:
+        full_params.update(params)
+
+    with client.stream("GET", path, params=full_params) as resp:
+        assert resp.status_code == 200
+        chunks = [c for c in resp.iter_raw()]
+    return b"".join(chunks).decode("utf-8")


### PR DESCRIPTION
## What this is

The frontend RippleGraphWidget PR (`paw-enterprise#110`) needs a live, pocket-scoped slice of the org journal. No such endpoint existed — the `Cluster B — reality brief` surfaced the gap in the wiring audit. This PR ships the stream.

## The wire

`GET /api/v1/pockets/{pocket_id}/journal/stream` returns SSE with three frame types:

- `connected` — handshake with `last_seq` so a reconnecting client can pin its cursor without a count query.
- `journal` — one per matched event, carrying `id`, `seq`, `ts`, `action`, `actor`, `scope`, `causation_id`, `correlation_id`, `payload`. The shape matches what the frontend parser expects.
- `: keepalive` — comment every 30s so nginx-style proxies don't drop the idle connection.

Cursor semantics: `since_seq=-1` asks for the recent backlog (cold start), any non-negative value resumes strictly after it. Backlog is capped at 200 entries so a very old cursor can't produce a flood.

## Filter rule

An event belongs to the pocket when `payload.pocket_id == pocket_id` (today's convention across `ee/widget/store.py` and `ee/retrieval/store.py`) OR when a scope entry is `pocket:<id>` (future-proofing for callers who prefer scope over payload tags). Either works — no write-side change needed for existing events to start showing up.

## Auth

Runs through `require_pocket_edit`, the same guard the PATCH route uses. No new scope rules; existing pocket access rules apply.

## Poll cadence

500ms — well inside the 2-second visibility budget the plan sets for the widget, adding ≤2 QPS per connection on the WAL reader. The backend uses SQLite's O(1) tail-peek before pulling rows so the check is cheap.

## Tests

- 9 new pytest cases in `tests/ee/test_pocket_journal_stream.py`:
  - Predicate unit tests: payload match, scope match, DataRef safety.
  - Route tests: connected handshake, backlog-only-matches, cursor resume, wire contract, empty pocket handshake, idle-poll shutdown.
- Existing 117 `ee/` tests remain green.

## Pairs with

`paw-enterprise#110` consumes this stream via `core/journal/stream.ts`. The contract between them is pinned both ways — this PR's wire format test and the frontend's parser test both reference the same 9-field payload shape.

## Test hook

`max_idle_polls` is a test-only query param. FastAPI's `TestClient` is synchronous and can't easily cancel a long-lived SSE generator; passing `max_idle_polls=1` tells the stream to emit a `closed` frame after its first idle iteration so tests can assert on a full response body. Production clients omit the param.

Do not merge — captain reviews all PRs before merge.