### PR TITLE
fix(daemon): suppress per-item delete log during orphan prune

### DIFF
--- a/src/pocketpaw/daemon/intentions.py
+++ b/src/pocketpaw/daemon/intentions.py
@@ -156,12 +156,15 @@ class IntentionStore:
 
         return None
 
-    def delete(self, intention_id: str) -> bool:
+    def delete(self, intention_id: str, quiet: bool = False) -> bool:
         """
         Delete an intention.
 
         Args:
             intention_id: ID of the intention to delete
+            quiet: When True, skip the per-deletion INFO log. Bulk callers
+                (e.g. the startup orphan pruner) emit a single summary line
+                instead of one log per item.
 
         Returns:
             True if deleted, False if not found
@@ -171,7 +174,8 @@ class IntentionStore:
                 deleted = self.intentions.pop(i)
                 self._save()
 
-                logger.info(f"Deleted intention: {deleted['name']} ({intention_id})")
+                if not quiet:
+                    logger.info(f"Deleted intention: {deleted['name']} ({intention_id})")
                 return True
 
         return False

--- a/src/pocketpaw/ee/automations/bridge.py
+++ b/src/pocketpaw/ee/automations/bridge.py
@@ -151,7 +151,9 @@ def prune_orphan_auto_intentions() -> int:
             continue
         if intention["id"] in valid_ids:
             continue
-        intention_store.delete(intention["id"])
+        # quiet=True suppresses the per-item ``Deleted intention: ...`` INFO
+        # log. The summary line below is the only output we want at boot.
+        intention_store.delete(intention["id"], quiet=True)
         pruned += 1
 
     if pruned:

--- a/tests/cloud/test_automations_prune.py
+++ b/tests/cloud/test_automations_prune.py
@@ -124,3 +124,24 @@ class TestPruneOrphanAutoIntentions:
 
     def test_no_intentions_is_a_noop(self, isolated_stores) -> None:
         assert prune_orphan_auto_intentions() == 0
+
+    def test_prune_emits_only_summary_log(self, isolated_stores, caplog) -> None:
+        """Prune must not log every deletion individually — only the summary."""
+        import logging
+
+        intention_store, _ = isolated_stores
+        for i in range(5):
+            _add_auto_intention(intention_store, f"Orphan {i}")
+
+        with caplog.at_level(logging.INFO):
+            pruned = prune_orphan_auto_intentions()
+
+        assert pruned == 5
+        delete_lines = [r for r in caplog.records if "Deleted intention" in r.message]
+        summary_lines = [
+            r
+            for r in caplog.records
+            if "Pruned" in r.message and "orphan" in r.message
+        ]
+        assert delete_lines == [], "per-item delete log must be suppressed during prune"
+        assert len(summary_lines) == 1, "expected exactly one summary line"

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -123,6 +123,39 @@ class TestIntentionStore:
         found = store.get_by_id(created["id"])
         assert found is None
 
+    def test_delete_logs_at_info_by_default(self, store, caplog):
+        """Default delete emits the per-item INFO log."""
+        import logging
+
+        created = store.create(
+            name="Loud Delete",
+            prompt="test",
+            trigger={"type": "cron", "schedule": "* * * * *"},
+        )
+
+        with caplog.at_level(logging.INFO, logger="pocketpaw.daemon.intentions"):
+            store.delete(created["id"])
+
+        assert any("Deleted intention" in r.message for r in caplog.records)
+
+    def test_delete_quiet_suppresses_per_item_log(self, store, caplog):
+        """quiet=True silences the per-deletion log so bulk callers stay clean."""
+        import logging
+
+        created = store.create(
+            name="Quiet Delete",
+            prompt="test",
+            trigger={"type": "cron", "schedule": "* * * * *"},
+        )
+
+        with caplog.at_level(logging.INFO, logger="pocketpaw.daemon.intentions"):
+            result = store.delete(created["id"], quiet=True)
+
+        assert result is True
+        assert not any("Deleted intention" in r.message for r in caplog.records)
+        # The intention is still gone — quiet only affects logging.
+        assert store.get_by_id(created["id"]) is None
+
     def test_toggle_intention(self, store):
         """Test toggling intention enabled state."""
         created = store.create(


### PR DESCRIPTION
## Why

`pocketpaw serve` boot output is unreadable when orphan `[auto] *` intentions accumulate in `~/.pocketpaw/intentions.json`. The pruner from #1024 catches them on startup, but `IntentionStore.delete()` logs every removal at INFO. With 22 orphans (the actual count seen on captain's machine), the boot log is 22 lines of:

```
INFO  Deleted intention:  API threshold rule (d2ed94e4-...)
INFO  Deleted intention:  Weekly digest (3f13a520-...)
... 20 more ...
INFO  Pruned 22 orphan  intentions on startup
```

Rich swallows the `[auto]` prefix in each line because it reads `[auto]` as a markup tag, so every name renders with a leading double-space and the summary loses its `[auto]` label too. PR #1025 fixes the summary log; this PR fixes the per-item spam.

The orphans pile up because tests that don't isolate `~/.pocketpaw/` create `[auto] *` intentions through `bridge.sync_rule_to_daemon` and don't always clean up. The pruner is the right safety net — it just shouldn't be loud about the cleanup.

## What changed

- `IntentionStore.delete(intention_id, quiet=False)` — new optional flag. When `True`, the per-item INFO log is suppressed. Default behaviour is unchanged so direct API and dashboard deletes still log.
- `prune_orphan_auto_intentions()` calls `delete(id, quiet=True)`. The single summary line stays as the only output.

## Tests

- `test_delete_logs_at_info_by_default` — confirms default still emits the log
- `test_delete_quiet_suppresses_per_item_log` — confirms `quiet=True` silences and the intention is still removed
- `test_prune_emits_only_summary_log` — seeds 5 orphans, runs the prune, asserts zero `Deleted intention` lines and exactly one `Pruned N orphan` summary line

All 14 IntentionStore + prune tests pass. Ruff clean.

## After this lands

Boot output for the same 22-orphan scenario becomes:

```
INFO  Pruned 22 orphan [auto] intentions on startup
```

(Once #1025 also lands, the `[auto]` prefix renders correctly.)
