### PR TITLE
feat(auth): cookie + CSRF chain alongside Bearer (security #1117 P1 backend)

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -93,13 +93,18 @@ def mount_cloud(app: FastAPI) -> None:
     from ee.cloud._core.http import add_error_handler
     from ee.cloud._core.timing import TimingMiddleware
 
-    # Request-timing middleware first so it wraps every subsequent route
-    # (including CSRF rejections, which we want to see in perf data).
+    # Starlette's add_middleware is a stack — LAST registered runs OUTERMOST
+    # on inbound. Effective order here: CSRF → Timing → route handler.
+    # A CSRF 403 short-circuits before Timing observes the request, so perf
+    # data won't include rejected POSTs. That's a deliberate tradeoff: the
+    # CSRF gate exists to be fast and predictable, not measured. Reorder
+    # ONLY if you want Timing to wrap CSRF rejections (swap the two add_
+    # middleware calls — TimingMiddleware would then run outermost).
     app.add_middleware(TimingMiddleware)
 
-    # CSRF middleware — runs after Timing, before any route. Cookie-auth
-    # callers must echo X-CSRF-Token; Bearer-auth callers (Tauri, MCP,
-    # scripts) bypass entirely. See ``ee/cloud/_core/csrf.py``.
+    # CSRF middleware — outermost on inbound, runs before any route.
+    # Cookie-auth callers must echo X-CSRF-Token; Bearer-auth callers
+    # (Tauri, MCP, scripts) bypass entirely. See ``ee/cloud/_core/csrf.py``.
     app.add_middleware(CSRFMiddleware)
 
     # Global error handler — extracted to ee.cloud._core.http

--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -1,5 +1,11 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Updated: 2026-05-17 (security #1117 P1) — Mounts ``CSRFMiddleware`` and
+    the ``/auth/csrf`` token endpoint so the web build can use the
+    HttpOnly auth cookie without exposing CSRF surface. Bearer-auth
+    clients (Tauri, MCP, scripts) skip the middleware entirely so
+    nothing breaks for existing callers; see ``ee/cloud/_core/csrf.py``
+    for the decision tree.
 Updated: 2026-05-16 — Mission Control backend completion. Mounts the
     Projects entity (workspace > project > pocket/task/cycle hierarchy)
     and wires the in-process daily-snapshot scheduler, gated on
@@ -83,11 +89,18 @@ def init_realtime() -> None:
 def mount_cloud(app: FastAPI) -> None:
     """Mount all cloud domain routers, the error handler, and the
     request-timing middleware."""
+    from ee.cloud._core.csrf import CSRFMiddleware, csrf_router
     from ee.cloud._core.http import add_error_handler
     from ee.cloud._core.timing import TimingMiddleware
 
     # Request-timing middleware first so it wraps every subsequent route
+    # (including CSRF rejections, which we want to see in perf data).
     app.add_middleware(TimingMiddleware)
+
+    # CSRF middleware — runs after Timing, before any route. Cookie-auth
+    # callers must echo X-CSRF-Token; Bearer-auth callers (Tauri, MCP,
+    # scripts) bypass entirely. See ``ee/cloud/_core/csrf.py``.
+    app.add_middleware(CSRFMiddleware)
 
     # Global error handler — extracted to ee.cloud._core.http
     add_error_handler(app)
@@ -110,6 +123,8 @@ def mount_cloud(app: FastAPI) -> None:
     from ee.cloud.workspace.router import router as workspace_router
 
     app.include_router(auth_router, prefix="/api/v1")
+    # CSRF token-mint endpoint sits alongside the rest of /auth/*.
+    app.include_router(csrf_router, prefix="/api/v1")
     app.include_router(workspace_router, prefix="/api/v1")
     app.include_router(agents_router, prefix="/api/v1")
     app.include_router(chat_router, prefix="/api/v1")

--- a/ee/cloud/_core/csrf.py
+++ b/ee/cloud/_core/csrf.py
@@ -108,11 +108,15 @@ class CSRFMiddleware(BaseHTTPMiddleware):
 
         # Safe methods: never check. Same for the bootstrap path list.
         if method not in _PROTECTED_METHODS or _path_is_exempt(request.url.path):
-            return await call_next(request)
+            response = await call_next(request)
+            self._maybe_clear_csrf_on_logout(request, response)
+            return response
 
         # Bearer caller — browsers won't auto-attach, so no CSRF surface.
         if _request_uses_bearer_auth(request):
-            return await call_next(request)
+            response = await call_next(request)
+            self._maybe_clear_csrf_on_logout(request, response)
+            return response
 
         # No cookie auth either? Let the route's own auth dep return 401
         # rather than masking it with a confusing 403.
@@ -138,7 +142,33 @@ class CSRFMiddleware(BaseHTTPMiddleware):
             logger.debug("csrf reject: mismatch path=%s", request.url.path)
             return JSONResponse({"detail": "csrf_invalid"}, status_code=403)
 
-        return await call_next(request)
+        response = await call_next(request)
+        self._maybe_clear_csrf_on_logout(request, response)
+        return response
+
+    def _maybe_clear_csrf_on_logout(self, request: Request, response) -> None:
+        """If this request hit a logout endpoint, expire the paw_csrf
+        cookie alongside the auth cookie fastapi-users just cleared.
+
+        Without this, paw_csrf lives for its 7-day max-age after logout —
+        JS can still read it (it's intentionally NOT HttpOnly) and submit
+        it on the next login. Clearing here keeps the two cookies'
+        lifecycles paired without forking the fastapi-users logout route.
+        """
+        path = request.url.path
+        is_logout = path in {
+            "/api/v1/auth/logout",
+            "/api/v1/auth/cookie/logout",
+            "/api/v1/auth/bearer/logout",
+        }
+        if not is_logout:
+            return
+        # Only clear on a successful logout — leave the cookie alone if
+        # fastapi-users rejected the request.
+        if 200 <= response.status_code < 300:
+            response.delete_cookie(
+                CSRF_COOKIE_NAME, path="/", samesite="lax", secure=False
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/ee/cloud/_core/csrf.py
+++ b/ee/cloud/_core/csrf.py
@@ -1,0 +1,195 @@
+"""CSRF middleware + token-mint endpoint for cookie-based auth.
+
+Created: 2026-05-17 (security #1117 P1) — Hardening the web auth chain
+    so an HttpOnly ``paw_auth`` cookie can carry the JWT without exposing
+    the surface area of a CSRF attack. Bearer-authenticated callers (the
+    Tauri client, automation scripts, MCP tools) skip this check entirely
+    because browsers never auto-attach an ``Authorization`` header.
+
+How it fits together:
+
+* On first state-changing request the web client calls ``GET /auth/csrf``
+  and receives ``{csrf_token: "<random>"}`` plus a non-HttpOnly
+  ``paw_csrf`` cookie that holds the same token. The client caches the
+  token in memory and re-attaches it as ``X-CSRF-Token`` on every
+  subsequent POST / PUT / PATCH / DELETE.
+* The middleware below sees the matching header + cookie and lets the
+  request through. If the header is missing, mismatched, or the cookie
+  is gone (cleared by logout) the middleware short-circuits with a 403
+  carrying ``{detail: "csrf_invalid"}`` so the client can refresh.
+* Bearer requests are detected by the ``Authorization`` header; they
+  bypass the check completely.
+* GET/HEAD/OPTIONS are always exempt — they should be side-effect free.
+* The bootstrap endpoints (login, logout, csrf, health) are exempt by
+  path so the client can establish a session before any token exists.
+
+The middleware deliberately doesn't try to enforce CSRF on requests with
+no auth at all. Those routes either return 401 (auth required) or are
+intentionally public; double-protecting them just adds an opaque 403 to
+the error space.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import Final
+
+from fastapi import APIRouter, Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+# Cookie + header names — kept module-level so tests can introspect.
+CSRF_COOKIE_NAME: Final = "paw_csrf"
+CSRF_HEADER_NAME: Final = "X-CSRF-Token"
+AUTH_COOKIE_NAME: Final = "paw_auth"
+
+# Verbs the browser can be tricked into firing cross-origin without a
+# preflight (or that mutate state). The middleware checks CSRF on these
+# and lets the rest through unmodified.
+_PROTECTED_METHODS: Final = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+# Path prefixes that bypass CSRF entirely. ``/auth/login`` and
+# ``/auth/logout`` are the bootstrap endpoints — login mints the auth
+# cookie in the same response, so requiring a CSRF token to call login
+# would be a chicken-and-egg. ``/auth/csrf`` itself is GET-only but
+# listed for clarity. ``/health`` is a liveness probe.
+_EXEMPT_PATH_PREFIXES: Final = (
+    "/api/v1/auth/login",
+    "/api/v1/auth/logout",
+    "/api/v1/auth/bearer/login",
+    "/api/v1/auth/bearer/logout",
+    "/api/v1/auth/csrf",
+    "/api/v1/auth/register",
+    "/health",
+)
+
+
+def _generate_token() -> str:
+    """Return a URL-safe random token suitable for double-submit CSRF."""
+
+    return secrets.token_urlsafe(32)
+
+
+def _path_is_exempt(path: str) -> bool:
+    return any(path.startswith(prefix) for prefix in _EXEMPT_PATH_PREFIXES)
+
+
+def _request_uses_bearer_auth(request: Request) -> bool:
+    """Bearer tokens are not auto-sent by browsers, so CSRF doesn't apply.
+
+    We treat any ``Authorization: Bearer ...`` header as bearer auth,
+    regardless of whether the token validates downstream — the goal here
+    is to decide whether the CSRF threat model applies, not whether the
+    request is actually authenticated.
+    """
+
+    auth_header = request.headers.get("authorization", "")
+    return auth_header.lower().startswith("bearer ")
+
+
+def _request_uses_cookie_auth(request: Request) -> bool:
+    return AUTH_COOKIE_NAME in request.cookies
+
+
+class CSRFMiddleware(BaseHTTPMiddleware):
+    """Double-submit CSRF for cookie-authenticated state-changing requests.
+
+    The check is intentionally narrow: only fires when the request both
+    uses cookie auth AND targets a non-exempt mutating verb. That keeps
+    the existing Bearer-based clients (Tauri, MCP, scripts) on their
+    current code path with zero changes.
+    """
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        method = request.method.upper()
+
+        # Safe methods: never check. Same for the bootstrap path list.
+        if method not in _PROTECTED_METHODS or _path_is_exempt(request.url.path):
+            return await call_next(request)
+
+        # Bearer caller — browsers won't auto-attach, so no CSRF surface.
+        if _request_uses_bearer_auth(request):
+            return await call_next(request)
+
+        # No cookie auth either? Let the route's own auth dep return 401
+        # rather than masking it with a confusing 403.
+        if not _request_uses_cookie_auth(request):
+            return await call_next(request)
+
+        cookie_value = request.cookies.get(CSRF_COOKIE_NAME, "")
+        header_value = request.headers.get(CSRF_HEADER_NAME, "")
+
+        # ``secrets.compare_digest`` so we don't leak length / prefix info
+        # via timing. Both must be present and equal — empty string can't
+        # match because we mint non-empty tokens.
+        if not cookie_value or not header_value:
+            logger.debug(
+                "csrf reject: missing token (cookie=%s header=%s) path=%s",
+                bool(cookie_value),
+                bool(header_value),
+                request.url.path,
+            )
+            return JSONResponse({"detail": "csrf_invalid"}, status_code=403)
+
+        if not secrets.compare_digest(cookie_value, header_value):
+            logger.debug("csrf reject: mismatch path=%s", request.url.path)
+            return JSONResponse({"detail": "csrf_invalid"}, status_code=403)
+
+        return await call_next(request)
+
+
+# ---------------------------------------------------------------------------
+# Router — exposes GET /auth/csrf for clients to mint a token
+# ---------------------------------------------------------------------------
+
+csrf_router = APIRouter(tags=["Auth"])
+
+
+@csrf_router.get("/auth/csrf")
+async def get_csrf_token(request: Request, response: Response) -> dict[str, str]:
+    """Mint (or rotate) a CSRF token and set the double-submit cookie.
+
+    Returns the token in the body so the client can cache it in memory
+    (where it lives next to the in-flight request, not in
+    persistent storage). Also writes the token to the ``paw_csrf``
+    cookie, which is intentionally NOT HttpOnly so JS can read it — the
+    secret is the *match* between header and cookie, not either value
+    alone.
+
+    Idempotent: calling repeatedly just rotates. Safe to call before the
+    user is authenticated; the token is per-browser, not per-user, so
+    the same token survives login.
+    """
+
+    # Reuse the existing cookie if the caller already has one. Rotating
+    # on every fetch would invalidate any in-flight request that grabbed
+    # the previous value from /auth/csrf milliseconds earlier.
+    token = request.cookies.get(CSRF_COOKIE_NAME) or _generate_token()
+
+    # cookie_secure mirrors the auth cookie's posture so dev / prod
+    # stays consistent. Importing inside the function keeps this module
+    # free of an auth.core import cycle.
+    from ee.cloud.auth.core import _COOKIE_SECURE
+
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=token,
+        max_age=60 * 60 * 24 * 7,  # 7 days — match JWT lifetime
+        secure=_COOKIE_SECURE,
+        httponly=False,  # JS must read this to echo it back as a header
+        samesite="lax",
+        path="/",
+    )
+    return {"csrf_token": token}
+
+
+__all__ = [
+    "AUTH_COOKIE_NAME",
+    "CSRF_COOKIE_NAME",
+    "CSRF_HEADER_NAME",
+    "CSRFMiddleware",
+    "csrf_router",
+]

--- a/ee/cloud/auth/core.py
+++ b/ee/cloud/auth/core.py
@@ -1,7 +1,17 @@
 """Enterprise auth — fastapi-users with JWT cookie + bearer transport.
 
-Changes: Added seed_workspace() to auto-create default workspace + General group
-on first boot, so admin can immediately use the app after seeding.
+Changes:
+    2026-05-17 (security #1117 P1) — Cookie transport hardening:
+        - cookie_secure is now env-driven (POCKETPAW_AUTH_COOKIE_SECURE,
+          defaults to false for local HTTP dev; production must set true).
+        - cookie_httponly explicitly pinned to True so JS can never read
+          the JWT (defence against XSS token theft).
+        - Bearer transport stays registered for back-compat (native /
+          Tauri / API consumers); web build moves to cookie + CSRF.
+        - Slated for removal once all clients ship the cookie path —
+          see ee/cloud/auth/router.py for the deprecation note.
+    Earlier: Added seed_workspace() to auto-create default workspace +
+        General group on first boot.
 
 Provides:
 - POST /auth/register — sign up with email + password
@@ -38,6 +48,11 @@ logger = logging.getLogger(__name__)
 
 SECRET = os.environ.get("AUTH_SECRET", "change-me-in-production-please")
 TOKEN_LIFETIME = 60 * 60 * 24 * 7  # 7 days
+
+# Cookie hardening — flip to true via env in any deployment that terminates
+# TLS in front of the cloud (i.e. production). Local dev runs over plain
+# HTTP, where Secure cookies would be silently dropped by the browser.
+_COOKIE_SECURE = os.environ.get("POCKETPAW_AUTH_COOKIE_SECURE", "false").lower() == "true"
 
 
 # ---------------------------------------------------------------------------
@@ -76,7 +91,8 @@ async def get_user_manager(user_db=Depends(get_user_db)):
 cookie_transport = CookieTransport(
     cookie_name="paw_auth",
     cookie_max_age=TOKEN_LIFETIME,
-    cookie_secure=False,  # Set True in production with HTTPS
+    cookie_secure=_COOKIE_SECURE,  # env-driven; True in prod (HTTPS), False locally
+    cookie_httponly=True,  # explicit — JS must never read the JWT
     cookie_samesite="lax",
 )
 

--- a/ee/cloud/auth/router.py
+++ b/ee/cloud/auth/router.py
@@ -40,7 +40,17 @@ _MAX_AVATAR_SIZE = 5 * 1024 * 1024  # 5 MB
 
 
 # ---------------------------------------------------------------------------
-# fastapi-users sub-routers (login/logout/register) — unchanged
+# fastapi-users sub-routers (login/logout/register)
+#
+# Both transports stay live during the cookie+CSRF rollout (security
+# #1117 P1). Cookie is the long-term path for browser clients; Bearer
+# is retained for back-compat with the Tauri desktop client and any
+# automation / MCP tools that hold a token directly.
+#
+# Deprecation timeline: drop the ``/auth/bearer/*`` sub-router once the
+# Tauri client moves to the OS keychain flow (#1117 P2) and we've
+# audited internal scripts. Until then, removing Bearer would force a
+# coordinated multi-repo migration with no rollback path.
 # ---------------------------------------------------------------------------
 
 router.include_router(

--- a/tests/cloud/test_auth_cookie_chain.py
+++ b/tests/cloud/test_auth_cookie_chain.py
@@ -1,0 +1,201 @@
+# tests/cloud/test_auth_cookie_chain.py
+# Created: 2026-05-17 (security #1117 P1) — Asserts that the JWT auth
+#   chain accepts BOTH the ``paw_auth`` HttpOnly cookie and the legacy
+#   ``Authorization: Bearer`` header during the cookie-mode rollout.
+#   Bearer is intentionally kept live for back-compat with the Tauri
+#   client and MCP/script callers; see ee/cloud/auth/router.py for the
+#   deprecation note.
+#
+#   These tests exercise the real fastapi-users login + /auth/me chain
+#   against a mongomock-motor user DB so we hit the actual cookie /
+#   bearer transports rather than the test-only dependency overrides.
+
+from __future__ import annotations
+
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ee.cloud._core.csrf import AUTH_COOKIE_NAME, CSRFMiddleware
+from ee.cloud._core.http import add_error_handler
+from ee.cloud.auth.core import (
+    UserCreate,
+    UserManager,
+    bearer_backend,
+    cookie_backend,
+    cookie_transport,
+    fastapi_users,
+    get_user_db,
+)
+from ee.cloud.auth.router import router as auth_router
+
+_TEST_EMAIL = "cookie-chain@example.com"
+_TEST_PASSWORD = "test-password-123"
+
+
+async def _seed_user() -> None:
+    """Create a real fastapi-users-managed user so the login path can
+    verify the hashed password and mint a JWT."""
+
+    async for db in get_user_db():
+        manager = UserManager(db)
+        await manager.create(
+            UserCreate(
+                email=_TEST_EMAIL,
+                password=_TEST_PASSWORD,
+                is_verified=True,
+            ),
+        )
+        return
+
+
+def _build_app() -> FastAPI:
+    """Spin up an app with the real auth router + CSRF middleware
+    (so the cookie path actually runs through both layers)."""
+
+    app = FastAPI()
+    add_error_handler(app)
+    # CSRF middleware mirrors the production stack — auth endpoints are
+    # exempt by path, so login/logout/me work without CSRF tokens.
+    app.add_middleware(CSRFMiddleware)
+    app.include_router(auth_router, prefix="/api/v1")
+    return app
+
+
+@pytest_asyncio.fixture
+async def app_client(mongo_db) -> AsyncClient:
+    await _seed_user()
+    app = _build_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Cookie attributes on login
+# ---------------------------------------------------------------------------
+
+
+def test_cookie_transport_pins_httponly_and_name() -> None:
+    """Spec-level assertion: the cookie name + httponly flag must not
+    drift. Drift here means tokens become readable by JS, which is the
+    exact vector P1 is closing."""
+
+    assert cookie_transport.cookie_name == AUTH_COOKIE_NAME == "paw_auth"
+    assert cookie_transport.cookie_httponly is True
+    assert cookie_transport.cookie_samesite == "lax"
+
+
+async def test_login_sets_httponly_cookie(app_client: AsyncClient) -> None:
+    """The cookie backend's login response must set the paw_auth cookie
+    with HttpOnly + SameSite=Lax. Secure is env-driven so we don't
+    assert on it here — production deploys flip POCKETPAW_AUTH_COOKIE_SECURE=true."""
+
+    resp = await app_client.post(
+        "/api/v1/auth/login",
+        data={"username": _TEST_EMAIL, "password": _TEST_PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code in (200, 204), resp.text
+
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert AUTH_COOKIE_NAME in set_cookie
+    assert "HttpOnly" in set_cookie
+    # SameSite case-insensitive in different httpx versions.
+    assert "samesite=lax" in set_cookie.lower()
+
+
+# ---------------------------------------------------------------------------
+# Cookie-only authentication path
+# ---------------------------------------------------------------------------
+
+
+async def test_cookie_only_authenticates(app_client: AsyncClient) -> None:
+    """After login, the cookie alone (no Authorization header) must
+    authenticate subsequent requests. Today this works because the
+    cookie backend is registered first in the FastAPIUsers stack; this
+    test pins that invariant so a future reordering can't silently break
+    the web build."""
+
+    login = await app_client.post(
+        "/api/v1/auth/login",
+        data={"username": _TEST_EMAIL, "password": _TEST_PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert login.status_code in (200, 204), login.text
+    # httpx auto-stores Set-Cookie into the client jar.
+    assert AUTH_COOKIE_NAME in app_client.cookies
+
+    me = await app_client.get("/api/v1/auth/me")
+    assert me.status_code == 200, me.text
+    assert me.json()["email"] == _TEST_EMAIL
+
+
+# ---------------------------------------------------------------------------
+# Bearer back-compat path
+# ---------------------------------------------------------------------------
+
+
+async def test_bearer_only_still_works(app_client: AsyncClient) -> None:
+    """The /auth/bearer/login endpoint returns a JSON body with the JWT;
+    callers should still be able to use it as an Authorization header.
+    Bearer is the Tauri/MCP/script path — P1 keeps it live, P2 migrates
+    Tauri to the OS keychain, and only after that audit do we drop it."""
+
+    login = await app_client.post(
+        "/api/v1/auth/bearer/login",
+        data={"username": _TEST_EMAIL, "password": _TEST_PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert login.status_code == 200, login.text
+    token = login.json().get("access_token")
+    assert token, "bearer login should return access_token in JSON body"
+
+    # Drop the cookie jar so we know the bearer header is what authenticates.
+    app_client.cookies.clear()
+
+    me = await app_client.get(
+        "/api/v1/auth/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert me.status_code == 200, me.text
+    assert me.json()["email"] == _TEST_EMAIL
+
+
+# ---------------------------------------------------------------------------
+# Logout clears the cookie
+# ---------------------------------------------------------------------------
+
+
+async def test_logout_clears_cookie(app_client: AsyncClient) -> None:
+    await app_client.post(
+        "/api/v1/auth/login",
+        data={"username": _TEST_EMAIL, "password": _TEST_PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert AUTH_COOKIE_NAME in app_client.cookies
+
+    logout = await app_client.post("/api/v1/auth/logout")
+    assert logout.status_code in (200, 204), logout.text
+
+    # The cookie's Set-Cookie header on logout has Max-Age=0 (or the
+    # equivalent expires-in-the-past attribute). Either way httpx drops
+    # it from the jar.
+    set_cookie = logout.headers.get("set-cookie", "")
+    assert AUTH_COOKIE_NAME in set_cookie
+    assert "max-age=0" in set_cookie.lower() or "expires=" in set_cookie.lower()
+
+
+# ---------------------------------------------------------------------------
+# Backend list ordering — pin against drift
+# ---------------------------------------------------------------------------
+
+
+def test_fastapi_users_has_both_backends_registered() -> None:
+    """The FastAPIUsers instance must carry the cookie backend (so the
+    web build can authenticate via Set-Cookie) AND the bearer backend
+    (so the Tauri client and MCP callers keep working). Dropping
+    either silently breaks one client class."""
+
+    backend_names = {b.name for b in fastapi_users.authenticator.backends}
+    assert {cookie_backend.name, bearer_backend.name} <= backend_names

--- a/tests/cloud/test_csrf_middleware.py
+++ b/tests/cloud/test_csrf_middleware.py
@@ -1,0 +1,182 @@
+# tests/cloud/test_csrf_middleware.py
+# Created: 2026-05-17 (security #1117 P1) — Behavior tests for the CSRF
+#   middleware that gates cookie-authenticated state-changing requests.
+#   Covers the token-mint endpoint, the happy path, the missing/mismatch
+#   rejection paths, the Bearer-skip path, and the exempt-route paths.
+#   The middleware lives at ``ee/cloud/_core/csrf.py``; this file is the
+#   canonical spec for its behavior.
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ee.cloud._core.csrf import (
+    AUTH_COOKIE_NAME,
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    CSRFMiddleware,
+    csrf_router,
+)
+
+
+def _build_app() -> FastAPI:
+    """Minimal app: CSRF middleware + token endpoint + a couple of
+    arbitrary state-changing routes so we can assert behavior without
+    pulling the full ``mount_cloud`` stack."""
+
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.include_router(csrf_router, prefix="/api/v1")
+
+    @app.post("/api/v1/widgets")
+    def create_widget() -> dict:
+        return {"ok": True}
+
+    @app.post("/api/v1/auth/login")
+    def fake_login() -> dict:
+        return {"ok": True}
+
+    @app.get("/api/v1/widgets")
+    def list_widgets() -> dict:
+        return {"items": []}
+
+    return app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(_build_app())
+
+
+# ---------------------------------------------------------------------------
+# /auth/csrf token mint
+# ---------------------------------------------------------------------------
+
+
+def test_get_csrf_returns_token_and_sets_paw_csrf_cookie(client: TestClient) -> None:
+    res = client.get("/api/v1/auth/csrf")
+    assert res.status_code == 200
+    body = res.json()
+    assert "csrf_token" in body
+    token = body["csrf_token"]
+    assert token, "token should be a non-empty string"
+
+    # Cookie is set on the response and the body value matches the cookie.
+    assert client.cookies.get(CSRF_COOKIE_NAME) == token
+
+    # Header reflects HttpOnly=False so JS can read it back. TestClient
+    # strips the attribute list, so we re-check by parsing the raw header.
+    set_cookie = res.headers.get("set-cookie", "")
+    assert CSRF_COOKIE_NAME in set_cookie
+    assert "HttpOnly" not in set_cookie  # JS needs to read this one
+
+
+def test_get_csrf_is_idempotent_when_cookie_already_present(client: TestClient) -> None:
+    """Calling /auth/csrf twice in the same browser keeps the same token —
+    rotating on every fetch would invalidate any in-flight request that
+    grabbed the previous token milliseconds earlier."""
+
+    first = client.get("/api/v1/auth/csrf").json()["csrf_token"]
+    second = client.get("/api/v1/auth/csrf").json()["csrf_token"]
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Happy path: cookie-auth POST with matching header
+# ---------------------------------------------------------------------------
+
+
+def test_post_with_valid_csrf_header_succeeds(client: TestClient) -> None:
+    token = client.get("/api/v1/auth/csrf").json()["csrf_token"]
+
+    res = client.post(
+        "/api/v1/widgets",
+        headers={CSRF_HEADER_NAME: token},
+        cookies={AUTH_COOKIE_NAME: "fake-jwt-for-test"},
+    )
+    assert res.status_code == 200
+    assert res.json() == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Reject path: cookie-auth POST without / with mismatched header
+# ---------------------------------------------------------------------------
+
+
+def test_post_without_csrf_header_returns_403_when_cookie_auth(
+    client: TestClient,
+) -> None:
+    # Mint the CSRF cookie so we know the rejection is about the header,
+    # not the cookie missing.
+    client.get("/api/v1/auth/csrf")
+
+    res = client.post(
+        "/api/v1/widgets",
+        cookies={AUTH_COOKIE_NAME: "fake-jwt-for-test"},
+    )
+    assert res.status_code == 403
+    assert res.json() == {"detail": "csrf_invalid"}
+
+
+def test_post_with_mismatched_csrf_header_returns_403(client: TestClient) -> None:
+    client.get("/api/v1/auth/csrf")  # mint cookie
+
+    res = client.post(
+        "/api/v1/widgets",
+        headers={CSRF_HEADER_NAME: "definitely-not-the-real-token"},
+        cookies={AUTH_COOKIE_NAME: "fake-jwt-for-test"},
+    )
+    assert res.status_code == 403
+    assert res.json() == {"detail": "csrf_invalid"}
+
+
+# ---------------------------------------------------------------------------
+# Bypass paths: Bearer auth, no auth, safe methods, exempt routes
+# ---------------------------------------------------------------------------
+
+
+def test_post_with_bearer_skips_csrf_check(client: TestClient) -> None:
+    """Browsers never auto-send Authorization headers, so a Bearer caller
+    isn't reachable via CSRF and we skip the check entirely."""
+
+    res = client.post(
+        "/api/v1/widgets",
+        headers={"Authorization": "Bearer fake-token"},
+        # Intentionally NO X-CSRF-Token header and no paw_csrf cookie.
+    )
+    assert res.status_code == 200
+
+
+def test_post_without_any_auth_passes_csrf_layer(client: TestClient) -> None:
+    """No cookie auth, no Bearer — the CSRF middleware lets the request
+    through so the route's own auth dep can return 401. Double-protecting
+    would mask the real error with an opaque 403."""
+
+    res = client.post("/api/v1/widgets")
+    # Our test route doesn't enforce auth, so we just confirm CSRF didn't
+    # intercept (status != 403).
+    assert res.status_code != 403
+
+
+def test_get_requests_skip_csrf(client: TestClient) -> None:
+    """Safe verbs (GET/HEAD/OPTIONS) are never checked — they should be
+    side-effect free."""
+
+    res = client.get("/api/v1/widgets", cookies={AUTH_COOKIE_NAME: "fake-jwt"})
+    assert res.status_code == 200
+
+
+def test_login_endpoint_exempt_from_csrf(client: TestClient) -> None:
+    """The bootstrap endpoints (login, logout, register, csrf, health) are
+    exempt — requiring a CSRF token to call login would be a chicken-and-
+    egg since login is what mints the auth cookie."""
+
+    # No cookie, no header — would normally be rejected on a POST with
+    # cookie auth, but login is exempt by path.
+    res = client.post(
+        "/api/v1/auth/login",
+        cookies={AUTH_COOKIE_NAME: "fake-jwt-for-test"},
+    )
+    assert res.status_code == 200

--- a/tests/cloud/test_csrf_middleware.py
+++ b/tests/cloud/test_csrf_middleware.py
@@ -180,3 +180,56 @@ def test_login_endpoint_exempt_from_csrf(client: TestClient) -> None:
         cookies={AUTH_COOKIE_NAME: "fake-jwt-for-test"},
     )
     assert res.status_code == 200
+
+
+def test_logout_clears_paw_csrf_cookie() -> None:
+    """A successful logout must expire paw_csrf alongside paw_auth.
+
+    Without this hook, paw_csrf lived its full 7-day max_age after the
+    auth cookie was cleared. JS can read paw_csrf (it's intentionally
+    NOT HttpOnly) and could submit it on the next login — narrow but
+    real CSRF replay surface flagged in the #1119 review.
+    """
+
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+
+    @app.post("/api/v1/auth/logout")
+    def fake_logout() -> dict:
+        return {"ok": True}
+
+    client = TestClient(app)
+    res = client.post(
+        "/api/v1/auth/logout",
+        cookies={CSRF_COOKIE_NAME: "stale-token"},
+    )
+    assert res.status_code == 200
+    # The response Set-Cookie should expire paw_csrf (Max-Age=0).
+    set_cookie = res.headers.get("set-cookie", "")
+    assert CSRF_COOKIE_NAME in set_cookie, set_cookie
+    assert "Max-Age=0" in set_cookie or 'expires=Thu, 01 Jan 1970' in set_cookie.lower()
+
+
+def test_logout_failure_does_not_clear_paw_csrf() -> None:
+    """If the logout route returns non-2xx (e.g. session was already
+    invalid), we leave paw_csrf alone — only successful logouts pair the
+    two cookies' lifecycles."""
+
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+
+    @app.post("/api/v1/auth/logout")
+    def failing_logout():
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=401)
+
+    client = TestClient(app)
+    res = client.post(
+        "/api/v1/auth/logout",
+        cookies={CSRF_COOKIE_NAME: "stale-token"},
+    )
+    assert res.status_code == 401
+    set_cookie = res.headers.get("set-cookie", "")
+    # No Set-Cookie for paw_csrf at all when logout failed.
+    assert CSRF_COOKIE_NAME not in set_cookie


### PR DESCRIPTION
P1 of #1117. The web build can now authenticate via the HttpOnly `paw_auth` cookie that fastapi-users was already minting, with a double-submit CSRF token on state-changing verbs. Bearer auth stays live so the Tauri client and MCP / script callers keep working — P2 migrates Tauri to the OS keychain, then a follow-up audits the rest before Bearer drops.

## What ships

- `ee/cloud/auth/core.py`: pin `cookie_httponly=True` explicitly; make `cookie_secure` env-driven via `POCKETPAW_AUTH_COOKIE_SECURE` (defaults false for local HTTP dev, production must set true).
- `ee/cloud/_core/csrf.py`: new module. `CSRFMiddleware` checks `X-CSRF-Token` vs `paw_csrf` cookie on POST / PUT / PATCH / DELETE for cookie-authenticated callers. Bearer callers bypass (browsers never auto-attach `Authorization`). Bootstrap endpoints (login, logout, register, csrf, health) are exempt by path. `GET /auth/csrf` mints the token and sets the (non-HttpOnly) `paw_csrf` cookie so the web client can read it back as a header.
- `ee/cloud/__init__.py`: wire `CSRFMiddleware` after `TimingMiddleware`; mount `csrf_router` under `/api/v1/auth/csrf`.
- `ee/cloud/auth/router.py`: deprecation note on the bearer sub-router.

## Tests

- `tests/cloud/test_auth_cookie_chain.py` (6): login sets HttpOnly cookie, cookie-only authenticates `/auth/me`, bearer back-compat still works, logout clears the cookie, both backends stay registered, cookie transport attribute spec pinned.
- `tests/cloud/test_csrf_middleware.py` (9): token mint + idempotence, valid happy path, missing / mismatched header rejections, Bearer bypass, no-auth pass-through, GET skip, login exempt.

Run targeted: `uv run pytest tests/cloud/test_auth_cookie_chain.py tests/cloud/test_csrf_middleware.py tests/cloud/test_mission_control_router.py tests/cloud/test_projects_router.py -v` — 37 passed.

Wider auth-adjacent sweep (auth/, _core/, rbac, knowledge) — 140 passed.

## Auth-chain surprise

The job ticket assumed the cookie was named `paw_token`. The actual fastapi-users registration uses `paw_auth` — kept as-is because renaming would expire every live session in dev environments without a migration path. The cookie name is exported as `AUTH_COOKIE_NAME` from `ee/cloud/_core/csrf.py` so the frontend can import it from a single source if the build ever shares constants.

## Out of scope

- Tauri keychain migration (P2, separate PR).
- Dropping Bearer support (deferred until P2 + internal audit).
- Token rotation (separate issue).

## Frontend PR

Wired to https://github.com/qbtrix/paw-enterprise/pull/195 (URL added once frontend PR exists). The web `http.ts` chokepoint branches on `isTauri()` and now uses cookie + CSRF; Tauri stays on Bearer. 16 other paw-enterprise modules that read `localStorage.paw_token` directly migrate at touch-time in follow-ups (tracked in #1117).