### PR TITLE
feat(mission-control): façade entity + Instinct bulk endpoints + activity buffer

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -9,8 +9,15 @@ Updated: 2026-04-19 (Cluster C / PR1) — Mounted ee.cloud.kb.knowledge_router,
 Updated: 2026-04-19 (Cluster B) — Added pocket journal SSE stream router to
     mount_cloud() — feeds the RippleGraphWidget with a live, pocket-scoped
     slice of the org journal.
+Updated: 2026-05-13 (feat/mission-control-facade) — mounted the Mission
+    Control façade router at /api/v1/mission-control/* and wired the
+    in-process activity buffer's bus subscribers after init_realtime so
+    the live ticker fills in from agent.thinking / agent.tool_use /
+    agent.stream_end events. PR 1 of three; Tasks (PR 2) and Cycles
+    (PR 3) plug into the same façade in follow-ups.
 
-Domains: auth, workspace, chat, pockets, sessions, agents, kb, knowledge.
+Domains: auth, workspace, chat, pockets, sessions, agents, kb, knowledge,
+mission_control.
 Each has router.py (thin), service.py (logic), schemas.py (validation).
 """
 
@@ -116,6 +123,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(pockets_journal_stream_router, prefix="/api/v1")
 
     from ee.cloud.kb.router import router as kb_router
+    from ee.cloud.mission_control.router import router as mission_control_router
     from ee.cloud.notifications.router import router as notifications_router
     from ee.cloud.uploads.router import router as uploads_router
     from ee.paw_print.router import router as paw_print_router
@@ -125,6 +133,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(uploads_router, prefix="/api/v1")
     app.include_router(notifications_router, prefix="/api/v1")
     app.include_router(files_router, prefix="/api/v1")
+    app.include_router(mission_control_router, prefix="/api/v1")
 
     # Files Tab v2 — /api/v1/files/tree + /api/v1/files/browse. Mounted
     # inline (instead of via build_router's ctx_factory) so the routes can
@@ -340,6 +349,13 @@ def mount_cloud(app: FastAPI) -> None:
     from ee.cloud.uploads.listeners import register_upload_listeners
 
     register_upload_listeners()
+
+    # Mission Control activity buffer — per-workspace ring buffer fed by
+    # agent.* bus events. Same constraint as the upload listeners: subscribe
+    # AFTER init_realtime installed the singleton bus.
+    from ee.cloud.activity.buffer import register_activity_listeners
+
+    register_activity_listeners()
 
     # Start/stop agent pool with app lifecycle.
     #

--- a/ee/cloud/activity/__init__.py
+++ b/ee/cloud/activity/__init__.py
@@ -1,0 +1,19 @@
+# ee/cloud/activity/__init__.py
+# Created: 2026-05-13 (feat/mission-control-facade) — per-workspace in-memory
+# activity buffer feeding Mission Control's live ticker. The durable record
+# of every agent decision still lives in Pawprints (Instinct audit); this
+# module is the ephemeral feed.
+"""Activity buffer package.
+
+Only ``buffer`` matters for now — it owns the per-workspace ring buffer and
+the bus subscription that fills it. ``register_activity_listeners`` is
+wired from ``ee.cloud.__init__.mount_cloud`` after ``init_realtime``.
+"""
+
+from ee.cloud.activity.buffer import (
+    ActivityEvent,
+    get_buffer,
+    register_activity_listeners,
+)
+
+__all__ = ["ActivityEvent", "get_buffer", "register_activity_listeners"]

--- a/ee/cloud/activity/buffer.py
+++ b/ee/cloud/activity/buffer.py
@@ -1,0 +1,283 @@
+# ee/cloud/activity/buffer.py
+# Created: 2026-05-13 (feat/mission-control-facade) — per-workspace activity
+# ring buffer. Subscribes to agent.thinking / agent.tool_use / agent.tool_start
+# / agent.stream_end on the in-process bus and feeds Mission Control's live
+# activity ticker. Bounded (~200 entries per workspace) with a 1-hour TTL so
+# memory stays flat on a long-running process. Durability lives in Pawprints
+# (Instinct audit); this module is decoration.
+"""Per-workspace in-memory activity buffer.
+
+Mission Control's status bar + Activity tab show "what the agent is doing
+right now": tool calls, thinking notes, completions. That stream is high-
+volume and low-value-per-entry — persisting every line to Mongo would
+swamp the journal for a feature that operators consume in seconds. So we
+buffer in-memory with eviction by both count and age, and rebuild from
+zero on process restart.
+
+The audit doc (`docs/internal/2026-05-mission-control-backend-audit.md`,
+section "C. Cross-cutting: activity buffer") commits to this trade-off:
+"Pawprints is the durable record; activity is the live decoration."
+
+Wiring:
+  1. ``register_activity_listeners()`` runs once at app boot from
+     ``mount_cloud`` (after ``init_realtime`` installs the singleton bus).
+  2. Each subscribed bus event maps to an ``ActivityEvent`` and gets
+     pushed onto the workspace's deque via :meth:`Buffer.push`.
+  3. The push also calls ``push_sse_event("activity.recorded", ...)`` so
+     SSE-streaming consumers see entries without polling.
+  4. ``ee.cloud.mission_control.service.agent_list_activity`` reads via
+     ``get_buffer().get_recent(workspace_id, limit)``.
+
+Concurrency:
+  All deque operations run inside ``asyncio`` handlers on the cloud event
+  loop — no thread pool, no locks needed. If we ever hand the buffer to a
+  worker thread we'll need to revisit.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+from ee.cloud._core.realtime.bus import get_bus
+from ee.cloud._core.realtime.events import Event
+
+logger = logging.getLogger(__name__)
+
+
+_MAX_ENTRIES_PER_WORKSPACE = 200
+_TTL_SECONDS = 60 * 60  # 1 hour
+
+
+@dataclass(frozen=True)
+class ActivityEvent:
+    """One entry in the workspace activity feed.
+
+    The shape is intentionally lossy compared to the source bus event —
+    the Mission Control consumer only needs the kind, agent, summary,
+    and pocket reference to render the ticker. The fully-detailed
+    reasoning trace stays on the originating ``AgentToolUse`` /
+    ``AgentThinking`` payload for callers that want it.
+    """
+
+    workspace_id: str
+    kind: str  # tool_call | thinking | completed | waiting
+    agent_id: str | None
+    summary: str
+    pocket_id: str | None
+    ts: float  # unix seconds — used for TTL pruning + display
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+class Buffer:
+    """Per-workspace deques of :class:`ActivityEvent` with TTL pruning.
+
+    Singleton-per-process: the module exposes one instance via
+    :func:`get_buffer`. Tests that need isolation call ``reset()`` between
+    cases.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_per_workspace: int = _MAX_ENTRIES_PER_WORKSPACE,
+        ttl_seconds: int = _TTL_SECONDS,
+    ) -> None:
+        self._max = max_per_workspace
+        self._ttl = ttl_seconds
+        self._deques: dict[str, deque[ActivityEvent]] = {}
+        # Local fan-out handlers so unit tests can assert without spinning
+        # up an SSE stream. Mission Control's SSE consumer also registers
+        # one here.
+        self._subscribers: list[Any] = []
+
+    def push(self, ev: ActivityEvent) -> None:
+        """Append ``ev`` to its workspace deque, prune expired neighbours.
+
+        Eviction order: TTL first (cheap O(k) scan from the front), then
+        the deque's built-in maxlen handles the overflow.
+        """
+        if not ev.workspace_id:
+            logger.debug("activity push without workspace_id; dropping kind=%s", ev.kind)
+            return
+        d = self._deques.get(ev.workspace_id)
+        if d is None:
+            d = deque(maxlen=self._max)
+            self._deques[ev.workspace_id] = d
+        # TTL prune from the left
+        cutoff = ev.ts - self._ttl
+        while d and d[0].ts < cutoff:
+            d.popleft()
+        d.append(ev)
+        for fn in list(self._subscribers):
+            try:
+                fn(ev)
+            except Exception:
+                logger.debug("activity subscriber failed; continuing", exc_info=True)
+
+    def get_recent(self, workspace_id: str, limit: int = 30) -> list[ActivityEvent]:
+        """Return the most-recent entries for ``workspace_id``, newest first.
+
+        Applies TTL pruning before returning so callers always see a
+        consistent view even if no recent push triggered an eviction.
+        """
+        d = self._deques.get(workspace_id)
+        if not d:
+            return []
+        cutoff = time.time() - self._ttl
+        while d and d[0].ts < cutoff:
+            d.popleft()
+        # newest first
+        return list(reversed(list(d)))[: max(0, limit)]
+
+    def subscribe(self, fn: Any) -> None:
+        """Register a synchronous fan-out callback. Used by Mission Control's
+        SSE bridge and by unit tests that assert delivery."""
+        self._subscribers.append(fn)
+
+    def unsubscribe(self, fn: Any) -> None:
+        try:
+            self._subscribers.remove(fn)
+        except ValueError:
+            pass
+
+    def reset(self) -> None:
+        """Empty every workspace deque and drop subscribers. Tests only."""
+        self._deques.clear()
+        self._subscribers.clear()
+
+
+_buffer: Buffer | None = None
+
+
+def get_buffer() -> Buffer:
+    """Return the module-level singleton (lazy-construct on first access)."""
+    global _buffer
+    if _buffer is None:
+        _buffer = Buffer()
+    return _buffer
+
+
+# ---------------------------------------------------------------------------
+# Bus handlers
+# ---------------------------------------------------------------------------
+
+
+def _extract_kind(event_type: str) -> str:
+    """Map a bus event type to the four buckets Mission Control surfaces.
+
+    Bus emits a richer vocabulary (``agent.tool_start`` /
+    ``agent.tool_result`` / ``agent.stream_end`` etc). Mission Control's
+    ticker only needs the operator-facing kind: ``tool_call``,
+    ``thinking``, ``completed``, ``waiting``. Unknown events fall back to
+    the raw type string so we don't silently drop new bus traffic.
+    """
+    if event_type in ("agent.tool_start", "agent.tool_use", "agent.tool_call"):
+        return "tool_call"
+    if event_type == "agent.thinking":
+        return "thinking"
+    if event_type in ("agent.stream_end", "agent.completed"):
+        return "completed"
+    if event_type in ("agent.waiting", "agent.tool_result"):
+        return "waiting"
+    return event_type
+
+
+def _summarise(event: Event) -> str:
+    """Best-effort one-line summary from the event payload.
+
+    Different agent events stash different fields — fish out the most
+    likely "what just happened" string. Falls back to the event type so
+    the ticker never renders an empty row.
+    """
+    data = event.data or {}
+    for key in ("summary", "message", "tool", "tool_name", "thought", "name"):
+        v = data.get(key)
+        if isinstance(v, str) and v:
+            return v
+    return event.type
+
+
+async def _handle_agent_event(event: Event) -> None:
+    """Bus handler — translates an agent event into an ActivityEvent.
+
+    Defensive: a malformed bus payload (missing workspace_id, weird
+    types) drops the entry rather than crashing the bus. The bus already
+    wraps each handler in try/except but we want the failure mode to
+    surface as a debug log, not a stacktrace.
+    """
+    data = event.data or {}
+    workspace_id = data.get("workspace_id") or data.get("workspace") or ""
+    if not workspace_id:
+        return
+    activity = ActivityEvent(
+        workspace_id=str(workspace_id),
+        kind=_extract_kind(event.type),
+        agent_id=data.get("agent_id"),
+        summary=_summarise(event),
+        pocket_id=data.get("pocket_id"),
+        ts=time.time(),
+        extra={"event_type": event.type, "raw": {k: v for k, v in data.items() if k != "raw"}},
+    )
+    get_buffer().push(activity)
+    # SSE fan-out: best-effort, no-op when there's no active stream in scope.
+    try:
+        from ee.cloud.chat.agent_service import push_sse_event
+
+        push_sse_event(
+            "activity.recorded",
+            {
+                "workspace_id": activity.workspace_id,
+                "kind": activity.kind,
+                "agent_id": activity.agent_id,
+                "summary": activity.summary,
+                "pocket_id": activity.pocket_id,
+                "ts": activity.ts,
+            },
+        )
+    except Exception:
+        logger.debug("activity SSE push failed; continuing", exc_info=True)
+
+
+_SUBSCRIBED_EVENT_TYPES = (
+    "agent.thinking",
+    "agent.tool_start",
+    "agent.tool_use",
+    "agent.tool_result",
+    "agent.stream_end",
+    # Forward-compat names — if a future bus event lands with these
+    # names we'll pick it up without changing the buffer.
+    "agent.tool_call",
+    "agent.completed",
+    "agent.waiting",
+)
+
+
+def register_activity_listeners() -> None:
+    """Wire the agent-event subscribers onto the singleton bus.
+
+    Idempotent at the framework level: ``mount_cloud`` calls this once.
+    Calling twice would register the handler twice, which would double
+    every entry — protect callers by checking the per-process flag.
+    """
+    global _registered
+    if _registered:
+        return
+    bus = get_bus()
+    for evt_type in _SUBSCRIBED_EVENT_TYPES:
+        bus.subscribe(evt_type, _handle_agent_event)
+    _registered = True
+
+
+_registered = False
+
+
+__all__ = [
+    "ActivityEvent",
+    "Buffer",
+    "get_buffer",
+    "register_activity_listeners",
+]

--- a/ee/cloud/mission_control/__init__.py
+++ b/ee/cloud/mission_control/__init__.py
@@ -1,0 +1,16 @@
+# ee/cloud/mission_control/__init__.py
+# Created: 2026-05-13 (feat/mission-control-facade) — workspace-aware façade
+# entity that composes Instinct pending actions / Pawprints + the in-process
+# activity buffer into the unified WorkItem shape the paw-enterprise Mission
+# Control UI consumes. PR 1 of the three-PR Mission Control series — Tasks
+# (PR 2) and Cycles (PR 3) plug into the same façade in follow-ups.
+"""Mission Control façade package.
+
+Re-exports the router so ``mount_cloud`` can import without reaching into
+``ee.cloud.mission_control.router`` explicitly. The 4-file shape inside
+mirrors ``ee/cloud/pockets/`` (the canonical reference per CLAUDE.md).
+"""
+
+from ee.cloud.mission_control.router import router
+
+__all__ = ["router"]

--- a/ee/cloud/mission_control/domain.py
+++ b/ee/cloud/mission_control/domain.py
@@ -1,0 +1,94 @@
+# ee/cloud/mission_control/domain.py
+# Created: 2026-05-13 (feat/mission-control-facade) — WorkItem value object
+# projecting Instinct's Action shape (and, later, the Tasks entity from PR 2)
+# into the unified frontend representation. Frozen dataclass per the ee/cloud
+# Code Rules (CLAUDE.md §3): workspace + assignee tenancy fields are required,
+# so constructing a WorkItem without them is a type error.
+"""Mission Control domain value objects.
+
+Pure-Python frozen dataclasses. No Beanie, no Pydantic, no FastAPI
+imports. The service maps from Instinct's ``Action`` (and other source
+shapes) into these; the DTO layer maps these into the wire response.
+
+Why this shape: the paw-enterprise mock UI consumes a single canonical
+``WorkItem`` for The Tray, Pawprints, Snags, and Agents-in-flight panes.
+That keeps the frontend store small. The audit doc
+(`docs/internal/2026-05-mission-control-backend-audit.md`) commits to it
+as the boundary between heterogeneous backend primitives and the
+homogeneous frontend feed.
+
+Tenancy:
+  - ``workspace_id`` is the active workspace. The façade service refuses
+    to construct a WorkItem without it. The pocket service already
+    enforces workspace scoping on its reads, so the façade can rely on
+    ``pockets_service.list_pockets(workspace_id, user_id)`` to gate which
+    Instinct actions are visible.
+  - ``assignee_kind`` / ``assignee_id`` mirror the polymorphic
+    assignment Tasks (PR 2) will carry. For PR 1 every Nudge surfaces as
+    ``assignee_kind="user"`` (Instinct is human-approval-driven).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+
+
+class WorkItemSection(StrEnum):
+    """The Mission Control pane a WorkItem belongs in."""
+
+    TRAY = "tray"  # awaiting approval — Instinct pending action
+    PAWPRINTS = "pawprints"  # approved / rejected — Instinct audit projection
+    SNAGS = "snags"  # blocked / failed
+    AGENTS = "agents"  # currently in-flight (Tasks, PR 2)
+
+
+class WorkItemStatus(StrEnum):
+    AWAITING_APPROVAL = "awaiting_approval"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    IN_PROGRESS = "in_progress"
+    DONE = "done"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+
+
+class AssigneeKind(StrEnum):
+    USER = "user"
+    AGENT = "agent"
+
+
+@dataclass(frozen=True)
+class WorkItem:
+    """Unified Mission Control work item.
+
+    The wire response (``WorkItemResponse``) is a 1:1 projection of these
+    fields — they're separated so callers that don't speak Pydantic
+    (CLI, jobs, bus handlers) can still construct + read them.
+    """
+
+    id: str
+    workspace_id: str
+    section: WorkItemSection
+    status: WorkItemStatus
+    title: str
+    description: str
+    assignee_kind: AssigneeKind
+    assignee_id: str
+    pocket_id: str | None
+    agent_id: str | None
+    source_kind: str  # 'nudge' (PR 1) | 'task' (PR 2) | 'cycle' (PR 3)
+    source_id: str
+    priority: str  # low | medium | high | critical
+    created_at: datetime | None
+    updated_at: datetime | None
+    fabric_refs: tuple[str, ...] = field(default_factory=tuple)
+
+
+__all__ = [
+    "AssigneeKind",
+    "WorkItem",
+    "WorkItemSection",
+    "WorkItemStatus",
+]

--- a/ee/cloud/mission_control/dto.py
+++ b/ee/cloud/mission_control/dto.py
@@ -1,0 +1,193 @@
+# ee/cloud/mission_control/dto.py
+# Created: 2026-05-13 (feat/mission-control-facade) — request + response DTOs
+# for the Mission Control façade. Request and response shapes are kept on
+# separate classes per ee/cloud rule #4 — never reuse a model across input
+# and output.
+"""Mission Control wire DTOs.
+
+The audit doc (``docs/internal/2026-05-mission-control-backend-audit.md``,
+section "A. ee/cloud/mission_control/") fixes the request + response
+shapes. Pydantic validation runs at the router boundary AND at the entry
+of every service function (per ee/cloud rule #6), so callers that hit
+the service directly (CLI, jobs, bus handlers) get the same input
+guarantees as HTTP callers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from ee.cloud.mission_control.domain import (
+    AssigneeKind,
+    WorkItem,
+    WorkItemSection,
+    WorkItemStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class ListWorkItemsRequest(BaseModel):
+    """Filters for ``GET /mission-control/items``.
+
+    All fields optional. ``section`` filters down to a single pane; the
+    other filters compose with it. ``limit`` caps the projected list
+    after Instinct fan-in so the response stays bounded even when the
+    backend store has thousands of historical rows.
+    """
+
+    section: WorkItemSection | None = None
+    agent: str | None = Field(default=None, description="Filter by agent id")
+    pocket: str | None = Field(default=None, description="Filter by pocket id")
+    limit: int = Field(default=50, ge=1, le=500)
+
+
+class BulkActionRequest(BaseModel):
+    """Body for the façade-level bulk endpoints.
+
+    Wraps Instinct's bulk endpoints with a workspace tenancy guard — the
+    façade resolves every ``id`` to a pocket and confirms the caller can
+    see the pocket before fanning out to Instinct. Ids that fail that
+    check come back in ``missing`` rather than raising.
+    """
+
+    ids: list[str] = Field(min_length=1)
+    note: str | None = None
+    reason: str | None = Field(
+        default=None,
+        description="Required for bulk-reject. Ignored on bulk-approve.",
+    )
+
+
+class BulkReassignRequest(BaseModel):
+    """Body for the (PR-2-blocked) bulk-reassign endpoint.
+
+    The Tasks entity ships in PR 2 with the assignee polymorphism this
+    needs; PR 1 surfaces this endpoint as a stub so the frontend can
+    wire its API client without conditional code paths.
+    """
+
+    class Assignee(BaseModel):
+        kind: AssigneeKind
+        id: str
+        name: str | None = None
+
+    ids: list[str] = Field(min_length=1)
+    to: Assignee
+
+
+class BulkSnoozeRequest(BaseModel):
+    """Body for the (PR-2-blocked) bulk-snooze endpoint. See note above."""
+
+    ids: list[str] = Field(min_length=1)
+    until_iso: str = Field(description="ISO-8601 timestamp to snooze until")
+
+
+class OutcomesQueryRequest(BaseModel):
+    """Query filters for ``GET /mission-control/outcomes``."""
+
+    window: str = Field(
+        default="24h",
+        description="Aggregation window — 1h, 24h, 7d.",
+        pattern=r"^(1h|24h|7d)$",
+    )
+
+
+class ListActivityRequest(BaseModel):
+    """Query filters for ``GET /mission-control/activity``."""
+
+    limit: int = Field(default=30, ge=1, le=200)
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class WorkItemResponse(BaseModel):
+    """Wire shape for one work item — mirrors :class:`WorkItem` 1:1."""
+
+    id: str
+    workspace_id: str
+    section: WorkItemSection
+    status: WorkItemStatus
+    title: str
+    description: str
+    assignee_kind: AssigneeKind
+    assignee_id: str
+    pocket_id: str | None = None
+    agent_id: str | None = None
+    source_kind: str
+    source_id: str
+    priority: str
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    fabric_refs: list[str] = Field(default_factory=list)
+
+
+def work_item_to_response(item: WorkItem) -> WorkItemResponse:
+    """Map a domain ``WorkItem`` to its wire DTO."""
+    return WorkItemResponse(
+        id=item.id,
+        workspace_id=item.workspace_id,
+        section=item.section,
+        status=item.status,
+        title=item.title,
+        description=item.description,
+        assignee_kind=item.assignee_kind,
+        assignee_id=item.assignee_id,
+        pocket_id=item.pocket_id,
+        agent_id=item.agent_id,
+        source_kind=item.source_kind,
+        source_id=item.source_id,
+        priority=item.priority,
+        created_at=item.created_at,
+        updated_at=item.updated_at,
+        fabric_refs=list(item.fabric_refs),
+    )
+
+
+class OutcomeSummaryResponse(BaseModel):
+    """Aggregated counts for the Outcomes pane.
+
+    Numbers are unchecked against historical drift — they're a live
+    snapshot of Instinct's audit table over the requested window. The
+    frontend formats them into the headline counters + sparkline.
+    """
+
+    window: str
+    total: int
+    approved: int
+    rejected: int
+    executed: int
+    failed: int
+    pending: int
+
+
+class ActivityEventResponse(BaseModel):
+    """Wire shape for an activity ticker entry."""
+
+    workspace_id: str
+    kind: str
+    agent_id: str | None = None
+    summary: str
+    pocket_id: str | None = None
+    ts: float
+
+
+__all__ = [
+    "ActivityEventResponse",
+    "BulkActionRequest",
+    "BulkReassignRequest",
+    "BulkSnoozeRequest",
+    "ListActivityRequest",
+    "ListWorkItemsRequest",
+    "OutcomeSummaryResponse",
+    "OutcomesQueryRequest",
+    "WorkItemResponse",
+    "work_item_to_response",
+]

--- a/ee/cloud/mission_control/router.py
+++ b/ee/cloud/mission_control/router.py
@@ -1,0 +1,134 @@
+# ee/cloud/mission_control/router.py
+# Created: 2026-05-13 (feat/mission-control-facade) — REST surface for the
+# Mission Control façade. Endpoints exactly as specified in the audit doc:
+# items list, bulk approve/reject, bulk reassign/snooze stubs (501 until
+# PR 2), outcomes summary, activity feed.
+"""Mission Control façade router.
+
+Thin per ee/cloud rule #4 — parses requests, delegates to
+``ee.cloud.mission_control.service``, returns DTOs. Errors flow as
+``CloudError`` (rule #10) — never ``HTTPException`` from here.
+
+Mount point: ``mount_cloud`` includes this router at ``/api/v1`` so the
+canonical URLs are:
+
+  GET  /api/v1/mission-control/items
+  POST /api/v1/mission-control/items/bulk-approve
+  POST /api/v1/mission-control/items/bulk-reject
+  POST /api/v1/mission-control/items/bulk-reassign   (501 — PR 2 wires it)
+  POST /api/v1/mission-control/items/bulk-snooze     (501 — PR 2 wires it)
+  GET  /api/v1/mission-control/outcomes
+  GET  /api/v1/mission-control/activity
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from ee.cloud._core.context import RequestContext, request_context
+from ee.cloud.license import require_license
+from ee.cloud.mission_control import service as mc_service
+from ee.cloud.mission_control.dto import (
+    ActivityEventResponse,
+    BulkActionRequest,
+    BulkReassignRequest,
+    BulkSnoozeRequest,
+    ListActivityRequest,
+    ListWorkItemsRequest,
+    OutcomesQueryRequest,
+    OutcomeSummaryResponse,
+    WorkItemResponse,
+)
+
+router = APIRouter(
+    prefix="/mission-control",
+    tags=["Mission Control"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.get("/items", response_model=list[WorkItemResponse])
+async def list_items(
+    section: str | None = Query(None),
+    agent: str | None = Query(None),
+    pocket: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=500),
+    ctx: RequestContext = Depends(request_context),
+) -> list[WorkItemResponse]:
+    """Workspace-aware work item feed.
+
+    Filters compose: ``section`` narrows to one pane; ``agent`` and
+    ``pocket`` further restrict; ``limit`` caps the projected list.
+    """
+    body = ListWorkItemsRequest(section=section, agent=agent, pocket=pocket, limit=limit)
+    return await mc_service.agent_list_work_items(ctx, body)
+
+
+@router.post("/items/bulk-approve")
+async def bulk_approve(
+    body: BulkActionRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> dict:
+    """Approve N pending Nudges. Returns ``{bulk_id, approved, missing}``."""
+    return await mc_service.agent_bulk_approve(ctx, body)
+
+
+@router.post("/items/bulk-reject")
+async def bulk_reject(
+    body: BulkActionRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> dict:
+    """Reject N pending Nudges. Requires non-empty ``reason``.
+
+    Returns ``{bulk_id, rejected, missing}``. The reason text lands on
+    every Action's ``rejected_reason`` AND on every audit row's
+    ``context.reason`` for soul-bridge replay.
+    """
+    return await mc_service.agent_bulk_reject(ctx, body)
+
+
+@router.post("/items/bulk-reassign")
+async def bulk_reassign(
+    body: BulkReassignRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> dict:
+    """Stub — surfaces 501 until the Tasks entity (PR 2) lands.
+
+    The endpoint exists so the frontend API client can wire it without
+    conditional code paths. Service returns a ``CloudError(501, ...)``
+    with the audit-doc reference in the message.
+    """
+    return await mc_service.agent_bulk_reassign(ctx, body)
+
+
+@router.post("/items/bulk-snooze")
+async def bulk_snooze(
+    body: BulkSnoozeRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> dict:
+    """Stub — surfaces 501 until the Tasks entity (PR 2) lands. See above."""
+    return await mc_service.agent_bulk_snooze(ctx, body)
+
+
+@router.get("/outcomes", response_model=OutcomeSummaryResponse)
+async def outcomes(
+    window: str = Query("24h", pattern=r"^(1h|24h|7d)$"),
+    ctx: RequestContext = Depends(request_context),
+) -> OutcomeSummaryResponse:
+    """Aggregated outcome counts over ``window`` (1h | 24h | 7d)."""
+    body = OutcomesQueryRequest(window=window)
+    return await mc_service.agent_outcomes_summary(ctx, body)
+
+
+@router.get("/activity", response_model=list[ActivityEventResponse])
+async def activity(
+    limit: int = Query(30, ge=1, le=200),
+    ctx: RequestContext = Depends(request_context),
+) -> list[ActivityEventResponse]:
+    """In-memory live activity feed for the workspace.
+
+    Bounded ring buffer (~200 entries) with a 1-hour TTL. Restart wipes
+    history by design — durability lives in Pawprints.
+    """
+    body = ListActivityRequest(limit=limit)
+    return await mc_service.agent_list_activity(ctx, body)

--- a/ee/cloud/mission_control/service.py
+++ b/ee/cloud/mission_control/service.py
@@ -1,0 +1,429 @@
+# ee/cloud/mission_control/service.py
+# Created: 2026-05-13 (feat/mission-control-facade) — façade service that
+# composes Instinct (Nudges + Pawprints) and the in-process activity buffer
+# into Mission Control's unified WorkItem shape. PR 1 of three. The Tasks
+# entity (PR 2) and Cycles entity (PR 3) plug into the same service surface
+# without changing the wire contract.
+"""Mission Control façade service.
+
+Every function is module-level ``async def`` per ee/cloud rule #5. The
+first line of each is ``body = <Request>.model_validate(body)`` (rule #6)
+so callers from non-HTTP entry points (CLI, bus handlers, jobs) get the
+same validation guarantees as HTTP routes.
+
+Tenancy:
+  - Service signature is ``(ctx, body)`` — the workspace lives on
+    ``ctx.workspace_id``. We never accept ``workspace_id`` as a
+    standalone arg (rule #5).
+  - The instinct store is workspace-agnostic at its schema, but we filter
+    via the pocket layer: a Nudge surfaces in Mission Control only if
+    its pocket is visible to the caller's workspace. The pockets
+    service's ``list_pockets`` already enforces this so we can rely on
+    it as the chokepoint.
+
+No Beanie writes here — the façade is read-only against Instinct + the
+activity buffer in PR 1. Bulk-approve / bulk-reject delegate to
+``ee.instinct.store`` (single ownership of the audit transaction lives
+inside Instinct's store). Bulk-reassign / bulk-snooze raise 501 until
+the Tasks entity (PR 2) lands the polymorphic assignee they need.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+from ee.api import get_instinct_store
+from ee.cloud._core.context import RequestContext
+from ee.cloud._core.errors import CloudError, ValidationError
+from ee.cloud.activity.buffer import ActivityEvent, get_buffer
+from ee.cloud.mission_control.domain import (
+    AssigneeKind,
+    WorkItem,
+    WorkItemSection,
+    WorkItemStatus,
+)
+from ee.cloud.mission_control.dto import (
+    ActivityEventResponse,
+    BulkActionRequest,
+    BulkReassignRequest,
+    BulkSnoozeRequest,
+    ListActivityRequest,
+    ListWorkItemsRequest,
+    OutcomesQueryRequest,
+    OutcomeSummaryResponse,
+    WorkItemResponse,
+    work_item_to_response,
+)
+from ee.cloud.pockets import service as pockets_service
+from ee.instinct.models import Action, ActionStatus
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_workspace(ctx: RequestContext) -> str:
+    """Refuse to project anything without a workspace.
+
+    Every Mission Control surface is workspace-scoped — there is no
+    cross-tenant view by design. A request with ``ctx.workspace_id is
+    None`` is a programmer error (probably forgot to set the active
+    workspace on the user) and surfaces as 422 instead of silently
+    leaking another tenant's data.
+    """
+    if not ctx.workspace_id:
+        raise ValidationError(
+            "mission_control.workspace_required",
+            "Mission Control requires an active workspace on the request context.",
+        )
+    return ctx.workspace_id
+
+
+async def _visible_pocket_ids(ctx: RequestContext) -> set[str]:
+    """Return the set of pocket ids the caller can see in their workspace.
+
+    Drives the workspace filter on Instinct reads: a Nudge surfaces in
+    Mission Control only if its ``pocket_id`` is in this set. We rely on
+    ``pockets_service.list_pockets`` as the chokepoint — it already
+    enforces ``workspace + (owner | shared_with | visibility)`` per
+    pocket. If a pocket isn't visible at the pocket layer, its Nudges
+    aren't visible at the Mission Control layer either.
+    """
+    workspace_id = _require_workspace(ctx)
+    pockets = await pockets_service.list_pockets(workspace_id, ctx.user_id)
+    return {p["_id"] for p in pockets if p.get("_id")}
+
+
+def _status_to_section_status(s: ActionStatus) -> tuple[WorkItemSection, WorkItemStatus]:
+    """Map Instinct ``ActionStatus`` to the (section, status) pair Mission
+    Control consumes."""
+    if s == ActionStatus.PENDING:
+        return WorkItemSection.TRAY, WorkItemStatus.AWAITING_APPROVAL
+    if s == ActionStatus.APPROVED:
+        return WorkItemSection.PAWPRINTS, WorkItemStatus.APPROVED
+    if s == ActionStatus.REJECTED:
+        return WorkItemSection.PAWPRINTS, WorkItemStatus.REJECTED
+    if s == ActionStatus.EXECUTED:
+        return WorkItemSection.PAWPRINTS, WorkItemStatus.DONE
+    if s == ActionStatus.FAILED:
+        return WorkItemSection.SNAGS, WorkItemStatus.FAILED
+    # Defensive — new enum values fall through to the SNAGS pane so they
+    # don't disappear from the operator console without explicit handling.
+    return WorkItemSection.SNAGS, WorkItemStatus.BLOCKED
+
+
+def _action_to_work_item(action: Action, workspace_id: str) -> WorkItem:
+    """Project an Instinct ``Action`` into a Mission Control ``WorkItem``.
+
+    The assignee field on Instinct is optional — when missing we surface
+    the trigger source as the implicit assignee so The Tray still shows
+    "who needs to act". This matches the operator mental model better
+    than an empty avatar slot.
+    """
+    section, status = _status_to_section_status(action.status)
+    assignee_id = action.assignee or _trigger_assignee(action) or ""
+    agent_id = action.trigger.source if action.trigger.type == "agent" else None
+    return WorkItem(
+        id=f"nudge:{action.id}",
+        workspace_id=workspace_id,
+        section=section,
+        status=status,
+        title=action.title,
+        description=action.description or action.recommendation or "",
+        assignee_kind=AssigneeKind.USER,
+        assignee_id=assignee_id,
+        pocket_id=action.pocket_id,
+        agent_id=agent_id,
+        source_kind="nudge",
+        source_id=action.id,
+        priority=action.priority.value,
+        created_at=action.created_at,
+        updated_at=action.updated_at,
+        fabric_refs=tuple(action.context.object_ids) if action.context else (),
+    )
+
+
+def _trigger_assignee(action: Action) -> str | None:
+    """Extract the implicit assignee from the trigger when the explicit
+    ``assignee`` column is unset.
+
+    Heuristic: if the trigger is human-sourced (``type='user'``) the
+    source IS the assignee — the human routed the work to themselves or
+    to a colleague captured in the source. Otherwise we have no signal
+    and return None.
+    """
+    if action.trigger and action.trigger.type == "user":
+        return action.trigger.source
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public service API
+# ---------------------------------------------------------------------------
+
+
+async def agent_list_work_items(
+    ctx: RequestContext, body: ListWorkItemsRequest | dict[str, Any]
+) -> list[WorkItemResponse]:
+    """List work items for the active workspace.
+
+    Source-of-truth for PR 1 is Instinct: the pending feed populates The
+    Tray, the audit projection populates Pawprints + Snags. PR 2 plugs
+    Tasks into the same response so the frontend doesn't have to switch
+    code paths when Tasks lands.
+    """
+    body = ListWorkItemsRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+    visible = await _visible_pocket_ids(ctx)
+    if not visible:
+        return []
+
+    store = get_instinct_store()
+    # Pull pending + recent resolved in two reads. The pending list lives
+    # under the section=TRAY bucket; the audit projection covers the rest.
+    pending = await store.pending(pocket_id=body.pocket)
+    resolved = await store.list_actions(pocket_id=body.pocket, limit=200)
+
+    actions: list[Action] = []
+    seen: set[str] = set()
+    for a in (*pending, *resolved):
+        if a.id in seen:
+            continue
+        if a.pocket_id not in visible:
+            continue
+        if body.agent and a.trigger.source != body.agent:
+            continue
+        seen.add(a.id)
+        actions.append(a)
+
+    items = [_action_to_work_item(a, workspace_id) for a in actions]
+    if body.section is not None:
+        items = [it for it in items if it.section == body.section]
+    # Stable order: newest first by created_at, falling back to id.
+    items.sort(key=lambda it: (it.created_at or datetime.min, it.id), reverse=True)
+    return [work_item_to_response(it) for it in items[: body.limit]]
+
+
+async def agent_bulk_approve(
+    ctx: RequestContext, body: BulkActionRequest | dict[str, Any]
+) -> dict[str, Any]:
+    """Approve N pending Nudges in one call.
+
+    Tenancy: each id is checked against the caller's visible-pocket set
+    before fanning out to Instinct. Ids that fail that check come back
+    in ``missing`` rather than approving across tenants. The shared
+    ``bulk_id`` lives in every audit row's ``context.bulk_id`` so the
+    operator can recover the bulk transaction.
+    """
+    body = BulkActionRequest.model_validate(body)
+    _require_workspace(ctx)
+    visible = await _visible_pocket_ids(ctx)
+    store = get_instinct_store()
+    eligible, blocked = await _split_ids_by_tenancy(store, list(body.ids), visible)
+    approved, missing, bulk_id = await store.bulk_approve(
+        eligible, approver=ctx.user_id, note=body.note
+    )
+    return {
+        "bulk_id": bulk_id,
+        "approved": [a.model_dump(mode="json") for a in approved],
+        "missing": [*missing, *blocked],
+    }
+
+
+async def agent_bulk_reject(
+    ctx: RequestContext, body: BulkActionRequest | dict[str, Any]
+) -> dict[str, Any]:
+    """Reject N pending Nudges in one call. ``reason`` is required.
+
+    Same tenancy semantics as ``agent_bulk_approve``. The reason text is
+    surfaced on every Action's ``rejected_reason`` AND on every audit
+    row's ``context.reason`` so the soul-bridge correction pipeline can
+    learn from bulk rejects the same way it learns from single-item
+    rejects.
+    """
+    body = BulkActionRequest.model_validate(body)
+    if not body.reason:
+        raise ValidationError(
+            "mission_control.reason_required",
+            "bulk-reject requires a reason — pass a non-empty string in ``reason``.",
+        )
+    _require_workspace(ctx)
+    visible = await _visible_pocket_ids(ctx)
+    store = get_instinct_store()
+    eligible, blocked = await _split_ids_by_tenancy(store, list(body.ids), visible)
+    rejected, missing, bulk_id = await store.bulk_reject(
+        eligible, reason=body.reason, rejector=ctx.user_id
+    )
+    return {
+        "bulk_id": bulk_id,
+        "rejected": [a.model_dump(mode="json") for a in rejected],
+        "missing": [*missing, *blocked],
+    }
+
+
+async def _split_ids_by_tenancy(
+    store: Any, ids: list[str], visible_pockets: set[str]
+) -> tuple[list[str], list[str]]:
+    """Partition ``ids`` into (visible-to-caller, blocked).
+
+    Reads each Action once to look up its pocket. Cheap for the bulk
+    sizes Mission Control surfaces (UI selection is bounded by the page
+    of items the operator sees). Missing rows fall on the eligible side
+    so Instinct's store returns them in its own ``missing`` slot and the
+    bulk-action response carries a single deduplicated list.
+    """
+    eligible: list[str] = []
+    blocked: list[str] = []
+    for action_id in ids:
+        action = await store.get_action(action_id)
+        if action is None:
+            # Unknown ids stay eligible — Instinct's bulk_* returns them
+            # in ``missing`` with no audit side-effect, which is the
+            # behavior the operator console expects.
+            eligible.append(action_id)
+            continue
+        if action.pocket_id in visible_pockets:
+            eligible.append(action_id)
+        else:
+            blocked.append(action_id)
+    return eligible, blocked
+
+
+async def agent_outcomes_summary(
+    ctx: RequestContext, body: OutcomesQueryRequest | dict[str, Any]
+) -> OutcomeSummaryResponse:
+    """Aggregate Instinct audit counts over the requested window.
+
+    The window options map to a simple wall-clock cutoff applied in
+    Python; there's no Mongo $match $group pipeline because Instinct
+    lives on SQLite. For workspaces with millions of audit rows we'd
+    push this into a SQL aggregate; the current call volume keeps the
+    in-process scan well under the 50ms TimingMiddleware budget.
+    """
+    body = OutcomesQueryRequest.model_validate(body)
+    _require_workspace(ctx)
+    visible = await _visible_pocket_ids(ctx)
+    store = get_instinct_store()
+    cutoff = datetime.now() - _window_to_delta(body.window)
+
+    # Pull a generous slice and filter in Python. ``list_actions`` does
+    # ORDER BY created_at DESC LIMIT, so the slice is the newest N.
+    actions = await store.list_actions(limit=500)
+    in_window = [
+        a
+        for a in actions
+        if a.pocket_id in visible and (a.updated_at or a.created_at or datetime.min) >= cutoff
+    ]
+
+    counters: dict[str, int] = {s.value: 0 for s in ActionStatus}
+    for a in in_window:
+        counters[a.status.value] = counters.get(a.status.value, 0) + 1
+
+    return OutcomeSummaryResponse(
+        window=body.window,
+        total=len(in_window),
+        approved=counters.get(ActionStatus.APPROVED.value, 0),
+        rejected=counters.get(ActionStatus.REJECTED.value, 0),
+        executed=counters.get(ActionStatus.EXECUTED.value, 0),
+        failed=counters.get(ActionStatus.FAILED.value, 0),
+        pending=counters.get(ActionStatus.PENDING.value, 0),
+    )
+
+
+def _window_to_delta(window: str) -> timedelta:
+    """Map the window string to a timedelta. Validated upstream by the
+    DTO regex; defaults to 24h as a safety net."""
+    if window == "1h":
+        return timedelta(hours=1)
+    if window == "24h":
+        return timedelta(hours=24)
+    if window == "7d":
+        return timedelta(days=7)
+    return timedelta(hours=24)
+
+
+async def agent_list_activity(
+    ctx: RequestContext, body: ListActivityRequest | dict[str, Any]
+) -> list[ActivityEventResponse]:
+    """Return the live activity ticker for the active workspace.
+
+    Reads from the in-process buffer (``ee.cloud.activity.buffer``).
+    Buffer is bounded + TTL'd so the response is cheap; restarts wipe
+    history by design (durable record lives in Pawprints).
+    """
+    body = ListActivityRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+    entries = get_buffer().get_recent(workspace_id, limit=body.limit)
+    return [_activity_to_response(e) for e in entries]
+
+
+def _activity_to_response(e: ActivityEvent) -> ActivityEventResponse:
+    return ActivityEventResponse(
+        workspace_id=e.workspace_id,
+        kind=e.kind,
+        agent_id=e.agent_id,
+        summary=e.summary,
+        pocket_id=e.pocket_id,
+        ts=e.ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 501 stubs — wait for PR 2 (Tasks)
+# ---------------------------------------------------------------------------
+
+
+async def agent_bulk_reassign(
+    ctx: RequestContext, body: BulkReassignRequest | dict[str, Any]
+) -> dict[str, Any]:
+    """Bulk reassign is gated on the Tasks entity (PR 2).
+
+    Instinct's Action doesn't carry a polymorphic assignee — the column
+    we added in this PR is ``assignee: str`` (a user id), not the
+    ``{kind, id, name}`` shape Mission Control needs. The Tasks entity
+    ships PR 2 with that shape; this endpoint stays as a 501 until then
+    so the frontend can wire its API client without conditional code.
+    """
+    body = BulkReassignRequest.model_validate(body)
+    _require_workspace(ctx)
+    raise CloudError(
+        501,
+        "mission_control.not_implemented",
+        (
+            "bulk-reassign needs the Tasks entity (PR 2 of the Mission Control "
+            "series). PR 1 ships only the Instinct façade — see "
+            "docs/internal/2026-05-mission-control-backend-audit.md."
+        ),
+    )
+
+
+async def agent_bulk_snooze(
+    ctx: RequestContext, body: BulkSnoozeRequest | dict[str, Any]
+) -> dict[str, Any]:
+    """Bulk snooze is gated on the Tasks entity (PR 2). See above."""
+    body = BulkSnoozeRequest.model_validate(body)
+    _require_workspace(ctx)
+    raise CloudError(
+        501,
+        "mission_control.not_implemented",
+        (
+            "bulk-snooze needs the Tasks entity (PR 2 of the Mission Control "
+            "series) to carry the snooze-until field on the work item."
+        ),
+    )
+
+
+__all__ = [
+    "agent_bulk_approve",
+    "agent_bulk_reassign",
+    "agent_bulk_reject",
+    "agent_bulk_snooze",
+    "agent_list_activity",
+    "agent_list_work_items",
+    "agent_outcomes_summary",
+]

--- a/ee/instinct/models.py
+++ b/ee/instinct/models.py
@@ -1,5 +1,7 @@
 # Instinct data models — decision pipeline types.
 # Created: 2026-03-28
+# Updated: 2026-05-13 (feat/mission-control-facade) — added optional ``assignee``
+#   to Action so The Tray can filter pending items to a specific human approver.
 
 from __future__ import annotations
 
@@ -71,6 +73,14 @@ class Action(BaseModel):
     approved_by: str | None = None
     approved_at: datetime | None = None
     rejected_reason: str | None = None
+    assignee: str | None = Field(
+        default=None,
+        description=(
+            "Optional human user id the Nudge is awaiting approval from. "
+            "Used by Mission Control's The Tray feed to filter to items "
+            "the current operator owns."
+        ),
+    )
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
     executed_at: datetime | None = None

--- a/ee/instinct/router.py
+++ b/ee/instinct/router.py
@@ -22,6 +22,12 @@
 #   business-tier (or higher) plans. Closes the plan-tier bypass where a
 #   team-plan member who passed the workspace RBAC check still hit Instinct for
 #   free.
+# Updated: 2026-05-13 (feat/mission-control-facade) — added ``assignee`` query
+#   param to GET /instinct/actions/pending (filter The Tray to a single human's
+#   queue) plus POST /instinct/actions/bulk-approve and
+#   POST /instinct/actions/bulk-reject. Bulk endpoints write N audit rows with
+#   a shared ``bulk_id`` UUID so the bulk transaction is replay-able per item
+#   and query-able as a unit.
 
 from __future__ import annotations
 
@@ -144,6 +150,54 @@ class CorrectionsListResponse(BaseModel):
     total: int
 
 
+class BulkApproveRequest(BaseModel):
+    """Body for POST /instinct/actions/bulk-approve.
+
+    ``ids`` is the list of pending action ids to flip to approved. ``note``
+    is an optional operator-supplied note tagged onto every audit row in
+    the bulk transaction (also surfaced in the shared ``bulk_id`` group).
+    """
+
+    ids: list[str] = Field(min_length=1)
+    note: str | None = None
+    approver: str = "user"
+
+
+class BulkRejectRequest(BaseModel):
+    """Body for POST /instinct/actions/bulk-reject.
+
+    ``reason`` is required — the UI gates the bulk-reject button behind a
+    typed reason. The server enforces non-empty so we don't end up with
+    silently rejected items that confuse a later audit review.
+    """
+
+    ids: list[str] = Field(min_length=1)
+    reason: str = Field(min_length=1)
+    rejector: str = "user"
+
+
+class BulkActionResponse(BaseModel):
+    """Response shape for both bulk-approve and bulk-reject."""
+
+    bulk_id: str = Field(
+        description=(
+            "UUID4 hex tag stamped onto every audit row written for this "
+            "bulk transaction. Query ``GET /instinct/audit`` and filter "
+            "client-side on ``context.bulk_id`` to recover the group."
+        ),
+    )
+    affected: list[Action]
+    missing: list[str] = Field(
+        default_factory=list,
+        description=(
+            "IDs that did not flip — either the row didn't exist or it was "
+            "not in ``pending`` state. The frontend can surface these "
+            "individually so the operator knows which items still need "
+            "manual attention."
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Action endpoints
 # ---------------------------------------------------------------------------
@@ -181,9 +235,20 @@ async def propose_action(req: ProposeRequest):
     response_model=list[Action],
     dependencies=[Depends(require_action_any_workspace("instinct.read"))],
 )
-async def pending_actions(pocket_id: str | None = Query(None)):
+async def pending_actions(
+    pocket_id: str | None = Query(None),
+    assignee: str | None = Query(
+        None,
+        description=(
+            "Filter to actions awaiting approval from a specific human "
+            "(user id). Drives The Tray in Mission Control so an operator "
+            "only sees the items they own. When omitted, behavior is "
+            "unchanged from before — every pending item is returned."
+        ),
+    ),
+):
     """List actions waiting for human approval."""
-    return await _store().pending(pocket_id=pocket_id)
+    return await _store().pending(pocket_id=pocket_id, assignee=assignee)
 
 
 @router.get(
@@ -207,6 +272,52 @@ async def list_actions(
         limit=limit,
     )
     return ActionsListResponse(actions=actions, total=len(actions))
+
+
+# Bulk endpoints must be registered BEFORE the parameterised
+# ``/instinct/actions/{action_id}/approve`` and ``.../reject`` routes:
+# FastAPI matches in registration order and ``bulk-approve`` would
+# otherwise be eaten by ``{action_id}`` and fail validation.
+@router.post(
+    "/instinct/actions/bulk-approve",
+    response_model=BulkActionResponse,
+    dependencies=[Depends(require_action_any_workspace("instinct.approve"))],
+)
+async def bulk_approve_actions(req: BulkApproveRequest) -> BulkActionResponse:
+    """Approve N pending actions in one call.
+
+    Each item is flipped individually (so per-item audit replay still
+    works) but every audit row carries a shared ``bulk_id`` UUID under
+    ``context.bulk_id``. The operator can query the audit log filtered
+    by that key to recover the bulk transaction as a unit. Items that
+    are missing or already resolved come back in ``missing`` rather than
+    raising — a partial-success surface beats a single all-or-nothing
+    failure on the operator console.
+    """
+    approved, missing, bulk_id = await _store().bulk_approve(
+        list(req.ids), approver=req.approver, note=req.note
+    )
+    return BulkActionResponse(bulk_id=bulk_id, affected=approved, missing=missing)
+
+
+@router.post(
+    "/instinct/actions/bulk-reject",
+    response_model=BulkActionResponse,
+    dependencies=[Depends(require_action_any_workspace("instinct.approve"))],
+)
+async def bulk_reject_actions(req: BulkRejectRequest) -> BulkActionResponse:
+    """Reject N pending actions in one call. ``reason`` is required.
+
+    Mirrors ``bulk_approve_actions``: shared ``bulk_id``, per-item audit
+    rows, partial-success surface via ``missing``. The reason text lands
+    on every audit row's ``context.reason`` and on each Action's
+    ``rejected_reason`` so the soul-bridge correction pipeline still
+    sees the same shape it sees on single-item rejects.
+    """
+    rejected, missing, bulk_id = await _store().bulk_reject(
+        list(req.ids), reason=req.reason, rejector=req.rejector
+    )
+    return BulkActionResponse(bulk_id=bulk_id, affected=rejected, missing=missing)
 
 
 @router.post(

--- a/ee/instinct/store.py
+++ b/ee/instinct/store.py
@@ -8,6 +8,13 @@
 #   record_fabric_snapshot/get_snapshots_*. propose() now accepts optional
 #   reasoning_trace and fabric_snapshots, persisting the trace as JSON inside
 #   AuditEntry.context["reasoning_trace"] and keying snapshots to the audit row.
+# Updated: 2026-05-13 (feat/mission-control-facade) — added optional ``assignee``
+#   column on ``instinct_actions`` (additive migration; pre-existing rows have
+#   NULL). ``propose()`` and ``pending()`` now accept an ``assignee`` argument so
+#   The Tray in Mission Control can filter to the items awaiting a specific
+#   human. ``bulk_approve()`` / ``bulk_reject()`` write N audit rows sharing a
+#   single ``bulk_id`` UUID in ``context['bulk_id']`` so the operator can replay
+#   per-item or query by the bulk transaction.
 
 from __future__ import annotations
 
@@ -31,6 +38,27 @@ from ee.instinct.models import (
 )
 from ee.instinct.trace import FabricObjectSnapshot, ReasoningTrace
 
+
+def _parse_iso(value: Any) -> datetime | None:
+    """Permissive ISO-8601 parse used by the row mappers.
+
+    SQLite's ``datetime('now')`` default returns a space-separated
+    ``YYYY-MM-DD HH:MM:SS`` string while application-side writes use
+    ``datetime.isoformat()`` (T-separated). Accept both, return ``None``
+    on anything we can't parse so a malformed row doesn't crash a read.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace(" ", "T", 1))
+        except ValueError:
+            return None
+    return None
+
+
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS instinct_actions (
     id TEXT PRIMARY KEY,
@@ -49,6 +77,7 @@ CREATE TABLE IF NOT EXISTS instinct_actions (
     approved_by TEXT,
     approved_at TEXT,
     rejected_reason TEXT,
+    assignee TEXT,
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now')),
     executed_at TEXT
@@ -111,6 +140,14 @@ class InstinctStore:
             return
         async with aiosqlite.connect(self._db_path) as db:
             await db.executescript(SCHEMA_SQL)
+            # Additive migration: ``assignee`` column landed in 2026-05-13 for
+            # Mission Control's per-human filter. CREATE TABLE IF NOT EXISTS
+            # won't add it to a pre-existing DB, so we ALTER and swallow the
+            # duplicate-column error that fires on every subsequent boot.
+            try:
+                await db.execute("ALTER TABLE instinct_actions ADD COLUMN assignee TEXT")
+            except aiosqlite.OperationalError:
+                pass
             await db.commit()
         self._initialized = True
 
@@ -133,6 +170,7 @@ class InstinctStore:
         context: ActionContext | None = None,
         reasoning_trace: ReasoningTrace | None = None,
         fabric_snapshots: list[FabricObjectSnapshot] | None = None,
+        assignee: str | None = None,
     ) -> Action:
         action = Action(
             pocket_id=pocket_id,
@@ -144,6 +182,7 @@ class InstinctStore:
             priority=priority,
             parameters=parameters or {},
             context=context or ActionContext(),
+            assignee=assignee,
         )
         await self._ensure_schema()
         async with self._conn() as db:
@@ -151,8 +190,8 @@ class InstinctStore:
                 "INSERT INTO instinct_actions"
                 " (id, pocket_id, title, description,"
                 " category, status, priority, trigger,"
-                " recommendation, parameters, context)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " recommendation, parameters, context, assignee)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     action.id,
                     pocket_id,
@@ -165,6 +204,7 @@ class InstinctStore:
                     recommendation,
                     json.dumps(parameters or {}),
                     action.context.model_dump_json(),
+                    assignee,
                 ),
             )
             await db.commit()
@@ -212,6 +252,88 @@ class InstinctStore:
             extra_desc=f" — {reason}" if reason else "",
         )
 
+    # ------------------------------------------------------------------
+    # Bulk lifecycle
+    # ------------------------------------------------------------------
+    #
+    # Mission Control's bulk action bar selects N items and POSTs them in one
+    # request. We fan out per-item so the audit replay stays per-item, but
+    # tag every audit row with a shared ``bulk_id`` UUID so the operator can
+    # query the audit log for the bulk transaction as a unit.
+
+    async def bulk_approve(
+        self,
+        action_ids: list[str],
+        *,
+        approver: str = "user",
+        note: str | None = None,
+        bulk_id: str | None = None,
+    ) -> tuple[list[Action], list[str], str]:
+        """Approve N pending actions with a shared ``bulk_id`` audit tag.
+
+        Returns ``(approved, missing, bulk_id)``. ``missing`` carries the
+        ids that didn't resolve (no matching row, or wrong status). The
+        caller chooses how to surface partial failures.
+        """
+        from uuid import uuid4 as _uuid4
+
+        bulk = bulk_id or _uuid4().hex
+        approved: list[Action] = []
+        missing: list[str] = []
+        for action_id in action_ids:
+            action = await self._update_status(
+                action_id,
+                ActionStatus.APPROVED,
+                approved_by=approver,
+                approved_at=datetime.now().isoformat(),
+                event="action_approved",
+                actor=approver,
+                require_status=ActionStatus.PENDING,
+                audit_context={"bulk_id": bulk, **({"note": note} if note else {})},
+            )
+            if action is None:
+                missing.append(action_id)
+            else:
+                approved.append(action)
+        return approved, missing, bulk
+
+    async def bulk_reject(
+        self,
+        action_ids: list[str],
+        *,
+        reason: str,
+        rejector: str = "user",
+        bulk_id: str | None = None,
+    ) -> tuple[list[Action], list[str], str]:
+        """Reject N pending actions with a shared ``bulk_id`` audit tag.
+
+        ``reason`` is required to mirror the bulk-reject UX gate (you have
+        to type a reason in the action bar before the button enables).
+        Returns ``(rejected, missing, bulk_id)`` with the same semantics
+        as :meth:`bulk_approve`.
+        """
+        from uuid import uuid4 as _uuid4
+
+        bulk = bulk_id or _uuid4().hex
+        rejected: list[Action] = []
+        missing: list[str] = []
+        for action_id in action_ids:
+            action = await self._update_status(
+                action_id,
+                ActionStatus.REJECTED,
+                rejected_reason=reason,
+                event="action_rejected",
+                actor=rejector,
+                extra_desc=f" — {reason}" if reason else "",
+                require_status=ActionStatus.PENDING,
+                audit_context={"bulk_id": bulk, "reason": reason},
+            )
+            if action is None:
+                missing.append(action_id)
+            else:
+                rejected.append(action)
+        return rejected, missing, bulk
+
     async def mark_executed(self, action_id: str, outcome: str | None = None) -> Action | None:
         return await self._update_status(
             action_id,
@@ -240,10 +362,17 @@ class InstinctStore:
         event: str,
         actor: str,
         extra_desc: str = "",
+        audit_context: dict[str, Any] | None = None,
+        require_status: ActionStatus | None = None,
         **fields: Any,
     ) -> Action | None:
         action = await self.get_action(action_id)
         if not action:
+            return None
+        # ``require_status`` lets bulk callers enforce "only act on rows
+        # still in this state" without breaking the existing pending →
+        # approved → executed flow used by mark_executed / mark_failed.
+        if require_status is not None and action.status != require_status:
             return None
 
         sets = ["status = ?", "updated_at = datetime('now')"]
@@ -265,6 +394,7 @@ class InstinctStore:
             actor=actor,
             event=event,
             description=f"{event.replace('_', ' ').title()}: {action.title}{extra_desc}",
+            context=audit_context,
         )
         return await self.get_action(action_id)
 
@@ -278,8 +408,12 @@ class InstinctStore:
                 row = await cur.fetchone()
                 return self._row_to_action(row) if row else None
 
-    async def pending(self, pocket_id: str | None = None) -> list[Action]:
-        return await self._query_actions(status=ActionStatus.PENDING, pocket_id=pocket_id)
+    async def pending(
+        self, pocket_id: str | None = None, assignee: str | None = None
+    ) -> list[Action]:
+        return await self._query_actions(
+            status=ActionStatus.PENDING, pocket_id=pocket_id, assignee=assignee
+        )
 
     async def pending_count(self, pocket_id: str | None = None) -> int:
         cond = "WHERE status = 'pending'"
@@ -310,6 +444,7 @@ class InstinctStore:
         status: ActionStatus | None = None,
         pocket_id: str | None = None,
         limit: int = 500,
+        assignee: str | None = None,
     ) -> list[Action]:
         conditions: list[str] = []
         params: list[Any] = []
@@ -319,6 +454,9 @@ class InstinctStore:
         if pocket_id:
             conditions.append("pocket_id = ?")
             params.append(pocket_id)
+        if assignee:
+            conditions.append("assignee = ?")
+            params.append(assignee)
         where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
         params.append(limit)
 
@@ -554,6 +692,17 @@ class InstinctStore:
     # --- Helpers ---
 
     def _row_to_action(self, row: Any) -> Action:
+        # ``assignee`` landed in 2026-05-13 (Mission Control). Old DBs may
+        # still surface a row missing the column despite the migration in
+        # ``_ensure_schema`` — use a key check so ``aiosqlite.Row`` (which
+        # raises IndexError on unknown keys) doesn't break the read.
+        assignee = row["assignee"] if "assignee" in row.keys() else None
+        # The SQLite layer stamps created_at/updated_at as ISO strings.
+        # Forward them on the rebuilt Action so consumers (outcome window
+        # filters, age sorting) see real history instead of "now". Old
+        # rows that ever had a NULL fall back to None.
+        created_at = _parse_iso(row["created_at"]) if "created_at" in row.keys() else None
+        updated_at = _parse_iso(row["updated_at"]) if "updated_at" in row.keys() else None
         return Action(
             id=row["id"],
             pocket_id=row["pocket_id"],
@@ -572,6 +721,9 @@ class InstinctStore:
             error=row["error"],
             approved_by=row["approved_by"],
             rejected_reason=row["rejected_reason"],
+            assignee=assignee,
+            **({"created_at": created_at} if created_at else {}),
+            **({"updated_at": updated_at} if updated_at else {}),
         )
 
     def _row_to_audit(self, row: Any) -> AuditEntry:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -580,3 +580,25 @@ forbidden_modules = [
     "ee.cloud.models.user",
     "ee.cloud.models.agent",
 ]
+
+# Mission Control façade — the façade reads through Instinct's store
+# (SQLite) plus the in-process activity buffer; it has no Beanie
+# collection of its own in PR 1. The forbidden contract here keeps the
+# router/dto/domain from sprouting one accidentally — when the Tasks
+# entity ships (PR 2) it adds its own ``models.work_item`` entry to the
+# forbidden list, matching the canonical Pockets shape.
+[[tool.importlinter.contracts]]
+name = "Mission Control — no Beanie touches from façade layer"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "ee.cloud.mission_control.router",
+    "ee.cloud.mission_control.dto",
+    "ee.cloud.mission_control.domain",
+]
+forbidden_modules = [
+    "ee.cloud.models.pocket",
+    "ee.cloud.models.notification",
+    "ee.cloud.models.user",
+    "ee.cloud.models.agent",
+]

--- a/tests/cloud/test_activity_buffer.py
+++ b/tests/cloud/test_activity_buffer.py
@@ -1,0 +1,176 @@
+# tests/cloud/test_activity_buffer.py
+# Created: 2026-05-13 (feat/mission-control-facade) — coverage for the
+# per-workspace activity ring buffer that feeds Mission Control's live
+# ticker. Asserts push, ordering, eviction, TTL pruning, and synchronous
+# fan-out to subscribers (used by the SSE bridge + tests).
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from ee.cloud._core.realtime.events import AgentThinking, AgentToolUse
+from ee.cloud.activity.buffer import ActivityEvent, Buffer, _handle_agent_event, get_buffer
+
+
+def _ev(
+    workspace_id: str = "w1",
+    kind: str = "tool_call",
+    ts: float | None = None,
+) -> ActivityEvent:
+    return ActivityEvent(
+        workspace_id=workspace_id,
+        kind=kind,
+        agent_id="agent-1",
+        summary="ran kb_search",
+        pocket_id="p1",
+        ts=ts if ts is not None else time.time(),
+    )
+
+
+class TestPushAndGetRecent:
+    def test_push_then_get_recent_returns_newest_first(self) -> None:
+        b = Buffer()
+        now = time.time()
+        b.push(_ev(ts=now))
+        b.push(_ev(ts=now + 1))
+        b.push(_ev(ts=now + 2))
+        out = b.get_recent("w1", limit=10)
+        expected = [round(now + 2, 3), round(now + 1, 3), round(now, 3)]
+        assert [round(e.ts, 3) for e in out] == expected
+
+    def test_get_recent_respects_limit(self) -> None:
+        b = Buffer()
+        now = time.time()
+        for i in range(20):
+            b.push(_ev(ts=now + i))
+        out = b.get_recent("w1", limit=5)
+        assert len(out) == 5
+        # newest first => now+19, now+18, ...
+        assert [round(e.ts, 3) for e in out] == [round(now + i, 3) for i in [19, 18, 17, 16, 15]]
+
+    def test_empty_workspace_returns_empty_list(self) -> None:
+        b = Buffer()
+        assert b.get_recent("never-seen-this-workspace") == []
+
+    def test_push_without_workspace_id_is_dropped(self) -> None:
+        b = Buffer()
+        b.push(_ev(workspace_id="", ts=time.time()))
+        assert b.get_recent("") == []
+
+
+class TestMaxLenEviction:
+    def test_overflow_evicts_oldest(self) -> None:
+        b = Buffer(max_per_workspace=3, ttl_seconds=10_000)
+        now = time.time()
+        for i in range(5):
+            b.push(_ev(ts=now + i))
+        out = b.get_recent("w1", limit=10)
+        # Only 3 most recent kept (newest first).
+        assert [round(e.ts, 3) for e in out] == [
+            round(now + 4, 3),
+            round(now + 3, 3),
+            round(now + 2, 3),
+        ]
+
+
+class TestTTLPruning:
+    def test_old_entries_are_pruned_on_push(self) -> None:
+        b = Buffer(ttl_seconds=1)
+        # Stale entry, definitely past the 1-second TTL.
+        b.push(_ev(ts=time.time() - 60))
+        # Fresh entry forces a prune on the way in.
+        b.push(_ev(ts=time.time()))
+        out = b.get_recent("w1", limit=10)
+        assert len(out) == 1
+
+    def test_old_entries_are_pruned_on_read(self) -> None:
+        b = Buffer(ttl_seconds=1)
+        b.push(_ev(ts=time.time()))
+        # Wait past the TTL then peek — the buffer should drop the stale row.
+        time.sleep(1.05)
+        out = b.get_recent("w1", limit=10)
+        assert out == []
+
+
+class TestWorkspaceIsolation:
+    def test_get_recent_does_not_leak_across_workspaces(self) -> None:
+        b = Buffer()
+        now = time.time()
+        b.push(_ev(workspace_id="w1", ts=now))
+        b.push(_ev(workspace_id="w2", ts=now))
+        assert len(b.get_recent("w1")) == 1
+        assert len(b.get_recent("w2")) == 1
+
+
+class TestSubscribers:
+    def test_subscribers_receive_pushed_events_in_order(self) -> None:
+        b = Buffer()
+        received: list[ActivityEvent] = []
+        b.subscribe(lambda e: received.append(e))
+        now = time.time()
+        b.push(_ev(ts=now))
+        b.push(_ev(ts=now + 1))
+        assert [round(e.ts, 3) for e in received] == [round(now, 3), round(now + 1, 3)]
+
+    def test_subscriber_failure_does_not_break_push(self) -> None:
+        b = Buffer()
+
+        def _bomb(_event: ActivityEvent) -> None:
+            raise RuntimeError("boom")
+
+        b.subscribe(_bomb)
+        # Push should not raise even with a broken subscriber.
+        b.push(_ev(ts=time.time()))
+        assert len(b.get_recent("w1")) == 1
+
+    def test_unsubscribe_removes_callback(self) -> None:
+        b = Buffer()
+        received: list[ActivityEvent] = []
+        cb = received.append
+        b.subscribe(cb)
+        b.unsubscribe(cb)
+        b.push(_ev(ts=time.time()))
+        assert received == []
+
+
+class TestGetBufferSingleton:
+    def test_get_buffer_returns_same_instance(self) -> None:
+        a = get_buffer()
+        b = get_buffer()
+        assert a is b
+
+
+class TestHandleAgentEvent:
+    @pytest.mark.asyncio
+    async def test_thinking_event_lands_with_kind_thinking(self) -> None:
+        get_buffer().reset()
+        ev = AgentThinking(
+            data={"workspace_id": "w-handle-1", "thought": "considering options", "agent_id": "a1"}
+        )
+        await _handle_agent_event(ev)
+        out = get_buffer().get_recent("w-handle-1")
+        assert len(out) == 1
+        assert out[0].kind == "thinking"
+        assert out[0].summary == "considering options"
+
+    @pytest.mark.asyncio
+    async def test_tool_use_event_lands_with_kind_tool_call(self) -> None:
+        get_buffer().reset()
+        ev = AgentToolUse(
+            data={"workspace_id": "w-handle-2", "tool": "kb_search", "agent_id": "a1"}
+        )
+        await _handle_agent_event(ev)
+        out = get_buffer().get_recent("w-handle-2")
+        assert len(out) == 1
+        assert out[0].kind == "tool_call"
+        assert out[0].summary == "kb_search"
+
+    @pytest.mark.asyncio
+    async def test_event_without_workspace_id_is_dropped(self) -> None:
+        get_buffer().reset()
+        ev = AgentThinking(data={"thought": "hmm"})  # no workspace_id
+        await _handle_agent_event(ev)
+        # No workspace_id key registered.
+        assert get_buffer().get_recent("") == []

--- a/tests/cloud/test_instinct_bulk_actions.py
+++ b/tests/cloud/test_instinct_bulk_actions.py
@@ -1,0 +1,313 @@
+# tests/cloud/test_instinct_bulk_actions.py
+# Created: 2026-05-13 (feat/mission-control-facade) — store + router tests for
+# the new bulk-approve / bulk-reject Instinct endpoints. Asserts the shared
+# bulk_id audit tag, the per-item Pawprint write, the require_status guard,
+# and the new ``assignee`` filter on /actions/pending.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ee.cloud._core.deps import current_workspace_id
+from ee.cloud.auth import current_active_user
+from ee.cloud.license import require_license
+from ee.instinct.models import ActionStatus, ActionTrigger
+from ee.instinct.router import router
+from ee.instinct.store import InstinctStore
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, workspace_id: str = "ws-test") -> None:
+        self.id = "user-test-1"
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+def _trigger(source: str = "claude") -> ActionTrigger:
+    return ActionTrigger(type="agent", source=source, reason="bulk-action test")
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "bulk_instinct.db")
+
+
+@pytest.fixture
+def test_app(tmp_path: Path, monkeypatch):
+    fake_user = _FakeUser()
+    import ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: fake_user
+    app.dependency_overrides[current_workspace_id] = lambda: fake_user.active_workspace
+    return app
+
+
+@pytest.fixture
+def router_store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "bulk_router.db")
+
+
+@pytest.fixture
+def client(test_app, router_store: InstinctStore):
+    with patch("ee.instinct.router._store", return_value=router_store):
+        yield TestClient(test_app)
+
+
+# ---------------------------------------------------------------------------
+# Store-level: bulk_approve
+# ---------------------------------------------------------------------------
+
+
+class TestBulkApprove:
+    @pytest.mark.asyncio
+    async def test_bulk_approve_flips_all_listed_pending(self, store: InstinctStore) -> None:
+        a = await store.propose("p1", "A", "", "", _trigger())
+        b = await store.propose("p1", "B", "", "", _trigger())
+        c = await store.propose("p1", "C", "", "", _trigger())
+
+        approved, missing, bulk_id = await store.bulk_approve([a.id, b.id, c.id])
+
+        assert {x.id for x in approved} == {a.id, b.id, c.id}
+        assert missing == []
+        assert bulk_id  # uuid4 hex
+        for x in approved:
+            assert x.status == ActionStatus.APPROVED
+
+    @pytest.mark.asyncio
+    async def test_bulk_approve_writes_shared_bulk_id_on_every_audit_row(
+        self, store: InstinctStore
+    ) -> None:
+        a = await store.propose("p1", "A", "", "", _trigger())
+        b = await store.propose("p1", "B", "", "", _trigger())
+
+        _, _, bulk_id = await store.bulk_approve([a.id, b.id], note="ship it")
+
+        entries = await store.query_audit(pocket_id="p1")
+        approved_rows = [e for e in entries if e.event == "action_approved"]
+        assert len(approved_rows) == 2
+        for row in approved_rows:
+            assert row.context.get("bulk_id") == bulk_id
+            assert row.context.get("note") == "ship it"
+
+    @pytest.mark.asyncio
+    async def test_bulk_approve_skips_already_resolved(self, store: InstinctStore) -> None:
+        a = await store.propose("p1", "A", "", "", _trigger())
+        b = await store.propose("p1", "B", "", "", _trigger())
+        # Approve a single-item first — b stays pending.
+        await store.approve(a.id)
+
+        approved, missing, _ = await store.bulk_approve([a.id, b.id])
+        # a is already approved -> not approved again. b flips.
+        assert [x.id for x in approved] == [b.id]
+        assert missing == [a.id]
+
+    @pytest.mark.asyncio
+    async def test_bulk_approve_records_missing_for_unknown_ids(
+        self, store: InstinctStore
+    ) -> None:
+        a = await store.propose("p1", "A", "", "", _trigger())
+        approved, missing, _ = await store.bulk_approve([a.id, "act-does-not-exist"])
+        assert [x.id for x in approved] == [a.id]
+        assert missing == ["act-does-not-exist"]
+
+    @pytest.mark.asyncio
+    async def test_rejected_items_dont_get_approved(self, store: InstinctStore) -> None:
+        a = await store.propose("p1", "A", "", "", _trigger())
+        b = await store.propose("p1", "B", "", "", _trigger())
+        await store.reject(a.id, reason="no")
+
+        approved, missing, _ = await store.bulk_approve([a.id, b.id])
+        assert [x.id for x in approved] == [b.id]
+        assert missing == [a.id]
+        # Confirm a stays rejected
+        fetched = await store.get_action(a.id)
+        assert fetched is not None and fetched.status == ActionStatus.REJECTED
+
+
+class TestBulkReject:
+    @pytest.mark.asyncio
+    async def test_bulk_reject_requires_reason_at_call_site(
+        self, store: InstinctStore
+    ) -> None:
+        # The store doesn't enforce non-empty (the router does), so this
+        # is a behavioural check that the empty reason still produces a
+        # bulk_id and audit row with reason=''.
+        a = await store.propose("p1", "A", "", "", _trigger())
+        rejected, _, bulk_id = await store.bulk_reject([a.id], reason="")
+        assert len(rejected) == 1
+        entries = await store.query_audit(pocket_id="p1")
+        reject_rows = [e for e in entries if e.event == "action_rejected"]
+        assert len(reject_rows) == 1
+        assert reject_rows[0].context.get("bulk_id") == bulk_id
+
+    @pytest.mark.asyncio
+    async def test_bulk_reject_writes_reason_on_audit_and_action(
+        self, store: InstinctStore
+    ) -> None:
+        a = await store.propose("p1", "A", "", "", _trigger())
+        b = await store.propose("p1", "B", "", "", _trigger())
+
+        rejected, _, bulk_id = await store.bulk_reject([a.id, b.id], reason="out of scope")
+        for x in rejected:
+            assert x.status == ActionStatus.REJECTED
+            assert x.rejected_reason == "out of scope"
+
+        entries = await store.query_audit(pocket_id="p1")
+        for row in [e for e in entries if e.event == "action_rejected"]:
+            assert row.context.get("bulk_id") == bulk_id
+            assert row.context.get("reason") == "out of scope"
+
+
+# ---------------------------------------------------------------------------
+# Store-level: assignee filter on pending
+# ---------------------------------------------------------------------------
+
+
+class TestPendingAssignee:
+    @pytest.mark.asyncio
+    async def test_pending_default_returns_all(self, store: InstinctStore) -> None:
+        await store.propose("p1", "A", "", "", _trigger(), assignee="alice")
+        await store.propose("p1", "B", "", "", _trigger(), assignee="bob")
+        await store.propose("p1", "C", "", "", _trigger())  # no assignee
+
+        pending = await store.pending()
+        assert len(pending) == 3
+
+    @pytest.mark.asyncio
+    async def test_pending_with_assignee_filters_to_owner(self, store: InstinctStore) -> None:
+        await store.propose("p1", "A", "", "", _trigger(), assignee="alice")
+        await store.propose("p1", "B", "", "", _trigger(), assignee="bob")
+        await store.propose("p1", "C", "", "", _trigger(), assignee="alice")
+
+        pending_alice = await store.pending(assignee="alice")
+        assert {a.title for a in pending_alice} == {"A", "C"}
+
+    @pytest.mark.asyncio
+    async def test_assignee_persists_across_load(self, store: InstinctStore) -> None:
+        a = await store.propose("p1", "A", "", "", _trigger(), assignee="alice")
+        fetched = await store.get_action(a.id)
+        assert fetched is not None and fetched.assignee == "alice"
+
+
+# ---------------------------------------------------------------------------
+# Router-level: HTTP endpoints
+# ---------------------------------------------------------------------------
+
+
+TRIGGER = {"type": "agent", "source": "claude", "reason": "router test"}
+
+
+class TestBulkApproveEndpoint:
+    def test_bulk_approve_returns_bulk_id_and_affected(self, client: TestClient) -> None:
+        r1 = client.post(
+            "/instinct/actions",
+            json={"pocket_id": "p1", "title": "A", "trigger": TRIGGER},
+        )
+        r2 = client.post(
+            "/instinct/actions",
+            json={"pocket_id": "p1", "title": "B", "trigger": TRIGGER},
+        )
+        ids = [r1.json()["id"], r2.json()["id"]]
+
+        resp = client.post(
+            "/instinct/actions/bulk-approve",
+            json={"ids": ids, "note": "ship-it"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "bulk_id" in data and data["bulk_id"]
+        assert len(data["affected"]) == 2
+        assert data["missing"] == []
+
+    def test_bulk_approve_does_not_consume_param_route(self, client: TestClient) -> None:
+        """``bulk-approve`` is a literal path; FastAPI must not eat it as a
+        parameter to ``/{action_id}/approve``."""
+        resp = client.post("/instinct/actions/bulk-approve", json={"ids": []})
+        # Empty ids fail schema validation (min_length=1); we want a 422
+        # — not a 404 from the parameterised route swallowing the path.
+        assert resp.status_code == 422
+
+    def test_bulk_approve_reports_missing_ids(self, client: TestClient) -> None:
+        resp = client.post(
+            "/instinct/actions/bulk-approve",
+            json={"ids": ["act-nope-1", "act-nope-2"]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["affected"] == []
+        assert set(data["missing"]) == {"act-nope-1", "act-nope-2"}
+
+
+class TestBulkRejectEndpoint:
+    def test_bulk_reject_requires_reason_in_body(self, client: TestClient) -> None:
+        resp = client.post("/instinct/actions/bulk-reject", json={"ids": ["x"]})
+        # reason has min_length=1; missing field is a 422.
+        assert resp.status_code == 422
+
+    def test_bulk_reject_persists_reason_per_item(self, client: TestClient) -> None:
+        r1 = client.post(
+            "/instinct/actions",
+            json={"pocket_id": "p1", "title": "A", "trigger": TRIGGER},
+        )
+        r2 = client.post(
+            "/instinct/actions",
+            json={"pocket_id": "p1", "title": "B", "trigger": TRIGGER},
+        )
+        ids = [r1.json()["id"], r2.json()["id"]]
+        resp = client.post(
+            "/instinct/actions/bulk-reject",
+            json={"ids": ids, "reason": "budget exhausted"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["affected"]) == 2
+        for item in data["affected"]:
+            assert item["status"] == "rejected"
+            assert item["rejected_reason"] == "budget exhausted"
+
+
+class TestPendingAssigneeEndpoint:
+    def test_pending_default_returns_all_pending(self, client: TestClient) -> None:
+        client.post(
+            "/instinct/actions",
+            json={"pocket_id": "p1", "title": "A", "trigger": TRIGGER},
+        )
+        client.post(
+            "/instinct/actions",
+            json={"pocket_id": "p1", "title": "B", "trigger": TRIGGER},
+        )
+        resp = client.get("/instinct/actions/pending")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_pending_with_assignee_yields_empty_when_unset(self, client: TestClient) -> None:
+        # We can't set assignee via the propose endpoint right now (it's
+        # a store-level field added in this PR). Calling the endpoint
+        # with an assignee filter should simply yield zero rows.
+        client.post(
+            "/instinct/actions",
+            json={"pocket_id": "p1", "title": "A", "trigger": TRIGGER},
+        )
+        resp = client.get("/instinct/actions/pending?assignee=alice")
+        assert resp.status_code == 200
+        assert resp.json() == []

--- a/tests/cloud/test_mission_control_router.py
+++ b/tests/cloud/test_mission_control_router.py
@@ -1,0 +1,250 @@
+# tests/cloud/test_mission_control_router.py
+# Created: 2026-05-13 (feat/mission-control-facade) — endpoint smoke + tenancy
+# isolation for the Mission Control façade. The router is thin (it forwards
+# to mc_service) so these tests focus on wire shape + per-workspace isolation;
+# the projection + filter logic lives in test_mission_control_service.py.
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from ee.cloud._core.http import add_error_handler
+from ee.cloud.activity.buffer import ActivityEvent, get_buffer
+from ee.cloud.license import require_license
+from ee.cloud.mission_control import service as mc_service
+from ee.cloud.mission_control.router import router as mc_router
+from ee.instinct.models import ActionTrigger
+from ee.instinct.store import InstinctStore
+
+
+def _trigger(source: str = "claude") -> ActionTrigger:
+    return ActionTrigger(type="agent", source=source, reason="router test")
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "mc_router.db")
+
+
+@pytest.fixture(autouse=True)
+def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
+    """Same test doubles as the service tests — the router delegates."""
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(
+        mc_service.pockets_service,
+        "list_pockets",
+        AsyncMock(return_value=[{"_id": "p1"}, {"_id": "p2"}]),
+    )
+    yield
+
+
+def _build_app(workspace_id: str = "w1") -> FastAPI:
+    """Build a minimal app with the MC router mounted and the request_context
+    dep overridden so we don't need a real JWT chain."""
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(mc_router, prefix="/api/v1")
+
+    async def _fake_ctx() -> RequestContext:
+        return RequestContext(
+            user_id="u1",
+            workspace_id=workspace_id,
+            request_id="req-test",
+            scope=ScopeKind.NONE,
+            started_at=datetime.now(UTC),
+        )
+
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[request_context] = _fake_ctx
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestItemsEndpoint:
+    @pytest.mark.asyncio
+    async def test_list_items_empty_initially(self, store: InstinctStore) -> None:
+        with TestClient(_build_app()) as client:
+            resp = client.get("/api/v1/mission-control/items")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    @pytest.mark.asyncio
+    async def test_list_items_projects_pending_to_tray(self, store: InstinctStore) -> None:
+        await store.propose("p1", "Order more wool", "low stock", "order 30", _trigger())
+        with TestClient(_build_app()) as client:
+            resp = client.get("/api/v1/mission-control/items")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["section"] == "tray"
+        assert data[0]["status"] == "awaiting_approval"
+        assert data[0]["source_kind"] == "nudge"
+        assert data[0]["pocket_id"] == "p1"
+
+    @pytest.mark.asyncio
+    async def test_list_items_section_filter(self, store: InstinctStore) -> None:
+        await store.propose("p1", "Pending", "", "", _trigger())
+        b = await store.propose("p1", "Approved", "", "", _trigger())
+        await store.approve(b.id)
+        with TestClient(_build_app()) as client:
+            tray = client.get("/api/v1/mission-control/items?section=tray").json()
+            pawprints = client.get(
+                "/api/v1/mission-control/items?section=pawprints",
+            ).json()
+        assert [it["title"] for it in tray] == ["Pending"]
+        assert [it["title"] for it in pawprints] == ["Approved"]
+
+
+class TestBulkApproveEndpoint:
+    @pytest.mark.asyncio
+    async def test_bulk_approve_flips_and_returns_bulk_id(self, store: InstinctStore) -> None:
+        a = await store.propose("p1", "A", "", "", _trigger())
+        b = await store.propose("p1", "B", "", "", _trigger())
+        with TestClient(_build_app()) as client:
+            resp = client.post(
+                "/api/v1/mission-control/items/bulk-approve",
+                json={"ids": [a.id, b.id]},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "bulk_id" in body and body["bulk_id"]
+        assert len(body["approved"]) == 2
+        assert body["missing"] == []
+
+
+class TestBulkRejectEndpoint:
+    @pytest.mark.asyncio
+    async def test_reason_required_in_body(self, store: InstinctStore) -> None:
+        a = await store.propose("p1", "A", "", "", _trigger())
+        with TestClient(_build_app()) as client:
+            resp = client.post(
+                "/api/v1/mission-control/items/bulk-reject",
+                json={"ids": [a.id]},
+            )
+        # Service raises a ValidationError -> CloudError 422.
+        assert resp.status_code == 422
+        assert resp.json()["error"]["code"] == "mission_control.reason_required"
+
+    @pytest.mark.asyncio
+    async def test_bulk_reject_writes_reason_through(self, store: InstinctStore) -> None:
+        a = await store.propose("p1", "A", "", "", _trigger())
+        with TestClient(_build_app()) as client:
+            resp = client.post(
+                "/api/v1/mission-control/items/bulk-reject",
+                json={"ids": [a.id], "reason": "no budget"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["rejected"][0]["rejected_reason"] == "no budget"
+
+
+class TestStubEndpoints:
+    @pytest.mark.asyncio
+    async def test_bulk_reassign_returns_501(self, store: InstinctStore) -> None:
+        with TestClient(_build_app()) as client:
+            resp = client.post(
+                "/api/v1/mission-control/items/bulk-reassign",
+                json={"ids": ["x"], "to": {"kind": "agent", "id": "a1"}},
+            )
+        assert resp.status_code == 501
+        assert resp.json()["error"]["code"] == "mission_control.not_implemented"
+
+    @pytest.mark.asyncio
+    async def test_bulk_snooze_returns_501(self, store: InstinctStore) -> None:
+        with TestClient(_build_app()) as client:
+            resp = client.post(
+                "/api/v1/mission-control/items/bulk-snooze",
+                json={"ids": ["x"], "until_iso": "2026-12-31T00:00:00Z"},
+            )
+        assert resp.status_code == 501
+
+
+class TestOutcomesEndpoint:
+    @pytest.mark.asyncio
+    async def test_outcomes_default_window_24h(self, store: InstinctStore) -> None:
+        a = await store.propose("p1", "A", "", "", _trigger())
+        await store.propose("p1", "B", "", "", _trigger())
+        await store.approve(a.id)
+        with TestClient(_build_app()) as client:
+            resp = client.get("/api/v1/mission-control/outcomes")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["window"] == "24h"
+        assert body["total"] == 2
+        assert body["approved"] == 1
+        assert body["pending"] == 1
+
+    @pytest.mark.asyncio
+    async def test_invalid_window_returns_422(self, store: InstinctStore) -> None:
+        with TestClient(_build_app()) as client:
+            resp = client.get("/api/v1/mission-control/outcomes?window=99y")
+        assert resp.status_code == 422
+
+
+class TestActivityEndpoint:
+    @pytest.mark.asyncio
+    async def test_activity_returns_buffer(self, store: InstinctStore) -> None:
+        buf = get_buffer()
+        buf.reset()
+        now = time.time()
+        buf.push(
+            ActivityEvent(
+                workspace_id="w1",
+                kind="thinking",
+                agent_id="a1",
+                summary="step 1",
+                pocket_id=None,
+                ts=now,
+            )
+        )
+        with TestClient(_build_app()) as client:
+            resp = client.get("/api/v1/mission-control/activity")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["kind"] == "thinking"
+        assert data[0]["summary"] == "step 1"
+
+    @pytest.mark.asyncio
+    async def test_activity_workspace_isolated(self, store: InstinctStore) -> None:
+        buf = get_buffer()
+        buf.reset()
+        now = time.time()
+        buf.push(ActivityEvent("w1", "thinking", "a1", "in w1", None, now))
+        buf.push(ActivityEvent("w2", "thinking", "a2", "in w2", None, now))
+
+        with TestClient(_build_app(workspace_id="w1")) as client:
+            data = client.get("/api/v1/mission-control/activity").json()
+        assert len(data) == 1
+        assert data[0]["summary"] == "in w1"
+
+
+class TestTenancyIsolation:
+    @pytest.mark.asyncio
+    async def test_invisible_pocket_actions_are_hidden(
+        self, monkeypatch, store: InstinctStore
+    ) -> None:
+        # Cap the workspace to only see p1.
+        monkeypatch.setattr(
+            mc_service.pockets_service,
+            "list_pockets",
+            AsyncMock(return_value=[{"_id": "p1"}]),
+        )
+        await store.propose("p1", "visible", "", "", _trigger())
+        await store.propose("p2", "hidden", "", "", _trigger())
+        with TestClient(_build_app()) as client:
+            resp = client.get("/api/v1/mission-control/items")
+        assert resp.status_code == 200
+        assert [it["title"] for it in resp.json()] == ["visible"]

--- a/tests/cloud/test_mission_control_service.py
+++ b/tests/cloud/test_mission_control_service.py
@@ -1,0 +1,301 @@
+# tests/cloud/test_mission_control_service.py
+# Created: 2026-05-13 (feat/mission-control-facade) — unit-level coverage of
+# the mission_control façade service. Asserts WorkItem projection, section
+# routing, agent/pocket/section filters, tenancy gating against
+# pockets_service.list_pockets, and outcome aggregation math.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud._core.errors import CloudError, ValidationError
+from ee.cloud.mission_control import service as mc_service
+from ee.cloud.mission_control.domain import WorkItemSection, WorkItemStatus
+from ee.cloud.mission_control.dto import (
+    BulkActionRequest,
+    BulkReassignRequest,
+    ListActivityRequest,
+    ListWorkItemsRequest,
+    OutcomesQueryRequest,
+)
+from ee.instinct.models import ActionTrigger
+from ee.instinct.store import InstinctStore
+
+
+def _ctx(workspace_id: str | None = "w1", user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="req-test",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _trigger(source: str = "claude") -> ActionTrigger:
+    return ActionTrigger(type="agent", source=source, reason="mc test")
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "mc_service.db")
+
+
+@pytest.fixture(autouse=True)
+def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
+    """Wire the service's two read sources to test doubles.
+
+    - ``get_instinct_store`` → the per-test SQLite store
+    - ``pockets_service.list_pockets`` → AsyncMock returning the seeded
+      pockets so we don't need a Mongo fixture for façade-level tests
+    """
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(
+        mc_service.pockets_service,
+        "list_pockets",
+        AsyncMock(return_value=[{"_id": "p1"}, {"_id": "p2"}]),
+    )
+    yield
+
+
+# ---------------------------------------------------------------------------
+# agent_list_work_items
+# ---------------------------------------------------------------------------
+
+
+class TestListWorkItems:
+    @pytest.mark.asyncio
+    async def test_workspace_required_or_validation_error(self, store: InstinctStore) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            await mc_service.agent_list_work_items(_ctx(workspace_id=None), {})
+        assert exc_info.value.code == "mission_control.workspace_required"
+
+    @pytest.mark.asyncio
+    async def test_projects_pending_action_to_tray_section(self, store: InstinctStore) -> None:
+        await store.propose("p1", "Order more wool", "low stock", "order 30", _trigger())
+        items = await mc_service.agent_list_work_items(_ctx(), {})
+        assert len(items) == 1
+        item = items[0]
+        assert item.section == WorkItemSection.TRAY
+        assert item.status == WorkItemStatus.AWAITING_APPROVAL
+        assert item.title == "Order more wool"
+        assert item.source_kind == "nudge"
+        assert item.pocket_id == "p1"
+
+    @pytest.mark.asyncio
+    async def test_section_filter_narrows_to_one_pane(self, store: InstinctStore) -> None:
+        a = await store.propose("p1", "pending one", "", "", _trigger())
+        b = await store.propose("p1", "approved one", "", "", _trigger())
+        await store.approve(b.id)
+
+        tray = await mc_service.agent_list_work_items(
+            _ctx(), ListWorkItemsRequest(section=WorkItemSection.TRAY)
+        )
+        assert [it.source_id for it in tray] == [a.id]
+        pawprints = await mc_service.agent_list_work_items(
+            _ctx(), ListWorkItemsRequest(section=WorkItemSection.PAWPRINTS)
+        )
+        assert [it.source_id for it in pawprints] == [b.id]
+
+    @pytest.mark.asyncio
+    async def test_pocket_filter_excludes_other_pockets(self, store: InstinctStore) -> None:
+        await store.propose("p1", "p1 item", "", "", _trigger())
+        await store.propose("p2", "p2 item", "", "", _trigger())
+        out = await mc_service.agent_list_work_items(_ctx(), ListWorkItemsRequest(pocket="p1"))
+        assert {it.pocket_id for it in out} == {"p1"}
+
+    @pytest.mark.asyncio
+    async def test_agent_filter_matches_trigger_source(self, store: InstinctStore) -> None:
+        await store.propose("p1", "by claude", "", "", _trigger("claude"))
+        await store.propose("p1", "by sage", "", "", _trigger("sage"))
+        out = await mc_service.agent_list_work_items(_ctx(), ListWorkItemsRequest(agent="sage"))
+        assert [it.title for it in out] == ["by sage"]
+
+    @pytest.mark.asyncio
+    async def test_tenancy_filters_out_invisible_pockets(
+        self, monkeypatch, store: InstinctStore
+    ) -> None:
+        # Restrict visible pockets to p1 only.
+        monkeypatch.setattr(
+            mc_service.pockets_service,
+            "list_pockets",
+            AsyncMock(return_value=[{"_id": "p1"}]),
+        )
+        await store.propose("p1", "visible", "", "", _trigger())
+        await store.propose("p2", "hidden", "", "", _trigger())
+        out = await mc_service.agent_list_work_items(_ctx(), {})
+        assert [it.title for it in out] == ["visible"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_workspace_has_no_pockets(
+        self, monkeypatch, store: InstinctStore
+    ) -> None:
+        monkeypatch.setattr(
+            mc_service.pockets_service, "list_pockets", AsyncMock(return_value=[])
+        )
+        await store.propose("p1", "would surface", "", "", _trigger())
+        out = await mc_service.agent_list_work_items(_ctx(), {})
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_limit_caps_returned_items(self, store: InstinctStore) -> None:
+        for i in range(10):
+            await store.propose("p1", f"item-{i}", "", "", _trigger())
+        out = await mc_service.agent_list_work_items(_ctx(), ListWorkItemsRequest(limit=3))
+        assert len(out) == 3
+
+
+# ---------------------------------------------------------------------------
+# bulk_approve / bulk_reject
+# ---------------------------------------------------------------------------
+
+
+class TestBulkApproveService:
+    @pytest.mark.asyncio
+    async def test_approves_visible_actions(self, store: InstinctStore) -> None:
+        a = await store.propose("p1", "A", "", "", _trigger())
+        b = await store.propose("p1", "B", "", "", _trigger())
+        result = await mc_service.agent_bulk_approve(
+            _ctx(), BulkActionRequest(ids=[a.id, b.id])
+        )
+        assert "bulk_id" in result
+        approved_ids = {row["id"] for row in result["approved"]}
+        assert approved_ids == {a.id, b.id}
+
+    @pytest.mark.asyncio
+    async def test_blocks_actions_in_invisible_pockets(
+        self, monkeypatch, store: InstinctStore
+    ) -> None:
+        monkeypatch.setattr(
+            mc_service.pockets_service,
+            "list_pockets",
+            AsyncMock(return_value=[{"_id": "p1"}]),
+        )
+        a = await store.propose("p1", "A", "", "", _trigger())
+        hidden = await store.propose("p2", "B", "", "", _trigger())
+        result = await mc_service.agent_bulk_approve(
+            _ctx(), BulkActionRequest(ids=[a.id, hidden.id])
+        )
+        assert {row["id"] for row in result["approved"]} == {a.id}
+        assert hidden.id in result["missing"]
+
+    @pytest.mark.asyncio
+    async def test_bulk_reject_requires_reason(self, store: InstinctStore) -> None:
+        a = await store.propose("p1", "A", "", "", _trigger())
+        with pytest.raises(ValidationError) as exc:
+            await mc_service.agent_bulk_reject(
+                _ctx(),
+                BulkActionRequest(ids=[a.id], reason=None),
+            )
+        assert exc.value.code == "mission_control.reason_required"
+
+
+# ---------------------------------------------------------------------------
+# outcomes summary
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomesSummary:
+    @pytest.mark.asyncio
+    async def test_counts_per_status_for_visible_pockets(self, store: InstinctStore) -> None:
+        approved = await store.propose("p1", "A", "", "", _trigger())
+        rejected = await store.propose("p1", "B", "", "", _trigger())
+        pending = await store.propose("p1", "C", "", "", _trigger())  # noqa: F841
+        await store.approve(approved.id)
+        await store.reject(rejected.id, reason="nah")
+
+        summary = await mc_service.agent_outcomes_summary(
+            _ctx(), OutcomesQueryRequest(window="24h")
+        )
+        assert summary.total == 3
+        assert summary.approved == 1
+        assert summary.rejected == 1
+        assert summary.pending == 1
+        assert summary.executed == 0
+        assert summary.failed == 0
+
+    @pytest.mark.asyncio
+    async def test_window_filter_excludes_old_rows(self, store: InstinctStore) -> None:
+        # Seed a row whose created_at SQL default is 'now', but force an
+        # older updated_at on it via direct DB write so the window cutoff
+        # excludes it.
+        import aiosqlite
+
+        a = await store.propose("p1", "old", "", "", _trigger())
+        old_ts = (datetime.now() - timedelta(days=30)).isoformat()
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET created_at = ?, updated_at = ? WHERE id = ?",
+                (old_ts, old_ts, a.id),
+            )
+            await db.commit()
+        await store.propose("p1", "recent", "", "", _trigger())
+
+        summary = await mc_service.agent_outcomes_summary(
+            _ctx(), OutcomesQueryRequest(window="24h")
+        )
+        # Only the "recent" row falls in the 24h window.
+        assert summary.total == 1
+
+
+# ---------------------------------------------------------------------------
+# 501 stubs
+# ---------------------------------------------------------------------------
+
+
+class TestStubEndpoints:
+    @pytest.mark.asyncio
+    async def test_bulk_reassign_raises_not_implemented(self, store: InstinctStore) -> None:
+        with pytest.raises(CloudError) as exc:
+            await mc_service.agent_bulk_reassign(
+                _ctx(),
+                BulkReassignRequest(
+                    ids=["x"], to={"kind": "agent", "id": "a1", "name": "claude"}
+                ),
+            )
+        assert exc.value.status_code == 501
+        assert exc.value.code == "mission_control.not_implemented"
+
+    @pytest.mark.asyncio
+    async def test_bulk_snooze_raises_not_implemented(self, store: InstinctStore) -> None:
+        with pytest.raises(CloudError) as exc:
+            await mc_service.agent_bulk_snooze(
+                _ctx(),
+                {"ids": ["x"], "until_iso": "2026-12-31T00:00:00Z"},
+            )
+        assert exc.value.status_code == 501
+
+
+# ---------------------------------------------------------------------------
+# activity feed
+# ---------------------------------------------------------------------------
+
+
+class TestListActivity:
+    @pytest.mark.asyncio
+    async def test_returns_buffer_entries_newest_first(self, store: InstinctStore) -> None:
+        import time
+
+        from ee.cloud.activity.buffer import ActivityEvent, get_buffer
+
+        buf = get_buffer()
+        buf.reset()
+        now = time.time()
+        for i in range(3):
+            buf.push(
+                ActivityEvent(
+                    workspace_id="w1",
+                    kind="thinking",
+                    agent_id="a1",
+                    summary=f"step {i}",
+                    pocket_id=None,
+                    ts=now + i,
+                )
+            )
+        out = await mc_service.agent_list_activity(_ctx(), ListActivityRequest(limit=10))
+        assert [e.summary for e in out] == ["step 2", "step 1", "step 0"]


### PR DESCRIPTION
## Summary

PR 1 of 3 for the Mission Control backend. Wires The Tray and Pawprints panes in the paw-enterprise UI to real data without inventing new primitives — the façade composes Instinct (existing) and an in-process activity buffer (new) and projects everything into the unified \`WorkItem\` shape the frontend already consumes. The remaining two PRs add Tasks and Cycles, which slot into the same façade.

## What this is

- A new \`ee/cloud/mission_control/\` entity in the canonical 4-file shape (\`domain.py\` / \`dto.py\` / \`service.py\` / \`router.py\`), pockets-style.
- A new \`ee/cloud/activity/buffer.py\` per-workspace ring buffer (~200 entries, 1-hour TTL) fed from \`agent.thinking\` / \`agent.tool_use\` / \`agent.stream_end\` bus events.
- Two new Instinct endpoints — \`POST /instinct/actions/bulk-approve\` and \`POST /instinct/actions/bulk-reject\` — plus an \`assignee\` query param on \`/instinct/actions/pending\`. Bulk endpoints write N audit rows that share a \`bulk_id\` UUID so the operator can replay per-item or query by the bulk transaction.
- \`bulk-reassign\` and \`bulk-snooze\` ship as 501 stubs. They need the polymorphic assignee shape that lands with the Tasks entity in PR 2; surfacing the route now lets the frontend wire its API client without conditional code paths.

## Decisions baked in (from the audit doc)

- Workspace filter is implicit via \`ctx.workspace_id\` plus the existing pocket access check. The façade asks \`pockets_service.list_pockets\` for the caller's pockets and refuses to project a Nudge whose \`pocket_id\` falls outside that set.
- Bulk-approve audit: N Pawprints + shared \`bulk_id\`. Replay-able per item, query-able by bulk.
- Activity buffer in-memory; durable record stays in Pawprints. Restart wipes the live ticker, which is fine — the live ticker doesn't need history.

## Files

| Path | Change |
|---|---|
| \`ee/cloud/mission_control/__init__.py\` | new — re-exports the router |
| \`ee/cloud/mission_control/domain.py\` | new — frozen \`WorkItem\` with required \`workspace_id\` |
| \`ee/cloud/mission_control/dto.py\` | new — request/response DTOs, separate per rule #4 |
| \`ee/cloud/mission_control/service.py\` | new — module-level \`async def\` per rule #5 |
| \`ee/cloud/mission_control/router.py\` | new — endpoints exactly as specified |
| \`ee/cloud/activity/__init__.py\` | new |
| \`ee/cloud/activity/buffer.py\` | new — bounded per-workspace deque + bus subscriber |
| \`ee/instinct/store.py\` | bulk_approve / bulk_reject, \`assignee\` column, additive migration, ISO timestamp parse fix |
| \`ee/instinct/router.py\` | \`assignee\` query param, bulk endpoints registered before the parameterised \`{action_id}\` route |
| \`ee/instinct/models.py\` | \`Action.assignee\` field |
| \`ee/cloud/__init__.py\` | mount the façade router, register the activity bus listeners after \`init_realtime\` |
| \`pyproject.toml\` | import-linter contract for the façade layer |

## Import-linter

The forbidden-modules contract for the façade layer is in place (\`router.py\` / \`dto.py\` / \`domain.py\` can't import any \`ee.cloud.models.*\` Beanie doc). The audit doc called out that the canonical \`models.work_item\` entry lands with PR 2 (Tasks); the PR 2 commit adds it to the forbidden list to match the pockets shape. The defensive contract here keeps the façade from sprouting a Beanie collection accidentally in the meantime.

## Test plan

- [x] \`tests/cloud/test_mission_control_router.py\` — endpoint smoke + tenancy isolation (13 cases)
- [x] \`tests/cloud/test_mission_control_service.py\` — WorkItem projection, section/agent/pocket filters, outcomes aggregation, 501 stubs, activity feed (16 cases)
- [x] \`tests/cloud/test_instinct_bulk_actions.py\` — bulk_id shared on every audit row, already-rejected items skip, assignee filter (17 cases)
- [x] \`tests/cloud/test_activity_buffer.py\` — push, ordering, maxlen eviction, TTL pruning, workspace isolation, subscribers, bus handlers (15 cases)
- [x] \`uv run pytest tests/cloud/test_mission_control* tests/cloud/test_instinct_bulk* tests/cloud/test_activity_buffer*\` → 61 / 61 pass
- [x] \`uv run pytest tests/cloud/test_ee_instinct.py\` → 67 / 67 still pass (no regression on the existing Instinct router + store coverage)
- [x] \`uv run ruff check\` on every new and modified file → clean
- [x] \`uv run lint-imports\` → 10 / 10 contracts kept

## What's next

- **PR 2 — Tasks.** Adds \`ee/cloud/tasks/\` as the assignable-to-agent work primitive. Carries the polymorphic \`{kind, id, name}\` assignee shape that unblocks the 501 stubs here. Touch-time adds \`models.work_item\` to the import-linter forbidden list.
- **PR 3 — Cycles.** Adds \`ee/cloud/cycles/\` plus the daily snapshot job that feeds the burnup chart, and the cross-cutting SSE wiring for \`activity.recorded\` / \`work_item.*\` / \`cycle.*\` event types.

Do NOT merge — captain review gate per CLAUDE.md.