### PR TITLE
fix(agents): thread user + workspace into agent pocket creation

### DIFF
--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -108,22 +108,62 @@ def _extract_pocket_json(content: str) -> dict | None:
     return None
 
 
-async def _create_pocket_and_session(spec: dict, session_key: str) -> str | None:
-    """Create pocket + session in MongoDB. Returns pocket _id or None on failure."""
+async def _create_pocket_and_session(
+    spec: dict,
+    session_key: str,
+    user_id: str | None = None,
+    workspace_id: str | None = None,
+) -> str | None:
+    """Create pocket + session in MongoDB. Returns pocket _id or None on failure.
+
+    ``user_id`` / ``workspace_id`` come from the caller's authenticated
+    context (threaded down from the chat endpoint via ``InboundMessage.metadata``).
+    When either is missing we fall back to the legacy heuristics —
+    ``user.active_workspace`` first, then first-owned workspace, then any
+    workspace — so self-hosted single-user deployments (CLI, Telegram) that
+    have no JWT auth still work.
+    """
     try:
         from ee.cloud.models.session import Session
         from ee.cloud.models.user import User
         from ee.cloud.models.workspace import Workspace
 
-        # Find user + workspace from existing cloud data
-        # Try to find user from any existing session, or get the first active user
-        user = await User.find_one()
+        # ── User selection ──────────────────────────────────────────────
+        # Prefer an explicitly-threaded user id from the chat context so
+        # agent-created pockets land under the caller, not whichever user
+        # happens to come first out of Mongo.
+        user = None
+        if user_id:
+            try:
+                from beanie import PydanticObjectId
+
+                user = await User.get(PydanticObjectId(user_id))
+            except Exception:  # noqa: BLE001
+                logger.warning("Invalid cloud_user_id %r; falling back to first user", user_id)
+                user = None
+        if not user:
+            user = await User.find_one()
         if not user:
             logger.warning("Cannot create pocket — no user in DB")
             return None
         user_id = str(user.id)
 
-        workspace = await Workspace.find_one(Workspace.owner == user_id)
+        # ── Workspace selection ─────────────────────────────────────────
+        # Priority: explicit workspace_id (from JWT) → user.active_workspace
+        # → first owned workspace → any workspace. Without this chain the
+        # pocket lands in whichever workspace Mongo returns first, which
+        # is almost never the one the user has open in the UI.
+        workspace = None
+        target_ws = workspace_id or getattr(user, "active_workspace", None)
+        if target_ws:
+            try:
+                from beanie import PydanticObjectId
+
+                workspace = await Workspace.get(PydanticObjectId(target_ws))
+            except Exception:  # noqa: BLE001
+                workspace = None
+        if not workspace:
+            workspace = await Workspace.find_one(Workspace.owner == user_id)
         if not workspace:
             # Try any workspace the user belongs to
             workspace = await Workspace.find_one()
@@ -178,7 +218,12 @@ async def _create_pocket_and_session(spec: dict, session_key: str) -> str | None
         return None
 
 
-async def _publish_pocket_event(bus: "MessageBus", content: str, session_key: str) -> None:
+async def _publish_pocket_event(
+    bus: "MessageBus",
+    content: str,
+    session_key: str,
+    metadata: dict | None = None,
+) -> None:
     """Detect pocket event JSON in tool output and publish a dedicated SystemEvent.
 
     Two shapes are recognised:
@@ -200,6 +245,11 @@ async def _publish_pocket_event(bus: "MessageBus", content: str, session_key: st
        manual reload. (The Mongo-side ``PocketUpdated`` realtime event
        fired in the subprocess can't reach the parent process's
        WebSocket connection manager — this is the bridge.)
+
+    ``metadata`` is the originating ``InboundMessage.metadata`` — for
+    shape 1 we read ``cloud_user_id`` / ``cloud_workspace_id`` so the
+    created pocket is attributed to the caller rather than the first
+    user in the DB.
     """
     # Cheap rejection — neither shape can be in the content otherwise.
     if '"pocket_event"' not in content and '"pocket"' not in content:
@@ -248,8 +298,18 @@ async def _publish_pocket_event(bus: "MessageBus", content: str, session_key: st
         "panes" in spec,
     )
     if evt_type == "created":
-        # Create pocket + session in MongoDB right here
-        pocket_cloud_id = await _create_pocket_and_session(spec, session_key)
+        # Create pocket + session in MongoDB right here. Pull the caller's
+        # identity out of the inbound metadata so multi-user / multi-
+        # workspace deployments route the pocket to the right tenant.
+        meta = metadata or {}
+        cloud_user_id = meta.get("cloud_user_id")
+        cloud_workspace_id = meta.get("cloud_workspace_id")
+        pocket_cloud_id = await _create_pocket_and_session(
+            spec,
+            session_key,
+            user_id=cloud_user_id,
+            workspace_id=cloud_workspace_id,
+        )
         await bus.publish_system(
             SystemEvent(
                 event_type="pocket_created",
@@ -881,9 +941,7 @@ class AgentLoop:
                 from pocketpaw.features import chat_titles_enabled
 
                 if chat_titles_enabled(self.settings):
-                    task = asyncio.create_task(
-                        self._generate_and_emit_title(session_key, content)
-                    )
+                    task = asyncio.create_task(self._generate_and_emit_title(session_key, content))
                     self._bg_tasks.add(task)
                     task.add_done_callback(self._bg_tasks.discard)
 
@@ -1169,8 +1227,13 @@ class AgentLoop:
                             )
                         )
                         # Detect pocket events in tool output and publish
-                        # dedicated SystemEvents for the SSE handler.
-                        await _publish_pocket_event(self.bus, econtent, session_key)
+                        # dedicated SystemEvents for the SSE handler. Pass
+                        # the inbound metadata so cloud_user_id /
+                        # cloud_workspace_id (threaded in from the chat
+                        # endpoint) reach the pocket creator.
+                        await _publish_pocket_event(
+                            self.bus, econtent, session_key, message.metadata
+                        )
                         media_paths.extend(_extract_media_paths(econtent))
 
                     elif etype == "error":

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -3,6 +3,9 @@
 # Updated: 2026-03-09 — Reduce blocking chat timeout from 3600s to 300s
 # Updated: 2026-02-25 — Tighten SSE session filter: block events without session_key
 #   instead of silently passing them through to all clients.
+# Updated: 2026-04-22 — Thread cloud user + active_workspace from the
+#   authenticated request into ``InboundMessage.metadata`` so agent-created
+#   pockets land under the caller, not the first user in the DB.
 #
 # Enables external clients to send messages and receive responses via HTTP.
 # SSE streaming reuses the entire AgentLoop pipeline via _APISessionBridge.
@@ -13,12 +16,56 @@ import asyncio
 import json
 import logging
 import uuid
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 
 from pocketpaw.api.deps import require_scope
 from pocketpaw.api.v1.schemas.chat import ChatRequest, ChatResponse
+
+# ── Optional ee.cloud auth wiring ──────────────────────────────────────
+# When the enterprise cloud module is mounted, we want to read the caller's
+# authenticated user + active workspace off the JWT so agent-created pockets
+# route to the right tenant. When it isn't mounted (self-hosted OSS, CLI,
+# Telegram), we fall back to a no-op dep that yields ``(None, None)`` — the
+# downstream pocket creator keeps its current first-user heuristic.
+try:
+    from ee.cloud.auth.core import current_optional_user as _cloud_optional_user
+
+    _CLOUD_AUTH_AVAILABLE = True
+except Exception:  # noqa: BLE001
+    _cloud_optional_user = None  # type: ignore[assignment]
+    _CLOUD_AUTH_AVAILABLE = False
+
+
+def _noop_user_dep() -> None:
+    """Zero-dependency placeholder. Used when ee.cloud is not mounted so
+    that ``resolve_cloud_context`` keeps a uniform signature either way —
+    FastAPI happily resolves a dep that takes no sub-deps and returns None."""
+    return None
+
+
+# Pick the real cloud dep when it's importable, else a no-op that just
+# yields ``None``. Keeping the callable identity stable lets the single
+# ``resolve_cloud_context`` definition below work in both environments
+# without conditional signatures (mypy is happier this way too).
+_effective_user_dep = _cloud_optional_user if _CLOUD_AUTH_AVAILABLE else _noop_user_dep
+
+
+async def resolve_cloud_context(
+    user: Any = Depends(_effective_user_dep),
+) -> tuple[str | None, str | None]:
+    """Extract ``(user_id, active_workspace)`` from the cloud JWT session.
+
+    Returns ``(None, None)`` when the caller is unauthenticated or when
+    ``ee.cloud`` is not mounted at all — preserves CLI / Telegram /
+    self-hosted behaviour.
+    """
+    if user is None:
+        return None, None
+    return str(user.id), getattr(user, "active_workspace", None)
+
 
 logger = logging.getLogger(__name__)
 
@@ -194,10 +241,18 @@ class _APISessionBridge:
             bus.unsubscribe_system(self._system_cb)
 
 
-async def _build_inbound_message(chat_request: ChatRequest):
+async def _build_inbound_message(
+    chat_request: ChatRequest,
+    cloud_ctx: tuple[str | None, str | None] = (None, None),
+):
     """Build an InboundMessage for ``chat_request`` — shared by the bus
     dispatch path (default loop) and the direct-call path (per-agent loop).
     Returns ``(chat_id, InboundMessage)``.
+
+    ``cloud_ctx`` carries the caller's ``(user_id, active_workspace)`` when
+    the request was authenticated via the cloud JWT. When both are None we
+    leave metadata untouched so non-cloud callers (CLI, Telegram, Discord,
+    self-hosted) behave identically to before.
     """
     from pocketpaw.bus.events import Channel, InboundMessage
     from pocketpaw.uploads.resolver import resolve_media_with_records
@@ -209,6 +264,16 @@ async def _build_inbound_message(chat_request: ChatRequest):
         meta["file_context"] = chat_request.file_context.model_dump(exclude_none=True)
     if chat_request.agent_id:
         meta["agent_id"] = chat_request.agent_id
+
+    # Thread the authenticated user + active workspace through to the agent
+    # loop so downstream code (agent pocket creation, audit logging, etc.)
+    # can attribute work to the correct tenant. Omit keys when absent so
+    # the fallback branches downstream can still trigger.
+    cloud_user_id, cloud_workspace_id = cloud_ctx
+    if cloud_user_id:
+        meta["cloud_user_id"] = cloud_user_id
+    if cloud_workspace_id:
+        meta["cloud_workspace_id"] = cloud_workspace_id
 
     # Resolve ``/api/v1/uploads/{id}`` URLs to (path, FileRecord) pairs so the
     # agent prompt can carry filename / mime / size, not just a bare disk path.
@@ -271,17 +336,23 @@ async def _build_inbound_message(chat_request: ChatRequest):
     return chat_id, msg
 
 
-async def _send_message(chat_request: ChatRequest) -> str:
+async def _send_message(
+    chat_request: ChatRequest,
+    cloud_ctx: tuple[str | None, str | None] = (None, None),
+) -> str:
     """Dispatch the message to the default loop (via bus) or to a per-agent
     loop directly when ``chat_request.agent_id`` is set.
 
     Per-agent loops bypass the bus consumer to avoid racing with the
     default loop for InboundMessages. Outbound events still flow through
     the bus so the SSE bridge sees them unchanged.
+
+    ``cloud_ctx`` is the ``(user_id, active_workspace)`` pair resolved from
+    the cloud JWT, propagated through to ``InboundMessage.metadata``.
     """
     from pocketpaw.bus import get_message_bus
 
-    chat_id, msg = await _build_inbound_message(chat_request)
+    chat_id, msg = await _build_inbound_message(chat_request, cloud_ctx=cloud_ctx)
 
     if chat_request.agent_id:
         try:
@@ -302,7 +373,10 @@ async def _send_message(chat_request: ChatRequest) -> str:
 
 
 @router.post("/chat", response_model=ChatResponse)
-async def chat_send(body: ChatRequest):
+async def chat_send(
+    body: ChatRequest,
+    cloud_ctx: tuple[str | None, str | None] = Depends(resolve_cloud_context),
+):
     """Send a message and get the complete response (non-streaming)."""
     chat_id = _extract_chat_id(body.session_id)
     bridge = _APISessionBridge(chat_id)
@@ -315,7 +389,8 @@ async def chat_send(body: ChatRequest):
             media=body.media,
             file_context=body.file_context,
             agent_id=body.agent_id,
-        )
+        ),
+        cloud_ctx=cloud_ctx,
     )
 
     # Collect all chunks until stream_end
@@ -350,7 +425,10 @@ async def chat_send(body: ChatRequest):
 
 
 @router.post("/chat/stream")
-async def chat_stream(body: ChatRequest):
+async def chat_stream(
+    body: ChatRequest,
+    cloud_ctx: tuple[str | None, str | None] = Depends(resolve_cloud_context),
+):
     """Send a message and receive SSE stream back."""
     chat_id = _extract_chat_id(body.session_id)
     safe_key = _to_safe_key(chat_id)
@@ -401,7 +479,8 @@ async def chat_stream(body: ChatRequest):
             media=body.media,
             file_context=body.file_context,
             agent_id=body.agent_id,
-        )
+        ),
+        cloud_ctx=cloud_ctx,
     )
 
     async def _event_generator():

--- a/tests/test_agent_loop_pocket_threading.py
+++ b/tests/test_agent_loop_pocket_threading.py
@@ -74,18 +74,23 @@ def _install_ee_cloud_stubs(monkeypatch, *, user, workspace_by_id=None, create_r
     _SessionDoc.find_one = AsyncMock(return_value=None)  # type: ignore[attr-defined]
     fake_session_mod.Session = _SessionDoc
 
-    # PocketService.create(...) — returns the created pocket doc.
+    # pockets_service.create(...) — returns the created pocket doc.
+    # 2026-05-12 rebase: the production code now imports
+    # ``from ee.cloud.pockets.dto import CreatePocketRequest`` (was
+    # ``.schemas``) and calls ``pockets_service.create(workspace_id,
+    # user_id, body)`` as a module-level function (was
+    # ``PocketService.create``). Stubs updated to match.
     pocket_create = AsyncMock(return_value=create_ret or {"_id": "pocket-xyz"})
-    fake_pockets_schemas = types.ModuleType("ee.cloud.pockets.schemas")
+    fake_pockets_dto = types.ModuleType("ee.cloud.pockets.dto")
 
     class _CreatePocketRequest:
         def __init__(self, **kwargs):
             self.kwargs = kwargs
 
-    fake_pockets_schemas.CreatePocketRequest = _CreatePocketRequest
+    fake_pockets_dto.CreatePocketRequest = _CreatePocketRequest
 
     fake_pockets_service = types.ModuleType("ee.cloud.pockets.service")
-    fake_pockets_service.PocketService = SimpleNamespace(create=pocket_create)
+    fake_pockets_service.create = pocket_create
 
     # PydanticObjectId(oid) — just return the string, the stub get/find
     # operations don't care about the real type.
@@ -101,7 +106,7 @@ def _install_ee_cloud_stubs(monkeypatch, *, user, workspace_by_id=None, create_r
         "ee.cloud.models.workspace": fake_ws_mod,
         "ee.cloud.models.session": fake_session_mod,
         "ee.cloud.pockets": types.ModuleType("ee.cloud.pockets"),
-        "ee.cloud.pockets.schemas": fake_pockets_schemas,
+        "ee.cloud.pockets.dto": fake_pockets_dto,
         "ee.cloud.pockets.service": fake_pockets_service,
     }.items():
         monkeypatch.setitem(sys.modules, name, mod)

--- a/tests/test_agent_loop_pocket_threading.py
+++ b/tests/test_agent_loop_pocket_threading.py
@@ -1,0 +1,352 @@
+# Tests for cloud user + workspace threading through the agent loop
+# pocket-creation path.
+# Created: 2026-04-22
+#
+# Covers ``_create_pocket_and_session`` and ``_publish_pocket_event``
+# in ``src/pocketpaw/agents/loop.py``. The module imports ee.cloud
+# models inside the function bodies, so we stub out the ``ee.cloud``
+# namespace via ``sys.modules`` before the call hits the import.
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _install_ee_cloud_stubs(monkeypatch, *, user, workspace_by_id=None, create_ret=None):
+    """Install fake ee.cloud.* modules so the loop's lazy imports resolve
+    without spinning up Mongo.
+
+    ``workspace_by_id`` is a dict ``{oid_str: workspace_or_None}`` consulted
+    by the stub ``Workspace.get`` — lets individual tests control whether
+    the active_workspace lookup hits or misses.
+    """
+    workspace_by_id = workspace_by_id or {}
+
+    # ── Fake User/Workspace/Session documents ──────────────────────────
+    get_user = AsyncMock(return_value=user)
+    find_user = AsyncMock(return_value=user)
+
+    # Workspace.get(oid) — dict-driven so tests can control hit/miss.
+    async def _ws_get(oid):
+        return workspace_by_id.get(str(oid))
+
+    get_ws = AsyncMock(side_effect=_ws_get)
+    # first-owned / any-workspace fallbacks
+    find_owned_ws = AsyncMock(return_value=None)
+
+    fake_user_mod = types.ModuleType("ee.cloud.models.user")
+    fake_user_mod.User = SimpleNamespace(get=get_user, find_one=find_user)
+
+    fake_ws_mod = types.ModuleType("ee.cloud.models.workspace")
+
+    class _WorkspaceStub:
+        # Mimic the Beanie Document constants used in the loop call
+        # (``Workspace.owner == user_id`` — evaluating at import time).
+        owner = "owner"  # placeholder; find_one mock ignores the value
+
+    _WorkspaceStub.get = get_ws
+    _WorkspaceStub.find_one = find_owned_ws
+    fake_ws_mod.Workspace = _WorkspaceStub
+
+    fake_session_mod = types.ModuleType("ee.cloud.models.session")
+    # Session(...) is instantiated inside the loop — return a spy instance.
+    session_insert = AsyncMock()
+
+    class _SessionDoc:
+        # The loop does ``Session.find_one(Session.sessionId == safe_key)``,
+        # so ``sessionId`` has to resolve to *something* that supports ``==``.
+        sessionId = "sessionId"  # placeholder — find_one ignores the value
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def insert(self):
+            await session_insert(self.kwargs)
+
+        async def save(self):  # used when an existing session is updated
+            pass
+
+    _SessionDoc.find_one = AsyncMock(return_value=None)  # type: ignore[attr-defined]
+    fake_session_mod.Session = _SessionDoc
+
+    # PocketService.create(...) — returns the created pocket doc.
+    pocket_create = AsyncMock(return_value=create_ret or {"_id": "pocket-xyz"})
+    fake_pockets_schemas = types.ModuleType("ee.cloud.pockets.schemas")
+
+    class _CreatePocketRequest:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    fake_pockets_schemas.CreatePocketRequest = _CreatePocketRequest
+
+    fake_pockets_service = types.ModuleType("ee.cloud.pockets.service")
+    fake_pockets_service.PocketService = SimpleNamespace(create=pocket_create)
+
+    # PydanticObjectId(oid) — just return the string, the stub get/find
+    # operations don't care about the real type.
+    fake_beanie = types.ModuleType("beanie")
+    fake_beanie.PydanticObjectId = lambda s: s  # type: ignore[assignment]
+
+    # Install stubs
+    for name, mod in {
+        "ee": types.ModuleType("ee"),
+        "ee.cloud": types.ModuleType("ee.cloud"),
+        "ee.cloud.models": types.ModuleType("ee.cloud.models"),
+        "ee.cloud.models.user": fake_user_mod,
+        "ee.cloud.models.workspace": fake_ws_mod,
+        "ee.cloud.models.session": fake_session_mod,
+        "ee.cloud.pockets": types.ModuleType("ee.cloud.pockets"),
+        "ee.cloud.pockets.schemas": fake_pockets_schemas,
+        "ee.cloud.pockets.service": fake_pockets_service,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    # beanie may or may not already be importable — ensure PydanticObjectId
+    # is a callable that doesn't choke on strings like "not-an-oid".
+    monkeypatch.setitem(sys.modules, "beanie", fake_beanie)
+
+    return SimpleNamespace(
+        pocket_create=pocket_create,
+        find_user=find_user,
+        get_user=get_user,
+        get_ws=get_ws,
+        find_owned_ws=find_owned_ws,
+        session_insert=session_insert,
+    )
+
+
+def _mk_user(user_id="u1", active_workspace=None):
+    return SimpleNamespace(id=user_id, active_workspace=active_workspace)
+
+
+def _mk_workspace(ws_id):
+    return SimpleNamespace(id=ws_id, owner="u1")
+
+
+@pytest.mark.asyncio
+async def test_explicit_user_and_workspace_are_used(monkeypatch):
+    """When cloud_user_id + cloud_workspace_id are passed, the pocket is
+    created against exactly those ids — no find_one fallback."""
+    from pocketpaw.agents import loop as loop_mod
+
+    user = _mk_user(user_id="u-alice", active_workspace="ws-stale")
+    ws_active = _mk_workspace("ws-active")
+
+    stubs = _install_ee_cloud_stubs(
+        monkeypatch,
+        user=user,
+        workspace_by_id={"ws-active": ws_active},
+    )
+
+    result = await loop_mod._create_pocket_and_session(
+        spec={"title": "Dashboard", "metadata": {"category": "custom"}},
+        session_key="websocket:abc",
+        user_id="u-alice",
+        workspace_id="ws-active",
+    )
+
+    assert result == "pocket-xyz"
+    # Workspace.get must have been called with the explicit id.
+    stubs.get_ws.assert_awaited_with("ws-active")
+    # PocketService.create must receive the explicit workspace_id + user_id.
+    args = stubs.pocket_create.await_args.args
+    assert args[0] == "ws-active"
+    assert args[1] == "u-alice"
+    # User.find_one must NOT have been consulted — explicit user_id wins.
+    stubs.find_user.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_only_user_id_falls_back_to_active_workspace(monkeypatch):
+    """When workspace_id is missing but user_id is given, ``user.active_workspace``
+    is used — not the legacy ``Workspace.find_one(owner=...)`` fallback."""
+    from pocketpaw.agents import loop as loop_mod
+
+    user = _mk_user(user_id="u-alice", active_workspace="ws-active")
+    ws_active = _mk_workspace("ws-active")
+
+    stubs = _install_ee_cloud_stubs(
+        monkeypatch,
+        user=user,
+        workspace_by_id={"ws-active": ws_active},
+    )
+
+    result = await loop_mod._create_pocket_and_session(
+        spec={"title": "Dashboard"},
+        session_key="websocket:abc",
+        user_id="u-alice",
+    )
+
+    assert result == "pocket-xyz"
+    stubs.get_ws.assert_awaited_with("ws-active")
+    # find_one (the legacy fallback) must never fire.
+    stubs.find_owned_ws.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_ids_falls_back_to_first_user_and_owned_workspace(monkeypatch):
+    """No context → legacy behaviour. Preserves single-user self-hosted."""
+    from pocketpaw.agents import loop as loop_mod
+
+    user = _mk_user(user_id="u-first", active_workspace=None)
+    ws_owned = _mk_workspace("ws-owned")
+
+    stubs = _install_ee_cloud_stubs(
+        monkeypatch,
+        user=user,
+        workspace_by_id={},  # no active_workspace — get() misses
+    )
+    stubs.find_owned_ws.return_value = ws_owned
+
+    result = await loop_mod._create_pocket_and_session(
+        spec={"title": "Dashboard"},
+        session_key="websocket:abc",
+    )
+
+    assert result == "pocket-xyz"
+    stubs.find_user.assert_awaited()
+    stubs.find_owned_ws.assert_awaited()
+    args = stubs.pocket_create.await_args.args
+    assert args[0] == "ws-owned"
+    assert args[1] == "u-first"
+
+
+@pytest.mark.asyncio
+async def test_invalid_user_id_falls_back_cleanly(monkeypatch, caplog):
+    """An unparseable cloud_user_id logs a warning and falls back to
+    ``User.find_one`` rather than raising."""
+    import logging
+
+    from pocketpaw.agents import loop as loop_mod
+
+    user = _mk_user(user_id="u-fallback", active_workspace="ws-active")
+    ws_active = _mk_workspace("ws-active")
+
+    stubs = _install_ee_cloud_stubs(
+        monkeypatch,
+        user=user,
+        workspace_by_id={"ws-active": ws_active},
+    )
+
+    # Force PydanticObjectId to raise on a specific bad id.
+    import beanie  # our stubbed version
+
+    def _bad_oid(s):
+        if s == "not-an-oid":
+            raise ValueError("bad oid")
+        return s
+
+    monkeypatch.setattr(beanie, "PydanticObjectId", _bad_oid)
+
+    caplog.set_level(logging.WARNING, logger="pocketpaw.agents.loop")
+
+    result = await loop_mod._create_pocket_and_session(
+        spec={"title": "Dashboard"},
+        session_key="websocket:abc",
+        user_id="not-an-oid",
+    )
+
+    assert result == "pocket-xyz"
+    assert any("Invalid cloud_user_id" in rec.message for rec in caplog.records)
+    stubs.find_user.assert_awaited()  # fallback engaged
+    args = stubs.pocket_create.await_args.args
+    assert args[1] == "u-fallback"
+
+
+@pytest.mark.asyncio
+async def test_session_is_linked_with_correct_workspace(monkeypatch):
+    """The Session document created alongside the pocket is keyed to the
+    explicit workspace/user ids, not the legacy fallback."""
+    from pocketpaw.agents import loop as loop_mod
+
+    user = _mk_user(user_id="u-alice", active_workspace=None)
+    ws_active = _mk_workspace("ws-active")
+
+    stubs = _install_ee_cloud_stubs(
+        monkeypatch,
+        user=user,
+        workspace_by_id={"ws-active": ws_active},
+    )
+
+    await loop_mod._create_pocket_and_session(
+        spec={"title": "Dashboard"},
+        session_key="websocket:abc",
+        user_id="u-alice",
+        workspace_id="ws-active",
+    )
+
+    # Session insert captured the expected workspace + owner.
+    stubs.session_insert.assert_awaited()
+    recorded = stubs.session_insert.await_args.args[0]
+    assert recorded["workspace"] == "ws-active"
+    assert recorded["owner"] == "u-alice"
+    assert recorded["sessionId"] == "websocket_abc"
+    assert recorded["pocket"] == "pocket-xyz"
+
+
+@pytest.mark.asyncio
+async def test_publish_pocket_event_forwards_metadata(monkeypatch):
+    """``_publish_pocket_event`` pulls cloud_user_id + cloud_workspace_id out
+    of the passed metadata dict and forwards them to the pocket creator."""
+    from pocketpaw.agents import loop as loop_mod
+
+    captured: dict = {}
+
+    async def _fake_create(spec, session_key, user_id=None, workspace_id=None):
+        captured["spec"] = spec
+        captured["session_key"] = session_key
+        captured["user_id"] = user_id
+        captured["workspace_id"] = workspace_id
+        return "pocket-123"
+
+    monkeypatch.setattr(loop_mod, "_create_pocket_and_session", _fake_create)
+
+    # Minimal bus stub — only publish_system is called.
+    bus = MagicMock()
+    bus.publish_system = AsyncMock()
+
+    content = '{"pocket_event": "created", "spec": {"title": "Dashboard"}}'
+    metadata = {
+        "cloud_user_id": "u-alice",
+        "cloud_workspace_id": "ws-active",
+        "source": "rest_api",
+    }
+
+    await loop_mod._publish_pocket_event(bus, content, "websocket:abc", metadata)
+
+    assert captured["user_id"] == "u-alice"
+    assert captured["workspace_id"] == "ws-active"
+    assert captured["session_key"] == "websocket:abc"
+    bus.publish_system.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_publish_pocket_event_without_metadata_uses_none(monkeypatch):
+    """Default metadata (None) is safe — the creator sees user_id=None,
+    workspace_id=None and hits the legacy fallback path."""
+    from pocketpaw.agents import loop as loop_mod
+
+    captured: dict = {}
+
+    async def _fake_create(spec, session_key, user_id=None, workspace_id=None):
+        captured["user_id"] = user_id
+        captured["workspace_id"] = workspace_id
+        return None
+
+    monkeypatch.setattr(loop_mod, "_create_pocket_and_session", _fake_create)
+
+    bus = MagicMock()
+    bus.publish_system = AsyncMock()
+
+    content = '{"pocket_event": "created", "spec": {"title": "x"}}'
+
+    # No metadata kwarg passed — backwards-compatible call shape.
+    await loop_mod._publish_pocket_event(bus, content, "websocket:abc")
+
+    assert captured["user_id"] is None
+    assert captured["workspace_id"] is None

--- a/tests/test_api_chat_cloud_context.py
+++ b/tests/test_api_chat_cloud_context.py
@@ -1,0 +1,161 @@
+# Tests for cloud user + active_workspace threading through the chat endpoints.
+# Created: 2026-04-22
+#
+# The chat router populates ``InboundMessage.metadata`` with
+# ``cloud_user_id`` + ``cloud_workspace_id`` when ``resolve_cloud_context``
+# returns a non-None user.
+#
+# We exercise the chat module at two levels:
+#   1. ``resolve_cloud_context`` — the FastAPI dep itself, unit-level.
+#   2. ``_build_inbound_message`` / ``_send_message`` — direct calls that
+#      capture the InboundMessage published to the bus so we can assert
+#      on metadata without standing up TestClient + streaming machinery.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def stub_bus(monkeypatch):
+    """Replace the message bus so publish_inbound captures the message
+    instead of routing it through the real loop."""
+    captured: dict = {}
+
+    class _StubBus:
+        async def publish_inbound(self, msg):
+            captured["msg"] = msg
+
+    from pocketpaw import bus as bus_mod
+
+    monkeypatch.setattr(bus_mod, "get_message_bus", lambda: _StubBus())
+    return captured
+
+
+@pytest.fixture(autouse=True)
+def stub_resolver(monkeypatch):
+    """Short-circuit media resolution so _build_inbound_message doesn't
+    attempt to read real files for our synthetic requests."""
+    from pocketpaw.uploads import resolver as resolver_mod
+
+    async def _noop(urls):
+        return []
+
+    monkeypatch.setattr(resolver_mod, "resolve_media_with_records", _noop)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_resolve_cloud_context_returns_none_pair_for_null_user():
+    """``resolve_cloud_context`` yields ``(None, None)`` when no user is
+    authenticated. Works whether or not ee.cloud is mounted — both
+    branches of the top-level try/except define a dep with this contract."""
+    import inspect
+
+    from pocketpaw.api.v1.chat import resolve_cloud_context
+
+    sig = inspect.signature(resolve_cloud_context)
+    if "user" in sig.parameters:
+        result = await resolve_cloud_context(user=None)  # type: ignore[call-arg]
+    else:
+        result = await resolve_cloud_context()
+    assert result == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_resolve_cloud_context_returns_ids_for_authenticated_user():
+    """With a resolved user, the dep yields (user_id, active_workspace)."""
+    import inspect
+
+    from pocketpaw.api.v1.chat import resolve_cloud_context
+
+    user = SimpleNamespace(id="u-alice", active_workspace="ws-active")
+
+    sig = inspect.signature(resolve_cloud_context)
+    if "user" in sig.parameters:
+        uid, wsid = await resolve_cloud_context(user=user)  # type: ignore[call-arg]
+        assert uid == "u-alice"
+        assert wsid == "ws-active"
+    else:
+        # ee.cloud not mounted in this environment — the dep is zero-arg.
+        # In that case the only contract is (None, None), which is what
+        # the no-auth case covers. Skip this assertion cleanly.
+        pytest.skip("ee.cloud not mounted — nothing to auth against")
+
+
+@pytest.mark.asyncio
+async def test_build_inbound_message_writes_cloud_keys_when_present():
+    """Given a non-empty cloud_ctx, the built message carries both ids
+    in metadata."""
+    from pocketpaw.api.v1.chat import _build_inbound_message
+    from pocketpaw.api.v1.schemas.chat import ChatRequest
+
+    req = ChatRequest(content="hi", session_id=None, media=[])
+    _, msg = await _build_inbound_message(req, cloud_ctx=("u-alice", "ws-active"))
+
+    assert msg.metadata["cloud_user_id"] == "u-alice"
+    assert msg.metadata["cloud_workspace_id"] == "ws-active"
+    assert msg.metadata["source"] == "rest_api"
+
+
+@pytest.mark.asyncio
+async def test_build_inbound_message_omits_missing_keys():
+    """Partial cloud_ctx (only user_id, no workspace) writes only the
+    populated key — the missing key is absent from the dict so the
+    downstream fallback branches can trigger."""
+    from pocketpaw.api.v1.chat import _build_inbound_message
+    from pocketpaw.api.v1.schemas.chat import ChatRequest
+
+    req = ChatRequest(content="hi", session_id=None, media=[])
+    _, msg = await _build_inbound_message(req, cloud_ctx=("u-alice", None))
+
+    assert msg.metadata["cloud_user_id"] == "u-alice"
+    assert "cloud_workspace_id" not in msg.metadata
+
+
+@pytest.mark.asyncio
+async def test_build_inbound_message_default_cloud_ctx_is_empty():
+    """No cloud_ctx (default) leaves metadata without cloud_* keys so
+    non-cloud callers (CLI, Telegram, Discord) behave as before."""
+    from pocketpaw.api.v1.chat import _build_inbound_message
+    from pocketpaw.api.v1.schemas.chat import ChatRequest
+
+    req = ChatRequest(content="hi", session_id=None, media=[])
+    _, msg = await _build_inbound_message(req)
+
+    assert "cloud_user_id" not in msg.metadata
+    assert "cloud_workspace_id" not in msg.metadata
+    assert msg.metadata["source"] == "rest_api"
+
+
+@pytest.mark.asyncio
+async def test_send_message_propagates_cloud_ctx_to_bus(stub_bus):
+    """_send_message threads cloud_ctx through to the InboundMessage
+    published on the bus. This is the contract the agent loop reads."""
+    from pocketpaw.api.v1.chat import _send_message
+    from pocketpaw.api.v1.schemas.chat import ChatRequest
+
+    req = ChatRequest(content="make me a dashboard", session_id=None, media=[])
+    await _send_message(req, cloud_ctx=("u-alice", "ws-active"))
+
+    msg = stub_bus["msg"]
+    assert msg.content == "make me a dashboard"
+    assert msg.metadata["cloud_user_id"] == "u-alice"
+    assert msg.metadata["cloud_workspace_id"] == "ws-active"
+
+
+@pytest.mark.asyncio
+async def test_send_message_without_cloud_ctx_publishes_clean_metadata(stub_bus):
+    """_send_message with the default cloud_ctx leaves metadata without
+    cloud_* keys — the non-cloud, backwards-compatible path."""
+    from pocketpaw.api.v1.chat import _send_message
+    from pocketpaw.api.v1.schemas.chat import ChatRequest
+
+    req = ChatRequest(content="hi", session_id=None, media=[])
+    await _send_message(req)
+
+    msg = stub_bus["msg"]
+    assert "cloud_user_id" not in msg.metadata
+    assert "cloud_workspace_id" not in msg.metadata


### PR DESCRIPTION
## Why

Agent-created pockets have been landing in whatever workspace Mongo returned first. The two offending lines in `src/pocketpaw/agents/loop.py`:

```python
user = await User.find_one()
...
workspace = await Workspace.find_one(Workspace.owner == user_id)
if not workspace:
    workspace = await Workspace.find_one()
```

In a multi-workspace deployment that routes every chat-created pocket to the wrong place. We hit it during local testing — pockets created via "make me a dashboard" in the UI always opened in the default workspace, not the one the user had selected.

## Change

Thread the caller's identity from the chat endpoint to the pocket creator:

- `src/pocketpaw/api/v1/chat.py`
  - Optional `resolve_cloud_context` dep. When ee.cloud is mounted and the caller has a JWT, it yields `(user_id, active_workspace)`. When ee.cloud is not mounted or the caller is unauthenticated, it yields `(None, None)`. Keeps a single signature in both branches so mypy stays happy and FastAPI can bind the dep cleanly.
  - `_build_inbound_message` and `_send_message` accept the resolved tuple and write `cloud_user_id` / `cloud_workspace_id` onto `InboundMessage.metadata`. Missing ids mean missing keys, not None values — so downstream fallback branches can trigger cleanly.

- `src/pocketpaw/agents/loop.py`
  - `_create_pocket_and_session` takes optional `user_id` / `workspace_id`. Resolution order:
    1. explicit `user_id` from metadata
    2. `User.find_one()` fallback
    3. explicit `workspace_id` from metadata
    4. `user.active_workspace`
    5. first-owned workspace
    6. any workspace
  - `_publish_pocket_event` accepts `metadata`, forwards the `cloud_*` keys to the creator. Call site at `_process_message_inner` passes `message.metadata`.

The behaviour change is strictly additive: a request that carries a cloud user pins the pocket to that user's active workspace; a request that does not (CLI, Telegram, Discord, self-hosted OSS) hits the same first-user path as before.

## Tests

Two new files, 14 new cases total, all green:

- `tests/test_agent_loop_pocket_threading.py` (7 cases)
  - explicit ids are used verbatim
  - user_id alone falls back to `user.active_workspace`
  - no ids falls back to the legacy first-user / first-owned path
  - an unparseable `cloud_user_id` logs and falls back cleanly
  - Session document is linked to the correct workspace + owner
  - `_publish_pocket_event` forwards metadata through
  - `_publish_pocket_event` with `metadata=None` is safe

- `tests/test_api_chat_cloud_context.py` (7 cases)
  - `resolve_cloud_context` yields `(None, None)` without a user
  - `resolve_cloud_context` yields `(id, active_workspace)` with one
  - `_build_inbound_message` writes both keys when both are present
  - `_build_inbound_message` omits missing keys (no None values)
  - default `cloud_ctx=(None, None)` leaves metadata clean
  - `_send_message` propagates the tuple to the bus
  - `_send_message` without context publishes clean metadata

Existing chat + agent loop tests still pass.

## Verification

```bash
uv run pytest tests/test_agent_loop_pocket_threading.py tests/test_api_chat_cloud_context.py tests/test_api_chat.py tests/test_agent_loop.py tests/test_pocket_tool.py -q
# 72 passed

uv run ruff check src/pocketpaw/agents/loop.py src/pocketpaw/api/v1/chat.py tests/test_agent_loop_pocket_threading.py tests/test_api_chat_cloud_context.py
# All checks passed!

uv run ruff format --check <same paths>
# 4 files already formatted

uv run mypy src/pocketpaw/api/v1/chat.py
# No new errors — only pre-existing camelCase / Callable-None issues on main
```

## Notes

- Base branch is `ee` rather than `main` because the ee.cloud module, User/Workspace models, and the pocket tool itself live only on `ee`. Happy to rebase to `main` if the cloud module gets promoted there, but right now a PR against `main` has nothing to patch.
- `src/pocketpaw/dashboard_auth.py` is untouched — the captain's local patch there is a separate concern.
- Resolution still falls back to `User.find_one()` as a last resort so single-user self-hosted keeps working. Tightening that further can wait for a clean multi-channel user identity story.