### PR TITLE
feat(pockets): back the home page with a per-user home pocket

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/pockets.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/pockets.py
@@ -7,14 +7,23 @@ tree — in the prompt is unsafe. The agent instead fetches the pocket on demand
 the response flows through the SDK's tool-result channel (stdio JSON, unbounded)
 and never touches the CLI command line.
 
-Mutations DO NOT live on this server. Pocket mutations flow through the
-``pocket_specialist__create`` / ``pocket_specialist__edit`` MCP tools (see
-``pocketpaw_ee.agent.pocket_specialist.mcp_tool``). This module is a thin
-adapter — the actual fetch lives in ``pocketpaw_ee.cloud.pockets.agent_context``.
+Pocket *designs* are still mutated through the ``pocket_specialist__create`` /
+``pocket_specialist__edit`` MCP tools (see
+``pocketpaw_ee.agent.pocket_specialist.mcp_tool``) — those rewrite a pocket's
+``rippleSpec.ui``. This server now ALSO carries a writable ``add_widget`` tool:
+it appends a single tile to a pocket's ``widgets[]`` array, which is the
+surface the home grid renders. ``add_widget`` exists so the home-pocket agent
+(on the ``claude_agent_sdk`` backend) can pin a real widget — a chart, a
+table — without delegating to the design specialist.
 
 Moved here from ``src/pocketpaw/agents/sdk_mcp_pocket.py`` in the OSS-EE split
 (Phase 3b). That file also carried the ripple widget-spec tools, which have no
 cloud dependency and stayed in core as ``pocketpaw.agents.sdk_mcp_widgets``.
+
+Changes: 2026-05-22 (#1174) — added the writable ``add_widget`` tool, its
+``ADD_WIDGET_TOOL_ID`` allowlist id, manifest validation of the widget's
+rippleSpec ``spec`` subtree (skipped for ``type="native"`` widgets), and the
+``_get_manifest_for_validation`` seam tests patch.
 """
 
 from __future__ import annotations
@@ -30,11 +39,18 @@ SERVER_NAME = "pocketpaw_pocket"
 # Allowlist entries must use this exact form.
 GET_POCKET_TOOL_ID = f"mcp__{SERVER_NAME}__get_pocket"
 LIST_POCKETS_TOOL_ID = f"mcp__{SERVER_NAME}__list_pockets"
+ADD_WIDGET_TOOL_ID = f"mcp__{SERVER_NAME}__add_widget"
 
 POCKET_TOOL_IDS = (
     GET_POCKET_TOOL_ID,
     LIST_POCKETS_TOOL_ID,
+    ADD_WIDGET_TOOL_ID,
 )
+
+# Widget ``type`` whose tiles carry no rippleSpec — the frontend renders them
+# as a built-in Svelte component keyed on ``name``. Manifest validation, which
+# only walks rippleSpec trees, is skipped for these.
+_NATIVE_WIDGET_TYPE = "native"
 
 
 def _result_payload(result: dict) -> dict:
@@ -54,6 +70,11 @@ def _result_payload(result: dict) -> dict:
             }
         ]
     }
+
+
+def _error(text: str) -> dict:
+    """Build an MCP error response. The agent reads ``text`` and retries."""
+    return {"content": [{"type": "text", "text": f"Error: {text}"}], "is_error": True}
 
 
 async def _get_pocket_handler(args: dict) -> dict:
@@ -79,6 +100,95 @@ async def _list_pockets_handler(args: dict) -> dict:
             }
         ]
     }
+
+
+async def _get_manifest_for_validation() -> dict[str, Any] | None:
+    """Fetch the Ripple widget manifest used to validate a widget's ``spec``.
+
+    Best-effort: returns ``None`` on any failure so a manifest outage never
+    blocks a widget add. A standalone seam so tests can patch it.
+    """
+    try:
+        from pocketpaw.config import get_settings
+        from pocketpaw.ripple.manifest import get_manifest
+
+        settings = get_settings()
+        return await get_manifest(
+            settings.ripple_manifest_url,
+            ttl_seconds=settings.ripple_manifest_ttl_seconds,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("ripple manifest fetch failed (non-fatal)", exc_info=True)
+        return None
+
+
+def _format_manifest_issues(issues: list[dict[str, Any]]) -> str:
+    """Render ``validate_against_manifest`` issues as an agent-readable error
+    string naming each offending prop so the agent can re-emit a fixed spec."""
+    lines: list[str] = []
+    for issue in issues[:10]:
+        wtype = issue.get("type", "?")
+        path = issue.get("path", "?")
+        unknown = ", ".join(f"`{p}`" for p in issue.get("unknown_props", []))
+        allowed = ", ".join(f"`{p}`" for p in issue.get("allowed_props", []))
+        if unknown:
+            lines.append(f"{path} ({wtype}): unknown props {unknown}; allowed: {allowed}")
+    return "; ".join(lines)
+
+
+async def _validate_widget_spec(widget: dict) -> str | None:
+    """Validate the widget's rippleSpec ``spec`` subtree against the manifest.
+
+    Returns an error string when the spec uses props the renderer would
+    ignore, or ``None`` when the spec is clean / has no spec to check.
+    ``type="native"`` widgets carry no rippleSpec — validation is skipped.
+    Best-effort: a manifest outage returns ``None`` (never block the agent).
+    """
+    if widget.get("type") == _NATIVE_WIDGET_TYPE:
+        return None
+    spec = widget.get("spec")
+    if not isinstance(spec, dict):
+        return None
+    manifest = await _get_manifest_for_validation()
+    if manifest is None:
+        return None
+    from pocketpaw.ripple.manifest import validate_against_manifest
+
+    issues = validate_against_manifest(spec, manifest, apply_aliases=True)
+    actionable = [i for i in issues if i.get("unknown_props")]
+    if not actionable:
+        return None
+    return (
+        "The widget spec uses props the renderer ignores. "
+        f"{_format_manifest_issues(actionable)}. "
+        "Re-emit the widget using only the allowed props for each type."
+    )
+
+
+async def _add_widget_handler(args: dict) -> dict:
+    """Append one widget tile to a pocket's ``widgets[]`` array.
+
+    Validates the widget's rippleSpec ``spec`` against the renderer's
+    manifest first (skipped for native widgets); on a validation failure
+    nothing is persisted and the agent gets a corrective error.
+    """
+    pocket_id = args.get("pocket_id")
+    if not pocket_id or not isinstance(pocket_id, str):
+        return _error(
+            "add_widget requires a `pocket_id` — pass the id of the pocket "
+            "(the current home pocket) the widget should be pinned to."
+        )
+    widget = args.get("widget")
+    if not isinstance(widget, dict):
+        return _error("add_widget requires a `widget` object.")
+
+    validation_error = await _validate_widget_spec(widget)
+    if validation_error is not None:
+        return _error(validation_error)
+
+    from pocketpaw_ee.cloud.pockets.agent_context import add_widget_for_agent
+
+    return _result_payload(await add_widget_for_agent(pocket_id, widget))
 
 
 def build_pocket_context_server() -> tuple[str, Any] | None:
@@ -115,15 +225,53 @@ def build_pocket_context_server() -> tuple[str, Any] | None:
     async def list_pockets(args):  # type: ignore[no-untyped-def]
         return await _list_pockets_handler(args)
 
+    @tool(
+        "add_widget",
+        (
+            "Pin one widget tile onto a pocket's home grid. Use this on the "
+            "home page to add a chart, table, list, stat, kanban, or any "
+            "other Ripple-catalog widget the user asked for. Args: "
+            "`pocket_id` (the pocket to pin onto — the current home pocket) "
+            "and `widget`, an object with `name`, `type` (the Ripple "
+            "catalog widget type, e.g. `chart`/`table`/`stat`/`list`/"
+            "`kanban`), optional `icon`/`color`, and `spec` — a Ripple "
+            "rippleSpec subtree for the tile (e.g. a `chart` node with a "
+            "real `data` series). Call `get_widget_spec` for the widget "
+            "type FIRST so the spec uses valid props; a spec with invented "
+            'props is rejected. Native widgets pass `type:"native"` and '
+            "no `spec`."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "pocket_id": {
+                    "type": "string",
+                    "description": "Id of the pocket to pin the widget onto.",
+                },
+                "widget": {
+                    "type": "object",
+                    "description": (
+                        "Widget entry: name, type, optional icon/color, and a "
+                        "rippleSpec `spec` subtree (omit for native widgets)."
+                    ),
+                },
+            },
+            "required": ["pocket_id", "widget"],
+        },
+    )
+    async def add_widget(args):  # type: ignore[no-untyped-def]
+        return await _add_widget_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
-        version="1.0.0",
-        tools=[get_pocket, list_pockets],
+        version="1.1.0",
+        tools=[get_pocket, list_pockets, add_widget],
     )
     return SERVER_NAME, server
 
 
 __all__ = [
+    "ADD_WIDGET_TOOL_ID",
     "GET_POCKET_TOOL_ID",
     "LIST_POCKETS_TOOL_ID",
     "POCKET_TOOL_IDS",

--- a/ee/pocketpaw_ee/cloud/auth/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/service.py
@@ -9,12 +9,14 @@ Public API is module-level ``async def`` functions:
 - ``update_profile(ctx, *, full_name?, avatar?, status?)``
 - ``set_active_workspace(ctx, workspace_id)``
 - ``set_avatar_path(ctx, avatar_path)``
-- ``get_home_pocket_id(user_id)`` / ``set_home_pocket_id(user_id, pocket_id)``
+- ``get_home_pocket_id(user_id)`` / ``claim_home_pocket_id(user_id, id, *, expected)``
 
-Updated: 2026-05-21 — added the ``home_pocket_id`` get/set pair. The
-pockets service owns home-pocket provisioning but stores the resolved id
-here so it survives across sessions and devices; routing the read/write
-through this service keeps ``models.user`` writes inside the auth entity.
+Updated: 2026-05-21 — added the ``home_pocket_id`` get + atomic-claim
+pair. The pockets service owns home-pocket provisioning but stores the
+resolved id here so it survives across sessions and devices; routing the
+read/write through this service keeps ``models.user`` writes inside the
+auth entity. ``claim_home_pocket_id`` is a compare-and-swap (not a plain
+write) so a first-login provision race resolves to a single home pocket.
 """
 
 from __future__ import annotations
@@ -110,17 +112,40 @@ async def get_home_pocket_id(user_id: str) -> str | None:
     return doc.home_pocket_id
 
 
-async def set_home_pocket_id(user_id: str, pocket_id: str | None) -> None:
-    """Persist ``home_pocket_id`` onto the user record.
+async def claim_home_pocket_id(user_id: str, new_pocket_id: str, *, expected: str | None) -> bool:
+    """Atomically set ``home_pocket_id`` to ``new_pocket_id`` — but only if
+    it still holds ``expected``. Returns ``True`` when the swap took.
 
-    Pass ``None`` to clear the setting (e.g. when the home pocket was
-    deleted). Raises ``NotFound`` when the user record is missing.
+    This is a compare-and-swap, not a plain write. It closes the
+    first-login provision race: two concurrent ``ensure_home_pocket`` calls
+    for the same new user can both read ``home_pocket_id is None`` and both
+    insert a pocket. The CAS lets exactly one of them commit its id — the
+    loser sees ``False``, re-reads, and adopts the winner's pocket.
+
+    ``expected`` is the value the caller read before provisioning:
+    ``None`` for a genuine first provision (a Mongo ``{field: null}``
+    filter matches both an explicit ``null`` and an absent field), or the
+    stale id when re-provisioning after the previous home pocket was
+    deleted. The single ``find_one_and_update`` mirrors the atomic-claim
+    pattern in ``tasks/service.py``.
+
+    Raises ``NotFound`` when the user record is missing entirely.
     """
-    doc = await _UserDoc.get(PydanticObjectId(user_id))
-    if doc is None:
+    collection = _UserDoc.get_pymongo_collection()
+    updated = await collection.find_one_and_update(
+        {"_id": PydanticObjectId(user_id), "home_pocket_id": expected},
+        {"$set": {"home_pocket_id": new_pocket_id}},
+        return_document=True,  # mongomock + pymongo accept bool: True == AFTER
+    )
+    if updated is not None:
+        return True
+    # The CAS didn't match. Either the user is gone, or another writer
+    # already moved home_pocket_id off ``expected`` — disambiguate so a
+    # missing user still surfaces as NotFound.
+    exists = await collection.find_one({"_id": PydanticObjectId(user_id)}, projection={"_id": 1})
+    if exists is None:
         raise NotFound("user", user_id)
-    doc.home_pocket_id = pocket_id
-    await doc.save()
+    return False
 
 
 async def suggest_workspace_members(workspace_id: str, q: str, *, limit: int = 8) -> list[dict]:
@@ -144,11 +169,11 @@ async def suggest_workspace_members(workspace_id: str, q: str, *, limit: int = 8
 
 
 __all__ = [
+    "claim_home_pocket_id",
     "get_home_pocket_id",
     "get_profile",
     "set_active_workspace",
     "set_avatar_path",
-    "set_home_pocket_id",
     "suggest_workspace_members",
     "update_profile",
 ]

--- a/ee/pocketpaw_ee/cloud/auth/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/service.py
@@ -1,4 +1,4 @@
-"""Auth service — profile, active-workspace, avatar.
+"""Auth service — profile, active-workspace, avatar, home pocket.
 
 Sole owner of writes to the ``User`` Beanie document for the auth domain.
 Note: fastapi-users manages registration / password / JWT lifecycle; this
@@ -9,6 +9,12 @@ Public API is module-level ``async def`` functions:
 - ``update_profile(ctx, *, full_name?, avatar?, status?)``
 - ``set_active_workspace(ctx, workspace_id)``
 - ``set_avatar_path(ctx, avatar_path)``
+- ``get_home_pocket_id(user_id)`` / ``set_home_pocket_id(user_id, pocket_id)``
+
+Updated: 2026-05-21 — added the ``home_pocket_id`` get/set pair. The
+pockets service owns home-pocket provisioning but stores the resolved id
+here so it survives across sessions and devices; routing the read/write
+through this service keeps ``models.user`` writes inside the auth entity.
 """
 
 from __future__ import annotations
@@ -91,6 +97,32 @@ async def set_avatar_path(ctx: RequestContext, avatar_path: str) -> AuthUser:
     return await update_profile(ctx, avatar=avatar_path)
 
 
+async def get_home_pocket_id(user_id: str) -> str | None:
+    """Return the user's persisted ``home_pocket_id``, or None if unset.
+
+    Takes a plain ``user_id`` (not a ``RequestContext``) so the pockets
+    service can resolve the home pocket without minting a context. Raises
+    ``NotFound`` when the user record is missing.
+    """
+    doc = await _UserDoc.get(PydanticObjectId(user_id))
+    if doc is None:
+        raise NotFound("user", user_id)
+    return doc.home_pocket_id
+
+
+async def set_home_pocket_id(user_id: str, pocket_id: str | None) -> None:
+    """Persist ``home_pocket_id`` onto the user record.
+
+    Pass ``None`` to clear the setting (e.g. when the home pocket was
+    deleted). Raises ``NotFound`` when the user record is missing.
+    """
+    doc = await _UserDoc.get(PydanticObjectId(user_id))
+    if doc is None:
+        raise NotFound("user", user_id)
+    doc.home_pocket_id = pocket_id
+    await doc.save()
+
+
 async def suggest_workspace_members(workspace_id: str, q: str, *, limit: int = 8) -> list[dict]:
     """Return up to ``limit`` workspace members matching ``q`` against
     full_name / email. Used by the chat ``/mentions/suggest`` endpoint."""
@@ -112,9 +144,11 @@ async def suggest_workspace_members(workspace_id: str, q: str, *, limit: int = 8
 
 
 __all__ = [
+    "get_home_pocket_id",
     "get_profile",
     "set_active_workspace",
     "set_avatar_path",
+    "set_home_pocket_id",
     "suggest_workspace_members",
     "update_profile",
 ]

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -9,6 +9,11 @@ handles *what the agent sees*:
 * ``load_history_for_scope`` rehydrates prior chat turns from Mongo so the
   agent carries context across backend restarts and pool evictions.
 
+Changes: 2026-05-22 — ``ScopeContext`` carries the anchored pocket's
+``pocket_type``; ``build_behavior_instructions`` appends ``HOME_POCKET_PROMPT``
+when that type is ``"home"`` so the agent behaves correctly on the home page
+(call ``add_widget`` for an explicit widget request, answer directly
+otherwise). ``_resolve_pocket`` / ``_resolve_session`` populate the field.
 Changes: 2026-05-22 (RFC 04 alpha follow-up 2) — ``build_behavior_instructions``
 fills the interaction prompt's current-pocket block via ``fill_current_pocket``
 (both the pocket-id and backend-summary tokens) instead of a bare
@@ -29,6 +34,7 @@ from enum import StrEnum
 from typing import Any
 
 from pocketpaw.ripple import (
+    HOME_POCKET_PROMPT,
     INLINE_RIPPLE_SYSTEM_PROMPT,
     POCKET_DELEGATION_RULE,
     fill_current_pocket,
@@ -179,6 +185,11 @@ class ScopeContext:
     # when the underlying ``Session.pocket`` is set. The system prompt uses
     # it to tell the agent which pocket it can edit via the write MCP tools.
     pocket_id: str | None = None
+    # The anchored pocket's free-form ``Pocket.type`` (``custom``, ``home``,
+    # …), populated alongside ``pocket_id``. ``build_behavior_instructions``
+    # uses it to inject ``HOME_POCKET_PROMPT`` when the chat is scoped to the
+    # per-user ``type="home"`` pocket that backs the home page.
+    pocket_type: str | None = None
     # Optional client-supplied intent hint that swaps which system-prompt
     # block ``build_context_block`` emits. ``pocket_create`` makes the
     # agent reach for the ``create_pocket`` MCP tool instead of rendering
@@ -286,11 +297,13 @@ async def _resolve_session(scope_id: str, user_id: str, agent_id_hint: str | Non
     # (pocket scope keys all sessions under one stream); without this lookup
     # those chats would silently lose pocket tools.
     pocket_tool_specs: list[dict[str, Any]] = []
+    pocket_type: str | None = None
     pocket_id = getattr(session, "pocket", None)
     if pocket_id:
         pocket = await _get_pocket(str(pocket_id))
         if pocket is not None:
             pocket_tool_specs = list(getattr(pocket, "tool_specs", []) or [])
+            pocket_type = getattr(pocket, "type", None)
 
     target = agent_id_hint or getattr(session, "agent", None)
     if not target:
@@ -314,6 +327,7 @@ async def _resolve_session(scope_id: str, user_id: str, agent_id_hint: str | Non
         agent_ids_in_scope=[target],
         pocket_tool_specs=pocket_tool_specs,
         pocket_id=str(pocket_id) if pocket_id else None,
+        pocket_type=pocket_type,
     )
 
 
@@ -416,6 +430,7 @@ async def _resolve_pocket(scope_id: str, user_id: str, agent_id_hint: str | None
         agent_ids_in_scope=agent_ids,
         pocket_tool_specs=list(getattr(pocket, "tool_specs", []) or []),
         pocket_id=scope_id,
+        pocket_type=getattr(pocket, "type", None),
     )
 
 
@@ -518,6 +533,14 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
             parts.append(fill_current_pocket(interaction_prompt, ctx.pocket_id, None))
         else:
             parts.append(INLINE_RIPPLE_SYSTEM_PROMPT)
+    # Home surface: when the chat is scoped to the per-user ``type="home"``
+    # pocket, append the home-surface prompt so the agent calls add_widget
+    # for an explicit widget request and answers directly otherwise. This
+    # rides on top of whichever pocket prompt the branch above selected and
+    # is backend-agnostic — the discriminator is the pocket type, not the
+    # backend or a settings id.
+    if ctx.pocket_type == "home":
+        parts.append(HOME_POCKET_PROMPT)
     return "\n".join(parts)
 
 

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -14,6 +14,11 @@ Changes: 2026-05-22 — ``ScopeContext`` carries the anchored pocket's
 when that type is ``"home"`` so the agent behaves correctly on the home page
 (call ``add_widget`` for an explicit widget request, answer directly
 otherwise). ``_resolve_pocket`` / ``_resolve_session`` populate the field.
+Changes: 2026-05-22 (#1174) — ``build_behavior_instructions`` no longer emits
+``POCKET_DELEGATION_RULE`` (nor the heavy interaction prompt) for a
+``type="home"`` scope. The delegation rule ("never call add_widget, delegate
+to the specialist") contradicts ``HOME_POCKET_PROMPT`` ("call add_widget");
+the home agent now gets exactly one consistent widget-creation instruction.
 Changes: 2026-05-22 (RFC 04 alpha follow-up 2) — ``build_behavior_instructions``
 fills the interaction prompt's current-pocket block via ``fill_current_pocket``
 (both the pocket-id and backend-summary tokens) instead of a bare
@@ -505,7 +510,11 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
 
     Backend gating mirrors ``build_context_block``: MCP-capable backends
     get ``INLINE_RIPPLE_SYSTEM_PROMPT + POCKET_DELEGATION_RULE``;
-    others get the heavy inline pocket prompt.
+    others get the heavy inline pocket prompt. A ``type="home"`` scope is
+    the exception — it gets ``INLINE_RIPPLE_SYSTEM_PROMPT +
+    HOME_POCKET_PROMPT`` and NOT the delegation rule, because the home
+    agent mutates widgets directly via the ``add_widget`` MCP tool rather
+    than delegating to the pocket specialist.
     """
     parts: list[str] = []
     parts.append(_RUNTIME_IDENTITY_RULE)
@@ -517,7 +526,23 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
     if _composio_service.is_enabled():
         parts.append(_COMPOSIO_AUTH_FLOW_RULE)
         parts.append(_COMPOSIO_SEARCH_FALLBACK_RULE)
-    if backend_name in _MCP_POCKET_BACKENDS:
+    # The home pocket is a special case: its agent mutates widgets directly
+    # via the ``add_widget`` MCP tool — it does NOT delegate to the pocket
+    # specialist. ``POCKET_DELEGATION_RULE`` ("never call add_widget,
+    # delegate to the specialist") and ``HOME_POCKET_PROMPT`` ("call
+    # add_widget") flatly contradict each other, so the delegation rule is
+    # dropped for a ``type="home"`` scope. The home agent then gets exactly
+    # one consistent widget-creation instruction.
+    is_home = ctx.pocket_type == "home"
+    if is_home:
+        # The home agent's only widget-creation instruction is
+        # HOME_POCKET_PROMPT (appended below). It must not also receive the
+        # specialist-delegation rule (MCP backends) or the heavy
+        # interaction prompt (CLI backends) — both carry the contradicting
+        # "delegate, don't call add_widget" framing. Just the base ripple
+        # conventions, then HOME_POCKET_PROMPT.
+        parts.append(INLINE_RIPPLE_SYSTEM_PROMPT)
+    elif backend_name in _MCP_POCKET_BACKENDS:
         parts.append(INLINE_RIPPLE_SYSTEM_PROMPT)
         parts.append(POCKET_DELEGATION_RULE)
     else:
@@ -533,13 +558,10 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
             parts.append(fill_current_pocket(interaction_prompt, ctx.pocket_id, None))
         else:
             parts.append(INLINE_RIPPLE_SYSTEM_PROMPT)
-    # Home surface: when the chat is scoped to the per-user ``type="home"``
-    # pocket, append the home-surface prompt so the agent calls add_widget
-    # for an explicit widget request and answers directly otherwise. This
-    # rides on top of whichever pocket prompt the branch above selected and
-    # is backend-agnostic — the discriminator is the pocket type, not the
-    # backend or a settings id.
-    if ctx.pocket_type == "home":
+    # Home surface: append the home-surface prompt so the agent calls
+    # add_widget for an explicit widget request and answers directly
+    # otherwise. Backend-agnostic — the discriminator is the pocket type.
+    if is_home:
         parts.append(HOME_POCKET_PROMPT)
     return "\n".join(parts)
 

--- a/ee/pocketpaw_ee/cloud/models/pocket.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket.py
@@ -1,4 +1,11 @@
-"""Pocket and Widget documents."""
+"""Pocket and Widget documents.
+
+Updated: 2026-05-21 — documented the ``type="home"`` pocket type (the
+per-user pocket that backs the home page) and the ``type="native"``
+widget type (rendered by the frontend as a built-in Svelte component
+keyed on ``name``). Both reuse the free-form ``type`` field — no schema
+change, just recognized values.
+"""
 
 from __future__ import annotations
 
@@ -25,6 +32,8 @@ class Widget(BaseModel):
 
     id: str = Field(default_factory=lambda: str(ObjectId()), alias="_id")
     name: str
+    # Free-form. ``type="native"`` marks a widget the frontend renders as a
+    # built-in Svelte component keyed on ``name`` (no rippleSpec).
     type: str = "custom"
     icon: str = ""
     color: str = ""
@@ -52,7 +61,9 @@ class Pocket(TimestampedDocument):
     project_id: str | None = None
     name: str
     description: str = ""
-    type: str = "custom"  # no pattern restriction — frontend sends data, deep-work, etc.
+    # No pattern restriction — frontend sends data, deep-work, etc.
+    # ``type="home"`` marks the per-user pocket that backs the home page.
+    type: str = "custom"
     icon: str = ""
     color: str = ""
     owner: str

--- a/ee/pocketpaw_ee/cloud/models/pocket.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket.py
@@ -5,6 +5,11 @@ per-user pocket that backs the home page) and the ``type="native"``
 widget type (rendered by the frontend as a built-in Svelte component
 keyed on ``name``). Both reuse the free-form ``type`` field — no schema
 change, just recognized values.
+Updated: 2026-05-22 — added the optional ``Widget.spec`` field: a Ripple
+rippleSpec subtree for a single tile (e.g. a ``chart`` node with a real
+``data`` series). The home grid renders a ``widgets[]`` entry from its
+``spec``; the home agent's ``add_widget`` MCP tool populates it. Native
+widgets leave it ``None``.
 """
 
 from __future__ import annotations
@@ -42,6 +47,11 @@ class Widget(BaseModel):
     config: dict[str, Any] = Field(default_factory=dict)
     props: dict[str, Any] = Field(default_factory=dict)
     data: Any = None
+    # Optional Ripple rippleSpec subtree for this single tile (e.g. a
+    # ``chart`` node carrying a real ``data`` series). The home grid
+    # renders the tile from ``spec`` when present. ``None`` for native
+    # widgets, which have no rippleSpec.
+    spec: dict[str, Any] | None = None
     assignedAgent: str | None = Field(default=None, alias="assignedAgent")
     position: WidgetPosition = Field(default_factory=WidgetPosition)
 

--- a/ee/pocketpaw_ee/cloud/models/user.py
+++ b/ee/pocketpaw_ee/cloud/models/user.py
@@ -1,4 +1,10 @@
-"""User and OAuth account models (fastapi-users + Beanie)."""
+"""User and OAuth account models (fastapi-users + Beanie).
+
+Updated: 2026-05-21 — added ``home_pocket_id`` so the home page can be
+backed by a per-user "home pocket". Optional (default None) — the auth
+service resolves-or-provisions it lazily; existing users read back as
+"no home pocket yet".
+"""
 
 from __future__ import annotations
 
@@ -27,6 +33,9 @@ class User(BeanieBaseUser, Document):  # type: ignore[misc]
     full_name: str = ""
     avatar: str = ""
     active_workspace: str | None = None  # Current workspace ID
+    # Id of the user's "home pocket" — the Pocket that backs the home page.
+    # Resolved-or-provisioned lazily by ``pockets.service.ensure_home_pocket``.
+    home_pocket_id: str | None = None
     workspaces: list[WorkspaceMembership] = Field(default_factory=list)
     status: str = Field(default="offline", pattern="^(online|offline|away|dnd)$")
     last_seen: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/ee/pocketpaw_ee/cloud/pockets/domain.py
+++ b/ee/pocketpaw_ee/cloud/pockets/domain.py
@@ -26,6 +26,11 @@ class Widget:
     Pocket field uses tuples for hashability. ``config``, ``props``, and
     ``data`` carry arbitrary JSON which we keep as ``Any`` (frozen
     dataclasses don't enforce immutability at deeper nesting).
+
+    ``type`` is free-form. A widget with ``type="native"`` is a "native"
+    widget — the frontend renders it as a built-in Svelte component looked
+    up by ``name``, rather than from a rippleSpec. Native widgets carry no
+    spec, so they are never manifest-validated.
     """
 
     id: str
@@ -50,6 +55,10 @@ class Pocket:
     grouped under a Mission Control Project. Optional (default None) so
     existing pocket records — and callers that don't care about projects —
     keep working unchanged.
+
+    ``type`` is free-form. ``type="home"`` marks the per-user pocket that
+    backs the home page — it behaves like an ordinary private pocket; the
+    type is just a marker the home route and frontend key on.
     """
 
     id: str

--- a/ee/pocketpaw_ee/cloud/pockets/domain.py
+++ b/ee/pocketpaw_ee/cloud/pockets/domain.py
@@ -23,14 +23,20 @@ class WidgetPosition:
 class Widget:
     """Widget subdocument inside a Pocket.
 
-    Pocket field uses tuples for hashability. ``config``, ``props``, and
-    ``data`` carry arbitrary JSON which we keep as ``Any`` (frozen
-    dataclasses don't enforce immutability at deeper nesting).
+    Pocket field uses tuples for hashability. ``config``, ``props``,
+    ``data``, and ``spec`` carry arbitrary JSON which we keep as ``Any`` /
+    ``dict`` (frozen dataclasses don't enforce immutability at deeper
+    nesting).
 
     ``type`` is free-form. A widget with ``type="native"`` is a "native"
     widget — the frontend renders it as a built-in Svelte component looked
     up by ``name``, rather than from a rippleSpec. Native widgets carry no
     spec, so they are never manifest-validated.
+
+    ``spec`` is an optional Ripple rippleSpec subtree for this single tile
+    (e.g. a ``chart`` node with a real ``data`` series). The home grid
+    renders a tile from its ``spec`` when present; ``None`` for native
+    widgets.
     """
 
     id: str
@@ -45,6 +51,7 @@ class Widget:
     data: Any
     assigned_agent: str | None
     position: WidgetPosition
+    spec: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -7,6 +7,12 @@ separate follow-up calls.
 Updated: 2026-05-16 — added optional ``project_id`` (aliased as
 ``projectId`` on the wire) to CreatePocketRequest / UpdatePocketRequest /
 PocketResponse so pockets can be grouped under a Mission Control Project.
+
+Updated: 2026-05-21 — documented the ``type="native"`` widget contract on
+``AddWidgetRequest`` (home-as-pocket foundation). A native widget is an
+ordinary widget entry whose ``type`` is ``"native"`` and whose ``name`` is
+the key the frontend uses to look up a built-in Svelte component — it
+carries no ``rippleSpec`` to render or validate.
 """
 
 from __future__ import annotations
@@ -47,6 +53,18 @@ class UpdatePocketRequest(BaseModel):
 
 
 class AddWidgetRequest(BaseModel):
+    """Body for POST /pockets/{id}/widgets.
+
+    ``type`` is free-form. Two kinds of widget ride this schema:
+
+    * ordinary Ripple-spec widgets — ``config``/``props`` carry the spec;
+    * native widgets — ``type="native"`` and ``name`` is the key the
+      frontend uses to resolve a built-in Svelte component. Native
+      widgets have no rippleSpec, so manifest validation (which only
+      walks rippleSpec trees) never touches them. ``icon``/``color`` are
+      kept for the tile chrome.
+    """
+
     name: str = Field(min_length=1, max_length=100)
     type: str = "custom"
     icon: str = ""

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -17,6 +17,10 @@ carries no ``rippleSpec`` to render or validate.
 Updated: 2026-05-21 — added ``HomePocketResponse`` so ``GET /pockets/home``
 has a real OpenAPI schema instead of an empty ``dict``.
 
+Updated: 2026-05-22 (#1174) — ``AddWidgetRequest`` and ``_widget_to_wire``
+carry the optional ``spec`` field: a per-tile rippleSpec subtree the home
+grid renders. Populated by the home agent's ``add_widget`` MCP tool.
+
 Updated: 2026-05-21 (RFC 04 alpha) — added PocketBackendConfigRequest /
 PocketBackendConfigResponse / RunSourcesRequest for the per-pocket backend
 binding + read-only source-run endpoints.
@@ -82,7 +86,9 @@ class AddWidgetRequest(BaseModel):
 
     ``type`` is free-form. Two kinds of widget ride this schema:
 
-    * ordinary Ripple-spec widgets — ``config``/``props`` carry the spec;
+    * ordinary Ripple-spec widgets — ``spec`` carries the rippleSpec
+      subtree the home grid renders for this tile (e.g. a ``chart`` node
+      with a real ``data`` series);
     * native widgets — ``type="native"`` and ``name`` is the key the
       frontend uses to resolve a built-in Svelte component. Native
       widgets have no rippleSpec, so manifest validation (which only
@@ -98,6 +104,9 @@ class AddWidgetRequest(BaseModel):
     data_source_type: str = "static"
     config: dict = Field(default_factory=dict)
     props: dict = Field(default_factory=dict)
+    # Optional per-tile rippleSpec subtree. The home grid renders the tile
+    # from ``spec`` when present; native widgets leave it ``None``.
+    spec: dict | None = None
     assigned_agent: str | None = None
 
 
@@ -399,6 +408,9 @@ def _widget_to_wire(w) -> dict:
         "config": dict(w.config),
         "props": dict(w.props),
         "data": w.data,
+        # Per-tile rippleSpec subtree the home grid renders; ``None`` for
+        # native and legacy widgets.
+        "spec": getattr(w, "spec", None),
         "assignedAgent": w.assigned_agent,
         "position": {"row": w.position.row, "col": w.position.col},
     }

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -13,6 +13,9 @@ Updated: 2026-05-21 — documented the ``type="native"`` widget contract on
 ordinary widget entry whose ``type`` is ``"native"`` and whose ``name`` is
 the key the frontend uses to look up a built-in Svelte component — it
 carries no ``rippleSpec`` to render or validate.
+
+Updated: 2026-05-21 — added ``HomePocketResponse`` so ``GET /pockets/home``
+has a real OpenAPI schema instead of an empty ``dict``.
 """
 
 from __future__ import annotations
@@ -119,6 +122,23 @@ class PocketResponse(BaseModel):
     project_id: str | None = None
     created_at: datetime
     updated_at: datetime
+
+
+class HomePocketResponse(BaseModel):
+    """Response for ``GET /pockets/home``.
+
+    ``pocket`` is the full pocket wire dict (camelCase keys, ``_id``,
+    ``rippleSpec`` — the legacy shape ``pocket_to_wire_dict`` emits), kept
+    as a free-form ``dict`` because it is not the snake_case
+    ``PocketResponse`` shape and the client builds against the wire dict
+    verbatim. ``created`` is ``True`` only when this call provisioned a
+    brand-new home pocket — the client gates one-time widget seeding /
+    localStorage migration on it.
+    """
+
+    pocket_id: str
+    pocket: dict[str, Any]
+    created: bool
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -13,9 +13,11 @@ REST contract matches the MongoDB-backed version that Wave 4 will ship.
 
 Updated: 2026-05-21 — added ``GET /pockets/home``, the home-as-pocket
 foundation. It resolves-or-provisions the caller's home pocket via
-``pockets_service.ensure_home_pocket`` and returns ``{pocket_id, pocket}``.
-Declared ahead of ``GET /{pocket_id}`` so the static ``/home`` segment
-wins the route match.
+``pockets_service.ensure_home_pocket`` and returns
+``{pocket_id, pocket, created}`` — ``created`` is True only when the call
+just provisioned a brand-new home pocket, so the client can gate one-time
+seeding/migration on it. Declared ahead of ``GET /{pocket_id}`` so the
+static ``/home`` segment wins the route match.
 """
 
 from __future__ import annotations
@@ -209,11 +211,15 @@ async def get_home_pocket(
     """Resolve-or-provision the caller's home pocket.
 
     Declared ahead of ``GET /{pocket_id}`` so the static ``/home`` segment
-    is matched before the pocket-id wildcard. Returns ``{pocket_id, pocket}``
-    where ``pocket`` is the full wire dict (rippleSpec + widgets).
+    is matched before the pocket-id wildcard. Returns
+    ``{pocket_id, pocket, created}`` where ``pocket`` is the full wire dict
+    (rippleSpec + widgets) and ``created`` is ``True`` only when this call
+    just provisioned a brand-new home pocket. The client gates one-time
+    work — seeding default widgets, migrating legacy localStorage widgets —
+    on ``created``.
     """
-    pocket = await pockets_service.ensure_home_pocket(workspace_id, user_id)
-    return {"pocket_id": pocket["_id"], "pocket": pocket}
+    pocket, created = await pockets_service.ensure_home_pocket(workspace_id, user_id)
+    return {"pocket_id": pocket["_id"], "pocket": pocket, "created": created}
 
 
 @router.get("/{pocket_id}")

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -13,11 +13,11 @@ REST contract matches the MongoDB-backed version that Wave 4 will ship.
 
 Updated: 2026-05-21 — added ``GET /pockets/home``, the home-as-pocket
 foundation. It resolves-or-provisions the caller's home pocket via
-``pockets_service.ensure_home_pocket`` and returns
-``{pocket_id, pocket, created}`` — ``created`` is True only when the call
-just provisioned a brand-new home pocket, so the client can gate one-time
-seeding/migration on it. Declared ahead of ``GET /{pocket_id}`` so the
-static ``/home`` segment wins the route match.
+``pockets_service.ensure_home_pocket`` and returns a typed
+``HomePocketResponse`` (``{pocket_id, pocket, created}``) — ``created`` is
+True only when the call just provisioned a brand-new home pocket, so the
+client can gate one-time seeding/migration on it. Declared ahead of
+``GET /{pocket_id}`` so the static ``/home`` segment wins the route match.
 """
 
 from __future__ import annotations
@@ -35,6 +35,7 @@ from pocketpaw_ee.cloud.pockets.dto import (
     AddCollaboratorRequest,
     AddWidgetRequest,
     CreatePocketRequest,
+    HomePocketResponse,
     ReorderWidgetsRequest,
     ShareLinkRequest,
     UpdatePocketRequest,
@@ -203,11 +204,11 @@ async def list_pockets(
     return await pockets_service.list_pockets(workspace_id, user_id, project_id=project_id)
 
 
-@router.get("/home")
+@router.get("/home", response_model=HomePocketResponse)
 async def get_home_pocket(
     workspace_id: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
-) -> dict:
+) -> HomePocketResponse:
     """Resolve-or-provision the caller's home pocket.
 
     Declared ahead of ``GET /{pocket_id}`` so the static ``/home`` segment
@@ -219,7 +220,7 @@ async def get_home_pocket(
     on ``created``.
     """
     pocket, created = await pockets_service.ensure_home_pocket(workspace_id, user_id)
-    return {"pocket_id": pocket["_id"], "pocket": pocket, "created": created}
+    return HomePocketResponse(pocket_id=pocket["_id"], pocket=pocket, created=created)
 
 
 @router.get("/{pocket_id}")

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -10,6 +10,12 @@ close UI-TESTING-GUIDE §11 gap B5 (no widget layout save/share):
 The YAML + in-process store live in ee.cloud.pockets.layouts. Export is
 pure. Template storage is workspace-scoped and in-process for now; the
 REST contract matches the MongoDB-backed version that Wave 4 will ship.
+
+Updated: 2026-05-21 — added ``GET /pockets/home``, the home-as-pocket
+foundation. It resolves-or-provisions the caller's home pocket via
+``pockets_service.ensure_home_pocket`` and returns ``{pocket_id, pocket}``.
+Declared ahead of ``GET /{pocket_id}`` so the static ``/home`` segment
+wins the route match.
 """
 
 from __future__ import annotations
@@ -193,6 +199,21 @@ async def list_pockets(
     project_id: str | None = Query(default=None, alias="project_id"),
 ) -> list[dict]:
     return await pockets_service.list_pockets(workspace_id, user_id, project_id=project_id)
+
+
+@router.get("/home")
+async def get_home_pocket(
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Resolve-or-provision the caller's home pocket.
+
+    Declared ahead of ``GET /{pocket_id}`` so the static ``/home`` segment
+    is matched before the pocket-id wildcard. Returns ``{pocket_id, pocket}``
+    where ``pocket`` is the full wire dict (rippleSpec + widgets).
+    """
+    pocket = await pockets_service.ensure_home_pocket(workspace_id, user_id)
+    return {"pocket_id": pocket["_id"], "pocket": pocket}
 
 
 @router.get("/{pocket_id}")

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -62,6 +62,10 @@ workspace-visible). ``get_pocket_backend`` /
 ``get_pocket_backend_for_executor`` / ``_agent_backend_summary`` now
 carry ``allowed_writes`` so the executor and the edit specialist can see
 the write policy.
+Changes: 2026-05-22 (#1174) — widgets carry an optional ``spec`` field (a
+per-tile rippleSpec subtree the home grid renders). ``_build_widget_doc``,
+``_widget_to_domain``, the REST ``add_widget``, and ``agent_update_widget``
+thread it through; the home agent's ``add_widget`` MCP tool populates it.
 """
 
 from __future__ import annotations
@@ -144,6 +148,7 @@ def _widget_to_domain(w: _WidgetDoc) -> Widget:
         data=w.data,
         assigned_agent=w.assignedAgent,
         position=WidgetPosition(row=w.position.row, col=w.position.col),
+        spec=getattr(w, "spec", None),
     )
 
 
@@ -225,6 +230,9 @@ def _build_widget_doc(payload: dict) -> _WidgetDoc:
         config=payload.get("config", {}),
         props=payload.get("props", {}),
         data=payload.get("data"),
+        # ``spec`` is the per-tile rippleSpec subtree the home grid renders.
+        # Optional — native widgets and legacy widget entries omit it.
+        spec=payload.get("spec"),
         assignedAgent=payload.get("assignedAgent", payload.get("assigned_agent")),
     )
 
@@ -665,6 +673,7 @@ async def add_widget(pocket_id: str, user_id: str, body: AddWidgetRequest) -> di
             "dataSourceType": body.data_source_type,
             "config": body.config,
             "props": body.props,
+            "spec": body.spec,
             "assignedAgent": body.assigned_agent,
         }
     )
@@ -1237,7 +1246,7 @@ async def agent_update_widget(
     widget = next((w for w in doc.widgets if w.id == widget_id), None)
     if widget is None:
         return None, f"widget {widget_id} not found in pocket {pocket_id}"
-    for k in ("name", "type", "icon", "color", "span", "data", "assignedAgent"):
+    for k in ("name", "type", "icon", "color", "span", "data", "spec", "assignedAgent"):
         if k in fields:
             setattr(widget, k, fields[k])
     if "config" in fields and isinstance(fields["config"], dict):

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -30,10 +30,12 @@ Changes: 2026-05-21 (#1172) — ``agent_view`` self-heals node ids via
 addressable by granular edit ops on first agent read.
 Changes: 2026-05-21 — added ``ensure_home_pocket`` (home-as-pocket
 foundation): idempotently resolves-or-provisions a per-user ``type="home"``
-pocket and persists its id onto the user's ``home_pocket_id`` setting.
-Native widgets (``type="native"``) ride the existing ``widgets[]`` paths
-unchanged — they carry no ``rippleSpec``, so manifest validation (which
-only walks ``rippleSpec`` trees) never touches them.
+pocket and persists its id onto the user's ``home_pocket_id`` setting via
+an atomic compare-and-swap, so a first-login provision race resolves to a
+single home pocket (the losing call deletes its orphan and adopts the
+winner's). Native widgets (``type="native"``) ride the existing
+``widgets[]`` paths unchanged — they carry no ``rippleSpec``, so manifest
+validation (which only walks ``rippleSpec`` trees) never touches them.
 """
 
 from __future__ import annotations
@@ -351,6 +353,13 @@ async def ensure_home_pocket(workspace_id: str, user_id: str) -> tuple[dict, boo
     A stale ``home_pocket_id`` — the pocket was deleted, or it now belongs
     to someone else — falls through to re-provisioning rather than raising.
 
+    **Concurrency.** Provisioning persists the new id with an atomic
+    compare-and-swap (``auth_service.claim_home_pocket_id``), not a plain
+    write. If two concurrent first-login calls both insert a pocket, only
+    one wins the swap; the loser deletes its own orphan pocket, adopts the
+    winner's, and returns it with ``created=False``. The home page is
+    therefore single-pocket even under a provision race.
+
     Provisioning is deliberately empty: the client owns the home page's
     default / seed widgets. This service only guarantees a backing pocket
     exists.
@@ -376,7 +385,26 @@ async def ensure_home_pocket(workspace_id: str, user_id: str) -> tuple[dict, boo
         widgets=[],
     )
     await doc.insert()
-    await auth_service.set_home_pocket_id(user_id, str(doc.id))
+
+    # Compare-and-swap the new id onto the user. ``expected`` is whatever we
+    # read above — None for a genuine first provision, the stale id when
+    # re-provisioning. If the swap fails another writer beat us here.
+    claimed = await auth_service.claim_home_pocket_id(user_id, str(doc.id), expected=existing_id)
+    if not claimed:
+        winner_id = await auth_service.get_home_pocket_id(user_id)
+        if winner_id and winner_id != str(doc.id):
+            try:
+                winner = await _fetch_pocket(winner_id)
+            except NotFound:
+                winner = None
+            if winner is not None and winner.owner == user_id:
+                # Adopt the winner's pocket and drop our orphan.
+                await doc.delete()
+                return await _resolved_wire_dict(winner, user_id), False
+        # The winner's pocket couldn't be resolved (deleted in the race
+        # window). Keep our own pocket rather than orphan the user — but it
+        # is not the id of record, so report created=True and move on.
+
     await emit(PocketCreated(data=await _pocket_event_payload(doc)))
     return await _resolved_wire_dict(doc, user_id), True
 

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -6,6 +6,7 @@ Sole owner of writes to the ``Pocket`` Beanie document. Module-level
 
 Public API (returns wire dicts for legacy router compatibility):
 - ``create``, ``list_pockets``, ``get``, ``update``, ``delete``
+- ``ensure_home_pocket`` — resolve-or-provision the user's home pocket
 - ``create_from_ripple_spec`` — agent-generated pockets
 - ``add_widget``, ``update_widget``, ``remove_widget``, ``reorder_widgets``
 - ``generate_share_link``, ``revoke_share_link``, ``update_share_link``,
@@ -27,6 +28,12 @@ onto the pocketpaw_ee layout from PR #1106).
 Changes: 2026-05-21 (#1172) — ``agent_view`` self-heals node ids via
 ``_heal_node_ids`` so pockets persisted before node-id stamping became
 addressable by granular edit ops on first agent read.
+Changes: 2026-05-21 — added ``ensure_home_pocket`` (home-as-pocket
+foundation): idempotently resolves-or-provisions a per-user ``type="home"``
+pocket and persists its id onto the user's ``home_pocket_id`` setting.
+Native widgets (``type="native"``) ride the existing ``widgets[]`` paths
+unchanged — they carry no ``rippleSpec``, so manifest validation (which
+only walks ``rippleSpec`` trees) never touches them.
 """
 
 from __future__ import annotations
@@ -64,6 +71,17 @@ from pocketpaw_ee.cloud.shared.errors import Forbidden, NotFound, ValidationErro
 from pocketpaw_ee.cloud.shared.events import event_bus
 
 logger = logging.getLogger(__name__)
+
+# Pocket ``type`` for the per-user pocket that backs the home page. Behaves
+# like an ordinary private pocket — the type is a marker the home route and
+# the frontend key on, not a behavioural switch.
+HOME_POCKET_TYPE = "home"
+
+# Widget ``type`` for "native" widgets — widgets the frontend renders as a
+# built-in Svelte component (looked up by ``name``) rather than from a
+# ``rippleSpec``. Native widgets have no spec, so manifest validation —
+# which only walks ``rippleSpec`` trees — never touches them.
+NATIVE_WIDGET_TYPE = "native"
 
 
 # ---------------------------------------------------------------------------
@@ -309,6 +327,48 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
     if body.session_id:
         await sessions_service.link_pocket(workspace_id, body.session_id, pocket.id)
 
+    await emit(PocketCreated(data=await _pocket_event_payload(doc)))
+    return await _resolved_wire_dict(doc, user_id)
+
+
+async def ensure_home_pocket(workspace_id: str, user_id: str) -> dict:
+    """Resolve-or-provision the caller's home pocket; return its wire dict.
+
+    Idempotent. If the user's ``home_pocket_id`` setting points at a pocket
+    that still exists and is owned by the user, that pocket is returned
+    unchanged. Otherwise a fresh ``type="home"`` pocket is created
+    (``name="Home"``, ``visibility="private"``, no widgets), its id is
+    persisted back onto the user setting, and the new pocket is returned.
+
+    A stale ``home_pocket_id`` — the pocket was deleted, or it now belongs
+    to someone else — falls through to re-provisioning rather than raising.
+
+    Provisioning is deliberately empty: the client owns the home page's
+    default / seed widgets. This service only guarantees a backing pocket
+    exists.
+    """
+    from pocketpaw_ee.cloud.auth import service as auth_service
+
+    existing_id = await auth_service.get_home_pocket_id(user_id)
+    if existing_id:
+        try:
+            doc = await _fetch_pocket(existing_id)
+        except NotFound:
+            doc = None
+        if doc is not None and doc.owner == user_id:
+            return await _resolved_wire_dict(doc, user_id)
+
+    doc = _PocketDoc(
+        workspace=workspace_id,
+        name="Home",
+        description="",
+        type=HOME_POCKET_TYPE,
+        owner=user_id,
+        visibility="private",
+        widgets=[],
+    )
+    await doc.insert()
+    await auth_service.set_home_pocket_id(user_id, str(doc.id))
     await emit(PocketCreated(data=await _pocket_event_payload(doc)))
     return await _resolved_wire_dict(doc, user_id)
 

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -331,14 +331,22 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
     return await _resolved_wire_dict(doc, user_id)
 
 
-async def ensure_home_pocket(workspace_id: str, user_id: str) -> dict:
-    """Resolve-or-provision the caller's home pocket; return its wire dict.
+async def ensure_home_pocket(workspace_id: str, user_id: str) -> tuple[dict, bool]:
+    """Resolve-or-provision the caller's home pocket.
+
+    Returns ``(pocket_wire_dict, created)``. ``created`` is ``True`` only
+    when this call provisioned a brand-new home pocket, ``False`` when it
+    returned an existing one. The home route surfaces ``created`` so the
+    client can gate one-time work — seeding default widgets, migrating
+    legacy ``localStorage`` widgets — on a genuinely fresh pocket and
+    never re-seed a returning user who deliberately cleared their grid.
 
     Idempotent. If the user's ``home_pocket_id`` setting points at a pocket
     that still exists and is owned by the user, that pocket is returned
-    unchanged. Otherwise a fresh ``type="home"`` pocket is created
-    (``name="Home"``, ``visibility="private"``, no widgets), its id is
-    persisted back onto the user setting, and the new pocket is returned.
+    unchanged with ``created=False``. Otherwise a fresh ``type="home"``
+    pocket is created (``name="Home"``, ``visibility="private"``, no
+    widgets), its id is persisted back onto the user setting, and it is
+    returned with ``created=True``.
 
     A stale ``home_pocket_id`` — the pocket was deleted, or it now belongs
     to someone else — falls through to re-provisioning rather than raising.
@@ -356,7 +364,7 @@ async def ensure_home_pocket(workspace_id: str, user_id: str) -> dict:
         except NotFound:
             doc = None
         if doc is not None and doc.owner == user_id:
-            return await _resolved_wire_dict(doc, user_id)
+            return await _resolved_wire_dict(doc, user_id), False
 
     doc = _PocketDoc(
         workspace=workspace_id,
@@ -370,7 +378,7 @@ async def ensure_home_pocket(workspace_id: str, user_id: str) -> dict:
     await doc.insert()
     await auth_service.set_home_pocket_id(user_id, str(doc.id))
     await emit(PocketCreated(data=await _pocket_event_payload(doc)))
-    return await _resolved_wire_dict(doc, user_id)
+    return await _resolved_wire_dict(doc, user_id), True
 
 
 async def list_pockets(

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,10 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-05-22 (#1174) — extracted the in-process MCP tool-id allowlist
+  collection into ``_collect_mcp_tool_ids``. The cloud ``pocketpaw_pocket``
+  server now carries a writable ``add_widget`` tool alongside the read tools;
+  its id flows through the same provider loop, so the home-pocket agent can
+  call ``add_widget`` on the ``claude_agent_sdk`` backend.
 Updated: 2026-05-21 — Gate the ``pocketpaw_planner`` in-process MCP server
   behind an explicit policy opt-in (``is_mcp_server_explicitly_allowed``).
   It was the only in-process MCP server with no gate, so the
@@ -594,6 +599,39 @@ class ClaudeSDKBackend(BaseAgentBackend):
 
         return servers
 
+    def _collect_mcp_tool_ids(self) -> list[str]:
+        """Collect the in-process MCP tool ids to add to the SDK allowlist.
+
+        An MCP tool is only callable if its id is on the allowlist. This
+        gathers the core ripple widget-spec ids plus every cloud
+        ``pocketpaw.mcp_servers`` provider's ``tool_ids()`` (which includes
+        the ``pocketpaw_pocket`` server's writable ``add_widget`` tool).
+
+        Opt-in servers (the planner) are skipped unless the policy opts
+        them in, mirroring the registration gate in ``_get_mcp_servers``.
+        Tool ids follow the ``mcp__<server>__<tool>`` convention, so the
+        server name is the segment between the first and second ``__``.
+        """
+        from pocketpaw._registry import providers as _ext_providers
+        from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
+
+        ids: list[str] = list(WIDGET_TOOL_IDS)
+        for provider in _ext_providers("pocketpaw.mcp_servers"):
+            try:
+                tool_ids = list(provider.tool_ids())
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("MCP provider tool ids not added to allowlist: %s", exc)
+                continue
+            for tool_id in tool_ids:
+                parts = tool_id.split("__")
+                server = parts[1] if len(parts) >= 3 and parts[0] == "mcp" else ""
+                if server in OPT_IN_MCP_SERVERS and not (
+                    self._policy.is_mcp_server_explicitly_allowed(server)
+                ):
+                    continue
+                ids.append(tool_id)
+        return ids
+
     async def _get_or_create_client(self, options: Any, *, session_key: str | None = None) -> Any:
         """Get or create a persistent ClaudeSDKClient.
 
@@ -913,34 +951,10 @@ class ClaudeSDKBackend(BaseAgentBackend):
             # callable. The ripple widget-spec tools are core; the cloud
             # pocket / Mission Control tasks / planner / pocket-specialist
             # ids come from the ``pocketpaw.mcp_servers`` providers (none on
-            # an OSS install). Mutations are NOT here — pocket writes flow
-            # through the pocket_specialist create/edit tools.
-            #
-            # Opt-in servers (the planner) are skipped here unless the
-            # policy opts them in, mirroring the registration gate in
-            # ``_get_mcp_servers``. An allowlist id without a registered
-            # server is harmless, but keeping the two gates consistent
-            # avoids a misleading entry. Tool ids follow the
-            # ``mcp__<server>__<tool>`` convention, so the server name is
-            # the segment between the first and second ``__``.
-            from pocketpaw._registry import providers as _ext_providers
-            from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
-
-            allowed_tools.extend(WIDGET_TOOL_IDS)
-            for provider in _ext_providers("pocketpaw.mcp_servers"):
-                try:
-                    tool_ids = list(provider.tool_ids())
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug("MCP provider tool ids not added to allowlist: %s", exc)
-                    continue
-                for tool_id in tool_ids:
-                    parts = tool_id.split("__")
-                    server = parts[1] if len(parts) >= 3 and parts[0] == "mcp" else ""
-                    if server in OPT_IN_MCP_SERVERS and not (
-                        self._policy.is_mcp_server_explicitly_allowed(server)
-                    ):
-                        continue
-                    allowed_tools.append(tool_id)
+            # an OSS install). The cloud ``pocketpaw_pocket`` server carries
+            # both read tools (get_pocket / list_pockets) and the writable
+            # ``add_widget`` tool — they all flow through the loop below.
+            allowed_tools.extend(self._collect_mcp_tool_ids())
 
             # Build hooks for security
             hooks = {

--- a/src/pocketpaw/ripple/__init__.py
+++ b/src/pocketpaw/ripple/__init__.py
@@ -18,6 +18,12 @@
 #
 # Use ``get_pocket_prompts(backend_name=...)`` to pick the right pair.
 #
+#   * HOME_POCKET_PROMPT — the home-surface analogue of the interaction
+#     prompt, injected when the chat is scoped to the per-user
+#     ``type="home"`` pocket. Tells the agent to call ``add_widget`` for
+#     an explicit widget request and otherwise answer directly.
+#
+# Changes: 2026-05-22 — re-export ``HOME_POCKET_PROMPT``.
 # Changes: 2026-05-22 (RFC 04 alpha follow-up 2) — re-export the new
 # ``fill_current_pocket`` helper + ``BACKEND_SUMMARY_TOKEN``.
 #
@@ -30,6 +36,7 @@ from pocketpaw.ripple._design import RIPPLE_DESIGN_RULES
 from pocketpaw.ripple._inline import INLINE_RIPPLE_SYSTEM_PROMPT
 from pocketpaw.ripple._pockets import (
     BACKEND_SUMMARY_TOKEN,
+    HOME_POCKET_PROMPT,
     POCKET_CREATION_PROMPT,
     POCKET_CREATION_PROMPT_CLI,
     POCKET_CREATION_PROMPT_MCP,
@@ -47,6 +54,7 @@ from pocketpaw.ripple._pockets import (
 
 __all__ = [
     "BACKEND_SUMMARY_TOKEN",
+    "HOME_POCKET_PROMPT",
     "INLINE_RIPPLE_SYSTEM_PROMPT",
     "POCKET_CREATION_PROMPT",
     "POCKET_CREATION_PROMPT_CLI",

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -1,5 +1,12 @@
 # pocketpaw/ripple/_pockets.py — System prompts for the Ripple Pockets surface.
 #
+# Changes: 2026-05-22 — added `HOME_POCKET_PROMPT`, the home-surface
+# analogue of the slim interaction prompt. It is injected when the chat
+# is scoped to the per-user `type="home"` pocket: the agent calls
+# `add_widget` for an explicit widget request and answers directly
+# otherwise. No specialist delegation — the home grid is curated one
+# widget at a time.
+#
 # Changes: 2026-05-21 (RFC 04 alpha) — added `_LIVE_DATA_SOURCES_BLOCK`,
 # spliced into the create specialist prompt. It teaches the agent to
 # declare a `sources` block (read-only GET bindings) and a `run_source`
@@ -2151,6 +2158,47 @@ POCKET_CREATION_PROMPT = POCKET_CREATION_PROMPT_MCP
 POCKET_INTERACTION_PROMPT = POCKET_INTERACTION_PROMPT_MCP
 
 
+# ---------------------------------------------------------------------------
+# Home surface — the per-user `type="home"` pocket that backs the home page.
+#
+# The home-surface analogue of POCKET_INTERACTION_PROMPT: slim, one tagged
+# block. The home page is a Pocket like any other, but its canvas is a grid
+# of pinned widgets the user curates — not a designed dashboard. The agent's
+# job here is narrow: add a widget when the user names one, otherwise just
+# talk. No specialist delegation, no spec-rewrite workflow.
+# ---------------------------------------------------------------------------
+
+HOME_POCKET_PROMPT = """\
+<home-pocket>
+This conversation is happening on the user's HOME page. The home page is
+backed by a Pocket whose canvas is a grid of pinned widgets — the things
+the user keeps an eye on (a revenue stat, a task list, an active-agents
+counter). It is the user's own dashboard, assembled one widget at a time.
+
+Two response paths:
+
+  1. ADD A WIDGET. The user asks to add, show, track, or pin a specific
+     widget — "show me revenue", "add a task list", "track active
+     agents", "put a chart of signups here". Call the `add_widget` tool
+     with a well-formed widget spec drawn from the Ripple widget catalog
+     (stat, chart, table, list, kanban, …). Pick the catalog widget that
+     fits what the user named, give it a clear `name`, and seed sensible
+     props/state so the tile is alive on first render.
+
+  2. CHAT. Anything else — a question, a request that isn't about pinning
+     a widget, ordinary conversation ("what's on my home page?", "how do
+     I do X", "summarize my week"). Answer directly. Do NOT call
+     `add_widget` — only add a widget when the user actually asked for one.
+
+To see what is already on the home grid before you add or answer, call
+`get_pocket` once and read the returned widgets.
+
+Add one widget per explicit request. Don't pre-populate the grid with
+widgets the user didn't ask for.
+</home-pocket>
+"""
+
+
 def get_pocket_prompts(*, backend_name: str | None = None) -> tuple[str, str]:
     """Return ``(creation_prompt, interaction_prompt)`` for ``backend_name``.
 
@@ -2166,6 +2214,7 @@ def get_pocket_prompts(*, backend_name: str | None = None) -> tuple[str, str]:
 
 __all__ = [
     "BACKEND_SUMMARY_TOKEN",
+    "HOME_POCKET_PROMPT",
     "POCKET_CREATION_PROMPT",
     "POCKET_CREATION_PROMPT_CLI",
     "POCKET_CREATION_PROMPT_MCP",

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -1,5 +1,12 @@
 # pocketpaw/ripple/_pockets.py — System prompts for the Ripple Pockets surface.
 #
+# Changes: 2026-05-22 (#1174) — rewrote `HOME_POCKET_PROMPT` to drive the
+# now-real `add_widget` MCP tool. It teaches the spec-first workflow:
+# `get_widget_spec` for the widget type FIRST, then `add_widget` with a
+# fully-populated rippleSpec `spec` (a chart MUST carry a real `data`
+# series). Includes one worked chart example so the agent never ships a
+# bare stat tile when asked for a chart.
+#
 # Changes: 2026-05-22 — added `HOME_POCKET_PROMPT`, the home-surface
 # analogue of the slim interaction prompt. It is injected when the chat
 # is scoped to the per-user `type="home"` pocket: the agent calls
@@ -2172,29 +2179,77 @@ HOME_POCKET_PROMPT = """\
 <home-pocket>
 This conversation is happening on the user's HOME page. The home page is
 backed by a Pocket whose canvas is a grid of pinned widgets — the things
-the user keeps an eye on (a revenue stat, a task list, an active-agents
-counter). It is the user's own dashboard, assembled one widget at a time.
+the user keeps an eye on (a revenue stat, a task list, a sales chart). It
+is the user's own dashboard, assembled one widget at a time. The pocket
+id is in the `<current-pocket>` block — pass it as `pocket_id`.
 
 Two response paths:
 
   1. ADD A WIDGET. The user asks to add, show, track, or pin a specific
-     widget — "show me revenue", "add a task list", "track active
-     agents", "put a chart of signups here". Call the `add_widget` tool
-     with a well-formed widget spec drawn from the Ripple widget catalog
-     (stat, chart, table, list, kanban, …). Pick the catalog widget that
-     fits what the user named, give it a clear `name`, and seed sensible
-     props/state so the tile is alive on first render.
+     widget — "show me a 7-day sales chart", "add a task list", "track
+     active agents". Pin it with the `add_widget` tool.
 
-  2. CHAT. Anything else — a question, a request that isn't about pinning
-     a widget, ordinary conversation ("what's on my home page?", "how do
-     I do X", "summarize my week"). Answer directly. Do NOT call
-     `add_widget` — only add a widget when the user actually asked for one.
+  2. CHAT. Anything else — a question, ordinary conversation ("what's on
+     my home page?", "how do I do X"). Answer directly. Do NOT call
+     `add_widget` unless the user actually asked for a widget.
 
-To see what is already on the home grid before you add or answer, call
-`get_pocket` once and read the returned widgets.
+## How to call add_widget
 
-Add one widget per explicit request. Don't pre-populate the grid with
-widgets the user didn't ask for.
+For any non-trivial widget — a chart, table, list, kanban, anything
+beyond a bare single-number `stat` — you MUST do two steps:
+
+  STEP 1. Call `get_widget_spec` for that widget type FIRST. It returns
+  the catalog widget's `data` / `props` shape. Never guess prop names.
+
+  STEP 2. Call `add_widget` with `pocket_id` and a `widget` object:
+    - `name`  — a clear tile title.
+    - `type`  — the Ripple catalog widget type: `chart`, `table`,
+      `stat`, `list`, `kanban`, …
+    - `icon`  — optional Lucide icon name.
+    - `spec`  — the rippleSpec subtree for the tile, populated with REAL
+      data. The home grid renders the tile from this `spec`.
+
+A `chart` MUST carry a real `data` series — never an empty array, never
+a placeholder. "A 7-day sales chart" means seven `{label, value}`
+points. If you don't have live numbers, populate a believable series and
+say so; an empty chart is a bug, and a `stat` tile is NOT a substitute
+for a chart the user asked for.
+
+Worked example — "add a 7-day sales chart":
+
+  add_widget({
+    "pocket_id": "<from current-pocket>",
+    "widget": {
+      "name": "7-day sales",
+      "type": "chart",
+      "icon": "trending-up",
+      "spec": {
+        "type": "chart",
+        "props": {
+          "variant": "bar",
+          "data": [
+            {"label": "Mon", "value": 1200},
+            {"label": "Tue", "value": 1850},
+            {"label": "Wed", "value": 1400},
+            {"label": "Thu", "value": 2100},
+            {"label": "Fri", "value": 2600},
+            {"label": "Sat", "value": 900},
+            {"label": "Sun", "value": 700}
+          ]
+        }
+      }
+    }
+  })
+
+A native widget (a built-in component the user picks by name) passes
+`type:"native"` and no `spec`.
+
+If `add_widget` returns an error about invalid props, read it, fix the
+spec to use only the allowed props, and call again.
+
+To see what is already on the home grid, call `get_pocket` once with the
+pocket id and read the returned widgets. Add one widget per explicit
+request — don't pre-populate the grid.
 </home-pocket>
 """
 

--- a/tests/cloud/test_agent_service_tools_context.py
+++ b/tests/cloud/test_agent_service_tools_context.py
@@ -397,6 +397,56 @@ def test_home_pocket_prompt_injected_for_cli_backend_too():
     assert "<home-pocket>" in block
 
 
+def test_home_pocket_scope_omits_specialist_delegation_rule():
+    """The home agent mutates widgets directly via ``add_widget`` — it does
+    NOT delegate to the pocket specialist. ``POCKET_DELEGATION_RULE`` and
+    ``HOME_POCKET_PROMPT`` contradict each other (one says "never call
+    add_widget, delegate"; the other says "call add_widget"). For a
+    type='home' scope on an MCP backend the delegation rule must be dropped
+    so the agent gets exactly one consistent widget-creation instruction."""
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    ctx = ScopeContext(
+        kind=ScopeKind.POCKET,
+        scope_id="home-pocket-1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        agent_ids_in_scope=["a1"],
+        pocket_id="home-pocket-1",
+        pocket_type="home",
+    )
+    block = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+    # The home prompt is present...
+    assert "<home-pocket>" in block
+    # ...and the contradicting delegation rule is NOT.
+    assert "<pocket-delegation>" not in block, (
+        "POCKET_DELEGATION_RULE contradicts HOME_POCKET_PROMPT — it must "
+        "not be emitted for a type='home' scope"
+    )
+
+
+def test_non_home_pocket_scope_keeps_specialist_delegation_rule():
+    """A normal (non-home) MCP pocket scope still gets the delegation rule —
+    the home-only drop must not regress ordinary pocket chats."""
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    ctx = ScopeContext(
+        kind=ScopeKind.POCKET,
+        scope_id="pocket-abc",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        agent_ids_in_scope=["a1"],
+        pocket_id="pocket-abc",
+        pocket_type="custom",
+    )
+    block = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+    assert "<pocket-delegation>" in block
+
+
 @pytest.mark.asyncio
 async def test_build_knowledge_context_includes_workspace_kb_hits_and_file_refs():
     ctx = ScopeContext(

--- a/tests/cloud/test_agent_service_tools_context.py
+++ b/tests/cloud/test_agent_service_tools_context.py
@@ -335,6 +335,68 @@ def test_non_subagent_backend_pocket_id_inlines_interaction_prompt():
     assert "<pocket-delegation>" not in block
 
 
+def test_home_pocket_scope_injects_home_prompt():
+    """When the resolved scope's pocket has ``type == "home"``, the
+    behavior instructions must carry HOME_POCKET_PROMPT so the agent
+    knows it is on the user's home surface."""
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    ctx = ScopeContext(
+        kind=ScopeKind.POCKET,
+        scope_id="home-pocket-1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        agent_ids_in_scope=["a1"],
+        pocket_id="home-pocket-1",
+        pocket_type="home",
+    )
+    block = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+    assert "<home-pocket>" in block, (
+        "HOME_POCKET_PROMPT must be injected for a type='home' pocket scope"
+    )
+
+
+def test_non_home_pocket_scope_omits_home_prompt():
+    """A normal (non-home) pocket scope must NOT receive HOME_POCKET_PROMPT."""
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    ctx = ScopeContext(
+        kind=ScopeKind.POCKET,
+        scope_id="pocket-abc",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        agent_ids_in_scope=["a1"],
+        pocket_id="pocket-abc",
+        pocket_type="custom",
+    )
+    block = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+    assert "<home-pocket>" not in block, "HOME_POCKET_PROMPT leaked into a non-home pocket scope"
+
+
+def test_home_pocket_prompt_injected_for_cli_backend_too():
+    """The home-pocket case is backend-agnostic — a CLI backend in a
+    type='home' scope also gets HOME_POCKET_PROMPT."""
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    ctx = ScopeContext(
+        kind=ScopeKind.POCKET,
+        scope_id="home-pocket-1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        agent_ids_in_scope=["a1"],
+        pocket_id="home-pocket-1",
+        pocket_type="home",
+    )
+    block = build_behavior_instructions(ctx, backend_name="codex_cli")
+    assert "<home-pocket>" in block
+
+
 @pytest.mark.asyncio
 async def test_build_knowledge_context_includes_workspace_kb_hits_and_file_refs():
     ctx = ScopeContext(

--- a/tests/cloud/test_home_pocket.py
+++ b/tests/cloud/test_home_pocket.py
@@ -1,14 +1,19 @@
 # tests/cloud/test_home_pocket.py — Home-as-Pocket backend foundation.
 # Created: 2026-05-21 — TDD coverage for the home-pocket migration:
-#   1. ``ensure_home_pocket`` provisions an empty ``type="home"`` pocket and
-#      persists its id onto the user's ``home_pocket_id`` setting.
+#   1. ``ensure_home_pocket`` provisions an empty ``type="home"`` pocket,
+#      persists its id onto the user's ``home_pocket_id`` setting, and
+#      reports ``created=True``.
 #   2. ``ensure_home_pocket`` is idempotent — a second call returns the same
-#      pocket, never double-provisions.
-#   3. A stale ``home_pocket_id`` (pocket deleted) re-provisions cleanly.
+#      pocket with ``created=False``, never double-provisions.
+#   3. A stale ``home_pocket_id`` (pocket deleted) re-provisions cleanly and
+#      reports ``created=True`` again.
 #   4. The ``"home"`` pocket type round-trips through create + read.
 #   5. A ``type="native"`` widget round-trips through ``add_widget`` and
 #      ``agent_add_widget`` — persisted and read back without manifest
 #      rejection (native widgets carry no rippleSpec to validate).
+#
+# Updated: 2026-05-21 — ``ensure_home_pocket`` now returns a
+# ``(pocket_dict, created)`` tuple; tests unpack it and assert the flag.
 #
 # Uses the shared ``mongo_db`` fixture so the service exercises real Beanie
 # reads/writes against an isolated mongomock-motor DB.
@@ -48,8 +53,10 @@ async def _seed_user(email: str = "owner@home.test") -> str:
 async def test_ensure_home_pocket_provisions_empty_home_pocket() -> None:
     user_id = await _seed_user()
 
-    pocket = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+    pocket, created = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
 
+    # First call on a fresh user provisions a brand-new home pocket.
+    assert created is True
     assert pocket["name"] == "Home"
     assert pocket["type"] == "home"
     assert pocket["visibility"] == "private"
@@ -63,10 +70,13 @@ async def test_ensure_home_pocket_provisions_empty_home_pocket() -> None:
 async def test_ensure_home_pocket_is_idempotent() -> None:
     user_id = await _seed_user()
 
-    first = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
-    second = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+    first, first_created = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+    second, second_created = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
 
     assert first["_id"] == second["_id"]
+    # Only the first call provisioned — the second returned the existing one.
+    assert first_created is True
+    assert second_created is False
     # Exactly one home pocket exists for the user — no double-provision.
     pockets = await pockets_service.list_pockets(WORKSPACE, user_id)
     home_pockets = [p for p in pockets if p["type"] == "home"]
@@ -76,14 +86,17 @@ async def test_ensure_home_pocket_is_idempotent() -> None:
 async def test_ensure_home_pocket_reprovisions_when_setting_is_stale() -> None:
     user_id = await _seed_user()
 
-    first = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+    first, first_created = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
     # Pocket is deleted out from under the user, setting now dangles.
     await pockets_service.delete(first["_id"], user_id)
 
-    second = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+    second, second_created = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
 
     assert second["_id"] != first["_id"]
     assert second["type"] == "home"
+    # A stale setting re-provisions — created is True on both genuine creates.
+    assert first_created is True
+    assert second_created is True
     assert await auth_service.get_home_pocket_id(user_id) == second["_id"]
 
 
@@ -94,7 +107,7 @@ async def test_ensure_home_pocket_reprovisions_when_setting_is_stale() -> None:
 
 async def test_home_type_pocket_round_trips() -> None:
     user_id = await _seed_user()
-    pocket = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+    pocket, _ = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
 
     fetched = await pockets_service.get(pocket["_id"], user_id)
     assert fetched["type"] == "home"
@@ -108,7 +121,7 @@ async def test_home_type_pocket_round_trips() -> None:
 
 async def test_native_widget_round_trips_through_add_widget() -> None:
     user_id = await _seed_user()
-    pocket = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+    pocket, _ = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
 
     result = await pockets_service.add_widget(
         pocket["_id"],
@@ -143,7 +156,7 @@ async def test_native_widget_round_trips_through_agent_add_widget() -> None:
     )
 
     user_id = await _seed_user()
-    pocket = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+    pocket, _ = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
 
     # agent_add_widget reads workspace/user from the per-stream ContextVars
     # the cloud SSE chat path sets; bind them so the agent path resolves.

--- a/tests/cloud/test_home_pocket.py
+++ b/tests/cloud/test_home_pocket.py
@@ -11,14 +11,20 @@
 #   5. A ``type="native"`` widget round-trips through ``add_widget`` and
 #      ``agent_add_widget`` — persisted and read back without manifest
 #      rejection (native widgets carry no rippleSpec to validate).
+#   6. Concurrent first-login ``ensure_home_pocket`` calls resolve to a
+#      single home pocket — the atomic CAS closes the provision race.
 #
 # Updated: 2026-05-21 — ``ensure_home_pocket`` now returns a
 # ``(pocket_dict, created)`` tuple; tests unpack it and assert the flag.
+# Updated: 2026-05-21 — added the provision-race coverage; ``ensure_home_pocket``
+# persists the new id via an atomic compare-and-swap.
 #
 # Uses the shared ``mongo_db`` fixture so the service exercises real Beanie
 # reads/writes against an isolated mongomock-motor DB.
 
 from __future__ import annotations
+
+import asyncio
 
 import pytest
 from pocketpaw_ee.cloud.auth import service as auth_service
@@ -182,3 +188,75 @@ async def test_native_widget_round_trips_through_agent_add_widget() -> None:
     native = fetched["widgets"][0]
     assert native["type"] == "native"
     assert native["name"] == "Mission · Agents in flight"
+
+
+# ---------------------------------------------------------------------------
+# claim_home_pocket_id — atomic compare-and-swap
+# ---------------------------------------------------------------------------
+
+
+async def test_claim_home_pocket_id_swaps_when_expected_matches() -> None:
+    user_id = await _seed_user()
+
+    # Fresh user: home_pocket_id is None — the None-expecting claim takes.
+    claimed = await auth_service.claim_home_pocket_id(user_id, "pkt-1", expected=None)
+    assert claimed is True
+    assert await auth_service.get_home_pocket_id(user_id) == "pkt-1"
+
+
+async def test_claim_home_pocket_id_rejects_when_expected_is_stale() -> None:
+    user_id = await _seed_user()
+    await auth_service.claim_home_pocket_id(user_id, "pkt-1", expected=None)
+
+    # A second claim that still expects None loses — the field already moved.
+    claimed = await auth_service.claim_home_pocket_id(user_id, "pkt-2", expected=None)
+    assert claimed is False
+    # The value of record is unchanged — no clobber.
+    assert await auth_service.get_home_pocket_id(user_id) == "pkt-1"
+
+
+# ---------------------------------------------------------------------------
+# first-login provision race — concurrent ensure_home_pocket calls
+# ---------------------------------------------------------------------------
+
+
+async def test_concurrent_ensure_home_pocket_resolves_to_one_pocket() -> None:
+    user_id = await _seed_user()
+
+    # Two first-login /home calls race. Both read home_pocket_id == None,
+    # both insert a pocket; the atomic CAS lets exactly one commit its id.
+    (pocket_a, created_a), (pocket_b, created_b) = await asyncio.gather(
+        pockets_service.ensure_home_pocket(WORKSPACE, user_id),
+        pockets_service.ensure_home_pocket(WORKSPACE, user_id),
+    )
+
+    # Both callers see the same home pocket — the loser adopted the winner's.
+    assert pocket_a["_id"] == pocket_b["_id"]
+    # Exactly one call reports created=True; the loser reports False.
+    assert {created_a, created_b} == {True, False}
+
+    # The user setting points at that one pocket.
+    home_id = await auth_service.get_home_pocket_id(user_id)
+    assert home_id == pocket_a["_id"]
+
+    # No orphan: exactly one home pocket exists for the user.
+    pockets = await pockets_service.list_pockets(WORKSPACE, user_id)
+    home_pockets = [p for p in pockets if p["type"] == "home"]
+    assert len(home_pockets) == 1
+    assert home_pockets[0]["_id"] == home_id
+
+
+async def test_concurrent_ensure_home_pocket_many_callers_one_pocket() -> None:
+    # Stress the race a little harder — five concurrent first-login calls.
+    user_id = await _seed_user()
+
+    results = await asyncio.gather(
+        *(pockets_service.ensure_home_pocket(WORKSPACE, user_id) for _ in range(5))
+    )
+
+    ids = {pocket["_id"] for pocket, _ in results}
+    assert len(ids) == 1  # every caller converged on the same pocket
+
+    pockets = await pockets_service.list_pockets(WORKSPACE, user_id)
+    home_pockets = [p for p in pockets if p["type"] == "home"]
+    assert len(home_pockets) == 1

--- a/tests/cloud/test_home_pocket.py
+++ b/tests/cloud/test_home_pocket.py
@@ -18,6 +18,10 @@
 # ``(pocket_dict, created)`` tuple; tests unpack it and assert the flag.
 # Updated: 2026-05-21 — added the provision-race coverage; ``ensure_home_pocket``
 # persists the new id via an atomic compare-and-swap.
+# Updated: 2026-05-22 — a Ripple-spec widget (``type="chart"`` with a real
+# ``data`` series) round-trips through ``add_widget`` / ``agent_add_widget``:
+# the widget's ``spec`` rippleSpec subtree is stored and read back so the
+# home grid can render the tile.
 #
 # Uses the shared ``mongo_db`` fixture so the service exercises real Beanie
 # reads/writes against an isolated mongomock-motor DB.
@@ -188,6 +192,101 @@ async def test_native_widget_round_trips_through_agent_add_widget() -> None:
     native = fetched["widgets"][0]
     assert native["type"] == "native"
     assert native["name"] == "Mission · Agents in flight"
+
+
+# ---------------------------------------------------------------------------
+# Ripple-spec widget round-trip — the home agent's add_widget path
+# ---------------------------------------------------------------------------
+
+
+def _chart_widget_payload() -> dict:
+    """A chart widget entry with a populated rippleSpec ``spec`` subtree —
+    the shape the home agent's ``add_widget`` MCP tool produces."""
+    return {
+        "name": "7-day sales",
+        "type": "chart",
+        "icon": "trending-up",
+        "color": "#0A84FF",
+        "spec": {
+            "type": "chart",
+            "props": {
+                "variant": "bar",
+                "data": [
+                    {"label": "Mon", "value": 1200},
+                    {"label": "Tue", "value": 1850},
+                    {"label": "Wed", "value": 1400},
+                    {"label": "Thu", "value": 2100},
+                    {"label": "Fri", "value": 2600},
+                    {"label": "Sat", "value": 900},
+                    {"label": "Sun", "value": 700},
+                ],
+            },
+        },
+    }
+
+
+async def test_chart_widget_round_trips_through_add_widget() -> None:
+    """A Ripple-spec widget carries a ``spec`` rippleSpec subtree. The home
+    grid renders the tile from ``widget.spec``, so the field must survive a
+    create + read round-trip."""
+    user_id = await _seed_user()
+    pocket, _ = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+
+    payload = _chart_widget_payload()
+    result = await pockets_service.add_widget(
+        pocket["_id"],
+        user_id,
+        AddWidgetRequest(
+            name=payload["name"],
+            type=payload["type"],
+            icon=payload["icon"],
+            color=payload["color"],
+            spec=payload["spec"],
+        ),
+    )
+
+    widgets = result["widgets"]
+    assert len(widgets) == 1
+    chart = widgets[0]
+    assert chart["type"] == "chart"
+    assert chart["spec"]["type"] == "chart"
+    # The chart carries a real 7-point data series — not a bare stat tile.
+    assert len(chart["spec"]["props"]["data"]) == 7
+    assert chart["spec"]["props"]["data"][0] == {"label": "Mon", "value": 1200}
+
+    # Read back: the spec survives a fresh fetch unchanged.
+    fetched = await pockets_service.get(pocket["_id"], user_id)
+    assert fetched["widgets"][0]["spec"]["props"]["data"][4]["value"] == 2600
+
+
+async def test_chart_widget_round_trips_through_agent_add_widget() -> None:
+    """The agent path (``agent_add_widget``) stores the chart ``spec`` too —
+    the home agent's MCP tool reaches the store through this helper."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_agent_identity,
+        detach_agent_identity,
+    )
+
+    user_id = await _seed_user()
+    pocket, _ = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+
+    tokens = attach_agent_identity(workspace_id=WORKSPACE, user_id=user_id)
+    try:
+        view, err = await pockets_service.agent_add_widget(
+            pocket["_id"],
+            _chart_widget_payload(),
+        )
+    finally:
+        detach_agent_identity(tokens)
+
+    assert err is None
+    assert view is not None
+    chart = view["widgets"][0]
+    assert chart["type"] == "chart"
+    assert len(chart["spec"]["props"]["data"]) == 7
+
+    fetched = await pockets_service.get(pocket["_id"], user_id)
+    assert fetched["widgets"][0]["spec"]["props"]["data"][3]["label"] == "Thu"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_home_pocket.py
+++ b/tests/cloud/test_home_pocket.py
@@ -1,0 +1,171 @@
+# tests/cloud/test_home_pocket.py — Home-as-Pocket backend foundation.
+# Created: 2026-05-21 — TDD coverage for the home-pocket migration:
+#   1. ``ensure_home_pocket`` provisions an empty ``type="home"`` pocket and
+#      persists its id onto the user's ``home_pocket_id`` setting.
+#   2. ``ensure_home_pocket`` is idempotent — a second call returns the same
+#      pocket, never double-provisions.
+#   3. A stale ``home_pocket_id`` (pocket deleted) re-provisions cleanly.
+#   4. The ``"home"`` pocket type round-trips through create + read.
+#   5. A ``type="native"`` widget round-trips through ``add_widget`` and
+#      ``agent_add_widget`` — persisted and read back without manifest
+#      rejection (native widgets carry no rippleSpec to validate).
+#
+# Uses the shared ``mongo_db`` fixture so the service exercises real Beanie
+# reads/writes against an isolated mongomock-motor DB.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.auth import service as auth_service
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import AddWidgetRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+WORKSPACE = "ws-home"
+
+
+async def _seed_user(email: str = "owner@home.test") -> str:
+    """Insert a User and return its id string."""
+    doc = _UserDoc(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="Home Owner",
+        active_workspace=WORKSPACE,
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+# ---------------------------------------------------------------------------
+# ensure_home_pocket — provision + idempotency
+# ---------------------------------------------------------------------------
+
+
+async def test_ensure_home_pocket_provisions_empty_home_pocket() -> None:
+    user_id = await _seed_user()
+
+    pocket = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+
+    assert pocket["name"] == "Home"
+    assert pocket["type"] == "home"
+    assert pocket["visibility"] == "private"
+    assert pocket["owner"] == user_id
+    # No seed widgets — the client owns default widgets.
+    assert pocket["widgets"] == []
+    # The new pocket id is persisted back onto the user setting.
+    assert await auth_service.get_home_pocket_id(user_id) == pocket["_id"]
+
+
+async def test_ensure_home_pocket_is_idempotent() -> None:
+    user_id = await _seed_user()
+
+    first = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+    second = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+
+    assert first["_id"] == second["_id"]
+    # Exactly one home pocket exists for the user — no double-provision.
+    pockets = await pockets_service.list_pockets(WORKSPACE, user_id)
+    home_pockets = [p for p in pockets if p["type"] == "home"]
+    assert len(home_pockets) == 1
+
+
+async def test_ensure_home_pocket_reprovisions_when_setting_is_stale() -> None:
+    user_id = await _seed_user()
+
+    first = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+    # Pocket is deleted out from under the user, setting now dangles.
+    await pockets_service.delete(first["_id"], user_id)
+
+    second = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+
+    assert second["_id"] != first["_id"]
+    assert second["type"] == "home"
+    assert await auth_service.get_home_pocket_id(user_id) == second["_id"]
+
+
+# ---------------------------------------------------------------------------
+# "home" pocket type accepted as an ordinary private pocket
+# ---------------------------------------------------------------------------
+
+
+async def test_home_type_pocket_round_trips() -> None:
+    user_id = await _seed_user()
+    pocket = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+
+    fetched = await pockets_service.get(pocket["_id"], user_id)
+    assert fetched["type"] == "home"
+    assert fetched["visibility"] == "private"
+
+
+# ---------------------------------------------------------------------------
+# native widget round-trip — add_widget + agent_add_widget
+# ---------------------------------------------------------------------------
+
+
+async def test_native_widget_round_trips_through_add_widget() -> None:
+    user_id = await _seed_user()
+    pocket = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+
+    result = await pockets_service.add_widget(
+        pocket["_id"],
+        user_id,
+        AddWidgetRequest(
+            name="Mission · Tray",
+            type="native",
+            icon="inbox",
+            color="#0A84FF",
+        ),
+    )
+
+    widgets = result["widgets"]
+    assert len(widgets) == 1
+    native = widgets[0]
+    assert native["type"] == "native"
+    # The frontend NATIVE_WIDGETS map keys on the widget name.
+    assert native["name"] == "Mission · Tray"
+    assert native["icon"] == "inbox"
+    assert native["color"] == "#0A84FF"
+
+    # Read back: the native widget survives a fresh fetch unchanged.
+    fetched = await pockets_service.get(pocket["_id"], user_id)
+    assert fetched["widgets"][0]["type"] == "native"
+    assert fetched["widgets"][0]["name"] == "Mission · Tray"
+
+
+async def test_native_widget_round_trips_through_agent_add_widget() -> None:
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_agent_identity,
+        detach_agent_identity,
+    )
+
+    user_id = await _seed_user()
+    pocket = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+
+    # agent_add_widget reads workspace/user from the per-stream ContextVars
+    # the cloud SSE chat path sets; bind them so the agent path resolves.
+    tokens = attach_agent_identity(workspace_id=WORKSPACE, user_id=user_id)
+    try:
+        view, err = await pockets_service.agent_add_widget(
+            pocket["_id"],
+            {
+                "name": "Mission · Agents in flight",
+                "type": "native",
+                "icon": "users",
+                "color": "#30D158",
+            },
+        )
+    finally:
+        detach_agent_identity(tokens)
+
+    # No manifest rejection — native widgets carry no rippleSpec to validate.
+    assert err is None
+    assert view is not None
+
+    fetched = await pockets_service.get(pocket["_id"], user_id)
+    native = fetched["widgets"][0]
+    assert native["type"] == "native"
+    assert native["name"] == "Mission · Agents in flight"

--- a/tests/cloud/test_home_pocket_route.py
+++ b/tests/cloud/test_home_pocket_route.py
@@ -13,6 +13,8 @@
 # Updated: 2026-05-21 — added the ``created`` flag to the response envelope so
 # the client can gate one-time widget seeding / localStorage migration; the
 # route now surfaces what path ``ensure_home_pocket`` took.
+# Updated: 2026-05-21 — route is typed with the ``HomePocketResponse`` DTO so
+# it has a real OpenAPI schema; added DTO + schema coverage.
 #
 # What this pins:
 #   1. GET /pockets/home returns 200 with {pocket_id, pocket, created}.
@@ -20,6 +22,7 @@
 #   3. ``created`` reflects whether ensure_home_pocket provisioned a new
 #      pocket (True) or returned an existing one (False).
 #   4. The static /home route is matched ahead of the /{pocket_id} route.
+#   5. The route has a non-empty OpenAPI schema (typed response model).
 
 from __future__ import annotations
 
@@ -30,6 +33,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import HomePocketResponse
 from pocketpaw_ee.cloud.pockets.router import router
 from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
 
@@ -120,3 +124,45 @@ def test_get_home_route_matches_ahead_of_pocket_id_route(client: TestClient) -> 
     res = client.get("/pockets/home")
     assert res.status_code == 200, res.text
     assert set(res.json().keys()) == {"pocket_id", "pocket", "created"}
+
+
+# ---------------------------------------------------------------------------
+# HomePocketResponse DTO + OpenAPI schema
+# ---------------------------------------------------------------------------
+
+
+def test_home_pocket_response_dto_shape() -> None:
+    # The DTO carries the three contract fields with the right types and
+    # serializes byte-identically to the {pocket_id, pocket, created} wire
+    # shape the client builds against.
+    model = HomePocketResponse(
+        pocket_id="home-pocket-1",
+        pocket=dict(HOME_POCKET),
+        created=True,
+    )
+    dumped = model.model_dump()
+    assert set(dumped.keys()) == {"pocket_id", "pocket", "created"}
+    assert dumped["pocket_id"] == "home-pocket-1"
+    assert dumped["created"] is True
+    # The pocket dict passes through verbatim — no field renaming.
+    assert dumped["pocket"] == dict(HOME_POCKET)
+
+
+def test_home_pocket_response_dto_rejects_missing_fields() -> None:
+    from pydantic import ValidationError as PydanticValidationError
+
+    with pytest.raises(PydanticValidationError):
+        HomePocketResponse(pocket_id="x", pocket={})  # missing created
+
+
+def test_home_route_has_non_empty_openapi_schema(app: FastAPI) -> None:
+    # Before the typed response model the route's schema was an empty {} —
+    # the client had nothing to generate against. Pin that it now resolves
+    # to the HomePocketResponse component.
+    schema = app.openapi()
+    home = schema["paths"]["/pockets/home"]["get"]
+    content = home["responses"]["200"]["content"]["application/json"]["schema"]
+    ref = content.get("$ref", "")
+    assert ref.endswith("/HomePocketResponse"), content
+    props = schema["components"]["schemas"]["HomePocketResponse"]["properties"]
+    assert set(props.keys()) == {"pocket_id", "pocket", "created"}

--- a/tests/cloud/test_home_pocket_route.py
+++ b/tests/cloud/test_home_pocket_route.py
@@ -1,0 +1,100 @@
+# tests/cloud/test_home_pocket_route.py — Home-as-Pocket endpoint coverage.
+# Created: 2026-05-21 — Integration coverage for the home-pocket route on the
+# pockets router:
+#
+#   GET /pockets/home  → {pocket_id, pocket}
+#
+# The route resolves-or-provisions the caller's home pocket via
+# ``ensure_home_pocket``. ``ensure_home_pocket`` is monkey-patched to a canned
+# pocket dict so the test stays independent of Beanie + MongoDB — same pattern
+# as ``test_pocket_layout_routes.py``. Auth + license guards are overridden via
+# ``app.dependency_overrides``.
+#
+# What this pins:
+#   1. GET /pockets/home returns 200 with {pocket_id, pocket}.
+#   2. The response carries the full pocket (rippleSpec / widgets).
+#   3. The static /home route is matched ahead of the /{pocket_id} route.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.router import router
+from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+FAKE_WORKSPACE = "ws-home"
+FAKE_USER = "user-home-owner"
+
+HOME_POCKET: dict[str, Any] = {
+    "_id": "home-pocket-1",
+    "workspace": FAKE_WORKSPACE,
+    "name": "Home",
+    "description": "",
+    "type": "home",
+    "icon": "",
+    "color": "",
+    "owner": FAKE_USER,
+    "visibility": "private",
+    "team": [],
+    "agents": [],
+    "widgets": [],
+    "rippleSpec": None,
+    "shareLinkToken": None,
+    "shareLinkAccess": "view",
+    "sharedWith": [],
+    "projectId": None,
+    "createdAt": "2026-05-21T00:00:00Z",
+    "updatedAt": "2026-05-21T00:00:00Z",
+}
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+
+    a = FastAPI()
+    add_error_handler(a)
+    a.include_router(router)
+
+    async def _fake_ensure(workspace_id: str, user_id: str) -> dict:
+        assert workspace_id == FAKE_WORKSPACE
+        assert user_id == FAKE_USER
+        return dict(HOME_POCKET)
+
+    monkeypatch.setattr(pockets_service, "ensure_home_pocket", _fake_ensure)
+
+    a.dependency_overrides[require_license] = lambda: None
+    a.dependency_overrides[current_user_id] = lambda: FAKE_USER
+    a.dependency_overrides[current_workspace_id] = lambda: FAKE_WORKSPACE
+    return a
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+def test_get_home_pocket_returns_pocket_id_and_pocket(client: TestClient) -> None:
+    res = client.get("/pockets/home")
+    assert res.status_code == 200, res.text
+
+    body = res.json()
+    assert body["pocket_id"] == "home-pocket-1"
+    assert body["pocket"]["type"] == "home"
+    assert body["pocket"]["name"] == "Home"
+    # The full pocket — rippleSpec / widgets — rides the response.
+    assert "widgets" in body["pocket"]
+    assert "rippleSpec" in body["pocket"]
+
+
+def test_get_home_route_matches_ahead_of_pocket_id_route(client: TestClient) -> None:
+    # If /{pocket_id} shadowed /home, "home" would be treated as a pocket id
+    # and the response would not carry the {pocket_id, pocket} envelope.
+    res = client.get("/pockets/home")
+    assert res.status_code == 200, res.text
+    assert set(res.json().keys()) == {"pocket_id", "pocket"}

--- a/tests/cloud/test_home_pocket_route.py
+++ b/tests/cloud/test_home_pocket_route.py
@@ -2,18 +2,24 @@
 # Created: 2026-05-21 — Integration coverage for the home-pocket route on the
 # pockets router:
 #
-#   GET /pockets/home  → {pocket_id, pocket}
+#   GET /pockets/home  → {pocket_id, pocket, created}
 #
 # The route resolves-or-provisions the caller's home pocket via
-# ``ensure_home_pocket``. ``ensure_home_pocket`` is monkey-patched to a canned
-# pocket dict so the test stays independent of Beanie + MongoDB — same pattern
-# as ``test_pocket_layout_routes.py``. Auth + license guards are overridden via
-# ``app.dependency_overrides``.
+# ``ensure_home_pocket``. ``ensure_home_pocket`` is monkey-patched to return a
+# canned ``(pocket_dict, created)`` tuple so the test stays independent of
+# Beanie + MongoDB — same pattern as ``test_pocket_layout_routes.py``. Auth +
+# license guards are overridden via ``app.dependency_overrides``.
+#
+# Updated: 2026-05-21 — added the ``created`` flag to the response envelope so
+# the client can gate one-time widget seeding / localStorage migration; the
+# route now surfaces what path ``ensure_home_pocket`` took.
 #
 # What this pins:
-#   1. GET /pockets/home returns 200 with {pocket_id, pocket}.
+#   1. GET /pockets/home returns 200 with {pocket_id, pocket, created}.
 #   2. The response carries the full pocket (rippleSpec / widgets).
-#   3. The static /home route is matched ahead of the /{pocket_id} route.
+#   3. ``created`` reflects whether ensure_home_pocket provisioned a new
+#      pocket (True) or returned an existing one (False).
+#   4. The static /home route is matched ahead of the /{pocket_id} route.
 
 from __future__ import annotations
 
@@ -53,18 +59,17 @@ HOME_POCKET: dict[str, Any] = {
 }
 
 
-@pytest.fixture
-def app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+def _make_app(monkeypatch: pytest.MonkeyPatch, *, created: bool) -> FastAPI:
     from pocketpaw_ee.cloud._core.http import add_error_handler
 
     a = FastAPI()
     add_error_handler(a)
     a.include_router(router)
 
-    async def _fake_ensure(workspace_id: str, user_id: str) -> dict:
+    async def _fake_ensure(workspace_id: str, user_id: str) -> tuple[dict, bool]:
         assert workspace_id == FAKE_WORKSPACE
         assert user_id == FAKE_USER
-        return dict(HOME_POCKET)
+        return dict(HOME_POCKET), created
 
     monkeypatch.setattr(pockets_service, "ensure_home_pocket", _fake_ensure)
 
@@ -75,11 +80,16 @@ def app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
 
 
 @pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    return _make_app(monkeypatch, created=False)
+
+
+@pytest.fixture
 def client(app: FastAPI) -> TestClient:
     return TestClient(app)
 
 
-def test_get_home_pocket_returns_pocket_id_and_pocket(client: TestClient) -> None:
+def test_get_home_pocket_returns_pocket_id_pocket_and_created(client: TestClient) -> None:
     res = client.get("/pockets/home")
     assert res.status_code == 200, res.text
 
@@ -90,11 +100,23 @@ def test_get_home_pocket_returns_pocket_id_and_pocket(client: TestClient) -> Non
     # The full pocket — rippleSpec / widgets — rides the response.
     assert "widgets" in body["pocket"]
     assert "rippleSpec" in body["pocket"]
+    # The provisioning flag rides the envelope alongside the pocket.
+    assert body["created"] is False
+
+
+@pytest.mark.parametrize("created", [True, False])
+def test_get_home_pocket_surfaces_created_flag(
+    monkeypatch: pytest.MonkeyPatch, created: bool
+) -> None:
+    app = _make_app(monkeypatch, created=created)
+    res = TestClient(app).get("/pockets/home")
+    assert res.status_code == 200, res.text
+    assert res.json()["created"] is created
 
 
 def test_get_home_route_matches_ahead_of_pocket_id_route(client: TestClient) -> None:
     # If /{pocket_id} shadowed /home, "home" would be treated as a pocket id
-    # and the response would not carry the {pocket_id, pocket} envelope.
+    # and the response would not carry the {pocket_id, pocket, created} envelope.
     res = client.get("/pockets/home")
     assert res.status_code == 200, res.text
-    assert set(res.json().keys()) == {"pocket_id", "pocket"}
+    assert set(res.json().keys()) == {"pocket_id", "pocket", "created"}

--- a/tests/cloud/test_pocket_prompts_single_source.py
+++ b/tests/cloud/test_pocket_prompts_single_source.py
@@ -161,6 +161,24 @@ def test_home_pocket_prompt_is_exported_and_focused() -> None:
     assert "pocket_specialist__edit" not in HOME_POCKET_PROMPT
 
 
+def test_home_pocket_prompt_teaches_the_spec_first_workflow() -> None:
+    """For a non-trivial widget the home agent must first look up the
+    catalog shape (``get_widget_spec``) and then call ``add_widget`` with a
+    populated rippleSpec ``spec``. A chart needs a real ``data`` series — the
+    prompt must say so and carry one worked example so the agent does not
+    ship a bare stat tile when asked for a chart."""
+    from pocketpaw.ripple import HOME_POCKET_PROMPT
+
+    # The catalog-lookup step is named — the agent must not guess prop shapes.
+    assert "get_widget_spec" in HOME_POCKET_PROMPT
+    # The prompt teaches the chart-data contract explicitly.
+    assert "data" in HOME_POCKET_PROMPT
+    # A worked example of a populated chart widget is embedded.
+    assert "label" in HOME_POCKET_PROMPT and "value" in HOME_POCKET_PROMPT
+    # The example shows the spec is stored under the widget's ``spec`` key.
+    assert "spec" in HOME_POCKET_PROMPT
+
+
 def test_pocket_id_token_substitution() -> None:
     """The interaction prompt has a literal ``__POCKET_ID__`` token the
     caller substitutes via ``str.replace``. A naive ``str.format`` would

--- a/tests/cloud/test_pocket_prompts_single_source.py
+++ b/tests/cloud/test_pocket_prompts_single_source.py
@@ -131,6 +131,36 @@ def test_get_pocket_prompts_selects_by_backend() -> None:
         assert cli_interact is POCKET_INTERACTION_PROMPT_CLI
 
 
+def test_home_pocket_prompt_is_exported_and_focused() -> None:
+    """``HOME_POCKET_PROMPT`` is the home-surface analogue of the slim
+    interaction prompt. It must be re-exported from ``pocketpaw.ripple``,
+    name the home tools it actually uses (``add_widget``, ``get_pocket``),
+    and stay slim — no heavier "inside a dashboard" framing."""
+    from pocketpaw.ripple import (
+        HOME_POCKET_PROMPT,
+        POCKET_INTERACTION_PROMPT_MCP,
+    )
+
+    # Tagged block, same shape as the other pocket-mode prompts.
+    assert "<home-pocket>" in HOME_POCKET_PROMPT
+
+    # Teaches the agent the two tools the home surface actually uses.
+    assert "add_widget" in HOME_POCKET_PROMPT
+    assert "get_pocket" in HOME_POCKET_PROMPT
+
+    # Slim — the home-surface analogue of POCKET_INTERACTION_PROMPT, not a
+    # heavier framing. It must not be longer than the slim interaction
+    # prompt it mirrors.
+    assert len(HOME_POCKET_PROMPT) < len(POCKET_INTERACTION_PROMPT_MCP), (
+        "HOME_POCKET_PROMPT should stay slimmer than the interaction prompt"
+    )
+
+    # It must NOT carry the heavy specialist-delegation machinery — the
+    # home surface mutates widgets directly via add_widget.
+    assert "pocket_specialist__create" not in HOME_POCKET_PROMPT
+    assert "pocket_specialist__edit" not in HOME_POCKET_PROMPT
+
+
 def test_pocket_id_token_substitution() -> None:
     """The interaction prompt has a literal ``__POCKET_ID__`` token the
     caller substitutes via ``str.replace``. A naive ``str.format`` would

--- a/tests/ee/test_mcp_claude_sdk.py
+++ b/tests/ee/test_mcp_claude_sdk.py
@@ -5,6 +5,10 @@ Updated: 2026-05-21 — refactor/gate-planner-mcp. Expanded the
   is stripped even though it is opt-in rather than always-on. Added
   ``TestPlannerMCPGate`` covering the opt-in gate: the planner loads only
   when an injected ``ToolPolicy`` names it in ``mcp_servers_allow``.
+Updated: 2026-05-22 (#1174) — added ``TestMcpToolAllowlist``: the resolved
+  in-process MCP tool-id allowlist (``_collect_mcp_tool_ids``) includes the
+  cloud ``pocketpaw_pocket`` server's writable ``add_widget`` tool, so the
+  home-pocket agent on this backend can pin real widgets.
 
 All SDK imports are mocked.
 """
@@ -261,3 +265,39 @@ class TestPlannerMCPGate:
         with patch("pocketpaw.mcp.config.load_mcp_config", return_value=[]):
             result = sdk._get_mcp_servers()
         assert _PLANNER_MCP_SERVER_NAME not in result
+
+
+class TestMcpToolAllowlist:
+    """The in-process MCP tool-id allowlist the claude_agent_sdk backend
+    builds. An MCP tool is only callable when its id is on this list, so the
+    home-pocket agent's ``add_widget`` tool must appear here."""
+
+    def _make_sdk(self) -> ClaudeAgentSDK:
+        settings = Settings(anthropic_api_key="test-key", tool_profile="full")
+        with patch.object(ClaudeAgentSDK, "_initialize"):
+            sdk = ClaudeAgentSDK(settings)
+            sdk._sdk_available = False
+        return sdk
+
+    def test_allowlist_includes_writable_add_widget_tool(self):
+        """The resolved tool list carries the cloud ``add_widget`` MCP tool —
+        the home agent's widget-creation tool — alongside the read tools."""
+        from pocketpaw_ee.agent.mcp_servers.pockets import (
+            ADD_WIDGET_TOOL_ID,
+            GET_POCKET_TOOL_ID,
+        )
+
+        sdk = self._make_sdk()
+        ids = sdk._collect_mcp_tool_ids()
+        assert ADD_WIDGET_TOOL_ID in ids, (
+            "the writable add_widget tool must be on the allowlist or the home agent cannot call it"
+        )
+        # The read tools are still there — add_widget is additive.
+        assert GET_POCKET_TOOL_ID in ids
+
+    def test_allowlist_excludes_opt_in_planner_by_default(self):
+        """Opt-in servers stay off the allowlist unless the policy opts them
+        in — the loop the writable tool rides must keep that gate."""
+        sdk = self._make_sdk()
+        ids = sdk._collect_mcp_tool_ids()
+        assert not any(f"__{_PLANNER_MCP_SERVER_NAME}__" in t for t in ids)

--- a/tests/ee/test_mcp_pocket_add_widget.py
+++ b/tests/ee/test_mcp_pocket_add_widget.py
@@ -1,0 +1,194 @@
+# tests/ee/test_mcp_pocket_add_widget.py — the home agent's add_widget MCP tool.
+# Created: 2026-05-22 — TDD coverage for the writable widget-mutation tool on
+# the in-process ``pocketpaw_pocket`` MCP server (reachable by the
+# claude_agent_sdk backend). The tool lets the home-pocket agent pin a real
+# widget (chart, table, list, …) onto the home grid:
+#   1. The tool id is published on ``POCKET_TOOL_IDS`` so the claude_sdk
+#      allowlist auto-includes it (no callable tool without an allowlist
+#      entry).
+#   2. The tool accepts a chart widget with a populated ``data`` series and
+#      round-trips the rippleSpec ``spec`` through ``add_widget_for_agent``.
+#   3. A malformed widget spec (invented props) is rejected by manifest
+#      validation — the tool returns an error so the agent can retry.
+#   4. A ``type="native"`` widget skips manifest validation (no rippleSpec).
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Fake manifest declaring ``chart`` with the canonical ``variant``/``data``
+# props. A chart with ``series``/``xAxis`` (invented) trips an unknown-prop
+# warning — the same drift the pocket specialist guards against.
+_FAKE_MANIFEST = {
+    "schema": "ripple.manifest/v1",
+    "widgets": [
+        {"type": "chart", "props": {"variant": {}, "data": {}}},
+        {"type": "stat", "props": {"label": {}, "value": {}}},
+    ],
+}
+
+
+def _chart_spec() -> dict:
+    return {
+        "type": "chart",
+        "props": {
+            "variant": "bar",
+            "data": [
+                {"label": "Mon", "value": 1200},
+                {"label": "Tue", "value": 1850},
+                {"label": "Wed", "value": 1400},
+                {"label": "Thu", "value": 2100},
+                {"label": "Fri", "value": 2600},
+                {"label": "Sat", "value": 900},
+                {"label": "Sun", "value": 700},
+            ],
+        },
+    }
+
+
+def test_add_widget_tool_id_is_published_for_the_allowlist() -> None:
+    """The claude_sdk backend only calls an MCP tool whose id is on the
+    allowlist, and that allowlist is built from each provider's
+    ``tool_ids()``. The new add_widget tool id must be on
+    ``POCKET_TOOL_IDS`` so it is reachable."""
+    from pocketpaw_ee.agent.mcp_servers.pockets import (
+        ADD_WIDGET_TOOL_ID,
+        POCKET_TOOL_IDS,
+        SERVER_NAME,
+    )
+
+    assert ADD_WIDGET_TOOL_ID == f"mcp__{SERVER_NAME}__add_widget"
+    assert ADD_WIDGET_TOOL_ID in POCKET_TOOL_IDS
+
+
+def test_pocket_mcp_provider_advertises_add_widget_tool_id() -> None:
+    """The entry-point provider's ``tool_ids()`` feeds the claude_sdk
+    allowlist loop — the new id must come through it."""
+    from pocketpaw_ee.agent.mcp_servers.pockets import ADD_WIDGET_TOOL_ID
+    from pocketpaw_ee.extensions import CloudPocketMcpProvider
+
+    assert ADD_WIDGET_TOOL_ID in CloudPocketMcpProvider().tool_ids()
+
+
+@pytest.mark.asyncio
+async def test_add_widget_handler_accepts_chart_with_data_series() -> None:
+    """A chart widget with a real 7-point data series round-trips: the
+    handler validates the spec, calls ``add_widget_for_agent``, and reports
+    success."""
+    from pocketpaw_ee.agent.mcp_servers import pockets as pockets_mcp
+
+    captured: dict = {}
+
+    async def _fake_add(pocket_id: str, widget: dict) -> dict:
+        captured["pocket_id"] = pocket_id
+        captured["widget"] = widget
+        return {"ok": True, "pocket": {"_id": pocket_id, "widgets": [widget]}}
+
+    with (
+        patch.object(
+            pockets_mcp,
+            "_get_manifest_for_validation",
+            new=AsyncMock(return_value=_FAKE_MANIFEST),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.pockets.agent_context.add_widget_for_agent",
+            new=AsyncMock(side_effect=_fake_add),
+        ),
+    ):
+        out = await pockets_mcp._add_widget_handler(
+            {
+                "pocket_id": "home-1",
+                "widget": {
+                    "name": "7-day sales",
+                    "type": "chart",
+                    "icon": "trending-up",
+                    "spec": _chart_spec(),
+                },
+            }
+        )
+
+    assert not out.get("is_error"), out
+    assert captured["pocket_id"] == "home-1"
+    # The rippleSpec subtree is forwarded as the widget's ``spec``.
+    assert captured["widget"]["spec"]["type"] == "chart"
+    assert len(captured["widget"]["spec"]["props"]["data"]) == 7
+    body = json.loads(out["content"][0]["text"])
+    assert body["_id"] == "home-1"
+
+
+@pytest.mark.asyncio
+async def test_add_widget_handler_rejects_malformed_spec() -> None:
+    """A chart spec with invented props (``series``/``xAxis``) fails manifest
+    validation. The handler must return an error WITHOUT persisting, so the
+    agent can re-emit a corrected spec."""
+    from pocketpaw_ee.agent.mcp_servers import pockets as pockets_mcp
+
+    add_mock = AsyncMock(return_value={"ok": True, "pocket": {}})
+    with (
+        patch.object(
+            pockets_mcp,
+            "_get_manifest_for_validation",
+            new=AsyncMock(return_value=_FAKE_MANIFEST),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.pockets.agent_context.add_widget_for_agent",
+            new=add_mock,
+        ),
+    ):
+        out = await pockets_mcp._add_widget_handler(
+            {
+                "pocket_id": "home-1",
+                "widget": {
+                    "name": "bad chart",
+                    "type": "chart",
+                    "spec": {
+                        "type": "chart",
+                        "props": {"series": [], "xAxis": "day"},
+                    },
+                },
+            }
+        )
+
+    assert out.get("is_error") is True
+    # Nothing was persisted — validation gates the write.
+    add_mock.assert_not_awaited()
+    # The error names the offending props so the agent can fix them.
+    text = out["content"][0]["text"]
+    assert "series" in text or "xAxis" in text
+
+
+@pytest.mark.asyncio
+async def test_add_widget_handler_skips_validation_for_native_widget() -> None:
+    """A ``type="native"`` widget has no rippleSpec — manifest validation is
+    skipped and the widget persists straight through."""
+    from pocketpaw_ee.agent.mcp_servers import pockets as pockets_mcp
+
+    async def _fake_add(pocket_id: str, widget: dict) -> dict:
+        return {"ok": True, "pocket": {"_id": pocket_id, "widgets": [widget]}}
+
+    # No manifest mock — a native widget must not need it.
+    with patch(
+        "pocketpaw_ee.cloud.pockets.agent_context.add_widget_for_agent",
+        new=AsyncMock(side_effect=_fake_add),
+    ):
+        out = await pockets_mcp._add_widget_handler(
+            {
+                "pocket_id": "home-1",
+                "widget": {"name": "Mission · Tray", "type": "native", "icon": "inbox"},
+            }
+        )
+
+    assert not out.get("is_error"), out
+
+
+@pytest.mark.asyncio
+async def test_add_widget_handler_requires_pocket_id() -> None:
+    """The tool is pocket-scoped — without a ``pocket_id`` it errors instead
+    of writing to an unknown surface."""
+    from pocketpaw_ee.agent.mcp_servers import pockets as pockets_mcp
+
+    out = await pockets_mcp._add_widget_handler({"widget": {"name": "x", "type": "native"}})
+    assert out.get("is_error") is True

--- a/tests/ee/test_pocket_specialist.py
+++ b/tests/ee/test_pocket_specialist.py
@@ -22,16 +22,13 @@ def test_delegation_rule_points_at_mcp_tool():
     assert "subagent_type='pocket_specialist'" not in POCKET_DELEGATION_RULE
 
 
-def test_pocket_mcp_server_is_read_only():
-    """The pocket-context MCP surface exposes ONLY read tools. All mutation
-    tool ids must be gone — pocket writes flow through the
-    ``pocket_specialist__create`` / ``__edit`` tools, which run an isolated
-    specialist backend with its own StructuredTool wrappers.
+def test_widget_spec_mcp_server_is_read_only():
+    """The core ``pocketpaw_widgets`` server exposes ONLY read tools — it
+    serves the catalog/manifest, nothing mutable.
 
     The OSS-EE split (Phase 3b) split the old ``pocketpaw_pocket`` server in
-    two: ripple widget-spec tools (core ``pocketpaw_widgets``) and the cloud
-    pocket-context tools (EE ``pocketpaw_pocket``). Both must stay read-only.
-    """
+    two: ripple widget-spec tools (core ``pocketpaw_widgets``, this one) and
+    the cloud pocket-context tools (EE ``pocketpaw_pocket``)."""
     from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
 
     assert set(WIDGET_TOOL_IDS) == {
@@ -39,6 +36,14 @@ def test_pocket_mcp_server_is_read_only():
         "mcp__pocketpaw_widgets__get_inline_widget_help",
     }, f"drift in widget MCP tool surface: {set(WIDGET_TOOL_IDS)}"
 
+
+def test_pocket_mcp_server_surface():
+    """The cloud ``pocketpaw_pocket`` server exposes the two read tools plus
+    the writable ``add_widget`` tool — the home agent's widget-creation
+    path. rippleSpec *design* mutations still flow through the
+    ``pocket_specialist__create`` / ``__edit`` tools; ``add_widget`` only
+    appends a tile to a pocket's ``widgets[]`` array, a different surface.
+    """
     # The cloud pocket-context server is EE-only — skip when absent.
     try:
         from pocketpaw_ee.agent.mcp_servers.pockets import POCKET_TOOL_IDS
@@ -47,6 +52,7 @@ def test_pocket_mcp_server_is_read_only():
     assert set(POCKET_TOOL_IDS) == {
         "mcp__pocketpaw_pocket__get_pocket",
         "mcp__pocketpaw_pocket__list_pockets",
+        "mcp__pocketpaw_pocket__add_widget",
     }, f"drift in pocket MCP tool surface: {set(POCKET_TOOL_IDS)}"
 
 


### PR DESCRIPTION
## What this does

Backend foundation for moving the home page off browser localStorage and onto a Pocket — the "home pocket". The frontend renderer (`HomeWidgetGrid.svelte`) already keys on a `NATIVE_WIDGETS` map; this PR gives the home page a server-side pocket to ride, with realtime `PocketUpdated` events and the existing widget paths for free.

The client migration is out of scope here. It ships separately against `paw-enterprise`.

## Changes

- **`ensure_home_pocket(workspace_id, user_id)`** in `pockets/service.py` — idempotent. If the user's `home_pocket_id` setting points at a pocket that still exists and they own, it returns that pocket. Otherwise it creates an empty `type="home"` private pocket (`name="Home"`, `widgets=[]`), persists the new id back, and returns it. A stale `home_pocket_id` (pocket deleted) re-provisions cleanly. Provisioning seeds no widgets — the client owns default widgets. Returns a `(pocket_dict, created)` tuple.
- **`GET /api/v1/pockets/home`** — resolves-or-provisions via `ensure_home_pocket` and returns `{pocket_id, pocket, created}`, typed with the `HomePocketResponse` DTO. `pocket` is the full wire dict (rippleSpec + widgets). `created` is `True` only when the call just provisioned a brand-new home pocket. Declared ahead of `GET /{pocket_id}` so the static `/home` segment wins the route match.
- **`home` pocket type** — a recognized value on the free-form pocket `type` field. It behaves like an ordinary private pocket; the type is just a marker the home route and frontend key on.
- **`native` widget type** — a `type="native"` widget carries a `name` the frontend uses to resolve a built-in Svelte component, plus `icon`/`color` for tile chrome. Native widgets have no rippleSpec, so manifest validation — which only walks rippleSpec trees, never the `widgets[]` array — never touches them. They round-trip through `add_widget` and `agent_add_widget` unchanged.
- **`home_pocket_id`** — stored on the `User` record. Read via `auth_service.get_home_pocket_id`; written via `auth_service.claim_home_pocket_id` so `models.user` writes stay inside the auth entity, per the cloud chokepoint rules.

## Typed response model

`GET /pockets/home` is typed with a `HomePocketResponse` DTO (`pockets/dto.py`) — `{pocket_id: str, pocket: dict, created: bool}` — so the route has a real OpenAPI schema instead of an empty `{}`. The `pocket` field is a free-form `dict`: the wire dict is camelCase with `_id` / `rippleSpec`, not the snake_case `PocketResponse` shape, and the client builds against the wire dict verbatim. The emitted JSON is byte-identical to the previous bare-dict response.

## The `created` flag

`created` tells the client whether this call provisioned a brand-new home pocket (`true`) or returned one that already existed (`false`). The client uses it to gate one-time work: seeding the default native widgets and migrating any legacy `localStorage` widgets happens only on `created: true`. A returning user who deliberately cleared their home grid never gets defaults re-seeded.

## Provision-race safety

`ensure_home_pocket` persists the new `home_pocket_id` with an atomic compare-and-swap (`auth_service.claim_home_pocket_id` → a single `find_one_and_update`, the same single-writer-claim pattern `tasks/service.py` uses), not a plain read-then-write. If two concurrent first-login `/home` calls both read `home_pocket_id is None` and both insert a pocket, only one wins the swap. The loser deletes its own orphan pocket, adopts the winner's, and returns it with `created=False`. The home page stays single-pocket even under a provision race.

## Response and entry shapes

The client PR will build against these.

`GET /api/v1/pockets/home` returns:

```json
{
  "pocket_id": "<id>",
  "pocket": { ...full pocket wire dict... },
  "created": true
}
```

`created` is `true` on a fresh provision, `false` when an existing home pocket is returned.

A native widget entry inside `pocket.widgets[]`:

```json
{
  "_id": "<widget id>",
  "name": "Mission · Tray",
  "type": "native",
  "icon": "inbox",
  "color": "#0A84FF",
  "span": "col-span-1",
  "dataSourceType": "static",
  "config": {},
  "props": {},
  "data": null,
  "assignedAgent": null,
  "position": { "row": 0, "col": 0 }
}
```

`name` is the frontend `NATIVE_WIDGETS` lookup key. `icon`/`color` feed the tile header.

## Tests

TDD — tests written first, all green:

- `tests/cloud/test_home_pocket.py` — `ensure_home_pocket` provisions an empty home pocket and reports `created=True`, is idempotent (second call returns `created=False`, no double-provision), re-provisions on a stale setting, `home` type round-trips, native widgets round-trip through `add_widget` and `agent_add_widget` with no manifest rejection. `claim_home_pocket_id` accepts a matching `expected` and rejects a stale one. Concurrent `ensure_home_pocket` calls (2 and 5 callers) converge on a single home pocket with no orphan.
- `tests/cloud/test_home_pocket_route.py` — the `/home` route returns `{pocket_id, pocket, created}`, surfaces `created` for both paths, is matched ahead of `/{pocket_id}`, the `HomePocketResponse` DTO validates and rejects missing fields, and the route resolves to a non-empty OpenAPI schema.

`uv run --group ee pytest` on the pockets + auth test modules is green (110 passed across the touched + related modules). `ruff check` and `ruff format --check` clean. Both import-linter contracts (OSS-EE boundary, cloud chokepoints) kept.

## Docs

No hand-authored doc enumerates the cloud pocket types or the `/api/v1/pockets/*` REST surface — the `docs/wiki/` articles are auto-generated and rebuild on commit via the kb-rebuild hook. The new type, endpoint, `created` field, `HomePocketResponse` DTO, and provision-race behavior are documented in the file-top comment blocks on `models/pocket.py`, `pockets/dto.py`, `pockets/domain.py`, `pockets/router.py`, `pockets/service.py`, and `auth/service.py`.


---

## Home-pocket agent behavior: `HOME_POCKET_PROMPT`

A follow-up commit on this branch makes the chat agent behave correctly when it runs inside the home pocket.

`HOME_POCKET_PROMPT` is a new prompt constant in `src/pocketpaw/ripple/_pockets.py`, re-exported from the `pocketpaw.ripple` package next to `POCKET_INTERACTION_PROMPT`, `POCKET_CREATION_PROMPT`, and `POCKET_DELEGATION_RULE`. It is the home-page version of `POCKET_INTERACTION_PROMPT` — slim, one `<home-pocket>` block. It tells the agent that it is on the user's home page, that the home grid is a set of pinned widgets the user curates, and that when the user asks to add or show a specific widget ("show me revenue", "add a task list", "track active agents") it should call the `add_widget` tool with a widget spec from the Ripple catalog. For ordinary questions it just answers, no `add_widget` call. It reads the current grid via `get_pocket`.

The injection lives in `build_behavior_instructions()` in `ee/pocketpaw_ee/cloud/chat/agent_service.py`. `ScopeContext` now carries the anchored pocket's `pocket_type`, populated by `_resolve_pocket` and `_resolve_session`. When that type is `"home"`, `build_behavior_instructions` appends `HOME_POCKET_PROMPT` after whichever pocket prompt the existing branch already picked. The discriminator is the pocket type, not a settings id, and the injection works the same across every backend.

The prompt constant is OSS (`src/pocketpaw/ripple/`); the injection is EE (`ee/pocketpaw_ee/`). EE importing from OSS is the allowed direction, so the import-linter OSS-EE contract stays kept.

This is an internal change to chat prompt assembly. No REST or CLI surface changed, so nothing in `api-reference.md` or `cli-reference.md` needs to move. The new constant and the `pocket_type` field are documented in the file-top comment blocks of the files they touch.

### Tests for this commit

Tests were written first and failed, then the implementation made them pass.

- `tests/cloud/test_pocket_prompts_single_source.py` checks that `HOME_POCKET_PROMPT` is re-exported from `pocketpaw.ripple`, names the `add_widget` and `get_pocket` tools, stays shorter than the interaction prompt it mirrors, and carries no specialist-delegation machinery.
- `tests/cloud/test_agent_service_tools_context.py` checks that `build_behavior_instructions` injects `HOME_POCKET_PROMPT` for a `type="home"` pocket scope, leaves it out for a non-home pocket, and injects it on both MCP and CLI backends.

54 tests across the affected agent_service and ripple-prompt modules pass, and the wider pocket-specialist suite (133 tests) passes too. `ruff check` and `ruff format --check` are clean.



---

## Home-pocket agent: a real add_widget tool

A follow-up commit fixes a bug: the home chat agent created weak widgets. Asked for a 7-day sales chart, it pinned a bare stat tile. Three things were wrong, and this commit fixes all three.

### The add_widget tool was a phantom

`HOME_POCKET_PROMPT` told the agent to call an `add_widget` tool. For the default `claude_agent_sdk` backend, no such tool existed. The cloud pocket MCP server was read-only, and the only writable widget path was the CLI bridge, which the SDK backend never reaches.

This commit adds a writable `add_widget` tool to the in-process `pocketpaw_pocket` MCP server, next to the existing `get_pocket` / `list_pockets` read tools. Its tool id (`mcp__pocketpaw_pocket__add_widget`) is published on `POCKET_TOOL_IDS`, so it flows through the same provider allowlist loop every other in-process MCP tool uses. That loop is now extracted into `_collect_mcp_tool_ids` on the Claude SDK backend. The tool wraps the existing `add_widget_for_agent` helper, so it inherits the per-stream workspace/user identity, the access-control checks, and the `PocketUpdated` SSE push for free.

The tool is pocket-scoped. It takes a `pocket_id` and a `widget` object with `name`, `type` (the Ripple catalog widget type, e.g. `chart`, `table`, `stat`, `list`, `kanban`), optional `icon`/`color`, and a `spec`, which is a Ripple rippleSpec subtree for the tile.

### Widgets gained a spec field

The home grid renders a `widgets[]` entry from its `spec`. Until now widgets had no `spec` field. This commit adds an optional `spec` to the `Widget` Beanie model, the domain dataclass, and the wire dict. It threads through `_build_widget_doc`, `_widget_to_domain`, `_widget_to_wire`, the REST `add_widget`, and `agent_update_widget`. Native and legacy widgets leave it `None`.

### Specs are manifest-validated

When `add_widget` gets a widget with a rippleSpec `spec`, it validates the spec with `validate_against_manifest`, the same check the pocket specialist runs. On a failure it returns a clear error naming the offending props, so the agent can re-emit a corrected spec without persisting bad data. `type="native"` widgets have no rippleSpec and skip validation.

### The contradiction is resolved

`HOME_POCKET_PROMPT` and `POCKET_DELEGATION_RULE` were both injected into the home agent's prompt and flatly contradicted each other. One said "call `add_widget`"; the other said "never call `add_widget`, delegate to the pocket specialist". `build_behavior_instructions` no longer emits `POCKET_DELEGATION_RULE` (nor the heavy interaction prompt) for a `type="home"` scope. The home agent now gets one consistent widget-creation instruction.

`HOME_POCKET_PROMPT` itself is rewritten to drive the now-real tool. For any non-trivial widget it tells the agent to call `get_widget_spec` for the widget type first to get the `data`/`props` shape, then call `add_widget` with a fully-populated spec. A chart has to carry a real data series, seven `{label, value}` points for a 7-day chart, never an empty array. The prompt carries one worked chart example.

### Tests for this commit

Tests written first, all green. The `add_widget` tool round-trips a chart with a 7-point data series and rejects a malformed spec. `build_behavior_instructions` for a `type="home"` scope omits `POCKET_DELEGATION_RULE` and includes the rewritten prompt. The resolved tool list for the `claude_agent_sdk` backend includes the new tool. 435 tests across the affected modules pass. `ruff` and the OSS-EE / cloud-chokepoint import-linter contracts stay clean.

### Client follow-up

The paw-enterprise `HomeWidgetGrid` already renders a `widgets[]` entry from `widget.spec` when present, so no client change is needed to display an agent-added chart. The default-widget seeding and `localStorage` migration the client owns are unaffected.
