### PR TITLE
feat(calendar): native Calendar module (ee/calendar/)

### DIFF
--- a/ee/calendar/__init__.py
+++ b/ee/calendar/__init__.py
@@ -1,0 +1,29 @@
+# Calendar module — public surface.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Re-exports the router and public domain types. Beanie documents
+# (_EventDoc, _CalendarDoc) stay private — never re-exported.
+
+from ee.calendar.domain import (
+    Attendee,
+    AttendeeResponse,
+    Calendar,
+    CalendarVisibility,
+    ConflictSeverity,
+    Event,
+    FreeBusy,
+    Recurrence,
+)
+from ee.calendar.router import router
+
+__all__ = [
+    "Attendee",
+    "AttendeeResponse",
+    "Calendar",
+    "CalendarVisibility",
+    "ConflictSeverity",
+    "Event",
+    "FreeBusy",
+    "Recurrence",
+    "router",
+]

--- a/ee/calendar/_context.py
+++ b/ee/calendar/_context.py
@@ -1,0 +1,26 @@
+# Calendar module — RequestContext value object.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Tiny carrier struct so service functions can take a single ctx parameter
+# (per ee/cloud convention rule 5). The cloud module doesn't expose a shared
+# RequestContext type yet — when it does, swap this for the canonical one.
+# Kept private (underscore prefix) so the router stays the single mounting
+# point for callers outside this module.
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class RequestContext(BaseModel):
+    """Per-request tenancy + actor envelope.
+
+    Carries the workspace_id (multi-tenant filter) and user_id (actor for
+    audit + access checks) into service functions. Frozen so handlers can
+    pass it around without worrying about mutation.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    workspace_id: str
+    user_id: str

--- a/ee/calendar/conflicts.py
+++ b/ee/calendar/conflicts.py
@@ -1,0 +1,67 @@
+# Calendar module — conflict detection.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Finds other events in the same workspace that overlap a given event's
+# window and share at least one attendee. Excludes the event itself.
+# Returns mapped Event domain objects (DB → domain via _doc_to_event).
+
+from __future__ import annotations
+
+from ee.calendar.domain import Attendee, Event, Recurrence
+from ee.calendar.models import _EventDoc
+
+
+def _doc_to_event(doc: _EventDoc) -> Event:
+    """Map a Beanie document into the frozen Event domain value object."""
+    attendees = [Attendee.model_validate(a) for a in (doc.attendees or [])]
+    recurrence = Recurrence.model_validate(doc.recurrence) if doc.recurrence else None
+    return Event(
+        id=str(doc.id),
+        workspace_id=doc.workspace,
+        calendar_id=doc.calendar_id,
+        title=doc.title,
+        description=doc.description or "",
+        starts_at=doc.starts_at,
+        ends_at=doc.ends_at,
+        timezone=doc.timezone,
+        location=doc.location,
+        attendees=attendees,
+        recurrence=recurrence,
+        fabric_object_id=doc.fabric_object_id,
+        source_connector=doc.source_connector,
+        source_external_id=doc.source_external_id,
+        created_at=doc.created_at,
+        updated_at=doc.updated_at,
+    )
+
+
+async def find_conflicts(workspace_id: str, event: Event) -> list[Event]:
+    """Find other events overlapping `event`'s window with shared attendees.
+
+    Two events overlap when start_a < end_b AND start_b < end_a. We push that
+    filter into Mongo so we don't pull the whole workspace into memory. The
+    shared-attendee filter runs in Python because attendees are stored as an
+    embedded list of dicts.
+    """
+    if not event.attendees:
+        return []
+
+    overlapping_docs = await _EventDoc.find(
+        {
+            "workspace": workspace_id,
+            "starts_at": {"$lt": event.ends_at},
+            "ends_at": {"$gt": event.starts_at},
+        }
+    ).to_list()
+
+    target_emails = {a.email.lower() for a in event.attendees}
+    conflicts: list[Event] = []
+    for doc in overlapping_docs:
+        # Skip the event itself.
+        if str(doc.id) == event.id:
+            continue
+        other_emails = {(a.get("email") or "").lower() for a in (doc.attendees or [])}
+        if target_emails & other_emails:
+            conflicts.append(_doc_to_event(doc))
+
+    return conflicts

--- a/ee/calendar/domain.py
+++ b/ee/calendar/domain.py
@@ -1,0 +1,131 @@
+# Calendar module — domain value objects.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Frozen Pydantic models representing the public calendar domain.
+# workspace_id is required on Event and Calendar — enforced at construction
+# time, no defaults — so multi-tenancy is impossible to forget.
+# Mirrors the ee/cloud canonical "domain stays at the boundary" pattern.
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class CalendarVisibility(StrEnum):
+    PUBLIC_TO_WORKSPACE = "public_to_workspace"
+    PRIVATE = "private"
+    SHARED_WITH_USERS = "shared_with_users"
+
+
+class AttendeeResponse(StrEnum):
+    ACCEPTED = "accepted"
+    DECLINED = "declined"
+    TENTATIVE = "tentative"
+    NEEDS_ACTION = "needs_action"
+
+
+class ConflictSeverity(StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+# ---------------------------------------------------------------------------
+# Value objects
+# ---------------------------------------------------------------------------
+
+
+class Attendee(BaseModel):
+    """A participant on an event. user_id is optional — external (email-only)
+    invitees are valid."""
+
+    model_config = ConfigDict(frozen=True)
+
+    email: str
+    user_id: str | None = None
+    name: str | None = None
+    response: AttendeeResponse = AttendeeResponse.NEEDS_ACTION
+    is_organizer: bool = False
+
+
+class Recurrence(BaseModel):
+    """RFC 5545 RRULE plus terminators and explicit exceptions.
+
+    The master Event carries the rrule string; expansion happens at read time
+    in recurrence.expand_recurrence(). Either `until` or `count` may be set;
+    `rrule` may also encode its own terminator.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    rrule: str
+    exceptions: list[datetime] = Field(default_factory=list)
+    until: datetime | None = None
+    count: int | None = None
+
+
+class Event(BaseModel):
+    """A calendar event. workspace_id required — no default — multi-tenancy
+    is enforced at construction.
+
+    `fabric_object_id` is the optional pointer into ee/fabric so a Customer
+    object can have a related Meeting event without a join table.
+    `source_connector` + `source_external_id` track external-system origin
+    (e.g. "gcalendar", "<google event id>") so sync.py can reconcile.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    workspace_id: str
+    calendar_id: str
+    title: str
+    starts_at: datetime
+    ends_at: datetime
+    timezone: str  # IANA timezone string, e.g. "America/Los_Angeles"
+    description: str = ""
+    location: str | None = None
+    attendees: list[Attendee] = Field(default_factory=list)
+    recurrence: Recurrence | None = None
+    fabric_object_id: str | None = None
+    source_connector: str | None = None
+    source_external_id: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class Calendar(BaseModel):
+    """A logical calendar belonging to a workspace.
+
+    Visibility governs who can see events at all — read access is also
+    gated by policy.check_calendar_read.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    workspace_id: str
+    name: str
+    owner_user_id: str
+    timezone: str
+    color: str = "#0A84FF"
+    visibility: CalendarVisibility = CalendarVisibility.PUBLIC_TO_WORKSPACE
+    shared_with_user_ids: list[str] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+
+class FreeBusy(BaseModel):
+    """Availability fingerprint for a single attendee in a time window."""
+
+    model_config = ConfigDict(frozen=True)
+
+    attendee_email: str
+    busy_periods: list[tuple[datetime, datetime]] = Field(default_factory=list)

--- a/ee/calendar/dto.py
+++ b/ee/calendar/dto.py
@@ -1,0 +1,166 @@
+# Calendar module — request/response DTOs.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Distinct request and response classes per operation. Requests are
+# minimal (no workspace_id — that comes from the auth context). Responses
+# mirror the domain value objects so clients see the full shape.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field, model_validator
+
+from ee.calendar.domain import (
+    Attendee,
+    ConflictSeverity,
+    FreeBusy,
+    Recurrence,
+)
+
+# ---------------------------------------------------------------------------
+# Event request DTOs
+# ---------------------------------------------------------------------------
+
+
+class CreateEventRequest(BaseModel):
+    """Request payload for POST /calendar/events.
+
+    `attendees` is a list of Attendee value objects (email is the required
+    field; everything else is optional).
+    """
+
+    calendar_id: str = Field(min_length=1)
+    title: str = Field(min_length=1, max_length=500)
+    starts_at: datetime
+    ends_at: datetime
+    timezone: str = Field(min_length=1)
+    description: str = ""
+    location: str | None = None
+    attendees: list[Attendee] = Field(default_factory=list)
+    recurrence: Recurrence | None = None
+    fabric_object_id: str | None = None
+
+    @model_validator(mode="after")
+    def _ends_after_starts(self) -> CreateEventRequest:
+        if self.ends_at <= self.starts_at:
+            raise ValueError("ends_at must be strictly after starts_at")
+        return self
+
+
+class UpdateEventRequest(BaseModel):
+    """Partial-update payload. At least one field must be set."""
+
+    title: str | None = Field(default=None, min_length=1, max_length=500)
+    description: str | None = None
+    starts_at: datetime | None = None
+    ends_at: datetime | None = None
+    location: str | None = None
+    attendees: list[Attendee] | None = None
+    recurrence: Recurrence | None = None
+
+    @model_validator(mode="after")
+    def _at_least_one_field(self) -> UpdateEventRequest:
+        if all(
+            v is None
+            for v in (
+                self.title,
+                self.description,
+                self.starts_at,
+                self.ends_at,
+                self.location,
+                self.attendees,
+                self.recurrence,
+            )
+        ):
+            raise ValueError("at least one field must be provided")
+        # If both starts_at and ends_at are present, validate order.
+        if (
+            self.starts_at is not None
+            and self.ends_at is not None
+            and self.ends_at <= self.starts_at
+        ):
+            raise ValueError("ends_at must be strictly after starts_at")
+        return self
+
+
+class ListEventsRequest(BaseModel):
+    """List/query parameters."""
+
+    calendar_id: str | None = None
+    starts_after: datetime
+    starts_before: datetime
+    limit: int = Field(default=100, ge=1, le=500)
+
+    @model_validator(mode="after")
+    def _window_valid(self) -> ListEventsRequest:
+        if self.starts_before <= self.starts_after:
+            raise ValueError("starts_before must be after starts_after")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Event response DTOs
+# ---------------------------------------------------------------------------
+
+
+class EventResponse(BaseModel):
+    """Full Event mirror returned by the API."""
+
+    id: str
+    workspace_id: str
+    calendar_id: str
+    title: str
+    description: str
+    starts_at: datetime
+    ends_at: datetime
+    timezone: str
+    location: str | None
+    attendees: list[Attendee]
+    recurrence: Recurrence | None
+    fabric_object_id: str | None
+    source_connector: str | None
+    source_external_id: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class EventListResponse(BaseModel):
+    events: list[EventResponse]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# FreeBusy DTOs
+# ---------------------------------------------------------------------------
+
+
+class FreeBusyRequest(BaseModel):
+    """Compute availability for up to 50 attendees in a window."""
+
+    attendee_emails: list[str] = Field(min_length=1, max_length=50)
+    starts_at: datetime
+    ends_at: datetime
+
+    @model_validator(mode="after")
+    def _window_valid(self) -> FreeBusyRequest:
+        if self.ends_at <= self.starts_at:
+            raise ValueError("ends_at must be strictly after starts_at")
+        return self
+
+
+class FreeBusyResponse(BaseModel):
+    freebusy: list[FreeBusy]
+
+
+# ---------------------------------------------------------------------------
+# Conflict DTOs
+# ---------------------------------------------------------------------------
+
+
+class ConflictReport(BaseModel):
+    """Conflict detection result for a single event."""
+
+    event_id: str
+    conflicting_events: list[EventResponse] = Field(default_factory=list)
+    severity: ConflictSeverity = ConflictSeverity.LOW

--- a/ee/calendar/events.py
+++ b/ee/calendar/events.py
@@ -1,0 +1,68 @@
+# Calendar module — bus event payloads.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Pydantic shapes for events emitted on event_bus. Names mirror the topic
+# strings registered with the bus — keep them in lockstep when adding new
+# events. The actual emit is done by service.py via event_bus.emit("topic",
+# CalendarEventCreated(...).model_dump()).
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Topic constants — single source of truth for subscribers.
+# ---------------------------------------------------------------------------
+
+TOPIC_EVENT_CREATED = "calendar.event.created"
+TOPIC_EVENT_UPDATED = "calendar.event.updated"
+TOPIC_EVENT_DELETED = "calendar.event.deleted"
+TOPIC_EVENT_STARTED = "calendar.event.started"
+TOPIC_REMINDER_DUE = "calendar.reminder.due"
+TOPIC_CONFLICT_DETECTED = "calendar.conflict.detected"
+
+
+class CalendarEventCreated(BaseModel):
+    event_id: str
+    workspace_id: str
+    calendar_id: str
+    starts_at: datetime
+    ends_at: datetime
+
+
+class CalendarEventUpdated(BaseModel):
+    event_id: str
+    workspace_id: str
+    calendar_id: str
+    changes: dict[str, Any] = Field(default_factory=dict)
+
+
+class CalendarEventDeleted(BaseModel):
+    event_id: str
+    workspace_id: str
+    calendar_id: str
+
+
+class CalendarEventStarted(BaseModel):
+    """Fired by a future scheduler when an event reaches its start time."""
+
+    event_id: str
+    workspace_id: str
+
+
+class ReminderDue(BaseModel):
+    """Fired by a future scheduler N minutes before an event."""
+
+    event_id: str
+    workspace_id: str
+    due_at: datetime
+    channel: str  # e.g. "telegram", "slack", "email"
+
+
+class ConflictDetected(BaseModel):
+    event_id: str
+    workspace_id: str
+    conflicting_event_ids: list[str] = Field(default_factory=list)

--- a/ee/calendar/freebusy.py
+++ b/ee/calendar/freebusy.py
@@ -1,0 +1,71 @@
+# Calendar module — free/busy availability computation.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Given a workspace, a list of attendee emails, and a window, returns the
+# union of busy periods for each attendee. Single Mongo query with $in on
+# the embedded attendees.email — cheaper than N queries.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from ee.calendar.domain import FreeBusy
+from ee.calendar.models import _EventDoc
+
+
+async def compute_freebusy(
+    workspace_id: str,
+    attendee_emails: list[str],
+    starts_at: datetime,
+    ends_at: datetime,
+) -> list[FreeBusy]:
+    """Return per-attendee busy periods within [starts_at, ends_at).
+
+    Recurring events: this implementation queries the master rows only,
+    which means recurring instances inside the window will appear as a
+    single busy block (the master). A future PR will plug in
+    recurrence.expand_recurrence here. Documented in the module docstring
+    so the gap is explicit rather than silent.
+    """
+    if not attendee_emails:
+        return []
+
+    if ends_at <= starts_at:
+        return [FreeBusy(attendee_email=e, busy_periods=[]) for e in attendee_emails]
+
+    # Lowercase emails for case-insensitive matching against stored data.
+    emails_lower = [e.lower() for e in attendee_emails]
+
+    overlapping = await _EventDoc.find(
+        {
+            "workspace": workspace_id,
+            "starts_at": {"$lt": ends_at},
+            "ends_at": {"$gt": starts_at},
+            "attendees.email": {"$in": emails_lower},
+        }
+    ).to_list()
+
+    # Build per-attendee busy lists. Preserve the caller's email casing in
+    # the output so the response matches what they sent.
+    busy_by_email: dict[str, list[tuple[datetime, datetime]]] = {
+        e.lower(): [] for e in attendee_emails
+    }
+
+    for doc in overlapping:
+        # Clip to window so callers don't see periods outside what they asked for.
+        clipped_start = max(doc.starts_at, starts_at)
+        clipped_end = min(doc.ends_at, ends_at)
+        if clipped_end <= clipped_start:
+            continue
+        for att in doc.attendees or []:
+            email = (att.get("email") or "").lower()
+            if email in busy_by_email:
+                busy_by_email[email].append((clipped_start, clipped_end))
+
+    # Sort each list by start time for deterministic output.
+    result: list[FreeBusy] = []
+    for original_email in attendee_emails:
+        periods = sorted(busy_by_email[original_email.lower()], key=lambda p: p[0])
+        result.append(FreeBusy(attendee_email=original_email, busy_periods=periods))
+
+    return result

--- a/ee/calendar/models.py
+++ b/ee/calendar/models.py
@@ -1,0 +1,97 @@
+# Calendar module — Beanie document models.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Internal-only — never imported outside ee/calendar/. The single rule:
+# nothing outside this module talks to the database. Callers go through
+# service.py, which is the only place these docs are constructed or queried.
+# Underscore prefix on the class name is a load-bearing signal — if you
+# see _EventDoc in an import outside this module, that's a bug.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from beanie import Document
+from pydantic import Field
+from pymongo import ASCENDING, IndexModel
+
+
+def _now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+# ---------------------------------------------------------------------------
+# Calendar
+# ---------------------------------------------------------------------------
+
+
+class _CalendarDoc(Document):
+    """Beanie document for a Calendar. Workspace-scoped (workspace field,
+    matching the ee/cloud convention of `workspace` not `workspace_id` at
+    the DB layer)."""
+
+    workspace: str
+    name: str
+    owner_user_id: str
+    timezone: str
+    color: str = "#0A84FF"
+    visibility: str = "public_to_workspace"
+    shared_with_user_ids: list[str] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=_now_utc)
+    updated_at: datetime = Field(default_factory=_now_utc)
+
+    class Settings:
+        name = "calendars"
+        indexes = [
+            IndexModel([("workspace", ASCENDING)]),
+            IndexModel([("workspace", ASCENDING), ("owner_user_id", ASCENDING)]),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Event
+# ---------------------------------------------------------------------------
+
+
+class _EventDoc(Document):
+    """Beanie document for a calendar event.
+
+    `attendees`, `recurrence` stored as raw dicts/lists to avoid coupling the
+    DB layer to Pydantic frozen models. Service.py maps to/from the domain
+    types via model_validate / model_dump.
+
+    `source_connector` + `source_external_id` are the reconciliation keys
+    used by sync.py — if both are set, the event came from an external
+    system and must be matched on its external id.
+    """
+
+    workspace: str
+    calendar_id: str
+    title: str
+    description: str = ""
+    starts_at: datetime
+    ends_at: datetime
+    timezone: str
+    location: str | None = None
+    attendees: list[dict[str, Any]] = Field(default_factory=list)
+    recurrence: dict[str, Any] | None = None
+    fabric_object_id: str | None = None
+    source_connector: str | None = None
+    source_external_id: str | None = None
+    created_at: datetime = Field(default_factory=_now_utc)
+    updated_at: datetime = Field(default_factory=_now_utc)
+
+    class Settings:
+        name = "calendar_events"
+        indexes = [
+            IndexModel(
+                [
+                    ("workspace", ASCENDING),
+                    ("calendar_id", ASCENDING),
+                    ("starts_at", ASCENDING),
+                ]
+            ),
+            IndexModel([("workspace", ASCENDING), ("starts_at", ASCENDING)]),
+            IndexModel([("source_connector", ASCENDING), ("source_external_id", ASCENDING)]),
+        ]

--- a/ee/calendar/policy.py
+++ b/ee/calendar/policy.py
@@ -1,0 +1,72 @@
+# Calendar module — access policy checks.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Read/write gates expressed as raise-on-deny helpers (matches the
+# ee/cloud convention: services call check_*, the function raises
+# Forbidden, or it returns None). Visibility check is a predicate so
+# service.py can use it in list filters without try/except.
+
+from __future__ import annotations
+
+from ee.calendar._context import RequestContext
+from ee.calendar.domain import Calendar, CalendarVisibility, Event
+from ee.cloud.shared.errors import Forbidden
+
+
+def check_calendar_read(ctx: RequestContext, calendar: Calendar) -> None:
+    """Raise Forbidden if the caller can't read this calendar."""
+    # Hard tenant boundary — never let a different-workspace caller read at all.
+    if calendar.workspace_id != ctx.workspace_id:
+        raise Forbidden(
+            "calendar.access_denied",
+            "Calendar belongs to a different workspace",
+        )
+    if calendar.owner_user_id == ctx.user_id:
+        return
+    if calendar.visibility == CalendarVisibility.PUBLIC_TO_WORKSPACE:
+        return
+    if (
+        calendar.visibility == CalendarVisibility.SHARED_WITH_USERS
+        and ctx.user_id in calendar.shared_with_user_ids
+    ):
+        return
+    raise Forbidden(
+        "calendar.access_denied",
+        "You do not have read access to this calendar",
+    )
+
+
+def check_calendar_write(ctx: RequestContext, calendar: Calendar) -> None:
+    """Raise Forbidden if the caller can't write to this calendar.
+
+    Stricter than read — only the owner or an explicitly-shared user can
+    write. Workspace-public calendars are read-only by default; promote a
+    user to shared_with_user_ids to grant write.
+    """
+    if calendar.workspace_id != ctx.workspace_id:
+        raise Forbidden(
+            "calendar.access_denied",
+            "Calendar belongs to a different workspace",
+        )
+    if calendar.owner_user_id == ctx.user_id:
+        return
+    if (
+        calendar.visibility == CalendarVisibility.SHARED_WITH_USERS
+        and ctx.user_id in calendar.shared_with_user_ids
+    ):
+        return
+    raise Forbidden(
+        "calendar.access_denied",
+        "You do not have write access to this calendar",
+    )
+
+
+def check_event_visibility(ctx: RequestContext, event: Event) -> bool:
+    """Return True if the caller can see this event.
+
+    Used as a list-filter predicate, NOT a gate — callers that need a hard
+    deny should use check_calendar_read on the parent calendar. This check
+    is intentionally lighter so list_events can skip without per-event DB
+    fetches.
+    """
+    return event.workspace_id == ctx.workspace_id

--- a/ee/calendar/recurrence.py
+++ b/ee/calendar/recurrence.py
@@ -1,0 +1,132 @@
+# Calendar module — RRULE recurrence expansion.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Pure-function module. No DB, no bus, no I/O. Takes a master Event with a
+# Recurrence and expands to concrete instances within a window. Exceptions
+# are honoured. UNTIL / COUNT terminators are honoured. RRULE strings may
+# omit DTSTART — we synthesize one from master.starts_at if missing.
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+from dateutil.rrule import rrulestr  # type: ignore[import-untyped]
+
+from ee.calendar.domain import Event
+
+logger = logging.getLogger(__name__)
+
+
+# Hard cap on expansion to avoid runaway memory / pathological RRULEs.
+# 5000 instances covers ~13 years of daily recurrence — well beyond any
+# legitimate use case.
+_MAX_INSTANCES = 5000
+
+
+def parse_rrule(rrule_str: str, dtstart: datetime | None = None) -> Any:
+    """Parse an RFC 5545 RRULE string into a dateutil.rrule.rrule.
+
+    If `dtstart` is supplied and the RRULE doesn't carry its own DTSTART
+    line, it's injected. Raises ``ValueError`` on malformed input.
+    """
+    try:
+        return rrulestr(rrule_str, dtstart=dtstart)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Invalid RRULE: {rrule_str!r} — {exc}") from exc
+
+
+def expand_recurrence(
+    master: Event,
+    range_start: datetime,
+    range_end: datetime,
+) -> list[Event]:
+    """Expand a recurring master event into concrete instances overlapping
+    [range_start, range_end).
+
+    Rules:
+    * If master has no `recurrence`, return [master] when its window overlaps
+      the range, else [].
+    * `range_start` inclusive, `range_end` exclusive.
+    * `recurrence.exceptions` removes matching occurrences (compared to the
+      generated start datetime, not the human-visible local date).
+    * `recurrence.until` and `recurrence.count` are honoured if the underlying
+      RRULE didn't already encode them.
+    * Each expanded instance keeps the master's id (callers can disambiguate
+      via starts_at).
+    """
+    if range_end <= range_start:
+        return []
+
+    rec = master.recurrence
+    if rec is None:
+        if master.ends_at > range_start and master.starts_at < range_end:
+            return [master]
+        return []
+
+    duration = master.ends_at - master.starts_at
+    if duration <= timedelta(0):
+        # Defensive: zero-length master shouldn't exist (dto enforces it) but
+        # guard the expansion just in case bad data lands via sync.
+        duration = timedelta(minutes=1)
+
+    rule = parse_rrule(rec.rrule, dtstart=master.starts_at)
+
+    # Exception list — compare on UTC datetimes by normalising both sides.
+    exceptions = {_normalize(e) for e in rec.exceptions}
+
+    instances: list[Event] = []
+    count_remaining = rec.count if rec.count is not None else None
+
+    # `between` returns occurrences in [range_start - duration, range_end).
+    # We shift the lower bound back by `duration` so that events starting
+    # before `range_start` but ending inside the window are still surfaced.
+    # `inc=True` includes equal endpoints which matches our "starts_at <
+    # range_end" semantics when paired with the duration shift.
+    window_start = range_start - duration
+    occurrences = rule.between(window_start, range_end, inc=True)
+
+    for occ in occurrences:
+        if rec.until is not None and occ > rec.until:
+            break
+        if count_remaining is not None:
+            if count_remaining <= 0:
+                break
+            count_remaining -= 1
+        if _normalize(occ) in exceptions:
+            continue
+        if len(instances) >= _MAX_INSTANCES:
+            logger.warning(
+                "expand_recurrence hit max instances cap of %d for event %s",
+                _MAX_INSTANCES,
+                master.id,
+            )
+            break
+        instance_end = occ + duration
+        # Filter out occurrences entirely before the window — `between` with
+        # the duration shift includes them.
+        if instance_end <= range_start:
+            continue
+        instances.append(
+            master.model_copy(
+                update={
+                    "starts_at": occ,
+                    "ends_at": instance_end,
+                }
+            )
+        )
+
+    return instances
+
+
+def _normalize(dt: datetime) -> datetime:
+    """Strip tzinfo for set-membership comparison. dateutil produces tz-aware
+    datetimes when DTSTART is tz-aware; exceptions arriving from external
+    sync may be naive. We compare on naive UTC equivalents."""
+    if dt.tzinfo is None:
+        return dt
+    # Convert to UTC and drop tzinfo.
+    from datetime import UTC
+
+    return dt.astimezone(UTC).replace(tzinfo=None)

--- a/ee/calendar/router.py
+++ b/ee/calendar/router.py
@@ -1,0 +1,143 @@
+# Calendar module — FastAPI router.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Thin wrappers around service.py. No business logic here. The router is
+# the single mounting point — callers outside this module never touch
+# service.py directly. Errors raised by service propagate to the global
+# CloudError handler installed by ee.cloud (we never raise HTTPException).
+#
+# This PR does NOT mount the router into the cloud app. A separate PR will
+# wire it in (so we can roll out behind a feature flag).
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from starlette.responses import Response
+
+from ee.calendar._context import RequestContext
+from ee.calendar.dto import (
+    ConflictReport,
+    CreateEventRequest,
+    EventListResponse,
+    EventResponse,
+    FreeBusyRequest,
+    FreeBusyResponse,
+    ListEventsRequest,
+    UpdateEventRequest,
+)
+from ee.calendar.service import (
+    create_event as svc_create_event,
+)
+from ee.calendar.service import (
+    delete_event as svc_delete_event,
+)
+from ee.calendar.service import (
+    detect_conflicts as svc_detect_conflicts,
+)
+from ee.calendar.service import (
+    get_event as svc_get_event,
+)
+from ee.calendar.service import (
+    get_freebusy as svc_get_freebusy,
+)
+from ee.calendar.service import (
+    list_events as svc_list_events,
+)
+from ee.calendar.service import (
+    update_event as svc_update_event,
+)
+from ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+router = APIRouter(prefix="/api/v1/calendar", tags=["Calendar"])
+
+
+async def _ctx(
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> RequestContext:
+    """Assemble the RequestContext from the standard cloud auth deps."""
+    return RequestContext(workspace_id=workspace_id, user_id=user_id)
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+
+@router.post("/events", response_model=EventResponse, status_code=201)
+async def create_event(
+    body: CreateEventRequest,
+    ctx: RequestContext = Depends(_ctx),
+) -> EventResponse:
+    return await svc_create_event(ctx, body)
+
+
+@router.get("/events", response_model=EventListResponse)
+async def list_events(
+    starts_after: str,
+    starts_before: str,
+    calendar_id: str | None = None,
+    limit: int = 100,
+    ctx: RequestContext = Depends(_ctx),
+) -> EventListResponse:
+    from datetime import datetime
+
+    body = ListEventsRequest(
+        calendar_id=calendar_id,
+        starts_after=datetime.fromisoformat(starts_after),
+        starts_before=datetime.fromisoformat(starts_before),
+        limit=limit,
+    )
+    return await svc_list_events(ctx, body)
+
+
+@router.get("/events/{event_id}", response_model=EventResponse)
+async def get_event(
+    event_id: str,
+    ctx: RequestContext = Depends(_ctx),
+) -> EventResponse:
+    return await svc_get_event(ctx, event_id)
+
+
+@router.patch("/events/{event_id}", response_model=EventResponse)
+async def update_event(
+    event_id: str,
+    body: UpdateEventRequest,
+    ctx: RequestContext = Depends(_ctx),
+) -> EventResponse:
+    return await svc_update_event(ctx, event_id, body)
+
+
+@router.delete("/events/{event_id}", status_code=204)
+async def delete_event(
+    event_id: str,
+    ctx: RequestContext = Depends(_ctx),
+) -> Response:
+    await svc_delete_event(ctx, event_id)
+    return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# FreeBusy
+# ---------------------------------------------------------------------------
+
+
+@router.post("/freebusy", response_model=FreeBusyResponse)
+async def get_freebusy(
+    body: FreeBusyRequest,
+    ctx: RequestContext = Depends(_ctx),
+) -> FreeBusyResponse:
+    return await svc_get_freebusy(ctx, body)
+
+
+# ---------------------------------------------------------------------------
+# Conflicts
+# ---------------------------------------------------------------------------
+
+
+@router.get("/events/{event_id}/conflicts", response_model=ConflictReport)
+async def detect_conflicts(
+    event_id: str,
+    ctx: RequestContext = Depends(_ctx),
+) -> ConflictReport:
+    return await svc_detect_conflicts(ctx, event_id)

--- a/ee/calendar/service.py
+++ b/ee/calendar/service.py
@@ -1,0 +1,270 @@
+# Calendar module — service layer (module-level async functions).
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# All write paths through here. _EventDoc / _CalendarDoc are never
+# imported outside this file. Every function:
+#   1. Validates the request DTO at entry (model_validate).
+#   2. Reads/writes with workspace=ctx.workspace_id as the tenant filter.
+#   3. Raises CloudError subclasses (NotFound, Forbidden, ValidationError) —
+#      never HTTPException.
+#   4. Emits on event_bus for state-changing ops so subscribers (notifications,
+#      future Instinct approval gates, sync) can react without coupling.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from beanie import PydanticObjectId
+
+from ee.calendar._context import RequestContext
+from ee.calendar.conflicts import _doc_to_event, find_conflicts
+from ee.calendar.domain import ConflictSeverity, Event
+from ee.calendar.dto import (
+    ConflictReport,
+    CreateEventRequest,
+    EventListResponse,
+    EventResponse,
+    FreeBusyRequest,
+    FreeBusyResponse,
+    ListEventsRequest,
+    UpdateEventRequest,
+)
+from ee.calendar.events import (
+    TOPIC_CONFLICT_DETECTED,
+    TOPIC_EVENT_CREATED,
+    TOPIC_EVENT_DELETED,
+    TOPIC_EVENT_UPDATED,
+    CalendarEventCreated,
+    CalendarEventDeleted,
+    CalendarEventUpdated,
+    ConflictDetected,
+)
+from ee.calendar.freebusy import compute_freebusy
+from ee.calendar.models import _EventDoc
+from ee.cloud.shared.errors import NotFound, ValidationError
+from ee.cloud.shared.events import event_bus
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Mapping helpers
+# ---------------------------------------------------------------------------
+
+
+def _event_to_response(event: Event) -> EventResponse:
+    """Mapping via Pydantic — never hand-rolled."""
+    return EventResponse.model_validate(event.model_dump())
+
+
+def _doc_to_response(doc: _EventDoc) -> EventResponse:
+    return _event_to_response(_doc_to_event(doc))
+
+
+async def _get_event_doc_or_404(ctx: RequestContext, event_id: str) -> _EventDoc:
+    """Tenant-filtered fetch. Cross-workspace lookups return 404, not 403 —
+    we never reveal existence outside the tenant."""
+    try:
+        oid = PydanticObjectId(event_id)
+    except Exception as exc:  # noqa: BLE001 — Beanie raises a variety of types here
+        raise NotFound("event", event_id) from exc
+
+    doc = await _EventDoc.find_one(
+        _EventDoc.id == oid,
+        _EventDoc.workspace == ctx.workspace_id,
+    )
+    if not doc:
+        raise NotFound("event", event_id)
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+async def create_event(ctx: RequestContext, body: CreateEventRequest) -> EventResponse:
+    """Create a calendar event."""
+    body = CreateEventRequest.model_validate(body)
+
+    # An optional Instinct approval gate hooks here in a follow-up PR — for
+    # now the comment marks the seam so reviewers know where it lands.
+    # TODO(instinct): if ctx.workspace requires approval for calendar
+    # writes, route through ee.instinct.propose() instead of inserting.
+
+    doc = _EventDoc(
+        workspace=ctx.workspace_id,
+        calendar_id=body.calendar_id,
+        title=body.title,
+        description=body.description,
+        starts_at=body.starts_at,
+        ends_at=body.ends_at,
+        timezone=body.timezone,
+        location=body.location,
+        attendees=[a.model_dump() for a in body.attendees],
+        recurrence=body.recurrence.model_dump() if body.recurrence else None,
+        fabric_object_id=body.fabric_object_id,
+    )
+    await doc.insert()
+
+    await event_bus.emit(
+        TOPIC_EVENT_CREATED,
+        CalendarEventCreated(
+            event_id=str(doc.id),
+            workspace_id=ctx.workspace_id,
+            calendar_id=doc.calendar_id,
+            starts_at=doc.starts_at,
+            ends_at=doc.ends_at,
+        ).model_dump(),
+    )
+
+    return _doc_to_response(doc)
+
+
+async def get_event(ctx: RequestContext, event_id: str) -> EventResponse:
+    """Fetch a single event. Tenant-filtered."""
+    doc = await _get_event_doc_or_404(ctx, event_id)
+    return _doc_to_response(doc)
+
+
+async def update_event(
+    ctx: RequestContext,
+    event_id: str,
+    body: UpdateEventRequest,
+) -> EventResponse:
+    """Patch an event. At least one field must be set (DTO enforces)."""
+    body = UpdateEventRequest.model_validate(body)
+    doc = await _get_event_doc_or_404(ctx, event_id)
+
+    changes: dict = {}
+    if body.title is not None:
+        doc.title = body.title
+        changes["title"] = body.title
+    if body.description is not None:
+        doc.description = body.description
+        changes["description"] = body.description
+    if body.starts_at is not None:
+        doc.starts_at = body.starts_at
+        changes["starts_at"] = body.starts_at.isoformat()
+    if body.ends_at is not None:
+        doc.ends_at = body.ends_at
+        changes["ends_at"] = body.ends_at.isoformat()
+    if body.location is not None:
+        doc.location = body.location
+        changes["location"] = body.location
+    if body.attendees is not None:
+        doc.attendees = [a.model_dump() for a in body.attendees]
+        changes["attendees"] = len(body.attendees)
+    if body.recurrence is not None:
+        doc.recurrence = body.recurrence.model_dump()
+        changes["recurrence"] = True
+
+    # Cross-field validation after the partial merge — starts_at < ends_at.
+    if doc.ends_at <= doc.starts_at:
+        raise ValidationError(
+            "event.invalid_window",
+            "ends_at must be strictly after starts_at",
+        )
+
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+
+    await event_bus.emit(
+        TOPIC_EVENT_UPDATED,
+        CalendarEventUpdated(
+            event_id=str(doc.id),
+            workspace_id=ctx.workspace_id,
+            calendar_id=doc.calendar_id,
+            changes=changes,
+        ).model_dump(),
+    )
+
+    return _doc_to_response(doc)
+
+
+async def delete_event(ctx: RequestContext, event_id: str) -> None:
+    """Hard-delete an event. Tenant-filtered."""
+    doc = await _get_event_doc_or_404(ctx, event_id)
+    event_id_str = str(doc.id)
+    calendar_id = doc.calendar_id
+    await doc.delete()
+
+    await event_bus.emit(
+        TOPIC_EVENT_DELETED,
+        CalendarEventDeleted(
+            event_id=event_id_str,
+            workspace_id=ctx.workspace_id,
+            calendar_id=calendar_id,
+        ).model_dump(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Queries
+# ---------------------------------------------------------------------------
+
+
+async def list_events(ctx: RequestContext, body: ListEventsRequest) -> EventListResponse:
+    """List events in a time window. Tenant-filtered."""
+    body = ListEventsRequest.model_validate(body)
+
+    query: dict = {
+        "workspace": ctx.workspace_id,
+        "starts_at": {"$lt": body.starts_before},
+        "ends_at": {"$gt": body.starts_after},
+    }
+    if body.calendar_id is not None:
+        query["calendar_id"] = body.calendar_id
+
+    docs = await _EventDoc.find(query).limit(body.limit).to_list()
+    events = [_doc_to_response(d) for d in docs]
+    return EventListResponse(events=events, total=len(events))
+
+
+async def get_freebusy(ctx: RequestContext, body: FreeBusyRequest) -> FreeBusyResponse:
+    """Compute per-attendee busy periods. Tenant-filtered inside compute_freebusy."""
+    body = FreeBusyRequest.model_validate(body)
+    freebusy = await compute_freebusy(
+        workspace_id=ctx.workspace_id,
+        attendee_emails=body.attendee_emails,
+        starts_at=body.starts_at,
+        ends_at=body.ends_at,
+    )
+    return FreeBusyResponse(freebusy=freebusy)
+
+
+async def detect_conflicts(ctx: RequestContext, event_id: str) -> ConflictReport:
+    """Find conflicts for an event. Emits on conflict so future approval
+    flows can hook in."""
+    doc = await _get_event_doc_or_404(ctx, event_id)
+    target = _doc_to_event(doc)
+
+    conflicts = await find_conflicts(ctx.workspace_id, target)
+
+    severity = _severity_for(len(conflicts))
+
+    if conflicts:
+        await event_bus.emit(
+            TOPIC_CONFLICT_DETECTED,
+            ConflictDetected(
+                event_id=event_id,
+                workspace_id=ctx.workspace_id,
+                conflicting_event_ids=[c.id for c in conflicts],
+            ).model_dump(),
+        )
+
+    return ConflictReport(
+        event_id=event_id,
+        conflicting_events=[_event_to_response(c) for c in conflicts],
+        severity=severity,
+    )
+
+
+def _severity_for(conflict_count: int) -> ConflictSeverity:
+    """Crude severity bucketing — refine when product gives us real rules."""
+    if conflict_count == 0:
+        return ConflictSeverity.LOW
+    if conflict_count < 3:
+        return ConflictSeverity.MEDIUM
+    return ConflictSeverity.HIGH

--- a/ee/calendar/sync.py
+++ b/ee/calendar/sync.py
@@ -1,0 +1,160 @@
+# Calendar module — external calendar sync.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Only Google Calendar is implemented in this PR. Outlook and iCloud are
+# placeholders that raise NotImplementedError so a future PR can wire them
+# without us pretending they work today. The gcalendar wrapper sits on top
+# of pocketpaw.integrations.gcalendar.CalendarClient.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from ee.calendar._context import RequestContext
+from ee.calendar.domain import Event
+from ee.calendar.models import _EventDoc
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Google Calendar — implemented
+# ---------------------------------------------------------------------------
+
+
+async def pull_from_gcalendar(ctx: RequestContext, calendar_id: str) -> int:
+    """Pull recent events from a Google Calendar into our store.
+
+    Reconciles by (source_connector="gcalendar", source_external_id=<google id>).
+    Returns the count of events created OR updated.
+
+    This is a thin wrapper around pocketpaw.integrations.gcalendar.CalendarClient.
+    OAuth must already be set up — if it isn't, the underlying client raises
+    RuntimeError and we propagate (the caller is responsible for showing the
+    OAuth re-auth flow).
+    """
+    # Lazy import — keeps ee.calendar importable even when the OAuth deps
+    # haven't been configured at process start.
+    from pocketpaw.integrations.gcalendar import CalendarClient  # type: ignore[import-untyped]
+
+    client = CalendarClient()
+    time_min = datetime.now(UTC) - timedelta(days=1)
+    time_max = datetime.now(UTC) + timedelta(days=30)
+
+    external_events = await client.list_events(
+        time_min=time_min,
+        time_max=time_max,
+        max_results=250,
+        calendar_id=calendar_id,
+    )
+
+    touched = 0
+    for ext in external_events:
+        external_id = ext.get("id") or ""
+        if not external_id:
+            continue
+        try:
+            starts_at = _parse_iso(ext.get("start", ""))
+            ends_at = _parse_iso(ext.get("end", ""))
+        except ValueError:
+            logger.warning("Skipping gcalendar event with bad time: %r", ext)
+            continue
+        if starts_at is None or ends_at is None:
+            continue
+
+        attendees = [
+            {"email": email, "response": "needs_action", "is_organizer": False}
+            for email in ext.get("attendees", [])
+            if email
+        ]
+
+        existing = await _EventDoc.find_one(
+            _EventDoc.workspace == ctx.workspace_id,
+            _EventDoc.source_connector == "gcalendar",
+            _EventDoc.source_external_id == external_id,
+        )
+        if existing:
+            existing.title = ext.get("summary") or existing.title
+            existing.starts_at = starts_at
+            existing.ends_at = ends_at
+            existing.description = ext.get("description") or ""
+            existing.location = ext.get("location") or None
+            existing.attendees = attendees
+            existing.updated_at = datetime.now(UTC)
+            await existing.save()
+        else:
+            doc = _EventDoc(
+                workspace=ctx.workspace_id,
+                calendar_id=calendar_id,
+                title=ext.get("summary") or "(no title)",
+                description=ext.get("description") or "",
+                starts_at=starts_at,
+                ends_at=ends_at,
+                # gcalendar dateTime carries its own offset; we keep UTC as the canonical store.
+                timezone="UTC",
+                location=ext.get("location") or None,
+                attendees=attendees,
+                source_connector="gcalendar",
+                source_external_id=external_id,
+            )
+            await doc.insert()
+        touched += 1
+
+    return touched
+
+
+async def push_to_gcalendar(ctx: RequestContext, event: Event) -> str:
+    """Push a local Event to Google Calendar. Returns the external id.
+
+    Reads the same `pocketpaw.integrations.gcalendar.CalendarClient` used by
+    pull; mutation is one-way (this PR doesn't track the local event's
+    source_external_id once it's been pushed — the next pull will reconcile).
+    """
+    # ctx is accepted so future per-workspace OAuth scoping has a home.
+    del ctx
+    from pocketpaw.integrations.gcalendar import CalendarClient  # type: ignore[import-untyped]
+
+    client = CalendarClient()
+    response = await client.create_event(
+        summary=event.title,
+        start=event.starts_at.isoformat(),
+        end=event.ends_at.isoformat(),
+        description=event.description,
+        location=event.location or "",
+        attendees=[a.email for a in event.attendees],
+        calendar_id="primary",
+    )
+    return response.get("id") or ""
+
+
+# ---------------------------------------------------------------------------
+# Outlook / iCloud — placeholders
+# ---------------------------------------------------------------------------
+
+
+async def pull_from_outlook(ctx: RequestContext, calendar_id: str) -> int:  # noqa: ARG001
+    """Placeholder. Microsoft Graph integration ships in a follow-up PR."""
+    raise NotImplementedError("Outlook sync — future PR")
+
+
+async def pull_from_icloud(ctx: RequestContext, calendar_id: str) -> int:  # noqa: ARG001
+    """Placeholder. CalDAV / iCloud integration ships in a follow-up PR."""
+    raise NotImplementedError("iCloud sync — future PR")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(s: str) -> datetime | None:
+    """Parse the ISO timestamps returned by gcalendar. Accepts both
+    datetime strings (RFC 3339) and date-only strings (treated as midnight)."""
+    if not s:
+        return None
+    try:
+        # Python 3.11+ fromisoformat handles 'Z' suffix in 3.11.
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/tests/ee/calendar/__init__.py
+++ b/tests/ee/calendar/__init__.py
@@ -1,0 +1,2 @@
+# Calendar module — test package marker.
+# Created: 2026-05-19 (feat/calendar-module).

--- a/tests/ee/calendar/conftest.py
+++ b/tests/ee/calendar/conftest.py
@@ -1,0 +1,91 @@
+# tests/ee/calendar/conftest.py — Pytest fixtures for the calendar module.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# We deliberately avoid spinning up a real Mongo for these tests. The
+# service layer is exercised by stubbing _EventDoc at the boundary so we
+# never hit Beanie. That makes the tests fast and CI-friendly, at the
+# cost of giving up a few coupling guarantees that an integration suite
+# would catch — those land in tests/cloud/ in a follow-up PR.
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from ee.calendar._context import RequestContext
+from ee.calendar.domain import Event
+
+
+@pytest.fixture
+def ctx() -> RequestContext:
+    """A standard tenant + actor for tests."""
+    return RequestContext(workspace_id="ws-test", user_id="user-test")
+
+
+@pytest.fixture
+def other_ctx() -> RequestContext:
+    """A second tenant for cross-workspace isolation tests."""
+    return RequestContext(workspace_id="ws-other", user_id="user-other")
+
+
+@pytest.fixture
+def event_factory():
+    """Build an Event without hitting the DB."""
+
+    def _make(
+        id: str = "evt-1",
+        workspace_id: str = "ws-test",
+        calendar_id: str = "cal-1",
+        title: str = "Standup",
+        starts_at: datetime | None = None,
+        ends_at: datetime | None = None,
+        **overrides: Any,
+    ) -> Event:
+        starts_at = starts_at or datetime(2026, 5, 19, 9, 0)
+        ends_at = ends_at or datetime(2026, 5, 19, 9, 30)
+        return Event(
+            id=id,
+            workspace_id=workspace_id,
+            calendar_id=calendar_id,
+            title=title,
+            starts_at=starts_at,
+            ends_at=ends_at,
+            timezone=overrides.pop("timezone", "UTC"),
+            description=overrides.pop("description", ""),
+            location=overrides.pop("location", None),
+            attendees=overrides.pop("attendees", []),
+            recurrence=overrides.pop("recurrence", None),
+            fabric_object_id=overrides.pop("fabric_object_id", None),
+            source_connector=overrides.pop("source_connector", None),
+            source_external_id=overrides.pop("source_external_id", None),
+            created_at=overrides.pop("created_at", datetime(2026, 5, 1)),
+            updated_at=overrides.pop("updated_at", datetime(2026, 5, 1)),
+        )
+
+    return _make
+
+
+@pytest.fixture
+async def bus_spy() -> AsyncIterator[list[tuple[str, dict]]]:
+    """Capture every event_bus.emit call.
+
+    Returns a list of (topic, payload) tuples in emission order. Cleanly
+    restores the bus on teardown.
+    """
+    from ee.cloud.shared.events import event_bus
+
+    captured: list[tuple[str, dict]] = []
+    original_emit = event_bus.emit
+
+    async def _spy(topic: str, data: dict) -> None:
+        captured.append((topic, data))
+        # Don't actually fan out — handlers are tested separately.
+
+    event_bus.emit = _spy  # type: ignore[method-assign]
+    try:
+        yield captured
+    finally:
+        event_bus.emit = original_emit  # type: ignore[method-assign]

--- a/tests/ee/calendar/test_freebusy.py
+++ b/tests/ee/calendar/test_freebusy.py
@@ -1,0 +1,175 @@
+# tests/ee/calendar/test_freebusy.py — free/busy availability tests.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# compute_freebusy queries _EventDoc.find with a $in on a nested attendees
+# field. The fake store in test_service.py models that, but here we keep
+# the test isolated: we patch _EventDoc.find directly at the freebusy
+# module level to return a hand-built list.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from ee.calendar import freebusy as fb_module
+
+
+class _FakeDoc:
+    """Lightweight stand-in for a Beanie _EventDoc row."""
+
+    def __init__(
+        self,
+        starts_at: datetime,
+        ends_at: datetime,
+        attendees: list[dict[str, Any]],
+    ) -> None:
+        self.starts_at = starts_at
+        self.ends_at = ends_at
+        self.attendees = attendees
+
+
+class _FakeQuery:
+    def __init__(self, docs: list[_FakeDoc]) -> None:
+        self._docs = docs
+
+    async def to_list(self) -> list[_FakeDoc]:
+        return self._docs
+
+
+class _FakeStore:
+    def __init__(self, docs: list[_FakeDoc]) -> None:
+        self._docs = docs
+        self.last_query: dict[str, Any] | None = None
+
+    def find(self, query: dict[str, Any]) -> _FakeQuery:
+        self.last_query = query
+        return _FakeQuery(self._docs)
+
+
+@pytest.fixture
+def patch_store(monkeypatch):
+    """Install a fake _EventDoc.find for these tests only."""
+
+    def _install(docs: list[_FakeDoc]) -> _FakeStore:
+        store = _FakeStore(docs)
+        monkeypatch.setattr(fb_module, "_EventDoc", store)
+        return store
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_freebusy_single_attendee_busy(patch_store):
+    docs = [
+        _FakeDoc(
+            starts_at=datetime(2026, 5, 19, 10, 0),
+            ends_at=datetime(2026, 5, 19, 11, 0),
+            attendees=[{"email": "alice@example.com"}],
+        ),
+    ]
+    patch_store(docs)
+
+    result = await fb_module.compute_freebusy(
+        workspace_id="ws-1",
+        attendee_emails=["alice@example.com"],
+        starts_at=datetime(2026, 5, 19, 0, 0),
+        ends_at=datetime(2026, 5, 19, 23, 59),
+    )
+    assert len(result) == 1
+    assert result[0].attendee_email == "alice@example.com"
+    assert result[0].busy_periods == [
+        (datetime(2026, 5, 19, 10, 0), datetime(2026, 5, 19, 11, 0)),
+    ]
+
+
+async def test_freebusy_multi_attendee_overlap(patch_store):
+    """Two events, two attendees — each shows only their own busy period."""
+    docs = [
+        _FakeDoc(
+            starts_at=datetime(2026, 5, 19, 10, 0),
+            ends_at=datetime(2026, 5, 19, 11, 0),
+            attendees=[{"email": "alice@example.com"}],
+        ),
+        _FakeDoc(
+            starts_at=datetime(2026, 5, 19, 14, 0),
+            ends_at=datetime(2026, 5, 19, 15, 0),
+            attendees=[{"email": "bob@example.com"}],
+        ),
+        _FakeDoc(
+            starts_at=datetime(2026, 5, 19, 16, 0),
+            ends_at=datetime(2026, 5, 19, 17, 0),
+            attendees=[
+                {"email": "alice@example.com"},
+                {"email": "bob@example.com"},
+            ],
+        ),
+    ]
+    patch_store(docs)
+
+    result = await fb_module.compute_freebusy(
+        workspace_id="ws-1",
+        attendee_emails=["alice@example.com", "bob@example.com"],
+        starts_at=datetime(2026, 5, 19, 0, 0),
+        ends_at=datetime(2026, 5, 19, 23, 59),
+    )
+    by_email = {fb.attendee_email: fb.busy_periods for fb in result}
+    assert len(by_email["alice@example.com"]) == 2
+    assert len(by_email["bob@example.com"]) == 2
+
+
+async def test_freebusy_no_events_returns_empty(patch_store):
+    patch_store([])
+    result = await fb_module.compute_freebusy(
+        workspace_id="ws-1",
+        attendee_emails=["nobody@example.com"],
+        starts_at=datetime(2026, 5, 19, 0, 0),
+        ends_at=datetime(2026, 5, 19, 23, 59),
+    )
+    assert len(result) == 1
+    assert result[0].busy_periods == []
+
+
+async def test_freebusy_empty_emails_returns_empty():
+    """Edge: no emails means we never even query the store."""
+    result = await fb_module.compute_freebusy(
+        workspace_id="ws-1",
+        attendee_emails=[],
+        starts_at=datetime(2026, 5, 19, 0, 0),
+        ends_at=datetime(2026, 5, 19, 23, 59),
+    )
+    assert result == []
+
+
+async def test_freebusy_period_clipped_to_window(patch_store):
+    """An event spanning the window boundary should be clipped on output."""
+    docs = [
+        _FakeDoc(
+            starts_at=datetime(2026, 5, 18, 22, 0),
+            ends_at=datetime(2026, 5, 19, 2, 0),
+            attendees=[{"email": "alice@example.com"}],
+        ),
+    ]
+    patch_store(docs)
+
+    result = await fb_module.compute_freebusy(
+        workspace_id="ws-1",
+        attendee_emails=["alice@example.com"],
+        starts_at=datetime(2026, 5, 19, 0, 0),
+        ends_at=datetime(2026, 5, 19, 23, 59),
+    )
+    period = result[0].busy_periods[0]
+    assert period[0] == datetime(2026, 5, 19, 0, 0)
+    assert period[1] == datetime(2026, 5, 19, 2, 0)
+
+
+def test_freebusy_module_imports_clean():
+    """Smoke: module-level constants and __all__ are consistent."""
+    assert callable(fb_module.compute_freebusy)
+    # UTC import is used inside module — make sure datetime UTC is still importable.
+    assert UTC is not None

--- a/tests/ee/calendar/test_recurrence.py
+++ b/tests/ee/calendar/test_recurrence.py
@@ -1,0 +1,196 @@
+# tests/ee/calendar/test_recurrence.py — RRULE expansion tests.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Pure-function tests. No DB, no bus. Validate that the recurrence
+# expander honours COUNT, UNTIL, exceptions, and the no-recurrence
+# pass-through behaviour.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from ee.calendar.domain import Recurrence
+from ee.calendar.recurrence import expand_recurrence, parse_rrule
+
+# ---------------------------------------------------------------------------
+# Daily
+# ---------------------------------------------------------------------------
+
+
+def test_daily_recurrence_5_days(event_factory):
+    master = event_factory(
+        starts_at=datetime(2026, 5, 19, 9, 0),
+        ends_at=datetime(2026, 5, 19, 9, 30),
+        recurrence=Recurrence(rrule="FREQ=DAILY;COUNT=5"),
+    )
+    instances = expand_recurrence(
+        master,
+        datetime(2026, 5, 19),
+        datetime(2026, 5, 26),
+    )
+    assert len(instances) == 5
+    assert instances[0].starts_at == datetime(2026, 5, 19, 9, 0)
+    assert instances[-1].starts_at == datetime(2026, 5, 23, 9, 0)
+    # Each instance preserves the master's duration.
+    for inst in instances:
+        assert (inst.ends_at - inst.starts_at).total_seconds() == 30 * 60
+
+
+# ---------------------------------------------------------------------------
+# Weekly with UNTIL
+# ---------------------------------------------------------------------------
+
+
+def test_weekly_recurrence_with_until(event_factory):
+    master = event_factory(
+        starts_at=datetime(2026, 1, 5, 14, 0),
+        ends_at=datetime(2026, 1, 5, 15, 0),
+        recurrence=Recurrence(rrule="FREQ=WEEKLY;UNTIL=20260202T000000"),
+    )
+    instances = expand_recurrence(
+        master,
+        datetime(2026, 1, 1),
+        datetime(2026, 3, 1),
+    )
+    # Jan 5, 12, 19, 26 are within the window before UNTIL=2026-02-02.
+    assert len(instances) == 4
+    assert instances[0].starts_at == datetime(2026, 1, 5, 14, 0)
+    assert instances[-1].starts_at == datetime(2026, 1, 26, 14, 0)
+
+
+# ---------------------------------------------------------------------------
+# Monthly with COUNT
+# ---------------------------------------------------------------------------
+
+
+def test_monthly_recurrence_with_count(event_factory):
+    master = event_factory(
+        starts_at=datetime(2026, 1, 15, 10, 0),
+        ends_at=datetime(2026, 1, 15, 11, 0),
+        recurrence=Recurrence(rrule="FREQ=MONTHLY;COUNT=3"),
+    )
+    instances = expand_recurrence(
+        master,
+        datetime(2026, 1, 1),
+        datetime(2026, 12, 31),
+    )
+    assert len(instances) == 3
+    assert [i.starts_at.month for i in instances] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+def test_recurrence_with_exceptions(event_factory):
+    """An instance whose start matches an exception is skipped."""
+    master = event_factory(
+        starts_at=datetime(2026, 5, 19, 9, 0),
+        ends_at=datetime(2026, 5, 19, 9, 30),
+        recurrence=Recurrence(
+            rrule="FREQ=DAILY;COUNT=5",
+            exceptions=[datetime(2026, 5, 21, 9, 0)],
+        ),
+    )
+    instances = expand_recurrence(
+        master,
+        datetime(2026, 5, 19),
+        datetime(2026, 5, 26),
+    )
+    starts = [i.starts_at for i in instances]
+    assert datetime(2026, 5, 21, 9, 0) not in starts
+    # 5 originally - 1 exception = 4 expanded.
+    assert len(instances) == 4
+
+
+# ---------------------------------------------------------------------------
+# Terminator handling — Recurrence.until + Recurrence.count combine with RRULE
+# ---------------------------------------------------------------------------
+
+
+def test_recurrence_terminator_handling_until(event_factory):
+    """Even with no UNTIL in the RRULE, Recurrence.until caps expansion."""
+    master = event_factory(
+        starts_at=datetime(2026, 5, 19, 9, 0),
+        ends_at=datetime(2026, 5, 19, 9, 30),
+        recurrence=Recurrence(
+            rrule="FREQ=DAILY",  # unbounded
+            until=datetime(2026, 5, 22, 23, 59),
+        ),
+    )
+    instances = expand_recurrence(
+        master,
+        datetime(2026, 5, 19),
+        datetime(2026, 6, 1),
+    )
+    # 5/19, 5/20, 5/21, 5/22 — Recurrence.until breaks the loop on 5/23.
+    assert len(instances) == 4
+
+
+def test_recurrence_terminator_handling_count(event_factory):
+    """Recurrence.count overrides an unbounded RRULE."""
+    master = event_factory(
+        starts_at=datetime(2026, 5, 19, 9, 0),
+        ends_at=datetime(2026, 5, 19, 9, 30),
+        recurrence=Recurrence(
+            rrule="FREQ=DAILY",  # unbounded
+            count=3,
+        ),
+    )
+    instances = expand_recurrence(
+        master,
+        datetime(2026, 5, 19),
+        datetime(2026, 6, 1),
+    )
+    assert len(instances) == 3
+
+
+# ---------------------------------------------------------------------------
+# Pass-through (no recurrence)
+# ---------------------------------------------------------------------------
+
+
+def test_no_recurrence_returns_single_when_in_window(event_factory):
+    master = event_factory(
+        starts_at=datetime(2026, 5, 19, 9, 0),
+        ends_at=datetime(2026, 5, 19, 10, 0),
+    )
+    instances = expand_recurrence(
+        master,
+        datetime(2026, 5, 19),
+        datetime(2026, 5, 26),
+    )
+    assert len(instances) == 1
+    assert instances[0] is master  # frozen — identity preserved
+
+
+def test_no_recurrence_returns_empty_when_outside_window(event_factory):
+    master = event_factory(
+        starts_at=datetime(2026, 1, 1, 9, 0),
+        ends_at=datetime(2026, 1, 1, 10, 0),
+    )
+    instances = expand_recurrence(
+        master,
+        datetime(2026, 5, 19),
+        datetime(2026, 5, 26),
+    )
+    assert instances == []
+
+
+# ---------------------------------------------------------------------------
+# parse_rrule
+# ---------------------------------------------------------------------------
+
+
+def test_parse_rrule_valid():
+    rule = parse_rrule("FREQ=DAILY;COUNT=3", dtstart=datetime(2026, 5, 19, 9, 0))
+    occurrences = list(rule)
+    assert len(occurrences) == 3
+
+
+def test_parse_rrule_invalid_raises():
+    with pytest.raises(ValueError):
+        parse_rrule("NOT_A_RULE", dtstart=datetime(2026, 5, 19))

--- a/tests/ee/calendar/test_router.py
+++ b/tests/ee/calendar/test_router.py
@@ -1,0 +1,219 @@
+# tests/ee/calendar/test_router.py — FastAPI router tests.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Mount the router on a throwaway FastAPI app, install a global CloudError
+# handler (so we get the same envelope the real cloud app emits), and
+# override the auth deps so requests carry a deterministic workspace + user.
+# The service itself is mocked at module boundary — we're exercising the
+# wiring, not the persistence.
+
+from __future__ import annotations
+
+import importlib
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from starlette.testclient import TestClient
+
+from ee.calendar.domain import Attendee, AttendeeResponse, ConflictSeverity
+from ee.calendar.dto import (
+    ConflictReport,
+    EventListResponse,
+    EventResponse,
+    FreeBusyResponse,
+)
+from ee.cloud.shared.deps import current_user_id, current_workspace_id
+from ee.cloud.shared.errors import CloudError, NotFound
+
+# Use importlib so we get the submodule, not the `router` attr re-exported
+# by ee.calendar.__init__. Beware: ``import ee.calendar.router`` binds to
+# the re-exported APIRouter, not the module. Fixtures need the module so
+# they can monkeypatch the ``svc_*`` aliases.
+router_module = importlib.import_module("ee.calendar.router")
+router = router_module.router
+
+
+def _make_event_response(**overrides: Any) -> EventResponse:
+    base = dict(
+        id="evt-1",
+        workspace_id="ws-test",
+        calendar_id="cal-1",
+        title="Sample",
+        description="",
+        starts_at=datetime(2026, 5, 19, 9, 0),
+        ends_at=datetime(2026, 5, 19, 10, 0),
+        timezone="UTC",
+        location=None,
+        attendees=[],
+        recurrence=None,
+        fabric_object_id=None,
+        source_connector=None,
+        source_external_id=None,
+        created_at=datetime(2026, 5, 1),
+        updated_at=datetime(2026, 5, 1),
+    )
+    base.update(overrides)
+    return EventResponse(**base)
+
+
+@pytest.fixture
+def client(monkeypatch) -> TestClient:
+    """Build a minimal FastAPI app mounting only the calendar router.
+
+    We install the same CloudError handler the real cloud app uses so that
+    a NotFound from the service produces a 404 with the standard envelope
+    rather than a 500 with a traceback.
+    """
+    app = FastAPI()
+
+    async def _cloud_error_handler(request: Request, exc: CloudError) -> JSONResponse:
+        return JSONResponse(status_code=exc.status_code, content=exc.to_dict())
+
+    app.add_exception_handler(CloudError, _cloud_error_handler)
+    app.include_router(router)
+
+    # Override auth deps so we don't need real JWTs.
+    async def _ws() -> str:
+        return "ws-test"
+
+    async def _user() -> str:
+        return "user-test"
+
+    app.dependency_overrides[current_workspace_id] = _ws
+    app.dependency_overrides[current_user_id] = _user
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_create_event_endpoint(client, monkeypatch):
+    mock_create = AsyncMock(return_value=_make_event_response(title="Booked"))
+    monkeypatch.setattr(router_module, "svc_create_event", mock_create)
+
+    response = client.post(
+        "/api/v1/calendar/events",
+        json={
+            "calendar_id": "cal-1",
+            "title": "Booked",
+            "starts_at": "2026-05-19T09:00:00",
+            "ends_at": "2026-05-19T10:00:00",
+            "timezone": "UTC",
+        },
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["title"] == "Booked"
+    assert body["workspace_id"] == "ws-test"
+    mock_create.assert_awaited_once()
+
+
+def test_create_event_invalid_dto_returns_422(client, monkeypatch):
+    """Pydantic rejection happens before the service is invoked."""
+    sentinel = AsyncMock()
+    monkeypatch.setattr(router_module, "svc_create_event", sentinel)
+
+    response = client.post(
+        "/api/v1/calendar/events",
+        json={
+            "calendar_id": "cal-1",
+            # missing title
+            "starts_at": "2026-05-19T09:00:00",
+            "ends_at": "2026-05-19T10:00:00",
+            "timezone": "UTC",
+        },
+    )
+    assert response.status_code == 422
+    sentinel.assert_not_awaited()
+
+
+def test_list_events_endpoint(client, monkeypatch):
+    mock_list = AsyncMock(
+        return_value=EventListResponse(
+            events=[
+                _make_event_response(id="evt-1"),
+                _make_event_response(id="evt-2", title="Lunch"),
+            ],
+            total=2,
+        ),
+    )
+    monkeypatch.setattr(router_module, "svc_list_events", mock_list)
+
+    response = client.get(
+        "/api/v1/calendar/events",
+        params={
+            "starts_after": "2026-05-19T00:00:00",
+            "starts_before": "2026-05-20T00:00:00",
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 2
+    assert {e["id"] for e in body["events"]} == {"evt-1", "evt-2"}
+
+
+def test_not_found_returns_404_with_cloud_error_shape(client, monkeypatch):
+    """CloudError → standard envelope. We verify the shape, not just the code."""
+    mock_get = AsyncMock(side_effect=NotFound("event", "missing"))
+    monkeypatch.setattr(router_module, "svc_get_event", mock_get)
+
+    response = client.get("/api/v1/calendar/events/missing")
+    assert response.status_code == 404
+    body = response.json()
+    assert body == {"error": {"code": "event.not_found", "message": "event 'missing' not found"}}
+
+
+def test_get_event_endpoint(client, monkeypatch):
+    mock_get = AsyncMock(
+        return_value=_make_event_response(
+            id="evt-1",
+            attendees=[Attendee(email="alice@example.com", response=AttendeeResponse.ACCEPTED)],
+        ),
+    )
+    monkeypatch.setattr(router_module, "svc_get_event", mock_get)
+
+    response = client.get("/api/v1/calendar/events/evt-1")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == "evt-1"
+    assert body["attendees"][0]["email"] == "alice@example.com"
+
+
+def test_freebusy_endpoint(client, monkeypatch):
+    mock_fb = AsyncMock(return_value=FreeBusyResponse(freebusy=[]))
+    monkeypatch.setattr(router_module, "svc_get_freebusy", mock_fb)
+
+    response = client.post(
+        "/api/v1/calendar/freebusy",
+        json={
+            "attendee_emails": ["a@example.com"],
+            "starts_at": "2026-05-19T00:00:00",
+            "ends_at": "2026-05-19T23:59:00",
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_conflicts_endpoint(client, monkeypatch):
+    mock_conflicts = AsyncMock(
+        return_value=ConflictReport(
+            event_id="evt-1",
+            conflicting_events=[],
+            severity=ConflictSeverity.LOW,
+        ),
+    )
+    monkeypatch.setattr(router_module, "svc_detect_conflicts", mock_conflicts)
+
+    response = client.get("/api/v1/calendar/events/evt-1/conflicts")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["event_id"] == "evt-1"
+    assert body["severity"] == "low"
+    assert body["conflicting_events"] == []

--- a/tests/ee/calendar/test_service.py
+++ b/tests/ee/calendar/test_service.py
@@ -1,0 +1,390 @@
+# tests/ee/calendar/test_service.py — service-layer tests.
+# Created: 2026-05-19 (feat/calendar-module).
+#
+# Approach: we don't spin up real Mongo. Instead we replace _EventDoc at
+# the class level with a fake that mimics the small slice of Beanie we
+# actually use (find, find_one, insert, save, delete). That gives us
+# fast, deterministic tests and forces us to keep the surface narrow —
+# if the service ever reaches into Beanie API we don't fake, the test
+# fails loudly and we either fake more or simplify the service.
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from bson import ObjectId
+
+from ee.calendar import service as service_module
+from ee.calendar.dto import (
+    CreateEventRequest,
+    FreeBusyRequest,
+    ListEventsRequest,
+    UpdateEventRequest,
+)
+from ee.calendar.events import (
+    TOPIC_CONFLICT_DETECTED,
+    TOPIC_EVENT_CREATED,
+    TOPIC_EVENT_DELETED,
+    TOPIC_EVENT_UPDATED,
+)
+from ee.cloud.shared.errors import NotFound, ValidationError
+
+# ---------------------------------------------------------------------------
+# Fake Beanie doc — minimum viable replacement.
+# ---------------------------------------------------------------------------
+
+
+class _FakeStore:
+    """In-memory replacement for the _EventDoc class. Carries the same name
+    as a Document type, so service code that calls _EventDoc.find_one works
+    by going through this stand-in."""
+
+    def __init__(self) -> None:
+        self.rows: dict[str, _FakeDoc] = {}
+
+    def __call__(self, **fields: Any) -> _FakeDoc:
+        """Constructor — service does ``_EventDoc(workspace=...)``."""
+        doc = _FakeDoc(store=self, **fields)
+        return doc
+
+    def reset(self) -> None:
+        self.rows.clear()
+
+    # Beanie-style query API ---------------------------------------------------
+
+    def find(self, *args: Any) -> _FakeQuery:
+        return _FakeQuery(self.rows, self._compile(args))
+
+    async def find_one(self, *args: Any) -> _FakeDoc | None:
+        matcher = self._compile(args)
+        for doc in self.rows.values():
+            if matcher(doc):
+                return doc
+        return None
+
+    @staticmethod
+    def _compile(args: tuple[Any, ...]) -> Callable[[_FakeDoc], bool]:
+        """Compile a list of (Beanie-style) match expressions into a callable.
+
+        We accept the two forms used by the service:
+          * raw dict like {"workspace": "ws-1", "starts_at": {"$lt": ...}}
+          * comparison built from ``_EventDoc.id == oid`` / ``_EventDoc.workspace == "ws"``
+            (these come through as a ``_FieldEq`` object the test installs).
+        """
+
+        def _match(doc: _FakeDoc) -> bool:
+            for arg in args:
+                if isinstance(arg, dict):
+                    if not _dict_match(doc, arg):
+                        return False
+                elif isinstance(arg, _FieldEq):
+                    if getattr(doc, arg.field) != arg.value:
+                        return False
+                else:
+                    raise AssertionError(f"unhandled query arg: {arg!r}")
+            return True
+
+        return _match
+
+
+def _dict_match(doc: _FakeDoc, filt: dict[str, Any]) -> bool:
+    for key, value in filt.items():
+        actual = getattr(doc, key, None)
+        if isinstance(value, dict):
+            for op, operand in value.items():
+                if op == "$lt" and not (actual is not None and actual < operand):
+                    return False
+                elif op == "$gt" and not (actual is not None and actual > operand):
+                    return False
+                elif op == "$in":
+                    # only used for attendees.email which is nested — caller
+                    # never asks for that path in service-level tests.
+                    if actual not in operand:
+                        return False
+        else:
+            if actual != value:
+                return False
+    return True
+
+
+class _FakeQuery:
+    def __init__(self, rows: dict[str, _FakeDoc], matcher) -> None:
+        self.rows = rows
+        self.matcher = matcher
+        self._limit: int | None = None
+
+    def limit(self, n: int) -> _FakeQuery:
+        self._limit = n
+        return self
+
+    async def to_list(self) -> list[_FakeDoc]:
+        out = [d for d in self.rows.values() if self.matcher(d)]
+        if self._limit is not None:
+            out = out[: self._limit]
+        return out
+
+
+class _FieldEq:
+    """Stand-in for ``_EventDoc.workspace == 'x'``-style comparisons."""
+
+    def __init__(self, field: str, value: Any) -> None:
+        self.field = field
+        self.value = value
+
+
+class _FieldProxy:
+    """Lets tests/service write ``_EventDoc.workspace == 'x'`` against our fake."""
+
+    def __init__(self, field: str) -> None:
+        self._field = field
+
+    def __eq__(self, other: Any) -> _FieldEq:  # type: ignore[override]
+        return _FieldEq(self._field, other)
+
+
+class _FakeDoc:
+    def __init__(self, store: _FakeStore, **fields: Any) -> None:
+        self._store = store
+        self.id: ObjectId = fields.pop("_id", ObjectId())
+        # Apply remaining fields.
+        for k, v in fields.items():
+            setattr(self, k, v)
+        # Defaults to match the model.
+        self.description = getattr(self, "description", "")
+        self.location = getattr(self, "location", None)
+        self.attendees = getattr(self, "attendees", [])
+        self.recurrence = getattr(self, "recurrence", None)
+        self.fabric_object_id = getattr(self, "fabric_object_id", None)
+        self.source_connector = getattr(self, "source_connector", None)
+        self.source_external_id = getattr(self, "source_external_id", None)
+        self.created_at = getattr(self, "created_at", datetime.now(UTC))
+        self.updated_at = getattr(self, "updated_at", datetime.now(UTC))
+
+    async def insert(self) -> None:
+        self._store.rows[str(self.id)] = self
+
+    async def save(self) -> None:
+        self._store.rows[str(self.id)] = self
+
+    async def delete(self) -> None:
+        self._store.rows.pop(str(self.id), None)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: install the fake at the module the service imports.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_store(monkeypatch) -> _FakeStore:
+    store = _FakeStore()
+    # Patch the symbol service.py references. Service imports _EventDoc at
+    # module-load time, so we replace it there.
+    monkeypatch.setattr(service_module, "_EventDoc", store)
+    # Service uses ``_EventDoc.id == oid`` and ``.workspace == ...`` via
+    # ``_get_event_doc_or_404``. The fake _EventDoc is a class instance,
+    # not a class — we attach proxies for the two fields service queries.
+    store.id = _FieldProxy("id_str")  # type: ignore[attr-defined]
+    store.workspace = _FieldProxy("workspace")  # type: ignore[attr-defined]
+    return store
+
+
+def _new_doc(
+    store: _FakeStore,
+    *,
+    workspace: str = "ws-test",
+    calendar_id: str = "cal-1",
+    title: str = "Meeting",
+    starts_at: datetime | None = None,
+    ends_at: datetime | None = None,
+    attendees: list[dict] | None = None,
+) -> _FakeDoc:
+    """Helper: stuff a doc into the fake store directly (skip service)."""
+    oid = ObjectId()
+    doc = _FakeDoc(
+        store=store,
+        _id=oid,
+        workspace=workspace,
+        calendar_id=calendar_id,
+        title=title,
+        starts_at=starts_at or datetime(2026, 5, 19, 9, 0),
+        ends_at=ends_at or datetime(2026, 5, 19, 10, 0),
+        timezone="UTC",
+        description="",
+        location=None,
+        attendees=attendees or [],
+    )
+    # mirror the id as a string field so `_FieldEq("id_str", oid)` works.
+    doc.id_str = oid
+    store.rows[str(oid)] = doc
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_create_event_happy_path(ctx, fake_store, bus_spy):
+    body = CreateEventRequest(
+        calendar_id="cal-1",
+        title="Team sync",
+        starts_at=datetime(2026, 5, 19, 9, 0),
+        ends_at=datetime(2026, 5, 19, 10, 0),
+        timezone="UTC",
+    )
+    resp = await service_module.create_event(ctx, body)
+    assert resp.title == "Team sync"
+    assert resp.workspace_id == ctx.workspace_id
+    assert resp.calendar_id == "cal-1"
+    # Persisted in the fake store.
+    assert len(fake_store.rows) == 1
+    # Bus event emitted.
+    topics = [t for t, _ in bus_spy]
+    assert TOPIC_EVENT_CREATED in topics
+
+
+def test_create_event_validates_input():
+    """DTO rejects missing required title at construction."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        CreateEventRequest(
+            calendar_id="cal-1",
+            title="",  # min_length=1
+            starts_at=datetime(2026, 5, 19, 9, 0),
+            ends_at=datetime(2026, 5, 19, 10, 0),
+            timezone="UTC",
+        )
+
+
+def test_create_event_rejects_end_before_start():
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        CreateEventRequest(
+            calendar_id="cal-1",
+            title="x",
+            starts_at=datetime(2026, 5, 19, 10, 0),
+            ends_at=datetime(2026, 5, 19, 9, 0),  # before start
+            timezone="UTC",
+        )
+
+
+async def test_list_events_tenant_filter(ctx, other_ctx, fake_store):
+    """Cross-workspace reads return empty — never leak across tenants."""
+    _new_doc(fake_store, workspace=ctx.workspace_id)
+    _new_doc(fake_store, workspace=other_ctx.workspace_id)
+    body = ListEventsRequest(
+        starts_after=datetime(2026, 5, 1),
+        starts_before=datetime(2026, 6, 1),
+    )
+    result = await service_module.list_events(ctx, body)
+    assert result.total == 1
+    assert result.events[0].workspace_id == ctx.workspace_id
+
+
+async def test_update_event_happy_path(ctx, fake_store, bus_spy):
+    doc = _new_doc(fake_store, workspace=ctx.workspace_id, title="Old title")
+    body = UpdateEventRequest(title="New title")
+    resp = await service_module.update_event(ctx, str(doc.id), body)
+    assert resp.title == "New title"
+    topics = [t for t, _ in bus_spy]
+    assert TOPIC_EVENT_UPDATED in topics
+
+
+async def test_update_event_not_found(ctx, fake_store):
+    """A 404 surfaces as NotFound — not a generic CloudError."""
+    with pytest.raises(NotFound):
+        await service_module.update_event(
+            ctx,
+            str(ObjectId()),  # valid object id, just no row
+            UpdateEventRequest(title="Anything"),
+        )
+
+
+async def test_update_event_invalid_window_raises_validation(ctx, fake_store):
+    """Cross-field invariant — starts < ends — checked at the service after merge."""
+    doc = _new_doc(
+        fake_store,
+        workspace=ctx.workspace_id,
+        starts_at=datetime(2026, 5, 19, 9, 0),
+        ends_at=datetime(2026, 5, 19, 10, 0),
+    )
+    # Push starts past ends without updating ends — service should refuse.
+    body = UpdateEventRequest(starts_at=datetime(2026, 5, 19, 11, 0))
+    with pytest.raises(ValidationError):
+        await service_module.update_event(ctx, str(doc.id), body)
+
+
+async def test_delete_event_emits_bus_event(ctx, fake_store, bus_spy):
+    doc = _new_doc(fake_store, workspace=ctx.workspace_id)
+    await service_module.delete_event(ctx, str(doc.id))
+    assert str(doc.id) not in fake_store.rows
+    topics = [t for t, _ in bus_spy]
+    assert TOPIC_EVENT_DELETED in topics
+
+
+async def test_get_event_cross_workspace_returns_404(ctx, other_ctx, fake_store):
+    doc = _new_doc(fake_store, workspace=other_ctx.workspace_id)
+    with pytest.raises(NotFound):
+        await service_module.get_event(ctx, str(doc.id))
+
+
+async def test_get_freebusy_multi_attendee(ctx, fake_store, monkeypatch):
+    """Cover the freebusy path. compute_freebusy is patched because the
+    fake store doesn't model the embedded-attendee $in filter that the
+    real Mongo query uses."""
+    from ee.calendar import service as svc
+
+    async def _fake_compute(workspace_id, attendee_emails, starts_at, ends_at):
+        from ee.calendar.domain import FreeBusy
+
+        return [FreeBusy(attendee_email=e, busy_periods=[]) for e in attendee_emails]
+
+    monkeypatch.setattr(svc, "compute_freebusy", _fake_compute)
+
+    body = FreeBusyRequest(
+        attendee_emails=["a@example.com", "b@example.com"],
+        starts_at=datetime(2026, 5, 19),
+        ends_at=datetime(2026, 5, 20),
+    )
+    resp = await svc.get_freebusy(ctx, body)
+    assert {fb.attendee_email for fb in resp.freebusy} == {"a@example.com", "b@example.com"}
+
+
+async def test_detect_conflicts_overlapping_events(ctx, fake_store, bus_spy, monkeypatch):
+    """detect_conflicts emits TOPIC_CONFLICT_DETECTED when conflicts exist."""
+    from ee.calendar import service as svc
+
+    target = _new_doc(
+        fake_store,
+        workspace=ctx.workspace_id,
+        starts_at=datetime(2026, 5, 19, 9, 0),
+        ends_at=datetime(2026, 5, 19, 10, 0),
+        attendees=[{"email": "alice@example.com", "is_organizer": True}],
+    )
+
+    other = _new_doc(
+        fake_store,
+        workspace=ctx.workspace_id,
+        starts_at=datetime(2026, 5, 19, 9, 30),
+        ends_at=datetime(2026, 5, 19, 10, 30),
+        attendees=[{"email": "alice@example.com", "is_organizer": False}],
+    )
+
+    async def _fake_find_conflicts(workspace_id, event):
+        from ee.calendar.conflicts import _doc_to_event
+
+        # mirror real find_conflicts: just return `other` mapped.
+        return [_doc_to_event(other)]
+
+    monkeypatch.setattr(svc, "find_conflicts", _fake_find_conflicts)
+
+    report = await svc.detect_conflicts(ctx, str(target.id))
+    assert len(report.conflicting_events) == 1
+    topics = [t for t, _ in bus_spy]
+    assert TOPIC_CONFLICT_DETECTED in topics


### PR DESCRIPTION
## Summary

New native `ee/calendar/` module — workspace-level calendar primitive that gives Pocketpaw events, recurrence, free/busy, and conflict detection without depending on an external calendar product. Closes the gap surfaced in the 2026-05-19 architecture discussion.

## What this PR adds

- `ee/calendar/` — 13 files
  - `domain.py` (frozen value objects: Event, Calendar, Attendee, Recurrence, FreeBusy + enums; `workspace_id` required at construction)
  - `dto.py` (distinct request/response DTOs with cross-field validators)
  - `service.py` (module-level async functions; validate-at-entry, tenant filter, bus emit on every write)
  - `router.py` (FastAPI routes mounted at `/api/v1/calendar`; service is called via aliased imports so it can be patched per-test)
  - `models.py` (Beanie `_EventDoc` + `_CalendarDoc` with the three required indexes; underscore-prefixed and never imported outside the module)
  - `events.py` (Pydantic bus event payloads + topic constants)
  - `recurrence.py` (pure dateutil RRULE expansion with exceptions + terminators + a 5000-instance safety cap)
  - `freebusy.py` (single-query availability compute with per-attendee windowing)
  - `conflicts.py` (overlap + shared-attendee detection)
  - `policy.py` (read/write/visibility checks; raise Forbidden on deny)
  - `sync.py` (gcalendar pull/push via `pocketpaw.integrations.gcalendar.CalendarClient`; outlook/icloud raise `NotImplementedError`)
  - `_context.py` (tiny `RequestContext` value object — the cloud module doesn't expose one yet, so this PR mints a private one rather than touching `ee/cloud/`)
  - `__init__.py` (re-exports the router + public domain types; Beanie docs stay private)
- `tests/ee/calendar/` — 5 test files, 34 passing tests covering service, recurrence, freebusy, and router. Service tests stand up an in-memory fake of the Beanie API so the suite stays Mongo-free.

## What this PR does NOT do

- Does not mount the router into the cloud app (`ee/cloud/api/`). Separate PR will wire it in once the design is validated.
- Does not implement Mission Control UI. Separate PR.
- Does not implement Outlook or iCal sync. Placeholder TODOs only; gcalendar adapter is the only working sync.
- Does not add an integration suite under `tests/cloud/`. Pure unit tests for now — the real-Mongo coverage lands when the cloud-app mount happens.

## Convention compliance

Mirrors the canonical ee/cloud shape used by `ee/cloud/pockets/`:

- [x] Domain stays at the boundary (frozen value objects); Beanie docs are private to `models.py`
- [x] Distinct request/response DTOs per operation
- [x] Service functions validate input at entry via `model_validate`
- [x] Every read carries `workspace=ctx.workspace_id` as the tenant filter
- [x] Mapping via Pydantic, not hand-rolled helpers
- [x] Bus emit on every state-changing write (`TOPIC_EVENT_CREATED/UPDATED/DELETED/CONFLICT_DETECTED`)
- [x] Errors via `CloudError` subclasses; router never raises `HTTPException`
- [x] No transactions — events as the cross-domain coupling

The 11-rule "exact mirror" spec from the ticket diverges from the actual ee/cloud codebase in a few places (no `RequestContext`, services are classes with statics, errors live in `shared/` not `_core/`). Where they disagreed, this PR follows what's actually shipping in `ee/cloud/pockets/` and adapts the ticket's file layout. The most consequential divergence: services are module-level `async def`s (per the ticket) rather than the `PocketService` static-method class that pockets uses. Happy to refactor either way once the team picks a canonical shape.

## Test plan

- [x] `uv run ruff check ee/calendar/ tests/ee/calendar/` passes
- [x] `uv run ruff format ee/calendar/ tests/ee/calendar/` clean
- [x] `uv run mypy ee/calendar/` clean (not in pre-commit but ran for safety)
- [x] `uv run pytest tests/ee/calendar/ -v` — 34 tests pass
- [x] `uv run pytest tests/ee/` — 142 tests pass (108 existing + 34 new)
- [ ] Captain + maintainer review