### PR TITLE
feat(uploads): index S3-stored files via download-to-temp

### DIFF
--- a/ee/cloud/uploads/listeners.py
+++ b/ee/cloud/uploads/listeners.py
@@ -2,14 +2,22 @@
 # Created: 2026-04-30 — Stage 1.B of "Files as Knowledge". Wires FileReady
 #   into the extraction chain and ingests the resulting text into the
 #   workspace KB scope. Pocket-scope routing lands in Stage 3.E.
+# Updated: 2026-04-30 evening — Stage 1.B follow-up. Remote storage
+#   adapters (S3, GCS) don't expose a local path; the listener now streams
+#   the blob into a NamedTemporaryFile via the adapter's async open() and
+#   runs extraction on the temp file, cleaning up afterwards. Local-disk
+#   adapters keep using the direct path with no extra I/O.
 """Upload bus subscribers.
 
 The upload pipeline emits :class:`FileReady` on every successful upload.
 This module subscribes that event and runs the indexing flow:
 
-  1. Resolve the storage path via the EE upload resolver.
+  1. Resolve a Path the extractor can read — either the adapter's local
+     path (local-disk deployments) or a temp file streamed from the
+     adapter's ``open()`` (S3, GCS, any remote adapter).
   2. Run the configured extraction chain to produce searchable text.
   3. Ingest the text into the kb-go scope ``workspace:{wid}``.
+  4. Clean up the temp file on the way out, regardless of success.
 
 Failures are isolated — a broken extraction or a missing kb binary must not
 propagate back to the upload publisher. The bus already wraps each handler
@@ -22,7 +30,11 @@ Pocket-scope routing arrives in Stage 3.E: the listener will check
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import mimetypes
+import tempfile
+from collections.abc import AsyncIterator
 from pathlib import Path
 
 from ee.cloud._core.realtime.bus import get_bus
@@ -56,64 +68,150 @@ async def index_uploaded_file(event: Event) -> None:
         )
         return
 
-    storage_path = _resolve_storage_path(storage_key)
-    if storage_path is None:
-        # Remote adapters (S3, GCS) don't expose a local path. Stage 1.B is
-        # local-disk only; Phase 2 wires download_to_local_temp for remote.
-        logger.info(
-            "skipping KB index: no local path for file_id=%s storage_key=%r",
-            file_id,
-            storage_key,
-        )
-        return
+    async with _path_for_extraction(storage_key, mime, filename) as path:
+        if path is None:
+            logger.info(
+                "skipping KB index: no path for file_id=%s storage_key=%r",
+                file_id,
+                storage_key,
+            )
+            return
 
-    try:
-        from ee.cloud.extraction import build_chain
-        from pocketpaw.config import get_settings
+        try:
+            from ee.cloud.extraction import build_chain
+            from pocketpaw.config import get_settings
 
-        chain = build_chain(get_settings())
-        result = await chain.run(storage_path, mime)
-    except Exception:
-        logger.exception("extraction failed for file_id=%s", file_id)
-        return
+            chain = build_chain(get_settings())
+            result = await chain.run(path, mime)
+        except Exception:
+            logger.exception("extraction failed for file_id=%s", file_id)
+            return
 
-    text = (result.text or "").strip()
-    if not text:
-        logger.info(
-            "extracted empty text for file_id=%s; skipping KB ingest", file_id
-        )
-        return
+        text = (result.text or "").strip()
+        if not text:
+            logger.info(
+                "extracted empty text for file_id=%s; skipping KB ingest",
+                file_id,
+            )
+            return
 
-    try:
-        from ee.cloud.agents.knowledge import KnowledgeService
+        try:
+            from ee.cloud.agents.knowledge import KnowledgeService
 
-        await KnowledgeService.ingest_text_to_scope(
-            scope=f"workspace:{workspace_id}",
-            text=text,
-            source=filename,
-        )
-    except Exception:
-        logger.exception("KB ingest failed for file_id=%s", file_id)
+            await KnowledgeService.ingest_text_to_scope(
+                scope=f"workspace:{workspace_id}",
+                text=text,
+                source=filename,
+            )
+        except Exception:
+            logger.exception("KB ingest failed for file_id=%s", file_id)
 
 
-def _resolve_storage_path(storage_key: str | None) -> Path | None:
-    """Look up the local on-disk path for the stored blob.
+@contextlib.asynccontextmanager
+async def _path_for_extraction(
+    storage_key: str | None,
+    mime: str,
+    filename: str,
+) -> AsyncIterator[Path | None]:
+    """Yield a Path the extraction chain can read.
 
-    Returns ``None`` when the adapter doesn't expose a local path (remote
-    storage) or when the EE upload singletons can't be reached (test
-    contexts that don't mount the upload router).
+    Local-disk adapter: yields the on-disk path unchanged (zero extra I/O).
+    Remote adapter (S3, GCS): streams the blob into a NamedTemporaryFile,
+    yields its Path, then deletes the file on exit. The temp suffix
+    matches the original filename so suffix-routed extractors (pypdf for
+    .pdf, python-docx for .docx, etc.) keep working.
+
+    Yields ``None`` when neither path works — the listener treats that as
+    "skip this upload, log, and move on".
     """
     if not storage_key:
+        yield None
+        return
+
+    direct = _resolve_local_path(storage_key)
+    if direct is not None:
+        yield direct
+        return
+
+    adapter = _resolve_adapter()
+    if adapter is None:
+        yield None
+        return
+
+    suffix = _extension_for(filename, mime)
+    tmp = tempfile.NamedTemporaryFile(  # noqa: SIM115 — manual lifecycle
+        prefix="paw-extract-",
+        suffix=suffix,
+        delete=False,
+    )
+    tmp_path = Path(tmp.name)
+    try:
+        try:
+            async for chunk in adapter.open(storage_key):
+                tmp.write(chunk)
+        except Exception:
+            logger.exception(
+                "stream-to-temp failed for storage_key=%r", storage_key
+            )
+            yield None
+            return
+        finally:
+            tmp.close()
+
+        yield tmp_path
+    finally:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("temp cleanup failed for %s", tmp_path)
+
+
+def _resolve_local_path(storage_key: str) -> Path | None:
+    """Return the adapter's on-disk path for ``storage_key`` if available."""
+    adapter = _resolve_adapter()
+    if adapter is None:
         return None
     try:
-        from ee.cloud.uploads.router import _ADAPTER
-
-        return _ADAPTER.local_path(storage_key)
+        return adapter.local_path(storage_key)
     except Exception:
         logger.exception(
             "local_path lookup failed for storage_key=%r", storage_key
         )
         return None
+
+
+def _resolve_adapter():
+    """Look up the EE upload singleton's storage adapter.
+
+    Returns ``None`` when the upload router hasn't been mounted (test
+    contexts without the cloud surface). Importing inside the function so
+    test harnesses can monkeypatch ``_ADAPTER`` between sub-tests without
+    hitting an import-time freeze.
+    """
+    try:
+        from ee.cloud.uploads.router import _ADAPTER
+
+        return _ADAPTER
+    except Exception:
+        logger.exception("upload adapter import failed")
+        return None
+
+
+def _extension_for(filename: str, mime: str) -> str:
+    """Pick a temp-file suffix the extractors will route correctly.
+
+    Prefers the original filename's extension (matches what the user
+    uploaded). Falls back to ``mimetypes.guess_extension`` and finally to
+    an empty string when the MIME isn't registered. Suffix matters because
+    ``LocalExtractor`` routes by ``path.suffix`` (pypdf for .pdf, docx for
+    .docx, pytesseract for .png/.jpg) and ``GeminiFlashExtractor`` checks
+    MIME directly so extension is forgiven there.
+    """
+    suffix = Path(filename).suffix
+    if suffix:
+        return suffix
+    guessed = mimetypes.guess_extension(mime, strict=False) or ""
+    return guessed
 
 
 def register_upload_listeners() -> None:

--- a/tests/cloud/uploads/test_listener.py
+++ b/tests/cloud/uploads/test_listener.py
@@ -3,6 +3,11 @@
 #   listener resolves the storage path, runs extraction, ingests into
 #   workspace KB, and contains failures so they don't propagate back to
 #   the publisher.
+# Updated: 2026-04-30 evening — Stage 1.B follow-up. Added S3 / remote
+#   adapter coverage: when local_path returns None the listener streams
+#   the blob into a NamedTemporaryFile, runs extraction on that, and
+#   deletes the temp file on the way out. Also covers stream failures
+#   and suffix preservation so suffix-routed extractors stay routed.
 """Tests for ``ee.cloud.uploads.listeners.index_uploaded_file``."""
 
 from __future__ import annotations
@@ -28,11 +33,43 @@ class _FakeChain:
         return self._result
 
 
+class _FakeAdapter:
+    """Stand-in for the upload StorageAdapter.
+
+    ``local_path_value`` controls what the local-path lookup returns; ``None``
+    simulates a remote adapter (S3, GCS) that has no on-disk surface.
+    ``open_chunks`` is the byte stream the listener will assemble into a
+    temp file; setting ``open_raises`` makes the iterator raise mid-stream
+    so the failure-isolation path is exercised.
+    """
+
+    def __init__(
+        self,
+        *,
+        local_path_value: Path | None = None,
+        open_chunks: list[bytes] | None = None,
+        open_raises: BaseException | None = None,
+    ):
+        self._local = local_path_value
+        self._chunks = open_chunks or []
+        self._raises = open_raises
+
+    def local_path(self, key: str) -> Path | None:
+        return self._local
+
+    async def open(self, key: str):
+        for chunk in self._chunks:
+            yield chunk
+        if self._raises is not None:
+            raise self._raises
+
+
 def _patch_listener(
     monkeypatch,
     *,
     chain: _FakeChain | None = None,
     storage_path: Path | None = None,
+    adapter: _FakeAdapter | None = None,
     ingest: AsyncMock | None = None,
 ):
     """Wire the listener's collaborators with test doubles."""
@@ -44,11 +81,19 @@ def _patch_listener(
             lambda settings: chain,
         )
 
-    if storage_path is not None:
+    # ``_resolve_adapter`` underpins both the local-path and the temp-file
+    # branches; ``adapter`` lets tests pin both at once.
+    if adapter is not None:
         monkeypatch.setattr(
-            listeners,
-            "_resolve_storage_path",
-            lambda key: storage_path,
+            listeners, "_resolve_adapter", lambda: adapter
+        )
+    elif storage_path is not None:
+        # Back-compat shortcut: tests that only care about the local-path
+        # branch can pass ``storage_path`` and we wire a fake adapter
+        # under the hood.
+        fake = _FakeAdapter(local_path_value=storage_path)
+        monkeypatch.setattr(
+            listeners, "_resolve_adapter", lambda: fake
         )
 
     if ingest is not None:
@@ -128,20 +173,207 @@ async def test_index_skips_when_file_id_missing(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_index_skips_when_storage_path_unresolved(monkeypatch):
-    """Remote adapters return None for local_path — listener must bail."""
+async def test_index_skips_when_no_storage_key(monkeypatch):
+    """No storage_key in the event → no path to extract from; bail cleanly."""
     from ee.cloud.uploads.listeners import index_uploaded_file
 
     chain = _FakeChain(ExtractionResult(text="ignored", backend="local"))
     ingest = AsyncMock()
-    _patch_listener(monkeypatch, chain=chain, storage_path=None, ingest=ingest)
+    _patch_listener(monkeypatch, chain=chain, ingest=ingest)
 
     await index_uploaded_file(
         FileReady(
             data={
                 "workspace_id": "w1",
                 "file_id": "f1",
-                "storage_key": "s3://bucket/f1",
+                # storage_key intentionally missing
+            }
+        )
+    )
+
+    assert chain.calls == []
+    ingest.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_remote_adapter_streams_into_temp_then_extracts(monkeypatch):
+    """S3 / GCS path: local_path=None → listener streams adapter.open() bytes
+    into a NamedTemporaryFile, runs extraction on it, deletes the file."""
+    from ee.cloud.uploads.listeners import index_uploaded_file
+
+    chain = _FakeChain(
+        ExtractionResult(text="caption from gemini", backend="gemini-flash")
+    )
+    adapter = _FakeAdapter(
+        local_path_value=None,
+        open_chunks=[b"chunk-1 ", b"chunk-2"],
+    )
+    ingest = AsyncMock(return_value={"id": "art-1"})
+    _patch_listener(monkeypatch, chain=chain, adapter=adapter, ingest=ingest)
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "whiteboard.png",
+                "mime": "image/png",
+                "storage_key": "ws/w1/whiteboard.png",
+            }
+        )
+    )
+
+    # Chain was called exactly once with a temp path that ends in .png so
+    # any suffix-routed extractor downstream would still recognize it.
+    assert len(chain.calls) == 1
+    temp_path, mime = chain.calls[0]
+    assert mime == "image/png"
+    assert temp_path.suffix == ".png", temp_path
+    assert temp_path.name.startswith("paw-extract-"), temp_path
+    # File was wiped after the context manager exited.
+    assert not temp_path.exists()
+    # The temp file held both chunks before extraction ran. We can't peek
+    # at the file post-cleanup, so we settle for the chain having been
+    # called — the absence of a half-written empty file would have shown
+    # up as test_kb_failure_does_not_propagate-style failure.
+
+    ingest.assert_awaited_once_with(
+        scope="workspace:w1",
+        text="caption from gemini",
+        source="whiteboard.png",
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_adapter_stream_failure_bails_cleanly(monkeypatch):
+    """If adapter.open() raises mid-stream, listener swallows + skips."""
+    from ee.cloud.uploads.listeners import index_uploaded_file
+
+    chain = _FakeChain(ExtractionResult(text="never reached", backend="local"))
+    adapter = _FakeAdapter(
+        local_path_value=None,
+        open_chunks=[b"partial"],
+        open_raises=ConnectionError("S3 disconnected"),
+    )
+    ingest = AsyncMock()
+    _patch_listener(monkeypatch, chain=chain, adapter=adapter, ingest=ingest)
+
+    # Must not raise — handler-level isolation is the whole point.
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "doc.pdf",
+                "mime": "application/pdf",
+                "storage_key": "ws/w1/doc.pdf",
+            }
+        )
+    )
+
+    assert chain.calls == []
+    ingest.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_remote_adapter_temp_suffix_falls_back_to_mime(monkeypatch):
+    """Filename has no extension → guess from MIME. Keeps suffix-routed
+    extractors (LocalExtractor's pypdf path, etc.) working in the remote
+    case too."""
+    from ee.cloud.uploads.listeners import index_uploaded_file
+
+    chain = _FakeChain(
+        ExtractionResult(text="extracted", backend="local")
+    )
+    adapter = _FakeAdapter(
+        local_path_value=None, open_chunks=[b"%PDF-1.4 ..."]
+    )
+    ingest = AsyncMock()
+    _patch_listener(monkeypatch, chain=chain, adapter=adapter, ingest=ingest)
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "no-extension-here",
+                "mime": "application/pdf",
+                "storage_key": "ws/w1/blob",
+            }
+        )
+    )
+
+    assert len(chain.calls) == 1
+    temp_path, _mime = chain.calls[0]
+    assert temp_path.suffix == ".pdf", temp_path
+    ingest.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_local_adapter_uses_direct_path_no_temp(monkeypatch, tmp_path):
+    """Local-disk adapter: listener uses the direct path, no temp file is
+    created — the regression case for the S3 fallback not breaking the
+    fast path."""
+    from ee.cloud.uploads.listeners import index_uploaded_file
+
+    direct = tmp_path / "doc.pdf"
+    direct.write_bytes(b"%PDF-1.4 ...")
+    chain = _FakeChain(ExtractionResult(text="from direct path", backend="local"))
+    # Adapter exposes a local path AND an open() — the listener should
+    # prefer the local path and never call open().
+    open_calls: list[str] = []
+
+    class _AdapterWithBoth(_FakeAdapter):
+        async def open(self, key: str):  # type: ignore[override]
+            open_calls.append(key)
+            yield b"unexpected"
+
+    adapter = _AdapterWithBoth(local_path_value=direct)
+    ingest = AsyncMock()
+    _patch_listener(monkeypatch, chain=chain, adapter=adapter, ingest=ingest)
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "doc.pdf",
+                "mime": "application/pdf",
+                "storage_key": "local/w1/doc.pdf",
+            }
+        )
+    )
+
+    assert chain.calls == [(direct, "application/pdf")]
+    assert open_calls == [], "local adapter must not stream when local_path works"
+    ingest.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_index_skips_when_adapter_unavailable(monkeypatch):
+    """Test contexts without the upload router mounted: _resolve_adapter
+    returns None → listener logs and skips, never calls extraction."""
+    from ee.cloud.uploads import listeners
+    from ee.cloud.uploads.listeners import index_uploaded_file
+
+    chain = _FakeChain(ExtractionResult(text="ignored", backend="local"))
+    ingest = AsyncMock()
+    monkeypatch.setattr(listeners, "_resolve_adapter", lambda: None)
+    monkeypatch.setattr(
+        "ee.cloud.extraction.build_chain", lambda settings: chain
+    )
+    from ee.cloud.agents import knowledge as kn
+
+    monkeypatch.setattr(kn.KnowledgeService, "ingest_text_to_scope", ingest)
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "x.pdf",
+                "mime": "application/pdf",
+                "storage_key": "k",
             }
         )
     )


### PR DESCRIPTION
Stage 1.B follow-up. The original listener bailed when `local_path` returned `None`, which silently skipped every upload on S3 / GCS deployments. Now the listener streams the blob through the adapter's existing async `open()` into a `NamedTemporaryFile`, runs extraction on that, ingests into the workspace KB, and deletes the temp file on the way out.

## Why this matters

Smoke testing Phase 1 on the captain's local pocketpaw revealed that the running setup uses Hetzner Object Storage (`nbg1.your-objectstorage.com/interacly-dev-private/...`), not local disk. Stage 1.B's listener checked `local_path` first, got `None`, and logged "skipping KB index: no local path" — exactly as designed. But that meant **every cloud-deployed upload was silently bypassing KB indexing**, which is the whole point of Phase 1.

This patch lifts the deferred Phase 2 download-to-temp logic into Stage 1.B's listener so the auto-index flow works on cloud deployments out of the box.

## What changed

`ee/cloud/uploads/listeners.py`:

- New `_path_for_extraction` async context manager. Yields a `Path` the extractor can read, or `None` when neither path works.
- Local-disk path: `local_path` returns the on-disk path → yields it directly, zero extra I/O.
- Remote path: `local_path` returns `None` → streams `adapter.open(storage_key)` chunks into a `NamedTemporaryFile` with the right suffix → yields the temp `Path` → deletes the file on exit.
- Suffix preservation: the temp file inherits the original filename's extension (or `mimetypes.guess_extension(mime)` when filename has none) so suffix-routed extractors keep working — `pypdf` for `.pdf`, `python-docx` for `.docx`, `pytesseract` for `.png`/`.jpg`.
- Stream-failure isolation: if `adapter.open()` raises mid-stream, the listener logs and bails with no temp file leaked.
- Adapter-unavailable: when the upload router isn't mounted (test contexts), `_resolve_adapter` returns `None` and the listener skips cleanly.

Internal helper `_resolve_storage_path` was renamed to `_resolve_local_path` and a `_resolve_adapter` helper was extracted so the temp-file branch can reuse the same lookup.

## Tests

`tests/cloud/uploads/test_listener.py` — 13 cases total (was 7):

New:
- `test_index_skips_when_no_storage_key` — replaces the old "remote skips" case which is no longer the policy
- `test_remote_adapter_streams_into_temp_then_extracts` — happy path: chunks stream, temp suffix matches, file deleted, ingest gets the right scope
- `test_remote_adapter_stream_failure_bails_cleanly` — `ConnectionError` mid-stream → no chain call, no ingest, no temp leak
- `test_remote_adapter_temp_suffix_falls_back_to_mime` — filename without extension still gets `.pdf` from mime
- `test_local_adapter_uses_direct_path_no_temp` — regression: local adapter never calls `open()`
- `test_index_skips_when_adapter_unavailable` — `_resolve_adapter` returns None → graceful skip

Existing 7 tests stay green via the `_FakeAdapter` shim that exposes `local_path()` + `open()` and routes through the unchanged listener public API.

## Verification

- 13/13 listener tests pass
- `ruff check` clean on touched files
- `mypy` no new errors (the pre-existing pocketpaw.config import-untyped is unchanged)

After this lands and the captain restarts pocketpaw, the smoke test in `paw-workspace/temp/smoke_phase1.py` should report new articles in `workspace:{wid}` instead of "0 new".