### PR TITLE
feat(composio): v1 tool-provider integration (OSS-EE split layout)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,21 @@
 # POCKETPAW_SPOTIFY_CLIENT_ID=
 # POCKETPAW_SPOTIFY_CLIENT_SECRET=
 
+# ── Composio (200+ pre-built OAuth integrations: Gmail, Slack, GitHub, …) ─
+# Wires Composio into every supported chat backend via the official
+# provider packages (composio_claude_agent_sdk, composio_openai_agents,
+# composio_google_adk, composio_langgraph). Per-stream a user-scoped
+# session is built — multi-tenant by construction.
+#
+# Setup: set the two required vars; tools are fetched per-user on first
+# use. No admin provisioning step needed.
+# POCKETPAW_COMPOSIO_API_KEY=
+# POCKETPAW_COMPOSIO_ENTERPRISE_ID=               # namespace prefix for per-user user_id (e.g. "ent_acme")
+# POCKETPAW_COMPOSIO_TOOLKITS=                    # CSV; informational/admin (Connectors panel)
+# POCKETPAW_COMPOSIO_BASE_URL=                    # unset = Composio cloud; set for self-hosted runtime
+# POCKETPAW_COMPOSIO_MCP_URL_TTL_SECONDS=3600     # in-process cache TTL for per-user tool sets
+# POCKETPAW_COMPOSIO_CONNECT_LINK_INLINE=true     # render needs-auth Connect Links as inline Ripple buttons
+
 # ── Soul (persistent AI identity) ────────────────────────
 # POCKETPAW_SOUL_ENABLED=false
 # POCKETPAW_SOUL_NAME=Paw

--- a/docs/api/configuration-reference.mdx
+++ b/docs/api/configuration-reference.mdx
@@ -171,6 +171,23 @@ When `llm_provider` is `auto`, PocketPaw uses Anthropic if an API key is set, ot
 | `spotify_client_id` | `POCKETPAW_SPOTIFY_CLIENT_ID` | string | — | Spotify client ID |
 | `spotify_client_secret` | `POCKETPAW_SPOTIFY_CLIENT_SECRET` | string | — | Spotify secret |
 
+## Composio
+
+Wires Composio into every supported chat backend (`claude_agent_sdk`, `openai_agents`, `google_adk`, `deep_agents`) so any agent can call 200+ pre-built OAuth integrations (Gmail, Slack, GitHub, Calendar, Drive, Linear, …). Each backend uses its official Composio provider package (`composio_claude_agent_sdk`, `composio_openai_agents`, `composio_google_adk`, `composio_langgraph`). Tools are fetched per-stream via `composio.create(user_id=…)` + `session.tools()` so every user gets their own tool surface bound to their own connected accounts.
+
+Setup: set `composio_api_key` + `composio_enterprise_id` and you're done. No admin provisioning step.
+
+The pocket specialist does NOT receive Composio — its tool surface stays narrow. When pocket UI needs Composio data, the parent agent fetches it first and passes it into the specialist brief.
+
+| Setting | Env Variable | Type | Default | Description |
+|---------|-------------|------|---------|-------------|
+| `composio_api_key` | `POCKETPAW_COMPOSIO_API_KEY` | string | — | Composio API key (enables Composio for all supported backends) |
+| `composio_enterprise_id` | `POCKETPAW_COMPOSIO_ENTERPRISE_ID` | string | — | Namespace prefix for per-user `user_id` (format: `f"{enterprise_id}:{user_id}"`). Required when `composio_api_key` is set; prevents collisions across deployments sharing one Composio org. |
+| `composio_toolkits` | `POCKETPAW_COMPOSIO_TOOLKITS` | list (CSV) | `[]` | Informational. Used by the Connectors panel + admin helpers; not a runtime allow-list. |
+| `composio_base_url` | `POCKETPAW_COMPOSIO_BASE_URL` | string | — | Composio base URL. Unset = Composio cloud; set for self-hosted Composio runtime. |
+| `composio_mcp_url_ttl_seconds` | `POCKETPAW_COMPOSIO_MCP_URL_TTL_SECONDS` | int | `3600` | In-process cache TTL for per-user Composio tool sets before re-fetching via `composio.create`. |
+| `composio_connect_link_inline` | `POCKETPAW_COMPOSIO_CONNECT_LINK_INLINE` | boolean | `true` | When true, "needs auth" responses render as an inline Ripple button. Set false to fall back to raw URL text. |
+
 ## MCP
 
 | Setting | Env Variable | Type | Default | Description |

--- a/docs/plans/2026-05-12-composio-integration.md
+++ b/docs/plans/2026-05-12-composio-integration.md
@@ -1,0 +1,343 @@
+# Composio Integration — v1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add [Composio](https://docs.composio.dev) as a tool provider for the cloud chat agent. Existing custom connectors stay; Composio is layered in as a second tool source so the pocket specialist (and, later, runtime chat) gain access to 200+ pre-built OAuth-managed integrations (Gmail, Slack, GitHub, Drive, Calendar, Linear, …) without us building one OAuth dance per service.
+
+**Architecture (one-paragraph summary):** Composio's `claude_agent_sdk` provider exposes Composio's meta-tools (`COMPOSIO_SEARCH_TOOLS`, `COMPOSIO_GET_TOOL_SCHEMAS`, `COMPOSIO_MULTI_EXECUTE_TOOL`, `COMPOSIO_MANAGE_CONNECTIONS`) as an MCP server. v1 wires this MCP server into the **parent cloud chat agent's** `ClaudeAgentOptions.mcp_servers` (via `src/pocketpaw/agents/claude_sdk.py::_get_mcp_servers`, alongside the existing `pocket_specialist` EE-guarded entry) so the agent can discover and call any Composio toolkit at runtime — no per-toolkit Python glue. The **pocket specialist does NOT get Composio**; when a pocket needs to render Composio-sourced data, the parent agent fetches the data first and passes it into the specialist's brief. A `ComposioConnector` adapter implementing the existing `ConnectorProtocol` is **out of scope for v1**; deferred until the MCP-direct path is proven and we know which toolkits non-agent code (Ripple `$source`, batch jobs) actually needs to call deterministically. Multi-tenancy is handled via Composio's `user_id` parameter, namespaced as `{enterprise_id}:{paw_user_id}` so one Composio account can serve multiple enterprise deployments without identifier collision. When a tool needs auth the user hasn't granted, Composio returns a Connect Link URL; we surface it to the chat as an inline Ripple spec (button → opens link in new tab), and the agent retries the tool after the user authorizes. Composio cloud only for v1 (no self-hosted runtime); revisit when an enterprise customer demands true data isolation.
+
+**Tech Stack:** Python 3.11+, `composio` SDK + `composio_claude_agent_sdk` provider (new deps), claude-agent-sdk (existing), pytest + pytest-asyncio, ruff (line-length 100). Implementation lands under `ee/cloud/composio/` following the 4-file shape (`domain.py`, `dto.py`, `service.py`, `router.py` — though v1 may not need a router).
+
+**Out of scope for v1 (do not add):**
+- `ComposioConnector` implementing `ConnectorProtocol` — defer until v2 (per-toolkit adapter layer for Ripple `$source` consumers).
+- Migration of existing custom connectors to Composio — keep both stacks running; case-by-case migration is a separate effort.
+- Toolkit allow-listing UX in paw-enterprise — v1 uses an env-var allow-list (`POCKETPAW_COMPOSIO_TOOLKITS`); admin UI comes later.
+- Self-hosted Composio runtime support — single `COMPOSIO_BASE_URL` env var is the only hook we'll add; full self-host validation is a follow-up.
+- Replacing the OSS-side tool registry (`src/pocketpaw/tools/`). This plan only touches the cloud agent path (`ee/cloud/`).
+- Composio Triggers / Webhooks. Tool-call path only for v1.
+
+**Convention reminders (from `backend/CLAUDE.md`):**
+- Tenant filter on every read. `RequestContext.workspace_id` is required for any Composio session creation.
+- Errors via `_core.errors` (`CloudError` subclasses). Never `HTTPException` outside routers.
+- Module-level `async def`, not classes. State stays in `RequestContext` or function arguments.
+- Run `uv run ruff check . && uv run ruff format .` before commits. Mypy clean.
+- `ee/cloud` lives under the 4-file shape; new entity `composio/` follows the same.
+- KB rebuild hook will fire on commits touching `ee/cloud/` — let it run.
+
+**Prerequisites:**
+- `ee/cloud/connectors/` (4-file shape) merged in. Existing on `feat/pocket-specialist` as of 2026-05-12.
+- `ee/ripple/_pockets.py` pocket specialist with `claude_agent_sdk` backend. Existing on `feat/pocket-specialist`.
+- `ee/cloud/ripple_normalizer.py` and inline-Ripple chat send loop (per `feedback_inline_ripple_not_pockets`). Existing.
+
+This plan should be implemented on a branch rebased onto a base that has all three. `feat/pocket-specialist` (or its merge into `ee`) is the natural base.
+
+---
+
+## Design decisions (locked)
+
+1. **`user_id` scope: one per end-user, namespaced.** Composio sessions are created with `user_id=f"{enterprise_id}:{paw_user_id}"`. Rationale: per-user OAuth is Composio's design (each human authorizes their own Gmail, Slack, etc.); namespacing prevents collisions if one Composio org serves multiple PocketPaw enterprise deployments.
+2. **MCP-direct in the parent chat agent** (v1). The parent agent (claude_agent_sdk backend used by the cloud chat path) gets Composio's meta-tools and discovers/calls toolkits dynamically. The pocket specialist sub-agent does NOT receive Composio MCP — data flows from parent → specialist brief, not specialist → Composio. No `ConnectorProtocol` adapter in v1 — that's v2 work, gated on a concrete need.
+3. **Cloud-only for v1.** `COMPOSIO_BASE_URL` env var is the escape hatch; self-hosted parity is a follow-up.
+4. **Connect Links render as inline Ripple, not raw markdown.** Per `feedback_inline_ripple_not_pockets` and `reference_inline_ripple_spec_shape` — clickable button, opens in new tab.
+5. **Env-var toolkit allow-list for v1.** `POCKETPAW_COMPOSIO_TOOLKITS="gmail,slack,github,googlecalendar,googledrive"`. Per-workspace admin UI deferred.
+6. **CLI path explicitly ruled out.** A `composio` CLI + Claude-Code-skill-via-Bash alternative was evaluated and rejected. Composio's CLI is single-identity by design: auth state lives in `~/.composio/`, and no general command accepts `--user-id` (only `composio dev playground-execute` does, and it's a developer sandbox). In a per-enterprise backend serving multiple end-users, the CLI cannot scope per user without either misusing the dev command or building our own user-switching layer on top of `~/.composio/`. Multi-tenant per-end-user execution is an SDK-only concern. Re-evaluate only if Composio ships a general `--user-id` flag on `composio execute`.
+
+---
+
+## Task 1: Add dependencies + config
+
+**Files:**
+- Modify: `backend/pyproject.toml` — add `composio` and `composio_claude_agent_sdk` to the `[project.optional-dependencies] ee` group (or wherever cloud deps live; check existing `ee` extra).
+- Modify: `backend/src/pocketpaw/config.py` — add 4 new settings under the existing `POCKETPAW_` prefix:
+  - `composio_api_key: SecretStr | None = None`
+  - `composio_base_url: str | None = None` (defaults to Composio cloud)
+  - `composio_toolkits: list[str] = []` (parsed from comma-separated env)
+  - `composio_enterprise_id: str | None = None` (the namespace prefix for `user_id`; required when `composio_api_key` is set)
+
+**Step 1: Write the failing test**
+
+```python
+# backend/tests/cloud/composio/test_config.py
+"""Composio config wiring — env-var parsing and required-fields validation."""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw.config import Settings
+
+
+def test_composio_disabled_by_default() -> None:
+    s = Settings(_env_file=None)
+    assert s.composio_api_key is None
+    assert s.composio_toolkits == []
+
+
+def test_composio_enabled_requires_enterprise_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_API_KEY", "ck_xxx")
+    monkeypatch.delenv("POCKETPAW_COMPOSIO_ENTERPRISE_ID", raising=False)
+    with pytest.raises(ValueError, match="composio_enterprise_id"):
+        Settings(_env_file=None)
+
+
+def test_composio_toolkits_csv_parsed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_API_KEY", "ck_xxx")
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_ENTERPRISE_ID", "ent_acme")
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_TOOLKITS", "gmail, slack ,github")
+    s = Settings(_env_file=None)
+    assert s.composio_toolkits == ["gmail", "slack", "github"]
+```
+
+**Step 2: Run** `uv run pytest tests/cloud/composio/test_config.py -v` — expect ImportError / AttributeError.
+
+**Step 3: Implement** the settings additions + a `model_validator(mode="after")` enforcing the `composio_api_key → composio_enterprise_id` invariant.
+
+**Step 4: Verify** tests pass. Run `uv run ruff check . && uv run mypy .`
+
+---
+
+## Task 2: Composio session factory + user_id namespacing
+
+**Files:**
+- Create: `backend/ee/cloud/composio/__init__.py`
+- Create: `backend/ee/cloud/composio/domain.py` — `ComposioUserId` value object, `ComposioSessionRef` (lightweight wrapper around the SDK's session object).
+- Create: `backend/ee/cloud/composio/service.py` — module-level async functions:
+  - `composio_user_id(ctx: RequestContext) -> str` — returns `f"{settings.composio_enterprise_id}:{ctx.user_id}"`.
+  - `get_session(ctx: RequestContext) -> ComposioSessionRef` — lazy-initializes a Composio client (singleton per-process, configured from settings), creates a session for the namespaced `user_id`, returns wrapped reference.
+  - `is_enabled() -> bool` — convenience for callers; returns `True` iff settings has both api_key and enterprise_id.
+
+**Step 1:** Write failing tests covering: namespacing format, missing-config raises `CloudError`, session factory caches the client across calls within a process.
+
+**Step 2 → 4:** Implement, verify.
+
+**Notes:**
+- Composio's client init is sync; wrap any blocking calls in `asyncio.to_thread` if the SDK exposes only sync methods.
+- Do not store the session globally — Composio sessions are cheap; create per-request and let GC clean up.
+- The client (API-key holder) IS process-global; cache it via `functools.lru_cache(maxsize=1)` or a module-level `_client` variable guarded by an `asyncio.Lock`.
+
+---
+
+## Task 3: MCP server injection into the parent chat agent
+
+**Files:**
+- Modify: `backend/src/pocketpaw/agents/claude_sdk.py::_get_mcp_servers` — append a Composio MCP server entry when `composio.service.is_enabled()` returns `True`. Follow the existing `pocket_specialist` pattern: try/except EE import so the OSS install still works without the EE dir present, gated by `self._policy.is_mcp_server_allowed("composio")`.
+- Create: `backend/ee/cloud/composio/mcp.py` — `build_composio_mcp_server()` returns the SDK MCP server entry (per `_get_mcp_servers`'s `dict[str, dict]` contract). Tool callables read the current `user_id` from the per-stream contextvars (`_active_workspace_id`, `_active_user_id` in `ee/cloud/chat/agent_service.py`) at call time, NOT at server-build time.
+- Explicitly do NOT touch `backend/ee/ripple/_pockets.py`. The pocket specialist must remain Composio-free; if pocket UI needs Composio data, the parent agent fetches and passes it via the specialist brief.
+
+**Step 1:** Write a failing test that builds the claude_sdk backend with Composio settings populated and asserts a `composio` entry appears in `_get_mcp_servers()`. Also assert no Composio entry appears in the pocket-specialist's options when invoked directly (regression guard for the redirected architecture).
+
+**Step 2 → 4:** Implement, verify.
+
+**Critical:**
+- The MCP server entry is built once per backend instance, but each tool invocation must resolve the `user_id` fresh from the contextvar — otherwise tools called by user B during user A's pool-shared instance would leak across tenants.
+- **Direct-tools mode is deliberate** (see `providers.py:215-235`). We use `composio.tools.get(user_id, toolkits=[...])` (direct tools), NOT `composio.create(user_id).tools()` (meta-tools-only). Reason captured in the code comment: production LLMs hallucinate when given only meta-tools, so we surface concrete tool names (`GMAIL_SEND_EMAIL`, `GITHUB_LIST_ISSUES_FOR_REPOSITORY`, …) the model can pattern-match against. Do NOT regress to meta-tools-only.
+- **No curated allow-list of action names.** Enterprise customers need the full toolkit surface — picking 15 "common" GitHub actions for them would cripple legitimate use cases. The per-toolkit `limit` parameter caps the count for tool-index sanity (Task 3a), but the cap selects breadth across the toolkit, not a hand-picked subset.
+- Toolkit-level allow-list: `settings.composio_toolkits` controls which toolkits are exposed at all (gmail, slack, github, …). Empty list = fail closed (no tools fetched, warning logged). This is a tenancy/cost control, not a per-action curation.
+- Expose an admin/discovery method `list_available_toolkits()` on `ee/cloud/composio/service.py` (queries Composio for the full catalog) so admins can pick what to put in `composio_toolkits` without spelunking docs.
+
+---
+
+## Task 3a: Search-fallback meta-tools alongside direct tools
+
+**Problem.** With ~50 tools/toolkit × N toolkits, the agent's tool index can exceed the runtime's threshold for inline schema loading, falling back to a deferred index where `ToolSearch` returns alphabetical batches. Concretely: a user asked for "open issues and PRs assigned to me" and the agent couldn't surface `GITHUB_SEARCH_ISSUES_AND_PULL_REQUESTS` because the deferred-tool index kept returning A–C matches. Curating action names is rejected (enterprise can use anything); reducing per-toolkit count too aggressively hides legitimate actions; pure meta-tools-only causes LLM hallucination (`providers.py:215-235`). The fix is a **hybrid**: keep direct tools as the primary surface, append the 3 search-flow meta-tools as a discovery fallback the agent can call when its built-in tool index misses.
+
+**Files:**
+- Modify: `backend/ee/cloud/composio/providers.py::_build_session_and_tools` — after the per-toolkit `composio.tools.get(...)` loop, also fetch `COMPOSIO_SEARCH_TOOLS`, `COMPOSIO_GET_TOOL_SCHEMAS`, `COMPOSIO_MULTI_EXECUTE_TOOL` (one call: `composio_client.tools.get(user_id=..., tools=[...])`) and append them to `combined`. Do NOT include `COMPOSIO_MANAGE_CONNECTIONS` — we already own that flow via `connection_tool.py` and don't want the agent fragmenting between two auth paths.
+- Modify: `backend/ee/cloud/chat/agent_service.py` (system prompt assembly) — add a Composio-search instruction block, gated on `composio_service.is_enabled()`:
+  ```
+  ## Composio fallback discovery
+
+  Your Composio tools cover the most common actions per toolkit, but
+  not every action is loaded into your tool index. If you need a
+  Composio action you can't find directly:
+    1. Call COMPOSIO_SEARCH_TOOLS with a keyword (e.g. "search issues
+       pull requests").
+    2. From the results, pick the exact tool name.
+    3. Call COMPOSIO_GET_TOOL_SCHEMAS([tool_name]) to load the schema.
+    4. Call COMPOSIO_MULTI_EXECUTE_TOOL with the resolved tool + args.
+  Use COMPOSIO_SEARCH_TOOLS only as a fallback — prefer direct tools
+  when they're already in your tool list.
+  ```
+- Modify: `backend/tests/cloud/composio/test_providers.py` (or whichever existing test file covers `build_tools_for_backend`) — add tests for the new behavior.
+
+**Step 1: Write the failing tests**
+
+```python
+# tests/cloud/composio/test_providers.py (excerpt)
+async def test_search_fallback_meta_tools_appended(mock_composio_client):
+    """The 3 search-flow meta-tools must be appended to the direct tools
+    so the agent has a discovery fallback when its tool index can't
+    surface a specific action."""
+    mock_composio_client.tools.get.side_effect = _mock_tools_get  # returns toolkit tools per call
+    reset_cache_for_tests()
+    tools = build_tools_for_backend(BACKEND_CLAUDE_SDK, settings=_settings_with(["gmail", "github"]))
+    tool_names = {_tool_name(t) for t in tools}
+    assert "COMPOSIO_SEARCH_TOOLS" in tool_names
+    assert "COMPOSIO_GET_TOOL_SCHEMAS" in tool_names
+    assert "COMPOSIO_MULTI_EXECUTE_TOOL" in tool_names
+    # We OWN the connect flow — don't expose Composio's MANAGE_CONNECTIONS too.
+    assert "COMPOSIO_MANAGE_CONNECTIONS" not in tool_names
+
+
+async def test_search_fallback_failure_is_non_fatal(mock_composio_client):
+    """If the meta-tools fetch fails, direct tools must still be returned —
+    losing search fallback degrades capability but doesn't break the turn."""
+    mock_composio_client.tools.get.side_effect = _mock_tools_get_meta_fails
+    reset_cache_for_tests()
+    tools = build_tools_for_backend(BACKEND_CLAUDE_SDK, settings=_settings_with(["gmail"]))
+    tool_names = {_tool_name(t) for t in tools}
+    assert "GMAIL_FETCH_EMAILS" in tool_names  # direct tools still present
+    assert "COMPOSIO_SEARCH_TOOLS" not in tool_names  # meta-tools absent
+```
+
+**Step 2: Run** — expect AssertionError on the missing meta-tools.
+
+**Step 3: Implement**
+- After the existing per-toolkit fetch loop in `_build_session_and_tools`, add a single bounded fetch for the 3 meta-tool slugs:
+  ```python
+  try:
+      meta_tools = composio_client.tools.get(
+          user_id=namespaced_user_id,
+          tools=[
+              "COMPOSIO_SEARCH_TOOLS",
+              "COMPOSIO_GET_TOOL_SCHEMAS",
+              "COMPOSIO_MULTI_EXECUTE_TOOL",
+          ],
+      )
+  except Exception:  # noqa: BLE001
+      logger.warning(
+          "Composio: meta-tools fetch failed — agent runs without search fallback this turn"
+      )
+      meta_tools = []
+  for t in meta_tools or []:
+      name = getattr(t, "name", None) or (t.get("name") if isinstance(t, dict) else None)
+      if name and name in seen_names:
+          continue
+      if name:
+          seen_names.add(name)
+      combined.append(t)
+  ```
+- System-prompt block: append in the existing Composio-availability branch of `agent_service.py`. Gate on `is_enabled()` so OSS-only runs don't reference tools the agent can't call.
+
+**Step 4: Verify** — tests pass, lint clean.
+
+**Notes:**
+- The `tools=[name,...]` form of `composio.tools.get` is documented; verify the exact kwarg name against the installed SDK (might be `actions=` in some minor versions).
+- Per-toolkit `limit` default stays at 50 for now. The search fallback covers the deferred-tool case without forcing us to lower coverage.
+- If we ever see the `tools=[name,...]` form return nothing for meta-tools (because the SDK requires a different surface for them), fall back to instantiating the meta-tool wrappers from `composio.tools_router` (or equivalent) directly. Validate at implementation time against the installed SDK version.
+
+---
+
+## Task 4: Connect Link → inline Ripple spec
+
+**Files:**
+- Create: `backend/ee/cloud/composio/connect_link.py` — `as_inline_ripple(url: str, toolkit: str, action_label: str) -> dict` returns a Ripple spec matching `reference_inline_ripple_spec_shape` (a single button that opens `url` in a new tab, with copy like "Connect {toolkit}").
+- Modify: `backend/ee/cloud/composio/service.py` — wrap `session.execute()` calls with auth-error detection. When Composio returns a "needs connection" response, extract the Connect Link URL and emit it via the existing agent-message channel as an inline Ripple, rather than letting the agent get a raw error string.
+
+**Step 1:** Write failing tests:
+- `as_inline_ripple` returns a `{version, ui}` shape that passes `ripple_normalizer` validation.
+- An auth-required Composio response triggers an inline Ripple emission instead of a raw exception.
+
+**Step 2 → 4:** Implement, verify.
+
+**Open question for implementation:** Composio's exact "needs auth" signal shape. Inspect a real failing call before finalizing the detection logic; the docs describe `COMPOSIO_MANAGE_CONNECTIONS` as the discovery path but don't pin down the exception class. Default to feature-flag-gated rollout (`composio_connect_link_inline: bool = True`) so we can disable inline rendering if the detection is too brittle.
+
+---
+
+## Task 4a: Post-connection identity verification
+
+Composio does **not** expose a uniform `whoami(user_id, toolkit)` primitive. `connected_accounts.get()` returns the OAuth token state but not the underlying GitHub login / Gmail address / Slack team. The documented pattern is toolkit-specific identity probes. Without this step, a user can authorize the wrong account (e.g. a personal GitHub instead of their work one) and the agent silently operates as the wrong identity — this is the bug surfaced in initial testing where a personal GitHub account got bound to a session expected to be a different teammate's.
+
+**Files:**
+- Create: `backend/ee/cloud/composio/identity.py` — per-toolkit identity-probe registry:
+  ```python
+  IDENTITY_PROBES: dict[str, IdentityProbe] = {
+      "github": IdentityProbe(action="GITHUB_GET_AUTHENTICATED_USER", field="login"),
+      "gmail":  IdentityProbe(action="GMAIL_USERS_GET_PROFILE",       field="emailAddress"),
+      "slack":  IdentityProbe(action="SLACK_AUTH_TEST",               field="user"),
+      "googlecalendar": IdentityProbe(action="GOOGLECALENDAR_GET_CURRENT_USER", field="email"),
+      "googledrive":    IdentityProbe(action="GOOGLEDRIVE_GET_ABOUT",           field="user.emailAddress"),
+      # extend per toolkit added to the allow-list
+  }
+  async def probe_identity(ctx, toolkit: str) -> str | None: ...
+  ```
+- Create: `backend/ee/cloud/composio/domain.py` — extend with `ComposioConnection` value object (frozen, fields: `workspace_id`, `paw_user_id`, `toolkit`, `external_identity`, `verified_at`).
+- Create: `backend/ee/cloud/models/composio_connection.py` — Beanie document, unique index on `(workspace, paw_user_id, toolkit)`.
+- Create: `backend/ee/cloud/composio/service.py::record_connection(ctx, toolkit, external_identity)` — upserts the doc, emits `ComposioConnectionVerified` event.
+- Modify: `backend/ee/cloud/composio/service.py` — after a Connect Link auth flow completes, the next agent turn runs `probe_identity` for the just-connected toolkit, stores the result via `record_connection`, and emits an inline Ripple confirmation ("Connected as `@octocat`. Continue / disconnect?") via the existing chat-send loop.
+- Modify: `backend/ee/cloud/composio/connect_link.py` — `as_inline_ripple` gains a "verification pending" variant that shows the identity once it's known.
+
+**Step 1: Write failing tests** covering:
+- Unknown toolkit returns `None` from `probe_identity` and logs (does not raise).
+- Successful probe upserts `ComposioConnection` with the expected `external_identity`.
+- A subsequent probe for the same `(workspace, user, toolkit)` with a **different** `external_identity` flags loudly (event emission + log.warning) — this is the tripwire: re-authorizing as a different person should not silently overwrite.
+- The post-link inline Ripple includes the resolved `external_identity` text.
+
+**Step 2 → 4:** Implement, verify.
+
+**Critical:**
+- The probe MUST happen before the original failing tool call retries — otherwise we burn a request as the wrong identity. Sequence is: (1) auth-required signal → (2) emit Connect Link → (3) user authorizes → (4) probe identity → (5) emit confirmation → (6) wait for explicit "yes/continue" → (7) retry original tool. NOT: probe-and-immediately-retry-original.
+- The stored `external_identity` is a **tripwire**, not just a label. Future probe mismatches must surface to the user, not be silently overwritten.
+- Probe failure (network, toolkit doesn't expose a whoami action) is non-fatal: log a warning, store `external_identity=None`, and let the user proceed (better than blocking when an obscure toolkit lacks a probe). Add the missing toolkit to `IDENTITY_PROBES` later.
+- Multi-tenancy: storing identity verification on a per-`(workspace_id, paw_user_id, toolkit)` key — not global — is required so two paw users in different workspaces can each have their own connected GitHub.
+
+---
+
+## Task 5: End-to-end smoke test (manual)
+
+Once Tasks 1–4 land:
+
+1. Set env vars in a dev shell:
+   ```
+   POCKETPAW_COMPOSIO_API_KEY=<dev-key>
+   POCKETPAW_COMPOSIO_ENTERPRISE_ID=ent_dev
+   POCKETPAW_COMPOSIO_TOOLKITS=gmail
+   ```
+2. Start backend (`uv run pocketpaw --dev`) and paw-enterprise (`bun run tauri dev`).
+3. From a chat in a pocket: prompt "summarize my last 3 unread emails".
+4. Expected: agent calls `COMPOSIO_SEARCH_TOOLS` → `GMAIL_FETCH_EMAILS` (or equivalent), gets a "needs connection" response on first try, chat renders an inline "Connect Gmail" button.
+5. Click button → authorize in browser → return to chat.
+6. Expected: chat renders an inline "Connected as `<your-email>`. Continue?" confirmation (Task 4a). Click "Continue".
+7. Expected: agent fetches and summarizes.
+8. **Identity tripwire check:** disconnect Gmail in Composio dashboard, re-authorize as a **different** Gmail account. Send the same prompt. Expected: chat surfaces a "Connected as `<new-email>` — this differs from previously verified `<old-email>`. Confirm?" warning, not silent reuse.
+
+If step 4 emits a raw URL instead of an inline button, Task 4's detection logic needs tightening. If step 6 doesn't include the email/login, Task 4a's probe registry is missing the toolkit. If step 8 silently proceeds without warning, the tripwire in `record_connection` is broken.
+
+**Sanity check before steps 1–8:** open a Python REPL with the dev env, run `from composio import Composio; print([t.name for t in Composio().create(user_id='probe').tools()])`. Output should be the 4–6 meta-tool slugs. If you see hundreds of toolkit actions, Task 3a's assertion will trip on the first chat turn — fix the config (likely a stray `preload=` or `session_preset=`) before proceeding.
+
+---
+
+## Test coverage targets
+
+- `tests/cloud/composio/test_config.py` — env parsing + invariants (Task 1).
+- `tests/cloud/composio/test_service.py` — user_id namespacing, client caching, is_enabled gate (Task 2).
+- `tests/cloud/composio/test_providers.py` — `build_tools_for_backend` direct-tools fetch per toolkit, search-fallback meta-tools appended (Task 3a), graceful degrade when meta-tools fetch fails, fail-closed on empty `composio_toolkits`.
+- `tests/cloud/composio/test_connect_link.py` — inline Ripple shape, auth-error detection (Task 4).
+- `tests/cloud/composio/test_identity.py` — per-toolkit probe registry, tripwire on identity mismatch, missing-toolkit graceful degrade (Task 4a).
+
+No live Composio calls in CI. Mock the `composio` SDK at the `Composio.create()` boundary. The hands-on "print tools after create()" verification step is one-time, manual, and documented in Task 3a — not part of CI.
+
+---
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Composio cloud outage takes down all tool-calling | MCP server build wraps `session.tools()` in try/except — on failure, return empty MCP server (agent falls back to its built-in tools and custom connectors) and log loudly. Never let Composio failure 500 the chat. |
+| Composio bills per tool call | `POCKETPAW_COMPOSIO_TOOLKITS` allow-list is the cost lever. Default empty = nothing enabled. |
+| Tool I/O leaks PII to Composio cloud | Documented in customer-facing docs as a v1 limitation. Enterprise customers requiring isolation must wait for self-hosted runtime support. |
+| Composio SDK breaking changes | Pin `composio` to a single minor version in `pyproject.toml`. Bump deliberately. |
+| `user_id` collision across enterprise deployments | Namespacing (Task 2) prevents this; enforced by the `composio_enterprise_id` required-when-enabled invariant (Task 1). |
+| Agent can't find a specific Composio action it needs | Task 3a's hybrid: direct tools as the primary surface + `COMPOSIO_SEARCH_TOOLS` / `GET_TOOL_SCHEMAS` / `MULTI_EXECUTE_TOOL` as a discovery fallback. System prompt instructs the agent to use search when direct tools miss. Caveat: if Composio's SDK changes `tools=[name,...]` arg name, the meta-tools fetch silently returns 0 — test covers the assertion that they're present. |
+| User authorizes Composio toolkit as wrong identity | Task 4a's probe + tripwire. Initial connection always renders an explicit "Connected as X — continue?" confirmation; re-authorizing as a different identity surfaces the mismatch instead of silently overwriting. |
+| Composio ships `--user-id` on CLI later, tempting us to rip out SDK | Not a risk today; flagged so future-us doesn't re-litigate. Re-evaluate only when Composio docs explicitly add `--user-id` to `composio execute` (not `composio dev`). The SDK path is the durable choice. |
+
+---
+
+## Follow-ups (NOT in this plan, but should land before any customer GA)
+
+1. **v2: `ComposioConnector` per-toolkit adapter** implementing `ConnectorProtocol.execute` — so Ripple `$source` and non-agent code paths can call Composio toolkits with the same interface as custom connectors.
+2. **Per-workspace toolkit allow-list** stored on the workspace document, with an admin UI in paw-enterprise's Settings → Integrations panel. Env var becomes the cluster-wide default; workspace can narrow it.
+3. **Self-hosted Composio validation** — confirm parity for at least Gmail/Slack/GitHub against a self-hosted Composio instance before promising it to a customer.
+4. **Audit logging** — every Composio tool execution emits an audit event (`composio.tool.executed`) with toolkit, action, user_id, latency. Hook into existing `_core/audit` (if it exists) or add it.
+5. **Composio Triggers / Webhooks** — receive Composio-side events (new email, new Slack message) and route them through the existing in-process bus. Big enough to be its own plan.
+6. **OSS-side integration** — once cloud path is stable, consider exposing Composio to `src/pocketpaw/` users via the same MCP injection pattern on the `claude_agent_sdk` OSS backend.

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -412,6 +412,12 @@ def mount_cloud(app: FastAPI) -> None:
 
     register_agent_bridge()
 
+    # NOTE: Composio is wired per-backend via ``pocketpaw_ee.cloud.composio.providers``
+    # — each agent backend (claude_sdk, openai_agents, google_adk,
+    # deep_agents) calls ``build_tools_for_backend()`` in its own tool-build
+    # path to fetch Composio tools using the official provider package for
+    # that SDK. No cloud-bootstrap registration is needed.
+
     # Initialise the realtime EventBus eagerly.
     #
     # The host app (src/pocketpaw/dashboard.py) uses a FastAPI ``lifespan``

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -408,3 +408,20 @@ class PlanGenerated(Event):
 @dataclass
 class PlanGapResolved(Event):
     EVENT_TYPE: ClassVar[str] = "plan.gap_resolved"
+
+
+# Composio — per-user OAuth integrations (Gmail, Slack, GitHub, …)
+# verified via per-toolkit identity probes. ``ComposioConnectionVerified``
+# fires when a probe succeeds and the stored identity matches (or first
+# time storing). ``ComposioConnectionMismatch`` fires when a fresh probe
+# returns a different external identity than the stored one — surfaces
+# to the chat as a "confirm this is what you intended" prompt rather
+# than silently overwriting.
+@dataclass
+class ComposioConnectionVerified(Event):
+    EVENT_TYPE: ClassVar[str] = "composio.connection.verified"
+
+
+@dataclass
+class ComposioConnectionMismatch(Event):
+    EVENT_TYPE: ClassVar[str] = "composio.connection.mismatch"

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -475,6 +475,15 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
     others get the heavy inline pocket prompt.
     """
     parts: list[str] = []
+    parts.append(_RUNTIME_IDENTITY_RULE)
+    # Composio search-fallback guidance is conditional: only useful if
+    # Composio is actually wired up for this deployment. Gating avoids
+    # telling the agent about tools it doesn't have.
+    from pocketpaw_ee.cloud.composio import service as _composio_service
+
+    if _composio_service.is_enabled():
+        parts.append(_COMPOSIO_AUTH_FLOW_RULE)
+        parts.append(_COMPOSIO_SEARCH_FALLBACK_RULE)
     if backend_name in _MCP_POCKET_BACKENDS:
         parts.append(INLINE_RIPPLE_SYSTEM_PROMPT)
         parts.append(POCKET_DELEGATION_RULE)
@@ -487,6 +496,107 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
         else:
             parts.append(INLINE_RIPPLE_SYSTEM_PROMPT)
     return "\n".join(parts)
+
+
+# Authoritative runtime-identity rule. Models trained on Claude Code
+# (and other CLI agents) frequently hallucinate environment-specific
+# guidance — telling users to "run /mcp" to authenticate an integration,
+# referencing tools by their Claude.ai-hosted names ("claude.ai Gmail"),
+# suggesting `/help`, `/clear`, and other slash commands. None of that
+# exists in the PocketPaw chat surface. When a tool is missing the
+# correct behavior is to call the tools that DO exist (e.g. Composio's
+# meta-tools or concrete GMAIL_* tools), not to invent a Claude Code
+# command for the user to run.
+_RUNTIME_IDENTITY_RULE = """\
+<runtime-identity>
+You are PocketPaw — an AI assistant embedded in the paw-enterprise chat
+interface. You are NOT Claude Code, NOT the Claude.ai web UI, NOT a CLI
+agent, and NOT inside the paw-enterprise Settings/admin panel. The user
+is in a graphical chat with you over a web/desktop surface.
+
+The ONLY integration path available to you for third-party services
+(Gmail, Slack, GitHub, Calendar, Drive, Linear, …) is the Composio
+tools. Every other integration affordance you may have seen in training
+DOES NOT EXIST in this environment:
+
+- Slash commands DO NOT EXIST here. Never tell the user to run "/mcp",
+  "/help", "/clear", "/login", "/auth", or any other slash-prefixed
+  command. They have no way to type or execute these.
+- "claude.ai Gmail", "claude.ai Google Calendar", and similar
+  Anthropic-hosted MCP names DO NOT exist here.
+- There is NO "Settings → Google OAuth", "Settings → Integrations", or
+  any other Settings-panel OAuth flow you can point the user at. Do NOT
+  fabricate instructions like "go to Settings → Google OAuth → Authorize
+  Gmail". The user authorizes integrations through Composio's Connect
+  Links, which YOU obtain by calling the relevant tool.
+- For ANY Gmail/Slack/Calendar/Drive/etc. operation, use the
+  Composio-prefixed tools you have (e.g. ``GMAIL_FETCH_EMAILS``,
+  ``GMAIL_SEND_EMAIL``, ``SLACK_SEND_MESSAGE``, ``GOOGLECALENDAR_*``).
+  When a tool returns a "needs auth / Connect Link" response, pass that
+  URL to the user verbatim — do NOT translate it into Settings-panel
+  instructions.
+- If you genuinely don't have a tool for what the user asked, say so
+  plainly. Don't fabricate instructions for a different environment.
+</runtime-identity>"""
+
+
+# Composio's direct-tools surface caps each toolkit at a fixed limit
+# (50 actions/toolkit by default in ``pocketpaw_ee.cloud.composio.providers``)
+# and paginates alphabetically. For big toolkits (github has 50+ actions),
+# a specific action the user asked about may not be in your tool list
+# even though Composio supports it. The 3 meta-tools below give you a
+# discovery fallback that asks Composio's own search index, which is
+# more reliable than the LLM-side tool-list lookup.
+_COMPOSIO_AUTH_FLOW_RULE = """\
+<composio-auth-flow>
+When a Composio tool returns "needs connection" / ``ConnectedAccountNotFound``
+/ any "not authorized" error, the auth sequence is:
+
+  1. Call ``initiate_connection(toolkit="<slug>")``. It returns a
+     ``redirect_url``. Surface that URL to the user EXACTLY as you got
+     it — do NOT translate it to "go to Settings" instructions; those
+     do not exist here.
+  2. After the user opens the URL, authorizes, and returns to chat,
+     call ``verify_connection(toolkit="<slug>")``. This probes the
+     toolkit's "who am I" action and returns the external identity
+     they connected as (GitHub login, Gmail address, etc.).
+  3. Surface the verified identity to the user verbatim:
+     "Connected as <external_identity>. Continue?". DO NOT retry the
+     original tool until the user confirms.
+  4. If ``verify_connection`` returns ``status: "mismatch"``, the user
+     re-authorized as a DIFFERENT account than the one previously
+     stored. Show both identities, ask which one they want, and do
+     NOT retry the original tool until the user confirms the change.
+  5. If ``verify_connection`` returns ``status: "unverified"``, the
+     toolkit doesn't expose a probe — surface "Connected to <toolkit>
+     (identity verification unavailable)" and proceed cautiously.
+
+Never skip step 2. Without it, the agent silently operates as whatever
+account the user picked, which can be the wrong one (personal Gmail
+instead of work, shared mailbox instead of personal).
+</composio-auth-flow>"""
+
+
+_COMPOSIO_SEARCH_FALLBACK_RULE = """\
+<composio-search-fallback>
+You have access to three Composio meta-tools for discovering actions
+that aren't loaded directly into your tool list:
+
+  COMPOSIO_SEARCH_TOOLS(query)  — keyword search across all Composio
+                                  actions you're permitted to use.
+                                  Returns matching tool names.
+  COMPOSIO_GET_TOOL_SCHEMAS([tool_names])
+                                — fetch the input schemas for the
+                                  tool names you picked.
+  COMPOSIO_MULTI_EXECUTE_TOOL(...)
+                                — execute one or more discovered tools
+                                  with their resolved arguments.
+
+Use these ONLY as a fallback. If the action you need is already in
+your direct tool list (e.g. ``GMAIL_FETCH_EMAILS``, ``GITHUB_LIST_ISSUES_FOR_REPOSITORY``),
+call it directly — don't round-trip through search. When you DO need
+search, the sequence is: SEARCH → pick a name → GET_SCHEMAS → EXECUTE.
+</composio-search-fallback>"""
 
 
 def build_dynamic_context(ctx: ScopeContext) -> str:

--- a/ee/pocketpaw_ee/cloud/composio/__init__.py
+++ b/ee/pocketpaw_ee/cloud/composio/__init__.py
@@ -1,0 +1,25 @@
+"""Composio integration — MCP-direct tool provider for the parent chat agent.
+
+Composio (https://docs.composio.dev) exposes 200+ pre-built OAuth-managed
+integrations (Gmail, Slack, GitHub, Drive, Calendar, Linear, …) as a single
+MCP server. This module wires the Composio MCP server into the parent
+``claude_agent_sdk`` backend so the cloud chat agent can discover and call
+any whitelisted toolkit at runtime, without us building per-toolkit Python
+glue or owning each service's OAuth dance.
+
+Architecture (v1, parent-agent only):
+    settings ─┐
+              ├─→ composio.service.get_session(ctx) ─→ Composio session
+    ctx ──────┘                                              │
+                                                             ▼
+                                            composio.mcp.build_composio_mcp_server()
+                                                             │
+                                                             ▼
+        src/pocketpaw/agents/claude_sdk.py::_get_mcp_servers (parent agent)
+
+The pocket specialist sub-agent does NOT receive Composio MCP — when a
+pocket UI needs Composio-sourced data, the parent fetches it first and
+passes it into the specialist brief.
+"""
+
+from __future__ import annotations

--- a/ee/pocketpaw_ee/cloud/composio/connect_link.py
+++ b/ee/pocketpaw_ee/cloud/composio/connect_link.py
@@ -1,0 +1,202 @@
+"""Composio Connect Link → inline Ripple spec.
+
+When a Composio tool call returns a "needs authorization" response, we
+extract the Connect Link URL and emit it to the active chat stream as
+an inline Ripple spec — a single button the user clicks to authorize
+the integration in a new browser tab. Once authorized, the user sends
+the same prompt again and the Composio call succeeds.
+
+Why inline Ripple instead of a markdown link: the cloud chat already
+supports interactive Ripple via the chat.send round-trip (see
+``feedback_inline_ripple_not_pockets`` memory). A clickable button is
+the consistent surface for chat-side interactions; a raw URL would mix
+two formats in the transcript and degrade UX.
+
+Detection (heuristic — refine when we have real Composio responses to
+calibrate against):
+    * dict with a ``connect_url`` / ``connect_link`` / ``auth_url`` key
+    * dict with ``needs_connection: true`` / ``requires_auth: true``
+      AND a URL key nested anywhere obvious
+
+The detection is feature-flag gated via
+``settings.composio_connect_link_inline``; set False to disable inline
+rendering (URL falls back to a text response).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw.config import Settings
+
+logger = logging.getLogger(__name__)
+
+_URL_KEYS: tuple[str, ...] = ("connect_url", "connect_link", "auth_url", "authorization_url")
+_AUTH_FLAGS: tuple[str, ...] = (
+    "needs_connection",
+    "requires_auth",
+    "needs_auth",
+    "auth_required",
+)
+
+
+def as_inline_ripple(
+    url: str,
+    toolkit: str,
+    action_label: str | None = None,
+) -> dict[str, Any]:
+    """Return a canonical inline Ripple ``{version, ui}`` spec.
+
+    The UI is a single button that opens ``url`` in a new browser tab.
+    The frontend's Ripple renderer maps ``actions=[{type:"open_url"}]``
+    to ``window.open(url, "_blank")``.
+
+    ``action_label`` defaults to ``Connect {Toolkit}`` (title-cased).
+    """
+    if not url:
+        raise ValueError("as_inline_ripple: url is required")
+    if not toolkit:
+        raise ValueError("as_inline_ripple: toolkit is required")
+
+    label = action_label or f"Connect {toolkit.title()}"
+
+    return {
+        "version": "1.0",
+        "ui": {
+            "type": "flex",
+            "props": {"direction": "column", "gap": 8, "align": "start"},
+            "children": [
+                {
+                    "type": "text",
+                    "props": {
+                        "value": (
+                            f"{toolkit.title()} isn't connected yet. Click below to "
+                            "authorize in a new tab, then send your message again."
+                        ),
+                    },
+                },
+                {
+                    "type": "button",
+                    "props": {
+                        "label": label,
+                        "variant": "primary",
+                    },
+                    "actions": [
+                        {
+                            "type": "open_url",
+                            "url": url,
+                            "target": "_blank",
+                        }
+                    ],
+                },
+            ],
+        },
+    }
+
+
+def detect_connect_link(payload: Any) -> tuple[str, str] | None:
+    """Inspect a Composio response payload for a Connect Link.
+
+    Returns ``(url, toolkit_hint)`` if a Connect Link is detected,
+    else ``None``. The toolkit hint is best-effort — derived from a
+    ``toolkit`` / ``app`` field when present, otherwise the empty
+    string (caller substitutes a sensible default).
+
+    Walks one level of nesting (top-level dict, then nested dicts under
+    common keys like ``error``, ``meta``, ``connection``). Deep search
+    is intentionally avoided — false positives from a stray "url" field
+    elsewhere in the payload would be worse than missing a Connect Link.
+    """
+    if not isinstance(payload, dict):
+        return None
+
+    url = _extract_url(payload)
+    if url is None:
+        # Check one level deeper for the most-likely nesting containers
+        for container_key in ("error", "meta", "connection", "details", "data"):
+            inner = payload.get(container_key)
+            if isinstance(inner, dict):
+                url = _extract_url(inner)
+                if url is not None:
+                    break
+
+    if url is None:
+        return None
+
+    # Require either an explicit auth-flag or that the URL came from
+    # one of the auth-named keys. Otherwise we'd mis-fire on any
+    # response that happens to contain a URL.
+    has_flag = any(_truthy(payload.get(flag)) for flag in _AUTH_FLAGS)
+    if not has_flag and not _has_url_key(payload):
+        return None
+
+    toolkit = payload.get("toolkit") or payload.get("app") or payload.get("app_name") or ""
+    return url, str(toolkit)
+
+
+def maybe_emit_connect_link(
+    payload: Any,
+    settings: Settings | None = None,
+) -> bool:
+    """Detect + push a Connect Link inline-Ripple SSE event.
+
+    Returns ``True`` when an event was pushed, ``False`` otherwise.
+
+    The push uses the same SSE sink as the rest of the cloud chat
+    (``pocketpaw_ee.cloud.chat.agent_service.push_sse_event``) under the event
+    name ``ripple_inline``. The frontend already handles inline Ripple
+    via that channel — no new wire format required.
+
+    Gated by ``settings.composio_connect_link_inline``; when False, this
+    is a no-op and the agent's response surfaces the raw URL string.
+    """
+    s = settings or Settings.load()
+    if not s.composio_connect_link_inline:
+        return False
+
+    detection = detect_connect_link(payload)
+    if detection is None:
+        return False
+
+    url, toolkit_hint = detection
+    toolkit = toolkit_hint or "this integration"
+    spec = as_inline_ripple(url, toolkit)
+
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import push_sse_event
+    except ImportError:
+        logger.debug("composio.connect_link: chat module unavailable, skip emit")
+        return False
+
+    push_sse_event("ripple_inline", {"source": "composio", "toolkit": toolkit, "spec": spec})
+    return True
+
+
+def _extract_url(d: dict[str, Any]) -> str | None:
+    """Return the first non-empty URL value at the top level of ``d``."""
+    for key in _URL_KEYS:
+        val = d.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return None
+
+
+def _has_url_key(d: dict[str, Any]) -> bool:
+    """True if any of the recognized URL keys is set on this dict."""
+    return any(isinstance(d.get(key), str) and d.get(key) for key in _URL_KEYS)
+
+
+def _truthy(v: Any) -> bool:
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        return v.lower() in ("true", "yes", "1")
+    return bool(v)
+
+
+__all__ = [
+    "as_inline_ripple",
+    "detect_connect_link",
+    "maybe_emit_connect_link",
+]

--- a/ee/pocketpaw_ee/cloud/composio/connection_tool.py
+++ b/ee/pocketpaw_ee/cloud/composio/connection_tool.py
@@ -1,0 +1,124 @@
+"""Composio connection-initiation helper — emits a Connect URL the agent
+hands to the user when a toolkit isn't authorized yet.
+
+We expose this as an extra MCP tool alongside the concrete Composio
+tools (``GMAIL_SEND_EMAIL`` etc.). When the agent calls e.g.
+``GMAIL_SEND_EMAIL`` and Composio returns ``ConnectedAccountNotFound``,
+the agent's next move is to call ``initiate_connection(toolkit="gmail")``
+which returns the Composio Connect URL — the user clicks the URL,
+authorizes, and the original tool call retries.
+
+Why this isn't in Composio's default tool set: ``composio.tools.get``
+returns *executable* tools for the user's already-connected accounts.
+Connection initiation is an admin/auth flow that lives on a different
+API surface (``c.connected_accounts.link`` + ``c.auth_configs.list``).
+We wrap that surface in a single agent-callable tool.
+
+Auth config resolution: we look up the existing Composio-managed
+auth config for the toolkit slug. The admin needs to have created one
+(or marked one as managed) at least once via the Composio dashboard
+or via ``c.auth_configs.create``. If none exists, we surface a clear
+error directing the admin to set one up.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _find_auth_config_id_for_toolkit(client: Any, toolkit_slug: str) -> str | None:
+    """Return the id of an existing Composio auth config for the toolkit.
+
+    Picks the first ``ENABLED`` config whose ``toolkit.slug`` matches.
+    Returns ``None`` if nothing is found — caller should surface a
+    "no auth config; admin must create one" error to the agent so it
+    doesn't waste a turn retrying.
+    """
+    try:
+        response = client.auth_configs.list()
+    except Exception:  # noqa: BLE001
+        logger.exception("composio.auth_configs.list failed")
+        return None
+
+    items: Any
+    if isinstance(response, dict):
+        items = response.get("items") or []
+    else:
+        items = getattr(response, "items", None) or []
+
+    target = toolkit_slug.lower()
+    for item in items:
+        tk = item.get("toolkit") if isinstance(item, dict) else getattr(item, "toolkit", None)
+        if tk is None:
+            continue
+        slug = tk.get("slug") if isinstance(tk, dict) else getattr(tk, "slug", None)
+        if not slug or str(slug).lower() != target:
+            continue
+        status = item.get("status") if isinstance(item, dict) else getattr(item, "status", None)
+        if status and str(status).upper() != "ENABLED":
+            continue
+        cfg_id = item.get("id") if isinstance(item, dict) else getattr(item, "id", None)
+        if cfg_id:
+            return str(cfg_id)
+    return None
+
+
+def initiate_connection_sync(client: Any, *, user_id: str, toolkit_slug: str) -> dict[str, Any]:
+    """Generate a Connect URL for ``user_id`` + ``toolkit_slug``.
+
+    Returns an envelope:
+        ``{ok: True, redirect_url, connection_id, toolkit}`` on success, or
+        ``{ok: False, error: <human-readable>, toolkit}`` on failure.
+
+    The agent calls this as a tool; we keep the response shape stable
+    so the LLM has a consistent contract regardless of the auth-config
+    state on the Composio side.
+    """
+    auth_config_id = _find_auth_config_id_for_toolkit(client, toolkit_slug)
+    if auth_config_id is None:
+        return {
+            "ok": False,
+            "toolkit": toolkit_slug,
+            "error": (
+                f"No Composio-managed auth config found for toolkit "
+                f"'{toolkit_slug}'. An admin must create one in the Composio "
+                f"dashboard (or via c.auth_configs.create) before users can "
+                f"connect this integration."
+            ),
+        }
+
+    try:
+        request = client.connected_accounts.link(user_id=user_id, auth_config_id=auth_config_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("composio.connected_accounts.link failed for %s", toolkit_slug)
+        return {
+            "ok": False,
+            "toolkit": toolkit_slug,
+            "error": f"Composio failed to issue a Connect Link: {exc}",
+        }
+
+    redirect = getattr(request, "redirect_url", None) or (
+        request.get("redirect_url") if isinstance(request, dict) else None
+    )
+    connection_id = getattr(request, "id", None) or (
+        request.get("id") if isinstance(request, dict) else None
+    )
+    if not redirect:
+        return {
+            "ok": False,
+            "toolkit": toolkit_slug,
+            "error": "Composio returned no redirect_url for the Connect Link.",
+        }
+
+    return {
+        "ok": True,
+        "toolkit": toolkit_slug,
+        "redirect_url": str(redirect),
+        "connection_id": str(connection_id) if connection_id else None,
+    }
+
+
+__all__ = ["initiate_connection_sync"]

--- a/ee/pocketpaw_ee/cloud/composio/domain.py
+++ b/ee/pocketpaw_ee/cloud/composio/domain.py
@@ -1,0 +1,41 @@
+"""Composio domain — value objects with multi-tenancy baked in.
+
+Per ``ee/pocketpaw_ee/cloud`` Rule 3: domain objects are frozen and enforce tenancy at
+construction. A ``ComposioUserId`` cannot exist without both its namespace
+prefix (``enterprise_id``) and the per-user ``user_id`` segment, so a
+mistakenly-empty user_id won't silently address the wrong tenant downstream.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ComposioUserId:
+    """Namespaced Composio user_id: ``f"{enterprise_id}:{user_id}"``.
+
+    The namespace prefix is required at construction. This prevents
+    user_id collisions when a single Composio org serves multiple
+    PocketPaw enterprise deployments (one prod tenant + one staging
+    tenant on the same Composio account, for instance).
+
+    Use ``ComposioUserId.from_ctx(ctx)`` from service code; do not
+    construct directly with raw strings outside the service layer.
+    """
+
+    enterprise_id: str
+    user_id: str
+
+    def __post_init__(self) -> None:
+        if not self.enterprise_id:
+            raise ValueError("ComposioUserId.enterprise_id is required")
+        if not self.user_id:
+            raise ValueError("ComposioUserId.user_id is required")
+        if ":" in self.enterprise_id:
+            raise ValueError(
+                "ComposioUserId.enterprise_id must not contain ':' (namespace separator)"
+            )
+
+    def __str__(self) -> str:
+        return f"{self.enterprise_id}:{self.user_id}"

--- a/ee/pocketpaw_ee/cloud/composio/identity.py
+++ b/ee/pocketpaw_ee/cloud/composio/identity.py
@@ -1,0 +1,169 @@
+"""Composio per-toolkit identity probes.
+
+Composio's connected-accounts API returns OAuth tokens but does NOT
+expose the underlying account identity (the GitHub login, Gmail
+address, Slack user) in a uniform way. The documented pattern is
+toolkit-specific: after a Connect Link auth flow completes, call the
+toolkit's own "who am I" action to learn whose account was actually
+authorized.
+
+This matters for our tenancy model: a user can click Connect, then
+authorize as ANY account they have access to — their personal GitHub
+instead of their work one, a shared mailbox instead of their own. The
+agent has no way to detect that without an explicit probe. We surface
+the probed identity back to the chat ("Connected as @octocat —
+continue?") so wrong-account binds are caught the first time.
+
+The registry below maps toolkit slug → ``IdentityProbe``. To add a
+toolkit:
+    1. Find the toolkit's "get current user" action (Composio docs).
+    2. Add a row; ``field_path`` is dot-separated for nested responses
+       (e.g. ``"user.emailAddress"``).
+    3. Add a unit test against a recorded fixture if possible.
+
+Unknown toolkit → ``probe_identity_sync`` returns ``None`` and logs
+``info``. The caller treats that as "verification unavailable" and
+proceeds (better than blocking when an obscure toolkit lacks a probe).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class IdentityProbe:
+    """How to ask a Composio toolkit "who is the connected account?"
+
+    ``action`` is the Composio action slug (e.g.
+    ``"GITHUB_GET_AUTHENTICATED_USER"``). ``field_path`` is the
+    dot-separated path into the action's response payload that holds
+    the human-readable identity (a login, an email, a user id).
+    """
+
+    action: str
+    field_path: str
+
+
+# Per-toolkit probe registry. Extend per toolkit added to
+# ``POCKETPAW_COMPOSIO_TOOLKITS``. Composio's response shapes vary by
+# toolkit — verify the ``field_path`` against a real call when adding
+# a new entry.
+IDENTITY_PROBES: dict[str, IdentityProbe] = {
+    "github": IdentityProbe(action="GITHUB_GET_THE_AUTHENTICATED_USER", field_path="login"),
+    "gmail": IdentityProbe(action="GMAIL_GET_PROFILE", field_path="emailAddress"),
+    "slack": IdentityProbe(action="SLACK_AUTH_TEST", field_path="user"),
+    "googlecalendar": IdentityProbe(
+        action="GOOGLECALENDAR_GET_CURRENT_DATE_TIME", field_path="user.email"
+    ),
+    "googledrive": IdentityProbe(action="GOOGLEDRIVE_GET_ABOUT", field_path="user.emailAddress"),
+    "linear": IdentityProbe(action="LINEAR_VIEWER", field_path="email"),
+}
+
+
+def probe_identity_sync(client: Any, *, user_id: str, toolkit: str) -> str | None:
+    """Probe the connected account's external identity for ``toolkit``.
+
+    Returns the identity string (login / email / user id), or ``None``
+    when:
+        * The toolkit has no entry in ``IDENTITY_PROBES``.
+        * The Composio call fails (network, action not enabled, etc.).
+        * The expected ``field_path`` is missing from the response.
+
+    All ``None`` returns are logged so an admin can extend the registry
+    or fix the field path. The caller treats ``None`` as "verification
+    unavailable" and proceeds without storing an identity for tripwire
+    comparison — better than blocking the user.
+    """
+    probe = IDENTITY_PROBES.get(toolkit.lower())
+    if probe is None:
+        logger.info(
+            "composio.identity: no probe registered for toolkit=%r — skipping verification",
+            toolkit,
+        )
+        return None
+
+    try:
+        result = client.tools.execute(probe.action, user_id=user_id, arguments={})
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "composio.identity: probe %s for toolkit=%s user=%s failed",
+            probe.action,
+            toolkit,
+            user_id,
+        )
+        return None
+
+    payload = _extract_payload(result)
+    if payload is None:
+        logger.warning(
+            "composio.identity: probe %s returned an unrecognized envelope: %r",
+            probe.action,
+            type(result).__name__,
+        )
+        return None
+
+    value = _walk_field_path(payload, probe.field_path)
+    if value is None:
+        logger.warning(
+            "composio.identity: probe %s response missing field_path=%r",
+            probe.action,
+            probe.field_path,
+        )
+        return None
+    return str(value)
+
+
+def _extract_payload(result: Any) -> dict[str, Any] | None:
+    """Unwrap Composio's typical response envelope.
+
+    Composio's ``tools.execute`` returns either a dict like
+    ``{"data": {...}, "successful": True}`` or a pydantic model with
+    those same attrs depending on minor SDK version. We extract the
+    ``data`` payload defensively without assuming a specific class.
+    """
+    if isinstance(result, dict):
+        data = result.get("data")
+        if isinstance(data, dict):
+            return data
+        if data is None and result.get("successful") is not None:
+            # Some calls return {"successful": True, ...} flat.
+            return {k: v for k, v in result.items() if k != "successful"}
+        return None
+    data = getattr(result, "data", None)
+    if isinstance(data, dict):
+        return data
+    if hasattr(result, "model_dump"):
+        try:
+            dumped = result.model_dump()
+        except Exception:  # noqa: BLE001
+            return None
+        if isinstance(dumped, dict):
+            inner = dumped.get("data")
+            return inner if isinstance(inner, dict) else dumped
+    return None
+
+
+def _walk_field_path(payload: dict[str, Any], path: str) -> Any | None:
+    """Walk a dot-separated path through a nested dict.
+
+    Returns ``None`` on any miss. Does not interpret list indices —
+    every level must be a dict. Composio response shapes for the
+    probes registered above all match this expectation; if a future
+    toolkit needs list indexing, extend here.
+    """
+    current: Any = payload
+    for segment in path.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(segment)
+        if current is None:
+            return None
+    return current
+
+
+__all__ = ["IDENTITY_PROBES", "IdentityProbe", "probe_identity_sync"]

--- a/ee/pocketpaw_ee/cloud/composio/providers.py
+++ b/ee/pocketpaw_ee/cloud/composio/providers.py
@@ -1,0 +1,567 @@
+"""Composio per-backend providers — the documented in-process pattern.
+
+Composio publishes a dedicated provider package per agent SDK:
+
+    backend_kind        provider package + class
+    ────────────────    ─────────────────────────────────────────────
+    claude_agent_sdk    composio_claude_agent_sdk.ClaudeAgentSDKProvider
+    openai_agents       composio_openai_agents.OpenAIAgentsProvider
+    google_adk          composio_google_adk.GoogleAdkProvider
+    deep_agents         composio_langgraph.LanggraphProvider
+                        (deep_agents is langgraph under the hood)
+
+All four follow the same shape (see Composio docs):
+
+    composio = Composio(provider=XxxProvider())
+    session = composio.create(user_id="user_123")
+    tools = session.tools()
+    # → pass `tools` to whatever the backend's agent constructor expects
+
+This module is invoked from each backend's tool-build path. The
+``user_id`` we pass is the namespaced ``f"{enterprise_id}:{user_id}"``
+form (so two PocketPaw deployments sharing one Composio org never
+collide). The backend's per-stream tool-build resolves the active user
+from ``pocketpaw_ee.cloud.chat.agent_service.current_user_id`` so multi-tenancy
+is per-call, not per-instance.
+
+Tools are cached per ``(user_id, backend_kind)`` for
+``settings.composio_mcp_url_ttl_seconds`` (default 1h). ``composio.create``
+costs a network round-trip; without caching we'd pay it on every chat
+turn even though the per-user toolset rarely changes within a session.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from pocketpaw.config import Settings
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.composio import service as composio_service
+
+logger = logging.getLogger(__name__)
+
+# Backend kinds we have Composio providers for. The string keys match
+# ``settings.agent_backend`` / agent doc ``backend`` values exactly so
+# callers can pass their backend name through without translation.
+BACKEND_CLAUDE_SDK = "claude_agent_sdk"
+BACKEND_OPENAI_AGENTS = "openai_agents"
+BACKEND_GOOGLE_ADK = "google_adk"
+BACKEND_DEEP_AGENTS = "deep_agents"
+
+SUPPORTED_BACKENDS: frozenset[str] = frozenset(
+    {
+        BACKEND_CLAUDE_SDK,
+        BACKEND_OPENAI_AGENTS,
+        BACKEND_GOOGLE_ADK,
+        BACKEND_DEEP_AGENTS,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _CachedTools:
+    """Process-local cache entry — per-user tools list + expiry epoch."""
+
+    tools: list[Any]
+    expires_at: float
+
+
+# Process-global cache keyed by (namespaced_user_id, backend_kind).
+# Composio sessions are user-scoped and the tools change only when the
+# user (un)connects an integration upstream — so caching for the TTL
+# duration is safe in practice.
+_tools_cache: dict[tuple[str, str], _CachedTools] = {}
+_tools_cache_lock = threading.Lock()
+
+
+def build_tools_for_backend(
+    backend_kind: str,
+    *,
+    settings: Settings | None = None,
+) -> list[Any]:
+    """Return the per-user Composio tools for ``backend_kind``.
+
+    Resolves the active user from ``pocketpaw_ee.cloud.chat.agent_service``
+    contextvars (per-stream), builds a Composio session for that user
+    via the documented provider pattern, and returns
+    ``session.tools()``.
+
+    Returns an empty list when:
+        * Composio isn't configured (no api_key + enterprise_id).
+        * No active chat-stream context (e.g. CLI run, KB rebuild) —
+          we have no user to scope to.
+        * The backend isn't in ``SUPPORTED_BACKENDS``.
+        * Upstream Composio call fails — we log and degrade rather
+          than 500'ing the chat run.
+
+    Caching: by ``(namespaced_user_id, backend_kind)`` for
+    ``settings.composio_mcp_url_ttl_seconds`` (default 1h).
+    """
+    if backend_kind not in SUPPORTED_BACKENDS:
+        return []
+
+    s = settings or Settings.load()
+    if not composio_service.is_enabled(s):
+        return []
+
+    ctx = _resolve_ctx()
+    if ctx is None:
+        return []
+
+    try:
+        namespaced = str(composio_service.composio_user_id(ctx, s))
+    except Exception:  # noqa: BLE001
+        logger.debug("composio: user_id resolution failed", exc_info=True)
+        return []
+
+    cache_key = (namespaced, backend_kind)
+    now = time.monotonic()
+    with _tools_cache_lock:
+        cached = _tools_cache.get(cache_key)
+        if cached is not None and cached.expires_at > now:
+            return cached.tools
+
+    try:
+        tools = _build_session_and_tools(backend_kind, namespaced, s)
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "Composio: failed to build tools for backend=%s user=%s — "
+            "agent will run without Composio this turn",
+            backend_kind,
+            namespaced,
+        )
+        return []
+
+    with _tools_cache_lock:
+        _tools_cache[cache_key] = _CachedTools(
+            tools=tools,
+            expires_at=now + s.composio_mcp_url_ttl_seconds,
+        )
+    return tools
+
+
+def reset_cache_for_tests() -> None:
+    """Wipe the tools cache. ONLY for tests."""
+    with _tools_cache_lock:
+        _tools_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _resolve_ctx() -> RequestContext | None:
+    """Build a RequestContext from per-stream contextvars, or return None."""
+    try:
+        from datetime import UTC, datetime
+
+        from pocketpaw_ee.cloud.chat.agent_service import (
+            current_user_id,
+            current_workspace_id,
+        )
+    except ImportError:
+        return None
+
+    user_id = current_user_id()
+    if not user_id:
+        return None
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=current_workspace_id(),
+        request_id="composio-provider",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _build_session_and_tools(
+    backend_kind: str, namespaced_user_id: str, settings: Settings
+) -> list[Any]:
+    """Build a fresh Composio session for the backend + user, return tools.
+
+    Each provider has its own ``Composio`` instance because the
+    provider is bound at construction time. We could share a singleton
+    per backend_kind but the SDK is light enough that re-init per
+    cache-miss is fine (and avoids races with concurrent provider
+    swaps).
+    """
+    composio_cls, provider_cls = _provider_class_for(backend_kind)
+
+    api_key = settings.composio_api_key
+    base_url = settings.composio_base_url
+
+    # Composio's SDK reads ``COMPOSIO_API_KEY`` from the env in several
+    # internal code paths (not just the ctor kwarg). Setting the env
+    # var here as a fallback guarantees the SDK sees the key even when
+    # something internal bypasses our kwarg.
+    import os as _os
+
+    if api_key:
+        _os.environ.setdefault("COMPOSIO_API_KEY", api_key)
+
+    kwargs: dict[str, Any] = {"provider": provider_cls()}
+    if api_key:
+        kwargs["api_key"] = api_key
+    if base_url:
+        kwargs["base_url"] = base_url
+
+    composio_client = composio_cls(**kwargs)
+
+    # Use ``c.tools.get(user_id, toolkits=[...])`` — the "direct tools"
+    # path — instead of ``c.create(user_id).tools()``. The latter
+    # returns a Tool Router session that ships only 6 *meta-tools*
+    # (``COMPOSIO_SEARCH_TOOLS``, ``COMPOSIO_MANAGE_CONNECTIONS``, …),
+    # which is a discovery-based pattern designed for agents trained to
+    # use it. Most production LLMs hallucinate other instructions when
+    # given meta-tools without concrete ones, so we surface concrete
+    # tools (``GMAIL_SEND_EMAIL``, ``GMAIL_FETCH_EMAILS``, …) directly.
+    #
+    # Requires ``composio_toolkits`` to be non-empty — otherwise we'd
+    # surface all 200+ integrations and blow context budgets. Failing
+    # loud here is friendlier than silently sending 0 tools.
+    toolkits = list(settings.composio_toolkits)
+    if not toolkits:
+        logger.warning(
+            "Composio: no toolkits configured. Set POCKETPAW_COMPOSIO_TOOLKITS=gmail,"
+            "slack,... to expose concrete tools to the agent. Agent will run with no "
+            "Composio tools this turn."
+        )
+        return []
+
+    # ``composio.tools.get`` paginates alphabetically across the
+    # combined toolkit set, so a single call with ``toolkits=[a,b,c]``
+    # can return ~200 entries from the first letter alone. Fetch
+    # per-toolkit so every requested integration is represented.
+    # 50 tools/toolkit keeps multi-toolkit setups under the typical
+    # LLM tool-schema budget (Claude historically caps ~128). Users
+    # who need the full surface of a single toolkit should narrow
+    # ``composio_toolkits`` to that one toolkit.
+    per_toolkit_limit = 50
+    combined: list[Any] = []
+    seen_names: set[str] = set()
+    for toolkit in toolkits:
+        try:
+            tk_tools = composio_client.tools.get(
+                user_id=namespaced_user_id, toolkits=[toolkit], limit=per_toolkit_limit
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("Composio: failed to fetch toolkit %r — skipping", toolkit)
+            continue
+        for t in tk_tools or []:
+            name = getattr(t, "name", None) or (t.get("name") if isinstance(t, dict) else None)
+            if name and name in seen_names:
+                continue
+            if name:
+                seen_names.add(name)
+            combined.append(t)
+
+    # Append Composio's search-flow meta-tools as a discovery fallback.
+    # The direct-tools surface above caps at ``per_toolkit_limit`` per
+    # toolkit and paginates alphabetically — for big toolkits (github
+    # has 50+ actions) the cap can hide a specific action the agent
+    # needs (the bug: agent couldn't find GITHUB_SEARCH_ISSUES_AND_PULL_REQUESTS
+    # because the harness deferred the per-letter pagination batch).
+    # Giving the agent SEARCH / GET_SCHEMAS / MULTI_EXECUTE means when
+    # the direct tool index misses, it can ask Composio's own (more
+    # reliable) search to find and load the right action. Connection
+    # management is intentionally NOT included — we own that flow via
+    # ``connection_tool.py`` and don't want the model fragmenting between
+    # two auth paths.
+    meta_slugs = [
+        "COMPOSIO_SEARCH_TOOLS",
+        "COMPOSIO_GET_TOOL_SCHEMAS",
+        "COMPOSIO_MULTI_EXECUTE_TOOL",
+    ]
+    try:
+        meta_tools = composio_client.tools.get(user_id=namespaced_user_id, tools=meta_slugs)
+    except Exception:  # noqa: BLE001
+        # Meta-tool fetch failure is non-fatal: direct tools still work,
+        # we just lose the discovery fallback for this turn.
+        logger.warning(
+            "Composio: meta-tools fetch failed — agent runs without search fallback this turn",
+            exc_info=True,
+        )
+        meta_tools = []
+    for t in meta_tools or []:
+        name = getattr(t, "name", None) or (t.get("name") if isinstance(t, dict) else None)
+        if name and name in seen_names:
+            continue
+        if name:
+            seen_names.add(name)
+        combined.append(t)
+
+    # Append the connection-initiation tool. ``composio.tools.get``
+    # returns executable tools for already-connected accounts; it does
+    # not include a way to start the OAuth flow for a NEW account. Without
+    # this addition, when Composio returns ``ConnectedAccountNotFound``
+    # the agent has no tool to call next — it would just tell the user
+    # "I can't authorize" (the bug we just shipped on top of).
+    connection_tool = _build_initiate_connection_tool(backend_kind, composio_client)
+    if connection_tool is not None:
+        combined.append(connection_tool)
+
+    # Append the identity-verification tool. Composio's connected_accounts
+    # API doesn't expose the underlying OAuth identity (GitHub login,
+    # Gmail address) in a uniform way — the documented pattern is a
+    # per-toolkit "who am I" probe. After ``initiate_connection`` and
+    # the user authorizes, the agent calls ``verify_connection(toolkit)``
+    # to learn whose account was actually authorized + surface a
+    # confirmation back to the user. Tripwire on re-authorization.
+    verify_tool = _build_verify_connection_tool(backend_kind, composio_client)
+    if verify_tool is not None:
+        combined.append(verify_tool)
+
+    return combined
+
+
+def _build_initiate_connection_tool(backend_kind: str, composio_client: Any) -> Any | None:
+    """Build the per-backend wrapper for ``initiate_connection_sync``.
+
+    Returns a tool object shaped for the target backend's tool surface,
+    or ``None`` if we don't have a wrapper for that backend yet (the
+    agent will still run with its concrete-tool surface; it just can't
+    initiate new connections from chat).
+    """
+    from pocketpaw_ee.cloud.composio.connection_tool import initiate_connection_sync
+
+    if backend_kind == BACKEND_CLAUDE_SDK:
+        try:
+            from claude_agent_sdk import tool
+        except ImportError:
+            return None
+
+        @tool(
+            "initiate_connection",
+            (
+                "Start a fresh OAuth/Connect flow for a Composio toolkit "
+                "(gmail, slack, github, googlecalendar, googledrive, …). Call "
+                "this when a Composio tool returned ConnectedAccountNotFound "
+                "or any 'needs auth' / 'not connected' error. Returns a "
+                "redirect_url the user opens in a new browser tab to authorize. "
+                "After the user authorizes, retry the original tool call."
+            ),
+            {
+                "type": "object",
+                "properties": {
+                    "toolkit": {
+                        "type": "string",
+                        "description": (
+                            "Toolkit slug to authorize (lowercase). Examples: "
+                            "'gmail', 'slack', 'github', 'googlecalendar', "
+                            "'googledrive'."
+                        ),
+                    },
+                },
+                "required": ["toolkit"],
+                "additionalProperties": False,
+            },
+        )
+        async def initiate_connection(args: dict[str, Any]) -> dict[str, Any]:
+            import asyncio
+            import json
+
+            ctx = _resolve_ctx()
+            if ctx is None:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "initiate_connection requires an active chat stream.",
+                        }
+                    ],
+                    "is_error": True,
+                }
+            from pocketpaw_ee.cloud.composio import service as svc
+
+            try:
+                user_id = str(svc.composio_user_id(ctx))
+            except Exception as exc:  # noqa: BLE001
+                return {
+                    "content": [{"type": "text", "text": f"user id resolution failed: {exc}"}],
+                    "is_error": True,
+                }
+
+            toolkit_slug = str(args.get("toolkit", "")).strip().lower()
+            if not toolkit_slug:
+                return {
+                    "content": [{"type": "text", "text": "toolkit argument is required"}],
+                    "is_error": True,
+                }
+
+            result = await asyncio.to_thread(
+                initiate_connection_sync,
+                composio_client,
+                user_id=user_id,
+                toolkit_slug=toolkit_slug,
+            )
+            return {"content": [{"type": "text", "text": json.dumps(result)}]}
+
+        return initiate_connection
+
+    # TODO: deep_agents / google_adk / openai_agents wrappers. For now
+    # other backends just don't get the initiate-connection tool —
+    # the agent runs without auth-initiation; admin can fall back to
+    # connecting accounts via the Composio dashboard. The cloud chat
+    # default is claude_agent_sdk per the agent doc, so this covers
+    # the common case.
+    return None
+
+
+def _build_verify_connection_tool(backend_kind: str, composio_client: Any) -> Any | None:
+    """Build the per-backend wrapper for the identity-verification flow.
+
+    The agent calls this after ``initiate_connection`` succeeds and the
+    user returns from authorizing. Probes the toolkit's "who am I"
+    action and upserts the result, with tripwire on identity change.
+    Returns ``None`` for backends we don't have a wrapper for yet.
+    """
+    from pocketpaw_ee.cloud.composio.identity import probe_identity_sync
+
+    if backend_kind == BACKEND_CLAUDE_SDK:
+        try:
+            from claude_agent_sdk import tool
+        except ImportError:
+            return None
+
+        @tool(
+            "verify_connection",
+            (
+                "Verify which external account a user authorized via Composio. "
+                "Call IMMEDIATELY after the user clicks the redirect URL from "
+                "initiate_connection and returns to chat. Returns the connected "
+                "account's external identity (GitHub login, Gmail address, "
+                "etc.). Surface the result to the user verbatim — they need "
+                "to know which account they connected, especially if they "
+                "have multiple. If status is 'mismatch', the user "
+                "re-authorized as a DIFFERENT account than the one previously "
+                "stored — ask them to confirm before retrying the original tool."
+            ),
+            {
+                "type": "object",
+                "properties": {
+                    "toolkit": {
+                        "type": "string",
+                        "description": (
+                            "Toolkit slug whose identity to probe. Same slug "
+                            "passed to initiate_connection (e.g. 'gmail', 'github')."
+                        ),
+                    },
+                },
+                "required": ["toolkit"],
+                "additionalProperties": False,
+            },
+        )
+        async def verify_connection(args: dict[str, Any]) -> dict[str, Any]:
+            import asyncio
+            import json
+            from dataclasses import asdict
+
+            ctx = _resolve_ctx()
+            if ctx is None:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "verify_connection requires an active chat stream.",
+                        }
+                    ],
+                    "is_error": True,
+                }
+            from pocketpaw_ee.cloud.composio import service as svc
+
+            try:
+                user_id = str(svc.composio_user_id(ctx))
+            except Exception as exc:  # noqa: BLE001
+                return {
+                    "content": [{"type": "text", "text": f"user id resolution failed: {exc}"}],
+                    "is_error": True,
+                }
+
+            toolkit_slug = str(args.get("toolkit", "")).strip().lower()
+            if not toolkit_slug:
+                return {
+                    "content": [{"type": "text", "text": "toolkit argument is required"}],
+                    "is_error": True,
+                }
+
+            try:
+                external_identity = await asyncio.to_thread(
+                    probe_identity_sync,
+                    composio_client,
+                    user_id=user_id,
+                    toolkit=toolkit_slug,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("composio.verify_connection: probe failed")
+                return {
+                    "content": [{"type": "text", "text": f"identity probe failed: {exc}"}],
+                    "is_error": True,
+                }
+
+            try:
+                record = await svc.record_connection(
+                    ctx, toolkit=toolkit_slug, external_identity=external_identity
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("composio.verify_connection: record_connection failed")
+                return {
+                    "content": [{"type": "text", "text": f"record_connection failed: {exc}"}],
+                    "is_error": True,
+                }
+
+            return {"content": [{"type": "text", "text": json.dumps(asdict(record))}]}
+
+        return verify_connection
+
+    return None
+
+
+def _provider_class_for(backend_kind: str) -> tuple[Any, Any]:
+    """Resolve (Composio class, Provider class) for a backend kind.
+
+    Imports are local so a missing provider package only breaks its
+    own backend, not the rest of ``pocketpaw_ee.cloud.composio``.
+    """
+    from composio import Composio  # type: ignore[import-not-found]
+
+    if backend_kind == BACKEND_CLAUDE_SDK:
+        from composio_claude_agent_sdk import (  # type: ignore[import-not-found]
+            ClaudeAgentSDKProvider,
+        )
+
+        return Composio, ClaudeAgentSDKProvider
+    if backend_kind == BACKEND_OPENAI_AGENTS:
+        from composio_openai_agents import (  # type: ignore[import-not-found]
+            OpenAIAgentsProvider,
+        )
+
+        return Composio, OpenAIAgentsProvider
+    if backend_kind == BACKEND_GOOGLE_ADK:
+        from composio_google_adk import (  # type: ignore[import-not-found]
+            GoogleAdkProvider,
+        )
+
+        return Composio, GoogleAdkProvider
+    if backend_kind == BACKEND_DEEP_AGENTS:
+        from composio_langgraph import (  # type: ignore[import-not-found]
+            LanggraphProvider,
+        )
+
+        return Composio, LanggraphProvider
+    raise ValueError(f"Composio: no provider mapping for backend kind {backend_kind!r}")
+
+
+__all__ = [
+    "BACKEND_CLAUDE_SDK",
+    "BACKEND_DEEP_AGENTS",
+    "BACKEND_GOOGLE_ADK",
+    "BACKEND_OPENAI_AGENTS",
+    "SUPPORTED_BACKENDS",
+    "build_tools_for_backend",
+    "reset_cache_for_tests",
+]

--- a/ee/pocketpaw_ee/cloud/composio/service.py
+++ b/ee/pocketpaw_ee/cloud/composio/service.py
@@ -1,0 +1,386 @@
+"""Composio service — session factory, user_id namespacing, toolkit discovery.
+
+Module-level ``async def`` functions per the ee/pocketpaw_ee/cloud entity convention
+(Rule 5). State (the process-global Composio client) lives behind a
+lazy-init helper, not on a class.
+
+Boundary: the upstream ``composio`` SDK is imported lazily inside
+``_get_client`` so this module is importable in environments that don't
+have ``pocketpaw[enterprise]`` installed (test collection in OSS-only
+checkouts, doc builds, etc.). Callers should gate on ``is_enabled()``
+before invoking any function that touches the SDK.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from pocketpaw.config import Settings
+from pocketpaw_ee.cloud._core.context import RequestContext
+from pocketpaw_ee.cloud._core.errors import Internal, ValidationError
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import (
+    ComposioConnectionMismatch,
+    ComposioConnectionVerified,
+)
+from pocketpaw_ee.cloud.composio.domain import ComposioUserId
+
+logger = logging.getLogger(__name__)
+
+
+# Process-global Composio client cache. The client holds the api_key and
+# is safe to share across requests (it does not carry per-user state —
+# per-user identity is the ``user_id`` passed at session-create time).
+# An ``asyncio.Lock`` guards against the thundering-herd at first use,
+# where N concurrent requests would otherwise each call the SDK init.
+_client: object | None = None
+_client_lock: asyncio.Lock = asyncio.Lock()
+
+
+def is_enabled(settings: Settings | None = None) -> bool:
+    """True when Composio is fully configured (api_key + enterprise_id).
+
+    The ``Settings`` validator already enforces ``api_key →
+    enterprise_id``; this is a cheap helper for the call sites that
+    just want a yes/no before deciding whether to inject the MCP
+    server. Accepts an optional ``Settings`` so callers that already
+    have one don't pay the ``Settings.load()`` cost twice.
+    """
+    s = settings or Settings.load()
+    return bool(s.composio_api_key and s.composio_enterprise_id)
+
+
+def composio_user_id(ctx: RequestContext, settings: Settings | None = None) -> ComposioUserId:
+    """Build the namespaced Composio user_id for the request.
+
+    Format: ``f"{enterprise_id}:{user_id}"``. Constructed via the
+    ``ComposioUserId`` value object so the tenancy invariants live
+    in one place (domain), not scattered across f-strings.
+    """
+    s = settings or Settings.load()
+    if not s.composio_enterprise_id:
+        raise ValidationError(
+            "composio.disabled",
+            "Composio is not configured (composio_enterprise_id missing)",
+        )
+    if not ctx.user_id:
+        raise ValidationError("composio.user_id_missing", "RequestContext.user_id is empty")
+    return ComposioUserId(enterprise_id=s.composio_enterprise_id, user_id=ctx.user_id)
+
+
+async def _get_client(settings: Settings | None = None) -> object:
+    """Lazy-init the process-global Composio client.
+
+    Cached because the client init touches network / FS in some SDK
+    versions and per-request setup would dominate latency for cheap
+    tool calls. The client is a-tenant-agnostic singleton — per-user
+    identity is supplied at session-create time, not client-init time.
+    """
+    global _client
+    if _client is not None:
+        return _client
+
+    s = settings or Settings.load()
+    if not is_enabled(s):
+        raise ValidationError(
+            "composio.disabled",
+            "Composio is not configured (composio_api_key + composio_enterprise_id required)",
+        )
+
+    async with _client_lock:
+        if _client is not None:  # double-checked locking
+            return _client
+        try:
+            from composio import Composio  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise Internal(
+                "composio.sdk_missing",
+                "composio SDK not installed (pip install 'pocketpaw[enterprise]')",
+            ) from exc
+        # ``Composio()`` can perform blocking I/O on init in some SDK
+        # versions; run it on the default executor so we don't block
+        # the event loop. ``base_url`` is None for Composio cloud.
+        client = await asyncio.to_thread(
+            _build_client_sync, Composio, s.composio_api_key, s.composio_base_url
+        )
+        _client = client
+        return _client
+
+
+def _build_client_sync(composio_cls: Any, api_key: str | None, base_url: str | None) -> object:
+    """Sync Composio() constructor — separated for ``asyncio.to_thread``."""
+    if base_url:
+        return composio_cls(api_key=api_key, base_url=base_url)
+    return composio_cls(api_key=api_key)
+
+
+async def list_available_toolkits(settings: Settings | None = None) -> list[str]:
+    """Return the full list of toolkit slugs available on the Composio account.
+
+    Admin-discovery helper for the fail-closed allow-list — operators
+    inspect this to decide what to put in ``POCKETPAW_COMPOSIO_TOOLKITS``
+    rather than spelunking the Composio docs. Returns slugs (e.g.
+    ``"gmail"``, ``"slack"``), not display names.
+
+    NOT cached: toolkit availability changes when Composio adds new
+    integrations or an admin disables one upstream. Callers that
+    want caching should wrap this themselves.
+    """
+    s = settings or Settings.load()
+    client = await _get_client(s)
+    try:
+        toolkits = await asyncio.to_thread(_list_toolkits_sync, client)
+    except Exception as exc:  # noqa: BLE001
+        raise Internal("composio.toolkit_list_failed", "Failed to list Composio toolkits") from exc
+    return toolkits
+
+
+def _list_toolkits_sync(client: Any) -> list[str]:
+    """Sync toolkit-list call — separated for ``asyncio.to_thread``.
+
+    ``client.toolkits.list()`` returns either a dict
+    (``{"items": [...]}``) or a pydantic model with an ``items``
+    attribute depending on minor SDK version. We extract defensively
+    so ``dict.items`` (the builtin method) doesn't get mistaken for
+    the list. Each item has a ``slug`` (e.g. ``"gmail"``).
+
+    The response is paginated; for v1 we surface only the first page —
+    admins can call upstream directly if they need the full catalog.
+    """
+    response = client.toolkits.list()
+    items: Any
+    if isinstance(response, dict):
+        items = response.get("items") or []
+    else:
+        items = getattr(response, "items", None) or []
+    slugs: list[str] = []
+    for tk in items:
+        slug = (tk.get("slug") if isinstance(tk, dict) else getattr(tk, "slug", None)) or (
+            tk.get("name") if isinstance(tk, dict) else getattr(tk, "name", None)
+        )
+        if slug:
+            slugs.append(str(slug))
+    return slugs
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectionRecord:
+    """Result of ``record_connection`` — what the caller surfaces to the agent.
+
+    ``status`` is one of:
+        * ``"verified"`` — first time recording this identity, or a fresh
+          probe matched the previously stored one. Caller renders
+          "Connected as X. Continue?".
+        * ``"mismatch"`` — probe returned a different identity than the
+          stored one. Caller renders "Connected as X — this differs from
+          previously verified Y. Confirm?" and waits for the user to
+          explicitly accept the change before retrying the original tool.
+        * ``"unverified"`` — probe returned ``None`` (toolkit lacks a
+          registered probe, or the probe call failed). Caller renders
+          "Connected to <toolkit> — identity verification unavailable".
+    """
+
+    status: str  # "verified" | "mismatch" | "unverified"
+    toolkit: str
+    external_identity: str | None
+    previous_identity: str | None = None
+
+
+async def record_connection(
+    ctx: RequestContext,
+    *,
+    toolkit: str,
+    external_identity: str | None,
+) -> ConnectionRecord:
+    """Upsert the verified identity for ``(workspace, user, toolkit)``.
+
+    ``external_identity=None`` means the probe couldn't resolve an
+    identity (no probe registered, call failed). We still bump
+    ``last_verified_at`` so the chat can confirm something was probed,
+    but we don't store a value for tripwire comparison.
+
+    Tripwire: when the new identity is non-empty and differs from the
+    stored one, we DO NOT overwrite. The mismatch is recorded
+    (``mismatch_count``, ``last_mismatch_identity``, ``last_mismatch_at``)
+    and surfaced via ``ComposioConnectionMismatch``. The agent layer
+    blocks until the user explicitly confirms the change, at which
+    point a second call (with ``external_identity`` matching) succeeds.
+
+    Multi-tenancy: ``workspace_id`` is required on ``ctx``; the find
+    filters on it. Two users in different workspaces can each have their
+    own connected GitHub without collision.
+    """
+    if not ctx.workspace_id:
+        raise ValidationError("composio.workspace_required", "RequestContext.workspace_id is empty")
+    if not ctx.user_id:
+        raise ValidationError("composio.user_id_missing", "RequestContext.user_id is empty")
+    toolkit_slug = toolkit.strip().lower()
+    if not toolkit_slug:
+        raise ValidationError("composio.toolkit_required", "toolkit slug is required")
+
+    from pocketpaw_ee.cloud.models.composio_connection import ComposioConnection
+
+    now = datetime.now(UTC)
+    doc = await ComposioConnection.find_one(
+        ComposioConnection.workspace == ctx.workspace_id,
+        ComposioConnection.paw_user_id == ctx.user_id,
+        ComposioConnection.toolkit == toolkit_slug,
+    )
+
+    if doc is None:
+        doc = ComposioConnection(
+            workspace=ctx.workspace_id,
+            paw_user_id=ctx.user_id,
+            toolkit=toolkit_slug,
+            external_identity=external_identity,
+            last_verified_at=now,
+        )
+        await doc.insert()
+        status = "verified" if external_identity else "unverified"
+        await emit(
+            ComposioConnectionVerified(
+                data={
+                    "workspace_id": ctx.workspace_id,
+                    "user_id": ctx.user_id,
+                    "toolkit": toolkit_slug,
+                    "external_identity": external_identity,
+                    "first_time": True,
+                }
+            )
+        )
+        return ConnectionRecord(
+            status=status,
+            toolkit=toolkit_slug,
+            external_identity=external_identity,
+        )
+
+    stored = doc.external_identity
+    if external_identity is None:
+        # Probe couldn't resolve — bump verified_at as a heartbeat but
+        # don't pretend we re-confirmed the identity.
+        doc.last_verified_at = now
+        await doc.save()
+        return ConnectionRecord(
+            status="unverified",
+            toolkit=toolkit_slug,
+            external_identity=stored,
+        )
+
+    if stored is None or stored == external_identity:
+        # First-time confirmation OR a matching re-probe. Safe to update.
+        doc.external_identity = external_identity
+        doc.last_verified_at = now
+        await doc.save()
+        await emit(
+            ComposioConnectionVerified(
+                data={
+                    "workspace_id": ctx.workspace_id,
+                    "user_id": ctx.user_id,
+                    "toolkit": toolkit_slug,
+                    "external_identity": external_identity,
+                    "first_time": stored is None,
+                }
+            )
+        )
+        return ConnectionRecord(
+            status="verified",
+            toolkit=toolkit_slug,
+            external_identity=external_identity,
+        )
+
+    # Tripwire: identity changed. Record the mismatch without
+    # overwriting the stored external_identity — the user must confirm.
+    doc.mismatch_count += 1
+    doc.last_mismatch_identity = external_identity
+    doc.last_mismatch_at = now
+    await doc.save()
+    await emit(
+        ComposioConnectionMismatch(
+            data={
+                "workspace_id": ctx.workspace_id,
+                "user_id": ctx.user_id,
+                "toolkit": toolkit_slug,
+                "stored_identity": stored,
+                "probed_identity": external_identity,
+                "mismatch_count": doc.mismatch_count,
+            }
+        )
+    )
+    return ConnectionRecord(
+        status="mismatch",
+        toolkit=toolkit_slug,
+        external_identity=external_identity,
+        previous_identity=stored,
+    )
+
+
+async def confirm_identity_change(
+    ctx: RequestContext,
+    *,
+    toolkit: str,
+    external_identity: str,
+) -> ConnectionRecord:
+    """Accept an identity change the user explicitly confirmed.
+
+    After a ``"mismatch"`` result from ``record_connection``, the chat
+    asks the user to confirm. On "yes", this overwrites the stored
+    ``external_identity`` so future probes match and re-verify cleanly.
+    """
+    if not ctx.workspace_id or not ctx.user_id:
+        raise ValidationError(
+            "composio.workspace_or_user_missing", "RequestContext.workspace_id/user_id is empty"
+        )
+    toolkit_slug = toolkit.strip().lower()
+
+    from pocketpaw_ee.cloud.models.composio_connection import ComposioConnection
+
+    doc = await ComposioConnection.find_one(
+        ComposioConnection.workspace == ctx.workspace_id,
+        ComposioConnection.paw_user_id == ctx.user_id,
+        ComposioConnection.toolkit == toolkit_slug,
+    )
+    if doc is None:
+        raise ValidationError(
+            "composio.connection_not_found",
+            f"No prior connection record for toolkit {toolkit_slug!r} — cannot confirm change",
+        )
+
+    previous = doc.external_identity
+    doc.external_identity = external_identity
+    doc.last_verified_at = datetime.now(UTC)
+    doc.last_mismatch_identity = None
+    doc.last_mismatch_at = None
+    await doc.save()
+    await emit(
+        ComposioConnectionVerified(
+            data={
+                "workspace_id": ctx.workspace_id,
+                "user_id": ctx.user_id,
+                "toolkit": toolkit_slug,
+                "external_identity": external_identity,
+                "first_time": False,
+                "confirmed_change_from": previous,
+            }
+        )
+    )
+    return ConnectionRecord(
+        status="verified",
+        toolkit=toolkit_slug,
+        external_identity=external_identity,
+        previous_identity=previous,
+    )
+
+
+def reset_client_cache_for_tests() -> None:
+    """Reset the process-global client cache. ONLY for tests.
+
+    The pool is fine to share across a real process lifetime, but tests
+    that swap settings between cases need to invalidate it to avoid the
+    second test seeing the first test's mocked client.
+    """
+    global _client
+    _client = None

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pocketpaw_ee.cloud.models.agent import Agent, AgentConfig
 from pocketpaw_ee.cloud.models.comment import Comment, CommentAuthor, CommentTarget
+from pocketpaw_ee.cloud.models.composio_connection import ComposioConnection
 from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
 from pocketpaw_ee.cloud.models.cycle import Cycle, CycleDailyPoint
 from pocketpaw_ee.cloud.models.file import FileObj
@@ -43,6 +44,7 @@ __all__ = [
     "Comment",
     "CommentAuthor",
     "CommentTarget",
+    "ComposioConnection",
     "Cycle",
     "CycleDailyPoint",
     "FileFolder",
@@ -91,6 +93,7 @@ def get_all_documents():
         FileFolder,
         Workspace,
         WorkspaceConnector,
+        ComposioConnection,
         Invite,
         Group,
         Message,

--- a/ee/pocketpaw_ee/cloud/models/composio_connection.py
+++ b/ee/pocketpaw_ee/cloud/models/composio_connection.py
@@ -1,0 +1,56 @@
+# ComposioConnection Beanie document — records the external identity
+# a paw user authorized for each Composio toolkit. Keyed on
+# ``(workspace, paw_user_id, toolkit)``. The stored ``external_identity``
+# is the toolkit's native id (GitHub login, Gmail address, Slack user
+# id) returned by the per-toolkit probe at
+# ``pocketpaw_ee.cloud.composio.identity``.
+#
+# Purpose: tripwire. When a user re-authorizes a toolkit, the next
+# probe may return a different ``external_identity`` than the stored
+# one. The service layer surfaces this mismatch ("Connected as X — this
+# differs from previously verified Y") rather than silently overwriting,
+# so wrong-account binds are caught the first time.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class ComposioConnection(TimestampedDocument):
+    """Verified external identity for one (workspace, user, toolkit).
+
+    Tenancy: ``workspace`` is required and indexed; every read in
+    ``service.py`` filters on it. ``paw_user_id`` + ``toolkit`` together
+    with ``workspace`` form the natural unique key — enforced at the
+    service layer via find-or-create rather than a Mongo unique index
+    (keeps re-verification idempotent under race).
+
+    ``external_identity`` is the verbatim string returned by the
+    per-toolkit probe (e.g. ``"octocat"`` for GitHub,
+    ``"user@example.com"`` for Gmail). ``None`` means a verification
+    was attempted but the probe couldn't resolve the identity (toolkit
+    has no probe registered, or the call failed) — distinct from no
+    record at all.
+
+    ``last_verified_at`` updates on every successful probe; ``mismatch_count``
+    increments when a fresh probe returns a different identity than the
+    stored one (without overwriting — the user must confirm the change
+    explicitly).
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    paw_user_id: str
+    toolkit: str
+    external_identity: str | None = None
+    last_verified_at: datetime | None = None
+    mismatch_count: int = Field(default=0, ge=0)
+    last_mismatch_identity: str | None = None
+    last_mismatch_at: datetime | None = None
+
+    class Settings(TimestampedDocument.Settings):
+        name = "composio_connections"

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -271,3 +271,57 @@ class CloudAgentExtension:
             if value:
                 env[var] = str(value)
         return env
+
+
+class CloudComposioToolProvider:
+    """`pocketpaw.composio_tools` — Composio integration tools for the
+    parent cloud chat agent.
+
+    Composio supplies 200+ pre-built OAuth integrations (Gmail, Slack,
+    GitHub, Calendar, Drive, …). Tools are fetched per-stream via the
+    official Composio provider package for the requesting backend and
+    returned in that backend's native tool format. The pocket specialist
+    deliberately does not receive Composio — the parent agent fetches the
+    data and passes it down in the brief.
+    """
+
+    def build_tools(self, backend: str, settings: Any) -> list[Any]:
+        from pocketpaw_ee.cloud.composio.providers import build_tools_for_backend
+
+        return list(build_tools_for_backend(backend, settings=settings))
+
+
+class CloudComposioMcpProvider:
+    """`pocketpaw.mcp_servers` — Composio integrations for the
+    ``claude_agent_sdk`` backend, exposed as an in-process MCP server.
+
+    The other agent backends consume Composio as native function tools
+    via ``CloudComposioToolProvider``; ``claude_agent_sdk`` instead
+    discovers MCP servers, so Composio reaches it this way. ``build_server``
+    runs once per ``_get_mcp_servers`` call (i.e. per stream) and the
+    tools are bound to the active user via Composio's per-user sessions,
+    so the server stays multi-tenant safe.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        try:
+            from claude_agent_sdk import create_sdk_mcp_server
+
+            from pocketpaw_ee.cloud.composio.providers import build_tools_for_backend
+        except ImportError:
+            # claude_agent_sdk / composio provider package not installed.
+            return None
+        try:
+            tools = build_tools_for_backend("claude_agent_sdk")
+        except Exception:  # noqa: BLE001
+            return None
+        if not tools:
+            return None
+        return "composio", create_sdk_mcp_server(name="composio", version="1.0.0", tools=tools)
+
+    def tool_ids(self) -> list[str]:
+        # Composio's tool set is per-user and per-toolkit (resolved at
+        # session-build time), so it can't be statically enumerated.
+        # ``mcp__composio`` is the server-level allowlist entry — it
+        # permits every tool the in-process ``composio`` server exposes.
+        return ["mcp__composio"]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -64,6 +64,18 @@ dependencies = [
     "google-api-python-client>=2.100.0",
     "google-auth>=2.25.0",
     "google-auth-oauthlib>=1.2.0",
+    # --- Composio — 200+ pre-built OAuth integrations (Gmail, Slack,
+    # GitHub, Calendar, Drive, Linear, …). Each agent backend gets its
+    # own Composio provider package; the wiring lives in
+    # ee/pocketpaw_ee/cloud/composio/providers.py and is reached from the
+    # OSS core via the ``pocketpaw.composio_tools`` entry point. The
+    # pocket specialist runs on deep_agents but is deliberately kept
+    # Composio-free, so Composio reaches only the parent agent.
+    "composio>=0.7.0",
+    "composio_claude_agent_sdk>=0.7.0",
+    "composio_openai_agents>=0.7.0",
+    "composio_google_adk>=0.7.0",
+    "composio_langgraph>=0.7.0",
 ]
 
 [project.optional-dependencies]
@@ -121,9 +133,13 @@ tasks = "pocketpaw_ee.extensions:CloudTasksMcpProvider"
 planner = "pocketpaw_ee.extensions:CloudPlannerMcpProvider"
 pocket = "pocketpaw_ee.extensions:CloudPocketMcpProvider"
 pocket_specialist = "pocketpaw_ee.extensions:CloudPocketSpecialistMcpProvider"
+composio = "pocketpaw_ee.extensions:CloudComposioMcpProvider"
 
 [project.entry-points."pocketpaw.agent_extensions"]
 cloud = "pocketpaw_ee.extensions:CloudAgentExtension"
+
+[project.entry-points."pocketpaw.composio_tools"]
+cloud = "pocketpaw_ee.extensions:CloudComposioToolProvider"
 
 [tool.hatch.build.targets.wheel]
 packages = ["pocketpaw_ee"]

--- a/src/pocketpaw/agents/deep_agents.py
+++ b/src/pocketpaw/agents/deep_agents.py
@@ -693,6 +693,21 @@ class DeepAgentsBackend:
             return self._cached_agent
 
         all_tools = self._build_custom_tools() + (mcp_tools or [])
+
+        # Composio — per-stream integration tools (Gmail, Slack, …) via the
+        # langgraph provider, discovered through the ``pocketpaw.composio_tools``
+        # entry point. Skipped on pocket sessions: the pocket specialist runs
+        # on this backend and we keep its tool surface narrow + Composio-free
+        # (the parent agent fetches Composio data and passes it down in the
+        # brief).
+        if not is_pocket_session:
+            from pocketpaw.agents.tool_bridge import composio_tools_for
+
+            composio_tools = composio_tools_for("deep_agents", self.settings)
+            if composio_tools:
+                all_tools = all_tools + list(composio_tools)
+                logger.info("Composio: appended %d langgraph tools", len(composio_tools))
+
         if is_pocket_session:
             # Drop shell + filesystem tools — pocket flow has MCP tools
             # for everything it needs. Without this filter the agent has

--- a/src/pocketpaw/agents/google_adk.py
+++ b/src/pocketpaw/agents/google_adk.py
@@ -252,8 +252,16 @@ class GoogleADKBackend(BaseAgentBackend):
 
             instruction = system_prompt or _DEFAULT_IDENTITY
 
-            # Build tools: custom PocketPaw tools + MCP toolsets
+            # Build tools: custom PocketPaw tools + MCP toolsets + Composio
+            # (per-stream via the documented composio_google_adk provider,
+            # discovered through the ``pocketpaw.composio_tools`` entry point).
             tools = self._build_custom_tools() + self._build_mcp_toolsets()
+            from pocketpaw.agents.tool_bridge import composio_tools_for
+
+            composio_tools = composio_tools_for("google_adk", self.settings)
+            if composio_tools:
+                tools = tools + list(composio_tools)
+                logger.info("Composio: appended %d ADK tools", len(composio_tools))
 
             # Session management: reuse sessions for multi-turn, seed history on first call
             user_id = "pocketpaw_user"

--- a/src/pocketpaw/agents/openai_agents.py
+++ b/src/pocketpaw/agents/openai_agents.py
@@ -248,6 +248,17 @@ class OpenAIAgentsBackend(BaseAgentBackend):
                 instructions = self._inject_history(instructions, history)
 
             custom_tools = self._build_custom_tools()
+
+            # Composio — per-stream integration tools via the documented
+            # ``composio_openai_agents`` provider, discovered through the
+            # ``pocketpaw.composio_tools`` entry point.
+            from pocketpaw.agents.tool_bridge import composio_tools_for
+
+            composio_tools = composio_tools_for("openai_agents", self.settings)
+            if composio_tools:
+                custom_tools = list(custom_tools) + list(composio_tools)
+                logger.info("Composio: appended %d openai-agents tools", len(composio_tools))
+
             agent = Agent(
                 name="PocketPaw",
                 instructions=instructions,

--- a/src/pocketpaw/agents/tool_bridge.py
+++ b/src/pocketpaw/agents/tool_bridge.py
@@ -42,6 +42,87 @@ _CLAUDE_SDK_EXCLUDED = frozenset(
     }
 )
 
+# Tool names (NOT class names) that overlap with Composio's hosted
+# integrations. When Composio is enabled (cloud, with ``composio_api_key``
+# set), these YAML-/native-connector-backed tools are dropped from the
+# agent's surface so the LLM has exactly one path per integration. Without
+# this, the agent gets confused between Composio's ``GMAIL_SEND_EMAIL`` and
+# the legacy ``gmail_send``, and tends to fall back on the legacy tool's
+# "Settings → Google OAuth" auth flow (a paw-enterprise UI affordance, not
+# a chat one).
+_COMPOSIO_OVERLAPPING_TOOL_NAMES = frozenset(
+    {
+        # Gmail
+        "gmail_search",
+        "gmail_read",
+        "gmail_send",
+        "gmail_list_labels",
+        "gmail_create_label",
+        "gmail_modify",
+        "gmail_trash",
+        "gmail_batch_modify",
+        # Google Calendar
+        "calendar_list",
+        "calendar_create",
+        "calendar_prep",
+        # Google Docs
+        "docs_read",
+        "docs_create",
+        "docs_search",
+        # Google Drive
+        "drive_list",
+        "drive_download",
+        "drive_upload",
+        "drive_share",
+        # Reddit
+        "reddit_search",
+        "reddit_read",
+        "reddit_trending",
+        # Spotify
+        "spotify_search",
+        "spotify_now_playing",
+        "spotify_playback",
+        "spotify_playlist",
+    }
+)
+
+
+def _is_composio_enabled() -> bool:
+    """True when Composio is configured. Read lazily so OSS-local runs
+    don't pay the ``Settings.load`` cost up front."""
+    try:
+        from pocketpaw.config import Settings
+
+        s = Settings.load()
+        return bool(s.composio_api_key and s.composio_enterprise_id)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def composio_tools_for(backend: str, settings: Any) -> list[Any]:
+    """Composio integration tools for *backend*, via the
+    ``pocketpaw.composio_tools`` entry point.
+
+    Returns ``[]`` on an OSS install (no provider registered), when
+    Composio is not configured, or when the per-stream fetch fails —
+    Composio is always additive to the agent's tool surface, never
+    load-bearing, so a failure degrades silently rather than aborting
+    the run. Keeps the OSS core free of any ``pocketpaw_ee`` import: the
+    cloud provider is discovered through the entry-point registry.
+    """
+    from pocketpaw._registry import first as _ext_first
+
+    provider = _ext_first("pocketpaw.composio_tools")
+    if provider is None:
+        return []
+    try:
+        return list(provider.build_tools(backend, settings))
+    except ImportError:
+        return []  # composio SDK / provider package not installed
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("composio_tools_for(%s) failed: %s", backend, exc)
+        return []
+
 
 def _instantiate_all_tools(backend: str = "claude_agent_sdk") -> list[BaseTool]:
     """Discover and instantiate all builtin tools, filtered by backend.
@@ -96,6 +177,21 @@ def _instantiate_all_tools(backend: str = "claude_agent_sdk") -> list[BaseTool]:
             tools.extend(ext.agent_tools(backend))
         except Exception as exc:  # noqa: BLE001
             logger.debug("agent extension %r agent_tools failed: %s", ext, exc)
+
+    # When Composio is configured, drop the YAML-/native-connector tools
+    # whose integrations are now served by Composio's hosted ``*_*`` tools
+    # (GMAIL_SEND_EMAIL, etc.). Prevents the LLM from mixing two
+    # integration paths and surfacing paw-enterprise's
+    # "Settings → Google OAuth" affordance in chat.
+    if _is_composio_enabled():
+        before = len(tools)
+        tools = [t for t in tools if t.name not in _COMPOSIO_OVERLAPPING_TOOL_NAMES]
+        dropped = before - len(tools)
+        if dropped:
+            logger.info(
+                "tool_bridge: dropped %d YAML-connector tools (Composio is enabled)",
+                dropped,
+            )
 
     return tools
 

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -34,8 +34,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Annotated, Literal
 
-from pydantic import AfterValidator, Field, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import AfterValidator, Field, field_validator, model_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from pocketpaw.security.url_validators import validate_external_url
 
@@ -1168,6 +1168,83 @@ class Settings(BaseSettings):
     max_concurrent_conversations: int = Field(
         default=5, gt=0, description="Max parallel conversations processed simultaneously"
     )
+
+    # Composio — MCP-direct tool provider for the parent cloud chat agent.
+    # Wired into src/pocketpaw/agents/claude_sdk.py::_get_mcp_servers; the
+    # pocket specialist does NOT receive Composio MCP. When api_key is set,
+    # composio_enterprise_id is required to namespace the per-user Composio
+    # user_id (avoids collisions across PocketPaw enterprise deployments
+    # that share one Composio org).
+    composio_api_key: str | None = Field(
+        default=None, description="Composio API key (enables Composio MCP for the parent agent)"
+    )
+    composio_base_url: str | None = Field(
+        default=None,
+        description="Composio base URL. None = Composio cloud; set for self-hosted runtime.",
+    )
+    # ``NoDecode`` keeps pydantic-settings from trying to JSON-parse the raw
+    # env string; the ``field_validator`` below handles CSV → list[str].
+    composio_toolkits: Annotated[list[str], NoDecode] = Field(
+        default_factory=list,
+        description=(
+            "Allow-list of Composio toolkit slugs (e.g. 'gmail,slack,github'). "
+            "Comma-separated when set via env. Empty = fail closed (no toolkits exposed)."
+        ),
+    )
+    composio_enterprise_id: str | None = Field(
+        default=None,
+        description=(
+            "Namespace prefix for Composio user_id (f'{enterprise_id}:{user_id}'). "
+            "Required when composio_api_key is set."
+        ),
+    )
+    composio_mcp_url_ttl_seconds: int = Field(
+        default=3600,
+        gt=0,
+        description=(
+            "How long per-user Composio tools are cached in-process before "
+            "re-fetching via the provider's ``composio.create(user_id=...)`` + "
+            "``session.tools()``. The Composio call is a network round-trip "
+            "and the per-user toolset rarely changes mid-session, so caching "
+            "covers the common case. Default: 1h."
+        ),
+    )
+    composio_connect_link_inline: bool = Field(
+        default=True,
+        description=(
+            "When True, Composio 'needs auth' responses render as an inline Ripple button "
+            "instead of a raw URL in the chat. Set False to disable if detection is brittle."
+        ),
+    )
+
+    @field_validator("composio_toolkits", mode="before")
+    @classmethod
+    def _parse_composio_toolkits_csv(cls, v: object) -> object:
+        """Accept comma-separated env values (e.g. 'gmail, slack ,github').
+
+        pydantic-settings normally requires JSON for list fields; this
+        before-validator lets ops set the allow-list as plain CSV in
+        ``POCKETPAW_COMPOSIO_TOOLKITS`` without quoting brackets.
+        """
+        if isinstance(v, str):
+            return [item.strip() for item in v.split(",") if item.strip()]
+        return v
+
+    @model_validator(mode="after")
+    def _validate_composio_invariants(self) -> Settings:
+        """Enforce composio_api_key → composio_enterprise_id required.
+
+        Without the enterprise_id namespace, two PocketPaw deployments
+        sharing one Composio org would collide on user_id space. Fail at
+        startup rather than at first tool call.
+        """
+        if self.composio_api_key and not self.composio_enterprise_id:
+            raise ValueError(
+                "composio_enterprise_id is required when composio_api_key is set "
+                "(POCKETPAW_COMPOSIO_ENTERPRISE_ID). Prevents user_id collisions "
+                "across enterprise deployments sharing one Composio org."
+            )
+        return self
 
     @model_validator(mode="after")
     def _migrate_kb_scope(self) -> Settings:

--- a/src/pocketpaw/extensions.py
+++ b/src/pocketpaw/extensions.py
@@ -199,3 +199,20 @@ class PocketWriter(Protocol):
         """Create the pocket + linked session. Returns the new pocket id,
         or ``None`` on failure."""
         ...
+
+
+@runtime_checkable
+class ComposioToolProvider(Protocol):
+    """Entry-point group: ``pocketpaw.composio_tools``
+
+    Fetches Composio integration tools for an agent backend. Composio
+    wires 200+ pre-built OAuth integrations (Gmail, Slack, GitHub,
+    Calendar, Drive, …); the cloud product fetches them per-stream and
+    returns them in the tool format native to *backend*. An OSS install
+    registers no provider, so agents run with only their built-in tools.
+    """
+
+    def build_tools(self, backend: str, settings: Any) -> list[Any]:
+        """Composio tool instances for *backend*, or ``[]`` when Composio
+        is not configured / not applicable."""
+        ...

--- a/tests/cloud/composio/smoke_wiring.py
+++ b/tests/cloud/composio/smoke_wiring.py
@@ -1,0 +1,118 @@
+"""Per-backend Composio provider smoke — not a pytest test.
+
+Run directly:  uv run python tests/cloud/composio/smoke_wiring.py
+
+Verifies the documented integration shape against the REAL Composio
+SDKs (no API call yet — composio.create() is the only network-touching
+call and we patch _build_session_and_tools so this script stays offline-safe):
+
+  1. Settings validate a Composio-enabled config.
+  2. All four provider packages import cleanly.
+  3. pocketpaw_ee.cloud.composio.providers.build_tools_for_backend() dispatches to
+     the right provider for each backend kind.
+  4. Real composio.Composio + each provider class construct without error.
+
+For a TRUE end-to-end test (which hits the Composio API), set
+POCKETPAW_COMPOSIO_API_KEY in the env and uncomment the live-call block
+at the bottom.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("POCKETPAW_COMPOSIO_API_KEY", "ck_smoke_dev_key")
+os.environ.setdefault("POCKETPAW_COMPOSIO_ENTERPRISE_ID", "ent_smoke")
+
+
+def _ok(msg: str) -> None:
+    print(f"  [OK] {msg}")
+
+
+def _fail(msg: str) -> None:
+    print(f"  [FAIL] {msg}")
+    sys.exit(1)
+
+
+def main() -> None:
+    print("== composio per-backend wiring smoke ==")
+
+    from pocketpaw.config import Settings
+
+    s = Settings(_env_file=None)
+    assert s.composio_enterprise_id == "ent_smoke"
+    _ok("Settings parsed api_key + enterprise_id")
+
+    from pocketpaw_ee.cloud.composio import providers as composio_providers
+    from pocketpaw_ee.cloud.composio import service as composio_service
+
+    assert composio_service.is_enabled(s) is True
+    _ok("composio_service.is_enabled(s) == True")
+
+    # All four provider packages import cleanly.
+    from composio import Composio  # noqa: F401
+    from composio_claude_agent_sdk import ClaudeAgentSDKProvider  # noqa: F401
+    from composio_google_adk import GoogleAdkProvider  # noqa: F401
+    from composio_langgraph import LanggraphProvider  # noqa: F401
+    from composio_openai_agents import OpenAIAgentsProvider  # noqa: F401
+
+    _ok("all four composio_* provider packages import cleanly")
+
+    # Stub _resolve_ctx + _build_session_and_tools so the dispatcher can run
+    # without making network calls.
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    composio_providers._resolve_ctx = lambda: RequestContext(  # type: ignore[assignment]
+        user_id="alice",
+        workspace_id="ws_smoke",
+        request_id="smoke",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+    called: list[tuple[str, str]] = []
+
+    def _fake_build(backend_kind: str, namespaced_user_id: str, settings: object) -> list[object]:
+        called.append((backend_kind, namespaced_user_id))
+        return [f"fake-tool-for-{backend_kind}"]
+
+    composio_providers._build_session_and_tools = _fake_build  # type: ignore[assignment]
+    composio_providers.reset_cache_for_tests()
+
+    # All four backends should dispatch successfully and namespace the user.
+    for backend in [
+        composio_providers.BACKEND_CLAUDE_SDK,
+        composio_providers.BACKEND_OPENAI_AGENTS,
+        composio_providers.BACKEND_GOOGLE_ADK,
+        composio_providers.BACKEND_DEEP_AGENTS,
+    ]:
+        tools = composio_providers.build_tools_for_backend(backend)
+        if not tools:
+            _fail(f"{backend}: build returned empty")
+    assert all(uid == "ent_smoke:alice" for _, uid in called)
+    _ok(f"build_tools_for_backend dispatched cleanly for {len(called)} backends")
+    _ok("namespaced user_id 'ent_smoke:alice' threaded through every call")
+
+    # Confirm the real ``_provider_class_for`` lookup works for each backend.
+    composio_providers._build_session_and_tools = (  # type: ignore[assignment]
+        _real_build_session_and_tools_safe
+    )
+
+    for backend in composio_providers.SUPPORTED_BACKENDS:
+        composio_cls, provider_cls = composio_providers._provider_class_for(backend)
+        provider_instance = provider_cls()
+        _ok(f"{backend}: resolved provider {provider_instance.__class__.__name__}")
+
+    print("\nAll wiring smoke checks passed.")
+
+
+def _real_build_session_and_tools_safe(*args, **kwargs):  # type: ignore[no-untyped-def]
+    """Sentinel — only called if we accidentally let the live path run."""
+    raise RuntimeError("smoke: live SDK call attempted (would hit Composio API)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cloud/composio/test_config.py
+++ b/tests/cloud/composio/test_config.py
@@ -1,0 +1,50 @@
+"""Composio config wiring — env-var parsing and required-fields validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.config import Settings
+
+
+def test_composio_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POCKETPAW_COMPOSIO_API_KEY", raising=False)
+    monkeypatch.delenv("POCKETPAW_COMPOSIO_ENTERPRISE_ID", raising=False)
+    monkeypatch.delenv("POCKETPAW_COMPOSIO_TOOLKITS", raising=False)
+    s = Settings(_env_file=None)
+    assert s.composio_api_key is None
+    assert s.composio_enterprise_id is None
+    assert s.composio_toolkits == []
+    assert s.composio_base_url is None
+    assert s.composio_connect_link_inline is True
+
+
+def test_composio_enabled_requires_enterprise_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_API_KEY", "ck_xxx")
+    monkeypatch.delenv("POCKETPAW_COMPOSIO_ENTERPRISE_ID", raising=False)
+    with pytest.raises(ValueError, match="composio_enterprise_id"):
+        Settings(_env_file=None)
+
+
+def test_composio_toolkits_csv_parsed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_API_KEY", "ck_xxx")
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_ENTERPRISE_ID", "ent_acme")
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_TOOLKITS", "gmail, slack ,github")
+    s = Settings(_env_file=None)
+    assert s.composio_toolkits == ["gmail", "slack", "github"]
+
+
+def test_composio_toolkits_blank_entries_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_API_KEY", "ck_xxx")
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_ENTERPRISE_ID", "ent_acme")
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_TOOLKITS", " , gmail, ,")
+    s = Settings(_env_file=None)
+    assert s.composio_toolkits == ["gmail"]
+
+
+def test_composio_base_url_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_API_KEY", "ck_xxx")
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_ENTERPRISE_ID", "ent_acme")
+    monkeypatch.setenv("POCKETPAW_COMPOSIO_BASE_URL", "https://composio.internal.example")
+    s = Settings(_env_file=None)
+    assert s.composio_base_url == "https://composio.internal.example"

--- a/tests/cloud/composio/test_connect_link.py
+++ b/tests/cloud/composio/test_connect_link.py
@@ -1,0 +1,216 @@
+"""Composio Connect Link tests — inline Ripple shape + auth-error detection."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from pocketpaw_ee.cloud.composio import connect_link
+from pocketpaw_ee.cloud.composio.connect_link import (
+    as_inline_ripple,
+    detect_connect_link,
+    maybe_emit_connect_link,
+)
+from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec
+
+from pocketpaw.config import Settings
+
+# ---------------------------------------------------------------------------
+# as_inline_ripple — spec shape
+# ---------------------------------------------------------------------------
+
+
+def test_as_inline_ripple_has_canonical_envelope() -> None:
+    spec = as_inline_ripple("https://composio.dev/auth/abc", "gmail")
+    assert spec["version"] == "1.0"
+    assert spec["ui"]["type"] == "flex"
+    assert "children" in spec["ui"]
+
+
+def test_as_inline_ripple_button_targets_blank_tab() -> None:
+    spec = as_inline_ripple("https://composio.dev/auth/abc", "gmail")
+    buttons = [c for c in spec["ui"]["children"] if c["type"] == "button"]
+    assert len(buttons) == 1
+    actions = buttons[0]["actions"]
+    assert actions[0]["type"] == "open_url"
+    assert actions[0]["url"] == "https://composio.dev/auth/abc"
+    assert actions[0]["target"] == "_blank"
+
+
+def test_as_inline_ripple_default_label_includes_toolkit() -> None:
+    spec = as_inline_ripple("https://composio.dev/auth/abc", "slack")
+    buttons = [c for c in spec["ui"]["children"] if c["type"] == "button"]
+    assert buttons[0]["props"]["label"] == "Connect Slack"
+
+
+def test_as_inline_ripple_respects_custom_label() -> None:
+    spec = as_inline_ripple(
+        "https://composio.dev/auth/abc", "slack", action_label="Authorize Slack workspace"
+    )
+    buttons = [c for c in spec["ui"]["children"] if c["type"] == "button"]
+    assert buttons[0]["props"]["label"] == "Authorize Slack workspace"
+
+
+def test_as_inline_ripple_passes_ripple_normalizer() -> None:
+    """The normalizer accepts ``{version, ui}`` shape without dropping
+    our button + actions. This is the guarantee the chat layer relies on."""
+    spec = as_inline_ripple("https://composio.dev/auth/abc", "gmail")
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+    assert normalized.get("version") == "1.0"
+    assert isinstance(normalized.get("ui"), dict)
+    # Button + open_url action should survive normalization.
+    children = normalized["ui"].get("children", [])
+    buttons = [c for c in children if isinstance(c, dict) and c.get("type") == "button"]
+    assert buttons
+    assert buttons[0]["actions"][0]["type"] == "open_url"
+
+
+def test_as_inline_ripple_rejects_empty_url() -> None:
+    with pytest.raises(ValueError, match="url"):
+        as_inline_ripple("", "gmail")
+
+
+def test_as_inline_ripple_rejects_empty_toolkit() -> None:
+    with pytest.raises(ValueError, match="toolkit"):
+        as_inline_ripple("https://x", "")
+
+
+# ---------------------------------------------------------------------------
+# detect_connect_link — heuristic auth-response detection
+# ---------------------------------------------------------------------------
+
+
+def test_detect_explicit_connect_url_key() -> None:
+    payload = {
+        "ok": False,
+        "connect_url": "https://composio.dev/auth/abc",
+        "toolkit": "gmail",
+    }
+    result = detect_connect_link(payload)
+    assert result == ("https://composio.dev/auth/abc", "gmail")
+
+
+def test_detect_nested_connection_block() -> None:
+    payload = {
+        "ok": False,
+        "needs_connection": True,
+        "connection": {"auth_url": "https://composio.dev/auth/xyz"},
+        "app": "slack",
+    }
+    result = detect_connect_link(payload)
+    assert result is not None
+    url, toolkit = result
+    assert url == "https://composio.dev/auth/xyz"
+    assert toolkit == "slack"
+
+
+def test_detect_returns_none_for_random_url_without_auth_flag() -> None:
+    """A URL elsewhere in the payload must NOT trigger detection — too
+    much false-positive risk. Only auth-named keys or explicit flags count."""
+    payload = {"ok": True, "data": [{"id": "1", "url": "https://example.com/article"}]}
+    assert detect_connect_link(payload) is None
+
+
+def test_detect_returns_none_for_non_dict() -> None:
+    assert detect_connect_link("a string") is None
+    assert detect_connect_link(None) is None
+    assert detect_connect_link(["list"]) is None
+
+
+def test_detect_returns_none_when_url_missing() -> None:
+    payload = {"needs_connection": True, "toolkit": "gmail"}
+    assert detect_connect_link(payload) is None
+
+
+def test_detect_truthy_string_flag() -> None:
+    payload = {
+        "requires_auth": "true",
+        "authorization_url": "https://composio.dev/auth/abc",
+    }
+    result = detect_connect_link(payload)
+    assert result is not None
+    assert result[0] == "https://composio.dev/auth/abc"
+
+
+# ---------------------------------------------------------------------------
+# maybe_emit_connect_link — SSE push + feature flag
+# ---------------------------------------------------------------------------
+
+
+def _enabled_settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "composio_api_key": "ck_test",
+        "composio_enterprise_id": "ent_acme",
+    }
+    base.update(overrides)
+    return Settings(_env_file=None, **base)  # type: ignore[arg-type]
+
+
+def test_emit_skipped_when_feature_flag_disabled() -> None:
+    s = _enabled_settings(composio_connect_link_inline=False)
+    payload = {"connect_url": "https://x", "toolkit": "gmail"}
+    with patch("pocketpaw_ee.cloud.chat.agent_service.push_sse_event") as push:
+        emitted = maybe_emit_connect_link(payload, s)
+    assert emitted is False
+    push.assert_not_called()
+
+
+def test_emit_skipped_when_no_connect_link_detected() -> None:
+    s = _enabled_settings()
+    with patch("pocketpaw_ee.cloud.chat.agent_service.push_sse_event") as push:
+        emitted = maybe_emit_connect_link({"ok": True, "data": []}, s)
+    assert emitted is False
+    push.assert_not_called()
+
+
+def test_emit_pushes_ripple_inline_event() -> None:
+    s = _enabled_settings()
+    payload = {
+        "ok": False,
+        "needs_connection": True,
+        "connect_url": "https://composio.dev/auth/abc",
+        "toolkit": "gmail",
+    }
+    with patch("pocketpaw_ee.cloud.chat.agent_service.push_sse_event") as push:
+        emitted = maybe_emit_connect_link(payload, s)
+    assert emitted is True
+    push.assert_called_once()
+    event_name, data = push.call_args[0]
+    assert event_name == "ripple_inline"
+    assert data["source"] == "composio"
+    assert data["toolkit"] == "gmail"
+    assert data["spec"]["version"] == "1.0"
+    # And the embedded spec is the same one as_inline_ripple would build.
+    actions = data["spec"]["ui"]["children"][-1]["actions"]
+    assert actions[0]["url"] == "https://composio.dev/auth/abc"
+
+
+def test_emit_uses_fallback_toolkit_label_when_unknown() -> None:
+    s = _enabled_settings()
+    payload = {
+        "needs_connection": True,
+        "connect_url": "https://composio.dev/auth/abc",
+        # no toolkit / app field — emitter substitutes a generic label
+    }
+    with patch("pocketpaw_ee.cloud.chat.agent_service.push_sse_event") as push:
+        emitted = maybe_emit_connect_link(payload, s)
+    assert emitted is True
+    _name, data = push.call_args[0]
+    assert data["toolkit"] == "this integration"
+
+
+# Note on architecture: in v2 of the wiring, Composio talks to the
+# parent agent via its own hosted MCP server (see
+# ``ee/pocketpaw_ee/cloud/composio/mcp.py``). Connect Link responses arrive at the
+# agent as MCP tool results, not through our in-process handler — so
+# there's no integration test here for an ``_execute_handler``.
+# ``as_inline_ripple`` + ``detect_connect_link`` remain as utility
+# functions for any downstream consumer (e.g. an agent-router hook
+# that intercepts MCP tool results to render inline UI).
+
+
+# Keep import alive even though only referenced indirectly via patches.
+_ = connect_link
+_ = asyncio

--- a/tests/cloud/composio/test_identity.py
+++ b/tests/cloud/composio/test_identity.py
@@ -1,0 +1,306 @@
+"""Composio identity-verification tests (Task 4a).
+
+Two layers:
+    * ``probe_identity_sync`` unit tests — registry lookup, envelope
+      extraction, field-path walking. Pure functions; no DB needed.
+    * ``record_connection`` / ``confirm_identity_change`` integration
+      tests — exercise the tripwire against an in-memory mongomock DB
+      via the shared ``mongo_db`` fixture. Asserts on the recording
+      bus to verify event emission.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.realtime.events import (
+    ComposioConnectionMismatch,
+    ComposioConnectionVerified,
+)
+from pocketpaw_ee.cloud.composio import identity
+from pocketpaw_ee.cloud.composio import service as composio_service
+from pocketpaw_ee.cloud.composio.service import ConnectionRecord
+
+
+def _ctx(*, user: str = "alice", workspace: str = "ws_acme") -> RequestContext:
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="r1",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# probe_identity_sync — pure-function layer
+# ---------------------------------------------------------------------------
+
+
+def test_probe_returns_none_for_unknown_toolkit() -> None:
+    """A toolkit with no entry in IDENTITY_PROBES short-circuits to None
+    without calling the client. Caller treats this as 'verification
+    unavailable' rather than blocking."""
+    client = MagicMock()
+    result = identity.probe_identity_sync(client, user_id="u", toolkit="madeupkit")
+    assert result is None
+    client.tools.execute.assert_not_called()
+
+
+def test_probe_returns_value_from_flat_dict_envelope() -> None:
+    """``tools.execute`` returns ``{"data": {"login": "x"}, "successful": True}``."""
+    client = MagicMock()
+    client.tools.execute.return_value = {
+        "data": {"login": "octocat"},
+        "successful": True,
+    }
+    out = identity.probe_identity_sync(client, user_id="u", toolkit="github")
+    assert out == "octocat"
+
+
+def test_probe_walks_nested_field_path() -> None:
+    """``googledrive``'s probe uses dot-path ``user.emailAddress``."""
+    client = MagicMock()
+    client.tools.execute.return_value = {
+        "data": {"user": {"emailAddress": "me@example.com", "displayName": "Me"}},
+    }
+    out = identity.probe_identity_sync(client, user_id="u", toolkit="googledrive")
+    assert out == "me@example.com"
+
+
+def test_probe_returns_none_on_client_exception() -> None:
+    """A 5xx from Composio must degrade to None, not raise. The
+    chat-side wrapper then surfaces 'verification unavailable'."""
+    client = MagicMock()
+    client.tools.execute.side_effect = RuntimeError("upstream 503")
+    out = identity.probe_identity_sync(client, user_id="u", toolkit="github")
+    assert out is None
+
+
+def test_probe_returns_none_when_field_path_missing() -> None:
+    """Response shape doesn't match the registered field_path → None."""
+    client = MagicMock()
+    client.tools.execute.return_value = {"data": {"unexpected": "shape"}}
+    out = identity.probe_identity_sync(client, user_id="u", toolkit="github")
+    assert out is None
+
+
+def test_probe_extracts_from_pydantic_like_envelope() -> None:
+    """SDK occasionally returns pydantic models — extract via attrs/model_dump."""
+
+    class FakeResponse:
+        data = {"login": "octocat"}
+
+    client = MagicMock()
+    client.tools.execute.return_value = FakeResponse()
+    out = identity.probe_identity_sync(client, user_id="u", toolkit="github")
+    assert out == "octocat"
+
+
+def test_probe_normalizes_toolkit_case() -> None:
+    """Toolkit slug lookup is case-insensitive."""
+    client = MagicMock()
+    client.tools.execute.return_value = {"data": {"login": "x"}}
+    assert identity.probe_identity_sync(client, user_id="u", toolkit="GitHub") == "x"
+    assert identity.probe_identity_sync(client, user_id="u", toolkit="GITHUB") == "x"
+
+
+# ---------------------------------------------------------------------------
+# record_connection — DB + tripwire integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_connection_first_time_inserts_and_emits_verified(
+    mongo_db: Any, recording_bus: Any
+) -> None:
+    """First call inserts the doc with the external_identity and
+    emits ``ComposioConnectionVerified`` (with first_time=True)."""
+    rec = await composio_service.record_connection(
+        _ctx(),
+        toolkit="github",
+        external_identity="octocat",
+    )
+    assert isinstance(rec, ConnectionRecord)
+    assert rec.status == "verified"
+    assert rec.external_identity == "octocat"
+    assert rec.previous_identity is None
+
+    from pocketpaw_ee.cloud.models.composio_connection import ComposioConnection
+
+    docs = await ComposioConnection.find().to_list()
+    assert len(docs) == 1
+    assert docs[0].external_identity == "octocat"
+    assert docs[0].mismatch_count == 0
+
+    events = [e for e in recording_bus.events if isinstance(e, ComposioConnectionVerified)]
+    assert len(events) == 1
+    assert events[0].data["first_time"] is True
+    assert events[0].data["toolkit"] == "github"
+
+
+@pytest.mark.asyncio
+async def test_record_connection_match_reverifies_quietly(
+    mongo_db: Any, recording_bus: Any
+) -> None:
+    """Re-probing with the same identity bumps last_verified_at and
+    emits verified-not-first-time, no mismatch."""
+    ctx = _ctx()
+    await composio_service.record_connection(ctx, toolkit="github", external_identity="octocat")
+    recording_bus.events.clear()
+
+    rec = await composio_service.record_connection(
+        ctx, toolkit="github", external_identity="octocat"
+    )
+    assert rec.status == "verified"
+    assert rec.previous_identity is None  # matched, no diff to surface
+
+    mismatch_events = [e for e in recording_bus.events if isinstance(e, ComposioConnectionMismatch)]
+    assert mismatch_events == []
+    verified = [e for e in recording_bus.events if isinstance(e, ComposioConnectionVerified)]
+    assert len(verified) == 1
+    assert verified[0].data["first_time"] is False
+
+
+@pytest.mark.asyncio
+async def test_record_connection_mismatch_does_not_overwrite(
+    mongo_db: Any, recording_bus: Any
+) -> None:
+    """Tripwire: probe returns a different identity. The stored
+    external_identity is NOT overwritten — the user must confirm
+    via confirm_identity_change."""
+    ctx = _ctx()
+    await composio_service.record_connection(ctx, toolkit="github", external_identity="octocat")
+    recording_bus.events.clear()
+
+    rec = await composio_service.record_connection(
+        ctx, toolkit="github", external_identity="octocat-alt"
+    )
+    assert rec.status == "mismatch"
+    assert rec.external_identity == "octocat-alt"  # what was probed
+    assert rec.previous_identity == "octocat"  # what was stored
+
+    from pocketpaw_ee.cloud.models.composio_connection import ComposioConnection
+
+    doc = await ComposioConnection.find_one(
+        ComposioConnection.workspace == ctx.workspace_id,
+        ComposioConnection.paw_user_id == ctx.user_id,
+        ComposioConnection.toolkit == "github",
+    )
+    assert doc is not None
+    assert doc.external_identity == "octocat"  # NOT overwritten
+    assert doc.mismatch_count == 1
+    assert doc.last_mismatch_identity == "octocat-alt"
+
+    mm = [e for e in recording_bus.events if isinstance(e, ComposioConnectionMismatch)]
+    assert len(mm) == 1
+    assert mm[0].data["stored_identity"] == "octocat"
+    assert mm[0].data["probed_identity"] == "octocat-alt"
+
+
+@pytest.mark.asyncio
+async def test_record_connection_none_identity_is_unverified(
+    mongo_db: Any, recording_bus: Any
+) -> None:
+    """``external_identity=None`` (probe failed / no registry entry)
+    inserts an unverified record on first call; subsequent calls
+    leave the stored identity intact and bump last_verified_at."""
+    ctx = _ctx()
+    rec = await composio_service.record_connection(ctx, toolkit="exotic", external_identity=None)
+    assert rec.status == "unverified"
+    assert rec.external_identity is None
+
+    # Now store a real identity, then probe again with None — the
+    # stored identity must survive.
+    await composio_service.record_connection(ctx, toolkit="github", external_identity="x")
+    rec2 = await composio_service.record_connection(ctx, toolkit="github", external_identity=None)
+    assert rec2.status == "unverified"
+    assert rec2.external_identity == "x"  # echoes the stored value
+
+
+@pytest.mark.asyncio
+async def test_record_connection_partitions_by_workspace_and_user(
+    mongo_db: Any, recording_bus: Any
+) -> None:
+    """Two users in different workspaces can each have their own
+    connected GitHub without collision. The (workspace, user, toolkit)
+    tuple is the natural unique key."""
+    await composio_service.record_connection(
+        _ctx(user="alice", workspace="ws_a"),
+        toolkit="github",
+        external_identity="alice-gh",
+    )
+    await composio_service.record_connection(
+        _ctx(user="bob", workspace="ws_a"),
+        toolkit="github",
+        external_identity="bob-gh",
+    )
+    await composio_service.record_connection(
+        _ctx(user="alice", workspace="ws_b"),
+        toolkit="github",
+        external_identity="alice-gh-altworkspace",
+    )
+
+    from pocketpaw_ee.cloud.models.composio_connection import ComposioConnection
+
+    docs = await ComposioConnection.find().to_list()
+    assert len(docs) == 3
+    by_key = {(d.workspace, d.paw_user_id): d.external_identity for d in docs}
+    assert by_key[("ws_a", "alice")] == "alice-gh"
+    assert by_key[("ws_a", "bob")] == "bob-gh"
+    assert by_key[("ws_b", "alice")] == "alice-gh-altworkspace"
+
+
+@pytest.mark.asyncio
+async def test_confirm_identity_change_overwrites_and_clears_mismatch(
+    mongo_db: Any, recording_bus: Any
+) -> None:
+    """After a mismatch, calling confirm_identity_change with the
+    new identity overwrites the stored value and clears the mismatch
+    flags so subsequent probes re-verify cleanly."""
+    ctx = _ctx()
+    await composio_service.record_connection(ctx, toolkit="github", external_identity="octocat")
+    await composio_service.record_connection(ctx, toolkit="github", external_identity="octocat-alt")
+    recording_bus.events.clear()
+
+    confirmed = await composio_service.confirm_identity_change(
+        ctx, toolkit="github", external_identity="octocat-alt"
+    )
+    assert confirmed.status == "verified"
+    assert confirmed.previous_identity == "octocat"
+
+    from pocketpaw_ee.cloud.models.composio_connection import ComposioConnection
+
+    doc = await ComposioConnection.find_one(
+        ComposioConnection.workspace == ctx.workspace_id,
+        ComposioConnection.paw_user_id == ctx.user_id,
+        ComposioConnection.toolkit == "github",
+    )
+    assert doc is not None
+    assert doc.external_identity == "octocat-alt"  # overwritten
+    assert doc.last_mismatch_identity is None
+    assert doc.last_mismatch_at is None
+
+    # Re-probing now treats octocat-alt as the canonical identity.
+    recording_bus.events.clear()
+    rec = await composio_service.record_connection(
+        ctx, toolkit="github", external_identity="octocat-alt"
+    )
+    assert rec.status == "verified"
+    mm = [e for e in recording_bus.events if isinstance(e, ComposioConnectionMismatch)]
+    assert mm == []
+
+
+@pytest.mark.asyncio
+async def test_confirm_identity_change_raises_without_prior_record(mongo_db: Any) -> None:
+    """Can't confirm a change for a connection we've never seen."""
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+
+    with pytest.raises(ValidationError):
+        await composio_service.confirm_identity_change(
+            _ctx(), toolkit="github", external_identity="x"
+        )

--- a/tests/cloud/composio/test_providers.py
+++ b/tests/cloud/composio/test_providers.py
@@ -1,0 +1,498 @@
+"""Composio per-backend provider tests — the documented integration shape.
+
+``build_tools_for_backend(backend_kind)`` is the single entry point every
+agent backend calls. It resolves the active user from per-stream
+contextvars, builds a Composio session via the documented provider for
+that backend, returns ``session.tools()``. Caching, fail-soft on errors,
+and namespace correctness are all tested here.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.composio import providers as composio_providers
+from pocketpaw_ee.cloud.composio import service as composio_service
+
+from pocketpaw.config import Settings
+
+
+def _enabled_settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "composio_api_key": "ck_test",
+        "composio_enterprise_id": "ent_acme",
+        # Non-empty toolkit list — the direct-tools path requires this.
+        # Tests that want the empty case override explicitly.
+        "composio_toolkits": ["gmail", "slack"],
+    }
+    base.update(overrides)
+    return Settings(_env_file=None, **base)  # type: ignore[arg-type]
+
+
+def _fake_ctx() -> RequestContext:
+    return RequestContext(
+        user_id="alice",
+        workspace_id="ws_acme",
+        request_id="r1",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _named_tool(name: str) -> MagicMock:
+    """Build a MagicMock whose ``.name`` attribute is the given string.
+
+    MagicMock auto-creates ``.name`` as a Mock by default — the dedup
+    loop in providers.py reads it via ``getattr(t, "name", None)`` so
+    we need a real string there for the seen-names set to work.
+    """
+    t = MagicMock()
+    t.name = name
+    return t
+
+
+def _tool_name(t: object) -> str | None:
+    """Mirror providers.py's name-extraction: getattr first, dict fallback."""
+    name = getattr(t, "name", None)
+    if isinstance(name, str):
+        return name
+    if isinstance(t, dict):
+        return t.get("name")  # type: ignore[no-any-return]
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    composio_service.reset_client_cache_for_tests()
+    composio_providers.reset_cache_for_tests()
+    yield
+    composio_service.reset_client_cache_for_tests()
+    composio_providers.reset_cache_for_tests()
+
+
+@pytest.fixture
+def force_settings(monkeypatch: pytest.MonkeyPatch):  # type: ignore[no-untyped-def]
+    """Make ``Settings.load()`` return a controlled instance."""
+
+    def _factory(settings: Settings) -> Settings:
+        monkeypatch.setattr(Settings, "load", classmethod(lambda cls: settings))
+        return settings
+
+    return _factory
+
+
+@pytest.fixture
+def stub_provider_modules(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
+    """Install fake ``composio`` + per-backend provider modules so
+    ``providers._provider_class_for`` works without the real SDKs."""
+    captured: dict[str, MagicMock] = {}
+
+    composio_cls = MagicMock(name="Composio")
+
+    def _composio_factory(*args: object, **kwargs: object) -> MagicMock:
+        instance = MagicMock(name="ComposioClient")
+        captured["last_init_kwargs"] = kwargs  # type: ignore[assignment]
+
+        # providers.py calls ``client.tools.get(...)`` in two shapes:
+        #   (a) per-toolkit direct tools: ``toolkits=[slug], limit=N``
+        #   (b) meta-tools by name:       ``tools=[slug1, slug2, ...]``
+        # We dispatch on which kwarg is present and return MagicMock
+        # objects with a ``name`` attribute the dedup loop in providers.py
+        # reads via ``getattr(t, "name", None)``.
+        def _fake_tools_get(
+            user_id: str,
+            toolkits: list[str] | None = None,
+            tools: list[str] | None = None,
+            limit: int | None = None,
+        ) -> list[object]:
+            if tools is not None:
+                captured["last_meta_get"] = {  # type: ignore[assignment]
+                    "user_id": user_id,
+                    "tools": list(tools),
+                }
+                return [_named_tool(slug) for slug in tools]
+            captured["last_tools_get"] = {  # type: ignore[assignment]
+                "user_id": user_id,
+                "toolkits": list(toolkits or []),
+                "limit": limit,
+            }
+            return [_named_tool(f"tool({tk})") for tk in (toolkits or [])]
+
+        instance.tools.get.side_effect = _fake_tools_get
+        return instance
+
+    composio_cls.side_effect = _composio_factory
+    fake_composio = types.ModuleType("composio")
+    fake_composio.Composio = composio_cls  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "composio", fake_composio)
+
+    for mod_name, cls_name in [
+        ("composio_claude_agent_sdk", "ClaudeAgentSDKProvider"),
+        ("composio_openai_agents", "OpenAIAgentsProvider"),
+        ("composio_google_adk", "GoogleAdkProvider"),
+        ("composio_langgraph", "LanggraphProvider"),
+    ]:
+        fake_mod = types.ModuleType(mod_name)
+        provider_cls = MagicMock(name=cls_name)
+        setattr(fake_mod, cls_name, provider_cls)
+        monkeypatch.setitem(sys.modules, mod_name, fake_mod)
+        captured[cls_name] = provider_cls
+
+    captured["Composio"] = composio_cls
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Backend mapping
+# ---------------------------------------------------------------------------
+
+
+def test_supported_backends_match_provider_table() -> None:
+    """The advertised SUPPORTED_BACKENDS set must match the lookup table.
+
+    A backend in SUPPORTED_BACKENDS but missing from the mapping would
+    blow up at runtime; a backend in the mapping but absent from the
+    set would be silently unreachable.
+    """
+    for kind in composio_providers.SUPPORTED_BACKENDS:
+        # Should not raise — each supported kind has a mapping.
+        # We can't actually import the SDKs in the unit test, so just
+        # verify the dispatcher doesn't choke on the lookup branches.
+        # The full import happens in the per-backend tests below.
+        assert kind in {
+            composio_providers.BACKEND_CLAUDE_SDK,
+            composio_providers.BACKEND_OPENAI_AGENTS,
+            composio_providers.BACKEND_GOOGLE_ADK,
+            composio_providers.BACKEND_DEEP_AGENTS,
+        }
+
+
+def test_unknown_backend_returns_empty(
+    stub_provider_modules: dict[str, MagicMock],
+    force_settings,
+    monkeypatch: pytest.MonkeyPatch,  # type: ignore[no-untyped-def]
+) -> None:
+    force_settings(_enabled_settings())
+    monkeypatch.setattr(composio_providers, "_resolve_ctx", lambda: _fake_ctx())
+    result = composio_providers.build_tools_for_backend("opencode")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed
+# ---------------------------------------------------------------------------
+
+
+def test_returns_empty_when_disabled(monkeypatch: pytest.MonkeyPatch, force_settings) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("POCKETPAW_COMPOSIO_API_KEY", raising=False)
+    monkeypatch.delenv("POCKETPAW_COMPOSIO_ENTERPRISE_ID", raising=False)
+    force_settings(Settings(_env_file=None))
+    assert composio_providers.build_tools_for_backend("claude_agent_sdk") == []
+
+
+def test_returns_empty_when_no_stream_context(
+    stub_provider_modules: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+    force_settings,  # type: ignore[no-untyped-def]
+) -> None:
+    """No user_id contextvar → no tools (CLI runs, KB rebuilds, etc.)."""
+    force_settings(_enabled_settings())
+    monkeypatch.setattr(composio_providers, "_resolve_ctx", lambda: None)
+    assert composio_providers.build_tools_for_backend("claude_agent_sdk") == []
+
+
+def test_returns_empty_when_session_build_raises(
+    stub_provider_modules: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+    force_settings,  # type: ignore[no-untyped-def]
+) -> None:
+    """Composio outage / 5xx must not 500 the chat run."""
+    force_settings(_enabled_settings())
+    monkeypatch.setattr(composio_providers, "_resolve_ctx", lambda: _fake_ctx())
+
+    def _boom(backend_kind: str, namespaced_user_id: str, settings: Settings) -> list[object]:
+        raise RuntimeError("upstream 503")
+
+    monkeypatch.setattr(composio_providers, "_build_session_and_tools", _boom)
+    assert composio_providers.build_tools_for_backend("claude_agent_sdk") == []
+
+
+# ---------------------------------------------------------------------------
+# Per-backend dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "backend_kind, provider_class_name",
+    [
+        ("claude_agent_sdk", "ClaudeAgentSDKProvider"),
+        ("openai_agents", "OpenAIAgentsProvider"),
+        ("google_adk", "GoogleAdkProvider"),
+        ("deep_agents", "LanggraphProvider"),
+    ],
+)
+def test_dispatches_to_correct_provider(
+    backend_kind: str,
+    provider_class_name: str,
+    stub_provider_modules: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+    force_settings,  # type: ignore[no-untyped-def]
+) -> None:
+    """Each backend kind must instantiate its own provider class."""
+    force_settings(_enabled_settings())
+    monkeypatch.setattr(composio_providers, "_resolve_ctx", lambda: _fake_ctx())
+
+    tools = composio_providers.build_tools_for_backend(backend_kind)
+    assert tools  # non-empty
+    # The expected provider class was instantiated:
+    stub_provider_modules[provider_class_name].assert_called_once()
+
+
+def test_namespaces_user_id(
+    stub_provider_modules: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+    force_settings,  # type: ignore[no-untyped-def]
+) -> None:
+    """composio.create is called with f'{enterprise_id}:{user_id}'."""
+    force_settings(_enabled_settings())
+    monkeypatch.setattr(composio_providers, "_resolve_ctx", lambda: _fake_ctx())
+    composio_providers.build_tools_for_backend("claude_agent_sdk")
+
+    # The cache key is (namespaced_user_id, backend_kind). If the user
+    # had been passed raw, the key would be ("alice", ...) — the fact
+    # that it's the namespaced form is the proof.
+    assert (
+        "ent_acme:alice",
+        "claude_agent_sdk",
+    ) in composio_providers._tools_cache
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+
+def test_caches_tools_within_ttl(
+    stub_provider_modules: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+    force_settings,  # type: ignore[no-untyped-def]
+) -> None:
+    force_settings(_enabled_settings(composio_mcp_url_ttl_seconds=3600))
+    monkeypatch.setattr(composio_providers, "_resolve_ctx", lambda: _fake_ctx())
+
+    call_count = [0]
+
+    def _build(backend_kind: str, namespaced_user_id: str, settings: Settings) -> list[object]:
+        call_count[0] += 1
+        return [object()]
+
+    monkeypatch.setattr(composio_providers, "_build_session_and_tools", _build)
+
+    composio_providers.build_tools_for_backend("claude_agent_sdk")
+    composio_providers.build_tools_for_backend("claude_agent_sdk")
+    composio_providers.build_tools_for_backend("claude_agent_sdk")
+    assert call_count[0] == 1  # cached after first build
+
+
+def test_remints_after_ttl_expires(
+    stub_provider_modules: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+    force_settings,  # type: ignore[no-untyped-def]
+) -> None:
+    force_settings(_enabled_settings(composio_mcp_url_ttl_seconds=1))
+    monkeypatch.setattr(composio_providers, "_resolve_ctx", lambda: _fake_ctx())
+
+    call_count = [0]
+    monkeypatch.setattr(
+        composio_providers,
+        "_build_session_and_tools",
+        lambda *a, **kw: [object()] if call_count.__setitem__(0, call_count[0] + 1) is None else [],
+    )
+    fake_time = [1000.0]
+    monkeypatch.setattr(composio_providers.time, "monotonic", lambda: fake_time[0])
+
+    composio_providers.build_tools_for_backend("claude_agent_sdk")
+    assert call_count[0] == 1
+    fake_time[0] += 0.5
+    composio_providers.build_tools_for_backend("claude_agent_sdk")
+    assert call_count[0] == 1
+    fake_time[0] += 10
+    composio_providers.build_tools_for_backend("claude_agent_sdk")
+    assert call_count[0] == 2
+
+
+def test_cache_partitioned_per_backend_and_user(
+    stub_provider_modules: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+    force_settings,  # type: ignore[no-untyped-def]
+) -> None:
+    """Two backends for the same user, or two users on the same backend,
+    must not share cache entries — that'd be a tenancy leak."""
+    force_settings(_enabled_settings())
+
+    user = [_fake_ctx()]
+    monkeypatch.setattr(composio_providers, "_resolve_ctx", lambda: user[0])
+
+    call_args: list[tuple[str, str]] = []
+
+    def _build(backend_kind: str, namespaced_user_id: str, settings: Settings) -> list[object]:
+        call_args.append((backend_kind, namespaced_user_id))
+        return [object()]
+
+    monkeypatch.setattr(composio_providers, "_build_session_and_tools", _build)
+
+    composio_providers.build_tools_for_backend("claude_agent_sdk")
+    composio_providers.build_tools_for_backend("deep_agents")  # different backend, same user
+    # Switch user
+    bob_ctx = RequestContext(
+        user_id="bob",
+        workspace_id="ws_acme",
+        request_id="r2",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+    user[0] = bob_ctx
+    composio_providers.build_tools_for_backend("claude_agent_sdk")  # different user, same backend
+
+    assert call_args == [
+        ("claude_agent_sdk", "ent_acme:alice"),
+        ("deep_agents", "ent_acme:alice"),
+        ("claude_agent_sdk", "ent_acme:bob"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Regression: pocket specialist path stays Composio-free
+# ---------------------------------------------------------------------------
+
+
+def test_pockets_prompts_has_no_composio_imports() -> None:
+    path = Path(__file__).resolve().parents[3] / "src" / "pocketpaw" / "ripple" / "_pockets.py"
+    source = path.read_text(encoding="utf-8")
+    assert "from pocketpaw_ee.cloud.composio" not in source
+    assert "build_tools_for_backend" not in source
+
+
+def test_deep_agents_skips_composio_on_pocket_session() -> None:
+    """The deep_agents backend gates Composio injection behind
+    ``not is_pocket_session`` — pocket runs are surgical and exclude
+    Composio. Static check guards against regressions."""
+    path = Path(__file__).resolve().parents[3] / "src" / "pocketpaw" / "agents" / "deep_agents.py"
+    source = path.read_text(encoding="utf-8")
+    # The injection block must live inside an ``if not is_pocket_session:`` guard.
+    assert "if not is_pocket_session:" in source
+    # And the call must go through the ``pocketpaw.composio_tools`` entry-point
+    # helper with the right backend key — the OSS core never imports the EE
+    # composio package directly.
+    assert 'composio_tools_for("deep_agents"' in source
+
+
+# ---------------------------------------------------------------------------
+# Search-fallback meta-tools (Task 3a)
+# ---------------------------------------------------------------------------
+
+
+def test_search_fallback_meta_tools_appended(
+    stub_provider_modules: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+    force_settings,  # type: ignore[no-untyped-def]
+) -> None:
+    """The 3 search-flow meta-tools must be appended to the direct tools
+    so the agent has a discovery fallback when its tool index can't
+    surface a specific action. COMPOSIO_MANAGE_CONNECTIONS must NOT be
+    included — we own the connect flow via connection_tool.py."""
+    force_settings(_enabled_settings(composio_toolkits=["gmail", "github"]))
+    monkeypatch.setattr(composio_providers, "_resolve_ctx", lambda: _fake_ctx())
+
+    tools = composio_providers.build_tools_for_backend("claude_agent_sdk")
+    names = {_tool_name(t) for t in tools}
+
+    assert "COMPOSIO_SEARCH_TOOLS" in names
+    assert "COMPOSIO_GET_TOOL_SCHEMAS" in names
+    assert "COMPOSIO_MULTI_EXECUTE_TOOL" in names
+    # Connect flow stays on our side; meta-tool form is excluded.
+    assert "COMPOSIO_MANAGE_CONNECTIONS" not in names
+    # Direct tools still present alongside meta-tools.
+    assert "tool(gmail)" in names
+    assert "tool(github)" in names
+
+
+def test_search_fallback_failure_keeps_direct_tools(
+    stub_provider_modules: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+    force_settings,  # type: ignore[no-untyped-def]
+) -> None:
+    """If the meta-tools fetch raises, direct tools must still come
+    back — losing search degrades capability, not the whole turn."""
+    force_settings(_enabled_settings(composio_toolkits=["gmail"]))
+    monkeypatch.setattr(composio_providers, "_resolve_ctx", lambda: _fake_ctx())
+
+    # Re-wire the fake client so meta-tool fetches (tools=[...]) raise
+    # but per-toolkit fetches (toolkits=[...]) still succeed.
+    composio_cls = stub_provider_modules["Composio"]
+
+    def _factory(*args: object, **kwargs: object) -> MagicMock:
+        inst = MagicMock(name="ComposioClient")
+
+        def _selective_get(
+            user_id: str,
+            toolkits: list[str] | None = None,
+            tools: list[str] | None = None,
+            limit: int | None = None,
+        ) -> list[object]:
+            if tools is not None:
+                raise RuntimeError("meta-tools 503")
+            return [_named_tool(f"tool({tk})") for tk in (toolkits or [])]
+
+        inst.tools.get.side_effect = _selective_get
+        return inst
+
+    composio_cls.side_effect = _factory
+
+    out = composio_providers.build_tools_for_backend("claude_agent_sdk")
+    names = {_tool_name(t) for t in out}
+    assert "tool(gmail)" in names  # direct tools survived
+    assert "COMPOSIO_SEARCH_TOOLS" not in names  # meta-tools absent
+
+
+def test_search_fallback_dedupes_against_direct_tools(
+    stub_provider_modules: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+    force_settings,  # type: ignore[no-untyped-def]
+) -> None:
+    """If Composio ever returned a meta-tool slug from a regular toolkit
+    fetch, we mustn't double-register it. Mirrors the seen_names guard
+    in providers.py."""
+    force_settings(_enabled_settings(composio_toolkits=["composio"]))
+    monkeypatch.setattr(composio_providers, "_resolve_ctx", lambda: _fake_ctx())
+
+    composio_cls = stub_provider_modules["Composio"]
+
+    def _factory(*args: object, **kwargs: object) -> MagicMock:
+        inst = MagicMock(name="ComposioClient")
+
+        def _get(
+            user_id: str,
+            toolkits: list[str] | None = None,
+            tools: list[str] | None = None,
+            limit: int | None = None,
+        ) -> list[object]:
+            if tools is not None:
+                return [_named_tool(s) for s in tools]
+            # Per-toolkit fetch happens to also include SEARCH_TOOLS:
+            return [_named_tool("COMPOSIO_SEARCH_TOOLS"), _named_tool("other")]
+
+        inst.tools.get.side_effect = _get
+        return inst
+
+    composio_cls.side_effect = _factory
+
+    out = composio_providers.build_tools_for_backend("claude_agent_sdk")
+    search_tools = [t for t in out if _tool_name(t) == "COMPOSIO_SEARCH_TOOLS"]
+    assert len(search_tools) == 1  # deduped, not double-listed

--- a/tests/cloud/composio/test_service.py
+++ b/tests/cloud/composio/test_service.py
@@ -1,0 +1,215 @@
+"""Composio service tests — namespacing, client cache, disabled gate."""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import Internal, ValidationError
+from pocketpaw_ee.cloud.composio import service as composio_service
+from pocketpaw_ee.cloud.composio.domain import ComposioUserId
+
+from pocketpaw.config import Settings
+
+
+def _ctx(user_id: str = "user_123", workspace_id: str | None = "ws_acme") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="req_test",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _enabled_settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {
+        "composio_api_key": "ck_test",
+        "composio_enterprise_id": "ent_acme",
+    }
+    base.update(overrides)
+    return Settings(_env_file=None, **base)  # type: ignore[arg-type]
+
+
+@pytest.fixture(autouse=True)
+def _reset_client_cache() -> None:
+    composio_service.reset_client_cache_for_tests()
+    yield
+    composio_service.reset_client_cache_for_tests()
+
+
+@pytest.fixture
+def stub_composio_module(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Install a fake ``composio`` module so ``service._get_client`` can
+    import it without the real SDK being present. Returns the ``Composio``
+    class mock so tests can assert on construction args.
+    """
+    fake_module = types.ModuleType("composio")
+    composio_cls = MagicMock(name="Composio")
+    # Each call returns a fresh client mock so caching is observable.
+    composio_cls.side_effect = lambda *a, **kw: MagicMock(name="client", init_args=(a, kw))
+    fake_module.Composio = composio_cls  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "composio", fake_module)
+    return composio_cls
+
+
+# ---------------------------------------------------------------------------
+# Domain — ComposioUserId
+# ---------------------------------------------------------------------------
+
+
+def test_composio_user_id_str_format() -> None:
+    uid = ComposioUserId(enterprise_id="ent_acme", user_id="user_42")
+    assert str(uid) == "ent_acme:user_42"
+
+
+def test_composio_user_id_requires_enterprise() -> None:
+    with pytest.raises(ValueError, match="enterprise_id"):
+        ComposioUserId(enterprise_id="", user_id="user_42")
+
+
+def test_composio_user_id_requires_user() -> None:
+    with pytest.raises(ValueError, match="user_id"):
+        ComposioUserId(enterprise_id="ent_acme", user_id="")
+
+
+def test_composio_user_id_rejects_separator_in_enterprise() -> None:
+    with pytest.raises(ValueError, match="separator"):
+        ComposioUserId(enterprise_id="ent:bad", user_id="user_42")
+
+
+# ---------------------------------------------------------------------------
+# is_enabled
+# ---------------------------------------------------------------------------
+
+
+def test_is_enabled_false_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POCKETPAW_COMPOSIO_API_KEY", raising=False)
+    monkeypatch.delenv("POCKETPAW_COMPOSIO_ENTERPRISE_ID", raising=False)
+    s = Settings(_env_file=None)
+    assert composio_service.is_enabled(s) is False
+
+
+def test_is_enabled_true_when_both_set() -> None:
+    s = _enabled_settings()
+    assert composio_service.is_enabled(s) is True
+
+
+# ---------------------------------------------------------------------------
+# composio_user_id (namespacing)
+# ---------------------------------------------------------------------------
+
+
+def test_composio_user_id_namespacing() -> None:
+    s = _enabled_settings()
+    ctx = _ctx(user_id="user_42")
+    uid = composio_service.composio_user_id(ctx, s)
+    assert uid.enterprise_id == "ent_acme"
+    assert uid.user_id == "user_42"
+    assert str(uid) == "ent_acme:user_42"
+
+
+def test_composio_user_id_raises_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POCKETPAW_COMPOSIO_API_KEY", raising=False)
+    monkeypatch.delenv("POCKETPAW_COMPOSIO_ENTERPRISE_ID", raising=False)
+    s = Settings(_env_file=None)
+    with pytest.raises(ValidationError, match="composio.disabled"):
+        composio_service.composio_user_id(_ctx(), s)
+
+
+# ---------------------------------------------------------------------------
+# Client caching
+# ---------------------------------------------------------------------------
+
+
+async def test_get_client_caches_singleton(
+    stub_composio_module: MagicMock,
+) -> None:
+    s = _enabled_settings()
+    c1 = await composio_service._get_client(s)
+    c2 = await composio_service._get_client(s)
+    assert c1 is c2
+    stub_composio_module.assert_called_once()
+
+
+async def test_get_client_raises_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POCKETPAW_COMPOSIO_API_KEY", raising=False)
+    monkeypatch.delenv("POCKETPAW_COMPOSIO_ENTERPRISE_ID", raising=False)
+    s = Settings(_env_file=None)
+    with pytest.raises(ValidationError, match="composio.disabled"):
+        await composio_service._get_client(s)
+
+
+async def test_get_client_passes_base_url_when_set(
+    stub_composio_module: MagicMock,
+) -> None:
+    s = _enabled_settings(composio_base_url="https://composio.internal")
+    await composio_service._get_client(s)
+    _, kwargs = stub_composio_module.call_args
+    assert kwargs.get("base_url") == "https://composio.internal"
+    assert kwargs.get("api_key") == "ck_test"
+
+
+async def test_get_client_omits_base_url_when_unset(
+    stub_composio_module: MagicMock,
+) -> None:
+    s = _enabled_settings()
+    await composio_service._get_client(s)
+    _, kwargs = stub_composio_module.call_args
+    assert "base_url" not in kwargs
+
+
+async def test_get_client_raises_when_sdk_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Ensure ``composio`` is not importable
+    monkeypatch.delitem(sys.modules, "composio", raising=False)
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "composio":
+            raise ImportError("composio not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    s = _enabled_settings()
+    with pytest.raises(Internal, match="composio.sdk_missing"):
+        await composio_service._get_client(s)
+
+
+# ---------------------------------------------------------------------------
+# list_available_toolkits  (Connectors-panel admin discovery helper)
+# ---------------------------------------------------------------------------
+
+
+async def test_list_available_toolkits_returns_slugs(
+    stub_composio_module: MagicMock,
+) -> None:
+    s = _enabled_settings()
+    client = await composio_service._get_client(s)
+    tk_gmail = MagicMock(slug="gmail")
+    tk_slack = MagicMock(slug="slack")
+    # Real SDK returns a ToolkitListResponse with ``.items``; mirror that.
+    response = MagicMock()
+    response.items = [tk_gmail, tk_slack]
+    client.toolkits.list.return_value = response
+
+    slugs = await composio_service.list_available_toolkits(s)
+    assert slugs == ["gmail", "slack"]
+
+
+async def test_list_available_toolkits_wraps_errors(
+    stub_composio_module: MagicMock,
+) -> None:
+    s = _enabled_settings()
+    client = await composio_service._get_client(s)
+    client.toolkits.list.side_effect = RuntimeError("upstream")
+
+    with pytest.raises(Internal, match="composio.toolkit_list_failed"):
+        await composio_service.list_available_toolkits(s)

--- a/uv.lock
+++ b/uv.lock
@@ -957,6 +957,92 @@ wheels = [
 ]
 
 [[package]]
+name = "composio"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "composio-client" },
+    { name = "json-schema-to-pydantic" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pysher" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/4e/3e7391c38e13a69ba8634282f14488fb80189c4c8b27460457bf7a34e498/composio-0.13.1.tar.gz", hash = "sha256:957327c6557704135d34e10f3a0c8a885082b3d650e08acfb0f562c69290d289", size = 210832, upload-time = "2026-05-14T07:46:03.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/a0/e4777e815c485015174f62e5d9562f814e2b1ea062b4a6a2ba09fe2abdfd/composio-0.13.1-py3-none-any.whl", hash = "sha256:9a9620499d792d8f3336533a68d71f704a55659eb9f7a575cfe8b930409793a5", size = 142353, upload-time = "2026-05-14T07:45:48.687Z" },
+]
+
+[[package]]
+name = "composio-claude-agent-sdk"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "claude-agent-sdk" },
+    { name = "composio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/59/4a3ddd64e5d642063d4f7bda1da36010ef703dea0c5fd7dae48ba23d5c3d/composio_claude_agent_sdk-0.13.1.tar.gz", hash = "sha256:891261aaa8d12dfa9c3c7733651d67031d3f851ebfc4155c8783ade2de28c6c4", size = 5927, upload-time = "2026-05-14T07:46:06.094Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/91/d4d035d55fe7bc3ef28581129978190dc07e9eaa43fbc0e4198837a990d4/composio_claude_agent_sdk-0.13.1-py3-none-any.whl", hash = "sha256:a83d20e1a0e012d4dde757aae9778d02d4c2a45f9045bda632b96274ea2b569d", size = 6865, upload-time = "2026-05-14T07:45:52.839Z" },
+]
+
+[[package]]
+name = "composio-client"
+version = "1.39.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/78/efc71b2df0d580c4550ee60644193644ae3ddc06fc89f3fc92998db6393c/composio_client-1.39.0.tar.gz", hash = "sha256:2086493925117b956a3166da18414925cb50829172c8211591137fcdc3d60c7d", size = 248246, upload-time = "2026-05-12T14:28:13.071Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/59/f4ddca56b9f02c8fed3277584111a687c9be986d0d2e8b421c80a20caa03/composio_client-1.39.0-py3-none-any.whl", hash = "sha256:bf6050dc0d523bd1e9d52e39e162f5b23bd029aa441b5c4a18e1751aae58571d", size = 284163, upload-time = "2026-05-12T14:28:11.681Z" },
+]
+
+[[package]]
+name = "composio-google-adk"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "composio" },
+    { name = "google-adk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/2b/24391ae7ce794b3451e0c6ec9da2c2c7961e0ad71f8c3c5cbc4a19b4bb56/composio_google_adk-0.13.1.tar.gz", hash = "sha256:bc2e4de874492ddbd38ffb327d98c226d6bfe93a52d97311d171dc887f58182e", size = 2496, upload-time = "2026-05-14T07:46:09.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/03/b9381027a36506d726319a6a87c80c1be08e1bc87d96f4cfac8f37e73757/composio_google_adk-0.13.1-py3-none-any.whl", hash = "sha256:b310009e4201b2de5fa40fc7b852725a2c182572e1688941f321e36bd39a9d24", size = 2808, upload-time = "2026-05-14T07:45:57.298Z" },
+]
+
+[[package]]
+name = "composio-langgraph"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "composio" },
+    { name = "langgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/c6/5cef3917dbd56311bbeedd3d428389de0cf6bf4d3bdb604ebd115f3dc794/composio_langgraph-0.13.1.tar.gz", hash = "sha256:45e8213648daaf6cd41704da7a7a456ce4dc65fae24949d46fc00bbc7b610142", size = 4151, upload-time = "2026-05-14T07:46:10.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/7e/5b2adab0a8ba1256c8abc0e6ab4d538990d92bf851dd570aca5ad020ec63/composio_langgraph-0.13.1-py3-none-any.whl", hash = "sha256:19c942af53cf2ee4b5481a2e0f0fbedaf4afc7efa89f5dde072975d2d01a43ea", size = 4386, upload-time = "2026-05-14T07:45:59.46Z" },
+]
+
+[[package]]
+name = "composio-openai-agents"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "composio" },
+    { name = "openai-agents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/cd/ad48daa380db49e84a2ed6feff71cebbea79ec80d61fcd358416efe969c2/composio_openai_agents-0.13.1.tar.gz", hash = "sha256:5319c66c1f45c840624546156f34ccbe76248886d9f84f22470541a5d4dfeea7", size = 3874, upload-time = "2026-05-14T07:46:12.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/61/01749fa69f83cfe35bead0e457d427b88982e4e2abe594bfa77c3b06b3de/composio_openai_agents-0.13.1-py3-none-any.whl", hash = "sha256:5e73f90f542c9af83a50f7693de0a1484908958be9c5673043f8d7c258126e3e", size = 4218, upload-time = "2026-05-14T07:46:02.619Z" },
+]
+
+[[package]]
 name = "courlan"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2328,6 +2414,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "json-schema-to-pydantic"
+version = "0.4.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/d8/423895b918706c80db1cee679c13fbe810200b9a9d9a9442c7a58d35c3f2/json_schema_to_pydantic-0.4.11.tar.gz", hash = "sha256:35448ed711a28dd33396b095c8492939b4925aa30eb31942e9b8e08d04279465", size = 56597, upload-time = "2026-03-09T20:53:55.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/64/7cfeb8c6d2a5e73e0f8d732032aa62be9a7724c04beb461d677de0b4beb3/json_schema_to_pydantic-0.4.11-py3-none-any.whl", hash = "sha256:da2ccc39d070ee03dbcf0517d16720e3e33f7aa8d61257ace09af8c51bd46348", size = 17842, upload-time = "2026-03-09T20:53:54.576Z" },
 ]
 
 [[package]]
@@ -4692,6 +4790,11 @@ source = { editable = "ee" }
 dependencies = [
     { name = "beanie" },
     { name = "boto3" },
+    { name = "composio" },
+    { name = "composio-claude-agent-sdk" },
+    { name = "composio-google-adk" },
+    { name = "composio-langgraph" },
+    { name = "composio-openai-agents" },
     { name = "fastapi-users", extra = ["beanie", "oauth"] },
     { name = "google-api-python-client" },
     { name = "google-auth" },
@@ -4712,6 +4815,11 @@ dependencies = [
 requires-dist = [
     { name = "beanie", specifier = ">=1.26.0" },
     { name = "boto3", specifier = ">=1.34.0" },
+    { name = "composio", specifier = ">=0.7.0" },
+    { name = "composio-claude-agent-sdk", specifier = ">=0.7.0" },
+    { name = "composio-google-adk", specifier = ">=0.7.0" },
+    { name = "composio-langgraph", specifier = ">=0.7.0" },
+    { name = "composio-openai-agents", specifier = ">=0.7.0" },
     { name = "fastapi-users", extras = ["beanie", "oauth"], specifier = ">=13.0.0" },
     { name = "google-api-python-client", specifier = ">=2.100.0" },
     { name = "google-auth", specifier = ">=2.25.0" },
@@ -5545,6 +5653,16 @@ dependencies = [
     { name = "pillow", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ee/f0/cb456ac4f1a73723d5b866933b7986f02bacea27516629c00f8e7da94c2d/pyscreeze-1.0.1.tar.gz", hash = "sha256:cf1662710f1b46aa5ff229ee23f367da9e20af4a78e6e365bee973cad0ead4be", size = 27826, upload-time = "2024-08-20T23:03:07.291Z" }
+
+[[package]]
+name = "pysher"
+version = "1.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/a0/d0638470df605ce266991fb04f74c69ab1bed3b90ac3838e9c3c8b69b66a/Pysher-1.0.8.tar.gz", hash = "sha256:7849c56032b208e49df67d7bd8d49029a69042ab0bb45b2ed59fa08f11ac5988", size = 9071, upload-time = "2022-10-10T13:41:09.936Z" }
 
 [[package]]
 name = "pytesseract"


### PR DESCRIPTION
## Summary

Re-ports the Composio integration from #1105 onto the post-split two-package layout (`pocketpaw` OSS core + `pocketpaw-ee`). #1105 was branched before the OSS-EE split and also carried unrelated pocket-specialist work; this PR contains **only** the Composio changes and is built on `chore/oss-ee-split` (#1152), so the diff here is Composio-only.

Composio gives every supported chat backend (`claude_agent_sdk`, `openai_agents`, `google_adk`, `deep_agents`) 200+ pre-built OAuth integrations (Gmail, Slack, GitHub, Calendar, Drive, Linear, …) via the official per-backend provider packages.

## Architecture — open-core safe

The feature module lives entirely in `pocketpaw-ee` (`ee/pocketpaw_ee/cloud/composio/`). The OSS core **never imports `pocketpaw_ee`** — Composio is reached only through entry points, same pattern as every other EE capability post-split:

- **`claude_agent_sdk`** — Composio is an in-process MCP server, contributed via a new `pocketpaw.mcp_servers` provider (`CloudComposioMcpProvider`). `claude_sdk.py` is **untouched** — its existing generic provider loop discovers and policy-checks it. `tool_ids()` returns the server-level allowlist entry `mcp__composio` (Composio's tool set is per-user/per-toolkit, so it can't be statically enumerated).
- **`deep_agents` / `google_adk` / `openai_agents`** — Composio tools are native function tools, fetched **per stream** via a new `pocketpaw.composio_tools` entry point (`CloudComposioToolProvider`), called from `tool_bridge.composio_tools_for()`. Per-stream fetch is required for multi-tenant correctness (tools are user-scoped and must never be cached across users).

`import-linter`'s `OSS core may not import from EE` contract stays **KEPT**.

## Behaviour

- `tool_bridge` drops the legacy YAML/native connector tools (`gmail_*`, `calendar_*`, `docs_*`, `drive_*`, `reddit_*`, `spotify_*`) when Composio is enabled, so the agent has exactly one integration path per service.
- `agent_service` adds a runtime-identity rule (blocks the model from fabricating `/mcp` slash commands or "Settings → Google OAuth" flows that don't exist in the chat surface) plus Composio auth/search prompt guidance, gated on `composio_service.is_enabled()`.
- `config.py` gains `composio_*` settings; `composio_api_key` without `composio_enterprise_id` fails fast at `Settings.load()`.
- Connect Link auth surfaces as an inline Ripple button.

## Notable changes vs #1105

- Composio is wired through entry points instead of inline edits to four backend files (`claude_sdk.py` ends up untouched).
- The Composio MCP server is now correctly allowlisted (`mcp__composio`) — #1105 registered the server but never added it to `claude_agent_sdk`'s allowlist.
- Dropped #1105's unrelated `google_adk` MCP transport change (`streamable-http` / `cfg.env`) — not part of the Composio path.

## Config

```bash
POCKETPAW_COMPOSIO_API_KEY=...
POCKETPAW_COMPOSIO_ENTERPRISE_ID=ent_acme   # required when api_key is set
POCKETPAW_COMPOSIO_TOOLKITS=gmail,slack,github,googlecalendar,googledrive
POCKETPAW_COMPOSIO_BASE_URL=                # unset = Composio cloud
POCKETPAW_COMPOSIO_MCP_URL_TTL_SECONDS=3600
POCKETPAW_COMPOSIO_CONNECT_LINK_INLINE=true
```

## Test plan

- [x] `uv run pytest tests/cloud/composio` — 69 passed
- [x] `uv run ruff check` — clean on touched files
- [x] `uv run lint-imports` — `OSS core may not import from EE` KEPT
- [x] Entry-point smoke: `CloudComposioMcpProvider` + `CloudComposioToolProvider` resolve; `claude_sdk.py` composio-free
- [x] Regression: `tool_bridge` / config / backend-registry / deep_agents / openai_agents / agent-service-scope suites pass (1 pre-existing unrelated env failure in provider auto-detection)

## Notes

- Base is `chore/oss-ee-split` (#1152) so this stacks cleanly and shows a Composio-only diff; GitHub will retarget it once #1152 merges.
- Supersedes #1105 — close that one in favour of this.