### PR TITLE
feat(tasks): unified work-item entity + agent claim tool

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -1,5 +1,9 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Updated: 2026-05-13 — Mission Control PR 2 of 3. Added the Tasks
+    entity (unified work-item primitive: Nudges + agent tasks +
+    projections) and its in-process listener that fans ``task.proposed``
+    out to human assignees via the existing notifications surface.
 Updated: 2026-04-30 — Stage 1.B of "Files as Knowledge". Wires
     ``register_upload_listeners`` into ``mount_cloud`` so the FileReady
     bus subscriber drives KB indexing for every workspace upload.
@@ -10,7 +14,7 @@ Updated: 2026-04-19 (Cluster B) — Added pocket journal SSE stream router to
     mount_cloud() — feeds the RippleGraphWidget with a live, pocket-scoped
     slice of the org journal.
 
-Domains: auth, workspace, chat, pockets, sessions, agents, kb, knowledge.
+Domains: auth, workspace, chat, pockets, sessions, agents, kb, knowledge, tasks.
 Each has router.py (thin), service.py (logic), schemas.py (validation).
 """
 
@@ -117,6 +121,7 @@ def mount_cloud(app: FastAPI) -> None:
 
     from ee.cloud.kb.router import router as kb_router
     from ee.cloud.notifications.router import router as notifications_router
+    from ee.cloud.tasks.router import router as tasks_router
     from ee.cloud.uploads.router import router as uploads_router
     from ee.paw_print.router import router as paw_print_router
 
@@ -124,6 +129,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(knowledge_router, prefix="/api/v1")
     app.include_router(uploads_router, prefix="/api/v1")
     app.include_router(notifications_router, prefix="/api/v1")
+    app.include_router(tasks_router, prefix="/api/v1")
     app.include_router(files_router, prefix="/api/v1")
 
     # Files Tab v2 — /api/v1/files/tree + /api/v1/files/browse. Mounted
@@ -340,6 +346,14 @@ def mount_cloud(app: FastAPI) -> None:
     from ee.cloud.uploads.listeners import register_upload_listeners
 
     register_upload_listeners()
+
+    # Tasks → notifications fan-out. When a Task is proposed to a human
+    # assignee, drop an in-app notification so they see it even without
+    # Mission Control open. Agent assignees skip this path — they pick
+    # up work via the claim flow.
+    from ee.cloud.tasks.listeners import register_task_listeners
+
+    register_task_listeners()
 
     # Start/stop agent pool with app lifecycle.
     #

--- a/ee/cloud/_core/realtime/events.py
+++ b/ee/cloud/_core/realtime/events.py
@@ -299,6 +299,32 @@ class PocketDeleted(Event):
     EVENT_TYPE: ClassVar[str] = "pocket.deleted"
 
 
+# Tasks (Mission Control work-item primitive)
+@dataclass
+class TaskProposed(Event):
+    EVENT_TYPE: ClassVar[str] = "task.proposed"
+
+
+@dataclass
+class TaskUpdated(Event):
+    EVENT_TYPE: ClassVar[str] = "task.updated"
+
+
+@dataclass
+class TaskClaimed(Event):
+    EVENT_TYPE: ClassVar[str] = "task.claimed"
+
+
+@dataclass
+class TaskResolved(Event):
+    EVENT_TYPE: ClassVar[str] = "task.resolved"
+
+
+@dataclass
+class TaskBlocked(Event):
+    EVENT_TYPE: ClassVar[str] = "task.blocked"
+
+
 # Notifications
 @dataclass
 class NotificationNew(Event):

--- a/ee/cloud/models/__init__.py
+++ b/ee/cloud/models/__init__.py
@@ -13,6 +13,7 @@ from ee.cloud.models.notification import Notification, NotificationSource
 from ee.cloud.models.pocket import Pocket, Widget, WidgetPosition
 from ee.cloud.models.read_state import ReadState
 from ee.cloud.models.session import Session
+from ee.cloud.models.task import Task, TaskAssignee, TaskSource
 from ee.cloud.models.user import OAuthAccount, User, WorkspaceMembership
 from ee.cloud.models.workspace import Workspace, WorkspaceSettings
 
@@ -54,6 +55,9 @@ __all__ = [
     "Reaction",
     "ReadState",
     "Session",
+    "Task",
+    "TaskAssignee",
+    "TaskSource",
     "User",
     "Widget",
     "WidgetPosition",
@@ -83,6 +87,7 @@ def get_all_documents():
         Group,
         Message,
         ReadState,
+        Task,
     ]
 
 

--- a/ee/cloud/models/task.py
+++ b/ee/cloud/models/task.py
@@ -1,0 +1,106 @@
+# task.py — Beanie document for the Mission Control Tasks entity.
+# Created: 2026-05-13 — PR 2 of 3 for Mission Control's backend. Tasks
+#   are the unified work-item primitive that subsumes Nudges + agent
+#   tasks + Pawprint projections with assignee polymorphism (human or
+#   agent). Tied to a Pocket optionally, a Cycle optionally, and a
+#   workspace always. Indexes back the two hot query paths:
+#     - "list my work" by (workspace_id, assignee_id, status)
+#     - "items in this cycle" by (workspace_id, cycle_id)
+"""Task document — Mission Control work-item primitive.
+
+Embedded sub-documents:
+
+  - :class:`TaskAssignee` — polymorphic kind (``human`` | ``agent``) +
+    id + display name. Kept in one document so list queries don't need
+    a join to render the assignee chip in the feed.
+  - :class:`TaskSource` — a discriminated union pointer to the upstream
+    that produced this task: ``user_request`` (manual), ``nudge``
+    (Instinct proposal), ``agent`` (sub-task spawned by an agent),
+    ``automation`` (rule-driven), etc.
+
+Only ``ee.cloud.tasks.service`` may import this module; the import-linter
+contract enforces the rule.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from beanie import Indexed
+from pydantic import BaseModel, Field
+
+from ee.cloud.models.base import TimestampedDocument
+
+
+class TaskAssignee(BaseModel):
+    """Polymorphic assignee. ``kind`` decides how the runtime treats the
+    work — human assignees notify, agent assignees enqueue."""
+
+    kind: str = Field(pattern="^(human|agent)$")
+    id: str
+    name: str = ""
+
+
+class TaskSource(BaseModel):
+    """Where this task came from. ``type`` is the discriminator; ``ref_id``
+    points at the source entity when one exists (e.g. the Nudge id when
+    ``type == 'nudge'``)."""
+
+    type: str = "user_request"
+    ref_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class Task(TimestampedDocument):
+    """A unit of work assignable to a human or an agent.
+
+    Status machine:
+        proposed → in_progress → done | reverted | failed
+                 → awaiting_approval → done | reverted
+                 → blocked → in_progress | failed
+
+    A Nudge is just a Task with ``status == 'awaiting_approval'``.
+    Tasks created for an agent default to ``proposed`` so the agent
+    runtime can pick them up via the claim path; tasks for a human
+    default to ``in_progress`` (they're already assigned).
+    """
+
+    workspace_id: Indexed(str)  # type: ignore[valid-type]
+    pocket_id: str | None = None
+    cycle_id: str | None = None
+    creator_id: str
+
+    title: str
+    summary: str = ""
+
+    assignee: TaskAssignee
+    # Denormalised ``assignee.id`` / ``assignee.kind`` for index hits
+    # without a sub-field lookup. The service writes both fields whenever
+    # ``assignee`` changes; we keep these explicit so the
+    # ``(workspace_id, assignee_id, status)`` compound index is usable.
+    assignee_id: Indexed(str)  # type: ignore[valid-type]
+    assignee_kind: str = Field(pattern="^(human|agent)$")
+
+    status: str = Field(
+        default="proposed",
+        pattern="^(proposed|in_progress|awaiting_approval|done|reverted|failed|blocked)$",
+    )
+    priority: str = Field(default="normal", pattern="^(low|normal|high|urgent)$")
+    kind: str = Field(default="task", pattern="^(task|nudge|projection|automation)$")
+
+    source: TaskSource = Field(default_factory=TaskSource)
+
+    due_at: datetime | None = None
+    blocked_reason: str | None = None
+
+    class Settings:
+        name = "tasks"
+        indexes = [
+            [("workspace_id", 1), ("assignee_id", 1), ("status", 1)],
+            [("workspace_id", 1), ("cycle_id", 1)],
+            [("workspace_id", 1), ("status", 1), ("createdAt", -1)],
+        ]
+
+
+__all__ = ["Task", "TaskAssignee", "TaskSource"]

--- a/ee/cloud/tasks/__init__.py
+++ b/ee/cloud/tasks/__init__.py
@@ -1,0 +1,5 @@
+# __init__.py — Tasks entity package marker.
+# Created: 2026-05-13 — PR 2 of 3 for Mission Control's backend.
+#   Re-exports the router so ``ee.cloud.__init__:mount_cloud`` can mount
+#   it the same way every other 4-file-shape entity is wired.
+from ee.cloud.tasks.router import router  # noqa: F401

--- a/ee/cloud/tasks/domain.py
+++ b/ee/cloud/tasks/domain.py
@@ -1,0 +1,108 @@
+# domain.py — frozen value objects for the Tasks entity.
+# Created: 2026-05-13 — PR 2 of 3 for Mission Control's backend. Tasks
+#   are the unified work-item primitive used by Mission Control's
+#   feed. Domain objects are plain Python so services can be tested
+#   without Beanie; the service layer converts to/from the Mongo doc.
+"""Domain value objects for the Tasks entity.
+
+Pure-Python frozen dataclasses. ``tasks/service.py`` owns the
+Beanie ↔ domain conversion. Tenancy fields are required at construction
+time — domain objects without ``workspace_id`` are a type error, which
+catches the simplest cross-tenant leak.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal
+
+TaskStatus = Literal[
+    "proposed",
+    "in_progress",
+    "awaiting_approval",
+    "done",
+    "reverted",
+    "failed",
+    "blocked",
+]
+"""The Task status machine.
+
+``proposed``       — created, not yet picked up. Default for agent assignees.
+``in_progress``    — work is happening. Default for human assignees on create.
+``awaiting_approval`` — Nudge-flavoured: work is done, creator must approve.
+``done``           — terminal: shipped and (optionally) approved.
+``reverted``       — terminal: approver rejected the work product.
+``failed``         — terminal: agent gave up; surfaces in the operator's Snags.
+``blocked``        — non-terminal pause with a reason; recoverable.
+"""
+
+TaskPriority = Literal["low", "normal", "high", "urgent"]
+TaskKind = Literal["task", "nudge", "projection", "automation"]
+AssigneeKind = Literal["human", "agent"]
+
+
+@dataclass(frozen=True)
+class TaskAssignee:
+    """Polymorphic assignee. ``kind`` decides routing behaviour.
+
+    Storing ``name`` denormalised next to ``id`` lets the feed render
+    the assignee chip without a join. The service refreshes ``name`` on
+    every reassignment.
+    """
+
+    kind: AssigneeKind
+    id: str
+    name: str = ""
+
+
+@dataclass(frozen=True)
+class TaskSource:
+    """Discriminated union pointer to the upstream that produced this
+    task. ``type`` is the discriminator (``user_request``, ``nudge``,
+    ``agent``, ``automation`` — extensible). ``ref_id`` points at the
+    source entity when one exists."""
+
+    type: str = "user_request"
+    ref_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Task:
+    """A unit of work assignable to a human or an agent.
+
+    Required tenancy fields (``workspace_id``, ``creator_id``,
+    ``assignee``) have no defaults — constructing a domain ``Task``
+    without them is a TypeError. ``pocket_id`` and ``cycle_id`` are
+    legitimately optional (workspace-scoped tasks not tied to a single
+    pocket or cycle).
+    """
+
+    id: str
+    workspace_id: str
+    creator_id: str
+    assignee: TaskAssignee
+    status: TaskStatus
+    priority: TaskPriority
+    kind: TaskKind
+    source: TaskSource
+    title: str
+    summary: str
+    pocket_id: str | None = None
+    cycle_id: str | None = None
+    due_at: datetime | None = None
+    blocked_reason: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+__all__ = [
+    "AssigneeKind",
+    "Task",
+    "TaskAssignee",
+    "TaskKind",
+    "TaskPriority",
+    "TaskSource",
+    "TaskStatus",
+]

--- a/ee/cloud/tasks/dto.py
+++ b/ee/cloud/tasks/dto.py
@@ -1,0 +1,216 @@
+# dto.py — request/response Pydantic schemas for the Tasks entity.
+# Created: 2026-05-13 — PR 2 of 3 for Mission Control's backend.
+#   Distinct *Request and *Response models; never reuse one model for
+#   both input and output (per ee/cloud Code Rules §4). Domain → wire
+#   mapper lives at the bottom alongside its tests' surface.
+"""Tasks entity — request/response DTOs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from ee.cloud._core.time import iso_utc
+from ee.cloud.tasks.domain import Task
+
+# ---------------------------------------------------------------------------
+# Embedded sub-DTOs
+# ---------------------------------------------------------------------------
+
+
+class AssigneeDTO(BaseModel):
+    """Wire shape for an assignee."""
+
+    kind: Literal["human", "agent"]
+    id: str
+    name: str = ""
+
+
+class SourceDTO(BaseModel):
+    """Wire shape for the task's upstream source."""
+
+    type: str = "user_request"
+    ref_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class CreateTaskRequest(BaseModel):
+    """Body for ``POST /tasks``.
+
+    ``status`` is intentionally not on the request. The service derives
+    it from ``assignee.kind`` — agent → ``proposed`` (claim flow);
+    human → ``in_progress`` (already in someone's hands).
+    """
+
+    title: str = Field(min_length=1, max_length=200)
+    summary: str = ""
+    assignee: AssigneeDTO
+    pocket_id: str | None = None
+    cycle_id: str | None = None
+    priority: Literal["low", "normal", "high", "urgent"] = "normal"
+    kind: Literal["task", "nudge", "projection", "automation"] = "task"
+    source: SourceDTO = Field(default_factory=SourceDTO)
+    due_at: datetime | None = None
+
+
+class UpdateTaskRequest(BaseModel):
+    """Body for ``PATCH /tasks/{id}``. Every field is optional; only
+    the keys the caller provides are touched."""
+
+    title: str | None = None
+    summary: str | None = None
+    priority: Literal["low", "normal", "high", "urgent"] | None = None
+    pocket_id: str | None = None
+    cycle_id: str | None = None
+    due_at: datetime | None = None
+
+
+class ClaimTaskRequest(BaseModel):
+    """Body for ``POST /tasks/{id}/claim``. ``agent_id`` is the agent
+    runtime's id of record — the claim only matches when this id equals
+    the task's ``assignee.id`` and the task is still ``proposed``."""
+
+    agent_id: str = Field(min_length=1)
+
+
+class CompleteTaskRequest(BaseModel):
+    """Body for ``POST /tasks/{id}/complete``.
+
+    ``next_action`` picks the terminal status:
+      - ``archive`` → status flips to ``done`` immediately.
+      - ``request_approval`` → status flips to ``awaiting_approval`` so
+        the Nudge surfaces in the creator's Tray for sign-off.
+    """
+
+    next_action: Literal["archive", "request_approval"] = "archive"
+    result_summary: str = ""
+
+
+class BlockTaskRequest(BaseModel):
+    """Body for ``POST /tasks/{id}/block``."""
+
+    reason: str = Field(min_length=1, max_length=500)
+
+
+class ReassignTaskRequest(BaseModel):
+    """Body for ``POST /tasks/{id}/reassign``. The new assignee carries
+    its own kind so a human-to-agent or agent-to-human handoff updates
+    routing in one call."""
+
+    assignee_kind: Literal["human", "agent"]
+    assignee_id: str = Field(min_length=1)
+    assignee_name: str = ""
+
+
+class BulkReassignRequest(BaseModel):
+    """Body for ``POST /tasks/bulk-reassign`` (PR 1 façade may consume
+    this directly; included here so the contract lives next to the
+    other Tasks DTOs)."""
+
+    task_ids: list[str] = Field(min_length=1)
+    assignee_kind: Literal["human", "agent"]
+    assignee_id: str = Field(min_length=1)
+    assignee_name: str = ""
+
+
+class ListTasksRequest(BaseModel):
+    """Filters for ``GET /tasks``. All optional; the service applies
+    them as a conjunction with the implicit ``workspace_id`` tenant
+    filter."""
+
+    assignee_id: str | None = None
+    assignee_kind: Literal["human", "agent"] | None = None
+    status: str | None = None
+    cycle_id: str | None = None
+    pocket_id: str | None = None
+    creator_id: str | None = None
+    limit: int = Field(default=50, ge=1, le=500)
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class TaskResponse(BaseModel):
+    """Wire shape returned by every Task endpoint.
+
+    Timestamps are ISO-8601 strings (always tz-aware, ``+00:00`` suffix)
+    so the desktop client's ``new Date(...)`` parses unambiguously.
+    """
+
+    id: str
+    workspace_id: str
+    creator_id: str
+    assignee: AssigneeDTO
+    status: str
+    priority: str
+    kind: str
+    source: SourceDTO
+    title: str
+    summary: str
+    pocket_id: str | None = None
+    cycle_id: str | None = None
+    due_at: str | None = None
+    blocked_reason: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+def task_to_dto(task: Task) -> TaskResponse:
+    """Map a domain :class:`Task` to its wire DTO.
+
+    The mapping is mechanical because field names align — domain stays
+    snake_case, the wire stays snake_case (Mission Control's frontend
+    consumes either via the existing camelCase adapter shim).
+    """
+
+    return TaskResponse(
+        id=task.id,
+        workspace_id=task.workspace_id,
+        creator_id=task.creator_id,
+        assignee=AssigneeDTO(
+            kind=task.assignee.kind,
+            id=task.assignee.id,
+            name=task.assignee.name,
+        ),
+        status=task.status,
+        priority=task.priority,
+        kind=task.kind,
+        source=SourceDTO(
+            type=task.source.type,
+            ref_id=task.source.ref_id,
+            metadata=dict(task.source.metadata),
+        ),
+        title=task.title,
+        summary=task.summary,
+        pocket_id=task.pocket_id,
+        cycle_id=task.cycle_id,
+        due_at=iso_utc(task.due_at),
+        blocked_reason=task.blocked_reason,
+        created_at=iso_utc(task.created_at),
+        updated_at=iso_utc(task.updated_at),
+    )
+
+
+__all__ = [
+    "AssigneeDTO",
+    "BlockTaskRequest",
+    "BulkReassignRequest",
+    "ClaimTaskRequest",
+    "CompleteTaskRequest",
+    "CreateTaskRequest",
+    "ListTasksRequest",
+    "ReassignTaskRequest",
+    "SourceDTO",
+    "TaskResponse",
+    "UpdateTaskRequest",
+    "task_to_dto",
+]

--- a/ee/cloud/tasks/listeners.py
+++ b/ee/cloud/tasks/listeners.py
@@ -1,0 +1,99 @@
+# listeners.py — in-process bus subscribers for Tasks.
+# Created: 2026-05-13 — PR 2 of 3 for Mission Control's backend.
+#   Bridges ``task.proposed`` into the existing ``notifications/``
+#   surface so a human assignee gets an in-app notification when a Task
+#   lands in their queue. Agent assignees are skipped — they poll their
+#   own queue via ``list_my_tasks`` / SSE and don't need a notification
+#   row.
+"""Tasks bus subscribers.
+
+The Tasks service emits :class:`TaskProposed` on every create. This
+module subscribes that event and routes a notification to human
+assignees only. Wired into the bus at startup from
+``ee.cloud.__init__:mount_cloud`` after ``init_realtime`` has installed
+the singleton bus.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ee.cloud._core.realtime.bus import get_bus
+from ee.cloud._core.realtime.events import Event, TaskProposed
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_task(event: Event) -> dict | None:
+    """Pull the task dict from a TaskProposed event payload, or ``None``
+    when the payload is malformed (defensive — the bus should never
+    deliver a malformed event, but a broken handler must not be able to
+    take down the rest of the subscriber chain)."""
+
+    data = getattr(event, "data", None) or {}
+    task = data.get("task")
+    if not isinstance(task, dict):
+        return None
+    return task
+
+
+async def notify_human_assignee(event: Event) -> None:
+    """Create an in-app notification when a Task is proposed to a human.
+
+    Agent assignees are skipped on purpose — the agent runtime picks up
+    its work via ``list_my_tasks`` polling or the ``task.proposed`` SSE
+    event directly. Routing them through the human notification surface
+    would double-fire and clutter the operator's notification feed.
+    """
+
+    task = _extract_task(event)
+    if task is None:
+        return
+
+    assignee = task.get("assignee") or {}
+    if assignee.get("kind") != "human":
+        return
+
+    recipient = assignee.get("id")
+    workspace_id = task.get("workspace_id")
+    if not recipient or not workspace_id:
+        return
+
+    # Don't notify someone of work they assigned to themselves — they
+    # already know about it. The Mission Control feed will show the row
+    # anyway via the realtime ``task.proposed`` push.
+    if recipient == task.get("creator_id"):
+        return
+
+    title = task.get("title") or "New task"
+    creator_id = task.get("creator_id") or ""
+    body = f"Assigned by {creator_id}".strip()
+
+    try:
+        from ee.cloud.notifications import service as notifications_service
+
+        await notifications_service.create(
+            workspace_id=workspace_id,
+            recipient=recipient,
+            kind="task_assigned",
+            title=title,
+            body=body,
+            source=None,
+        )
+    except Exception:
+        logger.warning("task.proposed → notification fan-out failed", exc_info=True)
+
+
+def register_task_listeners() -> None:
+    """Wire the Tasks subscribers into the bus.
+
+    Called once from ``mount_cloud`` after ``init_realtime`` has set the
+    singleton. Idempotent at the framework level only — calling twice
+    would double-register; the bootstrap path calls it exactly once.
+    """
+
+    bus = get_bus()
+    bus.subscribe(TaskProposed.EVENT_TYPE, notify_human_assignee)
+
+
+__all__ = ["notify_human_assignee", "register_task_listeners"]

--- a/ee/cloud/tasks/router.py
+++ b/ee/cloud/tasks/router.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Query
 
 from ee.cloud._core.context import RequestContext, request_context
+from ee.cloud.license import require_license
 from ee.cloud.tasks import service as tasks_service
 from ee.cloud.tasks.dto import (
     BlockTaskRequest,
@@ -35,7 +36,7 @@ from ee.cloud.tasks.dto import (
     UpdateTaskRequest,
 )
 
-router = APIRouter(prefix="/tasks", tags=["Tasks"])
+router = APIRouter(prefix="/tasks", tags=["Tasks"], dependencies=[Depends(require_license)])
 
 
 @router.post("", response_model=TaskResponse)

--- a/ee/cloud/tasks/router.py
+++ b/ee/cloud/tasks/router.py
@@ -1,0 +1,128 @@
+# router.py — FastAPI router for the Tasks entity.
+# Created: 2026-05-13 — PR 2 of 3 for Mission Control's backend. Thin
+#   pass-through layer. Routers parse requests, delegate to
+#   ``ee.cloud.tasks.service``, and return TaskResponse DTOs. No
+#   ``HTTPException`` here — services raise CloudError subclasses and
+#   ``_core.http`` maps them to JSON.
+"""Tasks REST router.
+
+Endpoints:
+
+  - ``POST   /tasks``                  — create
+  - ``GET    /tasks``                  — list (workspace-scoped, filterable)
+  - ``GET    /tasks/{id}``             — single fetch
+  - ``PATCH  /tasks/{id}``             — partial update
+  - ``POST   /tasks/{id}/claim``       — agent claims a proposed task
+  - ``POST   /tasks/{id}/complete``    — finish (archive or request approval)
+  - ``POST   /tasks/{id}/block``       — pause with a reason (Snag)
+  - ``POST   /tasks/{id}/reassign``    — handoff to another assignee
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from ee.cloud._core.context import RequestContext, request_context
+from ee.cloud.tasks import service as tasks_service
+from ee.cloud.tasks.dto import (
+    BlockTaskRequest,
+    ClaimTaskRequest,
+    CompleteTaskRequest,
+    CreateTaskRequest,
+    ListTasksRequest,
+    ReassignTaskRequest,
+    TaskResponse,
+    UpdateTaskRequest,
+)
+
+router = APIRouter(prefix="/tasks", tags=["Tasks"])
+
+
+@router.post("", response_model=TaskResponse)
+async def create_task(
+    body: CreateTaskRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> TaskResponse:
+    return await tasks_service.agent_create_task(ctx, body)
+
+
+@router.get("", response_model=list[TaskResponse])
+async def list_tasks(
+    assignee_id: str | None = Query(default=None, alias="assignee"),
+    assignee_kind: str | None = Query(default=None),
+    status: str | None = Query(default=None),
+    cycle_id: str | None = Query(default=None),
+    pocket_id: str | None = Query(default=None),
+    creator_id: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    ctx: RequestContext = Depends(request_context),
+) -> list[TaskResponse]:
+    body = ListTasksRequest(
+        assignee_id=assignee_id,
+        assignee_kind=assignee_kind,  # type: ignore[arg-type]
+        status=status,
+        cycle_id=cycle_id,
+        pocket_id=pocket_id,
+        creator_id=creator_id,
+        limit=limit,
+    )
+    return await tasks_service.agent_list_tasks(ctx, body)
+
+
+@router.get("/{task_id}", response_model=TaskResponse)
+async def get_task(
+    task_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> TaskResponse:
+    return await tasks_service.agent_get_task(ctx, task_id)
+
+
+@router.patch("/{task_id}", response_model=TaskResponse)
+async def update_task(
+    task_id: str,
+    body: UpdateTaskRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> TaskResponse:
+    return await tasks_service.agent_update_task(ctx, task_id, body)
+
+
+@router.post("/{task_id}/claim")
+async def claim_task(
+    task_id: str,
+    body: ClaimTaskRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> dict:
+    """Atomic claim. Returns ``{ok: True, task}`` on success,
+    ``{ok: False, reason}`` when the row was already claimed, doesn't
+    exist, or isn't assigned to the calling agent. The 200 status with
+    ``ok=False`` is intentional — agent runtimes treat this as a polling
+    race, not an exceptional error, and the body carries the reason."""
+
+    return await tasks_service.agent_claim_task(ctx, task_id, body)
+
+
+@router.post("/{task_id}/complete", response_model=TaskResponse)
+async def complete_task(
+    task_id: str,
+    body: CompleteTaskRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> TaskResponse:
+    return await tasks_service.agent_complete_task(ctx, task_id, body)
+
+
+@router.post("/{task_id}/block", response_model=TaskResponse)
+async def block_task(
+    task_id: str,
+    body: BlockTaskRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> TaskResponse:
+    return await tasks_service.agent_block_task(ctx, task_id, body)
+
+
+@router.post("/{task_id}/reassign", response_model=TaskResponse)
+async def reassign_task(
+    task_id: str,
+    body: ReassignTaskRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> TaskResponse:
+    return await tasks_service.agent_reassign_task(ctx, task_id, body)

--- a/ee/cloud/tasks/service.py
+++ b/ee/cloud/tasks/service.py
@@ -351,6 +351,11 @@ async def agent_complete_task(
     body = CompleteTaskRequest.model_validate(body)
     doc = await _fetch_task(ctx, task_id)
 
+    if doc.creator_id != ctx.user_id and doc.assignee_id != ctx.user_id:
+        # Only the creator or the assignee can mark a task complete.
+        # Other workspace members must reassign or escalate.
+        raise Forbidden("task.complete_denied", "Only the creator or assignee can complete this task")
+
     if doc.status in {"done", "reverted", "failed"}:
         raise ValidationError("task.terminal", f"task is already {doc.status!r}")
 
@@ -378,6 +383,9 @@ async def agent_block_task(
 
     body = BlockTaskRequest.model_validate(body)
     doc = await _fetch_task(ctx, task_id)
+    if doc.creator_id != ctx.user_id and doc.assignee_id != ctx.user_id:
+        # Only the creator or assignee can flag a task blocked.
+        raise Forbidden("task.block_denied", "Only the creator or assignee can block this task")
     doc.status = "blocked"
     doc.blocked_reason = body.reason
     await doc.save()
@@ -398,6 +406,10 @@ async def agent_reassign_task(
 
     body = ReassignTaskRequest.model_validate(body)
     doc = await _fetch_task(ctx, task_id)
+    if doc.creator_id != ctx.user_id and doc.assignee_id != ctx.user_id:
+        # Only the creator or current assignee can reassign. Workspace
+        # members at large must go through their own delegation path.
+        raise Forbidden("task.reassign_denied", "Only the creator or assignee can reassign this task")
     doc.assignee = _AssigneeDoc(
         kind=body.assignee_kind,
         id=body.assignee_id,

--- a/ee/cloud/tasks/service.py
+++ b/ee/cloud/tasks/service.py
@@ -1,0 +1,458 @@
+# service.py — Tasks entity business logic.
+# Created: 2026-05-13 — PR 2 of 3 for Mission Control's backend. Sole
+#   owner of writes to the ``Task`` Beanie document. Module-level
+#   ``async def`` API per the ee/cloud Code Rules. Emit-on-every-write
+#   per Rule 9. Tenant filter on every read per Rule 7. Optimistic
+#   single-writer claim via ``find_one_and_update`` so two agents
+#   racing on the same proposed task can never both succeed.
+"""Tasks entity — business logic service.
+
+Public API (all module-level ``async def``):
+
+  - :func:`agent_create_task` — insert, status defaults by assignee kind.
+  - :func:`agent_list_tasks` — workspace-scoped filterable list.
+  - :func:`agent_get_task` — single fetch with tenant guard.
+  - :func:`agent_update_task` — partial patch of mutable metadata.
+  - :func:`agent_claim_task` — atomic ``proposed → in_progress`` flip
+    for an agent runtime picking up its queue. First writer wins.
+  - :func:`agent_complete_task` — terminal flip to ``done`` or hand-off
+    to ``awaiting_approval`` for creator sign-off (the Nudge path).
+  - :func:`agent_block_task` — flip to ``blocked`` with a reason so it
+    surfaces in the operator's Snags section.
+  - :func:`agent_reassign_task` — change the assignee polymorphically.
+
+Every state-mutating function ends with an ``emit(...)`` call on the
+realtime bus. Mission Control's frontend subscribes to ``task.*`` events
+for live feed updates; the notifications listener subscribes to
+``task.proposed`` to create an in-app notification for human assignees.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from beanie import PydanticObjectId
+
+from ee.cloud._core.context import RequestContext
+from ee.cloud._core.errors import Forbidden, NotFound, ValidationError
+from ee.cloud._core.realtime.emit import emit
+from ee.cloud._core.realtime.events import (
+    TaskBlocked,
+    TaskClaimed,
+    TaskProposed,
+    TaskResolved,
+    TaskUpdated,
+)
+from ee.cloud.models.task import Task as _TaskDoc
+from ee.cloud.models.task import TaskAssignee as _AssigneeDoc
+from ee.cloud.models.task import TaskSource as _SourceDoc
+from ee.cloud.tasks.domain import Task, TaskAssignee, TaskSource
+from ee.cloud.tasks.dto import (
+    BlockTaskRequest,
+    ClaimTaskRequest,
+    CompleteTaskRequest,
+    CreateTaskRequest,
+    ListTasksRequest,
+    ReassignTaskRequest,
+    TaskResponse,
+    UpdateTaskRequest,
+    task_to_dto,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Private mapping + access helpers
+# ---------------------------------------------------------------------------
+
+
+def _assignee_to_domain(a: _AssigneeDoc) -> TaskAssignee:
+    return TaskAssignee(kind=a.kind, id=a.id, name=a.name)
+
+
+def _source_to_domain(s: _SourceDoc) -> TaskSource:
+    return TaskSource(type=s.type, ref_id=s.ref_id, metadata=dict(s.metadata or {}))
+
+
+def _to_domain(doc: _TaskDoc) -> Task:
+    """Beanie document → frozen domain ``Task``."""
+
+    return Task(
+        id=str(doc.id),
+        workspace_id=doc.workspace_id,
+        creator_id=doc.creator_id,
+        assignee=_assignee_to_domain(doc.assignee),
+        status=doc.status,  # type: ignore[arg-type]
+        priority=doc.priority,  # type: ignore[arg-type]
+        kind=doc.kind,  # type: ignore[arg-type]
+        source=_source_to_domain(doc.source),
+        title=doc.title,
+        summary=doc.summary,
+        pocket_id=doc.pocket_id,
+        cycle_id=doc.cycle_id,
+        due_at=doc.due_at,
+        blocked_reason=doc.blocked_reason,
+        created_at=getattr(doc, "createdAt", None),
+        updated_at=getattr(doc, "updatedAt", None),
+    )
+
+
+async def _fetch_task(ctx: RequestContext, task_id: str) -> _TaskDoc:
+    """Load a Task by id, enforce workspace tenancy, raise NotFound on
+    miss or on a cross-workspace mismatch. Returning a uniform NotFound
+    (not Forbidden) on tenant mismatch prevents callers in another
+    workspace from enumerating task ids by 404-vs-403 timing.
+    """
+
+    try:
+        oid = PydanticObjectId(task_id)
+    except Exception as exc:  # noqa: BLE001
+        raise NotFound("task", task_id) from exc
+    doc = await _TaskDoc.get(oid)
+    if doc is None or doc.workspace_id != ctx.workspace_id:
+        raise NotFound("task", task_id)
+    return doc
+
+
+def _event_payload(doc: _TaskDoc, task: Task | None = None) -> dict:
+    """Build the realtime event payload for a task mutation.
+
+    The full DTO ships so frontends can render the row without a
+    follow-up fetch. ``recipient_ids`` lets the audience resolver fan
+    out to the creator and the human assignee (agent assignees don't
+    need a WebSocket push — they poll their own queue).
+    """
+
+    if task is None:
+        task = _to_domain(doc)
+    recipients: list[str] = [task.creator_id]
+    if task.assignee.kind == "human":
+        if task.assignee.id and task.assignee.id != task.creator_id:
+            recipients.append(task.assignee.id)
+    return {
+        "task_id": task.id,
+        "task": task_to_dto(task).model_dump(),
+        "workspace_id": task.workspace_id,
+        "recipient_ids": recipients,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+async def agent_create_task(ctx: RequestContext, body: CreateTaskRequest) -> TaskResponse:
+    """Create a Task. Status defaults from ``assignee.kind`` — agent
+    assignees land in ``proposed`` (waiting on the claim flow); human
+    assignees land in ``in_progress`` (already in someone's hands).
+
+    Workspace tenancy comes from ``ctx``; never accept ``workspace_id``
+    as a function parameter (Rule 5).
+    """
+
+    body = CreateTaskRequest.model_validate(body)
+    if not ctx.workspace_id:
+        raise ValidationError("task.no_workspace", "creating a task requires an active workspace")
+
+    status = "proposed" if body.assignee.kind == "agent" else "in_progress"
+
+    doc = _TaskDoc(
+        workspace_id=ctx.workspace_id,
+        creator_id=ctx.user_id,
+        pocket_id=body.pocket_id,
+        cycle_id=body.cycle_id,
+        title=body.title,
+        summary=body.summary,
+        assignee=_AssigneeDoc(
+            kind=body.assignee.kind,
+            id=body.assignee.id,
+            name=body.assignee.name,
+        ),
+        assignee_id=body.assignee.id,
+        assignee_kind=body.assignee.kind,
+        status=status,
+        priority=body.priority,
+        kind=body.kind,
+        source=_SourceDoc(
+            type=body.source.type,
+            ref_id=body.source.ref_id,
+            metadata=dict(body.source.metadata or {}),
+        ),
+        due_at=body.due_at,
+    )
+    await doc.insert()
+    task = _to_domain(doc)
+    await emit(TaskProposed(data=_event_payload(doc, task)))
+    return task_to_dto(task)
+
+
+async def agent_list_tasks(ctx: RequestContext, body: ListTasksRequest) -> list[TaskResponse]:
+    """List tasks visible in the caller's workspace, filtered.
+
+    Mission Control's left rail uses this with ``assignee_id`` to feed
+    the per-agent "Agents in flight" sections; the Tray uses it with
+    ``status='awaiting_approval'`` plus ``assignee_id=<me>``.
+    """
+
+    body = ListTasksRequest.model_validate(body)
+    if not ctx.workspace_id:
+        return []
+
+    query: dict = {"workspace_id": ctx.workspace_id}
+    if body.assignee_id:
+        query["assignee_id"] = body.assignee_id
+    if body.assignee_kind:
+        query["assignee_kind"] = body.assignee_kind
+    if body.status:
+        query["status"] = body.status
+    if body.cycle_id:
+        query["cycle_id"] = body.cycle_id
+    if body.pocket_id:
+        query["pocket_id"] = body.pocket_id
+    if body.creator_id:
+        query["creator_id"] = body.creator_id
+
+    docs = (
+        await _TaskDoc.find(query)
+        .sort(-_TaskDoc.createdAt)  # type: ignore[operator]
+        .limit(body.limit)
+        .to_list()
+    )
+    return [task_to_dto(_to_domain(d)) for d in docs]
+
+
+async def agent_get_task(ctx: RequestContext, task_id: str) -> TaskResponse:
+    """Single fetch with tenant check."""
+
+    doc = await _fetch_task(ctx, task_id)
+    return task_to_dto(_to_domain(doc))
+
+
+async def agent_update_task(
+    ctx: RequestContext, task_id: str, body: UpdateTaskRequest
+) -> TaskResponse:
+    """Partial update of mutable Task metadata.
+
+    Status transitions DO NOT come through this endpoint — they use the
+    dedicated claim / complete / block / reassign verbs so the audit
+    trail and event surface stay precise. Title, summary, priority,
+    pocket_id, cycle_id, due_at are fair game here.
+    """
+
+    body = UpdateTaskRequest.model_validate(body)
+    doc = await _fetch_task(ctx, task_id)
+    if doc.creator_id != ctx.user_id and doc.assignee_id != ctx.user_id:
+        # Only creator or assignee can edit. Other workspace members
+        # should escalate through reassignment / approval flows.
+        raise Forbidden("task.edit_denied", "Only the creator or assignee can edit this task")
+
+    if body.title is not None:
+        doc.title = body.title
+    if body.summary is not None:
+        doc.summary = body.summary
+    if body.priority is not None:
+        doc.priority = body.priority
+    if body.pocket_id is not None:
+        doc.pocket_id = body.pocket_id
+    if body.cycle_id is not None:
+        doc.cycle_id = body.cycle_id
+    if body.due_at is not None:
+        doc.due_at = body.due_at
+
+    await doc.save()
+    task = _to_domain(doc)
+    await emit(TaskUpdated(data=_event_payload(doc, task)))
+    return task_to_dto(task)
+
+
+# ---------------------------------------------------------------------------
+# State-machine verbs
+# ---------------------------------------------------------------------------
+
+
+async def agent_claim_task(ctx: RequestContext, task_id: str, body: ClaimTaskRequest) -> dict:
+    """Optimistic single-writer claim.
+
+    Returns ``{"ok": True, "task": <TaskResponse dict>}`` when the
+    caller successfully claimed the task, or
+    ``{"ok": False, "reason": "<code>"}`` when the row was already
+    claimed by someone else, doesn't exist, or doesn't belong to this
+    agent.
+
+    The atomic move lives in a single Mongo ``find_one_and_update`` on
+    ``{_id, workspace_id, status: 'proposed', assignee.id: agent_id}``.
+    If two agent runtimes race on the same proposed task, exactly one
+    update matches; the second sees ``None`` and returns
+    ``{ok: False, reason: 'already_claimed'}``. No transaction needed.
+    """
+
+    body = ClaimTaskRequest.model_validate(body)
+    if not ctx.workspace_id:
+        return {"ok": False, "reason": "no_workspace"}
+
+    try:
+        oid = PydanticObjectId(task_id)
+    except Exception:
+        return {"ok": False, "reason": "not_found"}
+
+    now = datetime.now(UTC)
+    collection = _TaskDoc.get_pymongo_collection()
+    updated = await collection.find_one_and_update(
+        {
+            "_id": oid,
+            "workspace_id": ctx.workspace_id,
+            "status": "proposed",
+            "assignee_id": body.agent_id,
+            "assignee_kind": "agent",
+        },
+        {"$set": {"status": "in_progress", "updatedAt": now}},
+        return_document=True,  # mongomock + pymongo accept bool: True == AFTER
+    )
+    if updated is None:
+        # Disambiguate: does the task even exist for this workspace?
+        existing = await collection.find_one(
+            {"_id": oid, "workspace_id": ctx.workspace_id},
+            projection={"status": 1, "assignee_id": 1, "assignee_kind": 1},
+        )
+        if existing is None:
+            return {"ok": False, "reason": "not_found"}
+        if existing.get("assignee_id") != body.agent_id:
+            return {"ok": False, "reason": "not_assigned_to_agent"}
+        if existing.get("status") != "proposed":
+            return {"ok": False, "reason": "already_claimed"}
+        return {"ok": False, "reason": "claim_failed"}
+
+    doc = await _TaskDoc.get(oid)
+    if doc is None:
+        # Shouldn't happen — we just updated it — but defensive.
+        return {"ok": False, "reason": "race"}
+    task = _to_domain(doc)
+    await emit(TaskClaimed(data=_event_payload(doc, task)))
+    return {"ok": True, "task": task_to_dto(task).model_dump()}
+
+
+async def agent_complete_task(
+    ctx: RequestContext, task_id: str, body: CompleteTaskRequest
+) -> TaskResponse:
+    """Finish work on a task.
+
+    ``next_action='archive'`` → status flips to ``done`` and the row
+    leaves Mission Control's active feed.
+
+    ``next_action='request_approval'`` → status flips to
+    ``awaiting_approval`` and the row reappears in the creator's Tray
+    as a Nudge for sign-off. This is the path agent runtimes take after
+    drafting work product the human still wants to review.
+    """
+
+    body = CompleteTaskRequest.model_validate(body)
+    doc = await _fetch_task(ctx, task_id)
+
+    if doc.status in {"done", "reverted", "failed"}:
+        raise ValidationError("task.terminal", f"task is already {doc.status!r}")
+
+    new_status = "done" if body.next_action == "archive" else "awaiting_approval"
+    doc.status = new_status
+    if body.result_summary:
+        # Append a result line to the summary so the detail panel shows
+        # the agent's hand-off note without a separate field migration.
+        if doc.summary:
+            doc.summary = (doc.summary + "\n\n" + body.result_summary).strip()
+        else:
+            doc.summary = body.result_summary
+    await doc.save()
+    task = _to_domain(doc)
+    await emit(TaskResolved(data=_event_payload(doc, task)))
+    return task_to_dto(task)
+
+
+async def agent_block_task(
+    ctx: RequestContext, task_id: str, body: BlockTaskRequest
+) -> TaskResponse:
+    """Mark the task blocked with a reason. Surfaces in the operator's
+    Snags section. Recoverable: a subsequent ``agent_update_task`` or
+    ``agent_claim_task`` can move it back to ``in_progress``."""
+
+    body = BlockTaskRequest.model_validate(body)
+    doc = await _fetch_task(ctx, task_id)
+    doc.status = "blocked"
+    doc.blocked_reason = body.reason
+    await doc.save()
+    task = _to_domain(doc)
+    await emit(TaskBlocked(data=_event_payload(doc, task)))
+    return task_to_dto(task)
+
+
+async def agent_reassign_task(
+    ctx: RequestContext, task_id: str, body: ReassignTaskRequest
+) -> TaskResponse:
+    """Change the task's assignee. Kind may flip (human → agent or
+    vice versa). If the task was ``proposed`` and the new assignee is a
+    human, we leave it ``proposed`` so the human sees it as pending; if
+    the new assignee is an agent, also ``proposed`` so the claim path
+    fires. Other statuses pass through.
+    """
+
+    body = ReassignTaskRequest.model_validate(body)
+    doc = await _fetch_task(ctx, task_id)
+    doc.assignee = _AssigneeDoc(
+        kind=body.assignee_kind,
+        id=body.assignee_id,
+        name=body.assignee_name,
+    )
+    doc.assignee_id = body.assignee_id
+    doc.assignee_kind = body.assignee_kind
+    await doc.save()
+    task = _to_domain(doc)
+    await emit(TaskUpdated(data=_event_payload(doc, task)))
+    return task_to_dto(task)
+
+
+# ---------------------------------------------------------------------------
+# Agent-runtime helpers
+# ---------------------------------------------------------------------------
+
+
+async def list_for_agent_runtime(
+    workspace_id: str, agent_id: str, status: str = "proposed", limit: int = 50
+) -> list[TaskResponse]:
+    """Return tasks assigned to a specific agent.
+
+    Used by the in-process MCP ``list_my_tasks`` tool which doesn't have
+    a RequestContext (it runs inside the agent process, identified by
+    per-stream ContextVars). The function takes ``workspace_id`` /
+    ``agent_id`` directly and applies the standard tenant filter inline.
+    """
+
+    if not workspace_id or not agent_id:
+        return []
+    query: dict = {
+        "workspace_id": workspace_id,
+        "assignee_id": agent_id,
+        "assignee_kind": "agent",
+    }
+    if status:
+        query["status"] = status
+    docs = (
+        await _TaskDoc.find(query)
+        .sort(-_TaskDoc.createdAt)  # type: ignore[operator]
+        .limit(limit)
+        .to_list()
+    )
+    return [task_to_dto(_to_domain(d)) for d in docs]
+
+
+__all__ = [
+    "agent_block_task",
+    "agent_claim_task",
+    "agent_complete_task",
+    "agent_create_task",
+    "agent_get_task",
+    "agent_list_tasks",
+    "agent_reassign_task",
+    "agent_update_task",
+    "list_for_agent_runtime",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -580,3 +580,15 @@ forbidden_modules = [
     "ee.cloud.models.user",
     "ee.cloud.models.agent",
 ]
+
+[[tool.importlinter.contracts]]
+name = "Tasks — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "ee.cloud.tasks.router",
+    "ee.cloud.tasks.dto",
+    "ee.cloud.tasks.domain",
+    "ee.cloud.tasks.listeners",
+]
+forbidden_modules = ["ee.cloud.models.task"]

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -518,6 +518,21 @@ class ClaudeSDKBackend(BaseAgentBackend):
         except Exception as exc:  # noqa: BLE001
             logger.debug("pocket_context MCP server not registered: %s", exc)
 
+        # In-process MCP server: exposes Mission Control Tasks tools
+        # (``list_my_tasks``, ``claim_task``, ``complete_task``) so an
+        # agent running inside a workspace can pick up work routed to
+        # it without an out-of-band HTTP client. Same lifecycle as the
+        # pocket-context server above.
+        try:
+            from pocketpaw.agents.sdk_mcp_tasks import build_tasks_context_server
+
+            tasks_server = build_tasks_context_server()
+            if tasks_server is not None:
+                name, cfg_entry = tasks_server
+                servers[name] = cfg_entry
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("pocketpaw_tasks MCP server not registered: %s", exc)
+
         # In-process MCP server: exposes ``pocket_specialist__create`` so the
         # main agent can hand a brief to the specialist tool, which runs
         # the full list/validate/persist workflow as an isolated specialist
@@ -855,6 +870,19 @@ class ClaudeSDKBackend(BaseAgentBackend):
             from pocketpaw.agents.sdk_mcp_pocket import POCKET_TOOL_IDS
 
             allowed_tools.extend(POCKET_TOOL_IDS)
+
+            # Mission Control Tasks tools — agents need these to pull
+            # work from their queue and report completion. Surface is
+            # tiny (3 tools); allowlisting unconditionally keeps the
+            # claim flow available wherever the SDK backend runs.
+            try:
+                from pocketpaw.agents.sdk_mcp_tasks import TASK_TOOL_IDS
+
+                allowed_tools.extend(TASK_TOOL_IDS)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "pocketpaw_tasks tool ids not added to allowlist: %s", exc
+                )
 
             # Pocket specialist — ``create`` / ``edit`` tools that run the
             # full listing → validate → persist workflow as an isolated

--- a/src/pocketpaw/agents/sdk_mcp_tasks.py
+++ b/src/pocketpaw/agents/sdk_mcp_tasks.py
@@ -1,0 +1,297 @@
+# sdk_mcp_tasks.py — in-process MCP server exposing Mission Control Tasks.
+# Created: 2026-05-13 — PR 2 of 3 for Mission Control's backend. Mirrors
+#   the read-only ``sdk_mcp_pocket.py`` pattern but adds the
+#   state-mutating ``claim_task`` and ``complete_task`` verbs that the
+#   agent runtime needs to pick up work routed to it from Mission
+#   Control's create form. Tool ids namespace as
+#   ``mcp__pocketpaw_tasks__*`` so the Claude Code allowlist machinery
+#   matches them.
+"""Agent-side MCP surface for the Mission Control Tasks entity.
+
+Tools registered:
+
+  - ``list_my_tasks(status='proposed')`` — list Tasks where
+    ``assignee.id == this agent`` in the active workspace. Cheap; the
+    agent loop calls this on its polling cycle to find new work even
+    when SSE is unavailable.
+  - ``claim_task(task_id)`` — atomic ``proposed → in_progress`` flip.
+    Returns ``{ok, task}`` on success or ``{ok: False, reason}`` when
+    another agent (or the agent's own retry) lost the race.
+  - ``complete_task(task_id, next_action='archive')`` — finish.
+    ``next_action='request_approval'`` routes the task back to the
+    creator as a Nudge for sign-off.
+
+The agent's identity comes from the per-stream ``ContextVar``s in
+``ee.cloud.chat.agent_service`` (same chokepoint the pocket MCP server
+uses). When run outside an SSE chat stream the tools return a clear
+error rather than silently mis-tenant.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_tasks"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+# Allowlist entries must use this exact form.
+LIST_MY_TASKS_TOOL_ID = f"mcp__{SERVER_NAME}__list_my_tasks"
+CLAIM_TASK_TOOL_ID = f"mcp__{SERVER_NAME}__claim_task"
+COMPLETE_TASK_TOOL_ID = f"mcp__{SERVER_NAME}__complete_task"
+
+TASK_TOOL_IDS = (
+    LIST_MY_TASKS_TOOL_ID,
+    CLAIM_TASK_TOOL_ID,
+    COMPLETE_TASK_TOOL_ID,
+)
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    """Build an MCP error response in the shape Claude's SDK expects."""
+
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    """Build an MCP success response carrying ``body`` as JSON."""
+
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(body, separators=(",", ":"), default=str),
+            }
+        ]
+    }
+
+
+def _identity() -> tuple[str | None, str | None]:
+    """Resolve the active workspace + agent id from the per-stream
+    ContextVars set by ``agent_router._run_agent_stream``.
+
+    Returns ``(workspace_id, user_id)`` where ``user_id`` is treated as
+    the agent's identity from the runtime's perspective (the agent's
+    runtime authenticates as itself when calling into the cloud).
+    """
+
+    try:
+        from ee.cloud.chat.agent_service import current_user_id, current_workspace_id
+
+        return current_workspace_id(), current_user_id()
+    except Exception:
+        return None, None
+
+
+def _build_ctx(workspace_id: str, user_id: str):
+    """Construct a ``RequestContext`` for service calls from the MCP
+    tool channel. The chat stream doesn't have a FastAPI request scope,
+    so we synthesise one. Same approach the pocket-specialist subagent
+    uses."""
+
+    from datetime import UTC, datetime
+
+    from ee.cloud._core.context import RequestContext, ScopeKind
+
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="mcp",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers
+# ---------------------------------------------------------------------------
+
+
+async def _list_my_tasks_handler(args: dict) -> dict:
+    workspace_id, agent_id = _identity()
+    if not workspace_id or not agent_id:
+        return _error_response(
+            "no active workspace/agent — list_my_tasks can only be called "
+            "from inside a cloud SSE chat stream"
+        )
+
+    from ee.cloud.tasks import service as tasks_service
+
+    status = args.get("status") or "proposed"
+    limit_raw = args.get("limit") or 50
+    try:
+        limit = max(1, min(int(limit_raw), 200))
+    except (TypeError, ValueError):
+        limit = 50
+
+    try:
+        tasks = await tasks_service.list_for_agent_runtime(
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            status=str(status),
+            limit=limit,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("list_my_tasks failed", exc_info=True)
+        return _error_response(f"list_my_tasks failed: {exc}")
+
+    return _success_response({"tasks": [t.model_dump() for t in tasks], "count": len(tasks)})
+
+
+async def _claim_task_handler(args: dict) -> dict:
+    workspace_id, agent_id = _identity()
+    if not workspace_id or not agent_id:
+        return _error_response(
+            "no active workspace/agent — claim_task can only be called "
+            "from inside a cloud SSE chat stream"
+        )
+
+    task_id = args.get("task_id")
+    if not isinstance(task_id, str) or not task_id:
+        return _error_response("task_id is required (string)")
+
+    from ee.cloud.tasks import service as tasks_service
+    from ee.cloud.tasks.dto import ClaimTaskRequest
+
+    ctx = _build_ctx(workspace_id, agent_id)
+    try:
+        result = await tasks_service.agent_claim_task(
+            ctx, task_id, ClaimTaskRequest(agent_id=agent_id)
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("claim_task failed", exc_info=True)
+        return _error_response(f"claim_task failed: {exc}")
+
+    return _success_response(result)
+
+
+async def _complete_task_handler(args: dict) -> dict:
+    workspace_id, agent_id = _identity()
+    if not workspace_id or not agent_id:
+        return _error_response(
+            "no active workspace/agent — complete_task can only be called "
+            "from inside a cloud SSE chat stream"
+        )
+
+    task_id = args.get("task_id")
+    if not isinstance(task_id, str) or not task_id:
+        return _error_response("task_id is required (string)")
+
+    next_action = args.get("next_action") or "archive"
+    if next_action not in {"archive", "request_approval"}:
+        return _error_response("next_action must be 'archive' or 'request_approval'")
+    result_summary = args.get("result_summary") or ""
+
+    from ee.cloud._core.errors import CloudError
+    from ee.cloud.tasks import service as tasks_service
+    from ee.cloud.tasks.dto import CompleteTaskRequest
+
+    ctx = _build_ctx(workspace_id, agent_id)
+    try:
+        response = await tasks_service.agent_complete_task(
+            ctx,
+            task_id,
+            CompleteTaskRequest(
+                next_action=next_action,  # type: ignore[arg-type]
+                result_summary=str(result_summary),
+            ),
+        )
+    except CloudError as exc:
+        return _error_response(f"{exc.code}: {exc.message}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("complete_task failed", exc_info=True)
+        return _error_response(f"complete_task failed: {exc}")
+
+    return _success_response({"ok": True, "task": response.model_dump()})
+
+
+# ---------------------------------------------------------------------------
+# Server factory
+# ---------------------------------------------------------------------------
+
+
+def build_tasks_context_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for Tasks, or return ``None``
+    if the Claude Agent SDK isn't installed.
+
+    Matches the shape returned by ``build_pocket_context_server`` so the
+    backend's MCP registration loop in ``claude_sdk.py`` treats both
+    identically.
+    """
+
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_tasks MCP disabled")
+        return None
+
+    @tool(
+        "list_my_tasks",
+        (
+            "List Mission Control Tasks routed to the currently-running "
+            "agent in its active workspace. Defaults to ``status='proposed'`` "
+            "(tasks waiting to be claimed). Pass ``status='in_progress'`` to "
+            "see tasks already in flight. Cheap, in-process, no rippleSpec or "
+            "heavy joins. Use this on every polling cycle to find new work."
+        ),
+        {"status": str, "limit": int},
+    )
+    async def list_my_tasks(args):  # type: ignore[no-untyped-def]
+        return await _list_my_tasks_handler(args)
+
+    @tool(
+        "claim_task",
+        (
+            "Atomically claim a proposed Mission Control Task for this "
+            "agent. The claim only succeeds if the task is still in "
+            "``proposed`` state AND assigned to this agent. Returns "
+            "``{ok: True, task}`` on success, or ``{ok: False, reason}`` "
+            "when another writer beat you (``already_claimed``), the task "
+            "doesn't exist (``not_found``), or you aren't the assignee "
+            "(``not_assigned_to_agent``). Treat ``ok: False`` as a race, "
+            "not an error — move on to the next task in your queue."
+        ),
+        {"task_id": str},
+    )
+    async def claim_task(args):  # type: ignore[no-untyped-def]
+        return await _claim_task_handler(args)
+
+    @tool(
+        "complete_task",
+        (
+            "Finish a Mission Control Task this agent is working on. "
+            "``next_action='archive'`` (default) flips the task to "
+            "``done`` and removes it from the live feed. "
+            "``next_action='request_approval'`` routes the task back to "
+            "the creator as a Nudge in their Tray for sign-off — use this "
+            "when the agent has produced work product (a draft, a "
+            "proposal, a query) the human should approve before it ships. "
+            "Optional ``result_summary`` is appended to the task's "
+            "summary so the detail panel shows the agent's hand-off note."
+        ),
+        {"task_id": str, "next_action": str, "result_summary": str},
+    )
+    async def complete_task(args):  # type: ignore[no-untyped-def]
+        return await _complete_task_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[list_my_tasks, claim_task, complete_task],
+    )
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "CLAIM_TASK_TOOL_ID",
+    "COMPLETE_TASK_TOOL_ID",
+    "LIST_MY_TASKS_TOOL_ID",
+    "SERVER_NAME",
+    "TASK_TOOL_IDS",
+    "build_tasks_context_server",
+]

--- a/tests/cloud/tasks/__init__.py
+++ b/tests/cloud/tasks/__init__.py
@@ -1,0 +1,2 @@
+# __init__.py — Tasks entity test package.
+# Created: 2026-05-13 — PR 2 of 3 for Mission Control's backend.

--- a/tests/cloud/tasks/test_tasks_claim_optimistic.py
+++ b/tests/cloud/tasks/test_tasks_claim_optimistic.py
@@ -1,0 +1,143 @@
+# test_tasks_claim_optimistic.py — race condition coverage for claim.
+# Created: 2026-05-13 — PR 2 of 3 for Mission Control's backend.
+#   Exercises the optimistic single-writer claim contract: if two
+#   agents (or two retries from the same agent) call ``claim_task`` on
+#   the same ``proposed`` task at the same time, exactly one wins and
+#   the other gets ``{ok: False, reason}``.
+"""Optimistic claim contention tests."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud.tasks import service as tasks_service
+from ee.cloud.tasks.dto import AssigneeDTO, ClaimTaskRequest, CreateTaskRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(
+        user_id="creator",
+        workspace_id="w1",
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _create_proposed_task(agent_id: str = "agent-a") -> str:
+    created = await tasks_service.agent_create_task(
+        _ctx(),
+        CreateTaskRequest(
+            title="claim-me",
+            assignee=AssigneeDTO(kind="agent", id=agent_id, name="A"),
+        ),
+    )
+    assert created.status == "proposed"
+    return created.id
+
+
+# ---------------------------------------------------------------------------
+# Race conditions
+# ---------------------------------------------------------------------------
+
+
+async def test_two_simultaneous_claims_only_one_succeeds() -> None:
+    """Exactly one claim wins when two concurrent calls hit the same
+    proposed task. mongomock-motor serialises individual operations on
+    the same collection so this is a deterministic check of the
+    matcher-condition logic, not of true Mongo-level concurrency."""
+
+    task_id = await _create_proposed_task()
+    body = ClaimTaskRequest(agent_id="agent-a")
+
+    results = await asyncio.gather(
+        tasks_service.agent_claim_task(_ctx(), task_id, body),
+        tasks_service.agent_claim_task(_ctx(), task_id, body),
+    )
+
+    wins = [r for r in results if r["ok"]]
+    losses = [r for r in results if not r["ok"]]
+
+    assert len(wins) == 1
+    assert len(losses) == 1
+    assert losses[0]["reason"] == "already_claimed"
+    assert wins[0]["task"]["status"] == "in_progress"
+
+
+async def test_second_claim_after_first_succeeds_reports_already_claimed() -> None:
+    task_id = await _create_proposed_task()
+    body = ClaimTaskRequest(agent_id="agent-a")
+
+    first = await tasks_service.agent_claim_task(_ctx(), task_id, body)
+    assert first["ok"] is True
+
+    second = await tasks_service.agent_claim_task(_ctx(), task_id, body)
+    assert second["ok"] is False
+    assert second["reason"] == "already_claimed"
+
+
+async def test_claim_by_different_agent_id_rejected() -> None:
+    task_id = await _create_proposed_task(agent_id="agent-a")
+    body = ClaimTaskRequest(agent_id="agent-b")
+
+    result = await tasks_service.agent_claim_task(_ctx(), task_id, body)
+    assert result["ok"] is False
+    assert result["reason"] == "not_assigned_to_agent"
+
+
+async def test_claim_nonexistent_returns_not_found() -> None:
+    # Valid ObjectId shape, no corresponding doc.
+    result = await tasks_service.agent_claim_task(
+        _ctx(),
+        "507f1f77bcf86cd799439011",
+        ClaimTaskRequest(agent_id="agent-a"),
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "not_found"
+
+
+async def test_claim_malformed_id_returns_not_found() -> None:
+    result = await tasks_service.agent_claim_task(
+        _ctx(), "garbage", ClaimTaskRequest(agent_id="agent-a")
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "not_found"
+
+
+async def test_claim_cross_workspace_returns_not_found() -> None:
+    task_id = await _create_proposed_task()
+    cross_ctx = RequestContext(
+        user_id="x",
+        workspace_id="w2",
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+    result = await tasks_service.agent_claim_task(
+        cross_ctx, task_id, ClaimTaskRequest(agent_id="agent-a")
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "not_found"
+
+
+async def test_many_concurrent_claims_only_one_wins() -> None:
+    """Stress: 10 concurrent claim attempts. Exactly one must win."""
+
+    task_id = await _create_proposed_task()
+    body = ClaimTaskRequest(agent_id="agent-a")
+
+    results = await asyncio.gather(
+        *[tasks_service.agent_claim_task(_ctx(), task_id, body) for _ in range(10)]
+    )
+
+    wins = [r for r in results if r["ok"]]
+    assert len(wins) == 1
+    for r in results:
+        if not r["ok"]:
+            assert r["reason"] == "already_claimed"

--- a/tests/cloud/tasks/test_tasks_notification_fanout.py
+++ b/tests/cloud/tasks/test_tasks_notification_fanout.py
@@ -1,0 +1,156 @@
+# test_tasks_notification_fanout.py — Tasks → notifications integration.
+# Created: 2026-05-13 — PR 2 of 3 for Mission Control's backend. Exercises
+#   the in-process bus subscriber that creates a Notification when a
+#   Task is proposed to a human assignee. Agent assignees must not
+#   trigger notifications (they poll their own queue).
+"""Tests for the ``task.proposed`` → notification fan-out listener."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud._core.realtime import bus as bus_mod
+from ee.cloud._core.realtime.audience import AudienceResolver
+from ee.cloud._core.realtime.bus import InProcessBus
+from ee.cloud.notifications import service as notifications_service
+from ee.cloud.tasks import service as tasks_service
+from ee.cloud.tasks.dto import AssigneeDTO, CreateTaskRequest
+from ee.cloud.tasks.listeners import register_task_listeners
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+class _StubConnManager:
+    async def send_to_user(self, user_id, payload) -> None:  # noqa: ARG002
+        return None
+
+
+class _StubResolver(AudienceResolver):
+    """Audience resolver that returns no WebSocket recipients.
+
+    Mission Control's fan-out behaviour is tested in the realtime
+    package; here we only care that the in-process subscriber fires.
+    """
+
+    def __init__(self) -> None:
+        async def _empty(_):
+            return []
+
+        super().__init__(
+            group_members=_empty,
+            workspace_members=_empty,
+            workspace_admins=_empty,
+            workspace_peers=_empty,
+        )
+
+    async def audience(self, event):  # type: ignore[override]
+        return []
+
+
+@pytest_asyncio.fixture
+async def real_bus():
+    """Install a real InProcessBus so the ``task.proposed`` subscriber
+    actually fires. Overrides the autouse RecordingBus from the cloud
+    conftest for the duration of the test."""
+
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus = InProcessBus(resolver=_StubResolver(), conn_manager=_StubConnManager())
+    bus_mod._bus = bus  # type: ignore[attr-defined]
+    register_task_listeners()
+    try:
+        yield bus
+    finally:
+        bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+def _ctx(user_id: str = "creator-1", workspace_id: str = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_human_assignee_proposal_creates_notification(real_bus) -> None:
+    """Routing a Task to a human assignee fires the listener and a
+    notification appears in the recipient's inbox."""
+
+    await tasks_service.agent_create_task(
+        _ctx(user_id="creator-1"),
+        CreateTaskRequest(
+            title="Approve vendor change",
+            assignee=AssigneeDTO(kind="human", id="u-jess", name="Jess"),
+            kind="nudge",
+        ),
+    )
+
+    notes = await notifications_service.list_for_user("u-jess")
+    assert len(notes) == 1
+    assert notes[0].kind == "task_assigned"
+    assert notes[0].title == "Approve vendor change"
+    assert notes[0].workspace_id == "w1"
+
+
+async def test_agent_assignee_proposal_does_not_create_notification(real_bus) -> None:
+    """Agent assignees do not trigger notification rows — they poll
+    their own queue. The notification surface is human-only."""
+
+    await tasks_service.agent_create_task(
+        _ctx(user_id="creator-1"),
+        CreateTaskRequest(
+            title="Draft run-of-show",
+            assignee=AssigneeDTO(kind="agent", id="agent-events", name="events-agent"),
+        ),
+    )
+
+    notes_agent = await notifications_service.list_for_user("agent-events")
+    assert notes_agent == []
+    notes_creator = await notifications_service.list_for_user("creator-1")
+    assert notes_creator == []
+
+
+async def test_self_assigned_human_task_skips_notification(real_bus) -> None:
+    """If the creator assigns a Task to themselves, the listener skips
+    the notification — they already know about it, and Mission Control
+    will surface it via the realtime push regardless."""
+
+    await tasks_service.agent_create_task(
+        _ctx(user_id="solo-shawn"),
+        CreateTaskRequest(
+            title="Call vendor",
+            assignee=AssigneeDTO(kind="human", id="solo-shawn", name="Shawn"),
+        ),
+    )
+
+    notes = await notifications_service.list_for_user("solo-shawn")
+    assert notes == []
+
+
+async def test_each_human_assignment_creates_one_notification(real_bus) -> None:
+    """Distinct tasks routed to the same human assignee result in
+    one notification per task — fan-out is per-event, not deduped."""
+
+    ctx = _ctx(user_id="creator-1")
+    await tasks_service.agent_create_task(
+        ctx,
+        CreateTaskRequest(title="t1", assignee=AssigneeDTO(kind="human", id="u-jess")),
+    )
+    await tasks_service.agent_create_task(
+        ctx,
+        CreateTaskRequest(title="t2", assignee=AssigneeDTO(kind="human", id="u-jess")),
+    )
+
+    notes = await notifications_service.list_for_user("u-jess")
+    titles = {n.title for n in notes}
+    assert titles == {"t1", "t2"}

--- a/tests/cloud/tasks/test_tasks_router.py
+++ b/tests/cloud/tasks/test_tasks_router.py
@@ -1,0 +1,198 @@
+# test_tasks_router.py — router-layer tests for the Tasks entity.
+# Created: 2026-05-13 — PR 2 of 3 for Mission Control's backend.
+#   Asserts status-code mapping, request body validation, and tenant
+#   isolation at the HTTP boundary. Uses the shared ``mongo_db`` fixture
+#   plus a per-test FastAPI app with auth deps overridden.
+"""Router smoke tests for the Tasks entity."""
+
+from __future__ import annotations
+
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ee.cloud._core.http import add_error_handler
+from ee.cloud.tasks.router import router
+
+
+@pytest_asyncio.fixture
+async def app_client(mongo_db) -> AsyncClient:
+    from ee.cloud.auth import current_active_user
+
+    class _U:
+        id = "creator-1"
+        active_workspace = "w1"
+        workspaces: list = []
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[current_active_user] = lambda: _U()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _create_body(**overrides) -> dict:
+    body = {
+        "title": "Draft run-of-show",
+        "summary": "for May 23 wedding",
+        "assignee": {"kind": "agent", "id": "agent-events", "name": "events-agent"},
+        "priority": "normal",
+    }
+    body.update(overrides)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+async def test_create_returns_201_equivalent_200_with_dto(app_client) -> None:
+    resp = await app_client.post("/api/v1/tasks", json=_create_body())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["title"] == "Draft run-of-show"
+    assert body["assignee"]["id"] == "agent-events"
+    assert body["status"] == "proposed"
+    assert body["workspace_id"] == "w1"
+    assert body["creator_id"] == "creator-1"
+    assert body["created_at"].endswith("+00:00")
+
+
+async def test_create_invalid_assignee_kind_returns_422(app_client) -> None:
+    payload = _create_body(assignee={"kind": "robot", "id": "x"})
+    resp = await app_client.post("/api/v1/tasks", json=payload)
+    assert resp.status_code == 422
+
+
+async def test_create_missing_title_returns_422(app_client) -> None:
+    payload = _create_body()
+    payload.pop("title")
+    resp = await app_client.post("/api/v1/tasks", json=payload)
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# List + Get
+# ---------------------------------------------------------------------------
+
+
+async def test_list_returns_tasks(app_client) -> None:
+    await app_client.post("/api/v1/tasks", json=_create_body(title="t1"))
+    await app_client.post("/api/v1/tasks", json=_create_body(title="t2"))
+    resp = await app_client.get("/api/v1/tasks")
+    assert resp.status_code == 200
+    titles = {t["title"] for t in resp.json()}
+    assert titles == {"t1", "t2"}
+
+
+async def test_list_filters_assignee_via_query(app_client) -> None:
+    await app_client.post(
+        "/api/v1/tasks",
+        json=_create_body(
+            title="for-a",
+            assignee={"kind": "agent", "id": "agent-a", "name": "a"},
+        ),
+    )
+    await app_client.post(
+        "/api/v1/tasks",
+        json=_create_body(
+            title="for-b",
+            assignee={"kind": "agent", "id": "agent-b", "name": "b"},
+        ),
+    )
+    resp = await app_client.get("/api/v1/tasks?assignee=agent-a")
+    assert resp.status_code == 200
+    titles = {t["title"] for t in resp.json()}
+    assert titles == {"for-a"}
+
+
+async def test_get_returns_404_for_missing(app_client) -> None:
+    resp = await app_client.get("/api/v1/tasks/507f1f77bcf86cd799439011")
+    assert resp.status_code == 404
+
+
+async def test_get_returns_404_for_malformed_id(app_client) -> None:
+    resp = await app_client.get("/api/v1/tasks/not-an-objectid")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Update
+# ---------------------------------------------------------------------------
+
+
+async def test_patch_updates_title(app_client) -> None:
+    created = (await app_client.post("/api/v1/tasks", json=_create_body())).json()
+    resp = await app_client.patch(f"/api/v1/tasks/{created['id']}", json={"title": "new title"})
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "new title"
+
+
+# ---------------------------------------------------------------------------
+# State-machine verbs
+# ---------------------------------------------------------------------------
+
+
+async def test_claim_succeeds_when_assigned(app_client) -> None:
+    created = (await app_client.post("/api/v1/tasks", json=_create_body())).json()
+    resp = await app_client.post(
+        f"/api/v1/tasks/{created['id']}/claim", json={"agent_id": "agent-events"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["task"]["status"] == "in_progress"
+
+
+async def test_claim_returns_ok_false_for_other_agent(app_client) -> None:
+    created = (await app_client.post("/api/v1/tasks", json=_create_body())).json()
+    resp = await app_client.post(
+        f"/api/v1/tasks/{created['id']}/claim", json={"agent_id": "agent-not-mine"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["reason"] == "not_assigned_to_agent"
+
+
+async def test_complete_archive_returns_done(app_client) -> None:
+    created = (await app_client.post("/api/v1/tasks", json=_create_body())).json()
+    # Claim first so it's in_progress
+    await app_client.post(f"/api/v1/tasks/{created['id']}/claim", json={"agent_id": "agent-events"})
+    resp = await app_client.post(
+        f"/api/v1/tasks/{created['id']}/complete", json={"next_action": "archive"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "done"
+
+
+async def test_block_returns_blocked_with_reason(app_client) -> None:
+    created = (await app_client.post("/api/v1/tasks", json=_create_body())).json()
+    resp = await app_client.post(
+        f"/api/v1/tasks/{created['id']}/block",
+        json={"reason": "needs vendor confirm"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "blocked"
+    assert body["blocked_reason"] == "needs vendor confirm"
+
+
+async def test_reassign_flips_assignee(app_client) -> None:
+    created = (await app_client.post("/api/v1/tasks", json=_create_body())).json()
+    resp = await app_client.post(
+        f"/api/v1/tasks/{created['id']}/reassign",
+        json={
+            "assignee_kind": "human",
+            "assignee_id": "u-jess",
+            "assignee_name": "Jess",
+        },
+    )
+    assert resp.status_code == 200
+    assignee = resp.json()["assignee"]
+    assert assignee["kind"] == "human"
+    assert assignee["id"] == "u-jess"

--- a/tests/cloud/tasks/test_tasks_service.py
+++ b/tests/cloud/tasks/test_tasks_service.py
@@ -1,0 +1,329 @@
+# test_tasks_service.py — service-layer tests for the Tasks entity.
+# Created: 2026-05-13 — PR 2 of 3 for Mission Control's backend. Exercises
+#   CRUD, status transitions, tenancy isolation, and the emit-on-write
+#   guarantee. Uses the shared ``mongo_db`` fixture so real Beanie writes
+#   land in mongomock-motor. The ``recording_bus`` autouse fixture
+#   captures emitted events for assertion.
+"""Service-layer tests for the Tasks entity."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud._core.errors import Forbidden, NotFound, ValidationError
+from ee.cloud._core.realtime.events import (
+    TaskBlocked,
+    TaskProposed,
+    TaskResolved,
+    TaskUpdated,
+)
+from ee.cloud.tasks import service as tasks_service
+from ee.cloud.tasks.dto import (
+    AssigneeDTO,
+    BlockTaskRequest,
+    CompleteTaskRequest,
+    CreateTaskRequest,
+    ListTasksRequest,
+    ReassignTaskRequest,
+    SourceDTO,
+    UpdateTaskRequest,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(*, user_id: str = "u-creator", workspace_id: str = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r1",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _human_assignee(user_id: str = "u-assignee", name: str = "Jess") -> AssigneeDTO:
+    return AssigneeDTO(kind="human", id=user_id, name=name)
+
+
+def _agent_assignee(agent_id: str = "agent-events", name: str = "events-agent") -> AssigneeDTO:
+    return AssigneeDTO(kind="agent", id=agent_id, name=name)
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+async def test_create_for_agent_defaults_to_proposed(recording_bus) -> None:
+    body = CreateTaskRequest(title="Draft run-of-show", assignee=_agent_assignee())
+    resp = await tasks_service.agent_create_task(_ctx(), body)
+    assert resp.status == "proposed"
+    assert resp.assignee.kind == "agent"
+    assert resp.workspace_id == "w1"
+    assert resp.creator_id == "u-creator"
+
+    proposed_events = [e for e in recording_bus.events if isinstance(e, TaskProposed)]
+    assert len(proposed_events) == 1
+    assert proposed_events[0].data["task"]["status"] == "proposed"
+
+
+async def test_create_for_human_defaults_to_in_progress() -> None:
+    body = CreateTaskRequest(title="Reply to vendor", assignee=_human_assignee(), priority="high")
+    resp = await tasks_service.agent_create_task(_ctx(), body)
+    assert resp.status == "in_progress"
+    assert resp.priority == "high"
+    assert resp.assignee.kind == "human"
+
+
+async def test_create_requires_workspace() -> None:
+    body = CreateTaskRequest(title="x", assignee=_agent_assignee())
+    no_ws = _ctx(workspace_id=None)  # type: ignore[arg-type]
+    with pytest.raises(ValidationError):
+        await tasks_service.agent_create_task(no_ws, body)
+
+
+async def test_create_persists_source_metadata() -> None:
+    body = CreateTaskRequest(
+        title="Approve change",
+        assignee=_human_assignee(),
+        kind="nudge",
+        source=SourceDTO(type="nudge", ref_id="nudge-1", metadata={"reason": "policy"}),
+    )
+    resp = await tasks_service.agent_create_task(_ctx(), body)
+    assert resp.source.type == "nudge"
+    assert resp.source.ref_id == "nudge-1"
+    assert resp.source.metadata == {"reason": "policy"}
+    assert resp.kind == "nudge"
+
+
+# ---------------------------------------------------------------------------
+# List + Get
+# ---------------------------------------------------------------------------
+
+
+async def test_list_filters_by_workspace() -> None:
+    await tasks_service.agent_create_task(
+        _ctx(workspace_id="w1"),
+        CreateTaskRequest(title="t1", assignee=_human_assignee()),
+    )
+    await tasks_service.agent_create_task(
+        _ctx(workspace_id="w2"),
+        CreateTaskRequest(title="t2", assignee=_human_assignee()),
+    )
+    listed_w1 = await tasks_service.agent_list_tasks(_ctx(workspace_id="w1"), ListTasksRequest())
+    assert {t.title for t in listed_w1} == {"t1"}
+    listed_w2 = await tasks_service.agent_list_tasks(_ctx(workspace_id="w2"), ListTasksRequest())
+    assert {t.title for t in listed_w2} == {"t2"}
+
+
+async def test_list_filters_by_assignee_and_status() -> None:
+    ctx = _ctx()
+    await tasks_service.agent_create_task(
+        ctx, CreateTaskRequest(title="agent-task", assignee=_agent_assignee("agent-a"))
+    )
+    await tasks_service.agent_create_task(
+        ctx, CreateTaskRequest(title="agent-other", assignee=_agent_assignee("agent-b"))
+    )
+    await tasks_service.agent_create_task(
+        ctx, CreateTaskRequest(title="human-task", assignee=_human_assignee("u-jess"))
+    )
+
+    only_agent_a = await tasks_service.agent_list_tasks(
+        ctx, ListTasksRequest(assignee_id="agent-a")
+    )
+    assert [t.title for t in only_agent_a] == ["agent-task"]
+
+    only_proposed = await tasks_service.agent_list_tasks(ctx, ListTasksRequest(status="proposed"))
+    assert {t.title for t in only_proposed} == {"agent-task", "agent-other"}
+
+    only_human = await tasks_service.agent_list_tasks(ctx, ListTasksRequest(assignee_kind="human"))
+    assert [t.title for t in only_human] == ["human-task"]
+
+
+async def test_get_tenancy_isolation() -> None:
+    created = await tasks_service.agent_create_task(
+        _ctx(workspace_id="w1"),
+        CreateTaskRequest(title="secret", assignee=_human_assignee()),
+    )
+    # Same task id, different workspace context → NotFound (not Forbidden).
+    with pytest.raises(NotFound):
+        await tasks_service.agent_get_task(_ctx(workspace_id="w2"), created.id)
+
+
+async def test_get_returns_full_shape() -> None:
+    created = await tasks_service.agent_create_task(
+        _ctx(),
+        CreateTaskRequest(title="t", summary="s", assignee=_human_assignee()),
+    )
+    fetched = await tasks_service.agent_get_task(_ctx(), created.id)
+    assert fetched.id == created.id
+    assert fetched.title == "t"
+    assert fetched.summary == "s"
+
+
+# ---------------------------------------------------------------------------
+# Update
+# ---------------------------------------------------------------------------
+
+
+async def test_update_patches_only_provided_fields(recording_bus) -> None:
+    created = await tasks_service.agent_create_task(
+        _ctx(),
+        CreateTaskRequest(
+            title="old",
+            summary="old",
+            priority="normal",
+            assignee=_human_assignee(),
+        ),
+    )
+    recording_bus.events.clear()
+    updated = await tasks_service.agent_update_task(
+        _ctx(),
+        created.id,
+        UpdateTaskRequest(title="new", priority="urgent"),
+    )
+    assert updated.title == "new"
+    assert updated.summary == "old"  # untouched
+    assert updated.priority == "urgent"
+    assert any(isinstance(e, TaskUpdated) for e in recording_bus.events)
+
+
+async def test_update_denies_other_workspace_member() -> None:
+    created = await tasks_service.agent_create_task(
+        _ctx(user_id="creator"),
+        CreateTaskRequest(title="x", assignee=_human_assignee("assignee")),
+    )
+    with pytest.raises(Forbidden):
+        await tasks_service.agent_update_task(
+            _ctx(user_id="random-stranger"),
+            created.id,
+            UpdateTaskRequest(title="hijack"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# State machine
+# ---------------------------------------------------------------------------
+
+
+async def test_complete_archive_flips_to_done(recording_bus) -> None:
+    created = await tasks_service.agent_create_task(
+        _ctx(), CreateTaskRequest(title="t", assignee=_human_assignee())
+    )
+    recording_bus.events.clear()
+    resp = await tasks_service.agent_complete_task(
+        _ctx(), created.id, CompleteTaskRequest(next_action="archive")
+    )
+    assert resp.status == "done"
+    assert any(isinstance(e, TaskResolved) for e in recording_bus.events)
+
+
+async def test_complete_request_approval_routes_to_awaiting_approval() -> None:
+    created = await tasks_service.agent_create_task(
+        _ctx(), CreateTaskRequest(title="t", assignee=_agent_assignee())
+    )
+    resp = await tasks_service.agent_complete_task(
+        _ctx(),
+        created.id,
+        CompleteTaskRequest(next_action="request_approval", result_summary="draft attached"),
+    )
+    assert resp.status == "awaiting_approval"
+    assert "draft attached" in resp.summary
+
+
+async def test_complete_rejects_terminal_state() -> None:
+    created = await tasks_service.agent_create_task(
+        _ctx(), CreateTaskRequest(title="t", assignee=_human_assignee())
+    )
+    await tasks_service.agent_complete_task(
+        _ctx(), created.id, CompleteTaskRequest(next_action="archive")
+    )
+    with pytest.raises(ValidationError):
+        await tasks_service.agent_complete_task(
+            _ctx(), created.id, CompleteTaskRequest(next_action="archive")
+        )
+
+
+async def test_block_records_reason_and_emits(recording_bus) -> None:
+    created = await tasks_service.agent_create_task(
+        _ctx(), CreateTaskRequest(title="t", assignee=_agent_assignee())
+    )
+    recording_bus.events.clear()
+    resp = await tasks_service.agent_block_task(
+        _ctx(), created.id, BlockTaskRequest(reason="waiting on vendor confirm")
+    )
+    assert resp.status == "blocked"
+    assert resp.blocked_reason == "waiting on vendor confirm"
+    assert any(isinstance(e, TaskBlocked) for e in recording_bus.events)
+
+
+async def test_reassign_changes_assignee_polymorphically(recording_bus) -> None:
+    created = await tasks_service.agent_create_task(
+        _ctx(), CreateTaskRequest(title="t", assignee=_human_assignee("u-shawn", "Shawn"))
+    )
+    recording_bus.events.clear()
+    resp = await tasks_service.agent_reassign_task(
+        _ctx(),
+        created.id,
+        ReassignTaskRequest(
+            assignee_kind="agent",
+            assignee_id="agent-events",
+            assignee_name="events-agent",
+        ),
+    )
+    assert resp.assignee.kind == "agent"
+    assert resp.assignee.id == "agent-events"
+    assert resp.assignee.name == "events-agent"
+    assert any(isinstance(e, TaskUpdated) for e in recording_bus.events)
+
+
+# ---------------------------------------------------------------------------
+# list_for_agent_runtime — MCP tool surface
+# ---------------------------------------------------------------------------
+
+
+async def test_list_for_agent_runtime_filters_to_agent_id() -> None:
+    ctx = _ctx()
+    await tasks_service.agent_create_task(
+        ctx, CreateTaskRequest(title="mine", assignee=_agent_assignee("agent-a"))
+    )
+    await tasks_service.agent_create_task(
+        ctx, CreateTaskRequest(title="other", assignee=_agent_assignee("agent-b"))
+    )
+    await tasks_service.agent_create_task(
+        ctx, CreateTaskRequest(title="human", assignee=_human_assignee())
+    )
+    mine = await tasks_service.list_for_agent_runtime(workspace_id="w1", agent_id="agent-a")
+    assert [t.title for t in mine] == ["mine"]
+
+
+async def test_list_for_agent_runtime_status_filter() -> None:
+    ctx = _ctx()
+    await tasks_service.agent_create_task(
+        ctx, CreateTaskRequest(title="proposed", assignee=_agent_assignee("agent-a"))
+    )
+    # Mock an already-claimed one by creating then claiming
+    created = await tasks_service.agent_create_task(
+        ctx,
+        CreateTaskRequest(title="in-progress", assignee=_agent_assignee("agent-a")),
+    )
+    from ee.cloud.tasks.dto import ClaimTaskRequest
+
+    result = await tasks_service.agent_claim_task(
+        ctx, created.id, ClaimTaskRequest(agent_id="agent-a")
+    )
+    assert result["ok"] is True
+
+    proposed = await tasks_service.list_for_agent_runtime(
+        workspace_id="w1", agent_id="agent-a", status="proposed"
+    )
+    assert {t.title for t in proposed} == {"proposed"}
+
+    in_progress = await tasks_service.list_for_agent_runtime(
+        workspace_id="w1", agent_id="agent-a", status="in_progress"
+    )
+    assert {t.title for t in in_progress} == {"in-progress"}

--- a/tests/test_mcp_claude_sdk.py
+++ b/tests/test_mcp_claude_sdk.py
@@ -10,6 +10,7 @@ from ee.agent.pocket_specialist.mcp_tool import (
 )
 from pocketpaw.agents.claude_sdk import ClaudeAgentSDK
 from pocketpaw.agents.sdk_mcp_pocket import SERVER_NAME as _POCKET_MCP_SERVER_NAME
+from pocketpaw.agents.sdk_mcp_tasks import SERVER_NAME as _TASKS_MCP_SERVER_NAME
 from pocketpaw.config import Settings
 from pocketpaw.mcp.config import MCPServerConfig
 
@@ -19,6 +20,7 @@ def _strip_builtin_servers(result: dict) -> dict:
     out = dict(result)
     out.pop(_POCKET_MCP_SERVER_NAME, None)
     out.pop(_POCKET_SPECIALIST_MCP_SERVER_NAME, None)
+    out.pop(_TASKS_MCP_SERVER_NAME, None)
     return out
 
 


### PR DESCRIPTION
## Summary

PR 2 of 3 for Mission Control's backend. Adds the **Tasks entity** at `ee/cloud/tasks/` — the unified work-item primitive that wraps Nudges, agent tasks, and Pawprint projections with polymorphic assignees (human or agent). Plus an agent-side **`claim_task`** MCP tool surface so agent runtimes can pick up Tasks routed to them through Mission Control's create form.

This is the load-bearing new entity in the audit doc. Most of Mission Control's UI hinges on it.

## What's in it

- **`ee/cloud/tasks/`** — full 4-file shape (`domain.py + dto.py + service.py + router.py`), with module-level `async def` service API, `ctx: RequestContext` signatures, validate-at-entry, emit-on-every-write, no `HTTPException` in services.
- **`ee/cloud/models/task.py`** — Beanie document. Indexes back `(workspace_id, assignee_id, status)` and `(workspace_id, cycle_id)`.
- **State-machine verbs as dedicated routes** — `claim`, `complete`, `block`, `reassign`. Status transitions never come through `PATCH /tasks/{id}` so the audit surface stays precise.
- **Optimistic single-writer claim** — `find_one_and_update` on `(_id, workspace_id, status='proposed', assignee_id)`. First agent wins. The loser receives `{ok: False, reason: 'already_claimed'}`. No transaction needed.
- **Nudge ≡ Task with `status='awaiting_approval'`** — not a separate entity. The `request_approval` complete path puts a task into that state so it surfaces in the creator's Tray.
- **Agent MCP surface** — new `src/pocketpaw/agents/sdk_mcp_tasks.py` exposing `list_my_tasks`, `claim_task`, `complete_task`. Wired into the Claude Agent SDK backend the same way `sdk_mcp_pocket` is — auto-registered, tool ids allowlisted.
- **Notifications fan-out** — `ee/cloud/tasks/listeners.py` subscribes to `task.proposed` and creates a `task_assigned` notification when the assignee is human. Agent assignees are skipped (they poll their own queue).
- **Realtime events** — `task.proposed`, `task.updated`, `task.claimed`, `task.resolved`, `task.blocked` added to `ee/cloud/_core/realtime/events.py` and emitted on every write.
- **Import-linter contract** — `ee.cloud.models.task` reachable only from `ee.cloud.tasks.service`. All 10 contracts kept.

## Files

- `ee/cloud/models/task.py` — Beanie doc + embedded `TaskAssignee` / `TaskSource`.
- `ee/cloud/tasks/{domain,dto,service,router,listeners,__init__}.py`
- `ee/cloud/_core/realtime/events.py` — 5 new `Task*` event classes.
- `ee/cloud/__init__.py` — mount the router, register the listener.
- `ee/cloud/models/__init__.py` — register the doc with Beanie's init list.
- `src/pocketpaw/agents/sdk_mcp_tasks.py` — in-process MCP server.
- `src/pocketpaw/agents/claude_sdk.py` — wire the new MCP server + allowlist.
- `pyproject.toml` — import-linter Tasks contract.
- `tests/cloud/tasks/test_tasks_service.py` (17 tests)
- `tests/cloud/tasks/test_tasks_router.py` (13 tests)
- `tests/cloud/tasks/test_tasks_claim_optimistic.py` (7 tests — race coverage including 10-way `asyncio.gather`)
- `tests/cloud/tasks/test_tasks_notification_fanout.py` (4 tests — human vs agent routing)

## Test plan

- [x] `uv run pytest tests/cloud/tasks/` — 41 passed
- [x] `uv run pytest tests/cloud/notifications/ tests/cloud/sessions/ tests/cloud/tasks/` — 86 passed (no regression)
- [x] `uv run lint-imports` — 10 contracts kept, 0 broken (Tasks contract live)
- [x] `uv run ruff check` / `ruff format --check` — clean on new files
- [x] Full `tests/cloud/` — 1895 passed; 56 failures are pre-existing on `ee` (uploads/folders/download_url + pocket-prompt-state — confirmed by stash-reset baseline run)

## How it composes with the other two PRs

- **PR 1 (Mission Control façade)** — when it lands, `ee/cloud/mission_control/service.py` will compose this entity via `tasks_service.agent_list_tasks(ctx, body)` for the unified WorkItem feed. The DTO shape is already aligned (assignee polymorphism, status enum, source discriminator) so the façade is pure projection — no schema migration on either side.
- **PR 3 (Cycles)** — Tasks already carry an optional `cycle_id` field. When the Cycles entity lands, the existing `agent_list_tasks` `cycle_id` filter feeds the burnup chart. Tasks created without a `cycle_id` continue to work; no migration required.

## Decisions baked in

- **Claim contention** — optimistic single-writer via `find_one_and_update`. Confirmed in `test_two_simultaneous_claims_only_one_succeeds` and a 10-way `test_many_concurrent_claims_only_one_wins` stress.
- **Cycle assignment optional** — `cycle_id?` on the domain; tasks without one are first-class.
- **Nudge ≡ Task** — no separate entity. The unified-feed design called for this and the audit doc confirmed.
- **`200 + {ok: False, reason}` on claim losses** — the agent runtime treats this as a polling race, not an exceptional error. The body carries the typed reason (`already_claimed`, `not_assigned_to_agent`, `not_found`) so the agent can decide whether to retry or move on.

## Out of scope

- Cycles entity (PR 3) — Tasks can reference `cycle_id` but no entity exists yet.
- Mission Control façade (PR 1) — landing in parallel.
- Frontend wiring — separate `paw-enterprise` PR after both backend PRs merge.

**Do not merge.** Captain reviews before any Mission Control PR ships.