### PR TITLE
feat(embeddings): pluggable embedding adapters with hybrid retrieval path

### DIFF
--- a/ee/cloud/embeddings/__init__.py
+++ b/ee/cloud/embeddings/__init__.py
@@ -1,0 +1,37 @@
+# __init__.py — Public surface for the embeddings package.
+# Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
+# Exposes EmbeddingAdapter, EmbeddingResult, build_embedder, CostTracker,
+# get_cost_tracker. Concrete adapters are imported on demand from
+# build_embedder so this module imports in environments missing
+# google-cloud-aiplatform (the lazy-import pattern matches extraction/).
+"""Pluggable multimodal embedding adapters.
+
+Public API:
+  - ``EmbeddingResult`` — output model every adapter returns.
+  - ``EmbeddingAdapter`` — Protocol that adapters implement.
+  - ``build_embedder(settings)`` — factory; returns ``None`` when vectors
+    are disabled, credentials missing, or required SDK not installed.
+  - ``CostTracker`` / ``get_cost_tracker(settings)`` — soft monthly cap
+    on embedding spend.
+
+Concrete adapters (``VertexGeminiEmbedding2``, ``VertexMultimodal001``)
+are imported on demand from ``build_embedder`` so this package can be
+imported in environments missing the underlying SDKs.
+"""
+
+from ee.cloud.embeddings.adapter import EmbeddingAdapter, EmbeddingResult
+from ee.cloud.embeddings.cost_tracker import (
+    CostTracker,
+    get_cost_tracker,
+    reset_cost_tracker_for_tests,
+)
+from ee.cloud.embeddings.factory import build_embedder
+
+__all__ = [
+    "CostTracker",
+    "EmbeddingAdapter",
+    "EmbeddingResult",
+    "build_embedder",
+    "get_cost_tracker",
+    "reset_cost_tracker_for_tests",
+]

--- a/ee/cloud/embeddings/adapter.py
+++ b/ee/cloud/embeddings/adapter.py
@@ -1,0 +1,79 @@
+# adapter.py — EmbeddingAdapter Protocol + EmbeddingResult model.
+# Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
+# Defines the pluggable adapter contract for multimodal embedding so the
+# listener vector path and the interleaved-query path in context_builder
+# can swap models (Gemini Embedding 2 vs Vertex multimodalembedding@001)
+# without touching their callsites.
+"""Embedding adapter protocol.
+
+Mirrors the shape of ``ee.cloud.extraction.adapter.ExtractionAdapter``.
+Each adapter declares the modalities it handles (text / image / pdf /
+audio / video) and whether it needs network. Adapters return an
+:class:`EmbeddingResult` so the listener can record per-call cost without
+re-deriving it from the model name.
+
+Two implementations ship in Stage 2.D:
+
+* :class:`ee.cloud.embeddings.vertex_gemini2.VertexGeminiEmbedding2` —
+  preview, 3072-dim, multimodal (text/image/pdf/audio/video).
+* :class:`ee.cloud.embeddings.vertex_mm001.VertexMultimodal001` — GA,
+  1408-dim max, text + image only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+
+class EmbeddingResult(BaseModel):
+    """Output shape every adapter returns.
+
+    vector: the embedding (length == ``dim``).
+    dim: length of ``vector`` (after Matryoshka truncation if the adapter
+        applied one). May be smaller than the model's native size.
+    model: the model identifier the call used (e.g. ``"gemini-embedding-001"``).
+    estimated_cost_usd: rough $ for this call. NOT billing-grade — the
+        listener uses it as a soft cap. Real billing comes from the
+        provider's dashboard.
+    """
+
+    vector: list[float]
+    dim: int
+    model: str
+    estimated_cost_usd: float = Field(default=0.0)
+
+
+@runtime_checkable
+class EmbeddingAdapter(Protocol):
+    """Duck-typed embedding adapter.
+
+    Attributes:
+        name: stable identifier (``"vertex-gemini-embedding-2"``,
+            ``"vertex-mm-001"``). Used in settings and logs.
+        dim: default output dimensionality (after Matryoshka truncation).
+            The listener uses this to know what kb-go expects in the
+            per-scope vector index — all vectors in a single index must
+            agree on dim.
+        supports_modalities: set of modality strings; valid members are
+            ``"text"``, ``"image"``, ``"pdf"``, ``"audio"``, ``"video"``.
+            The listener consults this before calling ``embed_file`` /
+            ``embed_query`` so an unsupported file type skips embedding
+            instead of raising.
+        requires_network: when True the listener may skip when the host
+            is offline. (Today both shipped adapters always require
+            network; reserved for a future local-MiniLM fallback.)
+    """
+
+    name: str
+    dim: int
+    supports_modalities: set[str]
+    requires_network: bool
+
+    async def embed_file(self, path: Path, mime: str) -> EmbeddingResult: ...
+
+    async def embed_query(self, text: str, image_bytes: bytes | None = None) -> EmbeddingResult: ...
+
+    def estimate_cost(self, path: Path | None, mime: str | None) -> float: ...

--- a/ee/cloud/embeddings/cost_tracker.py
+++ b/ee/cloud/embeddings/cost_tracker.py
@@ -1,0 +1,170 @@
+# cost_tracker.py — Rough monthly spend tracker for embedding calls.
+# Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
+# Persists at ~/.pocketpaw/embedding_cost.json so a process restart inside
+# the same calendar month keeps the running total. NOT billing-grade —
+# cap is a soft guard so a runaway loop can't drain the embedding budget.
+"""Rough monthly spend tracker.
+
+The listener calls :meth:`can_spend` before each embedding call and
+:meth:`record` after a successful one. When ``can_spend`` says no, the
+listener falls back to extraction-only (text still goes to kb-go, vector
+ingest is skipped) and logs the cap hit at INFO so the captain sees it.
+
+Persistence is a tiny JSON file at ``~/.pocketpaw/embedding_cost.json``:
+
+    {"month": "2026-05", "spent_usd": 0.4231}
+
+Any deserialisation error resets the file to a fresh state for the
+current month. We trade strict accounting for never crashing the
+listener over a corrupted ledger.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from threading import Lock
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PATH = Path.home() / ".pocketpaw" / "embedding_cost.json"
+
+
+class CostTracker:
+    """Soft monthly cap for embedding spend.
+
+    Thread-safe via an internal lock — callers from the FastAPI worker
+    pool may share a single tracker (``get_cost_tracker``) so a parallel
+    upload burst can't double-count or race the rollover check.
+    """
+
+    def __init__(
+        self,
+        monthly_cap_usd: float,
+        path: Path | None = None,
+    ) -> None:
+        self._cap = monthly_cap_usd
+        self._path = path or _DEFAULT_PATH
+        self._lock = Lock()
+        self._state = self._load()
+
+    # --- public API ------------------------------------------------------
+
+    @property
+    def cap_usd(self) -> float:
+        return self._cap
+
+    @property
+    def spent_this_month(self) -> float:
+        with self._lock:
+            self._roll_if_new_month()
+            return float(self._state.get("spent_usd", 0.0))
+
+    def can_spend(self, estimated_cost: float) -> bool:
+        """Return False when adding ``estimated_cost`` would exceed the cap.
+
+        A non-positive ``estimated_cost`` is treated as zero — pre-call
+        estimates are best-effort and a bad guess shouldn't block the
+        whole pipeline.
+        """
+        if self._cap <= 0:
+            return True  # disabled cap: always allow
+        with self._lock:
+            self._roll_if_new_month()
+            spent = float(self._state.get("spent_usd", 0.0))
+            return spent + max(0.0, float(estimated_cost)) <= self._cap
+
+    def record(self, cost: float) -> None:
+        """Add ``cost`` to this month's running total. Negative costs ignored."""
+        if cost <= 0:
+            return
+        with self._lock:
+            self._roll_if_new_month()
+            current = float(self._state.get("spent_usd", 0.0))
+            self._state["spent_usd"] = current + float(cost)
+            self._save()
+
+    # --- internals -------------------------------------------------------
+
+    @staticmethod
+    def _current_month_key() -> str:
+        # UTC keeps the rollover unambiguous across hosts in different
+        # timezones. Real billing ledgers use UTC for the same reason.
+        return datetime.now(UTC).strftime("%Y-%m")
+
+    def _roll_if_new_month(self) -> None:
+        """Reset the running total when the calendar month rolls over."""
+        current_key = self._current_month_key()
+        if self._state.get("month") != current_key:
+            self._state = {"month": current_key, "spent_usd": 0.0}
+            self._save()
+
+    def _load(self) -> dict:
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return {"month": self._current_month_key(), "spent_usd": 0.0}
+        except OSError as exc:
+            logger.warning("cost tracker read failed (%s); resetting", exc)
+            return {"month": self._current_month_key(), "spent_usd": 0.0}
+        try:
+            data = json.loads(raw)
+            if not isinstance(data, dict):
+                raise ValueError("not an object")
+        except (ValueError, json.JSONDecodeError) as exc:
+            logger.warning("cost tracker parse failed (%s); resetting", exc)
+            return {"month": self._current_month_key(), "spent_usd": 0.0}
+
+        # If the persisted month doesn't match today, treat the file as
+        # rolled over. The first record() call will rewrite it.
+        if data.get("month") != self._current_month_key():
+            return {"month": self._current_month_key(), "spent_usd": 0.0}
+        # Coerce bad floats to zero rather than blow up on disk corruption.
+        try:
+            data["spent_usd"] = float(data.get("spent_usd", 0.0))
+        except (TypeError, ValueError):
+            data["spent_usd"] = 0.0
+        return data
+
+    def _save(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(
+                json.dumps(self._state, indent=2),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            # Persistence failure shouldn't crash the listener. The cap
+            # will reset on next process start — accept the loss.
+            logger.warning("cost tracker write failed (%s)", exc)
+
+
+_tracker: CostTracker | None = None
+
+
+def get_cost_tracker(settings) -> CostTracker:
+    """Return the process-wide tracker, building it lazily from settings.
+
+    The listener calls this on every event so we cache the instance to
+    avoid re-reading the JSON ledger from disk per upload.
+    """
+    global _tracker  # noqa: PLW0603 — process-wide singleton
+    if _tracker is None or _tracker.cap_usd != settings.embedding_monthly_cap_usd:
+        _tracker = CostTracker(monthly_cap_usd=settings.embedding_monthly_cap_usd)
+    return _tracker
+
+
+def reset_cost_tracker_for_tests() -> None:
+    """Test helper: clear the singleton so each test gets a fresh tracker.
+
+    Production paths shouldn't call this — the singleton is the whole
+    point of the soft cap. Tests use it to swap the on-disk path
+    between fixtures.
+    """
+    global _tracker  # noqa: PLW0603
+    _tracker = None
+
+
+__all__ = ["CostTracker", "get_cost_tracker", "reset_cost_tracker_for_tests"]

--- a/ee/cloud/embeddings/factory.py
+++ b/ee/cloud/embeddings/factory.py
@@ -1,0 +1,84 @@
+# factory.py — build_embedder(settings): pick the configured adapter.
+# Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
+# Mirrors ee.cloud.extraction.chain.build_chain — settings → adapter
+# instance, with cred / dep checks short-circuiting to None so the
+# listener degrades gracefully (text still ingests, vector skipped).
+"""Embedder factory.
+
+The settings shape:
+
+    settings.kb_vectors_enabled: bool
+    settings.embedding_adapter: str  # "" | "vertex-gemini-embedding-2" | "vertex-mm-001"
+    settings.embedding_dim: int
+    settings.gemini_api_key: str | None       # for vertex-gemini-embedding-2
+    settings.vertex_project_id: str | None    # for vertex-mm-001
+    settings.vertex_location: str | None      # for vertex-mm-001
+
+Returns ``None`` (vectors disabled) when:
+
+  * ``kb_vectors_enabled`` is False
+  * ``embedding_adapter`` is empty
+  * required credentials aren't set
+  * the adapter's SDK isn't installed (vertex-mm-001 needs
+    google-cloud-aiplatform; if absent, ImportError is caught and we
+    return None with an info log)
+
+Raises ``ValueError`` for an unknown adapter name. That's a config bug,
+not a runtime degradation, so it must be loud.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ee.cloud.embeddings.adapter import EmbeddingAdapter
+
+logger = logging.getLogger(__name__)
+
+
+def build_embedder(settings) -> EmbeddingAdapter | None:
+    """Return the configured adapter, or ``None`` when embeddings are disabled."""
+    if not getattr(settings, "kb_vectors_enabled", False):
+        return None
+
+    name = (getattr(settings, "embedding_adapter", "") or "").strip()
+    if not name:
+        return None
+
+    dim = int(getattr(settings, "embedding_dim", 1024))
+
+    if name == "vertex-gemini-embedding-2":
+        api_key = getattr(settings, "gemini_api_key", None)
+        if not api_key:
+            logger.info("vertex-gemini-embedding-2 requires gemini_api_key; embeddings disabled")
+            return None
+        from ee.cloud.embeddings.vertex_gemini2 import VertexGeminiEmbedding2
+
+        return VertexGeminiEmbedding2(api_key=api_key, dim=dim)
+
+    if name == "vertex-mm-001":
+        project_id = getattr(settings, "vertex_project_id", None)
+        if not project_id:
+            logger.info("vertex-mm-001 requires vertex_project_id; embeddings disabled")
+            return None
+        location = getattr(settings, "vertex_location", None) or "us-central1"
+        try:
+            from ee.cloud.embeddings.vertex_mm001 import VertexMultimodal001
+
+            return VertexMultimodal001(
+                project_id=project_id,
+                location=location,
+                dim=dim,
+            )
+        except ImportError:
+            logger.info(
+                "vertex-mm-001 needs google-cloud-aiplatform; not installed, embeddings disabled"
+            )
+            return None
+
+    raise ValueError(f"unknown embedding adapter: {name!r}")
+
+
+__all__ = ["build_embedder"]

--- a/ee/cloud/embeddings/vertex_gemini2.py
+++ b/ee/cloud/embeddings/vertex_gemini2.py
@@ -1,0 +1,211 @@
+# vertex_gemini2.py — Gemini Embedding 2 adapter (preview, 3072-dim, multimodal).
+# Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
+# Uses google-genai (already in pyproject for the gemini-flash extractor).
+# Native multimodal across text/image/pdf/audio/video; truncates via
+# Matryoshka representation learning so callers can drop to 1024 / 768 / 512
+# without re-running the model.
+"""VertexGeminiEmbedding2 — google-genai SDK adapter.
+
+The model identifier on google-genai is ``gemini-embedding-001`` (the
+"Gemini Embedding 2" preview surfaces under that name in the SDK as of
+2026-04). 3072-dim native output; we Matryoshka-truncate to
+``settings.embedding_dim`` so the per-scope kb-go vector index stays at
+the deployment's chosen size.
+
+Cost estimation is a flat $0.000025 per 1k input tokens. No public
+Vertex pricing exists for this preview model yet — we use the
+``gemini-embedding-001`` GA price as a stand-in. The listener treats
+the returned cost as a soft cap, not a billing source.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from pathlib import Path
+
+from ee.cloud.embeddings.adapter import EmbeddingResult
+
+logger = logging.getLogger(__name__)
+
+# Per-1k-token cost in USD. Gemini Embedding 2 preview pricing isn't
+# published yet; use the GA gemini-embedding-001 list price as a stand-in
+# so the cap tracker has a number to work with. Off by a factor is fine —
+# the cap is a soft guard, not a billing source.
+_COST_PER_1K_TOKENS_USD = 0.000025
+# Coarse token estimate: 1 token ~ 4 chars for text. For files we use the
+# byte count as a worst-case proxy.
+_CHARS_PER_TOKEN = 4
+# Native model dim. Matryoshka truncation lets callers pick something
+# smaller without re-running the model.
+_NATIVE_DIM = 3072
+
+
+class VertexGeminiEmbedding2:
+    """Gemini Embedding 2 (preview) via google-genai. Multimodal."""
+
+    name = "vertex-gemini-embedding-2"
+    supports_modalities = {"text", "image", "pdf", "audio", "video"}
+    requires_network = True
+
+    def __init__(
+        self,
+        api_key: str,
+        dim: int = 1024,
+        model: str = "gemini-embedding-001",
+    ) -> None:
+        # Lazy-import so the file imports in environments without
+        # google-genai (mirrors GeminiFlashExtractor). Tests patch
+        # ``google.genai.Client``.
+        from google import genai
+
+        if dim < 1 or dim > _NATIVE_DIM:
+            raise ValueError(f"embedding_dim={dim} out of range [1, {_NATIVE_DIM}]")
+        self.dim = dim
+        self._client = genai.Client(api_key=api_key)
+        self._model = model
+
+    async def embed_file(self, path: Path, mime: str) -> EmbeddingResult:
+        """Embed a file. Reads bytes, builds a Part, calls embed_content."""
+        from google.genai import types
+
+        data = path.read_bytes()
+        if mime.startswith("text/") or mime in {
+            "application/json",
+            "application/xml",
+        }:
+            # Plain text: skip the inline-Part path and embed as text.
+            return await self.embed_query(text=data.decode("utf-8", errors="replace"))
+
+        contents: list = [types.Part.from_bytes(data=data, mime_type=mime)]
+        response = await asyncio.to_thread(
+            self._client.models.embed_content,
+            model=self._model,
+            contents=contents,
+        )
+        vector = self._unwrap_vector(response)
+        cost = self._cost_for_bytes(len(data))
+        return self._matryoshka(vector, cost)
+
+    async def embed_query(self, text: str, image_bytes: bytes | None = None) -> EmbeddingResult:
+        """Embed a (text, image?) interleaved query.
+
+        When ``image_bytes`` is ``None`` we embed plain text. When set, the
+        text and image go to the model in one call as an interleaved input
+        — this is the property the chat-with-image path relies on.
+        """
+        from google.genai import types
+
+        if image_bytes is None:
+            contents: list = [text or ""]
+            cost = self._cost_for_text(text or "")
+        else:
+            contents = []
+            if text:
+                contents.append(text)
+            # MIME guess based on magic bytes — kept light so we don't pull
+            # ``filetype`` for one inline call. PNG / JPEG cover almost all
+            # paste-from-clipboard cases.
+            mime = _guess_image_mime(image_bytes)
+            contents.append(types.Part.from_bytes(data=image_bytes, mime_type=mime))
+            cost = self._cost_for_bytes(len(image_bytes)) + self._cost_for_text(text or "")
+
+        response = await asyncio.to_thread(
+            self._client.models.embed_content,
+            model=self._model,
+            contents=contents,
+        )
+        vector = self._unwrap_vector(response)
+        return self._matryoshka(vector, cost)
+
+    def estimate_cost(self, path: Path | None, mime: str | None) -> float:
+        """Cheap pre-call estimate. No I/O when ``path`` is None."""
+        if path is None:
+            return 0.0
+        try:
+            size = path.stat().st_size
+        except OSError:
+            return 0.0
+        return self._cost_for_bytes(size)
+
+    # --- internals -------------------------------------------------------
+
+    @staticmethod
+    def _cost_for_text(text: str) -> float:
+        tokens = max(1, len(text) // _CHARS_PER_TOKEN)
+        return (tokens / 1000.0) * _COST_PER_1K_TOKENS_USD
+
+    @staticmethod
+    def _cost_for_bytes(n_bytes: int) -> float:
+        # File embeddings are billed per token in practice; we proxy bytes
+        # to tokens at the same chars-per-token ratio so a 100kB image
+        # comes out to ~$0.000625. Exactness doesn't matter here.
+        tokens = max(1, n_bytes // _CHARS_PER_TOKEN)
+        return (tokens / 1000.0) * _COST_PER_1K_TOKENS_USD
+
+    @staticmethod
+    def _unwrap_vector(response) -> list[float]:
+        """Pull the embedding values out of an embed_content response.
+
+        google-genai's response shape varies by SDK version: older builds
+        return ``response.embedding.values``, newer ones expose
+        ``response.embeddings[0].values``. Accept both so the adapter
+        survives an SDK bump.
+        """
+        if hasattr(response, "embedding") and getattr(response.embedding, "values", None):
+            return list(response.embedding.values)
+        if hasattr(response, "embeddings"):
+            embeds = response.embeddings
+            if embeds and getattr(embeds[0], "values", None):
+                return list(embeds[0].values)
+        # Last-resort: response itself might be subscriptable in test mocks.
+        try:
+            return list(response["embedding"]["values"])  # type: ignore[index]
+        except (KeyError, TypeError):
+            pass
+        raise RuntimeError("could not locate embedding values on Gemini response")
+
+    def _matryoshka(self, vector: list[float], cost: float) -> EmbeddingResult:
+        """Truncate to ``self.dim`` if the model returned more.
+
+        Gemini Embedding 2 is trained with Matryoshka representation
+        learning, so the first N dims are a valid lower-dim embedding.
+        No re-normalization step required for the listener-side index —
+        kb-go's cosine search handles unnormalized vectors. (When kb-go
+        gets stricter we'll add an L2 step here.)
+        """
+        truncated = vector[: self.dim] if len(vector) > self.dim else vector
+        return EmbeddingResult(
+            vector=truncated,
+            dim=len(truncated),
+            model=self._model,
+            estimated_cost_usd=cost,
+        )
+
+
+def _guess_image_mime(image_bytes: bytes) -> str:
+    """Tiny magic-byte sniffer for PNG / JPEG. Defaults to PNG.
+
+    Used by the interleaved query path when the chat layer hands us raw
+    bytes without a MIME hint. Most paste-from-clipboard images are PNG;
+    camera uploads are usually JPEG.
+    """
+    if image_bytes.startswith(b"\x89PNG"):
+        return "image/png"
+    if image_bytes.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if image_bytes.startswith(b"GIF8"):
+        return "image/gif"
+    if image_bytes[:4] == b"RIFF" and image_bytes[8:12] == b"WEBP":
+        return "image/webp"
+    return "image/png"
+
+
+__all__ = ["VertexGeminiEmbedding2"]
+
+
+# A tiny helper so other modules can base64-encode bytes if needed.
+# (Kept here rather than util.py — only the chat path uses it.)
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")

--- a/ee/cloud/embeddings/vertex_mm001.py
+++ b/ee/cloud/embeddings/vertex_mm001.py
@@ -1,0 +1,164 @@
+# vertex_mm001.py — multimodalembedding@001 adapter (GA, 1408-dim, text+image).
+# Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
+# Uses google-cloud-aiplatform's vertexai.vision_models surface (lazy
+# imported; the package is not in pyproject.toml yet — captain decides
+# whether to add it). Adapter raises a clear ImportError at construction
+# time so build_embedder can return None and surface a single info log.
+"""VertexMultimodal001 — google-cloud-aiplatform adapter.
+
+The model (``multimodalembedding@001``, GA) embeds text and images into a
+shared 1408-dim space. Native dim choices are 128 / 256 / 512 / 1408 —
+the SDK accepts the 4 explicit values, and we pin to the closest one at
+or below ``settings.embedding_dim``. PDFs / audio / video are not
+supported by this model, so the adapter advertises only ``{"text", "image"}``.
+
+Cost is billed per image at $0.0001 each; text is ~$0.00002 per 1k chars.
+The estimator returns a flat per-image cost when given a path that looks
+like an image; it returns the text estimate otherwise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from ee.cloud.embeddings.adapter import EmbeddingResult
+
+logger = logging.getLogger(__name__)
+
+# Native dim choices for multimodalembedding@001. The SDK accepts these
+# four values explicitly; anything else is silently rejected.
+_VALID_DIMS = (128, 256, 512, 1408)
+_DEFAULT_DIM = 1408
+
+# Per-call cost constants. Vertex publishes per-image and per-text-token
+# pricing for multimodalembedding@001; we proxy text by 1k characters.
+_COST_PER_IMAGE_USD = 0.0001
+_COST_PER_1K_CHARS_USD = 0.00002
+
+# MIME prefixes the model will accept on the image side. PDF / audio /
+# video are not in this model's repertoire — the listener consults
+# ``supports_modalities`` to decide.
+_IMAGE_MIME_PREFIX = "image/"
+
+
+def _snap_to_valid_dim(requested: int) -> int:
+    """Pick the closest valid native dim at or below ``requested``."""
+    eligible = [d for d in _VALID_DIMS if d <= requested]
+    if eligible:
+        return max(eligible)
+    return min(_VALID_DIMS)  # below 128 → snap up to 128
+
+
+class VertexMultimodal001:
+    """Vertex multimodalembedding@001 (GA). Text + image."""
+
+    name = "vertex-mm-001"
+    supports_modalities = {"text", "image"}
+    requires_network = True
+
+    def __init__(
+        self,
+        project_id: str,
+        location: str = "us-central1",
+        dim: int = 1408,
+        model: str = "multimodalembedding@001",
+    ) -> None:
+        # Lazy-import so build_embedder can catch the ImportError and skip
+        # the adapter cleanly when google-cloud-aiplatform isn't installed.
+        try:
+            import vertexai
+            from vertexai.vision_models import MultiModalEmbeddingModel
+        except ImportError as exc:
+            raise ImportError(
+                "vertex-mm-001 requires google-cloud-aiplatform. "
+                "Install it with: pip install 'google-cloud-aiplatform>=1.50'"
+            ) from exc
+
+        self._vertexai = vertexai
+        self._MultiModalEmbeddingModel = MultiModalEmbeddingModel  # noqa: N806
+
+        self.dim = _snap_to_valid_dim(dim) if dim else _DEFAULT_DIM
+        self._project_id = project_id
+        self._location = location
+        self._model_name = model
+
+        # init() is idempotent and cheap — calling it once per adapter
+        # instance keeps the call shape identical across multiple
+        # embeddings even when the SDK caches its own state.
+        vertexai.init(project=project_id, location=location)
+        self._model = MultiModalEmbeddingModel.from_pretrained(model)
+
+    async def embed_file(self, path: Path, mime: str) -> EmbeddingResult:
+        """Embed an image file. Non-image MIMEs raise — the listener
+        consults ``supports_modalities`` first, so this is defensive."""
+        if not mime.startswith(_IMAGE_MIME_PREFIX):
+            raise ValueError(f"vertex-mm-001 supports text and image only; got mime={mime!r}")
+        from vertexai.vision_models import Image  # type: ignore[import-not-found]
+
+        image = Image.load_from_file(str(path))
+        embedding = await asyncio.to_thread(
+            self._model.get_embeddings,
+            image=image,
+            dimension=self.dim,
+        )
+        vector = list(getattr(embedding, "image_embedding", []) or [])
+        if not vector:
+            raise RuntimeError("vertex-mm-001 returned empty image embedding")
+        return EmbeddingResult(
+            vector=vector,
+            dim=len(vector),
+            model=self._model_name,
+            estimated_cost_usd=_COST_PER_IMAGE_USD,
+        )
+
+    async def embed_query(self, text: str, image_bytes: bytes | None = None) -> EmbeddingResult:
+        """Embed an interleaved (text, image?) query."""
+        from vertexai.vision_models import Image  # type: ignore[import-not-found]
+
+        kwargs: dict = {"dimension": self.dim}
+        cost = 0.0
+        if text:
+            kwargs["contextual_text"] = text
+            cost += self._cost_for_text(text)
+        if image_bytes is not None:
+            kwargs["image"] = Image(image_bytes=image_bytes)
+            cost += _COST_PER_IMAGE_USD
+
+        embedding = await asyncio.to_thread(self._model.get_embeddings, **kwargs)
+        # When both text and image are sent the SDK returns both
+        # embeddings; we prefer the image embedding (visual queries are
+        # the killer feature of this model). Fall back to text when the
+        # caller passed only text.
+        vector = list(
+            getattr(embedding, "image_embedding", None)
+            or getattr(embedding, "text_embedding", None)
+            or []
+        )
+        if not vector:
+            raise RuntimeError("vertex-mm-001 returned an empty embedding")
+        return EmbeddingResult(
+            vector=vector,
+            dim=len(vector),
+            model=self._model_name,
+            estimated_cost_usd=cost,
+        )
+
+    def estimate_cost(self, path: Path | None, mime: str | None) -> float:
+        """Pre-call cost estimate. No I/O on the path."""
+        if path is None:
+            return 0.0
+        if mime and mime.startswith(_IMAGE_MIME_PREFIX):
+            return _COST_PER_IMAGE_USD
+        return 0.0
+
+    # --- internals -------------------------------------------------------
+
+    @staticmethod
+    def _cost_for_text(text: str) -> float:
+        units = max(1, len(text) // 1000)
+        return units * _COST_PER_1K_CHARS_USD
+
+
+__all__ = ["VertexMultimodal001"]

--- a/ee/cloud/uploads/listeners.py
+++ b/ee/cloud/uploads/listeners.py
@@ -7,6 +7,12 @@
 #   the blob into a NamedTemporaryFile via the adapter's async open() and
 #   runs extraction on the temp file, cleaning up afterwards. Local-disk
 #   adapters keep using the direct path with no extra I/O.
+# Updated: 2026-04-30 — Stage 2.D of "Files as Knowledge". Added the
+#   vector path: after text-ingest succeeds, optionally compute an
+#   embedding via the configured EmbeddingAdapter and pipe it to kb-go's
+#   `kb ingest --vec <path>` surface. Cap-tracking via CostTracker keeps
+#   a runaway loop from draining the budget. Vector failures are
+#   contained — text-only KB still wins.
 """Upload bus subscribers.
 
 The upload pipeline emits :class:`FileReady` on every successful upload.
@@ -95,16 +101,209 @@ async def index_uploaded_file(event: Event) -> None:
             )
             return
 
+        scope = f"workspace:{workspace_id}"
         try:
             from ee.cloud.agents.knowledge import KnowledgeService
 
-            await KnowledgeService.ingest_text_to_scope(
-                scope=f"workspace:{workspace_id}",
+            ingest_result = await KnowledgeService.ingest_text_to_scope(
+                scope=scope,
                 text=text,
                 source=filename,
             )
         except Exception:
             logger.exception("KB ingest failed for file_id=%s", file_id)
+            return
+
+        article_id = _extract_article_id(ingest_result)
+        if not article_id:
+            logger.debug(
+                "no article_id returned from kb ingest for file_id=%s; "
+                "skipping vector path",
+                file_id,
+            )
+            return
+
+        await _maybe_attach_vector(
+            path=path,
+            mime=mime,
+            article_id=article_id,
+            scope=scope,
+            file_id=file_id,
+        )
+
+
+def _extract_article_id(ingest_result) -> str | None:
+    """Pull the article id out of a kb-go ingest response.
+
+    kb-go returns ``{"id": "<uuid-or-slug>"}`` on success. We handle the
+    str-fallback case (kb-go falls through to raw stdout when JSON parsing
+    fails — a known shape from agents/knowledge.py:_kb).
+    """
+    if isinstance(ingest_result, dict):
+        article_id = ingest_result.get("id") or ingest_result.get("article_id")
+        return article_id if isinstance(article_id, str) else None
+    return None
+
+
+async def _maybe_attach_vector(
+    *,
+    path: Path,
+    mime: str,
+    article_id: str,
+    scope: str,
+    file_id: str,
+) -> None:
+    """Compute an embedding and attach it to the kb-go article.
+
+    Bails out (logs at DEBUG/INFO) when:
+      - vectors are disabled in settings
+      - no embedder is configured
+      - the file's modality isn't supported by the configured adapter
+      - the monthly cap would be exceeded by this call's pre-call estimate
+      - the embed call or the kb subprocess raises (text-only KB still wins)
+    """
+    from pocketpaw.config import get_settings
+
+    settings = get_settings()
+    if not getattr(settings, "kb_vectors_enabled", False):
+        return
+
+    try:
+        from ee.cloud.embeddings import build_embedder, get_cost_tracker
+    except Exception:
+        # Should never happen — embeddings package imports are lazy.
+        # Defensive so a packaging hiccup never crashes the listener.
+        logger.exception("embeddings package import failed for file_id=%s", file_id)
+        return
+
+    embedder = build_embedder(settings)
+    if embedder is None:
+        return
+
+    modality = _modality_for_mime(mime)
+    if modality not in embedder.supports_modalities:
+        logger.debug(
+            "embedder %s does not support modality %r for mime %r; skipping",
+            embedder.name,
+            modality,
+            mime,
+        )
+        return
+
+    cost_tracker = get_cost_tracker(settings)
+    estimate = embedder.estimate_cost(path, mime)
+    if not cost_tracker.can_spend(estimate):
+        logger.info(
+            "monthly embedding cap (%.4f USD) reached; skipping vector for "
+            "file_id=%s (estimated cost %.6f USD, spent so far %.6f USD)",
+            cost_tracker.cap_usd,
+            file_id,
+            estimate,
+            cost_tracker.spent_this_month,
+        )
+        return
+
+    try:
+        emb = await embedder.embed_file(path, mime)
+    except Exception:
+        logger.exception(
+            "embedding failed for file_id=%s; text-only KB still ingested",
+            file_id,
+        )
+        return
+
+    cost_tracker.record(emb.estimated_cost_usd)
+
+    try:
+        await _write_vector_to_kb(
+            article_id=article_id,
+            scope=scope,
+            vector=emb.vector,
+        )
+    except Exception:
+        logger.exception(
+            "kb-go vector ingest failed for file_id=%s article_id=%s; "
+            "text-only KB still ingested",
+            file_id,
+            article_id,
+        )
+
+
+def _modality_for_mime(mime: str) -> str:
+    """Map a MIME string to a modality name the adapter Protocol uses."""
+    if mime.startswith("image/"):
+        return "image"
+    if mime == "application/pdf":
+        return "pdf"
+    if mime.startswith("audio/"):
+        return "audio"
+    if mime.startswith("video/"):
+        return "video"
+    return "text"
+
+
+async def _write_vector_to_kb(
+    *,
+    article_id: str,
+    scope: str,
+    vector: list[float],
+) -> None:
+    """Pipe the vector to kb-go via ``kb ingest --vec <path>``.
+
+    kb-go's --vec flag takes a file path (not stdin), per
+    kb-go/vector_cli.go:loadVectorFromFile. We write a NamedTemporaryFile
+    in the ``{"vector": [...]}`` form, run the subprocess, and clean up.
+    """
+    import asyncio
+    import json
+    import os
+    import tempfile
+
+    from ee.cloud.agents.knowledge import KB_BIN
+
+    payload = json.dumps({"vector": vector})
+    tmp = tempfile.NamedTemporaryFile(  # noqa: SIM115 — manual lifecycle
+        mode="w",
+        prefix="paw-vec-",
+        suffix=".json",
+        delete=False,
+        encoding="utf-8",
+    )
+    try:
+        tmp.write(payload)
+        tmp.flush()
+        tmp.close()
+        proc = await asyncio.create_subprocess_exec(
+            KB_BIN,
+            "ingest",
+            "--vec",
+            tmp.name,
+            "--id",
+            article_id,
+            "--scope",
+            scope,
+            "--json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            _stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=60.0
+            )
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise RuntimeError("kb ingest --vec timed out after 60s")
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"kb ingest --vec failed (exit {proc.returncode}): "
+                f"{stderr.decode('utf-8', errors='replace')[:200]}"
+            )
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            logger.debug("temp vec cleanup failed for %s", tmp.name)
 
 
 @contextlib.asynccontextmanager

--- a/src/pocketpaw/bootstrap/context_builder.py
+++ b/src/pocketpaw/bootstrap/context_builder.py
@@ -1,6 +1,12 @@
 """
 Builder for assembling the full agent context.
 Created: 2026-02-02
+Updated: 2026-04-30 - Stage 2.D "Files as Knowledge". _get_kb_context now
+accepts ``image_bytes`` for the chat-with-image path. When set and a
+multimodal embedder is configured, it embeds (text + image) once,
+caches the resulting vector to a temp file, and runs each scope's kb
+search in hybrid mode (BM25 + cosine via RRF). When unset (the common
+case) the call shape stays identical to the Phase 1 BM25-only path.
 Updated: 2026-04-30 - Multi-scope KB injection (Stage 1.B "Files as
 Knowledge"). _get_kb_context now reads ``settings.kb_scopes`` (list) and
 queries each scope independently, dividing the token budget by scope count
@@ -93,6 +99,7 @@ class AgentContextBuilder:
         agents_md_dir: str | None = None,
         metadata: dict | None = None,
         budget_chars: int = _DEFAULT_BUDGET_CHARS,
+        image_bytes: bytes | None = None,
     ) -> str:
         """Build the complete system prompt.
 
@@ -106,6 +113,12 @@ class AgentContextBuilder:
             agents_md_dir: Directory to search for AGENTS.md (walks up to repo root).
             metadata: Channel-specific metadata (e.g. discord username, guild_id).
             budget_chars: Maximum character budget for the assembled prompt.
+            image_bytes: Optional inline image attached to the chat message.
+                When set together with user_query and a multimodal embedder
+                is configured, the KB context fetch switches to hybrid mode
+                (BM25 + vector cosine fused via RRF). Phase 2 of "Files as
+                Knowledge". When None the call shape is identical to the
+                Phase 1 BM25-only path.
         """
         blocks: list[tuple[str, _Priority, str]] = []
 
@@ -120,12 +133,12 @@ class AgentContextBuilder:
             context, memory_context, kb_context = await asyncio.gather(
                 self.bootstrap.get_context(),
                 memory_coro,
-                self._get_kb_context(user_query),
+                self._get_kb_context(user_query, image_bytes=image_bytes),
             )
         else:
             context, kb_context = await asyncio.gather(
                 self.bootstrap.get_context(),
-                self._get_kb_context(user_query),
+                self._get_kb_context(user_query, image_bytes=image_bytes),
             )
             memory_context = ""
 
@@ -384,7 +397,11 @@ class AgentContextBuilder:
         return "\n\n".join(result_parts)
 
     @staticmethod
-    async def _get_kb_context(user_query: str | None) -> str:
+    async def _get_kb_context(
+        user_query: str | None,
+        *,
+        image_bytes: bytes | None = None,
+    ) -> str:
         """Fetch relevant articles from the kb-go CLI across configured scopes.
 
         Each scope in ``settings.kb_scopes`` is queried independently with
@@ -393,6 +410,13 @@ class AgentContextBuilder:
         under ``### From <scope>`` headers so the model can attribute hits.
         Per-scope failures are logged at debug and skipped so one missing
         scope cannot break the prompt build.
+
+        When ``image_bytes`` is set and a multimodal embedder is configured,
+        the call shape switches to hybrid mode: a single embedding pass
+        builds the (text + image) query vector and each scope is searched
+        with ``--hybrid --query-vec <vec.json>``. The temp vec file is
+        cleaned up before returning. Embedder failures fall back to the
+        BM25-only path so a transient cloud outage doesn't kill chat.
 
         Returns an empty string when ``user_query`` is empty, when no scopes
         are configured (or only the deprecated ``kb_scope`` is set, see the
@@ -416,18 +440,90 @@ class AgentContextBuilder:
         total_limit = settings.kb_limit or 3
         per_scope_limit = max(1, total_limit // len(scopes))
 
-        sections: list[str] = []
-        for scope in scopes:
-            section = await AgentContextBuilder._fetch_kb_scope(
-                binary=binary,
-                query=user_query,
-                scope=scope,
-                limit=per_scope_limit,
+        # Stage 2.D: if the user attached an image, embed (text + image) once
+        # and run hybrid searches across scopes. The vec file is shared
+        # across per-scope subprocesses to avoid re-serializing on each call.
+        query_vec_path: str | None = None
+        try:
+            query_vec_path = await AgentContextBuilder._maybe_build_query_vec(
+                user_query=user_query,
+                image_bytes=image_bytes,
+                settings=settings,
             )
-            if section:
-                sections.append(f"### From {scope}\n{section}")
+            sections: list[str] = []
+            for scope in scopes:
+                section = await AgentContextBuilder._fetch_kb_scope(
+                    binary=binary,
+                    query=user_query,
+                    scope=scope,
+                    limit=per_scope_limit,
+                    query_vec_path=query_vec_path,
+                )
+                if section:
+                    sections.append(f"### From {scope}\n{section}")
+        finally:
+            if query_vec_path:
+                import os
+
+                try:
+                    os.unlink(query_vec_path)
+                except OSError:
+                    logger.debug("query-vec cleanup failed for %s", query_vec_path)
 
         return "\n\n".join(sections)
+
+    @staticmethod
+    async def _maybe_build_query_vec(
+        *,
+        user_query: str,
+        image_bytes: bytes | None,
+        settings,
+    ) -> str | None:
+        """Embed (text + image) and write the vector to a temp JSON file.
+
+        Returns the path on success, ``None`` when the embedder isn't
+        configured / can't handle images / fails. The caller is
+        responsible for unlinking the file.
+        """
+        if image_bytes is None:
+            return None
+        if not getattr(settings, "kb_vectors_enabled", False):
+            return None
+
+        try:
+            from ee.cloud.embeddings import build_embedder
+        except Exception:
+            logger.debug("embeddings package unavailable; falling back to BM25")
+            return None
+
+        embedder = build_embedder(settings)
+        if embedder is None or "image" not in embedder.supports_modalities:
+            return None
+
+        try:
+            emb = await embedder.embed_query(text=user_query, image_bytes=image_bytes)
+        except Exception:
+            logger.exception(
+                "query embedding failed; falling back to BM25 for this turn"
+            )
+            return None
+
+        import json
+        import tempfile
+
+        tmp = tempfile.NamedTemporaryFile(  # noqa: SIM115 — manual lifecycle
+            mode="w",
+            prefix="paw-query-vec-",
+            suffix=".json",
+            delete=False,
+            encoding="utf-8",
+        )
+        try:
+            tmp.write(json.dumps({"vector": emb.vector}))
+            tmp.flush()
+        finally:
+            tmp.close()
+        return tmp.name
 
     @staticmethod
     async def _fetch_kb_scope(
@@ -436,8 +532,24 @@ class AgentContextBuilder:
         query: str,
         scope: str,
         limit: int,
+        query_vec_path: str | None = None,
     ) -> str:
-        """Run ``kb search ... --scope <scope>`` once. Empty on any failure."""
+        """Run ``kb search ... --scope <scope>`` once. Empty on any failure.
+
+        When ``query_vec_path`` is set the call switches to hybrid mode
+        (``--hybrid --query-vec <path> --topk <limit>``). The plain-text
+        ``--context`` flag is dropped in hybrid mode because kb-go's
+        hybrid output is JSON-shaped, so we re-derive the human-readable
+        section from the JSON title + summary fields.
+        """
+        if query_vec_path:
+            return await AgentContextBuilder._fetch_hybrid_scope(
+                binary=binary,
+                query=query,
+                scope=scope,
+                limit=limit,
+                query_vec_path=query_vec_path,
+            )
         try:
             proc = await asyncio.create_subprocess_exec(
                 binary,
@@ -469,6 +581,80 @@ class AgentContextBuilder:
             return ""
 
         return stdout.decode("utf-8", errors="replace").strip()
+
+    @staticmethod
+    async def _fetch_hybrid_scope(
+        *,
+        binary: str,
+        query: str,
+        scope: str,
+        limit: int,
+        query_vec_path: str,
+    ) -> str:
+        """Run ``kb search <query> --hybrid --query-vec <path> --scope <s>``.
+
+        Hybrid kb output is a JSON array of ``{id, title, summary, ...}``
+        rows. We render a compact text section per hit so the system
+        prompt assembler can drop it under ``### From <scope>`` without
+        further processing.
+        """
+        import json
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                binary,
+                "search",
+                query,
+                "--scope",
+                scope,
+                "--hybrid",
+                "--query-vec",
+                query_vec_path,
+                "--topk",
+                str(limit),
+                "--json",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5.0)
+            except TimeoutError:
+                proc.kill()
+                await proc.wait()
+                logger.debug(
+                    "kb hybrid fetch for scope %s timed out after 5s", scope
+                )
+                return ""
+        except FileNotFoundError:
+            logger.debug("kb binary not found at %s — skipping kb injection", binary)
+            return ""
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "kb hybrid fetch for scope %s failed (non-fatal): %s", scope, exc
+            )
+            return ""
+
+        if proc.returncode != 0:
+            return ""
+
+        try:
+            rows = json.loads(stdout.decode("utf-8", errors="replace"))
+        except json.JSONDecodeError:
+            return ""
+        if not isinstance(rows, list):
+            return ""
+
+        parts: list[str] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            title = row.get("title") or row.get("id") or ""
+            summary = (row.get("summary") or "").strip()
+            if title and summary:
+                parts.append(f"- {title}\n  {summary}")
+            elif title:
+                parts.append(f"- {title}")
+        return "\n".join(parts)
 
     @staticmethod
     def _load_channel_instructions(channel: Channel) -> str:

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,9 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-04-30: Added pluggable embedding adapter settings — ``kb_vectors_enabled``,
+    ``embedding_adapter``, ``embedding_dim``, ``embedding_monthly_cap_usd``,
+    ``vertex_project_id``, ``vertex_location``. Stage 2.D of "Files as Knowledge".
   - 2026-04-30: Added ``kb_scopes`` (list[str]) for multi-scope KB queries.
     ``kb_scope`` (single string) is now a deprecation shim — when set and
     ``kb_scopes`` is empty, it copies forward and emits DeprecationWarning.
@@ -938,6 +941,63 @@ class Settings(BaseSettings):
             "Google Gemini API key for the gemini-flash extraction adapter. "
             "Read from POCKETPAW_GEMINI_API_KEY. When unset, the gemini-flash "
             "adapter is silently skipped during chain construction."
+        ),
+    )
+
+    # Embedding adapter (Phase 2, "Files as Knowledge" Stage 2.D)
+    kb_vectors_enabled: bool = Field(
+        default=False,
+        description=(
+            "Master switch for the vector-embedding pipeline. When False the "
+            "FileReady listener stops after text-ingest and the chat path "
+            "skips interleaved-image queries. Set via POCKETPAW_KB_VECTORS_ENABLED."
+        ),
+    )
+    embedding_adapter: str = Field(
+        default="",
+        description=(
+            "Embedding adapter name. Empty disables embeddings even when "
+            "kb_vectors_enabled is True. Supported: "
+            "'vertex-gemini-embedding-2' (preview, 3072-dim, multimodal), "
+            "'vertex-mm-001' (GA, 1408-dim, text+image). Set via "
+            "POCKETPAW_EMBEDDING_ADAPTER."
+        ),
+    )
+    embedding_dim: int = Field(
+        default=1024,
+        gt=0,
+        description=(
+            "Target output dim. vertex-gemini-embedding-2 uses Matryoshka "
+            "truncation; vertex-mm-001 snaps to the closest valid native "
+            "dim (128/256/512/1408). All vectors in a single kb-go scope "
+            "must agree on this value. Set via POCKETPAW_EMBEDDING_DIM."
+        ),
+    )
+    embedding_monthly_cap_usd: float = Field(
+        default=10.0,
+        ge=0,
+        description=(
+            "Soft monthly USD cap for embedding spend. When the running "
+            "total would exceed this, the listener falls back to "
+            "extraction-only (text still ingests, vector skipped). 0 "
+            "disables the cap. Persisted at ~/.pocketpaw/embedding_cost.json. "
+            "NOT a billing source — real billing comes from the provider's "
+            "dashboard. Set via POCKETPAW_EMBEDDING_MONTHLY_CAP_USD."
+        ),
+    )
+    vertex_project_id: str | None = Field(
+        default=None,
+        description=(
+            "GCP project id for vertex-mm-001 (the multimodalembedding@001 "
+            "adapter). When unset, the adapter is silently skipped during "
+            "factory construction. Set via POCKETPAW_VERTEX_PROJECT_ID."
+        ),
+    )
+    vertex_location: str | None = Field(
+        default=None,
+        description=(
+            "GCP region for vertex-mm-001 (default: us-central1 when "
+            "unset). Set via POCKETPAW_VERTEX_LOCATION."
         ),
     )
 

--- a/tests/bootstrap/test_kb_multi_scope.py
+++ b/tests/bootstrap/test_kb_multi_scope.py
@@ -31,7 +31,7 @@ def _stub_settings(monkeypatch, **overrides: Any) -> None:
 async def test_multiple_scopes_each_queried_with_header(monkeypatch):
     calls: list[dict[str, Any]] = []
 
-    async def fake_fetch(*, binary, query, scope, limit):
+    async def fake_fetch(*, binary, query, scope, limit, query_vec_path=None):
         calls.append({"binary": binary, "query": query, "scope": scope, "limit": limit})
         return f"result-for-{scope}"
 
@@ -59,7 +59,7 @@ async def test_per_scope_limit_floor_is_one(monkeypatch):
     """When ``kb_limit < len(scopes)`` per-scope budget floors at 1."""
     captured: list[int] = []
 
-    async def fake_fetch(*, binary, query, scope, limit):  # noqa: ARG001
+    async def fake_fetch(*, binary, query, scope, limit, query_vec_path=None):  # noqa: ARG001
         captured.append(limit)
         return ""
 
@@ -77,7 +77,7 @@ async def test_per_scope_limit_floor_is_one(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_one_scope_errors_other_returns(monkeypatch):
-    async def fake_fetch(*, binary, query, scope, limit):  # noqa: ARG001
+    async def fake_fetch(*, binary, query, scope, limit, query_vec_path=None):  # noqa: ARG001
         if scope == "workspace:w1":
             return "good content"
         return ""  # the other scope returned empty
@@ -118,7 +118,7 @@ async def test_blank_scope_strings_filtered(monkeypatch):
     """Whitespace-only scope entries are dropped before the per-scope split."""
     captured: list[str] = []
 
-    async def fake_fetch(*, binary, query, scope, limit):  # noqa: ARG001
+    async def fake_fetch(*, binary, query, scope, limit, query_vec_path=None):  # noqa: ARG001
         captured.append(scope)
         return f"hit-{scope}"
 

--- a/tests/bootstrap/test_kb_query_with_image.py
+++ b/tests/bootstrap/test_kb_query_with_image.py
@@ -1,0 +1,279 @@
+# test_kb_query_with_image.py — interleaved-image query path tests.
+# Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
+# Verifies that when image_bytes is set on _get_kb_context, the embedder
+# is consulted, kb is invoked with --hybrid --query-vec, and a transient
+# embed failure falls back to BM25 mode without crashing the prompt build.
+"""Tests for the interleaved-image query path in AgentContextBuilder."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from pocketpaw.bootstrap.context_builder import AgentContextBuilder
+from pocketpaw.config import Settings
+
+
+def _stub_settings(monkeypatch, **overrides: Any) -> None:
+    base = Settings(_env_file=None)  # type: ignore[call-arg]
+    for k, v in overrides.items():
+        setattr(base, k, v)
+    monkeypatch.setattr(
+        "pocketpaw.config.get_settings",
+        lambda force_reload=False: base,
+    )
+
+
+class _FakeEmbedder:
+    name = "vertex-mm-001"
+    dim = 8
+    supports_modalities = {"text", "image"}
+    requires_network = True
+
+    def __init__(self, *, vector=None, fail=False):
+        self._vector = vector or [0.7] * 8
+        self._fail = fail
+        self.queries: list[tuple[str, bytes | None]] = []
+
+    async def embed_query(self, text, image_bytes=None):
+        self.queries.append((text, image_bytes))
+        if self._fail:
+            raise RuntimeError("upstream blew up")
+        from ee.cloud.embeddings import EmbeddingResult
+
+        return EmbeddingResult(
+            vector=list(self._vector),
+            dim=len(self._vector),
+            model=self.name,
+            estimated_cost_usd=0.0001,
+        )
+
+    async def embed_file(self, path, mime):  # pragma: no cover
+        raise NotImplementedError
+
+    def estimate_cost(self, path, mime):
+        return 0.0001
+
+
+class _TextOnlyEmbedder(_FakeEmbedder):
+    supports_modalities = {"text"}
+
+
+@pytest.mark.asyncio
+async def test_image_query_uses_hybrid_with_query_vec(monkeypatch):
+    """image_bytes provided → embed_query called → kb invoked --hybrid --query-vec."""
+    embedder = _FakeEmbedder()
+    monkeypatch.setattr(
+        "ee.cloud.embeddings.build_embedder", lambda s: embedder
+    )
+    _stub_settings(
+        monkeypatch,
+        kb_vectors_enabled=True,
+        embedding_adapter="vertex-mm-001",
+        kb_scopes=["workspace:w1"],
+        kb_limit=2,
+        kb_binary="kb",
+    )
+
+    captured: dict = {}
+
+    async def fake_subprocess_exec(*args, **kwargs):
+        captured["argv"] = list(args)
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                # JSON shape kb-go returns for hybrid mode.
+                rows = [
+                    {"id": "a1", "title": "Slide 3", "summary": "matrix diagram"},
+                    {"id": "a2", "title": "Notes", "summary": "follow-up tasks"},
+                ]
+                return json.dumps(rows).encode("utf-8"), b""
+
+        return _Proc()
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_subprocess_exec)
+
+    out = await AgentContextBuilder._get_kb_context(
+        "find the slide", image_bytes=b"\x89PNG\r\n\x1a\n"
+    )
+
+    # Embedder was called once with (text, image_bytes).
+    assert embedder.queries == [("find the slide", b"\x89PNG\r\n\x1a\n")]
+
+    # kb subprocess was hybrid-mode.
+    argv = captured["argv"]
+    assert argv[0] == "kb"
+    assert argv[1] == "search"
+    assert "--hybrid" in argv
+    assert "--query-vec" in argv
+    qv_idx = argv.index("--query-vec") + 1
+    assert argv[qv_idx].endswith(".json")  # temp file path
+    assert "--scope" in argv
+    assert argv[argv.index("--scope") + 1] == "workspace:w1"
+    assert "--topk" in argv
+
+    # The rendered section pulled title + summary from JSON rows.
+    assert "Slide 3" in out
+    assert "matrix diagram" in out
+    assert "### From workspace:w1" in out
+
+
+@pytest.mark.asyncio
+async def test_image_query_falls_back_to_bm25_when_embed_fails(monkeypatch):
+    failing = _FakeEmbedder(fail=True)
+    monkeypatch.setattr(
+        "ee.cloud.embeddings.build_embedder", lambda s: failing
+    )
+    _stub_settings(
+        monkeypatch,
+        kb_vectors_enabled=True,
+        embedding_adapter="vertex-mm-001",
+        kb_scopes=["workspace:w1"],
+        kb_limit=1,
+        kb_binary="kb",
+    )
+
+    captured_argvs: list[list[str]] = []
+
+    async def fake_subprocess_exec(*args, **kwargs):
+        captured_argvs.append(list(args))
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"plain BM25 hit", b""
+
+        return _Proc()
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_subprocess_exec)
+
+    out = await AgentContextBuilder._get_kb_context(
+        "find slide", image_bytes=b"\x89PNG"
+    )
+
+    assert "plain BM25 hit" in out
+    # Plain BM25 path: no --hybrid / --query-vec.
+    assert len(captured_argvs) == 1
+    argv = captured_argvs[0]
+    assert "--hybrid" not in argv
+    assert "--query-vec" not in argv
+    assert "--context" in argv
+
+
+@pytest.mark.asyncio
+async def test_image_query_falls_back_when_embedder_lacks_image_modality(monkeypatch):
+    text_only = _TextOnlyEmbedder()
+    monkeypatch.setattr(
+        "ee.cloud.embeddings.build_embedder", lambda s: text_only
+    )
+    _stub_settings(
+        monkeypatch,
+        kb_vectors_enabled=True,
+        embedding_adapter="text-only",
+        kb_scopes=["workspace:w1"],
+        kb_limit=1,
+        kb_binary="kb",
+    )
+
+    captured: list[list[str]] = []
+
+    async def fake_subprocess_exec(*args, **kwargs):
+        captured.append(list(args))
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"BM25 only", b""
+
+        return _Proc()
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_subprocess_exec)
+
+    await AgentContextBuilder._get_kb_context(
+        "any query", image_bytes=b"\x89PNG"
+    )
+
+    # Embedder lacks "image" modality → BM25 path.
+    assert text_only.queries == []
+    assert "--hybrid" not in captured[0]
+
+
+@pytest.mark.asyncio
+async def test_image_query_skips_when_vectors_disabled(monkeypatch):
+    embedder = _FakeEmbedder()
+    monkeypatch.setattr(
+        "ee.cloud.embeddings.build_embedder", lambda s: embedder
+    )
+    _stub_settings(
+        monkeypatch,
+        kb_vectors_enabled=False,
+        embedding_adapter="vertex-mm-001",
+        kb_scopes=["workspace:w1"],
+        kb_limit=1,
+        kb_binary="kb",
+    )
+
+    async def fake_subprocess_exec(*args, **kwargs):
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"BM25", b""
+
+        return _Proc()
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_subprocess_exec)
+
+    await AgentContextBuilder._get_kb_context(
+        "query", image_bytes=b"\x89PNG"
+    )
+
+    assert embedder.queries == []  # never called
+
+
+@pytest.mark.asyncio
+async def test_no_image_keeps_bm25_call_shape(monkeypatch):
+    """Regression: without image_bytes the call is the Phase 1 BM25 shape."""
+    embedder_called = False
+
+    def _build(_s):
+        nonlocal embedder_called
+        embedder_called = True
+        return _FakeEmbedder()
+
+    monkeypatch.setattr("ee.cloud.embeddings.build_embedder", _build)
+    _stub_settings(
+        monkeypatch,
+        kb_vectors_enabled=True,
+        embedding_adapter="vertex-mm-001",
+        kb_scopes=["workspace:w1"],
+        kb_limit=1,
+        kb_binary="kb",
+    )
+
+    captured: list[list[str]] = []
+
+    async def fake_subprocess_exec(*args, **kwargs):
+        captured.append(list(args))
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"plain hit", b""
+
+        return _Proc()
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_subprocess_exec)
+
+    out = await AgentContextBuilder._get_kb_context("just text query")
+
+    assert "plain hit" in out
+    assert not embedder_called  # build_embedder not consulted at all
+    assert "--hybrid" not in captured[0]

--- a/tests/cloud/embeddings/__init__.py
+++ b/tests/cloud/embeddings/__init__.py
@@ -1,0 +1,3 @@
+# tests/cloud/embeddings/__init__.py
+# Created: 2026-04-30 — Stage 2.D of "Files as Knowledge".
+# Marker package for pytest discovery of embedding-adapter tests.

--- a/tests/cloud/embeddings/test_adapter_protocol.py
+++ b/tests/cloud/embeddings/test_adapter_protocol.py
@@ -1,0 +1,78 @@
+# test_adapter_protocol.py — Protocol conformance for both shipped adapters.
+# Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
+# Verifies VertexGeminiEmbedding2 and VertexMultimodal001 satisfy the
+# EmbeddingAdapter Protocol at runtime — `isinstance(_, EmbeddingAdapter)`
+# uses the @runtime_checkable shape so the duck-typing stays honest as new
+# adapters land.
+"""Protocol conformance tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ee.cloud.embeddings import EmbeddingAdapter, EmbeddingResult
+
+
+def test_embedding_result_basic_shape() -> None:
+    """EmbeddingResult is a Pydantic model with the required fields."""
+    r = EmbeddingResult(vector=[0.1, 0.2, 0.3], dim=3, model="test", estimated_cost_usd=0.001)
+    assert r.vector == [0.1, 0.2, 0.3]
+    assert r.dim == 3
+    assert r.model == "test"
+    assert r.estimated_cost_usd == pytest.approx(0.001)
+
+
+def test_embedding_result_cost_defaults_to_zero() -> None:
+    r = EmbeddingResult(vector=[0.0], dim=1, model="x")
+    assert r.estimated_cost_usd == 0.0
+
+
+def test_vertex_gemini2_satisfies_protocol(monkeypatch) -> None:
+    """VertexGeminiEmbedding2 instance must satisfy EmbeddingAdapter."""
+    from google import genai
+
+    fake_client = MagicMock()
+    monkeypatch.setattr(genai, "Client", lambda api_key: fake_client)
+
+    from ee.cloud.embeddings.vertex_gemini2 import VertexGeminiEmbedding2
+
+    adapter = VertexGeminiEmbedding2(api_key="fake", dim=512)
+    assert isinstance(adapter, EmbeddingAdapter)
+    assert adapter.name == "vertex-gemini-embedding-2"
+    assert adapter.dim == 512
+    assert "image" in adapter.supports_modalities
+    assert "text" in adapter.supports_modalities
+    assert adapter.requires_network is True
+
+
+def test_vertex_mm001_satisfies_protocol(monkeypatch) -> None:
+    """VertexMultimodal001 instance satisfies EmbeddingAdapter when SDK is mocked."""
+    # Stub vertexai + vertexai.vision_models so the lazy import succeeds.
+    import sys
+    import types as _types
+
+    fake_image_cls = MagicMock()
+    fake_model = MagicMock()
+    fake_model.from_pretrained = MagicMock(return_value=fake_model)
+
+    fake_vision = _types.ModuleType("vertexai.vision_models")
+    fake_vision.MultiModalEmbeddingModel = fake_model  # type: ignore[attr-defined]
+    fake_vision.Image = fake_image_cls  # type: ignore[attr-defined]
+    fake_vertexai = _types.ModuleType("vertexai")
+    fake_vertexai.init = MagicMock()  # type: ignore[attr-defined]
+    fake_vertexai.vision_models = fake_vision  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "vertexai", fake_vertexai)
+    monkeypatch.setitem(sys.modules, "vertexai.vision_models", fake_vision)
+
+    from ee.cloud.embeddings.vertex_mm001 import VertexMultimodal001
+
+    adapter = VertexMultimodal001(project_id="test-proj", location="us-central1", dim=512)
+    assert isinstance(adapter, EmbeddingAdapter)
+    assert adapter.name == "vertex-mm-001"
+    # 512 is in the valid set so it's chosen as-is.
+    assert adapter.dim == 512
+    assert adapter.supports_modalities == {"text", "image"}
+    assert adapter.requires_network is True

--- a/tests/cloud/embeddings/test_cost_tracker.py
+++ b/tests/cloud/embeddings/test_cost_tracker.py
@@ -1,0 +1,125 @@
+# test_cost_tracker.py — CostTracker unit tests.
+# Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
+# Round-trips the JSON ledger, exercises month rollover, asserts can_spend
+# semantics at the cap edge, and verifies the singleton cache rebuilds when
+# the configured cap changes.
+"""Tests for ``ee.cloud.embeddings.cost_tracker``."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ee.cloud.embeddings.cost_tracker import (
+    CostTracker,
+    get_cost_tracker,
+    reset_cost_tracker_for_tests,
+)
+
+
+def _ledger(tmp_path: Path) -> Path:
+    return tmp_path / "embedding_cost.json"
+
+
+def test_record_and_can_spend_under_cap(tmp_path: Path) -> None:
+    t = CostTracker(monthly_cap_usd=1.0, path=_ledger(tmp_path))
+    assert t.spent_this_month == 0.0
+    assert t.can_spend(0.5)
+    t.record(0.5)
+    assert t.spent_this_month == 0.5
+    # 0.5 spent + 0.5 estimate = exactly the cap; allowed (<= cap).
+    assert t.can_spend(0.5)
+    # 0.5 spent + 0.51 estimate = above cap; rejected.
+    assert not t.can_spend(0.51)
+
+
+def test_zero_cap_disables_check(tmp_path: Path) -> None:
+    """A cap of 0 means "no cap" — the listener never blocks."""
+    t = CostTracker(monthly_cap_usd=0, path=_ledger(tmp_path))
+    assert t.can_spend(99999)
+
+
+def test_negative_estimate_treated_as_zero(tmp_path: Path) -> None:
+    t = CostTracker(monthly_cap_usd=1.0, path=_ledger(tmp_path))
+    t.record(0.99)
+    assert t.can_spend(-0.5)
+    # And record() ignores non-positive cost.
+    t.record(-1.0)
+    assert t.spent_this_month == 0.99
+
+
+def test_persistence_round_trip(tmp_path: Path) -> None:
+    path = _ledger(tmp_path)
+    t1 = CostTracker(monthly_cap_usd=2.0, path=path)
+    t1.record(0.42)
+
+    # Fresh tracker reading the same path keeps the running total.
+    t2 = CostTracker(monthly_cap_usd=2.0, path=path)
+    assert t2.spent_this_month == 0.42
+
+
+def test_reset_when_persisted_month_doesnt_match(tmp_path: Path) -> None:
+    path = _ledger(tmp_path)
+    # Pretend a stale ledger from last year is on disk.
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"month": "2000-01", "spent_usd": 99.0}))
+
+    t = CostTracker(monthly_cap_usd=1.0, path=path)
+    assert t.spent_this_month == 0.0
+
+
+def test_corrupt_ledger_resets_and_does_not_crash(tmp_path: Path) -> None:
+    path = _ledger(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not valid json")
+
+    t = CostTracker(monthly_cap_usd=1.0, path=path)
+    assert t.spent_this_month == 0.0
+    t.record(0.1)
+    # Recovers and persists the new state.
+    raw = json.loads(path.read_text())
+    assert raw["spent_usd"] == 0.1
+
+
+def test_get_cost_tracker_singleton(monkeypatch, tmp_path: Path) -> None:
+    """Repeated get_cost_tracker calls with the same cap return the same instance."""
+    reset_cost_tracker_for_tests()
+    # Redirect the default ledger to a temp file so production state isn't touched.
+    monkeypatch.setattr(
+        "ee.cloud.embeddings.cost_tracker._DEFAULT_PATH",
+        _ledger(tmp_path),
+    )
+
+    class _S:
+        embedding_monthly_cap_usd = 5.0
+
+    a = get_cost_tracker(_S())
+    b = get_cost_tracker(_S())
+    assert a is b
+
+
+def test_get_cost_tracker_rebuilds_when_cap_changes(monkeypatch, tmp_path: Path) -> None:
+    reset_cost_tracker_for_tests()
+    monkeypatch.setattr(
+        "ee.cloud.embeddings.cost_tracker._DEFAULT_PATH",
+        _ledger(tmp_path),
+    )
+
+    class _S:
+        embedding_monthly_cap_usd = 5.0
+
+    class _S2:
+        embedding_monthly_cap_usd = 10.0
+
+    a = get_cost_tracker(_S())
+    b = get_cost_tracker(_S2())
+    assert a is not b
+    assert b.cap_usd == 10.0
+
+
+def test_month_key_format() -> None:
+    """Sanity check on the month key — UTC YYYY-MM."""
+    expected = datetime.now(UTC).strftime("%Y-%m")
+    t = CostTracker(monthly_cap_usd=1.0)
+    assert t._current_month_key() == expected

--- a/tests/cloud/embeddings/test_factory.py
+++ b/tests/cloud/embeddings/test_factory.py
@@ -1,0 +1,152 @@
+# test_factory.py — build_embedder(settings) factory tests.
+# Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
+# Pins the disabled / missing-creds / unknown-name behaviour. Verifies
+# that the lazy import for vertex-mm-001 returns None (with an info log)
+# instead of raising when google-cloud-aiplatform isn't installed.
+"""Tests for ``ee.cloud.embeddings.factory.build_embedder``."""
+
+from __future__ import annotations
+
+import sys
+import types as _types
+from unittest.mock import MagicMock
+
+import pytest
+
+from ee.cloud.embeddings import build_embedder
+
+
+class _Stub:
+    """Plain object stand-in for Settings — only the fields we read."""
+
+    def __init__(self, **kwargs):
+        defaults = dict(
+            kb_vectors_enabled=True,
+            embedding_adapter="",
+            embedding_dim=1024,
+            gemini_api_key=None,
+            vertex_project_id=None,
+            vertex_location=None,
+        )
+        defaults.update(kwargs)
+        for k, v in defaults.items():
+            setattr(self, k, v)
+
+
+def test_returns_none_when_vectors_disabled() -> None:
+    s = _Stub(kb_vectors_enabled=False, embedding_adapter="vertex-gemini-embedding-2")
+    assert build_embedder(s) is None
+
+
+def test_returns_none_when_adapter_empty() -> None:
+    s = _Stub(kb_vectors_enabled=True, embedding_adapter="")
+    assert build_embedder(s) is None
+
+
+def test_returns_none_when_gemini_creds_missing() -> None:
+    s = _Stub(
+        kb_vectors_enabled=True,
+        embedding_adapter="vertex-gemini-embedding-2",
+        gemini_api_key=None,
+    )
+    assert build_embedder(s) is None
+
+
+def test_returns_none_when_vertex_project_id_missing() -> None:
+    s = _Stub(
+        kb_vectors_enabled=True,
+        embedding_adapter="vertex-mm-001",
+        vertex_project_id=None,
+    )
+    assert build_embedder(s) is None
+
+
+def test_returns_none_when_vertex_sdk_missing(monkeypatch) -> None:
+    """Lazy import: ImportError → factory returns None instead of raising."""
+    monkeypatch.setitem(sys.modules, "vertexai", None)
+    monkeypatch.setitem(sys.modules, "vertexai.vision_models", None)
+
+    s = _Stub(
+        kb_vectors_enabled=True,
+        embedding_adapter="vertex-mm-001",
+        vertex_project_id="proj-1",
+        vertex_location="us-central1",
+    )
+    assert build_embedder(s) is None
+
+
+def test_unknown_adapter_name_raises() -> None:
+    s = _Stub(kb_vectors_enabled=True, embedding_adapter="open-models-rocks")
+    with pytest.raises(ValueError, match="unknown embedding adapter"):
+        build_embedder(s)
+
+
+def test_builds_gemini_embedder_when_key_set(monkeypatch) -> None:
+    from google import genai
+
+    monkeypatch.setattr(genai, "Client", lambda api_key: MagicMock())
+    s = _Stub(
+        kb_vectors_enabled=True,
+        embedding_adapter="vertex-gemini-embedding-2",
+        gemini_api_key="fake",
+        embedding_dim=512,
+    )
+    adapter = build_embedder(s)
+    assert adapter is not None
+    assert adapter.name == "vertex-gemini-embedding-2"
+    assert adapter.dim == 512
+
+
+def test_builds_vertex_mm_embedder_when_creds_set(monkeypatch) -> None:
+    """Stub the vertex SDK so the lazy import succeeds."""
+    fake_image_cls = MagicMock()
+    fake_model = MagicMock()
+    fake_model.from_pretrained = MagicMock(return_value=fake_model)
+
+    fake_vision = _types.ModuleType("vertexai.vision_models")
+    fake_vision.MultiModalEmbeddingModel = fake_model  # type: ignore[attr-defined]
+    fake_vision.Image = fake_image_cls  # type: ignore[attr-defined]
+    fake_vertexai = _types.ModuleType("vertexai")
+    fake_vertexai.init = MagicMock()  # type: ignore[attr-defined]
+    fake_vertexai.vision_models = fake_vision  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "vertexai", fake_vertexai)
+    monkeypatch.setitem(sys.modules, "vertexai.vision_models", fake_vision)
+
+    s = _Stub(
+        kb_vectors_enabled=True,
+        embedding_adapter="vertex-mm-001",
+        vertex_project_id="proj-1",
+        vertex_location="us-central1",
+        embedding_dim=512,
+    )
+    adapter = build_embedder(s)
+    assert adapter is not None
+    assert adapter.name == "vertex-mm-001"
+    assert adapter.dim == 512
+
+
+def test_vertex_default_location_falls_back_to_us_central1(monkeypatch) -> None:
+    fake_image_cls = MagicMock()
+    fake_model = MagicMock()
+    fake_model.from_pretrained = MagicMock(return_value=fake_model)
+    fake_vision = _types.ModuleType("vertexai.vision_models")
+    fake_vision.MultiModalEmbeddingModel = fake_model  # type: ignore[attr-defined]
+    fake_vision.Image = fake_image_cls  # type: ignore[attr-defined]
+    fake_vertexai = _types.ModuleType("vertexai")
+    init_mock = MagicMock()
+    fake_vertexai.init = init_mock  # type: ignore[attr-defined]
+    fake_vertexai.vision_models = fake_vision  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "vertexai", fake_vertexai)
+    monkeypatch.setitem(sys.modules, "vertexai.vision_models", fake_vision)
+
+    s = _Stub(
+        kb_vectors_enabled=True,
+        embedding_adapter="vertex-mm-001",
+        vertex_project_id="proj-1",
+        vertex_location=None,  # no location set
+        embedding_dim=1408,
+    )
+    adapter = build_embedder(s)
+    assert adapter is not None
+    init_mock.assert_called_once_with(project="proj-1", location="us-central1")

--- a/tests/cloud/embeddings/test_vertex_gemini2.py
+++ b/tests/cloud/embeddings/test_vertex_gemini2.py
@@ -1,0 +1,198 @@
+# test_vertex_gemini2.py — VertexGeminiEmbedding2 unit tests.
+# Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
+# Mocks google.genai.Client to avoid network calls. Pins request shape
+# (model name, contents structure with Part for the image), Matryoshka
+# truncation behaviour, the empty-response failure path, and the
+# multiple-response-shape unwrap helper.
+"""Tests for ``ee.cloud.embeddings.vertex_gemini2.VertexGeminiEmbedding2``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_genai(monkeypatch):
+    """Patch google.genai.Client and return a (client, response) tuple."""
+    from google import genai
+
+    response = MagicMock()
+    response.embedding.values = [float(i) / 100.0 for i in range(3072)]
+    client = MagicMock()
+    client.models.embed_content.return_value = response
+    monkeypatch.setattr(genai, "Client", lambda api_key: client)
+    return client, response
+
+
+@pytest.fixture
+def tmp_image(tmp_path: Path) -> Path:
+    p = tmp_path / "diagram.png"
+    p.write_bytes(b"\x89PNG\r\n\x1a\nfake-bytes")
+    return p
+
+
+def test_dim_out_of_range_raises(monkeypatch, mock_genai) -> None:
+    from ee.cloud.embeddings.vertex_gemini2 import VertexGeminiEmbedding2
+
+    with pytest.raises(ValueError, match="out of range"):
+        VertexGeminiEmbedding2(api_key="fake", dim=4096)
+    with pytest.raises(ValueError, match="out of range"):
+        VertexGeminiEmbedding2(api_key="fake", dim=0)
+
+
+@pytest.mark.asyncio
+async def test_embed_file_image_calls_with_part(mock_genai, tmp_image) -> None:
+    """Image file → contents=[Part(image bytes, mime)] sent to embed_content."""
+    from ee.cloud.embeddings.vertex_gemini2 import VertexGeminiEmbedding2
+
+    client, _ = mock_genai
+    adapter = VertexGeminiEmbedding2(api_key="fake", dim=1024)
+    result = await adapter.embed_file(tmp_image, "image/png")
+
+    client.models.embed_content.assert_called_once()
+    kwargs = client.models.embed_content.call_args.kwargs
+    assert kwargs["model"] == "gemini-embedding-001"
+    contents = kwargs["contents"]
+    assert len(contents) == 1
+    part = contents[0]
+    # google.genai types.Part stores bytes on inline_data.
+    assert getattr(part.inline_data, "mime_type", None) == "image/png"
+    assert getattr(part.inline_data, "data", None) == tmp_image.read_bytes()
+
+    assert result.dim == 1024
+    assert len(result.vector) == 1024
+    assert result.model == "gemini-embedding-001"
+    assert result.estimated_cost_usd > 0
+
+
+@pytest.mark.asyncio
+async def test_embed_file_text_skips_part_path(mock_genai, tmp_path) -> None:
+    """text/plain files go through embed_query, not the inline-Part path."""
+    from ee.cloud.embeddings.vertex_gemini2 import VertexGeminiEmbedding2
+
+    client, _ = mock_genai
+    adapter = VertexGeminiEmbedding2(api_key="fake", dim=512)
+    p = tmp_path / "notes.txt"
+    p.write_text("hello world")
+    await adapter.embed_file(p, "text/plain")
+
+    kwargs = client.models.embed_content.call_args.kwargs
+    contents = kwargs["contents"]
+    assert contents == ["hello world"]
+
+
+@pytest.mark.asyncio
+async def test_matryoshka_truncates_when_dim_smaller_than_native(mock_genai, tmp_image) -> None:
+    """When dim < 3072 the result vector is the first dim values."""
+    from ee.cloud.embeddings.vertex_gemini2 import VertexGeminiEmbedding2
+
+    _, response = mock_genai
+    response.embedding.values = list(range(3072))  # 0..3071
+
+    adapter = VertexGeminiEmbedding2(api_key="fake", dim=8)
+    result = await adapter.embed_file(tmp_image, "image/png")
+
+    assert result.vector == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+    assert result.dim == 8
+
+
+@pytest.mark.asyncio
+async def test_embed_query_text_only(mock_genai) -> None:
+    from ee.cloud.embeddings.vertex_gemini2 import VertexGeminiEmbedding2
+
+    client, _ = mock_genai
+    adapter = VertexGeminiEmbedding2(api_key="fake", dim=64)
+    result = await adapter.embed_query(text="diagram of arrows")
+
+    kwargs = client.models.embed_content.call_args.kwargs
+    assert kwargs["contents"] == ["diagram of arrows"]
+    assert result.dim == 64
+
+
+@pytest.mark.asyncio
+async def test_embed_query_with_image_bytes(mock_genai) -> None:
+    from ee.cloud.embeddings.vertex_gemini2 import VertexGeminiEmbedding2
+
+    client, _ = mock_genai
+    adapter = VertexGeminiEmbedding2(api_key="fake", dim=64)
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+    await adapter.embed_query(text="find similar slide", image_bytes=png_bytes)
+
+    kwargs = client.models.embed_content.call_args.kwargs
+    contents = kwargs["contents"]
+    # [text, Part(image)]
+    assert len(contents) == 2
+    assert contents[0] == "find similar slide"
+    part = contents[1]
+    assert getattr(part.inline_data, "mime_type", None) == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_embed_query_with_jpeg_bytes_picks_jpeg_mime(mock_genai) -> None:
+    from ee.cloud.embeddings.vertex_gemini2 import VertexGeminiEmbedding2
+
+    client, _ = mock_genai
+    adapter = VertexGeminiEmbedding2(api_key="fake", dim=32)
+    jpeg = b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 8
+    await adapter.embed_query(text="", image_bytes=jpeg)
+
+    kwargs = client.models.embed_content.call_args.kwargs
+    contents = kwargs["contents"]
+    # Empty text is dropped; only the image Part comes through.
+    assert len(contents) == 1
+    assert getattr(contents[0].inline_data, "mime_type", None) == "image/jpeg"
+
+
+@pytest.mark.asyncio
+async def test_unwrap_handles_embeddings_list_shape(mock_genai, tmp_image) -> None:
+    """Newer google-genai versions return response.embeddings[0].values."""
+    from ee.cloud.embeddings.vertex_gemini2 import VertexGeminiEmbedding2
+
+    client, response = mock_genai
+    # Drop the singular .embedding shape, expose the plural.
+    delattr(response, "embedding")
+    plural_entry = MagicMock()
+    plural_entry.values = [0.1, 0.2, 0.3]
+    response.embeddings = [plural_entry]
+
+    adapter = VertexGeminiEmbedding2(api_key="fake", dim=2)
+    result = await adapter.embed_file(tmp_image, "image/png")
+    assert result.vector == [0.1, 0.2]
+
+
+@pytest.mark.asyncio
+async def test_unwrap_raises_on_unknown_shape(mock_genai, tmp_image) -> None:
+    from ee.cloud.embeddings.vertex_gemini2 import VertexGeminiEmbedding2
+
+    _, response = mock_genai
+    # Strip every shape we know how to unwrap.
+    delattr(response, "embedding")
+    response.embeddings = []
+    # Mock cannot subscript: raise TypeError.
+
+    class _UnsubscriptableResponse:
+        embeddings: list = []
+
+    adapter = VertexGeminiEmbedding2(api_key="fake", dim=2)
+    # Force the embed_content mock to return the unsubscriptable instance.
+    adapter._client.models.embed_content.return_value = _UnsubscriptableResponse()
+    with pytest.raises(RuntimeError, match="could not locate embedding"):
+        await adapter.embed_file(tmp_image, "image/png")
+
+
+def test_estimate_cost_handles_missing_path(mock_genai) -> None:
+    from ee.cloud.embeddings.vertex_gemini2 import VertexGeminiEmbedding2
+
+    adapter = VertexGeminiEmbedding2(api_key="fake", dim=64)
+    assert adapter.estimate_cost(None, None) == 0.0
+
+
+def test_estimate_cost_uses_file_size(mock_genai, tmp_image) -> None:
+    from ee.cloud.embeddings.vertex_gemini2 import VertexGeminiEmbedding2
+
+    adapter = VertexGeminiEmbedding2(api_key="fake", dim=64)
+    cost = adapter.estimate_cost(tmp_image, "image/png")
+    assert cost > 0

--- a/tests/cloud/embeddings/test_vertex_mm001.py
+++ b/tests/cloud/embeddings/test_vertex_mm001.py
@@ -1,0 +1,175 @@
+# test_vertex_mm001.py — VertexMultimodal001 unit tests.
+# Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
+# Mocks vertexai and vertexai.vision_models so the lazy import succeeds
+# without google-cloud-aiplatform installed. Pins the request shape
+# (dimension keyword, contextual_text, Image), the dim-snapping logic
+# (128/256/512/1408), and the unsupported-mime error.
+"""Tests for ``ee.cloud.embeddings.vertex_mm001.VertexMultimodal001``."""
+
+from __future__ import annotations
+
+import sys
+import types as _types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_vertex(monkeypatch):
+    """Provide stubbed vertexai + vertexai.vision_models modules."""
+    fake_image_cls = MagicMock()
+    fake_image_cls.load_from_file = MagicMock(return_value=MagicMock(name="image"))
+
+    fake_embed = MagicMock()
+    fake_embed.image_embedding = [0.1] * 1408
+    fake_embed.text_embedding = [0.5] * 1408
+
+    fake_model = MagicMock()
+    fake_model.get_embeddings = MagicMock(return_value=fake_embed)
+    fake_model_cls = MagicMock()
+    fake_model_cls.from_pretrained = MagicMock(return_value=fake_model)
+
+    fake_vision = _types.ModuleType("vertexai.vision_models")
+    fake_vision.MultiModalEmbeddingModel = fake_model_cls  # type: ignore[attr-defined]
+    fake_vision.Image = fake_image_cls  # type: ignore[attr-defined]
+
+    fake_vertexai = _types.ModuleType("vertexai")
+    fake_vertexai.init = MagicMock()  # type: ignore[attr-defined]
+    fake_vertexai.vision_models = fake_vision  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "vertexai", fake_vertexai)
+    monkeypatch.setitem(sys.modules, "vertexai.vision_models", fake_vision)
+
+    return {
+        "vertexai": fake_vertexai,
+        "Image": fake_image_cls,
+        "model": fake_model,
+        "embed": fake_embed,
+    }
+
+
+def test_init_calls_vertexai_init_and_loads_model(mock_vertex) -> None:
+    from ee.cloud.embeddings.vertex_mm001 import VertexMultimodal001
+
+    VertexMultimodal001(project_id="proj-1", location="us-central1", dim=512)
+    mock_vertex["vertexai"].init.assert_called_once_with(project="proj-1", location="us-central1")
+
+
+def test_dim_snaps_to_valid_native_choice(mock_vertex) -> None:
+    from ee.cloud.embeddings.vertex_mm001 import VertexMultimodal001
+
+    a512 = VertexMultimodal001(project_id="p", dim=512)
+    a1408 = VertexMultimodal001(project_id="p", dim=1408)
+    a300 = VertexMultimodal001(project_id="p", dim=300)
+    a64 = VertexMultimodal001(project_id="p", dim=64)
+    a2000 = VertexMultimodal001(project_id="p", dim=2000)
+
+    assert a512.dim == 512
+    assert a1408.dim == 1408
+    # 300 → 256 (closest valid at-or-below)
+    assert a300.dim == 256
+    # 64 → 128 (smallest valid)
+    assert a64.dim == 128
+    # 2000 → 1408 (largest valid)
+    assert a2000.dim == 1408
+
+
+def test_init_raises_clear_error_when_sdk_missing(monkeypatch) -> None:
+    """Lazy import path: ImportError surfaces with install hint."""
+    monkeypatch.setitem(sys.modules, "vertexai", None)
+    monkeypatch.setitem(sys.modules, "vertexai.vision_models", None)
+
+    from ee.cloud.embeddings.vertex_mm001 import VertexMultimodal001
+
+    with pytest.raises(ImportError, match="google-cloud-aiplatform"):
+        VertexMultimodal001(project_id="p")
+
+
+@pytest.mark.asyncio
+async def test_embed_file_image(mock_vertex, tmp_path: Path) -> None:
+    from ee.cloud.embeddings.vertex_mm001 import VertexMultimodal001
+
+    img = tmp_path / "diagram.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    adapter = VertexMultimodal001(project_id="p", dim=512)
+    result = await adapter.embed_file(img, "image/png")
+
+    mock_vertex["Image"].load_from_file.assert_called_once_with(str(img))
+    call_kwargs = mock_vertex["model"].get_embeddings.call_args.kwargs
+    assert call_kwargs["dimension"] == 512
+    assert "image" in call_kwargs
+
+    assert result.dim == 1408  # mock returns 1408-dim regardless of dimension arg
+    assert result.estimated_cost_usd == pytest.approx(0.0001)
+    assert result.model == "multimodalembedding@001"
+
+
+@pytest.mark.asyncio
+async def test_embed_file_rejects_non_image_mime(mock_vertex, tmp_path: Path) -> None:
+    from ee.cloud.embeddings.vertex_mm001 import VertexMultimodal001
+
+    pdf = tmp_path / "doc.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+
+    adapter = VertexMultimodal001(project_id="p", dim=512)
+    with pytest.raises(ValueError, match="text and image only"):
+        await adapter.embed_file(pdf, "application/pdf")
+
+
+@pytest.mark.asyncio
+async def test_embed_query_with_text_and_image(mock_vertex) -> None:
+    from ee.cloud.embeddings.vertex_mm001 import VertexMultimodal001
+
+    adapter = VertexMultimodal001(project_id="p", dim=1408)
+    image_bytes = b"\x89PNG\r\n\x1a\n"
+    result = await adapter.embed_query(text="similar diagram", image_bytes=image_bytes)
+
+    call_kwargs = mock_vertex["model"].get_embeddings.call_args.kwargs
+    assert call_kwargs["dimension"] == 1408
+    assert call_kwargs["contextual_text"] == "similar diagram"
+    assert "image" in call_kwargs
+    # Text + image cost: 0.0001 image + 0.00002 per 1k chars (1 unit min).
+    assert result.estimated_cost_usd > 0.0001
+
+
+@pytest.mark.asyncio
+async def test_embed_query_text_only_returns_text_embedding(mock_vertex) -> None:
+    """When the call is pure text the SDK returns only a text embedding;
+    the adapter must fall back to it instead of returning empty."""
+    from ee.cloud.embeddings.vertex_mm001 import VertexMultimodal001
+
+    # Drop image_embedding so the fallback path is exercised.
+    mock_vertex["embed"].image_embedding = None
+
+    adapter = VertexMultimodal001(project_id="p", dim=512)
+    result = await adapter.embed_query(text="lonely text")
+
+    assert len(result.vector) == 1408
+    # text path uses 1k-char text cost only — no image dollars.
+    assert result.estimated_cost_usd > 0
+
+
+@pytest.mark.asyncio
+async def test_embed_query_raises_when_both_embeddings_empty(mock_vertex) -> None:
+    from ee.cloud.embeddings.vertex_mm001 import VertexMultimodal001
+
+    mock_vertex["embed"].image_embedding = None
+    mock_vertex["embed"].text_embedding = None
+
+    adapter = VertexMultimodal001(project_id="p", dim=512)
+    with pytest.raises(RuntimeError, match="empty embedding"):
+        await adapter.embed_query(text="anything")
+
+
+def test_estimate_cost_for_image_returns_per_image_rate(mock_vertex, tmp_path) -> None:
+    from ee.cloud.embeddings.vertex_mm001 import VertexMultimodal001
+
+    img = tmp_path / "x.png"
+    img.write_bytes(b"\x89PNG")
+    adapter = VertexMultimodal001(project_id="p", dim=512)
+    assert adapter.estimate_cost(img, "image/png") == pytest.approx(0.0001)
+    assert adapter.estimate_cost(img, "application/pdf") == 0.0
+    assert adapter.estimate_cost(None, None) == 0.0

--- a/tests/cloud/uploads/test_listener_vector.py
+++ b/tests/cloud/uploads/test_listener_vector.py
@@ -1,0 +1,521 @@
+# test_listener_vector.py — listener vector-path coverage.
+# Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
+# Covers the post-text-ingest hook: vectors enabled → embedder called →
+# kb subprocess invoked with --vec; cap hit → vector skipped, text still
+# ingests; embedder failure → text-only path stays intact; modality
+# mismatch → vector skipped quietly. Mocks the kb-go subprocess (it
+# isn't on the test runner's PATH).
+"""Tests for the vector path inside ``index_uploaded_file``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ee.cloud._core.realtime.events import FileReady
+from ee.cloud.embeddings import EmbeddingResult
+from ee.cloud.extraction.adapter import ExtractionResult
+
+
+class _FakeChain:
+    def __init__(self, result: ExtractionResult):
+        self._result = result
+
+    async def run(self, path: Path, mime: str) -> ExtractionResult:
+        return self._result
+
+
+class _FakeAdapter:
+    def __init__(self, *, local_path_value: Path | None = None):
+        self._local = local_path_value
+
+    def local_path(self, key: str) -> Path | None:
+        return self._local
+
+    async def open(self, key: str):
+        if False:  # pragma: no cover
+            yield b""
+
+
+class _FakeEmbedder:
+    name = "vertex-mm-001"
+    dim = 1408
+    supports_modalities = {"text", "image"}
+    requires_network = True
+
+    def __init__(self, *, fail: bool = False, vector: list[float] | None = None):
+        self._fail = fail
+        self._vector = vector or [0.1] * 8
+        self.calls: list[tuple[Path, str]] = []
+
+    async def embed_file(self, path: Path, mime: str) -> EmbeddingResult:
+        self.calls.append((path, mime))
+        if self._fail:
+            raise RuntimeError("upstream blew up")
+        return EmbeddingResult(
+            vector=list(self._vector),
+            dim=len(self._vector),
+            model=self.name,
+            estimated_cost_usd=0.0001,
+        )
+
+    async def embed_query(self, text, image_bytes=None):  # pragma: no cover
+        raise NotImplementedError
+
+    def estimate_cost(self, path, mime):
+        return 0.0001
+
+
+class _FakeCostTracker:
+    def __init__(self, *, allow: bool = True, cap: float = 10.0):
+        self._allow = allow
+        self.cap_usd = cap
+        self.spent_this_month = 0.0
+        self.recorded: list[float] = []
+
+    def can_spend(self, estimated_cost):
+        return self._allow
+
+    def record(self, cost):
+        self.recorded.append(cost)
+
+
+def _settings_with_vectors(**overrides):
+    """Build a minimal stub settings object covering both pipelines."""
+    base = {
+        "kb_vectors_enabled": True,
+        "embedding_adapter": "vertex-mm-001",
+        "embedding_dim": 8,
+        "embedding_monthly_cap_usd": 10.0,
+        "vertex_project_id": "p",
+        "vertex_location": "us-central1",
+        "gemini_api_key": None,
+    }
+    base.update(overrides)
+    return MagicMock(**base)
+
+
+def _patch_pipeline(
+    monkeypatch,
+    *,
+    chain,
+    adapter,
+    ingest,
+    embedder,
+    cost_tracker,
+    settings,
+    subprocess_returncode: int = 0,
+    subprocess_calls: list | None = None,
+):
+    from ee.cloud.uploads import listeners
+
+    monkeypatch.setattr(
+        "ee.cloud.extraction.build_chain", lambda settings: chain
+    )
+    monkeypatch.setattr(listeners, "_resolve_adapter", lambda: adapter)
+
+    from ee.cloud.agents import knowledge as kn
+
+    monkeypatch.setattr(kn.KnowledgeService, "ingest_text_to_scope", ingest)
+
+    monkeypatch.setattr(
+        "pocketpaw.config.get_settings",
+        lambda force_reload=False: settings,
+    )
+    monkeypatch.setattr(
+        "ee.cloud.embeddings.build_embedder",
+        lambda s: embedder,
+    )
+    monkeypatch.setattr(
+        "ee.cloud.embeddings.get_cost_tracker",
+        lambda s: cost_tracker,
+    )
+
+    if subprocess_calls is not None:
+        async def _fake_subprocess_exec(*args, **kwargs):
+            subprocess_calls.append(list(args))
+
+            class _Proc:
+                returncode = subprocess_returncode
+
+                async def communicate(self):
+                    return b"{}", b""
+
+            return _Proc()
+
+        monkeypatch.setattr(
+            "asyncio.create_subprocess_exec", _fake_subprocess_exec
+        )
+
+
+@pytest.mark.asyncio
+async def test_vector_path_runs_when_enabled(monkeypatch, tmp_path):
+    """Vectors enabled → embedder called → kb subprocess invoked with --vec."""
+    from ee.cloud.uploads.listeners import index_uploaded_file
+
+    direct = tmp_path / "diagram.png"
+    direct.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    chain = _FakeChain(ExtractionResult(text="caption", backend="local"))
+    adapter = _FakeAdapter(local_path_value=direct)
+    ingest = AsyncMock(return_value={"id": "art-99"})
+    embedder = _FakeEmbedder()
+    cost_tracker = _FakeCostTracker(allow=True)
+    settings = _settings_with_vectors()
+    subprocess_calls: list = []
+
+    _patch_pipeline(
+        monkeypatch,
+        chain=chain,
+        adapter=adapter,
+        ingest=ingest,
+        embedder=embedder,
+        cost_tracker=cost_tracker,
+        settings=settings,
+        subprocess_calls=subprocess_calls,
+    )
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "diagram.png",
+                "mime": "image/png",
+                "storage_key": "ws/w1/diagram.png",
+            }
+        )
+    )
+
+    # Text ingest happened first.
+    ingest.assert_awaited_once_with(
+        scope="workspace:w1", text="caption", source="diagram.png"
+    )
+    # Embedder ran on the same path the chain saw.
+    assert embedder.calls == [(direct, "image/png")]
+    # Cost was recorded.
+    assert cost_tracker.recorded == [pytest.approx(0.0001)]
+    # kb subprocess was called with the right shape.
+    assert len(subprocess_calls) == 1
+    argv = subprocess_calls[0]
+    # asyncio.create_subprocess_exec args: (program, *flags)
+    assert argv[1] == "ingest"
+    assert "--vec" in argv
+    vec_idx = argv.index("--vec") + 1
+    vec_path = argv[vec_idx]
+    # The temp vec file is unlinked by the time we observe; we can only
+    # assert the shape, not contents. But the suffix tells the story.
+    assert vec_path.endswith(".json")
+    assert "--id" in argv
+    id_idx = argv.index("--id") + 1
+    assert argv[id_idx] == "art-99"
+    assert "--scope" in argv
+    scope_idx = argv.index("--scope") + 1
+    assert argv[scope_idx] == "workspace:w1"
+
+
+@pytest.mark.asyncio
+async def test_cap_hit_skips_vector_but_keeps_text_ingest(monkeypatch, tmp_path):
+    from ee.cloud.uploads.listeners import index_uploaded_file
+
+    direct = tmp_path / "x.png"
+    direct.write_bytes(b"\x89PNG")
+
+    chain = _FakeChain(ExtractionResult(text="text content", backend="local"))
+    adapter = _FakeAdapter(local_path_value=direct)
+    ingest = AsyncMock(return_value={"id": "art-1"})
+    embedder = _FakeEmbedder()
+    cost_tracker = _FakeCostTracker(allow=False)
+    settings = _settings_with_vectors()
+    subprocess_calls: list = []
+    _patch_pipeline(
+        monkeypatch,
+        chain=chain,
+        adapter=adapter,
+        ingest=ingest,
+        embedder=embedder,
+        cost_tracker=cost_tracker,
+        settings=settings,
+        subprocess_calls=subprocess_calls,
+    )
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "x.png",
+                "mime": "image/png",
+                "storage_key": "k",
+            }
+        )
+    )
+
+    ingest.assert_awaited_once()
+    assert embedder.calls == []  # cap blocked the embed call
+    assert subprocess_calls == []  # …and the kb call
+
+
+@pytest.mark.asyncio
+async def test_vectors_disabled_skips_embed(monkeypatch, tmp_path):
+    from ee.cloud.uploads.listeners import index_uploaded_file
+
+    direct = tmp_path / "x.png"
+    direct.write_bytes(b"\x89PNG")
+    chain = _FakeChain(ExtractionResult(text="text", backend="local"))
+    adapter = _FakeAdapter(local_path_value=direct)
+    ingest = AsyncMock(return_value={"id": "art-1"})
+    embedder = _FakeEmbedder()
+    settings = _settings_with_vectors(kb_vectors_enabled=False)
+    subprocess_calls: list = []
+    _patch_pipeline(
+        monkeypatch,
+        chain=chain,
+        adapter=adapter,
+        ingest=ingest,
+        embedder=embedder,
+        cost_tracker=_FakeCostTracker(),
+        settings=settings,
+        subprocess_calls=subprocess_calls,
+    )
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "x.png",
+                "mime": "image/png",
+                "storage_key": "k",
+            }
+        )
+    )
+    ingest.assert_awaited_once()
+    assert embedder.calls == []
+    assert subprocess_calls == []
+
+
+@pytest.mark.asyncio
+async def test_no_embedder_returned_skips_quietly(monkeypatch, tmp_path):
+    """build_embedder → None → vector path is a no-op (logged at INFO)."""
+    from ee.cloud.uploads.listeners import index_uploaded_file
+
+    direct = tmp_path / "x.png"
+    direct.write_bytes(b"\x89PNG")
+    chain = _FakeChain(ExtractionResult(text="text", backend="local"))
+    adapter = _FakeAdapter(local_path_value=direct)
+    ingest = AsyncMock(return_value={"id": "art-1"})
+    settings = _settings_with_vectors()
+    subprocess_calls: list = []
+    _patch_pipeline(
+        monkeypatch,
+        chain=chain,
+        adapter=adapter,
+        ingest=ingest,
+        embedder=None,
+        cost_tracker=_FakeCostTracker(),
+        settings=settings,
+        subprocess_calls=subprocess_calls,
+    )
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "x.png",
+                "mime": "image/png",
+                "storage_key": "k",
+            }
+        )
+    )
+    ingest.assert_awaited_once()
+    assert subprocess_calls == []
+
+
+@pytest.mark.asyncio
+async def test_modality_mismatch_skips_vector(monkeypatch, tmp_path):
+    """Audio file but text+image-only embedder → vector path skipped."""
+    from ee.cloud.uploads.listeners import index_uploaded_file
+
+    direct = tmp_path / "x.wav"
+    direct.write_bytes(b"RIFF...")
+    chain = _FakeChain(ExtractionResult(text="audio transcript", backend="local"))
+    adapter = _FakeAdapter(local_path_value=direct)
+    ingest = AsyncMock(return_value={"id": "art-1"})
+    embedder = _FakeEmbedder()  # supports text/image only
+    settings = _settings_with_vectors()
+    subprocess_calls: list = []
+    _patch_pipeline(
+        monkeypatch,
+        chain=chain,
+        adapter=adapter,
+        ingest=ingest,
+        embedder=embedder,
+        cost_tracker=_FakeCostTracker(),
+        settings=settings,
+        subprocess_calls=subprocess_calls,
+    )
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "x.wav",
+                "mime": "audio/wav",
+                "storage_key": "k",
+            }
+        )
+    )
+    ingest.assert_awaited_once()
+    # WAV is "audio" modality; embedder only does text/image.
+    assert embedder.calls == []
+    assert subprocess_calls == []
+
+
+@pytest.mark.asyncio
+async def test_embed_failure_does_not_break_text_path(monkeypatch, tmp_path):
+    from ee.cloud.uploads.listeners import index_uploaded_file
+
+    direct = tmp_path / "x.png"
+    direct.write_bytes(b"\x89PNG")
+    chain = _FakeChain(ExtractionResult(text="text", backend="local"))
+    adapter = _FakeAdapter(local_path_value=direct)
+    ingest = AsyncMock(return_value={"id": "art-1"})
+    embedder = _FakeEmbedder(fail=True)
+    settings = _settings_with_vectors()
+    subprocess_calls: list = []
+    _patch_pipeline(
+        monkeypatch,
+        chain=chain,
+        adapter=adapter,
+        ingest=ingest,
+        embedder=embedder,
+        cost_tracker=_FakeCostTracker(),
+        settings=settings,
+        subprocess_calls=subprocess_calls,
+    )
+
+    # Must not raise.
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "x.png",
+                "mime": "image/png",
+                "storage_key": "k",
+            }
+        )
+    )
+
+    ingest.assert_awaited_once()
+    assert embedder.calls != []
+    # Subprocess never reached because embed failed.
+    assert subprocess_calls == []
+
+
+@pytest.mark.asyncio
+async def test_kb_subprocess_failure_does_not_break_text_path(monkeypatch, tmp_path):
+    from ee.cloud.uploads.listeners import index_uploaded_file
+
+    direct = tmp_path / "x.png"
+    direct.write_bytes(b"\x89PNG")
+    chain = _FakeChain(ExtractionResult(text="text", backend="local"))
+    adapter = _FakeAdapter(local_path_value=direct)
+    ingest = AsyncMock(return_value={"id": "art-1"})
+    embedder = _FakeEmbedder()
+    settings = _settings_with_vectors()
+    subprocess_calls: list = []
+    _patch_pipeline(
+        monkeypatch,
+        chain=chain,
+        adapter=adapter,
+        ingest=ingest,
+        embedder=embedder,
+        cost_tracker=_FakeCostTracker(),
+        settings=settings,
+        subprocess_calls=subprocess_calls,
+        subprocess_returncode=2,
+    )
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "x.png",
+                "mime": "image/png",
+                "storage_key": "k",
+            }
+        )
+    )
+    ingest.assert_awaited_once()
+    # Embedder ran, subprocess attempted, but exit-2 didn't propagate.
+    assert embedder.calls != []
+    assert len(subprocess_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_article_id_skips_vector(monkeypatch, tmp_path):
+    """When kb-go ingest returns no id (legacy build), the vector path skips."""
+    from ee.cloud.uploads.listeners import index_uploaded_file
+
+    direct = tmp_path / "x.png"
+    direct.write_bytes(b"\x89PNG")
+    chain = _FakeChain(ExtractionResult(text="text", backend="local"))
+    adapter = _FakeAdapter(local_path_value=direct)
+    ingest = AsyncMock(return_value="bare-stdout-string")  # not a dict
+    embedder = _FakeEmbedder()
+    settings = _settings_with_vectors()
+    subprocess_calls: list = []
+    _patch_pipeline(
+        monkeypatch,
+        chain=chain,
+        adapter=adapter,
+        ingest=ingest,
+        embedder=embedder,
+        cost_tracker=_FakeCostTracker(),
+        settings=settings,
+        subprocess_calls=subprocess_calls,
+    )
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "x.png",
+                "mime": "image/png",
+                "storage_key": "k",
+            }
+        )
+    )
+    ingest.assert_awaited_once()
+    assert embedder.calls == []
+    assert subprocess_calls == []
+
+
+def test_extract_article_id_helper():
+    """Spot-check the parser used to read kb's ingest response."""
+    from ee.cloud.uploads.listeners import _extract_article_id
+
+    assert _extract_article_id({"id": "abc"}) == "abc"
+    assert _extract_article_id({"article_id": "xyz"}) == "xyz"
+    assert _extract_article_id({"id": 42}) is None
+    assert _extract_article_id("nope") is None
+    assert _extract_article_id(None) is None
+
+
+def test_modality_for_mime_helper():
+    from ee.cloud.uploads.listeners import _modality_for_mime
+
+    assert _modality_for_mime("image/png") == "image"
+    assert _modality_for_mime("application/pdf") == "pdf"
+    assert _modality_for_mime("audio/wav") == "audio"
+    assert _modality_for_mime("video/mp4") == "video"
+    assert _modality_for_mime("text/plain") == "text"
+    assert _modality_for_mime("application/json") == "text"


### PR DESCRIPTION
## Summary

Stage 2.D of Files-as-Knowledge, sitting on top of the kb-go vector CLI from PR #14.

What lands:

- New `ee/cloud/embeddings/` package. `EmbeddingAdapter` Protocol mirrors the extraction adapter shape. Two adapters ship today: `VertexGeminiEmbedding2` (preview, 3072-dim, multimodal across text/image/pdf/audio/video) and `VertexMultimodal001` (GA, 1408-dim, text + image only).
- `build_embedder(settings)` factory, keyed off `POCKETPAW_KB_VECTORS_ENABLED` and `POCKETPAW_EMBEDDING_ADAPTER`. Returns `None` (with an INFO log) when vectors are off, creds are missing, or the SDK is not installed.
- Soft monthly cost cap via `CostTracker` (`POCKETPAW_EMBEDDING_MONTHLY_CAP_USD`, default 10.0). State persists at `~/.pocketpaw/embedding_cost.json` and rolls over on UTC month boundaries. Not billing-grade — just a guard so a runaway loop cannot drain the budget.
- `FileReady` listener now computes the vector after text-ingest and pipes it to `kb ingest --vec <path> --id <article_id> --scope <s>`. Anything that goes wrong on the vector side (cap hit, modality mismatch, embedder error, kb subprocess error) gets logged and contained, so the text-only KB ingest is still authoritative.
- `AgentContextBuilder._get_kb_context` takes an optional `image_bytes`. When set together with a multimodal embedder, the builder embeds (text + image) once, writes a temp vec file, and runs each scope in hybrid mode via `kb search --hybrid --query-vec <path> --topk N`. If the embed call errors we fall back to the Phase 1 BM25 path, so a transient outage does not take chat down.

## Settings added

`POCKETPAW_KB_VECTORS_ENABLED` (bool, default false), `POCKETPAW_EMBEDDING_ADAPTER` (str), `POCKETPAW_EMBEDDING_DIM` (int, default 1024; Matryoshka truncation for Gemini, dim-snap for vertex-mm-001), `POCKETPAW_EMBEDDING_MONTHLY_CAP_USD` (float, default 10.0), `POCKETPAW_VERTEX_PROJECT_ID`, `POCKETPAW_VERTEX_LOCATION`. `POCKETPAW_GEMINI_API_KEY` already exists from Stage 1.A.

## Deviations from the brief

- `google-cloud-aiplatform` is not in `pyproject.toml`. The vertex-mm-001 adapter lazy-imports the SDK; the factory catches `ImportError` and returns `None`. So the adapter is selectable in settings but quietly unavailable until the dep lands. Whether to add it is a captain call.
- kb-go's `--vec` flag takes a file path (per `kb-go/vector_cli.go:loadVectorFromFile`), not stdin. The listener writes `{"vector": [...]}` to a `NamedTemporaryFile` and unlinks on the way out.
- Chat callers do not yet thread `image_bytes` into `build_system_prompt`. The arg defaults to `None`, so the call shape is identical for everything wired up today. The chat path can start passing real images whenever the upstream UI is ready; this PR does not block on that.

## Test plan

- [x] `uv run pytest tests/cloud/embeddings/ tests/cloud/uploads/test_listener_vector.py tests/cloud/uploads/test_listener.py tests/bootstrap/test_kb_query_with_image.py tests/bootstrap/test_kb_multi_scope.py tests/cloud/extraction/` — 180 passed
- [x] `uv run ruff check` on the touched files — clean
- [x] `uv run mypy ee/cloud/embeddings/` — clean (one pre-existing error in `config.py` unchanged)
- [ ] Recall@5 eval — deferred per the brief; Phase 2 sign-off concern