### PR TITLE
docs(claude.md): align ee/cloud rules with actual pockets canonical

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,9 +196,11 @@ uses different patterns; these rules don't apply there.
 
 5. **Service signature.**
    ```python
-   async def op(ctx: RequestContext, body: <RequestSchema>) -> <ResponseSchema>:
+   async def op(workspace_id: str, user_id: str, body: <RequestSchema>) -> dict:
    ```
-   Module-level `async def`, not a class. Multi-tenancy via `ctx.workspace_id` — never accept `workspace_id` as a separate parameter.
+   Module-level `async def`, not a class. Multi-tenancy via the explicit `workspace_id` parameter. `user_id` carries the viewer context for permission checks. Public APIs return wire dicts (`dict`) for legacy router compatibility — see `pockets/service.py` for the canonical shape, including the `_resolved_wire_dict` helper that produces the wire dict from a Beanie doc.
+
+   *Note: a future migration may move toward a `RequestContext` value object that bundles `(workspace_id, user_id, viewer_metadata)`. New modules that anticipate this can mint a private `_context.py:RequestContext` (see `ee/calendar/_context.py` in PR #1132 for an example), but the mainline pattern remains the explicit parameter pair until pockets migrates.*
 
 6. **Validate at entry.** First line of every service function: `body = <RequestSchema>.model_validate(body)`. FastAPI parses HTTP bodies; services re-parse for internal callers (bus handlers, MCP tools, CLI, jobs).
 
@@ -208,7 +210,7 @@ uses different patterns; these rules don't apply there.
 
 9. **Emit on every write.** State-mutating service functions end with `await emit(<Event>(data=...))` — or have an explicit `# no-event: <reason>` comment on the line before return. Silent mutations desync downstream handlers (search index, soul memory, ripple invalidation).
 
-10. **Errors via CloudError.** Use `_core.errors` subclasses (`NotFound`, `Forbidden`, `Conflict`, etc.). Never `raise HTTPException` in services or routers — `_core.http` maps `CloudError` to JSON.
+10. **Errors via CloudError.** Use `_core.errors` subclasses (`NotFound`, `Forbidden`, `Conflict`, `ValidationError`, etc.). The canonical location is `ee/cloud/_core/errors.py`; `ee/cloud/shared/errors.py` is a transitional re-export shim from the 2026-04-27 cloud-restructure that remains for backwards compatibility. **New code should import from `ee.cloud._core.errors` directly.** Some existing modules (including `pockets/service.py`) still import via the shared shim; that's tracked for touch-time migration. Never `raise HTTPException` in services or routers — `_core.http` maps `CloudError` to JSON.
 
 11. **Prefer events over transactions.** Only money, identity, and permission flows reach for `session.start_transaction()`.
 


### PR DESCRIPTION
## Summary

Fixes #1133. Re-aligns `pocketpaw/CLAUDE.md` ee/cloud rules 5 + 10 with what `ee/cloud/pockets/` actually does. The doc itself says pockets is the canonical reference, so the doc rules should match pockets, not the other way around.

## Base branch note

The ticket asked for `dev` as the base, but the `## ee/cloud Code Rules` section doesn't exist on `dev` yet — it landed via `7aeda84f` on the `ee` integration branch and hasn't merged down to `dev`. I based this PR on `ee` so the surgical edits land where the section actually lives. If the captain wants this on `dev`, the rules section itself needs to land in `dev` first (probably via the ee→dev integration flow), then this PR can rebase/retarget.

## Verified drift (corrected after manual ground-truth check)

The original Stream C report claimed four drifts. Only two were real, plus one missed.

**Real drifts (this PR fixes):**
- Rule 5: doc said `async def op(ctx: RequestContext, body) -> <ResponseSchema>`; actual pockets uses `(workspace_id, user_id, body) -> dict`
- Rule 10: doc didn't mention the `_core/errors.py` vs `shared/errors.py` transition (canonical is `_core`; `shared` is a shim)

**Stream C false alarms (no change needed):**
- "Module-level vs class methods" — code is module-level, matching doc
- "event_bus.emit(string, dict)" — code is `await emit(<Event>(data=...))`, matching doc

## Forward-looking note

The PR adds a paragraph to rule 5 acknowledging a possible future migration toward a `RequestContext` value object (Calendar PR #1132 minted a private `_context.py:RequestContext` as an experiment). The mainline canonical remains the explicit parameter pair until pockets migrates.

## Test plan
- [x] Markdown renders cleanly
- [x] All 11 rules present, touch-time migration sub-section unchanged
- [x] Refs to pockets/service.py + Calendar #1132 are accurate
- [ ] Captain review