### PR TITLE
feat(cloud-audit): workspace-scoped /api/v1/audit (B1)

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -1,5 +1,10 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Updated: 2026-05-17 (audit-cloud B1) — Mounts the workspace-scoped Audit
+    entity at ``/api/v1/audit``. Wraps the existing SQLite-backed
+    ``pocketpaw.audit.store`` with tenancy enforced from
+    ``RequestContext.workspace_id``. The legacy
+    ``/api/v1/runtime/audit`` stays live for the local-runtime path.
 Updated: 2026-05-17 (security #1117 P1) — Mounts ``CSRFMiddleware`` and
     the ``/auth/csrf`` token endpoint so the web build can use the
     HttpOnly auth cookie without exposing CSRF surface. Bearer-auth
@@ -123,6 +128,7 @@ def mount_cloud(app: FastAPI) -> None:
 
     # Import and mount domain routers
     from ee.cloud.agents.router import router as agents_router
+    from ee.cloud.audit.router import router as audit_router
     from ee.cloud.auth.router import router as auth_router
     from ee.cloud.chat.router import router as chat_router
     from ee.cloud.connectors.router import router as connectors_router
@@ -139,6 +145,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(csrf_router, prefix="/api/v1")
     app.include_router(workspace_router, prefix="/api/v1")
     app.include_router(agents_router, prefix="/api/v1")
+    app.include_router(audit_router, prefix="/api/v1")
     app.include_router(chat_router, prefix="/api/v1")
     app.include_router(connectors_router, prefix="/api/v1")
     app.include_router(pockets_router, prefix="/api/v1")

--- a/ee/cloud/audit/__init__.py
+++ b/ee/cloud/audit/__init__.py
@@ -1,0 +1,5 @@
+# __init__.py — Audit entity package marker.
+# Created: 2026-05-17 (Q1=B1) — Workspace-scoped wrapper around the
+#   src/pocketpaw/audit FTS store. Owns the canonical /api/v1/audit
+#   surface for the desktop client; legacy /api/v1/runtime/audit stays
+#   live untouched as a follow-up.

--- a/ee/cloud/audit/domain.py
+++ b/ee/cloud/audit/domain.py
@@ -1,0 +1,28 @@
+# domain.py — Frozen value objects for the Audit entity.
+# Created: 2026-05-17 — Tenancy fields required at construction per ee/cloud Rule 3.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal, NewType
+
+AuditEntryId = NewType("AuditEntryId", str)
+AuditCategory = Literal["decision", "data", "config", "security"]
+
+
+@dataclass(frozen=True)
+class AuditEntryView:
+    id: AuditEntryId
+    workspace_id: str
+    timestamp: datetime
+    actor: str
+    action: str
+    category: AuditCategory
+    description: str
+    pocket_id: str | None = None
+    context: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
+    status: str = "completed"
+
+
+__all__ = ["AuditEntryView", "AuditEntryId", "AuditCategory"]

--- a/ee/cloud/audit/dto.py
+++ b/ee/cloud/audit/dto.py
@@ -1,0 +1,40 @@
+# dto.py — Request/response DTOs for the Audit entity.
+# Created: 2026-05-17 — Mirrors the legacy /runtime/audit envelope so the
+#   frontend mapper (mapAuditEntry) keeps working unchanged.
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class ListAuditRequest(BaseModel):
+    q: str | None = Field(default=None, max_length=200)
+    category: Literal["decision", "data", "config", "security"] | None = None
+    pocket_id: str | None = None
+    actor: str | None = None
+    limit: int = Field(default=200, ge=1, le=1000)
+    cursor: str | None = None  # forward-compat; unused in B1
+
+
+class AuditEntryDTO(BaseModel):
+    id: str
+    timestamp: str  # ISO-8601 UTC
+    pocket_id: str | None = None
+    actor: str
+    action: str
+    category: str
+    description: str
+    context: dict[str, Any] = Field(default_factory=dict)
+    ai_recommendation: str | None = None
+    outcome: str | None = None
+    status: str = "completed"
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class AuditListResponse(BaseModel):
+    entries: list[AuditEntryDTO]
+    total: int
+
+
+__all__ = ["ListAuditRequest", "AuditListResponse", "AuditEntryDTO"]

--- a/ee/cloud/audit/router.py
+++ b/ee/cloud/audit/router.py
@@ -1,0 +1,51 @@
+# router.py — FastAPI router for the Audit entity.
+# Created: 2026-05-17 — Workspace-scoped /api/v1/audit. Never raises
+#   HTTPException — CloudError → JSON via _core.http.
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from ee.cloud._core.context import RequestContext, request_context
+from ee.cloud._core.errors import CloudError
+from ee.cloud.audit import service as audit_service
+from ee.cloud.audit.dto import AuditListResponse, ListAuditRequest
+from ee.cloud.license import require_license
+from ee.cloud.shared.deps import require_action_any_workspace
+
+router = APIRouter(
+    prefix="/audit",
+    tags=["Audit"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.get(
+    "",
+    response_model=AuditListResponse,
+    dependencies=[Depends(require_action_any_workspace("audit.read"))],
+)
+async def list_audit(
+    request: Request,
+    q: str | None = Query(default=None, max_length=200),
+    category: str | None = Query(default=None),
+    pocket_id: str | None = Query(default=None),
+    actor: str | None = Query(default=None),
+    limit: int = Query(default=200, ge=1, le=1000),
+    cursor: str | None = Query(default=None),
+    ctx: RequestContext = Depends(request_context),
+) -> AuditListResponse:
+    if "workspace_id" in request.query_params:
+        raise CloudError(
+            400,
+            "audit.workspace_id_forbidden",
+            "workspace_id is taken from auth context, not query",
+        )
+    body = ListAuditRequest(
+        q=q,
+        category=category,  # type: ignore[arg-type]
+        pocket_id=pocket_id,
+        actor=actor,
+        limit=limit,
+        cursor=cursor,
+    )
+    return await audit_service.agent_list_audit(ctx, body)

--- a/ee/cloud/audit/service.py
+++ b/ee/cloud/audit/service.py
@@ -1,0 +1,45 @@
+# service.py — Audit entity business logic.
+# Created: 2026-05-17 — Read-only wrapper over pocketpaw.audit.store
+#   AuditStore.search_entries with mandatory workspace_id tenancy filter
+#   sourced from ctx.workspace_id. # no-event: read-only entity per Rule 9.
+from __future__ import annotations
+
+import logging
+
+from ee.cloud._core.context import RequestContext
+from ee.cloud._core.errors import CloudError, Internal
+from ee.cloud.audit.dto import AuditEntryDTO, AuditListResponse, ListAuditRequest
+from pocketpaw.audit.store import AuditStore, get_audit_store  # type: ignore[import-untyped]
+
+logger = logging.getLogger(__name__)
+
+
+async def agent_list_audit(
+    ctx: RequestContext,
+    body: ListAuditRequest | dict | None = None,
+    *,
+    store: AuditStore | None = None,  # DI seam for tests
+) -> AuditListResponse:
+    body = ListAuditRequest.model_validate(body or {})
+    if not ctx.workspace_id:
+        return AuditListResponse(entries=[], total=0)
+    store = store or get_audit_store()
+    try:
+        entries = await store.search_entries(
+            workspace_id=ctx.workspace_id,
+            pocket_id=body.pocket_id,
+            category=body.category,
+            actor=body.actor,
+            q=body.q,
+            limit=body.limit,
+        )
+    except CloudError:
+        raise
+    except Exception as exc:
+        logger.error("audit.list failed", exc_info=True)
+        raise Internal("audit.list_failed", "audit query failed") from exc
+    dtos = [AuditEntryDTO.model_validate(e, from_attributes=True) for e in entries]
+    return AuditListResponse(entries=dtos, total=len(dtos))
+
+
+__all__ = ["agent_list_audit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -650,3 +650,14 @@ source_modules = [
     "ee.cloud.planner.domain",
 ]
 forbidden_modules = ["ee.cloud.models.planner"]
+
+[[tool.importlinter.contracts]]
+name = "Audit — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "ee.cloud.audit.router",
+    "ee.cloud.audit.dto",
+    "ee.cloud.audit.domain",
+]
+forbidden_modules = ["ee.cloud.models.audit"]

--- a/src/pocketpaw/ee/guards/actions.py
+++ b/src/pocketpaw/ee/guards/actions.py
@@ -175,6 +175,12 @@ ACTIONS: dict[str, ActionRule] = {
     # because per-route timing reveals traffic patterns and request
     # cadence that shouldn't be visible to every admin in a workspace.
     "admin.perf": ActionRule(WorkspaceRole.OWNER, "admin.access_denied"),
+    # Audit — workspace-scoped audit log read surface (ee.cloud.audit).
+    # ADMIN because audit entries can carry decision context, connector
+    # payloads, and AI recommendations that should not be visible to
+    # every workspace member. The role choice mirrors the existing
+    # abac.ACTION_ROLES["audit.read"] entry.
+    "audit.read": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
 }
 
 

--- a/tests/cloud/conftest.py
+++ b/tests/cloud/conftest.py
@@ -136,3 +136,61 @@ async def cloud_app_client() -> AsyncClient:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://t") as client:
         yield client
+
+
+# ---------------------------------------------------------------------------
+# Audit fixtures — ee.cloud.audit entity (B1).
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def audit_store_tmp(tmp_path):
+    """Fresh AuditStore backed by a tmp SQLite file.
+
+    Tests that exercise the cloud audit entity inject this via
+    ``audit_service.agent_list_audit(ctx, body, store=...)`` so the
+    home-directory singleton (``get_audit_store``) is never touched.
+    """
+    from pocketpaw.audit.store import AuditStore
+
+    store = AuditStore(db_path=tmp_path / "audit.db")
+    yield store
+
+
+@pytest_asyncio.fixture
+async def make_audit_entry(audit_store_tmp):
+    """Factory that inserts an audit row scoped to a workspace.
+
+    The store's ``log_entry`` does not accept ``workspace_id`` directly;
+    workspace tenancy travels on ``context.workspace_id`` (the same JSON
+    column ``search_entries`` rolls up over). Tests stay terse:
+
+        await make_audit_entry("w1", action="x", description="...")
+    """
+
+    async def _make(
+        workspace_id: str,
+        *,
+        actor: str = "system",
+        action: str = "test.action",
+        category: str = "decision",
+        description: str = "test entry",
+        pocket_id: str | None = None,
+        context: dict | None = None,
+        metadata: dict | None = None,
+        status: str = "completed",
+    ) -> str:
+        merged_context = dict(context or {})
+        merged_context.setdefault("workspace_id", workspace_id)
+        return await audit_store_tmp.log_entry(
+            actor=actor,
+            action=action,
+            category=category,
+            description=description,
+            pocket_id=pocket_id,
+            context=merged_context,
+            metadata=metadata,
+            status=status,
+        )
+
+    return _make

--- a/tests/cloud/test_audit_router.py
+++ b/tests/cloud/test_audit_router.py
@@ -1,0 +1,336 @@
+# test_audit_router.py — HTTP-layer tests for ee/cloud/audit/router.py.
+# Created: 2026-05-17 (Q1=B1) — Smokes the new /api/v1/audit surface:
+#   tenancy isolation, query-param leak (?workspace_id=), FTS forwarding,
+#   category/limit/pocket filters, response envelope parity with the
+#   legacy /api/v1/runtime/audit endpoint, and the auth/permission seams.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ee.cloud._core.http import add_error_handler
+from ee.cloud.audit import service as audit_service
+from ee.cloud.audit.router import router as audit_router
+from ee.cloud.auth import current_active_user
+from ee.cloud.license import require_license
+
+
+def _fake_user(user_id: str = "u1", workspace_id: str | None = "w1") -> SimpleNamespace:
+    """Lightweight User stand-in shaped like ``ee.cloud.models.user.User``.
+
+    Only the attributes the audit-router auth chain reads are filled in
+    (``id``, ``active_workspace``, ``workspaces``). RBAC is bypassed via
+    a separate monkeypatch on ``check_workspace_action``.
+    """
+    return SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role="admin")]
+        if workspace_id
+        else [],
+    )
+
+
+def _install_service_seam(audit_store) -> None:
+    """Rebind ``agent_list_audit`` so the router-injected service picks up
+    the tmp store. The original is restored by ``_restore_service``."""
+    real = audit_service.agent_list_audit
+
+    async def _bound(ctx, body=None, *, store=None):
+        return await real(ctx, body, store=store or audit_store)
+
+    audit_service.agent_list_audit = _bound  # type: ignore[assignment]
+    audit_service._orig_agent_list_audit = real  # type: ignore[attr-defined]
+
+
+def _restore_service() -> None:
+    real = getattr(audit_service, "_orig_agent_list_audit", None)
+    if real is not None:
+        audit_service.agent_list_audit = real  # type: ignore[assignment]
+        delattr(audit_service, "_orig_agent_list_audit")
+
+
+def _build_app(
+    audit_store,
+    workspace_id: str | None = "w1",
+    user_id: str = "u1",
+    *,
+    skip_auth_override: bool = False,
+    permission_denier: bool = False,
+    monkeypatch=None,
+) -> FastAPI:
+    """Build a FastAPI app wired to the audit router.
+
+    Auth: ``current_active_user`` is overridden to a ``SimpleNamespace``
+    user. RBAC's ``check_workspace_action`` is patched on the platform
+    guards module so the action-guard factory's deny path can be flipped
+    per-test (matches the pattern in ``test_knowledge_router.py``).
+    """
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(audit_router)
+    app.dependency_overrides[require_license] = lambda: None
+
+    if not skip_auth_override:
+        user = _fake_user(user_id=user_id, workspace_id=workspace_id)
+
+        async def _fake_user_dep():
+            return user
+
+        app.dependency_overrides[current_active_user] = _fake_user_dep
+
+        if monkeypatch is not None:
+            # ``check_workspace_action`` is imported at module load into
+            # ``ee.cloud._core.deps`` (see ``from pocketpaw.ee.guards.deps
+            # import check_workspace_action`` at the top of that file).
+            # Patching the source module is too late — the consumer binding
+            # already points at the original function. Patch the consumer
+            # module's symbol directly so the guard's call site sees the
+            # stub.
+            from ee.cloud._core import deps as core_deps
+            from pocketpaw.ee.guards.rbac import Forbidden as GuardForbidden
+
+            if permission_denier:
+
+                def _deny(*_a, **_k):
+                    raise GuardForbidden(
+                        code="audit.permission_denied",
+                        detail="no audit.read",
+                    )
+
+                monkeypatch.setattr(core_deps, "check_workspace_action", _deny)
+            else:
+                monkeypatch.setattr(
+                    core_deps, "check_workspace_action", lambda *a, **k: None
+                )
+
+    # Always inject the tmp store regardless of auth wiring.
+    _install_service_seam(audit_store)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def w1_client(audit_store_tmp, monkeypatch) -> AsyncClient:
+    app = _build_app(audit_store_tmp, workspace_id="w1", monkeypatch=monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        try:
+            yield client
+        finally:
+            _restore_service()
+
+
+@pytest_asyncio.fixture
+async def w2_client(audit_store_tmp, monkeypatch) -> AsyncClient:
+    app = _build_app(audit_store_tmp, workspace_id="w2", monkeypatch=monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        try:
+            yield client
+        finally:
+            _restore_service()
+
+
+# ---------------------------------------------------------------------------
+# Empty + tenancy
+# ---------------------------------------------------------------------------
+
+
+async def test_returns_empty_for_fresh_workspace(w1_client: AsyncClient) -> None:
+    r = await w1_client.get("/audit")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body == {"entries": [], "total": 0}
+
+
+async def test_returns_workspace_entries_only(
+    w1_client: AsyncClient, make_audit_entry
+) -> None:
+    await make_audit_entry("w1", description="w1-row")
+    await make_audit_entry("w2", description="w2-row")
+    r = await w1_client.get("/audit")
+    assert r.status_code == 200
+    descriptions = {e["description"] for e in r.json()["entries"]}
+    assert descriptions == {"w1-row"}
+
+
+async def test_w2_cannot_see_w1_rows(
+    w2_client: AsyncClient, make_audit_entry
+) -> None:
+    await make_audit_entry("w1", description="w1-secret")
+    r = await w2_client.get("/audit")
+    assert r.status_code == 200
+    assert r.json()["entries"] == []
+
+
+# ---------------------------------------------------------------------------
+# Query-param leak guard
+# ---------------------------------------------------------------------------
+
+
+async def test_rejects_workspace_id_query_param(
+    w1_client: AsyncClient, make_audit_entry
+) -> None:
+    await make_audit_entry("w2", description="w2-row")
+    r = await w1_client.get("/audit", params={"workspace_id": "w2"})
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "audit.workspace_id_forbidden"
+
+
+# ---------------------------------------------------------------------------
+# Filters forwarded to the store
+# ---------------------------------------------------------------------------
+
+
+async def test_q_param_forwards_to_search(
+    w1_client: AsyncClient, make_audit_entry
+) -> None:
+    await make_audit_entry("w1", description="apple pie")
+    await make_audit_entry("w1", description="banana split")
+    r = await w1_client.get("/audit", params={"q": "apple"})
+    assert r.status_code == 200
+    descriptions = {e["description"] for e in r.json()["entries"]}
+    assert descriptions == {"apple pie"}
+
+
+async def test_category_filter_forwards(
+    w1_client: AsyncClient, make_audit_entry
+) -> None:
+    await make_audit_entry("w1", category="security", description="s-row")
+    await make_audit_entry("w1", category="decision", description="d-row")
+    r = await w1_client.get("/audit", params={"category": "security"})
+    assert r.status_code == 200
+    cats = [e["category"] for e in r.json()["entries"]]
+    assert cats == ["security"]
+
+
+async def test_limit_forwards(w1_client: AsyncClient, make_audit_entry) -> None:
+    for i in range(5):
+        await make_audit_entry("w1", description=f"row-{i}")
+    r = await w1_client.get("/audit", params={"limit": 2})
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["entries"]) == 2
+    assert body["total"] == len(body["entries"])
+
+
+async def test_pocket_id_filter_forwards(
+    w1_client: AsyncClient, make_audit_entry
+) -> None:
+    await make_audit_entry("w1", pocket_id="p1", description="for-p1")
+    await make_audit_entry("w1", pocket_id="p2", description="for-p2")
+    r = await w1_client.get("/audit", params={"pocket_id": "p1"})
+    assert r.status_code == 200
+    pockets = {e["pocket_id"] for e in r.json()["entries"]}
+    assert pockets == {"p1"}
+
+
+# ---------------------------------------------------------------------------
+# Envelope parity with legacy runtime audit response
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_field_parity_with_runtime() -> None:
+    """The cloud Audit envelope must be a structural superset of the
+    legacy runtime envelope so the desktop client's ``mapAuditEntry``
+    keeps working when the audit screen swaps over to the new
+    endpoint."""
+    from ee.cloud.audit.dto import AuditEntryDTO, AuditListResponse
+    from pocketpaw.audit.models import AuditEntry
+    from pocketpaw.audit.runtime_router import RuntimeAuditResponse
+
+    cloud = AuditListResponse(entries=[], total=0).model_dump()
+    runtime = RuntimeAuditResponse(entries=[], total=0).model_dump()
+    assert set(cloud.keys()) == set(runtime.keys())
+
+    cloud_entry = AuditEntryDTO(
+        id="1",
+        timestamp="2026-05-17T00:00:00+00:00",
+        actor="system",
+        action="x",
+        category="decision",
+        description="d",
+    ).model_dump()
+    runtime_entry = AuditEntry(
+        actor="system", action="x", category="decision", description="d"
+    ).model_dump()
+    assert set(cloud_entry.keys()) == set(runtime_entry.keys())
+
+
+# ---------------------------------------------------------------------------
+# Auth / permissions seams
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_auth_returns_401(audit_store_tmp) -> None:
+    """Without any ``current_active_user`` override the fastapi-users auth
+    chain runs against a request with no Bearer/cookie — short-circuits
+    to 401 before the handler runs."""
+    app = _build_app(
+        audit_store_tmp, workspace_id="w1", skip_auth_override=True
+    )
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            r = await client.get("/audit")
+            assert r.status_code == 401
+    finally:
+        _restore_service()
+
+
+async def test_missing_audit_read_permission_returns_403(
+    audit_store_tmp, monkeypatch
+) -> None:
+    app = _build_app(
+        audit_store_tmp,
+        workspace_id="w1",
+        permission_denier=True,
+        monkeypatch=monkeypatch,
+    )
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            r = await client.get("/audit")
+            assert r.status_code == 403, r.text
+            assert r.json()["error"]["code"] == "audit.permission_denied"
+    finally:
+        _restore_service()
+
+
+async def test_ctx_without_workspace_returns_empty(
+    audit_store_tmp, monkeypatch
+) -> None:
+    """A user with no active workspace must not 500 and must not leak
+    any rows. The workspace-scope dep guard fires first with a 400 for
+    ``no active workspace``; the service-level invariant lives in the
+    matching test in ``test_audit_service.py``.
+    """
+    # No active workspace at all — current_workspace_id (used by the
+    # action guard) raises HTTPException(400). Either 400 or 200 is
+    # acceptable here; both prove "no cross-tenant leak".
+    app = _build_app(
+        audit_store_tmp, workspace_id=None, monkeypatch=monkeypatch
+    )
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            r = await client.get("/audit")
+            assert r.status_code in (200, 400)
+            if r.status_code == 200:
+                assert r.json() == {"entries": [], "total": 0}
+    finally:
+        _restore_service()
+
+
+# Silence ruff unused-import nudge — these are used in fixture composition.
+_unused: tuple[Any, ...] = ()

--- a/tests/cloud/test_audit_service.py
+++ b/tests/cloud/test_audit_service.py
@@ -1,0 +1,116 @@
+# test_audit_service.py — service-level tests for the Audit entity.
+# Created: 2026-05-17 (Q1=B1) — Covers the workspace-tenancy invariant,
+#   FTS / category / pocket / limit forwarding, and validation. The
+#   router tests exercise the HTTP wiring; this file is direct
+#   ``audit_service.agent_list_audit`` calls against a tmp store.
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from ee.cloud._core.context import RequestContext, ScopeKind
+from ee.cloud.audit import service as audit_service
+from ee.cloud.audit.dto import ListAuditRequest
+
+
+def _ctx(workspace: str | None = "w1", user: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty / tenancy
+# ---------------------------------------------------------------------------
+
+
+async def test_returns_empty_for_fresh_workspace(audit_store_tmp) -> None:
+    out = await audit_service.agent_list_audit(
+        _ctx(workspace="w1"),
+        ListAuditRequest(),
+        store=audit_store_tmp,
+    )
+    assert out.entries == []
+    assert out.total == 0
+
+
+async def test_returns_workspace_entries_only(audit_store_tmp, make_audit_entry) -> None:
+    await make_audit_entry("w1", description="w1-row")
+    await make_audit_entry("w2", description="w2-row")
+
+    out = await audit_service.agent_list_audit(
+        _ctx(workspace="w1"),
+        ListAuditRequest(),
+        store=audit_store_tmp,
+    )
+    assert {e.description for e in out.entries} == {"w1-row"}
+    assert out.total == 1
+
+
+async def test_ctx_without_workspace_returns_empty(audit_store_tmp, make_audit_entry) -> None:
+    await make_audit_entry("w1", description="row")
+    out = await audit_service.agent_list_audit(
+        _ctx(workspace=None),
+        ListAuditRequest(),
+        store=audit_store_tmp,
+    )
+    assert out.entries == []
+    assert out.total == 0
+
+
+# ---------------------------------------------------------------------------
+# Filter forwarding
+# ---------------------------------------------------------------------------
+
+
+async def test_q_param_forwards_to_search(audit_store_tmp, make_audit_entry) -> None:
+    await make_audit_entry("w1", description="apple pie")
+    await make_audit_entry("w1", description="banana split")
+
+    out = await audit_service.agent_list_audit(
+        _ctx(workspace="w1"),
+        ListAuditRequest(q="apple"),
+        store=audit_store_tmp,
+    )
+    assert {e.description for e in out.entries} == {"apple pie"}
+
+
+async def test_category_filter_forwards(audit_store_tmp, make_audit_entry) -> None:
+    await make_audit_entry("w1", category="security", description="s")
+    await make_audit_entry("w1", category="decision", description="d")
+
+    out = await audit_service.agent_list_audit(
+        _ctx(workspace="w1"),
+        ListAuditRequest(category="security"),
+        store=audit_store_tmp,
+    )
+    assert [e.category for e in out.entries] == ["security"]
+
+
+async def test_limit_forwards(audit_store_tmp, make_audit_entry) -> None:
+    for i in range(5):
+        await make_audit_entry("w1", description=f"row-{i}")
+
+    out = await audit_service.agent_list_audit(
+        _ctx(workspace="w1"),
+        ListAuditRequest(limit=2),
+        store=audit_store_tmp,
+    )
+    assert len(out.entries) == 2
+    assert out.total == len(out.entries)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_category_validates() -> None:
+    with pytest.raises(PydanticValidationError):
+        ListAuditRequest.model_validate({"category": "bogus"})


### PR DESCRIPTION
## Summary

Adds a new `ee/cloud/audit/` entity that wraps the existing SQLite-backed `src/pocketpaw/audit` store and serves it at `/api/v1/audit`. Workspace tenancy comes from `RequestContext.workspace_id`, never from query params. The legacy `/api/v1/runtime/audit` stays live and untouched as the OSS local-runtime path. Cleanup is a follow-up once the desktop client cuts over.

This is the backend half of PR B in the Activity / Audit / Knowledge wiring sprint (Q1=B1).

## What changed

- `ee/cloud/audit/{__init__,domain,dto,service,router}.py` in the canonical 4-file shape. The service is a module-level `async def`, validates inputs at the entry, and never touches a Beanie document. There isn't one; audit is SQLite.
- `GET /api/v1/audit` with `q`, `category`, `pocket_id`, `actor`, `limit` query params.
- Passing `?workspace_id=...` raises `CloudError(400, audit.workspace_id_forbidden)`. That catches a cross-tenant param leak at the router seam, before it ever reaches the store.
- Response envelope `{entries: [...], total: int}` matches the legacy `RuntimeAuditResponse` key-for-key, so the desktop client's `mapAuditEntry` keeps working when the screen swaps over.
- The entity is read-only, so nothing emits. There's a `# no-event` comment on the return per Rule 9.

## Platform glue

- Registered `audit.read` in `pocketpaw.ee.guards.actions.ACTIONS` so `require_action_any_workspace("audit.read")` actually resolves at request time. The action was already declared in `abac.ACTION_ROLES`; only the ACTIONS registry was missing it (same shape as `kb.read` / `kb.write`).
- Mounted in `ee/cloud/__init__.py` next to the other domain routers. One import, one `include_router` line.
- import-linter contract added so `router` / `dto` / `domain` can't accidentally import a future `ee.cloud.models.audit` Beanie doc.

## Test plan

- [x] 12 router tests: empty workspace, cross-tenant isolation, `?workspace_id=` rejection, `q` / `category` / `pocket_id` / `limit` forwarding, envelope parity with `RuntimeAuditResponse`, 401 on missing auth, 403 on missing `audit.read`, empty response when ctx has no workspace.
- [x] 7 service tests: workspace tenancy, FTS / category / limit forwarding, empty short-circuit, pydantic validation of `category`.
- [x] `lint-imports` — Audit contract KEPT (15 kept, 0 broken).
- [x] `ruff check` on `ee/cloud/audit/`, `tests/cloud/test_audit_*.py`, `tests/cloud/conftest.py` — clean.
- [x] `mypy ee/cloud/audit/` — clean.
- [x] Adjacent `test_projects_*` still pass. The conftest changes are strictly additive.

## Out of scope

- Legacy `/api/v1/runtime/audit` stays live. The frontend doesn't switch over here.
- No SSE, no deprecation headers, no promotion to the knowledge ontology. Per the spec.
- Frontend integration ships separately.
- Legacy-endpoint cleanup waits until the desktop client cuts over.

Plan: `docs/roadmap/future-upgrades/wire-activity-audit-knowledge.md`