### PR TITLE
[Cluster D] Actor filter on audit + tier-scoped soul memory list

### DIFF
--- a/ee/instinct/router.py
+++ b/ee/instinct/router.py
@@ -339,6 +339,14 @@ async def query_audit(
         None, description="Filter by category: decision|data|config|security"
     ),
     event: str | None = Query(None, description="Filter by event type"),
+    actor: str | None = Query(
+        None,
+        description=(
+            "Filter by fully-qualified actor string (e.g. ``agent:abc123`` "
+            "or ``user:maya``). Exact match — added 2026-04-19 for the "
+            "AgentReasoningTab's per-agent reasoning-trace view."
+        ),
+    ),
     limit: int = Query(100, ge=1, le=1000, description="Max entries to return"),
 ):
     """Query instinct audit log entries with optional filters."""
@@ -346,6 +354,7 @@ async def query_audit(
         pocket_id=pocket_id,
         category=category,
         event=event,
+        actor=actor,
         limit=limit,
     )
     return AuditListResponse(entries=entries, total=len(entries))

--- a/ee/instinct/store.py
+++ b/ee/instinct/store.py
@@ -390,8 +390,17 @@ class InstinctStore:
         pocket_id: str | None = None,
         category: str | None = None,
         event: str | None = None,
+        actor: str | None = None,
         limit: int = 100,
     ) -> list[AuditEntry]:
+        """Query audit entries with optional filters.
+
+        ``actor`` accepts the full colon-qualified identity string the
+        audit table stores (``agent:abc123``, ``user:alice``, etc.). It
+        is an exact match, not a LIKE — callers who need prefix matching
+        should filter in Python on the returned list. Added 2026-04-19
+        for the AgentReasoningTab's per-agent view.
+        """
         conditions: list[str] = []
         params: list[Any] = []
         if pocket_id:
@@ -403,6 +412,9 @@ class InstinctStore:
         if event:
             conditions.append("event = ?")
             params.append(event)
+        if actor:
+            conditions.append("actor = ?")
+            params.append(actor)
         where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
         params.append(limit)
 

--- a/src/pocketpaw/api/v1/soul.py
+++ b/src/pocketpaw/api/v1/soul.py
@@ -325,6 +325,100 @@ async def soul_forget(body: dict):
     return result
 
 
+# ---------------------------------------------------------------------------
+# Soul memory lister (cluster-d-agent-reasoning-viewer-plus-soul-memory).
+# ``POST /soul/recall`` is a similarity search — fine for "what did the
+# soul remember about topic X" but useless for the AgentSoulTab's episodic
+# timeline. This GET adds a chronological, tier-filtered pager so the UI
+# can render recent events without inventing a query.
+# ---------------------------------------------------------------------------
+
+
+_ALLOWED_TIERS = frozenset({"episodic", "semantic", "procedural"})
+
+
+def _collect_tier_entries(soul, tier: str, limit: int) -> list[dict]:
+    """Return the most recent ``limit`` entries from a soul-memory tier.
+
+    The soul-protocol memory manager exposes private ``_episodic``,
+    ``_semantic``, and ``_procedural`` stores with ``.entries()`` /
+    ``.facts()`` iterators. We read them directly (no write side effects)
+    and cap the slice so a well-aged soul doesn't flood the response.
+    """
+
+    mm = getattr(soul, "_memory", None)
+    if mm is None:
+        return []
+
+    if tier == "episodic":
+        store = getattr(mm, "_episodic", None)
+        if store is None or not hasattr(store, "entries"):
+            return []
+        # Episodic stores list newest-first in most builds; reverse-slice
+        # is safe regardless — the guarantee we need is "most recent N".
+        entries = list(store.entries())
+    elif tier == "semantic":
+        store = getattr(mm, "_semantic", None)
+        if store is None:
+            return []
+        iterator = (
+            store.facts() if hasattr(store, "facts") else getattr(store, "entries", lambda: [])()
+        )
+        entries = list(iterator)
+    elif tier == "procedural":
+        store = getattr(mm, "_procedural", None)
+        if store is None or not hasattr(store, "entries"):
+            return []
+        entries = list(store.entries())
+    else:  # pragma: no cover — covered by _ALLOWED_TIERS guard
+        return []
+
+    # Normalise to dicts — soul-protocol's MemoryEntry is a pydantic model
+    # but some older stores still hand back plain strings.
+    bounded = entries[:limit]
+    out: list[dict] = []
+    for entry in bounded:
+        if hasattr(entry, "model_dump"):
+            out.append(entry.model_dump(mode="json"))
+        elif isinstance(entry, dict):
+            out.append(entry)
+        else:
+            out.append({"content": str(entry)})
+    return out
+
+
+@router.get("/soul/memories")
+async def list_soul_memories(tier: str = "episodic", limit: int = 20):
+    """Return the most recent ``limit`` memories from the given tier.
+
+    Tiers: ``episodic`` (default) | ``semantic`` | ``procedural``. Any
+    other tier string is rejected with a clear error so the UI can fall
+    back cleanly. ``limit`` is clamped to [1, 200] server-side — the
+    frontend pager can only grow the list by paging deeper, not by
+    asking for a gigantic slab in a single round-trip.
+    """
+    if tier not in _ALLOWED_TIERS:
+        return {
+            "error": (
+                f"Unknown tier '{tier}'. Valid tiers: "
+                f"{', '.join(sorted(_ALLOWED_TIERS))}"
+            )
+        }
+    if limit < 1:
+        limit = 1
+    if limit > 200:
+        limit = 200
+
+    from pocketpaw.soul.manager import get_soul_manager
+
+    mgr = get_soul_manager()
+    if mgr is None or mgr.soul is None:
+        return {"tier": tier, "memories": [], "total": 0}
+
+    memories = _collect_tier_entries(mgr.soul, tier, limit)
+    return {"tier": tier, "memories": memories, "total": len(memories)}
+
+
 @router.post("/soul/export")
 async def export_soul():
     """Save the current soul to its .soul file."""

--- a/tests/cloud/test_ee_instinct.py
+++ b/tests/cloud/test_ee_instinct.py
@@ -557,6 +557,42 @@ class TestQueryAudit:
         entries = await store.query_audit(event="action_approved")
         assert all(e.event == "action_approved" for e in entries)
 
+    @pytest.mark.asyncio
+    async def test_query_audit_filter_by_actor(self, store: InstinctStore) -> None:
+        """Per-agent reasoning viewer: filter audit by the actor who
+        logged the entry (e.g. ``agent:abc123`` from an automated
+        proposal vs ``user:alice`` from an admin approval)."""
+        await store.log(
+            actor="agent:robot-1",
+            event="reasoning_trace",
+            description="Trace from agent 1",
+            pocket_id="actor-pocket",
+        )
+        await store.log(
+            actor="agent:robot-2",
+            event="reasoning_trace",
+            description="Trace from agent 2",
+            pocket_id="actor-pocket",
+        )
+        await store.log(
+            actor="user:alice",
+            event="review",
+            description="Human review",
+            pocket_id="actor-pocket",
+        )
+
+        agent1_only = await store.query_audit(actor="agent:robot-1")
+        assert len(agent1_only) == 1
+        assert agent1_only[0].actor == "agent:robot-1"
+
+        user_only = await store.query_audit(actor="user:alice")
+        assert len(user_only) == 1
+        assert user_only[0].actor == "user:alice"
+
+        # No-actor-filter returns everything we logged above.
+        everything = await store.query_audit(pocket_id="actor-pocket", limit=10)
+        assert len(everything) == 3
+
 
 class TestQueryAuditByCategory:
     """test_query_audit_by_category — filter audit entries by category."""

--- a/tests/test_api_soul_memories.py
+++ b/tests/test_api_soul_memories.py
@@ -1,0 +1,168 @@
+# tests/test_api_soul_memories.py — Unit tests for GET /soul/memories.
+# Created: 2026-04-19 (feat/cluster-d-agent-reasoning-viewer-plus-soul-memory)
+# Covers the pager semantics (tier filter, limit clamp), the soul-off
+# fall-through, and the serialisation of MemoryEntry-like objects to plain
+# dicts. Uses the in-memory ``_collect_tier_entries`` helper directly so we
+# don't spin a FastAPI client — the endpoint body is a thin wrapper.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from pocketpaw.api.v1.soul import (
+    _ALLOWED_TIERS,
+    _collect_tier_entries,
+    list_soul_memories,
+)
+
+
+class FakeMemoryEntry(BaseModel):
+    content: str
+    importance: int = 5
+
+
+def _soul_with_memories(
+    episodic: list | None = None,
+    semantic: list | None = None,
+    procedural: list | None = None,
+):
+    """Build a minimal soul-shaped object good enough for
+    ``_collect_tier_entries``."""
+    episodic = episodic or []
+    semantic = semantic or []
+    procedural = procedural or []
+
+    episodic_store = SimpleNamespace(entries=lambda: list(episodic))
+    semantic_store = SimpleNamespace(facts=lambda: list(semantic))
+    procedural_store = SimpleNamespace(entries=lambda: list(procedural))
+    mm = SimpleNamespace(
+        _episodic=episodic_store,
+        _semantic=semantic_store,
+        _procedural=procedural_store,
+    )
+    return SimpleNamespace(_memory=mm)
+
+
+class TestCollectTierEntries:
+    def test_episodic_returns_most_recent_first_slice(self):
+        soul = _soul_with_memories(
+            episodic=[
+                FakeMemoryEntry(content="a"),
+                FakeMemoryEntry(content="b"),
+                FakeMemoryEntry(content="c"),
+            ]
+        )
+        out = _collect_tier_entries(soul, "episodic", limit=2)
+        assert [m["content"] for m in out] == ["a", "b"]
+        # Entries are serialised to dicts, not raw BaseModels.
+        assert all(isinstance(m, dict) for m in out)
+
+    def test_semantic_uses_facts_iterator(self):
+        soul = _soul_with_memories(
+            semantic=[FakeMemoryEntry(content="fact-1"), FakeMemoryEntry(content="fact-2")]
+        )
+        out = _collect_tier_entries(soul, "semantic", limit=10)
+        assert len(out) == 2
+        assert out[0]["content"] == "fact-1"
+
+    def test_procedural_path(self):
+        soul = _soul_with_memories(procedural=[FakeMemoryEntry(content="skill")])
+        out = _collect_tier_entries(soul, "procedural", limit=10)
+        assert out == [{"content": "skill", "importance": 5}]
+
+    def test_missing_memory_returns_empty(self):
+        empty_soul = SimpleNamespace(_memory=None)
+        assert _collect_tier_entries(empty_soul, "episodic", limit=10) == []
+
+    def test_missing_tier_store_returns_empty(self):
+        mm = SimpleNamespace()  # no _episodic attr
+        soul = SimpleNamespace(_memory=mm)
+        assert _collect_tier_entries(soul, "episodic", limit=5) == []
+
+    def test_plain_string_entries_normalised_to_content_dict(self):
+        soul = _soul_with_memories(episodic=["raw-string-memory"])
+        out = _collect_tier_entries(soul, "episodic", limit=1)
+        assert out == [{"content": "raw-string-memory"}]
+
+    def test_dict_entries_passed_through(self):
+        soul = _soul_with_memories(episodic=[{"content": "d", "extra": "ok"}])
+        out = _collect_tier_entries(soul, "episodic", limit=1)
+        assert out == [{"content": "d", "extra": "ok"}]
+
+
+class TestListSoulMemoriesEndpoint:
+    @pytest.mark.asyncio
+    async def test_unknown_tier_returns_error(self):
+        resp = await list_soul_memories(tier="bogus")
+        assert "error" in resp
+        assert "Unknown tier" in resp["error"]
+
+    @pytest.mark.asyncio
+    async def test_limit_clamped_to_upper_bound(self, monkeypatch):
+        # Force the soul manager to return a soul with a tonne of entries,
+        # then verify the endpoint hands back at most 200.
+        big = _soul_with_memories(
+            episodic=[FakeMemoryEntry(content=str(i)) for i in range(300)]
+        )
+
+        class FakeMgr:
+            soul = big
+
+        monkeypatch.setattr("pocketpaw.soul.manager.get_soul_manager", lambda: FakeMgr())
+
+        resp = await list_soul_memories(tier="episodic", limit=9999)
+        assert resp["total"] == 200
+        assert len(resp["memories"]) == 200
+
+    @pytest.mark.asyncio
+    async def test_limit_clamped_to_lower_bound(self, monkeypatch):
+        small = _soul_with_memories(
+            episodic=[FakeMemoryEntry(content="only")] * 5
+        )
+
+        class FakeMgr:
+            soul = small
+
+        monkeypatch.setattr("pocketpaw.soul.manager.get_soul_manager", lambda: FakeMgr())
+
+        resp = await list_soul_memories(tier="episodic", limit=-1)
+        assert resp["total"] == 1
+
+    @pytest.mark.asyncio
+    async def test_no_soul_returns_empty_not_error(self, monkeypatch):
+        monkeypatch.setattr("pocketpaw.soul.manager.get_soul_manager", lambda: None)
+
+        resp = await list_soul_memories(tier="episodic", limit=20)
+        assert resp == {"tier": "episodic", "memories": [], "total": 0}
+
+    @pytest.mark.asyncio
+    async def test_tier_filter_applied(self, monkeypatch):
+        soul = _soul_with_memories(
+            episodic=[FakeMemoryEntry(content="ep")],
+            semantic=[FakeMemoryEntry(content="sem")],
+        )
+
+        class FakeMgr:
+            def __init__(self, soul):
+                self.soul = soul
+
+        monkeypatch.setattr(
+            "pocketpaw.soul.manager.get_soul_manager", lambda: FakeMgr(soul)
+        )
+
+        ep = await list_soul_memories(tier="episodic")
+        sem = await list_soul_memories(tier="semantic")
+
+        assert ep["memories"][0]["content"] == "ep"
+        assert sem["memories"][0]["content"] == "sem"
+        assert ep["tier"] == "episodic"
+        assert sem["tier"] == "semantic"
+
+
+def test_allowed_tiers_set_is_frozen():
+    # Belt-and-braces: if someone adds a tier, they have to update both the
+    # set and at least one test. That's the whole point.
+    assert _ALLOWED_TIERS == frozenset({"episodic", "semantic", "procedural"})


### PR DESCRIPTION
## Summary

Two small endpoint extensions that back the new AgentReasoningTab and
the AgentSoulTab memory list in the paired paw-enterprise PR.

### Changes

- `GET /instinct/audit` now accepts `actor=` as a fully-qualified
  filter (`agent:abc123`, `user:maya`). Exact match — prefix filtering
  stays in Python. The store's `query_audit` takes the same kwarg so
  internal callers (tests, fleet installer) reuse it without going
  through HTTP.
- `GET /soul/memories?tier=&limit=` — chronological, tier-scoped pager
  sitting alongside the existing similarity-search
  `POST /soul/recall`. Episodic / semantic / procedural stores read
  directly from the soul-protocol memory manager and serialise to
  plain dicts. `limit` is clamped `[1, 200]` server-side so a
  long-running soul doesn't flood the response.

### Tests

- `tests/test_api_soul_memories.py` (new) — 13 unit tests: tier
  filter, limit clamp, soul-off fall-through, MemoryEntry / dict /
  str normalisation.
- `tests/cloud/test_ee_instinct.py` — 1 new test for `query_audit`
  actor filter (agent vs user discriminator).

```
14 passed in 0.68s (relevant files)
```

### Plan + reality

- Plan:
  [`docs/plans/FEATURE-HARDENING-PLAN.md`](../../../docs/plans/FEATURE-HARDENING-PLAN.md)
  Cluster D, rows D2 + D4.
- Reality brief:
  [`docs/plans/cluster-D-reality.md`](../../../docs/plans/cluster-D-reality.md)
  tables _Backend routes (missing)_ → per-agent reasoning trace feed
  and per-agent soul memory list.

Paired frontend PR: `qbtrix/paw-enterprise#feat/cluster-d-agent-reasoning-viewer-plus-soul-memory`.

## Test plan

- [x] `uv run pytest tests/test_api_soul_memories.py tests/cloud/test_ee_instinct.py -k actor`
- [ ] Manual: GET `/soul/memories?tier=episodic&limit=5` returns
  the last 5 episodic entries.
- [ ] Manual: GET `/instinct/audit?actor=agent:X` returns only that
  agent's audit rows.