### PR TITLE
fix(mission-control): audit-log admin reassign + cover bare-id branch

### DIFF
--- a/ee/cloud/tasks/service.py
+++ b/ee/cloud/tasks/service.py
@@ -10,6 +10,11 @@
 #   tasks to the next active cycle (or clear ``cycle_id``) without the
 #   creator-or-assignee guard, since workspace admins close cycles
 #   they may not own personally.
+# Updated: 2026-05-13 (fix/mission-control-followup-nits) — the admin
+#   ``agent_reassign_task_cycle`` path now emits a structured audit log
+#   line on every call so the creator/assignee-guard bypass is
+#   reviewable. PR #1097's reviewer flagged the silent privilege bypass
+#   as the highest-priority follow-up.
 """Tasks entity — business logic service.
 
 Public API (all module-level ``async def``):
@@ -445,11 +450,25 @@ async def agent_reassign_task_cycle(
     creator/assignee guard that ``agent_update_task`` enforces, because
     the cycle owner (not the task owner) is the one closing the cycle.
     Still tenant-scoped via ``_fetch_task``.
+
+    Audit: emits a structured ``tasks.reassign_cycle`` log line on every
+    call (caller, task, from→to cycle) so the privilege bypass is
+    reviewable. The line is INFO-level — the operation is expected on
+    cycle close — but carries enough context for after-the-fact audit.
     """
 
     doc = await _fetch_task(ctx, task_id)
+    previous_cycle_id = doc.cycle_id
     doc.cycle_id = new_cycle_id
     await doc.save()
+    logger.info(
+        "tasks.reassign_cycle workspace=%s caller=%s task=%s from=%s to=%s",
+        ctx.workspace_id,
+        ctx.user_id,
+        task_id,
+        previous_cycle_id,
+        new_cycle_id,
+    )
     task = _to_domain(doc)
     await emit(TaskUpdated(data=_event_payload(doc, task)))
     return task_to_dto(task)

--- a/tests/cloud/test_mission_control_bulk_reassign.py
+++ b/tests/cloud/test_mission_control_bulk_reassign.py
@@ -4,6 +4,10 @@
 # to ``ee.cloud.tasks.service.agent_reassign_task``. Covers the success path,
 # the mixed Tasks-plus-Nudges payload (non-Tasks skipped), and the workspace
 # tenancy guarantee (cross-workspace ids land in ``skipped``).
+# Updated: 2026-05-13 (fix/mission-control-followup-nits) — added coverage
+# for the bare-id branch in ``_classify_task_id`` (no ``task:`` prefix is
+# accepted as a Task id for forward compatibility). PR #1097's reviewer
+# flagged the branch as untested.
 
 from __future__ import annotations
 
@@ -126,6 +130,32 @@ async def test_skips_non_task_ids() -> None:
         "nudge:not-a-task",
         "cycle:also-not-a-task",
     }
+
+
+async def test_classifies_bare_id_as_task() -> None:
+    """A bare id (no ``task:`` prefix) is accepted as a Task id for
+    forward compatibility — some callers pre-strip the prefix before
+    handing the selection back to the bulk endpoint."""
+    ctx = _ctx()
+    real = await tasks_service.agent_create_task(
+        ctx,
+        CreateTaskRequest(
+            title="bare",
+            assignee=AssigneeDTO(kind="human", id="u1", name="u1"),
+        ),
+    )
+
+    result = await mc_service.agent_bulk_reassign(
+        ctx,
+        BulkReassignRequest(ids=[real.id], to=_to()),
+    )
+    assert result["affected"] == [real.id]
+    assert result["skipped"] == []
+
+    # And the bare-id reassignment landed on the underlying row.
+    refreshed = await tasks_service.agent_get_task(ctx, real.id)
+    assert refreshed.assignee.kind == "agent"
+    assert refreshed.assignee.id == "agent-rover"
 
 
 async def test_tenant_isolation_routes_other_workspace_to_skipped() -> None:


### PR DESCRIPTION
## Summary

Picks up the two non-blocking nits from PR #1097's review.

- **Audit log on `agent_reassign_task_cycle`.** This was the only Tasks-service path that skipped the creator/assignee guard; it logged nothing, so closing a cycle could rewrite N tasks' cycle ids with no trail of who triggered it. The function now emits a structured `tasks.reassign_cycle` INFO line on every call (workspace, caller, task id, from→to cycle). The operation is expected — only its silence was the problem.
- **Test coverage for the bare-id branch in `_classify_task_id`.** The helper accepts a bare task id without a `task:` prefix for forward compatibility (callers that pre-strip the prefix). That branch was unexercised. Added an integration test that creates a real Task, passes the bare id through `agent_bulk_reassign`, and verifies the reassign actually lands on the underlying row.

No behavior change in the audit log addition — just a structured log line. No behavior change in the test addition either (it documents an existing branch).

## Verification

- `uv run pytest tests/cloud/test_mission_control_bulk_reassign.py tests/cloud/test_mission_control_bulk_snooze.py tests/cloud/test_cycles_service.py` → **26 passed, 1 skipped** (the skip is pre-existing and unrelated).
- The skipped `test_list_items_empty_when_tasks_unavailable` was already skipped before this PR.

## Test plan

- [ ] CI: full test sweep stays green
- [ ] Confirm `tasks.reassign_cycle` log lines appear in workspace logs after a real cycle close
- [ ] Confirm the bare-id branch test fails if `_classify_task_id`'s `return raw` is later removed