### PR TITLE
fix(paw-print): mount router and add store singleton

### DIFF
--- a/ee/api.py
+++ b/ee/api.py
@@ -1,17 +1,23 @@
-# ee/api.py — Singleton entry point for the Instinct decision pipeline store.
+# ee/api.py — Singleton entry points for the ee-scoped stores.
 # Created: 2026-03-30 — Bridges instinct_tools.py to the InstinctStore.
+# Updated: 2026-04-20 — Added get_paw_print_store() so the paw_print router
+#   can reach the SQLite-backed PawPrintStore from a non-DI import path.
 # The agent tools (pocketpaw.tools.builtin.instinct_tools) import from here
-# via `from ee.api import get_instinct_store`.
+# via `from ee.api import get_instinct_store`; paw_print router uses
+# `from ee.api import get_paw_print_store`.
 
 from __future__ import annotations
 
 from pathlib import Path
 
 from ee.instinct.store import InstinctStore
+from ee.paw_print.store import PawPrintStore
 
 _DB_PATH = Path.home() / ".pocketpaw" / "instinct.db"
+_PAW_PRINT_DB_PATH = Path.home() / ".pocketpaw" / "paw_print.db"
 
 _store: InstinctStore | None = None
+_paw_print_store: PawPrintStore | None = None
 
 
 def get_instinct_store() -> InstinctStore:
@@ -24,3 +30,17 @@ def get_instinct_store() -> InstinctStore:
     if _store is None:
         _store = InstinctStore(_DB_PATH)
     return _store
+
+
+def get_paw_print_store() -> PawPrintStore:
+    """Return the global PawPrintStore singleton.
+
+    Lazily creates the store on first call. The SQLite database lives at
+    ~/.pocketpaw/paw_print.db. Referenced by `ee/paw_print/router.py` via
+    its `_store()` helper so the widget CRUD and event ingest endpoints
+    can reach the shared instance.
+    """
+    global _paw_print_store
+    if _paw_print_store is None:
+        _paw_print_store = PawPrintStore(_PAW_PRINT_DB_PATH)
+    return _paw_print_store

--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -73,10 +73,15 @@ def mount_cloud(app: FastAPI) -> None:
     from ee.cloud.kb.router import router as kb_router
     from ee.cloud.notifications.router import router as notifications_router
     from ee.cloud.uploads.router import router as uploads_router
+    from ee.paw_print.router import router as paw_print_router
 
     app.include_router(kb_router, prefix="/api/v1")
     app.include_router(uploads_router, prefix="/api/v1")
     app.include_router(notifications_router, prefix="/api/v1")
+    # paw_print lives outside ee/cloud/ but is mounted alongside the cloud
+    # routers so the admin UI (paw-enterprise /pockets/<id> Paw Print tab) can
+    # reach /api/v1/paw-print/* without a second app setup entry point.
+    app.include_router(paw_print_router, prefix="/api/v1")
 
     # User search endpoint — used by group settings, pocket sharing
     from ee.cloud.models.user import User as UserModel


### PR DESCRIPTION
## Summary

- `ee/paw_print/router.py` was never mounted in the FastAPI app, so every `/api/v1/paw-print/*` route returned 404.
- The router's `_store()` helper imports `get_paw_print_store` from `ee.api`, but only `get_instinct_store` was defined there. A hypothetical mount would have died on first request.

Both halves went unnoticed because the existing unit tests patch `_store` directly — the wiring gap only shows up when the paw-enterprise admin UI (`/pockets/<id>` Paw Print tab, shipped with `feat/cluster-d-paw-print-panel-swap-plus-decision-viewer` on the client) actually calls the API.

## Changes

- Add `get_paw_print_store()` singleton in `ee/api.py`, parallel to the existing `InstinctStore` helper. SQLite path is `~/.pocketpaw/paw_print.db`.
- Mount `paw_print_router` inside `mount_cloud()` with the `/api/v1` prefix, next to the other ee routers. Includes a comment explaining why a non-cloud router lives in this function.

## Test plan

- [x] `uv run pytest tests/cloud/test_paw_print_ingest.py -q` — 19 passed.
- [ ] Smoke: hit `GET /api/v1/paw-print/widgets?pocket_id=<valid>&owner=<valid>` on a running server — expect 200 with a list (previously 404).
- [ ] Open the paw-enterprise admin UI, navigate to a pocket → Paw Print tab — the "Backend unreachable" banner should clear.