### PR TITLE
test(stream_event): pin agent_id so router-rebuild path doesn't fire on the test mock

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,6 @@ jobs:
         # changes and goes red when someone introduces a new regression:
         #   - #1079: tests/test_concurrency.py — list-membership flakes
         #   - #1080: tests/test_context_budget.py::TestKbContext::test_successful_kb_fetch
-        #   - #1081: tests/test_stream_event.py — thinking-event ordering
         # Remove the corresponding --deselect once each issue lands its fix.
         run: |
           uv run pytest tests/ \
@@ -52,8 +51,6 @@ jobs:
             --deselect tests/test_concurrency.py::test_cross_session_runs_in_parallel \
             --deselect tests/test_concurrency.py::test_global_semaphore_caps_concurrency \
             --deselect tests/test_context_budget.py::TestKbContext::test_successful_kb_fetch \
-            --deselect tests/test_stream_event.py::TestLoopThinkingIntegration::test_loop_thinking_publishes_system_event \
-            --deselect tests/test_stream_event.py::TestLoopThinkingIntegration::test_loop_thinking_not_in_memory \
             -q --tb=short
         env:
           POCKETPAW_LLM_PROVIDER: "ollama"

--- a/tests/test_stream_event.py
+++ b/tests/test_stream_event.py
@@ -264,6 +264,11 @@ class TestLoopThinkingIntegration:
             from pocketpaw.agents.loop import AgentLoop
 
             loop = AgentLoop()
+            # Pin agent_id so _get_router() returns the mocked router via the
+            # per-agent fast path (line 430-431 of loop.py) and skips the
+            # default-loop's backend-change rebuild — that rebuild calls
+            # ``old.stop()`` on the prior router and chokes on a MagicMock.
+            loop.agent_id = "test-agent"
 
             # Mock router to yield thinking + done
             router = MagicMock()
@@ -329,6 +334,9 @@ class TestLoopThinkingIntegration:
             from pocketpaw.agents.loop import AgentLoop
 
             loop = AgentLoop()
+            # See comment in test_loop_thinking_publishes_system_event re:
+            # agent_id pinning the per-agent fast path.
+            loop.agent_id = "test-agent"
 
             router = MagicMock()
 


### PR DESCRIPTION
## Summary

Closes #1081. Two tests in \`tests/test_stream_event.py::TestLoopThinkingIntegration\` were failing in CI:

- \`test_loop_thinking_publishes_system_event\` — \`AssertionError: assert 'thinking_done' in ['agents_md_loaded', 'agent_start', 'thinking', 'agent_end']\`
- \`test_loop_thinking_not_in_memory\` — \`assert 0 == 1\`

The original report (#1081) suggested the agent loop might have dropped a \`thinking_done\` event or the memory-write predicate may have changed. **Neither.** The loop still emits \`thinking_done\` correctly (loop.py:1081-1087) and still writes to memory. The tests broke because of a *different* loop change.

## Root cause

\`_get_router()\` picked up a backend-change rebuild path some time ago (loop.py:434+):

```python
fresh_settings = Settings.load()
active = getattr(self._router, "_active_backend_name", None)
if active != fresh_settings.agent_backend:
    old = self._router
    ...
    task = asyncio.create_task(old.stop())   # ← chokes on MagicMock
```

The tests directly inject \`loop._router = router\` (a MagicMock). When \`_process_message_inner\` calls \`self._get_router()\`, the default-loop branch sees \`self._router._active_backend_name\` is None (MagicMock attribute) and \`fresh_settings.agent_backend\` is whatever the test environment loaded — they don't match, the rebuild fires, and \`old.stop()\` returns a MagicMock instead of a coroutine. \`asyncio.create_task\` raises \`TypeError\`, the outer \`try/except\` in \`_process_message\` swallows it with \`logger.error("❌ Error processing message: a coroutine was expected, got <MagicMock ...>")\`, and the message handler returns before either \`thinking_done\` or the memory write fires. The assertions then fail on what *didn't* happen.

The error log is captured but pytest doesn't surface stderr from logger.error in CI by default — that's why the failure mode looked like "thinking_done is missing" rather than "the entire handler crashed".

## Fix

Set \`loop.agent_id = "test-agent"\` on each test. That sends \`_get_router()\` down the per-agent fast path (loop.py:430-431) which returns the cached router immediately, no rebuild. The per-agent path is the right shape for a unit test that injects its own router — the rebuild path is meant for runtime backend swaps in the dashboard.

Two-line change per test, plus a comment explaining the choice.

## Workflow change

Removes the two corresponding \`--deselect\` lines from \`.github/workflows/tests.yaml\` so the gate exercises these tests again. Comment block updated to drop \`#1081\` from the tracked-failure list (\`#1079\` and \`#1080\` remain).

## Test plan

- [x] \`uv run pytest tests/test_stream_event.py::TestLoopThinkingIntegration -v\` — 2 passed locally
- [ ] CI on this PR runs the de-deselected tests and stays green

## Out of scope

- The two tests still mock heavily (Settings, MessageBus, MemoryManager, ContextBuilder). A future refactor could extract \`_handle_agent_event\` from the giant \`_process_message_inner\` and make the test work against a smaller surface. Worth filing if/when someone adds a third \`TestLoopThinkingIntegration\` test and feels the duplication.