### PR TITLE
fix(rbac): wire missing access guards on connector and upload endpoints

### DIFF
--- a/ee/cloud/connectors/router.py
+++ b/ee/cloud/connectors/router.py
@@ -4,6 +4,11 @@
 # legacy src/pocketpaw/api/v1/connectors.py so the frontend's
 # ``getConnectors()`` works unchanged when this handler shadows the
 # runtime one in cloud deployments.
+#
+# Updated: 2026-05-06 (fix/rbac-connector-upload-guards) — added RBAC guards
+# to all mutation endpoints. execute → connector.execute (MEMBER); enable /
+# disable / config → connector.manage (ADMIN). Read-only routes (GET list,
+# GET detail, GET widget-recipes) retain require_license only.
 
 from __future__ import annotations
 
@@ -20,7 +25,11 @@ from ee.cloud.connectors.dto import (
     WidgetRecipeResponse,
 )
 from ee.cloud.license import require_license
-from ee.cloud.shared.deps import current_user_id, current_workspace_id
+from ee.cloud.shared.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_action_any_workspace,
+)
 
 # Mounted under /api/v1/cloud/connectors (not /api/v1/connectors) so it
 # does NOT shadow the legacy pocket-scoped routes in
@@ -62,7 +71,11 @@ async def list_widget_recipes(
     return await connectors_service.list_widget_recipes(workspace_id)
 
 
-@router.post("/{name}/execute", response_model=ExecuteActionResponse)
+@router.post(
+    "/{name}/execute",
+    response_model=ExecuteActionResponse,
+    dependencies=[Depends(require_action_any_workspace("connector.execute"))],
+)
 async def execute_action(
     name: str,
     body: ExecuteActionRequest,
@@ -89,7 +102,11 @@ async def get_connector(
     return await connectors_service.get_connector(workspace_id, name)
 
 
-@router.post("/{name}/enable", response_model=ConnectorResponse)
+@router.post(
+    "/{name}/enable",
+    response_model=ConnectorResponse,
+    dependencies=[Depends(require_action_any_workspace("connector.manage"))],
+)
 async def enable_connector(
     name: str,
     body: EnableConnectorRequest | None = None,
@@ -106,7 +123,11 @@ async def enable_connector(
     return await connectors_service.enable_connector(workspace_id, name, payload)
 
 
-@router.post("/{name}/disable", response_model=ConnectorResponse)
+@router.post(
+    "/{name}/disable",
+    response_model=ConnectorResponse,
+    dependencies=[Depends(require_action_any_workspace("connector.manage"))],
+)
 async def disable_connector(
     name: str,
     workspace_id: str = Depends(current_workspace_id),
@@ -115,7 +136,11 @@ async def disable_connector(
     return await connectors_service.disable_connector(workspace_id, name)
 
 
-@router.patch("/{name}/config", response_model=ConnectorResponse)
+@router.patch(
+    "/{name}/config",
+    response_model=ConnectorResponse,
+    dependencies=[Depends(require_action_any_workspace("connector.manage"))],
+)
 async def update_config(
     name: str,
     body: UpdateConnectorConfigRequest,

--- a/ee/cloud/uploads/router.py
+++ b/ee/cloud/uploads/router.py
@@ -19,6 +19,13 @@ by the pocket's ABAC (must have edit access via
 ``pockets.service.has_edit_access``) and the resulting ``FileUpload``
 row carries ``pocket_id`` so it's only visible through pocket-scoped
 listings + indexed into ``pocket:{id}`` KB.
+
+2026-05-06 (fix/rbac-connector-upload-guards): ``POST /uploads`` and
+``POST /uploads/folders`` now require ``uploads.write`` (MEMBER) via
+``require_action_any_workspace``. Previously ``current_workspace_id``
+authenticated the caller but did not verify workspace membership, so a
+user with a foreign workspace set as active_workspace could write files
+into it.
 """
 
 from __future__ import annotations
@@ -41,7 +48,11 @@ from fastapi import (
 from fastapi.responses import StreamingResponse
 
 from ee.cloud.license import require_license
-from ee.cloud.shared.deps import current_user_id, current_workspace_id
+from ee.cloud.shared.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_action_any_workspace,
+)
 from ee.cloud.shared.time import iso_utc
 from ee.cloud.uploads.folder_store import FolderStore
 from ee.cloud.uploads.mongo_store import MongoFileStore
@@ -113,7 +124,10 @@ def _record_to_dict(rec) -> dict:
 # ---------------------------------------------------------------------------
 
 
-@router.post("/folders")
+@router.post(
+    "/folders",
+    dependencies=[Depends(require_action_any_workspace("uploads.write"))],
+)
 async def create_folder(
     body: dict = Body(...),
     workspace: str = Depends(current_workspace_id),
@@ -253,7 +267,10 @@ async def delete_folder(
 # ---------------------------------------------------------------------------
 
 
-@router.post("")
+@router.post(
+    "",
+    dependencies=[Depends(require_action_any_workspace("uploads.write"))],
+)
 async def upload(
     files: Annotated[list[UploadFile], File(...)],
     chat_id: Annotated[str | None, Form()] = None,

--- a/src/pocketpaw/ee/guards/actions.py
+++ b/src/pocketpaw/ee/guards/actions.py
@@ -9,6 +9,12 @@
 # ``check_workspace_action`` (which already audits denials via
 # ``log_denial``) instead of hand-rolling the role check — closes the
 # P0 auth-bypass flagged in docs/plans/cluster-D-reality.md.
+#
+# Updated: 2026-05-06 (fix/rbac-connector-upload-guards) — registered
+# ``connector.execute`` (MEMBER), ``connector.manage`` (ADMIN),
+# ``uploads.write`` (MEMBER), and ``uploads.manage`` (ADMIN) so the
+# connector and uploads routers can use ``require_action_any_workspace``
+# instead of relying solely on ``require_license``.
 
 from __future__ import annotations
 
@@ -134,6 +140,17 @@ ACTIONS: dict[str, ActionRule] = {
     # authenticated caller could install into any workspace
     # (docs/plans/cluster-D-reality.md#106-112, P0 fix 2026-04-19).
     "fleet.install": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Connector — workspace-level connector lifecycle.
+    # execute is MEMBER so any team member can run actions against enabled connectors.
+    # manage (enable/disable/config) is ADMIN because it changes workspace-wide state
+    # visible to all members and can trigger OAuth flows or expose credentials.
+    "connector.execute": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
+    "connector.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Uploads — workspace-scoped file storage.
+    # write is MEMBER so any team member can upload files or create folders.
+    # manage is ADMIN for bulk moves, cross-user deletes, and storage policy changes.
+    "uploads.write": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
+    "uploads.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     # Admin — operational endpoints (perf timing dumps, etc.). Owner-only
     # because per-route timing reveals traffic patterns and request
     # cadence that shouldn't be visible to every admin in a workspace.


### PR DESCRIPTION
## What

\`require_license\` checks whether the workspace has a valid plan — it doesn't check whether the caller is actually allowed to do the thing. Three routers relied on it as the only gate on mutation endpoints, so any workspace member could enable connectors or upload files into a workspace they don't belong to.

Endpoints fixed:
- \`POST /cloud/connectors/{name}/execute\` — now requires \`connector.execute\` (MEMBER+)
- \`POST /cloud/connectors/{name}/enable\` — now requires \`connector.manage\` (ADMIN+)
- \`POST /cloud/connectors/{name}/disable\` — now requires \`connector.manage\` (ADMIN+)
- \`PATCH /cloud/connectors/{name}/config\` — now requires \`connector.manage\` (ADMIN+)
- \`POST /uploads\` — now requires \`uploads.write\` (MEMBER+)
- \`POST /uploads/folders\` — now requires \`uploads.write\` (MEMBER+)

\`POST /fleet/install\` was flagged in the same audit but was already fixed on 2026-04-19 — no change there.

## How

Added four entries to the ACTIONS matrix in \`src/pocketpaw/ee/guards/actions.py\`:

- \`connector.execute\` → MEMBER (any member can run connector actions)
- \`connector.manage\` → ADMIN (enabling/disabling changes workspace-wide state)
- \`uploads.write\` → MEMBER (upload files, create folders)
- \`uploads.manage\` → ADMIN (reserved for cross-user mutations)

Each mutation endpoint gets \`dependencies=[Depends(require_action_any_workspace(...))]\` in its decorator. Read routes untouched.

## Testing

\`tests/cloud/test_rbac_matrix.py\` is parametrized over every ACTIONS entry, so the 4 new rules get picked up automatically — allow path at minimum role, deny path below it. 204 pass. The one failure (\`test_context_budget.py::test_successful_kb_fetch\`) is pre-existing on \`ee\`.

## Still open

A broader RBAC audit turned up more gaps not covered here:
- 6 agent knowledge ingestion endpoints have no guards at all
- Fabric/Fleet/Instinct routes don't check plan gates
- Tool whitelist per role is defined in \`abac.py\` but never enforced at execution time
- No route-level integration tests yet (\`test_rbac_routes.py\` referenced in SPEC but not written)