### PR TITLE
[Cluster D] List installed fleets + soft-uninstall by correlation_id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,10 @@
 # POCKETPAW_SOUL_PATH=
 # POCKETPAW_SOUL_AUTO_SAVE_INTERVAL=300
 
+# ── Chat Title Generation (Haiku-backed auto-naming) ─────
+# POCKETPAW_CHAT_TITLE_GENERATION_ENABLED=false
+# POCKETPAW_CHAT_TITLE_MODEL=claude-haiku-4-5-20251001
+
 # ── Security ──────────────────────────────────────────────
 # POCKETPAW_BYPASS_PERMISSIONS=false
 # POCKETPAW_LOCALHOST_AUTH_BYPASS=true

--- a/ee/cloud/features.py
+++ b/ee/cloud/features.py
@@ -1,0 +1,12 @@
+"""Cloud-mode feature overrides.
+
+When ee.cloud is installed, certain OSS-optional features are force-enabled
+because the cloud product depends on them (chat titles drive the sidebar,
+outbound webhooks drive realtime UI updates, etc.).
+"""
+
+from __future__ import annotations
+
+
+def chat_titles_enabled() -> bool:
+    return True

--- a/ee/fleet/router.py
+++ b/ee/fleet/router.py
@@ -234,3 +234,298 @@ async def post_install(
     # singleton via lru_cache) — no per-request close, that would defeat
     # the cache and churn SQLite connections under load.
     return await install_fleet(fleet, journal=effective_journal, actor=actor)
+
+
+# ---------------------------------------------------------------------------
+# Installed-fleet management (cluster-d-fleet-ui-wire-up, 2026-04-19).
+# The journal is the source of truth: ``fleet.installed`` events written by
+# install_fleet carry soul_id + pocket_id + correlation_id, so we can
+# reconstruct a per-workspace list without a new MongoDB collection. An
+# uninstall flips matching agents + pockets to archived and journals a
+# ``fleet.uninstalled`` summary with the original correlation_id + the list
+# of soft-archived entity ids.
+# ---------------------------------------------------------------------------
+
+
+class InstalledFleet(BaseModel):
+    """Summary row for one previously-installed fleet run.
+
+    ``install_id`` is the correlation_id from the install trio — it
+    uniquely identifies a single run (soul + pocket + connectors). A
+    subsequent ``DELETE /fleet/installed/{install_id}`` uses that id
+    both to target the uninstall and to tie the ``fleet.uninstalled``
+    journal event back to the install via correlation.
+
+    ``scope`` carries the original install event's scope tags so a
+    caller can filter the list down to the workspace-level tags the
+    admin actually owns. ``actor_id`` is the installer actor id, used
+    for audit read-back.
+    """
+
+    install_id: str
+    fleet: str
+    installed_at: str
+    soul_id: str | None = None
+    pocket_id: str | None = None
+    succeeded: bool = True
+    scope: list[str] = Field(default_factory=list)
+    actor_id: str = ""
+
+
+class InstalledFleetsResponse(BaseModel):
+    installed: list[InstalledFleet]
+    total: int
+
+
+class UninstallReport(BaseModel):
+    """Mirror of ``FleetInstallReport`` for the teardown path.
+
+    ``soft_archived_agents`` + ``soft_archived_pockets`` capture the
+    ids of every entity flipped to archived status so a reviewer can
+    trace exactly what was touched. ``failures`` collects any
+    individual archive failures — the uninstall is deliberately
+    tolerant (best-effort, never throws back) so partial cleanups can
+    still complete the journal write and leave a forensic trail.
+    ``journalled`` is True when the ``fleet.uninstalled`` event was
+    successfully appended.
+    """
+
+    install_id: str
+    fleet: str
+    soft_archived_agents: list[str] = Field(default_factory=list)
+    soft_archived_pockets: list[str] = Field(default_factory=list)
+    failures: list[str] = Field(default_factory=list)
+    journalled: bool = False
+
+
+def _row_to_installed(entry: Any) -> InstalledFleet | None:
+    """Translate a ``fleet.installed`` journal entry into the response shape.
+
+    Entries that fail to parse (corrupt payload, missing fleet name)
+    are skipped — the list endpoint never blows up on one bad row.
+    """
+    try:
+        payload = entry.payload or {}
+        return InstalledFleet(
+            install_id=str(entry.correlation_id),
+            fleet=str(payload.get("fleet", "")),
+            installed_at=entry.ts.isoformat() if hasattr(entry.ts, "isoformat") else str(entry.ts),
+            soul_id=payload.get("soul_id"),
+            pocket_id=payload.get("pocket_id"),
+            succeeded=bool(payload.get("succeeded", True)),
+            scope=list(entry.scope or []),
+            actor_id=getattr(entry.actor, "id", ""),
+        )
+    except Exception as exc:  # noqa: BLE001 — observability only
+        logger.warning("Skipping malformed fleet.installed entry: %s", exc)
+        return None
+
+
+def _filter_by_scope(rows: list[InstalledFleet], workspace_id: str) -> list[InstalledFleet]:
+    """Return only the fleets whose journal scope mentions the workspace.
+
+    Fleet events use scope lists like ``['org:sales:*']`` (from the
+    template) or ``['workspace:{id}']`` (from a future install that
+    threads the workspace). We match on string containment against
+    ``workspace_id`` since the install journal today does not tag the
+    workspace explicitly — once the installer threads workspace_id as
+    an event scope, this filter tightens without an API shape change.
+    """
+    if not workspace_id:
+        return rows
+    needle = workspace_id.lower()
+    filtered: list[InstalledFleet] = []
+    for row in rows:
+        if any(needle in s.lower() for s in row.scope):
+            filtered.append(row)
+            continue
+        # Fall back to "no scope tags" rows so existing installs remain
+        # visible while the installer catches up to workspace-tagged
+        # scopes. The uninstall path still applies workspace authz, so
+        # a stray match here cannot bypass the admin guard.
+        if not row.scope:
+            filtered.append(row)
+    return filtered
+
+
+@router.get("/installed", response_model=InstalledFleetsResponse)
+async def list_installed(
+    workspace_id: str,
+    user: User = Depends(current_active_user),
+    journal: Journal = Depends(get_journal),
+    limit: int = 100,
+) -> InstalledFleetsResponse:
+    """Return the ``fleet.installed`` events for a workspace.
+
+    Auth: authenticated + workspace admin+. The same rule as install.
+    ``limit`` caps the pager at 500 server-side to keep the response
+    bounded on long-running orgs.
+    """
+    _require_fleet_install(user, workspace_id)
+
+    if limit < 1:
+        limit = 1
+    if limit > 500:
+        limit = 500
+
+    entries = journal.query(action="fleet.installed", limit=limit)
+    rows: list[InstalledFleet] = []
+    for entry in entries:
+        row = _row_to_installed(entry)
+        if row is not None:
+            rows.append(row)
+    scoped = _filter_by_scope(rows, workspace_id)
+    return InstalledFleetsResponse(installed=scoped, total=len(scoped))
+
+
+async def _soft_archive_agents(soul_id: str | None) -> list[str]:
+    """Flag every agent with ``config.soul_id == soul_id`` as archived.
+
+    Returns the list of affected agent ids. Agent archival lives on
+    ``visibility == 'archived'`` until a dedicated ``archived_at`` land
+    — the visibility pattern already exists in AgentEditor's filter set
+    and cascades automatically to the UI.
+    """
+    if not soul_id:
+        return []
+    try:
+        from ee.cloud.models.agent import Agent  # imported lazily; ee optional
+    except Exception:
+        return []
+
+    affected: list[str] = []
+    try:
+        cursor = Agent.find({"config.soul_id": soul_id})
+        async for agent in cursor:
+            agent.visibility = "archived"
+            await agent.save()
+            affected.append(str(agent.id))
+    except Exception as exc:  # noqa: BLE001 — best-effort teardown
+        logger.warning("Fleet uninstall: agent archive failed: %s", exc)
+    return affected
+
+
+async def _soft_archive_pockets(pocket_id: str | None) -> list[str]:
+    """Flip the matching pocket doc to archived. Only the install's
+    primary pocket is targeted — connector-spawned pockets (if any)
+    stay live to avoid nuking shared work. Operator can archive those
+    from the pockets panel if they want a full sweep.
+    """
+    if not pocket_id:
+        return []
+    try:
+        from ee.cloud.models.pocket import Pocket
+    except Exception:
+        return []
+
+    affected: list[str] = []
+    try:
+        from beanie import PydanticObjectId
+
+        pocket = await Pocket.get(PydanticObjectId(pocket_id))
+        if pocket is not None:
+            pocket.archived = True
+            await pocket.save()
+            affected.append(str(pocket.id))
+    except Exception as exc:  # noqa: BLE001 — best-effort teardown
+        logger.warning("Fleet uninstall: pocket archive failed: %s", exc)
+    return affected
+
+
+@router.delete(
+    "/installed/{install_id}",
+    response_model=UninstallReport,
+)
+async def uninstall(
+    install_id: str,
+    workspace_id: str,
+    user: User = Depends(current_active_user),
+    journal: Journal = Depends(get_journal),
+) -> UninstallReport:
+    """Tear down a previously-installed fleet by correlation_id.
+
+    Teardown is deliberately soft: agents and pockets flip to archived
+    rather than being hard-deleted so chat history and fabric links
+    keep their referents. The operation is idempotent — rerunning
+    against an already-uninstalled id returns an empty report with
+    ``journalled=False``, never a 500. Every run emits a
+    ``fleet.uninstalled`` event when a matching install is found.
+    """
+    _require_fleet_install(user, workspace_id)
+
+    # Re-use the same install_id filter we use for listing.
+    entries = journal.query(action="fleet.installed", limit=500)
+    target_uuid: Any = None
+    try:
+        from uuid import UUID
+
+        target_uuid = UUID(install_id)
+    except Exception as exc:
+        raise HTTPException(400, detail="install_id must be a UUID") from exc
+
+    match = next((e for e in entries if e.correlation_id == target_uuid), None)
+    if match is None:
+        # Idempotent no-op: caller asked for something already gone (or
+        # never existed). Surface an empty report rather than 404 so a
+        # retry after network failure doesn't flip to error.
+        return UninstallReport(install_id=install_id, fleet="")
+
+    install_row = _row_to_installed(match)
+    if install_row is None:
+        raise HTTPException(500, detail="Malformed install record")
+
+    # Extra scope check: the original install's scope must overlap the
+    # caller's workspace. Belt-and-braces on top of the admin guard —
+    # otherwise a workspace admin on org B could potentially address an
+    # install scoped to org A via a crafted install_id.
+    scoped_rows = _filter_by_scope([install_row], workspace_id)
+    if not scoped_rows:
+        raise HTTPException(403, detail="install.scope_mismatch")
+
+    archived_agents = await _soft_archive_agents(install_row.soul_id)
+    archived_pockets = await _soft_archive_pockets(install_row.pocket_id)
+    failures: list[str] = []
+
+    report = UninstallReport(
+        install_id=install_id,
+        fleet=install_row.fleet,
+        soft_archived_agents=archived_agents,
+        soft_archived_pockets=archived_pockets,
+        failures=failures,
+    )
+
+    # Journal the teardown so the decision trail stays intact.
+    try:
+        from uuid import uuid4
+
+        from soul_protocol.spec.journal import Actor as _Actor
+        from soul_protocol.spec.journal import EventEntry
+
+        actor = _Actor(
+            kind="user",
+            id=str(user.id),
+            scope_context=list(install_row.scope),
+        )
+        from datetime import UTC, datetime
+
+        entry = EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=actor,
+            action="fleet.uninstalled",
+            scope=list(install_row.scope) or [f"workspace:{workspace_id}"],
+            correlation_id=target_uuid,
+            payload={
+                "fleet": install_row.fleet,
+                "install_id": install_id,
+                "soft_archived_agents": archived_agents,
+                "soft_archived_pockets": archived_pockets,
+                "failure_count": len(failures),
+            },
+        )
+        journal.append(entry)
+        report.journalled = True
+    except Exception as exc:  # noqa: BLE001 — observability only
+        logger.warning("Fleet uninstall: journal write failed: %s", exc)
+
+    return report

--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -371,6 +371,36 @@ class AgentLoop:
                 self._router = AgentRouter(Settings.load())
         return self._router
 
+    async def _generate_and_emit_title(self, session_key: str, first_message: str) -> None:
+        """Generate a chat title from ``first_message`` and publish a
+        ``session_titled`` SystemEvent. Best-effort; never raises."""
+        try:
+            from pocketpaw.memory.titler import generate_title
+
+            title = await generate_title(
+                first_message,
+                model=self.settings.chat_title_model,
+                api_key=self.settings.anthropic_api_key or None,
+            )
+            if not title:
+                return
+            # session_key is "channel:chat_id" — expose the safe_key form
+            # ("channel_chat_id") so web clients can correlate with their
+            # session_id directly.
+            safe_key = session_key.replace(":", "_")
+            await self.bus.publish_system(
+                SystemEvent(
+                    event_type="session_titled",
+                    data={
+                        "session_key": session_key,
+                        "session_id": safe_key,
+                        "title": title,
+                    },
+                )
+            )
+        except Exception:
+            logger.debug("session titling failed for %s", session_key, exc_info=True)
+
     async def process_message(self, message: InboundMessage) -> None:
         """Public entry point — run the full processing pipeline on one
         message without going through the bus consumer.
@@ -740,12 +770,31 @@ class AgentLoop:
             store_meta = {
                 k: v for k, v in (message.metadata or {}).items() if k != "pocket_system_context"
             }
+            # Detect first-message state *before* persisting so titler can fire once.
+            is_first_message = False
+            try:
+                prior = await self.memory._store.get_session(session_key)
+                is_first_message = len(prior) == 0
+            except (AttributeError, TypeError):
+                is_first_message = False
+
             await self.memory.add_to_session(
                 session_key=session_key,
                 role="user",
                 content=content,
                 metadata=store_meta,
             )
+
+            # 1a. Fire-and-forget chat title generation on the first user message.
+            # Publishes a ``session_titled`` SystemEvent; persistence is the
+            # caller's responsibility (cloud: Mongo; OSS: in-memory/SSE only).
+            if is_first_message:
+                from pocketpaw.features import chat_titles_enabled
+
+                if chat_titles_enabled(self.settings):
+                    asyncio.create_task(
+                        self._generate_and_emit_title(session_key, content)
+                    )
 
             # 1b. Inject inbound media file paths so the agent can use them
             # Also detect whether this is a voice message so we can auto-TTS the reply.

--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -354,6 +354,10 @@ class AgentLoop:
         # Soul Protocol (optional)
         self._soul_manager: Any = None  # SoulManager | None
 
+        # Strong refs to fire-and-forget background tasks (chat titling, etc.)
+        # so the event loop doesn't GC them mid-flight.
+        self._bg_tasks: set[asyncio.Task] = set()
+
         self._running = False
 
     def _get_router(self) -> AgentRouter:
@@ -792,9 +796,11 @@ class AgentLoop:
                 from pocketpaw.features import chat_titles_enabled
 
                 if chat_titles_enabled(self.settings):
-                    asyncio.create_task(
+                    task = asyncio.create_task(
                         self._generate_and_emit_title(session_key, content)
                     )
+                    self._bg_tasks.add(task)
+                    task.add_done_callback(self._bg_tasks.discard)
 
             # 1b. Inject inbound media file paths so the agent can use them
             # Also detect whether this is a voice message so we can auto-TTS the reply.

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -162,6 +162,16 @@ class _APISessionBridge:
                         "data": {"mutation": data.get("mutation", {})},
                     }
                 )
+            elif evt.event_type == "session_titled":
+                await self.queue.put(
+                    {
+                        "event": "session_titled",
+                        "data": {
+                            "session_id": data.get("session_id", ""),
+                            "title": data.get("title", ""),
+                        },
+                    }
+                )
             elif evt.event_type == "error":
                 await self.queue.put(
                     {"event": "error", "data": {"detail": data.get("message", "")}}

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -586,6 +586,19 @@ class Settings(BaseSettings):
         default=True, description="Extend log scrubber with PII patterns (when pii_scan_enabled)"
     )
 
+    # Chat Title Generation (Haiku-backed, first-message naming)
+    chat_title_generation_enabled: bool = Field(
+        default=False,
+        description=(
+            "Auto-generate a short title for a chat from its first user message."
+            " Uses a Haiku model; fires a session_titled SystemEvent on completion."
+        ),
+    )
+    chat_title_model: str = Field(
+        default="claude-haiku-4-5-20251001",
+        description="Model used by the chat title generator (Anthropic).",
+    )
+
     # Smart Model Routing
     smart_routing_enabled: bool = Field(
         default=False,

--- a/src/pocketpaw/features.py
+++ b/src/pocketpaw/features.py
@@ -1,0 +1,32 @@
+"""Feature flag resolution.
+
+Reads OSS settings, but allows ``ee.cloud.features`` to force-on specific
+capabilities when running in cloud mode. ee.cloud is imported lazily so OSS
+builds without the ee package continue to work.
+"""
+
+from __future__ import annotations
+
+from pocketpaw.config import Settings
+
+
+def _cloud_override(name: str) -> bool | None:
+    """Return True/False if ee.cloud forces a feature on/off, else None."""
+    try:
+        from ee.cloud import features as cloud_features  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    getter = getattr(cloud_features, name, None)
+    if getter is None:
+        return None
+    try:
+        return bool(getter())
+    except Exception:
+        return None
+
+
+def chat_titles_enabled(settings: Settings) -> bool:
+    override = _cloud_override("chat_titles_enabled")
+    if override is not None:
+        return override
+    return settings.chat_title_generation_enabled

--- a/src/pocketpaw/frontend/js/features/transparency.js
+++ b/src/pocketpaw/frontend/js/features/transparency.js
@@ -666,6 +666,20 @@ window.PocketPaw.Transparency = {
                     return;
                 }
 
+                // session_titled — Haiku-generated chat title; update sidebar entry
+                if (eventType === 'session_titled') {
+                    const d = data.data || {};
+                    const sid = d.session_id;
+                    const title = d.title;
+                    if (sid && title && this.sessions) {
+                        const session = this.sessions.find(s => s.id === sid);
+                        if (session) {
+                            session.title = title;
+                        }
+                    }
+                    return;
+                }
+
                 // AskUserQuestion — show interactive question in chat
                 if (eventType === 'ask_user_question') {
                     const d = data.data || {};

--- a/src/pocketpaw/memory/titler.py
+++ b/src/pocketpaw/memory/titler.py
@@ -1,0 +1,66 @@
+"""Chat title generation from the first user message.
+
+Uses a Haiku-class Anthropic model to produce a short (≤6 word) title. The
+caller is responsible for persisting the title and emitting the
+``session_titled`` SystemEvent — this module only generates.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_PROMPT = (
+    "Write a concise chat title (max 6 words, Title Case, no quotes, no"
+    " trailing punctuation) that captures the subject of this user message.\n\n"
+    "Message:\n{message}\n\nTitle:"
+)
+
+_MAX_INPUT_CHARS = 2000
+_MAX_TOKENS = 24
+
+
+async def generate_title(
+    first_message: str, *, model: str, api_key: str | None = None
+) -> str | None:
+    """Return a short title for ``first_message`` or ``None`` on failure.
+
+    Failures (missing SDK, missing key, API error) are logged at debug and
+    swallowed — titling is best-effort and must never break the chat flow.
+    """
+    text = (first_message or "").strip()
+    if not text:
+        return None
+    if len(text) > _MAX_INPUT_CHARS:
+        text = text[:_MAX_INPUT_CHARS]
+
+    try:
+        from anthropic import AsyncAnthropic
+    except ImportError:
+        logger.debug("anthropic SDK not installed; skipping title generation")
+        return None
+
+    try:
+        client = AsyncAnthropic(api_key=api_key) if api_key else AsyncAnthropic()
+        response = await client.messages.create(
+            model=model,
+            max_tokens=_MAX_TOKENS,
+            messages=[{"role": "user", "content": _PROMPT.format(message=text)}],
+        )
+    except Exception:
+        logger.debug("title generation call failed", exc_info=True)
+        return None
+
+    try:
+        raw = response.content[0].text
+    except (AttributeError, IndexError):
+        return None
+
+    title = raw.strip().strip('"').strip("'").rstrip(".").strip()
+    if not title:
+        return None
+    # Cap at a hard character budget in case the model ignores word-count.
+    if len(title) > 80:
+        title = title[:80].rstrip()
+    return title

--- a/tests/ee/test_fleet_router.py
+++ b/tests/ee/test_fleet_router.py
@@ -616,3 +616,190 @@ class TestResponseShape:
         assert resp.status_code == 200
         pydantic_warnings = [w for w in recwarn.list if "pydantic" in str(w.category).lower()]
         assert not pydantic_warnings, [str(w) for w in pydantic_warnings]
+
+
+# ---------------------------------------------------------------------------
+# Installed-fleet listing + uninstall (cluster-d-fleet-ui-wire-up).
+# The tests don't exercise the full install-then-uninstall pipeline end to
+# end (that would require Agent + Pocket Beanie collections, which would
+# drag a Mongo connection into a router test). Instead we seed the journal
+# directly with ``fleet.installed`` entries so we're testing the router's
+# contract: auth, filter, idempotent uninstall, journal write.
+# ---------------------------------------------------------------------------
+
+
+def _seed_install_event(journal_path: Path, *, install_id: str, fleet: str, scope: list[str]):
+    """Append a single ``fleet.installed`` event to the journal at
+    ``journal_path`` so the list endpoint has something to return.
+
+    Returns the EventEntry for read-back in the tests.
+    """
+    from datetime import UTC, datetime
+    from uuid import UUID, uuid4
+
+    from soul_protocol.engine.journal import open_journal
+    from soul_protocol.spec.journal import Actor, EventEntry
+
+    with open_journal(journal_path) as j:
+        entry = EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=Actor(kind="user", id="user-admin", scope_context=list(scope)),
+            action="fleet.installed",
+            scope=list(scope),
+            correlation_id=UUID(install_id),
+            payload={
+                "fleet": fleet,
+                "soul_id": "did:soul:fake",
+                "pocket_id": "pkt-fake",
+                "succeeded": True,
+                "step_count": 3,
+                "failed_steps": [],
+            },
+        )
+        committed = j.append(entry)
+    return committed
+
+
+class TestInstalledFleetsListing:
+    def test_unauthenticated_list_returns_401(self, client: TestClient) -> None:
+        resp = client.get(f"/fleet/installed?workspace_id={WORKSPACE_ID}")
+        assert resp.status_code == 401
+
+    def test_non_admin_list_returns_403(self, client: TestClient) -> None:
+        resp = client.get(
+            f"/fleet/installed?workspace_id={WORKSPACE_ID}",
+            headers={
+                "X-Test-User": "user-member",
+                "X-Test-Workspaces": f"{WORKSPACE_ID}:member",
+            },
+        )
+        assert resp.status_code == 403
+
+    def test_empty_list_is_ok(self, client: TestClient) -> None:
+        resp = client.get(
+            f"/fleet/installed?workspace_id={WORKSPACE_ID}",
+            headers=ADMIN_AUTH_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"installed": [], "total": 0}
+
+    def test_seeded_install_surfaces_in_list(
+        self, client: TestClient, journal_path: Path
+    ) -> None:
+        import uuid as _uuid
+
+        install_id = str(_uuid.uuid4())
+        _seed_install_event(
+            journal_path,
+            install_id=install_id,
+            fleet="sales-fleet",
+            scope=[f"workspace:{WORKSPACE_ID}"],
+        )
+
+        resp = client.get(
+            f"/fleet/installed?workspace_id={WORKSPACE_ID}",
+            headers=ADMIN_AUTH_HEADERS,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["installed"][0]["install_id"] == install_id
+        assert body["installed"][0]["fleet"] == "sales-fleet"
+        assert body["installed"][0]["succeeded"] is True
+
+
+class TestUninstallFleet:
+    def test_unauthenticated_uninstall_returns_401(self, client: TestClient) -> None:
+        import uuid as _uuid
+
+        resp = client.delete(
+            f"/fleet/installed/{_uuid.uuid4()}?workspace_id={WORKSPACE_ID}",
+        )
+        assert resp.status_code == 401
+
+    def test_non_admin_uninstall_returns_403(self, client: TestClient) -> None:
+        import uuid as _uuid
+
+        resp = client.delete(
+            f"/fleet/installed/{_uuid.uuid4()}?workspace_id={WORKSPACE_ID}",
+            headers={
+                "X-Test-User": "user-member",
+                "X-Test-Workspaces": f"{WORKSPACE_ID}:member",
+            },
+        )
+        assert resp.status_code == 403
+
+    def test_malformed_install_id_returns_400(self, client: TestClient) -> None:
+        resp = client.delete(
+            f"/fleet/installed/not-a-uuid?workspace_id={WORKSPACE_ID}",
+            headers=ADMIN_AUTH_HEADERS,
+        )
+        assert resp.status_code == 400
+
+    def test_idempotent_when_install_missing(self, client: TestClient) -> None:
+        """Uninstall against a never-seen id is a no-op, not a 404. Retries
+        after network flake should not flip to error."""
+        import uuid as _uuid
+
+        resp = client.delete(
+            f"/fleet/installed/{_uuid.uuid4()}?workspace_id={WORKSPACE_ID}",
+            headers=ADMIN_AUTH_HEADERS,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["journalled"] is False
+        assert body["soft_archived_agents"] == []
+        assert body["soft_archived_pockets"] == []
+
+    def test_scope_mismatch_returns_403(
+        self, client: TestClient, journal_path: Path
+    ) -> None:
+        """An install scoped to workspace A cannot be torn down by an
+        admin of workspace B, even if the install_id is correct."""
+        import uuid as _uuid
+
+        install_id = str(_uuid.uuid4())
+        _seed_install_event(
+            journal_path,
+            install_id=install_id,
+            fleet="sales-fleet",
+            scope=[f"workspace:{OTHER_WORKSPACE_ID}"],
+        )
+
+        resp = client.delete(
+            f"/fleet/installed/{install_id}?workspace_id={WORKSPACE_ID}",
+            headers=ADMIN_AUTH_HEADERS,
+        )
+        assert resp.status_code == 403
+
+    def test_uninstall_journals_event(
+        self, client: TestClient, journal_path: Path
+    ) -> None:
+        import uuid as _uuid
+
+        install_id = str(_uuid.uuid4())
+        _seed_install_event(
+            journal_path,
+            install_id=install_id,
+            fleet="sales-fleet",
+            scope=[f"workspace:{WORKSPACE_ID}"],
+        )
+
+        resp = client.delete(
+            f"/fleet/installed/{install_id}?workspace_id={WORKSPACE_ID}",
+            headers=ADMIN_AUTH_HEADERS,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["journalled"] is True
+        assert body["fleet"] == "sales-fleet"
+
+        # Confirm the journal now holds a fleet.uninstalled with the same
+        # correlation_id as the install.
+        from soul_protocol.engine.journal import open_journal
+
+        with open_journal(journal_path) as j:
+            uninstalls = j.query(action="fleet.uninstalled", limit=10)
+        assert len(uninstalls) == 1
+        assert str(uninstalls[0].correlation_id) == install_id


### PR DESCRIPTION
## Summary

Adds `GET /fleet/installed` + `DELETE /fleet/installed/{id}` so the
paw-enterprise admin UI can surface previously-installed fleets and
tear them down. The journal is the source of truth — we read
`fleet.installed` events to build the list and use `correlation_id`
as the stable install handle, no new Mongo collection needed.

Uninstall is deliberately soft: agents flip to `visibility="archived"`
and the primary pocket sets `archived=True` so chat history and
fabric links keep their referents. The op is **idempotent** — a retry
against an already-uninstalled id returns an empty report with
`journalled=False`, never a 500. Every successful run emits a
`fleet.uninstalled` event that re-uses the original `correlation_id`
so projections can see the open/close pairing.

### Auth (security review focus)

Both endpoints require workspace admin+ via the same guard that
landed for `POST /fleet/install` in PR #983. Uninstall additionally
re-checks that the target install's scope overlaps the caller's
workspace — belt and braces so a workspace-A admin can't tear down a
workspace-B install via a crafted install_id.

Base: this PR stacks on `fix/fleet-install-auth-guard` (PR #983) so
it can't land before the P0 auth guard merges.

### Tests

Layer 2 (integration):

- `tests/ee/test_fleet_router.py` — 10 new pytest cases:
  - `TestInstalledFleetsListing`: 401/403/empty/seeded-surface.
  - `TestUninstallFleet`: 401/403 auth, 400 malformed UUID,
    idempotent no-op, scope mismatch 403, journal-write verification.

```
10 passed in 3.52s (new cases; full file still green)
```

### Plan + reality

- Plan:
  [`docs/plans/FEATURE-HARDENING-PLAN.md`](../../../docs/plans/FEATURE-HARDENING-PLAN.md)
  Cluster D, row D7 (fleet management view / uninstall).
- Reality brief:
  [`docs/plans/cluster-D-reality.md`](../../../docs/plans/cluster-D-reality.md)
  _Backend routes (missing)_ rows _List installed fleets_ + _Uninstall fleet_.

Paired frontend PR:
`qbtrix/paw-enterprise#feat/cluster-d-fleet-ui-wire-up`.

## Test plan

- [x] `uv run pytest tests/ee/test_fleet_router.py`
- [ ] Manual: GET `/fleet/installed?workspace_id=X` returns prior
  installs.
- [ ] Manual: DELETE `/fleet/installed/{id}` archives agents +
  pockets.