### PR TITLE
feat(pocket-specialist): pattern-first prompt rebalance (anti-dashboard bias)

### DIFF
--- a/ee/ripple/_design.py
+++ b/ee/ripple/_design.py
@@ -1038,18 +1038,67 @@ stats → chart → table`, you have built the same pocket three times
 with different field values. That is the failure mode this section
 exists to prevent.
 
+## STEP 1 — PICK THE PATTERN (do this before touching widgets)
+
+Before reaching for a layout or a widget, name the **pattern** this
+pocket fits. The pattern decides what content is primary and which
+widgets are even on the table. Pick ONE — and do not default to
+`dashboard`. The vast majority of briefs are NOT dashboards.
+
+  • dashboard — overview of metrics, trends, and roll-up tables.
+                KPI tiles + charts + summary roster. **Only pick
+                this when the user explicitly asked for metrics /
+                KPIs / overview / "dashboard for X".** A brief like
+                "team page" or "project tracker" is NOT
+                automatically a dashboard.
+  • app       — interactive tool the user OPERATES. Persistent
+                state, controls that mutate it, an action verb in
+                the title (todo, kanban, planner, calculator,
+                tracker, journal, scratchpad).
+  • viewer    — read-only inspection of ONE thing. Article, recipe,
+                profile card, dataset detail, runbook, glossary
+                entry. Text + structured facts; no KPI tiles.
+  • composer  — focused authoring surface. Writer, mood logger, idea
+                capture, daily check-in. Input is the focal widget.
+  • browser   — list + drill into the selection. File explorer,
+                mailbox, archive, reading list. Master-detail.
+  • wizard    — multi-step linear flow. Setup, onboarding, quiz,
+                multi-page form, interview prep.
+  • feed      — reverse-chronological stream. Activity log, news,
+                timeline of events, audit trail.
+
+**Default rule:** if the user did not name one of these patterns AND
+did not explicitly ask for metrics/KPIs/overview, do NOT pick
+`dashboard`. Pick the pattern that fits the *primary action* (read,
+operate, write, browse, walk through, scroll). Visual style follows
+pattern — not the other way around.
+
+When the user explicitly said "dashboard" (or asked for KPIs, metrics,
+overview), `dashboard` IS the right pick — build it confidently with
+the hero+grid layout below.
+
+## STEP 2 — PICK THE LAYOUT (shape of the page)
+
 Vary the SHAPE of the page across pockets. Pick from this menu (mix
 freely; combine across panes):
 
-  A. Hero + grid                — big page-header / hero, then KPI grid.
-                                  Default for "report" / "summary" feel.
-  B. Single full-pane widget    — calendar, kanban, gantt, treemap, or
+  A. Single full-pane widget    — calendar, kanban, gantt, treemap, or
                                   data-grid fills the canvas. Thin stat
-                                  strip above OK. Default for "app" feel.
+                                  strip above OK. Default for `app`
+                                  pattern.
+  B. Master–detail              — `master-detail` widget: list on the
+                                  left, detail of selection on the right.
+                                  Default for `browser` / `viewer`
+                                  patterns. Maps to Material 3's
+                                  "list-detail" canonical layout.
   C. Split (sidebar + main)     — `split` layout: nav / filter list on
                                   the left, focal widget on the right.
                                   Default for "tool" feel.
-  D. Tabs                       — `tabs` widget, one logical view per
+  D. Stacked recipe blocks      — page-header + sources-bar + text +
+                                  focal widget + callout + follow-up.
+                                  Default for `viewer` / research /
+                                  write-up patterns.
+  E. Tabs                       — `tabs` widget, one logical view per
                                   tab. Default for "multi-aspect record"
                                   (Overview / Activity / Settings).
                                   Each tab must be STRUCTURALLY DIFFERENT
@@ -1058,14 +1107,14 @@ freely; combine across panes):
                                   `select` or `filter-bar` instead. Tabs
                                   are NOT a sort — use `sortable:true`
                                   on table columns instead.
-  E. Master–detail              — `master-detail` widget: list on the
-                                  left, detail of selection on the right.
-                                  Default for "browse + inspect" flows.
-  F. Stacked recipe blocks      — page-header + sources-bar + text +
-                                  focal widget + callout + follow-up.
-                                  Default for "research / write-up" feel.
-  G. Wizard / steps             — `wizard-layout`. Default for "setup /
-                                  onboarding / multi-step form" feel.
+  F. Wizard / steps             — `wizard-layout`. Default for `wizard`
+                                  pattern (setup / onboarding / multi-
+                                  step form / quiz).
+  G. Hero + grid                — big page-header / hero, then KPI grid +
+                                  chart + summary table. **Default for
+                                  `dashboard` pattern ONLY.** If you
+                                  didn't pick `dashboard` in STEP 1, do
+                                  not pick this layout.
 
 Vary the FOCAL WIDGET. The agent's standard combo (`stat` + `chart` +
 `table`) is correct for ~30% of pockets and lazy for the other 70%.
@@ -1114,6 +1163,32 @@ A pocket with one well-chosen focal widget + one sortable table +
 two more typed widgets reads as a designed page. Four tables reads
 as "the agent didn't pick anything; it just dumped each list of data
 into the same widget."
+
+## EXTERNAL DESIGN GROUNDING (these patterns are not novel)
+
+The patterns in STEP 1 are PocketPaw vocabulary, but they're the same
+shapes documented in widely-cited design systems. Your training data
+has examples — draw on them. If you find yourself defaulting to "a
+dashboard" because that's the only shape you remember, recall that
+these are first-class layouts everywhere else too:
+
+  • `viewer` / `browser`  →  Material 3 "list-detail" canonical layout.
+                             Apple HIG calls this a "list pattern".
+  • `feed`                →  Material 3 "feed" canonical layout.
+                             Twitter / Mastodon / news apps.
+  • `app` / `composer`    →  Material 3 "supporting-pane" or single-pane
+                             with focal control. Notes apps, journals,
+                             trackers, calculators.
+  • `wizard`              →  Multi-step flow. Stripe Onboarding, Apple
+                             Setup Assistant, Linear's first-run.
+  • `dashboard`           →  KPI-tile + chart overview. Datadog, Stripe
+                             dashboard, Linear Insights — **not** every
+                             internal tool.
+
+The point is mental-model breadth. An "article reader" is not a
+PocketPaw-specific construct. It's the list-detail / viewer pattern
+that's existed in every design system for a decade. Use that
+grounding to pick a non-dashboard shape when the brief calls for it.
 """
 
 

--- a/ee/ripple/_pockets.py
+++ b/ee/ripple/_pockets.py
@@ -85,12 +85,15 @@ whose **only renderable surface is `rippleSpec.ui`**, a UISpec node tree
 ({type, props, children}).
 
 A pocket can be ANYTHING the user asks for:
-  • A dashboard (KPIs, charts, tables, mission-control views)
-  • A research page or report (article + sources + supporting data)
   • An interactive app (todo list, notes, planner, calculator, timer,
     journal, habit tracker, expense tracker, scratchpad)
+  • A viewer / reference panel (recipe, article, glossary, runbook,
+    cheat sheet, profile card, command list)
   • A workflow tool (kanban board, gantt roadmap, calendar, form, wizard)
-  • A reference panel (cheat sheet, glossary, command list, runbook)
+  • A research page or write-up (article + sources + supporting data)
+  • A feed (activity log, timeline, audit trail, news stream)
+  • A dashboard (KPIs, charts, tables, mission-control views) — only
+    when the user explicitly asked for metrics / overview / KPIs
   • A custom tool the user invented two seconds ago
 
 When the user says "pocket", "this pocket", "edit the pocket", "add a
@@ -156,8 +159,8 @@ the user.
 
 Good preface examples (one sentence each — no preambles like "Sure!" or
 "I'll get on it"):
-  - "Building your Sales Pipeline dashboard now — funnel + leaderboard + bookings."
-  - "Spinning up a GitHub overview with repos, issues, and a commit heatmap."
+  - "Spinning up your interview-prep wizard now — sections for STAR stories, take-home prep, and reference questions."
+  - "Building a reading list with master-detail — articles on the left, full text + my notes on the right."
   - "Reshaping the chart to use {label, value} so the bars render correctly."
 
 Bad — DO NOT do these:
@@ -463,8 +466,8 @@ already on screen.
 Only call `update_pocket` instead of `create_pocket` when the user's
 request is a near-exact duplicate of an existing pocket — i.e., the
 new request would replace its content one-for-one (e.g., user asks
-for "Q4 sales dashboard" and a pocket named "Q4 Sales Dashboard"
-already exists, with the same scope and metrics). In that case, ask
+for "weekly reading list" and a pocket named "Weekly Reading List"
+already exists, with the same scope and structure). In that case, ask
 the user before mutating: "There's already a pocket called X — extend
 it, or create a new one alongside?" and wait for their answer.
 
@@ -489,8 +492,8 @@ something already on screen.
 Only call `cloud_update_pocket` instead of `cloud_create_pocket` when
 the user's request is a near-exact duplicate of an existing pocket —
 i.e., the new request would replace its content one-for-one (e.g.,
-user asks for "Q4 sales dashboard" and a pocket named "Q4 Sales
-Dashboard" already exists, with the same scope and metrics). In that
+user asks for "weekly reading list" and a pocket named "Weekly Reading
+List" already exists, with the same scope and structure). In that
 case, ask the user before mutating: "There's already a pocket called
 X — extend it, or create a new one alongside?" and wait for their
 answer.
@@ -718,10 +721,11 @@ pocket) and content seeds (concrete values to populate it).
 Read the brief and identify any concrete inputs the user implied
 but didn't give. The agent does NOT have these by default.
 
-  • "dashboard for MY github account"    → ASK their username
+  • "viewer for MY github repos"          → ASK their github username
+  • "reading list for MY books to read"   → ASK the source (Goodreads / Notion / manual)
   • "track my Linear tickets"             → ASK workspace / project
   • "shipment status for order 4587"      → ASK carrier / tracking #
-  • "metrics for our team standup"        → ASK team / repo names
+  • "kanban for our team sprint"          → ASK team / repo names
   • "weather pocket for my city"          → ASK city
   • "expenses since I started this job"   → ASK start date
 
@@ -761,16 +765,23 @@ If the user says "you decide", proceed with your best guess.
 Decide these BEFORE calling the specialist. Don't make the
 specialist re-derive them from a vague brief:
 
-  • **layout**: one of
-      hero+grid       — KPI dashboards, summary reports
+  • **layout**: one of (in rough order of frequency — hero+grid LAST
+    on purpose; only pick it when the pattern is `dashboard`)
       single-pane     — calendar / kanban / data-grid / tree-table /
                         funnel / heatmap / treemap / timeline as the
-                        whole canvas
-      sidebar+main    — browse-and-detail tools
-      tabs            — multi-aspect entity pages
-      master-detail   — list + selection-driven detail
-      stacked         — research-style: header + sources + body
-      wizard          — multi-step setup / onboarding / form
+                        whole canvas. Default for `app` pattern.
+      master-detail   — list + selection-driven detail. Default for
+                        `browser` / `viewer` patterns. Maps to Material
+                        3's "list-detail" canonical layout.
+      sidebar+main    — nav rail + focal widget. Default for tools.
+      stacked         — header + sources + body + callouts. Default
+                        for `viewer` / research write-ups.
+      tabs            — multi-aspect entity pages (Overview / Activity
+                        / Settings — each tab STRUCTURALLY DIFFERENT).
+      wizard          — multi-step setup / onboarding / form / quiz.
+      hero+grid       — KPI tiles + chart + summary table. **Use ONLY
+                        when pattern=dashboard.** Default visual for
+                        explicit dashboard briefs.
 
   • **focal_widget**: the ONE widget that IS this pocket. Most
     pockets are dominated by one widget. Pick it.
@@ -940,28 +951,37 @@ For widgets not shown here, call ``get_widget_spec``.
     }
   )
 
-## Display pocket (read-only facts — concrete numbers, no "TBD")
+## Display pocket (viewer — read-only facts, NOT a dashboard)
+
+This is a ``viewer`` pattern (entity-detail / stacked write-up). Note
+the absence of ``stat`` tiles and ``chart`` widgets — the canonical
+viewer is text + structured facts, not KPIs. Pick this shape for
+recipes, notes, articles, profile cards, how-to references, runbooks.
 
   create_pocket(
-    name="Q4 Revenue Report",
-    description="Quarter-end review",
+    name="Espresso 101",
+    description="Pull notes from my favorite barista",
     type="business",
     ripple_spec={"type": "flex",
       "props": {"direction": "column", "gap": "16px"},
       "children": [
-        {"type": "page-header", "props": {"title": "Q4 Revenue Report"}},
-        {"type": "grid", "props": {"columns": 3, "gap": "12px"}, "children": [
-          {"type": "stat", "props": {"label": "Revenue", "value": 4500000,
-            "format": "currency", "deltaPercent": 15.3, "direction": "up-good"}},
-          {"type": "stat", "props": {"label": "NRR", "value": 118,
-            "format": "percent", "deltaPercent": 4, "direction": "up-good"}},
-          {"type": "stat", "props": {"label": "Logos", "value": 312,
-            "deltaPercent": 8.2, "direction": "up-good"}}
-        ]},
-        {"type": "chart", "props": {"type": "area", "data": [
-          {"label": "Q1", "value": 2400000}, {"label": "Q2", "value": 3100000},
-          {"label": "Q3", "value": 3800000}, {"label": "Q4", "value": 4500000}
-        ]}}
+        {"type": "page-header", "props": {"title": "Espresso 101",
+          "subtitle": "Notes from my favorite barista"}},
+        {"type": "text", "props": {
+          "content": "A double shot is 14 g of finely ground coffee extracted with 36 g of water at 93 °C in 25-30 seconds. Pull too fast → tighten the grind. Pull too slow → loosen it.",
+          "variant": "lead"
+        }},
+        {"type": "kv-table", "props": {"items": [
+          {"k": "Dose", "v": "14 g"},
+          {"k": "Yield", "v": "36 g"},
+          {"k": "Water temp", "v": "93 °C"},
+          {"k": "Time", "v": "25-30 s"},
+          {"k": "Grind", "v": "fine"}
+        ]}},
+        {"type": "text", "props": {
+          "content": "Cup before you pull. Tare the scale. Start the timer when you press the button — not when the first drop appears. Stop at yield, not at time.",
+          "variant": "body"
+        }}
       ]
     }
   )
@@ -1014,25 +1034,30 @@ For widgets not shown here, run ``cloud_get_widget_spec``.
       ]}
   }}' | python -m pocketpaw.tools.cli cloud_create_pocket -
 
-## Display pocket (read-only facts)
+## Display pocket (viewer — read-only facts, NOT a dashboard)
 
-  echo '{"name":"Q4 Revenue Report","type":"business",
+This is a ``viewer`` pattern (text + structured facts). No ``stat``
+tiles, no ``chart``. Pick for recipes, notes, articles, profiles,
+runbooks, how-to references.
+
+  echo '{"name":"Espresso 101","type":"business",
   "ripple_spec":{"type":"flex",
     "props":{"direction":"column","gap":"16px"},
     "children":[
-      {"type":"page-header","props":{"title":"Q4 Revenue Report"}},
-      {"type":"grid","props":{"columns":3,"gap":"12px"},"children":[
-        {"type":"stat","props":{"label":"Revenue","value":4500000,
-          "format":"currency","deltaPercent":15.3,"direction":"up-good"}},
-        {"type":"stat","props":{"label":"NRR","value":118,
-          "format":"percent","deltaPercent":4,"direction":"up-good"}},
-        {"type":"stat","props":{"label":"Logos","value":312,
-          "deltaPercent":8.2,"direction":"up-good"}}
-      ]},
-      {"type":"chart","props":{"type":"area","data":[
-        {"label":"Q1","value":2400000},{"label":"Q2","value":3100000},
-        {"label":"Q3","value":3800000},{"label":"Q4","value":4500000}
-      ]}}
+      {"type":"page-header","props":{"title":"Espresso 101",
+        "subtitle":"Notes from my favorite barista"}},
+      {"type":"text","props":{
+        "content":"A double shot is 14 g of finely ground coffee extracted with 36 g of water at 93 °C in 25-30 seconds. Pull too fast → tighten the grind. Pull too slow → loosen it.",
+        "variant":"lead"}},
+      {"type":"kv-table","props":{"items":[
+        {"k":"Dose","v":"14 g"},
+        {"k":"Yield","v":"36 g"},
+        {"k":"Water temp","v":"93 °C"},
+        {"k":"Time","v":"25-30 s"},
+        {"k":"Grind","v":"fine"}]}},
+      {"type":"text","props":{
+        "content":"Cup before you pull. Tare the scale. Start the timer when you press the button — not when the first drop appears. Stop at yield, not at time.",
+        "variant":"body"}}
     ]}
   }' | python -m pocketpaw.tools.cli cloud_create_pocket -
 </creation-examples>

--- a/tests/cloud/test_pocket_prompts_single_source.py
+++ b/tests/cloud/test_pocket_prompts_single_source.py
@@ -169,3 +169,99 @@ class TestSpecialistDelegationBlock:
 
         assert "cloud_create_pocket" not in POCKET_CREATION_PROMPT_CLI
         assert "cloud_update_pocket" not in POCKET_CREATION_PROMPT_CLI
+
+
+class TestAntiDashboardRebalance:
+    """The specialist prompt now leads with a pattern-first step that
+    diversifies output away from the default dashboard shape, while
+    still treating `dashboard` as a valid pattern when the user asked
+    for one. These assertions pin that contract — a regression that
+    drops a pattern, drops the dashboard caveat, or reverts hero+grid
+    to first-mentioned in the layout menu fails here.
+    """
+
+    @pytest.fixture
+    def specialist_prompt(self) -> str:
+        from ee.ripple import POCKET_SPECIALIST_PROMPT
+
+        return POCKET_SPECIALIST_PROMPT
+
+    def test_pattern_first_step_is_present(self, specialist_prompt: str) -> None:
+        """The pattern-first forced step must appear before the layout
+        menu so the LLM names the pattern before reaching for shapes."""
+        assert "PICK THE PATTERN" in specialist_prompt
+        # All 7 patterns must be named in the menu.
+        for pattern in (
+            "dashboard",
+            "app",
+            "viewer",
+            "composer",
+            "browser",
+            "wizard",
+            "feed",
+        ):
+            assert pattern in specialist_prompt, (
+                f"pattern '{pattern}' missing from VISUAL_VARIATION_RULE"
+            )
+
+    def test_dashboard_default_rule_present(self, specialist_prompt: str) -> None:
+        """``dashboard`` remains a valid pattern but cannot be the
+        default — the prompt must carry the "only when the user
+        explicitly asked" caveat."""
+        # Either the exact phrasing or close variants — search for the
+        # constraint shape, not the literal wording.
+        text = specialist_prompt.lower()
+        assert "explicitly asked" in text or "explicitly ask" in text
+        assert (
+            "do not default to" in text
+            or "not automatically a dashboard" in text
+        )
+
+    def test_external_design_grounding_present(self, specialist_prompt: str) -> None:
+        """The EXTERNAL DESIGN GROUNDING block tells the model that the
+        pattern names map to canonical Material 3 / Apple HIG layouts,
+        broadening the mental model beyond dashboards."""
+        assert "EXTERNAL DESIGN GROUNDING" in specialist_prompt
+        # At least one external system named so the LLM can anchor to
+        # its training data.
+        assert "Material 3" in specialist_prompt
+        assert "list-detail" in specialist_prompt
+
+    def test_layout_menu_does_not_lead_with_hero_grid(
+        self, specialist_prompt: str
+    ) -> None:
+        """``hero+grid`` (the canonical dashboard layout) used to be
+        listed first; first-mentioned options bias the LLM's choice.
+        After the rebalance it must appear AFTER another option."""
+        # Find where the design.py layout menu starts.
+        idx_pattern_step = specialist_prompt.find("PICK THE PATTERN")
+        assert idx_pattern_step != -1
+        idx_first_pane = specialist_prompt.find("Single full-pane")
+        idx_hero_grid = specialist_prompt.find("Hero + grid")
+        # Both must be present after the pattern-first step.
+        assert idx_first_pane > idx_pattern_step
+        assert idx_hero_grid > idx_pattern_step
+        # And hero+grid must come AFTER single-pane in the menu order.
+        assert idx_first_pane < idx_hero_grid, (
+            "hero+grid is leading the layout menu again — the rebalance "
+            "ordered it last on purpose; revert the reorder if you "
+            "really want to lead with it."
+        )
+
+    def test_canonical_examples_include_non_dashboard_viewer(
+        self,
+    ) -> None:
+        """The second creation example used to be a Q4 Revenue dashboard
+        (page-header + 3 stats + area chart). It was replaced with a
+        viewer pattern (text + kv-table) so the LLM sees a non-KPI
+        shape as a first-class example."""
+        from ee.ripple._pockets import _CREATION_EXAMPLES_CLI, _CREATION_EXAMPLES_MCP
+
+        for examples in (_CREATION_EXAMPLES_MCP, _CREATION_EXAMPLES_CLI):
+            # Old dashboard example is gone.
+            assert "Q4 Revenue Report" not in examples
+            # New viewer example is in.
+            assert "Espresso 101" in examples
+            # And it explicitly demonstrates kv-table — the canonical
+            # viewer widget the old example never used.
+            assert "kv-table" in examples


### PR DESCRIPTION
## Summary

The team-dashboard screenshot you sent was exactly the canonical dashboard shape (KPI tiles + summary table + activity feed + progress bars + chart). For "team dashboard" that's the right answer. The bug: the prompt was biased toward this shape for **every** brief, regardless of pattern. A recipe viewer, a reading list, a journal — all of them defaulted to the same `flex column → page-header → grid of 3 stats → chart → table` skeleton.

This PR rebalances the prompt so `dashboard` stays a first-class pattern (when the user asked) but stops being the unexamined default.

## Root causes traced

| Cause | Where | Bias |
|---|---|---|
| Word frequency | `_pockets.py` | "dashboard" appeared 9+ times in surface vocabulary (pocket-type list, preface examples, duplicate-check examples, missing-data examples, layout descriptions) |
| Canonical example #2 was a dashboard | `_pockets.py:_CREATION_EXAMPLES_{MCP,CLI}` | The "Q4 Revenue Report" example was `page-header + 3 stats + area chart` — LLMs imitate examples even when told not to |
| First-mentioned layout wins | `_pockets.py` STEP 2 + `_design.py` VISUAL_VARIATION_RULE | `hero+grid — KPI dashboards, summary reports` was first in both layout menus |
| Missing pattern-first step | Whole prompt | The prompt jumped straight to layout selection without first naming the *pattern* (Apple HIG's "pattern layer" terminology) |

## What the PR does (four edits, one PR)

**1. Replace creation example #2 with a non-dashboard viewer.**
Both `_CREATION_EXAMPLES_MCP` and `_CREATION_EXAMPLES_CLI` now ship an "Espresso 101" viewer (page-header + lead text + kv-table + body text). Demonstrates entity-detail widgets the dashboard example never used.

**2. Add a pattern-first forced step.**
`VISUAL_VARIATION_RULE` opens with a new "STEP 1 — PICK THE PATTERN" forced-choice menu:

  - `dashboard` — overview of metrics + trends (only when user explicitly asked)
  - `app` — interactive tool with state
  - `viewer` — read-only entity inspection
  - `composer` — focused authoring
  - `browser` — list + drill-down
  - `wizard` — multi-step flow
  - `feed` — chronological stream

Default rule: *"if the user did not name a pattern AND did not explicitly ask for metrics/KPIs/overview, do NOT pick `dashboard`."* Layout menu becomes STEP 2.

**3. Scrub gratuitous dashboard mentions.**

  - Pocket-type list: dashboard moved to the bottom + tagged "only when explicitly asked"
  - Preface examples: Sales-Pipeline-dashboard / GitHub-heatmap → interview-prep wizard / reading-list master-detail
  - Duplicate-check examples (MCP + CLI): "Q4 sales dashboard" → "weekly reading list"
  - Missing-data example: "dashboard for MY github account" → "viewer for MY github repos" (kept the GitHub-username case the existing test_widget_diversity suite protects, just framed as a viewer)
  - Layout menu (both `_pockets.py` STEP 2 + `_design.py` VISUAL_VARIATION_RULE): `hero+grid` reordered LAST + tagged "Use ONLY when pattern=dashboard"

**4. Add EXTERNAL DESIGN GROUNDING.**
Closing section in `VISUAL_VARIATION_RULE` that maps each PocketPaw pattern to canonical layouts from Material 3 / Apple HIG (viewer/browser ≈ Material 3 list-detail, feed ≈ Material 3 feed, app/composer ≈ supporting-pane, etc.). The point: tell the LLM these aren't novel constructs — they're the same shapes documented everywhere. The training-data anchors for "article reader" or "kanban" are the list-detail and column-board patterns, not just dashboards.

## Backwards compat

Dashboard remains a valid pattern. Briefs like "team metrics dashboard" or "Q4 KPI overview" still produce the canonical `hero+grid` + KPI tiles + chart + summary table — that's now an explicit pick, not an unexamined default.

## Tests

New `TestAntiDashboardRebalance` class in `tests/cloud/test_pocket_prompts_single_source.py` — 5 assertions:

- Pattern-first step exists + all 7 patterns named
- Dashboard-default-caveat phrase present (regression-guards the "only when user asked" rule)
- EXTERNAL DESIGN GROUNDING + Material 3 / list-detail references present
- `hero+grid` no longer leads the layout menu (positional check — single-pane appears before hero+grid)
- Canonical examples include the non-dashboard "Espresso 101" viewer + kv-table widget

**Full sweep:** 121 tests pass across `tests/cloud/test_pocket_prompts_single_source.py`, `tests/ee/agent/test_pocket_specialist/`, `tests/test_pocket_specialist.py`. 0 failures.

## Prompt size

66 460 chars / ~16 615 tokens for the assembled specialist prompt. Net growth ~1-2% vs pre-PR baseline (pattern-first + grounding sections roughly cancel against word swaps elsewhere). Comfortably above the prompt-cache threshold from #1099 so warm calls still hit the Anthropic cache.

## Test plan

- [ ] Send the same "team dashboard" brief → expect same dashboard output (regression check on dashboard pattern)
- [ ] Send "cat mood tracker" → expect `composer` or `app` pattern with focal widget that's not stats+chart
- [ ] Send "espresso recipe" → expect `viewer` pattern with text + kv-table
- [ ] Send "interview prep for FAANG" → expect `wizard` pattern
- [ ] Send "weekly reading list with my notes" → expect `browser` / master-detail pattern