### PR TITLE
Stabilize agent-driven pocket editing

### DIFF
--- a/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
@@ -16,6 +16,11 @@
 # create does. Edit was previously asymmetric — it always spawned a
 # backend and ignored agent mode, crashing Claude Code deployments that
 # have no ANTHROPIC_API_KEY.
+# Modified: 2026-05-21 — ``_apply_ops`` no longer reports
+# ``ok=True, action="applied"`` when every supplied op was rejected /
+# unknown (zero ops actually applied). That silent-failure state — the
+# agent-mode root-replace symptom — now returns ``ok=False,
+# action="failed"`` with the reason in ``error`` + ``warnings``.
 """Mode-specific adapters for the pocket specialist's create + edit endpoints.
 
 The MCP tool handlers (``mcp_tool._create_handler`` / ``_edit_handler``)
@@ -619,10 +624,18 @@ def _edit_kit_response(input: Any, *, started: float) -> Any:
         "granular_ops": _GRANULAR_EDIT_OPS,
         "op_shape": (
             "Each op is ``{op: <name>, args: {...}}``. ``op`` is one of "
-            "``granular_ops`` above; ``args`` are that op's arguments "
-            "(e.g. set_state takes ``{path, value}``, set_node_prop takes "
-            "``{node_id, prop, value}``, add_node takes "
-            "``{parent_id, index, node}``). Apply the SMALLEST set of ops "
+            "``granular_ops`` above. Exact args per op: "
+            "set_state ``{path, value}``; "
+            "set_node_prop ``{node_id, prop, value}``; "
+            "add_node ``{parent_id, spec, after_id?, index?}`` — ``spec`` is "
+            "the new UINode object (NOT ``node``); position it with "
+            "``after_id`` (a sibling node id) or ``index`` (0-based slot), "
+            "else it appends; "
+            "replace_node ``{node_id, spec}``; "
+            "move_node ``{node_id, parent_id, after_id?}``; "
+            "remove_node ``{node_id}``; "
+            "the prop-array ops take ``{node_id, prop, match}`` (plus "
+            "``value`` for set / append). Apply the SMALLEST set of ops "
             "that satisfies the intent."
         ),
         "next_step": (
@@ -723,7 +736,23 @@ async def _apply_ops(input: Any, *, started: float) -> Any:
     for bad in unknown_ops:
         warnings.append(f"Edit op '{bad}' is not a supported granular op and was skipped.")
 
-    success = error_msg is None
+    # Success accounting. A raised exception (``error_msg``) is a hard
+    # failure. But a run can also "fail silently": every op the chat
+    # agent supplied got rejected by the service or was unknown, so
+    # ZERO ops actually applied. That state must NOT report
+    # ``ok=True, action="applied"`` — the canvas never changed, and the
+    # caller would believe the edit landed. This was the agent-mode
+    # root-replace symptom: ``replace_node`` on the root was rejected by
+    # the service, the rejection went into ``warnings``, but the run
+    # still claimed ``applied``. Mirrors the #1163 contract — a run that
+    # changed nothing is not a success.
+    nothing_applied = bool(input.ops) and not ops
+    success = error_msg is None and not nothing_applied
+    if nothing_applied and error_msg is None:
+        error_msg = (
+            "No edit ops were applied — every supplied op was rejected or "
+            "unsupported. See warnings for the per-op reasons."
+        )
     logger.info(
         "[pocket-specialist:edit] agent-mode apply complete: pocket_id=%s "
         "ops=%d rejected=%d unknown=%d success=%s duration=%dms",

--- a/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
@@ -565,18 +565,33 @@ class _AddNodeArgs(BaseModel):
     parent_id: str
     spec: dict[str, Any] = Field(..., description="UINode to insert.")
     after_id: str | None = Field(default=None, description="Insert after this sibling.")
+    index: int | None = Field(
+        default=None,
+        description=(
+            "Insert at this 0-based position among the parent's children. "
+            "Takes precedence over after_id; clamped to the child count."
+        ),
+    )
 
 
 def make_add_node_tool(*, pocket_id: str, capture: dict[str, Any] | None = None) -> StructuredTool:
     """Add a new widget under a parent."""
 
     async def _run(
-        parent_id: str, spec: dict[str, Any], after_id: str | None = None
+        parent_id: str,
+        spec: dict[str, Any],
+        after_id: str | None = None,
+        index: int | None = None,
     ) -> dict[str, Any]:
         from pocketpaw_ee.cloud.pockets.agent_context import add_node_for_agent
 
-        result = await add_node_for_agent(pocket_id, parent_id, spec, after_id)
-        _capture_op(capture, "add_node", {"parent_id": parent_id, "after_id": after_id}, result)
+        result = await add_node_for_agent(pocket_id, parent_id, spec, after_id, index)
+        _capture_op(
+            capture,
+            "add_node",
+            {"parent_id": parent_id, "after_id": after_id, "index": index},
+            result,
+        )
         return result
 
     return StructuredTool.from_function(
@@ -584,8 +599,9 @@ def make_add_node_tool(*, pocket_id: str, capture: dict[str, Any] | None = None)
         name="add_node",
         description=(
             "Insert a new widget as a child of `parent_id`. Pass `spec` as "
-            "a UINode object. Use `after_id` to position after a specific "
-            "sibling; omit to append. Returns the new node with id assigned."
+            "a UINode object. Position it with `index` (0-based slot) or "
+            "`after_id` (after a specific sibling); omit both to append. "
+            "Returns the new node with id assigned."
         ),
         args_schema=_AddNodeArgs,
     )
@@ -622,21 +638,23 @@ def make_replace_node_tool(
 
 class _MoveNodeArgs(BaseModel):
     node_id: str
-    new_parent_id: str
+    # `parent_id` for consistency with add_node — was `new_parent_id`, an
+    # asymmetry the chat agent kept tripping on.
+    parent_id: str
     after_id: str | None = None
 
 
 def make_move_node_tool(*, pocket_id: str, capture: dict[str, Any] | None = None) -> StructuredTool:
     """Move a subtree to a new parent / position."""
 
-    async def _run(node_id: str, new_parent_id: str, after_id: str | None = None) -> dict[str, Any]:
+    async def _run(node_id: str, parent_id: str, after_id: str | None = None) -> dict[str, Any]:
         from pocketpaw_ee.cloud.pockets.agent_context import move_node_for_agent
 
-        result = await move_node_for_agent(pocket_id, node_id, new_parent_id, after_id)
+        result = await move_node_for_agent(pocket_id, node_id, parent_id, after_id)
         _capture_op(
             capture,
             "move_node",
-            {"node_id": node_id, "new_parent_id": new_parent_id, "after_id": after_id},
+            {"node_id": node_id, "parent_id": parent_id, "after_id": after_id},
             result,
         )
         return result

--- a/ee/pocketpaw_ee/cloud/pockets/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/pockets/agent_context.py
@@ -440,10 +440,11 @@ async def add_node_for_agent(
     parent_id: str,
     spec: dict[str, Any],
     after_id: str | None = None,
+    index: int | None = None,
 ) -> dict[str, Any]:
     """Insert a new node into the pocket's UI tree."""
     result, err = await pockets_service.agent_add_node(
-        pocket_id, parent_id=parent_id, spec=spec, after_id=after_id
+        pocket_id, parent_id=parent_id, spec=spec, after_id=after_id, index=index
     )
     if err is not None or result is None:
         return {"ok": False, "error": err or "add_node failed"}
@@ -455,6 +456,7 @@ async def add_node_for_agent(
         {
             "parent_id": parent_id,
             "after_id": after_id,
+            "index": index,
             "subtree": subtree,
         },
     )

--- a/ee/pocketpaw_ee/cloud/pockets/prop_arrays.py
+++ b/ee/pocketpaw_ee/cloud/pockets/prop_arrays.py
@@ -1,28 +1,31 @@
 # prop_arrays.py — closed allowlist of widget prop-arrays the Tier-2
 # array-item edit ops are permitted to touch.
 # Created: 2026-05-14. Reworked onto the pocketpaw_ee layout from PR #1106.
+# Changes: 2026-05-21 — regenerated from the @ripple-ui/svelte widget
+# manifest. Now covers every widget with an object-element array prop
+# (63 widgets / 101 props, was 9). Fixes drift: the old hand-written
+# table had `tabs.items` / `form-layout.fields`, but the manifest's real
+# props are `tabs.tabs` / `form-layout.sections`; `feed` / `nav` no
+# longer exist as widget types.
 """Closed allowlist of ``(widget_type, prop_name)`` pairs that support the
 Tier-2 array-element ops (``set_prop_array_item`` /
 ``append_prop_array_item`` / ``remove_prop_array_item``).
 
-Why a closed list:
+What's enrolled: every widget prop in the renderer manifest whose type is
+an array of OBJECTS — the row-style content collections an agent edits
+item-by-item (``table.rows``, ``chart.data``, ``calendar.events``,
+``checklist-layout.items``, ``kanban.columns`` …). Scalar arrays
+(``chart.colors`` is ``string[]``, ``kbd.keys``, heatmap axis-label
+lists) are deliberately excluded — there is no record to merge into.
 
-  * The renderer's manifest already enumerates every prop a widget
-    accepts, but only a small subset of those are user-editable
-    arrays the agent should surgically poke at item-level. Many props
-    happen to be lists (e.g. ``chart.colors``) but aren't intended
-    for row-style edits.
-  * Locking the surface here means a typo (``cloud_set_prop_array_item
-    target=stat prop=value``) is rejected up-front with a clear error,
-    rather than silently mangling a scalar prop.
+Why a closed list rather than a live manifest lookup: ``is_allowed`` is a
+hot, synchronous check; the manifest is fetched async with a TTL. A
+static table avoids threading the manifest through every call site. The
+cost is that this must be regenerated when the widget catalog changes.
 
-Keep this in sync with:
-
-  * ``backend/docs/plans/2026-05-12-pocket-edit-api-design.md`` (Tier 2 table)
-  * the edit-specialist prompt examples in ``pocketpaw.ripple._pockets``
-
-Adding a new widget? Add the row here AND extend the edit-specialist
-prompt's cheatsheet so the agent knows the prop is targetable.
+Regenerating: for each widget in the ``@ripple-ui/svelte`` manifest,
+enroll each prop whose ``type`` denotes an array of objects — the type
+string contains ``Array<`` or ``[]`` AND ``{`` or ``Record<``.
 """
 
 from __future__ import annotations
@@ -30,15 +33,69 @@ from __future__ import annotations
 from typing import Final
 
 _ALLOWED: Final[dict[str, frozenset[str]]] = {
-    "chart": frozenset({"data"}),
-    "table": frozenset({"rows", "columns"}),
-    "kanban": frozenset({"columns"}),
+    "accordion": frozenset({"items"}),
+    "analytics-dashboard": frozenset({"secondaryMetrics", "topItems"}),
+    "audit-log": frozenset({"entries"}),
+    "avatar-group": frozenset({"users"}),
+    "breadcrumb": frozenset({"items"}),
+    "bulk-action-bar": frozenset({"actions"}),
+    "c4": frozenset({"diagram"}),
     "calendar": frozenset({"events"}),
-    "feed": frozenset({"items"}),
-    "tabs": frozenset({"items"}),
-    "nav": frozenset({"items"}),
+    "chart": frozenset({"data"}),
+    "checklist-layout": frozenset({"items"}),
+    "coachmark": frozenset({"steps"}),
+    "combobox": frozenset({"options"}),
+    "command-palette": frozenset({"commands"}),
+    "comment-thread": frozenset({"comments"}),
+    "comparison-layout": frozenset({"features", "items"}),
+    "comparison-table": frozenset({"columns", "rows"}),
+    "context-menu": frozenset({"items"}),
+    "data-grid": frozenset({"columns", "rows"}),
+    "definition-list": frozenset({"items"}),
+    "dropdown-menu": frozenset({"items"}),
+    "entity-detail": frozenset({"actions", "kpis", "meta", "tags"}),
+    "exec-dashboard": frozenset({"actions", "activity", "kpis", "primaryChart", "table"}),
+    "filter-bar": frozenset({"options"}),
+    "form-layout": frozenset({"sections"}),
+    "funnel": frozenset({"data"}),
+    "gantt": frozenset({"tasks"}),
+    "heatmap": frozenset({"cells"}),
+    "invoice-layout": frozenset({"actions", "lines", "paymentMethods", "summary"}),
+    "invoice-lines": frozenset({"lines", "summary"}),
+    "kanban": frozenset({"columns", "value"}),
+    "kv-table": frozenset({"rows"}),
+    "map": frozenset({"markers", "paths", "polygons", "trackers"}),
+    "master-detail": frozenset({"items"}),
+    "multi-select": frozenset({"options"}),
+    "notification-center": frozenset({"value"}),
+    "ops-dashboard": frozenset({"deploys", "incidents", "metrics", "services"}),
+    "order-status": frozenset({"actions", "events", "steps"}),
+    "people-picker": frozenset({"people"}),
+    "permission-matrix": frozenset({"permissions", "roles"}),
+    "pipeline-dashboard": frozenset({"conversion", "deals", "funnel", "leaderboard", "ticker"}),
+    "pricing-table": frozenset({"tiers"}),
+    "project-dashboard": frozenset({"burndown", "meta", "milestones", "team", "updates"}),
+    "radio-group": frozenset({"options"}),
+    "report-layout": frozenset({"actions", "meta"}),
+    "sankey": frozenset({"links", "nodes"}),
+    "saved-views": frozenset({"views"}),
+    "search": frozenset({"results"}),
+    "segmented": frozenset({"options"}),
     "select": frozenset({"options"}),
-    "form-layout": frozenset({"fields"}),
+    "settings-list": frozenset({"items"}),
+    "sidebar": frozenset({"items"}),
+    "sources-bar": frozenset({"sources"}),
+    "steps": frozenset({"steps"}),
+    "table": frozenset({"columns", "rows"}),
+    "tabs": frozenset({"tabs"}),
+    "terminal": frozenset({"lines"}),
+    "ticker": frozenset({"items"}),
+    "timeline": frozenset({"events"}),
+    "tree": frozenset({"nodes"}),
+    "tree-table": frozenset({"columns", "rows"}),
+    "treemap": frozenset({"data"}),
+    "wizard-layout": frozenset({"steps"}),
+    "workflow": frozenset({"edges", "nodes"}),
 }
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -1135,6 +1135,7 @@ async def agent_add_node(
     parent_id: str,
     spec: dict[str, Any],
     after_id: str | None = None,
+    index: int | None = None,
 ) -> tuple[dict | None, str | None]:
     """Insert ``spec`` as a child of ``parent_id`` (after ``after_id`` or
     appended). The new node's id is assigned if absent.
@@ -1159,7 +1160,7 @@ async def agent_add_node(
         # Make sure any nested children also have ids.
         spec_ops.ensure_ids(new_node)
         try:
-            spec_ops.insert_child(parent, new_node, after_id=after_id)
+            spec_ops.insert_child(parent, new_node, after_id=after_id, index=index)
         except ValueError as exc:
             return None, str(exc)
         if doc.rippleSpec is not None:

--- a/ee/pocketpaw_ee/cloud/pockets/spec_ops.py
+++ b/ee/pocketpaw_ee/cloud/pockets/spec_ops.py
@@ -136,10 +136,13 @@ def insert_child(
     child: dict[str, Any],
     *,
     after_id: str | None = None,
+    index: int | None = None,
     child_key: str = "children",
 ) -> None:
-    """Insert ``child`` into ``parent[child_key]``. If ``after_id`` is
-    given, insert immediately after that sibling; otherwise append.
+    """Insert ``child`` into ``parent[child_key]``. If ``index`` is given,
+    insert at that 0-based position (clamped to the list bounds). Else if
+    ``after_id`` is given, insert immediately after that sibling.
+    Otherwise append.
 
     Raises ``ValueError`` if ``after_id`` is given but not found among
     siblings, or if ``parent`` is not a container (i.e. its existing
@@ -150,6 +153,12 @@ def insert_child(
         existing = parent[child_key]
     if not isinstance(existing, list):
         raise ValueError(f"parent {parent.get('id', '<?>')} has non-list '{child_key}'")
+
+    if index is not None:
+        # Clamp — an out-of-range index from the agent lands at the
+        # nearest valid slot rather than raising.
+        existing.insert(max(0, min(index, len(existing))), child)
+        return
 
     if after_id is None:
         existing.append(child)
@@ -170,11 +179,24 @@ def replace_node(
     id. Returns the OLD subtree (the caller stores it as the inverse for
     undo).
 
-    Raises ``ValueError`` if ``target_id`` isn't found or if it points
-    at the root (replacing the root is conceptually ``update_pocket``).
+    When ``target_id`` is the root node, the whole tree is swapped:
+    ``root`` is mutated in place to become ``replacement``. This is how a
+    single-widget pocket gains a container at the root — e.g. wrapping a
+    bare ``project-dashboard`` root in a ``flex`` so a sibling section can
+    be added next to it.
+
+    Raises ``ValueError`` only if ``target_id`` isn't found.
     """
     if root.get("id") == target_id:
-        raise ValueError("cannot replace the root via replace_node; use update_pocket")
+        # Root replacement — there is no parent. Mutate the root dict in
+        # place so callers holding a reference to it (doc.rippleSpec.ui)
+        # see the swap. Preserve the root id when the replacement omits one.
+        old = dict(root)
+        if not is_valid_id(replacement.get("id")):
+            replacement["id"] = old.get("id") or new_node_id()
+        root.clear()
+        root.update(replacement)
+        return old
     loc = find_parent(root, target_id)
     if loc is None:
         raise ValueError(f"no node with id {target_id!r}")

--- a/tests/cloud/test_pocket_granular_ops.py
+++ b/tests/cloud/test_pocket_granular_ops.py
@@ -733,18 +733,18 @@ class TestAppendPropArrayItem:
 
     @pytest.mark.asyncio
     async def test_creates_empty_array_if_missing(self, fake_doc):
-        feed = {"id": "n_feed0001", "type": "feed", "props": {}}
-        fake_doc.rippleSpec["ui"]["children"].append(feed)
+        node = {"id": "n_node0001", "type": "checklist-layout", "props": {}}
+        fake_doc.rippleSpec["ui"]["children"].append(node)
         ctx, _ = _patches(fake_doc)
         with ctx:
             result, err = await pocket_service.agent_append_prop_array_item(
                 fake_doc.id,
-                node_id="n_feed0001",
+                node_id="n_node0001",
                 prop="items",
                 value={"text": "Hi"},
             )
         assert err is None
-        assert feed["props"]["items"] == [{"text": "Hi"}]
+        assert node["props"]["items"] == [{"text": "Hi"}]
         assert result["item_index"] == 0
 
     @pytest.mark.asyncio

--- a/tests/cloud/test_pocket_mutation_sse.py
+++ b/tests/cloud/test_pocket_mutation_sse.py
@@ -1,0 +1,100 @@
+# tests/cloud/test_pocket_mutation_sse.py
+# Created: 2026-05-21 — diagnostic for the "canvas doesn't update, I have
+# to refresh" bug. Verifies that a successful agent-mode edit pushes a
+# ``pocket_mutation`` SSE event onto the active sink — the event the
+# paw-enterprise canvas re-renders from.
+"""Does an agent-mode edit emit the pocket_mutation SSE event?"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+
+async def _make_flex_pocket() -> Any:
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    spec = {
+        "version": "1.0",
+        "ui": {
+            "id": "n_root0000",
+            "type": "flex",
+            "props": {"direction": "column"},
+            "children": [
+                {"id": "n_head0000", "type": "heading", "props": {"text": "Hi"}},
+            ],
+        },
+    }
+    doc = Pocket(workspace="w1", name="SSE", owner="u1", visibility="workspace", rippleSpec=spec)
+    await doc.insert()
+    return doc
+
+
+@pytest.fixture
+def agent_identity():
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_agent_identity,
+        detach_agent_identity,
+    )
+
+    tokens = attach_agent_identity(workspace_id="w1", user_id="u1")
+    try:
+        yield
+    finally:
+        detach_agent_identity(tokens)
+
+
+@pytest.mark.asyncio
+async def test_agent_mode_edit_pushes_pocket_mutation(mongo_db, agent_identity):
+    """A successful agent-mode add_node edit must push a ``pocket_mutation``
+    event onto the active SSE sink — that is what the canvas re-renders
+    from. If this fails, the canvas never updates and the user must
+    refresh (the live-update bug)."""
+    from pocketpaw_ee.agent.pocket_specialist.adapters import EditAgentModeAdapter
+    from pocketpaw_ee.agent.pocket_specialist.runtime import PocketSpecialistEditInput
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_sse_event_sink,
+        detach_sse_event_sink,
+    )
+
+    from pocketpaw.config import Settings
+
+    doc = await _make_flex_pocket()
+    pocket_id = str(doc.id)
+
+    sink: asyncio.Queue = asyncio.Queue()
+    token = attach_sse_event_sink(sink)
+    try:
+        out = await EditAgentModeAdapter().edit(
+            PocketSpecialistEditInput(
+                pocket_id=pocket_id,
+                intent="add a stat tile",
+                ops=[
+                    {
+                        "op": "add_node",
+                        "args": {
+                            "parent_id": "n_root0000",
+                            "spec": {"type": "stat", "props": {"value": "42"}},
+                        },
+                    }
+                ],
+            ),
+            workspace_id="w1",
+            user_id="u1",
+            settings=Settings(),
+        )
+    finally:
+        detach_sse_event_sink(token)
+
+    assert out.ok is True, f"edit failed: {out.error} / {out.warnings}"
+
+    events: list[tuple[str, dict]] = []
+    while not sink.empty():
+        events.append(sink.get_nowait())
+    names = [n for n, _ in events]
+    assert "pocket_mutation" in names, (
+        "agent-mode edit applied an op but pushed NO pocket_mutation SSE "
+        f"event — the canvas cannot update live. Events seen: {names}"
+    )

--- a/tests/cloud/test_pocket_root_replace.py
+++ b/tests/cloud/test_pocket_root_replace.py
@@ -1,0 +1,290 @@
+# tests/cloud/test_pocket_root_replace.py
+# Created: 2026-05-21 — reproduction + regression coverage for the
+# agent-mode root-replace bug: calling ``replace_node`` on the ROOT node
+# of a pocket reported ``ok=true, action="applied"`` but the swap did
+# not persist.
+#
+# The reproduction uses the REAL Beanie doc (mongomock via the
+# ``mongo_db`` fixture) so it exercises genuine ``doc.save()`` and a real
+# re-fetch from the database — the in-memory fake doc used by
+# ``test_pocket_granular_ops.py`` shares one Python object, so a "swap
+# lost on persist" gap could never surface there.
+#
+# Two fixes are covered here:
+#   1. ``spec_ops.replace_node`` now handles the root by mutating it in
+#      place (``root.clear()/update()``) instead of raising — the
+#      partially-applied fix this task kept.
+#   2. ``adapters._apply_ops`` no longer reports ``ok=True,
+#      action="applied"`` when ZERO ops actually applied. Before the
+#      fix, the root ``replace_node`` op was rejected by the service,
+#      the rejection went into ``warnings``, and the run still claimed
+#      ``applied`` — the silent failure the captain observed. A run
+#      whose only op was rejected now returns ``ok=False,
+#      action="failed"``.
+"""Regression tests for replacing the ROOT node of a pocket's UI tree."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pocket_service
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_bare_dashboard_pocket() -> Any:
+    """Insert a real Pocket whose UI root is a single bare
+    ``project-dashboard`` — the exact shape the bug report names: a
+    single-widget pocket that needs its root wrapped in a ``flex`` so a
+    sibling section can be added beside it.
+    """
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    spec = {
+        "version": "1.0",
+        "lifecycle": {"type": "persistent", "id": "pocket-abc123"},
+        "title": "Delivery",
+        "name": "Delivery",
+        "color": "#0A84FF",
+        "metadata": {"category": "custom", "color": "#0A84FF"},
+        "ui": {
+            "id": "n_root0000",
+            "type": "project-dashboard",
+            "props": {"title": "Delivery"},
+        },
+    }
+    doc = Pocket(
+        workspace="w1",
+        name="Delivery",
+        description="",
+        type="custom",
+        icon="",
+        color="",
+        owner="u1",
+        visibility="workspace",
+        rippleSpec=spec,
+    )
+    await doc.insert()
+    return doc
+
+
+def _flex_wrapping(root_node: dict[str, Any]) -> dict[str, Any]:
+    """Build a ``flex`` replacement whose first child is the original
+    root — the canonical "wrap a bare root so a sibling fits" shape."""
+    return {
+        "type": "flex",
+        "props": {"direction": "column", "gap": 16},
+        "children": [
+            copy.deepcopy(root_node),
+            {"type": "section", "props": {"title": "New section"}},
+        ],
+    }
+
+
+@pytest.fixture
+def agent_identity():
+    """Attach the ``w1`` / ``u1`` per-stream identity that
+    ``_agent_load_doc`` reads for its workspace + edit-access checks."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_agent_identity,
+        detach_agent_identity,
+    )
+
+    tokens = attach_agent_identity(workspace_id="w1", user_id="u1")
+    try:
+        yield
+    finally:
+        detach_agent_identity(tokens)
+
+
+# ---------------------------------------------------------------------------
+# Service-level reproduction — agent_replace_node on the ROOT, then a real
+# re-fetch from the database.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_root_replace_persists_via_service(mongo_db, agent_identity):
+    """REPRO: replacing the root via ``agent_replace_node`` must persist
+    to the database.
+
+    Before the fix this failed — the re-fetched pocket still showed the
+    original bare ``project-dashboard`` root, not the ``flex`` wrapper.
+    """
+    doc = await _make_bare_dashboard_pocket()
+    pocket_id = str(doc.id)
+    original_root = copy.deepcopy(doc.rippleSpec["ui"])
+    assert original_root["type"] == "project-dashboard"
+
+    result, err = await pocket_service.agent_replace_node(
+        pocket_id,
+        node_id=original_root["id"],
+        spec=_flex_wrapping(original_root),
+    )
+
+    assert err is None, f"agent_replace_node reported an error: {err}"
+    assert result is not None
+
+    # Re-fetch from the database — a genuinely fresh load, not the same
+    # Python object. This is what the canvas / chat re-fetch sees.
+    view, view_err = await pocket_service.agent_view(pocket_id)
+    assert view_err is None
+    assert view is not None
+
+    ui = view["rippleSpec"]["ui"]
+    assert ui["type"] == "flex", (
+        f"root swap did not persist — re-fetched UI root is still {ui.get('type')!r}"
+    )
+    assert isinstance(ui.get("children"), list) and len(ui["children"]) == 2
+    assert ui["children"][0]["type"] == "project-dashboard"
+    assert ui["children"][1]["type"] == "section"
+
+
+@pytest.mark.asyncio
+async def test_nonroot_replace_still_persists(mongo_db, agent_identity):
+    """REGRESSION GUARD: a non-root replace must keep persisting."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    spec = {
+        "version": "1.0",
+        "ui": {
+            "id": "n_root0000",
+            "type": "flex",
+            "props": {"direction": "column"},
+            "children": [
+                {"id": "n_header00", "type": "heading", "props": {"text": "Hi"}},
+            ],
+        },
+    }
+    doc = Pocket(
+        workspace="w1",
+        name="Two",
+        owner="u1",
+        visibility="workspace",
+        rippleSpec=spec,
+    )
+    await doc.insert()
+    pocket_id = str(doc.id)
+
+    result, err = await pocket_service.agent_replace_node(
+        pocket_id,
+        node_id="n_header00",
+        spec={"type": "stat", "props": {"value": "42"}},
+    )
+    assert err is None
+    assert result is not None
+
+    view, view_err = await pocket_service.agent_view(pocket_id)
+    assert view_err is None
+    child = view["rippleSpec"]["ui"]["children"][0]
+    assert child["type"] == "stat"
+    assert child["id"] == "n_header00"  # id preserved
+
+
+# ---------------------------------------------------------------------------
+# Agent-mode reproduction — the full EditAgentModeAdapter op path.
+#
+# This is the path the captain's deployment runs: pocket_specialist_mode=
+# agent on the Claude Code backend. The chat agent hands back a
+# ``replace_node`` op; ``_apply_ops`` dispatches it through the same
+# granular edit tools the subagent flow uses.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_root_replace_via_agent_mode_adapter(mongo_db, agent_identity):
+    """REPRO (agent-mode): an agent-mode ``replace_node`` op targeting the
+    root must persist the swap to the database."""
+    from pocketpaw_ee.agent.pocket_specialist.adapters import EditAgentModeAdapter
+    from pocketpaw_ee.agent.pocket_specialist.runtime import PocketSpecialistEditInput
+
+    from pocketpaw.config import Settings
+
+    doc = await _make_bare_dashboard_pocket()
+    pocket_id = str(doc.id)
+    original_root = copy.deepcopy(doc.rippleSpec["ui"])
+
+    edit_input = PocketSpecialistEditInput(
+        pocket_id=pocket_id,
+        intent="Wrap the dashboard in a flex so I can add a section beside it.",
+        ops=[
+            {
+                "op": "replace_node",
+                "args": {
+                    "node_id": original_root["id"],
+                    "spec": _flex_wrapping(original_root),
+                },
+            }
+        ],
+    )
+
+    adapter = EditAgentModeAdapter()
+    out = await adapter.edit(
+        edit_input,
+        workspace_id="w1",
+        user_id="u1",
+        settings=Settings(),
+    )
+
+    assert out.ok is True, f"agent-mode edit reported failure: {out.error}"
+    assert not out.warnings, f"agent-mode edit produced warnings: {out.warnings}"
+
+    view, view_err = await pocket_service.agent_view(pocket_id)
+    assert view_err is None
+    ui = view["rippleSpec"]["ui"]
+    assert ui["type"] == "flex", (
+        f"agent-mode root swap did not persist — re-fetched root is still {ui.get('type')!r}"
+    )
+    assert len(ui["children"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_agent_mode_reports_failure_when_no_op_applied(mongo_db, agent_identity):
+    """ACCOUNTING GUARD: when every supplied op is rejected and ZERO ops
+    apply, the agent-mode edit must report ``ok=False, action="failed"``
+    — not the silent ``ok=True, action="applied"`` that hid the
+    root-replace rejection.
+
+    A ``replace_node`` op targeting a node id that does not exist is
+    rejected by the service (``{ok: false}``, not a raised exception) —
+    the exact rejection class that previously slipped through as a
+    misleading ``applied``.
+    """
+    from pocketpaw_ee.agent.pocket_specialist.adapters import EditAgentModeAdapter
+    from pocketpaw_ee.agent.pocket_specialist.runtime import PocketSpecialistEditInput
+
+    from pocketpaw.config import Settings
+
+    doc = await _make_bare_dashboard_pocket()
+    pocket_id = str(doc.id)
+
+    edit_input = PocketSpecialistEditInput(
+        pocket_id=pocket_id,
+        intent="Replace a node that isn't there.",
+        ops=[
+            {
+                "op": "replace_node",
+                "args": {"node_id": "n_ghost000", "spec": {"type": "flex"}},
+            }
+        ],
+    )
+
+    adapter = EditAgentModeAdapter()
+    out = await adapter.edit(
+        edit_input,
+        workspace_id="w1",
+        user_id="u1",
+        settings=Settings(),
+    )
+
+    assert out.ok is False, "rejected-only run must report ok=False"
+    assert out.action == "failed", (
+        f"rejected-only run must report action='failed', got {out.action!r}"
+    )
+    assert out.error, "a failed run must carry an error explaining why"
+    assert out.warnings, "the per-op rejection reason must surface in warnings"
+    assert out.ops == [], "no ops were applied"

--- a/tests/cloud/test_prop_arrays.py
+++ b/tests/cloud/test_prop_arrays.py
@@ -24,16 +24,16 @@ def test_calendar_events_allowed():
     assert prop_arrays.is_allowed("calendar", "events")
 
 
-def test_feed_items_allowed():
-    assert prop_arrays.is_allowed("feed", "items")
+def test_checklist_layout_items_allowed():
+    assert prop_arrays.is_allowed("checklist-layout", "items")
 
 
 def test_select_options_allowed():
     assert prop_arrays.is_allowed("select", "options")
 
 
-def test_form_layout_fields_allowed():
-    assert prop_arrays.is_allowed("form-layout", "fields")
+def test_form_layout_sections_allowed():
+    assert prop_arrays.is_allowed("form-layout", "sections")
 
 
 def test_random_prop_rejected():

--- a/tests/cloud/test_spec_ops.py
+++ b/tests/cloud/test_spec_ops.py
@@ -183,10 +183,17 @@ def test_replace_node_keeps_explicit_id():
     assert spec_ops.find_by_id(tree, "n_newhead0") is not None
 
 
-def test_replace_root_raises():
+def test_replace_root_swaps_the_whole_tree():
+    """Root replacement is allowed: replace_node on the root id swaps the
+    entire ui tree in place (the wrap-the-root path — e.g. wrapping a
+    bare project-dashboard root in a flex). The root id is preserved and
+    the old root is returned for undo."""
     tree = _tree()
-    with pytest.raises(ValueError, match="root"):
-        spec_ops.replace_node(tree, "n_root0000", {"type": "flex"})
+    old = spec_ops.replace_node(tree, "n_root0000", {"type": "flex", "props": {"gap": 8}})
+    assert tree["type"] == "flex"
+    assert tree["props"] == {"gap": 8}
+    assert tree["id"] == "n_root0000"  # root id preserved
+    assert old["id"] == "n_root0000"  # old root returned for undo
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ee/agent/test_pocket_specialist/test_edit.py
+++ b/tests/ee/agent/test_pocket_specialist/test_edit.py
@@ -874,7 +874,13 @@ class TestAgentModeEditDispatch:
     async def test_agent_mode_rejected_op_surfaces_in_warnings(self) -> None:
         """A service-rejected op in agent mode must NOT count as applied —
         its reason folds into ``warnings``, same contract as subagent mode
-        (#1163 class). The run stays ``ok=True`` (nothing crashed)."""
+        (#1163 class).
+
+        When the rejected op was the ONLY op, zero ops applied — the run
+        reports ``ok=False, action="failed"`` so the caller can't mistake
+        a no-change run for a successful edit (the agent-mode root-replace
+        silent-failure class). ``warnings`` still carries the per-op
+        reason; ``error`` explains nothing applied."""
         from pocketpaw_ee.agent.pocket_specialist.runtime import (
             PocketSpecialistEditInput,
             run_edit_specialist,
@@ -905,8 +911,10 @@ class TestAgentModeEditDispatch:
             )
 
         mock_create_backend.assert_not_called()
-        assert out.ok is True
+        assert out.ok is False, "a run that applied zero ops is not a success"
+        assert out.action == "failed"
         assert out.ops == []
+        assert out.error, "a no-op-applied run must explain why in error"
         assert out.warnings, "a rejected op must surface its reason in warnings"
         joined = " ".join(out.warnings)
         assert "set_state" in joined and "does not exist" in joined
@@ -914,7 +922,11 @@ class TestAgentModeEditDispatch:
     @pytest.mark.asyncio
     async def test_agent_mode_unknown_op_surfaces_in_warnings(self) -> None:
         """An op naming a tool the specialist does not hold must be skipped
-        and reported in ``warnings`` — not crash the run."""
+        and reported in ``warnings`` — not crash the run.
+
+        When the unknown op was the ONLY op, zero ops applied — the run
+        reports ``ok=False, action="failed"`` (zero-ops-applied is not a
+        success). ``warnings`` still names the skipped op."""
         from pocketpaw_ee.agent.pocket_specialist.runtime import (
             PocketSpecialistEditInput,
             run_edit_specialist,
@@ -937,7 +949,9 @@ class TestAgentModeEditDispatch:
             )
 
         mock_create_backend.assert_not_called()
-        assert out.ok is True
+        assert out.ok is False, "a run that applied zero ops is not a success"
+        assert out.action == "failed"
         assert out.ops == []
+        assert out.error
         assert out.warnings
         assert "create_pocket" in " ".join(out.warnings)


### PR DESCRIPTION
Pocket editing accumulated edit-API gaps that surfaced once the agent-mode path started exercising it for real. This is the batch that makes agent-driven editing stable, verified through local testing on the live app.

## What changed

- `replace_node` now handles the root node — it swaps the whole `ui` tree in place, so a single-widget pocket (a bare `project-dashboard` root) can be wrapped in a `flex` to gain sibling sections. It used to hard-raise "cannot replace the root" and point at an `update_pocket` op the edit specialist does not hold.
- `add_node` honours an `index` argument for positional insertion. The arg was silently dropped before, so the agent could only append or position by `after_id`.
- `move_node`'s parent argument is now `parent_id`, matching `add_node`. It was `new_parent_id` — an asymmetry the agent kept tripping on.
- The agent-mode edit kit's op-shape hint said `add_node` takes `node`; the real field is `spec`. Corrected, and the hint now lists every op's real arguments.
- The agent-mode adapter no longer reports `ok=true, action=applied` when zero ops actually applied — a fully-rejected run returns `ok=false`.
- The prop-array allowlist is regenerated from the `@ripple-ui/svelte` manifest: 9 widgets to 63, covering every widget with an object-element array prop (`checklist-layout.items` and the rest). This also fixes drift — the hand-written table had `tabs.items` and `form-layout.fields`, but the manifest's real props are `tabs.tabs` and `form-layout.sections`, and `feed`/`nav` are no longer widget types.

## Tests

219 pocket-edit tests pass, including new coverage for root replacement, the agent-mode SSE push, and node-id round-trips. `ruff check` and `ruff format` clean.
