### PR TITLE
Surface edit-specialist failures instead of returning silent 0-ops

### DIFF
--- a/ee/pocketpaw_ee/agent/pocket_specialist/mcp_tool.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/mcp_tool.py
@@ -7,6 +7,10 @@ single tool ``create`` accepts ``{brief, hints?}`` and hands off to
 per-stream ``ContextVar`` accessors in ``ee.cloud.chat.agent_service``
 because the in-process MCP channel doesn't reach the FastAPI request
 scope.
+
+Changes: 2026-05-21 (#1163) — updated the ``edit`` tool description to
+document the full response shape, including the new ``warnings`` field
+that carries the specialist's reason when it declines to act.
 """
 
 from __future__ import annotations
@@ -277,7 +281,12 @@ def build_pocket_specialist_server() -> Any:
             "widget appearance, add/move/remove_node for structure), and "
             "applies them. Each op persists and pushes its own SSE event "
             "so the canvas updates in place. Returns "
-            "{ok, pocket_id, ops, duration_ms}."
+            "{ok, pocket_id, ops, duration_ms, backend_used, error, "
+            "warnings}. ok=false with a populated error means the run "
+            "failed — relay the error. ok=true with an empty ops list and "
+            "a populated warnings list means the specialist declined to "
+            "act — relay the warning so the user learns why nothing "
+            "changed; do NOT report success."
         ),
         {
             "type": "object",

--- a/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
@@ -2,6 +2,15 @@
 
 Orchestrates backend selection, tool wiring, event emission, and result
 assembly. Always persists a pocket - see feedback_pocket_always_ships.md.
+
+Changes: 2026-05-21 (#1163) — the edit-specialist stream loop now inspects
+``event.type == "error"`` (the deep_agents backend yields error events
+instead of raising), so a backend failure surfaces as ``ok=False`` with a
+populated ``error`` field instead of a silent ``ok=True, ops=[]``. A
+genuine 0-ops outcome with no error now surfaces the planner's final text
+reply via the new ``PocketSpecialistEditOutput.warnings`` field so the
+caller learns WHY the specialist declined. Added targeted observability
+logging for error events and tool_use-vs-ops counts.
 """
 
 from __future__ import annotations
@@ -498,7 +507,24 @@ class PocketSpecialistEditOutput(BaseModel):
     ops: list[dict[str, Any]] = Field(default_factory=list)
     duration_ms: int
     backend_used: str
-    error: str | None = None
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Set when the specialist run FAILED — backend raised, or the "
+            "deep_agents backend yielded an error event. ``ok`` is False "
+            "whenever this is populated. Distinct from ``warnings``."
+        ),
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Set when the run SUCCEEDED but applied zero ops — the planner "
+            "declined to act (target not found, intent ambiguous, no change "
+            "needed). Carries the planner's final text reply so the caller "
+            "knows WHY. ``ok`` stays True; this is not a failure. A silent "
+            "``ok=True, ops=[]`` with no explanation is the #1163 bug."
+        ),
+    )
 
 
 async def run_edit_specialist(
@@ -575,21 +601,44 @@ async def run_edit_specialist(
         "patch_",
     )
     # success starts False and flips True only after the backend.run
-    # loop completes without exception. Catches the silent-failure mode
-    # where the inner backend errors mid-stream (transport drop, model
-    # 400, etc.) and the caller previously saw ok=True with ops=[].
+    # loop completes without exception AND without an error event.
+    # Catches two silent-failure modes the caller previously saw as
+    # ok=True with ops=[]:
+    #   1. the inner backend raises mid-stream (transport drop, 400)
+    #   2. the deep_agents backend yields AgentEvent(type="error")
+    #      instead of raising — see deep_agents.py:974-977.
     success = False
     error_msg: str | None = None
+    tool_use_count = 0
+    # The planner's running text — used to explain a genuine 0-ops run.
+    final_text_parts: list[str] = []
     try:
         async for event in backend.run(user_message, system_prompt=system_prompt):
+            if event.type == "error":
+                # #1163 root cause A — deep_agents converts internal
+                # failures into error events rather than raising. Capture
+                # the message, mark the run failed, and stop trusting the
+                # clean loop exit.
+                error_msg = str(event.content or "backend emitted an error event")
+                log.warning(
+                    "[pocket-specialist:edit] backend emitted error event: %s",
+                    error_msg,
+                )
+                continue
             if event.type == "tool_use":
+                tool_use_count += 1
                 tool_name = (event.metadata or {}).get("name", "")
                 if tool_name.startswith(_GRANULAR_OP_PREFIXES):
                     # Forward each inner op to the outer chat SSE stream so
                     # the desktop client renders per-op progress (matches
                     # TOOL_LABELS entries in paw-enterprise chat/service.ts).
                     _push_chat_status(tool_name, event.metadata.get("input") or {})
-        success = True
+            elif event.type == "message" and event.content:
+                # Keep the planner's text — it explains a no-op decline.
+                final_text_parts.append(str(event.content))
+        # A clean loop exit only counts as success when no error event
+        # passed through. error_msg is set above for the error-event path.
+        success = error_msg is None
     except Exception as exc:  # noqa: BLE001
         log.warning(
             "[pocket-specialist:edit] backend stream errored: %s: %s",
@@ -598,11 +647,41 @@ async def run_edit_specialist(
             exc_info=True,
         )
         error_msg = f"{type(exc).__name__}: {exc}"
+        success = False
     finally:
         await backend.stop()
 
     duration_ms = int((time.monotonic() - started) * 1000)
     ops = list(ops_capture.get("ops", []))
+
+    # Observability — distinguish "planner declined to act" (tool_use=0)
+    # from "tool called but the service rejected it" (tool_use>0, ops=0).
+    log.info(
+        "[pocket-specialist:edit] planner emitted %d tool_use events, %d granular ops captured",
+        tool_use_count,
+        len(ops),
+    )
+
+    # A successful run that applied zero ops must NOT be a silent ok=True
+    # with no explanation (#1163). Surface the planner's final text reply
+    # in warnings so the caller can tell the user WHY nothing changed.
+    warnings: list[str] = []
+    if success and not ops:
+        reason = "\n".join(p for p in final_text_parts if p.strip()).strip()
+        warnings.append(
+            reason
+            or (
+                "The edit specialist applied no changes and gave no "
+                "reason. The target may not have been found, or the "
+                "intent may not have mapped to a supported edit."
+            )
+        )
+        log.warning(
+            "[pocket-specialist:edit] 0-ops run — surfacing planner reply "
+            "as a warning (pocket_id=%s tool_use=%d)",
+            input.pocket_id,
+            tool_use_count,
+        )
 
     log.info(
         "[pocket-specialist:edit] complete: pocket_id=%s ops=%d success=%s "
@@ -621,4 +700,5 @@ async def run_edit_specialist(
         duration_ms=duration_ms,
         backend_used=backend_name,
         error=error_msg,
+        warnings=warnings,
     )

--- a/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
@@ -9,8 +9,12 @@ instead of raising), so a backend failure surfaces as ``ok=False`` with a
 populated ``error`` field instead of a silent ``ok=True, ops=[]``. A
 genuine 0-ops outcome with no error now surfaces the planner's final text
 reply via the new ``PocketSpecialistEditOutput.warnings`` field so the
-caller learns WHY the specialist declined. Added targeted observability
-logging for error events and tool_use-vs-ops counts.
+caller learns WHY the specialist declined. Service-rejected granular ops
+are no longer counted as applied — their rejection reasons are folded
+into ``warnings`` whether or not other ops landed. The 0-ops reason is
+joined with "" because deep_agents emits message events as token-level
+chunks. Added targeted observability logging for error events and
+tool_use / applied / rejected counts.
 """
 
 from __future__ import annotations
@@ -635,6 +639,11 @@ async def run_edit_specialist(
                     _push_chat_status(tool_name, event.metadata.get("input") or {})
             elif event.type == "message" and event.content:
                 # Keep the planner's text — it explains a no-op decline.
+                # The deep_agents backend yields message events as
+                # TOKEN-LEVEL chunks (deep_agents.py:897, inside the v2
+                # "messages" stream path), so these parts are fragments of
+                # one reply, not whole messages. They are joined with ""
+                # below — joining with "\n" would chop the prose.
                 final_text_parts.append(str(event.content))
         # A clean loop exit only counts as success when no error event
         # passed through. error_msg is set above for the error-event path.
@@ -653,21 +662,42 @@ async def run_edit_specialist(
 
     duration_ms = int((time.monotonic() - started) * 1000)
     ops = list(ops_capture.get("ops", []))
+    rejected = list(ops_capture.get("rejected", []))
 
     # Observability — distinguish "planner declined to act" (tool_use=0)
     # from "tool called but the service rejected it" (tool_use>0, ops=0).
     log.info(
-        "[pocket-specialist:edit] planner emitted %d tool_use events, %d granular ops captured",
+        "[pocket-specialist:edit] planner emitted %d tool_use events, "
+        "%d granular ops applied, %d rejected by the service",
         tool_use_count,
         len(ops),
+        len(rejected),
     )
 
-    # A successful run that applied zero ops must NOT be a silent ok=True
-    # with no explanation (#1163). Surface the planner's final text reply
-    # in warnings so the caller can tell the user WHY nothing changed.
+    # Build the warnings list. ``warnings`` is the channel for "the run
+    # succeeded but the caller should know something" — never a failure
+    # (that is ``error``). Two sources feed it:
+    #
+    #   1. Service-rejected ops. A granular op the planner attempted but
+    #      the service refused. Surfaced WHETHER OR NOT other ops applied
+    #      — a partial-apply still owes the caller the rejection reason.
+    #      A run where every op was rejected ends up ok=true, ops=[], with
+    #      the reasons in warnings — not a silent success (#1163 class).
+    #
+    #   2. A genuine 0-ops decline. The planner emitted no granular tool
+    #      call at all and ops/rejected are both empty — surface its
+    #      final text reply so the caller can tell the user WHY.
     warnings: list[str] = []
-    if success and not ops:
-        reason = "\n".join(p for p in final_text_parts if p.strip()).strip()
+    for rej in rejected:
+        op_name = rej.get("op", "edit op")
+        reason = rej.get("error", "rejected by the service")
+        warnings.append(f"Edit op '{op_name}' could not be applied: {reason}")
+
+    if success and not ops and not rejected:
+        # deep_agents yields message events as token-level chunks — join
+        # with "" so the surfaced reason reads as clean prose, not a
+        # newline-chopped fragment soup.
+        reason = "".join(final_text_parts).strip()
         warnings.append(
             reason
             or (

--- a/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
@@ -15,8 +15,10 @@ Changes: 2026-05-14 — added the Tier-2 prop-array item tool factories
 (set / append / remove ``_prop_array_item``), reworked onto the
 pocketpaw_ee layout from PR #1106.
 Changes: 2026-05-21 (#1163) — ``_capture_op`` now accepts the tool's
-result dict and logs a warning when a granular op was invoked but its
-service returned ``{ok: false}`` (the silent-rejection path).
+result dict. A service-rejected op (``{ok: false}``) is NO LONGER
+appended to ``capture['ops']`` — a rejected op is not an applied op.
+Instead it is recorded in ``capture['rejected']`` with its error so the
+runtime can fold the reason into the response ``warnings``.
 """
 
 from __future__ import annotations
@@ -351,19 +353,33 @@ def _capture_op(
     args: dict[str, Any],
     result: dict[str, Any] | None = None,
 ) -> None:
-    """Append an op record to ``capture['ops']`` for the runtime to inspect.
+    """Record a granular op for the runtime to inspect.
 
-    When ``result`` is supplied and reports ``{ok: false}``, log a warning
-    so an operator can see a granular tool WAS invoked but the underlying
-    service rejected it — distinct from the planner never calling a tool
-    at all (#1163 observability).
+    An op the service ACCEPTED lands in ``capture['ops']`` — that list is
+    the runtime's source of truth for "what changed."
+
+    An op the service REJECTED (``result`` reports ``{ok: false}``) is NOT
+    an applied op, so it must NOT land in ``capture['ops']`` — counting it
+    there would let a run whose only op was rejected return
+    ``ok=true, ops=[<rejected op>]``, the same silent-failure class as
+    #1163. A rejected op is logged and recorded in ``capture['rejected']``
+    with its error so ``run_edit_specialist`` can surface the reason in
+    the response ``warnings``.
     """
     if isinstance(result, dict) and result.get("ok") is False:
+        error = result.get("error") or result
         log.warning(
             "[pocket-specialist:edit] granular op %s rejected by service: %s",
             op,
-            result.get("error") or result,
+            error,
         )
+        if capture is not None:
+            rejected = capture.get("rejected")
+            if not isinstance(rejected, list):
+                rejected = []
+                capture["rejected"] = rejected
+            rejected.append({"op": op, "args": args, "error": str(error)})
+        return
     if capture is None:
         return
     ops = capture.get("ops")

--- a/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
@@ -14,10 +14,14 @@ without reaching into ``pocketpaw_ee.cloud`` internals.
 Changes: 2026-05-14 — added the Tier-2 prop-array item tool factories
 (set / append / remove ``_prop_array_item``), reworked onto the
 pocketpaw_ee layout from PR #1106.
+Changes: 2026-05-21 (#1163) — ``_capture_op`` now accepts the tool's
+result dict and logs a warning when a granular op was invoked but its
+service returned ``{ok: false}`` (the silent-rejection path).
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from langchain_core.tools import StructuredTool
@@ -28,6 +32,8 @@ from pocketpaw.ripple.manifest import validate_against_manifest
 from pocketpaw_ee.cloud.pockets.service import agent_create as _agent_create
 from pocketpaw_ee.cloud.pockets.service import agent_list as _agent_list_pockets
 from pocketpaw_ee.cloud.pockets.service import agent_update as _agent_update
+
+log = logging.getLogger(__name__)
 
 
 class _ListPocketsArgs(BaseModel):
@@ -339,8 +345,25 @@ def make_persist_pocket_tool(
 # ---------------------------------------------------------------------------
 
 
-def _capture_op(capture: dict[str, Any] | None, op: str, args: dict[str, Any]) -> None:
-    """Append an op record to ``capture['ops']`` for the runtime to inspect."""
+def _capture_op(
+    capture: dict[str, Any] | None,
+    op: str,
+    args: dict[str, Any],
+    result: dict[str, Any] | None = None,
+) -> None:
+    """Append an op record to ``capture['ops']`` for the runtime to inspect.
+
+    When ``result`` is supplied and reports ``{ok: false}``, log a warning
+    so an operator can see a granular tool WAS invoked but the underlying
+    service rejected it — distinct from the planner never calling a tool
+    at all (#1163 observability).
+    """
+    if isinstance(result, dict) and result.get("ok") is False:
+        log.warning(
+            "[pocket-specialist:edit] granular op %s rejected by service: %s",
+            op,
+            result.get("error") or result,
+        )
     if capture is None:
         return
     ops = capture.get("ops")
@@ -388,7 +411,7 @@ def make_set_state_tool(*, pocket_id: str, capture: dict[str, Any] | None = None
         from pocketpaw_ee.cloud.pockets.agent_context import set_state_for_agent
 
         result = await set_state_for_agent(pocket_id, path, value)
-        _capture_op(capture, "set_state", {"path": path, "value": value})
+        _capture_op(capture, "set_state", {"path": path, "value": value}, result)
         return result
 
     return StructuredTool.from_function(
@@ -419,7 +442,7 @@ def make_append_state_tool(
         from pocketpaw_ee.cloud.pockets.agent_context import append_state_for_agent
 
         result = await append_state_for_agent(pocket_id, path, item)
-        _capture_op(capture, "append_state", {"path": path, "item": item})
+        _capture_op(capture, "append_state", {"path": path, "item": item}, result)
         return result
 
     return StructuredTool.from_function(
@@ -447,7 +470,7 @@ def make_remove_state_tool(
         from pocketpaw_ee.cloud.pockets.agent_context import remove_state_for_agent
 
         result = await remove_state_for_agent(pocket_id, path)
-        _capture_op(capture, "remove_state", {"path": path})
+        _capture_op(capture, "remove_state", {"path": path}, result)
         return result
 
     return StructuredTool.from_function(
@@ -475,7 +498,7 @@ def make_patch_state_tool(
         from pocketpaw_ee.cloud.pockets.agent_context import patch_state_for_agent
 
         result = await patch_state_for_agent(pocket_id, partial)
-        _capture_op(capture, "patch_state", {"partial": partial})
+        _capture_op(capture, "patch_state", {"partial": partial}, result)
         return result
 
     return StructuredTool.from_function(
@@ -505,7 +528,7 @@ def make_set_node_prop_tool(
         from pocketpaw_ee.cloud.pockets.agent_context import set_node_prop_for_agent
 
         result = await set_node_prop_for_agent(pocket_id, node_id, prop, value)
-        _capture_op(capture, "set_node_prop", {"node_id": node_id, "prop": prop})
+        _capture_op(capture, "set_node_prop", {"node_id": node_id, "prop": prop}, result)
         return result
 
     return StructuredTool.from_function(
@@ -537,7 +560,7 @@ def make_add_node_tool(*, pocket_id: str, capture: dict[str, Any] | None = None)
         from pocketpaw_ee.cloud.pockets.agent_context import add_node_for_agent
 
         result = await add_node_for_agent(pocket_id, parent_id, spec, after_id)
-        _capture_op(capture, "add_node", {"parent_id": parent_id, "after_id": after_id})
+        _capture_op(capture, "add_node", {"parent_id": parent_id, "after_id": after_id}, result)
         return result
 
     return StructuredTool.from_function(
@@ -566,7 +589,7 @@ def make_replace_node_tool(
         from pocketpaw_ee.cloud.pockets.agent_context import replace_node_for_agent
 
         result = await replace_node_for_agent(pocket_id, node_id, spec)
-        _capture_op(capture, "replace_node", {"node_id": node_id})
+        _capture_op(capture, "replace_node", {"node_id": node_id}, result)
         return result
 
     return StructuredTool.from_function(
@@ -598,6 +621,7 @@ def make_move_node_tool(*, pocket_id: str, capture: dict[str, Any] | None = None
             capture,
             "move_node",
             {"node_id": node_id, "new_parent_id": new_parent_id, "after_id": after_id},
+            result,
         )
         return result
 
@@ -626,7 +650,7 @@ def make_remove_node_tool(
         from pocketpaw_ee.cloud.pockets.agent_context import remove_node_for_agent
 
         result = await remove_node_for_agent(pocket_id, node_id)
-        _capture_op(capture, "remove_node", {"node_id": node_id})
+        _capture_op(capture, "remove_node", {"node_id": node_id}, result)
         return result
 
     return StructuredTool.from_function(
@@ -672,6 +696,7 @@ def make_set_prop_array_item_tool(
             capture,
             "set_prop_array_item",
             {"node_id": node_id, "prop": prop, "match": match},
+            result,
         )
         return result
 
@@ -718,6 +743,7 @@ def make_append_prop_array_item_tool(
             capture,
             "append_prop_array_item",
             {"node_id": node_id, "prop": prop, "after": after},
+            result,
         )
         return result
 
@@ -756,6 +782,7 @@ def make_remove_prop_array_item_tool(
             capture,
             "remove_prop_array_item",
             {"node_id": node_id, "prop": prop, "match": match},
+            result,
         )
         return result
 

--- a/src/pocketpaw/bundled_skills/_bundled/pocketpaw-edit-pocket/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/pocketpaw-edit-pocket/SKILL.md
@@ -147,13 +147,27 @@ mcp__pocketpaw_pocket_specialist__edit({
 The tool schema validates all four fields. Backwards-compatible with
 intent-only calls (Type A).
 
-After the call returns, give the user a **one-line summary** drawn
-from the specialist's ``ops`` array in the return. Don't re-list
-every op — the canvas already shows the result.
+## Reading the response
 
-  ✓ "Marked task 1 as done."
-  ✓ "Added a revenue chart below the KPI strip."
-  ✓ "Rebuilt as a kanban with three columns."
+``pocket_specialist__edit`` returns
+``{ok, pocket_id, ops, duration_ms, backend_used, error, warnings}``.
+Three outcomes:
+
+- **Applied** — ``ok: true`` and ``ops`` is non-empty. Give the user a
+  **one-line summary** drawn from the ``ops`` array. Don't re-list every
+  op — the canvas already shows the result.
+
+    ✓ "Marked task 1 as done."
+    ✓ "Added a revenue chart below the KPI strip."
+    ✓ "Rebuilt as a kanban with three columns."
+
+- **Declined** — ``ok: true`` but ``ops`` is empty and ``warnings`` is
+  populated. The specialist looked at the request and chose not to act
+  (target not found, intent ambiguous, nothing to change). Relay the
+  ``warnings`` text to the user — do NOT claim the edit succeeded.
+
+- **Failed** — ``ok: false`` with ``error`` populated. The run errored.
+  Surface the ``error`` and stop.
 
 ## Hard rules
 

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -1,5 +1,13 @@
 # pocketpaw/ripple/_pockets.py — System prompts for the Ripple Pockets surface.
 #
+# Changes: 2026-05-21 (#1163) — the edit-specialist prompt now splices in
+# `_EDIT_TOOLS_MCP`, a tools block naming the granular edit ops the
+# specialist ACTUALLY holds (get_pocket, the state/node/array-item ops),
+# instead of `_TOOLS_MCP` which advertised creation tools (create_pocket,
+# update_pocket, add_widget) the specialist does not hold. The
+# `<mutation-strategy>` block gained the Tier-2 prop-array item ops from
+# PR #1159 with guidance on when to use them.
+#
 # Canonical source for every pocket-mode system prompt the agent ever sees.
 # Four strings are exported, one per (action × backend) cell:
 #
@@ -491,6 +499,79 @@ render. Don't use them for visible changes.)
 """
 
 
+# ---------------------------------------------------------------------------
+# Edit-specialist tool surface. Splices into the EDIT SPECIALIST prompt
+# only — see _assemble_interaction. This is the granular-op toolset that
+# `make_edit_pocket_tools` (ee/pocketpaw_ee/agent/pocket_specialist/tools.py)
+# actually attaches to the specialist's backend. It deliberately does NOT
+# name create_pocket / update_pocket / add_widget — the specialist does
+# not hold those, and advertising them made the planner pick a tool that
+# does not exist and silently emit zero ops (#1163 root cause B).
+# ---------------------------------------------------------------------------
+_EDIT_TOOLS_MCP = """\
+<pocket-tools>
+You hold the GRANULAR EDIT toolset — and only this toolset. Every tool
+below mutates `rippleSpec` directly and persists as it runs; there is no
+separate save step. You never pass pocket_id, workspace_id, or owner_id —
+they are bound for you.
+
+READ
+
+  get_pocket()
+    → {"ok": true, "pocket": {...full document including rippleSpec...}}
+    Call ONCE at the start to see the existing widget tree and state —
+    unless the parent already handed you the pocket payload.
+
+STATE OPS — data the widgets bind to
+
+  set_state(path, value)        write one value at a dotted path
+                                (e.g. `tasks[0].status`)
+  append_state(path, item)      push an element onto a state array
+  remove_state(path)            delete a key or array element
+  patch_state(partial)          shallow-merge a dict into the top of state
+
+NODE OPS — the widget tree itself
+
+  set_node_prop(node_id, prop, value)
+                                change ONE prop on a widget
+  add_node(parent_id, spec, after_id?)
+                                insert a new widget under a parent
+  replace_node(node_id, spec)   swap one subtree for another
+  move_node(node_id, new_parent_id, after_id?)
+                                relocate / reorder a subtree
+  remove_node(node_id)          delete a subtree
+
+PROP-ARRAY ITEM OPS — surgical single-item edits inside a widget's
+prop-array (chart.data, table.rows, calendar.events, kanban.columns,
+project-dashboard.team, feed.items, select.options, form-layout.fields…)
+
+  set_prop_array_item(node_id, prop, match, partial)
+                                shallow-merge `partial` into ONE matched
+                                item
+  append_prop_array_item(node_id, prop, value, after?)
+                                add ONE item to the array (insert after a
+                                matched item, or append)
+  remove_prop_array_item(node_id, prop, match)
+                                delete ONE matched item
+
+`match` (and `after`) is an ItemMatch: {index:N} | {id:"..."} |
+{by_field:"label", equals:"X"} | {by_key:{k:v}}.
+
+The toolset above is the WHOLE interface. Apply the smallest granular op
+that satisfies the intent.
+</pocket-tools>
+
+<edit-specialist-scope>
+You do NOT hold a pocket-creation tool, a whole-canvas-replace tool, or
+the legacy embedded-widget tools. The pocket already exists — never try
+to spawn another one or rewrite the canvas wholesale. Every change goes
+through a granular op from the `<pocket-tools>` block above. For a
+full-canvas redesign, `replace_node` against the root node is your
+equivalent of a whole-tree swap.
+</edit-specialist-scope>
+"""
+
+
 _TOOLS_CLI = """\
 <pocket-cli>
 Pocket reads/writes happen through `python -m pocketpaw.tools.cli
@@ -658,6 +739,14 @@ Three layers, pick the right tool for the edit:
                                  (label, show, on_click, color…)
     replace_node(node_id, spec)  swap one subtree for another
 
+  LAYER 2.5 — ONE ITEM INSIDE A WIDGET'S PROP-ARRAY
+    set_prop_array_item(node_id, prop, match, partial)
+                                 surgically merge into ONE item
+    append_prop_array_item(node_id, prop, value, after?)
+                                 add ONE item to the array
+    remove_prop_array_item(node_id, prop, match)
+                                 delete ONE matched item
+
   LAYER 3 — STRUCTURE
     add_node(parent_id, spec, after_id?)
     move_node(node_id, new_parent_id, after_id?)
@@ -672,9 +761,30 @@ ALWAYS reach for the LOWEST applicable layer:
 - "change the button label to Save"     → set_node_prop(button_id, "label", "Save")
 - "hide the chart"                      → set_node_prop(chart_id, "show", "false")
 - "make the button red"                 → set_node_prop(button_id, "class", "bg-red-500")
+- "fix team member 4's name"            → set_prop_array_item(dashboard_id, "team",
+                                          {index:3}, {name:"Gaurav Dewani"})
+- "add a row to the PR table"           → append_prop_array_item(table_id, "rows", {...})
+- "drop the cancelled chart bar"        → remove_prop_array_item(chart_id, "data",
+                                          {by_field:"label", equals:"Cancelled"})
 - "add a stat widget for revenue"       → add_node(parent_id, {type:"stat",…})
 - "move the chart below the table"      → move_node(chart_id, root_id, after_id=table_id)
 - "remove the old metric card"          → remove_node(metric_id)
+
+When to use the LAYER 2.5 prop-array item ops — and when NOT to:
+
+- Use them for a SURGICAL edit of ONE item in a widget prop that holds
+  an array: a single chart bar, one table row, one calendar event, one
+  `team` entry of a project-dashboard. They touch only the matched item;
+  every other item stays byte-identical, so nothing can drift.
+- This is the right tool the moment the intent is "change/add/remove
+  ONE of N" inside a widget — e.g. "update team[3] of the dashboard".
+  Do NOT re-ship the whole `team` array via set_node_prop just to change
+  one entry: copying the unchanged items risks silent drift and is far
+  more tokens. set_node_prop is for SCALAR props (label, color, show) or
+  for genuinely replacing an entire array wholesale.
+- `match` selects the item by {index:N}, {id:"..."}, {by_field, equals},
+  or {by_key:{...}}. Prefer a stable field over a raw index when one
+  exists.
 
 Why this matters: every widget bound to `{state.x}` re-renders
 automatically when state changes — set_state is the cheapest possible
@@ -685,13 +795,14 @@ the shape actually needs to change.
 Rule of thumb: if widgets bind to it, edit state. If it's the widget
 itself, edit the node. If it's a new widget, add a node.
 
-Reach for `update_pocket(ripple_spec=...)` only when:
-- You're rewriting the entire canvas (the user said "redesign this"
-  or asked for a structural shift touching >30% of the tree).
-- The initial creation of a brand-new sub-area replaces the whole UI.
+For a full-canvas rewrite (the user said "redesign this" or asked for a
+structural shift touching >30% of the tree), `replace_node` on the ROOT
+node swaps the whole subtree in one op. You do NOT have `update_pocket`
+— `replace_node` against the root is the equivalent.
 
-Never use `update_pocket` to change one row, one prop, one widget, or
-to nudge an existing node. The granular ops exist for exactly that.
+Never reach for a whole-tree replace to change one row, one prop, one
+widget, or to nudge an existing node. The granular ops above — down to
+the LAYER 2.5 prop-array item ops — exist for exactly that.
 </mutation-strategy>
 
 Step 2 — when building a new subtree (for add_node / replace_node):
@@ -1388,11 +1499,18 @@ set_state, set_node_prop, add_node, etc.).
 def _assemble_interaction(*, mcp: bool) -> str:
     """Heavy interaction prompt — owned by the EDIT SPECIALIST. Contains
     the full mutation-strategy / design-rules block the specialist needs
-    to perform granular edits. Not for the main chat agent."""
+    to perform granular edits. Not for the main chat agent.
+
+    The MCP variant splices in ``_EDIT_TOOLS_MCP`` — the granular edit
+    toolset the specialist actually holds. It must NOT use ``_TOOLS_MCP``
+    (the creation toolset): advertising create_pocket / update_pocket /
+    add_widget to a specialist that only holds set_node_prop / add_node /
+    *_prop_array_item made the planner pick a non-existent tool and emit
+    zero ops with no error (#1163 root cause B)."""
     parts = [
         _SCOPE_BLOCK,
         _CANVAS_BLOCK,
-        _TOOLS_MCP if mcp else _TOOLS_CLI,
+        _EDIT_TOOLS_MCP if mcp else _TOOLS_CLI,
         _WORKFLOW_INTERACTION_MCP if mcp else _WORKFLOW_INTERACTION_CLI,
         _INTERACTIVE_DEFAULT_BLOCK,
         _STATE_SOURCES_BLOCK,

--- a/tests/ee/agent/test_pocket_specialist/test_edit.py
+++ b/tests/ee/agent/test_pocket_specialist/test_edit.py
@@ -341,12 +341,13 @@ class TestRunEditSpecialistSuccessFlag:
         """
         from unittest.mock import MagicMock
 
-        from pocketpaw.agents.protocol import AgentEvent
-        from pocketpaw.config import Settings
         from pocketpaw_ee.agent.pocket_specialist.runtime import (
             PocketSpecialistEditInput,
             run_edit_specialist,
         )
+
+        from pocketpaw.agents.protocol import AgentEvent
+        from pocketpaw.config import Settings
 
         # Mirrors the exact pattern in deep_agents.py:974-977 — no raise,
         # just two yield statements: error then done.
@@ -477,12 +478,9 @@ class TestPromptSeparation:
 
         # Extract the tools block from the prompt — look for the first
         # <pocket-tools> ... </pocket-tools> section.
-        tools_block_match = re.search(
-            r"<pocket-tools>(.*?)</pocket-tools>", prompt, re.DOTALL
-        )
+        tools_block_match = re.search(r"<pocket-tools>(.*?)</pocket-tools>", prompt, re.DOTALL)
         assert tools_block_match is not None, (
-            "Edit specialist prompt has no <pocket-tools> block — "
-            "cannot verify tool surface"
+            "Edit specialist prompt has no <pocket-tools> block — cannot verify tool surface"
         )
         tools_block = tools_block_match.group(1)
 

--- a/tests/ee/agent/test_pocket_specialist/test_edit.py
+++ b/tests/ee/agent/test_pocket_specialist/test_edit.py
@@ -6,6 +6,13 @@ Covers the public wiring:
   * tool factories produce StructuredTool objects with the right names
   * main-agent interaction prompt is the thin delegation variant;
     specialist prompt is the heavy variant
+
+Regression tests for #1163 (silent 0-ops edits):
+  * Root cause A — backend yields AgentEvent(type="error") without raising;
+    runtime must surface ok=False, not ok=True.
+  * Root cause B — edit specialist system prompt must name the granular edit
+    tools it actually holds and must NOT advertise create_pocket / update_pocket
+    / add_widget.
 """
 
 from __future__ import annotations
@@ -317,6 +324,73 @@ class TestRunEditSpecialistSuccessFlag:
         # backend.stop must still run on the error path.
         fake_backend.stop.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_ok_false_when_backend_yields_error_event(self) -> None:
+        """#1163 root cause A — the deep_agents backend NEVER raises on error.
+        Instead it yields AgentEvent(type="error", ...) followed by
+        AgentEvent(type="done").  The runtime loop only inspects
+        ``event.type == "tool_use"`` so the error event passes silently, the
+        loop exits cleanly, ``success`` flips to ``True``, and the caller
+        gets ``ok=True, ops=[], error=None``.
+
+        Post-fix contract: a yielded error event must produce
+        ``ok=False`` with ``error`` populated — indistinguishable from a
+        raised exception from the caller's perspective.
+
+        This test FAILS today (current code returns ok=True, error=None).
+        """
+        from unittest.mock import MagicMock
+
+        from pocketpaw.agents.protocol import AgentEvent
+        from pocketpaw.config import Settings
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditInput,
+            run_edit_specialist,
+        )
+
+        # Mirrors the exact pattern in deep_agents.py:974-977 — no raise,
+        # just two yield statements: error then done.
+        async def _deep_agents_error_stream(*args, **kwargs):
+            yield AgentEvent(type="message", content="planning edit...")
+            yield AgentEvent(
+                type="error",
+                content="Deep Agents error: context length exceeded for 12KB spec",
+            )
+            yield AgentEvent(type="done", content="")
+
+        fake_backend = MagicMock()
+        fake_backend.run = _deep_agents_error_stream
+        fake_backend.attach_specialist_tools = MagicMock()
+        fake_backend.stop = AsyncMock()
+
+        with patch(
+            "pocketpaw_ee.agent.pocket_specialist.runtime.AgentRouter.create_isolated_backend",
+            return_value=fake_backend,
+        ):
+            out = await run_edit_specialist(
+                PocketSpecialistEditInput(
+                    pocket_id="6a0eb47ac0dd58069139b985",
+                    intent="replace team[3] Gaurv (handle TBD) with Gaurav Dewani (dewani12)",
+                ),
+                workspace_id="69e4f93b57ff64b3903868e3",
+                user_id="69d0f4d09dfb6ddfd8e2da84",
+                settings=Settings(),
+            )
+
+        # POST-FIX expectation (fails today — current code returns ok=True):
+        assert out.ok is False, (
+            f"Expected ok=False when backend yields error event, got ok={out.ok} "
+            f"error={out.error!r} — this is #1163 root cause A"
+        )
+        assert out.error is not None, "error field must be populated with backend error message"
+        assert "context length exceeded" in out.error, (
+            f"error should contain the backend's message, got: {out.error!r}"
+        )
+        # ops must be empty — no work was done.
+        assert out.ops == []
+        # backend.stop must still run regardless.
+        fake_backend.stop.assert_awaited_once()
+
 
 class TestPromptSeparation:
     def test_main_agent_interaction_prompt_is_thin(self) -> None:
@@ -345,3 +419,78 @@ class TestPromptSeparation:
         assert len(POCKET_EDIT_SPECIALIST_PROMPT_MCP) > len(POCKET_INTERACTION_PROMPT_MCP) * 5, (
             "edit specialist prompt should dwarf the thin main-agent prompt"
         )
+
+    def test_edit_specialist_prompt_names_granular_tools_not_creation_tools(self) -> None:
+        """#1163 root cause B — the edit specialist's system prompt is assembled
+        by ``_assemble_interaction`` which splices in ``_TOOLS_MCP``.  That
+        block advertises ``create_pocket``, ``update_pocket``, and ``add_widget``
+        — tools the edit specialist does NOT hold — and makes zero mention of
+        the granular edit ops the specialist actually holds (including the
+        Tier-2 array-item ops added in PR #1159).
+
+        When the LLM is told it has ``create_pocket`` but not
+        ``set_prop_array_item``, it either picks the wrong tool or declines to
+        act and emits 0 ops — exactly the silent-success pattern in #1163.
+
+        Post-fix contract:
+          (a) The prompt NAMES each granular edit tool the specialist holds —
+              at minimum: set_prop_array_item, append_prop_array_item,
+              remove_prop_array_item, set_node_prop, add_node.
+          (b) The prompt does NOT advertise create_pocket, update_pocket, or
+              add_widget as available tools.
+
+        This test FAILS today (0 mentions of the array-item ops in the prompt).
+        """
+        from pocketpaw.ripple import POCKET_EDIT_SPECIALIST_PROMPT_MCP
+
+        prompt = POCKET_EDIT_SPECIALIST_PROMPT_MCP
+
+        # --- (a) granular edit tools the specialist DOES hold ---
+        # These are the tools from make_edit_pocket_tools() — the edit
+        # specialist's actual tool surface, including the Tier-2 array-item
+        # ops from PR #1159.
+        required_tools = [
+            "set_prop_array_item",
+            "append_prop_array_item",
+            "remove_prop_array_item",
+            "set_node_prop",
+            "add_node",
+        ]
+        missing = [t for t in required_tools if t not in prompt]
+        assert not missing, (
+            f"Edit specialist prompt is missing these granular tool names: {missing}\n"
+            "The LLM cannot use tools it is not told about — "
+            "this is #1163 root cause B."
+        )
+
+        # --- (b) creation tools the specialist does NOT hold ---
+        # These should NOT appear as available tool calls.  Their presence
+        # causes the LLM to attempt the wrong tool and receive no result,
+        # producing 0 ops silently.
+        forbidden_as_available = ["create_pocket", "update_pocket", "add_widget"]
+        # Allow the words to appear in HARD RULES / prohibition text
+        # (e.g. "NEVER call create_pocket") — those are correct guard rails.
+        # What we're checking is that they do NOT appear in a tool-surface
+        # description (i.e. inside a <pocket-tools> / <specialist-tools> block
+        # that describes what the specialist can call).
+        import re
+
+        # Extract the tools block from the prompt — look for the first
+        # <pocket-tools> ... </pocket-tools> section.
+        tools_block_match = re.search(
+            r"<pocket-tools>(.*?)</pocket-tools>", prompt, re.DOTALL
+        )
+        assert tools_block_match is not None, (
+            "Edit specialist prompt has no <pocket-tools> block — "
+            "cannot verify tool surface"
+        )
+        tools_block = tools_block_match.group(1)
+
+        for forbidden in forbidden_as_available:
+            assert forbidden not in tools_block, (
+                f"Edit specialist prompt's <pocket-tools> block advertises "
+                f"'{forbidden}' — a creation tool the specialist does NOT hold. "
+                "This causes the LLM to attempt the wrong tool and produce 0 ops "
+                "(#1163 root cause B). Remove it from the tools block; "
+                "prohibition text in HARD RULES is still fine."
+            )

--- a/tests/ee/agent/test_pocket_specialist/test_edit.py
+++ b/tests/ee/agent/test_pocket_specialist/test_edit.py
@@ -13,6 +13,10 @@ Regression tests for #1163 (silent 0-ops edits):
   * Root cause B — edit specialist system prompt must name the granular edit
     tools it actually holds and must NOT advertise create_pocket / update_pocket
     / add_widget.
+  * Decline path — a 0-ops run with no error must surface the planner's
+    reply in ``warnings`` rather than a silent ok=True.
+  * Rejected op — a service-rejected granular op must not count as applied;
+    its error is folded into ``warnings`` (PR #1165 review finding #2).
 """
 
 from __future__ import annotations
@@ -390,6 +394,155 @@ class TestRunEditSpecialistSuccessFlag:
         # ops must be empty — no work was done.
         assert out.ops == []
         # backend.stop must still run regardless.
+        fake_backend.stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_decline_run_surfaces_planner_reply_in_warnings(self) -> None:
+        """#1163 headline contract — the planner reads the pocket, decides
+        no granular op is warranted, and replies with plain text. NO
+        tool_use event is emitted, so ``ops`` is empty.
+
+        Before the fix this returned ``ok=True, ops=[], warnings=[]`` — a
+        silent success indistinguishable from a real edit. Post-fix the
+        run is still ``ok=True`` (nothing failed) but ``warnings`` carries
+        the planner's reply so the caller can tell the user WHY nothing
+        changed.
+        """
+        from unittest.mock import MagicMock
+
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditInput,
+            run_edit_specialist,
+        )
+
+        from pocketpaw.agents.protocol import AgentEvent
+        from pocketpaw.config import Settings
+
+        # deep_agents emits message events as token-level chunks — model
+        # that here so the test also pins the ""-join (no choppy prose).
+        async def _decline_stream(*args, **kwargs):
+            yield AgentEvent(type="message", content="The team member ")
+            yield AgentEvent(type="message", content="you named already ")
+            yield AgentEvent(type="message", content="matches the current value.")
+            yield AgentEvent(type="done", content="")
+
+        fake_backend = MagicMock()
+        fake_backend.run = _decline_stream
+        fake_backend.attach_specialist_tools = MagicMock()
+        fake_backend.stop = AsyncMock()
+
+        with patch(
+            "pocketpaw_ee.agent.pocket_specialist.runtime.AgentRouter.create_isolated_backend",
+            return_value=fake_backend,
+        ):
+            out = await run_edit_specialist(
+                PocketSpecialistEditInput(
+                    pocket_id="6a0eb47ac0dd58069139b985",
+                    intent="rename team member 4 to the name they already have",
+                ),
+                workspace_id="69e4f93b57ff64b3903868e3",
+                user_id="69d0f4d09dfb6ddfd8e2da84",
+                settings=Settings(),
+            )
+
+        # A decline is NOT a failure — the run completed cleanly.
+        assert out.ok is True
+        assert out.error is None
+        # No granular op ran.
+        assert out.ops == []
+        # The headline contract — the reason reaches the caller.
+        assert out.warnings, "a 0-ops run must surface a reason in warnings"
+        joined = " ".join(out.warnings)
+        assert "matches the current value" in joined, (
+            f"warnings must carry the planner's reply, got: {out.warnings!r}"
+        )
+        # Token chunks joined with "" — clean prose, no newline soup.
+        assert "The team member you named already matches the current value." in joined, (
+            f"message chunks must join cleanly, got: {out.warnings!r}"
+        )
+        fake_backend.stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_service_rejected_op_not_counted_and_surfaced_in_warnings(self) -> None:
+        """#1165 review finding #2 — a granular op the service REJECTS
+        (``{ok: false}``) must not count as applied. Before the fix the op
+        still landed in ``ops``, so a run whose only op was rejected
+        returned ``ok=True, ops=[<rejected op>]`` — another silent failure
+        of the #1163 class.
+
+        Post-fix: the rejected op is absent from ``ops`` and its error is
+        surfaced in ``warnings``. The run is ``ok=True`` (nothing crashed)
+        but the caller can see the edit did not land.
+        """
+        from unittest.mock import MagicMock
+
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditInput,
+            run_edit_specialist,
+        )
+
+        from pocketpaw.agents.protocol import AgentEvent
+        from pocketpaw.config import Settings
+
+        captured_tools: dict = {}
+
+        def _grab_tools(tools):
+            captured_tools["tools"] = {t.name: t for t in tools}
+
+        # The fake backend invokes a real granular tool mid-stream — the
+        # same StructuredTool the runtime attached. The tool's wrapper hits
+        # set_state_for_agent, which we patch to reject the write.
+        async def _rejecting_stream(*args, **kwargs):
+            yield AgentEvent(type="message", content="applying the edit...")
+            tool = captured_tools["tools"]["set_state"]
+            yield AgentEvent(
+                type="tool_use",
+                content="Using set_state...",
+                metadata={"name": "set_state", "input": {}},
+            )
+            await tool.coroutine(path="filter", value="overdue")
+            yield AgentEvent(type="done", content="")
+
+        fake_backend = MagicMock()
+        fake_backend.run = _rejecting_stream
+        fake_backend.attach_specialist_tools = MagicMock(side_effect=_grab_tools)
+        fake_backend.stop = AsyncMock()
+
+        with (
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.runtime.AgentRouter.create_isolated_backend",
+                return_value=fake_backend,
+            ),
+            patch(
+                "pocketpaw_ee.cloud.pockets.agent_context.set_state_for_agent",
+                new=AsyncMock(
+                    return_value={"ok": False, "error": "state path 'filter' does not exist"}
+                ),
+            ),
+        ):
+            out = await run_edit_specialist(
+                PocketSpecialistEditInput(
+                    pocket_id="6a0eb47ac0dd58069139b985",
+                    intent="filter to overdue only",
+                ),
+                workspace_id="69e4f93b57ff64b3903868e3",
+                user_id="69d0f4d09dfb6ddfd8e2da84",
+                settings=Settings(),
+            )
+
+        # The run completed — nothing raised.
+        assert out.ok is True
+        assert out.error is None
+        # A rejected op is NOT an applied op — it must not be in ops.
+        assert out.ops == [], (
+            f"a service-rejected op must not count as applied, got ops={out.ops!r}"
+        )
+        # The rejection reason must reach the caller.
+        assert out.warnings, "a rejected op must surface its reason in warnings"
+        joined = " ".join(out.warnings)
+        assert "set_state" in joined and "does not exist" in joined, (
+            f"warnings must name the rejected op and its error, got: {out.warnings!r}"
+        )
         fake_backend.stop.assert_awaited_once()
 
 


### PR DESCRIPTION
## What this fixes

`pocket_specialist__edit` returned `{ok: true, ops: [], error: null}` on every edit attempt against a large pocket — six different intents, all silently 0-ops, nothing landing on the canvas, no error to relay to the user. The chat agent could not tell "no change needed" apart from "the specialist gave up."

Two separate problems were behind it.

### Root cause A — the success flag was lying

`run_edit_specialist` set `ok` from a flag that only flipped to `false` when the backend stream *raised* an exception. The `deep_agents` backend never raises — on failure it yields an error event and then a done event. The stream loop only looked at `tool_use` events, so the error event passed through, the loop exited cleanly, and the run reported success with an empty ops list.

The loop now inspects error events: it captures the backend's message, marks the run failed, and returns `ok: false` with `error` populated — the same outcome a raised exception would produce.

Separately, a run that genuinely applied zero ops without any error is no longer a silent success. The runtime now collects the planner's final text reply and returns it in a new `warnings` field, so the caller can tell the user *why* nothing changed. Failed runs (`ok: false` + `error`) stay distinct from declined runs (`ok: true` + `warnings`).

### Root cause B — the prompt described the wrong tools

The edit specialist's system prompt was assembled from a tools block that described the **creation** toolset — `create_pocket`, `update_pocket`, `add_widget` — none of which the edit specialist holds. It never named the granular edit tools it actually holds, including the array-item ops added in #1159. Told it had `create_pocket` but not `set_prop_array_item`, the planner picked a tool that did not exist or declined to act, and emitted zero ops.

The edit specialist prompt now gets its own tools block naming the real granular toolset: `get_pocket`, the state ops, the node ops, and the `set_prop_array_item` / `append_prop_array_item` / `remove_prop_array_item` ops. The mutation-strategy block gained a layer for the array-item ops with guidance on when to use them — surgical single-item edits of a widget prop-array (e.g. fixing one `team` entry of a project-dashboard) rather than re-shipping the whole array via `set_node_prop`.

## Observability

The issue asked for it. Added targeted logging on the edit path:

- error events from the backend
- the count of `tool_use` events the planner emitted vs granular ops captured — distinguishes "planner declined to act" from "tool called but service rejected it"
- a warning when a granular op is invoked but its service returns `{ok: false}`
- a warning when a run finishes with zero ops, with the planner's reply

## Contract change

`PocketSpecialistEditOutput` gains a `warnings: list[str]` field. The `edit` MCP tool description and the `pocketpaw-edit-pocket` bundled skill were updated to document the three response outcomes (applied / declined / failed).

## Tests

- `test_ok_false_when_backend_yields_error_event` and `test_edit_specialist_prompt_names_granular_tools_not_creation_tools` — the two reproduction tests for this issue — now pass.
- All 19 tests in `test_edit.py` pass (17 pre-existing + 2 new).
- `tests/ee/agent/test_pocket_specialist/` — 125 passed.
- `tests/cloud/` pocket-related tests — the 9 failures there are pre-existing on the base branch and unrelated to this change (upload ACL auth, connector router, an extraction module missing `pypdf`).

Closes #1163