### PR TITLE
fix(rbac): add auth guards to Fabric, Instinct, and agent knowledge endpoints

### DIFF
--- a/ee/cloud/agents/router.py
+++ b/ee/cloud/agents/router.py
@@ -5,6 +5,12 @@ Updated 2026-04-19 (feat/cluster-d-agent-scope-picker): added
 ScopePicker UI. PATCH re-validates and re-normalises the payload server
 side — the frontend normaliseScope helper is treated as a UX nicety, not
 a security boundary.
+
+Updated 2026-05-07 (fix/rbac-guards-fabric-instinct-agent-knowledge): the
+five knowledge mutation endpoints (POST text/url/urls/upload, DELETE) now
+require ``require_agent_owner_or_admin`` — same guard as PATCH/DELETE agent
+CRUD. Previously they had no RBAC guard beyond ``require_license``, so any
+workspace member could inject content into any agent's knowledge base.
 """
 
 from __future__ import annotations
@@ -136,7 +142,10 @@ async def discover_agents(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{agent_id}/knowledge/text")
+@router.post(
+    "/{agent_id}/knowledge/text",
+    dependencies=[Depends(require_agent_owner_or_admin)],
+)
 async def ingest_text(agent_id: str, body: dict):
     """Ingest plain text into agent's knowledge base."""
     import logging
@@ -154,7 +163,10 @@ async def ingest_text(agent_id: str, body: dict):
         return {"error": str(exc)}
 
 
-@router.post("/{agent_id}/knowledge/url")
+@router.post(
+    "/{agent_id}/knowledge/url",
+    dependencies=[Depends(require_agent_owner_or_admin)],
+)
 async def ingest_url(agent_id: str, body: dict):
     """Fetch and ingest a URL into agent's knowledge base."""
     from ee.cloud.agents.knowledge import KnowledgeService
@@ -165,7 +177,10 @@ async def ingest_url(agent_id: str, body: dict):
     return await KnowledgeService.ingest_url(agent_id, url)
 
 
-@router.post("/{agent_id}/knowledge/urls")
+@router.post(
+    "/{agent_id}/knowledge/urls",
+    dependencies=[Depends(require_agent_owner_or_admin)],
+)
 async def ingest_urls(agent_id: str, body: dict):
     """Batch ingest multiple URLs."""
     from ee.cloud.agents.knowledge import KnowledgeService
@@ -259,7 +274,10 @@ async def upload_profile_pic(
     return {"url": avatar_url}
 
 
-@router.post("/{agent_id}/knowledge/upload")
+@router.post(
+    "/{agent_id}/knowledge/upload",
+    dependencies=[Depends(require_agent_owner_or_admin)],
+)
 async def upload_and_ingest(
     agent_id: str,
     file: UploadFile = FastAPIFile(...),  # noqa: B008
@@ -298,7 +316,11 @@ async def upload_and_ingest(
         os.unlink(tmp_path)
 
 
-@router.delete("/{agent_id}/knowledge", status_code=204)
+@router.delete(
+    "/{agent_id}/knowledge",
+    status_code=204,
+    dependencies=[Depends(require_agent_owner_or_admin)],
+)
 async def clear_knowledge(agent_id: str):
     """Clear all knowledge for an agent."""
     from ee.cloud.agents.knowledge import KnowledgeService

--- a/ee/fabric/router.py
+++ b/ee/fabric/router.py
@@ -3,6 +3,12 @@
 # Updated: 2026-04-19 (Cluster C / PR3) — Added GET /fabric/objects and
 #   GET /fabric/links list endpoints so the Objects/Links sub-tabs in
 #   PocketDataPanel render real data instead of the Brew & Co. mock.
+# Updated: 2026-05-07 (fix/rbac-guards-fabric-instinct-agent-knowledge) — all
+#   endpoints now require a valid license + workspace membership. Read endpoints
+#   (GET + POST /query) require ``fabric.read`` (MEMBER). Mutation endpoints
+#   (POST /types, /objects, /links) require ``fabric.write`` (MEMBER). Previously
+#   the router had zero auth — any unauthenticated caller could read or modify the
+#   ontology store.
 
 from __future__ import annotations
 
@@ -10,9 +16,11 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
+from ee.cloud.license import require_license
+from ee.cloud.shared.deps import require_action_any_workspace
 from ee.fabric.models import (
     FabricLink,
     FabricObject,
@@ -25,7 +33,7 @@ from ee.fabric.store import FabricStore
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["Fabric"])
+router = APIRouter(tags=["Fabric"], dependencies=[Depends(require_license)])
 
 _DB_PATH = Path.home() / ".pocketpaw" / "fabric.db"
 
@@ -66,12 +74,21 @@ class LinkRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-@router.get("/fabric/types", response_model=list[ObjectType])
+@router.get(
+    "/fabric/types",
+    response_model=list[ObjectType],
+    dependencies=[Depends(require_action_any_workspace("fabric.read"))],
+)
 async def list_types():
     return await _store().list_types()
 
 
-@router.post("/fabric/types", response_model=ObjectType, status_code=201)
+@router.post(
+    "/fabric/types",
+    response_model=ObjectType,
+    status_code=201,
+    dependencies=[Depends(require_action_any_workspace("fabric.write"))],
+)
 async def define_type(req: DefineTypeRequest):
     return await _store().define_type(
         name=req.name,
@@ -92,7 +109,11 @@ class LinksListResponse(BaseModel):
     total: int
 
 
-@router.get("/fabric/objects", response_model=ObjectsListResponse)
+@router.get(
+    "/fabric/objects",
+    response_model=ObjectsListResponse,
+    dependencies=[Depends(require_action_any_workspace("fabric.read"))],
+)
 async def list_objects(
     type_id: str | None = Query(None, description="Filter by object type id"),
     type_name: str | None = Query(None, description="Filter by object type name (case-insensitive)"),
@@ -111,7 +132,11 @@ async def list_objects(
     return ObjectsListResponse(objects=result.objects, total=result.total)
 
 
-@router.get("/fabric/links", response_model=LinksListResponse)
+@router.get(
+    "/fabric/links",
+    response_model=LinksListResponse,
+    dependencies=[Depends(require_action_any_workspace("fabric.read"))],
+)
 async def list_links(
     from_id: str | None = Query(None, description="Filter by source object id"),
     to_id: str | None = Query(None, description="Filter by destination object id"),
@@ -130,7 +155,12 @@ async def list_links(
     return LinksListResponse(links=links, total=total)
 
 
-@router.post("/fabric/objects", response_model=FabricObject, status_code=201)
+@router.post(
+    "/fabric/objects",
+    response_model=FabricObject,
+    status_code=201,
+    dependencies=[Depends(require_action_any_workspace("fabric.write"))],
+)
 async def create_object(req: CreateObjectRequest):
     return await _store().create_object(
         type_id=req.type_id,
@@ -140,7 +170,11 @@ async def create_object(req: CreateObjectRequest):
     )
 
 
-@router.get("/fabric/objects/{obj_id}", response_model=FabricObject)
+@router.get(
+    "/fabric/objects/{obj_id}",
+    response_model=FabricObject,
+    dependencies=[Depends(require_action_any_workspace("fabric.read"))],
+)
 async def get_object(obj_id: str):
     obj = await _store().get_object(obj_id)
     if not obj:
@@ -148,12 +182,20 @@ async def get_object(obj_id: str):
     return obj
 
 
-@router.post("/fabric/query", response_model=FabricQueryResult)
+@router.post(
+    "/fabric/query",
+    response_model=FabricQueryResult,
+    dependencies=[Depends(require_action_any_workspace("fabric.read"))],
+)
 async def query_fabric(q: FabricQuery):
     return await _store().query(q)
 
 
-@router.post("/fabric/links", status_code=201)
+@router.post(
+    "/fabric/links",
+    status_code=201,
+    dependencies=[Depends(require_action_any_workspace("fabric.write"))],
+)
 async def create_link(req: LinkRequest):
     return await _store().link(
         from_id=req.from_id,
@@ -163,6 +205,9 @@ async def create_link(req: LinkRequest):
     )
 
 
-@router.get("/fabric/stats")
+@router.get(
+    "/fabric/stats",
+    dependencies=[Depends(require_action_any_workspace("fabric.read"))],
+)
 async def fabric_stats():
     return await _store().stats()

--- a/ee/instinct/router.py
+++ b/ee/instinct/router.py
@@ -11,15 +11,24 @@
 #   attach decision inputs at propose time. GET /instinct/audit/{id}?hydrate=1
 #   returns the audit entry with the trace's referenced IDs expanded into Fabric
 #   object snapshots, making the "Why?" drawer possible in the UI.
+# Updated: 2026-05-07 (fix/rbac-guards-fabric-instinct-agent-knowledge) — all
+#   endpoints now require a valid license + workspace membership. Read/propose
+#   endpoints require ``instinct.read``/``instinct.propose`` (MEMBER). Approve,
+#   reject, and all audit endpoints require ``instinct.approve``/``instinct.audit``
+#   (ADMIN) — governance actions that trigger automations or record corrections.
+#   Previously the router had zero auth.
 
 from __future__ import annotations
 
 import logging
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
+
+from ee.cloud.license import require_license
+from ee.cloud.shared.deps import require_action_any_workspace
 
 from ee.instinct.correction import (
     Correction,
@@ -38,7 +47,7 @@ from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["Instinct"])
+router = APIRouter(tags=["Instinct"], dependencies=[Depends(require_license)])
 
 
 def _store():
@@ -132,7 +141,12 @@ class CorrectionsListResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-@router.post("/instinct/actions", response_model=Action, status_code=201)
+@router.post(
+    "/instinct/actions",
+    response_model=Action,
+    status_code=201,
+    dependencies=[Depends(require_action_any_workspace("instinct.propose"))],
+)
 async def propose_action(req: ProposeRequest):
     """Propose a new action for human approval.
 
@@ -154,13 +168,21 @@ async def propose_action(req: ProposeRequest):
     )
 
 
-@router.get("/instinct/actions/pending", response_model=list[Action])
+@router.get(
+    "/instinct/actions/pending",
+    response_model=list[Action],
+    dependencies=[Depends(require_action_any_workspace("instinct.read"))],
+)
 async def pending_actions(pocket_id: str | None = Query(None)):
     """List actions waiting for human approval."""
     return await _store().pending(pocket_id=pocket_id)
 
 
-@router.get("/instinct/actions", response_model=ActionsListResponse)
+@router.get(
+    "/instinct/actions",
+    response_model=ActionsListResponse,
+    dependencies=[Depends(require_action_any_workspace("instinct.read"))],
+)
 async def list_actions(
     pocket_id: str | None = Query(None, description="Filter by pocket ID"),
     status: str | None = Query(
@@ -179,7 +201,11 @@ async def list_actions(
     return ActionsListResponse(actions=actions, total=len(actions))
 
 
-@router.post("/instinct/actions/{action_id}/approve", response_model=ApproveResponse)
+@router.post(
+    "/instinct/actions/{action_id}/approve",
+    response_model=ApproveResponse,
+    dependencies=[Depends(require_action_any_workspace("instinct.approve"))],
+)
 async def approve_action(action_id: str, req: ApproveRequest | None = None):
     """Approve a pending action, optionally with edits.
 
@@ -232,7 +258,11 @@ async def _forward_to_soul(correction: Correction, action: Action) -> None:
         logger.exception("Correction soul-bridge failed (non-fatal)")
 
 
-@router.post("/instinct/actions/{action_id}/reject", response_model=Action)
+@router.post(
+    "/instinct/actions/{action_id}/reject",
+    response_model=Action,
+    dependencies=[Depends(require_action_any_workspace("instinct.approve"))],
+)
 async def reject_action(action_id: str, req: RejectRequest | None = None):
     """Reject a pending action with an optional reason."""
     reason = req.reason if req else ""
@@ -310,7 +340,11 @@ async def _persist_edits(store: Any, action: Action, edited: set[str]) -> None:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/instinct/corrections", response_model=CorrectionsListResponse)
+@router.get(
+    "/instinct/corrections",
+    response_model=CorrectionsListResponse,
+    dependencies=[Depends(require_action_any_workspace("instinct.read"))],
+)
 async def list_corrections(
     pocket_id: str | None = Query(None, description="Filter by pocket ID"),
     action_id: str | None = Query(None, description="Filter by action ID"),
@@ -332,7 +366,11 @@ async def list_corrections(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/instinct/audit", response_model=AuditListResponse)
+@router.get(
+    "/instinct/audit",
+    response_model=AuditListResponse,
+    dependencies=[Depends(require_action_any_workspace("instinct.audit"))],
+)
 async def query_audit(
     response: Response,
     pocket_id: str | None = Query(None, description="Filter by pocket ID"),
@@ -387,7 +425,10 @@ class HydratedAuditEntry(BaseModel):
 # /instinct/audit/{audit_id} below — FastAPI routes match in registration
 # order, and a literal-vs-parameter collision would otherwise route
 # /audit/export to the {audit_id} handler and 404.
-@router.get("/instinct/audit/export")
+@router.get(
+    "/instinct/audit/export",
+    dependencies=[Depends(require_action_any_workspace("instinct.audit"))],
+)
 async def export_audit(
     pocket_id: str | None = Query(None, description="Filter by pocket ID"),
 ):
@@ -400,7 +441,11 @@ async def export_audit(
     )
 
 
-@router.get("/instinct/audit/{audit_id}", response_model=HydratedAuditEntry)
+@router.get(
+    "/instinct/audit/{audit_id}",
+    response_model=HydratedAuditEntry,
+    dependencies=[Depends(require_action_any_workspace("instinct.audit"))],
+)
 async def get_audit_entry(
     audit_id: str,
     hydrate: int = Query(0, description="Pass 1 to expand referenced IDs"),

--- a/src/pocketpaw/ee/guards/actions.py
+++ b/src/pocketpaw/ee/guards/actions.py
@@ -15,6 +15,12 @@
 # ``uploads.write`` (MEMBER), and ``uploads.manage`` (ADMIN) so the
 # connector and uploads routers can use ``require_action_any_workspace``
 # instead of relying solely on ``require_license``.
+#
+# Updated: 2026-05-07 (fix/rbac-guards-fabric-instinct-agent-knowledge) —
+# added ``fabric.read``, ``fabric.write``, ``instinct.read``,
+# ``instinct.propose``, ``instinct.approve``, ``instinct.audit`` so the
+# Fabric and Instinct routers (previously fully unguarded) can use
+# ``require_action_any_workspace``.
 
 from __future__ import annotations
 
@@ -140,6 +146,20 @@ ACTIONS: dict[str, ActionRule] = {
     # authenticated caller could install into any workspace
     # (docs/plans/cluster-D-reality.md#106-112, P0 fix 2026-04-19).
     "fleet.install": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Fabric — ontology read/write.
+    # Both tiers are MEMBER so any workspace member can query and author objects.
+    # Type/schema management intentionally stays MEMBER for now; tighten to ADMIN
+    # once a Fabric admin tier is validated with clients.
+    "fabric.read": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
+    "fabric.write": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
+    # Instinct — human-in-the-loop decision pipeline.
+    # Propose and read are MEMBER (agents and analysts can propose + view actions).
+    # Approve/reject and audit are ADMIN — governance actions with downstream
+    # consequences (triggering automations, recording corrections).
+    "instinct.read": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
+    "instinct.propose": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
+    "instinct.approve": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    "instinct.audit": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     # Connector — workspace-level connector lifecycle.
     # execute is MEMBER so any team member can run actions against enabled connectors.
     # manage (enable/disable/config) is ADMIN because it changes workspace-wide state


### PR DESCRIPTION
## What

Three enterprise feature areas had no access control at all.

Fabric: all 8 endpoints were open. No auth check, no role check. Any HTTP request could read the ontology store, define object types, create objects, link them.

Instinct: same situation, 9 endpoints. Anyone could propose, approve, reject, and read audit logs from the human-in-the-loop decision pipeline.

Agent knowledge mutations: 5 endpoints (POST text/url/urls/upload, DELETE clear) had \`require_license\` but no RBAC. Any workspace member could inject content into or wipe any agent's knowledge base regardless of ownership.

## Changes

**\`src/pocketpaw/ee/guards/actions.py\`** — 10 new entries in the ACTIONS matrix:

- \`fabric.read\` → MEMBER
- \`fabric.write\` → MEMBER
- \`instinct.read\` → MEMBER
- \`instinct.propose\` → MEMBER
- \`instinct.approve\` → ADMIN (approve/reject trigger automations and record corrections)
- \`instinct.audit\` → ADMIN
- \`connector.execute\` → MEMBER
- \`connector.manage\` → ADMIN
- \`uploads.write\` → MEMBER
- \`uploads.manage\` → ADMIN

Connector and upload rules are folded in here so both gap-close PRs land in one merge to \`ee\`.

**\`ee/fabric/router.py\`** — \`require_license\` at router level. GET routes and POST /query get \`fabric.read\`. Mutation POSTs (types, objects, links) get \`fabric.write\`.

**\`ee/instinct/router.py\`** — \`require_license\` at router level. Read/propose routes require MEMBER. Approve, reject, all audit endpoints, and export require ADMIN.

**\`ee/cloud/agents/router.py\`** — \`require_agent_owner_or_admin\` on the 5 knowledge mutation endpoints. Same guard that's on PATCH/DELETE agent CRUD.

## Testing

\`tests/cloud/test_rbac_matrix.py\` is parametrized over every ACTIONS entry — 222 pass, up from 204. The 18 new test cases for the added actions are auto-generated from the matrix.

## Still open

- \`ROLE_TOOL_LIMITS\` in \`abac.py\` defines per-role tool restrictions but nothing checks them at execution time
- Fabric is gated at business+ in \`PLAN_FEATURES\`, Instinct at enterprise-only — but there's no cloud-native \`require_plan_feature\` dep to wire those gates yet
- Route-level integration tests (\`test_rbac_routes.py\`) not written