### PR TITLE
fix(tests): seed auth context in Fabric/Instinct fixtures (#1064)

### DIFF
--- a/tests/cloud/test_ee_fabric_list_endpoints.py
+++ b/tests/cloud/test_ee_fabric_list_endpoints.py
@@ -4,29 +4,67 @@
 # alongside PocketDataPanel's Objects/Links sub-tab wire-up. Exercises the
 # store + router round-trip so the frontend contract holds without a live
 # SQLite db.
+# Updated: 2026-05-07 (fix/test-fixtures-auth-context) — seed auth context in
+#   the client fixture so route tests pass against the workspace RBAC guards
+#   added in #1059 and the require_plan_feature("fabric") gate added in #1060.
 
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 import ee.fabric.router as fabric_router_module
+from ee.cloud._core.deps import current_workspace_id
+from ee.cloud.auth import current_active_user
+from ee.cloud.license import require_license
 from ee.fabric.store import FabricStore
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "member") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    """Member of the test workspace — fabric.read/write are MEMBER-tier."""
+
+    def __init__(self, workspace_id: str = "ws-test") -> None:
+        self.id = "user-test-1"
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="member")]
 
 
 @pytest.fixture()
 def client(tmp_path: Path, monkeypatch) -> TestClient:
-    """Build an isolated app with the fabric router pointed at a tmp db."""
+    """Build an isolated app with the fabric router and seeded auth context.
+
+    Overrides:
+      - require_license: no-op so license validation doesn't gate tests.
+      - current_active_user: returns a fake member of ws-test.
+      - current_workspace_id: returns 'ws-test'.
+      - workspace_service.get_workspace_plan: returns 'business' so the
+        require_plan_feature('fabric') gate added in #1060 passes (fabric
+        is a business+ feature in PLAN_FEATURES).
+    """
     # Point the module-level store at the tmp db. The router always calls
     # _store() lazily so setattr is enough.
     test_db = tmp_path / "fabric-test.db"
     monkeypatch.setattr(fabric_router_module, "_DB_PATH", test_db)
 
+    import ee.cloud.workspace.service as ws_svc
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="business"))
+
+    fake_user = _FakeUser()
     app = FastAPI()
     app.include_router(fabric_router_module.router, prefix="/api/v1")
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: fake_user
+    app.dependency_overrides[current_workspace_id] = lambda: fake_user.active_workspace
     return TestClient(app)
 
 

--- a/tests/cloud/test_ee_instinct.py
+++ b/tests/cloud/test_ee_instinct.py
@@ -1,17 +1,24 @@
 # tests/test_ee_instinct.py — Comprehensive tests for ee/instinct (store + router).
 # Created: 2026-03-28 — Initial store tests.
 # Updated: 2026-03-30 — Full store unit tests + FastAPI router integration tests added.
+# Updated: 2026-05-07 (fix/test-fixtures-auth-context) — seed auth context in
+#   the test_app fixture so route tests pass against the workspace RBAC guards
+#   added in #1059 and the plan-feature gate added in #1060. Pattern mirrors
+#   tests/cloud/test_rbac_routes.py (the #1061 reference).
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from ee.cloud._core.deps import current_workspace_id
+from ee.cloud.auth import current_active_user
+from ee.cloud.license import require_license
 from ee.instinct.models import (
     ActionCategory,
     ActionPriority,
@@ -21,6 +28,25 @@ from ee.instinct.models import (
 )
 from ee.instinct.router import router
 from ee.instinct.store import InstinctStore
+
+
+class _FakeMembership:
+    """Mimics ee.cloud.models.user.WorkspaceMembership — duck-typed."""
+
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    """Duck-typed stand-in for ee.cloud.models.user.User. Admin role so the
+    instinct.audit and instinct.approve actions (both ADMIN-tier) pass the
+    workspace-action guard. Read/propose pass at any role."""
+
+    def __init__(self, workspace_id: str = "ws-test") -> None:
+        self.id = "user-test-1"
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -44,10 +70,32 @@ def store(tmp_path: Path) -> InstinctStore:
 
 
 @pytest.fixture
-def test_app(tmp_path: Path):
-    """FastAPI app with the instinct router and a patched store singleton."""
+def test_app(tmp_path: Path, monkeypatch):
+    """FastAPI app with the instinct router and seeded auth context.
+
+    Overrides:
+      - require_license: no-op so license validation doesn't gate tests.
+      - current_active_user: returns a fake admin (instinct.approve/audit
+        are ADMIN-tier; admin satisfies the workspace-action guard).
+      - current_workspace_id: returns the fake user's active workspace.
+      - workspace_service.get_workspace_plan: returns 'business' so the
+        require_plan_feature('instinct') gate added in #1060 passes.
+    """
+    fake_user = _FakeUser()
+
+    # instinct is an enterprise-tier feature in PLAN_FEATURES; team and
+    # business plans don't include it, so the require_plan_feature guard
+    # only passes at enterprise. Mirror the AsyncMock pattern from
+    # tests/cloud/test_plan_feature_gate.py so the patch reaches the same
+    # module attribute the guard reads from.
+    import ee.cloud.workspace.service as ws_svc
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
     app = FastAPI()
     app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: fake_user
+    app.dependency_overrides[current_workspace_id] = lambda: fake_user.active_workspace
     return app
 
 


### PR DESCRIPTION
## Summary

Closes #1064. Seeds `current_active_user`, `current_workspace_id`, `require_license`, and `workspace_service.get_workspace_plan` in the route-test fixtures so the workspace RBAC guards (#1059) and plan-feature gate (#1060) don't 401/403 every test.

## Before / after

```
Before: 35 failed, 38 passed
After:  73 passed (test_ee_instinct.py 67/67 + test_ee_fabric_list_endpoints.py 6/6)
```

Full cloud suite still green.

## Pattern

Mirrors `tests/cloud/test_rbac_routes.py` (#1061) for the `dependency_overrides` shape and `tests/cloud/test_plan_feature_gate.py` for the `AsyncMock(return_value=plan)` patch on `ee.cloud.workspace.service.get_workspace_plan`.

- Instinct: admin role + enterprise plan (instinct is enterprise-only in `PLAN_FEATURES`)
- Fabric: member role + business plan (fabric is business+)
- `test_e2e_connector_to_fabric.py` was not affected — already green.

## Why this slipped through

`#1059` landed without updating these fixtures because the PR Quality Gate workflows on pocketpaw don't run pytest — only `check-quality` (lint) and `security-scan`. Tracked in #1065.

## Test plan

- [x] `tests/cloud/test_ee_instinct.py` — 67 passed
- [x] `tests/cloud/test_ee_fabric_list_endpoints.py` — 6 passed
- [x] Full `tests/cloud/` suite — exit 0