### PR TITLE
fix(kb): auto-resolve kb-go binary across env / PATH / workspace checkout

### DIFF
--- a/ee/cloud/agents/knowledge.py
+++ b/ee/cloud/agents/knowledge.py
@@ -25,12 +25,46 @@ import json
 import logging
 import mimetypes
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-KB_BIN = os.environ.get("POCKETPAW_KB_BIN", "kb-go")
+
+def _resolve_kb_bin() -> str:
+    """Find the kb binary, in order of preference.
+
+    1. ``POCKETPAW_KB_BIN`` env var (explicit override).
+    2. ``kb-go`` on PATH (preferred name).
+    3. ``kb`` on PATH (alternate name; kb-go releases ship the binary as
+       ``kb`` from a build step).
+    4. Workspace-local checkout at ``<paw-workspace>/kb-go/kb`` — the
+       common dev layout where the kb-go repo sits next to pocketpaw.
+
+    Returns the literal string ``"kb-go"`` when nothing resolves so the
+    error message stays informative ("kb binary not found at 'kb-go'").
+
+    Resolved at import time; override via env if your binary moves.
+    """
+    explicit = os.environ.get("POCKETPAW_KB_BIN")
+    if explicit:
+        return explicit
+    for name in ("kb-go", "kb"):
+        path = shutil.which(name)
+        if path:
+            return path
+    # Workspace-local fallback — pocketpaw lives at <ws>/pocketpaw and
+    # kb-go at <ws>/kb-go in the canonical OCEAN-workspace layout. Walk
+    # up from this file looking for any ancestor that contains kb-go/kb.
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "kb-go" / "kb"
+        if candidate.exists():
+            return str(candidate)
+    return "kb-go"
+
+
+KB_BIN = _resolve_kb_bin()
 
 
 def _kb(*args: str, input_text: str | None = None, timeout: int = 120) -> dict | list | str:
@@ -48,9 +82,10 @@ def _kb(*args: str, input_text: str | None = None, timeout: int = 120) -> dict |
         )
     except FileNotFoundError:
         raise RuntimeError(
-            f"kb binary not found at '{KB_BIN}'. "
-            "Install: go install github.com/qbtrix/kb-go@latest "
-            "or set POCKETPAW_KB_BIN to the binary path (e.g. kb-go)."
+            f"kb binary not found at {KB_BIN!r}. "
+            "Install: go install github.com/qbtrix/kb-go@latest, "
+            "or set POCKETPAW_KB_BIN to the binary path (e.g. /path/to/kb-go/kb), "
+            "or place the workspace-local checkout at <paw-workspace>/kb-go/kb."
         )
     if result.returncode != 0:
         logger.warning("kb failed (exit %d): %s", result.returncode, result.stderr[:200])

--- a/tests/cloud/test_kb_bin_resolution.py
+++ b/tests/cloud/test_kb_bin_resolution.py
@@ -1,0 +1,108 @@
+# test_kb_bin_resolution.py — kb-go binary auto-resolution.
+# Created: 2026-04-30 — Verifies _resolve_kb_bin() walks the fallback chain
+#   (env → kb-go on PATH → kb on PATH → workspace-local checkout) so
+#   pocketpaw works out of the box on dev machines that have the kb-go
+#   repo checked out next to pocketpaw but no system-installed binary.
+"""Tests for ``ee.cloud.agents.knowledge._resolve_kb_bin``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def reset_kb_bin_env(monkeypatch):
+    """Strip POCKETPAW_KB_BIN so each test starts from a clean slate."""
+    monkeypatch.delenv("POCKETPAW_KB_BIN", raising=False)
+
+
+def test_explicit_env_var_wins(monkeypatch, reset_kb_bin_env):
+    """POCKETPAW_KB_BIN, when set, is returned verbatim."""
+    from ee.cloud.agents.knowledge import _resolve_kb_bin
+
+    monkeypatch.setenv("POCKETPAW_KB_BIN", "/custom/path/to/kb")
+    assert _resolve_kb_bin() == "/custom/path/to/kb"
+
+
+def test_falls_through_to_kb_go_on_path(monkeypatch, reset_kb_bin_env, tmp_path):
+    """When env unset, prefer ``kb-go`` from PATH."""
+    from ee.cloud.agents import knowledge as kn
+
+    fake_kb_go = tmp_path / "kb-go"
+    fake_kb_go.write_text("#!/bin/sh\nexit 0\n")
+    fake_kb_go.chmod(0o755)
+    monkeypatch.setattr(
+        kn.shutil,
+        "which",
+        lambda name: str(fake_kb_go) if name == "kb-go" else None,
+    )
+
+    assert kn._resolve_kb_bin() == str(fake_kb_go)
+
+
+def test_falls_through_to_kb_on_path(monkeypatch, reset_kb_bin_env, tmp_path):
+    """When ``kb-go`` is missing but ``kb`` is on PATH, use that."""
+    from ee.cloud.agents import knowledge as kn
+
+    fake_kb = tmp_path / "kb"
+    fake_kb.write_text("#!/bin/sh\nexit 0\n")
+    fake_kb.chmod(0o755)
+    monkeypatch.setattr(kn.shutil, "which", lambda name: str(fake_kb) if name == "kb" else None)
+
+    assert kn._resolve_kb_bin() == str(fake_kb)
+
+
+def test_falls_through_to_workspace_checkout(monkeypatch, reset_kb_bin_env, tmp_path):
+    """No PATH entry → walk parents looking for ``<ancestor>/kb-go/kb``."""
+    from ee.cloud.agents import knowledge as kn
+
+    # Stage a fake workspace layout: <root>/{ee/cloud/agents/file.py, kb-go/kb}.
+    project = tmp_path / "fake-pocketpaw"
+    knowledge_file = project / "ee" / "cloud" / "agents" / "knowledge.py"
+    knowledge_file.parent.mkdir(parents=True)
+    knowledge_file.touch()
+    kb_bin = tmp_path / "kb-go" / "kb"
+    kb_bin.parent.mkdir()
+    kb_bin.write_text("#!/bin/sh\nexit 0\n")
+    kb_bin.chmod(0o755)
+
+    # Force shutil.which to return None so the PATH branch is skipped.
+    monkeypatch.setattr(kn.shutil, "which", lambda name: None)
+    # Pretend the source file lives in the staged tree so the parent walk
+    # finds the staged kb-go/kb.
+    monkeypatch.setattr(kn, "__file__", str(knowledge_file))
+
+    assert kn._resolve_kb_bin() == str(kb_bin)
+
+
+def test_returns_default_string_when_nothing_found(monkeypatch, reset_kb_bin_env, tmp_path):
+    """Last resort: literal ``"kb-go"`` so the FileNotFoundError message
+    stays informative even when no binary is reachable."""
+    from ee.cloud.agents import knowledge as kn
+
+    monkeypatch.setattr(kn.shutil, "which", lambda name: None)
+    # Point __file__ at a tree that contains no kb-go anywhere.
+    isolated = tmp_path / "no-kb-here" / "knowledge.py"
+    isolated.parent.mkdir()
+    isolated.touch()
+    monkeypatch.setattr(kn, "__file__", str(isolated))
+
+    assert kn._resolve_kb_bin() == "kb-go"
+
+
+def test_resolver_finds_workspace_checkout_in_real_repo():
+    """End-to-end smoke against the real workspace layout this repo lives
+    in. kb-go is a sibling of pocketpaw, so the resolver's parent walk
+    must find ``<workspace>/kb-go/kb`` regardless of PATH state.
+    """
+    from ee.cloud.agents.knowledge import KB_BIN
+
+    # KB_BIN was resolved at import time. In CI without kb-go on PATH it
+    # should fall through to the workspace-local kb. In a sandbox without
+    # the kb-go repo it returns "kb-go" (the default), which is also fine.
+    assert KB_BIN, "KB_BIN must be a non-empty string"
+    if KB_BIN != "kb-go":
+        path = Path(KB_BIN)
+        assert path.is_absolute() or path.exists()


### PR DESCRIPTION
The hardcoded `KB_BIN = "kb-go"` default broke pocketpaw on dev machines that have the kb-go repo checked out next to pocketpaw but no system-installed binary. The kb-go release ships the binary as `kb` from a build step, so a checkout produces `<ws>/kb-go/kb` which used to require setting `POCKETPAW_KB_BIN` manually.

## How the new resolver picks the binary

```
POCKETPAW_KB_BIN env override
  ↓ unset
shutil.which("kb-go")     ← preferred name; matches `go install`
  ↓ not found
shutil.which("kb")        ← alternate name; matches `make build` checkout
  ↓ not found
Walk up parents looking for `<ancestor>/kb-go/kb`   ← OCEAN-workspace dev layout
  ↓ not found
Returns "kb-go" so the FileNotFoundError stays informative
```

## Why this surfaced

Smoke-testing Phase 1 of the files-as-knowledge feature on the captain's local pocketpaw — the captain's setup has `<ws>/kb-go/kb` (the workspace-local checkout) but no kb-go on PATH. The `FileReady` listener was extracting cleanly, the S3 download-to-temp from PR #1035 was working, but `KnowledgeService.ingest_text_to_scope` kept raising `FileNotFoundError: [Errno 2] No such file or directory: 'kb-go'`. The pre-existing default value forced the user to set the env var, which isn't documented in any onboarding flow.

## Tests

`tests/cloud/test_kb_bin_resolution.py` — 6 cases:

- env override wins
- `kb-go` on PATH wins after env
- `kb` on PATH wins after `kb-go`
- workspace-local `<ancestor>/kb-go/kb` wins after PATH
- last-resort default `"kb-go"` so the error message stays informative
- real-repo smoke that asserts `KB_BIN` is non-empty in any environment

## Files

- Modified: `ee/cloud/agents/knowledge.py` — `_resolve_kb_bin()` helper, expanded error hint
- New: `tests/cloud/test_kb_bin_resolution.py`

## Test plan

- [x] 6/6 resolver tests pass
- [x] `ruff check` clean on touched files
- [ ] After merge, captain's smoke test (`temp/smoke_phase1.py`) runs end-to-end without setting `POCKETPAW_KB_BIN` first