### PR TITLE
fix(calendar): wire policy + restrict freebusy + handle date parsing (#1142)

### DIFF
--- a/ee/calendar/conflicts.py
+++ b/ee/calendar/conflicts.py
@@ -1,5 +1,10 @@
 # Calendar module — conflict detection.
-# Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H-NEW-1).
+#
+# Changes:
+# - _doc_to_event now propagates created_by_user_id from the Beanie doc
+#   into the domain Event. Required for policy.check_event_modify on
+#   update/delete paths.
 #
 # Finds other events in the same workspace that overlap a given event's
 # window and share at least one attendee. Excludes the event itself.
@@ -24,6 +29,10 @@ def _doc_to_event(doc: _EventDoc) -> Event:
         starts_at=doc.starts_at,
         ends_at=doc.ends_at,
         timezone=doc.timezone,
+        # H-NEW-1: hydrate the creator field so check_event_modify works
+        # on Events returned by conflict scans (and any other domain
+        # transit through this helper).
+        created_by_user_id=doc.created_by_user_id,
         location=doc.location,
         attendees=attendees,
         recurrence=recurrence,

--- a/ee/calendar/domain.py
+++ b/ee/calendar/domain.py
@@ -1,5 +1,5 @@
 # Calendar module — domain value objects.
-# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 M1-M3).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 M1-M3 + H-NEW-1).
 #
 # Changes:
 # - Attendee.email now uses EmailStr (M3) — Pydantic's email-validator
@@ -9,6 +9,10 @@
 #   pathological RRULE strings that could choke recurrence expansion.
 # - Recurrence.exceptions capped at 500 entries (M2) — guards against
 #   unbounded growth that would slow down conflict detection.
+# - H-NEW-1: Event now requires created_by_user_id (no default). The
+#   service sets it from ctx.user_id on create_event. policy.
+#   check_event_modify gates update/delete on creator-equality so a
+#   synthetic-default Calendar doesn't grant cross-user modify access.
 #
 # Frozen Pydantic models representing the public calendar domain.
 # workspace_id is required on Event and Calendar — enforced at construction
@@ -104,6 +108,13 @@ class Event(BaseModel):
     starts_at: datetime
     ends_at: datetime
     timezone: str  # IANA timezone string, e.g. "America/Los_Angeles"
+    created_by_user_id: str = Field(
+        ...,
+        description=(
+            "User who created this event. Used by policy.check_event_modify "
+            "to gate update/delete authz on synthetic-default calendars."
+        ),
+    )
     description: str = ""
     location: str | None = None
     attendees: list[Attendee] = Field(default_factory=list)

--- a/ee/calendar/domain.py
+++ b/ee/calendar/domain.py
@@ -1,5 +1,14 @@
 # Calendar module — domain value objects.
-# Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 M1-M3).
+#
+# Changes:
+# - Attendee.email now uses EmailStr (M3) — Pydantic's email-validator
+#   integration. Rejects malformed emails at the boundary instead of
+#   propagating them into the DB.
+# - Recurrence.rrule capped at 2048 chars (M1) — guards against
+#   pathological RRULE strings that could choke recurrence expansion.
+# - Recurrence.exceptions capped at 500 entries (M2) — guards against
+#   unbounded growth that would slow down conflict detection.
 #
 # Frozen Pydantic models representing the public calendar domain.
 # workspace_id is required on Event and Calendar — enforced at construction
@@ -11,7 +20,7 @@ from __future__ import annotations
 from datetime import datetime
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -48,7 +57,7 @@ class Attendee(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    email: str
+    email: EmailStr
     user_id: str | None = None
     name: str | None = None
     response: AttendeeResponse = AttendeeResponse.NEEDS_ACTION
@@ -61,12 +70,17 @@ class Recurrence(BaseModel):
     The master Event carries the rrule string; expansion happens at read time
     in recurrence.expand_recurrence(). Either `until` or `count` may be set;
     `rrule` may also encode its own terminator.
+
+    Length caps:
+      - rrule limited to 2048 chars (well above realistic RFC 5545 rules).
+      - exceptions limited to 500 entries (caps memory + conflict-detection
+        work for pathological inputs).
     """
 
     model_config = ConfigDict(frozen=True)
 
-    rrule: str
-    exceptions: list[datetime] = Field(default_factory=list)
+    rrule: str = Field(min_length=1, max_length=2048)
+    exceptions: list[datetime] = Field(default_factory=list, max_length=500)
     until: datetime | None = None
     count: int | None = None
 

--- a/ee/calendar/dto.py
+++ b/ee/calendar/dto.py
@@ -1,5 +1,12 @@
 # Calendar module — request/response DTOs.
-# Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H-NEW-1).
+#
+# Changes:
+# - H-NEW-1: EventResponse now exposes created_by_user_id so the
+#   frontend can render "created by X" badges and gate Edit/Delete
+#   buttons on the client. CreateEventRequest deliberately omits it —
+#   the server fills it from ctx.user_id; never trust the client to
+#   self-attest the creator.
 #
 # Distinct request and response classes per operation. Requests are
 # minimal (no workspace_id — that comes from the auth context). Responses
@@ -115,6 +122,10 @@ class EventResponse(BaseModel):
     starts_at: datetime
     ends_at: datetime
     timezone: str
+    # H-NEW-1: surfaced to the client so the UI can render "created by X"
+    # and decide whether to show Edit/Delete affordances. The server is
+    # the source of truth; never accept this from the client on writes.
+    created_by_user_id: str
     location: str | None
     attendees: list[Attendee]
     recurrence: Recurrence | None

--- a/ee/calendar/freebusy.py
+++ b/ee/calendar/freebusy.py
@@ -1,5 +1,18 @@
 # Calendar module — free/busy availability computation.
-# Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H2).
+#
+# Changes (H2 — close the availability-oracle):
+# - compute_freebusy now accepts ``accessible_calendar_ids``: an optional
+#   set restricting which calendars contribute to the returned busy
+#   periods. Callers that have already verified the requester can read
+#   those calendars pass the resolved set; events on calendars outside
+#   the set are silently dropped from the result rather than appearing
+#   as a busy block. None preserves the legacy behaviour for callers
+#   that aren't ready to enforce yet.
+# - The function itself doesn't validate the attendee list — the service
+#   layer is the chokepoint for the "is this email known on a calendar
+#   I can see?" pre-validation (raises ValidationError before we get
+#   here).
 #
 # Given a workspace, a list of attendee emails, and a window, returns the
 # union of busy periods for each attendee. Single Mongo query with $in on
@@ -18,8 +31,16 @@ async def compute_freebusy(
     attendee_emails: list[str],
     starts_at: datetime,
     ends_at: datetime,
+    accessible_calendar_ids: set[str] | None = None,
 ) -> list[FreeBusy]:
     """Return per-attendee busy periods within [starts_at, ends_at).
+
+    ``accessible_calendar_ids`` (H2): when provided, only events whose
+    ``calendar_id`` is in the set contribute to the returned busy
+    periods. This closes the availability oracle — a requester only
+    sees busy blocks for calendars they could already read directly.
+    ``None`` keeps the legacy behaviour (return everything in the
+    workspace) and is reserved for trusted internal callers.
 
     Recurring events: this implementation queries the master rows only,
     which means recurring instances inside the window will appear as a
@@ -52,6 +73,12 @@ async def compute_freebusy(
     }
 
     for doc in overlapping:
+        # H2: skip events on calendars the caller can't read.
+        if (
+            accessible_calendar_ids is not None
+            and getattr(doc, "calendar_id", None) not in accessible_calendar_ids
+        ):
+            continue
         # Clip to window so callers don't see periods outside what they asked for.
         clipped_start = max(doc.starts_at, starts_at)
         clipped_end = min(doc.ends_at, ends_at)

--- a/ee/calendar/models.py
+++ b/ee/calendar/models.py
@@ -1,5 +1,11 @@
 # Calendar module — Beanie document models.
-# Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H-NEW-1).
+#
+# Changes:
+# - H-NEW-1: _EventDoc now persists created_by_user_id (no default). The
+#   service writes ctx.user_id on insert; policy.check_event_modify reads
+#   it on update/delete to gate authz on the synthetic-default calendar
+#   path.
 #
 # Internal-only — never imported outside ee/calendar/. The single rule:
 # nothing outside this module talks to the database. Callers go through
@@ -73,6 +79,11 @@ class _EventDoc(Document):
     starts_at: datetime
     ends_at: datetime
     timezone: str
+    # H-NEW-1: required for event-level modify authz. Set from ctx.user_id
+    # on insert. No default — old docs predating the field will surface as
+    # a Pydantic validation error on read, which is the right behaviour
+    # since H-NEW-1 shipped before any production data was written.
+    created_by_user_id: str
     location: str | None = None
     attendees: list[dict[str, Any]] = Field(default_factory=list)
     recurrence: dict[str, Any] | None = None
@@ -94,4 +105,8 @@ class _EventDoc(Document):
             ),
             IndexModel([("workspace", ASCENDING), ("starts_at", ASCENDING)]),
             IndexModel([("source_connector", ASCENDING), ("source_external_id", ASCENDING)]),
+            # H-NEW-1: support cheap "events I created" filters (future:
+            # personal-view, modify-allowlist UI). Composite with workspace
+            # to honour the tenant filter rule.
+            IndexModel([("workspace", ASCENDING), ("created_by_user_id", ASCENDING)]),
         ]

--- a/ee/calendar/policy.py
+++ b/ee/calendar/policy.py
@@ -1,10 +1,21 @@
 # Calendar module — access policy checks.
-# Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H1).
 #
-# Read/write gates expressed as raise-on-deny helpers (matches the
+# Changes:
+# - Read/write gates now reused by service.py on every CRUD path. The
+#   functions were previously defined but never called — H1 of the
+#   #1132 audit. The semantics here are unchanged, but the doc clarifies
+#   the contract callers see (owner OR explicit share OR public read).
+# - Added check_calendar_freebusy as an explicit predicate (returns bool,
+#   no raise) so service.compute_freebusy can filter events without
+#   per-call try/except.
+# - Workspace-admin override is intentionally out of scope: there is no
+#   workspace-role plumbing yet in ee/calendar. Tracked as a follow-up.
+#
+# Read/write gates are expressed as raise-on-deny helpers (matches the
 # ee/cloud convention: services call check_*, the function raises
 # Forbidden, or it returns None). Visibility check is a predicate so
-# service.py can use it in list filters without try/except.
+# callers can use it in list filters without try/except.
 
 from __future__ import annotations
 
@@ -14,7 +25,17 @@ from ee.cloud.shared.errors import Forbidden
 
 
 def check_calendar_read(ctx: RequestContext, calendar: Calendar) -> None:
-    """Raise Forbidden if the caller can't read this calendar."""
+    """Raise Forbidden if the caller can't read this calendar.
+
+    Read access is granted when ANY of the following is true:
+      1. The calendar's workspace matches the caller's workspace AND
+      2a. The caller is the calendar owner, OR
+      2b. The calendar is workspace-public, OR
+      2c. The caller is in ``shared_with_user_ids``.
+
+    Otherwise Forbidden is raised. Different-workspace lookups always
+    fail closed — this is the tenant boundary.
+    """
     # Hard tenant boundary — never let a different-workspace caller read at all.
     if calendar.workspace_id != ctx.workspace_id:
         raise Forbidden(
@@ -41,7 +62,7 @@ def check_calendar_write(ctx: RequestContext, calendar: Calendar) -> None:
 
     Stricter than read — only the owner or an explicitly-shared user can
     write. Workspace-public calendars are read-only by default; promote a
-    user to shared_with_user_ids to grant write.
+    user to ``shared_with_user_ids`` to grant write.
     """
     if calendar.workspace_id != ctx.workspace_id:
         raise Forbidden(
@@ -59,6 +80,17 @@ def check_calendar_write(ctx: RequestContext, calendar: Calendar) -> None:
         "calendar.access_denied",
         "You do not have write access to this calendar",
     )
+
+
+def can_read_calendar(ctx: RequestContext, calendar: Calendar) -> bool:
+    """Predicate form of check_calendar_read. Use in list filters and the
+    freebusy attendee-access check, where a False answer means "skip" not
+    "abort"."""
+    try:
+        check_calendar_read(ctx, calendar)
+    except Forbidden:
+        return False
+    return True
 
 
 def check_event_visibility(ctx: RequestContext, event: Event) -> bool:

--- a/ee/calendar/policy.py
+++ b/ee/calendar/policy.py
@@ -1,5 +1,5 @@
 # Calendar module — access policy checks.
-# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H1).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H1 + H-NEW-1).
 #
 # Changes:
 # - Read/write gates now reused by service.py on every CRUD path. The
@@ -9,8 +9,20 @@
 # - Added check_calendar_freebusy as an explicit predicate (returns bool,
 #   no raise) so service.compute_freebusy can filter events without
 #   per-call try/except.
+# - H-NEW-1: added check_event_modify(ctx, event). The synthetic-default
+#   Calendar that _load_calendar falls back to (until Calendar CRUD ships)
+#   sets owner_user_id = ctx.user_id, which makes check_calendar_write
+#   pass for every workspace member. That re-opens the original H1 hole
+#   on update_event / delete_event: any workspace member could mutate any
+#   other member's event when the parent Calendar row didn't exist yet.
+#   The new gate requires event.created_by_user_id == ctx.user_id (or, in
+#   a follow-up, the caller being a workspace admin) before update/delete
+#   proceeds. create_event keeps using check_calendar_write only — there
+#   is no existing event ownership for it to bypass.
 # - Workspace-admin override is intentionally out of scope: there is no
-#   workspace-role plumbing yet in ee/calendar. Tracked as a follow-up.
+#   workspace-role plumbing yet in ee/calendar's RequestContext. Tracked
+#   as a follow-up so the new check_event_modify carries an explicit TODO
+#   rather than silently denying every admin caller forever.
 #
 # Read/write gates are expressed as raise-on-deny helpers (matches the
 # ee/cloud convention: services call check_*, the function raises
@@ -102,3 +114,59 @@ def check_event_visibility(ctx: RequestContext, event: Event) -> bool:
     fetches.
     """
     return event.workspace_id == ctx.workspace_id
+
+
+def check_event_modify(ctx: RequestContext, event: Event) -> None:
+    """Raise Forbidden if the caller can't modify this specific event.
+
+    This is the event-level companion to check_calendar_write. It exists
+    to close H-NEW-1: while check_calendar_write decides who can write
+    anywhere on a calendar, this decides who can edit a particular event
+    once it exists. The combination matters because service._load_calendar
+    falls back to a synthetic default Calendar (owner = caller) when no
+    backing _CalendarDoc row exists yet, which makes check_calendar_write
+    a no-op for the synthetic-default path. update_event and delete_event
+    therefore call BOTH check_calendar_write AND this function — the
+    second one prevents one workspace member from mutating another
+    member's events on a synthetic calendar.
+
+    Modify access is granted when ANY of the following is true:
+      1. The caller is the event's creator
+         (``event.created_by_user_id == ctx.user_id``), OR
+      2. The caller is a workspace admin (TODO — admin path not yet
+         plumbed through RequestContext; see comment below).
+
+    Otherwise Forbidden is raised. The tenant boundary is assumed to be
+    enforced upstream (by ``_get_event_doc_or_404``'s tenant filter), so
+    we don't re-check ``event.workspace_id`` here — but a defensive guard
+    catches the case where a caller hand-builds an Event from another
+    workspace.
+    """
+    # Defensive tenant guard. _get_event_doc_or_404 already filters on
+    # workspace, but if a caller constructs an Event directly (tests, future
+    # callers) this still fails closed.
+    if event.workspace_id != ctx.workspace_id:
+        raise Forbidden(
+            "event.modify_denied",
+            "Event belongs to a different workspace",
+        )
+
+    if event.created_by_user_id == ctx.user_id:
+        return
+
+    # TODO(h-new-1-admin): workspace-admin override. The cloud's
+    # auth/domain.py models workspace membership with role ∈ {owner,
+    # admin, member, viewer}, but RequestContext in ee/calendar only
+    # carries (workspace_id, user_id) today. Wiring the role through
+    # requires either (a) extending RequestContext with a role/permissions
+    # field populated by the router's _ctx dep, or (b) a one-shot lookup
+    # against the workspace membership store from within this function.
+    # Option (b) keeps the change local to ee/calendar but adds a DB
+    # round-trip per modify call; option (a) is cleaner but touches the
+    # router + every test that builds a RequestContext. Tracked separately
+    # so this H-NEW-1 fix doesn't block on the broader RBAC plumbing.
+
+    raise Forbidden(
+        "event.modify_denied",
+        "Only the event creator can modify or delete this event",
+    )

--- a/ee/calendar/router.py
+++ b/ee/calendar/router.py
@@ -1,15 +1,21 @@
 # Calendar module — FastAPI router.
-# Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H3).
+#
+# Changes (H3):
+# - ``list_events`` now declares ``starts_after`` and ``starts_before`` as
+#   ``datetime`` query parameters directly. FastAPI parses them via
+#   Pydantic and returns a 422 on malformed input. Previously we received
+#   raw ``str`` and called ``datetime.fromisoformat`` unguarded, which
+#   bubbled a ``ValueError`` into the global handler as HTTP 500.
 #
 # Thin wrappers around service.py. No business logic here. The router is
 # the single mounting point — callers outside this module never touch
 # service.py directly. Errors raised by service propagate to the global
 # CloudError handler installed by ee.cloud (we never raise HTTPException).
-#
-# This PR does NOT mount the router into the cloud app. A separate PR will
-# wire it in (so we can roll out behind a feature flag).
 
 from __future__ import annotations
+
+from datetime import datetime
 
 from fastapi import APIRouter, Depends
 from starlette.responses import Response
@@ -74,18 +80,19 @@ async def create_event(
 
 @router.get("/events", response_model=EventListResponse)
 async def list_events(
-    starts_after: str,
-    starts_before: str,
+    starts_after: datetime,
+    starts_before: datetime,
     calendar_id: str | None = None,
     limit: int = 100,
     ctx: RequestContext = Depends(_ctx),
 ) -> EventListResponse:
-    from datetime import datetime
-
+    # H3: starts_after / starts_before are now declared as datetime — FastAPI
+    # parses them via Pydantic and returns 422 on malformed input. No more
+    # try/except around datetime.fromisoformat.
     body = ListEventsRequest(
         calendar_id=calendar_id,
-        starts_after=datetime.fromisoformat(starts_after),
-        starts_before=datetime.fromisoformat(starts_before),
+        starts_after=starts_after,
+        starts_before=starts_before,
         limit=limit,
     )
     return await svc_list_events(ctx, body)

--- a/ee/calendar/service.py
+++ b/ee/calendar/service.py
@@ -1,5 +1,5 @@
 # Calendar module — service layer (module-level async functions).
-# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H1/H2/M4).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H1/H2/M4 + H-NEW-1).
 #
 # Changes:
 # - H1: Every CRUD path now resolves the parent Calendar and invokes
@@ -14,6 +14,14 @@
 #   ``location``/``starts_at``/``ends_at`` content into the
 #   ``CalendarEventUpdated`` bus payload. Bus subscribers receive a
 #   ``changed_fields`` list (field names only) instead.
+# - H-NEW-1: ``create_event`` now stamps ``created_by_user_id`` from
+#   ``ctx.user_id`` on the new ``_EventDoc``. ``update_event`` and
+#   ``delete_event`` call ``policy.check_event_modify(ctx, event)`` after
+#   ``check_calendar_write`` so the synthetic-default Calendar path (used
+#   until Calendar CRUD ships) can't be exploited to mutate other
+#   members' events. ``_doc_to_event`` (in conflicts.py) propagates the
+#   field into the domain Event so the modify check has the data it
+#   needs.
 # - Helper ``_load_calendar`` falls back to a synthesized default
 #   Calendar when no ``_CalendarDoc`` row exists yet. The Calendar CRUD
 #   surface ships in a follow-up; until then policy still enforces the
@@ -198,6 +206,9 @@ async def create_event(ctx: RequestContext, body: CreateEventRequest) -> EventRe
         starts_at=body.starts_at,
         ends_at=body.ends_at,
         timezone=body.timezone,
+        # H-NEW-1: stamp the creator from the request context. Never accept
+        # this from the client — the DTO doesn't expose it for that reason.
+        created_by_user_id=ctx.user_id,
         location=body.location,
         attendees=[a.model_dump() for a in body.attendees],
         recurrence=body.recurrence.model_dump() if body.recurrence else None,
@@ -241,6 +252,13 @@ async def update_event(
     # H1: enforce write access on the event's calendar.
     calendar = await _load_calendar(ctx, doc.calendar_id)
     policy.check_calendar_write(ctx, calendar)
+
+    # H-NEW-1: calendar-level write isn't enough on a synthetic-default
+    # Calendar, where check_calendar_write trivially passes for every
+    # workspace member (because the synthetic owner = ctx.user_id). The
+    # event-level gate ensures only the creator (or, later, a workspace
+    # admin) can edit an existing event.
+    policy.check_event_modify(ctx, _doc_to_event(doc))
 
     # M4: track only the names of fields that changed, NOT the values.
     # Bus subscribers (notifications, search reindex, soul memory) only
@@ -307,6 +325,11 @@ async def delete_event(ctx: RequestContext, event_id: str) -> None:
     # H1: enforce write access before deletion.
     calendar = await _load_calendar(ctx, doc.calendar_id)
     policy.check_calendar_write(ctx, calendar)
+
+    # H-NEW-1: same rationale as update_event — calendar-level write
+    # passes trivially on a synthetic-default Calendar, so we add the
+    # event-level creator gate before destroying the row.
+    policy.check_event_modify(ctx, _doc_to_event(doc))
 
     event_id_str = str(doc.id)
     calendar_id = doc.calendar_id

--- a/ee/calendar/service.py
+++ b/ee/calendar/service.py
@@ -1,5 +1,25 @@
 # Calendar module — service layer (module-level async functions).
-# Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H1/H2/M4).
+#
+# Changes:
+# - H1: Every CRUD path now resolves the parent Calendar and invokes
+#   ``policy.check_calendar_read`` / ``policy.check_calendar_write`` before
+#   touching the event. The policy module was previously dead code; this
+#   wires it as the authz chokepoint.
+# - H2: ``get_freebusy`` pre-validates the requested attendee list and
+#   passes ``accessible_calendar_ids`` into ``compute_freebusy`` so the
+#   result only contains busy windows the caller could read directly.
+#   Unknown attendees → ``ValidationError`` (was: silent oracle).
+# - M4: ``update_event`` no longer puts raw ``title``/``description``/
+#   ``location``/``starts_at``/``ends_at`` content into the
+#   ``CalendarEventUpdated`` bus payload. Bus subscribers receive a
+#   ``changed_fields`` list (field names only) instead.
+# - Helper ``_load_calendar`` falls back to a synthesized default
+#   Calendar when no ``_CalendarDoc`` row exists yet. The Calendar CRUD
+#   surface ships in a follow-up; until then policy still enforces the
+#   tenant boundary and lets the event creator (= caller's workspace)
+#   proceed by default. Override the default by inserting a
+#   ``_CalendarDoc`` with the desired ``visibility``/``owner_user_id``.
 #
 # All write paths through here. _EventDoc / _CalendarDoc are never
 # imported outside this file. Every function:
@@ -14,12 +34,14 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
+from typing import Any
 
 from beanie import PydanticObjectId
 
+from ee.calendar import policy
 from ee.calendar._context import RequestContext
 from ee.calendar.conflicts import _doc_to_event, find_conflicts
-from ee.calendar.domain import ConflictSeverity, Event
+from ee.calendar.domain import Calendar, CalendarVisibility, ConflictSeverity, Event
 from ee.calendar.dto import (
     ConflictReport,
     CreateEventRequest,
@@ -41,7 +63,7 @@ from ee.calendar.events import (
     ConflictDetected,
 )
 from ee.calendar.freebusy import compute_freebusy
-from ee.calendar.models import _EventDoc
+from ee.calendar.models import _CalendarDoc, _EventDoc
 from ee.cloud.shared.errors import NotFound, ValidationError
 from ee.cloud.shared.events import event_bus
 
@@ -60,6 +82,77 @@ def _event_to_response(event: Event) -> EventResponse:
 
 def _doc_to_response(doc: _EventDoc) -> EventResponse:
     return _event_to_response(_doc_to_event(doc))
+
+
+def _doc_to_calendar(doc: _CalendarDoc) -> Calendar:
+    """Map a Beanie ``_CalendarDoc`` to a domain ``Calendar``.
+
+    The DB schema uses string-typed visibility; coerce to the StrEnum so
+    policy can pattern-match on the enum value rather than a raw string.
+    """
+    try:
+        vis = CalendarVisibility(doc.visibility)
+    except ValueError:
+        # Defensive fallback — should never happen for rows written by this
+        # service, but a hand-edit could put a garbage string in. Treat as
+        # the most restrictive option.
+        vis = CalendarVisibility.PRIVATE
+    return Calendar(
+        id=str(doc.id),
+        workspace_id=doc.workspace,
+        name=doc.name,
+        owner_user_id=doc.owner_user_id,
+        timezone=doc.timezone,
+        color=doc.color,
+        visibility=vis,
+        shared_with_user_ids=list(doc.shared_with_user_ids or []),
+        created_at=doc.created_at,
+        updated_at=doc.updated_at,
+    )
+
+
+async def _load_calendar(ctx: RequestContext, calendar_id: str) -> Calendar:
+    """Resolve a ``Calendar`` domain object for ``calendar_id``.
+
+    If a ``_CalendarDoc`` exists in the caller's workspace, it's returned.
+    Otherwise a synthetic default Calendar is returned (workspace-public,
+    owned by the caller) so policy still runs and the tenant boundary
+    holds. The synthetic path is the bridge until the Calendar CRUD
+    surface lands; once Calendar rows are required, this falls back to
+    raising NotFound.
+    """
+    doc = await _CalendarDoc.find_one(
+        {"_id": _maybe_object_id(calendar_id), "workspace": ctx.workspace_id}
+    )
+    if doc is not None:
+        return _doc_to_calendar(doc)
+    # No row yet — synthesize a default so policy still enforces the
+    # tenant boundary. Owner = caller so subsequent writes by the caller
+    # still succeed; visibility = workspace-public so reads in-workspace
+    # still succeed. This matches the pre-#1142 behaviour where the only
+    # check was the tenant filter.
+    now = datetime.now(UTC)
+    return Calendar(
+        id=calendar_id,
+        workspace_id=ctx.workspace_id,
+        name=calendar_id,
+        owner_user_id=ctx.user_id,
+        timezone="UTC",
+        visibility=CalendarVisibility.PUBLIC_TO_WORKSPACE,
+        shared_with_user_ids=[],
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _maybe_object_id(value: str) -> Any:
+    """Try to coerce ``value`` to ``PydanticObjectId``; on failure return the
+    raw string so Beanie can still match on opaque external ids (rare,
+    but supported for calendars synced from external systems)."""
+    try:
+        return PydanticObjectId(value)
+    except Exception:  # noqa: BLE001 — Beanie / bson raise a variety of types
+        return value
 
 
 async def _get_event_doc_or_404(ctx: RequestContext, event_id: str) -> _EventDoc:
@@ -87,6 +180,10 @@ async def _get_event_doc_or_404(ctx: RequestContext, event_id: str) -> _EventDoc
 async def create_event(ctx: RequestContext, body: CreateEventRequest) -> EventResponse:
     """Create a calendar event."""
     body = CreateEventRequest.model_validate(body)
+
+    # H1: enforce write access on the parent calendar before any insert.
+    calendar = await _load_calendar(ctx, body.calendar_id)
+    policy.check_calendar_write(ctx, calendar)
 
     # An optional Instinct approval gate hooks here in a follow-up PR — for
     # now the comment marks the seam so reviewers know where it lands.
@@ -123,8 +220,12 @@ async def create_event(ctx: RequestContext, body: CreateEventRequest) -> EventRe
 
 
 async def get_event(ctx: RequestContext, event_id: str) -> EventResponse:
-    """Fetch a single event. Tenant-filtered."""
+    """Fetch a single event. Tenant-filtered + policy-gated."""
     doc = await _get_event_doc_or_404(ctx, event_id)
+    calendar = await _load_calendar(ctx, doc.calendar_id)
+    # H1: read gate. Tenant filter already passed; this enforces
+    # within-workspace authz (private/shared calendars).
+    policy.check_calendar_read(ctx, calendar)
     return _doc_to_response(doc)
 
 
@@ -137,28 +238,37 @@ async def update_event(
     body = UpdateEventRequest.model_validate(body)
     doc = await _get_event_doc_or_404(ctx, event_id)
 
-    changes: dict = {}
+    # H1: enforce write access on the event's calendar.
+    calendar = await _load_calendar(ctx, doc.calendar_id)
+    policy.check_calendar_write(ctx, calendar)
+
+    # M4: track only the names of fields that changed, NOT the values.
+    # Bus subscribers (notifications, search reindex, soul memory) only
+    # need to know WHAT changed to invalidate their caches — leaking the
+    # raw title/description content into the in-process bus widened the
+    # blast radius for any future handler that logs payloads.
+    changed_fields: list[str] = []
     if body.title is not None:
         doc.title = body.title
-        changes["title"] = body.title
+        changed_fields.append("title")
     if body.description is not None:
         doc.description = body.description
-        changes["description"] = body.description
+        changed_fields.append("description")
     if body.starts_at is not None:
         doc.starts_at = body.starts_at
-        changes["starts_at"] = body.starts_at.isoformat()
+        changed_fields.append("starts_at")
     if body.ends_at is not None:
         doc.ends_at = body.ends_at
-        changes["ends_at"] = body.ends_at.isoformat()
+        changed_fields.append("ends_at")
     if body.location is not None:
         doc.location = body.location
-        changes["location"] = body.location
+        changed_fields.append("location")
     if body.attendees is not None:
         doc.attendees = [a.model_dump() for a in body.attendees]
-        changes["attendees"] = len(body.attendees)
+        changed_fields.append("attendees")
     if body.recurrence is not None:
         doc.recurrence = body.recurrence.model_dump()
-        changes["recurrence"] = True
+        changed_fields.append("recurrence")
 
     # Cross-field validation after the partial merge — starts_at < ends_at.
     if doc.ends_at <= doc.starts_at:
@@ -169,6 +279,13 @@ async def update_event(
 
     doc.updated_at = datetime.now(UTC)
     await doc.save()
+
+    # M4: payload now carries only field names. Attendees still carries a
+    # count (no PII) for consumers that wanted "did the attendee list
+    # change in shape".
+    changes: dict[str, Any] = {"changed_fields": changed_fields}
+    if body.attendees is not None:
+        changes["attendees_count"] = len(body.attendees)
 
     await event_bus.emit(
         TOPIC_EVENT_UPDATED,
@@ -184,8 +301,13 @@ async def update_event(
 
 
 async def delete_event(ctx: RequestContext, event_id: str) -> None:
-    """Hard-delete an event. Tenant-filtered."""
+    """Hard-delete an event. Tenant-filtered + policy-gated."""
     doc = await _get_event_doc_or_404(ctx, event_id)
+
+    # H1: enforce write access before deletion.
+    calendar = await _load_calendar(ctx, doc.calendar_id)
+    policy.check_calendar_write(ctx, calendar)
+
     event_id_str = str(doc.id)
     calendar_id = doc.calendar_id
     await doc.delete()
@@ -206,8 +328,20 @@ async def delete_event(ctx: RequestContext, event_id: str) -> None:
 
 
 async def list_events(ctx: RequestContext, body: ListEventsRequest) -> EventListResponse:
-    """List events in a time window. Tenant-filtered."""
+    """List events in a time window. Tenant-filtered + per-event policy filter.
+
+    H1: events on calendars the caller can't read are silently dropped
+    from the result. When ``calendar_id`` is supplied, the calendar is
+    resolved once and a hard read-gate is raised on deny (so the caller
+    sees a clear 403 rather than an empty list).
+    """
     body = ListEventsRequest.model_validate(body)
+
+    if body.calendar_id is not None:
+        calendar = await _load_calendar(ctx, body.calendar_id)
+        # Hard gate for the single-calendar case — better UX than silently
+        # returning empty.
+        policy.check_calendar_read(ctx, calendar)
 
     query: dict = {
         "workspace": ctx.workspace_id,
@@ -218,26 +352,148 @@ async def list_events(ctx: RequestContext, body: ListEventsRequest) -> EventList
         query["calendar_id"] = body.calendar_id
 
     docs = await _EventDoc.find(query).limit(body.limit).to_list()
-    events = [_doc_to_response(d) for d in docs]
+
+    # Resolve the set of unique calendar_ids in the result and check
+    # read access in one pass. Cache per-calendar decisions so the
+    # filter stays O(events).
+    accessible: dict[str, bool] = {}
+    visible_docs: list[_EventDoc] = []
+    for d in docs:
+        cid = getattr(d, "calendar_id", None)
+        if cid is None:
+            continue
+        if cid not in accessible:
+            cal = await _load_calendar(ctx, cid)
+            accessible[cid] = policy.can_read_calendar(ctx, cal)
+        if accessible[cid]:
+            visible_docs.append(d)
+
+    events = [_doc_to_response(d) for d in visible_docs]
     return EventListResponse(events=events, total=len(events))
 
 
 async def get_freebusy(ctx: RequestContext, body: FreeBusyRequest) -> FreeBusyResponse:
-    """Compute per-attendee busy periods. Tenant-filtered inside compute_freebusy."""
+    """Compute per-attendee busy periods.
+
+    H2: closes the workspace-wide oracle that #1132 flagged. Two layers:
+      1. Pre-validate the attendee list — every requested email must
+         appear as an attendee on at least one event sitting on a
+         calendar the caller can already read. Unknown emails raise
+         ``ValidationError`` so a probe attempt isn't ambiguous.
+      2. Pass ``accessible_calendar_ids`` into ``compute_freebusy`` so
+         that even after pre-validation, events on other calendars don't
+         contribute to the busy windows.
+    """
     body = FreeBusyRequest.model_validate(body)
+
+    accessible_calendar_ids = await _accessible_calendar_ids_with_email_match(
+        ctx,
+        attendee_emails=body.attendee_emails,
+        starts_at=body.starts_at,
+        ends_at=body.ends_at,
+    )
+
     freebusy = await compute_freebusy(
         workspace_id=ctx.workspace_id,
         attendee_emails=body.attendee_emails,
         starts_at=body.starts_at,
         ends_at=body.ends_at,
+        accessible_calendar_ids=accessible_calendar_ids,
     )
     return FreeBusyResponse(freebusy=freebusy)
+
+
+async def _accessible_calendar_ids_with_email_match(
+    ctx: RequestContext,
+    *,
+    attendee_emails: list[str],
+    starts_at: datetime,
+    ends_at: datetime,
+) -> set[str]:
+    """Compute the set of calendar_ids the caller can read AND that host
+    at least one event whose attendee list overlaps the requested emails
+    in the window.
+
+    Also enforces the "no unknown emails" half of H2: every requested
+    email must appear in the resolved set; otherwise raise
+    ``ValidationError``. This prevents using freebusy as a directory
+    probe.
+    """
+    emails_lower = {e.lower() for e in attendee_emails}
+
+    # Find candidate events touching the window with at least one of the
+    # requested attendees. We restrict to the caller's workspace from the
+    # start — no cross-tenant leak.
+    candidate_docs = await _EventDoc.find(
+        {
+            "workspace": ctx.workspace_id,
+            "starts_at": {"$lt": ends_at},
+            "ends_at": {"$gt": starts_at},
+            "attendees.email": {"$in": list(emails_lower)},
+        }
+    ).to_list()
+
+    # Bucket emails by the calendars they appear on (for the unknown-email
+    # check). Also collect the unique set of calendar_ids we still need
+    # to resolve.
+    emails_with_match: set[str] = set()
+    candidate_calendar_ids: set[str] = set()
+    for doc in candidate_docs:
+        cid = getattr(doc, "calendar_id", None)
+        if cid is None:
+            continue
+        candidate_calendar_ids.add(cid)
+        for att in getattr(doc, "attendees", None) or []:
+            email = (att.get("email") or "").lower()
+            if email in emails_lower:
+                emails_with_match.add(email)
+
+    # Resolve each candidate calendar's read access once.
+    accessible: set[str] = set()
+    for cid in candidate_calendar_ids:
+        cal = await _load_calendar(ctx, cid)
+        if policy.can_read_calendar(ctx, cal):
+            accessible.add(cid)
+
+    # Unknown-email check — every requested email must be matched to at
+    # least one event on a calendar the caller can read. We rebuild
+    # ``emails_with_match`` over accessible calendars only.
+    visible_emails: set[str] = set()
+    for doc in candidate_docs:
+        cid = getattr(doc, "calendar_id", None)
+        if cid not in accessible:
+            continue
+        for att in getattr(doc, "attendees", None) or []:
+            email = (att.get("email") or "").lower()
+            if email in emails_lower:
+                visible_emails.add(email)
+
+    missing = emails_lower - visible_emails
+    if missing:
+        # Don't leak which specific emails were unknown — the response
+        # only says one or more attendees aren't reachable from the
+        # caller's calendars. This still tells a malicious caller "this
+        # query was refused" but never "this email exists in another
+        # workspace" or "this email is real but on a private calendar".
+        raise ValidationError(
+            "calendar.unknown_attendee",
+            "One or more attendee emails are not reachable from your accessible calendars",
+        )
+
+    return accessible
 
 
 async def detect_conflicts(ctx: RequestContext, event_id: str) -> ConflictReport:
     """Find conflicts for an event. Emits on conflict so future approval
     flows can hook in."""
     doc = await _get_event_doc_or_404(ctx, event_id)
+
+    # H1: caller must be able to read the calendar this event lives on
+    # before we run conflict detection (which scans other events in the
+    # workspace).
+    calendar = await _load_calendar(ctx, doc.calendar_id)
+    policy.check_calendar_read(ctx, calendar)
+
     target = _doc_to_event(doc)
 
     conflicts = await find_conflicts(ctx.workspace_id, target)

--- a/ee/calendar/sync.py
+++ b/ee/calendar/sync.py
@@ -1,5 +1,11 @@
 # Calendar module — external calendar sync.
-# Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H-NEW-1).
+#
+# Changes:
+# - H-NEW-1: imported gcalendar events now carry created_by_user_id =
+#   ctx.user_id (the syncing user). The external creator isn't always a
+#   user in the workspace; the syncing user becomes the local steward
+#   and can edit / delete the imported event.
 #
 # Only Google Calendar is implemented in this PR. Outlook and iCloud are
 # placeholders that raise NotImplementedError so a future PR can wire them
@@ -93,6 +99,12 @@ async def pull_from_gcalendar(ctx: RequestContext, calendar_id: str) -> int:
                 ends_at=ends_at,
                 # gcalendar dateTime carries its own offset; we keep UTC as the canonical store.
                 timezone="UTC",
+                # H-NEW-1: imported events are owned by the user running the
+                # sync. We don't try to reconstruct the original gcalendar
+                # creator — that user may not exist in the workspace. The
+                # syncing user therefore acts as the local steward and can
+                # update or delete the imported event.
+                created_by_user_id=ctx.user_id,
                 location=ext.get("location") or None,
                 attendees=attendees,
                 source_connector="gcalendar",

--- a/tests/ee/calendar/conftest.py
+++ b/tests/ee/calendar/conftest.py
@@ -1,5 +1,11 @@
 # tests/ee/calendar/conftest.py — Pytest fixtures for the calendar module.
-# Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H-NEW-1).
+#
+# Changes:
+# - event_factory now sets created_by_user_id (default "user-test", the
+#   same id ctx() uses) so freshly-built domain Events satisfy the new
+#   required field. Tests that need a non-creator scenario pass it
+#   explicitly.
 #
 # We deliberately avoid spinning up a real Mongo for these tests. The
 # service layer is exercised by stubbing _EventDoc at the boundary so we
@@ -54,6 +60,10 @@ def event_factory():
             starts_at=starts_at,
             ends_at=ends_at,
             timezone=overrides.pop("timezone", "UTC"),
+            # H-NEW-1: required field; default matches ctx() so happy-path
+            # tests just work. Pass `created_by_user_id="someone-else"` to
+            # exercise the non-creator-denied path.
+            created_by_user_id=overrides.pop("created_by_user_id", "user-test"),
             description=overrides.pop("description", ""),
             location=overrides.pop("location", None),
             attendees=overrides.pop("attendees", []),

--- a/tests/ee/calendar/test_freebusy.py
+++ b/tests/ee/calendar/test_freebusy.py
@@ -1,5 +1,16 @@
 # tests/ee/calendar/test_freebusy.py — free/busy availability tests.
-# Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H2).
+#
+# Changes:
+# - Added test_freebusy_respects_accessible_calendar_ids: when the caller
+#   supplies the H2 access-set, events on other calendars must NOT
+#   contribute to the returned busy windows.
+# - Added test_freebusy_empty_accessible_set_returns_no_busy: an empty
+#   set means "no calendars I can read" — the response should reflect
+#   that.
+# - Added test_freebusy_none_accessible_preserves_legacy_behaviour: None
+#   means "no enforcement" — the legacy callers (trusted internal use)
+#   still get every busy block, no filtering.
 #
 # compute_freebusy queries _EventDoc.find with a $in on a nested attendees
 # field. The fake store in test_service.py models that, but here we keep
@@ -24,10 +35,12 @@ class _FakeDoc:
         starts_at: datetime,
         ends_at: datetime,
         attendees: list[dict[str, Any]],
+        calendar_id: str = "cal-1",
     ) -> None:
         self.starts_at = starts_at
         self.ends_at = ends_at
         self.attendees = attendees
+        self.calendar_id = calendar_id
 
 
 class _FakeQuery:
@@ -173,3 +186,93 @@ def test_freebusy_module_imports_clean():
     assert callable(fb_module.compute_freebusy)
     # UTC import is used inside module — make sure datetime UTC is still importable.
     assert UTC is not None
+
+
+# ---------------------------------------------------------------------------
+# H2 — accessible_calendar_ids restriction tests.
+# ---------------------------------------------------------------------------
+
+
+async def test_freebusy_respects_accessible_calendar_ids(patch_store):
+    """Two events for the same attendee, only one on an accessible calendar.
+
+    With ``accessible_calendar_ids`` restricting to that one calendar, only
+    that event's window contributes to the result — the other is silently
+    dropped (it would have leaked the private calendar's busy window
+    otherwise — the H2 oracle).
+    """
+    docs = [
+        _FakeDoc(
+            starts_at=datetime(2026, 5, 19, 10, 0),
+            ends_at=datetime(2026, 5, 19, 11, 0),
+            attendees=[{"email": "alice@example.com"}],
+            calendar_id="cal-public",
+        ),
+        _FakeDoc(
+            starts_at=datetime(2026, 5, 19, 14, 0),
+            ends_at=datetime(2026, 5, 19, 15, 0),
+            attendees=[{"email": "alice@example.com"}],
+            calendar_id="cal-private",
+        ),
+    ]
+    patch_store(docs)
+
+    result = await fb_module.compute_freebusy(
+        workspace_id="ws-1",
+        attendee_emails=["alice@example.com"],
+        starts_at=datetime(2026, 5, 19, 0, 0),
+        ends_at=datetime(2026, 5, 19, 23, 59),
+        accessible_calendar_ids={"cal-public"},
+    )
+    assert len(result) == 1
+    assert result[0].busy_periods == [
+        (datetime(2026, 5, 19, 10, 0), datetime(2026, 5, 19, 11, 0)),
+    ]
+
+
+async def test_freebusy_empty_accessible_set_returns_no_busy(patch_store):
+    """Empty accessible set means the caller has no calendars they can
+    read — the response is an empty-busy list for every requested email."""
+    docs = [
+        _FakeDoc(
+            starts_at=datetime(2026, 5, 19, 10, 0),
+            ends_at=datetime(2026, 5, 19, 11, 0),
+            attendees=[{"email": "alice@example.com"}],
+            calendar_id="cal-private",
+        ),
+    ]
+    patch_store(docs)
+
+    result = await fb_module.compute_freebusy(
+        workspace_id="ws-1",
+        attendee_emails=["alice@example.com"],
+        starts_at=datetime(2026, 5, 19, 0, 0),
+        ends_at=datetime(2026, 5, 19, 23, 59),
+        accessible_calendar_ids=set(),
+    )
+    assert len(result) == 1
+    assert result[0].busy_periods == []
+
+
+async def test_freebusy_none_accessible_preserves_legacy_behaviour(patch_store):
+    """``accessible_calendar_ids=None`` (default) keeps the pre-H2 path so
+    trusted internal callers still see every busy block."""
+    docs = [
+        _FakeDoc(
+            starts_at=datetime(2026, 5, 19, 10, 0),
+            ends_at=datetime(2026, 5, 19, 11, 0),
+            attendees=[{"email": "alice@example.com"}],
+            calendar_id="cal-private",
+        ),
+    ]
+    patch_store(docs)
+
+    result = await fb_module.compute_freebusy(
+        workspace_id="ws-1",
+        attendee_emails=["alice@example.com"],
+        starts_at=datetime(2026, 5, 19, 0, 0),
+        ends_at=datetime(2026, 5, 19, 23, 59),
+        # accessible_calendar_ids defaults to None
+    )
+    assert len(result) == 1
+    assert len(result[0].busy_periods) == 1

--- a/tests/ee/calendar/test_policy.py
+++ b/tests/ee/calendar/test_policy.py
@@ -1,0 +1,572 @@
+# tests/ee/calendar/test_policy.py — calendar access-policy tests.
+# Created: 2026-05-19 (fix/calendar-security-hardening, #1142 H1).
+#
+# Exercises the policy.check_calendar_read / check_calendar_write /
+# can_read_calendar helpers across the cross-workspace + within-workspace
+# matrix. Also runs an end-to-end check that service.create_event,
+# update_event, delete_event, get_event, list_events, detect_conflicts,
+# and get_freebusy all surface Forbidden when a non-owner / non-shared
+# user touches a private or shared calendar.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from bson import ObjectId
+
+from ee.calendar import policy
+from ee.calendar import service as service_module
+from ee.calendar._context import RequestContext
+from ee.calendar.domain import Calendar, CalendarVisibility
+from ee.calendar.dto import (
+    CreateEventRequest,
+    FreeBusyRequest,
+    ListEventsRequest,
+    UpdateEventRequest,
+)
+from ee.cloud.shared.errors import Forbidden
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal Calendar + RequestContext factories.
+# ---------------------------------------------------------------------------
+
+
+def _make_calendar(
+    *,
+    owner: str = "alice",
+    workspace_id: str = "ws-1",
+    visibility: CalendarVisibility = CalendarVisibility.PUBLIC_TO_WORKSPACE,
+    shared_with: list[str] | None = None,
+) -> Calendar:
+    return Calendar(
+        id="cal-1",
+        workspace_id=workspace_id,
+        name="Team",
+        owner_user_id=owner,
+        timezone="UTC",
+        visibility=visibility,
+        shared_with_user_ids=shared_with or [],
+        created_at=datetime(2026, 5, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+
+
+def _ctx(user_id: str = "alice", workspace_id: str = "ws-1") -> RequestContext:
+    return RequestContext(workspace_id=workspace_id, user_id=user_id)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — policy functions in isolation.
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCalendarRead:
+    def test_owner_can_read(self):
+        cal = _make_calendar(owner="alice")
+        # No exception means access granted.
+        policy.check_calendar_read(_ctx("alice"), cal)
+
+    def test_workspace_public_grants_read_to_non_owner(self):
+        cal = _make_calendar(
+            owner="alice",
+            visibility=CalendarVisibility.PUBLIC_TO_WORKSPACE,
+        )
+        policy.check_calendar_read(_ctx("bob"), cal)
+
+    def test_private_denies_non_owner(self):
+        cal = _make_calendar(owner="alice", visibility=CalendarVisibility.PRIVATE)
+        with pytest.raises(Forbidden):
+            policy.check_calendar_read(_ctx("bob"), cal)
+
+    def test_shared_grants_to_listed_user(self):
+        cal = _make_calendar(
+            owner="alice",
+            visibility=CalendarVisibility.SHARED_WITH_USERS,
+            shared_with=["bob"],
+        )
+        policy.check_calendar_read(_ctx("bob"), cal)
+
+    def test_shared_denies_unlisted_user(self):
+        cal = _make_calendar(
+            owner="alice",
+            visibility=CalendarVisibility.SHARED_WITH_USERS,
+            shared_with=["charlie"],
+        )
+        with pytest.raises(Forbidden):
+            policy.check_calendar_read(_ctx("bob"), cal)
+
+    def test_cross_workspace_always_denied(self):
+        """Hard tenant boundary — even the owner can't read across workspaces."""
+        cal = _make_calendar(owner="alice", workspace_id="ws-other")
+        with pytest.raises(Forbidden):
+            policy.check_calendar_read(_ctx("alice", workspace_id="ws-1"), cal)
+
+
+class TestCheckCalendarWrite:
+    def test_owner_can_write(self):
+        cal = _make_calendar(owner="alice")
+        policy.check_calendar_write(_ctx("alice"), cal)
+
+    def test_public_does_not_grant_write(self):
+        """Workspace-public is read-only by default — promote to shared
+        for write."""
+        cal = _make_calendar(
+            owner="alice",
+            visibility=CalendarVisibility.PUBLIC_TO_WORKSPACE,
+        )
+        with pytest.raises(Forbidden):
+            policy.check_calendar_write(_ctx("bob"), cal)
+
+    def test_shared_grants_write(self):
+        cal = _make_calendar(
+            owner="alice",
+            visibility=CalendarVisibility.SHARED_WITH_USERS,
+            shared_with=["bob"],
+        )
+        policy.check_calendar_write(_ctx("bob"), cal)
+
+    def test_private_denies_non_owner_write(self):
+        cal = _make_calendar(owner="alice", visibility=CalendarVisibility.PRIVATE)
+        with pytest.raises(Forbidden):
+            policy.check_calendar_write(_ctx("bob"), cal)
+
+    def test_cross_workspace_write_denied(self):
+        cal = _make_calendar(owner="alice", workspace_id="ws-other")
+        with pytest.raises(Forbidden):
+            policy.check_calendar_write(_ctx("alice", workspace_id="ws-1"), cal)
+
+
+class TestCanReadCalendar:
+    """can_read_calendar is the predicate form — returns bool, no raise."""
+
+    def test_returns_true_for_owner(self):
+        cal = _make_calendar(owner="alice")
+        assert policy.can_read_calendar(_ctx("alice"), cal) is True
+
+    def test_returns_false_for_private_non_owner(self):
+        cal = _make_calendar(owner="alice", visibility=CalendarVisibility.PRIVATE)
+        assert policy.can_read_calendar(_ctx("bob"), cal) is False
+
+    def test_returns_false_cross_workspace(self):
+        cal = _make_calendar(owner="alice", workspace_id="ws-other")
+        assert policy.can_read_calendar(_ctx("alice", workspace_id="ws-1"), cal) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — policy wired into service.* operations.
+# ---------------------------------------------------------------------------
+#
+# We patch _CalendarDoc + _EventDoc on the service module so we don't need
+# Beanie at all. The seed: a "private" calendar owned by alice, plus a few
+# events. Non-owner bob should not be able to read or write those events.
+
+
+class _PolicyFakeCalDoc:
+    def __init__(self, **fields: Any) -> None:
+        self.id = fields.get("_id", ObjectId())
+        for k, v in fields.items():
+            if k == "_id":
+                continue
+            setattr(self, k, v)
+        # Domain defaults.
+        self.color = getattr(self, "color", "#0A84FF")
+        self.shared_with_user_ids = getattr(self, "shared_with_user_ids", [])
+        self.created_at = getattr(self, "created_at", datetime.now(UTC))
+        self.updated_at = getattr(self, "updated_at", datetime.now(UTC))
+
+
+class _PolicyFakeCalStore:
+    """Calendar store that returns a fixed _CalendarDoc per (id, workspace)
+    lookup, or None to force the synthetic-default fallback."""
+
+    def __init__(self) -> None:
+        self.rows: list[_PolicyFakeCalDoc] = []
+
+    async def find_one(self, query: dict[str, Any]) -> _PolicyFakeCalDoc | None:
+        cal_id = query.get("_id")
+        workspace = query.get("workspace")
+        for r in self.rows:
+            if (
+                # service.py passes either a PydanticObjectId or the raw str
+                (str(r.id) == str(cal_id) or r.id == cal_id) and r.workspace == workspace
+            ):
+                return r
+        return None
+
+
+class _PolicyFakeEventDoc:
+    def __init__(self, **fields: Any) -> None:
+        self.id = fields.pop("_id", ObjectId())
+        for k, v in fields.items():
+            setattr(self, k, v)
+        self.description = getattr(self, "description", "")
+        self.attendees = getattr(self, "attendees", [])
+        self.recurrence = getattr(self, "recurrence", None)
+        self.location = getattr(self, "location", None)
+        self.fabric_object_id = getattr(self, "fabric_object_id", None)
+        self.source_connector = getattr(self, "source_connector", None)
+        self.source_external_id = getattr(self, "source_external_id", None)
+        self.created_at = getattr(self, "created_at", datetime.now(UTC))
+        self.updated_at = getattr(self, "updated_at", datetime.now(UTC))
+
+    async def insert(self) -> None:
+        pass
+
+    async def save(self) -> None:
+        pass
+
+    async def delete(self) -> None:
+        pass
+
+
+class _PolicyFakeEventQuery:
+    def __init__(self, docs: list[_PolicyFakeEventDoc]) -> None:
+        self._docs = docs
+        self._limit: int | None = None
+
+    def limit(self, n: int) -> _PolicyFakeEventQuery:
+        self._limit = n
+        return self
+
+    async def to_list(self) -> list[_PolicyFakeEventDoc]:
+        if self._limit is not None:
+            return self._docs[: self._limit]
+        return self._docs
+
+
+class _PolicyFakeEventStore:
+    def __init__(self) -> None:
+        self.rows: list[_PolicyFakeEventDoc] = []
+
+    def find(self, *args: Any) -> _PolicyFakeEventQuery:
+        # Return everything — the per-event policy check filters.
+        return _PolicyFakeEventQuery(list(self.rows))
+
+    async def find_one(self, *args: Any) -> _PolicyFakeEventDoc | None:
+        # The service compares by id; pull the requested id off the args.
+        for arg in args:
+            if hasattr(arg, "field") and arg.field == "id_str":
+                target_id = arg.value
+                for r in self.rows:
+                    if str(r.id) == str(target_id):
+                        return r
+        # First-match fallback (used by single-doc tests).
+        return self.rows[0] if self.rows else None
+
+
+class _PolicyFieldEq:
+    def __init__(self, field: str, value: Any) -> None:
+        self.field = field
+        self.value = value
+
+
+class _PolicyFieldProxy:
+    def __init__(self, field: str) -> None:
+        self._field = field
+
+    def __eq__(self, other: Any) -> _PolicyFieldEq:  # type: ignore[override]
+        return _PolicyFieldEq(self._field, other)
+
+
+@pytest.fixture
+def patch_stores(monkeypatch) -> tuple[_PolicyFakeCalStore, _PolicyFakeEventStore]:
+    """Install fake stores for both _CalendarDoc and _EventDoc."""
+    cal_store = _PolicyFakeCalStore()
+    event_store = _PolicyFakeEventStore()
+    monkeypatch.setattr(service_module, "_CalendarDoc", cal_store)
+    monkeypatch.setattr(service_module, "_EventDoc", event_store)
+    # service uses ``_EventDoc.id == oid`` and ``.workspace == ...`` via the
+    # _get_event_doc_or_404 helper. Mirror what test_service.py does.
+    event_store.id = _PolicyFieldProxy("id_str")  # type: ignore[attr-defined]
+    event_store.workspace = _PolicyFieldProxy("workspace")  # type: ignore[attr-defined]
+    return cal_store, event_store
+
+
+@pytest.fixture
+def bus_spy(monkeypatch):
+    """No-op bus so emits don't blow up."""
+    from ee.cloud.shared.events import event_bus
+
+    async def _spy(topic: str, data: dict) -> None:
+        pass
+
+    monkeypatch.setattr(event_bus, "emit", _spy)
+
+
+def _seed_calendar(
+    store: _PolicyFakeCalStore,
+    *,
+    cal_id: str = "cal-1",
+    workspace: str = "ws-1",
+    owner: str = "alice",
+    visibility: str = "private",
+    shared_with: list[str] | None = None,
+) -> _PolicyFakeCalDoc:
+    doc = _PolicyFakeCalDoc(
+        _id=cal_id,
+        workspace=workspace,
+        name="Team",
+        owner_user_id=owner,
+        timezone="UTC",
+        visibility=visibility,
+        shared_with_user_ids=shared_with or [],
+    )
+    store.rows.append(doc)
+    return doc
+
+
+def _seed_event(
+    store: _PolicyFakeEventStore,
+    *,
+    workspace: str = "ws-1",
+    calendar_id: str = "cal-1",
+    starts: datetime | None = None,
+    ends: datetime | None = None,
+    attendees: list[dict] | None = None,
+) -> _PolicyFakeEventDoc:
+    doc = _PolicyFakeEventDoc(
+        workspace=workspace,
+        calendar_id=calendar_id,
+        title="Standup",
+        starts_at=starts or datetime(2026, 5, 19, 9, 0),
+        ends_at=ends or datetime(2026, 5, 19, 9, 30),
+        timezone="UTC",
+        attendees=attendees or [],
+    )
+    # Mirror id as a separate field so _PolicyFakeEventStore.find_one
+    # can match by `_FieldEq("id_str", ...)`.
+    doc.id_str = doc.id
+    store.rows.append(doc)
+    return doc
+
+
+# ---------------------------------------------------------------------------
+
+
+async def test_non_owner_cannot_get_event_on_private_calendar(patch_stores, bus_spy):
+    cal_store, event_store = patch_stores
+    _seed_calendar(cal_store, owner="alice", visibility="private")
+    event = _seed_event(event_store)
+
+    with pytest.raises(Forbidden):
+        await service_module.get_event(_ctx("bob"), str(event.id))
+
+
+async def test_non_owner_cannot_update_event_on_private_calendar(patch_stores, bus_spy):
+    cal_store, event_store = patch_stores
+    _seed_calendar(cal_store, owner="alice", visibility="private")
+    event = _seed_event(event_store)
+
+    with pytest.raises(Forbidden):
+        await service_module.update_event(
+            _ctx("bob"),
+            str(event.id),
+            UpdateEventRequest(title="Hacked"),
+        )
+
+
+async def test_non_owner_cannot_delete_event_on_private_calendar(patch_stores, bus_spy):
+    cal_store, event_store = patch_stores
+    _seed_calendar(cal_store, owner="alice", visibility="private")
+    event = _seed_event(event_store)
+
+    with pytest.raises(Forbidden):
+        await service_module.delete_event(_ctx("bob"), str(event.id))
+
+
+async def test_non_owner_cannot_create_event_on_private_calendar(patch_stores, bus_spy):
+    cal_store, _event_store = patch_stores
+    _seed_calendar(cal_store, owner="alice", visibility="private")
+
+    with pytest.raises(Forbidden):
+        await service_module.create_event(
+            _ctx("bob"),
+            CreateEventRequest(
+                calendar_id="cal-1",
+                title="Sneaky",
+                starts_at=datetime(2026, 5, 19, 9, 0),
+                ends_at=datetime(2026, 5, 19, 10, 0),
+                timezone="UTC",
+            ),
+        )
+
+
+async def test_non_owner_cannot_create_event_on_public_calendar(patch_stores, bus_spy):
+    """Public calendars are READ-only by default — write requires explicit share."""
+    cal_store, _event_store = patch_stores
+    _seed_calendar(cal_store, owner="alice", visibility="public_to_workspace")
+
+    with pytest.raises(Forbidden):
+        await service_module.create_event(
+            _ctx("bob"),
+            CreateEventRequest(
+                calendar_id="cal-1",
+                title="Should be denied",
+                starts_at=datetime(2026, 5, 19, 9, 0),
+                ends_at=datetime(2026, 5, 19, 10, 0),
+                timezone="UTC",
+            ),
+        )
+
+
+async def test_owner_can_update_event_on_private_calendar(patch_stores, bus_spy):
+    cal_store, event_store = patch_stores
+    _seed_calendar(cal_store, owner="alice", visibility="private")
+    event = _seed_event(event_store)
+
+    result = await service_module.update_event(
+        _ctx("alice"),
+        str(event.id),
+        UpdateEventRequest(title="Owner-driven update"),
+    )
+    assert result.title == "Owner-driven update"
+
+
+async def test_shared_user_can_update_event(patch_stores, bus_spy):
+    cal_store, event_store = patch_stores
+    _seed_calendar(
+        cal_store,
+        owner="alice",
+        visibility="shared_with_users",
+        shared_with=["bob"],
+    )
+    event = _seed_event(event_store)
+
+    result = await service_module.update_event(
+        _ctx("bob"),
+        str(event.id),
+        UpdateEventRequest(title="Shared user update"),
+    )
+    assert result.title == "Shared user update"
+
+
+async def test_list_events_filters_inaccessible_calendars(patch_stores):
+    """Events on a private calendar I don't own are silently dropped from list."""
+    cal_store, event_store = patch_stores
+    # alice's private calendar
+    _seed_calendar(
+        cal_store,
+        cal_id="cal-private",
+        owner="alice",
+        visibility="private",
+    )
+    # bob's public calendar
+    _seed_calendar(
+        cal_store,
+        cal_id="cal-public",
+        owner="bob",
+        visibility="public_to_workspace",
+    )
+
+    _seed_event(event_store, calendar_id="cal-private")
+    _seed_event(event_store, calendar_id="cal-public")
+
+    body = ListEventsRequest(
+        starts_after=datetime(2026, 5, 1),
+        starts_before=datetime(2026, 6, 1),
+    )
+    # Bob lists — only sees the public calendar event.
+    result = await service_module.list_events(_ctx("bob"), body)
+    assert result.total == 1
+    assert result.events[0].calendar_id == "cal-public"
+
+
+async def test_list_events_hard_403_when_calendar_id_inaccessible(patch_stores):
+    """When the caller filters by a specific calendar they can't read,
+    we return a 403 (clearer UX than an empty list)."""
+    cal_store, _event_store = patch_stores
+    _seed_calendar(cal_store, owner="alice", visibility="private")
+
+    body = ListEventsRequest(
+        calendar_id="cal-1",
+        starts_after=datetime(2026, 5, 1),
+        starts_before=datetime(2026, 6, 1),
+    )
+    with pytest.raises(Forbidden):
+        await service_module.list_events(_ctx("bob"), body)
+
+
+async def test_freebusy_denied_for_emails_on_inaccessible_calendar(patch_stores):
+    """H2 — alice's private calendar shouldn't leak as an availability oracle
+    to bob, even if bob asks for alice's email directly."""
+    cal_store, event_store = patch_stores
+    _seed_calendar(
+        cal_store,
+        cal_id="cal-private",
+        owner="alice",
+        visibility="private",
+    )
+    _seed_event(
+        event_store,
+        calendar_id="cal-private",
+        attendees=[{"email": "alice@example.com"}],
+    )
+
+    # Bob requests freebusy for alice. The only event matching alice is on
+    # a calendar bob can't read — so the unknown-attendee gate fires.
+    with pytest.raises(Exception) as exc_info:  # ValidationError
+        await service_module.get_freebusy(
+            _ctx("bob"),
+            FreeBusyRequest(
+                attendee_emails=["alice@example.com"],
+                starts_at=datetime(2026, 5, 19, 0, 0),
+                ends_at=datetime(2026, 5, 20, 0, 0),
+            ),
+        )
+    # Confirm it surfaces as our cloud ValidationError, not a 500.
+    assert "calendar.unknown_attendee" in str(exc_info.value)
+
+
+async def test_freebusy_succeeds_for_emails_on_accessible_calendar(patch_stores, monkeypatch):
+    """Sanity inverse: bob CAN query freebusy for alice if the event lives
+    on a workspace-public calendar."""
+    cal_store, event_store = patch_stores
+    _seed_calendar(
+        cal_store,
+        cal_id="cal-public",
+        owner="alice",
+        visibility="public_to_workspace",
+    )
+    _seed_event(
+        event_store,
+        calendar_id="cal-public",
+        attendees=[{"email": "alice@example.com"}],
+    )
+
+    # compute_freebusy issues its own _EventDoc.find call; patch the
+    # symbol the freebusy module sees so we don't need Beanie.
+    from ee.calendar import freebusy as fb_module
+
+    monkeypatch.setattr(fb_module, "_EventDoc", event_store)
+
+    resp = await service_module.get_freebusy(
+        _ctx("bob"),
+        FreeBusyRequest(
+            attendee_emails=["alice@example.com"],
+            starts_at=datetime(2026, 5, 19, 0, 0),
+            ends_at=datetime(2026, 5, 20, 0, 0),
+        ),
+    )
+    assert len(resp.freebusy) == 1
+    assert resp.freebusy[0].attendee_email == "alice@example.com"
+
+
+async def test_detect_conflicts_blocked_for_non_owner_on_private_calendar(
+    patch_stores, bus_spy, monkeypatch
+):
+    """Conflict detection scans the workspace; non-owner with no read
+    access to the event's calendar must not be allowed to invoke it."""
+    cal_store, event_store = patch_stores
+    _seed_calendar(cal_store, owner="alice", visibility="private")
+    event = _seed_event(event_store)
+
+    # find_conflicts is real but we don't care — should fail before that.
+    async def _no_conflicts(workspace_id, target):
+        return []
+
+    monkeypatch.setattr(service_module, "find_conflicts", _no_conflicts)
+
+    with pytest.raises(Forbidden):
+        await service_module.detect_conflicts(_ctx("bob"), str(event.id))

--- a/tests/ee/calendar/test_policy.py
+++ b/tests/ee/calendar/test_policy.py
@@ -1,12 +1,19 @@
 # tests/ee/calendar/test_policy.py — calendar access-policy tests.
-# Created: 2026-05-19 (fix/calendar-security-hardening, #1142 H1).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H1 + H-NEW-1).
+#
+# Changes:
+# - Added unit tests for policy.check_event_modify (creator allowed,
+#   non-creator denied, cross-workspace denied, admin path TODO'd).
+# - _PolicyFakeEventDoc now defaults created_by_user_id so existing
+#   tests keep working; H-NEW-1 tests pass explicit ids.
 #
 # Exercises the policy.check_calendar_read / check_calendar_write /
-# can_read_calendar helpers across the cross-workspace + within-workspace
-# matrix. Also runs an end-to-end check that service.create_event,
-# update_event, delete_event, get_event, list_events, detect_conflicts,
-# and get_freebusy all surface Forbidden when a non-owner / non-shared
-# user touches a private or shared calendar.
+# can_read_calendar / check_event_modify helpers across the
+# cross-workspace + within-workspace matrix. Also runs an end-to-end
+# check that service.create_event, update_event, delete_event, get_event,
+# list_events, detect_conflicts, and get_freebusy all surface Forbidden
+# when a non-owner / non-shared / non-creator user touches a private or
+# shared calendar.
 
 from __future__ import annotations
 
@@ -154,6 +161,65 @@ class TestCanReadCalendar:
         assert policy.can_read_calendar(_ctx("alice", workspace_id="ws-1"), cal) is False
 
 
+class TestCheckEventModify:
+    """check_event_modify is the H-NEW-1 gate — creator-or-admin only.
+
+    Synthetic-default Calendar makes check_calendar_write trivially pass
+    for every workspace member, so update_event / delete_event must call
+    this on the event itself to keep cross-user modify access closed.
+    """
+
+    def test_event_modify_creator_allowed(self, event_factory):
+        """Alice created the event → alice can modify."""
+        event = event_factory(
+            workspace_id="ws-1",
+            created_by_user_id="alice",
+        )
+        # No exception means access granted.
+        policy.check_event_modify(_ctx("alice", workspace_id="ws-1"), event)
+
+    def test_event_modify_non_creator_denied(self, event_factory):
+        """Bob, same workspace, is NOT the creator → Forbidden."""
+        event = event_factory(
+            workspace_id="ws-1",
+            created_by_user_id="alice",
+        )
+        with pytest.raises(Forbidden) as exc_info:
+            policy.check_event_modify(_ctx("bob", workspace_id="ws-1"), event)
+        assert "event.modify_denied" in str(exc_info.value)
+
+    def test_event_modify_cross_workspace_denied(self, event_factory):
+        """Defensive guard: even if the caller IS the creator, a workspace
+        mismatch fails closed. The tenant filter upstream usually catches
+        this first via 404, but this assertion documents the policy itself."""
+        event = event_factory(
+            workspace_id="ws-other",
+            created_by_user_id="alice",
+        )
+        with pytest.raises(Forbidden) as exc_info:
+            policy.check_event_modify(_ctx("alice", workspace_id="ws-1"), event)
+        assert "event.modify_denied" in str(exc_info.value)
+
+    @pytest.mark.skip(
+        reason=(
+            "TODO(h-new-1-admin): workspace-admin override not yet plumbed "
+            "through RequestContext. Once the calendar context carries a "
+            "role/permissions field, this test asserts an admin (non-creator) "
+            "can still modify. Tracked alongside the policy.check_event_modify "
+            "TODO."
+        )
+    )
+    def test_event_modify_admin_allowed(self, event_factory):  # pragma: no cover
+        """Workspace admins should bypass the creator check. Skipped until
+        the role plumbing lands."""
+        event = event_factory(
+            workspace_id="ws-1",
+            created_by_user_id="alice",
+        )
+        # Future shape: _ctx("bob-admin") would resolve a role of "admin".
+        policy.check_event_modify(_ctx("bob-admin", workspace_id="ws-1"), event)
+
+
 # ---------------------------------------------------------------------------
 # Integration tests — policy wired into service.* operations.
 # ---------------------------------------------------------------------------
@@ -210,6 +276,10 @@ class _PolicyFakeEventDoc:
         self.source_external_id = getattr(self, "source_external_id", None)
         self.created_at = getattr(self, "created_at", datetime.now(UTC))
         self.updated_at = getattr(self, "updated_at", datetime.now(UTC))
+        # H-NEW-1: real _EventDoc requires it. Default to the test's owner
+        # ("alice") so existing tests where alice is both calendar owner
+        # and event creator stay green.
+        self.created_by_user_id = getattr(self, "created_by_user_id", "alice")
 
     async def insert(self) -> None:
         pass
@@ -325,6 +395,7 @@ def _seed_event(
     starts: datetime | None = None,
     ends: datetime | None = None,
     attendees: list[dict] | None = None,
+    created_by_user_id: str = "alice",
 ) -> _PolicyFakeEventDoc:
     doc = _PolicyFakeEventDoc(
         workspace=workspace,
@@ -334,6 +405,10 @@ def _seed_event(
         ends_at=ends or datetime(2026, 5, 19, 9, 30),
         timezone="UTC",
         attendees=attendees or [],
+        # H-NEW-1: default matches the alice-owned calendar fixture so
+        # existing tests stay green. Pass explicitly for non-creator
+        # scenarios.
+        created_by_user_id=created_by_user_id,
     )
     # Mirror id as a separate field so _PolicyFakeEventStore.find_one
     # can match by `_FieldEq("id_str", ...)`.
@@ -424,7 +499,11 @@ async def test_owner_can_update_event_on_private_calendar(patch_stores, bus_spy)
     assert result.title == "Owner-driven update"
 
 
-async def test_shared_user_can_update_event(patch_stores, bus_spy):
+async def test_shared_user_can_update_their_own_event(patch_stores, bus_spy):
+    """H-NEW-1 tightening: a shared user can WRITE to the calendar (e.g.,
+    create new events), but on UPDATE they must also be the event creator.
+    Here bob is shared on alice's calendar AND created the event himself,
+    so the update succeeds."""
     cal_store, event_store = patch_stores
     _seed_calendar(
         cal_store,
@@ -432,7 +511,10 @@ async def test_shared_user_can_update_event(patch_stores, bus_spy):
         visibility="shared_with_users",
         shared_with=["bob"],
     )
-    event = _seed_event(event_store)
+    # Bob created this event (not alice). check_calendar_write passes
+    # because bob is in shared_with; check_event_modify passes because
+    # bob == created_by_user_id.
+    event = _seed_event(event_store, created_by_user_id="bob")
 
     result = await service_module.update_event(
         _ctx("bob"),
@@ -440,6 +522,29 @@ async def test_shared_user_can_update_event(patch_stores, bus_spy):
         UpdateEventRequest(title="Shared user update"),
     )
     assert result.title == "Shared user update"
+
+
+async def test_shared_user_cannot_update_someone_elses_event(patch_stores, bus_spy):
+    """H-NEW-1: even with calendar-write access, a shared user cannot edit
+    events they didn't create. The event-level gate fires."""
+    cal_store, event_store = patch_stores
+    _seed_calendar(
+        cal_store,
+        owner="alice",
+        visibility="shared_with_users",
+        shared_with=["bob"],
+    )
+    # Event was created by alice. Bob has calendar-write but no
+    # event-modify access.
+    event = _seed_event(event_store, created_by_user_id="alice")
+
+    with pytest.raises(Forbidden) as exc_info:
+        await service_module.update_event(
+            _ctx("bob"),
+            str(event.id),
+            UpdateEventRequest(title="Bob tries to overwrite alice's event"),
+        )
+    assert "event.modify_denied" in str(exc_info.value)
 
 
 async def test_list_events_filters_inaccessible_calendars(patch_stores):
@@ -570,3 +675,57 @@ async def test_detect_conflicts_blocked_for_non_owner_on_private_calendar(
 
     with pytest.raises(Forbidden):
         await service_module.detect_conflicts(_ctx("bob"), str(event.id))
+
+
+# ---------------------------------------------------------------------------
+# H-NEW-1: synthetic-default Calendar must not bypass event-level authz.
+# ---------------------------------------------------------------------------
+#
+# When _CalendarDoc has no row for a calendar_id, service._load_calendar
+# returns a synthetic Calendar with owner_user_id = ctx.user_id +
+# visibility = public-to-workspace. That makes check_calendar_write a
+# no-op for every caller. These tests assert that policy.check_event_modify
+# still blocks non-creators from mutating other users' events on that path.
+
+
+async def test_h_new_1_update_blocked_on_synthetic_calendar(patch_stores, bus_spy):
+    """Alice creates an event on a calendar with no backing _CalendarDoc
+    row (synthetic-default path). Bob (same workspace) cannot update it
+    even though check_calendar_write trivially passes."""
+    _cal_store, event_store = patch_stores
+    # IMPORTANT: NO _seed_calendar — leaving the store empty forces the
+    # service to fall through to the synthetic default.
+    event = _seed_event(event_store, created_by_user_id="alice")
+
+    with pytest.raises(Forbidden) as exc_info:
+        await service_module.update_event(
+            _ctx("bob"),
+            str(event.id),
+            UpdateEventRequest(title="Should be denied"),
+        )
+    assert "event.modify_denied" in str(exc_info.value)
+
+
+async def test_h_new_1_delete_blocked_on_synthetic_calendar(patch_stores, bus_spy):
+    """Same shape — delete must also fail when bob tries to drop alice's
+    event on a synthetic-default Calendar."""
+    _cal_store, event_store = patch_stores
+    event = _seed_event(event_store, created_by_user_id="alice")
+
+    with pytest.raises(Forbidden) as exc_info:
+        await service_module.delete_event(_ctx("bob"), str(event.id))
+    assert "event.modify_denied" in str(exc_info.value)
+
+
+async def test_h_new_1_creator_can_still_update_on_synthetic_calendar(patch_stores, bus_spy):
+    """The fix is creator-equality, not "synthetic = read-only". Alice (the
+    creator) still has the happy path."""
+    _cal_store, event_store = patch_stores
+    event = _seed_event(event_store, created_by_user_id="alice")
+
+    resp = await service_module.update_event(
+        _ctx("alice"),
+        str(event.id),
+        UpdateEventRequest(title="Owner-edit ok"),
+    )
+    assert resp.title == "Owner-edit ok"

--- a/tests/ee/calendar/test_router.py
+++ b/tests/ee/calendar/test_router.py
@@ -1,5 +1,13 @@
 # tests/ee/calendar/test_router.py — FastAPI router tests.
-# Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H3).
+#
+# Changes:
+# - Added test_list_events_malformed_starts_after_returns_422 — covers H3.
+#   Previously a non-ISO ``starts_after`` propagated a ``ValueError`` and
+#   became HTTP 500; with the FastAPI-native ``datetime`` query type the
+#   response is now 422 with the standard validation envelope.
+# - Added test_list_events_missing_starts_before_returns_422 — required
+#   query params are still required.
 #
 # Mount the router on a throwaway FastAPI app, install a global CloudError
 # handler (so we get the same envelope the real cloud app emits), and
@@ -217,3 +225,59 @@ def test_conflicts_endpoint(client, monkeypatch):
     assert body["event_id"] == "evt-1"
     assert body["severity"] == "low"
     assert body["conflicting_events"] == []
+
+
+# ---------------------------------------------------------------------------
+# H3 — datetime query parameter validation.
+# ---------------------------------------------------------------------------
+
+
+def test_list_events_malformed_starts_after_returns_422(client, monkeypatch):
+    """Malformed datetime → 422 (not 500). H3 of the #1132 audit.
+
+    Before the fix, the router called ``datetime.fromisoformat`` on the
+    raw string and let the ValueError bubble into the global handler as
+    HTTP 500. With the FastAPI-native ``datetime`` query type, Pydantic
+    rejects the input cleanly.
+    """
+    sentinel = AsyncMock()
+    monkeypatch.setattr(router_module, "svc_list_events", sentinel)
+
+    response = client.get(
+        "/api/v1/calendar/events",
+        params={
+            "starts_after": "not-a-date",
+            "starts_before": "2026-05-20T00:00:00",
+        },
+    )
+    assert response.status_code == 422, response.text
+    sentinel.assert_not_awaited()
+
+
+def test_list_events_malformed_starts_before_returns_422(client, monkeypatch):
+    """Same as above but on the other query param."""
+    sentinel = AsyncMock()
+    monkeypatch.setattr(router_module, "svc_list_events", sentinel)
+
+    response = client.get(
+        "/api/v1/calendar/events",
+        params={
+            "starts_after": "2026-05-19T00:00:00",
+            "starts_before": "not-a-date-either",
+        },
+    )
+    assert response.status_code == 422, response.text
+    sentinel.assert_not_awaited()
+
+
+def test_list_events_missing_starts_before_returns_422(client, monkeypatch):
+    """Both query params are required — omitting one yields 422."""
+    sentinel = AsyncMock()
+    monkeypatch.setattr(router_module, "svc_list_events", sentinel)
+
+    response = client.get(
+        "/api/v1/calendar/events",
+        params={"starts_after": "2026-05-19T00:00:00"},
+    )
+    assert response.status_code == 422
+    sentinel.assert_not_awaited()

--- a/tests/ee/calendar/test_router.py
+++ b/tests/ee/calendar/test_router.py
@@ -1,5 +1,5 @@
 # tests/ee/calendar/test_router.py — FastAPI router tests.
-# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H3).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H3 + H-NEW-1).
 #
 # Changes:
 # - Added test_list_events_malformed_starts_after_returns_422 — covers H3.
@@ -8,6 +8,8 @@
 #   response is now 422 with the standard validation envelope.
 # - Added test_list_events_missing_starts_before_returns_422 — required
 #   query params are still required.
+# - H-NEW-1: _make_event_response now populates created_by_user_id since
+#   EventResponse exposes it for the UI.
 #
 # Mount the router on a throwaway FastAPI app, install a global CloudError
 # handler (so we get the same envelope the real cloud app emits), and
@@ -55,6 +57,9 @@ def _make_event_response(**overrides: Any) -> EventResponse:
         starts_at=datetime(2026, 5, 19, 9, 0),
         ends_at=datetime(2026, 5, 19, 10, 0),
         timezone="UTC",
+        # H-NEW-1: EventResponse now exposes this so the UI can render
+        # "created by X" and gate Edit/Delete affordances.
+        created_by_user_id="user-test",
         location=None,
         attendees=[],
         recurrence=None,

--- a/tests/ee/calendar/test_router_mount.py
+++ b/tests/ee/calendar/test_router_mount.py
@@ -1,5 +1,9 @@
 # tests/ee/calendar/test_router_mount.py — Calendar router mount smoke test.
-# Created: 2026-05-19 (feat/calendar-router-mount).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H-NEW-1).
+#
+# Changes:
+# - _make_event_response now sets created_by_user_id; EventResponse
+#   requires it after the H-NEW-1 fix.
 #
 # Verifies that mount_cloud() wires the calendar router into the cloud app
 # so /api/v1/calendar/* endpoints are reachable. The companion file
@@ -50,6 +54,8 @@ def _make_event_response() -> EventResponse:
         starts_at=datetime(2026, 5, 19, 9, 0),
         ends_at=datetime(2026, 5, 19, 10, 0),
         timezone="UTC",
+        # H-NEW-1: required on EventResponse now.
+        created_by_user_id="user-test",
         location=None,
         attendees=[],
         recurrence=None,

--- a/tests/ee/calendar/test_service.py
+++ b/tests/ee/calendar/test_service.py
@@ -1,5 +1,15 @@
 # tests/ee/calendar/test_service.py — service-layer tests.
-# Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142).
+#
+# Changes:
+# - Added ``fake_calendar_store`` (auto-applied) that patches
+#   ``_CalendarDoc`` to a stub returning ``None`` on every ``find_one``.
+#   The service then falls back to its synthetic default calendar so
+#   existing tests keep their pre-#1142 behaviour (within-workspace
+#   reads/writes by the caller still pass).
+# - update_event payload assertion lives in test_policy.py /
+#   test_update_event_changed_fields below — the bus event now carries
+#   ``changed_fields`` (names only), not raw content.
 #
 # Approach: we don't spin up real Mongo. Instead we replace _EventDoc at
 # the class level with a fake that mimics the small slice of Beanie we
@@ -192,6 +202,32 @@ def fake_store(monkeypatch) -> _FakeStore:
     return store
 
 
+class _FakeCalendarStore:
+    """Stand-in for ``_CalendarDoc``. By default returns ``None`` on every
+    ``find_one`` so the service falls back to its synthetic default
+    calendar (the bridge until Calendar CRUD ships). Individual tests can
+    set ``.rows`` to override and exercise the private/shared paths."""
+
+    def __init__(self) -> None:
+        self.rows: list[Any] = []
+
+    async def find_one(self, query: dict[str, Any]) -> Any | None:
+        for row in self.rows:
+            if all(getattr(row, k, None) == v for k, v in query.items() if not k.startswith("_")):
+                return row
+        return None
+
+
+@pytest.fixture(autouse=True)
+def fake_calendar_store(monkeypatch) -> _FakeCalendarStore:
+    """Patch ``_CalendarDoc`` to return ``None`` on every lookup so the
+    service exercises its synthetic-default fallback. Auto-applied to
+    every test in this module so existing behaviour is preserved."""
+    store = _FakeCalendarStore()
+    monkeypatch.setattr(service_module, "_CalendarDoc", store)
+    return store
+
+
 def _new_doc(
     store: _FakeStore,
     *,
@@ -337,15 +373,25 @@ async def test_get_event_cross_workspace_returns_404(ctx, other_ctx, fake_store)
 async def test_get_freebusy_multi_attendee(ctx, fake_store, monkeypatch):
     """Cover the freebusy path. compute_freebusy is patched because the
     fake store doesn't model the embedded-attendee $in filter that the
-    real Mongo query uses."""
+    real Mongo query uses. The H2 access-resolver is also patched so we
+    bypass the unknown-attendee gate (separately covered in
+    test_freebusy.py)."""
     from ee.calendar import service as svc
 
-    async def _fake_compute(workspace_id, attendee_emails, starts_at, ends_at):
+    async def _fake_compute(
+        workspace_id, attendee_emails, starts_at, ends_at, accessible_calendar_ids=None
+    ):
         from ee.calendar.domain import FreeBusy
 
         return [FreeBusy(attendee_email=e, busy_periods=[]) for e in attendee_emails]
 
+    async def _fake_access(ctx, *, attendee_emails, starts_at, ends_at):
+        # All emails resolve to the canonical "cal-1" — bypass the
+        # unknown-attendee gate so this test focuses on the happy path.
+        return {"cal-1"}
+
     monkeypatch.setattr(svc, "compute_freebusy", _fake_compute)
+    monkeypatch.setattr(svc, "_accessible_calendar_ids_with_email_match", _fake_access)
 
     body = FreeBusyRequest(
         attendee_emails=["a@example.com", "b@example.com"],

--- a/tests/ee/calendar/test_service.py
+++ b/tests/ee/calendar/test_service.py
@@ -1,5 +1,5 @@
 # tests/ee/calendar/test_service.py — service-layer tests.
-# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142).
+# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 + H-NEW-1).
 #
 # Changes:
 # - Added ``fake_calendar_store`` (auto-applied) that patches
@@ -10,6 +10,12 @@
 # - update_event payload assertion lives in test_policy.py /
 #   test_update_event_changed_fields below — the bus event now carries
 #   ``changed_fields`` (names only), not raw content.
+# - H-NEW-1: ``_FakeDoc`` now defaults ``created_by_user_id`` to
+#   "user-test" (matching ctx()), and ``_new_doc`` accepts an explicit
+#   override so non-creator scenarios can be set up. Four new tests cover
+#   the synthetic-calendar modify-authz behaviour: creator can update +
+#   delete, non-creator can't, and create still works for any workspace
+#   member.
 #
 # Approach: we don't spin up real Mongo. Instead we replace _EventDoc at
 # the class level with a fake that mimics the small slice of Beanie we
@@ -172,6 +178,10 @@ class _FakeDoc:
         self.source_external_id = getattr(self, "source_external_id", None)
         self.created_at = getattr(self, "created_at", datetime.now(UTC))
         self.updated_at = getattr(self, "updated_at", datetime.now(UTC))
+        # H-NEW-1: required on the real _EventDoc — default here to keep
+        # legacy tests happy. The user id matches the default ctx() fixture
+        # so creator-equality passes by default.
+        self.created_by_user_id = getattr(self, "created_by_user_id", "user-test")
 
     async def insert(self) -> None:
         self._store.rows[str(self.id)] = self
@@ -237,6 +247,7 @@ def _new_doc(
     starts_at: datetime | None = None,
     ends_at: datetime | None = None,
     attendees: list[dict] | None = None,
+    created_by_user_id: str = "user-test",
 ) -> _FakeDoc:
     """Helper: stuff a doc into the fake store directly (skip service)."""
     oid = ObjectId()
@@ -252,6 +263,10 @@ def _new_doc(
         description="",
         location=None,
         attendees=attendees or [],
+        # H-NEW-1: defaults to the ctx() user so happy-path callers don't
+        # have to know about this. Pass a different id to exercise the
+        # non-creator denial path on update_event / delete_event.
+        created_by_user_id=created_by_user_id,
     )
     # mirror the id as a string field so `_FieldEq("id_str", oid)` works.
     doc.id_str = oid
@@ -434,3 +449,103 @@ async def test_detect_conflicts_overlapping_events(ctx, fake_store, bus_spy, mon
     assert len(report.conflicting_events) == 1
     topics = [t for t, _ in bus_spy]
     assert TOPIC_CONFLICT_DETECTED in topics
+
+
+# ---------------------------------------------------------------------------
+# H-NEW-1: event-level modify authz on the synthetic-default Calendar path.
+# ---------------------------------------------------------------------------
+#
+# The audit on #1143 surfaced that _load_calendar returns a synthetic Calendar
+# with owner_user_id = ctx.user_id whenever no _CalendarDoc row exists. The
+# autouse `fake_calendar_store` fixture in this module always returns None
+# from find_one, so every test here exercises that synthetic-default path.
+# These four tests assert that policy.check_event_modify closes the gap.
+
+
+async def test_update_event_non_creator_denied_synthetic_calendar(fake_store, bus_spy):
+    """Bob (same workspace, NOT the event creator) cannot update Alice's event
+    even though the parent Calendar is synthetic-default."""
+    from ee.calendar._context import RequestContext
+    from ee.cloud.shared.errors import Forbidden
+
+    # Event was created by alice. Bob shares the workspace.
+    doc = _new_doc(fake_store, workspace="ws-test", created_by_user_id="alice")
+    bob_ctx = RequestContext(workspace_id="ws-test", user_id="bob")
+
+    with pytest.raises(Forbidden) as exc_info:
+        await service_module.update_event(
+            bob_ctx,
+            str(doc.id),
+            UpdateEventRequest(title="Hijacked"),
+        )
+    assert "event.modify_denied" in str(exc_info.value)
+
+
+async def test_delete_event_non_creator_denied_synthetic_calendar(fake_store, bus_spy):
+    """Same shape as the update test but for delete_event — bob can't drop
+    alice's event on the synthetic-default Calendar."""
+    from ee.calendar._context import RequestContext
+    from ee.cloud.shared.errors import Forbidden
+
+    doc = _new_doc(fake_store, workspace="ws-test", created_by_user_id="alice")
+    bob_ctx = RequestContext(workspace_id="ws-test", user_id="bob")
+
+    with pytest.raises(Forbidden) as exc_info:
+        await service_module.delete_event(bob_ctx, str(doc.id))
+    assert "event.modify_denied" in str(exc_info.value)
+    # Event still in the store — delete must have aborted before .delete().
+    assert str(doc.id) in fake_store.rows
+
+
+async def test_update_event_creator_allowed_synthetic_calendar(ctx, fake_store, bus_spy):
+    """Regression: the creator can still update their own event on a
+    synthetic-default Calendar (happy path after the H-NEW-1 fix)."""
+    # ctx fixture: user_id="user-test". Doc default creator matches.
+    doc = _new_doc(fake_store, workspace=ctx.workspace_id, title="Original")
+    resp = await service_module.update_event(
+        ctx,
+        str(doc.id),
+        UpdateEventRequest(title="Edited by creator"),
+    )
+    assert resp.title == "Edited by creator"
+    assert resp.created_by_user_id == "user-test"
+
+
+async def test_create_event_synthetic_calendar_still_works(ctx, fake_store, bus_spy):
+    """Regression: any workspace member can create events on a synthetic-
+    default Calendar. The H-NEW-1 fix gates update/delete, not create."""
+    body = CreateEventRequest(
+        calendar_id="cal-1",
+        title="Newcomer's first event",
+        starts_at=datetime(2026, 5, 20, 14, 0),
+        ends_at=datetime(2026, 5, 20, 15, 0),
+        timezone="UTC",
+    )
+    resp = await service_module.create_event(ctx, body)
+    # Creator stamped from ctx.user_id, never from the body.
+    assert resp.created_by_user_id == ctx.user_id
+    assert resp.title == "Newcomer's first event"
+
+
+async def test_create_event_ignores_client_supplied_creator(ctx, fake_store, bus_spy):
+    """The DTO doesn't accept created_by_user_id; even if a malicious client
+    appends it, Pydantic's default model_config (extra=ignore) drops it and
+    the service stamps ctx.user_id."""
+    # Build the DTO with extra fields — Pydantic silently drops them by default.
+    raw = {
+        "calendar_id": "cal-1",
+        "title": "Spoof attempt",
+        "starts_at": datetime(2026, 5, 20, 14, 0),
+        "ends_at": datetime(2026, 5, 20, 15, 0),
+        "timezone": "UTC",
+        # Attempt to override the creator. Should be ignored.
+        "created_by_user_id": "someone-else",
+    }
+    body = CreateEventRequest.model_validate(raw)
+    # Sanity: DTO doesn't carry the spoofed field on the way in.
+    assert not hasattr(body, "created_by_user_id")
+
+    resp = await service_module.create_event(ctx, body)
+    # Service stamped its own ctx.user_id, not the spoofed value.
+    assert resp.created_by_user_id == ctx.user_id
+    assert resp.created_by_user_id != "someone-else"


### PR DESCRIPTION
## Summary

Addresses the three High security findings from #1132's security audit (per issue #1142). Plus four Mediums that were tractable in scope.

## Findings addressed

| Finding | File:line | Fix |
|---|---|---|
| H1 - policy.py dead code | service.py multiple | Wired check_calendar_read/write into every CRUD service fn |
| H2 - freebusy oracle | freebusy.py / service.py | Restrict attendee emails to requester-accessible set |
| H3 - datetime 500 | router.py list_events | Use FastAPI native datetime type -> 422 on bad input |
| M1 - RRULE no length cap | domain.py | Field(max_length=2048) |
| M2 - exceptions unbounded | domain.py | Field(max_length=500) |
| M3 - email not validated | domain.py | EmailStr |
| M4 - bus event leaks raw content | service.py update_event | Changed dict to log field names only, not values |

## Deferred to follow-up

- M5 audit log emission (separate concern - needs AuditLogger.log wiring decision across the cloud)
- L1 push_to_gcalendar credentials
- L2 sync.py content caps
- L3 sync.py raw-event logging

## Tests added

- tests/ee/calendar/test_policy.py (new) - authz scenarios
- Expanded test_freebusy.py - attendee-access restriction
- Expanded test_router.py - malformed datetime returns 422

## Test plan
- [x] ruff check / format pass
- [x] pytest tests/ee/calendar/ all green (69 passed)
- [x] Targets ee (NOT dev - ee-separation directive)
- [ ] Captain review