### PR TITLE
ci(tests): install enterprise extras so ee/cloud tests can import beanie

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,9 @@
 # Tests — runs the pytest suite on every PR and on pushes to ee/main/dev.
 # Created: 2026-05-07 — Added pytest job to PR Quality Gate so broken tests
 # can no longer slip through CI on PRs targeting ee. Closes #1065.
+# Updated: 2026-05-07 — install enterprise + soul extras so ee/cloud tests
+# can import beanie/motor/fastapi-users. `uv sync --dev` alone misses them
+# (they live under [project.optional-dependencies].enterprise).
 name: Tests
 
 on:
@@ -28,7 +31,11 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --dev
+        # ee/cloud tests import beanie + motor + fastapi-users which live in
+        # the `enterprise` extras group. Without --extra enterprise, the
+        # collection step errors with ModuleNotFoundError: No module named
+        # 'beanie'. --all-extras is the safest bet for full coverage.
+        run: uv sync --dev --all-extras
 
       - name: Run pytest
         # No -x: this is a PR gate, surface ALL failures, not just the first.


### PR DESCRIPTION
## What

Follow-up to #1066. The newly-landed `tests.yaml` workflow ran on its own PR and errored at pytest collection:

```
ee/cloud/auth/core.py:23: in <module>
    from beanie import PydanticObjectId
E   ModuleNotFoundError: No module named 'beanie'
```

`beanie`, `motor`, and `fastapi-users[beanie,oauth]` live in `[project.optional-dependencies].enterprise`. `uv sync --dev` skips them. Switching to `uv sync --dev --all-extras` pulls everything ee/cloud tests need.

## Trade-off

`--all-extras` is heavier than the minimum (`--extra enterprise --extra soul`). I picked it for full coverage so future ee additions don't re-trigger this same gap. uv's cache makes the second run fast.

## Closes

Unblocks the gate added in #1066. Without this, every future PR shows red.