### PR TITLE
feat(connectors): CLI adapters adopt the protocol + local-agent bus listener

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -81,6 +81,21 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(pockets_router, prefix="/api/v1")
     app.include_router(sessions_router, prefix="/api/v1")
 
+    # Phase 1 PR-8: register the connector bus listener so local-mode
+    # CLI actions (firebase, gcp, …) get picked up by the in-process
+    # runtime. In multi-tenant deployments this becomes a cross-process
+    # listener once Task 33 ships RedisBus; the contract is identical.
+    try:
+        from pocketpaw.runtime.connector_bus import register_listener
+
+        register_listener()
+    except Exception:
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning(
+            "connector bus listener failed to register", exc_info=True,
+        )
+
     from ee.cloud.files.router import router as files_router
     from ee.cloud.kb.knowledge_router import router as knowledge_router
 

--- a/src/pocketpaw/connectors/firebase_adapter.py
+++ b/src/pocketpaw/connectors/firebase_adapter.py
@@ -15,9 +15,13 @@ from pocketpaw.connectors.protocol import (
     ActionResult,
     ActionSchema,
     ConnectionResult,
+    ConnectorHealth,
+    ConnectorScope,
     ConnectorStatus,
+    ExecutionMode,
     SyncResult,
     TrustLevel,
+    WidgetRecipe,
 )
 
 # Default path to the firebase CLI binary. Overridden via FIREBASE_CLI_PATH if needed.
@@ -168,7 +172,16 @@ class FirebaseAdapter:
         return True
 
     async def actions(self) -> list[ActionSchema]:
-        """Return the action schemas for all supported Firebase operations."""
+        """Return the action schemas for all supported Firebase operations.
+
+        Phase 1 PR-8: every action is ``execution_mode=LOCAL`` (Firebase
+        CLI must run on the user's host where ``firebase login`` config
+        lives) and declares ``requires_binary="firebase"`` so the local
+        agent fails fast with a clear error if the binary isn't installed.
+        """
+        return [_local_action(s, "firebase") for s in self._raw_actions()]
+
+    def _raw_actions(self) -> list[ActionSchema]:
         return [
             # Project Management
             ActionSchema(
@@ -545,3 +558,71 @@ class FirebaseAdapter:
 
     async def schema(self) -> dict[str, Any]:
         return {"table": None, "mapping": {}, "schedule": "manual"}
+
+    # -- Phase 1 PR-8 protocol additions ------------------------------------------
+
+    async def widgets(self) -> list[WidgetRecipe]:
+        """No default home widgets for Firebase — admin-only operations.
+
+        Custom widgets (e.g. "Hosting deploys this week") can be added
+        via chat once the local-agent bus is fully wired; CLI output
+        formatting is per-customer.
+        """
+        return []
+
+    async def health(self, scope: ConnectorScope | None = None) -> ConnectorHealth:
+        """Check whether the firebase CLI is reachable on this host.
+
+        Runs ``firebase --version`` with a short timeout. Cheap, no
+        Firebase project state required.
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self._firebase_bin, "--version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5)
+            except TimeoutError:
+                proc.kill()
+                return ConnectorHealth(
+                    ok=False,
+                    status=ConnectorStatus.ERROR,
+                    message="firebase --version timed out",
+                )
+            ok = proc.returncode == 0
+            return ConnectorHealth(
+                ok=ok,
+                status=ConnectorStatus.CONNECTED if ok else ConnectorStatus.ERROR,
+                message="firebase CLI reachable" if ok else "firebase CLI not on PATH",
+            )
+        except FileNotFoundError:
+            return ConnectorHealth(
+                ok=False,
+                status=ConnectorStatus.ERROR,
+                message=f"firebase binary missing ({self._firebase_bin})",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ConnectorHealth(
+                ok=False,
+                status=ConnectorStatus.ERROR,
+                message=str(exc),
+            )
+
+
+def _local_action(schema: ActionSchema, binary: str) -> ActionSchema:
+    """Decorator: stamp execution_mode=LOCAL and requires_binary onto a schema.
+
+    Used by CLI adapters (firebase, gcp) to declare local-mode uniformly
+    without touching every ActionSchema construction site.
+    """
+    return ActionSchema(
+        name=schema.name,
+        description=schema.description,
+        method=schema.method,
+        parameters=schema.parameters,
+        trust_level=schema.trust_level,
+        execution_mode=ExecutionMode.LOCAL,
+        requires_binary=binary,
+    )

--- a/src/pocketpaw/connectors/gcp_adapter.py
+++ b/src/pocketpaw/connectors/gcp_adapter.py
@@ -11,13 +11,17 @@ import shutil
 from pathlib import Path
 from typing import Any
 
+from pocketpaw.connectors.firebase_adapter import _local_action
 from pocketpaw.connectors.protocol import (
     ActionResult,
     ActionSchema,
     ConnectionResult,
+    ConnectorHealth,
+    ConnectorScope,
     ConnectorStatus,
     SyncResult,
     TrustLevel,
+    WidgetRecipe,
 )
 from pocketpaw.connectors.yaml_engine import ConnectorDef
 
@@ -125,7 +129,11 @@ class GCPAdapter:
         return True
 
     async def actions(self) -> list[ActionSchema]:
-        """Return action schemas from the YAML definition if available."""
+        """Return action schemas from the YAML definition if available.
+
+        Phase 1 PR-8: every action is stamped with execution_mode=LOCAL
+        and requires_binary="gcloud" via _local_action().
+        """
         if self._def:
             schemas = []
             for act in self._def.actions:
@@ -141,9 +149,9 @@ class GCPAdapter:
                         trust_level=TrustLevel(act.get("trust_level", "confirm")),
                     )
                 )
-            return schemas
+            return [_local_action(s, "gcloud") for s in schemas]
         # Fallback: return hardcoded action list
-        return self._hardcoded_actions()
+        return [_local_action(s, "gcloud") for s in self._hardcoded_actions()]
 
     async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
         """Execute a gcloud CLI command for the given action."""
@@ -168,6 +176,48 @@ class GCPAdapter:
 
     async def schema(self) -> dict[str, Any]:
         return {"table": None, "mapping": {}, "schedule": "manual"}
+
+    # -- Phase 1 PR-8 protocol additions ------------------------------------------
+
+    async def widgets(self) -> list[WidgetRecipe]:
+        """No default home widgets for GCP — admin-only ops."""
+        return []
+
+    async def health(self, scope: ConnectorScope | None = None) -> ConnectorHealth:
+        """Check whether the gcloud CLI is reachable."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self._gcloud or "gcloud", "--version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5)
+            except TimeoutError:
+                proc.kill()
+                return ConnectorHealth(
+                    ok=False,
+                    status=ConnectorStatus.ERROR,
+                    message="gcloud --version timed out",
+                )
+            ok = proc.returncode == 0
+            return ConnectorHealth(
+                ok=ok,
+                status=ConnectorStatus.CONNECTED if ok else ConnectorStatus.ERROR,
+                message="gcloud CLI reachable" if ok else "gcloud CLI not on PATH",
+            )
+        except FileNotFoundError:
+            return ConnectorHealth(
+                ok=False,
+                status=ConnectorStatus.ERROR,
+                message="gcloud binary missing",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ConnectorHealth(
+                ok=False,
+                status=ConnectorStatus.ERROR,
+                message=str(exc),
+            )
 
     # -- Internal helpers --
 

--- a/src/pocketpaw/runtime/__init__.py
+++ b/src/pocketpaw/runtime/__init__.py
@@ -1,0 +1,6 @@
+# pocketpaw runtime — local-process side of the connector bus.
+# Created: 2026-05-03 — Phase 1 PR-8.
+# Hosts the connector bus listener that picks up
+# `connector.exec.requested` events and runs CLI adapters
+# (firebase, gcp, future kubectl/gh/aws/...) on the user's machine,
+# then publishes `connector.exec.completed` back.

--- a/src/pocketpaw/runtime/connector_bus.py
+++ b/src/pocketpaw/runtime/connector_bus.py
@@ -1,0 +1,180 @@
+# Connector bus listener — runs CLI connectors on the user's host.
+# Created: 2026-05-03 — Phase 1 PR-8.
+#
+# Subscribes to the cloud's `connector.exec.requested` event. When
+# the cloud router dispatches a local-mode action (firebase, gcp, …),
+# this listener runs the matching adapter on the local machine and
+# publishes `connector.exec.completed` with the result.
+#
+# In single-process pocketpaw deployments (the captain's primary
+# shape — `mount_cloud(app)` runs inside the same FastAPI app as the
+# local runtime), the bus is in-process and the round-trip is direct.
+# In multi-tenant cloud deployments the bus must be cross-process
+# (RedisBus, Task 33) — the contract here is identical, only the
+# transport changes.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+from pathlib import Path
+from typing import Any
+
+from ee.cloud.shared.events import event_bus
+from pocketpaw.connectors.registry import ConnectorRegistry, _create_native_adapter
+
+logger = logging.getLogger(__name__)
+
+# Topics shared with ee/cloud/connectors/service.py
+EXEC_REQUESTED = "connector.exec.requested"
+EXEC_COMPLETED = "connector.exec.completed"
+
+# Default timeout per CLI invocation. CLI ops (firebase deploy, gcloud
+# pubsub publish) can take ~30-60s in practice; cap so a stuck command
+# doesn't block the listener forever.
+_EXEC_TIMEOUT_S = 60
+
+
+_registered = False
+
+
+def register_listener(connectors_dir: Path | None = None) -> None:
+    """Register the connector exec listener on the cloud event bus.
+
+    Idempotent — safe to call multiple times during boot.
+
+    Call from app startup once the cloud is mounted. In the captain's
+    local-first shape that's right after ``mount_cloud(app)`` in
+    pocketpaw's dashboard.py.
+    """
+    global _registered
+    if _registered:
+        return
+    handler = _build_handler(connectors_dir or Path("connectors"))
+    event_bus.subscribe(EXEC_REQUESTED, handler)
+    _registered = True
+    logger.info("connector bus listener registered on %s", EXEC_REQUESTED)
+
+
+def _build_handler(connectors_dir: Path):
+    """Build the async handler closed over a registry instance."""
+    registry = ConnectorRegistry(connectors_dir)
+
+    async def handler(payload: dict[str, Any]) -> None:
+        request_id = payload.get("request_id", "")
+        connector = payload.get("connector", "")
+        action = payload.get("action", "")
+        params = payload.get("params") or {}
+        requires_binary = payload.get("requires_binary")
+
+        if not connector or not action:
+            await _emit_completed(request_id, success=False, error="malformed exec request")
+            return
+
+        # Fail fast if the required binary is missing on this host.
+        if requires_binary and shutil.which(requires_binary) is None:
+            await _emit_completed(
+                request_id,
+                success=False,
+                error=f"connector.binary_missing: {requires_binary} not found on PATH",
+                connector=connector,
+                action=action,
+            )
+            return
+
+        adapter = _create_native_adapter(connector)
+        if adapter is None:
+            # Fall back to the YAML registry for connectors without a
+            # native Python class (rare for local-mode actions).
+            defn = registry.get_definition(connector)
+            if defn is None:
+                await _emit_completed(
+                    request_id,
+                    success=False,
+                    error=f"connector.not_found: {connector}",
+                )
+                return
+            from pocketpaw.connectors.yaml_engine import DirectRESTAdapter
+
+            adapter = DirectRESTAdapter(defn)
+
+        # CLI adapters expect connect() to be called before execute().
+        try:
+            if not getattr(adapter, "_connected", False):
+                await adapter.connect(payload.get("scope", "default"), {})
+        except Exception as exc:  # noqa: BLE001
+            await _emit_completed(
+                request_id,
+                success=False,
+                error=f"connect failed: {exc}",
+                connector=connector,
+                action=action,
+            )
+            return
+
+        try:
+            result = await asyncio.wait_for(
+                adapter.execute(action, params),
+                timeout=_EXEC_TIMEOUT_S,
+            )
+        except TimeoutError:
+            await _emit_completed(
+                request_id,
+                success=False,
+                error=f"action timed out after {_EXEC_TIMEOUT_S}s",
+                connector=connector,
+                action=action,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001
+            await _emit_completed(
+                request_id,
+                success=False,
+                error=str(exc),
+                connector=connector,
+                action=action,
+            )
+            return
+
+        await _emit_completed(
+            request_id,
+            success=result.success,
+            data=result.data,
+            error=result.error,
+            records_affected=result.records_affected,
+            connector=connector,
+            action=action,
+        )
+
+    return handler
+
+
+async def _emit_completed(
+    request_id: str,
+    *,
+    success: bool,
+    data: Any = None,
+    error: str | None = None,
+    records_affected: int = 0,
+    connector: str = "",
+    action: str = "",
+) -> None:
+    await event_bus.emit(
+        EXEC_COMPLETED,
+        {
+            "request_id": request_id,
+            "connector": connector,
+            "action": action,
+            "success": success,
+            "data": data,
+            "error": error,
+            "records_affected": records_affected,
+        },
+    )
+
+
+def reset_for_tests() -> None:
+    """Test-only — clear the registered flag so a fresh handler can subscribe."""
+    global _registered
+    _registered = False

--- a/tests/connectors/test_connector_bus.py
+++ b/tests/connectors/test_connector_bus.py
@@ -1,0 +1,159 @@
+# Connector bus listener — Phase 1 PR-8 contract tests.
+# Created: 2026-05-03 — pins the in-process round-trip:
+#   1. Cloud emits connector.exec.requested.
+#   2. Listener picks it up, runs the adapter on this host, publishes
+#      connector.exec.completed.
+#   3. Failure modes: missing binary → connector.binary_missing,
+#      unknown connector → connector.not_found, timeout, bare emit
+#      shapes.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ee.cloud.shared.events import event_bus
+from pocketpaw.connectors.protocol import ActionResult
+from pocketpaw.runtime import connector_bus
+
+
+@pytest.fixture(autouse=True)
+def _clean_subscribers():
+    """Reset the listener registration between tests."""
+    connector_bus.reset_for_tests()
+    # Snapshot + clear subscribers so previous tests don't bleed into ours.
+    saved = dict(event_bus._handlers)  # noqa: SLF001
+    event_bus._handlers.clear()  # noqa: SLF001
+    yield
+    event_bus._handlers.clear()  # noqa: SLF001
+    event_bus._handlers.update(saved)  # noqa: SLF001
+    connector_bus.reset_for_tests()
+
+
+def _capture_completed() -> list[dict]:
+    """Subscribe a capturing handler to connector.exec.completed."""
+    captured: list[dict] = []
+
+    async def handler(payload):
+        captured.append(payload)
+
+    event_bus.subscribe(connector_bus.EXEC_COMPLETED, handler)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# register_listener idempotence
+# ---------------------------------------------------------------------------
+
+
+def test_register_is_idempotent():
+    connector_bus.register_listener()
+    connector_bus.register_listener()
+    handlers = event_bus._handlers[connector_bus.EXEC_REQUESTED]  # noqa: SLF001
+    assert len(handlers) == 1
+
+
+# ---------------------------------------------------------------------------
+# Happy path — Gmail (cloud-mode adapter; tests the round-trip plumbing
+# even though Gmail isn't local-mode in production)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_trip_runs_adapter_and_publishes_completed():
+    captured = _capture_completed()
+    connector_bus.register_listener()
+
+    with patch(
+        "pocketpaw.connectors.adapters.gmail.GmailConnector.execute",
+        new=AsyncMock(return_value=ActionResult(success=True, data={"x": 1}, records_affected=1)),
+    ):
+        await event_bus.emit(
+            connector_bus.EXEC_REQUESTED,
+            {
+                "request_id": "req-1",
+                "connector": "gmail",
+                "action": "gmail_search",
+                "params": {"query": "x"},
+                "scope": "workspace",
+            },
+        )
+
+    assert len(captured) == 1
+    completed = captured[0]
+    assert completed["request_id"] == "req-1"
+    assert completed["success"] is True
+    assert completed["data"] == {"x": 1}
+    assert completed["records_affected"] == 1
+    assert completed["error"] is None
+
+
+# ---------------------------------------------------------------------------
+# Missing binary path — fails fast with connector.binary_missing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_binary_fails_fast(monkeypatch):
+    captured = _capture_completed()
+    connector_bus.register_listener()
+
+    monkeypatch.setattr("pocketpaw.runtime.connector_bus.shutil.which", lambda _: None)
+
+    await event_bus.emit(
+        connector_bus.EXEC_REQUESTED,
+        {
+            "request_id": "req-2",
+            "connector": "firebase",
+            "action": "list_projects",
+            "params": {},
+            "requires_binary": "firebase",
+        },
+    )
+
+    assert len(captured) == 1
+    assert captured[0]["success"] is False
+    assert "connector.binary_missing" in (captured[0]["error"] or "")
+
+
+# ---------------------------------------------------------------------------
+# Unknown connector — connector.not_found
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_connector_returns_not_found():
+    captured = _capture_completed()
+    connector_bus.register_listener()
+
+    await event_bus.emit(
+        connector_bus.EXEC_REQUESTED,
+        {
+            "request_id": "req-3",
+            "connector": "this-is-not-a-real-connector",
+            "action": "x",
+            "params": {},
+        },
+    )
+
+    assert len(captured) == 1
+    assert captured[0]["success"] is False
+    assert "connector.not_found" in (captured[0]["error"] or "")
+
+
+# ---------------------------------------------------------------------------
+# Malformed payload — emits an error completed event, doesn't crash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload():
+    captured = _capture_completed()
+    connector_bus.register_listener()
+
+    await event_bus.emit(connector_bus.EXEC_REQUESTED, {"request_id": "req-4"})
+
+    assert len(captured) == 1
+    assert captured[0]["success"] is False
+    assert "malformed" in (captured[0]["error"] or "")


### PR DESCRIPTION
Phase 1 PR-8. Wires the cross-process dispatch contract for CLI connectors so the cloud router can hand local-mode actions off to the user's pocketpaw runtime.

## What landed

- **firebase_adapter.py / gcp_adapter.py** — actions() now stamps every schema with `execution_mode=LOCAL` + `requires_binary="firebase" | "gcloud"`. `widgets()` returns `[]` (admin ops). `health()` runs the binary's `--version` for a cheap probe.
- **`src/pocketpaw/runtime/connector_bus.py`** — new listener subscribing to `connector.exec.requested`. Looks up the adapter, runs it on the local host, publishes `connector.exec.completed`. Fails fast on missing binary, unknown connector, timeout, malformed payload.
- **`ee/cloud/__init__.py`** — `register_listener()` called from `mount_cloud()` so the in-process round-trip works in single-user pocketpaw mode.

## Cross-process caveat

The bus is in-process today (`ee.cloud.shared.events.event_bus`). In single-user pocketpaw deployments cloud + runtime live in the same FastAPI app — round-trip is direct. Multi-tenant cloud needs RedisBus (Task 33). The contract is unchanged; only the transport swaps. The cloud router still 503s when a local-mode action is invoked — await-with-correlation lands alongside RedisBus.

## Tests (5 new)

- register_is_idempotent
- round_trip_runs_adapter_and_publishes_completed
- missing_binary_fails_fast
- unknown_connector_returns_not_found
- malformed_payload

179 connector-related tests pass. ruff clean.

## Test plan

- [x] 5 new bus tests
- [x] firebase + gcp existing tests still green
- [x] No regression in cloud router or other adapters
- [ ] Smoke: enable firebase via panel, dispatch a local action, observe 503 with hint to install firebase CLI