### PR TITLE
docs(internal): pocket specialist + ripple mutation feature doc

### DIFF
--- a/docs/internal/2026-05-pocket-specialist-and-ripple-mutation.md
+++ b/docs/internal/2026-05-pocket-specialist-and-ripple-mutation.md
@@ -1,0 +1,346 @@
+# Pocket Specialist & Ripple Mutation
+
+*Status: living document. v1 captures what shipped on [#1069](https://github.com/pocketpaw/pocketpaw/pull/1069); subsequent sections lay out the design path the team has agreed to and the gaps that the next PRs need to close.*
+
+*Owners: Rohit (current implementation), Prakash (direction). Reviewers: anyone touching `ee/ripple/`, `ee/cloud/pockets/`, or `src/pocketpaw/agents/sdk_mcp_pocket.py`.*
+
+---
+
+## TL;DR
+
+Pocket creation and editing are no longer the main chat agent's job. They run on a dedicated **`pocket_specialist`** subagent, called as a tool from the main agent. Mutation tools (`create_pocket`, `update_pocket`, `add_widget`, `update_widget`, `remove_widget`) are filtered off the main agent's allowlist and live only on the specialist — architecture enforced structurally, not by instruction. Result on chat-mode prompt cost: ~12k → ~1.7k tokens per turn.
+
+The shape we want long-term is the same shape Claude Code uses on files: the agent **reads** the current state, **edits** in place with surgical ops, **observes** the result, and the platform records every op for replay, undo, and Instinct review. PR #1069 builds the agent boundary; the **granular mutation surface** is the next move.
+
+---
+
+## Why this exists
+
+Three problems collide on every Ripple-pocket interaction:
+
+1. **Token economics.** The full pocket-mode prompt runs ~12k tokens. Every chat turn — even a one-line "what pockets do I have?" — paid for the entire creation + interaction prompt before this work landed. Most turns don't need it.
+2. **Mutation fragility.** Today an "add a chart" request makes the agent: `get_pocket` → reason about the full tree → emit a complete new `ripple_spec` → `update_pocket(pocket_id, ripple_spec=<the entire thing>)`. The agent has to **rewrite untouched panes verbatim** to preserve them. Every rewrite is a chance to drop a binding, lose a handler, hallucinate a prop, or strip an interactive control.
+3. **Architectural enforcement.** Telling the model "don't call `add_widget` for visible changes" via prompt alone is a request, not a guarantee. With wide tool access, models eventually find the wrong tool. Filter the tools off the allowlist and the wrong call stops being possible.
+
+The pattern that solves all three is the same pattern Anthropic landed on for Claude Code: **agents that edit state should look like agents that edit files.** They `Read`, they `Edit`, they `Write` — surgical, observable, reversible, audit-trailable. PR #1069 is step one toward that for Ripple pockets.
+
+---
+
+## What shipped on PR #1069
+
+### 1. The `pocket_specialist` subagent
+
+A `claude_agent_sdk.AgentDefinition` registered on the `ClaudeAgentOptions.agents` map (`src/pocketpaw/agents/claude_sdk.py:_build_pocket_specialist_agent_def`). The main agent reaches it through the SDK's built-in `Agent` tool with `subagent_type="pocket_specialist"`. The specialist owns:
+
+- The heavy `POCKET_CREATION_PROMPT_MCP` + `POCKET_INTERACTION_PROMPT_MCP` text (`ee/ripple/_pockets.py`).
+- The full mutation tool whitelist: `create_pocket`, `update_pocket`, `add_widget`, `update_widget`, `remove_widget`.
+- Read tools needed during edits: `get_pocket`, `list_pockets`, `get_widget_spec`.
+
+### 2. Tool-allowlist filtering on the main agent
+
+`src/pocketpaw/agents/claude_sdk.py:_POCKET_MUTATION_TOOL_IDS` is removed from `allowed_tools` before the `ClaudeAgentOptions` is constructed. The main agent literally cannot call mutation tools. `Agent` is added to `_TOOL_POLICY_MAP` (mapped to `shell` privilege) so subagent invocation passes the policy gate even on restrictive profiles.
+
+### 3. `POCKET_DELEGATION_RULE`
+
+A small block in the main chat agent's system prompt that teaches it *when* and *how* to delegate. It references the literal subagent name (`pocket_specialist`) — there's a contract test asserting both sides of the string match.
+
+### 4. Slim inline-ripple prompt + on-demand catalog
+
+`INLINE_RIPPLE_SYSTEM_PROMPT` cut from ~9k to ~1.7k tokens. The slim prompt names six core widgets (`text`, `heading`, `stat`, `button`, `table`, `flex`); everything else (charts, kanbans, sparklines, gauges, timelines) lives behind a new `get_inline_widget_help` MCP tool that returns the relevant catalog slice on demand (`ee/ripple/_inline_core.py`).
+
+### 5. Cache-friendly system prompt assembly
+
+`build_context_block` reordered so static content leads and dynamic `<scope>` / `<participants>` / `<current-pocket>` tags trail. The static prefix now hits Anthropic's prompt cache. Combined with the slim chat prompt, this is where the ~12k → ~1.7k chat-mode reduction comes from.
+
+### 6. Ripple resolver — array methods + bracket indexing
+
+`ee/cloud/ripple_resolver.py` (new) adds `.where(field, op, value)`, `.whereIn(field, [values])`, `.sortBy(field)`, `.limit(n)`, `.reverse()`, plus bracket indexing (`tasks[0]`, `state.tasks[state.selected_index]`). Fixes the **dead-binding pattern** where filter/sort controls couldn't actually filter or sort because expressions had no way to express the operation.
+
+### 7. Ripple normalizer — dead-handler stripper
+
+`ee/cloud/ripple_normalizer.py` strips `entity-detail.props.actions[]` items lacking handlers and lifts items using `on_click` instead of `actions` to the right field. Fixes the **dead-button pattern** where an action item rendered visually but did nothing on click.
+
+### 8. Backend gating
+
+The specialist mechanism is Claude-only — it relies on `ClaudeAgentOptions.agents` and the SDK's built-in `Agent` tool. Other backends (`openai_agents`, `google_adk`, `codex_cli`, `opencode`, `copilot_sdk`, `deep_agents`) fall back to the pre-split path with the heavy pocket prompt inlined. They still work — they just don't get the token savings or the architectural separation. Universal backend-agnostic version is the planned next step.
+
+---
+
+## How a mutation flows today
+
+```
+┌─ Main chat agent (slim prompt, no mutation tools) ────────────────┐
+│                                                                   │
+│  user: "add a status badge to the alice row that turns red on     │
+│         overdue"                                                  │
+│                                                                   │
+│  agent reasons: this is pocket-mutation intent.                   │
+│  agent calls: Agent(                                              │
+│    subagent_type="pocket_specialist",                             │
+│    description="add overdue badge",                               │
+│    prompt="On pocket <id>: add a status badge..."                 │
+│  )                                                                │
+└────────────────────────┬──────────────────────────────────────────┘
+                         │
+┌────────────────────────▼──────────────────────────────────────────┐
+│ pocket_specialist subagent (full pocket prompt, mutation tools)   │
+│                                                                   │
+│  1. get_pocket(pocket_id) → full document                         │
+│  2. reason locally; build the FULL new ripple_spec                │
+│  3. update_pocket(pocket_id, ripple_spec=<entire new tree>)       │
+│  4. return short status to main agent                             │
+└────────────────────────┬──────────────────────────────────────────┘
+                         │
+┌────────────────────────▼──────────────────────────────────────────┐
+│ Main agent relays the specialist's status to the user.            │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+The architecture **separation** is good. The mutation **granularity** is the part we still need to fix.
+
+---
+
+## The MCP tool surface
+
+Defined in `src/pocketpaw/agents/sdk_mcp_pocket.py`. Tools are registered on the in-process `pocketpaw_pocket` SDK MCP server and namespaced as `mcp__pocketpaw_pocket__<tool>`.
+
+| Tool | Args | Returns | Where it lives |
+|---|---|---|---|
+| `get_pocket` | `pocket_id: str` | full pocket document | both agents |
+| `list_pockets` | — | list of `{id, name, description, type, icon, color}` | both agents |
+| `create_pocket` | `name, description, type, icon, color, ripple_spec` | `{ok, pocket, pocket_id}` | specialist only |
+| `update_pocket` | `pocket_id, ripple_spec?, name?, description?, icon?, color?` | updated pocket document | specialist only |
+| `add_widget` ⚠️ | `pocket_id, widget` | updated pocket | specialist only |
+| `update_widget` ⚠️ | `pocket_id, widget_id, fields` | updated pocket | specialist only |
+| `remove_widget` ⚠️ | `pocket_id, widget_id` | updated pocket | specialist only |
+| `get_widget_spec` | `types: list[str]` | markdown reference per requested widget type | both agents |
+| `get_inline_widget_help` | `types: list[str]` | catalog slice for chat-inline rendering | both agents |
+
+⚠️ **`add_widget` / `update_widget` / `remove_widget` mutate the legacy embedded `widgets` array, not `rippleSpec.ui`.** The desktop client renders only from `rippleSpec.ui`, so writes to the legacy array are invisible. The system prompt explicitly tells the specialist not to use these for visible changes — they're held for backwards compatibility with older pockets.
+
+**This is a key gap.** We have *names* like `add_widget` and `update_widget` already on the surface, but they target the wrong field. The next PR's job is to repurpose those names (or add new ones) to mutate `rippleSpec.ui` granularly with stable IDs. See [§ Next moves](#next-moves) below.
+
+---
+
+## Design principles
+
+These are the rules the implementation already follows; document them so future PRs don't drift:
+
+1. **Architectural enforcement beats instruction.** If a tool shouldn't be called from a context, remove it from that context's allowlist. Don't rely on "please don't call this" in the prompt.
+2. **Read tools stay cheap and broadly available.** `get_pocket`, `list_pockets`, `get_widget_spec`, `get_inline_widget_help` are read-only and stay on the main agent so conversational queries don't pay subagent overhead.
+3. **Heavy domain prompt lives with the agent that needs it.** The 10k-token pocket prompt rides with the specialist. The chat agent gets a 200-token delegation rule pointing at it.
+4. **Tool definitions are the contract, not docs.** Each MCP tool carries a Zod-style schema and a docstring that doubles as the LLM-facing description. The specialist's behavior is shaped by the tool descriptions, not by separate prompt instructions about each tool.
+5. **List before create.** Hard-coded gate in every creation prompt: the agent runs `list_pockets` first; same-name / same-intent pockets get extended via `update_pocket` rather than spawning duplicates. (Soft gate today — the prompt asks the agent to confirm with the user. Could harden later.)
+6. **Interactive by default.** Every new pocket gets at least one in-canvas control wired to top-level `state` via `bind` + `on_click` action chains. Edits preserve interactivity instead of stripping it. The pattern is canonical and lives in `_INTERACTIVE_DEFAULT_BLOCK`.
+7. **Real values only.** No "TBD", "...", or null in display content. Estimates get a `~` prefix. No widget without data is shipped.
+8. **Two-pass UI for streaming.** Streaming partial JSON drops invalid enum values mid-stream rather than rendering a half-typed widget type. Lives in the renderer, not in the agent — but the agent benefits because partial output never visibly breaks.
+
+---
+
+## Open gaps (in priority order)
+
+### Gap 1 — Granular UI-tree mutations *(biggest payoff)*
+
+**Problem.** `update_pocket(ripple_spec=<full tree>)` is the only way to change anything visible. To rename one row in a table, the specialist re-emits the entire spec. That's wasteful and fragile — the rewrite is where bindings get lost.
+
+**Fix.** Stable IDs on every UINode + ID-targeted mutation tools. The shape:
+
+```
+read_node(pocket_id, id?)              → returns the subtree (or whole spec)
+list_nodes(pocket_id, parent_id?)      → flat list of {id, type, label?}
+add_node(pocket_id, parent_id, spec, after_id?)
+replace_node(pocket_id, id, spec)
+set_node_prop(pocket_id, id, prop, value)
+move_node(pocket_id, id, new_parent_id, after_id?)
+remove_node(pocket_id, id)
+```
+
+Each call mutates `rippleSpec.ui` server-side, returns the changed subtree (not the full document), and emits a `pocket_widget_changed` SSE event the client can apply incrementally.
+
+The names `add_widget` / `update_widget` / `remove_widget` are already on the MCP surface — repurposing them to target `rippleSpec.ui` (instead of the legacy embedded array) is the natural migration. The legacy-array versions get retired once no client depends on them.
+
+**Why this matters.** Same shape as Claude Code's `Read` / `Edit` / `Write` on files. Same operational properties: idempotent, surgical, observable, audit-trailable. Compounds with every gap below.
+
+### Gap 2 — Inverse op log → undo/redo
+
+Once mutations are granular, every op has a defined inverse: `addNode ↔ removeNode`, `setProp(new) ↔ setProp(old)`, `moveNode(a → b) ↔ moveNode(b → a)`. Store the last N inverses in a per-pocket ring buffer and you get:
+
+- Undo / redo on the canvas.
+- Optimistic UI with rollback when a server write fails.
+- "Agent made a wrong edit, retry from before that op" without re-streaming the whole conversation.
+
+The Command pattern, applied properly. Not new tech — just discipline.
+
+### Gap 3 — Vision-in-the-loop verification
+
+After each mutation cycle, snapshot the rendered canvas (Playwright server-side, or `html2canvas` client-side) and feed the screenshot back to a vision-capable model with the question *"did the requested change actually happen?"*. Closes the loop on the most common silent-failure mode (typo'd prop names, wrong target IDs, `bind` strings that don't match state shape). The validator can be the same specialist or a smaller second pass — either way, the human stops being the only one who notices when an edit didn't visibly land.
+
+### Gap 4 — Backend portability
+
+The specialist mechanism is gated to `claude_agent_sdk` because it leans on `ClaudeAgentOptions.agents` + the built-in `Agent` tool. Other backends fall back to the inlined heavy prompt — they work, but they pay the full token cost and don't get the architectural separation.
+
+Universal version probably looks like a backend-agnostic "subagent" wrapper that compiles to:
+- `claude_agent_sdk` → `AgentDefinition` + `Agent` tool (today's path)
+- `openai_agents` → handoff agent
+- `google_adk` → sub-agent
+- `deep_agents` → planning subagent
+- everything else → an in-process synthetic subagent that's just a second `query()` call with the specialist's prompt + tool slice
+
+Rohit flagged this as the planned next step. Concrete spec deserves its own RFC.
+
+### Gap 5 — Streaming as op stream, not partial JSON
+
+Today the specialist emits `update_pocket(ripple_spec=<huge JSON>)` and the renderer parses partial JSON to render progressively. With granular ops (gap 1), each tool call is its own atomic unit — the renderer applies them as they arrive, no partial-JSON gymnastics. This removes one of the messiest pieces of the current renderer.
+
+### Gap 6 — Instinct integration
+
+Every pocket mutation is, conceptually, a proposed action: the agent is going to change something the user sees. PocketPaw already has Instinct (the approval/audit layer at `ee/instinct/`). Wiring pocket mutations through Instinct gives:
+
+- Captain (or end-user) review of mutations before they land — same gate as `send_email`.
+- Reasoning-trace capture per mutation, not per turn.
+- Outcome metering — was the rename right? Did the user revert it within 30 seconds?
+- Audit log of *every* edit, queryable like any other Instinct event.
+
+Default policy can be permissive (auto-approve) for low-risk ops; sensitive surfaces (workspace pockets, shared with other members) can require explicit approval. This composes cleanly with gap 2 — undo *is* a revert flow Instinct can offer.
+
+### Gap 7 — Soul memory for design preferences
+
+The specialist's soul records "captain prefers density over whitespace", "we use rounded corners not sharp", "this user reverted the last three pie charts to bar charts". Survives across sessions. Loads at the start of every specialist invocation. Makes the design system something the agent *learns* rather than something it *reads from a static prompt*.
+
+### Gap 8 — Named-statement spec view *(long-term)*
+
+OpenUI Lang ([thesysdev/openui](https://github.com/thesysdev/openui)) flattens the spec into a dictionary of named statements: `root = Stack([header, chart, tbl])`, `chart = PieChart(...)`. Incremental edits become trivial dictionary union by name; their measurement: 85% token reduction on followup edits.
+
+We don't need to adopt the storage format to get most of the benefit. The path is:
+
+1. Land stable IDs (gap 1). The IDs *are* the names.
+2. Provide a "named-statement view" serializer the agent reads from. The view is the thin DSL; the storage stays JSON.
+3. When (and only when) the token cost on long-session refinement hurts in real numbers, lift the view to be the source of truth.
+
+This is *years*-out work; documenting the destination so we don't accidentally choose a path that closes the door.
+
+---
+
+## Next moves
+
+The captain reviews PR scope; this is a proposal, not a commitment.
+
+| # | PR | Scope | Depends on |
+|---|---|---|---|
+| 1 | `feat(ripple): granular UI-tree mutation tools` | Stable IDs on UINodes + new `add_node` / `replace_node` / `set_node_prop` / `move_node` / `remove_node` MCP tools targeting `rippleSpec.ui`. Repurpose existing `add_widget`/`update_widget`/`remove_widget` names. Specialist prompt updated to prefer granular ops over `update_pocket` for surgical edits. | #1069 |
+| 2 | `feat(ripple): inverse op log + undo/redo` | Per-pocket ring buffer of inverse ops. New SSE event `pocket_op_committed` with op + inverse. Client-side undo/redo controls. | PR 1 |
+| 3 | `feat(agents): backend-agnostic subagent wrapper` | Lift `pocket_specialist` registration into a backend-agnostic factory. Targets at minimum `openai_agents`, `google_adk`, `deep_agents`. | #1069 |
+| 4 | `feat(ripple): vision verification on mutation` | After every specialist mutation cycle, snapshot the rendered canvas and run a vision check before returning success to the main agent. | PR 1 |
+| 5 | `feat(instinct): pocket mutations as proposed actions` | Wire each pocket mutation through Instinct's proposal pipeline. Default policy permissive; per-pocket override. | PR 1 |
+
+Tests track the contracts that already matter: `tests/test_pocket_specialist.py` asserts the delegation-rule string matches the registered subagent name; `tests/cloud/test_pocket_service_resolver.py` exercises the new resolver methods; `tests/test_sdk_mcp_inline_help.py` covers the catalog-slice tool. New PRs should add cross-file contract tests in the same style.
+
+---
+
+## Appendix A — File map
+
+| File | Role |
+|---|---|
+| `src/pocketpaw/agents/sdk_mcp_pocket.py` | In-process MCP server. Tool definitions + handlers. |
+| `src/pocketpaw/agents/claude_sdk.py` | Backend wiring. Specialist registration, allowlist filtering, `Agent` tool policy mapping. |
+| `ee/cloud/pockets/agent_context.py` | The actual mutation logic (`fetch_pocket_for_agent`, `update_pocket_for_agent`, etc.). MCP server is a thin adapter over this. |
+| `ee/cloud/pockets/service.py` | Beanie writes. Where the mutation actually persists. |
+| `ee/ripple/_pockets.py` | All pocket-mode system prompts (creation × interaction × MCP × CLI). `POCKET_DELEGATION_RULE` lives here too. |
+| `ee/ripple/_design.py` | The widget catalog + design rules. Spliced into every creation/interaction prompt. |
+| `ee/ripple/_inline.py` / `_inline_core.py` | Slim chat-inline prompt + the catalog payload behind `get_inline_widget_help`. |
+| `ee/cloud/ripple_resolver.py` | Expression evaluator. Owns `.where`, `.sortBy`, `.limit`, `.reverse`, bracket indexing. |
+| `ee/cloud/ripple_normalizer.py` | Dead-handler stripper, `on_click → actions` lift. |
+| `ee/cloud/ripple_sources.py` | `$source` marker hydration (`workspace.pockets`, `workspace.members`). |
+
+## Appendix B — Pocket-mode prompt structure
+
+Every pocket-mode prompt (creation or interaction, MCP or CLI variant) is assembled from the same blocks in the same order. Source: `ee/ripple/_pockets.py:_assemble_creation` / `_assemble_interaction`.
+
+**Creation prompt:**
+1. `_SCOPE_BLOCK` — what "pocket" means in this conversation
+2. `_CANVAS_BLOCK` — `rippleSpec.ui` is the only renderable surface
+3. `_LIST_BEFORE_CREATE_*` — the duplicate-avoidance gate
+4. `_TOOLS_*` — tool surface description (MCP or CLI)
+5. `_CREATION_OVERVIEW_*` — high-level "you're making a new pocket" framing
+6. `_INTERACTIVE_DEFAULT_BLOCK` — controls + state + bind pattern
+7. `_STATE_SOURCES_BLOCK` — `$source` markers for live workspace data
+8. `_CREATION_EXAMPLES_*` — two minimal examples (todo app, revenue report)
+9. `_RESEARCH_PROTOCOL` — multi-search research gate for display pockets
+10. `RIPPLE_DESIGN_RULES` — the widget catalog + design quality bar (heavy)
+
+**Interaction prompt:**
+1. `_SCOPE_BLOCK`
+2. `_CANVAS_BLOCK`
+3. `_TOOLS_*`
+4. `_WORKFLOW_INTERACTION_*` — read/write/chat classification + the "preserve untouched panes" rule
+5. `_INTERACTIVE_DEFAULT_BLOCK`
+6. `_STATE_SOURCES_BLOCK`
+7. `RIPPLE_DESIGN_RULES`
+
+The interaction prompt carries a literal `__POCKET_ID__` token that the specialist wiring substitutes at invocation time (`src/pocketpaw/agents/claude_sdk.py:_pocket_specialist_system_prompt`).
+
+## Appendix C — Sequence: a small edit, end to end
+
+```
+User → Main agent (chat-mode):  "add a chart of completed tasks"
+
+Main agent reasons: pocket-mutation intent. Calls:
+    Agent(
+      subagent_type="pocket_specialist",
+      description="add completed-tasks chart",
+      prompt="On pocket P-7f3: add a chart of completed tasks..."
+    )
+
+Specialist starts. System prompt = full pocket-mode interaction prompt
+(POCKET_INTERACTION_PROMPT_MCP). Available tools: get_pocket,
+list_pockets, get_widget_spec, create_pocket, update_pocket,
+add_widget, update_widget, remove_widget.
+
+Specialist calls: get_pocket(pocket_id="P-7f3")
+  → returns full document including current rippleSpec.ui
+
+Specialist calls: get_widget_spec(types=["chart"])
+  → returns markdown reference for the chart widget
+
+Specialist reasons locally; builds the FULL new ripple_spec preserving
+every existing node and adding the chart node.
+
+Specialist calls: update_pocket(
+  pocket_id="P-7f3",
+  ripple_spec=<entire new tree>
+)
+  → server persists, emits pocket_updated SSE, returns updated doc
+
+Specialist returns to main agent: "Added a bar chart of completed tasks
+to the dashboard."
+
+Main agent relays to user.
+```
+
+In the post-Gap-1 world, the specialist's mutation step shrinks to:
+
+```
+Specialist calls: list_nodes(pocket_id="P-7f3", parent_id="dashboard-root")
+  → flat list including {id: "dashboard-root", type: "flex", ...}
+
+Specialist calls: add_node(
+  pocket_id="P-7f3",
+  parent_id="dashboard-root",
+  spec={type: "chart", id: "completed-chart", props: {...}, ...},
+  after_id: "tasks-table"
+)
+  → server inserts, emits pocket_op_committed, returns subtree
+```
+
+Two surgical calls, no full-spec rewrite. Same auditability. Same correctness. Far fewer ways to silently lose a binding on the way through.
+
+---
+
+## Cross-references
+
+- [PR #1069](https://github.com/pocketpaw/pocketpaw/pull/1069) — implementation
+- [thesysdev/openui](https://github.com/thesysdev/openui) — the named-statement / incremental-editing reference design (for Gap 8)
+- `ripple/src/lib/schema/ui-spec.ts` — Ripple's UISpec v1.0 definition
+- `ripple/src/lib/schema/universal-spec.ts` — Ripple's UniversalSpec v2.0 definition
+- `ripple/src/lib/core/state-manager.svelte.ts` — runtime state container; eventual consumer of granular ops
+- `ee/instinct/` — Instinct layer, eventual home for pocket-mutation review (Gap 6)

--- a/docs/internal/2026-05-ripple-mutation-handover.md
+++ b/docs/internal/2026-05-ripple-mutation-handover.md
@@ -1,0 +1,441 @@
+# Ripple Mutation: Implementation Handover
+
+*Companion to [`2026-05-pocket-specialist-and-ripple-mutation.md`](./2026-05-pocket-specialist-and-ripple-mutation.md). The vision doc says **what** and **why**; this doc says **how**, in PR-sized chunks Rohit can pick up directly.*
+
+*Owner: Rohit. Reviewer: Prakash. Each section is self-contained — read top-to-bottom for context, or jump to the PR you're starting next.*
+
+---
+
+## Roadmap at a glance
+
+| # | PR | Depends on | Sized | Goal in one sentence |
+|---|---|---|---|---|
+| 1 | Granular UI-tree mutations | #1069 merged | L | Replace whole-spec rewrites with surgical ID-targeted ops on `rippleSpec.ui`. |
+| 2 | Inverse op log + undo/redo | PR 1 | M | Every committed op stores its inverse; `undo_op` / `redo_op` MCP tools roll forward/back. |
+| 3 | Backend-agnostic specialist wrapper | #1069 merged | L | Lift `pocket_specialist` registration out of `claude_sdk.py` into a backend-agnostic factory; cover at least `openai_agents`, `google_adk`, `deep_agents`. |
+| 4 | Vision-in-the-loop verification | PR 1 | M | After every specialist mutation cycle, snapshot the canvas and ask a vision model "did this land?" before returning success. |
+| 5 | Instinct integration for pocket mutations | PR 1, ideally PR 2 | L | Each granular mutation flows through Instinct as a proposed action with audit trail and approval policy. |
+
+PR 1 unblocks 2 / 4 / 5 — land it first. PR 3 is independent and can run in parallel with 1.
+
+**Out of scope for this batch:** Streaming as op stream (becomes free once PR 1 lands — call it PR 1.5 if it comes naturally). Soul memory of design preferences. Named-statement spec view (long-term — needs a separate RFC).
+
+---
+
+## PR 1: Granular UI-tree mutations
+
+### Goal
+Replace `update_pocket(ripple_spec=<entire tree>)` as the primary mutation path with five surgical ops keyed on stable node IDs. The specialist no longer rewrites untouched panes to preserve them.
+
+### Definition of done
+
+- [ ] Every node in `rippleSpec.ui` carries an `id` field (auto-generated where missing on read).
+- [ ] Five new MCP tools: `add_node`, `replace_node`, `set_node_prop`, `move_node`, `remove_node` — registered in `sdk_mcp_pocket.py`, surfaced on the specialist allowlist, **filtered off** the main agent allowlist.
+- [ ] Server-side handlers in `ee/cloud/pockets/service.py` apply ops to `rippleSpec.ui` and persist the changed document.
+- [ ] New SSE event payloads (`action: "node_added" | "node_replaced" | "node_prop_set" | "node_moved" | "node_removed"`) carry only the changed subtree, not the full pocket.
+- [ ] Specialist prompt updated to **prefer** granular ops over `update_pocket` for surgical edits; `update_pocket` remains for whole-canvas rewrites and initial creation.
+- [ ] Ripple renderer applies incremental mutations in place without remounting unchanged subtrees.
+- [ ] Contract tests + the canonical "rename one row in a 100-row table" integration test (assertion: only one node in the spec changed; only one SSE frame emitted).
+- [ ] Backwards compat: existing `update_pocket(ripple_spec=full)` still works, still emits `action: "replace"`. No existing pockets break.
+
+### Stable IDs spec
+
+```ts
+// ripple/src/lib/schema/ui-spec.ts — UINode shape
+
+UINode = {
+  id: string;          // ← was optional; now REQUIRED at read time
+  type: UINodeType;
+  props?: Record<string, any>;
+  children?: UINode[];
+  // ... existing fields
+};
+```
+
+**Generation rules:**
+
+- Format: `n_<8-char-base32>` (e.g. `n_3kfa9zxq`). 40 bits of randomness — collision risk negligible at any pocket size we'll see.
+- Generated server-side on read whenever a node lacks an `id`. Persisted on the next write.
+- Migration is lazy: a pocket without IDs gets them on its next mutation. No big-bang migration script.
+- Uniqueness scope: per-pocket. Cross-pocket collisions are fine.
+
+**Validation:**
+
+- Add a Pydantic / Zod check in `_validate_ripple_spec` that every node has a string `id` matching `^n_[a-z0-9]{8}$` *or* is missing entirely (which means: the read path will assign one).
+- Reject writes where two siblings share an ID — that's a real bug, not a missing ID.
+
+### MCP tool surface
+
+All five tools are namespaced under `mcp__pocketpaw_pocket__` and registered in `src/pocketpaw/agents/sdk_mcp_pocket.py` via the existing `@tool` pattern. Add their IDs to `POCKET_TOOL_IDS` and to `_POCKET_MUTATION_TOOL_IDS` in `claude_sdk.py` so the main agent can't call them.
+
+```python
+# Schema sketch — finalize naming with Rohit before coding.
+
+add_node(
+    pocket_id: str,
+    parent_id: str,            # ID of the node to insert under
+    spec: dict,                # the new UINode (id auto-assigned if absent)
+    after_id: str | None = None,  # insert after this sibling; None = append
+) -> {"ok": True, "node_id": str, "subtree": dict}
+  | {"ok": False, "error": str}
+
+replace_node(
+    pocket_id: str,
+    node_id: str,              # full subtree replacement; preserves id
+    spec: dict,
+) -> {"ok": True, "subtree": dict}
+  | {"ok": False, "error": str}
+
+set_node_prop(
+    pocket_id: str,
+    node_id: str,
+    prop: str,                 # dot-path inside props; e.g. "label" or "data.rows"
+    value: Any,
+) -> {"ok": True, "subtree": dict, "old_value": Any}
+  | {"ok": False, "error": str}
+
+move_node(
+    pocket_id: str,
+    node_id: str,
+    new_parent_id: str,
+    after_id: str | None = None,
+) -> {"ok": True, "subtree": dict}
+  | {"ok": False, "error": str}
+
+remove_node(
+    pocket_id: str,
+    node_id: str,
+) -> {"ok": True, "removed_id": str}
+  | {"ok": False, "error": str}
+```
+
+**Returns the changed subtree** (not the full pocket) so the specialist's reasoning context stays small. The SSE event carries the same payload — client applies it without a re-fetch.
+
+**Errors that should fail loudly (not silently no-op):**
+
+- `node_id` not found in spec → `error: "no node with id <x>"`.
+- `parent_id` not found / `parent_id` not a container type → `error: "..."`.
+- `after_id` not a child of `parent_id` → `error: "..."`.
+- `set_node_prop` with a `prop` path that doesn't match the widget's manifest schema → `error: "unknown prop <x> for widget <type>"`. *(This is the silent-failure killer — manifest validation is already wired for `update_pocket`; reuse it per-op.)*
+
+### Server-side wiring
+
+Per `pocketpaw/CLAUDE.md` ee/cloud 4-file shape, the implementation lives in:
+
+- `ee/cloud/pockets/service.py` — five new module-level `async def agent_<op>(ctx, body)` functions. Each: validate body, fetch document with `workspace=ctx.workspace_id`, walk `rippleSpec.ui` to find the target by ID, mutate, persist, emit event.
+- `ee/cloud/pockets/dto.py` — five `<Op>Request` + `<Op>Response` DTOs. Reuse `model_validate` at entry per ee/cloud rule 6.
+- `ee/cloud/pockets/agent_context.py` — five new `<op>_for_agent` MCP-shape wrappers (mirror the existing `update_pocket_for_agent` pattern).
+
+**Walk + mutate primitives.** Add a small helper module — `ee/cloud/pockets/spec_ops.py` (new) — with pure functions:
+
+```python
+def find_by_id(node: dict, target_id: str) -> tuple[dict, list[int]] | None:
+    """Return (node, path) where path is the index trail from root."""
+
+def insert_after(parent: dict, after_id: str | None, child: dict) -> None:
+    """Insert child into parent.children. None => append."""
+
+def replace_at(node: dict, path: list[int], new_node: dict) -> None: ...
+def remove_at(node: dict, path: list[int]) -> dict: ...  # returns removed
+def set_prop(node: dict, prop_path: str, value: Any) -> Any: ...  # returns old
+```
+
+These stay pure (no DB, no events, no logging). The service wraps them with persistence + emission. Pure helpers are easy to test against fixture trees.
+
+**Event emission** (per ee/cloud rule 9 — every write emits):
+
+```python
+# ee/cloud/pockets/service.py — sketch
+
+async def agent_set_node_prop(ctx, body):
+    body = SetNodePropRequest.model_validate(body)
+    doc = await _PocketDoc.find_one(_id=body.pocket_id, workspace=ctx.workspace_id)
+    if not doc:
+        raise NotFound(f"pocket {body.pocket_id}")
+    spec = doc.rippleSpec or {}
+    found = spec_ops.find_by_id(spec.get("ui", {}), body.node_id)
+    if not found:
+        raise NotFound(f"no node with id {body.node_id}")
+    node, _path = found
+    old = spec_ops.set_prop(node, body.prop, body.value)
+    await doc.save()
+    await emit(NodePropChanged(
+        pocket_id=body.pocket_id,
+        node_id=body.node_id,
+        prop=body.prop,
+        old_value=old,
+        new_value=body.value,
+    ))
+    return SetNodePropResponse(subtree=node, old_value=old)
+```
+
+**SSE push.** Update `_push_replace` in `agent_context.py` (or add a sibling `_push_op`):
+
+```python
+async def _push_op(action: str, pocket_id: str, payload: dict) -> None:
+    push_pocket_mutation({
+        "action": action,             # "node_added" | "node_replaced" | etc.
+        "pocket_id": pocket_id,
+        **payload,                    # subtree / removed_id / etc.
+    })
+```
+
+The renderer needs a corresponding switch — see [Renderer integration](#renderer-integration) below.
+
+### Renderer integration (ripple repo)
+
+Single biggest "watch out": the renderer today does `state.current = spec` on every update. That has to become "apply op in place to a stable mutable spec, let Svelte's reactivity handle the rest."
+
+**Files to touch in `ripple/`:**
+
+- `src/lib/streaming/stream-spec.svelte.ts` — add a new path that consumes incremental ops alongside the existing whole-spec parser. Whole-spec writes still work for `action: "replace"`.
+- `src/lib/core/state-manager.svelte.ts` — already has path-based mutation for `state.*`. Extend with a separate ID-keyed index for `ui.*` nodes.
+- `src/lib/Ripple.svelte` — when the incoming spec is keyed by ID, mutate in place rather than replacing `state.current`.
+- New: `src/lib/core/spec-mutator.ts` — mirror of the server-side `spec_ops.py`. Pure functions over the in-memory spec. The renderer applies ops via these.
+
+**Strategy:** maintain `Map<id, UINode>` alongside the tree. Ops mutate via the map (O(1) lookup) and Svelte's `$state` reactivity surfaces the change. Keyed `{#each}` with `id` as the key prevents row-thrash when arrays mutate.
+
+### Specialist prompt updates
+
+`ee/ripple/_pockets.py` — extend `_WORKFLOW_INTERACTION_MCP` with an "ops over whole-spec" preference rule:
+
+```text
+<mutation-strategy>
+For surgical edits (renaming one cell, toggling one prop, adding one
+widget, moving a card), use the granular ops:
+
+  add_node, replace_node, set_node_prop, move_node, remove_node
+
+These touch only the target node. Cheaper, safer, and the user's
+focus / scroll position survive.
+
+Reach for `update_pocket(ripple_spec=...)` only when:
+  - You're rewriting the entire canvas (rare — usually "redesign this").
+  - The user asked for a structural shift that touches more than ~30%
+    of nodes.
+
+Never use `update_pocket` to change one row, one prop, or one widget.
+The ops above exist for exactly that.
+</mutation-strategy>
+```
+
+Don't gut the existing "build the FULL updated tree locally" instruction — keep it as the fallback path. The new block sits *above* it as the preferred default.
+
+### Tests
+
+- `tests/cloud/test_spec_ops.py` (new) — pure unit tests for the walk+mutate helpers.
+- `tests/cloud/test_pocket_granular_ops.py` (new) — integration: each of the 5 ops, success + each error class, ID assignment on first read of a legacy pocket, sibling-ID-collision rejection.
+- `tests/test_pocket_specialist.py` — add: specialist can call all 5 new tools; main agent's allowlist excludes them.
+- `tests/cloud/test_pocket_agent_context.py` — extend: SSE event shapes for each op.
+- `tests/test_sdk_mcp_inline_help.py` — no change.
+- **The canonical regression test:** start with a 100-row table pocket; have the specialist rename one row; assert (a) `agent_update` was *not* called, (b) `agent_set_node_prop` was called once, (c) the SSE payload's subtree is the single row, not the full table.
+
+### Migration / backwards compat
+
+| Layer | Behavior |
+|---|---|
+| Existing pockets | Lazy ID assignment on first read after deploy. No migration script. |
+| `update_pocket(ripple_spec=full)` | Stays. Same `action: "replace"` SSE event. Specialist still reaches for it on whole-canvas rewrites. |
+| Legacy `add_widget`/`update_widget`/`remove_widget` | **Stay (separately)** — they target the legacy embedded `widgets` array which the desktop client doesn't render. Don't repurpose their names. |
+| Old clients | Receive the new `action` values they don't recognize. Renderer should ignore unknown `action`s and fall back to a refetch — define this contract in the renderer PR. |
+
+**Decision flagged for Rohit:** *do* we repurpose `add_widget`/`update_widget`/`remove_widget` to target `rippleSpec.ui` (since the legacy array is dead) and rename the new ops accordingly, *or* introduce fresh names (`add_node` / `replace_node` / `set_node_prop` / `move_node` / `remove_node`)? My recommendation: fresh names — cleaner contract, no risk of confusion with old behavior, easier to delete the legacy tools later. Open question.
+
+### Gotchas
+
+- **`set_node_prop` and dot-paths.** Allowing `prop="data.rows"` is convenient but lets the specialist write into a Ripple-resolver expression context where it shouldn't. Constrain to schema-known prop paths via the manifest validator. If `data` is `"{state.tasks}"`, refuse to set `data.rows` directly — refuse with a clear error.
+- **Move across parents vs reorder within a parent.** `move_node` covers both. Same op, same inverse.
+- **Concurrency.** Two ops arriving in quick succession on the same pocket: today no concurrency control beyond Beanie's optimistic update. Granular ops won't make this worse, but if the agent issues a flurry of ops in parallel (which it might), we should serialize per-pocket. Add an `asyncio.Lock` keyed on `pocket_id` in `service.py` with a small per-pocket lock cache (LRU 256). If we ever ship CRDTs, the lock retires.
+- **Validation timing.** `_validate_ripple_spec` is whole-spec today (manifest walk). For per-op validation, validate only the touched subtree. Cheap.
+- **Widget catalog drift.** If a widget's prop set changes upstream, old pockets may have unknown props. Today we warn-and-pass; keep that behavior on per-op writes too.
+
+---
+
+## PR 2: Inverse op log + undo/redo
+
+### Goal
+Every committed op stores its inverse in a per-pocket ring buffer. New tools `undo_op` / `redo_op` roll the ledger forward/back. Falls out of PR 1 almost for free — the inverses are trivial to derive at write time.
+
+### Definition of done
+
+- [ ] Per-pocket op ledger persisted. Recommend a `pocket_ops` Mongo collection with `{pocket_id, seq, op, inverse, actor, ts}`. Capped at the last 100 ops per pocket via a TTL+seq policy.
+- [ ] Each granular op (PR 1) writes a ledger entry with its computed inverse before returning.
+- [ ] Two new MCP tools on the specialist: `undo_op(pocket_id)` (pops the most recent op, applies its inverse, returns the inverse subtree) and `redo_op(pocket_id)` (re-applies a previously undone op).
+- [ ] Client-side undo/redo controls in the desktop client wired to these tools (or to dedicated REST endpoints — see Open question below).
+- [ ] Tests asserting op + inverse round-trip restores the exact pre-state for every op type.
+
+### Inverse op table
+
+| Op | Inverse |
+|---|---|
+| `add_node(parent, spec, after)` | `remove_node(spec.id)` |
+| `remove_node(id)` | `add_node(parent_id_at_remove, removed_subtree, after_id_at_remove)` |
+| `replace_node(id, new)` | `replace_node(id, old)` |
+| `set_node_prop(id, prop, new)` | `set_node_prop(id, prop, old)` |
+| `move_node(id, new_parent, after)` | `move_node(id, old_parent, old_after)` |
+
+Capture the "before" data at op-application time (in PR 1's service handlers) and write it into the ledger. Cheap — `find_by_id` is already running.
+
+### Open questions
+
+- **Tool vs. endpoint?** Undo/redo could be MCP tools the agent triggers ("undo my last change"), or REST endpoints the user triggers from a UI button. Probably both — start with the agent-facing tool, add the endpoint when the desktop client wants the UI affordance.
+- **Branching.** What happens if user does op A, undoes it, then does op B? Standard editor behavior: B clears the redo stack. Document explicitly.
+- **Cross-actor undo.** Two users in the same workspace editing the same pocket — should undo respect actor ID? Probably yes (each actor's undo only sees their own ops). Defer to a follow-up.
+
+### Tests
+
+- Per op type: apply → undo → assert spec equals pre-state byte-for-byte.
+- Apply N ops → undo N times → assert spec equals seed.
+- Apply A, undo A, apply B → redo stack is empty (assert redo errors with `no op to redo`).
+
+---
+
+## PR 3: Backend-agnostic specialist wrapper
+
+### Goal
+Lift the `pocket_specialist` registration out of `claude_sdk.py` so all backends benefit from the architectural separation (and the token savings). Today it's gated to `claude_agent_sdk` because it relies on the SDK's `agents=` map + built-in `Agent` tool.
+
+### Definition of done
+
+- [ ] New module `src/pocketpaw/agents/specialist.py` exposes a backend-agnostic `register_pocket_specialist(backend) -> SpecialistHandle` factory.
+- [ ] Each backend's `run()` calls `register_pocket_specialist(self)` if available; the handle exposes `delegate(prompt) -> AsyncIterator[Event]`.
+- [ ] Compiles to:
+  - `claude_agent_sdk` → `AgentDefinition` + `Agent` tool (today's path; refactor to use the shared factory).
+  - `openai_agents` → handoff agent.
+  - `google_adk` → sub-agent / tool-as-agent.
+  - `deep_agents` → planning subagent (LangChain Deep Agents already supports subagents natively).
+  - `codex_cli` / `opencode` / `copilot_sdk` → in-process synthetic specialist: a second `query()` call with the specialist's prompt + tool slice, results streamed back into the main agent's transcript as tool-result.
+- [ ] `POCKET_DELEGATION_RULE` stays generic (no backend-specific tool name). The delegation glue is each backend's responsibility.
+- [ ] Per-backend tests covering: specialist invokable, mutation tools fired only from specialist, main agent's `_TOOL_POLICY_MAP` doesn't reference `Agent` directly (the factory abstracts it).
+
+### Architecture sketch
+
+```python
+# src/pocketpaw/agents/specialist.py
+
+@dataclass
+class SpecialistDefinition:
+    name: str
+    description: str
+    system_prompt: str
+    tool_ids: list[str]            # MCP tool ids the specialist owns
+    main_agent_filter: list[str]   # tool ids to filter off main agent
+
+class SpecialistHandle(Protocol):
+    async def delegate(self, prompt: str, *, context: dict | None = None) -> AsyncIterator[AgentEvent]:
+        ...
+
+def build_pocket_specialist_definition() -> SpecialistDefinition:
+    """One source of truth for the specialist's prompt + tools."""
+    ...
+
+# Backend integration — each backend implements one of these.
+
+class BackendSpecialistAdapter(Protocol):
+    def register(self, defn: SpecialistDefinition) -> SpecialistHandle: ...
+```
+
+The synthetic-fallback adapter (for backends without native subagent support) is a small wrapper around the backend's own `run()` with a tighter system prompt and tool allowlist — at the cost of a second LLM round-trip but with the same architectural separation.
+
+### Tests
+- Per backend: invoke the specialist, assert mutation tools fired only inside the specialist's transcript, never as direct main-agent tool calls.
+- Cross-backend contract test: every backend listed above returns a working `SpecialistHandle`.
+
+### Gotchas
+- `deep_agents` already has its own subagent primitives — use them, don't fight them.
+- `codex_cli` and `opencode` are subprocess-based; "synthetic specialist" means an extra subprocess invocation. Cost is real; document it.
+
+---
+
+## PR 4: Vision-in-the-loop verification
+
+### Goal
+After every specialist mutation cycle, snapshot the rendered canvas and ask a vision model "did the requested change land?". Catches the silent-failure class (typo'd prop names, wrong target IDs, `bind` strings that miss state shape).
+
+### Definition of done
+
+- [ ] New module `ee/cloud/pockets/vision_verify.py`. Single entry point `verify_mutation(pocket_id, intent, mutation_summary) -> VerifyResult`.
+- [ ] Snapshot mechanism: server-side Playwright (Chromium headless) hitting an internal render route that takes a pocket id and returns a static-rendered image. Already partially possible — the desktop client renders Ripple, so we can spin up a Playwright worker against a "render server" route. Concrete decision needed (see Open questions).
+- [ ] Vision call: the active LLM provider's vision-capable variant. Reuse the `pocketpaw.llm.client` resolver; pick the smallest sufficient model (Haiku-tier).
+- [ ] Specialist's flow: at end of mutation, call `verify_mutation`. If verify fails, return a structured error to the main agent that includes the user's original intent + the vision model's "what's missing" string. Main agent decides whether to re-delegate or surface to user.
+- [ ] Configurable per-workspace: `verify_pocket_mutations: bool` setting (default `False` until rollout proven; flip to `True` after).
+- [ ] Tests with mocked vision provider asserting (a) verify passes when the snapshot matches intent, (b) verify fails with structured error when snapshot doesn't, (c) the failure path doesn't break the SSE stream.
+
+### Open questions
+
+- **Where does the snapshot come from?** Three options:
+  1. Server-side Playwright against a synthetic render route — most reliable, most infrastructure.
+  2. Client round-trip: client takes `html2canvas`, posts back. No new infra; latency cost; fragile if user has the pocket closed.
+  3. Skip image entirely — feed the resolved spec to a non-vision model and ask "does this match the intent?". Cheapest. Less accurate but probably 80% there.
+  
+  Recommend 3 for v1 (no infrastructure cost), 1 for v2 once we know it's worth the lift.
+
+- **Cost.** A vision call per mutation cycle is real money. Either rate-limit (one verify per N ops) or only verify on completion of a multi-step specialist transcript, not after each tool call.
+
+### Tests
+- Mock vision provider returning "matches" → mutation completes, no error event.
+- Mock provider returning "missing X" → main agent receives structured retry hint.
+- Mock provider unavailable → mutation completes (best-effort verify), warning logged.
+
+---
+
+## PR 5: Instinct integration for pocket mutations
+
+### Goal
+Every granular mutation flows through Instinct (`ee/instinct/`) as a proposed action with: reasoning trace, fabric snapshot of the pocket pre-state, audit trail, and approval policy. Same gate as `send_email`.
+
+### Definition of done
+
+- [ ] New `MutationProposal` Instinct event type. Carries: pocket id, op, op args, inverse (from PR 2), specialist's reasoning trace, the user's verbatim intent.
+- [ ] Each granular service-layer call routes through Instinct's proposal pipeline:
+  - Auto-approve path: low-risk ops on user-owned pockets (current default).
+  - Approval-required path: ops on workspace-shared pockets, ops marked sensitive by per-pocket setting.
+- [ ] Instinct UI affordance for reviewing pending pocket mutation proposals (probably extends the existing Instinct panel — coordinate with that surface owner).
+- [ ] Outcome metering: was the mutation reverted within N seconds? Did the user undo it? Counts as negative outcome. Plumbs into the existing Instinct outcome table.
+- [ ] Tests: auto-approve path identical to current behavior; approval-required path correctly blocks until approval; rejection path applies the inverse op.
+
+### Wiring
+
+- `ee/cloud/pockets/service.py` — each granular service function ends not with a direct `emit(NodePropChanged(...))` but with `await instinct.propose(MutationProposal(...))`. Instinct decides whether to apply immediately (auto-approve) or queue.
+- `ee/instinct/decisions.py` — extend the policy table with a new `pocket_mutation` action class.
+- `ee/cloud/pockets/dto.py` — add `sensitivity: PocketSensitivity` field on the pocket document. Defaults to `private`. Workspace-shared pockets default to `team` which routes to approval.
+
+### Tests
+- End-to-end: low-risk op auto-approves and emits SSE within the same request.
+- Approval-required op: SSE shows "pending approval"; second request approves; SSE then shows the mutation applied.
+- Rejection path: rejected op applies inverse, no SSE for the original op.
+
+---
+
+## Out of scope (documenting so we don't forget)
+
+These come after the five above. Tracking here so they're not lost:
+
+- **Op streaming.** Once granular ops exist (PR 1), streaming the agent's tool calls **is** streaming the mutations. The renderer applies them as they arrive. No more partial-JSON parsing for spec writes. Worth a small follow-up PR after PR 1 + PR 2 stabilize.
+- **Soul memory of design preferences.** Specialist's soul records "captain prefers density", "avoid pie charts", "use rounded corners". Loads at the start of every specialist invocation. Survives across sessions. Roadmap item, no PR yet.
+- **Named-statement spec view (OpenUI Lang style).** The agent reads a flat-dictionary view; storage stays nested JSON. 85%-ish token savings on long-session refinement. Long-term — separate RFC required.
+- **CRDTs for concurrent agent editing.** Don't need it today (per-pocket lock from PR 1 is enough). Door stays open.
+- **Cross-actor undo.** Multi-user pockets where each actor's undo only sees their own ops. Follow-up to PR 2.
+
+---
+
+## Open questions for Prakash / Rohit
+
+These need decisions before PR 1 starts. Recommend a 30-min sync.
+
+1. **Tool naming.** Repurpose `add_widget`/`update_widget`/`remove_widget` (kill the legacy embedded array), or introduce fresh `add_node`/`replace_node`/`remove_node`? My recommendation: fresh names; retire legacy in a follow-up.
+2. **Vision verification (PR 4).** Start with prose-only verify (no snapshot) or invest in Playwright render route? My recommendation: prose-only for v1.
+3. **Instinct policy default (PR 5).** Auto-approve all pocket mutations by default, or require approval for any workspace-shared pocket? My recommendation: auto-approve everywhere for v1; ratchet down once Instinct UI is in place.
+4. **Op ledger storage (PR 2).** New Mongo collection or embed in the pocket document? My recommendation: separate collection — pocket documents stay small, ledger TTLs cleanly.
+5. **PR 1 size.** As specified above, PR 1 is L (server + tool registration + renderer + prompt + tests). Worth splitting into PR 1a (server + tools, renderer falls back to refetch on unknown actions) and PR 1b (renderer applies in place)? My recommendation: keep as one PR — the renderer-side change is small enough and ships together cleanly.
+
+---
+
+## Cross-references
+
+- [Vision doc](./2026-05-pocket-specialist-and-ripple-mutation.md) — the "why" companion to this "how".
+- [PR #1069](https://github.com/pocketpaw/pocketpaw/pull/1069) — the foundation this builds on.
+- `pocketpaw/CLAUDE.md` § ee/cloud Code Rules — the 4-file shape every PR-1 code path follows.
+- `ripple/src/lib/schema/ui-spec.ts` — UISpec schema; PR 1 makes `id` required at read time.
+- `ee/cloud/pockets/agent_context.py` — current MCP-shape wrappers; pattern to mirror for granular ops.
+- `ee/cloud/chat/agent_service.py:push_pocket_mutation` — SSE push site; new action types layer in here.


### PR DESCRIPTION
## Summary

Living design doc for the pocket-specialist subagent + Ripple mutation surface. Captures what shipped on [#1069](https://github.com/pocketpaw/pocketpaw/pull/1069) and the path forward toward file-tool-style granular UI-tree mutations.

Lives at `docs/internal/2026-05-pocket-specialist-and-ripple-mutation.md`.

## What it covers

- **Why this exists** — token economics, mutation fragility, architectural enforcement.
- **What shipped on #1069** — the `pocket_specialist` subagent, allowlist filtering, `POCKET_DELEGATION_RULE`, slim inline prompt, cache-friendly ordering, resolver array methods (`.where`/`.sortBy`/etc.), normalizer dead-handler stripper, backend gating.
- **How a mutation flows today** — sequence diagram from user → main agent → specialist → MCP tools.
- **MCP tool reference** — all 9 tools, where they live (main vs specialist), what they target. Calls out that `add_widget`/`update_widget`/`remove_widget` currently target the legacy embedded array, not `rippleSpec.ui`.
- **Design principles** — 8 rules the implementation already follows; documenting them so future PRs don't drift.
- **Eight prioritized gaps** — granular UI-tree mutations (biggest), inverse op log + undo/redo, vision verification, backend portability, op streaming, Instinct integration, soul memory, named-statement view (long-term, references OpenUI Lang).
- **Proposed next-PR sequence** — five PRs with dependencies.
- **Appendices** — file map, prompt assembly order, full sequence example before/after granular ops.

## Why now

Rohit's #1069 ships the subagent boundary; the granular mutation surface is the natural next move. We need a single canonical place that describes the destination so the next PRs don't drift apart. The PR description on #1069 references this doc path; this PR fills it.

## Test plan

- [x] Doc renders cleanly on GitHub (markdown headings, tables, fenced code blocks).
- [x] Cross-references to actual files / PRs / external repos verified.
- [ ] Captain review — direction + scope. Edit liberally; the doc is meant to live and update as PRs land.