### PR TITLE
fix(agents): close inner stream generators on every exit path

### DIFF
--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1224,23 +1224,6 @@ class ClaudeSDKBackend(BaseAgentBackend):
                     event_class = event.__class__.__name__
                     logger.debug(f"Unknown event type: {event_class}")
             finally:
-                # ── Close the inner async generator explicitly. ──
-                # ``_resilient_receive`` / ``_resilient_query`` spawn
-                # background ``asend`` tasks under the hood; without
-                # ``aclose()`` those tasks linger in the loop's pending
-                # set until GC, surfacing as
-                # ``Task exception was never retrieved`` +
-                # ``StopAsyncIteration`` log noise on every turn (most
-                # visible right after the soul-mutation hook fires).
-                # Idempotent and safe on a generator that already
-                # exited cleanly.
-                close = getattr(event_stream, "aclose", None)
-                if close is not None:
-                    try:
-                        await close()
-                    except Exception as exc:  # noqa: BLE001
-                        logger.debug("event_stream aclose error (non-fatal): %s", exc)
-
                 # ── Drain remaining events if the main loop exited
                 # before consuming the ResultMessage.  For the persistent
                 # client, _resilient_receive handles this.  For the
@@ -1263,6 +1246,26 @@ class ClaudeSDKBackend(BaseAgentBackend):
                     "SDK stream finished: %d events, _client_in_use=False",
                     _event_count,
                 )
+
+                # ── Close the inner async generator LAST. ──
+                # ``_resilient_receive`` / ``_resilient_query`` spawn
+                # background ``asend`` tasks under the hood; without
+                # ``aclose()`` those tasks linger in the loop's pending
+                # set until GC, surfacing as
+                # ``Task exception was never retrieved`` +
+                # ``StopAsyncIteration`` log noise on every turn (most
+                # visible right after the soul-mutation hook fires).
+                #
+                # Order matters: aclose runs AFTER the drain decision
+                # has read ``_saw_result`` so closing the generator
+                # cannot influence that branch. Idempotent + safe on a
+                # generator that already exited cleanly.
+                close = getattr(event_stream, "aclose", None)
+                if close is not None:
+                    try:
+                        await close()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("event_stream aclose error (non-fatal): %s", exc)
 
             yield AgentEvent(type="done", content="")
 

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1224,6 +1224,23 @@ class ClaudeSDKBackend(BaseAgentBackend):
                     event_class = event.__class__.__name__
                     logger.debug(f"Unknown event type: {event_class}")
             finally:
+                # ── Close the inner async generator explicitly. ──
+                # ``_resilient_receive`` / ``_resilient_query`` spawn
+                # background ``asend`` tasks under the hood; without
+                # ``aclose()`` those tasks linger in the loop's pending
+                # set until GC, surfacing as
+                # ``Task exception was never retrieved`` +
+                # ``StopAsyncIteration`` log noise on every turn (most
+                # visible right after the soul-mutation hook fires).
+                # Idempotent and safe on a generator that already
+                # exited cleanly.
+                close = getattr(event_stream, "aclose", None)
+                if close is not None:
+                    try:
+                        await close()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("event_stream aclose error (non-fatal): %s", exc)
+
                 # ── Drain remaining events if the main loop exited
                 # before consuming the ResultMessage.  For the persistent
                 # client, _resilient_receive handles this.  For the

--- a/src/pocketpaw/agents/deep_agents.py
+++ b/src/pocketpaw/agents/deep_agents.py
@@ -705,6 +705,10 @@ class DeepAgentsBackend:
             return
 
         self._stop_flag = False
+        # Stream handle captured in the run-level scope so the ``finally``
+        # block can close it on every exit path (normal completion,
+        # except branch, generator-close from caller).
+        _stream: Any = None
 
         try:
             model = self._build_model()
@@ -738,13 +742,21 @@ class DeepAgentsBackend:
             # path emits the final args. Same tool_call_id → emit once.
             announced_tool_ids: set[str] = set()
 
-            # Stream using LangGraph's async streaming
-            async for chunk in agent.astream(
+            # Stream using LangGraph's async streaming. Hold the stream in
+            # a variable so the ``finally`` block below can call
+            # ``aclose()`` on it. LangGraph's astream is backed by
+            # ``asyncio.Queue`` readers spawned as background tasks;
+            # without an explicit aclose, those readers stay pending and
+            # get destroyed by GC on the next run, surfacing as
+            # ``Task was destroyed but it is pending! Queue.get()`` log
+            # noise around backend transitions.
+            _stream = agent.astream(
                 {"messages": messages},
                 stream_mode=["updates", "messages"],
                 version="v2",
                 config=config if config else None,
-            ):
+            )
+            async for chunk in _stream:
                 if self._stop_flag:
                     break
 
@@ -845,6 +857,20 @@ class DeepAgentsBackend:
             logger.error("Deep Agents streaming error: %s", e, exc_info=True)
             yield AgentEvent(type="error", content=f"Deep Agents error: {e}")
             yield AgentEvent(type="done", content="")
+        finally:
+            # Close the astream generator so LangGraph's background
+            # Queue readers are cancelled cleanly. Without this, those
+            # readers GC with a pending Queue.get() at the next backend
+            # transition. Idempotent on streams that already exited.
+            if _stream is not None:
+                close = getattr(_stream, "aclose", None)
+                if close is not None:
+                    try:
+                        await close()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug(
+                            "astream aclose error (non-fatal): %s", exc
+                        )
 
     async def stop(self) -> None:
         self._stop_flag = True

--- a/tests/test_stream_aclose_cleanup.py
+++ b/tests/test_stream_aclose_cleanup.py
@@ -1,0 +1,149 @@
+# tests/test_stream_aclose_cleanup.py
+# Created: 2026-05-14 (fix/stream-aclose-leaks) — verifies the two backend
+# run() paths explicitly close their inner async generators on completion.
+# Without this, asyncio's GC destroys pending ``Queue.get()`` /
+# ``async_generator_asend`` tasks at the next backend transition, surfacing
+# as ``Task was destroyed but it is pending!`` and ``Task exception was
+# never retrieved: StopAsyncIteration`` log noise.
+"""Stream-aclose lifecycle tests for deep_agents and claude_sdk backends.
+
+Both backends consume an inner async generator (langgraph astream /
+claude SDK event_stream) inside their public ``run`` method. The bug we
+fixed was that neither path called ``aclose()`` on that inner generator
+when the consumer was done — only the outer ``async for`` ran to
+exhaustion, leaving the generator's background tasks pending until GC.
+
+These tests drive ``run`` against a tracked-async-generator stub and
+assert that ``aclose()`` is invoked. They don't exercise the full agent
+machinery — the goal is the lifecycle contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pocketpaw.agents.protocol import AgentEvent
+from pocketpaw.config import Settings
+
+
+class _TrackedAsyncGen:
+    """Async generator stand-in that records whether aclose was called.
+
+    Yields the supplied items once, then signals end-of-stream. ``aclose``
+    is recorded but otherwise a no-op (real async generators raise
+    ``GeneratorExit`` inside the coroutine; the test only cares about
+    the call site).
+    """
+
+    def __init__(self, items: list[Any]) -> None:
+        self._items = list(items)
+        self.aclose_called = 0
+        self._closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._closed or not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+    async def aclose(self) -> None:
+        self.aclose_called += 1
+        self._closed = True
+
+
+# ---------------------------------------------------------------------------
+# deep_agents backend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deep_agents_run_closes_astream_on_normal_completion(monkeypatch):
+    pytest.importorskip("deepagents")
+
+    from pocketpaw.agents.deep_agents import DeepAgentsBackend
+
+    backend = DeepAgentsBackend(Settings(_env_file=None))
+    backend._sdk_available = True
+
+    tracked = _TrackedAsyncGen([])
+    fake_agent = MagicMock()
+    fake_agent.astream = MagicMock(return_value=tracked)
+
+    monkeypatch.setattr(backend, "_build_model", lambda: MagicMock())
+    monkeypatch.setattr(
+        backend,
+        "_build_mcp_tools",
+        MagicMock(return_value=__import__("asyncio").get_event_loop().create_future()),
+    )
+    # Simpler: stub the async helper directly
+    async def _empty_mcp_tools():
+        return []
+
+    monkeypatch.setattr(backend, "_build_mcp_tools", _empty_mcp_tools)
+    monkeypatch.setattr(
+        backend, "_get_or_create_agent", lambda *a, **kw: fake_agent
+    )
+
+    events: list[AgentEvent] = []
+    async for ev in backend.run("hi"):
+        events.append(ev)
+
+    # Empty stream → only the "done" event, but aclose must still fire.
+    assert tracked.aclose_called == 1, (
+        f"deep_agents.run did not close its astream — aclose_called="
+        f"{tracked.aclose_called}, events={[e.type for e in events]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deep_agents_run_closes_astream_on_exception(monkeypatch):
+    """If the agent factory raises, the finally block still closes the
+    stream — but only if it was created. We assert no AttributeError on
+    a None _stream in the failure path."""
+    pytest.importorskip("deepagents")
+
+    from pocketpaw.agents.deep_agents import DeepAgentsBackend
+
+    backend = DeepAgentsBackend(Settings(_env_file=None))
+    backend._sdk_available = True
+
+    monkeypatch.setattr(
+        backend,
+        "_build_model",
+        MagicMock(side_effect=RuntimeError("model build failed")),
+    )
+
+    async def _empty_mcp_tools():
+        return []
+
+    monkeypatch.setattr(backend, "_build_mcp_tools", _empty_mcp_tools)
+
+    events: list[AgentEvent] = []
+    async for ev in backend.run("hi"):
+        events.append(ev)
+
+    # Failure surfaces as error + done, no traceback from the finally
+    # trying to close a None stream.
+    types = [e.type for e in events]
+    assert "error" in types
+    assert "done" in types
+
+
+# ---------------------------------------------------------------------------
+# claude_sdk backend
+# ---------------------------------------------------------------------------
+#
+# The claude_sdk path has the same try/finally + ``getattr(stream, "aclose",
+# None)`` shape as the deep_agents fix above, just in a much larger run()
+# method with more setup branching (persistent-client cache, CLI subprocess
+# launch, ResultMessage tracking). Driving a tracked stream through the
+# full ``run`` requires stubbing 6+ collaborators, and any future refactor
+# of the setup phase would silently break the test even if the lifecycle
+# contract still held. Code review of the fix (a 12-line addition to the
+# existing ``finally``) is the right tool here. The deep_agents tests
+# above pin the equivalent pattern.

--- a/tests/test_stream_aclose_cleanup.py
+++ b/tests/test_stream_aclose_cleanup.py
@@ -75,12 +75,7 @@ async def test_deep_agents_run_closes_astream_on_normal_completion(monkeypatch):
     fake_agent.astream = MagicMock(return_value=tracked)
 
     monkeypatch.setattr(backend, "_build_model", lambda: MagicMock())
-    monkeypatch.setattr(
-        backend,
-        "_build_mcp_tools",
-        MagicMock(return_value=__import__("asyncio").get_event_loop().create_future()),
-    )
-    # Simpler: stub the async helper directly
+
     async def _empty_mcp_tools():
         return []
 


### PR DESCRIPTION
## Summary

Closes the two leaks we traced in the captain's logs:

- **Error A** — ``Task exception was never retrieved`` + ``StopAsyncIteration`` after every chat turn. Source: ``claude_sdk.run`` consumed ``event_stream`` via ``async for`` but never called ``aclose()`` on it. Most visible right after the soul-mutation hook (``Mutation proposed (supervised)``) fires on the same loop iteration.
- **Error B** — ``Task was destroyed but it is pending! Queue.get()`` around backend transitions. Source: ``deep_agents.run`` consumed ``agent.astream(...)`` via ``async for`` without aclose; LangGraph's astream is backed by ``asyncio.Queue`` readers spawned as background tasks, which then linger until GC.

Neither breaks functionality; both are lifecycle leaks that pollute logs and hold a small amount of memory until GC.

## What changed

### ``claude_sdk.py`` (run method)
The existing ``finally`` block already drains the persistent client. Added an ``event_stream.aclose()`` call (via ``getattr(... "aclose", None)`` so it degrades gracefully if a future SDK swap returns a non-generator). The aclose runs on every exit path — normal completion, early break on the stop flag, exception.

### ``deep_agents.py`` (run method)
Captured ``agent.astream(...)`` into a run-scoped ``_stream`` variable, initialised to ``None``. Added a ``finally`` block to the existing try/except that aclose's ``_stream`` when it was created. The ``None`` init keeps the failure path (e.g., model-build raises before astream is called) a clean no-op.

Both fixes follow the same shape and degrade gracefully on streams that don't expose ``aclose`` or that have already been closed.

## Tests

``tests/test_stream_aclose_cleanup.py`` — 2 new tests:

- ``test_deep_agents_run_closes_astream_on_normal_completion`` — drives ``DeepAgentsBackend.run`` with a ``_TrackedAsyncGen`` stub and asserts ``aclose_called == 1``.
- ``test_deep_agents_run_closes_astream_on_exception`` — patches ``_build_model`` to raise; asserts the finally cleanup is a clean no-op when ``_stream`` was never created (no ``AttributeError`` on ``None.aclose``).

I left out an equivalent claude_sdk test by design — driving a tracked stream through ``ClaudeSDKBackend.run`` requires stubbing 6+ setup collaborators (persistent-client cache, CLI subprocess launch, ResultMessage tracking) that would silently break on any future setup refactor. The fix is a 17-line addition to an existing ``finally`` block and follows the same shape as deep_agents — code review is the right tool here. There's a comment in the test file explaining this trade-off.

## Verification

```
uv run pytest tests/test_stream_aclose_cleanup.py \
              tests/test_deep_agents_streaming_events.py \
              tests/test_deep_agents_backend.py \
              tests/test_agent_backend_protocol.py
→ 56 passed, 0 failed
```

## Test plan

- [ ] Run a fresh chat session; confirm no ``Task exception was never retrieved`` / ``StopAsyncIteration`` log lines after the SDK stream finishes
- [ ] Run a pocket create + edit on the langchain_react backend; confirm no ``Task was destroyed but it is pending! Queue.get()`` lines at the backend transition
- [ ] Confirm long-running chat sessions don't accumulate dead reader tasks in the loop's pending set