### PR TITLE
fix(agents/codex): strip codex CLI deprecation prefix from agent reply (#1070)

### DIFF
--- a/src/pocketpaw/agents/codex_cli.py
+++ b/src/pocketpaw/agents/codex_cli.py
@@ -63,6 +63,41 @@ logger = logging.getLogger(__name__)
 _CURRENT_POCKET_ID_RE = re.compile(r'<current-pocket\s+id="([^"]+)"')
 
 
+# Codex CLI 0.125+ emits a leading deprecation warning that the SDK packages
+# into the first ``AgentMessageItem.text`` field. The warning has no separator
+# from the actual model reply, so users see it concatenated to their answer:
+#
+#   ``[features].web_search_request is deprecated because web search is
+#   enabled by default. (Set web_search to "live", "cached", or "disabled"
+#   at the top level (or under a profile) in config.toml if you want to
+#   override it.)Hello there, Test.``
+#
+# The expected response is just ``Hello there, Test.``. Strip the known
+# warning when it appears at the start of a message. If codex CLI fixes the
+# leak in a future release the regex simply won't match. Add new patterns
+# here as they surface — keep each one specific so we don't accidentally eat
+# real model output.
+_CODEX_STDERR_NOISE_RES: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"^\s*\[features\]\.web_search_request is deprecated"
+        r".*?override it\.\)\s*",
+        re.DOTALL,
+    ),
+)
+
+
+def _strip_codex_stderr_noise(text: str) -> str:
+    """Remove leading codex CLI stderr noise that leaks into agent message text.
+
+    Defensive cleanup for the codex 0.125 deprecation-prefix bug. Returns
+    the text unchanged when no known noise pattern matches.
+    """
+    cleaned = text
+    for pattern in _CODEX_STDERR_NOISE_RES:
+        cleaned = pattern.sub("", cleaned, count=1)
+    return cleaned
+
+
 def _build_subprocess_env(system_prompt: str) -> dict[str, str]:
     """Compose the env passed to the Codex subprocess.
 
@@ -427,7 +462,9 @@ class CodexCLIBackend:
                     item = event.item
                     if isinstance(item, AgentMessageItem):
                         if item.text:
-                            yield AgentEvent(type="message", content=item.text)
+                            cleaned = _strip_codex_stderr_noise(item.text)
+                            if cleaned:
+                                yield AgentEvent(type="message", content=cleaned)
                     elif isinstance(item, CommandExecutionItem):
                         # ``aggregated_output`` is the canonical field on the
                         # typed item — no schema drift, no fallbacks needed.

--- a/tests/test_codex_cli_backend.py
+++ b/tests/test_codex_cli_backend.py
@@ -243,6 +243,80 @@ class TestCodexCLIRun:
         assert messages[0].content == "Hello from Codex!"
 
     @pytest.mark.asyncio
+    async def test_strips_codex_stderr_deprecation_prefix(self):
+        """Codex 0.125 leaks a [features].web_search_request deprecation
+        warning into the first AgentMessageItem.text. The user-visible
+        message must start with the real model reply, not the warning.
+        Closes pocketpaw#1070."""
+        from openai_codex_sdk import AgentMessageItem
+
+        from pocketpaw.agents.codex_cli import CodexCLIBackend
+
+        polluted = (
+            "[features].web_search_request is deprecated because web search "
+            "is enabled by default. (Set web_search to \"live\", \"cached\", "
+            "or \"disabled\" at the top level (or under a profile) in "
+            "config.toml if you want to override it.)Hello there, Test."
+        )
+
+        backend = CodexCLIBackend(Settings())
+        events_in = _events_from(
+            [
+                (
+                    "completed",
+                    AgentMessageItem(
+                        id="i1", type="agent_message", text=polluted
+                    ),
+                ),
+            ]
+        )
+        ctx, _ = _patch_codex(events_in)
+        with ctx:
+            out = []
+            async for event in backend.run("say hello"):
+                out.append(event)
+
+        messages = [e for e in out if e.type == "message"]
+        assert len(messages) == 1
+        assert messages[0].content == "Hello there, Test."
+        assert "deprecated" not in messages[0].content
+        assert "web_search_request" not in messages[0].content
+
+    @pytest.mark.asyncio
+    async def test_clean_messages_pass_through_unchanged(self):
+        """Sanity guard: a message with no known stderr-noise pattern is
+        forwarded verbatim. If the noise-stripper ever over-matches and
+        eats real model output this test will fail loudly."""
+        from openai_codex_sdk import AgentMessageItem
+
+        from pocketpaw.agents.codex_cli import CodexCLIBackend
+
+        backend = CodexCLIBackend(Settings())
+        clean = (
+            "Here is a snippet: `[features].web_search_request` was the "
+            "old config key — your snippet about deprecation should not "
+            "trigger the stripper because it is not at the start of the "
+            "message and lacks the trailing override-clause."
+        )
+        events_in = _events_from(
+            [
+                (
+                    "completed",
+                    AgentMessageItem(id="i1", type="agent_message", text=clean),
+                ),
+            ]
+        )
+        ctx, _ = _patch_codex(events_in)
+        with ctx:
+            out = []
+            async for event in backend.run("explain web_search"):
+                out.append(event)
+
+        messages = [e for e in out if e.type == "message"]
+        assert len(messages) == 1
+        assert messages[0].content == clean
+
+    @pytest.mark.asyncio
     async def test_parses_command_execution_started_and_completed(self):
         from openai_codex_sdk import CommandExecutionItem
 


### PR DESCRIPTION
## Summary

Closes #1070. Codex CLI 0.125+ emits a `[features].web_search_request` deprecation warning that the SDK packages into the first `AgentMessageItem.text`. The warning has no separator from the actual model reply, so users see it concatenated to their answer in the UI:

```
[features].web_search_request is deprecated because web search is enabled by default. (Set web_search to "live", "cached", or "disabled" at the top level (or under a profile) in config.toml if you want to override it.)Hello there, Test.
```

The actual reply was just `Hello there, Test.`

## What this PR does

Adds a defensive `_strip_codex_stderr_noise()` helper in `src/pocketpaw/agents/codex_cli.py` that removes the known warning when it appears at the start of an agent message. Wired in the `AgentMessageItem` branch of the event handler.

If codex CLI fixes the leak in a future release the regex simply won't match — no behaviour change. New noise patterns can be added to `_CODEX_STDERR_NOISE_RES` as they surface, kept specific so we don't accidentally strip real model output.

## Tests

Two new cases in `tests/test_codex_cli_backend.py`:

- `test_strips_codex_stderr_deprecation_prefix` — feeds a polluted text through the backend, asserts the deprecation chunk is gone and the real reply remains.
- `test_clean_messages_pass_through_unchanged` — sanity guard: a real model output that contains the substring `web_search_request` (e.g. an explanation about the config key) is forwarded unchanged. Catches regex over-match if anyone broadens the pattern later.

```
26 passed in 3.45s
```

## Live verification

Unit tests cover the regression directly. End-to-end re-verification through the home command bar was attempted but blocked by an unrelated paw-cloud connection error (the home command bar routes through paw-cloud:3000 which wasn't running locally). The codex backend itself is exercised by the existing chat-tab DM path which produced the captain's screenshot of the bug.