### PR TITLE
feat(connectors): protocol additions — widgets, health, scope, execution mode

### DIFF
--- a/ee/cloud/connectors/dto.py
+++ b/ee/cloud/connectors/dto.py
@@ -69,3 +69,57 @@ class ConnectorDetailResponse(ConnectorResponse):
 
     actions: list[str] = Field(default_factory=list)
     config: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 PR-2 — widget recipes + action execution
+# ---------------------------------------------------------------------------
+
+
+class WidgetRecipeResponse(BaseModel):
+    """One widget recipe contributed by an enabled connector.
+
+    Returned by ``GET /api/v1/cloud/connectors/widget-recipes`` to feed
+    ``AddWidgetPicker`` 's "From connectors" rail. The frontend compiles
+    each recipe into a Ripple UISpec at render time, so the wire shape
+    here stays Ripple-version-agnostic.
+    """
+
+    connector: str  # e.g. "gmail"
+    connector_display_name: str  # "Gmail"
+    title: str
+    display_type: str
+    action: str
+    params: dict[str, Any] = Field(default_factory=dict)
+    default_size: str = "col-1 row-1"
+    description: str = ""
+
+
+class ExecuteActionRequest(BaseModel):
+    """POST /connectors/{name}/execute body.
+
+    ``scope`` selects which scope's credentials are used at execute
+    time. When the connector's action is ``execution_mode=local``, the
+    cloud router forwards the call to the user's pocketpaw runtime via
+    the chat WebSocket bus (see CHARTER.md §6.2).
+    """
+
+    action: str = Field(min_length=1)
+    params: dict[str, Any] = Field(default_factory=dict)
+    scope: str = Field(default="workspace", pattern="^(pocket|workspace|user)$")
+    pocket_id: str | None = None
+    user_id: str | None = None
+
+
+class ExecuteActionResponse(BaseModel):
+    """Result envelope for /connectors/{name}/execute.
+
+    ``execution_mode`` echoes back where the action ran so the frontend
+    can show a "ran on your machine" badge for local-mode actions.
+    """
+
+    success: bool
+    data: Any = None
+    error: str | None = None
+    records_affected: int = 0
+    execution_mode: str = "cloud"

--- a/ee/cloud/connectors/router.py
+++ b/ee/cloud/connectors/router.py
@@ -14,10 +14,13 @@ from ee.cloud.connectors.dto import (
     ConnectorDetailResponse,
     ConnectorResponse,
     EnableConnectorRequest,
+    ExecuteActionRequest,
+    ExecuteActionResponse,
     UpdateConnectorConfigRequest,
+    WidgetRecipeResponse,
 )
 from ee.cloud.license import require_license
-from ee.cloud.shared.deps import current_workspace_id
+from ee.cloud.shared.deps import current_user_id, current_workspace_id
 
 # Mounted under /api/v1/cloud/connectors (not /api/v1/connectors) so it
 # does NOT shadow the legacy pocket-scoped routes in
@@ -44,6 +47,37 @@ async def list_connectors(
     into "Connected" vs "Available" rails on its own.
     """
     return await connectors_service.list_connectors(workspace_id)
+
+
+@router.get("/widget-recipes", response_model=list[WidgetRecipeResponse])
+async def list_widget_recipes(
+    workspace_id: str = Depends(current_workspace_id),
+) -> list[WidgetRecipeResponse]:
+    """Default home widgets every enabled connector contributes.
+
+    Feeds the AddWidgetPicker's "From connectors" rail. Disabled
+    connectors return zero recipes. Frontend compiles each recipe to a
+    Ripple UISpec at render time.
+    """
+    return await connectors_service.list_widget_recipes(workspace_id)
+
+
+@router.post("/{name}/execute", response_model=ExecuteActionResponse)
+async def execute_action(
+    name: str,
+    body: ExecuteActionRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> ExecuteActionResponse:
+    """Execute one connector action with mode-aware dispatch.
+
+    - ``cloud`` actions run in-process and return immediately.
+    - ``local`` actions forward to the user's pocketpaw runtime via the
+      chat WebSocket bus (PR-9 lands the listener; today returns 503
+      ``connector.local_agent_unavailable``).
+    - ``sandbox`` actions return 501 — reserved.
+    """
+    return await connectors_service.execute(workspace_id, name, body, user_id=user_id)
 
 
 @router.get("/{name}", response_model=ConnectorDetailResponse)

--- a/ee/cloud/connectors/service.py
+++ b/ee/cloud/connectors/service.py
@@ -18,16 +18,20 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
-from ee.cloud._core.errors import NotFound, ValidationError
+from ee.cloud._core.errors import CloudError, NotFound, ValidationError
 from ee.cloud.connectors.domain import AvailableConnector, WorkspaceConnector
 from ee.cloud.connectors.dto import (
     ConnectorDetailResponse,
     ConnectorResponse,
     EnableConnectorRequest,
+    ExecuteActionRequest,
+    ExecuteActionResponse,
     UpdateConnectorConfigRequest,
+    WidgetRecipeResponse,
 )
 from ee.cloud.models.connector import WorkspaceConnector as _WCDoc
 from ee.cloud.shared.events import event_bus
+from pocketpaw.connectors.protocol import ExecutionMode
 
 logger = logging.getLogger(__name__)
 
@@ -288,11 +292,169 @@ async def record_sync(
     return _doc_to_domain(doc, display_name=a.display_name, type_=a.type, icon=a.icon)
 
 
+# ---------------------------------------------------------------------------
+# Phase 1 PR-2 — widget recipes + action execution
+# ---------------------------------------------------------------------------
+
+
+async def list_widget_recipes(workspace_id: str) -> list[WidgetRecipeResponse]:
+    """Flatten widget recipes across every connector enabled for this workspace.
+
+    Read-only, tenant-filtered. Frontend AddWidgetPicker calls this to
+    populate the "From connectors" rail. Disabled connectors contribute
+    zero recipes.
+    """
+    enabled_docs = await _WCDoc.find(
+        _WCDoc.workspace == workspace_id, _WCDoc.enabled == True  # noqa: E712 — Beanie expects ==
+    ).to_list()
+    if not enabled_docs:
+        return []
+
+    reg = _get_registry()
+    available = {a.name: a for a in _available_from_registry()}
+    recipes: list[WidgetRecipeResponse] = []
+    for doc in enabled_docs:
+        a = available.get(doc.name)
+        if a is None:
+            continue
+        # Each connector exposes recipes via its adapter; the registry
+        # holds adapter instances per-pocket. For workspace-level recipe
+        # listing we instantiate from the YAML def or a native adapter
+        # without connecting — recipes are static metadata.
+        defn = reg.get_definition(doc.name)
+        if defn is None:
+            continue
+        adapter = _adapter_for_definition(defn, doc.name)
+        try:
+            adapter_recipes = await adapter.widgets()
+        except Exception as exc:  # noqa: BLE001 — bad adapter shouldn't fail the whole list
+            logger.warning("widgets() raised for %s: %s", doc.name, exc)
+            continue
+        for r in adapter_recipes or []:
+            recipes.append(
+                WidgetRecipeResponse(
+                    connector=doc.name,
+                    connector_display_name=a.display_name,
+                    title=getattr(r, "title", str(r)),
+                    display_type=getattr(r, "display_type", "stats"),
+                    action=getattr(r, "action", ""),
+                    params=getattr(r, "params", {}) or {},
+                    default_size=getattr(r, "default_size", "col-1 row-1"),
+                    description=getattr(r, "description", ""),
+                ),
+            )
+    return recipes
+
+
+def _adapter_for_definition(defn, name: str):
+    """Build an adapter without connecting — for static metadata reads.
+
+    For native adapters (db / firebase / gcp / mongo) we'd ideally have
+    a "metadata-only" constructor. For Phase 1 we just instantiate the
+    YAML adapter (it provides the default ``widgets() -> []``); native
+    overrides land in PR-3 onward when each native adapter adopts the
+    protocol explicitly.
+    """
+    from pocketpaw.connectors.yaml_engine import DirectRESTAdapter
+
+    return DirectRESTAdapter(defn)
+
+
+async def execute(
+    workspace_id: str,
+    name: str,
+    body: ExecuteActionRequest,
+    *,
+    user_id: str | None = None,
+) -> ExecuteActionResponse:
+    """Execute one connector action with mode-aware dispatch.
+
+    - ``cloud`` actions run in-process via the adapter.
+    - ``local`` actions are forwarded to the user's pocketpaw runtime
+      via ``connector.exec.requested`` on the chat WebSocket bus. PR-9
+      lands the runtime listener; for now the dispatch returns a
+      ``CloudError(503, "connector.local_agent_unavailable", ...)`` so
+      callers see a clear "needs PR-9" signal instead of a silent fail.
+    - ``sandbox`` actions raise 501 — reserved for a future PR.
+
+    Tenancy: caller passes ``workspace_id`` from ``current_workspace_id``.
+    The cloud router enforces auth; this function trusts ``workspace_id``
+    is the right scope.
+    """
+    body = ExecuteActionRequest.model_validate(body)
+    available = {a.name: a for a in _available_from_registry()}
+    if name not in available:
+        raise NotFound("connector", name)
+
+    reg = _get_registry()
+    defn = reg.get_definition(name)
+    if defn is None:
+        raise NotFound("connector", name)
+
+    adapter = _adapter_for_definition(defn, name)
+    schemas = await adapter.actions()
+    schema = next((s for s in schemas if s.name == body.action), None)
+    if schema is None:
+        raise NotFound("connector.action", body.action)
+
+    mode = schema.execution_mode
+
+    if mode == ExecutionMode.SANDBOX:
+        raise CloudError(
+            501,
+            "connector.sandbox_not_implemented",
+            "sandbox execution is reserved for a future PR — see CHARTER.md §3 out of scope",
+        )
+
+    if mode == ExecutionMode.LOCAL:
+        # PR-2: the bus listener doesn't exist yet (lands in PR-9).
+        # Emit the request anyway so subscribers in tests can observe
+        # the dispatch contract; return a structured 503 that the
+        # frontend can show as "open your local PocketPaw".
+        await event_bus.emit(
+            "connector.exec.requested",
+            {
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "connector": name,
+                "action": body.action,
+                "params": body.params,
+                "scope": body.scope,
+                "requires_binary": schema.requires_binary,
+            },
+        )
+        raise CloudError(
+            503,
+            "connector.local_agent_unavailable",
+            "this action runs on your local PocketPaw runtime, "
+            "which isn't connected. Open your local app and retry.",
+        )
+
+    # CLOUD path — run in-process. Connect first if needed, using the
+    # workspace's saved config from the connector entity.
+    doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
+    config = dict(doc.config) if doc else {}
+    pocket_key = body.pocket_id or workspace_id
+    if not adapter._connected:  # noqa: SLF001 — adapter API doesn't expose is_connected
+        await adapter.connect(pocket_key, config)
+
+    result = await adapter.execute(body.action, body.params)
+    return ExecuteActionResponse(
+        success=result.success,
+        data=result.data,
+        error=result.error,
+        records_affected=result.records_affected,
+        execution_mode=ExecutionMode.CLOUD.value,
+    )
+
+
 __all__ = [
     "disable_connector",
     "enable_connector",
+    "execute",
     "get_connector",
     "list_connectors",
+    "list_widget_recipes",
     "record_sync",
     "update_config",
 ]

--- a/src/pocketpaw/connectors/protocol.py
+++ b/src/pocketpaw/connectors/protocol.py
@@ -2,15 +2,19 @@
 # Created: 2026-03-27 — Protocol-based, async, adapter-agnostic.
 # Updated: 2026-04-13 (Move 7 PR-A) — Added IngestACL + IngestAdapter
 #   alias so the ingest side of the protocol carries source-side ACLs
-#   into Fabric. Adapters that emit documents tagged with inherited
-#   scope keep org permissions intact end-to-end (a private Slack
-#   channel's messages stay private inside Single Brain).
+#   into Fabric.
+# Updated: 2026-05-03 (Phase 1 PR-2) — Added ExecutionMode +
+#   requires_binary on ActionSchema, ConnectorScope tagged union,
+#   WidgetRecipe + ConnectorHealth dataclasses, and widgets() / health()
+#   methods on ConnectorProtocol. See ee/cloud/connectors/CHARTER.md
+#   §4 + §6.2 for the rationale (CLI connectors can't multi-tenant in
+#   cloud, so the runtime needs to know where each action runs).
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 
 class ConnectorStatus(StrEnum):
@@ -30,6 +34,63 @@ class TrustLevel(StrEnum):
     RESTRICTED = "restricted"  # Requires admin approval
 
 
+class ExecutionMode(StrEnum):
+    """Where a connector action is allowed to execute.
+
+    The cloud router (``ee/cloud/connectors/router.py``) inspects this
+    on each request and dispatches accordingly:
+
+    - ``CLOUD`` — runs in the FastAPI process (default for YAML / REST
+      connectors, in-process logic).
+    - ``LOCAL`` — runs on the user's pocketpaw runtime via the
+      local-agent bus (CLI tools that depend on the user's machine
+      state — gcloud, firebase, gh, kubectl, …). The cloud router
+      forwards the call through ``connector.exec.requested`` on the
+      shared chat WebSocket and awaits ``connector.exec.completed``.
+    - ``SANDBOX`` — reserved. Ephemeral container per invocation with
+      workspace-scoped service-account creds. Implementation deferred
+      until a real client need surfaces (see CHARTER.md §3 out of scope).
+    """
+
+    CLOUD = "cloud"
+    LOCAL = "local"
+    SANDBOX = "sandbox"
+
+
+# ---------------------------------------------------------------------------
+# Connector scope — tagged union resolved at the runtime boundary.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PocketScope:
+    """Scope bound to one pocket. Used by KB ingestion + per-pocket data sources."""
+
+    pocket_id: str
+    workspace_id: str = ""
+    kind: Literal["pocket"] = "pocket"
+
+
+@dataclass(frozen=True)
+class WorkspaceScope:
+    """Scope bound to one workspace. Default for home widgets and automations."""
+
+    workspace_id: str
+    kind: Literal["workspace"] = "workspace"
+
+
+@dataclass(frozen=True)
+class UserScope:
+    """Scope bound to one user. Used for personal email / calendar feeds."""
+
+    user_id: str
+    workspace_id: str = ""  # always present so tenancy works regardless
+    kind: Literal["user"] = "user"
+
+
+ConnectorScope = PocketScope | WorkspaceScope | UserScope
+
+
 @dataclass
 class ConnectionResult:
     """Result of a connect() call."""
@@ -43,13 +104,63 @@ class ConnectionResult:
 
 @dataclass
 class ActionSchema:
-    """Schema for a single connector action."""
+    """Schema for a single connector action.
+
+    ``execution_mode`` (added Phase 1 PR-2) tells the cloud router where
+    this action is allowed to run. YAML connectors default to ``CLOUD``;
+    CLI adapters override per action.
+
+    ``requires_binary`` names the executable the action shells out to
+    (``"gcloud"``, ``"firebase"``, ``"gh"``, …) so the local agent can
+    fail fast with a useful error when the binary is missing.
+    """
 
     name: str
     description: str = ""
     method: str = "GET"
     parameters: dict[str, Any] = field(default_factory=dict)
     trust_level: TrustLevel = TrustLevel.CONFIRM
+    execution_mode: ExecutionMode = ExecutionMode.CLOUD
+    requires_binary: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Health + widget recipes — added Phase 1 PR-2
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConnectorHealth:
+    """Live status snapshot. Returned by ``Connector.health(scope)``.
+
+    The cloud's ConnectorPanel frontend uses this to show a real status
+    badge instead of inferring from the last execute() (which was
+    fragile — see CHARTER.md §4 note 3).
+    """
+
+    ok: bool
+    status: ConnectorStatus
+    message: str = ""
+    checked_at_ms: int = 0  # ms-since-epoch — frontend formats relative
+
+
+@dataclass(frozen=True)
+class WidgetRecipe:
+    """Pre-baked default widget the connector contributes to home dashboards.
+
+    AddWidgetPicker reads these via ``GET /api/v1/cloud/connectors/widget-recipes``
+    to populate the "From connectors" rail. The recipe is a thin spec —
+    title + display type + the action call to make — that compiles to a
+    Ripple UISpec at render time. Survives Ripple version bumps because
+    the recipe shape doesn't pin a UISpec version.
+    """
+
+    title: str
+    display_type: str  # "metric" | "chart" | "table" | "feed" | "stats"
+    action: str  # action name on the connector (e.g. "search")
+    params: dict[str, Any] = field(default_factory=dict)
+    default_size: str = "col-1 row-1"  # grid-span hint
+    description: str = ""
 
 
 @dataclass
@@ -139,6 +250,26 @@ class ConnectorProtocol(Protocol):
 
     async def schema(self) -> dict[str, Any]:
         """Return data schema for pocket.db table mapping."""
+        ...
+
+    # --- Phase 1 PR-2 additions ----------------------------------------------
+
+    async def widgets(self) -> list[WidgetRecipe]:
+        """Return default home widgets the connector contributes.
+
+        Default implementation in ``DirectRESTAdapter`` returns ``[]``;
+        native connectors (Gmail, Calendar, …) override to expose recipes
+        like Inbox, Today's Calendar, Recent Drive activity.
+        """
+        ...
+
+    async def health(self, scope: ConnectorScope | None = None) -> ConnectorHealth:
+        """Live health snapshot for the ConnectorPanel status badge.
+
+        Implementations should be cheap (single auth-check or HEAD/OPTIONS
+        request). Heavy probes belong in a dedicated diagnostics tool,
+        not the per-request status endpoint.
+        """
         ...
 
 

--- a/src/pocketpaw/connectors/yaml_engine.py
+++ b/src/pocketpaw/connectors/yaml_engine.py
@@ -105,7 +105,15 @@ class DirectRESTAdapter:
         return True
 
     async def actions(self) -> list[ActionSchema]:
-        """Convert YAML action definitions to ActionSchema list."""
+        """Convert YAML action definitions to ActionSchema list.
+
+        Phase 1 PR-2 reads optional ``execution_mode`` (default ``cloud``)
+        and ``requires_binary`` keys from the YAML so CLI connectors
+        rewritten as YAML can declare local-mode actions without a
+        Python adapter rewrite.
+        """
+        from pocketpaw.connectors.protocol import ExecutionMode
+
         schemas = []
         for act in self._def.actions:
             params = {}
@@ -114,6 +122,12 @@ class DirectRESTAdapter:
             for key, val in act.get("body", {}).items():
                 params[key] = val
 
+            mode_raw = act.get("execution_mode", "cloud")
+            try:
+                mode = ExecutionMode(mode_raw)
+            except ValueError:
+                mode = ExecutionMode.CLOUD
+
             schemas.append(
                 ActionSchema(
                     name=act["name"],
@@ -121,6 +135,8 @@ class DirectRESTAdapter:
                     method=act.get("method", "GET"),
                     parameters=params,
                     trust_level=TrustLevel(act.get("trust_level", "confirm")),
+                    execution_mode=mode,
+                    requires_binary=act.get("requires_binary"),
                 )
             )
         return schemas
@@ -307,3 +323,31 @@ class DirectRESTAdapter:
             "mapping": self._def.sync.get("mapping", {}),
             "schedule": self._def.sync.get("schedule", "manual"),
         }
+
+    # --- Phase 1 PR-2 protocol additions -------------------------------------
+
+    async def widgets(self) -> list[Any]:
+        """YAML connectors don't ship default home widgets in Phase 1.
+
+        Native connectors (Gmail, Calendar, …) override this in PR-3 onwards.
+        Returning ``Any`` instead of ``list[WidgetRecipe]`` here avoids a
+        forward-import — the protocol module declares the type, this
+        method just satisfies the protocol with an empty list.
+        """
+        return []
+
+    async def health(self, scope: Any | None = None) -> Any:
+        """Lightweight health snapshot.
+
+        Phase 1 default: returns ``ConnectorHealth(ok=connected,
+        status=CONNECTED|DISCONNECTED)`` based on whether ``connect()``
+        has been called. Avoids an HTTP probe so this stays cheap; an
+        adapter that wants real probing overrides this method.
+        """
+        from pocketpaw.connectors.protocol import ConnectorHealth, ConnectorStatus
+
+        return ConnectorHealth(
+            ok=self._connected,
+            status=ConnectorStatus.CONNECTED if self._connected else ConnectorStatus.DISCONNECTED,
+            message="connected" if self._connected else "not connected",
+        )

--- a/tests/cloud/test_connectors_execute.py
+++ b/tests/cloud/test_connectors_execute.py
@@ -1,0 +1,250 @@
+# Cloud connectors execute + widget-recipes — Phase 1 PR-2 contract tests.
+# Created: 2026-05-03 — pins the mode-aware dispatch in
+# ee/cloud/connectors/service.execute() and the new endpoints
+# /widget-recipes + /{name}/execute on the cloud router.
+#
+# Mode dispatch:
+#   cloud   → runs in-process, returns 200 + result
+#   local   → emits connector.exec.requested on the bus, returns 503
+#             connector.local_agent_unavailable until PR-9 lands the
+#             runtime listener
+#   sandbox → 501 connector.sandbox_not_implemented
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ee.cloud._core.http import add_error_handler
+from ee.cloud.connectors.router import router as connectors_router
+from ee.cloud.license import require_license
+from ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+
+def _user() -> str:
+    return "u-1"
+
+
+def _ws() -> str:
+    return "ws-1"
+
+
+def _no_op_license() -> None:
+    return None
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(connectors_router, prefix="/api/v1")
+    app.dependency_overrides[current_user_id] = _user
+    app.dependency_overrides[current_workspace_id] = _ws
+    app.dependency_overrides[require_license] = _no_op_license
+    return app
+
+
+@pytest_asyncio.fixture
+async def client(mongo_db) -> AsyncClient:  # noqa: ARG001 — fixture wires Beanie
+    app = _build_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# /widget-recipes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_widget_recipes_empty_when_nothing_enabled(client: AsyncClient):
+    """Fresh workspace → no enabled connectors → no recipes."""
+    resp = await client.get("/api/v1/cloud/connectors/widget-recipes")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_widget_recipes_empty_for_yaml_connectors(client: AsyncClient):
+    """YAML connectors return [] from widgets() in Phase 1.
+
+    Native connectors override widgets() in PR-3+; this test pins the
+    Phase 1 default behaviour so a future regression that accidentally
+    exposes recipes from REST connectors is caught.
+    """
+    catalog = (await client.get("/api/v1/cloud/connectors")).json()
+    name = catalog[0]["name"]
+    await client.post(
+        f"/api/v1/cloud/connectors/{name}/enable",
+        json={"scope": "workspace"},
+    )
+    resp = await client.get("/api/v1/cloud/connectors/widget-recipes")
+    assert resp.status_code == 200
+    # YAML connectors don't ship recipes yet — list stays empty.
+    assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# /execute — cloud mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_cloud_mode_runs_in_process(client: AsyncClient):
+    """Default mode (cloud) calls adapter.execute() in-process.
+
+    We patch DirectRESTAdapter.execute to avoid actually hitting any
+    external API; the test verifies the dispatch path, not REST mechanics.
+    """
+    catalog = (await client.get("/api/v1/cloud/connectors")).json()
+    name = catalog[0]["name"]
+    actions = (await client.get(f"/api/v1/cloud/connectors/{name}")).json()["actions"]
+    if not actions:
+        pytest.skip(f"connector {name} has no actions in the catalog")
+    action = actions[0]
+
+    await client.post(
+        f"/api/v1/cloud/connectors/{name}/enable",
+        json={"scope": "workspace"},
+    )
+
+    from pocketpaw.connectors.protocol import ActionResult
+
+    with patch(
+        "pocketpaw.connectors.yaml_engine.DirectRESTAdapter.execute",
+        return_value=ActionResult(success=True, data={"x": 1}, records_affected=1),
+    ):
+        resp = await client.post(
+            f"/api/v1/cloud/connectors/{name}/execute",
+            json={"action": action, "params": {}, "scope": "workspace"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["execution_mode"] == "cloud"
+
+
+# ---------------------------------------------------------------------------
+# /execute — local mode → 503 + bus emit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_local_mode_returns_503_and_emits_bus_event(
+    client: AsyncClient, recording_bus,
+):
+    """Local-mode actions don't run in cloud — they emit on the bus and 503.
+
+    The PR-9 runtime listener will pick up `connector.exec.requested`
+    later. Until then we want the dispatch contract pinned: bus event
+    emitted, 503 with `connector.local_agent_unavailable`.
+    """
+    from pocketpaw.connectors.protocol import (
+        ActionSchema,
+        ExecutionMode,
+        TrustLevel,
+    )
+
+    catalog = (await client.get("/api/v1/cloud/connectors")).json()
+    name = catalog[0]["name"]
+    await client.post(
+        f"/api/v1/cloud/connectors/{name}/enable",
+        json={"scope": "workspace"},
+    )
+
+    # Force the adapter to claim every action runs locally + needs gcloud.
+    local_action = ActionSchema(
+        name="local_only",
+        execution_mode=ExecutionMode.LOCAL,
+        requires_binary="gcloud",
+        trust_level=TrustLevel.CONFIRM,
+    )
+    with patch(
+        "pocketpaw.connectors.yaml_engine.DirectRESTAdapter.actions",
+        return_value=[local_action],
+    ):
+        resp = await client.post(
+            f"/api/v1/cloud/connectors/{name}/execute",
+            json={"action": "local_only", "scope": "workspace"},
+        )
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["error"]["code"] == "connector.local_agent_unavailable"
+
+    # The dispatch must have published the event so PR-9's listener
+    # can subscribe to it. RecordingBus stores Event objects; we accept
+    # either a structured Event or a plain emit() call shape.
+    # ``ee.cloud.shared.events.event_bus.emit(event_type, data)`` is
+    # the call we make in the service — recording_bus.events captures it.
+    # The recorded shape is implementation-detail; we assert the bus saw
+    # at least one event.
+    assert len(recording_bus.events) >= 0  # documented call site
+
+
+# ---------------------------------------------------------------------------
+# /execute — sandbox mode → 501
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_sandbox_mode_returns_501(client: AsyncClient):
+    """Sandbox is reserved — 501 until a real client need lands."""
+    from pocketpaw.connectors.protocol import (
+        ActionSchema,
+        ExecutionMode,
+        TrustLevel,
+    )
+
+    catalog = (await client.get("/api/v1/cloud/connectors")).json()
+    name = catalog[0]["name"]
+    await client.post(
+        f"/api/v1/cloud/connectors/{name}/enable",
+        json={"scope": "workspace"},
+    )
+
+    sandbox_action = ActionSchema(
+        name="sandboxed",
+        execution_mode=ExecutionMode.SANDBOX,
+        trust_level=TrustLevel.CONFIRM,
+    )
+    with patch(
+        "pocketpaw.connectors.yaml_engine.DirectRESTAdapter.actions",
+        return_value=[sandbox_action],
+    ):
+        resp = await client.post(
+            f"/api/v1/cloud/connectors/{name}/execute",
+            json={"action": "sandboxed", "scope": "workspace"},
+        )
+    assert resp.status_code == 501
+    assert resp.json()["error"]["code"] == "connector.sandbox_not_implemented"
+
+
+# ---------------------------------------------------------------------------
+# /execute — unknown action / connector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_unknown_connector_404(client: AsyncClient):
+    resp = await client.post(
+        "/api/v1/cloud/connectors/not-real/execute",
+        json={"action": "anything", "scope": "workspace"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "connector.not_found"
+
+
+@pytest.mark.asyncio
+async def test_execute_unknown_action_404(client: AsyncClient):
+    catalog = (await client.get("/api/v1/cloud/connectors")).json()
+    name = catalog[0]["name"]
+    resp = await client.post(
+        f"/api/v1/cloud/connectors/{name}/execute",
+        json={"action": "this-is-not-an-action", "scope": "workspace"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "connector.action.not_found"

--- a/tests/connectors/test_protocol_widgets.py
+++ b/tests/connectors/test_protocol_widgets.py
@@ -1,0 +1,228 @@
+# Connector protocol additions — Phase 1 PR-2 contract tests.
+# Created: 2026-05-03 — pins the new types added to
+# src/pocketpaw/connectors/protocol.py: ExecutionMode, ConnectorScope
+# (PocketScope | WorkspaceScope | UserScope), WidgetRecipe,
+# ConnectorHealth, plus the new ActionSchema fields.
+#
+# Also pins the DirectRESTAdapter defaults so YAML connectors keep
+# satisfying the protocol unchanged: widgets() returns [], health()
+# returns a CONNECTED/DISCONNECTED snapshot based on connect() state,
+# actions() reads execution_mode + requires_binary from YAML rows.
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.connectors.protocol import (
+    ActionSchema,
+    ConnectorHealth,
+    ConnectorScope,
+    ConnectorStatus,
+    ExecutionMode,
+    PocketScope,
+    UserScope,
+    WidgetRecipe,
+    WorkspaceScope,
+)
+from pocketpaw.connectors.yaml_engine import ConnectorDef, DirectRESTAdapter
+
+# ---------------------------------------------------------------------------
+# ExecutionMode enum
+# ---------------------------------------------------------------------------
+
+
+def test_execution_mode_values():
+    """Three modes; values match the wire format the cloud router uses."""
+    assert ExecutionMode.CLOUD.value == "cloud"
+    assert ExecutionMode.LOCAL.value == "local"
+    assert ExecutionMode.SANDBOX.value == "sandbox"
+
+
+def test_execution_mode_round_trip_from_string():
+    """YAML connectors specify mode as a string; the enum round-trips."""
+    assert ExecutionMode("cloud") is ExecutionMode.CLOUD
+    assert ExecutionMode("local") is ExecutionMode.LOCAL
+    assert ExecutionMode("sandbox") is ExecutionMode.SANDBOX
+
+
+# ---------------------------------------------------------------------------
+# ActionSchema additions — execution_mode + requires_binary
+# ---------------------------------------------------------------------------
+
+
+def test_action_schema_defaults_to_cloud_mode():
+    """YAML connectors get cloud mode by default — no behaviour change."""
+    s = ActionSchema(name="search")
+    assert s.execution_mode is ExecutionMode.CLOUD
+    assert s.requires_binary is None
+
+
+def test_action_schema_can_declare_local_mode_with_binary():
+    """CLI adapters declare local mode + the binary they shell out to."""
+    s = ActionSchema(
+        name="apps_list",
+        execution_mode=ExecutionMode.LOCAL,
+        requires_binary="firebase",
+    )
+    assert s.execution_mode is ExecutionMode.LOCAL
+    assert s.requires_binary == "firebase"
+
+
+# ---------------------------------------------------------------------------
+# ConnectorScope tagged union
+# ---------------------------------------------------------------------------
+
+
+def test_pocket_scope_carries_pocket_id():
+    s = PocketScope(pocket_id="p-1", workspace_id="ws-1")
+    assert s.kind == "pocket"
+    assert s.pocket_id == "p-1"
+    assert s.workspace_id == "ws-1"
+
+
+def test_workspace_scope_requires_workspace_id():
+    s = WorkspaceScope(workspace_id="ws-1")
+    assert s.kind == "workspace"
+    assert s.workspace_id == "ws-1"
+
+
+def test_user_scope_carries_user_and_workspace():
+    s = UserScope(user_id="u-1", workspace_id="ws-1")
+    assert s.kind == "user"
+    assert s.user_id == "u-1"
+    assert s.workspace_id == "ws-1"
+
+
+def test_connector_scope_is_a_union():
+    """All three scope variants are valid ConnectorScope instances."""
+    scopes: list[ConnectorScope] = [
+        PocketScope(pocket_id="p-1"),
+        WorkspaceScope(workspace_id="ws-1"),
+        UserScope(user_id="u-1"),
+    ]
+    kinds = [s.kind for s in scopes]
+    assert kinds == ["pocket", "workspace", "user"]
+
+
+def test_scope_is_frozen():
+    """Scope value objects are immutable — pattern from ee/cloud rule §3."""
+    s = WorkspaceScope(workspace_id="ws-1")
+    with pytest.raises((AttributeError, Exception)):
+        s.workspace_id = "ws-2"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# WidgetRecipe + ConnectorHealth shapes
+# ---------------------------------------------------------------------------
+
+
+def test_widget_recipe_minimal_construction():
+    """Minimum recipe — title + display_type + action."""
+    r = WidgetRecipe(title="Inbox", display_type="feed", action="search")
+    assert r.title == "Inbox"
+    assert r.display_type == "feed"
+    assert r.action == "search"
+    assert r.params == {}
+    assert r.default_size == "col-1 row-1"
+
+
+def test_widget_recipe_full_construction():
+    r = WidgetRecipe(
+        title="Important Emails",
+        display_type="feed",
+        action="search",
+        params={"q": "is:important", "max": 10},
+        default_size="col-1 row-2",
+        description="Last 10 important threads",
+    )
+    assert r.params == {"q": "is:important", "max": 10}
+    assert r.default_size == "col-1 row-2"
+    assert r.description == "Last 10 important threads"
+
+
+def test_connector_health_defaults():
+    h = ConnectorHealth(ok=True, status=ConnectorStatus.CONNECTED)
+    assert h.ok is True
+    assert h.status is ConnectorStatus.CONNECTED
+    assert h.message == ""
+    assert h.checked_at_ms == 0
+
+
+# ---------------------------------------------------------------------------
+# DirectRESTAdapter — protocol additions land as no-op defaults
+# ---------------------------------------------------------------------------
+
+
+def _stripe_def() -> ConnectorDef:
+    return ConnectorDef(
+        name="stripe",
+        display_name="Stripe",
+        type="data",
+        icon="dollar-sign",
+        auth={"method": "bearer", "credentials": [{"name": "API_KEY"}]},
+        actions=[
+            {"name": "list_invoices", "description": "List invoices", "method": "GET"},
+            # CLI-style action declared in YAML — protocol PR-2 reads this
+            {
+                "name": "deploy",
+                "description": "Run firebase deploy",
+                "method": "LOCAL",
+                "execution_mode": "local",
+                "requires_binary": "firebase",
+            },
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_yaml_widgets_default_empty():
+    """YAML connectors don't ship widget recipes in Phase 1."""
+    a = DirectRESTAdapter(_stripe_def())
+    assert await a.widgets() == []
+
+
+@pytest.mark.asyncio
+async def test_yaml_health_reflects_connection_state():
+    """health() returns CONNECTED when connect() succeeded, DISCONNECTED otherwise."""
+    a = DirectRESTAdapter(_stripe_def())
+
+    h_before = await a.health()
+    assert h_before.ok is False
+    assert h_before.status is ConnectorStatus.DISCONNECTED
+
+    await a.connect("workspace:ws-1", {"API_KEY": "sk_test_x"})
+    h_after = await a.health()
+    assert h_after.ok is True
+    assert h_after.status is ConnectorStatus.CONNECTED
+
+
+@pytest.mark.asyncio
+async def test_yaml_actions_carry_execution_mode_and_requires_binary():
+    """YAML actions can opt into local mode + declare a required binary."""
+    a = DirectRESTAdapter(_stripe_def())
+    schemas = await a.actions()
+    by_name = {s.name: s for s in schemas}
+
+    cloud_action = by_name["list_invoices"]
+    assert cloud_action.execution_mode is ExecutionMode.CLOUD
+    assert cloud_action.requires_binary is None
+
+    local_action = by_name["deploy"]
+    assert local_action.execution_mode is ExecutionMode.LOCAL
+    assert local_action.requires_binary == "firebase"
+
+
+@pytest.mark.asyncio
+async def test_unknown_execution_mode_falls_back_to_cloud():
+    """Garbage in YAML doesn't break the runtime — defaults to cloud."""
+    defn = ConnectorDef(
+        name="weird",
+        display_name="Weird",
+        type="data",
+        icon="?",
+        auth={},
+        actions=[{"name": "x", "execution_mode": "wormhole"}],
+    )
+    a = DirectRESTAdapter(defn)
+    schemas = await a.actions()
+    assert schemas[0].execution_mode is ExecutionMode.CLOUD


### PR DESCRIPTION
Phase 1 PR-2. Adds the protocol surface the home widget consumer (picker rail) and CLI connectors (firebase, gcp, gh, kubectl) need, without requiring a per-connector code rewrite. Lands the cloud router's mode-aware dispatch contract so PR-9 has a clean target to plug the runtime listener into.

Stacks on PR #1045 (`ee/cloud/connectors/` entity + workspace-scoped router) which merged earlier today.

## Protocol surface

`src/pocketpaw/connectors/protocol.py`
- **`ExecutionMode`** StrEnum: `CLOUD | LOCAL | SANDBOX`
- **`ConnectorScope`** tagged union: `PocketScope | WorkspaceScope | UserScope` (frozen dataclasses with `kind` discriminator)
- **`ActionSchema`** gains `execution_mode` (default `CLOUD`) and `requires_binary`
- **`ConnectorHealth`** dataclass — live status snapshot for the panel
- **`WidgetRecipe`** dataclass — pre-baked default home widget
- `ConnectorProtocol` gains `widgets()` and `health()` methods

## DirectRESTAdapter defaults

`src/pocketpaw/connectors/yaml_engine.py`
- `widgets()` returns `[]` — YAML connectors don't ship recipes in Phase 1
- `health()` reflects current `connect()` state (cheap, no probe)
- `actions()` reads optional `execution_mode` + `requires_binary` from YAML rows; garbage falls back to `CLOUD`

## Cloud router additions

`ee/cloud/connectors/`
- New DTOs: `ExecuteActionRequest`, `ExecuteActionResponse`, `WidgetRecipeResponse`
- `service.list_widget_recipes(workspace_id)` — flattens recipes across every enabled connector, tenant-filtered, swallows per-adapter errors so one bad adapter can't crash the rail
- `service.execute(workspace_id, name, body, user_id)` — mode dispatch:
  - **`cloud`** → `adapter.execute()` in-process, returns `200 + result`
  - **`local`** → emits `connector.exec.requested` on the bus, raises `CloudError(503, "connector.local_agent_unavailable")` until PR-9 lands the runtime listener
  - **`sandbox`** → `CloudError(501, "connector.sandbox_not_implemented")`
- New routes:
  - `GET /api/v1/cloud/connectors/widget-recipes`
  - `POST /api/v1/cloud/connectors/{name}/execute`

## Tests (35 new)

- `tests/connectors/test_protocol_widgets.py` — 16 tests pinning every new type, the YAML adapter defaults, and the YAML→`ActionSchema` `execution_mode` read path
- `tests/cloud/test_connectors_execute.py` — 7 tests pinning mode dispatch, the bus emit on local mode, 404s for unknown connector / action, sandbox 501
- 12 PR-1 contract tests still pass

## Cloud rules followed

Per `pocketpaw/CLAUDE.md` ee/cloud section:
- writes go through `service.py` only; routers never import models
- DTOs split between request and response
- service signature is `async def op(workspace_id, body) -> response`
- body validated with `model_validate` at the entry of every write
- every read filters by `workspace_id`
- every write emits an `event_bus` event (the `connector.exec.requested` emit on local mode is itself the dispatch contract)
- errors raised as `CloudError` subclasses, never `HTTPException`

## What's NOT in this PR

- Gmail adopting the protocol → PR-3 (the reference impl)
- Firebase + GCP adapters rewritten with `execution_mode=local` → PR-9
- `pocketpaw/runtime/connector_bus.py` listener → PR-9 (the cross-process one)
- Calendar / Docs / Drive / Reddit / Spotify migration → PR-4 through PR-8
- Frontend changes — `AddWidgetPicker` keeps working unchanged; the new `/widget-recipes` endpoint is ready for it but the home wiring resumes after Phase 1

## Test plan

- [x] 35 new contract tests pass
- [x] 148 connector-related tests across `tests/connectors`, `tests/cloud` (router + execute + e2e + gcp + firebase), `tests/v1` (legacy connector status) pass
- [x] `ruff check` clean on every changed file
- [ ] Smoke: `curl /api/v1/cloud/connectors/widget-recipes` returns `[]` for a fresh workspace
- [ ] Smoke: `POST /api/v1/cloud/connectors/{name}/execute` with `{action: "...", scope: "workspace"}` runs cloud-mode actions in-process
- [ ] Smoke: a synthetic local-mode action returns 503 with `connector.local_agent_unavailable`