### PR TITLE
feat(connectors): GoogleCalendarConnector adopts the protocol

### DIFF
--- a/connectors/gcalendar.yaml
+++ b/connectors/gcalendar.yaml
@@ -1,0 +1,37 @@
+# Google Calendar connector — REST over OAuth bearer.
+# Created: 2026-05-03 — Phase 1 PR-4. Same shape as gmail.yaml.
+# Native runtime in src/pocketpaw/connectors/adapters/gcalendar.py.
+
+name: gcalendar
+display_name: Google Calendar
+type: communication
+icon: calendar
+
+auth:
+  method: oauth2
+  credentials:
+    - name: GOOGLE_OAUTH_TOKEN
+      description: OAuth access token with https://www.googleapis.com/auth/calendar scope
+      required: true
+
+actions:
+  - name: calendar_list
+    description: List upcoming calendar events.
+    method: GET
+    trust_level: auto
+    execution_mode: cloud
+  - name: calendar_create
+    description: Create a new calendar event.
+    method: POST
+    trust_level: confirm
+    execution_mode: cloud
+  - name: calendar_prep
+    description: Briefing for the next upcoming meeting.
+    method: GET
+    trust_level: auto
+    execution_mode: cloud
+  - name: calendar_summary
+    description: Aggregate calendar stats (today / this week / busy hours) for the home widget.
+    method: GET
+    trust_level: auto
+    execution_mode: cloud

--- a/src/pocketpaw/connectors/adapters/gcalendar.py
+++ b/src/pocketpaw/connectors/adapters/gcalendar.py
@@ -1,0 +1,271 @@
+# GoogleCalendarConnector — native adapter wrapping CalendarClient.
+# Created: 2026-05-03 — Phase 1 PR-4 (follows the GmailConnector
+# pattern). Wraps the existing CalendarClient at
+# src/pocketpaw/integrations/gcalendar.py — that client owns OAuth +
+# RFC 3339 datetime serialization.
+#
+# Action surface mirrors the 3 hand-written tools in
+# src/pocketpaw/tools/builtin/calendar.py + adds calendar_summary
+# for the home widget aggregator.
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from pocketpaw.connectors.protocol import (
+    ActionResult,
+    ActionSchema,
+    ConnectionResult,
+    ConnectorHealth,
+    ConnectorScope,
+    ConnectorStatus,
+    ExecutionMode,
+    SyncResult,
+    TrustLevel,
+    WidgetRecipe,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleCalendarConnector:
+    """Native Google Calendar connector implementing ConnectorProtocol."""
+
+    @property
+    def name(self) -> str:
+        return "gcalendar"
+
+    @property
+    def display_name(self) -> str:
+        return "Google Calendar"
+
+    @property
+    def type(self) -> str:
+        return "communication"
+
+    @property
+    def icon(self) -> str:
+        return "calendar"
+
+    def __init__(self) -> None:
+        self._connected = False
+
+    async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        try:
+            from pocketpaw.integrations.gcalendar import CalendarClient
+
+            client = CalendarClient()
+            await client._get_token()  # noqa: SLF001
+            self._connected = True
+            return ConnectionResult(
+                success=True,
+                connector_name=self.name,
+                status=ConnectorStatus.CONNECTED,
+                message="Calendar connected",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ConnectionResult(
+                success=False,
+                connector_name=self.name,
+                status=ConnectorStatus.ERROR,
+                message=str(exc),
+            )
+
+    async def disconnect(self, pocket_id: str) -> bool:
+        self._connected = False
+        return True
+
+    async def actions(self) -> list[ActionSchema]:
+        return [
+            ActionSchema(
+                name="calendar_list",
+                description=(
+                    "List upcoming calendar events. Defaults to the next 24 hours; "
+                    "set days_ahead to look further."
+                ),
+                method="GET",
+                parameters={
+                    "days_ahead": {
+                        "type": "integer",
+                        "description": "Days to look ahead (default 1)",
+                        "default": 1,
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Max events to return (default 10, capped at 50)",
+                        "default": 10,
+                    },
+                },
+                trust_level=TrustLevel.AUTO,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+            ActionSchema(
+                name="calendar_create",
+                description=(
+                    "Create a new event on Google Calendar with title, time, "
+                    "location, and attendees."
+                ),
+                method="POST",
+                parameters={
+                    "summary": {"type": "string", "description": "Event title"},
+                    "start": {
+                        "type": "string",
+                        "description": "Start time in ISO 8601",
+                    },
+                    "end": {"type": "string", "description": "End time in ISO 8601"},
+                    "description": {"type": "string", "description": "Event description"},
+                    "location": {"type": "string", "description": "Event location"},
+                    "attendees": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Attendee email addresses",
+                    },
+                },
+                trust_level=TrustLevel.CONFIRM,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+            ActionSchema(
+                name="calendar_prep",
+                description=(
+                    "Briefing for the next upcoming meeting — event details, "
+                    "attendee list, location."
+                ),
+                method="GET",
+                parameters={},
+                trust_level=TrustLevel.AUTO,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+            ActionSchema(
+                name="calendar_summary",
+                description=(
+                    "Aggregate calendar stats — today's count, this week's count, "
+                    "next meeting time. Backs the Calendar Today widget."
+                ),
+                method="GET",
+                parameters={},
+                trust_level=TrustLevel.AUTO,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+        ]
+
+    async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
+        from pocketpaw.integrations.gcalendar import CalendarClient
+
+        try:
+            client = CalendarClient()
+            now = datetime.now(UTC)
+
+            if action == "calendar_list":
+                days_ahead = max(int(params.get("days_ahead", 1)), 1)
+                max_results = min(int(params.get("max_results", 10)), 50)
+                events = await client.list_events(
+                    time_min=now,
+                    time_max=now + timedelta(days=days_ahead),
+                    max_results=max_results,
+                )
+                return ActionResult(success=True, data=events, records_affected=len(events))
+            if action == "calendar_create":
+                data = await client.create_event(
+                    summary=params["summary"],
+                    start=params["start"],
+                    end=params["end"],
+                    description=params.get("description", ""),
+                    location=params.get("location", ""),
+                    attendees=params.get("attendees"),
+                )
+                return ActionResult(success=True, data=data, records_affected=1)
+            if action == "calendar_prep":
+                events = await client.list_events(
+                    time_min=now,
+                    time_max=now + timedelta(days=1),
+                    max_results=1,
+                )
+                if not events:
+                    return ActionResult(
+                        success=True,
+                        data={"message": "No upcoming meetings in the next 24 hours."},
+                    )
+                return ActionResult(success=True, data=events[0], records_affected=1)
+            if action == "calendar_summary":
+                today_events = await client.list_events(
+                    time_min=now,
+                    time_max=now + timedelta(days=1),
+                    max_results=50,
+                )
+                week_events = await client.list_events(
+                    time_min=now,
+                    time_max=now + timedelta(days=7),
+                    max_results=50,
+                )
+                next_summary = today_events[0]["summary"] if today_events else "—"
+                return ActionResult(
+                    success=True,
+                    data={
+                        "today": len(today_events),
+                        "this_week": len(week_events),
+                        "next": next_summary,
+                    },
+                )
+            return ActionResult(success=False, error=f"Unknown action: {action}")
+        except RuntimeError as exc:
+            return ActionResult(success=False, error=str(exc))
+        except Exception as exc:  # noqa: BLE001
+            return ActionResult(success=False, error=f"Calendar {action} failed: {exc}")
+
+    async def sync(self, pocket_id: str) -> SyncResult:
+        return SyncResult(success=True, connector_name=self.name, records_synced=0)
+
+    async def schema(self) -> dict[str, Any]:
+        return {"table": "calendar_events", "mapping": {}, "schedule": "manual"}
+
+    async def widgets(self) -> list[WidgetRecipe]:
+        return [
+            WidgetRecipe(
+                title="Today's Calendar",
+                display_type="feed",
+                action="calendar_list",
+                params={"days_ahead": 1, "max_results": 10},
+                default_size="col-1 row-2",
+                description="Events in the next 24 hours",
+            ),
+            WidgetRecipe(
+                title="This Week",
+                display_type="feed",
+                action="calendar_list",
+                params={"days_ahead": 7, "max_results": 15},
+                default_size="col-1 row-2",
+                description="Events in the next 7 days",
+            ),
+            WidgetRecipe(
+                title="Calendar Stats",
+                display_type="stats",
+                action="calendar_summary",
+                params={},
+                default_size="col-1 row-1",
+                description="Today / this week / next meeting at a glance",
+            ),
+        ]
+
+    async def health(self, scope: ConnectorScope | None = None) -> ConnectorHealth:
+        try:
+            from pocketpaw.integrations.gcalendar import CalendarClient
+
+            client = CalendarClient()
+            now = datetime.now(UTC)
+            await client.list_events(time_min=now, time_max=now + timedelta(hours=1), max_results=1)
+            return ConnectorHealth(
+                ok=True,
+                status=ConnectorStatus.CONNECTED,
+                message="Calendar reachable",
+                checked_at_ms=int(time.time() * 1000),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ConnectorHealth(
+                ok=False,
+                status=ConnectorStatus.ERROR,
+                message=str(exc),
+                checked_at_ms=int(time.time() * 1000),
+            )

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -43,7 +43,7 @@ class AnyAdapter(Protocol):
 _SQL_CONNECTORS: set[str] = {"postgresql", "mysql", "mssql", "sqlite"}
 _NOSQL_CONNECTORS: set[str] = {"mongodb"}
 _CLI_CONNECTORS: set[str] = {"firebase", "gcp"}
-_NATIVE_COMM_CONNECTORS: set[str] = {"gmail"}  # PR-3; Calendar/Docs/Drive land in PR-4..6
+_NATIVE_COMM_CONNECTORS: set[str] = {"gmail", "gcalendar"}  # PR-3..4; Docs/Drive land in PR-5..6
 
 
 def _create_native_adapter(connector_name: str) -> AnyAdapter | None:
@@ -79,6 +79,10 @@ def _create_native_adapter(connector_name: str) -> AnyAdapter | None:
                 from pocketpaw.connectors.adapters.gmail import GmailConnector
 
                 return GmailConnector()
+            if connector_name == "gcalendar":
+                from pocketpaw.connectors.adapters.gcalendar import GoogleCalendarConnector
+
+                return GoogleCalendarConnector()
         except Exception:
             return None
     return None

--- a/tests/connectors/test_gcalendar_connector.py
+++ b/tests/connectors/test_gcalendar_connector.py
@@ -1,0 +1,145 @@
+# GoogleCalendarConnector — Phase 1 PR-4 contract + snapshot tests.
+# Created: 2026-05-03 — pins the 4-action surface (3 mirror existing
+# tools + calendar_summary for the home widget) and the 3 widget
+# recipes (Today / This Week / Calendar Stats).
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pocketpaw.connectors.adapters.gcalendar import GoogleCalendarConnector
+from pocketpaw.connectors.protocol import (
+    ConnectorStatus,
+    ExecutionMode,
+    TrustLevel,
+    WidgetRecipe,
+)
+
+
+def test_metadata():
+    c = GoogleCalendarConnector()
+    assert c.name == "gcalendar"
+    assert c.display_name == "Google Calendar"
+    assert c.type == "communication"
+    assert c.icon == "calendar"
+
+
+@pytest.mark.asyncio
+async def test_action_names_match_existing_tool_classes():
+    """Pins the 3 existing tool names + calendar_summary for the widget."""
+    c = GoogleCalendarConnector()
+    schemas = await c.actions()
+    names = sorted(s.name for s in schemas)
+    assert names == [
+        "calendar_create",
+        "calendar_list",
+        "calendar_prep",
+        "calendar_summary",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_actions_use_cloud_mode():
+    c = GoogleCalendarConnector()
+    schemas = await c.actions()
+    for s in schemas:
+        assert s.execution_mode is ExecutionMode.CLOUD
+        assert s.requires_binary is None
+
+
+@pytest.mark.asyncio
+async def test_action_trust_levels():
+    c = GoogleCalendarConnector()
+    by_name = {s.name: s for s in await c.actions()}
+    assert by_name["calendar_list"].trust_level is TrustLevel.AUTO
+    assert by_name["calendar_prep"].trust_level is TrustLevel.AUTO
+    assert by_name["calendar_summary"].trust_level is TrustLevel.AUTO
+    assert by_name["calendar_create"].trust_level is TrustLevel.CONFIRM
+
+
+@pytest.mark.asyncio
+async def test_widget_recipes():
+    c = GoogleCalendarConnector()
+    recipes = await c.widgets()
+    assert len(recipes) == 3
+    titles = [r.title for r in recipes]
+    assert titles == ["Today's Calendar", "This Week", "Calendar Stats"]
+    assert all(isinstance(r, WidgetRecipe) for r in recipes)
+    assert recipes[0].action == "calendar_list"
+    assert recipes[0].params == {"days_ahead": 1, "max_results": 10}
+    assert recipes[1].params == {"days_ahead": 7, "max_results": 15}
+    assert recipes[2].action == "calendar_summary"
+
+
+@pytest.mark.asyncio
+async def test_health_ok_when_list_events_succeeds():
+    c = GoogleCalendarConnector()
+    with patch(
+        "pocketpaw.integrations.gcalendar.CalendarClient.list_events",
+        new=AsyncMock(return_value=[]),
+    ):
+        h = await c.health()
+    assert h.ok is True
+    assert h.status is ConnectorStatus.CONNECTED
+
+
+@pytest.mark.asyncio
+async def test_health_error_when_list_events_raises():
+    c = GoogleCalendarConnector()
+    with patch(
+        "pocketpaw.integrations.gcalendar.CalendarClient.list_events",
+        new=AsyncMock(side_effect=RuntimeError("token expired")),
+    ):
+        h = await c.health()
+    assert h.ok is False
+    assert h.status is ConnectorStatus.ERROR
+
+
+@pytest.mark.asyncio
+async def test_execute_list_delegates_to_client():
+    c = GoogleCalendarConnector()
+    sample = [{"summary": "Standup", "start": "now", "end": "later"}]
+    with patch(
+        "pocketpaw.integrations.gcalendar.CalendarClient.list_events",
+        new=AsyncMock(return_value=sample),
+    ):
+        result = await c.execute("calendar_list", {"days_ahead": 1, "max_results": 5})
+    assert result.success is True
+    assert result.records_affected == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_summary_aggregates():
+    """Aggregator calls list_events twice — short window for today,
+    longer window for the week. Stub picks the right list by which
+    call we're on (first call = today, second = week)."""
+    c = GoogleCalendarConnector()
+    today = [{"summary": "Standup"}, {"summary": "Lunch with X"}]
+    week = today + [{"summary": "Q2 review"}, {"summary": "1:1"}]
+
+    mock = AsyncMock(side_effect=[today, week])
+    with patch(
+        "pocketpaw.integrations.gcalendar.CalendarClient.list_events",
+        new=mock,
+    ):
+        result = await c.execute("calendar_summary", {})
+    assert result.success is True
+    assert result.data["today"] == 2
+    assert result.data["this_week"] == 4
+    assert result.data["next"] == "Standup"
+
+
+@pytest.mark.asyncio
+async def test_execute_unknown_action():
+    c = GoogleCalendarConnector()
+    result = await c.execute("not_real", {})
+    assert result.success is False
+
+
+def test_registry_returns_calendar_connector():
+    from pocketpaw.connectors.registry import _create_native_adapter
+
+    adapter = _create_native_adapter("gcalendar")
+    assert isinstance(adapter, GoogleCalendarConnector)


### PR DESCRIPTION
Phase 1 PR-4. Same pattern as PR #1047 (Gmail). 4-action surface + 3 widget recipes (Today / This Week / Stats). 11 new tests pin the contract.

## Test plan
- [x] 11 new tests pass
- [x] 45 connector tests pass across PR-3 + PR-4 surfaces
- [x] ruff check clean