### PR TITLE
fix(automations): prune orphan [auto] intentions on startup

### DIFF
--- a/src/pocketpaw/dashboard_lifecycle.py
+++ b/src/pocketpaw/dashboard_lifecycle.py
@@ -344,7 +344,16 @@ async def startup_event(
     scheduler = get_scheduler()
     scheduler.start(callback=broadcast_reminder)
 
-    # Start proactive daemon
+    # Start proactive daemon. Prune orphan ``[auto] *`` intentions first so
+    # bridged-from-EE entries whose Rule no longer exists don't keep
+    # firing crons forever (test fixtures, deleted rules, manual edits).
+    try:
+        from pocketpaw.ee.automations.bridge import prune_orphan_auto_intentions
+
+        prune_orphan_auto_intentions()
+    except Exception:
+        logger.exception("Failed to prune orphan [auto] intentions; continuing")
+
     daemon = get_daemon()
     daemon.start(stream_callback=broadcast_intention)
 

--- a/src/pocketpaw/ee/automations/bridge.py
+++ b/src/pocketpaw/ee/automations/bridge.py
@@ -1,6 +1,11 @@
 # bridge.py — Syncs enterprise automation rules to core daemon intentions.
 # Created: 2026-03-30 — Schedule/threshold/data_change rules mapped to daemon
 #   intentions with cron triggers. Supports create, update, and delete sync.
+# Updated: 2026-04-27 — Added ``prune_orphan_auto_intentions()`` so the
+#   startup path can drop bridged ``[auto] *`` intentions whose source
+#   Rule no longer exists. Tests that don't isolate ``~/.pocketpaw/`` left
+#   stale entries that re-saved on every cron fire and registered phantom
+#   jobs with the trigger engine on every restart.
 
 """
 bridge.py — Syncs enterprise automation rules to core daemon intentions.
@@ -105,3 +110,50 @@ def unsync_rule_from_daemon(rule: Rule) -> bool:
     except Exception as e:
         logger.warning("Failed to unsync rule %s: %s", rule.id, e)
         return False
+
+
+_AUTO_PREFIX = "[auto] "
+
+
+def prune_orphan_auto_intentions() -> int:
+    """Drop ``[auto] *`` daemon intentions whose source Rule no longer exists.
+
+    The bridge writes ``[auto] <name>`` intentions when an EE automation rule
+    is created. If the rule is deleted out-of-band — test fixtures that don't
+    isolate ``~/.pocketpaw/``, manual edits to ``automations/rules.json``,
+    a corrupted rules file — the linked intention stays in
+    ``intentions.json`` and keeps firing its cron forever. Run this on
+    startup so a clean slate stays clean.
+
+    A bridged intention is "orphan" when no Rule has
+    ``linked_intention_id`` pointing at it.
+
+    Returns the number of intentions pruned.
+    """
+    from pocketpaw.daemon.intentions import get_intention_store
+    from pocketpaw.ee.automations.store import get_automation_store
+
+    intention_store = get_intention_store()
+    automation_store = get_automation_store()
+
+    valid_ids: set[str] = {
+        rule.linked_intention_id
+        for rule in automation_store.list_rules()
+        if rule.linked_intention_id
+    }
+
+    pruned = 0
+    # ``get_all`` returns a copy, so deleting during iteration is safe, but
+    # snapshot anyway to be explicit about intent.
+    for intention in list(intention_store.get_all()):
+        name = intention.get("name", "")
+        if not name.startswith(_AUTO_PREFIX):
+            continue
+        if intention["id"] in valid_ids:
+            continue
+        intention_store.delete(intention["id"])
+        pruned += 1
+
+    if pruned:
+        logger.info("Pruned %d orphan [auto] intentions on startup", pruned)
+    return pruned

--- a/tests/cloud/test_automations_prune.py
+++ b/tests/cloud/test_automations_prune.py
@@ -1,0 +1,126 @@
+# test_automations_prune.py — Tests for prune_orphan_auto_intentions().
+# Created: 2026-04-27 — Cover the startup-time orphan sweep so bridged
+#   ``[auto] *`` intentions whose Rule no longer exists don't keep firing
+#   crons forever. All file I/O uses tmp_path; no writes to ~/.pocketpaw.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pocketpaw.daemon.intentions import IntentionStore
+from pocketpaw.ee.automations.bridge import prune_orphan_auto_intentions
+from pocketpaw.ee.automations.models import CreateRuleRequest, RuleType
+from pocketpaw.ee.automations.store import AutomationStore
+
+
+@pytest.fixture
+def isolated_stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Patch both singleton getters with tmp_path-backed instances."""
+    monkeypatch.setattr(
+        "pocketpaw.daemon.intentions.get_intentions_path",
+        lambda: tmp_path / "intentions.json",
+    )
+    intention_store = IntentionStore()
+    automation_store = AutomationStore(path=tmp_path / "rules.json")
+
+    # ``prune_orphan_auto_intentions`` lazy-imports both getters inside the
+    # function body to avoid circular deps, so patch their canonical
+    # locations rather than re-binding on the bridge module.
+    with (
+        patch(
+            "pocketpaw.daemon.intentions.get_intention_store",
+            return_value=intention_store,
+        ),
+        patch(
+            "pocketpaw.ee.automations.store.get_automation_store",
+            return_value=automation_store,
+        ),
+    ):
+        yield intention_store, automation_store
+
+
+def _add_auto_intention(store: IntentionStore, name: str) -> dict:
+    return store.create(
+        name=f"[auto] {name}",
+        prompt="seeded for test",
+        trigger={"type": "cron", "schedule": "*/5 * * * *"},
+        enabled=True,
+    )
+
+
+class TestPruneOrphanAutoIntentions:
+    def test_drops_orphan_auto_intention(self, isolated_stores) -> None:
+        intention_store, _ = isolated_stores
+        _add_auto_intention(intention_store, "Stale rule")
+
+        pruned = prune_orphan_auto_intentions()
+
+        assert pruned == 1
+        assert intention_store.get_all() == []
+
+    def test_keeps_auto_intention_with_live_rule(self, isolated_stores) -> None:
+        intention_store, automation_store = isolated_stores
+        intention = _add_auto_intention(intention_store, "Live rule")
+        rule = automation_store.create_rule(
+            CreateRuleRequest(
+                name="Live rule",
+                description="kept",
+                type=RuleType.SCHEDULE,
+                schedule="0 9 * * 1",
+                action="ping",
+            )
+        )
+        rule.linked_intention_id = intention["id"]
+
+        pruned = prune_orphan_auto_intentions()
+
+        assert pruned == 0
+        assert len(intention_store.get_all()) == 1
+
+    def test_keeps_user_created_intention(self, isolated_stores) -> None:
+        """Non-``[auto]`` entries are user-managed — never touch them."""
+        intention_store, _ = isolated_stores
+        intention_store.create(
+            name="Morning standup",
+            prompt="What are your top 3?",
+            trigger={"type": "cron", "schedule": "0 8 * * 1-5"},
+        )
+
+        pruned = prune_orphan_auto_intentions()
+
+        assert pruned == 0
+        assert len(intention_store.get_all()) == 1
+
+    def test_mixed_set(self, isolated_stores) -> None:
+        intention_store, automation_store = isolated_stores
+        live = _add_auto_intention(intention_store, "Live")
+        _add_auto_intention(intention_store, "Orphan A")
+        _add_auto_intention(intention_store, "Orphan B")
+        intention_store.create(
+            name="User intention",
+            prompt="hi",
+            trigger={"type": "cron", "schedule": "0 * * * *"},
+        )
+
+        rule = automation_store.create_rule(
+            CreateRuleRequest(
+                name="Live",
+                description="kept",
+                type=RuleType.SCHEDULE,
+                schedule="0 9 * * 1",
+                action="ping",
+            )
+        )
+        rule.linked_intention_id = live["id"]
+
+        pruned = prune_orphan_auto_intentions()
+
+        assert pruned == 2
+        names = {i["name"] for i in intention_store.get_all()}
+        assert names == {"[auto] Live", "User intention"}
+
+    def test_no_intentions_is_a_noop(self, isolated_stores) -> None:
+        assert prune_orphan_auto_intentions() == 0


### PR DESCRIPTION
## Summary

Bridged `[auto] *` daemon intentions whose source Rule no longer exists were piling up in `~/.pocketpaw/intentions.json` and re-registering phantom cron jobs on every backend restart, then re-saving themselves on every cron fire (`mark_run` writes the whole list back to disk). Test fixtures that don't isolate the user-data dir reproduced the leak — manual edits to `automations/rules.json` would do the same.

## What changed

- **`bridge.py`** — new `prune_orphan_auto_intentions()` that walks the IntentionStore, drops any `[auto] *` entry whose id isn't pointed at by some Rule's `linked_intention_id`, and leaves user-created intentions alone.
- **`dashboard_lifecycle.py:startup_event`** — calls the pruner before `daemon.start()`. Wrapped in try/except so a transient store error never blocks startup.
- **`tests/cloud/test_automations_prune.py`** — five cases: orphan removal, live-rule retention, user-intention preservation, mixed set, empty-store no-op.

## How an `[auto]` intention becomes orphan

`bridge.sync_rule_to_daemon` records `intention_id` on the Rule, then writes `[auto] <name>` to the IntentionStore. If the Rule disappears via any path that bypasses `unsync_rule_from_daemon` (rules.json deleted, partial test cleanup, file corruption), the intention has no back-reference and survives forever.

## Test plan

- [ ] `uv run pytest tests/cloud/test_automations_prune.py -v` — 5 pass.
- [ ] `uv run pytest tests/cloud/test_ee_automations.py -q` — 42 pass, no regression.
- [ ] `uv run ruff check src/pocketpaw/ee/automations/bridge.py src/pocketpaw/dashboard_lifecycle.py tests/cloud/test_automations_prune.py` — clean.
- [ ] Smoke: with stale `[auto] *` entries in `~/.pocketpaw/intentions.json`, restart the dashboard. Look for `INFO Pruned N orphan [auto] intentions on startup`. Subsequent restarts log `Loaded 0 intentions` and don't register the phantom cron jobs.