### PR TITLE
Add GET /mission-control/plan-sessions for the Plan tab drafts list

### DIFF
--- a/ee/cloud/mission_control/dto.py
+++ b/ee/cloud/mission_control/dto.py
@@ -14,6 +14,13 @@
 # added ``blocked_by: list[str]`` to ``WorkItemResponse`` and threaded it
 # through ``work_item_to_response`` so the frontend feed shows dependency
 # edges in the unified WorkItem shape.
+# Updated: 2026-05-18 (feat/mc-plan-sessions-endpoint) — added
+# ``ListPlanSessionsRequest``, ``PlanSessionDTO`` and
+# ``PlanSessionListResponse`` for the new
+# ``GET /mission-control/plan-sessions`` endpoint. Status values on the
+# wire use the operator vocabulary (``draft``/``active``/``archived``);
+# the service maps to the doc-level ``ready``/``stale`` storage form so
+# the frontend never has to learn the planner's internal terms.
 """Mission Control wire DTOs.
 
 The audit doc (``docs/internal/2026-05-mission-control-backend-audit.md``,
@@ -133,6 +140,26 @@ class ListActivityRequest(BaseModel):
     limit: int = Field(default=30, ge=1, le=200)
 
 
+# Wire-level vocabulary the frontend speaks. The Mission Control Plan tab
+# renders "Draft · N tasks" rows; status semantics map to the underlying
+# planner doc statuses at the service boundary so the wire stays stable
+# even when the doc-level state machine evolves.
+PlanSessionStatus = Literal["draft", "active", "archived"]
+
+
+class ListPlanSessionsRequest(BaseModel):
+    """Query filters for ``GET /mission-control/plan-sessions``.
+
+    Both fields are optional. ``status`` narrows to a single Plan-tab
+    bucket (drafts vs. active vs. archived); ``limit`` caps the listing
+    so a workspace with hundreds of plan sessions doesn't blow up the
+    drafts panel.
+    """
+
+    status: PlanSessionStatus | None = None
+    limit: int = Field(default=50, ge=1, le=200)
+
+
 # ---------------------------------------------------------------------------
 # Responses
 # ---------------------------------------------------------------------------
@@ -211,15 +238,62 @@ class ActivityEventResponse(BaseModel):
     ts: float
 
 
+class PlanSessionDTO(BaseModel):
+    """Wire shape for one plan session in the drafts list.
+
+    Carries only the metadata the drafts list needs:
+      - ``id`` — opaque PlanSession doc id; the frontend round-trips it
+        when the operator opens a draft for full detail (separate
+        endpoint, not in scope here).
+      - ``name`` — display label from the linked Project. Empty string
+        when the project was deleted underneath the session.
+      - ``status`` — wire vocabulary (``draft``/``active``/``archived``).
+        The service maps doc-level ``ready``/``stale`` into this enum.
+      - ``task_count`` — number of materialized tasks at plan time.
+      - ``created_at`` / ``updated_at`` — ISO-8601 strings rather than
+        ``datetime`` objects so the frontend doesn't have to parse a
+        Pydantic-serialized timestamp; matches the audit envelope's
+        approach.
+
+    The Plan detail (PRD, plan.json, agent gaps) lives behind the
+    existing planner endpoints — this DTO intentionally does NOT
+    expose the plan content so the drafts list stays cheap.
+    """
+
+    id: str
+    name: str
+    status: PlanSessionStatus
+    task_count: int
+    created_at: str
+    updated_at: str
+
+
+class PlanSessionListResponse(BaseModel):
+    """Envelope for ``GET /mission-control/plan-sessions``.
+
+    Matches the Audit endpoint's ``{ entries, total }`` shape with a
+    ``sessions`` key instead of ``entries`` to keep the resource name
+    visible. ``total`` is the count of sessions in this response (not
+    a workspace-wide total) — the drafts list isn't paginated in v0.
+    """
+
+    sessions: list[PlanSessionDTO]
+    total: int
+
+
 __all__ = [
     "ActivityEventResponse",
     "BulkActionRequest",
     "BulkReassignRequest",
     "BulkSnoozeRequest",
     "ListActivityRequest",
+    "ListPlanSessionsRequest",
     "ListWorkItemsRequest",
     "OutcomeSummaryResponse",
     "OutcomesQueryRequest",
+    "PlanSessionDTO",
+    "PlanSessionListResponse",
+    "PlanSessionStatus",
     "WorkItemResponse",
     "work_item_to_response",
 ]

--- a/ee/cloud/mission_control/router.py
+++ b/ee/cloud/mission_control/router.py
@@ -7,6 +7,10 @@
 # bulk-reassign / bulk-snooze. Both now return a ``BulkActionResponse``
 # shape (``affected`` + ``skipped`` + ``bulk_id``) by delegating per-id
 # to the Tasks service.
+# Updated: 2026-05-18 (feat/mc-plan-sessions-endpoint) — added
+# ``GET /plan-sessions`` for the Plan tab drafts list. Rejects the
+# ``?workspace_id`` query param before DTO construction (tenancy from
+# auth ctx) per the Audit endpoint's pattern.
 """Mission Control façade router.
 
 Thin per ee/cloud rule #4 — parses requests, delegates to
@@ -23,13 +27,15 @@ canonical URLs are:
   POST /api/v1/mission-control/items/bulk-snooze
   GET  /api/v1/mission-control/outcomes
   GET  /api/v1/mission-control/activity
+  GET  /api/v1/mission-control/plan-sessions
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 
 from ee.cloud._core.context import RequestContext, request_context
+from ee.cloud._core.errors import CloudError
 from ee.cloud.license import require_license
 from ee.cloud.mission_control import service as mc_service
 from ee.cloud.mission_control.dto import (
@@ -38,9 +44,12 @@ from ee.cloud.mission_control.dto import (
     BulkReassignRequest,
     BulkSnoozeRequest,
     ListActivityRequest,
+    ListPlanSessionsRequest,
     ListWorkItemsRequest,
     OutcomesQueryRequest,
     OutcomeSummaryResponse,
+    PlanSessionListResponse,
+    PlanSessionStatus,
     WorkItemResponse,
 )
 
@@ -153,3 +162,31 @@ async def activity(
     """
     body = ListActivityRequest(limit=limit)
     return await mc_service.agent_list_activity(ctx, body)
+
+
+@router.get("/plan-sessions", response_model=PlanSessionListResponse)
+async def list_plan_sessions(
+    request: Request,
+    status: PlanSessionStatus | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    ctx: RequestContext = Depends(request_context),
+) -> PlanSessionListResponse:
+    """List the workspace's persisted plan sessions for the Plan tab drafts list.
+
+    Tenancy lives on the auth ctx — passing ``?workspace_id`` is a 400
+    rather than a silent leak. ``status`` filters to one drafts-list
+    bucket (``draft`` / ``active`` / ``archived``); the service maps to
+    the doc-level vocabulary internally.
+
+    Response keys: ``sessions`` (list of plan-session DTOs) + ``total``
+    (count of returned sessions). Empty workspaces return
+    ``{"sessions": [], "total": 0}`` with HTTP 200.
+    """
+    if "workspace_id" in request.query_params:
+        raise CloudError(
+            400,
+            "plan_sessions.workspace_id_forbidden",
+            "workspace_id is taken from auth context, not query",
+        )
+    body = ListPlanSessionsRequest(status=status, limit=limit)
+    return await mc_service.agent_list_plan_sessions(ctx, body)

--- a/ee/cloud/mission_control/service.py
+++ b/ee/cloud/mission_control/service.py
@@ -13,6 +13,13 @@
 # dependency id is prefixed with ``task:`` so the frontend's heterogeneous
 # feed can link dependency edges to their corresponding WorkItem rows
 # without translating ids client-side.
+# Updated: 2026-05-18 (feat/mc-plan-sessions-endpoint) — added
+# ``agent_list_plan_sessions`` that delegates to
+# ``planner.service.list_plan_sessions`` (the only module allowed to
+# touch the PlanSession Beanie doc) and DTO-maps the typed summaries to
+# the wire envelope. Status vocabulary mapping (ready/stale ↔
+# draft/archived) lives here so the planner entity keeps its internal
+# vocabulary while Mission Control surfaces the operator's terms.
 """Mission Control façade service.
 
 Every function is module-level ``async def`` per ee/cloud rule #5. The
@@ -67,9 +74,12 @@ from ee.cloud.mission_control.dto import (
     BulkReassignRequest,
     BulkSnoozeRequest,
     ListActivityRequest,
+    ListPlanSessionsRequest,
     ListWorkItemsRequest,
     OutcomesQueryRequest,
     OutcomeSummaryResponse,
+    PlanSessionDTO,
+    PlanSessionListResponse,
     WorkItemResponse,
     work_item_to_response,
 )
@@ -622,12 +632,103 @@ async def agent_bulk_snooze(
     return {"bulk_id": bulk_id, "affected": affected, "skipped": skipped}
 
 
+# ---------------------------------------------------------------------------
+# Plan sessions — drafts list for the Mission Control Plan tab
+# ---------------------------------------------------------------------------
+
+
+# Doc-level → wire status. ``ready`` plans are the current materialized
+# plan for a project (operator can still review + ship), so they surface
+# as ``draft`` in the drafts list. ``stale`` plans were superseded by a
+# re-plan or marked outdated, so they land in ``archived``. There is no
+# ``active`` state in the doc today — reserved for "plan currently
+# executing" once the runtime ships it.
+_WIRE_STATUS_BY_DOC: dict[str, str] = {
+    "ready": "draft",
+    "stale": "archived",
+}
+
+# Inverse map for filtering: the wire filter ``?status=draft`` reads
+# back as the doc-level ``ready`` query. Unknown wire values produce
+# ``None`` and the service returns an empty list — the DTO regex on
+# the wire enum already catches typos before we get here.
+_DOC_STATUS_BY_WIRE: dict[str, str] = {v: k for k, v in _WIRE_STATUS_BY_DOC.items()}
+
+
+def _plan_session_to_dto(summary: Any) -> PlanSessionDTO:
+    """Map a ``PlanSessionSummary`` domain object to its wire DTO.
+
+    Status falls back to ``draft`` when the doc carries an unknown
+    value — defensive against future doc-level statuses we haven't
+    taught Mission Control about yet. Timestamps are serialized to
+    ISO-8601 with timezone so the frontend doesn't have to coerce
+    naive datetimes.
+    """
+    wire_status = _WIRE_STATUS_BY_DOC.get(summary.status, "draft")
+    return PlanSessionDTO(
+        id=summary.id,
+        name=summary.name,
+        status=wire_status,  # type: ignore[arg-type]
+        task_count=summary.task_count,
+        created_at=summary.created_at.isoformat(),
+        updated_at=summary.updated_at.isoformat(),
+    )
+
+
+async def agent_list_plan_sessions(
+    ctx: RequestContext, body: ListPlanSessionsRequest | dict[str, Any]
+) -> PlanSessionListResponse:
+    """List the workspace's persisted plan sessions for the drafts list.
+
+    Read-only — no Beanie writes here. Delegates to
+    ``planner.service.list_plan_sessions`` (the entity that owns the
+    PlanSession doc per ee/cloud Rule 2) and wire-maps the typed
+    summaries into the response envelope.
+
+    Tenancy:
+      - ``ctx.workspace_id`` is the source of truth; an empty / missing
+        workspace returns an empty envelope rather than 500ing. Routers
+        reject ``?workspace_id=`` query params before we get here.
+
+    # no-event: read-only per Rule 9.
+    """
+    body = ListPlanSessionsRequest.model_validate(body)
+    if not ctx.workspace_id:
+        return PlanSessionListResponse(sessions=[], total=0)
+
+    # Lazy import so the façade still installs cleanly on forks that
+    # disabled the planner entity (mirrors the Tasks branch in
+    # ``agent_list_work_items``). When planner is missing we surface an
+    # empty list — the drafts tab renders the empty-state copy without
+    # crashing the whole MC console.
+    try:
+        from ee.cloud.planner import service as planner_service
+    except ImportError:
+        logger.info("mission_control.plan_sessions: planner entity not installed")
+        return PlanSessionListResponse(sessions=[], total=0)
+
+    doc_status: str | None = None
+    if body.status is not None:
+        doc_status = _DOC_STATUS_BY_WIRE.get(body.status)
+        if doc_status is None:
+            # Wire status that doesn't map to any doc state today
+            # (``active`` until the runtime ships it). Return empty so
+            # the frontend doesn't break when the operator filters by
+            # a reserved-but-empty bucket.
+            return PlanSessionListResponse(sessions=[], total=0)
+
+    summaries = await planner_service.list_plan_sessions(ctx, status=doc_status, limit=body.limit)
+    dtos = [_plan_session_to_dto(s) for s in summaries]
+    return PlanSessionListResponse(sessions=dtos, total=len(dtos))
+
+
 __all__ = [
     "agent_bulk_approve",
     "agent_bulk_reassign",
     "agent_bulk_reject",
     "agent_bulk_snooze",
     "agent_list_activity",
+    "agent_list_plan_sessions",
     "agent_list_work_items",
     "agent_outcomes_summary",
 ]

--- a/ee/cloud/planner/domain.py
+++ b/ee/cloud/planner/domain.py
@@ -7,6 +7,12 @@
 #   added ``dependency_warnings`` to PlanSession so the planner can
 #   surface unresolved TaskSpec.blocked_by_keys without failing the
 #   whole materialization.
+# Updated: 2026-05-18 (feat/mc-plan-sessions-endpoint) — added
+#   ``PlanSessionSummary`` value object: a workspace-listing projection
+#   that drops the file-id + agent-gap detail and keeps just what the
+#   Mission Control Plan tab drafts list needs (name from project,
+#   status, task_count, timestamps). Workspace-scoped reads land via
+#   ``planner.service.list_plan_sessions``.
 """Planner entity — domain value objects.
 
 A :class:`PlanSession` is the cloud-side record of one OSS planner run.
@@ -24,6 +30,7 @@ the planner already wrote into the materialized tasks.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 
 
 @dataclass(frozen=True)
@@ -66,4 +73,38 @@ class AgentGap:
     specialties: tuple[str, ...]
 
 
-__all__ = ["AgentGap", "PlanSession"]
+@dataclass(frozen=True)
+class PlanSessionSummary:
+    """Compact listing projection for the Mission Control Plan tab.
+
+    The full :class:`PlanSession` carries file ids + agent-gap detail
+    that the drafts list does not need. The summary drops those and
+    adds:
+
+      - ``name`` — display label sourced from the linked Project's
+        name. The cloud-side ``PlanSession`` doc has no name field of
+        its own (a plan is "the plan for that project"), so we resolve
+        it at read time.
+      - ``task_count`` — len(task_ids) snapshotted at materialization
+        time. Cheap, and stable across the drafts list refresh cycle.
+
+    ``status`` is intentionally the raw doc-level status (``ready`` |
+    ``stale``); the DTO layer maps it to the wire vocabulary
+    (``active`` | ``draft`` | ``archived``) so the domain stays a
+    1:1 projection of the storage shape.
+
+    Tenancy required at construction time per ee/cloud Rule 3 —
+    constructing a summary without ``workspace_id`` is a type error.
+    """
+
+    id: str
+    workspace_id: str
+    project_id: str
+    name: str
+    status: str
+    task_count: int
+    created_at: datetime
+    updated_at: datetime
+
+
+__all__ = ["AgentGap", "PlanSession", "PlanSessionSummary"]

--- a/ee/cloud/planner/service.py
+++ b/ee/cloud/planner/service.py
@@ -17,6 +17,13 @@
 #   2 patches ``blocked_by`` via ``agent_update_task``. Unknown deps
 #   surface as ``dependency_warnings`` on the response, not as a fatal
 #   error — the planner keeps a partial result the operator can ship.
+# Updated: 2026-05-18 (feat/mc-plan-sessions-endpoint) — added
+#   ``list_plan_sessions(ctx, status, limit)``: workspace-scoped Beanie
+#   read that returns ``PlanSessionSummary`` value objects for the
+#   Mission Control Plan tab drafts list. Kept in this entity because
+#   ee/cloud Rule 2 forbids any module other than planner.service from
+#   importing ``ee.cloud.models.planner`` — Mission Control consumes
+#   the typed summaries via the public API.
 """Planner entity — business logic service.
 
 Public API (all module-level ``async def``):
@@ -60,7 +67,7 @@ from ee.cloud._core.realtime.emit import emit
 from ee.cloud._core.realtime.events import PlanGapResolved, PlanGenerated
 from ee.cloud.models.planner import PlanSession as _PlanSessionDoc
 from ee.cloud.models.planner import PlanSessionAgentGap as _PlanSessionAgentGapDoc
-from ee.cloud.planner.domain import AgentGap, PlanSession
+from ee.cloud.planner.domain import AgentGap, PlanSession, PlanSessionSummary
 from ee.cloud.planner.dto import (
     AgentGapDTO,
     PlanProjectRequest,
@@ -364,6 +371,96 @@ async def get_plan_for_project(ctx: RequestContext, project_id: str) -> PlanProj
         agent_gaps=(),  # See docstring — gaps are point-in-time
     )
     return _session_to_dto(session)
+
+
+async def list_plan_sessions(
+    ctx: RequestContext,
+    *,
+    status: str | None = None,
+    limit: int = 50,
+) -> list[PlanSessionSummary]:
+    """List persisted plan sessions for the active workspace.
+
+    Powers the Mission Control Plan tab drafts list — the façade calls
+    this and DTO-maps the summaries to the wire shape. We keep the
+    Beanie read here (per ee/cloud Rule 2: only ``planner.service`` may
+    import ``ee.cloud.models.planner``) so Mission Control stays a
+    pure consumer of typed value objects.
+
+    Tenancy:
+      - Workspace filter is mandatory; an empty / missing
+        ``ctx.workspace_id`` returns ``[]`` rather than raising, mirroring
+        the audit service's defensive empty-response pattern. The
+        router-level dep guard already 400s before we get here when the
+        user has no active workspace.
+
+    Status filter:
+      - The doc-level vocabulary is ``ready`` | ``stale``; the wire
+        vocabulary (``draft`` | ``active`` | ``archived``) is mapped at
+        the DTO boundary. Callers passing an unknown ``status`` get an
+        empty list — we don't 400, because the wire-side enum is
+        DTO-validated upstream of this call.
+
+    Name resolution:
+      - PlanSession docs don't carry a name field of their own. We
+        batch-load the linked Project docs once and inject the project
+        name into each summary. Projects in a different workspace
+        (shouldn't happen given the workspace filter, but defensive)
+        are skipped — the session shows an empty name rather than
+        leaking the other tenant's project label.
+
+    # no-event: read-only path per Rule 9.
+    """
+
+    if not ctx.workspace_id:
+        return []
+
+    query: dict[str, Any] = {"workspace": ctx.workspace_id}
+    if status is not None:
+        query["status"] = status
+
+    docs = (
+        await _PlanSessionDoc.find(query)
+        .sort("-updatedAt")
+        .limit(max(1, min(limit, 200)))
+        .to_list()
+    )
+    if not docs:
+        return []
+
+    # Batch-load project names so the listing doesn't N+1. We only
+    # surface projects that live in the caller's workspace — the
+    # ``projects.service.agent_get`` chokepoint enforces this anyway, so
+    # we go straight to the Beanie collection via the projects entity's
+    # public ``exists_in_workspace`` + ``agent_get`` pair.
+    from ee.cloud.projects import service as projects_service
+
+    project_ids = sorted({d.project_id for d in docs})
+    name_by_id: dict[str, str] = {}
+    for pid in project_ids:
+        try:
+            proj = await projects_service.agent_get(ctx, pid)
+        except NotFound:
+            # Project gone (deleted) — leave name empty. The drafts list
+            # row still renders so the operator can audit / clean up.
+            continue
+        name_by_id[pid] = proj.name
+
+    summaries: list[PlanSessionSummary] = []
+    for d in docs:
+        summaries.append(
+            PlanSessionSummary(
+                id=str(d.id),
+                workspace_id=ctx.workspace_id,
+                project_id=d.project_id,
+                name=name_by_id.get(d.project_id, ""),
+                status=d.status,
+                task_count=len(d.task_ids),
+                created_at=d.createdAt,
+                updated_at=d.updatedAt,
+            )
+        )
+    return summaries
 
 
 # ---------------------------------------------------------------------------
@@ -969,4 +1066,5 @@ __all__ = [
     "agent_plan_project",
     "agent_resolve_gap",
     "get_plan_for_project",
+    "list_plan_sessions",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -608,12 +608,14 @@ source_modules = [
     "ee.cloud.mission_control.router",
     "ee.cloud.mission_control.dto",
     "ee.cloud.mission_control.domain",
+    "ee.cloud.mission_control.service",
 ]
 forbidden_modules = [
     "ee.cloud.models.pocket",
     "ee.cloud.models.notification",
     "ee.cloud.models.user",
     "ee.cloud.models.agent",
+    "ee.cloud.models.planner",
 ]
 
 [[tool.importlinter.contracts]]

--- a/tests/cloud/conftest.py
+++ b/tests/cloud/conftest.py
@@ -194,3 +194,62 @@ async def make_audit_entry(audit_store_tmp):
         )
 
     return _make
+
+
+# ---------------------------------------------------------------------------
+# Plan session fixtures — ee.cloud.planner / mission_control plan-sessions
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def make_plan_session(mongo_db):  # noqa: ARG001 — fixture forces Beanie init
+    """Factory that inserts a ``PlanSession`` Beanie doc + a linked Project.
+
+    The drafts list endpoint resolves session ``name`` from the linked
+    Project, so the factory inserts both — callers that only care about
+    the session can ignore the returned project id.
+
+    Each call returns ``(plan_session_id, project_id)`` so tests can
+    correlate the inserted doc with its display name.
+    """
+
+    from ee.cloud.models.planner import PlanSession as _PlanSessionDoc
+    from ee.cloud.models.project import Project as _ProjectDoc
+
+    async def _make(
+        workspace_id: str,
+        *,
+        name: str = "Q2 Marketing Plan",
+        status: str = "ready",
+        task_ids: list[str] | None = None,
+        project_id: str | None = None,
+    ) -> tuple[str, str]:
+        # Insert the Project first so the listing endpoint can resolve
+        # the display name.
+        proj = _ProjectDoc(
+            workspace=workspace_id,
+            name=name,
+            description="",
+            color="",
+            lead_id=None,
+            status="active",
+            created_by="u1",
+        )
+        await proj.insert()
+        resolved_project_id = project_id or str(proj.id)
+
+        doc = _PlanSessionDoc(
+            workspace=workspace_id,
+            project_id=resolved_project_id,
+            status=status,
+            prd_file_id=None,
+            plan_file_id=None,
+            goal_file_id=None,
+            task_ids=list(task_ids or []),
+            agent_gaps=[],
+            dependency_warnings=[],
+        )
+        await doc.insert()
+        return str(doc.id), resolved_project_id
+
+    return _make

--- a/tests/cloud/test_plan_sessions_router.py
+++ b/tests/cloud/test_plan_sessions_router.py
@@ -1,0 +1,213 @@
+# test_plan_sessions_router.py — HTTP-layer tests for
+#   ee/cloud/mission_control/router.py::list_plan_sessions.
+# Created: 2026-05-18 (feat/mc-plan-sessions-endpoint) — Smokes the new
+#   /api/v1/mission-control/plan-sessions surface: tenancy isolation,
+#   query-param leak guard (?workspace_id=), status + limit filters,
+#   response envelope parity with the spec, and the auth seam. Service-
+#   level mapping (ready → draft, stale → archived) is covered here at
+#   the wire boundary since the router is thin.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from ee.cloud._core.http import add_error_handler
+from ee.cloud.license import require_license
+from ee.cloud.mission_control.router import router as mc_router
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    """Mount the Mission Control router with the request_context dep
+    overridden so we don't need a real JWT chain.
+
+    Mirrors the planner / mission_control router test scaffolding so the
+    test surface is consistent across the three sibling Plan-tab tests.
+    """
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(mc_router, prefix="/api/v1")
+
+    async def _fake_ctx() -> RequestContext:
+        return RequestContext(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            request_id="req-test",
+            scope=ScopeKind.WORKSPACE,
+            started_at=datetime.now(UTC),
+        )
+
+    app.dependency_overrides[request_context] = _fake_ctx
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def w1_client() -> AsyncClient:
+    transport = ASGITransport(app=_build_app(workspace_id="w1"))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client() -> AsyncClient:
+    transport = ASGITransport(app=_build_app(workspace_id="w2"))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Empty + tenancy
+# ---------------------------------------------------------------------------
+
+
+async def test_returns_empty_for_fresh_workspace(w1_client: AsyncClient) -> None:
+    """A workspace with no plan sessions returns the canonical empty
+    envelope — never 500, never null."""
+    r = await w1_client.get("/api/v1/mission-control/plan-sessions")
+    assert r.status_code == 200, r.text
+    assert r.json() == {"sessions": [], "total": 0}
+
+
+async def test_returns_workspace_sessions_only(w1_client: AsyncClient, make_plan_session) -> None:
+    """The listing surfaces only sessions owned by the active workspace."""
+    await make_plan_session("w1", name="Q2 Marketing Plan", task_ids=["t1", "t2"])
+    await make_plan_session("w2", name="Other Tenant Plan", task_ids=["x1"])
+    r = await w1_client.get("/api/v1/mission-control/plan-sessions")
+    assert r.status_code == 200
+    body = r.json()
+    names = {s["name"] for s in body["sessions"]}
+    assert names == {"Q2 Marketing Plan"}
+    assert body["total"] == 1
+
+
+async def test_w2_cannot_see_w1_sessions(w2_client: AsyncClient, make_plan_session) -> None:
+    """Cross-tenant probe — w2 sees nothing of w1's drafts."""
+    await make_plan_session("w1", name="w1-only")
+    r = await w2_client.get("/api/v1/mission-control/plan-sessions")
+    assert r.status_code == 200
+    assert r.json() == {"sessions": [], "total": 0}
+
+
+# ---------------------------------------------------------------------------
+# Query-param leak guard
+# ---------------------------------------------------------------------------
+
+
+async def test_rejects_workspace_id_query_param(w1_client: AsyncClient, make_plan_session) -> None:
+    """Passing ``?workspace_id=`` is a 400 — workspace lives on the auth
+    ctx, never on the query string."""
+    await make_plan_session("w2", name="forbidden")
+    r = await w1_client.get(
+        "/api/v1/mission-control/plan-sessions",
+        params={"workspace_id": "w2"},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "plan_sessions.workspace_id_forbidden"
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+
+async def test_status_filter_forwards(w1_client: AsyncClient, make_plan_session) -> None:
+    """``?status=draft`` filters down to ``ready`` plan sessions; the
+    service maps the wire vocabulary to the doc-level statuses."""
+    await make_plan_session("w1", name="Current Plan", status="ready")
+    await make_plan_session("w1", name="Old Plan", status="stale")
+    r = await w1_client.get("/api/v1/mission-control/plan-sessions", params={"status": "draft"})
+    assert r.status_code == 200
+    sessions = r.json()["sessions"]
+    assert len(sessions) == 1
+    assert sessions[0]["name"] == "Current Plan"
+    assert sessions[0]["status"] == "draft"
+
+
+async def test_status_archived_filters_to_stale(w1_client: AsyncClient, make_plan_session) -> None:
+    """``?status=archived`` only surfaces stale (superseded) plans."""
+    await make_plan_session("w1", name="Current", status="ready")
+    await make_plan_session("w1", name="Superseded", status="stale")
+    r = await w1_client.get("/api/v1/mission-control/plan-sessions", params={"status": "archived"})
+    assert r.status_code == 200
+    sessions = r.json()["sessions"]
+    assert len(sessions) == 1
+    assert sessions[0]["name"] == "Superseded"
+    assert sessions[0]["status"] == "archived"
+
+
+async def test_limit_forwards(w1_client: AsyncClient, make_plan_session) -> None:
+    """``?limit=N`` caps the returned list."""
+    for i in range(5):
+        await make_plan_session("w1", name=f"Plan {i}")
+    r = await w1_client.get("/api/v1/mission-control/plan-sessions", params={"limit": 2})
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["sessions"]) == 2
+    assert body["total"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Envelope shape
+# ---------------------------------------------------------------------------
+
+
+async def test_envelope_field_parity(w1_client: AsyncClient, make_plan_session) -> None:
+    """The response carries exactly the keys the spec promises — never
+    more, never less. Frontend mappers depend on this verbatim."""
+    await make_plan_session("w1", name="Spec Plan", task_ids=["a", "b", "c"])
+    r = await w1_client.get("/api/v1/mission-control/plan-sessions")
+    assert r.status_code == 200
+    body = r.json()
+    assert set(body.keys()) == {"sessions", "total"}
+    assert len(body["sessions"]) == 1
+    session = body["sessions"][0]
+    expected_keys = {"id", "name", "status", "task_count", "created_at", "updated_at"}
+    assert set(session.keys()) == expected_keys
+    assert session["name"] == "Spec Plan"
+    assert session["task_count"] == 3
+    assert session["status"] == "draft"  # ready → draft mapping
+
+
+# ---------------------------------------------------------------------------
+# Auth / context invariants
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_auth_returns_401() -> None:
+    """Without a ``request_context`` override the fastapi-users auth
+    chain runs against a request with no Bearer/cookie — short-circuits
+    to 401 before the handler runs."""
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(mc_router, prefix="/api/v1")
+    app.dependency_overrides[require_license] = lambda: None
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        r = await client.get("/api/v1/mission-control/plan-sessions")
+        assert r.status_code == 401
+
+
+async def test_ctx_without_workspace_returns_empty(make_plan_session) -> None:
+    """A request whose ctx has no active workspace must NOT 500 and must
+    NOT leak rows from any other tenant — it returns the empty envelope.
+    Mirrors the audit service invariant."""
+    await make_plan_session("w1", name="leaky")
+    transport = ASGITransport(app=_build_app(workspace_id=None))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        r = await client.get("/api/v1/mission-control/plan-sessions")
+        assert r.status_code == 200, r.text
+        assert r.json() == {"sessions": [], "total": 0}
+
+
+# Silence ruff unused-import nudge — these are imported for fixture
+# composition (the make_plan_session fixture is request-injected).
+_unused: tuple[Any, ...] = ()


### PR DESCRIPTION
## What

New read endpoint: GET /api/v1/mission-control/plan-sessions

Lists a workspace's saved plan sessions so the Mission Control Plan tab can render its drafts list against real data instead of the hardcoded array in the frontend stub.

## Path taken

**Path A** — PlanSession already exists as a Beanie doc (ee/cloud/models/planner.py, landed in #1118 P3). No new model was needed. The new endpoint reads the existing collection, projects each row into a small DTO, and surfaces the linked Project's name as the row label.

The investigation also turned up the ee/cloud Rule 2 implication: only planner.service may import ee.cloud.models.planner. So the actual Beanie read sits in a new additive function on the planner service (list_plan_sessions), and the Mission Control façade calls into it.

## Wire shape

- GET /api/v1/mission-control/plan-sessions
- Optional ?status=draft|active|archived, ?limit=N (default 50, max 200)
- Rejects ?workspace_id with 400 plan_sessions.workspace_id_forbidden (tenancy from auth ctx)
- Returns { sessions: PlanSessionDTO[], total: int }
- PlanSessionDTO: id, name, status, task_count, created_at, updated_at

Status mapping (doc-level to wire):
- ready → draft (current plan, operator can ship it)
- stale → archived (superseded by a re-plan)
- active is reserved for the runtime's "currently executing" state

## Files touched

- ee/cloud/mission_control/router.py — new GET route + query-param guard
- ee/cloud/mission_control/dto.py — ListPlanSessionsRequest, PlanSessionDTO, PlanSessionListResponse
- ee/cloud/mission_control/service.py — agent_list_plan_sessions delegating to planner.service
- ee/cloud/planner/service.py — list_plan_sessions (additive, the only module allowed to read PlanSession)
- ee/cloud/planner/domain.py — PlanSessionSummary value object
- pyproject.toml — import-linter contract extended (mission_control.service added to source_modules, models.planner added to forbidden_modules)
- tests/cloud/conftest.py — make_plan_session factory
- tests/cloud/test_plan_sessions_router.py — 10 new HTTP tests

## Test plan

- [x] tests/cloud/test_plan_sessions_router.py — 10/10 passing
- [x] Sibling test sweep — 84/84 passing across audit, mission_control, planner, projects, tasks
- [x] uv run lint-imports — 15 contracts kept, 0 broken
- [x] uv run ruff check — passes on touched files
- [x] uv run ruff format — passes
- [x] uv run mypy — only pre-existing errors on lines this PR doesn't touch

## Not in scope

- Plan detail (PRD content, plan.json, agent gaps) — already exposed by the planner endpoints; the drafts list intentionally stays metadata-only
- Frontend swap — paw-enterprise follow-up
- "Active" status semantics — needs the runtime to ship a currently-executing concept first