### PR TITLE
chore(cloud-audit): tidy up three review NITs from #1124

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -1,16 +1,11 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
-Updated: 2026-05-17 (audit-cloud B1) — Mounts the workspace-scoped Audit
-    entity at ``/api/v1/audit``. Wraps the existing SQLite-backed
-    ``pocketpaw.audit.store`` with tenancy enforced from
-    ``RequestContext.workspace_id``. The legacy
-    ``/api/v1/runtime/audit`` stays live for the local-runtime path.
-Updated: 2026-05-17 (security #1117 P1) — Mounts ``CSRFMiddleware`` and
-    the ``/auth/csrf`` token endpoint so the web build can use the
-    HttpOnly auth cookie without exposing CSRF surface. Bearer-auth
-    clients (Tauri, MCP, scripts) skip the middleware entirely so
-    nothing breaks for existing callers; see ``ee/cloud/_core/csrf.py``
-    for the decision tree.
+Updated: 2026-05-17 — Mounts the workspace-scoped Audit entity at
+    ``/api/v1/audit`` (B1) with tenancy from ``RequestContext.workspace_id``,
+    the legacy ``/api/v1/runtime/audit`` remaining live; also mounts
+    ``CSRFMiddleware`` and the ``/auth/csrf`` token endpoint (#1117) so
+    cookie-auth callers echo ``X-CSRF-Token`` while Bearer-auth clients
+    (Tauri, MCP, scripts) bypass entirely — see ``ee/cloud/_core/csrf.py``.
 Updated: 2026-05-17 (pocketpaw#1118 P1) — Mounts the planner router
     (``/api/v1/planner/run``, ``/api/v1/planner/by-project/{id}``).
     The planner module wraps the OSS deep_work planner and lands its

--- a/tests/cloud/test_audit_router.py
+++ b/tests/cloud/test_audit_router.py
@@ -316,8 +316,9 @@ async def test_ctx_without_workspace_returns_empty(
     matching test in ``test_audit_service.py``.
     """
     # No active workspace at all — current_workspace_id (used by the
-    # action guard) raises HTTPException(400). Either 400 or 200 is
-    # acceptable here; both prove "no cross-tenant leak".
+    # action guard) raises HTTPException(400) before the handler runs.
+    # The service-level empty-response invariant is owned by
+    # test_audit_service.py::test_ctx_without_workspace_returns_empty.
     app = _build_app(
         audit_store_tmp, workspace_id=None, monkeypatch=monkeypatch
     )
@@ -325,9 +326,7 @@ async def test_ctx_without_workspace_returns_empty(
     try:
         async with AsyncClient(transport=transport, base_url="http://t") as client:
             r = await client.get("/audit")
-            assert r.status_code in (200, 400)
-            if r.status_code == 200:
-                assert r.json() == {"entries": [], "total": 0}
+            assert r.status_code == 400
     finally:
         _restore_service()
 

--- a/tests/cloud/test_knowledge_router.py
+++ b/tests/cloud/test_knowledge_router.py
@@ -50,6 +50,9 @@ def client(monkeypatch):
     )
 
     # Stub RBAC: make every action check pass for our fake user.
+    # Note: knowledge_router goes through ee.cloud.shared.deps.require_action_any_workspace
+    # (NOT ee.cloud._core.deps.check_workspace_action), so patching the source here works.
+    # For routers that DO consume _core.deps, patch the consumer instead — see test_audit_router.py.
     from pocketpaw.ee.guards import deps as guards_deps
 
     monkeypatch.setattr(guards_deps, "check_workspace_action", lambda *a, **k: None)


### PR DESCRIPTION
## What

Three non-behavior-changing follow-ups surfaced during the #1124 review.

- **`ee/cloud/__init__.py`** — Two `Updated: 2026-05-17` entries were stacked at the top of the module docstring (one from #1117, one from #1124). Collapsed into a single consolidated line that covers both changes, matching the one-date-per-entry style used by every other module in `ee/cloud/`.

- **`tests/cloud/test_audit_router.py`** — `test_ctx_without_workspace_returns_empty` was asserting `status_code in (200, 400)`. The router's `current_workspace_id` guard always fires first and raises a 400 when `workspace_id is None`, so the 200 branch was dead. Tightened to `== 400`; the 200 path (service returns empty list) is already owned by the matching test in `test_audit_service.py`.

- **`tests/cloud/test_knowledge_router.py`** — Added a three-line comment above the `monkeypatch.setattr(guards_deps, "check_workspace_action", ...)` call explaining why patching the source works here (knowledge_router goes through `ee.cloud.shared.deps.require_action_any_workspace`, not `_core.deps`) and pointing future authors at the consumer-seam pattern used in `test_audit_router.py` for routers that do consume `_core.deps`. No patch logic changed.

## Tests

```
24 passed in 0.36s
```

All three test files pass. Ruff clean.

## Checklist

- [ ] No executable code changed
- [ ] Single commit
- [ ] Targets `ee` branch