### PR TITLE
Tier-2 array-item edit ops + slim design prompts

### DIFF
--- a/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
@@ -8,8 +8,12 @@ hallucinates argument names.
 
 The thunk indirections (``_agent_list_pockets``, ``_agent_create``,
 ``_agent_update``, ``_get_manifest``) are bound at module level so
-tests can patch ``ee.agent.pocket_specialist.tools.<name>`` without
-reaching into ``ee.cloud`` internals.
+tests can patch ``pocketpaw_ee.agent.pocket_specialist.tools.<name>``
+without reaching into ``pocketpaw_ee.cloud`` internals.
+
+Changes: 2026-05-14 — added the Tier-2 prop-array item tool factories
+(set / append / remove ``_prop_array_item``), reworked onto the
+pocketpaw_ee layout from PR #1106.
 """
 
 from __future__ import annotations
@@ -633,6 +637,140 @@ def make_remove_node_tool(
     )
 
 
+class _SetPropArrayItemArgs(BaseModel):
+    node_id: str
+    prop: str
+    match: dict[str, Any] = Field(
+        ...,
+        description=(
+            "How to locate the item. One of: {index:0}, {id:'...'},"
+            " {by_field:'label', equals:'X'}, {by_key:{k:v,...}}."
+        ),
+    )
+    partial: dict[str, Any] = Field(
+        ...,
+        description="Fields to merge into the matched item (shallow merge).",
+    )
+
+
+def make_set_prop_array_item_tool(
+    *, pocket_id: str, capture: dict[str, Any] | None = None
+) -> StructuredTool:
+    """Edit ONE item inside a widget's prop-array — surgical alternative
+    to set_node_prop for chart.data / table.rows / etc."""
+
+    async def _run(
+        node_id: str,
+        prop: str,
+        match: dict[str, Any],
+        partial: dict[str, Any],
+    ) -> dict[str, Any]:
+        from pocketpaw_ee.cloud.pockets.agent_context import set_prop_array_item_for_agent
+
+        result = await set_prop_array_item_for_agent(pocket_id, node_id, prop, match, partial)
+        _capture_op(
+            capture,
+            "set_prop_array_item",
+            {"node_id": node_id, "prop": prop, "match": match},
+        )
+        return result
+
+    return StructuredTool.from_function(
+        coroutine=_run,
+        name="set_prop_array_item",
+        description=(
+            "Surgically edit ONE item in a widget's prop-array (chart.data, "
+            "table.rows, calendar.events, kanban.columns, feed.items, "
+            "tabs.items, nav.items, select.options, form-layout.fields). "
+            "Cheaper and safer than set_node_prop when you only need to "
+            "change one row/slice — you never copy the unchanged items, "
+            "so they can't drift. `match` picks the item: "
+            "{index:N} | {id:'...'} | {by_field:'label', equals:'X'} | "
+            "{by_key:{k:v}}. `partial` is shallow-merged into that item."
+        ),
+        args_schema=_SetPropArrayItemArgs,
+    )
+
+
+class _AppendPropArrayItemArgs(BaseModel):
+    node_id: str
+    prop: str
+    value: Any
+    after: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional ItemMatch — insert after the matching item; omit to append.",
+    )
+
+
+def make_append_prop_array_item_tool(
+    *, pocket_id: str, capture: dict[str, Any] | None = None
+) -> StructuredTool:
+    async def _run(
+        node_id: str,
+        prop: str,
+        value: Any,
+        after: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        from pocketpaw_ee.cloud.pockets.agent_context import append_prop_array_item_for_agent
+
+        result = await append_prop_array_item_for_agent(pocket_id, node_id, prop, value, after)
+        _capture_op(
+            capture,
+            "append_prop_array_item",
+            {"node_id": node_id, "prop": prop, "after": after},
+        )
+        return result
+
+    return StructuredTool.from_function(
+        coroutine=_run,
+        name="append_prop_array_item",
+        description=(
+            "Append (or insert-after) ONE item into a widget's prop-array. "
+            "Same allowed widgets as set_prop_array_item. If `after` is "
+            "given it must be an ItemMatch — the new item is inserted right "
+            "after the matched item; otherwise appended. Creates the array "
+            "if it does not yet exist on the node."
+        ),
+        args_schema=_AppendPropArrayItemArgs,
+    )
+
+
+class _RemovePropArrayItemArgs(BaseModel):
+    node_id: str
+    prop: str
+    match: dict[str, Any]
+
+
+def make_remove_prop_array_item_tool(
+    *, pocket_id: str, capture: dict[str, Any] | None = None
+) -> StructuredTool:
+    async def _run(
+        node_id: str,
+        prop: str,
+        match: dict[str, Any],
+    ) -> dict[str, Any]:
+        from pocketpaw_ee.cloud.pockets.agent_context import remove_prop_array_item_for_agent
+
+        result = await remove_prop_array_item_for_agent(pocket_id, node_id, prop, match)
+        _capture_op(
+            capture,
+            "remove_prop_array_item",
+            {"node_id": node_id, "prop": prop, "match": match},
+        )
+        return result
+
+    return StructuredTool.from_function(
+        coroutine=_run,
+        name="remove_prop_array_item",
+        description=(
+            "Remove ONE matched item from a widget's prop-array. Same "
+            "allowed widgets and match grammar as set_prop_array_item. "
+            "Refuses ambiguous matches — disambiguate with by_key or index."
+        ),
+        args_schema=_RemovePropArrayItemArgs,
+    )
+
+
 def make_edit_pocket_tools(
     *, pocket_id: str, capture: dict[str, Any] | None = None
 ) -> list[StructuredTool]:
@@ -640,7 +778,8 @@ def make_edit_pocket_tools(
 
     Order is the order the LLM sees them; we lead with the read tool
     so the agent is prompted toward "get then mutate" rather than
-    blind writes.
+    blind writes. The Tier-2 ``*_prop_array_item`` ops sit next to
+    ``set_node_prop`` — they are the surgical alternative to it.
     """
     return [
         make_get_pocket_tool(pocket_id=pocket_id),
@@ -649,6 +788,9 @@ def make_edit_pocket_tools(
         make_remove_state_tool(pocket_id=pocket_id, capture=capture),
         make_patch_state_tool(pocket_id=pocket_id, capture=capture),
         make_set_node_prop_tool(pocket_id=pocket_id, capture=capture),
+        make_set_prop_array_item_tool(pocket_id=pocket_id, capture=capture),
+        make_append_prop_array_item_tool(pocket_id=pocket_id, capture=capture),
+        make_remove_prop_array_item_tool(pocket_id=pocket_id, capture=capture),
         make_add_node_tool(pocket_id=pocket_id, capture=capture),
         make_replace_node_tool(pocket_id=pocket_id, capture=capture),
         make_move_node_tool(pocket_id=pocket_id, capture=capture),

--- a/ee/pocketpaw_ee/cloud/pockets/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/pockets/agent_context.py
@@ -503,6 +503,109 @@ async def set_node_prop_for_agent(
     return {"ok": True, "subtree": subtree, "old_value": old_value}
 
 
+async def set_prop_array_item_for_agent(
+    pocket_id: str,
+    node_id: str,
+    prop: str,
+    match: dict[str, Any],
+    partial: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge ``partial`` into one matched item inside a node prop-array
+    (chart.data, table.rows, …) without forcing the agent to re-ship the
+    whole array. Locked to the ``prop_arrays`` allowlist at the service
+    layer."""
+    result, err = await pockets_service.agent_set_prop_array_item(
+        pocket_id, node_id=node_id, prop=prop, match=match, partial=partial
+    )
+    if err is not None or result is None:
+        return {"ok": False, "error": err or "set_prop_array_item failed"}
+    pocket_view = result.get("pocket") or {}
+    item_index = result.get("item_index")
+    item = result.get("item")
+    old_item = result.get("old_item")
+    await _push_node_op(
+        "node_prop_array_item_set",
+        pocket_view,
+        {
+            "node_id": node_id,
+            "prop": prop,
+            "item_index": item_index,
+            "item": item,
+        },
+    )
+    return {
+        "ok": True,
+        "item_index": item_index,
+        "item": item,
+        "old_item": old_item,
+    }
+
+
+async def append_prop_array_item_for_agent(
+    pocket_id: str,
+    node_id: str,
+    prop: str,
+    value: Any,
+    after: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Append ``value`` to a node prop-array, or insert immediately after
+    a matched item when ``after`` is given. Creates the array if missing.
+    Locked to the ``prop_arrays`` allowlist at the service layer."""
+    result, err = await pockets_service.agent_append_prop_array_item(
+        pocket_id, node_id=node_id, prop=prop, value=value, after=after
+    )
+    if err is not None or result is None:
+        return {"ok": False, "error": err or "append_prop_array_item failed"}
+    pocket_view = result.get("pocket") or {}
+    item_index = result.get("item_index")
+    item = result.get("item")
+    await _push_node_op(
+        "node_prop_array_item_appended",
+        pocket_view,
+        {
+            "node_id": node_id,
+            "prop": prop,
+            "item_index": item_index,
+            "item": item,
+        },
+    )
+    return {"ok": True, "item_index": item_index, "item": item}
+
+
+async def remove_prop_array_item_for_agent(
+    pocket_id: str,
+    node_id: str,
+    prop: str,
+    match: dict[str, Any],
+) -> dict[str, Any]:
+    """Remove the matched item from a node prop-array. Refuses ambiguous
+    matches (the agent must disambiguate). Locked to the ``prop_arrays``
+    allowlist at the service layer."""
+    result, err = await pockets_service.agent_remove_prop_array_item(
+        pocket_id, node_id=node_id, prop=prop, match=match
+    )
+    if err is not None or result is None:
+        return {"ok": False, "error": err or "remove_prop_array_item failed"}
+    pocket_view = result.get("pocket") or {}
+    removed_index = result.get("removed_index")
+    removed_item = result.get("removed_item")
+    await _push_node_op(
+        "node_prop_array_item_removed",
+        pocket_view,
+        {
+            "node_id": node_id,
+            "prop": prop,
+            "removed_index": removed_index,
+            "removed_item": removed_item,
+        },
+    )
+    return {
+        "ok": True,
+        "removed_index": removed_index,
+        "removed_item": removed_item,
+    }
+
+
 async def move_node_for_agent(
     pocket_id: str,
     node_id: str,
@@ -633,6 +736,7 @@ async def patch_state_for_agent(pocket_id: str, partial: dict[str, Any]) -> dict
 __all__ = [
     "add_node_for_agent",
     "add_widget_for_agent",
+    "append_prop_array_item_for_agent",
     "append_state_for_agent",
     "create_pocket_for_agent",
     "fetch_pocket_for_agent",
@@ -640,10 +744,12 @@ __all__ = [
     "move_node_for_agent",
     "patch_state_for_agent",
     "remove_node_for_agent",
+    "remove_prop_array_item_for_agent",
     "remove_state_for_agent",
     "remove_widget_for_agent",
     "replace_node_for_agent",
     "set_node_prop_for_agent",
+    "set_prop_array_item_for_agent",
     "set_state_for_agent",
     "update_pocket_for_agent",
     "update_widget_for_agent",

--- a/ee/pocketpaw_ee/cloud/pockets/prop_arrays.py
+++ b/ee/pocketpaw_ee/cloud/pockets/prop_arrays.py
@@ -1,0 +1,56 @@
+# prop_arrays.py — closed allowlist of widget prop-arrays the Tier-2
+# array-item edit ops are permitted to touch.
+# Created: 2026-05-14. Reworked onto the pocketpaw_ee layout from PR #1106.
+"""Closed allowlist of ``(widget_type, prop_name)`` pairs that support the
+Tier-2 array-element ops (``set_prop_array_item`` /
+``append_prop_array_item`` / ``remove_prop_array_item``).
+
+Why a closed list:
+
+  * The renderer's manifest already enumerates every prop a widget
+    accepts, but only a small subset of those are user-editable
+    arrays the agent should surgically poke at item-level. Many props
+    happen to be lists (e.g. ``chart.colors``) but aren't intended
+    for row-style edits.
+  * Locking the surface here means a typo (``cloud_set_prop_array_item
+    target=stat prop=value``) is rejected up-front with a clear error,
+    rather than silently mangling a scalar prop.
+
+Keep this in sync with:
+
+  * ``backend/docs/plans/2026-05-12-pocket-edit-api-design.md`` (Tier 2 table)
+  * the edit-specialist prompt examples in ``pocketpaw.ripple._pockets``
+
+Adding a new widget? Add the row here AND extend the edit-specialist
+prompt's cheatsheet so the agent knows the prop is targetable.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+_ALLOWED: Final[dict[str, frozenset[str]]] = {
+    "chart": frozenset({"data"}),
+    "table": frozenset({"rows", "columns"}),
+    "kanban": frozenset({"columns"}),
+    "calendar": frozenset({"events"}),
+    "feed": frozenset({"items"}),
+    "tabs": frozenset({"items"}),
+    "nav": frozenset({"items"}),
+    "select": frozenset({"options"}),
+    "form-layout": frozenset({"fields"}),
+}
+
+
+def is_allowed(widget_type: str, prop: str) -> bool:
+    """Return True iff ``prop`` is in the array-edit allowlist for ``widget_type``."""
+    return prop in _ALLOWED.get(widget_type, frozenset())
+
+
+def allowed_props_for(widget_type: str) -> tuple[str, ...]:
+    """Return the sorted tuple of allowed prop names for ``widget_type``,
+    or an empty tuple if unknown."""
+    return tuple(sorted(_ALLOWED.get(widget_type, frozenset())))
+
+
+__all__ = ["allowed_props_for", "is_allowed"]

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -18,11 +18,18 @@ Agent-facing granular ``rippleSpec.ui`` mutations (called from the
 ``pocket_specialist`` subagent via the in-process MCP server):
 - ``agent_add_node``, ``agent_replace_node``, ``agent_set_node_prop``,
   ``agent_move_node``, ``agent_remove_node``
+- ``agent_set_prop_array_item``, ``agent_append_prop_array_item``,
+  ``agent_remove_prop_array_item`` — Tier-2 surgical edits on a single
+  item inside a widget prop-array (chart.data, table.rows, …)
+
+Changes: 2026-05-14 — added the Tier-2 prop-array item ops (reworked
+onto the pocketpaw_ee layout from PR #1106).
 """
 
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 import secrets
 from collections import OrderedDict
@@ -38,7 +45,7 @@ from pocketpaw_ee.cloud._core.realtime.events import (
 )
 from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
 from pocketpaw_ee.cloud.models.pocket import Widget as _WidgetDoc
-from pocketpaw_ee.cloud.pockets import spec_ops, state_ops
+from pocketpaw_ee.cloud.pockets import prop_arrays, spec_ops, state_ops
 from pocketpaw_ee.cloud.pockets.domain import Pocket, Widget, WidgetPosition
 from pocketpaw_ee.cloud.pockets.dto import (
     AddCollaboratorRequest,
@@ -1210,6 +1217,252 @@ async def agent_set_node_prop(
                 "subtree": node,
                 "old_value": old,
                 "prop": prop,
+                "pocket": _agent_view_dict(doc),
+            },
+            None,
+        )
+
+
+async def agent_set_prop_array_item(
+    pocket_id: str,
+    *,
+    node_id: str,
+    prop: str,
+    match: dict[str, Any],
+    partial: dict[str, Any],
+) -> tuple[dict | None, str | None]:
+    """Merge ``partial`` into the first item of ``node.props[prop]`` that
+    matches ``match``. Surgical alternative to ``set_node_prop`` when the
+    agent only wants to change one row/slice in a chart/table/etc.
+
+    Merge is SHALLOW: top-level keys in ``partial`` overwrite the matched
+    item's keys, but nested dicts/lists are replaced wholesale rather
+    than deep-merged. Matches ``patch_state`` semantics; if the agent
+    needs to preserve nested structure, fetch the item first and pass a
+    fully-built nested dict in ``partial``. Non-dict matched items are
+    replaced wholesale by ``partial`` (rare — most prop-array items are
+    dicts).
+
+    Returns ``({"item_index": int, "item": <new item>, "old_item": <prev>,
+    "pocket": <view>}, None)``.
+
+    Error codes (returned as the error string):
+      * ``"unsupported_prop_array: <type>.<prop>"``
+      * ``"no node with id 'n_xxx'"``
+      * ``"prop {prop!r} is not an array on node {node_id!r}"``
+      * ``"not_found: no item matched"``
+      * ``"ambiguous: N items matched; candidates=[idx, ...]"``
+    """
+    if not node_id:
+        return None, "node_id is required"
+    if not prop:
+        return None, "prop is required"
+    if not isinstance(partial, dict):
+        return None, "partial must be a dict"
+
+    async with _pocket_lock(pocket_id):
+        doc, ui, err = await _load_and_ensure_ids(pocket_id)
+        if err or doc is None or ui is None:
+            return None, err
+        node = spec_ops.find_by_id(ui, node_id)
+        if node is None:
+            return None, f"no node with id {node_id!r}"
+
+        wtype = node.get("type")
+        if not isinstance(wtype, str) or not prop_arrays.is_allowed(wtype, prop):
+            return None, f"unsupported_prop_array: {wtype}.{prop}"
+
+        props = node.get("props")
+        if props is None:
+            return None, f"node {node_id!r} has no props"
+        if not isinstance(props, dict):
+            return None, f"node {node_id!r} has non-dict props"
+        arr = props.get(prop)
+        if not isinstance(arr, list):
+            return None, f"prop {prop!r} is not an array on node {node_id!r}"
+
+        try:
+            candidates = spec_ops.match_array_item_candidates(arr, match)
+        except ValueError as exc:
+            return None, str(exc)
+        if len(candidates) == 0:
+            return None, "not_found: no item matched"
+        if len(candidates) > 1:
+            preview = candidates[:5]
+            return None, f"ambiguous: {len(candidates)} items matched; candidates={preview}"
+
+        idx = candidates[0]
+        old_item = copy.deepcopy(arr[idx])
+        if isinstance(arr[idx], dict):
+            arr[idx] = {**arr[idx], **partial}
+        else:
+            arr[idx] = partial  # non-dict element: replace wholesale
+
+        if doc.rippleSpec is not None:
+            doc.rippleSpec = normalize_ripple_spec(doc.rippleSpec) or doc.rippleSpec
+        try:
+            await doc.save()
+        except Exception as exc:  # noqa: BLE001
+            return None, f"save failed: {exc}"
+        await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+        return (
+            {
+                "item_index": idx,
+                "item": arr[idx],
+                "old_item": old_item,
+                "pocket": _agent_view_dict(doc),
+            },
+            None,
+        )
+
+
+async def agent_append_prop_array_item(
+    pocket_id: str,
+    *,
+    node_id: str,
+    prop: str,
+    value: Any,
+    after: dict[str, Any] | None = None,
+) -> tuple[dict | None, str | None]:
+    """Append ``value`` to ``node.props[prop]``. If ``after`` is given,
+    insert immediately AFTER the first item matching that ItemMatch.
+
+    Returns ``({"item_index": int, "item": <inserted>, "pocket": <view>}, None)``.
+
+    Errors: see ``agent_set_prop_array_item``. ``after`` resolution uses
+    the same match grammar; ``not_found`` / ``ambiguous`` propagate.
+    """
+    if not node_id:
+        return None, "node_id is required"
+    if not prop:
+        return None, "prop is required"
+
+    async with _pocket_lock(pocket_id):
+        doc, ui, err = await _load_and_ensure_ids(pocket_id)
+        if err or doc is None or ui is None:
+            return None, err
+        node = spec_ops.find_by_id(ui, node_id)
+        if node is None:
+            return None, f"no node with id {node_id!r}"
+
+        wtype = node.get("type")
+        if not isinstance(wtype, str) or not prop_arrays.is_allowed(wtype, prop):
+            return None, f"unsupported_prop_array: {wtype}.{prop}"
+
+        # Append intentionally creates props and the array on demand —
+        # set/remove bail when either is missing because there is no
+        # item to address, but append's whole job is to add the first
+        # one. Asymmetry is by design.
+        props = node.setdefault("props", {})
+        if not isinstance(props, dict):
+            return None, f"node {node_id!r} has non-dict props"
+        arr = props.get(prop)
+        if arr is None:
+            arr = []
+            props[prop] = arr
+        if not isinstance(arr, list):
+            return None, f"prop {prop!r} is not an array on node {node_id!r}"
+
+        if after is None:
+            arr.append(value)
+            idx = len(arr) - 1
+        else:
+            try:
+                candidates = spec_ops.match_array_item_candidates(arr, after)
+            except ValueError as exc:
+                return None, str(exc)
+            if len(candidates) == 0:
+                return None, "not_found: after target did not match"
+            if len(candidates) > 1:
+                return (
+                    None,
+                    f"ambiguous: after matched {len(candidates)} items; "
+                    f"candidates={candidates[:5]}",
+                )
+            arr.insert(candidates[0] + 1, value)
+            idx = candidates[0] + 1
+
+        if doc.rippleSpec is not None:
+            doc.rippleSpec = normalize_ripple_spec(doc.rippleSpec) or doc.rippleSpec
+        try:
+            await doc.save()
+        except Exception as exc:  # noqa: BLE001
+            return None, f"save failed: {exc}"
+        await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+        return (
+            {
+                "item_index": idx,
+                "item": value,
+                "pocket": _agent_view_dict(doc),
+            },
+            None,
+        )
+
+
+async def agent_remove_prop_array_item(
+    pocket_id: str,
+    *,
+    node_id: str,
+    prop: str,
+    match: dict[str, Any],
+) -> tuple[dict | None, str | None]:
+    """Remove the first item in ``node.props[prop]`` matching ``match``.
+
+    Returns ``({"removed_index": int, "removed_item": Any, "pocket": <view>},
+    None)``.
+
+    Errors: see ``agent_set_prop_array_item``. Refuses ambiguous matches —
+    the agent must disambiguate.
+    """
+    if not node_id:
+        return None, "node_id is required"
+    if not prop:
+        return None, "prop is required"
+
+    async with _pocket_lock(pocket_id):
+        doc, ui, err = await _load_and_ensure_ids(pocket_id)
+        if err or doc is None or ui is None:
+            return None, err
+        node = spec_ops.find_by_id(ui, node_id)
+        if node is None:
+            return None, f"no node with id {node_id!r}"
+
+        wtype = node.get("type")
+        if not isinstance(wtype, str) or not prop_arrays.is_allowed(wtype, prop):
+            return None, f"unsupported_prop_array: {wtype}.{prop}"
+
+        props = node.get("props")
+        if props is None:
+            return None, f"node {node_id!r} has no props"
+        if not isinstance(props, dict):
+            return None, f"node {node_id!r} has non-dict props"
+        arr = props.get(prop)
+        if not isinstance(arr, list):
+            return None, f"prop {prop!r} is not an array on node {node_id!r}"
+
+        try:
+            candidates = spec_ops.match_array_item_candidates(arr, match)
+        except ValueError as exc:
+            return None, str(exc)
+        if len(candidates) == 0:
+            return None, "not_found: no item matched"
+        if len(candidates) > 1:
+            return None, f"ambiguous: {len(candidates)} items matched; candidates={candidates[:5]}"
+
+        idx = candidates[0]
+        removed = arr.pop(idx)
+
+        if doc.rippleSpec is not None:
+            doc.rippleSpec = normalize_ripple_spec(doc.rippleSpec) or doc.rippleSpec
+        try:
+            await doc.save()
+        except Exception as exc:  # noqa: BLE001
+            return None, f"save failed: {exc}"
+        await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+        return (
+            {
+                "removed_index": idx,
+                "removed_item": removed,
                 "pocket": _agent_view_dict(doc),
             },
             None,

--- a/ee/pocketpaw_ee/cloud/pockets/spec_ops.py
+++ b/ee/pocketpaw_ee/cloud/pockets/spec_ops.py
@@ -323,12 +323,83 @@ def move_node(
     return old_parent_id, src_idx
 
 
+# ---------------------------------------------------------------------------
+# Prop-array item matching
+#
+# Used by the Tier-2 array-element ops (set_prop_array_item etc.) to locate
+# a single item inside a node's prop-array (chart.data, table.rows, …)
+# without forcing the agent to copy-paste the entire array.
+# ---------------------------------------------------------------------------
+
+
+def _match_form(match: dict[str, Any]) -> str:
+    if not isinstance(match, dict) or not match:
+        raise ValueError("empty match")
+    if "index" in match:
+        return "index"
+    if "id" in match:
+        return "id"
+    if "by_key" in match:
+        return "by_key"
+    if "by_field" in match and "equals" in match:
+        return "by_field"
+    raise ValueError(f"unknown match form: {sorted(match.keys())}")
+
+
+def _item_matches(item: Any, form: str, match: dict[str, Any]) -> bool:
+    if not isinstance(item, dict):
+        return False
+    if form == "id":
+        return item.get("id") == match["id"]
+    if form == "by_key":
+        pairs = match["by_key"]
+        if not isinstance(pairs, dict) or not pairs:
+            raise ValueError("by_key must be a non-empty mapping")
+        return all(item.get(k) == v for k, v in pairs.items())
+    if form == "by_field":
+        return item.get(match["by_field"]) == match["equals"]
+    return False
+
+
+def match_array_item(arr: list[Any], match: dict[str, Any]) -> int | None:
+    """Return the index of the FIRST item in ``arr`` matching ``match``,
+    or ``None`` if no item matches. Raises ``ValueError`` on a malformed
+    or out-of-range ``index`` match form.
+
+    Match forms: see module docstring / design doc. Use
+    ``match_array_item_candidates`` to detect ambiguity (multiple matches).
+    """
+    form = _match_form(match)
+    if form == "index":
+        idx = match["index"]
+        if not isinstance(idx, int) or idx < 0 or idx >= len(arr):
+            raise ValueError(f"index {idx!r} out of range [0,{len(arr)})")
+        return idx
+    for i, item in enumerate(arr):
+        if _item_matches(item, form, match):
+            return i
+    return None
+
+
+def match_array_item_candidates(arr: list[Any], match: dict[str, Any]) -> list[int]:
+    """Return ALL indices in ``arr`` whose item matches ``match``. Used by
+    the service layer to render `ambiguous` errors with candidates."""
+    form = _match_form(match)
+    if form == "index":
+        # Positional match is never ambiguous.
+        idx = match_array_item(arr, match)
+        return [idx] if idx is not None else []
+    return [i for i, item in enumerate(arr) if _item_matches(item, form, match)]
+
+
 __all__ = [
     "ensure_ids",
     "find_by_id",
     "find_parent",
     "insert_child",
     "is_valid_id",
+    "match_array_item",
+    "match_array_item_candidates",
     "move_node",
     "new_node_id",
     "remove_node",

--- a/src/pocketpaw/ripple/_design.py
+++ b/src/pocketpaw/ripple/_design.py
@@ -15,6 +15,10 @@
 # Modified: 2026-05-21 — added a "Full-fledged app chrome" composition
 # block (app-shell / sidebar / breadcrumb + overlay chrome) for
 # "an app for X" briefs.
+# Modified: 2026-05-21 — refactored CANONICAL_SHAPES into a keyed
+# WIDGET_SHAPES dict (per-widget lazy retrieval) and added
+# OPTIONAL_DESIGN_SECTIONS for the two-tier inline widget_help lookup.
+# Reworked from PR #1106.
 
 WIDGET_CATALOG = """\
 # WIDGET CATALOG
@@ -352,15 +356,24 @@ rows with bullets and the user notices instantly.
 """
 
 
-CANONICAL_SHAPES = """\
-# CANONICAL SHAPES — inlined for the highest-traffic widgets only
+_CANONICAL_SHAPES_PREAMBLE = """\
+# CANONICAL SHAPES — inlined for the highest-traffic widgets
 
-The four shapes below are inlined because EVERY pocket touches them.
-For every other widget — stat, timeline, gantt, calendar,
-heatmap, pricing-table, comparison-table, kv-table, source-card,
-sources-bar, gauge, funnel, sankey, treemap, sparkline, etc. — call
-`get_widget_spec` per the WIDGET SPEC TOOL RULE above. Don't guess.
+The shapes below are inlined because they're the highest-traffic
+widgets and the prop schema is most often hallucinated. For widgets
+outside this list (stat, gantt, calendar, heatmap, pricing-table,
+comparison-table, kv-table, source-card, sources-bar, gauge, funnel,
+sankey, treemap, sparkline, etc.) call `get_widget_spec` — don't guess.
+"""
 
+
+# Per-widget canonical shapes. Keyed by widget `type` so both the
+# inline-Ripple `widget_help` tool and the pocket create specialist
+# can fetch JUST the widget they need, instead of loading the entire
+# blob. Keeping per-widget granularity is what makes lazy retrieval
+# actually lazy.
+WIDGET_SHAPES: dict[str, str] = {
+    "chart": """\
 `chart` — Ripple's chart has a SMALL fixed prop set. **Allowed props:**
 `type`, `data`, `title`, `height`, `colors`, `tooltip`. THAT IS THE
 WHOLE LIST. Anything else is invented and the renderer ignores it.
@@ -416,7 +429,8 @@ and want a chart, you have two options:
       the state — emit `chartData` alongside the source array), or
   (b) emit the chart-shaped array directly as `chartData` in state and
       keep the source array for the table.
-
+""",
+    "table": """\
 `table` — `columns` are OBJECTS with `accessorKey`; `rows` is an array
 of OBJECTS keyed by accessorKey. NEVER pass `columns: [str]` +
 `rows: [[]]` — the cells silently render empty.
@@ -455,7 +469,8 @@ table.
   Format at display time via the renderer's column formatter, not at
   emit time. If you must emit pre-formatted strings, do not enable
   sort on that column.
-
+""",
+    "data-grid": """\
 `data-grid` — HIGH DENSITY tabular: sticky headers, resizable columns,
 search, per-column sort, dense cells. Use when row count ≥ 50 or the
 user wants a "power user" feel (operational dashboards, log viewers,
@@ -496,7 +511,8 @@ ranked datasets, monitoring lists).
   - For 1000+ rows prefer `virtual-list` (call get_widget_spec).
   - Same numeric-sort gotcha as `table`: emit numbers, not formatted
     strings, on any column where sort is enabled.
-
+""",
+    "kanban": """\
 `kanban` — columns are headers ONLY; cards live in a flat list in
 `state`, reach the widget via `bind`, and `columnKey` says which card
 field maps to which column. Without `bind`, drag-to-move snaps back:
@@ -510,7 +526,8 @@ field maps to which column. Without `bind`, drag-to-move snaps back:
                    { "id": "done", "title": "Done" } ],
       "columnKey": "status"
   }}
-
+""",
+    "audit-log": """\
 `audit-log` — THE widget for "Recent Activity", event streams, audit
 trails, history logs. Each entry has actor + action + target. Far
 better than a `table` for this shape: dense per-row layout, icon per
@@ -532,7 +549,8 @@ timestamp}" rows is an audit-log emitted as the wrong widget.
   Use `groupBy: "day"` or `"week"` for chronological feeds; omit
   (`"none"`) for tight chronological streams. `showFilters: true`
   surfaces a filter-by-type chip row.
-
+""",
+    "timeline": """\
 `timeline` — milestones / dated events with optional rich detail.
 Vertical timeline rendering. Use for project history, release notes,
 contribution graphs, lifecycle events.
@@ -551,7 +569,8 @@ contribution graphs, lifecycle events.
   When in doubt between `audit-log` and `timeline`:
     audit-log → who did what (actor-driven)
     timeline  → what happened when (event-driven, often single actor)
-
+""",
+    "tabs": """\
 `tabs` — labels in `props.tabs`; CONTENT in the node's `children` array,
 one child per tab by index. Do NOT use `props.tabs[i].content` — ignored:
   { "type": "tabs",
@@ -595,7 +614,14 @@ one child per tab by index. Do NOT use `props.tabs[i].content` — ignored:
   one screen would feel CROWDED with structurally different things,
   tabs are correct. If it would feel REPETITIVE (same widget, same
   rows, just filtered differently), use a filter — not tabs.
-"""
+""",
+}
+
+
+# Backward-compat: the full canonical-shapes block remains exported as
+# the same prose blob it always was. Callers that want per-widget
+# granularity should reach for ``WIDGET_SHAPES`` directly.
+CANONICAL_SHAPES = _CANONICAL_SHAPES_PREAMBLE + "\n" + "\n".join(WIDGET_SHAPES.values())
 
 
 INTERACTIVE_STATE_RULE = """\
@@ -1280,6 +1306,22 @@ RIPPLE_DESIGN_RULES = "\n".join(
 )
 
 
+# Niche / situational design sections, keyed for on-demand retrieval by
+# the inline-Ripple ``widget_help`` tool. These are already part of the
+# eager ``RIPPLE_DESIGN_RULES`` superblock; surfacing them here lets the
+# two-tier ``widget_help`` lookup answer a "tell me about <section>"
+# request without splitting the whole blob by heading.
+OPTIONAL_DESIGN_SECTIONS: dict[str, str] = {
+    "tabular-picker": TABULAR_PICKER_RULE,
+    "activity-picker": ACTIVITY_PICKER_RULE,
+    "visual-variation": VISUAL_VARIATION_RULE,
+    "composition-cookbook": COMPOSITION_COOKBOOK,
+    "full-pane": FULL_PANE_RULE,
+    "logo": LOGO_RULE,
+    "design-quality": DESIGN_QUALITY,
+}
+
+
 __all__ = [
     "WIDGET_CATALOG",
     "USE_THE_WIDGET_RULE",
@@ -1288,6 +1330,8 @@ __all__ = [
     "WIDGET_SPEC_TOOL_RULE",
     "COMPOSITION_COOKBOOK",
     "CANONICAL_SHAPES",
+    "WIDGET_SHAPES",
+    "OPTIONAL_DESIGN_SECTIONS",
     "TABULAR_PICKER_RULE",
     "ACTIVITY_PICKER_RULE",
     "VISUAL_VARIATION_RULE",

--- a/src/pocketpaw/ripple/_inline.py
+++ b/src/pocketpaw/ripple/_inline.py
@@ -12,8 +12,65 @@
 # Composition: surface-specific framing here (intro, chat.send loop, fence
 # rules) + the shared design language from pocketpaw.ripple._design (widget
 # catalog, canonical shapes, full-pane rule, theme, design-quality bar).
+#
+# Modified: 2026-05-21 — prepended a ground-truth / do-not-mock rule to
+# the inline system prompt. Reworked from PR #1106.
 
 from pocketpaw.ripple._design import USE_THE_WIDGET_RULE, WIDGET_CATALOG
+
+_GROUND_TRUTH_RULE = """\
+<ground-truth>
+# IMPORTANT — DO NOT MOCK. DO NOT TRUST YOUR OWN KNOWLEDGE.
+
+You know NOTHING about the user's world, their data, their tools, the
+current state of any library/API/SDK, or what is "true" right now. Your
+training data is months to years out of date and quietly wrong on
+specifics — function signatures rename, APIs deprecate, package versions
+move, prices change, events happen. A confident-sounding answer from
+memory is the #1 failure mode here; it ships broken pockets, dead links,
+and wrong numbers that look real.
+
+Default posture: research first, then answer. Memory is a hypothesis,
+not a fact.
+
+## Never invent
+
+Do NOT fabricate any of the following, ever:
+- User-specific data (their username, repo, project, team, customers,
+  bookings, revenue, calendar events, file paths). If the brief implies
+  it but doesn't name it, ASK.
+- Real-world facts that drift over time (current prices, scores,
+  weather, exchange rates, version numbers, latest releases, news,
+  policy text, API endpoints, library APIs).
+- Placeholder names that look real ("Acme Corp", "Mona Octocat",
+  "john@example.com", "user1", "Q3 2024 revenue: $4.2M") — these read
+  as production data and the user will trust them.
+
+## Acceptable order of operations
+
+1. **Research** with the tools you have (web search, fetch, get_widget_spec,
+   read docs, list_pockets, etc.) BEFORE answering anything you can't
+   verify from the current turn.
+2. **Ask** the user when you can't research — one short, concrete
+   question is always better than a guess. "What's your GitHub username?"
+   beats inventing `octocat`.
+3. **Labelled placeholders** are allowed ONLY when (a) you have no way
+   to research, (b) the user hasn't given the value, AND (c) you cannot
+   reasonably ask (e.g. they explicitly said "just put something there",
+   "stub it", "fake data is fine"). Even then, label them obviously
+   (`<your username>`, `[example value]`) so the user knows what to
+   replace.
+
+If you catch yourself about to write a confident specific (a version
+number, a function name, a price, a fact about a product) and you
+haven't verified it this turn — stop, research or ask. "I'm not sure —
+do you want to check that, or should I look it up?" is a good answer.
+A wrong-sounding-confident answer is the worst answer.
+</ground-truth>
+
+
+"""
+
 
 _INLINE_PREAMBLE = """\
 <ripple>
@@ -223,7 +280,8 @@ Final self-check before sending:
 
 
 INLINE_RIPPLE_SYSTEM_PROMPT = (
-    _INLINE_PREAMBLE
+    _GROUND_TRUTH_RULE
+    + _INLINE_PREAMBLE
     + WIDGET_CATALOG
     + "\n"
     + USE_THE_WIDGET_RULE

--- a/src/pocketpaw/ripple/_inline_core.py
+++ b/src/pocketpaw/ripple/_inline_core.py
@@ -4,10 +4,27 @@
 # system prompt. Most replies use 1-3 widgets, so 90%+ of those tokens
 # were paid for nothing. This module owns the lookup payload that
 # powers the on-demand `get_inline_widget_help` MCP tool.
+#
+# Modified: 2026-05-21 — widget_help is now a two-tier lookup
+# (per-widget WIDGET_SHAPES first, section search second). Reworked
+# from PR #1106.
+#
+# Lookup is two-tier:
+#  1. Per-widget canonical shapes via WIDGET_SHAPES — preferred.
+#     Asking for ["chart"] returns just the chart shape (~2k chars),
+#     not the whole CANONICAL_SHAPES blob (~10k).
+#  2. Section search across the rest of RIPPLE_DESIGN_RULES — for
+#     niche rules (TABULAR_PICKER, ACTIVITY_PICKER, etc.) or widgets
+#     not in WIDGET_SHAPES, we still split-by-heading and fuzzy-match.
 
 from __future__ import annotations
 
-from pocketpaw.ripple._design import RIPPLE_DESIGN_RULES
+from pocketpaw.ripple._design import (
+    INTERACTIVE_STATE_RULE,
+    OPTIONAL_DESIGN_SECTIONS,
+    RIPPLE_DESIGN_RULES,
+    WIDGET_SHAPES,
+)
 
 
 def widget_help(types: list[str] | None = None) -> str:
@@ -17,10 +34,16 @@ def widget_help(types: list[str] | None = None) -> str:
     only requests this when it needs the catalog overview). With
     specific types, returns sections matching those widget kinds.
 
-    Section matching is naive substring search on the existing rules
-    text. It deliberately errs toward returning too much rather than
-    too little — the agent already paid the round-trip; better to
-    over-deliver than to leave it guessing.
+    Resolution order for each requested type:
+      1. WIDGET_SHAPES[type] — exact canonical shape, ~600–2400 chars.
+      2. OPTIONAL_DESIGN_SECTIONS[type] — niche layout sections that
+         aren't eagerly in RIPPLE_DESIGN_RULES (tabular-picker,
+         activity-picker, visual-variation, etc.).
+      3. Fall back to section search across RIPPLE_DESIGN_RULES.
+
+    Errs toward returning too much rather than too little — the agent
+    already paid the round-trip; better to over-deliver than leave it
+    guessing.
     """
     if not types:
         return RIPPLE_DESIGN_RULES
@@ -29,21 +52,33 @@ def widget_help(types: list[str] | None = None) -> str:
     if not wanted:
         return RIPPLE_DESIGN_RULES
 
-    # Split RIPPLE_DESIGN_RULES into top-level sections at "# " headings,
-    # return any section whose body mentions a wanted type. Always include
-    # the section carrying the toolkit / expression-language vocabulary —
-    # the agent rarely uses widgets without bindings.
-    sections = _split_sections(RIPPLE_DESIGN_RULES)
-    keep: list[str] = []
-    for sect in sections:
-        body = sect.lower()
-        # Always keep the section that carries the toolkit /
-        # expression-language vocabulary — agents need handler syntax
-        # and binding shape for any widget with on_click or {state.x}.
-        always_keep = "toolkit" in body or "expression language" in body
-        if always_keep or any(t in body for t in wanted):
-            keep.append(sect)
-    return "\n\n".join(keep) if keep else RIPPLE_DESIGN_RULES
+    parts: list[str] = []
+    unresolved: set[str] = set()
+    for t in wanted:
+        if t in WIDGET_SHAPES:
+            parts.append(WIDGET_SHAPES[t])
+        elif t in OPTIONAL_DESIGN_SECTIONS:
+            parts.append(OPTIONAL_DESIGN_SECTIONS[t])
+        else:
+            unresolved.add(t)
+
+    if unresolved:
+        # Section search across RIPPLE_DESIGN_RULES for any type we
+        # couldn't resolve directly.
+        sections = _split_sections(RIPPLE_DESIGN_RULES)
+        for sect in sections:
+            body = sect.lower()
+            if any(t in body for t in unresolved):
+                parts.append(sect)
+
+    # Always tack the interactive-state rule on the end. Bindings,
+    # {state.x} expressions, and action-chain vocabulary apply to every
+    # widget — the agent rarely uses a widget without them, so shipping
+    # the toolkit alongside any retrieval avoids a follow-up round-trip.
+    if parts:
+        parts.append(INTERACTIVE_STATE_RULE)
+        return "\n\n".join(parts)
+    return RIPPLE_DESIGN_RULES
 
 
 def _split_sections(text: str) -> list[str]:

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -41,10 +41,48 @@
 # ``pocketpaw-create-pocket`` skill), a HARD RULE recipe-preflight block,
 # and a STEP 0 recipe-library check pointing at the bundled
 # ``ripple-recipes`` kb-go scope.
+# Modified: 2026-05-21 — the create specialist's prompt now splices in
+# the slim ``_RIPPLE_DESIGN_ESSENTIALS`` instead of the full
+# ``RIPPLE_DESIGN_RULES`` superblock. Reworked from PR #1106.
 
 from __future__ import annotations
 
-from pocketpaw.ripple._design import RIPPLE_DESIGN_RULES
+from pocketpaw.ripple._design import (
+    CANONICAL_SHAPES,
+    INTERACTIVE_STATE_RULE,
+    RIPPLE_DESIGN_RULES,
+    THEME_RULE,
+    USE_THE_WIDGET_RULE,
+    VISUAL_VARIATION_RULE,
+    WIDGET_CATALOG,
+)
+
+# Slim subset of RIPPLE_DESIGN_RULES for the create specialist. The
+# full RIPPLE_DESIGN_RULES superblock is ~47k chars (~12k tokens) —
+# well past the 3k-token point where attention degrades. The blocks
+# below are the load-bearing ones: widget vocabulary so the model
+# names widgets correctly, canonical prop shapes so persist_pocket's
+# validator doesn't have to bounce every spec, and the interactive
+# state pattern so pockets aren't dead read-only canvases.
+#
+# VISUAL_VARIATION_RULE is included even on a one-brief-at-a-time path:
+# the pattern-first / anti-dashboard rebalance (which lives in that
+# block) corrects a per-brief bias, not a cross-brief one. Dropped:
+# COMPOSITION_COOKBOOK (parent decides composition via hints),
+# TABULAR/ACTIVITY_PICKER_RULE (niche), DESIGN_QUALITY (aspirational),
+# NO_INVENTED_WIDGETS_RULE / WIDGET_SPEC_TOOL_RULE (overlap with
+# WIDGET_CATALOG + manifest validator). LOGO_RULE is small but
+# entirely cosmetic; left out to keep the prompt tight.
+_RIPPLE_DESIGN_ESSENTIALS = "\n".join(
+    [
+        USE_THE_WIDGET_RULE,
+        WIDGET_CATALOG,
+        CANONICAL_SHAPES,
+        INTERACTIVE_STATE_RULE,
+        VISUAL_VARIATION_RULE,
+        THEME_RULE,
+    ]
+)
 
 POCKET_ID_TOKEN = "__POCKET_ID__"
 
@@ -1310,6 +1348,12 @@ def _assemble_specialist() -> str:
     they document the rippleSpec shape, not the tool surface; the
     specialist calls ``persist_pocket`` instead but the spec body is
     identical.
+
+    Design rules are spliced in via the slim ``_RIPPLE_DESIGN_ESSENTIALS``
+    (widget vocab + canonical shapes + interactive-state pattern +
+    visual-variation + theme) rather than the full ~47k-char
+    ``RIPPLE_DESIGN_RULES`` — the dropped sub-blocks are either covered
+    by the parent's structural plan or by the runtime manifest validator.
     """
     parts = [
         _SCOPE_BLOCK,
@@ -1320,7 +1364,7 @@ def _assemble_specialist() -> str:
         _STATE_SOURCES_BLOCK,
         _CREATION_EXAMPLES_MCP,
         _RESEARCH_PROTOCOL,
-        RIPPLE_DESIGN_RULES,
+        _RIPPLE_DESIGN_ESSENTIALS,
     ]
     return "\n".join(parts) + "\n"
 

--- a/tests/cloud/test_pocket_granular_ops.py
+++ b/tests/cloud/test_pocket_granular_ops.py
@@ -563,3 +563,429 @@ async def test_no_active_stream_rejected(fake_doc):
     assert result["ok"] is False
     assert "no active workspace/user" in result["error"]
     assert push_calls == []
+
+
+# ---------------------------------------------------------------------------
+# set_prop_array_item — surgical edit of one item inside a node prop-array.
+# ---------------------------------------------------------------------------
+
+
+class TestSetPropArrayItem:
+    """Surgical edit of one item inside a node's prop-array."""
+
+    @pytest.mark.asyncio
+    async def test_updates_matched_item_by_field(self, fake_doc):
+        # Seed a chart with a 4-slice donut.
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {
+                "type": "donut",
+                "data": [
+                    {"label": "Online Store", "value": 62},
+                    {"label": "POS", "value": 18},
+                    {"label": "Social", "value": 12},
+                    {"label": "Other", "value": 8},
+                ],
+            },
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_set_prop_array_item(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Other"},
+                partial={"value": 5},
+            )
+
+        assert err is None
+        assert result["item_index"] == 3
+        assert result["item"] == {"label": "Other", "value": 5}
+        assert chart["props"]["data"][3]["value"] == 5
+        # Unchanged siblings preserved.
+        assert chart["props"]["data"][0]["value"] == 62
+        assert fake_doc.saves == 1
+
+    @pytest.mark.asyncio
+    async def test_unsupported_prop_array_rejected(self, fake_doc):
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_set_prop_array_item(
+                fake_doc.id,
+                node_id="n_header00",  # heading, not chart/table/etc.
+                prop="text",
+                match={"index": 0},
+                partial={"text": "Hi"},
+            )
+        assert result is None
+        assert err is not None
+        assert "unsupported_prop_array" in err
+
+    @pytest.mark.asyncio
+    async def test_missing_node_errors_cleanly(self, fake_doc):
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_set_prop_array_item(
+                fake_doc.id,
+                node_id="n_does_not_exist",
+                prop="data",
+                match={"index": 0},
+                partial={},
+            )
+        assert result is None
+        assert "no node with id" in err
+
+    @pytest.mark.asyncio
+    async def test_item_not_found_returns_error(self, fake_doc):
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {"data": [{"label": "A", "value": 1}]},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_set_prop_array_item(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Z"},
+                partial={"value": 99},
+            )
+        assert result is None
+        assert "not_found" in err
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_match_returns_candidates(self, fake_doc):
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {
+                "data": [
+                    {"label": "Other", "value": 1},
+                    {"label": "Other", "value": 2},
+                ]
+            },
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_set_prop_array_item(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Other"},
+                partial={"value": 99},
+            )
+        assert result is None
+        assert "ambiguous" in err
+
+
+# ---------------------------------------------------------------------------
+# append_prop_array_item — append (or insert-after-match) into a prop-array.
+# ---------------------------------------------------------------------------
+
+
+class TestAppendPropArrayItem:
+    @pytest.mark.asyncio
+    async def test_appends_to_end_by_default(self, fake_doc):
+        table = {
+            "id": "n_table111",
+            "type": "table",
+            "props": {"rows": [{"orderId": "#1"}, {"orderId": "#2"}]},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(table)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_append_prop_array_item(
+                fake_doc.id,
+                node_id="n_table111",
+                prop="rows",
+                value={"orderId": "#3"},
+            )
+        assert err is None
+        assert result["item_index"] == 2
+        assert table["props"]["rows"][-1] == {"orderId": "#3"}
+
+    @pytest.mark.asyncio
+    async def test_inserts_after_matched_item(self, fake_doc):
+        table = {
+            "id": "n_table111",
+            "type": "table",
+            "props": {"rows": [{"orderId": "#1"}, {"orderId": "#3"}]},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(table)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_append_prop_array_item(
+                fake_doc.id,
+                node_id="n_table111",
+                prop="rows",
+                value={"orderId": "#2"},
+                after={"by_field": "orderId", "equals": "#1"},
+            )
+        assert err is None
+        assert result["item_index"] == 1
+        assert [r["orderId"] for r in table["props"]["rows"]] == ["#1", "#2", "#3"]
+
+    @pytest.mark.asyncio
+    async def test_creates_empty_array_if_missing(self, fake_doc):
+        feed = {"id": "n_feed0001", "type": "feed", "props": {}}
+        fake_doc.rippleSpec["ui"]["children"].append(feed)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_append_prop_array_item(
+                fake_doc.id,
+                node_id="n_feed0001",
+                prop="items",
+                value={"text": "Hi"},
+            )
+        assert err is None
+        assert feed["props"]["items"] == [{"text": "Hi"}]
+        assert result["item_index"] == 0
+
+    @pytest.mark.asyncio
+    async def test_after_target_not_found_errors(self, fake_doc):
+        table = {
+            "id": "n_table111",
+            "type": "table",
+            "props": {"rows": [{"orderId": "#1"}]},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(table)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_append_prop_array_item(
+                fake_doc.id,
+                node_id="n_table111",
+                prop="rows",
+                value={"orderId": "#2"},
+                after={"by_field": "orderId", "equals": "#999"},
+            )
+        assert result is None
+        assert "not_found" in err
+
+
+class TestRemovePropArrayItem:
+    @pytest.mark.asyncio
+    async def test_removes_matched_item(self, fake_doc):
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {
+                "data": [
+                    {"label": "A", "value": 1},
+                    {"label": "Other", "value": 2},
+                    {"label": "B", "value": 3},
+                ]
+            },
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_remove_prop_array_item(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Other"},
+            )
+        assert err is None
+        assert result["removed_index"] == 1
+        assert result["removed_item"] == {"label": "Other", "value": 2}
+        assert [d["label"] for d in chart["props"]["data"]] == ["A", "B"]
+
+    @pytest.mark.asyncio
+    async def test_not_found_errors(self, fake_doc):
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {"data": [{"label": "A"}]},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result, err = await pocket_service.agent_remove_prop_array_item(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Z"},
+            )
+        assert result is None
+        assert "not_found" in err
+
+
+# ---------------------------------------------------------------------------
+# *_for_agent wrappers — exercise the agent_context.py layer that drives
+# SSE node ops + the uniform {ok, ...} shape consumed by LangChain tools.
+# ---------------------------------------------------------------------------
+
+
+class TestPropArrayItemWrappers:
+    """The thin wrappers in agent_context.py: push SSE node ops + return
+    the uniform {ok, ...} shape consumed by the LangChain edit tools."""
+
+    @pytest.mark.asyncio
+    async def test_set_prop_array_item_for_agent_pushes_sse(self, fake_doc):
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {
+                "data": [
+                    {"label": "Online Store", "value": 62},
+                    {"label": "Other", "value": 8},
+                ],
+            },
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+
+        ctx, push_calls = _patches(fake_doc)
+        with ctx:
+            result = await agent_context.set_prop_array_item_for_agent(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Other"},
+                partial={"value": 5},
+            )
+
+        assert result["ok"] is True
+        assert result["item_index"] == 1
+        assert result["item"] == {"label": "Other", "value": 5}
+        assert chart["props"]["data"][1]["value"] == 5
+        # Exactly one SSE push with the granular action.
+        assert len(push_calls) == 1
+        push = push_calls[0]
+        assert push["action"] == "node_prop_array_item_set"
+        assert push["node_id"] == "n_chart000"
+        assert push["prop"] == "data"
+        assert push["item_index"] == 1
+        assert push["item"] == {"label": "Other", "value": 5}
+        # Subtree-only; never the full pocket.
+        assert "pocket" not in push
+
+    @pytest.mark.asyncio
+    async def test_set_prop_array_item_for_agent_propagates_error(self, fake_doc):
+        ctx, push_calls = _patches(fake_doc)
+        with ctx:
+            result = await agent_context.set_prop_array_item_for_agent(
+                fake_doc.id,
+                node_id="n_header00",  # unsupported widget for prop-array ops
+                prop="text",
+                match={"index": 0},
+                partial={"text": "x"},
+            )
+        assert result["ok"] is False
+        assert "unsupported_prop_array" in result["error"]
+        assert push_calls == []
+
+    @pytest.mark.asyncio
+    async def test_append_prop_array_item_for_agent_pushes_sse(self, fake_doc):
+        table = {
+            "id": "n_table111",
+            "type": "table",
+            "props": {"rows": [{"orderId": "#1"}, {"orderId": "#3"}]},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(table)
+
+        ctx, push_calls = _patches(fake_doc)
+        with ctx:
+            result = await agent_context.append_prop_array_item_for_agent(
+                fake_doc.id,
+                node_id="n_table111",
+                prop="rows",
+                value={"orderId": "#2"},
+                after={"by_field": "orderId", "equals": "#1"},
+            )
+
+        assert result["ok"] is True
+        assert result["item_index"] == 1
+        assert [r["orderId"] for r in table["props"]["rows"]] == ["#1", "#2", "#3"]
+        assert len(push_calls) == 1
+        push = push_calls[0]
+        assert push["action"] == "node_prop_array_item_appended"
+        assert push["node_id"] == "n_table111"
+        assert push["prop"] == "rows"
+        assert push["item_index"] == 1
+        assert push["item"] == {"orderId": "#2"}
+
+    @pytest.mark.asyncio
+    async def test_remove_prop_array_item_for_agent_pushes_sse(self, fake_doc):
+        chart = {
+            "id": "n_chart000",
+            "type": "chart",
+            "props": {
+                "data": [
+                    {"label": "A", "value": 1},
+                    {"label": "Other", "value": 2},
+                    {"label": "B", "value": 3},
+                ],
+            },
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(chart)
+
+        ctx, push_calls = _patches(fake_doc)
+        with ctx:
+            result = await agent_context.remove_prop_array_item_for_agent(
+                fake_doc.id,
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "Other"},
+            )
+
+        assert result["ok"] is True
+        assert result["removed_index"] == 1
+        assert result["removed_item"] == {"label": "Other", "value": 2}
+        assert [d["label"] for d in chart["props"]["data"]] == ["A", "B"]
+        assert len(push_calls) == 1
+        push = push_calls[0]
+        assert push["action"] == "node_prop_array_item_removed"
+        assert push["node_id"] == "n_chart000"
+        assert push["prop"] == "data"
+        assert push["removed_index"] == 1
+        assert push["removed_item"] == {"label": "Other", "value": 2}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end canary: the 12-row "All Orders" table edit from the design doc.
+# This is the regression the whole Tier-2 work was driven by — editing one
+# row must leave every other row byte-identical.
+# ---------------------------------------------------------------------------
+
+
+class TestArrayItemCanary:
+    """End-to-end: the 12-row 'All Orders' table edit from the design doc."""
+
+    @pytest.mark.asyncio
+    async def test_one_row_edit_does_not_rewrite_other_rows(self, fake_doc):
+        rows = [
+            {"orderId": f"#{1030 + i}", "customer": f"C{i}", "status": "Fulfilled"}
+            for i in range(12)
+        ]
+        snapshot = [dict(r) for r in rows]
+        table = {
+            "id": "n_orders00",
+            "type": "table",
+            "props": {"rows": rows},
+        }
+        fake_doc.rippleSpec["ui"]["children"].append(table)
+
+        ctx, _ = _patches(fake_doc)
+        with ctx:
+            result = await agent_context.set_prop_array_item_for_agent(
+                fake_doc.id,
+                node_id="n_orders00",
+                prop="rows",
+                match={"by_field": "orderId", "equals": "#1039"},
+                partial={"status": "Shipped"},
+            )
+        assert result["ok"] is True
+        assert result["item_index"] == 9
+        # All other rows are byte-identical.
+        for i, original in enumerate(snapshot):
+            if i == 9:
+                continue
+            assert table["props"]["rows"][i] == original, f"row {i} drifted"
+        assert table["props"]["rows"][9]["status"] == "Shipped"
+        assert table["props"]["rows"][9]["customer"] == "C9"  # untouched field

--- a/tests/cloud/test_prop_arrays.py
+++ b/tests/cloud/test_prop_arrays.py
@@ -1,0 +1,54 @@
+# test_prop_arrays.py — unit tests for the closed prop-array allowlist.
+# Created: 2026-05-14. Reworked onto the pocketpaw_ee layout from PR #1106.
+"""Tests for the closed (widget_type, prop_name) prop-array allowlist."""
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.pockets import prop_arrays
+
+
+def test_chart_data_is_allowed():
+    assert prop_arrays.is_allowed("chart", "data")
+
+
+def test_table_rows_and_columns_allowed():
+    assert prop_arrays.is_allowed("table", "rows")
+    assert prop_arrays.is_allowed("table", "columns")
+
+
+def test_kanban_columns_allowed():
+    assert prop_arrays.is_allowed("kanban", "columns")
+
+
+def test_calendar_events_allowed():
+    assert prop_arrays.is_allowed("calendar", "events")
+
+
+def test_feed_items_allowed():
+    assert prop_arrays.is_allowed("feed", "items")
+
+
+def test_select_options_allowed():
+    assert prop_arrays.is_allowed("select", "options")
+
+
+def test_form_layout_fields_allowed():
+    assert prop_arrays.is_allowed("form-layout", "fields")
+
+
+def test_random_prop_rejected():
+    assert not prop_arrays.is_allowed("chart", "title")
+    assert not prop_arrays.is_allowed("stat", "value")
+    assert not prop_arrays.is_allowed("chart", "series")
+
+
+def test_unknown_widget_rejected():
+    assert not prop_arrays.is_allowed("frobnicator", "data")
+
+
+def test_allowed_props_for_known_type():
+    assert sorted(prop_arrays.allowed_props_for("table")) == ["columns", "rows"]
+
+
+def test_allowed_props_for_unknown_returns_empty():
+    assert prop_arrays.allowed_props_for("frobnicator") == ()

--- a/tests/cloud/test_spec_ops.py
+++ b/tests/cloud/test_spec_ops.py
@@ -292,3 +292,75 @@ def test_move_root_raises():
     tree = _tree()
     with pytest.raises(ValueError, match="root"):
         spec_ops.move_node(tree, "n_root0000", "n_table000")
+
+
+# ---------------------------------------------------------------------------
+# Prop-array item matching
+# ---------------------------------------------------------------------------
+
+
+def _sample_array() -> list[dict]:
+    return [
+        {"id": "b1", "label": "Online Store", "value": 62},
+        {"id": "b2", "label": "POS", "value": 18},
+        {"id": "b3", "label": "Social", "value": 12},
+        {"id": "b4", "label": "Other", "value": 8},
+    ]
+
+
+def test_match_by_index_returns_position():
+    idx = spec_ops.match_array_item(_sample_array(), {"index": 0})
+    assert idx == 0
+
+
+def test_match_by_index_negative_rejected():
+    with pytest.raises(ValueError, match="index"):
+        spec_ops.match_array_item(_sample_array(), {"index": -1})
+
+
+def test_match_by_index_out_of_range_rejected():
+    with pytest.raises(ValueError, match="index"):
+        spec_ops.match_array_item(_sample_array(), {"index": 99})
+
+
+def test_match_by_field_equals_finds_first():
+    idx = spec_ops.match_array_item(_sample_array(), {"by_field": "label", "equals": "Other"})
+    assert idx == 3
+
+
+def test_match_by_field_missing_returns_none():
+    idx = spec_ops.match_array_item(_sample_array(), {"by_field": "label", "equals": "Nope"})
+    assert idx is None
+
+
+def test_match_by_key_requires_all_pairs():
+    arr = [
+        {"orderId": "#1039", "channel": "Online"},
+        {"orderId": "#1039", "channel": "POS"},
+    ]
+    idx = spec_ops.match_array_item(arr, {"by_key": {"orderId": "#1039", "channel": "POS"}})
+    assert idx == 1
+
+
+def test_match_id_shortcut_equivalent_to_by_key_id():
+    idx = spec_ops.match_array_item(_sample_array(), {"id": "b3"})
+    assert idx == 2
+
+
+def test_match_ambiguous_returns_candidates_indices():
+    arr = [
+        {"label": "Other", "value": 1},
+        {"label": "Other", "value": 2},
+    ]
+    candidates = spec_ops.match_array_item_candidates(arr, {"by_field": "label", "equals": "Other"})
+    assert candidates == [0, 1]
+
+
+def test_match_rejects_unknown_match_form():
+    with pytest.raises(ValueError, match="unknown match form"):
+        spec_ops.match_array_item(_sample_array(), {"weird": "shape"})
+
+
+def test_match_rejects_empty_match():
+    with pytest.raises(ValueError, match="empty"):
+        spec_ops.match_array_item(_sample_array(), {})

--- a/tests/ee/agent/test_pocket_specialist/test_edit.py
+++ b/tests/ee/agent/test_pocket_specialist/test_edit.py
@@ -80,7 +80,8 @@ class TestEditToolFactories:
 
         tools = make_edit_pocket_tools(pocket_id="p1")
         names = [t.name for t in tools]
-        # The 10 granular ops the edit specialist gets.
+        # The granular ops the edit specialist gets — including the
+        # Tier-2 surgical prop-array item ops.
         for expected in (
             "get_pocket",
             "set_state",
@@ -88,6 +89,9 @@ class TestEditToolFactories:
             "remove_state",
             "patch_state",
             "set_node_prop",
+            "set_prop_array_item",
+            "append_prop_array_item",
+            "remove_prop_array_item",
             "add_node",
             "replace_node",
             "move_node",
@@ -131,6 +135,103 @@ class TestEditToolFactories:
         assert capture.get("ops") == [
             {"op": "set_state", "args": {"path": "filter", "value": "done"}}
         ]
+
+
+class TestPropArrayItemToolFactories:
+    async def test_set_prop_array_item_tool_invokes_wrapper(self) -> None:
+        from pocketpaw_ee.agent.pocket_specialist import tools
+
+        capture: dict = {}
+        tool = tools.make_set_prop_array_item_tool(pocket_id="p1", capture=capture)
+        with patch(
+            "pocketpaw_ee.cloud.pockets.agent_context.set_prop_array_item_for_agent",
+            new_callable=AsyncMock,
+        ) as wrapper:
+            wrapper.return_value = {
+                "ok": True,
+                "item_index": 0,
+                "item": {"x": 1},
+                "old_item": {"x": 0},
+            }
+            result = await tool.coroutine(
+                node_id="n_chart000",
+                prop="data",
+                match={"index": 0},
+                partial={"x": 1},
+            )
+        wrapper.assert_awaited_once_with("p1", "n_chart000", "data", {"index": 0}, {"x": 1})
+        assert result["ok"] is True
+        assert capture["ops"] == [
+            {
+                "op": "set_prop_array_item",
+                "args": {"node_id": "n_chart000", "prop": "data", "match": {"index": 0}},
+            }
+        ]
+
+    async def test_append_prop_array_item_tool_invokes_wrapper(self) -> None:
+        from pocketpaw_ee.agent.pocket_specialist import tools
+
+        capture: dict = {}
+        tool = tools.make_append_prop_array_item_tool(pocket_id="p1", capture=capture)
+        with patch(
+            "pocketpaw_ee.cloud.pockets.agent_context.append_prop_array_item_for_agent",
+            new_callable=AsyncMock,
+        ) as wrapper:
+            wrapper.return_value = {"ok": True, "item_index": 3, "item": {"x": 9}}
+            result = await tool.coroutine(
+                node_id="n_chart000",
+                prop="data",
+                value={"x": 9},
+                after={"id": "row_b"},
+            )
+        wrapper.assert_awaited_once_with("p1", "n_chart000", "data", {"x": 9}, {"id": "row_b"})
+        assert result["ok"] is True
+        assert capture["ops"] == [
+            {
+                "op": "append_prop_array_item",
+                "args": {"node_id": "n_chart000", "prop": "data", "after": {"id": "row_b"}},
+            }
+        ]
+
+    async def test_remove_prop_array_item_tool_invokes_wrapper(self) -> None:
+        from pocketpaw_ee.agent.pocket_specialist import tools
+
+        capture: dict = {}
+        tool = tools.make_remove_prop_array_item_tool(pocket_id="p1", capture=capture)
+        with patch(
+            "pocketpaw_ee.cloud.pockets.agent_context.remove_prop_array_item_for_agent",
+            new_callable=AsyncMock,
+        ) as wrapper:
+            wrapper.return_value = {"ok": True, "item_index": 2, "old_item": {"x": 5}}
+            result = await tool.coroutine(
+                node_id="n_chart000",
+                prop="data",
+                match={"by_field": "label", "equals": "X"},
+            )
+        wrapper.assert_awaited_once_with(
+            "p1", "n_chart000", "data", {"by_field": "label", "equals": "X"}
+        )
+        assert result["ok"] is True
+        assert capture["ops"] == [
+            {
+                "op": "remove_prop_array_item",
+                "args": {
+                    "node_id": "n_chart000",
+                    "prop": "data",
+                    "match": {"by_field": "label", "equals": "X"},
+                },
+            }
+        ]
+
+
+def test_edit_tool_bundle_includes_prop_array_item_tools():
+    from pocketpaw_ee.agent.pocket_specialist import tools
+
+    bundle = tools.make_edit_pocket_tools(pocket_id="p1")
+    names = {t.name for t in bundle}
+    assert "set_prop_array_item" in names
+    assert "append_prop_array_item" in names
+    assert "remove_prop_array_item" in names
 
 
 class TestRunEditSpecialistSuccessFlag:


### PR DESCRIPTION
Reworks #1106 onto the current `ee` layout. The original PR was opened against `ee` before the OSS-EE split landed, so it targeted dead paths (`ee.*`, `ee/ripple/`) and showed CONFLICTING. The content was genuinely unmerged net-new work — this transplants it onto `pocketpaw_ee.*` / `src/pocketpaw/ripple/`.

Stacked on #1158 (`feat/bundled-assets-autoinstall`) — that PR also touches `_pockets.py` and `_design.py`, so this branches off it rather than `ee`. Review and merge #1158 first.

## What landed

**Tier-2 array-item edit ops** (the whole half — all net-new, nothing on `ee` did this):

- `prop_arrays.py` — closed `(widget_type, prop)` allowlist. A typo like `set_prop_array_item target=stat prop=value` is rejected up front instead of silently mangling a scalar prop.
- `match_array_item` / `match_array_item_candidates` in `spec_ops.py` — locate one item by `index`, `id`, `by_field`, or `by_key`. The candidates helper surfaces ambiguity so the service layer can refuse an ambiguous match with a candidate list.
- `agent_set_prop_array_item` / `agent_append_prop_array_item` / `agent_remove_prop_array_item` service functions — locked to the allowlist, hold `_pocket_lock`, return `(result, error)` tuples, emit `PocketUpdated`.
- `set/append/remove_prop_array_item_for_agent` wrappers in `agent_context.py` and three `StructuredTool` factories, all wired into the edit-specialist tool bundle.

Why it matters: the existing `set_node_prop` takes the whole array wholesale, so editing one row of a 50-row table meant the LLM re-emitting all 50 rows — and any copy mistake silently drifts the untouched rows. These ops change exactly the item you target.

**Design-prompt changes** (only the parts not already superseded by #1104/#1107):

- `WIDGET_SHAPES` — `CANONICAL_SHAPES` refactored from a monolithic string into a per-widget dict, so the inline `widget_help` tool and the create specialist can pull one widget's shape instead of the full ~10k-char blob. `CANONICAL_SHAPES` stays exported as the joined string for existing callers.
- `widget_help()` is now a two-tier lookup — per-widget `WIDGET_SHAPES` first, section search second, with the interactive-state rule always appended.
- A ground-truth / do-not-mock rule prepended to the inline Ripple system prompt.
- The create specialist gets the slim `_RIPPLE_DESIGN_ESSENTIALS` (~39k chars) instead of the full `RIPPLE_DESIGN_RULES` superblock (~54k).

Nothing from #1104's anti-dashboard rebalance or #1107's widget-catalog widening was re-applied — those are already on `ee`.

## On the `pocket`-required schema change

#1106 also made `pocket` a required field in the edit MCP tool schema. I did **not** apply that, and here is the caller evidence behind the call:

The current `ee` `_pockets.py` chat-agent prompt documents a "Type A" edit path that delegates with **intent only, no `pocket`** for self-contained state edits ("mark task 1 as done"). The edit specialist on `ee` supports that path — `_build_edit_user_message` tells it to "Read the pocket first with get_pocket" when no payload is passed, and `make_edit_pocket_tools` includes a `get_pocket` read tool.

The schema-required change, the fail-fast guard in `runtime.py`, and #1106's removal of `get_pocket` from the bundle are a coupled trio: together they make the specialist a one-shot edit with no read tool. But that only works if the chat-agent prompt is also rewritten to always pass `pocket` — and that prompt rewrite (`_pockets.py` delegation blocks + the `_EDIT_SPECIALIST_RULES` block) is a deep prompt-architecture change outside this PR's scope. Shipping the schema change without it would break the live Type A intent-only flow.

So this PR keeps `pocket` optional, keeps `get_pocket` in the edit bundle, and does not add the `runtime.py` fail-fast guard (which would also break Type A). The full one-shot-edit redesign — schema-required + runtime guard + `get_pocket` removal + the matched chat-agent prompt rewrite — should ship together as a follow-up. Flagging for a captain call: if you want the one-shot redesign now, it's a separate focused PR.

## Tests

`uv run pytest tests/ -k "prop_array or spec_ops or pocket_granular or pocket_specialist or edit"` — 153 passed, 1 skipped.

Wider affected scope (pockets / ripple / pocket_specialist): 239 passed. Three pre-existing failures on the base branch (`test_pocket_prompt_state_sources`, `test_agent_service_tools_context`) are unrelated — confirmed failing on `feat/bundled-assets-autoinstall` without these changes. The known `test_frontend_syntax.py::test_app_returns_object` failure is also unrelated.

New coverage: allowlist unit tests, matcher unit tests (index/id/by_field/by_key, ambiguity, range errors), service-layer integration tests for all three ops including a canary that a one-row edit leaves the other rows untouched, and tool-factory wiring tests.

`WIDGET_SHAPES` was checked against the current 150-widget catalog — #1107 widened the catalog list but never expanded `CANONICAL_SHAPES`, so the seven detailed shapes are byte-identical to `ee`. No widget reconciliation was needed.

Closes #1106
