### PR TITLE
Stop blocking workspace-wide sprint overlap

### DIFF
--- a/ee/cloud/cycles/service.py
+++ b/ee/cloud/cycles/service.py
@@ -275,8 +275,17 @@ async def agent_create_cycle(ctx: RequestContext, body: CreateCycleRequest) -> C
     body = CreateCycleRequest.model_validate(body)
     workspace_id = _require_workspace(ctx)
 
-    if body.status == "active" and await _has_active_overlap(
-        workspace_id, body.pocket_id, body.start, body.end
+    # Overlap is a pocket-scoped constraint (one active sprint per pocket
+    # at a time). Workspace-wide cycles (no pocket_id) are allowed to
+    # coexist — operators routinely run multiple workspace-level cycles
+    # in parallel and getting blocked on first-create was the wrong
+    # default. (Local fix 2026-05-19; track follow-up to land formally.)
+    if (
+        body.status == "active"
+        and body.pocket_id is not None
+        and await _has_active_overlap(
+            workspace_id, body.pocket_id, body.start, body.end
+        )
     ):
         raise ConflictError(
             "cycle.overlap",


### PR DESCRIPTION
## What changed

The cycle-create overlap guard now scopes itself to pocket-scoped sprints. Workspace-wide sprints (where ``pocket_id is None``) are allowed to coexist on overlapping dates.

## Why

Operators routinely run multiple workspace-level sprints in parallel — different events, workstreams, or experiments all live at the workspace tier with overlapping date ranges. The original guard collapsed every workspace-wide sprint into a single ``pocket_id=None`` bucket and rejected the second one on create. That broke the Mission Control rail's "+ New sprint" flow on any workspace that already had one running (which is most of them).

The real domain constraint — "one active sprint per pocket at a time" — stays enforced for pocket-scoped sprints.

## Test plan

- [x] Local: created a second workspace-wide sprint with overlapping dates → succeeded (was 409 before)
- [ ] Sprint create with ``pocket_id`` overlapping an existing active sprint on the same pocket → still 409 ``cycle.overlap``

## Notes

The module docstring already flagged this as a "relaxing the rule entirely is tracked as a follow-up if operators push back" thread. The captain pushed back during the rail UX iteration, so closing the thread here.