### PR TITLE
feat(connectors): cloud entity + workspace-scoped REST router

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -67,6 +67,7 @@ def mount_cloud(app: FastAPI) -> None:
     from ee.cloud.agents.router import router as agents_router
     from ee.cloud.auth.router import router as auth_router
     from ee.cloud.chat.router import router as chat_router
+    from ee.cloud.connectors.router import router as connectors_router
     from ee.cloud.license import get_license_info
     from ee.cloud.pockets.router import router as pockets_router
     from ee.cloud.sessions.router import router as sessions_router
@@ -76,6 +77,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(workspace_router, prefix="/api/v1")
     app.include_router(agents_router, prefix="/api/v1")
     app.include_router(chat_router, prefix="/api/v1")
+    app.include_router(connectors_router, prefix="/api/v1")
     app.include_router(pockets_router, prefix="/api/v1")
     app.include_router(sessions_router, prefix="/api/v1")
 

--- a/ee/cloud/connectors/CHARTER.md
+++ b/ee/cloud/connectors/CHARTER.md
@@ -1,0 +1,398 @@
+# Connectors — Phase 1 Charter
+
+**Status:** draft, 2026-05-03
+**Owner:** crew
+**Captain sign-off pending**
+
+This charter locks the boundaries for the connector layer **before** any
+extraction. It exists so we don't lock the abstraction wrong on the way to
+spinning out `paw-connectors/` as a workspace sibling later.
+
+Phase 1 = consolidate the four scattered layers behind one protocol, land
+the tenanted-state entity at `ee/cloud/connectors/`, ship without changing
+the public agent-tool surface. **No package extraction in Phase 1.** That's
+Phase 2, planned for ~3–4 weeks after Phase 1 ships.
+
+---
+
+## 1 — The problem
+
+Connectors live in four places today, and three of them duplicate work:
+
+| Layer | Path | Purpose |
+|---|---|---|
+| YAML specs | `pocketpaw/connectors/*.yaml` | Declarative — 30 connectors, drives KB ingestion |
+| YAML runtime + native adapters | `src/pocketpaw/connectors/{protocol,registry,yaml_engine,db_adapter,firebase_adapter,gcp_adapter,mongo_adapter,drive/}.py` | `ConnectorProtocol`, registry, `DirectRESTAdapter` |
+| Direct integrations | `src/pocketpaw/integrations/{gmail,gcalendar,gdocs,gdrive,oauth,token_store,reddit,spotify}.py` | HTTP clients for Google Workspace + Reddit + Spotify |
+| Agent tools | `src/pocketpaw/tools/builtin/{gmail,calendar,gdocs,gdrive}.py` | LLM-facing wrappers over the direct integrations |
+
+Drive lives in **all four** layers. Gmail lives in three (no YAML).
+Stripe lives in only YAML. The four layers don't share an interface, so
+every consumer (KB / agent tools / home widgets / automations) reaches
+into a different one.
+
+Five consumers exist today or are imminent:
+
+- KB ingestion (Files-as-Knowledge)
+- Agent tools (LLM tool calls)
+- Home widgets (`paw-enterprise` AddWidgetPicker, generated 2026-05-02)
+- Automations / scheduled routines
+- Soul memory (e.g. "remember inbox this morning")
+
+Each one currently couples to a different layer. That's the smell.
+
+## 2 — Phase 1 goal
+
+**Every connector — YAML-driven or native Python — implements one protocol.
+Every consumer reads from one registry.**
+
+After Phase 1:
+
+- Gmail / Calendar / Docs / Drive / Reddit / Spotify register as
+  `Connector` instances alongside the YAML-defined ones.
+- The home widget picker, the agent tool generator, the KB ingest router,
+  and the automations engine all consume the same registry.
+- Per-workspace state (which connectors are enabled, OAuth tokens, sync
+  status) lives in a tenanted `ee/cloud/connectors/` entity following the
+  4-file shape.
+- The legacy `tools/builtin/{gmail,calendar,gdocs,gdrive}.py` tool classes
+  remain as thin generators on top of the new registry — no breaking
+  changes to the agent's tool surface.
+
+## 3 — Boundary
+
+### In scope (Phase 1)
+
+1. **Unified `Connector` protocol** in `src/pocketpaw/connectors/protocol.py`.
+   Builds on the existing `ConnectorProtocol` + `IngestAdapter` already
+   defined there.
+2. **Registry expansion** so the existing YAML registry also discovers
+   native Python connectors (Gmail, Calendar, Docs, Drive, etc.).
+3. **`Connector.widgets()`** — new capability. Each connector exposes a
+   list of default home-page widget recipes (display type + title + data
+   action). Drives AddWidgetPicker's "From your pockets" + "From
+   connectors" sections.
+4. **Tenanted state at `ee/cloud/connectors/`** — 4-file shape
+   (`domain.py / dto.py / service.py / router.py`) tracking which
+   connectors a workspace has enabled, per-workspace OAuth tokens
+   (referenced not stored — token bytes stay in `integrations/token_store.py`),
+   sync status, and per-connector config.
+5. **Consumer adapters** — thin functions that map registry entries to
+   each consumer's interface:
+   - `tools.builtin.connector_tools_for(c) -> list[BaseTool]`
+   - `kb.sources.connector_source_for(c) -> SourceAdapter`
+   - `home.widget_recipes_for(c) -> list[WidgetRecipe]`
+   - `automations.connector_step_for(c) -> RoutineStep`
+6. **OAuth consolidation** — the existing `integrations/oauth.py` +
+   `token_store.py` become the single OAuth surface for all connectors,
+   regardless of layer of origin.
+7. **`/api/v1/connectors` REST router** in `ee/cloud/connectors/router.py`
+   replacing whatever `getConnectors()` reads today (verify in
+   `paw-enterprise/src/lib/components/os/ConnectorPanel.svelte`).
+
+### Out of scope (defer to Phase 2 / 3)
+
+- Extracting connectors to a sibling package. **Phase 2.**
+- `Connector` schema versioning / breaking-change policy. **Phase 2.**
+- Public OSS contribution model + governance. **Phase 3.**
+- ComposioAdapter, CuratedMCPAdapter (mentioned in the existing protocol
+  docstring) — protocol contract should accommodate them, but
+  implementations come later.
+- Connector-level rate limiting, circuit breaking, retries. The
+  `core/runtime` retry/circuit breaker layer (per Linear backlog notes
+  on infra PR review patterns) handles that.
+- New connectors. Phase 1 ships zero net-new connectors; we only unify
+  what exists.
+
+### Outside the connector layer (always)
+
+- Tenanted Mongo entities outside `ee/cloud/connectors/`. Connectors
+  themselves are stateless.
+- KB ingestion logic, agent reasoning, widget rendering. The connector
+  layer exposes capabilities; consumers own their behaviour.
+- Soul memory writes. Connectors expose data; the soul layer decides
+  what to remember.
+
+## 4 — Protocol shape (locked for Phase 1)
+
+The existing `ConnectorProtocol` in
+`src/pocketpaw/connectors/protocol.py` is the starting point and is
+mostly correct. Phase 1 adds `widgets()` and clarifies a few semantics.
+
+```python
+class Connector(Protocol):
+    name: str                            # "gmail"
+    display_name: str                    # "Gmail"
+    auth: AuthSpec                       # bearer | oauth2 | api_key | none
+    actions: list[ActionSchema]          # search, read, send, list, …
+    widgets: list[WidgetRecipe]          # NEW — default home widgets
+
+    async def connect(self, scope: ConnectorScope, config: dict) -> ConnectionResult: ...
+    async def disconnect(self, scope: ConnectorScope) -> bool: ...
+    async def execute(self, action: str, params: dict, scope: ConnectorScope) -> ActionResult: ...
+    async def sync(self, scope: ConnectorScope) -> SyncResult: ...
+    async def schema(self) -> dict: ...
+    async def health(self, scope: ConnectorScope) -> ConnectorHealth: ...
+```
+
+Notes on the change from today's protocol:
+
+1. **`pocket_id: str` → `scope: ConnectorScope`.** Scope is one of
+   `pocket | workspace | user`. The current API is pocket-only, but home
+   widgets and email/calendar are workspace-scoped (sometimes user-scoped).
+   `ConnectorScope` is a tagged union the runtime resolves to the right
+   token + ACL set.
+2. **`widgets()` is new.** Each connector returns a list of pre-baked
+   widget recipes — `("Inbox", display="feed", action="gmail.search",
+   params={"q":"is:unread", "max":10})`. AddWidgetPicker reads them
+   directly.
+3. **`health()` is new.** The frontend ConnectorPanel shows
+   connected / disconnected / errored. Today that's inferred from the
+   last execute() — fragile. Explicit health check keeps the UI honest.
+4. **`IngestAdapter.permissions()` stays as-is.** It's already correct
+   for Fabric scope inheritance.
+
+`AuthSpec`, `ActionSchema`, `ActionResult`, `ConnectionResult`,
+`SyncResult`, `IngestACL` exist already and are reused without change.
+
+## 5 — Layers in their final shape
+
+```
+src/pocketpaw/connectors/                  ← runtime (stateless)
+├── protocol.py                            Connector + ConnectorScope + WidgetRecipe + AuthSpec
+├── registry.py                            discovers YAML specs + native adapters
+├── yaml_engine.py                         compiles YAML → DirectRESTAdapter
+├── oauth.py                               (moved from integrations/)
+├── token_store.py                         (moved from integrations/)
+├── adapters/
+│   ├── gmail.py                           (moved from integrations/gmail.py + tools/builtin/gmail.py)
+│   ├── gcalendar.py                       (moved from integrations/gcalendar.py + tools/builtin/calendar.py)
+│   ├── gdocs.py                           (moved from integrations/gdocs.py + tools/builtin/gdocs.py)
+│   ├── gdrive.py                          (moved from integrations/gdrive.py + tools/builtin/gdrive.py)
+│   ├── reddit.py
+│   ├── spotify.py
+│   ├── db.py                              (was db_adapter.py)
+│   ├── firebase.py                        (was firebase_adapter.py)
+│   ├── gcp.py                             (was gcp_adapter.py)
+│   └── mongo.py                           (was mongo_adapter.py)
+└── specs/                                  (moved from pocketpaw/connectors/*.yaml)
+    └── *.yaml
+
+ee/cloud/connectors/                       ← tenanted state (Mongo via Beanie)
+├── domain.py                              WorkspaceConnector value object — frozen, requires workspace_id
+├── dto.py                                 EnableConnectorRequest / ConnectorResponse / SyncStatusResponse
+├── service.py                             enable / disable / list / set_config / record_sync
+└── router.py                              GET/POST/PATCH/DELETE /api/v1/connectors
+
+src/pocketpaw/tools/builtin/__init__.py   ← shrinks
+                                            connector_tools_for(c) generates BaseTool instances
+                                            from c.actions; replaces the per-tool .py files
+```
+
+## 6 — Consumer adapters (no behaviour change)
+
+Each consumer ships a small adapter so it reads from the registry instead
+of one of the four layers.
+
+### Agent tools
+
+```python
+# src/pocketpaw/tools/builtin/__init__.py (replacement for the per-tool registry dict)
+def connector_tools_for(c: Connector) -> list[BaseTool]:
+    return [_action_to_tool(c, action) for action in c.actions]
+
+def all_builtin_tools(registry: ConnectorRegistry) -> list[BaseTool]:
+    return [t for c in registry.list() for t in connector_tools_for(c)]
+```
+
+The 18 hand-written Google Workspace tool classes get deleted in favour
+of generated ones with identical names + descriptions (named tests pin
+them).
+
+### KB ingestion
+
+```python
+# ee/cloud/uploads/listeners.py + kb/source_adapters.py
+async def kb_source_for(c: Connector, scope: ConnectorScope) -> SourceAdapter: ...
+```
+
+### Home widgets
+
+```python
+# ee/cloud/connectors/service.py
+async def list_widget_recipes(ctx: RequestContext) -> list[WidgetRecipe]:
+    enabled = await list_enabled_connectors(ctx)
+    return [recipe for c in enabled for recipe in c.widgets]
+```
+
+The frontend AddWidgetPicker calls `GET /api/v1/connectors/widget-recipes`
+to populate the new "From connectors" section alongside today's "From
+your pockets" + generative paths.
+
+### Automations
+
+```python
+# ee/cloud/automations/runtime.py
+async def connector_step(c: Connector, action: str, params: dict, scope: ConnectorScope) -> StepResult: ...
+```
+
+## 7 — OAuth + token store
+
+The existing `integrations/oauth.py` + `integrations/token_store.py`
+become the single OAuth surface, moved to
+`src/pocketpaw/connectors/{oauth,token_store}.py`. No protocol change.
+
+Per-workspace token references (not the token bytes) are persisted via
+`ee/cloud/connectors/service.py` so the cloud knows which workspaces
+have which connectors authed. Token bytes stay in the local token store
+for now — moving them to Mongo is part of Cluster H (audit persistence)
+and out of scope here.
+
+## 8 — Migration
+
+Touch-time, not big-bang. Per workspace CLAUDE.md rule on entity
+migration: when a PR touches any connector-layer file, that file moves
+to the new shape in the same PR. We don't ship a 30-PR sweep.
+
+Migration order, by risk:
+
+1. **Charter merged** (this doc). No code.
+2. **`ee/cloud/connectors/` entity** with empty registry-backing service +
+   `GET /api/v1/connectors` returning the existing YAML registry's list.
+   Frontend ConnectorPanel keeps working, new endpoint replaces old.
+3. **`Connector.widgets()` + `health()`** added to the protocol.
+   `DirectRESTAdapter` provides a default empty list for both. The home
+   widget picker reads `GET /api/v1/connectors/widget-recipes` and
+   continues to fall back to the mock POCKET_MAP if the registry is
+   empty.
+4. **Gmail adopts the protocol** — first integration to migrate.
+   `connector_tools_for(gmail)` generates the existing 8 BaseTool classes.
+   Snapshot tests pin tool names + descriptions. The home widget picker
+   shows real "Inbox / Important / Stats" recipes.
+5. **Calendar / Docs / Drive / Reddit / Spotify** in subsequent PRs,
+   one per session. Same pattern as Gmail.
+6. **Drive directory subpackage merge** — `src/pocketpaw/connectors/drive/`
+   folds into `adapters/gdrive.py` (or stays if it's substantially bigger).
+7. **Native adapters renamed** — `db_adapter.py` → `adapters/db.py`,
+   `firebase_adapter.py` → `adapters/firebase.py`, etc.
+8. **Phase 1 sealed.** Protocol stable, all consumers reading from one
+   registry, no behaviour change to the agent or to existing UIs.
+
+Each migration step is a single PR. Captain reviews before merge.
+
+## 9 — Open questions
+
+1. **Scope semantics.** Today's protocol is pocket-scoped. Home widgets
+   are workspace-scoped. Email/calendar are arguably user-scoped (each
+   member has their own inbox). Does `ConnectorScope` need three discrete
+   values, or do we always resolve up the chain (user → workspace → pocket)
+   and let the connector decide? **Captain's call before §4 is locked.**
+2. **Where does fleet-template auth live?** The fleet system already
+   bundles connectors with templates. After Phase 1, do fleets reference
+   connectors by name + scope, or carry their own connector overrides?
+3. **OAuth broker centralization.** There's an existing credential broker
+   pattern in the YAML connectors. Does it move into the new
+   `connectors/oauth.py`, or stay as-is and just be called by adapters?
+4. **What happens to `pocketpaw/connectors/*.yaml` (workspace root)?** Move
+   into `src/pocketpaw/connectors/specs/` or keep them at the package root
+   for OSS contribution surface? Phase 2 has a strong opinion (move),
+   Phase 1 is neutral.
+5. **Should `Connector.widgets()` return Ripple UISpec directly or a
+   higher-level `WidgetRecipe` that compiles to UISpec at render time?**
+   Recipe gives us a stable contract that survives Ripple version bumps.
+   Strong vote for Recipe.
+
+## 10 — Phase 2 preview (informational, not committed)
+
+After Phase 1 stabilizes (~3–4 weeks live, all five consumers wired,
+no protocol churn), we extract:
+
+```
+paw-workspace/
+├── pocketpaw/                           runtime, depends on paw-connectors
+├── paw-enterprise/                      consumes via REST router
+├── soul-protocol/                       can also depend on paw-connectors
+├── paw-connectors/   ← NEW SIBLING
+│   ├── pyproject.toml
+│   ├── src/paw_connectors/             (← src/pocketpaw/connectors/* moves here)
+│   ├── tests/
+│   ├── cli.py                           connectors list / test / oauth / health
+│   └── docs/
+└── ripple-svelte/
+```
+
+`ee/cloud/connectors/` stays in pocketpaw (it's tenanted Mongo state).
+
+Phase 3 (informational): OSS the registry. Public spec, contribution
+guide, scope hygiene rules. Strategic surface area = "30+ first-party
+connectors, community-extensible, agent-native."
+
+## 11 — Phase 1 acceptance criteria
+
+Phase 1 is done when **all five** are true:
+
+1. Every existing connector — Gmail, Calendar, Docs, Drive, Reddit, Spotify,
+   30 YAML — implements `Connector`. Registry returns them all.
+2. The home widget picker reads `GET /api/v1/connectors/widget-recipes`
+   and shows real recipes from at least three connectors (Gmail target).
+3. The agent's tool list generates from `connector_tools_for(c)`. Snapshot
+   tests pin the existing 18 Google tool names + descriptions.
+4. ConnectorPanel.svelte's `getConnectors()` reads from
+   `GET /api/v1/connectors` (cloud router) instead of whatever it talks
+   to today.
+5. `pocketpaw/integrations/` is empty (or holds only `oauth_integrations`
+   the API endpoint). The body has moved into `connectors/adapters/`.
+
+When these five hold for two weeks with zero hotfixes, Phase 2
+extraction can start.
+
+---
+
+## Appendix A — Why we're not extracting in Phase 1
+
+1. The current four-layer mess has real coupling to pocketpaw internals
+   (`BaseTool`, `OAuthManager`, `Settings`, `pocket_id` everywhere). Extracting
+   first means eating two weeks of "unbreak imports" with nothing to show.
+2. We don't yet know what `Connector.widgets()` needs from the home
+   widget consumer because we haven't built that consumer yet. Lock the
+   protocol after the consumer is real, not before.
+3. The 4-file ee/cloud rule applies only to tenanted state. Connector
+   implementations are declarative — they don't fit. Pulling them out
+   without first defining the protocol risks copying the wrong pattern.
+
+## Appendix B — Files this charter implies will move (Phase 1)
+
+- `src/pocketpaw/integrations/gmail.py` → `src/pocketpaw/connectors/adapters/gmail.py`
+- `src/pocketpaw/integrations/gcalendar.py` → `src/pocketpaw/connectors/adapters/gcalendar.py`
+- `src/pocketpaw/integrations/gdocs.py` → `src/pocketpaw/connectors/adapters/gdocs.py`
+- `src/pocketpaw/integrations/gdrive.py` → `src/pocketpaw/connectors/adapters/gdrive.py`
+- `src/pocketpaw/integrations/reddit.py` → `src/pocketpaw/connectors/adapters/reddit.py`
+- `src/pocketpaw/integrations/spotify.py` → `src/pocketpaw/connectors/adapters/spotify.py`
+- `src/pocketpaw/integrations/oauth.py` → `src/pocketpaw/connectors/oauth.py`
+- `src/pocketpaw/integrations/token_store.py` → `src/pocketpaw/connectors/token_store.py`
+- `src/pocketpaw/connectors/db_adapter.py` → `src/pocketpaw/connectors/adapters/db.py`
+- `src/pocketpaw/connectors/firebase_adapter.py` → `src/pocketpaw/connectors/adapters/firebase.py`
+- `src/pocketpaw/connectors/gcp_adapter.py` → `src/pocketpaw/connectors/adapters/gcp.py`
+- `src/pocketpaw/connectors/mongo_adapter.py` → `src/pocketpaw/connectors/adapters/mongo.py`
+- `src/pocketpaw/tools/builtin/{gmail,calendar,gdocs,gdrive}.py` → deleted, generated by `connector_tools_for(c)`
+- `pocketpaw/connectors/*.yaml` (workspace root) → **stays** for Phase 1; moves in Phase 2.
+
+## Appendix C — Files created by Phase 1
+
+- `pocketpaw/ee/cloud/connectors/CHARTER.md` (this doc)
+- `pocketpaw/ee/cloud/connectors/__init__.py`
+- `pocketpaw/ee/cloud/connectors/domain.py`
+- `pocketpaw/ee/cloud/connectors/dto.py`
+- `pocketpaw/ee/cloud/connectors/service.py`
+- `pocketpaw/ee/cloud/connectors/router.py`
+- `pocketpaw/src/pocketpaw/connectors/adapters/__init__.py` + the moved adapter files
+- New tests under `pocketpaw/tests/connectors/`
+
+No new dependencies. No schema migrations beyond the new
+`WorkspaceConnectorDocument` Beanie model.
+
+---
+
+**Action requested:** captain reviews §4 (protocol) and §9 (open questions),
+signs off, then PR-1 of the migration begins (the empty `ee/cloud/connectors/`
+entity + new REST router + frontend ConnectorPanel pointed at it).

--- a/ee/cloud/connectors/CHARTER.md
+++ b/ee/cloud/connectors/CHARTER.md
@@ -106,6 +106,13 @@ After Phase 1:
 - Connector-level rate limiting, circuit breaking, retries. The
   `core/runtime` retry/circuit breaker layer (per Linear backlog notes
   on infra PR review patterns) handles that.
+- **`ExecutionMode.SANDBOX`** — ephemeral container per invocation with
+  workspace-scoped service-account creds. Needed for prod database
+  CLIs (`psql`, `mongosh`) and untrusted code execution. Defer until a
+  Nerve client genuinely needs DB-CLI widgets running 24/7. Phase 1
+  ships only `cloud` and `local` modes. The protocol enum carries
+  `SANDBOX` from day one so a future PR is purely runtime, not a
+  schema change.
 - New connectors. Phase 1 ships zero net-new connectors; we only unify
   what exists.
 
@@ -122,7 +129,11 @@ After Phase 1:
 
 The existing `ConnectorProtocol` in
 `src/pocketpaw/connectors/protocol.py` is the starting point and is
-mostly correct. Phase 1 adds `widgets()` and clarifies a few semantics.
+mostly correct. Phase 1 adds `widgets()`, `health()`, `ConnectorScope`,
+and **`ExecutionMode`** on the action schema. The `ExecutionMode` axis
+exists because CLI-based connectors (`firebase`, `gcp`, `gh`, `kubectl`,
+…) cannot execute in the cloud's FastAPI process — there's no clean way
+to multi-tenant per-workspace `gcloud` configs on a shared host.
 
 ```python
 class Connector(Protocol):
@@ -138,6 +149,26 @@ class Connector(Protocol):
     async def sync(self, scope: ConnectorScope) -> SyncResult: ...
     async def schema(self) -> dict: ...
     async def health(self, scope: ConnectorScope) -> ConnectorHealth: ...
+```
+
+`ActionSchema` gains two fields so the runtime knows where each action
+is allowed to execute:
+
+```python
+class ExecutionMode(StrEnum):
+    CLOUD = "cloud"        # runs in the FastAPI process (REST APIs, in-process logic)
+    LOCAL = "local"        # runs in the user's pocketpaw runtime (CLI tools)
+    SANDBOX = "sandbox"    # ephemeral container per call (deferred — see Out of scope)
+
+
+class ActionSchema:
+    name: str
+    description: str
+    method: str
+    params: list[ParamSpec]
+    trust_level: TrustLevel
+    execution_mode: ExecutionMode = ExecutionMode.CLOUD   # NEW
+    requires_binary: str | None = None                    # NEW — "gcloud", "firebase", "gh", …
 ```
 
 Notes on the change from today's protocol:
@@ -156,9 +187,15 @@ Notes on the change from today's protocol:
    last execute() — fragile. Explicit health check keeps the UI honest.
 4. **`IngestAdapter.permissions()` stays as-is.** It's already correct
    for Fabric scope inheritance.
+5. **`ExecutionMode` + `requires_binary` are new on `ActionSchema`.**
+   YAML connectors default to `cloud` (no behaviour change). CLI
+   adapters (`firebase`, `gcp`) declare `local` per action with the
+   binary they shell out to. The cloud router refuses to execute
+   `local` actions in-process — it forwards them to the local-agent
+   bus instead (see §6.2 below).
 
-`AuthSpec`, `ActionSchema`, `ActionResult`, `ConnectionResult`,
-`SyncResult`, `IngestACL` exist already and are reused without change.
+`AuthSpec`, `ActionResult`, `ConnectionResult`, `SyncResult`,
+`IngestACL` exist already and are reused without change.
 
 ## 5 — Layers in their final shape
 
@@ -241,6 +278,80 @@ your pockets" + generative paths.
 async def connector_step(c: Connector, action: str, params: dict, scope: ConnectorScope) -> StepResult: ...
 ```
 
+### 6.2 — CLI connectors and the local-agent bus
+
+`firebase`, `gcp`, `gh`, `kubectl`, and any future CLI-driven connectors
+cannot execute on the cloud's FastAPI host — there's no way to multi-tenant
+per-workspace `gcloud` configs cleanly on a shared server. Their
+`ActionSchema.execution_mode` is `local`, and execution flows through the
+user's already-running pocketpaw runtime via the existing chat WebSocket
+bus.
+
+**Path for a local action:**
+
+```
+Frontend  →  POST /api/v1/cloud/connectors/{name}/execute
+                  {action, params, scope, request_id}
+                       ↓
+          ee/cloud/connectors/service.execute()
+                       ↓
+      inspects action.execution_mode
+       ┌──────────┴──────────┐
+   cloud                    local
+     ↓                        ↓
+  adapter.execute()      publish "connector.exec.requested"
+  in-process             onto chat WS to (workspace_id, user_id)
+  return result            ↓
+                         user's local pocketpaw runtime
+                         picks up, runs gcloud/firebase
+                         publishes "connector.exec.completed"
+                           {request_id, result}
+                           ↓
+                         service correlates by request_id,
+                         resolves the awaiting future,
+                         returns 200 + result to caller
+```
+
+**Bus topics added (Phase 1):**
+
+- `connector.exec.requested` — cloud → local-agent
+  `{request_id, workspace_id, connector, action, params, scope}`
+- `connector.exec.completed` — local-agent → cloud
+  `{request_id, success, result?, error?}`
+
+The transport reuses the chat WebSocket (`InProcessBus` + the existing
+client→server channel `ChatPill` already has). No new socket, no new
+auth — the agent that runs the user's chat IS the agent that runs the
+CLI. One persistent connection, one identity.
+
+**Failure modes:**
+
+- *User offline / runtime not running.* Cloud router times out at 30s,
+  returns `503 connector.local_agent_unavailable`. Frontend shows
+  "Open your local PocketPaw to run this widget."
+- *Binary not installed on user's machine.* Local agent introspects
+  `action.requires_binary`, fails fast with
+  `connector.binary_missing`. Frontend shows "Install `gcloud` to use
+  Firebase widgets" with a link to setup docs.
+- *Cloud service is offline.* Local actions don't fire because they
+  originate from the cloud router. Read-only home widgets fall back
+  to last-known cached values (cached `last_sync_status` already in
+  the entity).
+
+**What the local agent needs (PR-9 deliverable):**
+
+Listener bound at boot in `pocketpaw/runtime/connector_bus.py` that:
+
+1. Subscribes to `connector.exec.requested` for messages addressed to
+   the local user_id.
+2. Looks up the connector adapter from the local registry.
+3. Calls `adapter.execute(action, params, scope)` on the running host
+   (the user's machine has gcloud/firebase configured).
+4. Publishes `connector.exec.completed` with the result.
+
+This wiring already mirrors how chat messages flow today — the streaming
+chunks come in over the same WS, just on a different topic.
+
 ## 7 — OAuth + token store
 
 The existing `integrations/oauth.py` + `integrations/token_store.py`
@@ -279,8 +390,15 @@ Migration order, by risk:
 6. **Drive directory subpackage merge** — `src/pocketpaw/connectors/drive/`
    folds into `adapters/gdrive.py` (or stays if it's substantially bigger).
 7. **Native adapters renamed** — `db_adapter.py` → `adapters/db.py`,
-   `firebase_adapter.py` → `adapters/firebase.py`, etc.
-8. **Phase 1 sealed.** Protocol stable, all consumers reading from one
+   `firebase_adapter.py` → `adapters/firebase.py`, etc. Each declares
+   `execution_mode=local` on its actions and includes
+   `requires_binary` (`firebase` / `gcloud`).
+8. **Local-agent bus listener** — `pocketpaw/runtime/connector_bus.py`
+   lands in the runtime. Subscribes to `connector.exec.requested`,
+   runs CLI adapters against the user's machine, publishes
+   `connector.exec.completed`. The cloud router's
+   `local`-mode dispatch becomes operational.
+9. **Phase 1 sealed.** Protocol stable, all consumers reading from one
    registry, no behaviour change to the agent or to existing UIs.
 
 Each migration step is a single PR. Captain reviews before merge.
@@ -306,6 +424,18 @@ Each migration step is a single PR. Captain reviews before merge.
    higher-level `WidgetRecipe` that compiles to UISpec at render time?**
    Recipe gives us a stable contract that survives Ripple version bumps.
    Strong vote for Recipe.
+
+### Resolved by captain (2026-05-03)
+
+- **Local mode requires the user's pocketpaw runtime to be online.**
+  Same constraint Slack/iMessage live with. CLI widgets show a
+  "needs local agent" banner when the agent isn't connected.
+- **`SANDBOX` execution mode deferred.** Ships when a Nerve client
+  needs DB-CLI widgets running 24/7. Enum carries `SANDBOX` from day
+  one so the future PR is runtime-only, not a schema change.
+- **Local-agent bus reuses the existing chat WebSocket.** Two new
+  topics (`connector.exec.requested` / `connector.exec.completed`),
+  one persistent socket, one identity. No new transport.
 
 ## 10 — Phase 2 preview (informational, not committed)
 
@@ -334,21 +464,27 @@ connectors, community-extensible, agent-native."
 
 ## 11 — Phase 1 acceptance criteria
 
-Phase 1 is done when **all five** are true:
+Phase 1 is done when **all six** are true:
 
 1. Every existing connector — Gmail, Calendar, Docs, Drive, Reddit, Spotify,
    30 YAML — implements `Connector`. Registry returns them all.
-2. The home widget picker reads `GET /api/v1/connectors/widget-recipes`
+2. The home widget picker reads `GET /api/v1/cloud/connectors/widget-recipes`
    and shows real recipes from at least three connectors (Gmail target).
 3. The agent's tool list generates from `connector_tools_for(c)`. Snapshot
    tests pin the existing 18 Google tool names + descriptions.
 4. ConnectorPanel.svelte's `getConnectors()` reads from
-   `GET /api/v1/connectors` (cloud router) instead of whatever it talks
-   to today.
+   `GET /api/v1/cloud/connectors` (cloud router) for workspace-level
+   state. `PocketDataPanel` keeps reading the legacy `/api/v1/connectors`
+   path for pocket-scoped operations until its own migration PR.
 5. `pocketpaw/integrations/` is empty (or holds only `oauth_integrations`
    the API endpoint). The body has moved into `connectors/adapters/`.
+6. **CLI connectors (firebase, gcp) execute via the local-agent bus.**
+   Cloud router refuses `local`-mode actions in-process and forwards
+   them to `connector.exec.requested`. The local pocketpaw runtime's
+   `connector_bus.py` listener completes them. End-to-end test pins
+   the round-trip.
 
-When these five hold for two weeks with zero hotfixes, Phase 2
+When these six hold for two weeks with zero hotfixes, Phase 2
 extraction can start.
 
 ---

--- a/ee/cloud/connectors/CHARTER.md
+++ b/ee/cloud/connectors/CHARTER.md
@@ -86,9 +86,14 @@ After Phase 1:
 6. **OAuth consolidation** — the existing `integrations/oauth.py` +
    `token_store.py` become the single OAuth surface for all connectors,
    regardless of layer of origin.
-7. **`/api/v1/connectors` REST router** in `ee/cloud/connectors/router.py`
-   replacing whatever `getConnectors()` reads today (verify in
-   `paw-enterprise/src/lib/components/os/ConnectorPanel.svelte`).
+7. **`/api/v1/cloud/connectors` REST router** in `ee/cloud/connectors/router.py`.
+   Lives under `/cloud/` to coexist with the legacy pocket-scoped routes
+   at `/api/v1/connectors` (`connect / disconnect / execute / status`,
+   used by `PocketDataPanel`). Frontend home-widget integration calls
+   the new `/cloud/connectors` path; `PocketDataPanel` keeps using the
+   legacy path. Long-term, when PR-2 lands `Connector.widgets()` and
+   we migrate `PocketDataPanel` to consume the cloud entity directly,
+   the legacy path retires.
 
 ### Out of scope (defer to Phase 2 / 3)
 

--- a/ee/cloud/connectors/__init__.py
+++ b/ee/cloud/connectors/__init__.py
@@ -1,0 +1,11 @@
+# Cloud connectors entity — re-exports for the mount_cloud wiring.
+# Created: 2026-05-03 — PR-1 of Phase 1 connector consolidation.
+# Strategy locked at ee/cloud/connectors/CHARTER.md. The runtime
+# (registry + adapters + protocol) lives at src/pocketpaw/connectors/;
+# this module owns the tenanted state and the cloud REST router.
+
+from __future__ import annotations
+
+from ee.cloud.connectors.router import router
+
+__all__ = ["router"]

--- a/ee/cloud/connectors/domain.py
+++ b/ee/cloud/connectors/domain.py
@@ -1,0 +1,54 @@
+# Connectors — domain value objects.
+# Created: 2026-05-03 — PR-1 of Phase 1 connector consolidation. Frozen
+# dataclasses constructed from Beanie docs in service.py. Tenancy is
+# required at construction (workspace_id has no default) per the
+# ee/cloud rule §3.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class WorkspaceConnector:
+    """One connector enabled for one workspace.
+
+    Constructed by ``service.py`` from the matching Beanie document plus
+    the registry definition (display_name / type / icon come from the
+    static registry, the rest from Mongo). Consumers outside the service
+    only ever see this domain object.
+    """
+
+    name: str
+    workspace_id: str
+    display_name: str
+    type: str  # "knowledge" | "data" | "communication" | …
+    icon: str
+    enabled: bool
+    scope: str  # "pocket" | "workspace" | "user"
+    pocket_id: str | None
+    user_id: str | None
+    config: tuple[tuple[str, Any], ...]  # frozen view of the config dict
+    last_sync_at: datetime | None
+    last_sync_status: str
+    last_sync_error: str
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class AvailableConnector:
+    """A connector definition exposed by the registry, not yet enabled.
+
+    The ``GET /connectors`` route returns a merge of these (the catalog)
+    and ``WorkspaceConnector`` instances (the workspace's selections).
+    """
+
+    name: str
+    display_name: str
+    type: str
+    icon: str
+    auth_method: str
+    actions: tuple[str, ...] = field(default_factory=tuple)

--- a/ee/cloud/connectors/dto.py
+++ b/ee/cloud/connectors/dto.py
@@ -1,0 +1,71 @@
+# Connectors — request / response schemas.
+# Created: 2026-05-03 — PR-1 of Phase 1 connector consolidation.
+# Every request schema is distinct from every response schema (cloud
+# rule §4). The wire shape mirrors the existing
+# src/pocketpaw/api/v1/connectors.py ``ConnectorInfo`` so the frontend
+# type stays unchanged when the cloud handler shadows the runtime one.
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class EnableConnectorRequest(BaseModel):
+    """POST /connectors/{name}/enable body.
+
+    ``scope`` is one of ``pocket | workspace | user``. ``pocket_id`` and
+    ``user_id`` are required when scope picks them; the service raises
+    ``ValidationError`` if they're missing or set on the wrong scope.
+    """
+
+    scope: str = Field(default="workspace", pattern="^(pocket|workspace|user)$")
+    pocket_id: str | None = None
+    user_id: str | None = None
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class UpdateConnectorConfigRequest(BaseModel):
+    """PATCH /connectors/{name}/config body."""
+
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Responses — match existing ConnectorInfo wire shape for frontend compat
+# ---------------------------------------------------------------------------
+
+
+class ConnectorResponse(BaseModel):
+    """Single row in the GET /connectors list.
+
+    Mirrors ``src/pocketpaw/api/v1/connectors.py:ConnectorInfo`` exactly
+    so paw-enterprise's ``getConnectors()`` keeps working unchanged. The
+    extended fields below are optional additions for the cloud-only
+    consumer.
+    """
+
+    name: str
+    display_name: str
+    type: str
+    icon: str
+    status: str = "disconnected"  # "connected" | "disconnected" | "error"
+
+    # Cloud-only extensions — frontend already tolerates extra fields.
+    enabled: bool = False
+    scope: str | None = None
+    last_sync_at: datetime | None = None
+    last_sync_status: str = "never"
+
+
+class ConnectorDetailResponse(ConnectorResponse):
+    """Single connector detail returned by GET /connectors/{name}."""
+
+    actions: list[str] = Field(default_factory=list)
+    config: dict[str, Any] = Field(default_factory=dict)

--- a/ee/cloud/connectors/router.py
+++ b/ee/cloud/connectors/router.py
@@ -19,8 +19,15 @@ from ee.cloud.connectors.dto import (
 from ee.cloud.license import require_license
 from ee.cloud.shared.deps import current_workspace_id
 
+# Mounted under /api/v1/cloud/connectors (not /api/v1/connectors) so it
+# does NOT shadow the legacy pocket-scoped routes in
+# src/pocketpaw/api/v1/connectors.py. The legacy routes (connect /
+# disconnect / execute / status) remain the source of truth for
+# pocket-bound connector instances; this cloud router owns the
+# workspace-level enabled/disabled state used by the home widgets
+# (and, eventually, automations and soul memory).
 router = APIRouter(
-    prefix="/connectors",
+    prefix="/cloud/connectors",
     tags=["Connectors"],
     dependencies=[Depends(require_license)],
 )

--- a/ee/cloud/connectors/router.py
+++ b/ee/cloud/connectors/router.py
@@ -1,0 +1,84 @@
+# Connectors — FastAPI router.
+# Created: 2026-05-03 — PR-1 of Phase 1 connector consolidation.
+# Mounted at /api/v1/connectors via mount_cloud(). Wire shape mirrors the
+# legacy src/pocketpaw/api/v1/connectors.py so the frontend's
+# ``getConnectors()`` works unchanged when this handler shadows the
+# runtime one in cloud deployments.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from ee.cloud.connectors import service as connectors_service
+from ee.cloud.connectors.dto import (
+    ConnectorDetailResponse,
+    ConnectorResponse,
+    EnableConnectorRequest,
+    UpdateConnectorConfigRequest,
+)
+from ee.cloud.license import require_license
+from ee.cloud.shared.deps import current_workspace_id
+
+router = APIRouter(
+    prefix="/connectors",
+    tags=["Connectors"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.get("", response_model=list[ConnectorResponse])
+async def list_connectors(
+    workspace_id: str = Depends(current_workspace_id),
+) -> list[ConnectorResponse]:
+    """List all available connectors with this workspace's enabled state.
+
+    Always returns the full registry catalog — disabled connectors carry
+    ``enabled=false`` / ``status="disconnected"``. The frontend filters
+    into "Connected" vs "Available" rails on its own.
+    """
+    return await connectors_service.list_connectors(workspace_id)
+
+
+@router.get("/{name}", response_model=ConnectorDetailResponse)
+async def get_connector(
+    name: str,
+    workspace_id: str = Depends(current_workspace_id),
+) -> ConnectorDetailResponse:
+    """Detail row for one connector — actions list + saved config."""
+    return await connectors_service.get_connector(workspace_id, name)
+
+
+@router.post("/{name}/enable", response_model=ConnectorResponse)
+async def enable_connector(
+    name: str,
+    body: EnableConnectorRequest | None = None,
+    workspace_id: str = Depends(current_workspace_id),
+) -> ConnectorResponse:
+    """Enable a connector for this workspace.
+
+    Idempotent — re-enabling an already-enabled connector simply updates
+    the scope/config. The actual OAuth flow runs in
+    ``api/v1/oauth_integrations.py``; this endpoint records the workspace's
+    intent to use the connector and the scope it was granted at.
+    """
+    payload = body or EnableConnectorRequest()
+    return await connectors_service.enable_connector(workspace_id, name, payload)
+
+
+@router.post("/{name}/disable", response_model=ConnectorResponse)
+async def disable_connector(
+    name: str,
+    workspace_id: str = Depends(current_workspace_id),
+) -> ConnectorResponse:
+    """Soft-disable a connector. Config + history survive."""
+    return await connectors_service.disable_connector(workspace_id, name)
+
+
+@router.patch("/{name}/config", response_model=ConnectorResponse)
+async def update_config(
+    name: str,
+    body: UpdateConnectorConfigRequest,
+    workspace_id: str = Depends(current_workspace_id),
+) -> ConnectorResponse:
+    """Merge-patch the saved config for one connector."""
+    return await connectors_service.update_config(workspace_id, name, body)

--- a/ee/cloud/connectors/service.py
+++ b/ee/cloud/connectors/service.py
@@ -1,0 +1,298 @@
+# Connectors — workspace-scoped business logic.
+# Created: 2026-05-03 — PR-1 of Phase 1 connector consolidation.
+# Module-level async API. Sole owner of writes to the
+# ``WorkspaceConnector`` Beanie document. Reads merge the static
+# registry catalog from src/pocketpaw/connectors/registry.py with the
+# per-workspace state stored here.
+#
+# Cloud rules followed (per workspace CLAUDE.md):
+# §2  Writes go through this service; routers never import models.
+# §5  Module-level async functions, not a class.
+# §6  Every request schema is re-validated at the service entry.
+# §7  Every read filters by workspace_id.
+# §9  Every write emits an event (or carries a ``# no-event`` justification).
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+from ee.cloud._core.errors import NotFound, ValidationError
+from ee.cloud.connectors.domain import AvailableConnector, WorkspaceConnector
+from ee.cloud.connectors.dto import (
+    ConnectorDetailResponse,
+    ConnectorResponse,
+    EnableConnectorRequest,
+    UpdateConnectorConfigRequest,
+)
+from ee.cloud.models.connector import WorkspaceConnector as _WCDoc
+from ee.cloud.shared.events import event_bus
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Registry access — lazy singleton, mirrors src/pocketpaw/api/v1/connectors.py
+# ---------------------------------------------------------------------------
+
+_registry = None
+
+
+def _get_registry():
+    """Lazy-init the static registry. Reused across calls."""
+    global _registry
+    if _registry is None:
+        from pocketpaw.connectors.registry import ConnectorRegistry
+
+        _registry = ConnectorRegistry(Path("connectors"))
+    return _registry
+
+
+def _available_from_registry() -> list[AvailableConnector]:
+    """Catalog of connectors the registry knows about.
+
+    ``ConnectorDef.actions`` is ``list[dict[str, Any]]`` — raw YAML rows.
+    Each row has a ``name`` key. ``ConnectorDef.auth`` is a dict shaped
+    like ``{method: "bearer", credentials: [...]}``.
+    """
+    reg = _get_registry()
+    out: list[AvailableConnector] = []
+    for d in reg._definitions.values():  # noqa: SLF001 — registry exposes no public iter yet
+        actions = tuple(
+            a.get("name", "") for a in (d.actions or []) if isinstance(a, dict) and a.get("name")
+        )
+        auth_method = (d.auth or {}).get("method", "none") if isinstance(d.auth, dict) else "none"
+        out.append(
+            AvailableConnector(
+                name=d.name,
+                display_name=d.display_name,
+                type=d.type,
+                icon=d.icon,
+                auth_method=auth_method,
+                actions=actions,
+            ),
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Mapping helpers
+# ---------------------------------------------------------------------------
+
+
+def _doc_to_domain(
+    doc: _WCDoc,
+    *,
+    display_name: str,
+    type_: str,
+    icon: str,
+) -> WorkspaceConnector:
+    return WorkspaceConnector(
+        name=doc.name,
+        workspace_id=doc.workspace,
+        display_name=display_name,
+        type=type_,
+        icon=icon,
+        enabled=doc.enabled,
+        scope=doc.scope,
+        pocket_id=doc.pocket_id,
+        user_id=doc.user_id,
+        config=tuple(doc.config.items()),
+        last_sync_at=doc.last_sync_at,
+        last_sync_status=doc.last_sync_status,
+        last_sync_error=doc.last_sync_error,
+        created_at=doc.createdAt,
+        updated_at=doc.updatedAt,
+    )
+
+
+def _row_response(d: AvailableConnector, doc: _WCDoc | None) -> ConnectorResponse:
+    """Build the wire row by merging registry + Mongo state."""
+    if doc is None:
+        return ConnectorResponse(
+            name=d.name,
+            display_name=d.display_name,
+            type=d.type,
+            icon=d.icon,
+            status="disconnected",
+            enabled=False,
+        )
+    return ConnectorResponse(
+        name=d.name,
+        display_name=d.display_name,
+        type=d.type,
+        icon=d.icon,
+        status="connected" if doc.enabled else "disconnected",
+        enabled=doc.enabled,
+        scope=doc.scope,
+        last_sync_at=doc.last_sync_at,
+        last_sync_status=doc.last_sync_status,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def list_connectors(workspace_id: str) -> list[ConnectorResponse]:
+    """List all available connectors with this workspace's enabled state.
+
+    Read-only. Tenant filter on the Beanie query (cloud rule §7); the
+    registry catalog is global by design.
+    """
+    available = _available_from_registry()
+    docs = await _WCDoc.find(_WCDoc.workspace == workspace_id).to_list()
+    by_name = {d.name: d for d in docs}
+    return [_row_response(a, by_name.get(a.name)) for a in available]
+
+
+async def get_connector(workspace_id: str, name: str) -> ConnectorDetailResponse:
+    """One connector's detail row + actions + saved config.
+
+    Raises ``NotFound`` if the registry doesn't know the name.
+    """
+    available = {a.name: a for a in _available_from_registry()}
+    if name not in available:
+        raise NotFound("connector", name)
+    a = available[name]
+    doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
+    base = _row_response(a, doc).model_dump()
+    return ConnectorDetailResponse(
+        **base,
+        actions=list(a.actions),
+        config=dict(doc.config) if doc else {},
+    )
+
+
+async def enable_connector(
+    workspace_id: str,
+    name: str,
+    body: EnableConnectorRequest,
+) -> ConnectorResponse:
+    """Enable a connector for this workspace, creating the row if needed."""
+    body = EnableConnectorRequest.model_validate(body)
+    available = {a.name: a for a in _available_from_registry()}
+    if name not in available:
+        raise NotFound("connector", name)
+
+    if body.scope == "pocket" and not body.pocket_id:
+        raise ValidationError("connector.scope_missing_pocket", "scope=pocket requires pocket_id")
+    if body.scope == "user" and not body.user_id:
+        raise ValidationError("connector.scope_missing_user", "scope=user requires user_id")
+
+    doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
+    if doc is None:
+        doc = _WCDoc(
+            workspace=workspace_id,
+            name=name,
+            enabled=True,
+            scope=body.scope,
+            pocket_id=body.pocket_id,
+            user_id=body.user_id,
+            config=body.config,
+        )
+        await doc.insert()
+    else:
+        doc.enabled = True
+        doc.scope = body.scope
+        doc.pocket_id = body.pocket_id
+        doc.user_id = body.user_id
+        if body.config:
+            doc.config = body.config
+        await doc.save()
+
+    a = available[name]
+    await event_bus.emit(
+        "connector.enabled",
+        {"workspace_id": workspace_id, "name": name, "scope": body.scope},
+    )
+    return _row_response(a, doc)
+
+
+async def disable_connector(workspace_id: str, name: str) -> ConnectorResponse:
+    """Disable (soft) a connector for this workspace.
+
+    Keeps the row so config + history survive re-enable. The actual token
+    revocation lives in the adapter's ``disconnect()`` method and is
+    orchestrated separately — Phase 1 just flips the flag.
+    """
+    available = {a.name: a for a in _available_from_registry()}
+    if name not in available:
+        raise NotFound("connector", name)
+    doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
+    if doc is None:
+        # Already not enabled — return the disconnected row.
+        return _row_response(available[name], None)
+    doc.enabled = False
+    await doc.save()
+    await event_bus.emit(
+        "connector.disabled",
+        {"workspace_id": workspace_id, "name": name},
+    )
+    return _row_response(available[name], doc)
+
+
+async def update_config(
+    workspace_id: str,
+    name: str,
+    body: UpdateConnectorConfigRequest,
+) -> ConnectorResponse:
+    """Patch the saved config for one connector. Connector must be enabled first."""
+    body = UpdateConnectorConfigRequest.model_validate(body)
+    available = {a.name: a for a in _available_from_registry()}
+    if name not in available:
+        raise NotFound("connector", name)
+    doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
+    if doc is None:
+        raise NotFound("connector", name)
+    doc.config = {**doc.config, **body.config}
+    await doc.save()
+    await event_bus.emit(
+        "connector.config_updated",
+        {"workspace_id": workspace_id, "name": name},
+    )
+    return _row_response(available[name], doc)
+
+
+async def record_sync(
+    workspace_id: str,
+    name: str,
+    *,
+    status: str,
+    error: str = "",
+) -> WorkspaceConnector:
+    """Update last_sync_at + last_sync_status from an adapter callback.
+
+    No HTTP route in PR-1 — this is for adapters to call after a successful
+    or failed sync. PR-3 (Gmail) is the first caller.
+    """
+    if status not in {"ok", "error"}:
+        raise ValidationError("connector.invalid_sync_status", f"unknown status {status!r}")
+    available = {a.name: a for a in _available_from_registry()}
+    if name not in available:
+        raise NotFound("connector", name)
+    doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
+    if doc is None:
+        raise NotFound("connector", name)
+    doc.last_sync_at = datetime.utcnow()
+    doc.last_sync_status = status
+    doc.last_sync_error = error if status == "error" else ""
+    await doc.save()
+    a = available[name]
+    await event_bus.emit(
+        "connector.sync_recorded",
+        {"workspace_id": workspace_id, "name": name, "status": status},
+    )
+    return _doc_to_domain(doc, display_name=a.display_name, type_=a.type, icon=a.icon)
+
+
+__all__ = [
+    "disable_connector",
+    "enable_connector",
+    "get_connector",
+    "list_connectors",
+    "record_sync",
+    "update_config",
+]

--- a/ee/cloud/models/__init__.py
+++ b/ee/cloud/models/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ee.cloud.models.agent import Agent, AgentConfig
 from ee.cloud.models.comment import Comment, CommentAuthor, CommentTarget
+from ee.cloud.models.connector import WorkspaceConnector
 from ee.cloud.models.file import FileObj
 from ee.cloud.models.group import Group, GroupAgent
 from ee.cloud.models.invite import Invite
@@ -57,6 +58,7 @@ __all__ = [
     "Widget",
     "WidgetPosition",
     "Workspace",
+    "WorkspaceConnector",
     "WorkspaceMembership",
     "WorkspaceSettings",
 ]
@@ -76,6 +78,7 @@ def get_all_documents():
         FileUpload,
         FileFolder,
         Workspace,
+        WorkspaceConnector,
         Invite,
         Group,
         Message,

--- a/ee/cloud/models/connector.py
+++ b/ee/cloud/models/connector.py
@@ -1,0 +1,45 @@
+# WorkspaceConnector Beanie document — per-workspace enabled flags + sync state.
+# Created: 2026-05-03 — PR-1 of the Phase 1 connector consolidation.
+# One row per (workspace, connector_name) tracking the enabled state, last
+# sync timestamp, scope (pocket | workspace | user) the OAuth token was
+# granted at, and a free-form config blob the connector adapter reads on
+# execute. Token bytes themselves stay in src/pocketpaw/integrations/
+# token_store.py for Phase 1 — only the *reference* + scope live here.
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from beanie import Indexed
+from pydantic import Field
+
+from ee.cloud.models.base import TimestampedDocument
+
+
+class WorkspaceConnector(TimestampedDocument):
+    """One connector configuration for one workspace.
+
+    Tenancy: ``workspace`` is required and indexed; every read in
+    ``service.py`` filters on it. ``name`` is the registry key (e.g.
+    ``"gmail"``, ``"stripe"``); paired with ``workspace`` it is unique
+    per workspace, enforced at the service layer (no Mongo unique index
+    yet so re-enabling is idempotent and forgiving on race conditions).
+
+    The ``status`` field is intentionally minimal — adapter ``health()``
+    output is computed live and merged at read time in ``service.list``.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    name: str
+    enabled: bool = True
+    scope: str = "workspace"  # "pocket" | "workspace" | "user"
+    pocket_id: str | None = None  # set when scope == "pocket"
+    user_id: str | None = None  # set when scope == "user"
+    config: dict[str, Any] = Field(default_factory=dict)
+    last_sync_at: datetime | None = None
+    last_sync_status: str = "never"  # "never" | "ok" | "error"
+    last_sync_error: str = ""
+
+    class Settings(TimestampedDocument.Settings):
+        name = "workspace_connectors"

--- a/tests/cloud/test_connectors_router.py
+++ b/tests/cloud/test_connectors_router.py
@@ -1,0 +1,250 @@
+# Cloud connectors router — contract tests.
+# Created: 2026-05-03 — PR-1 of Phase 1 connector consolidation.
+# Locks the wire shape and the workspace tenancy filter so future
+# refactors can't silently change either.
+#
+# Pattern: tests build a tiny FastAPI app with the connectors router
+# mounted, override the auth dependencies the same way conftest's
+# cloud_app_client does, and exercise the routes via httpx.AsyncClient
+# against an isolated mongomock-motor DB.
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ee.cloud._core.http import add_error_handler
+from ee.cloud.connectors.router import router as connectors_router
+from ee.cloud.license import require_license
+from ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+
+def _user_a() -> str:
+    return "u-a"
+
+
+def _user_b() -> str:
+    return "u-b"
+
+
+def _ws_a() -> str:
+    return "ws-a"
+
+
+def _ws_b() -> str:
+    return "ws-b"
+
+
+def _no_op_license() -> None:
+    return None
+
+
+def _build_app(workspace_id: str, user_id: str) -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(connectors_router, prefix="/api/v1")
+    app.dependency_overrides[current_user_id] = lambda: user_id
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    app.dependency_overrides[require_license] = _no_op_license
+    return app
+
+
+@pytest_asyncio.fixture
+async def client_a(mongo_db) -> AsyncClient:  # noqa: ARG001 — fixture wires Beanie
+    app = _build_app(_ws_a(), _user_a())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def client_b(mongo_db) -> AsyncClient:  # noqa: ARG001
+    app = _build_app(_ws_b(), _user_b())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# GET /connectors — listing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_returns_registry_catalog(client_a: AsyncClient):
+    """List returns every connector the registry knows about, all disabled by default."""
+    resp = await client_a.get("/api/v1/connectors")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert isinstance(rows, list)
+    # We don't pin the exact count (the YAML dir may grow), just that the
+    # registry is non-empty and rows have the expected wire shape.
+    assert len(rows) > 0
+    sample = rows[0]
+    for key in ("name", "display_name", "type", "icon", "status", "enabled"):
+        assert key in sample
+    # No connector is enabled in a fresh workspace.
+    assert all(r["enabled"] is False for r in rows)
+    assert all(r["status"] == "disconnected" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_list_reflects_enable(client_a: AsyncClient):
+    """After /enable, the connector flips to enabled=true / status=connected."""
+    # Pick an arbitrary connector from the registry.
+    catalog = (await client_a.get("/api/v1/connectors")).json()
+    name = catalog[0]["name"]
+
+    enable = await client_a.post(f"/api/v1/connectors/{name}/enable", json={"scope": "workspace"})
+    assert enable.status_code == 200
+    assert enable.json()["enabled"] is True
+    assert enable.json()["status"] == "connected"
+
+    listed = (await client_a.get("/api/v1/connectors")).json()
+    row = next(r for r in listed if r["name"] == name)
+    assert row["enabled"] is True
+    assert row["status"] == "connected"
+    assert row["scope"] == "workspace"
+
+
+# ---------------------------------------------------------------------------
+# Tenant isolation — workspace A's enabled connectors don't leak to B
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workspace_isolation(client_a: AsyncClient, client_b: AsyncClient):
+    """Enabling a connector in workspace A leaves workspace B untouched."""
+    catalog = (await client_a.get("/api/v1/connectors")).json()
+    name = catalog[0]["name"]
+
+    await client_a.post(f"/api/v1/connectors/{name}/enable", json={"scope": "workspace"})
+
+    a_rows = (await client_a.get("/api/v1/connectors")).json()
+    b_rows = (await client_b.get("/api/v1/connectors")).json()
+
+    assert next(r for r in a_rows if r["name"] == name)["enabled"] is True
+    assert next(r for r in b_rows if r["name"] == name)["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# /enable — validation + scope handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enable_unknown_connector_404(client_a: AsyncClient):
+    resp = await client_a.post(
+        "/api/v1/connectors/this-is-not-a-real-connector/enable",
+        json={"scope": "workspace"},
+    )
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["error"]["code"] == "connector.not_found"
+
+
+@pytest.mark.asyncio
+async def test_enable_pocket_scope_requires_pocket_id(client_a: AsyncClient):
+    catalog = (await client_a.get("/api/v1/connectors")).json()
+    name = catalog[0]["name"]
+    resp = await client_a.post(
+        f"/api/v1/connectors/{name}/enable",
+        json={"scope": "pocket"},  # pocket_id missing
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "connector.scope_missing_pocket"
+
+
+@pytest.mark.asyncio
+async def test_enable_user_scope_requires_user_id(client_a: AsyncClient):
+    catalog = (await client_a.get("/api/v1/connectors")).json()
+    name = catalog[0]["name"]
+    resp = await client_a.post(
+        f"/api/v1/connectors/{name}/enable",
+        json={"scope": "user"},  # user_id missing
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "connector.scope_missing_user"
+
+
+# ---------------------------------------------------------------------------
+# /disable — soft, idempotent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disable_flips_status(client_a: AsyncClient):
+    catalog = (await client_a.get("/api/v1/connectors")).json()
+    name = catalog[0]["name"]
+    await client_a.post(f"/api/v1/connectors/{name}/enable", json={"scope": "workspace"})
+    resp = await client_a.post(f"/api/v1/connectors/{name}/disable")
+    assert resp.status_code == 200
+    assert resp.json()["enabled"] is False
+    assert resp.json()["status"] == "disconnected"
+
+
+@pytest.mark.asyncio
+async def test_disable_idempotent_when_not_enabled(client_a: AsyncClient):
+    """Disabling a never-enabled connector returns the disconnected row, not 404."""
+    catalog = (await client_a.get("/api/v1/connectors")).json()
+    name = catalog[0]["name"]
+    resp = await client_a.post(f"/api/v1/connectors/{name}/disable")
+    assert resp.status_code == 200
+    assert resp.json()["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# PATCH /config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_config_merges(client_a: AsyncClient):
+    catalog = (await client_a.get("/api/v1/connectors")).json()
+    name = catalog[0]["name"]
+    await client_a.post(
+        f"/api/v1/connectors/{name}/enable",
+        json={"scope": "workspace", "config": {"a": 1, "b": 2}},
+    )
+    resp = await client_a.patch(
+        f"/api/v1/connectors/{name}/config",
+        json={"config": {"b": 99, "c": 3}},
+    )
+    assert resp.status_code == 200
+    detail = (await client_a.get(f"/api/v1/connectors/{name}")).json()
+    assert detail["config"] == {"a": 1, "b": 99, "c": 3}
+
+
+@pytest.mark.asyncio
+async def test_update_config_404_when_not_enabled(client_a: AsyncClient):
+    catalog = (await client_a.get("/api/v1/connectors")).json()
+    name = catalog[0]["name"]
+    resp = await client_a.patch(
+        f"/api/v1/connectors/{name}/config",
+        json={"config": {"a": 1}},
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /{name} — detail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_detail_includes_actions(client_a: AsyncClient):
+    catalog = (await client_a.get("/api/v1/connectors")).json()
+    name = catalog[0]["name"]
+    resp = await client_a.get(f"/api/v1/connectors/{name}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == name
+    assert isinstance(body["actions"], list)
+
+
+@pytest.mark.asyncio
+async def test_get_detail_404(client_a: AsyncClient):
+    resp = await client_a.get("/api/v1/connectors/not-real")
+    assert resp.status_code == 404

--- a/tests/cloud/test_connectors_router.py
+++ b/tests/cloud/test_connectors_router.py
@@ -75,7 +75,7 @@ async def client_b(mongo_db) -> AsyncClient:  # noqa: ARG001
 @pytest.mark.asyncio
 async def test_list_returns_registry_catalog(client_a: AsyncClient):
     """List returns every connector the registry knows about, all disabled by default."""
-    resp = await client_a.get("/api/v1/connectors")
+    resp = await client_a.get("/api/v1/cloud/connectors")
     assert resp.status_code == 200
     rows = resp.json()
     assert isinstance(rows, list)
@@ -94,15 +94,18 @@ async def test_list_returns_registry_catalog(client_a: AsyncClient):
 async def test_list_reflects_enable(client_a: AsyncClient):
     """After /enable, the connector flips to enabled=true / status=connected."""
     # Pick an arbitrary connector from the registry.
-    catalog = (await client_a.get("/api/v1/connectors")).json()
+    catalog = (await client_a.get("/api/v1/cloud/connectors")).json()
     name = catalog[0]["name"]
 
-    enable = await client_a.post(f"/api/v1/connectors/{name}/enable", json={"scope": "workspace"})
+    enable = await client_a.post(
+        f"/api/v1/cloud/connectors/{name}/enable",
+        json={"scope": "workspace"},
+    )
     assert enable.status_code == 200
     assert enable.json()["enabled"] is True
     assert enable.json()["status"] == "connected"
 
-    listed = (await client_a.get("/api/v1/connectors")).json()
+    listed = (await client_a.get("/api/v1/cloud/connectors")).json()
     row = next(r for r in listed if r["name"] == name)
     assert row["enabled"] is True
     assert row["status"] == "connected"
@@ -117,13 +120,13 @@ async def test_list_reflects_enable(client_a: AsyncClient):
 @pytest.mark.asyncio
 async def test_workspace_isolation(client_a: AsyncClient, client_b: AsyncClient):
     """Enabling a connector in workspace A leaves workspace B untouched."""
-    catalog = (await client_a.get("/api/v1/connectors")).json()
+    catalog = (await client_a.get("/api/v1/cloud/connectors")).json()
     name = catalog[0]["name"]
 
-    await client_a.post(f"/api/v1/connectors/{name}/enable", json={"scope": "workspace"})
+    await client_a.post(f"/api/v1/cloud/connectors/{name}/enable", json={"scope": "workspace"})
 
-    a_rows = (await client_a.get("/api/v1/connectors")).json()
-    b_rows = (await client_b.get("/api/v1/connectors")).json()
+    a_rows = (await client_a.get("/api/v1/cloud/connectors")).json()
+    b_rows = (await client_b.get("/api/v1/cloud/connectors")).json()
 
     assert next(r for r in a_rows if r["name"] == name)["enabled"] is True
     assert next(r for r in b_rows if r["name"] == name)["enabled"] is False
@@ -137,7 +140,7 @@ async def test_workspace_isolation(client_a: AsyncClient, client_b: AsyncClient)
 @pytest.mark.asyncio
 async def test_enable_unknown_connector_404(client_a: AsyncClient):
     resp = await client_a.post(
-        "/api/v1/connectors/this-is-not-a-real-connector/enable",
+        "/api/v1/cloud/connectors/this-is-not-a-real-connector/enable",
         json={"scope": "workspace"},
     )
     assert resp.status_code == 404
@@ -147,10 +150,10 @@ async def test_enable_unknown_connector_404(client_a: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_enable_pocket_scope_requires_pocket_id(client_a: AsyncClient):
-    catalog = (await client_a.get("/api/v1/connectors")).json()
+    catalog = (await client_a.get("/api/v1/cloud/connectors")).json()
     name = catalog[0]["name"]
     resp = await client_a.post(
-        f"/api/v1/connectors/{name}/enable",
+        f"/api/v1/cloud/connectors/{name}/enable",
         json={"scope": "pocket"},  # pocket_id missing
     )
     assert resp.status_code == 422
@@ -159,10 +162,10 @@ async def test_enable_pocket_scope_requires_pocket_id(client_a: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_enable_user_scope_requires_user_id(client_a: AsyncClient):
-    catalog = (await client_a.get("/api/v1/connectors")).json()
+    catalog = (await client_a.get("/api/v1/cloud/connectors")).json()
     name = catalog[0]["name"]
     resp = await client_a.post(
-        f"/api/v1/connectors/{name}/enable",
+        f"/api/v1/cloud/connectors/{name}/enable",
         json={"scope": "user"},  # user_id missing
     )
     assert resp.status_code == 422
@@ -176,10 +179,10 @@ async def test_enable_user_scope_requires_user_id(client_a: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_disable_flips_status(client_a: AsyncClient):
-    catalog = (await client_a.get("/api/v1/connectors")).json()
+    catalog = (await client_a.get("/api/v1/cloud/connectors")).json()
     name = catalog[0]["name"]
-    await client_a.post(f"/api/v1/connectors/{name}/enable", json={"scope": "workspace"})
-    resp = await client_a.post(f"/api/v1/connectors/{name}/disable")
+    await client_a.post(f"/api/v1/cloud/connectors/{name}/enable", json={"scope": "workspace"})
+    resp = await client_a.post(f"/api/v1/cloud/connectors/{name}/disable")
     assert resp.status_code == 200
     assert resp.json()["enabled"] is False
     assert resp.json()["status"] == "disconnected"
@@ -188,9 +191,9 @@ async def test_disable_flips_status(client_a: AsyncClient):
 @pytest.mark.asyncio
 async def test_disable_idempotent_when_not_enabled(client_a: AsyncClient):
     """Disabling a never-enabled connector returns the disconnected row, not 404."""
-    catalog = (await client_a.get("/api/v1/connectors")).json()
+    catalog = (await client_a.get("/api/v1/cloud/connectors")).json()
     name = catalog[0]["name"]
-    resp = await client_a.post(f"/api/v1/connectors/{name}/disable")
+    resp = await client_a.post(f"/api/v1/cloud/connectors/{name}/disable")
     assert resp.status_code == 200
     assert resp.json()["enabled"] is False
 
@@ -202,27 +205,27 @@ async def test_disable_idempotent_when_not_enabled(client_a: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_update_config_merges(client_a: AsyncClient):
-    catalog = (await client_a.get("/api/v1/connectors")).json()
+    catalog = (await client_a.get("/api/v1/cloud/connectors")).json()
     name = catalog[0]["name"]
     await client_a.post(
-        f"/api/v1/connectors/{name}/enable",
+        f"/api/v1/cloud/connectors/{name}/enable",
         json={"scope": "workspace", "config": {"a": 1, "b": 2}},
     )
     resp = await client_a.patch(
-        f"/api/v1/connectors/{name}/config",
+        f"/api/v1/cloud/connectors/{name}/config",
         json={"config": {"b": 99, "c": 3}},
     )
     assert resp.status_code == 200
-    detail = (await client_a.get(f"/api/v1/connectors/{name}")).json()
+    detail = (await client_a.get(f"/api/v1/cloud/connectors/{name}")).json()
     assert detail["config"] == {"a": 1, "b": 99, "c": 3}
 
 
 @pytest.mark.asyncio
 async def test_update_config_404_when_not_enabled(client_a: AsyncClient):
-    catalog = (await client_a.get("/api/v1/connectors")).json()
+    catalog = (await client_a.get("/api/v1/cloud/connectors")).json()
     name = catalog[0]["name"]
     resp = await client_a.patch(
-        f"/api/v1/connectors/{name}/config",
+        f"/api/v1/cloud/connectors/{name}/config",
         json={"config": {"a": 1}},
     )
     assert resp.status_code == 404
@@ -235,9 +238,9 @@ async def test_update_config_404_when_not_enabled(client_a: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_get_detail_includes_actions(client_a: AsyncClient):
-    catalog = (await client_a.get("/api/v1/connectors")).json()
+    catalog = (await client_a.get("/api/v1/cloud/connectors")).json()
     name = catalog[0]["name"]
-    resp = await client_a.get(f"/api/v1/connectors/{name}")
+    resp = await client_a.get(f"/api/v1/cloud/connectors/{name}")
     assert resp.status_code == 200
     body = resp.json()
     assert body["name"] == name
@@ -246,5 +249,5 @@ async def test_get_detail_includes_actions(client_a: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_get_detail_404(client_a: AsyncClient):
-    resp = await client_a.get("/api/v1/connectors/not-real")
+    resp = await client_a.get("/api/v1/cloud/connectors/not-real")
     assert resp.status_code == 404


### PR DESCRIPTION
First land of the connector layer Phase 1. Strategy is locked at `ee/cloud/connectors/CHARTER.md` — this PR adds tenanted state and a workspace-scoped cloud REST router. **No protocol changes yet, no behavior change to the existing four layers.**

## Why now

Connectors live in four places today (YAML specs, `src/pocketpaw/connectors/` runtime, `src/pocketpaw/integrations/` HTTP clients, `tools/builtin/` agent tools). Drive lives in all four; Gmail in three; Stripe in only YAML. Five consumers (KB, agent tools, home widgets, automations, soul memory) each reach into a different layer.

Phase 1 consolidates everything behind one protocol inside pocketpaw. Phase 2 extracts to `paw-connectors/` as a workspace sibling once the protocol stabilizes. This is the first of three load-bearing PRs.

## What landed

- `ee/cloud/connectors/` following the 4-file shape:
  - `domain.py` — `WorkspaceConnector` + `AvailableConnector` frozen dataclasses
  - `dto.py` — split request/response Pydantic models
  - `service.py` — module-level async API: `list / get / enable / disable / update_config / record_sync`
  - `router.py` — REST endpoints under `/api/v1/cloud/connectors`
- `ee/cloud/models/connector.py` — `WorkspaceConnector` Beanie document, one row per `(workspace, name)`
- Registered in `ALL_DOCUMENTS` so `init_beanie` picks it up
- `mount_cloud()` includes the new router alongside pockets / agents / etc.
- 12 contract tests covering list / enable / disable / config patch / detail, plus tenancy isolation and scope validation

## Path coexistence (the important call)

The legacy `src/pocketpaw/api/v1/connectors.py` owns `/api/v1/connectors` for **pocket-scoped** operations (`connect / disconnect / execute / status`) used by `PocketDataPanel.svelte`. `mount_cloud(app)` runs **before** `mount_v1_routers(app)` per `dashboard.py:214`, so a same-path cloud router would shadow the legacy `GET` and break `PocketDataPanel`'s pocket-scoped list.

Solution: cloud router lives at `/api/v1/cloud/connectors` instead. The two surfaces coexist:

| Path | Scope | Owner |
|---|---|---|
| `/api/v1/connectors` (and sub-routes) | pocket-scoped | legacy `api/v1/connectors.py` — untouched |
| `/api/v1/cloud/connectors` | workspace-scoped | new cloud entity (this PR) |

The home-widget integration in PR-2 onwards calls `/api/v1/cloud/connectors`. `PocketDataPanel` migrates to the cloud entity later (its own PR), and the legacy path retires once nothing else points at it.

## Cloud rules followed

Per `pocketpaw/CLAUDE.md` ee/cloud section:
- entity has the 4-file shape with no `repositories.py`
- writes go through `service.py` only; routers never import models
- domain value objects are frozen with required `workspace_id`
- DTOs split between request and response
- service signature is `async def op(workspace_id, body) -> response`
- body validated with `model_validate` at the entry of every write
- every read filters by `workspace_id`
- mapping helpers live in `service.py`
- every state-mutating function emits an `event_bus` event
- errors raised as `CloudError` subclasses, never `HTTPException`

## What's NOT in this PR

- `Connector.widgets()` and `Connector.health()` protocol additions → PR-2
- Gmail adopting the protocol as the reference implementation → PR-3
- Frontend changes — `paw-enterprise` keeps working unchanged
- Token bytes in Mongo — stays local in `token_store.py` for Phase 1
- Calendar / Docs / Drive / Reddit / Spotify migration → PR-4 through PR-8
- `PocketDataPanel` migration to the cloud entity → its own PR after PR-2

## Test plan

- [x] 12 new contract tests pass (`tests/cloud/test_connectors_router.py`)
- [x] All 87 connector-related tests across `tests/v1` + `tests/cloud` + `tests/cloud/test_e2e_connector_to_fabric.py` pass
- [x] 1673 tests in `tests/cloud/` pass (one pre-existing failure unrelated: `test_agent_bridge_does_not_import_ws_manager_broadcast_directly` hard-codes a Windows path `D:/paw/backend/...`)
- [x] `ruff check` clean on every new file
- [ ] Smoke against the running stack: open `PocketDataPanel` from a pocket, confirm same connector list as before (pocket-scoped, legacy path still wins)
- [ ] Smoke: `curl /api/v1/cloud/connectors` returns the new wire shape; `curl /api/v1/connectors?pocket_id=X` still returns pocket-scoped data