### PR TITLE
Stamp pocket node ids at persist time so edits can address nodes

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -24,6 +24,9 @@ Agent-facing granular ``rippleSpec.ui`` mutations (called from the
 
 Changes: 2026-05-14 — added the Tier-2 prop-array item ops (reworked
 onto the pocketpaw_ee layout from PR #1106).
+Changes: 2026-05-21 (#1172) — ``agent_view`` self-heals node ids via
+``_heal_node_ids`` so pockets persisted before node-id stamping became
+addressable by granular edit ops on first agent read.
 """
 
 from __future__ import annotations
@@ -876,9 +879,43 @@ async def is_member(pocket_id: str, user_id: str) -> bool:
     return getattr(doc, "visibility", "workspace") == "workspace"
 
 
+async def _heal_node_ids(doc: _PocketDoc) -> None:
+    """Defense-in-depth: stamp ``n_xxxxxxxx`` ids on a pocket's UISpec
+    tree(s) if any node lacks one, persisting the heal.
+
+    Pockets created or persisted after #1172 always carry node ids
+    (``normalize_ripple_spec`` stamps them). This heals pockets written
+    before the fix so they become editable on first agent read without
+    a separate DB migration. Idempotent — a no-op when ids are already
+    present.
+    """
+    spec = doc.rippleSpec
+    if not isinstance(spec, dict):
+        return
+    changed = False
+    ui = spec.get("ui")
+    if isinstance(ui, dict) and spec_ops.ensure_ids(ui):
+        changed = True
+    panes = spec.get("panes")
+    if isinstance(panes, dict):
+        for pane in panes.values():
+            if isinstance(pane, dict) and spec_ops.ensure_ids(pane):
+                changed = True
+    if changed:
+        try:
+            await doc.save()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("pocket %s node-id heal save failed: %s", doc.id, exc)
+
+
 async def agent_view(pocket_id: str) -> tuple[dict | None, str | None]:
     """Read-only fetch — returns ``(view_dict, None)`` on success or
     ``(None, error)`` on failure.
+
+    Self-heals node ids: a legacy pocket persisted before #1172 has an
+    id-less ``ui`` tree, so the chat agent would have no ``n_xxxxxxxx``
+    id to address with granular edit ops. ``_heal_node_ids`` stamps and
+    persists them on first read.
 
     Note: $source markers in rippleSpec are intentionally NOT resolved
     here. The agent must see raw markers so that on edit it preserves
@@ -888,6 +925,7 @@ async def agent_view(pocket_id: str) -> tuple[dict | None, str | None]:
     doc, err = await _agent_load_doc(pocket_id)
     if err:
         return None, err
+    await _heal_node_ids(doc)
     return _agent_view_dict(doc), None
 
 

--- a/ee/pocketpaw_ee/cloud/ripple_normalizer.py
+++ b/ee/pocketpaw_ee/cloud/ripple_normalizer.py
@@ -1,4 +1,13 @@
-"""Minimal ripple spec normalizer — ensures envelope fields and widget IDs."""
+"""Minimal ripple spec normalizer — ensures envelope fields and widget IDs.
+
+Changes: 2026-05-21 (#1172) — ``normalize_ripple_spec`` now stamps a
+stable ``n_xxxxxxxx`` id on every node of a UISpec ``ui`` tree (and
+each ``panes`` value) via ``spec_ops.ensure_ids``. Every persist path
+routes through this normalizer, so stored specs always carry node ids
+and the chat agent can address nodes with granular edit ops. Previously
+ids were minted only at the start of a granular mutation op, leaving a
+freshly created pocket's tree id-less and unaddressable.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +16,23 @@ import secrets
 from typing import Any
 
 log = logging.getLogger(__name__)
+
+
+def _stamp_node_ids(ui: Any) -> Any:
+    """Assign a stable ``n_xxxxxxxx`` id to every node in a UISpec
+    tree that lacks one. Idempotent and collision-safe — nodes that
+    already carry a valid unique id pass through untouched. Returns the
+    same object (``ensure_ids`` mutates in place).
+
+    ``spec_ops`` is imported lazily: ``pockets/__init__`` pulls in the
+    pockets router, which imports ``pockets/service``, which imports
+    this module — a top-level import here would close the cycle.
+    """
+    if isinstance(ui, dict):
+        from pocketpaw_ee.cloud.pockets import spec_ops
+
+        spec_ops.ensure_ids(ui)
+    return ui
 
 
 def _short_id() -> str:
@@ -148,19 +174,20 @@ def normalize_ripple_spec(spec: dict[str, Any] | None) -> dict[str, Any] | None:
         },
     }
 
-    # Multi-pane: walk every pane to fix control-flow nodes inside.
+    # Multi-pane: walk every pane to fix control-flow nodes inside, then
+    # stamp node ids so each pane tree is addressable by edit ops.
     if spec.get("panes") and isinstance(spec["panes"], dict):
-        fixed_panes = {k: _walk_and_fix(v) for k, v in spec["panes"].items()}
+        fixed_panes = {k: _stamp_node_ids(_walk_and_fix(v)) for k, v in spec["panes"].items()}
         return {**spec, **envelope, "version": spec.get("version", "1.0"), "panes": fixed_panes}
 
-    # UISpec v1.0: walk the tree before persisting.
+    # UISpec v1.0: walk the tree, then stamp node ids before persisting.
     ui = spec.get("ui")
     if isinstance(ui, dict) and ui.get("type"):
         return {
             **spec,
             **envelope,
             "version": spec.get("version", "1.0"),
-            "ui": _walk_and_fix(ui),
+            "ui": _stamp_node_ids(_walk_and_fix(ui)),
         }
 
     # UISpec under a misnamed top-level key — the agent occasionally
@@ -178,7 +205,7 @@ def normalize_ripple_spec(spec: dict[str, Any] | None) -> dict[str, Any] | None:
                 **promoted,
                 **envelope,
                 "version": spec.get("version", "1.0"),
-                "ui": _walk_and_fix(candidate),
+                "ui": _stamp_node_ids(_walk_and_fix(candidate)),
             }
 
     # UISpec passed as a raw root node — i.e. ``{type: "flex", props,
@@ -194,7 +221,11 @@ def normalize_ripple_spec(spec: dict[str, Any] | None) -> dict[str, Any] | None:
     if isinstance(spec_type, str) and spec_type and ("props" in spec or "children" in spec):
         node_keys = ("type", "props", "children", "style", "show", "id")
         node = {k: v for k, v in spec.items() if k in node_keys}
-        return {**envelope, "version": spec.get("version", "1.0"), "ui": _walk_and_fix(node)}
+        return {
+            **envelope,
+            "version": spec.get("version", "1.0"),
+            "ui": _stamp_node_ids(_walk_and_fix(node)),
+        }
 
     # Flat widgets: ensure IDs
     raw_widgets = spec.get("widgets")

--- a/tests/cloud/test_pocket_node_ids.py
+++ b/tests/cloud/test_pocket_node_ids.py
@@ -5,7 +5,10 @@ freshly created pocket has an id-less ``rippleSpec.ui`` tree, so the
 chat agent fetching it via ``fetch_pocket_for_agent`` has no
 ``n_xxxxxxxx`` id to target with granular edit ops. Verifies node ids
 are stamped at persist time (in ``normalize_ripple_spec``) and that
-existing id-less pockets self-heal on first agent read.
+existing id-less pockets self-heal on first agent read. Includes an
+end-to-end round-trip test that fetches a real id and feeds it back
+into ``set_node_prop`` / ``add_node`` to prove the chicken-and-egg is
+closed.
 """
 
 from __future__ import annotations
@@ -162,3 +165,85 @@ async def test_agent_view_self_heals_legacy_id_less_pocket(mongo_db, agent_ident
     # The heal must be persisted, not just applied to the returned view.
     refreshed = await Pocket.get(doc.id)
     _assert_every_node_has_valid_id(refreshed.rippleSpec["ui"])
+
+
+@pytest.mark.asyncio
+async def test_fetched_node_id_round_trips_through_granular_ops(mongo_db, agent_identity):
+    """End-to-end proof that the #1172 chicken-and-egg is closed.
+
+    The exact failure: the chat agent fetches a pocket with
+    ``get_pocket``, pulls a node id out of the returned ``ui`` tree, and
+    feeds it to a granular edit op — which rejected it with
+    ``no node with id X`` because the fetched tree carried no ids. This
+    test walks that path with no LLM:
+
+      1. create a pocket via the normal create/persist path,
+      2. fetch it through ``fetch_pocket_for_agent`` (the ``get_pocket``
+         path) and read REAL ids off the root and a nested child,
+      3. call ``set_node_prop`` on the child id and ``add_node`` with
+         the root id as ``parent_id``,
+      4. assert both ops return ``ok: true`` and the changes landed.
+
+    Before the fix step 2 returned an id-less tree, so step 3 had
+    nothing valid to pass and every op was rejected.
+    """
+    from pocketpaw_ee.cloud.pockets.agent_context import (
+        add_node_for_agent,
+        fetch_pocket_for_agent,
+        set_node_prop_for_agent,
+    )
+    from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+    from pocketpaw_ee.cloud.pockets.service import create
+
+    body = CreatePocketRequest(
+        name="Todos",
+        description="",
+        type="custom",
+        icon="check-square",
+        color="#0A84FF",
+        visibility="workspace",
+        ripple_spec=dict(_ID_LESS_SPEC),
+    )
+    created = await create("w1", "u1", body)
+    pocket_id = str(created.get("_id") or created.get("id"))
+
+    # Step 2 — fetch the way the chat agent does, pull real ids.
+    fetched = await fetch_pocket_for_agent(pocket_id)
+    assert fetched["ok"] is True, fetched.get("error")
+    ui = fetched["pocket"]["rippleSpec"]["ui"]
+
+    root_id = ui["id"]
+    # The heading is the first child — a nested node, not the root.
+    heading = ui["children"][0]
+    assert heading["type"] == "heading"
+    child_id = heading["id"]
+    assert spec_ops.is_valid_id(root_id)
+    assert spec_ops.is_valid_id(child_id)
+
+    # Step 3a — set a prop on the fetched child id.
+    set_result = await set_node_prop_for_agent(pocket_id, child_id, "text", "Today's Todos")
+    assert set_result["ok"] is True, set_result.get("error")
+    assert "no node with id" not in str(set_result)
+
+    # Step 3b — add a node under the fetched root id.
+    add_result = await add_node_for_agent(
+        pocket_id,
+        root_id,
+        {"type": "text", "props": {"text": "footer"}},
+    )
+    assert add_result["ok"] is True, add_result.get("error")
+    new_node_id = add_result["node_id"]
+    assert spec_ops.is_valid_id(new_node_id)
+
+    # Step 4 — both changes actually landed in the persisted spec.
+    after = await fetch_pocket_for_agent(pocket_id)
+    assert after["ok"] is True, after.get("error")
+    after_ui = after["pocket"]["rippleSpec"]["ui"]
+
+    healed_heading = spec_ops.find_by_id(after_ui, child_id)
+    assert healed_heading is not None
+    assert healed_heading["props"]["text"] == "Today's Todos"
+
+    appended = spec_ops.find_by_id(after_ui, new_node_id)
+    assert appended is not None
+    assert appended["props"]["text"] == "footer"

--- a/tests/cloud/test_pocket_node_ids.py
+++ b/tests/cloud/test_pocket_node_ids.py
@@ -1,0 +1,164 @@
+"""Regression tests for pocket rippleSpec node-id stamping (#1172).
+
+Changes: 2026-05-21 (#1172) — new file. Reproduces the bug where a
+freshly created pocket has an id-less ``rippleSpec.ui`` tree, so the
+chat agent fetching it via ``fetch_pocket_for_agent`` has no
+``n_xxxxxxxx`` id to target with granular edit ops. Verifies node ids
+are stamped at persist time (in ``normalize_ripple_spec``) and that
+existing id-less pockets self-heal on first agent read.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.pockets import spec_ops
+
+
+def _all_nodes(node: object) -> list[dict]:
+    """Flatten every dict node in a UISpec tree (walks children +
+    else_children)."""
+    out: list[dict] = []
+    if isinstance(node, dict):
+        out.append(node)
+        for key in ("children", "else_children"):
+            kids = node.get(key)
+            if isinstance(kids, list):
+                for kid in kids:
+                    out.extend(_all_nodes(kid))
+    return out
+
+
+def _assert_every_node_has_valid_id(ui: object) -> None:
+    nodes = _all_nodes(ui)
+    assert nodes, "expected at least one node in the ui tree"
+    for n in nodes:
+        nid = n.get("id")
+        assert spec_ops.is_valid_id(nid), (
+            f"node type={n.get('type')!r} has invalid/missing id {nid!r} "
+            f"— expected an n_xxxxxxxx id"
+        )
+    # Ids must be unique across the tree.
+    ids = [n["id"] for n in nodes]
+    assert len(ids) == len(set(ids)), "node ids must be unique across the tree"
+
+
+async def _make_pocket(**fields):
+    """Insert a fresh Pocket through the normal Beanie path."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    base = dict(
+        workspace="w1",
+        name="Test Pocket",
+        description="",
+        type="custom",
+        icon="",
+        color="",
+        owner="u1",
+        visibility="workspace",
+    )
+    base.update(fields)
+    doc = Pocket(**base)
+    await doc.insert()
+    return doc
+
+
+@pytest.fixture
+def agent_identity():
+    """Attach the default ``w1`` / ``u1`` SSE-stream identity so
+    ``agent_view`` / ``_agent_load_doc`` pass their workspace +
+    edit-access checks."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_agent_identity,
+        detach_agent_identity,
+    )
+
+    tokens = attach_agent_identity(workspace_id="w1", user_id="u1")
+    try:
+        yield
+    finally:
+        detach_agent_identity(tokens)
+
+
+# A nested UISpec tree as the drafting LLM produces it — no node ids
+# anywhere, exactly the shape #1172 reproduces.
+_ID_LESS_SPEC = {
+    "version": "1.0",
+    "state": {"draft": "", "todos": []},
+    "ui": {
+        "type": "flex",
+        "props": {"direction": "column", "gap": 16},
+        "children": [
+            {"type": "heading", "props": {"text": "Todos", "level": 1}},
+            {"type": "input", "bind": "draft", "props": {"placeholder": "Add..."}},
+            {
+                "type": "each",
+                "items": "todos",
+                "children": [
+                    {"type": "text", "props": {"text": "{item.text}"}},
+                ],
+            },
+        ],
+    },
+}
+
+
+@pytest.mark.asyncio
+async def test_fetch_pocket_for_agent_returns_node_ids(mongo_db, agent_identity):
+    """A pocket created via the normal create/persist path must, when
+    fetched through ``fetch_pocket_for_agent``, return a rippleSpec
+    ``ui`` tree where EVERY node carries a valid ``n_xxxxxxxx`` id.
+
+    Without ids the chat agent has nothing to put in ``parent_id`` /
+    ``node_id`` and every granular edit op fails with
+    ``no node with id X``.
+    """
+    from pocketpaw_ee.cloud.pockets.agent_context import fetch_pocket_for_agent
+    from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+    from pocketpaw_ee.cloud.pockets.service import create
+
+    # Create a pocket exactly the way the create flow does — the spec
+    # goes through normalize_ripple_spec on the way to MongoDB.
+    body = CreatePocketRequest(
+        name="Todos",
+        description="",
+        type="custom",
+        icon="check-square",
+        color="#0A84FF",
+        visibility="workspace",
+        ripple_spec=dict(_ID_LESS_SPEC),
+    )
+    created = await create("w1", "u1", body)
+    # The wire dict keys the pocket id under ``_id`` (Mongo-style).
+    pocket_id = str(created.get("_id") or created.get("id"))
+
+    result = await fetch_pocket_for_agent(pocket_id)
+    assert result["ok"] is True, result.get("error")
+
+    spec = result["pocket"]["rippleSpec"]
+    assert spec is not None, "fetched pocket has no rippleSpec"
+    ui = spec.get("ui")
+    assert isinstance(ui, dict), "fetched rippleSpec has no 'ui' root"
+
+    _assert_every_node_has_valid_id(ui)
+
+
+@pytest.mark.asyncio
+async def test_agent_view_self_heals_legacy_id_less_pocket(mongo_db, agent_identity):
+    """Defense-in-depth: a pocket already in MongoDB without node ids
+    (persisted before the fix) must self-heal on first agent read so
+    legacy pockets become editable without a DB migration."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+    from pocketpaw_ee.cloud.pockets.service import agent_view
+
+    # Insert the id-less spec straight onto the doc, bypassing the
+    # normalizer — simulates a pocket persisted before the fix shipped.
+    doc = await _make_pocket(rippleSpec=dict(_ID_LESS_SPEC))
+
+    view, err = await agent_view(str(doc.id))
+    assert err is None, err
+    ui = view["rippleSpec"]["ui"]
+    _assert_every_node_has_valid_id(ui)
+
+    # The heal must be persisted, not just applied to the returned view.
+    refreshed = await Pocket.get(doc.id)
+    _assert_every_node_has_valid_id(refreshed.rippleSpec["ui"])

--- a/tests/cloud/test_pocket_service_resolver.py
+++ b/tests/cloud/test_pocket_service_resolver.py
@@ -82,7 +82,14 @@ async def test_get_passes_through_when_no_markers():
     ):
         out = await pocket_service.get(pocket_id="pocket-1", user_id="u1")
     assert out["rippleSpec"]["state"] == spec["state"]
-    assert out["rippleSpec"]["ui"] == spec["ui"]
+    # The resolver leaves a marker-free spec untouched, but read-time
+    # normalization (#1172) stamps an n_xxxxxxxx id on every ui node so
+    # the spec is addressable by granular edit ops. Type is preserved.
+    ui = out["rippleSpec"]["ui"]
+    assert ui["type"] == "stat"
+    from pocketpaw_ee.cloud.pockets import spec_ops
+
+    assert spec_ops.is_valid_id(ui.get("id"))
 
 
 async def test_get_with_no_ripple_spec_does_not_crash():


### PR DESCRIPTION
## What was wrong

Pocket editing was broken: the chat agent could not address any node.

In agent mode the agent reads a pocket with `get_pocket`, then issues granular ops (`add_node`, `replace_node`, `set_node_prop`, `move_node`) that each need a `parent_id` or `node_id`. Those ids never existed. A freshly created pocket had a rippleSpec `ui` tree with no per-node ids, so every op came back with `no node with id X`.

## Root cause

The `n_xxxxxxxx` node-id machinery (`spec_ops.ensure_ids` / `new_node_id` / `is_valid_id`) was wired into exactly one place: `service._load_and_ensure_ids`, which runs at the start of a granular mutation op. It never ran on the create/persist path or the read path.

So pockets were created and stored id-less. `get_pocket` to `agent_view` to `_agent_view_dict` returned the raw tree, still id-less. The agent had no real id to target. When it then called `add_node`, the op did stamp ids lazily, but it resolved the agent's *guess* against the freshly-stamped tree, and the guess was never a valid id. The ids were minted during the first op, but the agent had to pick a target before that op, from a view that never carried them.

This was not agent-mode-specific. The subagent path hit the same id-less spec.

## The fix

Stamp node ids at write time, reusing the existing `ensure_ids` machinery (idempotent, collision-safe):

- `normalize_ripple_spec` (`ripple_normalizer.py`) now walks the UISpec `ui` tree and each `panes` value through `spec_ops.ensure_ids`. Every persist path already routes through this normalizer, so stored specs now always carry node ids. The `spec_ops` import is lazy to avoid a circular import (`pockets/__init__` pulls in the router, which imports `service`, which imports this module).
- `agent_view` (`pockets/service.py`) self-heals on read via `_heal_node_ids` — a pocket persisted before this change gets ids stamped and saved on first agent fetch, no DB migration needed.

## Tests

New `tests/cloud/test_pocket_node_ids.py`:
- `test_fetch_pocket_for_agent_returns_node_ids` — creates a pocket through the normal create path, fetches it via `fetch_pocket_for_agent`, asserts every node carries a valid `n_xxxxxxxx` id.
- `test_agent_view_self_heals_legacy_id_less_pocket` — inserts an id-less pocket straight into Mongo, confirms `agent_view` stamps and persists ids.

Both fail on `dev` (nodes are id-less) and pass with this change.

Updated `test_pocket_service_resolver.py::test_get_passes_through_when_no_markers` — read-time normalization now stamps a node id, so the assertion checks the node type plus a valid id rather than byte-identical pass-through.

Verification (local, targeted):
- `tests/cloud/ -k "ripple or normaliz or pocket or spec_ops or node"` — 418 passed. The 9 remaining failures are pre-existing and unrelated (upload ACL auth, connector router, prompt-state-sources, ee-correction, agent-service-tools-context — all confirmed failing on `dev` with this change stashed).
- `tests/ee/agent/test_pocket_specialist/` — 133 passed.
- `ruff check` and `ruff format --check` clean.

## Review notes

- The lazy `spec_ops` import in `_stamp_node_ids` is deliberate — a top-level import closes a circular dependency. There is a comment explaining it.
- `_heal_node_ids` is defense-in-depth. Once `dev` ships this, new pockets always carry ids from the normalizer; the heal only matters for pockets created before the change.

Closes #1172