### PR TITLE
Interactive goal-intake mode for Deep Work

### DIFF
--- a/docs/advanced/deep-work.mdx
+++ b/docs/advanced/deep-work.mdx
@@ -3,7 +3,7 @@ title: "Deep Work: Long-Running Autonomous Projects"
 description: "Deep Work is PocketPaw's AI-powered project orchestrator: describe a project and it researches the domain, writes a PRD, decomposes tasks with dependencies, assembles an agent team, and executes autonomously."
 section: Advanced
 ogType: article
-keywords: ["deep work", "project planning", "task decomposition", "multi-agent", "autonomous execution", "prd", "retry", "timeout", "pawkit"]
+keywords: ["deep work", "project planning", "task decomposition", "multi-agent", "autonomous execution", "prd", "retry", "timeout", "pawkit", "goal intake", "clarification"]
 tags: ["advanced", "orchestration", "multi-agent"]
 ---
 
@@ -16,6 +16,9 @@ Deep Work is PocketPaw's orchestration system for complex, multi-step projects. 
 <Steps>
   <Step title="Describe Your Project">
     Provide a natural-language description of what you want to build or accomplish.
+  </Step>
+  <Step title="Clarify (optional)">
+    If the goal is vague, Deep Work asks a few clarification questions first and folds your answers back into the goal. A clear goal skips this step. See [Interactive Goal Intake](#interactive-goal-intake).
   </Step>
   <Step title="AI Research & Planning">
     The planner agent researches the domain, writes a PRD, decomposes the project into atomic tasks, and recommends an agent team.
@@ -30,6 +33,75 @@ Deep Work is PocketPaw's orchestration system for complex, multi-step projects. 
     When all tasks finish, the project is marked complete and deliverables are saved to disk.
   </Step>
 </Steps>
+
+## Interactive Goal Intake
+
+Deep Work plans best from a well-formed goal — one with a verifiable end state, not a wish. A developer can write one straight off ("Build a REST API for recipe management with JWT auth, deployed on Fly.io"). A goal like "chase down overdue invoices" is too vague to plan well: how overdue, on what channel, do reminders escalate?
+
+Intake mode closes that gap. Before planning, Deep Work analyzes the goal and, if it is ambiguous, asks a short set of clarification questions. Your answers are folded back into the goal, and the planner works from the enriched version.
+
+**Intake is optional.** A goal the analyzer judges well-formed skips the conversation entirely and goes straight to planning — the one-shot path is unchanged.
+
+### How intake works
+
+<Steps>
+  <Step title="Analyze">
+    The goal parser inspects the goal. A clear goal produces no clarification questions; a vague one produces up to four.
+  </Step>
+  <Step title="Ask">
+    Each clarification question is surfaced to you — in the dashboard chat, this is a normal back-and-forth turn.
+  </Step>
+  <Step title="Fold">
+    Your answers are appended to the goal as a "Clarifications gathered during intake" block, producing an enriched goal. Skipped (blank) answers are dropped.
+  </Step>
+  <Step title="Plan">
+    The planner runs against the enriched goal. The intake transcript is stored on the project so the dashboard can show what shaped the plan.
+  </Step>
+</Steps>
+
+### Success criteria and preconditions
+
+Intake makes the planner produce two structured fields per task that used to be buried as free text in the description:
+
+| Field | Purpose |
+|-------|---------|
+| `success_criteria` | A verifiable end state — concrete "this task is done when…" checks (e.g. "the endpoint returns 200", "tests pass"), not vague claims like "works well". |
+| `preconditions` | "When NOT to act" guardrails — conditions that must hold before the task runs, or signals that mean it should be skipped. |
+
+`success_criteria` is what makes a task checkable after it runs — it is the foundation the [outcome-verification](#related) work builds on to confirm a task solved the original problem, not just that it finished.
+
+### Using intake
+
+```
+User: Start a deep work project to chase down overdue invoices
+Agent: A couple of questions before I plan this:
+       1. How many days overdue before an invoice counts?
+       2. Which channel should reminders go out on?
+User: 30 days, and email
+Agent: Got it. Planning a project to email reminders for invoices 30+ days overdue...
+```
+
+Via the REST API, intake is two calls — fetch the questions, then submit the goal with the answers:
+
+```bash
+# 1. Get clarification questions
+curl -X POST http://localhost:8000/api/deep-work/intake/clarify \
+  -H "Content-Type: application/json" \
+  -d '{"description": "Chase down overdue invoices"}'
+
+# 2. Submit the goal with the collected answers
+curl -X POST http://localhost:8000/api/deep-work/start-with-intake \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Chase down overdue invoices",
+    "answers": [
+      {"question": "How many days overdue before an invoice counts?", "answer": "30 days"},
+      {"question": "Which channel should reminders go out on?", "answer": "email"}
+    ]
+  }'
+```
+
+An empty `answers` list means the goal was well-formed — `start-with-intake` then behaves identically to `start`.
 
 ## Project Lifecycle
 
@@ -77,7 +149,7 @@ Decomposes the PRD into atomic tasks. Each task includes:
 |-------|-------------|
 | `key` | Short unique identifier (e.g., `t1`, `t2`) |
 | `title` | Human-readable name |
-| `description` | Full description with acceptance criteria |
+| `description` | Full description of the work |
 | `task_type` | `agent`, `human`, or `review` |
 | `priority` | `low`, `medium`, `high`, or `urgent` |
 | `estimated_minutes` | Time estimate (15-120 min range) |
@@ -85,7 +157,7 @@ Decomposes the PRD into atomic tasks. Each task includes:
 | `blocked_by_keys` | Dependencies on other tasks |
 | `max_retries` | How many times to auto-retry on failure (default: 1) |
 | `timeout_minutes` | Per-task execution time limit (optional) |
-| `success_criteria` | Objectively-verifiable conditions that must hold once the task is done — each a single concrete, checkable statement. Carried onto the materialized Mission Control Task so completion can be verified, not just marked finished. |
+| `success_criteria` | Objectively-verifiable conditions that must hold once the task is done — each a single concrete, checkable statement. Carried onto the materialized Mission Control Task so completion can be verified, not just marked finished. See [Success criteria and preconditions](#success-criteria-and-preconditions). |
 | `preconditions` | State or environment conditions that must hold before the task starts (or conditions under which it should not run). Distinct from `blocked_by_keys`, which tracks dependencies on other tasks. |
 
 ### 4. Team Assembly

--- a/docs/api/post-deep-work-intake-clarify.mdx
+++ b/docs/api/post-deep-work-intake-clarify.mdx
@@ -1,0 +1,106 @@
+---
+title: Clarify Goal (Intake)
+description: "Analyze a Deep Work goal and return the clarification questions needed before planning. The first step of the interactive intake mode — an empty question list means the goal is already well-formed."
+api: POST /api/deep-work/intake/clarify
+baseUrl: http://localhost:8000
+layout: '@/layouts/APIEndpointLayout.astro'
+auth: bearer
+section: API Reference
+ogType: article
+keywords: ["goal intake", "clarification", "deep work", "interactive planning"]
+tags: ["api", "deep-work"]
+---
+
+## Overview
+
+Inspects a project goal and returns the clarification questions the planner needs answered before it can plan well. This is the first step of [interactive intake mode](/advanced/deep-work#interactive-goal-intake).
+
+If `clarifications` comes back empty, the goal is already well-formed — skip straight to [Start Project](/api/post-deep-work-start), or call [Start with Intake](/api/post-deep-work-start-with-intake) with no answers, which is equivalent.
+
+Once you have the questions, collect answers from the user and submit them to [Start with Intake](/api/post-deep-work-start-with-intake).
+
+## Request Body
+
+<ResponseField name="description" type="string" required>
+  Natural-language description of the goal to analyze. Min 10, max 5000 characters.
+</ResponseField>
+
+## Response
+
+<ResponseField name="success" type="boolean">
+  Whether the goal was analyzed successfully.
+</ResponseField>
+
+<ResponseField name="clarifications" type="string[]">
+  Clarification questions to ask the user before planning. Up to four. Empty when the goal is well-formed.
+</ResponseField>
+
+<ResponseField name="needs_clarification" type="boolean">
+  Convenience flag — `true` when `clarifications` is non-empty.
+</ResponseField>
+
+<ResponseField name="goal_analysis" type="object">
+  The full structured goal analysis (domain, complexity, AI/human roles, suggested research depth).
+</ResponseField>
+
+<RequestExample>
+<Tabs items={["cURL", "JavaScript", "Python"]}>
+  <Tab title="cURL">
+```bash
+curl -X POST http://localhost:8000/api/deep-work/intake/clarify \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"description": "Chase down overdue invoices"}'
+```
+  </Tab>
+  <Tab title="JavaScript">
+```javascript
+const res = await fetch('http://localhost:8000/api/deep-work/intake/clarify', {
+  method: 'POST',
+  headers: {
+    'Authorization': 'Bearer YOUR_TOKEN',
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({ description: 'Chase down overdue invoices' }),
+});
+const data = await res.json();
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import httpx
+
+res = httpx.post(
+    "http://localhost:8000/api/deep-work/intake/clarify",
+    headers={"Authorization": "Bearer YOUR_TOKEN"},
+    json={"description": "Chase down overdue invoices"},
+)
+data = res.json()
+```
+  </Tab>
+</Tabs>
+</RequestExample>
+
+<ResponseExample>
+<Tabs items={["200"]}>
+  <Tab title="200">
+```json
+{
+  "success": true,
+  "needs_clarification": true,
+  "clarifications": [
+    "How many days overdue before an invoice counts?",
+    "Which channel should reminders go out on?"
+  ],
+  "goal_analysis": {
+    "goal": "Chase down overdue invoices",
+    "domain": "business",
+    "complexity": "M",
+    "suggested_research_depth": "quick",
+    "confidence": 0.5
+  }
+}
+```
+  </Tab>
+</Tabs>
+</ResponseExample>

--- a/docs/api/post-deep-work-start-with-intake.mdx
+++ b/docs/api/post-deep-work-start-with-intake.mdx
@@ -1,0 +1,131 @@
+---
+title: Start with Intake
+description: "Start a Deep Work project through the interactive intake mode — submit the goal plus clarification answers, and the goal is enriched before planning. An empty answers list behaves like a plain Start Project call."
+api: POST /api/deep-work/start-with-intake
+baseUrl: http://localhost:8000
+layout: '@/layouts/APIEndpointLayout.astro'
+auth: bearer
+section: API Reference
+ogType: article
+keywords: ["goal intake", "clarification", "deep work", "ai planning", "project creation"]
+tags: ["api", "deep-work"]
+---
+
+## Overview
+
+Starts a Deep Work project through [interactive intake mode](/advanced/deep-work#interactive-goal-intake). Submit the original goal plus the clarification answers you collected — Deep Work folds the answers into the goal and plans against the enriched version.
+
+The usual flow is two calls: [Clarify Goal](/api/post-deep-work-intake-clarify) to get the questions, then this endpoint with the answers.
+
+The project is returned immediately in `PLANNING` status. Planning runs in the background — track progress via WebSocket events (`dw_planning_phase`, `dw_planning_complete`), the same as [Start Project](/api/post-deep-work-start).
+
+An empty `answers` list means the goal was well-formed; this endpoint then behaves identically to [Start Project](/api/post-deep-work-start).
+
+## Request Body
+
+<ResponseField name="description" type="string" required>
+  The original natural-language goal. Min 10, max 5000 characters.
+</ResponseField>
+
+<ResponseField name="answers" type="object[]" default="[]">
+  Clarification answers collected from the intake conversation. Each entry has a `question` and an `answer`. Entries with a blank `answer` are treated as skipped and dropped.
+  <ResponseField name="question" type="string">The clarification question that was asked.</ResponseField>
+  <ResponseField name="answer" type="string">The user's answer. Blank means skipped.</ResponseField>
+</ResponseField>
+
+<ResponseField name="research_depth" type="string" default="auto">
+  How deeply to research before planning. One of: `auto`, `none`, `quick`, `standard`, `deep`. `auto` uses the goal parser's suggestion.
+</ResponseField>
+
+## Response
+
+<ResponseField name="success" type="boolean">
+  Whether the project was created successfully.
+</ResponseField>
+
+<ResponseField name="project" type="object">
+  The created project object. `description` is the enriched goal; `metadata.intake` holds the Q&A transcript.
+  <ResponseField name="id" type="string">Unique project ID.</ResponseField>
+  <ResponseField name="status" type="string">Current status — `planning` initially.</ResponseField>
+  <ResponseField name="created_at" type="string">ISO 8601 timestamp.</ResponseField>
+</ResponseField>
+
+<RequestExample>
+<Tabs items={["cURL", "JavaScript", "Python"]}>
+  <Tab title="cURL">
+```bash
+curl -X POST http://localhost:8000/api/deep-work/start-with-intake \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Chase down overdue invoices",
+    "answers": [
+      {"question": "How many days overdue before an invoice counts?", "answer": "30 days"},
+      {"question": "Which channel should reminders go out on?", "answer": "email"}
+    ]
+  }'
+```
+  </Tab>
+  <Tab title="JavaScript">
+```javascript
+const res = await fetch('http://localhost:8000/api/deep-work/start-with-intake', {
+  method: 'POST',
+  headers: {
+    'Authorization': 'Bearer YOUR_TOKEN',
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    description: 'Chase down overdue invoices',
+    answers: [
+      { question: 'How many days overdue before an invoice counts?', answer: '30 days' },
+      { question: 'Which channel should reminders go out on?', answer: 'email' },
+    ],
+  }),
+});
+const data = await res.json();
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import httpx
+
+res = httpx.post(
+    "http://localhost:8000/api/deep-work/start-with-intake",
+    headers={"Authorization": "Bearer YOUR_TOKEN"},
+    json={
+        "description": "Chase down overdue invoices",
+        "answers": [
+            {"question": "How many days overdue before an invoice counts?", "answer": "30 days"},
+            {"question": "Which channel should reminders go out on?", "answer": "email"},
+        ],
+    },
+)
+data = res.json()
+```
+  </Tab>
+</Tabs>
+</RequestExample>
+
+<ResponseExample>
+<Tabs items={["200"]}>
+  <Tab title="200">
+```json
+{
+  "success": true,
+  "project": {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "title": "Chase down overdue invoices",
+    "description": "Chase down overdue invoices\n\nClarifications gathered during intake:\n- How many days overdue before an invoice counts? → 30 days\n- Which channel should reminders go out on? → email",
+    "status": "planning",
+    "creator_id": "human",
+    "task_ids": [],
+    "team_agent_ids": [],
+    "tags": [],
+    "created_at": "2024-01-15T14:30:00Z",
+    "updated_at": "2024-01-15T14:30:00Z"
+  }
+}
+```
+  </Tab>
+</Tabs>
+</ResponseExample>

--- a/docs/docs-config.json
+++ b/docs/docs-config.json
@@ -756,7 +756,9 @@
           {
             "label": "Deep Work",
             "items": [
+              { "label": "Clarify Goal", "href": "/api/post-deep-work-intake-clarify", "method": "POST" },
               { "label": "Start Project", "href": "/api/post-deep-work-start", "method": "POST" },
+              { "label": "Start with Intake", "href": "/api/post-deep-work-start-with-intake", "method": "POST" },
               { "label": "Get Plan", "href": "/api/get-deep-work-plan", "method": "GET" },
               { "label": "Approve Plan", "href": "/api/post-deep-work-approve", "method": "POST" },
               { "label": "Pause Project", "href": "/api/post-deep-work-pause", "method": "POST" },

--- a/src/pocketpaw/deep_work/__init__.py
+++ b/src/pocketpaw/deep_work/__init__.py
@@ -1,5 +1,8 @@
 # Deep Work — AI project orchestration layer for PocketPaw.
 # Created: 2026-02-12
+# Updated: 2026-05-21 (feat/deep-work-intake) — issue #1161: exported the
+#   interactive intake primitives (GoalIntake, IntakeResult, QAPair) and
+#   added the start_deep_work_with_intake() convenience function.
 # Updated: 2026-02-26 — Deep Work v2: Added cancel_project() for project cancellation.
 #   Added PawKitConfig export. Retry/timeout/output fields propagated through.
 # Updated: 2026-02-18 — Added GoalParser and GoalAnalysis exports.
@@ -14,6 +17,7 @@
 #   reset_deep_work_session() -> None
 #   parse_goal(user_input) -> GoalAnalysis
 #   start_deep_work(user_input) -> Project
+#   start_deep_work_with_intake(user_input, answer_provider) -> Project
 #   approve_project(project_id) -> Project
 #   pause_project(project_id) -> Project
 #   resume_project(project_id) -> Project
@@ -22,7 +26,13 @@
 import logging
 
 from pocketpaw.deep_work.clock import SimulationClock, TickSnapshot
-from pocketpaw.deep_work.goal_parser import GoalAnalysis, GoalParser
+from pocketpaw.deep_work.goal_parser import (
+    GoalAnalysis,
+    GoalIntake,
+    GoalParser,
+    IntakeResult,
+    QAPair,
+)
 from pocketpaw.deep_work.models import (
     AgentSpec,
     PlannerResult,
@@ -36,10 +46,13 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "AgentSpec",
     "GoalAnalysis",
+    "GoalIntake",
     "GoalParser",
+    "IntakeResult",
     "PlannerResult",
     "Project",
     "ProjectStatus",
+    "QAPair",
     "SimulationClock",
     "TaskSpec",
     "TickSnapshot",
@@ -47,6 +60,7 @@ __all__ = [
     "reset_deep_work_session",
     "parse_goal",
     "start_deep_work",
+    "start_deep_work_with_intake",
     "approve_project",
     "pause_project",
     "resume_project",
@@ -104,6 +118,10 @@ async def parse_goal(user_input: str) -> GoalAnalysis:
 async def start_deep_work(user_input: str, research_depth: str = "standard") -> Project:
     """Submit a new project for Deep Work planning.
 
+    This is the one-shot path: the goal goes straight to the planner. For
+    a vague goal that needs clarification first, use
+    :func:`start_deep_work_with_intake`.
+
     Args:
         user_input: Natural language project description.
         research_depth: "none" (skip), "quick", "standard", or "deep".
@@ -113,6 +131,33 @@ async def start_deep_work(user_input: str, research_depth: str = "standard") -> 
     """
     session = get_deep_work_session()
     return await session.start(user_input, research_depth=research_depth)
+
+
+async def start_deep_work_with_intake(
+    user_input: str,
+    answer_provider,
+    research_depth: str = "auto",
+) -> Project:
+    """Submit a project through the interactive intake mode (issue #1161).
+
+    Runs a clarification conversation for a vague goal before planning. A
+    well-formed goal skips the conversation and behaves like
+    :func:`start_deep_work`.
+
+    Args:
+        user_input: Natural language project description (may be vague).
+        answer_provider: Async callable ``(question: str) -> str`` that
+            answers each clarification question.
+        research_depth: "auto" (goal-parser suggestion), "none", "quick",
+            "standard", or "deep".
+
+    Returns:
+        The created Project (status=AWAITING_APPROVAL after planning).
+    """
+    session = get_deep_work_session()
+    return await session.start_with_intake(
+        user_input, answer_provider, research_depth=research_depth
+    )
 
 
 async def approve_project(project_id: str) -> Project:

--- a/src/pocketpaw/deep_work/api.py
+++ b/src/pocketpaw/deep_work/api.py
@@ -1,5 +1,11 @@
 # Deep Work API endpoints.
 # Created: 2026-02-12
+# Updated: 2026-05-21 (feat/deep-work-intake) — issue #1161: added the
+#   interactive intake endpoints. POST /intake/clarify returns the
+#   clarification questions for a vague goal (empty list = well-formed,
+#   no intake needed). POST /start-with-intake submits the goal plus the
+#   collected answers — the goal is enriched before planning. The plain
+#   POST /start one-shot path is unchanged.
 # Updated: 2026-02-26 — Deep Work v2: Added cancel and retry endpoints.
 #   POST /projects/{id}/cancel — cancel project, stop all tasks
 #   POST /projects/{id}/tasks/{tid}/retry — manual retry of a failed task
@@ -8,7 +14,9 @@
 #
 # FastAPI router for Deep Work orchestration:
 #   POST /parse-goal                          — analyze goal (domain, complexity)
-#   POST /start                               — submit project (natural language)
+#   POST /intake/clarify                      — get clarification questions for a goal
+#   POST /start                               — submit project (one-shot)
+#   POST /start-with-intake                   — submit project + clarification answers
 #   GET  /projects/{id}/plan                  — get plan with execution_levels
 #   POST /projects/{id}/approve               — approve plan, start execution
 #   POST /projects/{id}/pause                 — pause execution
@@ -58,6 +66,43 @@ class StartDeepWorkRequest(BaseModel):
     )
 
 
+class ClarifyGoalRequest(BaseModel):
+    """Request body for the intake clarification step (issue #1161)."""
+
+    description: str = Field(
+        ..., min_length=10, max_length=5000, description="Natural language goal description"
+    )
+
+
+class IntakeAnswer(BaseModel):
+    """One clarification question and the user's answer to it."""
+
+    question: str = Field(..., description="The clarification question that was asked")
+    answer: str = Field(default="", description="The user's answer (blank = skipped)")
+
+
+class StartWithIntakeRequest(BaseModel):
+    """Request body for starting a project through the intake mode.
+
+    The dashboard first calls ``/intake/clarify`` to get the questions,
+    collects answers in a chat turn, then submits them here. An empty
+    ``answers`` list means the goal was well-formed and intake was a
+    no-op — this behaves identically to ``/start``.
+    """
+
+    description: str = Field(
+        ..., min_length=10, max_length=5000, description="Natural language project description"
+    )
+    answers: list[IntakeAnswer] = Field(
+        default_factory=list,
+        description="Clarification answers collected from the intake conversation",
+    )
+    research_depth: str = Field(
+        default="auto",
+        description="Research thoroughness: 'auto', 'none', 'quick', 'standard', or 'deep'",
+    )
+
+
 def _enrich_project_dict(project_dict: dict) -> dict:
     """Add folder_path and file_count to a project dict for frontend output panel."""
     from pathlib import Path
@@ -97,9 +142,39 @@ async def parse_goal(request: ParseGoalRequest) -> dict[str, Any]:
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.post("/intake/clarify")
+async def clarify_goal(request: ClarifyGoalRequest) -> dict[str, Any]:
+    """Return the clarification questions for a goal (issue #1161).
+
+    This is the first step of the interactive intake mode. The frontend
+    calls it, shows each question in a chat turn, collects answers, then
+    posts them to ``/start-with-intake``.
+
+    An empty ``clarifications`` list means the goal is already well-formed
+    — the frontend should skip straight to ``/start`` (or call
+    ``/start-with-intake`` with no answers, which is equivalent).
+    """
+    from pocketpaw.deep_work.goal_parser import GoalParser
+
+    try:
+        parser = GoalParser()
+        analysis = await parser.parse(request.description)
+        return {
+            "success": True,
+            "clarifications": analysis.clarifications_needed,
+            "needs_clarification": analysis.needs_clarification,
+            "goal_analysis": analysis.to_dict(),
+        }
+    except RuntimeError as e:
+        raise HTTPException(status_code=502, detail=str(e))
+    except Exception as e:
+        logger.exception(f"Goal clarification failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.post("/start")
 async def start_deep_work(request: StartDeepWorkRequest) -> dict[str, Any]:
-    """Submit a new project for Deep Work planning.
+    """Submit a new project for Deep Work planning (one-shot path).
 
     Returns the project immediately in PLANNING status and runs the
     planner in the background. Frontend tracks progress via WebSocket
@@ -132,6 +207,68 @@ async def start_deep_work(request: StartDeepWorkRequest) -> dict[str, Any]:
             )
         except Exception as e:
             logger.exception(f"Background planning failed for {project.id}: {e}")
+
+    asyncio.create_task(_plan_in_background())
+
+    return {"success": True, "project": project.to_dict()}
+
+
+@router.post("/start-with-intake")
+async def start_deep_work_with_intake(request: StartWithIntakeRequest) -> dict[str, Any]:
+    """Submit a project through the interactive intake mode (issue #1161).
+
+    The frontend has already run the clarification conversation (via
+    ``/intake/clarify``) and collected answers. This endpoint folds those
+    answers into the goal, then plans against the *enriched* goal.
+
+    Returns the project immediately in PLANNING status; planning (and the
+    final re-parse of the enriched goal) runs in the background, tracked
+    via the same WebSocket events as ``/start``.
+
+    With an empty ``answers`` list this is equivalent to ``/start`` — the
+    goal is used as-is.
+    """
+    from pocketpaw.deep_work import get_deep_work_session
+    from pocketpaw.deep_work.goal_parser import QAPair, _fold_transcript
+    from pocketpaw.deep_work.models import ProjectStatus
+    from pocketpaw.mission_control.manager import get_mission_control_manager
+
+    manager = get_mission_control_manager()
+
+    # Fold the collected answers into the goal up-front. This is pure
+    # string work (no LLM call), so the project description we persist and
+    # return is already the enriched one. Blank answers are dropped.
+    transcript = [
+        QAPair(question=a.question, answer=a.answer)
+        for a in request.answers
+        if a.answer and a.answer.strip()
+    ]
+    enriched_goal = _fold_transcript(request.description, transcript)
+
+    project = await manager.create_project(
+        title=enriched_goal[:80],
+        description=enriched_goal,
+        creator_id="human",
+    )
+    project.status = ProjectStatus.PLANNING
+    project.metadata["intake"] = {
+        "original_input": request.description,
+        "enriched_goal": enriched_goal,
+        "transcript": [qa.to_dict() for qa in transcript],
+        "clarified": len(transcript) > 0,
+    }
+    await manager.update_project(project)
+
+    async def _plan_in_background():
+        session = get_deep_work_session()
+        try:
+            await session.plan_existing_project(
+                project.id,
+                enriched_goal,
+                research_depth=request.research_depth,
+            )
+        except Exception as e:
+            logger.exception(f"Background intake planning failed for {project.id}: {e}")
 
     asyncio.create_task(_plan_in_background())
 

--- a/src/pocketpaw/deep_work/goal_parser.py
+++ b/src/pocketpaw/deep_work/goal_parser.py
@@ -1,5 +1,12 @@
 # Deep Work Goal Parser — structured goal analysis via LLM.
 # Created: 2026-02-18
+# Updated: 2026-05-21 (feat/deep-work-intake) — issue #1161: added the
+#   interactive intake loop. GoalParser already produced a
+#   `clarifications_needed` list but nothing asked the questions. The new
+#   GoalIntake runs that conversation: it asks each clarification, takes an
+#   answer via an injected async callback, folds the Q&A back into the goal
+#   text, and re-parses so planning starts from a well-formed goal. A
+#   well-formed goal (no clarifications) skips the loop entirely.
 #
 # First primitive in the Deep Work pipeline. Takes messy human input
 # and produces a structured GoalAnalysis: domain detection, complexity
@@ -9,14 +16,23 @@
 #   GoalAnalysis — dataclass with parsed goal structure
 #   GoalParser.parse(user_input) -> GoalAnalysis
 #   GoalParser.parse_raw(raw_json) -> GoalAnalysis (for testing)
+#   IntakeResult — dataclass: enriched goal text + Q&A transcript + analysis
+#   GoalIntake.run(user_input, answer_provider) -> IntakeResult
 
 import json
 import logging
 import re
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Max clarification rounds before the intake loop gives up. The parser
+# already caps `clarifications_needed` at 4, but a defensive bound here
+# keeps a misbehaving answer provider (one that keeps surfacing new
+# ambiguity) from looping forever.
+MAX_INTAKE_ROUNDS = 3
 
 # Regex to strip markdown code fences (```json ... ``` or ``` ... ```)
 _CODE_FENCE_RE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?\s*```", re.DOTALL)
@@ -273,3 +289,188 @@ def _clamp(value, minimum, maximum):
         return max(minimum, min(maximum, float(value)))
     except (TypeError, ValueError):
         return minimum
+
+
+# ============================================================================
+# Interactive intake (issue #1161)
+# ============================================================================
+#
+# `clarifications_needed` is the half-built intake: it holds the exact
+# questions you would ask a human to disambiguate a vague goal, but nothing
+# asks them. GoalIntake closes that loop.
+#
+# An "answer provider" is any async callable `(question: str) -> str`. The
+# dashboard wires it to a chat turn; tests wire it to a dict lookup; a CLI
+# could wire it to `input()`. The intake layer doesn't care where answers
+# come from — it just asks, collects, and folds.
+
+
+# An answer provider takes a clarification question and returns the human's
+# answer. Async so a real implementation can await a chat round-trip.
+AnswerProvider = Callable[[str], Awaitable[str]]
+
+
+@dataclass
+class QAPair:
+    """A single clarification question and the answer the human gave."""
+
+    question: str
+    answer: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"question": self.question, "answer": self.answer}
+
+
+@dataclass
+class IntakeResult:
+    """Outcome of an interactive goal-intake conversation.
+
+    Attributes:
+        original_input: The raw goal the user first submitted.
+        enriched_goal: The goal text after folding in clarification answers.
+            This is what gets handed to the planner. When no clarification
+            was needed it equals ``original_input``.
+        transcript: Ordered Q&A pairs collected during intake (empty when
+            the goal was well-formed and intake was skipped).
+        analysis: The final GoalAnalysis (re-parsed after enrichment when
+            clarifications were folded in).
+        clarified: True if at least one clarification question was answered.
+    """
+
+    original_input: str = ""
+    enriched_goal: str = ""
+    transcript: list[QAPair] = field(default_factory=list)
+    analysis: GoalAnalysis = field(default_factory=GoalAnalysis)
+    clarified: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization / API output."""
+        return {
+            "original_input": self.original_input,
+            "enriched_goal": self.enriched_goal,
+            "transcript": [qa.to_dict() for qa in self.transcript],
+            "analysis": self.analysis.to_dict(),
+            "clarified": self.clarified,
+        }
+
+
+class GoalIntake:
+    """Runs the interactive clarification conversation for a vague goal.
+
+    Wraps :class:`GoalParser`. The flow:
+
+      1. Parse the raw input into a GoalAnalysis.
+      2. If ``clarifications_needed`` is empty, the goal is well-formed —
+         return immediately with the input unchanged (one-shot path).
+      3. Otherwise, ask each question via the injected answer provider,
+         collect the answers, and fold the Q&A into an enriched goal text.
+      4. Re-parse the enriched goal so planning starts from a clean
+         analysis. If the re-parse still surfaces clarifications, loop —
+         bounded by ``MAX_INTAKE_ROUNDS``.
+
+    GoalIntake never blocks on a real human directly; the caller supplies
+    the answer provider. That keeps this class testable and channel-agnostic.
+    """
+
+    def __init__(self, parser: GoalParser | None = None) -> None:
+        self.parser = parser or GoalParser()
+
+    async def run(
+        self,
+        user_input: str,
+        answer_provider: AnswerProvider,
+    ) -> IntakeResult:
+        """Run intake for ``user_input``, asking questions as needed.
+
+        Args:
+            user_input: The raw goal description from the user.
+            answer_provider: Async callable that, given a clarification
+                question, returns the human's answer. Called once per
+                question. An empty-string answer is treated as "skip this
+                question" and is not folded into the goal.
+
+        Returns:
+            An :class:`IntakeResult`. ``enriched_goal`` is what the caller
+            should hand to the planner.
+        """
+        analysis = await self.parser.parse(user_input)
+
+        # Fast path: a well-formed goal needs no conversation. This is the
+        # existing one-shot behaviour — start_deep_work(good_goal) still
+        # runs straight through.
+        if not analysis.needs_clarification:
+            logger.info("Goal intake: no clarifications needed, skipping intake loop")
+            return IntakeResult(
+                original_input=user_input,
+                enriched_goal=user_input,
+                transcript=[],
+                analysis=analysis,
+                clarified=False,
+            )
+
+        transcript: list[QAPair] = []
+        enriched_goal = user_input
+
+        for round_num in range(1, MAX_INTAKE_ROUNDS + 1):
+            questions = list(analysis.clarifications_needed)
+            if not questions:
+                break
+
+            logger.info(
+                "Goal intake round %d: asking %d clarification(s)",
+                round_num,
+                len(questions),
+            )
+
+            asked_this_round = 0
+            for question in questions:
+                answer = await answer_provider(question)
+                answer = (answer or "").strip()
+                if not answer:
+                    # Treat a blank answer as "no further detail" — record
+                    # nothing and move on rather than polluting the goal.
+                    continue
+                transcript.append(QAPair(question=question, answer=answer))
+                asked_this_round += 1
+
+            if asked_this_round == 0:
+                # The human skipped every question this round. Folding
+                # nothing in and re-parsing would just resurface the same
+                # questions, so stop here with what we have.
+                logger.info("Goal intake: all questions skipped, ending intake")
+                break
+
+            # Fold the full Q&A transcript into the goal and re-parse so
+            # the planner sees a single coherent, enriched goal.
+            enriched_goal = _fold_transcript(user_input, transcript)
+            analysis = await self.parser.parse(enriched_goal)
+
+        clarified = len(transcript) > 0
+        # When the goal was clarified, the enriched text is the real goal —
+        # make sure the analysis.goal reflects it rather than the vague input.
+        if clarified and not analysis.goal:
+            analysis.goal = enriched_goal[:200]
+
+        return IntakeResult(
+            original_input=user_input,
+            enriched_goal=enriched_goal,
+            transcript=transcript,
+            analysis=analysis,
+            clarified=clarified,
+        )
+
+
+def _fold_transcript(original_input: str, transcript: list[QAPair]) -> str:
+    """Build an enriched goal string from the original input + Q&A.
+
+    The result is plain text the planner's prompts can consume directly:
+    the original goal followed by a "Clarifications" block. Keeping it as
+    readable prose (not JSON) means every downstream prompt — research,
+    PRD, task breakdown — gets the extra context for free.
+    """
+    if not transcript:
+        return original_input
+    lines = [original_input.strip(), "", "Clarifications gathered during intake:"]
+    for qa in transcript:
+        lines.append(f"- {qa.question.strip()} → {qa.answer.strip()}")
+    return "\n".join(lines)

--- a/src/pocketpaw/deep_work/session.py
+++ b/src/pocketpaw/deep_work/session.py
@@ -1,5 +1,12 @@
 # Deep Work Session — project lifecycle orchestrator.
 # Created: 2026-02-12
+# Updated: 2026-05-21 (feat/deep-work-intake) — issue #1161: added the
+#   optional interactive intake mode. start_with_intake() runs GoalIntake's
+#   clarification loop before planning so a vague goal becomes well-formed.
+#   The one-shot start() path is untouched — a good goal still skips
+#   straight to GoalParser. _materialize_tasks now carries success_criteria
+#   and preconditions from TaskSpec onto each MC Task's metadata so the
+#   outcome-verification sibling (issue #1162) can check them later.
 # Updated: 2026-02-26 — Deep Work v2: Added cancel() method for project cancellation.
 #   _materialize_tasks now copies max_retries and timeout_minutes from TaskSpec to Task.
 #   New broadcast: dw_project_cancelled. Cancel stops all running tasks and skips pending.
@@ -7,13 +14,15 @@
 # Updated: 2026-02-17 — Record planning errors to health engine ErrorStore.
 # Updated: 2026-02-12 — Added executor integration for pause/stop.
 #
-# Ties together GoalParser, Planner, DependencyScheduler, MCTaskExecutor,
-# and HumanTaskRouter into a single class that manages a Deep Work project
-# from user input through goal analysis, planning, approval, execution,
-# and completion.
+# Ties together GoalParser, GoalIntake, Planner, DependencyScheduler,
+# MCTaskExecutor, and HumanTaskRouter into a single class that manages a
+# Deep Work project from user input through goal analysis, optional
+# clarification intake, planning, approval, execution, and completion.
 #
 # Public API:
 #   session.start(user_input) -> Project   (create + plan + await approval)
+#   session.start_with_intake(user_input, answer_provider) -> Project
+#       (run clarification loop, then plan with the enriched goal)
 #   session.approve(project_id) -> Project (kick off ready tasks)
 #   session.pause(project_id) -> Project   (stop running tasks)
 #   session.resume(project_id) -> Project  (resume dispatching)
@@ -182,6 +191,71 @@ class DeepWorkSession:
         # 2. Run planning on the new project
         return await self.plan_existing_project(
             project.id, user_input, research_depth=research_depth
+        )
+
+    async def start_with_intake(
+        self,
+        user_input: str,
+        answer_provider,
+        research_depth: str = "auto",
+    ) -> Project:
+        """Create a project, run interactive intake, then plan (issue #1161).
+
+        This is the optional intake front-end for a vague goal. It runs
+        :class:`GoalIntake`'s clarification loop first — asking questions
+        through ``answer_provider`` and folding the answers back into the
+        goal — and only then hands the *enriched* goal to the planner.
+
+        A well-formed goal still costs nothing extra: GoalIntake parses it,
+        sees no ``clarifications_needed``, and returns immediately, so this
+        path collapses to the same behaviour as :meth:`start`.
+
+        The full intake transcript is stored in ``project.metadata`` under
+        ``"intake"`` so the dashboard can render the conversation that
+        shaped the plan.
+
+        Args:
+            user_input: Natural language project description (may be vague).
+            answer_provider: Async callable ``(question: str) -> str`` that
+                supplies an answer for each clarification question. The
+                dashboard wires this to a chat turn.
+            research_depth: How thorough to research — "auto" (use the goal
+                parser's suggestion), "none", "quick", "standard", or "deep".
+
+        Returns:
+            The created Project (status=AWAITING_APPROVAL on success).
+        """
+        from pocketpaw.deep_work.goal_parser import GoalIntake
+
+        # Phase -1: interactive clarification. GoalIntake re-parses the
+        # enriched goal internally, so its result.analysis is already the
+        # post-clarification analysis — pass it to planning to avoid a
+        # redundant parse.
+        intake = GoalIntake()
+        result = await intake.run(user_input, answer_provider)
+
+        if result.clarified:
+            logger.info(
+                "Deep Work intake clarified goal with %d Q&A pair(s)",
+                len(result.transcript),
+            )
+
+        # Create the project from the enriched goal — the description the
+        # user (and the planner) should see is the clarified one.
+        project = await self.manager.create_project(
+            title=result.enriched_goal[:80],
+            description=result.enriched_goal,
+            creator_id="human",
+        )
+        # Stash the intake transcript so the UI can show what was asked.
+        project.metadata["intake"] = result.to_dict()
+        await self.manager.update_project(project)
+
+        return await self.plan_existing_project(
+            project.id,
+            result.enriched_goal,
+            research_depth=research_depth,
+            goal_analysis=result.analysis.to_dict(),
         )
 
     async def plan_existing_project(
@@ -645,6 +719,16 @@ class DeepWorkSession:
             task.max_retries = spec.max_retries
             task.timeout_minutes = spec.timeout_minutes
             task.blocked_by = [key_to_id[k] for k in spec.blocked_by_keys if k in key_to_id]
+
+            # Carry the intake-captured verifiable end state and "when not
+            # to act" guardrails onto the MC Task. They live in metadata
+            # rather than as first-class Task columns so this PR stays
+            # scoped to deep_work — the outcome-verification sibling
+            # (issue #1162) reads task.metadata["success_criteria"].
+            if spec.success_criteria:
+                task.metadata["success_criteria"] = list(spec.success_criteria)
+            if spec.preconditions:
+                task.metadata["preconditions"] = list(spec.preconditions)
 
             # Set inverse blocks on upstream tasks
             for dep_key in spec.blocked_by_keys:

--- a/tests/test_deep_work_e2e.py
+++ b/tests/test_deep_work_e2e.py
@@ -1,0 +1,355 @@
+# End-to-end tests for the Deep Work interactive intake mode (issue #1161).
+# Created: 2026-05-21 (feat/deep-work-intake)
+#
+# These exercise the full intake → planning path against a real
+# DeepWorkSession + real GoalParser + real PlannerAgent + real
+# FileMissionControlStore. Only the LLM boundary is mocked — both the
+# GoalParser and the PlannerAgent reach the model through ``_run_prompt``,
+# which we replace with scripted responses.
+#
+# Coverage:
+#   - A vague goal triggers the clarification loop.
+#   - The clarification questions are surfaced to the answer provider.
+#   - The collected answers are folded into the goal that planning sees.
+#   - Planning runs to completion and produces a project + MC tasks.
+#   - The resulting MC tasks carry the intake-captured ``success_criteria``.
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pocketpaw.deep_work.models import ProjectStatus
+from pocketpaw.deep_work.planner import PlannerAgent
+from pocketpaw.deep_work.session import DeepWorkSession
+from pocketpaw.mission_control.manager import (
+    MissionControlManager,
+    reset_mission_control_manager,
+)
+from pocketpaw.mission_control.store import (
+    FileMissionControlStore,
+    reset_mission_control_store,
+)
+
+# ---------------------------------------------------------------------------
+# Scripted LLM responses
+# ---------------------------------------------------------------------------
+
+# Goal parser, first call: a vague goal — two clarifications needed.
+GOAL_PARSE_VAGUE = json.dumps(
+    {
+        "goal": "Chase down overdue invoices",
+        "domain": "business",
+        "complexity": "M",
+        "estimated_phases": 2,
+        "clarifications_needed": [
+            "How many days overdue before an invoice counts?",
+            "Which channel should reminders go out on?",
+        ],
+        "suggested_research_depth": "quick",
+        "confidence": 0.5,
+    }
+)
+
+# Goal parser, second call (after answers folded in): well-formed now.
+GOAL_PARSE_CLEAR = json.dumps(
+    {
+        "goal": "Email reminders for invoices 30+ days overdue",
+        "domain": "business",
+        "complexity": "M",
+        "estimated_phases": 2,
+        "clarifications_needed": [],
+        "suggested_research_depth": "quick",
+        "confidence": 0.9,
+    }
+)
+
+# Planner task-breakdown response — two tasks, each with success_criteria
+# and preconditions (the fields issue #1161 adds to TaskSpec).
+PLANNER_TASKS = json.dumps(
+    [
+        {
+            "key": "t1",
+            "title": "Pull the list of overdue invoices",
+            "description": "Query accounting for invoices 30+ days overdue",
+            "task_type": "agent",
+            "priority": "high",
+            "tags": ["finance"],
+            "estimated_minutes": 20,
+            "required_specialties": ["data"],
+            "blocked_by_keys": [],
+            "success_criteria": [
+                "A list of invoices each 30+ days past due is produced",
+                "Every row has an amount and a customer email",
+            ],
+            "preconditions": ["Skip if the accounting connector is not configured"],
+        },
+        {
+            "key": "t2",
+            "title": "Send reminder emails",
+            "description": "Email each overdue customer a payment reminder",
+            "task_type": "agent",
+            "priority": "high",
+            "tags": ["finance"],
+            "estimated_minutes": 30,
+            "required_specialties": ["email"],
+            "blocked_by_keys": ["t1"],
+            "success_criteria": ["One reminder email is sent per overdue invoice"],
+            "preconditions": ["Do not email customers flagged do-not-contact"],
+        },
+    ]
+)
+
+# Planner team-assembly response.
+PLANNER_TEAM = json.dumps(
+    [
+        {
+            "name": "finance-bot",
+            "role": "Finance Assistant",
+            "description": "Handles invoice chasing",
+            "specialties": ["data", "email"],
+            "backend": "claude_agent_sdk",
+        }
+    ]
+)
+
+# A short PRD / research blob — anything non-empty works.
+PRD_TEXT = "# Overdue Invoice Chaser\n\n## Problem Statement\nChase overdue invoices."
+RESEARCH_TEXT = "Domain overview: invoice collection."
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_store_path():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture
+def manager(temp_store_path):
+    reset_mission_control_store()
+    reset_mission_control_manager()
+    return MissionControlManager(FileMissionControlStore(temp_store_path))
+
+
+@pytest.fixture
+def mock_executor():
+    executor = MagicMock()
+    executor.is_task_running = MagicMock(return_value=False)
+    executor.stop_task = AsyncMock(return_value=True)
+    executor.execute_task_background = AsyncMock()
+    return executor
+
+
+@pytest.fixture
+def mock_human_router():
+    router = MagicMock()
+    router.notify_human_task = AsyncMock()
+    router.notify_review_task = AsyncMock()
+    router.notify_plan_ready = AsyncMock()
+    router.notify_project_completed = AsyncMock()
+    return router
+
+
+@pytest.fixture
+def planner(manager):
+    """A real PlannerAgent with its LLM boundary (_run_prompt) scripted.
+
+    The planner runs research → PRD → task breakdown → team assembly. We
+    return the right scripted blob based on which phase the prompt is for,
+    so a real PlannerResult (with TaskSpecs) comes out the other end.
+    """
+    agent = PlannerAgent(manager)
+
+    async def scripted_run_prompt(prompt: str, router=None) -> str:
+        # Cheap phase detection off the prompt's distinguishing text.
+        if "JSON array of task objects" in prompt or "project architect" in prompt:
+            return PLANNER_TASKS
+        if "team architect" in prompt:
+            return PLANNER_TEAM
+        if "product manager" in prompt:
+            return PRD_TEXT
+        return RESEARCH_TEXT
+
+    agent._run_prompt = scripted_run_prompt
+    return agent
+
+
+@pytest.fixture
+def session(manager, mock_executor, planner, mock_human_router):
+    return DeepWorkSession(
+        manager=manager,
+        executor=mock_executor,
+        planner=planner,
+        human_router=mock_human_router,
+    )
+
+
+def _patched_goal_parser():
+    """Patch GoalParser._run_prompt so both the initial parse (vague) and
+    the post-fold re-parse (clear) get scripted responses in order."""
+    calls = {"n": 0}
+    responses = [GOAL_PARSE_VAGUE, GOAL_PARSE_CLEAR]
+
+    async def scripted(self, prompt: str) -> str:  # noqa: ARG001
+        idx = min(calls["n"], len(responses) - 1)
+        calls["n"] += 1
+        return responses[idx]
+
+    return patch.object(
+        __import__("pocketpaw.deep_work.goal_parser", fromlist=["GoalParser"]).GoalParser,
+        "_run_prompt",
+        scripted,
+    ), calls
+
+
+# ---------------------------------------------------------------------------
+# End-to-end intake tests
+# ---------------------------------------------------------------------------
+
+
+class TestIntakeEndToEnd:
+    """The full vague-goal → clarify → fold → plan path."""
+
+    @pytest.mark.asyncio
+    async def test_vague_goal_runs_intake_then_plans(self, session, manager):
+        """A vague goal: clarifications are asked, answers folded, planning
+        runs to AWAITING_APPROVAL, and the resulting tasks carry
+        success_criteria."""
+        parser_patch, parser_calls = _patched_goal_parser()
+
+        asked: list[str] = []
+
+        async def answer_provider(question: str) -> str:
+            asked.append(question)
+            if "overdue" in question:
+                return "30 days"
+            return "email"
+
+        with parser_patch:
+            project = await session.start_with_intake(
+                "Chase down overdue invoices", answer_provider
+            )
+
+        # --- intake happened ---
+        # Both clarification questions were surfaced to the human.
+        assert len(asked) == 2
+        # The goal parser ran twice: initial vague parse + re-parse of the
+        # enriched goal.
+        assert parser_calls["n"] == 2
+
+        # --- the answers were folded into the planned goal ---
+        assert project.metadata.get("intake") is not None
+        intake = project.metadata["intake"]
+        assert intake["clarified"] is True
+        assert "30 days" in intake["enriched_goal"]
+        assert "email" in intake["enriched_goal"]
+        # The project description is the enriched goal.
+        assert "Chase down overdue invoices" in project.description
+        assert "30 days" in project.description
+
+        # --- planning ran to completion ---
+        assert project.status == ProjectStatus.AWAITING_APPROVAL
+
+        # --- resulting MC tasks carry success_criteria ---
+        tasks = await manager.get_project_tasks(project.id)
+        assert len(tasks) == 2
+        for task in tasks:
+            criteria = task.metadata.get("success_criteria")
+            assert criteria, f"task {task.title!r} is missing success_criteria"
+            assert isinstance(criteria, list)
+            assert all(isinstance(c, str) and c for c in criteria)
+
+        # The first task's preconditions also rode through.
+        t1 = next(t for t in tasks if "Pull the list" in t.title)
+        assert t1.metadata.get("preconditions") == [
+            "Skip if the accounting connector is not configured"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_success_criteria_survive_store_round_trip(self, session, manager):
+        """success_criteria persisted on a task must reload intact — this is
+        the field the outcome-verification sibling (#1162) depends on."""
+        parser_patch, _ = _patched_goal_parser()
+
+        async def answer_provider(question: str) -> str:
+            return "a concrete answer"
+
+        with parser_patch:
+            project = await session.start_with_intake(
+                "Chase down overdue invoices", answer_provider
+            )
+
+        # Reload each task fresh from the store (not the in-memory copy).
+        tasks = await manager.get_project_tasks(project.id)
+        for task in tasks:
+            reloaded = await manager.get_task(task.id)
+            assert reloaded is not None
+            assert reloaded.metadata.get("success_criteria") == task.metadata.get(
+                "success_criteria"
+            )
+
+    @pytest.mark.asyncio
+    async def test_intake_transcript_recorded_in_order(self, session, manager):
+        """The Q&A transcript on the project preserves question order."""
+        parser_patch, _ = _patched_goal_parser()
+
+        async def answer_provider(question: str) -> str:
+            return "30 days" if "overdue" in question else "email"
+
+        with parser_patch:
+            project = await session.start_with_intake(
+                "Chase down overdue invoices", answer_provider
+            )
+
+        transcript = project.metadata["intake"]["transcript"]
+        assert len(transcript) == 2
+        assert "overdue" in transcript[0]["question"]
+        assert transcript[0]["answer"] == "30 days"
+        assert transcript[1]["answer"] == "email"
+
+
+class TestIntakeOneShotPath:
+    """A well-formed goal must skip intake and behave like start()."""
+
+    @pytest.mark.asyncio
+    async def test_well_formed_goal_skips_clarification(self, session, manager):
+        """When the goal parser surfaces no clarifications, the answer
+        provider is never called and planning runs straight through."""
+        calls = {"n": 0}
+
+        async def scripted(self, prompt: str) -> str:  # noqa: ARG001
+            calls["n"] += 1
+            # Always well-formed — no clarifications_needed.
+            return GOAL_PARSE_CLEAR
+
+        asked: list[str] = []
+
+        async def answer_provider(question: str) -> str:
+            asked.append(question)
+            return "unused"
+
+        from pocketpaw.deep_work.goal_parser import GoalParser
+
+        with patch.object(GoalParser, "_run_prompt", scripted):
+            project = await session.start_with_intake(
+                "Email reminders for invoices 30+ days overdue", answer_provider
+            )
+
+        # The answer provider was never invoked — intake was a no-op.
+        assert asked == []
+        # Parser ran exactly once (the initial parse; no re-parse needed).
+        assert calls["n"] == 1
+        # Planning still completed.
+        assert project.status == ProjectStatus.AWAITING_APPROVAL
+        # intake metadata records that nothing was clarified.
+        assert project.metadata["intake"]["clarified"] is False
+
+        tasks = await manager.get_project_tasks(project.id)
+        assert len(tasks) == 2

--- a/tests/test_deep_work_goal_parser.py
+++ b/tests/test_deep_work_goal_parser.py
@@ -1,12 +1,10 @@
 # Tests for Deep Work Goal Parser module.
 # Created: 2026-02-18
-#
-# Tests cover:
-#   - GoalAnalysis dataclass: from_dict, to_dict, defaults, properties
-#   - GoalParser.parse_raw(): valid JSON, fenced JSON, invalid input
-#   - GoalParser._strip_code_fences(): edge cases
-#   - Validation helpers: domain, complexity, research depth, clamp
-#   - GoalParser.parse(): full flow with mocked _run_prompt
+# Updated: 2026-05-21 (feat/deep-work-intake) — issue #1161: added the
+#   GoalIntake test suite — the interactive clarification loop with mocked
+#   answer providers. Covers the well-formed-goal fast path (intake
+#   skipped), the vague-goal path (questions asked, answers folded,
+#   goal re-parsed), blank-answer handling, and the round bound.
 
 import json
 from unittest.mock import MagicMock, patch
@@ -15,12 +13,17 @@ import pytest
 
 from pocketpaw.agents.protocol import AgentEvent
 from pocketpaw.deep_work.goal_parser import (
+    MAX_INTAKE_ROUNDS,
     VALID_COMPLEXITIES,
     VALID_DOMAINS,
     VALID_RESEARCH_DEPTHS,
     GoalAnalysis,
+    GoalIntake,
     GoalParser,
+    IntakeResult,
+    QAPair,
     _clamp,
+    _fold_transcript,
     _sanitize_str_list,
     _validate_complexity,
     _validate_domain,
@@ -708,3 +711,257 @@ class TestPromptInjection:
         # Malicious format string should not cause KeyError
         await parser.parse("Build {__class__.__mro__[1]}")
         assert captured_prompt is not None
+
+
+# ============================================================================
+# Interactive intake — GoalIntake (issue #1161)
+# ============================================================================
+
+# A goal the parser flags as vague — two clarification questions.
+VAGUE_GOAL_JSON = json.dumps(
+    {
+        "goal": "Chase down overdue invoices",
+        "domain": "business",
+        "complexity": "M",
+        "clarifications_needed": [
+            "How overdue must an invoice be before you chase it?",
+            "What channel should the reminders go out on?",
+        ],
+        "confidence": 0.55,
+    }
+)
+
+# The same goal after clarification — no questions left.
+WELL_FORMED_GOAL_JSON = json.dumps(
+    {
+        "goal": "Email a reminder for every invoice 30+ days overdue",
+        "domain": "business",
+        "complexity": "M",
+        "clarifications_needed": [],
+        "confidence": 0.9,
+    }
+)
+
+
+def _scripted_parser(*responses: str) -> GoalParser:
+    """A GoalParser whose ``parse`` calls return the scripted responses in
+    order. The first call returns ``responses[0]``, etc.; the last response
+    repeats once the script is exhausted."""
+    parser = GoalParser()
+    calls = {"n": 0}
+
+    async def mock_run_prompt(prompt: str) -> str:
+        idx = min(calls["n"], len(responses) - 1)
+        calls["n"] += 1
+        return responses[idx]
+
+    parser._run_prompt = mock_run_prompt
+    parser._scripted_calls = calls  # type: ignore[attr-defined]
+    return parser
+
+
+class TestFoldTranscript:
+    """_fold_transcript builds the enriched goal text."""
+
+    def test_empty_transcript_returns_original(self):
+        assert _fold_transcript("build a thing", []) == "build a thing"
+
+    def test_folds_questions_and_answers(self):
+        transcript = [
+            QAPair("Which framework?", "FastAPI"),
+            QAPair("Which database?", "Postgres"),
+        ]
+        result = _fold_transcript("build an API", transcript)
+        assert "build an API" in result
+        assert "Which framework? → FastAPI" in result
+        assert "Which database? → Postgres" in result
+
+    def test_strips_whitespace(self):
+        transcript = [QAPair("  Q?  ", "  A  ")]
+        result = _fold_transcript("  goal  ", transcript)
+        assert "Q? → A" in result
+        assert result.startswith("goal")
+
+
+class TestIntakeResult:
+    """IntakeResult serialization."""
+
+    def test_to_dict_round_trip(self):
+        result = IntakeResult(
+            original_input="vague",
+            enriched_goal="vague\n\nClarifications...",
+            transcript=[QAPair("Q?", "A")],
+            analysis=GoalAnalysis(goal="enriched"),
+            clarified=True,
+        )
+        d = result.to_dict()
+        assert d["original_input"] == "vague"
+        assert d["clarified"] is True
+        assert d["transcript"] == [{"question": "Q?", "answer": "A"}]
+        assert d["analysis"]["goal"] == "enriched"
+
+
+class TestGoalIntakeWellFormed:
+    """A well-formed goal skips the intake loop entirely (one-shot path)."""
+
+    @pytest.mark.asyncio
+    async def test_well_formed_goal_skips_intake(self):
+        parser = _scripted_parser(WELL_FORMED_GOAL_JSON)
+        intake = GoalIntake(parser=parser)
+
+        asked: list[str] = []
+
+        async def answer_provider(question: str) -> str:
+            asked.append(question)
+            return "should not be called"
+
+        result = await intake.run("A perfectly clear goal", answer_provider)
+
+        # No question was asked — the answer provider stayed untouched.
+        assert asked == []
+        assert result.clarified is False
+        assert result.transcript == []
+        # Enriched goal is the input unchanged.
+        assert result.enriched_goal == "A perfectly clear goal"
+        # Parser was called exactly once (the initial parse).
+        assert parser._scripted_calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_well_formed_result_carries_analysis(self):
+        parser = _scripted_parser(WELL_FORMED_GOAL_JSON)
+        intake = GoalIntake(parser=parser)
+
+        async def answer_provider(question: str) -> str:
+            return ""
+
+        result = await intake.run("Clear goal", answer_provider)
+        assert isinstance(result.analysis, GoalAnalysis)
+        assert result.analysis.needs_clarification is False
+
+
+class TestGoalIntakeClarificationLoop:
+    """A vague goal triggers the clarification loop — questions asked,
+    answers folded, goal re-parsed."""
+
+    @pytest.mark.asyncio
+    async def test_vague_goal_asks_clarifications(self):
+        # First parse: vague (2 questions). Second parse (after folding):
+        # well-formed, loop ends.
+        parser = _scripted_parser(VAGUE_GOAL_JSON, WELL_FORMED_GOAL_JSON)
+        intake = GoalIntake(parser=parser)
+
+        asked: list[str] = []
+
+        async def answer_provider(question: str) -> str:
+            asked.append(question)
+            return f"answer to: {question}"
+
+        result = await intake.run("Chase down overdue invoices", answer_provider)
+
+        # Both clarification questions were asked.
+        assert len(asked) == 2
+        assert "How overdue" in asked[0]
+        assert "channel" in asked[1]
+        # And the answers landed in the transcript.
+        assert len(result.transcript) == 2
+
+    @pytest.mark.asyncio
+    async def test_answers_folded_into_enriched_goal(self):
+        parser = _scripted_parser(VAGUE_GOAL_JSON, WELL_FORMED_GOAL_JSON)
+        intake = GoalIntake(parser=parser)
+
+        async def answer_provider(question: str) -> str:
+            if "overdue" in question:
+                return "30 days"
+            return "email"
+
+        result = await intake.run("Chase down overdue invoices", answer_provider)
+
+        assert result.clarified is True
+        # The enriched goal carries the original input plus the answers.
+        assert "Chase down overdue invoices" in result.enriched_goal
+        assert "30 days" in result.enriched_goal
+        assert "email" in result.enriched_goal
+        # Two Q&A pairs recorded.
+        assert len(result.transcript) == 2
+        assert result.transcript[0].answer == "30 days"
+
+    @pytest.mark.asyncio
+    async def test_enriched_goal_is_reparsed(self):
+        # The re-parse should be reflected in result.analysis — it should
+        # be the well-formed analysis, not the vague one.
+        parser = _scripted_parser(VAGUE_GOAL_JSON, WELL_FORMED_GOAL_JSON)
+        intake = GoalIntake(parser=parser)
+
+        async def answer_provider(question: str) -> str:
+            return "concrete answer"
+
+        result = await intake.run("Chase down overdue invoices", answer_provider)
+
+        # After folding + re-parse, the analysis has no clarifications left.
+        assert result.analysis.needs_clarification is False
+        assert result.analysis.confidence == 0.9
+        # Parser ran twice: initial parse + re-parse of enriched goal.
+        assert parser._scripted_calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_blank_answers_are_not_folded(self):
+        # If the human skips every question (blank answers), nothing is
+        # folded and the loop ends without claiming the goal was clarified.
+        parser = _scripted_parser(VAGUE_GOAL_JSON)
+        intake = GoalIntake(parser=parser)
+
+        async def answer_provider(question: str) -> str:
+            return "   "  # whitespace only = skipped
+
+        result = await intake.run("Chase down overdue invoices", answer_provider)
+
+        assert result.clarified is False
+        assert result.transcript == []
+        # Enriched goal stays as the original input.
+        assert result.enriched_goal == "Chase down overdue invoices"
+        # Only the initial parse ran — no re-parse, since nothing was folded.
+        assert parser._scripted_calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_partial_answers_fold_only_answered(self):
+        # One answered, one skipped — only the answered one is folded.
+        parser = _scripted_parser(VAGUE_GOAL_JSON, WELL_FORMED_GOAL_JSON)
+        intake = GoalIntake(parser=parser)
+
+        async def answer_provider(question: str) -> str:
+            return "60 days" if "overdue" in question else ""
+
+        result = await intake.run("Chase down overdue invoices", answer_provider)
+
+        assert result.clarified is True
+        assert len(result.transcript) == 1
+        assert result.transcript[0].answer == "60 days"
+        assert "60 days" in result.enriched_goal
+
+    @pytest.mark.asyncio
+    async def test_intake_loop_is_bounded(self):
+        # A parser that NEVER stops surfacing clarifications must not loop
+        # forever — MAX_INTAKE_ROUNDS caps it.
+        parser = _scripted_parser(VAGUE_GOAL_JSON)  # always vague
+        intake = GoalIntake(parser=parser)
+
+        rounds_seen = {"n": 0}
+
+        async def answer_provider(question: str) -> str:
+            rounds_seen["n"] += 1
+            return "an answer"
+
+        result = await intake.run("Chase down overdue invoices", answer_provider)
+
+        # 2 questions per round, capped at MAX_INTAKE_ROUNDS rounds.
+        assert rounds_seen["n"] <= 2 * MAX_INTAKE_ROUNDS
+        # Loop terminated and produced a result rather than hanging.
+        assert isinstance(result, IntakeResult)
+        assert result.clarified is True
+
+    @pytest.mark.asyncio
+    async def test_default_parser_constructed_when_none(self):
+        # GoalIntake() with no parser still works.
+        intake = GoalIntake()
+        assert isinstance(intake.parser, GoalParser)


### PR DESCRIPTION
## What

`deep_work` gets an optional interactive intake mode on top of `start_deep_work(goal)`. A vague goal, the kind a non-developer writes ("chase down overdue invoices"), gets a short clarification conversation before planning. A well-formed goal skips the conversation and behaves the same as it does today.

## Why

`GoalParser` already produced a `clarifications_needed` list: the exact questions you'd ask a human to disambiguate a vague goal. Nothing asked them. The dashboard just rendered them as a static advisory box. The questions existed; the conversation that used them didn't.

A developer can hand `deep_work` a good goal and it plans fine. A non-developer SMB user can't. Their goal first has to become an explicit goal with success criteria and preconditions. This PR builds the step that does that.

## What changed

- `goal_parser.py` adds a `GoalIntake` class. Given an injected async answer provider, it asks each clarification question, folds the answers back into the goal, and re-parses so planning starts from a well-formed goal. The loop is bounded so a misbehaving provider can't spin forever.
- `models.py`: `TaskSpec` gains `success_criteria` (a verifiable end state) and `preconditions` (when not to act). Both default to empty lists, so plans serialized before this PR still load. Acceptance criteria used to be free text inside `description`.
- `prompts.py`: the task-breakdown prompt now asks the planner to emit those two fields per task.
- `session.py` adds `start_with_intake()`. It runs the intake loop, then plans against the enriched goal. The one-shot `start()` is untouched. `_materialize_tasks` carries `success_criteria` and `preconditions` onto each MC Task's metadata so the outcome-verification sibling issue can check them later.
- `api.py`: `POST /intake/clarify` returns the clarification questions, `POST /start-with-intake` submits the goal plus the collected answers. `POST /start` is unchanged.
- Docs updated under `docs/`.

## Testing

- `tests/test_deep_work_goal_parser.py`: a `GoalIntake` suite covering the well-formed-goal fast path (intake skipped, answer provider never called), the vague-goal path (questions asked, answers folded, goal re-parsed), blank-answer handling, partial answers, and the round bound.
- `tests/test_deep_work_e2e.py`: new file. End to end, a vague goal runs intake, clarifications are asked, answers are folded, planning runs to completion, and the resulting MC tasks carry `success_criteria`. Both the LLM and the answer provider are mocked.
- Verify-set green: `uv run pytest tests/test_deep_work_goal_parser.py tests/test_deep_work_session.py tests/test_deep_work_api.py tests/test_deep_work_planner.py tests/test_deep_work_e2e.py -q` reports 200 passed.
- Broader sanity: `uv run pytest tests/ -k "deep_work or mission_control or pawkit"` reports 431 passed, no regressions.

Closes #1161