### PR TITLE
feat(daemon): log Active intentions count after startup prune

### DIFF
--- a/src/pocketpaw/dashboard_lifecycle.py
+++ b/src/pocketpaw/dashboard_lifecycle.py
@@ -348,9 +348,16 @@ async def startup_event(
     # bridged-from-EE entries whose Rule no longer exists don't keep
     # firing crons forever (test fixtures, deleted rules, manual edits).
     try:
+        from pocketpaw.daemon.intentions import get_intention_store
         from pocketpaw.ee.automations.bridge import prune_orphan_auto_intentions
 
         prune_orphan_auto_intentions()
+        # Single line that tells the truth at startup-completion. The
+        # ``Loaded N intentions`` line from the IntentionStore singleton
+        # fires before pruning and can mislead readers when N includes
+        # orphans that get cleared a few lines later.
+        active = len(get_intention_store().get_enabled())
+        logger.info("Active intentions: %d", active)
     except Exception:
         logger.exception("Failed to prune orphan [auto] intentions; continuing")
 


### PR DESCRIPTION
## Summary

Companion to #1024 / #1025. The IntentionStore singleton emits `Loaded N intentions` during its own `__init__`, which fires before `prune_orphan_auto_intentions` can clear orphans. Readers see `Loaded 11` and assume the daemon registered 11 cron jobs — when in fact the pruner zeroes them out a few lines later and the daemon starts clean.

This adds a single `Active intentions: N` log line right after the prune call so the startup story is honest by the time the user sees the summary.

## Before

```
INFO  Loaded 11 intentions
INFO  Deleted intention: [auto] API threshold rule (...)
... 10 more deletes ...
INFO  Pruned 11 orphan [auto] intentions on startup
INFO  ProactiveDaemon started with 0 enabled intentions
```

## After

```
INFO  Loaded 11 intentions
INFO  Deleted intention: [auto] API threshold rule (...)
... 10 more deletes ...
INFO  Pruned 11 orphan [auto] intentions on startup
INFO  Active intentions: 0
INFO  ProactiveDaemon started with 0 enabled intentions
```

## Verify

- `uv run pytest tests/cloud/test_automations_prune.py tests/cloud/test_ee_automations.py` — 47 pass.
- Restart the dashboard with stale `[auto]` entries; confirm the new log line shows up.