### PR TITLE
Outcome-verification foundation for Instinct

### DIFF
--- a/docs/advanced/mission-control-cloud.mdx
+++ b/docs/advanced/mission-control-cloud.mdx
@@ -29,6 +29,7 @@ Mission Control (Cloud) is the operator console for the PocketPaw enterprise clo
 | **Project** | A workspace-scoped grouping of pockets, tasks, and cycles. Optional reference everywhere. |
 | **Pocket** | The canvas / workspace surface. Pockets live inside a workspace and optionally inside a Project. |
 | **Nudge** | A pending action proposed by Instinct, surfaced in the Tray for human approval. |
+| **Outcome verdict** | A checked answer to "did this action solve the problem" — `solved` / `partial` / `not_solved` / `unknown` — recorded on an Instinct action after it executes. See [Outcome verification](#outcome-verification). |
 
 ## Hierarchy
 
@@ -63,6 +64,35 @@ Every level except the workspace is optional. A task created without a `project_
 | `priority` | string | `low` / `normal` / `high` / `urgent` (Tasks) or `low` / `medium` / `high` / `critical` (Instinct). |
 | `created_at`, `updated_at` | datetime | UTC ISO-8601. |
 | `fabric_refs` | string[] | Fabric object ids linked from the source. |
+
+## Outcome verification
+
+A completed action is an *output*. Whether it solved the problem the operator cared about is an *outcome*, and the two are not the same thing. Instinct's `Action` carries an `outcome` field that `mark_executed()` writes when an action runs.
+
+That field used to hold a free-text "what happened" string. It can now also hold a structured **`OutcomeVerdict`**: a checked answer to "did this solve the problem." The plain string still works, so older executed actions and any caller passing a string keep behaving as before.
+
+An `OutcomeVerdict` has:
+
+| Field | Meaning |
+|-------|---------|
+| `status` | `solved` (every criterion met), `partial` (some met), `not_solved` (none met), or `unknown` (no criteria captured, so nothing to check). |
+| `criteria_results` | Per-criterion breakdown — each `success_criteria` entry plus whether it was met and a short detail. |
+| `summary` | A one-line human-readable roll-up, e.g. `2/3 success criteria met`. |
+
+The verdict is produced by a **deterministic verifier** (`pocketpaw.instinct.verification.verify_outcome`). It checks an action's result text against the `success_criteria` captured at task creation — these are the verifiable "this is done when…" checks the planning intake records (see [Deep Work](/advanced/deep-work#success-criteria-and-preconditions)). The cloud `Task` model carries the same `success_criteria` field so the criteria survive from planning through to verification.
+
+"Deterministic" means the verifier uses plain keyword matching, with no model call, so the same result and criteria always produce the same verdict. It catches whether the result clearly mentions what each criterion asked for. Subtler judgement — soft or subjective criteria, results phrased in synonyms — is out of scope for this foundation and is tracked as separate follow-up work on LLM-as-judge scoring.
+
+```python
+from pocketpaw.instinct import verify_outcome
+
+verdict = verify_outcome(
+    action_result_text,
+    success_criteria=["A reminder email is sent to each overdue customer"],
+)
+# verdict.status -> OutcomeStatus.SOLVED / PARTIAL / NOT_SOLVED / UNKNOWN
+await store.mark_executed(action_id, verdict)
+```
 
 ## REST endpoints
 

--- a/src/pocketpaw/instinct/__init__.py
+++ b/src/pocketpaw/instinct/__init__.py
@@ -1,9 +1,14 @@
 # Instinct — decision pipeline for Paw OS.
 # Created: 2026-03-28 — Actions, approvals, audit log.
+# Updated: 2026-05-21 (feat/instinct-outcome-verification) — issue #1162:
+#   exported the outcome-verification primitives — OutcomeStatus,
+#   CriterionResult, OutcomeVerdict, and the deterministic verify_outcome /
+#   check_criterion functions.
 # Updated: 2026-03-30 — Exported ActionStatus, ActionCategory, ActionPriority, AuditCategory.
 # Updated: 2026-04-12 (Move 1 PR-A) — Exported Correction, CorrectionPatch, compute_patches.
 # The decision loop: Agent proposes -> Human approves (optionally edits) ->
-# Action executes -> Correction captured -> Soul learns.
+# Action executes -> outcome verified against success criteria -> Correction
+# captured -> Soul learns.
 
 from pocketpaw.instinct.correction import (
     Correction,
@@ -20,10 +25,14 @@ from pocketpaw.instinct.models import (
     ActionTrigger,
     AuditCategory,
     AuditEntry,
+    CriterionResult,
+    OutcomeStatus,
+    OutcomeVerdict,
 )
 from pocketpaw.instinct.store import InstinctStore
 from pocketpaw.instinct.trace import FabricObjectSnapshot, ReasoningTrace, ToolCallRef
 from pocketpaw.instinct.trace_collector import TraceCollector
+from pocketpaw.instinct.verification import check_criterion, verify_outcome
 
 __all__ = [
     "Action",
@@ -36,11 +45,16 @@ __all__ = [
     "AuditEntry",
     "Correction",
     "CorrectionPatch",
+    "CriterionResult",
     "FabricObjectSnapshot",
     "InstinctStore",
+    "OutcomeStatus",
+    "OutcomeVerdict",
     "ReasoningTrace",
     "ToolCallRef",
     "TraceCollector",
+    "check_criterion",
     "compute_patches",
     "summarize_correction",
+    "verify_outcome",
 ]

--- a/src/pocketpaw/instinct/models.py
+++ b/src/pocketpaw/instinct/models.py
@@ -1,5 +1,11 @@
 # Instinct data models — decision pipeline types.
 # Created: 2026-03-28
+# Updated: 2026-05-21 (feat/instinct-outcome-verification) — issue #1162:
+#   Action.outcome can now hold a structured OutcomeVerdict (status +
+#   per-criterion results) instead of only a free-text "what happened"
+#   string. The field still accepts a plain string for backward
+#   compatibility — old executed actions and callers that pass a string
+#   keep working. Added OutcomeStatus, CriterionResult, OutcomeVerdict.
 # Updated: 2026-05-13 (feat/mission-control-facade) — added optional ``assignee``
 #   to Action so The Tray can filter pending items to a specific human approver.
 
@@ -20,6 +26,59 @@ class ActionStatus(StrEnum):
     REJECTED = "rejected"
     EXECUTED = "executed"
     FAILED = "failed"
+
+
+class OutcomeStatus(StrEnum):
+    """Verdict on whether an executed action solved the original problem.
+
+    A completed action is an *output*. Whether it solved the problem is an
+    *outcome* — and those are not the same thing. This is the verdict half
+    of the distinction (issue #1162).
+    """
+
+    SOLVED = "solved"  # every success criterion was met
+    PARTIAL = "partial"  # some criteria met, some not
+    NOT_SOLVED = "not_solved"  # no criteria met
+    UNKNOWN = "unknown"  # no criteria were captured — nothing to check
+
+
+class CriterionResult(BaseModel):
+    """Whether one captured success criterion was met by the action result.
+
+    ``criterion`` is the verifiable "this is done when…" statement captured
+    at task intake (see deep_work issue #1161). ``met`` is the verifier's
+    deterministic verdict for it. ``detail`` carries a short human-readable
+    note on how the verdict was reached.
+    """
+
+    criterion: str
+    met: bool
+    detail: str = ""
+
+
+class OutcomeVerdict(BaseModel):
+    """A checked verdict on an executed action — the structured replacement
+    for the free-text ``Action.outcome`` string.
+
+    Produced by :func:`pocketpaw.instinct.verification.verify_outcome`. The
+    ``status`` summarizes the per-criterion ``criteria_results``; ``summary``
+    keeps a free-text "what happened" note so nothing is lost relative to
+    the old string-only field.
+    """
+
+    status: OutcomeStatus
+    criteria_results: list[CriterionResult] = Field(default_factory=list)
+    summary: str = ""
+
+    @property
+    def met_count(self) -> int:
+        """How many success criteria were met."""
+        return sum(1 for c in self.criteria_results if c.met)
+
+    @property
+    def total_count(self) -> int:
+        """How many success criteria were checked."""
+        return len(self.criteria_results)
 
 
 class ActionPriority(StrEnum):
@@ -68,7 +127,12 @@ class Action(BaseModel):
     recommendation: str
     parameters: dict[str, Any] = Field(default_factory=dict)
     context: ActionContext = Field(default_factory=ActionContext)
-    outcome: str | None = None
+    # outcome holds the result of executing the action. Originally a
+    # free-text "what happened" string; issue #1162 lets it also be a
+    # structured OutcomeVerdict (a checked "did this solve the problem"
+    # answer). Both are accepted — a string is the legacy form, still
+    # valid. ``mark_executed`` writes whichever the caller passes.
+    outcome: str | OutcomeVerdict | None = None
     error: str | None = None
     approved_by: str | None = None
     approved_at: datetime | None = None

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -1,5 +1,11 @@
 # Instinct store — async SQLite operations for the decision pipeline.
 # Created: 2026-03-28 — Action lifecycle + audit log.
+# Updated: 2026-05-21 (feat/instinct-outcome-verification) — issue #1162:
+#   mark_executed() now accepts a structured OutcomeVerdict as well as a
+#   plain string. A verdict is stored as JSON in the existing ``outcome``
+#   TEXT column; _row_to_action() detects JSON-encoded verdicts on read and
+#   rebuilds them, falling back to a plain string for legacy free-text rows.
+#   No schema migration — the column type is unchanged.
 # Updated: 2026-03-30 — Added limit param to _query_actions, list_actions() public method.
 # Updated: 2026-04-12 (Move 1 PR-A) — Corrections table + record_correction() and
 #   get_corrections*() methods for the correction loop. Human edits between
@@ -35,8 +41,24 @@ from pocketpaw.instinct.models import (
     ActionTrigger,
     AuditCategory,
     AuditEntry,
+    OutcomeVerdict,
 )
 from pocketpaw.instinct.trace import FabricObjectSnapshot, ReasoningTrace
+
+
+def _serialize_outcome(outcome: str | OutcomeVerdict | None) -> str | None:
+    """Serialize an Action outcome for the ``outcome`` TEXT column.
+
+    A structured :class:`OutcomeVerdict` is stored as its JSON dump; a plain
+    string is stored as-is (the legacy free-text form). ``None`` stays
+    ``None``. The matching read-side decode lives in
+    :meth:`InstinctStore._deserialize_outcome`.
+    """
+    if outcome is None:
+        return None
+    if isinstance(outcome, OutcomeVerdict):
+        return outcome.model_dump_json()
+    return outcome
 
 
 def _parse_iso(value: Any) -> datetime | None:
@@ -334,11 +356,25 @@ class InstinctStore:
                 rejected.append(action)
         return rejected, missing, bulk
 
-    async def mark_executed(self, action_id: str, outcome: str | None = None) -> Action | None:
+    async def mark_executed(
+        self, action_id: str, outcome: str | OutcomeVerdict | None = None
+    ) -> Action | None:
+        """Mark an approved action as executed and record its outcome.
+
+        Args:
+            action_id: The action to mark executed.
+            outcome: What happened. Either a structured
+                :class:`OutcomeVerdict` (a checked "did this solve the
+                problem" verdict — see issue #1162) or a plain free-text
+                string (the legacy form). Both persist to the same column.
+
+        Returns:
+            The updated Action, or ``None`` if no such action exists.
+        """
         return await self._update_status(
             action_id,
             ActionStatus.EXECUTED,
-            outcome=outcome,
+            outcome=_serialize_outcome(outcome),
             executed_at=datetime.now().isoformat(),
             event="action_executed",
             actor="system",
@@ -691,6 +727,37 @@ class InstinctStore:
 
     # --- Helpers ---
 
+    @staticmethod
+    def _deserialize_outcome(raw: Any) -> str | OutcomeVerdict | None:
+        """Decode the ``outcome`` column back into a string or OutcomeVerdict.
+
+        Issue #1162 lets ``outcome`` hold a structured verdict, stored as
+        JSON. A row written before #1162 (or by a caller passing a string)
+        holds plain free text. We try to parse the column as a verdict;
+        anything that isn't a verdict-shaped JSON object is returned as the
+        original string, so legacy rows keep working unchanged.
+        """
+        if raw is None:
+            return None
+        if not isinstance(raw, str):
+            return raw
+        text = raw.strip()
+        # A structured verdict is always a JSON object. Cheap prefix check
+        # avoids a json.loads attempt on every plain-text outcome.
+        if not text.startswith("{"):
+            return raw
+        try:
+            data = json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            return raw
+        if not isinstance(data, dict) or "status" not in data:
+            # Valid JSON but not a verdict — treat as legacy free text.
+            return raw
+        try:
+            return OutcomeVerdict.model_validate(data)
+        except Exception:  # noqa: BLE001 — malformed verdict, fall back to raw text
+            return raw
+
     def _row_to_action(self, row: Any) -> Action:
         # ``assignee`` landed in 2026-05-13 (Mission Control). Old DBs may
         # still surface a row missing the column despite the migration in
@@ -717,7 +784,7 @@ class InstinctStore:
             context=ActionContext.model_validate_json(row["context"])
             if row["context"]
             else ActionContext(),
-            outcome=row["outcome"],
+            outcome=self._deserialize_outcome(row["outcome"]),
             error=row["error"],
             approved_by=row["approved_by"],
             rejected_reason=row["rejected_reason"],

--- a/src/pocketpaw/instinct/verification.py
+++ b/src/pocketpaw/instinct/verification.py
@@ -118,9 +118,7 @@ def _tokenize(text: str) -> list[str]:
     grammatical filler, then stems each so plural and singular forms match.
     """
     tokens = _WORD_RE.findall(text.lower())
-    return [
-        _stem(t) for t in tokens if len(t) >= _MIN_TOKEN_LEN and t not in _STOPWORDS
-    ]
+    return [_stem(t) for t in tokens if len(t) >= _MIN_TOKEN_LEN and t not in _STOPWORDS]
 
 
 def _result_to_text(result: Any) -> str:
@@ -182,8 +180,7 @@ def check_criterion(result: Any, criterion: str) -> CriterionResult:
         criterion=criterion,
         met=False,
         detail=(
-            f"Matched {matched}/{len(criterion_tokens)} keywords; "
-            f"missing: {', '.join(missing)}"
+            f"Matched {matched}/{len(criterion_tokens)} keywords; missing: {', '.join(missing)}"
         ),
     )
 

--- a/src/pocketpaw/instinct/verification.py
+++ b/src/pocketpaw/instinct/verification.py
@@ -1,0 +1,237 @@
+# Instinct outcome verification — deterministic success-criteria checker.
+# Created: 2026-05-21 (feat/instinct-outcome-verification)
+#
+# Issue #1162, foundation half. Spotify's background-coding-agent post ends
+# on an honest admission: "even if we make it to a merged PR, how do we know
+# if it actually solved the original problem?" A completed action is an
+# output. Whether it solved the problem is an outcome — and they are not the
+# same thing.
+#
+# This module is the FOUNDATION for answering that: a deterministic verifier
+# that checks an action's result text against the success_criteria captured
+# at task intake (deep_work issue #1161) and returns a structured
+# OutcomeVerdict. "Deterministic" means it uses plain token matching — no
+# LLM, no model call, fully repeatable. The sophisticated half, LLM-as-judge
+# scoring for soft / subjective criteria, is deliberately out of scope here
+# and tracked as a separate follow-up issue.
+#
+# Public API:
+#   verify_outcome(result, success_criteria) -> OutcomeVerdict
+#   check_criterion(result, criterion) -> CriterionResult
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from pocketpaw.instinct.models import (
+    CriterionResult,
+    OutcomeStatus,
+    OutcomeVerdict,
+)
+
+# Tokens shorter than this are ignored when matching a criterion against a
+# result — "a", "is", "the" carry no signal and would match everything.
+_MIN_TOKEN_LEN = 3
+
+# Words that pass the length filter but carry no content signal: articles,
+# conjunctions, auxiliary verbs, and — importantly — quantifiers like "one",
+# "per", "each", "all". A criterion such as "one email is sent per invoice"
+# keys off "email", "sent", "invoice"; the quantifiers are grammatical glue,
+# and demanding the result echo them verbatim produces false negatives.
+# Kept deliberately small — this is a deterministic foundation, not a search
+# engine — but it has to cover quantifiers to be usable.
+_STOPWORDS = frozenset(
+    {
+        # articles / conjunctions / prepositions
+        "the",
+        "and",
+        "for",
+        "with",
+        "that",
+        "this",
+        "from",
+        "into",
+        "its",
+        "his",
+        "her",
+        "not",
+        # auxiliary / modal verbs
+        "are",
+        "was",
+        "has",
+        "have",
+        "been",
+        "will",
+        "should",
+        "must",
+        "when",
+        # quantifiers — grammatical glue, not content
+        "one",
+        "per",
+        "each",
+        "all",
+        "any",
+        "every",
+        "some",
+        "least",
+        "most",
+    }
+)
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def _stem(token: str) -> str:
+    """Strip a common plural suffix so "email"/"emails" match.
+
+    Deliberately crude — a deterministic suffix trim, not a real stemmer.
+    The rules, in order:
+
+      - ``-ies`` → ``-y`` ("categories" → "category")
+      - ``-es`` → drop ``es`` only after a sibilant (s/x/z/ch/sh), where
+        the ``e`` is part of the plural marker ("boxes" → "box",
+        "matches" → "match")
+      - ``-s`` → drop ``s`` otherwise ("invoices" → "invoice",
+        "emails" → "email")
+
+    This collapses regular plurals without over-trimming words like
+    "invoices" (which must become "invoice", not "invoic"). Tokens of
+    three characters or fewer are left alone.
+    """
+    if len(token) <= 3:
+        return token
+    if token.endswith("ies"):
+        return token[:-3] + "y"
+    if token.endswith("es") and token[:-2].endswith(("s", "x", "z", "ch", "sh")):
+        return token[:-2]
+    if token.endswith("s") and not token.endswith("ss"):
+        return token[:-1]
+    return token
+
+
+def _tokenize(text: str) -> list[str]:
+    """Lowercase a string into significant, stemmed word tokens.
+
+    Drops short tokens and stopwords so the matcher keys off the content
+    words of a criterion ("invoice", "overdue", "email") rather than
+    grammatical filler, then stems each so plural and singular forms match.
+    """
+    tokens = _WORD_RE.findall(text.lower())
+    return [
+        _stem(t) for t in tokens if len(t) >= _MIN_TOKEN_LEN and t not in _STOPWORDS
+    ]
+
+
+def _result_to_text(result: Any) -> str:
+    """Flatten an action result into a single searchable string.
+
+    A result may be a plain string, or a dict / list (e.g. structured tool
+    output). We stringify the whole thing — the verifier only needs the
+    text content, not the shape.
+    """
+    if result is None:
+        return ""
+    if isinstance(result, str):
+        return result
+    if isinstance(result, dict):
+        return " ".join(_result_to_text(v) for v in result.values())
+    if isinstance(result, (list, tuple)):
+        return " ".join(_result_to_text(v) for v in result)
+    return str(result)
+
+
+def check_criterion(result: Any, criterion: str) -> CriterionResult:
+    """Check a single success criterion against an action result.
+
+    Deterministic rule: the criterion is *met* when every significant token
+    of the criterion appears somewhere in the result text. This is a
+    foundation-level check — it catches "the result clearly mentions what
+    the criterion asked for" and nothing subtler. A criterion with no
+    significant tokens (e.g. punctuation only) cannot be verified and is
+    reported as not met with an explanatory detail.
+
+    Args:
+        result: The action result — string, dict, or list.
+        criterion: One "this is done when…" statement.
+
+    Returns:
+        A :class:`CriterionResult` with the met verdict and a short detail.
+    """
+    result_text = _result_to_text(result)
+    result_tokens = set(_tokenize(result_text))
+    criterion_tokens = _tokenize(criterion)
+
+    if not criterion_tokens:
+        return CriterionResult(
+            criterion=criterion,
+            met=False,
+            detail="Criterion has no checkable content",
+        )
+
+    missing = [t for t in criterion_tokens if t not in result_tokens]
+    if not missing:
+        return CriterionResult(
+            criterion=criterion,
+            met=True,
+            detail="All criterion keywords found in the result",
+        )
+
+    matched = len(criterion_tokens) - len(missing)
+    return CriterionResult(
+        criterion=criterion,
+        met=False,
+        detail=(
+            f"Matched {matched}/{len(criterion_tokens)} keywords; "
+            f"missing: {', '.join(missing)}"
+        ),
+    )
+
+
+def verify_outcome(result: Any, success_criteria: list[str]) -> OutcomeVerdict:
+    """Verify an action result against its captured success criteria.
+
+    This is the deterministic foundation verifier for issue #1162. It checks
+    each criterion with :func:`check_criterion` and rolls the per-criterion
+    results into a single :class:`OutcomeVerdict`:
+
+      - every criterion met → ``SOLVED``
+      - some met, some not → ``PARTIAL``
+      - none met → ``NOT_SOLVED``
+      - no criteria captured → ``UNKNOWN`` (there is nothing to check —
+        a bare completion, exactly the gap issue #1162 calls out)
+
+    Args:
+        result: The action result to verify — string, dict, or list.
+        success_criteria: The verifiable end-state checks captured at task
+            intake. May be empty.
+
+    Returns:
+        An :class:`OutcomeVerdict`. ``summary`` carries a one-line
+        human-readable roll-up; ``criteria_results`` carries the detail.
+    """
+    criteria = [c for c in (success_criteria or []) if c and c.strip()]
+
+    if not criteria:
+        return OutcomeVerdict(
+            status=OutcomeStatus.UNKNOWN,
+            criteria_results=[],
+            summary="No success criteria were captured — outcome cannot be verified",
+        )
+
+    results = [check_criterion(result, c) for c in criteria]
+    met = sum(1 for r in results if r.met)
+    total = len(results)
+
+    if met == total:
+        status = OutcomeStatus.SOLVED
+    elif met == 0:
+        status = OutcomeStatus.NOT_SOLVED
+    else:
+        status = OutcomeStatus.PARTIAL
+
+    return OutcomeVerdict(
+        status=status,
+        criteria_results=results,
+        summary=f"{met}/{total} success criteria met",
+    )

--- a/tests/cloud/test_ee_instinct.py
+++ b/tests/cloud/test_ee_instinct.py
@@ -1,10 +1,14 @@
 # tests/test_ee_instinct.py — Comprehensive tests for ee/instinct (store + router).
 # Created: 2026-03-28 — Initial store tests.
-# Updated: 2026-03-30 — Full store unit tests + FastAPI router integration tests added.
+# Updated: 2026-05-21 (feat/instinct-outcome-verification) — issue #1162:
+#   added the outcome-verification e2e — an Action runs, the deterministic
+#   verifier checks the result against captured success_criteria, and the
+#   structured OutcomeVerdict is recorded on the Action via mark_executed.
 # Updated: 2026-05-07 (fix/test-fixtures-auth-context) — seed auth context in
 #   the test_app fixture so route tests pass against the workspace RBAC guards
 #   added in #1059 and the plan-feature gate added in #1060. Pattern mirrors
 #   tests/cloud/test_rbac_routes.py (the #1061 reference).
+# Updated: 2026-03-30 — Full store unit tests + FastAPI router integration tests added.
 
 from __future__ import annotations
 
@@ -26,8 +30,11 @@ from pocketpaw.instinct.models import (
     ActionStatus,
     ActionTrigger,
     AuditCategory,
+    OutcomeStatus,
+    OutcomeVerdict,
 )
 from pocketpaw.instinct.store import InstinctStore
+from pocketpaw.instinct.verification import verify_outcome
 
 
 class _FakeMembership:
@@ -1173,3 +1180,137 @@ class TestFullLifecycle:
         # Total in store is 3
         all_actions = client.get("/instinct/actions").json()
         assert all_actions["total"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Outcome verification e2e (issue #1162)
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeVerificationE2E:
+    """End-to-end: an Action executes, the deterministic verifier checks the
+    result against captured success_criteria, and the structured verdict
+    lands on the Action via mark_executed.
+
+    This is the loop issue #1162 makes concrete — a completed action is an
+    output; the verdict says whether it was an outcome."""
+
+    @pytest.mark.asyncio
+    async def test_executed_action_records_verified_outcome(
+        self, store: InstinctStore
+    ) -> None:
+        # 1. An agent proposes an action. The task it came from carried
+        #    success_criteria captured at planning intake (issue #1161).
+        success_criteria = [
+            "An overdue invoice list is generated",
+            "A reminder email is sent to each customer",
+        ]
+        action = await store.propose(
+            pocket_id="pocket-invoices",
+            title="Chase overdue invoices",
+            description="Pull overdue invoices and email reminders",
+            recommendation="Email every customer 30+ days overdue",
+            trigger=make_trigger(),
+        )
+
+        # 2. A human approves it.
+        approved = await store.approve(action.id, approver="user:owner")
+        assert approved is not None
+        assert approved.status == ActionStatus.APPROVED
+
+        # 3. The action executes and produces a result. The deterministic
+        #    verifier checks that result against the captured criteria.
+        execution_result = (
+            "Generated the overdue invoice list and sent a reminder "
+            "email to each customer on it."
+        )
+        verdict = verify_outcome(execution_result, success_criteria)
+
+        # 4. The structured verdict is recorded on the Action.
+        executed = await store.mark_executed(action.id, verdict)
+
+        assert executed is not None
+        assert executed.status == ActionStatus.EXECUTED
+        # The outcome is a checked verdict, not a bare "what happened" string.
+        assert isinstance(executed.outcome, OutcomeVerdict)
+        assert executed.outcome.status == OutcomeStatus.SOLVED
+        assert executed.outcome.met_count == 2
+        assert executed.outcome.total_count == 2
+
+    @pytest.mark.asyncio
+    async def test_executed_action_records_partial_verdict(
+        self, store: InstinctStore
+    ) -> None:
+        # An action whose result only satisfies some of its success
+        # criteria gets a PARTIAL verdict — finishing is not solving.
+        success_criteria = [
+            "Reminder emails are sent",
+            "Customers flagged do-not-contact are skipped",
+        ]
+        action = await store.propose(
+            pocket_id="pocket-invoices",
+            title="Chase overdue invoices",
+            description="",
+            recommendation="",
+            trigger=make_trigger(),
+        )
+        await store.approve(action.id)
+
+        # The result mentions sending emails but says nothing about the
+        # do-not-contact skip — one criterion met, one not.
+        verdict = verify_outcome("Sent the reminder emails", success_criteria)
+        executed = await store.mark_executed(action.id, verdict)
+
+        assert executed is not None
+        assert isinstance(executed.outcome, OutcomeVerdict)
+        assert executed.outcome.status == OutcomeStatus.PARTIAL
+        assert executed.outcome.met_count == 1
+
+    @pytest.mark.asyncio
+    async def test_verified_outcome_survives_store_reload(
+        self, store: InstinctStore
+    ) -> None:
+        # The structured verdict must rebuild intact when the Action is
+        # reloaded from SQLite — it is stored as JSON in the outcome column.
+        action = await store.propose(
+            pocket_id="pocket-1",
+            title="Verifiable task",
+            description="",
+            recommendation="",
+            trigger=make_trigger(),
+        )
+        await store.approve(action.id)
+        verdict = verify_outcome(
+            "The report was generated",
+            ["A report is generated"],
+        )
+        await store.mark_executed(action.id, verdict)
+
+        reloaded = await store.get_action(action.id)
+        assert reloaded is not None
+        assert isinstance(reloaded.outcome, OutcomeVerdict)
+        assert reloaded.outcome.status == OutcomeStatus.SOLVED
+        assert reloaded.outcome.criteria_results[0].criterion == "A report is generated"
+
+    @pytest.mark.asyncio
+    async def test_executed_action_audit_trail_intact(
+        self, store: InstinctStore
+    ) -> None:
+        # Recording a structured verdict must not disturb the audit log —
+        # the action_executed entry is still written.
+        action = await store.propose(
+            pocket_id="pocket-audit",
+            title="Audited verification task",
+            description="",
+            recommendation="",
+            trigger=make_trigger(),
+        )
+        await store.approve(action.id)
+        verdict = verify_outcome("the email was sent", ["An email is sent"])
+        await store.mark_executed(action.id, verdict)
+
+        entries = await store.query_audit(pocket_id="pocket-audit")
+        events = {e.event for e in entries}
+        assert "action_proposed" in events
+        assert "action_approved" in events
+        assert "action_executed" in events

--- a/tests/cloud/test_ee_instinct.py
+++ b/tests/cloud/test_ee_instinct.py
@@ -1196,9 +1196,7 @@ class TestOutcomeVerificationE2E:
     output; the verdict says whether it was an outcome."""
 
     @pytest.mark.asyncio
-    async def test_executed_action_records_verified_outcome(
-        self, store: InstinctStore
-    ) -> None:
+    async def test_executed_action_records_verified_outcome(self, store: InstinctStore) -> None:
         # 1. An agent proposes an action. The task it came from carried
         #    success_criteria captured at planning intake (issue #1161).
         success_criteria = [
@@ -1221,8 +1219,7 @@ class TestOutcomeVerificationE2E:
         # 3. The action executes and produces a result. The deterministic
         #    verifier checks that result against the captured criteria.
         execution_result = (
-            "Generated the overdue invoice list and sent a reminder "
-            "email to each customer on it."
+            "Generated the overdue invoice list and sent a reminder email to each customer on it."
         )
         verdict = verify_outcome(execution_result, success_criteria)
 
@@ -1238,9 +1235,7 @@ class TestOutcomeVerificationE2E:
         assert executed.outcome.total_count == 2
 
     @pytest.mark.asyncio
-    async def test_executed_action_records_partial_verdict(
-        self, store: InstinctStore
-    ) -> None:
+    async def test_executed_action_records_partial_verdict(self, store: InstinctStore) -> None:
         # An action whose result only satisfies some of its success
         # criteria gets a PARTIAL verdict — finishing is not solving.
         success_criteria = [
@@ -1267,9 +1262,7 @@ class TestOutcomeVerificationE2E:
         assert executed.outcome.met_count == 1
 
     @pytest.mark.asyncio
-    async def test_verified_outcome_survives_store_reload(
-        self, store: InstinctStore
-    ) -> None:
+    async def test_verified_outcome_survives_store_reload(self, store: InstinctStore) -> None:
         # The structured verdict must rebuild intact when the Action is
         # reloaded from SQLite — it is stored as JSON in the outcome column.
         action = await store.propose(
@@ -1293,9 +1286,7 @@ class TestOutcomeVerificationE2E:
         assert reloaded.outcome.criteria_results[0].criterion == "A report is generated"
 
     @pytest.mark.asyncio
-    async def test_executed_action_audit_trail_intact(
-        self, store: InstinctStore
-    ) -> None:
+    async def test_executed_action_audit_trail_intact(self, store: InstinctStore) -> None:
         # Recording a structured verdict must not disturb the audit log —
         # the action_executed entry is still written.
         action = await store.propose(

--- a/tests/cloud/test_instinct_verification.py
+++ b/tests/cloud/test_instinct_verification.py
@@ -1,0 +1,284 @@
+# tests/cloud/test_instinct_verification.py — smoke tests for the
+# deterministic outcome verifier (issue #1162).
+# Created: 2026-05-21 (feat/instinct-outcome-verification)
+#
+# Covers the foundation verifier: verify_outcome / check_criterion against
+# simple criteria/result pairs. The verifier is deterministic — no LLM — so
+# every assertion here is an exact, repeatable check. The four verdict
+# states (solved / partial / not_solved / unknown), the OutcomeVerdict
+# roll-up counts, and the structured-verdict round-trip through the
+# instinct store all get exercised.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.instinct.models import (
+    ActionTrigger,
+    OutcomeStatus,
+    OutcomeVerdict,
+)
+from pocketpaw.instinct.store import InstinctStore
+from pocketpaw.instinct.verification import check_criterion, verify_outcome
+
+# ---------------------------------------------------------------------------
+# check_criterion — single criterion against a result
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCriterion:
+    """A single success criterion checked against an action result."""
+
+    def test_criterion_met_when_keywords_present(self):
+        # The result text contains every content word of the criterion
+        # (list, overdue, invoice) — the deterministic matcher passes it.
+        result = "Produced a list of every overdue invoice in the system"
+        cr = check_criterion(result, "A list of overdue invoices is produced")
+        assert cr.met is True
+        assert cr.criterion == "A list of overdue invoices is produced"
+
+    def test_criterion_not_met_on_synonym_only_overlap(self):
+        # Deterministic foundation: it keys off the criterion's actual
+        # words. A result that uses a synonym ("pulled" for "produced")
+        # does NOT satisfy the criterion — catching that is the deferred
+        # LLM-as-judge follow-up, not this verifier.
+        result = "Pulled a list of overdue invoices"
+        cr = check_criterion(result, "A list of overdue invoices is produced")
+        assert cr.met is False
+        assert "produced" in cr.detail
+
+    def test_criterion_not_met_when_keywords_absent(self):
+        result = "The connector returned an authentication error"
+        cr = check_criterion(result, "A list of overdue invoices is produced")
+        assert cr.met is False
+        # The detail names what was missing.
+        assert "missing" in cr.detail.lower()
+
+    def test_plural_and_singular_match(self):
+        # "emails" in the result should satisfy "email" in the criterion.
+        cr = check_criterion("Sent three reminder emails", "A reminder email is sent")
+        assert cr.met is True
+
+    def test_criterion_with_no_content_is_not_met(self):
+        cr = check_criterion("any result text", "...")
+        assert cr.met is False
+        assert "no checkable content" in cr.detail.lower()
+
+    def test_dict_result_is_searched(self):
+        # A structured (dict) result is flattened and searched.
+        result = {"status": "done", "note": "invoice reminder emails sent"}
+        cr = check_criterion(result, "reminder emails sent")
+        assert cr.met is True
+
+
+# ---------------------------------------------------------------------------
+# verify_outcome — roll-up verdict over multiple criteria
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyOutcomeSolved:
+    """All criteria met -> SOLVED."""
+
+    def test_all_criteria_met_is_solved(self):
+        result = "Generated the overdue invoice list and emailed every customer"
+        verdict = verify_outcome(
+            result,
+            [
+                "An overdue invoice list is generated",
+                "Every customer is emailed",
+            ],
+        )
+        assert verdict.status == OutcomeStatus.SOLVED
+        assert verdict.met_count == 2
+        assert verdict.total_count == 2
+
+    def test_single_criterion_met_is_solved(self):
+        verdict = verify_outcome(
+            "The reminder email was sent",
+            ["A reminder email is sent"],
+        )
+        assert verdict.status == OutcomeStatus.SOLVED
+
+
+class TestVerifyOutcomeNotSolved:
+    """No criteria met -> NOT_SOLVED."""
+
+    def test_no_criteria_met_is_not_solved(self):
+        verdict = verify_outcome(
+            "The job crashed before doing anything useful",
+            ["An overdue invoice list is generated"],
+        )
+        assert verdict.status == OutcomeStatus.NOT_SOLVED
+        assert verdict.met_count == 0
+
+    def test_empty_result_is_not_solved(self):
+        verdict = verify_outcome("", ["A reminder email is sent"])
+        assert verdict.status == OutcomeStatus.NOT_SOLVED
+
+
+class TestVerifyOutcomePartial:
+    """Some criteria met, some not -> PARTIAL."""
+
+    def test_some_criteria_met_is_partial(self):
+        result = "Sent the reminder emails"
+        verdict = verify_outcome(
+            result,
+            [
+                "Reminder emails are sent",
+                "A do-not-contact customer is skipped",
+            ],
+        )
+        assert verdict.status == OutcomeStatus.PARTIAL
+        assert verdict.met_count == 1
+        assert verdict.total_count == 2
+        # The per-criterion breakdown shows which one passed.
+        met = [c for c in verdict.criteria_results if c.met]
+        assert len(met) == 1
+        assert "Reminder emails" in met[0].criterion
+
+
+class TestVerifyOutcomeUnknown:
+    """No criteria captured -> UNKNOWN — nothing to check."""
+
+    def test_empty_criteria_is_unknown(self):
+        verdict = verify_outcome("the task finished", [])
+        assert verdict.status == OutcomeStatus.UNKNOWN
+        assert verdict.criteria_results == []
+
+    def test_blank_criteria_are_ignored(self):
+        # Whitespace-only criteria are dropped; nothing left -> UNKNOWN.
+        verdict = verify_outcome("the task finished", ["", "   "])
+        assert verdict.status == OutcomeStatus.UNKNOWN
+
+    def test_summary_explains_unknown(self):
+        verdict = verify_outcome("done", [])
+        assert "cannot be verified" in verdict.summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# OutcomeVerdict — model behavior
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeVerdict:
+    """The structured verdict model."""
+
+    def test_met_and_total_counts(self):
+        verdict = verify_outcome(
+            "Generated the report",
+            ["A report is generated", "An email is sent", "A file is saved"],
+        )
+        # Only the first criterion's keywords appear in the result.
+        assert verdict.total_count == 3
+        assert verdict.met_count == 1
+        assert verdict.status == OutcomeStatus.PARTIAL
+
+    def test_verdict_json_round_trip(self):
+        verdict = verify_outcome("the email was sent", ["An email is sent"])
+        restored = OutcomeVerdict.model_validate_json(verdict.model_dump_json())
+        assert restored.status == verdict.status
+        assert restored.met_count == verdict.met_count
+        assert restored.criteria_results[0].criterion == "An email is sent"
+
+
+# ---------------------------------------------------------------------------
+# InstinctStore — structured verdict persists through mark_executed
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    """Isolated SQLite store on a temp file."""
+    return InstinctStore(tmp_path / "verification_test.db")
+
+
+def _trigger() -> ActionTrigger:
+    return ActionTrigger(type="agent", source="claude", reason="verification test")
+
+
+class TestStoreOutcomeVerdict:
+    """mark_executed accepts and round-trips a structured OutcomeVerdict."""
+
+    @pytest.mark.asyncio
+    async def test_mark_executed_stores_structured_verdict(self, store: InstinctStore):
+        action = await store.propose(
+            pocket_id="pocket-1",
+            title="Send overdue reminders",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+        )
+        await store.approve(action.id)
+
+        verdict = verify_outcome(
+            "Sent the reminder email to every overdue customer",
+            ["A reminder email is sent to every overdue customer"],
+        )
+        executed = await store.mark_executed(action.id, verdict)
+
+        assert executed is not None
+        # The outcome came back as a structured verdict, not a bare string.
+        assert isinstance(executed.outcome, OutcomeVerdict)
+        assert executed.outcome.status == OutcomeStatus.SOLVED
+
+    @pytest.mark.asyncio
+    async def test_structured_verdict_survives_reload(self, store: InstinctStore):
+        action = await store.propose(
+            pocket_id="pocket-1",
+            title="Partial task",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+        )
+        await store.approve(action.id)
+
+        verdict = verify_outcome(
+            "Generated the report",
+            ["A report is generated", "An email is sent"],
+        )
+        await store.mark_executed(action.id, verdict)
+
+        # Reload from the DB — the verdict must rebuild intact.
+        reloaded = await store.get_action(action.id)
+        assert reloaded is not None
+        assert isinstance(reloaded.outcome, OutcomeVerdict)
+        assert reloaded.outcome.status == OutcomeStatus.PARTIAL
+        assert reloaded.outcome.met_count == 1
+        assert reloaded.outcome.total_count == 2
+
+    @pytest.mark.asyncio
+    async def test_legacy_string_outcome_still_works(self, store: InstinctStore):
+        """Backward compatibility — a plain free-text outcome string still
+        persists and reloads as a string (the pre-#1162 behavior)."""
+        action = await store.propose(
+            pocket_id="pocket-1",
+            title="Legacy outcome task",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+        )
+        await store.approve(action.id)
+        await store.mark_executed(action.id, "Did the thing successfully")
+
+        reloaded = await store.get_action(action.id)
+        assert reloaded is not None
+        assert reloaded.outcome == "Did the thing successfully"
+        assert isinstance(reloaded.outcome, str)
+
+    @pytest.mark.asyncio
+    async def test_none_outcome_still_works(self, store: InstinctStore):
+        """mark_executed with no outcome leaves the field None."""
+        action = await store.propose(
+            pocket_id="pocket-1",
+            title="No outcome task",
+            description="",
+            recommendation="",
+            trigger=_trigger(),
+        )
+        await store.approve(action.id)
+        executed = await store.mark_executed(action.id)
+
+        assert executed is not None
+        assert executed.outcome is None


### PR DESCRIPTION
> Stacked on #1167 (the #1161 deep_work intake PR). Review and merge #1167 first.

## What

Instinct can now record a *checked verdict* on an executed action, whether it actually solved the problem, instead of only a free-text "what happened" string. This is the foundation half of #1162.

## Why

#1162 makes the point plainly: a merged PR or a completed task is an output, not an outcome. Instinct's `Action` already carried an `outcome` field, but `mark_executed()` wrote a bare "what happened" string into it. Nothing checked whether the work solved the original problem.

The success criteria captured at planning intake (the #1161 sibling PR, #1167) are the thing to check against. This PR adds the verifier and the structured verdict; #1161 captures the criteria.

## What changed

- `instinct/models.py`: `Action.outcome` can now hold a structured `OutcomeVerdict` as well as a plain string. A verdict has a `status` (`solved` / `partial` / `not_solved` / `unknown`) and per-criterion `CriterionResult`s. The string form still works, so old executed actions and any string caller are unaffected.
- `instinct/store.py`: `mark_executed()` accepts the verdict. It serializes to JSON in the existing `outcome` TEXT column; reads detect a JSON-encoded verdict and rebuild it, falling back to a plain string for legacy rows. No schema migration.
- `instinct/verification.py` (new): a deterministic verifier. `verify_outcome(result, success_criteria)` checks the result against the criteria with plain keyword matching and returns a verdict. No model call, fully repeatable.
- `ee/.../cloud/models/task.py`: adds a `success_criteria` field so the criteria survive from planning intake through to verification on the cloud Task.
- Instinct docs updated.

## Scope

This is foundation only. The verifier is deterministic. It does not do LLM-as-judge scoring for soft or subjective criteria. That is the sophisticated half of #1162 and is tracked as a follow-up: #1168.

## Testing

- `tests/cloud/test_instinct_verification.py` (new): the deterministic verifier across all four verdict states (solved / partial / not_solved / unknown), criterion keyword matching, plural/singular handling, and the structured verdict round-tripping through the instinct store.
- `tests/cloud/test_ee_instinct.py`: an outcome-verification e2e. An Action executes, the verifier checks the result against captured `success_criteria`, and the structured verdict is recorded via `mark_executed`. Backward compatibility is covered too: a legacy string outcome still persists and reloads as a string.
- Verify-set green: `uv run pytest tests/cloud/test_ee_instinct.py tests/cloud/test_decision_traces.py -q` reports 89 passed, 1 xpassed (a pre-existing timestamp-tie xfail in test_decision_traces.py, unrelated).
- The deterministic verifier handles plurals but not synonyms by design. A result phrased differently from the criterion is a deliberate not-met, and that boundary is the #1168 follow-up.

Closes #1162