### PR TITLE
Read-only live data sources for pockets (RFC 04 alpha)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,6 +6,10 @@ Created: 2026-05-21 (RFC 04 alpha) — documents the per-pocket backend
 binding + read-only source-run endpoints. The rest of the cloud pockets
 API is described in the auto-generated wiki article
 `ee/docs/wiki/pockets-router-*.md`.
+
+Updated: 2026-05-21 (PR #1177 security pass) — documented the new
+DELETE /pockets/{id}/backend endpoint and the edit-access requirement on
+GET /pockets/{id}/backend.
 -->
 
 # Cloud REST API Reference
@@ -46,10 +50,15 @@ Response `200`:
 The token is never echoed back. A non-https or internal `base_url` yields
 a `400`.
 
+For `basic` auth, send `auth_token` as the raw `user:pass` credential —
+the server base64-encodes it into the `Authorization: Basic` header. Do
+not pre-encode it yourself.
+
 ### `GET /pockets/{pocket_id}/backend`
 
-Read the pocket's backend binding summary. Read access mirrors
-`GET /pockets/{pocket_id}`.
+Read the pocket's backend binding summary. Requires pocket **edit** access
+(owner or editor) — backend config metadata is owner/editor-facing,
+consistent with the `PUT` route. Viewers receive a `403`.
 
 Response `200`:
 
@@ -60,10 +69,23 @@ Response `200`:
 Returns `404` when the pocket has no backend configured. The token is
 never included in the response.
 
+### `DELETE /pockets/{pocket_id}/backend`
+
+Revoke the pocket's backend binding — deletes the stored (encrypted)
+credential. Requires pocket **owner** access.
+
+Returns `204 No Content`. Idempotent: deleting when no backend is
+configured still returns `204`. The removal is written to the audit log.
+
 ### `POST /pockets/{pocket_id}/sources/run`
 
 Run the pocket's read-only `rippleSpec.sources` (GET bindings) against its
-configured backend. Read access mirrors `GET /pockets/{pocket_id}`.
+configured backend. Read access mirrors `GET /pockets/{pocket_id}` —
+deliberately **not** gated on edit access. Any pocket reader may run the
+already-authored sources: a viewer of a shared live pocket triggering the
+`pocket_open` refresh is the core shared-dashboard UX. A viewer cannot
+change the backend or the source paths (both are edit-only), so the SSRF
+hardening plus the immutable, edit-authored source list bound the risk.
 
 Request body (all fields optional):
 
@@ -99,4 +121,6 @@ Returns `400` when the pocket has no backend configured.
 the base URL, rejects absolute-URL paths / `..` traversal / cross-host
 joins, runs a DNS check against internal IPs, disables redirects, applies
 tight timeouts, caps response bodies at 512 KB, sanitizes error messages,
-and rate-limits to 10 runs per pocket per minute.
+and rate-limits to 10 runs per `(pocket, user)` pair per minute. Every run
+is written to the audit log (actor, pocket, status, query-stripped base
+URL) — the credential token is never logged.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,102 @@
+<!--
+docs/api-reference.md — Hand-maintained reference for cloud REST endpoints
+that are not covered by the per-endpoint Mintlify pages under docs/api/.
+
+Created: 2026-05-21 (RFC 04 alpha) — documents the per-pocket backend
+binding + read-only source-run endpoints. The rest of the cloud pockets
+API is described in the auto-generated wiki article
+`ee/docs/wiki/pockets-router-*.md`.
+-->
+
+# Cloud REST API Reference
+
+This file documents cloud (`pocketpaw-ee`) REST endpoints that do not yet
+have a dedicated page under `docs/api/`. All cloud endpoints require a
+valid enterprise license and an authenticated workspace context.
+
+## Pockets — Backend Binding & Live Data Sources
+
+RFC 04 alpha. A pocket can be bound to **one** external backend (base URL +
+auth credential). Its `rippleSpec.sources` declares read-only `GET`
+bindings; a server-side executor runs them and returns the JSON results.
+
+The credential is stored in a **separate, encrypted collection**
+(`pocket_backend_credentials`) — never inside the `Pocket` document and
+never inside `rippleSpec`, so the spec stays shareable and secret-free.
+
+### `PUT /pockets/{pocket_id}/backend`
+
+Bind a pocket to one backend. Requires pocket **edit** access.
+
+Request body:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `base_url` | string | Required. Must be `https://` and point to an external host (no loopback / RFC1918 / link-local). |
+| `auth_type` | string | One of `bearer`, `api_key`, `basic`, `none`. |
+| `auth_token` | string | The secret. Encrypted at rest; never returned. Required unless `auth_type` is `none`. |
+| `auth_header` | string \| null | Custom header name for `api_key` auth. Defaults to `X-Api-Key`. |
+
+Response `200`:
+
+```json
+{ "base_url": "https://api.example.com", "auth_type": "bearer", "configured": true }
+```
+
+The token is never echoed back. A non-https or internal `base_url` yields
+a `400`.
+
+### `GET /pockets/{pocket_id}/backend`
+
+Read the pocket's backend binding summary. Read access mirrors
+`GET /pockets/{pocket_id}`.
+
+Response `200`:
+
+```json
+{ "base_url": "https://api.example.com", "auth_type": "bearer", "configured": true }
+```
+
+Returns `404` when the pocket has no backend configured. The token is
+never included in the response.
+
+### `POST /pockets/{pocket_id}/sources/run`
+
+Run the pocket's read-only `rippleSpec.sources` (GET bindings) against its
+configured backend. Read access mirrors `GET /pockets/{pocket_id}`.
+
+Request body (all fields optional):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `trigger` | `pocket_open` \| `manual` \| null | Run only sources whose `refresh` list contains this trigger. |
+| `source` | string \| null | Run a single named source regardless of refresh policy. |
+
+When both are omitted, every source in the spec runs.
+
+Response `200`:
+
+```json
+{
+  "ran": [
+    { "source": "prs", "bind": "prs", "value": [ { "id": 1, "title": "PR one" } ] }
+  ],
+  "errors": [
+    { "source": "issues", "error": "backend returned status 503", "code": "http_error" }
+  ]
+}
+```
+
+`bind` is the dotted state path the value should be written to, with a
+leading `state.` stripped. The hydrated state is delivered **in this
+response body** — there is no `pocket_mutation` SSE emit, because the run
+endpoint is a standalone REST call outside any SSE-stream context. The
+caller applies the results to the pocket's ripple state.
+
+Returns `400` when the pocket has no backend configured.
+
+**Security.** This endpoint is an SSRF boundary. The executor re-validates
+the base URL, rejects absolute-URL paths / `..` traversal / cross-host
+joins, runs a DNS check against internal IPs, disables redirects, applies
+tight timeouts, caps response bodies at 512 KB, sanitizes error messages,
+and rate-limits to 10 runs per pocket per minute.

--- a/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
@@ -672,9 +672,7 @@ async def _run_edit_subagent_pipeline(
     try:
         from pocketpaw_ee.cloud.pockets import service as _pockets_service
 
-        backend_summary = await _pockets_service.get_pocket_backend(
-            workspace_id, input.pocket_id
-        )
+        backend_summary = await _pockets_service.get_pocket_backend(workspace_id, input.pocket_id)
     except Exception:  # noqa: BLE001 — a missing backend summary must not block the edit
         log.debug("[pocket-specialist:edit] backend summary fetch failed", exc_info=True)
     system_prompt = fill_current_pocket(

--- a/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
@@ -24,6 +24,11 @@ the chat agent computes the granular ops inline and the new
 backend-spawn flow moved into the private ``_run_edit_subagent_pipeline``.
 A new ``PocketSpecialistEditInput.ops`` field carries the chat agent's
 pre-computed ops on the agent-mode second call.
+Changes: 2026-05-22 (RFC 04 alpha follow-up 2) — the subagent-mode edit
+pipeline now fetches the pocket's non-secret backend summary and fills it
+into the ``<current-pocket>`` block via ``fill_current_pocket`` so the
+specialist sees whether a backend is configured before authoring a
+``sources`` block. The token is never surfaced.
 """
 
 from __future__ import annotations
@@ -40,6 +45,7 @@ from pocketpaw.ripple._pockets import (
     POCKET_EDIT_SPECIALIST_PROMPT_MCP,
     POCKET_ID_TOKEN,
     POCKET_SPECIALIST_PROMPT,
+    fill_current_pocket,
 )
 from pocketpaw_ee.agent.pocket_specialist.settings import (
     _BACKEND_MODEL_FIELD,
@@ -659,7 +665,21 @@ async def _run_edit_subagent_pipeline(
         make_edit_pocket_tools(pocket_id=input.pocket_id, capture=ops_capture)
     )
 
-    system_prompt = POCKET_EDIT_SPECIALIST_PROMPT_MCP.replace(POCKET_ID_TOKEN, input.pocket_id)
+    # Surface the NON-SECRET backend summary so the specialist knows
+    # whether a backend is already configured before it authors a
+    # ``sources`` block. ``get_pocket_backend`` never returns the token.
+    backend_summary: dict[str, Any] | None = None
+    try:
+        from pocketpaw_ee.cloud.pockets import service as _pockets_service
+
+        backend_summary = await _pockets_service.get_pocket_backend(
+            workspace_id, input.pocket_id
+        )
+    except Exception:  # noqa: BLE001 — a missing backend summary must not block the edit
+        log.debug("[pocket-specialist:edit] backend summary fetch failed", exc_info=True)
+    system_prompt = fill_current_pocket(
+        POCKET_EDIT_SPECIALIST_PROMPT_MCP, input.pocket_id, backend_summary
+    )
     user_message = _build_edit_user_message(input)
 
     log.info(

--- a/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
@@ -861,7 +861,7 @@ class _SetSourceArgs(BaseModel):
         default=None,
         description=(
             "When to run the source: `pocket_open` (on open) and/or `manual` "
-            "(refresh button). Defaults to `[\"pocket_open\"]` when omitted."
+            '(refresh button). Defaults to `["pocket_open"]` when omitted.'
         ),
     )
 

--- a/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
@@ -19,6 +19,10 @@ result dict. A service-rejected op (``{ok: false}``) is NO LONGER
 appended to ``capture['ops']`` — a rejected op is not an applied op.
 Instead it is recorded in ``capture['rejected']`` with its error so the
 runtime can fold the reason into the response ``warnings``.
+Changes: 2026-05-22 (RFC 04 alpha follow-up) — added the ``set_source``
+/ ``remove_source`` edit-tool factories so the specialist can author the
+pocket's top-level ``rippleSpec.sources`` block (read-only GET data
+bindings). Registered in ``make_edit_pocket_tools``.
 """
 
 from __future__ import annotations
@@ -832,6 +836,103 @@ def make_remove_prop_array_item_tool(
     )
 
 
+# ---------------------------------------------------------------------------
+# rippleSpec.sources ops — read-only data bindings (RFC 04 alpha)
+# ---------------------------------------------------------------------------
+
+
+class _SetSourceArgs(BaseModel):
+    source_key: str = Field(
+        ..., description="Short name for the source — also the `sources` map key."
+    )
+    path: str = Field(
+        ...,
+        description=(
+            "RELATIVE path against the pocket's configured backend "
+            "(e.g. `/pulls?state=open`). Never an absolute URL."
+        ),
+    )
+    bind: str = Field(
+        ...,
+        description="Dotted `state.` path the fetched JSON is written to (e.g. `state.prs`).",
+    )
+    method: str = Field(default="GET", description='Always "GET" — alpha is read-only.')
+    refresh: list[str] | None = Field(
+        default=None,
+        description=(
+            "When to run the source: `pocket_open` (on open) and/or `manual` "
+            "(refresh button). Defaults to `[\"pocket_open\"]` when omitted."
+        ),
+    )
+
+
+def make_set_source_tool(
+    *, pocket_id: str, capture: dict[str, Any] | None = None
+) -> StructuredTool:
+    """Declare (or replace) a read-only data source on the pocket."""
+
+    async def _run(
+        source_key: str,
+        path: str,
+        bind: str,
+        method: str = "GET",
+        refresh: list[str] | None = None,
+    ) -> dict[str, Any]:
+        from pocketpaw_ee.cloud.pockets.agent_context import set_source_for_agent
+
+        binding: dict[str, Any] = {"method": method, "path": path, "bind": bind}
+        if refresh is not None:
+            binding["refresh"] = refresh
+        result = await set_source_for_agent(pocket_id, source_key, binding)
+        _capture_op(capture, "set_source", {"source_key": source_key, "path": path}, result)
+        return result
+
+    return StructuredTool.from_function(
+        coroutine=_run,
+        name="set_source",
+        description=(
+            "Declare a READ-ONLY live data source in rippleSpec.sources — a "
+            "GET binding that fetches from the pocket's own configured "
+            "backend (a CRM, an internal API) and writes the JSON into "
+            "state at `bind`. Use this when the user wants live data from "
+            "THEIR backend. The pocket must have a backend configured "
+            "(base URL + auth, set in backend settings). Seed state at the "
+            "`bind` target with an empty value so the widget renders before "
+            "the first fetch. For a manual refresh, add a button with "
+            "on_click {action: 'run_source', source: '<source_key>'}."
+        ),
+        args_schema=_SetSourceArgs,
+    )
+
+
+class _RemoveSourceArgs(BaseModel):
+    source_key: str = Field(..., description="The `sources` map key to remove.")
+
+
+def make_remove_source_tool(
+    *, pocket_id: str, capture: dict[str, Any] | None = None
+) -> StructuredTool:
+    """Remove a read-only data source declaration from the pocket."""
+
+    async def _run(source_key: str) -> dict[str, Any]:
+        from pocketpaw_ee.cloud.pockets.agent_context import remove_source_for_agent
+
+        result = await remove_source_for_agent(pocket_id, source_key)
+        _capture_op(capture, "remove_source", {"source_key": source_key}, result)
+        return result
+
+    return StructuredTool.from_function(
+        coroutine=_run,
+        name="remove_source",
+        description=(
+            "Remove a read-only data source from rippleSpec.sources by its "
+            "key. Idempotent — removing a source that was never declared "
+            "still succeeds. The state the source bound to is left alone."
+        ),
+        args_schema=_RemoveSourceArgs,
+    )
+
+
 def make_edit_pocket_tools(
     *, pocket_id: str, capture: dict[str, Any] | None = None
 ) -> list[StructuredTool]:
@@ -840,7 +941,9 @@ def make_edit_pocket_tools(
     Order is the order the LLM sees them; we lead with the read tool
     so the agent is prompted toward "get then mutate" rather than
     blind writes. The Tier-2 ``*_prop_array_item`` ops sit next to
-    ``set_node_prop`` — they are the surgical alternative to it.
+    ``set_node_prop`` — they are the surgical alternative to it. The
+    ``*_source`` ops sit last — they write the top-level
+    ``rippleSpec.sources`` block, not the ui tree or state.
     """
     return [
         make_get_pocket_tool(pocket_id=pocket_id),
@@ -856,4 +959,6 @@ def make_edit_pocket_tools(
         make_replace_node_tool(pocket_id=pocket_id, capture=capture),
         make_move_node_tool(pocket_id=pocket_id, capture=capture),
         make_remove_node_tool(pocket_id=pocket_id, capture=capture),
+        make_set_source_tool(pocket_id=pocket_id, capture=capture),
+        make_remove_source_tool(pocket_id=pocket_id, capture=capture),
     ]

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -8,6 +8,12 @@ handles *what the agent sees*:
   pocket-scoped tool specs where applicable.
 * ``load_history_for_scope`` rehydrates prior chat turns from Mongo so the
   agent carries context across backend restarts and pool evictions.
+
+Changes: 2026-05-22 (RFC 04 alpha follow-up 2) — ``build_behavior_instructions``
+fills the interaction prompt's current-pocket block via ``fill_current_pocket``
+(both the pocket-id and backend-summary tokens) instead of a bare
+``POCKET_ID_TOKEN`` replace, so the new ``__BACKEND_SUMMARY__`` token never
+leaks as literal text.
 """
 
 from __future__ import annotations
@@ -22,7 +28,7 @@ from typing import Any
 from pocketpaw.ripple import (
     INLINE_RIPPLE_SYSTEM_PROMPT,
     POCKET_DELEGATION_RULE,
-    POCKET_ID_TOKEN,
+    fill_current_pocket,
     get_pocket_prompts,
 )
 from pocketpaw.ripple._pockets import _MCP_POCKET_BACKENDS
@@ -492,7 +498,12 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
         if ctx.intent == "pocket_create":
             parts.append(creation_prompt)
         elif ctx.pocket_id:
-            parts.append(interaction_prompt.replace(POCKET_ID_TOKEN, ctx.pocket_id))
+            # build_behavior_instructions is sync — it cannot await the
+            # backend-summary read. The main chat agent delegates edits
+            # to the specialist anyway, so pass None: the prompt renders
+            # "configured state unknown — call get_pocket to check",
+            # and get_pocket now carries the real backend summary.
+            parts.append(fill_current_pocket(interaction_prompt, ctx.pocket_id, None))
         else:
             parts.append(INLINE_RIPPLE_SYSTEM_PROMPT)
     return "\n".join(parts)

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,4 +1,9 @@
-"""Cloud document models — re-exports for Beanie init."""
+"""Cloud document models — re-exports for Beanie init.
+
+Updated: 2026-05-21 (PR #1177 security pass) — dropped PocketBackendCredential
+from ``__all__`` so it cannot be star-imported into routers/DTOs/domains; it
+remains registered in ``get_all_documents()`` for Beanie init.
+"""
 
 from __future__ import annotations
 
@@ -62,7 +67,6 @@ __all__ = [
     "PlanSession",
     "PlanSessionAgentGap",
     "Pocket",
-    "PocketBackendCredential",
     "Project",
     "Reaction",
     "ReadState",

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -14,6 +14,7 @@ from pocketpaw_ee.cloud.models.message import Attachment, Mention, Message, Reac
 from pocketpaw_ee.cloud.models.notification import Notification, NotificationSource
 from pocketpaw_ee.cloud.models.planner import PlanSession, PlanSessionAgentGap
 from pocketpaw_ee.cloud.models.pocket import Pocket, Widget, WidgetPosition
+from pocketpaw_ee.cloud.models.pocket_backend import PocketBackendCredential
 from pocketpaw_ee.cloud.models.project import Project
 from pocketpaw_ee.cloud.models.read_state import ReadState
 from pocketpaw_ee.cloud.models.session import Session
@@ -61,6 +62,7 @@ __all__ = [
     "PlanSession",
     "PlanSessionAgentGap",
     "Pocket",
+    "PocketBackendCredential",
     "Project",
     "Reaction",
     "ReadState",
@@ -85,6 +87,7 @@ def get_all_documents():
         User,
         Agent,
         Pocket,
+        PocketBackendCredential,
         Session,
         Comment,
         Notification,

--- a/ee/pocketpaw_ee/cloud/models/pocket_backend.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket_backend.py
@@ -1,0 +1,40 @@
+# pocket_backend.py — Beanie document for per-pocket backend credentials.
+# Created: 2026-05-21 (RFC 04 alpha) — A Pocket can be bound to ONE external
+#   backend (base URL + auth credential). The credential is stored here, in a
+#   SEPARATE collection (`pocket_backend_credentials`) — never inside the
+#   `Pocket` document and never inside `rippleSpec`. Keeping it out of the
+#   pocket keeps the spec shareable and secret-free.
+#
+#   The auth token is encrypted at rest: `encrypted_token` / `nonce` / `salt`
+#   are produced by `pockets/backend_crypto.py` (AES-GCM + HKDF-SHA256).
+#   The plaintext token never touches this document.
+
+from __future__ import annotations
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class PocketBackendCredential(TimestampedDocument):
+    """Per-pocket backend binding: base URL + (encrypted) auth credential.
+
+    One row per pocket. The run-sources executor decrypts the token at call
+    time; every other read path returns only `base_url` / `auth_type` /
+    `configured` so the secret never leaves this collection.
+    """
+
+    pocket_id: Indexed(str)  # type: ignore[valid-type]
+    workspace_id: Indexed(str)  # type: ignore[valid-type]
+    base_url: str
+    # bearer | api_key | basic | none
+    auth_type: str = "none"
+    # Custom header name for the api_key auth type. Defaults to "X-Api-Key".
+    auth_header: str | None = None
+    # Encrypted token material. All three are None when auth_type == "none".
+    encrypted_token: bytes | None = None
+    nonce: bytes | None = None
+    salt: bytes | None = None
+
+    class Settings:
+        name = "pocket_backend_credentials"

--- a/ee/pocketpaw_ee/cloud/pockets/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/pockets/agent_context.py
@@ -7,6 +7,13 @@ workspace/user/session identity from the per-stream ``ContextVar``s,
 and pushes ``pocket_mutation`` / ``pocket_created`` events onto the
 active SSE stream's queue. All Beanie reads/writes live in the
 service modules.
+
+Changes: 2026-05-22 (RFC 04 alpha follow-up) — added the
+``set_source_for_agent`` / ``remove_source_for_agent`` wrappers so the
+edit specialist can author the pocket's ``rippleSpec.sources`` block.
+They emit a full-document ``replace`` ``pocket_mutation`` (the
+frontend's ``applyMutation`` already understands ``replace``) so no
+paw-enterprise change is needed.
 """
 
 from __future__ import annotations
@@ -735,6 +742,43 @@ async def patch_state_for_agent(pocket_id: str, partial: dict[str, Any]) -> dict
     return {"ok": True, "previous": result.get("previous")}
 
 
+# ---------------------------------------------------------------------------
+# rippleSpec.sources mutations — the read-only data-binding surface (RFC 04)
+# ---------------------------------------------------------------------------
+#
+# A ``sources`` declaration is part of the persisted pocket document, so
+# unlike the granular node / state ops there is no in-place frontend op for
+# it — these wrappers push a full-document ``replace`` ``pocket_mutation``
+# via ``_push_replace``. The frontend's ``applyMutation`` already handles
+# ``replace``; no paw-enterprise change is needed for this fix.
+
+
+async def set_source_for_agent(
+    pocket_id: str, source_key: str, binding: dict[str, Any]
+) -> dict[str, Any]:
+    """Declare (or replace) a read-only data source on the pocket."""
+    result, err = await pockets_service.agent_set_source(
+        pocket_id, source_key=source_key, binding=binding
+    )
+    if err is not None or result is None:
+        return {"ok": False, "error": err or "set_source failed"}
+    pocket_view: dict[str, Any] = result.get("pocket") or {}
+    await _push_replace(pocket_view)
+    return {"ok": True, "source_key": source_key, "binding": result.get("binding")}
+
+
+async def remove_source_for_agent(pocket_id: str, source_key: str) -> dict[str, Any]:
+    """Remove a read-only data source declaration from the pocket."""
+    result, err = await pockets_service.agent_remove_source(
+        pocket_id, source_key=source_key
+    )
+    if err is not None or result is None:
+        return {"ok": False, "error": err or "remove_source failed"}
+    pocket_view: dict[str, Any] = result.get("pocket") or {}
+    await _push_replace(pocket_view)
+    return {"ok": True, "source_key": source_key}
+
+
 __all__ = [
     "add_node_for_agent",
     "add_widget_for_agent",
@@ -747,11 +791,13 @@ __all__ = [
     "patch_state_for_agent",
     "remove_node_for_agent",
     "remove_prop_array_item_for_agent",
+    "remove_source_for_agent",
     "remove_state_for_agent",
     "remove_widget_for_agent",
     "replace_node_for_agent",
     "set_node_prop_for_agent",
     "set_prop_array_item_for_agent",
+    "set_source_for_agent",
     "set_state_for_agent",
     "update_pocket_for_agent",
     "update_widget_for_agent",

--- a/ee/pocketpaw_ee/cloud/pockets/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/pockets/agent_context.py
@@ -769,9 +769,7 @@ async def set_source_for_agent(
 
 async def remove_source_for_agent(pocket_id: str, source_key: str) -> dict[str, Any]:
     """Remove a read-only data source declaration from the pocket."""
-    result, err = await pockets_service.agent_remove_source(
-        pocket_id, source_key=source_key
-    )
+    result, err = await pockets_service.agent_remove_source(pocket_id, source_key=source_key)
     if err is not None or result is None:
         return {"ok": False, "error": err or "remove_source failed"}
     pocket_view: dict[str, Any] = result.get("pocket") or {}

--- a/ee/pocketpaw_ee/cloud/pockets/backend_crypto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/backend_crypto.py
@@ -1,0 +1,82 @@
+# backend_crypto.py — Encrypt / decrypt pocket-backend auth tokens at rest.
+# Created: 2026-05-21 (RFC 04 alpha) — pure crypto helper for the per-pocket
+#   backend credential store. No Beanie imports; the Beanie document
+#   (`models/pocket_backend.py`) just carries the ciphertext bytes this
+#   module produces.
+#
+#   Scheme: a per-document random 16-byte salt feeds HKDF-SHA256 (length 32)
+#   over `AUTH_SECRET`, producing an AES-256 key used with AES-GCM. Each
+#   encryption also draws a fresh 12-byte nonce. Storing the salt per row
+#   means two pockets bound to the same backend with the same token still
+#   get different ciphertext.
+#
+#   SECURITY: never log derived keys or plaintext tokens.
+
+from __future__ import annotations
+
+import os
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+# Info label binds the derived key to this purpose + version. Bumping the
+# suffix (v2, …) would invalidate every existing ciphertext on purpose.
+_HKDF_INFO = b"pocket-backend-credentials-v1"
+_KEY_LENGTH = 32  # AES-256
+_SALT_LENGTH = 16
+_NONCE_LENGTH = 12
+
+
+def _auth_secret() -> bytes:
+    """Return the configured ``AUTH_SECRET`` as bytes.
+
+    Raises a clear error when it is unset — credential encryption must
+    never silently fall back to an empty / predictable key.
+    """
+    secret = os.environ.get("AUTH_SECRET")
+    if not secret:
+        raise RuntimeError(
+            "AUTH_SECRET is not set — pocket backend credential encryption "
+            "requires it. Set AUTH_SECRET in the environment before "
+            "configuring a pocket backend."
+        )
+    return secret.encode()
+
+
+def _derive_key(salt: bytes) -> bytes:
+    """Derive a 32-byte AES key from ``AUTH_SECRET`` + ``salt`` via HKDF-SHA256."""
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=_KEY_LENGTH,
+        salt=salt,
+        info=_HKDF_INFO,
+    )
+    return hkdf.derive(_auth_secret())
+
+
+def encrypt_token(token: str) -> tuple[bytes, bytes, bytes]:
+    """Encrypt ``token`` and return ``(ciphertext, nonce, salt)``.
+
+    Every call draws a fresh random salt and nonce, so encrypting the same
+    token twice yields different ciphertext.
+    """
+    salt = os.urandom(_SALT_LENGTH)
+    nonce = os.urandom(_NONCE_LENGTH)
+    key = _derive_key(salt)
+    ciphertext = AESGCM(key).encrypt(nonce, token.encode(), None)
+    return ciphertext, nonce, salt
+
+
+def decrypt_token(ciphertext: bytes, nonce: bytes, salt: bytes) -> str:
+    """Decrypt a token produced by :func:`encrypt_token`.
+
+    Raises ``cryptography.exceptions.InvalidTag`` if the ciphertext, nonce,
+    salt, or ``AUTH_SECRET`` does not match what produced the ciphertext.
+    """
+    key = _derive_key(salt)
+    plaintext = AESGCM(key).decrypt(nonce, ciphertext, None)
+    return plaintext.decode()
+
+
+__all__ = ["encrypt_token", "decrypt_token"]

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -10,6 +10,10 @@ PocketResponse so pockets can be grouped under a Mission Control Project.
 Updated: 2026-05-21 (RFC 04 alpha) — added PocketBackendConfigRequest /
 PocketBackendConfigResponse / RunSourcesRequest for the per-pocket backend
 binding + read-only source-run endpoints.
+Updated: 2026-05-21 (PR #1177 security pass) — PocketBackendConfigRequest
+.base_url now requires min_length=1; RunSourcesRequest.source coerces an
+empty string to None; documented that `auth_token` for `basic` is the
+`user:pass` credential (base64-encoded server-side).
 """
 
 from __future__ import annotations
@@ -17,7 +21,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class CreatePocketRequest(BaseModel):
@@ -115,11 +119,19 @@ class PocketBackendConfigRequest(BaseModel):
     """Body for ``PUT /pockets/{id}/backend`` — bind a pocket to one backend.
 
     ``auth_token`` carries the secret only on the way IN; it is encrypted
-    server-side and never returned. ``auth_header`` names the custom header
-    for the ``api_key`` auth type (defaults to ``X-Api-Key`` when omitted).
+    server-side and never returned. Its meaning depends on ``auth_type``:
+
+    * ``bearer`` — the bearer token, sent as ``Authorization: Bearer <token>``.
+    * ``api_key`` — the API key value, sent in the ``auth_header`` header.
+    * ``basic`` — the raw ``user:pass`` credential. The server base64-encodes
+      it to form a valid ``Authorization: Basic`` header — do NOT pre-encode.
+    * ``none`` — unused.
+
+    ``auth_header`` names the custom header for the ``api_key`` auth type
+    (defaults to ``X-Api-Key`` when omitted).
     """
 
-    base_url: str
+    base_url: str = Field(min_length=1)
     auth_type: Literal["bearer", "api_key", "basic", "none"]
     auth_token: str = ""
     auth_header: str | None = None
@@ -140,10 +152,18 @@ class RunSourcesRequest(BaseModel):
     on-open set; ``manual`` runs the refresh-button set). ``source`` runs a
     single named source regardless of policy. Both omitted runs every
     source declared in the spec.
+
+    An empty-string ``source`` is coerced to ``None`` — it would otherwise
+    select zero sources (no source key is named "") and silently no-op.
     """
 
     trigger: Literal["pocket_open", "manual"] | None = None
     source: str | None = None
+
+    @field_validator("source")
+    @classmethod
+    def _empty_source_is_none(cls, v: str | None) -> str | None:
+        return v or None
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -7,12 +7,15 @@ separate follow-up calls.
 Updated: 2026-05-16 — added optional ``project_id`` (aliased as
 ``projectId`` on the wire) to CreatePocketRequest / UpdatePocketRequest /
 PocketResponse so pockets can be grouped under a Mission Control Project.
+Updated: 2026-05-21 (RFC 04 alpha) — added PocketBackendConfigRequest /
+PocketBackendConfigResponse / RunSourcesRequest for the per-pocket backend
+binding + read-only source-run endpoints.
 """
 
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -101,6 +104,46 @@ class PocketResponse(BaseModel):
     project_id: str | None = None
     created_at: datetime
     updated_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Pocket backend binding + source-run (RFC 04 alpha)
+# ---------------------------------------------------------------------------
+
+
+class PocketBackendConfigRequest(BaseModel):
+    """Body for ``PUT /pockets/{id}/backend`` — bind a pocket to one backend.
+
+    ``auth_token`` carries the secret only on the way IN; it is encrypted
+    server-side and never returned. ``auth_header`` names the custom header
+    for the ``api_key`` auth type (defaults to ``X-Api-Key`` when omitted).
+    """
+
+    base_url: str
+    auth_type: Literal["bearer", "api_key", "basic", "none"]
+    auth_token: str = ""
+    auth_header: str | None = None
+
+
+class PocketBackendConfigResponse(BaseModel):
+    """Backend binding as returned to clients — never carries the token."""
+
+    base_url: str
+    auth_type: str
+    configured: bool
+
+
+class RunSourcesRequest(BaseModel):
+    """Body for ``POST /pockets/{id}/sources/run``.
+
+    ``trigger`` selects sources by refresh policy (``pocket_open`` runs the
+    on-open set; ``manual`` runs the refresh-button set). ``source`` runs a
+    single named source regardless of policy. Both omitted runs every
+    source declared in the spec.
+    """
+
+    trigger: Literal["pocket_open", "manual"] | None = None
+    source: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -10,6 +10,13 @@ close UI-TESTING-GUIDE §11 gap B5 (no widget layout save/share):
 The YAML + in-process store live in ee.cloud.pockets.layouts. Export is
 pure. Template storage is workspace-scoped and in-process for now; the
 REST contract matches the MongoDB-backed version that Wave 4 will ship.
+
+Updated: 2026-05-21 (RFC 04 alpha) — Added three routes for the per-pocket
+backend binding + read-only source-run feature:
+
+    PUT  /pockets/{id}/backend       — bind a pocket to one backend
+    GET  /pockets/{id}/backend       — read the binding summary (no token)
+    POST /pockets/{id}/sources/run   — run the spec's read-only GET sources
 """
 
 from __future__ import annotations
@@ -27,7 +34,10 @@ from pocketpaw_ee.cloud.pockets.dto import (
     AddCollaboratorRequest,
     AddWidgetRequest,
     CreatePocketRequest,
+    PocketBackendConfigRequest,
+    PocketBackendConfigResponse,
     ReorderWidgetsRequest,
+    RunSourcesRequest,
     ShareLinkRequest,
     UpdatePocketRequest,
     UpdateWidgetRequest,
@@ -219,6 +229,95 @@ async def delete_pocket(
 ) -> Response:
     await pockets_service.delete(pocket_id, user_id)
     return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# Backend binding + read-only source run (RFC 04 alpha)
+# ---------------------------------------------------------------------------
+
+
+@router.put("/{pocket_id}/backend", dependencies=[Depends(require_pocket_edit)])
+async def set_pocket_backend(
+    pocket_id: str,
+    body: PocketBackendConfigRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> PocketBackendConfigResponse:
+    """Bind this pocket to one external backend (base URL + auth credential).
+
+    The token is encrypted server-side; the response never echoes it back.
+    A bad base URL (non-https, internal host) yields a 400.
+    """
+    result = await pockets_service.set_pocket_backend(
+        workspace_id,
+        user_id,
+        pocket_id,
+        body.base_url,
+        body.auth_type,
+        body.auth_token,
+        body.auth_header,
+    )
+    return PocketBackendConfigResponse(**result)
+
+
+@router.get("/{pocket_id}/backend")
+async def get_pocket_backend(
+    pocket_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> PocketBackendConfigResponse:
+    """Read this pocket's backend binding summary. Never returns the token.
+
+    Read access mirrors ``get_pocket`` — the service load 404s if the
+    pocket is missing or the caller cannot see it. A 404 here also means
+    "no backend configured" for this pocket.
+    """
+    # Mirror get_pocket's access check before exposing the binding.
+    await pockets_service.get(pocket_id, user_id)
+    result = await pockets_service.get_pocket_backend(workspace_id, pocket_id)
+    if result is None:
+        raise CloudError(404, "pocket_backend.not_found", "No backend configured for this pocket")
+    return PocketBackendConfigResponse(**result)
+
+
+@router.post("/{pocket_id}/sources/run")
+async def run_pocket_sources(
+    pocket_id: str,
+    body: RunSourcesRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Run the pocket's read-only ``rippleSpec.sources`` against its backend.
+
+    Read access mirrors ``get_pocket``. The hydrated state is returned in
+    THIS response body — there is no ``pocket_mutation`` SSE emit, because
+    the run endpoint is a standalone REST call outside any SSE stream.
+    """
+    pocket = await pockets_service.get(pocket_id, user_id)
+    ripple_spec = pocket.get("rippleSpec") or {}
+
+    creds = await pockets_service.get_pocket_backend_for_executor(workspace_id, pocket_id)
+    if creds is None:
+        raise CloudError(
+            400,
+            "pocket_backend.not_configured",
+            "This pocket has no backend configured — set one via PUT /pockets/{id}/backend",
+        )
+    base_url, auth_type, auth_header, token = creds
+
+    from pocketpaw_ee.cloud.pockets import source_executor
+
+    # no-event: source hydration is response-body delivery, not persisted
+    return await source_executor.run_sources(
+        pocket_id=pocket_id,
+        ripple_spec=ripple_spec,
+        base_url=base_url,
+        auth_type=auth_type,
+        auth_header=auth_header,
+        token=token,
+        trigger=body.trigger,
+        only_source=body.source,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -17,6 +17,12 @@ backend binding + read-only source-run feature:
     PUT  /pockets/{id}/backend       — bind a pocket to one backend
     GET  /pockets/{id}/backend       — read the binding summary (no token)
     POST /pockets/{id}/sources/run   — run the spec's read-only GET sources
+
+Updated: 2026-05-21 (PR #1177 security pass) — added the missing
+DELETE /pockets/{id}/backend route so a configured credential can be
+revoked; the GET route now requires pocket edit access (owner/editor),
+matching the PUT route; the source-run route threads user_id into the
+executor for per-user rate limiting + audit logging.
 """
 
 from __future__ import annotations
@@ -260,7 +266,7 @@ async def set_pocket_backend(
     return PocketBackendConfigResponse(**result)
 
 
-@router.get("/{pocket_id}/backend")
+@router.get("/{pocket_id}/backend", dependencies=[Depends(require_pocket_edit)])
 async def get_pocket_backend(
     pocket_id: str,
     workspace_id: str = Depends(current_workspace_id),
@@ -268,8 +274,8 @@ async def get_pocket_backend(
 ) -> PocketBackendConfigResponse:
     """Read this pocket's backend binding summary. Never returns the token.
 
-    Read access mirrors ``get_pocket`` — the service load 404s if the
-    pocket is missing or the caller cannot see it. A 404 here also means
+    Requires pocket **edit** access — backend config metadata is
+    owner/editor-facing, consistent with the PUT route. A 404 here means
     "no backend configured" for this pocket.
     """
     # Mirror get_pocket's access check before exposing the binding.
@@ -278,6 +284,25 @@ async def get_pocket_backend(
     if result is None:
         raise CloudError(404, "pocket_backend.not_found", "No backend configured for this pocket")
     return PocketBackendConfigResponse(**result)
+
+
+@router.delete(
+    "/{pocket_id}/backend",
+    status_code=204,
+    dependencies=[Depends(require_pocket_owner)],
+)
+async def delete_pocket_backend(
+    pocket_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> Response:
+    """Revoke this pocket's backend binding — deletes the stored credential.
+
+    Requires pocket **owner** access. Idempotent: a pocket with no backend
+    configured still returns 204.
+    """
+    await pockets_service.remove_pocket_backend(workspace_id, user_id, pocket_id)
+    return Response(status_code=204)
 
 
 @router.post("/{pocket_id}/sources/run")
@@ -289,9 +314,17 @@ async def run_pocket_sources(
 ) -> dict:
     """Run the pocket's read-only ``rippleSpec.sources`` against its backend.
 
-    Read access mirrors ``get_pocket``. The hydrated state is returned in
-    THIS response body — there is no ``pocket_mutation`` SSE emit, because
-    the run endpoint is a standalone REST call outside any SSE stream.
+    Read access mirrors ``get_pocket`` — deliberately NOT gated on edit
+    access. Any pocket reader may run already-authored sources: that is the
+    core shared-live-pocket UX, where a viewer triggers the ``pocket_open``
+    refresh of a shared dashboard. A viewer cannot change the backend or the
+    source paths (both are edit-only), so the SSRF hardening in
+    ``source_executor`` plus the immutable, edit-authored source list bound
+    the risk to "fetch the same GET bindings the editors already approved".
+
+    The hydrated state is returned in THIS response body — there is no
+    ``pocket_mutation`` SSE emit, because the run endpoint is a standalone
+    REST call outside any SSE stream.
     """
     pocket = await pockets_service.get(pocket_id, user_id)
     ripple_spec = pocket.get("rippleSpec") or {}
@@ -310,6 +343,7 @@ async def run_pocket_sources(
     # no-event: source hydration is response-body delivery, not persisted
     return await source_executor.run_sources(
         pocket_id=pocket_id,
+        user_id=user_id,
         ripple_spec=ripple_spec,
         base_url=base_url,
         auth_type=auth_type,

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -27,6 +27,11 @@ onto the pocketpaw_ee layout from PR #1106).
 Changes: 2026-05-21 (#1172) — ``agent_view`` self-heals node ids via
 ``_heal_node_ids`` so pockets persisted before node-id stamping became
 addressable by granular edit ops on first agent read.
+Changes: 2026-05-21 (RFC 04 alpha) — added the per-pocket backend
+binding API: ``set_pocket_backend``, ``get_pocket_backend``,
+``get_pocket_backend_for_executor``, ``remove_pocket_backend``. The
+credential lives in a SEPARATE collection (``PocketBackendCredential``);
+this service is the sole Beanie writer for it, same as for ``Pocket``.
 """
 
 from __future__ import annotations
@@ -48,7 +53,10 @@ from pocketpaw_ee.cloud._core.realtime.events import (
 )
 from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
 from pocketpaw_ee.cloud.models.pocket import Widget as _WidgetDoc
-from pocketpaw_ee.cloud.pockets import prop_arrays, spec_ops, state_ops
+from pocketpaw_ee.cloud.models.pocket_backend import (
+    PocketBackendCredential as _BackendCredentialDoc,
+)
+from pocketpaw_ee.cloud.pockets import backend_crypto, prop_arrays, spec_ops, state_ops
 from pocketpaw_ee.cloud.pockets.domain import Pocket, Widget, WidgetPosition
 from pocketpaw_ee.cloud.pockets.dto import (
     AddCollaboratorRequest,
@@ -1912,6 +1920,181 @@ async def create_pocket_and_session(
         return None
 
 
+# ---------------------------------------------------------------------------
+# Pocket backend binding (RFC 04 alpha)
+#
+# A pocket is bound to ONE external backend (base URL + auth credential).
+# The credential lives in the separate ``PocketBackendCredential``
+# collection — never on the Pocket document, never in ``rippleSpec``. This
+# service is the sole Beanie writer for that collection.
+# ---------------------------------------------------------------------------
+
+
+def _audit_backend_config(
+    *, actor: str, action: str, workspace_id: str, pocket_id: str, base_url: str, auth_type: str
+) -> None:
+    """Write an audit-log entry for a backend-config mutation.
+
+    Logs ``base_url`` / ``auth_type`` / ``pocket_id`` only — the token is
+    NEVER passed here. Category ``pocket_backend_config``, severity WARNING.
+    Audit failures must not break the config flow, so the call is wrapped.
+    """
+    try:
+        from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+
+        get_audit_logger().log(
+            AuditEvent.create(
+                severity=AuditSeverity.WARNING,
+                actor=actor,
+                action=action,
+                target=pocket_id,
+                status="success",
+                category="pocket_backend_config",
+                workspace_id=workspace_id,
+                pocket_id=pocket_id,
+                base_url=base_url,
+                auth_type=auth_type,
+            )
+        )
+    except Exception:  # noqa: BLE001 — audit must never break the mutation
+        logger.warning("pocket backend config audit-log write failed", exc_info=True)
+
+
+async def set_pocket_backend(
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    base_url: str,
+    auth_type: str,
+    auth_token: str,
+    auth_header: str | None = None,
+) -> dict:
+    """Bind a pocket to one backend — upsert its credential row.
+
+    ``base_url`` is validated strictly (https-only, no internal hosts). The
+    token is encrypted via ``backend_crypto`` before it touches the DB; the
+    plaintext is never persisted or logged. Returns the non-secret summary.
+    """
+    from pocketpaw.security.url_validators import validate_external_url_strict
+
+    # Raises ValueError on a bad URL — surfaces as a 400 via the router.
+    try:
+        base_url = validate_external_url_strict(base_url)
+    except ValueError as exc:
+        raise ValidationError("pocket_backend.invalid_url", str(exc)) from exc
+
+    if auth_type != "none" and not auth_token:
+        raise ValidationError(
+            "pocket_backend.missing_token",
+            f"auth_type '{auth_type}' requires a non-empty auth_token",
+        )
+
+    encrypted_token: bytes | None = None
+    nonce: bytes | None = None
+    salt: bytes | None = None
+    if auth_type != "none":
+        encrypted_token, nonce, salt = backend_crypto.encrypt_token(auth_token)
+
+    existing = await _BackendCredentialDoc.find_one(
+        _BackendCredentialDoc.pocket_id == pocket_id,
+        _BackendCredentialDoc.workspace_id == workspace_id,
+    )
+    if existing is not None:
+        existing.base_url = base_url
+        existing.auth_type = auth_type
+        existing.auth_header = auth_header
+        existing.encrypted_token = encrypted_token
+        existing.nonce = nonce
+        existing.salt = salt
+        await existing.save()
+    else:
+        await _BackendCredentialDoc(
+            pocket_id=pocket_id,
+            workspace_id=workspace_id,
+            base_url=base_url,
+            auth_type=auth_type,
+            auth_header=auth_header,
+            encrypted_token=encrypted_token,
+            nonce=nonce,
+            salt=salt,
+        ).insert()
+
+    _audit_backend_config(
+        actor=user_id,
+        action="pocket.backend.configure",
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        base_url=base_url,
+        auth_type=auth_type,
+    )
+    # no-event: backend credentials are a separate collection, not pocket
+    # state — no downstream handler keys off a PocketUpdated for them.
+    return {"base_url": base_url, "auth_type": auth_type, "configured": True}
+
+
+async def get_pocket_backend(workspace_id: str, pocket_id: str) -> dict | None:
+    """Return the pocket's backend binding summary, or ``None`` if unset.
+
+    NEVER returns the token — only ``base_url`` / ``auth_type`` /
+    ``configured``.
+    """
+    doc = await _BackendCredentialDoc.find_one(
+        _BackendCredentialDoc.pocket_id == pocket_id,
+        _BackendCredentialDoc.workspace_id == workspace_id,
+    )
+    if doc is None:
+        return None
+    return {"base_url": doc.base_url, "auth_type": doc.auth_type, "configured": True}
+
+
+async def get_pocket_backend_for_executor(
+    workspace_id: str, pocket_id: str
+) -> tuple[str, str, str | None, str] | None:
+    """Internal — return ``(base_url, auth_type, auth_header, token)``.
+
+    Decrypts the stored token. Used ONLY by the run-sources route handler
+    to pass credentials to the source executor. Returns ``None`` when the
+    pocket has no backend configured. The plaintext token returned here
+    must never be logged or returned to a client.
+    """
+    doc = await _BackendCredentialDoc.find_one(
+        _BackendCredentialDoc.pocket_id == pocket_id,
+        _BackendCredentialDoc.workspace_id == workspace_id,
+    )
+    if doc is None:
+        return None
+
+    token = ""
+    if doc.auth_type != "none" and doc.encrypted_token and doc.nonce and doc.salt:
+        token = backend_crypto.decrypt_token(doc.encrypted_token, doc.nonce, doc.salt)
+    return doc.base_url, doc.auth_type, doc.auth_header, token
+
+
+async def remove_pocket_backend(workspace_id: str, user_id: str, pocket_id: str) -> None:
+    """Delete a pocket's backend credential row. Idempotent.
+
+    Audit-logs the removal. A no-op (no row) still returns cleanly so the
+    route is idempotent.
+    """
+    doc = await _BackendCredentialDoc.find_one(
+        _BackendCredentialDoc.pocket_id == pocket_id,
+        _BackendCredentialDoc.workspace_id == workspace_id,
+    )
+    if doc is None:
+        return
+    base_url, auth_type = doc.base_url, doc.auth_type
+    await doc.delete()
+    _audit_backend_config(
+        actor=user_id,
+        action="pocket.backend.remove",
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        base_url=base_url,
+        auth_type=auth_type,
+    )
+    # no-event: see set_pocket_backend — credential rows aren't pocket state.
+
+
 __all__ = [
     "access_via_share_link",
     "add_agent",
@@ -1940,16 +2123,20 @@ __all__ = [
     "delete",
     "generate_share_link",
     "get",
+    "get_pocket_backend",
+    "get_pocket_backend_for_executor",
     "has_edit_access",
     "is_member",
     "is_owner",
     "list_pockets",
     "remove_agent",
     "remove_collaborator",
+    "remove_pocket_backend",
     "remove_team_member",
     "remove_widget",
     "reorder_widgets",
     "revoke_share_link",
+    "set_pocket_backend",
     "unassign_project_on_pockets",
     "update",
     "update_share_link",

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -32,6 +32,11 @@ binding API: ``set_pocket_backend``, ``get_pocket_backend``,
 ``get_pocket_backend_for_executor``, ``remove_pocket_backend``. The
 credential lives in a SEPARATE collection (``PocketBackendCredential``);
 this service is the sole Beanie writer for it, same as for ``Pocket``.
+Changes: 2026-05-22 (RFC 04 alpha follow-up) — added the agent-facing
+``rippleSpec.sources`` ops ``agent_set_source`` / ``agent_remove_source``
+so the pocket EDIT specialist (not just the create flow) can author the
+top-level read-only data-source block. Bindings are validated through
+the ``SourceBinding`` model before persistence.
 """
 
 from __future__ import annotations
@@ -44,6 +49,7 @@ from collections import OrderedDict
 from typing import Any
 
 from beanie import PydanticObjectId
+from pydantic import ValidationError as PydanticValidationError
 
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
@@ -56,7 +62,13 @@ from pocketpaw_ee.cloud.models.pocket import Widget as _WidgetDoc
 from pocketpaw_ee.cloud.models.pocket_backend import (
     PocketBackendCredential as _BackendCredentialDoc,
 )
-from pocketpaw_ee.cloud.pockets import backend_crypto, prop_arrays, spec_ops, state_ops
+from pocketpaw_ee.cloud.pockets import (
+    backend_crypto,
+    prop_arrays,
+    sources_ops,
+    spec_ops,
+    state_ops,
+)
 from pocketpaw_ee.cloud.pockets.domain import Pocket, Widget, WidgetPosition
 from pocketpaw_ee.cloud.pockets.dto import (
     AddCollaboratorRequest,
@@ -1775,6 +1787,115 @@ async def agent_patch_state(
         )
 
 
+# ---------------------------------------------------------------------------
+# Granular rippleSpec.sources mutations — agent-facing (RFC 04 alpha)
+# ---------------------------------------------------------------------------
+#
+# The third top-level rippleSpec key, alongside ``ui`` (node ops) and
+# ``state`` (state ops). ``sources`` declares read-only GET data bindings
+# the ``source_executor`` runs against the pocket's configured backend.
+#
+# Unlike hydrated state — which is response-body only and never persisted —
+# a ``sources`` declaration IS part of the pocket document, so these ops
+# call ``doc.save()``. The create flow already accepts ``sources`` in the
+# rippleSpec it persists; these ops give the EDIT specialist the same
+# reach on an existing pocket.
+#
+# Each binding is validated through ``SourceBinding`` (source_executor.py)
+# before it is written — an invalid binding is rejected, never stored.
+
+
+def _sources_root(doc: _PocketDoc) -> dict[str, Any]:
+    """Return the mutable ``rippleSpec`` dict for a doc, creating it if
+    absent. ``sources_ops`` materialises the ``sources`` key on demand."""
+    spec = doc.rippleSpec
+    if not isinstance(spec, dict):
+        spec = {}
+        doc.rippleSpec = spec
+    return spec
+
+
+async def agent_set_source(
+    pocket_id: str,
+    *,
+    source_key: str,
+    binding: dict[str, Any],
+) -> tuple[dict | None, str | None]:
+    """Declare (or replace) a read-only data source on the pocket.
+
+    ``binding`` is validated through the ``SourceBinding`` model — an
+    entry missing ``path`` / ``bind``, or carrying a write verb, is
+    rejected before any write. The validated, normalized binding (with
+    ``refresh`` defaulted) is what gets persisted.
+
+    Returns ``({"source_key": ..., "binding": ..., "pocket": <view>},
+    None)`` on success.
+    """
+    from pocketpaw_ee.cloud.pockets.source_executor import SourceBinding
+
+    if not source_key:
+        return None, "source_key is required"
+    if not isinstance(binding, dict):
+        return None, "binding must be an object"
+    try:
+        validated = SourceBinding.model_validate(binding)
+    except PydanticValidationError as exc:
+        return None, f"invalid source binding: {exc.errors()[0].get('msg', exc)}"
+
+    normalized = validated.model_dump(mode="json")
+    async with _pocket_lock(pocket_id):
+        doc, err = await _agent_load_doc(pocket_id)
+        if err or doc is None:
+            return None, err
+        spec = _sources_root(doc)
+        try:
+            sources_ops.set_source(spec, source_key, normalized)
+        except ValueError as exc:
+            return None, str(exc)
+        try:
+            await doc.save()
+        except Exception as exc:  # noqa: BLE001
+            return None, f"save failed: {exc}"
+        await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+        return (
+            {
+                "source_key": source_key,
+                "binding": normalized,
+                "pocket": _agent_view_dict(doc),
+            },
+            None,
+        )
+
+
+async def agent_remove_source(
+    pocket_id: str,
+    *,
+    source_key: str,
+) -> tuple[dict | None, str | None]:
+    """Remove a read-only data source declaration from the pocket.
+
+    Idempotent — removing a source that was never declared still
+    succeeds. Returns ``({"source_key": ..., "pocket": <view>}, None)``.
+    """
+    if not source_key:
+        return None, "source_key is required"
+    async with _pocket_lock(pocket_id):
+        doc, err = await _agent_load_doc(pocket_id)
+        if err or doc is None:
+            return None, err
+        spec = _sources_root(doc)
+        sources_ops.remove_source(spec, source_key)
+        try:
+            await doc.save()
+        except Exception as exc:  # noqa: BLE001
+            return None, f"save failed: {exc}"
+        await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+        return (
+            {"source_key": source_key, "pocket": _agent_view_dict(doc)},
+            None,
+        )
+
+
 async def agent_create(
     *,
     workspace_id: str,
@@ -2109,10 +2230,12 @@ __all__ = [
     "agent_move_node",
     "agent_patch_state",
     "agent_remove_node",
+    "agent_remove_source",
     "agent_remove_state",
     "agent_remove_widget",
     "agent_replace_node",
     "agent_set_node_prop",
+    "agent_set_source",
     "agent_set_state",
     "agent_update",
     "agent_update_widget",

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -37,6 +37,11 @@ Changes: 2026-05-22 (RFC 04 alpha follow-up) — added the agent-facing
 so the pocket EDIT specialist (not just the create flow) can author the
 top-level read-only data-source block. Bindings are validated through
 the ``SourceBinding`` model before persistence.
+Changes: 2026-05-22 (RFC 04 alpha follow-up 2) — ``agent_view`` now
+attaches a non-secret ``backend`` summary (``{base_url, auth_type,
+configured}``) so the edit specialist knows whether a backend is already
+configured before it authors a ``sources`` block. The token is NEVER
+included — the summary comes from ``get_pocket_backend``.
 """
 
 from __future__ import annotations
@@ -928,6 +933,37 @@ async def _heal_node_ids(doc: _PocketDoc) -> None:
             logger.warning("pocket %s node-id heal save failed: %s", doc.id, exc)
 
 
+async def _agent_backend_summary(doc: _PocketDoc) -> dict[str, Any]:
+    """Return the NON-SECRET backend summary for a pocket, agent-safe.
+
+    Shape: ``{base_url, auth_type, configured}`` — the same shape
+    ``get_pocket_backend`` returns, never the token. When the pocket
+    has no backend configured, returns ``{"configured": False}``.
+
+    The backend credential lives in a separate collection (security
+    design D1), so nothing surfaces it to the edit specialist by
+    default. This makes ``get_pocket`` / ``agent_view`` carry the
+    summary so the specialist knows whether a backend exists and what
+    its base URL is — without ever seeing the token.
+    """
+    try:
+        summary = await get_pocket_backend(doc.workspace, str(doc.id))
+    except Exception:  # noqa: BLE001 — a backend-read failure must not break the view
+        logger.warning(
+            "agent_view: backend summary fetch failed for pocket %s", str(doc.id), exc_info=True
+        )
+        return {"configured": False}
+    if summary is None:
+        return {"configured": False}
+    # get_pocket_backend already excludes the token — assert the shape
+    # and never pass anything else through.
+    return {
+        "base_url": summary.get("base_url"),
+        "auth_type": summary.get("auth_type"),
+        "configured": True,
+    }
+
+
 async def agent_view(pocket_id: str) -> tuple[dict | None, str | None]:
     """Read-only fetch — returns ``(view_dict, None)`` on success or
     ``(None, error)`` on failure.
@@ -937,16 +973,23 @@ async def agent_view(pocket_id: str) -> tuple[dict | None, str | None]:
     id to address with granular edit ops. ``_heal_node_ids`` stamps and
     persists them on first read.
 
+    The returned view carries a non-secret ``backend`` summary
+    (``{base_url, auth_type, configured}``) so the edit specialist can
+    see whether the pocket already has a backend configured before it
+    authors a ``sources`` block. The token is NEVER included.
+
     Note: $source markers in rippleSpec are intentionally NOT resolved
     here. The agent must see raw markers so that on edit it preserves
     them; resolving would let the agent bake a snapshot of live data
     into the spec, defeating the marker mechanism. Resolution happens
     only in ``service.get`` (the user-facing read path)."""
     doc, err = await _agent_load_doc(pocket_id)
-    if err:
+    if err or doc is None:
         return None, err
     await _heal_node_ids(doc)
-    return _agent_view_dict(doc), None
+    view = _agent_view_dict(doc)
+    view["backend"] = await _agent_backend_summary(doc)
+    return view, None
 
 
 async def agent_list(workspace_id: str, user_id: str) -> list[dict]:

--- a/ee/pocketpaw_ee/cloud/pockets/source_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/source_executor.py
@@ -1,0 +1,353 @@
+# source_executor.py — Server-side executor for pocket read-only data sources.
+# Created: 2026-05-21 (RFC 04 alpha) — runs the GET "bindings" declared in a
+#   pocket's `rippleSpec.sources` against the pocket's single configured
+#   backend and returns the JSON results. Read-only (GET) only — write
+#   bindings land in RFC 04 Milestone 2.
+#
+# SSRF BOUNDARY. This module is the ONLY pocket-domain module that makes
+# outbound HTTP. Every defense from the locked security review is enforced
+# here: strict base-URL re-validation, path-traversal rejection, same-host
+# assertion after URL join, DNS rebinding check, no redirect following,
+# tight timeouts, a 512 KB response cap, error-message sanitization, and a
+# per-pocket rate limit.
+#
+# IMPORT-LINTER: must NOT import `pocketpaw_ee.cloud.models.*`. The executor
+# receives base_url / auth / spec by parameter only — `pockets/service.py`
+# owns all Beanie access.
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import socket
+import time
+import urllib.parse
+from typing import Literal
+
+import httpx
+from pydantic import BaseModel, Field, ValidationError
+
+from pocketpaw.security.url_validators import _host_is_internal, validate_external_url_strict
+
+logger = logging.getLogger(__name__)
+
+# --- limits / policy --------------------------------------------------------
+_PER_SOURCE_TIMEOUT_S = 10.0
+_MAX_RESPONSE_BYTES = 524_288  # 512 KB (D11)
+_RATE_LIMIT_MAX = 10  # runs per window per pocket (D16)
+_RATE_LIMIT_WINDOW_S = 60.0
+_HTTP_TIMEOUT = httpx.Timeout(connect=5.0, read=10.0, write=5.0, pool=5.0)  # D10
+
+# Per-pocket run timestamps for the rate limiter. In-memory is fine for the
+# alpha — a single process owns the run endpoint. M3 moves this to a shared
+# store when refresh-cost controls land.
+_run_log: dict[str, list[float]] = {}
+
+# Default refresh policy for a source that omits ``refresh``.
+_DEFAULT_REFRESH: list[Literal["pocket_open", "manual"]] = ["pocket_open"]
+
+
+class SourceBinding(BaseModel):
+    """One read-only data binding parsed from `rippleSpec.sources`.
+
+    Unknown keys on a source entry are ignored — the spec may carry fields
+    a later milestone reads. ``method`` is a Literal so only GET is ever
+    accepted (write verbs are Milestone 2).
+    """
+
+    method: Literal["GET"] = "GET"
+    path: str
+    bind: str
+    refresh: list[Literal["pocket_open", "manual"]] = Field(
+        default_factory=lambda: _DEFAULT_REFRESH.copy()
+    )
+
+
+def _normalize_bind(bind: str) -> str:
+    """Strip a leading ``state.`` from a bind path.
+
+    ``state.prs`` and ``prs`` both target the ``prs`` key of pocket state.
+    """
+    return bind[len("state.") :] if bind.startswith("state.") else bind
+
+
+def _rate_limited(pocket_id: str) -> bool:
+    """Return True when ``pocket_id`` has used its run budget for the window.
+
+    Records the call timestamp when it returns False (call permitted).
+    """
+    now = time.monotonic()
+    window_start = now - _RATE_LIMIT_WINDOW_S
+    stamps = [t for t in _run_log.get(pocket_id, []) if t >= window_start]
+    if len(stamps) >= _RATE_LIMIT_MAX:
+        _run_log[pocket_id] = stamps
+        return True
+    stamps.append(now)
+    _run_log[pocket_id] = stamps
+    return False
+
+
+def _strip_query(url: str) -> str:
+    """Return ``url`` with query string and fragment removed — safe to log."""
+    return urllib.parse.urlsplit(url)._replace(query="", fragment="").geturl()
+
+
+class _SourceError(Exception):
+    """Internal: a per-source failure with an already-sanitized message."""
+
+    def __init__(self, message: str, code: str = "error") -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+
+
+def _resolve_url(base_url: str, path: str) -> str:
+    """Join ``path`` onto ``base_url`` and reject anything that escapes it.
+
+    Implements D7: reject absolute URLs, ``..`` segments, null bytes /
+    non-printable chars, and any join whose resulting netloc differs from
+    the base. Returns the safe absolute URL.
+    """
+    if "\x00" in path or any(not ch.isprintable() for ch in path):
+        raise _SourceError("source path contains illegal characters", code="bad_path")
+
+    split_path = urllib.parse.urlsplit(path)
+    if split_path.scheme or split_path.netloc:
+        raise _SourceError("source path must be relative, not an absolute URL", code="bad_path")
+
+    # Percent-decode and reject traversal segments.
+    decoded = urllib.parse.unquote(split_path.path)
+    if any(seg == ".." for seg in decoded.split("/")):
+        raise _SourceError("source path may not contain '..' segments", code="bad_path")
+
+    joined = urllib.parse.urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
+    if urllib.parse.urlsplit(joined).netloc != urllib.parse.urlsplit(base_url).netloc:
+        raise _SourceError("source path resolves to a different host", code="bad_path")
+    return joined
+
+
+async def _assert_host_external(hostname: str) -> None:
+    """D8 — resolve ``hostname`` and reject if any IP is internal.
+
+    Guards against DNS rebinding: the base URL may be a public name that
+    resolves to a private address. ``getaddrinfo`` runs in a worker thread
+    so the event loop is not blocked.
+    """
+    try:
+        infos = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
+    except socket.gaierror as exc:
+        raise _SourceError("backend host could not be resolved", code="dns_error") from exc
+
+    for info in infos:
+        # info[4] is the sockaddr — (host, port[, flowinfo, scope_id]).
+        ip = str(info[4][0])
+        # strip a zone id (fe80::1%eth0) before parsing
+        ip = ip.split("%", 1)[0]
+        if _host_is_internal(ip):
+            raise _SourceError("backend host resolves to an internal address", code="bad_host")
+        try:
+            addr = ipaddress.ip_address(ip)
+        except ValueError:
+            continue
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+            raise _SourceError("backend host resolves to an internal address", code="bad_host")
+
+
+def _auth_headers(auth_type: str, auth_header: str | None, token: str) -> dict[str, str]:
+    """Build the request auth header for the configured auth type.
+
+    ``none`` adds no header. Unknown types are treated as ``none`` —
+    the DTO Literal already constrains the wire input.
+    """
+    if auth_type == "bearer":
+        return {"Authorization": f"Bearer {token}"}
+    if auth_type == "api_key":
+        return {(auth_header or "X-Api-Key"): token}
+    if auth_type == "basic":
+        return {"Authorization": f"Basic {token}"}
+    return {}
+
+
+def _select_sources(
+    bindings: dict[str, SourceBinding],
+    *,
+    trigger: str | None,
+    only_source: str | None,
+) -> dict[str, SourceBinding]:
+    """Pick which sources to run.
+
+    ``only_source`` wins (single named source); else if ``trigger`` is set,
+    every source whose ``refresh`` list contains it; else all sources.
+    """
+    if only_source is not None:
+        if only_source in bindings:
+            return {only_source: bindings[only_source]}
+        return {}
+    if trigger is not None:
+        return {k: b for k, b in bindings.items() if trigger in b.refresh}
+    return dict(bindings)
+
+
+def _parse_bindings(ripple_spec: dict) -> tuple[dict[str, SourceBinding], list[dict]]:
+    """Parse ``rippleSpec.sources`` into SourceBinding objects.
+
+    Returns ``(valid_bindings, parse_errors)``. A malformed entry becomes a
+    parse error rather than aborting the whole run.
+    """
+    raw = (ripple_spec or {}).get("sources") or {}
+    bindings: dict[str, SourceBinding] = {}
+    errors: list[dict] = []
+    if not isinstance(raw, dict):
+        return bindings, errors
+    for key, entry in raw.items():
+        if not isinstance(entry, dict):
+            errors.append({"source": key, "error": "source entry must be an object"})
+            continue
+        try:
+            bindings[key] = SourceBinding.model_validate(entry)
+        except ValidationError:
+            errors.append({"source": key, "error": "source entry is malformed"})
+    return bindings, errors
+
+
+async def _run_one(
+    *,
+    client: httpx.AsyncClient,
+    key: str,
+    binding: SourceBinding,
+    base_url: str,
+    headers: dict[str, str],
+) -> dict:
+    """Fetch a single source. Returns a ``ran`` row; raises ``_SourceError``."""
+    url = _resolve_url(base_url, binding.path)
+    await _assert_host_external(urllib.parse.urlsplit(url).hostname or "")
+
+    try:
+        resp = await client.get(url, headers=headers)
+    except httpx.HTTPError as exc:
+        # D12 — never propagate raw exception text; log a query-stripped URL.
+        logger.warning(
+            "source %s: request to %s failed: %s",
+            key,
+            _strip_query(url),
+            type(exc).__name__,
+        )
+        raise _SourceError("request to backend failed", code="request_failed") from exc
+
+    # D9 — redirects are disabled on the client; treat any 3xx as an error.
+    if 300 <= resp.status_code < 400:
+        raise _SourceError("backend returned a redirect (not followed)", code="redirect")
+    if resp.status_code >= 400:
+        raise _SourceError(f"backend returned status {resp.status_code}", code="http_error")
+
+    # D11 — reject oversized bodies; never write partial data.
+    body = resp.content
+    if len(body) > _MAX_RESPONSE_BYTES:
+        raise _SourceError("backend response exceeds the 512 KB limit", code="too_large")
+
+    try:
+        value = resp.json()
+    except ValueError as exc:
+        raise _SourceError("backend response is not valid JSON", code="bad_json") from exc
+
+    return {"source": key, "bind": _normalize_bind(binding.bind), "value": value}
+
+
+async def run_sources(
+    *,
+    pocket_id: str,
+    ripple_spec: dict,
+    base_url: str,
+    auth_type: str,
+    auth_header: str | None,
+    token: str,
+    trigger: str | None = None,
+    only_source: str | None = None,
+) -> dict:
+    """Run the pocket's selected read-only sources and return the results.
+
+    The result shape is::
+
+        {"ran": [{"source", "bind", "value"}, ...],
+         "errors": [{"source", "error"}, ...]}
+
+    The executor is pure: it fetches and returns. It does NOT persist to the
+    Pocket document and does NOT emit ``pocket_mutation`` — hydrated state is
+    delivered in the HTTP response body of the calling route.
+    """
+    # D16 — per-pocket rate limit. On breach, return a source-level error
+    # for every selected source without making any call.
+    if _rate_limited(pocket_id):
+        bindings, parse_errors = _parse_bindings(ripple_spec)
+        selected = _select_sources(bindings, trigger=trigger, only_source=only_source)
+        return {
+            "ran": [],
+            "errors": parse_errors
+            + [
+                {"source": key, "error": "rate limit exceeded", "code": "rate_limited"}
+                for key in selected
+            ],
+        }
+
+    # D6/D15 — re-validate the base URL at call time even though config-time
+    # validation already ran. Defense in depth against a tampered row.
+    validate_external_url_strict(base_url)
+
+    bindings, parse_errors = _parse_bindings(ripple_spec)
+    selected = _select_sources(bindings, trigger=trigger, only_source=only_source)
+    headers = _auth_headers(auth_type, auth_header, token)
+
+    ran: list[dict] = []
+    errors: list[dict] = list(parse_errors)
+
+    if not selected:
+        return {"ran": ran, "errors": errors}
+
+    # D9 — redirects disabled. D10 — tight timeouts.
+    async with httpx.AsyncClient(
+        follow_redirects=False,
+        timeout=_HTTP_TIMEOUT,
+    ) as client:
+
+        async def _guarded(key: str, binding: SourceBinding) -> dict:
+            try:
+                return await asyncio.wait_for(
+                    _run_one(
+                        client=client,
+                        key=key,
+                        binding=binding,
+                        base_url=base_url,
+                        headers=headers,
+                    ),
+                    timeout=_PER_SOURCE_TIMEOUT_S,
+                )
+            except TimeoutError:
+                return {
+                    "__error__": {
+                        "source": key,
+                        "error": "source timed out",
+                        "code": "timeout",
+                    }
+                }
+            except _SourceError as exc:
+                return {"__error__": {"source": key, "error": exc.message, "code": exc.code}}
+            except Exception:
+                # Catch-all: never let a raw exception escape into the body.
+                logger.warning("source %s: unexpected failure", key, exc_info=True)
+                return {"__error__": {"source": key, "error": "source failed", "code": "error"}}
+
+        results = await asyncio.gather(
+            *(_guarded(key, binding) for key, binding in selected.items())
+        )
+
+    for result in results:
+        if "__error__" in result:
+            errors.append(result["__error__"])
+        else:
+            ran.append(result)
+
+    return {"ran": ran, "errors": errors}
+
+
+__all__ = ["run_sources", "SourceBinding"]

--- a/ee/pocketpaw_ee/cloud/pockets/source_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/source_executor.py
@@ -3,13 +3,17 @@
 #   pocket's `rippleSpec.sources` against the pocket's single configured
 #   backend and returns the JSON results. Read-only (GET) only — write
 #   bindings land in RFC 04 Milestone 2.
+# Updated: 2026-05-21 (PR #1177 security pass) — basic auth now base64-encodes
+#   the `user:pass` credential; the rate limiter is keyed per (pocket, user)
+#   and guarded by an asyncio.Lock; imports the public `host_is_internal`;
+#   `run_sources` writes an audit-log entry for every run.
 #
 # SSRF BOUNDARY. This module is the ONLY pocket-domain module that makes
 # outbound HTTP. Every defense from the locked security review is enforced
 # here: strict base-URL re-validation, path-traversal rejection, same-host
 # assertion after URL join, DNS rebinding check, no redirect following,
 # tight timeouts, a 512 KB response cap, error-message sanitization, and a
-# per-pocket rate limit.
+# per-(pocket, user) rate limit.
 #
 # IMPORT-LINTER: must NOT import `pocketpaw_ee.cloud.models.*`. The executor
 # receives base_url / auth / spec by parameter only — `pockets/service.py`
@@ -18,6 +22,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import ipaddress
 import logging
 import socket
@@ -28,21 +33,26 @@ from typing import Literal
 import httpx
 from pydantic import BaseModel, Field, ValidationError
 
-from pocketpaw.security.url_validators import _host_is_internal, validate_external_url_strict
+from pocketpaw.security.url_validators import host_is_internal, validate_external_url_strict
 
 logger = logging.getLogger(__name__)
 
 # --- limits / policy --------------------------------------------------------
 _PER_SOURCE_TIMEOUT_S = 10.0
 _MAX_RESPONSE_BYTES = 524_288  # 512 KB (D11)
-_RATE_LIMIT_MAX = 10  # runs per window per pocket (D16)
+_RATE_LIMIT_MAX = 10  # runs per window per (pocket, user) (D16)
 _RATE_LIMIT_WINDOW_S = 60.0
 _HTTP_TIMEOUT = httpx.Timeout(connect=5.0, read=10.0, write=5.0, pool=5.0)  # D10
 
-# Per-pocket run timestamps for the rate limiter. In-memory is fine for the
-# alpha — a single process owns the run endpoint. M3 moves this to a shared
-# store when refresh-cost controls land.
-_run_log: dict[str, list[float]] = {}
+# Per-(pocket, user) run timestamps for the rate limiter. Keyed on both so a
+# single member cannot exhaust another member's budget on a shared pocket.
+# In-memory is fine for the alpha — a single process owns the run endpoint.
+# M3 moves this to a shared store when refresh-cost controls land.
+_run_log: dict[tuple[str, str], list[float]] = {}
+
+# Guards the check-and-record on ``_run_log``. The read-filter-write is a
+# TOCTOU race under ``asyncio.gather``; the lock makes it atomic.
+_run_log_lock = asyncio.Lock()
 
 # Default refresh policy for a source that omits ``refresh``.
 _DEFAULT_REFRESH: list[Literal["pocket_open", "manual"]] = ["pocket_open"]
@@ -72,25 +82,60 @@ def _normalize_bind(bind: str) -> str:
     return bind[len("state.") :] if bind.startswith("state.") else bind
 
 
-def _rate_limited(pocket_id: str) -> bool:
-    """Return True when ``pocket_id`` has used its run budget for the window.
+async def _rate_limited(pocket_id: str, user_id: str) -> bool:
+    """Return True when ``(pocket_id, user_id)`` has used its run budget.
 
-    Records the call timestamp when it returns False (call permitted).
+    Records the call timestamp when it returns False (call permitted). The
+    check-and-record runs under ``_run_log_lock`` so concurrent runs cannot
+    race past the limit (TOCTOU under ``asyncio.gather``).
     """
+    key = (pocket_id, user_id)
     now = time.monotonic()
     window_start = now - _RATE_LIMIT_WINDOW_S
-    stamps = [t for t in _run_log.get(pocket_id, []) if t >= window_start]
-    if len(stamps) >= _RATE_LIMIT_MAX:
-        _run_log[pocket_id] = stamps
-        return True
-    stamps.append(now)
-    _run_log[pocket_id] = stamps
-    return False
+    async with _run_log_lock:
+        stamps = [t for t in _run_log.get(key, []) if t >= window_start]
+        if len(stamps) >= _RATE_LIMIT_MAX:
+            _run_log[key] = stamps
+            return True
+        stamps.append(now)
+        _run_log[key] = stamps
+        return False
 
 
 def _strip_query(url: str) -> str:
     """Return ``url`` with query string and fragment removed — safe to log."""
     return urllib.parse.urlsplit(url)._replace(query="", fragment="").geturl()
+
+
+def _audit_source_run(
+    *, actor: str, pocket_id: str, status: str, base_url: str, ran: int, errors: int
+) -> None:
+    """Write an audit-log entry for a source run.
+
+    Mirrors ``pockets/service.py:_audit_backend_config`` — same audit path,
+    category ``pocket_backend_config``, severity WARNING. The token is NEVER
+    passed; ``base_url`` is query-stripped before it is logged. Audit
+    failures must not break the run, so the call is wrapped.
+    """
+    try:
+        from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+
+        get_audit_logger().log(
+            AuditEvent.create(
+                severity=AuditSeverity.WARNING,
+                actor=actor,
+                action="pocket.sources.run",
+                target=pocket_id,
+                status=status,
+                category="pocket_backend_config",
+                pocket_id=pocket_id,
+                base_url=_strip_query(base_url),
+                ran=ran,
+                errors=errors,
+            )
+        )
+    except Exception:  # noqa: BLE001 — audit must never break the run
+        logger.warning("pocket source-run audit-log write failed", exc_info=True)
 
 
 class _SourceError(Exception):
@@ -144,7 +189,7 @@ async def _assert_host_external(hostname: str) -> None:
         ip = str(info[4][0])
         # strip a zone id (fe80::1%eth0) before parsing
         ip = ip.split("%", 1)[0]
-        if _host_is_internal(ip):
+        if host_is_internal(ip):
             raise _SourceError("backend host resolves to an internal address", code="bad_host")
         try:
             addr = ipaddress.ip_address(ip)
@@ -159,13 +204,17 @@ def _auth_headers(auth_type: str, auth_header: str | None, token: str) -> dict[s
 
     ``none`` adds no header. Unknown types are treated as ``none`` —
     the DTO Literal already constrains the wire input.
+
+    For ``basic`` the stored token is the raw ``user:pass`` credential; it
+    is base64-encoded here to form a valid ``Authorization: Basic`` header.
     """
     if auth_type == "bearer":
         return {"Authorization": f"Bearer {token}"}
     if auth_type == "api_key":
         return {(auth_header or "X-Api-Key"): token}
     if auth_type == "basic":
-        return {"Authorization": f"Basic {token}"}
+        encoded = base64.b64encode(token.encode()).decode()
+        return {"Authorization": f"Basic {encoded}"}
     return {}
 
 
@@ -257,6 +306,7 @@ async def _run_one(
 async def run_sources(
     *,
     pocket_id: str,
+    user_id: str,
     ripple_spec: dict,
     base_url: str,
     auth_type: str,
@@ -275,12 +325,23 @@ async def run_sources(
     The executor is pure: it fetches and returns. It does NOT persist to the
     Pocket document and does NOT emit ``pocket_mutation`` — hydrated state is
     delivered in the HTTP response body of the calling route.
+
+    ``user_id`` keys the rate limiter (per pocket *and* per user) and is the
+    actor on the audit-log entry written for every run.
     """
-    # D16 — per-pocket rate limit. On breach, return a source-level error
-    # for every selected source without making any call.
-    if _rate_limited(pocket_id):
+    # D16 — per-(pocket, user) rate limit. On breach, return a source-level
+    # error for every selected source without making any call.
+    if await _rate_limited(pocket_id, user_id):
         bindings, parse_errors = _parse_bindings(ripple_spec)
         selected = _select_sources(bindings, trigger=trigger, only_source=only_source)
+        _audit_source_run(
+            actor=user_id,
+            pocket_id=pocket_id,
+            status="rate-limited",
+            base_url=base_url,
+            ran=0,
+            errors=len(parse_errors) + len(selected),
+        )
         return {
             "ran": [],
             "errors": parse_errors
@@ -292,7 +353,18 @@ async def run_sources(
 
     # D6/D15 — re-validate the base URL at call time even though config-time
     # validation already ran. Defense in depth against a tampered row.
-    validate_external_url_strict(base_url)
+    try:
+        validate_external_url_strict(base_url)
+    except ValueError:
+        _audit_source_run(
+            actor=user_id,
+            pocket_id=pocket_id,
+            status="rejected",
+            base_url=base_url,
+            ran=0,
+            errors=0,
+        )
+        raise
 
     bindings, parse_errors = _parse_bindings(ripple_spec)
     selected = _select_sources(bindings, trigger=trigger, only_source=only_source)
@@ -302,6 +374,14 @@ async def run_sources(
     errors: list[dict] = list(parse_errors)
 
     if not selected:
+        _audit_source_run(
+            actor=user_id,
+            pocket_id=pocket_id,
+            status="success",
+            base_url=base_url,
+            ran=0,
+            errors=len(errors),
+        )
         return {"ran": ran, "errors": errors}
 
     # D9 — redirects disabled. D10 — tight timeouts.
@@ -347,6 +427,14 @@ async def run_sources(
         else:
             ran.append(result)
 
+    _audit_source_run(
+        actor=user_id,
+        pocket_id=pocket_id,
+        status="success",
+        base_url=base_url,
+        ran=len(ran),
+        errors=len(errors),
+    )
     return {"ran": ran, "errors": errors}
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/sources_ops.py
+++ b/ee/pocketpaw_ee/cloud/pockets/sources_ops.py
@@ -1,0 +1,65 @@
+# sources_ops.py — Pure mutate helpers for ``rippleSpec.sources``.
+# Created: 2026-05-22 (RFC 04 alpha follow-up) — closes the edit-path gap:
+#   RFC 04 lets a pocket carry a top-level ``rippleSpec.sources`` block of
+#   read-only GET data bindings. It worked on CREATE but the pocket EDIT
+#   specialist had no op that could write the ``sources`` key on an
+#   EXISTING pocket. This module is the pure-helper sibling of
+#   ``state_ops.py`` (which mutates ``rippleSpec.state``) and
+#   ``spec_ops.py`` (which mutates ``rippleSpec.ui``) — it owns the
+#   third top-level key.
+#
+# These helpers are side-effect-free: they take and return plain ``dict``
+# structures, never touch Beanie or the SSE bus, and never log. The
+# service layer (``service.py``) wraps them with binding validation,
+# persistence, and event emission. Keeping this module Beanie-free is an
+# import-linter contract (``ee/pyproject.toml``).
+#
+# Unlike ``state`` (dotted-path addressable) a source entry is keyed by a
+# single flat name — ``sources["prs"]`` — so these helpers take a bare
+# ``key`` rather than a path. The binding *value* is validated upstream by
+# the ``SourceBinding`` Pydantic model in ``source_executor.py``; this
+# module stores whatever dict it is handed.
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def set_source(spec: dict[str, Any], key: str, binding: dict[str, Any]) -> dict[str, Any]:
+    """Write ``binding`` at ``spec["sources"][key]``, creating the
+    ``sources`` dict if it is absent. Overwrites an existing entry.
+
+    Returns ``spec`` (mutated in place) so callers can chain.
+
+    Raises ``ValueError`` if ``key`` is empty or if ``spec["sources"]``
+    exists but is not a dict (a malformed spec the agent should not be
+    appending to).
+    """
+    if not key:
+        raise ValueError("source key is required")
+    sources = spec.get("sources")
+    if sources is None:
+        sources = {}
+        spec["sources"] = sources
+    if not isinstance(sources, dict):
+        raise ValueError(
+            f"rippleSpec.sources is a {type(sources).__name__}, expected an object"
+        )
+    sources[key] = binding
+    return spec
+
+
+def remove_source(spec: dict[str, Any], key: str) -> dict[str, Any]:
+    """Remove ``spec["sources"][key]``. No-op when the ``sources`` block
+    or the key is absent — removal is idempotent so the agent can call it
+    without first checking existence.
+
+    Returns ``spec`` (mutated in place).
+    """
+    sources = spec.get("sources")
+    if isinstance(sources, dict):
+        sources.pop(key, None)
+    return spec
+
+
+__all__ = ["remove_source", "set_source"]

--- a/ee/pocketpaw_ee/cloud/pockets/sources_ops.py
+++ b/ee/pocketpaw_ee/cloud/pockets/sources_ops.py
@@ -42,9 +42,7 @@ def set_source(spec: dict[str, Any], key: str, binding: dict[str, Any]) -> dict[
         sources = {}
         spec["sources"] = sources
     if not isinstance(sources, dict):
-        raise ValueError(
-            f"rippleSpec.sources is a {type(sources).__name__}, expected an object"
-        )
+        raise ValueError(f"rippleSpec.sources is a {type(sources).__name__}, expected an object")
     sources[key] = binding
     return spec
 

--- a/ee/pocketpaw_ee/cloud/ripple_normalizer.py
+++ b/ee/pocketpaw_ee/cloud/ripple_normalizer.py
@@ -72,9 +72,7 @@ def _looks_like_rest_source(entry: dict[str, Any]) -> bool:
     return has_endpoint and has_target
 
 
-def _lifted_source_entry(
-    entry: dict[str, Any], key: str
-) -> dict[str, Any] | None:
+def _lifted_source_entry(entry: dict[str, Any], key: str) -> dict[str, Any] | None:
     """Translate one hallucinated REST ``tool_specs`` entry into a canonical
     ``rippleSpec.sources`` entry. Returns ``None`` when the entry cannot be
     represented as an alpha source (non-GET method — alpha is GET-only).
@@ -91,9 +89,7 @@ def _lifted_source_entry(
 
     raw_path = entry.get("path") or entry.get("url")
     if not isinstance(raw_path, str) or not raw_path:
-        log.warning(
-            "ripple_normalizer: skipped tool_specs entry %r — no path/url", key
-        )
+        log.warning("ripple_normalizer: skipped tool_specs entry %r — no path/url", key)
         return None
 
     into = entry.get("into")
@@ -196,9 +192,9 @@ def _lift_rest_sources(spec: dict[str, Any]) -> dict[str, Any]:
     passes through structurally unchanged.
     """
     result = spec
-    sources: dict[str, Any] = dict(spec.get("sources") or {}) if isinstance(
-        spec.get("sources"), dict
-    ) else {}
+    sources: dict[str, Any] = (
+        dict(spec.get("sources") or {}) if isinstance(spec.get("sources"), dict) else {}
+    )
 
     raw_tool_specs = spec.get("tool_specs")
     if isinstance(raw_tool_specs, list) and raw_tool_specs:
@@ -237,9 +233,7 @@ def _lift_rest_sources(spec: dict[str, Any]) -> dict[str, Any]:
     if isinstance(result.get("panes"), dict):
         result = {
             **result,
-            "panes": {
-                k: _walk_repair_handlers(v, sources) for k, v in result["panes"].items()
-            },
+            "panes": {k: _walk_repair_handlers(v, sources) for k, v in result["panes"].items()},
         }
     return result
 

--- a/ee/pocketpaw_ee/cloud/ripple_normalizer.py
+++ b/ee/pocketpaw_ee/cloud/ripple_normalizer.py
@@ -7,15 +7,241 @@ routes through this normalizer, so stored specs always carry node ids
 and the chat agent can address nodes with granular edit ops. Previously
 ids were minted only at the start of a granular mutation op, leaving a
 freshly created pocket's tree id-less and unaddressable.
+
+Changes: 2026-05-22 (PR #1177, RFC 04 alpha) — ``normalize_ripple_spec``
+now runs ``_lift_rest_sources`` before everything else. The
+pocket-authoring agent reliably emits a hallucinated data-source shape:
+a ``rippleSpec.tool_specs`` REST list (with invented ``kind`` / ``url``
+/ ``auto_fetch`` / ``into`` fields) instead of the RFC 04
+``rippleSpec.sources`` block, and refresh buttons wired with a ``source_id``
+field instead of ``source``. The runtime reads only ``sources`` and only
+``handler.source``, so that output is inert. Prompt guidance has not
+beaten the model's prior, so we translate the output deterministically:
+lift the REST entries into ``sources`` and repair the button handlers.
 """
 
 from __future__ import annotations
 
 import logging
 import secrets
+import urllib.parse
 from typing import Any
 
 log = logging.getLogger(__name__)
+
+
+# Event-handler slots a node may carry. A run_source button uses one of
+# these (``on_click`` in practice); the repair walk checks all of them.
+_HANDLER_SLOTS = (
+    "on_click",
+    "on_change",
+    "on_input",
+    "on_submit",
+    "on_focus",
+    "on_blur",
+)
+
+
+def _relative_path(raw: str) -> str:
+    """Return ``raw`` as a relative path. If ``raw`` is an absolute URL,
+    keep only its path + query portion (the source executor joins it onto
+    the pocket's configured backend base URL). A path that is already
+    relative is returned untouched.
+    """
+    split = urllib.parse.urlsplit(raw)
+    if split.scheme or split.netloc:
+        rebuilt = split.path or "/"
+        if split.query:
+            rebuilt = f"{rebuilt}?{split.query}"
+        return rebuilt
+    return raw
+
+
+def _looks_like_rest_source(entry: dict[str, Any]) -> bool:
+    """Heuristic: is this ``tool_specs`` entry a REST data source?
+
+    True when it declares ``kind == "rest"``, or when it carries both a
+    ``url``/``path`` and an ``into``/``bind`` — the minimum a data binding
+    needs. LLM-tool specs (the legitimate ``tool_specs`` shape) carry none
+    of these and are left alone.
+    """
+    if entry.get("kind") == "rest":
+        return True
+    has_endpoint = bool(entry.get("url")) or bool(entry.get("path"))
+    has_target = bool(entry.get("into")) or bool(entry.get("bind"))
+    return has_endpoint and has_target
+
+
+def _lifted_source_entry(
+    entry: dict[str, Any], key: str
+) -> dict[str, Any] | None:
+    """Translate one hallucinated REST ``tool_specs`` entry into a canonical
+    ``rippleSpec.sources`` entry. Returns ``None`` when the entry cannot be
+    represented as an alpha source (non-GET method — alpha is GET-only).
+    """
+    method = str(entry.get("method") or "GET").upper()
+    if method != "GET":
+        log.warning(
+            "ripple_normalizer: skipped tool_specs entry %r — method %s "
+            "is not GET (RFC 04 alpha is read-only)",
+            key,
+            method,
+        )
+        return None
+
+    raw_path = entry.get("path") or entry.get("url")
+    if not isinstance(raw_path, str) or not raw_path:
+        log.warning(
+            "ripple_normalizer: skipped tool_specs entry %r — no path/url", key
+        )
+        return None
+
+    into = entry.get("into")
+    bind = entry.get("bind")
+    if isinstance(bind, str) and bind:
+        resolved_bind = bind
+    elif isinstance(into, str) and into:
+        resolved_bind = f"state.{into}"
+    else:
+        resolved_bind = f"state.{key}"
+
+    refresh = entry.get("refresh")
+    if isinstance(refresh, list) and refresh:
+        resolved_refresh = refresh
+    elif entry.get("auto_fetch"):
+        resolved_refresh = ["pocket_open", "manual"]
+    else:
+        resolved_refresh = ["manual"]
+
+    return {
+        "method": "GET",
+        "path": _relative_path(raw_path),
+        "bind": resolved_bind,
+        "refresh": resolved_refresh,
+    }
+
+
+def _repair_run_source_handler(handler: Any, sources: dict[str, Any]) -> Any:
+    """Repair a single action handler that targets ``run_source``.
+
+    Fixes the agent's ``source_id`` field-name miss (the runtime reads
+    ``handler.source``), and binds a sourceless handler to the lone source
+    when there is exactly one. Non-``run_source`` handlers pass through.
+    """
+    if not isinstance(handler, dict) or handler.get("action") != "run_source":
+        return handler
+    repaired = dict(handler)
+    if "source" not in repaired and "source_id" in repaired:
+        repaired["source"] = repaired.pop("source_id")
+    elif "source_id" in repaired:
+        # `source` already present — drop the stray alias.
+        repaired.pop("source_id")
+    if not repaired.get("source") and len(sources) == 1:
+        repaired["source"] = next(iter(sources))
+    return repaired
+
+
+def _repair_handlers_in_node(node: dict[str, Any], sources: dict[str, Any]) -> dict[str, Any]:
+    """Repair every ``run_source`` handler reachable from a node's event
+    slots. A slot value can be a single handler object or a list of them.
+    """
+    repaired = node
+    for slot in _HANDLER_SLOTS:
+        if slot not in repaired:
+            continue
+        value = repaired[slot]
+        if isinstance(value, list):
+            new_value: Any = [_repair_run_source_handler(h, sources) for h in value]
+        else:
+            new_value = _repair_run_source_handler(value, sources)
+        if new_value != value:
+            repaired = {**repaired, slot: new_value}
+    return repaired
+
+
+def _walk_repair_handlers(node: Any, sources: dict[str, Any]) -> Any:
+    """Recursively walk a UI structure (dict tree or list) repairing every
+    ``run_source`` handler. Returns a new structure; input is not mutated.
+    """
+    if isinstance(node, dict):
+        fixed = _repair_handlers_in_node(node, sources)
+        for key in ("children", "else_children"):
+            kids = fixed.get(key)
+            if isinstance(kids, list):
+                fixed = {**fixed, key: [_walk_repair_handlers(c, sources) for c in kids]}
+        return fixed
+    if isinstance(node, list):
+        return [_walk_repair_handlers(c, sources) for c in node]
+    return node
+
+
+def _lift_rest_sources(spec: dict[str, Any]) -> dict[str, Any]:
+    """Translate the authoring agent's hallucinated data-source output into
+    the canonical RFC 04 shape.
+
+    Two repairs, both pure (the input ``spec`` is not mutated):
+
+    1. Lift REST entries out of a ``rippleSpec.tool_specs`` list into
+       ``rippleSpec.sources``. ``tool_specs`` is NOT a real rippleSpec field
+       (the real ``tool_specs`` is a top-level Pocket field for LLM tools);
+       the agent invents it for data sources. Lifted entries are removed
+       from the nested ``tool_specs`` list, and the key is dropped entirely
+       once empty. A correctly-authored ``sources`` block is never clobbered
+       — lifted entries merge in without overwriting existing keys.
+    2. Repair ``run_source`` button handlers — rename the agent's
+       ``source_id`` field to ``source``, and bind a sourceless handler to
+       the lone source when there is exactly one.
+
+    A spec with no nested ``tool_specs`` and no ``run_source`` handlers
+    passes through structurally unchanged.
+    """
+    result = spec
+    sources: dict[str, Any] = dict(spec.get("sources") or {}) if isinstance(
+        spec.get("sources"), dict
+    ) else {}
+
+    raw_tool_specs = spec.get("tool_specs")
+    if isinstance(raw_tool_specs, list) and raw_tool_specs:
+        remaining: list[Any] = []
+        lifted_any = False
+        generated = 0
+        for entry in raw_tool_specs:
+            if not isinstance(entry, dict) or not _looks_like_rest_source(entry):
+                remaining.append(entry)
+                continue
+            key = entry.get("id") or entry.get("into")
+            if not isinstance(key, str) or not key:
+                generated += 1
+                key = f"src_{generated}"
+            lifted = _lifted_source_entry(entry, key)
+            if lifted is None:
+                # Non-GET / unrepresentable — drop it (not a real LLM tool
+                # spec either, so it does not belong back in tool_specs).
+                lifted_any = True
+                continue
+            lifted_any = True
+            # Do not clobber a correctly-authored source under the same key.
+            if key not in sources:
+                sources[key] = lifted
+        if lifted_any:
+            new_spec = {k: v for k, v in result.items() if k != "tool_specs"}
+            if remaining:
+                new_spec["tool_specs"] = remaining
+            if sources:
+                new_spec["sources"] = sources
+            result = new_spec
+
+    # Repair run_source handlers across every UI surface.
+    if isinstance(result.get("ui"), (dict, list)):
+        result = {**result, "ui": _walk_repair_handlers(result["ui"], sources)}
+    if isinstance(result.get("panes"), dict):
+        result = {
+            **result,
+            "panes": {
+                k: _walk_repair_handlers(v, sources) for k, v in result["panes"].items()
+            },
+        }
+    return result
 
 
 def _stamp_node_ids(ui: Any) -> Any:
@@ -156,6 +382,12 @@ def normalize_ripple_spec(spec: dict[str, Any] | None) -> dict[str, Any] | None:
     """
     if not spec or not isinstance(spec, dict):
         return None
+
+    # Translate the authoring agent's hallucinated data-source output
+    # (``rippleSpec.tool_specs`` REST list + ``source_id`` buttons) into the
+    # canonical RFC 04 shape before any other normalization. Pure: returns
+    # a new dict, leaves a correctly-authored spec structurally unchanged.
+    spec = _lift_rest_sources(spec)
 
     name = spec.get("title") or spec.get("name")
     pocket_id = spec.get("id") or (spec.get("lifecycle") or {}).get("id") or f"pocket-{_short_id()}"

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -171,9 +171,11 @@ source_modules = [
     "pocketpaw_ee.cloud.pockets.dto",
     "pocketpaw_ee.cloud.pockets.domain",
     "pocketpaw_ee.cloud.pockets.agent_context",
+    "pocketpaw_ee.cloud.pockets.source_executor",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.pocket",
+    "pocketpaw_ee.cloud.models.pocket_backend",
     "pocketpaw_ee.cloud.models.session",
 ]
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -172,6 +172,7 @@ source_modules = [
     "pocketpaw_ee.cloud.pockets.domain",
     "pocketpaw_ee.cloud.pockets.agent_context",
     "pocketpaw_ee.cloud.pockets.source_executor",
+    "pocketpaw_ee.cloud.pockets.sources_ops",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.pocket",

--- a/src/pocketpaw/ripple/__init__.py
+++ b/src/pocketpaw/ripple/__init__.py
@@ -12,10 +12,14 @@
 #
 #   * POCKET_INTERACTION_PROMPT_{MCP,CLI} — when the conversation is anchored
 #     to an existing pocket. Read/write/chat intent flow with `get_pocket`
-#     first. Contains a literal ``__POCKET_ID__`` token (POCKET_ID_TOKEN) the
-#     caller replaces before injection.
+#     first. Contains literal ``__POCKET_ID__`` (POCKET_ID_TOKEN) and
+#     ``__BACKEND_SUMMARY__`` (BACKEND_SUMMARY_TOKEN) tokens — fill BOTH
+#     via ``fill_current_pocket`` before injection.
 #
 # Use ``get_pocket_prompts(backend_name=...)`` to pick the right pair.
+#
+# Changes: 2026-05-22 (RFC 04 alpha follow-up 2) — re-export the new
+# ``fill_current_pocket`` helper + ``BACKEND_SUMMARY_TOKEN``.
 #
 # Model selection, sampling parameters, and prompt caching are decided by
 # the agent backend — this module exports prompt strings only.
@@ -25,6 +29,7 @@ from __future__ import annotations
 from pocketpaw.ripple._design import RIPPLE_DESIGN_RULES
 from pocketpaw.ripple._inline import INLINE_RIPPLE_SYSTEM_PROMPT
 from pocketpaw.ripple._pockets import (
+    BACKEND_SUMMARY_TOKEN,
     POCKET_CREATION_PROMPT,
     POCKET_CREATION_PROMPT_CLI,
     POCKET_CREATION_PROMPT_MCP,
@@ -36,10 +41,12 @@ from pocketpaw.ripple._pockets import (
     POCKET_INTERACTION_PROMPT_CLI,
     POCKET_INTERACTION_PROMPT_MCP,
     POCKET_SPECIALIST_PROMPT,
+    fill_current_pocket,
     get_pocket_prompts,
 )
 
 __all__ = [
+    "BACKEND_SUMMARY_TOKEN",
     "INLINE_RIPPLE_SYSTEM_PROMPT",
     "POCKET_CREATION_PROMPT",
     "POCKET_CREATION_PROMPT_CLI",
@@ -53,5 +60,6 @@ __all__ = [
     "POCKET_INTERACTION_PROMPT_MCP",
     "POCKET_SPECIALIST_PROMPT",
     "RIPPLE_DESIGN_RULES",
+    "fill_current_pocket",
     "get_pocket_prompts",
 ]

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -508,6 +508,28 @@ Rules:
   widget renders before the first fetch.
 - Use `sources` ONLY for the user's real backend. For workspace data use
   the `$source` markers above; for canvas-local input use literal values.
+
+DO NOT GET THIS WRONG — the runtime reads `rippleSpec.sources` and
+nothing else:
+- Data sources go in `rippleSpec.sources` ONLY. NEVER put them in
+  `tool_specs` — `tool_specs` is for LLM tools, not data, and a
+  `tool_specs` entry inside the rippleSpec is silently inert.
+- A source entry has EXACTLY four fields: `method`, `path`, `bind`,
+  `refresh`. Do NOT invent `kind`, `url`, `auto_fetch`, `into`, or `id` —
+  none of those exist and the source will not run.
+- The refresh button targets the source by `source` (the sources-map
+  key). NEVER use `source_id`.
+
+  WRONG — inert, the runtime ignores all of this:
+    "tool_specs": [{"id": "src_todos", "kind": "rest", "method": "GET",
+                    "url": "/todos", "auto_fetch": true, "into": "todos"}]
+    {"action": "run_source", "source_id": "src_todos"}
+
+  RIGHT:
+    "sources": {"todos": {"method": "GET", "path": "/todos",
+                          "bind": "state.todos",
+                          "refresh": ["pocket_open", "manual"]}}
+    {"action": "run_source", "source": "todos"}
 </live-data-sources>
 """
 
@@ -569,6 +591,22 @@ Rules:
   `run_source` action.
 - Use sources ONLY for the user's real backend. For workspace data use
   the `$source` markers; for canvas-local input use literal values.
+
+DO NOT GET THIS WRONG — the runtime reads `rippleSpec.sources` and
+nothing else:
+- Live data sources go in `rippleSpec.sources` ONLY, written via
+  `set_source`. NEVER author a `tool_specs` entry for data — `tool_specs`
+  is for LLM tools, not data, and is silently inert as a data source.
+- A source is EXACTLY `{method, path, bind, refresh}`. Do NOT invent
+  `kind`, `url`, `auto_fetch`, `into`, or `id` — they do not exist.
+- The refresh button targets the source by `source` (the source key),
+  NEVER `source_id`.
+
+  WRONG — inert, the runtime ignores it:
+    {"action": "run_source", "source_id": "todos"}
+
+  RIGHT:
+    {"action": "run_source", "source": "todos"}
 </live-data-sources>
 """
 

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -1,5 +1,10 @@
 # pocketpaw/ripple/_pockets.py — System prompts for the Ripple Pockets surface.
 #
+# Changes: 2026-05-21 (RFC 04 alpha) — added `_LIVE_DATA_SOURCES_BLOCK`,
+# spliced into the create specialist prompt. It teaches the agent to
+# declare a `sources` block (read-only GET bindings) and a `run_source`
+# refresh button when the user wants live data from a real backend.
+#
 # Changes: 2026-05-21 (#1163) — the edit-specialist prompt now splices in
 # `_EDIT_TOOLS_MCP`, a tools block naming the granular edit ops the
 # specialist ACTUALLY holds (get_pocket, the state/node/array-item ops),
@@ -439,6 +444,48 @@ the widget rather than fabricating rows.
 
 Unknown source names resolve to `null`. Stick to the allowlist above.
 </state-sources>
+"""
+
+
+_LIVE_DATA_SOURCES_BLOCK = """\
+<live-data-sources>
+When the user wants live data from THEIR OWN backend (a CRM, an internal
+API, a service with a base URL + token) — not the workspace `$source`
+markers above — declare a `sources` block in the rippleSpec. Alpha is
+READ-ONLY: GET bindings only.
+
+  "rippleSpec": {
+    "sources": {
+      "prs": {
+        "method": "GET",
+        "path": "/pulls?state=open",
+        "bind": "state.prs",
+        "refresh": ["pocket_open", "manual"]
+      }
+    },
+    "ui": [ ... ],
+    "state": { "prs": [] }
+  }
+
+Each source entry: `method` (always "GET"), `path` (a RELATIVE path
+against the pocket's backend — never an absolute URL), `bind` (a dotted
+`state.` path the result is written to), and `refresh` (when to run it —
+`pocket_open` on open, `manual` for a refresh button).
+
+For a manual refresh, add a button wired to the `run_source` action:
+
+  {"type": "button", "props": {"label": "Refresh"},
+   "on_click": {"action": "run_source", "source": "prs"}}
+
+Rules:
+- A pocket using `sources` MUST have a backend configured (base URL +
+  auth, set once via the pocket's backend settings — outside the spec).
+  If no backend is configured, the sources will not run.
+- Seed `state` with an empty list/value for each `bind` target so the
+  widget renders before the first fetch.
+- Use `sources` ONLY for the user's real backend. For workspace data use
+  the `$source` markers above; for canvas-local input use literal values.
+</live-data-sources>
 """
 
 
@@ -1473,6 +1520,7 @@ def _assemble_specialist() -> str:
         _SPECIALIST_WORKFLOW,
         _INTERACTIVE_DEFAULT_BLOCK,
         _STATE_SOURCES_BLOCK,
+        _LIVE_DATA_SOURCES_BLOCK,
         _CREATION_EXAMPLES_MCP,
         _RESEARCH_PROTOCOL,
         _RIPPLE_DESIGN_ESSENTIALS,

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -19,6 +19,13 @@
 # splices in `_LIVE_DATA_SOURCES_EDIT_BLOCK` so the EDIT specialist (not
 # just the create flow) knows it can author a `rippleSpec.sources` block.
 #
+# Changes: 2026-05-22 (RFC 04 alpha follow-up 2) — `_CURRENT_POCKET_BLOCK`
+# now carries a `Backend:` line (the non-secret {base_url, auth_type,
+# configured} summary), filled via the new `fill_current_pocket` helper +
+# `BACKEND_SUMMARY_TOKEN`. The sources prompt blocks tell the specialist
+# to read that line instead of asking the user for a backend URL it can
+# already see.
+#
 # Canonical source for every pocket-mode system prompt the agent ever sees.
 # Four strings are exported, one per (action × backend) cell:
 #
@@ -104,6 +111,10 @@ _RIPPLE_DESIGN_ESSENTIALS = "\n".join(
 )
 
 POCKET_ID_TOKEN = "__POCKET_ID__"
+# Placeholder in _CURRENT_POCKET_BLOCK_TEMPLATE for the non-secret backend
+# summary line. Filled by ``fill_current_pocket`` — callers that only have
+# the pocket id pass ``backend_summary=None`` and the line reads "unknown".
+BACKEND_SUMMARY_TOKEN = "__BACKEND_SUMMARY__"
 
 # ---------------------------------------------------------------------------
 # Backends that delegate pocket creation/editing to the specialist via a
@@ -487,6 +498,12 @@ Rules:
 - A pocket using `sources` MUST have a backend configured (base URL +
   auth, set once via the pocket's backend settings — outside the spec).
   If no backend is configured, the sources will not run.
+- A source `path` is ALWAYS relative to the configured backend base URL
+  — never put an absolute URL in `path`. You only ever author the
+  relative path. If you are extending an existing pocket, `get_pocket`
+  returns a non-secret `backend` field ({base_url, auth_type,
+  configured}) so you can see whether a backend is already set and what
+  its base URL is — do not ask the user for a URL you can already see.
 - Seed `state` with an empty list/value for each `bind` target so the
   widget renders before the first fetch.
 - Use `sources` ONLY for the user's real backend. For workspace data use
@@ -524,6 +541,24 @@ After `set_source`, do the wiring with the normal ops:
 - For a manual refresh, `add_node` a button whose on_click is
   {"action": "run_source", "source": "prs"} — `run_source` is a
   client-side action, NOT a chat round-trip.
+
+THE BACKEND IS ALREADY KNOWN — DO NOT ASK FOR IT.
+The `<current-pocket>` block above has a `Backend:` line telling you
+whether this pocket already has a backend configured and its base URL:
+- "Backend: configured — https://api.example.com (auth: bearer)" — a
+  backend EXISTS. Author the source against it directly. A source `path`
+  is ALWAYS relative to that base URL, so you only ever need the
+  relative path — never ask the user for the backend URL, you can see it.
+- "Backend: not configured" — the pocket has no backend. The source
+  cannot run until one is set in the pocket's backend settings. Tell the
+  user to configure a backend first (it's outside the spec — the
+  "Configure Backend" modal), then you can add the source.
+- "Backend: configured state unknown ..." — call `get_pocket`; its
+  result carries a `backend` field with the same summary.
+
+If the backend is configured but you cannot infer the relative path for
+the data the user wants, ask ONLY for the relative path (e.g. "which
+endpoint — /pulls? /issues?"), NOT for the whole backend URL.
 
 Rules:
 - A pocket using sources MUST have a backend configured (base URL + auth,
@@ -1599,8 +1634,45 @@ _CURRENT_POCKET_BLOCK_TEMPLATE = """\
 You are inside pocket id: `__POCKET_ID__`. Pass this id verbatim as the
 ``pocket_id`` argument to every pocket tool call (get_pocket,
 set_state, set_node_prop, add_node, etc.).
+Backend: __BACKEND_SUMMARY__
 </current-pocket>
 """
+
+
+def fill_current_pocket(prompt: str, pocket_id: str, backend_summary: dict | None) -> str:
+    """Fill the `__POCKET_ID__` and `__BACKEND_SUMMARY__` tokens in a
+    prompt that carries ``_CURRENT_POCKET_BLOCK_TEMPLATE``.
+
+    ``backend_summary`` is the non-secret ``{base_url, auth_type,
+    configured}`` dict from ``pockets.service.get_pocket_backend`` (it
+    never carries the token). ``None`` — or a summary without
+    ``configured`` — renders as "configured state unknown" so the agent
+    falls back to ``get_pocket`` rather than assuming there is no
+    backend.
+
+    Always replace BOTH tokens: a prompt that fills only `__POCKET_ID__`
+    would leak the literal `__BACKEND_SUMMARY__` text to the model.
+    """
+    return prompt.replace(POCKET_ID_TOKEN, pocket_id).replace(
+        BACKEND_SUMMARY_TOKEN, _render_backend_summary(backend_summary)
+    )
+
+
+def _render_backend_summary(summary: dict | None) -> str:
+    """One-line human-readable rendering of the non-secret backend
+    summary for the `<current-pocket>` block.
+
+    "configured — <base_url> (auth: <type>)" when a backend exists,
+    "not configured" when it explicitly does not, "configured state
+    unknown — call get_pocket to check" when the caller had no summary.
+    """
+    if not summary or "configured" not in summary:
+        return "configured state unknown — call get_pocket to check"
+    if not summary.get("configured"):
+        return "not configured"
+    base_url = summary.get("base_url") or "(unknown URL)"
+    auth_type = summary.get("auth_type") or "none"
+    return f"configured — {base_url} (auth: {auth_type})"
 
 
 def _assemble_interaction(*, mcp: bool) -> str:
@@ -1815,6 +1887,7 @@ def get_pocket_prompts(*, backend_name: str | None = None) -> tuple[str, str]:
 
 
 __all__ = [
+    "BACKEND_SUMMARY_TOKEN",
     "POCKET_CREATION_PROMPT",
     "POCKET_CREATION_PROMPT_CLI",
     "POCKET_CREATION_PROMPT_MCP",
@@ -1826,5 +1899,6 @@ __all__ = [
     "POCKET_INTERACTION_PROMPT_CLI",
     "POCKET_INTERACTION_PROMPT_MCP",
     "POCKET_SPECIALIST_PROMPT",
+    "fill_current_pocket",
     "get_pocket_prompts",
 ]

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -13,6 +13,12 @@
 # `<mutation-strategy>` block gained the Tier-2 prop-array item ops from
 # PR #1159 with guidance on when to use them.
 #
+# Changes: 2026-05-22 (RFC 04 alpha follow-up) — the edit-specialist prompt
+# now also carries RFC 04 `sources` guidance: `_EDIT_TOOLS_MCP` lists the
+# new `set_source` / `remove_source` ops, and `_assemble_interaction()`
+# splices in `_LIVE_DATA_SOURCES_EDIT_BLOCK` so the EDIT specialist (not
+# just the create flow) knows it can author a `rippleSpec.sources` block.
+#
 # Canonical source for every pocket-mode system prompt the agent ever sees.
 # Four strings are exported, one per (action × backend) cell:
 #
@@ -489,6 +495,49 @@ Rules:
 """
 
 
+# Edit-specialist variant of the live-data-sources guidance. The create
+# block above describes authoring the `sources` JSON directly inside the
+# rippleSpec; the EDIT specialist never authors whole-spec JSON — it works
+# through granular ops, so it gets the `set_source` / `remove_source`
+# instructions instead. Spliced into _assemble_interaction.
+_LIVE_DATA_SOURCES_EDIT_BLOCK = """\
+<live-data-sources>
+When the user asks for live data from THEIR OWN backend (a CRM, an
+internal API, a service with a base URL + token) — not the workspace
+`$source` markers — use the `set_source` / `remove_source` ops. Alpha is
+READ-ONLY: GET bindings only. These write the pocket's top-level
+`rippleSpec.sources` block; the state/node ops cannot.
+
+  set_source(
+    source_key="prs",            # the sources map key
+    path="/pulls?state=open",    # RELATIVE path on the backend, never a URL
+    bind="state.prs",            # dotted state path the JSON is written to
+    method="GET",                # always GET
+    refresh=["pocket_open", "manual"],   # when to run it
+  )
+
+  remove_source(source_key="prs")
+
+After `set_source`, do the wiring with the normal ops:
+- `set_state` the `bind` target to an empty list/value so the bound
+  widget renders before the first fetch (e.g. set_state("prs", [])).
+- For a manual refresh, `add_node` a button whose on_click is
+  {"action": "run_source", "source": "prs"} — `run_source` is a
+  client-side action, NOT a chat round-trip.
+
+Rules:
+- A pocket using sources MUST have a backend configured (base URL + auth,
+  set once in the pocket's backend settings — outside the spec). Without
+  a backend the sources will not run.
+- Do NOT stash a fake source descriptor in `state`, and do NOT build a
+  refresh button that sends a chat message — use `set_source` + the
+  `run_source` action.
+- Use sources ONLY for the user's real backend. For workspace data use
+  the `$source` markers; for canvas-local input use literal values.
+</live-data-sources>
+"""
+
+
 # ---------------------------------------------------------------------------
 # Tool surface — MCP variant (claude_agent_sdk).
 # Identity (workspace, user, session) is bound from the active SSE
@@ -603,6 +652,16 @@ project-dashboard.team, feed.items, select.options, form-layout.fields…)
 
 `match` (and `after`) is an ItemMatch: {index:N} | {id:"..."} |
 {by_field:"label", equals:"X"} | {by_key:{k:v}}.
+
+DATA-SOURCE OPS — read-only live data bindings (rippleSpec.sources)
+
+  set_source(source_key, path, bind, method?, refresh?)
+                                declare a GET binding that fetches from the
+                                pocket's configured backend into state
+  remove_source(source_key)     delete a data-source declaration
+
+Use these only for the user's OWN backend (a CRM, an internal API). See
+the `<live-data-sources>` block for when and how.
 
 The toolset above is the WHOLE interface. Apply the smallest granular op
 that satisfies the intent.
@@ -1554,7 +1613,13 @@ def _assemble_interaction(*, mcp: bool) -> str:
     (the creation toolset): advertising create_pocket / update_pocket /
     add_widget to a specialist that only holds set_node_prop / add_node /
     *_prop_array_item made the planner pick a non-existent tool and emit
-    zero ops with no error (#1163 root cause B)."""
+    zero ops with no error (#1163 root cause B).
+
+    ``_LIVE_DATA_SOURCES_EDIT_BLOCK`` is spliced in so the edit specialist
+    knows it can author a ``rippleSpec.sources`` block via the
+    ``set_source`` / ``remove_source`` ops (RFC 04 alpha follow-up) —
+    without it, the specialist stashed fake source descriptors in state
+    and built chat-round-trip refresh buttons."""
     parts = [
         _SCOPE_BLOCK,
         _CANVAS_BLOCK,
@@ -1562,6 +1627,7 @@ def _assemble_interaction(*, mcp: bool) -> str:
         _WORKFLOW_INTERACTION_MCP if mcp else _WORKFLOW_INTERACTION_CLI,
         _INTERACTIVE_DEFAULT_BLOCK,
         _STATE_SOURCES_BLOCK,
+        _LIVE_DATA_SOURCES_EDIT_BLOCK,
         RIPPLE_DESIGN_RULES,
         # MUST be last — see _CURRENT_POCKET_BLOCK_TEMPLATE rationale.
         _CURRENT_POCKET_BLOCK_TEMPLATE,

--- a/src/pocketpaw/security/url_validators.py
+++ b/src/pocketpaw/security/url_validators.py
@@ -1,5 +1,10 @@
 # URL validators for Settings fields — guards against SSRF via config.
 # Added: 2026-04-16 for security cluster E (#703).
+# Updated: 2026-05-21 (RFC 04 alpha) — added validate_external_url_strict():
+#   https-only, unconditionally blocks internal/loopback/RFC1918/link-local
+#   hosts (no POCKETPAW_ALLOW_INTERNAL_URLS escape hatch), rejects empty
+#   input. Used to validate pocket-backend base URLs, which are an SSRF
+#   boundary and must never be relaxed by an operator env flag.
 
 from __future__ import annotations
 
@@ -108,5 +113,38 @@ def validate_external_url(value: str) -> str:
         raise ValueError(
             f"URL host '{parts.hostname}' is internal/loopback/private and "
             f"POCKETPAW_ALLOW_INTERNAL_URLS is set to false"
+        )
+    return value
+
+
+def validate_external_url_strict(value: str) -> str:
+    """Strict external-URL validator for pocket backend base URLs.
+
+    Differs from :func:`validate_external_url` in three ways, because a
+    pocket-backend base URL is an SSRF boundary and must not be relaxed:
+
+    * ``https://`` ONLY — plain ``http://`` is rejected.
+    * Internal / loopback / RFC1918 / link-local / CGNAT hosts are blocked
+      UNCONDITIONALLY — there is no ``POCKETPAW_ALLOW_INTERNAL_URLS`` escape
+      hatch (this function never reads that flag).
+    * Empty / blank input raises ``ValueError`` instead of passing through.
+
+    Returns the URL unchanged when it passes; raises ``ValueError`` otherwise.
+    """
+    if value is None or not isinstance(value, str) or value.strip() == "":
+        raise ValueError("URL must be a non-empty string")
+
+    parts = urlsplit(value)
+    if parts.scheme != "https":
+        raise ValueError(
+            f"URL scheme '{parts.scheme or '(none)'}' not allowed — backend "
+            f"URLs must use https"
+        )
+    if not parts.hostname:
+        raise ValueError(f"URL has no host: {value!r}")
+    if _host_is_internal(parts.hostname):
+        raise ValueError(
+            f"URL host '{parts.hostname}' is internal/loopback/private — "
+            f"backend URLs must point to an external host"
         )
     return value

--- a/src/pocketpaw/security/url_validators.py
+++ b/src/pocketpaw/security/url_validators.py
@@ -5,6 +5,9 @@
 #   hosts (no POCKETPAW_ALLOW_INTERNAL_URLS escape hatch), rejects empty
 #   input. Used to validate pocket-backend base URLs, which are an SSRF
 #   boundary and must never be relaxed by an operator env flag.
+# Updated: 2026-05-21 (PR #1177 security pass) — exposed a public
+#   ``host_is_internal`` alias and an ``__all__`` so callers no longer
+#   import the private ``_host_is_internal`` symbol.
 
 from __future__ import annotations
 
@@ -79,7 +82,13 @@ def _allow_internal() -> bool:
     return val.strip().lower() in _TRUTHY
 
 
-def _host_is_internal(host: str) -> bool:
+def host_is_internal(host: str) -> bool:
+    """Return True when ``host`` is loopback / RFC1918 / link-local / CGNAT.
+
+    Public entry point for the host classification used by the SSRF guards.
+    A bare hostname (not an IP literal) returns False — name resolution is
+    the caller's job.
+    """
     host = host.lower().strip("[]")
     if host in _BLOCKED_HOSTS:
         return True
@@ -88,6 +97,10 @@ def _host_is_internal(host: str) -> bool:
     except ValueError:
         return False
     return any(addr in net for net in _BLOCKED_NETWORKS)
+
+
+# Back-compat alias — kept for callers that imported the private name.
+_host_is_internal = host_is_internal
 
 
 def validate_external_url(value: str) -> str:
@@ -109,7 +122,7 @@ def validate_external_url(value: str) -> str:
     if not parts.hostname:
         raise ValueError(f"URL has no host: {value!r}")
 
-    if _host_is_internal(parts.hostname) and not _allow_internal():
+    if host_is_internal(parts.hostname) and not _allow_internal():
         raise ValueError(
             f"URL host '{parts.hostname}' is internal/loopback/private and "
             f"POCKETPAW_ALLOW_INTERNAL_URLS is set to false"
@@ -142,9 +155,16 @@ def validate_external_url_strict(value: str) -> str:
         )
     if not parts.hostname:
         raise ValueError(f"URL has no host: {value!r}")
-    if _host_is_internal(parts.hostname):
+    if host_is_internal(parts.hostname):
         raise ValueError(
             f"URL host '{parts.hostname}' is internal/loopback/private — "
             f"backend URLs must point to an external host"
         )
     return value
+
+
+__all__ = [
+    "host_is_internal",
+    "validate_external_url",
+    "validate_external_url_strict",
+]

--- a/src/pocketpaw/security/url_validators.py
+++ b/src/pocketpaw/security/url_validators.py
@@ -150,8 +150,7 @@ def validate_external_url_strict(value: str) -> str:
     parts = urlsplit(value)
     if parts.scheme != "https":
         raise ValueError(
-            f"URL scheme '{parts.scheme or '(none)'}' not allowed — backend "
-            f"URLs must use https"
+            f"URL scheme '{parts.scheme or '(none)'}' not allowed — backend URLs must use https"
         )
     if not parts.hostname:
         raise ValueError(f"URL has no host: {value!r}")

--- a/tests/cloud/test_agent_service_tools_context.py
+++ b/tests/cloud/test_agent_service_tools_context.py
@@ -324,9 +324,14 @@ def test_non_subagent_backend_pocket_id_inlines_interaction_prompt():
     block = build_context_block(ctx_edit, backend_name="codex_cli")
     # The pocket id was substituted into the interaction prompt.
     assert "pocket-abc" in block
-    # Heavy interaction guidance IS present.
-    assert "<pocket-workflow>" in block
-    # Delegation rule is NOT.
+    # The interaction prompt IS inlined — post-#1163 the calling-agent
+    # interaction prompt is the slim delegation flow (<pocket-interaction>),
+    # while the heavy <pocket-workflow> block lives on the edit specialist
+    # only (see test_subagent_backend... above, line ~275).
+    assert "<pocket-interaction>" in block
+    assert "<pocket-workflow>" not in block
+    # The subagent-style delegation rule is NOT (codex_cli has no
+    # native subagent concept).
     assert "<pocket-delegation>" not in block
 
 

--- a/tests/cloud/test_pocket_agent_backend_view.py
+++ b/tests/cloud/test_pocket_agent_backend_view.py
@@ -210,9 +210,7 @@ def test_fill_current_pocket_renders_not_configured():
     from pocketpaw.ripple import fill_current_pocket
     from pocketpaw.ripple._pockets import _CURRENT_POCKET_BLOCK_TEMPLATE
 
-    out = fill_current_pocket(
-        _CURRENT_POCKET_BLOCK_TEMPLATE, "pkt-123", {"configured": False}
-    )
+    out = fill_current_pocket(_CURRENT_POCKET_BLOCK_TEMPLATE, "pkt-123", {"configured": False})
     assert "__BACKEND_SUMMARY__" not in out
     assert "Backend: not configured" in out
 

--- a/tests/cloud/test_pocket_agent_backend_view.py
+++ b/tests/cloud/test_pocket_agent_backend_view.py
@@ -1,0 +1,240 @@
+# test_pocket_agent_backend_view.py — RFC 04 alpha follow-up 2.
+# Created: 2026-05-22 — closes the gap where the pocket EDIT specialist had
+#   NO signal that a backend was already configured. The backend credential
+#   lives in a separate collection (security design D1), so nothing
+#   surfaced it to the agent — it would ask the user for a URL it could not
+#   see. This pins that agent_view / get_pocket now carries a non-secret
+#   `backend` summary ({base_url, auth_type, configured}), and that the
+#   token NEVER reaches agent context.
+#
+# Exercises the real Beanie path against the in-memory mongomock-motor DB
+# (mongo_db fixture) with the w1/u1 SSE-stream identity (agent_identity).
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auth_secret(monkeypatch):
+    """set_pocket_backend encrypts the token — it needs AUTH_SECRET."""
+    monkeypatch.setenv("AUTH_SECRET", "agent-backend-view-test-secret")
+
+
+async def _make_pocket(**fields):
+    """Insert a fresh Pocket through the normal Beanie path."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    base = dict(
+        workspace="w1",
+        name="Test Pocket",
+        description="",
+        type="custom",
+        icon="",
+        color="",
+        owner="u1",
+        visibility="workspace",
+        rippleSpec={"version": "1.0", "ui": {"id": "n_root0000", "type": "flex"}},
+    )
+    base.update(fields)
+    doc = Pocket(**base)
+    await doc.insert()
+    return doc
+
+
+@pytest.fixture
+def agent_identity():
+    """Attach the default w1 / u1 SSE-stream identity so agent_view /
+    _agent_load_doc pass their workspace + edit-access checks."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_agent_identity,
+        detach_agent_identity,
+    )
+
+    tokens = attach_agent_identity(workspace_id="w1", user_id="u1")
+    try:
+        yield
+    finally:
+        detach_agent_identity(tokens)
+
+
+# ---------------------------------------------------------------------------
+# agent_view backend summary
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_view_reports_not_configured_when_no_backend(mongo_db, agent_identity):
+    """A pocket with no backend credential row gets
+    ``backend = {"configured": False}``."""
+    from pocketpaw_ee.cloud.pockets.service import agent_view
+
+    doc = await _make_pocket()
+    view, err = await agent_view(str(doc.id))
+
+    assert err is None
+    assert view is not None
+    assert view["backend"] == {"configured": False}
+
+
+async def test_agent_view_includes_configured_backend_summary(mongo_db, agent_identity):
+    """When a backend IS configured, agent_view carries the non-secret
+    summary — base_url + auth_type + configured."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    doc = await _make_pocket()
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=str(doc.id),
+        base_url="https://jsonplaceholder.typicode.com",
+        auth_type="none",
+        auth_token="",
+    )
+
+    view, err = await pockets_service.agent_view(str(doc.id))
+
+    assert err is None
+    assert view is not None
+    assert view["backend"] == {
+        "base_url": "https://jsonplaceholder.typicode.com",
+        "auth_type": "none",
+        "configured": True,
+    }
+
+
+async def test_agent_view_backend_summary_never_leaks_the_token(mongo_db, agent_identity):
+    """The token is encrypted into a separate collection — it must never
+    appear anywhere in the agent-facing view, even when auth is bearer."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    doc = await _make_pocket()
+    secret = "super-secret-bearer-token-xyz"
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=str(doc.id),
+        base_url="https://api.example.com",
+        auth_type="bearer",
+        auth_token=secret,
+    )
+
+    view, err = await pockets_service.agent_view(str(doc.id))
+
+    assert err is None
+    assert view is not None
+    backend = view["backend"]
+    assert backend["configured"] is True
+    assert backend["auth_type"] == "bearer"
+    # The summary carries only the three non-secret keys.
+    assert set(backend) == {"base_url", "auth_type", "configured"}
+    # The token must not appear anywhere in the serialized view.
+    import json
+
+    blob = json.dumps(view)
+    assert secret not in blob
+    assert "encrypted_token" not in blob
+    assert "auth_token" not in blob
+
+
+async def test_agent_view_backend_summary_is_workspace_scoped(mongo_db, agent_identity):
+    """A backend row for a different workspace must not bleed into this
+    pocket's summary — get_pocket_backend is workspace-scoped."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    doc = await _make_pocket()
+    # A backend row keyed to the same pocket id but a different workspace.
+    await pockets_service.set_pocket_backend(
+        workspace_id="w2",
+        user_id="u2",
+        pocket_id=str(doc.id),
+        base_url="https://other-workspace.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+
+    view, err = await pockets_service.agent_view(str(doc.id))
+
+    assert err is None
+    assert view is not None
+    # The pocket is in w1; the w2 backend row must not surface.
+    assert view["backend"] == {"configured": False}
+
+
+async def test_fetch_pocket_for_agent_carries_backend_summary(mongo_db, agent_identity):
+    """The agent_context wrapper (what get_pocket returns to the tool)
+    passes the backend summary straight through."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.cloud.pockets.agent_context import fetch_pocket_for_agent
+
+    doc = await _make_pocket()
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=str(doc.id),
+        base_url="https://jsonplaceholder.typicode.com",
+        auth_type="none",
+        auth_token="",
+    )
+
+    result = await fetch_pocket_for_agent(str(doc.id))
+
+    assert result["ok"] is True
+    assert result["pocket"]["backend"] == {
+        "base_url": "https://jsonplaceholder.typicode.com",
+        "auth_type": "none",
+        "configured": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# fill_current_pocket — prompt token substitution
+# ---------------------------------------------------------------------------
+
+
+def test_fill_current_pocket_renders_configured_backend():
+    from pocketpaw.ripple import fill_current_pocket
+    from pocketpaw.ripple._pockets import _CURRENT_POCKET_BLOCK_TEMPLATE
+
+    out = fill_current_pocket(
+        _CURRENT_POCKET_BLOCK_TEMPLATE,
+        "pkt-123",
+        {"base_url": "https://api.example.com", "auth_type": "bearer", "configured": True},
+    )
+    assert "__POCKET_ID__" not in out
+    assert "__BACKEND_SUMMARY__" not in out
+    assert "pkt-123" in out
+    assert "configured — https://api.example.com (auth: bearer)" in out
+
+
+def test_fill_current_pocket_renders_not_configured():
+    from pocketpaw.ripple import fill_current_pocket
+    from pocketpaw.ripple._pockets import _CURRENT_POCKET_BLOCK_TEMPLATE
+
+    out = fill_current_pocket(
+        _CURRENT_POCKET_BLOCK_TEMPLATE, "pkt-123", {"configured": False}
+    )
+    assert "__BACKEND_SUMMARY__" not in out
+    assert "Backend: not configured" in out
+
+
+def test_fill_current_pocket_renders_unknown_when_summary_is_none():
+    """Callers that cannot await the backend read pass None — the line
+    must say 'unknown', never imply there is no backend."""
+    from pocketpaw.ripple import fill_current_pocket
+    from pocketpaw.ripple._pockets import _CURRENT_POCKET_BLOCK_TEMPLATE
+
+    out = fill_current_pocket(_CURRENT_POCKET_BLOCK_TEMPLATE, "pkt-123", None)
+    assert "__BACKEND_SUMMARY__" not in out
+    assert "configured state unknown" in out
+    assert "not configured" not in out
+
+
+def test_edit_specialist_prompt_has_no_unfilled_backend_token():
+    """The raw edit-specialist prompt carries the token; after
+    fill_current_pocket no literal token may remain."""
+    from pocketpaw.ripple import POCKET_EDIT_SPECIALIST_PROMPT_MCP, fill_current_pocket
+
+    assert "__BACKEND_SUMMARY__" in POCKET_EDIT_SPECIALIST_PROMPT_MCP
+    filled = fill_current_pocket(POCKET_EDIT_SPECIALIST_PROMPT_MCP, "pkt-1", None)
+    assert "__BACKEND_SUMMARY__" not in filled
+    assert "__POCKET_ID__" not in filled

--- a/tests/cloud/test_pocket_backend_crypto.py
+++ b/tests/cloud/test_pocket_backend_crypto.py
@@ -73,8 +73,7 @@ def test_missing_auth_secret_raises(monkeypatch):
 def test_strict_url_accepts_normal_https():
     assert validate_external_url_strict("https://api.example.com") == "https://api.example.com"
     assert (
-        validate_external_url_strict("https://api.example.com/v1")
-        == "https://api.example.com/v1"
+        validate_external_url_strict("https://api.example.com/v1") == "https://api.example.com/v1"
     )
 
 

--- a/tests/cloud/test_pocket_backend_crypto.py
+++ b/tests/cloud/test_pocket_backend_crypto.py
@@ -1,0 +1,103 @@
+# tests/cloud/test_pocket_backend_crypto.py — RFC 04 alpha.
+# Created: 2026-05-21 — Coverage for the pocket-backend credential crypto
+# helper and the strict external-URL validator.
+#
+# What this pins:
+#   1. encrypt_token -> decrypt_token round-trips.
+#   2. Two encryptions of the same token use different salts/nonces and
+#      therefore produce different ciphertext.
+#   3. decrypt with a mismatched salt fails (InvalidTag).
+#   4. Missing AUTH_SECRET raises a clear error.
+#   5. validate_external_url_strict rejects http://, localhost, loopback,
+#      the EC2 metadata IP, RFC1918 ranges, and empty input — and accepts
+#      a normal https host.
+
+from __future__ import annotations
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from pocketpaw.security.url_validators import validate_external_url_strict
+
+
+@pytest.fixture
+def auth_secret(monkeypatch):
+    monkeypatch.setenv("AUTH_SECRET", "unit-test-auth-secret-value")
+
+
+def test_encrypt_decrypt_round_trip(auth_secret):
+    from pocketpaw_ee.cloud.pockets import backend_crypto
+
+    token = "ghp_supersecrettoken1234567890"
+    ciphertext, nonce, salt = backend_crypto.encrypt_token(token)
+    assert backend_crypto.decrypt_token(ciphertext, nonce, salt) == token
+
+
+def test_different_salts_produce_different_ciphertext(auth_secret):
+    from pocketpaw_ee.cloud.pockets import backend_crypto
+
+    token = "the-same-token"
+    ct1, n1, s1 = backend_crypto.encrypt_token(token)
+    ct2, n2, s2 = backend_crypto.encrypt_token(token)
+
+    assert s1 != s2
+    assert n1 != n2
+    assert ct1 != ct2
+    # Both still decrypt back to the original.
+    assert backend_crypto.decrypt_token(ct1, n1, s1) == token
+    assert backend_crypto.decrypt_token(ct2, n2, s2) == token
+
+
+def test_decrypt_with_wrong_salt_fails(auth_secret):
+    from pocketpaw_ee.cloud.pockets import backend_crypto
+
+    ct, nonce, _salt = backend_crypto.encrypt_token("secret")
+    _, _, other_salt = backend_crypto.encrypt_token("other")
+    with pytest.raises(InvalidTag):
+        backend_crypto.decrypt_token(ct, nonce, other_salt)
+
+
+def test_missing_auth_secret_raises(monkeypatch):
+    from pocketpaw_ee.cloud.pockets import backend_crypto
+
+    monkeypatch.delenv("AUTH_SECRET", raising=False)
+    with pytest.raises(RuntimeError, match="AUTH_SECRET"):
+        backend_crypto.encrypt_token("secret")
+
+
+# ---------------------------------------------------------------------------
+# validate_external_url_strict
+# ---------------------------------------------------------------------------
+
+
+def test_strict_url_accepts_normal_https():
+    assert validate_external_url_strict("https://api.example.com") == "https://api.example.com"
+    assert (
+        validate_external_url_strict("https://api.example.com/v1")
+        == "https://api.example.com/v1"
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "http://api.example.com",  # plain http rejected
+        "https://localhost",
+        "https://127.0.0.1",
+        "https://127.5.5.5",
+        "https://169.254.169.254",  # EC2 metadata
+        "https://10.0.0.5",
+        "https://192.168.1.1",
+        "https://172.16.0.1",
+        "ftp://api.example.com",
+    ],
+)
+def test_strict_url_rejects_unsafe(bad_url):
+    with pytest.raises(ValueError):
+        validate_external_url_strict(bad_url)
+
+
+@pytest.mark.parametrize("empty", ["", "   ", None])
+def test_strict_url_rejects_empty(empty):
+    with pytest.raises(ValueError):
+        validate_external_url_strict(empty)  # type: ignore[arg-type]

--- a/tests/cloud/test_pocket_backend_routes.py
+++ b/tests/cloud/test_pocket_backend_routes.py
@@ -1,0 +1,190 @@
+# tests/cloud/test_pocket_backend_routes.py — RFC 04 alpha.
+# Created: 2026-05-21 — Integration coverage for the three pocket-backend
+# routes added to the pockets router:
+#
+#   PUT  /pockets/{id}/backend
+#   GET  /pockets/{id}/backend
+#   POST /pockets/{id}/sources/run
+#
+# The service functions and the source executor are monkeypatched so the
+# tests pin the route wiring (request body parsing, status codes, response
+# shape) without a Mongo connection or real outbound HTTP. Auth + license
+# guards are overridden — same pattern as test_pocket_layout_routes.py.
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.router import router
+from pocketpaw_ee.cloud.shared.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_pocket_edit,
+    require_pocket_owner,
+)
+
+FAKE_USER = "user-alice"
+FAKE_WORKSPACE = "ws-alpha"
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+
+    a = FastAPI()
+    add_error_handler(a)
+    a.include_router(router)
+
+    a.dependency_overrides[require_license] = lambda: None
+    a.dependency_overrides[require_pocket_edit] = lambda: None
+    a.dependency_overrides[require_pocket_owner] = lambda: None
+    a.dependency_overrides[current_user_id] = lambda: FAKE_USER
+    a.dependency_overrides[current_workspace_id] = lambda: FAKE_WORKSPACE
+    return a
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# PUT /pockets/{id}/backend
+# ---------------------------------------------------------------------------
+
+
+def test_put_backend_configures(monkeypatch, client):
+    captured = {}
+
+    async def _set(workspace_id, user_id, pocket_id, base_url, auth_type, auth_token, auth_header):
+        captured.update(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            base_url=base_url,
+            auth_type=auth_type,
+            auth_token=auth_token,
+        )
+        return {"base_url": base_url, "auth_type": auth_type, "configured": True}
+
+    monkeypatch.setattr(pockets_service, "set_pocket_backend", _set)
+
+    res = client.put(
+        "/pockets/pocket-1/backend",
+        json={
+            "base_url": "https://api.example.com",
+            "auth_type": "bearer",
+            "auth_token": "secret",
+        },
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body == {
+        "base_url": "https://api.example.com",
+        "auth_type": "bearer",
+        "configured": True,
+    }
+    # The route forwarded the right identity + body to the service.
+    assert captured["workspace_id"] == FAKE_WORKSPACE
+    assert captured["pocket_id"] == "pocket-1"
+    assert captured["auth_token"] == "secret"
+
+
+def test_put_backend_rejects_bad_auth_type(client):
+    res = client.put(
+        "/pockets/pocket-1/backend",
+        json={"base_url": "https://api.example.com", "auth_type": "oauth2"},
+    )
+    assert res.status_code == 422  # Literal validation
+
+
+# ---------------------------------------------------------------------------
+# GET /pockets/{id}/backend
+# ---------------------------------------------------------------------------
+
+
+def test_get_backend_returns_summary(monkeypatch, client):
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id, "name": "P"}
+
+    async def _get_backend(workspace_id, pocket_id):
+        return {"base_url": "https://api.example.com", "auth_type": "none", "configured": True}
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend", _get_backend)
+
+    res = client.get("/pockets/pocket-1/backend")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["configured"] is True
+    assert "token" not in body
+
+
+def test_get_backend_404_when_unconfigured(monkeypatch, client):
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id}
+
+    async def _get_backend(workspace_id, pocket_id):
+        return None
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend", _get_backend)
+
+    res = client.get("/pockets/pocket-1/backend")
+    assert res.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /pockets/{id}/sources/run
+# ---------------------------------------------------------------------------
+
+
+def test_run_sources_happy_path(monkeypatch, client):
+    spec = {"sources": {"prs": {"method": "GET", "path": "/pulls", "bind": "state.prs"}}}
+
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id, "rippleSpec": spec}
+
+    async def _get_creds(workspace_id, pocket_id):
+        return ("https://api.example.com", "bearer", None, "tok")
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _get_creds)
+
+    from pocketpaw_ee.cloud.pockets import source_executor
+
+    captured = {}
+
+    async def _run_sources(**kwargs):
+        captured.update(kwargs)
+        return {"ran": [{"source": "prs", "bind": "prs", "value": [1, 2]}], "errors": []}
+
+    monkeypatch.setattr(source_executor, "run_sources", _run_sources)
+
+    res = client.post("/pockets/pocket-1/sources/run", json={"trigger": "manual"})
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ran"][0]["bind"] == "prs"
+    assert body["errors"] == []
+    # The route passed the spec + creds + trigger through.
+    assert captured["ripple_spec"] == spec
+    assert captured["base_url"] == "https://api.example.com"
+    assert captured["token"] == "tok"
+    assert captured["trigger"] == "manual"
+
+
+def test_run_sources_400_when_no_backend(monkeypatch, client):
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id, "rippleSpec": {}}
+
+    async def _no_creds(workspace_id, pocket_id):
+        return None
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _no_creds)
+
+    res = client.post("/pockets/pocket-1/sources/run", json={})
+    assert res.status_code == 400, res.text

--- a/tests/cloud/test_pocket_backend_routes.py
+++ b/tests/cloud/test_pocket_backend_routes.py
@@ -1,15 +1,20 @@
 # tests/cloud/test_pocket_backend_routes.py — RFC 04 alpha.
-# Created: 2026-05-21 — Integration coverage for the three pocket-backend
-# routes added to the pockets router:
+# Created: 2026-05-21 — Integration coverage for the pocket-backend routes
+# added to the pockets router:
 #
-#   PUT  /pockets/{id}/backend
-#   GET  /pockets/{id}/backend
-#   POST /pockets/{id}/sources/run
+#   PUT    /pockets/{id}/backend
+#   GET    /pockets/{id}/backend
+#   DELETE /pockets/{id}/backend
+#   POST   /pockets/{id}/sources/run
 #
 # The service functions and the source executor are monkeypatched so the
 # tests pin the route wiring (request body parsing, status codes, response
 # shape) without a Mongo connection or real outbound HTTP. Auth + license
 # guards are overridden — same pattern as test_pocket_layout_routes.py.
+#
+# Updated: 2026-05-21 (PR #1177 security pass) — added coverage for the
+# DELETE route, the edit-access guard on GET, and the user_id thread-through
+# on the source-run route.
 
 from __future__ import annotations
 
@@ -137,6 +142,66 @@ def test_get_backend_404_when_unconfigured(monkeypatch, client):
     assert res.status_code == 404
 
 
+def test_get_backend_forbidden_for_non_editor(monkeypatch):
+    """SHOULD-FIX-1 — a viewer (no edit access) gets 403, not the binding."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from pocketpaw_ee.cloud._core.errors import Forbidden
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+
+    a = FastAPI()
+    add_error_handler(a)
+    a.include_router(router)
+    a.dependency_overrides[require_license] = lambda: None
+    a.dependency_overrides[require_pocket_owner] = lambda: None
+    a.dependency_overrides[current_user_id] = lambda: FAKE_USER
+    a.dependency_overrides[current_workspace_id] = lambda: FAKE_WORKSPACE
+
+    def _deny_edit():
+        raise Forbidden("pocket.forbidden", "edit access required")
+
+    a.dependency_overrides[require_pocket_edit] = _deny_edit
+
+    res = TestClient(a).get("/pockets/pocket-1/backend")
+    assert res.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# DELETE /pockets/{id}/backend
+# ---------------------------------------------------------------------------
+
+
+def test_delete_backend_revokes(monkeypatch, client):
+    captured = {}
+
+    async def _remove(workspace_id, user_id, pocket_id):
+        captured.update(workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id)
+
+    monkeypatch.setattr(pockets_service, "remove_pocket_backend", _remove)
+
+    res = client.delete("/pockets/pocket-1/backend")
+    assert res.status_code == 204, res.text
+    assert res.content == b""
+    assert captured == {
+        "workspace_id": FAKE_WORKSPACE,
+        "user_id": FAKE_USER,
+        "pocket_id": "pocket-1",
+    }
+
+
+def test_delete_backend_idempotent_when_unconfigured(monkeypatch, client):
+    """remove_pocket_backend is a no-op on a pocket with no credential —
+    the route still returns 204."""
+
+    async def _remove(workspace_id, user_id, pocket_id):
+        return None  # service no-ops when there is no row
+
+    monkeypatch.setattr(pockets_service, "remove_pocket_backend", _remove)
+
+    res = client.delete("/pockets/pocket-with-no-backend/backend")
+    assert res.status_code == 204
+
+
 # ---------------------------------------------------------------------------
 # POST /pockets/{id}/sources/run
 # ---------------------------------------------------------------------------
@@ -169,11 +234,12 @@ def test_run_sources_happy_path(monkeypatch, client):
     body = res.json()
     assert body["ran"][0]["bind"] == "prs"
     assert body["errors"] == []
-    # The route passed the spec + creds + trigger through.
+    # The route passed the spec + creds + trigger + identity through.
     assert captured["ripple_spec"] == spec
     assert captured["base_url"] == "https://api.example.com"
     assert captured["token"] == "tok"
     assert captured["trigger"] == "manual"
+    assert captured["user_id"] == FAKE_USER
 
 
 def test_run_sources_400_when_no_backend(monkeypatch, client):

--- a/tests/cloud/test_pocket_backend_service.py
+++ b/tests/cloud/test_pocket_backend_service.py
@@ -3,6 +3,9 @@
 # binding: set / get / get-for-executor / remove. Exercises the real
 # Beanie path against the in-memory mongomock-motor DB (mongo_db fixture).
 #
+# Updated: 2026-05-21 (PR #1177 security pass) — added coverage that
+# remove_pocket_backend writes an audit-log entry.
+#
 # What this pins:
 #   - set_pocket_backend then get_pocket_backend returns configured:true
 #     and the right base_url/auth_type — never the token.
@@ -10,7 +13,7 @@
 #   - get_pocket_backend_for_executor decrypts the token round-trip.
 #   - set_pocket_backend upserts (a second call updates, not duplicates).
 #   - set_pocket_backend rejects a non-https / internal base URL.
-#   - remove_pocket_backend deletes the row and is idempotent.
+#   - remove_pocket_backend deletes the row, is idempotent, and audit-logs.
 
 from __future__ import annotations
 
@@ -189,3 +192,35 @@ async def test_remove_backend(mongo_db):
 
     # Idempotent — removing again does not raise.
     await pockets_service.remove_pocket_backend("w1", "u1", "pocket-1")
+
+
+async def test_remove_backend_audit_logs(mongo_db, monkeypatch):
+    """remove_pocket_backend writes an audit entry for the revocation."""
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="bearer",
+        auth_token="secret-token",
+    )
+
+    logged: list = []
+
+    class _FakeLogger:
+        def log(self, event):
+            logged.append(event)
+
+    import pocketpaw.security.audit as audit_mod
+
+    monkeypatch.setattr(audit_mod, "get_audit_logger", lambda: _FakeLogger())
+
+    await pockets_service.remove_pocket_backend("w1", "u1", "pocket-1")
+
+    assert len(logged) == 1
+    event = logged[0]
+    assert event.actor == "u1"
+    assert event.action == "pocket.backend.remove"
+    assert event.target == "pocket-1"
+    # The token is never part of the audit entry.
+    assert "secret-token" not in str(event.context)

--- a/tests/cloud/test_pocket_backend_service.py
+++ b/tests/cloud/test_pocket_backend_service.py
@@ -1,0 +1,191 @@
+# tests/cloud/test_pocket_backend_service.py — RFC 04 alpha.
+# Created: 2026-05-21 — Service-layer coverage for the per-pocket backend
+# binding: set / get / get-for-executor / remove. Exercises the real
+# Beanie path against the in-memory mongomock-motor DB (mongo_db fixture).
+#
+# What this pins:
+#   - set_pocket_backend then get_pocket_backend returns configured:true
+#     and the right base_url/auth_type — never the token.
+#   - get_pocket_backend returns None when no row exists.
+#   - get_pocket_backend_for_executor decrypts the token round-trip.
+#   - set_pocket_backend upserts (a second call updates, not duplicates).
+#   - set_pocket_backend rejects a non-https / internal base URL.
+#   - remove_pocket_backend deletes the row and is idempotent.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+
+@pytest.fixture(autouse=True)
+def auth_secret(monkeypatch):
+    monkeypatch.setenv("AUTH_SECRET", "service-test-auth-secret")
+
+
+async def test_set_then_get_backend(mongo_db):
+    result = await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="bearer",
+        auth_token="secret-token-xyz",
+    )
+    assert result == {
+        "base_url": "https://api.example.com",
+        "auth_type": "bearer",
+        "configured": True,
+    }
+    # The summary never carries the token.
+    assert "auth_token" not in result
+    assert "token" not in result
+
+    summary = await pockets_service.get_pocket_backend("w1", "pocket-1")
+    assert summary == {
+        "base_url": "https://api.example.com",
+        "auth_type": "bearer",
+        "configured": True,
+    }
+    assert "token" not in summary
+    assert "encrypted_token" not in summary
+
+
+async def test_get_backend_returns_none_when_unset(mongo_db):
+    assert await pockets_service.get_pocket_backend("w1", "no-such-pocket") is None
+
+
+async def test_get_backend_is_workspace_scoped(mongo_db):
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+    # A different workspace cannot see the row.
+    assert await pockets_service.get_pocket_backend("w2", "pocket-1") is None
+
+
+async def test_get_for_executor_decrypts_token(mongo_db):
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="api_key",
+        auth_token="my-api-key",
+        auth_header="X-Custom-Key",
+    )
+    creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
+    assert creds is not None
+    base_url, auth_type, auth_header, token = creds
+    assert base_url == "https://api.example.com"
+    assert auth_type == "api_key"
+    assert auth_header == "X-Custom-Key"
+    assert token == "my-api-key"
+
+
+async def test_get_for_executor_none_when_unset(mongo_db):
+    assert await pockets_service.get_pocket_backend_for_executor("w1", "missing") is None
+
+
+async def test_get_for_executor_no_token_for_none_auth(mongo_db):
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+    creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
+    assert creds is not None
+    _, auth_type, _, token = creds
+    assert auth_type == "none"
+    assert token == ""
+
+
+async def test_set_backend_upserts(mongo_db):
+    from pocketpaw_ee.cloud.models.pocket_backend import PocketBackendCredential
+
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://old.example.com",
+        auth_type="bearer",
+        auth_token="old-token",
+    )
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://new.example.com",
+        auth_type="bearer",
+        auth_token="new-token",
+    )
+    rows = await PocketBackendCredential.find(
+        PocketBackendCredential.pocket_id == "pocket-1"
+    ).to_list()
+    assert len(rows) == 1  # upsert, not duplicate
+
+    creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
+    assert creds[0] == "https://new.example.com"
+    assert creds[3] == "new-token"
+
+
+async def test_set_backend_rejects_http_url(mongo_db):
+    with pytest.raises(ValidationError):
+        await pockets_service.set_pocket_backend(
+            workspace_id="w1",
+            user_id="u1",
+            pocket_id="pocket-1",
+            base_url="http://api.example.com",
+            auth_type="none",
+            auth_token="",
+        )
+
+
+async def test_set_backend_rejects_internal_url(mongo_db):
+    with pytest.raises(ValidationError):
+        await pockets_service.set_pocket_backend(
+            workspace_id="w1",
+            user_id="u1",
+            pocket_id="pocket-1",
+            base_url="https://169.254.169.254",
+            auth_type="none",
+            auth_token="",
+        )
+
+
+async def test_set_backend_requires_token_for_auth(mongo_db):
+    with pytest.raises(ValidationError):
+        await pockets_service.set_pocket_backend(
+            workspace_id="w1",
+            user_id="u1",
+            pocket_id="pocket-1",
+            base_url="https://api.example.com",
+            auth_type="bearer",
+            auth_token="",
+        )
+
+
+async def test_remove_backend(mongo_db):
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+    assert await pockets_service.get_pocket_backend("w1", "pocket-1") is not None
+
+    await pockets_service.remove_pocket_backend("w1", "u1", "pocket-1")
+    assert await pockets_service.get_pocket_backend("w1", "pocket-1") is None
+
+    # Idempotent — removing again does not raise.
+    await pockets_service.remove_pocket_backend("w1", "u1", "pocket-1")

--- a/tests/cloud/test_pocket_prompt_state_sources.py
+++ b/tests/cloud/test_pocket_prompt_state_sources.py
@@ -3,8 +3,13 @@
 Post-Task-11: the calling-agent creation prompts only carry the STEP 0
 delegation block, so the heavy ``<state-sources>`` / ``<creation-examples>``
 content moved onto the specialist's own prompt
-(``POCKET_SPECIALIST_PROMPT``). Interaction prompts still need it because
-they edit existing pockets directly.
+(``POCKET_SPECIALIST_PROMPT``).
+
+Post-#1163: the prompt-split moved the heavy mutation block off the main
+chat agent's ``POCKET_INTERACTION_PROMPT_*`` (now a slim delegation rule)
+and onto the edit specialist's ``POCKET_EDIT_SPECIALIST_PROMPT_*``. The
+edit specialist is the agent that actually edits rippleSpec directly, so
+that is the prompt that must carry ``<state-sources>``.
 """
 
 from __future__ import annotations
@@ -12,17 +17,17 @@ from __future__ import annotations
 import pytest
 
 from pocketpaw.ripple._pockets import (
-    POCKET_INTERACTION_PROMPT_CLI,
-    POCKET_INTERACTION_PROMPT_MCP,
+    POCKET_EDIT_SPECIALIST_PROMPT_CLI,
+    POCKET_EDIT_SPECIALIST_PROMPT_MCP,
     POCKET_SPECIALIST_PROMPT,
 )
 
 _PROMPTS_WITH_SOURCES = [
     POCKET_SPECIALIST_PROMPT,
-    POCKET_INTERACTION_PROMPT_MCP,
-    POCKET_INTERACTION_PROMPT_CLI,
+    POCKET_EDIT_SPECIALIST_PROMPT_MCP,
+    POCKET_EDIT_SPECIALIST_PROMPT_CLI,
 ]
-_IDS = ["specialist", "interact-mcp", "interact-cli"]
+_IDS = ["specialist", "edit-mcp", "edit-cli"]
 
 
 @pytest.mark.parametrize("prompt", _PROMPTS_WITH_SOURCES, ids=_IDS)

--- a/tests/cloud/test_pocket_source_executor.py
+++ b/tests/cloud/test_pocket_source_executor.py
@@ -1,0 +1,439 @@
+# tests/cloud/test_pocket_source_executor.py — RFC 04 alpha.
+# Created: 2026-05-21 — Coverage for the read-only pocket source executor,
+# the SSRF boundary of the feature. No real network calls — outbound HTTP
+# is faked via httpx.MockTransport and socket.getaddrinfo is monkeypatched
+# so fake hostnames "resolve" to a public IP.
+#
+# What this pins:
+#   - SSRF rejections: absolute-URL path, `..` traversal, path to a
+#     different host, internal base_url, host that resolves internal.
+#   - Response-size cap (512 KB).
+#   - Refresh-policy selection: pocket_open vs manual vs only_source vs all.
+#   - bind-path `state.` stripping.
+#   - Happy path with a mocked transport returning JSON.
+#   - Redirect -> source error (redirects not followed).
+#   - Per-pocket rate-limit breach.
+#   - Auth header shaping per auth_type.
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud.pockets import source_executor
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limit():
+    """Clear the module-level rate-limit log between tests."""
+    source_executor._run_log.clear()
+    yield
+    source_executor._run_log.clear()
+
+
+@pytest.fixture(autouse=True)
+def _public_dns(monkeypatch):
+    """Make every hostname resolve to a public IP so the DNS guard passes.
+
+    Individual tests that need an internal-resolving host override this.
+    """
+
+    def _fake_getaddrinfo(host, *_args, **_kwargs):
+        # 8.8.8.8 — a genuinely public IP (TEST-NET ranges read as
+        # is_private=True on modern Python and would trip the guard).
+        return [(2, 1, 6, "", ("8.8.8.8", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", _fake_getaddrinfo)
+
+
+def _mock_client_patch(monkeypatch, handler):
+    """Patch httpx.AsyncClient so the executor uses a MockTransport.
+
+    The executor builds its own AsyncClient; we wrap the constructor to
+    inject ``transport=MockTransport(handler)`` while preserving the
+    follow_redirects=False / timeout settings the executor passes.
+    """
+    real_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(source_executor.httpx, "AsyncClient", _factory)
+
+
+BASE = "https://api.example.com"
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_happy_path_returns_parsed_json(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/pulls"
+        return httpx.Response(200, json=[{"id": 1, "title": "PR one"}])
+
+    _mock_client_patch(monkeypatch, handler)
+
+    spec = {"sources": {"prs": {"method": "GET", "path": "/pulls", "bind": "state.prs"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert result["errors"] == []
+    assert len(result["ran"]) == 1
+    ran = result["ran"][0]
+    assert ran["source"] == "prs"
+    assert ran["bind"] == "prs"  # `state.` stripped
+    assert ran["value"] == [{"id": 1, "title": "PR one"}]
+
+
+async def test_bind_without_state_prefix_passes_through(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": True}))
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "prs"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert result["ran"][0]["bind"] == "prs"
+
+
+# ---------------------------------------------------------------------------
+# SSRF rejections
+# ---------------------------------------------------------------------------
+
+
+async def test_absolute_url_path_rejected(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
+    spec = {"sources": {"s": {"method": "GET", "path": "https://evil.com/x", "bind": "x"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert result["ran"] == []
+    assert result["errors"][0]["source"] == "s"
+    assert result["errors"][0]["code"] == "bad_path"
+
+
+async def test_dotdot_traversal_rejected(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
+    spec = {"sources": {"s": {"method": "GET", "path": "/a/../../etc/passwd", "bind": "x"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert result["ran"] == []
+    assert result["errors"][0]["code"] == "bad_path"
+
+
+async def test_encoded_dotdot_traversal_rejected(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
+    spec = {"sources": {"s": {"method": "GET", "path": "/a/%2e%2e/secret", "bind": "x"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert result["ran"] == []
+    assert result["errors"][0]["code"] == "bad_path"
+
+
+async def test_protocol_relative_path_to_other_host_rejected(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
+    # //evil.com/x has a netloc -> absolute, must be rejected.
+    spec = {"sources": {"s": {"method": "GET", "path": "//evil.com/x", "bind": "x"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert result["ran"] == []
+    assert result["errors"][0]["code"] == "bad_path"
+
+
+async def test_internal_base_url_rejected(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
+    with pytest.raises(ValueError):
+        await source_executor.run_sources(
+            pocket_id="p1",
+            ripple_spec=spec,
+            base_url="http://127.0.0.1",
+            auth_type="none",
+            auth_header=None,
+            token="",
+        )
+
+
+async def test_host_resolving_internal_rejected(monkeypatch):
+    """DNS rebinding guard — a public name resolving to a private IP."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
+
+    def _internal_getaddrinfo(host, *_a, **_k):
+        return [(2, 1, 6, "", ("169.254.169.254", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", _internal_getaddrinfo)
+
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert result["ran"] == []
+    assert result["errors"][0]["code"] == "bad_host"
+
+
+# ---------------------------------------------------------------------------
+# Response-size cap
+# ---------------------------------------------------------------------------
+
+
+async def test_oversize_response_rejected(monkeypatch):
+    big = json.dumps([{"x": "a" * 1000}] * 600)  # > 512 KB
+    assert len(big.encode()) > source_executor._MAX_RESPONSE_BYTES
+
+    _mock_client_patch(
+        monkeypatch,
+        lambda r: httpx.Response(200, content=big, headers={"content-type": "application/json"}),
+    )
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert result["ran"] == []
+    assert result["errors"][0]["code"] == "too_large"
+
+
+# ---------------------------------------------------------------------------
+# Refresh-policy selection
+# ---------------------------------------------------------------------------
+
+
+def _multi_source_spec() -> dict:
+    return {
+        "sources": {
+            "open_only": {"method": "GET", "path": "/a", "bind": "a", "refresh": ["pocket_open"]},
+            "manual_only": {"method": "GET", "path": "/b", "bind": "b", "refresh": ["manual"]},
+            "both": {
+                "method": "GET",
+                "path": "/c",
+                "bind": "c",
+                "refresh": ["pocket_open", "manual"],
+            },
+        }
+    }
+
+
+async def test_trigger_pocket_open_selects_open_sources(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=_multi_source_spec(),
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        trigger="pocket_open",
+    )
+    ran_sources = {r["source"] for r in result["ran"]}
+    assert ran_sources == {"open_only", "both"}
+
+
+async def test_trigger_manual_selects_manual_sources(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=_multi_source_spec(),
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        trigger="manual",
+    )
+    ran_sources = {r["source"] for r in result["ran"]}
+    assert ran_sources == {"manual_only", "both"}
+
+
+async def test_only_source_runs_just_that_source(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=_multi_source_spec(),
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        only_source="manual_only",
+    )
+    assert {r["source"] for r in result["ran"]} == {"manual_only"}
+
+
+async def test_no_trigger_runs_all_sources(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=_multi_source_spec(),
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert {r["source"] for r in result["ran"]} == {"open_only", "manual_only", "both"}
+
+
+# ---------------------------------------------------------------------------
+# Redirects
+# ---------------------------------------------------------------------------
+
+
+async def test_redirect_becomes_source_error(monkeypatch):
+    _mock_client_patch(
+        monkeypatch,
+        lambda r: httpx.Response(302, headers={"location": "https://evil.com/x"}),
+    )
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert result["ran"] == []
+    assert result["errors"][0]["code"] == "redirect"
+
+
+# ---------------------------------------------------------------------------
+# Rate limit
+# ---------------------------------------------------------------------------
+
+
+async def test_rate_limit_breach_returns_rate_limited(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
+
+    # Burn the budget (10 runs/min).
+    for _ in range(source_executor._RATE_LIMIT_MAX):
+        await source_executor.run_sources(
+            pocket_id="p-rl",
+            ripple_spec=spec,
+            base_url=BASE,
+            auth_type="none",
+            auth_header=None,
+            token="",
+        )
+
+    breach = await source_executor.run_sources(
+        pocket_id="p-rl",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert breach["ran"] == []
+    assert breach["errors"][0]["code"] == "rate_limited"
+
+
+async def test_rate_limit_is_per_pocket(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
+    for _ in range(source_executor._RATE_LIMIT_MAX):
+        await source_executor.run_sources(
+            pocket_id="pocket-a",
+            ripple_spec=spec,
+            base_url=BASE,
+            auth_type="none",
+            auth_header=None,
+            token="",
+        )
+    # A different pocket still has its full budget.
+    other = await source_executor.run_sources(
+        pocket_id="pocket-b",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert len(other["ran"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Auth header shaping
+# ---------------------------------------------------------------------------
+
+
+async def test_bearer_auth_header(monkeypatch):
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json={})
+
+    _mock_client_patch(monkeypatch, handler)
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
+    await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="bearer",
+        auth_header=None,
+        token="tok123",
+    )
+    assert seen["auth"] == "Bearer tok123"
+
+
+async def test_api_key_custom_header(monkeypatch):
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["key"] = request.headers.get("x-internal-key")
+        return httpx.Response(200, json={})
+
+    _mock_client_patch(monkeypatch, handler)
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
+    await source_executor.run_sources(
+        pocket_id="p1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="api_key",
+        auth_header="X-Internal-Key",
+        token="abc",
+    )
+    assert seen["key"] == "abc"

--- a/tests/cloud/test_pocket_source_executor.py
+++ b/tests/cloud/test_pocket_source_executor.py
@@ -3,6 +3,10 @@
 # the SSRF boundary of the feature. No real network calls — outbound HTTP
 # is faked via httpx.MockTransport and socket.getaddrinfo is monkeypatched
 # so fake hostnames "resolve" to a public IP.
+# Updated: 2026-05-21 (PR #1177 security pass) — run_sources now takes a
+# required user_id; added coverage for basic-auth base64 encoding, the
+# per-(pocket, user) rate-limit key, the async-safe limiter under
+# asyncio.gather, and the audit-log entry written for every run.
 #
 # What this pins:
 #   - SSRF rejections: absolute-URL path, `..` traversal, path to a
@@ -12,8 +16,9 @@
 #   - bind-path `state.` stripping.
 #   - Happy path with a mocked transport returning JSON.
 #   - Redirect -> source error (redirects not followed).
-#   - Per-pocket rate-limit breach.
-#   - Auth header shaping per auth_type.
+#   - Per-(pocket, user) rate-limit breach + async-safety.
+#   - Auth header shaping per auth_type (bearer / api_key / basic).
+#   - Audit-log entry written per run.
 
 from __future__ import annotations
 
@@ -81,6 +86,7 @@ async def test_happy_path_returns_parsed_json(monkeypatch):
     spec = {"sources": {"prs": {"method": "GET", "path": "/pulls", "bind": "state.prs"}}}
     result = await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -100,6 +106,7 @@ async def test_bind_without_state_prefix_passes_through(monkeypatch):
     spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "prs"}}}
     result = await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -119,6 +126,7 @@ async def test_absolute_url_path_rejected(monkeypatch):
     spec = {"sources": {"s": {"method": "GET", "path": "https://evil.com/x", "bind": "x"}}}
     result = await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -135,6 +143,7 @@ async def test_dotdot_traversal_rejected(monkeypatch):
     spec = {"sources": {"s": {"method": "GET", "path": "/a/../../etc/passwd", "bind": "x"}}}
     result = await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -150,6 +159,7 @@ async def test_encoded_dotdot_traversal_rejected(monkeypatch):
     spec = {"sources": {"s": {"method": "GET", "path": "/a/%2e%2e/secret", "bind": "x"}}}
     result = await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -166,6 +176,7 @@ async def test_protocol_relative_path_to_other_host_rejected(monkeypatch):
     spec = {"sources": {"s": {"method": "GET", "path": "//evil.com/x", "bind": "x"}}}
     result = await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -182,6 +193,7 @@ async def test_internal_base_url_rejected(monkeypatch):
     with pytest.raises(ValueError):
         await source_executor.run_sources(
             pocket_id="p1",
+            user_id="runner-1",
             ripple_spec=spec,
             base_url="http://127.0.0.1",
             auth_type="none",
@@ -202,6 +214,7 @@ async def test_host_resolving_internal_rejected(monkeypatch):
     spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
     result = await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -228,6 +241,7 @@ async def test_oversize_response_rejected(monkeypatch):
     spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
     result = await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -262,6 +276,7 @@ async def test_trigger_pocket_open_selects_open_sources(monkeypatch):
     _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
     result = await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=_multi_source_spec(),
         base_url=BASE,
         auth_type="none",
@@ -277,6 +292,7 @@ async def test_trigger_manual_selects_manual_sources(monkeypatch):
     _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
     result = await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=_multi_source_spec(),
         base_url=BASE,
         auth_type="none",
@@ -292,6 +308,7 @@ async def test_only_source_runs_just_that_source(monkeypatch):
     _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
     result = await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=_multi_source_spec(),
         base_url=BASE,
         auth_type="none",
@@ -306,6 +323,7 @@ async def test_no_trigger_runs_all_sources(monkeypatch):
     _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
     result = await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=_multi_source_spec(),
         base_url=BASE,
         auth_type="none",
@@ -328,6 +346,7 @@ async def test_redirect_becomes_source_error(monkeypatch):
     spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
     result = await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -351,6 +370,7 @@ async def test_rate_limit_breach_returns_rate_limited(monkeypatch):
     for _ in range(source_executor._RATE_LIMIT_MAX):
         await source_executor.run_sources(
             pocket_id="p-rl",
+            user_id="runner-1",
             ripple_spec=spec,
             base_url=BASE,
             auth_type="none",
@@ -360,6 +380,7 @@ async def test_rate_limit_breach_returns_rate_limited(monkeypatch):
 
     breach = await source_executor.run_sources(
         pocket_id="p-rl",
+        user_id="runner-1",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -376,6 +397,7 @@ async def test_rate_limit_is_per_pocket(monkeypatch):
     for _ in range(source_executor._RATE_LIMIT_MAX):
         await source_executor.run_sources(
             pocket_id="pocket-a",
+            user_id="runner-1",
             ripple_spec=spec,
             base_url=BASE,
             auth_type="none",
@@ -385,6 +407,7 @@ async def test_rate_limit_is_per_pocket(monkeypatch):
     # A different pocket still has its full budget.
     other = await source_executor.run_sources(
         pocket_id="pocket-b",
+        user_id="runner-1",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -410,6 +433,7 @@ async def test_bearer_auth_header(monkeypatch):
     spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
     await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="bearer",
@@ -430,6 +454,7 @@ async def test_api_key_custom_header(monkeypatch):
     spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
     await source_executor.run_sources(
         pocket_id="p1",
+        user_id="runner-1",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="api_key",
@@ -437,3 +462,179 @@ async def test_api_key_custom_header(monkeypatch):
         token="abc",
     )
     assert seen["key"] == "abc"
+
+
+async def test_basic_auth_header_is_base64_encoded(monkeypatch):
+    """BLOCKER-1 — `basic` auth must base64-encode the user:pass credential."""
+    import base64
+
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json={})
+
+    _mock_client_patch(monkeypatch, handler)
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
+    await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="runner-1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="basic",
+        auth_header=None,
+        token="alice:s3cret",
+    )
+    expected = base64.b64encode(b"alice:s3cret").decode()
+    assert seen["auth"] == f"Basic {expected}"
+    # The raw user:pass must never appear unencoded on the wire.
+    assert "alice:s3cret" not in seen["auth"]
+
+
+# ---------------------------------------------------------------------------
+# Rate limit — per (pocket, user) key + async safety
+# ---------------------------------------------------------------------------
+
+
+async def test_rate_limit_is_per_user(monkeypatch):
+    """SHOULD-FIX-2 — one member exhausting a pocket's budget must not
+    starve another member of the same shared pocket."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
+
+    # alice burns her whole budget on the shared pocket.
+    for _ in range(source_executor._RATE_LIMIT_MAX):
+        await source_executor.run_sources(
+            pocket_id="shared-pocket",
+            user_id="alice",
+            ripple_spec=spec,
+            base_url=BASE,
+            auth_type="none",
+            auth_header=None,
+            token="",
+        )
+    alice_breach = await source_executor.run_sources(
+        pocket_id="shared-pocket",
+        user_id="alice",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert alice_breach["errors"][0]["code"] == "rate_limited"
+
+    # bob still has his full budget on the SAME pocket.
+    bob = await source_executor.run_sources(
+        pocket_id="shared-pocket",
+        user_id="bob",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+    )
+    assert len(bob["ran"]) == 1
+
+
+async def test_rate_limit_async_safe_under_gather(monkeypatch):
+    """SHOULD-FIX-3 — concurrent runs must not race past the limit.
+
+    Fires 4x the budget concurrently; with the lock, exactly
+    _RATE_LIMIT_MAX runs are permitted and the rest are rate-limited.
+    """
+    import asyncio
+
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
+
+    total = source_executor._RATE_LIMIT_MAX * 4
+    results = await asyncio.gather(
+        *(
+            source_executor.run_sources(
+                pocket_id="race-pocket",
+                user_id="racer",
+                ripple_spec=spec,
+                base_url=BASE,
+                auth_type="none",
+                auth_header=None,
+                token="",
+            )
+            for _ in range(total)
+        )
+    )
+    permitted = sum(1 for r in results if r["ran"])
+    limited = sum(
+        1 for r in results if r["errors"] and r["errors"][0].get("code") == "rate_limited"
+    )
+    assert permitted == source_executor._RATE_LIMIT_MAX
+    assert limited == total - source_executor._RATE_LIMIT_MAX
+
+
+# ---------------------------------------------------------------------------
+# Audit log
+# ---------------------------------------------------------------------------
+
+
+async def test_run_writes_audit_entry(monkeypatch):
+    """SHOULD-FIX-5 — every source run writes one audit-log entry."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
+
+    logged: list = []
+
+    class _FakeLogger:
+        def log(self, event):
+            logged.append(event)
+
+    import pocketpaw.security.audit as audit_mod
+
+    monkeypatch.setattr(audit_mod, "get_audit_logger", lambda: _FakeLogger())
+
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "state.s"}}}
+    await source_executor.run_sources(
+        pocket_id="audited-pocket",
+        user_id="auditor",
+        ripple_spec=spec,
+        base_url=BASE + "/?token=leak",
+        auth_type="bearer",
+        auth_header=None,
+        token="super-secret-token",
+    )
+    assert len(logged) == 1
+    event = logged[0]
+    assert event.actor == "auditor"
+    assert event.action == "pocket.sources.run"
+    assert event.target == "audited-pocket"
+    assert event.status == "success"
+    # The query string is stripped from the logged base URL; the token
+    # value never appears anywhere in the entry.
+    assert "token=leak" not in event.context["base_url"]
+    assert "super-secret-token" not in str(event.context)
+
+
+async def test_rate_limited_run_audits_as_rate_limited(monkeypatch):
+    """A rate-limited run still writes an audit entry, status rate-limited."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"v": 1}))
+
+    logged: list = []
+
+    class _FakeLogger:
+        def log(self, event):
+            logged.append(event)
+
+    import pocketpaw.security.audit as audit_mod
+
+    monkeypatch.setattr(audit_mod, "get_audit_logger", lambda: _FakeLogger())
+
+    spec = {"sources": {"s": {"method": "GET", "path": "/x", "bind": "x"}}}
+    for _ in range(source_executor._RATE_LIMIT_MAX + 1):
+        await source_executor.run_sources(
+            pocket_id="rl-audit",
+            user_id="auditor",
+            ripple_spec=spec,
+            base_url=BASE,
+            auth_type="none",
+            auth_header=None,
+            token="",
+        )
+    assert logged[-1].status == "rate-limited"

--- a/tests/cloud/test_pocket_sources_lift.py
+++ b/tests/cloud/test_pocket_sources_lift.py
@@ -194,9 +194,7 @@ def test_lift_heuristic_without_kind_field():
     spec = {
         "title": "No Kind",
         "version": "1.0",
-        "tool_specs": [
-            {"id": "src_todos", "method": "GET", "url": "/todos", "into": "todos"}
-        ],
+        "tool_specs": [{"id": "src_todos", "method": "GET", "url": "/todos", "into": "todos"}],
         "state": {"todos": []},
         "ui": {"type": "flex", "children": []},
     }

--- a/tests/cloud/test_pocket_sources_lift.py
+++ b/tests/cloud/test_pocket_sources_lift.py
@@ -1,0 +1,273 @@
+# tests/cloud/test_pocket_sources_lift.py — RFC 04 alpha.
+# Created: 2026-05-22 (PR #1177) — pins the deterministic translation that
+# the spec normalizer applies to the pocket-authoring agent's hallucinated
+# data-source output. The agent reliably emits a `rippleSpec.tool_specs`
+# REST schema (invented `kind`/`url`/`auto_fetch`/`into` fields) instead of
+# the RFC 04 `rippleSpec.sources` block, and wires refresh buttons with the
+# wrong `source_id` field. `normalize_ripple_spec` now lifts that output
+# into a working `sources` block and repairs the buttons.
+#
+# What this pins:
+#   - tool_specs REST entry -> rippleSpec.sources entry, button repaired.
+#   - a correctly-authored `sources` spec passes through UNCHANGED.
+#   - auto_fetch:false -> refresh ["manual"].
+#   - an absolute `url` is reduced to a relative `path`.
+#   - a non-GET method entry is skipped (alpha is GET-only).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec
+
+
+def _hallucinated_spec() -> dict:
+    """The exact bad shape the authoring agent emits, from MongoDB ground
+    truth: a `tool_specs` REST list nested in the rippleSpec plus a refresh
+    button wired with `source_id` instead of `source`."""
+    return {
+        "title": "Todo Tracker",
+        "version": "1.0",
+        "tool_specs": [
+            {
+                "id": "src_todos",
+                "kind": "rest",
+                "method": "GET",
+                "url": "/todos",
+                "auto_fetch": True,
+                "into": "todos",
+            }
+        ],
+        "state": {"todos": []},
+        "ui": {
+            "type": "flex",
+            "children": [
+                {
+                    "type": "button",
+                    "props": {"label": "Refresh"},
+                    "on_click": {"action": "run_source", "source_id": "src_todos"},
+                }
+            ],
+        },
+    }
+
+
+def test_tool_specs_rest_entry_is_lifted_into_sources():
+    """The hallucinated tool_specs REST entry becomes a sources entry."""
+    normalized = normalize_ripple_spec(_hallucinated_spec())
+    assert normalized is not None
+
+    sources = normalized.get("sources")
+    assert sources == {
+        "src_todos": {
+            "method": "GET",
+            "path": "/todos",
+            "bind": "state.todos",
+            "refresh": ["pocket_open", "manual"],
+        }
+    }
+
+
+def test_lifted_tool_specs_key_is_removed():
+    """`rippleSpec.tool_specs` is not a real field — drop it once empty."""
+    normalized = normalize_ripple_spec(_hallucinated_spec())
+    assert normalized is not None
+    assert "tool_specs" not in normalized
+
+
+def test_run_source_button_handler_is_repaired():
+    """`source_id` on a run_source handler is renamed to `source`."""
+    normalized = normalize_ripple_spec(_hallucinated_spec())
+    assert normalized is not None
+
+    button = normalized["ui"]["children"][0]
+    handler = button["on_click"]
+    assert handler["action"] == "run_source"
+    assert handler["source"] == "src_todos"
+    assert "source_id" not in handler
+
+
+def test_correctly_authored_sources_spec_passes_through_unchanged():
+    """A spec already using rippleSpec.sources must not be mutated."""
+    good = {
+        "title": "PR Tracker",
+        "version": "1.0",
+        "sources": {
+            "prs": {
+                "method": "GET",
+                "path": "/pulls?state=open",
+                "bind": "state.prs",
+                "refresh": ["pocket_open", "manual"],
+            }
+        },
+        "state": {"prs": []},
+        "ui": {
+            "type": "flex",
+            "children": [
+                {
+                    "type": "button",
+                    "props": {"label": "Refresh"},
+                    "on_click": {"action": "run_source", "source": "prs"},
+                }
+            ],
+        },
+    }
+    normalized = normalize_ripple_spec(good)
+    assert normalized is not None
+    assert normalized["sources"] == good["sources"]
+    assert "tool_specs" not in normalized
+    handler = normalized["ui"]["children"][0]["on_click"]
+    assert handler == {"action": "run_source", "source": "prs"}
+
+
+def test_auto_fetch_false_gives_manual_only_refresh():
+    """auto_fetch:false -> refresh ["manual"] (no pocket_open trigger)."""
+    spec = {
+        "title": "Manual Todo",
+        "version": "1.0",
+        "tool_specs": [
+            {
+                "id": "src_todos",
+                "kind": "rest",
+                "method": "GET",
+                "url": "/todos",
+                "auto_fetch": False,
+                "into": "todos",
+            }
+        ],
+        "state": {"todos": []},
+        "ui": {"type": "flex", "children": []},
+    }
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+    assert normalized["sources"]["src_todos"]["refresh"] == ["manual"]
+
+
+def test_absolute_url_is_reduced_to_relative_path():
+    """An absolute URL in `url` keeps only its path+query portion."""
+    spec = {
+        "title": "Absolute URL",
+        "version": "1.0",
+        "tool_specs": [
+            {
+                "id": "src_todos",
+                "kind": "rest",
+                "method": "GET",
+                "url": "https://api.example.com/todos?state=open",
+                "auto_fetch": True,
+                "into": "todos",
+            }
+        ],
+        "state": {"todos": []},
+        "ui": {"type": "flex", "children": []},
+    }
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+    assert normalized["sources"]["src_todos"]["path"] == "/todos?state=open"
+
+
+def test_non_get_method_entry_is_skipped():
+    """Alpha is GET-only — a non-GET tool_specs entry is dropped, not lifted."""
+    spec = {
+        "title": "Write Source",
+        "version": "1.0",
+        "tool_specs": [
+            {
+                "id": "src_create",
+                "kind": "rest",
+                "method": "POST",
+                "url": "/todos",
+                "auto_fetch": True,
+                "into": "todos",
+            }
+        ],
+        "state": {"todos": []},
+        "ui": {"type": "flex", "children": []},
+    }
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+    assert "sources" not in normalized or "src_create" not in normalized.get("sources", {})
+    assert "tool_specs" not in normalized
+
+
+def test_lift_heuristic_without_kind_field():
+    """An entry with url+into but no `kind:"rest"` still looks like a REST
+    data source and is lifted."""
+    spec = {
+        "title": "No Kind",
+        "version": "1.0",
+        "tool_specs": [
+            {"id": "src_todos", "method": "GET", "url": "/todos", "into": "todos"}
+        ],
+        "state": {"todos": []},
+        "ui": {"type": "flex", "children": []},
+    }
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+    assert "src_todos" in normalized["sources"]
+
+
+def test_run_source_button_bound_to_sole_source_when_source_missing():
+    """A run_source handler with no source at all binds to the only source."""
+    spec = {
+        "title": "Sole Source",
+        "version": "1.0",
+        "sources": {
+            "todos": {
+                "method": "GET",
+                "path": "/todos",
+                "bind": "state.todos",
+                "refresh": ["manual"],
+            }
+        },
+        "state": {"todos": []},
+        "ui": {
+            "type": "flex",
+            "children": [
+                {
+                    "type": "button",
+                    "props": {"label": "Refresh"},
+                    "on_click": {"action": "run_source"},
+                }
+            ],
+        },
+    }
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+    handler = normalized["ui"]["children"][0]["on_click"]
+    assert handler["source"] == "todos"
+
+
+def test_handler_arrays_are_walked():
+    """A run_source handler inside an on_click array is repaired too."""
+    spec = {
+        "title": "Array Handler",
+        "version": "1.0",
+        "tool_specs": [
+            {
+                "id": "src_todos",
+                "kind": "rest",
+                "method": "GET",
+                "url": "/todos",
+                "auto_fetch": True,
+                "into": "todos",
+            }
+        ],
+        "state": {"todos": []},
+        "ui": {
+            "type": "flex",
+            "children": [
+                {
+                    "type": "button",
+                    "props": {"label": "Refresh"},
+                    "on_click": [
+                        {"action": "run_source", "source_id": "src_todos"},
+                        {"action": "set_state", "path": "todos", "value": []},
+                    ],
+                }
+            ],
+        },
+    }
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+    handlers = normalized["ui"]["children"][0]["on_click"]
+    assert handlers[0] == {"action": "run_source", "source": "src_todos"}
+    assert handlers[1] == {"action": "set_state", "path": "todos", "value": []}

--- a/tests/cloud/test_pocket_sources_ops.py
+++ b/tests/cloud/test_pocket_sources_ops.py
@@ -1,0 +1,391 @@
+# test_pocket_sources_ops.py — Tests for the edit-specialist `sources` ops.
+# Created: 2026-05-21 (RFC 04 alpha follow-up) — closes the edit-path gap
+#   where the pocket EDIT specialist could not author a top-level
+#   `rippleSpec.sources` block on an existing pocket (create worked, edit
+#   did not). Covers the pure `sources_ops` helpers, the service-layer
+#   `agent_set_source` / `agent_remove_source` functions (happy path,
+#   invalid-binding rejection, persistence, emitted mutation), and the
+#   new `set_source` / `remove_source` edit tool factories.
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pocketpaw_ee.cloud.pockets import agent_context, sources_ops
+from pocketpaw_ee.cloud.pockets import service as pocket_service
+
+# ---------------------------------------------------------------------------
+# Fake doc + patch helper (mirrors test_pocket_state_ops.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeDoc:
+    """Minimum surface to stand in for a ``_PocketDoc`` in these tests.
+
+    Mutations operate on ``self.rippleSpec`` in place, like a real Beanie
+    doc. ``save()`` is an async no-op; calls are counted via ``saves``.
+    """
+
+    def __init__(self, pocket_id: str, ripple_spec: dict[str, Any]):
+        self.id = pocket_id
+        self.workspace = "w1"
+        self.name = "Test"
+        self.description = ""
+        self.type = "custom"
+        self.icon = ""
+        self.color = ""
+        self.owner = "u1"
+        self.visibility = "workspace"
+        self.team: list[str] = []
+        self.agents: list[str] = []
+        self.widgets: list[Any] = []
+        self.rippleSpec = ripple_spec
+        self.share_link_token = None
+        self.share_link_access = "view"
+        self.shared_with: list[str] = []
+        self.tool_specs: list[Any] = []
+        self.saves = 0
+
+    async def save(self) -> None:
+        self.saves += 1
+
+    def model_dump(self, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "_id": self.id,
+            "workspace": self.workspace,
+            "rippleSpec": self.rippleSpec,
+            "owner": self.owner,
+        }
+
+
+@pytest.fixture
+def fake_doc() -> _FakeDoc:
+    """A persisted pocket with a UI tree + seeded state but NO sources."""
+    return _FakeDoc(
+        "507f1f77bcf86cd799439011",
+        {
+            "version": "1.0",
+            "state": {"prs": []},
+            "ui": {"id": "n_root0000", "type": "flex", "children": []},
+        },
+    )
+
+
+def _patches(doc: _FakeDoc):
+    """Patch the doc fetch + emit/push seams + identity ContextVars.
+
+    Returns ``(ExitStack, push_calls)`` — use as ``with ctx: ...``.
+    """
+    push_calls: list[dict[str, Any]] = []
+
+    def _capture(payload: dict[str, Any]) -> None:
+        push_calls.append(payload)
+
+    stack = ExitStack()
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service._PocketDoc.get",
+            new=AsyncMock(return_value=doc),
+        )
+    )
+    stack.enter_context(patch("pocketpaw_ee.cloud.pockets.service.emit", new=AsyncMock()))
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service._pocket_event_payload",
+            new=AsyncMock(return_value={"pocket_id": doc.id}),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.push_pocket_mutation",
+            new=MagicMock(side_effect=_capture),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service.normalize_ripple_spec",
+            new=lambda s: s,
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+            new=MagicMock(return_value=doc.workspace),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+            new=MagicMock(return_value=doc.owner),
+        )
+    )
+    return stack, push_calls
+
+
+_VALID_BINDING = {
+    "method": "GET",
+    "path": "/pulls?state=open",
+    "bind": "state.prs",
+    "refresh": ["pocket_open", "manual"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — the red test: the edit specialist can add a sources block.
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_set_source_adds_sources_block_to_existing_pocket(fake_doc):
+    """The core regression: an EXISTING persisted pocket with no
+    ``rippleSpec.sources`` gains a binding when the edit specialist calls
+    ``agent_set_source``. This is the gap RFC 04 alpha left open."""
+    ctx, _ = _patches(fake_doc)
+    with ctx:
+        result, err = await pocket_service.agent_set_source(
+            fake_doc.id, source_key="prs", binding=dict(_VALID_BINDING)
+        )
+    assert err is None
+    assert result is not None
+    assert fake_doc.rippleSpec["sources"]["prs"]["path"] == "/pulls?state=open"
+    assert fake_doc.rippleSpec["sources"]["prs"]["bind"] == "state.prs"
+    assert fake_doc.saves == 1
+
+
+# ---------------------------------------------------------------------------
+# Pure ops — sources_ops.set_source / remove_source
+# ---------------------------------------------------------------------------
+
+
+def test_set_source_creates_sources_dict_when_absent():
+    spec: dict[str, Any] = {"ui": {}, "state": {}}
+    out = sources_ops.set_source(spec, "prs", dict(_VALID_BINDING))
+    assert out is spec
+    assert spec["sources"]["prs"] == _VALID_BINDING
+
+
+def test_set_source_adds_alongside_existing_sources():
+    spec = {"sources": {"a": dict(_VALID_BINDING)}}
+    sources_ops.set_source(spec, "b", dict(_VALID_BINDING))
+    assert set(spec["sources"]) == {"a", "b"}
+
+
+def test_set_source_overwrites_existing_key():
+    spec = {"sources": {"prs": {"path": "/old", "bind": "state.prs"}}}
+    sources_ops.set_source(spec, "prs", dict(_VALID_BINDING))
+    assert spec["sources"]["prs"]["path"] == "/pulls?state=open"
+
+
+def test_remove_source_drops_the_key():
+    spec = {"sources": {"prs": dict(_VALID_BINDING), "issues": dict(_VALID_BINDING)}}
+    sources_ops.remove_source(spec, "prs")
+    assert "prs" not in spec["sources"]
+    assert "issues" in spec["sources"]
+
+
+def test_remove_source_is_a_noop_when_key_absent():
+    spec = {"sources": {"prs": dict(_VALID_BINDING)}}
+    out = sources_ops.remove_source(spec, "nope")
+    assert out is spec
+    assert "prs" in spec["sources"]
+
+
+def test_remove_source_is_a_noop_when_sources_absent():
+    spec: dict[str, Any] = {"ui": {}}
+    out = sources_ops.remove_source(spec, "prs")
+    assert out is spec
+    assert "sources" not in spec
+
+
+# ---------------------------------------------------------------------------
+# Service layer — agent_set_source
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_set_source_returns_view_with_binding(fake_doc):
+    """The service layer persists + returns the agent view; the
+    pocket_mutation push happens in the agent_context wrapper (covered
+    separately below)."""
+    ctx, _ = _patches(fake_doc)
+    with ctx:
+        result, err = await pocket_service.agent_set_source(
+            fake_doc.id, source_key="prs", binding=dict(_VALID_BINDING)
+        )
+    assert err is None
+    assert result is not None
+    assert result["source_key"] == "prs"
+    assert result["binding"]["path"] == "/pulls?state=open"
+    assert result["pocket"]["rippleSpec"]["sources"]["prs"]["bind"] == "state.prs"
+
+
+async def test_agent_set_source_rejects_invalid_binding(fake_doc):
+    """A binding missing required fields (``path``/``bind``) is rejected
+    via the ``SourceBinding`` model before any write happens."""
+    ctx, push_calls = _patches(fake_doc)
+    with ctx:
+        result, err = await pocket_service.agent_set_source(
+            fake_doc.id, source_key="prs", binding={"method": "GET"}
+        )
+    assert result is None
+    assert err is not None
+    assert "binding" in err.lower()
+    assert "sources" not in fake_doc.rippleSpec
+    assert fake_doc.saves == 0
+    assert not push_calls
+
+
+async def test_agent_set_source_rejects_write_verb(fake_doc):
+    """``method`` is a Literal["GET"] — a POST binding is rejected."""
+    ctx, _ = _patches(fake_doc)
+    bad = dict(_VALID_BINDING, method="POST")
+    with ctx:
+        result, err = await pocket_service.agent_set_source(
+            fake_doc.id, source_key="prs", binding=bad
+        )
+    assert result is None
+    assert err is not None
+
+
+async def test_agent_set_source_requires_a_key(fake_doc):
+    ctx, _ = _patches(fake_doc)
+    with ctx:
+        result, err = await pocket_service.agent_set_source(
+            fake_doc.id, source_key="", binding=dict(_VALID_BINDING)
+        )
+    assert result is None
+    assert err is not None
+    assert "source_key" in err
+
+
+async def test_agent_set_source_persists_defaults_for_omitted_refresh(fake_doc):
+    """``refresh`` defaults to ``["pocket_open"]`` via SourceBinding."""
+    ctx, _ = _patches(fake_doc)
+    binding = {"method": "GET", "path": "/pulls", "bind": "state.prs"}
+    with ctx:
+        result, err = await pocket_service.agent_set_source(
+            fake_doc.id, source_key="prs", binding=binding
+        )
+    assert err is None
+    assert fake_doc.rippleSpec["sources"]["prs"]["refresh"] == ["pocket_open"]
+
+
+# ---------------------------------------------------------------------------
+# Service layer — agent_remove_source
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_remove_source_drops_the_binding():
+    doc = _FakeDoc(
+        "507f1f77bcf86cd799439022",
+        {
+            "version": "1.0",
+            "sources": {"prs": dict(_VALID_BINDING)},
+            "state": {"prs": []},
+            "ui": {"id": "n_root0000", "type": "flex"},
+        },
+    )
+    ctx, _ = _patches(doc)
+    with ctx:
+        result, err = await pocket_service.agent_remove_source(doc.id, source_key="prs")
+    assert err is None
+    assert result is not None
+    assert "prs" not in doc.rippleSpec.get("sources", {})
+    assert doc.saves == 1
+
+
+async def test_agent_remove_source_noop_when_absent(fake_doc):
+    """Removing a source that was never declared still succeeds (idempotent)."""
+    ctx, _ = _patches(fake_doc)
+    with ctx:
+        result, err = await pocket_service.agent_remove_source(fake_doc.id, source_key="ghost")
+    assert err is None
+    assert result is not None
+    assert fake_doc.saves == 1
+
+
+# ---------------------------------------------------------------------------
+# agent_context wrappers
+# ---------------------------------------------------------------------------
+
+
+async def test_set_source_for_agent_returns_ok_shape(fake_doc):
+    ctx, push_calls = _patches(fake_doc)
+    with ctx:
+        result = await agent_context.set_source_for_agent(
+            fake_doc.id, "prs", dict(_VALID_BINDING)
+        )
+    assert result["ok"] is True
+    assert fake_doc.rippleSpec["sources"]["prs"]["bind"] == "state.prs"
+    assert push_calls[0]["action"] == "replace"
+
+
+async def test_set_source_for_agent_surfaces_error(fake_doc):
+    ctx, _ = _patches(fake_doc)
+    with ctx:
+        result = await agent_context.set_source_for_agent(fake_doc.id, "prs", {"method": "GET"})
+    assert result["ok"] is False
+    assert "error" in result
+
+
+async def test_remove_source_for_agent_returns_ok_shape():
+    doc = _FakeDoc(
+        "507f1f77bcf86cd799439033",
+        {"version": "1.0", "sources": {"prs": dict(_VALID_BINDING)}, "ui": {}},
+    )
+    ctx, _ = _patches(doc)
+    with ctx:
+        result = await agent_context.remove_source_for_agent(doc.id, "prs")
+    assert result["ok"] is True
+    assert "prs" not in doc.rippleSpec.get("sources", {})
+
+
+# ---------------------------------------------------------------------------
+# Edit tool factories
+# ---------------------------------------------------------------------------
+
+
+async def test_set_source_tool_is_registered_in_edit_toolset():
+    from pocketpaw_ee.agent.pocket_specialist.tools import make_edit_pocket_tools
+
+    tools = make_edit_pocket_tools(pocket_id="507f1f77bcf86cd799439011")
+    names = {t.name for t in tools}
+    assert "set_source" in names
+    assert "remove_source" in names
+
+
+async def test_set_source_tool_runs_and_captures_op(fake_doc):
+    from pocketpaw_ee.agent.pocket_specialist.tools import make_set_source_tool
+
+    capture: dict[str, Any] = {}
+    tool = make_set_source_tool(pocket_id=fake_doc.id, capture=capture)
+    ctx, _ = _patches(fake_doc)
+    with ctx:
+        result = await tool.coroutine(
+            source_key="prs",
+            path="/pulls?state=open",
+            bind="state.prs",
+            method="GET",
+            refresh=["pocket_open", "manual"],
+        )
+    assert result["ok"] is True
+    assert fake_doc.rippleSpec["sources"]["prs"]["path"] == "/pulls?state=open"
+    assert capture["ops"][0]["op"] == "set_source"
+
+
+async def test_remove_source_tool_runs_and_captures_op():
+    from pocketpaw_ee.agent.pocket_specialist.tools import make_remove_source_tool
+
+    doc = _FakeDoc(
+        "507f1f77bcf86cd799439044",
+        {"version": "1.0", "sources": {"prs": dict(_VALID_BINDING)}, "ui": {}},
+    )
+    capture: dict[str, Any] = {}
+    tool = make_remove_source_tool(pocket_id=doc.id, capture=capture)
+    ctx, _ = _patches(doc)
+    with ctx:
+        result = await tool.coroutine(source_key="prs")
+    assert result["ok"] is True
+    assert "prs" not in doc.rippleSpec.get("sources", {})
+    assert capture["ops"][0]["op"] == "remove_source"

--- a/tests/cloud/test_pocket_sources_ops.py
+++ b/tests/cloud/test_pocket_sources_ops.py
@@ -313,9 +313,7 @@ async def test_agent_remove_source_noop_when_absent(fake_doc):
 async def test_set_source_for_agent_returns_ok_shape(fake_doc):
     ctx, push_calls = _patches(fake_doc)
     with ctx:
-        result = await agent_context.set_source_for_agent(
-            fake_doc.id, "prs", dict(_VALID_BINDING)
-        )
+        result = await agent_context.set_source_for_agent(fake_doc.id, "prs", dict(_VALID_BINDING))
     assert result["ok"] is True
     assert fake_doc.rippleSpec["sources"]["prs"]["bind"] == "state.prs"
     assert push_calls[0]["action"] == "replace"


### PR DESCRIPTION
## What this does

Pockets render a static `rippleSpec` today — a one-time data snapshot. This PR adds the first piece of RFC 04: a pocket can be bound to one external backend and declare read-only GET "sources" in its spec. A server-side executor runs the GETs and returns the JSON; the frontend applies the results to the pocket's ripple state.

Alpha is read-only — GET bindings only. Write bindings are the next milestone.

## How it works

- A pocket is bound to one backend: a base URL plus an auth credential, set once via `PUT /pockets/{id}/backend`.
- The spec's `rippleSpec.sources` declares GET bindings — a path, a `state` path to write into, and a refresh policy (`pocket_open` / `manual`).
- `POST /pockets/{id}/sources/run` loads the spec, runs the selected sources against the backend, and returns the results.

Three routes added to the existing pockets router:

- `PUT /pockets/{id}/backend` — bind a pocket to a backend
- `GET /pockets/{id}/backend` — read the binding summary (never the token)
- `POST /pockets/{id}/sources/run` — run the read-only sources

## Security model

**The credential lives in its own collection.** `PocketBackendCredential` is a separate Beanie document in `pocket_backend_credentials` — never on the `Pocket` doc, never in `rippleSpec`. The spec stays shareable and secret-free. The token is encrypted at rest with AES-GCM; the key is derived per row via HKDF-SHA256 over `AUTH_SECRET` with a random salt. Reads return only `base_url` / `auth_type` / `configured` — the plaintext token only ever leaves the collection to be handed straight to the executor.

**The executor is an SSRF boundary.** `source_executor.py` is the one pocket-domain module that makes outbound HTTP, and it carries the full set of defenses from the security review:

- base URL re-validated strict at call time (https-only, no internal hosts, no env escape hatch)
- relative paths only — absolute URLs, `..` traversal, and cross-host joins are rejected
- DNS check before each call so a public name that resolves to a private IP is blocked
- redirects disabled — any 3xx is a source error
- tight connect/read/write timeouts and a 512 KB response cap
- error messages sanitized — no raw exception text, query strings stripped from logged URLs
- per-pocket rate limit, 10 runs per minute

## Delivery channel

The hydrated state comes back in the `POST /sources/run` HTTP response body, not via a `pocket_mutation` SSE event. The run endpoint is a standalone REST call made outside any SSE-stream context, so there is no live stream to emit onto — the caller reads the results from the response and patches ripple state client-side. The RFC has been amended to record this.

## One of three PRs

This is 1 of 3 for the RFC 04 alpha:

1. **This PR** — backend binding, the source executor, the run endpoints (pocketpaw)
2. ripple — the `run_source` action type
3. paw-enterprise — the backend-config UI and the wiring that calls `/sources/run` on pocket open and on the refresh button

There is no merge-order dependency for the tests in any one repo, but all three are needed for the feature end to end.

## Tests

New tests under `tests/cloud/`:

- `test_pocket_backend_crypto.py` — encrypt/decrypt round-trip, salt uniqueness, strict URL validation
- `test_pocket_source_executor.py` — SSRF rejections, size cap, refresh-policy selection, bind-path stripping, redirect handling, rate-limit breach, auth headers
- `test_pocket_backend_service.py` — set/get/remove, upsert, token never returned, workspace scoping
- `test_pocket_backend_routes.py` — the three endpoints

52 new tests pass. The full cloud suite shows no new failures attributable to this change — the pre-existing `uploads/` and `test_pocket_prompt_state_sources.py` failures reproduce identically on `dev`.

## Docs

- New endpoints documented in `docs/api-reference.md`
- RFC 04 amended: status moved to "Alpha — in implementation", delivery-channel note added