### PR TITLE
fix(cloud): scope session listings by surface + match history on session_key prefix

### DIFF
--- a/ee/cloud/models/session.py
+++ b/ee/cloud/models/session.py
@@ -1,4 +1,14 @@
-"""Session document — unified chat session metadata for pocket and group contexts."""
+"""Session document — unified chat session metadata for pocket and group contexts.
+
+Recent change: added the optional ``surface`` field so the frontend can tell
+where a session-scope row originated (``chat`` vs ``files`` vs
+``pocket_creation``). Without it the three /chat / /files / /pockets
+chat surfaces all produced ``Session`` rows indistinguishable on
+``pocket=None`` + ``context_type="session"``, which the /chat sidebar then
+listed together (the "session bleed" bug). Legacy rows keep ``surface=None``
+and are still returned from unfiltered listings so the migration is non-
+disruptive.
+"""
 
 from __future__ import annotations
 
@@ -11,6 +21,10 @@ from pydantic import Field, model_validator
 from ee.cloud.models.base import TimestampedDocument
 
 ContextType = Literal["pocket", "group", "session"]
+# Surface tags the chat UI that minted this session — used by the /chat
+# sidebar to filter out pocket-creation / files-panel sessions that would
+# otherwise appear alongside DM threads (see "session bleed" fix).
+SurfaceType = Literal["chat", "files", "pocket_creation"]
 
 
 class Session(TimestampedDocument):
@@ -27,6 +41,9 @@ class Session(TimestampedDocument):
     pocket: str | None = None
     group: str | None = None
     agent: str | None = None
+    # Surface tag — see module docstring. Optional because pre-fix rows
+    # don't carry one and we deliberately don't backfill them.
+    surface: SurfaceType | None = None
     workspace: Indexed(str)  # type: ignore[valid-type]
     owner: str
     title: str = "New Chat"
@@ -71,4 +88,7 @@ class Session(TimestampedDocument):
             [("workspace", 1), ("pocket", 1), ("lastActivity", -1)],
             [("workspace", 1), ("group", 1), ("agent", 1)],
             [("workspace", 1), ("owner", 1), ("lastActivity", -1)],
+            # Sidebar listing per (workspace, owner, surface) — the /chat
+            # frontend's filtered query path.
+            [("workspace", 1), ("owner", 1), ("surface", 1), ("lastActivity", -1)],
         ]

--- a/ee/cloud/sessions/domain.py
+++ b/ee/cloud/sessions/domain.py
@@ -2,6 +2,10 @@
 
 Pure-Python frozen dataclass mirroring the persistence ``Session``
 document. The repository converts between this and the Beanie doc.
+
+Recent change: added the optional ``surface`` field so callers can
+distinguish chat / files / pocket-creation origin without re-fetching the
+Beanie doc (see "session bleed" fix).
 """
 
 from __future__ import annotations
@@ -21,6 +25,9 @@ class Session:
 
     Field names follow the persistence layer (``sessionId`` camelCase
     because the unique-indexed Mongo column uses that alias).
+
+    ``surface`` tags the originating UI surface (``chat`` / ``files`` /
+    ``pocket_creation``). Optional — pre-fix rows have ``surface=None``.
     """
 
     id: str  # Mongo _id as string
@@ -36,6 +43,7 @@ class Session:
     last_activity: datetime
     created_at: datetime
     deleted_at: datetime | None = None
+    surface: str | None = None  # chat | files | pocket_creation
 
 
 __all__ = ["Session"]

--- a/ee/cloud/sessions/dto.py
+++ b/ee/cloud/sessions/dto.py
@@ -1,14 +1,24 @@
-"""Sessions domain — Pydantic request/response schemas + domain → wire mapper."""
+"""Sessions domain — Pydantic request/response schemas + domain → wire mapper.
+
+Recent change: added the ``surface`` field on ``CreateSessionRequest`` and
+``SessionResponse`` (and the wire dict) so the frontend can stamp / read the
+originating chat surface (``chat`` / ``files`` / ``pocket_creation``). Field
+is optional everywhere so legacy callers and pre-fix rows still validate.
+"""
 
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
 from ee.cloud._core.time import iso_utc
 from ee.cloud.sessions.domain import Session
+
+# Surface tag values — kept in lockstep with ``models.session.SurfaceType``.
+Surface = Literal["chat", "files", "pocket_creation"]
+
 
 # ---------------------------------------------------------------------------
 # Requests
@@ -21,6 +31,10 @@ class CreateSessionRequest(BaseModel):
     group_id: str | None = None
     agent_id: str | None = None
     session_id: str | None = None  # Link to existing runtime session (e.g. "websocket_abc123")
+    # Originating UI surface — frontend stamps this so /chat sidebar can
+    # filter out pocket-creation / files-panel sessions. Optional; legacy
+    # callers can omit it.
+    surface: Surface | None = None
 
 
 class UpdateSessionRequest(BaseModel):
@@ -46,6 +60,7 @@ class SessionResponse(BaseModel):
     last_activity: datetime
     created_at: datetime
     deleted_at: datetime | None = None
+    surface: Surface | None = None
 
 
 def session_to_wire_dict(s: Session) -> dict[str, Any]:
@@ -64,6 +79,7 @@ def session_to_wire_dict(s: Session) -> dict[str, Any]:
         "pocket": s.pocket,
         "group": s.group,
         "agent": s.agent,
+        "surface": s.surface,
         "messageCount": s.message_count,
         "lastActivity": iso_utc(s.last_activity),
         "createdAt": iso_utc(s.created_at),

--- a/ee/cloud/sessions/router.py
+++ b/ee/cloud/sessions/router.py
@@ -39,16 +39,24 @@ async def create_session(
 @router.get("", dependencies=[Depends(require_action_any_workspace("session.read_own"))])
 async def list_sessions(
     agent_id: str | None = None,
+    surface: str | None = None,
     workspace_id: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
 ) -> list[dict]:
-    """List the user's sessions. ``?agent_id=X`` filters to DM sessions for
-    that agent (used by the frontend to resolve the DM room)."""
+    """List the user's sessions.
+
+    Query params:
+    - ``agent_id`` filters to DM sessions for that agent (used by the
+      frontend to resolve the DM room).
+    - ``surface`` filters to sessions stamped with the given originating
+      surface (``chat`` / ``files`` / ``pocket_creation``). Omitted →
+      every row, including legacy ``surface=None`` rows.
+    """
     ctx = sessions_service.legacy_ctx(user_id, workspace_id)
     if agent_id:
         items = await sessions_service.list_by_agent(ctx, workspace_id, agent_id)
     else:
-        items = await sessions_service.list_for_owner(ctx, workspace_id)
+        items = await sessions_service.list_for_owner(ctx, workspace_id, surface=surface)
     return [session_to_wire_dict(s) for s in items]
 
 

--- a/ee/cloud/sessions/router.py
+++ b/ee/cloud/sessions/router.py
@@ -9,6 +9,7 @@ from ee.cloud.license import require_license
 from ee.cloud.sessions import service as sessions_service
 from ee.cloud.sessions.dto import (
     CreateSessionRequest,
+    Surface,
     UpdateSessionRequest,
     session_to_wire_dict,
 )
@@ -39,7 +40,7 @@ async def create_session(
 @router.get("", dependencies=[Depends(require_action_any_workspace("session.read_own"))])
 async def list_sessions(
     agent_id: str | None = None,
-    surface: str | None = None,
+    surface: Surface | None = None,
     workspace_id: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
 ) -> list[dict]:

--- a/ee/cloud/sessions/service.py
+++ b/ee/cloud/sessions/service.py
@@ -74,6 +74,7 @@ def _to_domain(doc: _SessionDoc) -> DomainSession:
         last_activity=doc.lastActivity,
         created_at=getattr(doc, "createdAt", datetime.now(UTC)),  # type: ignore[arg-type]
         deleted_at=doc.deleted_at,
+        surface=getattr(doc, "surface", None),
     )
 
 
@@ -104,9 +105,7 @@ async def create(
     sid = body.session_id or f"websocket_{uuid.uuid4().hex[:12]}"
 
     if body.session_id:
-        existing_doc = await _SessionDoc.find_one(
-            _SessionDoc.sessionId == body.session_id
-        )
+        existing_doc = await _SessionDoc.find_one(_SessionDoc.sessionId == body.session_id)
         if existing_doc is not None:
             patched: dict = {}
             if body.pocket_id and body.pocket_id != existing_doc.pocket:
@@ -117,13 +116,15 @@ async def create(
                 if existing_doc.context_type == "session":
                     existing_doc.context_type = "pocket"
                 patched["pocket_id"] = body.pocket_id
-            if (
-                body.title
-                and body.title != "New Chat"
-                and body.title != existing_doc.title
-            ):
+            if body.title and body.title != "New Chat" and body.title != existing_doc.title:
                 existing_doc.title = body.title
                 patched["title"] = body.title
+            # Stamp ``surface`` only when missing — it tags the *origin* of
+            # the session so a re-link from a different surface shouldn't
+            # rewrite history.
+            if body.surface and getattr(existing_doc, "surface", None) is None:
+                existing_doc.surface = body.surface
+                patched["surface"] = body.surface
             if patched:
                 await existing_doc.save()
                 await emit(
@@ -153,6 +154,7 @@ async def create(
         pocket=body.pocket_id,
         group=body.group_id,
         agent=body.agent_id,
+        surface=body.surface,
     )
     await doc.insert()
     session = _to_domain(doc)
@@ -182,14 +184,27 @@ async def create(
 
 
 async def list_for_owner(
-    ctx: RequestContext, workspace_id: str
+    ctx: RequestContext,
+    workspace_id: str,
+    *,
+    surface: str | None = None,
 ) -> list[DomainSession]:
+    """List the caller's sessions in ``workspace_id``.
+
+    ``surface`` (when provided) restricts the listing to rows stamped with
+    that originating surface (``"chat"`` / ``"files"`` / ``"pocket_creation"``).
+    Passing ``None`` (the default) preserves legacy behavior — every row
+    returns, including pre-fix rows that have ``surface=None``.
+    """
+    filters: list[Any] = [
+        _SessionDoc.workspace == workspace_id,
+        _SessionDoc.owner == ctx.user_id,
+        _SessionDoc.deleted_at == None,  # noqa: E711
+    ]
+    if surface is not None:
+        filters.append(_SessionDoc.surface == surface)
     docs = (
-        await _SessionDoc.find(
-            _SessionDoc.workspace == workspace_id,
-            _SessionDoc.owner == ctx.user_id,
-            _SessionDoc.deleted_at == None,  # noqa: E711
-        )
+        await _SessionDoc.find(*filters)
         .sort(-_SessionDoc.lastActivity)  # type: ignore[arg-type, operator]
         .to_list()
     )
@@ -212,9 +227,7 @@ async def list_by_agent(
     return [_to_domain(d) for d in docs]
 
 
-async def list_for_pocket(
-    ctx: RequestContext, pocket_id: str
-) -> list[DomainSession]:
+async def list_for_pocket(ctx: RequestContext, pocket_id: str) -> list[DomainSession]:
     docs = (
         await _SessionDoc.find(
             _SessionDoc.pocket == pocket_id,
@@ -292,9 +305,7 @@ async def delete(ctx: RequestContext, session_id: str) -> None:
     )
 
 
-async def link_pocket(
-    workspace_id: str, session_id_str: str, pocket_id: str
-) -> None:
+async def link_pocket(workspace_id: str, session_id_str: str, pocket_id: str) -> None:
     """Link a session (looked up by its sessionId string) to a pocket.
 
     Used by ``pockets/service.create_pocket`` when called with
@@ -329,11 +340,21 @@ async def get_history(session_id: str, user_id: str, limit: int = 100) -> dict:
     session = await _fetch_owned(session_id, user_id)
 
     if session.context_type == "session":
+        # Prefix-match on session_key so reads stay aligned with whatever
+        # ``target_agent_id`` the SSE writer used at write time. The writer
+        # builds ``cloud:session:{session.id}:{target_agent_id}`` per stream;
+        # ``Session.agent`` is backfilled best-effort and may lag (or stay
+        # None when the backfill save fails). Matching the literal stored
+        # ``session.agent`` would miss those rows entirely — symptom: user
+        # sees their optimistic message with no agent reply.
+        import re
+
+        prefix = f"cloud:session:{session.id}:"
         messages = (
             await Message.find(
                 {
                     "context_type": "session",
-                    "session_key": f"cloud:session:{session.id}:{session.agent}",
+                    "session_key": {"$regex": f"^{re.escape(prefix)}"},
                 }
             )
             .sort("createdAt")
@@ -387,9 +408,7 @@ async def get_history(session_id: str, user_id: str, limit: int = 100) -> dict:
     # session_key shapes; preserved verbatim from the legacy implementation.
     pocket_candidate_keys = [session.sessionId]
     if session.pocket and session.agent:
-        pocket_candidate_keys.append(
-            f"cloud:pocket:{session.pocket}:{session.agent}"
-        )
+        pocket_candidate_keys.append(f"cloud:pocket:{session.pocket}:{session.agent}")
     or_clauses: list[dict[str, Any]] = [
         {"context_type": "pocket", "session_key": {"$in": pocket_candidate_keys}}
     ]
@@ -401,12 +420,7 @@ async def get_history(session_id: str, user_id: str, limit: int = 100) -> dict:
             }
         )
 
-    messages = (
-        await Message.find({"$or": or_clauses})
-        .sort("createdAt")
-        .limit(limit)
-        .to_list()
-    )
+    messages = await Message.find({"$or": or_clauses}).sort("createdAt").limit(limit).to_list()
     return {
         "messages": [
             {
@@ -501,16 +515,23 @@ async def ensure_for_agent_scope(
             return None
         if doc is None:
             return None
-        # Backfill Session.agent when the session was created without one
-        # so the read-side ``cloud:session:{sid}:{agent}`` history key
-        # matches the write side.
+        # Backfill Session.agent when the session was created without one.
+        # The read-side history query no longer keys on ``Session.agent``
+        # (it prefix-matches ``cloud:session:{sid}:`` so any writer-supplied
+        # agent id matches), but persisting the field still keeps the
+        # sidebar's per-agent grouping correct. Log at warning so a recurring
+        # save failure shows up in dashboard logs — historically this failure
+        # mode caused the "user message with no agent reply" symptom and went
+        # undetected for too long.
         if not getattr(doc, "agent", None) and target_agent_id:
             doc.agent = target_agent_id
             try:
                 await doc.save()
             except Exception:
-                logger.debug(
-                    "Session.agent backfill failed for %s",
+                logger.warning(
+                    "Session.agent backfill failed for %s — read path uses "
+                    "prefix-match so history still resolves, but downstream "
+                    "consumers grouping by agent may misroute",
                     doc.sessionId,
                     exc_info=True,
                 )
@@ -556,9 +577,7 @@ async def auto_create_pocket_session(
         title="Chat",
     )
     await doc.insert()
-    logger.info(
-        "auto-created pocket session: sessionId=%s owner=%s", session_key, user.id
-    )
+    logger.info("auto-created pocket session: sessionId=%s owner=%s", session_key, user.id)
     return doc
 
 

--- a/ee/cloud/sessions/service.py
+++ b/ee/cloud/sessions/service.py
@@ -24,6 +24,7 @@ Public API:
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -347,8 +348,6 @@ async def get_history(session_id: str, user_id: str, limit: int = 100) -> dict:
         # None when the backfill save fails). Matching the literal stored
         # ``session.agent`` would miss those rows entirely — symptom: user
         # sees their optimistic message with no agent reply.
-        import re
-
         prefix = f"cloud:session:{session.id}:"
         messages = (
             await Message.find(

--- a/tests/cloud/sessions/test_get_history_session_agent_backfill.py
+++ b/tests/cloud/sessions/test_get_history_session_agent_backfill.py
@@ -1,0 +1,123 @@
+"""Regression: ``get_history`` must match session-scope writes by ``session_key``
+prefix so messages still surface when the ``Session.agent`` backfill silently
+fails.
+
+Bug recap (parent diagnosis): the SSE stream writes messages keyed by
+``cloud:session:{session_id}:{target_agent_id}``, but the read side in
+``sessions/service.get_history`` queries
+``cloud:session:{session_id}:{session.agent}``. When ``_ensure_scope_session``
+fails to backfill ``Session.agent`` on a freshly-created session-scope row, the
+stored field stays ``None`` and the read returns 0 rows — the user sees their
+optimistically-pushed message but no agent reply, even though the agent did
+respond and persist the assistant message.
+
+The fix uses a regex/prefix match: any row whose ``session_key`` starts with
+``cloud:session:{session_id}:`` belongs to this session, regardless of which
+``agent`` value the writer used at the time.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud.chat import message_service
+from ee.cloud.sessions import service as sessions_service
+from ee.cloud.sessions.dto import CreateSessionRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(user_id: str = "u1", workspace_id: str | None = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def test_get_history_returns_messages_when_session_agent_is_null() -> None:
+    """The bug: a session row with ``agent=None`` cannot read its own history.
+
+    The writer (SSE stream) used the live ``target_agent_id`` to build
+    ``session_key=cloud:session:{sid}:agent-x``. If the ``Session.agent``
+    backfill failed (broad ``except`` swallowed it), the read query becomes
+    ``cloud:session:{sid}:None`` and matches zero rows.
+
+    With the prefix-match fix, both the user message and the assistant reply
+    must come back regardless of the stored ``Session.agent`` value.
+    """
+    # Create a session-scope row with no agent attached — exactly the state
+    # left behind when ``_ensure_scope_session`` silently fails its save.
+    session = await sessions_service.create(
+        _ctx(), "w1", CreateSessionRequest(title="t")
+    )
+    assert session.context_type == "session"
+    assert session.agent is None  # the precondition the bug depends on
+
+    # The SSE stream wrote messages with the live ``target_agent_id``. Mirror
+    # the exact key the writer would have produced.
+    session_key = f"cloud:session:{session.id}:agent-x"
+
+    await message_service.persist_user_message_for_scope(
+        kind="session",
+        scope_id=session.id,
+        user_id="u1",
+        workspace_id="w1",
+        session_key=session_key,
+        content="what's the weather?",
+    )
+    await message_service.persist_assistant_message_for_scope(
+        kind="session",
+        scope_id=session.id,
+        user_id="u1",
+        workspace_id="w1",
+        session_key=session_key,
+        target_agent_id="agent-x",
+        content="sunny and 70F",
+    )
+
+    history = await sessions_service.get_history(session.id, "u1")
+
+    contents = [m["content"] for m in history["messages"]]
+    assert "what's the weather?" in contents, (
+        "user message must surface even when Session.agent is None"
+    )
+    assert "sunny and 70F" in contents, (
+        "assistant reply must surface even when Session.agent is None"
+    )
+
+
+async def test_get_history_with_backfilled_agent_still_works() -> None:
+    """The fix must be backwards-compatible: sessions with a stored ``agent``
+    keep returning the same history. We backfill ``Session.agent`` post-hoc
+    and confirm the row count is unchanged."""
+    session = await sessions_service.create(
+        _ctx(), "w1", CreateSessionRequest(title="t", agent_id="agent-x")
+    )
+    session_key = f"cloud:session:{session.id}:agent-x"
+
+    await message_service.persist_user_message_for_scope(
+        kind="session",
+        scope_id=session.id,
+        user_id="u1",
+        workspace_id="w1",
+        session_key=session_key,
+        content="hi",
+    )
+    await message_service.persist_assistant_message_for_scope(
+        kind="session",
+        scope_id=session.id,
+        user_id="u1",
+        workspace_id="w1",
+        session_key=session_key,
+        target_agent_id="agent-x",
+        content="hi back",
+    )
+
+    history = await sessions_service.get_history(session.id, "u1")
+    assert len(history["messages"]) == 2

--- a/tests/cloud/sessions/test_get_history_session_agent_backfill.py
+++ b/tests/cloud/sessions/test_get_history_session_agent_backfill.py
@@ -53,9 +53,7 @@ async def test_get_history_returns_messages_when_session_agent_is_null() -> None
     """
     # Create a session-scope row with no agent attached — exactly the state
     # left behind when ``_ensure_scope_session`` silently fails its save.
-    session = await sessions_service.create(
-        _ctx(), "w1", CreateSessionRequest(title="t")
-    )
+    session = await sessions_service.create(_ctx(), "w1", CreateSessionRequest(title="t"))
     assert session.context_type == "session"
     assert session.agent is None  # the precondition the bug depends on
 

--- a/tests/cloud/sessions/test_session_surface_filter.py
+++ b/tests/cloud/sessions/test_session_surface_filter.py
@@ -72,7 +72,9 @@ async def test_list_for_owner_filters_by_surface() -> None:
         CreateSessionRequest(title="from pockets", surface="pocket_creation"),
     )
     await sessions_service.create(
-        _ctx(), "w1", CreateSessionRequest(title="legacy")  # surface=None
+        _ctx(),
+        "w1",
+        CreateSessionRequest(title="legacy"),  # surface=None
     )
 
     chat_only = await sessions_service.list_for_owner(_ctx(), "w1", surface="chat")
@@ -98,7 +100,9 @@ async def test_list_for_owner_without_filter_returns_all() -> None:
         CreateSessionRequest(title="from pockets", surface="pocket_creation"),
     )
     await sessions_service.create(
-        _ctx(), "w1", CreateSessionRequest(title="legacy")  # surface=None
+        _ctx(),
+        "w1",
+        CreateSessionRequest(title="legacy"),  # surface=None
     )
 
     all_sessions = await sessions_service.list_for_owner(_ctx(), "w1")

--- a/tests/cloud/sessions/test_session_surface_filter.py
+++ b/tests/cloud/sessions/test_session_surface_filter.py
@@ -1,0 +1,107 @@
+"""Regression: session bleed across /chat, /pockets, /files surfaces.
+
+Bug recap (parent diagnosis): three frontend chat surfaces (``/chat``,
+``/pockets`` pocket-creation mode, ``/files``) all hit
+``POST /sessions`` followed by ``POST /cloud/chat/session/{mongo_id}/agent``.
+The resulting ``Session`` rows are indistinguishable on
+``pocket=None`` + ``context_type="session"``, so the ``/chat`` sidebar
+filter ``(s) => !s.pocket`` lists every session-scope row regardless of
+which surface created it.
+
+Fix: stamp the originating surface on the ``Session`` row. Backwards
+compatible — legacy rows keep ``surface=None`` and continue to appear in
+unfiltered listings.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud.sessions import service as sessions_service
+from ee.cloud.sessions.dto import CreateSessionRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(user_id: str = "u1", workspace_id: str | None = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def test_create_persists_surface_field() -> None:
+    """The DTO accepts ``surface`` and the domain mirrors it."""
+    s = await sessions_service.create(
+        _ctx(),
+        "w1",
+        CreateSessionRequest(title="from chat", surface="chat"),
+    )
+    assert s.surface == "chat"
+
+    # Refetch to confirm the value round-trips through Mongo.
+    refetched = await sessions_service.get(_ctx(), s.id)
+    assert refetched.surface == "chat"
+
+
+async def test_create_without_surface_defaults_to_none() -> None:
+    """Backwards compatibility: legacy callers omitting ``surface`` get None."""
+    s = await sessions_service.create(_ctx(), "w1", CreateSessionRequest(title="legacy"))
+    assert s.surface is None
+
+
+async def test_list_for_owner_filters_by_surface() -> None:
+    """``surface="chat"`` returns only chat-originated rows; legacy ``surface=None``
+    rows are excluded from the filtered listing (they originated elsewhere /
+    pre-migration and shouldn't pollute the /chat sidebar)."""
+    await sessions_service.create(
+        _ctx(), "w1", CreateSessionRequest(title="from chat", surface="chat")
+    )
+    await sessions_service.create(
+        _ctx(), "w1", CreateSessionRequest(title="from files", surface="files")
+    )
+    await sessions_service.create(
+        _ctx(),
+        "w1",
+        CreateSessionRequest(title="from pockets", surface="pocket_creation"),
+    )
+    await sessions_service.create(
+        _ctx(), "w1", CreateSessionRequest(title="legacy")  # surface=None
+    )
+
+    chat_only = await sessions_service.list_for_owner(_ctx(), "w1", surface="chat")
+    titles = {s.title for s in chat_only}
+    assert titles == {"from chat"}, (
+        "surface=chat filter must return only sessions stamped with surface=chat"
+    )
+
+
+async def test_list_for_owner_without_filter_returns_all() -> None:
+    """No filter passed → preserve legacy behavior: every row (including
+    legacy ``surface=None`` rows) is returned. This is critical so the
+    migration is non-disruptive for callers that haven't adopted the param."""
+    await sessions_service.create(
+        _ctx(), "w1", CreateSessionRequest(title="from chat", surface="chat")
+    )
+    await sessions_service.create(
+        _ctx(), "w1", CreateSessionRequest(title="from files", surface="files")
+    )
+    await sessions_service.create(
+        _ctx(),
+        "w1",
+        CreateSessionRequest(title="from pockets", surface="pocket_creation"),
+    )
+    await sessions_service.create(
+        _ctx(), "w1", CreateSessionRequest(title="legacy")  # surface=None
+    )
+
+    all_sessions = await sessions_service.list_for_owner(_ctx(), "w1")
+    assert len(all_sessions) == 4
+    titles = {s.title for s in all_sessions}
+    assert titles == {"from chat", "from files", "from pockets", "legacy"}

--- a/tests/cloud/test_api_contracts.py
+++ b/tests/cloud/test_api_contracts.py
@@ -70,6 +70,7 @@ SESSION_RESPONSE_KEYS = frozenset(
         "pocket",
         "group",
         "agent",
+        "surface",  # added: which UI surface minted this session
         "messageCount",
         "lastActivity",
         "createdAt",


### PR DESCRIPTION
## Summary

Backend half of two related bugs in the enterprise cloud chat. The frontend half (paw-enterprise sidebar filter, `surface` stamp at the three `POST /sessions` call sites) ships in a separate PR.

### Bug 1 — cross-route session bleed

`/chat`, `/pockets` pocket-creation mode, and `/files` all hit `POST /sessions` and then `POST /cloud/chat/session/{mongo_id}/agent`. The resulting `Session` rows are indistinguishable on `pocket=None` + `context_type="session"`, so the `/chat` sidebar's `(s) => !s.pocket` filter lists every session-scope row regardless of where it came from. Pocket-creation sessions and Files sessions both end up in the chat list.

Fix: tag the originating UI surface on the `Session` row.

- `models/session.py`: optional `surface` field, `Literal["chat", "files", "pocket_creation"]`. New compound index on `(workspace, owner, surface, lastActivity)` for the filtered listing path.
- `sessions/domain.py`: `surface` on the frozen value object.
- `sessions/dto.py`: `CreateSessionRequest` accepts `surface`; `SessionResponse` and the wire dict expose it.
- `sessions/service.py`: `create()` writes it; `_to_domain` reads it; `list_for_owner` gained an optional `surface` kwarg. The existing-session update path stamps `surface` only when missing — re-linking from a different surface should not rewrite origin.
- `sessions/router.py`: `GET /sessions` accepts `?surface=`.

Backwards compatible: legacy rows keep `surface=None` and still show up in unfiltered listings. Callers that pass no `surface` see the same behavior they always saw.

### Bug 2 — `Session.agent` backfill failure returned 0 history rows

The SSE stream writes messages keyed on `cloud:session:{session.id}:{target_agent_id}`. The read in `sessions/service.get_history` was querying `cloud:session:{session.id}:{session.agent}`. When `_ensure_scope_session` swallowed a backfill save failure, the stored `Session.agent` stayed `None` and the read returned 0 rows — the user saw their optimistic message with no agent reply, even though the agent had persisted a response.

Fix: prefix-match `^cloud:session:{session.id}:` so reads pick up whatever `target_agent_id` the writer used, regardless of what `Session.agent` actually persisted. The backfill-save failure log was bumped from `debug` to `warning` so this failure mode no longer hides in dashboard logs.

### Tests

Failing repros are in the first commit; the fix commit makes them pass.

- `tests/cloud/sessions/test_get_history_session_agent_backfill.py` — pins the prefix-match behavior. Creates a session with `agent=None`, persists messages with the writer's actual `target_agent_id`, asserts `get_history` returns both rows.
- `tests/cloud/sessions/test_session_surface_filter.py` — pins the field round-trip end to end (DTO → domain → Mongo → list filter).

`test_api_contracts.SESSION_RESPONSE_KEYS` gained `surface` so the contract test tracks the new field.

## Test plan

- [x] `uv run pytest tests/cloud/sessions/ tests/cloud/test_api_contracts.py` — all pass
- [x] `uv run pytest tests/cloud/` — 1539 pass, 1 pre-existing failure unrelated to this PR (`test_agent_bridge_does_not_import_ws_manager_broadcast_directly` hardcodes a Windows path)
- [x] `uv run lint-imports` — 9 / 9 contracts kept
- [x] `uv run ruff check ee/cloud/sessions/ ee/cloud/models/session.py tests/cloud/sessions/` — clean

## Notes for the captain

Backend only. Frontend follow-up PR (paw-enterprise) needs to:

1. Stamp `surface` on the three call sites that hit `POST /sessions` (`/chat`, `/pockets` pocket-creation mode, `/files`).
2. Update the `/chat` sidebar fetch to pass `?surface=chat` so it stops listing pocket-creation and files sessions.