### PR TITLE
feat(connectors): GoogleDocsConnector adopts the protocol

### DIFF
--- a/connectors/gdocs.yaml
+++ b/connectors/gdocs.yaml
@@ -1,0 +1,31 @@
+# Google Docs connector — REST over OAuth bearer.
+# Created: 2026-05-03 — Phase 1 PR-5. Mirrors gmail.yaml + gcalendar.yaml.
+
+name: gdocs
+display_name: Google Docs
+type: knowledge
+icon: file-text
+
+auth:
+  method: oauth2
+  credentials:
+    - name: GOOGLE_OAUTH_TOKEN
+      description: OAuth access token with documents + drive.readonly scopes
+      required: true
+
+actions:
+  - name: docs_read
+    description: Read the full text content of a Google Doc by ID.
+    method: GET
+    trust_level: auto
+    execution_mode: cloud
+  - name: docs_create
+    description: Create a new Google Doc with optional initial content.
+    method: POST
+    trust_level: confirm
+    execution_mode: cloud
+  - name: docs_search
+    description: Search your Google Docs by name / title.
+    method: GET
+    trust_level: auto
+    execution_mode: cloud

--- a/src/pocketpaw/connectors/adapters/gdocs.py
+++ b/src/pocketpaw/connectors/adapters/gdocs.py
@@ -1,0 +1,183 @@
+# GoogleDocsConnector — native adapter wrapping DocsClient.
+# Created: 2026-05-03 — Phase 1 PR-5.
+# Action surface mirrors src/pocketpaw/tools/builtin/gdocs.py.
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from pocketpaw.connectors.protocol import (
+    ActionResult,
+    ActionSchema,
+    ConnectionResult,
+    ConnectorHealth,
+    ConnectorScope,
+    ConnectorStatus,
+    ExecutionMode,
+    SyncResult,
+    TrustLevel,
+    WidgetRecipe,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleDocsConnector:
+    """Native Google Docs connector implementing ConnectorProtocol."""
+
+    @property
+    def name(self) -> str:
+        return "gdocs"
+
+    @property
+    def display_name(self) -> str:
+        return "Google Docs"
+
+    @property
+    def type(self) -> str:
+        return "knowledge"
+
+    @property
+    def icon(self) -> str:
+        return "file-text"
+
+    def __init__(self) -> None:
+        self._connected = False
+
+    async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        try:
+            from pocketpaw.integrations.gdocs import DocsClient
+
+            client = DocsClient()
+            await client._get_token()  # noqa: SLF001
+            self._connected = True
+            return ConnectionResult(
+                success=True,
+                connector_name=self.name,
+                status=ConnectorStatus.CONNECTED,
+                message="Docs connected",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ConnectionResult(
+                success=False,
+                connector_name=self.name,
+                status=ConnectorStatus.ERROR,
+                message=str(exc),
+            )
+
+    async def disconnect(self, pocket_id: str) -> bool:
+        self._connected = False
+        return True
+
+    async def actions(self) -> list[ActionSchema]:
+        return [
+            ActionSchema(
+                name="docs_read",
+                description="Read the full text content of a Google Doc by ID.",
+                method="GET",
+                parameters={
+                    "document_id": {
+                        "type": "string",
+                        "description": "Google Doc document ID",
+                    },
+                },
+                trust_level=TrustLevel.AUTO,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+            ActionSchema(
+                name="docs_create",
+                description="Create a new Google Doc with optional initial content.",
+                method="POST",
+                parameters={
+                    "title": {"type": "string", "description": "Document title"},
+                    "content": {
+                        "type": "string",
+                        "description": "Initial document content (optional)",
+                        "default": "",
+                    },
+                },
+                trust_level=TrustLevel.CONFIRM,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+            ActionSchema(
+                name="docs_search",
+                description="Search your Google Docs by name / title.",
+                method="GET",
+                parameters={
+                    "query": {"type": "string", "description": "Search query"},
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Max results (default 10, capped at 50)",
+                        "default": 10,
+                    },
+                },
+                trust_level=TrustLevel.AUTO,
+                execution_mode=ExecutionMode.CLOUD,
+            ),
+        ]
+
+    async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
+        from pocketpaw.integrations.gdocs import DocsClient
+
+        try:
+            client = DocsClient()
+            if action == "docs_read":
+                data = await client.get_document(params["document_id"])
+                return ActionResult(success=True, data=data, records_affected=1)
+            if action == "docs_create":
+                data = await client.create_document(
+                    params["title"],
+                    params.get("content", ""),
+                )
+                return ActionResult(success=True, data=data, records_affected=1)
+            if action == "docs_search":
+                results = await client.search_docs(
+                    params["query"],
+                    max_results=min(int(params.get("max_results", 10)), 50),
+                )
+                return ActionResult(success=True, data=results, records_affected=len(results))
+            return ActionResult(success=False, error=f"Unknown action: {action}")
+        except RuntimeError as exc:
+            return ActionResult(success=False, error=str(exc))
+        except Exception as exc:  # noqa: BLE001
+            return ActionResult(success=False, error=f"Docs {action} failed: {exc}")
+
+    async def sync(self, pocket_id: str) -> SyncResult:
+        return SyncResult(success=True, connector_name=self.name, records_synced=0)
+
+    async def schema(self) -> dict[str, Any]:
+        return {"table": "google_docs", "mapping": {}, "schedule": "manual"}
+
+    async def widgets(self) -> list[WidgetRecipe]:
+        return [
+            WidgetRecipe(
+                title="Recent Docs",
+                display_type="feed",
+                action="docs_search",
+                params={"query": "modifiedTime > 'now-7d'", "max_results": 10},
+                default_size="col-1 row-2",
+                description="Docs you've touched in the last 7 days",
+            ),
+        ]
+
+    async def health(self, scope: ConnectorScope | None = None) -> ConnectorHealth:
+        try:
+            from pocketpaw.integrations.gdocs import DocsClient
+
+            client = DocsClient()
+            await client.search_docs("", max_results=1)
+            return ConnectorHealth(
+                ok=True,
+                status=ConnectorStatus.CONNECTED,
+                message="Docs reachable",
+                checked_at_ms=int(time.time() * 1000),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ConnectorHealth(
+                ok=False,
+                status=ConnectorStatus.ERROR,
+                message=str(exc),
+                checked_at_ms=int(time.time() * 1000),
+            )

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -43,7 +43,7 @@ class AnyAdapter(Protocol):
 _SQL_CONNECTORS: set[str] = {"postgresql", "mysql", "mssql", "sqlite"}
 _NOSQL_CONNECTORS: set[str] = {"mongodb"}
 _CLI_CONNECTORS: set[str] = {"firebase", "gcp"}
-_NATIVE_COMM_CONNECTORS: set[str] = {"gmail", "gcalendar"}  # PR-3..4; Docs/Drive land in PR-5..6
+_NATIVE_COMM_CONNECTORS: set[str] = {"gmail", "gcalendar", "gdocs"}  # PR-3..5; Drive lands in PR-6
 
 
 def _create_native_adapter(connector_name: str) -> AnyAdapter | None:
@@ -83,6 +83,10 @@ def _create_native_adapter(connector_name: str) -> AnyAdapter | None:
                 from pocketpaw.connectors.adapters.gcalendar import GoogleCalendarConnector
 
                 return GoogleCalendarConnector()
+            if connector_name == "gdocs":
+                from pocketpaw.connectors.adapters.gdocs import GoogleDocsConnector
+
+                return GoogleDocsConnector()
         except Exception:
             return None
     return None

--- a/tests/connectors/test_gdocs_connector.py
+++ b/tests/connectors/test_gdocs_connector.py
@@ -1,0 +1,83 @@
+# GoogleDocsConnector — Phase 1 PR-5 contract tests.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pocketpaw.connectors.adapters.gdocs import GoogleDocsConnector
+from pocketpaw.connectors.protocol import (
+    ConnectorStatus,
+    ExecutionMode,
+    TrustLevel,
+)
+
+
+def test_metadata():
+    c = GoogleDocsConnector()
+    assert c.name == "gdocs"
+    assert c.display_name == "Google Docs"
+    assert c.type == "knowledge"
+
+
+@pytest.mark.asyncio
+async def test_action_names():
+    c = GoogleDocsConnector()
+    schemas = await c.actions()
+    assert sorted(s.name for s in schemas) == ["docs_create", "docs_read", "docs_search"]
+
+
+@pytest.mark.asyncio
+async def test_actions_use_cloud_mode():
+    c = GoogleDocsConnector()
+    for s in await c.actions():
+        assert s.execution_mode is ExecutionMode.CLOUD
+
+
+@pytest.mark.asyncio
+async def test_trust_levels():
+    c = GoogleDocsConnector()
+    by_name = {s.name: s for s in await c.actions()}
+    assert by_name["docs_read"].trust_level is TrustLevel.AUTO
+    assert by_name["docs_search"].trust_level is TrustLevel.AUTO
+    assert by_name["docs_create"].trust_level is TrustLevel.CONFIRM
+
+
+@pytest.mark.asyncio
+async def test_widget_recipes():
+    c = GoogleDocsConnector()
+    recipes = await c.widgets()
+    assert len(recipes) == 1
+    assert recipes[0].title == "Recent Docs"
+    assert recipes[0].action == "docs_search"
+
+
+@pytest.mark.asyncio
+async def test_execute_search_caps_at_50():
+    c = GoogleDocsConnector()
+    with patch(
+        "pocketpaw.integrations.gdocs.DocsClient.search_docs",
+        new=AsyncMock(return_value=[]),
+    ) as mock:
+        await c.execute("docs_search", {"query": "x", "max_results": 999})
+    mock.assert_called_once_with("x", max_results=50)
+
+
+@pytest.mark.asyncio
+async def test_health_ok():
+    c = GoogleDocsConnector()
+    with patch(
+        "pocketpaw.integrations.gdocs.DocsClient.search_docs",
+        new=AsyncMock(return_value=[]),
+    ):
+        h = await c.health()
+    assert h.ok is True
+    assert h.status is ConnectorStatus.CONNECTED
+
+
+def test_registry_returns_docs_connector():
+    from pocketpaw.connectors.registry import _create_native_adapter
+
+    adapter = _create_native_adapter("gdocs")
+    assert isinstance(adapter, GoogleDocsConnector)


### PR DESCRIPTION
Phase 1 PR-5. Same pattern as PR #1047 / #1048. 3-action surface (docs_read / docs_create / docs_search) + 1 widget recipe (Recent Docs). 8 new tests pin the contract.