### PR TITLE
docs(internal): mission control operator surface spec

### DIFF
--- a/docs/internal/2026-05-mission-control-backend-audit.md
+++ b/docs/internal/2026-05-mission-control-backend-audit.md
@@ -1,0 +1,302 @@
+# Mission Control — backend integration + primitive audit
+
+*Companion to [`2026-05-mission-control.md`](./2026-05-mission-control.md). The vision doc says what Mission Control is; this doc lists, primitive by primitive, **what already exists in the codebase vs what needs to be built** to wire the mock UI to real data. Honest accounting, not aspirational scoping.*
+
+*Audience: Rohit (backend), reviewer of any Mission Control v0.5 / v1 work.*
+
+---
+
+## TL;DR
+
+**~60% of Mission Control wires to endpoints that already exist.** The Tray + Pawprints + per-item audit are essentially shipped — `ee/instinct/router.py` already exposes propose/approve/reject/query-audit. Fabric, Pockets, Soul, Connectors, Notifications are all in place. The two new entities we genuinely need:
+
+1. **Tasks** — a unified `WorkItem` entity covering Nudges + agent tasks + audit projections, with cycle assignment. Doesn't exist.
+2. **Cycles** — time-boxed work windows + a per-cycle daily series for the burnup chart. Doesn't exist.
+
+Plus one aggregation endpoint (Outcomes summary) and one cross-cutting activity feed buffer.
+
+Everything else is glue.
+
+---
+
+## What exists in `ee/` today
+
+```
+ee/
+├── instinct/                ← Nudge proposal / approval / audit pipeline
+│   ├── router.py            (Tray + Pawprints endpoints live here)
+│   ├── store.py
+│   ├── models.py
+│   ├── trace.py
+│   ├── correction.py
+│   └── correction_soul_bridge.py
+├── fabric/                  ← Typed ontology + provenance
+│   ├── router.py            (objects, links, types, query)
+│   ├── journal_store.py
+│   ├── policy.py
+│   ├── projection.py
+│   └── store.py
+└── cloud/                   ← Workspace SaaS surfaces (per CLAUDE.md 4-file shape)
+    ├── pockets/             (CRUD + widgets · already 4-file)
+    ├── agents/              (CRUD · already 4-file)
+    ├── notifications/       (list / read / clear)
+    ├── connectors/
+    ├── kb/
+    ├── chat/
+    ├── workspace/
+    ├── auth/
+    ├── sessions/
+    ├── files/
+    └── uploads/
+```
+
+`ee/instinct/` and `ee/fabric/` are *engine primitives* — they live at the `ee/` root, not under `ee/cloud/`. `ee/cloud/` is the multi-tenant SaaS surface. Mission Control is hosted in `ee/cloud` but consumes both.
+
+---
+
+## Primitive-by-primitive audit
+
+### 1. Instinct → The Tray + Pawprints + per-item action history
+
+**What Mission Control needs.** List pending Nudges scoped to the current user + workspace. Approve / reject / bulk-approve a Nudge. Query the audit log (Pawprints) with filters. Fetch a single Pawprint's full reasoning trace.
+
+**What's already in `ee/instinct/router.py`:**
+
+| Endpoint | Status | Maps to |
+|---|---|---|
+| `POST /propose_action` | ✅ exists | Agent proposes a Nudge (called from agent runtime, not MC) |
+| `GET /pending_actions?pocket_id=…` | ✅ exists | The Tray feed — close but needs `assignee` filter |
+| `GET /actions` | ✅ exists | Full Instinct action list |
+| `POST /{action_id}/approve` | ✅ exists | Single-item approve from detail panel |
+| `POST /{action_id}/reject` | ✅ exists | Single-item reject from detail panel |
+| `GET /audit` (`query_audit`) | ✅ exists | Pawprints section feed |
+| `GET /audit/{id}` (`get_audit_entry`) | ✅ exists | Per-Pawprint detail expand |
+| `GET /audit/export` | ✅ exists | "Export" affordance (future) |
+| `GET /corrections` | ✅ exists | Reasoning-trace surface (future) |
+
+**Gaps for v0.5:**
+
+- **Bulk approve / bulk reject.** Current router takes a single `action_id` in the path. Mission Control's bulk action bar selects N items and POSTs them in one call. Two options: (a) add `POST /actions/bulk-approve` body `{ids, note?}` in `ee/instinct/router.py`; (b) the frontend fans out N parallel single-item calls. **Recommend (a)** — atomic semantics, single audit transaction per bulk operation, cheaper round-trip. ~20 lines of router code + a `bulk_approve` service method.
+- **`assignee` filter on `pending_actions`.** Today it filters by `pocket_id`. For The Tray we want `pending_actions?assignee=<user_id>` so we don't show other humans' pending items. ~5-line change in the existing handler.
+- **Response shape alignment.** Current `pending_actions` likely returns `Action` shape (proposal-flavored). Mission Control consumes `WorkItem` shape (status + assignee + cycle_id + source). Map at the cloud-layer boundary: `ee/cloud/mission_control/service.py` (new) wraps `instinct.pending_actions()` and projects to `WorkItemResponse`. Don't change Instinct's internal types — wrap.
+
+**ee/cloud 4-file conformance** (per `pocketpaw/CLAUDE.md`): new wrapper lives at `ee/cloud/mission_control/{domain.py, dto.py, service.py, router.py}`. Service imports `ee.instinct.store` for reads, never touches Beanie directly for Instinct entities. Tenant filter (`workspace_id`) on every read.
+
+### 2. Fabric → typed object references in items
+
+**What Mission Control needs.** When a Work Item references a Fabric object (e.g., a Nudge proposing to update `Customer:Stripe → ContractStatus:active`), the detail panel surfaces the typed reference with link + provenance.
+
+**What's already in `ee/fabric/router.py`:**
+
+| Endpoint | Status |
+|---|---|
+| `GET /fabric/types` | ✅ exists |
+| `GET /fabric/objects` | ✅ exists |
+| `GET /fabric/objects/{id}` | ✅ exists |
+| `POST /fabric/objects` | ✅ exists |
+| `POST /fabric/query` | ✅ exists |
+| `GET /fabric/links` | ✅ exists |
+| `POST /fabric/links` | ✅ exists |
+| `GET /fabric/stats` | ✅ exists |
+
+**Gaps for v0.5:** **None for read-side.** Mission Control just needs to display Fabric references; the existing `GET /fabric/objects/{id}` covers the look-up. The WorkItem shape needs an optional `fabric_refs: FabricRef[]` field, and the detail panel renders chips for each.
+
+**Gaps for v1:** Inline editing of a Fabric object from the detail panel (when approving a Nudge that proposes a Fabric mutation, show the diff inline before commit). Defer until UX tested.
+
+### 3. Pockets → scope for cycles and work items
+
+**What Mission Control needs.** Items + cycles are scoped to a Pocket. The left rail lists Pockets to filter the feed; cycles attach to a Pocket.
+
+**What's already in `ee/cloud/pockets/router.py`:**
+
+| Endpoint | Status |
+|---|---|
+| `GET /pockets` | ✅ exists |
+| `GET /pockets/{id}` | ✅ exists |
+| `POST /pockets` | ✅ exists |
+| `PATCH /pockets/{id}` | ✅ exists |
+| `DELETE /pockets/{id}` | ✅ exists |
+| `POST /pockets/{id}/widgets` etc. | ✅ exists (used by ripple) |
+
+**Gaps:** **None.** Mission Control reads Pockets but does not mutate them. Left-rail filter is purely a frontend concern over the existing `GET /pockets` payload.
+
+### 4. Soul → agent identity + memory exposure
+
+**What Mission Control needs.** When viewing an agent-assigned item, surface the agent's Soul context: name, age, last-evolved timestamp, the memory layer that informs this proposal (semantic vs episodic). For v0.5 just the static metadata; v1 lets the operator drill into the relevant memory.
+
+**What's available.** Soul Protocol exposes `soul status`, `soul recall`, etc. via the soul-protocol CLI + MCP tools (per `paw-workspace/.claude/CLAUDE.md`). No HTTP endpoint inside `ee/cloud/`; soul reads happen in-process via the soul-protocol library.
+
+**Gaps:** **A thin read endpoint at `ee/cloud/agents/router.py:GET /agents/{id}/soul-summary`** that returns `{ name, archetype, age_days, last_evolved_at, ocean_traits }`. Backed by a service method that calls `Soul.status()` on the agent's bound soul file. ~30 lines. Already partially present? Worth a grep before building; if `agent.get_status()` returns soul fields, this collapses to a frontend display change.
+
+### 5. Notifications → bridges into Mission Control
+
+**What Mission Control needs.** When a new Nudge lands, notify the assigned human via the existing notification surface. When Mission Control is open, the live SSE event surfaces it directly; when Mission Control is closed, a notification persists. Don't duplicate channels — the existing `ee/cloud/notifications/` handles this.
+
+**What's already there:**
+
+| Endpoint | Status |
+|---|---|
+| `GET /notifications` | ✅ exists |
+| `POST /notifications/{id}/read` | ✅ exists |
+| `POST /notifications/clear` | ✅ exists |
+
+**Gaps:** A listener that creates a `Notification` whenever a Nudge in `awaiting_approval` state is routed to a human. Hook lives in `ee/instinct/` (after `propose_action` resolves to a human assignee) → emits `nudge.proposed` → notification service subscribes → creates a notification.
+
+### 6. Channels → multi-surface deploy of approvals
+
+**Not v0.5 scope.** Mission Control is the in-app operator surface. Channel adapters (Slack / Telegram / WhatsApp) for approve-from-message are a follow-up. The pocketpaw channel adapter framework is already in place for this; wiring is straightforward when we get there.
+
+---
+
+## What needs to be built
+
+Three new ee/cloud entities. Each follows the 4-file shape (`domain.py + dto.py + service.py + router.py`) per `pocketpaw/CLAUDE.md`, with `import-linter` contract entry.
+
+### A. `ee/cloud/mission_control/` (the entry-point façade)
+
+**Why a wrapper entity?** Mission Control composes data from Instinct + new Tasks + new Cycles + the activity buffer. Rather than make the frontend stitch four endpoints together, expose a workspace-aware façade that returns the canonical `WorkItem` shape from a single endpoint.
+
+```
+ee/cloud/mission_control/
+├── domain.py     ← WorkItem value object (frozen, workspace_id required)
+├── dto.py        ← WorkItemResponse, ListWorkItemsRequest, BulkActionRequest,
+│                   OutcomeSummaryResponse, ListSectionResponse
+├── service.py    ← agent_list_work_items(ctx, body)
+│                   agent_bulk_approve(ctx, body)
+│                   agent_bulk_reject(ctx, body)
+│                   agent_outcomes_summary(ctx, body)
+│                   agent_list_activity(ctx, body)
+└── router.py     ← GET /mission-control/items?section=…&agent=…&pocket=…
+                   POST /mission-control/items/bulk-approve
+                   POST /mission-control/items/bulk-reject
+                   POST /mission-control/items/bulk-reassign
+                   POST /mission-control/items/bulk-snooze
+                   GET  /mission-control/outcomes?window=24h
+                   GET  /mission-control/activity?limit=30
+```
+
+Service implementation reads from `ee.instinct.store` (Nudges + Pawprints), `ee.cloud.tasks.service` (the new Tasks entity), and an in-memory `activity_buffer` (see C below). Projects everything into `WorkItem` shape on the way out.
+
+### B. `ee/cloud/tasks/` (the assignable-to-agent work primitive)
+
+**Why a new entity?** A Nudge is a proposal awaiting human approval. A Task is durable work assigned to either a human or an agent. They share a lot of shape but lifecycles differ: a Task spans `proposed → in_progress → done | blocked | failed`, may produce intermediate Nudges, and ties to a Cycle. Modeling them as the same Mongo collection makes queries simpler; keeping `Nudge` as a domain type within `Task` (status = `awaiting_approval`) is cleaner than a separate entity.
+
+```
+ee/cloud/tasks/
+├── domain.py     ← Task (assignee polymorphism, status enum, cycle_id?,
+│                   source kind, priority, fabric_refs[])
+├── dto.py        ← CreateTaskRequest, UpdateTaskRequest, ListTasksRequest,
+│                   TaskResponse, ClaimTaskRequest
+├── service.py    ← agent_create_task, agent_list_tasks,
+│                   agent_update_task, agent_claim_task,
+│                   agent_complete_task, agent_block_task,
+│                   agent_reassign_task
+└── router.py     ← POST /tasks
+                   GET  /tasks?assignee=…&status=…&cycle_id=…
+                   PATCH /tasks/{id}
+                   POST /tasks/{id}/claim       (agent picks it up)
+                   POST /tasks/{id}/complete
+                   POST /tasks/{id}/block
+                   POST /tasks/{id}/reassign
+```
+
+**Agent task-claim flow** (v1):
+- A user (or another agent) creates a Task with `assignee.kind = agent`. Status: `proposed`.
+- The assigned agent's runtime polls `GET /tasks?assignee=<my_id>&status=proposed` on its loop OR receives the `task.proposed` SSE event.
+- Agent calls `POST /tasks/{id}/claim` → status: `in_progress`.
+- Agent executes. Sub-actions surface as `activity.recorded` events bound to the task id.
+- Agent completes via `POST /tasks/{id}/complete` (auto-archives) or `POST /tasks/{id}/block` (surfaces as a Snag).
+
+Pair the claim/complete tools with the existing pocket-specialist subagent's MCP surface from [#1069](https://github.com/pocketpaw/pocketpaw/pull/1069). Same architectural pattern.
+
+### C. `ee/cloud/cycles/` (time-boxed work windows)
+
+**Why a new entity?** Cycles are aggregate views over Tasks within a time window. Could be a derived projection, but the burnup chart needs daily snapshots that don't reconstruct cleanly from raw Tasks alone — we need a job that snapshots scope/started/completed each midnight.
+
+```
+ee/cloud/cycles/
+├── domain.py     ← Cycle (pocket_id?, start, end, status, scope, started,
+│                   completed, daily snapshots)
+├── dto.py        ← CreateCycleRequest, CycleResponse, CycleDailyPointResponse
+├── service.py    ← agent_create_cycle, agent_list_cycles, agent_get_cycle,
+│                   agent_close_cycle (rolls incomplete tasks to next)
+│                   _snapshot_cycle_daily (background job)
+└── router.py     ← POST /cycles
+                   GET  /cycles
+                   GET  /cycles/{id}
+                   POST /cycles/{id}/close
+                   GET  /cycles/{id}/items
+```
+
+**Daily snapshot job.** A simple async loop running once per day (or per workspace policy) computes the (scope, started, completed) tuple for each active cycle and appends to its `daily` array. Cycle close moves un-done tasks to the next cycle (matches Linear's no-keep-incomplete behavior).
+
+### D. Cross-cutting: activity buffer
+
+**What it is.** A bounded in-memory ring buffer per workspace (~200 entries, 1-hour TTL) capturing every agent tool call, thinking step, completion, and waiting state. Feeds the live ticker in the Mission Control status bar + the full Activity tab.
+
+**Why not persistent?** The activity feed is operational decoration, not source-of-truth. The durable record lives in Pawprints (Instinct's audit). Activity is the live ticker; Pawprints is the journal. Separate concerns, different storage.
+
+**Implementation.** New module `ee/cloud/activity/buffer.py`. Subscribes to the in-process event bus (`ee.cloud._core.realtime.bus`) for `agent.tool_call`, `agent.thinking`, `agent.completed`. Pushes onto a per-workspace deque. Exposes `GET /mission-control/activity` (routed via the façade in A above). Emits a `activity.recorded` SSE event for each entry.
+
+---
+
+## SSE event surface
+
+Existing `push_pocket_mutation` pattern in `ee/cloud/chat/agent_service.py:110` is the precedent. Mission Control adds:
+
+| Event | When | Payload shape |
+|---|---|---|
+| `work_item.proposed` | new Task or Nudge enters the system | `{ item: WorkItem }` |
+| `work_item.updated` | status / assignee / priority change | `{ id, changes: Partial<WorkItem> }` |
+| `work_item.resolved` | terminal state (done / reverted / failed) | `{ id, status }` |
+| `activity.recorded` | new agent activity entry | `{ event: ActivityEvent }` |
+| `cycle.snapshotted` | nightly snapshot job appended a daily point | `{ cycle_id, daily_point }` |
+| `cycle.closed` | a cycle ended; items rolled to next | `{ cycle_id, rolled_count }` |
+
+Frontend `RealtimeClient` (`paw-enterprise/src/lib/core/realtime/client.ts`) already supports typed `on<T>()` registration. Each Mission Control pane subscribes to the events it cares about.
+
+---
+
+## Migration plan
+
+Three PRs, in order:
+
+| PR | Scope | Risk |
+|---|---|---|
+| **1. Mission Control façade + Instinct alignment** | `ee/cloud/mission_control/` 4-file shape. Add `assignee` filter + bulk approve/reject to `ee/instinct/router.py`. Frontend flips `VITE_MISSION_CONTROL_MOCK=false` for The Tray + Pawprints panes; other panes stay mocked. | Low — touches Instinct only at the read-filter level. Existing tests stay green. |
+| **2. Tasks entity** | `ee/cloud/tasks/` 4-file shape, agent claim/complete/block tools, lint contract entry. Frontend wires "Agents in flight", "Delegated", "+ new task" → real backend. | Medium — new entity, new SSE events, new agent-side claim tool. Touch-time-migrate `notifications/` listener to subscribe to `task.proposed`. |
+| **3. Cycles + activity buffer** | `ee/cloud/cycles/` 4-file shape with daily snapshot job. `ee/cloud/activity/buffer.py` + SSE wire-up. Frontend wires the Cycles tab + activity ticker. | Medium — daily job is the most novel piece. Lightweight: an async task running every 24h per workspace, or driven by a cron primitive. |
+
+After PR 3, Mission Control is fully wired. Total estimate at agent-time scale: **~12–18 agent-hours of crew work**, mostly in PR 2 (Tasks entity carries the most novelty).
+
+---
+
+## Decision log (for the build)
+
+- **Mission Control façade vs direct multi-endpoint calls** → façade. One round-trip per pane, simpler frontend, single tenant-filter chokepoint.
+- **Tasks as one entity, Nudge as a status** → yes. The unified `WorkItem` design (frontend) carries through to the backend. Reduces table count, simplifies queries, matches the Linear precedent.
+- **Activity buffer in-memory vs persistent** → in-memory. Pawprints is the durable record; activity is the live decoration. Buffer rebuilds on process restart (acceptable — the live ticker doesn't need history).
+- **Cycle daily snapshots vs derived on read** → snapshotted. The burnup chart needs historical scope/started/completed at past timestamps which can't be reconstructed from raw Tasks after status changes. Daily snapshot is cheap.
+- **Bulk approve as a new endpoint vs frontend fan-out** → new endpoint. Atomic Pawprint, single audit transaction.
+- **Soul exposure** → thin read-only `agents/{id}/soul-summary`. Don't expose full memory via HTTP — that's a security surface we don't want until we have a real auth story.
+
+---
+
+## Open questions for the captain / Rohit
+
+These need a call before PR 1 starts.
+
+1. **Should `pending_actions` ever cross workspace boundaries?** Today it filters by `pocket_id`. For Mission Control we want workspace-scoped queries. Is `workspace_id` already an implicit filter via the `ctx.workspace_id` chain, or do we need to make it explicit? *My read: implicit via ctx — confirm.*
+2. **Bulk-approve audit semantics.** Single Pawprint with `affected_ids: list[str]`, or N Pawprints (one per item) with a shared `bulk_id`? *Rec: N Pawprints + shared bulk_id. Replay-ability per item, query-able by bulk.*
+3. **Task claim contention.** If two agents are eligible for the same Task (rare but possible), what happens? Optimistic claim with status check (first wins, second errors)? *Rec: yes, single-writer claim with Mongo `update_one` on `{id, status: 'proposed'}`.*
+4. **Cycle creation — auto or manual?** Linear auto-creates a rolling schedule. For Mission Control / events-production, cycles are likely manual (each engagement is a one-off). *Rec: manual for v1; auto-create as workspace policy in v1.5.*
+5. **Soul exposure on agents endpoint** — does any existing route already return soul fields? Need to grep. If yes, augment; if no, add the thin endpoint.
+
+---
+
+## Cross-references
+
+- [`2026-05-mission-control.md`](./2026-05-mission-control.md) — the architectural spec this audit operationalizes.
+- [`2026-05-pocket-specialist-and-ripple-mutation.md`](./2026-05-pocket-specialist-and-ripple-mutation.md) — the pocket-specialist subagent pattern from #1069 is the template for the agent task-claim tool surface.
+- `pocketpaw/CLAUDE.md` § ee/cloud Code Rules — the 4-file shape every new entity above conforms to.
+- `paw-enterprise/PR #181` — the mock UI that calls every endpoint listed in this audit (via `$lib/core/mission-control/api`).

--- a/docs/internal/2026-05-mission-control-user-flows.md
+++ b/docs/internal/2026-05-mission-control-user-flows.md
@@ -1,0 +1,307 @@
+# Mission Control — user flows
+
+*Companion to the architecture spec and the backend audit. Concrete end-to-end journeys through Mission Control, written so Rohit (or any new joiner) can ground every UI choice in a real operator's day. Each flow names the primitives touched, the data path, and what success looks like.*
+
+*Persona: **Shawn**, CTO/operator at a 25-person events-production company, $6–10M/year. Uses Mission Control daily. Co-operator: **Jess**, the ops manager — has 7 years of institutional knowledge, less computer-time than Shawn, will adopt or sabotage the tool.*
+
+---
+
+## The seven flows that matter
+
+In rough order of frequency:
+
+1. [Monday-morning sweep](#1-monday-morning-sweep) — most common, daily
+2. [Approving a Nudge mid-day](#2-approving-a-nudge-mid-day) — multiple times daily
+3. [Delegating new work to an agent](#3-delegating-new-work-to-an-agent) — daily to weekly
+4. [Bulk-approving a batch](#4-bulk-approving-a-batch) — weekly
+5. [Multi-coordinator handoff](#5-multi-coordinator-handoff) — weekly
+6. [Investigating a Pawprint](#6-investigating-a-pawprint) — when something complaints
+7. [Cycle + analytics review](#7-cycle--analytics-review) — Friday afternoon, weekly
+
+Three of these (1, 2, 4) carry 80% of the daily-use weight. The others surface when the operator needs them. Build for the 80% first.
+
+---
+
+## 1. Monday-morning sweep
+
+**Who · When.** Shawn, 8:45 AM Monday. Coffee in hand. Wants to know what changed over the weekend, what needs his eyes, anything broken.
+
+**Trigger.** Opens Mission Control via the desktop client (paw-enterprise → `/mission-control`).
+
+**Screen state on arrival.**
+
+- Toolbar: `Mission Control` / search input (empty) / refresh.
+- Tab bar: **Feed** active. Pending badge on Feed shows `4`.
+- Outcomes strip: `47 shipped · 4 pending · 2 reverted · 1 failed` (24h window).
+- WorkFeed sections, expanded by default:
+  - **The Tray (4)** — *needs your eyes*
+  - **Agents in flight (5)** — *autonomous work*
+  - **Delegated (2)** — *with another human (Jess)*
+  - **Pawprints (47)** — collapsed by default, *shipped today*
+  - **Snags (1)** — *needs attention*
+- Right rail: assistant sidebar with suggestion chips.
+- Status bar: live activity ticker `● 10:42 sales-agent · Reading HubSpot deals`.
+
+**What Shawn does.**
+
+1. Glances at Outcomes strip. 47 shipped weekend → fine. 1 failed → flagged but not urgent yet.
+2. Scrolls to **Snags (1)**. Sees `Stripe refund retry — gateway timeout`. Clicks → detail panel slides in.
+3. Reads the timeline. Sees finance-agent tried twice, both 504. The summary explains contract clause 4.2 was honored, refund is valid. Decides: retry manually.
+4. Closes detail (Esc). Opens **The Tray**. Reviews 4 Nudges. Approves the Stripe follow-up and the Greenline vendor confirm (separate clicks, ~10s each). Snoozes the HubSpot deal stage update — not urgent today.
+5. Notices Tray badge drops from 4 → 1. Pending count in status bar updates live.
+6. Glances at **Agents in flight (5)**. sales-agent is drafting Bluefin contract, events-agent is reading venue calendar. All healthy.
+7. Total time: ~3 minutes. Mission Control closes; the desktop client switches to chat.
+
+**Primitives touched.** Instinct (Tray approvals → Pawprints) · Soul (agent context surfaced in detail) · Pockets (sectioned by source pocket) · Fabric (the Bluefin Customer object referenced in the Stripe follow-up).
+
+**Success state.** Every weekend agent action accounted for; everything pending is either approved, rejected, snoozed, or deliberately deferred. Mission Control screen takes 3 minutes, not 30.
+
+**Failure modes to guard against.**
+
+- The Snag should never be buried below collapsed sections. **Snags is expanded by default.**
+- Tray items missing summaries make a single approval take 30s instead of 5s. Mock data already enforces summaries; backend write path must too.
+- If overnight activity is voluminous (>50 items), Pawprints section opens collapsed so the screen isn't overwhelming.
+
+---
+
+## 2. Approving a Nudge mid-day
+
+**Who · When.** Shawn, mid-day. Mission Control is in a background window or pinned tab.
+
+**Trigger.** Tray-bound Nudge fires — sales-agent drafted an email reply to a $40K-deal lead. Notification surfaces via the existing notification surface (`ee/cloud/notifications/`).
+
+**Screen state.**
+
+- Live ticker in the status bar flashes the new event.
+- Tab badge on `Feed` increments from `0` → `1`.
+- New row appears at the top of **The Tray**, with a subtle highlight animation (no row reorder shuffle below it).
+
+**What Shawn does.**
+
+1. Switches windows. Clicks the row.
+2. **Detail panel slides in.** Shows: status pill `awaiting approval`, title, full summary (the email draft + reasoning), meta (assignee = shawn, source = `@sales-agent`, pocket = Sales pipeline, priority = high), full activity timeline (the agent's tool calls leading to this proposal), Instinct callout: *"Routed to you because the proposing agent's policy requires human approval for this kind of action."*
+3. Reads the draft. Edits one sentence inline (future feature — for v0.5, Reject + re-prompt via the assistant sidebar covers it).
+4. Clicks **Approve**. The detail panel closes, the row moves from The Tray to Pawprints, the Tray badge decrements, a confirmation toast surfaces briefly.
+
+**Primitives.** Instinct (propose → approve → Pawprint) · Notifications (mid-day surface) · Soul (sales-agent's context in the timeline).
+
+**Backend round-trips.**
+- `POST /mission-control/items/bulk-approve` with `{ids: [id]}` (single-item via the bulk endpoint — same contract).
+- Server emits `work_item.resolved` SSE → frontend moves row + updates count.
+
+**Success state.** Approval takes <15 seconds from notification to row-moved. No more than one click between "row" and "approve" once intent is formed.
+
+---
+
+## 3. Delegating new work to an agent
+
+**Who · When.** Shawn, Tuesday morning. After his Monday sweep he wants events-agent to handle the May 23 wedding's day-of run-of-show drafting.
+
+**Trigger.** Has the thought "events-agent should draft the run-of-show." Opens Mission Control.
+
+**Screen state.**
+
+- WorkFeed visible. Shawn hits `⌘N` (keyboard hint visible in left rail).
+- Inline create form slides into the feed header.
+
+**What Shawn does.**
+
+1. Types in the title input: `Draft the May 23 wedding run-of-show, format like the Stripe summit one, ping me when done`.
+2. Assignee dropdown: defaults to last-used. Picks `events-agent`.
+3. Hits Enter.
+4. Form collapses. New row appears at the top of **Agents in flight** with status `proposed`. Sub-second.
+5. events-agent's runtime polls its task queue (or receives `work_item.proposed` SSE), claims the task. Status flips to `in_progress`. Status icon shifts from open-circle to dashed-circle in the row.
+6. Activity ticker reflects new work: `● events-agent · Claimed task w_local_…`
+7. Shawn closes Mission Control. Hours later, when events-agent completes the draft, a new Nudge appears in The Tray: `Run-of-show draft ready — review`. Click → detail panel shows the full draft. Approve → moves to Pawprints.
+
+**Primitives.** Tasks entity (create → claim → complete) · Instinct (the optional review step at end) · Soul (events-agent picks up the task via its loop).
+
+**Backend round-trips.**
+- `POST /tasks` from the create form.
+- Server emits `task.proposed` → events-agent runtime receives it.
+- Agent calls `POST /tasks/{id}/claim`. Status updates.
+- Agent works. Tool calls stream as `activity.recorded` events bound to task id.
+- Agent calls `POST /tasks/{id}/complete` with a `next_action: 'request_approval'` flag → server transitions item to `awaiting_approval`, routes to creator (Shawn) as a Nudge.
+
+**Success state.** Shawn types one sentence and hits Enter. Agent picks it up. Hours later he reviews + ships. He never opened the events Pocket directly to wire this up.
+
+**Failure modes.**
+- Agent fails to claim within N minutes → task stays in `proposed`, surfaces in **Snags** with `unclaimed` reason after a configurable timeout.
+- Agent gets stuck mid-task → status moves to `blocked`, surfaces as a Snag with the blocker reason in the summary.
+
+---
+
+## 4. Bulk-approving a batch
+
+**Who · When.** Shawn, Wednesday afternoon. Five vendor confirmations are pending — all events-agent proposed, all low-stakes formulaic emails to known vendors.
+
+**Trigger.** Shawn opens Mission Control. Sees **The Tray (5)** in the badge.
+
+**What Shawn does.**
+
+1. Clicks the **Tray** filter pill in the WorkFeed header. View narrows to just the Tray items.
+2. Hovers the first row — checkbox appears in the leading position.
+3. Clicks the checkbox on the top row. The whole feed shifts into select-mode (all rows show checkboxes).
+4. Shift-clicks the bottom row of the 5 vendor confirms. Range selected; the row count badge appears.
+5. Sticky bulk-action bar slides into view: `5 selected · Approve · Reject · Snooze 24h · (clear)`.
+6. Clicks **Approve**. Bar disappears, rows animate out of The Tray, badge resets to 0.
+7. Pawprints count jumps by 5 (visible in the status bar / Outcomes strip).
+
+**Primitives.** Instinct bulk approve (single audit transaction with shared `bulk_id`) · Notifications fan out per item.
+
+**Backend round-trip.**
+- One `POST /mission-control/items/bulk-approve` with `{ids: [5 ids]}`.
+- Server creates 5 Pawprints (each carrying the shared `bulk_id` so the bulk action is queryable).
+- Single SSE batch emits `work_item.resolved` per item.
+
+**Success state.** Five approvals in ~10 seconds (one shift-click + one button) instead of five sequential row-click + approve cycles. The audit trail captures the bulk operation atomically.
+
+---
+
+## 5. Multi-coordinator handoff
+
+**Who · When.** Friday, mid-afternoon. Shawn is heading out for a venue walkthrough. Notices three Tray items he can't get to. Wants Jess to handle them.
+
+**What Shawn does.**
+
+1. Filter pill: **Tray**. Selects all 3 items via checkboxes.
+2. Bulk action bar: clicks `…` (more) → `Reassign to…` dropdown. Picks `jess`.
+3. Items vanish from Shawn's **Tray** and appear in his **Delegated** section (now showing `5 · with another human`).
+4. Jess opens her Mission Control 30 minutes later. Her notification surface has 3 pending items. Her **Tray** shows them at the top. She handles them.
+5. Each approval Jess makes creates a Pawprint tagged with her actor name. Visible from Shawn's view in **Pawprints** with `@jess · Approved vendor confirm…`.
+
+**Primitives.** Tasks (reassign endpoint) · Instinct (Pawprint with delegated-by reference) · Notifications (Jess gets pinged).
+
+**Success state.** Three reassignments in <30 seconds. The handoff carries context — Jess sees the full agent-side reasoning timeline when she opens each item. She isn't operating blind.
+
+**Failure modes.**
+
+- Jess refuses an item (not her scope) → she rejects with reason → item moves to Snags with `rejected by delegate` status, surfaces back to Shawn as a Snag.
+- Item has Fabric refs Jess doesn't have access to → access-control on Fabric kicks in. The detail panel shows a degraded view (title + summary, no typed-object preview). Defer the policy details to v1.5.
+
+---
+
+## 6. Investigating a Pawprint
+
+**Who · When.** Tuesday. A customer (Bluefin) calls Shawn saying "we got the wrong invoice — your AI sent the May invoice with the wrong amount."
+
+**Trigger.** Customer complaint. Shawn opens Mission Control.
+
+**What Shawn does.**
+
+1. In the toolbar search, types `Bluefin invoice`. Feed filters live to matching items.
+2. Sees ~6 matching items in Pawprints (recent invoice-related actions). Scans by timestamp.
+3. Finds `Email sent → Bluefin (May invoice)`. Clicks → detail panel.
+4. Reads the full timeline: finance-agent ran the invoicing query at 10:42, generated the email, the *Instinct gate auto-approved it* per policy (low-stakes routine email under $1k threshold), sent at 10:43.
+5. The Pawprint detail surfaces the Fabric reference: invoice object id, line items, total. Shawn sees the amount was wrong — agent pulled stale pricing from a cached Fabric snapshot.
+6. Shawn captures the bug → creates a new Task assigned to himself: `Audit finance-agent's pricing source; cached Fabric snapshot stale`.
+7. Sends an apology + correction to Bluefin manually.
+
+**Primitives.** Instinct audit query (existing endpoint) · Fabric provenance · Soul (the agent's reasoning at the time, replayable from the timeline) · Tasks (creating the follow-up).
+
+**Backend round-trips.**
+- `GET /mission-control/items?q=bluefin invoice` → 6 results.
+- `GET /mission-control/items/{id}` → full Pawprint with reasoning trace.
+- `GET /fabric/objects/{invoice_id}` → the Fabric object referenced.
+- `POST /tasks` → the follow-up Task.
+
+**Success state.** Customer complaint → root cause identified in <2 minutes. The full provenance chain is intact: who proposed, who approved (Instinct policy), what data was read, what was sent, when. No archeology across 4 tools.
+
+This flow is the C-suite-buyer-closer demo. Every enterprise buyer evaluating an agentic platform asks "what happens when the agent gets it wrong?" Mission Control's answer is this flow.
+
+---
+
+## 7. Cycle + analytics review
+
+**Who · When.** Friday, 4 PM. Shawn prepping for the Monday operations call.
+
+**What Shawn does.**
+
+**Cycle review.**
+
+1. Clicks **Cycles** tab.
+2. Left list shows 4 cycles. Selects `Crestline · May 23 Wedding` (active).
+3. Detail panel: header with `Current` pill, date range, scope/started/completed metrics, the burnup chart.
+4. Reads the chart: completed line (blue) is slightly below the dashed ideal target. Started line (yellow) is well above completed → some accumulated WIP.
+5. Scrolls to the items list. Filters mentally — sees 2 items overdue (due-date passed, still in-progress). Identifies blockers.
+6. Captures one bullet for Monday call: "Crestline at 63% complete, slightly behind ideal pace, watch the venue-walkthrough Task."
+
+**Analytics review.**
+
+1. Clicks **Analytics** tab.
+2. Reads the 4-stat band: 47 shipped (24h), 96% approval rate, p50 4m12s, p90 38m.
+3. Glances at by-agent split — notices `finance-agent` has higher revert rate (5 of 39 = 13%) than the others.
+4. Captures another bullet: "finance-agent revert rate trending up — investigate next week."
+
+**Primitives.** Cycles entity (daily snapshots feed the burnup) · Instinct outcome telemetry (drives the analytics) · Tasks (item list scoped to cycle).
+
+**Backend round-trips.**
+- `GET /cycles` → list.
+- `GET /cycles/{id}` → cycle + daily series.
+- `GET /cycles/{id}/items` → items in that cycle.
+- `GET /mission-control/outcomes?window=7d` → analytics card data.
+
+**Success state.** Two bullets in 5 minutes from a single screen, ready for Monday's standup. No spreadsheet export, no manual filtering across pockets.
+
+---
+
+## Cross-cutting interactions
+
+These show up across multiple flows; documenting once to avoid repetition.
+
+### The assistant sidebar (right rail)
+
+Always present. Three behaviors:
+- **Idle:** shows the 4 suggestion chips (`What needs my eyes?`, `Filter the Tray`, `Create a task`, `Summarize today`).
+- **Active conversation:** chat-style messages between the operator and the assistant. The assistant's responses can include shortcuts that, when clicked, set filters or open detail panels in the main canvas.
+- **Mode shift in v1:** when an item is selected, the assistant context-switches to "talk about this item" mode. Suggestions become `Explain the agent's reasoning`, `Suggest an alternative`, `Find similar past Pawprints`.
+
+### The keyboard shortcuts
+
+Surfaced in the left rail. Most-used to least:
+
+| Shortcut | Action |
+|---|---|
+| `⌘K` | Focus the search input |
+| `⌘N` | New work item (create form) |
+| `shift-click` | Range-select rows |
+| `⌘A` | Select all visible rows (future) |
+| `esc` | Close detail · clear filters · cancel create — in that order |
+| `1` – `5` | Jump to filter pill (future) |
+| `j` / `k` | Move row selection (future, Linear-style) |
+
+For v0.5, ship the first four. The others are v1.
+
+### Notifications fan-out
+
+Mission Control creates entries in the existing notification surface for any item routed to the current user. Three policies:
+
+| Item state | Notification |
+|---|---|
+| `awaiting_approval` routed to me | Yes (default) |
+| Task `proposed` to me by another human | Yes |
+| Task `proposed` to an agent (any) | No — agent's loop picks it up |
+| Status `blocked` on an item I created | Yes |
+| Status `done` on an item I delegated | Yes |
+| Status `done` on an item I approved | No — noise |
+
+Per-workspace policy can override these defaults (v1).
+
+---
+
+## What we deliberately are NOT building (yet)
+
+- **Item comments / threaded discussion** — the comment input in the detail panel posts to the timeline today; richer commenting (mentions, replies, etc.) is v1.5.
+- **Custom views / saved filters** — Linear has them; Mission Control v0/v1 has the standard 5 sections only. Save-view is v1.5.
+- **Mobile responsive Mission Control** — desktop only. Channel adapters (Slack/Telegram inline approval) cover the mobile case better than a responsive screen.
+- **Inline editing of agent-proposed content** — Shawn rejecting + re-prompting via the assistant is the v0.5 alternative.
+- **Right-panel detail navigation** — the detail panel is one item at a time. Linear lets you navigate next/prev within a filtered list; we add this in v1.
+
+---
+
+## Cross-references
+
+- [`2026-05-mission-control.md`](./2026-05-mission-control.md) — architectural spec
+- [`2026-05-mission-control-backend-audit.md`](./2026-05-mission-control-backend-audit.md) — what exists, what needs building (the primitive-by-primitive audit)
+- [`2026-05-pocket-specialist-and-ripple-mutation.md`](./2026-05-pocket-specialist-and-ripple-mutation.md) — the pocket-specialist subagent pattern that the agent task-claim flow (Flow 3) builds on
+- `paw-enterprise/PR #181` — the mock UI implementing every flow above

--- a/docs/internal/2026-05-mission-control.md
+++ b/docs/internal/2026-05-mission-control.md
@@ -1,0 +1,201 @@
+# Mission Control — operator surface spec
+
+*Status: design + mock UI first; backend wiring follows. Vocabulary aligns with the captain's prior Paw OS Enterprise Strategy (`paw-enterprise/docs/enterprise/PAW-OS-STRATEGY.md`): **The Tray** (approvals), **Pawprints** (audit), **Nudges** (proposed actions), **Instinct** (decision pipeline).*
+
+*Owners: Prakash (direction), Rohit (backend integration after UI lands). Reviewers: anyone touching `ee/cloud/instinct/`, `ee/cloud/pockets/`, or paw-enterprise's `os/` components.*
+
+---
+
+## Why this exists
+
+PocketPaw today has the right primitives for human-agent collaboration — Pockets, Instinct, Nudges, Pawprints, agent runtime — but **no single screen that lets a human see all of it at once.** Each pocket is a scoped decision context. Mission Control is the *opposite-shape* surface: a cross-cutting operator view across every pocket, every agent, every pending Nudge, every recent Pawprint.
+
+For Nerve Systems clients (Shawn, SNCTM, NexWrk hospitality engagements), this is the moneyshot screen. The pitch is: *"Log in once a day. This screen shows what your agents did, what needs your eyes, what shipped. Everything else is delegated."* That's not "look at how this Pocket works" — it's "look at this one screen that shows your whole company."
+
+## Why standalone, not a Pocket
+
+A Pocket is a *scoped workspace*: one job, one team's data, one Instinct policy. Mission Control is a *cross-pocket aggregate view* — same shape relationship as filesystem-vs-file or task-manager-vs-task. Trying to build it as a Pocket means putting the manager-of-X inside one X. Wrong layer.
+
+Two separate constraints reinforce this:
+
+1. **Mission Control needs latency + interactivity** (sub-second updates on Nudges, click-expand-approve, real-time activity stream) that the current Pocket primitive can't deliver until granular UI-tree mutation ops land (see [`2026-05-ripple-mutation-handover.md`](./2026-05-ripple-mutation-handover.md) PR 1).
+2. **The shell is operator-meta**, not domain-specific. RBAC, workspace switching, global search, keyboard shortcuts, cross-pocket navigation are best as plain Svelte code. Generating them as a spec gives no benefit; the per-client customization happens at the **pane** level.
+
+The right shape: **a standalone shell route in paw-enterprise** (`/mission-control`) that hosts panes. Panes are bespoke Svelte today, Ripple-rendered later as PR 1's granular ops land. Per-client customization happens by swapping pane specs, not rewriting the shell.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  workspace ▼   global search                🔔 4 pending   user ▼   │   ← shell header
+├──────────────┬──────────────────────────────────────────┬───────────┤
+│              │  ┌─ The Tray (Nudges queue) ──────────┐  │           │
+│  Pockets     │  │ • email to Stripe (sales pkt)      │  │           │
+│   • sales    │  │ • vendor confirm (events pkt)      │  │  context  │
+│   • support  │  │ • schedule shift (ops pkt)         │  │  panel    │
+│   • events ●│  └────────────────────────────────────┘  │  (full    │
+│              │                                          │   trans-  │
+│  Agents (3)  │  ┌─ Agent activity feed ─────────────┐   │   cript,  │
+│   • notes    │  │ 10:42 sales-agent reading hubspot  │  │   related │
+│   • triage●  │  │ 10:41 ops-agent posting to slack   │  │   pocket, │
+│   • coord    │  │ 10:40 events-agent waiting (you)   │  │   related │
+│              │  └────────────────────────────────────┘  │   Nudges) │
+│  Tasks (you) │                                          │           │
+│   • approve  │  ┌─ Outcomes (24h) ───────────────────┐  │           │
+│   • review   │  │   shipped 47   reverted 2  pending │  │           │
+│              │  └────────────────────────────────────┘  │           │
+│              │                                          │           │
+│              │  ┌─ Pawprints (recent audit) ─────────┐  │           │
+│              │  │ • 10:42 ops-agent: schedule update │  │           │
+│              │  │ • 10:41 sales-agent: email sent    │  │           │
+│              │  └────────────────────────────────────┘  │           │
+├──────────────┴──────────────────────────────────────────┴───────────┤
+│  3 agents · 4 Nudges pending · system: healthy · 12 actions / hr     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Shell** owns: layout, workspace context, RBAC, search, navigation, real-time fan-out (SSE), keyboard shortcuts, notification badges.
+
+**Panes** (independent components, each backed by one API call + optional SSE subscription):
+
+| Pane | Source endpoint | Status |
+|---|---|---|
+| The Tray (Nudges queue) | `GET /api/v1/instinct/nudges?status=pending` | ✅ exists (ApprovalsPanel.svelte today) |
+| Agent activity feed | `GET /api/v1/agents/activity` + SSE | 🟡 partial (activity route exists, no unified endpoint) |
+| Outcomes (24h) | `GET /api/v1/instinct/outcomes?window=24h` | ⛔ missing — needs aggregation endpoint |
+| Pawprints (recent) | `GET /api/v1/audit?limit=20` | ✅ exists (AuditLogPanel.svelte today) |
+| Tasks-for-humans | `GET /api/v1/tasks?assignee=me&status=open` | ⛔ missing — needs new entity |
+| Left rail: pockets | `GET /api/v1/pockets` | ✅ exists |
+| Left rail: agents | `GET /api/v1/agents?status=active` | 🟡 partial (no status filter) |
+| Context panel | `GET /api/v1/instinct/nudges/{id}` | 🟡 partial (need full envelope) |
+
+**Real-time updates** flow through the existing `RealtimeClient` at `paw-enterprise/src/lib/core/realtime/client.ts`. Event types to subscribe in Mission Control:
+
+- `nudge.proposed` → prepend to The Tray
+- `nudge.resolved` → remove from The Tray, push to Pawprints
+- `agent.activity` → prepend to activity feed
+- `pawprint.recorded` → prepend to Pawprints
+- `outcome.metered` → refresh outcomes pane
+
+## ee/cloud conformance
+
+Per `pocketpaw/CLAUDE.md` § ee/cloud Code Rules, every new/modified endpoint follows the 4-file shape. Two new entities ship as Mission Control evolves:
+
+### 1. Aggregation endpoints on existing `instinct/`
+
+Existing `ee/cloud/instinct/` likely gains:
+
+```
+ee/cloud/instinct/
+  domain.py         # Nudge value object (existing)
+  dto.py            # + ListNudgesRequest, NudgeResponse, OutcomeSummaryResponse
+  service.py        # + agent_list_nudges(ctx, body), agent_outcomes_summary(ctx, body)
+  router.py         # + GET /nudges, GET /outcomes, POST /nudges/{id}/approve, POST /nudges/{id}/reject
+```
+
+All reads filter `workspace=ctx.workspace_id` (Rule 7). Approval/reject writes emit `nudge.resolved` events (Rule 9). No `HTTPException` in services or routers (Rule 10).
+
+### 2. New `tasks/` entity for tasks-for-humans
+
+Tasks are work-items explicitly assigned to a human (could be queued by an agent, by another human, or by Instinct's reject path). Distinct from Nudges (which are agent *proposed actions* awaiting approval).
+
+```
+ee/cloud/tasks/
+  domain.py         # Task(id, workspace_id, assignee_id, status, source_pocket_id?, ...)
+  dto.py            # CreateTaskRequest, ListTasksRequest, UpdateTaskRequest, TaskResponse
+  service.py        # agent_create_task, agent_list_tasks, agent_update_task, agent_close_task
+  router.py         # POST/GET/PATCH/DELETE /tasks
+```
+
+Per the touch-time rule, register `TaskDocument` in the `import-linter` contract; add `tasks/router.py`, `tasks/dto.py`, `tasks/domain.py` to the source-modules list.
+
+### 3. Aggregated activity feed (cross-cutting read)
+
+Activity feed is read-only across multiple sources (agent sessions, tool calls, Instinct events). Options:
+
+- **A:** new lightweight `activity/` read-only router that subscribes to in-process bus events and materializes a small recent-N buffer per workspace. No persistence beyond the buffer.
+- **B:** extend existing `chat/` or `sessions/` with `GET /activity?workspace=ctx` that joins across.
+
+Recommend **A** — purpose-built, doesn't entangle the activity surface with chat/session lifecycle. Buffer size 200 events per workspace, TTL 1 hour, no DB writes. SSE channel `activity.recorded` fans out new events as they arrive.
+
+### 4. Eventual Mission Control config (per-workspace pane layout)
+
+Once panes become Ripple-rendered (PR 1 land), workspace admins can pick which panes show and in what order. Persist as `workspace.mission_control_layout: list[PaneSpec]`. Defer until v1.5.
+
+## Mock-first development
+
+The captain explicitly asked: *"first build the UI with mock easily replaceable with backend calls."* Right call — the shell shape needs validation before the backend bakes in.
+
+**Mock layer design** (paw-enterprise side):
+
+```ts
+// src/lib/core/mission-control/api.ts
+// Typed API client. Mock impl today; flip the imports to real `http()`
+// when backend endpoints land.
+
+import { mockApi } from './api.mock';
+import { realApi } from './api.real';
+
+const USE_MOCK = import.meta.env.VITE_MISSION_CONTROL_MOCK !== 'false';
+
+export const missionControlApi = USE_MOCK ? mockApi : realApi;
+```
+
+Both impls share the same TypeScript interface, defined once:
+
+```ts
+export interface MissionControlApi {
+  listNudges(opts?: { status?: NudgeStatus }): Promise<Nudge[]>;
+  approveNudge(id: string, note?: string): Promise<void>;
+  rejectNudge(id: string, reason: string): Promise<void>;
+  listAgentActivity(opts?: { limit?: number }): Promise<ActivityEvent[]>;
+  listPawprints(opts?: { limit?: number }): Promise<PawprintEntry[]>;
+  outcomesSummary(window: '1h' | '24h' | '7d'): Promise<OutcomeSummary>;
+  listTasks(opts?: { assignee?: string; status?: TaskStatus }): Promise<Task[]>;
+}
+```
+
+The mock impl returns realistic fake data (with timestamps, agent names matching configured agents, plausible Nudge descriptions). It also emits fake `RealtimeClient` events on a timer so the live-update path can be tested before real SSE wires up. **Flipping from mock to real is one env var.**
+
+## Phasing
+
+| Phase | Window | What ships | Gate |
+|---|---|---|---|
+| **v0 — mock UI** | now → 1 week | `/mission-control` route in paw-enterprise. Shell + The Tray + Pawprints + outcomes + activity panes wired to mock API. Existing `ApprovalsPanel.svelte` and `AuditLogPanel.svelte` reused in the new shell. | Captain demo's the screen, signs off on layout. |
+| **v0.5 — real wiring for existing endpoints** | 1 → 3 weeks | Flip `VITE_MISSION_CONTROL_MOCK=false`. The Tray + Pockets + Pawprints panes hit real `/api/v1/instinct/*` and `/api/v1/audit/*` endpoints (these exist today). Outcomes + tasks panes stay mocked. | First real Nudge approved end-to-end through Mission Control on a dev workspace. |
+| **v1 — new backend surfaces** | 3 → 8 weeks | Outcomes aggregation endpoint, activity feed buffer + SSE, tasks entity. ee/cloud 4-file shape, lint contract, tests. All panes go live against real data. | First Nerve Systems client demoed against Mission Control. |
+| **v1.5 — Ripple-rendered panes** | After PR 1 (granular UI-tree mutation ops) lands | Panes migrate from bespoke Svelte to Ripple specs. Per-workspace layout configurability. Per-client pane variants for Nerve Systems engagements. | Shawn's Mission Control has different default panes than another client's, served from the same shell. |
+
+**v0 unblocks demos this week.** v1 unblocks first paying Nerve Systems engagement at full capability. v1.5 unblocks productization.
+
+## Out of scope (this doc)
+
+These come after v1 ships:
+
+- **Multi-window Mission Control** (operator monitors multiple workspaces side-by-side) — Pro/Enterprise tier feature.
+- **Operator console for Nerve Systems team** (cross-client view across all our deployments). Separate surface, same primitives. Wait until 3+ live clients.
+- **Mission Control as a Pocket type** for workspace-scoped variants — defer until Ripple-rendered panes prove out.
+- **Mobile responsive Mission Control** — desktop-only for v0/v1. Mobile gets channel-adapter surface (Slack/Telegram inline approval), not a full Mission Control.
+- **Webhook / API surface for external mission-control integrations** — defer until customer pull.
+
+## Open questions
+
+These need a decision before v0.5 work starts. Recommend a 20-minute sync.
+
+1. **Endpoint naming.** Is the surface `/api/v1/instinct/nudges` (vocabulary-aligned) or `/api/v1/instinct/proposals` (more generic)? Recommend **nudges** — matches the captain's prior strategy doc, distinctive, won't collide with anything.
+2. **Activity feed persistence.** In-memory buffer only (cheap, lossy on restart) or persist to a capped collection (durable, more infra)? Recommend in-memory buffer for v1, persist via Pawprints (which we already write) — operator can scroll back through Pawprints if they need older activity.
+3. **Tasks entity scope.** Should a Task be a first-class entity, or just a Nudge-with-status="awaiting-human" + assignee? Recommend **first-class entity** — Tasks have different lifecycle (long-running, status updates, comments) than Nudges (one-shot decision).
+4. **Mock layer location.** `src/lib/core/mission-control/api.mock.ts` (lives with the real impl) or `src/lib/mocks/`? Recommend **alongside real impl** — keeps the interface contract co-located.
+
+---
+
+## Cross-references
+
+- [Vision doc — Pocket specialist + Ripple mutation](./2026-05-pocket-specialist-and-ripple-mutation.md) — the architectural foundation v1.5 builds on.
+- [Implementation handover — Ripple mutation](./2026-05-ripple-mutation-handover.md) — PR 1 (granular UI ops) is the prerequisite for v1.5.
+- `paw-enterprise/docs/enterprise/PAW-OS-STRATEGY.md` — the captain's prior naming map (Tray, Pawprints, Nudges, Instinct).
+- `docs/roadmap/future-upgrades/engineering-patterns/adoption-plan.md` — ee/cloud 4-file shape and import-linter contract this work conforms to.
+- `docs/roadmap/future-upgrades/engineering-patterns/paw-enterprise.md` — frontend API chokepoint at `src/lib/core/shared/http.ts`, ESLint rule mock layer must respect.
+- `paw-enterprise/src/lib/components/os/ApprovalsPanel.svelte` — existing component to reuse as The Tray pane.
+- `paw-enterprise/src/lib/components/os/AuditLogPanel.svelte` — existing component to reuse as Pawprints pane.
+- `paw-enterprise/src/lib/core/realtime/client.ts` — SSE channel the panes subscribe to for live updates.


### PR DESCRIPTION
## What this is

Design + integration spec for **Mission Control** — the operator surface for human-agent collaboration. Cross-cutting screen that hosts The Tray (Nudges queue), Pawprints (audit), Agent Activity, Outcomes, and Tasks-for-humans. Aligned with the captain's prior Paw OS Enterprise Strategy vocabulary.

Companion UI PR (mock-backed v0, ready to demo): [qbtrix/paw-enterprise#181](https://github.com/qbtrix/paw-enterprise/pull/181).

## Key design calls

1. **Not a Pocket.** Mission Control is operator-meta — cross-pocket aggregate view. Same shape relationship as filesystem-vs-file. Standalone shell route in paw-enterprise, panes inside.
2. **Mock-first.** Ship v0 against a mock API that mirrors the future backend interface. Flip `VITE_MISSION_CONTROL_MOCK=false` to swap to real impl. Zero component changes between mock and real.
3. **Reuses existing surfaces where possible.** The Tray maps to existing `ApprovalsPanel` / runtime `/approvals` endpoints. Pawprints maps to existing `AuditLogPanel` / runtime `/audit` endpoints. Outcomes + Activity + Tasks need new aggregation endpoints — spec defines the 4-file shape conformance.
4. **Naming aligns with prior strategy doc.** Tray, Pawprints, Nudges (terms from `paw-enterprise/docs/enterprise/PAW-OS-STRATEGY.md`).

## Phasing

| Phase | Window | What ships |
|---|---|---|
| v0 — mock UI | now (already PR'd to paw-enterprise) | Shell + 5 panes against mock |
| v0.5 — real wiring (existing endpoints) | 1–3 weeks | The Tray + Pawprints hit real `/api/v1/runtime/*` |
| v1 — new backend surfaces | 3–8 weeks | Outcomes aggregation, activity buffer + SSE, new `tasks/` entity (4-file shape) |
| v1.5 — Ripple-rendered panes | after PR 1 of Ripple mutation handover | Per-workspace pane customization |

## Open questions before v0.5 starts

1. Endpoint naming: `/api/v1/instinct/nudges` vs `/api/v1/instinct/proposals` (recommend nudges).
2. Activity feed persistence: in-memory buffer or capped collection (recommend in-memory; long history via Pawprints).
3. Tasks: first-class entity or Nudge variant (recommend first-class — different lifecycle).
4. Mock layer location: alongside real impl or in `mocks/` (recommend alongside).

## Test plan

- [x] Doc renders cleanly on GitHub (tables, fenced blocks, ASCII layout diagram).
- [x] Cross-refs to existing files / PRs / engineering charters all verified.
- [x] Companion mock-UI PR opens and renders without errors.
- [ ] Captain reviews scope + open questions. Edit liberally.