### PR TITLE
feat(tools): cap oversized tool output before it reaches agent context

### DIFF
--- a/docs/concepts/tool-system.mdx
+++ b/docs/concepts/tool-system.mdx
@@ -62,6 +62,45 @@ result = await registry.execute("my_tool", param1="value")
 
 The registry automatically filters tools based on the active [tool policy](/tools/tool-policy).
 
+## Output Budget
+
+A tool that returns a large blob — a long test run, a build log, a big HTTP
+response body, verbose command stdout — used to drop that blob straight into
+the agent's context window. That burns tokens and buries the signal the
+agent actually needs.
+
+Every tool result now passes through an output budget before it reaches the
+model. Small results are untouched. A result over the cap is shortened in one
+of two ways:
+
+- **Structured formats** (pytest runs, ruff/flake8 lint output) get a
+  salient-lines extract: the failures, errors, assertion details, and the
+  summary line are kept; the thousands of `PASSED` lines are dropped.
+- **Everything else** gets a deterministic head + tail slice with an elision
+  marker stating how many characters were removed.
+
+The transform runs at two boundaries, so it applies whether a tool returns
+through `BaseTool._success` / `_error` or returns a string directly (the way
+`shell` and `run_python` do):
+
+- `BaseTool._success` and `BaseTool._error`
+- `ToolRegistry.execute` — the universal chokepoint
+
+The transform is deterministic (no LLM call) and idempotent — running it
+twice changes nothing — so applying it at both boundaries never
+double-truncates. The cap defaults to 12,000 characters and is configurable
+through the `tool_output_char_cap` setting.
+
+```python
+from pocketpaw.tools.output_budget import cap_tool_output
+
+# Normal-sized output passes through unchanged.
+cap_tool_output("Wrote 3 files.")            # -> "Wrote 3 files."
+
+# An oversized blob is shortened to <= tool_output_char_cap chars.
+cap_tool_output(huge_test_log)               # -> salient-lines extract
+```
+
 ## Built-in Tools
 
 PocketPaw ships with these built-in tools:

--- a/docs/tools/custom-tools.mdx
+++ b/docs/tools/custom-tools.mdx
@@ -83,6 +83,20 @@ openai_schema = tool.definition.to_openai()
 5. **Be async** - The `execute` method must be async
 6. **Document inputs** - Provide clear descriptions in the schema so the LLM knows how to use the tool
 
+## Output Size
+
+You do not need to truncate large output yourself. Every tool result passes
+through an [output budget](/concepts/tool-system#output-budget) before it
+reaches the agent: oversized blobs are shortened to a head + tail slice, or a
+salient-lines extract for recognised test and lint formats. This runs at
+`BaseTool._success` / `_error` and again at `ToolRegistry.execute`, so it
+applies whether your tool returns through `_success` or returns a string
+directly. The cap defaults to 12,000 characters (`tool_output_char_cap`).
+
+Return the full, accurate result from `execute` and let the budget handle
+size. Avoid ad hoc per-tool slicing — it loses the salient-lines treatment
+and is harder to tune than one central cap.
+
 ## Related
 
 <CardGroup>

--- a/src/pocketpaw/agents/tool_bridge.py
+++ b/src/pocketpaw/agents/tool_bridge.py
@@ -14,6 +14,9 @@ Backend-aware exclusion:
 
 Changes:
 - 2026-03-12: Added EditFileTool to _CLAUDE_SDK_EXCLUDED (has native Edit)
+- 2026-05-21 (#1160): _scan_tool_output now also caps oversized results via
+  cap_tool_output(), so tool blobs returned through the OpenAI / ADK /
+  LangChain wrappers can't flood agent context.
 """
 
 from __future__ import annotations
@@ -259,7 +262,20 @@ def build_openai_function_tools(
 
 
 def _scan_tool_output(result: str, tool_name: str) -> str:
-    """Scan tool output for injection attacks, return sanitized content if needed."""
+    """Post-process a tool result before it reaches agent context.
+
+    Two steps, both best-effort (an error in either leaves the result
+    unchanged rather than breaking tool execution):
+
+    1. Injection scan — sanitise content that trips the prompt-injection
+       scanner (e.g. hostile web pages).
+    2. Output budget — cap an oversized blob (a long test run, a build log,
+       a big HTTP body) via ``cap_tool_output`` so it can't flood the
+       context window. Normal-sized output passes through untouched.
+
+    This runs inside the OpenAI / ADK / LangChain tool wrappers, which call
+    ``tool.execute`` directly rather than through ``ToolRegistry.execute``.
+    """
     try:
         from pocketpaw.config import get_settings
         from pocketpaw.security.injection_scanner import get_injection_scanner
@@ -269,9 +285,22 @@ def _scan_tool_output(result: str, tool_name: str) -> str:
             scanner = get_injection_scanner()
             scan = scanner.scan(result, source=f"tool:{tool_name}")
             if scan.threat_level.value != "none":
-                return scan.sanitized_content
+                result = scan.sanitized_content
     except Exception:
         pass  # Don't let scanner errors break tool execution
+
+    # Output budget — cap a noisy blob. Idempotent, so a result already
+    # capped inside BaseTool._success passes through unchanged.
+    if result:
+        try:
+            from pocketpaw.config import get_settings
+            from pocketpaw.tools.output_budget import cap_tool_output
+
+            cap = getattr(get_settings(), "tool_output_char_cap", None)
+            result = cap_tool_output(result, cap=cap, tool_name=tool_name)
+        except Exception:
+            logger.debug("Tool output cap failed for %s", tool_name, exc_info=True)
+
     return result
 
 

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -608,6 +608,15 @@ class Settings(BaseSettings):
     tools_deny: list[str] = Field(
         default_factory=list, description="Explicit tool deny list (highest priority)"
     )
+    tool_output_char_cap: int = Field(
+        default=12000,
+        gt=0,
+        description=(
+            "Max characters a single tool result may add to agent context. "
+            "Oversized results are truncated (head+tail, or a salient-lines "
+            "extract for test/lint output) before reaching the LLM."
+        ),
+    )
 
     # Discord
     discord_bot_token: str | None = Field(default=None, description="Discord bot token")

--- a/src/pocketpaw/tools/output_budget.py
+++ b/src/pocketpaw/tools/output_budget.py
@@ -1,0 +1,183 @@
+# Tool-output budget — caps noisy tool results before they reach agent context.
+# Created: 2026-05-21 (#1160)
+#
+# A tool that returns a large blob (a test run, a build log, an HTTP body,
+# long command stdout) used to drop the raw blob straight into the agent's
+# context window. That burns tokens and buries the signal the agent needs.
+#
+# cap_tool_output() is the single post-processor applied at the tool return
+# boundary (BaseTool._success / BaseTool._error) and at the registry
+# chokepoint (ToolRegistry.execute). Small results pass through untouched.
+# Oversized results get one of two treatments:
+#   - structured formats (pytest, ruff/flake8 lint output) -> a salient-lines
+#     extract that keeps failures, errors, and the summary line
+#   - everything else -> a deterministic head + tail slice with an elision
+#     marker stating how much was dropped
+#
+# The transform is deterministic (no LLM call) and idempotent: feeding a
+# capped string back through cap_tool_output() is a no-op, so applying it at
+# two boundaries never double-truncates.
+
+from __future__ import annotations
+
+import re
+
+# Default cap on a single tool result, in characters. Roughly 3k tokens.
+# Override per call via the ``cap`` argument — the tool registry passes
+# ``Settings.tool_output_char_cap`` so deployments can tune it.
+TOOL_OUTPUT_CHAR_CAP = 12_000
+
+# When a blob is sliced, how to split the kept budget between head and tail.
+# Head gets the larger share — the start of a log usually carries the command,
+# the config, and the first failure; the tail carries the summary line.
+_HEAD_FRACTION = 0.6
+
+# Marker dropped between the head and tail slices. Stays recognisable so the
+# agent (and a human reading a transcript) can see truncation happened, and so
+# a second pass through cap_tool_output() detects an already-capped string.
+_ELISION_PREFIX = "... [tool output truncated:"
+
+# A salient-lines extract caps how many lines it keeps so a pathological run
+# with thousands of failures still can't blow the budget.
+_MAX_SALIENT_LINES = 120
+
+# Lines worth keeping from a structured test / lint blob. Case-insensitive.
+_SALIENT_PATTERNS = (
+    re.compile(r"\bFAILED\b"),
+    re.compile(r"\bERROR\b"),
+    re.compile(r"\bPASSED\b.*\bFAILED\b"),  # mixed pytest summary lines
+    re.compile(r"^={3,}.*={3,}$"),  # pytest === short test summary === banners
+    re.compile(r"^_{3,}"),  # pytest per-failure ____ separators
+    re.compile(r"\b\d+ (passed|failed|error|errors|skipped|xfailed|warning)"),
+    re.compile(r"^E\s"),  # pytest assertion detail lines
+    re.compile(r":\d+:\d+:\s+[EWF]\d"),  # ruff / flake8 "file:line:col: E501 ..."
+    re.compile(r"\bwould reformat\b"),  # ruff format check
+    re.compile(r"\b(traceback|exception)\b", re.IGNORECASE),
+)
+
+# Cheap signal that a blob is a test / lint run rather than free-form text.
+# Needs at least one of these before the salient-lines path is taken.
+_STRUCTURED_HINTS = (
+    re.compile(r"\b\d+ (passed|failed|error|errors)\b"),
+    re.compile(r"={3,}\s*(test session starts|short test summary)", re.IGNORECASE),
+    re.compile(r":\d+:\d+:\s+[EWF]\d{2,}"),  # ruff/flake8 diagnostic line
+    re.compile(r"^(FAILED|ERROR) ", re.MULTILINE),
+)
+
+
+def _looks_structured(text: str) -> bool:
+    """True when *text* looks like pytest / ruff / flake8 output.
+
+    Conservative on purpose: a false negative just falls back to the head+tail
+    slice, but a false positive could drop the wrong lines from prose.
+    """
+    return any(hint.search(text) for hint in _STRUCTURED_HINTS)
+
+
+def _is_salient(line: str) -> bool:
+    """True when *line* carries signal worth keeping from a structured blob."""
+    return any(pat.search(line) for pat in _SALIENT_PATTERNS)
+
+
+def _format_marker(dropped_chars: int, dropped_lines: int | None = None) -> str:
+    """Build the elision marker describing how much content was removed."""
+    if dropped_lines is not None:
+        return f"{_ELISION_PREFIX} {dropped_chars:,} chars / {dropped_lines:,} lines elided] ..."
+    return f"{_ELISION_PREFIX} {dropped_chars:,} chars elided] ..."
+
+
+def _head_tail(text: str, cap: int) -> str:
+    """Deterministic head + tail slice of *text* with an elision marker.
+
+    The marker itself counts against the budget so the result is always
+    ``<= cap`` characters. If the cap is too small to fit the marker plus a
+    little content, fall back to a plain head slice.
+    """
+    marker_estimate = len(_format_marker(len(text)))
+    usable = cap - marker_estimate - 2  # 2 for the joining newlines
+    if usable <= 0:
+        # Cap is pathologically small — just hard-truncate the head.
+        return text[:cap]
+
+    head_len = int(usable * _HEAD_FRACTION)
+    tail_len = usable - head_len
+    head = text[:head_len]
+    tail = text[-tail_len:] if tail_len > 0 else ""
+    dropped = len(text) - head_len - tail_len
+    marker = _format_marker(dropped)
+    return f"{head}\n{marker}\n{tail}"
+
+
+def _salient_extract(text: str, cap: int) -> str:
+    """Pull the signal lines out of a structured test / lint blob.
+
+    Keeps lines that match a salient pattern, in original order, up to
+    ``_MAX_SALIENT_LINES`` and the character cap. Prepends a marker noting how
+    many lines were dropped. Falls back to ``_head_tail`` when no salient line
+    is found (so a misclassified blob is still capped sanely).
+    """
+    lines = text.splitlines()
+    kept: list[str] = [ln for ln in lines if _is_salient(ln)]
+    if not kept:
+        return _head_tail(text, cap)
+
+    # When there are more salient lines than the line budget, keep a head
+    # AND a tail of them. The tail matters: a test / lint run's tally line
+    # ("2 failed, 1998 passed", "Found 2000 errors.") and short-summary
+    # section sit at the very end and are the lines an agent needs most.
+    if len(kept) > _MAX_SALIENT_LINES:
+        head_count = int(_MAX_SALIENT_LINES * _HEAD_FRACTION)
+        tail_count = _MAX_SALIENT_LINES - head_count
+        inner_dropped = len(kept) - head_count - tail_count
+        kept = (
+            kept[:head_count]
+            + [f"... [{inner_dropped:,} more salient lines elided] ..."]
+            + kept[-tail_count:]
+        )
+
+    dropped_lines = len(lines) - sum(1 for ln in kept if not ln.startswith("... ["))
+    body = "\n".join(kept)
+    marker = _format_marker(len(text) - len(body), dropped_lines)
+    extract = f"{marker}\n{body}"
+
+    # The extract can itself exceed the cap on a run with very many failures;
+    # head+tail the assembled extract so the contract (<= cap) always holds.
+    if len(extract) > cap:
+        return _head_tail(extract, cap)
+    return extract
+
+
+def cap_tool_output(
+    result: str,
+    *,
+    cap: int | None = None,
+    tool_name: str = "",
+) -> str:
+    """Cap a single tool result so a noisy blob can't flood agent context.
+
+    Args:
+        result: The raw string a tool produced.
+        cap: Maximum characters to allow through. Defaults to
+            ``TOOL_OUTPUT_CHAR_CAP``. A non-positive cap disables capping.
+        tool_name: Optional tool name, kept for future per-tool tuning and
+            logging. Unused today.
+
+    Returns:
+        ``result`` unchanged when it is within the cap, otherwise a shorter
+        string: a salient-lines extract for recognised structured formats, or
+        a deterministic head + tail slice for everything else. The result is
+        always ``<= cap`` characters and the transform is idempotent.
+    """
+    if not result:
+        return result
+
+    effective_cap = TOOL_OUTPUT_CHAR_CAP if cap is None else cap
+    if effective_cap <= 0:
+        return result  # capping disabled
+
+    if len(result) <= effective_cap:
+        return result  # common case — normal-sized output, untouched
+
+    if _looks_structured(result):
+        return _salient_extract(result, effective_cap)
+    return _head_tail(result, effective_cap)

--- a/src/pocketpaw/tools/protocol.py
+++ b/src/pocketpaw/tools/protocol.py
@@ -1,10 +1,14 @@
 # Tool protocol - simple, string-based tool interface.
 # Created: 2026-02-02
+# Updated: 2026-05-21 (#1160) — BaseTool._success / _error now pass results
+# through cap_tool_output() so a noisy tool blob can't flood agent context.
 
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Protocol
+
+from pocketpaw.tools.output_budget import cap_tool_output
 
 
 def normalize_schema(schema: dict[str, Any]) -> dict[str, Any]:
@@ -141,9 +145,18 @@ class BaseTool(ABC):
         return tag
 
     def _error(self, message: str) -> str:
-        """Format an error response."""
-        return f"Error: {message}"
+        """Format an error response.
+
+        Capped via ``cap_tool_output`` so an error carrying a large blob
+        (a full stack trace, a failed-build log) can't flood agent context.
+        """
+        return cap_tool_output(f"Error: {message}", tool_name=self.name)
 
     def _success(self, message: str) -> str:
-        """Format a success response."""
-        return message
+        """Format a success response.
+
+        Capped via ``cap_tool_output`` so a noisy success payload (a long
+        test run, a build log, a big HTTP body) can't flood agent context.
+        Normal-sized output passes through untouched.
+        """
+        return cap_tool_output(message, tool_name=self.name)

--- a/src/pocketpaw/tools/registry.py
+++ b/src/pocketpaw/tools/registry.py
@@ -5,6 +5,10 @@
 # Updated: 2026-04-16 — Debug log scrubs params so that credentials in tool
 # inputs don't leak to stdout if DEBUG logging is on (#890 belt-and-braces;
 # the audit write is already scrubbed centrally in AuditLogger.log).
+# Updated: 2026-05-21 (#1160) — execute() caps oversized tool results via
+# cap_tool_output() so a noisy blob can't flood agent context. This is the
+# universal chokepoint: it also covers tools (shell, run_python) that return
+# strings directly without going through BaseTool._success.
 
 
 from __future__ import annotations
@@ -161,6 +165,21 @@ class ToolRegistry:
                         result = scan.sanitized_content
             except Exception:
                 pass  # Don't let scanner errors break tool execution
+
+            # Output budget — cap a noisy blob before it reaches agent context.
+            # This is the universal chokepoint: it catches tools that return
+            # strings directly (shell, run_python) and not just BaseTool
+            # subclasses that route through _success. Capping is idempotent,
+            # so a result already capped by _success passes through untouched.
+            if result:
+                try:
+                    from pocketpaw.config import get_settings
+                    from pocketpaw.tools.output_budget import cap_tool_output
+
+                    cap = getattr(get_settings(), "tool_output_char_cap", None)
+                    result = cap_tool_output(result, cap=cap, tool_name=name)
+                except Exception:
+                    logger.debug("Tool output cap failed for %s", name, exc_info=True)
 
             # Log truncation to avoid massive log files
             log_result = result[:200] + "..." if len(result) > 200 else result

--- a/tests/e2e/test_tool_output_summary_e2e.py
+++ b/tests/e2e/test_tool_output_summary_e2e.py
@@ -1,0 +1,233 @@
+# E2E test for the tool-output budget (#1160).
+# Created: 2026-05-21
+#
+# Proves that an oversized tool result is capped before it reaches agent
+# context, through the real production tool paths:
+#
+#   1. ToolRegistry.execute — the universal chokepoint. A real ~50KB tool is
+#      registered and run; the registry return value (the tool_result fed
+#      back to the model) must be the capped form.
+#   2. tool_bridge FunctionTool callback — the exact callback the OpenAI
+#      Agents SDK Runner invokes for a tool call. Its tool_call_output must
+#      be the capped form.
+#   3. The real AgentLoop — a mocked LLM backend (AsyncMock-style async
+#      generator) drives a tool call by running the real registry on the
+#      ~50KB tool, then yields the result as a tool_result event. The loop
+#      processes the run end-to-end; the tool_result it handles is capped.
+#
+# Only the LLM is mocked. The tool, the registry, the injection scanner, the
+# output budget, and the AgentLoop are all real.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pocketpaw.agents.loop import AgentLoop
+from pocketpaw.agents.protocol import AgentEvent
+from pocketpaw.bus import Channel, InboundMessage
+from pocketpaw.tools.output_budget import TOOL_OUTPUT_CHAR_CAP
+from pocketpaw.tools.protocol import BaseTool
+from pocketpaw.tools.registry import ToolRegistry
+
+# Size of the blob the noisy tool returns — well over the 12k cap.
+_BIG_OUTPUT_SIZE = 50_000
+
+
+@pytest.fixture(scope="session", autouse=True)
+def require_playwright_browsers():
+    """Override the Playwright autouse skip from tests/e2e/conftest.py.
+
+    This file drives the agent loop and tool registry — no browser needed —
+    so it must run even when Playwright Chromium is not installed.
+    """
+    yield
+
+
+# --------------------------------------------------------------------------
+# A realistic noisy tool
+# --------------------------------------------------------------------------
+
+
+class BigOutputTool(BaseTool):
+    """A tool that dumps a ~50KB blob — stands in for a long test run, a
+    build log, or a large HTTP response body."""
+
+    @property
+    def name(self) -> str:
+        return "big_output"
+
+    @property
+    def description(self) -> str:
+        return "Returns a very large output blob for budget testing."
+
+    async def execute(self, **params: object) -> str:
+        # Return the blob directly (no _success), the way ShellTool and
+        # RunPythonTool do — this is the path the registry chokepoint must
+        # still catch.
+        return "noisy-log-line " * (_BIG_OUTPUT_SIZE // len("noisy-log-line "))
+
+
+# --------------------------------------------------------------------------
+# 1. Registry chokepoint
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registry_caps_oversized_tool_result():
+    """ToolRegistry.execute caps a ~50KB result before returning it."""
+    registry = ToolRegistry()
+    registry.register(BigOutputTool())
+
+    raw_size = len(await BigOutputTool().execute())
+    assert raw_size > TOOL_OUTPUT_CHAR_CAP, "fixture should exceed the cap"
+
+    result = await registry.execute("big_output")
+
+    assert len(result) <= TOOL_OUTPUT_CHAR_CAP
+    assert len(result) < raw_size
+    assert "tool output truncated" in result
+
+
+# --------------------------------------------------------------------------
+# 2. tool_bridge FunctionTool callback (OpenAI Agents path)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_function_tool_callback_returns_capped_output():
+    """The FunctionTool callback the OpenAI Agents Runner invokes for a tool
+    call hands back the capped form as the tool_call_output."""
+    pytest.importorskip("agents", reason="OpenAI Agents SDK not installed")
+
+    from pocketpaw.agents.tool_bridge import build_openai_function_tools
+    from pocketpaw.config import Settings
+
+    # Build the real FunctionTool wrappers, but over just our noisy tool so
+    # the test is hermetic and fast.
+    with patch(
+        "pocketpaw.agents.tool_bridge._instantiate_all_tools",
+        return_value=[BigOutputTool()],
+    ):
+        function_tools = build_openai_function_tools(Settings(), backend="openai_agents")
+
+    big_tool_ft = next(ft for ft in function_tools if ft.name == "big_output")
+
+    # on_invoke_tool is exactly what Runner calls when the model emits a
+    # function call. args is the JSON arguments string.
+    output = await big_tool_ft.on_invoke_tool(MagicMock(), "{}")
+
+    assert len(output) <= TOOL_OUTPUT_CHAR_CAP
+    assert "tool output truncated" in output
+
+
+# --------------------------------------------------------------------------
+# 3. The real AgentLoop with a mocked LLM backend
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_bus():
+    bus = MagicMock()
+    bus.consume_inbound = AsyncMock()
+    bus.publish_outbound = AsyncMock()
+    bus.publish_system = AsyncMock()
+    return bus
+
+
+@pytest.fixture
+def mock_memory():
+    mem = MagicMock()
+    mem.add_to_session = AsyncMock()
+    mem.get_session_history = AsyncMock(return_value=[])
+    mem.get_compacted_history = AsyncMock(return_value=[])
+    mem.resolve_session_key = AsyncMock(side_effect=lambda k: k)
+    return mem
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_tool_result_is_capped(mock_bus, mock_memory):
+    """Drive the real AgentLoop with a mocked LLM backend that triggers a
+    tool call. The tool runs through the real registry; the tool_result the
+    loop receives and forwards is the capped form, not the ~50KB blob."""
+    registry = ToolRegistry()
+    registry.register(BigOutputTool())
+
+    # Records what the mocked backend produced as the tool_result content,
+    # so the test can assert on the exact string that flowed into the loop.
+    captured: dict[str, str] = {}
+
+    async def mock_run(message, *, system_prompt=None, history=None, session_key=None):
+        """Stand-in for the LLM backend. A real backend would call the tool
+        and stream a tool_result; here we run the real registry and yield
+        the real (capped) result."""
+        yield AgentEvent(
+            type="tool_use",
+            content="Using big_output...",
+            metadata={"name": "big_output", "input": {}},
+        )
+        tool_result = await registry.execute("big_output")
+        captured["tool_result"] = tool_result
+        yield AgentEvent(
+            type="tool_result",
+            content=tool_result,
+            metadata={"name": "big_output"},
+        )
+        yield AgentEvent(type="message", content="Done.")
+        yield AgentEvent(type="done", content="")
+
+    mock_router = MagicMock()
+    mock_router.run = mock_run
+    mock_router.stop = AsyncMock()
+    mock_router._backend = MagicMock()
+    mock_router.scoped_tool_policy = MagicMock()
+
+    settings = MagicMock()
+    settings.agent_backend = "claude_agent_sdk"
+    settings.max_concurrent_conversations = 5
+    settings.welcome_hint_enabled = False
+    settings.injection_scan_enabled = False
+    settings.pii_scan_enabled = False
+    settings.tool_profile = "full"
+    settings.compaction_recent_window = 10
+    settings.compaction_char_budget = 16000
+    settings.compaction_summary_chars = 300
+    settings.compaction_llm_summarize = False
+
+    with (
+        patch("pocketpaw.agents.loop.get_message_bus", return_value=mock_bus),
+        patch("pocketpaw.agents.loop.get_memory_manager", return_value=mock_memory),
+        patch("pocketpaw.agents.loop.AgentContextBuilder") as mock_builder_cls,
+        patch("pocketpaw.agents.loop.AgentRouter", return_value=mock_router),
+        patch("pocketpaw.agents.loop.get_settings", return_value=settings),
+        patch("pocketpaw.agents.loop.Settings") as mock_settings_cls,
+    ):
+        mock_settings_cls.load.return_value = settings
+        mock_builder_cls.return_value.build_system_prompt = AsyncMock(return_value="System Prompt")
+
+        loop = AgentLoop()
+        msg = InboundMessage(
+            channel=Channel.CLI,
+            sender_id="user1",
+            chat_id="chat1",
+            content="run the big tool",
+        )
+        await loop._process_message(msg)
+
+    # The backend produced a tool_result, and it was the capped form.
+    assert "tool_result" in captured, "mocked backend never produced a tool_result"
+    tool_result = captured["tool_result"]
+    assert len(tool_result) <= TOOL_OUTPUT_CHAR_CAP
+    assert "tool output truncated" in tool_result
+
+    # The loop ran the tool call end-to-end and fanned out tool events.
+    published_events = [
+        call.args[0].event_type for call in mock_bus.publish_system.call_args_list if call.args
+    ]
+    assert "tool_start" in published_events
+    assert "tool_result" in published_events
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_tool_output_summary.py
+++ b/tests/test_tool_output_summary.py
@@ -1,0 +1,306 @@
+# Unit tests for the tool-output budget (#1160).
+# Created: 2026-05-21
+#
+# Covers pocketpaw.tools.output_budget.cap_tool_output and its wiring into
+# BaseTool._success / _error and ToolRegistry.execute:
+#   - small input passes through unchanged (no regression)
+#   - oversized free-form input gets a head+tail slice with an elision marker
+#   - structured test/lint output gets a salient-lines extract
+#   - the transform is idempotent and always respects the cap
+#   - the cap reaches tools through both wired boundaries
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.tools.output_budget import (
+    TOOL_OUTPUT_CHAR_CAP,
+    cap_tool_output,
+)
+from pocketpaw.tools.protocol import BaseTool
+from pocketpaw.tools.registry import ToolRegistry
+
+# --------------------------------------------------------------------------
+# Sample blobs
+# --------------------------------------------------------------------------
+
+
+def _pytest_blob(passing: int = 1500) -> str:
+    """A realistic pytest run: a banner, many PASSED lines, two failures,
+    a short-summary section, and a final tally line."""
+    lines = ["=" * 26 + " test session starts " + "=" * 26]
+    lines += [f"tests/test_mod.py::test_case_{i} PASSED" for i in range(passing)]
+    lines += [
+        "_" * 70,
+        "________________________ test_broken_thing ________________________",
+        "E   AssertionError: expected 3, got 4",
+        "_" * 70,
+        "________________________ test_other_break _________________________",
+        "E   ValueError: bad input",
+        "=" * 24 + " short test summary info " + "=" * 24,
+        "FAILED tests/test_mod.py::test_broken_thing - AssertionError: expected 3, got 4",
+        "FAILED tests/test_mod.py::test_other_break - ValueError: bad input",
+        f"2 failed, {passing} passed, 3 skipped in 5.12s",
+    ]
+    return "\n".join(lines)
+
+
+def _ruff_blob(violations: int = 1500) -> str:
+    """A realistic ruff lint run: many file:line:col diagnostics + a tally."""
+    lines = [
+        f"src/pkg/module_{i}.py:{i + 1}:80: E501 Line too long (105 > 100)"
+        for i in range(violations)
+    ]
+    lines.append(f"Found {violations} errors.")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# cap_tool_output — core behaviour
+# --------------------------------------------------------------------------
+
+
+class TestCapPassThrough:
+    """Small / normal-sized output must never be touched."""
+
+    def test_small_string_unchanged(self):
+        text = "Successfully wrote 3 files to /tmp/out."
+        assert cap_tool_output(text) == text
+
+    def test_empty_string_unchanged(self):
+        assert cap_tool_output("") == ""
+
+    def test_string_exactly_at_cap_unchanged(self):
+        text = "a" * TOOL_OUTPUT_CHAR_CAP
+        assert cap_tool_output(text) == text
+
+    def test_string_one_under_cap_unchanged(self):
+        text = "a" * (TOOL_OUTPUT_CHAR_CAP - 1)
+        assert cap_tool_output(text) == text
+
+    def test_non_positive_cap_disables_capping(self):
+        big = "x" * (TOOL_OUTPUT_CHAR_CAP * 3)
+        assert cap_tool_output(big, cap=0) == big
+        assert cap_tool_output(big, cap=-10) == big
+
+
+class TestCapHeadTail:
+    """Oversized free-form output gets a deterministic head+tail slice."""
+
+    def test_large_input_is_capped(self):
+        big = "x" * (TOOL_OUTPUT_CHAR_CAP * 4)
+        out = cap_tool_output(big)
+        assert len(out) <= TOOL_OUTPUT_CHAR_CAP
+        assert len(out) < len(big)
+
+    def test_large_input_has_elision_marker(self):
+        big = "lorem ipsum " * 5000
+        out = cap_tool_output(big)
+        assert "tool output truncated" in out
+        # The marker reports a positive number of elided chars.
+        assert "chars elided" in out
+
+    def test_head_and_tail_are_preserved(self):
+        # Distinct head and tail markers so we can prove both survive.
+        head = "HEAD_MARKER_START "
+        tail = " TAIL_MARKER_END"
+        big = head + ("middle filler " * 5000) + tail
+        out = cap_tool_output(big)
+        assert out.startswith("HEAD_MARKER_START")
+        assert out.endswith("TAIL_MARKER_END")
+
+    def test_deterministic(self):
+        big = "repeatable content " * 4000
+        assert cap_tool_output(big) == cap_tool_output(big)
+
+    def test_idempotent(self):
+        big = "some noisy output " * 5000
+        once = cap_tool_output(big)
+        twice = cap_tool_output(once)
+        assert once == twice
+
+    def test_custom_cap_is_respected(self):
+        big = "y" * 40000
+        out = cap_tool_output(big, cap=2000)
+        assert len(out) <= 2000
+
+    def test_tiny_cap_still_bounded(self):
+        # Cap smaller than the marker — must still not exceed the cap.
+        big = "z" * 5000
+        out = cap_tool_output(big, cap=20)
+        assert len(out) <= 20
+
+
+class TestCapStructuredExtract:
+    """Recognised test / lint output gets a salient-lines extract."""
+
+    def test_pytest_output_is_capped(self):
+        blob = _pytest_blob(passing=2000)
+        out = cap_tool_output(blob)
+        assert len(out) <= TOOL_OUTPUT_CHAR_CAP
+        assert len(out) < len(blob)
+
+    def test_pytest_extract_keeps_failures(self):
+        blob = _pytest_blob(passing=2000)
+        out = cap_tool_output(blob)
+        # Both failing test names survive the extract.
+        assert "test_broken_thing" in out
+        assert "test_other_break" in out
+
+    def test_pytest_extract_keeps_summary_line(self):
+        blob = _pytest_blob(passing=2000)
+        out = cap_tool_output(blob)
+        assert "2 failed" in out
+
+    def test_pytest_extract_keeps_assertion_detail(self):
+        blob = _pytest_blob(passing=2000)
+        out = cap_tool_output(blob)
+        assert "AssertionError: expected 3, got 4" in out
+
+    def test_pytest_extract_drops_passing_noise(self):
+        blob = _pytest_blob(passing=2000)
+        out = cap_tool_output(blob)
+        # The thousands of individual PASSED lines are noise — dropped.
+        assert "test_case_1000 PASSED" not in out
+
+    def test_pytest_extract_reports_dropped_lines(self):
+        blob = _pytest_blob(passing=2000)
+        out = cap_tool_output(blob)
+        assert "lines elided" in out
+
+    def test_ruff_output_is_capped(self):
+        blob = _ruff_blob(violations=2000)
+        out = cap_tool_output(blob)
+        assert len(out) <= TOOL_OUTPUT_CHAR_CAP
+        assert len(out) < len(blob)
+
+    def test_ruff_extract_keeps_diagnostics_and_tally(self):
+        blob = _ruff_blob(violations=2000)
+        out = cap_tool_output(blob)
+        assert "E501 Line too long" in out
+        assert "Found 2000 errors." in out
+
+    def test_structured_extract_is_idempotent(self):
+        blob = _pytest_blob(passing=2000)
+        once = cap_tool_output(blob)
+        twice = cap_tool_output(once)
+        assert once == twice
+
+    def test_pathological_failure_count_still_bounded(self):
+        # A run where almost every line is a FAILED line — the salient
+        # extract itself could blow the budget, so it must be re-capped.
+        lines = [f"FAILED tests/test_mod.py::test_{i} - boom" for i in range(50000)]
+        blob = "\n".join(lines)
+        out = cap_tool_output(blob)
+        assert len(out) <= TOOL_OUTPUT_CHAR_CAP
+
+
+# --------------------------------------------------------------------------
+# Wiring — the cap reaches tools through both boundaries
+# --------------------------------------------------------------------------
+
+
+class _SuccessTool(BaseTool):
+    """Tool that returns a big payload through BaseTool._success."""
+
+    @property
+    def name(self) -> str:
+        return "big_success_tool"
+
+    @property
+    def description(self) -> str:
+        return "Returns a large payload via _success."
+
+    async def execute(self, **params: object) -> str:
+        return self._success("payload " * 6000)
+
+
+class _ErrorTool(BaseTool):
+    """Tool that returns a big payload through BaseTool._error."""
+
+    @property
+    def name(self) -> str:
+        return "big_error_tool"
+
+    @property
+    def description(self) -> str:
+        return "Returns a large error via _error."
+
+    async def execute(self, **params: object) -> str:
+        return self._error("stacktrace line " * 6000)
+
+
+class _DirectReturnTool(BaseTool):
+    """Tool that returns a big string directly — bypasses _success,
+    the way ShellTool and RunPythonTool do."""
+
+    @property
+    def name(self) -> str:
+        return "big_direct_tool"
+
+    @property
+    def description(self) -> str:
+        return "Returns a large string without _success."
+
+    async def execute(self, **params: object) -> str:
+        return "raw command stdout " * 6000
+
+
+class _SmallTool(BaseTool):
+    """Tool with normal-sized output — must pass through unchanged."""
+
+    @property
+    def name(self) -> str:
+        return "small_tool"
+
+    @property
+    def description(self) -> str:
+        return "Returns a small string."
+
+    async def execute(self, **params: object) -> str:
+        return "ok: done"
+
+
+class TestBaseToolWiring:
+    """BaseTool._success / _error apply the cap at the return boundary."""
+
+    async def test_success_payload_is_capped(self):
+        out = await _SuccessTool().execute()
+        assert len(out) <= TOOL_OUTPUT_CHAR_CAP
+
+    async def test_error_payload_is_capped(self):
+        out = await _ErrorTool().execute()
+        assert len(out) <= TOOL_OUTPUT_CHAR_CAP
+        # Still recognisable as an error.
+        assert out.startswith("Error:")
+
+    async def test_small_success_unchanged(self):
+        tool = _SmallTool()
+        assert await tool.execute() == "ok: done"
+
+
+class TestRegistryWiring:
+    """ToolRegistry.execute caps every tool, including ones that bypass
+    _success by returning a string directly."""
+
+    async def test_direct_return_tool_is_capped(self):
+        registry = ToolRegistry()
+        registry.register(_DirectReturnTool())
+        out = await registry.execute("big_direct_tool")
+        assert len(out) <= TOOL_OUTPUT_CHAR_CAP
+
+    async def test_success_tool_through_registry_is_capped(self):
+        registry = ToolRegistry()
+        registry.register(_SuccessTool())
+        out = await registry.execute("big_success_tool")
+        assert len(out) <= TOOL_OUTPUT_CHAR_CAP
+
+    async def test_small_tool_through_registry_unchanged(self):
+        registry = ToolRegistry()
+        registry.register(_SmallTool())
+        out = await registry.execute("small_tool")
+        assert out == "ok: done"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Tool results that came back oversized used to flow straight into the agent's context window with nothing capping them. A long pytest run, a build log, a big HTTP response body, verbose command stdout: the whole blob went in. That wasted tokens and buried the lines the agent actually needed.

This adds an output budget at the tool return boundary.

`src/pocketpaw/tools/output_budget.py` adds `cap_tool_output(result, *, cap, tool_name)`:

- Output within the cap is returned unchanged.
- An oversized blob gets a deterministic head and tail slice with an elision marker stating how many characters were dropped.
- A recognized structured format (pytest run, ruff or flake8 lint output) gets a salient-lines extract instead. The failures, errors, assertion details, and the summary line are kept; the thousands of `PASSED` lines are dropped.
- The transform is deterministic (no LLM call) and idempotent.

## Why

Issue #1160 distilled Spotify's background-coding-agent posts onto our tool primitive. Their `verify` tool summarizes logs so the agent gets something digestible. We checked our path and found nothing did this. `shell` and `run_python` return stdout with no size limit. `research` slices at hardcoded offsets. No agent backend caps tool-result content, and `AgentContextBuilder`'s budget only governs static system-prompt blocks, so it never sees a mid-conversation tool result.

## How it is wired

The cap runs at two boundaries:

- `BaseTool._success` and `_error`
- `ToolRegistry.execute`, and the `tool_bridge` wrappers via `_scan_tool_output`

Two boundaries because `shell` and `run_python` return strings directly and never touch `_success`. The registry is the universal chokepoint that catches them. Since the transform is idempotent, a result already capped by `_success` passes through the registry unchanged.

The cap defaults to 12000 characters and is configurable through the new `tool_output_char_cap` setting.

## Testing

`uv run pytest tests/test_tool_output_summary.py tests/test_tools_protocol.py tests/test_tools.py -q` — 60 passed.

`uv run pytest tests/e2e/test_tool_output_summary_e2e.py -q` — 3 passed.

Broader sweep `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/cloud --ignore=tests/ee --ignore=tests/test_frontend_syntax.py -q` — 4516 passed, 17 failed. The 17 failures all pre-exist on `dev` and are unrelated to this change: 16 in `test_codex_cli_backend.py` (optional `openai_codex_sdk` package not installed in this checkout) and 1 in `test_context_budget.py` (a kb subprocess test on the system-prompt path, not the tool path). Confirmed by running both against pristine `dev`.

New tests:

- `tests/test_tool_output_summary.py` — unit tests for the summarizer. Small input unchanged, large input capped with the marker, structured pytest and ruff extraction, idempotency, and the cap reaching tools through both wired boundaries.
- `tests/e2e/test_tool_output_summary_e2e.py` — registers a tool returning a ~50KB string and checks that the capped form is what reaches context, through the registry, the OpenAI Agents `FunctionTool` callback, and the real `AgentLoop` driven by a mocked LLM backend.

## Docs

`docs/concepts/tool-system.mdx` gets an Output Budget section. `docs/tools/custom-tools.mdx` gets a note telling tool authors to return full output and let the budget handle size.

Closes #1160