### PR TITLE
feat(cycles): time-boxed work windows + daily burnup snapshot

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -1,5 +1,10 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Updated: 2026-05-13 — Mission Control PR 3. Mounts the Cycles router on
+    ``mount_cloud()``. The Cycles daily-snapshot job lives at
+    ``ee.cloud.cycles.snapshot_job`` and is invoked by the host platform's
+    scheduler (cron / Kubernetes CronJob / Celery beat) rather than wired
+    as an in-process loop — see that module's docstring for rationale.
 Updated: 2026-04-30 — Stage 1.B of "Files as Knowledge". Wires
     ``register_upload_listeners`` into ``mount_cloud`` so the FileReady
     bus subscriber drives KB indexing for every workspace upload.
@@ -10,7 +15,7 @@ Updated: 2026-04-19 (Cluster B) — Added pocket journal SSE stream router to
     mount_cloud() — feeds the RippleGraphWidget with a live, pocket-scoped
     slice of the org journal.
 
-Domains: auth, workspace, chat, pockets, sessions, agents, kb, knowledge.
+Domains: auth, workspace, chat, pockets, sessions, agents, kb, knowledge, cycles.
 Each has router.py (thin), service.py (logic), schemas.py (validation).
 """
 
@@ -73,6 +78,7 @@ def mount_cloud(app: FastAPI) -> None:
     from ee.cloud.auth.router import router as auth_router
     from ee.cloud.chat.router import router as chat_router
     from ee.cloud.connectors.router import router as connectors_router
+    from ee.cloud.cycles.router import router as cycles_router
     from ee.cloud.license import get_license_info
     from ee.cloud.pockets.router import router as pockets_router
     from ee.cloud.sessions.router import router as sessions_router
@@ -85,6 +91,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(connectors_router, prefix="/api/v1")
     app.include_router(pockets_router, prefix="/api/v1")
     app.include_router(sessions_router, prefix="/api/v1")
+    app.include_router(cycles_router, prefix="/api/v1")
 
     # Phase 1 PR-8: register the connector bus listener so local-mode
     # CLI actions (firebase, gcp, …) get picked up by the in-process

--- a/ee/cloud/_core/realtime/events.py
+++ b/ee/cloud/_core/realtime/events.py
@@ -313,3 +313,28 @@ class NotificationRead(Event):
 @dataclass
 class NotificationCleared(Event):
     EVENT_TYPE: ClassVar[str] = "notification.cleared"
+
+
+# Cycles — Mission Control time-boxed work windows.
+# The daily-snapshot job (``ee.cloud.cycles.snapshot_job``) emits
+# ``CycleSnapshotted`` after appending a new point to a cycle's daily
+# series; the frontend's burnup chart subscribes and patches the active
+# cycle without a full refetch.
+@dataclass
+class CycleCreated(Event):
+    EVENT_TYPE: ClassVar[str] = "cycle.created"
+
+
+@dataclass
+class CycleUpdated(Event):
+    EVENT_TYPE: ClassVar[str] = "cycle.updated"
+
+
+@dataclass
+class CycleClosed(Event):
+    EVENT_TYPE: ClassVar[str] = "cycle.closed"
+
+
+@dataclass
+class CycleSnapshotted(Event):
+    EVENT_TYPE: ClassVar[str] = "cycle.snapshotted"

--- a/ee/cloud/cycles/__init__.py
+++ b/ee/cloud/cycles/__init__.py
@@ -1,0 +1,8 @@
+"""Cycles domain — time-boxed work windows for Mission Control.
+
+PR 3 of 3 for the Mission Control backend. Houses the 4-file shape
+(``domain.py + dto.py + service.py + router.py``) plus the daily-snapshot
+job that feeds the burnup chart in the paw-enterprise Cycles tab.
+"""
+
+from ee.cloud.cycles.router import router  # noqa: F401

--- a/ee/cloud/cycles/domain.py
+++ b/ee/cloud/cycles/domain.py
@@ -1,0 +1,69 @@
+"""Cycles domain — frozen value objects.
+
+Pure Python dataclasses, no Beanie / Pydantic / FastAPI imports. The
+service maps between these and the ``Cycle`` Beanie document; the DTO
+layer maps these to Pydantic responses.
+
+Multi-tenancy is enforced at construction: ``workspace_id`` is required
+positionally with no default — building a ``Cycle`` without one is a type
+error. Same rule as the rest of ``ee/cloud``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Literal
+
+CycleStatus = Literal["active", "upcoming", "completed"]
+
+
+@dataclass(frozen=True)
+class CycleDailyPoint:
+    """One day's snapshot of cycle counters.
+
+    Captured by the daily snapshot job. ``is_weekend`` is recorded at
+    snapshot time so the burnup chart can flatten the ideal target line
+    over weekends without a calendar round-trip on read.
+    """
+
+    date: date
+    scope: int = 0
+    started: int = 0
+    completed: int = 0
+    is_weekend: bool = False
+
+
+@dataclass(frozen=True)
+class Cycle:
+    """Cycle value object — a time-boxed work window inside a workspace.
+
+    ``pocket_id`` is optional: a cycle can span multiple pockets (an
+    engagement may pull on multiple ops surfaces). When set, the cycle is
+    primarily filtered against that pocket; tasks across other pockets in
+    the same workspace can still attach via ``cycle_id`` on the task.
+
+    Counters (``scope`` / ``started`` / ``completed``) are denormalized
+    for cheap list reads. The detail endpoint refreshes them from Tasks
+    at fetch time; the snapshot job captures historical values into
+    ``daily``.
+    """
+
+    id: str
+    workspace_id: str
+    name: str
+    description: str
+    pocket_id: str | None
+    start: date
+    end: date
+    status: CycleStatus
+    scope: int = 0
+    started: int = 0
+    completed: int = 0
+    daily: tuple[CycleDailyPoint, ...] = field(default_factory=tuple)
+    created_by: str = ""
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+__all__ = ["Cycle", "CycleDailyPoint", "CycleStatus"]

--- a/ee/cloud/cycles/dto.py
+++ b/ee/cloud/cycles/dto.py
@@ -1,0 +1,128 @@
+"""Cycles domain — request and response schemas.
+
+Pydantic models that cross the HTTP boundary. Distinct Request and
+Response shapes per the ee/cloud rule — never reuse a model for input
+and output (fields leak silently).
+
+Domain → DTO mapping lives in ``service.py`` as private helpers. The
+``Response`` shapes here are deliberately denormalized into wire-friendly
+ISO strings so the frontend doesn't have to parse timezones.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+CycleStatusLiteral = Literal["active", "upcoming", "completed"]
+
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class CreateCycleRequest(BaseModel):
+    """Body for ``POST /cycles``.
+
+    ``status`` defaults to ``upcoming``; the service promotes a cycle to
+    ``active`` only when explicitly created with that status (and the
+    overlap rule passes) or via the snapshot job once ``start`` arrives.
+    """
+
+    name: str = Field(min_length=1, max_length=200)
+    description: str = ""
+    pocket_id: str | None = None
+    start: date
+    end: date
+    status: CycleStatusLiteral = "upcoming"
+
+    @model_validator(mode="after")
+    def _check_dates(self) -> CreateCycleRequest:
+        if self.start >= self.end:
+            raise ValueError("cycle.invalid_range: start must be before end")
+        return self
+
+
+class UpdateCycleRequest(BaseModel):
+    """Body for ``PATCH /cycles/{id}``.
+
+    Per spec only ``upcoming`` cycles can have their name / description /
+    dates edited — the router enforces the status check via the service.
+    Status transitions go through ``POST /cycles/{id}/close`` (or the
+    snapshot job's auto-promote) rather than this PATCH endpoint.
+    """
+
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+    start: date | None = None
+    end: date | None = None
+
+    @model_validator(mode="after")
+    def _check_dates(self) -> UpdateCycleRequest:
+        if self.start is not None and self.end is not None and self.start >= self.end:
+            raise ValueError("cycle.invalid_range: start must be before end")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class CycleDailyPointResponse(BaseModel):
+    """One point on the burnup chart's daily series."""
+
+    date: str  # ISO date — "2026-05-13"
+    scope: int
+    started: int
+    completed: int
+    is_weekend: bool
+
+
+class CycleListItemResponse(BaseModel):
+    """Lighter shape for ``GET /cycles`` (no daily series).
+
+    The Cycles tab's left list renders dozens of these — keeping the
+    daily array off the wire here is a ~10x payload reduction per row on
+    a long engagement (90+ snapshot points).
+    """
+
+    id: str
+    workspace_id: str
+    name: str
+    description: str
+    pocket_id: str | None
+    start: str  # ISO date
+    end: str  # ISO date
+    status: CycleStatusLiteral
+    scope: int
+    started: int
+    completed: int
+    created_by: str
+    created_at: str | None
+    updated_at: str | None
+
+
+class CycleResponse(CycleListItemResponse):
+    """Full cycle detail including the daily snapshot series.
+
+    ``GET /cycles/{id}`` returns this; the burnup chart consumes
+    ``daily`` directly. The base fields are inherited from
+    ``CycleListItemResponse`` to keep the shape consistent across the
+    two endpoints — any new metadata added to one shows up on both.
+    """
+
+    daily: list[CycleDailyPointResponse] = Field(default_factory=list)
+
+
+__all__ = [
+    "CreateCycleRequest",
+    "CycleDailyPointResponse",
+    "CycleListItemResponse",
+    "CycleResponse",
+    "CycleStatusLiteral",
+    "UpdateCycleRequest",
+]

--- a/ee/cloud/cycles/router.py
+++ b/ee/cloud/cycles/router.py
@@ -1,0 +1,80 @@
+"""Cycles domain — FastAPI router.
+
+Thin shell over ``ee.cloud.cycles.service``: parses requests, delegates,
+returns DTOs. License gate + canonical ``request_context`` dependency on
+every route — services never see raw ``Request`` objects.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from ee.cloud._core.context import RequestContext, request_context
+from ee.cloud.cycles import service as cycles_service
+from ee.cloud.cycles.dto import (
+    CreateCycleRequest,
+    CycleListItemResponse,
+    CycleResponse,
+    UpdateCycleRequest,
+)
+from ee.cloud.license import require_license
+
+router = APIRouter(prefix="/cycles", tags=["Cycles"], dependencies=[Depends(require_license)])
+
+
+@router.post("", response_model=CycleResponse)
+async def create_cycle(
+    body: CreateCycleRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> CycleResponse:
+    return await cycles_service.agent_create_cycle(ctx, body)
+
+
+@router.get("", response_model=list[CycleListItemResponse])
+async def list_cycles(
+    ctx: RequestContext = Depends(request_context),
+) -> list[CycleListItemResponse]:
+    return await cycles_service.agent_list_cycles(ctx)
+
+
+@router.get("/{cycle_id}", response_model=CycleResponse)
+async def get_cycle(
+    cycle_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> CycleResponse:
+    return await cycles_service.agent_get_cycle(ctx, cycle_id)
+
+
+@router.patch("/{cycle_id}", response_model=CycleResponse)
+async def update_cycle(
+    cycle_id: str,
+    body: UpdateCycleRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> CycleResponse:
+    return await cycles_service.agent_update_cycle(ctx, cycle_id, body)
+
+
+@router.post("/{cycle_id}/close", response_model=CycleResponse)
+async def close_cycle(
+    cycle_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> CycleResponse:
+    return await cycles_service.agent_close_cycle(ctx, cycle_id)
+
+
+@router.get("/{cycle_id}/items")
+async def list_cycle_items(
+    cycle_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> list[Any]:
+    """Return tasks attached to this cycle.
+
+    Falls back to ``[]`` when the Tasks entity (PR 2 of the Mission Control
+    series) isn't merged into this branch's ``ee`` snapshot. The wire shape
+    matches whatever ``ee.cloud.tasks.service.agent_list_tasks`` returns,
+    so the frontend's existing TaskResponse handling passes through
+    unchanged once PR 2 ships.
+    """
+    return await cycles_service.agent_list_cycle_items(ctx, cycle_id)

--- a/ee/cloud/cycles/service.py
+++ b/ee/cloud/cycles/service.py
@@ -1,0 +1,573 @@
+"""Cycles domain — business logic service.
+
+Sole owner of writes to the ``Cycle`` Beanie document. Module-level
+``async def`` functions, ``ctx: RequestContext`` first, validate-at-entry,
+emit-on-every-write.
+
+Composition with the Tasks entity (``ee.cloud.tasks.service``) is via lazy
+import — that entity ships in PR 2 of the Mission Control series and may
+not be merged onto whichever ``ee`` snapshot this branch was cut from.
+When tasks isn't importable, the relevant methods (item list, counter
+refresh, snapshot job) gracefully degrade rather than crashing the cycles
+endpoints. The same lazy-import gate is exercised in tests.
+
+Public API:
+- ``agent_create_cycle(ctx, body)``
+- ``agent_list_cycles(ctx)``
+- ``agent_get_cycle(ctx, cycle_id)``
+- ``agent_update_cycle(ctx, cycle_id, body)``
+- ``agent_close_cycle(ctx, cycle_id)``
+- ``agent_list_cycle_items(ctx, cycle_id)``
+
+Internal:
+- ``_snapshot_cycle_daily(ctx, cycle_id)`` — idempotent within a day.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, date, datetime
+from typing import Any
+
+from beanie import PydanticObjectId
+
+from ee.cloud._core.context import RequestContext
+from ee.cloud._core.errors import ConflictError, Forbidden, NotFound, ValidationError
+from ee.cloud._core.realtime.emit import emit
+from ee.cloud._core.realtime.events import (
+    CycleClosed,
+    CycleCreated,
+    CycleSnapshotted,
+    CycleUpdated,
+)
+from ee.cloud._core.time import iso_utc
+from ee.cloud.cycles.domain import Cycle, CycleDailyPoint
+from ee.cloud.cycles.dto import (
+    CreateCycleRequest,
+    CycleDailyPointResponse,
+    CycleListItemResponse,
+    CycleResponse,
+    UpdateCycleRequest,
+)
+from ee.cloud.models.cycle import Cycle as _CycleDoc
+from ee.cloud.models.cycle import CycleDailyPoint as _CycleDailyPointDoc
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Private mapping helpers
+# ---------------------------------------------------------------------------
+
+
+def _daily_to_domain(p: _CycleDailyPointDoc) -> CycleDailyPoint:
+    return CycleDailyPoint(
+        date=p.date,
+        scope=p.scope,
+        started=p.started,
+        completed=p.completed,
+        is_weekend=p.is_weekend,
+    )
+
+
+def _to_domain(doc: _CycleDoc) -> Cycle:
+    return Cycle(
+        id=str(doc.id),
+        workspace_id=doc.workspace,
+        name=doc.name,
+        description=doc.description,
+        pocket_id=doc.pocket_id,
+        start=doc.start,
+        end=doc.end,
+        status=doc.status,  # type: ignore[arg-type]
+        scope=doc.scope,
+        started=doc.started,
+        completed=doc.completed,
+        daily=tuple(_daily_to_domain(p) for p in doc.daily),
+        created_by=doc.created_by,
+        created_at=getattr(doc, "createdAt", None),
+        updated_at=getattr(doc, "updatedAt", None),
+    )
+
+
+def _date_str(d: date | None) -> str | None:
+    return d.isoformat() if d is not None else None
+
+
+def _daily_to_dto(p: CycleDailyPoint) -> CycleDailyPointResponse:
+    return CycleDailyPointResponse(
+        date=p.date.isoformat(),
+        scope=p.scope,
+        started=p.started,
+        completed=p.completed,
+        is_weekend=p.is_weekend,
+    )
+
+
+def _to_list_response(c: Cycle) -> CycleListItemResponse:
+    return CycleListItemResponse(
+        id=c.id,
+        workspace_id=c.workspace_id,
+        name=c.name,
+        description=c.description,
+        pocket_id=c.pocket_id,
+        start=c.start.isoformat(),
+        end=c.end.isoformat(),
+        status=c.status,
+        scope=c.scope,
+        started=c.started,
+        completed=c.completed,
+        created_by=c.created_by,
+        created_at=iso_utc(c.created_at),
+        updated_at=iso_utc(c.updated_at),
+    )
+
+
+def _to_response(c: Cycle) -> CycleResponse:
+    base = _to_list_response(c)
+    return CycleResponse(
+        **base.model_dump(),
+        daily=[_daily_to_dto(p) for p in c.daily],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tenancy + access helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_workspace(ctx: RequestContext) -> str:
+    """Cycles always operate in a workspace; routes that bypass an active
+    workspace should never reach the service. Raise a Forbidden so the
+    caller gets a clean 403 rather than a 500."""
+    if not ctx.workspace_id:
+        raise Forbidden("cycle.no_workspace", "Active workspace required for cycle operations")
+    return ctx.workspace_id
+
+
+async def _fetch_in_workspace(workspace_id: str, cycle_id: str) -> _CycleDoc:
+    """Fetch a cycle scoped to the caller's workspace; raise NotFound if
+    the id is malformed, the doc is missing, or it lives in another
+    workspace (so we don't leak existence across tenants)."""
+    try:
+        oid = PydanticObjectId(cycle_id)
+    except Exception:
+        raise NotFound("cycle", cycle_id) from None
+    doc = await _CycleDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        raise NotFound("cycle", cycle_id)
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Tasks composition — lazy import
+# ---------------------------------------------------------------------------
+
+
+async def _tasks_for_cycle(ctx: RequestContext, cycle_id: str) -> list[Any] | None:
+    """Return the list of tasks attached to a cycle, or ``None`` when the
+    Tasks entity isn't available on this branch.
+
+    The cycles entity composes with ``ee.cloud.tasks.service.agent_list_tasks``
+    once PR 2 of the Mission Control series lands. Until then we lazy-import
+    inside this helper and degrade silently — the 4-file rule forbids
+    inlining a Beanie query against the Tasks collection from here, so the
+    fallback is "no data" rather than "wrong data".
+    """
+    try:
+        from ee.cloud.tasks import service as tasks_service
+        from ee.cloud.tasks.dto import ListTasksRequest
+    except Exception:
+        logger.debug(
+            "cycles: tasks entity not available; returning None for cycle %s items",
+            cycle_id,
+        )
+        return None
+
+    try:
+        body = ListTasksRequest(cycle_id=cycle_id)  # type: ignore[call-arg]
+        return await tasks_service.agent_list_tasks(ctx, body)  # type: ignore[attr-defined]
+    except Exception:
+        logger.warning(
+            "cycles: tasks.agent_list_tasks failed for cycle %s; treating as empty",
+            cycle_id,
+            exc_info=True,
+        )
+        return None
+
+
+def _counters_from_tasks(tasks: list[Any]) -> tuple[int, int, int]:
+    """Project (scope, started, completed) from a tasks list.
+
+    Tasks status vocabulary lives in PR 2; we use the documented values from
+    the audit doc: ``proposed | in_progress | done | blocked | failed`` (the
+    last three are terminal). "Started" is anything past ``proposed``;
+    "completed" is ``done`` only. Anything else counts towards scope only.
+    """
+    scope = len(tasks)
+    started = 0
+    completed = 0
+    for t in tasks:
+        status = getattr(t, "status", None) or (t.get("status") if isinstance(t, dict) else None)
+        if status in ("in_progress", "done", "blocked", "failed"):
+            started += 1
+        if status == "done":
+            completed += 1
+    return scope, started, completed
+
+
+# ---------------------------------------------------------------------------
+# Overlap check
+# ---------------------------------------------------------------------------
+
+
+async def _has_active_overlap(
+    workspace_id: str,
+    pocket_id: str | None,
+    start: date,
+    end: date,
+    exclude_id: str | None = None,
+) -> bool:
+    """Return True if another active cycle on the same pocket overlaps the
+    proposed range.
+
+    Decision (v1): we only block overlap on the **same pocket** — workspaces
+    routinely have multiple engagements in flight on different pockets at
+    the same time. Cycles with no ``pocket_id`` collide only with other
+    no-pocket cycles. Relaxing the rule entirely (allow any overlap) is
+    tracked as a follow-up if operators push back.
+    """
+    query: dict[str, Any] = {
+        "workspace": workspace_id,
+        "status": "active",
+        "pocket_id": pocket_id,
+    }
+    if exclude_id is not None:
+        try:
+            query["_id"] = {"$ne": PydanticObjectId(exclude_id)}
+        except Exception:
+            pass
+    async for doc in _CycleDoc.find(query):
+        # Two ranges [a, b] and [c, d] overlap iff a <= d and c <= b.
+        if doc.start <= end and start <= doc.end:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Public service API
+# ---------------------------------------------------------------------------
+
+
+async def agent_create_cycle(ctx: RequestContext, body: CreateCycleRequest) -> CycleResponse:
+    """Create a new cycle in the caller's workspace.
+
+    Validates dates (start < end via the DTO model_validator) and rejects
+    overlap with another active cycle on the same pocket. The cycle is
+    persisted with denormalized counters at zero and an empty daily series;
+    the first call to ``agent_get_cycle`` / ``_snapshot_cycle_daily`` after
+    Tasks are attached will populate them.
+    """
+    body = CreateCycleRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+
+    if body.status == "active" and await _has_active_overlap(
+        workspace_id, body.pocket_id, body.start, body.end
+    ):
+        raise ConflictError(
+            "cycle.overlap",
+            "Another active cycle on the same pocket overlaps this date range",
+        )
+
+    doc = _CycleDoc(
+        workspace=workspace_id,
+        name=body.name,
+        description=body.description,
+        pocket_id=body.pocket_id,
+        start=body.start,
+        end=body.end,
+        status=body.status,
+        created_by=ctx.user_id,
+    )
+    await doc.insert()
+
+    response = _to_response(_to_domain(doc))
+    await emit(CycleCreated(data=response.model_dump()))
+    return response
+
+
+async def agent_list_cycles(ctx: RequestContext) -> list[CycleListItemResponse]:
+    """List cycles in the caller's workspace.
+
+    Sorted by status (active → upcoming → completed) then ``start`` date
+    descending — the Mission Control left list expects active engagements
+    on top, then upcoming, then the historical archive most-recent-first.
+    """
+    workspace_id = _require_workspace(ctx)
+    docs = await _CycleDoc.find({"workspace": workspace_id}).to_list()
+    domains = [_to_domain(d) for d in docs]
+
+    status_rank = {"active": 0, "upcoming": 1, "completed": 2}
+    domains.sort(key=lambda c: (status_rank.get(c.status, 9), -c.start.toordinal()))
+    return [_to_list_response(c) for c in domains]
+
+
+async def agent_get_cycle(ctx: RequestContext, cycle_id: str) -> CycleResponse:
+    """Fetch a single cycle with its full daily series.
+
+    Refreshes the denormalized counters from the Tasks collection at read
+    time so the detail panel reflects the latest state. The persisted
+    counters are still useful for cheap list reads — the freshness gap
+    closes whenever this endpoint is called.
+    """
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_in_workspace(workspace_id, cycle_id)
+
+    tasks = await _tasks_for_cycle(ctx, str(doc.id))
+    if tasks is not None:
+        scope, started, completed = _counters_from_tasks(tasks)
+        if (doc.scope, doc.started, doc.completed) != (scope, started, completed):
+            doc.scope = scope
+            doc.started = started
+            doc.completed = completed
+            await doc.save()
+
+    return _to_response(_to_domain(doc))
+
+
+async def agent_update_cycle(
+    ctx: RequestContext, cycle_id: str, body: UpdateCycleRequest
+) -> CycleResponse:
+    """Patch ``name``, ``description``, or ``start`` / ``end`` dates.
+
+    Editable only while the cycle is ``upcoming`` — once a cycle goes
+    active, its boundaries are part of the historical record. Status
+    transitions go through ``agent_close_cycle`` instead.
+    """
+    body = UpdateCycleRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_in_workspace(workspace_id, cycle_id)
+
+    if doc.status != "upcoming":
+        raise Forbidden(
+            "cycle.not_upcoming",
+            "Only upcoming cycles can have their name, description, or dates edited",
+        )
+
+    new_start = body.start if body.start is not None else doc.start
+    new_end = body.end if body.end is not None else doc.end
+    if new_start >= new_end:
+        raise ValidationError("cycle.invalid_range", "start must be before end")
+
+    if body.name is not None:
+        doc.name = body.name
+    if body.description is not None:
+        doc.description = body.description
+    if body.start is not None:
+        doc.start = body.start
+    if body.end is not None:
+        doc.end = body.end
+    await doc.save()
+
+    response = _to_response(_to_domain(doc))
+    await emit(CycleUpdated(data=response.model_dump()))
+    return response
+
+
+async def agent_close_cycle(ctx: RequestContext, cycle_id: str) -> CycleResponse:
+    """Mark a cycle ``completed`` and roll incomplete tasks forward.
+
+    Matches Linear's behavior: every Task with ``cycle_id == this`` and
+    ``status != done`` is reassigned to the next active cycle on the same
+    pocket (if any); otherwise the task's ``cycle_id`` is cleared so it
+    surfaces back in the unscheduled list.
+
+    Rolling is a no-op when the Tasks entity isn't available on the branch —
+    the cycle still closes, and the rollover runs implicitly once PR 2 is
+    merged (newly-created tasks won't pick the closed cycle as their
+    default).
+    """
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_in_workspace(workspace_id, cycle_id)
+
+    if doc.status == "completed":
+        raise ConflictError("cycle.already_closed", "This cycle is already completed")
+
+    rolled = await _roll_incomplete_tasks(ctx, doc)
+
+    doc.status = "completed"
+    await doc.save()
+
+    response = _to_response(_to_domain(doc))
+    payload = {**response.model_dump(), "rolled_count": rolled}
+    await emit(CycleClosed(data=payload))
+    return response
+
+
+async def _roll_incomplete_tasks(ctx: RequestContext, doc: _CycleDoc) -> int:
+    """Reassign incomplete tasks attached to this cycle to the next active
+    cycle on the same pocket (or clear ``cycle_id`` if none exists).
+
+    Returns the number of tasks that were rolled. Composes via
+    ``ee.cloud.tasks.service`` — degrades to 0 when Tasks isn't available.
+    """
+    tasks = await _tasks_for_cycle(ctx, str(doc.id))
+    if not tasks:
+        return 0
+
+    try:
+        from ee.cloud.tasks import service as tasks_service
+    except Exception:
+        return 0
+
+    # Pick the next active cycle on the same pocket as the rollover target.
+    # If none exists, ``next_id`` stays None and the task drops back into
+    # the unscheduled list.
+    next_id: str | None = None
+    async for candidate in _CycleDoc.find(
+        {
+            "workspace": doc.workspace,
+            "status": "active",
+            "pocket_id": doc.pocket_id,
+            "_id": {"$ne": doc.id},
+        }
+    ).sort([("start", 1)]):
+        next_id = str(candidate.id)
+        break
+
+    rolled = 0
+    for task in tasks:
+        status = getattr(task, "status", None) or (
+            task.get("status") if isinstance(task, dict) else None
+        )
+        if status == "done":
+            continue
+        task_id = getattr(task, "id", None) or (task.get("id") if isinstance(task, dict) else None)
+        if not task_id:
+            continue
+        reassign = getattr(tasks_service, "agent_reassign_task_cycle", None)
+        if reassign is None:
+            # PR 2's task service hasn't exposed the rollover method yet —
+            # log and continue so the cycle still closes cleanly.
+            logger.info(
+                "cycles.close: tasks.agent_reassign_task_cycle not yet available; skipping roll"
+            )
+            break
+        try:
+            await reassign(ctx, task_id, next_id)
+            rolled += 1
+        except Exception:
+            logger.warning(
+                "cycles.close: failed to roll task %s to cycle %s", task_id, next_id, exc_info=True
+            )
+    return rolled
+
+
+async def agent_list_cycle_items(ctx: RequestContext, cycle_id: str) -> list[Any]:
+    """Return the tasks attached to a cycle.
+
+    Composes via ``ee.cloud.tasks.service.agent_list_tasks`` and returns the
+    list directly so the frontend's existing TaskResponse shape passes
+    through unchanged. When Tasks isn't available on this branch, returns
+    ``[]`` — the Cycles tab's items list shows an empty state until PR 2
+    merges into ``ee``.
+
+    Inlining a Beanie query against the tasks collection here would violate
+    the 4-file rule (only ``tasks/service.py`` may import the Beanie task
+    document), so we accept the temporary empty state as the cost of clean
+    layering.
+    """
+    workspace_id = _require_workspace(ctx)
+    # Tenant-check by fetching the cycle — this also gives 404 on bad ids.
+    await _fetch_in_workspace(workspace_id, cycle_id)
+    tasks = await _tasks_for_cycle(ctx, cycle_id)
+    return list(tasks) if tasks is not None else []
+
+
+# ---------------------------------------------------------------------------
+# Daily snapshot — feeds the burnup chart
+# ---------------------------------------------------------------------------
+
+
+async def _snapshot_cycle_daily(
+    ctx: RequestContext, cycle_id: str, *, today: date | None = None
+) -> CycleDailyPointResponse | None:
+    """Append today's (scope, started, completed) point to a cycle's daily
+    series, or return ``None`` if today's point already exists.
+
+    Idempotent within a single calendar day. The job runs once per 24h
+    per workspace; if it runs twice (manual trigger + scheduled), the
+    second call is a no-op.
+
+    Caps the daily array at 100 entries — a cycle longer than ~14 weeks
+    is unusual but possible. Beyond the cap we downgrade to a weekly
+    cadence by only appending when the most recent point is at least 7
+    days old. Documented in the model docstring.
+
+    Returns the newly-appended point as a DTO so the snapshot job can emit
+    ``CycleSnapshotted`` with a payload the frontend's burnup chart can
+    consume directly.
+    """
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_in_workspace(workspace_id, cycle_id)
+    if doc.status == "completed":
+        return None
+
+    today = today or datetime.now(UTC).date()
+
+    # Idempotency: if today's point exists, skip.
+    if any(p.date == today for p in doc.daily):
+        return None
+
+    # Cap rule: once we hit 100 points, only append weekly thereafter.
+    if len(doc.daily) >= 100:
+        latest = max((p.date for p in doc.daily), default=None)
+        if latest is not None and (today - latest).days < 7:
+            return None
+
+    tasks = await _tasks_for_cycle(ctx, cycle_id)
+    if tasks is None:
+        # Tasks entity not available — log and bail. The cycle's daily
+        # array stays empty until PR 2 lands and the next scheduled run
+        # picks up.
+        logger.info(
+            "cycles.snapshot: tasks entity unavailable; skipping snapshot for cycle %s", cycle_id
+        )
+        return None
+
+    scope, started, completed = _counters_from_tasks(tasks)
+    point = _CycleDailyPointDoc(
+        date=today,
+        scope=scope,
+        started=started,
+        completed=completed,
+        is_weekend=today.weekday() >= 5,
+    )
+    doc.daily.append(point)
+    doc.scope = scope
+    doc.started = started
+    doc.completed = completed
+    await doc.save()
+
+    dto = _daily_to_dto(_daily_to_domain(point))
+    await emit(
+        CycleSnapshotted(
+            data={
+                "cycle_id": cycle_id,
+                "workspace_id": workspace_id,
+                "daily_point": dto.model_dump(),
+            }
+        )
+    )
+    return dto
+
+
+__all__ = [
+    "agent_close_cycle",
+    "agent_create_cycle",
+    "agent_get_cycle",
+    "agent_list_cycle_items",
+    "agent_list_cycles",
+    "agent_update_cycle",
+    "_snapshot_cycle_daily",
+]

--- a/ee/cloud/cycles/snapshot_job.py
+++ b/ee/cloud/cycles/snapshot_job.py
@@ -1,0 +1,127 @@
+"""Cycles — daily snapshot job.
+
+Captures one (scope, started, completed) data point per active cycle per
+day. The output feeds the burnup chart in the paw-enterprise Cycles tab
+(Linear-style: gray scope, blue dashed target — flattened on weekends via
+``is_weekend`` — yellow started, solid blue completed).
+
+This module ships the callable (``snapshot_all_active``) plus an optional
+``run_forever_loop`` that sleeps 24h between passes. **It does not register
+itself onto a scheduler.** Whatever cron primitive the host platform uses
+(Kubernetes CronJob, Celery beat, APScheduler, OS cron) imports this module
+and dispatches ``snapshot_all_active`` once per day per workspace. The
+``mount_cloud()`` startup hook in ``ee/cloud/__init__.py`` is the natural
+wiring point; until the platform's scheduling story converges, the captain
+wires this in deployment.
+
+When the Tasks entity (PR 2 of the Mission Control series) isn't available
+on the importing branch, the job warns and returns rather than crashing —
+the cycles entity continues to serve list / detail / close endpoints
+normally; the daily array stays empty.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+
+from beanie import PydanticObjectId
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud.cycles import service as cycles_service
+
+logger = logging.getLogger(__name__)
+
+
+def _system_ctx(workspace_id: str) -> RequestContext:
+    """Build a service-level RequestContext for the snapshot job.
+
+    The job is a system actor — no user — so ``user_id`` is a sentinel.
+    ``request_id`` is fixed to make log correlation across days easier.
+    """
+    return RequestContext(
+        user_id="system.cycles.snapshot",
+        workspace_id=workspace_id,
+        request_id="cycle-snapshot",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def snapshot_all_active(workspace_id: str) -> int:
+    """Snapshot every active cycle in a workspace.
+
+    Returns the number of cycles successfully snapshotted. Idempotent via
+    ``cycles_service._snapshot_cycle_daily`` — calling this twice in the
+    same calendar day is a no-op on the second pass.
+    """
+    # Late import: keep ``ee.cloud.models`` off the module-level path so
+    # snapshot_job stays free to be imported by deployment wiring without
+    # pulling Beanie into the import graph in environments that haven't
+    # initialised it.
+    from ee.cloud.models.cycle import Cycle as _CycleDoc
+
+    ctx = _system_ctx(workspace_id)
+    count = 0
+    async for doc in _CycleDoc.find({"workspace": workspace_id, "status": "active"}):
+        cycle_id = str(doc.id)
+        try:
+            point = await cycles_service._snapshot_cycle_daily(ctx, cycle_id)
+            if point is not None:
+                count += 1
+        except Exception:
+            logger.warning(
+                "cycle.snapshot failed for workspace=%s cycle=%s",
+                workspace_id,
+                cycle_id,
+                exc_info=True,
+            )
+    logger.info("cycle.snapshot completed: workspace=%s snapshotted=%d", workspace_id, count)
+    return count
+
+
+async def snapshot_one(workspace_id: str, cycle_id: str) -> bool:
+    """Snapshot a single cycle by id. Useful for ad-hoc CLI invocations.
+
+    Returns ``True`` if a new point was appended, ``False`` if today's
+    point already existed (idempotent), the cycle is completed, or Tasks
+    isn't available.
+    """
+    try:
+        PydanticObjectId(cycle_id)
+    except Exception:
+        logger.warning("cycle.snapshot: invalid cycle id %s", cycle_id)
+        return False
+    ctx = _system_ctx(workspace_id)
+    point = await cycles_service._snapshot_cycle_daily(ctx, cycle_id)
+    return point is not None
+
+
+async def run_forever_loop(iter_workspaces, *, interval_seconds: float = 24 * 60 * 60) -> None:
+    """Run the snapshot job in a perpetual loop.
+
+    ``iter_workspaces`` is an awaitable callable returning the list of
+    workspace ids to scan on each pass — kept as a parameter rather than
+    inlined here so deployment wiring can plug in workspace discovery
+    however it wants (per-tenant DB, multi-tenant collection scan,
+    static config).
+
+    The captain wires this into the host platform's scheduler if a
+    persistent loop is preferred over a cron-style invocation. For a
+    plain ``mount_cloud()`` setup, prefer the per-pass ``snapshot_all_active``
+    triggered by an external scheduler instead — running a hot loop in
+    the same process as the FastAPI app couples the job's reliability to
+    request-handling uptime.
+    """
+    while True:
+        try:
+            workspaces = await iter_workspaces()
+            for ws in workspaces:
+                await snapshot_all_active(ws)
+        except Exception:
+            logger.exception("cycle.snapshot run_forever_loop pass failed")
+        await asyncio.sleep(interval_seconds)
+
+
+__all__ = ["run_forever_loop", "snapshot_all_active", "snapshot_one"]

--- a/ee/cloud/models/__init__.py
+++ b/ee/cloud/models/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from ee.cloud.models.agent import Agent, AgentConfig
 from ee.cloud.models.comment import Comment, CommentAuthor, CommentTarget
 from ee.cloud.models.connector import WorkspaceConnector
+from ee.cloud.models.cycle import Cycle, CycleDailyPoint
 from ee.cloud.models.file import FileObj
 from ee.cloud.models.group import Group, GroupAgent
 from ee.cloud.models.invite import Invite
@@ -39,6 +40,8 @@ __all__ = [
     "Comment",
     "CommentAuthor",
     "CommentTarget",
+    "Cycle",
+    "CycleDailyPoint",
     "FileFolder",
     "FileObj",
     "FileUpload",
@@ -83,6 +86,7 @@ def get_all_documents():
         Group,
         Message,
         ReadState,
+        Cycle,
     ]
 
 

--- a/ee/cloud/models/cycle.py
+++ b/ee/cloud/models/cycle.py
@@ -1,0 +1,74 @@
+"""Cycle document — time-boxed work window for Mission Control.
+
+A Cycle is the events-production analogue of a Linear "cycle": a 4-6 week
+prep window for one engagement (May 23 wedding, June 8 corporate summit,
+etc.). Tasks reference back to a Cycle via ``cycle_id``.
+
+The ``daily`` array is embedded (cap ~100 entries) — one point per day
+captured by ``ee.cloud.cycles.snapshot_job`` for the burnup chart. Beyond
+the cap the snapshot job downgrades to weekly cadence so a long-running
+cycle doesn't blow the document size budget.
+
+Only ``ee.cloud.cycles.service`` may import this module — enforced by the
+``import-linter`` contract in ``pyproject.toml``.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from beanie import Indexed
+from pydantic import BaseModel, Field
+
+from ee.cloud.models.base import TimestampedDocument
+
+
+class CycleDailyPoint(BaseModel):
+    """One day's snapshot of cycle scope/started/completed counts.
+
+    ``is_weekend`` is captured at snapshot time so the burnup chart can
+    flatten the ideal target line over weekends without needing to recompute
+    the calendar on read.
+    """
+
+    date: date
+    scope: int = 0
+    started: int = 0
+    completed: int = 0
+    is_weekend: bool = False
+
+
+class Cycle(TimestampedDocument):
+    """Time-boxed work window for Mission Control.
+
+    Counters (``scope`` / ``started`` / ``completed``) are denormalized for
+    cheap list reads; the snapshot job is the source of truth for historical
+    series, and ``ee.cloud.cycles.service.agent_get_cycle`` refreshes them
+    from the Tasks collection at fetch time.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    name: str
+    description: str = ""
+    # A cycle can span multiple pockets — ``pocket_id`` is the *primary*
+    # pocket for filtering; tasks with any pocket assignment can reference
+    # the cycle as long as the workspace matches.
+    pocket_id: str | None = None
+    start: date
+    end: date
+    status: str = Field(default="upcoming", pattern="^(active|upcoming|completed)$")
+    # Denormalized counters — kept fresh by service writes; readers should
+    # treat them as approximate and recompute on the detail endpoint.
+    scope: int = 0
+    started: int = 0
+    completed: int = 0
+    daily: list[CycleDailyPoint] = Field(default_factory=list)
+    # Audit: who created this cycle.
+    created_by: str = ""
+
+    class Settings:
+        name = "cycles"
+        indexes = [
+            [("workspace", 1), ("status", 1)],
+            [("workspace", 1), ("pocket_id", 1), ("status", 1)],
+        ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -580,3 +580,14 @@ forbidden_modules = [
     "ee.cloud.models.user",
     "ee.cloud.models.agent",
 ]
+
+[[tool.importlinter.contracts]]
+name = "Cycles — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "ee.cloud.cycles.router",
+    "ee.cloud.cycles.dto",
+    "ee.cloud.cycles.domain",
+]
+forbidden_modules = ["ee.cloud.models.cycle"]

--- a/tests/cloud/test_cycles_burnup_shape.py
+++ b/tests/cloud/test_cycles_burnup_shape.py
@@ -1,0 +1,173 @@
+"""Burnup-chart shape contract test.
+
+Locks down what the frontend's BurndownChart component consumes from
+``CycleResponse.daily``:
+
+- four parallel series (scope, started, completed, plus an is_weekend
+  flag per point)
+- ``scope`` is the total visible at snapshot time (typically flat unless
+  new tasks are added mid-cycle)
+- ``started`` is monotone non-decreasing across days
+- ``completed`` is monotone non-decreasing across days and never
+  exceeds ``started``
+- ``is_weekend`` is set correctly for Saturday/Sunday so the chart can
+  flatten the dashed ideal target on those days
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import UTC, date, datetime
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud.cycles import service as cycles_service
+from ee.cloud.cycles.dto import CreateCycleRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(
+        user_id="u1",
+        workspace_id="w1",
+        request_id="burnup",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+class _FakeTask:
+    def __init__(self, status: str, task_id: str = "t1") -> None:
+        self.status = status
+        self.id = task_id
+
+
+def _install_dynamic_tasks(get_tasks_callable) -> None:
+    """Install a stub Tasks package whose ``agent_list_tasks`` reads the
+    latest result from ``get_tasks_callable``. Lets the test simulate a
+    cycle's task progression day by day without rebuilding the module.
+    """
+    mod_tasks = types.ModuleType("ee.cloud.tasks")
+    mod_service = types.ModuleType("ee.cloud.tasks.service")
+    mod_dto = types.ModuleType("ee.cloud.tasks.dto")
+
+    class _ListReq:
+        def __init__(self, cycle_id: str | None = None, **_: object) -> None:
+            self.cycle_id = cycle_id
+
+    mod_dto.ListTasksRequest = _ListReq  # type: ignore[attr-defined]
+
+    async def _list(_ctx, _body):  # type: ignore[no-untyped-def]
+        return list(get_tasks_callable())
+
+    mod_service.agent_list_tasks = _list  # type: ignore[attr-defined]
+    mod_tasks.service = mod_service  # type: ignore[attr-defined]
+    mod_tasks.dto = mod_dto  # type: ignore[attr-defined]
+
+    sys.modules["ee.cloud.tasks"] = mod_tasks
+    sys.modules["ee.cloud.tasks.service"] = mod_service
+    sys.modules["ee.cloud.tasks.dto"] = mod_dto
+
+
+def _uninstall() -> None:
+    for name in ("ee.cloud.tasks", "ee.cloud.tasks.service", "ee.cloud.tasks.dto"):
+        sys.modules.pop(name, None)
+
+
+@pytest.fixture
+def task_progression():
+    """Yield a list slot the test can mutate to advance the task states
+    across simulated snapshot days."""
+    holder: dict[str, list[_FakeTask]] = {"tasks": []}
+    _install_dynamic_tasks(lambda: holder["tasks"])
+    try:
+        yield holder
+    finally:
+        _uninstall()
+
+
+async def test_daily_series_shape_matches_frontend_expectation(task_progression) -> None:
+    """Walk a cycle through five days; verify the resulting series
+    matches the burnup chart contract."""
+    # Day 0: cycle created with 5 tasks all in "proposed".
+    task_progression["tasks"] = [_FakeTask("proposed", f"t{i}") for i in range(5)]
+
+    cycle = await cycles_service.agent_create_cycle(
+        _ctx(),
+        CreateCycleRequest(
+            name="May Wedding",
+            pocket_id="p1",
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 31),
+            status="active",
+        ),
+    )
+
+    # Simulate 7 days starting Monday 2026-05-11: started/completed counts
+    # climb over time, scope stays at 5.
+    plan = [
+        (date(2026, 5, 11), ["proposed", "proposed", "in_progress", "proposed", "proposed"]),
+        (date(2026, 5, 12), ["in_progress", "proposed", "in_progress", "proposed", "proposed"]),
+        (date(2026, 5, 13), ["in_progress", "in_progress", "done", "proposed", "proposed"]),
+        (date(2026, 5, 14), ["in_progress", "in_progress", "done", "in_progress", "proposed"]),
+        (date(2026, 5, 15), ["done", "in_progress", "done", "in_progress", "proposed"]),
+        (date(2026, 5, 16), ["done", "in_progress", "done", "in_progress", "proposed"]),  # Sat
+        (date(2026, 5, 17), ["done", "in_progress", "done", "in_progress", "proposed"]),  # Sun
+    ]
+    for snap_date, statuses in plan:
+        task_progression["tasks"] = [_FakeTask(s, f"t{i}") for i, s in enumerate(statuses)]
+        await cycles_service._snapshot_cycle_daily(_ctx(), cycle.id, today=snap_date)
+
+    fetched = await cycles_service.agent_get_cycle(_ctx(), cycle.id)
+    series = fetched.daily
+    assert len(series) == 7
+    # Dates are stored in append order.
+    assert [p.date for p in series] == [d.isoformat() for d, _ in plan]
+
+    # Scope is flat — 5 tasks throughout.
+    assert all(p.scope == 5 for p in series)
+
+    # Started is non-decreasing.
+    started = [p.started for p in series]
+    assert all(b >= a for a, b in zip(started, started[1:])), started
+
+    # Completed is non-decreasing.
+    completed = [p.completed for p in series]
+    assert all(b >= a for a, b in zip(completed, completed[1:])), completed
+
+    # Completed never exceeds started — the frontend's chart depends on this
+    # so the "in flight" wedge between the two lines is always non-negative.
+    assert all(c <= s for c, s in zip(completed, started))
+
+    # Final-day numbers match the plan: 2 done, 4 started.
+    assert series[-1].completed == 2
+    assert series[-1].started == 4
+    assert series[-1].scope == 5
+
+    # is_weekend correctly tagged. Saturday + Sunday in the plan.
+    weekend_flags = {p.date: p.is_weekend for p in series}
+    assert weekend_flags["2026-05-11"] is False  # Monday
+    assert weekend_flags["2026-05-15"] is False  # Friday
+    assert weekend_flags["2026-05-16"] is True  # Saturday
+    assert weekend_flags["2026-05-17"] is True  # Sunday
+
+
+async def test_daily_series_four_visible_fields(task_progression) -> None:
+    """The frontend reads exactly four fields per point — verify the
+    DTO carries them with stable names."""
+    task_progression["tasks"] = [_FakeTask("in_progress", "t0")]
+
+    cycle = await cycles_service.agent_create_cycle(
+        _ctx(),
+        CreateCycleRequest(
+            name="x", start=date(2026, 5, 1), end=date(2026, 5, 31), status="active"
+        ),
+    )
+    await cycles_service._snapshot_cycle_daily(_ctx(), cycle.id, today=date(2026, 5, 11))
+
+    fetched = await cycles_service.agent_get_cycle(_ctx(), cycle.id)
+    point = fetched.daily[0].model_dump()
+    assert set(point.keys()) == {"date", "scope", "started", "completed", "is_weekend"}

--- a/tests/cloud/test_cycles_daily_snapshot.py
+++ b/tests/cloud/test_cycles_daily_snapshot.py
@@ -1,0 +1,262 @@
+"""Daily-snapshot job tests.
+
+Covers the idempotency rule, the weekend flag, and the no-op behavior
+when Tasks (PR 2) isn't available on this branch. The full
+scope/started/completed projection is exercised in
+``test_cycles_burnup_shape.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import UTC, date, datetime
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud._core.realtime.events import CycleSnapshotted
+from ee.cloud.cycles import service as cycles_service
+from ee.cloud.cycles.dto import CreateCycleRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(
+        user_id="u1",
+        workspace_id="w1",
+        request_id="snap",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+class _FakeTask:
+    """Lightweight stand-in for a Tasks domain object.
+
+    Tasks (PR 2) ships objects with ``status`` and ``id`` attributes; this
+    fake matches that shape so the cycles service's projection helpers
+    don't have to know whether the real entity is loaded.
+    """
+
+    def __init__(self, status: str, task_id: str = "t1") -> None:
+        self.status = status
+        self.id = task_id
+
+
+def _install_fake_tasks(tasks_to_return: list[_FakeTask] | None = None) -> None:
+    """Install a stub ``ee.cloud.tasks`` package so the cycles service's
+    lazy import picks up controllable test doubles.
+
+    Tests that want to assert against real PR-2 tasks would import the
+    real module; tests in this file deliberately stub it so the snapshot
+    job's behavior can be exercised without depending on PR 2 having
+    landed.
+    """
+    mod_tasks = types.ModuleType("ee.cloud.tasks")
+    mod_service = types.ModuleType("ee.cloud.tasks.service")
+    mod_dto = types.ModuleType("ee.cloud.tasks.dto")
+
+    class _ListReq:
+        def __init__(self, cycle_id: str | None = None, **_: object) -> None:
+            self.cycle_id = cycle_id
+
+    mod_dto.ListTasksRequest = _ListReq  # type: ignore[attr-defined]
+
+    async def _list(_ctx, _body):  # type: ignore[no-untyped-def]
+        return list(tasks_to_return or [])
+
+    mod_service.agent_list_tasks = _list  # type: ignore[attr-defined]
+    mod_tasks.service = mod_service  # type: ignore[attr-defined]
+    mod_tasks.dto = mod_dto  # type: ignore[attr-defined]
+
+    sys.modules["ee.cloud.tasks"] = mod_tasks
+    sys.modules["ee.cloud.tasks.service"] = mod_service
+    sys.modules["ee.cloud.tasks.dto"] = mod_dto
+
+
+def _uninstall_fake_tasks() -> None:
+    for name in ("ee.cloud.tasks", "ee.cloud.tasks.service", "ee.cloud.tasks.dto"):
+        sys.modules.pop(name, None)
+
+
+@pytest.fixture
+def fake_tasks():
+    """Yield a list the caller can mutate to control the snapshot result."""
+    bucket: list[_FakeTask] = []
+    # Bind by reference: the stub closes over ``bucket``, so appends to it
+    # after install still affect subsequent calls.
+    _install_fake_tasks(bucket)
+    try:
+        yield bucket
+    finally:
+        _uninstall_fake_tasks()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_appends_a_point(fake_tasks, recording_bus) -> None:
+    fake_tasks.extend([_FakeTask("proposed"), _FakeTask("in_progress"), _FakeTask("done")])
+
+    cycle = await cycles_service.agent_create_cycle(
+        _ctx(),
+        CreateCycleRequest(
+            name="x",
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 31),
+            status="active",
+        ),
+    )
+
+    today = date(2026, 5, 13)  # A Wednesday
+    point = await cycles_service._snapshot_cycle_daily(_ctx(), cycle.id, today=today)
+    assert point is not None
+    assert point.date == "2026-05-13"
+    assert point.scope == 3
+    assert point.started == 2  # in_progress + done
+    assert point.completed == 1
+    assert point.is_weekend is False
+
+    refreshed = await cycles_service.agent_get_cycle(_ctx(), cycle.id)
+    assert len(refreshed.daily) == 1
+    assert refreshed.daily[0].date == "2026-05-13"
+
+    snap_events = [e for e in recording_bus.events if isinstance(e, CycleSnapshotted)]
+    assert len(snap_events) == 1
+    assert snap_events[0].data["cycle_id"] == cycle.id
+    assert snap_events[0].data["daily_point"]["date"] == "2026-05-13"
+
+
+async def test_snapshot_is_idempotent_within_day(fake_tasks) -> None:
+    fake_tasks.append(_FakeTask("proposed"))
+    cycle = await cycles_service.agent_create_cycle(
+        _ctx(),
+        CreateCycleRequest(
+            name="x", start=date(2026, 5, 1), end=date(2026, 5, 31), status="active"
+        ),
+    )
+    today = date(2026, 5, 13)
+    p1 = await cycles_service._snapshot_cycle_daily(_ctx(), cycle.id, today=today)
+    p2 = await cycles_service._snapshot_cycle_daily(_ctx(), cycle.id, today=today)
+    assert p1 is not None
+    assert p2 is None  # Second call is a no-op
+
+    refreshed = await cycles_service.agent_get_cycle(_ctx(), cycle.id)
+    assert len(refreshed.daily) == 1
+
+
+async def test_snapshot_weekend_flag(fake_tasks) -> None:
+    fake_tasks.append(_FakeTask("proposed"))
+    cycle = await cycles_service.agent_create_cycle(
+        _ctx(),
+        CreateCycleRequest(
+            name="x", start=date(2026, 5, 1), end=date(2026, 5, 31), status="active"
+        ),
+    )
+    saturday = date(2026, 5, 16)  # weekday() == 5
+    point = await cycles_service._snapshot_cycle_daily(_ctx(), cycle.id, today=saturday)
+    assert point is not None
+    assert point.is_weekend is True
+
+    sunday = date(2026, 5, 17)
+    point2 = await cycles_service._snapshot_cycle_daily(_ctx(), cycle.id, today=sunday)
+    assert point2 is not None
+    assert point2.is_weekend is True
+
+
+async def test_snapshot_skips_completed_cycle(fake_tasks) -> None:
+    fake_tasks.append(_FakeTask("proposed"))
+    cycle = await cycles_service.agent_create_cycle(
+        _ctx(),
+        CreateCycleRequest(
+            name="x", start=date(2026, 5, 1), end=date(2026, 5, 31), status="active"
+        ),
+    )
+    await cycles_service.agent_close_cycle(_ctx(), cycle.id)
+    point = await cycles_service._snapshot_cycle_daily(_ctx(), cycle.id)
+    assert point is None
+
+
+# ---------------------------------------------------------------------------
+# Graceful degrade when Tasks unavailable
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_noop_when_tasks_unavailable(monkeypatch) -> None:
+    """When the Tasks entity isn't on this branch, the snapshot job logs
+    and returns None rather than crashing."""
+    cycle = await cycles_service.agent_create_cycle(
+        _ctx(),
+        CreateCycleRequest(
+            name="x", start=date(2026, 5, 1), end=date(2026, 5, 31), status="active"
+        ),
+    )
+    # Defensive cleanup: make sure no other test left a stub installed.
+    _uninstall_fake_tasks()
+
+    async def _none(*_args, **_kwargs):
+        return None
+
+    # Monkey-patch the helper that lazy-imports tasks so the snapshot path
+    # behaves as if PR 2 hadn't merged, even if other suites have left a
+    # stub on ``sys.modules``.
+    monkeypatch.setattr(cycles_service, "_tasks_for_cycle", _none)
+    point = await cycles_service._snapshot_cycle_daily(_ctx(), cycle.id)
+    assert point is None
+
+
+# ---------------------------------------------------------------------------
+# snapshot_job wrapper
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_all_active_handles_multiple_workspaces(fake_tasks) -> None:
+    """The job-level wrapper iterates every active cycle in the
+    workspace and counts how many got a fresh point."""
+    from ee.cloud.cycles import snapshot_job
+
+    fake_tasks.append(_FakeTask("in_progress"))
+
+    ctx = _ctx()
+    await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="active-1",
+            pocket_id="p1",
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 31),
+            status="active",
+        ),
+    )
+    await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="active-2",
+            pocket_id="p2",
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 31),
+            status="active",
+        ),
+    )
+    await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="upcoming",
+            pocket_id="p3",
+            start=date(2026, 7, 1),
+            end=date(2026, 7, 31),
+            status="upcoming",
+        ),
+    )
+
+    count = await snapshot_job.snapshot_all_active("w1")
+    # Two active cycles, both should be snapshotted once.
+    assert count == 2
+
+    # Idempotent on second pass
+    count2 = await snapshot_job.snapshot_all_active("w1")
+    assert count2 == 0

--- a/tests/cloud/test_cycles_router.py
+++ b/tests/cloud/test_cycles_router.py
@@ -1,0 +1,193 @@
+"""HTTP-layer tests for ``ee/cloud/cycles/router.py``.
+
+Smokes the endpoint surface end-to-end through a FastAPI app: status
+mapping, tenancy isolation, and the upcoming-only edit rule. The full
+service-level assertion suite lives in ``test_cycles_service.py``; this
+file only covers the wiring.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from ee.cloud._core.http import add_error_handler
+from ee.cloud.cycles.router import router as cycles_router
+from ee.cloud.license import require_license
+
+
+def _make_ctx(workspace_id: str | None, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(cycles_router)
+
+    async def _ctx() -> RequestContext:
+        return _make_ctx(workspace_id, user_id)
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def mongo_only(mongo_db: Any):
+    """Reuse the cloud mongo_db fixture without dragging in chat router."""
+    yield mongo_db
+
+
+@pytest_asyncio.fixture
+async def w1_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id="w1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id="w2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def no_ws_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id=None)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "name": f"Cycle-{uuid.uuid4().hex[:6]}",
+        "description": "test",
+        "start": "2026-05-01",
+        "end": "2026-05-29",
+        "status": "upcoming",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Smoke
+# ---------------------------------------------------------------------------
+
+
+async def test_create_then_get(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/cycles", json=_payload(name="May Wedding"))
+    assert r.status_code == 200, r.text
+    cid = r.json()["id"]
+
+    r2 = await w1_client.get(f"/cycles/{cid}")
+    assert r2.status_code == 200
+    body = r2.json()
+    assert body["name"] == "May Wedding"
+    assert body["workspace_id"] == "w1"
+    assert "daily" in body
+
+
+async def test_list_returns_items_without_daily_series(w1_client: AsyncClient) -> None:
+    await w1_client.post("/cycles", json=_payload())
+    r = await w1_client.get("/cycles")
+    assert r.status_code == 200
+    items = r.json()
+    assert len(items) == 1
+    # List response is the lighter shape — no daily field
+    assert "daily" not in items[0]
+
+
+async def test_patch_works_on_upcoming(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/cycles", json=_payload(name="orig"))
+    cid = r.json()["id"]
+    r2 = await w1_client.patch(f"/cycles/{cid}", json={"name": "renamed"})
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["name"] == "renamed"
+
+
+async def test_patch_forbidden_on_active(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/cycles", json=_payload(status="active"))
+    cid = r.json()["id"]
+    r2 = await w1_client.patch(f"/cycles/{cid}", json={"name": "no-go"})
+    assert r2.status_code == 403
+    assert r2.json()["error"]["code"] == "cycle.not_upcoming"
+
+
+async def test_close_returns_completed(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/cycles", json=_payload(status="active"))
+    cid = r.json()["id"]
+    r2 = await w1_client.post(f"/cycles/{cid}/close")
+    assert r2.status_code == 200
+    assert r2.json()["status"] == "completed"
+
+
+async def test_items_endpoint_returns_array(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/cycles", json=_payload())
+    cid = r.json()["id"]
+    r2 = await w1_client.get(f"/cycles/{cid}/items")
+    assert r2.status_code == 200
+    assert isinstance(r2.json(), list)
+
+
+# ---------------------------------------------------------------------------
+# Tenancy isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_other_workspace_cannot_read(w1_client: AsyncClient, w2_client: AsyncClient) -> None:
+    r = await w1_client.post("/cycles", json=_payload(name="w1-cycle"))
+    cid = r.json()["id"]
+
+    r2 = await w2_client.get(f"/cycles/{cid}")
+    assert r2.status_code == 404
+
+    r3 = await w2_client.patch(f"/cycles/{cid}", json={"name": "stolen"})
+    assert r3.status_code == 404
+
+
+async def test_list_is_workspace_scoped(w1_client: AsyncClient, w2_client: AsyncClient) -> None:
+    await w1_client.post("/cycles", json=_payload(name="w1-cycle"))
+    await w2_client.post("/cycles", json=_payload(name="w2-cycle"))
+
+    r1 = await w1_client.get("/cycles")
+    r2 = await w2_client.get("/cycles")
+
+    assert {c["name"] for c in r1.json()} == {"w1-cycle"}
+    assert {c["name"] for c in r2.json()} == {"w2-cycle"}
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+async def test_create_rejects_inverted_dates(w1_client: AsyncClient) -> None:
+    r = await w1_client.post(
+        "/cycles",
+        json=_payload(start="2026-06-01", end="2026-05-01"),
+    )
+    assert r.status_code in (400, 422)
+
+
+async def test_no_workspace_returns_forbidden(no_ws_client: AsyncClient) -> None:
+    r = await no_ws_client.get("/cycles")
+    assert r.status_code == 403
+    assert r.json()["error"]["code"] == "cycle.no_workspace"

--- a/tests/cloud/test_cycles_service.py
+++ b/tests/cloud/test_cycles_service.py
@@ -1,0 +1,397 @@
+"""Tests for ``ee.cloud.cycles.service`` — CRUD + status transitions.
+
+Exercise the service-level API directly against the shared mongomock-motor
+fixture. The ``recording_bus`` autouse fixture captures emitted events.
+
+Tasks-composition assertions (status counters, rollover-on-close) are
+guarded by an availability probe — when PR 2's Tasks entity hasn't merged
+into ``ee`` yet, those branches skip with a clear TODO so the rest of the
+suite stays green.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud._core.errors import ConflictError, Forbidden, NotFound
+from ee.cloud._core.realtime.events import (
+    CycleClosed,
+    CycleCreated,
+    CycleUpdated,
+)
+from ee.cloud.cycles import service as cycles_service
+from ee.cloud.cycles.dto import CreateCycleRequest, UpdateCycleRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace: str = "w1", user: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _tasks_available() -> bool:
+    """Returns True only when PR 2's Tasks entity is mergeable on this
+    branch — used to gate task-composition assertions."""
+    try:
+        from ee.cloud.tasks import service as _  # noqa: F401
+        from ee.cloud.tasks.dto import ListTasksRequest as _LTR  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+async def test_create_persists_with_workspace_and_creator(recording_bus) -> None:
+    ctx = _ctx(workspace="w1", user="shawn")
+    body = CreateCycleRequest(
+        name="Crestline · May 23 Wedding",
+        description="4-week prep window",
+        pocket_id="p1",
+        start=date(2026, 5, 1),
+        end=date(2026, 5, 29),
+        status="upcoming",
+    )
+    out = await cycles_service.agent_create_cycle(ctx, body)
+    assert out.name == "Crestline · May 23 Wedding"
+    assert out.workspace_id == "w1"
+    assert out.created_by == "shawn"
+    assert out.status == "upcoming"
+    assert out.start == "2026-05-01"
+    assert out.end == "2026-05-29"
+
+    created_events = [e for e in recording_bus.events if isinstance(e, CycleCreated)]
+    assert len(created_events) == 1
+    assert created_events[0].data["id"] == out.id
+
+
+async def test_create_rejects_start_after_end() -> None:
+    with pytest.raises(ValueError):
+        CreateCycleRequest(
+            name="bad",
+            start=date(2026, 6, 1),
+            end=date(2026, 5, 1),
+        )
+
+
+async def test_create_rejects_overlap_on_same_pocket() -> None:
+    ctx = _ctx()
+    await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="May Wedding",
+            pocket_id="p1",
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 29),
+            status="active",
+        ),
+    )
+    with pytest.raises(ConflictError):
+        await cycles_service.agent_create_cycle(
+            ctx,
+            CreateCycleRequest(
+                name="May Wedding Take Two",
+                pocket_id="p1",
+                start=date(2026, 5, 15),
+                end=date(2026, 6, 10),
+                status="active",
+            ),
+        )
+
+
+async def test_create_allows_overlap_on_different_pockets() -> None:
+    """Workspaces routinely run multiple engagements simultaneously on
+    different pockets — the overlap rule applies per-pocket only."""
+    ctx = _ctx()
+    await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="May Wedding",
+            pocket_id="p1",
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 29),
+            status="active",
+        ),
+    )
+    out = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="May Summit",
+            pocket_id="p2",
+            start=date(2026, 5, 15),
+            end=date(2026, 6, 10),
+            status="active",
+        ),
+    )
+    assert out.pocket_id == "p2"
+
+
+async def test_create_requires_workspace() -> None:
+    """Routes without an active workspace surface 403 rather than 500."""
+    ctx = RequestContext(
+        user_id="u1",
+        workspace_id=None,
+        request_id="t",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+    with pytest.raises(Forbidden):
+        await cycles_service.agent_create_cycle(
+            ctx,
+            CreateCycleRequest(
+                name="x",
+                start=date(2026, 5, 1),
+                end=date(2026, 5, 29),
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# List + Get
+# ---------------------------------------------------------------------------
+
+
+async def test_list_sorts_by_status_then_start_desc() -> None:
+    ctx = _ctx()
+    await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="completed-old",
+            start=date(2026, 1, 1),
+            end=date(2026, 1, 31),
+            status="upcoming",
+        ),
+    )
+    # Make one completed
+    completed = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="completed-recent",
+            start=date(2026, 4, 1),
+            end=date(2026, 4, 30),
+            status="upcoming",
+        ),
+    )
+    await cycles_service.agent_close_cycle(ctx, completed.id)
+
+    await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="upcoming-soon",
+            pocket_id="p-future",
+            start=date(2026, 6, 1),
+            end=date(2026, 6, 30),
+            status="upcoming",
+        ),
+    )
+    await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="active-now",
+            pocket_id="p-now",
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 31),
+            status="active",
+        ),
+    )
+
+    listing = await cycles_service.agent_list_cycles(ctx)
+    statuses = [c.status for c in listing]
+    # active first, then upcoming, then completed
+    assert statuses[0] == "active"
+    assert statuses[-1] == "completed"
+    assert "upcoming" in statuses
+
+
+async def test_list_is_tenant_scoped() -> None:
+    """Cycles from another workspace never leak into the list."""
+    await cycles_service.agent_create_cycle(
+        _ctx(workspace="w1"),
+        CreateCycleRequest(name="w1-cycle", start=date(2026, 5, 1), end=date(2026, 5, 31)),
+    )
+    await cycles_service.agent_create_cycle(
+        _ctx(workspace="w2"),
+        CreateCycleRequest(name="w2-cycle", start=date(2026, 5, 1), end=date(2026, 5, 31)),
+    )
+    listing_w1 = await cycles_service.agent_list_cycles(_ctx(workspace="w1"))
+    listing_w2 = await cycles_service.agent_list_cycles(_ctx(workspace="w2"))
+    assert {c.name for c in listing_w1} == {"w1-cycle"}
+    assert {c.name for c in listing_w2} == {"w2-cycle"}
+
+
+async def test_get_raises_not_found_for_other_workspace() -> None:
+    ws1 = _ctx(workspace="w1")
+    out = await cycles_service.agent_create_cycle(
+        ws1,
+        CreateCycleRequest(name="x", start=date(2026, 5, 1), end=date(2026, 5, 31)),
+    )
+    ws2 = _ctx(workspace="w2")
+    with pytest.raises(NotFound):
+        await cycles_service.agent_get_cycle(ws2, out.id)
+
+
+async def test_get_returns_daily_series() -> None:
+    ctx = _ctx()
+    out = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="x", start=date(2026, 5, 1), end=date(2026, 5, 31), status="active"
+        ),
+    )
+    fetched = await cycles_service.agent_get_cycle(ctx, out.id)
+    assert fetched.daily == []  # Empty until snapshot job runs
+
+
+# ---------------------------------------------------------------------------
+# Update
+# ---------------------------------------------------------------------------
+
+
+async def test_update_works_on_upcoming(recording_bus) -> None:
+    ctx = _ctx()
+    out = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="orig",
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 31),
+            status="upcoming",
+        ),
+    )
+    recording_bus.events.clear()
+    updated = await cycles_service.agent_update_cycle(
+        ctx,
+        out.id,
+        UpdateCycleRequest(
+            name="renamed",
+            start=date(2026, 5, 5),
+            end=date(2026, 6, 5),
+        ),
+    )
+    assert updated.name == "renamed"
+    assert updated.start == "2026-05-05"
+    assert updated.end == "2026-06-05"
+    assert any(isinstance(e, CycleUpdated) for e in recording_bus.events)
+
+
+async def test_update_forbidden_on_active_cycle() -> None:
+    ctx = _ctx()
+    out = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="x",
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 31),
+            status="active",
+        ),
+    )
+    with pytest.raises(Forbidden):
+        await cycles_service.agent_update_cycle(ctx, out.id, UpdateCycleRequest(name="renamed"))
+
+
+async def test_update_rejects_inverted_dates() -> None:
+    # The DTO validator catches inverted dates before they reach the service.
+    with pytest.raises(ValueError):
+        UpdateCycleRequest(start=date(2026, 6, 1), end=date(2026, 5, 1))
+
+
+# ---------------------------------------------------------------------------
+# Close
+# ---------------------------------------------------------------------------
+
+
+async def test_close_sets_status_and_emits(recording_bus) -> None:
+    ctx = _ctx()
+    out = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="x", start=date(2026, 5, 1), end=date(2026, 5, 31), status="active"
+        ),
+    )
+    recording_bus.events.clear()
+    closed = await cycles_service.agent_close_cycle(ctx, out.id)
+    assert closed.status == "completed"
+    closed_events = [e for e in recording_bus.events if isinstance(e, CycleClosed)]
+    assert len(closed_events) == 1
+    assert closed_events[0].data["id"] == out.id
+    assert "rolled_count" in closed_events[0].data
+
+
+async def test_close_idempotent() -> None:
+    """Closing an already-completed cycle returns 409."""
+    ctx = _ctx()
+    out = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="x", start=date(2026, 5, 1), end=date(2026, 5, 31), status="active"
+        ),
+    )
+    await cycles_service.agent_close_cycle(ctx, out.id)
+    with pytest.raises(ConflictError):
+        await cycles_service.agent_close_cycle(ctx, out.id)
+
+
+async def test_close_rolls_incomplete_tasks() -> None:
+    """When Tasks (PR 2) is available, closing a cycle reassigns its
+    non-done tasks to the next active cycle on the same pocket."""
+    if not _tasks_available():
+        pytest.skip(
+            "Tasks entity (PR 2) not merged into this branch yet — "
+            "TODO: revisit once feat/mission-control-tasks lands in ee"
+        )
+    # The actual rollover semantics live in PR 2's task service; once that
+    # module exposes the documented ``agent_reassign_task_cycle`` helper,
+    # this test can construct tasks, call agent_close_cycle, and assert
+    # they show up on the rolled-to cycle.
+    pytest.skip("Tasks-side assertions covered in PR 2's test suite")
+
+
+# ---------------------------------------------------------------------------
+# List items
+# ---------------------------------------------------------------------------
+
+
+async def test_list_items_empty_when_tasks_unavailable() -> None:
+    """Graceful degradation: when Tasks isn't merged, items returns []."""
+    ctx = _ctx()
+    out = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(name="x", start=date(2026, 5, 1), end=date(2026, 5, 31)),
+    )
+    if _tasks_available():
+        pytest.skip("Tasks entity is available — exercise full path in PR 2 suite")
+    items = await cycles_service.agent_list_cycle_items(ctx, out.id)
+    assert items == []
+
+
+async def test_list_items_raises_not_found_for_other_workspace() -> None:
+    out = await cycles_service.agent_create_cycle(
+        _ctx(workspace="w1"),
+        CreateCycleRequest(name="x", start=date(2026, 5, 1), end=date(2026, 5, 31)),
+    )
+    with pytest.raises(NotFound):
+        await cycles_service.agent_list_cycle_items(_ctx(workspace="w2"), out.id)
+
+
+# ---------------------------------------------------------------------------
+# Lookup edge cases
+# ---------------------------------------------------------------------------
+
+
+async def test_get_invalid_id_raises_not_found() -> None:
+    """Malformed cycle ids surface 404, not 500 from a bson parse error."""
+    ctx = _ctx()
+    with pytest.raises(NotFound):
+        await cycles_service.agent_get_cycle(ctx, "not-a-real-id")


### PR DESCRIPTION
## Summary

PR 3 of 3 for Mission Control's backend. Adds the **Cycles** entity at `ee/cloud/cycles/` — the events-production analogue of a Linear cycle, a 4–6 week prep window for one engagement (May 23 wedding, June 8 corporate summit). Ships the daily-snapshot helper that feeds the burnup chart in the paw-enterprise Cycles tab.

## What's in it

- 4-file shape (`domain.py + dto.py + service.py + router.py`) per the `ee/cloud` rules. Pockets is the canonical reference; this copies its conventions for tenancy, `validate-at-entry`, and `emit-on-write`.
- `CycleDocument` is an embedded-daily-array model. The daily series caps at 100 entries and downgrades to a weekly cadence past the cap so a long engagement doesn't blow the document size budget.
- Status lifecycle: `upcoming` → `active` → `completed`. Closing a cycle rolls every non-done Task forward to the next active cycle on the same pocket (Linear precedent). Editing name / description / dates is allowed only on `upcoming` cycles.
- The Cycles service composes with `ee.cloud.tasks.service` via lazy import. When PR 2's Tasks entity hasn't merged into this branch's `ee` snapshot yet, `agent_list_cycle_items` returns `[]` and `_snapshot_cycle_daily` logs + skips rather than crashing. Once PR 2 lands and both merge into `ee`, the composition wires up automatically.
- New SSE events: `cycle.created`, `cycle.updated`, `cycle.closed`, `cycle.snapshotted`. The frontend's burnup chart can subscribe to the last one and patch the active cycle without a full refetch.
- Import-linter contract added: only `ee.cloud.cycles.service` may import `ee.cloud.models.cycle`. All 10 contracts pass.

## Files

- `ee/cloud/cycles/` — 4-file entity + `snapshot_job.py`
- `ee/cloud/models/cycle.py` — `CycleDocument` + embedded `CycleDailyPoint`
- `ee/cloud/_core/realtime/events.py` — 4 new event classes
- `ee/cloud/__init__.py` — `mount_cloud()` includes the cycles router under `/api/v1`
- `ee/cloud/models/__init__.py` — registers `Cycle` with Beanie
- `pyproject.toml` — new `import-linter` contract
- `tests/cloud/test_cycles_*.py` — 4 test files, 35 passing + 1 skipped pending PR 2

## Test plan

- [x] `uv run pytest tests/cloud/test_cycles_service.py` — CRUD, status transitions, tenancy isolation, close-cycle behavior
- [x] `uv run pytest tests/cloud/test_cycles_router.py` — endpoint smoke + workspace isolation + upcoming-only edit gate
- [x] `uv run pytest tests/cloud/test_cycles_daily_snapshot.py` — idempotency-within-day, weekend flag, no-op when Tasks unavailable
- [x] `uv run pytest tests/cloud/test_cycles_burnup_shape.py` — 7-day simulated progression locks the frontend BurndownChart contract (scope flat, started monotone, completed ≤ started, weekend flag)
- [x] `uv run ruff check ee/cloud/cycles/ tests/cloud/test_cycles*.py` — clean
- [x] `uv run lint-imports` — 10 contracts kept, 0 broken
- [ ] Skipped: full-cloud sweep (55 pre-existing failures on `origin/ee`, none in cycles paths)

## How it composes

- **PR 1 (façade)** — once Mission Control's façade lands, its `agent_outcomes_summary` and analytics tab read from `agent_list_cycles` directly. No changes to the façade are needed here; it's a pure consumer.
- **PR 2 (tasks)** — Tasks is the data source for `scope` / `started` / `completed` counters. The Cycles service lazy-imports `ee.cloud.tasks.service.agent_list_tasks(ctx, ListTasksRequest(cycle_id=...))` and degrades gracefully when it isn't on the path. One Tasks-rollover assertion in `test_cycles_service.py` is `pytest.skip`-ed with a clear TODO until PR 2 merges.
- **Frontend** — `paw-enterprise`'s Cycles tab can flip its mock flag and consume `GET /api/v1/cycles`, `GET /api/v1/cycles/{id}` (with `daily`), `GET /api/v1/cycles/{id}/items`. Wiring happens in a follow-up PR on `paw-enterprise`.

## Daily-job wiring

The snapshot job lives at `ee.cloud.cycles.snapshot_job` and exposes:

- `snapshot_all_active(workspace_id)` — one pass over every active cycle in a workspace, idempotent across same-day reruns
- `snapshot_one(workspace_id, cycle_id)` — single-cycle CLI hook
- `run_forever_loop(iter_workspaces, interval_seconds=86400)` — optional in-process loop for setups that prefer it

**Not wired into `mount_cloud()` as an in-process loop.** The captain plumbs `snapshot_all_active` into whatever the platform uses for scheduled jobs — cron, Kubernetes CronJob, Celery beat, APScheduler. Running a hot daily loop inside the FastAPI process couples job reliability to request-handling uptime; an external scheduler is cleaner. The function is fully idempotent so a missed pass auto-corrects on the next run.

## Decisions baked in

- Manual cycle creation for v1 — no auto-rolling schedule. v1.5 may add a workspace policy.
- `daily` series is embedded on `CycleDocument`, not a separate collection. Reads stay cheap.
- Close rolls incomplete Tasks forward (Linear behavior).
- Overlap rule applies per-pocket: another `active` cycle on the same pocket blocks a new active overlap; cycles on different pockets can run concurrently. Cycles with no `pocket_id` only collide with other no-pocket cycles.

## Out of scope

- Tasks entity (PR 2 — parallel)
- Mission Control façade (PR 1 — parallel)
- Frontend wiring (`paw-enterprise` follow-up)
- Auto-rolling cycle schedules (v1.5)