### PR TITLE
Honor agent mode in pocket edit

### DIFF
--- a/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
@@ -10,17 +10,24 @@
 # dropdown-menu, command-palette, coachmark) to the starter list and
 # the ``app`` pattern bucket so "build me an app for X" briefs land on
 # real chrome instead of composing it from primitives.
-"""Mode-specific adapters for the pocket specialist's create endpoint.
+# Modified: 2026-05-21 (#1170) — added the edit-side adapters
+# (``EditSubagentAdapter``, ``EditAgentModeAdapter``, ``pick_edit_adapter``)
+# so the edit endpoint honors ``pocket_specialist_mode`` the same way
+# create does. Edit was previously asymmetric — it always spawned a
+# backend and ignored agent mode, crashing Claude Code deployments that
+# have no ANTHROPIC_API_KEY.
+"""Mode-specific adapters for the pocket specialist's create + edit endpoints.
 
-The MCP tool handler (``mcp_tool._create_handler``) doesn't know — and
-shouldn't care — whether the specialist is spawning a subagent or
-piggybacking on the chat agent. It calls one of these adapters via
-``pick_adapter(settings.pocket_specialist_mode)`` and gets a uniform
-``PocketSpecialistCreateOutput`` back.
+The MCP tool handlers (``mcp_tool._create_handler`` / ``_edit_handler``)
+don't know — and shouldn't care — whether the specialist is spawning a
+subagent or piggybacking on the chat agent. They call one of these
+adapters via ``pick_adapter`` / ``pick_edit_adapter`` (keyed on
+``settings.pocket_specialist_mode``) and get a uniform output back.
 
 Adding a new mode (e.g., ``remote`` calling a hosted spec service):
-implement the ``SpecialistCreateAdapter`` protocol and wire a branch
-into ``pick_adapter`` at the bottom of this file.
+implement the ``SpecialistCreateAdapter`` / ``SpecialistEditAdapter``
+protocol and wire a branch into the matching ``pick_*`` function at the
+bottom of this file.
 """
 
 from __future__ import annotations
@@ -477,9 +484,294 @@ def pick_adapter(mode: str) -> SpecialistCreateAdapter:
     return SubagentAdapter()
 
 
+# ---------------------------------------------------------------------------
+# Edit-side adapters — symmetric with the create-side adapters above.
+#
+# Edit was built asymmetrically (#1170): ``run_edit_specialist`` always
+# spawned a backend and never consulted ``pocket_specialist_mode``. On a
+# Claude Code deployment (no ANTHROPIC_API_KEY) the default ``deep_agents``
+# backend crashes inside LangChain ``ChatAnthropic`` on every edit. These
+# adapters give edit the same mode dispatch create already has.
+# ---------------------------------------------------------------------------
+
+
+class SpecialistEditAdapter(Protocol):
+    """Dispatch interface for ``pocket_specialist__edit`` request shapes.
+
+    Implementations decide HOW the granular ops get computed (subagent,
+    chat-agent inline, …). They all return the same
+    ``PocketSpecialistEditOutput`` so the MCP tool handler and the chat
+    agent don't branch on mode."""
+
+    async def edit(
+        self,
+        input: Any,
+        *,
+        workspace_id: str,
+        user_id: str,
+        settings: Settings,
+    ) -> Any: ...
+
+
+class EditSubagentAdapter:
+    """Spawn an isolated backend that runs the edit specialist's own LLM.
+
+    Wraps the historical flow in ``runtime._run_edit_subagent_pipeline``.
+    The runtime keeps that function as the implementation — this adapter
+    is the dispatch shim. Importing inside ``edit`` avoids a circular
+    import between ``adapters`` and ``runtime``.
+    """
+
+    async def edit(
+        self,
+        input: Any,
+        *,
+        workspace_id: str,
+        user_id: str,
+        settings: Settings,
+    ) -> Any:
+        from pocketpaw_ee.agent.pocket_specialist.runtime import _run_edit_subagent_pipeline
+
+        return await _run_edit_subagent_pipeline(
+            input,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            settings=settings,
+        )
+
+
+class EditAgentModeAdapter:
+    """Two-call protocol for edits — the calling chat agent IS the
+    specialist. The edit-side mirror of ``AgentModeAdapter``.
+
+    First call (``input.ops is None``): return an edit kit (current
+    pocket echo + the granular-op vocabulary + next-step instructions).
+    The chat agent then decides WHICH granular ops express the intent,
+    using its own model.
+
+    Second call (``input.ops`` populated): skip the LLM planning phase
+    and apply each op deterministically through the SAME granular tools
+    the subagent flow uses internally (``make_edit_pocket_tools``). No
+    backend is spawned in either call — ``pocket_specialist_backend`` and
+    ``pocket_specialist_model`` are ignored entirely.
+
+    Design choice (#1170): the chat agent hands back GRANULAR OPS, not a
+    full mutated rippleSpec. Edit has no whole-spec persist primitive —
+    its persistence layer IS the granular ops (each one persists in place
+    and emits its own SSE event so the canvas updates live). Reusing those
+    ops keeps the per-op SSE updates, the manifest/service validation, and
+    the rejected-op semantics ``run_edit_specialist`` already shapes into
+    ``warnings``. It also matches create's adapter, which hands the
+    persist tool the chat agent's already-computed output rather than a
+    diff. The chat agent decides WHAT and WHERE; the adapter applies.
+    """
+
+    async def edit(
+        self,
+        input: Any,
+        *,
+        workspace_id: str,
+        user_id: str,
+        settings: Settings,
+    ) -> Any:
+        started = time.monotonic()
+        if input.ops is None:
+            return _edit_kit_response(input, started=started)
+        return await _apply_ops(input, started=started)
+
+
+# Granular edit tools the chat agent may reach for in agent mode. Names
+# match the tool names produced by ``make_edit_pocket_tools`` — the same
+# tools the subagent flow attaches. ``get_pocket`` is intentionally
+# omitted: it is a read, and in agent mode the chat agent already has the
+# pocket in context.
+_GRANULAR_EDIT_OPS: dict[str, str] = {
+    "set_state": "Write a value into state at a dotted path. Cheapest data edit.",
+    "append_state": "Append an item to an array in state.",
+    "remove_state": "Remove a key or array element from state.",
+    "patch_state": "Batched top-level merge into state.",
+    "set_node_prop": "Set one prop on one widget node (appearance / labels).",
+    "set_prop_array_item": "Surgically update one item inside a node's prop array.",
+    "append_prop_array_item": "Append one item to a node's prop array.",
+    "remove_prop_array_item": "Remove one item from a node's prop array.",
+    "add_node": "Add a new widget node into the tree.",
+    "replace_node": "Replace a widget node with a new subtree.",
+    "move_node": "Move a widget node to a new parent / position.",
+    "remove_node": "Remove a widget node from the tree.",
+}
+
+
+def _edit_kit_response(input: Any, *, started: float) -> Any:
+    """Build the first-call response: enough scaffolding for the chat
+    agent to compute granular ops inline, without spawning a backend.
+
+    The chat agent already holds the heavy edit guidance in the
+    ``pocketpaw-edit-pocket`` skill — the kit names the op vocabulary and
+    tells it how to call back, it does not re-inline the specialist
+    prompt.
+    """
+    from pocketpaw_ee.agent.pocket_specialist.runtime import PocketSpecialistEditOutput
+
+    kit: dict[str, Any] = {
+        "intent": input.intent,
+        "pocket": input.pocket,
+        "target_node_ids": input.target_node_ids,
+        "granular_ops": _GRANULAR_EDIT_OPS,
+        "op_shape": (
+            "Each op is ``{op: <name>, args: {...}}``. ``op`` is one of "
+            "``granular_ops`` above; ``args`` are that op's arguments "
+            "(e.g. set_state takes ``{path, value}``, set_node_prop takes "
+            "``{node_id, prop, value}``, add_node takes "
+            "``{parent_id, index, node}``). Apply the SMALLEST set of ops "
+            "that satisfies the intent."
+        ),
+        "next_step": (
+            "Compute the granular ops for the intent above. Use your own "
+            "model — no subagent will be spawned. When ready, call "
+            "``pocket_specialist__edit`` again with the same pocket_id + "
+            "intent AND ``ops=<your op list>``. Each op is validated and "
+            "applied in order; rejected ops come back in ``warnings``."
+        ),
+        "lookup_tool": (
+            "Use ``mcp__pocketpaw_pocket__get_widget_spec`` to confirm a "
+            "widget's allowed props before a set_node_prop / add_node op. "
+            "If you did not receive the pocket above, read it first."
+        ),
+    }
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    logger.info(
+        "[pocket-specialist:edit] agent-mode edit kit returned "
+        "(pocket_id=%s has_pocket=%s targets=%d duration=%dms)",
+        input.pocket_id,
+        input.pocket is not None,
+        len(input.target_node_ids or []),
+        duration_ms,
+    )
+
+    return PocketSpecialistEditOutput(
+        ok=False,
+        action="draft_kit",
+        pocket_id=input.pocket_id,
+        ops=[],
+        duration_ms=duration_ms,
+        backend_used="agent_mode",
+        draft_kit=kit,
+    )
+
+
+async def _apply_ops(input: Any, *, started: float) -> Any:
+    """Second-call path: apply the chat agent's pre-computed granular ops.
+
+    Reuses ``make_edit_pocket_tools`` so every op runs through the exact
+    same wrapper, capture, and service-rejection path the subagent flow
+    uses. ``_capture_op`` (inside each tool) sorts accepted ops into
+    ``capture['ops']`` and rejected ones into ``capture['rejected']`` —
+    the runtime's response-shaping logic for ``ops`` / ``warnings`` is
+    rebuilt here so the agent-mode output matches the subagent output.
+    No LLM runs in this step.
+    """
+    from pocketpaw_ee.agent.pocket_specialist.runtime import PocketSpecialistEditOutput
+    from pocketpaw_ee.agent.pocket_specialist.tools import make_edit_pocket_tools
+
+    ops_capture: dict[str, Any] = {"ops": []}
+    tools_by_name = {
+        t.name: t for t in make_edit_pocket_tools(pocket_id=input.pocket_id, capture=ops_capture)
+    }
+
+    error_msg: str | None = None
+    unknown_ops: list[str] = []
+    for raw_op in input.ops:
+        if not isinstance(raw_op, dict):
+            unknown_ops.append(str(raw_op))
+            continue
+        op_name = raw_op.get("op", "")
+        op_args = raw_op.get("args") or {}
+        tool = tools_by_name.get(op_name)
+        if tool is None:
+            # An op the chat agent named that isn't a granular edit tool.
+            # Not a crash — record it so it surfaces in warnings, same
+            # spirit as a service-rejected op.
+            unknown_ops.append(op_name or "<missing op name>")
+            logger.warning(
+                "[pocket-specialist:edit] agent-mode op %r is not a granular edit tool — skipping",
+                op_name,
+            )
+            continue
+        try:
+            await tool.ainvoke(op_args)
+        except Exception as exc:  # noqa: BLE001
+            # A single op blew up — stop and surface it. Ops applied
+            # before this one already persisted in place.
+            error_msg = f"edit op '{op_name}' failed: {type(exc).__name__}: {exc}"
+            logger.warning(
+                "[pocket-specialist:edit] agent-mode op %r raised: %s",
+                op_name,
+                exc,
+            )
+            break
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    ops = list(ops_capture.get("ops", []))
+    rejected = list(ops_capture.get("rejected", []))
+
+    warnings: list[str] = []
+    for rej in rejected:
+        op_name = rej.get("op", "edit op")
+        reason = rej.get("error", "rejected by the service")
+        warnings.append(f"Edit op '{op_name}' could not be applied: {reason}")
+    for bad in unknown_ops:
+        warnings.append(f"Edit op '{bad}' is not a supported granular op and was skipped.")
+
+    success = error_msg is None
+    logger.info(
+        "[pocket-specialist:edit] agent-mode apply complete: pocket_id=%s "
+        "ops=%d rejected=%d unknown=%d success=%s duration=%dms",
+        input.pocket_id,
+        len(ops),
+        len(rejected),
+        len(unknown_ops),
+        success,
+        duration_ms,
+    )
+
+    return PocketSpecialistEditOutput(
+        ok=success,
+        action="applied" if success else "failed",
+        pocket_id=input.pocket_id,
+        ops=ops,
+        duration_ms=duration_ms,
+        backend_used="agent_mode",
+        error=error_msg,
+        warnings=warnings,
+    )
+
+
+def pick_edit_adapter(mode: str) -> SpecialistEditAdapter:
+    """Pick the edit adapter for the configured specialist mode.
+
+    Unknown modes fall through to the historical subagent adapter so a
+    stale config never bricks a deployed instance — the operator sees
+    the warning in logs and can correct the value. Mirrors ``pick_adapter``.
+    """
+    if mode == "agent":
+        return EditAgentModeAdapter()
+    if mode != "subagent":
+        logger.warning(
+            "Unknown pocket_specialist_mode=%r — falling back to subagent "
+            "for edit. Valid values: 'subagent', 'agent'.",
+            mode,
+        )
+    return EditSubagentAdapter()
+
+
 __all__ = [
     "AgentModeAdapter",
+    "EditAgentModeAdapter",
+    "EditSubagentAdapter",
     "SpecialistCreateAdapter",
+    "SpecialistEditAdapter",
     "SubagentAdapter",
     "pick_adapter",
+    "pick_edit_adapter",
 ]

--- a/ee/pocketpaw_ee/agent/pocket_specialist/mcp_tool.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/mcp_tool.py
@@ -11,6 +11,10 @@ scope.
 Changes: 2026-05-21 (#1163) — updated the ``edit`` tool description to
 document the full response shape, including the new ``warnings`` field
 that carries the specialist's reason when it declines to act.
+Changes: 2026-05-21 (#1170) — the ``edit`` tool now accepts an optional
+``ops`` argument: the agent-mode second-call payload. In agent mode the
+first ``edit`` call returns ``action='draft_kit'`` and the chat agent
+calls back with ``ops=<granular op list>``. Subagent mode ignores it.
 """
 
 from __future__ import annotations
@@ -120,11 +124,13 @@ async def _edit_handler(args: dict[str, Any]) -> dict[str, Any]:
             "is_error": True,
         }
 
+    raw_ops = args.get("ops")
     payload = PocketSpecialistEditInput(
         pocket_id=args.get("pocket_id", ""),
         intent=args.get("intent", ""),
         pocket=args.get("pocket"),
         target_node_ids=args.get("target_node_ids"),
+        ops=raw_ops if isinstance(raw_ops, list) else None,
     )
 
     try:
@@ -281,12 +287,15 @@ def build_pocket_specialist_server() -> Any:
             "widget appearance, add/move/remove_node for structure), and "
             "applies them. Each op persists and pushes its own SSE event "
             "so the canvas updates in place. Returns "
-            "{ok, pocket_id, ops, duration_ms, backend_used, error, "
-            "warnings}. ok=false with a populated error means the run "
-            "failed — relay the error. ok=true with an empty ops list and "
-            "a populated warnings list means the specialist declined to "
-            "act — relay the warning so the user learns why nothing "
-            "changed; do NOT report success."
+            "{ok, pocket_id, ops, action, duration_ms, backend_used, "
+            "error, warnings, draft_kit}. ok=false with a populated error "
+            "means the run failed — relay the error. ok=true with an empty "
+            "ops list and a populated warnings list means the specialist "
+            "declined to act — relay the warning so the user learns why "
+            "nothing changed; do NOT report success. In agent mode the "
+            "first call returns action='draft_kit' with a draft_kit — "
+            "compute the granular ops it describes and call again with "
+            "the same pocket_id + intent AND ops=<your op list>."
         ),
         {
             "type": "object",
@@ -326,6 +335,31 @@ def build_pocket_specialist_server() -> Any:
                         "and does not search. Best practice for any "
                         "edit that needs disambiguation (the user said "
                         "'the chart' and there are three)."
+                    ),
+                },
+                "ops": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "op": {"type": "string"},
+                            "args": {"type": "object", "additionalProperties": True},
+                        },
+                        "required": ["op", "args"],
+                        "additionalProperties": False,
+                    },
+                    "description": (
+                        "Agent-mode second call: the granular ops you "
+                        "computed for the intent. Each op is "
+                        "{op: <name>, args: {...}} — op is one of "
+                        "set_state / append_state / remove_state / "
+                        "patch_state / set_node_prop / set_prop_array_item "
+                        "/ append_prop_array_item / remove_prop_array_item "
+                        "/ add_node / replace_node / move_node / "
+                        "remove_node. Omit on the first call (in agent "
+                        "mode you'll get back action='draft_kit' with "
+                        "instructions). In subagent mode this argument is "
+                        "ignored — the spawned specialist plans its own ops."
                     ),
                 },
             },

--- a/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
@@ -15,6 +15,15 @@ into ``warnings`` whether or not other ops landed. The 0-ops reason is
 joined with "" because deep_agents emits message events as token-level
 chunks. Added targeted observability logging for error events and
 tool_use / applied / rejected counts.
+Changes: 2026-05-21 (#1170) — ``run_edit_specialist`` now dispatches
+through ``pick_edit_adapter`` so it honors ``pocket_specialist_mode``,
+mirroring how ``run_specialist`` (create) routes through ``pick_adapter``.
+In ``agent`` mode the edit path no longer spawns a sub-agent backend —
+the chat agent computes the granular ops inline and the new
+``EditAgentModeAdapter`` applies them deterministically. The historical
+backend-spawn flow moved into the private ``_run_edit_subagent_pipeline``.
+A new ``PocketSpecialistEditInput.ops`` field carries the chat agent's
+pre-computed ops on the agent-mode second call.
 """
 
 from __future__ import annotations
@@ -504,6 +513,22 @@ class PocketSpecialistEditInput(BaseModel):
         ),
     )
 
+    # ---- agent-mode second-call payload ----
+    ops: list[dict[str, Any]] | None = Field(
+        default=None,
+        description=(
+            "Pre-computed granular ops for agent-mode's second call. Each "
+            "op is ``{op: <tool name>, args: {...}}`` where ``op`` is one "
+            "of the granular edit tools (set_state, append_state, "
+            "remove_state, patch_state, set_node_prop, set_prop_array_item, "
+            "append_prop_array_item, remove_prop_array_item, add_node, "
+            "replace_node, move_node, remove_node) and ``args`` are that "
+            "tool's arguments. When set, the specialist skips its own LLM "
+            "planning phase and applies the ops directly. Ignored in "
+            "subagent mode — the spawned specialist plans its own ops."
+        ),
+    )
+
 
 class PocketSpecialistEditOutput(BaseModel):
     ok: bool
@@ -511,6 +536,16 @@ class PocketSpecialistEditOutput(BaseModel):
     ops: list[dict[str, Any]] = Field(default_factory=list)
     duration_ms: int
     backend_used: str
+    action: Literal["applied", "failed", "draft_kit"] = Field(
+        default="applied",
+        description=(
+            "What the run did. ``applied`` — ops ran (subagent mode, or "
+            "agent-mode second call). ``failed`` — the run errored. "
+            "``draft_kit`` — agent-mode first call: no ops were supplied, "
+            "so the response carries a ``draft_kit`` telling the chat agent "
+            "how to compute ops and call back with ``ops=<list>``."
+        ),
+    )
     error: str | None = Field(
         default=None,
         description=(
@@ -529,6 +564,15 @@ class PocketSpecialistEditOutput(BaseModel):
             "``ok=True, ops=[]`` with no explanation is the #1163 bug."
         ),
     )
+    draft_kit: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Agent-mode first-call payload: the granular-op vocabulary, "
+            "the current pocket echo, and instructions for the calling "
+            "chat agent to compute the granular ops and call back with "
+            "``ops=<list>``. None in subagent mode and on the second call."
+        ),
+    )
 
 
 async def run_edit_specialist(
@@ -538,12 +582,41 @@ async def run_edit_specialist(
     user_id: str,
     settings: Settings,
 ) -> PocketSpecialistEditOutput:
-    """Run the pocket edit specialist end-to-end.
+    """Entry point — pick the edit adapter for ``settings.pocket_specialist_mode``
+    and delegate.
+
+    Mirrors ``run_specialist`` (create). The default ``subagent`` mode
+    runs ``_run_edit_subagent_pipeline`` below — an isolated backend
+    running the specialist's own model. The ``agent`` mode short-circuits
+    the backend spawn: the calling chat agent computes the granular ops
+    inline using its own LLM and hands them back for deterministic apply.
+
+    Signature is the public contract — ``mcp_tool``, ``cli_tool``, and
+    ``tool`` call sites rely on it being adapter-agnostic.
+    """
+    from pocketpaw_ee.agent.pocket_specialist.adapters import pick_edit_adapter
+
+    adapter = pick_edit_adapter(settings.pocket_specialist_mode)
+    return await adapter.edit(input, workspace_id=workspace_id, user_id=user_id, settings=settings)
+
+
+async def _run_edit_subagent_pipeline(
+    input: PocketSpecialistEditInput,
+    *,
+    workspace_id: str,
+    user_id: str,
+    settings: Settings,
+) -> PocketSpecialistEditOutput:
+    """Subagent-mode edit pipeline (historical flow).
 
     Spawns an isolated backend with the interaction prompt + granular
     mutation tools. The granular ops persist as they go (no
     persist_pocket needed); each op also emits its own SSE event so
     the canvas updates in place.
+
+    Invoked by ``EditSubagentAdapter.edit`` — kept private so the only
+    entry point remains ``run_edit_specialist`` (which dispatches via
+    ``pick_edit_adapter``).
     """
     started = time.monotonic()
     backend_name = settings.pocket_specialist_backend

--- a/tests/ee/agent/test_pocket_specialist/test_edit.py
+++ b/tests/ee/agent/test_pocket_specialist/test_edit.py
@@ -18,7 +18,7 @@ Regression tests for #1163 (silent 0-ops edits):
   * Rejected op — a service-rejected granular op must not count as applied;
     its error is folded into ``warnings`` (PR #1165 review finding #2).
 
-Regression test for edit-ignores-agent-mode bug:
+Regression test for edit-ignores-agent-mode bug (#1170):
   * In agent mode (POCKETPAW_POCKET_SPECIALIST_MODE=agent), pocket CREATE goes
     through AgentModeAdapter which never spawns a sub-agent backend.  Pocket
     EDIT ignores the mode setting entirely and always calls
@@ -28,6 +28,10 @@ Regression test for edit-ignores-agent-mode bug:
     deployments.
   * Post-fix contract: run_edit_specialist in agent mode MUST NOT call
     create_isolated_backend.
+  * Agent-mode two-call protocol coverage: the first call (no ``ops``)
+    returns a draft kit; the second call (``ops`` populated) applies the
+    chat agent's granular ops through the real edit tools — rejected and
+    unknown ops fold into ``warnings`` like the subagent path.
 """
 
 from __future__ import annotations
@@ -261,7 +265,13 @@ class TestRunEditSpecialistSuccessFlag:
     completed. Before this guard, ``run_edit_specialist`` returned
     ``ok=True`` even when the inner backend errored mid-stream — the
     caller had no way to tell "no work needed" from "specialist
-    crashed"."""
+    crashed".
+
+    These tests exercise the SUBAGENT pipeline (the backend-spawn path),
+    so they pin ``pocket_specialist_mode="subagent"`` explicitly rather
+    than relying on the ambient ``Settings()`` default — that default is
+    overridable by env / ``.env`` (#1170 added the ``agent`` mode edit
+    path, which never spawns a backend)."""
 
     @pytest.mark.asyncio
     async def test_ok_true_when_stream_completes(self) -> None:
@@ -291,7 +301,7 @@ class TestRunEditSpecialistSuccessFlag:
                 PocketSpecialistEditInput(pocket_id="p1", intent="rename row 1"),
                 workspace_id="w1",
                 user_id="u1",
-                settings=Settings(),
+                settings=Settings(pocket_specialist_mode="subagent"),
             )
 
         assert out.ok is True
@@ -329,7 +339,7 @@ class TestRunEditSpecialistSuccessFlag:
                 PocketSpecialistEditInput(pocket_id="p1", intent="rename row 1"),
                 workspace_id="w1",
                 user_id="u1",
-                settings=Settings(),
+                settings=Settings(pocket_specialist_mode="subagent"),
             )
 
         assert out.ok is False
@@ -390,7 +400,7 @@ class TestRunEditSpecialistSuccessFlag:
                 ),
                 workspace_id="69e4f93b57ff64b3903868e3",
                 user_id="69d0f4d09dfb6ddfd8e2da84",
-                settings=Settings(),
+                settings=Settings(pocket_specialist_mode="subagent"),
             )
 
         # POST-FIX expectation (fails today — current code returns ok=True):
@@ -453,7 +463,7 @@ class TestRunEditSpecialistSuccessFlag:
                 ),
                 workspace_id="69e4f93b57ff64b3903868e3",
                 user_id="69d0f4d09dfb6ddfd8e2da84",
-                settings=Settings(),
+                settings=Settings(pocket_specialist_mode="subagent"),
             )
 
         # A decline is NOT a failure — the run completed cleanly.
@@ -538,7 +548,7 @@ class TestRunEditSpecialistSuccessFlag:
                 ),
                 workspace_id="69e4f93b57ff64b3903868e3",
                 user_id="69d0f4d09dfb6ddfd8e2da84",
-                settings=Settings(),
+                settings=Settings(pocket_specialist_mode="subagent"),
             )
 
         # The run completed — nothing raised.
@@ -689,13 +699,13 @@ class TestAgentModeEditDispatch:
         This test FAILS today because create_isolated_backend is called unconditionally
         in run_edit_specialist regardless of pocket_specialist_mode.
         """
-        from unittest.mock import MagicMock
 
-        from pocketpaw.config import Settings
         from pocketpaw_ee.agent.pocket_specialist.runtime import (
             PocketSpecialistEditInput,
             run_edit_specialist,
         )
+
+        from pocketpaw.config import Settings
 
         settings = Settings(pocket_specialist_mode="agent")
         # Confirm the setting is actually agent mode (belt-and-suspenders)
@@ -726,14 +736,17 @@ class TestAgentModeEditDispatch:
                 # acceptable is reaching create_isolated_backend at all.
                 pass
 
-        mock_create_backend.assert_not_called(), (
-            "run_edit_specialist called AgentRouter.create_isolated_backend even though "
-            "pocket_specialist_mode='agent'. In agent mode the edit path must NOT spawn "
-            "a sub-agent backend — doing so triggers "
-            "TypeError: Could not resolve authentication method when ANTHROPIC_API_KEY "
-            "is absent (the bug on Claude Code deployments). "
-            "Fix: add mode-dispatch to run_edit_specialist mirroring run_specialist's "
-            "pick_adapter call so agent mode takes an adapter path that skips the backend."
+        (
+            mock_create_backend.assert_not_called(),
+            (
+                "run_edit_specialist called AgentRouter.create_isolated_backend even though "
+                "pocket_specialist_mode='agent'. In agent mode the edit path must NOT spawn "
+                "a sub-agent backend — doing so triggers "
+                "TypeError: Could not resolve authentication method when ANTHROPIC_API_KEY "
+                "is absent (the bug on Claude Code deployments). "
+                "Fix: add mode-dispatch to run_edit_specialist mirroring run_specialist's "
+                "pick_adapter call so agent mode takes an adapter path that skips the backend."
+            ),
         )
 
     @pytest.mark.asyncio
@@ -746,12 +759,13 @@ class TestAgentModeEditDispatch:
         """
         from unittest.mock import MagicMock
 
-        from pocketpaw.agents.protocol import AgentEvent
-        from pocketpaw.config import Settings
         from pocketpaw_ee.agent.pocket_specialist.runtime import (
             PocketSpecialistEditInput,
             run_edit_specialist,
         )
+
+        from pocketpaw.agents.protocol import AgentEvent
+        from pocketpaw.config import Settings
 
         settings = Settings(pocket_specialist_mode="subagent")
 
@@ -777,7 +791,153 @@ class TestAgentModeEditDispatch:
                 settings=settings,
             )
 
-        mock_create_backend.assert_called_once(), (
-            "subagent mode must still call create_isolated_backend — "
-            "the agent-mode fix must not break the existing subagent path."
+        (
+            mock_create_backend.assert_called_once(),
+            (
+                "subagent mode must still call create_isolated_backend — "
+                "the agent-mode fix must not break the existing subagent path."
+            ),
         )
+
+    @pytest.mark.asyncio
+    async def test_agent_mode_first_call_returns_draft_kit(self) -> None:
+        """Agent-mode first call (no ``ops``) must return a draft kit so
+        the chat agent knows how to compute the granular ops — mirroring
+        create's ``action='draft_kit'`` first call. No backend spawned."""
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditInput,
+            run_edit_specialist,
+        )
+
+        from pocketpaw.config import Settings
+
+        with patch(
+            "pocketpaw_ee.agent.pocket_specialist.runtime.AgentRouter.create_isolated_backend",
+        ) as mock_create_backend:
+            out = await run_edit_specialist(
+                PocketSpecialistEditInput(pocket_id="p1", intent="rename the first row"),
+                workspace_id="w1",
+                user_id="u1",
+                settings=Settings(pocket_specialist_mode="agent"),
+            )
+
+        mock_create_backend.assert_not_called()
+        assert out.action == "draft_kit"
+        assert out.ok is False
+        assert out.backend_used == "agent_mode"
+        assert out.draft_kit is not None
+        # The kit must name the granular op vocabulary.
+        assert "set_state" in out.draft_kit["granular_ops"]
+        assert "add_node" in out.draft_kit["granular_ops"]
+        assert out.ops == []
+
+    @pytest.mark.asyncio
+    async def test_agent_mode_second_call_applies_ops_without_backend(self) -> None:
+        """Agent-mode second call (``ops`` populated) must apply the chat
+        agent's granular ops through the real edit tools — no backend
+        spawned, no LLM. Mirrors create's validate-and-persist second call."""
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditInput,
+            run_edit_specialist,
+        )
+
+        from pocketpaw.config import Settings
+
+        with (
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.runtime.AgentRouter.create_isolated_backend",
+            ) as mock_create_backend,
+            patch(
+                "pocketpaw_ee.cloud.pockets.agent_context.set_state_for_agent",
+                new=AsyncMock(return_value={"ok": True}),
+            ),
+        ):
+            out = await run_edit_specialist(
+                PocketSpecialistEditInput(
+                    pocket_id="p1",
+                    intent="filter to overdue",
+                    ops=[{"op": "set_state", "args": {"path": "filter", "value": "overdue"}}],
+                ),
+                workspace_id="w1",
+                user_id="u1",
+                settings=Settings(pocket_specialist_mode="agent"),
+            )
+
+        mock_create_backend.assert_not_called()
+        assert out.ok is True
+        assert out.action == "applied"
+        assert out.backend_used == "agent_mode"
+        assert out.ops == [{"op": "set_state", "args": {"path": "filter", "value": "overdue"}}]
+        assert out.error is None
+
+    @pytest.mark.asyncio
+    async def test_agent_mode_rejected_op_surfaces_in_warnings(self) -> None:
+        """A service-rejected op in agent mode must NOT count as applied —
+        its reason folds into ``warnings``, same contract as subagent mode
+        (#1163 class). The run stays ``ok=True`` (nothing crashed)."""
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditInput,
+            run_edit_specialist,
+        )
+
+        from pocketpaw.config import Settings
+
+        with (
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.runtime.AgentRouter.create_isolated_backend",
+            ) as mock_create_backend,
+            patch(
+                "pocketpaw_ee.cloud.pockets.agent_context.set_state_for_agent",
+                new=AsyncMock(
+                    return_value={"ok": False, "error": "state path 'filter' does not exist"}
+                ),
+            ),
+        ):
+            out = await run_edit_specialist(
+                PocketSpecialistEditInput(
+                    pocket_id="p1",
+                    intent="filter to overdue",
+                    ops=[{"op": "set_state", "args": {"path": "filter", "value": "overdue"}}],
+                ),
+                workspace_id="w1",
+                user_id="u1",
+                settings=Settings(pocket_specialist_mode="agent"),
+            )
+
+        mock_create_backend.assert_not_called()
+        assert out.ok is True
+        assert out.ops == []
+        assert out.warnings, "a rejected op must surface its reason in warnings"
+        joined = " ".join(out.warnings)
+        assert "set_state" in joined and "does not exist" in joined
+
+    @pytest.mark.asyncio
+    async def test_agent_mode_unknown_op_surfaces_in_warnings(self) -> None:
+        """An op naming a tool the specialist does not hold must be skipped
+        and reported in ``warnings`` — not crash the run."""
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditInput,
+            run_edit_specialist,
+        )
+
+        from pocketpaw.config import Settings
+
+        with patch(
+            "pocketpaw_ee.agent.pocket_specialist.runtime.AgentRouter.create_isolated_backend",
+        ) as mock_create_backend:
+            out = await run_edit_specialist(
+                PocketSpecialistEditInput(
+                    pocket_id="p1",
+                    intent="do something unsupported",
+                    ops=[{"op": "create_pocket", "args": {}}],
+                ),
+                workspace_id="w1",
+                user_id="u1",
+                settings=Settings(pocket_specialist_mode="agent"),
+            )
+
+        mock_create_backend.assert_not_called()
+        assert out.ok is True
+        assert out.ops == []
+        assert out.warnings
+        assert "create_pocket" in " ".join(out.warnings)

--- a/tests/ee/agent/test_pocket_specialist/test_edit.py
+++ b/tests/ee/agent/test_pocket_specialist/test_edit.py
@@ -17,6 +17,17 @@ Regression tests for #1163 (silent 0-ops edits):
     reply in ``warnings`` rather than a silent ok=True.
   * Rejected op — a service-rejected granular op must not count as applied;
     its error is folded into ``warnings`` (PR #1165 review finding #2).
+
+Regression test for edit-ignores-agent-mode bug:
+  * In agent mode (POCKETPAW_POCKET_SPECIALIST_MODE=agent), pocket CREATE goes
+    through AgentModeAdapter which never spawns a sub-agent backend.  Pocket
+    EDIT ignores the mode setting entirely and always calls
+    AgentRouter.create_isolated_backend — which needs ANTHROPIC_API_KEY when
+    the default ``deep_agents`` backend is selected, crashing with
+    ``TypeError: Could not resolve authentication method`` on Claude Code
+    deployments.
+  * Post-fix contract: run_edit_specialist in agent mode MUST NOT call
+    create_isolated_backend.
 """
 
 from __future__ import annotations
@@ -645,3 +656,128 @@ class TestPromptSeparation:
                 "(#1163 root cause B). Remove it from the tools block; "
                 "prohibition text in HARD RULES is still fine."
             )
+
+
+class TestAgentModeEditDispatch:
+    """Regression tests for the bug where run_edit_specialist ignores
+    pocket_specialist_mode and always spawns an isolated backend even when
+    mode is ``agent``.
+
+    The create path (run_specialist) correctly dispatches through pick_adapter:
+    when mode is ``agent``, AgentModeAdapter handles the call without ever
+    touching AgentRouter.create_isolated_backend.
+
+    The edit path has no equivalent dispatch — it calls create_isolated_backend
+    unconditionally at runtime.py line ~578. With the default
+    pocket_specialist_backend=deep_agents, that backend's __init__ reaches
+    LangChain ChatAnthropic, which raises
+    ``TypeError: Could not resolve authentication method`` when ANTHROPIC_API_KEY
+    is absent (e.g., on a Claude Code deployment).
+
+    Post-fix contract: in agent mode run_edit_specialist must NOT call
+    create_isolated_backend.
+    """
+
+    @pytest.mark.asyncio
+    async def test_agent_mode_edit_does_not_spawn_isolated_backend(self) -> None:
+        """Bug reproduction: run_edit_specialist with pocket_specialist_mode='agent'
+        ALWAYS calls AgentRouter.create_isolated_backend today, ignoring the mode.
+
+        Post-fix contract: when mode is 'agent', the edit path mirrors the create
+        path's AgentModeAdapter and returns without ever calling create_isolated_backend.
+
+        This test FAILS today because create_isolated_backend is called unconditionally
+        in run_edit_specialist regardless of pocket_specialist_mode.
+        """
+        from unittest.mock import MagicMock
+
+        from pocketpaw.config import Settings
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditInput,
+            run_edit_specialist,
+        )
+
+        settings = Settings(pocket_specialist_mode="agent")
+        # Confirm the setting is actually agent mode (belt-and-suspenders)
+        assert settings.pocket_specialist_mode == "agent"
+
+        with patch(
+            "pocketpaw_ee.agent.pocket_specialist.runtime.AgentRouter.create_isolated_backend",
+        ) as mock_create_backend:
+            # In agent mode the edit path should handle the request without
+            # spawning a backend. We do NOT set a return value on mock_create_backend
+            # because it must never be called — if it is called the test fails on
+            # assert_not_called() below.  We also don't need to configure a fake
+            # streaming backend because the agent-mode path should exit before
+            # reaching the backend.run() loop.
+            try:
+                await run_edit_specialist(
+                    PocketSpecialistEditInput(
+                        pocket_id="p1",
+                        intent="rename the first row to 'Active'",
+                    ),
+                    workspace_id="w1",
+                    user_id="u1",
+                    settings=settings,
+                )
+            except Exception:
+                # The agent-mode path may raise NotImplementedError or similar
+                # while it is being built — that is acceptable.  What is NOT
+                # acceptable is reaching create_isolated_backend at all.
+                pass
+
+        mock_create_backend.assert_not_called(), (
+            "run_edit_specialist called AgentRouter.create_isolated_backend even though "
+            "pocket_specialist_mode='agent'. In agent mode the edit path must NOT spawn "
+            "a sub-agent backend — doing so triggers "
+            "TypeError: Could not resolve authentication method when ANTHROPIC_API_KEY "
+            "is absent (the bug on Claude Code deployments). "
+            "Fix: add mode-dispatch to run_edit_specialist mirroring run_specialist's "
+            "pick_adapter call so agent mode takes an adapter path that skips the backend."
+        )
+
+    @pytest.mark.asyncio
+    async def test_subagent_mode_edit_still_spawns_backend(self) -> None:
+        """Companion guard: subagent mode (the default) must CONTINUE to spawn
+        an isolated backend after the agent-mode fix lands.
+
+        This test must PASS today and must continue to pass after the fix.
+        It verifies that the fix doesn't accidentally break the subagent path.
+        """
+        from unittest.mock import MagicMock
+
+        from pocketpaw.agents.protocol import AgentEvent
+        from pocketpaw.config import Settings
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditInput,
+            run_edit_specialist,
+        )
+
+        settings = Settings(pocket_specialist_mode="subagent")
+
+        async def _noop_stream(*args, **kwargs):
+            yield AgentEvent(type="done", content="")
+
+        fake_backend = MagicMock()
+        fake_backend.run = _noop_stream
+        fake_backend.attach_specialist_tools = MagicMock()
+        fake_backend.stop = AsyncMock()
+
+        with patch(
+            "pocketpaw_ee.agent.pocket_specialist.runtime.AgentRouter.create_isolated_backend",
+            return_value=fake_backend,
+        ) as mock_create_backend:
+            await run_edit_specialist(
+                PocketSpecialistEditInput(
+                    pocket_id="p1",
+                    intent="rename the first row to 'Active'",
+                ),
+                workspace_id="w1",
+                user_id="u1",
+                settings=settings,
+            )
+
+        mock_create_backend.assert_called_once(), (
+            "subagent mode must still call create_isolated_backend — "
+            "the agent-mode fix must not break the existing subagent path."
+        )


### PR DESCRIPTION
## The bug

With `POCKETPAW_POCKET_SPECIALIST_MODE=agent`, creating a pocket works but editing one crashes.

`run_specialist` (create) routes through `pick_adapter`. In agent mode it picks `AgentModeAdapter`, which spawns no sub-agent backend — the main Claude Code agent drafts the rippleSpec and the specialist only validates and persists.

`run_edit_specialist` (edit) had no such dispatch. It always called `AgentRouter.create_isolated_backend(settings.pocket_specialist_backend, ...)` regardless of the mode. With the default `deep_agents` backend, that reaches LangChain `ChatAnthropic`, which needs an `ANTHROPIC_API_KEY`. A Claude Code deployment has none — the `claude` CLI handles its own auth — so every edit failed with:

```
TypeError: Could not resolve authentication method. Expected one of
api_key, auth_token, or credentials to be set.
```

The two paths were built asymmetrically. #1165 made the failure surface as `ok=false` with a real error instead of a silent `ok:true, ops:[]` (#1163), which is what made this diagnosable.

## The fix

Edit now gets the same mode dispatch create has.

- `run_edit_specialist` is now a thin entry point that routes through a new `pick_edit_adapter`, mirroring how `run_specialist` routes through `pick_adapter`.
- The historical backend-spawn flow moved verbatim into the private `_run_edit_subagent_pipeline` — subagent deployments are unchanged.
- `EditAgentModeAdapter` runs a two-call protocol that mirrors `AgentModeAdapter`:
  - First call (no `ops`): returns a draft kit — the current pocket, the granular-op vocabulary, and instructions to call back with the computed ops. `action="draft_kit"`.
  - Second call (`ops` populated): applies each op through the same `make_edit_pocket_tools` the subagent uses. No backend, no LLM. `action="applied"`.
- `EditSubagentAdapter` is the dispatch shim for the existing path.

No backend is spawned in either agent-mode call, so there is nothing for the missing API key to break.

## Design choice — granular ops, not a full mutated spec

The chat agent hands the edit adapter a list of **granular ops** (`{op, args}`), not a fully mutated rippleSpec.

Create's adapter hands the persist tool the chat agent's drafted spec because create has a whole-spec persist primitive. Edit does not. Edit's persistence layer *is* the granular ops — `set_state`, `set_node_prop`, `add_node`, the Tier-2 array-item ops, and so on. Each op persists in place and pushes its own SSE event so the canvas updates live as the edit lands.

Replacing the whole spec on every edit would throw away those in-place updates and the surgical semantics the edit subsystem was built around. Granular ops also reuse the existing tool wrappers, so the agent-mode path gets the same manifest and service validation, and the same rejected-op handling that `run_edit_specialist` already folds into `warnings`. Rejected ops and unrecognized op names come back as warnings; the run stays `ok=true` because nothing crashed.

This matches the create adapter in spirit — the chat agent does the thinking, the adapter does the deterministic apply — and matches the `pocketpaw-edit-pocket` skill: the chat agent decides what and where, the specialist applies the granular mutations.

## Wiring

- `PocketSpecialistEditInput` gains an optional `ops` field — the agent-mode second-call payload, the edit counterpart of create's `spec`.
- `PocketSpecialistEditOutput` gains `action` (`applied` / `failed` / `draft_kit`) and `draft_kit`, mirroring the create output.
- The `edit` MCP tool accepts and documents the `ops` argument.

## Tests

`tests/ee/agent/test_pocket_specialist/` — 133 passing, including the committed reproduction test `test_agent_mode_edit_does_not_spawn_isolated_backend` (red before this change). New coverage for the agent-mode two-call protocol: draft kit on the first call, ops applied on the second, rejected ops and unknown ops surfaced in warnings.

The five `TestRunEditSpecialistSuccessFlag` tests now pin `pocket_specialist_mode="subagent"` explicitly. They exercise the subagent backend-spawn pipeline; before this change they only passed in agent mode because the bug routed agent mode through the subagent path anyway. Pinning the mode keeps them honest and independent of ambient `.env` config.

`ruff check` and `ruff format --check` clean across the repo.

Closes #1170