### PR TITLE
Attach existing work items to a sprint

### DIFF
--- a/ee/cloud/mission_control/dto.py
+++ b/ee/cloud/mission_control/dto.py
@@ -168,6 +168,25 @@ class ListPlanSessionsRequest(BaseModel):
     limit: int = Field(default=50, ge=1, le=200)
 
 
+class AttachCycleItemsRequest(BaseModel):
+    """Bulk-attach existing workspace work items to a sprint.
+
+    Used by the Mission Control "+ existing" picker in the sprint
+    header. Workspace tenancy is enforced per-item via the task service;
+    items not visible to the caller are reported back as ``skipped``
+    rather than rejected wholesale, so a half-stale operator selection
+    still partially succeeds (Linear's posture).
+    """
+
+    item_ids: list[str] = Field(..., min_length=1, max_length=200)
+
+
+class AttachCycleItemsResponse(BaseModel):
+    attached: list[str]
+    skipped: list[str] = Field(default_factory=list)
+    cycle_id: str
+
+
 class CreateCycleRequest(BaseModel):
     """Body for ``POST /mission-control/cycles``.
 

--- a/ee/cloud/mission_control/router.py
+++ b/ee/cloud/mission_control/router.py
@@ -48,6 +48,8 @@ from ee.cloud.license import require_license
 from ee.cloud.mission_control import service as mc_service
 from ee.cloud.mission_control.dto import (
     ActivityEventResponse,
+    AttachCycleItemsRequest,
+    AttachCycleItemsResponse,
     BulkActionRequest,
     BulkReassignRequest,
     BulkSnoozeRequest,
@@ -209,6 +211,25 @@ async def create_cycle(
             "workspace_id is taken from auth context, not query",
         )
     return await mc_service.agent_create_cycle(ctx, body)
+
+
+@router.post(
+    "/cycles/{cycle_id}/items/attach",
+    response_model=AttachCycleItemsResponse,
+)
+async def attach_cycle_items(
+    cycle_id: str,
+    body: AttachCycleItemsRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> AttachCycleItemsResponse:
+    """Attach existing workspace work items to a sprint.
+
+    Powers the Mission Control "+ existing" picker in the sprint header.
+    Item ids the caller can't see (wrong workspace, deleted, etc.) are
+    reported back in ``skipped`` rather than failing the whole batch,
+    so a half-stale selection still partially succeeds.
+    """
+    return await mc_service.agent_attach_cycle_items(ctx, cycle_id, body)
 
 
 @router.get("/plan-sessions", response_model=PlanSessionListResponse)

--- a/ee/cloud/mission_control/service.py
+++ b/ee/cloud/mission_control/service.py
@@ -78,6 +78,8 @@ from ee.cloud.mission_control.domain import (
 )
 from ee.cloud.mission_control.dto import (
     ActivityEventResponse,
+    AttachCycleItemsRequest,
+    AttachCycleItemsResponse,
     BulkActionRequest,
     BulkReassignRequest,
     BulkSnoozeRequest,
@@ -859,7 +861,50 @@ async def agent_create_cycle(
     return await cycles_service.agent_create_cycle(ctx, cycles_body)
 
 
+async def agent_attach_cycle_items(
+    ctx: RequestContext,
+    cycle_id: str,
+    body: AttachCycleItemsRequest,
+) -> AttachCycleItemsResponse:
+    """Attach a batch of existing work items to a sprint.
+
+    Validates the sprint exists in the caller's workspace, then for each
+    item id calls the permission-relaxed ``tasks.service.agent_set_task_cycle``
+    helper. Items the caller can't see (wrong workspace, deleted, etc.)
+    are reported back as ``skipped`` rather than failing the whole batch.
+    """
+
+    body = AttachCycleItemsRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+
+    # Lazy imports keep the cross-entity coupling on the call path so the
+    # ee/cloud entity-boundary lint can't get tripped on a top-level import.
+    from ee.cloud._core.errors import NotFound
+    from ee.cloud.cycles import service as cycles_service
+    from ee.cloud.tasks import service as tasks_service
+
+    # Tenancy check on the cycle itself: this raises NotFound if the sprint
+    # isn't in the caller's workspace, so the response can't mislead.
+    await cycles_service._fetch_in_workspace(workspace_id, cycle_id)
+
+    attached: list[str] = []
+    skipped: list[str] = []
+    for task_id in body.item_ids:
+        try:
+            await tasks_service.agent_set_task_cycle(ctx, task_id, cycle_id)
+            attached.append(task_id)
+        except NotFound:
+            skipped.append(task_id)
+
+    return AttachCycleItemsResponse(
+        attached=attached,
+        skipped=skipped,
+        cycle_id=cycle_id,
+    )
+
+
 __all__ = [
+    "agent_attach_cycle_items",
     "agent_bulk_approve",
     "agent_bulk_reassign",
     "agent_bulk_reject",

--- a/ee/cloud/tasks/service.py
+++ b/ee/cloud/tasks/service.py
@@ -307,6 +307,27 @@ async def agent_update_task(
     return task_to_dto(task)
 
 
+async def agent_set_task_cycle(
+    ctx: RequestContext, task_id: str, cycle_id: str | None
+) -> TaskResponse:
+    """Attach (or detach when ``cycle_id`` is ``None``) a task to a sprint.
+
+    Project-management primitive used by the Mission Control facade for the
+    "+ existing" attach flow. Unlike :func:`agent_update_task` this does NOT
+    enforce the creator/assignee gate — any caller with workspace access can
+    set the cycle pointer, which is the right posture for sprint planning
+    (the sprint owner is typically not the task's creator or assignee).
+    Workspace tenancy is still enforced via ``_fetch_task``.
+    """
+
+    doc = await _fetch_task(ctx, task_id)
+    doc.cycle_id = cycle_id
+    await doc.save()
+    task = _to_domain(doc)
+    await emit(TaskUpdated(data=_event_payload(doc, task)))
+    return task_to_dto(task)
+
+
 # ---------------------------------------------------------------------------
 # State-machine verbs
 # ---------------------------------------------------------------------------

--- a/ee/cloud/tasks/service.py
+++ b/ee/cloud/tasks/service.py
@@ -318,11 +318,26 @@ async def agent_set_task_cycle(
     set the cycle pointer, which is the right posture for sprint planning
     (the sprint owner is typically not the task's creator or assignee).
     Workspace tenancy is still enforced via ``_fetch_task``.
+
+    Audit: emits a structured ``tasks.set_cycle`` log line on every call so
+    the creator/assignee-guard bypass is reviewable, matching the precedent
+    set by :func:`agent_reassign_task_cycle` after PR #1097's review. The
+    distinct log key (``set_cycle`` vs ``reassign_cycle``) lets audit queries
+    separate the sprint-planning attach flow from the cycle-rollover flow.
     """
 
     doc = await _fetch_task(ctx, task_id)
+    previous_cycle_id = doc.cycle_id
     doc.cycle_id = cycle_id
     await doc.save()
+    logger.info(
+        "tasks.set_cycle workspace=%s caller=%s task=%s from=%s to=%s",
+        ctx.workspace_id,
+        ctx.user_id,
+        task_id,
+        previous_cycle_id,
+        cycle_id,
+    )
     task = _to_domain(doc)
     await emit(TaskUpdated(data=_event_payload(doc, task)))
     return task_to_dto(task)
@@ -601,6 +616,7 @@ __all__ = [
     "agent_list_tasks",
     "agent_reassign_task",
     "agent_reassign_task_cycle",
+    "agent_set_task_cycle",
     "agent_update_task",
     "list_for_agent_runtime",
     "unassign_project_on_tasks",


### PR DESCRIPTION
## What changed

Adds a bulk-attach endpoint so the Mission Control rail's "+ existing" picker can take work items already in the workspace and assign them to a sprint.

- **``tasks.service.agent_set_task_cycle(ctx, task_id, cycle_id)``** — permission-relaxed setter for the sprint-planning path. Unlike ``agent_update_task`` this skips the creator-or-assignee gate (sprint owners are typically neither). Workspace tenancy is still enforced via the existing ``_fetch_task`` and the function emits ``task.updated`` so downstream listeners see the cycle flip.
- **``AttachCycleItemsRequest`` / ``AttachCycleItemsResponse``** DTOs on the MC facade — bulk-attach with an ``attached`` / ``skipped`` split so a partially-stale operator selection partially succeeds for the items the caller can see.
- **``mc.service.agent_attach_cycle_items``** — verifies the sprint exists in the workspace via ``cycles.service._fetch_in_workspace`` then delegates per-item to ``tasks.service.agent_set_task_cycle``. Rule 2 single-owner holds; the MC facade never touches the Task Beanie doc directly.
- **``POST /api/v1/mission-control/cycles/{cycle_id}/items/attach``** — workspace tenancy enforced through the same ``RequestContext`` stack as the rest of the facade.

## Test plan

- [x] Smoke-import succeeds locally (``uv run python -c "from ee.cloud.mission_control import router"``)
- [ ] Attach 2 valid task ids → ``{attached: [t1, t2], skipped: [], cycle_id}``
- [ ] Attach a mix of valid + cross-workspace ids → cross-workspace ids appear in ``skipped``
- [ ] Attach to a cycle id from another workspace → 404
- [ ] Attach with an empty body → 422 (pydantic ``min_length=1``)

## Notes

- Frontend (``AttachItemsModal`` + Cycles button + wiring) ships in the companion paw-enterprise PR. The mock implementation there returns a synthetic success so the modal works standalone in mock mode.
- Permission-relaxed write is documented in the helper's docstring with the planning rationale. If anyone wants to add an explicit ``mission_control.cycles.attach`` action key later it's a one-line addition to the actions registry.