### PR TITLE
feat(mc-cycles): POST /api/v1/mission-control/cycles create endpoint

### DIFF
--- a/ee/cloud/cycles/dto.py
+++ b/ee/cloud/cycles/dto.py
@@ -7,6 +7,12 @@ and output (fields leak silently).
 Domain → DTO mapping lives in ``service.py`` as private helpers. The
 ``Response`` shapes here are deliberately denormalized into wire-friendly
 ISO strings so the frontend doesn't have to parse timezones.
+
+Updated: 2026-05-19 (feat/mc-create-cycle-endpoint) — added ``scope`` to
+``CreateCycleRequest`` so the Mission Control "+ New cycle" form can
+seed the planned-task-count target. The denormalized counter is then
+overwritten from Tasks at read time and by the snapshot job; the
+operator's initial value is treated as the starting point.
 """
 
 from __future__ import annotations
@@ -30,6 +36,14 @@ class CreateCycleRequest(BaseModel):
     ``status`` defaults to ``upcoming``; the service promotes a cycle to
     ``active`` only when explicitly created with that status (and the
     overlap rule passes) or via the snapshot job once ``start`` arrives.
+
+    ``scope`` is the operator-supplied planned-task-count target — the
+    Mission Control rail surfaces it as the "+ New cycle" form's
+    headline number ("planning ~20 tasks this week"). It seeds the
+    denormalized counter; the snapshot job + read-time refresh will
+    overwrite it from the Tasks collection as tasks attach to the cycle.
+    Defaults to ``0`` ("unscoped") so existing call sites that don't pass
+    a target keep working.
     """
 
     name: str = Field(min_length=1, max_length=200)
@@ -39,6 +53,7 @@ class CreateCycleRequest(BaseModel):
     start: date
     end: date
     status: CycleStatusLiteral = "upcoming"
+    scope: int = Field(default=0, ge=0)
 
     @model_validator(mode="after")
     def _check_dates(self) -> CreateCycleRequest:

--- a/ee/cloud/cycles/service.py
+++ b/ee/cloud/cycles/service.py
@@ -295,6 +295,7 @@ async def agent_create_cycle(ctx: RequestContext, body: CreateCycleRequest) -> C
         start=body.start,
         end=body.end,
         status=body.status,
+        scope=body.scope,
         created_by=ctx.user_id,
     )
     await doc.insert()

--- a/ee/cloud/mission_control/dto.py
+++ b/ee/cloud/mission_control/dto.py
@@ -21,6 +21,14 @@
 # wire use the operator vocabulary (``draft``/``active``/``archived``);
 # the service maps to the doc-level ``ready``/``stale`` storage form so
 # the frontend never has to learn the planner's internal terms.
+# Updated: 2026-05-19 (feat/mc-create-cycle-endpoint) — added
+# ``CreateCycleRequest`` for the new POST /mission-control/cycles
+# endpoint that backs the rail's "+ New cycle" button. Wire format takes
+# ISO-8601 strings for ``start`` / ``end`` (date or datetime) so the
+# frontend's native ``<input type="date">`` value can post directly
+# without coercion. The service derives ``status`` from the dates
+# relative to ``now`` (``upcoming`` vs ``active``); ``completed`` is set
+# by a separate workflow.
 """Mission Control wire DTOs.
 
 The audit doc (``docs/internal/2026-05-mission-control-backend-audit.md``,
@@ -160,6 +168,42 @@ class ListPlanSessionsRequest(BaseModel):
     limit: int = Field(default=50, ge=1, le=200)
 
 
+class CreateCycleRequest(BaseModel):
+    """Body for ``POST /mission-control/cycles``.
+
+    Wire format from the rail's "+ New cycle" form. Mirrors the audit +
+    plan-sessions surface conventions: wire stays string-friendly so
+    the frontend can post the raw ``<input type="date">`` values without
+    coercion, and the service does the parsing + status derivation.
+
+    Fields:
+      - ``name`` — operator-supplied label; 1-200 chars per the spec.
+      - ``start`` / ``end`` — ISO-8601 date ("2026-05-19") or datetime
+        ("2026-05-19T12:00:00Z"). The service parses these and stores
+        the date component; ``start`` must be strictly before ``end``.
+      - ``project_id`` — optional Mission Control Project the cycle is
+        grouped under. When set, the service verifies the project
+        belongs to the caller's workspace.
+      - ``scope`` — operator's planned-task-count target. Seeds the
+        denormalized counter; tasks attaching to the cycle later
+        overwrite it from the Tasks collection. ``0`` means unscoped.
+
+    Notes:
+      - ``status`` is intentionally absent — the service derives it from
+        the parsed dates relative to ``now``. ``completed`` is set via a
+        separate close workflow, not by create.
+      - ``pocket_id`` isn't in the wire body either — the rail's "+ New
+        cycle" button is a workspace-level action; cycles created from
+        within a pocket use the cycles entity's own endpoint.
+    """
+
+    name: str = Field(min_length=1, max_length=200)
+    start: str
+    end: str
+    project_id: str | None = None
+    scope: int = Field(default=0, ge=0)
+
+
 # ---------------------------------------------------------------------------
 # Responses
 # ---------------------------------------------------------------------------
@@ -286,6 +330,7 @@ __all__ = [
     "BulkActionRequest",
     "BulkReassignRequest",
     "BulkSnoozeRequest",
+    "CreateCycleRequest",
     "ListActivityRequest",
     "ListPlanSessionsRequest",
     "ListWorkItemsRequest",

--- a/ee/cloud/mission_control/router.py
+++ b/ee/cloud/mission_control/router.py
@@ -11,6 +11,12 @@
 # ``GET /plan-sessions`` for the Plan tab drafts list. Rejects the
 # ``?workspace_id`` query param before DTO construction (tenancy from
 # auth ctx) per the Audit endpoint's pattern.
+# Updated: 2026-05-19 (feat/mc-create-cycle-endpoint) — added
+# ``POST /cycles`` so the rail's "+ New cycle" button has a façade
+# endpoint to call. Rejects ``?workspace_id`` before DTO construction
+# (mirrors the audit + plan-sessions guard); the actual Beanie write
+# is delegated to ``cycles.service.agent_create_cycle`` via the MC
+# service so the cycles entity stays the sole owner of the write path.
 """Mission Control façade router.
 
 Thin per ee/cloud rule #4 — parses requests, delegates to
@@ -28,6 +34,7 @@ canonical URLs are:
   GET  /api/v1/mission-control/outcomes
   GET  /api/v1/mission-control/activity
   GET  /api/v1/mission-control/plan-sessions
+  POST /api/v1/mission-control/cycles
 """
 
 from __future__ import annotations
@@ -36,6 +43,7 @@ from fastapi import APIRouter, Depends, Query, Request
 
 from ee.cloud._core.context import RequestContext, request_context
 from ee.cloud._core.errors import CloudError
+from ee.cloud.cycles.dto import CycleResponse
 from ee.cloud.license import require_license
 from ee.cloud.mission_control import service as mc_service
 from ee.cloud.mission_control.dto import (
@@ -43,6 +51,7 @@ from ee.cloud.mission_control.dto import (
     BulkActionRequest,
     BulkReassignRequest,
     BulkSnoozeRequest,
+    CreateCycleRequest,
     ListActivityRequest,
     ListPlanSessionsRequest,
     ListWorkItemsRequest,
@@ -162,6 +171,44 @@ async def activity(
     """
     body = ListActivityRequest(limit=limit)
     return await mc_service.agent_list_activity(ctx, body)
+
+
+@router.post("/cycles", response_model=CycleResponse)
+async def create_cycle(
+    request: Request,
+    body: CreateCycleRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> CycleResponse:
+    """Create a workspace-scoped cycle from the Mission Control rail.
+
+    Mirrors the audit + plan-sessions endpoint patterns:
+      - Tenancy lives on the auth ctx; passing ``?workspace_id`` is a
+        400 ``cycles.workspace_id_forbidden`` rather than a silent leak.
+      - The wire body uses ISO-8601 strings for ``start`` / ``end`` so
+        a raw ``<input type="date">`` value posts directly.
+      - ``status`` is derived in the service from the parsed dates
+        (``upcoming`` vs ``active``); the wire intentionally doesn't
+        accept a status — the rail's flow is "create a new one" not
+        "backfill historical state".
+
+    The handler delegates straight to ``mc_service.agent_create_cycle``
+    which itself delegates the Beanie write to
+    ``ee.cloud.cycles.service.agent_create_cycle`` — single-owner rule
+    (Rule 2) holds, and the cycles service already emits
+    ``cycle.created`` so the frontend's live activity feed and the
+    rail's left list update via the bus.
+
+    Returns the cycles entity's ``CycleResponse`` directly so the
+    frontend can ``cycles.unshift(response)`` after the post and avoid
+    a re-fetch.
+    """
+    if "workspace_id" in request.query_params:
+        raise CloudError(
+            400,
+            "cycles.workspace_id_forbidden",
+            "workspace_id is taken from auth context, not query",
+        )
+    return await mc_service.agent_create_cycle(ctx, body)
 
 
 @router.get("/plan-sessions", response_model=PlanSessionListResponse)

--- a/ee/cloud/mission_control/service.py
+++ b/ee/cloud/mission_control/service.py
@@ -20,6 +20,14 @@
 # the wire envelope. Status vocabulary mapping (ready/stale ↔
 # draft/archived) lives here so the planner entity keeps its internal
 # vocabulary while Mission Control surfaces the operator's terms.
+# Updated: 2026-05-19 (feat/mc-create-cycle-endpoint) — added
+# ``agent_create_cycle`` that backs POST /mission-control/cycles for the
+# rail's "+ New cycle" button. Parses the wire's ISO strings, derives
+# ``status`` from start/end relative to ``now`` (upcoming | active), and
+# delegates the actual Beanie write to ``cycles.service.agent_create_cycle``
+# — the single-owner rule (only ``ee.cloud.cycles.service`` may write to
+# the Cycle Beanie doc) is enforced by an import-linter forbidden
+# contract; the MC façade can never bypass it.
 """Mission Control façade service.
 
 Every function is module-level ``async def`` per ee/cloud rule #5. The
@@ -55,7 +63,7 @@ Actions don't carry a polymorphic assignee or a due date.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 from ee.api import get_instinct_store
@@ -73,6 +81,7 @@ from ee.cloud.mission_control.dto import (
     BulkActionRequest,
     BulkReassignRequest,
     BulkSnoozeRequest,
+    CreateCycleRequest,
     ListActivityRequest,
     ListPlanSessionsRequest,
     ListWorkItemsRequest,
@@ -722,11 +731,140 @@ async def agent_list_plan_sessions(
     return PlanSessionListResponse(sessions=dtos, total=len(dtos))
 
 
+# ---------------------------------------------------------------------------
+# Cycles — workspace-scoped create for the Mission Control rail's
+# "+ New cycle" button.
+# ---------------------------------------------------------------------------
+
+
+def _parse_wire_date(value: str, *, field_name: str) -> date:
+    """Parse an ISO-8601 date or datetime string into a ``date``.
+
+    The wire takes either "2026-05-19" (the raw <input type="date"> value
+    the frontend posts) or "2026-05-19T12:00:00Z" (a datetime, in case a
+    different caller serializes a JS ``Date`` straight to ISO). Invalid
+    strings surface as a 422 ``cycle.invalid_date`` so the operator gets
+    a clear error rather than a 500.
+
+    We accept both the bare date and the datetime forms by trying date
+    first then datetime — fromisoformat handles each in one pass without
+    a regex or third-party parser.
+    """
+    try:
+        # date.fromisoformat handles "2026-05-19" cleanly. It rejects
+        # "2026-05-19T12:00:00Z", which falls through to the datetime
+        # path below.
+        return date.fromisoformat(value)
+    except ValueError:
+        pass
+    try:
+        # Coerce trailing "Z" to "+00:00" so datetime.fromisoformat
+        # accepts the common JS toISOString() output.
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
+    except ValueError as exc:
+        raise ValidationError(
+            "cycle.invalid_date",
+            f"{field_name} must be an ISO-8601 date or datetime; got {value!r}",
+        ) from exc
+
+
+def _derive_status_from_dates(start: date, end: date, *, today: date | None = None) -> str:
+    """Derive a cycle's status from its date range relative to today.
+
+    Rule (per spec): a cycle whose ``start`` is in the future is
+    ``upcoming``; one whose ``start`` has passed and ``end`` hasn't is
+    ``active``. ``completed`` is intentionally NOT derived here — it's
+    set by the separate close workflow (``cycles.service.agent_close_cycle``)
+    or by the daily snapshot job's auto-rollover, never by create.
+
+    A cycle whose ``end`` is already in the past at create time falls
+    through to ``upcoming`` — backfilling historical cycles isn't a
+    create-time concern, so we don't silently promote them to a
+    terminal state.
+    """
+    today = today or datetime.now(UTC).date()
+    if start <= today < end:
+        return "active"
+    return "upcoming"
+
+
+async def agent_create_cycle(
+    ctx: RequestContext, body: CreateCycleRequest | dict[str, Any]
+) -> Any:
+    """Create a cycle in the caller's workspace from the Mission Control rail.
+
+    Mirrors the audit + plan-sessions pattern: workspace tenancy from
+    ``ctx``, wire-friendly string dates, status derived from the parsed
+    range. The actual Beanie write happens inside
+    ``cycles.service.agent_create_cycle`` — single owner per ee/cloud
+    Rule 2, enforced by an import-linter contract that forbids
+    ``ee.cloud.models.cycle`` from this façade module.
+
+    Behavior:
+      - Reads ``ctx.workspace_id`` (rejected ``?workspace_id`` upstream
+        in the router).
+      - Parses ``start`` / ``end`` from ISO strings; surfaces invalid
+        strings as 422 ``cycle.invalid_date``.
+      - Requires ``start < end`` — 422 ``cycle.invalid_date_range`` when
+        violated.
+      - Derives ``status`` from the dates: future → ``upcoming``;
+        spanning now → ``active``.
+      - Delegates project tenancy + the actual write to the cycles
+        service, which already enforces project-in-workspace and emits
+        ``cycle.created`` on the bus.
+
+    Returns the cycles entity's ``CycleResponse`` directly — the
+    frontend's existing listCycles row shape matches verbatim so
+    ``cycles.unshift(response)`` works without re-fetch.
+    """
+    body = CreateCycleRequest.model_validate(body)
+
+    start = _parse_wire_date(body.start, field_name="start")
+    end = _parse_wire_date(body.end, field_name="end")
+    if start >= end:
+        raise ValidationError(
+            "cycle.invalid_date_range",
+            "start must be before end",
+        )
+
+    status = _derive_status_from_dates(start, end)
+
+    # Lazy import keeps the façade installable on forks that disabled
+    # the cycles entity (same pattern as the planner / tasks branches
+    # above). When cycles is missing we raise a clear 422 rather than
+    # a 500 — the operator's frontend renders the message.
+    try:
+        from ee.cloud.cycles import service as cycles_service
+        from ee.cloud.cycles.dto import CreateCycleRequest as CyclesCreateRequest
+    except ImportError as exc:
+        raise ValidationError(
+            "cycle.entity_unavailable",
+            "Cycles entity is not installed on this deployment.",
+        ) from exc
+
+    cycles_body = CyclesCreateRequest(
+        name=body.name,
+        description="",
+        pocket_id=None,
+        project_id=body.project_id,
+        start=start,
+        end=end,
+        status=status,  # type: ignore[arg-type]
+        scope=body.scope,
+    )
+    # The cycles service performs the Beanie write, validates project
+    # tenancy via ``_ensure_project_in_workspace`` (raises NotFound when
+    # the project isn't in this workspace), and emits ``cycle.created``
+    # — no second emit needed from here per Rule 9.
+    return await cycles_service.agent_create_cycle(ctx, cycles_body)
+
+
 __all__ = [
     "agent_bulk_approve",
     "agent_bulk_reassign",
     "agent_bulk_reject",
     "agent_bulk_snooze",
+    "agent_create_cycle",
     "agent_list_activity",
     "agent_list_plan_sessions",
     "agent_list_work_items",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -616,6 +616,7 @@ forbidden_modules = [
     "ee.cloud.models.user",
     "ee.cloud.models.agent",
     "ee.cloud.models.planner",
+    "ee.cloud.models.cycle",
 ]
 
 [[tool.importlinter.contracts]]

--- a/tests/cloud/test_mission_control_create_cycle.py
+++ b/tests/cloud/test_mission_control_create_cycle.py
@@ -1,0 +1,361 @@
+# test_mission_control_create_cycle.py — HTTP-layer tests for
+#   ee/cloud/mission_control/router.py::create_cycle (POST /cycles).
+# Created: 2026-05-19 (feat/mc-create-cycle-endpoint) — smokes the new
+#   /api/v1/mission-control/cycles façade endpoint: tenancy isolation,
+#   query-param leak guard, status derivation from dates, project
+#   tenancy, event emission, and DTO validation edges. The actual
+#   Beanie write happens in ``cycles.service.agent_create_cycle`` —
+#   tested separately in test_cycles_service.py; this file only covers
+#   the façade wiring + status-derivation contract.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from ee.cloud._core.http import add_error_handler
+from ee.cloud.license import require_license
+from ee.cloud.mission_control.router import router as mc_router
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# App + client builders — mirror the plan-sessions test scaffolding so all
+# three Mission Control HTTP suites stay readable side-by-side.
+# ---------------------------------------------------------------------------
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(mc_router, prefix="/api/v1")
+
+    async def _fake_ctx() -> RequestContext:
+        return RequestContext(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            request_id="req-test",
+            scope=ScopeKind.WORKSPACE,
+            started_at=datetime.now(UTC),
+        )
+
+    app.dependency_overrides[request_context] = _fake_ctx
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def w1_client() -> AsyncClient:
+    transport = ASGITransport(app=_build_app(workspace_id="w1"))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client() -> AsyncClient:
+    transport = ASGITransport(app=_build_app(workspace_id="w2"))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _today_str() -> str:
+    return datetime.now(UTC).date().isoformat()
+
+
+def _future_str(days: int) -> str:
+    return (datetime.now(UTC).date() + timedelta(days=days)).isoformat()
+
+
+def _past_str(days: int) -> str:
+    return (datetime.now(UTC).date() - timedelta(days=days)).isoformat()
+
+
+def make_cycle_request(**overrides: Any) -> dict[str, Any]:
+    """Factory for a valid POST /mission-control/cycles body.
+
+    Defaults to a future-dated cycle ("+New cycle" form's most common
+    flow). Tests override only the fields they care about.
+    """
+    body: dict[str, Any] = {
+        "name": "Spring Engagement",
+        "start": _future_str(1),
+        "end": _future_str(15),
+        "project_id": None,
+        "scope": 0,
+    }
+    body.update(overrides)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path — response shape + persistence
+# ---------------------------------------------------------------------------
+
+
+async def test_create_cycle_returns_response_shape(w1_client: AsyncClient) -> None:
+    """Happy path — verify all CycleResponse fields are populated and the
+    frontend can ``cycles.unshift(response)`` without re-fetch."""
+    body = make_cycle_request(name="May Wedding Prep", scope=12)
+    r = await w1_client.post("/api/v1/mission-control/cycles", json=body)
+    assert r.status_code == 200, r.text
+    data = r.json()
+
+    # Mirrors CycleResponse → CycleListItemResponse field set.
+    expected_keys = {
+        "id",
+        "workspace_id",
+        "name",
+        "description",
+        "pocket_id",
+        "project_id",
+        "start",
+        "end",
+        "status",
+        "scope",
+        "started",
+        "completed",
+        "created_by",
+        "created_at",
+        "updated_at",
+        "daily",
+    }
+    assert set(data.keys()) == expected_keys
+    assert data["name"] == "May Wedding Prep"
+    assert data["workspace_id"] == "w1"
+    assert data["scope"] == 12  # operator-supplied target seeded
+    assert data["started"] == 0
+    assert data["completed"] == 0
+    assert data["daily"] == []
+    assert data["created_by"] == "u1"
+    assert data["id"]  # opaque ObjectId string
+
+
+# ---------------------------------------------------------------------------
+# 2. Cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_create_persists_for_workspace_only(
+    w1_client: AsyncClient, w2_client: AsyncClient
+) -> None:
+    """w1 creates a cycle; w2 sees nothing in its workspace listing."""
+    r = await w1_client.post(
+        "/api/v1/mission-control/cycles",
+        json=make_cycle_request(name="W1 cycle"),
+    )
+    assert r.status_code == 200
+    cycle_id = r.json()["id"]
+
+    # Pull w1's cycles via the cycles read endpoint (it's the simplest
+    # cross-tenant probe; the MC façade has its own list flow but the
+    # service is shared so this is sufficient for tenancy proof).
+    from ee.cloud.cycles.router import router as cycles_router
+
+    w1_app = _build_app(workspace_id="w1")
+    w1_app.include_router(cycles_router)
+    w2_app = _build_app(workspace_id="w2")
+    w2_app.include_router(cycles_router)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=w1_app), base_url="http://t"
+    ) as w1c:
+        listing = await w1c.get("/cycles")
+        assert listing.status_code == 200
+        assert any(c["id"] == cycle_id for c in listing.json())
+
+    async with AsyncClient(
+        transport=ASGITransport(app=w2_app), base_url="http://t"
+    ) as w2c:
+        listing = await w2c.get("/cycles")
+        assert listing.status_code == 200
+        assert all(c["id"] != cycle_id for c in listing.json())
+
+
+# ---------------------------------------------------------------------------
+# 3. ?workspace_id query-param leak guard
+# ---------------------------------------------------------------------------
+
+
+async def test_rejects_workspace_id_query_param(w1_client: AsyncClient) -> None:
+    """Passing ``?workspace_id=w2`` is a 400 — tenancy must come from the
+    auth context, never the query string. Mirrors the audit + plan-sessions
+    pattern."""
+    r = await w1_client.post(
+        "/api/v1/mission-control/cycles",
+        params={"workspace_id": "w2"},
+        json=make_cycle_request(),
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "cycles.workspace_id_forbidden"
+
+
+# ---------------------------------------------------------------------------
+# 4. Invalid date range
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_date_range_rejected(w1_client: AsyncClient) -> None:
+    """``start >= end`` is a 422 with the documented machine-readable code."""
+    body = make_cycle_request(start=_future_str(10), end=_future_str(5))
+    r = await w1_client.post("/api/v1/mission-control/cycles", json=body)
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "cycle.invalid_date_range"
+
+
+# ---------------------------------------------------------------------------
+# 5 + 6. Status derivation
+# ---------------------------------------------------------------------------
+
+
+async def test_status_derives_from_dates_upcoming(w1_client: AsyncClient) -> None:
+    """A cycle whose start is in the future surfaces as ``upcoming``."""
+    body = make_cycle_request(start=_future_str(3), end=_future_str(20))
+    r = await w1_client.post("/api/v1/mission-control/cycles", json=body)
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "upcoming"
+
+
+async def test_status_derives_from_dates_active(w1_client: AsyncClient) -> None:
+    """A cycle whose start has passed and end is still in the future
+    surfaces as ``active`` — the daily snapshot job picks it up
+    immediately."""
+    body = make_cycle_request(start=_past_str(2), end=_future_str(10))
+    r = await w1_client.post("/api/v1/mission-control/cycles", json=body)
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "active"
+
+
+# ---------------------------------------------------------------------------
+# 7. Project tenancy
+# ---------------------------------------------------------------------------
+
+
+async def test_project_tenancy_enforced(
+    w1_client: AsyncClient, w2_client: AsyncClient
+) -> None:
+    """A project belonging to w2 cannot be referenced from w1's create
+    call. The cycles service surfaces this as 404 ``project.not_found``
+    rather than 403 — by design, so cross-tenant probes can't infer the
+    existence of an id they don't own."""
+    # Seed a project in w2 directly via the Beanie doc (the projects
+    # service write path is tested elsewhere; here we only need a
+    # populated project_id that w1 can't claim).
+    from ee.cloud.models.project import Project as _ProjectDoc
+
+    proj = _ProjectDoc(
+        workspace="w2",
+        name="W2 Project",
+        description="",
+        color="",
+        lead_id=None,
+        status="active",
+        created_by="u-w2",
+    )
+    await proj.insert()
+    foreign_project_id = str(proj.id)
+
+    body = make_cycle_request(project_id=foreign_project_id)
+    r = await w1_client.post("/api/v1/mission-control/cycles", json=body)
+    # The cycles service uses NotFound for cross-tenant project refs
+    # — we mirror that contract so the rail's error renderer matches
+    # whatever the existing cycles POST surfaces.
+    assert r.status_code == 404, r.text
+    assert r.json()["error"]["code"] == "project.not_found"
+
+
+# ---------------------------------------------------------------------------
+# 8. Bus event emission
+# ---------------------------------------------------------------------------
+
+
+async def test_emits_cycle_created_event(
+    w1_client: AsyncClient, recording_bus: Any
+) -> None:
+    """The cycles service emits ``cycle.created`` on the bus; the façade
+    delegates through so the same event fires for the rail flow. The
+    frontend's live activity ticker depends on this for the
+    just-created row to appear instantly."""
+    r = await w1_client.post(
+        "/api/v1/mission-control/cycles",
+        json=make_cycle_request(name="Bus Event Cycle"),
+    )
+    assert r.status_code == 200
+    response_id = r.json()["id"]
+
+    created_events = [
+        e for e in recording_bus.events if e.EVENT_TYPE == "cycle.created"
+    ]
+    assert len(created_events) == 1
+    payload = created_events[0].data
+    assert payload["id"] == response_id
+    assert payload["workspace_id"] == "w1"
+    assert payload["name"] == "Bus Event Cycle"
+
+
+# ---------------------------------------------------------------------------
+# 9. Auth seam
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_auth_returns_401() -> None:
+    """Without a ``request_context`` override the fastapi-users auth
+    chain runs against a request with no Bearer/cookie — short-circuits
+    to 401 before the handler runs. Same invariant as the plan-sessions
+    auth test."""
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(mc_router, prefix="/api/v1")
+    app.dependency_overrides[require_license] = lambda: None
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        r = await client.post(
+            "/api/v1/mission-control/cycles", json=make_cycle_request()
+        )
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# 10. Validation edges
+# ---------------------------------------------------------------------------
+
+
+async def test_name_too_long_rejected(w1_client: AsyncClient) -> None:
+    """The 200-char name cap from the spec is enforced — Pydantic returns
+    422 with the FastAPI validation envelope."""
+    body = make_cycle_request(name="x" * 201)
+    r = await w1_client.post("/api/v1/mission-control/cycles", json=body)
+    assert r.status_code == 422, r.text
+
+
+async def test_invalid_date_string_rejected(w1_client: AsyncClient) -> None:
+    """A malformed ISO string surfaces as a clean 422 ``cycle.invalid_date``
+    rather than a 500. The frontend renders the message directly."""
+    body = make_cycle_request(start="not-a-date", end=_future_str(10))
+    r = await w1_client.post("/api/v1/mission-control/cycles", json=body)
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "cycle.invalid_date"
+
+
+async def test_accepts_datetime_strings(w1_client: AsyncClient) -> None:
+    """ISO datetime strings (the common JS toISOString() output) are
+    accepted alongside bare dates — both produce the same stored cycle
+    so the frontend can post either form without coercion."""
+    start_dt = (datetime.now(UTC) + timedelta(days=1)).isoformat()
+    end_dt = (datetime.now(UTC) + timedelta(days=10)).isoformat()
+    body = make_cycle_request(start=start_dt, end=end_dt)
+    r = await w1_client.post("/api/v1/mission-control/cycles", json=body)
+    assert r.status_code == 200, r.text
+    # The wire response stores dates as ISO date strings, not datetimes.
+    assert "T" not in r.json()["start"]
+    assert "T" not in r.json()["end"]
+
+
+# Silence ruff unused-import nudges — fixtures are request-injected.
+_unused: tuple[Any, ...] = ()


### PR DESCRIPTION
## Summary

- New `POST /api/v1/mission-control/cycles` endpoint for the rail's "+ New cycle" button. The frontend wires up in a separate paw-enterprise PR.
- Same facade shape as audit (#1124) and plan-sessions (#1127): workspace tenancy from `ctx`, 400 on `?workspace_id`, ISO-8601 `start`/`end` (accepts date or datetime), CloudError per Rule 10.
- Status is derived from the dates — `upcoming` if start is in the future, `active` if start is past and end isn't. `completed` is the close workflow's job, not create's.
- Beanie write delegates to `cycles.service.agent_create_cycle` so Rule 2's single-owner rule holds. Added `ee.cloud.models.cycle` to the MC import-linter forbidden list so the facade can't bypass that later.
- Also added an optional `scope: int = 0` to the cycles entity's `CreateCycleRequest` so the rail can seed the operator's planned-task-count target. Old callers that don't pass it are unaffected.

## Test plan

- [x] `uv run pytest tests/cloud/test_mission_control_create_cycle.py -x` — 12/12 pass
- [x] Sibling sweep across `test_mission_control_router.py`, `test_plan_sessions_router.py`, `test_cycles_router.py`, `test_cycles_service.py`, `test_mission_control_service.py`, `test_projects_service.py` — 79 pass, 1 pre-existing skip
- [x] `uv run ruff check ee/cloud/mission_control/ ee/cloud/cycles/` clean
- [x] `uv run mypy ee/cloud/mission_control/ ee/cloud/cycles/` — 0 new errors (2 pre-existing on `ee` unchanged)
- [x] `uv run lint-imports --config pyproject.toml` — 15/15 contracts kept, including the strengthened MC contract

## Notes

- Project tenancy matches the existing cycles convention (`NotFound`, not `Forbidden`) so a probe can't infer the existence of an id the caller doesn't own. Covered in `test_project_tenancy_enforced`.
- No action keys added. The existing GET `/cycles` doesn't gate on a `mission_control.cycles.read` key, so the POST doesn't either (per the task spec's "follow the same pattern" rule).
- The wire accepts both `2026-05-19` and `2026-05-19T12:00:00Z` so the frontend can post a raw `<input type="date">` value or a `Date.toISOString()` without coercion.
- `cycles.service.agent_create_cycle` already emits `cycle.created`, so the facade doesn't double-emit (Rule 9).

DO NOT merge — captain reviews before merge per the PR review gate.