### PR TITLE
feat(pocket-specialist): widen widget visibility (10 → 40 starter, 118 → 150 catalog)

### DIFF
--- a/ee/agent/pocket_specialist/adapters.py
+++ b/ee/agent/pocket_specialist/adapters.py
@@ -29,23 +29,38 @@ from pocketpaw.config import Settings
 logger = logging.getLogger(__name__)
 
 
-# A small, hand-curated starter list of widget kinds the chat agent can
-# reach for in agent-mode drafts. NOT exhaustive — the manifest is the
-# source of truth and the chat agent should use the
+# Hand-curated starter list of widget kinds the chat agent can reach
+# for in agent-mode drafts. NOT exhaustive — the Ripple manifest is
+# the source of truth (150 widgets) and the chat agent should use the
 # ``mcp__pocketpaw_pocket__get_widget_spec`` tool to look up props for
-# any kind it wants to use. Listing these here keeps the kit response
-# small while still giving the chat agent a productive starting set.
+# any kind it wants. The 10-widget version of this list (flex / grid /
+# stat / chart / table / text / button / badge / progress / kanban)
+# was provably too narrow — the LLM defaulted to those 10 widgets and
+# never reached for the polished layouts already in the library. The
+# list below covers the same canonical patterns the showcase at
+# https://localhost:5173/showcase demonstrates, organized by use case.
 _STARTER_WIDGET_KINDS: tuple[str, ...] = (
-    "flex",
-    "grid",
-    "stat",
-    "chart",
-    "table",
-    "text",
-    "button",
-    "badge",
-    "progress",
-    "kanban",
+    # containers + structure
+    "flex", "grid", "split", "tabs", "card", "section", "page-header", "hero",
+    # display
+    "text", "heading", "badge", "callout", "stat", "metric",
+    # apps (interactive focal widgets)
+    "kanban", "calendar", "gantt", "form-layout", "wizard-layout",
+    # data viz
+    "chart", "table", "data-grid", "audit-log", "timeline", "kv-table",
+    "funnel", "heatmap", "treemap", "gauge", "sparkline",
+    # polished pattern layouts (Material 3 / HIG canonical shapes)
+    "master-detail", "entity-detail", "pricing-table", "invoice-layout",
+    "order-status", "report-layout", "comparison-layout", "checklist-layout",
+    # high-leverage dashboards (use when pattern=dashboard)
+    "pipeline-dashboard", "analytics-dashboard", "ops-dashboard",
+    "project-dashboard", "exec-dashboard",
+    # rich inputs
+    "input", "textarea", "select", "combobox", "multi-select", "filter-bar",
+    "date-picker", "location-picker", "search",
+    # enterprise / advanced
+    "comment-thread", "tree-table", "org-chart", "saved-views",
+    "notification-center", "error-state", "empty-state",
 )
 
 
@@ -167,6 +182,65 @@ def _draft_kit_response(input: Any, *, started: float) -> Any:
             "``[{label, value}]`` list)."
         ),
         "starter_widget_kinds": list(_STARTER_WIDGET_KINDS),
+        "rich_widgets_by_pattern": {
+            # Pattern → high-leverage widgets that already encapsulate
+            # the canonical layout. Reach for these BEFORE composing
+            # the same shape from primitives — e.g., use
+            # ``pipeline-dashboard`` instead of building a quota progress
+            # bar + top reps leaderboard + funnel + recent deals table
+            # by hand. The widget exists; let it do the work.
+            "dashboard": [
+                "pipeline-dashboard",
+                "analytics-dashboard",
+                "ops-dashboard",
+                "project-dashboard",
+                "exec-dashboard",
+            ],
+            "viewer": [
+                "entity-detail",
+                "pricing-table",
+                "invoice-layout",
+                "order-status",
+                "report-layout",
+                "comparison-layout",
+            ],
+            "app": [
+                "kanban",
+                "calendar",
+                "gantt",
+                "form-layout",
+                "wizard-layout",
+                "checklist-layout",
+            ],
+            "browser": [
+                "master-detail",
+                "tree-table",
+                "filter-bar",
+                "saved-views",
+            ],
+            "wizard": [
+                "wizard-layout",
+                "checklist-layout",
+                "form-layout",
+            ],
+            "feed": [
+                "audit-log",
+                "timeline",
+                "comment-thread",
+                "notification-center",
+            ],
+        },
+        "widget_quality_bar": (
+            "If you're tempted to compose a dashboard out of a 3-stat grid "
+            "+ a chart + a table, check ``rich_widgets_by_pattern`` first. "
+            "The polished domain layout (``pipeline-dashboard`` for sales, "
+            "``ops-dashboard`` for incidents, ``project-dashboard`` for "
+            "delivery) already gives you the funnel, the leaderboard, the "
+            "conversion rates, and the quota progress — composed and styled "
+            "to match. Same for viewers: an article isn't ``page-header`` + "
+            "``text`` + ``text``, it's ``entity-detail`` or ``report-layout`` "
+            "with a body slot. Use the focal widget."
+        ),
         "next_step": (
             "Draft a rippleSpec for the structural plan above. Use your own "
             "model — no subagent will be spawned. When ready, call "
@@ -178,9 +252,10 @@ def _draft_kit_response(input: Any, *, started: float) -> Any:
         ),
         "lookup_tool": (
             "Use ``mcp__pocketpaw_pocket__get_widget_spec`` to fetch allowed "
-            "props for any widget kind before drafting. Use "
-            "``mcp__pocketpaw_pocket__list_pockets`` to see existing pockets "
-            "in the workspace."
+            "props for any widget kind before drafting (especially the rich "
+            "layouts above — they take richer prop shapes than the "
+            "primitives). Use ``mcp__pocketpaw_pocket__list_pockets`` to see "
+            "existing pockets in the workspace."
         ),
     }
 

--- a/ee/ripple/_design.py
+++ b/ee/ripple/_design.py
@@ -21,22 +21,27 @@ layout      flex, grid, card, container, tabs, accordion, split,
             section, app-shell, sidebar, breadcrumb, comparison-layout,
             map, checklist-layout, entity-detail, form-layout,
             invoice-layout, location-picker, order-status,
-            report-layout, wizard-layout
+            report-layout, wizard-layout, glass-card, ripple-frame
 display     heading, text, badge, metric, stat, progress, progress-ring,
-            avatar, image, markdown, code-block, code, kbd, icon,
-            quote, highlight, definition-list, comparison-table,
+            avatar, image, markdown, rich-text, code-block, code, kbd,
+            icon, quote, highlight, definition-list, comparison-table,
             pros-cons, steps, status-dot, trend, link-preview, qr,
-            diff, copy, chip, empty-state, loading
+            diff, copy, chip, empty-state, loading, skeleton,
+            company-header, article-meta, soul-status, c4, terminal
 input       button, input, textarea, select, combobox, multi-select,
             checkbox, switch, radio-group, slider, rating, date-picker,
             time-picker, number-input, segmented, color-picker,
-            file-upload, form, filter-bar
+            file-upload, form, filter-bar, search, mention, otp-input,
+            range-bar, code-editor
 data        chart, table, data-grid, kanban, gantt, calendar, timeline,
             tree, tree-table, virtual-list, sparkline, gauge, funnel,
-            heatmap, sankey, treemap
+            heatmap, sankey, treemap, workflow
+dashboard   pipeline-dashboard, analytics-dashboard, ops-dashboard,
+            exec-dashboard, project-dashboard, dashboard, dashboard-slot,
+            analyst-bar, bulk-action-bar, saved-views
 overlay     alert, callout, tooltip, popover, hover-card, dropdown-menu,
             toast, command-palette, context-menu, notification-center,
-            error-state
+            error-state, sheet, modal, confirm-dialog, coachmark
 research    source-card, citation, sources-bar, discover-card, follow-up,
             kv-table, news-card, ticker
 vertical    pricing-table, settings-list, comment-thread, audit-log,
@@ -90,6 +95,51 @@ of text rows" rebuild looks worse than the real widget.
   filter a list by status/category    → `select` or `filter-bar`
                                         bound to `state.filter`
                                         — NOT tabs
+
+  ## Polished pattern layouts — reach for these BEFORE composing from primitives
+
+  When the user described a familiar domain shape, the library
+  already has the composed layout. Picking the polished widget reads
+  better than rebuilding it from a 3-stat grid + chart + table:
+
+  sales pipeline / quota tracker     → pipeline-dashboard
+                                        (funnel + reps + conversions
+                                        + quota progress, composed)
+  product / web analytics            → analytics-dashboard
+  on-call / incidents / sre          → ops-dashboard
+  delivery / project status          → project-dashboard
+  exec / leadership weekly review    → exec-dashboard
+  invoice / quote / receipt          → invoice-layout
+  order / shipment tracking          → order-status
+  record / profile / entity facts    → entity-detail (NOT page-header
+                                        + grid of stats)
+  pricing / plans / tiers            → pricing-table
+  quarterly / status write-up        → report-layout
+  feature / product comparison       → comparison-layout
+  launch checklist / runbook         → checklist-layout
+  multi-step setup / onboarding      → wizard-layout
+  signup / contact / multi-field     → form-layout
+
+  ## Other widgets to reach for when the brief matches
+
+  product tour / onboarding hint     → coachmark
+  notification bell / inbox          → notification-center
+  saved filter / view picker         → saved-views
+  bulk action bar (select N rows)    → bulk-action-bar
+  analyst control bar (date+filter)  → analyst-bar
+  mention picker (@user)             → mention
+  one-time password input            → otp-input
+  range slider (min/max)             → range-bar
+  rich text editor                   → rich-text (NOT markdown for
+                                        editable content)
+  code editor (IDE-like)             → code-editor (NOT code-block)
+  terminal / shell output            → terminal
+  loading placeholder                → skeleton (NOT empty `text`)
+  modal dialog                       → modal (lightweight) or sheet
+                                        (drawer-style)
+  confirm before destructive action  → confirm-dialog
+  glass-tinted card surface          → glass-card
+  C4 architecture diagram            → c4
 """
 
 

--- a/tests/ee/agent/test_pocket_specialist/test_adapters.py
+++ b/tests/ee/agent/test_pocket_specialist/test_adapters.py
@@ -190,8 +190,62 @@ class TestAgentModeAdapterDraftKit:
         assert out.action == "draft_kit"
         assert out.draft_kit is not None
         assert out.draft_kit["structural_plan"] == {}
-        assert isinstance(out.draft_kit["starter_widget_kinds"], list)
-        assert len(out.draft_kit["starter_widget_kinds"]) > 0
+        # Starter list expanded from 10 → 40+ widgets so the chat agent
+        # has visibility into the actual library (Ripple ships 150
+        # widgets; the prior 10-item starter list was provably too
+        # narrow). Bound is conservative — drop in case someone trims
+        # the tuple aggressively in a future cleanup.
+        starters = out.draft_kit["starter_widget_kinds"]
+        assert isinstance(starters, list)
+        assert len(starters) >= 30
+        # The polished pattern layouts MUST be in the starter list —
+        # they're the lever that flips the LLM away from "compose a
+        # dashboard from scratch" toward "use the pre-composed widget".
+        for required in (
+            "pipeline-dashboard",
+            "analytics-dashboard",
+            "entity-detail",
+            "master-detail",
+            "filter-bar",
+            "wizard-layout",
+            "audit-log",
+        ):
+            assert required in starters, (
+                f"starter_widget_kinds missing high-leverage widget {required!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_draft_kit_includes_rich_widgets_by_pattern(
+        self, agent_settings
+    ) -> None:
+        """The kit carries a pattern → polished-widget map so the chat
+        agent picks the composed layout instead of rebuilding it from
+        primitives. Every pattern from STEP 1 of VISUAL_VARIATION_RULE
+        must have at least one entry."""
+        adapter = AgentModeAdapter()
+        payload = PocketSpecialistCreateInput(brief="brief enough to clear minlen")
+        out = await adapter.create(
+            payload, workspace_id="w1", user_id="u1", settings=agent_settings
+        )
+        assert out.draft_kit is not None
+        rich = out.draft_kit.get("rich_widgets_by_pattern")
+        assert isinstance(rich, dict)
+        # Every pattern from VISUAL_VARIATION_RULE STEP 1 must be
+        # covered. Missing a pattern here means the LLM falls back to
+        # primitives for that whole category.
+        for pattern in ("dashboard", "viewer", "app", "browser", "wizard", "feed"):
+            assert pattern in rich, f"rich_widgets_by_pattern missing {pattern!r}"
+            assert isinstance(rich[pattern], list)
+            assert len(rich[pattern]) >= 1
+        # Spot-check the dashboard family — this is the case the team-
+        # dashboard regression came in through.
+        assert "pipeline-dashboard" in rich["dashboard"]
+        # And the widget-quality-bar reminder ties it together.
+        assert "widget_quality_bar" in out.draft_kit
+        assert (
+            "pipeline-dashboard"
+            in out.draft_kit["widget_quality_bar"].lower()
+        )
 
     @pytest.mark.asyncio
     async def test_no_backend_spawned_on_draft_kit(self, agent_settings) -> None:

--- a/tests/ee/agent/test_pocket_specialist/test_runtime.py
+++ b/tests/ee/agent/test_pocket_specialist/test_runtime.py
@@ -1,4 +1,13 @@
-"""run_specialist end-to-end with a mocked backend."""
+"""run_specialist end-to-end with a mocked backend.
+
+These tests exercise the SUBAGENT-mode pipeline specifically — they
+mock the backend stream and assert that ``run_specialist`` returns
+the persisted pocket via the side-channel capture dict. The
+``_subagent_settings`` fixture pins ``pocket_specialist_mode="subagent"``
+so an operator shell env var (POCKETPAW_POCKET_SPECIALIST_MODE=agent)
+doesn't reroute the run through ``AgentModeAdapter`` and produce a
+``draft_kit`` response that these assertions weren't designed for.
+"""
 
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,6 +21,16 @@ from ee.agent.pocket_specialist.runtime import (
 )
 from pocketpaw.agents.protocol import AgentEvent
 from pocketpaw.config import Settings
+
+
+@pytest.fixture
+def _subagent_settings() -> Settings:
+    """Settings pinned to subagent mode so operator env vars don't
+    smuggle agent mode into these tests. Use this instead of
+    ``Settings()`` whenever a test calls ``run_specialist`` and
+    expects the subagent pipeline to run."""
+
+    return Settings(_env_file=None, pocket_specialist_mode="subagent")
 
 
 def _stream(events: list[AgentEvent]):
@@ -64,7 +83,7 @@ def _validate_factory_stub(warnings: list[str] | None = None):
 
 class TestRunSpecialistHappyPath:
     @pytest.mark.asyncio
-    async def test_returns_persisted_pocket_via_tool_capture(self):
+    async def test_returns_persisted_pocket_via_tool_capture(self, _subagent_settings):
         captured_pocket = {"id": "p-new", "name": "Repos", "color": "#0ea5e9"}
         # Real backends only emit {"name": tool_name} in tool_result metadata
         # - they never include the tool's return dict. The runtime now relies
@@ -96,7 +115,7 @@ class TestRunSpecialistHappyPath:
                 PocketSpecialistCreateInput(brief="Track my repos across repos foo, bar, baz"),
                 workspace_id="ws-1",
                 user_id="user-A",
-                settings=Settings(),
+                settings=_subagent_settings,
             )
 
         assert out.ok is True
@@ -104,7 +123,7 @@ class TestRunSpecialistHappyPath:
         assert out.pocket["id"] == "p-new"
 
     @pytest.mark.asyncio
-    async def test_hints_target_pocket_id_locks_update_path(self):
+    async def test_hints_target_pocket_id_locks_update_path(self, _subagent_settings):
         captured_pocket = {"id": "p-1", "name": "Updated"}
         events = [
             AgentEvent(type="tool_use", content="", metadata={"name": "persist_pocket"}),
@@ -133,7 +152,7 @@ class TestRunSpecialistHappyPath:
                 ),
                 workspace_id="ws-1",
                 user_id="user-A",
-                settings=Settings(),
+                settings=_subagent_settings,
             )
 
         assert out.action == "extended"
@@ -148,7 +167,7 @@ class TestRunSpecialistFailureMode:
     from a brief" are worse than "I couldn't build that, try again"."""
 
     @pytest.mark.asyncio
-    async def test_no_pocket_returns_failure_result(self):
+    async def test_no_pocket_returns_failure_result(self, _subagent_settings):
         events = [
             AgentEvent(type="message", content="I'm done."),
             AgentEvent(type="done", content=""),
@@ -168,7 +187,7 @@ class TestRunSpecialistFailureMode:
                 PocketSpecialistCreateInput(brief="A vague brief here for testing"),
                 workspace_id="ws-1",
                 user_id="user-A",
-                settings=Settings(),
+                settings=_subagent_settings,
             )
 
         assert out.ok is False


### PR DESCRIPTION
## Summary

You ran Ripple's showcase at ``localhost:5173/showcase`` and noticed the 150-widget library is producing much richer UIs than the Sales Todo pocket the specialist generated. Traced the gap to three places where the LLM's view of the library was too narrow.

## Root cause

| Surface | Pre-PR | After |
|---|---|---|
| ``_STARTER_WIDGET_KINDS`` (agent-mode draft kit) | **10 widgets** (flex/grid/stat/chart/table/text/button/badge/progress/kanban) | **~50 widgets** covering containers + display + apps + data viz + pattern layouts + dashboards + rich inputs + enterprise patterns |
| ``WIDGET_CATALOG`` (LLM's system-prompt reference) | **118 widgets** | **150 widgets** — matches the manifest at `cdn.jsdelivr.net/gh/qbtrix/ripple-iui@v0.0.1/static/manifest.json` |
| ``USE_THE_WIDGET_RULE`` (intent → widget mapping) | Generic patterns only | + "Polished pattern layouts" + "Other widgets" sections explicitly mapping sales pipeline → pipeline-dashboard, on-call → ops-dashboard, profile → entity-detail, etc. |

The LLM picked from the 10-widget starter list and never reached for the polished layouts (``pipeline-dashboard``, ``entity-detail``, ``invoice-layout``, ``location-picker``, ``coachmark``, ``analytics-dashboard``, etc.) that were sitting right there in the manifest but invisible in the prompt.

## What's added

### Agent-mode kit gains two new fields

```json
"rich_widgets_by_pattern": {
  "dashboard": ["pipeline-dashboard", "analytics-dashboard", "ops-dashboard", "project-dashboard", "exec-dashboard"],
  "viewer": ["entity-detail", "pricing-table", "invoice-layout", "order-status", "report-layout", "comparison-layout"],
  "app": ["kanban", "calendar", "gantt", "form-layout", "wizard-layout", "checklist-layout"],
  "browser": ["master-detail", "tree-table", "filter-bar", "saved-views"],
  "wizard": ["wizard-layout", "checklist-layout", "form-layout"],
  "feed": ["audit-log", "timeline", "comment-thread", "notification-center"]
},
"widget_quality_bar": "If you're tempted to compose a dashboard out of a 3-stat grid + chart + table, check rich_widgets_by_pattern first. The polished domain layout (pipeline-dashboard for sales, ops-dashboard for incidents, ...) already gives you the funnel, the leaderboard, the conversion rates, and the quota progress — composed and styled to match."
```

### USE_THE_WIDGET_RULE additions

- **Polished pattern layouts** — sales pipeline → `pipeline-dashboard`, on-call/incidents → `ops-dashboard`, profile/facts → `entity-detail` (NOT `page-header + grid of stats`), pricing → `pricing-table`, quarterly write-up → `report-layout`, multi-step setup → `wizard-layout`, etc.
- **Other widgets** — coachmark for product tours, saved-views, bulk-action-bar, analyst-bar, mention / otp-input / range-bar, rich-text (vs markdown for editable content), code-editor (vs code-block), terminal, skeleton (vs empty text), modal/sheet/confirm-dialog, glass-card, c4 diagrams.

## Tests

- ``test_first_call_no_hints_returns_empty_plan`` tightened — bound `>= 30` starter widgets + required membership of 7 high-leverage widgets (pipeline-dashboard, analytics-dashboard, entity-detail, master-detail, filter-bar, wizard-layout, audit-log). Drop in case someone trims the tuple in a future cleanup.
- ``test_draft_kit_includes_rich_widgets_by_pattern`` (new) — every STEP 1 pattern (dashboard/viewer/app/browser/wizard/feed) covered with `>= 1` entry, dashboard family contains pipeline-dashboard, widget_quality_bar mentions pipeline-dashboard.
- ``test_runtime.py`` test-isolation patch — pre-existing gap I tripped over: the three subagent-pipeline tests constructed `Settings()` without `_env_file=None`, so an operator shell with `POCKETPAW_POCKET_SPECIALIST_MODE=agent` rerouted them into agent mode and the assertions on `action="failed" / "created"` started failing with `action="draft_kit"`. New `_subagent_settings` fixture pins mode + env-isolation. Same idea as the existing `_isolate_env` fixture in `test_settings.py`.
- Full sweep: **137 tests pass**.

## What you should see

For "create a sales todo for our team":
- LLM sees `kanban`, `filter-bar`, `form-layout`, `saved-views`, `master-detail` in the kit (vs prior 10 widgets where only `kanban` was applicable)
- The widget_quality_bar nudge specifically calls out "use the focal widget" instead of composing from primitives

For "create a sales dashboard / team dashboard":
- `pipeline-dashboard` / `analytics-dashboard` / `project-dashboard` / `exec-dashboard` show up in `rich_widgets_by_pattern.dashboard` and `starter_widget_kinds`
- The LLM should pick the closest domain layout instead of building KPIs from scratch

## Test plan

- [ ] Create a fresh "sales todo" pocket; expect kanban + filter-bar (vs prior basic stat+table+form)
- [ ] Create a "sales pipeline dashboard" pocket; expect `pipeline-dashboard` widget (the composed sales-pipeline layout from your showcase screenshot)
- [ ] Create an "espresso recipe" pocket; expect `entity-detail` or stacked `report-layout` (vs basic page-header + text + text)
- [ ] Spot-check the agent-mode kit response in logs — should see `rich_widgets_by_pattern` populated and `widget_quality_bar` text present