### PR TITLE
feat(extraction): pluggable extraction adapters with local + gemini-flash

### DIFF
--- a/ee/cloud/agents/knowledge.py
+++ b/ee/cloud/agents/knowledge.py
@@ -1,18 +1,24 @@
 # knowledge.py — Agent knowledge service via the kb-go binary.
+# Updated: 2026-04-30 — File extraction routed through the pluggable
+#   ee/cloud/extraction chain (LocalExtractor preserves the previous pypdf
+#   / python-docx / pytesseract behaviour; cloud adapters slot in via
+#   POCKETPAW_EXTRACTION_CHAIN). Stage 1.A of "Files as Knowledge".
 # Updated: 2026-04-07 — Switched from Python knowledge_base package to kb Go binary.
 # Heavy extraction (PDF, OCR, URL) done in Python, piped as text to kb.
 # All other operations delegate to subprocess calls.
 """Agent knowledge service — thin wrapper over the `kb` Go binary.
 
 The kb binary (github.com/qbtrix/kb-go) handles compilation, search, indexing,
-and storage. This wrapper handles heavy extraction (PDF, URL, OCR, DOCX) in
-Python and pipes extracted text to kb via stdin.
+and storage. URL extraction stays inline (trafilatura). File extraction is
+routed through `ee.cloud.extraction.build_chain` so cloud captioning can be
+configured without touching this file.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import mimetypes
 import os
 import subprocess
 from pathlib import Path
@@ -170,36 +176,19 @@ async def _extract_url(url: str) -> str:
 
 
 async def _extract_file(file_path: str) -> str:
-    """Extract text from PDF, DOCX, or image files."""
+    """Extract text via the configured extraction chain.
+
+    Behaviour parity with the previous suffix-routed pypdf/python-docx/
+    pytesseract helper is preserved by `LocalExtractor`, which is always
+    available as the offline fallback. Chain config (`extraction_chain`,
+    `extraction_per_mime`) lives on `Settings`.
+    """
+    from ee.cloud.extraction import build_chain
+    from pocketpaw.config import get_settings
+
     path = Path(file_path)
-    suffix = path.suffix.lower()
-
-    if suffix == ".pdf":
-        try:
-            from pypdf import PdfReader
-
-            reader = PdfReader(file_path)
-            return "\n".join(p.extract_text() or "" for p in reader.pages)
-        except ImportError:
-            raise RuntimeError("pypdf not installed — run: pip install pypdf")
-
-    if suffix in (".docx", ".doc"):
-        try:
-            from docx import Document
-
-            doc = Document(file_path)
-            return "\n".join(p.text for p in doc.paragraphs)
-        except ImportError:
-            raise RuntimeError("python-docx not installed — run: pip install python-docx")
-
-    if suffix in (".png", ".jpg", ".jpeg"):
-        try:
-            import pytesseract
-            from PIL import Image
-
-            return pytesseract.image_to_string(Image.open(file_path))
-        except ImportError:
-            raise RuntimeError("pytesseract not installed — run: pip install pytesseract Pillow")
-
-    # Fallback: read as text
-    return path.read_text(encoding="utf-8", errors="replace")
+    mime, _ = mimetypes.guess_type(file_path)
+    mime = mime or "application/octet-stream"
+    chain = build_chain(get_settings())
+    result = await chain.run(path, mime)
+    return result.text

--- a/ee/cloud/extraction/__init__.py
+++ b/ee/cloud/extraction/__init__.py
@@ -1,0 +1,25 @@
+# __init__.py — Public surface for the extraction package.
+# Created: 2026-04-30 — Phase 1 of "Files as Knowledge" plan, Stage 1.A.
+# Exposes ExtractionResult, ExtractionAdapter, ExtractionChain, build_chain.
+"""Pluggable file-content extraction.
+
+Public API:
+  - `ExtractionResult` — output model every adapter returns.
+  - `ExtractionAdapter` — Protocol that adapters implement.
+  - `ExtractionChain` — runner with offline detection and fallback.
+  - `build_chain(settings)` — factory that reads pocketpaw Settings.
+
+Concrete adapters (`LocalExtractor`, `GeminiFlashExtractor`) are
+imported on demand from `build_chain` so this package can be imported
+in environments missing google-genai.
+"""
+
+from ee.cloud.extraction.adapter import ExtractionAdapter, ExtractionResult
+from ee.cloud.extraction.chain import ExtractionChain, build_chain
+
+__all__ = [
+    "ExtractionAdapter",
+    "ExtractionChain",
+    "ExtractionResult",
+    "build_chain",
+]

--- a/ee/cloud/extraction/adapter.py
+++ b/ee/cloud/extraction/adapter.py
@@ -1,0 +1,55 @@
+# adapter.py — ExtractionAdapter Protocol + ExtractionResult model.
+# Created: 2026-04-30 — Phase 1 of "Files as Knowledge" plan, Stage 1.A.
+# Defines the pluggable adapter contract for file content extraction.
+"""Extraction adapter protocol.
+
+The captain's directive: keep the traditional extractors (pypdf, python-docx,
+pytesseract) and add cloud-backed adapters as siblings, not replacements.
+Each adapter declares the MIME types it handles and whether it needs network.
+The chain runner picks the first matching adapter and falls through on
+failure or offline conditions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+
+class ExtractionResult(BaseModel):
+    """Output shape every adapter returns.
+
+    text: the primary searchable content. Required.
+    title: detected title or first heading; None when not detected.
+    captions: per-image / per-page captions. Empty list when not applicable.
+    metadata: free-form bag (author, page_count, language, source path, ...).
+    backend: which adapter produced this result (e.g. "local", "gemini-flash").
+    """
+
+    text: str
+    title: str | None = None
+    captions: list[str] = Field(default_factory=list)
+    metadata: dict = Field(default_factory=dict)
+    backend: str
+
+
+@runtime_checkable
+class ExtractionAdapter(Protocol):
+    """Duck-typed extraction adapter.
+
+    Attributes:
+        name: stable identifier ("local", "gemini-flash"). Used in settings,
+            logs, and the per-MIME override map.
+        supports_mimes: set of MIME strings this adapter handles. Use "*" as
+            a wildcard for adapters that handle anything.
+        requires_network: when True the chain skips this adapter if the host
+            is offline and falls through to the offline fallback.
+    """
+
+    name: str
+    supports_mimes: set[str]
+    requires_network: bool
+
+    async def extract(self, path: Path, mime: str) -> ExtractionResult: ...

--- a/ee/cloud/extraction/chain.py
+++ b/ee/cloud/extraction/chain.py
@@ -1,0 +1,119 @@
+# chain.py — ExtractionChain runner + build_chain factory.
+# Created: 2026-04-30 — Phase 1 of "Files as Knowledge" plan, Stage 1.A.
+# Routes a (path, mime) pair to the configured adapter chain with offline
+# detection and per-MIME overrides. Always falls back to a network-free
+# adapter on failure or offline conditions.
+"""Extraction chain runner.
+
+Selection order on `run(path, mime)`:
+  1. If `per_mime_override` has an entry for `mime`, that adapter wins.
+  2. Otherwise the first adapter in the chain whose `supports_mimes`
+     contains `mime` (or the wildcard "*") is picked.
+  3. Network-required adapters get skipped if `_is_online()` returns False.
+  4. On adapter exception the chain falls through to the offline fallback.
+  5. If nothing matches the mime at all, the offline fallback handles it.
+
+The fallback is always available — it's wired to LocalExtractor in
+`build_chain` regardless of what the user puts in `extraction_chain`.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+from pathlib import Path
+
+from ee.cloud.extraction.adapter import ExtractionAdapter, ExtractionResult
+
+logger = logging.getLogger(__name__)
+
+
+def _is_online() -> bool:
+    """Cheap reachability check. Tests monkeypatch this."""
+    try:
+        with socket.create_connection(("8.8.8.8", 53), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+class ExtractionChain:
+    def __init__(
+        self,
+        adapters: list[ExtractionAdapter],
+        offline_fallback: ExtractionAdapter,
+        per_mime_override: dict[str, str] | None = None,
+    ) -> None:
+        self._adapters = adapters
+        self._offline_fallback = offline_fallback
+        self._by_name: dict[str, ExtractionAdapter] = {
+            a.name: a for a in [*adapters, offline_fallback]
+        }
+        self._per_mime = per_mime_override or {}
+
+    async def run(self, path: Path, mime: str) -> ExtractionResult:
+        # 1. Per-MIME override wins.
+        override = self._per_mime.get(mime)
+        if override:
+            adapter = self._by_name.get(override)
+            if adapter is not None:
+                return await self._call(adapter, path, mime)
+            logger.warning(
+                "per-mime override %r unknown; falling through to chain", override
+            )
+
+        # 2. First chain adapter that supports the mime (wildcard or explicit).
+        for adapter in self._adapters:
+            if "*" in adapter.supports_mimes or mime in adapter.supports_mimes:
+                return await self._call(adapter, path, mime)
+
+        # 3. No adapter claimed this mime — let the fallback take it.
+        return await self._offline_fallback.extract(path, mime)
+
+    async def _call(
+        self, adapter: ExtractionAdapter, path: Path, mime: str
+    ) -> ExtractionResult:
+        if adapter.requires_network and not _is_online():
+            logger.info(
+                "adapter %s requires network but host is offline; using fallback",
+                adapter.name,
+            )
+            return await self._offline_fallback.extract(path, mime)
+        try:
+            return await adapter.extract(path, mime)
+        except Exception as exc:  # noqa: BLE001 — fall-through is the contract
+            logger.warning("adapter %s failed for %s: %s", adapter.name, path, exc)
+            if adapter is self._offline_fallback:
+                raise
+            return await self._offline_fallback.extract(path, mime)
+
+
+def build_chain(settings) -> ExtractionChain:
+    """Build the chain from `Settings`.
+
+    Reads `settings.extraction_chain` (ordered list of adapter names),
+    `settings.extraction_per_mime` (override map), and the offline fallback
+    name. The fallback is always a `LocalExtractor`, regardless of what the
+    chain config says — local is the only adapter guaranteed to work without
+    network access.
+    """
+    from ee.cloud.extraction.gemini_flash import GeminiFlashExtractor
+    from ee.cloud.extraction.local import LocalExtractor
+
+    adapters: list[ExtractionAdapter] = []
+    for name in settings.extraction_chain:
+        if name == "local":
+            adapters.append(LocalExtractor())
+        elif name == "gemini-flash":
+            api_key = getattr(settings, "gemini_api_key", None)
+            if api_key:
+                adapters.append(GeminiFlashExtractor(api_key))
+            else:
+                logger.info(
+                    "gemini-flash adapter skipped: POCKETPAW_GEMINI_API_KEY not set"
+                )
+        else:
+            raise ValueError(f"unknown extraction adapter: {name!r}")
+
+    fallback = LocalExtractor()
+    return ExtractionChain(adapters, fallback, dict(settings.extraction_per_mime))

--- a/ee/cloud/extraction/gemini_flash.py
+++ b/ee/cloud/extraction/gemini_flash.py
@@ -1,0 +1,112 @@
+# gemini_flash.py — Gemini Flash extraction adapter.
+# Created: 2026-04-30 — Phase 1 of "Files as Knowledge" plan, Stage 1.A.
+# Cloud captioning sibling to LocalExtractor: rich descriptions for images,
+# per-page captions for sparse PDF pages. No replacement of pypdf — it
+# augments where pypdf returns near-empty text.
+"""GeminiFlashExtractor — google-genai SDK adapter.
+
+Captions images with `gemini-2.5-flash` (or whatever model is configured).
+For PDFs the strategy is hybrid: pypdf extracts text per page; pages with
+<200 chars of extracted text are marked image-heavy and *not* captioned in
+this stage (heavy PDF→image rendering deferred to a later PR — Stage 1.A
+ships without a new dep). When network is unavailable the chain falls
+through to LocalExtractor before this adapter is asked to run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from ee.cloud.extraction.adapter import ExtractionResult
+
+CAPTION_PROMPT = (
+    "Describe this image for a knowledge base. Cover: subject matter, "
+    "any visible text verbatim, the structure if it's a diagram (boxes, "
+    "arrows, labels), colors only if semantically meaningful. Output "
+    "100-300 words. No preamble."
+)
+
+# Below this character count per pypdf-extracted page we treat the page
+# as image-heavy and skip captioning. 200 is a heuristic; tune later.
+_SPARSE_PAGE_THRESHOLD = 200
+
+
+class GeminiFlashExtractor:
+    """Cloud-backed image and PDF-page captioning via google-genai."""
+
+    name = "gemini-flash"
+    supports_mimes = {"image/png", "image/jpeg", "image/jpg", "application/pdf"}
+    requires_network = True
+
+    def __init__(self, api_key: str, model: str = "gemini-2.5-flash") -> None:
+        # Lazy-import the SDK so the adapter file can be imported in
+        # environments where google-genai isn't installed (tests mock the
+        # client with patch.dict on sys.modules).
+        from google import genai
+
+        self._client = genai.Client(api_key=api_key)
+        self._model = model
+
+    async def extract(self, path: Path, mime: str) -> ExtractionResult:
+        if mime.startswith("image/"):
+            return await self._extract_image(path, mime)
+        if mime == "application/pdf":
+            return await self._extract_pdf_with_captions(path)
+        raise ValueError(f"unsupported mime: {mime}")
+
+    async def _extract_image(self, path: Path, mime: str) -> ExtractionResult:
+        from google.genai import types
+
+        img = path.read_bytes()
+        contents: list = [
+            CAPTION_PROMPT,
+            types.Part.from_bytes(data=img, mime_type=mime),
+        ]
+        response = await asyncio.to_thread(
+            self._client.models.generate_content,
+            model=self._model,
+            contents=contents,
+        )
+        caption = (response.text or "").strip()
+        return ExtractionResult(
+            text=caption,
+            captions=[caption],
+            metadata={"path": str(path), "mime": mime, "model": self._model},
+            backend=self.name,
+        )
+
+    async def _extract_pdf_with_captions(self, path: Path) -> ExtractionResult:
+        try:
+            from pypdf import PdfReader
+        except ImportError as exc:
+            raise RuntimeError("pypdf not installed — run: pip install pypdf") from exc
+
+        reader = PdfReader(str(path))
+        sections: list[str] = []
+        captions: list[str] = []
+        sparse_pages: list[int] = []
+
+        for idx, page in enumerate(reader.pages, start=1):
+            page_text = (page.extract_text() or "").strip()
+            if len(page_text) < _SPARSE_PAGE_THRESHOLD:
+                # Stage 1.A doesn't ship a PDF-to-image renderer dependency.
+                # Mark the page so downstream search knows the gap exists.
+                sections.append(f"[page {idx}: image-heavy, no caption]")
+                sparse_pages.append(idx)
+                continue
+            sections.append(f"[page {idx}]\n{page_text}")
+
+        text = "\n\n".join(sections)
+        return ExtractionResult(
+            text=text,
+            captions=captions,
+            metadata={
+                "path": str(path),
+                "mime": "application/pdf",
+                "model": self._model,
+                "page_count": len(reader.pages),
+                "sparse_pages": sparse_pages,
+            },
+            backend=self.name,
+        )

--- a/ee/cloud/extraction/local.py
+++ b/ee/cloud/extraction/local.py
@@ -1,0 +1,77 @@
+# local.py — Local extraction adapter (pypdf + python-docx + pytesseract).
+# Created: 2026-04-30 — Phase 1 of "Files as Knowledge" plan, Stage 1.A.
+# Wraps the existing _extract_file logic from agents/knowledge.py so
+# self-hosted and offline deployments keep a no-network extraction path.
+"""LocalExtractor — wraps the traditional extraction libraries.
+
+Behavior must match the previous `_extract_file` in `agents/knowledge.py`
+(line-for-line port). MIME routing here is suffix-based to mirror the
+original helper, with the public `supports_mimes = {"*"}` so the chain
+treats Local as a catch-all fallback.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ee.cloud.extraction.adapter import ExtractionResult
+
+
+class LocalExtractor:
+    """Behavior-preserving wrapper around pypdf / python-docx / pytesseract."""
+
+    name = "local"
+    supports_mimes = {"*"}
+    requires_network = False
+
+    async def extract(self, path: Path, mime: str) -> ExtractionResult:
+        text = await _extract_text(path)
+        return ExtractionResult(
+            text=text,
+            metadata={"path": str(path), "mime": mime},
+            backend=self.name,
+        )
+
+
+async def _extract_text(path: Path) -> str:
+    """Extract text from PDF, DOCX, image, or fall back to raw read.
+
+    Matches the previous `_extract_file` implementation byte-for-byte so the
+    output of `LocalExtractor.extract(...).text` is identical to what callers
+    used to get from `await _extract_file(file_path)`.
+    """
+    file_path = str(path)
+    suffix = path.suffix.lower()
+
+    if suffix == ".pdf":
+        try:
+            from pypdf import PdfReader
+
+            reader = PdfReader(file_path)
+            return "\n".join(p.extract_text() or "" for p in reader.pages)
+        except ImportError as exc:
+            raise RuntimeError("pypdf not installed — run: pip install pypdf") from exc
+
+    if suffix in (".docx", ".doc"):
+        try:
+            from docx import Document
+
+            doc = Document(file_path)
+            return "\n".join(p.text for p in doc.paragraphs)
+        except ImportError as exc:
+            raise RuntimeError(
+                "python-docx not installed — run: pip install python-docx"
+            ) from exc
+
+    if suffix in (".png", ".jpg", ".jpeg"):
+        try:
+            import pytesseract
+            from PIL import Image
+
+            return pytesseract.image_to_string(Image.open(file_path))
+        except ImportError as exc:
+            raise RuntimeError(
+                "pytesseract not installed — run: pip install pytesseract Pillow"
+            ) from exc
+
+    return path.read_text(encoding="utf-8", errors="replace")

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -890,6 +890,41 @@ class Settings(BaseSettings):
         description="Number of top articles to inject from kb search (default: 3)",
     )
 
+    # File extraction chain (Phase 1, "Files as Knowledge")
+    extraction_chain: list[str] = Field(
+        default_factory=lambda: ["local"],
+        description=(
+            "Ordered list of extraction adapter names "
+            "(e.g. ['gemini-flash', 'local']). The chain runs first-match-wins "
+            "per MIME, with offline fallback to 'local'. Set via "
+            "POCKETPAW_EXTRACTION_CHAIN as a JSON array."
+        ),
+    )
+    extraction_per_mime: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Per-MIME adapter override map (e.g. {'image/png': 'gemini-flash'}). "
+            "Wins over the chain order. Set via POCKETPAW_EXTRACTION_PER_MIME "
+            "as a JSON object."
+        ),
+    )
+    extraction_offline_fallback: str = Field(
+        default="local",
+        description=(
+            "Adapter name used when the chosen adapter requires network and "
+            "the host is offline. Today the chain hardcodes LocalExtractor as "
+            "fallback; this setting reserves the env key for future overrides."
+        ),
+    )
+    gemini_api_key: str | None = Field(
+        default=None,
+        description=(
+            "Google Gemini API key for the gemini-flash extraction adapter. "
+            "Read from POCKETPAW_GEMINI_API_KEY. When unset, the gemini-flash "
+            "adapter is silently skipped during chain construction."
+        ),
+    )
+
     soul_cognitive_model: str = Field(
         default="",
         description=(

--- a/tests/cloud/extraction/test_chain.py
+++ b/tests/cloud/extraction/test_chain.py
@@ -1,0 +1,236 @@
+# test_chain.py — ExtractionChain routing tests.
+# Created: 2026-04-30 — Phase 1 of "Files as Knowledge" plan, Stage 1.A.
+# Pins the chain's selection algorithm: per-MIME override wins, otherwise
+# first matching adapter, with offline detection and fallback on failure.
+"""Tests for `ee.cloud.extraction.chain.ExtractionChain` and `build_chain`.
+
+The chain owns three orthogonal pieces of behaviour:
+
+  1. Selection — per-MIME override beats chain order; chain is searched in
+     registration order using `supports_mimes` (with "*" as a wildcard).
+  2. Offline detection — adapters with `requires_network = True` are
+     skipped when `_is_online()` returns False.
+  3. Failure recovery — adapter exceptions log and fall through to the
+     offline fallback. The fallback's exceptions propagate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from ee.cloud.extraction import (
+    ExtractionChain,
+    ExtractionResult,
+    build_chain,
+)
+from ee.cloud.extraction import chain as chain_mod
+
+
+class _StubAdapter:
+    """Minimal adapter for testing — records calls, returns canned text."""
+
+    def __init__(
+        self,
+        name: str,
+        mimes: set[str],
+        requires_network: bool = False,
+        raise_on_extract: Exception | None = None,
+        text: str | None = None,
+    ) -> None:
+        self.name = name
+        self.supports_mimes = mimes
+        self.requires_network = requires_network
+        self._raise = raise_on_extract
+        self._text = text if text is not None else f"text-from-{name}"
+        self.calls: list[tuple[Path, str]] = []
+
+    async def extract(self, path: Path, mime: str) -> ExtractionResult:
+        self.calls.append((path, mime))
+        if self._raise is not None:
+            raise self._raise
+        return ExtractionResult(text=self._text, backend=self.name)
+
+
+@pytest.fixture(autouse=True)
+def _force_online(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests opt in to offline behaviour explicitly."""
+    monkeypatch.setattr(chain_mod, "_is_online", lambda: True)
+
+
+@pytest.fixture
+def fallback() -> _StubAdapter:
+    return _StubAdapter("local", {"*"})
+
+
+def _settings(
+    extraction_chain: list[str],
+    extraction_per_mime: dict[str, str] | None = None,
+    gemini_api_key: str | None = None,
+) -> Any:
+    return SimpleNamespace(
+        extraction_chain=extraction_chain,
+        extraction_per_mime=extraction_per_mime or {},
+        extraction_offline_fallback="local",
+        gemini_api_key=gemini_api_key,
+    )
+
+
+async def test_per_mime_override_wins(fallback: _StubAdapter) -> None:
+    primary = _StubAdapter("primary", {"*"})
+    override = _StubAdapter("special", {"image/png"})
+    chain = ExtractionChain(
+        adapters=[primary, override],
+        offline_fallback=fallback,
+        per_mime_override={"image/png": "special"},
+    )
+
+    result = await chain.run(Path("/tmp/x.png"), "image/png")
+
+    assert result.backend == "special"
+    assert override.calls == [(Path("/tmp/x.png"), "image/png")]
+    assert primary.calls == []
+
+
+async def test_first_matching_adapter_wins(fallback: _StubAdapter) -> None:
+    a = _StubAdapter("first", {"image/png"})
+    b = _StubAdapter("second", {"image/png"})
+    chain = ExtractionChain(adapters=[a, b], offline_fallback=fallback)
+
+    result = await chain.run(Path("/tmp/x.png"), "image/png")
+
+    assert result.backend == "first"
+    assert b.calls == []
+
+
+async def test_wildcard_supports_unmatched_mimes(fallback: _StubAdapter) -> None:
+    catchall = _StubAdapter("catch", {"*"})
+    chain = ExtractionChain(adapters=[catchall], offline_fallback=fallback)
+
+    result = await chain.run(Path("/tmp/x.weird"), "application/x-weird")
+
+    assert result.backend == "catch"
+
+
+async def test_unmatched_mime_falls_through_to_fallback(
+    fallback: _StubAdapter,
+) -> None:
+    narrow = _StubAdapter("narrow", {"image/png"})
+    chain = ExtractionChain(adapters=[narrow], offline_fallback=fallback)
+
+    result = await chain.run(Path("/tmp/x.pdf"), "application/pdf")
+
+    assert result.backend == "local"
+    assert narrow.calls == []
+
+
+async def test_offline_skips_network_adapter(
+    monkeypatch: pytest.MonkeyPatch, fallback: _StubAdapter
+) -> None:
+    monkeypatch.setattr(chain_mod, "_is_online", lambda: False)
+    cloud = _StubAdapter("cloud", {"image/png"}, requires_network=True)
+    chain = ExtractionChain(adapters=[cloud], offline_fallback=fallback)
+
+    result = await chain.run(Path("/tmp/x.png"), "image/png")
+
+    assert result.backend == "local"
+    assert cloud.calls == []
+
+
+async def test_failing_adapter_falls_through(fallback: _StubAdapter) -> None:
+    flaky = _StubAdapter(
+        "flaky", {"image/png"}, raise_on_extract=RuntimeError("boom")
+    )
+    chain = ExtractionChain(adapters=[flaky], offline_fallback=fallback)
+
+    result = await chain.run(Path("/tmp/x.png"), "image/png")
+
+    assert result.backend == "local"
+    assert flaky.calls == [(Path("/tmp/x.png"), "image/png")]
+
+
+async def test_fallback_failure_propagates() -> None:
+    bad_fallback = _StubAdapter(
+        "local", {"*"}, raise_on_extract=RuntimeError("fallback failed")
+    )
+    chain = ExtractionChain(adapters=[], offline_fallback=bad_fallback)
+
+    with pytest.raises(RuntimeError, match="fallback failed"):
+        await chain.run(Path("/tmp/x"), "text/plain")
+
+
+async def test_per_mime_override_with_unknown_name_falls_through(
+    fallback: _StubAdapter,
+) -> None:
+    primary = _StubAdapter("primary", {"image/png"})
+    chain = ExtractionChain(
+        adapters=[primary],
+        offline_fallback=fallback,
+        per_mime_override={"image/png": "no-such-adapter"},
+    )
+
+    result = await chain.run(Path("/tmp/x.png"), "image/png")
+
+    # Unknown override → search the chain → primary matches.
+    assert result.backend == "primary"
+
+
+# --- build_chain factory --------------------------------------------------
+
+
+def test_build_chain_local_only() -> None:
+    settings = _settings(extraction_chain=["local"])
+    chain = build_chain(settings)
+
+    assert len(chain._adapters) == 1
+    assert chain._adapters[0].name == "local"
+    assert chain._offline_fallback.name == "local"
+
+
+def test_build_chain_skips_gemini_when_no_api_key() -> None:
+    settings = _settings(extraction_chain=["gemini-flash", "local"])
+    chain = build_chain(settings)
+
+    # gemini-flash is silently dropped (no key) but local is included.
+    names = [a.name for a in chain._adapters]
+    assert "gemini-flash" not in names
+    assert "local" in names
+
+
+def test_build_chain_includes_gemini_with_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Patch GeminiFlashExtractor so we don't need a real google.genai Client.
+    from ee.cloud.extraction import gemini_flash as gem_mod
+
+    sentinel = _StubAdapter("gemini-flash", {"image/png"}, requires_network=True)
+    monkeypatch.setattr(
+        gem_mod, "GeminiFlashExtractor", lambda api_key, **kw: sentinel
+    )
+
+    settings = _settings(
+        extraction_chain=["gemini-flash", "local"], gemini_api_key="fake-key"
+    )
+    chain = build_chain(settings)
+
+    names = [a.name for a in chain._adapters]
+    assert names == ["gemini-flash", "local"]
+
+
+def test_build_chain_unknown_adapter_raises() -> None:
+    settings = _settings(extraction_chain=["bogus-name"])
+
+    with pytest.raises(ValueError, match="unknown extraction adapter"):
+        build_chain(settings)
+
+
+def test_build_chain_propagates_per_mime_override() -> None:
+    settings = _settings(
+        extraction_chain=["local"],
+        extraction_per_mime={"image/png": "local"},
+    )
+    chain = build_chain(settings)
+    assert chain._per_mime == {"image/png": "local"}

--- a/tests/cloud/extraction/test_gemini_flash.py
+++ b/tests/cloud/extraction/test_gemini_flash.py
@@ -1,0 +1,163 @@
+# test_gemini_flash.py — GeminiFlashExtractor tests.
+# Created: 2026-04-30 — Phase 1 of "Files as Knowledge" plan, Stage 1.A.
+# Asserts request structure (model, MIME on Part, image bytes) plus PDF
+# strategy (pypdf text per page, sparse-page marker for image-heavy pages).
+# No real network calls — google.genai.Client is mocked.
+"""Tests for `ee.cloud.extraction.gemini_flash.GeminiFlashExtractor`.
+
+Mocking approach: monkeypatch `google.genai.Client` to return a MagicMock
+whose `models.generate_content(...)` returns a stub response. We assert on
+the args the SDK was called with — the model name, the inline `Part`
+contents, and the MIME type — to pin the request shape.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pypdf import PdfWriter
+
+from ee.cloud.extraction import ExtractionResult
+
+
+@pytest.fixture
+def mock_genai_client(monkeypatch: pytest.MonkeyPatch):
+    """Patch `google.genai.Client` to return a MagicMock factory.
+
+    The fixture returns the (client, response) tuple so tests can
+    configure response.text and inspect call args.
+    """
+    from google import genai
+
+    fake_response = MagicMock()
+    fake_response.text = "stub caption"
+    fake_client = MagicMock()
+    fake_client.models.generate_content.return_value = fake_response
+
+    def _factory(api_key: str):
+        return fake_client
+
+    monkeypatch.setattr(genai, "Client", _factory)
+    return fake_client, fake_response
+
+
+@pytest.fixture
+def tmp_image(tmp_path: Path) -> Path:
+    p = tmp_path / "diagram.png"
+    p.write_bytes(b"\x89PNG\r\n\x1a\nfake-bytes")
+    return p
+
+
+@pytest.fixture
+def tmp_blank_pdf(tmp_path: Path) -> Path:
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    buf = io.BytesIO()
+    writer.write(buf)
+    p = tmp_path / "blank.pdf"
+    p.write_bytes(buf.getvalue())
+    return p
+
+
+async def test_image_extract_calls_gemini_with_inline_bytes(
+    mock_genai_client, tmp_image: Path
+) -> None:
+    from ee.cloud.extraction.gemini_flash import GeminiFlashExtractor
+
+    fake_client, fake_response = mock_genai_client
+    fake_response.text = "Caption: a small PNG image."
+
+    extractor = GeminiFlashExtractor(api_key="fake-key")
+    result = await extractor.extract(tmp_image, "image/png")
+
+    assert isinstance(result, ExtractionResult)
+    assert result.text == "Caption: a small PNG image."
+    assert result.captions == ["Caption: a small PNG image."]
+    assert result.backend == "gemini-flash"
+    assert result.metadata["model"] == "gemini-2.5-flash"
+
+    fake_client.models.generate_content.assert_called_once()
+    call_kwargs = fake_client.models.generate_content.call_args.kwargs
+    assert call_kwargs["model"] == "gemini-2.5-flash"
+
+    # Request body: [prompt_text, Part(image bytes, image/png)]
+    contents = call_kwargs["contents"]
+    assert len(contents) == 2
+    assert "knowledge base" in contents[0]
+    part = contents[1]
+    # types.Part is a Pydantic model; the bytes live on inline_data.
+    assert getattr(part.inline_data, "mime_type", None) == "image/png"
+    assert getattr(part.inline_data, "data", None) == tmp_image.read_bytes()
+
+
+async def test_image_extract_uses_configured_model(
+    mock_genai_client, tmp_image: Path
+) -> None:
+    from ee.cloud.extraction.gemini_flash import GeminiFlashExtractor
+
+    fake_client, _ = mock_genai_client
+    extractor = GeminiFlashExtractor(api_key="fake-key", model="custom-model")
+    await extractor.extract(tmp_image, "image/png")
+
+    call_kwargs = fake_client.models.generate_content.call_args.kwargs
+    assert call_kwargs["model"] == "custom-model"
+
+
+async def test_image_extract_handles_empty_response(
+    mock_genai_client, tmp_image: Path
+) -> None:
+    from ee.cloud.extraction.gemini_flash import GeminiFlashExtractor
+
+    _, fake_response = mock_genai_client
+    fake_response.text = None
+
+    extractor = GeminiFlashExtractor(api_key="fake-key")
+    result = await extractor.extract(tmp_image, "image/png")
+
+    assert result.text == ""
+    assert result.captions == [""]
+
+
+async def test_pdf_extract_blank_page_marked_sparse(
+    mock_genai_client, tmp_blank_pdf: Path
+) -> None:
+    from ee.cloud.extraction.gemini_flash import GeminiFlashExtractor
+
+    fake_client, _ = mock_genai_client
+    extractor = GeminiFlashExtractor(api_key="fake-key")
+    result = await extractor.extract(tmp_blank_pdf, "application/pdf")
+
+    # Stage 1.A doesn't ship a PDF→image renderer; sparse pages get a marker.
+    assert "[page 1: image-heavy, no caption]" in result.text
+    assert result.metadata["sparse_pages"] == [1]
+    assert result.metadata["page_count"] == 1
+    assert result.backend == "gemini-flash"
+
+    # No Gemini call is made when every page is sparse — the renderer is
+    # the missing piece, not the API. This pins the "no heavy dep" promise.
+    fake_client.models.generate_content.assert_not_called()
+
+
+async def test_unsupported_mime_raises(mock_genai_client, tmp_path: Path) -> None:
+    from ee.cloud.extraction.gemini_flash import GeminiFlashExtractor
+
+    p = tmp_path / "audio.wav"
+    p.write_bytes(b"RIFF...")
+
+    extractor = GeminiFlashExtractor(api_key="fake-key")
+    with pytest.raises(ValueError, match="unsupported mime"):
+        await extractor.extract(p, "audio/wav")
+
+
+async def test_supports_metadata(mock_genai_client) -> None:
+    from ee.cloud.extraction.gemini_flash import GeminiFlashExtractor
+
+    extractor = GeminiFlashExtractor(api_key="fake-key")
+    assert extractor.name == "gemini-flash"
+    assert "image/png" in extractor.supports_mimes
+    assert "image/jpeg" in extractor.supports_mimes
+    assert "application/pdf" in extractor.supports_mimes
+    assert extractor.requires_network is True

--- a/tests/cloud/extraction/test_local.py
+++ b/tests/cloud/extraction/test_local.py
@@ -1,0 +1,155 @@
+# test_local.py — LocalExtractor parity tests.
+# Created: 2026-04-30 — Phase 1 of "Files as Knowledge" plan, Stage 1.A.
+# Behavior parity check: LocalExtractor.extract(...).text must match the
+# previous suffix-routed _extract_file output for the same input.
+"""Tests for `ee.cloud.extraction.local.LocalExtractor`.
+
+The LocalExtractor is a behavior-preserving port of the old `_extract_file`
+helper from `agents/knowledge.py`. These tests pin that contract:
+
+  - Text-file fallback returns the file body verbatim with errors='replace'.
+  - PDF route uses pypdf's PdfReader; an empty-page PDF returns "".
+  - DOCX route uses python-docx Document.paragraphs.
+  - Image route delegates to pytesseract (mocked here).
+  - Missing optional deps raise RuntimeError with install hints.
+  - The result wraps the same text into ExtractionResult with backend="local".
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pypdf import PdfWriter
+
+from ee.cloud.extraction import ExtractionResult
+from ee.cloud.extraction.local import LocalExtractor
+
+
+@pytest.fixture
+def tmp_text_file(tmp_path: Path) -> Path:
+    p = tmp_path / "notes.txt"
+    p.write_text("hello local extractor\nsecond line\n", encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def tmp_blank_pdf(tmp_path: Path) -> Path:
+    """Blank single-page PDF — pypdf reads it back as an empty string."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    buf = io.BytesIO()
+    writer.write(buf)
+    p = tmp_path / "blank.pdf"
+    p.write_bytes(buf.getvalue())
+    return p
+
+
+async def test_text_file_fallback(tmp_text_file: Path) -> None:
+    extractor = LocalExtractor()
+    result = await extractor.extract(tmp_text_file, "text/plain")
+
+    assert isinstance(result, ExtractionResult)
+    assert result.text == "hello local extractor\nsecond line\n"
+    assert result.backend == "local"
+    assert result.captions == []
+    assert result.metadata["path"] == str(tmp_text_file)
+    assert result.metadata["mime"] == "text/plain"
+
+
+async def test_text_file_with_invalid_utf8(tmp_path: Path) -> None:
+    """errors='replace' contract: unreadable bytes do not raise."""
+    p = tmp_path / "bad.txt"
+    p.write_bytes(b"good text \xff\xfe trailing")
+    extractor = LocalExtractor()
+
+    result = await extractor.extract(p, "text/plain")
+
+    # The U+FFFD replacement char appears for the bad bytes.
+    assert "good text" in result.text
+    assert "trailing" in result.text
+
+
+async def test_pdf_blank_page(tmp_blank_pdf: Path) -> None:
+    extractor = LocalExtractor()
+    result = await extractor.extract(tmp_blank_pdf, "application/pdf")
+
+    # Blank page yields empty extracted text — same as the prior _extract_file.
+    assert result.text == ""
+    assert result.backend == "local"
+
+
+async def test_pdf_missing_pypdf_raises(tmp_path: Path) -> None:
+    p = tmp_path / "x.pdf"
+    p.write_bytes(b"%PDF-1.4\n")
+    extractor = LocalExtractor()
+
+    # Force ImportError on `from pypdf import PdfReader`.
+    with patch.dict(sys.modules, {"pypdf": None}):
+        with pytest.raises(RuntimeError, match="pypdf not installed"):
+            await extractor.extract(p, "application/pdf")
+
+
+async def test_docx_path_uses_docx_paragraphs(tmp_path: Path) -> None:
+    p = tmp_path / "doc.docx"
+    p.write_bytes(b"placeholder")  # contents irrelevant — Document() is mocked
+
+    fake_docx = MagicMock()
+    fake_paragraph_a = MagicMock(text="first para")
+    fake_paragraph_b = MagicMock(text="second para")
+    fake_doc = MagicMock(paragraphs=[fake_paragraph_a, fake_paragraph_b])
+    fake_docx.Document.return_value = fake_doc
+
+    with patch.dict(sys.modules, {"docx": fake_docx}):
+        result = await LocalExtractor().extract(p, "application/vnd.openxmlformats")
+
+    fake_docx.Document.assert_called_once_with(str(p))
+    assert result.text == "first para\nsecond para"
+    assert result.backend == "local"
+
+
+async def test_docx_missing_lib_raises(tmp_path: Path) -> None:
+    p = tmp_path / "x.docx"
+    p.write_bytes(b"placeholder")
+
+    with patch.dict(sys.modules, {"docx": None}):
+        with pytest.raises(RuntimeError, match="python-docx not installed"):
+            await LocalExtractor().extract(p, "application/vnd.openxmlformats")
+
+
+async def test_image_path_uses_pytesseract(tmp_path: Path) -> None:
+    p = tmp_path / "diagram.png"
+    p.write_bytes(b"\x89PNG\r\n\x1a\n")  # bytes irrelevant — PIL/tesseract are mocked
+
+    fake_pytesseract = MagicMock()
+    fake_pytesseract.image_to_string.return_value = "ocr text from image"
+    fake_pil = MagicMock()
+    fake_image = MagicMock()
+    fake_pil.Image.open.return_value = fake_image
+
+    with patch.dict(sys.modules, {"pytesseract": fake_pytesseract, "PIL": fake_pil}):
+        result = await LocalExtractor().extract(p, "image/png")
+
+    fake_pil.Image.open.assert_called_once_with(str(p))
+    fake_pytesseract.image_to_string.assert_called_once_with(fake_image)
+    assert result.text == "ocr text from image"
+    assert result.backend == "local"
+
+
+async def test_image_missing_lib_raises(tmp_path: Path) -> None:
+    p = tmp_path / "x.jpg"
+    p.write_bytes(b"\xff\xd8\xff")  # JPEG magic
+
+    with patch.dict(sys.modules, {"pytesseract": None, "PIL": None}):
+        with pytest.raises(RuntimeError, match="pytesseract not installed"):
+            await LocalExtractor().extract(p, "image/jpeg")
+
+
+async def test_supports_wildcard_mime() -> None:
+    extractor = LocalExtractor()
+    assert "*" in extractor.supports_mimes
+    assert extractor.requires_network is False
+    assert extractor.name == "local"

--- a/uv.lock
+++ b/uv.lock
@@ -4443,7 +4443,7 @@ wheels = [
 
 [[package]]
 name = "pocketpaw"
-version = "0.4.16"
+version = "0.4.18"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## What ships

Adds `ee/cloud/extraction/`, a pluggable package that lets each MIME pick its own extractor. Wraps the existing pypdf, python-docx, and pytesseract logic into `LocalExtractor` and adds a `GeminiFlashExtractor` sibling for image captioning. `agents/knowledge.py:_extract_file` now dispatches through the chain.

This is Stage 1.A of the "Files as Knowledge" plan (paw-workspace PR #9). The `FileReady` listener and indexing wiring are Stage 1.B's PR.

## Why pluggable, not a swap

Captain directive: keep the traditional extractors. Reasons:

- Self-hosted and offline deployments need a no-network path.
- Cost-sensitive uploads (large text-only PDFs) don't need cloud captioning.
- Privacy-classified files may not be allowed to leave the network.

`POCKETPAW_EXTRACTION_CHAIN` controls the order. `LocalExtractor` is always built as the offline fallback regardless of config.

## New surface

```python
class ExtractionAdapter(Protocol):
    name: str
    supports_mimes: set[str]
    requires_network: bool
    async def extract(self, path: Path, mime: str) -> ExtractionResult: ...
```

Concrete adapters:

- `LocalExtractor` — `name="local"`, wildcard MIME, `requires_network=False`. Behaviour-preserving port of the previous `_extract_file`.
- `GeminiFlashExtractor` — `name="gemini-flash"`, image/png + image/jpeg + image/jpg + application/pdf, `requires_network=True`. Uses google-genai (already in pyproject).

`build_chain(settings)` reads:

- `POCKETPAW_EXTRACTION_CHAIN` (list, default `["local"]`)
- `POCKETPAW_EXTRACTION_PER_MIME` (dict, default `{}`)
- `POCKETPAW_EXTRACTION_OFFLINE_FALLBACK` (str, default `"local"`)
- `POCKETPAW_GEMINI_API_KEY` (str, default `None`)

When `POCKETPAW_GEMINI_API_KEY` is unset, `gemini-flash` is silently dropped during chain construction so misconfigured prod doesn't crash startup.

## Selection rules

1. Per-MIME override wins.
2. Otherwise the first chain adapter whose `supports_mimes` matches the MIME (or has `*`).
3. Network-required adapters get skipped if the host is offline; the fallback handles it.
4. On adapter exception the chain logs and falls through to the offline fallback. Fallback exceptions propagate.
5. If no adapter claims the MIME, the offline fallback handles it.

## PDF strategy in GeminiFlashExtractor

Stage 1.A doesn't ship a PDF-to-image renderer (no new dep). The PDF path uses pypdf for text per page; pages with <200 chars get marked `[page N: image-heavy, no caption]` and excluded from captioning. If we want to caption image-heavy pages later, that's a follow-up and the dep choice (pdf2image, pypdfium2, etc.) needs to be picked then.

## Test plan

- [x] LocalExtractor parity tests: text fallback, invalid UTF-8 with errors='replace', blank PDF, missing pypdf raises, DOCX with mocked python-docx, missing python-docx raises, image with mocked pytesseract+PIL, missing pytesseract raises, wildcard MIME / metadata.
- [x] GeminiFlashExtractor: model name + MIME on Part + image bytes go through the SDK; configured model; empty response handled; PDF sparse-page marker; PDF makes no Gemini call when every page is sparse; unsupported MIME raises.
- [x] ExtractionChain: per-MIME override wins; first match wins; wildcard supports any MIME; unmatched MIME falls through to fallback; offline skips network adapter; failing adapter falls through; fallback failure propagates; unknown override name falls through.
- [x] `build_chain`: local-only; skips gemini without key; includes gemini with key; unknown adapter name raises; per-MIME map passed through.
- [x] Full non-e2e suite green: 4327 passed, 1 skipped.
- [x] `ruff check` clean on touched files.
- [ ] `mypy ee/cloud/extraction/`: 2 pre-existing import-not-found errors for `docx` and `pytesseract` (no public type stubs). Same errors existed in the previous `_extract_file`.

## Files

- New: `ee/cloud/extraction/{__init__,adapter,local,gemini_flash,chain}.py`
- New: `tests/cloud/extraction/{test_local,test_gemini_flash,test_chain}.py`
- Modified: `ee/cloud/agents/knowledge.py` (`_extract_file` now calls the chain)
- Modified: `src/pocketpaw/config.py` (4 new settings)

## Out of scope (Stage 1.B)

- FileReady listener subscription
- `KnowledgeService.ingest_text_to_scope`
- Multi-scope context_builder
- Wiring extraction into `uploads/service.py`

---

> **Rebase note:** content cherry-picked from the closed [#1032](https://github.com/pocketpaw/pocketpaw/pull/1032) onto `ee` per the 2026-04-30 branch policy update (pocketpaw stages target `ee` until the sprint converges, then a rollup PR brings ee → dev). Auto-merge of `agents/knowledge.py`, `config.py`, and `uv.lock` was clean; all 28 extraction tests pass against the rebased base; full non-e2e suite stays green at 4327 passed.