### PR TITLE
feat(calendar): mount ee/calendar/router into cloud app (#1137 part 1)

### DIFF
--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -294,6 +294,12 @@ def mount_cloud(app: FastAPI) -> None:
     # reach /api/v1/paw-print/* without a second app setup entry point.
     app.include_router(paw_print_router, prefix="/api/v1")
 
+    # Calendar router declares its own full prefix (/api/v1/calendar) so it
+    # is mounted without an additional prefix here. See ee/calendar/router.py.
+    from ee.calendar import router as calendar_router
+
+    app.include_router(calendar_router)
+
     # User search endpoint — used by group settings, pocket sharing
     from ee.cloud.models.user import User as UserModel
     from ee.cloud.shared.deps import (

--- a/tests/ee/calendar/test_router_mount.py
+++ b/tests/ee/calendar/test_router_mount.py
@@ -1,0 +1,133 @@
+# tests/ee/calendar/test_router_mount.py — Calendar router mount smoke test.
+# Created: 2026-05-19 (feat/calendar-router-mount).
+#
+# Verifies that mount_cloud() wires the calendar router into the cloud app
+# so /api/v1/calendar/* endpoints are reachable. The companion file
+# test_router.py already exercises the route handlers in isolation; this
+# file's job is to prove the wiring: that mount_cloud() registers the
+# right paths and that requests to those paths don't 404.
+#
+# We deliberately mock the service-layer entry points so the test never
+# touches Mongo. A 422 (validation failure) or 401 (auth failure) on a
+# route is sufficient evidence that the route IS mounted — only a 404 on
+# the path would indicate the mount didn't happen.
+
+from __future__ import annotations
+
+import importlib
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from ee.calendar.dto import EventListResponse, EventResponse
+from ee.cloud import mount_cloud
+from ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+# Use importlib to grab the module, not the re-exported APIRouter. Mirrors
+# the same trick in tests/ee/calendar/test_router.py.
+_router_module = importlib.import_module("ee.calendar.router")
+
+
+def _get_route_paths(app: FastAPI) -> list[str]:
+    """Extract all route paths from a FastAPI app."""
+    paths = []
+    for route in app.routes:
+        if hasattr(route, "path"):
+            paths.append(route.path)
+    return paths
+
+
+def _make_event_response() -> EventResponse:
+    return EventResponse(
+        id="evt-1",
+        workspace_id="ws-test",
+        calendar_id="cal-1",
+        title="Smoke",
+        description="",
+        starts_at=datetime(2026, 5, 19, 9, 0),
+        ends_at=datetime(2026, 5, 19, 10, 0),
+        timezone="UTC",
+        location=None,
+        attendees=[],
+        recurrence=None,
+        fabric_object_id=None,
+        source_connector=None,
+        source_external_id=None,
+        created_at=datetime(2026, 5, 1),
+        updated_at=datetime(2026, 5, 1),
+    )
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """Build a cloud app with all routers mounted, then override calendar deps."""
+    instance = FastAPI()
+    mount_cloud(instance)
+
+    async def _ws() -> str:
+        return "ws-test"
+
+    async def _user() -> str:
+        return "user-test"
+
+    instance.dependency_overrides[current_workspace_id] = _ws
+    instance.dependency_overrides[current_user_id] = _user
+    return instance
+
+
+def test_calendar_routes_mounted_on_cloud_app(app: FastAPI) -> None:
+    """mount_cloud() should register the calendar router's paths."""
+    paths = _get_route_paths(app)
+    calendar_paths = [p for p in paths if "/calendar" in p]
+    assert calendar_paths, (
+        "Expected /api/v1/calendar/* paths after mount_cloud(); got none. "
+        "Calendar router import / include_router probably failed."
+    )
+    # Spot-check the canonical event paths.
+    assert "/api/v1/calendar/events" in paths
+    assert "/api/v1/calendar/events/{event_id}" in paths
+    assert "/api/v1/calendar/freebusy" in paths
+
+
+def test_post_events_routes_through_mount(app: FastAPI, monkeypatch) -> None:
+    """POST /api/v1/calendar/events resolves through the cloud app — not 404."""
+    mock_create = AsyncMock(return_value=_make_event_response())
+    monkeypatch.setattr(_router_module, "svc_create_event", mock_create)
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/calendar/events",
+        json={
+            "calendar_id": "cal-1",
+            "title": "Smoke",
+            "starts_at": "2026-05-19T09:00:00",
+            "ends_at": "2026-05-19T10:00:00",
+            "timezone": "UTC",
+        },
+    )
+    # Route exists and handler ran (201). A 404 here would mean the mount
+    # didn't happen.
+    assert response.status_code != 404, f"Calendar POST not mounted: {response.text}"
+    assert response.status_code == 201, response.text
+    mock_create.assert_awaited_once()
+
+
+def test_get_events_routes_through_mount(app: FastAPI, monkeypatch) -> None:
+    """GET /api/v1/calendar/events resolves through the cloud app — not 404."""
+    mock_list = AsyncMock(return_value=EventListResponse(events=[], total=0))
+    monkeypatch.setattr(_router_module, "svc_list_events", mock_list)
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/calendar/events",
+        params={
+            "starts_after": "2026-05-19T00:00:00",
+            "starts_before": "2026-05-20T00:00:00",
+        },
+    )
+    assert response.status_code != 404, f"Calendar GET not mounted: {response.text}"
+    assert response.status_code == 200, response.text
+    assert response.json() == {"events": [], "total": 0}


### PR DESCRIPTION
## Summary

Mounts `ee/calendar/router` into the cloud app's URL surface. The calendar router was deliberately left unmounted in #1132; this is the follow-up to make `/api/v1/calendar/*` endpoints live.

## Stack

Stacks on **#1132** (the calendar module PR). Merge order: #1132 → this. When #1132 merges, this PR's diff narrows to just the mount change.

Part of #1137 — paw-enterprise USE_MOCK flag flip is the other half (separate PR in paw-enterprise).

## What this PR adds

- Mounts `calendar_router` in the cloud app's main FastAPI app
- Re-exports the router from `ee/calendar/__init__.py` if not already
- Smoke test verifying the routes are reachable

## Test plan
- [x] `uv run ruff check` passes on touched files
- [x] `uv run pytest tests/ee/calendar/ -v` — all green
- [x] Smoke check: cloud app boots and `/api/v1/calendar/*` paths appear in the route table
- [ ] Captain + maintainer review