### PR TITLE
fix(security): SSRF guard on URL config fields (re-targeted to dev)

### DIFF
--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,10 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-04-16: SSRF guard on URL config fields — opencode_base_url,
+    litellm_api_base, openai_compatible_base_url, mem0_ollama_base_url,
+    embedding_base_url, signal_api_url, mcp_client_metadata_url are now
+    validated by security.url_validators.validate_external_url. Closes #703.
   - 2026-04-10: Removed old pocketclaw migration warning — fully shifted to pocketpaw.
   - 2026-04-04: Added soul_cognitive_model setting for cheaper cognitive processing.
   - 2026-03-16: Use Literal types for whatsapp_mode, tts_provider, stt_provider (#638).
@@ -19,10 +23,16 @@ import logging
 import re
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import AfterValidator, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from pocketpaw.security.url_validators import validate_external_url
+
+# Shorthand for Settings URL fields that must be safe from SSRF (#703).
+# Applies scheme + loopback/RFC1918 guards from security.url_validators.
+ExternalUrl = Annotated[str, AfterValidator(validate_external_url)]
 
 logger = logging.getLogger(__name__)
 
@@ -250,7 +260,7 @@ class Settings(BaseSettings):
     )
 
     # OpenCode Settings
-    opencode_base_url: str = Field(
+    opencode_base_url: ExternalUrl = Field(
         default="http://localhost:4096",
         description="OpenCode server URL",
     )
@@ -263,7 +273,7 @@ class Settings(BaseSettings):
     )
 
     # LiteLLM Proxy / SDK Configuration
-    litellm_api_base: str = Field(
+    litellm_api_base: ExternalUrl = Field(
         default="http://localhost:4000",
         description="LiteLLM proxy server URL (used when any backend provider is set to 'litellm')",
     )
@@ -294,7 +304,7 @@ class Settings(BaseSettings):
     )
     ollama_host: str = Field(default="http://localhost:11434", description="Ollama API host")
     ollama_model: str = Field(default="llama3.2", description="Ollama model to use")
-    openai_compatible_base_url: str = Field(
+    openai_compatible_base_url: ExternalUrl = Field(
         default="",
         description="Base URL for OpenAI-compatible endpoint (LiteLLM, OpenRouter, vLLM, etc.)",
     )
@@ -377,7 +387,7 @@ class Settings(BaseSettings):
         default="qdrant",
         description="Vector store for mem0: 'qdrant' or 'chroma'",
     )
-    mem0_ollama_base_url: str = Field(
+    mem0_ollama_base_url: ExternalUrl = Field(
         default="http://localhost:11434",
         description="Ollama base URL for mem0 (when using ollama provider)",
     )
@@ -409,7 +419,7 @@ class Settings(BaseSettings):
         default="nomic-embed-text",
         description="Embedding model for file memory semantic retrieval",
     )
-    embedding_base_url: str = Field(
+    embedding_base_url: ExternalUrl = Field(
         default="http://localhost:11434",
         description="Embedding provider base URL (for ollama)",
     )
@@ -692,7 +702,7 @@ class Settings(BaseSettings):
     )
 
     # Signal
-    signal_api_url: str = Field(
+    signal_api_url: ExternalUrl = Field(
         default="http://localhost:8080", description="Signal-cli REST API URL"
     )
     signal_phone_number: str | None = Field(
@@ -777,7 +787,7 @@ class Settings(BaseSettings):
     )
 
     # MCP OAuth
-    mcp_client_metadata_url: str = Field(
+    mcp_client_metadata_url: ExternalUrl = Field(
         default="",
         description="CIMD URL for MCP OAuth (optional, for servers without dynamic registration)",
     )

--- a/src/pocketpaw/security/url_validators.py
+++ b/src/pocketpaw/security/url_validators.py
@@ -1,0 +1,79 @@
+# URL validators for Settings fields — guards against SSRF via config.
+# Added: 2026-04-16 for security cluster E (#703).
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from urllib.parse import urlsplit
+
+_ALLOWED_SCHEMES: frozenset[str] = frozenset({"http", "https"})
+
+# Loopback + link-local + RFC1918 + carrier-grade NAT — blocked unless the
+# operator explicitly opts in via ``POCKETPAW_ALLOW_INTERNAL_URLS=true``.
+# Dev-mode defaults (`http://localhost:4096`, `http://localhost:11434`, …)
+# rely on this opt-in; OSS / production deployments should leave it off.
+_BLOCKED_HOSTS: frozenset[str] = frozenset(
+    {"localhost", "ip6-localhost", "ip6-loopback"}
+)
+_BLOCKED_NETWORKS: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),  # link-local / EC2 metadata
+    ipaddress.ip_network("100.64.0.0/10"),   # carrier-grade NAT
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+)
+
+
+def _allow_internal() -> bool:
+    return os.getenv("POCKETPAW_ALLOW_INTERNAL_URLS", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _host_is_internal(host: str) -> bool:
+    host = host.lower().strip("[]")
+    if host in _BLOCKED_HOSTS:
+        return True
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return any(addr in net for net in _BLOCKED_NETWORKS)
+
+
+def validate_external_url(value: str) -> str:
+    """Pydantic validator for Settings URL fields.
+
+    * Empty string is passed through — means "not configured" in this codebase.
+    * Scheme must be ``http`` or ``https``.
+    * Loopback / RFC1918 / link-local / carrier-grade NAT hosts are blocked
+      unless ``POCKETPAW_ALLOW_INTERNAL_URLS`` is set to a truthy value.
+    """
+    if value is None or value == "":
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"URL must be a string, got {type(value).__name__}")
+
+    parts = urlsplit(value)
+    if parts.scheme not in _ALLOWED_SCHEMES:
+        raise ValueError(
+            f"URL scheme '{parts.scheme or '(none)'}' not allowed — use http or https"
+        )
+    if not parts.hostname:
+        raise ValueError(f"URL has no host: {value!r}")
+
+    if _host_is_internal(parts.hostname) and not _allow_internal():
+        raise ValueError(
+            f"URL host '{parts.hostname}' is internal/loopback/private — "
+            f"set POCKETPAW_ALLOW_INTERNAL_URLS=true to permit it"
+        )
+    return value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,20 @@
 """Pytest configuration."""
 
 import asyncio
+import os
 import sys
 from unittest.mock import patch
 
 import pytest
 
 from pocketpaw.security.audit import AuditLogger
+
+# Tests run with loopback / RFC1918 URLs in many places (`http://localhost:*`
+# ollama defaults, mock HTTP servers, etc). In production that's the exact
+# SSRF shape blocked by security.url_validators.validate_external_url — here
+# we relax the check so Settings() instantiates cleanly. Tests that need the
+# strict behaviour monkeypatch POCKETPAW_ALLOW_INTERNAL_URLS=false themselves.
+os.environ.setdefault("POCKETPAW_ALLOW_INTERNAL_URLS", "true")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_config_url_validation.py
+++ b/tests/test_config_url_validation.py
@@ -1,0 +1,98 @@
+# SSRF URL-validation tests for Settings URL fields.
+# Added: 2026-04-16 for security sprint cluster E (#703).
+
+from __future__ import annotations
+
+import pytest
+
+
+def _reload_settings():
+    """Force a fresh Settings() read so env changes take effect.
+
+    The Settings singleton caches the first-loaded instance; we want each
+    test to see its own environment variables.
+    """
+    from pocketpaw import config as cfg
+
+    cfg._settings = None  # invalidate singleton if present
+    return cfg
+
+
+class TestExternalUrlValidator:
+    def test_internal_url_rejected_when_not_allowed(self, monkeypatch):
+        from pocketpaw.security.url_validators import validate_external_url
+
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "false")
+        with pytest.raises(ValueError):
+            validate_external_url("http://169.254.169.254/")  # EC2 metadata
+        with pytest.raises(ValueError):
+            validate_external_url("http://127.0.0.1:8080/")
+        with pytest.raises(ValueError):
+            validate_external_url("http://10.0.0.5/")
+        with pytest.raises(ValueError):
+            validate_external_url("http://192.168.1.1/")
+
+    def test_public_url_accepted(self, monkeypatch):
+        from pocketpaw.security.url_validators import validate_external_url
+
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "false")
+        # Public URLs pass
+        assert validate_external_url("https://api.openai.com") == "https://api.openai.com"
+        assert validate_external_url("http://example.com") == "http://example.com"
+
+    def test_non_http_scheme_always_rejected(self, monkeypatch):
+        from pocketpaw.security.url_validators import validate_external_url
+
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "true")
+        with pytest.raises(ValueError, match="scheme"):
+            validate_external_url("file:///etc/passwd")
+        with pytest.raises(ValueError, match="scheme"):
+            validate_external_url("ftp://example.com/")
+        with pytest.raises(ValueError, match="scheme"):
+            validate_external_url("gopher://x")
+
+    def test_internal_url_accepted_when_flag_set(self, monkeypatch):
+        from pocketpaw.security.url_validators import validate_external_url
+
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "true")
+        # Localhost & RFC1918 pass when explicitly allowed (dev default)
+        assert validate_external_url("http://localhost:4096") == "http://localhost:4096"
+        assert validate_external_url("http://127.0.0.1:11434") == "http://127.0.0.1:11434"
+        assert validate_external_url("http://192.168.1.100") == "http://192.168.1.100"
+
+    def test_empty_string_accepted(self, monkeypatch):
+        """Empty string means "not configured" — Settings defaults use this."""
+        from pocketpaw.security.url_validators import validate_external_url
+
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "false")
+        assert validate_external_url("") == ""
+
+    def test_malformed_url_rejected(self, monkeypatch):
+        from pocketpaw.security.url_validators import validate_external_url
+
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "true")
+        with pytest.raises(ValueError):
+            validate_external_url("not-a-url")
+        with pytest.raises(ValueError):
+            validate_external_url("http://")
+
+
+class TestSettingsAppliesValidator:
+    """Integration: a Settings load with a malicious URL env var fails fast."""
+
+    def test_opencode_base_url_rejects_metadata_service(self, monkeypatch):
+        _reload_settings()
+        from pocketpaw.config import Settings
+
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "false")
+        monkeypatch.setenv("POCKETPAW_OPENCODE_BASE_URL", "http://169.254.169.254/")
+        with pytest.raises(Exception):  # pydantic wraps ValueError in ValidationError
+            Settings()
+
+    def test_signal_api_url_rejects_file_scheme(self, monkeypatch):
+        _reload_settings()
+        from pocketpaw.config import Settings
+
+        monkeypatch.setenv("POCKETPAW_SIGNAL_API_URL", "file:///etc/passwd")
+        with pytest.raises(Exception):
+            Settings()


### PR DESCRIPTION
## Summary

Cherry-pick of the SSRF guard in #963 onto `dev`. The original branch was cut off `ee` and carried 10+ ee-specific commits that don't belong on `dev`, so a clean rebase wasn't possible. This is the same two commits as #963 (tests + guard) replayed on a dev-based branch so the dev→ee cascade picks them up for free.

Supersedes #963.

## Commits

- `0dc661d` test(security): failing tests for URL config validators (SSRF)
- `79eb218` fix(security): SSRF guard on URL config fields

## Test plan

- [x] `uv run pytest tests/test_config_url_validation.py` — green on the new test file.
- [ ] Smoke: a webhook URL config with `localhost`, `127.0.0.1`, or a private-subnet host rejects at load.