### PR TITLE
feat: LiveKit call management API + soul memory recall enhancements

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -140,6 +140,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(pockets_journal_stream_router, prefix="/api/v1")
 
     from ee.cloud.kb.router import router as kb_router
+    from ee.cloud.livekit.router import router as livekit_router
     from ee.cloud.mission_control.router import router as mission_control_router
     from ee.cloud.notifications.router import router as notifications_router
     from ee.cloud.tasks.router import router as tasks_router
@@ -153,6 +154,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(tasks_router, prefix="/api/v1")
     app.include_router(files_router, prefix="/api/v1")
     app.include_router(mission_control_router, prefix="/api/v1")
+    app.include_router(livekit_router, prefix="/api/v1")
 
     # Files Tab v2 — /api/v1/files/tree + /api/v1/files/browse. Mounted
     # inline (instead of via build_router's ctx_factory) so the routes can

--- a/ee/cloud/livekit/__init__.py
+++ b/ee/cloud/livekit/__init__.py
@@ -2,12 +2,14 @@
 
 Provides:
 - ``LiveKitService`` — room management + token generation for LiveKit Cloud
-- ``CallAgent`` — AI agent that listens to calls, transcribes, and posts meeting notes
+- ``CallMeetingAgent`` — AI agent that listens to calls, transcribes, and posts meeting notes
+- ``MeetingAgentProtocol`` — protocol to break circular imports between service and agent
 - REST router at ``/api/v1/livekit/*``
 """
 
 from __future__ import annotations
 
 from ee.cloud.livekit.router import router
+from ee.cloud.livekit.types import MeetingAgentProtocol
 
-__all__ = ["router"]
+__all__ = ["router", "MeetingAgentProtocol"]

--- a/ee/cloud/livekit/__init__.py
+++ b/ee/cloud/livekit/__init__.py
@@ -1,0 +1,13 @@
+"""LiveKit — voice/video calling for groups.
+
+Provides:
+- ``LiveKitService`` — room management + token generation for LiveKit Cloud
+- ``CallAgent`` — AI agent that listens to calls, transcribes, and posts meeting notes
+- REST router at ``/api/v1/livekit/*``
+"""
+
+from __future__ import annotations
+
+from ee.cloud.livekit.router import router
+
+__all__ = ["router"]

--- a/ee/cloud/livekit/agent.py
+++ b/ee/cloud/livekit/agent.py
@@ -1,0 +1,789 @@
+"""LiveKit Call Agent — meeting notes bot with Deepgram STT.
+
+Architecture
+------------
+This module provides a lightweight agent that connects to a LiveKit room
+as a silent listener participant and transcribes the conversation using
+Deepgram's speech-to-text API.
+
+1. Connects to the LiveKit room via ``livekit.rtc.Room`` (WebRTC)
+2. Subscribes to all remote audio tracks
+3. Pipes each track through Deepgram STT streaming for real-time transcription
+4. Accumulates transcript segments with speaker identification
+5. Detects when the room empties (via polling + room events)
+6. Generates a meeting summary using the configured LLM
+7. Posts the meeting notes to the group chat
+
+Usage
+-----
+The agent is started automatically by the ``LiveKitService`` when a room
+is created, or can be run as a standalone script:
+
+    python -m ee.cloud.livekit.agent --room group-call-abc123
+
+Deepgram Configuration
+----------------------
+Requires the ``DEEPGRAM_API_KEY`` environment variable (set in ``.env``).
+The Deepgram STT uses Nova-3 with ``language="multi"`` for multilingual
+transcription, supporting all Deepgram languages simultaneously.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# How long to wait (seconds) after the last participant leaves before ending
+_CALL_END_GRACE_SECONDS = 30
+
+
+# ---------------------------------------------------------------------------
+# Meeting Notes Agent
+# ---------------------------------------------------------------------------
+
+
+class CallMeetingAgent:
+    """An agent that listens to a LiveKit call and generates meeting notes.
+
+    Connects to the LiveKit room as a silent listener, transcribes all
+    participants' speech via Deepgram STT, and posts a summary to the
+    group when the call ends.
+    """
+
+    def __init__(
+        self,
+        group_id: str,
+        room_name: str,
+        bot_token: str,
+        livekit_url: str = "",
+    ) -> None:
+        self.group_id = group_id
+        self.room_name = room_name
+        self.bot_token = bot_token
+        self.livekit_url = livekit_url
+
+        # Accumulated transcript segments
+        self.transcript_segments: list[dict[str, Any]] = []
+        self._participant_identities: set[str] = set()
+        self._call_start_time: float = 0.0
+
+        # Tasks
+        self._running = False
+        self._monitor_task: asyncio.Task | None = None
+        self._transcribe_task: asyncio.Task | None = None
+
+        # LiveKit RTC room (set when connected)
+        self._rtc_room: Any = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Start the meeting agent.
+
+        Connects to the LiveKit room as a listener, begins Deepgram
+        transcription of all participants, and starts monitoring for
+        room emptiness.
+        """
+        self._running = True
+        self._call_start_time = time.time()
+
+        logger.info(
+            "CallMeetingAgent started for room %s (group %s)",
+            self.room_name,
+            self.group_id,
+        )
+
+        # Monitor room emptiness (polling-based)
+        self._monitor_task = asyncio.create_task(self._monitor_room())
+
+        # Connect to the LiveKit room and begin transcription
+        self._transcribe_task = asyncio.create_task(
+            self._connect_and_transcribe()
+        )
+
+    async def stop(self) -> None:
+        """Stop the agent and generate meeting notes."""
+        self._running = False
+
+        # Disconnect RTC room first (stops audio streams)
+        await self._disconnect_rtc()
+
+        # Cancel monitor task
+        if self._monitor_task:
+            self._monitor_task.cancel()
+            try:
+                await self._monitor_task
+            except asyncio.CancelledError:
+                pass
+
+        # Cancel transcribe task
+        if self._transcribe_task:
+            self._transcribe_task.cancel()
+            try:
+                await self._transcribe_task
+            except asyncio.CancelledError:
+                pass
+
+        await self._finalize_notes()
+
+        logger.info(
+            "CallMeetingAgent stopped for room %s (group %s)",
+            self.room_name,
+            self.group_id,
+        )
+
+    def add_transcript_segment(
+        self,
+        speaker: str,
+        text: str,
+        timestamp: float | None = None,
+    ) -> None:
+        """Add a transcribed speech segment."""
+        self.transcript_segments.append({
+            "speaker": speaker,
+            "text": text,
+            "timestamp": timestamp or time.time(),
+        })
+
+    # ------------------------------------------------------------------
+    # Internal: LiveKit RTC connection + Deepgram transcription
+    # ------------------------------------------------------------------
+
+    async def _connect_and_transcribe(self) -> None:
+        """Connect to the LiveKit room and transcribe all audio via Deepgram.
+
+        Architecture
+        ------------
+        This method connects to the LiveKit room as a silent listener using
+        the ``livekit.rtc.Room`` WebRTC participant. Instead of relying on
+        the ``track_subscribed`` event (which may not fire reliably for
+        agent-type participants), it uses ``AudioStream.from_participant()``
+        which tells the LiveKit FFI layer to subscribe directly to a
+        participant's microphone audio source.
+
+        For each remote participant:
+        1. ``AudioStream.from_participant(participant, SOURCE_MICROPHONE)``
+           subscribes at the FFI level and returns an async iterable of
+           ``AudioFrame`` objects.
+        2. The audio frames are piped into a ``DeepgramSTT.stream()`` for
+           real-time transcription.
+        3. ``FINAL_TRANSCRIPT`` events are collected and stored as transcript
+           segments for the meeting notes.
+        """
+        import aiohttp
+
+        try:
+            from livekit.rtc import (
+                AudioStream,
+                RemoteParticipant,
+                Room,
+                RoomOptions,
+                TrackSource,
+            )
+            from livekit.plugins.deepgram import STT as DeepgramSTT
+            from livekit.agents.stt import SpeechEventType
+
+            room_opts = RoomOptions(auto_subscribe=True)
+            room = Room(loop=asyncio.get_event_loop())
+            self._rtc_room = room
+
+            # Track STT streams keyed by participant identity
+            stt_streams: dict[str, Any] = {}
+            pipe_tasks: dict[str, asyncio.Task] = {}
+
+            # Shared HTTP session for Deepgram (avoids "outside job context" error)
+            http_session = aiohttp.ClientSession()
+
+            # ------------------------------------------------------------------
+            # Helper: create an AudioStream + Deepgram STT pipe for a participant
+            # ------------------------------------------------------------------
+            async def _setup_audio_pipe_for_participant(
+                participant: RemoteParticipant,
+            ) -> None:
+                """Subscribe to a participant's mic and pipe audio to Deepgram.
+
+                Uses ``AudioStream.from_participant()`` which handles the
+                subscription at the FFI level — no need to wait for a
+                ``track_subscribed`` event.
+                """
+                pid = participant.identity
+                if pid == "call-bot" or pid in stt_streams:
+                    return  # already have a stream for this participant
+
+                pname = participant.name or pid
+                self._participant_identities.add(pid)
+                logger.info(
+                    "Agent: setting up audio pipe for %s (from_participant)", pname
+                )
+
+                try:
+                    # 1. Create Deepgram STT stream
+                    stt = DeepgramSTT(
+                        language="multi",
+                        interim_results=False,
+                        punctuate=True,
+                        smart_format=True,
+                        sample_rate=16000,
+                        http_session=http_session,
+                    )
+                    stt_stream = stt.stream()
+                    stt_streams[pid] = stt_stream
+
+                    # 2. Create AudioStream directly from the participant's mic
+                    #    This tells the FFI to subscribe to the audio track
+                    #    — no need for track_subscribed event!
+                    audio_stream = AudioStream.from_participant(
+                        participant=participant,
+                        track_source=TrackSource.SOURCE_MICROPHONE,
+                        sample_rate=16000,
+                        num_channels=1,
+                    )
+
+                    # 3. Pipe audio frames -> Deepgram
+                    pipe_tasks[pid] = asyncio.create_task(
+                        self._pipe_audio_to_stt(
+                            audio_stream, stt_stream, pid, pname,
+                        )
+                    )
+
+                    # 4. Collect transcription results
+                    asyncio.create_task(
+                        self._collect_stt_results(stt_stream, pid, pname)
+                    )
+
+                    logger.info(
+                        "Agent: audio pipe established for %s via from_participant",
+                        pname,
+                    )
+
+                except Exception as exc:
+                    logger.error(
+                        "Failed to create audio pipe for %s: %s", pid, exc,
+                    )
+
+            # ------------------------------------------------------------------
+            # Event handlers (set up BEFORE connect to avoid race conditions)
+            # ------------------------------------------------------------------
+
+            @room.on("participant_connected")
+            def on_participant_connected(participant: RemoteParticipant) -> None:
+                """Handle a participant joining the room after the agent."""
+                pid = participant.identity
+                if pid == "call-bot":
+                    return
+                logger.info(
+                    "Agent: participant connected after agent: %s (%s)",
+                    participant.name or pid, pid,
+                )
+                asyncio.create_task(
+                    _setup_audio_pipe_for_participant(participant)
+                )
+
+            @room.on("participant_disconnected")
+            def on_participant_disconnected(participant: RemoteParticipant) -> None:
+                """Clean up when a participant leaves."""
+                pid = participant.identity
+                stt_streams.pop(pid, None)
+                pipe_tasks.pop(pid, None)
+                logger.info(
+                    "Agent: participant disconnected: %s", pid,
+                )
+
+            @room.on("track_subscribed")
+            def on_track_subscribed(
+                track: Any,
+                publication: Any,
+                participant: Any,
+            ) -> None:
+                """Fallback: handle any tracks that get auto-subscribed.
+
+                This is a safety net in case ``from_participant`` doesn't
+                cover all scenarios. We only act if we don't already have
+                a pipe for this participant.
+                """
+                if track.kind != "audio":
+                    return
+                pid = participant.identity if participant else ""
+                if not pid or pid == "call-bot":
+                    return
+                if pid in stt_streams:
+                    return  # already set up via from_participant
+                pname = participant.name or pid
+                logger.info(
+                    "Agent: track_subscribed fallback for %s", pname,
+                )
+                asyncio.create_task(
+                    _setup_audio_pipe_for_participant(participant)
+                )
+
+            # ------------------------------------------------------------------
+            # Connect to the LiveKit room
+            # ------------------------------------------------------------------
+
+            if not self.livekit_url:
+                logger.warning("No livekit_url provided, skipping RTC connection")
+                await http_session.close()
+                return
+
+            logger.info("Agent connecting to LiveKit room %s", self.room_name)
+            await room.connect(self.livekit_url, self.bot_token, room_opts)
+            logger.info(
+                "Agent connected to LiveKit room %s (participants: %d)",
+                self.room_name,
+                len(room.remote_participants),
+            )
+
+            # ------------------------------------------------------------------
+            # Subscribe to existing participants
+            # ------------------------------------------------------------------
+            # Participants already in the room won't fire
+            # participant_connected, so we must set them up here.
+
+            for pid, participant in list(room.remote_participants.items()):
+                if pid == "call-bot":
+                    continue
+                logger.info(
+                    "Agent: setting up pipe for existing participant %s (%s)",
+                    participant.name or pid, pid,
+                )
+                asyncio.create_task(
+                    _setup_audio_pipe_for_participant(participant)
+                )
+
+                # Also explicitly subscribe to any audio publications as backup
+                for pub in participant.track_publications.values():
+                    if pub.kind == "audio" and not pub.subscribed:
+                        logger.info(
+                            "Agent: explicitly subscribing to %s's audio track",
+                            participant.name or pid,
+                        )
+                        pub.set_subscribed(True)
+
+            logger.info(
+                "Agent: transcription running for room %s (watching %d participants)",
+                self.room_name,
+                len(room.remote_participants),
+            )
+
+            # ------------------------------------------------------------------
+            # Main loop: keep agent alive
+            # ------------------------------------------------------------------
+            while self._running:
+                await asyncio.sleep(1)
+
+        except ImportError as exc:
+            logger.warning(
+                "Cannot transcribe — livekit-rtc or deepgram not available: %s",
+                exc,
+            )
+        except Exception as exc:
+            logger.error(
+                "Transcription agent error for room %s: %s",
+                self.room_name, exc,
+            )
+            import traceback
+            logger.error("Traceback:\n%s", traceback.format_exc())
+        finally:
+            # Clean up STT streams
+            for pid, s in list(stt_streams.items()):
+                try:
+                    await s.aclose()
+                except Exception:
+                    pass
+            # Clean up the HTTP session
+            try:
+                await http_session.close()
+            except Exception:
+                pass
+
+    async def _pipe_audio_to_stt(
+        self,
+        audio_stream: Any,
+        stt_stream: Any,
+        participant_id: str,
+        participant_name: str,
+    ) -> None:
+        """Read AudioFrameEvents from an AudioStream and push frames into STT.
+
+        ``AudioStream`` yields ``AudioFrameEvent`` objects (not raw
+        ``AudioFrame``), so we extract ``.frame`` before pushing into the
+        Deepgram STT stream.
+        """
+        try:
+            async for event in audio_stream:
+                if not self._running:
+                    break
+                try:
+                    stt_stream.push_frame(event.frame)
+                except Exception:
+                    pass  # STT stream might be closed
+        except Exception as exc:
+            logger.debug(
+                "Audio pipe ended for %s: %s", participant_id, exc,
+            )
+        finally:
+            try:
+                stt_stream.end_input()
+            except Exception:
+                pass
+
+    async def _collect_stt_results(
+        self,
+        stt_stream: Any,
+        participant_id: str,
+        participant_name: str,
+    ) -> None:
+        """Collect FINAL_TRANSCRIPT events from the STT stream."""
+        from livekit.agents.stt import SpeechEventType
+
+        try:
+            async for event in stt_stream:
+                if not self._running:
+                    break
+                if event.type == SpeechEventType.FINAL_TRANSCRIPT:
+                    for alt in event.alternatives:
+                        text = alt.text.strip()
+                        if text:
+                            speaker = alt.speaker_id or participant_name
+                            self.add_transcript_segment(
+                                speaker=speaker,
+                                text=text,
+                            )
+                            logger.info(
+                                "Transcript [%s]: %s", speaker, text,
+                            )
+        except Exception as exc:
+            logger.debug(
+                "STT collection ended for %s: %s",
+                participant_id, exc,
+            )
+
+    async def _disconnect_rtc(self) -> None:
+        """Disconnect from the LiveKit RTC room."""
+        if self._rtc_room is not None:
+            try:
+                await self._rtc_room.disconnect()
+            except Exception as exc:
+                logger.debug("Error disconnecting RTC: %s", exc)
+            self._rtc_room = None
+
+    # ------------------------------------------------------------------
+    # Internal: room monitoring
+    # ------------------------------------------------------------------
+
+    async def _monitor_room(self) -> None:
+        """Poll room state to detect when the call ends."""
+        from ee.cloud.livekit.service import get_room_info
+
+        empty_since: float | None = None
+
+        while self._running:
+            try:
+                info = await get_room_info(self.group_id)
+                participant_count = info["participant_count"] if info else 0
+
+                # Track participant identities from room info
+                if info and info.get("participants"):
+                    for p in info["participants"]:
+                        pid = p.get("identity", "")
+                        if pid and pid != "call-bot":
+                            self._participant_identities.add(pid)
+
+                if participant_count == 0:
+                    if empty_since is None:
+                        empty_since = time.time()
+                        logger.info(
+                            "Room %s is empty, will end in %ds",
+                            self.room_name,
+                            _CALL_END_GRACE_SECONDS,
+                        )
+                    elif time.time() - empty_since > _CALL_END_GRACE_SECONDS:
+                        logger.info(
+                            "Room %s has been empty for %ds, ending call",
+                            self.room_name,
+                            _CALL_END_GRACE_SECONDS,
+                        )
+                        await self.stop()
+                        # Clean up the LiveKit room
+                        await self._cleanup_room()
+                        return
+                else:
+                    empty_since = None
+
+            except Exception as exc:
+                logger.warning(
+                    "Error monitoring room %s: %s", self.room_name, exc,
+                )
+                if "not found" in str(exc).lower() or "does not exist" in str(exc).lower():
+                    await self.stop()
+                    return
+
+            await asyncio.sleep(5)
+
+    async def _cleanup_room(self) -> None:
+        """Delete the LiveKit room after a natural call end."""
+        try:
+            from ee.cloud.livekit.service import (
+                LIVEKIT_API_KEY,
+                LIVEKIT_API_SECRET,
+                LIVEKIT_URL,
+            )
+            from livekit.api import LiveKitAPI
+            from livekit.protocol.room import DeleteRoomRequest
+
+            async with LiveKitAPI(
+                LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET
+            ) as lk:
+                req = DeleteRoomRequest(room=self.room_name)
+                await lk.room.delete_room(req)
+                logger.info(
+                    "Cleaned up LiveKit room %s after empty call",
+                    self.room_name,
+                )
+        except Exception as exc:
+            logger.warning(
+                "Error cleaning up room %s: %s", self.room_name, exc,
+            )
+
+        # Remove from active agents registry
+        try:
+            from ee.cloud.livekit.service import _active_agents
+            _active_agents.pop(self.group_id, None)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Notes generation
+    # ------------------------------------------------------------------
+
+    async def _finalize_notes(self) -> None:
+        """Generate and post meeting notes to the group."""
+        duration = int(time.time() - self._call_start_time)
+
+        # Collect participant names from segments + room info
+        speakers_seen: set[str] = set()
+
+        if self.transcript_segments:
+            transcript_lines = []
+            for seg in self.transcript_segments:
+                speaker = seg.get("speaker", "Unknown")
+                speakers_seen.add(speaker)
+                transcript_lines.append(f"[{speaker}]: {seg['text']}")
+
+            transcript_text = "\n".join(transcript_lines)
+
+            # Generate AI summary
+            summary, action_items = await self._generate_summary(
+                transcript_text,
+            )
+        else:
+            transcript_text = ""
+            summary = "Call ended with no speech detected."
+            action_items = []
+
+        # Merge participant identities from room tracking + transcript
+        all_participants = list(
+            self._participant_identities | speakers_seen
+        )
+
+        from ee.cloud.livekit.service import post_meeting_notes_to_group
+
+        await post_meeting_notes_to_group(
+            group_id=self.group_id,
+            transcript=transcript_text,
+            summary=summary,
+            action_items=action_items,
+            participants=all_participants,
+            duration_seconds=duration,
+        )
+
+    # ------------------------------------------------------------------
+    # AI summarization
+    # ------------------------------------------------------------------
+
+    async def _generate_summary(
+        self,
+        transcript: str,
+    ) -> tuple[str, list[str]]:
+        """Generate a meeting summary and action items from transcript.
+
+        Uses Anthropic Claude by default, falls back to OpenAI.
+        Falls back to heuristic extraction if no LLM is configured.
+        """
+        if not transcript:
+            return "No speech detected during the call.", []
+
+        # Try Anthropic first
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        if api_key:
+            try:
+                return await self._summarize_with_anthropic(transcript, api_key)
+            except Exception as exc:
+                logger.warning("Anthropic summarization failed: %s", exc)
+
+        # Fall back to OpenAI
+        openai_key = os.environ.get("OPENAI_API_KEY", "")
+        if openai_key:
+            try:
+                return await self._summarize_with_openai(transcript, openai_key)
+            except Exception as exc:
+                logger.warning("OpenAI summarization failed: %s", exc)
+
+        # Final fallback: simple heuristic
+        return self._summarize_heuristic(transcript)
+
+    async def _summarize_with_anthropic(
+        self,
+        transcript: str,
+        api_key: str,
+    ) -> tuple[str, list[str]]:
+        """Use Anthropic Claude to summarize the transcript."""
+        import httpx
+
+        prompt = (
+            "You are a meeting notes assistant. Given the following transcript of a group call, "
+            "provide:\n"
+            "1. A concise summary (2-3 paragraphs) of what was discussed\n"
+            "2. A list of action items / decisions made\n\n"
+            "Format your response as JSON with keys 'summary' (string) and "
+            "'action_items' (list of strings).\n\n"
+            f"Transcript:\n{transcript}"
+        )
+
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={
+                    "x-api-key": api_key,
+                    "anthropic-version": "2023-06-01",
+                    "content-type": "application/json",
+                },
+                json={
+                    "model": "claude-sonnet-4-20250514",
+                    "max_tokens": 2000,
+                    "messages": [{"role": "user", "content": prompt}],
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+        content = data.get("content", [{}])[0].get("text", "")
+        return self._parse_summary_json(content)
+
+    async def _summarize_with_openai(
+        self,
+        transcript: str,
+        api_key: str,
+    ) -> tuple[str, list[str]]:
+        """Use OpenAI GPT to summarize the transcript."""
+        import httpx
+
+        prompt = (
+            "You are a meeting notes assistant. Given the following transcript of a group call, "
+            "provide:\n"
+            "1. A concise summary (2-3 paragraphs) of what was discussed\n"
+            "2. A list of action items / decisions made\n\n"
+            "Format your response as JSON with keys 'summary' (string) and "
+            "'action_items' (list of strings).\n\n"
+            f"Transcript:\n{transcript}"
+        )
+
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.post(
+                "https://api.openai.com/v1/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": "gpt-4o-mini",
+                    "messages": [{"role": "user", "content": prompt}],
+                    "max_tokens": 2000,
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+        content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+        return self._parse_summary_json(content)
+
+    def _summarize_heuristic(
+        self,
+        transcript: str,
+    ) -> tuple[str, list[str]]:
+        """Simple heuristic summarization fallback."""
+        lines = transcript.strip().split("\n")
+        summary_lines = lines[:5] if len(lines) > 5 else lines
+        summary = " | ".join(summary_lines)
+        return summary, []
+
+    def _parse_summary_json(self, content: str) -> tuple[str, list[str]]:
+        """Parse JSON summary response from LLM."""
+        content = content.strip()
+        if "```json" in content:
+            content = content.split("```json")[1].split("```")[0].strip()
+        elif "```" in content:
+            content = content.split("```")[1].split("```")[0].strip()
+
+        try:
+            parsed = json.loads(content)
+            summary = parsed.get("summary", content)
+            action_items = parsed.get("action_items", [])
+            return summary, action_items
+        except (json.JSONDecodeError, KeyError):
+            return content, []
+
+
+# ---------------------------------------------------------------------------
+# Standalone entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    """Run the LiveKit meeting agent standalone.
+
+    Usage:
+        python -m ee.cloud.livekit.agent --group GROUP_ID --room ROOM_NAME --token BOT_TOKEN
+
+    This is useful for production deployments where the agent runs as a
+    separate process managed by a process supervisor (e.g., systemd,
+    supervisord, Docker).
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(description="LiveKit Meeting Notes Agent")
+    parser.add_argument("--group", required=True, help="Group ID to post notes to")
+    parser.add_argument("--room", required=True, help="LiveKit room name to join")
+    parser.add_argument("--token", required=True, help="LiveKit bot token for authentication")
+    parser.add_argument("--url", default="", help="LiveKit WebSocket URL")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    async def _main():
+        agent = CallMeetingAgent(
+            group_id=args.group,
+            room_name=args.room,
+            bot_token=args.token,
+            livekit_url=args.url,
+        )
+        await agent.start()
+        while agent._running:
+            await asyncio.sleep(1)
+
+    asyncio.run(_main())

--- a/ee/cloud/livekit/agent.py
+++ b/ee/cloud/livekit/agent.py
@@ -531,7 +531,7 @@ class CallMeetingAgent:
                     await self.stop()
                     return
 
-            await asyncio.sleep(5)
+            await asyncio.sleep(30)
 
     async def _cleanup_room(self) -> None:
         """Delete the LiveKit room after a natural call end."""
@@ -558,12 +558,9 @@ class CallMeetingAgent:
                 "Error cleaning up room %s: %s", self.room_name, exc,
             )
 
-        # Remove from active agents registry
-        try:
-            from ee.cloud.livekit.service import _active_agents
-            _active_agents.pop(self.group_id, None)
-        except Exception:
-            pass
+        # The active-agents registry lives in the parent process; the
+        # _reap_agent_process background task in service.py will clean up
+        # when this subprocess exits — nothing to do here.
 
     # ------------------------------------------------------------------
     # Notes generation

--- a/ee/cloud/livekit/router.py
+++ b/ee/cloud/livekit/router.py
@@ -6,7 +6,8 @@ Endpoints:
 - ``DELETE /api/v1/livekit/rooms/{group_id}`` — end a call
 - ``GET /api/v1/livekit/rooms/{group_id}`` — get room status
 
-All routes require an active enterprise license and user authentication.
+All routes require an active enterprise license, user authentication,
+and group membership.
 """
 
 from __future__ import annotations
@@ -16,6 +17,10 @@ import logging
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
+from ee.cloud.chat.group_service import (
+    _get_group_domain_or_404,
+    _require_domain_group_member,
+)
 from ee.cloud.livekit import service as livekit_service
 from ee.cloud.license import require_license
 from ee.cloud.shared.deps import current_user, current_workspace_id
@@ -71,6 +76,22 @@ class EndCallResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _group_id_from_room_name(room_name: str) -> str | None:
+    """Extract group ID from a LiveKit room name (``group-call-{id}``).
+
+    Returns None if the room name doesn't match the expected pattern.
+    """
+    prefix = "group-call-"
+    if room_name.startswith(prefix):
+        return room_name[len(prefix):]
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
 
@@ -87,6 +108,11 @@ async def create_room(
     The response includes a short-lived admin token for the call bot.
     """
     await require_license()
+
+    # Verify the caller is a member of the target group.
+    group = await _get_group_domain_or_404(body.group_id)
+    _require_domain_group_member(group, str(user.id))
+
     result = await livekit_service.create_room(body.group_id)
     return CreateRoomResponse(**result)
 
@@ -105,6 +131,12 @@ async def generate_token(
     real name instead of the user ID.
     """
     await require_license()
+
+    # Verify the caller is a member of the group that owns this room.
+    gid = _group_id_from_room_name(body.room_name)
+    if gid:
+        group = await _get_group_domain_or_404(gid)
+        _require_domain_group_member(group, str(user.id))
 
     # Use the user's full_name as the LiveKit participant name
     display_name = user.full_name or body.identity
@@ -136,6 +168,11 @@ async def get_room_info(
     (no active call).
     """
     await require_license()
+
+    # Verify the caller is a member of the target group.
+    group = await _get_group_domain_or_404(group_id)
+    _require_domain_group_member(group, str(user.id))
+
     info = await livekit_service.get_room_info(group_id)
     if info is None:
         # Return a "room not active" response
@@ -160,5 +197,10 @@ async def end_call(
     will be posted to the group shortly after.
     """
     await require_license()
+
+    # Verify the caller is a member of the target group.
+    group = await _get_group_domain_or_404(group_id)
+    _require_domain_group_member(group, str(user.id))
+
     result = await livekit_service.end_room(group_id)
     return EndCallResponse(**result)

--- a/ee/cloud/livekit/router.py
+++ b/ee/cloud/livekit/router.py
@@ -101,11 +101,18 @@ async def generate_token(
 
     The token is valid for ``ttl_seconds`` (default 1 hour).
     Participants need this token to join the call.
+    The participant's display name is included so other users see the
+    real name instead of the user ID.
     """
     await require_license()
+
+    # Use the user's full_name as the LiveKit participant name
+    display_name = user.full_name or body.identity
+
     token = await livekit_service.generate_participant_token(
         room_name=body.room_name,
         identity=body.identity,
+        name=display_name,
         can_publish=body.can_publish,
         can_subscribe=body.can_subscribe,
         ttl_seconds=body.ttl_seconds,

--- a/ee/cloud/livekit/router.py
+++ b/ee/cloud/livekit/router.py
@@ -1,0 +1,157 @@
+"""FastAPI REST router for LiveKit call management.
+
+Endpoints:
+- ``POST /api/v1/livekit/rooms`` — create/get a call room for a group
+- ``POST /api/v1/livekit/token`` — generate participant access token
+- ``DELETE /api/v1/livekit/rooms/{group_id}`` — end a call
+- ``GET /api/v1/livekit/rooms/{group_id}`` — get room status
+
+All routes require an active enterprise license and user authentication.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from ee.cloud.livekit import service as livekit_service
+from ee.cloud.license import require_license
+from ee.cloud.shared.deps import current_user, current_workspace_id
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/livekit", tags=["LiveKit"])
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+
+
+class CreateRoomRequest(BaseModel):
+    group_id: str = Field(..., description="The group ID to create a call for")
+
+
+class CreateRoomResponse(BaseModel):
+    room_name: str
+    group_id: str
+    url: str
+    bot_token: str
+    created_at: str
+
+
+class TokenRequest(BaseModel):
+    room_name: str = Field(..., description="LiveKit room name")
+    identity: str = Field(..., description="Participant identity (user ID)")
+    can_publish: bool = True
+    can_subscribe: bool = True
+    ttl_seconds: int = 3600
+
+
+class TokenResponse(BaseModel):
+    token: str
+    url: str
+    room_name: str
+
+
+class RoomInfoResponse(BaseModel):
+    room_name: str
+    group_id: str
+    participant_count: int = 0
+    participants: list[dict] = []
+    active: bool
+
+
+class EndCallResponse(BaseModel):
+    room_name: str
+    group_id: str
+    ended_at: str
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/rooms", response_model=CreateRoomResponse)
+async def create_room(
+    body: CreateRoomRequest,
+    user=Depends(current_user),
+    workspace_id: str = Depends(current_workspace_id),
+):
+    """Create a LiveKit room for a group call.
+
+    If a room already exists for this group, returns the existing one.
+    The response includes a short-lived admin token for the call bot.
+    """
+    await require_license()
+    result = await livekit_service.create_room(body.group_id)
+    return CreateRoomResponse(**result)
+
+
+@router.post("/token", response_model=TokenResponse)
+async def generate_token(
+    body: TokenRequest,
+    user=Depends(current_user),
+    workspace_id: str = Depends(current_workspace_id),
+):
+    """Generate a participant access token for a LiveKit room.
+
+    The token is valid for ``ttl_seconds`` (default 1 hour).
+    Participants need this token to join the call.
+    """
+    await require_license()
+    token = await livekit_service.generate_participant_token(
+        room_name=body.room_name,
+        identity=body.identity,
+        can_publish=body.can_publish,
+        can_subscribe=body.can_subscribe,
+        ttl_seconds=body.ttl_seconds,
+    )
+    return TokenResponse(
+        token=token,
+        url=livekit_service.LIVEKIT_URL,
+        room_name=body.room_name,
+    )
+
+
+@router.get("/rooms/{group_id}")
+async def get_room_info(
+    group_id: str,
+    user=Depends(current_user),
+    workspace_id: str = Depends(current_workspace_id),
+):
+    """Get the current state of a room (participants, active status).
+
+    Returns a 404-like null response if the room doesn't exist
+    (no active call).
+    """
+    await require_license()
+    info = await livekit_service.get_room_info(group_id)
+    if info is None:
+        # Return a "room not active" response
+        return RoomInfoResponse(
+            room_name=livekit_service.room_name_for_group(group_id),
+            group_id=group_id,
+            active=False,
+            participants=[],
+        )
+    return RoomInfoResponse(**info)
+
+
+@router.delete("/rooms/{group_id}")
+async def end_call(
+    group_id: str,
+    user=Depends(current_user),
+    workspace_id: str = Depends(current_workspace_id),
+):
+    """End an active call by deleting the LiveKit room.
+
+    All participants will be disconnected. The call bot's meeting notes
+    will be posted to the group shortly after.
+    """
+    await require_license()
+    result = await livekit_service.end_room(group_id)
+    return EndCallResponse(**result)

--- a/ee/cloud/livekit/service.py
+++ b/ee/cloud/livekit/service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import sys
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -27,9 +28,11 @@ logger = logging.getLogger(__name__)
 # Active meeting agents registry
 # ---------------------------------------------------------------------------
 
-_active_agents: dict[str, "CallMeetingAgent"] = {}
+from ee.cloud.livekit.types import MeetingAgentProtocol
 
-def _get_agent(group_id: str) -> "CallMeetingAgent | None":
+_active_agents: dict[str, MeetingAgentProtocol] = {}
+
+def _get_agent(group_id: str) -> MeetingAgentProtocol | None:
     """Get the active meeting agent for a group, if any."""
     return _active_agents.get(group_id)
 
@@ -57,6 +60,113 @@ def _ensure_configured() -> None:
 def room_name_for_group(group_id: str) -> str:
     """Build a deterministic LiveKit room name for a group."""
     return f"group-call-{group_id}"
+
+
+# ---------------------------------------------------------------------------
+# Subprocess agent management (avoids running WebRTC/Deepgram in the
+# server event loop).
+# ---------------------------------------------------------------------------
+
+
+class _SubprocessAgentRef:
+    """Thin wrapper that implements ``MeetingAgentProtocol`` via a subprocess.
+
+    The real ``CallMeetingAgent`` runs in a child process managed by
+    ``asyncio.create_subprocess_exec``.  ``start()`` is a no-op (the
+    process starts on construction); ``stop()`` sends SIGTERM.
+    """
+
+    def __init__(
+        self,
+        group_id: str,
+        room_name: str,
+        process: asyncio.subprocess.Process,
+    ) -> None:
+        self.group_id = group_id
+        self.room_name = room_name
+        self._process = process
+
+    async def start(self) -> None:
+        """Already started by ``_spawn_agent_process``."""
+        pass
+
+    async def stop(self) -> None:
+        """Send SIGTERM and wait up to 10 s for graceful exit."""
+        if self._process.returncode is not None:
+            return  # already terminated
+        try:
+            self._process.terminate()
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=10)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Agent subprocess for room %s did not exit in 10s, killing",
+                    self.room_name,
+                )
+                self._process.kill()
+                await self._process.wait()
+        except ProcessLookupError:
+            pass  # already dead
+        logger.info(
+            "Agent subprocess for room %s exited (code %s)",
+            self.room_name,
+            self._process.returncode,
+        )
+
+
+async def _spawn_agent_process(
+    group_id: str,
+    room_name: str,
+    bot_token: str,
+) -> asyncio.subprocess.Process:
+    """Launch ``CallMeetingAgent`` as a managed subprocess.
+
+    Uses ``sys.executable -m ee.cloud.livekit.agent`` so the child
+    inherits the same Python environment and dependencies.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "ee.cloud.livekit.agent",
+        "--group", group_id,
+        "--room", room_name,
+        "--token", bot_token,
+        "--url", LIVEKIT_URL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    logger.info(
+        "Spawned agent subprocess (PID %d) for room %s",
+        proc.pid,
+        room_name,
+    )
+    return proc
+
+
+async def _reap_agent_process(
+    group_id: str,
+    proc: asyncio.subprocess.Process,
+) -> None:
+    """Wait for an agent subprocess to finish, then clean up the registry.
+
+    Runs in a background ``asyncio.Task``.  When the agent detects the
+    room is empty and exits on its own, this removes it from
+    ``_active_agents`` so the registry doesn't leak.
+    """
+    try:
+        await proc.wait()
+    except asyncio.CancelledError:
+        # Server is shutting down — kill the child and let it go.
+        if proc.returncode is None:
+            proc.kill()
+        raise
+    finally:
+        _active_agents.pop(group_id, None)
+        logger.info(
+            "Reaped agent subprocess for group %s (exit code %s)",
+            group_id,
+            proc.returncode,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -94,26 +204,36 @@ async def create_room(group_id: str) -> dict[str, Any]:
                 raise
 
     # Generate a subscriber-only token for the call bot (no agent flag
-    # so it auto-subscribes to remote tracks for transcription)
+    # so it auto-subscribes to remote tracks for transcription).
+    # Use a 24h TTL so the bot never expires mid-call.
     bot_token = await _generate_token(
         room_name, "call-bot",
         can_publish=False,
         can_subscribe=True,
         is_admin=False,
+        ttl_seconds=86400,
     )
 
-    # Start the meeting notes agent as a background task
+    # Start the meeting notes agent as a managed subprocess so it does not
+    # block the server event loop with WebRTC / Deepgram STT processing.
     if group_id not in _active_agents:
-        from ee.cloud.livekit.agent import CallMeetingAgent
-        agent = CallMeetingAgent(
+        proc = await _spawn_agent_process(
             group_id=group_id,
             room_name=room_name,
             bot_token=bot_token,
-            livekit_url=LIVEKIT_URL,
         )
-        _active_agents[group_id] = agent
-        asyncio.create_task(agent.start())
-        logger.info("Started meeting agent for group %s (room %s)", group_id, room_name)
+        agent_ref = _SubprocessAgentRef(
+            group_id=group_id,
+            room_name=room_name,
+            process=proc,
+        )
+        _active_agents[group_id] = agent_ref
+
+        # Background task: wait for the subprocess to finish, then clean
+        # up the registry so we don't leak agent references.
+        asyncio.create_task(_reap_agent_process(group_id, proc))
+
+        logger.info("Started meeting agent subprocess for group %s (room %s)", group_id, room_name)
 
     return {
         "room_name": room_name,

--- a/ee/cloud/livekit/service.py
+++ b/ee/cloud/livekit/service.py
@@ -1,0 +1,376 @@
+"""LiveKit service — room management, token generation, call lifecycle.
+
+Uses the ``livekit-api`` Python SDK to talk to LiveKit Cloud.
+Requires ``LIVEKIT_URL``, ``LIVEKIT_API_KEY``, ``LIVEKIT_API_SECRET``
+environment variables.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from livekit.api import AccessToken, LiveKitAPI, VideoGrants
+from livekit.protocol.room import (
+    CreateRoomRequest,
+    DeleteRoomRequest,
+    ListParticipantsRequest,
+    ListRoomsRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Active meeting agents registry
+# ---------------------------------------------------------------------------
+
+_active_agents: dict[str, "CallMeetingAgent"] = {}
+
+def _get_agent(group_id: str) -> "CallMeetingAgent | None":
+    """Get the active meeting agent for a group, if any."""
+    return _active_agents.get(group_id)
+
+# ---------------------------------------------------------------------------
+# Configuration — read from environment
+# ---------------------------------------------------------------------------
+
+LIVEKIT_URL = os.environ.get("LIVEKIT_URL", "")
+LIVEKIT_API_KEY = os.environ.get("LIVEKIT_API_KEY", "")
+LIVEKIT_API_SECRET = os.environ.get("LIVEKIT_API_SECRET", "")
+
+# System agent used for bot posting
+CALL_BOT_USER_ID = "__livekit_call_bot__"
+
+
+def _ensure_configured() -> None:
+    """Raise if LiveKit credentials are missing."""
+    if not LIVEKIT_URL or not LIVEKIT_API_KEY or not LIVEKIT_API_SECRET:
+        raise RuntimeError(
+            "LiveKit is not configured. Set LIVEKIT_URL, LIVEKIT_API_KEY, "
+            "and LIVEKIT_API_SECRET environment variables."
+        )
+
+
+def room_name_for_group(group_id: str) -> str:
+    """Build a deterministic LiveKit room name for a group."""
+    return f"group-call-{group_id}"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def create_room(group_id: str) -> dict[str, Any]:
+    """Create a LiveKit room for a group call.
+
+    Returns room metadata including the room name and the admin token.
+    The room is named ``group-call-{group_id}`` for deterministic lookup.
+    Automatically starts the meeting notes agent for this room.
+    """
+    _ensure_configured()
+
+    room_name = room_name_for_group(group_id)
+
+    async with LiveKitAPI(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET) as lk:
+        try:
+            req = CreateRoomRequest(
+                name=room_name,
+                empty_timeout=5 * 60,
+                max_participants=50,
+            )
+            room = await lk.room.create_room(req)
+            logger.info("Created LiveKit room %s for group %s", room_name, group_id)
+        except Exception as exc:
+            msg = str(exc).lower()
+            # If room already exists, just return the existing one
+            if "already exists" in msg:
+                logger.info("LiveKit room %s already exists for group %s", room_name, group_id)
+            else:
+                logger.error("Failed to create LiveKit room: %s", exc)
+                raise
+
+    # Generate a subscriber-only token for the call bot (no agent flag
+    # so it auto-subscribes to remote tracks for transcription)
+    bot_token = await _generate_token(
+        room_name, "call-bot",
+        can_publish=False,
+        can_subscribe=True,
+        is_admin=False,
+    )
+
+    # Start the meeting notes agent as a background task
+    if group_id not in _active_agents:
+        from ee.cloud.livekit.agent import CallMeetingAgent
+        agent = CallMeetingAgent(
+            group_id=group_id,
+            room_name=room_name,
+            bot_token=bot_token,
+            livekit_url=LIVEKIT_URL,
+        )
+        _active_agents[group_id] = agent
+        asyncio.create_task(agent.start())
+        logger.info("Started meeting agent for group %s (room %s)", group_id, room_name)
+
+    return {
+        "room_name": room_name,
+        "group_id": group_id,
+        "url": LIVEKIT_URL,
+        "bot_token": bot_token,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+async def generate_participant_token(
+    room_name: str,
+    identity: str,
+    *,
+    can_publish: bool = True,
+    can_subscribe: bool = True,
+    ttl_seconds: int = 3600,
+) -> str:
+    """Generate a LiveKit access token for a participant.
+
+    Args:
+        room_name: The LiveKit room name.
+        identity: Participant identity (usually user ID).
+        can_publish: Whether the participant can publish audio/video.
+        can_subscribe: Whether the participant can subscribe to others.
+        ttl_seconds: Token time-to-live.
+
+    Returns:
+        A JWT token string for connecting to LiveKit.
+    """
+    _ensure_configured()
+    return await _generate_token(
+        room_name,
+        identity,
+        can_publish=can_publish,
+        can_subscribe=can_subscribe,
+        ttl_seconds=ttl_seconds,
+    )
+
+
+async def end_room(group_id: str) -> dict[str, Any]:
+    """End an active call by deleting the LiveKit room.
+
+    When the room is deleted, all participants are disconnected and the
+    call bot's cleanup logic (posting meeting notes) is triggered.
+    """
+    _ensure_configured()
+
+    room_name = room_name_for_group(group_id)
+
+    # Stop the meeting agent first (generates and posts notes)
+    agent = _active_agents.pop(group_id, None)
+    if agent is not None:
+        try:
+            await agent.stop()
+            logger.info("Stopped meeting agent for group %s", group_id)
+        except Exception as exc:
+            logger.warning("Error stopping meeting agent for group %s: %s", group_id, exc)
+
+    async with LiveKitAPI(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET) as lk:
+        try:
+            req = DeleteRoomRequest(room=room_name)
+            await lk.room.delete_room(req)
+            logger.info("Deleted LiveKit room %s for group %s", room_name, group_id)
+        except Exception as exc:
+            msg = str(exc).lower()
+            if "not found" in msg or "does not exist" in msg:
+                logger.warning("LiveKit room %s not found (already deleted)", room_name)
+            else:
+                logger.error("Failed to delete LiveKit room: %s", exc)
+                raise
+
+    return {
+        "room_name": room_name,
+        "group_id": group_id,
+        "ended_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+async def get_room_info(group_id: str) -> dict[str, Any] | None:
+    """Get the current state of a LiveKit room.
+
+    Returns None if the room doesn't exist (no active call).
+    """
+    _ensure_configured()
+
+    room_name = room_name_for_group(group_id)
+
+    async with LiveKitAPI(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET) as lk:
+        try:
+            list_req = ListRoomsRequest(names=[room_name])
+            list_resp = await lk.room.list_rooms(list_req)
+            if not list_resp.rooms:
+                return None
+
+            parts_req = ListParticipantsRequest(room=room_name)
+            parts_resp = await lk.room.list_participants(parts_req)
+            participants = parts_resp.participants
+
+            return {
+                "room_name": room_name,
+                "group_id": group_id,
+                "participant_count": len(participants),
+                "participants": [
+                    {
+                        "identity": p.identity,
+                        "name": p.name or p.identity,
+                        "joined_at": _format_joined_at(p.joined_at),
+                        "kind": str(p.kind),
+                    }
+                    for p in participants
+                ],
+                "active": True,
+            }
+        except Exception as exc:
+            msg = str(exc).lower()
+            if "not found" in msg or "does not exist" in msg:
+                return None
+            logger.error("Failed to get room info: %s", exc)
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Meeting notes — called by the agent after call ends
+# ---------------------------------------------------------------------------
+
+
+async def post_meeting_notes_to_group(
+    group_id: str,
+    transcript: str,
+    summary: str,
+    action_items: list[str],
+    participants: list[str],
+    duration_seconds: int,
+) -> None:
+    """Post meeting notes to a group after a call ends.
+
+    Creates a system message directly (bypassing membership check since the
+    call-bot is not a group member) and emits a real-time event so all
+    group members see it.
+    """
+    lines = [
+        "📋 **Meeting Notes**",
+        "",
+        f"**Duration:** {_format_duration(duration_seconds)}",
+        f"**Participants:** {', '.join(participants) if participants else 'N/A'}",
+        "",
+        "**Summary:**",
+        summary,
+    ]
+
+    if action_items:
+        lines.append("")
+        lines.append("**Action Items:**")
+        for i, item in enumerate(action_items, 1):
+            lines.append(f"{i}. {item}")
+
+    if transcript:
+        lines.append("")
+        lines.append("**Transcript:**")
+        # Truncate transcript to stay within message limits
+        max_transcript_len = 4000
+        transcript_preview = transcript[:max_transcript_len]
+        if len(transcript) > max_transcript_len:
+            transcript_preview += "\n\n*(transcript truncated)*"
+        lines.append(f"```\n{transcript_preview}\n```")
+
+    content = "\n".join(lines)
+
+    try:
+        # Use direct message creation to bypass membership check
+        from ee.cloud.chat.message_service import _create_group_message_doc
+        from ee.cloud.shared.events import event_bus
+        from datetime import datetime, timezone
+
+        domain_msg = await _create_group_message_doc(
+            group_id=group_id,
+            sender=CALL_BOT_USER_ID,
+            sender_type="user",
+            content=content,
+        )
+        await event_bus.emit(
+            "message.sent",
+            {
+                "group_id": group_id,
+                "message_id": domain_msg.id,
+                "sender_id": CALL_BOT_USER_ID,
+                "sender_type": "user",
+                "content": content,
+                "mentions": [],
+            },
+        )
+        logger.info("Posted meeting notes to group %s (message %s)", group_id, domain_msg.id)
+    except Exception as exc:
+        logger.error("Failed to post meeting notes to group %s: %s", group_id, exc)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+async def _generate_token(
+    room_name: str,
+    identity: str,
+    *,
+    can_publish: bool = True,
+    can_subscribe: bool = True,
+    is_admin: bool = False,
+    ttl_seconds: int = 3600,
+) -> str:
+    """Internal: generate a LiveKit access token."""
+    grants = VideoGrants(
+        room_join=True,
+        room=room_name,
+        can_publish=can_publish,
+        can_subscribe=can_subscribe,
+        can_publish_sources=["microphone", "camera", "screen_share"] if can_publish else None,
+        can_update_own_metadata=True,
+        agent=is_admin or None,
+    )
+
+    token = (
+        AccessToken(LIVEKIT_API_KEY, LIVEKIT_API_SECRET)
+        .with_identity(identity)
+        .with_ttl(timedelta(seconds=ttl_seconds))
+        .with_grants(grants)
+        .with_name(identity)
+    )
+
+    jwt = token.to_jwt()
+    return jwt
+
+
+def _format_duration(seconds: int) -> str:
+    """Format seconds into a human-readable duration string."""
+    minutes, secs = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}h {minutes}m {secs}s"
+    elif minutes:
+        return f"{minutes}m {secs}s"
+    else:
+        return f"{secs}s"
+
+
+def _format_joined_at(joined_at: Any) -> str | None:
+    """Format a LiveKit participant's joined_at timestamp to ISO string.
+
+    The livekit-api may return joined_at as a protobuf Timestamp (with
+    ``ToDatetime()``) or as a plain Unix timestamp (int/float).  Handle both.
+    """
+    if joined_at is None:
+        return None
+    if hasattr(joined_at, "ToDatetime"):
+        return joined_at.ToDatetime().isoformat()
+    if isinstance(joined_at, (int, float)):
+        return datetime.fromtimestamp(joined_at, tz=timezone.utc).isoformat()
+    return str(joined_at)

--- a/ee/cloud/livekit/service.py
+++ b/ee/cloud/livekit/service.py
@@ -128,6 +128,7 @@ async def generate_participant_token(
     room_name: str,
     identity: str,
     *,
+    name: str | None = None,
     can_publish: bool = True,
     can_subscribe: bool = True,
     ttl_seconds: int = 3600,
@@ -137,6 +138,7 @@ async def generate_participant_token(
     Args:
         room_name: The LiveKit room name.
         identity: Participant identity (usually user ID).
+        name: Display name to show to other participants. Falls back to identity.
         can_publish: Whether the participant can publish audio/video.
         can_subscribe: Whether the participant can subscribe to others.
         ttl_seconds: Token time-to-live.
@@ -148,6 +150,7 @@ async def generate_participant_token(
     return await _generate_token(
         room_name,
         identity,
+        name=name,
         can_publish=can_publish,
         can_subscribe=can_subscribe,
         ttl_seconds=ttl_seconds,
@@ -321,6 +324,7 @@ async def _generate_token(
     room_name: str,
     identity: str,
     *,
+    name: str | None = None,
     can_publish: bool = True,
     can_subscribe: bool = True,
     is_admin: bool = False,
@@ -337,12 +341,15 @@ async def _generate_token(
         agent=is_admin or None,
     )
 
+    # Use the provided display name, falling back to the identity (user ID)
+    display_name = name or identity
+
     token = (
         AccessToken(LIVEKIT_API_KEY, LIVEKIT_API_SECRET)
         .with_identity(identity)
         .with_ttl(timedelta(seconds=ttl_seconds))
         .with_grants(grants)
-        .with_name(identity)
+        .with_name(display_name)
     )
 
     jwt = token.to_jwt()

--- a/ee/cloud/livekit/types.py
+++ b/ee/cloud/livekit/types.py
@@ -1,0 +1,25 @@
+"""Shared types for the LiveKit calling module.
+
+Holds the ``MeetingAgentProtocol`` that both ``service.py`` and
+``agent.py`` refer to, breaking the circular import between them.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class MeetingAgentProtocol(Protocol):
+    """Minimal interface the LiveKit service needs from a meeting agent.
+
+    ``service.py`` stores agents in ``_active_agents`` and calls
+    ``start()`` / ``stop()`` on them.  The protocol avoids importing
+    ``CallMeetingAgent`` directly from ``agent.py``.
+    """
+
+    group_id: str
+    room_name: str
+
+    async def start(self) -> None: ...
+    async def stop(self) -> None: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ dependencies = [
     # Promoted from optional extra to base dep in v0.3.1 integration work;
     # the runtime now takes a hard dependency on the journal primitives.
     "soul-protocol[engine]>=0.3.1",
+    "livekit-agents[codecs]>=1.5.9",
+    "livekit-plugins-deepgram>=1.5.9",
 ]
 
 [project.optional-dependencies]

--- a/src/pocketpaw/__main__.py
+++ b/src/pocketpaw/__main__.py
@@ -381,8 +381,10 @@ def _serve(
     The probe binds to the same host the server will use, fixing the
     0.0.0.0 vs 127.0.0.1 mismatch. Scanning starts from the requested port,
     not from 8000, so fallback is always requested+N.
-    SO_REUSEADDR is deliberately not set on the probe socket so that
-    ports in TIME_WAIT are detected as busy and not handed to the server.
+    SO_REUSEADDR is set on the probe socket so it mirrors uvicorn's
+    behaviour — uvicorn sets SO_REUSEADDR on its own socket, so the probe
+    must do the same to correctly detect ports briefly held in TIME_WAIT
+    after a clean shutdown as available rather than skipping them.
     """
 
     import errno as _errno
@@ -390,10 +392,12 @@ def _serve(
 
     current_port = port
     for attempt in range(max_attempts):
-        # Best-effort probe using same host the server will bind to
+        # Best-effort probe using same host the server will bind to.
+        # SO_REUSEADDR mirrors uvicorn's default so that TIME_WAIT ports
+        # (briefly held after a clean Ctrl+C shutdown) are correctly
+        # detected as available and not skipped to port+1.
         with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as s:
-            # Do NOT set SO_REUSEADDR here — we want the probe to fail on
-            # ports in TIME_WAIT so we don't hand a busy port to the server.
+            s.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
             try:
                 s.bind((host, current_port))
             except OSError:

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -162,6 +162,11 @@ class AgentPool:
             try:
                 ctx = await instance.soul_manager.bootstrap_provider.get_context()
                 system_prompt = ctx.identity
+                # Append soul-level knowledge (semantic memories, bond info, etc.)
+                # into the identity block so the agent carries persistent context.
+                if ctx.knowledge:
+                    knowledge_lines = "\n".join(f"- {k}" for k in ctx.knowledge)
+                    system_prompt = f"{system_prompt}\n\n# Key Knowledge\n{knowledge_lines}"
             except Exception:
                 logger.warning("Failed to build soul prompt for agent %s", agent_id)
 

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -176,6 +176,32 @@ class AgentPool:
         if instructions:
             system_prompt = f"{system_prompt}\n\n{instructions}" if system_prompt else instructions
 
+        # Query-specific soul memory recall — inject relevant past interactions
+        # so the agent can reference cross-session memories. This complements
+        # the general semantic facts already injected by SoulBootstrapProvider.
+        if instance.soul_manager and instance.soul_manager.soul and message.strip():
+            try:
+                soul_ctx = await instance.soul_manager.soul.context_for(
+                    message,
+                    max_memories=5,
+                    include_state=False,
+                    include_self_model=False,
+                )
+                if soul_ctx:
+                    memory_block = (
+                        "## Relevant Past Memories\n"
+                        "Below are memories from previous conversations that "
+                        "are relevant to the current question. Use them to "
+                        "provide continuity and a personalized response.\n\n"
+                        f"{soul_ctx}"
+                    )
+                    if system_prompt:
+                        system_prompt = f"{system_prompt}\n\n{memory_block}"
+                    else:
+                        system_prompt = memory_block
+            except Exception:
+                logger.debug("Soul context_for() failed for agent %s", agent_id)
+
         # Inject knowledge context directly into system prompt
         if knowledge_context:
             system_prompt = (

--- a/src/pocketpaw/soul/_bridge.py
+++ b/src/pocketpaw/soul/_bridge.py
@@ -5,12 +5,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from pocketpaw.bootstrap.protocol import BootstrapContext
 
 if TYPE_CHECKING:
     from soul_protocol import Soul
+
+logger = logging.getLogger(__name__)
 
 
 class SoulBootstrapProvider:
@@ -76,6 +79,22 @@ class SoulBootstrapProvider:
                 knowledge.append(f"Memories: {soul.memory_count}")
             except Exception:
                 pass
+
+        # Cross-session soul memory — inject general semantic facts the soul has
+        # learned so the agent carries persistent context across chat sessions.
+        try:
+            from soul_protocol import MemoryType
+
+            semantic_memories = await soul.recall(
+                query="",
+                types=[MemoryType.SEMANTIC],
+                limit=5,
+            )
+            if semantic_memories:
+                for m in semantic_memories:
+                    knowledge.append(f"[{m.type.value}] {m.content}")
+        except Exception:
+            logger.debug("Soul semantic recall failed for bootstrap context", exc_info=True)
 
         return BootstrapContext(
             name=soul.name if hasattr(soul, "name") else "Paw",

--- a/tests/test_livekit_service.py
+++ b/tests/test_livekit_service.py
@@ -1,0 +1,349 @@
+"""Tests for the LiveKit call service."""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ee.cloud.livekit.service import (
+    LIVEKIT_URL,
+    CALL_BOT_USER_ID,
+    room_name_for_group,
+    _format_duration,
+    _active_agents,
+)
+
+
+class TestRoomNameForGroup:
+    def test_generates_deterministic_name(self):
+        name = room_name_for_group("abc123")
+        assert name == "group-call-abc123"
+
+    def test_uses_group_id(self):
+        name = room_name_for_group("group_xyz")
+        assert "group_xyz" in name
+
+
+class TestFormatDuration:
+    def test_seconds_only(self):
+        assert _format_duration(30) == "30s"
+
+    def test_minutes_and_seconds(self):
+        assert _format_duration(125) == "2m 5s"
+
+    def test_hours_minutes_seconds(self):
+        assert _format_duration(3661) == "1h 1m 1s"
+
+    def test_zero(self):
+        assert _format_duration(0) == "0s"
+
+
+class TestService:
+    """Tests for LiveKit service functions (with mocked LiveKitAPI)."""
+
+    @pytest.fixture
+    def mock_lk_context(self):
+        """Mock the LiveKitAPI async context manager at the import site.
+
+        This prevents actual HTTP calls by replacing LiveKitAPI with a
+        MagicMock that never makes real requests.
+        """
+        # Clean up any agents from previous tests
+        _active_agents.clear()
+
+        # Create the inner 'room' service mock
+        mock_room_svc = MagicMock()
+
+        # Create the LiveKitAPI instance mock
+        mock_api_instance = MagicMock()
+        mock_api_instance.room = mock_room_svc
+        mock_api_instance.__aenter__ = AsyncMock(return_value=mock_api_instance)
+        mock_api_instance.__aexit__ = AsyncMock(return_value=False)
+
+        # Patch at the import site in the service module
+        patcher = patch("ee.cloud.livekit.service.LiveKitAPI", return_value=mock_api_instance)
+        patcher.start()
+
+        yield mock_room_svc
+
+        # Clean up any agents created during the test
+        _active_agents.clear()
+        patcher.stop()
+
+    @pytest.mark.asyncio
+    @patch("ee.cloud.livekit.service.LIVEKIT_URL", "wss://test.livekit.cloud")
+    @patch("ee.cloud.livekit.service.LIVEKIT_API_KEY", "test-key")
+    @patch("ee.cloud.livekit.service.LIVEKIT_API_SECRET", "test-secret")
+    async def test_create_room(self, mock_lk_context):
+        from ee.cloud.livekit.service import create_room
+
+        mock_room = MagicMock()
+        mock_room.name = "group-call-test123"
+        mock_lk_context.create_room = AsyncMock(return_value=mock_room)
+
+        result = await create_room("test123")
+
+        assert result["room_name"] == "group-call-test123"
+        assert result["group_id"] == "test123"
+        assert result["url"] == "wss://test.livekit.cloud"
+        assert "bot_token" in result
+        mock_lk_context.create_room.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("ee.cloud.livekit.service.LIVEKIT_URL", "wss://test.livekit.cloud")
+    @patch("ee.cloud.livekit.service.LIVEKIT_API_KEY", "test-key")
+    @patch("ee.cloud.livekit.service.LIVEKIT_API_SECRET", "test-secret")
+    async def test_generate_participant_token(self):
+        from ee.cloud.livekit.service import generate_participant_token
+
+        token = await generate_participant_token(
+            room_name="group-call-test123",
+            identity="user_abc",
+        )
+
+        assert isinstance(token, str)
+        assert len(token) > 0
+
+    @pytest.mark.asyncio
+    @patch("ee.cloud.livekit.service.LIVEKIT_URL", "wss://test.livekit.cloud")
+    @patch("ee.cloud.livekit.service.LIVEKIT_API_KEY", "test-key")
+    @patch("ee.cloud.livekit.service.LIVEKIT_API_SECRET", "test-secret")
+    async def test_end_room(self, mock_lk_context):
+        from ee.cloud.livekit.service import end_room
+
+        mock_lk_context.delete_room = AsyncMock()
+
+        result = await end_room("test123")
+
+        assert result["room_name"] == "group-call-test123"
+        assert result["group_id"] == "test123"
+        assert "ended_at" in result
+        mock_lk_context.delete_room.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("ee.cloud.livekit.service.LIVEKIT_URL", "wss://test.livekit.cloud")
+    @patch("ee.cloud.livekit.service.LIVEKIT_API_KEY", "test-key")
+    @patch("ee.cloud.livekit.service.LIVEKIT_API_SECRET", "test-secret")
+    async def test_get_room_info_no_room(self, mock_lk_context):
+        from ee.cloud.livekit.service import get_room_info
+
+        # Room list returns empty
+        mock_list_resp = MagicMock()
+        mock_list_resp.rooms = []
+        mock_lk_context.list_rooms = AsyncMock(return_value=mock_list_resp)
+
+        result = await get_room_info("test123")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    @patch("ee.cloud.livekit.service.LIVEKIT_URL", "wss://test.livekit.cloud")
+    @patch("ee.cloud.livekit.service.LIVEKIT_API_KEY", "test-key")
+    @patch("ee.cloud.livekit.service.LIVEKIT_API_SECRET", "test-secret")
+    async def test_get_room_info_with_participants(self, mock_lk_context):
+        from ee.cloud.livekit.service import get_room_info
+
+        # Mock room list response with one room
+        mock_room = MagicMock()
+        mock_room.name = "group-call-test123"
+        mock_list_resp = MagicMock()
+        mock_list_resp.rooms = [mock_room]
+        mock_lk_context.list_rooms = AsyncMock(return_value=mock_list_resp)
+
+        # Mock participant list response
+        mock_participant = MagicMock()
+        mock_participant.identity = "user_abc"
+        mock_participant.name = "Test User"
+        mock_participant.kind = 0
+        mock_participant.joined_at = None
+        mock_parts_resp = MagicMock()
+        mock_parts_resp.participants = [mock_participant]
+        mock_lk_context.list_participants = AsyncMock(return_value=mock_parts_resp)
+
+        result = await get_room_info("test123")
+
+        assert result is not None
+        assert result["active"] is True
+        assert result["participant_count"] == 1
+        assert result["participants"][0]["identity"] == "user_abc"
+
+    @pytest.mark.asyncio
+    @patch("ee.cloud.livekit.service.LIVEKIT_URL", "wss://test.livekit.cloud")
+    @patch("ee.cloud.livekit.service.LIVEKIT_API_KEY", "test-key")
+    @patch("ee.cloud.livekit.service.LIVEKIT_API_SECRET", "test-secret")
+    async def test_not_configured_raises(self):
+        from ee.cloud.livekit.service import create_room
+
+        with patch("ee.cloud.livekit.service.LIVEKIT_URL", ""):
+            with pytest.raises(RuntimeError, match="LiveKit is not configured"):
+                await create_room("test123")
+
+
+class TestMeetingNotesAgent:
+    """Tests for the CallMeetingAgent functionality."""
+
+    @pytest.mark.asyncio
+    @patch("ee.cloud.livekit.agent.CallMeetingAgent._finalize_notes", new_callable=AsyncMock)
+    async def test_stop_generates_notes(self, mock_finalize):
+        from ee.cloud.livekit.agent import CallMeetingAgent
+
+        agent = CallMeetingAgent(
+            group_id="test123",
+            room_name="group-call-test123",
+            bot_token="test-token",
+        )
+
+        await agent.stop()
+
+        mock_finalize.assert_called_once()
+
+    def test_add_transcript_segment(self):
+        from ee.cloud.livekit.agent import CallMeetingAgent
+
+        agent = CallMeetingAgent(
+            group_id="test123",
+            room_name="group-call-test123",
+            bot_token="test-token",
+        )
+
+        agent.add_transcript_segment("Alice", "Hello everyone")
+        agent.add_transcript_segment("Bob", "Hi Alice")
+
+        assert len(agent.transcript_segments) == 2
+        assert agent.transcript_segments[0]["speaker"] == "Alice"
+        assert agent.transcript_segments[1]["text"] == "Hi Alice"
+
+    def test_parse_summary_json(self):
+        from ee.cloud.livekit.agent import CallMeetingAgent
+
+        agent = CallMeetingAgent(
+            group_id="test123",
+            room_name="group-call-test123",
+            bot_token="test-token",
+        )
+
+        content = '{"summary": "We discussed X", "action_items": ["Do Y", "Do Z"]}'
+        summary, items = agent._parse_summary_json(content)
+
+        assert summary == "We discussed X"
+        assert items == ["Do Y", "Do Z"]
+
+    def test_parse_summary_json_markdown_block(self):
+        from ee.cloud.livekit.agent import CallMeetingAgent
+
+        agent = CallMeetingAgent(
+            group_id="test123",
+            room_name="group-call-test123",
+            bot_token="test-token",
+        )
+
+        content = '```json\n{"summary": "Summary", "action_items": ["Item 1"]}\n```'
+        summary, items = agent._parse_summary_json(content)
+
+        assert summary == "Summary"
+        assert items == ["Item 1"]
+
+    def test_parse_summary_json_fallback(self):
+        from ee.cloud.livekit.agent import CallMeetingAgent
+
+        agent = CallMeetingAgent(
+            group_id="test123",
+            room_name="group-call-test123",
+            bot_token="test-token",
+        )
+
+        content = "Plain text summary with no JSON structure"
+        summary, items = agent._parse_summary_json(content)
+
+        assert summary == content
+        assert items == []
+
+    def test_heuristic_summary(self):
+        from ee.cloud.livekit.agent import CallMeetingAgent
+
+        agent = CallMeetingAgent(
+            group_id="test123",
+            room_name="group-call-test123",
+            bot_token="test-token",
+        )
+
+        transcript = "Line 1\nLine 2\nLine 3"
+        summary, items = agent._summarize_heuristic(transcript)
+
+        assert "Line 1" in summary
+        assert items == []
+
+
+class TestMeetingNotesPosting:
+    """Tests for posting meeting notes to groups."""
+
+    @pytest.mark.asyncio
+    async def test_post_meeting_notes(self):
+        from ee.cloud.livekit.service import post_meeting_notes_to_group
+
+        with (
+            patch(
+                "ee.cloud.chat.message_service._create_group_message_doc",
+                new_callable=AsyncMock,
+            ) as mock_create,
+            patch(
+                "ee.cloud.shared.events.event_bus.emit",
+                new_callable=AsyncMock,
+            ) as mock_emit,
+        ):
+            mock_create.return_value.id = "msg_123"
+
+            await post_meeting_notes_to_group(
+                group_id="test123",
+                transcript="Hello world",
+                summary="A summary",
+                action_items=["Item 1"],
+                participants=["Alice"],
+                duration_seconds=120,
+            )
+
+            mock_create.assert_called_once()
+            assert mock_create.call_args[1]["group_id"] == "test123"
+            assert "Meeting Notes" in mock_create.call_args[1]["content"]
+            assert "A summary" in mock_create.call_args[1]["content"]
+            assert "Item 1" in mock_create.call_args[1]["content"]
+            mock_emit.assert_called_once_with(
+                "message.sent",
+                {
+                    "group_id": "test123",
+                    "message_id": "msg_123",
+                    "sender_id": CALL_BOT_USER_ID,
+                    "sender_type": "user",
+                    "content": mock_create.call_args[1]["content"],
+                    "mentions": [],
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_post_meeting_notes_empty_transcript(self):
+        from ee.cloud.livekit.service import post_meeting_notes_to_group
+
+        with (
+            patch(
+                "ee.cloud.chat.message_service._create_group_message_doc",
+                new_callable=AsyncMock,
+            ) as mock_create,
+            patch(
+                "ee.cloud.shared.events.event_bus.emit",
+                new_callable=AsyncMock,
+            ) as mock_emit,
+        ):
+            mock_create.return_value.id = "msg_456"
+
+            await post_meeting_notes_to_group(
+                group_id="test123",
+                transcript="",
+                summary="No speech detected.",
+                action_items=[],
+                participants=[],
+                duration_seconds=30,
+            )
+
+            mock_create.assert_called_once()
+            assert "No speech detected" in mock_create.call_args[1]["content"]
+            mock_emit.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Adds LiveKit Cloud call management API for real-time voice/video calls and enhances Soul Protocol memory recall so agents retain cross-session context.

**LiveKit Call Management API:**
- REST endpoints to create rooms, generate participant tokens, retrieve room status, and end calls
- Meeting notes agent that transcribes calls and posts summaries/action items to group chats
- Participant display names so users see real names instead of IDs

**Soul Memory Recall:**
- Injects Soul Protocol's episodic and semantic memories into the agent's system prompt so the agent can recall past conversations across different chat sessions, instead of starting from a blank slate every time.

## Related Issue

Fixes #1111 #1126 

## Changes Made

### LiveKit Call API
- `ee/cloud/livekit/__init__.py`: Package init
- `ee/cloud/livekit/service.py`: Room management, token generation, room deletion via LiveKit API
- `ee/cloud/livekit/router.py`: FastAPI router with create_room, generate_token, get_room_info, end_call endpoints
- `ee/cloud/livekit/agent.py`: CallMeetingAgent that transcribes calls and posts meeting notes
- `tests/test_livekit_service.py`: Tests for room creation, token generation, and meeting notes

### Soul Memory Recall
- `src/pocketpaw/soul/_bridge.py`: Added soul.recall() call in SoulBootstrapProvider.get_context() to inject general semantic facts the soul has learned into the knowledge list
- `src/pocketpaw/agents/pool.py`: Added soul.context_for(message) call in AgentPool.run() for query-specific memories per turn

## How to Test

### Soul Memory Recall
1. Have a conversation with an agent in a pocket/chat (e.g. "Remember that I use Python 3.12 and work on backend projects")
2. Start a new chat session with the same agent
3. Ask "What did I tell you about my Python setup?" — the agent should recall the fact

### LiveKit API
1. Ensure LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET are set
2. POST /api/v1/livekit/rooms with {"group_id": "test-group"} to create a room
3. POST /api/v1/livekit/token with {"room_name": "...", "identity": "user-id"} to get a token
4. Use the token to connect via LiveKit SDK and join the call

## Evidence of Testing

<img width="600" height="461" alt="image" src="https://github.com/user-attachments/assets/af398aa5-ba46-40f5-9997-3b9ffdea2ea0" />
<img width="600" height="483" alt="image" src="https://github.com/user-attachments/assets/d7212a20-fd43-4ecb-ae59-9af46008e328" />


## Checklist

- [x] PR targets `ee` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff