### PR TITLE
feat(planner): agent-gap resolution + task dependencies (#1118 P3 + P4)

### DIFF
--- a/ee/cloud/_core/realtime/events.py
+++ b/ee/cloud/_core/realtime/events.py
@@ -398,3 +398,13 @@ class ProjectDeleted(Event):
 @dataclass
 class PlanGenerated(Event):
     EVENT_TYPE: ClassVar[str] = "plan.generated"
+
+
+# Planner — fires after ``ee.cloud.planner.service.agent_resolve_gap``
+# reassigns the human-fallback tasks for a previously-missing agent spec
+# to a newly-created cloud Agent. Listeners refresh the Plan tab's
+# agent-gap card (removing the resolved spec) and the Mission Control
+# feed (rows whose assignee changed).
+@dataclass
+class PlanGapResolved(Event):
+    EVENT_TYPE: ClassVar[str] = "plan.gap_resolved"

--- a/ee/cloud/mission_control/domain.py
+++ b/ee/cloud/mission_control/domain.py
@@ -4,6 +4,11 @@
 # into the unified frontend representation. Frozen dataclass per the ee/cloud
 # Code Rules (CLAUDE.md §3): workspace + assignee tenancy fields are required,
 # so constructing a WorkItem without them is a type error.
+# Updated: 2026-05-17 (feat/planner-gaps-and-deps) — pocketpaw#1118 P4
+# added ``blocked_by: tuple[str, ...]`` carrying ``task:<id>``-prefixed
+# WorkItem ids the row depends on. The projector in mission_control.service
+# threads ``Task.blocked_by`` through with the prefix so the frontend can
+# render dependency edges in the unified feed.
 """Mission Control domain value objects.
 
 Pure-Python frozen dataclasses. No Beanie, no Pydantic, no FastAPI
@@ -84,6 +89,11 @@ class WorkItem:
     created_at: datetime | None
     updated_at: datetime | None
     fabric_refs: tuple[str, ...] = field(default_factory=tuple)
+    # Prefixed WorkItem ids this row depends on (``task:<task_id>`` for
+    # Tasks, future ``nudge:<id>`` etc. when other sources gain deps).
+    # Empty tuple for sources that don't model dependencies (Instinct
+    # Nudges, activity ticker entries).
+    blocked_by: tuple[str, ...] = field(default_factory=tuple)
 
 
 __all__ = [

--- a/ee/cloud/mission_control/dto.py
+++ b/ee/cloud/mission_control/dto.py
@@ -10,6 +10,10 @@
 # WorkItem domain still uses ``AssigneeKind.USER`` ("user") for Instinct
 # projections, but the reassign endpoint only acts on Tasks, so the wire
 # contract for the request body follows Tasks.
+# Updated: 2026-05-17 (feat/planner-gaps-and-deps) — pocketpaw#1118 P4
+# added ``blocked_by: list[str]`` to ``WorkItemResponse`` and threaded it
+# through ``work_item_to_response`` so the frontend feed shows dependency
+# edges in the unified WorkItem shape.
 """Mission Control wire DTOs.
 
 The audit doc (``docs/internal/2026-05-mission-control-backend-audit.md``,
@@ -153,6 +157,7 @@ class WorkItemResponse(BaseModel):
     created_at: datetime | None = None
     updated_at: datetime | None = None
     fabric_refs: list[str] = Field(default_factory=list)
+    blocked_by: list[str] = Field(default_factory=list)
 
 
 def work_item_to_response(item: WorkItem) -> WorkItemResponse:
@@ -174,6 +179,7 @@ def work_item_to_response(item: WorkItem) -> WorkItemResponse:
         created_at=item.created_at,
         updated_at=item.updated_at,
         fabric_refs=list(item.fabric_refs),
+        blocked_by=list(item.blocked_by),
     )
 
 

--- a/ee/cloud/mission_control/service.py
+++ b/ee/cloud/mission_control/service.py
@@ -8,6 +8,11 @@
 # skip non-Task ids (Instinct Actions don't reassign or snooze). Also
 # tagged the per-bulk approve/reject loops with ``# no-event`` comments
 # so rule #9 is satisfied without redundant double-emits.
+# Updated: 2026-05-17 (feat/planner-gaps-and-deps) — pocketpaw#1118 P4
+# threaded ``task.blocked_by`` through the WorkItem projection. Each
+# dependency id is prefixed with ``task:`` so the frontend's heterogeneous
+# feed can link dependency edges to their corresponding WorkItem rows
+# without translating ids client-side.
 """Mission Control façade service.
 
 Every function is module-level ``async def`` per ee/cloud rule #5. The
@@ -215,11 +220,17 @@ def _task_to_work_item(task: Any, workspace_id: str) -> WorkItem:
 
     Accepts either a ``tasks.domain.Task`` or a ``TaskResponse`` DTO —
     both expose the same field names so attribute access works on either.
+
+    ``blocked_by`` ids are prefixed with ``task:`` to match the
+    WorkItem id convention — the frontend can resolve a dependency edge
+    back to its WorkItem row without a translation step.
     """
     assignee = task.assignee
     assignee_kind = AssigneeKind.AGENT if assignee.kind == "agent" else AssigneeKind.USER
     status = _TASK_STATUS_MAP.get(task.status, WorkItemStatus.IN_PROGRESS)
     section = _task_section(task.status, assignee.kind)
+    blocked_by_raw = getattr(task, "blocked_by", None) or ()
+    blocked_by = tuple(f"task:{dep_id}" for dep_id in blocked_by_raw)
     return WorkItem(
         id=f"task:{task.id}",
         workspace_id=workspace_id,
@@ -237,6 +248,7 @@ def _task_to_work_item(task: Any, workspace_id: str) -> WorkItem:
         created_at=task.created_at,
         updated_at=task.updated_at,
         fabric_refs=(),
+        blocked_by=blocked_by,
     )
 
 

--- a/ee/cloud/models/__init__.py
+++ b/ee/cloud/models/__init__.py
@@ -11,6 +11,7 @@ from ee.cloud.models.group import Group, GroupAgent
 from ee.cloud.models.invite import Invite
 from ee.cloud.models.message import Attachment, Mention, Message, Reaction
 from ee.cloud.models.notification import Notification, NotificationSource
+from ee.cloud.models.planner import PlanSession, PlanSessionAgentGap
 from ee.cloud.models.pocket import Pocket, Widget, WidgetPosition
 from ee.cloud.models.project import Project
 from ee.cloud.models.read_state import ReadState
@@ -55,6 +56,8 @@ __all__ = [
     "Notification",
     "NotificationSource",
     "OAuthAccount",
+    "PlanSession",
+    "PlanSessionAgentGap",
     "Pocket",
     "Project",
     "Reaction",
@@ -95,6 +98,7 @@ def get_all_documents():
         Task,
         Cycle,
         Project,
+        PlanSession,
     ]
 
 

--- a/ee/cloud/models/planner.py
+++ b/ee/cloud/models/planner.py
@@ -1,0 +1,65 @@
+# planner.py — Beanie document for the Planner entity.
+# Created: 2026-05-17 — pocketpaw#1118 P3. Persists the cloud-side
+#   record of one OSS planner run (PRD + plan.json + goal.md + tasks +
+#   the agent-gap diagnostic). v0 stored nothing — the plan was
+#   reconstructed from files on every read. P3 needs a queryable record
+#   so ``planner.service.agent_resolve_gap`` can look up which tasks a
+#   plan session created and which gaps it surfaced without parsing
+#   plan.json.
+"""PlanSession document — one OSS planner run materialized into cloud.
+
+Embedded sub-document :class:`PlanSessionAgentGap` mirrors the wire
+``AgentGapDTO`` shape so the read path is a 1:1 mapping. The document is
+workspace-scoped (Indexed on ``workspace``) and pinned to the cloud
+``project_id`` so a re-plan replaces the prior session for that project
+rather than accumulating duplicates.
+
+Only ``ee.cloud.planner.service`` may import this module — enforced by
+the ``import-linter`` contract in ``pyproject.toml``.
+"""
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pydantic import BaseModel, Field
+
+from ee.cloud.models.base import TimestampedDocument
+
+
+class PlanSessionAgentGap(BaseModel):
+    """Embedded shape for one planner-recommended agent missing from the
+    workspace. Carries the spec_name + role + specialties the planner
+    suggested so the operator UI can render the gap card without a
+    follow-up fetch."""
+
+    spec_name: str
+    recommended_role: str = ""
+    specialties: list[str] = Field(default_factory=list)
+
+
+class PlanSession(TimestampedDocument):
+    """One materialized OSS planner run.
+
+    ``project_id`` pins the session to a cloud Project; we look the doc
+    up by ``(workspace, project_id)`` for the resolve-gap flow rather
+    than relying on the OSS planner's own session id (which today is
+    just the project_id verbatim).
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    project_id: str
+    status: str = Field(default="ready", pattern="^(ready|stale)$")
+    prd_file_id: str | None = None
+    plan_file_id: str | None = None
+    goal_file_id: str | None = None
+    task_ids: list[str] = Field(default_factory=list)
+    agent_gaps: list[PlanSessionAgentGap] = Field(default_factory=list)
+
+    class Settings:
+        name = "plan_sessions"
+        indexes = [
+            [("workspace", 1), ("project_id", 1)],
+        ]
+
+
+__all__ = ["PlanSession", "PlanSessionAgentGap"]

--- a/ee/cloud/models/task.py
+++ b/ee/cloud/models/task.py
@@ -6,6 +6,10 @@
 #   workspace always. Indexes back the two hot query paths:
 #     - "list my work" by (workspace_id, assignee_id, status)
 #     - "items in this cycle" by (workspace_id, cycle_id)
+# Updated: 2026-05-17 (feat/planner-gaps-and-deps) — pocketpaw#1118 P4
+#   added ``blocked_by: list[str]`` carrying cloud Task ids this task
+#   depends on. No migration script — Mongo absorbs the new field on
+#   next write; reads of old docs default to ``[]``.
 """Task document — Mission Control work-item primitive.
 
 Embedded sub-documents:
@@ -91,6 +95,14 @@ class Task(TimestampedDocument):
     kind: str = Field(default="task", pattern="^(task|nudge|projection|automation)$")
 
     source: TaskSource = Field(default_factory=TaskSource)
+
+    # Task ids this task depends on. Populated by the planner's two-pass
+    # materializer for ``TaskSpec.blocked_by_keys`` and by direct callers
+    # that pass ``blocked_by`` on Create/Update. Plain string list — we
+    # don't enforce referential integrity at the DB layer because cross-
+    # workspace ids are already filtered out by the tenant guard on every
+    # service write.
+    blocked_by: list[str] = Field(default_factory=list)
 
     due_at: datetime | None = None
     blocked_reason: str | None = None

--- a/ee/cloud/planner/domain.py
+++ b/ee/cloud/planner/domain.py
@@ -3,6 +3,10 @@
 #   operator UI. Both are constructed only by ``planner.service`` after
 #   a successful OSS planner run; routers + tests consume the DTO wire
 #   shapes in ``planner.dto``.
+# Updated: 2026-05-17 (feat/planner-gaps-and-deps) — pocketpaw#1118 P4
+#   added ``dependency_warnings`` to PlanSession so the planner can
+#   surface unresolved TaskSpec.blocked_by_keys without failing the
+#   whole materialization.
 """Planner entity — domain value objects.
 
 A :class:`PlanSession` is the cloud-side record of one OSS planner run.
@@ -44,6 +48,7 @@ class PlanSession:
     goal_file_id: str | None
     task_ids: tuple[str, ...]
     agent_gaps: tuple[AgentGap, ...]
+    dependency_warnings: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/ee/cloud/planner/dto.py
+++ b/ee/cloud/planner/dto.py
@@ -3,7 +3,13 @@
 #   ee/cloud Code Rule §4 — request shapes carry the goal + project_id
 #   the operator picked, response shapes carry the materialized cloud
 #   primitive ids (file_id, task_ids) the FE Plan tab renders.
-"""Planner entity — request/response DTOs."""
+# Updated: 2026-05-17 (feat/planner-gaps-and-deps) — pocketpaw#1118 P3
+#   added ``ResolveGapRequest`` + ``ResolveGapResult`` for
+#   ``POST /api/v1/planner/resolve-gap`` — the route the FE calls after
+#   the operator creates the agent for a previously-missing spec.
+#   pocketpaw#1118 P4 added ``dependency_warnings`` to
+#   ``PlanProjectResult`` so the planner can surface unresolved
+#   ``TaskSpec.blocked_by_keys`` without failing the whole run.
 
 from __future__ import annotations
 
@@ -32,6 +38,25 @@ class PlanProjectRequest(BaseModel):
     deep_research: bool = False
 
 
+class ResolveGapRequest(BaseModel):
+    """Body for ``POST /api/v1/planner/resolve-gap``.
+
+    Called after the operator creates a cloud Agent for a planner-
+    recommended spec the workspace was missing. The service finds every
+    task in this plan session that fell back to a human assignee for
+    this spec and reassigns it to the new agent.
+
+    ``new_agent_id`` is the cloud agent id returned by the existing
+    ``POST /api/v1/agents`` endpoint — we don't add a new agent-creation
+    surface here; the FE calls agents-create directly and then posts to
+    this route with the id it got back.
+    """
+
+    plan_session_id: str = Field(min_length=1)
+    spec_name: str = Field(min_length=1)
+    new_agent_id: str = Field(min_length=1)
+
+
 # ---------------------------------------------------------------------------
 # Responses
 # ---------------------------------------------------------------------------
@@ -54,9 +79,13 @@ class PlanProjectResult(BaseModel):
         Files panel download route.
       - ``task_ids`` to scroll the WorkFeed to the newly-created tasks.
       - ``agent_gaps`` to drive the "Create missing agents" CTA.
+      - ``dependency_warnings`` to surface TaskSpec.blocked_by_keys
+        entries that didn't resolve to a sibling spec (planner output
+        bug — task created with empty blocked_by, not aborted).
 
-    ``plan_session_id`` is exposed for round-trip debugging; the FE does
-    not render it in the v0 surface.
+    ``plan_session_id`` is exposed for round-trip debugging; the FE
+    threads it back to the resolve-gap endpoint after the operator
+    creates a missing agent.
     """
 
     plan_session_id: str
@@ -67,10 +96,28 @@ class PlanProjectResult(BaseModel):
     goal_file_id: str | None = None
     task_ids: list[str] = Field(default_factory=list)
     agent_gaps: list[AgentGapDTO] = Field(default_factory=list)
+    dependency_warnings: list[str] = Field(default_factory=list)
+
+
+class ResolveGapResult(BaseModel):
+    """Wire shape returned by ``POST /api/v1/planner/resolve-gap``.
+
+    ``reassigned_task_ids`` lets the FE patch the WorkFeed rows without
+    a refetch. ``remaining_gaps`` is the up-to-date list after removing
+    the resolved spec so the FE re-renders the gap card stack cleanly.
+    """
+
+    plan_session_id: str
+    spec_name: str
+    new_agent_id: str
+    reassigned_task_ids: list[str] = Field(default_factory=list)
+    remaining_gaps: list[AgentGapDTO] = Field(default_factory=list)
 
 
 __all__ = [
     "AgentGapDTO",
     "PlanProjectRequest",
     "PlanProjectResult",
+    "ResolveGapRequest",
+    "ResolveGapResult",
 ]

--- a/ee/cloud/planner/router.py
+++ b/ee/cloud/planner/router.py
@@ -3,6 +3,11 @@
 #   ``planner.service`` → return DTO. No ``HTTPException`` here —
 #   services raise CloudError subclasses and ``_core.http`` maps them
 #   to JSON.
+# Updated: 2026-05-17 (feat/planner-gaps-and-deps) — pocketpaw#1118 P3
+#   added ``POST /planner/resolve-gap`` for the agent-gap → create-agent
+#   flow. Frontend calls ``POST /api/v1/agents`` directly to create the
+#   missing agent (no NEW agent-creation endpoint here) and then posts
+#   to this route with the agent id it received.
 """Planner REST router.
 
 Endpoints:
@@ -23,7 +28,12 @@ from starlette.responses import Response
 from ee.cloud._core.context import RequestContext, request_context
 from ee.cloud.license import require_license
 from ee.cloud.planner import service as planner_service
-from ee.cloud.planner.dto import PlanProjectRequest, PlanProjectResult
+from ee.cloud.planner.dto import (
+    PlanProjectRequest,
+    PlanProjectResult,
+    ResolveGapRequest,
+    ResolveGapResult,
+)
 
 router = APIRouter(
     prefix="/planner",
@@ -61,3 +71,19 @@ async def get_plan_by_project(
     if result is None:
         return Response(status_code=204)
     return result
+
+
+@router.post("/resolve-gap", response_model=ResolveGapResult)
+async def resolve_agent_gap(
+    body: ResolveGapRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> ResolveGapResult:
+    """Reassign human-fallback tasks for a missing agent spec to the
+    newly-created cloud Agent.
+
+    Called by the FE after the operator creates an agent for a
+    planner-recommended spec the workspace was missing. The FE's
+    create-agent call goes to ``POST /api/v1/agents`` directly; this
+    route handles the post-create reassignment + gap cleanup.
+    """
+    return await planner_service.agent_resolve_gap(ctx, body)

--- a/ee/cloud/planner/service.py
+++ b/ee/cloud/planner/service.py
@@ -5,6 +5,18 @@
 #   except via the public OSS API surface (``PlannerAgent``, ``PlannerResult``,
 #   ``TaskSpec``, ``AgentSpec``) — the OSS module is sacred and changes go
 #   through the OSS PR flow, not through ee/cloud.
+# Updated: 2026-05-17 (feat/planner-gaps-and-deps) — pocketpaw#1118 P3 + P4.
+#   P3: persist a ``PlanSession`` Beanie doc per run so ``agent_resolve_gap``
+#   can look up which tasks fell back to a human for a given missing spec
+#   and reassign them after the operator creates the cloud Agent. Tasks
+#   that fall back from agent → human now record the wanted spec name on
+#   ``assignee.name`` (and on ``source.metadata.wanted_agent_spec_name``)
+#   so the resolve flow can filter precisely without a JSON-blob parse.
+#   P4: two-pass task materialization — pass 1 inserts each task with
+#   ``blocked_by=[]`` and builds a ``spec_key → cloud_task_id`` map; pass
+#   2 patches ``blocked_by`` via ``agent_update_task``. Unknown deps
+#   surface as ``dependency_warnings`` on the response, not as a fatal
+#   error — the planner keeps a partial result the operator can ship.
 """Planner entity — business logic service.
 
 Public API (all module-level ``async def``):
@@ -45,12 +57,16 @@ from typing import Any
 from ee.cloud._core.context import RequestContext
 from ee.cloud._core.errors import NotFound, ValidationError
 from ee.cloud._core.realtime.emit import emit
-from ee.cloud._core.realtime.events import PlanGenerated
+from ee.cloud._core.realtime.events import PlanGapResolved, PlanGenerated
+from ee.cloud.models.planner import PlanSession as _PlanSessionDoc
+from ee.cloud.models.planner import PlanSessionAgentGap as _PlanSessionAgentGapDoc
 from ee.cloud.planner.domain import AgentGap, PlanSession
 from ee.cloud.planner.dto import (
     AgentGapDTO,
     PlanProjectRequest,
     PlanProjectResult,
+    ResolveGapRequest,
+    ResolveGapResult,
 )
 
 logger = logging.getLogger(__name__)
@@ -95,7 +111,7 @@ async def agent_plan_project(ctx: RequestContext, body: PlanProjectRequest) -> P
         goal=body.goal,
         planner_result=planner_result,
     )
-    task_ids = await _materialize_tasks(
+    task_ids, dependency_warnings = await _materialize_tasks(
         ctx=ctx,
         project=project,
         planner_result=planner_result,
@@ -105,8 +121,16 @@ async def agent_plan_project(ctx: RequestContext, body: PlanProjectRequest) -> P
         planner_result=planner_result,
     )
 
+    session_id = await _persist_plan_session(
+        workspace_id=ctx.workspace_id,
+        project_id=project.id,
+        file_refs=file_refs,
+        task_ids=task_ids,
+        agent_gaps=agent_gaps,
+    )
+
     session = PlanSession(
-        id=project.id,  # OSS planner doesn't mint a separate session id today
+        id=session_id,
         workspace_id=ctx.workspace_id,
         project_id=project.id,
         status="ready",
@@ -115,6 +139,7 @@ async def agent_plan_project(ctx: RequestContext, body: PlanProjectRequest) -> P
         goal_file_id=file_refs.get("goal"),
         task_ids=tuple(task_ids),
         agent_gaps=tuple(agent_gaps),
+        dependency_warnings=tuple(dependency_warnings),
     )
 
     await emit(
@@ -133,31 +158,183 @@ async def agent_plan_project(ctx: RequestContext, body: PlanProjectRequest) -> P
     return _session_to_dto(session)
 
 
+async def agent_resolve_gap(ctx: RequestContext, body: ResolveGapRequest) -> ResolveGapResult:
+    """Reassign human-fallback tasks for a missing agent spec to the
+    newly-created cloud Agent.
+
+    Called after the operator creates an Agent (via ``POST /api/v1/agents``)
+    for a spec the planner originally wanted but the workspace was
+    missing. The service:
+
+      1. Loads the PlanSession doc — workspace tenant-checked. Unknown
+         session id → ``NotFound``.
+      2. Loads the new cloud Agent — workspace tenant-checked via
+         ``agents_service.get`` + a workspace cross-check. Unknown agent
+         id or cross-workspace → ``NotFound`` (uniform 404 to prevent
+         id enumeration).
+      3. Finds every task in the session whose ``assignee.kind == 'human'``
+         AND ``assignee.name == spec_name`` (the fallback marker set in
+         ``_resolve_assignee``). The ``source.metadata.wanted_agent_spec_name``
+         column is the defensive cross-check.
+      4. Reassigns each matching task to the new agent via
+         ``tasks_service.agent_reassign_task``.
+      5. Pops the resolved spec out of the PlanSession's ``agent_gaps``.
+      6. Emits ``PlanGapResolved`` so the FE Plan tab can patch the
+         gap card stack without a refetch.
+    """
+
+    body = ResolveGapRequest.model_validate(body)
+    if not ctx.workspace_id:
+        raise ValidationError(
+            "planner.no_workspace",
+            "resolving a plan gap requires an active workspace",
+        )
+
+    session_doc = await _load_plan_session_or_404(ctx, body.plan_session_id)
+    new_agent = await _load_agent_for_gap_or_404(
+        workspace_id=ctx.workspace_id,
+        agent_id=body.new_agent_id,
+    )
+
+    from ee.cloud.tasks import service as tasks_service
+    from ee.cloud.tasks.dto import ListTasksRequest, ReassignTaskRequest
+
+    # The list of tasks belonging to this plan session is canonical on
+    # the PlanSession doc — we filter the session-scoped slice down to
+    # human-fallback rows matching the spec name. The wanted-spec
+    # metadata is the safe cross-check (an operator could have renamed
+    # the assignee in the meantime; the source metadata is immutable).
+    rows = await tasks_service.agent_list_tasks(
+        ctx, ListTasksRequest(project_id=session_doc.project_id, limit=500)
+    )
+    spec_name_lower = body.spec_name.lower()
+    targets = [
+        r
+        for r in rows
+        if r.id in session_doc.task_ids
+        and r.assignee.kind == "human"
+        and (
+            (r.assignee.name or "").lower() == spec_name_lower
+            or (r.source.metadata or {}).get("wanted_agent_spec_name", "").lower()
+            == spec_name_lower
+        )
+    ]
+
+    reassign_body = ReassignTaskRequest(
+        assignee_kind="agent",
+        assignee_id=body.new_agent_id,
+        assignee_name=new_agent.name,
+    )
+    reassigned_task_ids: list[str] = []
+    for task_row in targets:
+        try:
+            await tasks_service.agent_reassign_task(ctx, task_row.id, reassign_body)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "resolve_gap reassignment failed for task=%s spec=%s",
+                task_row.id,
+                body.spec_name,
+            )
+            continue
+        reassigned_task_ids.append(task_row.id)
+
+    # Strip the resolved spec out of the persisted gap list. Match is
+    # case-insensitive on spec_name to mirror the planner's detection
+    # path (``_detect_agent_gaps`` lowercases for the existing-name set).
+    remaining_gaps_docs = [
+        g for g in session_doc.agent_gaps if (g.spec_name or "").lower() != spec_name_lower
+    ]
+    session_doc.agent_gaps = remaining_gaps_docs
+    if reassigned_task_ids:
+        # Refresh task_ids only if we actually wrote — keeps the doc
+        # stable when the resolve hits an empty target set.
+        pass  # task_ids unchanged: same tasks, different assignee.
+    await session_doc.save()
+
+    remaining_dto = [
+        AgentGapDTO(
+            spec_name=g.spec_name,
+            recommended_role=g.recommended_role,
+            specialties=list(g.specialties),
+        )
+        for g in remaining_gaps_docs
+    ]
+
+    await emit(
+        PlanGapResolved(
+            data={
+                "workspace_id": ctx.workspace_id,
+                "project_id": session_doc.project_id,
+                "plan_session_id": str(session_doc.id),
+                "spec_name": body.spec_name,
+                "new_agent_id": body.new_agent_id,
+                "reassigned_task_count": len(reassigned_task_ids),
+                "remaining_gap_count": len(remaining_gaps_docs),
+            }
+        )
+    )
+
+    return ResolveGapResult(
+        plan_session_id=str(session_doc.id),
+        spec_name=body.spec_name,
+        new_agent_id=body.new_agent_id,
+        reassigned_task_ids=reassigned_task_ids,
+        remaining_gaps=remaining_dto,
+    )
+
+
 async def get_plan_for_project(ctx: RequestContext, project_id: str) -> PlanProjectResult | None:
     """Return the most recent plan summary for ``project_id``, or ``None``.
 
-    There is no PlanSession Beanie document in v0 — the plan output IS
-    the persistent record (files in the Files panel + tasks in
-    Mission Control). We reconstruct the summary by:
+    P3 added a persisted PlanSession Beanie doc — when it exists we
+    return its persisted shape (so plan_session_id, agent_gaps, and
+    dependency_warnings round-trip across refreshes). Pre-P3 plans (and
+    forks that disabled the doc) still reconstruct from the files panel
+    so the read path stays backwards-compatible.
 
-      1. Verifying the project exists in the caller's workspace
+    Reconstruction steps:
+
+      1. Verify the project exists in the caller's workspace
          (tenant check; raises NotFound otherwise).
-      2. Looking for the PRD file at the conventional path
-         ``/projects/{project_id}/prd.md``. If absent, no plan exists yet.
-      3. Surfacing the matching tasks via the existing tasks service.
+      2. If a PlanSession doc exists, hydrate from it directly.
+      3. Otherwise look for the PRD file at
+         ``/projects/{project_id}/prd.md``; absent → no plan yet.
+      4. Surface the matching tasks via the existing tasks service.
 
     Agent-gap detection is intentionally NOT re-run here — it's a
     point-in-time signal from the original plan; re-running it on
     every Plan-tab refresh would hit the agents list for nothing.
-    The FE renders the persisted gaps from the most recent
-    ``PlanGenerated`` event payload, or shows an empty gap list when
-    the route is a cold-start hydration.
     """
 
     if not ctx.workspace_id:
         return None
 
     project = await _load_project_or_404(ctx, project_id)
+
+    # P3 happy path — persisted doc carries everything the FE needs.
+    persisted = await _PlanSessionDoc.find_one(
+        {"workspace": ctx.workspace_id, "project_id": project.id}
+    )
+    if persisted is not None:
+        session = PlanSession(
+            id=str(persisted.id),
+            workspace_id=ctx.workspace_id,
+            project_id=project.id,
+            status=persisted.status,
+            prd_file_id=persisted.prd_file_id,
+            plan_file_id=persisted.plan_file_id,
+            goal_file_id=persisted.goal_file_id,
+            task_ids=tuple(persisted.task_ids),
+            agent_gaps=tuple(
+                AgentGap(
+                    spec_name=g.spec_name,
+                    recommended_role=g.recommended_role,
+                    specialties=tuple(g.specialties),
+                )
+                for g in persisted.agent_gaps
+            ),
+        )
+        return _session_to_dto(session)
 
     folder_path = f"/projects/{project.id}"
     files_by_name = await _list_planner_files(
@@ -324,8 +501,14 @@ async def _materialize_tasks(
     ctx: RequestContext,
     project: Any,
     planner_result: Any,
-) -> list[str]:
-    """Create one cloud Task per OSS TaskSpec.
+) -> tuple[list[str], list[str]]:
+    """Create one cloud Task per OSS TaskSpec via two passes.
+
+    Pass 1 inserts every Task with ``blocked_by=[]`` so we have cloud
+    ids to point at; pass 2 patches ``blocked_by`` once the
+    ``spec_key → cloud_task_id`` map is fully populated. This handles
+    forward references — a TaskSpec may depend on a sibling that wasn't
+    created yet at the time of its own insert.
 
     Assignee resolution:
 
@@ -334,21 +517,22 @@ async def _materialize_tasks(
         team_recommendation entry that covers any of those specialties,
         assign the task to that agent (kind=agent).
       * Otherwise fall back to the project's lead_id (or the caller)
-        as a human assignee — the operator sees the task in their tray
-        and can re-route from there.
+        as a human assignee, recording the planner-wanted spec name on
+        ``assignee.name`` so the resolve-gap flow can find the row.
 
-    OSS TaskSpec → cloud CreateTaskRequest field map:
-      - key → ignored (cloud Task id is mongo-generated)
-      - title → title
-      - description → summary
-      - priority → priority (normalized to the cloud's normal/high/etc.)
-      - task_type → drives assignee kind (human/agent/review)
-      - blocked_by_keys → ignored in v0 (P4 per the brief)
+    Returns ``(task_ids, dependency_warnings)`` — warnings carry any
+    ``blocked_by_keys`` entries that didn't resolve to a sibling spec
+    (planner bug — we skip the unknown dep but still create the task).
     """
 
     from ee.cloud.agents import service as agents_service
     from ee.cloud.tasks import service as tasks_service
-    from ee.cloud.tasks.dto import AssigneeDTO, CreateTaskRequest, SourceDTO
+    from ee.cloud.tasks.dto import (
+        AssigneeDTO,
+        CreateTaskRequest,
+        SourceDTO,
+        UpdateTaskRequest,
+    )
 
     # Build a name → cloud Agent lookup once so the per-task loop is
     # O(1). Cloud's ``list_agents`` is workspace-scoped and cheap.
@@ -372,9 +556,14 @@ async def _materialize_tasks(
     plan_session_ref = project.id  # see PlanSession.id comment in service top
     fallback_assignee_id = getattr(project, "lead_id", None) or ctx.user_id
 
+    # Pass 1 — create every task with empty blocked_by, build the
+    # spec_key → cloud_task_id map for pass 2.
     task_ids: list[str] = []
+    spec_key_to_task_id: dict[str, str] = {}
+    created_pairs: list[tuple[Any, str]] = []  # (spec, task_id) for pass 2
+
     for spec in all_specs:
-        assignee_kind, assignee_id, assignee_name = _resolve_assignee(
+        assignee_kind, assignee_id, assignee_name, wanted_spec_name = _resolve_assignee(
             spec=spec,
             specialty_to_agent_name=specialty_to_agent_name,
             by_name=by_name,
@@ -382,6 +571,16 @@ async def _materialize_tasks(
             fallback_name="",
         )
         priority = _normalize_priority(getattr(spec, "priority", "medium"))
+
+        source_metadata = {
+            "planner_task_key": getattr(spec, "key", ""),
+            "task_type": getattr(spec, "task_type", "agent"),
+        }
+        if wanted_spec_name:
+            # Resolve-gap filters on this key — the planner wanted spec
+            # X but no cloud Agent matched, so we recorded the want
+            # alongside the fallback assignment.
+            source_metadata["wanted_agent_spec_name"] = wanted_spec_name
 
         req = CreateTaskRequest(
             title=spec.title or spec.key or "Untitled task",
@@ -396,11 +595,9 @@ async def _materialize_tasks(
             source=SourceDTO(
                 type="planner",
                 ref_id=plan_session_ref,
-                metadata={
-                    "planner_task_key": getattr(spec, "key", ""),
-                    "task_type": getattr(spec, "task_type", "agent"),
-                },
+                metadata=source_metadata,
             ),
+            blocked_by=[],
         )
 
         try:
@@ -412,8 +609,46 @@ async def _materialize_tasks(
             )
             continue
         task_ids.append(created.id)
+        spec_key = getattr(spec, "key", "") or ""
+        if spec_key:
+            spec_key_to_task_id[spec_key] = created.id
+        created_pairs.append((spec, created.id))
 
-    return task_ids
+    # Pass 2 — wire dependencies. Each TaskSpec's ``blocked_by_keys``
+    # references sibling spec keys; we translate to the cloud task ids
+    # we minted in pass 1 and patch the row via agent_update_task. Any
+    # unresolved name surfaces as a warning rather than aborting.
+    dependency_warnings: list[str] = []
+    for spec, task_id in created_pairs:
+        dep_keys = list(getattr(spec, "blocked_by_keys", []) or [])
+        if not dep_keys:
+            continue
+        resolved_ids: list[str] = []
+        for dep_key in dep_keys:
+            cloud_id = spec_key_to_task_id.get(dep_key)
+            if cloud_id is None:
+                warning = (
+                    f"task {getattr(spec, 'key', '?')!r} depends on unknown "
+                    f"spec {dep_key!r}; skipping"
+                )
+                logger.warning(warning)
+                dependency_warnings.append(dep_key)
+                continue
+            resolved_ids.append(cloud_id)
+        if not resolved_ids:
+            continue
+        try:
+            await tasks_service.agent_update_task(
+                ctx, task_id, UpdateTaskRequest(blocked_by=resolved_ids)
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "dependency wiring failed for task %s spec=%s",
+                task_id,
+                getattr(spec, "key", "?"),
+            )
+
+    return task_ids, dependency_warnings
 
 
 def _resolve_assignee(
@@ -423,31 +658,46 @@ def _resolve_assignee(
     by_name: dict[str, Any],
     fallback_id: str,
     fallback_name: str,
-) -> tuple[str, str, str]:
-    """Map an OSS TaskSpec to a cloud assignee triple.
+) -> tuple[str, str, str, str]:
+    """Map an OSS TaskSpec to a cloud assignee 4-tuple.
 
-    Returns ``(kind, id, name)`` suitable for AssigneeDTO. Human falls
-    back to the project lead — the cloud tasks service flips human
-    tasks straight into ``in_progress`` so the operator sees them.
+    Returns ``(kind, id, name, wanted_spec_name)``. ``wanted_spec_name``
+    is non-empty only when the planner wanted an agent we couldn't
+    resolve — it records which team-recommendation spec we fell back
+    from so the resolve-gap flow can match the rows precisely. For
+    human-typed specs the wanted name stays empty (the planner
+    explicitly asked for a human; there's no "missing agent" to resolve).
+
+    Human fallback assignees carry ``assignee.name = wanted_spec_name``
+    so the operator UI can render "wanted: events-coordinator (fallback
+    to lead)" without a separate field, and so the resolve-gap filter
+    matches on a single column.
     """
 
     task_type = getattr(spec, "task_type", "agent")
     if task_type == "human":
-        return ("human", fallback_id, fallback_name)
+        return ("human", fallback_id, fallback_name, "")
 
     specialties = [sp.lower() for sp in getattr(spec, "required_specialties", []) or []]
+    wanted_team_name = ""
     for sp in specialties:
         team_name = specialty_to_agent_name.get(sp)
         if not team_name:
             continue
+        # Remember the first team-recommendation name we tried so the
+        # fallback path can record it even when no cloud Agent matched.
+        if not wanted_team_name:
+            wanted_team_name = team_name
         agent = by_name.get(team_name.lower())
         if agent is not None:
-            return ("agent", str(agent.id), agent.name)
+            return ("agent", str(agent.id), agent.name, "")
 
     # No specialty match — fall back to ``human`` so the operator
     # explicitly re-routes rather than us silently picking a random
-    # cloud agent.
-    return ("human", fallback_id, fallback_name)
+    # cloud agent. Record the wanted spec name on the assignee so the
+    # resolve-gap flow can find the row by ``assignee.name``.
+    fallback_display_name = wanted_team_name or fallback_name
+    return ("human", fallback_id, fallback_display_name, wanted_team_name)
 
 
 def _normalize_priority(raw: str) -> str:
@@ -596,10 +846,100 @@ def _session_to_dto(session: PlanSession) -> PlanProjectResult:
             )
             for g in session.agent_gaps
         ],
+        dependency_warnings=list(session.dependency_warnings),
     )
+
+
+# ---------------------------------------------------------------------------
+# PlanSession persistence + load helpers
+# ---------------------------------------------------------------------------
+
+
+async def _persist_plan_session(
+    *,
+    workspace_id: str,
+    project_id: str,
+    file_refs: dict[str, str],
+    task_ids: list[str],
+    agent_gaps: list[AgentGap],
+) -> str:
+    """Insert (or replace) the PlanSession doc for ``project_id``.
+
+    We re-run by deleting the prior doc rather than upserting because
+    Beanie docs carry a generated ObjectId we don't want to retain
+    across re-plans (the previous run's id would still flow through
+    PlanGapResolved events for the new run). One doc per workspace +
+    project enforces "one active plan session per project".
+    """
+
+    existing = await _PlanSessionDoc.find(
+        {"workspace": workspace_id, "project_id": project_id}
+    ).to_list()
+    for prior in existing:
+        await prior.delete()
+
+    doc = _PlanSessionDoc(
+        workspace=workspace_id,
+        project_id=project_id,
+        status="ready",
+        prd_file_id=file_refs.get("prd"),
+        plan_file_id=file_refs.get("plan"),
+        goal_file_id=file_refs.get("goal"),
+        task_ids=list(task_ids),
+        agent_gaps=[
+            _PlanSessionAgentGapDoc(
+                spec_name=g.spec_name,
+                recommended_role=g.recommended_role,
+                specialties=list(g.specialties),
+            )
+            for g in agent_gaps
+        ],
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+async def _load_plan_session_or_404(ctx: RequestContext, plan_session_id: str) -> _PlanSessionDoc:
+    """Tenant-checked PlanSession load. Uniform NotFound on miss /
+    cross-workspace ids (id enumeration mitigation, matching the tasks
+    service ``_fetch_task`` pattern).
+    """
+
+    from beanie import PydanticObjectId
+
+    try:
+        oid = PydanticObjectId(plan_session_id)
+    except Exception as exc:  # noqa: BLE001
+        raise NotFound("plan_session", plan_session_id) from exc
+    doc = await _PlanSessionDoc.get(oid)
+    if doc is None or doc.workspace != ctx.workspace_id:
+        raise NotFound("plan_session", plan_session_id)
+    return doc
+
+
+async def _load_agent_for_gap_or_404(*, workspace_id: str, agent_id: str) -> Any:
+    """Load a cloud Agent + cross-check workspace tenancy.
+
+    ``agents_service.get`` doesn't take a workspace argument (it's a
+    by-id loader that returns the agent regardless of workspace) so we
+    enforce the tenancy check here. Uniform NotFound on either branch
+    so the operator can't probe whether a given agent id exists in
+    another workspace.
+    """
+
+    from ee.cloud.agents import service as agents_service
+
+    try:
+        agent = await agents_service.get(agent_id)
+    except NotFound:
+        raise NotFound("agent", agent_id) from None
+    if agent.workspace_id != workspace_id:
+        raise NotFound("agent", agent_id)
+    return agent
 
 
 __all__ = [
     "agent_plan_project",
+    "agent_resolve_gap",
     "get_plan_for_project",
 ]

--- a/ee/cloud/tasks/domain.py
+++ b/ee/cloud/tasks/domain.py
@@ -3,6 +3,10 @@
 #   are the unified work-item primitive used by Mission Control's
 #   feed. Domain objects are plain Python so services can be tested
 #   without Beanie; the service layer converts to/from the Mongo doc.
+# Updated: 2026-05-17 (feat/planner-gaps-and-deps) — pocketpaw#1118 P4
+#   added the ``blocked_by`` field carrying cloud Task ids this task
+#   depends on. Tuple stays read-only on the frozen dataclass; the
+#   service writes it via ``agent_create_task`` + ``agent_update_task``.
 """Domain value objects for the Tasks entity.
 
 Pure-Python frozen dataclasses. ``tasks/service.py`` owns the
@@ -92,6 +96,7 @@ class Task:
     pocket_id: str | None = None
     cycle_id: str | None = None
     project_id: str | None = None
+    blocked_by: tuple[str, ...] = ()
     due_at: datetime | None = None
     blocked_reason: str | None = None
     created_at: datetime | None = None

--- a/ee/cloud/tasks/dto.py
+++ b/ee/cloud/tasks/dto.py
@@ -3,6 +3,11 @@
 #   Distinct *Request and *Response models; never reuse one model for
 #   both input and output (per ee/cloud Code Rules §4). Domain → wire
 #   mapper lives at the bottom alongside its tests' surface.
+# Updated: 2026-05-17 (feat/planner-gaps-and-deps) — pocketpaw#1118 P4
+#   added ``blocked_by`` to CreateTaskRequest, UpdateTaskRequest, and
+#   TaskResponse. Update semantics distinguish None (no change) from
+#   an explicit empty list (clear dependencies). Domain ↔ wire mapper
+#   threads the field through ``task_to_dto``.
 """Tasks entity — request/response DTOs."""
 
 from __future__ import annotations
@@ -47,6 +52,11 @@ class CreateTaskRequest(BaseModel):
     ``status`` is intentionally not on the request. The service derives
     it from ``assignee.kind`` — agent → ``proposed`` (claim flow);
     human → ``in_progress`` (already in someone's hands).
+
+    ``blocked_by`` carries cloud Task ids this task depends on. The
+    planner's two-pass materializer uses it to wire up TaskSpec
+    ``blocked_by_keys`` after both endpoints exist; manual callers may
+    pass it directly to register a dependency edge at create time.
     """
 
     title: str = Field(min_length=1, max_length=200)
@@ -55,6 +65,7 @@ class CreateTaskRequest(BaseModel):
     pocket_id: str | None = None
     cycle_id: str | None = None
     project_id: str | None = None
+    blocked_by: list[str] = Field(default_factory=list)
     priority: Literal["low", "normal", "high", "urgent"] = "normal"
     kind: Literal["task", "nudge", "projection", "automation"] = "task"
     source: SourceDTO = Field(default_factory=SourceDTO)
@@ -63,7 +74,13 @@ class CreateTaskRequest(BaseModel):
 
 class UpdateTaskRequest(BaseModel):
     """Body for ``PATCH /tasks/{id}``. Every field is optional; only
-    the keys the caller provides are touched."""
+    the keys the caller provides are touched.
+
+    ``blocked_by`` is tri-state: ``None`` (omitted) leaves dependencies
+    alone, ``[]`` explicitly clears them, a non-empty list replaces the
+    full set. This lets a caller distinguish "I didn't pass it" from
+    "I want it cleared" without a separate verb.
+    """
 
     title: str | None = None
     summary: str | None = None
@@ -71,6 +88,7 @@ class UpdateTaskRequest(BaseModel):
     pocket_id: str | None = None
     cycle_id: str | None = None
     project_id: str | None = None
+    blocked_by: list[str] | None = None
     due_at: datetime | None = None
 
 
@@ -162,6 +180,7 @@ class TaskResponse(BaseModel):
     pocket_id: str | None = None
     cycle_id: str | None = None
     project_id: str | None = None
+    blocked_by: list[str] = Field(default_factory=list)
     due_at: str | None = None
     blocked_reason: str | None = None
     created_at: str | None = None
@@ -198,6 +217,7 @@ def task_to_dto(task: Task) -> TaskResponse:
         pocket_id=task.pocket_id,
         cycle_id=task.cycle_id,
         project_id=task.project_id,
+        blocked_by=list(task.blocked_by),
         due_at=iso_utc(task.due_at),
         blocked_reason=task.blocked_reason,
         created_at=iso_utc(task.created_at),

--- a/ee/cloud/tasks/service.py
+++ b/ee/cloud/tasks/service.py
@@ -15,6 +15,12 @@
 #   line on every call so the creator/assignee-guard bypass is
 #   reviewable. PR #1097's reviewer flagged the silent privilege bypass
 #   as the highest-priority follow-up.
+# Updated: 2026-05-17 (feat/planner-gaps-and-deps) — pocketpaw#1118 P4
+#   ``agent_create_task`` persists ``blocked_by`` from the request;
+#   ``agent_update_task`` flips it tri-state (None = no change, [] =
+#   explicit clear, [...] = replace). Domain mapper threads the field
+#   through ``_to_domain`` so projectors (Mission Control's WorkItem)
+#   pick it up automatically.
 """Tasks entity — business logic service.
 
 Public API (all module-level ``async def``):
@@ -103,6 +109,7 @@ def _to_domain(doc: _TaskDoc) -> Task:
         pocket_id=doc.pocket_id,
         cycle_id=doc.cycle_id,
         project_id=getattr(doc, "project_id", None),
+        blocked_by=tuple(getattr(doc, "blocked_by", None) or ()),
         due_at=doc.due_at,
         blocked_reason=doc.blocked_reason,
         created_at=getattr(doc, "createdAt", None),
@@ -196,6 +203,7 @@ async def agent_create_task(ctx: RequestContext, body: CreateTaskRequest) -> Tas
             ref_id=body.source.ref_id,
             metadata=dict(body.source.metadata or {}),
         ),
+        blocked_by=list(body.blocked_by or []),
         due_at=body.due_at,
     )
     await doc.insert()
@@ -284,6 +292,12 @@ async def agent_update_task(
             doc.project_id = body.project_id
         else:
             doc.project_id = None
+    if body.blocked_by is not None:
+        # Tri-state: None = no change (handled by the outer guard),
+        # [] = explicit clear, [...] = replace the full set. The Beanie
+        # field defaults to ``[]`` for old docs so the assignment is
+        # always safe.
+        doc.blocked_by = list(body.blocked_by)
     if body.due_at is not None:
         doc.due_at = body.due_at
 

--- a/ee/cloud/uploads/service.py
+++ b/ee/cloud/uploads/service.py
@@ -305,9 +305,7 @@ async def write_text_file(
     adapter = build_adapter(root)
 
     payload = content.encode("utf-8") if isinstance(content, str) else content
-    storage_key = new_storage_key(
-        "planner", _PLANNER_EXTENSION_BY_MIME.get(mime, "bin")
-    )
+    storage_key = new_storage_key("planner", _PLANNER_EXTENSION_BY_MIME.get(mime, "bin"))
 
     async def _body() -> AsyncIterator[bytes]:
         yield payload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -639,3 +639,14 @@ source_modules = [
     "ee.cloud.projects.domain",
 ]
 forbidden_modules = ["ee.cloud.models.project"]
+
+[[tool.importlinter.contracts]]
+name = "Planner — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "ee.cloud.planner.router",
+    "ee.cloud.planner.dto",
+    "ee.cloud.planner.domain",
+]
+forbidden_modules = ["ee.cloud.models.planner"]

--- a/tests/cloud/test_mission_control_service.py
+++ b/tests/cloud/test_mission_control_service.py
@@ -160,7 +160,12 @@ class TestListWorkItems:
         """Regression: a Task created via POST /tasks must surface in
         GET /mission-control/items. The original façade only queried
         Instinct and silently dropped Tasks — operators creating tasks
-        through the modal saw their new work disappear from the feed."""
+        through the modal saw their new work disappear from the feed.
+
+        Also asserts (P4) that the projected WorkItem carries
+        ``blocked_by`` with the ``task:`` prefix applied so the
+        frontend can resolve dependency edges to other WorkItem rows.
+        """
         from datetime import UTC
         from datetime import datetime as _dt
 
@@ -179,6 +184,7 @@ class TestListWorkItems:
             title="Drafted from the modal",
             summary="",
             pocket_id=None,
+            blocked_by=("t_dep1", "t_dep2"),
             created_at=_dt.now(UTC),
             updated_at=_dt.now(UTC),
         )
@@ -190,6 +196,13 @@ class TestListWorkItems:
         out = await mc_service.agent_list_work_items(_ctx(), {})
         titles = [it.title for it in out]
         assert "Drafted from the modal" in titles
+
+        # P4: the projected WorkItem prefixes each blocked_by id with
+        # ``task:`` so the frontend can dereference dependency edges to
+        # the right WorkItem rows in the heterogeneous feed.
+        target = next(it for it in out if it.title == "Drafted from the modal")
+        assert target.blocked_by == ["task:t_dep1", "task:t_dep2"]
+
         # Pocket-less tasks must surface even when the workspace has no
         # visible pockets at all (Tasks are workspace-scoped, not
         # pocket-scoped).

--- a/tests/cloud/test_planner_resolve_gap.py
+++ b/tests/cloud/test_planner_resolve_gap.py
@@ -1,0 +1,291 @@
+# Created: 2026-05-17 — pocketpaw#1118 P3. Tests for
+#   ``planner.service.agent_resolve_gap`` — the agent-gap →
+#   create-agent → reassign flow. Drives an end-to-end materialization
+#   with a stubbed OSS planner so the test fixtures look like the
+#   production code path; resolve_gap then exercises the
+#   tenant-checked reassignment + gap pruning.
+"""Service-level coverage for ``planner.service.agent_resolve_gap``."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud._core.errors import NotFound
+from ee.cloud._core.realtime.events import PlanGapResolved
+from ee.cloud.agents import service as agents_service
+from ee.cloud.agents.dto import CreateAgentRequest
+from ee.cloud.planner import service as planner_service
+from ee.cloud.planner.dto import PlanProjectRequest, ResolveGapRequest
+from ee.cloud.projects import service as projects_service
+from ee.cloud.projects.dto import CreateProjectRequest
+from ee.cloud.tasks import service as tasks_service
+from ee.cloud.tasks.dto import ListTasksRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(*, user_id: str = "u-creator", workspace_id: str = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r-resolve",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+class _FakeTaskSpec:
+    def __init__(
+        self,
+        *,
+        key: str,
+        title: str = "",
+        description: str = "",
+        task_type: str = "agent",
+        priority: str = "medium",
+        required_specialties: list[str] | None = None,
+        blocked_by_keys: list[str] | None = None,
+    ) -> None:
+        self.key = key
+        self.title = title or f"Task {key}"
+        self.description = description
+        self.task_type = task_type
+        self.priority = priority
+        self.required_specialties = required_specialties or []
+        self.blocked_by_keys = blocked_by_keys or []
+
+    def to_dict(self) -> dict:
+        return {"key": self.key, "title": self.title}
+
+
+class _FakeAgentSpec:
+    def __init__(self, *, name: str, role: str = "", specialties: list[str] | None = None) -> None:
+        self.name = name
+        self.role = role
+        self.specialties = specialties or []
+        self.backend = ""
+
+    def to_dict(self) -> dict:
+        return {"name": self.name, "role": self.role}
+
+
+class _FakePlannerResult:
+    def __init__(
+        self,
+        *,
+        prd_content: str = "# PRD",
+        tasks: list[_FakeTaskSpec] | None = None,
+        human_tasks: list[_FakeTaskSpec] | None = None,
+        team_recommendation: list[_FakeAgentSpec] | None = None,
+    ) -> None:
+        self.prd_content = prd_content
+        self.tasks = tasks or []
+        self.human_tasks = human_tasks or []
+        self.team_recommendation = team_recommendation or []
+        self.dependency_graph: dict = {}
+        self.research_notes = ""
+        self.project_id = ""
+        self.estimated_total_minutes = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "prd_content": self.prd_content,
+            "tasks": [t.to_dict() for t in self.tasks],
+            "team_recommendation": [a.to_dict() for a in self.team_recommendation],
+        }
+
+
+def _patched_planner(result: _FakePlannerResult):
+    async def _fake_plan(self, project_description, project_id="", research_depth="standard"):  # noqa: ARG001
+        result.project_id = project_id
+        return result
+
+    return patch("pocketpaw.deep_work.planner.PlannerAgent.plan", new=_fake_plan)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_upload_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin Path.home() into tmp_path so planner file writes stay hermetic."""
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+
+async def _make_project(workspace_id: str = "w1", lead_id: str = "u-lead") -> str:
+    proj = await projects_service.agent_create(
+        _ctx(workspace_id=workspace_id),
+        CreateProjectRequest(name="Crestline", lead_id=lead_id),
+    )
+    return proj.id
+
+
+async def _create_agent(
+    workspace_id: str = "w1",
+    *,
+    name: str,
+    slug: str | None = None,
+) -> str:
+    agent = await agents_service.create(
+        _ctx(workspace_id=workspace_id),
+        workspace_id,
+        CreateAgentRequest(name=name, slug=slug or name.lower().replace(" ", "-")),
+    )
+    return agent.id
+
+
+async def _plan_with_unmatched_spec(
+    *,
+    project_id: str,
+    spec_name: str = "events-coordinator",
+    extra_specs: list[_FakeAgentSpec] | None = None,
+) -> str:
+    """Run a plan that creates 3 tasks wanting ``spec_name``. All three
+    fall back to the project lead (human) because no cloud Agent exists.
+    Returns the plan_session_id.
+    """
+
+    fake = _FakePlannerResult(
+        tasks=[
+            _FakeTaskSpec(
+                key=f"t{i}",
+                title=f"Task {i}",
+                required_specialties=["events"],
+            )
+            for i in range(3)
+        ],
+        team_recommendation=[
+            _FakeAgentSpec(name=spec_name, role="Events Lead", specialties=["events"]),
+            *(extra_specs or []),
+        ],
+    )
+    with _patched_planner(fake):
+        result = await planner_service.agent_plan_project(
+            _ctx(),
+            PlanProjectRequest(project_id=project_id, goal="Plan the wedding for May 23."),
+        )
+    return result.plan_session_id
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_gap_reassigns_human_fallback_tasks(recording_bus) -> None:
+    project_id = await _make_project()
+    plan_session_id = await _plan_with_unmatched_spec(project_id=project_id)
+
+    # Confirm baseline: three tasks landed as human fallback with the
+    # planner-wanted spec name on assignee.name.
+    rows_before = await tasks_service.agent_list_tasks(
+        _ctx(), ListTasksRequest(project_id=project_id, limit=100)
+    )
+    assert len(rows_before) == 3
+    assert all(r.assignee.kind == "human" for r in rows_before)
+    assert all(r.assignee.name == "events-coordinator" for r in rows_before)
+
+    # Operator creates the agent the planner wanted. Frontend hits
+    # ``POST /api/v1/agents`` directly; we simulate that here.
+    new_agent_id = await _create_agent(name="events-coordinator")
+
+    result = await planner_service.agent_resolve_gap(
+        _ctx(),
+        ResolveGapRequest(
+            plan_session_id=plan_session_id,
+            spec_name="events-coordinator",
+            new_agent_id=new_agent_id,
+        ),
+    )
+
+    assert len(result.reassigned_task_ids) == 3
+    assert result.remaining_gaps == []
+    assert result.new_agent_id == new_agent_id
+
+    rows_after = await tasks_service.agent_list_tasks(
+        _ctx(), ListTasksRequest(project_id=project_id, limit=100)
+    )
+    assert all(r.assignee.kind == "agent" for r in rows_after)
+    assert all(r.assignee.id == new_agent_id for r in rows_after)
+    assert all(r.assignee.name == "events-coordinator" for r in rows_after)
+
+    # Event fan-out: at least one PlanGapResolved per resolve call.
+    gap_events = [e for e in recording_bus.events if isinstance(e, PlanGapResolved)]
+    assert len(gap_events) == 1
+    payload = gap_events[0].data
+    assert payload["spec_name"] == "events-coordinator"
+    assert payload["new_agent_id"] == new_agent_id
+    assert payload["reassigned_task_count"] == 3
+    assert payload["remaining_gap_count"] == 0
+
+
+async def test_resolve_gap_returns_remaining_gaps() -> None:
+    project_id = await _make_project()
+    plan_session_id = await _plan_with_unmatched_spec(
+        project_id=project_id,
+        extra_specs=[
+            _FakeAgentSpec(name="vendor-comms", role="Comms", specialties=["comms"]),
+        ],
+    )
+
+    new_agent_id = await _create_agent(name="events-coordinator")
+    result = await planner_service.agent_resolve_gap(
+        _ctx(),
+        ResolveGapRequest(
+            plan_session_id=plan_session_id,
+            spec_name="events-coordinator",
+            new_agent_id=new_agent_id,
+        ),
+    )
+
+    remaining_names = {g.spec_name for g in result.remaining_gaps}
+    assert remaining_names == {"vendor-comms"}
+
+
+async def test_resolve_gap_404_for_unknown_session() -> None:
+    new_agent_id = await _create_agent(name="some-agent")
+    with pytest.raises(NotFound):
+        await planner_service.agent_resolve_gap(
+            _ctx(),
+            ResolveGapRequest(
+                plan_session_id="000000000000000000000000",
+                spec_name="some-agent",
+                new_agent_id=new_agent_id,
+            ),
+        )
+
+
+async def test_resolve_gap_404_for_unknown_agent_id() -> None:
+    project_id = await _make_project()
+    plan_session_id = await _plan_with_unmatched_spec(project_id=project_id)
+
+    with pytest.raises(NotFound):
+        await planner_service.agent_resolve_gap(
+            _ctx(),
+            ResolveGapRequest(
+                plan_session_id=plan_session_id,
+                spec_name="events-coordinator",
+                new_agent_id="000000000000000000000000",
+            ),
+        )
+
+
+async def test_resolve_gap_tenant_isolation() -> None:
+    project_id = await _make_project(workspace_id="w1")
+    plan_session_id = await _plan_with_unmatched_spec(project_id=project_id)
+    # Agent lives in another workspace; the resolve attempt from w2
+    # against w1's session must 404 — same uniform code path the tasks
+    # service uses to mitigate id enumeration.
+    foreign_agent_id = await _create_agent(workspace_id="w2", name="events-coordinator")
+    with pytest.raises(NotFound):
+        await planner_service.agent_resolve_gap(
+            _ctx(workspace_id="w2"),
+            ResolveGapRequest(
+                plan_session_id=plan_session_id,
+                spec_name="events-coordinator",
+                new_agent_id=foreign_agent_id,
+            ),
+        )

--- a/tests/cloud/test_planner_task_dependencies.py
+++ b/tests/cloud/test_planner_task_dependencies.py
@@ -1,0 +1,186 @@
+# Created: 2026-05-17 — pocketpaw#1118 P4. Tests for the planner's
+#   two-pass task materialization — the part that wires
+#   ``TaskSpec.blocked_by_keys`` into cloud ``Task.blocked_by`` after
+#   every sibling task exists. Forward references and unknown deps are
+#   the failure modes the two-pass refactor exists to handle, so each
+#   case has its own test.
+"""Service-level coverage for the planner's two-pass dependency wiring."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud.planner import service as planner_service
+from ee.cloud.planner.dto import PlanProjectRequest
+from ee.cloud.projects import service as projects_service
+from ee.cloud.projects.dto import CreateProjectRequest
+from ee.cloud.tasks import service as tasks_service
+from ee.cloud.tasks.dto import ListTasksRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(*, user_id: str = "u-creator", workspace_id: str = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r-deps",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+class _FakeTaskSpec:
+    def __init__(
+        self,
+        *,
+        key: str,
+        title: str = "",
+        description: str = "",
+        task_type: str = "agent",
+        priority: str = "medium",
+        required_specialties: list[str] | None = None,
+        blocked_by_keys: list[str] | None = None,
+    ) -> None:
+        self.key = key
+        self.title = title or f"Task {key}"
+        self.description = description
+        self.task_type = task_type
+        self.priority = priority
+        self.required_specialties = required_specialties or []
+        self.blocked_by_keys = blocked_by_keys or []
+
+    def to_dict(self) -> dict:
+        return {"key": self.key, "title": self.title}
+
+
+class _FakePlannerResult:
+    def __init__(
+        self,
+        *,
+        tasks: list[_FakeTaskSpec] | None = None,
+        team_recommendation: list | None = None,
+    ) -> None:
+        self.prd_content = "# PRD"
+        self.tasks = tasks or []
+        self.human_tasks: list = []
+        self.team_recommendation = team_recommendation or []
+        self.project_id = ""
+
+    def to_dict(self) -> dict:
+        return {"tasks": [t.to_dict() for t in self.tasks]}
+
+
+def _patched_planner(result: _FakePlannerResult):
+    async def _fake_plan(self, project_description, project_id="", research_depth="standard"):  # noqa: ARG001
+        result.project_id = project_id
+        return result
+
+    return patch("pocketpaw.deep_work.planner.PlannerAgent.plan", new=_fake_plan)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_upload_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+
+async def _make_project() -> str:
+    proj = await projects_service.agent_create(_ctx(), CreateProjectRequest(name="Crestline"))
+    return proj.id
+
+
+async def _tasks_by_planner_key(project_id: str) -> dict[str, str]:
+    """Map ``TaskSpec.key`` (carried via ``source.metadata.planner_task_key``)
+    back to the cloud Task id so the assertions can read 'task B depends
+    on task A' rather than juggling ObjectId strings."""
+
+    rows = await tasks_service.agent_list_tasks(
+        _ctx(), ListTasksRequest(project_id=project_id, limit=500)
+    )
+    out: dict[str, str] = {}
+    for r in rows:
+        key = (r.source.metadata or {}).get("planner_task_key", "")
+        if key:
+            out[key] = r.id
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Two-pass wiring
+# ---------------------------------------------------------------------------
+
+
+async def test_planner_materializes_dependencies_in_two_passes() -> None:
+    """TaskSpec A depends on B; both materialize; A.blocked_by contains
+    B's cloud id (not the spec key)."""
+
+    project_id = await _make_project()
+    fake = _FakePlannerResult(
+        tasks=[
+            _FakeTaskSpec(key="b", title="Build vendor list"),
+            _FakeTaskSpec(key="a", title="Outreach", blocked_by_keys=["b"]),
+        ],
+    )
+    with _patched_planner(fake):
+        result = await planner_service.agent_plan_project(
+            _ctx(), PlanProjectRequest(project_id=project_id, goal="Plan a thing carefully.")
+        )
+
+    assert result.dependency_warnings == []
+    by_key = await _tasks_by_planner_key(project_id)
+    task_a = await tasks_service.agent_get_task(_ctx(), by_key["a"])
+    task_b = await tasks_service.agent_get_task(_ctx(), by_key["b"])
+    assert task_a.blocked_by == [task_b.id]
+    assert task_b.blocked_by == []
+
+
+async def test_planner_handles_forward_references() -> None:
+    """TaskSpec A is in the spec list BEFORE its dependency B. The
+    two-pass refactor exists specifically so this case resolves cleanly
+    instead of dropping A's dependency."""
+
+    project_id = await _make_project()
+    fake = _FakePlannerResult(
+        tasks=[
+            _FakeTaskSpec(key="a", title="Outreach", blocked_by_keys=["b"]),
+            _FakeTaskSpec(key="b", title="Build vendor list"),
+        ],
+    )
+    with _patched_planner(fake):
+        result = await planner_service.agent_plan_project(
+            _ctx(), PlanProjectRequest(project_id=project_id, goal="Plan a thing carefully.")
+        )
+
+    assert result.dependency_warnings == []
+    by_key = await _tasks_by_planner_key(project_id)
+    task_a = await tasks_service.agent_get_task(_ctx(), by_key["a"])
+    task_b = await tasks_service.agent_get_task(_ctx(), by_key["b"])
+    assert task_a.blocked_by == [task_b.id]
+
+
+async def test_planner_skips_unknown_dep_names_with_warning() -> None:
+    """TaskSpec A depends on a nonexistent spec X; A is still created
+    with an empty blocked_by, and 'X' surfaces in dependency_warnings.
+    This matches the brief — never cascade-delete tasks for a missing
+    dep, just record the bug."""
+
+    project_id = await _make_project()
+    fake = _FakePlannerResult(
+        tasks=[
+            _FakeTaskSpec(key="a", title="Outreach", blocked_by_keys=["never-existed"]),
+        ],
+    )
+    with _patched_planner(fake):
+        result = await planner_service.agent_plan_project(
+            _ctx(), PlanProjectRequest(project_id=project_id, goal="Plan a thing carefully.")
+        )
+
+    assert "never-existed" in result.dependency_warnings
+    by_key = await _tasks_by_planner_key(project_id)
+    task_a = await tasks_service.agent_get_task(_ctx(), by_key["a"])
+    assert task_a.blocked_by == []

--- a/tests/cloud/test_tasks_blocked_by.py
+++ b/tests/cloud/test_tasks_blocked_by.py
@@ -1,0 +1,131 @@
+# Created: 2026-05-17 — pocketpaw#1118 P4. Tests for the Tasks
+#   ``blocked_by`` field — create persists, update obeys tri-state
+#   semantics (None = no change, [] = explicit clear, [...] = replace).
+#   The planner relies on these guarantees for its two-pass dependency
+#   wiring; manual callers do too.
+"""Tasks ``blocked_by`` field — create + update tri-state semantics."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud.tasks import service as tasks_service
+from ee.cloud.tasks.dto import (
+    AssigneeDTO,
+    CreateTaskRequest,
+    UpdateTaskRequest,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(*, user_id: str = "u-creator", workspace_id: str = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r-bb",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _human_assignee() -> AssigneeDTO:
+    return AssigneeDTO(kind="human", id="u-creator", name="Creator")
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+async def test_create_with_blocked_by_persists() -> None:
+    """Round-trip — the ids set on create come back on the response and
+    on a subsequent get."""
+
+    body = CreateTaskRequest(
+        title="Outreach",
+        assignee=_human_assignee(),
+        blocked_by=["task-abc", "task-def"],
+    )
+    resp = await tasks_service.agent_create_task(_ctx(), body)
+    assert resp.blocked_by == ["task-abc", "task-def"]
+
+    fetched = await tasks_service.agent_get_task(_ctx(), resp.id)
+    assert fetched.blocked_by == ["task-abc", "task-def"]
+
+
+async def test_create_with_no_blocked_by_defaults_to_empty() -> None:
+    """Field omitted on create → empty list, not None."""
+
+    body = CreateTaskRequest(title="Standalone", assignee=_human_assignee())
+    resp = await tasks_service.agent_create_task(_ctx(), body)
+    assert resp.blocked_by == []
+
+
+# ---------------------------------------------------------------------------
+# Update tri-state
+# ---------------------------------------------------------------------------
+
+
+async def test_update_clears_blocked_by_when_empty_list() -> None:
+    """Explicit clear semantics: an empty list MUST overwrite stored
+    deps so the operator can "unblock" a task in one call."""
+
+    created = await tasks_service.agent_create_task(
+        _ctx(),
+        CreateTaskRequest(
+            title="x",
+            assignee=_human_assignee(),
+            blocked_by=["task-1", "task-2"],
+        ),
+    )
+    assert created.blocked_by == ["task-1", "task-2"]
+
+    updated = await tasks_service.agent_update_task(
+        _ctx(), created.id, UpdateTaskRequest(blocked_by=[])
+    )
+    assert updated.blocked_by == []
+    refetched = await tasks_service.agent_get_task(_ctx(), created.id)
+    assert refetched.blocked_by == []
+
+
+async def test_update_leaves_blocked_by_alone_when_omitted() -> None:
+    """None = no change. The DTO's ``blocked_by`` defaults to ``None``
+    so a caller patching unrelated fields doesn't accidentally clear
+    deps."""
+
+    created = await tasks_service.agent_create_task(
+        _ctx(),
+        CreateTaskRequest(
+            title="x",
+            assignee=_human_assignee(),
+            blocked_by=["task-1"],
+        ),
+    )
+    # Patch an unrelated field; blocked_by stays put.
+    updated = await tasks_service.agent_update_task(
+        _ctx(), created.id, UpdateTaskRequest(title="new title")
+    )
+    assert updated.blocked_by == ["task-1"]
+    assert updated.title == "new title"
+
+
+async def test_update_replaces_blocked_by_with_new_list() -> None:
+    """A non-empty list overwrites the stored set wholesale — there is
+    no merge semantic. Callers wanting append must read-merge-write."""
+
+    created = await tasks_service.agent_create_task(
+        _ctx(),
+        CreateTaskRequest(
+            title="x",
+            assignee=_human_assignee(),
+            blocked_by=["task-1"],
+        ),
+    )
+    updated = await tasks_service.agent_update_task(
+        _ctx(), created.id, UpdateTaskRequest(blocked_by=["task-2", "task-3"])
+    )
+    assert updated.blocked_by == ["task-2", "task-3"]


### PR DESCRIPTION
Two stacked shifts. Both build on #1120 (parent branch — will auto-retarget to \`ee\` when #1120 merges).

## P3 — agent-gap → create-agent flow

Plan sessions now persist as a \`PlanSession\` Beanie doc (\`ee.cloud.models.planner\`) so we can find the session again after the operator creates the missing agent. \`POST /api/v1/planner/resolve-gap\` takes \`{plan_session_id, spec_name, new_agent_id}\`, locates the human-fallback tasks for that spec, reassigns them to the new agent, strips the resolved spec from the persisted gap list, and emits \`PlanGapResolved\`. Fallback tasks now carry the wanted spec name on \`assignee.name\` and on \`source.metadata.wanted_agent_spec_name\` so the resolve flow can find the rows without parsing plan.json. The frontend creates the agent itself via \`POST /api/v1/agents\` — no new agent-creation route here.

## P4 — task dependencies

Added \`blocked_by: list[str]\` to the Task domain, DTO, and the Beanie doc. Update is tri-state — \`None\` leaves stored deps alone, \`[]\` clears them, a list replaces them outright. \`_materialize_tasks\` is now two passes: pass 1 inserts every task with empty \`blocked_by\` and builds a \`spec_key → task_id\` map, pass 2 patches deps via \`agent_update_task\` so forward references resolve correctly. Unresolved \`blocked_by_keys\` surface as \`PlanProjectResult.dependency_warnings\` instead of failing the run. The WorkItem projection threads \`Task.blocked_by\` through with the \`task:\` prefix so the frontend can dereference dependency edges without translating ids.

## Other touched bits

- \`PlanGapResolved\` registered in \`_core/realtime/events.py\`
- \`PlanSession\` added to \`ALL_DOCUMENTS\`
- New import-linter contract: \"Planner — Beanie writes only from service.py\"

## Tests

- \`test_planner_resolve_gap.py\` — 5 (happy path, multi-gap, three 404 cases)
- \`test_planner_task_dependencies.py\` — 3 (two-pass, forward refs, unknown dep with warning)
- \`test_tasks_blocked_by.py\` — 5 (create round-trip + tri-state update semantics)
- \`test_mission_control_service.py\` — extended for the prefixed \`blocked_by\` on the projected WorkItem

42 touched-area tests pass. Ruff + import-linter clean.

## Companion PR

paw-enterprise**#197** — wires the inline create-agent flow on the Plan tab + renders the blocked-by state in WorkFeed + WorkItemDetail.

## Tracks

- Closes part of #1118 (P3 + P4)
- P5 (replay + edit history) is the remaining follow-up