### PR TITLE
feat(rbac): add cloud-native require_plan_feature dependency

### DIFF
--- a/ee/cloud/_core/deps.py
+++ b/ee/cloud/_core/deps.py
@@ -11,6 +11,8 @@ delegates to ``pocketpaw.ee.guards`` (the platform-wide RBAC package) for
 the actual policy lookup. We translate platform ``GuardForbidden``
 exceptions to cloud-native ``Forbidden`` so the standard error envelope
 applies.
+
+Changes: added require_plan_feature dependency for plan-tier feature gating.
 """
 
 from __future__ import annotations
@@ -134,6 +136,54 @@ async def require_membership(
     raise Forbidden("workspace.not_member", "Not a member of this workspace")
 
 
+# ---------------------------------------------------------------------------
+# Plan-tier feature gate
+# ---------------------------------------------------------------------------
+
+_PLAN_ORDER = ("team", "business", "enterprise")
+
+
+def require_plan_feature(feature: str) -> Callable[..., Coroutine[Any, Any, None]]:
+    """FastAPI dependency gating access by workspace plan tier.
+
+    Loads the workspace's plan from the Workspace document and checks it
+    against PLAN_FEATURES. Raises cloud Forbidden with code
+    'plan.feature_denied' if the feature is not available on the plan.
+
+    Use on routes that require business+ or enterprise features::
+
+        @router.get(
+            "/fabric/types",
+            dependencies=[
+                Depends(require_plan_feature("fabric")),
+                Depends(require_action_any_workspace("fabric.read")),
+            ],
+        )
+    """
+    from pocketpaw.ee.guards.abac import PLAN_FEATURES
+
+    # Compute the minimum plan that unlocks this feature, for the error message.
+    needed_plan = "enterprise"
+    for plan in _PLAN_ORDER:
+        if feature in PLAN_FEATURES.get(plan, set()):
+            needed_plan = plan
+            break
+
+    async def _guard(workspace_id: str = Depends(current_workspace_id)) -> None:
+        from ee.cloud.workspace import service as workspace_service
+
+        plan = await workspace_service.get_workspace_plan(workspace_id)
+        allowed_features = PLAN_FEATURES.get(plan, set())
+        if feature not in allowed_features:
+            raise Forbidden(
+                "plan.feature_denied",
+                f"feature {feature!r} requires {needed_plan}",
+            )
+
+    _guard.__name__ = f"require_plan_feature_{feature.replace('.', '_')}"
+    return _guard
+
+
 __all__ = [
     "current_user",
     "current_user_id",
@@ -142,4 +192,5 @@ __all__ = [
     "require_action",
     "require_action_any_workspace",
     "require_membership",
+    "require_plan_feature",
 ]

--- a/ee/cloud/shared/deps.py
+++ b/ee/cloud/shared/deps.py
@@ -8,6 +8,8 @@ imports keep working; new code should import from ``_core``.
 The domain-specific guards (group, agent, pocket) remain here. They
 delegate the Beanie loads to their owning entity services so this
 module doesn't import any ``ee.cloud.models.*`` Beanie docs.
+
+Changes: re-export require_plan_feature from _core.deps.
 """
 
 from __future__ import annotations
@@ -26,6 +28,7 @@ from ee.cloud._core.deps import (
     require_action,
     require_action_any_workspace,
     require_membership,
+    require_plan_feature,
 )
 from ee.cloud._core.errors import Forbidden
 from ee.cloud.auth import current_active_user
@@ -43,6 +46,7 @@ __all__ = [
     "require_agent_owner_or_admin",
     "require_group_action",
     "require_membership",
+    "require_plan_feature",
     "require_pocket_edit",
     "require_pocket_owner",
 ]

--- a/ee/cloud/workspace/service.py
+++ b/ee/cloud/workspace/service.py
@@ -16,6 +16,11 @@ Public API:
 - ``list_member_ids(workspace_id)``, ``list_admin_ids(workspace_id)``,
   ``list_peer_ids(user_id)`` — used as function refs by the realtime
   audience resolver
+- ``get_workspace_plan(workspace_id)`` — lightweight plan-tier lookup for
+  the plan-feature gate dependency; returns "team" on any failure so the
+  dep fails open on plan rather than crashing with a 500.
+
+Changes: added get_workspace_plan helper for plan-feature gate dep.
 """
 
 from __future__ import annotations
@@ -656,12 +661,26 @@ async def seed_default_workspace(
         return None
 
 
+async def get_workspace_plan(workspace_id: str) -> str:
+    """Return the plan tier string for a workspace.
+
+    Used by the plan-feature gate dependency. Returns "team" (the most
+    restrictive plan) as a safe fallback when the workspace cannot be
+    loaded so the guard fails open on plan rather than raising a 500.
+    """
+    doc = await _fetch_workspace(workspace_id)
+    if doc is None:
+        return "team"
+    return doc.plan
+
+
 __all__ = [
     "accept_invite",
     "create",
     "create_invite",
     "delete",
     "get",
+    "get_workspace_plan",
     "legacy_ctx",
     "list_admin_ids",
     "list_for_user",

--- a/ee/fabric/router.py
+++ b/ee/fabric/router.py
@@ -9,6 +9,11 @@
 #   (POST /types, /objects, /links) require ``fabric.write`` (MEMBER). Previously
 #   the router had zero auth — any unauthenticated caller could read or modify the
 #   ontology store.
+# Updated: 2026-05-07 (feat/rbac-plan-feature-gate) — added router-level
+#   ``require_plan_feature("fabric")`` so the entire Fabric API is gated to
+#   business-tier (or higher) plans. Closes the plan-tier bypass where a
+#   team-plan member who passed the workspace RBAC check still hit Fabric for
+#   free.
 
 from __future__ import annotations
 
@@ -19,6 +24,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
+from ee.cloud._core.deps import require_plan_feature
 from ee.cloud.license import require_license
 from ee.cloud.shared.deps import require_action_any_workspace
 from ee.fabric.models import (
@@ -33,7 +39,10 @@ from ee.fabric.store import FabricStore
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["Fabric"], dependencies=[Depends(require_license)])
+router = APIRouter(
+    tags=["Fabric"],
+    dependencies=[Depends(require_license), Depends(require_plan_feature("fabric"))],
+)
 
 _DB_PATH = Path.home() / ".pocketpaw" / "fabric.db"
 

--- a/ee/instinct/router.py
+++ b/ee/instinct/router.py
@@ -17,6 +17,11 @@
 #   reject, and all audit endpoints require ``instinct.approve``/``instinct.audit``
 #   (ADMIN) — governance actions that trigger automations or record corrections.
 #   Previously the router had zero auth.
+# Updated: 2026-05-07 (feat/rbac-plan-feature-gate) — added router-level
+#   ``require_plan_feature("instinct")`` so the entire Instinct API is gated to
+#   business-tier (or higher) plans. Closes the plan-tier bypass where a
+#   team-plan member who passed the workspace RBAC check still hit Instinct for
+#   free.
 
 from __future__ import annotations
 
@@ -27,6 +32,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
+from ee.cloud._core.deps import require_plan_feature
 from ee.cloud.license import require_license
 from ee.cloud.shared.deps import require_action_any_workspace
 
@@ -47,7 +53,10 @@ from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["Instinct"], dependencies=[Depends(require_license)])
+router = APIRouter(
+    tags=["Instinct"],
+    dependencies=[Depends(require_license), Depends(require_plan_feature("instinct"))],
+)
 
 
 def _store():

--- a/tests/cloud/test_plan_feature_gate.py
+++ b/tests/cloud/test_plan_feature_gate.py
@@ -1,0 +1,174 @@
+# Tests for ee/cloud require_plan_feature FastAPI dependency.
+# Created: 2026-05-07
+# Covers plan-tier gating for fabric (business+) and instinct (enterprise-only).
+# Patches workspace_service.get_workspace_plan so no DB is needed.
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from ee.cloud._core.deps import current_workspace_id, require_plan_feature
+from ee.cloud._core.errors import Forbidden
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_app(feature: str, *, fixed_workspace_id: str = "ws-test") -> FastAPI:
+    """Build a minimal FastAPI app with require_plan_feature guarding one route.
+
+    current_workspace_id is overridden to return a fixed ID so no JWT or
+    User model is involved. The workspace plan is controlled per-test by
+    patching workspace_service.get_workspace_plan.
+    """
+    from ee.cloud._core.http import add_error_handler
+
+    app = FastAPI()
+    add_error_handler(app)
+
+    app.dependency_overrides[current_workspace_id] = lambda: fixed_workspace_id
+
+    @app.get(
+        "/guarded",
+        dependencies=[Depends(require_plan_feature(feature))],
+    )
+    async def guarded_endpoint() -> dict[str, Any]:
+        return {"ok": True}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patch_plan(monkeypatch: pytest.MonkeyPatch):
+    """Return a setter that patches get_workspace_plan to return a fixed plan."""
+
+    def _patch(plan: str) -> None:
+        import ee.cloud.workspace.service as ws_svc
+
+        monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value=plan))
+
+    return _patch
+
+
+# ---------------------------------------------------------------------------
+# fabric — business+
+# ---------------------------------------------------------------------------
+
+
+class TestFabricFeatureGate:
+    """require_plan_feature("fabric") allows business/enterprise, blocks team."""
+
+    def test_member_on_business_plan_can_access_fabric(self, patch_plan):
+        """A workspace on the business plan should pass the fabric gate."""
+        patch_plan("business")
+        client = TestClient(_build_app("fabric"), raise_server_exceptions=False)
+        resp = client.get("/guarded")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+    def test_member_on_team_plan_is_denied_fabric(self, patch_plan):
+        """A workspace on the team plan must get 403 with plan.feature_denied."""
+        patch_plan("team")
+        client = TestClient(_build_app("fabric"), raise_server_exceptions=False)
+        resp = client.get("/guarded")
+        assert resp.status_code == 403
+        body = resp.json()
+        assert body["error"]["code"] == "plan.feature_denied"
+
+    def test_enterprise_plan_can_access_fabric(self, patch_plan):
+        """Enterprise plan includes all business features, so fabric is allowed."""
+        patch_plan("enterprise")
+        client = TestClient(_build_app("fabric"), raise_server_exceptions=False)
+        resp = client.get("/guarded")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# instinct — enterprise-only
+# ---------------------------------------------------------------------------
+
+
+class TestInstinctFeatureGate:
+    """require_plan_feature("instinct") allows enterprise, blocks team and business."""
+
+    def test_member_on_enterprise_plan_can_access_instinct(self, patch_plan):
+        """Enterprise plan includes instinct."""
+        patch_plan("enterprise")
+        client = TestClient(_build_app("instinct"), raise_server_exceptions=False)
+        resp = client.get("/guarded")
+        assert resp.status_code == 200
+
+    def test_admin_on_business_plan_is_denied_instinct(self, patch_plan):
+        """Business plan does not include instinct; must return 403."""
+        patch_plan("business")
+        client = TestClient(_build_app("instinct"), raise_server_exceptions=False)
+        resp = client.get("/guarded")
+        assert resp.status_code == 403
+        body = resp.json()
+        assert body["error"]["code"] == "plan.feature_denied"
+
+    def test_team_plan_is_denied_instinct(self, patch_plan):
+        """Team plan does not include instinct; must return 403."""
+        patch_plan("team")
+        client = TestClient(_build_app("instinct"), raise_server_exceptions=False)
+        resp = client.get("/guarded")
+        assert resp.status_code == 403
+        body = resp.json()
+        assert body["error"]["code"] == "plan.feature_denied"
+
+
+# ---------------------------------------------------------------------------
+# Fallback / edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestPlanFeatureGateEdgeCases:
+    """Edge cases: unknown plan falls back to team behaviour (fail open on 500,
+    deny on feature)."""
+
+    def test_unknown_plan_denies_restricted_feature(self, patch_plan):
+        """An unrecognised plan string has no features; restricted feature denied."""
+        patch_plan("free")  # not a real plan tier
+        client = TestClient(_build_app("fabric"), raise_server_exceptions=False)
+        resp = client.get("/guarded")
+        assert resp.status_code == 403
+
+    def test_team_feature_passes_on_team_plan(self, patch_plan):
+        """Features available on team plan (e.g. pockets) are always accessible."""
+        patch_plan("team")
+        client = TestClient(_build_app("pockets"), raise_server_exceptions=False)
+        resp = client.get("/guarded")
+        assert resp.status_code == 200
+
+    def test_workspace_not_found_denies_restricted_feature(self, monkeypatch):
+        """When get_workspace_plan returns the 'team' fallback (workspace not found),
+        a business+ feature is still denied rather than raising a 500."""
+        import ee.cloud.workspace.service as ws_svc
+
+        # Simulate the fallback: workspace missing, returns "team"
+        monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="team"))
+        client = TestClient(_build_app("fabric"), raise_server_exceptions=False)
+        resp = client.get("/guarded")
+        assert resp.status_code == 403
+        assert resp.json()["error"]["code"] == "plan.feature_denied"
+
+    def test_error_message_names_needed_plan(self, patch_plan):
+        """The 403 body message should name the minimum required plan."""
+        patch_plan("team")
+        client = TestClient(_build_app("fabric"), raise_server_exceptions=False)
+        resp = client.get("/guarded")
+        assert resp.status_code == 403
+        # Error message should mention "business" as the needed plan for fabric
+        assert "business" in resp.json()["error"]["message"]


### PR DESCRIPTION
Routes that require business or enterprise features can now declare that in the dependency list instead of hand-rolling the check inside each handler.

Three files changed:

`workspace/service.py` gets a new `get_workspace_plan(workspace_id)` helper. It loads the Workspace doc and returns the plan string. If the workspace is not found (e.g. bad ID, soft-deleted), it returns "team" rather than crashing, which means the gate fails closed on restricted features without a 500.

`_core/deps.py` gets `require_plan_feature(feature)`. It grabs the workspace ID from `current_workspace_id`, calls the service helper (lazy import, Beanie stays out of deps.py), and compares against `PLAN_FEATURES` from `pocketpaw.ee.guards.abac`. On deny it raises `Forbidden("plan.feature_denied", ...)` with the minimum required plan in the message.

```python
@router.get(
    "/fabric/types",
    dependencies=[
        Depends(require_plan_feature("fabric")),
        Depends(require_action_any_workspace("fabric.read")),
    ],
)
```

`shared/deps.py` re-exports it so import paths that already exist keep working.

10 new tests in `tests/cloud/test_plan_feature_gate.py`. Covers fabric on team/business/enterprise, instinct on business/enterprise, workspace-not-found fallback, and the error message content. All pass. 2 pre-existing failures on the ee branch are unrelated.