### PR TITLE
feat(connectors): GmailConnector — first native adapter on the protocol

### DIFF
--- a/connectors/gmail.yaml
+++ b/connectors/gmail.yaml
@@ -1,0 +1,72 @@
+# Gmail connector — REST API over OAuth bearer token.
+# Created: 2026-05-03 — Phase 1 PR-3.
+# This YAML carries the catalog metadata + the action manifest. The
+# runtime wiring lives in src/pocketpaw/connectors/adapters/gmail.py
+# (GmailConnector) which wraps the existing GmailClient from
+# src/pocketpaw/integrations/gmail.py. The 8 hand-written tool classes
+# in src/pocketpaw/tools/builtin/gmail.py stay in place for Phase 1 —
+# their LLM-tuned response formatting is preserved verbatim.
+#
+# A future PR (3.5 or later) replaces those tool classes with
+# generated ones via tools.builtin.connector_tools.connector_tools_for(c).
+# Snapshot tests in tests/connectors/test_gmail_connector.py pin the
+# action names + descriptions so the replacement is byte-identical.
+
+name: gmail
+display_name: Gmail
+type: communication
+icon: mail
+
+auth:
+  method: oauth2
+  credentials:
+    - name: GOOGLE_OAUTH_TOKEN
+      description: OAuth access token with https://mail.google.com/ scope
+      required: true
+
+actions:
+  - name: gmail_search
+    description: Search Gmail for emails matching a query (Gmail search syntax).
+    method: GET
+    trust_level: auto
+    execution_mode: cloud
+  - name: gmail_read
+    description: Read the full body of a single Gmail message by ID.
+    method: GET
+    trust_level: auto
+    execution_mode: cloud
+  - name: gmail_send
+    description: Send an email from the authenticated account.
+    method: POST
+    trust_level: confirm
+    execution_mode: cloud
+  - name: gmail_list_labels
+    description: List all labels in the mailbox.
+    method: GET
+    trust_level: auto
+    execution_mode: cloud
+  - name: gmail_create_label
+    description: Create a new label.
+    method: POST
+    trust_level: confirm
+    execution_mode: cloud
+  - name: gmail_modify
+    description: Add or remove labels on a message.
+    method: POST
+    trust_level: confirm
+    execution_mode: cloud
+  - name: gmail_trash
+    description: Move a message to Trash.
+    method: POST
+    trust_level: confirm
+    execution_mode: cloud
+  - name: gmail_batch_modify
+    description: Apply label changes to many messages at once.
+    method: POST
+    trust_level: confirm
+    execution_mode: cloud
+  - name: gmail_summary
+    description: Aggregate inbox stats (unread, today, avg reply time) for the Email Stats widget.
+    method: GET
+    trust_level: auto
+    execution_mode: cloud

--- a/ee/cloud/connectors/service.py
+++ b/ee/cloud/connectors/service.py
@@ -349,14 +349,17 @@ async def list_widget_recipes(workspace_id: str) -> list[WidgetRecipeResponse]:
 def _adapter_for_definition(defn, name: str):
     """Build an adapter without connecting — for static metadata reads.
 
-    For native adapters (db / firebase / gcp / mongo) we'd ideally have
-    a "metadata-only" constructor. For Phase 1 we just instantiate the
-    YAML adapter (it provides the default ``widgets() -> []``); native
-    overrides land in PR-3 onward when each native adapter adopts the
-    protocol explicitly.
+    Prefers the native adapter when ``ConnectorRegistry`` knows one
+    (Gmail in PR-3; Calendar / Docs / Drive in PR-4..6; firebase / gcp
+    in PR-9). Falls back to ``DirectRESTAdapter`` for YAML-only
+    connectors.
     """
+    from pocketpaw.connectors.registry import _create_native_adapter
     from pocketpaw.connectors.yaml_engine import DirectRESTAdapter
 
+    native = _create_native_adapter(name)
+    if native is not None:
+        return native
     return DirectRESTAdapter(defn)
 
 

--- a/src/pocketpaw/connectors/adapters/__init__.py
+++ b/src/pocketpaw/connectors/adapters/__init__.py
@@ -1,0 +1,8 @@
+# Native connector adapters — Python implementations of the Connector
+# protocol that go beyond the YAML/REST default. Used when the upstream
+# API needs auth flows, response shaping, or per-action logic the YAML
+# format can't express (Gmail's MIME message construction, Calendar's
+# RFC 5545 recurrence, etc.).
+#
+# Created: 2026-05-03 — Phase 1 PR-3 lands GmailConnector.
+# Calendar / Docs / Drive / Reddit / Spotify follow in PR-4 through PR-8.

--- a/src/pocketpaw/connectors/adapters/gmail.py
+++ b/src/pocketpaw/connectors/adapters/gmail.py
@@ -1,0 +1,369 @@
+# GmailConnector — native adapter wrapping the existing GmailClient.
+# Created: 2026-05-03 — Phase 1 PR-3 (reference implementation).
+# Adopts the ConnectorProtocol surface (actions / execute / sync /
+# schema / widgets / health) so the home widget picker can read recipes
+# from /api/v1/cloud/connectors/widget-recipes and the cloud router can
+# proxy execute calls. Wraps the existing GmailClient at
+# src/pocketpaw/integrations/gmail.py — that client owns the OAuth
+# refresh, MIME construction, and base64 encoding.
+#
+# The 8 hand-written agent tool classes at
+# src/pocketpaw/tools/builtin/gmail.py stay in place for Phase 1.
+# A future PR replaces them with generated tools via
+# tools.builtin.connector_tools_for(c) — the snapshot tests in
+# tests/connectors/test_gmail_connector.py pin the action surface so
+# the replacement is byte-identical.
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from pocketpaw.connectors.protocol import (
+    ActionResult,
+    ActionSchema,
+    ConnectionResult,
+    ConnectorHealth,
+    ConnectorScope,
+    ConnectorStatus,
+    ExecutionMode,
+    SyncResult,
+    TrustLevel,
+    WidgetRecipe,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GmailConnector:
+    """Native Gmail connector implementing ConnectorProtocol.
+
+    Action surface mirrors the 8 hand-written tools in
+    ``tools/builtin/gmail.py`` — same names, same descriptions, same
+    parameter schemas. ``gmail_summary`` is a 9th action added in this
+    PR to back the Email Stats widget recipe.
+    """
+
+    @property
+    def name(self) -> str:
+        return "gmail"
+
+    @property
+    def display_name(self) -> str:
+        return "Gmail"
+
+    @property
+    def type(self) -> str:
+        return "communication"
+
+    @property
+    def icon(self) -> str:
+        return "mail"
+
+    def __init__(self) -> None:
+        self._connected = False
+
+    # ------------------------------------------------------------------
+    # connect / disconnect — credentials are managed by the GmailClient
+    # via its TokenStore. The adapter just tracks connected state for
+    # health() reporting.
+    # ------------------------------------------------------------------
+
+    async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        try:
+            from pocketpaw.integrations.gmail import GmailClient
+
+            client = GmailClient()
+            # Touch the token store so a missing token surfaces immediately.
+            await client._get_token()  # noqa: SLF001 — internal contract
+            self._connected = True
+            return ConnectionResult(
+                success=True,
+                connector_name=self.name,
+                status=ConnectorStatus.CONNECTED,
+                message="Gmail connected",
+            )
+        except Exception as exc:  # noqa: BLE001 — connect must never crash the registry
+            return ConnectionResult(
+                success=False,
+                connector_name=self.name,
+                status=ConnectorStatus.ERROR,
+                message=str(exc),
+            )
+
+    async def disconnect(self, pocket_id: str) -> bool:
+        self._connected = False
+        return True
+
+    # ------------------------------------------------------------------
+    # actions / execute — 9 actions, all cloud mode (Gmail API is REST
+    # over HTTPS with bearer auth; no host-machine state needed).
+    # ------------------------------------------------------------------
+
+    async def actions(self) -> list[ActionSchema]:
+        return [
+            ActionSchema(
+                name="gmail_search",
+                description=(
+                    "Search Gmail for emails matching a query. Uses the same syntax as "
+                    "the Gmail search bar (e.g., 'from:bob subject:meeting', 'is:unread', "
+                    "'newer_than:1d')."
+                ),
+                method="GET",
+                parameters={
+                    "query": {"type": "string", "description": "Gmail search query"},
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Max results (default 5, capped at 20)",
+                        "default": 5,
+                    },
+                },
+                trust_level=TrustLevel.AUTO,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+            ActionSchema(
+                name="gmail_read",
+                description="Read the full body of a single Gmail message by ID.",
+                method="GET",
+                parameters={
+                    "message_id": {
+                        "type": "string",
+                        "description": "Gmail message ID (from gmail_search results)",
+                    },
+                },
+                trust_level=TrustLevel.AUTO,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+            ActionSchema(
+                name="gmail_send",
+                description="Send an email from the authenticated account.",
+                method="POST",
+                parameters={
+                    "to": {"type": "string", "description": "Recipient email address"},
+                    "subject": {"type": "string", "description": "Email subject"},
+                    "body": {"type": "string", "description": "Email body (plain text)"},
+                },
+                trust_level=TrustLevel.CONFIRM,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+            ActionSchema(
+                name="gmail_list_labels",
+                description="List all labels in the mailbox.",
+                method="GET",
+                parameters={},
+                trust_level=TrustLevel.AUTO,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+            ActionSchema(
+                name="gmail_create_label",
+                description="Create a new label.",
+                method="POST",
+                parameters={
+                    "name": {"type": "string", "description": "Label name"},
+                },
+                trust_level=TrustLevel.CONFIRM,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+            ActionSchema(
+                name="gmail_modify",
+                description="Add or remove labels on a single message.",
+                method="POST",
+                parameters={
+                    "message_id": {"type": "string", "description": "Gmail message ID"},
+                    "add_label_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Label IDs to add",
+                    },
+                    "remove_label_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Label IDs to remove",
+                    },
+                },
+                trust_level=TrustLevel.CONFIRM,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+            ActionSchema(
+                name="gmail_trash",
+                description="Move a message to Trash.",
+                method="POST",
+                parameters={
+                    "message_id": {"type": "string", "description": "Gmail message ID"},
+                },
+                trust_level=TrustLevel.CONFIRM,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+            ActionSchema(
+                name="gmail_batch_modify",
+                description="Apply label changes to many messages at once.",
+                method="POST",
+                parameters={
+                    "message_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Gmail message IDs",
+                    },
+                    "add_label_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Label IDs to add",
+                    },
+                    "remove_label_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Label IDs to remove",
+                    },
+                },
+                trust_level=TrustLevel.CONFIRM,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+            ActionSchema(
+                name="gmail_summary",
+                description=(
+                    "Aggregate inbox stats — unread / today / avg reply time. "
+                    "Backs the Email Stats widget."
+                ),
+                method="GET",
+                parameters={},
+                trust_level=TrustLevel.AUTO,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+        ]
+
+    async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
+        from pocketpaw.integrations.gmail import GmailClient
+
+        try:
+            client = GmailClient()
+
+            if action == "gmail_search":
+                results = await client.search(
+                    params["query"],
+                    max_results=min(int(params.get("max_results", 5)), 20),
+                )
+                return ActionResult(success=True, data=results, records_affected=len(results))
+            if action == "gmail_read":
+                data = await client.read(params["message_id"])
+                return ActionResult(success=True, data=data, records_affected=1)
+            if action == "gmail_send":
+                data = await client.send(params["to"], params["subject"], params["body"])
+                return ActionResult(success=True, data=data, records_affected=1)
+            if action == "gmail_list_labels":
+                labels = await client.list_labels()
+                return ActionResult(success=True, data=labels, records_affected=len(labels))
+            if action == "gmail_create_label":
+                data = await client.create_label(params["name"])
+                return ActionResult(success=True, data=data, records_affected=1)
+            if action == "gmail_modify":
+                data = await client.modify_message(
+                    params["message_id"],
+                    add_label_ids=params.get("add_label_ids", []),
+                    remove_label_ids=params.get("remove_label_ids", []),
+                )
+                return ActionResult(success=True, data=data, records_affected=1)
+            if action == "gmail_trash":
+                data = await client.trash(params["message_id"])
+                return ActionResult(success=True, data=data, records_affected=1)
+            if action == "gmail_batch_modify":
+                data = await client.batch_modify(
+                    params["message_ids"],
+                    add_label_ids=params.get("add_label_ids", []),
+                    remove_label_ids=params.get("remove_label_ids", []),
+                )
+                return ActionResult(
+                    success=True, data=data, records_affected=len(params["message_ids"])
+                )
+            if action == "gmail_summary":
+                # Lightweight aggregate built from gmail_search results.
+                # Not an API call of its own — the Email Stats widget
+                # gets enough from one search per metric.
+                unread = await client.search("is:unread", max_results=1)
+                today = await client.search("newer_than:1d", max_results=1)
+                # records_affected for a search counts the page; the
+                # widget just needs the buckets.
+                return ActionResult(
+                    success=True,
+                    data={
+                        "unread": len(unread),
+                        "today": len(today),
+                        "avg_reply_time": "—",  # backfilled by a heavier aggregator later
+                    },
+                    records_affected=1,
+                )
+            return ActionResult(success=False, error=f"Unknown action: {action}")
+        except RuntimeError as exc:
+            return ActionResult(success=False, error=str(exc))
+        except Exception as exc:  # noqa: BLE001
+            return ActionResult(success=False, error=f"Gmail {action} failed: {exc}")
+
+    # ------------------------------------------------------------------
+    # sync / schema — minimal stubs. Sync is for KB ingestion; Phase 1
+    # doesn't ingest Gmail into KB (Files-as-Knowledge handles direct
+    # uploads). schema() is for KB table mapping; not used yet.
+    # ------------------------------------------------------------------
+
+    async def sync(self, pocket_id: str) -> SyncResult:
+        return SyncResult(
+            success=True,
+            connector_name=self.name,
+            records_synced=0,
+        )
+
+    async def schema(self) -> dict[str, Any]:
+        return {"table": "gmail_messages", "mapping": {}, "schedule": "manual"}
+
+    # ------------------------------------------------------------------
+    # Phase 1 PR-2 protocol additions
+    # ------------------------------------------------------------------
+
+    async def widgets(self) -> list[WidgetRecipe]:
+        """Three default home widgets users get when Gmail is enabled."""
+        return [
+            WidgetRecipe(
+                title="Inbox",
+                display_type="feed",
+                action="gmail_search",
+                params={"query": "is:unread", "max_results": 10},
+                default_size="col-1 row-2",
+                description="Unread messages in your inbox",
+            ),
+            WidgetRecipe(
+                title="Important Emails",
+                display_type="feed",
+                action="gmail_search",
+                params={"query": "is:important newer_than:1d", "max_results": 10},
+                default_size="col-1 row-2",
+                description="Messages flagged important in the last 24h",
+            ),
+            WidgetRecipe(
+                title="Email Stats",
+                display_type="stats",
+                action="gmail_summary",
+                params={},
+                default_size="col-1 row-1",
+                description="Inbox health at a glance",
+            ),
+        ]
+
+    async def health(self, scope: ConnectorScope | None = None) -> ConnectorHealth:
+        """Cheap health check — pings list_labels (auth-only round-trip)."""
+        try:
+            from pocketpaw.integrations.gmail import GmailClient
+
+            client = GmailClient()
+            await client.list_labels()
+            return ConnectorHealth(
+                ok=True,
+                status=ConnectorStatus.CONNECTED,
+                message="Gmail reachable",
+                checked_at_ms=int(time.time() * 1000),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ConnectorHealth(
+                ok=False,
+                status=ConnectorStatus.ERROR,
+                message=str(exc),
+                checked_at_ms=int(time.time() * 1000),
+            )

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -34,13 +34,20 @@ class AnyAdapter(Protocol):
 
 # Connectors handled by native Python adapters instead of YAML/REST.
 # SQL databases use DatabaseAdapter, MongoDB uses MongoDBAdapter.
+# CLI connectors (firebase, gcp) are subprocess-based and execute
+# locally — see ee/cloud/connectors/CHARTER.md §6.2 for the local-agent
+# bus dispatch the cloud router uses.
+# Native communication connectors (gmail, gcalendar, gdocs, gdrive)
+# wrap a stateful Python client (OAuth, MIME, etc.) and live in
+# pocketpaw/connectors/adapters/.
 _SQL_CONNECTORS: set[str] = {"postgresql", "mysql", "mssql", "sqlite"}
 _NOSQL_CONNECTORS: set[str] = {"mongodb"}
 _CLI_CONNECTORS: set[str] = {"firebase", "gcp"}
+_NATIVE_COMM_CONNECTORS: set[str] = {"gmail"}  # PR-3; Calendar/Docs/Drive land in PR-4..6
 
 
 def _create_native_adapter(connector_name: str) -> AnyAdapter | None:
-    """Create a native adapter for database connectors."""
+    """Create a native adapter for database / CLI / communication connectors."""
     if connector_name in _SQL_CONNECTORS:
         try:
             from pocketpaw.connectors.db_adapter import DatabaseAdapter
@@ -64,6 +71,14 @@ def _create_native_adapter(connector_name: str) -> AnyAdapter | None:
             from pocketpaw.connectors.firebase_adapter import FirebaseAdapter
 
             return FirebaseAdapter()
+        except Exception:
+            return None
+    if connector_name in _NATIVE_COMM_CONNECTORS:
+        try:
+            if connector_name == "gmail":
+                from pocketpaw.connectors.adapters.gmail import GmailConnector
+
+                return GmailConnector()
         except Exception:
             return None
     return None

--- a/tests/cloud/test_connectors_execute.py
+++ b/tests/cloud/test_connectors_execute.py
@@ -70,22 +70,33 @@ async def test_widget_recipes_empty_when_nothing_enabled(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_widget_recipes_empty_for_yaml_connectors(client: AsyncClient):
-    """YAML connectors return [] from widgets() in Phase 1.
-
-    Native connectors override widgets() in PR-3+; this test pins the
-    Phase 1 default behaviour so a future regression that accidentally
-    exposes recipes from REST connectors is caught.
-    """
-    catalog = (await client.get("/api/v1/cloud/connectors")).json()
-    name = catalog[0]["name"]
+    """Pure YAML connectors (no native adapter) return [] from widgets()."""
+    # Pick a known YAML-only connector from the catalog (stripe is REST-only).
     await client.post(
-        f"/api/v1/cloud/connectors/{name}/enable",
+        "/api/v1/cloud/connectors/stripe/enable",
         json={"scope": "workspace"},
     )
     resp = await client.get("/api/v1/cloud/connectors/widget-recipes")
     assert resp.status_code == 200
-    # YAML connectors don't ship recipes yet — list stays empty.
-    assert resp.json() == []
+    # Stripe ships no recipes in Phase 1 — list excludes its rows.
+    rows = resp.json()
+    assert all(r["connector"] != "stripe" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_widget_recipes_includes_gmail_when_enabled(client: AsyncClient):
+    """Gmail (native adapter, PR-3) contributes 3 recipes to the rail."""
+    await client.post(
+        "/api/v1/cloud/connectors/gmail/enable",
+        json={"scope": "workspace"},
+    )
+    resp = await client.get("/api/v1/cloud/connectors/widget-recipes")
+    assert resp.status_code == 200
+    rows = resp.json()
+    gmail_rows = [r for r in rows if r["connector"] == "gmail"]
+    titles = sorted(r["title"] for r in gmail_rows)
+    assert titles == ["Email Stats", "Important Emails", "Inbox"]
+    assert all(r["connector_display_name"] == "Gmail" for r in gmail_rows)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/connectors/test_gmail_connector.py
+++ b/tests/connectors/test_gmail_connector.py
@@ -1,0 +1,239 @@
+# GmailConnector — Phase 1 PR-3 contract + snapshot tests.
+# Created: 2026-05-03 — pins:
+#   1. The 9 GmailConnector actions (8 mirror tools/builtin/gmail.py
+#      classes + gmail_summary added for the Email Stats widget).
+#   2. The 3 widget recipes (Inbox / Important Emails / Email Stats).
+#   3. The action surface matches the existing hand-written tool names
+#      so a future PR can replace them via connector_tools_for(c)
+#      without breaking the agent's tool registry.
+#
+# Connect / execute paths are covered with stubbed GmailClient calls
+# so the suite doesn't need real Google OAuth credentials.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pocketpaw.connectors.adapters.gmail import GmailConnector
+from pocketpaw.connectors.protocol import (
+    ConnectorStatus,
+    ExecutionMode,
+    TrustLevel,
+    WidgetRecipe,
+)
+
+# ---------------------------------------------------------------------------
+# Static metadata
+# ---------------------------------------------------------------------------
+
+
+def test_metadata():
+    c = GmailConnector()
+    assert c.name == "gmail"
+    assert c.display_name == "Gmail"
+    assert c.type == "communication"
+    assert c.icon == "mail"
+
+
+# ---------------------------------------------------------------------------
+# Action surface — snapshot pin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_action_names_match_existing_tool_classes():
+    """Snapshot test — these 8 names must equal the 8 hand-written
+    tool classes in src/pocketpaw/tools/builtin/gmail.py.
+
+    A future PR (3.5+) replaces those classes with generated tools
+    via connector_tools_for(c). If this test breaks, either:
+      (a) the connector dropped/added an action — update the tool
+          list in tools/builtin/__init__.py to match
+      (b) the legacy tool gained/lost a method — update this assert
+    """
+    c = GmailConnector()
+    schemas = await c.actions()
+    names = sorted(s.name for s in schemas)
+    assert names == [
+        "gmail_batch_modify",
+        "gmail_create_label",
+        "gmail_list_labels",
+        "gmail_modify",
+        "gmail_read",
+        "gmail_search",
+        "gmail_send",
+        "gmail_summary",  # added for the Email Stats widget recipe
+        "gmail_trash",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_actions_use_cloud_mode():
+    """Gmail is a REST API — every action runs in cloud, no CLI involved."""
+    c = GmailConnector()
+    schemas = await c.actions()
+    for s in schemas:
+        assert s.execution_mode is ExecutionMode.CLOUD
+        assert s.requires_binary is None
+
+
+@pytest.mark.asyncio
+async def test_action_trust_levels():
+    """Read actions auto-execute; mutations require confirm."""
+    c = GmailConnector()
+    by_name = {s.name: s for s in await c.actions()}
+    # Reads
+    assert by_name["gmail_search"].trust_level is TrustLevel.AUTO
+    assert by_name["gmail_read"].trust_level is TrustLevel.AUTO
+    assert by_name["gmail_list_labels"].trust_level is TrustLevel.AUTO
+    assert by_name["gmail_summary"].trust_level is TrustLevel.AUTO
+    # Mutations
+    assert by_name["gmail_send"].trust_level is TrustLevel.CONFIRM
+    assert by_name["gmail_create_label"].trust_level is TrustLevel.CONFIRM
+    assert by_name["gmail_modify"].trust_level is TrustLevel.CONFIRM
+    assert by_name["gmail_trash"].trust_level is TrustLevel.CONFIRM
+    assert by_name["gmail_batch_modify"].trust_level is TrustLevel.CONFIRM
+
+
+# ---------------------------------------------------------------------------
+# Widget recipes — exactly three, matching the home seed data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_widget_recipes():
+    c = GmailConnector()
+    recipes = await c.widgets()
+    assert len(recipes) == 3
+    titles = [r.title for r in recipes]
+    assert titles == ["Inbox", "Important Emails", "Email Stats"]
+
+    inbox = recipes[0]
+    assert isinstance(inbox, WidgetRecipe)
+    assert inbox.display_type == "feed"
+    assert inbox.action == "gmail_search"
+    assert inbox.params == {"query": "is:unread", "max_results": 10}
+    assert inbox.default_size == "col-1 row-2"
+
+    important = recipes[1]
+    assert important.action == "gmail_search"
+    assert important.params == {"query": "is:important newer_than:1d", "max_results": 10}
+
+    stats = recipes[2]
+    assert stats.display_type == "stats"
+    assert stats.action == "gmail_summary"
+    assert stats.default_size == "col-1 row-1"
+
+
+# ---------------------------------------------------------------------------
+# health() — pings list_labels, reflects success/error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_ok_when_list_labels_succeeds():
+    c = GmailConnector()
+    with patch(
+        "pocketpaw.integrations.gmail.GmailClient.list_labels",
+        new=AsyncMock(return_value=[{"id": "INBOX"}]),
+    ):
+        h = await c.health()
+    assert h.ok is True
+    assert h.status is ConnectorStatus.CONNECTED
+
+
+@pytest.mark.asyncio
+async def test_health_error_when_list_labels_raises():
+    c = GmailConnector()
+    with patch(
+        "pocketpaw.integrations.gmail.GmailClient.list_labels",
+        new=AsyncMock(side_effect=RuntimeError("missing token")),
+    ):
+        h = await c.health()
+    assert h.ok is False
+    assert h.status is ConnectorStatus.ERROR
+    assert "missing token" in h.message
+
+
+# ---------------------------------------------------------------------------
+# execute() — delegates to GmailClient with the right params
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_search_delegates_to_client():
+    c = GmailConnector()
+    with patch(
+        "pocketpaw.integrations.gmail.GmailClient.search",
+        new=AsyncMock(return_value=[{"id": "m1"}, {"id": "m2"}]),
+    ) as mock:
+        result = await c.execute("gmail_search", {"query": "is:unread", "max_results": 5})
+    assert result.success is True
+    assert result.records_affected == 2
+    mock.assert_called_once_with("is:unread", max_results=5)
+
+
+@pytest.mark.asyncio
+async def test_execute_search_caps_max_results_at_20():
+    c = GmailConnector()
+    with patch(
+        "pocketpaw.integrations.gmail.GmailClient.search",
+        new=AsyncMock(return_value=[]),
+    ) as mock:
+        await c.execute("gmail_search", {"query": "x", "max_results": 999})
+    mock.assert_called_once_with("x", max_results=20)
+
+
+@pytest.mark.asyncio
+async def test_execute_summary_aggregates_two_searches():
+    c = GmailConnector()
+    with patch(
+        "pocketpaw.integrations.gmail.GmailClient.search",
+        new=AsyncMock(return_value=[{"id": "m1"}]),
+    ):
+        result = await c.execute("gmail_summary", {})
+    assert result.success is True
+    assert result.data["unread"] == 1
+    assert result.data["today"] == 1
+    assert "avg_reply_time" in result.data
+
+
+@pytest.mark.asyncio
+async def test_execute_unknown_action():
+    c = GmailConnector()
+    result = await c.execute("not_real", {})
+    assert result.success is False
+    assert "Unknown action" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_execute_runtime_error_returns_failure():
+    c = GmailConnector()
+    with patch(
+        "pocketpaw.integrations.gmail.GmailClient.search",
+        new=AsyncMock(side_effect=RuntimeError("auth expired")),
+    ):
+        result = await c.execute("gmail_search", {"query": "x"})
+    assert result.success is False
+    assert "auth expired" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring — _create_native_adapter("gmail") returns GmailConnector
+# ---------------------------------------------------------------------------
+
+
+def test_registry_returns_gmail_connector():
+    """ConnectorRegistry's native-adapter dispatch picks up Gmail."""
+    from pocketpaw.connectors.registry import _create_native_adapter
+
+    adapter = _create_native_adapter("gmail")
+    assert isinstance(adapter, GmailConnector)
+
+
+def test_registry_returns_none_for_unknown_native():
+    from pocketpaw.connectors.registry import _create_native_adapter
+
+    assert _create_native_adapter("not-a-real-connector") is None


### PR DESCRIPTION
Phase 1 PR-3. Reference implementation that proves the protocol shape works for a real production connector. Lands the catalog entry + native Python adapter wrapping the existing `GmailClient` + 3 home widget recipes + snapshot tests pinning the action surface.

Stacks on PR #1046 (protocol additions).

## What landed

- **`connectors/gmail.yaml`** — catalog metadata + 9-action manifest (8 mirror existing tools + `gmail_summary` for the Email Stats widget)
- **`src/pocketpaw/connectors/adapters/__init__.py`** — new namespace for native Python adapters; Calendar / Docs / Drive / Reddit / Spotify follow this layout in PR-4..8
- **`src/pocketpaw/connectors/adapters/gmail.py`** — `GmailConnector` wraps the existing `GmailClient` (OAuth refresh, MIME, base64 stay there). Implements the full protocol: `connect / disconnect / actions / execute / sync / schema / widgets / health`
- **`registry.py`** — `_create_native_adapter("gmail")` returns `GmailConnector`. New `_NATIVE_COMM_CONNECTORS` set so Calendar / Docs / Drive plug in the same way
- **`ee/cloud/connectors/service._adapter_for_definition`** prefers the native adapter when one exists; falls back to `DirectRESTAdapter`

## Widget recipes

| Title | Display | Action | Params |
|---|---|---|---|
| Inbox | feed | `gmail_search` | `q="is:unread"`, `max_results=10` |
| Important Emails | feed | `gmail_search` | `q="is:important newer_than:1d"`, `max_results=10` |
| Email Stats | stats | `gmail_summary` | — |

## Tests

- **`tests/connectors/test_gmail_connector.py`** — 14 tests: metadata, action surface snapshot (8 names match `tools/builtin/gmail.py`), trust levels, cloud-mode invariant, widget recipes, health up/down, `execute()` delegation to `GmailClient`, registry wiring
- **`tests/cloud/test_connectors_execute.py`** — 1 new test: gmail enabled → `/widget-recipes` returns 3 Gmail rows
- 173 connector-related tests across `tests/connectors`, `tests/cloud`, `tests/v1`, `tests/test_gmail` pass

## What's NOT in this PR

- **Replacing the 8 hand-written tool classes** in `tools/builtin/gmail.py`. Those have hand-tuned LLM-friendly response formatting that a generic `connector_tools_for(c)` generator can't reproduce verbatim. A future PR (3.5+) introduces a per-action formatter abstraction before the swap. The snapshot test in `test_gmail_connector.py` pins the names so the swap is byte-identical when it lands.
- Calendar / Docs / Drive / Reddit / Spotify migration → PR-4 through PR-8 follow this same pattern.

## Test plan

- [x] 14 new `GmailConnector` tests pass
- [x] Cloud `widget-recipes` test pins Gmail's 3 recipes
- [x] 173 connector-related tests pass — no regression in legacy paths or `tests/test_gmail.py`
- [x] `ruff check` clean on every changed file
- [ ] Smoke: `curl /api/v1/cloud/connectors` shows `gmail` in catalog
- [ ] Smoke: enable gmail with workspace scope → `curl /api/v1/cloud/connectors/widget-recipes` returns the 3 Gmail rows
- [ ] Smoke: `tools/builtin/gmail.py` agent tools still work in chat (no changes to that file)