### PR TITLE
feat(core): extension-point Protocols, convert 7 surfaces (OSS-EE split Phase 3a)

### DIFF
--- a/ee/pocketpaw_ee/api.py
+++ b/ee/pocketpaw_ee/api.py
@@ -1,46 +1,13 @@
-# ee/api.py — Singleton entry points for the ee-scoped stores.
-# Created: 2026-03-30 — Bridges instinct_tools.py to the InstinctStore.
-# Updated: 2026-04-20 — Added get_paw_print_store() so the paw_print router
-#   can reach the SQLite-backed PawPrintStore from a non-DI import path.
-# The agent tools (pocketpaw.tools.builtin.instinct_tools) import from here
-# via `from ee.api import get_instinct_store`; paw_print router uses
-# `from ee.api import get_paw_print_store`.
+# pocketpaw_ee/api.py — backwards-compatible re-export shim.
+#
+# The singleton store factories moved to pocketpaw.stores (OSS core) in the
+# open-core split (Phase 3) — they are plain SQLite stores with no cloud
+# dependency. The enterprise routers (instinct/router.py, paw_print/router.py)
+# still import `from pocketpaw_ee.api import get_*_store`; this shim keeps
+# those import paths valid. New code should import from pocketpaw.stores.
 
 from __future__ import annotations
 
-from pathlib import Path
+from pocketpaw.stores import get_fabric_store, get_instinct_store, get_paw_print_store
 
-from pocketpaw.instinct.store import InstinctStore
-from pocketpaw.paw_print.store import PawPrintStore
-
-_DB_PATH = Path.home() / ".pocketpaw" / "instinct.db"
-_PAW_PRINT_DB_PATH = Path.home() / ".pocketpaw" / "paw_print.db"
-
-_store: InstinctStore | None = None
-_paw_print_store: PawPrintStore | None = None
-
-
-def get_instinct_store() -> InstinctStore:
-    """Return the global InstinctStore singleton.
-
-    Lazily creates the store on first call. The SQLite database is stored
-    at ~/.pocketpaw/instinct.db (same as the router uses).
-    """
-    global _store
-    if _store is None:
-        _store = InstinctStore(_DB_PATH)
-    return _store
-
-
-def get_paw_print_store() -> PawPrintStore:
-    """Return the global PawPrintStore singleton.
-
-    Lazily creates the store on first call. The SQLite database lives at
-    ~/.pocketpaw/paw_print.db. Referenced by `ee/paw_print/router.py` via
-    its `_store()` helper so the widget CRUD and event ingest endpoints
-    can reach the shared instance.
-    """
-    global _paw_print_store
-    if _paw_print_store is None:
-        _paw_print_store = PawPrintStore(_PAW_PRINT_DB_PATH)
-    return _paw_print_store
+__all__ = ["get_fabric_store", "get_instinct_store", "get_paw_print_store"]

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -1,0 +1,63 @@
+"""Entry-point provider classes for the OSS-EE extension surfaces.
+
+Core (`pocketpaw`) defines the Protocols in `pocketpaw.extensions` and
+discovers implementations via `importlib.metadata.entry_points`. This module
+collects every `pocketpaw_ee` provider in one place; the entry-points that
+point at these classes are declared in `pyproject.toml` (and will migrate to
+`ee/pyproject.toml` in Phase 4).
+
+Each provider does its heavy `pocketpaw_ee` imports lazily inside methods so
+that merely loading this module — which the registry does on first access —
+stays cheap and free of import cycles.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class CloudEventBusProvider:
+    """`pocketpaw.event_bus` — the process-wide async pub/sub bus."""
+
+    def get_event_bus(self) -> Any:
+        from pocketpaw_ee.cloud.shared.events import event_bus
+
+        return event_bus
+
+
+class CloudEmbeddingProvider:
+    """`pocketpaw.embeddings` — KB text/image embedder factory."""
+
+    def build_embedder(self, settings: Any) -> Any:
+        from pocketpaw_ee.cloud.embeddings import build_embedder
+
+        return build_embedder(settings)
+
+
+class MongoMemoryBackendProvider:
+    """`pocketpaw.memory_backends` — MongoDB-backed memory store."""
+
+    name = "mongodb"
+
+    def build(self, settings: Any) -> Any:
+        from pocketpaw_ee.cloud.memory.mongo_store import MongoMemoryStore
+
+        return MongoMemoryStore()
+
+
+class CloudCapabilityProvider:
+    """`pocketpaw.capabilities` — features the cloud product force-enables."""
+
+    def capabilities(self) -> dict[str, bool]:
+        from pocketpaw_ee.cloud import features
+
+        return {"chat_titles_enabled": features.chat_titles_enabled()}
+
+
+class CloudAuthProvider:
+    """`pocketpaw.auth` — FastAPI auth dependencies for cloud-mounted routes."""
+
+    def current_optional_user(self) -> Any:
+        from pocketpaw_ee.cloud.auth.core import current_optional_user
+
+        return current_optional_user

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -61,3 +61,71 @@ class CloudAuthProvider:
         from pocketpaw_ee.cloud.auth.core import current_optional_user
 
         return current_optional_user
+
+
+class CloudRouteProvider:
+    """`pocketpaw.routes` — mounts the multi-tenant cloud API."""
+
+    def mount(self, app: Any) -> None:
+        from pocketpaw_ee.cloud import mount_cloud
+
+        mount_cloud(app)
+
+
+class CloudLifecycleHook:
+    """`pocketpaw.lifecycle` — cloud DB init + admin/workspace seeding +
+    chat-title listener registration, run on dashboard startup."""
+
+    async def on_startup(self, app: Any) -> None:
+        import logging
+        import os
+
+        logger = logging.getLogger(__name__)
+
+        from pocketpaw_ee.cloud.db import init_cloud_db
+
+        mongo_uri = os.environ.get(
+            "CLOUD_MONGODB_URI", "mongodb://localhost:27017/paw-enterprise"
+        )
+        await init_cloud_db(mongo_uri)
+
+        from pocketpaw_ee.cloud.auth.core import (
+            ensure_default_agent_all_workspaces,
+            seed_admin,
+            seed_workspace,
+        )
+
+        admin = await seed_admin()
+        await seed_workspace(admin)
+        # Back-fill the pocketpaw agent for workspaces that predate agent seeding.
+        await ensure_default_agent_all_workspaces()
+
+        # Persist Haiku-generated chat titles into MongoDB.
+        try:
+            from pocketpaw_ee.cloud.sessions.title_listener import (
+                register as register_title_listener,
+            )
+
+            register_title_listener()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Cloud chat-title listener registration failed: %s", exc)
+
+    async def on_shutdown(self, app: Any) -> None:
+        # Cloud teardown is handled inside mount_cloud's own shutdown hook.
+        return None
+
+
+class CloudStorageBackend:
+    """`pocketpaw.storage_backends` — the EE Mongo-backed upload store."""
+
+    name = "cloud"
+
+    def adapter(self) -> Any:
+        from pocketpaw_ee.cloud.uploads.router import _ADAPTER
+
+        return _ADAPTER
+
+    def meta(self) -> Any:
+        from pocketpaw_ee.cloud.uploads.router import _META
+
+        return _META

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -388,6 +388,15 @@ cloud = "pocketpaw_ee.extensions:CloudCapabilityProvider"
 [project.entry-points."pocketpaw.auth"]
 cloud = "pocketpaw_ee.extensions:CloudAuthProvider"
 
+[project.entry-points."pocketpaw.routes"]
+cloud = "pocketpaw_ee.extensions:CloudRouteProvider"
+
+[project.entry-points."pocketpaw.lifecycle"]
+cloud = "pocketpaw_ee.extensions:CloudLifecycleHook"
+
+[project.entry-points."pocketpaw.storage_backends"]
+cloud = "pocketpaw_ee.extensions:CloudStorageBackend"
+
 [project.urls]
 Homepage = "https://pocketpaw.xyz"
 Repository = "https://github.com/pocketpaw/pocketpaw"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,6 +368,26 @@ dev = [
 [project.scripts]
 pocketpaw = "pocketpaw.__main__:main"
 
+# --- Extension-point providers (OSS-EE split, Phase 3) ---
+# Core (`pocketpaw`) discovers these via importlib entry-points; see
+# pocketpaw/extensions.py for the Protocols and pocketpaw/_registry.py for
+# discovery. These all point at pocketpaw_ee and migrate to ee/pyproject.toml
+# in Phase 4 when the EE package is split out.
+[project.entry-points."pocketpaw.event_bus"]
+cloud = "pocketpaw_ee.extensions:CloudEventBusProvider"
+
+[project.entry-points."pocketpaw.embeddings"]
+cloud = "pocketpaw_ee.extensions:CloudEmbeddingProvider"
+
+[project.entry-points."pocketpaw.memory_backends"]
+mongodb = "pocketpaw_ee.extensions:MongoMemoryBackendProvider"
+
+[project.entry-points."pocketpaw.capabilities"]
+cloud = "pocketpaw_ee.extensions:CloudCapabilityProvider"
+
+[project.entry-points."pocketpaw.auth"]
+cloud = "pocketpaw_ee.extensions:CloudAuthProvider"
+
 [project.urls]
 Homepage = "https://pocketpaw.xyz"
 Repository = "https://github.com/pocketpaw/pocketpaw"

--- a/src/pocketpaw/_registry.py
+++ b/src/pocketpaw/_registry.py
@@ -1,0 +1,59 @@
+"""Runtime discovery of extension implementations registered via entry-points.
+
+Implementations declared under a ``pocketpaw.*`` entry-point group (see
+`pocketpaw.extensions` for the group names) are loaded lazily on first
+access and cached. An OSS install with no `pocketpaw_ee` package on disk
+simply finds no entry-points and pays no import cost for cloud features.
+
+Usage::
+
+    from pocketpaw._registry import first, providers, has
+
+    provider = first("pocketpaw.embeddings")
+    embedder = provider.build_embedder(settings) if provider else None
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from importlib.metadata import entry_points
+from typing import Any
+
+_log_once: set[str] = set()
+
+
+@lru_cache(maxsize=None)
+def providers(group: str) -> tuple[Any, ...]:
+    """Return instantiated providers for *group*, cached for the process.
+
+    Each entry-point must point at a zero-arg callable (typically the
+    provider class). A provider whose module fails to import is skipped
+    with a debug log rather than taking the whole process down — a broken
+    EE plugin must not break an otherwise-working core.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    found: list[Any] = []
+    for ep in entry_points(group=group):
+        try:
+            found.append(ep.load()())
+        except Exception as exc:  # noqa: BLE001 — isolate plugin failures
+            logger.warning("extension %r in group %r failed to load: %s", ep.name, group, exc)
+    return tuple(found)
+
+
+def first(group: str) -> Any | None:
+    """Return the first registered provider for *group*, or ``None``."""
+    items = providers(group)
+    return items[0] if items else None
+
+
+def has(group: str) -> bool:
+    """True if any provider is registered for *group*."""
+    return bool(providers(group))
+
+
+def clear_cache() -> None:
+    """Drop the provider cache. For tests that install/remove entry-points."""
+    providers.cache_clear()

--- a/src/pocketpaw/_registry.py
+++ b/src/pocketpaw/_registry.py
@@ -15,14 +15,12 @@ Usage::
 
 from __future__ import annotations
 
-from functools import lru_cache
+from functools import cache
 from importlib.metadata import entry_points
 from typing import Any
 
-_log_once: set[str] = set()
 
-
-@lru_cache(maxsize=None)
+@cache
 def providers(group: str) -> tuple[Any, ...]:
     """Return instantiated providers for *group*, cached for the process.
 

--- a/src/pocketpaw/api/serve.py
+++ b/src/pocketpaw/api/serve.py
@@ -90,16 +90,18 @@ def create_api_app():
     app.include_router(mission_control_router, prefix="/api/mission-control")
     app.include_router(deep_work_router, prefix="/api/deep-work")
 
-    # --- Mount enterprise cloud module FIRST (takes priority over core) --
-    try:
-        from pocketpaw_ee.cloud import mount_cloud
+    # --- Mount enterprise route providers FIRST (priority over core) -----
+    from pocketpaw._registry import first as _first_provider
 
-        mount_cloud(app)
-        logger.info("Enterprise cloud module mounted successfully")
-    except ImportError as exc:
-        logger.debug("Enterprise cloud module not available: %s", exc)
-    except Exception:
-        logger.warning("Cloud module mount failed", exc_info=True)
+    _route_provider = _first_provider("pocketpaw.routes")
+    if _route_provider is not None:
+        try:
+            _route_provider.mount(app)
+            logger.info("Enterprise route provider mounted successfully")
+        except Exception:
+            logger.warning("Route provider mount failed", exc_info=True)
+    else:
+        logger.debug("No enterprise route provider registered")
 
     # --- Mount all /api/v1/ routers -------------------------------------
     mount_v1_routers(app)

--- a/src/pocketpaw/api/v1/chat.py
+++ b/src/pocketpaw/api/v1/chat.py
@@ -24,19 +24,24 @@ from fastapi.responses import StreamingResponse
 from pocketpaw.api.deps import require_scope
 from pocketpaw.api.v1.schemas.chat import ChatRequest, ChatResponse
 
-# ── Optional ee.cloud auth wiring ──────────────────────────────────────
-# When the enterprise cloud module is mounted, we want to read the caller's
-# authenticated user + active workspace off the JWT so agent-created pockets
-# route to the right tenant. When it isn't mounted (self-hosted OSS, CLI,
-# Telegram), we fall back to a no-op dep that yields ``(None, None)`` — the
-# downstream pocket creator keeps its current first-user heuristic.
+# ── Optional enterprise auth wiring ────────────────────────────────────
+# When an enterprise auth provider is registered (entry-point group
+# ``pocketpaw.auth``), we read the caller's authenticated user + active
+# workspace off the JWT so agent-created pockets route to the right tenant.
+# In an OSS install with no provider we fall back to a no-op dep that
+# yields ``None`` — the downstream pocket creator keeps its first-user
+# heuristic. Core never imports ``pocketpaw_ee`` directly.
+_cloud_optional_user = None
 try:
-    from pocketpaw_ee.cloud.auth.core import current_optional_user as _cloud_optional_user
+    from pocketpaw._registry import first as _first_provider
 
-    _CLOUD_AUTH_AVAILABLE = True
+    _auth_provider = _first_provider("pocketpaw.auth")
+    if _auth_provider is not None:
+        _cloud_optional_user = _auth_provider.current_optional_user()
 except Exception:  # noqa: BLE001
-    _cloud_optional_user = None  # type: ignore[assignment]
-    _CLOUD_AUTH_AVAILABLE = False
+    _cloud_optional_user = None
+
+_CLOUD_AUTH_AVAILABLE = _cloud_optional_user is not None
 
 
 def _noop_user_dep() -> None:

--- a/src/pocketpaw/automations/evaluator.py
+++ b/src/pocketpaw/automations/evaluator.py
@@ -134,9 +134,8 @@ class AutomationEvaluator:
         """Propose an Instinct action for human approval."""
         try:
             # Lazy import to avoid circular deps and heavy startup cost
-            from pocketpaw_ee.api import get_instinct_store
-
             from pocketpaw.instinct.models import ActionTrigger
+            from pocketpaw.stores import get_instinct_store
 
             instinct = get_instinct_store()
             trigger = ActionTrigger(

--- a/src/pocketpaw/bootstrap/context_builder.py
+++ b/src/pocketpaw/bootstrap/context_builder.py
@@ -563,13 +563,14 @@ class AgentContextBuilder:
         if not getattr(settings, "kb_vectors_enabled", False):
             return None
 
-        try:
-            from pocketpaw_ee.cloud.embeddings import build_embedder
-        except Exception:
-            logger.debug("embeddings package unavailable; falling back to BM25")
+        from pocketpaw._registry import first
+
+        provider = first("pocketpaw.embeddings")
+        if provider is None:
+            logger.debug("no embeddings provider registered; falling back to BM25")
             return None
 
-        embedder = build_embedder(settings)
+        embedder = provider.build_embedder(settings)
         if embedder is None or "image" not in embedder.supports_modalities:
             return None
 

--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -211,16 +211,18 @@ app.include_router(mission_control_router, prefix="/api/mission-control")
 
 app.include_router(deep_work_router, prefix="/api/deep-work")
 
-# Mount enterprise cloud module FIRST (takes priority over core v1 routers)
-try:
-    from pocketpaw_ee.cloud import mount_cloud
+# Mount enterprise route providers FIRST (priority over core v1 routers)
+from pocketpaw._registry import first as _first_provider
 
-    mount_cloud(app)
-    logger.info("Enterprise cloud module mounted successfully")
-except ImportError as exc:
-    logger.debug("Enterprise cloud module not available: %s", exc)
-except Exception:
-    logger.warning("Cloud module mount failed", exc_info=True)
+_route_provider = _first_provider("pocketpaw.routes")
+if _route_provider is not None:
+    try:
+        _route_provider.mount(app)
+        logger.info("Enterprise route provider mounted successfully")
+    except Exception:
+        logger.warning("Route provider mount failed", exc_info=True)
+else:
+    logger.debug("No enterprise route provider registered")
 
 # Mount API v1 routers at /api/v1/ (canonical) — see api/v1/__init__.py
 mount_v1_routers(app)
@@ -1808,21 +1810,6 @@ def run_dashboard(
                 logger.error("Max restart limit (%d) reached, exiting.", _MAX_RESTARTS)
                 break
             logger.info("Restarting server with updated settings...")
-
-
-# ---------------------------------------------------------------------------
-# Wrap FastAPI app with Socket.IO ASGI middleware (enterprise real-time chat)
-# Must be AFTER all routes and middleware are registered.
-# ---------------------------------------------------------------------------
-try:
-    from pocketpaw_ee.cloud.socketio_server import wrap_asgi_app
-
-    app = wrap_asgi_app(app)
-    logger.info("Socket.IO ASGI wrapper applied")
-except ImportError:
-    pass
-except Exception as _sio_exc:
-    logger.warning("Socket.IO wrapper failed: %s", _sio_exc)
 
 
 if __name__ == "__main__":

--- a/src/pocketpaw/dashboard_lifecycle.py
+++ b/src/pocketpaw/dashboard_lifecycle.py
@@ -173,41 +173,18 @@ async def startup_event(
     except ImportError:
         pass
 
-    # Initialize enterprise cloud DB (Beanie/MongoDB) — best-effort
-    try:
-        import os
+    # Run enterprise lifecycle startup hooks — best-effort. The cloud hook
+    # initializes the Beanie/MongoDB database, seeds the default admin +
+    # workspace, back-fills agents and registers the chat-title listener.
+    # Discovered via the `pocketpaw.lifecycle` entry-point; an OSS install
+    # has no provider and skips this entirely.
+    from pocketpaw._registry import providers as _ext_providers
 
-        from pocketpaw_ee.cloud.db import init_cloud_db
-
-        mongo_uri = os.environ.get("CLOUD_MONGODB_URI", "mongodb://localhost:27017/paw-enterprise")
-        await init_cloud_db(mongo_uri)
-        # Seed default admin user and workspace
-        from pocketpaw_ee.cloud.auth.core import (
-            ensure_default_agent_all_workspaces,
-            seed_admin,
-            seed_workspace,
-        )
-
-        admin = await seed_admin()
-        await seed_workspace(admin)
-        # Back-fill the pocketpaw agent for workspaces that predate agent seeding.
-        await ensure_default_agent_all_workspaces()
-
-        # Persist Haiku-generated chat titles into MongoDB. The pocketpaw bus
-        # emits ``session_titled`` after the first user message; this listener
-        # writes the title onto the Session document so it survives a refresh.
+    for _hook in _ext_providers("pocketpaw.lifecycle"):
         try:
-            from pocketpaw_ee.cloud.sessions.title_listener import (
-                register as register_title_listener,
-            )
-
-            register_title_listener()
+            await _hook.on_startup(None)
         except Exception as exc:
-            logger.warning("Cloud chat-title listener registration failed: %s", exc)
-    except ImportError:
-        logger.debug("Enterprise cloud module not available — skipping MongoDB init")
-    except Exception as exc:
-        logger.warning("Enterprise cloud DB init failed (cloud features disabled): %s", exc)
+            logger.warning("Lifecycle startup hook failed (cloud features disabled): %s", exc)
 
     # Start the cloud agent pool GC task. Previously registered via
     # ``@app.on_event("startup")`` inside ``mount_cloud()`` but that path is

--- a/src/pocketpaw/extensions.py
+++ b/src/pocketpaw/extensions.py
@@ -89,11 +89,12 @@ class RouteProvider(Protocol):
     """Entry-point group: ``pocketpaw.routes``
 
     Mounts additional sub-applications / routers onto the dashboard app
-    (the multi-tenant cloud API, the Socket.IO server, …).
+    (the multi-tenant cloud API).
     """
 
-    def mount(self, app: Any) -> Any:
-        """Mount onto *app*; may return a wrapped ASGI app or ``None``."""
+    def mount(self, app: Any) -> None:
+        """Mount sub-applications / routers onto *app*. Called early, before
+        the core v1 routers, so EE routes take priority."""
         ...
 
 

--- a/src/pocketpaw/extensions.py
+++ b/src/pocketpaw/extensions.py
@@ -1,0 +1,163 @@
+"""Extension-point Protocols for pluggable PocketPaw functionality.
+
+Core (`pocketpaw`) defines narrow `typing.Protocol` contracts here. Concrete
+implementations live in `pocketpaw_ee` (and potentially third-party packages)
+and are discovered at runtime via `importlib.metadata.entry_points` — see
+`pocketpaw._registry`. Core code must never `import pocketpaw_ee` directly;
+the OSS-EE split (open-core) depends on that boundary, and an `import-linter`
+contract enforces it.
+
+Each Protocol documents the entry-point group that carries its implementations.
+An entry-point points at a zero-arg callable (usually the class itself) that
+the registry instantiates once and caches.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class EventBusProvider(Protocol):
+    """Entry-point group: ``pocketpaw.event_bus``
+
+    Supplies the process-wide async event bus. When no provider is
+    registered, core falls back to a local in-process bus.
+    """
+
+    def get_event_bus(self) -> Any: ...
+
+
+@runtime_checkable
+class EmbeddingProvider(Protocol):
+    """Entry-point group: ``pocketpaw.embeddings``
+
+    Builds a text/image embedder for knowledge-base retrieval.
+    """
+
+    def build_embedder(self, settings: Any) -> Any: ...
+
+
+@runtime_checkable
+class MemoryBackendProvider(Protocol):
+    """Entry-point group: ``pocketpaw.memory_backends``
+
+    Supplies an alternative `MemoryStoreProtocol` implementation keyed by
+    ``name`` (e.g. ``"mongodb"``). Core ships ``file`` and ``mem0``.
+    """
+
+    name: str
+
+    def build(self, settings: Any) -> Any: ...
+
+
+@runtime_checkable
+class CapabilityProvider(Protocol):
+    """Entry-point group: ``pocketpaw.capabilities``
+
+    Reports which optional capabilities an install has. Core's
+    ``features.py`` merges every provider's map into the capability registry.
+    """
+
+    def capabilities(self) -> dict[str, bool]: ...
+
+
+@runtime_checkable
+class AuthProvider(Protocol):
+    """Entry-point group: ``pocketpaw.auth``
+
+    Supplies FastAPI auth dependencies for routes that behave differently
+    under multi-tenant cloud auth vs the single-tenant dashboard.
+    """
+
+    def current_optional_user(self) -> Any: ...
+
+
+@runtime_checkable
+class StoreProvider(Protocol):
+    """Entry-point group: ``pocketpaw.stores``
+
+    Overrides the default singleton store factories (instinct, fabric, …).
+    Core ships local SQLite-backed defaults; EE swaps in cloud-backed ones.
+    """
+
+    def get_store(self, name: str) -> Any: ...
+
+
+@runtime_checkable
+class RouteProvider(Protocol):
+    """Entry-point group: ``pocketpaw.routes``
+
+    Mounts additional sub-applications / routers onto the dashboard app
+    (the multi-tenant cloud API, the Socket.IO server, …).
+    """
+
+    def mount(self, app: Any) -> Any:
+        """Mount onto *app*; may return a wrapped ASGI app or ``None``."""
+        ...
+
+
+@runtime_checkable
+class LifecycleHook(Protocol):
+    """Entry-point group: ``pocketpaw.lifecycle``
+
+    Startup/shutdown hooks run by the dashboard lifecycle. Used for things
+    like initializing the cloud database or registering event listeners.
+    """
+
+    async def on_startup(self, app: Any) -> None: ...
+
+    async def on_shutdown(self, app: Any) -> None: ...
+
+
+@runtime_checkable
+class StorageBackend(Protocol):
+    """Entry-point group: ``pocketpaw.storage_backends``
+
+    Supplies a file-storage adapter + metadata store for upload resolution.
+    """
+
+    name: str
+
+    def adapter(self) -> Any: ...
+
+    def meta(self) -> Any: ...
+
+
+@runtime_checkable
+class ModelProvider(Protocol):
+    """Entry-point group: ``pocketpaw.models``
+
+    Exposes Beanie document classes (cloud entities: Agent, Session, User,
+    Workspace, …) so core code can look them up by name without importing
+    `pocketpaw_ee`. Returns ``None`` for unknown names.
+    """
+
+    def get_model(self, name: str) -> type | None: ...
+
+
+@runtime_checkable
+class McpServerProvider(Protocol):
+    """Entry-point group: ``pocketpaw.mcp_servers``
+
+    Builds in-process MCP servers exposed to agent backends. Each provider
+    returns ``(name, config_entry)`` or ``None`` when its feature is
+    unavailable in the current context.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None: ...
+
+    def tool_ids(self) -> list[str]:
+        """Tool ids this server exposes (for allowlist matching)."""
+        ...
+
+
+@runtime_checkable
+class AgentExtension(Protocol):
+    """Entry-point group: ``pocketpaw.agent_extensions``
+
+    Installs agent-runtime extensions — the cloud chat agent service, the
+    pocket specialist tool, etc.
+    """
+
+    def install(self, agent_runtime: Any) -> None: ...

--- a/src/pocketpaw/features.py
+++ b/src/pocketpaw/features.py
@@ -1,8 +1,9 @@
 """Feature flag resolution.
 
-Reads OSS settings, but allows ``ee.cloud.features`` to force-on specific
-capabilities when running in cloud mode. ee.cloud is imported lazily so OSS
-builds without the ee package continue to work.
+Reads OSS settings, but lets enterprise capability providers force-on
+specific features when running in cloud mode. Providers are registered via
+the ``pocketpaw.capabilities`` entry-point and discovered through the
+extension registry — core never imports ``pocketpaw_ee`` directly.
 """
 
 from __future__ import annotations
@@ -11,18 +12,17 @@ from pocketpaw.config import Settings
 
 
 def _cloud_override(name: str) -> bool | None:
-    """Return True/False if ee.cloud forces a feature on/off, else None."""
-    try:
-        from pocketpaw_ee.cloud import features as cloud_features  # type: ignore[import-not-found]
-    except ImportError:
-        return None
-    getter = getattr(cloud_features, name, None)
-    if getter is None:
-        return None
-    try:
-        return bool(getter())
-    except Exception:
-        return None
+    """Return True/False if a capability provider forces *name*, else None."""
+    from pocketpaw._registry import providers
+
+    for provider in providers("pocketpaw.capabilities"):
+        try:
+            caps = provider.capabilities()
+        except Exception:
+            continue
+        if name in caps:
+            return bool(caps[name])
+    return None
 
 
 def chat_titles_enabled(settings: Settings) -> bool:

--- a/src/pocketpaw/memory/manager.py
+++ b/src/pocketpaw/memory/manager.py
@@ -54,13 +54,19 @@ def create_memory_store(
         MemoryStoreProtocol implementation
     """
     if backend == "mongodb":
-        # Lazy import so OSS builds don't need motor/beanie loaded.
-        from pocketpaw_ee.cloud.memory.mongo_store import (
-            MongoMemoryStore,  # type: ignore[import-not-found]
-        )
+        # MongoDB is an enterprise memory backend, supplied via the
+        # `pocketpaw.memory_backends` entry-point. OSS builds have no
+        # provider and never reach this branch with backend="mongodb".
+        from pocketpaw._registry import providers
 
-        logger.info("Using MongoDB memory backend (ee)")
-        return MongoMemoryStore()
+        for provider in providers("pocketpaw.memory_backends"):
+            if getattr(provider, "name", None) == "mongodb":
+                logger.info("Using MongoDB memory backend (ee)")
+                return provider.build(None)
+        raise RuntimeError(
+            "memory backend 'mongodb' requested but no provider is registered "
+            "(install pocketpaw_ee for the cloud memory backend)"
+        )
     if backend == "mem0":
         try:
             # Check if mem0 is actually available before creating store

--- a/src/pocketpaw/runtime/connector_bus.py
+++ b/src/pocketpaw/runtime/connector_bus.py
@@ -21,11 +21,21 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-from pocketpaw_ee.cloud.shared.events import event_bus
-
+from pocketpaw._registry import first
 from pocketpaw.connectors.registry import ConnectorRegistry, _create_native_adapter
 
 logger = logging.getLogger(__name__)
+
+
+def _get_event_bus() -> Any:
+    """Return the event bus from the registered provider, or ``None``.
+
+    The bus is an enterprise extension (entry-point group
+    ``pocketpaw.event_bus``). An OSS install with no provider has no
+    cross-domain bus — the connector listener simply does not register.
+    """
+    provider = first("pocketpaw.event_bus")
+    return provider.get_event_bus() if provider else None
 
 # Topics shared with ee/cloud/connectors/service.py
 EXEC_REQUESTED = "connector.exec.requested"
@@ -52,8 +62,12 @@ def register_listener(connectors_dir: Path | None = None) -> None:
     global _registered
     if _registered:
         return
+    bus = _get_event_bus()
+    if bus is None:
+        logger.debug("connector bus listener skipped — no event_bus provider")
+        return
     handler = _build_handler(connectors_dir or Path("connectors"))
-    event_bus.subscribe(EXEC_REQUESTED, handler)
+    bus.subscribe(EXEC_REQUESTED, handler)
     _registered = True
     logger.info("connector bus listener registered on %s", EXEC_REQUESTED)
 
@@ -161,7 +175,11 @@ async def _emit_completed(
     connector: str = "",
     action: str = "",
 ) -> None:
-    await event_bus.emit(
+    bus = _get_event_bus()
+    if bus is None:
+        logger.debug("connector exec result dropped — no event_bus provider")
+        return
+    await bus.emit(
         EXEC_COMPLETED,
         {
             "request_id": request_id,

--- a/src/pocketpaw/stores.py
+++ b/src/pocketpaw/stores.py
@@ -1,0 +1,49 @@
+"""Process-wide singletons for the local SQLite-backed runtime stores.
+
+Instinct, Fabric and Paw Print all keep their state in SQLite under
+``~/.pocketpaw/``. These factories return a lazily-created singleton each so
+agent tools, automations and routers share one instance per process.
+
+This is plain core infrastructure — there is no cloud-backed override. The
+factories moved here from ``pocketpaw_ee/api.py`` in the OSS-EE split
+(Phase 3); ``pocketpaw_ee.api`` now re-exports from this module for the
+enterprise routers that still import via that path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pocketpaw.fabric.store import FabricStore
+from pocketpaw.instinct.store import InstinctStore
+from pocketpaw.paw_print.store import PawPrintStore
+
+_DATA_DIR = Path.home() / ".pocketpaw"
+
+_instinct_store: InstinctStore | None = None
+_fabric_store: FabricStore | None = None
+_paw_print_store: PawPrintStore | None = None
+
+
+def get_instinct_store() -> InstinctStore:
+    """Return the global InstinctStore singleton (``~/.pocketpaw/instinct.db``)."""
+    global _instinct_store
+    if _instinct_store is None:
+        _instinct_store = InstinctStore(_DATA_DIR / "instinct.db")
+    return _instinct_store
+
+
+def get_fabric_store() -> FabricStore:
+    """Return the global FabricStore singleton (``~/.pocketpaw/fabric.db``)."""
+    global _fabric_store
+    if _fabric_store is None:
+        _fabric_store = FabricStore(_DATA_DIR / "fabric.db")
+    return _fabric_store
+
+
+def get_paw_print_store() -> PawPrintStore:
+    """Return the global PawPrintStore singleton (``~/.pocketpaw/paw_print.db``)."""
+    global _paw_print_store
+    if _paw_print_store is None:
+        _paw_print_store = PawPrintStore(_DATA_DIR / "paw_print.db")
+    return _paw_print_store

--- a/src/pocketpaw/tools/builtin/fabric_tools.py
+++ b/src/pocketpaw/tools/builtin/fabric_tools.py
@@ -10,9 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 def _get_fabric_store():
-    """Lazy import to avoid circular deps and missing ee/ module."""
+    """Lazy import to avoid circular deps at module load."""
     try:
-        from pocketpaw_ee.api import get_fabric_store
+        from pocketpaw.stores import get_fabric_store
 
         return get_fabric_store()
     except ImportError:

--- a/src/pocketpaw/tools/builtin/instinct_corrections.py
+++ b/src/pocketpaw/tools/builtin/instinct_corrections.py
@@ -15,9 +15,9 @@ logger = logging.getLogger(__name__)
 
 
 def _get_instinct_store():
-    """Lazy import — degrades gracefully when ee/ is not installed."""
+    """Lazy import to avoid circular deps at module load."""
     try:
-        from pocketpaw_ee.api import get_instinct_store
+        from pocketpaw.stores import get_instinct_store
 
         return get_instinct_store()
     except ImportError:

--- a/src/pocketpaw/tools/builtin/instinct_tools.py
+++ b/src/pocketpaw/tools/builtin/instinct_tools.py
@@ -10,9 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 def _get_instinct_store():
-    """Lazy import to avoid circular deps and missing ee/ module."""
+    """Lazy import to avoid circular deps at module load."""
     try:
-        from pocketpaw_ee.api import get_instinct_store
+        from pocketpaw.stores import get_instinct_store
 
         return get_instinct_store()
     except ImportError:

--- a/src/pocketpaw/uploads/resolver.py
+++ b/src/pocketpaw/uploads/resolver.py
@@ -19,6 +19,7 @@ from typing import Protocol
 import aiofiles
 import aiofiles.os
 
+from pocketpaw._registry import first
 from pocketpaw.uploads.adapter import StorageAdapter
 from pocketpaw.uploads.config import extension_for
 from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
@@ -148,11 +149,11 @@ async def _resolve_via_ee_mongo(
     endpoint. Multi-tenant cloud chat should route through EE with explicit
     workspace context instead of calling this.
     """
-    try:
-        from pocketpaw_ee.cloud.uploads.router import _ADAPTER as EE_ADAPTER
-        from pocketpaw_ee.cloud.uploads.router import _META as EE_META
-    except Exception:
+    provider = first("pocketpaw.storage_backends")
+    if provider is None:
         return None, None
+    EE_ADAPTER = provider.adapter()
+    EE_META = provider.meta()
 
     try:
         rec = await EE_META.get_unscoped(file_id)
@@ -211,9 +212,11 @@ async def resolve_media_with_records(media: list[str]) -> list[ResolvedMedia]:
             ee_path, ee_rec = await _resolve_via_ee_mongo(fid)
             if ee_rec is not None:
                 rec = ee_rec
-                from pocketpaw_ee.cloud.uploads.router import _ADAPTER as EE_ADAPTER
-
-                adapter = EE_ADAPTER
+                # _resolve_via_ee_mongo only returns a record when a storage
+                # backend provider is registered, so first() is non-None here.
+                _sb = first("pocketpaw.storage_backends")
+                if _sb is not None:
+                    adapter = _sb.adapter()
                 # EE's LocalStorageAdapter may have given us a local path already.
                 if ee_path is not None:
                     out.append(ResolvedMedia(path=str(ee_path), record=rec))


### PR DESCRIPTION
## Summary

Phase 3 of the open-core split (`docs/plans/2026-05-16-oss-ee-split-design.md`) — invert the `core → ee` dependency via `typing.Protocol` extension points discovered through `importlib` entry-points. **Stacked on PR #1145 (Phase 2).**

This is **Phase 3a** — the foundation plus every cleanly-convertible surface. The remaining `agents/` cluster (agent loop, pool, in-process MCP servers, SDK backends) is intricate critical-path code that needs MongoDB to test properly, so it lands as a focused **Phase 3b** with the `import-linter` enforcement contract.

### Foundation

- `src/pocketpaw/extensions.py` — `Protocol` contracts, one per extension surface.
- `src/pocketpaw/_registry.py` — lazy entry-point discovery (`providers`/`first`/`has`), cached per group, plugin-failure-isolated.
- `pocketpaw_ee/extensions.py` — the EE provider classes; entry-points declared in `pyproject.toml` (migrate to `ee/pyproject.toml` in Phase 4).

### Surfaces converted (core no longer imports `pocketpaw_ee` at these sites)

| Surface | Core file(s) |
|---|---|
| `pocketpaw.event_bus` | `runtime/connector_bus.py` (was a module-level import) |
| `pocketpaw.embeddings` | `bootstrap/context_builder.py` |
| `pocketpaw.memory_backends` | `memory/manager.py` |
| `pocketpaw.capabilities` | `features.py` |
| `pocketpaw.auth` | `api/v1/chat.py` |
| `pocketpaw.routes` | `api/serve.py`, `dashboard.py` |
| `pocketpaw.lifecycle` | `dashboard_lifecycle.py` |
| `pocketpaw.storage_backends` | `uploads/resolver.py` |

Plus: the `get_*_store` factories moved from `pocketpaw_ee/api.py` to a new `pocketpaw.stores` (they were already pure-core post-Phase-2 — no cloud override exists, so not an extension point; `pocketpaw_ee/api.py` is now a re-export shim).

Also removed a dead Socket.IO wrap block in `dashboard.py` (imported `pocketpaw_ee.cloud.socketio_server`, which does not exist — the `try/except` always swallowed `ImportError`).

### Progress

Core `pocketpaw_ee` import sites: **56 → 39** lines. The remaining 39 are all in `agents/` (~30 real, intricate) + `tools/cli.py` (8, the documented admin-CLI exception) + 1 docstring false-positive.

## Test plan

- [x] `ruff check` on all converted files — clean
- [x] entry-point resolution verified for all 8 groups
- [x] `pocketpaw.dashboard` / `api.serve` / `dashboard_lifecycle` import clean
- [x] 125 tests pass across connectors, memory-backend-selection, uploads resolver, remote-access
- [ ] `import-linter` "Core may not import from EE" contract — deferred to Phase 3b (agents/ still violates by design until converted)

## Phase 3b (follow-up)

`agents/loop.py` (108-line cloud pocket-creation), `agents/pool.py`, `dashboard_state.py` → `pocketpaw.models`; move `agents/sdk_mcp_{tasks,planner,pocket}.py` to EE behind `pocketpaw.mcp_servers`; `claude_sdk.py`/`codex_cli.py`/`tool_bridge.py` pocket-specialist + agent_service → `pocketpaw.agent_extensions`; then the `import-linter` enforcement contract + OSS-only CI job.