### PR TITLE
Oath csrf - first commit

### DIFF
--- a/src/pocketpaw/api/oauth2/models.py
+++ b/src/pocketpaw/api/oauth2/models.py
@@ -30,6 +30,7 @@ class OAuthClient:
         parsed = urlparse(uri)
         if parsed.scheme == "http" and parsed.hostname in ("localhost", "127.0.0.1"):
             path = parsed.path or "/"
+            
             for registered in self.redirect_uris:
                 rp = urlparse(registered)
                 if rp.scheme == "http" and rp.hostname in ("localhost", "127.0.0.1"):

--- a/src/pocketpaw/api/oauth2/server.py
+++ b/src/pocketpaw/api/oauth2/server.py
@@ -223,6 +223,8 @@ class AuthorizationServer:
         return token
 
 
+
+
 # Singleton
 _server: AuthorizationServer | None = None
 

--- a/src/pocketpaw/mcp/manager.py
+++ b/src/pocketpaw/mcp/manager.py
@@ -12,22 +12,86 @@ Created: 2026-02-07
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
+import hmac
+import json
 import logging
 import os
+import secrets
+import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from pocketpaw.mcp.config import MCPServerConfig, load_mcp_config, save_mcp_config
 
 logger = logging.getLogger(__name__)
 
-# OAuth callback coordination: state -> Future[(code, state)]
-_oauth_pending: dict[str, asyncio.Future] = {}
+_OAUTH_STATE_TTL_SECONDS = 300
+
+
+@dataclass
+class _PendingOAuthFlow:
+    """Tracks one in-flight OAuth state and its callback Future."""
+
+    future: asyncio.Future
+    server_name: str
+    created_at: float
+    provider: str
+    user_id: str
+    upstream_state: str
+
+
+# OAuth callback coordination: state -> pending flow
+_oauth_pending: dict[str, _PendingOAuthFlow] = {}
 
 # WebSocket broadcast function injected by dashboard at startup
 _ws_broadcast: Callable | None = None
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(data: str) -> bytes:
+    return base64.urlsafe_b64decode(data + ("=" * (-len(data) % 4)))
+
+
+def _state_signing_key() -> bytes:
+    return (os.getenv("POCKETPAW_OAUTH_STATE_SECRET") or "dev-oauth-state-secret").encode()
+
+
+def _create_state_token(*, user_id: str, provider: str, upstream_state: str) -> tuple[str, str]:
+    issued = int(time.time())
+    state_id = secrets.token_urlsafe(16)
+    payload = {
+        "sid": state_id,
+        "uid": user_id,
+        "prv": provider,
+        "iat": issued,
+        "exp": issued + _OAUTH_STATE_TTL_SECONDS,
+        "n": secrets.token_urlsafe(32),
+        "ups": upstream_state,
+    }
+    payload_b64 = _b64url(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode())
+    sig = _b64url(hmac.new(_state_signing_key(), payload_b64.encode(), hashlib.sha256).digest())
+    return f"{payload_b64}.{sig}", state_id
+
+
+def _verify_state_token(state_token: str) -> dict[str, Any] | None:
+    try:
+        payload_b64, sig_b64 = state_token.split(".", 1)
+        expected = hmac.new(_state_signing_key(), payload_b64.encode(), hashlib.sha256).digest()
+        if not hmac.compare_digest(expected, _b64url_decode(sig_b64)):
+            return None
+        payload = json.loads(_b64url_decode(payload_b64).decode("utf-8"))
+        if int(time.time()) > int(payload["exp"]):
+            return None
+        return payload
+    except Exception:
+        return None
 
 
 def set_ws_broadcast(fn: Callable) -> None:
@@ -44,9 +108,30 @@ def set_oauth_callback_result(state: str, code: str) -> bool:
 
     Returns True if a pending Future was found and resolved.
     """
-    future = _oauth_pending.get(state)
-    if future and not future.done():
-        future.set_result((code, state))
+    payload = _verify_state_token(state)
+    if not payload:
+        logger.warning("Invalid OAuth state signature/format")
+        return False
+    state_id = payload.get("sid", "")
+    entry = _oauth_pending.get(state_id)
+    if not entry:
+        logger.warning("No pending OAuth flow for state=%s", state[:16])
+        return False
+
+    # Reject stale callbacks even if the state still exists in memory.
+    if (time.time() - entry.created_at) > _OAUTH_STATE_TTL_SECONDS:
+        _oauth_pending.pop(state_id, None)
+        logger.warning("Expired OAuth state for server=%s", entry.server_name)
+        return False
+
+    if not entry.future.done():
+        # Strict binding checks before resolving callback.
+        if payload.get("uid") != entry.user_id or payload.get("prv") != entry.provider:
+            _oauth_pending.pop(state_id, None)
+            logger.warning("OAuth state binding mismatch for server=%s", entry.server_name)
+            return False
+        entry.future.set_result((code, entry.upstream_state))
+        _oauth_pending.pop(state_id, None)
         return True
     logger.warning("No pending OAuth flow for state=%s", state[:16])
     return False
@@ -235,13 +320,28 @@ class MCPManager:
             parsed = urlparse(auth_url)
             params = parse_qs(parsed.query)
             state_values = params.get("state", [])
-            state = state_values[0] if state_values else ""
+            upstream_state = state_values[0] if state_values else ""
 
-            if state:
+            if upstream_state:
                 loop = asyncio.get_running_loop()
                 future = loop.create_future()
-                _oauth_pending[state] = future
-                _flow_state["state"] = state
+                user_id = "local_user"
+                signed_state, state_id = _create_state_token(
+                    user_id=user_id,
+                    provider=config.name,
+                    upstream_state=upstream_state,
+                )
+                _oauth_pending[state_id] = _PendingOAuthFlow(
+                    future=future,
+                    server_name=config.name,
+                    created_at=time.time(),
+                    provider=config.name,
+                    user_id=user_id,
+                    upstream_state=upstream_state,
+                )
+                _flow_state["state"] = state_id
+                params["state"] = [signed_state]
+                auth_url = urlunparse(parsed._replace(query=urlencode(params, doseq=True)))
 
             if _ws_broadcast:
                 await _ws_broadcast(
@@ -258,10 +358,14 @@ class MCPManager:
             state = _flow_state.get("state")
             if not state or state not in _oauth_pending:
                 raise RuntimeError(f"No pending OAuth flow for server '{config.name}'")
-
-            future = _oauth_pending[state]
+            pending = _oauth_pending[state]
+            if pending.server_name != config.name:
+                _oauth_pending.pop(state, None)
+                raise RuntimeError(f"OAuth state/server mismatch for server '{config.name}'")
             try:
-                code, returned_state = await asyncio.wait_for(future, timeout=300)
+                code, returned_state = await asyncio.wait_for(
+                    pending.future, timeout=_OAUTH_STATE_TTL_SECONDS
+                )
                 return (code, returned_state)
             finally:
                 _oauth_pending.pop(state, None)

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -240,19 +240,35 @@ class TestOAuthCallbackCoordination:
         manager._oauth_pending.clear()
 
     def test_set_oauth_callback_result_resolves_future(self):
-        from pocketpaw.mcp.manager import set_oauth_callback_result
+        import time
+
+        from pocketpaw.mcp.manager import (
+            _create_state_token,
+            _PendingOAuthFlow,
+            set_oauth_callback_result,
+        )
 
         loop = asyncio.new_event_loop()
         future = loop.create_future()
 
         from pocketpaw.mcp import manager
 
-        manager._oauth_pending["test_state_123"] = future
+        state_token, state_id = _create_state_token(
+            user_id="local_user", provider="test_server", upstream_state="upstream_state_1"
+        )
+        manager._oauth_pending[state_id] = _PendingOAuthFlow(
+            future=future,
+            server_name="test_server",
+            created_at=time.time(),
+            provider="test_server",
+            user_id="local_user",
+            upstream_state="upstream_state_1",
+        )
 
-        result = set_oauth_callback_result("test_state_123", "auth_code_456")
+        result = set_oauth_callback_result(state_token, "auth_code_456")
         assert result is True
         assert future.done()
-        assert future.result() == ("auth_code_456", "test_state_123")
+        assert future.result() == ("auth_code_456", "upstream_state_1")
         loop.close()
 
     def test_set_oauth_callback_result_unknown_state(self):
@@ -262,7 +278,13 @@ class TestOAuthCallbackCoordination:
         assert result is False
 
     def test_set_oauth_callback_result_already_resolved(self):
-        from pocketpaw.mcp.manager import set_oauth_callback_result
+        import time
+
+        from pocketpaw.mcp.manager import (
+            _create_state_token,
+            _PendingOAuthFlow,
+            set_oauth_callback_result,
+        )
 
         loop = asyncio.new_event_loop()
         future = loop.create_future()
@@ -270,9 +292,19 @@ class TestOAuthCallbackCoordination:
 
         from pocketpaw.mcp import manager
 
-        manager._oauth_pending["done_state"] = future
+        state_token, state_id = _create_state_token(
+            user_id="local_user", provider="test_server", upstream_state="upstream_state_2"
+        )
+        manager._oauth_pending[state_id] = _PendingOAuthFlow(
+            future=future,
+            server_name="test_server",
+            created_at=time.time(),
+            provider="test_server",
+            user_id="local_user",
+            upstream_state="upstream_state_2",
+        )
 
-        result = set_oauth_callback_result("done_state", "new_code")
+        result = set_oauth_callback_result(state_token, "new_code")
         assert result is False
         loop.close()
 

--- a/uv.lock
+++ b/uv.lock
@@ -707,18 +707,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.39"
+version = "0.1.69"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
+    { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/86/52c75a8737d96524611b738fa649d4555eff361b9f8ae393557644fb15e9/claude_agent_sdk-0.1.39.tar.gz", hash = "sha256:dcf0ebd5a638c9a7d9f3af7640932a9212b2705b7056e4f08bd3968a865b4268", size = 61612, upload-time = "2026-02-19T23:43:48.836Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/fa/c6913cf92796cf2d9792ebb30247880cc5740be70d0cc2663ab1d0e253f2/claude_agent_sdk-0.1.69.tar.gz", hash = "sha256:4034a1c9d550329af7aeb0615f9bd2e7b853a9a53da7be5278ee062330df223a", size = 241101, upload-time = "2026-04-28T00:43:39.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/bc/405ac4a079cd9257d3e39c8ede213e6ca7d8cb358486b7cfedf01ef1a7fe/claude_agent_sdk-0.1.39-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ed6a79781f545b761b9fe467bc5ae213a103c9d3f0fe7a9dad3c01790ed58fa", size = 55221981, upload-time = "2026-02-19T23:43:32.845Z" },
-    { url = "https://files.pythonhosted.org/packages/70/40/09e75b15f606def0c67a7ef86580f8c4d431a25549fcca28a3748b478323/claude_agent_sdk-0.1.39-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:0c03b5a3772eaec42e29ea39240c7d24b760358082f2e36336db9e71dde3dda4", size = 69964932, upload-time = "2026-02-19T23:43:37.004Z" },
-    { url = "https://files.pythonhosted.org/packages/83/77/80888ccf8da8e4ff6b86d82ac1384a179e959d06af40a4f2090a6215b4ed/claude_agent_sdk-0.1.39-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:d2665c9e87b6ffece590bcdd6eb9def47cde4809b0d2f66e0a61a719189be7c9", size = 70577920, upload-time = "2026-02-19T23:43:41.662Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/d1/22afacdb20da881c82fd4c5c53f0e22a76a66010b3b11133ddc975d898d4/claude_agent_sdk-0.1.39-py3-none-win_amd64.whl", hash = "sha256:d03324daf7076be79d2dd05944559aabf4cc11c98d3a574b992a442a7c7a26d6", size = 72886448, upload-time = "2026-02-19T23:43:45.965Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/1b/14ad5b8686f68bc3c41ce5c287d9b6a919bf5a4c6d70cb1513ccec03df64/claude_agent_sdk-0.1.69-py3-none-macosx_11_0_arm64.whl", hash = "sha256:dd896e6e30719d4824687b2aa968d603e4d4f0056fdd848932cf969f393a32a7", size = 63446754, upload-time = "2026-04-28T00:43:43.296Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ee/a183b8b9ca5c7b8cc51d93ba83676938803b8f63f0c788b402d4056cc606/claude_agent_sdk-0.1.69-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:09f1e0b75811e2777bfde119af24a1c1c3a13e333f23af11eb049eccf1dece64", size = 65296492, upload-time = "2026-04-28T00:43:46.336Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a1/2252335f8991c62ba2b6ec2441406978c4267e357e9659092bce6af6a614/claude_agent_sdk-0.1.69-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:1aab5107a71290f5afa38b1f967c7b27df986248b662a81fc69b5a38be3f17f2", size = 76619235, upload-time = "2026-04-28T00:43:49.63Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a4/8426b7325e64bc2487ee943d8f0ad885920f0919466f039ebe70b40ed42e/claude_agent_sdk-0.1.69-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:f8caf9f2d29f109b1c5e5c1336984376b3597634ab0cd4d7d902f43bb33ee020", size = 76786152, upload-time = "2026-04-28T00:43:53.675Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/d64cbe0ecd68f7b5c255316ce78e158eb499d6da988b99d5fbee00cc4824/claude_agent_sdk-0.1.69-py3-none-win_amd64.whl", hash = "sha256:d8327e7f60a687b1cbfcc6da3b1428c89a60194c884bebee3fb282807163bd2c", size = 78193701, upload-time = "2026-04-28T00:43:57.983Z" },
 ]
 
 [[package]]
@@ -828,15 +830,15 @@ wheels = [
 
 [[package]]
 name = "discord-cli-agent"
-version = "0.6.4"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "discord-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/5a/3da941ae2151485f9578a68eb53875e85962e1ebb7a96992487fc0f68013/discord_cli_agent-0.6.4.tar.gz", hash = "sha256:05d452bda26b01acde26ba6dfcef34e1a7e03ed1f343a9cff981e18f5f710c75", size = 34201, upload-time = "2026-03-16T10:15:13.145Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/0e/757d3657635c763a51cf6fd00921452d036ade183f9bb12e05da69f71d99/discord_cli_agent-0.7.0.tar.gz", hash = "sha256:52696cb948b4d64726d52b6e90aad2e336707527f6a9dfe2d45bca21627eb897", size = 45725, upload-time = "2026-03-22T13:08:48.605Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/b6/a6339cd0be37fff1d4514e95020e26e585e82db39092dafefb9691afe77a/discord_cli_agent-0.6.4-py3-none-any.whl", hash = "sha256:d429dbfe87d069382b6b44b0c012218777b73a5c1df899308fe87dcf32281a09", size = 36624, upload-time = "2026-03-16T10:15:11.691Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/9b/4473edc24330dd5bdfd8a6cc5bff2b592055b0881d80e9d46a061e6dd617/discord_cli_agent-0.7.0-py3-none-any.whl", hash = "sha256:5b8dc65c0a81adae7a49e3d6893e92b9467abd761014a7746949dd9f4b3469ca", size = 47945, upload-time = "2026-03-22T13:08:47.201Z" },
 ]
 
 [[package]]
@@ -3873,17 +3875,17 @@ requires-dist = [
     { name = "botbuilder-integration-aiohttp", marker = "extra == 'dev'", specifier = ">=4.16.0" },
     { name = "botbuilder-integration-aiohttp", marker = "extra == 'teams'", specifier = ">=4.16.0" },
     { name = "chromadb", marker = "extra == 'vector'" },
-    { name = "claude-agent-sdk", specifier = ">=0.1.30" },
+    { name = "claude-agent-sdk", specifier = ">=0.1.56" },
     { name = "click", specifier = ">=8.0" },
     { name = "cryptography", specifier = ">=46.0.0" },
     { name = "deepagents", marker = "extra == 'all'", specifier = ">=0.1.0" },
     { name = "deepagents", marker = "extra == 'deep-agents'", specifier = ">=0.1.0" },
     { name = "deepagents", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "discord-cli-agent", marker = "extra == 'all'", specifier = ">=0.6.0" },
-    { name = "discord-cli-agent", marker = "extra == 'all-channels'", specifier = ">=0.6.0" },
-    { name = "discord-cli-agent", marker = "extra == 'channels'", specifier = ">=0.6.0" },
-    { name = "discord-cli-agent", marker = "extra == 'dev'", specifier = ">=0.6.0" },
-    { name = "discord-cli-agent", marker = "extra == 'discord'", specifier = ">=0.6.0" },
+    { name = "discord-cli-agent", marker = "extra == 'all'", specifier = ">=0.7.0" },
+    { name = "discord-cli-agent", marker = "extra == 'all-channels'", specifier = ">=0.7.0" },
+    { name = "discord-cli-agent", marker = "extra == 'channels'", specifier = ">=0.7.0" },
+    { name = "discord-cli-agent", marker = "extra == 'dev'", specifier = ">=0.7.0" },
+    { name = "discord-cli-agent", marker = "extra == 'discord'", specifier = ">=0.7.0" },
     { name = "elevenlabs", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "elevenlabs", marker = "extra == 'all-tools'", specifier = ">=1.0.0" },
     { name = "elevenlabs", marker = "extra == 'dev'", specifier = ">=1.0.0" },
@@ -4003,7 +4005,7 @@ dev = [
     { name = "botbuilder-core", specifier = ">=4.16.0" },
     { name = "botbuilder-integration-aiohttp", specifier = ">=4.16.0" },
     { name = "deepagents", specifier = ">=0.1.0" },
-    { name = "discord-cli-agent", specifier = ">=0.6.4" },
+    { name = "discord-cli-agent", specifier = ">=0.7.0" },
     { name = "elevenlabs", specifier = ">=1.0.0" },
     { name = "github-copilot-sdk", specifier = ">=0.1.0" },
     { name = "google-adk", specifier = ">=1.0.0" },


### PR DESCRIPTION
# MCP OAuth State Flow

This document explains the OAuth `state` hardening used in `src/pocketpaw/mcp/manager.py`.

## Why this exists

PocketPaw now wraps OAuth callback state in a signed token to prevent:

- forged callback state values,
- cross-flow mixups,
- replay of previously valid callback states.

The implementation preserves SDK compatibility by carrying the original upstream state inside the signed payload.

## Terms

- **Upstream state**: the original `state` generated by the OAuth SDK/client flow.
- **Signed state token**: PocketPaw-generated state sent to provider/browser roundtrip.
- **Pending flow**: server-side one-time record keyed by internal `sid`.

## Top-to-bottom flow

1. OAuth SDK creates auth URL and calls `redirect_handler(auth_url)`.
2. PocketPaw extracts the original upstream `state` from query params.
3. PocketPaw creates a signed token payload containing:
   - `sid` (internal state id)
   - `uid` (user binding)
   - `prv` (provider/server binding)
   - `iat` and `exp` (issue/expiry)
   - `n` (random nonce)
   - `ups` (original upstream state)
4. PocketPaw stores `_PendingOAuthFlow` in `_oauth_pending[sid]`.
5. PocketPaw replaces outbound URL `state` with the signed token and broadcasts URL to UI.
6. Provider redirects callback with `code` + signed `state`.
7. Callback endpoint calls `set_oauth_callback_result(state, code)`.
8. PocketPaw verifies signature + expiry, loads pending flow by `sid`, validates bindings (`uid`, `prv`), and resolves future with `(code, upstream_state)`.
9. Pending state is removed (`pop`) to enforce one-time use.
10. `callback_handler()` resumes and returns `(code, returned_state)` to SDK, which continues token exchange and token storage.

## Why we keep upstream state

We intentionally preserve upstream state (`ups`) because SDK internals may expect the original state value for correlation.

So we use:

- **signed state** for browser/provider security boundary,
- **upstream state** for SDK compatibility after validation.

## Security checks performed

- HMAC signature verification for state token integrity.
- Expiration checks (`exp` and pending TTL checks).
- Binding checks against pending flow metadata.
- One-time consume semantics (`_oauth_pending.pop(...)`).

## Current limitations / future improvements

- `user_id` is currently set to `"local_user"` in this flow and can be upgraded to real authenticated session identity.
- Secret fallback (`dev-oauth-state-secret`) is for development; production should always set `POCKETPAW_OAUTH_STATE_SECRET`.
- Persisted distributed replay protection (e.g., Redis) could be added if multi-process callback handling is required.
