### PR TITLE
feat(pockets): Tier-2 array-item ops + slim edit-specialist prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ Thumbs.db
 htmlcov/
 .tox/
 .nox/
+.tmp/
 
 # Internal drafts
 idocs/

--- a/ee/agent/pocket_specialist/mcp_tool.py
+++ b/ee/agent/pocket_specialist/mcp_tool.py
@@ -253,12 +253,14 @@ def build_pocket_specialist_server() -> Any:
     @tool(
         "edit",
         (
-            "Edit an existing pocket from a natural-language intent. The "
-            "specialist reads the current pocket, picks the smallest set "
-            "of granular ops (set_state for data, set_node_prop for "
-            "widget appearance, add/move/remove_node for structure), and "
-            "applies them. Each op persists and pushes its own SSE event "
-            "so the canvas updates in place. Returns "
+            "Edit an existing pocket in ONE LLM round-trip. Call "
+            "get_pocket first, then pass the result here as `pocket` "
+            "(required). The specialist has no read tool — without "
+            "`pocket` the edit fails. It picks the smallest set of "
+            "granular ops (set_state for data, set_node_prop for "
+            "widget appearance, add/move/remove_node for structure) "
+            "and applies them. Each op persists and pushes its own "
+            "SSE event so the canvas updates in place. Returns "
             "{ok, pocket_id, ops, duration_ms}."
         ),
         {
@@ -282,27 +284,25 @@ def build_pocket_specialist_server() -> Any:
                 "pocket": {
                     "type": "object",
                     "description": (
-                        "OPTIONAL handoff. The current pocket view "
-                        "(rippleSpec + metadata) you already fetched. "
-                        "When passed, the specialist skips its own "
-                        "get_pocket call. Pass this when you read the "
-                        "pocket to disambiguate or confirm the edit."
+                        "REQUIRED. The current pocket view (rippleSpec "
+                        "+ metadata) you fetched with get_pocket. The "
+                        "specialist reads this directly and has no way "
+                        "to fetch it itself — pass it on EVERY edit "
+                        "call, no exceptions."
                     ),
                 },
                 "target_node_ids": {
                     "type": "array",
                     "items": {"type": "string"},
                     "description": (
-                        "OPTIONAL handoff. Node ids you identified as "
-                        "edit targets after reading the pocket. When "
-                        "set, the specialist works ONLY on these nodes "
-                        "and does not search. Best practice for any "
-                        "edit that needs disambiguation (the user said "
-                        "'the chart' and there are three)."
+                        "OPTIONAL but encouraged. Node ids you "
+                        "identified as edit targets after reading the "
+                        "pocket. When set, the specialist works ONLY "
+                        "on these nodes and does not search."
                     ),
                 },
             },
-            "required": ["pocket_id", "intent"],
+            "required": ["pocket_id", "intent", "pocket"],
             "additionalProperties": False,
         },
     )

--- a/ee/agent/pocket_specialist/runtime.py
+++ b/ee/agent/pocket_specialist/runtime.py
@@ -354,10 +354,9 @@ def _build_user_message(input: PocketSpecialistCreateInput) -> str:
 def _build_edit_user_message(input: PocketSpecialistEditInput) -> str:
     """Build the edit specialist's first user message.
 
-    When the parent already read the pocket and/or identified the
-    target nodes, surface that in the body of the message. The
-    specialist's system prompt has matching rules for skipping its
-    own ``get_pocket`` call and working only on the targeted nodes.
+    The parent agent is contractually required to send the current
+    ``pocket`` payload — the specialist has no read tool. The message
+    always inlines the pocket, plus optional target node ids.
     """
     import json as _json
 
@@ -370,27 +369,19 @@ def _build_edit_user_message(input: PocketSpecialistEditInput) -> str:
     if input.target_node_ids:
         lines.append("")
         lines.append(
-            "TARGET NODE IDS (from parent agent — these are already "
-            "the right nodes; do not search for others):"
+            "TARGET NODE IDS (from parent agent — authoritative, "
+            "work ONLY on these; do not search for others):"
         )
         for nid in input.target_node_ids:
             lines.append(f"  - {nid}")
     if input.pocket is not None:
-        # Compact JSON to keep token count tight. The specialist prompt
-        # tells it where to look.
         try:
             payload = _json.dumps(input.pocket, separators=(",", ":"))
         except Exception:
             payload = str(input.pocket)
         lines.append("")
-        lines.append(
-            "CURRENT POCKET (parent agent already read it — skip get_pocket, use this directly):"
-        )
+        lines.append("CURRENT POCKET (use directly — there is no get_pocket tool):")
         lines.append(payload)
-    elif not input.target_node_ids:
-        # No payload, no targets — tell the specialist to read first.
-        lines.append("")
-        lines.append("Read the pocket first with get_pocket, then apply ops.")
     return "\n".join(lines)
 
 
@@ -477,6 +468,29 @@ async def run_edit_specialist(
         input.intent[:80],
         backend_name,
     )
+
+    # Parent contract: pocket payload is required. The specialist has no
+    # read tool — without the payload it cannot proceed. Fail fast so
+    # the parent can re-issue with the prefetched pocket rather than
+    # burning an LLM call that is doomed to noop.
+    if input.pocket is None:
+        duration_ms = int((time.monotonic() - started) * 1000)
+        log.warning(
+            "[pocket-specialist:edit] missing pocket payload — refusing run (pocket_id=%s)",
+            input.pocket_id,
+        )
+        return PocketSpecialistEditOutput(
+            ok=False,
+            pocket_id=input.pocket_id,
+            ops=[],
+            duration_ms=duration_ms,
+            backend_used=backend_name,
+            error=(
+                "pocket payload missing — the edit specialist has no read "
+                "tool. Parent agent must call get_pocket once and pass the "
+                "result as `pocket` on every pocket_specialist__edit call."
+            ),
+        )
 
     # Push a chat-stream tool_start so the desktop client shows
     # "Editing pocket..." while the inner specialist works. Each granular

--- a/ee/agent/pocket_specialist/tools.py
+++ b/ee/agent/pocket_specialist/tools.py
@@ -633,22 +633,161 @@ def make_remove_node_tool(
     )
 
 
+class _SetPropArrayItemArgs(BaseModel):
+    node_id: str
+    prop: str
+    match: dict[str, Any] = Field(
+        ...,
+        description=(
+            "How to locate the item. One of: {index:0}, {id:'...'},"
+            " {by_field:'label', equals:'X'}, {by_key:{k:v,...}}."
+        ),
+    )
+    partial: dict[str, Any] = Field(
+        ...,
+        description="Fields to merge into the matched item (shallow merge).",
+    )
+
+
+def make_set_prop_array_item_tool(
+    *, pocket_id: str, capture: dict[str, Any] | None = None
+) -> StructuredTool:
+    """Edit ONE item inside a widget's prop-array — surgical alternative
+    to set_node_prop for chart.data / table.rows / etc."""
+
+    async def _run(
+        node_id: str,
+        prop: str,
+        match: dict[str, Any],
+        partial: dict[str, Any],
+    ) -> dict[str, Any]:
+        from ee.cloud.pockets.agent_context import set_prop_array_item_for_agent
+
+        result = await set_prop_array_item_for_agent(pocket_id, node_id, prop, match, partial)
+        _capture_op(
+            capture,
+            "set_prop_array_item",
+            {"node_id": node_id, "prop": prop, "match": match},
+        )
+        return result
+
+    return StructuredTool.from_function(
+        coroutine=_run,
+        name="set_prop_array_item",
+        description=(
+            "Surgically edit ONE item in a widget's prop-array (chart.data, "
+            "table.rows, calendar.events, kanban.columns, feed.items, "
+            "tabs.items, nav.items, select.options, form-layout.fields). "
+            "Cheaper and safer than set_node_prop when you only need to "
+            "change one row/slice — you never copy the unchanged items, "
+            "so they can't drift. `match` picks the item: "
+            "{index:N} | {id:'...'} | {by_field:'label', equals:'X'} | "
+            "{by_key:{k:v}}. `partial` is shallow-merged into that item."
+        ),
+        args_schema=_SetPropArrayItemArgs,
+    )
+
+
+class _AppendPropArrayItemArgs(BaseModel):
+    node_id: str
+    prop: str
+    value: Any
+    after: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional ItemMatch — insert after the matching item; omit to append.",
+    )
+
+
+def make_append_prop_array_item_tool(
+    *, pocket_id: str, capture: dict[str, Any] | None = None
+) -> StructuredTool:
+    async def _run(
+        node_id: str,
+        prop: str,
+        value: Any,
+        after: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        from ee.cloud.pockets.agent_context import append_prop_array_item_for_agent
+
+        result = await append_prop_array_item_for_agent(pocket_id, node_id, prop, value, after)
+        _capture_op(
+            capture,
+            "append_prop_array_item",
+            {"node_id": node_id, "prop": prop, "after": after},
+        )
+        return result
+
+    return StructuredTool.from_function(
+        coroutine=_run,
+        name="append_prop_array_item",
+        description=(
+            "Append (or insert-after) ONE item into a widget's prop-array. "
+            "Same allowed widgets as set_prop_array_item. If `after` is "
+            "given it must be an ItemMatch — the new item is inserted right "
+            "after the matched item; otherwise appended. Creates the array "
+            "if it does not yet exist on the node."
+        ),
+        args_schema=_AppendPropArrayItemArgs,
+    )
+
+
+class _RemovePropArrayItemArgs(BaseModel):
+    node_id: str
+    prop: str
+    match: dict[str, Any]
+
+
+def make_remove_prop_array_item_tool(
+    *, pocket_id: str, capture: dict[str, Any] | None = None
+) -> StructuredTool:
+    async def _run(
+        node_id: str,
+        prop: str,
+        match: dict[str, Any],
+    ) -> dict[str, Any]:
+        from ee.cloud.pockets.agent_context import remove_prop_array_item_for_agent
+
+        result = await remove_prop_array_item_for_agent(pocket_id, node_id, prop, match)
+        _capture_op(
+            capture,
+            "remove_prop_array_item",
+            {"node_id": node_id, "prop": prop, "match": match},
+        )
+        return result
+
+    return StructuredTool.from_function(
+        coroutine=_run,
+        name="remove_prop_array_item",
+        description=(
+            "Remove ONE matched item from a widget's prop-array. Same "
+            "allowed widgets and match grammar as set_prop_array_item. "
+            "Refuses ambiguous matches — disambiguate with by_key or index."
+        ),
+        args_schema=_RemovePropArrayItemArgs,
+    )
+
+
 def make_edit_pocket_tools(
     *, pocket_id: str, capture: dict[str, Any] | None = None
 ) -> list[StructuredTool]:
-    """Bundle the full edit-specialist tool set for one pocket.
+    """Bundle the edit-specialist tool set for one pocket.
 
-    Order is the order the LLM sees them; we lead with the read tool
-    so the agent is prompted toward "get then mutate" rather than
-    blind writes.
+    The parent agent fetches the pocket and passes it in the user
+    message. The specialist therefore has NO read tool — it cannot
+    re-fetch and never needs to: one-shot edit, no round-trips.
+    ``make_get_pocket_tool`` is still exported for any external caller
+    that needs a read-only view but is intentionally not part of this
+    bundle.
     """
     return [
-        make_get_pocket_tool(pocket_id=pocket_id),
         make_set_state_tool(pocket_id=pocket_id, capture=capture),
         make_append_state_tool(pocket_id=pocket_id, capture=capture),
         make_remove_state_tool(pocket_id=pocket_id, capture=capture),
         make_patch_state_tool(pocket_id=pocket_id, capture=capture),
         make_set_node_prop_tool(pocket_id=pocket_id, capture=capture),
+        make_set_prop_array_item_tool(pocket_id=pocket_id, capture=capture),
+        make_append_prop_array_item_tool(pocket_id=pocket_id, capture=capture),
+        make_remove_prop_array_item_tool(pocket_id=pocket_id, capture=capture),
         make_add_node_tool(pocket_id=pocket_id, capture=capture),
         make_replace_node_tool(pocket_id=pocket_id, capture=capture),
         make_move_node_tool(pocket_id=pocket_id, capture=capture),

--- a/ee/cloud/pockets/agent_context.py
+++ b/ee/cloud/pockets/agent_context.py
@@ -503,6 +503,109 @@ async def set_node_prop_for_agent(
     return {"ok": True, "subtree": subtree, "old_value": old_value}
 
 
+async def set_prop_array_item_for_agent(
+    pocket_id: str,
+    node_id: str,
+    prop: str,
+    match: dict[str, Any],
+    partial: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge ``partial`` into one matched item inside a node prop-array
+    (chart.data, table.rows, …) without forcing the agent to re-ship the
+    whole array. Locked to the ``prop_arrays`` allowlist at the service
+    layer."""
+    result, err = await pockets_service.agent_set_prop_array_item(
+        pocket_id, node_id=node_id, prop=prop, match=match, partial=partial
+    )
+    if err is not None or result is None:
+        return {"ok": False, "error": err or "set_prop_array_item failed"}
+    pocket_view = result.get("pocket") or {}
+    item_index = result.get("item_index")
+    item = result.get("item")
+    old_item = result.get("old_item")
+    await _push_node_op(
+        "node_prop_array_item_set",
+        pocket_view,
+        {
+            "node_id": node_id,
+            "prop": prop,
+            "item_index": item_index,
+            "item": item,
+        },
+    )
+    return {
+        "ok": True,
+        "item_index": item_index,
+        "item": item,
+        "old_item": old_item,
+    }
+
+
+async def append_prop_array_item_for_agent(
+    pocket_id: str,
+    node_id: str,
+    prop: str,
+    value: Any,
+    after: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Append ``value`` to a node prop-array, or insert immediately after
+    a matched item when ``after`` is given. Creates the array if missing.
+    Locked to the ``prop_arrays`` allowlist at the service layer."""
+    result, err = await pockets_service.agent_append_prop_array_item(
+        pocket_id, node_id=node_id, prop=prop, value=value, after=after
+    )
+    if err is not None or result is None:
+        return {"ok": False, "error": err or "append_prop_array_item failed"}
+    pocket_view = result.get("pocket") or {}
+    item_index = result.get("item_index")
+    item = result.get("item")
+    await _push_node_op(
+        "node_prop_array_item_appended",
+        pocket_view,
+        {
+            "node_id": node_id,
+            "prop": prop,
+            "item_index": item_index,
+            "item": item,
+        },
+    )
+    return {"ok": True, "item_index": item_index, "item": item}
+
+
+async def remove_prop_array_item_for_agent(
+    pocket_id: str,
+    node_id: str,
+    prop: str,
+    match: dict[str, Any],
+) -> dict[str, Any]:
+    """Remove the matched item from a node prop-array. Refuses ambiguous
+    matches (the agent must disambiguate). Locked to the ``prop_arrays``
+    allowlist at the service layer."""
+    result, err = await pockets_service.agent_remove_prop_array_item(
+        pocket_id, node_id=node_id, prop=prop, match=match
+    )
+    if err is not None or result is None:
+        return {"ok": False, "error": err or "remove_prop_array_item failed"}
+    pocket_view = result.get("pocket") or {}
+    removed_index = result.get("removed_index")
+    removed_item = result.get("removed_item")
+    await _push_node_op(
+        "node_prop_array_item_removed",
+        pocket_view,
+        {
+            "node_id": node_id,
+            "prop": prop,
+            "removed_index": removed_index,
+            "removed_item": removed_item,
+        },
+    )
+    return {
+        "ok": True,
+        "removed_index": removed_index,
+        "removed_item": removed_item,
+    }
+
+
 async def move_node_for_agent(
     pocket_id: str,
     node_id: str,
@@ -633,6 +736,7 @@ async def patch_state_for_agent(pocket_id: str, partial: dict[str, Any]) -> dict
 __all__ = [
     "add_node_for_agent",
     "add_widget_for_agent",
+    "append_prop_array_item_for_agent",
     "append_state_for_agent",
     "create_pocket_for_agent",
     "fetch_pocket_for_agent",
@@ -640,10 +744,12 @@ __all__ = [
     "move_node_for_agent",
     "patch_state_for_agent",
     "remove_node_for_agent",
+    "remove_prop_array_item_for_agent",
     "remove_state_for_agent",
     "remove_widget_for_agent",
     "replace_node_for_agent",
     "set_node_prop_for_agent",
+    "set_prop_array_item_for_agent",
     "set_state_for_agent",
     "update_pocket_for_agent",
     "update_widget_for_agent",

--- a/ee/cloud/pockets/prop_arrays.py
+++ b/ee/cloud/pockets/prop_arrays.py
@@ -1,0 +1,53 @@
+"""Closed allowlist of ``(widget_type, prop_name)`` pairs that support the
+Tier-2 array-element ops (``set_prop_array_item`` /
+``append_prop_array_item`` / ``remove_prop_array_item``).
+
+Why a closed list:
+
+  * The renderer's manifest already enumerates every prop a widget
+    accepts, but only a small subset of those are user-editable
+    arrays the agent should surgically poke at item-level. Many props
+    happen to be lists (e.g. ``chart.colors``) but aren't intended
+    for row-style edits.
+  * Locking the surface here means a typo (``cloud_set_prop_array_item
+    target=stat prop=value``) is rejected up-front with a clear error,
+    rather than silently mangling a scalar prop.
+
+Keep this in sync with:
+
+  * ``backend/docs/plans/2026-05-12-pocket-edit-api-design.md`` (Tier 2 table)
+  * ``ee/ripple/_pockets.py`` edit-specialist prompt examples
+
+Adding a new widget? Add the row here AND extend the edit-specialist
+prompt's cheatsheet so the agent knows the prop is targetable.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+_ALLOWED: Final[dict[str, frozenset[str]]] = {
+    "chart": frozenset({"data"}),
+    "table": frozenset({"rows", "columns"}),
+    "kanban": frozenset({"columns"}),
+    "calendar": frozenset({"events"}),
+    "feed": frozenset({"items"}),
+    "tabs": frozenset({"items"}),
+    "nav": frozenset({"items"}),
+    "select": frozenset({"options"}),
+    "form-layout": frozenset({"fields"}),
+}
+
+
+def is_allowed(widget_type: str, prop: str) -> bool:
+    """Return True iff ``prop`` is in the array-edit allowlist for ``widget_type``."""
+    return prop in _ALLOWED.get(widget_type, frozenset())
+
+
+def allowed_props_for(widget_type: str) -> tuple[str, ...]:
+    """Return the sorted tuple of allowed prop names for ``widget_type``,
+    or an empty tuple if unknown."""
+    return tuple(sorted(_ALLOWED.get(widget_type, frozenset())))
+
+
+__all__ = ["allowed_props_for", "is_allowed"]

--- a/ee/cloud/pockets/service.py
+++ b/ee/cloud/pockets/service.py
@@ -23,6 +23,7 @@ Agent-facing granular ``rippleSpec.ui`` mutations (called from the
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 import secrets
 from collections import OrderedDict
@@ -38,7 +39,7 @@ from ee.cloud._core.realtime.events import (
 )
 from ee.cloud.models.pocket import Pocket as _PocketDoc
 from ee.cloud.models.pocket import Widget as _WidgetDoc
-from ee.cloud.pockets import spec_ops, state_ops
+from ee.cloud.pockets import prop_arrays, spec_ops, state_ops
 from ee.cloud.pockets.domain import Pocket, Widget, WidgetPosition
 from ee.cloud.pockets.dto import (
     AddCollaboratorRequest,
@@ -1143,6 +1144,236 @@ async def agent_set_node_prop(
                 "subtree": node,
                 "old_value": old,
                 "prop": prop,
+                "pocket": _agent_view_dict(doc),
+            },
+            None,
+        )
+
+
+async def agent_set_prop_array_item(
+    pocket_id: str,
+    *,
+    node_id: str,
+    prop: str,
+    match: dict[str, Any],
+    partial: dict[str, Any],
+) -> tuple[dict | None, str | None]:
+    """Merge ``partial`` into the first item of ``node.props[prop]`` that
+    matches ``match``. Surgical alternative to ``set_node_prop`` when the
+    agent only wants to change one row/slice in a chart/table/etc.
+
+    Returns ``({"item_index": int, "item": <new item>, "old_item": <prev>,
+    "pocket": <view>}, None)``.
+
+    Error codes (returned as the error string):
+      * ``"unsupported_prop_array: <type>.<prop>"``
+      * ``"no node with id 'n_xxx'"``
+      * ``"prop {prop!r} is not an array on node {node_id!r}"``
+      * ``"not_found: no item matched"``
+      * ``"ambiguous: N items matched; candidates=[idx, ...]"``
+    """
+    if not node_id:
+        return None, "node_id is required"
+    if not prop:
+        return None, "prop is required"
+    if not isinstance(partial, dict):
+        return None, "partial must be a dict"
+
+    async with _pocket_lock(pocket_id):
+        doc, ui, err = await _load_and_ensure_ids(pocket_id)
+        if err or doc is None or ui is None:
+            return None, err
+        node = spec_ops.find_by_id(ui, node_id)
+        if node is None:
+            return None, f"no node with id {node_id!r}"
+
+        wtype = node.get("type")
+        if not isinstance(wtype, str) or not prop_arrays.is_allowed(wtype, prop):
+            return None, f"unsupported_prop_array: {wtype}.{prop}"
+
+        props = node.get("props")
+        if not isinstance(props, dict):
+            return None, f"node {node_id!r} has no props"
+        arr = props.get(prop)
+        if not isinstance(arr, list):
+            return None, f"prop {prop!r} is not an array on node {node_id!r}"
+
+        try:
+            candidates = spec_ops.match_array_item_candidates(arr, match)
+        except ValueError as exc:
+            return None, str(exc)
+        if len(candidates) == 0:
+            return None, "not_found: no item matched"
+        if len(candidates) > 1:
+            preview = candidates[:5]
+            return None, f"ambiguous: {len(candidates)} items matched; candidates={preview}"
+
+        idx = candidates[0]
+        old_item = copy.deepcopy(arr[idx]) if isinstance(arr[idx], dict) else arr[idx]
+        if isinstance(arr[idx], dict):
+            arr[idx] = {**arr[idx], **partial}
+        else:
+            arr[idx] = partial  # non-dict element: replace wholesale
+
+        if doc.rippleSpec is not None:
+            doc.rippleSpec = normalize_ripple_spec(doc.rippleSpec) or doc.rippleSpec
+        try:
+            await doc.save()
+        except Exception as exc:  # noqa: BLE001
+            return None, f"save failed: {exc}"
+        await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+        return (
+            {
+                "item_index": idx,
+                "item": arr[idx],
+                "old_item": old_item,
+                "pocket": _agent_view_dict(doc),
+            },
+            None,
+        )
+
+
+async def agent_append_prop_array_item(
+    pocket_id: str,
+    *,
+    node_id: str,
+    prop: str,
+    value: Any,
+    after: dict[str, Any] | None = None,
+) -> tuple[dict | None, str | None]:
+    """Append ``value`` to ``node.props[prop]``. If ``after`` is given,
+    insert immediately AFTER the first item matching that ItemMatch.
+
+    Returns ``({"item_index": int, "item": <inserted>, "pocket": <view>}, None)``.
+
+    Errors: see ``agent_set_prop_array_item``. ``after`` resolution uses
+    the same match grammar; ``not_found`` / ``ambiguous`` propagate.
+    """
+    if not node_id:
+        return None, "node_id is required"
+    if not prop:
+        return None, "prop is required"
+
+    async with _pocket_lock(pocket_id):
+        doc, ui, err = await _load_and_ensure_ids(pocket_id)
+        if err or doc is None or ui is None:
+            return None, err
+        node = spec_ops.find_by_id(ui, node_id)
+        if node is None:
+            return None, f"no node with id {node_id!r}"
+
+        wtype = node.get("type")
+        if not isinstance(wtype, str) or not prop_arrays.is_allowed(wtype, prop):
+            return None, f"unsupported_prop_array: {wtype}.{prop}"
+
+        props = node.setdefault("props", {})
+        if not isinstance(props, dict):
+            return None, f"node {node_id!r} has non-dict props"
+        arr = props.get(prop)
+        if arr is None:
+            arr = []
+            props[prop] = arr
+        if not isinstance(arr, list):
+            return None, f"prop {prop!r} is not an array on node {node_id!r}"
+
+        if after is None:
+            arr.append(value)
+            idx = len(arr) - 1
+        else:
+            try:
+                candidates = spec_ops.match_array_item_candidates(arr, after)
+            except ValueError as exc:
+                return None, str(exc)
+            if len(candidates) == 0:
+                return None, "not_found: after target did not match"
+            if len(candidates) > 1:
+                return (
+                    None,
+                    f"ambiguous: after matched {len(candidates)} items; "
+                    f"candidates={candidates[:5]}",
+                )
+            arr.insert(candidates[0] + 1, value)
+            idx = candidates[0] + 1
+
+        if doc.rippleSpec is not None:
+            doc.rippleSpec = normalize_ripple_spec(doc.rippleSpec) or doc.rippleSpec
+        try:
+            await doc.save()
+        except Exception as exc:  # noqa: BLE001
+            return None, f"save failed: {exc}"
+        await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+        return (
+            {
+                "item_index": idx,
+                "item": value,
+                "pocket": _agent_view_dict(doc),
+            },
+            None,
+        )
+
+
+async def agent_remove_prop_array_item(
+    pocket_id: str,
+    *,
+    node_id: str,
+    prop: str,
+    match: dict[str, Any],
+) -> tuple[dict | None, str | None]:
+    """Remove the first item in ``node.props[prop]`` matching ``match``.
+
+    Returns ``({"removed_index": int, "removed_item": Any, "pocket": <view>},
+    None)``.
+
+    Errors: see ``agent_set_prop_array_item``. Refuses ambiguous matches —
+    the agent must disambiguate.
+    """
+    if not node_id:
+        return None, "node_id is required"
+    if not prop:
+        return None, "prop is required"
+
+    async with _pocket_lock(pocket_id):
+        doc, ui, err = await _load_and_ensure_ids(pocket_id)
+        if err or doc is None or ui is None:
+            return None, err
+        node = spec_ops.find_by_id(ui, node_id)
+        if node is None:
+            return None, f"no node with id {node_id!r}"
+
+        wtype = node.get("type")
+        if not isinstance(wtype, str) or not prop_arrays.is_allowed(wtype, prop):
+            return None, f"unsupported_prop_array: {wtype}.{prop}"
+
+        props = node.get("props")
+        if not isinstance(props, dict):
+            return None, f"node {node_id!r} has no props"
+        arr = props.get(prop)
+        if not isinstance(arr, list):
+            return None, f"prop {prop!r} is not an array on node {node_id!r}"
+
+        try:
+            candidates = spec_ops.match_array_item_candidates(arr, match)
+        except ValueError as exc:
+            return None, str(exc)
+        if len(candidates) == 0:
+            return None, "not_found: no item matched"
+        if len(candidates) > 1:
+            return None, f"ambiguous: {len(candidates)} items matched; candidates={candidates[:5]}"
+
+        idx = candidates[0]
+        removed = arr.pop(idx)
+
+        if doc.rippleSpec is not None:
+            doc.rippleSpec = normalize_ripple_spec(doc.rippleSpec) or doc.rippleSpec
+        try:
+            await doc.save()
+        except Exception as exc:  # noqa: BLE001
+            return None, f"save failed: {exc}"
+        await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+        return (
+            {
+                "removed_index": idx,
+                "removed_item": removed,
                 "pocket": _agent_view_dict(doc),
             },
             None,

--- a/ee/cloud/pockets/service.py
+++ b/ee/cloud/pockets/service.py
@@ -1162,6 +1162,14 @@ async def agent_set_prop_array_item(
     matches ``match``. Surgical alternative to ``set_node_prop`` when the
     agent only wants to change one row/slice in a chart/table/etc.
 
+    Merge is SHALLOW: top-level keys in ``partial`` overwrite the matched
+    item's keys, but nested dicts/lists are replaced wholesale rather
+    than deep-merged. Matches ``patch_state`` semantics; if the agent
+    needs to preserve nested structure, fetch the item first and pass a
+    fully-built nested dict in ``partial``. Non-dict matched items are
+    replaced wholesale by ``partial`` (rare — most prop-array items are
+    dicts).
+
     Returns ``({"item_index": int, "item": <new item>, "old_item": <prev>,
     "pocket": <view>}, None)``.
 
@@ -1192,8 +1200,10 @@ async def agent_set_prop_array_item(
             return None, f"unsupported_prop_array: {wtype}.{prop}"
 
         props = node.get("props")
-        if not isinstance(props, dict):
+        if props is None:
             return None, f"node {node_id!r} has no props"
+        if not isinstance(props, dict):
+            return None, f"node {node_id!r} has non-dict props"
         arr = props.get(prop)
         if not isinstance(arr, list):
             return None, f"prop {prop!r} is not an array on node {node_id!r}"
@@ -1209,7 +1219,7 @@ async def agent_set_prop_array_item(
             return None, f"ambiguous: {len(candidates)} items matched; candidates={preview}"
 
         idx = candidates[0]
-        old_item = copy.deepcopy(arr[idx]) if isinstance(arr[idx], dict) else arr[idx]
+        old_item = copy.deepcopy(arr[idx])
         if isinstance(arr[idx], dict):
             arr[idx] = {**arr[idx], **partial}
         else:
@@ -1266,6 +1276,10 @@ async def agent_append_prop_array_item(
         if not isinstance(wtype, str) or not prop_arrays.is_allowed(wtype, prop):
             return None, f"unsupported_prop_array: {wtype}.{prop}"
 
+        # Append intentionally creates props and the array on demand —
+        # set/remove bail when either is missing because there is no
+        # item to address, but append's whole job is to add the first
+        # one. Asymmetry is by design.
         props = node.setdefault("props", {})
         if not isinstance(props, dict):
             return None, f"node {node_id!r} has non-dict props"
@@ -1345,8 +1359,10 @@ async def agent_remove_prop_array_item(
             return None, f"unsupported_prop_array: {wtype}.{prop}"
 
         props = node.get("props")
-        if not isinstance(props, dict):
+        if props is None:
             return None, f"node {node_id!r} has no props"
+        if not isinstance(props, dict):
+            return None, f"node {node_id!r} has non-dict props"
         arr = props.get(prop)
         if not isinstance(arr, list):
             return None, f"prop {prop!r} is not an array on node {node_id!r}"

--- a/ee/cloud/pockets/spec_ops.py
+++ b/ee/cloud/pockets/spec_ops.py
@@ -323,12 +323,83 @@ def move_node(
     return old_parent_id, src_idx
 
 
+# ---------------------------------------------------------------------------
+# Prop-array item matching
+#
+# Used by the Tier-2 array-element ops (set_prop_array_item etc.) to locate
+# a single item inside a node's prop-array (chart.data, table.rows, …)
+# without forcing the agent to copy-paste the entire array.
+# ---------------------------------------------------------------------------
+
+
+def _match_form(match: dict[str, Any]) -> str:
+    if not isinstance(match, dict) or not match:
+        raise ValueError("empty match")
+    if "index" in match:
+        return "index"
+    if "id" in match:
+        return "id"
+    if "by_key" in match:
+        return "by_key"
+    if "by_field" in match and "equals" in match:
+        return "by_field"
+    raise ValueError(f"unknown match form: {sorted(match.keys())}")
+
+
+def _item_matches(item: Any, form: str, match: dict[str, Any]) -> bool:
+    if not isinstance(item, dict):
+        return False
+    if form == "id":
+        return item.get("id") == match["id"]
+    if form == "by_key":
+        pairs = match["by_key"]
+        if not isinstance(pairs, dict) or not pairs:
+            raise ValueError("by_key must be a non-empty mapping")
+        return all(item.get(k) == v for k, v in pairs.items())
+    if form == "by_field":
+        return item.get(match["by_field"]) == match["equals"]
+    return False
+
+
+def match_array_item(arr: list[Any], match: dict[str, Any]) -> int | None:
+    """Return the index of the FIRST item in ``arr`` matching ``match``,
+    or ``None`` if no item matches. Raises ``ValueError`` on a malformed
+    or out-of-range ``index`` match form.
+
+    Match forms: see module docstring / design doc. Use
+    ``match_array_item_candidates`` to detect ambiguity (multiple matches).
+    """
+    form = _match_form(match)
+    if form == "index":
+        idx = match["index"]
+        if not isinstance(idx, int) or idx < 0 or idx >= len(arr):
+            raise ValueError(f"index {idx!r} out of range [0,{len(arr)})")
+        return idx
+    for i, item in enumerate(arr):
+        if _item_matches(item, form, match):
+            return i
+    return None
+
+
+def match_array_item_candidates(arr: list[Any], match: dict[str, Any]) -> list[int]:
+    """Return ALL indices in ``arr`` whose item matches ``match``. Used by
+    the service layer to render `ambiguous` errors with candidates."""
+    form = _match_form(match)
+    if form == "index":
+        # Positional match is never ambiguous.
+        idx = match_array_item(arr, match)
+        return [idx] if idx is not None else []
+    return [i for i, item in enumerate(arr) if _item_matches(item, form, match)]
+
+
 __all__ = [
     "ensure_ids",
     "find_by_id",
     "find_parent",
     "insert_child",
     "is_valid_id",
+    "match_array_item",
+    "match_array_item_candidates",
     "move_node",
     "new_node_id",
     "remove_node",

--- a/ee/ripple/_design.py
+++ b/ee/ripple/_design.py
@@ -285,15 +285,24 @@ rows with bullets and the user notices instantly.
 """
 
 
-CANONICAL_SHAPES = """\
-# CANONICAL SHAPES — inlined for the highest-traffic widgets only
+_CANONICAL_SHAPES_PREAMBLE = """\
+# CANONICAL SHAPES — inlined for the highest-traffic widgets
 
-The four shapes below are inlined because EVERY pocket touches them.
-For every other widget — stat, timeline, gantt, calendar,
-heatmap, pricing-table, comparison-table, kv-table, source-card,
-sources-bar, gauge, funnel, sankey, treemap, sparkline, etc. — call
-`get_widget_spec` per the WIDGET SPEC TOOL RULE above. Don't guess.
+The shapes below are inlined because they're the highest-traffic
+widgets and the prop schema is most often hallucinated. For widgets
+outside this list (stat, gantt, calendar, heatmap, pricing-table,
+comparison-table, kv-table, source-card, sources-bar, gauge, funnel,
+sankey, treemap, sparkline, etc.) call `get_widget_spec` — don't guess.
+"""
 
+
+# Per-widget canonical shapes. Keyed by widget `type` so both the
+# inline-Ripple `widget_help` tool and the pocket create specialist
+# can fetch JUST the widget they need, instead of loading the entire
+# blob. Keeping per-widget granularity is what makes lazy retrieval
+# actually lazy.
+WIDGET_SHAPES: dict[str, str] = {
+    "chart": """\
 `chart` — Ripple's chart has a SMALL fixed prop set. **Allowed props:**
 `type`, `data`, `title`, `height`, `colors`, `tooltip`. THAT IS THE
 WHOLE LIST. Anything else is invented and the renderer ignores it.
@@ -349,7 +358,8 @@ and want a chart, you have two options:
       the state — emit `chartData` alongside the source array), or
   (b) emit the chart-shaped array directly as `chartData` in state and
       keep the source array for the table.
-
+""",
+    "table": """\
 `table` — `columns` are OBJECTS with `accessorKey`; `rows` is an array
 of OBJECTS keyed by accessorKey. NEVER pass `columns: [str]` +
 `rows: [[]]` — the cells silently render empty.
@@ -388,7 +398,8 @@ table.
   Format at display time via the renderer's column formatter, not at
   emit time. If you must emit pre-formatted strings, do not enable
   sort on that column.
-
+""",
+    "data-grid": """\
 `data-grid` — HIGH DENSITY tabular: sticky headers, resizable columns,
 search, per-column sort, dense cells. Use when row count ≥ 50 or the
 user wants a "power user" feel (operational dashboards, log viewers,
@@ -429,7 +440,8 @@ ranked datasets, monitoring lists).
   - For 1000+ rows prefer `virtual-list` (call get_widget_spec).
   - Same numeric-sort gotcha as `table`: emit numbers, not formatted
     strings, on any column where sort is enabled.
-
+""",
+    "kanban": """\
 `kanban` — columns are headers ONLY; cards live in a flat list in
 `state`, reach the widget via `bind`, and `columnKey` says which card
 field maps to which column. Without `bind`, drag-to-move snaps back:
@@ -443,7 +455,8 @@ field maps to which column. Without `bind`, drag-to-move snaps back:
                    { "id": "done", "title": "Done" } ],
       "columnKey": "status"
   }}
-
+""",
+    "audit-log": """\
 `audit-log` — THE widget for "Recent Activity", event streams, audit
 trails, history logs. Each entry has actor + action + target. Far
 better than a `table` for this shape: dense per-row layout, icon per
@@ -465,7 +478,8 @@ timestamp}" rows is an audit-log emitted as the wrong widget.
   Use `groupBy: "day"` or `"week"` for chronological feeds; omit
   (`"none"`) for tight chronological streams. `showFilters: true`
   surfaces a filter-by-type chip row.
-
+""",
+    "timeline": """\
 `timeline` — milestones / dated events with optional rich detail.
 Vertical timeline rendering. Use for project history, release notes,
 contribution graphs, lifecycle events.
@@ -484,7 +498,8 @@ contribution graphs, lifecycle events.
   When in doubt between `audit-log` and `timeline`:
     audit-log → who did what (actor-driven)
     timeline  → what happened when (event-driven, often single actor)
-
+""",
+    "tabs": """\
 `tabs` — labels in `props.tabs`; CONTENT in the node's `children` array,
 one child per tab by index. Do NOT use `props.tabs[i].content` — ignored:
   { "type": "tabs",
@@ -528,308 +543,174 @@ one child per tab by index. Do NOT use `props.tabs[i].content` — ignored:
   one screen would feel CROWDED with structurally different things,
   tabs are correct. If it would feel REPETITIVE (same widget, same
   rows, just filtered differently), use a filter — not tabs.
-"""
+""",
+}
+
+
+# Backward-compat: the full canonical-shapes block remains exported as
+# the same prose blob it always was. Callers that want per-widget
+# granularity should reach for ``WIDGET_SHAPES`` directly.
+CANONICAL_SHAPES = _CANONICAL_SHAPES_PREAMBLE + "\n" + "\n".join(WIDGET_SHAPES.values())
 
 
 INTERACTIVE_STATE_RULE = """\
-# INTERACTIVE STATE RULE — universal principles for interactive UI
+# INTERACTIVE STATE RULE
 
-## Spec shape (read this first)
+## Spec shape
 
-Every spec has TWO top-level keys that matter for interactivity:
+Top-level keys: `state` (mutable data) + `ui` (renderable tree).
+The tree field is `ui` — not root/tree/view/body/content. Missing
+`ui` renders as "No widgets yet".
 
-  {
-    "state": { ... },   // top-level — the source of truth for mutable data
-    "ui":    { ... }    // top-level — the renderable node tree (REQUIRED)
-  }
+Each node: `{type, props, children?, style?, bind?, on_click?, ...}`.
+Nest with `children` in flex/grid/each.
 
-The renderable tree's field name is **`ui`** — not `root`, not `tree`,
-not `view`, not `body`, not `content`. Ripple reads `spec.ui` to mount
-the canvas; if `ui` is missing the pocket renders as "No widgets yet"
-even when the rest of the spec is valid.
+## Control flow widgets use NODE fields, not `bind`
 
-Inside `ui`, each node is `{type, props, children?, style?, bind?,
-on_click?, ...}`. Nest with `children` arrays in `flex`/`grid`/`each`.
+  each: { "type":"each", "items":"{state.todos}",
+          "item_as":"todo", "index_as":"i",
+          "children":[ <one node rendered per item> ] }
+  if:   { "type":"if", "condition":"{state.signed_in}",
+          "children":[...], "else_children":[...] }
 
-## Node-level fields vs `bind` — DON'T confuse them
-
+`each.bind` / `if.when` / `if.if` are all ignored.
 `bind` is for value-bound DATA widgets (input, checkbox, switch,
-kanban cards, slider, rating, date-picker, etc.) — the renderer
-routes the widget's `value` and `onchange` through it.
+kanban cards, slider, rating, date-picker, etc.).
 
-Control-flow widgets do NOT use `bind`. They have their own
-node-level fields:
+## Mutation triangle — any mutable data needs all three
 
-  `each` reads from `items`:
-    { "type": "each", "items": "{state.todos}",
-      "item_as": "todo", "index_as": "i",
-      "children": [ <one or more nodes rendered per item> ] }
+  (1) DATA in top-level `state`.
+  (2) READ via `bind` or a `{state.x}` expression.
+  (3) WRITE via an action chain on a button / on_change / drag handler.
 
-  `if` reads from `condition`:
-    { "type": "if", "condition": "{state.user.signed_in}",
-      "children": [...], "else_children": [...] }
+Drop any leg → broken UI (data in props with no state, state with no
+read, data+read with no write).
 
-If you write `{ "type": "each", "bind": "todos" }`, the loop renders
-zero iterations and the user sees an empty list. The field is
-`items`, and its value is a path expression (`"{state.todos}"` or the
-shorthand `"todos"`). Same rule for `if`: the gate is `condition`,
-not `bind` / `when` / `if`.
+## First-load test
 
-These are PRINCIPLES the agent applies to any widget, not a cookbook
-of per-widget recipes. If a widget is interactive, you compose the
-solution from the toolkit below — the principles tell you what
-"finished" looks like.
+The fresh canvas must let the user DO the thing implied by the pocket
+without going back to chat. Clear it by:
+  (a) seeding `state` with 3–5 starter items, AND
+  (b) providing in-canvas controls (add / remove / edit).
 
-## Principle 1 — The Mutation Triangle
+## Identity
 
-For any data the user is supposed to MUTATE (drag, click, type,
-toggle, edit, drop, sort, add, remove), three things must coexist:
+Items in state arrays need stable unique `id` fields. Use a counter
+(`state.next_id`) and bump it in the same on_click chain that pushes;
+never reuse user-typed strings.
 
-  (1) DATA in `state` — the source of truth, top-level on the spec.
-  (2) READ via `bind` (or via a `{state.x}` expression for widgets
-      that read non-`value` props like `data` / `items` / `events`).
-  (3) WRITE via an action chain — the user's path to mutate the data
-      (button, input on_change, drag handler, etc.).
+## Native inputs are already interactive
 
-Drop any leg of the triangle and the UI is broken:
-  - data inline in `props`, no `state` → mutations have nowhere to go.
-  - `state` exists but no `bind`/expression reading from it → stale UI.
-  - data + bind but no buttons / no editable inputs / no drag target →
-    user is stranded; can only mutate by going back to chat.
-
-## Principle 2 — Empty state never strands the user
-
-Before emitting an interactive pocket, run the FIRST-LOAD test:
-"If the user opens this fresh and stays in the canvas (never goes
-back to chat), can they DO the thing this pocket implies?"
-
-If the answer is "only by going back to chat" or "they have to wait
-for the agent to put data here," the spec is incomplete. Two ways to
-clear the test, used together:
-
-  (a) Seed `state` with 3–5 sample / starter items so the canvas is
-      alive on first paint. They give the user something to drag,
-      check, edit, or delete immediately.
-  (b) Provide IN-CANVAS controls to add / remove / edit. A bound
-      list / board / timeline paired with no controls and no items is the
-      worst possible first impression.
-
-This applies to every app pocket, regardless of widget — kanban,
-table-as-list, calendar of events, calculator history,
-form draft, anything user-mutable.
-
-## Principle 3 — Identity for collections
-
-Items in a state array MUST have stable unique `id` fields. Drag
-trackers, list reconciliation, and `remove` by value all rely on it.
-Use a counter (`state.next_id`) and bump it in the same on_click
-chain that pushes the new item — never reuse a user-typed string as
-the id (collisions break the widget).
-
-## Principle 4 — Read tools first, only build composites when needed
-
-Many widgets accept inputs natively (input/textarea/select/
-checkbox/switch/slider/rating/date-picker/file-upload — all the
-input-category widgets) and only need `bind` to be interactive. Only
-when the widget is purely read-only (kanban, table, timeline, calendar,
-chart) do you compose external CONTROLS around it. Don't add a
-composer next to a `form` widget — the form already IS one.
+Input-category widgets (input/textarea/select/checkbox/switch/slider/
+rating/date-picker/file-upload, plus `form`) only need `bind`. Only
+read-only widgets (kanban, table, timeline, calendar, chart) need
+external controls composed around them. Don't wrap a `form` widget
+in a custom composer — the form already IS one.
 
 ---
 
-## Toolkit — the action vocabulary
+## Action vocabulary
 
-The dispatcher recognizes these actions inside `on_click` /
-`on_change` / `on_submit`. Combine them; `on_click` accepts an array
-of actions run in order.
+  set       overwrite a state key
+            { "action":"set", "target":"draft", "value":"" }
+  push      append to an array (creates if missing)
+            { "action":"push", "target":"items", "value":{...} }
+  remove    drop array item by `index` or deep-equal `value`
+            { "action":"remove", "target":"items", "index":2 }
+            { "action":"remove", "target":"items", "value":"{item}" }
+  toggle    flip a boolean, or add/remove value in array
+            { "action":"toggle", "target":"done.{i}" }
+  branch    if/else: { "action":"branch", "if":"{state.x > 0}",
+                       "then":[...], "else":[...] }
+  validate  guard: { "action":"validate",
+                     "condition":"{state.draft.length > 0}",
+                     "message":"Type something first" }
+  flow      sequence with on_error rescue
+  confirm   prompt then on_confirm / on_cancel
+  api       backend call with on_success / on_error
+  navigate / toast / emit / pin / unpin — host-handled
 
-  set      — overwrite a state key
-             { "action": "set", "target": "draft", "value": "" }
+## Expression language
 
-  push     — append to an array (creates one if missing)
-             { "action": "push", "target": "items",
-               "value": { ... } }
+Resolved inside any string value:
 
-  remove   — drop an array item by `index` or by deep-equal `value`
-             { "action": "remove", "target": "items", "index": 2 }
-             { "action": "remove", "target": "items", "value": "{item}" }
+  {state.x}              read state
+  {state.x + 1}          arithmetic (+ - * / %)
+  {state.x.length}       property access
+  {a > 0 ? b : c}        ternary, comparisons (== === != !== > < >= <=)
+  {a && b} {a || b} {!f} {a ?? b}
+  {item} {card} {index}  loop context
+  {event}                payload from on_change / on_submit
 
-  toggle   — flip a boolean, or add/remove `value` in an array
-             { "action": "toggle", "target": "done.{i}" }
+Inline literals — arrays [1,'two'], objects {k:v}, strings, numbers,
+bool, null/undefined.
 
-  branch   — if/else: { "action":"branch", "if":"{state.x > 0}",
-                        "then":[...], "else":[...] }
+Whitelisted method calls (no callbacks):
 
-  validate — guard a flow: { "action":"validate",
-                             "condition":"{state.draft.length > 0}",
-                             "message":"Type something first" }
+  string  .toLowerCase() .toUpperCase() .trim()
+          .includes(s) .startsWith(s) .endsWith(s)
+  number  .toFixed(n)
+  array   .includes(v) .join(sep) .sum(field) .count()
+          .first() .last() .reverse() .limit(n)
+          .where(field, value)        equality filter; pass-through
+                                       on null/undefined/'All'
+          .whereIn(field, values)     pass-through on empty array
+          .sortBy(field, 'asc'|'desc') non-mutating, numeric-aware
 
-  flow     — sequence with on_error rescue
-  confirm  — prompt the user, then run on_confirm / on_cancel
-  api      — call backend; chain on_success / on_error
-  navigate / toast / emit / pin / unpin — host-handled events
+NEVER: arrow fns, .map/.filter/.find/.reduce/.flatMap, function /
+class / new / typeof / instanceof / await, for/while loops, template
+literals, spread, any method outside the whitelist. Anything outside
+returns `undefined`.
 
-## Toolkit — the expression language
+Bracket indexing: {state.repos[0].name}, {state.byLang['Astro']},
+{state.byLang[state.language]}.
 
-This is the EXACT grammar the renderer's expression resolver supports.
-Anything outside it returns `undefined` at runtime and triggers a
-write-time warning. There is no `eval`, no arbitrary JS — keep
-expressions simple and use state seed values for anything richer.
+For "no value" placeholder options, seed the placeholder list in
+state — don't inline it inside a ternary:
 
-Inside any string value the dispatcher resolves:
+  ✓  state: { team: [], team_options: [{value:"-",label:"None"}] }
+     options: "{state.team.length > 0 ? state.team : state.team_options}"
 
-  {state.x}              — read state
-  {state.x + 1}          — arithmetic (+ - * / %)
-  {state.x.length}       — property access
-  {state.x > 0 ? a : b}  — ternary, comparisons (== === != !== > < >= <=)
-  {a && b} / {a || b} / {!flag} / {a ?? b}
-  {item} / {card} / {index}    — loop context
-  {event}                — payload from on_change / on_submit
+## Deriving filtered / sorted views
 
-Inline literals (each item / value is itself an expression):
+Read derived views in the binding so external controls aren't dead:
 
-  Array literal   — [1, 2, 'three']  /  [{value: 'a', label: 'A'}]
-  Object literal  — {n: state.x, label: 'Hello'}
-  String literal  — 'foo' or "foo"
-  Number literal  — 42, -1.5
-  Boolean / null  — true, false, null, undefined
+  state: { language_filter: "All", sort_by: "stars", all_repos: [...] }
+  select bind: language_filter
+  segmented bind: sort_by
+  table rows: "{state.all_repos
+                .where('language', state.language_filter)
+                .sortBy(state.sort_by, 'desc')}"
 
-Whitelisted method calls on resolved values (no callbacks; args are
-literals or expressions only):
+`.where` treats 'All'/null/undefined as "no filter" — default select
+option needs no special branch.
 
-  string  — .toLowerCase() .toUpperCase() .trim()
-            .includes(s) .startsWith(s) .endsWith(s)
-  number  — .toFixed(n)
-  array   — .includes(v) .join(sep) .sum(field) .count()
-            .first() .last() .reverse() .limit(n)
-            .where(field, value)         — equality filter; pass-through
-                                           when value is null/undefined
-                                           or the literal 'All', so a
-                                           "no filter" select binds
-                                           directly with no ternary
-            .whereIn(field, values)      — pass-through on empty array
-            .sortBy(field, 'asc'|'desc') — non-mutating, numeric-aware
+## Every interactive element has a handler
 
-NEVER use these — they will silently break the widget:
+A labeled button / chip / nav item with no on_click (or no `actions`
+on entity-detail items) is dead UI. If there's nothing for it to do,
+omit it.
 
-  ✗ arrow functions       i => i.name
-  ✗ .map / .filter / .find / .reduce / .flatMap   (use .where / .sortBy /
-                                                   .limit instead, or
-                                                   precompute in `state`)
-  ✗ function / class / new / typeof / instanceof / await
-  ✗ for / while loops, template literals (backticks), spread (...x)
-  ✗ ANY method not in the whitelist above
+  ✓ { id:"view", label:"View", icon:"external-link",
+      actions:[{ action:"navigate", url:"https://github.com/{state.handle}" }] }
 
-When a control's "no value" option needs a placeholder list, put the
-placeholder in `state` and bind directly — don't put a literal array of
-placeholder objects inside a ternary expression on the prop.
+## Recipe — add an item to a list (generalize from this one)
 
-  ✗ wrong:
-    "options": "{state.team.length > 0 ? state.team
-                : [{value: 'placeholder', label: 'No teammates'}]}"
+  state: { draft:"", next_id:1, items:[] }
+  input  bind:"draft"
+  button on_click:[
+    { action:"validate",
+      condition:"{state.draft.length > 0}",
+      message:"Type something first" },
+    { action:"push", target:"items",
+      value:{ id:"i-{state.next_id}", title:"{state.draft}" } },
+    { action:"set", target:"next_id", value:"{state.next_id + 1}" },
+    { action:"set", target:"draft", value:"" }
+  ]
 
-  ✓ right:
-    "state": { "team": [], "team_options": [
-        {"value": "placeholder", "label": "No teammates"}
-      ] }
-    "options": "{state.team.length > 0 ? state.team : state.team_options}"
-
-Bracket indexing in paths (key may be literal or an expression):
-
-  {state.repos[0].name}
-  {state.byLang['Astro']}
-  {state.byLang[state.language]}
-
-### Deriving filtered / sorted views from state
-
-NEVER read a raw collection into a list/table when external controls
-exist to filter or sort it — the controls become dead UI. Compose
-`.where(...).sortBy(...).limit(...)` in the data binding so the view
-recomputes when bound state changes.
-
-  // state seed
-  "state": {
-    "language_filter": "All",
-    "sort_by": "stars",
-    "all_repos": [ ... ]
-  }
-
-  // controls
-  { "type": "select", "bind": "language_filter",
-    "props": { "options": [{"value":"All","label":"All"}, ...] } }
-  { "type": "segmented", "bind": "sort_by",
-    "props": { "options": [{"value":"stars","label":"Stars"}, ...] } }
-
-  // the table reads a derived view, not the raw array
-  { "type": "table",
-    "props": {
-      "columns": [...],
-      "rows": "{state.all_repos
-                 .where('language', state.language_filter)
-                 .sortBy(state.sort_by, 'desc')}"
-    } }
-
-  (Newlines shown above for readability — emit the expression on a single
-   line in the actual JSON.)
-
-`where` treats `'All'`/`null`/`undefined` as "no filter", so the
-default-selected option needs no special branch. Same composition
-works for `data` on charts, `items` on grids/feeds, etc.
-
-This is enough to build any add/remove/edit/toggle/filter/sort flow
-without inventing new actions.
-
-## Interactive elements must have handlers
-
-Every clickable / changeable widget in a pocket needs a wired handler.
-A button with `id` and `label` but no `on_click` (or, on `entity-detail`
-action items, no `actions` field) is dead UI — it renders, the user
-clicks, nothing happens.
-
-  // wrong — looks interactive, isn't
-  { "id": "view", "label": "View on GitHub", "icon": "external-link" }
-
-  // right — every action item declares what it does
-  { "id": "view", "label": "View on GitHub", "icon": "external-link",
-    "actions": [{ "action": "navigate",
-                  "url": "https://github.com/{state.handle}" }] }
-  { "id": "refresh", "label": "Refresh", "icon": "refresh-cw",
-    "actions": [{ "action": "emit", "target": "refresh.repos" }] }
-
-If you genuinely have nothing for a button to do, omit the button.
-Never ship a labeled control with no behavior behind it.
-
-## Generic recipe — adding an item to a list (any widget)
-
-This is the ONLY recipe the prompt needs to show. It generalizes:
-input bound to a draft + button whose on_click runs [push,
-bump-counter, clear-draft]. Swap the input for whatever the widget
-needs (textarea for long notes, select for category, multi-input
-form, etc.). Swap the bound list widget for whatever displays the
-items.
-
-  // state seed
-  "state": { "draft": "", "next_id": 1, "items": [] }
-
-  // controls
-  { "type": "input", "bind": "draft", "props": { "placeholder": "..." } }
-  { "type": "button", "props": { "label": "Add" },
-    "on_click": [
-      { "action": "validate",
-        "condition": "{state.draft.length > 0}",
-        "message": "Type something first" },
-      { "action": "push", "target": "items",
-        "value": { "id": "i-{state.next_id}", "title": "{state.draft}" } },
-      { "action": "set", "target": "next_id",
-        "value": "{state.next_id + 1}" },
-      { "action": "set", "target": "draft", "value": "" }
-    ]
-  }
-
-For removing: per-row button with
-  { "action": "remove", "target": "items", "value": "{item}" }
-inside a loop / cardTemplate, or
-  { "action": "remove", "target": "items", "index": "{index}" }
+Remove (per-row button inside an `each` / cardTemplate):
+  { action:"remove", target:"items", value:"{item}" }
+  // or by index: { action:"remove", target:"items", index:"{index}" }
 
 For toggling done state:
   { "action": "toggle", "target": "items.{index}.done" }
@@ -1117,10 +998,33 @@ into the same widget."
 """
 
 
+# Niche / situational blocks — pulled out of the eager
+# RIPPLE_DESIGN_RULES assembly. They're still callable via
+# get_inline_widget_help / get_widget_spec by passing one of these
+# keys, but they don't bloat the base prompt for the 95% of pockets
+# that don't need them. Keys are lowercased layout / picker / theme
+# identifiers the parent agent might pass via `hints.layout` or that
+# the inline-Ripple agent might ask about explicitly.
+OPTIONAL_DESIGN_SECTIONS: dict[str, str] = {
+    "tabular-picker": TABULAR_PICKER_RULE,
+    "activity-picker": ACTIVITY_PICKER_RULE,
+    "visual-variation": VISUAL_VARIATION_RULE,
+    "composition-cookbook": COMPOSITION_COOKBOOK,
+    "full-pane": FULL_PANE_RULE,
+    "logo": LOGO_RULE,
+    "design-quality": DESIGN_QUALITY,
+}
+
+
+# Eager design-rules superblock. Trimmed to the load-bearing rules
+# every pocket / chat reply touches. Niche rules live in
+# OPTIONAL_DESIGN_SECTIONS and are fetched on demand. The full-pane,
+# composition cookbook, picker, visual-variation, logo, and design-
+# quality blocks are intentionally NOT inlined here — they were paid
+# for by 100% of calls and used by maybe 10%.
 RIPPLE_DESIGN_RULES = "\n".join(
     [
         USE_THE_WIDGET_RULE,
-        # FULL_PANE_RULE,
         WIDGET_CATALOG,
         NO_INVENTED_WIDGETS_RULE,
         WIDGET_SPEC_TOOL_RULE,
@@ -1128,29 +1032,27 @@ RIPPLE_DESIGN_RULES = "\n".join(
         TABULAR_PICKER_RULE,
         ACTIVITY_PICKER_RULE,
         INTERACTIVE_STATE_RULE,
-        COMPOSITION_COOKBOOK,
-        VISUAL_VARIATION_RULE,
         THEME_RULE,
-        LOGO_RULE,
-        DESIGN_QUALITY,
     ]
 )
 
 
 __all__ = [
-    "WIDGET_CATALOG",
-    "USE_THE_WIDGET_RULE",
-    "FULL_PANE_RULE",
-    "NO_INVENTED_WIDGETS_RULE",
-    "WIDGET_SPEC_TOOL_RULE",
-    "COMPOSITION_COOKBOOK",
-    "CANONICAL_SHAPES",
-    "TABULAR_PICKER_RULE",
     "ACTIVITY_PICKER_RULE",
-    "VISUAL_VARIATION_RULE",
-    "INTERACTIVE_STATE_RULE",
-    "THEME_RULE",
-    "LOGO_RULE",
+    "CANONICAL_SHAPES",
+    "COMPOSITION_COOKBOOK",
     "DESIGN_QUALITY",
+    "FULL_PANE_RULE",
+    "INTERACTIVE_STATE_RULE",
+    "LOGO_RULE",
+    "NO_INVENTED_WIDGETS_RULE",
+    "OPTIONAL_DESIGN_SECTIONS",
     "RIPPLE_DESIGN_RULES",
+    "TABULAR_PICKER_RULE",
+    "THEME_RULE",
+    "USE_THE_WIDGET_RULE",
+    "VISUAL_VARIATION_RULE",
+    "WIDGET_CATALOG",
+    "WIDGET_SHAPES",
+    "WIDGET_SPEC_TOOL_RULE",
 ]

--- a/ee/ripple/_inline.py
+++ b/ee/ripple/_inline.py
@@ -15,6 +15,60 @@
 # catalog, canonical shapes, full-pane rule, theme, design-quality bar).
 
 
+_GROUND_TRUTH_RULE = """\
+<ground-truth>
+# IMPORTANT — DO NOT MOCK. DO NOT TRUST YOUR OWN KNOWLEDGE.
+
+You know NOTHING about the user's world, their data, their tools, the
+current state of any library/API/SDK, or what is "true" right now. Your
+training data is months to years out of date and quietly wrong on
+specifics — function signatures rename, APIs deprecate, package versions
+move, prices change, events happen. A confident-sounding answer from
+memory is the #1 failure mode here; it ships broken pockets, dead links,
+and wrong numbers that look real.
+
+Default posture: research first, then answer. Memory is a hypothesis,
+not a fact.
+
+## Never invent
+
+Do NOT fabricate any of the following, ever:
+- User-specific data (their username, repo, project, team, customers,
+  bookings, revenue, calendar events, file paths). If the brief implies
+  it but doesn't name it, ASK.
+- Real-world facts that drift over time (current prices, scores,
+  weather, exchange rates, version numbers, latest releases, news,
+  policy text, API endpoints, library APIs).
+- Placeholder names that look real ("Acme Corp", "Mona Octocat",
+  "john@example.com", "user1", "Q3 2024 revenue: $4.2M") — these read
+  as production data and the user will trust them.
+
+## Acceptable order of operations
+
+1. **Research** with the tools you have (web search, fetch, get_widget_spec,
+   read docs, list_pockets, etc.) BEFORE answering anything you can't
+   verify from the current turn.
+2. **Ask** the user when you can't research — one short, concrete
+   question is always better than a guess. "What's your GitHub username?"
+   beats inventing `octocat`.
+3. **Labelled placeholders** are allowed ONLY when (a) you have no way
+   to research, (b) the user hasn't given the value, AND (c) you cannot
+   reasonably ask (e.g. they explicitly said "just put something there",
+   "stub it", "fake data is fine"). Even then, label them obviously
+   (`<your username>`, `[example value]`) so the user knows what to
+   replace.
+
+If you catch yourself about to write a confident specific (a version
+number, a function name, a price, a fact about a product) and you
+haven't verified it this turn — stop, research or ask. "I'm not sure —
+do you want to check that, or should I look it up?" is a good answer.
+A wrong-sounding-confident answer is the worst answer.
+</ground-truth>
+
+
+"""
+
+
 _INLINE_PREAMBLE = """\
 <ripple>
 You can render rich UI inline in your chat responses by emitting a JSON
@@ -197,7 +251,9 @@ Final self-check before sending:
 </ripple>"""
 
 
-INLINE_RIPPLE_SYSTEM_PROMPT = _INLINE_PREAMBLE + _INLINE_CORE_CATALOG + "\n" + _INLINE_RULES
+INLINE_RIPPLE_SYSTEM_PROMPT = (
+    _GROUND_TRUTH_RULE + _INLINE_PREAMBLE + _INLINE_CORE_CATALOG + "\n" + _INLINE_RULES
+)
 
 
 __all__ = ["INLINE_RIPPLE_SYSTEM_PROMPT"]

--- a/ee/ripple/_inline_core.py
+++ b/ee/ripple/_inline_core.py
@@ -5,10 +5,23 @@
 # system prompt. Most replies use 1-3 widgets, so 90%+ of those tokens
 # were paid for nothing. This module owns the lookup payload that
 # powers the on-demand `get_inline_widget_help` MCP tool.
+#
+# Lookup is two-tier:
+#  1. Per-widget canonical shapes via WIDGET_SHAPES — preferred.
+#     Asking for ["chart"] returns just the chart shape (~2k chars),
+#     not the whole CANONICAL_SHAPES blob (~10k).
+#  2. Section search across the rest of RIPPLE_DESIGN_RULES — for
+#     niche rules (TABULAR_PICKER, ACTIVITY_PICKER, etc.) or widgets
+#     not in WIDGET_SHAPES, we still split-by-heading and fuzzy-match.
 
 from __future__ import annotations
 
-from ee.ripple._design import RIPPLE_DESIGN_RULES
+from ee.ripple._design import (
+    INTERACTIVE_STATE_RULE,
+    OPTIONAL_DESIGN_SECTIONS,
+    RIPPLE_DESIGN_RULES,
+    WIDGET_SHAPES,
+)
 
 
 def widget_help(types: list[str] | None = None) -> str:
@@ -18,10 +31,16 @@ def widget_help(types: list[str] | None = None) -> str:
     only requests this when it needs the catalog overview). With
     specific types, returns sections matching those widget kinds.
 
-    Section matching is naive substring search on the existing rules
-    text. It deliberately errs toward returning too much rather than
-    too little — the agent already paid the round-trip; better to
-    over-deliver than to leave it guessing.
+    Resolution order for each requested type:
+      1. WIDGET_SHAPES[type] — exact canonical shape, ~600–2400 chars.
+      2. OPTIONAL_DESIGN_SECTIONS[type] — niche layout sections that
+         aren't eagerly in RIPPLE_DESIGN_RULES (tabular-picker,
+         activity-picker, visual-variation, etc.).
+      3. Fall back to section search across RIPPLE_DESIGN_RULES.
+
+    Errs toward returning too much rather than too little — the agent
+    already paid the round-trip; better to over-deliver than leave it
+    guessing.
     """
     if not types:
         return RIPPLE_DESIGN_RULES
@@ -30,21 +49,33 @@ def widget_help(types: list[str] | None = None) -> str:
     if not wanted:
         return RIPPLE_DESIGN_RULES
 
-    # Split RIPPLE_DESIGN_RULES into top-level sections at "# " headings,
-    # return any section whose body mentions a wanted type. Always include
-    # the section carrying the toolkit / expression-language vocabulary —
-    # the agent rarely uses widgets without bindings.
-    sections = _split_sections(RIPPLE_DESIGN_RULES)
-    keep: list[str] = []
-    for sect in sections:
-        body = sect.lower()
-        # Always keep the section that carries the toolkit /
-        # expression-language vocabulary — agents need handler syntax
-        # and binding shape for any widget with on_click or {state.x}.
-        always_keep = "toolkit" in body or "expression language" in body
-        if always_keep or any(t in body for t in wanted):
-            keep.append(sect)
-    return "\n\n".join(keep) if keep else RIPPLE_DESIGN_RULES
+    parts: list[str] = []
+    unresolved: set[str] = set()
+    for t in wanted:
+        if t in WIDGET_SHAPES:
+            parts.append(WIDGET_SHAPES[t])
+        elif t in OPTIONAL_DESIGN_SECTIONS:
+            parts.append(OPTIONAL_DESIGN_SECTIONS[t])
+        else:
+            unresolved.add(t)
+
+    if unresolved:
+        # Section search across RIPPLE_DESIGN_RULES for any type we
+        # couldn't resolve directly.
+        sections = _split_sections(RIPPLE_DESIGN_RULES)
+        for sect in sections:
+            body = sect.lower()
+            if any(t in body for t in unresolved):
+                parts.append(sect)
+
+    # Always tack the interactive-state rule on the end. Bindings,
+    # {state.x} expressions, and action-chain vocabulary apply to every
+    # widget — the agent rarely uses a widget without them, so shipping
+    # the toolkit alongside any retrieval avoids a follow-up round-trip.
+    if parts:
+        parts.append(INTERACTIVE_STATE_RULE)
+        return "\n\n".join(parts)
+    return RIPPLE_DESIGN_RULES
 
 
 def _split_sections(text: str) -> list[str]:

--- a/ee/ripple/_pockets.py
+++ b/ee/ripple/_pockets.py
@@ -373,6 +373,32 @@ Unknown source names resolve to `null`. Stick to the allowlist above.
 """
 
 
+_CHAT_SEND_BLOCK = """\
+<chat-send-from-canvas>
+Buttons on the canvas can drop a pre-filled prompt into the pocket's
+chat sidebar — useful for "Ask the agent" affordances on a widget (a
+table row's "Summarize", a chart's "Explain this dip", a stat card's
+"Draft an email about this"). Pattern:
+
+  {"type": "button",
+   "props": {"label": "Summarize Q4 revenue"},
+   "on_click": {"action": "emit", "name": "chat.send",
+                "value": "Summarize the Q4 revenue chart and call out the biggest mover."}}
+
+The value can interpolate state: `"value": "Draft an email about
+{state.selected_deal.account}"`. The chat sidebar receives the text and
+submits it as if the user typed it — full SSE stream, full tool access.
+
+Use this sparingly: a chat-send button is a SLOW interaction (multiple
+seconds for the agent to respond). Reach for it only when the canvas
+naturally hands off to free-form reasoning — never for actions that
+can be solved by `set_state` or a deterministic widget click. Two
+chat-send buttons per pocket is plenty; ten is a sign the canvas
+should be doing more itself.
+</chat-send-from-canvas>
+"""
+
+
 # ---------------------------------------------------------------------------
 # Creation overview blocks. Substitute the right tool surface description.
 # ---------------------------------------------------------------------------
@@ -876,6 +902,7 @@ def _assemble_specialist() -> str:
         _SPECIALIST_WORKFLOW,
         _INTERACTIVE_DEFAULT_BLOCK,
         _STATE_SOURCES_BLOCK,
+        _CHAT_SEND_BLOCK,
         _RIPPLE_DESIGN_ESSENTIALS,
     ]
     return "\n".join(parts) + "\n"
@@ -934,15 +961,45 @@ OPS:
     remove_node(node_id)
 
 PICK THE SMALLEST:
-  bound to state           → set_state family
-  one item in a prop-array → *_prop_array_item (don't rewrite the
-                              whole array via set_node_prop)
-  one prop on a widget     → set_node_prop
-  shape change             → add/move/remove/replace_node
+  CHECK THE WIDGET FIRST. Read the target widget from CURRENT POCKET
+  and look at the array prop you want to edit (chart.data, table.rows,
+  feed.items, etc.):
+
+    props.<arr> is "{state.<path>}"  → BOUND. Edit STATE at <path>:
+                                       set_state("orders[3].status",
+                                       "Shipped")
+                                       append_state("orders",
+                                       {id, ...})
+                                       remove_state("orders[3]")
+    props.<arr> is a literal array   → UNBOUND. Edit the PROP-ARRAY ITEM:
+                                       set_prop_array_item(node_id,
+                                       "data",
+                                       {by_field: "label",
+                                       equals: "Other"},
+                                       {value: 5})
+
+  Then for the remaining cases:
+    one prop on a widget (non-array) → set_node_prop
+    shape change                     → add/move/remove/replace_node
+
+  Most pockets are state-first (data lives in top-level `state`,
+  widgets bind via `{state.<path>}`) so the majority of edits route
+  through the set_state family. The Tier-2 prop-array ops are ONLY
+  correct when the array lives DIRECTLY in props — display pockets,
+  static charts, hard-coded reference rows. Reaching for
+  *_prop_array_item on a bound widget writes the change in the wrong
+  place; the bound state stays stale and the canvas drifts.
 
 NOTES:
 - Values must be concrete. No "TBD", null. Estimates → "~".
 - Drop metric.trendDirection — Metric infers it from +/- on trend.
+- NEVER rewrite a whole prop-array via set_node_prop when you only
+  need to change one item — copy mistakes drift the untouched rows.
+  Use set/append/remove_prop_array_item instead.
+- "Ask the agent" / "Summarize" / "Explain this" buttons emit
+  `{action:'emit', name:'chat.send', value:'<prompt>'}` — preserve
+  these on edits and add new ones when the user asks for a "talk to
+  the agent" affordance.
 - Apply op(s), then stop. The parent agent replies to the user.
 </edit-specialist>
 """

--- a/ee/ripple/_pockets.py
+++ b/ee/ripple/_pockets.py
@@ -40,7 +40,36 @@
 
 from __future__ import annotations
 
-from ee.ripple._design import RIPPLE_DESIGN_RULES
+from ee.ripple._design import (
+    CANONICAL_SHAPES,
+    INTERACTIVE_STATE_RULE,
+    THEME_RULE,
+    USE_THE_WIDGET_RULE,
+    WIDGET_CATALOG,
+)
+
+# Slim subset of RIPPLE_DESIGN_RULES for the create specialist. The
+# full RIPPLE_DESIGN_RULES superblock is ~47k chars (~12k tokens) —
+# well past the 3k-token point where attention degrades. The blocks
+# below are the load-bearing ones: widget vocabulary so the model
+# names widgets correctly, canonical prop shapes so persist_pocket's
+# validator doesn't have to bounce every spec, and the interactive
+# state pattern so pockets aren't dead read-only canvases. Dropped:
+# COMPOSITION_COOKBOOK (parent decides composition via hints),
+# VISUAL_VARIATION_RULE (specialist gets one brief at a time),
+# TABULAR/ACTIVITY_PICKER_RULE (niche), DESIGN_QUALITY (aspirational),
+# NO_INVENTED_WIDGETS_RULE / WIDGET_SPEC_TOOL_RULE (overlap with
+# WIDGET_CATALOG + manifest validator). LOGO_RULE is small but
+# entirely cosmetic; left out to keep the prompt tight.
+_RIPPLE_DESIGN_ESSENTIALS = "\n".join(
+    [
+        USE_THE_WIDGET_RULE,
+        WIDGET_CATALOG,
+        CANONICAL_SHAPES,
+        INTERACTIVE_STATE_RULE,
+        THEME_RULE,
+    ]
+)
 
 POCKET_ID_TOKEN = "__POCKET_ID__"
 
@@ -341,355 +370,6 @@ the widget rather than fabricating rows.
 
 Unknown source names resolve to `null`. Stick to the allowlist above.
 </state-sources>
-"""
-
-
-# ---------------------------------------------------------------------------
-# Tool surface — MCP variant (claude_agent_sdk).
-# Identity (workspace, user, session) is bound from the active SSE
-# stream's ContextVars; the agent never passes workspace_id or owner_id.
-# ---------------------------------------------------------------------------
-
-
-_TOOLS_MCP = """\
-<pocket-tools>
-Pocket reads/writes happen through the in-process pocket MCP tools. You
-never pass workspace_id or owner_id — they are inferred from the active
-stream.
-
-  list_pockets()
-    → {"ok": true, "pockets": [{id, name, description, type, icon, color}, ...]}
-    Lists EVERY pocket in the user's workspace. CALL THIS BEFORE
-    `create_pocket` (see <list-before-create> below). Cheap — id +
-    metadata only, no rippleSpec.
-
-  get_pocket(pocket_id="...")
-    → {"ok": true, "pocket": {...full document including rippleSpec...}}
-    Always call this before any write that depends on existing content.
-
-  create_pocket(
-    name="<short title>",                           # required
-    description="<one-line summary>",
-    type="research|business|data|mission|deep-work|custom|hospitality",
-    icon="<icon name>",
-    color="#0A84FF",
-    ripple_spec={ ... UISpec tree — REQUIRED, this is the canvas ... },
-  )
-    → {"ok": true, "pocket": {...}, "pocket_id": "..."}
-    The new pocket auto-mounts on the user's sidebar. Do NOT follow up
-    with `get_pocket`.
-
-  update_pocket(
-    pocket_id="...",
-    ripple_spec={ ... full new UISpec tree ... },
-    name?, description?, icon?, color?,
-  )
-    Replace the canvas. `ripple_spec` accepts a bare UISpec node tree
-    ({type, props, children}) OR a {ui: <node>, ...} envelope; both
-    normalize on the server. Each write returns the new state inline —
-    don't re-run `get_pocket` to verify.
-
-  get_widget_spec(types=["metric", "kanban", ...])
-    → markdown reference with each widget's props schema and a runnable
-    example. Call this BEFORE composing a ui-spec — never guess prop
-    names or shapes.
-
-(The `add_widget` / `update_widget` / `remove_widget` MCP tools mutate
-the LEGACY embedded widget array which the desktop client does not
-render. Don't use them for visible changes.)
-</pocket-tools>
-"""
-
-
-_TOOLS_CLI = """\
-<pocket-cli>
-Pocket reads/writes happen through `python -m pocketpaw.tools.cli
-cloud_<command>`. Pipe JSON via stdin (the `-` arg) so the shell
-doesn't mangle `$`-prefixed values like `$74.30`:
-
-  echo '<json>' | python -m pocketpaw.tools.cli cloud_<command> -
-
-Always use SINGLE QUOTES around the JSON — bash eats `$` in double
-quotes and mangles prices like $74.30 → 4.30.
-
-  cloud_list_pockets
-    JSON: {} (empty)
-    → {"ok": true, "pockets": [{id, name, description, type, icon, color}, ...]}
-    Lists every pocket in the workspace. CALL THIS BEFORE
-    `cloud_create_pocket` (see <list-before-create> below).
-
-  cloud_get_pocket
-    JSON: {"pocket_id": "..."}
-    → {"ok": true, "pocket": {...full document including rippleSpec...}}
-
-  cloud_create_pocket
-    JSON: {
-      "name": "<short title>",                          // required
-      "description": "<one-line summary>",
-      "type": "research|business|data|mission|deep-work|custom|hospitality",
-      "icon": "<icon name>",
-      "color": "#0A84FF",
-      "ripple_spec": { ...UISpec tree — REQUIRED... }
-    }
-    → {"ok": true, "pocket": {...}, "pocket_id": "..."}
-
-  cloud_update_pocket
-    JSON: {"pocket_id": "...", "ripple_spec": { ...full new UISpec... },
-           "name"?, "description"?, "icon"?, "color"?}
-    Each write returns the new state inline. Don't re-run
-    `cloud_get_pocket` to "verify" — the write echoes the result.
-
-Windows: PowerShell here-strings keep JSON literal —
-  @'<json>'@ | python -m pocketpaw.tools.cli cloud_update_pocket -
-
-(The `cloud_add_widget` / `cloud_update_widget` / `cloud_remove_widget`
-commands mutate the LEGACY embedded widget array which the desktop
-client does not render. Don't use them for visible changes.)
-</pocket-cli>
-"""
-
-
-# ---------------------------------------------------------------------------
-# List-before-create gate — appears in EVERY creation prompt.
-# ---------------------------------------------------------------------------
-
-
-_LIST_BEFORE_CREATE_MCP = """\
-<list-before-create>
-The user clicked "new chat" with explicit creation intent. Default to
-`create_pocket` — they want a fresh canvas, not an edit to something
-already on screen.
-
-Only call `update_pocket` instead of `create_pocket` when the user's
-request is a near-exact duplicate of an existing pocket — i.e., the
-new request would replace its content one-for-one (e.g., user asks
-for "Q4 sales dashboard" and a pocket named "Q4 Sales Dashboard"
-already exists, with the same scope and metrics). In that case, ask
-the user before mutating: "There's already a pocket called X — extend
-it, or create a new one alongside?" and wait for their answer.
-
-A request that is merely "related" or "in the same area" as an
-existing pocket (e.g., the user has a "Kanban board" and now asks for
-a "Todo list") is NOT a duplicate. CREATE A NEW POCKET. Different
-intent = different pocket. Do not collapse them into one canvas.
-
-You may call `list_pockets` first if you want to verify a duplicate,
-but the default action when the user clicked "new chat" is
-`create_pocket`. When in doubt, create.
-</list-before-create>
-"""
-
-
-_LIST_BEFORE_CREATE_CLI = """\
-<list-before-create>
-The user clicked "new chat" with explicit creation intent. Default to
-`cloud_create_pocket` — they want a fresh canvas, not an edit to
-something already on screen.
-
-Only call `cloud_update_pocket` instead of `cloud_create_pocket` when
-the user's request is a near-exact duplicate of an existing pocket —
-i.e., the new request would replace its content one-for-one (e.g.,
-user asks for "Q4 sales dashboard" and a pocket named "Q4 Sales
-Dashboard" already exists, with the same scope and metrics). In that
-case, ask the user before mutating: "There's already a pocket called
-X — extend it, or create a new one alongside?" and wait for their
-answer.
-
-A request that is merely "related" or "in the same area" as an
-existing pocket (e.g., the user has a "Kanban board" and now asks for
-a "Todo list") is NOT a duplicate. CREATE A NEW POCKET. Different
-intent = different pocket. Do not collapse them into one canvas.
-
-You may run `cloud_list_pockets` first if you want to verify a
-duplicate, but the default action when the user clicked "new chat" is
-`cloud_create_pocket`. When in doubt, create.
-</list-before-create>
-"""
-
-
-# ---------------------------------------------------------------------------
-# Workflow blocks — interaction (read / write / chat).
-# ``__POCKET_ID__`` is replaced by the caller before injection.
-# ---------------------------------------------------------------------------
-
-
-_WORKFLOW_INTERACTION_MCP = """\
-<pocket-workflow>
-This conversation is happening INSIDE an existing pocket — see the
-`<current-pocket>` block at the end of this prompt for its id. You are
-NOT creating a new pocket; it already exists.
-
-<parent-handoff>
-The user message may include handoff blocks from the parent agent:
-
-  - `TARGET NODE IDS:` — the parent already identified WHICH nodes to
-    edit. Work ONLY on these. Do NOT search for other matches. The
-    parent's lookup is authoritative; trust it.
-
-  - `CURRENT POCKET:` — the parent already fetched the pocket.
-    SKIP your own `get_pocket` call. Use this payload directly.
-
-When BOTH are present: you have everything you need to act immediately.
-Pick the smallest op (set_state / set_node_prop / add_node / etc.) and
-apply it.
-
-When NEITHER is present: read the pocket first with `get_pocket`, then
-plan your ops.
-
-When only one is present: use it. e.g. TARGET NODE IDS without pocket
-is fine for simple state edits where you don't need surrounding
-structure — just call `set_node_prop` or `set_state` on the named
-target.
-</parent-handoff>
-
-
-Step 1 — classify the user's intent:
-
-- READ: "what's in this", "show me", "summarize", "explain", "where is X".
-  → call `get_pocket` once, answer from the returned `rippleSpec.ui`.
-- WRITE: "add", "remove", "change", "rename", "make it X", "more widgets",
-  "another chart", "make it interactive".
-  → see <mutation-strategy> below — pick the smallest tool that fits.
-- CHAT: message doesn't reference the pocket / widgets / layout.
-  → reply directly; do not call any pocket tool.
-
-<mutation-strategy>
-Three layers, pick the right tool for the edit:
-
-  LAYER 1 — DATA (what the user sees)
-    set_state(path, value)       update a single value in state
-    append_state(path, item)     push to an array (tasks, comments…)
-    remove_state(path)           delete a key or array element
-    patch_state(partial)         batched top-level merge
-
-  LAYER 2 — WIDGET APPEARANCE / BEHAVIOR
-    set_node_prop(node_id, prop, value)
-                                 change one prop on a widget
-                                 (label, show, on_click, color…)
-    replace_node(node_id, spec)  swap one subtree for another
-
-  LAYER 3 — STRUCTURE
-    add_node(parent_id, spec, after_id?)
-    move_node(node_id, new_parent_id, after_id?)
-    remove_node(node_id)
-
-ALWAYS reach for the LOWEST applicable layer:
-
-- "mark task 1 done"                    → set_state("tasks[0].status", "done")
-- "rename alice to alicia"              → set_state on the relevant tasks[i].label
-- "filter to overdue only"              → set_state("filter", "overdue")
-- "add a new task 'buy milk'"           → append_state("tasks", {label:"buy milk",…})
-- "change the button label to Save"     → set_node_prop(button_id, "label", "Save")
-- "hide the chart"                      → set_node_prop(chart_id, "show", "false")
-- "make the button red"                 → set_node_prop(button_id, "class", "bg-red-500")
-- "add a stat widget for revenue"       → add_node(parent_id, {type:"stat",…})
-- "move the chart below the table"      → move_node(chart_id, root_id, after_id=table_id)
-- "remove the old metric card"          → remove_node(metric_id)
-
-Why this matters: every widget bound to `{state.x}` re-renders
-automatically when state changes — set_state is the cheapest possible
-edit, no widget hunt needed. set_node_prop touches one widget
-property, no re-layout. Structural ops touch the tree shape only when
-the shape actually needs to change.
-
-Rule of thumb: if widgets bind to it, edit state. If it's the widget
-itself, edit the node. If it's a new widget, add a node.
-
-Reach for `update_pocket(ripple_spec=...)` only when:
-- You're rewriting the entire canvas (the user said "redesign this"
-  or asked for a structural shift touching >30% of the tree).
-- The initial creation of a brand-new sub-area replaces the whole UI.
-
-Never use `update_pocket` to change one row, one prop, one widget, or
-to nudge an existing node. The granular ops exist for exactly that.
-</mutation-strategy>
-
-Step 2 — when building a new subtree (for add_node / replace_node):
-
-- Preserve everything the user didn't ask to change. The granular ops
-  only mutate the node you target; do not re-emit unrelated panes.
-- **Keep interactivity intact.** If the existing pocket has controls
-  (input + button, select, toggle, composer row), DO NOT strip them on
-  edit — extend them. If the user asks to "make it interactive" or
-  "let me add items", apply the <interactive-by-default> pattern: add
-  top-level `state` if missing, wire a controls row, and bind the
-  focal widget to state.
-- Reference real values from the existing tree (metric numbers, chart
-  points, table rows). Do NOT invent content. No "N/A", "TBD", "...",
-  null. If estimating, prefix with "~" (e.g. "~$5B").
-- One quirk specific to the desktop client: drop `metric.trendDirection`
-  — Metric infers direction from the `+`/`-` prefix on `trend`.
-
-Step 3 — hard rules:
-
-- NEVER call `create_pocket` to fulfill an edit request. The pocket
-  already exists; creating another spawns a duplicate.
-- NEVER call `add_widget` / `update_widget` / `remove_widget`. Those
-  mutate the legacy embedded-widgets array the client doesn't render.
-  They are NOT the same as `add_node` / `replace_node` / `remove_node`
-  — the `*_node` tools operate on `rippleSpec.ui`, which IS what the
-  client renders. Always use `*_node`.
-- NEVER read source files, grep the repo, or run web_search to figure
-  out a pocket operation. The tools above are the whole interface.
-- NEVER write files to disk or generate HTML. The client renders
-  straight from rippleSpec.
-- If a mutation tool returns {"ok": false, "error": "..."}, surface
-  the error and stop. Do NOT shell-grep the codebase to debug.
-</pocket-workflow>
-"""
-
-
-_WORKFLOW_INTERACTION_CLI = """\
-<pocket-workflow>
-This conversation is happening INSIDE an existing pocket — see the
-`<current-pocket>` block at the end of this prompt for its id. You are
-NOT creating a new pocket; it already exists.
-
-Step 1 — classify the user's intent:
-
-- READ: "what's in this", "show me", "summarize", "explain", "where is X".
-  → call `cloud_get_pocket` once, answer from the returned
-  `rippleSpec.ui`.
-- WRITE: "add", "remove", "change", "rename", "make it X", "more widgets",
-  "another chart", "make it interactive".
-  → call `cloud_get_pocket` first, build the FULL updated tree locally,
-  then call `cloud_update_pocket` once with the new `ripple_spec`.
-- CHAT: message doesn't reference the pocket / widgets / layout.
-  → reply directly; do not call any cloud_* command.
-
-Step 2 — build the new rippleSpec:
-
-- Start from the existing `rippleSpec.ui` returned by `cloud_get_pocket`.
-  Preserve everything the user didn't ask to change.
-- Insert / replace / remove only the nodes the user asked about. Don't
-  rewrite untouched panes, headings, charts, or tables.
-- **Keep interactivity intact.** If the existing pocket has controls
-  (input + button, select, toggle, composer row), DO NOT strip them on
-  edit — extend them. If the user asks to "make it interactive" or
-  "let me add items", apply the <interactive-by-default> pattern: add
-  top-level `state` if missing, wire a controls row, and bind the
-  focal widget to state.
-- Reference real values from the existing tree (metric numbers, chart
-  points, table rows). Do NOT invent content. No "N/A", "TBD", "...",
-  null. If estimating, prefix with "~" (e.g. "~$5B").
-- One quirk specific to the desktop client: drop `metric.trendDirection`
-  — Metric infers direction from the `+`/`-` prefix on `trend`.
-
-Step 3 — hard rules:
-
-- NEVER call `cloud_create_pocket` to fulfill an edit request. The
-  pocket already exists; creating another spawns a duplicate.
-- NEVER call `cloud_add_widget` / `cloud_update_widget` /
-  `cloud_remove_widget`. They mutate the legacy embedded array the
-  client doesn't render.
-- NEVER use curl/fetch/HTTP to hit /api/v1/pockets. Use the CLI bridge.
-- NEVER read source files, grep the repo, or run web_search to figure
-  out a pocket operation. The two commands above are the whole interface.
-- NEVER write files to disk or generate HTML. The client renders
-  straight from rippleSpec.
-- If `cloud_update_pocket` returns {"ok": false, "error": "..."},
-  surface the error and stop. Do NOT shell-grep the codebase to debug.
-</pocket-workflow>
 """
 
 
@@ -1174,25 +854,29 @@ def _assemble_creation(*, mcp: bool) -> str:
 
 
 def _assemble_specialist() -> str:
-    """Specialist runtime prompt: scope/canvas + tools + workflow +
-    interactive-by-default + state-sources + examples + research +
-    design rules. The specialist owns the heavy creation lift.
+    """Slim create-specialist prompt.
 
-    The example blocks still show the legacy ``create_pocket`` envelope —
-    they document the rippleSpec shape, not the tool surface; the
-    specialist calls ``persist_pocket`` instead but the spec body is
-    identical.
+    Dropped from the previous heavy version:
+      * ``_SCOPE_BLOCK`` — the specialist has only ``persist_pocket`` in
+        its toolset; the shell / file / HTTP warnings were aimed at
+        general-purpose backends.
+      * ``_CANVAS_BLOCK`` — covered by ``_SPECIALIST_WORKFLOW``.
+      * ``_CREATION_EXAMPLES_MCP`` — ``CANONICAL_SHAPES`` already shows
+        every load-bearing widget envelope.
+      * ``_RESEARCH_PROTOCOL`` — research is the parent agent's job;
+        the specialist receives a brief that already has the data.
+      * Full ``RIPPLE_DESIGN_RULES`` (~47k chars) → trimmed to
+        ``_RIPPLE_DESIGN_ESSENTIALS`` (widget vocab + canonical shapes
+        + interactive state pattern + theme). The dropped sub-blocks
+        are either covered by the parent's structural plan or by the
+        runtime manifest validator.
     """
     parts = [
-        _SCOPE_BLOCK,
-        _CANVAS_BLOCK,
         _SPECIALIST_TOOLS,
         _SPECIALIST_WORKFLOW,
         _INTERACTIVE_DEFAULT_BLOCK,
         _STATE_SOURCES_BLOCK,
-        _CREATION_EXAMPLES_MCP,
-        _RESEARCH_PROTOCOL,
-        RIPPLE_DESIGN_RULES,
+        _RIPPLE_DESIGN_ESSENTIALS,
     ]
     return "\n".join(parts) + "\n"
 
@@ -1213,18 +897,72 @@ set_state, set_node_prop, add_node, etc.).
 """
 
 
+_EDIT_SPECIALIST_RULES = """\
+<edit-specialist>
+You are the pocket EDIT specialist. Apply ONE small op and stop.
+
+The user message contains:
+- INTENT — what to change.
+- CURRENT POCKET — the full payload. You have NO read tool.
+- TARGET NODE IDS (sometimes) — when set, AUTHORITATIVE.
+  work ONLY on these — never search the tree.
+
+You have ONLY the ops below. No shell, no files, no HTTP, no get_pocket.
+
+OPS:
+  DATA (cheapest; bound widgets re-render):
+    set_state(path, value)
+    append_state(path, item)
+    remove_state(path)
+    patch_state(partial)
+
+  PROP-ARRAY ITEMS — chart.data, table.rows, kanban.columns,
+  calendar.events, feed.items, tabs.items, nav.items,
+  select.options, form-layout.fields:
+    set_prop_array_item(node_id, prop, match, partial)
+    append_prop_array_item(node_id, prop, value, after?)
+    remove_prop_array_item(node_id, prop, match)
+    match: {index:N} | {id:"..."} | {by_field:"label", equals:"X"}
+
+  WIDGET PROP — label, color, show, on_click, class, …:
+    set_node_prop(node_id, prop, value)
+
+  STRUCTURE:
+    add_node(parent_id, spec, after_id?)
+    move_node(node_id, new_parent_id, after_id?)
+    replace_node(node_id, spec)
+    remove_node(node_id)
+
+PICK THE SMALLEST:
+  bound to state           → set_state family
+  one item in a prop-array → *_prop_array_item (don't rewrite the
+                              whole array via set_node_prop)
+  one prop on a widget     → set_node_prop
+  shape change             → add/move/remove/replace_node
+
+NOTES:
+- Values must be concrete. No "TBD", null. Estimates → "~".
+- Drop metric.trendDirection — Metric infers it from +/- on trend.
+- Apply op(s), then stop. The parent agent replies to the user.
+</edit-specialist>
+"""
+
+
 def _assemble_interaction(*, mcp: bool) -> str:
-    """Heavy interaction prompt — owned by the EDIT SPECIALIST. Contains
-    the full mutation-strategy / design-rules block the specialist needs
-    to perform granular edits. Not for the main chat agent."""
+    """Slim edit-specialist prompt — owned by the edit specialist.
+
+    Pre-condition: the parent agent has fetched the pocket and is
+    sending the full payload in the user message. The specialist has
+    no read tool, no design authority, and its toolset is restricted
+    to the granular ops only — so it does NOT need the parent's
+    pocket-scope shell-warning block (`_SCOPE_BLOCK`) or the
+    rippleSpec-canvas-rewriting block (`_CANVAS_BLOCK`). The
+    `mcp` flag is kept for caller symmetry but both variants produce
+    the same prompt today.
+    """
+    del mcp  # tools and rules are identical across backends
     parts = [
-        _SCOPE_BLOCK,
-        _CANVAS_BLOCK,
-        _TOOLS_MCP if mcp else _TOOLS_CLI,
-        _WORKFLOW_INTERACTION_MCP if mcp else _WORKFLOW_INTERACTION_CLI,
-        _INTERACTIVE_DEFAULT_BLOCK,
-        _STATE_SOURCES_BLOCK,
-        RIPPLE_DESIGN_RULES,
+        _EDIT_SPECIALIST_RULES,
         # MUST be last — see _CURRENT_POCKET_BLOCK_TEMPLATE rationale.
         _CURRENT_POCKET_BLOCK_TEMPLATE,
     ]
@@ -1233,104 +971,54 @@ def _assemble_interaction(*, mcp: bool) -> str:
 
 _INTERACTION_DELEGATION_BLOCK_MCP = """\
 <pocket-interaction>
-This conversation is happening INSIDE an existing pocket — see the
-`<current-pocket>` block at the end of this prompt for its id. The
-pocket is already loaded on the user's canvas.
+You are inside an existing pocket — see `<current-pocket>` for its id.
 
-Three valid response paths:
+Three response paths:
 
-  1. READ. The user asks "what's in this", "summarize", "explain", or
-     a general question they could answer from looking at the canvas.
-     → Call `get_pocket` ONCE with the pocket id, answer from the
-       returned rippleSpec.ui / rippleSpec.state.
+  1. READ ("what's in this", "summarize", "explain"):
+     → Call `get_pocket` ONCE and answer from the returned
+       rippleSpec.
 
-  2. EDIT. The user asks to "add", "remove", "change", "rename",
-     "filter", "mark as", "move", "redesign", or otherwise mutate the
-     pocket. See the EDIT DECISION TREE below — different intents
-     deserve different levels of preparation.
+  2. EDIT ("add", "change", "remove", "rename", "filter", "mark as",
+     "redesign", or anything that mutates state / widgets / layout):
+     → ONE-SHOT FLOW — never two trips, never silent fetches:
 
-  3. CHAT. The message doesn't reference the pocket / widgets / data.
-     → Reply directly. Do not call any pocket tool.
+         a. Call `get_pocket` ONCE to load the current pocket.
+         b. (Optional) From the returned rippleSpec.ui, collect the
+            ids of nodes the user named. State-only edits ("mark
+            task 1 done") can skip this — leave `target_node_ids`
+            empty.
+         c. Call `pocket_specialist__edit` ONCE with all four fields:
 
-## EDIT DECISION TREE
+              {
+                "pocket_id": "<id>",
+                "intent":    "<verbatim user request>",
+                "pocket":    <the payload you JUST got from get_pocket>,
+                "target_node_ids": ["..."]   // optional
+              }
 
-Edit work is a two-agent flow: you decide WHAT and WHERE, the
-specialist applies the change. Your preparation determines how
-deterministic the specialist's run is.
+       The `pocket` field is REQUIRED. The specialist has no
+       read tool; if you forget to pass `pocket` the edit fails.
+       Never call `get_pocket` a second time inside the same edit —
+       reuse the first fetch's payload.
 
-### Type A — Simple state edit, intent is self-contained
+  3. CHAT (no canvas reference): reply directly. No tools.
 
-The user names what they want done in a way that needs no lookup:
-  ✓ "mark task 1 as done"
-  ✓ "filter to overdue only"
-  ✓ "clear the draft"
+DISAMBIGUATION: if the user said "the chart" and rippleSpec.ui has
+several, ask ONE tight question and stop. Never more than one.
 
-These map cleanly to `set_state` / `append_state` / `remove_state`
-without needing to know the widget tree. DELEGATE with intent only:
+After delegating, give the user a one-line summary of what changed
+(drawn from `ops` in the specialist's return). The canvas already
+reflects the change — don't restate every op.
 
-    pocket_specialist__edit({
-        "pocket_id": "<id>",
-        "intent": "<verbatim user request>"
-    })
-
-### Type B — Structural / disambiguation edit
-
-The user references a widget that could be one of several, or asks
-for a structural change ("add a chart", "remove that card", "rename
-the table header"). The specialist would have to guess.
-
-→ Call `get_pocket` FIRST to see the structure. Then either:
-
-  (a) The target is unambiguous — pass it along by id:
-
-      pocket_specialist__edit({
-          "pocket_id": "<id>",
-          "intent": "<verbatim user request>",
-          "pocket": <pocket payload from get_pocket>,
-          "target_node_ids": ["n_chart00", ...]
-      })
-
-  (b) The target is ambiguous (multiple matches) — ASK the user in
-      ONE tight question:
-
-        "There are two charts on the page — the revenue one at the
-         top, or the channel breakdown below?"
-
-      Once the user clarifies, proceed with target_node_ids set.
-
-The `target_node_ids` field tells the specialist exactly which nodes
-to touch — it does not search. This is the deterministic path.
-
-### Type C — Open-ended redesign
-
-"Rebuild this as a kanban", "make this less cluttered", "switch the
-layout". The specialist will replan most of the spec.
-
-→ Pass `pocket` (so the specialist sees current state) but NOT
-   `target_node_ids` (the targets are everywhere). Specialist will
-   apply several ops in sequence.
-
-## CALLING THE SPECIALIST
-
-Required: `pocket_id`, `intent`. Optional: `pocket`, `target_node_ids`.
-All four are validated by the tool schema; backwards-compatible with
-intent-only calls.
-
-After delegating, give the user a one-line summary of what was
-changed (drawn from the specialist's `ops` array in the return).
-Do not re-list every op; the canvas already shows the result.
-
-## HARD RULES
-
+HARD RULES:
 - NEVER call `set_state`, `set_node_prop`, `add_node`, `move_node`,
-  `remove_node`, `update_pocket`, `add_widget`, `update_widget`,
-  `remove_widget`, `create_pocket`, or any other pocket mutation
-  tool. They are not on your allowlist in chat mode. Use
-  `pocket_specialist__edit` for every edit, no matter how small.
-- NEVER call `pocket_specialist__create` for edits. That tool spawns
-  a brand-new pocket; you are inside an existing one.
-- NEVER ask more than 1 disambiguation question. The user came here
-  to edit, not be interrogated.
+  `remove_node`, `replace_node`, `update_pocket`, `add_widget`,
+  `update_widget`, `remove_widget`, `create_pocket`, or any other
+  pocket mutation tool. They are not on your allowlist. Every edit
+  goes through `pocket_specialist__edit`.
+- NEVER call `pocket_specialist__create` for edits — that spawns a
+  brand-new pocket.
 - If `pocket_specialist__edit` returns an error, surface it to the
   user and stop. Do NOT improvise with shell, files, or HTTP.
 </pocket-interaction>
@@ -1339,26 +1027,35 @@ Do not re-list every op; the canvas already shows the result.
 
 _INTERACTION_DELEGATION_BLOCK_CLI = """\
 <pocket-interaction>
-This conversation is happening INSIDE an existing pocket — see the
-`<current-pocket>` block at the end of this prompt for its id.
+You are inside an existing pocket — see `<current-pocket>` for its id.
 
-Three valid response paths:
+Three response paths:
 
   1. READ ("what's in this", "summarize", "explain"):
-     → run `cloud_get_pocket` once, answer from its return.
+     → Run `cloud_get_pocket` once, answer from its return.
 
-  2. EDIT ("add", "change", "remove", "rename", "redesign", anything
+  2. EDIT ("add", "change", "remove", "rename", "redesign", or anything
      that mutates state / widgets / layout):
-     → DELEGATE: pipe a JSON brief into the specialist edit CLI:
+     → ONE-SHOT FLOW. First fetch the pocket, then ship the payload
+       to the specialist in a single call:
 
-       echo '{"pocket_id":"<id>","intent":"<user request>"}' \\
-         | python -m pocketpaw.tools.cli cloud_pocket_specialist_edit -
+         echo '{"pocket_id":"<id>"}' \\
+           | python -m pocketpaw.tools.cli cloud_get_pocket -
 
-     The specialist runs the full edit workflow (read, plan, granular
-     ops, persist). The canvas updates in place via SSE.
+       Then with the returned pocket JSON inlined:
 
-  3. CHAT (message doesn't reference the pocket):
-     → reply directly; do not call any cloud_* command.
+         echo '{"pocket_id":"<id>","intent":"<user request>",
+                "pocket":<the JSON you just fetched>,
+                "target_node_ids":["..."]}' \\
+           | python -m pocketpaw.tools.cli cloud_pocket_specialist_edit -
+
+       `pocket` is REQUIRED — the specialist has no read tool. Never
+       call `cloud_get_pocket` a second time inside the same edit.
+       `target_node_ids` is optional but encouraged when the user
+       named a specific widget.
+
+  3. CHAT (no canvas reference): reply directly; do not call any
+     cloud_* command.
 
 Never call cloud_pocket_specialist_create for edits — that spawns a
 new pocket. Never run granular ops directly; always delegate.

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -518,21 +518,6 @@ class ClaudeSDKBackend(BaseAgentBackend):
         except Exception as exc:  # noqa: BLE001
             logger.debug("pocket_context MCP server not registered: %s", exc)
 
-        # In-process MCP server: exposes Mission Control Tasks tools
-        # (``list_my_tasks``, ``claim_task``, ``complete_task``) so an
-        # agent running inside a workspace can pick up work routed to
-        # it without an out-of-band HTTP client. Same lifecycle as the
-        # pocket-context server above.
-        try:
-            from pocketpaw.agents.sdk_mcp_tasks import build_tasks_context_server
-
-            tasks_server = build_tasks_context_server()
-            if tasks_server is not None:
-                name, cfg_entry = tasks_server
-                servers[name] = cfg_entry
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("pocketpaw_tasks MCP server not registered: %s", exc)
-
         # In-process MCP server: exposes ``pocket_specialist__create`` so the
         # main agent can hand a brief to the specialist tool, which runs
         # the full list/validate/persist workflow as an isolated specialist
@@ -870,19 +855,6 @@ class ClaudeSDKBackend(BaseAgentBackend):
             from pocketpaw.agents.sdk_mcp_pocket import POCKET_TOOL_IDS
 
             allowed_tools.extend(POCKET_TOOL_IDS)
-
-            # Mission Control Tasks tools — agents need these to pull
-            # work from their queue and report completion. Surface is
-            # tiny (3 tools); allowlisting unconditionally keeps the
-            # claim flow available wherever the SDK backend runs.
-            try:
-                from pocketpaw.agents.sdk_mcp_tasks import TASK_TOOL_IDS
-
-                allowed_tools.extend(TASK_TOOL_IDS)
-            except Exception as exc:  # noqa: BLE001
-                logger.debug(
-                    "pocketpaw_tasks tool ids not added to allowlist: %s", exc
-                )
 
             # Pocket specialist — ``create`` / ``edit`` tools that run the
             # full listing → validate → persist workflow as an isolated

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -518,6 +518,21 @@ class ClaudeSDKBackend(BaseAgentBackend):
         except Exception as exc:  # noqa: BLE001
             logger.debug("pocket_context MCP server not registered: %s", exc)
 
+        # In-process MCP server: exposes Mission Control Tasks tools
+        # (``list_my_tasks``, ``claim_task``, ``complete_task``) so an
+        # agent running inside a workspace can pick up work routed to
+        # it without an out-of-band HTTP client. Same lifecycle as the
+        # pocket-context server above.
+        try:
+            from pocketpaw.agents.sdk_mcp_tasks import build_tasks_context_server
+
+            tasks_server = build_tasks_context_server()
+            if tasks_server is not None:
+                name, cfg_entry = tasks_server
+                servers[name] = cfg_entry
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("pocketpaw_tasks MCP server not registered: %s", exc)
+
         # In-process MCP server: exposes ``pocket_specialist__create`` so the
         # main agent can hand a brief to the specialist tool, which runs
         # the full list/validate/persist workflow as an isolated specialist
@@ -855,6 +870,17 @@ class ClaudeSDKBackend(BaseAgentBackend):
             from pocketpaw.agents.sdk_mcp_pocket import POCKET_TOOL_IDS
 
             allowed_tools.extend(POCKET_TOOL_IDS)
+
+            # Mission Control Tasks tools — agents need these to pull
+            # work from their queue and report completion. Surface is
+            # tiny (3 tools); allowlisting unconditionally keeps the
+            # claim flow available wherever the SDK backend runs.
+            try:
+                from pocketpaw.agents.sdk_mcp_tasks import TASK_TOOL_IDS
+
+                allowed_tools.extend(TASK_TOOL_IDS)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("pocketpaw_tasks tool ids not added to allowlist: %s", exc)
 
             # Pocket specialist — ``create`` / ``edit`` tools that run the
             # full listing → validate → persist workflow as an isolated

--- a/tests/cloud/test_agent_service_tools_context.py
+++ b/tests/cloud/test_agent_service_tools_context.py
@@ -324,8 +324,10 @@ def test_non_subagent_backend_pocket_id_inlines_interaction_prompt():
     block = build_context_block(ctx_edit, backend_name="codex_cli")
     # The pocket id was substituted into the interaction prompt.
     assert "pocket-abc" in block
-    # Heavy interaction guidance IS present.
-    assert "<pocket-workflow>" in block
+    # Interaction guidance IS present. (Block tag was renamed from the
+    # legacy <pocket-workflow> to <pocket-interaction> when the prompt
+    # was slimmed to a one-shot delegation flow.)
+    assert "<pocket-interaction>" in block
     # Delegation rule is NOT.
     assert "<pocket-delegation>" not in block
 

--- a/tests/cloud/test_pocket_granular_ops.py
+++ b/tests/cloud/test_pocket_granular_ops.py
@@ -564,3 +564,429 @@ async def test_no_active_stream_rejected(fake_doc):
     assert result["ok"] is False
     assert "no active workspace/user" in result["error"]
     assert push_calls == []
+
+
+# ---------------------------------------------------------------------------
+# set_prop_array_item — surgical edit of one item inside a node prop-array.
+# ---------------------------------------------------------------------------
+
+
+class TestSetPropArrayItem:
+    """Surgical edit of one item inside a node's prop-array."""
+
+    @pytest.mark.asyncio
+    async def test_updates_matched_item_by_field(self, fake_doc):
+        # Seed a chart with a 4-slice donut.
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {
+                "type": "donut",
+                "data": [
+                    {"label": "Online Store", "value": 62},
+                    {"label": "POS", "value": 18},
+                    {"label": "Social", "value": 12},
+                    {"label": "Other", "value": 8},
+                ],
+            },
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_set_prop_array_item(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Other"},
+                partial={"value": 5},
+            )
+
+        assert err is None
+        assert result["item_index"] == 3
+        assert result["item"] == {"label": "Other", "value": 5}
+        assert chart["props"]["data"][3]["value"] == 5
+        # Unchanged siblings preserved.
+        assert chart["props"]["data"][0]["value"] == 62
+        assert fake_doc.saves == 1
+
+    @pytest.mark.asyncio
+    async def test_unsupported_prop_array_rejected(self, fake_doc):
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_set_prop_array_item(
+                fake_doc.id,
+                node_id="n_header00",  # heading, not chart/table/etc.
+                prop="text",
+                match={"index": 0},
+                partial={"text": "Hi"},
+            )
+        assert result is None
+        assert err is not None
+        assert "unsupported_prop_array" in err
+
+    @pytest.mark.asyncio
+    async def test_missing_node_errors_cleanly(self, fake_doc):
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_set_prop_array_item(
+                fake_doc.id,
+                node_id="n_does_not_exist",
+                prop="data",
+                match={"index": 0},
+                partial={},
+            )
+        assert result is None
+        assert "no node with id" in err
+
+    @pytest.mark.asyncio
+    async def test_item_not_found_returns_error(self, fake_doc):
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {"data": [{"label": "A", "value": 1}]},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_set_prop_array_item(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Z"},
+                partial={"value": 99},
+            )
+        assert result is None
+        assert "not_found" in err
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_match_returns_candidates(self, fake_doc):
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {
+                "data": [
+                    {"label": "Other", "value": 1},
+                    {"label": "Other", "value": 2},
+                ]
+            },
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_set_prop_array_item(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Other"},
+                partial={"value": 99},
+            )
+        assert result is None
+        assert "ambiguous" in err
+
+
+# ---------------------------------------------------------------------------
+# append_prop_array_item — append (or insert-after-match) into a prop-array.
+# ---------------------------------------------------------------------------
+
+
+class TestAppendPropArrayItem:
+    @pytest.mark.asyncio
+    async def test_appends_to_end_by_default(self, fake_doc):
+        table = {
+            "id": "n_table111",
+            "type": "table",
+            "props": {"rows": [{"orderId": "#1"}, {"orderId": "#2"}]},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(table)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_append_prop_array_item(
+                fake_doc.id,
+                node_id="n_table111",
+                prop="rows",
+                value={"orderId": "#3"},
+            )
+        assert err is None
+        assert result["item_index"] == 2
+        assert table["props"]["rows"][-1] == {"orderId": "#3"}
+
+    @pytest.mark.asyncio
+    async def test_inserts_after_matched_item(self, fake_doc):
+        table = {
+            "id": "n_table111",
+            "type": "table",
+            "props": {"rows": [{"orderId": "#1"}, {"orderId": "#3"}]},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(table)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_append_prop_array_item(
+                fake_doc.id,
+                node_id="n_table111",
+                prop="rows",
+                value={"orderId": "#2"},
+                after={"by_field": "orderId", "equals": "#1"},
+            )
+        assert err is None
+        assert result["item_index"] == 1
+        assert [r["orderId"] for r in table["props"]["rows"]] == ["#1", "#2", "#3"]
+
+    @pytest.mark.asyncio
+    async def test_creates_empty_array_if_missing(self, fake_doc):
+        feed = {"id": "n_feed0001", "type": "feed", "props": {}}
+        fake_doc.rippleSpec["ui"]["children"].append(feed)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_append_prop_array_item(
+                fake_doc.id,
+                node_id="n_feed0001",
+                prop="items",
+                value={"text": "Hi"},
+            )
+        assert err is None
+        assert feed["props"]["items"] == [{"text": "Hi"}]
+        assert result["item_index"] == 0
+
+    @pytest.mark.asyncio
+    async def test_after_target_not_found_errors(self, fake_doc):
+        table = {
+            "id": "n_table111",
+            "type": "table",
+            "props": {"rows": [{"orderId": "#1"}]},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(table)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_append_prop_array_item(
+                fake_doc.id,
+                node_id="n_table111",
+                prop="rows",
+                value={"orderId": "#2"},
+                after={"by_field": "orderId", "equals": "#999"},
+            )
+        assert result is None
+        assert "not_found" in err
+
+
+class TestRemovePropArrayItem:
+    @pytest.mark.asyncio
+    async def test_removes_matched_item(self, fake_doc):
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {
+                "data": [
+                    {"label": "A", "value": 1},
+                    {"label": "Other", "value": 2},
+                    {"label": "B", "value": 3},
+                ]
+            },
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_remove_prop_array_item(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Other"},
+            )
+        assert err is None
+        assert result["removed_index"] == 1
+        assert result["removed_item"] == {"label": "Other", "value": 2}
+        assert [d["label"] for d in chart["props"]["data"]] == ["A", "B"]
+
+    @pytest.mark.asyncio
+    async def test_not_found_errors(self, fake_doc):
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {"data": [{"label": "A"}]},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_remove_prop_array_item(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Z"},
+            )
+        assert result is None
+        assert "not_found" in err
+
+
+# ---------------------------------------------------------------------------
+# *_for_agent wrappers — exercise the agent_context.py layer that drives
+# SSE node ops + the uniform {ok, ...} shape consumed by LangChain tools.
+# ---------------------------------------------------------------------------
+
+
+class TestPropArrayItemWrappers:
+    """The thin wrappers in agent_context.py: push SSE node ops + return
+    the uniform {ok, ...} shape consumed by the LangChain edit tools."""
+
+    @pytest.mark.asyncio
+    async def test_set_prop_array_item_for_agent_pushes_sse(self, fake_doc):
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {
+                "data": [
+                    {"label": "Online Store", "value": 62},
+                    {"label": "Other", "value": 8},
+                ],
+            },
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+
+        ctx, push_calls = _patches(fake_doc)
+        with ctx:
+            result = await agent_context.set_prop_array_item_for_agent(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Other"},
+                partial={"value": 5},
+            )
+
+        assert result["ok"] is True
+        assert result["item_index"] == 1
+        assert result["item"] == {"label": "Other", "value": 5}
+        assert chart["props"]["data"][1]["value"] == 5
+        # Exactly one SSE push with the granular action.
+        assert len(push_calls) == 1
+        push = push_calls[0]
+        assert push["action"] == "node_prop_array_item_set"
+        assert push["node_id"] == "n_chart000"
+        assert push["prop"] == "data"
+        assert push["item_index"] == 1
+        assert push["item"] == {"label": "Other", "value": 5}
+        # Subtree-only; never the full pocket.
+        assert "pocket" not in push
+
+    @pytest.mark.asyncio
+    async def test_set_prop_array_item_for_agent_propagates_error(self, fake_doc):
+        ctx, push_calls = _patches(fake_doc)
+        with ctx:
+            result = await agent_context.set_prop_array_item_for_agent(
+                fake_doc.id,
+                node_id="n_header00",  # unsupported widget for prop-array ops
+                prop="text",
+                match={"index": 0},
+                partial={"text": "x"},
+            )
+        assert result["ok"] is False
+        assert "unsupported_prop_array" in result["error"]
+        assert push_calls == []
+
+    @pytest.mark.asyncio
+    async def test_append_prop_array_item_for_agent_pushes_sse(self, fake_doc):
+        table = {
+            "id": "n_table111",
+            "type": "table",
+            "props": {"rows": [{"orderId": "#1"}, {"orderId": "#3"}]},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(table)
+
+        ctx, push_calls = _patches(fake_doc)
+        with ctx:
+            result = await agent_context.append_prop_array_item_for_agent(
+                fake_doc.id,
+                node_id="n_table111",
+                prop="rows",
+                value={"orderId": "#2"},
+                after={"by_field": "orderId", "equals": "#1"},
+            )
+
+        assert result["ok"] is True
+        assert result["item_index"] == 1
+        assert [r["orderId"] for r in table["props"]["rows"]] == ["#1", "#2", "#3"]
+        assert len(push_calls) == 1
+        push = push_calls[0]
+        assert push["action"] == "node_prop_array_item_appended"
+        assert push["node_id"] == "n_table111"
+        assert push["prop"] == "rows"
+        assert push["item_index"] == 1
+        assert push["item"] == {"orderId": "#2"}
+
+    @pytest.mark.asyncio
+    async def test_remove_prop_array_item_for_agent_pushes_sse(self, fake_doc):
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {
+                "data": [
+                    {"label": "A", "value": 1},
+                    {"label": "Other", "value": 2},
+                    {"label": "B", "value": 3},
+                ],
+            },
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+
+        ctx, push_calls = _patches(fake_doc)
+        with ctx:
+            result = await agent_context.remove_prop_array_item_for_agent(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Other"},
+            )
+
+        assert result["ok"] is True
+        assert result["removed_index"] == 1
+        assert result["removed_item"] == {"label": "Other", "value": 2}
+        assert [d["label"] for d in chart["props"]["data"]] == ["A", "B"]
+        assert len(push_calls) == 1
+        push = push_calls[0]
+        assert push["action"] == "node_prop_array_item_removed"
+        assert push["node_id"] == "n_chart000"
+        assert push["prop"] == "data"
+        assert push["removed_index"] == 1
+        assert push["removed_item"] == {"label": "Other", "value": 2}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end canary: the 12-row "All Orders" table edit from the design doc.
+# This is the regression the whole Tier-2 work was driven by — editing one
+# row must leave every other row byte-identical.
+# ---------------------------------------------------------------------------
+
+
+class TestArrayItemCanary:
+    """End-to-end: the 12-row 'All Orders' table edit from the design doc."""
+
+    @pytest.mark.asyncio
+    async def test_one_row_edit_does_not_rewrite_other_rows(self, fake_doc):
+        rows = [
+            {"orderId": f"#{1030 + i}", "customer": f"C{i}", "status": "Fulfilled"}
+            for i in range(12)
+        ]
+        snapshot = [dict(r) for r in rows]
+        table = {
+            "id": "n_orders00",
+            "type": "table",
+            "props": {"rows": rows},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(table)
+
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result = await agent_context.set_prop_array_item_for_agent(
+                fake_doc.id,
+                node_id="n_orders00",
+                prop="rows",
+                match={"by_field": "orderId", "equals": "#1039"},
+                partial={"status": "Shipped"},
+            )
+        assert result["ok"] is True
+        assert result["item_index"] == 9
+        # All other rows are byte-identical.
+        for i, original in enumerate(snapshot):
+            if i == 9:
+                continue
+            assert table["props"]["rows"][i] == original, f"row {i} drifted"
+        assert table["props"]["rows"][9]["status"] == "Shipped"
+        assert table["props"]["rows"][9]["customer"] == "C9"  # untouched field

--- a/tests/cloud/test_pocket_prompt_cache.py
+++ b/tests/cloud/test_pocket_prompt_cache.py
@@ -21,10 +21,14 @@ from ee.ripple import (
     POCKET_ID_TOKEN,
 )
 
-# If you legitimately need to shrink the prompt, drop this floor —
-# but check that the prompt still teaches the design rules adequately.
-# The number is in chars, not tokens (chars/4 ≈ tokens).
-_MIN_CACHEABLE_CHARS = 40_000  # ~10k tokens at minimum
+# The edit-specialist prompt is intentionally slim now (one-shot edit
+# contract: the parent agent fetches the pocket and sends the full
+# payload; the specialist has no read tool). Prompt caching still
+# matters but the entire prompt is small enough that cache hits aren't
+# load-bearing the way they were under the previous ~40k-char heavy
+# variant. This floor only guards against POCKET_ID_TOKEN drifting up
+# into the body of the prompt — keep it modest. Chars, not tokens.
+_MIN_CACHEABLE_CHARS = 1_500
 
 
 @pytest.mark.parametrize(
@@ -51,8 +55,11 @@ def test_pocket_id_token_appears_only_once_at_end(name: str, prompt: str) -> Non
         f"(< {_MIN_CACHEABLE_CHARS}). Something moved POCKET_ID_TOKEN earlier "
         "in the prompt — DeepSeek/Anthropic cache hit rate will crater."
     )
-    # And it must be in the trailing region — within the last 5% of the prompt.
-    trailing_threshold = int(len(prompt) * 0.95)
+    # And it must be in the trailing region — within the last 250 chars,
+    # which fits the `<current-pocket>` template comfortably. A percentage
+    # threshold worked for the old ~60k-char prompt but breaks down on
+    # a 2k-char prompt where the trailing template itself is ~170 chars.
+    trailing_threshold = max(len(prompt) - 250, 0)
     assert first >= trailing_threshold, (
         f"{name} prompt: POCKET_ID_TOKEN sits at offset {first} of "
         f"{len(prompt)} ({first / len(prompt) * 100:.1f}%). It must live in "

--- a/tests/cloud/test_pocket_prompt_state_sources.py
+++ b/tests/cloud/test_pocket_prompt_state_sources.py
@@ -1,34 +1,22 @@
-"""Regression: every prompt that builds rippleSpec teaches the $source mechanism.
+"""Regression: every prompt that AUTHORS a fresh rippleSpec teaches the
+``$source`` mechanism.
 
-Post-Task-11: the calling-agent creation prompts only carry the STEP 0
-delegation block, so the heavy ``<state-sources>`` / ``<creation-examples>``
-content moved onto the specialist's own prompt
-(``POCKET_SPECIALIST_PROMPT``). Interaction prompts still need it because
-they edit existing pockets directly.
+Post one-shot edit redesign: the parent interaction prompts delegate
+(no authoring) and the edit specialist prompt only applies granular
+ops to a payload the parent already fetched (no fresh authoring) — so
+``<state-sources>`` is only required on the create specialist's prompt,
+which is the one drafting brand-new ``rippleSpec`` from scratch.
 """
 
 from __future__ import annotations
 
-import pytest
-
-from ee.ripple._pockets import (
-    POCKET_INTERACTION_PROMPT_CLI,
-    POCKET_INTERACTION_PROMPT_MCP,
-    POCKET_SPECIALIST_PROMPT,
-)
-
-_PROMPTS_WITH_SOURCES = [
-    POCKET_SPECIALIST_PROMPT,
-    POCKET_INTERACTION_PROMPT_MCP,
-    POCKET_INTERACTION_PROMPT_CLI,
-]
-_IDS = ["specialist", "interact-mcp", "interact-cli"]
+from ee.ripple._pockets import POCKET_SPECIALIST_PROMPT
 
 
-@pytest.mark.parametrize("prompt", _PROMPTS_WITH_SOURCES, ids=_IDS)
-def test_prompts_that_build_specs_contain_state_sources_block(prompt: str) -> None:
-    """Specialist (creates) and interaction (edits) agents must know about
-    $source — they're the ones authoring rippleSpec."""
+def test_specialist_prompt_contains_state_sources_block() -> None:
+    """The create specialist is the only agent authoring fresh rippleSpec
+    from scratch, so it must know about $source markers."""
+    prompt = POCKET_SPECIALIST_PROMPT
     assert "<state-sources>" in prompt
     assert "</state-sources>" in prompt
     assert "workspace.pockets" in prompt
@@ -36,10 +24,12 @@ def test_prompts_that_build_specs_contain_state_sources_block(prompt: str) -> No
     assert '"$source"' in prompt
 
 
-def test_state_sources_block_appears_before_examples_in_specialist() -> None:
-    """Agents anchor on examples; the rule must come first so the example
-    can demonstrate it. Specialist prompt only — interaction prompts have
-    no examples block, calling-agent creation prompts have neither."""
+def test_state_sources_block_appears_before_canonical_shapes_in_specialist() -> None:
+    """Agents anchor on concrete props; the state-sources rule must come
+    first so the canonical-shapes block can demonstrate $source seeds
+    in context. The slim specialist prompt dropped the standalone
+    examples block — CANONICAL_SHAPES carries the worked examples now,
+    so we anchor the ordering check to it instead."""
     sources_idx = POCKET_SPECIALIST_PROMPT.index("<state-sources>")
-    examples_idx = POCKET_SPECIALIST_PROMPT.index("<creation-examples>")
-    assert sources_idx < examples_idx
+    shapes_idx = POCKET_SPECIALIST_PROMPT.index("CANONICAL SHAPES")
+    assert sources_idx < shapes_idx

--- a/tests/cloud/test_pocket_prompts_single_source.py
+++ b/tests/cloud/test_pocket_prompts_single_source.py
@@ -84,10 +84,13 @@ def test_canonical_prompts_carry_required_features() -> None:
         assert "<pocket-interaction>" in prompt
         assert "<current-pocket>" in prompt
 
-    # Edit specialist carries the heavy edit-time guidance.
+    # Edit specialist prompt is now slim — the parent agent ships the
+    # pocket payload and the specialist needs only a granular-op cheat
+    # sheet. Heavy design/interactive blocks are intentionally absent.
     for prompt in (POCKET_EDIT_SPECIALIST_PROMPT_MCP, POCKET_EDIT_SPECIALIST_PROMPT_CLI):
-        assert "<interactive-by-default>" in prompt
-        assert "<pocket-workflow>" in prompt
+        assert "<edit-specialist>" in prompt
+        assert "<interactive-by-default>" not in prompt
+        assert "<pocket-workflow>" not in prompt
 
     # Creation specialist carries the heavy create-time lift. The
     # specialist runtime only attaches ``persist_pocket`` (validation is
@@ -169,3 +172,22 @@ class TestSpecialistDelegationBlock:
 
         assert "cloud_create_pocket" not in POCKET_CREATION_PROMPT_CLI
         assert "cloud_update_pocket" not in POCKET_CREATION_PROMPT_CLI
+
+
+def test_edit_specialist_prompt_mentions_array_item_ops():
+    from ee.ripple._pockets import POCKET_EDIT_SPECIALIST_PROMPT_MCP
+
+    prompt = POCKET_EDIT_SPECIALIST_PROMPT_MCP
+    assert "set_prop_array_item" in prompt
+    assert "append_prop_array_item" in prompt
+    assert "remove_prop_array_item" in prompt
+
+
+def test_edit_specialist_prompt_warns_against_full_array_rewrite():
+    from ee.ripple._pockets import POCKET_EDIT_SPECIALIST_PROMPT_MCP
+
+    prompt = POCKET_EDIT_SPECIALIST_PROMPT_MCP
+    # The cheatsheet must steer the agent to the array-item ops for
+    # single-row edits rather than set_node_prop on the whole array.
+    assert "set_prop_array_item" in prompt
+    assert "rewrite" in prompt.lower() or "copy" in prompt.lower()

--- a/tests/cloud/test_prop_arrays.py
+++ b/tests/cloud/test_prop_arrays.py
@@ -1,0 +1,52 @@
+"""Tests for the closed (widget_type, prop_name) prop-array allowlist."""
+
+from __future__ import annotations
+
+from ee.cloud.pockets import prop_arrays
+
+
+def test_chart_data_is_allowed():
+    assert prop_arrays.is_allowed("chart", "data")
+
+
+def test_table_rows_and_columns_allowed():
+    assert prop_arrays.is_allowed("table", "rows")
+    assert prop_arrays.is_allowed("table", "columns")
+
+
+def test_kanban_columns_allowed():
+    assert prop_arrays.is_allowed("kanban", "columns")
+
+
+def test_calendar_events_allowed():
+    assert prop_arrays.is_allowed("calendar", "events")
+
+
+def test_feed_items_allowed():
+    assert prop_arrays.is_allowed("feed", "items")
+
+
+def test_select_options_allowed():
+    assert prop_arrays.is_allowed("select", "options")
+
+
+def test_form_layout_fields_allowed():
+    assert prop_arrays.is_allowed("form-layout", "fields")
+
+
+def test_random_prop_rejected():
+    assert not prop_arrays.is_allowed("chart", "title")
+    assert not prop_arrays.is_allowed("stat", "value")
+    assert not prop_arrays.is_allowed("chart", "series")
+
+
+def test_unknown_widget_rejected():
+    assert not prop_arrays.is_allowed("frobnicator", "data")
+
+
+def test_allowed_props_for_known_type():
+    assert sorted(prop_arrays.allowed_props_for("table")) == ["columns", "rows"]
+
+
+def test_allowed_props_for_unknown_returns_empty():
+    assert prop_arrays.allowed_props_for("frobnicator") == ()

--- a/tests/cloud/test_spec_ops.py
+++ b/tests/cloud/test_spec_ops.py
@@ -293,3 +293,75 @@ def test_move_root_raises():
     tree = _tree()
     with pytest.raises(ValueError, match="root"):
         spec_ops.move_node(tree, "n_root0000", "n_table000")
+
+
+# ---------------------------------------------------------------------------
+# Prop-array item matching
+# ---------------------------------------------------------------------------
+
+
+def _sample_array() -> list[dict]:
+    return [
+        {"id": "b1", "label": "Online Store", "value": 62},
+        {"id": "b2", "label": "POS", "value": 18},
+        {"id": "b3", "label": "Social", "value": 12},
+        {"id": "b4", "label": "Other", "value": 8},
+    ]
+
+
+def test_match_by_index_returns_position():
+    idx = spec_ops.match_array_item(_sample_array(), {"index": 0})
+    assert idx == 0
+
+
+def test_match_by_index_negative_rejected():
+    with pytest.raises(ValueError, match="index"):
+        spec_ops.match_array_item(_sample_array(), {"index": -1})
+
+
+def test_match_by_index_out_of_range_rejected():
+    with pytest.raises(ValueError, match="index"):
+        spec_ops.match_array_item(_sample_array(), {"index": 99})
+
+
+def test_match_by_field_equals_finds_first():
+    idx = spec_ops.match_array_item(_sample_array(), {"by_field": "label", "equals": "Other"})
+    assert idx == 3
+
+
+def test_match_by_field_missing_returns_none():
+    idx = spec_ops.match_array_item(_sample_array(), {"by_field": "label", "equals": "Nope"})
+    assert idx is None
+
+
+def test_match_by_key_requires_all_pairs():
+    arr = [
+        {"orderId": "#1039", "channel": "Online"},
+        {"orderId": "#1039", "channel": "POS"},
+    ]
+    idx = spec_ops.match_array_item(arr, {"by_key": {"orderId": "#1039", "channel": "POS"}})
+    assert idx == 1
+
+
+def test_match_id_shortcut_equivalent_to_by_key_id():
+    idx = spec_ops.match_array_item(_sample_array(), {"id": "b3"})
+    assert idx == 2
+
+
+def test_match_ambiguous_returns_candidates_indices():
+    arr = [
+        {"label": "Other", "value": 1},
+        {"label": "Other", "value": 2},
+    ]
+    candidates = spec_ops.match_array_item_candidates(arr, {"by_field": "label", "equals": "Other"})
+    assert candidates == [0, 1]
+
+
+def test_match_rejects_unknown_match_form():
+    with pytest.raises(ValueError, match="unknown match form"):
+        spec_ops.match_array_item(_sample_array(), {"weird": "shape"})
+
+
+def test_match_rejects_empty_match():
+    with pytest.raises(ValueError, match="empty"):
+        spec_ops.match_array_item(_sample_array(), {})

--- a/tests/ee/agent/test_pocket_specialist/test_edit.py
+++ b/tests/ee/agent/test_pocket_specialist/test_edit.py
@@ -82,9 +82,10 @@ class TestEditToolFactories:
 
         tools = make_edit_pocket_tools(pocket_id="p1")
         names = [t.name for t in tools]
-        # The 10 granular ops the edit specialist gets.
+        # Granular ops the edit specialist gets. NO get_pocket — the
+        # parent agent fetches the pocket and passes it in the user
+        # message; the specialist has no read tool by design.
         for expected in (
-            "get_pocket",
             "set_state",
             "append_state",
             "remove_state",
@@ -96,6 +97,11 @@ class TestEditToolFactories:
             "remove_node",
         ):
             assert expected in names, f"missing tool: {expected}"
+        # Explicit absence — adding get_pocket back here is a regression.
+        assert "get_pocket" not in names, (
+            "edit specialist must not have a read tool; parent agent passes "
+            "the pocket payload in the user message instead"
+        )
 
     def test_pocket_id_is_closed_over_not_exposed_to_llm(self) -> None:
         """The LLM should NEVER see pocket_id as an argument — it's
@@ -135,12 +141,107 @@ class TestEditToolFactories:
         ]
 
 
+class TestPropArrayItemToolFactories:
+    async def test_set_prop_array_item_tool_invokes_wrapper(self) -> None:
+        from ee.agent.pocket_specialist import tools
+
+        capture: dict = {}
+        tool = tools.make_set_prop_array_item_tool(pocket_id="p1", capture=capture)
+        with patch(
+            "ee.cloud.pockets.agent_context.set_prop_array_item_for_agent",
+            new_callable=AsyncMock,
+        ) as wrapper:
+            wrapper.return_value = {
+                "ok": True,
+                "item_index": 0,
+                "item": {"x": 1},
+                "old_item": {"x": 0},
+            }
+            result = await tool.coroutine(
+                node_id="n_chart000",
+                prop="data",
+                match={"index": 0},
+                partial={"x": 1},
+            )
+        wrapper.assert_awaited_once_with("p1", "n_chart000", "data", {"index": 0}, {"x": 1})
+        assert result["ok"] is True
+        assert capture["ops"] == [
+            {
+                "op": "set_prop_array_item",
+                "args": {"node_id": "n_chart000", "prop": "data", "match": {"index": 0}},
+            }
+        ]
+
+    async def test_append_prop_array_item_tool_invokes_wrapper(self) -> None:
+        from ee.agent.pocket_specialist import tools
+
+        capture: dict = {}
+        tool = tools.make_append_prop_array_item_tool(pocket_id="p1", capture=capture)
+        with patch(
+            "ee.cloud.pockets.agent_context.append_prop_array_item_for_agent",
+            new_callable=AsyncMock,
+        ) as wrapper:
+            wrapper.return_value = {"ok": True, "item_index": 3, "item": {"x": 9}}
+            result = await tool.coroutine(
+                node_id="n_chart000",
+                prop="data",
+                value={"x": 9},
+                after={"id": "row_b"},
+            )
+        wrapper.assert_awaited_once_with("p1", "n_chart000", "data", {"x": 9}, {"id": "row_b"})
+        assert result["ok"] is True
+        assert capture["ops"] == [
+            {
+                "op": "append_prop_array_item",
+                "args": {"node_id": "n_chart000", "prop": "data", "after": {"id": "row_b"}},
+            }
+        ]
+
+    async def test_remove_prop_array_item_tool_invokes_wrapper(self) -> None:
+        from ee.agent.pocket_specialist import tools
+
+        capture: dict = {}
+        tool = tools.make_remove_prop_array_item_tool(pocket_id="p1", capture=capture)
+        with patch(
+            "ee.cloud.pockets.agent_context.remove_prop_array_item_for_agent",
+            new_callable=AsyncMock,
+        ) as wrapper:
+            wrapper.return_value = {"ok": True, "item_index": 2, "old_item": {"x": 5}}
+            result = await tool.coroutine(
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "X"},
+            )
+        wrapper.assert_awaited_once_with(
+            "p1", "n_chart000", "data", {"by_field": "label", "equals": "X"}
+        )
+        assert result["ok"] is True
+        assert capture["ops"] == [
+            {
+                "op": "remove_prop_array_item",
+                "args": {
+                    "node_id": "n_chart000",
+                    "prop": "data",
+                    "match": {"by_field": "label", "equals": "X"},
+                },
+            }
+        ]
+
+
 class TestRunEditSpecialistSuccessFlag:
     """Lock down that ``ok`` reflects whether the backend stream actually
     completed. Before this guard, ``run_edit_specialist`` returned
     ``ok=True`` even when the inner backend errored mid-stream — the
     caller had no way to tell "no work needed" from "specialist
-    crashed"."""
+    crashed".
+
+    All tests pass a non-None ``pocket`` — the runtime fail-fasts when
+    pocket is missing (covered by TestRuntimeFailsFastWithoutPocket in
+    test_edit_handoff.py), so success-flag tests need to clear that
+    gate first.
+    """
+
+    _POCKET_FIXTURE = {"_id": "p1", "rippleSpec": {"state": {}, "ui": {"type": "flex"}}}
 
     @pytest.mark.asyncio
     async def test_ok_true_when_stream_completes(self) -> None:
@@ -166,7 +267,11 @@ class TestRunEditSpecialistSuccessFlag:
             return_value=fake_backend,
         ):
             out = await run_edit_specialist(
-                PocketSpecialistEditInput(pocket_id="p1", intent="rename row 1"),
+                PocketSpecialistEditInput(
+                    pocket_id="p1",
+                    intent="rename row 1",
+                    pocket=self._POCKET_FIXTURE,
+                ),
                 workspace_id="w1",
                 user_id="u1",
                 settings=Settings(),
@@ -203,7 +308,11 @@ class TestRunEditSpecialistSuccessFlag:
             return_value=fake_backend,
         ):
             out = await run_edit_specialist(
-                PocketSpecialistEditInput(pocket_id="p1", intent="rename row 1"),
+                PocketSpecialistEditInput(
+                    pocket_id="p1",
+                    intent="rename row 1",
+                    pocket=self._POCKET_FIXTURE,
+                ),
                 workspace_id="w1",
                 user_id="u1",
                 settings=Settings(),
@@ -232,15 +341,45 @@ class TestPromptSeparation:
         # Pocket-scope guardrails still apply:
         assert "<pocket-scope>" in POCKET_INTERACTION_PROMPT_MCP
 
-    def test_edit_specialist_prompt_is_heavy(self) -> None:
-        """The specialist's prompt MUST carry the full mutation rules
-        + design block — it's the agent actually doing edits."""
-        from ee.ripple import POCKET_EDIT_SPECIALIST_PROMPT_MCP
-
-        assert "<mutation-strategy>" in POCKET_EDIT_SPECIALIST_PROMPT_MCP
-        # Should be substantially larger than the main agent's prompt.
-        from ee.ripple import POCKET_INTERACTION_PROMPT_MCP
-
-        assert len(POCKET_EDIT_SPECIALIST_PROMPT_MCP) > len(POCKET_INTERACTION_PROMPT_MCP) * 5, (
-            "edit specialist prompt should dwarf the thin main-agent prompt"
+    def test_edit_specialist_prompt_is_slim(self) -> None:
+        """The specialist's prompt is deliberately small now — the
+        parent agent sends the pocket payload and (optionally) target
+        node ids, so the specialist needs only a granular-op cheat
+        sheet, not the full design-rules block. Big prompts caused the
+        model to hallucinate read tools and redesign the canvas."""
+        from ee.ripple import (
+            POCKET_EDIT_SPECIALIST_PROMPT_MCP,
+            POCKET_INTERACTION_PROMPT_MCP,
         )
+
+        # The block the slim prompt is built around must exist:
+        assert "<edit-specialist>" in POCKET_EDIT_SPECIALIST_PROMPT_MCP
+        # And the heavy design block + mutation-strategy block are GONE:
+        assert "<mutation-strategy>" not in POCKET_EDIT_SPECIALIST_PROMPT_MCP
+        # RIPPLE_DESIGN_RULES is no longer spliced in.
+        assert "VISUAL VARIATION" not in POCKET_EDIT_SPECIALIST_PROMPT_MCP
+
+        # Hard ceiling — the whole point of this change is to keep the
+        # specialist prompt well under the size that caused trouble
+        # (the old prompt was ~40k chars). 12k chars (~3k tokens) is a
+        # comfortable upper bound for the slim version; raise this only
+        # if a deliberate addition justifies it.
+        assert len(POCKET_EDIT_SPECIALIST_PROMPT_MCP) < 12_000, (
+            f"edit specialist prompt is {len(POCKET_EDIT_SPECIALIST_PROMPT_MCP)} "
+            "chars; the one-shot redesign expects it to stay slim"
+        )
+
+        # Still in the same order of magnitude as the parent (both are
+        # slim now) — the specialist no longer dwarfs the parent.
+        ratio = len(POCKET_EDIT_SPECIALIST_PROMPT_MCP) / max(len(POCKET_INTERACTION_PROMPT_MCP), 1)
+        assert ratio < 5, f"specialist/parent prompt ratio is {ratio:.1f}x; should be small now"
+
+
+def test_edit_tool_bundle_includes_prop_array_item_tools():
+    from ee.agent.pocket_specialist import tools
+
+    bundle = tools.make_edit_pocket_tools(pocket_id="p1")
+    names = {t.name for t in bundle}
+    assert "set_prop_array_item" in names
+    assert "append_prop_array_item" in names
+    assert "remove_prop_array_item" in names

--- a/tests/ee/agent/test_pocket_specialist/test_edit_handoff.py
+++ b/tests/ee/agent/test_pocket_specialist/test_edit_handoff.py
@@ -1,13 +1,16 @@
-"""Tests for the parent → edit-specialist handoff.
+"""Tests for the parent → edit-specialist one-shot handoff.
 
-The parent (Claude) decides WHAT and WHERE; the specialist (DeepSeek)
-applies the change. These tests lock the contract:
+The parent (Claude) fetches the pocket once and ships the full payload
+to the specialist (DeepSeek). The specialist has no read tool. These
+tests lock the contract:
 
-  * Edit input accepts optional pocket + target_node_ids.
-  * MCP edit-tool schema advertises both as optional.
-  * _build_edit_user_message surfaces them prominently when set.
-  * Specialist prompt teaches the skip-read behavior.
-  * Parent prompt teaches the 3-way edit decision tree.
+  * Edit input requires intent + pocket_id; pocket is the parent's
+    contractual handoff and target_node_ids is optional.
+  * MCP edit-tool schema marks pocket as required.
+  * _build_edit_user_message inlines the pocket payload and surfaces
+    target node ids when set.
+  * Parent prompt teaches the one-shot flow (fetch → ship → done).
+  * Specialist prompt teaches "no get_pocket; pocket is in the message".
 """
 
 from __future__ import annotations
@@ -24,7 +27,7 @@ class TestEditInputAcceptsHandoff:
         )
         assert inp.target_node_ids == ["n_chart00", "n_legend0"]
 
-    def test_pocket_optional_dict(self) -> None:
+    def test_pocket_handoff_dict(self) -> None:
         from ee.agent.pocket_specialist.runtime import PocketSpecialistEditInput
 
         inp = PocketSpecialistEditInput(
@@ -34,8 +37,11 @@ class TestEditInputAcceptsHandoff:
         )
         assert inp.pocket and inp.pocket["_id"] == "p1"
 
-    def test_bare_input_still_valid(self) -> None:
-        """Backwards-compat: just pocket_id + intent still works."""
+    def test_bare_input_still_constructs(self) -> None:
+        """The Pydantic model still accepts a bare input — the runtime
+        layer rejects it with a clear error rather than the model. Keeps
+        the wire schema permissive for tests / fixtures while the
+        runtime enforces the always-send-pocket contract."""
         from ee.agent.pocket_specialist.runtime import PocketSpecialistEditInput
 
         inp = PocketSpecialistEditInput(pocket_id="p1", intent="mark task 1 done")
@@ -54,16 +60,15 @@ class TestUserMessageSurfacesHandoff:
             PocketSpecialistEditInput(
                 pocket_id="p1",
                 intent="rename the chart to Revenue Q4",
+                pocket={"_id": "p1", "rippleSpec": {}},
                 target_node_ids=["n_chart00"],
             )
         )
         assert "TARGET NODE IDS" in msg
         assert "n_chart00" in msg
-        # Without pocket, the read-first prompt should NOT appear since
-        # target node ids alone are enough to act on.
-        assert "Read the pocket first" not in msg
+        assert "authoritative" in msg.lower()
 
-    def test_pocket_block_when_set(self) -> None:
+    def test_pocket_block_inlines_payload(self) -> None:
         from ee.agent.pocket_specialist.runtime import (
             PocketSpecialistEditInput,
             _build_edit_user_message,
@@ -77,68 +82,59 @@ class TestUserMessageSurfacesHandoff:
             )
         )
         assert "CURRENT POCKET" in msg
-        # The pocket payload must be inline (skip-read instruction is the point).
         assert "rippleSpec" in msg
-        assert "skip" in msg.lower() or "use this directly" in msg
-
-    def test_read_first_when_neither_handoff_field_set(self) -> None:
-        from ee.agent.pocket_specialist.runtime import (
-            PocketSpecialistEditInput,
-            _build_edit_user_message,
-        )
-
-        msg = _build_edit_user_message(
-            PocketSpecialistEditInput(pocket_id="p1", intent="add a stat widget")
-        )
-        assert "Read the pocket first" in msg
-
-    def test_both_handoff_fields_omit_read_first(self) -> None:
-        from ee.agent.pocket_specialist.runtime import (
-            PocketSpecialistEditInput,
-            _build_edit_user_message,
-        )
-
-        msg = _build_edit_user_message(
-            PocketSpecialistEditInput(
-                pocket_id="p1",
-                intent="rename the chart",
-                pocket={"x": 1},
-                target_node_ids=["n_chart00"],
-            )
-        )
+        # Tell the model not to look for a read tool.
+        assert "no get_pocket" in msg.lower()
+        # No "Read the pocket first" fallback in the new contract.
         assert "Read the pocket first" not in msg
-        assert "TARGET NODE IDS" in msg
-        assert "CURRENT POCKET" in msg
 
 
-class TestMCPSchemaAdvertisesHandoff:
-    def test_edit_tool_schema_includes_handoff_fields(self) -> None:
-        """The MCP edit tool's args schema must advertise both
-        optional handoff fields so Claude's tool layer surfaces them."""
+class TestRuntimeFailsFastWithoutPocket:
+    """The runtime refuses an edit run that did not receive the
+    pocket payload. Cheaper than burning an LLM call doomed to noop."""
+
+    async def test_run_returns_error_when_pocket_missing(self) -> None:
+        from ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditInput,
+            run_edit_specialist,
+        )
+        from pocketpaw.config import Settings
+
+        out = await run_edit_specialist(
+            PocketSpecialistEditInput(pocket_id="p1", intent="add a stat widget"),
+            workspace_id="w1",
+            user_id="u1",
+            settings=Settings(),
+        )
+        assert out.ok is False
+        assert out.error is not None
+        assert "pocket payload missing" in out.error
+        assert out.ops == []
+
+
+class TestMCPSchemaRequiresPocket:
+    def test_edit_tool_schema_requires_pocket(self) -> None:
+        """The MCP edit tool's args schema must mark `pocket` required
+        so Claude's tool layer enforces the always-send contract."""
         from ee.agent.pocket_specialist import mcp_tool
 
         with open(mcp_tool.__file__, encoding="utf-8") as fh:
             text = fh.read()
 
-        # Both fields named in the edit handler arg pass-through.
+        # Handler still pulls all three.
         assert 'args.get("pocket")' in text
         assert 'args.get("target_node_ids")' in text
-        # And advertised in the schema's properties block.
-        # Two `"pocket"` strings (handler + schema) is fine; we want at
-        # least one schema-style entry with array items for target_node_ids.
+        # And the schema lists pocket inside the required tuple.
+        assert '"required": ["pocket_id", "intent", "pocket"]' in text
         assert '"target_node_ids"' in text
         assert '"items": {"type": "string"}' in text
 
 
-class TestParentPromptEditDecisionTree:
-    def test_parent_prompt_has_decision_tree(self) -> None:
+class TestParentPromptOneShotFlow:
+    def test_parent_prompt_describes_one_shot_flow(self) -> None:
         from ee.ripple._pockets import POCKET_INTERACTION_PROMPT_MCP
 
-        assert "EDIT DECISION TREE" in POCKET_INTERACTION_PROMPT_MCP
-        # Three explicit branches:
-        assert "Type A" in POCKET_INTERACTION_PROMPT_MCP
-        assert "Type B" in POCKET_INTERACTION_PROMPT_MCP
-        assert "Type C" in POCKET_INTERACTION_PROMPT_MCP
+        assert "ONE-SHOT FLOW" in POCKET_INTERACTION_PROMPT_MCP
 
     def test_parent_prompt_mentions_target_node_ids(self) -> None:
         from ee.ripple._pockets import POCKET_INTERACTION_PROMPT_MCP
@@ -153,23 +149,33 @@ class TestParentPromptEditDecisionTree:
         for field in ("pocket_id", "intent", "pocket", "target_node_ids"):
             assert f'"{field}"' in POCKET_INTERACTION_PROMPT_MCP
 
+    def test_parent_prompt_marks_pocket_required(self) -> None:
+        from ee.ripple._pockets import POCKET_INTERACTION_PROMPT_MCP
+
+        # Some flag that the parent must always send pocket — not
+        # locking to exact phrasing, but the word REQUIRED applied to
+        # pocket should be there.
+        assert "REQUIRED" in POCKET_INTERACTION_PROMPT_MCP
+
     def test_parent_prompt_caps_disambiguation_questions(self) -> None:
         from ee.ripple._pockets import POCKET_INTERACTION_PROMPT_MCP
 
-        assert "NEVER ask more than 1 disambiguation question" in POCKET_INTERACTION_PROMPT_MCP
+        assert "Never more than one" in POCKET_INTERACTION_PROMPT_MCP
 
 
 class TestSpecialistPromptHandoffRules:
-    def test_specialist_prompt_teaches_skip_read_when_pocket_passed(self) -> None:
+    def test_specialist_prompt_teaches_no_get_pocket(self) -> None:
         from ee.ripple._pockets import POCKET_EDIT_SPECIALIST_PROMPT_MCP
 
-        assert "<parent-handoff>" in POCKET_EDIT_SPECIALIST_PROMPT_MCP
-        assert "SKIP your own `get_pocket`" in POCKET_EDIT_SPECIALIST_PROMPT_MCP
+        prompt = POCKET_EDIT_SPECIALIST_PROMPT_MCP
+        assert "<edit-specialist>" in prompt
+        # The specialist must be told it has no read tool, in any
+        # phrasing — the slim prompt strips backticks for brevity.
+        assert "no get_pocket" in prompt.lower() or "NO read tool" in prompt
 
     def test_specialist_prompt_teaches_target_node_ids_authoritative(self) -> None:
         from ee.ripple._pockets import POCKET_EDIT_SPECIALIST_PROMPT_MCP
 
-        # Authoritative — don't search past the parent's lookup.
         assert "TARGET NODE IDS" in POCKET_EDIT_SPECIALIST_PROMPT_MCP
-        assert "authoritative" in POCKET_EDIT_SPECIALIST_PROMPT_MCP.lower()
-        assert "Work ONLY on these" in POCKET_EDIT_SPECIALIST_PROMPT_MCP
+        assert "AUTHORITATIVE" in POCKET_EDIT_SPECIALIST_PROMPT_MCP
+        assert "work ONLY on these" in POCKET_EDIT_SPECIALIST_PROMPT_MCP

--- a/tests/ee/agent/test_pocket_specialist/test_edit_handoff.py
+++ b/tests/ee/agent/test_pocket_specialist/test_edit_handoff.py
@@ -179,3 +179,22 @@ class TestSpecialistPromptHandoffRules:
         assert "TARGET NODE IDS" in POCKET_EDIT_SPECIALIST_PROMPT_MCP
         assert "AUTHORITATIVE" in POCKET_EDIT_SPECIALIST_PROMPT_MCP
         assert "work ONLY on these" in POCKET_EDIT_SPECIALIST_PROMPT_MCP
+
+    def test_specialist_prompt_teaches_bound_vs_literal_decision(self) -> None:
+        """When `widget.props.<arr>` is `{state.<path>}`, the specialist
+        must route to the state ops; only LITERAL arrays should reach
+        for the Tier-2 prop-array ops. State-first pockets dominate, so
+        without this guidance the agent reaches for set_prop_array_item
+        on bound widgets and the canvas drifts."""
+        from ee.ripple._pockets import POCKET_EDIT_SPECIALIST_PROMPT_MCP
+
+        prompt = POCKET_EDIT_SPECIALIST_PROMPT_MCP
+        # Both branches of the decision must appear.
+        assert "BOUND" in prompt
+        assert "UNBOUND" in prompt
+        # Concrete handle the agent can grep for in the pocket payload.
+        assert '"{state.' in prompt or "{state." in prompt
+        # Worked examples for each branch so the model sees the shape,
+        # not just the rule.
+        assert "set_state(" in prompt
+        assert "set_prop_array_item(" in prompt

--- a/tests/ee/agent/test_pocket_specialist/test_widget_diversity.py
+++ b/tests/ee/agent/test_pocket_specialist/test_widget_diversity.py
@@ -79,12 +79,18 @@ class TestActivityPickerRule:
 
         assert "NEVER a `table`" in ACTIVITY_PICKER_RULE or "NEVER a table" in ACTIVITY_PICKER_RULE
 
-    def test_activity_picker_in_ripple_design_rules(self) -> None:
-        """The block must be wired into the assembled prompt the
-        specialist actually reads."""
-        from ee.ripple._design import RIPPLE_DESIGN_RULES
+    def test_activity_picker_reachable_via_widget_help(self) -> None:
+        """The activity-picker rule is no longer eager in
+        RIPPLE_DESIGN_RULES (it was paid for by 100% of calls and
+        used by maybe 10%). It now lives in OPTIONAL_DESIGN_SECTIONS
+        and is fetched on demand by widget_help() / get_widget_spec.
+        Verify the lookup path returns the block."""
+        from ee.ripple._design import OPTIONAL_DESIGN_SECTIONS
+        from ee.ripple._inline_core import widget_help
 
-        assert "ACTIVITY PICKER" in RIPPLE_DESIGN_RULES
+        assert "activity-picker" in OPTIONAL_DESIGN_SECTIONS
+        out = widget_help(types=["activity-picker"])
+        assert "ACTIVITY PICKER" in out
 
 
 class TestTableCap:

--- a/tests/test_mcp_claude_sdk.py
+++ b/tests/test_mcp_claude_sdk.py
@@ -10,6 +10,7 @@ from ee.agent.pocket_specialist.mcp_tool import (
 )
 from pocketpaw.agents.claude_sdk import ClaudeAgentSDK
 from pocketpaw.agents.sdk_mcp_pocket import SERVER_NAME as _POCKET_MCP_SERVER_NAME
+from pocketpaw.agents.sdk_mcp_tasks import SERVER_NAME as _TASKS_MCP_SERVER_NAME
 from pocketpaw.config import Settings
 from pocketpaw.mcp.config import MCPServerConfig
 
@@ -19,6 +20,7 @@ def _strip_builtin_servers(result: dict) -> dict:
     out = dict(result)
     out.pop(_POCKET_MCP_SERVER_NAME, None)
     out.pop(_POCKET_SPECIALIST_MCP_SERVER_NAME, None)
+    out.pop(_TASKS_MCP_SERVER_NAME, None)
     return out
 
 

--- a/tests/test_mcp_claude_sdk.py
+++ b/tests/test_mcp_claude_sdk.py
@@ -10,7 +10,6 @@ from ee.agent.pocket_specialist.mcp_tool import (
 )
 from pocketpaw.agents.claude_sdk import ClaudeAgentSDK
 from pocketpaw.agents.sdk_mcp_pocket import SERVER_NAME as _POCKET_MCP_SERVER_NAME
-from pocketpaw.agents.sdk_mcp_tasks import SERVER_NAME as _TASKS_MCP_SERVER_NAME
 from pocketpaw.config import Settings
 from pocketpaw.mcp.config import MCPServerConfig
 
@@ -20,7 +19,6 @@ def _strip_builtin_servers(result: dict) -> dict:
     out = dict(result)
     out.pop(_POCKET_MCP_SERVER_NAME, None)
     out.pop(_POCKET_SPECIALIST_MCP_SERVER_NAME, None)
-    out.pop(_TASKS_MCP_SERVER_NAME, None)
     return out
 
 


### PR DESCRIPTION
Follow-up to #1085. Adds granular (Tier-2) array-item operations on pocket widget props, slims the ripple/pocket-specialist prompts, and tightens the one-shot edit handoff.

## Changes

**Tier-2 array-item ops** (`ee/cloud/pockets/`)
- `prop_arrays.py` — allowlist of editable prop-array paths
- `spec_ops.py` — `match_array_item` helpers (id / index / predicate)
- `service.py` — `agent_set_prop_array_item`, `agent_append_prop_array_item`, `agent_remove_prop_array_item` + `*_for_agent` wrappers
- `agent_context.py` — wires the new ops into agent-side context

**Pocket specialist** (`ee/agent/pocket_specialist/`)
- `tools.py` — Tier-2 LangChain tool factories surface the new service handlers
- `runtime.py` / `mcp_tool.py` — refreshed wiring; one-shot edit handoff

**Ripple prompts** (`ee/ripple/`)
- `_design.py`, `_inline_core.py`, `_pockets.py` — slim prompts; document Tier-2 ops; drop dead branches

**Tests**
- New: `test_prop_arrays.py`, `test_spec_ops.py`, `test_pocket_granular_ops.py`
- Refreshed: edit / edit-handoff / widget-diversity suites; prompt-cache and prompt-single-source assertions

## Test plan

- [x] `uv run pytest tests/cloud/test_prop_arrays.py tests/cloud/test_spec_ops.py tests/cloud/test_pocket_granular_ops.py`
- [x] `uv run pytest tests/ee/agent/test_pocket_specialist/`
- [x] `uv run ruff check .`