### PR TITLE
feat(planner): promote success_criteria and preconditions to first-class TaskSpec fields

### DIFF
--- a/docs/advanced/deep-work.mdx
+++ b/docs/advanced/deep-work.mdx
@@ -85,6 +85,8 @@ Decomposes the PRD into atomic tasks. Each task includes:
 | `blocked_by_keys` | Dependencies on other tasks |
 | `max_retries` | How many times to auto-retry on failure (default: 1) |
 | `timeout_minutes` | Per-task execution time limit (optional) |
+| `success_criteria` | Objectively-verifiable conditions that must hold once the task is done — each a single concrete, checkable statement. Carried onto the materialized Mission Control Task so completion can be verified, not just marked finished. |
+| `preconditions` | State or environment conditions that must hold before the task starts (or conditions under which it should not run). Distinct from `blocked_by_keys`, which tracks dependencies on other tasks. |
 
 ### 4. Team Assembly
 

--- a/ee/pocketpaw_ee/cloud/models/task.py
+++ b/ee/pocketpaw_ee/cloud/models/task.py
@@ -10,6 +10,11 @@
 #   added ``blocked_by: list[str]`` carrying cloud Task ids this task
 #   depends on. No migration script — Mongo absorbs the new field on
 #   next write; reads of old docs default to ``[]``.
+# Updated: 2026-05-21 (feat/taskspec-success-criteria) — added
+#   ``success_criteria`` and ``preconditions`` (list[str], default
+#   empty) carrying the planner's machine-verifiable criteria. No
+#   migration — Mongo absorbs them on next write; old docs read back as
+#   ``[]``. Unblocks completion-time verification (pocketpaw#1162).
 """Task document — Mission Control work-item primitive.
 
 Embedded sub-documents:
@@ -103,6 +108,15 @@ class Task(TimestampedDocument):
     # workspace ids are already filtered out by the tenant guard on every
     # service write.
     blocked_by: list[str] = Field(default_factory=list)
+
+    # Machine-verifiable criteria carried from the planner's TaskSpec.
+    # ``success_criteria`` — objectively-checkable conditions true once
+    # the task is done; ``preconditions`` — state/environment conditions
+    # that must hold before it starts. Distinct from ``blocked_by``,
+    # which is the inter-task dependency graph. Read by completion-time
+    # verification (pocketpaw#1162). Old docs read back as ``[]``.
+    success_criteria: list[str] = Field(default_factory=list)
+    preconditions: list[str] = Field(default_factory=list)
 
     due_at: datetime | None = None
     blocked_reason: str | None = None

--- a/ee/pocketpaw_ee/cloud/planner/service.py
+++ b/ee/pocketpaw_ee/cloud/planner/service.py
@@ -24,6 +24,11 @@
 #   ee/cloud Rule 2 forbids any module other than planner.service from
 #   importing ``ee.cloud.models.planner`` — Mission Control consumes
 #   the typed summaries via the public API.
+# Updated: 2026-05-21 (feat/taskspec-success-criteria) —
+#   ``_materialize_tasks`` carries ``success_criteria`` and
+#   ``preconditions`` from each OSS TaskSpec onto the cloud Task it
+#   creates, so completion-time verification (pocketpaw#1162) can read
+#   machine-checkable criteria off the materialized Task.
 """Planner entity — business logic service.
 
 Public API (all module-level ``async def``):
@@ -720,6 +725,12 @@ async def _materialize_tasks(
                 metadata=source_metadata,
             ),
             blocked_by=[],
+            # Machine-verifiable criteria the planner emitted on the
+            # TaskSpec. Carried onto the cloud Task so completion-time
+            # verification (pocketpaw#1162) has them. ``getattr`` keeps
+            # the materializer tolerant of an older TaskSpec shape.
+            success_criteria=list(getattr(spec, "success_criteria", None) or []),
+            preconditions=list(getattr(spec, "preconditions", None) or []),
         )
 
         try:

--- a/ee/pocketpaw_ee/cloud/tasks/domain.py
+++ b/ee/pocketpaw_ee/cloud/tasks/domain.py
@@ -7,6 +7,11 @@
 #   added the ``blocked_by`` field carrying cloud Task ids this task
 #   depends on. Tuple stays read-only on the frozen dataclass; the
 #   service writes it via ``agent_create_task`` + ``agent_update_task``.
+# Updated: 2026-05-21 (feat/taskspec-success-criteria) — added
+#   ``success_criteria`` and ``preconditions`` tuples carrying the
+#   machine-verifiable criteria the planner emits on each TaskSpec.
+#   Read-only on the frozen dataclass; the service maps them from the
+#   Beanie doc. Unblocks completion-time verification (pocketpaw#1162).
 """Domain value objects for the Tasks entity.
 
 Pure-Python frozen dataclasses. ``tasks/service.py`` owns the
@@ -97,6 +102,8 @@ class Task:
     cycle_id: str | None = None
     project_id: str | None = None
     blocked_by: tuple[str, ...] = ()
+    success_criteria: tuple[str, ...] = ()
+    preconditions: tuple[str, ...] = ()
     due_at: datetime | None = None
     blocked_reason: str | None = None
     created_at: datetime | None = None

--- a/ee/pocketpaw_ee/cloud/tasks/dto.py
+++ b/ee/pocketpaw_ee/cloud/tasks/dto.py
@@ -13,6 +13,9 @@
 #   to CreateTaskRequest and TaskResponse. The planner's materializer
 #   carries them from the OSS TaskSpec so completion-time verification
 #   (pocketpaw#1162) can read machine-checkable criteria off the Task.
+# Updated: 2026-05-21 (PR #1164 review) — bounded the CreateTaskRequest
+#   success_criteria / preconditions lists at max_length=20 so a
+#   hallucinating planner LLM can't write a runaway list.
 """Tasks entity — request/response DTOs."""
 
 from __future__ import annotations
@@ -77,8 +80,8 @@ class CreateTaskRequest(BaseModel):
     cycle_id: str | None = None
     project_id: str | None = None
     blocked_by: list[str] = Field(default_factory=list)
-    success_criteria: list[str] = Field(default_factory=list)
-    preconditions: list[str] = Field(default_factory=list)
+    success_criteria: list[str] = Field(default_factory=list, max_length=20)
+    preconditions: list[str] = Field(default_factory=list, max_length=20)
     priority: Literal["low", "normal", "high", "urgent"] = "normal"
     kind: Literal["task", "nudge", "projection", "automation"] = "task"
     source: SourceDTO = Field(default_factory=SourceDTO)

--- a/ee/pocketpaw_ee/cloud/tasks/dto.py
+++ b/ee/pocketpaw_ee/cloud/tasks/dto.py
@@ -8,6 +8,11 @@
 #   TaskResponse. Update semantics distinguish None (no change) from
 #   an explicit empty list (clear dependencies). Domain ↔ wire mapper
 #   threads the field through ``task_to_dto``.
+# Updated: 2026-05-21 (feat/taskspec-success-criteria) — added
+#   ``success_criteria`` and ``preconditions`` (list[str], default empty)
+#   to CreateTaskRequest and TaskResponse. The planner's materializer
+#   carries them from the OSS TaskSpec so completion-time verification
+#   (pocketpaw#1162) can read machine-checkable criteria off the Task.
 """Tasks entity — request/response DTOs."""
 
 from __future__ import annotations
@@ -57,6 +62,12 @@ class CreateTaskRequest(BaseModel):
     planner's two-pass materializer uses it to wire up TaskSpec
     ``blocked_by_keys`` after both endpoints exist; manual callers may
     pass it directly to register a dependency edge at create time.
+
+    ``success_criteria`` and ``preconditions`` are machine-verifiable
+    criteria carried from the OSS planner's TaskSpec — objectively
+    checkable conditions for, respectively, task completion and task
+    start. Both default to an empty list so existing callers are
+    unaffected.
     """
 
     title: str = Field(min_length=1, max_length=200)
@@ -66,6 +77,8 @@ class CreateTaskRequest(BaseModel):
     cycle_id: str | None = None
     project_id: str | None = None
     blocked_by: list[str] = Field(default_factory=list)
+    success_criteria: list[str] = Field(default_factory=list)
+    preconditions: list[str] = Field(default_factory=list)
     priority: Literal["low", "normal", "high", "urgent"] = "normal"
     kind: Literal["task", "nudge", "projection", "automation"] = "task"
     source: SourceDTO = Field(default_factory=SourceDTO)
@@ -181,6 +194,8 @@ class TaskResponse(BaseModel):
     cycle_id: str | None = None
     project_id: str | None = None
     blocked_by: list[str] = Field(default_factory=list)
+    success_criteria: list[str] = Field(default_factory=list)
+    preconditions: list[str] = Field(default_factory=list)
     due_at: str | None = None
     blocked_reason: str | None = None
     created_at: str | None = None
@@ -218,6 +233,8 @@ def task_to_dto(task: Task) -> TaskResponse:
         cycle_id=task.cycle_id,
         project_id=task.project_id,
         blocked_by=list(task.blocked_by),
+        success_criteria=list(task.success_criteria),
+        preconditions=list(task.preconditions),
         due_at=iso_utc(task.due_at),
         blocked_reason=task.blocked_reason,
         created_at=iso_utc(task.created_at),

--- a/ee/pocketpaw_ee/cloud/tasks/service.py
+++ b/ee/pocketpaw_ee/cloud/tasks/service.py
@@ -21,6 +21,11 @@
 #   explicit clear, [...] = replace). Domain mapper threads the field
 #   through ``_to_domain`` so projectors (Mission Control's WorkItem)
 #   pick it up automatically.
+# Updated: 2026-05-21 (feat/taskspec-success-criteria) —
+#   ``agent_create_task`` persists ``success_criteria`` and
+#   ``preconditions`` from the request; ``_to_domain`` threads them
+#   through so completion-time verification (pocketpaw#1162) can read
+#   them off the Task.
 """Tasks entity — business logic service.
 
 Public API (all module-level ``async def``):
@@ -110,6 +115,8 @@ def _to_domain(doc: _TaskDoc) -> Task:
         cycle_id=doc.cycle_id,
         project_id=getattr(doc, "project_id", None),
         blocked_by=tuple(getattr(doc, "blocked_by", None) or ()),
+        success_criteria=tuple(getattr(doc, "success_criteria", None) or ()),
+        preconditions=tuple(getattr(doc, "preconditions", None) or ()),
         due_at=doc.due_at,
         blocked_reason=doc.blocked_reason,
         created_at=getattr(doc, "createdAt", None),
@@ -204,6 +211,8 @@ async def agent_create_task(ctx: RequestContext, body: CreateTaskRequest) -> Tas
             metadata=dict(body.source.metadata or {}),
         ),
         blocked_by=list(body.blocked_by or []),
+        success_criteria=list(body.success_criteria or []),
+        preconditions=list(body.preconditions or []),
         due_at=body.due_at,
     )
     await doc.insert()

--- a/ee/pocketpaw_ee/cloud/tasks/service.py
+++ b/ee/pocketpaw_ee/cloud/tasks/service.py
@@ -26,6 +26,9 @@
 #   ``preconditions`` from the request; ``_to_domain`` threads them
 #   through so completion-time verification (pocketpaw#1162) can read
 #   them off the Task.
+# Updated: 2026-05-21 (PR #1164 review) — documented in
+#   ``agent_update_task`` that success_criteria / preconditions are
+#   intentionally not patchable (planner-set, not ad-hoc editable).
 """Tasks entity — business logic service.
 
 Public API (all module-level ``async def``):
@@ -309,6 +312,11 @@ async def agent_update_task(
         doc.blocked_by = list(body.blocked_by)
     if body.due_at is not None:
         doc.due_at = body.due_at
+
+    # success_criteria / preconditions are deliberately NOT patchable
+    # here: they are planner-set at materialization time (the verifiable
+    # contract for the task) and should not drift via ad-hoc edits.
+    # UpdateTaskRequest omits them on purpose — not an oversight.
 
     await doc.save()
     task = _to_domain(doc)

--- a/src/pocketpaw/deep_work/models.py
+++ b/src/pocketpaw/deep_work/models.py
@@ -9,6 +9,11 @@
 #   task starts). Both default to empty list — to_dict/from_dict stay
 #   backward-compatible with TaskSpec data persisted before this change.
 #   Unblocks the Verification primitive (pocketpaw#1162).
+# Updated: 2026-05-21 (PR #1164 review) — TaskSpec.from_dict now coerces
+#   success_criteria / preconditions items to str and drops None entries,
+#   so non-string LLM output deserializes cleanly. Reworded the
+#   description docstring: criteria live in success_criteria now, not in
+#   the freeform description string.
 #
 # Defines data structures for:
 # - Project: top-level orchestration unit grouping tasks and agents
@@ -139,7 +144,8 @@ class TaskSpec:
     Attributes:
         key: Short unique key within the project (e.g., "research-competitors")
         title: Human-readable task title
-        description: Full task description and acceptance criteria
+        description: Full task description — freeform context and approach.
+            Verifiable criteria live in ``success_criteria``, not here.
         task_type: "agent" | "human" | "review"
         priority: "low" | "medium" | "high" | "urgent"
         tags: Categorization tags
@@ -199,6 +205,8 @@ class TaskSpec:
         ``success_criteria`` and ``preconditions`` default to ``[]`` when
         absent, so TaskSpec data serialized before those fields existed
         (and LLM output that omits them) deserializes without error.
+        Their items are coerced to ``str`` (and ``None`` entries dropped)
+        because LLM output occasionally emits non-string list items.
         """
         return cls(
             key=data.get("key", ""),
@@ -212,8 +220,8 @@ class TaskSpec:
             blocked_by_keys=data.get("blocked_by_keys", []),
             max_retries=data.get("max_retries", 1),
             timeout_minutes=data.get("timeout_minutes"),
-            success_criteria=data.get("success_criteria", []),
-            preconditions=data.get("preconditions", []),
+            success_criteria=[str(v) for v in data.get("success_criteria", []) if v is not None],
+            preconditions=[str(v) for v in data.get("preconditions", []) if v is not None],
         )
 
 

--- a/src/pocketpaw/deep_work/models.py
+++ b/src/pocketpaw/deep_work/models.py
@@ -2,6 +2,13 @@
 # Created: 2026-02-12
 # Updated: 2026-02-26 — Deep Work v2: Added CANCELLED status to ProjectStatus.
 #   Added max_retries and timeout_minutes to TaskSpec for retry/timeout control.
+# Updated: 2026-05-21 (feat/taskspec-success-criteria) — promoted machine-
+#   verifiable criteria to first-class TaskSpec fields: success_criteria
+#   (objectively-verifiable conditions true at task completion) and
+#   preconditions (state/environment conditions that must hold before the
+#   task starts). Both default to empty list — to_dict/from_dict stay
+#   backward-compatible with TaskSpec data persisted before this change.
+#   Unblocks the Verification primitive (pocketpaw#1162).
 #
 # Defines data structures for:
 # - Project: top-level orchestration unit grouping tasks and agents
@@ -141,6 +148,16 @@ class TaskSpec:
         blocked_by_keys: Keys of other TaskSpecs this depends on
         max_retries: Maximum auto-retries for failed tasks (Deep Work v2)
         timeout_minutes: Per-task execution timeout in minutes (Deep Work v2)
+        success_criteria: Objectively-verifiable conditions that must be
+            true once the task is complete. Each entry is a single
+            concrete, checkable statement (not a vague "works as
+            expected"). Promoted from the freeform ``description`` so a
+            downstream verifier can check completion programmatically.
+        preconditions: State/environment conditions that must hold before
+            the task can start — including when NOT to act. Distinct from
+            ``blocked_by_keys``: that field is the inter-task dependency
+            graph (other TaskSpecs), whereas these are conditions about
+            the world (e.g. "a workspace API key is configured").
     """
 
     key: str = ""
@@ -154,6 +171,8 @@ class TaskSpec:
     blocked_by_keys: list[str] = field(default_factory=list)
     max_retries: int = 1
     timeout_minutes: int | None = None
+    success_criteria: list[str] = field(default_factory=list)
+    preconditions: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
@@ -169,11 +188,18 @@ class TaskSpec:
             "blocked_by_keys": self.blocked_by_keys,
             "max_retries": self.max_retries,
             "timeout_minutes": self.timeout_minutes,
+            "success_criteria": self.success_criteria,
+            "preconditions": self.preconditions,
         }
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "TaskSpec":
-        """Create from dictionary."""
+        """Create from dictionary.
+
+        ``success_criteria`` and ``preconditions`` default to ``[]`` when
+        absent, so TaskSpec data serialized before those fields existed
+        (and LLM output that omits them) deserializes without error.
+        """
         return cls(
             key=data.get("key", ""),
             title=data.get("title", ""),
@@ -186,6 +212,8 @@ class TaskSpec:
             blocked_by_keys=data.get("blocked_by_keys", []),
             max_retries=data.get("max_retries", 1),
             timeout_minutes=data.get("timeout_minutes"),
+            success_criteria=data.get("success_criteria", []),
+            preconditions=data.get("preconditions", []),
         )
 
 

--- a/src/pocketpaw/deep_work/prompts.py
+++ b/src/pocketpaw/deep_work/prompts.py
@@ -4,6 +4,11 @@
 #   (domain detection, complexity estimation, clarification questions).
 # Updated: 2026-02-12 — Added RESEARCH_PROMPT_QUICK and RESEARCH_PROMPT_DEEP
 #   for configurable research depth.
+# Updated: 2026-05-21 (feat/taskspec-success-criteria) — TASK_BREAKDOWN_PROMPT
+#   now instructs the planner to emit machine-verifiable success_criteria
+#   and preconditions per task, with explicit discipline: criteria must be
+#   objectively checkable (no "works as expected" / "should work
+#   correctly"). Feeds the new first-class TaskSpec fields.
 #
 # Prompt templates:
 #   GOAL_PARSE_PROMPT — structured goal analysis (domain, complexity, roles)
@@ -169,6 +174,26 @@ or access to external systems that an AI agent cannot reach
 - Use short keys like "t1", "t2", etc.
 - Keep estimated_minutes realistic (15-120 range for most tasks)
 
+SUCCESS CRITERIA — every task MUST have a "success_criteria" array:
+- Each entry is ONE concrete, objectively-verifiable statement that is true \
+once the task is done. Someone who did not do the work must be able to check \
+it without judgement calls.
+- BANNED — never write vague criteria like "works as expected", "should work \
+correctly", "is high quality", "looks good", or "is done properly". These \
+cannot be verified and will be rejected.
+- GOOD examples: "GET /health returns HTTP 200 with body {{\\"status\\":\\"ok\\"}}", \
+"the invoice CSV has one row per overdue account", "pytest tests/ exits 0".
+- Give 1-4 criteria per task — enough to confirm the deliverable, no filler.
+
+PRECONDITIONS — every task MUST have a "preconditions" array:
+- Each entry is ONE state/environment condition that must hold BEFORE the task \
+can start, OR a condition under which the task should NOT run.
+- These are conditions about the world — NOT dependencies on other tasks \
+(those go in blocked_by_keys). Example preconditions: "a Postgres database \
+is reachable", "the customer list has been uploaded to the workspace", \
+"do not run if no invoices are overdue".
+- Use an empty array [] when a task genuinely has no preconditions.
+
 Output ONLY a valid JSON array. No markdown code fences. No commentary. \
 Just the raw JSON array:
 
@@ -182,7 +207,9 @@ Just the raw JSON array:
     "tags": ["..."],
     "estimated_minutes": 30,
     "required_specialties": ["..."],
-    "blocked_by_keys": []
+    "blocked_by_keys": [],
+    "success_criteria": ["concrete verifiable statement", "..."],
+    "preconditions": ["concrete state condition", "..."]
   }}
 ]
 """

--- a/src/pocketpaw/deep_work/prompts.py
+++ b/src/pocketpaw/deep_work/prompts.py
@@ -9,6 +9,9 @@
 #   and preconditions per task, with explicit discipline: criteria must be
 #   objectively checkable (no "works as expected" / "should work
 #   correctly"). Feeds the new first-class TaskSpec fields.
+# Updated: 2026-05-21 (PR #1164 review) — TASK_BREAKDOWN_PROMPT JSON
+#   example no longer says the description holds "acceptance criteria";
+#   criteria belong in the dedicated success_criteria array.
 #
 # Prompt templates:
 #   GOAL_PARSE_PROMPT — structured goal analysis (domain, complexity, roles)
@@ -201,7 +204,7 @@ Just the raw JSON array:
   {{
     "key": "t1",
     "title": "...",
-    "description": "... with acceptance criteria",
+    "description": "freeform context and approach for this task",
     "task_type": "agent",
     "priority": "medium",
     "tags": ["..."],

--- a/tests/cloud/test_planner_service.py
+++ b/tests/cloud/test_planner_service.py
@@ -3,6 +3,10 @@
 #   *materialization* layer — the OSS planner itself has its own test
 #   suite under ``tests/test_deep_work_planner.py`` and we should not
 #   re-test it here.
+# Updated: 2026-05-21 (feat/taskspec-success-criteria) — ``_FakeTaskSpec``
+#   gained ``success_criteria`` / ``preconditions`` and a new test
+#   asserts ``_materialize_tasks`` carries them from the TaskSpec onto
+#   the materialized cloud Task (read back via the tasks service).
 """Tests for ``ee.cloud.planner.service`` — happy path + agent-gap +
 tenant guard.
 
@@ -61,6 +65,8 @@ class _FakeTaskSpec:
         task_type: str = "agent",
         priority: str = "high",
         required_specialties: list[str] | None = None,
+        success_criteria: list[str] | None = None,
+        preconditions: list[str] | None = None,
     ) -> None:
         self.key = key
         self.title = title
@@ -69,6 +75,8 @@ class _FakeTaskSpec:
         self.priority = priority
         self.required_specialties = required_specialties or []
         self.blocked_by_keys: list[str] = []
+        self.success_criteria = success_criteria or []
+        self.preconditions = preconditions or []
 
     def to_dict(self) -> dict:
         return {
@@ -207,6 +215,73 @@ async def test_plan_project_writes_files_and_creates_tasks(recording_bus) -> Non
     assert plan_events[0].data["project_id"] == project_id
     assert plan_events[0].data["task_count"] == 2
     assert plan_events[0].data["agent_gap_count"] == 1
+
+
+async def test_plan_project_carries_success_criteria_onto_cloud_tasks(
+    recording_bus,
+) -> None:
+    """Materialization threads TaskSpec success_criteria / preconditions
+    onto the cloud Task so completion-time verification (#1162) can read
+    them back."""
+    from pocketpaw_ee.cloud.tasks import service as tasks_service
+    from pocketpaw_ee.cloud.tasks.dto import ListTasksRequest
+
+    project_id = await _make_project()
+    fake = _FakePlannerResult(
+        tasks=[
+            _FakeTaskSpec(
+                key="research",
+                title="Research vendors",
+                success_criteria=[
+                    "at least 3 vendors are shortlisted",
+                    "each vendor has a quoted price",
+                ],
+                preconditions=["the vendor category has been chosen"],
+            ),
+        ],
+    )
+
+    with _patched_planner(fake):
+        result = await planner_service.agent_plan_project(
+            _ctx(),
+            PlanProjectRequest(
+                project_id=project_id,
+                goal="Find catering vendors.",
+                deep_research=False,
+            ),
+        )
+
+    assert len(result.task_ids) == 1
+    tasks = await tasks_service.agent_list_tasks(_ctx(), ListTasksRequest(project_id=project_id))
+    assert len(tasks) == 1
+    assert tasks[0].success_criteria == [
+        "at least 3 vendors are shortlisted",
+        "each vendor has a quoted price",
+    ]
+    assert tasks[0].preconditions == ["the vendor category has been chosen"]
+
+
+async def test_plan_project_defaults_empty_criteria_when_planner_omits_them(
+    recording_bus,
+) -> None:
+    """A TaskSpec with no criteria materializes a Task with empty lists —
+    backward-compatible with planner output predating the fields."""
+    from pocketpaw_ee.cloud.tasks import service as tasks_service
+    from pocketpaw_ee.cloud.tasks.dto import ListTasksRequest
+
+    project_id = await _make_project()
+    fake = _FakePlannerResult(tasks=[_FakeTaskSpec(key="t1", title="Bare task")])
+
+    with _patched_planner(fake):
+        await planner_service.agent_plan_project(
+            _ctx(),
+            PlanProjectRequest(project_id=project_id, goal="Do a thing.", deep_research=False),
+        )
+
+    tasks = await tasks_service.agent_list_tasks(_ctx(), ListTasksRequest(project_id=project_id))
+    assert len(tasks) == 1
+    assert tasks[0].success_criteria == []
+    assert tasks[0].preconditions == []
 
 
 async def test_plan_project_surfaces_agent_gaps(recording_bus) -> None:

--- a/tests/cloud/test_tasks_success_criteria.py
+++ b/tests/cloud/test_tasks_success_criteria.py
@@ -1,0 +1,87 @@
+# Created: 2026-05-21 — feat/taskspec-success-criteria. Tests for the
+#   Tasks ``success_criteria`` / ``preconditions`` fields: create
+#   persists them, omitting them defaults to an empty list, and they
+#   round-trip through a subsequent get. These machine-verifiable
+#   criteria are what completion-time verification (pocketpaw#1162)
+#   reads off the Task.
+"""Tasks ``success_criteria`` / ``preconditions`` — create + round-trip."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.tasks import service as tasks_service
+from pocketpaw_ee.cloud.tasks.dto import AssigneeDTO, CreateTaskRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(*, user_id: str = "u-creator", workspace_id: str = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r-sc",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _human_assignee() -> AssigneeDTO:
+    return AssigneeDTO(kind="human", id="u-creator", name="Creator")
+
+
+async def test_create_with_criteria_persists_and_round_trips() -> None:
+    """Both fields set on create come back on the response and on a
+    subsequent get."""
+
+    body = CreateTaskRequest(
+        title="Build the health endpoint",
+        assignee=_human_assignee(),
+        success_criteria=[
+            "GET /health returns HTTP 200",
+            'the body is {"status":"ok"}',
+        ],
+        preconditions=["the FastAPI app is scaffolded"],
+    )
+    resp = await tasks_service.agent_create_task(_ctx(), body)
+    assert resp.success_criteria == [
+        "GET /health returns HTTP 200",
+        'the body is {"status":"ok"}',
+    ]
+    assert resp.preconditions == ["the FastAPI app is scaffolded"]
+
+    fetched = await tasks_service.agent_get_task(_ctx(), resp.id)
+    assert fetched.success_criteria == [
+        "GET /health returns HTTP 200",
+        'the body is {"status":"ok"}',
+    ]
+    assert fetched.preconditions == ["the FastAPI app is scaffolded"]
+
+
+async def test_create_without_criteria_defaults_to_empty() -> None:
+    """Fields omitted on create → empty lists, not None. This is the
+    backward-compatible path for callers predating the fields."""
+
+    body = CreateTaskRequest(title="Standalone", assignee=_human_assignee())
+    resp = await tasks_service.agent_create_task(_ctx(), body)
+    assert resp.success_criteria == []
+    assert resp.preconditions == []
+
+    fetched = await tasks_service.agent_get_task(_ctx(), resp.id)
+    assert fetched.success_criteria == []
+    assert fetched.preconditions == []
+
+
+async def test_success_criteria_independent_of_preconditions() -> None:
+    """Setting one field does not bleed into the other."""
+
+    body = CreateTaskRequest(
+        title="Chase overdue invoices",
+        assignee=_human_assignee(),
+        success_criteria=["one reminder email per overdue account is sent"],
+    )
+    resp = await tasks_service.agent_create_task(_ctx(), body)
+    assert resp.success_criteria == ["one reminder email per overdue account is sent"]
+    assert resp.preconditions == []

--- a/tests/test_deep_work_planner.py
+++ b/tests/test_deep_work_planner.py
@@ -8,6 +8,9 @@
 #   fields: the planner parses success_criteria / preconditions from LLM
 #   JSON, omitting them defaults cleanly to [], and the prompt instructs
 #   the planner to emit them.
+# Updated: 2026-05-21 (PR #1164 review) — added a from_dict coercion
+#   test: non-string list items are coerced to str and None entries
+#   dropped.
 #
 # Tests cover:
 #   - Prompt template placeholders
@@ -280,6 +283,25 @@ class TestTaskSpecSuccessCriteria:
         task = TaskSpec.from_dict(old_data)
         assert task.success_criteria == []
         assert task.preconditions == []
+
+    def test_from_dict_coerces_non_string_items(self):
+        """LLM output occasionally puts non-string items in the lists.
+
+        from_dict must coerce each item to str and drop None entries so a
+        downstream verifier always gets a clean list[str].
+        """
+        data = {
+            "key": "t1",
+            "title": "Task",
+            "success_criteria": ["a real criterion", 42, True, None, 3.5],
+            "preconditions": [None, "state X", 0],
+        }
+        task = TaskSpec.from_dict(data)
+        assert task.success_criteria == ["a real criterion", "42", "True", "3.5"]
+        assert task.preconditions == ["state X", "0"]
+        # Every surviving item is a plain str.
+        assert all(isinstance(c, str) for c in task.success_criteria)
+        assert all(isinstance(p, str) for p in task.preconditions)
 
     def test_default_taskspec_has_empty_criteria(self):
         """A bare TaskSpec() defaults both fields to empty list."""

--- a/tests/test_deep_work_planner.py
+++ b/tests/test_deep_work_planner.py
@@ -3,6 +3,11 @@
 # Updated: 2026-02-16 — Added TestRunPromptErrorHandling to reproduce silent
 #   error swallowing in _run_prompt(). When the LLM returns only error events,
 #   _run_prompt should raise instead of returning an empty string.
+# Updated: 2026-05-21 (feat/taskspec-success-criteria) — added
+#   TestTaskSpecSuccessCriteria covering the new first-class TaskSpec
+#   fields: the planner parses success_criteria / preconditions from LLM
+#   JSON, omitting them defaults cleanly to [], and the prompt instructs
+#   the planner to emit them.
 #
 # Tests cover:
 #   - Prompt template placeholders
@@ -11,6 +16,7 @@
 #   - ensure_profile (mocked manager)
 #   - _broadcast_phase resilience
 #   - _run_prompt error event handling (bug reproduction)
+#   - TaskSpec success_criteria / preconditions parsing + defaults
 
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -204,6 +210,90 @@ class TestParseTasksInvalid:
     def test_json_with_non_dict_items(self):
         tasks = self.planner._parse_tasks('[1, 2, "string"]')
         assert tasks == []
+
+
+class TestTaskSpecSuccessCriteria:
+    """The planner parses success_criteria / preconditions off LLM JSON.
+
+    Promoted to first-class TaskSpec fields (feat/taskspec-success-criteria)
+    so a downstream verifier can check completion programmatically instead
+    of scraping the freeform description string.
+    """
+
+    def setup_method(self):
+        manager = MagicMock()
+        self.planner = PlannerAgent(manager)
+
+    def test_parses_success_criteria_and_preconditions(self):
+        """A task carrying both fields round-trips into the TaskSpec."""
+        raw = json.dumps(
+            [
+                {
+                    "key": "t1",
+                    "title": "Build the health endpoint",
+                    "description": "Add GET /health",
+                    "task_type": "agent",
+                    "success_criteria": [
+                        "GET /health returns HTTP 200",
+                        'the response body is {"status":"ok"}',
+                    ],
+                    "preconditions": ["the FastAPI app is scaffolded"],
+                }
+            ]
+        )
+        tasks = self.planner._parse_tasks(raw)
+        assert len(tasks) == 1
+        assert isinstance(tasks[0], TaskSpec)
+        assert tasks[0].success_criteria == [
+            "GET /health returns HTTP 200",
+            'the response body is {"status":"ok"}',
+        ]
+        assert tasks[0].preconditions == ["the FastAPI app is scaffolded"]
+
+    def test_absent_fields_default_to_empty_list(self):
+        """LLM output that omits the new fields must not hard-fail.
+
+        ``VALID_TASKS_JSON`` deliberately has no success_criteria /
+        preconditions keys — they should default cleanly to ``[]``.
+        """
+        tasks = self.planner._parse_tasks(VALID_TASKS_JSON)
+        assert len(tasks) == 2
+        for task in tasks:
+            assert task.success_criteria == []
+            assert task.preconditions == []
+
+    def test_taskspec_round_trips_new_fields(self):
+        """to_dict / from_dict preserve the new fields."""
+        original = TaskSpec(
+            key="t1",
+            title="Task",
+            success_criteria=["criterion A", "criterion B"],
+            preconditions=["state X holds"],
+        )
+        restored = TaskSpec.from_dict(original.to_dict())
+        assert restored.success_criteria == ["criterion A", "criterion B"]
+        assert restored.preconditions == ["state X holds"]
+
+    def test_from_dict_backward_compat_without_new_fields(self):
+        """A dict serialized before these fields existed still parses."""
+        old_data = {"key": "t1", "title": "Legacy task", "task_type": "agent"}
+        task = TaskSpec.from_dict(old_data)
+        assert task.success_criteria == []
+        assert task.preconditions == []
+
+    def test_default_taskspec_has_empty_criteria(self):
+        """A bare TaskSpec() defaults both fields to empty list."""
+        task = TaskSpec()
+        assert task.success_criteria == []
+        assert task.preconditions == []
+
+    def test_breakdown_prompt_instructs_emitting_the_fields(self):
+        """The prompt must tell the planner to emit the new fields and
+        ban vague criteria so the discipline is enforced upstream."""
+        assert "success_criteria" in TASK_BREAKDOWN_PROMPT
+        assert "preconditions" in TASK_BREAKDOWN_PROMPT
+        # Vague-criteria ban — Phalanx learning #4.
+        assert "works as expected" in TASK_BREAKDOWN_PROMPT
 
 
 class TestParseTeam:


### PR DESCRIPTION
## What

Acceptance criteria used to live inside the freeform `TaskSpec.description` string, so nothing downstream could read or check them. This PR turns two checkable fields into real fields on `TaskSpec` and threads them through the layers that need them: the OSS planner, the breakdown prompt, cloud materialization, and the cloud Task model.


## The two fields

- `success_criteria: list[str]` — conditions that must be true once the task is done. Each entry is one concrete, checkable statement.
- `preconditions: list[str]` — conditions about the environment that must hold before the task starts, including cases where it should not run at all.

Both default to an empty list. `to_dict`/`from_dict` and the cloud DTO/model stay backward-compatible: older serialized `TaskSpec` data, LLM output that skips the fields, and Task documents written before this change all parse fine and read back as `[]`.

## Why preconditions is its own field

The brief asked me to check whether `preconditions` is just a duplicate of `blocked_by_keys`. It isn't. `blocked_by_keys` is the task dependency graph — keys of other `TaskSpec`s this one waits on. `preconditions` is about the state of the world: a database is reachable, a file has been uploaded, don't run if nothing is overdue. Issue #1161 lists both separately, so both ship here.

## Layers changed

1. `TaskSpec` (`src/pocketpaw/deep_work/models.py`) — the two fields plus `to_dict`/`from_dict`.
2. `TASK_BREAKDOWN_PROMPT` (`deep_work/prompts.py`) — tells the planner to emit both per task, and bans vague criteria like "works as expected".
3. `planner.py` `_parse_tasks` — no code change; it already builds `TaskSpec` through `from_dict`, which now picks the fields up.
4. Cloud materialization (`ee/.../planner/service.py`) — copies the fields from each `TaskSpec` onto the cloud Task.
5. Cloud Task model, DTO, and domain object — added the fields so they persist and can be queried.

No Mongo migration. The new fields land on the next write; old docs read back as `[]`.

## OSS/EE boundary

Respected. OSS `deep_work` imports no EE code; EE reads the OSS `TaskSpec`. Both import-linter contracts pass (the core OSS-EE boundary and the enterprise Beanie-write contracts).

## Tests

Written TDD. 11 new tests across the OSS planner test module, the cloud planner service test module, and a new `test_tasks_success_criteria.py`. They cover: the planner parses both fields, absence in LLM JSON defaults to `[]`, round-trip, backward-compat with old data, and materialization carrying the fields onto cloud Tasks. All green.

`tests/cloud/tasks/test_tasks_router.py` has 13 failures (`KeyError: 'id'` in the router test harness). Those reproduce identically on a clean `dev` checkout, so they predate this PR and aren't touched by it.

## Docs

Updated the task breakdown table in `docs/advanced/deep-work.mdx` with the two new fields.

## Scope

This advances the `TaskSpec` gap noted in #1161 and unblocks the completion-time verification in #1162. It closes neither — both issues need more than this PR.