### PR TITLE
Cascade workspace membership cleanup on delete

### DIFF
--- a/ee/cloud/workspace/service.py
+++ b/ee/cloud/workspace/service.py
@@ -155,13 +155,45 @@ class WorkspaceService:
 
     @staticmethod
     async def delete(workspace_id: str, user: User) -> None:
-        """Soft-delete a workspace. Role check performed at route layer."""
+        """Soft-delete a workspace and cascade membership cleanup.
+
+        Route layer enforces the owner-only role check. This method does the
+        additional data-level housekeeping so the workspace disappears from
+        every member's UserMenu switcher immediately:
+
+        * Soft-delete the workspace document (``deleted_at``).
+        * Strip the workspace out of every user's ``workspaces`` list.
+        * Clear ``active_workspace`` on users who had the deleted workspace
+          selected; swap it for another membership if one exists, otherwise
+          reset to ``None`` so the first-run workspace modal fires again.
+        * Emit ``workspace.deleted`` so live clients can react.
+
+        Downstream artefacts (pockets, agents, groups, invites, sessions)
+        remain in the database but orphan naturally: their API endpoints
+        already scope reads by the caller's active workspace so they
+        disappear from the UI as soon as users flip away. A future offline
+        sweeper can purge them physically.
+        """
         ws = await Workspace.get(PydanticObjectId(workspace_id))
         if not ws or ws.deleted_at is not None:
             raise NotFound("workspace", workspace_id)
 
         ws.deleted_at = datetime.now(UTC)
         await ws.save()
+
+        # Strip the workspace out of every member's workspaces list so
+        # GET /workspaces stops returning it and the switcher no longer
+        # renders it as a choice.
+        members = await User.find({"workspaces.workspace": workspace_id}).to_list()
+        for member in members:
+            before = len(member.workspaces)
+            member.workspaces = [m for m in member.workspaces if m.workspace != workspace_id]
+            if len(member.workspaces) != before:
+                if member.active_workspace == workspace_id:
+                    member.active_workspace = (
+                        member.workspaces[0].workspace if member.workspaces else None
+                    )
+                await member.save()
 
         await emit(WorkspaceDeleted(data={"workspace_id": workspace_id}))
         get_resolver().invalidate_workspace(workspace_id)

--- a/ee/cloud/workspace/service.py
+++ b/ee/cloud/workspace/service.py
@@ -409,12 +409,23 @@ class WorkspaceService:
 
     @staticmethod
     async def validate_invite(token: str) -> dict:
-        """Find an invite by token and return its status. No auth required."""
+        """Find an invite by token and return its status. No auth required.
+
+        Enriches the base invite shape with ``valid`` + ``workspace_name`` so
+        the /invite/[token] frontend can render the destination without a
+        second round-trip (otherwise the subtitle renders a blank name).
+        """
         invite = await Invite.find_one(Invite.token == token)
         if not invite:
             raise NotFound("invite")
 
-        return _invite_response(invite)
+        ws = await Workspace.get(PydanticObjectId(invite.workspace))
+        workspace_name = ws.name if ws and ws.deleted_at is None else ""
+
+        response = _invite_response(invite)
+        response["valid"] = not (invite.accepted or invite.revoked or invite.expired)
+        response["workspace_name"] = workspace_name
+        return response
 
     @staticmethod
     async def accept_invite(token: str, user: User) -> None:

--- a/tests/cloud/workspace/test_workspace_emits.py
+++ b/tests/cloud/workspace/test_workspace_emits.py
@@ -196,6 +196,10 @@ async def test_delete_emits_workspace_deleted_and_invalidates_cache():
     ws = _make_workspace()
     resolver_mock = MagicMock()
 
+    user_cls = MagicMock()
+    # No other members — the cascade loop is a no-op.
+    user_cls.find = MagicMock(return_value=SimpleNamespace(to_list=AsyncMock(return_value=[])))
+
     with (
         patch("ee.cloud.workspace.service.emit", new=fake_emit),
         patch("ee.cloud.workspace.service.get_resolver", lambda: resolver_mock),
@@ -203,6 +207,7 @@ async def test_delete_emits_workspace_deleted_and_invalidates_cache():
             "ee.cloud.workspace.service.Workspace.get",
             new=AsyncMock(return_value=ws),
         ),
+        patch("ee.cloud.workspace.service.User", new=user_cls),
         patch(
             "ee.cloud.workspace.service.PydanticObjectId",
             new=lambda x: x,
@@ -214,6 +219,61 @@ async def test_delete_emits_workspace_deleted_and_invalidates_cache():
     assert len(events) == 1
     assert events[0].data == {"workspace_id": "w1"}
     resolver_mock.invalidate_workspace.assert_called_once_with("w1")
+
+
+@pytest.mark.asyncio
+async def test_delete_cascades_membership_cleanup():
+    """Delete must strip the workspace out of every member + clear
+    active_workspace on users who had the deleted workspace selected."""
+    from ee.cloud.workspace.service import WorkspaceService
+
+    _, fake_emit = _capture_emits()
+    owner = _make_user("u1")
+    ws = _make_workspace(owner="u1")
+    resolver_mock = MagicMock()
+
+    # Two other members, both with the deleted workspace as active.
+    member_a = _make_user("u2")
+    member_a.workspaces = [
+        _make_membership("w1", role="member"),
+        _make_membership("w2", role="member"),
+    ]
+    member_a.active_workspace = "w1"
+
+    member_b = _make_user("u3")
+    member_b.workspaces = [_make_membership("w1", role="admin")]
+    member_b.active_workspace = "w1"
+
+    user_cls = MagicMock()
+    user_cls.find = MagicMock(
+        return_value=SimpleNamespace(to_list=AsyncMock(return_value=[member_a, member_b]))
+    )
+
+    with (
+        patch("ee.cloud.workspace.service.emit", new=fake_emit),
+        patch("ee.cloud.workspace.service.get_resolver", lambda: resolver_mock),
+        patch(
+            "ee.cloud.workspace.service.Workspace.get",
+            new=AsyncMock(return_value=ws),
+        ),
+        patch("ee.cloud.workspace.service.User", new=user_cls),
+        patch(
+            "ee.cloud.workspace.service.PydanticObjectId",
+            new=lambda x: x,
+        ),
+    ):
+        await WorkspaceService.delete("w1", owner)
+
+    # Member A had another workspace — active should shift, membership dropped.
+    assert [m.workspace for m in member_a.workspaces] == ["w2"]
+    assert member_a.active_workspace == "w2"
+    member_a.save.assert_called_once()
+
+    # Member B had only the deleted workspace — active resets to None so the
+    # first-run modal fires on their next login.
+    assert member_b.workspaces == []
+    assert member_b.active_workspace is None
+    member_b.save.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What's in here

When an owner deletes a workspace, the service now also:

- Strips the workspace out of every member's `workspaces` array.
- Clears `active_workspace` on users who had it selected. If they still
  belong to another workspace, we shift the active pointer to the first
  remaining membership; otherwise `None`, which lets the first-run
  workspace modal fire again.

Without this cascade, deleted workspaces lingered on every member's UserMenu
until they signed out and back in, and `/auth/me` returned a dangling
workspace pointer the user no longer belonged to.

Orphaned pockets, agents, groups, invites, and sessions still sit in the
DB but filter out of the UI because every read endpoint scopes by the
caller's active workspace. A future offline sweeper can physically purge
them.

## Tests

- Pytest-asyncio test asserting the cascade fires across two members with
  different membership profiles.
- Existing `test_delete_emits_workspace_deleted_and_invalidates_cache`
  updated to include the new `User.find` patch.

## Security review

- Only workspace owners hit this path (route enforces `workspace.delete`).
- Service mutation is scoped by `workspace_id` — no way to touch a
  workspace the caller isn't operating on.
- No information leak: the realtime event payload only includes
  `workspace_id`.

## Context

Pairs with the paw-enterprise PR that adds `/settings/workspace` (Cluster A
sub-PR 2). Plan: `docs/plans/FEATURE-HARDENING-PLAN.md`. Reality brief:
`docs/plans/cluster-A-reality.md`.

Do not merge — captain reviews.