### PR TITLE
Post-review cleanups: cycle overlap docstring, AttachCycle DTO doc, lock-in test

### DIFF
--- a/ee/cloud/cycles/service.py
+++ b/ee/cloud/cycles/service.py
@@ -235,11 +235,15 @@ async def _has_active_overlap(
     """Return True if another active cycle on the same pocket overlaps the
     proposed range.
 
-    Decision (v1): we only block overlap on the **same pocket** — workspaces
-    routinely have multiple engagements in flight on different pockets at
-    the same time. Cycles with no ``pocket_id`` collide only with other
-    no-pocket cycles. Relaxing the rule entirely (allow any overlap) is
-    tracked as a follow-up if operators push back.
+    Decision (v1): we only block overlap on the **same pocket** —
+    workspaces routinely have multiple engagements in flight on
+    different pockets at the same time. Workspace-wide cycles (no
+    ``pocket_id``) were originally collapsed into a single
+    ``pocket_id=None`` bucket but as of 2026-05-19 the caller in
+    ``agent_create_cycle`` short-circuits this helper when
+    ``pocket_id is None``, so multiple workspace-wide cycles can run
+    in parallel — operators routinely do that across events,
+    workstreams, and experiments.
     """
     query: dict[str, Any] = {
         "workspace": workspace_id,

--- a/ee/cloud/mission_control/dto.py
+++ b/ee/cloud/mission_control/dto.py
@@ -182,6 +182,17 @@ class AttachCycleItemsRequest(BaseModel):
 
 
 class AttachCycleItemsResponse(BaseModel):
+    """Result of a bulk-attach call.
+
+    Partial success is the explicit posture: every input ``item_id``
+    lands in exactly one of ``attached`` or ``skipped``. ``attached``
+    lists ids that were successfully written to the sprint (cycle_id
+    flipped on the underlying Task). ``skipped`` lists ids the caller
+    couldn't see in their workspace (cross-tenant, deleted, malformed
+    id) — the operation never raises for these, so a partially-stale
+    operator selection still succeeds for the visible subset.
+    """
+
     attached: list[str]
     skipped: list[str] = Field(default_factory=list)
     cycle_id: str

--- a/tests/cloud/test_cycles_service.py
+++ b/tests/cloud/test_cycles_service.py
@@ -138,6 +138,40 @@ async def test_create_allows_overlap_on_different_pockets() -> None:
     assert out.pocket_id == "p2"
 
 
+async def test_create_allows_workspace_wide_overlap() -> None:
+    """Workspace-wide cycles (no ``pocket_id``) are allowed to coexist on
+    overlapping dates. Operators routinely run multiple workspace-level
+    cycles in parallel — different events, workstreams, experiments —
+    all at the workspace tier. Locks in the 2026-05-19 relaxation in
+    ``agent_create_cycle`` so a future refactor can't silently
+    re-collapse the overlap check to ``pocket_id=None``.
+    """
+    ctx = _ctx()
+    first = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="Workspace Cycle A",
+            pocket_id=None,
+            start=date(2026, 5, 1),
+            end=date(2026, 5, 29),
+            status="active",
+        ),
+    )
+    second = await cycles_service.agent_create_cycle(
+        ctx,
+        CreateCycleRequest(
+            name="Workspace Cycle B",
+            pocket_id=None,
+            start=date(2026, 5, 15),
+            end=date(2026, 6, 10),
+            status="active",
+        ),
+    )
+    assert first.pocket_id is None
+    assert second.pocket_id is None
+    assert first.id != second.id
+
+
 async def test_create_requires_workspace() -> None:
     """Routes without an active workspace surface 403 rather than 500."""
     ctx = RequestContext(


### PR DESCRIPTION
## What changed

Three non-blocking NITs from the [#1134](https://github.com/pocketpaw/pocketpaw/pull/1134) and [#1135](https://github.com/pocketpaw/pocketpaw/pull/1135) reviews, bundled into one chore PR.

1. **Stale docstring in `_has_active_overlap`** (`ee/cloud/cycles/service.py`) — the "Relaxing the rule entirely is tracked as a follow-up if operators push back" sentence was the thread that #1134 closed. Replaced with a sentence describing the actual current behavior so the next reader doesn't go looking for an open follow-up that already shipped.

2. **`AttachCycleItemsResponse` docstring** (`ee/cloud/mission_control/dto.py`) — the partial-success `attached` / `skipped` split deserved a docstring explaining why some ids land in `skipped` (cross-tenant, deleted, malformed). A caller skimming the DTO shouldn't have to dig into the service to figure that out.

3. **New `test_create_allows_workspace_wide_overlap`** (`tests/cloud/test_cycles_service.py`) — locks in #1134's relaxation. Asserts two workspace-wide cycles (`pocket_id=None`) with overlapping dates both succeed. Catches any future refactor that silently re-collapses the overlap check.

## Test plan

- [x] `uv run pytest tests/cloud/test_cycles_service.py::test_create_allows_workspace_wide_overlap tests/cloud/test_cycles_service.py::test_create_rejects_overlap_on_same_pocket tests/cloud/test_cycles_service.py::test_create_allows_overlap_on_different_pockets -x` — 3/3 pass

## Notes

Companion frontend NIT (button label double-space when `selected.size === 0`) ships separately in a paw-enterprise PR.