### PR TITLE
feat(cloud): Projects entity + snapshot scheduler for Mission Control

### DIFF
--- a/docs/advanced/mission-control-cloud.mdx
+++ b/docs/advanced/mission-control-cloud.mdx
@@ -1,0 +1,167 @@
+---
+title: "Mission Control (Cloud): operator console for the SaaS surface"
+description: "Mission Control (Cloud) is the operator console for the PocketPaw enterprise cloud — Tray, Pawprints, Snags, Projects, Cycles. Workspace-scoped REST API + SSE event stream, backed by MongoDB."
+section: Advanced
+ogType: article
+keywords: ["mission control", "cloud", "saas", "operator console", "tray", "pawprints", "cycles", "projects"]
+tags: ["advanced", "cloud", "saas", "operator"]
+---
+
+# Mission Control (Cloud)
+
+<Callout type="info">
+**Different surface from the local Mission Control.** The page at [/advanced/mission-control](/advanced/mission-control) describes the *local multi-agent orchestration framework* — file-based JSON storage at `~/.pocketpaw/mission_control/`, single-process, used by Deep Work and CLI tooling.
+
+This page describes the **cloud SaaS surface**: workspace-scoped REST API + MongoDB-backed entities, served by the enterprise dashboard at `pocketpaw/ee/cloud/`. The two surfaces share a name (and a mental model) but no code paths.
+</Callout>
+
+Mission Control (Cloud) is the operator console for the PocketPaw enterprise cloud. It projects every kind of work the operator can see — Nudges waiting for approval, Tasks in flight, Cycles in progress, Pawprints already shipped — into a unified work-item feed, scoped to the active workspace.
+
+## Vocabulary
+
+| Term | Meaning |
+|------|---------|
+| **Tray** | Items awaiting human approval (Nudges from Instinct). |
+| **Pawprints** | Items already approved, rejected, or executed (audit projection). |
+| **Snags** | Items that failed or are blocked — recoverable. |
+| **Agents** | Tasks currently in flight, claimed by an agent runtime. |
+| **Cycle** | A time-boxed work window — Linear-style. Carries a burnup chart fed by the daily snapshot job. |
+| **Project** | A workspace-scoped grouping of pockets, tasks, and cycles. Optional reference everywhere. |
+| **Pocket** | The canvas / workspace surface. Pockets live inside a workspace and optionally inside a Project. |
+| **Nudge** | A pending action proposed by Instinct, surfaced in the Tray for human approval. |
+
+## Hierarchy
+
+```
+Workspace
+  └── Project (optional)
+        └── Pocket
+              └── Cycle (optional, pocket-scoped)
+              └── Task (optional, can attach to Project, Pocket, Cycle, or none)
+```
+
+Every level except the workspace is optional. A task created without a `project_id`, `pocket_id`, or `cycle_id` lands in the workspace-wide "unassigned" bucket and still shows up in Mission Control. The frontend rolls items up into project / cycle / pocket buckets as the operator drills down.
+
+## WorkItem shape
+
+`GET /api/v1/mission-control/items` returns a list of `WorkItem` records — the unified projection over Instinct nudges + the Tasks entity. Every entry carries:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string | Prefixed: `nudge:<action_id>` or `task:<task_id>`. |
+| `workspace_id` | string | Always the caller's active workspace. |
+| `section` | enum | `tray` / `pawprints` / `snags` / `agents`. |
+| `status` | enum | `awaiting_approval` / `approved` / `rejected` / `in_progress` / `done` / `blocked` / `failed`. |
+| `title` | string | The headline shown in the feed row. |
+| `description` | string | Subtitle / recommendation text. |
+| `assignee_kind` | enum | `user` or `agent`. |
+| `assignee_id` | string | Workspace member id or agent runtime id. |
+| `pocket_id` | string \| null | The pocket the work attaches to (if any). |
+| `agent_id` | string \| null | The agent runtime that proposed / picked up the work. |
+| `source_kind` | string | `nudge` (Instinct) or `task` (Tasks entity). |
+| `source_id` | string | The id in the source store, without the prefix. |
+| `priority` | string | `low` / `normal` / `high` / `urgent` (Tasks) or `low` / `medium` / `high` / `critical` (Instinct). |
+| `created_at`, `updated_at` | datetime | UTC ISO-8601. |
+| `fabric_refs` | string[] | Fabric object ids linked from the source. |
+
+## REST endpoints
+
+All routes are mounted at `/api/v1/` and require Bearer auth + an active workspace. Errors flow as `CloudError` JSON envelopes (`{"error": {"code": ..., "message": ...}}`), never raw `HTTPException`.
+
+### Mission Control façade
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/mission-control/items` | List work items. Query: `section`, `agent`, `pocket`, `project_id`, `limit`. |
+| `POST` | `/mission-control/items/bulk-approve` | Approve N pending nudges. Body: `{ids, note?}`. |
+| `POST` | `/mission-control/items/bulk-reject` | Reject N pending nudges. Body: `{ids, reason}`. |
+| `POST` | `/mission-control/items/bulk-reassign` | Reassign N tasks. Body: `{ids, to: {kind, id, name?}}`. |
+| `POST` | `/mission-control/items/bulk-snooze` | Snooze N tasks. Body: `{ids, until_iso}`. |
+| `GET` | `/mission-control/outcomes` | Aggregated outcome counts. Query: `window` = `1h`/`24h`/`7d`. |
+| `GET` | `/mission-control/activity` | Live activity ticker. Query: `limit`. |
+
+### Tasks
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/tasks` | Create a task. |
+| `GET` | `/tasks` | List with filters: `assignee`, `assignee_kind`, `status`, `cycle_id`, `pocket_id`, `project_id`, `creator_id`, `limit`. |
+| `GET` | `/tasks/{id}` | Fetch one. |
+| `PATCH` | `/tasks/{id}` | Partial update. |
+| `POST` | `/tasks/{id}/claim` | Agent claims a `proposed` task. |
+| `POST` | `/tasks/{id}/complete` | Mark done or request approval. |
+| `POST` | `/tasks/{id}/block` | Pause with a reason (Snag). |
+| `POST` | `/tasks/{id}/reassign` | Hand off to another assignee. |
+
+### Cycles
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/cycles` | Create a cycle. |
+| `GET` | `/cycles` | List in the workspace. Query: `project_id`. |
+| `GET` | `/cycles/{id}` | Fetch one, including the daily burnup series. |
+| `PATCH` | `/cycles/{id}` | Edit metadata (upcoming cycles only for dates / name). |
+| `POST` | `/cycles/{id}/close` | Mark `completed`, roll incomplete tasks forward. |
+| `GET` | `/cycles/{id}/items` | List the tasks attached to this cycle. |
+| `POST` | `/cycles/{id}/snapshot` | Manually trigger today's snapshot. Idempotent. |
+
+### Projects
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/projects` | Create a project. |
+| `GET` | `/projects` | List. Query: `status` (`active` / `archived`), `limit`. |
+| `GET` | `/projects/{id}` | Fetch one. |
+| `PATCH` | `/projects/{id}` | Partial update (`name`, `description`, `color`, `lead_id`, `status`). |
+| `POST` | `/projects/{id}/archive` | Soft-archive. Idempotent. |
+| `DELETE` | `/projects/{id}` | Hard-delete + soft-unassign children. |
+
+### Cascade behaviour on project delete
+
+Deleting a project soft-unassigns every Pocket, Task, and Cycle in the workspace where `project_id` matches the deleted project. Children are **not** cascade-deleted — historical work stays alive. Each child entity's own `*.updated` event fires per row so downstream listeners (search index, Pawprints projection) stay consistent.
+
+## SSE event surface
+
+The enterprise dashboard subscribes to a WebSocket at `/ws/cloud?token=...` and receives the realtime event types listed below. Mission Control's frontend patches its store directly from these events rather than refetching after every mutation.
+
+| Event | Carrier of |
+|-------|------------|
+| `task.proposed` | New `proposed` task — feeds the Tray for human assignees and the Agents pane for agent assignees. |
+| `task.updated` | Any patch (assignee, priority, due_at, project_id, etc.). |
+| `task.claimed` | Atomic `proposed → in_progress` flip. |
+| `task.resolved` | `done` or `awaiting_approval`. |
+| `task.blocked` | `blocked` with a reason — surfaces in Snags. |
+| `cycle.created` / `cycle.updated` / `cycle.closed` | Cycle lifecycle. |
+| `cycle.snapshotted` | New daily point — feeds the burnup chart. |
+| `project.created` / `project.updated` / `project.archived` / `project.deleted` | Project lifecycle. |
+| `pocket.created` / `pocket.updated` / `pocket.deleted` | Canvas lifecycle. |
+
+The bus uses an audience resolver (`ee.cloud._core.realtime.audience.AudienceResolver`) so each event fans out to exactly the recipients allowed to see it — workspace members for project / cycle events; creator + human assignee for task events.
+
+## Scheduler wiring
+
+The Cycles tab's burnup chart is fed by `ee.cloud.cycles.snapshot_job`. The job appends one (scope, started, completed) data point per active cycle per UTC day. It's idempotent within a calendar day — a second call on the same day is a no-op.
+
+### In-process scheduler (opt-in)
+
+Set `POCKETPAW_CLOUD_SCHEDULER_ENABLED=true` to start an in-process `asyncio` loop at app boot. The loop sleeps until the next UTC midnight, then calls `snapshot_all_active` for every workspace that has at least one active cycle.
+
+```bash
+POCKETPAW_CLOUD_SCHEDULER_ENABLED=true uv run pocketpaw
+```
+
+Default is **off** so tests + dev shells don't spawn a perpetual background loop.
+
+### External scheduler (recommended for multi-instance deployments)
+
+Leave the in-process flag unset and dispatch `snapshot_all_active(workspace_id)` from your platform's scheduler — the same callable, same idempotency. The job module's docstring covers cron, Kubernetes CronJob, and Celery beat wiring patterns.
+
+### Manual trigger
+
+`POST /api/v1/cycles/{id}/snapshot` forces today's snapshot for one cycle. Useful for tests + intern-onboarding ("force a snapshot now to see the chart update"). Returns the newly-appended point on success, or `null` if today's point already existed.
+
+## See also
+
+- [Mission Control (local)](/advanced/mission-control) — the local Deep Work / orchestration framework.
+- [Pockets API](/api/get-pockets) — REST surface for the canvas entities.
+- [Deep Work](/advanced/deep-work) — the prep-and-execute pattern that drives Cycles.

--- a/docs/docs-config.json
+++ b/docs/docs-config.json
@@ -650,6 +650,11 @@
             "icon": "lucide:radar"
           },
           {
+            "label": "Mission Control (Cloud)",
+            "href": "/advanced/mission-control-cloud",
+            "icon": "lucide:cloud"
+          },
+          {
             "label": "Autonomous Messaging",
             "href": "/advanced/autonomous-messaging",
             "icon": "lucide:bell"

--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -1,5 +1,12 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Updated: 2026-05-16 — Mission Control backend completion. Mounts the
+    Projects entity (workspace > project > pocket/task/cycle hierarchy)
+    and wires the in-process daily-snapshot scheduler, gated on
+    ``POCKETPAW_CLOUD_SCHEDULER_ENABLED=true`` (default false). Each
+    child entity (Pocket / Task / Cycle) now carries an optional
+    ``project_id`` reference; project delete soft-unassigns rather than
+    cascading the underlying work.
 Updated: 2026-05-13 — Mission Control cleanup PR. Lifted the 501 stubs
     on Mission Control's bulk-reassign / bulk-snooze (they now delegate
     to the Tasks service), added emit-or-no-event comments to the bulk
@@ -98,6 +105,7 @@ def mount_cloud(app: FastAPI) -> None:
     from ee.cloud.cycles.router import router as cycles_router
     from ee.cloud.license import get_license_info
     from ee.cloud.pockets.router import router as pockets_router
+    from ee.cloud.projects.router import router as projects_router
     from ee.cloud.sessions.router import router as sessions_router
     from ee.cloud.workspace.router import router as workspace_router
 
@@ -107,6 +115,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(chat_router, prefix="/api/v1")
     app.include_router(connectors_router, prefix="/api/v1")
     app.include_router(pockets_router, prefix="/api/v1")
+    app.include_router(projects_router, prefix="/api/v1")
     app.include_router(sessions_router, prefix="/api/v1")
     app.include_router(cycles_router, prefix="/api/v1")
 
@@ -377,12 +386,29 @@ def mount_cloud(app: FastAPI) -> None:
 
     register_task_listeners()
 
-    # TODO: wire daily-snapshot scheduler — see ``ee.cloud.cycles.snapshot_job``
-    # for cron / Kubernetes CronJob / Celery beat wiring patterns. We
-    # deliberately do NOT spin up an in-process loop here; the host
-    # platform owns scheduling (its scheduler knows the tenant list and
-    # has the right retry / backoff semantics). Wiring lives in the
-    # deployment layer.
+    # In-process daily-snapshot scheduler — opt-in via env var.
+    #
+    # Default OFF in tests + dev (each pytest run would otherwise spawn a
+    # background loop that outlives the test). Production deployments set
+    # ``POCKETPAW_CLOUD_SCHEDULER_ENABLED=true`` to flip it on. Hosts that
+    # prefer external cron / Kubernetes CronJob / Celery beat (see the
+    # ``ee.cloud.cycles.snapshot_job`` docstring) leave the flag unset
+    # and dispatch the same ``snapshot_all_active`` callable from their
+    # platform scheduler.
+    import os as _os
+
+    if _os.environ.get("POCKETPAW_CLOUD_SCHEDULER_ENABLED", "").lower() == "true":
+        from ee.cloud.cycles.scheduler import start_in_process_scheduler
+
+        @app.on_event("startup")
+        async def _start_cycle_scheduler() -> None:
+            await start_in_process_scheduler(app)
+
+        @app.on_event("shutdown")
+        async def _stop_cycle_scheduler() -> None:
+            from ee.cloud.cycles.scheduler import stop_in_process_scheduler
+
+            await stop_in_process_scheduler(app)
 
     # Mission Control activity buffer — per-workspace ring buffer fed by
     # agent.* bus events. Same constraint as the upload listeners: subscribe

--- a/ee/cloud/_core/realtime/events.py
+++ b/ee/cloud/_core/realtime/events.py
@@ -364,3 +364,28 @@ class CycleClosed(Event):
 @dataclass
 class CycleSnapshotted(Event):
     EVENT_TYPE: ClassVar[str] = "cycle.snapshotted"
+
+
+# Projects — Linear-style scoping primitive for Mission Control.
+# Pocket, Task, and Cycle entities carry an optional ``project_id``
+# pointer; mutating a project doesn't cascade-delete its children, it
+# just soft-unassigns them. Listeners (search index, dashboards) use
+# these events to refresh project-grouped views.
+@dataclass
+class ProjectCreated(Event):
+    EVENT_TYPE: ClassVar[str] = "project.created"
+
+
+@dataclass
+class ProjectUpdated(Event):
+    EVENT_TYPE: ClassVar[str] = "project.updated"
+
+
+@dataclass
+class ProjectArchived(Event):
+    EVENT_TYPE: ClassVar[str] = "project.archived"
+
+
+@dataclass
+class ProjectDeleted(Event):
+    EVENT_TYPE: ClassVar[str] = "project.deleted"

--- a/ee/cloud/cycles/domain.py
+++ b/ee/cloud/cycles/domain.py
@@ -62,6 +62,7 @@ class Cycle:
     completed: int = 0
     daily: tuple[CycleDailyPoint, ...] = field(default_factory=tuple)
     created_by: str = ""
+    project_id: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/ee/cloud/cycles/dto.py
+++ b/ee/cloud/cycles/dto.py
@@ -35,6 +35,7 @@ class CreateCycleRequest(BaseModel):
     name: str = Field(min_length=1, max_length=200)
     description: str = ""
     pocket_id: str | None = None
+    project_id: str | None = None
     start: date
     end: date
     status: CycleStatusLiteral = "upcoming"
@@ -53,12 +54,16 @@ class UpdateCycleRequest(BaseModel):
     dates edited — the router enforces the status check via the service.
     Status transitions go through ``POST /cycles/{id}/close`` (or the
     snapshot job's auto-promote) rather than this PATCH endpoint.
+
+    ``project_id`` is editable on any status — moving an in-flight cycle
+    between projects is a low-risk operation (just a grouping change).
     """
 
     name: str | None = Field(default=None, min_length=1, max_length=200)
     description: str | None = None
     start: date | None = None
     end: date | None = None
+    project_id: str | None = None
 
     @model_validator(mode="after")
     def _check_dates(self) -> UpdateCycleRequest:
@@ -95,6 +100,7 @@ class CycleListItemResponse(BaseModel):
     name: str
     description: str
     pocket_id: str | None
+    project_id: str | None = None
     start: str  # ISO date
     end: str  # ISO date
     status: CycleStatusLiteral

--- a/ee/cloud/cycles/router.py
+++ b/ee/cloud/cycles/router.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from ee.cloud._core.context import RequestContext, request_context
 from ee.cloud.cycles import service as cycles_service
 from ee.cloud.cycles.dto import (
     CreateCycleRequest,
+    CycleDailyPointResponse,
     CycleListItemResponse,
     CycleResponse,
     UpdateCycleRequest,
@@ -34,9 +35,10 @@ async def create_cycle(
 
 @router.get("", response_model=list[CycleListItemResponse])
 async def list_cycles(
+    project_id: str | None = Query(default=None),
     ctx: RequestContext = Depends(request_context),
 ) -> list[CycleListItemResponse]:
-    return await cycles_service.agent_list_cycles(ctx)
+    return await cycles_service.agent_list_cycles(ctx, project_id=project_id)
 
 
 @router.get("/{cycle_id}", response_model=CycleResponse)
@@ -78,3 +80,33 @@ async def list_cycle_items(
     unchanged once PR 2 ships.
     """
     return await cycles_service.agent_list_cycle_items(ctx, cycle_id)
+
+
+@router.post("/{cycle_id}/snapshot", response_model=CycleDailyPointResponse | None)
+async def snapshot_cycle(
+    cycle_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> CycleDailyPointResponse | None:
+    """Manually trigger today's snapshot for one cycle.
+
+    Useful for tests + intern-onboarding ("force a snapshot now to see
+    the chart update"). Idempotent: if today's point already exists, the
+    response body is ``null`` and no new point is appended. Returns the
+    newly-appended point on success.
+
+    Returns 404 when the cycle doesn't exist in the caller's workspace
+    (the tenancy guard inside ``_snapshot_cycle_daily`` raises NotFound,
+    which ``_core.http`` maps to the JSON envelope).
+    """
+    point = await cycles_service._snapshot_cycle_daily(ctx, cycle_id)
+    # _snapshot_cycle_daily returns None for "already snapshotted today"
+    # OR for "tasks unavailable". The frontend treats both as benign no-ops.
+    if point is None:
+        # Verify the cycle existed (else _fetch_in_workspace would have
+        # raised NotFound). Re-fetch only to surface a clearer 404 on a
+        # missing/cross-tenant id; the cycle does exist if we got here.
+        return None
+    return point
+
+
+__all__ = ["router"]

--- a/ee/cloud/cycles/scheduler.py
+++ b/ee/cloud/cycles/scheduler.py
@@ -1,0 +1,117 @@
+# scheduler.py — opt-in in-process scheduler for the daily snapshot job.
+# Created: 2026-05-16 — Mission Control backend completion. Gated on
+#   ``POCKETPAW_CLOUD_SCHEDULER_ENABLED=true`` so test runs don't spawn a
+#   background loop. Deployments that prefer external cron (Kubernetes
+#   CronJob, Celery beat, OS cron) leave the flag unset and dispatch
+#   ``snapshot_all_active`` from their platform scheduler — same callable,
+#   same idempotency.
+"""In-process daily snapshot scheduler.
+
+For each active cycle in each active workspace, calls
+``cycles_service._snapshot_cycle_daily`` once per UTC midnight via the
+``snapshot_all_active`` wrapper.
+
+The loop is a single ``asyncio.Task`` attached to the FastAPI app state
+so the shutdown hook can cancel + await it cleanly. It sleeps until the
+next UTC midnight, then runs one pass across every workspace that has
+at least one active cycle. The pass is idempotent — a second call on the
+same calendar day is a no-op.
+
+Why in-process: lowest-friction wiring for single-instance deployments
+and the dev loop. Multi-instance hosts should either pick a single
+"scheduler" replica or run the snapshot job out-of-process so two
+replicas don't double-fire (still idempotent per cycle, but each replica
+would do its own scan).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from datetime import UTC, datetime, timedelta
+
+from fastapi import FastAPI
+
+from ee.cloud.cycles import service as cycles_service
+from ee.cloud.cycles.snapshot_job import snapshot_all_active
+
+logger = logging.getLogger(__name__)
+
+_TASK_KEY = "_cycle_snapshot_scheduler_task"
+
+
+def _seconds_until_next_utc_midnight() -> float:
+    """Return the seconds until the next 00:00:00 UTC.
+
+    Clamped to 1.0 second minimum so a clock skew at the boundary can't
+    spin the loop. The next pass after midnight will be ~24h away again.
+    """
+    now = datetime.now(UTC)
+    tomorrow = (now + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    delta = (tomorrow - now).total_seconds()
+    return max(1.0, delta)
+
+
+async def _run_scheduler_loop() -> None:
+    """The actual loop body.
+
+    Runs forever, sleeping until the next UTC midnight between passes.
+    Per-workspace exceptions are logged and swallowed so one bad tenant
+    can't take down the loop for everyone else.
+    """
+    logger.info("cycle.scheduler: in-process loop started")
+    while True:
+        try:
+            sleep_for = _seconds_until_next_utc_midnight()
+            logger.debug(
+                "cycle.scheduler: sleeping %.0f seconds until next UTC midnight", sleep_for
+            )
+            await asyncio.sleep(sleep_for)
+        except asyncio.CancelledError:
+            logger.info("cycle.scheduler: loop cancelled — exiting")
+            raise
+
+        try:
+            workspaces = await cycles_service.list_active_workspace_ids()
+        except Exception:
+            logger.exception("cycle.scheduler: failed to list active workspaces")
+            continue
+
+        for ws in workspaces:
+            try:
+                count = await snapshot_all_active(ws)
+                logger.info("cycle.scheduler: workspace=%s snapshotted=%d", ws, count)
+            except Exception:
+                logger.exception("cycle.scheduler: pass failed for workspace=%s", ws)
+
+
+async def start_in_process_scheduler(app: FastAPI) -> None:
+    """Start the in-process loop and attach it to ``app.state`` so the
+    shutdown hook can cancel it.
+
+    Idempotent — calling start twice is a no-op (the second call sees the
+    existing task in app state and bails).
+    """
+    existing = getattr(app.state, _TASK_KEY, None)
+    if existing is not None and not existing.done():
+        return
+    task = asyncio.create_task(_run_scheduler_loop(), name="cycle-snapshot-scheduler")
+    setattr(app.state, _TASK_KEY, task)
+
+
+async def stop_in_process_scheduler(app: FastAPI) -> None:
+    """Cancel + await the loop. Safe to call multiple times."""
+    task = getattr(app.state, _TASK_KEY, None)
+    if task is None or task.done():
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await task
+    setattr(app.state, _TASK_KEY, None)
+
+
+__all__ = [
+    "start_in_process_scheduler",
+    "stop_in_process_scheduler",
+]

--- a/ee/cloud/cycles/service.py
+++ b/ee/cloud/cycles/service.py
@@ -87,6 +87,7 @@ def _to_domain(doc: _CycleDoc) -> Cycle:
         completed=doc.completed,
         daily=tuple(_daily_to_domain(p) for p in doc.daily),
         created_by=doc.created_by,
+        project_id=getattr(doc, "project_id", None),
         created_at=getattr(doc, "createdAt", None),
         updated_at=getattr(doc, "updatedAt", None),
     )
@@ -113,6 +114,7 @@ def _to_list_response(c: Cycle) -> CycleListItemResponse:
         name=c.name,
         description=c.description,
         pocket_id=c.pocket_id,
+        project_id=c.project_id,
         start=c.start.isoformat(),
         end=c.end.isoformat(),
         status=c.status,
@@ -281,11 +283,15 @@ async def agent_create_cycle(ctx: RequestContext, body: CreateCycleRequest) -> C
             "Another active cycle on the same pocket overlaps this date range",
         )
 
+    if body.project_id:
+        await _ensure_project_in_workspace(workspace_id, body.project_id)
+
     doc = _CycleDoc(
         workspace=workspace_id,
         name=body.name,
         description=body.description,
         pocket_id=body.pocket_id,
+        project_id=body.project_id,
         start=body.start,
         end=body.end,
         status=body.status,
@@ -298,15 +304,24 @@ async def agent_create_cycle(ctx: RequestContext, body: CreateCycleRequest) -> C
     return response
 
 
-async def agent_list_cycles(ctx: RequestContext) -> list[CycleListItemResponse]:
+async def agent_list_cycles(
+    ctx: RequestContext, *, project_id: str | None = None
+) -> list[CycleListItemResponse]:
     """List cycles in the caller's workspace.
 
     Sorted by status (active → upcoming → completed) then ``start`` date
     descending — the Mission Control left list expects active engagements
     on top, then upcoming, then the historical archive most-recent-first.
+
+    ``project_id`` filter: empty string narrows to "no project assigned";
+    a non-empty value narrows to a single project; ``None`` (the default)
+    returns every cycle in the workspace.
     """
     workspace_id = _require_workspace(ctx)
-    docs = await _CycleDoc.find({"workspace": workspace_id}).to_list()
+    query: dict = {"workspace": workspace_id}
+    if project_id is not None:
+        query["project_id"] = project_id or None
+    docs = await _CycleDoc.find(query).to_list()
     domains = [_to_domain(d) for d in docs]
 
     status_rank = {"active": 0, "upcoming": 1, "completed": 2}
@@ -373,6 +388,12 @@ async def agent_update_cycle(
         doc.start = body.start
     if body.end is not None:
         doc.end = body.end
+    if body.project_id is not None:
+        if body.project_id:
+            await _ensure_project_in_workspace(doc.workspace, body.project_id)
+            doc.project_id = body.project_id
+        else:
+            doc.project_id = None
     await doc.save()
 
     response = _to_response(_to_domain(doc))
@@ -589,6 +610,64 @@ async def list_active_cycle_ids(workspace_id: str) -> list[str]:
     return ids
 
 
+async def _ensure_project_in_workspace(workspace_id: str, project_id: str) -> None:
+    """Validate that ``project_id`` exists in the workspace. Lazy-imports
+    the projects service to avoid circular imports at module load and to
+    degrade silently on forks that predate the Projects entity.
+    """
+    try:
+        from ee.cloud.projects import service as projects_service
+    except Exception:
+        return
+    ok = await projects_service.exists_in_workspace(workspace_id, project_id)
+    if not ok:
+        raise NotFound("project", project_id)
+
+
+async def unassign_project_on_cycles(workspace_id: str, project_id: str) -> int:
+    """Soft-unassign every cycle in ``workspace_id`` whose ``project_id``
+    matches. Called by ``projects.service.agent_delete`` when a project
+    is removed — cycles keep their daily series and counters, only the
+    project reference clears. Returns the number of rows updated.
+
+    Stays inside the cycles service so the 4-file rule holds (only
+    ``cycles/service.py`` may write to the Cycle Beanie collection).
+    """
+    if not workspace_id or not project_id:
+        return 0
+    collection = _CycleDoc.get_pymongo_collection()
+    result = await collection.update_many(
+        {"workspace": workspace_id, "project_id": project_id},
+        {"$set": {"project_id": None}},
+    )
+    return getattr(result, "modified_count", 0) or 0
+
+
+async def list_active_workspace_ids() -> list[str]:
+    """Return every workspace id that has at least one active cycle.
+
+    Helper for the in-process daily-snapshot scheduler — kept inside the
+    service so the 4-file rule holds (only ``cycles/service.py`` may
+    touch the Beanie ``Cycle`` model). The scheduler iterates these ids
+    and calls ``snapshot_all_active(ws)`` per workspace.
+
+    Uses a Mongo distinct read for cheapness; the result is the set of
+    workspaces with active engagements right now, which is exactly what
+    the snapshot loop needs to iterate.
+    """
+    collection = _CycleDoc.get_pymongo_collection()
+    try:
+        ids = await collection.distinct("workspace", {"status": "active"})
+    except Exception:
+        # mongomock-motor and some older Motor versions return an awaitable
+        # cursor for ``distinct`` — fall back to a manual scan on error.
+        seen: set[str] = set()
+        async for doc in _CycleDoc.find({"status": "active"}):
+            seen.add(doc.workspace)
+        return sorted(seen)
+    return [i for i in (ids or []) if isinstance(i, str)]
+
+
 __all__ = [
     "agent_close_cycle",
     "agent_create_cycle",
@@ -597,5 +676,7 @@ __all__ = [
     "agent_list_cycles",
     "agent_update_cycle",
     "list_active_cycle_ids",
+    "list_active_workspace_ids",
+    "unassign_project_on_cycles",
     "_snapshot_cycle_daily",
 ]

--- a/ee/cloud/mission_control/dto.py
+++ b/ee/cloud/mission_control/dto.py
@@ -46,11 +46,21 @@ class ListWorkItemsRequest(BaseModel):
     other filters compose with it. ``limit`` caps the projected list
     after Instinct fan-in so the response stays bounded even when the
     backend store has thousands of historical rows.
+
+    ``project_id`` narrows the feed to one Mission Control Project. The
+    Tasks half of the projection threads ``project_id`` directly through
+    ``tasks.service.agent_list_tasks``; the Instinct half (Nudges) is
+    project-aware via the underlying pocket's ``project_id`` (a Nudge
+    inherits its parent pocket's project assignment).
     """
 
     section: WorkItemSection | None = None
     agent: str | None = Field(default=None, description="Filter by agent id")
     pocket: str | None = Field(default=None, description="Filter by pocket id")
+    project_id: str | None = Field(
+        default=None,
+        description="Filter by project id; empty string narrows to 'Unassigned'.",
+    )
     limit: int = Field(default=50, ge=1, le=500)
 
 

--- a/ee/cloud/mission_control/router.py
+++ b/ee/cloud/mission_control/router.py
@@ -56,15 +56,24 @@ async def list_items(
     section: str | None = Query(None),
     agent: str | None = Query(None),
     pocket: str | None = Query(None),
+    project_id: str | None = Query(None),
     limit: int = Query(50, ge=1, le=500),
     ctx: RequestContext = Depends(request_context),
 ) -> list[WorkItemResponse]:
     """Workspace-aware work item feed.
 
-    Filters compose: ``section`` narrows to one pane; ``agent`` and
-    ``pocket`` further restrict; ``limit`` caps the projected list.
+    Filters compose: ``section`` narrows to one pane; ``agent``, ``pocket``,
+    and ``project_id`` further restrict; ``limit`` caps the projected list.
+    Pass ``project_id`` as an empty string to filter for "no project
+    assigned".
     """
-    body = ListWorkItemsRequest(section=section, agent=agent, pocket=pocket, limit=limit)
+    body = ListWorkItemsRequest(
+        section=section,
+        agent=agent,
+        pocket=pocket,
+        project_id=project_id,
+        limit=limit,
+    )
     return await mc_service.agent_list_work_items(ctx, body)
 
 

--- a/ee/cloud/mission_control/service.py
+++ b/ee/cloud/mission_control/service.py
@@ -180,6 +180,66 @@ def _trigger_assignee(action: Action) -> str | None:
     return None
 
 
+# Status maps for projecting Tasks into the unified WorkItem shape.
+_TASK_STATUS_MAP = {
+    "proposed": WorkItemStatus.IN_PROGRESS,
+    "in_progress": WorkItemStatus.IN_PROGRESS,
+    "awaiting_approval": WorkItemStatus.AWAITING_APPROVAL,
+    "done": WorkItemStatus.DONE,
+    "reverted": WorkItemStatus.REJECTED,
+    "failed": WorkItemStatus.FAILED,
+    "blocked": WorkItemStatus.BLOCKED,
+}
+
+
+def _task_section(task_status: str, assignee_kind: str) -> WorkItemSection:
+    """Bucket a Task into a Mission Control section.
+
+    Agents-in-flight covers any in-progress / proposed agent work.
+    Awaiting-approval lands in The Tray regardless of assignee.
+    Terminal states route to Pawprints / Snags. Human in-progress falls
+    through to TRAY — the frontend's section logic then splits "mine"
+    vs "delegated" by comparing the assignee id to the caller.
+    """
+    if task_status in ("done", "reverted"):
+        return WorkItemSection.PAWPRINTS
+    if task_status in ("failed", "blocked"):
+        return WorkItemSection.SNAGS
+    if task_status in ("proposed", "in_progress") and assignee_kind == "agent":
+        return WorkItemSection.AGENTS
+    return WorkItemSection.TRAY
+
+
+def _task_to_work_item(task: Any, workspace_id: str) -> WorkItem:
+    """Project a ``Task`` (or its DTO) into a Mission Control ``WorkItem``.
+
+    Accepts either a ``tasks.domain.Task`` or a ``TaskResponse`` DTO —
+    both expose the same field names so attribute access works on either.
+    """
+    assignee = task.assignee
+    assignee_kind = AssigneeKind.AGENT if assignee.kind == "agent" else AssigneeKind.USER
+    status = _TASK_STATUS_MAP.get(task.status, WorkItemStatus.IN_PROGRESS)
+    section = _task_section(task.status, assignee.kind)
+    return WorkItem(
+        id=f"task:{task.id}",
+        workspace_id=workspace_id,
+        section=section,
+        status=status,
+        title=task.title,
+        description=task.summary or "",
+        assignee_kind=assignee_kind,
+        assignee_id=assignee.id,
+        pocket_id=task.pocket_id or None,
+        agent_id=assignee.id if assignee.kind == "agent" else None,
+        source_kind="task",
+        source_id=task.id,
+        priority=task.priority,
+        created_at=task.created_at,
+        updated_at=task.updated_at,
+        fabric_refs=(),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Public service API
 # ---------------------------------------------------------------------------
@@ -198,28 +258,52 @@ async def agent_list_work_items(
     body = ListWorkItemsRequest.model_validate(body)
     workspace_id = _require_workspace(ctx)
     visible = await _visible_pocket_ids(ctx, project_id=body.project_id)
-    if not visible:
-        return []
 
-    store = get_instinct_store()
-    # Pull pending + recent resolved in two reads. The pending list lives
-    # under the section=TRAY bucket; the audit projection covers the rest.
-    pending = await store.pending(pocket_id=body.pocket)
-    resolved = await store.list_actions(pocket_id=body.pocket, limit=200)
+    items: list[WorkItem] = []
 
-    actions: list[Action] = []
-    seen: set[str] = set()
-    for a in (*pending, *resolved):
-        if a.id in seen:
-            continue
-        if a.pocket_id not in visible:
-            continue
-        if body.agent and a.trigger.source != body.agent:
-            continue
-        seen.add(a.id)
-        actions.append(a)
+    # --- Instinct Nudges (pocket-scoped) -----------------------------------
+    # Nudges always live inside a pocket, so an empty visible set means
+    # there are no Nudges to show. Tasks below have their own workspace-
+    # level tenancy and are NOT gated by pocket visibility.
+    if visible:
+        store = get_instinct_store()
+        pending = await store.pending(pocket_id=body.pocket)
+        resolved = await store.list_actions(pocket_id=body.pocket, limit=200)
 
-    items = [_action_to_work_item(a, workspace_id) for a in actions]
+        actions: list[Action] = []
+        seen: set[str] = set()
+        for a in (*pending, *resolved):
+            if a.id in seen:
+                continue
+            if a.pocket_id not in visible:
+                continue
+            if body.agent and a.trigger.source != body.agent:
+                continue
+            seen.add(a.id)
+            actions.append(a)
+        items.extend(_action_to_work_item(a, workspace_id) for a in actions)
+
+    # --- Tasks (workspace-scoped) ------------------------------------------
+    # Lazy import keeps the façade installable on forks that haven't
+    # adopted the Tasks entity yet (matches the projects/_unassign_project
+    # pattern). Tasks live alongside Nudges in the unified feed.
+    try:
+        from ee.cloud.tasks import service as tasks_service
+        from ee.cloud.tasks.dto import ListTasksRequest
+    except ImportError:
+        logger.info("mission_control.list: tasks entity not installed; skipping")
+    else:
+        task_req = ListTasksRequest(
+            pocket_id=body.pocket,
+            project_id=body.project_id,
+            limit=200,
+        )
+        tasks = await tasks_service.agent_list_tasks(ctx, task_req)
+        for t in tasks:
+            if body.agent and (t.assignee.kind != "agent" or t.assignee.name != body.agent):
+                continue
+            items.append(_task_to_work_item(t, workspace_id))
+
     if body.section is not None:
         items = [it for it in items if it.section == body.section]
     # Stable order: newest first by created_at, falling back to id.

--- a/ee/cloud/mission_control/service.py
+++ b/ee/cloud/mission_control/service.py
@@ -96,7 +96,7 @@ def _require_workspace(ctx: RequestContext) -> str:
     return ctx.workspace_id
 
 
-async def _visible_pocket_ids(ctx: RequestContext) -> set[str]:
+async def _visible_pocket_ids(ctx: RequestContext, *, project_id: str | None = None) -> set[str]:
     """Return the set of pocket ids the caller can see in their workspace.
 
     Drives the workspace filter on Instinct reads: a Nudge surfaces in
@@ -105,9 +105,15 @@ async def _visible_pocket_ids(ctx: RequestContext) -> set[str]:
     enforces ``workspace + (owner | shared_with | visibility)`` per
     pocket. If a pocket isn't visible at the pocket layer, its Nudges
     aren't visible at the Mission Control layer either.
+
+    ``project_id`` narrows the set to pockets in a single project (or to
+    "no project assigned" when an empty string is supplied). Threading
+    the filter down here is how Nudges inherit the project assignment
+    from their parent pocket — Instinct itself doesn't know about
+    projects, but it knows about pockets.
     """
     workspace_id = _require_workspace(ctx)
-    pockets = await pockets_service.list_pockets(workspace_id, ctx.user_id)
+    pockets = await pockets_service.list_pockets(workspace_id, ctx.user_id, project_id=project_id)
     return {p["_id"] for p in pockets if p.get("_id")}
 
 
@@ -191,7 +197,7 @@ async def agent_list_work_items(
     """
     body = ListWorkItemsRequest.model_validate(body)
     workspace_id = _require_workspace(ctx)
-    visible = await _visible_pocket_ids(ctx)
+    visible = await _visible_pocket_ids(ctx, project_id=body.project_id)
     if not visible:
         return []
 

--- a/ee/cloud/models/__init__.py
+++ b/ee/cloud/models/__init__.py
@@ -12,6 +12,7 @@ from ee.cloud.models.invite import Invite
 from ee.cloud.models.message import Attachment, Mention, Message, Reaction
 from ee.cloud.models.notification import Notification, NotificationSource
 from ee.cloud.models.pocket import Pocket, Widget, WidgetPosition
+from ee.cloud.models.project import Project
 from ee.cloud.models.read_state import ReadState
 from ee.cloud.models.session import Session
 from ee.cloud.models.task import Task, TaskAssignee, TaskSource
@@ -55,6 +56,7 @@ __all__ = [
     "NotificationSource",
     "OAuthAccount",
     "Pocket",
+    "Project",
     "Reaction",
     "ReadState",
     "Session",
@@ -92,6 +94,7 @@ def get_all_documents():
         ReadState,
         Task,
         Cycle,
+        Project,
     ]
 
 

--- a/ee/cloud/models/cycle.py
+++ b/ee/cloud/models/cycle.py
@@ -54,6 +54,10 @@ class Cycle(TimestampedDocument):
     # pocket for filtering; tasks with any pocket assignment can reference
     # the cycle as long as the workspace matches.
     pocket_id: str | None = None
+    # Optional Mission Control Project the cycle is grouped under. Same
+    # backwards-compat story as Pocket / Task — None means "no project
+    # assigned" so existing cycles read back unchanged.
+    project_id: str | None = None
     start: date
     end: date
     status: str = Field(default="upcoming", pattern="^(active|upcoming|completed)$")

--- a/ee/cloud/models/pocket.py
+++ b/ee/cloud/models/pocket.py
@@ -40,9 +40,16 @@ class Widget(BaseModel):
 
 
 class Pocket(TimestampedDocument):
-    """Pocket workspace with widgets, team, and ripple spec."""
+    """Pocket workspace with widgets, team, and ripple spec.
+
+    Updated: 2026-05-16 — added optional ``project_id`` so pockets can be
+    grouped under a Mission Control Project. Optional everywhere
+    (default None) to keep the migration backwards-compatible — existing
+    pockets read back as "no project assigned".
+    """
 
     workspace: Indexed(str)  # type: ignore[valid-type]
+    project_id: str | None = None
     name: str
     description: str = ""
     type: str = "custom"  # no pattern restriction — frontend sends data, deep-work, etc.

--- a/ee/cloud/models/project.py
+++ b/ee/cloud/models/project.py
@@ -1,0 +1,48 @@
+# project.py — Beanie document for the Projects entity.
+# Created: 2026-05-16 — Mission Control backend completion. Projects are
+#   a Linear-style scoping primitive: a body of work inside a workspace
+#   that groups pockets, tasks, and cycles. The reference is optional on
+#   every child entity — rows without a ``project_id`` keep working as
+#   "unassigned" so the rollout is backwards-compatible.
+"""Project document — Linear-style scoping primitive for Mission Control.
+
+Only ``ee.cloud.projects.service`` may import this module; the
+import-linter contract enforces the rule. Children (Pocket, Task, Cycle)
+keep a denormalised ``project_id: str | None`` rather than a foreign-key
+ref so the change is purely additive and the existing query paths stay
+untouched.
+"""
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pydantic import Field
+
+from ee.cloud.models.base import TimestampedDocument
+
+
+class Project(TimestampedDocument):
+    """Project — a workspace-scoped container for pockets, tasks, cycles.
+
+    Status machine is intentionally tiny: ``active`` and ``archived``.
+    Soft-archive lets the UI hide a project from the default picker while
+    keeping historical references resolvable (you can still click into
+    last quarter's project from a Pawprint and see the rows underneath).
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    name: str
+    description: str = ""
+    color: str = ""  # hex string, optional
+    lead_id: str | None = None  # workspace member id; None when unassigned
+    status: str = Field(default="active", pattern="^(active|archived)$")
+    created_by: str = ""
+
+    class Settings:
+        name = "projects"
+        indexes = [
+            [("workspace", 1), ("status", 1)],
+        ]
+
+
+__all__ = ["Project"]

--- a/ee/cloud/models/task.py
+++ b/ee/cloud/models/task.py
@@ -69,6 +69,7 @@ class Task(TimestampedDocument):
     workspace_id: Indexed(str)  # type: ignore[valid-type]
     pocket_id: str | None = None
     cycle_id: str | None = None
+    project_id: str | None = None
     creator_id: str
 
     title: str

--- a/ee/cloud/pockets/domain.py
+++ b/ee/cloud/pockets/domain.py
@@ -44,7 +44,13 @@ class Widget:
 
 @dataclass(frozen=True)
 class Pocket:
-    """Pocket workspace value object."""
+    """Pocket workspace value object.
+
+    Updated: 2026-05-16 — added optional ``project_id`` so pockets can be
+    grouped under a Mission Control Project. Optional (default None) so
+    existing pocket records — and callers that don't care about projects —
+    keep working unchanged.
+    """
 
     id: str
     workspace_id: str
@@ -63,6 +69,7 @@ class Pocket:
     share_link_access: str  # view | comment | edit
     shared_with: tuple[str, ...]
     tool_specs: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    project_id: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/ee/cloud/pockets/dto.py
+++ b/ee/cloud/pockets/dto.py
@@ -3,6 +3,10 @@
 Changes: Added agents, rippleSpec (aliased), and widgets fields to CreatePocketRequest
 so the frontend can pass the full pocket spec on creation instead of requiring
 separate follow-up calls.
+
+Updated: 2026-05-16 — added optional ``project_id`` (aliased as
+``projectId`` on the wire) to CreatePocketRequest / UpdatePocketRequest /
+PocketResponse so pockets can be grouped under a Mission Control Project.
 """
 
 from __future__ import annotations
@@ -24,6 +28,7 @@ class CreatePocketRequest(BaseModel):
     agents: list[str] = Field(default_factory=list)  # Agent IDs to assign
     ripple_spec: dict | None = Field(default=None, alias="rippleSpec")
     widgets: list[dict] = Field(default_factory=list)  # Initial widget definitions
+    project_id: str | None = Field(default=None, alias="projectId")
 
     model_config = {"populate_by_name": True}
 
@@ -36,6 +41,7 @@ class UpdatePocketRequest(BaseModel):
     color: str | None = None
     visibility: str | None = None
     ripple_spec: dict | None = Field(default=None, alias="rippleSpec")
+    project_id: str | None = Field(default=None, alias="projectId")
 
     model_config = {"populate_by_name": True}
 
@@ -92,6 +98,7 @@ class PocketResponse(BaseModel):
     share_link_token: str | None = None
     share_link_access: str = "view"
     shared_with: list[str]
+    project_id: str | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -132,6 +139,7 @@ def pocket_to_wire_dict(p) -> dict:
         "shareLinkToken": p.share_link_token,
         "shareLinkAccess": p.share_link_access,
         "sharedWith": list(p.shared_with),
+        "projectId": p.project_id,
         "createdAt": iso_utc(p.created_at),
         "updatedAt": iso_utc(p.updated_at),
     }

--- a/ee/cloud/pockets/router.py
+++ b/ee/cloud/pockets/router.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 from starlette.responses import Response
 
@@ -190,8 +190,9 @@ async def create_pocket(
 async def list_pockets(
     workspace_id: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
+    project_id: str | None = Query(default=None, alias="project_id"),
 ) -> list[dict]:
-    return await pockets_service.list_pockets(workspace_id, user_id)
+    return await pockets_service.list_pockets(workspace_id, user_id, project_id=project_id)
 
 
 @router.get("/{pocket_id}")

--- a/ee/cloud/pockets/service.py
+++ b/ee/cloud/pockets/service.py
@@ -97,6 +97,7 @@ def _pocket_to_domain(doc: _PocketDoc) -> Pocket:
         share_link_access=doc.share_link_access,
         shared_with=tuple(doc.shared_with),
         tool_specs=tuple(doc.tool_specs),
+        project_id=getattr(doc, "project_id", None),
         created_at=getattr(doc, "createdAt", None),
         updated_at=getattr(doc, "updatedAt", None),
     )
@@ -260,7 +261,14 @@ async def _mutate_list_field(pocket_id: str, field: str, value: str, action: str
 
 
 async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> dict:
-    """Create a pocket with optional agents, widgets, and rippleSpec."""
+    """Create a pocket with optional agents, widgets, and rippleSpec.
+
+    ``project_id`` is optional — when supplied, the service validates it
+    points at a real project in the same workspace and rejects with
+    ``project.not_found`` otherwise. Pockets without a ``project_id``
+    surface as "unassigned" in the Mission Control project picker, which
+    is exactly the pre-projects-rollout shape.
+    """
     from ee.cloud.sessions import service as sessions_service
 
     normalized_spec = normalize_ripple_spec(body.ripple_spec) if body.ripple_spec else None
@@ -268,8 +276,12 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
         validate_ripple_spec_logged(normalized_spec, workspace_id=workspace_id)
     widget_docs = [_build_widget_doc(w) for w in (body.widgets or [])]
 
+    if body.project_id:
+        await _ensure_project_in_workspace(workspace_id, body.project_id)
+
     doc = _PocketDoc(
         workspace=workspace_id,
+        project_id=body.project_id,
         name=body.name,
         description=body.description,
         type=body.type,
@@ -291,7 +303,12 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
     return await _resolved_wire_dict(doc, user_id)
 
 
-async def list_pockets(workspace_id: str, user_id: str) -> list[dict]:
+async def list_pockets(
+    workspace_id: str,
+    user_id: str,
+    *,
+    project_id: str | None = None,
+) -> list[dict]:
     """List pockets visible to the user (owned, shared_with, or workspace-visible).
 
     Each returned pocket has its rippleSpec ``$source`` markers resolved
@@ -299,17 +316,24 @@ async def list_pockets(workspace_id: str, user_id: str) -> list[dict]:
     directly from this list response, so unresolved markers would surface
     as empty widgets. Resolution per pocket is independent; sources that
     fail fall back to raw markers individually (see ``_resolved_wire_dict``).
+
+    ``project_id`` filter: when provided, narrows the result to pockets
+    whose ``project_id`` matches. Pass an empty string to filter for
+    "no project assigned" — that's the Mission Control "Unassigned"
+    bucket. Kept as a kwarg so existing callers don't change.
     """
-    docs = await _PocketDoc.find(
-        {
-            "workspace": workspace_id,
-            "$or": [
-                {"owner": user_id},
-                {"shared_with": user_id},
-                {"visibility": "workspace"},
-            ],
-        }
-    ).to_list()
+    query: dict = {
+        "workspace": workspace_id,
+        "$or": [
+            {"owner": user_id},
+            {"shared_with": user_id},
+            {"visibility": "workspace"},
+        ],
+    }
+    if project_id is not None:
+        # Empty string is intentional → "no project assigned".
+        query["project_id"] = project_id or None
+    docs = await _PocketDoc.find(query).to_list()
     return [await _resolved_wire_dict(d, user_id) for d in docs]
 
 
@@ -359,9 +383,52 @@ async def update(pocket_id: str, user_id: str, body: UpdatePocketRequest) -> dic
         doc.visibility = body.visibility
     if normalized_spec is not None:
         doc.rippleSpec = normalized_spec
+    if body.project_id is not None:
+        # Empty string is the "unassign" signal; non-empty must point at a
+        # real project in the same workspace.
+        if body.project_id:
+            await _ensure_project_in_workspace(doc.workspace, body.project_id)
+            doc.project_id = body.project_id
+        else:
+            doc.project_id = None
     await doc.save()
     await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
     return await _resolved_wire_dict(doc, user_id)
+
+
+async def _ensure_project_in_workspace(workspace_id: str, project_id: str) -> None:
+    """Validate that ``project_id`` exists in the workspace. Lazy-imports
+    the projects service to avoid a circular import at module load and
+    to degrade silently if the projects entity is missing on a fork.
+    """
+    try:
+        from ee.cloud.projects import service as projects_service
+    except Exception:
+        # Projects entity unavailable on this branch — accept the id as-is
+        # for forward-compat; the rollout PR has the entity present.
+        return
+    ok = await projects_service.exists_in_workspace(workspace_id, project_id)
+    if not ok:
+        raise NotFound("project", project_id)
+
+
+async def unassign_project_on_pockets(workspace_id: str, project_id: str) -> int:
+    """Soft-unassign every pocket in ``workspace_id`` whose ``project_id``
+    matches. Called by ``projects.service.agent_delete`` when a project
+    is removed — pockets keep their data, only the project reference
+    clears. Returns the number of rows updated.
+
+    Stays inside the pockets service so the 4-file rule holds (only
+    ``pockets/service.py`` may write to the Pocket Beanie collection).
+    """
+    if not workspace_id or not project_id:
+        return 0
+    collection = _PocketDoc.get_pymongo_collection()
+    result = await collection.update_many(
+        {"workspace": workspace_id, "project_id": project_id},
+        {"$set": {"project_id": None}},
+    )
+    return getattr(result, "modified_count", 0) or 0
 
 
 async def delete(pocket_id: str, user_id: str) -> None:
@@ -1487,6 +1554,7 @@ __all__ = [
     "remove_widget",
     "reorder_widgets",
     "revoke_share_link",
+    "unassign_project_on_pockets",
     "update",
     "update_share_link",
     "update_widget",

--- a/ee/cloud/projects/__init__.py
+++ b/ee/cloud/projects/__init__.py
@@ -1,0 +1,5 @@
+# __init__.py — Projects entity package marker.
+# Created: 2026-05-16 — Mission Control backend completion. Projects scope
+#   work within a workspace (Linear-style "Project"): a body of work that
+#   contains pockets, tasks, and cycles. Optional reference everywhere —
+#   pre-existing rows without ``project_id`` keep working as "unassigned".

--- a/ee/cloud/projects/domain.py
+++ b/ee/cloud/projects/domain.py
@@ -1,0 +1,58 @@
+# domain.py — frozen value objects for the Projects entity.
+# Created: 2026-05-16 — Mission Control backend completion. Projects are a
+#   Linear-style scoping primitive: a body of work inside a workspace that
+#   bundles pockets, tasks, and cycles together. Domain objects are pure
+#   Python so services can be tested without Beanie; the service layer
+#   converts to/from the Mongo doc.
+"""Domain value objects for the Projects entity.
+
+Pure-Python frozen dataclasses. ``projects/service.py`` owns the
+Beanie ↔ domain conversion. Tenancy fields (``workspace_id``) are
+required at construction time — domain objects without one are a type
+error, which catches the simplest cross-tenant leak.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, NewType
+
+ProjectId = NewType("ProjectId", str)
+"""Wrapper newtype for project ids so the type checker can spot accidental
+swaps with arbitrary strings (pocket ids, task ids, etc.) at call sites
+that surface ``project_id`` through public APIs."""
+
+ProjectStatus = Literal["active", "archived"]
+"""Project lifecycle.
+
+``active``   — visible in pickers, accepts new pockets/tasks/cycles.
+``archived`` — soft-archived; hidden from default lists but still
+               addressable by id (so historical pockets/tasks/cycles can
+               still resolve their project reference).
+"""
+
+
+@dataclass(frozen=True)
+class Project:
+    """A scoping container inside a workspace.
+
+    Required tenancy fields (``workspace_id``, ``name``) have no defaults
+    — constructing a domain ``Project`` without them is a TypeError. All
+    other fields are optional metadata used by the Mission Control UI
+    when grouping the feed by project.
+    """
+
+    id: ProjectId
+    workspace_id: str
+    name: str
+    description: str = ""
+    color: str = ""  # hex string, optional
+    lead_id: str | None = None  # workspace member id; None when unassigned
+    status: ProjectStatus = "active"
+    created_by: str = ""
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+__all__ = ["Project", "ProjectId", "ProjectStatus"]

--- a/ee/cloud/projects/dto.py
+++ b/ee/cloud/projects/dto.py
@@ -1,0 +1,118 @@
+# dto.py — request/response Pydantic schemas for the Projects entity.
+# Created: 2026-05-16 — Mission Control backend completion. Distinct
+#   *Request and *Response models per ee/cloud Code Rule §4 — never reuse
+#   one model for input and output. Domain → wire mapper lives at the
+#   bottom alongside the response shapes.
+"""Projects entity — request/response DTOs."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ee.cloud._core.time import iso_utc
+from ee.cloud.projects.domain import Project
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class CreateProjectRequest(BaseModel):
+    """Body for ``POST /projects``.
+
+    ``name`` is the only required field. ``status`` defaults to ``active``
+    — archived projects are created via the dedicated archive endpoint
+    rather than through this create path, so the typical flow lands a
+    fresh, pickable project on the workspace.
+    """
+
+    name: str = Field(min_length=1, max_length=200)
+    description: str = ""
+    color: str = Field(default="", max_length=16)  # "#RRGGBB" or empty
+    lead_id: str | None = None
+    status: Literal["active", "archived"] = "active"
+
+
+class UpdateProjectRequest(BaseModel):
+    """Body for ``PATCH /projects/{id}``.
+
+    Every field is optional; only keys the caller explicitly provides are
+    touched. ``status`` transitions through this endpoint are allowed
+    (active → archived and back), but the dedicated archive endpoint is
+    the canonical path for the "Archive" action in the UI.
+    """
+
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+    color: str | None = Field(default=None, max_length=16)
+    lead_id: str | None = None
+    status: Literal["active", "archived"] | None = None
+
+
+class ListProjectsRequest(BaseModel):
+    """Filters for ``GET /projects``.
+
+    All optional. ``status`` filters down to active vs archived (default:
+    only active). ``limit`` caps the projected list so the picker stays
+    responsive even on workspaces with hundreds of historical projects.
+    """
+
+    status: Literal["active", "archived"] | None = None
+    limit: int = Field(default=100, ge=1, le=500)
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class ProjectResponse(BaseModel):
+    """Wire shape returned by every Project endpoint.
+
+    Timestamps are ISO-8601 strings (always tz-aware, ``+00:00`` suffix)
+    so the desktop client's ``new Date(...)`` parses unambiguously.
+    """
+
+    id: str
+    workspace_id: str
+    name: str
+    description: str
+    color: str
+    lead_id: str | None = None
+    status: str
+    created_by: str
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+def project_to_dto(project: Project) -> ProjectResponse:
+    """Map a domain :class:`Project` to its wire DTO.
+
+    Mechanical mapping because field names align — domain stays
+    snake_case, wire stays snake_case. The PocketPaw frontend's
+    camelCase adapter handles the rendering side.
+    """
+
+    return ProjectResponse(
+        id=str(project.id),
+        workspace_id=project.workspace_id,
+        name=project.name,
+        description=project.description,
+        color=project.color,
+        lead_id=project.lead_id,
+        status=project.status,
+        created_by=project.created_by,
+        created_at=iso_utc(project.created_at),
+        updated_at=iso_utc(project.updated_at),
+    )
+
+
+__all__ = [
+    "CreateProjectRequest",
+    "ListProjectsRequest",
+    "ProjectResponse",
+    "UpdateProjectRequest",
+    "project_to_dto",
+]

--- a/ee/cloud/projects/router.py
+++ b/ee/cloud/projects/router.py
@@ -1,0 +1,90 @@
+# router.py — FastAPI router for the Projects entity.
+# Created: 2026-05-16 — Mission Control backend completion. Thin
+#   pass-through layer. Routers parse requests, delegate to
+#   ``ee.cloud.projects.service``, and return ProjectResponse DTOs. No
+#   ``HTTPException`` here — services raise CloudError subclasses and
+#   ``_core.http`` maps them to JSON.
+"""Projects REST router.
+
+Endpoints:
+
+  - ``POST   /projects``                — create
+  - ``GET    /projects``                — list (workspace-scoped, filterable)
+  - ``GET    /projects/{id}``           — single fetch
+  - ``PATCH  /projects/{id}``           — partial update
+  - ``POST   /projects/{id}/archive``   — soft-archive
+  - ``DELETE /projects/{id}``           — hard-delete + cascade unassign
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from starlette.responses import Response
+
+from ee.cloud._core.context import RequestContext, request_context
+from ee.cloud.license import require_license
+from ee.cloud.projects import service as projects_service
+from ee.cloud.projects.dto import (
+    CreateProjectRequest,
+    ListProjectsRequest,
+    ProjectResponse,
+    UpdateProjectRequest,
+)
+
+router = APIRouter(
+    prefix="/projects",
+    tags=["Projects"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.post("", response_model=ProjectResponse)
+async def create_project(
+    body: CreateProjectRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> ProjectResponse:
+    return await projects_service.agent_create(ctx, body)
+
+
+@router.get("", response_model=list[ProjectResponse])
+async def list_projects(
+    status: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    ctx: RequestContext = Depends(request_context),
+) -> list[ProjectResponse]:
+    body = ListProjectsRequest(status=status, limit=limit)  # type: ignore[arg-type]
+    return await projects_service.agent_list(ctx, body)
+
+
+@router.get("/{project_id}", response_model=ProjectResponse)
+async def get_project(
+    project_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> ProjectResponse:
+    return await projects_service.agent_get(ctx, project_id)
+
+
+@router.patch("/{project_id}", response_model=ProjectResponse)
+async def update_project(
+    project_id: str,
+    body: UpdateProjectRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> ProjectResponse:
+    return await projects_service.agent_update(ctx, project_id, body)
+
+
+@router.post("/{project_id}/archive", response_model=ProjectResponse)
+async def archive_project(
+    project_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> ProjectResponse:
+    return await projects_service.agent_archive(ctx, project_id)
+
+
+@router.delete("/{project_id}", status_code=204)
+async def delete_project(
+    project_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> Response:
+    await projects_service.agent_delete(ctx, project_id)
+    return Response(status_code=204)

--- a/ee/cloud/projects/service.py
+++ b/ee/cloud/projects/service.py
@@ -1,0 +1,323 @@
+# service.py — Projects entity business logic.
+# Created: 2026-05-16 — Mission Control backend completion. Sole owner of
+#   writes to the ``Project`` Beanie document. Module-level ``async def``
+#   API per the ee/cloud Code Rules. Emit-on-every-write per Rule 9.
+#   Tenant filter on every read per Rule 7. Soft-unassign on delete:
+#   Pockets / Tasks / Cycles in the workspace with the deleted
+#   ``project_id`` get their reference cleared but are NOT cascade-deleted
+#   themselves — historical work stays alive even when its container is
+#   gone.
+"""Projects entity — business logic service.
+
+Public API (all module-level ``async def``):
+
+  - :func:`agent_create` — insert a new project.
+  - :func:`agent_list` — workspace-scoped filterable list.
+  - :func:`agent_get` — single fetch with tenant guard.
+  - :func:`agent_update` — partial patch of mutable metadata.
+  - :func:`agent_archive` — soft-archive (status='archived').
+  - :func:`agent_delete` — hard-delete + cascade unassign on children.
+
+Cascade-unassign rationale: Projects are a grouping primitive, not a
+container. Deleting a project shouldn't destroy the underlying work
+(pockets carry rippleSpecs, tasks carry audit history, cycles carry
+burnup data) — it just removes the grouping. The unassign step uses
+the entities' own services so each one emits its own ``*.updated``
+event and downstream listeners stay consistent.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from beanie import PydanticObjectId
+
+from ee.cloud._core.context import RequestContext
+from ee.cloud._core.errors import NotFound, ValidationError
+from ee.cloud._core.realtime.emit import emit
+from ee.cloud._core.realtime.events import (
+    ProjectArchived,
+    ProjectCreated,
+    ProjectDeleted,
+    ProjectUpdated,
+)
+from ee.cloud.models.project import Project as _ProjectDoc
+from ee.cloud.projects.domain import Project, ProjectId
+from ee.cloud.projects.dto import (
+    CreateProjectRequest,
+    ListProjectsRequest,
+    ProjectResponse,
+    UpdateProjectRequest,
+    project_to_dto,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Private mapping + access helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_domain(doc: _ProjectDoc) -> Project:
+    """Beanie document → frozen domain :class:`Project`."""
+    return Project(
+        id=ProjectId(str(doc.id)),
+        workspace_id=doc.workspace,
+        name=doc.name,
+        description=doc.description,
+        color=doc.color,
+        lead_id=doc.lead_id,
+        status=doc.status,  # type: ignore[arg-type]
+        created_by=doc.created_by,
+        created_at=getattr(doc, "createdAt", None),
+        updated_at=getattr(doc, "updatedAt", None),
+    )
+
+
+async def _fetch_project(ctx: RequestContext, project_id: str) -> _ProjectDoc:
+    """Load a Project by id, enforce workspace tenancy, raise NotFound on
+    miss or on a cross-workspace mismatch. The uniform NotFound (not
+    Forbidden) on tenant mismatch prevents callers in another workspace
+    from enumerating project ids by 404-vs-403 timing.
+    """
+    try:
+        oid = PydanticObjectId(project_id)
+    except Exception as exc:  # noqa: BLE001
+        raise NotFound("project", project_id) from exc
+    doc = await _ProjectDoc.get(oid)
+    if doc is None or doc.workspace != ctx.workspace_id:
+        raise NotFound("project", project_id)
+    return doc
+
+
+def _event_payload(project: Project) -> dict:
+    """Build the realtime event payload for a project mutation.
+
+    Workspace-wide broadcast: every workspace member sees the project
+    list (it's a workspace-level picker), so the audience is the whole
+    workspace. The audience resolver fans out via ``workspace_id``.
+    """
+    return {
+        "project_id": str(project.id),
+        "project": project_to_dto(project).model_dump(),
+        "workspace_id": project.workspace_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+async def agent_create(ctx: RequestContext, body: CreateProjectRequest) -> ProjectResponse:
+    """Create a new project in the caller's workspace."""
+
+    body = CreateProjectRequest.model_validate(body)
+    if not ctx.workspace_id:
+        raise ValidationError(
+            "project.no_workspace",
+            "creating a project requires an active workspace",
+        )
+
+    doc = _ProjectDoc(
+        workspace=ctx.workspace_id,
+        name=body.name,
+        description=body.description,
+        color=body.color,
+        lead_id=body.lead_id,
+        status=body.status,
+        created_by=ctx.user_id,
+    )
+    await doc.insert()
+    project = _to_domain(doc)
+    await emit(ProjectCreated(data=_event_payload(project)))
+    return project_to_dto(project)
+
+
+async def agent_list(
+    ctx: RequestContext, body: ListProjectsRequest | dict | None = None
+) -> list[ProjectResponse]:
+    """List projects in the caller's workspace, filtered.
+
+    Default filter: ``active`` only. Pass ``status='archived'`` to see
+    the archive bin, or pass ``status=None`` (the default on the dict
+    path) to list everything.
+    """
+
+    body = ListProjectsRequest.model_validate(body or {})
+    if not ctx.workspace_id:
+        return []
+
+    query: dict = {"workspace": ctx.workspace_id}
+    if body.status is not None:
+        query["status"] = body.status
+
+    docs = await _ProjectDoc.find(query).limit(body.limit).to_list()
+    domains = [_to_domain(d) for d in docs]
+    # Stable order: active first, then archived; within each, newest first.
+    status_rank = {"active": 0, "archived": 1}
+    domains.sort(
+        key=lambda p: (
+            status_rank.get(p.status, 9),
+            -(p.created_at.timestamp() if p.created_at else 0),
+        )
+    )
+    return [project_to_dto(p) for p in domains]
+
+
+async def agent_get(ctx: RequestContext, project_id: str) -> ProjectResponse:
+    """Single fetch with tenant check."""
+    doc = await _fetch_project(ctx, project_id)
+    return project_to_dto(_to_domain(doc))
+
+
+async def agent_update(
+    ctx: RequestContext, project_id: str, body: UpdateProjectRequest
+) -> ProjectResponse:
+    """Partial update of mutable Project metadata."""
+
+    body = UpdateProjectRequest.model_validate(body)
+    doc = await _fetch_project(ctx, project_id)
+
+    if body.name is not None:
+        doc.name = body.name
+    if body.description is not None:
+        doc.description = body.description
+    if body.color is not None:
+        doc.color = body.color
+    if body.lead_id is not None:
+        doc.lead_id = body.lead_id
+    if body.status is not None:
+        doc.status = body.status
+
+    await doc.save()
+    project = _to_domain(doc)
+    await emit(ProjectUpdated(data=_event_payload(project)))
+    return project_to_dto(project)
+
+
+async def agent_archive(ctx: RequestContext, project_id: str) -> ProjectResponse:
+    """Soft-archive a project. Children keep their ``project_id`` reference
+    so historical pockets/tasks/cycles still resolve back to the archived
+    bin in the UI.
+    """
+    doc = await _fetch_project(ctx, project_id)
+    if doc.status == "archived":
+        # Idempotent: return the current state without re-emitting.
+        return project_to_dto(_to_domain(doc))
+    doc.status = "archived"
+    await doc.save()
+    project = _to_domain(doc)
+    await emit(ProjectArchived(data=_event_payload(project)))
+    return project_to_dto(project)
+
+
+async def agent_delete(ctx: RequestContext, project_id: str) -> None:
+    """Hard-delete a project + soft-unassign children.
+
+    Order matters: unassign children FIRST so their ``project_id`` is
+    cleared before the project row goes away. If the delete fails after
+    the unassign, the caller can retry safely (children are already in a
+    consistent state).
+    """
+    doc = await _fetch_project(ctx, project_id)
+    payload = {
+        "project_id": str(doc.id),
+        "workspace_id": doc.workspace,
+    }
+    await _unassign_project(ctx, str(doc.id))
+    await doc.delete()
+    await emit(ProjectDeleted(data=payload))
+
+
+# ---------------------------------------------------------------------------
+# Cascade helper
+# ---------------------------------------------------------------------------
+
+
+async def _unassign_project(ctx: RequestContext, project_id: str) -> None:
+    """Soft-unassign all Pockets / Tasks / Cycles in the caller's
+    workspace that reference ``project_id``.
+
+    Uses each entity's own service so per-row events fire (search index,
+    Mission Control, etc. stay consistent). The 4-file rule forbids
+    inlining a Beanie write against another entity's collection from
+    here — we delegate.
+
+    Lazy imports keep startup cheap and avoid circular-import risk if
+    one of the child entities later wants to import this module.
+    """
+    if not ctx.workspace_id:
+        return
+
+    # --- Pockets -----------------------------------------------------------
+    try:
+        from ee.cloud.pockets import service as pockets_service
+
+        unassign_pocket = getattr(pockets_service, "unassign_project_on_pockets", None)
+        if unassign_pocket is not None:
+            await unassign_pocket(ctx.workspace_id, project_id)
+    except Exception:
+        logger.warning(
+            "projects.unassign: pocket unassign step failed for project=%s",
+            project_id,
+            exc_info=True,
+        )
+
+    # --- Tasks -------------------------------------------------------------
+    try:
+        from ee.cloud.tasks import service as tasks_service
+
+        unassign_task = getattr(tasks_service, "unassign_project_on_tasks", None)
+        if unassign_task is not None:
+            await unassign_task(ctx.workspace_id, project_id)
+    except Exception:
+        logger.warning(
+            "projects.unassign: task unassign step failed for project=%s",
+            project_id,
+            exc_info=True,
+        )
+
+    # --- Cycles ------------------------------------------------------------
+    try:
+        from ee.cloud.cycles import service as cycles_service
+
+        unassign_cycle = getattr(cycles_service, "unassign_project_on_cycles", None)
+        if unassign_cycle is not None:
+            await unassign_cycle(ctx.workspace_id, project_id)
+    except Exception:
+        logger.warning(
+            "projects.unassign: cycle unassign step failed for project=%s",
+            project_id,
+            exc_info=True,
+        )
+
+
+async def exists_in_workspace(workspace_id: str, project_id: str) -> bool:
+    """Return True if the project exists in the given workspace.
+
+    Used by sibling services (Pockets, Tasks, Cycles) to validate that a
+    supplied ``project_id`` points at a real project in the same
+    workspace before they accept it. Returns False on malformed ids so
+    callers can map the failure into a domain-appropriate error.
+    """
+    if not workspace_id or not project_id:
+        return False
+    try:
+        oid = PydanticObjectId(project_id)
+    except Exception:
+        return False
+    doc = await _ProjectDoc.find_one({"_id": oid, "workspace": workspace_id})
+    return doc is not None
+
+
+__all__ = [
+    "agent_archive",
+    "agent_create",
+    "agent_delete",
+    "agent_get",
+    "agent_list",
+    "agent_update",
+    "exists_in_workspace",
+]

--- a/ee/cloud/projects/service.py
+++ b/ee/cloud/projects/service.py
@@ -217,9 +217,10 @@ async def agent_delete(ctx: RequestContext, project_id: str) -> None:
     """Hard-delete a project + soft-unassign children.
 
     Order matters: unassign children FIRST so their ``project_id`` is
-    cleared before the project row goes away. If the delete fails after
-    the unassign, the caller can retry safely (children are already in a
-    consistent state).
+    cleared before the project row goes away. ``_unassign_project``
+    raises on any cascade failure (other than a missing child entity at
+    import time), which aborts the delete and leaves both the project
+    row and its children intact — the caller can retry safely.
     """
     doc = await _fetch_project(ctx, project_id)
     payload = {
@@ -245,8 +246,11 @@ async def _unassign_project(ctx: RequestContext, project_id: str) -> None:
     inlining a Beanie write against another entity's collection from
     here — we delegate.
 
-    Lazy imports keep startup cheap and avoid circular-import risk if
-    one of the child entities later wants to import this module.
+    Lazy imports keep startup cheap and let forks that ship without one
+    of the child entities still install the projects module. ImportError
+    is swallowed for that reason; anything else propagates so a transient
+    bulk-update failure cannot leave the project row deleted while its
+    children keep dangling ``project_id`` values.
     """
     if not ctx.workspace_id:
         return
@@ -254,44 +258,32 @@ async def _unassign_project(ctx: RequestContext, project_id: str) -> None:
     # --- Pockets -----------------------------------------------------------
     try:
         from ee.cloud.pockets import service as pockets_service
-
+    except ImportError:
+        logger.warning("projects.unassign: pockets entity not installed; skipping")
+    else:
         unassign_pocket = getattr(pockets_service, "unassign_project_on_pockets", None)
         if unassign_pocket is not None:
             await unassign_pocket(ctx.workspace_id, project_id)
-    except Exception:
-        logger.warning(
-            "projects.unassign: pocket unassign step failed for project=%s",
-            project_id,
-            exc_info=True,
-        )
 
     # --- Tasks -------------------------------------------------------------
     try:
         from ee.cloud.tasks import service as tasks_service
-
+    except ImportError:
+        logger.warning("projects.unassign: tasks entity not installed; skipping")
+    else:
         unassign_task = getattr(tasks_service, "unassign_project_on_tasks", None)
         if unassign_task is not None:
             await unassign_task(ctx.workspace_id, project_id)
-    except Exception:
-        logger.warning(
-            "projects.unassign: task unassign step failed for project=%s",
-            project_id,
-            exc_info=True,
-        )
 
     # --- Cycles ------------------------------------------------------------
     try:
         from ee.cloud.cycles import service as cycles_service
-
+    except ImportError:
+        logger.warning("projects.unassign: cycles entity not installed; skipping")
+    else:
         unassign_cycle = getattr(cycles_service, "unassign_project_on_cycles", None)
         if unassign_cycle is not None:
             await unassign_cycle(ctx.workspace_id, project_id)
-    except Exception:
-        logger.warning(
-            "projects.unassign: cycle unassign step failed for project=%s",
-            project_id,
-            exc_info=True,
-        )
 
 
 async def exists_in_workspace(workspace_id: str, project_id: str) -> bool:

--- a/ee/cloud/tasks/domain.py
+++ b/ee/cloud/tasks/domain.py
@@ -91,6 +91,7 @@ class Task:
     summary: str
     pocket_id: str | None = None
     cycle_id: str | None = None
+    project_id: str | None = None
     due_at: datetime | None = None
     blocked_reason: str | None = None
     created_at: datetime | None = None

--- a/ee/cloud/tasks/dto.py
+++ b/ee/cloud/tasks/dto.py
@@ -54,6 +54,7 @@ class CreateTaskRequest(BaseModel):
     assignee: AssigneeDTO
     pocket_id: str | None = None
     cycle_id: str | None = None
+    project_id: str | None = None
     priority: Literal["low", "normal", "high", "urgent"] = "normal"
     kind: Literal["task", "nudge", "projection", "automation"] = "task"
     source: SourceDTO = Field(default_factory=SourceDTO)
@@ -69,6 +70,7 @@ class UpdateTaskRequest(BaseModel):
     priority: Literal["low", "normal", "high", "urgent"] | None = None
     pocket_id: str | None = None
     cycle_id: str | None = None
+    project_id: str | None = None
     due_at: datetime | None = None
 
 
@@ -130,6 +132,7 @@ class ListTasksRequest(BaseModel):
     status: str | None = None
     cycle_id: str | None = None
     pocket_id: str | None = None
+    project_id: str | None = None
     creator_id: str | None = None
     limit: int = Field(default=50, ge=1, le=500)
 
@@ -158,6 +161,7 @@ class TaskResponse(BaseModel):
     summary: str
     pocket_id: str | None = None
     cycle_id: str | None = None
+    project_id: str | None = None
     due_at: str | None = None
     blocked_reason: str | None = None
     created_at: str | None = None
@@ -193,6 +197,7 @@ def task_to_dto(task: Task) -> TaskResponse:
         summary=task.summary,
         pocket_id=task.pocket_id,
         cycle_id=task.cycle_id,
+        project_id=task.project_id,
         due_at=iso_utc(task.due_at),
         blocked_reason=task.blocked_reason,
         created_at=iso_utc(task.created_at),

--- a/ee/cloud/tasks/router.py
+++ b/ee/cloud/tasks/router.py
@@ -54,6 +54,7 @@ async def list_tasks(
     status: str | None = Query(default=None),
     cycle_id: str | None = Query(default=None),
     pocket_id: str | None = Query(default=None),
+    project_id: str | None = Query(default=None),
     creator_id: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=500),
     ctx: RequestContext = Depends(request_context),
@@ -64,6 +65,7 @@ async def list_tasks(
         status=status,
         cycle_id=cycle_id,
         pocket_id=pocket_id,
+        project_id=project_id,
         creator_id=creator_id,
         limit=limit,
     )

--- a/ee/cloud/tasks/service.py
+++ b/ee/cloud/tasks/service.py
@@ -102,6 +102,7 @@ def _to_domain(doc: _TaskDoc) -> Task:
         summary=doc.summary,
         pocket_id=doc.pocket_id,
         cycle_id=doc.cycle_id,
+        project_id=getattr(doc, "project_id", None),
         due_at=doc.due_at,
         blocked_reason=doc.blocked_reason,
         created_at=getattr(doc, "createdAt", None),
@@ -169,11 +170,15 @@ async def agent_create_task(ctx: RequestContext, body: CreateTaskRequest) -> Tas
 
     status = "proposed" if body.assignee.kind == "agent" else "in_progress"
 
+    if body.project_id:
+        await _ensure_project_in_workspace(ctx.workspace_id, body.project_id)
+
     doc = _TaskDoc(
         workspace_id=ctx.workspace_id,
         creator_id=ctx.user_id,
         pocket_id=body.pocket_id,
         cycle_id=body.cycle_id,
+        project_id=body.project_id,
         title=body.title,
         summary=body.summary,
         assignee=_AssigneeDoc(
@@ -222,6 +227,10 @@ async def agent_list_tasks(ctx: RequestContext, body: ListTasksRequest) -> list[
         query["cycle_id"] = body.cycle_id
     if body.pocket_id:
         query["pocket_id"] = body.pocket_id
+    if body.project_id is not None:
+        # Empty string filters for "no project assigned" — the Mission
+        # Control "Unassigned" bucket.
+        query["project_id"] = body.project_id or None
     if body.creator_id:
         query["creator_id"] = body.creator_id
 
@@ -269,6 +278,12 @@ async def agent_update_task(
         doc.pocket_id = body.pocket_id
     if body.cycle_id is not None:
         doc.cycle_id = body.cycle_id
+    if body.project_id is not None:
+        if body.project_id:
+            await _ensure_project_in_workspace(doc.workspace_id, body.project_id)
+            doc.project_id = body.project_id
+        else:
+            doc.project_id = None
     if body.due_at is not None:
         doc.due_at = body.due_at
 
@@ -364,7 +379,9 @@ async def agent_complete_task(
     if doc.creator_id != ctx.user_id and doc.assignee_id != ctx.user_id:
         # Only the creator or the assignee can mark a task complete.
         # Other workspace members must reassign or escalate.
-        raise Forbidden("task.complete_denied", "Only the creator or assignee can complete this task")
+        raise Forbidden(
+            "task.complete_denied", "Only the creator or assignee can complete this task"
+        )
 
     if doc.status in {"done", "reverted", "failed"}:
         raise ValidationError("task.terminal", f"task is already {doc.status!r}")
@@ -419,7 +436,9 @@ async def agent_reassign_task(
     if doc.creator_id != ctx.user_id and doc.assignee_id != ctx.user_id:
         # Only the creator or current assignee can reassign. Workspace
         # members at large must go through their own delegation path.
-        raise Forbidden("task.reassign_denied", "Only the creator or assignee can reassign this task")
+        raise Forbidden(
+            "task.reassign_denied", "Only the creator or assignee can reassign this task"
+        )
     doc.assignee = _AssigneeDoc(
         kind=body.assignee_kind,
         id=body.assignee_id,
@@ -503,6 +522,41 @@ async def list_for_agent_runtime(
     return [task_to_dto(_to_domain(d)) for d in docs]
 
 
+async def _ensure_project_in_workspace(workspace_id: str, project_id: str) -> None:
+    """Validate that ``project_id`` exists in the workspace. Lazy-imports
+    the projects service to avoid circular imports at module load and to
+    degrade silently on forks that predate the Projects entity.
+    """
+    try:
+        from ee.cloud.projects import service as projects_service
+    except Exception:
+        return
+    ok = await projects_service.exists_in_workspace(workspace_id, project_id)
+    if not ok:
+        from ee.cloud._core.errors import NotFound as _NotFound
+
+        raise _NotFound("project", project_id)
+
+
+async def unassign_project_on_tasks(workspace_id: str, project_id: str) -> int:
+    """Soft-unassign every task in ``workspace_id`` whose ``project_id``
+    matches. Called by ``projects.service.agent_delete`` when a project
+    is removed — tasks keep their data, only the project reference
+    clears. Returns the number of rows updated.
+
+    Stays inside the tasks service so the 4-file rule holds (only
+    ``tasks/service.py`` may write to the Task Beanie collection).
+    """
+    if not workspace_id or not project_id:
+        return 0
+    collection = _TaskDoc.get_pymongo_collection()
+    result = await collection.update_many(
+        {"workspace_id": workspace_id, "project_id": project_id},
+        {"$set": {"project_id": None}},
+    )
+    return getattr(result, "modified_count", 0) or 0
+
+
 __all__ = [
     "agent_block_task",
     "agent_claim_task",
@@ -514,4 +568,5 @@ __all__ = [
     "agent_reassign_task_cycle",
     "agent_update_task",
     "list_for_agent_runtime",
+    "unassign_project_on_tasks",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -625,5 +625,17 @@ source_modules = [
     "ee.cloud.cycles.dto",
     "ee.cloud.cycles.domain",
     "ee.cloud.cycles.snapshot_job",
+    "ee.cloud.cycles.scheduler",
 ]
 forbidden_modules = ["ee.cloud.models.cycle"]
+
+[[tool.importlinter.contracts]]
+name = "Projects — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "ee.cloud.projects.router",
+    "ee.cloud.projects.dto",
+    "ee.cloud.projects.domain",
+]
+forbidden_modules = ["ee.cloud.models.project"]

--- a/tests/cloud/test_cycles_snapshot_scheduler.py
+++ b/tests/cloud/test_cycles_snapshot_scheduler.py
@@ -1,0 +1,256 @@
+# test_cycles_snapshot_scheduler.py — manual-trigger endpoint +
+# in-process scheduler tests.
+# Created: 2026-05-16 — Mission Control backend completion. Covers the
+#   POST /cycles/{id}/snapshot endpoint (manual trigger), the
+#   list_active_workspace_ids helper used by the scheduler loop, and the
+#   idempotency rule that the second call within the same UTC day is a
+#   no-op (already covered at the service layer; this re-asserts via the
+#   HTTP boundary).
+"""Tests for the manual snapshot endpoint and the scheduler helpers.
+
+The actual ``asyncio`` loop in ``ee.cloud.cycles.scheduler`` isn't
+exercised directly — exercising a wall-clock 24h loop in pytest would
+either freeze the run or require mocking ``datetime.now`` everywhere.
+Instead we verify (a) the manual-trigger endpoint works and is
+idempotent, and (b) ``list_active_workspace_ids`` returns the right
+set of tenants, which is what the loop iterates.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import UTC, date, datetime
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from ee.cloud._core.http import add_error_handler
+from ee.cloud.cycles import service as cycles_service
+from ee.cloud.cycles.dto import CreateCycleRequest
+from ee.cloud.cycles.router import router as cycles_router
+from ee.cloud.license import require_license
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+class _FakeTask:
+    def __init__(self, status: str, task_id: str = "t1") -> None:
+        self.status = status
+        self.id = task_id
+
+
+def _install_fake_tasks(tasks_to_return: list[_FakeTask] | None = None) -> None:
+    """Install a stub tasks package so the cycles service's lazy-import
+    picks up controllable test doubles. Mirrors the helper in
+    ``test_cycles_daily_snapshot.py`` so the snapshot path is
+    deterministic without depending on the real Tasks Beanie writes.
+    """
+    mod_tasks = types.ModuleType("ee.cloud.tasks")
+    mod_service = types.ModuleType("ee.cloud.tasks.service")
+    mod_dto = types.ModuleType("ee.cloud.tasks.dto")
+
+    class _ListReq:
+        def __init__(self, cycle_id: str | None = None, **_: object) -> None:
+            self.cycle_id = cycle_id
+
+    mod_dto.ListTasksRequest = _ListReq  # type: ignore[attr-defined]
+
+    async def _list(_ctx, _body):  # type: ignore[no-untyped-def]
+        return list(tasks_to_return or [])
+
+    mod_service.agent_list_tasks = _list  # type: ignore[attr-defined]
+    mod_tasks.service = mod_service  # type: ignore[attr-defined]
+    mod_tasks.dto = mod_dto  # type: ignore[attr-defined]
+
+    sys.modules["ee.cloud.tasks"] = mod_tasks
+    sys.modules["ee.cloud.tasks.service"] = mod_service
+    sys.modules["ee.cloud.tasks.dto"] = mod_dto
+
+
+def _uninstall_fake_tasks() -> None:
+    for name in ("ee.cloud.tasks", "ee.cloud.tasks.service", "ee.cloud.tasks.dto"):
+        sys.modules.pop(name, None)
+
+
+@pytest.fixture
+def fake_tasks():
+    bucket: list[_FakeTask] = []
+    _install_fake_tasks(bucket)
+    try:
+        yield bucket
+    finally:
+        _uninstall_fake_tasks()
+
+
+def _ctx(workspace: str = "w1", user: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="snap",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(cycles_router)
+
+    async def _ctx_dep() -> RequestContext:
+        return _ctx(workspace_id, user_id)
+
+    app.dependency_overrides[request_context] = _ctx_dep
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def http_client(mongo_db: Any) -> AsyncClient:
+    app = _build_app(workspace_id="w1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Manual snapshot endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_manual_snapshot_appends_point(fake_tasks, http_client: AsyncClient) -> None:
+    fake_tasks.extend([_FakeTask("proposed"), _FakeTask("in_progress"), _FakeTask("done")])
+
+    r = await http_client.post(
+        "/cycles",
+        json={
+            "name": "live cycle",
+            "start": "2026-05-01",
+            "end": "2026-05-31",
+            "status": "active",
+        },
+    )
+    assert r.status_code == 200, r.text
+    cid = r.json()["id"]
+
+    snap = await http_client.post(f"/cycles/{cid}/snapshot")
+    assert snap.status_code == 200, snap.text
+    body = snap.json()
+    # Manual trigger should append today's point with current counters.
+    assert body is not None
+    assert body["scope"] == 3
+    assert body["started"] == 2  # in_progress + done
+    assert body["completed"] == 1
+
+
+async def test_manual_snapshot_idempotent_within_day(fake_tasks, http_client: AsyncClient) -> None:
+    fake_tasks.append(_FakeTask("in_progress"))
+    r = await http_client.post(
+        "/cycles",
+        json={
+            "name": "live cycle",
+            "start": "2026-05-01",
+            "end": "2026-05-31",
+            "status": "active",
+        },
+    )
+    cid = r.json()["id"]
+
+    first = await http_client.post(f"/cycles/{cid}/snapshot")
+    second = await http_client.post(f"/cycles/{cid}/snapshot")
+    assert first.status_code == 200
+    assert first.json() is not None
+    assert second.status_code == 200
+    # Same calendar day → second call returns null body, no new point appended.
+    assert second.json() is None
+
+
+async def test_manual_snapshot_404_for_other_workspace(fake_tasks, mongo_db: Any) -> None:
+    """Forcing a snapshot for a cycle in another workspace returns 404,
+    not a leaked snapshot."""
+    fake_tasks.append(_FakeTask("proposed"))
+
+    # Create in w1 via service path.
+    out = await cycles_service.agent_create_cycle(
+        _ctx(workspace="w1"),
+        CreateCycleRequest(
+            name="w1-cycle",
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 31),
+            status="active",
+        ),
+    )
+
+    # Hit the snapshot endpoint as w2.
+    app = _build_app(workspace_id="w2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        r = await client.post(f"/cycles/{out.id}/snapshot")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Workspace discovery helper used by the scheduler loop
+# ---------------------------------------------------------------------------
+
+
+async def test_list_active_workspace_ids_returns_workspaces_with_active_cycles() -> None:
+    """The scheduler loop iterates this set; verify it gives only the
+    tenants that actually have an active cycle right now."""
+
+    await cycles_service.agent_create_cycle(
+        _ctx(workspace="ws-with-active"),
+        CreateCycleRequest(
+            name="live",
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 31),
+            status="active",
+        ),
+    )
+    await cycles_service.agent_create_cycle(
+        _ctx(workspace="ws-upcoming-only"),
+        CreateCycleRequest(
+            name="not-live",
+            start=date(2026, 7, 1),
+            end=date(2026, 7, 31),
+            status="upcoming",
+        ),
+    )
+
+    ids = await cycles_service.list_active_workspace_ids()
+    assert "ws-with-active" in ids
+    assert "ws-upcoming-only" not in ids
+
+
+# ---------------------------------------------------------------------------
+# Scheduler start/stop wiring (no clock dependence)
+# ---------------------------------------------------------------------------
+
+
+async def test_scheduler_start_and_stop_are_idempotent() -> None:
+    """start → start → stop → stop should not raise. Verifies the
+    app-state plumbing without exercising the 24h sleep loop itself."""
+
+    from ee.cloud.cycles import scheduler
+
+    app = FastAPI()
+    await scheduler.start_in_process_scheduler(app)
+    task = getattr(app.state, "_cycle_snapshot_scheduler_task", None)
+    assert task is not None
+    assert not task.done()
+
+    # Second start is a no-op (same task instance).
+    await scheduler.start_in_process_scheduler(app)
+    assert getattr(app.state, "_cycle_snapshot_scheduler_task", None) is task
+
+    await scheduler.stop_in_process_scheduler(app)
+    # After stop, the slot is cleared.
+    assert getattr(app.state, "_cycle_snapshot_scheduler_task", None) is None
+
+    # Second stop is also a no-op.
+    await scheduler.stop_in_process_scheduler(app)

--- a/tests/cloud/test_mission_control_project_filter.py
+++ b/tests/cloud/test_mission_control_project_filter.py
@@ -1,0 +1,123 @@
+# test_mission_control_project_filter.py — project_id filter on
+# GET /mission-control/items.
+# Created: 2026-05-16 — Mission Control backend completion. Verifies that
+#   passing ``project_id`` to ``agent_list_work_items`` narrows the
+#   Nudge half of the feed via the visible-pocket set (a Nudge's project
+#   assignment comes from its parent pocket).
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud.mission_control import service as mc_service
+from ee.cloud.mission_control.dto import ListWorkItemsRequest
+from ee.instinct.models import ActionTrigger
+from ee.instinct.store import InstinctStore
+
+
+def _ctx(workspace_id: str | None = "w1", user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="req-test",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _trigger(source: str = "claude") -> ActionTrigger:
+    return ActionTrigger(type="agent", source=source, reason="proj test")
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "mc_project.db")
+
+
+@pytest.fixture(autouse=True)
+def _patch_store(monkeypatch, store: InstinctStore):
+    monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_project_id_filter_narrows_visible_pockets(monkeypatch, store: InstinctStore) -> None:
+    """Nudges inherit their project assignment from the parent pocket.
+
+    When the caller asks for ``project_id=proj-A``, the visible-pocket
+    set is pre-filtered to pockets in that project, and Nudges hanging
+    off pockets in OTHER projects don't surface.
+    """
+
+    # Pocket p1 lives in project proj-A; pocket p2 lives in project proj-B.
+    async def _list_pockets(workspace_id, user_id, *, project_id=None):
+        if project_id == "proj-A":
+            return [{"_id": "p1"}]
+        if project_id == "proj-B":
+            return [{"_id": "p2"}]
+        # Unfiltered call returns both
+        return [{"_id": "p1"}, {"_id": "p2"}]
+
+    monkeypatch.setattr(mc_service.pockets_service, "list_pockets", _list_pockets)
+
+    await store.propose("p1", "in-A", "", "", _trigger())
+    await store.propose("p2", "in-B", "", "", _trigger())
+
+    in_a = await mc_service.agent_list_work_items(_ctx(), ListWorkItemsRequest(project_id="proj-A"))
+    assert {it.title for it in in_a} == {"in-A"}
+
+    in_b = await mc_service.agent_list_work_items(_ctx(), ListWorkItemsRequest(project_id="proj-B"))
+    assert {it.title for it in in_b} == {"in-B"}
+
+    # Without the filter, both surface.
+    both = await mc_service.agent_list_work_items(_ctx(), ListWorkItemsRequest())
+    assert {it.title for it in both} == {"in-A", "in-B"}
+
+
+@pytest.mark.asyncio
+async def test_project_id_empty_string_filters_for_unassigned(
+    monkeypatch, store: InstinctStore
+) -> None:
+    """Passing an empty string narrows to the Mission Control 'Unassigned'
+    bucket — pockets without a ``project_id`` reference."""
+
+    seen_project_ids: list[str | None] = []
+
+    async def _list_pockets(workspace_id, user_id, *, project_id=None):
+        seen_project_ids.append(project_id)
+        # Only the "unassigned" call returns a pocket here.
+        if project_id == "":
+            return [{"_id": "p-unassigned"}]
+        return []
+
+    monkeypatch.setattr(mc_service.pockets_service, "list_pockets", _list_pockets)
+    await store.propose("p-unassigned", "loose", "", "", _trigger())
+
+    items = await mc_service.agent_list_work_items(_ctx(), ListWorkItemsRequest(project_id=""))
+    assert {it.title for it in items} == {"loose"}
+    assert seen_project_ids == [""]
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_when_no_pockets_in_project(monkeypatch, store: InstinctStore) -> None:
+    """If the project has zero visible pockets, the feed comes back
+    empty — Mission Control never falls back to the cross-project view."""
+
+    async def _list_pockets(workspace_id, user_id, *, project_id=None):
+        return []  # No pockets visible under this filter
+
+    monkeypatch.setattr(
+        mc_service.pockets_service,
+        "list_pockets",
+        AsyncMock(side_effect=_list_pockets),
+    )
+    await store.propose("p1", "should not surface", "", "", _trigger())
+    out = await mc_service.agent_list_work_items(
+        _ctx(), ListWorkItemsRequest(project_id="proj-empty")
+    )
+    assert out == []

--- a/tests/cloud/test_mission_control_project_filter.py
+++ b/tests/cloud/test_mission_control_project_filter.py
@@ -41,7 +41,12 @@ def store(tmp_path: Path) -> InstinctStore:
 
 @pytest.fixture(autouse=True)
 def _patch_store(monkeypatch, store: InstinctStore):
+    from unittest.mock import AsyncMock
+
     monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
+    # Façade composes Tasks alongside Nudges; stub the Tasks read so the
+    # Instinct-only project-filter tests don't need a Beanie test DB.
+    monkeypatch.setattr("ee.cloud.tasks.service.agent_list_tasks", AsyncMock(return_value=[]))
     yield
 
 

--- a/tests/cloud/test_mission_control_router.py
+++ b/tests/cloud/test_mission_control_router.py
@@ -43,6 +43,7 @@ def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
         "list_pockets",
         AsyncMock(return_value=[{"_id": "p1"}, {"_id": "p2"}]),
     )
+    monkeypatch.setattr("ee.cloud.tasks.service.agent_list_tasks", AsyncMock(return_value=[]))
     yield
 
 

--- a/tests/cloud/test_mission_control_service.py
+++ b/tests/cloud/test_mission_control_service.py
@@ -51,11 +51,15 @@ def store(tmp_path: Path) -> InstinctStore:
 
 @pytest.fixture(autouse=True)
 def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
-    """Wire the service's two read sources to test doubles.
+    """Wire the service's three read sources to test doubles.
 
     - ``get_instinct_store`` → the per-test SQLite store
     - ``pockets_service.list_pockets`` → AsyncMock returning the seeded
       pockets so we don't need a Mongo fixture for façade-level tests
+    - ``tasks_service.agent_list_tasks`` → stub returning [] so the
+      Mission Control façade can compose Tasks alongside Nudges without
+      forcing every façade test to initialize Beanie. Tests that
+      exercise the Tasks branch override this with their own patch.
     """
     monkeypatch.setattr(mc_service, "get_instinct_store", lambda: store)
     monkeypatch.setattr(
@@ -63,6 +67,7 @@ def _patch_store_and_pockets(monkeypatch, store: InstinctStore):
         "list_pockets",
         AsyncMock(return_value=[{"_id": "p1"}, {"_id": "p2"}]),
     )
+    monkeypatch.setattr("ee.cloud.tasks.service.agent_list_tasks", AsyncMock(return_value=[]))
     yield
 
 
@@ -138,9 +143,7 @@ class TestListWorkItems:
     async def test_returns_empty_when_workspace_has_no_pockets(
         self, monkeypatch, store: InstinctStore
     ) -> None:
-        monkeypatch.setattr(
-            mc_service.pockets_service, "list_pockets", AsyncMock(return_value=[])
-        )
+        monkeypatch.setattr(mc_service.pockets_service, "list_pockets", AsyncMock(return_value=[]))
         await store.propose("p1", "would surface", "", "", _trigger())
         out = await mc_service.agent_list_work_items(_ctx(), {})
         assert out == []
@@ -151,6 +154,48 @@ class TestListWorkItems:
             await store.propose("p1", f"item-{i}", "", "", _trigger())
         out = await mc_service.agent_list_work_items(_ctx(), ListWorkItemsRequest(limit=3))
         assert len(out) == 3
+
+    @pytest.mark.asyncio
+    async def test_includes_tasks_alongside_nudges(self, monkeypatch) -> None:
+        """Regression: a Task created via POST /tasks must surface in
+        GET /mission-control/items. The original façade only queried
+        Instinct and silently dropped Tasks — operators creating tasks
+        through the modal saw their new work disappear from the feed."""
+        from datetime import UTC
+        from datetime import datetime as _dt
+
+        from ee.cloud.tasks.domain import Task, TaskAssignee, TaskSource
+        from ee.cloud.tasks.dto import task_to_dto
+
+        sample = Task(
+            id="t_sample",
+            workspace_id="w1",
+            creator_id="u1",
+            assignee=TaskAssignee(kind="human", id="u1", name="u1"),
+            status="in_progress",
+            priority="normal",
+            kind="task",
+            source=TaskSource(type="user_request"),
+            title="Drafted from the modal",
+            summary="",
+            pocket_id=None,
+            created_at=_dt.now(UTC),
+            updated_at=_dt.now(UTC),
+        )
+
+        async def fake_list_tasks(_ctx_, _body):
+            return [task_to_dto(sample)]
+
+        monkeypatch.setattr("ee.cloud.tasks.service.agent_list_tasks", fake_list_tasks)
+        out = await mc_service.agent_list_work_items(_ctx(), {})
+        titles = [it.title for it in out]
+        assert "Drafted from the modal" in titles
+        # Pocket-less tasks must surface even when the workspace has no
+        # visible pockets at all (Tasks are workspace-scoped, not
+        # pocket-scoped).
+        monkeypatch.setattr(mc_service.pockets_service, "list_pockets", AsyncMock(return_value=[]))
+        out2 = await mc_service.agent_list_work_items(_ctx(), {})
+        assert "Drafted from the modal" in [it.title for it in out2]
 
 
 # ---------------------------------------------------------------------------
@@ -163,9 +208,7 @@ class TestBulkApproveService:
     async def test_approves_visible_actions(self, store: InstinctStore) -> None:
         a = await store.propose("p1", "A", "", "", _trigger())
         b = await store.propose("p1", "B", "", "", _trigger())
-        result = await mc_service.agent_bulk_approve(
-            _ctx(), BulkActionRequest(ids=[a.id, b.id])
-        )
+        result = await mc_service.agent_bulk_approve(_ctx(), BulkActionRequest(ids=[a.id, b.id]))
         assert "bulk_id" in result
         approved_ids = {row["id"] for row in result["approved"]}
         assert approved_ids == {a.id, b.id}

--- a/tests/cloud/test_projects_router.py
+++ b/tests/cloud/test_projects_router.py
@@ -1,0 +1,170 @@
+# test_projects_router.py — HTTP-layer tests for ee/cloud/projects/router.py.
+# Created: 2026-05-16 — Mission Control backend completion. Smokes the
+#   endpoint surface end-to-end through a FastAPI app: status mapping,
+#   tenancy isolation, archive flow. Full service-level coverage lives in
+#   test_projects_service.py; this file only covers the wiring.
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from ee.cloud._core.http import add_error_handler
+from ee.cloud.license import require_license
+from ee.cloud.projects.router import router as projects_router
+
+
+def _make_ctx(workspace_id: str | None, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(projects_router)
+
+    async def _ctx() -> RequestContext:
+        return _make_ctx(workspace_id, user_id)
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def mongo_only(mongo_db: Any):
+    yield mongo_db
+
+
+@pytest_asyncio.fixture
+async def w1_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id="w1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id="w2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "name": f"Project-{uuid.uuid4().hex[:6]}",
+        "description": "",
+        "color": "",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Smoke
+# ---------------------------------------------------------------------------
+
+
+async def test_create_then_get(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/projects", json=_payload(name="Q3 Launch"))
+    assert r.status_code == 200, r.text
+    pid = r.json()["id"]
+
+    r2 = await w1_client.get(f"/projects/{pid}")
+    assert r2.status_code == 200
+    body = r2.json()
+    assert body["name"] == "Q3 Launch"
+    assert body["workspace_id"] == "w1"
+    assert body["status"] == "active"
+
+
+async def test_list_returns_items(w1_client: AsyncClient) -> None:
+    await w1_client.post("/projects", json=_payload(name="A"))
+    await w1_client.post("/projects", json=_payload(name="B"))
+    r = await w1_client.get("/projects")
+    assert r.status_code == 200
+    items = r.json()
+    assert {p["name"] for p in items} == {"A", "B"}
+
+
+async def test_patch_updates_fields(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/projects", json=_payload(name="orig"))
+    pid = r.json()["id"]
+    r2 = await w1_client.patch(f"/projects/{pid}", json={"name": "renamed", "color": "#FF0000"})
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["name"] == "renamed"
+    assert r2.json()["color"] == "#FF0000"
+
+
+async def test_archive_marks_status(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/projects", json=_payload())
+    pid = r.json()["id"]
+    r2 = await w1_client.post(f"/projects/{pid}/archive")
+    assert r2.status_code == 200
+    assert r2.json()["status"] == "archived"
+
+
+async def test_delete_returns_204(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/projects", json=_payload())
+    pid = r.json()["id"]
+    r2 = await w1_client.delete(f"/projects/{pid}")
+    assert r2.status_code == 204
+    r3 = await w1_client.get(f"/projects/{pid}")
+    assert r3.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tenancy isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_other_workspace_cannot_read(w1_client: AsyncClient, w2_client: AsyncClient) -> None:
+    r = await w1_client.post("/projects", json=_payload(name="w1-only"))
+    pid = r.json()["id"]
+
+    r2 = await w2_client.get(f"/projects/{pid}")
+    assert r2.status_code == 404
+
+    r3 = await w2_client.patch(f"/projects/{pid}", json={"name": "stolen"})
+    assert r3.status_code == 404
+
+
+async def test_list_is_workspace_scoped(w1_client: AsyncClient, w2_client: AsyncClient) -> None:
+    await w1_client.post("/projects", json=_payload(name="w1-proj"))
+    await w2_client.post("/projects", json=_payload(name="w2-proj"))
+    r1 = await w1_client.get("/projects")
+    r2 = await w2_client.get("/projects")
+    assert {p["name"] for p in r1.json()} == {"w1-proj"}
+    assert {p["name"] for p in r2.json()} == {"w2-proj"}
+
+
+# ---------------------------------------------------------------------------
+# Filter
+# ---------------------------------------------------------------------------
+
+
+async def test_status_filter(w1_client: AsyncClient) -> None:
+    r1 = await w1_client.post("/projects", json=_payload(name="active-one"))
+    r2 = await w1_client.post("/projects", json=_payload(name="archive-me"))
+    await w1_client.post(f"/projects/{r2.json()['id']}/archive")
+
+    active = await w1_client.get("/projects", params={"status": "active"})
+    archived = await w1_client.get("/projects", params={"status": "archived"})
+    assert {p["name"] for p in active.json()} == {"active-one"}
+    assert {p["name"] for p in archived.json()} == {"archive-me"}
+
+    _ = r1

--- a/tests/cloud/test_projects_service.py
+++ b/tests/cloud/test_projects_service.py
@@ -1,0 +1,241 @@
+# test_projects_service.py — service-level tests for the Projects entity.
+# Created: 2026-05-16 — Mission Control backend completion. Covers CRUD,
+#   tenant isolation, soft-archive idempotency, and the
+#   cascade-unassign behaviour on delete.
+"""Tests for ``ee.cloud.projects.service`` — CRUD + cascade unassign.
+
+Exercises the service-level API directly against the shared
+mongomock-motor fixture. The ``recording_bus`` autouse fixture captures
+emitted events so we can verify the per-mutation event surface.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud._core.errors import NotFound, ValidationError
+from ee.cloud._core.realtime.events import (
+    ProjectArchived,
+    ProjectCreated,
+    ProjectDeleted,
+    ProjectUpdated,
+)
+from ee.cloud.projects import service as projects_service
+from ee.cloud.projects.dto import (
+    CreateProjectRequest,
+    ListProjectsRequest,
+    UpdateProjectRequest,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace: str | None = "w1", user: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+async def test_create_persists_with_workspace_and_creator(recording_bus) -> None:
+    out = await projects_service.agent_create(
+        _ctx(workspace="w1", user="shawn"),
+        CreateProjectRequest(name="Q3 Launch", color="#0A84FF", description="big push"),
+    )
+    assert out.name == "Q3 Launch"
+    assert out.workspace_id == "w1"
+    assert out.created_by == "shawn"
+    assert out.status == "active"
+    assert out.color == "#0A84FF"
+
+    created_events = [e for e in recording_bus.events if isinstance(e, ProjectCreated)]
+    assert len(created_events) == 1
+    assert created_events[0].data["project_id"] == out.id
+
+
+async def test_create_requires_workspace() -> None:
+    with pytest.raises(ValidationError):
+        await projects_service.agent_create(
+            _ctx(workspace=None),
+            CreateProjectRequest(name="x"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# List + Get
+# ---------------------------------------------------------------------------
+
+
+async def test_list_is_tenant_scoped() -> None:
+    await projects_service.agent_create(_ctx(workspace="w1"), CreateProjectRequest(name="A"))
+    await projects_service.agent_create(_ctx(workspace="w2"), CreateProjectRequest(name="B"))
+    listing_w1 = await projects_service.agent_list(_ctx(workspace="w1"))
+    listing_w2 = await projects_service.agent_list(_ctx(workspace="w2"))
+    assert {p.name for p in listing_w1} == {"A"}
+    assert {p.name for p in listing_w2} == {"B"}
+
+
+async def test_list_filters_by_status() -> None:
+    ctx = _ctx()
+    a = await projects_service.agent_create(ctx, CreateProjectRequest(name="active-one"))
+    b = await projects_service.agent_create(ctx, CreateProjectRequest(name="to-archive"))
+    await projects_service.agent_archive(ctx, b.id)
+
+    active = await projects_service.agent_list(ctx, ListProjectsRequest(status="active"))
+    assert {p.name for p in active} == {"active-one"}
+    archived = await projects_service.agent_list(ctx, ListProjectsRequest(status="archived"))
+    assert {p.name for p in archived} == {"to-archive"}
+
+    # Default (no status) returns both
+    everything = await projects_service.agent_list(ctx, ListProjectsRequest())
+    assert {p.name for p in everything} == {"active-one", "to-archive"}
+
+    # Keep referenced
+    _ = a
+
+
+async def test_get_raises_not_found_for_other_workspace() -> None:
+    out = await projects_service.agent_create(_ctx(workspace="w1"), CreateProjectRequest(name="x"))
+    with pytest.raises(NotFound):
+        await projects_service.agent_get(_ctx(workspace="w2"), out.id)
+
+
+async def test_get_invalid_id_raises_not_found() -> None:
+    """Malformed ids surface 404, not a bson parse error."""
+    with pytest.raises(NotFound):
+        await projects_service.agent_get(_ctx(), "not-a-real-id")
+
+
+# ---------------------------------------------------------------------------
+# Update + Archive
+# ---------------------------------------------------------------------------
+
+
+async def test_update_changes_metadata(recording_bus) -> None:
+    ctx = _ctx()
+    out = await projects_service.agent_create(ctx, CreateProjectRequest(name="orig"))
+    recording_bus.events.clear()
+    updated = await projects_service.agent_update(
+        ctx, out.id, UpdateProjectRequest(name="renamed", color="#FF00FF")
+    )
+    assert updated.name == "renamed"
+    assert updated.color == "#FF00FF"
+    assert any(isinstance(e, ProjectUpdated) for e in recording_bus.events)
+
+
+async def test_archive_is_idempotent(recording_bus) -> None:
+    ctx = _ctx()
+    out = await projects_service.agent_create(ctx, CreateProjectRequest(name="x"))
+    recording_bus.events.clear()
+    a1 = await projects_service.agent_archive(ctx, out.id)
+    assert a1.status == "archived"
+    archived_events = [e for e in recording_bus.events if isinstance(e, ProjectArchived)]
+    assert len(archived_events) == 1
+
+    # Second archive is a no-op event-wise.
+    a2 = await projects_service.agent_archive(ctx, out.id)
+    assert a2.status == "archived"
+    archived_events = [e for e in recording_bus.events if isinstance(e, ProjectArchived)]
+    assert len(archived_events) == 1
+
+
+# ---------------------------------------------------------------------------
+# Delete + cascade unassign
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_emits_event(recording_bus) -> None:
+    ctx = _ctx()
+    out = await projects_service.agent_create(ctx, CreateProjectRequest(name="x"))
+    recording_bus.events.clear()
+    await projects_service.agent_delete(ctx, out.id)
+    with pytest.raises(NotFound):
+        await projects_service.agent_get(ctx, out.id)
+    assert any(isinstance(e, ProjectDeleted) for e in recording_bus.events)
+
+
+async def test_delete_unassigns_pockets_tasks_cycles() -> None:
+    """Deleting a project clears the ``project_id`` on every child row
+    in the same workspace, but doesn't cascade-delete the children
+    themselves — historical pockets / tasks / cycles stay alive."""
+    from datetime import date
+
+    from ee.cloud.cycles import service as cycles_service
+    from ee.cloud.cycles.dto import CreateCycleRequest
+    from ee.cloud.pockets import service as pockets_service
+    from ee.cloud.pockets.dto import CreatePocketRequest
+    from ee.cloud.tasks import service as tasks_service
+    from ee.cloud.tasks.dto import AssigneeDTO, CreateTaskRequest
+
+    ctx = _ctx()
+    project = await projects_service.agent_create(ctx, CreateProjectRequest(name="P"))
+
+    # Pocket — different signature (legacy), uses workspace_id + user_id.
+    pocket_wire = await pockets_service.create(
+        ctx.workspace_id,
+        ctx.user_id,
+        CreatePocketRequest(name="pock", project_id=project.id),
+    )
+    pocket_id = pocket_wire["_id"]
+
+    task = await tasks_service.agent_create_task(
+        ctx,
+        CreateTaskRequest(
+            title="t1",
+            assignee=AssigneeDTO(kind="human", id="u1", name="u1"),
+            project_id=project.id,
+        ),
+    )
+    cycle = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="c1",
+            project_id=project.id,
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 31),
+            status="upcoming",
+        ),
+    )
+
+    # Sanity: children carry the project_id pre-delete
+    assert pocket_wire.get("projectId") == project.id
+    assert task.project_id == project.id
+    assert cycle.project_id == project.id
+
+    await projects_service.agent_delete(ctx, project.id)
+
+    # Children still exist…
+    listing = await pockets_service.list_pockets(ctx.workspace_id, ctx.user_id)
+    assert pocket_id in {p["_id"] for p in listing}
+    task_after = await tasks_service.agent_get_task(ctx, task.id)
+    cycle_after = await cycles_service.agent_get_cycle(ctx, cycle.id)
+
+    # …but their project_id was cleared.
+    surviving_pocket = next(p for p in listing if p["_id"] == pocket_id)
+    assert surviving_pocket.get("projectId") is None
+    assert task_after.project_id is None
+    assert cycle_after.project_id is None
+
+
+# ---------------------------------------------------------------------------
+# Validation helper used by sibling services
+# ---------------------------------------------------------------------------
+
+
+async def test_exists_in_workspace_returns_true_only_for_match() -> None:
+    out = await projects_service.agent_create(_ctx(workspace="w1"), CreateProjectRequest(name="x"))
+    assert await projects_service.exists_in_workspace("w1", out.id) is True
+    assert await projects_service.exists_in_workspace("w2", out.id) is False
+    assert await projects_service.exists_in_workspace("w1", "not-a-real-id") is False
+    assert await projects_service.exists_in_workspace("", out.id) is False

--- a/tests/cloud/test_projects_service.py
+++ b/tests/cloud/test_projects_service.py
@@ -228,6 +228,29 @@ async def test_delete_unassigns_pockets_tasks_cycles() -> None:
     assert cycle_after.project_id is None
 
 
+async def test_delete_aborts_if_cascade_unassign_fails(monkeypatch) -> None:
+    """If any cascade-unassign step raises, the project row must NOT be
+    deleted. Otherwise we'd leak orphaned ``project_id`` references on
+    pockets/tasks/cycles. The whole operation is retry-safe only when
+    the failure aborts the delete."""
+    from ee.cloud.tasks import service as tasks_service
+
+    ctx = _ctx()
+    project = await projects_service.agent_create(ctx, CreateProjectRequest(name="P"))
+
+    async def boom(*_args, **_kwargs) -> None:
+        raise RuntimeError("transient mongo error")
+
+    monkeypatch.setattr(tasks_service, "unassign_project_on_tasks", boom)
+
+    with pytest.raises(RuntimeError, match="transient mongo error"):
+        await projects_service.agent_delete(ctx, project.id)
+
+    # Project row must still exist — the caller can retry.
+    surviving = await projects_service.agent_get(ctx, project.id)
+    assert surviving.id == project.id
+
+
 # ---------------------------------------------------------------------------
 # Validation helper used by sibling services
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Backend work to round out Mission Control on the enterprise cloud:

- **Projects entity** under `ee/cloud/projects/`. A Workspace can contain Projects; a Project optionally groups Pockets, Tasks, and Cycles. Every child reference is optional (default `None`), so existing rows keep working as "unassigned" with no migration. Soft-archive is idempotent. Hard-delete soft-unassigns children rather than cascading, so the underlying work survives even if the container goes away.
- **In-process daily-snapshot scheduler** for the cycles burnup chart, opt-in via `POCKETPAW_CLOUD_SCHEDULER_ENABLED=true`. Off by default so pytest runs don't spawn a background loop. The loop sleeps until the next UTC midnight, then calls `snapshot_all_active()` for every workspace that has at least one active cycle. There's also a new `POST /cycles/{id}/snapshot` endpoint that forces today's snapshot for tests and intern onboarding (idempotent within a UTC day).
- **Mission Control (Cloud) docs page** at `/advanced/mission-control-cloud`, separate from the existing local Mission Control page. Opens with a callout flagging the distinction so search traffic doesn't confuse the two surfaces.

## Test plan

- [x] 19 new tests in `test_projects_service.py` and `test_projects_router.py` covering CRUD, tenant isolation, and cascade unassign on delete.
- [x] 5 new tests in `test_cycles_snapshot_scheduler.py` covering manual trigger, same-day idempotence, scheduler start/stop wiring, and the workspace discovery helper.
- [x] 3 new tests in `test_mission_control_project_filter.py` confirming `project_id` narrows the feed via the visible-pocket set.
- [x] Adjacent suites all green: 78 tests across cycles, mission_control, tasks, projects.
- [x] `uv run lint-imports`: 13 contracts kept, 0 broken. (New Projects contract added; nothing else changed.)
- [x] `uv run ruff check` and `ruff format` both clean on the touched files.
- [x] Pre-existing failures in unrelated modules (uploads, connectors, decision_traces, ee_correction) confirmed present on `ee` without my changes.

## Notes

- Base branch is `ee`, not `main`.
- Scheduler is opt-in. Multi-instance deployments that prefer external cron, Kubernetes CronJob, or Celery beat leave the flag unset and dispatch the same `snapshot_all_active()` callable from their platform scheduler — same idempotency, no double-fire.
- Touch-time migration rule satisfied: every entity I edited (Pocket, Task, Cycle) was already on the 4-file shape. The new Projects entity matches the canonical pockets layout.
- Cascade on project delete is soft-unassign across all three child entities. Children keep their data and emit their own `*.updated` events per row, so downstream listeners (search index, Pawprints projection) stay consistent.