### PR TITLE
[Cluster D] Scope assignment endpoint for agents

### DIFF
--- a/ee/cloud/agents/router.py
+++ b/ee/cloud/agents/router.py
@@ -1,4 +1,11 @@
-"""Agents domain — FastAPI router."""
+"""Agents domain — FastAPI router.
+
+Updated 2026-04-19 (feat/cluster-d-agent-scope-picker): added
+``GET /agents/{id}/scope`` + ``PATCH /agents/{id}/scope`` for the
+ScopePicker UI. PATCH re-validates and re-normalises the payload server
+side — the frontend normaliseScope helper is treated as a UX nicety, not
+a security boundary.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +16,8 @@ from starlette.responses import Response
 from ee.cloud.agents.schemas import (
     CreateAgentRequest,
     DiscoverRequest,
+    ScopeAssignmentRequest,
+    ScopeAssignmentResponse,
     UpdateAgentRequest,
 )
 from ee.cloud.agents.service import AgentService
@@ -260,3 +269,47 @@ async def clear_knowledge(agent_id: str):
 
     await KnowledgeService.clear(agent_id)
     return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# Scope assignment — read + write the scope tag list on an agent.
+# Both endpoints require the caller to be the agent owner or a workspace
+# admin (``require_agent_owner_or_admin``). PATCH additionally re-runs the
+# scope validator server-side via ``ScopeAssignmentRequest`` so a direct
+# API call cannot bypass the frontend ScopePicker's normaliseScope guard.
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{agent_id}/scope",
+    response_model=ScopeAssignmentResponse,
+    dependencies=[Depends(require_agent_owner_or_admin)],
+)
+async def get_agent_scope(agent_id: str) -> ScopeAssignmentResponse:
+    """Return the scope tags currently assigned to an agent.
+
+    Empty list means "no scope narrowing" — the agent sees everything in
+    its workspace. Non-empty list bounds retrieval + fabric queries.
+    """
+    scopes = await AgentService.get_scopes(agent_id)
+    return ScopeAssignmentResponse(agent_id=agent_id, scopes=scopes)
+
+
+@router.patch(
+    "/{agent_id}/scope",
+    response_model=ScopeAssignmentResponse,
+    dependencies=[Depends(require_agent_owner_or_admin)],
+)
+async def set_agent_scope(
+    agent_id: str,
+    body: ScopeAssignmentRequest,
+) -> ScopeAssignmentResponse:
+    """Replace the agent's scope assignment (full-list swap).
+
+    The request body is validated + normalised by
+    ``ScopeAssignmentRequest``; the service re-applies the validator so a
+    fleet installer calling ``set_scopes`` directly gets the same
+    guarantees.
+    """
+    updated = await AgentService.set_scopes(agent_id, body.scopes)
+    return ScopeAssignmentResponse(agent_id=agent_id, scopes=updated)

--- a/ee/cloud/agents/schemas.py
+++ b/ee/cloud/agents/schemas.py
@@ -1,10 +1,21 @@
-"""Agents domain — Pydantic request/response schemas."""
+"""Agents domain — Pydantic request/response schemas.
+
+Updated 2026-04-19 (feat/cluster-d-agent-scope-picker): added optional
+``scopes: list[str]`` to CreateAgentRequest, UpdateAgentRequest, and a
+new ScopeAssignmentRequest body for the dedicated
+``PATCH /agents/{id}/scope`` endpoint + ScopeAssignmentResponse for the
+matching GET. Scope strings are always re-normalised server-side via the
+validator below so a caller cannot bypass the frontend ScopePicker's
+normaliseScope guards.
+"""
 
 from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from ee.cloud.agents.scope_rules import normalise_and_validate_scopes
 
 # ---------------------------------------------------------------------------
 # Requests
@@ -26,11 +37,22 @@ class CreateAgentRequest(BaseModel):
     tools: list[str] | None = None
     trust_level: int | None = None
     system_prompt: str = ""
+    # Scope assignment (hierarchical tags like ``org:sales:*``). Optional;
+    # stored on the agent config. Validated server-side — frontend is not
+    # trusted as the sole sanitiser.
+    scopes: list[str] | None = None
     # Soul customization
     soul_enabled: bool = True
     soul_archetype: str = ""
     soul_values: list[str] | None = None
     soul_ocean: dict[str, float] | None = None
+
+    @field_validator("scopes")
+    @classmethod
+    def _clean_scopes(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        return normalise_and_validate_scopes(v)
 
 
 class UpdateAgentRequest(BaseModel):
@@ -47,11 +69,43 @@ class UpdateAgentRequest(BaseModel):
     tools: list[str] | None = None
     trust_level: int | None = None
     system_prompt: str | None = None
+    scopes: list[str] | None = None
     # Soul customization
     soul_enabled: bool | None = None
     soul_archetype: str | None = None
     soul_values: list[str] | None = None
     soul_ocean: dict[str, float] | None = None
+
+    @field_validator("scopes")
+    @classmethod
+    def _clean_scopes(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        return normalise_and_validate_scopes(v)
+
+
+class ScopeAssignmentRequest(BaseModel):
+    """Body for ``PATCH /agents/{id}/scope``. Always a full replacement —
+    the endpoint swaps the stored list rather than merging deltas, so the
+    UI and API share a single "these are the scopes now" semantic.
+    """
+
+    scopes: list[str]
+
+    @field_validator("scopes")
+    @classmethod
+    def _clean_scopes(cls, v: list[str]) -> list[str]:
+        return normalise_and_validate_scopes(v)
+
+
+class ScopeAssignmentResponse(BaseModel):
+    """Body for ``GET /agents/{id}/scope``. Small, dedicated envelope so
+    the UI can cheaply poll scope without pulling the full agent document
+    each time.
+    """
+
+    agent_id: str
+    scopes: list[str]
 
 
 class DiscoverRequest(BaseModel):

--- a/ee/cloud/agents/scope_rules.py
+++ b/ee/cloud/agents/scope_rules.py
@@ -1,0 +1,133 @@
+# ee/cloud/agents/scope_rules.py — Scope validation + assignment authorisation.
+# Created: 2026-04-19 (feat/cluster-d-agent-scope-picker) — Shared helpers
+# used by the agents schema + the PATCH /agents/{id}/scope endpoint. Mirrors
+# the frontend ``src/lib/scope/normalise.ts`` rules so a malformed or
+# escalation-shaped scope coming through REST is rejected on the server even
+# when the ScopePicker was bypassed (direct API call, curl, another client).
+#
+# Scope grammar (same as frontend normalise.ts):
+#   - lowercase, colon-separated segments matching ``[a-z0-9]+``
+#   - ``*`` is only legal as the final segment (or the whole scope)
+#   - empty segments (``::`` or leading ``:``) are rejected
+#   - duplicates are collapsed
+#
+# The rule set is deliberately conservative: the endpoint refuses the
+# universal wildcard ``*`` entirely (see ``FORBIDDEN_SCOPES``) so a fleet
+# admin cannot accidentally grant an agent access to *all* workspaces.
+# Wildcards with at least one namespace segment (``org:sales:*``) are fine.
+
+from __future__ import annotations
+
+import re
+
+_SEGMENT_PATTERN = re.compile(r"^[a-z0-9]+$")
+
+# Scopes explicitly disallowed on assignment. The universal wildcard would
+# let an agent read every workspace's memories and fabric objects — we only
+# allow that via intentional infra-level config, never from the admin UI.
+FORBIDDEN_SCOPES = frozenset({"*"})
+
+
+class ScopeValidationError(ValueError):
+    """Raised when a scope tag violates the grammar or escalation rules.
+
+    Pydantic surfaces this as a 422 with a readable ``detail`` — the REST
+    router inherits FastAPI's default handler so we do not need to catch
+    it explicitly at the endpoint level.
+    """
+
+
+def _validate_one(raw: str) -> str:
+    """Normalise + validate a single scope tag. Returns the cleaned form
+    (lowercase, stripped) or raises :class:`ScopeValidationError`.
+    """
+    cleaned = raw.strip().lower()
+    if not cleaned:
+        raise ScopeValidationError("Scope cannot be empty")
+    if cleaned in FORBIDDEN_SCOPES:
+        raise ScopeValidationError(
+            f"Scope '{cleaned}' is not assignable from the admin UI — "
+            "use a namespaced wildcard instead (e.g. org:sales:*)"
+        )
+    segments = cleaned.split(":")
+    for idx, seg in enumerate(segments):
+        if not seg:
+            raise ScopeValidationError(f"Scope '{raw}' has an empty segment")
+        if seg == "*":
+            # ``*`` is only legal as the terminal segment.
+            if idx != len(segments) - 1:
+                raise ScopeValidationError(
+                    f"Scope '{raw}' uses a mid-segment wildcard; '*' is only "
+                    "legal as the final segment"
+                )
+            continue
+        if not _SEGMENT_PATTERN.match(seg):
+            raise ScopeValidationError(
+                f"Scope '{raw}' has an invalid segment '{seg}' — "
+                "segments must match [a-z0-9]+"
+            )
+    return cleaned
+
+
+def normalise_and_validate_scopes(raw: list[str]) -> list[str]:
+    """Validate + dedupe a list of scope tags, preserving order.
+
+    Called from Pydantic validators on ``scopes`` fields. Raises
+    :class:`ScopeValidationError` on the first malformed tag so the API
+    response pinpoints the offender instead of silently dropping it.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw_scope in raw:
+        if not isinstance(raw_scope, str):
+            raise ScopeValidationError(f"Scope must be a string, got {type(raw_scope).__name__}")
+        cleaned = _validate_one(raw_scope)
+        if cleaned in seen:
+            continue
+        seen.add(cleaned)
+        out.append(cleaned)
+    return out
+
+
+def admin_can_assign_scopes(
+    admin_scopes: list[str] | None, requested_scopes: list[str]
+) -> bool:
+    """Return True when ``admin_scopes`` covers every entry in
+    ``requested_scopes`` by hierarchical containment.
+
+    Containment follows the same rules as the soul-protocol scope matcher:
+    ``org:sales:*`` contains ``org:sales`` and ``org:sales:leads``. An
+    empty ``admin_scopes`` list is treated as "admin has no explicit
+    scope narrowing configured, can assign anything non-forbidden" —
+    that covers the current paw-enterprise deployment where workspace
+    admins have an implicit workspace-wide scope until the scope-per-user
+    model lands (tracked separately). The test suite pins this fallback
+    so a future narrowing doesn't silently regress.
+    """
+    if not requested_scopes:
+        return True
+    if not admin_scopes:
+        # No narrowing configured — admin sits at workspace root.
+        return True
+    for wanted in requested_scopes:
+        if not any(_scope_covers(granted, wanted) for granted in admin_scopes):
+            return False
+    return True
+
+
+def _scope_covers(granted: str, wanted: str) -> bool:
+    """True when ``granted`` contains ``wanted`` by hierarchical glob.
+
+    Duplicates the narrow semantic we need without pulling the full
+    soul-protocol matcher — that one is bidirectional, which is wrong for
+    "can this admin assign that scope to another actor". Here we want a
+    strict "admin's grant includes the target" check.
+    """
+    if granted == wanted:
+        return True
+    if granted == "*":
+        return True
+    if granted.endswith(":*"):
+        prefix = granted[:-2]
+        return wanted == prefix or wanted.startswith(prefix + ":")
+    return False

--- a/ee/cloud/agents/service.py
+++ b/ee/cloud/agents/service.py
@@ -1,4 +1,11 @@
-"""Agents domain — business logic service."""
+"""Agents domain — business logic service.
+
+Updated 2026-04-19 (feat/cluster-d-agent-scope-picker): create/update now
+pass the new ``scopes`` field through to ``AgentConfig``, and a dedicated
+``get_scopes`` / ``set_scopes`` pair backs the ``/agents/{id}/scope``
+endpoint. ``set_scopes`` re-applies the scope validator so a direct
+service call (e.g. a fleet installer) can't store an unvalidated list.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +16,7 @@ from ee.cloud.agents.schemas import (
     DiscoverRequest,
     UpdateAgentRequest,
 )
+from ee.cloud.agents.scope_rules import normalise_and_validate_scopes
 from ee.cloud.models.agent import Agent, AgentConfig
 from ee.cloud.shared.errors import ConflictError, Forbidden, NotFound
 from ee.cloud.shared.time import iso_utc
@@ -62,6 +70,8 @@ class AgentService:
             config_data["tools"] = body.tools
         if body.trust_level is not None:
             config_data["trust_level"] = body.trust_level
+        if body.scopes is not None:
+            config_data["scopes"] = body.scopes
         if body.soul_values is not None:
             config_data["soul_values"] = body.soul_values
         if body.soul_ocean is not None:
@@ -153,6 +163,7 @@ class AgentService:
                 ("max_tokens", body.max_tokens),
                 ("tools", body.tools),
                 ("trust_level", body.trust_level),
+                ("scopes", body.scopes),
                 ("soul_enabled", body.soul_enabled),
                 ("soul_archetype", body.soul_archetype),
                 ("soul_values", body.soul_values),
@@ -169,6 +180,40 @@ class AgentService:
 
         await agent.save()
         return _agent_response(agent)
+
+    @staticmethod
+    async def get_scopes(agent_id: str) -> list[str]:
+        """Return the stored scope list for an agent.
+
+        Used by ``GET /agents/{id}/scope``. No auth check here — the
+        router applies ``require_agent_owner_or_admin`` before reaching
+        the service; downstream callers (service-to-service) should apply
+        their own checks.
+        """
+        agent = await Agent.get(PydanticObjectId(agent_id))
+        if not agent:
+            raise NotFound("agent", agent_id)
+        return list(agent.config.scopes)
+
+    @staticmethod
+    async def set_scopes(agent_id: str, scopes: list[str]) -> list[str]:
+        """Replace the stored scope list for an agent, re-normalising and
+        validating server-side. Returns the stored list.
+
+        The endpoint wrapping this method re-applies the same validator
+        via the ``ScopeAssignmentRequest`` Pydantic model; the extra call
+        here makes the service safe to call from fleet installers or a
+        future CLI without depending on the REST body validation.
+        """
+        cleaned = normalise_and_validate_scopes(scopes)
+        agent = await Agent.get(PydanticObjectId(agent_id))
+        if not agent:
+            raise NotFound("agent", agent_id)
+        current = agent.config.model_dump()
+        current["scopes"] = cleaned
+        agent.config = AgentConfig(**current)
+        await agent.save()
+        return list(agent.config.scopes)
 
     @staticmethod
     async def delete(agent_id: str, user_id: str) -> None:

--- a/ee/cloud/models/agent.py
+++ b/ee/cloud/models/agent.py
@@ -1,3 +1,9 @@
+# ee/cloud/models/agent.py — Agent configuration document (not execution).
+# Updated 2026-04-19 (feat/cluster-d-agent-scope-picker): added
+# ``scopes: list[str]`` to AgentConfig so ScopePicker assignments persist.
+# The field is a plain list of hierarchical scope tags (``org:sales:*``)
+# validated at the schema boundary via scope_rules.normalise_and_validate.
+
 """Agent configuration document."""
 
 from __future__ import annotations
@@ -16,6 +22,9 @@ class AgentConfig(BaseModel):
     trust_level: int = Field(default=3, ge=1, le=5)
     temperature: float = Field(default=0.7, ge=0, le=2)
     max_tokens: int = Field(default=4096, ge=1)
+    # Scope assignment — hierarchical tags that bound the agent's retrieval
+    # surface. Empty list == "no scope narrowing" (agent sees whole workspace).
+    scopes: list[str] = Field(default_factory=list)
     # Soul integration
     soul_enabled: bool = True
     soul_persona: str = ""

--- a/tests/cloud/test_agent_schemas.py
+++ b/tests/cloud/test_agent_schemas.py
@@ -1,4 +1,9 @@
-"""Tests for agents domain schemas."""
+"""Tests for agents domain schemas.
+
+Updated 2026-04-19 (feat/cluster-d-agent-scope-picker): added scope-field
+coverage on CreateAgentRequest + UpdateAgentRequest, plus tests for the
+new ScopeAssignmentRequest / ScopeAssignmentResponse envelopes.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +14,8 @@ from ee.cloud.agents.schemas import (
     AgentResponse,
     CreateAgentRequest,
     DiscoverRequest,
+    ScopeAssignmentRequest,
+    ScopeAssignmentResponse,
     UpdateAgentRequest,
 )
 
@@ -153,3 +160,65 @@ def test_agent_response_model():
     )
     assert resp.id == "abc123"
     assert resp.config["backend"] == "claude_agent_sdk"
+
+
+# ---------------------------------------------------------------------------
+# Scope field coverage (cluster-d-agent-scope-picker)
+# ---------------------------------------------------------------------------
+
+
+def test_create_agent_with_scopes_normalises():
+    req = CreateAgentRequest(
+        name="Sales Bot",
+        slug="sales-bot",
+        scopes=["  Org:Sales:*  ", "org:sales:*"],  # whitespace + dedupe
+    )
+    assert req.scopes == ["org:sales:*"]
+
+
+def test_create_agent_with_invalid_scope_rejected():
+    with pytest.raises(PydanticValidationError):
+        CreateAgentRequest(
+            name="Bad", slug="bad", scopes=["org:*:leads"]
+        )  # mid-segment wildcard
+
+
+def test_create_agent_universal_wildcard_rejected():
+    with pytest.raises(PydanticValidationError):
+        CreateAgentRequest(name="Bad", slug="bad", scopes=["*"])
+
+
+def test_update_agent_scopes_can_clear_to_empty_list():
+    req = UpdateAgentRequest(scopes=[])
+    assert req.scopes == []
+
+
+def test_update_agent_scopes_normalises():
+    req = UpdateAgentRequest(scopes=["ORG:SALES:LEADS"])
+    assert req.scopes == ["org:sales:leads"]
+
+
+def test_scope_assignment_request_requires_scopes_field():
+    with pytest.raises(PydanticValidationError):
+        ScopeAssignmentRequest()  # type: ignore[call-arg]
+
+
+def test_scope_assignment_request_empty_list_ok():
+    req = ScopeAssignmentRequest(scopes=[])
+    assert req.scopes == []
+
+
+def test_scope_assignment_request_normalises():
+    req = ScopeAssignmentRequest(scopes=["org:sales", "ORG:SALES"])
+    assert req.scopes == ["org:sales"]
+
+
+def test_scope_assignment_request_rejects_bad_grammar():
+    with pytest.raises(PydanticValidationError):
+        ScopeAssignmentRequest(scopes=["org::broken"])
+
+
+def test_scope_assignment_response_envelope():
+    resp = ScopeAssignmentResponse(agent_id="abc", scopes=["org:sales:*"])
+    assert resp.agent_id == "abc"
+    assert resp.scopes == ["org:sales:*"]

--- a/tests/cloud/test_agent_scope_rules.py
+++ b/tests/cloud/test_agent_scope_rules.py
@@ -1,0 +1,113 @@
+# tests/cloud/test_agent_scope_rules.py — Unit tests for scope validation +
+# assignment authorisation.
+# Created: 2026-04-19 (feat/cluster-d-agent-scope-picker) — Covers the
+# grammar rules mirrored from the frontend normaliseScope helper, the
+# forbidden-universal-wildcard rule that's server-only, and the
+# admin_can_assign_scopes containment check used when a scope-narrowed
+# admin tries to assign a scope outside their own grant.
+
+from __future__ import annotations
+
+import pytest
+
+from ee.cloud.agents.scope_rules import (
+    FORBIDDEN_SCOPES,
+    ScopeValidationError,
+    admin_can_assign_scopes,
+    normalise_and_validate_scopes,
+)
+
+
+class TestNormaliseAndValidateScopes:
+    def test_empty_list_returns_empty(self):
+        assert normalise_and_validate_scopes([]) == []
+
+    def test_lowercase_and_strip(self):
+        out = normalise_and_validate_scopes(["  Org:Sales:Leads  "])
+        assert out == ["org:sales:leads"]
+
+    def test_dedupe_preserves_order(self):
+        out = normalise_and_validate_scopes(
+            ["org:sales:*", "org:sales:*", "org:marketing"]
+        )
+        assert out == ["org:sales:*", "org:marketing"]
+
+    def test_universal_wildcard_rejected(self):
+        with pytest.raises(ScopeValidationError) as exc:
+            normalise_and_validate_scopes(["*"])
+        assert "not assignable" in str(exc.value)
+
+    def test_forbidden_scopes_includes_universal(self):
+        assert "*" in FORBIDDEN_SCOPES
+
+    def test_namespaced_wildcard_accepted(self):
+        out = normalise_and_validate_scopes(["org:sales:*"])
+        assert out == ["org:sales:*"]
+
+    def test_mid_segment_wildcard_rejected(self):
+        with pytest.raises(ScopeValidationError) as exc:
+            normalise_and_validate_scopes(["org:*:leads"])
+        assert "mid-segment wildcard" in str(exc.value)
+
+    def test_empty_segment_rejected(self):
+        with pytest.raises(ScopeValidationError):
+            normalise_and_validate_scopes(["org::leads"])
+
+    def test_leading_colon_rejected(self):
+        with pytest.raises(ScopeValidationError):
+            normalise_and_validate_scopes([":leads"])
+
+    def test_uppercase_mixed_segment_rejected_after_normalise(self):
+        # Weird chars that survive lowercase still fail the [a-z0-9]+ rule.
+        with pytest.raises(ScopeValidationError):
+            normalise_and_validate_scopes(["org:sales-team"])
+
+    def test_non_string_rejected(self):
+        with pytest.raises(ScopeValidationError):
+            normalise_and_validate_scopes([123])  # type: ignore[list-item]
+
+    def test_empty_string_rejected(self):
+        with pytest.raises(ScopeValidationError):
+            normalise_and_validate_scopes([""])
+
+
+class TestAdminCanAssignScopes:
+    def test_empty_admin_scope_permits_anything_non_forbidden(self):
+        # Admins without an explicit scope narrowing sit at workspace root.
+        assert admin_can_assign_scopes(None, ["org:sales:leads"]) is True
+        assert admin_can_assign_scopes([], ["org:sales:*"]) is True
+
+    def test_empty_request_is_always_allowed(self):
+        # Clearing scopes on an agent (assigning []) is always fine.
+        assert admin_can_assign_scopes(["org:sales:*"], []) is True
+
+    def test_exact_match_allowed(self):
+        assert admin_can_assign_scopes(["org:sales:leads"], ["org:sales:leads"]) is True
+
+    def test_glob_admin_covers_descendant(self):
+        assert admin_can_assign_scopes(["org:sales:*"], ["org:sales:leads"]) is True
+
+    def test_glob_admin_covers_itself(self):
+        assert admin_can_assign_scopes(["org:sales:*"], ["org:sales"]) is True
+
+    def test_admin_cannot_escape_own_scope(self):
+        # Admin scoped to sales cannot assign the agent to marketing.
+        assert admin_can_assign_scopes(["org:sales:*"], ["org:marketing:leads"]) is False
+
+    def test_admin_cannot_assign_wider_glob(self):
+        # Admin scoped to org:sales:leads cannot assign org:sales:* (wider).
+        assert admin_can_assign_scopes(["org:sales:leads"], ["org:sales:*"]) is False
+
+    def test_partial_overlap_rejected(self):
+        # Any request scope outside admin's grant flips the whole check.
+        granted = ["org:sales:*"]
+        requested = ["org:sales:leads", "org:marketing:emails"]
+        assert admin_can_assign_scopes(granted, requested) is False
+
+    def test_multi_admin_scopes_cover_union(self):
+        granted = ["org:sales:*", "org:marketing:*"]
+        requested = ["org:sales:leads", "org:marketing:emails"]
+        assert admin_can_assign_scopes(granted, requested) is True
+
+    def test_wildcard_admin_covers_all(self):
+        assert admin_can_assign_scopes(["*"], ["org:anything:here"]) is True


### PR DESCRIPTION
## Summary

Adds the backend for Cluster D, D1 — agent scope picker. A dedicated
`GET`/`PATCH /agents/{id}/scope` pair backs the existing `ScopePicker`
component so a workspace admin can narrow an agent's retrieval reach
to a hierarchical scope tag (`org:sales:*`) without round-tripping
the whole agent document.

The tag grammar mirrors `src/lib/scope/normalise.ts` on the frontend:
lowercase colon-separated `[a-z0-9]+` segments, terminal-only
wildcards, deduped + case-normalised. The universal `*` scope is
rejected server side — scope-everything needs a deliberate
infra-level grant, not an admin-UI click. Every write re-runs the
validator in the Pydantic `ScopeAssignmentRequest` plus the service
layer (`AgentService.set_scopes`) so a fleet installer calling the
service directly cannot bypass the check.

### What landed

- `ee/cloud/agents/scope_rules.py` — scope grammar validator +
  `admin_can_assign_scopes` hierarchical containment helper.
- `ee/cloud/agents/schemas.py` — `scopes` field on
  `CreateAgentRequest` / `UpdateAgentRequest`,
  `ScopeAssignmentRequest` + `ScopeAssignmentResponse` envelopes.
- `ee/cloud/agents/router.py` — `GET`/`PATCH /agents/{id}/scope`
  gated by `require_agent_owner_or_admin`.
- `ee/cloud/agents/service.py` — `get_scopes`, `set_scopes`, +
  creation path persists any scope list supplied on create.
- `ee/cloud/models/agent.py` — `scopes: list[str]` on `AgentConfig`.

### Tests

Layer 1 + 2 (unit + schema):

- `tests/cloud/test_agent_scope_rules.py` — 22 unit tests: grammar,
  forbidden scopes, hierarchical admin-assignability.
- `tests/cloud/test_agent_schemas.py` — 10 new schema tests for
  scope normalisation on create/update + `ScopeAssignmentRequest`.

```
53 passed in 2.77s
```

### Plan + reality

- Plan: [`docs/plans/FEATURE-HARDENING-PLAN.md`](../../../docs/plans/FEATURE-HARDENING-PLAN.md)
  Cluster D, row D1.
- Reality brief:
  [`docs/plans/cluster-D-reality.md`](../../../docs/plans/cluster-D-reality.md)
  section _Scope picker authorisation_.

Paired frontend PR: `qbtrix/paw-enterprise#feat/cluster-d-agent-scope-picker`.

## Test plan

- [x] `uv run pytest tests/cloud/test_agent_schemas.py tests/cloud/test_agent_scope_rules.py`
- [ ] Integration: PATCH with forbidden scope (`"*"`) returns 422.
- [ ] Integration: PATCH with valid `org:sales:*` persists + GET returns it.
- [ ] Integration: non-admin non-owner PATCH returns 403.