### PR TITLE
ci: add pytest workflow to PR Quality Gate (#1065)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,36 @@
+# Tests — runs the pytest suite on every PR and on pushes to ee/main/dev.
+# Created: 2026-05-07 — Added pytest job to PR Quality Gate so broken tests
+# can no longer slip through CI on PRs targeting ee. Closes #1065.
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [ee, main, dev]
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set Python version
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run pytest
+        run: uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py -q --tb=short
+        env:
+          POCKETPAW_LLM_PROVIDER: "ollama"
+          POCKETPAW_OLLAMA_HOST: "http://localhost:11434"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,7 @@ name: Tests
 
 on:
   pull_request:
+    branches: [ee, main, dev]
   push:
     branches: [ee, main, dev]
 
@@ -30,6 +31,7 @@ jobs:
         run: uv sync --dev
 
       - name: Run pytest
+        # No -x: this is a PR gate, surface ALL failures, not just the first.
         run: uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py -q --tb=short
         env:
           POCKETPAW_LLM_PROVIDER: "ollama"


### PR DESCRIPTION
## Why

The PR Quality Gate currently runs lint (`check-quality`) and `security-scan`, but no pytest. The result: PRs targeting `ee` ship with broken tests undetected. #1059 broke 35 tests on `ee` and merged with all-green CI because nothing actually runs the suite for `ee`-targeted PRs (the existing `ci.yml` only triggers on `dev`/`main`).

## What this adds

A single new workflow file: `.github/workflows/tests.yaml`.

- Triggers on every `pull_request` and on `push` to `ee`, `main`, `dev`.
- One job, `pytest`, on `ubuntu-latest`.
- Mirrors the uv setup pattern from the existing `ci.yml` — `astral-sh/setup-uv@v5` with cache enabled, Python 3.12, `uv sync --dev`.
- Runs `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py -q --tb=short` (matches the captain's local pytest invocation).
- `concurrency` group cancels in-progress runs on the same ref to avoid wasting CI minutes.
- Does not modify `pr-quality-gate.yml` or `ci.yml`.

## Expected runtime

Roughly 3–6 minutes per run (uv install with cache + pytest on the default suite). Should be comparable to the matrix job in `ci.yml` since this drops the Python matrix down to a single 3.12 row.

## DEPENDENCY: do not merge until #1064 lands

CI on this branch will fail on first run because the test suite on `ee` is currently broken (35 failing tests from #1059). The companion fix is being shipped as #1064. Order:

1. Merge #1064 (fix the broken tests).
2. Rebase this branch on the new `ee` tip.
3. Confirm green.
4. Merge.

This PR is opened as a draft for that reason.

## Out of scope

- Fixing the 35 broken tests (that's #1064).
- Adding e2e tests to the workflow.
- Sharding or parallelism across the suite.

Closes #1065