### PR TITLE
feat(cloud/knowledge): list/get endpoints + ingest source label

### DIFF
--- a/ee/cloud/agents/knowledge.py
+++ b/ee/cloud/agents/knowledge.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-KB_BIN = os.environ.get("POCKETPAW_KB_BIN", "kb")
+KB_BIN = os.environ.get("POCKETPAW_KB_BIN", "kb-go")
 
 
 def _kb(*args: str, input_text: str | None = None, timeout: int = 120) -> dict | list | str:
@@ -31,13 +31,15 @@ def _kb(*args: str, input_text: str | None = None, timeout: int = 120) -> dict |
             input=input_text,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
         )
     except FileNotFoundError:
         raise RuntimeError(
             f"kb binary not found at '{KB_BIN}'. "
             "Install: go install github.com/qbtrix/kb-go@latest "
-            "or set POCKETPAW_KB_BIN to the binary path."
+            "or set POCKETPAW_KB_BIN to the binary path (e.g. kb-go)."
         )
     if result.returncode != 0:
         logger.warning("kb failed (exit %d): %s", result.returncode, result.stderr[:200])
@@ -72,24 +74,42 @@ class KnowledgeService:
             return {"error": str(exc), "url": url}
 
     @staticmethod
-    async def ingest_file(agent_id: str, file_path: str) -> dict:
-        """Extract file content (PDF/DOCX via Python if needed), pipe to kb."""
-        try:
-            path = Path(file_path)
-            if path.suffix in (".pdf", ".docx", ".doc", ".png", ".jpg", ".jpeg"):
-                text = await _extract_file(file_path)
-                return _kb(
-                    "ingest",
-                    "--scope",
-                    f"agent:{agent_id}",
-                    "--source",
-                    file_path,
-                    input_text=text,
-                )
-            # Text/code files go directly to kb
-            return _kb("ingest", file_path, "--scope", f"agent:{agent_id}")
-        except Exception as exc:
-            return {"error": str(exc)}
+    async def ingest_file(
+        agent_id: str, file_path: str, source: str | None = None
+    ) -> dict:
+        """Extract file content (PDF/DOCX via Python if needed), pipe to kb.
+
+        ``source`` overrides the stored title/source — pass the original
+        filename so the KB doesn't store temp paths.
+        """
+        path = Path(file_path)
+        label = source or path.name
+        if path.suffix.lower() in (".pdf", ".docx", ".doc", ".png", ".jpg", ".jpeg"):
+            text = await _extract_file(file_path)
+            return _kb(
+                "ingest",
+                "--scope",
+                f"agent:{agent_id}",
+                "--source",
+                label,
+                input_text=text,
+            )
+        # Text/code files go directly to kb
+        return _kb(
+            "ingest", file_path, "--scope", f"agent:{agent_id}", "--source", label
+        )
+
+    @staticmethod
+    async def list_articles(agent_id: str) -> list[dict]:
+        """List ingested articles for an agent."""
+        result = _kb("list", "--scope", f"agent:{agent_id}")
+        return result if isinstance(result, list) else []
+
+    @staticmethod
+    async def get_article(agent_id: str, article_id: str) -> dict:
+        """Fetch a single article's full body."""
+        result = _kb("show", article_id, "--scope", f"agent:{agent_id}")
+        return result if isinstance(result, dict) else {"content": str(result)}
 
     @staticmethod
     async def search(agent_id: str, query: str, limit: int = 5) -> list[str]:

--- a/ee/cloud/agents/router.py
+++ b/ee/cloud/agents/router.py
@@ -9,7 +9,7 @@ a security boundary.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query, Request, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, UploadFile
 from fastapi import File as FastAPIFile
 from starlette.responses import Response
 
@@ -180,6 +180,29 @@ async def search_knowledge(agent_id: str, q: str = Query(..., min_length=1), lim
     return {"results": results}
 
 
+@router.get("/{agent_id}/knowledge")
+async def list_knowledge(agent_id: str):
+    """List all knowledge articles for an agent."""
+    from ee.cloud.agents.knowledge import KnowledgeService
+
+    try:
+        articles = await KnowledgeService.list_articles(agent_id)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to list knowledge: {exc}")
+    return {"items": articles}
+
+
+@router.get("/{agent_id}/knowledge/{article_id}")
+async def get_knowledge_article(agent_id: str, article_id: str):
+    """Fetch the full body of a single knowledge article."""
+    from ee.cloud.agents.knowledge import KnowledgeService
+
+    try:
+        return await KnowledgeService.get_article(agent_id, article_id)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=404, detail=f"Article not found: {exc}")
+
+
 # ---------------------------------------------------------------------------
 # Profile Picture Upload
 # ---------------------------------------------------------------------------
@@ -243,7 +266,7 @@ async def upload_and_ingest(
     from ee.cloud.agents.knowledge import KnowledgeService
 
     if not file.filename:
-        return {"error": "No filename provided"}
+        raise HTTPException(status_code=400, detail="No filename provided")
 
     suffix = Path(file.filename).suffix.lower()
     with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
@@ -252,7 +275,14 @@ async def upload_and_ingest(
         tmp_path = tmp.name
 
     try:
-        result = await KnowledgeService.ingest_file(agent_id, tmp_path)
+        try:
+            result = await KnowledgeService.ingest_file(
+                agent_id, tmp_path, source=file.filename
+            )
+        except RuntimeError as exc:
+            raise HTTPException(status_code=500, detail=f"Knowledge ingestion failed: {exc}")
+        if not isinstance(result, dict):
+            result = {"result": result}
         result["originalName"] = file.filename
         result["size"] = len(content)
         return result


### PR DESCRIPTION
## Summary
- Add `GET /{agent_id}/knowledge` and `GET /{agent_id}/knowledge/{article_id}` so the UI can browse and open ingested articles.
- Pass the original filename as `--source` when ingesting uploads, so the KB stores the real title instead of a temp path.
- Replace plain-dict error returns in upload/ingest with `HTTPException` (400/500) and harden the `kb` subprocess (utf-8 + `errors=replace`) to avoid Windows decoding crashes.
- Default `POCKETPAW_KB_BIN` to `kb-go` to match the documented install command.

## Test plan
- [ ] `uv run pytest --ignore=tests/e2e`
- [ ] Upload a PDF via the dashboard → article appears under `GET /{agent_id}/knowledge` with the original filename
- [ ] `GET /{agent_id}/knowledge/{article_id}` returns the full body
- [ ] With `POCKETPAW_KB_BIN` unset and no `kb-go` on PATH, upload returns 500 JSON (not a crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)