### PR TITLE
chore(deps): bump deepagents to 0.5.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,8 +115,8 @@ copilot-sdk = [
     "github-copilot-sdk>=0.1.0",
 ]
 deep-agents = [
-    "deepagents>=0.1.0",
-    "langchain-mcp-adapters>=0.1.0",
+    "deepagents>=0.4.12,<0.5.0",
+    "langchain-mcp-adapters>=0.2.2,<0.3.0",
 ]
 litellm = [
     "litellm>=1.40.0",
@@ -303,8 +303,8 @@ all = [
     "openai-agents>=0.2.0",
     "google-adk>=1.0.0",
     "github-copilot-sdk>=0.1.0",
-    "deepagents>=0.1.0",
-    "langchain-mcp-adapters>=0.1.0",
+    "deepagents>=0.4.12,<0.5.0",
+    "langchain-mcp-adapters>=0.2.2,<0.3.0",
 ]
 dev = [
     # all deps (flattened from [all])
@@ -331,8 +331,8 @@ dev = [
     "openai-agents>=0.2.0",
     "google-adk>=1.0.0",
     "github-copilot-sdk>=0.1.0",
-    "deepagents>=0.1.0",
-    "langchain-mcp-adapters>=0.1.0",
+    "deepagents>=0.4.12,<0.5.0",
+    "langchain-mcp-adapters>=0.2.2,<0.3.0",
     # dev tools
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0,<1.0.0",  # pinned: incompatible with pytest-asyncio 1.x until asyncio.run() call sites are migrated
@@ -399,8 +399,8 @@ dev = [
     "openai-agents>=0.2.0",
     "google-adk>=1.0.0",
     "github-copilot-sdk>=0.1.0",
-    "deepagents>=0.1.0",
-    "langchain-mcp-adapters>=0.1.0",
+    "deepagents>=0.4.12,<0.5.0",
+    "langchain-mcp-adapters>=0.2.2,<0.3.0",
     # dev tools
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0,<1.0.0",  # pinned: incompatible with pytest-asyncio 1.x until asyncio.run() call sites are migrated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ copilot-sdk = [
     "github-copilot-sdk>=0.1.0",
 ]
 deep-agents = [
-    "deepagents>=0.4.12,<0.5.0",
+    "deepagents>=0.5.8,<0.6.0",
     "langchain-mcp-adapters>=0.2.2,<0.3.0",
 ]
 litellm = [
@@ -303,7 +303,7 @@ all = [
     "openai-agents>=0.2.0",
     "google-adk>=1.0.0",
     "github-copilot-sdk>=0.1.0",
-    "deepagents>=0.4.12,<0.5.0",
+    "deepagents>=0.5.8,<0.6.0",
     "langchain-mcp-adapters>=0.2.2,<0.3.0",
 ]
 dev = [
@@ -331,7 +331,7 @@ dev = [
     "openai-agents>=0.2.0",
     "google-adk>=1.0.0",
     "github-copilot-sdk>=0.1.0",
-    "deepagents>=0.4.12,<0.5.0",
+    "deepagents>=0.5.8,<0.6.0",
     "langchain-mcp-adapters>=0.2.2,<0.3.0",
     # dev tools
     "pytest>=8.0.0",
@@ -399,7 +399,7 @@ dev = [
     "openai-agents>=0.2.0",
     "google-adk>=1.0.0",
     "github-copilot-sdk>=0.1.0",
-    "deepagents>=0.4.12,<0.5.0",
+    "deepagents>=0.5.8,<0.6.0",
     "langchain-mcp-adapters>=0.2.2,<0.3.0",
     # dev tools
     "pytest>=8.0.0",


### PR DESCRIPTION
## Summary

- Bumps `deepagents` from `>=0.1.0` to `>=0.5.8,<0.6.0` (latest stable on PyPI).
- Bumps `langchain-mcp-adapters` from `>=0.1.0` to `>=0.2.2,<0.3.0`.
- Applied across all four pin sites: `deep-agents` extra, `all` composite extra, `dev` optional-dep, and `[dependency-groups].dev`.

> **Note:** the branch name says `0.4.12` because the initial pin was based on stale PyPI metadata; the corrected pin (`0.5.8`) is in the second commit on this branch. Branch was not renamed to keep the PR thread intact.

## Why

The `>=0.1.0` floor was set when the backend first integrated deepagents and is now several minor versions stale. The 0.5.x signature surface is what we'll actually code against in follow-up work:

| 0.5.x parameter | What it unlocks |
|---|---|
| `cache=langgraph.cache.base.BaseCache` | LLM response cache — big cost/latency win with DeepSeek prompt-cache pricing |
| `response_format=ToolStrategy\|ProviderStrategy\|AutoStrategy` | Pydantic-validated structured output (e.g. pocket-spec JSON) |
| `middleware=Sequence[AgentMiddleware]` | `FilesystemMiddleware`, `MemoryMiddleware`, `SubAgentMiddleware` (verified exports) |
| `subagents=list[SubAgent\|CompiledSubAgent]` | Declarative sub-agent specs |
| `skills=list[str]`, `memory=list[str]` | Progressive context loading |
| `interrupt_on`, `checkpointer`, `store`, `backend` | HITL gates, durability, custom backends |

## Verified 0.5.1 top-level exports

`CompiledSubAgent`, `FilesystemMiddleware`, `MemoryMiddleware`, `SubAgent`, `SubAgentMiddleware`, `create_deep_agent`, `backends`, `graph`, `middleware`. Note: `SkillsMiddleware`, `SummarizationMiddleware`, and `ProviderProfile` are NOT at the package root in 0.5.x — those moved or were removed since the 0.4.x docs.

Existing implementation in `src/pocketpaw/agents/deep_agents.py` (`init_chat_model` + `astream` v2 + compiled-graph cache) stays API-compatible — this is a pure floor bump, no code changes.

## Test plan

- [ ] `uv sync --dev` resolves cleanly.
- [ ] `uv run pocketpaw --help` boots without import errors.
- [ ] Existing `deep_agents` backend tests still pass: `uv run pytest tests/agents -k deep_agents -v`.
- [ ] Manual smoke: `POCKETPAW_AGENT_BACKEND=deep_agents uv run pocketpaw` — single-turn chat completes, MCP tool invocation works.