### PR TITLE
chore(mission-control): cleanup — lift stubs, emit comments, scheduler doc

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -1,5 +1,11 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Updated: 2026-05-13 — Mission Control cleanup PR. Lifted the 501 stubs
+    on Mission Control's bulk-reassign / bulk-snooze (they now delegate
+    to the Tasks service), added emit-or-no-event comments to the bulk
+    approve/reject paths and the cycle counter-sync read, documented the
+    snapshot_job's wiring placeholder in ``mount_cloud``, and pinned the
+    UTC weekend-flag drift note onto the cycle snapshot docstring.
 Updated: 2026-05-13 — Mission Control PR 2 of 3. Added the Tasks
     entity (unified work-item primitive: Nudges + agent tasks +
     projections) and its in-process listener that fans ``task.proposed``
@@ -370,6 +376,13 @@ def mount_cloud(app: FastAPI) -> None:
     from ee.cloud.tasks.listeners import register_task_listeners
 
     register_task_listeners()
+
+    # TODO: wire daily-snapshot scheduler — see ``ee.cloud.cycles.snapshot_job``
+    # for cron / Kubernetes CronJob / Celery beat wiring patterns. We
+    # deliberately do NOT spin up an in-process loop here; the host
+    # platform owns scheduling (its scheduler knows the tenant list and
+    # has the right retry / backoff semantics). Wiring lives in the
+    # deployment layer.
 
     # Mission Control activity buffer — per-workspace ring buffer fed by
     # agent.* bus events. Same constraint as the upload listeners: subscribe

--- a/ee/cloud/cycles/service.py
+++ b/ee/cloud/cycles/service.py
@@ -5,11 +5,10 @@ Sole owner of writes to the ``Cycle`` Beanie document. Module-level
 emit-on-every-write.
 
 Composition with the Tasks entity (``ee.cloud.tasks.service``) is via lazy
-import — that entity ships in PR 2 of the Mission Control series and may
-not be merged onto whichever ``ee`` snapshot this branch was cut from.
-When tasks isn't importable, the relevant methods (item list, counter
-refresh, snapshot job) gracefully degrade rather than crashing the cycles
-endpoints. The same lazy-import gate is exercised in tests.
+import — kept lazy so cycles can still operate when the host branch
+hasn't merged Tasks yet. Once both entities are present (the default on
+``ee`` post-PR-2), the composition runs at full fidelity; the
+lazy-import path stays as a safety net for trunk forks.
 
 Public API:
 - ``agent_create_cycle(ctx, body)``
@@ -21,6 +20,9 @@ Public API:
 
 Internal:
 - ``_snapshot_cycle_daily(ctx, cycle_id)`` — idempotent within a day.
+  Weekend flag is computed against the UTC date; deployments in
+  non-UTC timezones may observe ±12h drift on the weekend boundary.
+  Pass an explicit ``today`` param to align with local time.
 """
 
 from __future__ import annotations
@@ -332,6 +334,10 @@ async def agent_get_cycle(ctx: RequestContext, cycle_id: str) -> CycleResponse:
             doc.completed = completed
             await doc.save()
 
+    # no-event: silent counter sync on read — avoids CycleUpdated churn on every
+    # cycle detail fetch. The authoritative ``CycleUpdated`` emits live on writes
+    # (agent_update_cycle, agent_close_cycle); the daily snapshot job emits
+    # ``CycleSnapshotted`` for chart updates.
     return _to_response(_to_domain(doc))
 
 
@@ -504,6 +510,10 @@ async def _snapshot_cycle_daily(
     cadence by only appending when the most recent point is at least 7
     days old. Documented in the model docstring.
 
+    Weekend flag is computed against the UTC date; deployments in non-UTC
+    timezones may observe ±12h drift on the weekend boundary. Pass an
+    explicit ``today`` param to align with local time.
+
     Returns the newly-appended point as a DTO so the snapshot job can emit
     ``CycleSnapshotted`` with a payload the frontend's burnup chart can
     consume directly.
@@ -562,6 +572,23 @@ async def _snapshot_cycle_daily(
     return dto
 
 
+async def list_active_cycle_ids(workspace_id: str) -> list[str]:
+    """Return the ids of every active cycle in a workspace.
+
+    Helper for the snapshot job — kept inside the service so the 4-file
+    rule holds (only service.py may touch ``models.cycle``). The job
+    iterates these ids and calls ``_snapshot_cycle_daily`` per cycle.
+    Workspace is passed explicitly (not via a RequestContext) because
+    the snapshot job runs as a system actor without a user identity.
+    """
+    if not workspace_id:
+        return []
+    ids: list[str] = []
+    async for doc in _CycleDoc.find({"workspace": workspace_id, "status": "active"}):
+        ids.append(str(doc.id))
+    return ids
+
+
 __all__ = [
     "agent_close_cycle",
     "agent_create_cycle",
@@ -569,5 +596,6 @@ __all__ = [
     "agent_list_cycle_items",
     "agent_list_cycles",
     "agent_update_cycle",
+    "list_active_cycle_ids",
     "_snapshot_cycle_daily",
 ]

--- a/ee/cloud/cycles/snapshot_job.py
+++ b/ee/cloud/cycles/snapshot_job.py
@@ -14,14 +14,44 @@ and dispatches ``snapshot_all_active`` once per day per workspace. The
 wiring point; until the platform's scheduling story converges, the captain
 wires this in deployment.
 
-When the Tasks entity (PR 2 of the Mission Control series) isn't available
-on the importing branch, the job warns and returns rather than crashing —
-the cycles entity continues to serve list / detail / close endpoints
-normally; the daily array stays empty.
+Recommended wiring patterns (pick one based on platform):
+
+  - **Unix cron** — drop a line in the crontab to invoke the module
+    entry point once per day per workspace::
+
+        0 6 * * *  cd /app && uv run python -m ee.cloud.cycles.snapshot_job --workspace-id <id>
+
+  - **Kubernetes CronJob** — wrap the same command in a CronJob spec::
+
+        spec:
+          schedule: "0 6 * * *"
+          jobTemplate:
+            spec:
+              template:
+                spec:
+                  containers:
+                  - name: cycle-snapshot
+                    image: pocketpaw-ee:latest
+                    command: ["python", "-m", "ee.cloud.cycles.snapshot_job",
+                              "--workspace-id", "<id>"]
+
+  - **Celery beat** — register a periodic task that calls
+    ``snapshot_all_active(workspace_id)`` from the ``ee.cloud.cycles.snapshot_job``
+    module; the bus events fan out to subscribers in the same process.
+
+For multi-tenant deployments, prefer iterating workspaces in the host
+layer (your scheduler knows the tenant list) rather than baking a
+workspace discovery loop into this module.
+
+When the Tasks entity isn't available on the importing branch (forked
+``ee`` snapshots that predate PR 2), the job warns and returns rather
+than crashing — the cycles entity continues to serve list / detail /
+close endpoints normally; the daily array stays empty.
 """
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import logging
 from datetime import UTC, datetime
@@ -55,17 +85,15 @@ async def snapshot_all_active(workspace_id: str) -> int:
     Returns the number of cycles successfully snapshotted. Idempotent via
     ``cycles_service._snapshot_cycle_daily`` — calling this twice in the
     same calendar day is a no-op on the second pass.
-    """
-    # Late import: keep ``ee.cloud.models`` off the module-level path so
-    # snapshot_job stays free to be imported by deployment wiring without
-    # pulling Beanie into the import graph in environments that haven't
-    # initialised it.
-    from ee.cloud.models.cycle import Cycle as _CycleDoc
 
+    The active-cycle iteration runs through
+    ``cycles_service.list_active_cycle_ids`` so the 4-file rule holds
+    (only ``cycles/service.py`` may touch the Beanie ``Cycle`` model).
+    """
     ctx = _system_ctx(workspace_id)
     count = 0
-    async for doc in _CycleDoc.find({"workspace": workspace_id, "status": "active"}):
-        cycle_id = str(doc.id)
+    cycle_ids = await cycles_service.list_active_cycle_ids(workspace_id)
+    for cycle_id in cycle_ids:
         try:
             point = await cycles_service._snapshot_cycle_daily(ctx, cycle_id)
             if point is not None:
@@ -124,4 +152,48 @@ async def run_forever_loop(iter_workspaces, *, interval_seconds: float = 24 * 60
         await asyncio.sleep(interval_seconds)
 
 
-__all__ = ["run_forever_loop", "snapshot_all_active", "snapshot_one"]
+async def _main_async(workspace_id: str, cycle_id: str | None) -> int:
+    """Module entry point body: dispatch one snapshot pass.
+
+    Kept out of the synchronous ``main`` wrapper so tests can call this
+    directly with an already-initialised Beanie environment.
+    """
+    if cycle_id:
+        ok = await snapshot_one(workspace_id, cycle_id)
+        return 0 if ok else 1
+    await snapshot_all_active(workspace_id)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Sync entry point for ``python -m ee.cloud.cycles.snapshot_job``.
+
+    Expects Beanie to be already initialised in the runtime environment
+    (the host platform's bootstrap is responsible for that). For
+    one-shot invocations from a deployment script, wire a small driver
+    that initialises Beanie before calling ``main`` — same constraint
+    as any other ``ee.cloud`` entry point.
+    """
+    parser = argparse.ArgumentParser(
+        prog="ee.cloud.cycles.snapshot_job",
+        description="Daily snapshot job for the Cycles burnup chart.",
+    )
+    parser.add_argument(
+        "--workspace-id",
+        required=True,
+        help="Workspace id to scan for active cycles.",
+    )
+    parser.add_argument(
+        "--cycle-id",
+        default=None,
+        help="If set, snapshot only this one cycle instead of every active cycle.",
+    )
+    args = parser.parse_args(argv)
+    return asyncio.run(_main_async(args.workspace_id, args.cycle_id))
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI driver
+    raise SystemExit(main())
+
+
+__all__ = ["main", "run_forever_loop", "snapshot_all_active", "snapshot_one"]

--- a/ee/cloud/mission_control/dto.py
+++ b/ee/cloud/mission_control/dto.py
@@ -3,6 +3,13 @@
 # for the Mission Control façade. Request and response shapes are kept on
 # separate classes per ee/cloud rule #4 — never reuse a model across input
 # and output.
+# Updated: 2026-05-13 (feat/mission-control-cleanup) — pinned
+# BulkReassignRequest.Assignee.kind to the Tasks vocabulary
+# (``Literal["human", "agent"]``) now that the endpoint delegates to
+# ``tasks.service.agent_reassign_task`` directly. The Mission Control
+# WorkItem domain still uses ``AssigneeKind.USER`` ("user") for Instinct
+# projections, but the reassign endpoint only acts on Tasks, so the wire
+# contract for the request body follows Tasks.
 """Mission Control wire DTOs.
 
 The audit doc (``docs/internal/2026-05-mission-control-backend-audit.md``,
@@ -16,6 +23,7 @@ guarantees as HTTP callers.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -64,15 +72,18 @@ class BulkActionRequest(BaseModel):
 
 
 class BulkReassignRequest(BaseModel):
-    """Body for the (PR-2-blocked) bulk-reassign endpoint.
+    """Body for ``POST /mission-control/items/bulk-reassign``.
 
-    The Tasks entity ships in PR 2 with the assignee polymorphism this
-    needs; PR 1 surfaces this endpoint as a stub so the frontend can
-    wire its API client without conditional code paths.
+    Delegates per-id to ``ee.cloud.tasks.service.agent_reassign_task``.
+    ``to.kind`` uses the Tasks vocabulary (``human`` / ``agent``) rather
+    than the Mission Control display vocabulary (``user`` / ``agent``) so
+    the body is forward-routed without translation. Ids that aren't
+    Tasks (e.g. ``nudge:<id>``) come back in ``skipped`` — Instinct
+    Actions don't carry a polymorphic assignee.
     """
 
     class Assignee(BaseModel):
-        kind: AssigneeKind
+        kind: Literal["human", "agent"]
         id: str
         name: str | None = None
 
@@ -81,7 +92,12 @@ class BulkReassignRequest(BaseModel):
 
 
 class BulkSnoozeRequest(BaseModel):
-    """Body for the (PR-2-blocked) bulk-snooze endpoint. See note above."""
+    """Body for ``POST /mission-control/items/bulk-snooze``.
+
+    Snoozes N Tasks by setting their ``due_at`` to ``until_iso`` via
+    ``tasks.service.agent_update_task``. Ids that aren't Tasks come back
+    in ``skipped`` — Instinct Actions don't carry a due date.
+    """
 
     ids: list[str] = Field(min_length=1)
     until_iso: str = Field(description="ISO-8601 timestamp to snooze until")

--- a/ee/cloud/mission_control/router.py
+++ b/ee/cloud/mission_control/router.py
@@ -3,6 +3,10 @@
 # Mission Control façade. Endpoints exactly as specified in the audit doc:
 # items list, bulk approve/reject, bulk reassign/snooze stubs (501 until
 # PR 2), outcomes summary, activity feed.
+# Updated: 2026-05-13 (feat/mission-control-cleanup) — lifted the 501s on
+# bulk-reassign / bulk-snooze. Both now return a ``BulkActionResponse``
+# shape (``affected`` + ``skipped`` + ``bulk_id``) by delegating per-id
+# to the Tasks service.
 """Mission Control façade router.
 
 Thin per ee/cloud rule #4 — parses requests, delegates to
@@ -15,8 +19,8 @@ canonical URLs are:
   GET  /api/v1/mission-control/items
   POST /api/v1/mission-control/items/bulk-approve
   POST /api/v1/mission-control/items/bulk-reject
-  POST /api/v1/mission-control/items/bulk-reassign   (501 — PR 2 wires it)
-  POST /api/v1/mission-control/items/bulk-snooze     (501 — PR 2 wires it)
+  POST /api/v1/mission-control/items/bulk-reassign
+  POST /api/v1/mission-control/items/bulk-snooze
   GET  /api/v1/mission-control/outcomes
   GET  /api/v1/mission-control/activity
 """
@@ -92,11 +96,13 @@ async def bulk_reassign(
     body: BulkReassignRequest,
     ctx: RequestContext = Depends(request_context),
 ) -> dict:
-    """Stub — surfaces 501 until the Tasks entity (PR 2) lands.
+    """Reassign N Tasks in one call.
 
-    The endpoint exists so the frontend API client can wire it without
-    conditional code paths. Service returns a ``CloudError(501, ...)``
-    with the audit-doc reference in the message.
+    Delegates per-id to ``tasks.service.agent_reassign_task``. Returns
+    ``{bulk_id, affected, skipped}``: ids that aren't Tasks (Nudges, any
+    non-Task prefix) land in ``skipped``. Cross-workspace ids also land
+    in ``skipped`` rather than raising, so a mixed operator selection
+    can't leak across tenants.
     """
     return await mc_service.agent_bulk_reassign(ctx, body)
 
@@ -106,7 +112,13 @@ async def bulk_snooze(
     body: BulkSnoozeRequest,
     ctx: RequestContext = Depends(request_context),
 ) -> dict:
-    """Stub — surfaces 501 until the Tasks entity (PR 2) lands. See above."""
+    """Snooze N Tasks to a future ``until_iso`` timestamp.
+
+    Delegates per-id to ``tasks.service.agent_update_task`` setting the
+    Task's ``due_at`` to the snooze deadline. Same ``skipped`` semantics
+    as ``bulk-reassign``. Invalid ISO timestamps return 422 via
+    ``mission_control.invalid_until_iso``.
+    """
     return await mc_service.agent_bulk_snooze(ctx, body)
 
 

--- a/ee/cloud/mission_control/service.py
+++ b/ee/cloud/mission_control/service.py
@@ -1,9 +1,13 @@
 # ee/cloud/mission_control/service.py
 # Created: 2026-05-13 (feat/mission-control-facade) — façade service that
 # composes Instinct (Nudges + Pawprints) and the in-process activity buffer
-# into Mission Control's unified WorkItem shape. PR 1 of three. The Tasks
-# entity (PR 2) and Cycles entity (PR 3) plug into the same service surface
-# without changing the wire contract.
+# into Mission Control's unified WorkItem shape. PR 1 of three.
+# Updated: 2026-05-13 (feat/mission-control-cleanup) — lifted the 501 stubs
+# on bulk-reassign + bulk-snooze now that the Tasks entity (PR 2) is on
+# ``ee``. Both endpoints delegate per-id to ``ee.cloud.tasks.service`` and
+# skip non-Task ids (Instinct Actions don't reassign or snooze). Also
+# tagged the per-bulk approve/reject loops with ``# no-event`` comments
+# so rule #9 is satisfied without redundant double-emits.
 """Mission Control façade service.
 
 Every function is module-level ``async def`` per ee/cloud rule #5. The
@@ -22,10 +26,18 @@ Tenancy:
     it as the chokepoint.
 
 No Beanie writes here — the façade is read-only against Instinct + the
-activity buffer in PR 1. Bulk-approve / bulk-reject delegate to
+activity buffer. Bulk-approve / bulk-reject delegate to
 ``ee.instinct.store`` (single ownership of the audit transaction lives
-inside Instinct's store). Bulk-reassign / bulk-snooze raise 501 until
-the Tasks entity (PR 2) lands the polymorphic assignee they need.
+inside Instinct's store). Bulk-reassign / bulk-snooze fan out per-id to
+``ee.cloud.tasks.service`` and report which ids weren't Tasks in
+``skipped``.
+
+Id conventions inherited from ``_action_to_work_item``: Instinct nudges
+project as ``"nudge:<action_id>"``; Tasks project as ``"task:<task_id>"``
+(via the Tasks entity's own projector). The bulk endpoints accept either
+prefixed or bare ids — anything starting with ``nudge:`` (or any
+non-Task prefix) is silently skipped by reassign/snooze because Instinct
+Actions don't carry a polymorphic assignee or a due date.
 """
 
 from __future__ import annotations
@@ -36,7 +48,7 @@ from typing import Any
 
 from ee.api import get_instinct_store
 from ee.cloud._core.context import RequestContext
-from ee.cloud._core.errors import CloudError, ValidationError
+from ee.cloud._core.errors import ValidationError
 from ee.cloud.activity.buffer import ActivityEvent, get_buffer
 from ee.cloud.mission_control.domain import (
     AssigneeKind,
@@ -228,6 +240,7 @@ async def agent_bulk_approve(
     approved, missing, bulk_id = await store.bulk_approve(
         eligible, approver=ctx.user_id, note=body.note
     )
+    # no-event: per-item approve/reject inside the loop already emits the events
     return {
         "bulk_id": bulk_id,
         "approved": [a.model_dump(mode="json") for a in approved],
@@ -259,6 +272,7 @@ async def agent_bulk_reject(
     rejected, missing, bulk_id = await store.bulk_reject(
         eligible, reason=body.reason, rejector=ctx.user_id
     )
+    # no-event: per-item approve/reject inside the loop already emits the events
     return {
         "bulk_id": bulk_id,
         "rejected": [a.model_dump(mode="json") for a in rejected],
@@ -374,48 +388,136 @@ def _activity_to_response(e: ActivityEvent) -> ActivityEventResponse:
 
 
 # ---------------------------------------------------------------------------
-# 501 stubs — wait for PR 2 (Tasks)
+# Bulk reassign / snooze — fan out to ee.cloud.tasks.service
 # ---------------------------------------------------------------------------
+
+
+def _classify_task_id(raw: str) -> str | None:
+    """Pick the Task id out of a Mission Control work-item id, or ``None``
+    when the id doesn't refer to a Task.
+
+    The Mission Control wire shape prefixes ids with their source so the
+    frontend can render a heterogeneous feed from a single store:
+      - ``nudge:<action_id>``  → Instinct action (no reassign, no snooze)
+      - ``task:<task_id>``     → Tasks entity
+      - bare id                → treated as a Task id for forward
+        compatibility with callers that pre-strip the prefix.
+    """
+    if not raw:
+        return None
+    if raw.startswith("task:"):
+        return raw[len("task:") :] or None
+    if ":" in raw:
+        # nudge: / cycle: / any other typed prefix — not a Task.
+        return None
+    return raw
 
 
 async def agent_bulk_reassign(
     ctx: RequestContext, body: BulkReassignRequest | dict[str, Any]
 ) -> dict[str, Any]:
-    """Bulk reassign is gated on the Tasks entity (PR 2).
+    """Reassign N Tasks to the same new assignee in one call.
 
-    Instinct's Action doesn't carry a polymorphic assignee — the column
-    we added in this PR is ``assignee: str`` (a user id), not the
-    ``{kind, id, name}`` shape Mission Control needs. The Tasks entity
-    ships PR 2 with that shape; this endpoint stays as a 501 until then
-    so the frontend can wire its API client without conditional code.
+    Fans out per-id to ``ee.cloud.tasks.service.agent_reassign_task`` so
+    each leg lands its own ``task.updated`` event (per-row notifications
+    + audit trail stay precise). Ids that don't refer to Tasks land in
+    ``skipped`` rather than raising — bulk selections in Mission Control
+    routinely mix Nudges and Tasks; the operator's action bar splits
+    routing client-side, and the server treats the wrong-kind path
+    defensively.
     """
     body = BulkReassignRequest.model_validate(body)
     _require_workspace(ctx)
-    raise CloudError(
-        501,
-        "mission_control.not_implemented",
-        (
-            "bulk-reassign needs the Tasks entity (PR 2 of the Mission Control "
-            "series). PR 1 ships only the Instinct façade — see "
-            "docs/internal/2026-05-mission-control-backend-audit.md."
-        ),
+
+    from uuid import uuid4
+
+    from ee.cloud.tasks import service as tasks_service
+    from ee.cloud.tasks.dto import ReassignTaskRequest
+
+    bulk_id = uuid4().hex
+    affected: list[str] = []
+    skipped: list[str] = []
+    reassign_body = ReassignTaskRequest(
+        assignee_kind=body.to.kind,
+        assignee_id=body.to.id,
+        assignee_name=body.to.name or "",
     )
+
+    for raw_id in body.ids:
+        task_id = _classify_task_id(raw_id)
+        if task_id is None:
+            skipped.append(raw_id)
+            continue
+        try:
+            await tasks_service.agent_reassign_task(ctx, task_id, reassign_body)
+            affected.append(raw_id)
+        except Exception:
+            # NotFound (wrong workspace / missing), Forbidden (caller
+            # isn't creator/assignee), or any other Task-level reject —
+            # all surface to the operator as "couldn't apply", which is
+            # exactly what ``skipped`` represents.
+            logger.info(
+                "mission_control.bulk_reassign: skipped id %s",
+                raw_id,
+                exc_info=True,
+            )
+            skipped.append(raw_id)
+
+    # no-event: per-item agent_reassign_task already emits TaskUpdated per row
+    return {"bulk_id": bulk_id, "affected": affected, "skipped": skipped}
 
 
 async def agent_bulk_snooze(
     ctx: RequestContext, body: BulkSnoozeRequest | dict[str, Any]
 ) -> dict[str, Any]:
-    """Bulk snooze is gated on the Tasks entity (PR 2). See above."""
+    """Snooze N Tasks to the same ``until_iso`` timestamp in one call.
+
+    Implemented as a partial update on ``due_at`` per task — the Tasks
+    entity treats ``due_at`` as the snooze-until column (a Nudge that
+    snoozes for an hour is just a Task whose due_at is one hour out).
+    Skips ids that aren't Tasks, same semantics as ``agent_bulk_reassign``.
+    """
     body = BulkSnoozeRequest.model_validate(body)
     _require_workspace(ctx)
-    raise CloudError(
-        501,
-        "mission_control.not_implemented",
-        (
-            "bulk-snooze needs the Tasks entity (PR 2 of the Mission Control "
-            "series) to carry the snooze-until field on the work item."
-        ),
-    )
+
+    from uuid import uuid4
+
+    from ee.cloud.tasks import service as tasks_service
+    from ee.cloud.tasks.dto import UpdateTaskRequest
+
+    # Parse the ISO timestamp once so an invalid string surfaces as a
+    # 422 ValidationError rather than failing per-row inside the loop.
+    try:
+        until_dt = datetime.fromisoformat(body.until_iso.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValidationError(
+            "mission_control.invalid_until_iso",
+            f"until_iso must be an ISO-8601 timestamp; got {body.until_iso!r}",
+        ) from exc
+
+    bulk_id = uuid4().hex
+    affected: list[str] = []
+    skipped: list[str] = []
+    update_body = UpdateTaskRequest(due_at=until_dt)
+
+    for raw_id in body.ids:
+        task_id = _classify_task_id(raw_id)
+        if task_id is None:
+            skipped.append(raw_id)
+            continue
+        try:
+            await tasks_service.agent_update_task(ctx, task_id, update_body)
+            affected.append(raw_id)
+        except Exception:
+            logger.info(
+                "mission_control.bulk_snooze: skipped id %s",
+                raw_id,
+                exc_info=True,
+            )
+            skipped.append(raw_id)
+
+    # no-event: per-item agent_update_task already emits TaskUpdated per row
+    return {"bulk_id": bulk_id, "affected": affected, "skipped": skipped}
 
 
 __all__ = [

--- a/ee/cloud/tasks/service.py
+++ b/ee/cloud/tasks/service.py
@@ -5,6 +5,11 @@
 #   per Rule 9. Tenant filter on every read per Rule 7. Optimistic
 #   single-writer claim via ``find_one_and_update`` so two agents
 #   racing on the same proposed task can never both succeed.
+# Updated: 2026-05-13 (feat/mission-control-cleanup) — added
+#   ``agent_reassign_task_cycle`` so cycle-close rollover can move
+#   tasks to the next active cycle (or clear ``cycle_id``) without the
+#   creator-or-assignee guard, since workspace admins close cycles
+#   they may not own personally.
 """Tasks entity — business logic service.
 
 Public API (all module-level ``async def``):
@@ -428,6 +433,28 @@ async def agent_reassign_task(
 # ---------------------------------------------------------------------------
 
 
+async def agent_reassign_task_cycle(
+    ctx: RequestContext, task_id: str, new_cycle_id: str | None
+) -> TaskResponse:
+    """Move a Task to a different cycle (or clear its cycle).
+
+    Used by ``cycles.service._roll_incomplete_tasks`` when a cycle
+    closes — incomplete tasks roll to the next active cycle on the same
+    pocket, and ``new_cycle_id=None`` drops them back into the
+    unscheduled list. Workspace-admin pathway: skips the per-row
+    creator/assignee guard that ``agent_update_task`` enforces, because
+    the cycle owner (not the task owner) is the one closing the cycle.
+    Still tenant-scoped via ``_fetch_task``.
+    """
+
+    doc = await _fetch_task(ctx, task_id)
+    doc.cycle_id = new_cycle_id
+    await doc.save()
+    task = _to_domain(doc)
+    await emit(TaskUpdated(data=_event_payload(doc, task)))
+    return task_to_dto(task)
+
+
 async def list_for_agent_runtime(
     workspace_id: str, agent_id: str, status: str = "proposed", limit: int = 50
 ) -> list[TaskResponse]:
@@ -465,6 +492,7 @@ __all__ = [
     "agent_get_task",
     "agent_list_tasks",
     "agent_reassign_task",
+    "agent_reassign_task_cycle",
     "agent_update_task",
     "list_for_agent_runtime",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -624,5 +624,6 @@ source_modules = [
     "ee.cloud.cycles.router",
     "ee.cloud.cycles.dto",
     "ee.cloud.cycles.domain",
+    "ee.cloud.cycles.snapshot_job",
 ]
 forbidden_modules = ["ee.cloud.models.cycle"]

--- a/tests/cloud/test_cycles_service.py
+++ b/tests/cloud/test_cycles_service.py
@@ -3,10 +3,10 @@
 Exercise the service-level API directly against the shared mongomock-motor
 fixture. The ``recording_bus`` autouse fixture captures emitted events.
 
-Tasks-composition assertions (status counters, rollover-on-close) are
-guarded by an availability probe — when PR 2's Tasks entity hasn't merged
-into ``ee`` yet, those branches skip with a clear TODO so the rest of the
-suite stays green.
+Tasks-composition assertions (status counters, rollover-on-close) run
+against the live Tasks service now that PR 2 has merged. The
+``_tasks_available`` probe is kept as a safety net for trunk forks that
+predate PR 2 — those still see the gated paths skip rather than crash.
 """
 
 from __future__ import annotations
@@ -344,18 +344,113 @@ async def test_close_idempotent() -> None:
 
 
 async def test_close_rolls_incomplete_tasks() -> None:
-    """When Tasks (PR 2) is available, closing a cycle reassigns its
-    non-done tasks to the next active cycle on the same pocket."""
+    """Closing a cycle moves incomplete tasks to the next active cycle on
+    the same pocket; ``done`` tasks stay attached to the closing cycle."""
     if not _tasks_available():
         pytest.skip(
-            "Tasks entity (PR 2) not merged into this branch yet — "
-            "TODO: revisit once feat/mission-control-tasks lands in ee"
+            "Tasks entity not present on this branch — fork predates PR 2"
         )
-    # The actual rollover semantics live in PR 2's task service; once that
-    # module exposes the documented ``agent_reassign_task_cycle`` helper,
-    # this test can construct tasks, call agent_close_cycle, and assert
-    # they show up on the rolled-to cycle.
-    pytest.skip("Tasks-side assertions covered in PR 2's test suite")
+
+    from ee.cloud.tasks import service as tasks_service
+    from ee.cloud.tasks.dto import (
+        AssigneeDTO,
+        CompleteTaskRequest,
+        CreateTaskRequest,
+    )
+
+    ctx = _ctx()
+    # Closing cycle on pocket p1, with a follow-up active cycle on the
+    # same pocket so the rollover has a target.
+    closing = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="closing",
+            pocket_id="p1",
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 14),
+            status="active",
+        ),
+    )
+    follow_up = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="follow-up",
+            pocket_id="p1",
+            start=date(2026, 5, 15),
+            end=date(2026, 5, 28),
+            status="active",
+        ),
+    )
+
+    # Two tasks attached to the closing cycle: one done (stays put), one
+    # in-progress (rolls forward).
+    done_task = await tasks_service.agent_create_task(
+        ctx,
+        CreateTaskRequest(
+            title="done",
+            assignee=AssigneeDTO(kind="human", id="u1", name="u1"),
+            cycle_id=closing.id,
+            pocket_id="p1",
+        ),
+    )
+    await tasks_service.agent_complete_task(
+        ctx, done_task.id, CompleteTaskRequest(next_action="archive")
+    )
+    incomplete_task = await tasks_service.agent_create_task(
+        ctx,
+        CreateTaskRequest(
+            title="incomplete",
+            assignee=AssigneeDTO(kind="human", id="u1", name="u1"),
+            cycle_id=closing.id,
+            pocket_id="p1",
+        ),
+    )
+
+    closed = await cycles_service.agent_close_cycle(ctx, closing.id)
+    assert closed.status == "completed"
+
+    # The incomplete task moved to the follow-up cycle; the done task
+    # stayed on the (now closed) original cycle.
+    rolled = await tasks_service.agent_get_task(ctx, incomplete_task.id)
+    assert rolled.cycle_id == follow_up.id
+    stayed = await tasks_service.agent_get_task(ctx, done_task.id)
+    assert stayed.cycle_id == closing.id
+
+
+async def test_close_drops_to_unscheduled_when_no_follow_up() -> None:
+    """Cycle close with no other active cycle on the same pocket clears
+    the incomplete tasks' cycle_id instead of rolling forward."""
+    if not _tasks_available():
+        pytest.skip(
+            "Tasks entity not present on this branch — fork predates PR 2"
+        )
+
+    from ee.cloud.tasks import service as tasks_service
+    from ee.cloud.tasks.dto import AssigneeDTO, CreateTaskRequest
+
+    ctx = _ctx()
+    closing = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="closing-orphan",
+            pocket_id="p-orphan",
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 14),
+            status="active",
+        ),
+    )
+    orphan = await tasks_service.agent_create_task(
+        ctx,
+        CreateTaskRequest(
+            title="orphan",
+            assignee=AssigneeDTO(kind="human", id="u1", name="u1"),
+            cycle_id=closing.id,
+            pocket_id="p-orphan",
+        ),
+    )
+    await cycles_service.agent_close_cycle(ctx, closing.id)
+    fetched = await tasks_service.agent_get_task(ctx, orphan.id)
+    assert fetched.cycle_id is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_mission_control_bulk_reassign.py
+++ b/tests/cloud/test_mission_control_bulk_reassign.py
@@ -1,0 +1,151 @@
+# tests/cloud/test_mission_control_bulk_reassign.py
+# Created: 2026-05-13 (feat/mission-control-cleanup) — service-layer tests for
+# the Mission Control façade's bulk-reassign endpoint, which delegates per-id
+# to ``ee.cloud.tasks.service.agent_reassign_task``. Covers the success path,
+# the mixed Tasks-plus-Nudges payload (non-Tasks skipped), and the workspace
+# tenancy guarantee (cross-workspace ids land in ``skipped``).
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud.mission_control import service as mc_service
+from ee.cloud.mission_control.dto import BulkReassignRequest
+from ee.cloud.tasks import service as tasks_service
+from ee.cloud.tasks.dto import AssigneeDTO, CreateTaskRequest
+from ee.instinct.store import InstinctStore
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace_id: str = "w1", user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="req-test",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "mc_bulk_reassign.db")
+
+
+@pytest.fixture(autouse=True)
+def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
+    """Same test doubles as the other Mission Control suites."""
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(
+        mc_service.pockets_service,
+        "list_pockets",
+        AsyncMock(return_value=[{"_id": "p1"}, {"_id": "p2"}]),
+    )
+    yield
+
+
+def _to(kind: str = "agent", task_id: str = "agent-rover", name: str = "Rover"):
+    return BulkReassignRequest.Assignee(kind=kind, id=task_id, name=name)
+
+
+async def test_reassigns_tasks_emitting_per_row_event(recording_bus) -> None:
+    """Each prefixed Task id maps to one agent_reassign_task call. The
+    response carries ``affected`` ids and a single ``bulk_id``."""
+    ctx = _ctx()
+    a = await tasks_service.agent_create_task(
+        ctx,
+        CreateTaskRequest(
+            title="t-a",
+            assignee=AssigneeDTO(kind="human", id="u1", name="u1"),
+        ),
+    )
+    b = await tasks_service.agent_create_task(
+        ctx,
+        CreateTaskRequest(
+            title="t-b",
+            assignee=AssigneeDTO(kind="human", id="u1", name="u1"),
+        ),
+    )
+
+    recording_bus.events.clear()
+    result = await mc_service.agent_bulk_reassign(
+        ctx,
+        BulkReassignRequest(
+            ids=[f"task:{a.id}", f"task:{b.id}"], to=_to()
+        ),
+    )
+    assert set(result["affected"]) == {f"task:{a.id}", f"task:{b.id}"}
+    assert result["skipped"] == []
+    assert "bulk_id" in result
+
+    # Tasks service emits TaskUpdated per row; the bulk path doesn't add
+    # its own event on top.
+    from ee.cloud._core.realtime.events import TaskUpdated
+
+    updates = [e for e in recording_bus.events if isinstance(e, TaskUpdated)]
+    assert len(updates) == 2
+
+    # And the underlying Task rows reflect the new assignee.
+    refreshed_a = await tasks_service.agent_get_task(ctx, a.id)
+    assert refreshed_a.assignee.kind == "agent"
+    assert refreshed_a.assignee.id == "agent-rover"
+
+
+async def test_skips_non_task_ids() -> None:
+    """``nudge:<id>``, bare-prefix garbage, and unknown task ids land in
+    ``skipped`` rather than raising. The affected list only carries the
+    real Tasks."""
+    ctx = _ctx()
+    real = await tasks_service.agent_create_task(
+        ctx,
+        CreateTaskRequest(
+            title="real",
+            assignee=AssigneeDTO(kind="human", id="u1", name="u1"),
+        ),
+    )
+
+    result = await mc_service.agent_bulk_reassign(
+        ctx,
+        BulkReassignRequest(
+            ids=[
+                f"task:{real.id}",
+                "nudge:not-a-task",
+                "cycle:also-not-a-task",
+            ],
+            to=_to(),
+        ),
+    )
+    assert result["affected"] == [f"task:{real.id}"]
+    assert set(result["skipped"]) == {
+        "nudge:not-a-task",
+        "cycle:also-not-a-task",
+    }
+
+
+async def test_tenant_isolation_routes_other_workspace_to_skipped() -> None:
+    """A Task in workspace w2 is invisible to a w1 caller; the bulk
+    endpoint reports it as ``skipped`` instead of leaking the reassign
+    across tenants."""
+    cross = await tasks_service.agent_create_task(
+        _ctx(workspace_id="w2"),
+        CreateTaskRequest(
+            title="cross-tenant",
+            assignee=AssigneeDTO(kind="human", id="u-other", name="u-other"),
+        ),
+    )
+    result = await mc_service.agent_bulk_reassign(
+        _ctx(workspace_id="w1"),
+        BulkReassignRequest(ids=[f"task:{cross.id}"], to=_to()),
+    )
+    assert result["affected"] == []
+    assert result["skipped"] == [f"task:{cross.id}"]
+
+    # The task in w2 wasn't touched — its original assignee survives.
+    untouched = await tasks_service.agent_get_task(_ctx(workspace_id="w2"), cross.id)
+    assert untouched.assignee.id == "u-other"

--- a/tests/cloud/test_mission_control_bulk_snooze.py
+++ b/tests/cloud/test_mission_control_bulk_snooze.py
@@ -1,0 +1,140 @@
+# tests/cloud/test_mission_control_bulk_snooze.py
+# Created: 2026-05-13 (feat/mission-control-cleanup) — service-layer tests for
+# the Mission Control façade's bulk-snooze endpoint, which delegates per-id to
+# ``ee.cloud.tasks.service.agent_update_task`` setting ``due_at`` to the snooze
+# timestamp. Covers the success path (``due_at`` actually landed on the Task),
+# the mixed Tasks-plus-Nudges payload (non-Tasks skipped), tenant isolation,
+# and ISO-validation surfacing as a 422.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud._core.errors import ValidationError
+from ee.cloud.mission_control import service as mc_service
+from ee.cloud.mission_control.dto import BulkSnoozeRequest
+from ee.cloud.tasks import service as tasks_service
+from ee.cloud.tasks.dto import AssigneeDTO, CreateTaskRequest
+from ee.instinct.store import InstinctStore
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace_id: str = "w1", user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="req-test",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "mc_bulk_snooze.db")
+
+
+@pytest.fixture(autouse=True)
+def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    monkeypatch.setattr(
+        mc_service.pockets_service,
+        "list_pockets",
+        AsyncMock(return_value=[{"_id": "p1"}, {"_id": "p2"}]),
+    )
+    yield
+
+
+async def test_snoozes_tasks_setting_due_at() -> None:
+    """The snooze ``until_iso`` lands on each Task's ``due_at`` column."""
+    ctx = _ctx()
+    a = await tasks_service.agent_create_task(
+        ctx,
+        CreateTaskRequest(
+            title="snooze-a",
+            assignee=AssigneeDTO(kind="human", id="u1", name="u1"),
+        ),
+    )
+    until = (datetime.now(UTC) + timedelta(hours=4)).replace(microsecond=0)
+
+    result = await mc_service.agent_bulk_snooze(
+        ctx,
+        BulkSnoozeRequest(ids=[f"task:{a.id}"], until_iso=until.isoformat()),
+    )
+    assert result["affected"] == [f"task:{a.id}"]
+    assert result["skipped"] == []
+    assert "bulk_id" in result
+
+    # The Task row reflects the snooze.
+    refreshed = await tasks_service.agent_get_task(ctx, a.id)
+    assert refreshed.due_at is not None
+    parsed = datetime.fromisoformat(refreshed.due_at)
+    assert parsed.replace(microsecond=0) == until
+
+
+async def test_skips_non_task_ids() -> None:
+    """Nudge ids and any non-Task prefix end up in ``skipped``."""
+    ctx = _ctx()
+    real = await tasks_service.agent_create_task(
+        ctx,
+        CreateTaskRequest(
+            title="real",
+            assignee=AssigneeDTO(kind="human", id="u1", name="u1"),
+        ),
+    )
+    until = (datetime.now(UTC) + timedelta(days=1)).isoformat()
+
+    result = await mc_service.agent_bulk_snooze(
+        ctx,
+        BulkSnoozeRequest(
+            ids=[
+                f"task:{real.id}",
+                "nudge:not-a-task",
+                "cycle:also-not-a-task",
+            ],
+            until_iso=until,
+        ),
+    )
+    assert result["affected"] == [f"task:{real.id}"]
+    assert set(result["skipped"]) == {
+        "nudge:not-a-task",
+        "cycle:also-not-a-task",
+    }
+
+
+async def test_tenant_isolation_routes_other_workspace_to_skipped() -> None:
+    cross = await tasks_service.agent_create_task(
+        _ctx(workspace_id="w2"),
+        CreateTaskRequest(
+            title="cross-tenant",
+            assignee=AssigneeDTO(kind="human", id="u-other", name="u-other"),
+        ),
+    )
+    until = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+    result = await mc_service.agent_bulk_snooze(
+        _ctx(workspace_id="w1"),
+        BulkSnoozeRequest(ids=[f"task:{cross.id}"], until_iso=until),
+    )
+    assert result["affected"] == []
+    assert result["skipped"] == [f"task:{cross.id}"]
+
+    # The task in w2 wasn't touched — its due_at stays None.
+    untouched = await tasks_service.agent_get_task(_ctx(workspace_id="w2"), cross.id)
+    assert untouched.due_at is None
+
+
+async def test_invalid_until_iso_raises_validation_error() -> None:
+    """A malformed timestamp surfaces as 422 before any task is touched."""
+    with pytest.raises(ValidationError) as exc:
+        await mc_service.agent_bulk_snooze(
+            _ctx(),
+            BulkSnoozeRequest(ids=["task:any"], until_iso="not-a-real-iso"),
+        )
+    assert exc.value.code == "mission_control.invalid_until_iso"

--- a/tests/cloud/test_mission_control_router.py
+++ b/tests/cloud/test_mission_control_router.py
@@ -150,25 +150,54 @@ class TestBulkRejectEndpoint:
         assert body["rejected"][0]["rejected_reason"] == "no budget"
 
 
-class TestStubEndpoints:
+class TestBulkRoutingStubs:
+    """Skip-only smoke tests — verifies the wire shape (``affected`` +
+    ``skipped`` + ``bulk_id``) and that nudge-prefixed ids never reach
+    the Tasks service. Full Tasks-side coverage lives in
+    ``test_mission_control_bulk_reassign.py`` /
+    ``test_mission_control_bulk_snooze.py`` against the real ``mongo_db``
+    fixture."""
+
     @pytest.mark.asyncio
-    async def test_bulk_reassign_returns_501(self, store: InstinctStore) -> None:
+    async def test_bulk_reassign_skips_nudge_ids(self, store: InstinctStore) -> None:
         with TestClient(_build_app()) as client:
             resp = client.post(
                 "/api/v1/mission-control/items/bulk-reassign",
-                json={"ids": ["x"], "to": {"kind": "agent", "id": "a1"}},
+                json={
+                    "ids": ["nudge:abc", "nudge:def"],
+                    "to": {"kind": "agent", "id": "a1", "name": "claude"},
+                },
             )
-        assert resp.status_code == 501
-        assert resp.json()["error"]["code"] == "mission_control.not_implemented"
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["affected"] == []
+        assert set(body["skipped"]) == {"nudge:abc", "nudge:def"}
+        assert "bulk_id" in body
 
     @pytest.mark.asyncio
-    async def test_bulk_snooze_returns_501(self, store: InstinctStore) -> None:
+    async def test_bulk_snooze_skips_nudge_ids(self, store: InstinctStore) -> None:
         with TestClient(_build_app()) as client:
             resp = client.post(
                 "/api/v1/mission-control/items/bulk-snooze",
-                json={"ids": ["x"], "until_iso": "2026-12-31T00:00:00Z"},
+                json={
+                    "ids": ["nudge:abc"],
+                    "until_iso": "2026-12-31T00:00:00Z",
+                },
             )
-        assert resp.status_code == 501
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["affected"] == []
+        assert body["skipped"] == ["nudge:abc"]
+
+    @pytest.mark.asyncio
+    async def test_bulk_snooze_invalid_iso_returns_422(self, store: InstinctStore) -> None:
+        with TestClient(_build_app()) as client:
+            resp = client.post(
+                "/api/v1/mission-control/items/bulk-snooze",
+                json={"ids": ["task:x"], "until_iso": "not-a-real-iso"},
+            )
+        assert resp.status_code == 422
+        assert resp.json()["error"]["code"] == "mission_control.invalid_until_iso"
 
 
 class TestOutcomesEndpoint:

--- a/tests/cloud/test_mission_control_service.py
+++ b/tests/cloud/test_mission_control_service.py
@@ -3,6 +3,10 @@
 # the mission_control façade service. Asserts WorkItem projection, section
 # routing, agent/pocket/section filters, tenancy gating against
 # pockets_service.list_pockets, and outcome aggregation math.
+# Updated: 2026-05-13 (feat/mission-control-cleanup) — dropped the
+# TestStubEndpoints block now that bulk-reassign and bulk-snooze delegate
+# to the Tasks service. Full coverage of those endpoints lives in
+# test_mission_control_bulk_reassign.py and test_mission_control_bulk_snooze.py.
 
 from __future__ import annotations
 
@@ -13,12 +17,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from ee.cloud._core.context import RequestContext, ScopeKind
-from ee.cloud._core.errors import CloudError, ValidationError
+from ee.cloud._core.errors import ValidationError
 from ee.cloud.mission_control import service as mc_service
 from ee.cloud.mission_control.domain import WorkItemSection, WorkItemStatus
 from ee.cloud.mission_control.dto import (
     BulkActionRequest,
-    BulkReassignRequest,
     ListActivityRequest,
     ListWorkItemsRequest,
     OutcomesQueryRequest,
@@ -241,34 +244,6 @@ class TestOutcomesSummary:
         )
         # Only the "recent" row falls in the 24h window.
         assert summary.total == 1
-
-
-# ---------------------------------------------------------------------------
-# 501 stubs
-# ---------------------------------------------------------------------------
-
-
-class TestStubEndpoints:
-    @pytest.mark.asyncio
-    async def test_bulk_reassign_raises_not_implemented(self, store: InstinctStore) -> None:
-        with pytest.raises(CloudError) as exc:
-            await mc_service.agent_bulk_reassign(
-                _ctx(),
-                BulkReassignRequest(
-                    ids=["x"], to={"kind": "agent", "id": "a1", "name": "claude"}
-                ),
-            )
-        assert exc.value.status_code == 501
-        assert exc.value.code == "mission_control.not_implemented"
-
-    @pytest.mark.asyncio
-    async def test_bulk_snooze_raises_not_implemented(self, store: InstinctStore) -> None:
-        with pytest.raises(CloudError) as exc:
-            await mc_service.agent_bulk_snooze(
-                _ctx(),
-                {"ids": ["x"], "until_iso": "2026-12-31T00:00:00Z"},
-            )
-        assert exc.value.status_code == 501
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to the three Mission Control PRs (#1094 Tasks, #1095 Cycles, #1096 Façade) — closes their deferred items and the non-blocker review comments. No new surfaces; the façade and entity routes already shipped on `ee`. This PR fills in the gaps they explicitly punted on.

## Closes

- **501 stubs on `bulk-reassign` + `bulk-snooze`** — both endpoints now fan out per-id to the Tasks service. Body shapes match the captain spec (`{ids, to: {kind, id, name}}` and `{ids, until_iso}`); response shape is `{bulk_id, affected, skipped}` consistent with `bulk-approve`. Non-Task ids (`nudge:<id>`, any non-task prefix) land in `skipped`; cross-workspace ids also skip rather than raising.
- **`pytest.skip` in `test_cycles_service::test_close_rolls_incomplete_tasks`** — Tasks merged, so the rollover assertions are live. Added a second `test_close_drops_to_unscheduled_when_no_follow_up` covering the no-follow-up branch.
- **`emit()` rule #9 comments**:
  - `mission_control/service.py::agent_bulk_approve` and `agent_bulk_reject` — per-item Instinct emits inside the loop, no aggregate event needed.
  - `mission_control/service.py::agent_bulk_reassign` and `agent_bulk_snooze` — per-item Task emits inside the loop.
  - `cycles/service.py::agent_get_cycle` — silent counter sync on read; aggregate event would churn.
- **Cycles import-linter contract** — added `ee.cloud.cycles.snapshot_job` to the source-modules list. To keep the 4-file rule, moved the active-cycle iteration into `cycles_service.list_active_cycle_ids` so `snapshot_job` no longer touches the Beanie model directly.
- **UTC weekend-flag caveat** — pinned the docstring clarification onto `_snapshot_cycle_daily` and the module docstring.

## Scheduler-wiring placeholder

- `cycles/snapshot_job.py` header now documents three wiring patterns (Unix cron / Kubernetes CronJob / Celery beat) with example invocations against the new `python -m ee.cloud.cycles.snapshot_job --workspace-id <id>` entry point.
- `ee/cloud/__init__.py::mount_cloud` carries a `# TODO: wire daily-snapshot scheduler` marker near `register_task_listeners()` pointing at the snapshot_job module.
- No in-process loop — the host platform owns scheduling.

## Files

- `ee/cloud/mission_control/{service,dto,router}.py` — lift stubs, comments, wire response shape.
- `ee/cloud/cycles/service.py` — no-event comment on `agent_get_cycle`, UTC weekend caveat, new `list_active_cycle_ids` helper for `snapshot_job`.
- `ee/cloud/cycles/snapshot_job.py` — wiring-pattern documentation, `main()` entry point with argparse, refactored to use the service helper.
- `ee/cloud/tasks/service.py` — added `agent_reassign_task_cycle` so cycle close can actually roll incomplete tasks (the prior code looked up a non-existent method).
- `ee/cloud/__init__.py` — TODO marker pointing at the snapshot_job module.
- `pyproject.toml` — `ee.cloud.cycles.snapshot_job` added to the Cycles import-linter contract source-modules.
- `tests/cloud/test_mission_control_bulk_reassign.py` (new) — success path, mixed Tasks + non-Tasks (non-Tasks skipped), tenant isolation.
- `tests/cloud/test_mission_control_bulk_snooze.py` (new) — success path with `due_at` assertion, mixed ids, tenant isolation, invalid-ISO → 422.
- `tests/cloud/test_cycles_service.py` — lifted skip, two real rollover tests.
- `tests/cloud/test_mission_control_{service,router}.py` — dropped the obsolete 501 stub tests; router tests now cover the skip-non-Tasks path and the 422 ISO-validation path.

## Test plan

- [x] `uv run pytest tests/cloud/test_mission_control* tests/cloud/test_cycles_service.py` → 53 passed, 1 skipped (the legacy `test_list_items_empty_when_tasks_unavailable` that gates on Tasks-not-available, which is the inverse condition now).
- [x] `uv run lint-imports` → 12 contracts kept, 0 broken.
- [x] `uv run ruff check` on changed files → no new violations.

## Out of scope

- Actually scheduling the snapshot job on a host platform. The wiring placeholder + module entry point are in; the platform-side cron / CronJob / Celery beat config is a deployment task, not a code change.
- Fixing the pre-existing `test_list_for_agent_runtime_status_filter` cross-module flake in `tests/cloud/tasks/test_tasks_service.py`. That predates this PR and reproduces on `ee` itself.

**Do NOT merge.** Captain reviews before any merge.