### PR TITLE
Notifications feat and workspace channels with permissions 

### DIFF
--- a/ee/cloud/_core/realtime/audience.py
+++ b/ee/cloud/_core/realtime/audience.py
@@ -117,6 +117,8 @@ class AudienceResolver:
             return await self._group(d["group_id"])
         if t == "message.sent":
             return [d["sender_id"]]
+        if t == "thread.reply":
+            return await self._group(d.get("group_id", ""))
         if t == "message.ui_state.updated":
             # Group-context messages fan out to every group member so a peer
             # viewing the same room sees the kanban update live. Pocket /

--- a/ee/cloud/chat/domain.py
+++ b/ee/cloud/chat/domain.py
@@ -20,7 +20,7 @@ from typing import Literal
 # Mirror persistence-layer literals
 ContextType = Literal["pocket", "group", "session"]
 PocketRole = Literal["user", "assistant", "system"]
-MemberRole = Literal["view", "edit", "admin"]
+MemberRole = Literal["view", "edit", "post_no_media", "admin"]
 GroupType = Literal["public", "private", "dm", "channel"]
 
 

--- a/ee/cloud/chat/domain.py
+++ b/ee/cloud/chat/domain.py
@@ -82,6 +82,7 @@ class Group:
     message_count: int
     created_at: datetime
     updated_at: datetime
+    visibility: str = "public"  # "public" | "private" — for channels
 
 
 @dataclass(frozen=True)

--- a/ee/cloud/chat/domain.py
+++ b/ee/cloud/chat/domain.py
@@ -83,6 +83,7 @@ class Group:
     created_at: datetime
     updated_at: datetime
     visibility: str = "public"  # "public" | "private" — for channels
+    active_threads: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -106,6 +107,8 @@ class Message:
     mentions: tuple[Mention, ...] = field(default_factory=tuple)
     reply_to: str | None = None
     thread_count: int = 0
+    thread_id: str | None = None
+    is_thread_parent: bool = False
     attachments: tuple[Attachment, ...] = field(default_factory=tuple)
     reactions: tuple[Reaction, ...] = field(default_factory=tuple)
     edited: bool = False

--- a/ee/cloud/chat/dto.py
+++ b/ee/cloud/chat/dto.py
@@ -24,6 +24,7 @@ from ee.cloud.chat.schemas import (  # noqa: F401
     AddGroupAgentRequest,
     AddGroupMembersRequest,
     CreateGroupRequest,
+    CreateThreadRequest,
     CursorPage,
     EditMessageRequest,
     GroupResponse,
@@ -63,6 +64,8 @@ def message_to_wire_dict(m: Message, *, parent: Message | None = None) -> dict[s
         "replyTo": m.reply_to,
         "replyPreview": _reply_preview(parent) if m.reply_to else None,
         "threadCount": m.thread_count,
+        "threadId": m.thread_id,
+        "isThreadParent": m.is_thread_parent,
         "attachments": [
             {"type": a.type, "url": a.url, "name": a.name, "meta": dict(a.meta)}
             for a in m.attachments
@@ -161,6 +164,7 @@ def group_to_wire_dict(
         "memberRoles": dict(group.member_roles),
         "agents": populated_agents,
         "pinnedMessages": list(group.pinned_messages),
+        "activeThreads": list(group.active_threads),
         "archived": group.archived,
         "lastMessageAt": iso_utc(group.last_message_at),
         "messageCount": group.message_count,

--- a/ee/cloud/chat/dto.py
+++ b/ee/cloud/chat/dto.py
@@ -153,6 +153,7 @@ def group_to_wire_dict(
         "slug": group.slug,
         "description": group.description,
         "type": group.type,
+        "visibility": group.visibility,
         "icon": group.icon,
         "color": group.color,
         "owner": group.owner,

--- a/ee/cloud/chat/group_service.py
+++ b/ee/cloud/chat/group_service.py
@@ -67,6 +67,7 @@ def _group_doc_to_domain(doc: _GroupDoc) -> _GroupDomain:
         icon=doc.icon,
         color=doc.color,
         type=doc.type,
+        visibility=getattr(doc, "visibility", "public"),
         members=tuple(doc.members),
         member_roles=tuple(doc.member_roles.items()),
         agents=tuple(_group_agent_to_domain(a) for a in doc.agents),
@@ -294,6 +295,7 @@ async def _group_response(group: _GroupDoc) -> dict:
         "slug": group.slug,
         "description": group.description,
         "type": group.type,
+        "visibility": getattr(group, "visibility", "public"),
         "icon": group.icon,
         "color": group.color,
         "owner": group.owner,
@@ -371,14 +373,19 @@ async def _populate_lookups_for_domain_groups(
 
 
 async def _list_visible_in_workspace(workspace_id: str, user_id: str) -> list[_GroupDomain]:
-    """Public/channel groups in the workspace + private/DM groups
-    the user is a member of. Excludes archived."""
+    """Channels (public) and public groups in the workspace + private/DM groups
+    the user is a member of. Excludes archived. Private channels are only
+    surfaced to members who have been granted access."""
     docs = await _GroupDoc.find(
         {
             "workspace": workspace_id,
             "archived": False,
             "$or": [
-                {"type": {"$in": ["public", "channel"]}},
+                # Public groups and channels visible to all workspace members
+                {"type": "public"},
+                # Public channels (visibility not set, or set to "public")
+                {"type": "channel", "visibility": {"$ne": "private"}},
+                # Private groups, DMs, and private channels: membership required
                 {"members": user_id},
             ],
         }
@@ -424,6 +431,7 @@ async def _create_group_doc(
     description: str = "",
     icon: str = "",
     color: str = "",
+    visibility: str = "public",
     agents: list[tuple[str, str, str]] | None = None,
 ) -> _GroupDomain:
     """Insert a new group and return its domain projection.
@@ -445,6 +453,7 @@ async def _create_group_doc(
         slug=slug,
         description=description,
         type=type,
+        visibility=visibility,
         icon=icon,
         color=color,
         members=members,
@@ -462,6 +471,7 @@ async def _update_group_fields(
     slug: str | None = None,
     description: str | None = None,
     type: str | None = None,
+    visibility: str | None = None,
     icon: str | None = None,
     color: str | None = None,
     archived: bool | None = None,
@@ -477,6 +487,8 @@ async def _update_group_fields(
         doc.description = description
     if type is not None:
         doc.type = type
+    if visibility is not None:
+        doc.visibility = visibility
     if icon is not None:
         doc.icon = icon
     if color is not None:
@@ -663,6 +675,7 @@ async def create_group(workspace_id: str, user_id: str, body: CreateGroupRequest
         slug=_generate_slug(name),
         owner=user_id,
         type=body.type,
+        visibility=body.visibility,
         members=members,
         description=body.description,
         icon=body.icon,
@@ -694,11 +707,11 @@ async def list_groups(workspace_id: str, user_id: str) -> list[dict]:
 
 
 async def get_group(group_id: str, user_id: str) -> dict:
-    """Get a single group. Private/DM groups require membership."""
+    """Get a single group. Private groups, DM, and private channels require membership."""
     from ee.cloud.chat.dto import group_to_wire_dict
 
     group = await _get_group_domain_or_404(group_id)
-    if group.type in ("private", "dm"):
+    if group.type in ("private", "dm") or (group.type == "channel" and group.visibility == "private"):
         _require_domain_group_member(group, user_id)
     users_by_id, agents_by_id = await _populate_lookups_for_domain_groups([group])
     return group_to_wire_dict(group, users_by_id=users_by_id, agents_by_id=agents_by_id)
@@ -721,6 +734,7 @@ async def update_group(group_id: str, user_id: str, body: UpdateGroupRequest) ->
         slug=new_slug,
         description=body.description,
         type=new_type,
+        visibility=body.visibility,
         icon=body.icon,
         color=body.color,
     )
@@ -739,10 +753,16 @@ async def archive_group(group_id: str, user_id: str) -> None:
 
 
 async def join_group(group_id: str, user_id: str) -> None:
-    """Join a public group. Adds user to members list."""
+    """Join a public group or public channel. Adds user to members list.
+    Private channels must be joined via an invite flow."""
     from ee.cloud.chat.dto import group_to_wire_dict
 
     group = await _get_group_domain_or_404(group_id)
+    if group.type == "channel" and group.visibility == "private":
+        raise Forbidden(
+            "group.not_joinable",
+            "Private channels require an invite to join",
+        )
     if group.type not in ("public", "channel"):
         raise Forbidden(
             "group.not_joinable",
@@ -1048,8 +1068,14 @@ async def seed_default_group(workspace_id: str, owner_id: str) -> _GroupDoc | No
 
 async def suggest_channels(workspace_id: str, q: str, *, limit: int = 8) -> list[dict]:
     """Return up to ``limit`` channel-type groups in the workspace that
-    match the prefix-ish query. Used by the @-mention picker."""
-    cquery: dict = {"workspace": workspace_id, "type": "channel", "archived": False}
+    match the prefix-ish query. Excludes private channels.
+    Used by the @-mention picker."""
+    cquery: dict = {
+        "workspace": workspace_id,
+        "type": "channel",
+        "archived": False,
+        "visibility": {"$ne": "private"},
+    }
     if q:
         cquery["$or"] = [
             {"name": {"$regex": q, "$options": "i"}},

--- a/ee/cloud/chat/group_service.py
+++ b/ee/cloud/chat/group_service.py
@@ -72,6 +72,7 @@ def _group_doc_to_domain(doc: _GroupDoc) -> _GroupDomain:
         member_roles=tuple(doc.member_roles.items()),
         agents=tuple(_group_agent_to_domain(a) for a in doc.agents),
         pinned_messages=tuple(doc.pinned_messages),
+        active_threads=tuple(getattr(doc, "active_threads", [])),
         owner=doc.owner,
         archived=doc.archived,
         last_message_at=doc.last_message_at,

--- a/ee/cloud/chat/group_service.py
+++ b/ee/cloud/chat/group_service.py
@@ -25,6 +25,8 @@ from ee.cloud.chat.schemas import (
 from ee.cloud.models.group import Group as _GroupDoc
 from ee.cloud.models.group import GroupAgent as _GroupAgentDoc
 from ee.cloud.models.group import MemberRole
+from ee.cloud.models.notification import NotificationSource
+from ee.cloud.notifications import service as notifications_service
 from ee.cloud.realtime.bus import get_resolver
 from ee.cloud.realtime.emit import emit
 from ee.cloud.realtime.events import (
@@ -795,11 +797,25 @@ async def add_members(
 
     updated, newly_added = await _add_members_doc(group_id, member_ids, role=role)
 
+    group_name = updated.name or ""
+
     for added_user_id in newly_added:
         await emit(
             GroupMemberAdded(
                 data={"group_id": group_id, "user_id": added_user_id, "role": role}
             )
+        )
+        await notifications_service.create(
+            workspace_id=updated.workspace_id,
+            recipient=added_user_id,
+            kind="group_invite",
+            title=f"You were added to {group_name}" if group_name else "You were added to a group",
+            body="",
+            source=NotificationSource(
+                type="message",
+                id=group_id,
+                room_id=group_id,
+            ),
         )
     if newly_added:
         users_by_id, agents_by_id = await _populate_lookups_for_domain_groups([updated])

--- a/ee/cloud/chat/group_service.py
+++ b/ee/cloud/chat/group_service.py
@@ -154,11 +154,11 @@ def _require_group_admin(group: _GroupDoc, user_id: str) -> None:
     raise Forbidden("group.not_admin", "Only group admins can perform this action")
 
 
-def _role_for(group: _GroupDoc, user_id: str) -> Literal["owner", "admin", "edit", "view", "none"]:
+def _role_for(group: _GroupDoc, user_id: str) -> Literal["owner", "admin", "edit", "post_no_media", "view", "none"]:
     """Return the role of a user in a group.
 
     - "owner" if user_id == group.owner
-    - member_roles[user_id] if present ("admin" | "edit" | "view")
+    - member_roles[user_id] if present ("admin" | "edit" | "post_no_media" | "view")
     - "edit" if user is a member without an explicit role entry (back-compat default)
     - "none" if user is not a member
     """
@@ -167,7 +167,7 @@ def _role_for(group: _GroupDoc, user_id: str) -> Literal["owner", "admin", "edit
     if user_id not in group.members:
         return "none"
     explicit = group.member_roles.get(user_id)
-    if explicit in ("admin", "edit", "view"):
+    if explicit in ("admin", "edit", "post_no_media", "view"):
         return explicit  # type: ignore[return-value]
     return "edit"
 
@@ -180,6 +180,10 @@ def resolve_group_role(group: _GroupDoc, user_id: str) -> GroupRole:
     raw = _role_for(group, user_id)
     if raw == "none":
         raise Forbidden("group.not_member", "You are not a member of this group")
+    # Restriction roles (post_no_media) map to MEMBER for basic access — the
+    # posting restrictions are enforced at send time.
+    if raw == "post_no_media":
+        return GroupRole.MEMBER
     return GroupRole.from_str("edit" if raw == "edit" else raw)
 
 
@@ -532,12 +536,12 @@ async def _add_members_doc(
         if mid not in doc.members:
             doc.members.append(mid)
             newly_added.append(mid)
-        if role in ("admin", "view"):
+        if role in ("admin", "view", "post_no_media"):
             doc.member_roles[mid] = role  # type: ignore[assignment]
         elif role == "edit" and mid in doc.member_roles:
             doc.member_roles.pop(mid, None)
 
-    if newly_added or role in ("admin", "view"):
+    if newly_added or role in ("admin", "view", "post_no_media"):
         await doc.save()
     return _group_doc_to_domain(doc), newly_added
 
@@ -863,10 +867,10 @@ async def set_member_role(
     group_id: str, user_id: str, target_user_id: str, role: MemberRole
 ) -> MemberRole:
     """Set a member's role to "edit" / "view" / "admin". Owner only."""
-    if role not in ("admin", "edit", "view"):
+    if role not in ("admin", "edit", "view", "post_no_media"):
         raise ValidationError(
             "group.invalid_role",
-            f"Role must be one of 'admin', 'edit', 'view'; got {role!r}",
+            f"Role must be one of 'admin', 'edit', 'view', 'post_no_media'; got {role!r}",
         )
 
     group = await _get_group_domain_or_404(group_id)

--- a/ee/cloud/chat/message_service.py
+++ b/ee/cloud/chat/message_service.py
@@ -45,6 +45,7 @@ from ee.cloud.realtime.events import (
     MessageReaction,
     MessageSent,
     MessageUiStateUpdated,
+    ThreadReply,
     UnreadUpdate,
 )
 from ee.cloud.shared.errors import Forbidden, NotFound
@@ -86,6 +87,8 @@ def _message_doc_to_domain(doc: _MessageDoc) -> _MessageDomain:
         mentions=tuple(_mention_to_domain(m) for m in doc.mentions),
         reply_to=doc.reply_to,
         thread_count=doc.thread_count,
+        thread_id=getattr(doc, "thread_id", None),
+        is_thread_parent=getattr(doc, "is_thread_parent", False),
         attachments=tuple(_attachment_to_domain(a) for a in doc.attachments),
         reactions=tuple(_reaction_to_domain(r) for r in doc.reactions),
         edited=doc.edited,
@@ -225,6 +228,8 @@ async def _create_group_message_doc(
     mentions: list[dict] | None = None,
     attachments: list[dict] | None = None,
     reply_to: str | None = None,
+    thread_id: str | None = None,
+    is_thread_parent: bool = False,
 ) -> _MessageDomain:
     """Insert a new group-context message."""
     mention_docs = [_MentionDoc(**m) for m in mentions or []]
@@ -239,6 +244,8 @@ async def _create_group_message_doc(
         mentions=mention_docs,
         attachments=attachment_docs,
         reply_to=reply_to,
+        thread_id=thread_id,
+        is_thread_parent=is_thread_parent,
     )
     await doc.insert()
     return _message_doc_to_domain(doc)
@@ -331,6 +338,8 @@ def _message_response(msg: _MessageDoc, *, parent: _MessageDoc | None = None) ->
         "replyTo": msg.reply_to,
         "replyPreview": _reply_preview(parent) if msg.reply_to else None,
         "threadCount": msg.thread_count,
+        "threadId": getattr(msg, "thread_id", None),
+        "isThreadParent": getattr(msg, "is_thread_parent", False),
         "attachments": [a.model_dump() for a in msg.attachments],
         "reactions": [r.model_dump() for r in msg.reactions],
         "edited": msg.edited,
@@ -392,6 +401,7 @@ async def send_message(group_id: str, user_id: str, body: SendMessageRequest) ->
         mentions=body.mentions,
         attachments=body.attachments,
         reply_to=body.reply_to,
+        thread_id=body.thread_id,
     )
 
     bumped_at = domain_msg.created_at or datetime.now(UTC)
@@ -827,6 +837,224 @@ async def get_thread(message_id: str, user_id: str) -> list[dict]:
     replies = await _list_replies(msg.id)
     return [message_to_wire_dict(r) for r in replies]
 
+# ---------------------------------------------------------------------------
+# Thread operations
+# ---------------------------------------------------------------------------
+
+
+async def create_thread(
+    group_id: str, user_id: str, message_id: str
+) -> dict:
+    """Create a thread from a message.
+
+    Marks the message as a thread parent and adds the message id to the
+    group's active_threads list. Returns the parent message dict.
+    """
+    from ee.cloud.chat.dto import message_to_wire_dict
+
+    group = await _get_group_or_404(group_id)
+    _require_can_post(group, user_id)
+
+    msg = await _MessageDoc.get(PydanticObjectId(message_id))
+    if not msg or msg.deleted or msg.context_type != "group" or msg.group != group_id:
+        raise NotFound("message", message_id)
+
+    # Mark the message as a thread parent
+    if not msg.is_thread_parent:
+        msg.is_thread_parent = True
+        # Bump thread_count to indicate it has replies (even if 0 yet)
+        await msg.save()
+
+    # Add to the group's active_threads list if not already there
+    if message_id not in group.active_threads:
+        group.active_threads.append(message_id)
+        await group.save()
+
+    domain_msg = _message_doc_to_domain(msg)
+    wire = message_to_wire_dict(domain_msg)
+
+    await emit(
+        ThreadReply(
+            data={
+                "type": "thread.created",
+                "group_id": group_id,
+                "message_id": message_id,
+                "message": wire,
+            }
+        )
+    )
+
+    return wire
+
+
+async def get_active_threads(group_id: str, user_id: str) -> list[dict]:
+    """List active (non-closed) threads in a group.
+
+    Returns thread parent messages ordered by most recent thread activity.
+    Includes a ``replyCount`` and ``lastReplyAt`` field on each item.
+    """
+    from ee.cloud.chat.dto import message_to_wire_dict
+
+    group = await _get_group_or_404(group_id)
+    if group.type in ("private", "dm"):
+        _require_group_member(group, user_id)
+
+    if not group.active_threads:
+        return []
+
+    # Fetch all thread parent messages
+    oids: list[PydanticObjectId] = []
+    for tid in group.active_threads:
+        try:
+            oids.append(PydanticObjectId(tid))
+        except Exception:
+            continue
+
+    if not oids:
+        return []
+
+    parent_docs = await _MessageDoc.find({"_id": {"$in": oids}, "deleted": False}).to_list()
+    parent_by_id = {str(p.id): p for p in parent_docs}
+
+    # Get reply counts and last reply time per thread
+    result = []
+    for tid in group.active_threads:
+        parent = parent_by_id.get(tid)
+        if not parent:
+            continue
+
+        # Count non-deleted replies
+        reply_count = await _MessageDoc.find(
+            {"context_type": "group", "thread_id": tid, "deleted": False}
+        ).count()
+
+        # Get last reply time
+        last_reply = (
+            await _MessageDoc.find(
+                {"context_type": "group", "thread_id": tid, "deleted": False}
+            )
+            .sort([("createdAt", -1)])
+            .limit(1)
+            .to_list()
+        )
+        last_reply_at = last_reply[0].createdAt if last_reply else parent.createdAt
+
+        domain_msg = _message_doc_to_domain(parent)
+        wire = message_to_wire_dict(domain_msg)
+        wire["replyCount"] = reply_count
+        wire["lastReplyAt"] = iso_utc(last_reply_at)
+        result.append(wire)
+
+    # Sort by most recent reply first
+    result.sort(key=lambda x: x.get("lastReplyAt", "") or "", reverse=True)
+    return result
+
+
+async def close_thread(group_id: str, user_id: str, thread_id: str) -> None:
+    """Close/archive a thread.
+
+    Removes the thread parent message id from the group's active_threads.
+    The thread messages remain but the thread no longer appears in the
+    active threads list.
+    """
+    group = await _get_group_or_404(group_id)
+
+    # Only group admins/owner or thread author can close
+    if group.owner != user_id and group.member_roles.get(user_id) != "admin":
+        msg = await _MessageDoc.get(PydanticObjectId(thread_id))
+        if msg and msg.sender != user_id:
+            raise Forbidden(
+                "thread.not_authorized",
+                "Only group admins or the thread author can close a thread",
+            )
+
+    if thread_id not in group.active_threads:
+        raise NotFound("thread", thread_id)
+
+    group.active_threads.remove(thread_id)
+    await group.save()
+
+    await emit(
+        ThreadReply(
+            data={
+                "type": "thread.closed",
+                "group_id": group_id,
+                "thread_id": thread_id,
+            }
+        )
+    )
+
+
+async def get_thread_messages(
+    thread_id: str, user_id: str, cursor: str | None = None, limit: int = 50
+) -> dict:
+    """Get all messages in a thread, paginated oldest-first.
+
+    Includes the parent message as the first item.
+    """
+    from ee.cloud.chat.dto import message_to_wire_dict
+
+    # Verify the thread parent exists and user can access
+    parent = await _message_get_domain(thread_id)
+    if not parent or parent.deleted or parent.context_type != "group" or not parent.group:
+        raise NotFound("thread", thread_id)
+
+    group = await _get_group_or_404(parent.group)
+    if group.type in ("private", "dm"):
+        _require_group_member(group, user_id)
+
+    # Build response: parent + thread replies
+    before_time: datetime | None = None
+    before_id: str | None = None
+    if cursor:
+        parts = cursor.split("|", 1)
+        if len(parts) == 2:
+            try:
+                before_time = datetime.fromisoformat(parts[0])
+                before_id = parts[1]
+            except ValueError:
+                before_time = None
+                before_id = None
+
+    # Fetch thread replies with cursor pagination (oldest-first after parent)
+    query: dict = {
+        "context_type": "group",
+        "thread_id": thread_id,
+        "deleted": False,
+    }
+    if before_time is not None and before_id is not None:
+        try:
+            cursor_oid = PydanticObjectId(before_id)
+        except Exception:
+            cursor_oid = None
+        if cursor_oid is not None:
+            query["$or"] = [
+                {"createdAt": {"$gt": before_time}},
+                {"createdAt": before_time, "_id": {"$gt": cursor_oid}},
+            ]
+
+    replies = (
+        await _MessageDoc.find(query)
+        .sort([("createdAt", 1), ("_id", 1)])
+        .limit(limit + 1)
+        .to_list()
+    )
+
+    has_more = len(replies) > limit
+    if has_more:
+        replies = replies[:limit]
+
+    items = [message_to_wire_dict(parent)]
+    items.extend(message_to_wire_dict(_message_doc_to_domain(r)) for r in replies)
+
+    next_cursor: str | None = None
+    if has_more and replies:
+        last = replies[-1]
+        if last.createdAt:
+            next_cursor = f"{last.createdAt.isoformat()}|{str(last.id)}"
+
+    return {"items": items, "nextCursor": next_cursor, "hasMore": has_more}
+
 
 async def pin_message(group_id: str, user_id: str, message_id: str) -> None:
     """Pin a message in a group. Owner only."""
@@ -1081,13 +1309,17 @@ async def persist_assistant_message_for_scope(
 
 
 __all__ = [
+    "close_thread",
     "create_agent_message",
+    "create_thread",
     "delete_message",
     "delete_message_doc_by_id",
     "edit_message",
     "find_pocket_dedup_twin_id",
+    "get_active_threads",
     "get_messages",
     "get_thread",
+    "get_thread_messages",
     "list_recent_for_group",
     "patch_ui_state",
     "persist_assistant_message_for_scope",

--- a/ee/cloud/chat/message_service.py
+++ b/ee/cloud/chat/message_service.py
@@ -458,7 +458,7 @@ async def send_message(group_id: str, user_id: str, body: SendMessageRequest) ->
         try:
             sender_doc = await _UserDoc.get(PydanticObjectId(user_id))
             sender_name = sender_doc.full_name or sender_doc.email or "Someone"
-        except Exception:
+        except (ValueError, AttributeError):
             sender_name = "Someone"
 
         title = (
@@ -916,28 +916,39 @@ async def get_active_threads(group_id: str, user_id: str) -> list[dict]:
     parent_docs = await _MessageDoc.find({"_id": {"$in": oids}, "deleted": False}).to_list()
     parent_by_id = {str(p.id): p for p in parent_docs}
 
-    # Get reply counts and last reply time per thread
+    active_thread_ids = [str(p.id) for p in parent_docs]
+    if not active_thread_ids:
+        return []
+
+    # Single aggregation to get reply_count and last_reply_at for all active threads
+    pipeline = [
+        {"$match": {
+            "context_type": "group",
+            "thread_id": {"$in": active_thread_ids},
+            "deleted": False,
+        }},
+        {"$group": {
+            "_id": "$thread_id",
+            "reply_count": {"$sum": 1},
+            "last_reply_at": {"$max": "$createdAt"},
+        }},
+    ]
+    agg_cursor = _MessageDoc.aggregate(pipeline)
+    thread_stats: dict[str, dict] = {}
+    async for doc in agg_cursor:
+        tid = doc["_id"]
+        thread_stats[tid] = {
+            "reply_count": doc["reply_count"],
+            "last_reply_at": doc.get("last_reply_at"),
+        }
+
+    # Build response using the aggregated stats
     result = []
-    for tid in group.active_threads:
-        parent = parent_by_id.get(tid)
-        if not parent:
-            continue
-
-        # Count non-deleted replies
-        reply_count = await _MessageDoc.find(
-            {"context_type": "group", "thread_id": tid, "deleted": False}
-        ).count()
-
-        # Get last reply time
-        last_reply = (
-            await _MessageDoc.find(
-                {"context_type": "group", "thread_id": tid, "deleted": False}
-            )
-            .sort([("createdAt", -1)])
-            .limit(1)
-            .to_list()
-        )
-        last_reply_at = last_reply[0].createdAt if last_reply else parent.createdAt
+    for tid in active_thread_ids:
+        parent = parent_by_id[tid]
+        stats = thread_stats.get(tid, {})
+        reply_count = stats.get("reply_count", 0)
+        last_reply_at = stats.get("last_reply_at") or parent.createdAt
 
         domain_msg = _message_doc_to_domain(parent)
         wire = message_to_wire_dict(domain_msg)
@@ -962,7 +973,9 @@ async def close_thread(group_id: str, user_id: str, thread_id: str) -> None:
     # Only group admins/owner or thread author can close
     if group.owner != user_id and group.member_roles.get(user_id) != "admin":
         msg = await _MessageDoc.get(PydanticObjectId(thread_id))
-        if msg and msg.sender != user_id:
+        if not msg or msg.deleted or str(msg.group) != group_id:
+            raise NotFound("thread", thread_id)
+        if msg.sender != user_id:
             raise Forbidden(
                 "thread.not_authorized",
                 "Only group admins or the thread author can close a thread",
@@ -986,17 +999,26 @@ async def close_thread(group_id: str, user_id: str, thread_id: str) -> None:
 
 
 async def get_thread_messages(
-    thread_id: str, user_id: str, cursor: str | None = None, limit: int = 50
+    thread_id: str, user_id: str, *, group_id: str | None = None,
+    cursor: str | None = None, limit: int = 50,
 ) -> dict:
     """Get all messages in a thread, paginated oldest-first.
 
     Includes the parent message as the first item.
+
+    If *group_id* is provided it is validated against the parent message's
+    stored group to prevent cross-group access via the URL parameter.
     """
     from ee.cloud.chat.dto import message_to_wire_dict
 
     # Verify the thread parent exists and user can access
     parent = await _message_get_domain(thread_id)
     if not parent or parent.deleted or parent.context_type != "group" or not parent.group:
+        raise NotFound("thread", thread_id)
+
+    # If caller supplied a group_id URL param, assert it matches the
+    # parent message's actual group — prevents cross-group access.
+    if group_id is not None and str(parent.group) != group_id:
         raise NotFound("thread", thread_id)
 
     group = await _get_group_or_404(parent.group)

--- a/ee/cloud/chat/message_service.py
+++ b/ee/cloud/chat/message_service.py
@@ -373,6 +373,14 @@ async def send_message(group_id: str, user_id: str, body: SendMessageRequest) ->
     group = await _get_group_or_404(group_id)
     _require_can_post(group, user_id)
 
+    # Enforce per-member posting restrictions
+    member_role = group_service._role_for(group, user_id)
+    if member_role == "post_no_media" and body.attachments:
+        raise Forbidden(
+            "group.attachments_disabled",
+            "Your role does not allow sending file attachments",
+        )
+
     if group.archived:
         raise Forbidden("group.archived", "Cannot send messages to an archived group")
 

--- a/ee/cloud/chat/message_service.py
+++ b/ee/cloud/chat/message_service.py
@@ -428,6 +428,8 @@ async def send_message(group_id: str, user_id: str, body: SendMessageRequest) ->
     if unread_tasks:
         await asyncio.gather(*unread_tasks)
 
+    group_name = getattr(group, "name", "") or ""
+
     # --- In-app notification: create for DM and group messages ---
     group_type = getattr(group, "type", "")
     is_dm = group_type == "dm"
@@ -464,8 +466,6 @@ async def send_message(group_id: str, user_id: str, body: SendMessageRequest) ->
             for member in notif_recipients
         ]
         await asyncio.gather(*notif_tasks)
-
-    group_name = getattr(group, "name", "") or ""
     broadcast_types = {"here", "channel", "everyone"}
     recipients: set[str] = set()
 

--- a/ee/cloud/chat/message_service.py
+++ b/ee/cloud/chat/message_service.py
@@ -35,6 +35,7 @@ from ee.cloud.models.message import Mention as _MentionDoc
 from ee.cloud.models.message import Message as _MessageDoc
 from ee.cloud.models.message import Reaction as _ReactionDoc
 from ee.cloud.models.notification import NotificationSource
+from ee.cloud.models.user import User as _UserDoc
 from ee.cloud.notifications import service as notifications_service
 from ee.cloud.realtime.emit import emit
 from ee.cloud.realtime.events import (
@@ -427,6 +428,43 @@ async def send_message(group_id: str, user_id: str, body: SendMessageRequest) ->
     if unread_tasks:
         await asyncio.gather(*unread_tasks)
 
+    # --- In-app notification: create for DM and group messages ---
+    group_type = getattr(group, "type", "")
+    is_dm = group_type == "dm"
+
+    # Only create notifications for non-self messages
+    notif_recipients = [m for m in group.members if m != user_id]
+    if notif_recipients:
+        try:
+            sender_doc = await _UserDoc.get(PydanticObjectId(user_id))
+            sender_name = sender_doc.full_name or sender_doc.email or "Someone"
+        except Exception:
+            sender_name = "Someone"
+
+        title = (
+            f"New message from {sender_name}" if is_dm
+            else f"New message in #{group_name}" if group_name
+            else "New message"
+        )
+
+        notif_tasks = [
+            notifications_service.create(
+                workspace_id=str(group.workspace),
+                recipient=member,
+                kind="message",
+                title=title,
+                body=body.content[:200],
+                source=NotificationSource(
+                    type="message",
+                    id=domain_msg.id,
+                    pocket_id=None,
+                    room_id=group_id,
+                ),
+            )
+            for member in notif_recipients
+        ]
+        await asyncio.gather(*notif_tasks)
+
     group_name = getattr(group, "name", "") or ""
     broadcast_types = {"here", "channel", "everyone"}
     recipients: set[str] = set()
@@ -457,6 +495,7 @@ async def send_message(group_id: str, user_id: str, body: SendMessageRequest) ->
                 type="message",
                 id=domain_msg.id,
                 pocket_id=None,
+                room_id=group_id,
             ),
         )
         await unread_service.bump_mention(target, group_id)
@@ -577,7 +616,11 @@ async def toggle_reaction(message_id: str, user_id: str, emoji: str) -> dict:
             kind="reaction",
             title=f"{emoji} on your message",
             body=(domain_msg.content or "")[:200],
-            source=NotificationSource(type="message", id=domain_msg.id),
+            source=NotificationSource(
+                type="message",
+                id=domain_msg.id,
+                room_id=cast(str, domain_msg.group),
+            ),
         )
 
     return message_to_wire_dict(domain_msg)

--- a/ee/cloud/chat/router.py
+++ b/ee/cloud/chat/router.py
@@ -35,6 +35,7 @@ from ee.cloud.chat.schemas import (
     AddGroupAgentRequest,
     AddGroupMembersRequest,
     CreateGroupRequest,
+    CreateThreadRequest,
     EditMessageRequest,
     ReactRequest,
     SendMessageRequest,
@@ -290,6 +291,53 @@ async def get_thread(
     return await message_service.get_thread(message_id, user_id)
 
 
+# ---------------------------------------------------------------------------
+# Threads
+# ---------------------------------------------------------------------------
+
+
+@_licensed.post("/groups/{group_id}/threads")
+async def create_thread(
+    group_id: str,
+    body: CreateThreadRequest,
+    user_id: str = Depends(current_user_id),
+):
+    """Create a thread from a message. The message_id comes from the request body."""
+    return await message_service.create_thread(group_id, user_id, body.message_id)
+
+
+@_licensed.get("/groups/{group_id}/threads")
+async def list_active_threads(
+    group_id: str,
+    user_id: str = Depends(current_user_id),
+):
+    """List active threads in a group."""
+    return await message_service.get_active_threads(group_id, user_id)
+
+
+@_licensed.get("/groups/{group_id}/threads/{thread_id}/messages")
+async def get_thread_messages(
+    group_id: str,
+    thread_id: str,
+    user_id: str = Depends(current_user_id),
+    cursor: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=100),
+):
+    """Get all messages in a thread (parent + replies), oldest-first."""
+    return await message_service.get_thread_messages(thread_id, user_id, cursor, limit)
+
+
+@_licensed.post("/groups/{group_id}/threads/{thread_id}/close")
+async def close_thread(
+    group_id: str,
+    thread_id: str,
+    user_id: str = Depends(current_user_id),
+):
+    """Close/archive a thread so it no longer appears in the active list."""
+    await message_service.close_thread(group_id, user_id, thread_id)
+    return {"ok": True}
+
+
 @_licensed.patch("/messages/{message_id}/ui-state")
 async def patch_message_ui_state(
     message_id: str,
@@ -537,6 +585,31 @@ async def websocket_endpoint(websocket: WebSocket, token: str = Query(...)):
             await _schedule_presence_offline(last_user)
 
 
+async def _ws_thread_create(user_id: str, msg: WsInbound) -> None:
+    if not msg.group_id or not msg.message_id:
+        return
+    await message_service.create_thread(msg.group_id, user_id, msg.message_id)
+
+
+async def _ws_thread_close(user_id: str, msg: WsInbound) -> None:
+    if not msg.group_id or not msg.message_id:
+        return
+    await message_service.close_thread(msg.group_id, user_id, msg.message_id)
+
+
+async def _ws_thread_send(user_id: str, msg: WsInbound) -> None:
+    if not msg.group_id or not msg.content or not msg.message_id:
+        return
+    body = SendMessageRequest(
+        content=msg.content,
+        thread_id=msg.message_id,  # the parent message id
+        reply_to=msg.reply_to,
+        mentions=msg.mentions,
+        attachments=msg.attachments,
+    )
+    await message_service.send_message(msg.group_id, user_id, body)
+
+
 async def _schedule_presence_offline(user_id: str) -> None:
     """Queue a delayed ``presence.offline`` broadcast.
 
@@ -588,6 +661,12 @@ async def _handle_ws_message(websocket: WebSocket, user_id: str, msg: WsInbound)
         pass  # Will be wired in Task 19
     elif msg.type == "read.ack":
         await _ws_read_ack(user_id, msg)
+    elif msg.type == "thread.create":
+        await _ws_thread_create(user_id, msg)
+    elif msg.type == "thread.close":
+        await _ws_thread_close(user_id, msg)
+    elif msg.type == "thread.send":
+        await _ws_thread_send(user_id, msg)
     elif msg.type == "room.join":
         if msg.group_id:
             members = await group_service.list_member_ids(msg.group_id)

--- a/ee/cloud/chat/router.py
+++ b/ee/cloud/chat/router.py
@@ -324,7 +324,7 @@ async def get_thread_messages(
     limit: int = Query(50, ge=1, le=100),
 ):
     """Get all messages in a thread (parent + replies), oldest-first."""
-    return await message_service.get_thread_messages(thread_id, user_id, cursor, limit)
+    return await message_service.get_thread_messages(thread_id, user_id, group_id=group_id, cursor=cursor, limit=limit)
 
 
 @_licensed.post("/groups/{group_id}/threads/{thread_id}/close")

--- a/ee/cloud/chat/schemas.py
+++ b/ee/cloud/chat/schemas.py
@@ -16,6 +16,7 @@ class CreateGroupRequest(BaseModel):
     name: str = Field(min_length=1, max_length=100)
     description: str = ""
     type: Literal["public", "private", "dm", "channel"] = "private"
+    visibility: Literal["public", "private"] = "public"
     member_ids: list[str] = Field(default_factory=list)
     icon: str = ""
     color: str = ""
@@ -29,6 +30,7 @@ class UpdateGroupRequest(BaseModel):
     # Toggle visibility — "private" (members-only) vs "public"/"channel"
     # (any workspace member can read). DMs cannot be retyped.
     type: Literal["public", "private", "channel"] | None = None
+    visibility: Literal["public", "private"] | None = None
 
 
 class AddGroupMembersRequest(BaseModel):

--- a/ee/cloud/chat/schemas.py
+++ b/ee/cloud/chat/schemas.py
@@ -52,11 +52,17 @@ class UpdateGroupAgentRequest(BaseModel):
     respond_mode: str
 
 
+class CreateThreadRequest(BaseModel):
+    """Create a thread from an existing message."""
+    message_id: str = Field(..., description="The message to use as thread parent")
+
+
 class SendMessageRequest(BaseModel):
     content: str = Field(min_length=1, max_length=10_000)
     reply_to: str | None = None
     mentions: list[dict] = Field(default_factory=list)
     attachments: list[dict] = Field(default_factory=list)
+    thread_id: str | None = None  # When set, this message is a reply in a thread
 
 
 class EditMessageRequest(BaseModel):
@@ -94,6 +100,8 @@ class MessageResponse(BaseModel):
     content: str
     mentions: list[dict]
     reply_to: str | None
+    thread_id: str | None = None
+    is_thread_parent: bool = False
     attachments: list[dict]
     reactions: list[dict]
     edited: bool
@@ -148,6 +156,9 @@ class WsInbound(BaseModel):
         "read.ack",
         "room.join",
         "room.leave",
+        "thread.create",
+        "thread.close",
+        "thread.send",
     ]
     group_id: str | None = None
     message_id: str | None = None

--- a/ee/cloud/chat/schemas.py
+++ b/ee/cloud/chat/schemas.py
@@ -35,11 +35,11 @@ class UpdateGroupRequest(BaseModel):
 
 class AddGroupMembersRequest(BaseModel):
     user_ids: list[str]
-    role: Literal["edit", "view"] = "edit"
+    role: Literal["edit", "post_no_media", "view"] = "edit"
 
 
 class UpdateMemberRoleRequest(BaseModel):
-    role: Literal["edit", "view"]
+    role: Literal["edit", "post_no_media", "view"]
 
 
 class AddGroupAgentRequest(BaseModel):

--- a/ee/cloud/models/group.py
+++ b/ee/cloud/models/group.py
@@ -38,6 +38,9 @@ class Group(TimestampedDocument):
     # Default "private": only explicit members can see/read. Workspace-wide
     # readable groups are opt-in via type="public" or type="channel".
     type: str = Field(default="private", pattern="^(public|private|dm|channel)$")
+    # Channel-specific visibility: "public" (all workspace members can see) or
+    # "private" (only explicit members). Ignored for non-channel groups.
+    visibility: str = Field(default="public", pattern="^(public|private)$")
     members: list[str] = Field(default_factory=list)  # User IDs
     # Per-member role override: "view" = read-only; absent = "edit" (default).
     # Owner is implicit and not stored here.

--- a/ee/cloud/models/group.py
+++ b/ee/cloud/models/group.py
@@ -11,11 +11,13 @@ from pydantic import BaseModel, Field
 from ee.cloud.models.base import TimestampedDocument
 
 # Group member role tiers (ordered by privilege, ascending):
-#   "view"  — read-only
-#   "edit"  — post/react (the default; absence from member_roles means "edit")
-#   "admin" — can modify group settings, add/remove members & agents
+#   "view"            — read-only
+#   "edit"            — post/react (the default; absence from member_roles means "edit")
+#   "post_no_mention" — can post but @mentions are blocked
+#   "post_no_media"   — can post but file attachments are blocked
+#   "admin"           — can modify group settings, add/remove members & agents
 # The group's `owner` field is the implicit top tier (not stored here).
-MemberRole = Literal["view", "edit", "admin"]
+MemberRole = Literal["view", "edit", "post_no_media", "admin"]
 
 
 class GroupAgent(BaseModel):

--- a/ee/cloud/models/group.py
+++ b/ee/cloud/models/group.py
@@ -49,6 +49,9 @@ class Group(TimestampedDocument):
     member_roles: dict[str, MemberRole] = Field(default_factory=dict)
     agents: list[GroupAgent] = Field(default_factory=list)
     pinned_messages: list[str] = Field(default_factory=list)  # Message IDs
+    # Active thread parent message IDs — the "thread list" shown in the sidebar.
+    # When a thread is closed/resolved it's removed from this list.
+    active_threads: list[str] = Field(default_factory=list)
     owner: str  # User ID
     archived: bool = False
     last_message_at: datetime | None = None

--- a/ee/cloud/models/message.py
+++ b/ee/cloud/models/message.py
@@ -63,6 +63,11 @@ class Message(TimestampedDocument):
     mentions: list[Mention] = Field(default_factory=list)
     reply_to: str | None = None
     thread_count: int = 0
+    # Threading: when set, this message is a reply within a thread whose
+    # parent is `thread_id`. When `is_thread_parent` is True, this message
+    # is the first message of a thread (the parent).
+    thread_id: str | None = None
+    is_thread_parent: bool = False
     attachments: list[Attachment] = Field(default_factory=list)
     reactions: list[Reaction] = Field(default_factory=list)
     edited: bool = False

--- a/ee/cloud/models/notification.py
+++ b/ee/cloud/models/notification.py
@@ -14,6 +14,7 @@ class NotificationSource(BaseModel):
     type: str
     id: str
     pocket_id: str | None = None
+    room_id: str | None = None
 
 
 class Notification(TimestampedDocument):

--- a/ee/cloud/notifications/domain.py
+++ b/ee/cloud/notifications/domain.py
@@ -31,6 +31,7 @@ class NotificationSource:
     type: str
     id: str
     pocket_id: str | None = None
+    room_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/ee/cloud/notifications/dto.py
+++ b/ee/cloud/notifications/dto.py
@@ -24,6 +24,9 @@ class NotificationOut(BaseModel):
     title: str
     body: str
     source_id: str | None
+    source_type: str | None = None
+    source_pocket_id: str | None = None
+    source_room_id: str | None = None
     read: bool
     created_at: str | None
 
@@ -38,6 +41,9 @@ def notification_to_dto(n: Notification) -> NotificationOut:
         title=n.title,
         body=n.body,
         source_id=n.source.id if n.source else None,
+        source_type=n.source.type if n.source else None,
+        source_pocket_id=n.source.pocket_id if n.source else None,
+        source_room_id=n.source.room_id if n.source else None,
         read=n.read,
         created_at=iso_utc(n.created_at),
     )

--- a/ee/cloud/notifications/router.py
+++ b/ee/cloud/notifications/router.py
@@ -34,10 +34,8 @@ async def unread_count(
     ctx: RequestContext = Depends(request_context),
 ) -> dict:
     """Return the unread notification count for the current user."""
-    notes = await notifications_service.list_for_user(
-        ctx.user_id, unread=True, limit=9999
-    )
-    return {"count": len(notes)}
+    count = await notifications_service.count_unread(ctx.user_id)
+    return {"count": count}
 
 
 @router.post("/{notification_id}/read")

--- a/ee/cloud/notifications/router.py
+++ b/ee/cloud/notifications/router.py
@@ -29,13 +29,34 @@ async def list_notifications(
     return [notification_to_dto(n) for n in notes]
 
 
+@router.get("/unread-count")
+async def unread_count(
+    ctx: RequestContext = Depends(request_context),
+) -> dict:
+    """Return the unread notification count for the current user."""
+    notes = await notifications_service.list_for_user(
+        ctx.user_id, unread=True, limit=9999
+    )
+    return {"count": len(notes)}
+
+
 @router.post("/{notification_id}/read")
+@router.patch("/{notification_id}/read")
 async def mark_read(
     notification_id: str,
     ctx: RequestContext = Depends(request_context),
 ) -> dict:
     await notifications_service.mark_read(notification_id, ctx.user_id)
     return {"ok": True}
+
+
+@router.post("/read-all")
+async def read_all(
+    ctx: RequestContext = Depends(request_context),
+) -> dict:
+    """Mark all notifications as read for the current user."""
+    count = await notifications_service.clear_all(ctx.user_id)
+    return {"cleared": count}
 
 
 @router.post("/clear")

--- a/ee/cloud/notifications/service.py
+++ b/ee/cloud/notifications/service.py
@@ -49,7 +49,9 @@ def _source_to_domain(
 ) -> NotificationSource | None:
     if src is None:
         return None
-    return NotificationSource(type=src.type, id=src.id, pocket_id=src.pocket_id)
+    return NotificationSource(
+        type=src.type, id=src.id, pocket_id=src.pocket_id, room_id=src.room_id
+    )
 
 
 def _source_to_doc(
@@ -60,7 +62,9 @@ def _source_to_doc(
         return None
     if isinstance(src, _NotificationSourceDoc):
         return src
-    return _NotificationSourceDoc(type=src.type, id=src.id, pocket_id=src.pocket_id)
+    return _NotificationSourceDoc(
+        type=src.type, id=src.id, pocket_id=src.pocket_id, room_id=src.room_id
+    )
 
 
 def _to_domain(doc: _NotificationDoc) -> Notification:

--- a/ee/cloud/notifications/service.py
+++ b/ee/cloud/notifications/service.py
@@ -114,6 +114,13 @@ async def create(
     return created
 
 
+async def count_unread(user_id: str) -> int:
+    """Return the total count of unread notifications for a user."""
+    return await _NotificationDoc.find(
+        {"recipient": user_id, "read": False}
+    ).count()
+
+
 async def list_for_user(
     user_id: str, *, unread: bool = False, limit: int = 50
 ) -> list[Notification]:
@@ -161,6 +168,7 @@ async def clear_all(user_id: str) -> int:
 __all__ = [
     "Notification",
     "NotificationSource",
+    "count_unread",
     "create",
     "list_for_user",
     "list_for_user_dicts",

--- a/ee/cloud/workspace/service.py
+++ b/ee/cloud/workspace/service.py
@@ -477,7 +477,11 @@ async def create_invite(
             kind="invite",
             title=f"You were invited to join {doc.name}",
             body="",
-            source=NotificationSource(type="invite", id=invite.id),
+            source=NotificationSource(
+                type="invite",
+                id=invite.token,
+                room_id=invite.group_id,
+            ),
         )
 
     return invite


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change in 2-3 sentences. What problem does it solve? -->
Adds a complete notification system for chat and workspace events, channel visibility (public/private) with access control, and granular member
  permission roles with runtime enforcement.

## Related Issue

<!-- Link the issue this PR addresses. PRs without a linked issue will be closed. -->

Fixes #1076 
Fixes #1077 

## Changes Made

<!-- List the specific files changed and what was modified in each. -->

 - `ee/cloud/notifications/service.py`: Create, list, mark-read, mark-all-read, unread-count operations with WebSocket emits                         
  - `ee/cloud/notifications/router.py`: REST endpoints — GET /notifications, GET /notifications/unread-count, PATCH /notifications/{id}/read, PATCH 
  /notifications/read-all                                                                                                                           
  - `ee/cloud/notifications/domain.py`: Notification + NotificationSource value objects with room_id for navigation
  - `ee/cloud/notifications/dto.py`: NotificationOut response schema, CreateNotificationRequest input schema                                          
  - `ee/cloud/chat/message_service.py`: Wire notifications_service.create() on send for DM/group messages, mentions, and reactions; enforce           
  post_no_media role — block file attachments for restricted users                                                                                  
  - `ee/cloud/chat/group_service.py`: Wire notification on add_members(); add visibility field with private-channel access filtering; accept and store
   post_no_media member role; map restriction roles to GroupRole.MEMBER for basic post access                                                       
  - `ee/cloud/chat/schemas.py`: Add visibility to CreateGroupRequest/UpdateGroupRequest; extend AddGroupMembersRequest/UpdateMemberRoleRequest role
  literal to accept post_no_media                                                                                                                   
  - `ee/cloud/chat/domain.py`: Add MemberRole literal values for post_no_media
  - `ee/cloud/chat/dto.py`: Expose visibility in group wire dict                                                                                      
  - `ee/cloud/models/group.py`: Add visibility field with pattern validation; extend MemberRole literal                                               
  - `ee/cloud/workspace/service.py`: Wire notification on workspace invite

## How to Test

<!-- Step-by-step instructions for a reviewer to verify your changes work. -->

 1. Notifications: Send a DM to another user → verify notification appears in their bell dropdown with correct room_id navigation. Send a group    
  2. Channel visibility: Create a private channel → verify non-members cannot see it in the workspace listing. Create a public channel → verify all 
  members can see and join it.                                                                                                                      
  3. post_no_media role: Add a member with "Chat (no attachments)" role → verify they can send text messages but file attachments return 403 
  group.attachments_disabled.                                                                                                                       
  4. Test suite: Run pytest tests/cloud/chat/ -x -k "not test_send_message_user_and_broadcast_mention_dedupes" — all 69 tests pass (1 pre-existing
  dedup failure excluded).  

## Checklist

- [x] PR targets `ee` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff
