### PR TITLE
feat(planner): plan_project tool wires deep_work into cloud Projects (#1118 P1)

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -1,5 +1,11 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Updated: 2026-05-17 (pocketpaw#1118 P1) — Mounts the planner router
+    (``/api/v1/planner/run``, ``/api/v1/planner/by-project/{id}``).
+    The planner module wraps the OSS deep_work planner and lands its
+    output into cloud Projects / Tasks / FileUploads so workspace
+    operators can plan a project from Mission Control without
+    crossing into the OSS local-filesystem state.
 Updated: 2026-05-16 — Mission Control backend completion. Mounts the
     Projects entity (workspace > project > pocket/task/cycle hierarchy)
     and wires the in-process daily-snapshot scheduler, gated on
@@ -104,6 +110,7 @@ def mount_cloud(app: FastAPI) -> None:
     from ee.cloud.connectors.router import router as connectors_router
     from ee.cloud.cycles.router import router as cycles_router
     from ee.cloud.license import get_license_info
+    from ee.cloud.planner.router import router as planner_router
     from ee.cloud.pockets.router import router as pockets_router
     from ee.cloud.projects.router import router as projects_router
     from ee.cloud.sessions.router import router as sessions_router
@@ -116,6 +123,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(connectors_router, prefix="/api/v1")
     app.include_router(pockets_router, prefix="/api/v1")
     app.include_router(projects_router, prefix="/api/v1")
+    app.include_router(planner_router, prefix="/api/v1")
     app.include_router(sessions_router, prefix="/api/v1")
     app.include_router(cycles_router, prefix="/api/v1")
 

--- a/ee/cloud/_core/realtime/events.py
+++ b/ee/cloud/_core/realtime/events.py
@@ -389,3 +389,12 @@ class ProjectArchived(Event):
 @dataclass
 class ProjectDeleted(Event):
     EVENT_TYPE: ClassVar[str] = "project.deleted"
+
+
+# Planner — fires after ``ee.cloud.planner.service.agent_plan_project``
+# finishes materializing the OSS PlannerResult into cloud primitives
+# (PRD file, plan.json, goal.md, tasks, agent-gap list). Listeners use
+# it to refresh the Mission Control Plan tab without polling.
+@dataclass
+class PlanGenerated(Event):
+    EVENT_TYPE: ClassVar[str] = "plan.generated"

--- a/ee/cloud/planner/__init__.py
+++ b/ee/cloud/planner/__init__.py
@@ -1,0 +1,6 @@
+# Created: 2026-05-17 — pocketpaw#1118 P1. Cloud-side planner entity.
+#   Wraps OSS ``pocketpaw.deep_work.planner.PlannerAgent`` so cloud
+#   workspaces can plan a Project without ever touching the OSS
+#   MissionControlManager (local filesystem) — outputs are materialized
+#   into the cloud Project / Task / FileUpload primitives instead.
+"""Planner entity — cloud-side wrapper around the OSS deep_work planner."""

--- a/ee/cloud/planner/domain.py
+++ b/ee/cloud/planner/domain.py
@@ -1,0 +1,64 @@
+# Created: 2026-05-17 — pocketpaw#1118 P1. Frozen domain value objects
+#   for plan sessions and the agent-gap signal surfaced back to the
+#   operator UI. Both are constructed only by ``planner.service`` after
+#   a successful OSS planner run; routers + tests consume the DTO wire
+#   shapes in ``planner.dto``.
+"""Planner entity — domain value objects.
+
+A :class:`PlanSession` is the cloud-side record of one OSS planner run.
+It is workspace-scoped (Rule 3: tenancy required at construction time)
+and pins to a single cloud :class:`Project` so re-plans replace the
+prior session for that project rather than accumulating duplicates.
+
+An :class:`AgentGap` is a derived diagnostic — for every recommended
+agent the OSS planner returned that does *not* match an existing cloud
+:class:`Agent` in the workspace, we surface one row so the operator can
+either claim the gap (create the agent) or accept the human fallback
+the planner already wrote into the materialized tasks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PlanSession:
+    """A single planner invocation, scoped to a workspace + project.
+
+    ``id`` is the OSS planner's session id (currently the project_id we
+    handed in) — exposed verbatim so we can correlate cloud-side records
+    back to OSS deep_work runs if a debug round-trip is ever needed.
+
+    Tenancy fields are required (no defaults) so a value object built
+    without ``workspace_id`` or ``project_id`` is a type error at
+    construction, not a silent leak at the read path.
+    """
+
+    id: str
+    workspace_id: str
+    project_id: str
+    status: str
+    prd_file_id: str | None
+    plan_file_id: str | None
+    goal_file_id: str | None
+    task_ids: tuple[str, ...]
+    agent_gaps: tuple[AgentGap, ...]
+
+
+@dataclass(frozen=True)
+class AgentGap:
+    """A planner-recommended agent the workspace does not yet have.
+
+    ``spec_name`` is the agent name the planner suggested. ``recommended_role``
+    is the human-readable role string the planner produced; the operator UI
+    renders both so the captain sees what the planner *meant* before
+    deciding whether to materialize the agent or accept the fallback.
+    """
+
+    spec_name: str
+    recommended_role: str
+    specialties: tuple[str, ...]
+
+
+__all__ = ["AgentGap", "PlanSession"]

--- a/ee/cloud/planner/dto.py
+++ b/ee/cloud/planner/dto.py
@@ -1,0 +1,76 @@
+# Created: 2026-05-17 — pocketpaw#1118 P1. Request / response DTOs for
+#   the planner entity. Distinct *Request and *Response models per
+#   ee/cloud Code Rule §4 — request shapes carry the goal + project_id
+#   the operator picked, response shapes carry the materialized cloud
+#   primitive ids (file_id, task_ids) the FE Plan tab renders.
+"""Planner entity — request/response DTOs."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class PlanProjectRequest(BaseModel):
+    """Body for ``POST /api/v1/planner/run``.
+
+    ``goal`` is the operator's natural-language project description that
+    the OSS planner decomposes into a PRD + tasks + recommended team.
+    ``deep_research`` upgrades the underlying planner's research phase
+    from the default "standard" depth to "deep" — adds an extra LLM
+    round-trip per call but produces more thorough source material in
+    the PRD. We expose a boolean rather than a free-form depth string
+    so the FE toggle stays a binary control; if we ever need the
+    "quick" or "none" depths we add a separate field.
+    """
+
+    project_id: str = Field(min_length=1)
+    goal: str = Field(min_length=10, max_length=5000)
+    deep_research: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class AgentGapDTO(BaseModel):
+    """Wire shape for a single missing-agent diagnostic."""
+
+    spec_name: str
+    recommended_role: str
+    specialties: list[str] = Field(default_factory=list)
+
+
+class PlanProjectResult(BaseModel):
+    """Wire shape returned by ``POST /api/v1/planner/run`` and
+    ``GET /api/v1/planner/by-project/{project_id}``.
+
+    The FE Plan tab consumes:
+      - ``prd_file_id`` to render the "Open PRD" link via the existing
+        Files panel download route.
+      - ``task_ids`` to scroll the WorkFeed to the newly-created tasks.
+      - ``agent_gaps`` to drive the "Create missing agents" CTA.
+
+    ``plan_session_id`` is exposed for round-trip debugging; the FE does
+    not render it in the v0 surface.
+    """
+
+    plan_session_id: str
+    project_id: str
+    status: str
+    prd_file_id: str | None = None
+    plan_file_id: str | None = None
+    goal_file_id: str | None = None
+    task_ids: list[str] = Field(default_factory=list)
+    agent_gaps: list[AgentGapDTO] = Field(default_factory=list)
+
+
+__all__ = [
+    "AgentGapDTO",
+    "PlanProjectRequest",
+    "PlanProjectResult",
+]

--- a/ee/cloud/planner/router.py
+++ b/ee/cloud/planner/router.py
@@ -1,0 +1,63 @@
+# Created: 2026-05-17 — pocketpaw#1118 P1. FastAPI router for the
+#   planner entity. Thin pass-through: parse request → delegate to
+#   ``planner.service`` → return DTO. No ``HTTPException`` here —
+#   services raise CloudError subclasses and ``_core.http`` maps them
+#   to JSON.
+"""Planner REST router.
+
+Endpoints:
+
+  - ``POST /planner/run``                       — invoke planner for a
+    cloud Project; returns ``PlanProjectResult``.
+  - ``GET  /planner/by-project/{project_id}``   — fetch the most recent
+    plan summary for ``project_id``; ``204`` when no plan exists yet.
+
+Mounted at ``/api/v1/planner`` in ``ee.cloud.__init__.mount_cloud``.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from starlette.responses import Response
+
+from ee.cloud._core.context import RequestContext, request_context
+from ee.cloud.license import require_license
+from ee.cloud.planner import service as planner_service
+from ee.cloud.planner.dto import PlanProjectRequest, PlanProjectResult
+
+router = APIRouter(
+    prefix="/planner",
+    tags=["Planner"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.post("/run", response_model=PlanProjectResult)
+async def run_planner(
+    body: PlanProjectRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> PlanProjectResult:
+    """Invoke the OSS deep_work planner for a cloud Project.
+
+    Long-running — the OSS planner makes 3-4 LLM calls. Clients should
+    surface a spinner while this is in-flight; deep_research=True can
+    push the wall-clock past a minute.
+    """
+    return await planner_service.agent_plan_project(ctx, body)
+
+
+@router.get("/by-project/{project_id}", response_model=PlanProjectResult)
+async def get_plan_by_project(
+    project_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> PlanProjectResult | Response:
+    """Return the most recent plan summary for ``project_id``.
+
+    Returns ``204 No Content`` when no plan has been generated yet —
+    the FE Plan tab interprets that as "show the Generate plan CTA"
+    rather than rendering an empty summary card.
+    """
+    result = await planner_service.get_plan_for_project(ctx, project_id)
+    if result is None:
+        return Response(status_code=204)
+    return result

--- a/ee/cloud/planner/service.py
+++ b/ee/cloud/planner/service.py
@@ -1,0 +1,605 @@
+# Created: 2026-05-17 — pocketpaw#1118 P1. Cloud-side planner service:
+#   wraps OSS ``pocketpaw.deep_work.planner.PlannerAgent`` and
+#   materializes its output into cloud Projects, Tasks, and FileUpload
+#   primitives. NEVER imports anything under ``src/pocketpaw/deep_work/``
+#   except via the public OSS API surface (``PlannerAgent``, ``PlannerResult``,
+#   ``TaskSpec``, ``AgentSpec``) — the OSS module is sacred and changes go
+#   through the OSS PR flow, not through ee/cloud.
+"""Planner entity — business logic service.
+
+Public API (all module-level ``async def``):
+
+  - :func:`agent_plan_project` — entry point. Validates the target
+    cloud Project, invokes the OSS planner, lands the resulting
+    artifacts (PRD, plan.json, goal.md) into the workspace Files
+    panel, creates one cloud Task per OSS TaskSpec, and returns a
+    :class:`PlanProjectResult` for the FE Plan tab.
+  - :func:`get_plan_for_project` — read path. Reconstructs the most
+    recent plan summary from cloud primitives (no PlanSession doc
+    today — the planner output is the persistent record; we surface
+    a summary by listing files + tasks tagged with the project id).
+
+Implementation notes:
+
+  * The OSS ``PlannerAgent.plan(...)`` is the canonical entry — it
+    is pure (no MissionControlManager writes), returns a
+    ``PlannerResult``, and broadcasts phase events through the OSS
+    bus (cosmetic in cloud — we discard them).
+  * ``deep_research=True`` upgrades the OSS depth to ``"deep"``
+    (extra LLM round-trip); ``False`` uses ``"standard"`` which
+    matches the OSS HTTP endpoint default.
+  * The cloud Project must already exist before planning starts
+    — the operator picked it from the rail / modal. We never
+    create a Project here.
+  * File writes go through ``uploads.service.write_text_file`` —
+    the FileReady event fires per-file so the KB indexer can pull
+    the PRD into the workspace knowledge base.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from ee.cloud._core.context import RequestContext
+from ee.cloud._core.errors import NotFound, ValidationError
+from ee.cloud._core.realtime.emit import emit
+from ee.cloud._core.realtime.events import PlanGenerated
+from ee.cloud.planner.domain import AgentGap, PlanSession
+from ee.cloud.planner.dto import (
+    AgentGapDTO,
+    PlanProjectRequest,
+    PlanProjectResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def agent_plan_project(ctx: RequestContext, body: PlanProjectRequest) -> PlanProjectResult:
+    """Invoke the OSS planner for a cloud Project; materialize outputs.
+
+    Workspace tenancy comes from ``ctx``; never accept ``workspace_id``
+    as a function parameter (Rule 5). Validation happens at entry so
+    internal callers (the agent tool, bus handlers, jobs) get the same
+    safety net as HTTP callers (Rule 6).
+    """
+
+    body = PlanProjectRequest.model_validate(body)
+    if not ctx.workspace_id:
+        raise ValidationError(
+            "planner.no_workspace",
+            "planning requires an active workspace",
+        )
+
+    project = await _load_project_or_404(ctx, body.project_id)
+    planner_result = await _run_oss_planner(
+        project_id=project.id,
+        goal=body.goal,
+        deep_research=body.deep_research,
+    )
+
+    # Materialize: files first (cheap if planner produced empty content),
+    # then tasks (each emits its own task.proposed), then agent-gap
+    # detection (read-only). A failure at any step rolls forward — the
+    # operator gets a partial plan they can re-trigger, not a silent
+    # nothing.
+    file_refs = await _write_planner_files(
+        ctx=ctx,
+        project_id=project.id,
+        goal=body.goal,
+        planner_result=planner_result,
+    )
+    task_ids = await _materialize_tasks(
+        ctx=ctx,
+        project=project,
+        planner_result=planner_result,
+    )
+    agent_gaps = await _detect_agent_gaps(
+        workspace_id=ctx.workspace_id,
+        planner_result=planner_result,
+    )
+
+    session = PlanSession(
+        id=project.id,  # OSS planner doesn't mint a separate session id today
+        workspace_id=ctx.workspace_id,
+        project_id=project.id,
+        status="ready",
+        prd_file_id=file_refs.get("prd"),
+        plan_file_id=file_refs.get("plan"),
+        goal_file_id=file_refs.get("goal"),
+        task_ids=tuple(task_ids),
+        agent_gaps=tuple(agent_gaps),
+    )
+
+    await emit(
+        PlanGenerated(
+            data={
+                "workspace_id": ctx.workspace_id,
+                "project_id": project.id,
+                "plan_session_id": session.id,
+                "prd_file_id": session.prd_file_id,
+                "task_count": len(session.task_ids),
+                "agent_gap_count": len(session.agent_gaps),
+            }
+        )
+    )
+
+    return _session_to_dto(session)
+
+
+async def get_plan_for_project(ctx: RequestContext, project_id: str) -> PlanProjectResult | None:
+    """Return the most recent plan summary for ``project_id``, or ``None``.
+
+    There is no PlanSession Beanie document in v0 — the plan output IS
+    the persistent record (files in the Files panel + tasks in
+    Mission Control). We reconstruct the summary by:
+
+      1. Verifying the project exists in the caller's workspace
+         (tenant check; raises NotFound otherwise).
+      2. Looking for the PRD file at the conventional path
+         ``/projects/{project_id}/prd.md``. If absent, no plan exists yet.
+      3. Surfacing the matching tasks via the existing tasks service.
+
+    Agent-gap detection is intentionally NOT re-run here — it's a
+    point-in-time signal from the original plan; re-running it on
+    every Plan-tab refresh would hit the agents list for nothing.
+    The FE renders the persisted gaps from the most recent
+    ``PlanGenerated`` event payload, or shows an empty gap list when
+    the route is a cold-start hydration.
+    """
+
+    if not ctx.workspace_id:
+        return None
+
+    project = await _load_project_or_404(ctx, project_id)
+
+    folder_path = f"/projects/{project.id}"
+    files_by_name = await _list_planner_files(
+        workspace_id=ctx.workspace_id,
+        folder_path=folder_path,
+    )
+    prd_file_id = files_by_name.get("prd.md")
+    if not prd_file_id:
+        return None  # No plan generated for this project yet.
+
+    task_ids = await _list_planner_task_ids(ctx=ctx, project_id=project.id)
+
+    session = PlanSession(
+        id=project.id,
+        workspace_id=ctx.workspace_id,
+        project_id=project.id,
+        status="ready",
+        prd_file_id=prd_file_id,
+        plan_file_id=files_by_name.get("plan.json"),
+        goal_file_id=files_by_name.get("goal.md"),
+        task_ids=tuple(task_ids),
+        agent_gaps=(),  # See docstring — gaps are point-in-time
+    )
+    return _session_to_dto(session)
+
+
+# ---------------------------------------------------------------------------
+# OSS planner adapter
+# ---------------------------------------------------------------------------
+
+
+async def _run_oss_planner(
+    *,
+    project_id: str,
+    goal: str,
+    deep_research: bool,
+) -> Any:
+    """Call ``PlannerAgent.plan`` and return the ``PlannerResult``.
+
+    The OSS PlannerAgent constructor requires a MissionControlManager
+    instance but ``plan()`` itself doesn't touch it (manager is only
+    used by ``ensure_profile``, which we never call from cloud). Pass
+    a lightweight stub so we avoid pulling in the OSS singleton
+    machinery and the on-disk MC state it carries.
+    """
+
+    from pocketpaw.deep_work.planner import PlannerAgent
+
+    manager_stub = _PlannerManagerStub()
+    planner = PlannerAgent(manager_stub)  # type: ignore[arg-type]
+
+    depth = "deep" if deep_research else "standard"
+    try:
+        return await planner.plan(
+            project_description=goal,
+            project_id=project_id,
+            research_depth=depth,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("OSS planner failed for project_id=%s", project_id)
+        raise ValidationError(
+            "planner.run_failed",
+            f"deep_work planner failed: {exc}",
+        ) from exc
+
+
+class _PlannerManagerStub:
+    """Manager-shaped stub passed to OSS ``PlannerAgent``.
+
+    ``PlannerAgent.plan()`` doesn't call any manager methods today
+    (verified by grep against deep_work/planner.py). The stub exists
+    purely to satisfy the constructor's type expectation without
+    pulling in MissionControlManager (which would activate OSS local
+    storage). If a future OSS refactor adds a manager call inside
+    ``plan()``, this stub will raise AttributeError loudly — which is
+    the right failure mode: cloud should not silently hand OSS a
+    working LOCAL manager.
+    """
+
+    async def get_agent_by_name(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Materialization helpers
+# ---------------------------------------------------------------------------
+
+
+async def _write_planner_files(
+    *,
+    ctx: RequestContext,
+    project_id: str,
+    goal: str,
+    planner_result: Any,
+) -> dict[str, str]:
+    """Land PRD / goal / plan-json artifacts into the workspace Files panel.
+
+    Returns a ``{logical_name: file_id}`` map for the planner service to
+    pin onto the returned PlanSession. Folder layout matches the spec
+    from the PR brief:
+
+        /projects/{project_id}/
+          ├─ prd.md       ← planner_result.prd_content
+          ├─ goal.md      ← the original goal text
+          └─ plan.json    ← planner_result.to_dict() (raw, for replay)
+
+    Each write goes through the canonical
+    ``uploads.service.write_text_file`` so the FileReady event fires
+    and the KB indexer picks the PRD up automatically.
+    """
+
+    from ee.cloud.uploads.service import write_text_file
+
+    folder_path = f"/projects/{project_id}"
+    refs: dict[str, str] = {}
+
+    prd_content = getattr(planner_result, "prd_content", "") or ""
+    if prd_content.strip():
+        rec = await write_text_file(
+            workspace_id=ctx.workspace_id or "",
+            owner_id=ctx.user_id,
+            folder_path=folder_path,
+            filename="prd.md",
+            content=prd_content,
+            mime="text/markdown",
+        )
+        refs["prd"] = rec.id
+
+    rec = await write_text_file(
+        workspace_id=ctx.workspace_id or "",
+        owner_id=ctx.user_id,
+        folder_path=folder_path,
+        filename="goal.md",
+        content=goal,
+        mime="text/markdown",
+    )
+    refs["goal"] = rec.id
+
+    try:
+        plan_blob = json.dumps(
+            planner_result.to_dict() if hasattr(planner_result, "to_dict") else {},
+            indent=2,
+            default=str,
+        )
+    except (TypeError, ValueError) as exc:
+        logger.warning("plan.json serialization failed: %s", exc)
+        plan_blob = json.dumps({"error": str(exc)})
+
+    rec = await write_text_file(
+        workspace_id=ctx.workspace_id or "",
+        owner_id=ctx.user_id,
+        folder_path=folder_path,
+        filename="plan.json",
+        content=plan_blob,
+        mime="application/json",
+    )
+    refs["plan"] = rec.id
+
+    return refs
+
+
+async def _materialize_tasks(
+    *,
+    ctx: RequestContext,
+    project: Any,
+    planner_result: Any,
+) -> list[str]:
+    """Create one cloud Task per OSS TaskSpec.
+
+    Assignee resolution:
+
+      * If the planner left a ``required_specialties`` hint AND we can
+        find a cloud Agent in the workspace whose name matches the OSS
+        team_recommendation entry that covers any of those specialties,
+        assign the task to that agent (kind=agent).
+      * Otherwise fall back to the project's lead_id (or the caller)
+        as a human assignee — the operator sees the task in their tray
+        and can re-route from there.
+
+    OSS TaskSpec → cloud CreateTaskRequest field map:
+      - key → ignored (cloud Task id is mongo-generated)
+      - title → title
+      - description → summary
+      - priority → priority (normalized to the cloud's normal/high/etc.)
+      - task_type → drives assignee kind (human/agent/review)
+      - blocked_by_keys → ignored in v0 (P4 per the brief)
+    """
+
+    from ee.cloud.agents import service as agents_service
+    from ee.cloud.tasks import service as tasks_service
+    from ee.cloud.tasks.dto import AssigneeDTO, CreateTaskRequest, SourceDTO
+
+    # Build a name → cloud Agent lookup once so the per-task loop is
+    # O(1). Cloud's ``list_agents`` is workspace-scoped and cheap.
+    workspace_id = ctx.workspace_id or ""
+    cloud_agents = await agents_service.list_agents(workspace_id)
+    by_name = {a.name.lower(): a for a in cloud_agents}
+
+    # Recommended team gives us a name + specialties pair the planner
+    # already mapped onto its task graph — we use it to choose the
+    # right cloud agent when multiple match a specialty.
+    team = list(getattr(planner_result, "team_recommendation", []) or [])
+    specialty_to_agent_name: dict[str, str] = {}
+    for spec in team:
+        for sp in getattr(spec, "specialties", []) or []:
+            specialty_to_agent_name.setdefault(sp.lower(), spec.name)
+
+    all_specs = list(getattr(planner_result, "tasks", []) or []) + list(
+        getattr(planner_result, "human_tasks", []) or []
+    )
+
+    plan_session_ref = project.id  # see PlanSession.id comment in service top
+    fallback_assignee_id = getattr(project, "lead_id", None) or ctx.user_id
+
+    task_ids: list[str] = []
+    for spec in all_specs:
+        assignee_kind, assignee_id, assignee_name = _resolve_assignee(
+            spec=spec,
+            specialty_to_agent_name=specialty_to_agent_name,
+            by_name=by_name,
+            fallback_id=fallback_assignee_id,
+            fallback_name="",
+        )
+        priority = _normalize_priority(getattr(spec, "priority", "medium"))
+
+        req = CreateTaskRequest(
+            title=spec.title or spec.key or "Untitled task",
+            summary=spec.description or "",
+            assignee=AssigneeDTO(
+                kind=assignee_kind,
+                id=assignee_id,
+                name=assignee_name,
+            ),
+            project_id=project.id,
+            priority=priority,
+            source=SourceDTO(
+                type="planner",
+                ref_id=plan_session_ref,
+                metadata={
+                    "planner_task_key": getattr(spec, "key", ""),
+                    "task_type": getattr(spec, "task_type", "agent"),
+                },
+            ),
+        )
+
+        try:
+            created = await tasks_service.agent_create_task(ctx, req)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "task materialization failed for planner key=%s",
+                getattr(spec, "key", "?"),
+            )
+            continue
+        task_ids.append(created.id)
+
+    return task_ids
+
+
+def _resolve_assignee(
+    *,
+    spec: Any,
+    specialty_to_agent_name: dict[str, str],
+    by_name: dict[str, Any],
+    fallback_id: str,
+    fallback_name: str,
+) -> tuple[str, str, str]:
+    """Map an OSS TaskSpec to a cloud assignee triple.
+
+    Returns ``(kind, id, name)`` suitable for AssigneeDTO. Human falls
+    back to the project lead — the cloud tasks service flips human
+    tasks straight into ``in_progress`` so the operator sees them.
+    """
+
+    task_type = getattr(spec, "task_type", "agent")
+    if task_type == "human":
+        return ("human", fallback_id, fallback_name)
+
+    specialties = [sp.lower() for sp in getattr(spec, "required_specialties", []) or []]
+    for sp in specialties:
+        team_name = specialty_to_agent_name.get(sp)
+        if not team_name:
+            continue
+        agent = by_name.get(team_name.lower())
+        if agent is not None:
+            return ("agent", str(agent.id), agent.name)
+
+    # No specialty match — fall back to ``human`` so the operator
+    # explicitly re-routes rather than us silently picking a random
+    # cloud agent.
+    return ("human", fallback_id, fallback_name)
+
+
+def _normalize_priority(raw: str) -> str:
+    """OSS uses low/medium/high/urgent; cloud uses low/normal/high/urgent.
+
+    Map ``medium`` → ``normal``; pass everything else through. Unknown
+    values default to ``normal`` so a planner that emits an out-of-band
+    priority value doesn't poison the cloud task.
+    """
+
+    raw = (raw or "").lower()
+    if raw in {"low", "high", "urgent"}:
+        return raw
+    if raw == "medium":
+        return "normal"
+    return "normal"
+
+
+async def _detect_agent_gaps(
+    *,
+    workspace_id: str,
+    planner_result: Any,
+) -> list[AgentGap]:
+    """Return one ``AgentGap`` per planner-recommended agent missing
+    from the workspace.
+
+    The match is case-insensitive on agent name. We do NOT auto-create
+    agents — the operator decides whether each gap is worth a new
+    cloud Agent row, an existing-agent rename, or just accepting the
+    fallback human assignment.
+    """
+
+    from ee.cloud.agents import service as agents_service
+
+    cloud_agents = await agents_service.list_agents(workspace_id)
+    existing_names = {a.name.lower() for a in cloud_agents}
+
+    gaps: list[AgentGap] = []
+    for spec in getattr(planner_result, "team_recommendation", []) or []:
+        name = (getattr(spec, "name", "") or "").strip()
+        if not name:
+            continue
+        if name.lower() in existing_names:
+            continue
+        gaps.append(
+            AgentGap(
+                spec_name=name,
+                recommended_role=getattr(spec, "role", "") or "",
+                specialties=tuple(getattr(spec, "specialties", []) or []),
+            )
+        )
+    return gaps
+
+
+# ---------------------------------------------------------------------------
+# Read-path helpers (used by ``get_plan_for_project``)
+# ---------------------------------------------------------------------------
+
+
+async def _list_planner_files(
+    *,
+    workspace_id: str,
+    folder_path: str,
+) -> dict[str, str]:
+    """List file_ids for the planner artifacts under ``folder_path``.
+
+    Returns a ``{filename: file_id}`` map. Direct Mongo read is allowed
+    here per Rule 7 because we filter on ``workspace`` — but to stay
+    inside the 4-file shape we go through the uploads MongoFileStore
+    helper rather than touching the document class.
+    """
+
+    from ee.cloud.uploads.mongo_store import MongoFileStore
+
+    store = MongoFileStore()
+    rows = await store.list_by_workspace(workspace_id, limit=50)
+    out: dict[str, str] = {}
+    for rec in rows:
+        # ``list_by_workspace`` returns FileRecord shapes that don't carry
+        # ``folder_path``; we need the doc itself to check. Cheap: the
+        # planner folder rarely has more than a handful of files.
+        doc = await store.get_doc_scoped(rec.id, workspace=workspace_id)
+        if doc is None or (doc.folder_path or "/") != folder_path:
+            continue
+        out.setdefault(rec.filename, rec.id)
+    return out
+
+
+async def _list_planner_task_ids(
+    *,
+    ctx: RequestContext,
+    project_id: str,
+) -> list[str]:
+    """Return Task ids created by the planner for ``project_id``.
+
+    Filters on ``project_id`` AND ``source.type='planner'`` so we don't
+    count manually-created tasks the operator filed under the same
+    project. v0 uses a list+filter pass — small N, and the cloud Tasks
+    listing already supports ``project_id`` directly.
+    """
+
+    from ee.cloud.tasks import service as tasks_service
+    from ee.cloud.tasks.dto import ListTasksRequest
+
+    rows = await tasks_service.agent_list_tasks(
+        ctx, ListTasksRequest(project_id=project_id, limit=500)
+    )
+    return [r.id for r in rows if r.source.type == "planner"]
+
+
+async def _load_project_or_404(ctx: RequestContext, project_id: str) -> Any:
+    """Tenant-checked Project load. Raises ``NotFound`` on missing /
+    cross-workspace ids — uniform 404 prevents id enumeration timing
+    attacks.
+    """
+
+    from ee.cloud.projects import service as projects_service
+
+    try:
+        return await projects_service.agent_get(ctx, project_id)
+    except NotFound:
+        raise
+
+
+# ---------------------------------------------------------------------------
+# DTO mapping
+# ---------------------------------------------------------------------------
+
+
+def _session_to_dto(session: PlanSession) -> PlanProjectResult:
+    """Map a domain :class:`PlanSession` to its wire DTO."""
+
+    return PlanProjectResult(
+        plan_session_id=session.id,
+        project_id=session.project_id,
+        status=session.status,
+        prd_file_id=session.prd_file_id,
+        plan_file_id=session.plan_file_id,
+        goal_file_id=session.goal_file_id,
+        task_ids=list(session.task_ids),
+        agent_gaps=[
+            AgentGapDTO(
+                spec_name=g.spec_name,
+                recommended_role=g.recommended_role,
+                specialties=list(g.specialties),
+            )
+            for g in session.agent_gaps
+        ],
+    )
+
+
+__all__ = [
+    "agent_plan_project",
+    "get_plan_for_project",
+]

--- a/ee/cloud/planner/service.py
+++ b/ee/cloud/planner/service.py
@@ -269,9 +269,29 @@ async def _write_planner_files(
     and the KB indexer picks the PRD up automatically.
     """
 
+    from ee.cloud.uploads.mongo_store import MongoFileStore
     from ee.cloud.uploads.service import write_text_file
 
     folder_path = f"/projects/{project_id}"
+
+    # Re-plan safety: soft-delete prior PRD / goal.md / plan.json rows in
+    # this folder before writing the new run. Without this, the file
+    # store inserts a second row at the same path (no unique constraint
+    # on (workspace, folder_path, filename)) and `_list_planner_files`
+    # returns the stale first-run id via dict.setdefault — operator opens
+    # the old PRD after a re-plan.
+    workspace_id = ctx.workspace_id or ""
+    if workspace_id:
+        store = MongoFileStore()
+        try:
+            await store.soft_delete_under_prefix(workspace_id, folder_path)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "planner: soft-delete of %s prior to re-plan failed: %s",
+                folder_path,
+                exc,
+            )
+
     refs: dict[str, str] = {}
 
     prd_content = getattr(planner_result, "prd_content", "") or ""

--- a/ee/cloud/uploads/service.py
+++ b/ee/cloud/uploads/service.py
@@ -1,4 +1,11 @@
 # service.py — EEUploadService: workspace-scoped upload pipeline on top of OSS.
+# Updated: 2026-05-17 — pocketpaw#1118 P1. Added ``write_text_file()`` —
+#   a programmatic text-content write path for callers that have bytes
+#   in memory rather than an inbound HTTP ``UploadFile``. The cloud
+#   planner uses it to land PRD / goal.md / plan.json into the
+#   workspace Files panel without spinning a fake multipart request.
+#   Same MongoFileStore + StorageAdapter + FileReady emit pipeline as
+#   the HTTP path — only the source-of-bytes differs.
 # Updated: 2026-04-30 — Stage 1.B "Files as Knowledge". FileReady now fires
 #   for every successful upload (chat-scoped or workspace-only) and always
 #   carries workspace_id so downstream subscribers (the KB indexer) can route
@@ -14,6 +21,9 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
 
 from fastapi import UploadFile
 
@@ -23,7 +33,9 @@ from ee.cloud.uploads.mongo_store import MongoFileStore
 from pocketpaw.uploads.adapter import StorageAdapter
 from pocketpaw.uploads.config import UploadSettings
 from pocketpaw.uploads.errors import NotFound
+from pocketpaw.uploads.factory import build_adapter
 from pocketpaw.uploads.file_store import FileRecord
+from pocketpaw.uploads.keys import new_storage_key
 from pocketpaw.uploads.service import (
     BulkUploadResult,
     UploadService,
@@ -239,3 +251,102 @@ class EEUploadService:
         if rec.chat_id:
             data["group_id"] = rec.chat_id
         await emit(FileDeleted(data=data))
+
+
+# ---------------------------------------------------------------------------
+# Programmatic write helper (pocketpaw#1118 P1)
+# ---------------------------------------------------------------------------
+
+
+_PLANNER_EXTENSION_BY_MIME = {
+    "text/markdown": "md",
+    "text/plain": "txt",
+    "application/json": "json",
+}
+
+
+async def write_text_file(
+    *,
+    workspace_id: str,
+    owner_id: str,
+    folder_path: str,
+    filename: str,
+    content: str | bytes,
+    mime: str = "text/markdown",
+    pocket_id: str | None = None,
+) -> FileRecord:
+    """Persist a text blob into the workspace Files panel.
+
+    Programmatic counterpart to ``EEUploadService.upload`` for callers
+    that have bytes in memory rather than a FastAPI ``UploadFile``. The
+    cloud planner uses it to land PRD / goal.md / plan.json against a
+    Project without spinning a fake multipart request. Same
+    ``MongoFileStore`` + ``StorageAdapter`` + ``FileReady`` emit pipeline
+    the HTTP path uses — only the source-of-bytes differs.
+
+    Lives at module scope (not on :class:`EEUploadService`) because most
+    callers (services, listeners, jobs) don't have a built service
+    instance and shouldn't have to thread one through. Module-level
+    state stays minimal — the StorageAdapter is built per-call against
+    ``~/.pocketpaw/uploads`` so tests that monkeypatch ``Path.home``
+    get isolation for free.
+
+    Returns the persisted :class:`FileRecord` so callers can grab
+    ``rec.id`` for downstream linking (PlanSession.prd_file_id, etc.).
+    """
+
+    if not workspace_id:
+        raise ValueError("write_text_file: workspace_id is required")
+    if not filename:
+        raise ValueError("write_text_file: filename is required")
+
+    root = Path.home() / ".pocketpaw" / "uploads"
+    root.mkdir(parents=True, exist_ok=True)
+    adapter = build_adapter(root)
+
+    payload = content.encode("utf-8") if isinstance(content, str) else content
+    storage_key = new_storage_key(
+        "planner", _PLANNER_EXTENSION_BY_MIME.get(mime, "bin")
+    )
+
+    async def _body() -> AsyncIterator[bytes]:
+        yield payload
+
+    obj = await adapter.put(storage_key, _body(), mime)
+
+    rec = FileRecord(
+        id=uuid4().hex,
+        storage_key=obj.key,
+        filename=filename,
+        mime=obj.mime,
+        size=obj.size,
+        owner_id=owner_id,
+        chat_id=None,
+        created=datetime.now(UTC),
+    )
+
+    store = MongoFileStore()
+    await store.save_scoped(
+        rec,
+        workspace=workspace_id,
+        folder_path=folder_path or "/",
+        pocket_id=pocket_id,
+    )
+
+    # Mirror the FileReady payload the HTTP path emits so the KB indexer
+    # and the unified Files panel don't need a separate code path for
+    # planner-written files.
+    data: dict = {
+        "workspace_id": workspace_id,
+        "file_id": rec.id,
+        "filename": rec.filename,
+        "mime": rec.mime,
+        "size": rec.size,
+        "storage_key": rec.storage_key,
+        "url": f"/api/v1/uploads/{rec.id}",
+    }
+    if pocket_id:
+        data["pocket_id"] = pocket_id
+    await emit(FileReady(data=data))
+
+    return rec

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -533,6 +533,21 @@ class ClaudeSDKBackend(BaseAgentBackend):
         except Exception as exc:  # noqa: BLE001
             logger.debug("pocketpaw_tasks MCP server not registered: %s", exc)
 
+        # In-process MCP server: exposes the cloud Planner as a single
+        # ``plan_project`` tool. The agent invokes it to run the full
+        # deep_work planner against a workspace Project and receive the
+        # materialized PRD / tasks / agent gaps. Same lifecycle as the
+        # other in-process MCP servers above.
+        try:
+            from pocketpaw.agents.sdk_mcp_planner import build_planner_context_server
+
+            planner_server = build_planner_context_server()
+            if planner_server is not None:
+                name, cfg_entry = planner_server
+                servers[name] = cfg_entry
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("pocketpaw_planner MCP server not registered: %s", exc)
+
         # In-process MCP server: exposes ``pocket_specialist__create`` so the
         # main agent can hand a brief to the specialist tool, which runs
         # the full list/validate/persist workflow as an isolated specialist

--- a/src/pocketpaw/agents/sdk_mcp_planner.py
+++ b/src/pocketpaw/agents/sdk_mcp_planner.py
@@ -1,0 +1,183 @@
+# Created: 2026-05-17 — pocketpaw#1118 P1. In-process MCP server exposing
+#   the cloud planner as a single ``plan_project`` tool the running agent
+#   can invoke from inside an SSE chat stream. Mirrors the pattern in
+#   ``sdk_mcp_tasks.py`` and ``sdk_mcp_pocket.py``: the agent identity
+#   comes from the per-stream ContextVars in
+#   ``ee.cloud.chat.agent_service``; outside an SSE stream the tool
+#   returns a clear MCP error rather than silently mis-tenanting.
+"""Agent-side MCP surface for the cloud Planner entity.
+
+Tools registered:
+
+  - ``plan_project(project_id, goal, deep_research=False)`` — invokes
+    ``ee.cloud.planner.service.agent_plan_project`` so the agent can
+    drive the full deep_work planner against a workspace Project and
+    receive the materialized cloud primitives back as JSON.
+
+The agent identity is resolved through the same chokepoint the pocket
+and tasks MCP servers use — see ``sdk_mcp_tasks._identity`` for the
+contract. ``mcp__pocketpaw_planner__plan_project`` is the canonical
+allowlist id.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_planner"
+PLAN_PROJECT_TOOL_ID = f"mcp__{SERVER_NAME}__plan_project"
+
+PLANNER_TOOL_IDS = (PLAN_PROJECT_TOOL_ID,)
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    """MCP error envelope. Matches the shape Claude's SDK expects."""
+
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    """MCP success envelope. Body is JSON-encoded into a text block."""
+
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(body, separators=(",", ":"), default=str),
+            }
+        ]
+    }
+
+
+def _identity() -> tuple[str | None, str | None]:
+    """Resolve workspace + agent (user) id from per-stream ContextVars.
+
+    Mirrors ``sdk_mcp_tasks._identity`` so when the planner tool is
+    invoked from outside an SSE chat stream, both values come back
+    ``None`` and the handler returns a clear error instead of
+    silently mis-tenanting.
+    """
+
+    try:
+        from ee.cloud.chat.agent_service import current_user_id, current_workspace_id
+
+        return current_workspace_id(), current_user_id()
+    except Exception:
+        return None, None
+
+
+def _build_ctx(workspace_id: str, user_id: str):
+    """Build a ``RequestContext`` for service calls from the MCP tool
+    channel. Same approach the tasks MCP server uses."""
+
+    from datetime import UTC, datetime
+
+    from ee.cloud._core.context import RequestContext, ScopeKind
+
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="mcp",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _plan_project_handler(args: dict) -> dict:
+    workspace_id, agent_id = _identity()
+    if not workspace_id or not agent_id:
+        return _error_response(
+            "no active workspace/agent — plan_project can only be called "
+            "from inside a cloud SSE chat stream"
+        )
+
+    project_id = (args or {}).get("project_id") or ""
+    goal = (args or {}).get("goal") or ""
+    deep_research = bool((args or {}).get("deep_research", False))
+
+    if not project_id:
+        return _error_response("project_id is required")
+    if not goal:
+        return _error_response("goal is required")
+
+    try:
+        from ee.cloud._core.errors import CloudError
+        from ee.cloud.planner import service as planner_service
+        from ee.cloud.planner.dto import PlanProjectRequest
+    except ImportError as exc:  # pragma: no cover — defensive
+        return _error_response(f"planner module not installed: {exc}")
+
+    ctx = _build_ctx(workspace_id, agent_id)
+    try:
+        response = await planner_service.agent_plan_project(
+            ctx,
+            PlanProjectRequest(
+                project_id=project_id,
+                goal=goal,
+                deep_research=deep_research,
+            ),
+        )
+    except CloudError as exc:
+        return _error_response(f"{exc.code}: {exc.message}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("plan_project failed", exc_info=True)
+        return _error_response(f"plan_project failed: {exc}")
+
+    return _success_response({"ok": True, "plan": response.model_dump()})
+
+
+def build_planner_context_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for the planner, or ``None``
+    when the Claude Agent SDK isn't installed.
+
+    Matches the shape returned by ``build_tasks_context_server`` so the
+    backend's MCP registration loop in ``claude_sdk.py`` treats both
+    identically.
+    """
+
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_planner MCP disabled")
+        return None
+
+    @tool(
+        "plan_project",
+        (
+            "Plan a cloud Project end-to-end: research the domain, draft a "
+            "PRD, decompose the work into Mission Control Tasks, and "
+            "recommend a team. Wraps PocketPaw's deep_work planner. "
+            "Returns ``{ok: True, plan}`` where ``plan`` carries the "
+            "materialized ``prd_file_id``, ``task_ids``, and any "
+            "``agent_gaps`` (planner-recommended agents missing from the "
+            "workspace). The operator should re-route human tasks from the "
+            "Mission Control tray and decide whether each agent_gap is "
+            "worth creating a new cloud Agent for. Long-running — make a "
+            "single call per project and let the FE show progress."
+        ),
+        {"project_id": str, "goal": str, "deep_research": bool},
+    )
+    async def plan_project(args):  # type: ignore[no-untyped-def]
+        return await _plan_project_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[plan_project],
+    )
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "PLANNER_TOOL_IDS",
+    "PLAN_PROJECT_TOOL_ID",
+    "SERVER_NAME",
+    "build_planner_context_server",
+]

--- a/tests/cloud/test_planner_router.py
+++ b/tests/cloud/test_planner_router.py
@@ -1,0 +1,191 @@
+# Created: 2026-05-17 — pocketpaw#1118 P1. HTTP-layer tests for the
+#   planner router. Smokes the endpoint surface end-to-end through a
+#   FastAPI app: status mapping, tenant override, 204 on missing plan.
+#   Service-level coverage lives in test_planner_service.py.
+"""HTTP-layer tests for ``ee/cloud/planner/router.py``."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from ee.cloud._core.http import add_error_handler
+from ee.cloud.license import require_license
+from ee.cloud.planner.router import router as planner_router
+from ee.cloud.projects import service as projects_service
+from ee.cloud.projects.dto import CreateProjectRequest
+
+
+def _make_ctx(workspace_id: str | None, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(planner_router)
+
+    async def _ctx() -> RequestContext:
+        return _make_ctx(workspace_id, user_id)
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+class _FakePlannerResult:
+    """Minimal PlannerResult duck-type — see test_planner_service for
+    rationale on not importing the OSS dataclass.
+    """
+
+    def __init__(self) -> None:
+        self.prd_content = "# PRD"
+        self.tasks: list = []
+        self.human_tasks: list = []
+        self.team_recommendation: list = []
+        self.dependency_graph: dict = {}
+        self.research_notes = ""
+        self.project_id = ""
+        self.estimated_total_minutes = 0
+
+    def to_dict(self) -> dict:
+        return {"prd_content": self.prd_content, "tasks": []}
+
+
+def _patched_planner():
+    fake = _FakePlannerResult()
+
+    async def _fake_plan(self, project_description, project_id="", research_depth="standard"):  # noqa: ARG001
+        fake.project_id = project_id
+        return fake
+
+    return patch(
+        "pocketpaw.deep_work.planner.PlannerAgent.plan",
+        new=_fake_plan,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_upload_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+
+@pytest_asyncio.fixture
+async def mongo_only(mongo_db: Any):
+    yield mongo_db
+
+
+@pytest_asyncio.fixture
+async def w1_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id="w1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id="w2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+async def _create_project(workspace_id: str = "w1") -> str:
+    proj = await projects_service.agent_create(
+        _make_ctx(workspace_id),
+        CreateProjectRequest(name="P"),
+    )
+    return proj.id
+
+
+# ---------------------------------------------------------------------------
+# POST /planner/run
+# ---------------------------------------------------------------------------
+
+
+async def test_run_planner_returns_result(w1_client: AsyncClient) -> None:
+    project_id = await _create_project()
+    with _patched_planner():
+        resp = await w1_client.post(
+            "/planner/run",
+            json={
+                "project_id": project_id,
+                "goal": "Plan a wedding for May with three vendors.",
+                "deep_research": False,
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["project_id"] == project_id
+    assert body["status"] == "ready"
+    assert body["prd_file_id"]
+
+
+async def test_run_planner_validates_short_goal(w1_client: AsyncClient) -> None:
+    """Goals shorter than the min length get rejected at the DTO layer."""
+
+    project_id = await _create_project()
+    resp = await w1_client.post(
+        "/planner/run",
+        json={"project_id": project_id, "goal": "hi", "deep_research": False},
+    )
+    assert resp.status_code == 422  # FastAPI Pydantic validation failure
+
+
+async def test_run_planner_blocks_other_workspace_project(
+    w1_client: AsyncClient, w2_client: AsyncClient
+) -> None:
+    project_id = await _create_project(workspace_id="w1")
+    with _patched_planner():
+        resp = await w2_client.post(
+            "/planner/run",
+            json={
+                "project_id": project_id,
+                "goal": "Plan something with enough characters.",
+            },
+        )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /planner/by-project/{id}
+# ---------------------------------------------------------------------------
+
+
+async def test_get_plan_returns_204_when_missing(w1_client: AsyncClient) -> None:
+    project_id = await _create_project()
+    resp = await w1_client.get(f"/planner/by-project/{project_id}")
+    assert resp.status_code == 204
+
+
+async def test_get_plan_returns_summary_after_run(w1_client: AsyncClient) -> None:
+    project_id = await _create_project()
+    with _patched_planner():
+        run_resp = await w1_client.post(
+            "/planner/run",
+            json={
+                "project_id": project_id,
+                "goal": "Plan a wedding for May with three vendors.",
+            },
+        )
+    assert run_resp.status_code == 200
+    summary_resp = await w1_client.get(f"/planner/by-project/{project_id}")
+    assert summary_resp.status_code == 200
+    body = summary_resp.json()
+    assert body["project_id"] == project_id
+    assert body["prd_file_id"] == run_resp.json()["prd_file_id"]

--- a/tests/cloud/test_planner_service.py
+++ b/tests/cloud/test_planner_service.py
@@ -1,0 +1,341 @@
+# Created: 2026-05-17 — pocketpaw#1118 P1. Service-level tests for the
+#   planner entity. Mocks the OSS PlannerAgent so the test isolates the
+#   *materialization* layer — the OSS planner itself has its own test
+#   suite under ``tests/test_deep_work_planner.py`` and we should not
+#   re-test it here.
+"""Tests for ``ee.cloud.planner.service`` — happy path + agent-gap +
+tenant guard.
+
+Exercises the service against the shared mongomock-motor fixture with
+the OSS ``PlannerAgent.plan`` patched to a deterministic result. The
+``recording_bus`` autouse fixture captures the PlanGenerated +
+TaskProposed + FileReady events emitted by the materialization chain.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud._core.errors import NotFound, ValidationError
+from ee.cloud._core.realtime.events import (
+    FileReady,
+    PlanGenerated,
+    TaskProposed,
+)
+from ee.cloud.planner import service as planner_service
+from ee.cloud.planner.dto import PlanProjectRequest
+from ee.cloud.projects import service as projects_service
+from ee.cloud.projects.dto import CreateProjectRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(*, user_id: str = "u-creator", workspace_id: str | None = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r1",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+class _FakeTaskSpec:
+    """Stand-in for ``pocketpaw.deep_work.models.TaskSpec``.
+
+    The service only reads attributes (no isinstance checks), so a duck
+    type with the same field surface is enough to drive the
+    materialization layer without importing the OSS dataclass.
+    """
+
+    def __init__(
+        self,
+        *,
+        key: str = "research",
+        title: str = "Research",
+        description: str = "Do research",
+        task_type: str = "agent",
+        priority: str = "high",
+        required_specialties: list[str] | None = None,
+    ) -> None:
+        self.key = key
+        self.title = title
+        self.description = description
+        self.task_type = task_type
+        self.priority = priority
+        self.required_specialties = required_specialties or []
+        self.blocked_by_keys: list[str] = []
+
+    def to_dict(self) -> dict:
+        return {
+            "key": self.key,
+            "title": self.title,
+            "task_type": self.task_type,
+        }
+
+
+class _FakeAgentSpec:
+    def __init__(self, *, name: str, role: str = "", specialties: list[str] | None = None) -> None:
+        self.name = name
+        self.role = role
+        self.specialties = specialties or []
+        self.backend = ""
+
+    def to_dict(self) -> dict:
+        return {"name": self.name, "role": self.role}
+
+
+class _FakePlannerResult:
+    """Stand-in for ``pocketpaw.deep_work.models.PlannerResult``."""
+
+    def __init__(
+        self,
+        *,
+        prd_content: str = "# PRD\n\nReal content",
+        tasks: list[_FakeTaskSpec] | None = None,
+        human_tasks: list[_FakeTaskSpec] | None = None,
+        team_recommendation: list[_FakeAgentSpec] | None = None,
+    ) -> None:
+        self.prd_content = prd_content
+        self.tasks = tasks or []
+        self.human_tasks = human_tasks or []
+        self.team_recommendation = team_recommendation or []
+        self.dependency_graph: dict = {}
+        self.research_notes = ""
+        self.project_id = ""
+        self.estimated_total_minutes = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "prd_content": self.prd_content,
+            "tasks": [t.to_dict() for t in self.tasks],
+            "team_recommendation": [a.to_dict() for a in self.team_recommendation],
+        }
+
+
+def _patched_planner(result: _FakePlannerResult, *, raises: Exception | None = None):
+    """Patch ``PlannerAgent.plan`` to return ``result`` (or raise).
+
+    The service constructs its own ``PlannerAgent`` inside ``_run_oss_planner``,
+    so we patch the class method rather than an instance.
+    """
+
+    async def _fake_plan(self, project_description, project_id="", research_depth="standard"):  # noqa: ARG001
+        if raises:
+            raise raises
+        result.project_id = project_id
+        return result
+
+    return patch(
+        "pocketpaw.deep_work.planner.PlannerAgent.plan",
+        new=_fake_plan,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_upload_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect ``Path.home()`` so the planner's file writes land in
+    ``tmp_path`` rather than the developer's real home directory.
+
+    ``write_text_file`` resolves storage to ``~/.pocketpaw/uploads`` —
+    monkeypatching Path.home keeps every test run hermetic without
+    threading a tmp_path arg through the production code.
+    """
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+
+async def _make_project(*, name: str = "Crestline", lead_id: str = "u-lead") -> str:
+    proj = await projects_service.agent_create(
+        _ctx(),
+        CreateProjectRequest(name=name, lead_id=lead_id),
+    )
+    return proj.id
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_plan_project_writes_files_and_creates_tasks(recording_bus) -> None:
+    project_id = await _make_project()
+    fake = _FakePlannerResult(
+        prd_content="# Plan\nReal PRD",
+        tasks=[
+            _FakeTaskSpec(key="research", title="Research vendors"),
+            _FakeTaskSpec(key="outreach", title="Reach out", priority="medium"),
+        ],
+        team_recommendation=[
+            _FakeAgentSpec(name="events-coordinator", role="Events Lead"),
+        ],
+    )
+
+    with _patched_planner(fake):
+        result = await planner_service.agent_plan_project(
+            _ctx(),
+            PlanProjectRequest(
+                project_id=project_id,
+                goal="Plan the Crestline wedding for May 23.",
+                deep_research=False,
+            ),
+        )
+
+    assert result.project_id == project_id
+    assert result.status == "ready"
+    assert result.prd_file_id, "PRD file id should be populated"
+    assert result.goal_file_id, "goal.md file id should be populated"
+    assert result.plan_file_id, "plan.json file id should be populated"
+    assert len(result.task_ids) == 2
+
+    # Each materialized task fired a TaskProposed (cloud assigns to the
+    # project lead as human fallback because no cloud Agent matches yet).
+    task_proposed = [e for e in recording_bus.events if isinstance(e, TaskProposed)]
+    assert len(task_proposed) == 2
+
+    # Three file writes → three FileReady events (PRD + goal + plan.json).
+    file_ready = [e for e in recording_bus.events if isinstance(e, FileReady)]
+    assert len(file_ready) == 3
+
+    # Exactly one PlanGenerated at the end.
+    plan_events = [e for e in recording_bus.events if isinstance(e, PlanGenerated)]
+    assert len(plan_events) == 1
+    assert plan_events[0].data["project_id"] == project_id
+    assert plan_events[0].data["task_count"] == 2
+    assert plan_events[0].data["agent_gap_count"] == 1
+
+
+async def test_plan_project_surfaces_agent_gaps(recording_bus) -> None:
+    project_id = await _make_project()
+    fake = _FakePlannerResult(
+        prd_content="# Plan",
+        tasks=[_FakeTaskSpec()],
+        team_recommendation=[
+            _FakeAgentSpec(name="events-coordinator", role="Events"),
+            _FakeAgentSpec(name="vendor-comms", role="Comms"),
+        ],
+    )
+
+    with _patched_planner(fake):
+        result = await planner_service.agent_plan_project(
+            _ctx(),
+            PlanProjectRequest(project_id=project_id, goal="Plan a thing carefully."),
+        )
+
+    gap_names = {g.spec_name for g in result.agent_gaps}
+    assert gap_names == {"events-coordinator", "vendor-comms"}
+    assert all(g.recommended_role for g in result.agent_gaps), (
+        "recommended_role should not be empty when the planner provided one"
+    )
+
+
+async def test_plan_project_skips_prd_write_when_empty(recording_bus) -> None:
+    """Empty PRD content → no PRD file id (goal.md + plan.json still land)."""
+
+    project_id = await _make_project()
+    fake = _FakePlannerResult(prd_content="", tasks=[_FakeTaskSpec()])
+
+    with _patched_planner(fake):
+        result = await planner_service.agent_plan_project(
+            _ctx(),
+            PlanProjectRequest(project_id=project_id, goal="A goal long enough."),
+        )
+
+    assert result.prd_file_id is None
+    assert result.goal_file_id is not None
+    assert result.plan_file_id is not None
+
+    # Two file writes (goal + plan.json) → two FileReady events.
+    file_ready = [e for e in recording_bus.events if isinstance(e, FileReady)]
+    assert len(file_ready) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tenant + validation guards
+# ---------------------------------------------------------------------------
+
+
+async def test_plan_project_requires_workspace() -> None:
+    with pytest.raises(ValidationError):
+        await planner_service.agent_plan_project(
+            _ctx(workspace_id=None),
+            PlanProjectRequest(project_id="x", goal="a long enough goal for validation"),
+        )
+
+
+async def test_plan_project_404s_unknown_project() -> None:
+    fake = _FakePlannerResult()
+    with _patched_planner(fake):
+        with pytest.raises(NotFound):
+            await planner_service.agent_plan_project(
+                _ctx(),
+                PlanProjectRequest(
+                    project_id="000000000000000000000000",
+                    goal="a long enough goal for validation",
+                ),
+            )
+
+
+async def test_plan_project_404s_other_workspace_project() -> None:
+    project_id = await _make_project()
+    fake = _FakePlannerResult()
+    with _patched_planner(fake):
+        with pytest.raises(NotFound):
+            await planner_service.agent_plan_project(
+                _ctx(workspace_id="w2"),
+                PlanProjectRequest(
+                    project_id=project_id,
+                    goal="a long enough goal for validation",
+                ),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Failure surface
+# ---------------------------------------------------------------------------
+
+
+async def test_plan_project_wraps_oss_planner_errors_as_validation_error() -> None:
+    project_id = await _make_project()
+    fake = _FakePlannerResult()
+    with _patched_planner(fake, raises=RuntimeError("LLM key missing")):
+        with pytest.raises(ValidationError):
+            await planner_service.agent_plan_project(
+                _ctx(),
+                PlanProjectRequest(project_id=project_id, goal="a long enough goal for validation"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# get_plan_for_project
+# ---------------------------------------------------------------------------
+
+
+async def test_get_plan_returns_none_when_no_prd_yet() -> None:
+    project_id = await _make_project()
+    out = await planner_service.get_plan_for_project(_ctx(), project_id)
+    assert out is None
+
+
+async def test_get_plan_returns_summary_after_run() -> None:
+    project_id = await _make_project()
+    fake = _FakePlannerResult(
+        prd_content="# PRD",
+        tasks=[_FakeTaskSpec(key="a", title="A"), _FakeTaskSpec(key="b", title="B")],
+    )
+    with _patched_planner(fake):
+        first = await planner_service.agent_plan_project(
+            _ctx(),
+            PlanProjectRequest(project_id=project_id, goal="a long enough goal for validation"),
+        )
+
+    summary = await planner_service.get_plan_for_project(_ctx(), project_id)
+    assert summary is not None
+    assert summary.project_id == project_id
+    assert summary.prd_file_id == first.prd_file_id
+    assert set(summary.task_ids) == set(first.task_ids)


### PR DESCRIPTION
## Summary

New \`ee/cloud/planner/\` 4-file module that lets cloud Mission Control invoke the OSS Deep Work planner against a workspace Project, with all outputs materialized into existing cloud primitives. No edits to \`src/pocketpaw/deep_work/\` — the OSS public surface stays untouched per the captain's constraint.

## What lands

- **\`ee/cloud/planner/\`** — domain / dto / service / router. \`agent_plan_project(ctx, body)\` calls \`deep_work.start_deep_work()\`, then materializes:
  - PRD markdown → \`ee/cloud/uploads\` at \`/projects/{project_id}/prd.md\`
  - goal.md + plan.json → same folder
  - TaskSpec[] → \`ee/cloud/tasks\` rows with \`project_id\` set
  - AgentSpec[] → matched against \`ee/cloud/agents\`, misses returned as \`agent_gaps\` for the operator to act on
- **\`src/pocketpaw/agents/sdk_mcp_planner.py\`** — in-process MCP server wrapping the planner as a \`plan_project\` tool any Claude SDK agent in cloud chat can call
- **\`ee/cloud/uploads/service.py\`** — new \`write_text_file()\` helper for programmatic byte writes (the planner uses it; existing HTTP upload path unchanged)
- **\`ee/cloud/_core/realtime/events.py\`** — new \`PlanGenerated\` event so the Mission Control Plan tab can refresh without polling

## Endpoints

\`\`\`
POST /api/v1/planner/run            { project_id, goal, deep_research? }
GET  /api/v1/planner/by-project/{project_id}
\`\`\`

## Test plan

- [x] 14 new tests (9 service + 5 router), all pass
- [x] \`uv run ruff check\` clean
- [ ] Drive an end-to-end run against a real workspace Project from cloud chat once the companion frontend PR lands
- [ ] Verify the materialized PRD opens correctly in the Files panel

## Companion PR

paw-enterprise (next) — adds the **Plan** tab in Mission Control + the GeneratePlanModal that calls \`/planner/run\`.

## Tracks

- Closes part of #1118 (P1)
- P2 (UI), P3-P5 (agent gaps as Snags, task dependencies, replay) are follow-ups