### PR TITLE
Pocket write actions: increment 1 (RFC 05 M2a)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,6 +10,10 @@ API is described in the auto-generated wiki article
 Updated: 2026-05-21 (PR #1177 security pass) — documented the new
 DELETE /pockets/{id}/backend endpoint and the edit-access requirement on
 GET /pockets/{id}/backend.
+
+Updated: 2026-05-22 (RFC 05 M2a) — documented the write-action endpoints
+(POST /pockets/{id}/actions/run, PUT /pockets/{id}/backend/write-policy)
+and the per-pocket write allowlist now carried on the backend summary.
 -->
 
 # Cloud REST API Reference
@@ -44,11 +48,18 @@ Request body:
 Response `200`:
 
 ```json
-{ "base_url": "https://api.example.com", "auth_type": "bearer", "configured": true }
+{
+  "base_url": "https://api.example.com",
+  "auth_type": "bearer",
+  "configured": true,
+  "allowed_writes": []
+}
 ```
 
 The token is never echoed back. A non-https or internal `base_url` yields
-a `400`.
+a `400`. `allowed_writes` is the per-pocket write allowlist (RFC 05 M2a) —
+empty by default, so no write action can fire until an owner sets a policy
+via `PUT /pockets/{id}/backend/write-policy`.
 
 For `basic` auth, send `auth_token` as the raw `user:pass` credential —
 the server base64-encodes it into the `Authorization: Basic` header. Do
@@ -63,11 +74,17 @@ consistent with the `PUT` route. Viewers receive a `403`.
 Response `200`:
 
 ```json
-{ "base_url": "https://api.example.com", "auth_type": "bearer", "configured": true }
+{
+  "base_url": "https://api.example.com",
+  "auth_type": "bearer",
+  "configured": true,
+  "allowed_writes": [{ "method": "POST", "path_pattern": "/leases/*/renew" }]
+}
 ```
 
 Returns `404` when the pocket has no backend configured. The token is
-never included in the response.
+never included in the response. `allowed_writes` carries the current
+write allowlist (RFC 05 M2a).
 
 ### `DELETE /pockets/{pocket_id}/backend`
 
@@ -124,3 +141,95 @@ tight timeouts, caps response bodies at 512 KB, sanitizes error messages,
 and rate-limits to 10 runs per `(pocket, user)` pair per minute. Every run
 is written to the audit log (actor, pocket, status, query-stripped base
 URL) — the credential token is never logged.
+
+## Pockets — Write Actions
+
+RFC 05 M2a. A pocket's `rippleSpec.actions` declares **write** bindings
+(`POST` / `PUT` / `PATCH` / `DELETE`) — the write half of the data layer.
+A write has blast radius a read does not, so two controls sit on top of the
+SSRF guards the read executor already enforces:
+
+- **The per-pocket write allowlist** (`allowed_writes` on the backend
+  config). A write whose `(method, path)` does not match an allowlist entry
+  is rejected server-side before any call leaves PocketPaw. The allowlist
+  lives **outside** `rippleSpec`, in the same human-configured store as the
+  credential — the agent authors bindings, a human authorizes the *class*
+  of writes. The allowlist is **empty by default**: fail-closed, no write
+  fires until an owner sets a policy.
+- **Instinct-reject (fail-closed).** An action whose declaration carries a
+  truthy `requires_instinct` is rejected with `code: instinct_required` and
+  makes no call — M2a has no Instinct approval surface, so it refuses
+  rather than silently honor-then-ignore the flag. M2b wires the approval
+  routing.
+
+### `PUT /pockets/{pocket_id}/backend/write-policy`
+
+Set the pocket's write allowlist. Requires pocket **owner** access.
+
+Request body:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `allowed_writes` | array | List of `{method, path_pattern}` rules. Replaces the whole list. An empty list is valid — it revokes every write. |
+
+Each rule: `method` is one of `POST` / `PUT` / `PATCH` / `DELETE`;
+`path_pattern` is a glob (`/leases/*/renew` allows `POST /leases/42/renew`).
+Omitting a verb means no action with that verb can ever fire.
+
+Response `200`: the backend summary, including the updated `allowed_writes`.
+
+Returns `400` when the pocket has no backend configured — a write policy
+with no backend to apply it to is meaningless. The change is audit-logged.
+
+### `POST /pockets/{pocket_id}/actions/run`
+
+Run one declared `rippleSpec.actions` write action against the pocket's
+configured backend. Access is **owner or explicit `shared_with` only** —
+deliberately narrower than the source-run route: a write has blast radius,
+so a workspace-visible pocket does **not** grant run access.
+
+Request body:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `action` | string | Required. The action's name (its key in `rippleSpec.actions`). |
+| `path` | string | Required. The resolved path — Ripple's `{...}` expression resolver runs client-side at click time. |
+| `params` | object | Optional. The resolved request body. |
+| `idempotency_key` | string \| null | Optional. When omitted the server generates one so a write retried after a timeout cannot double-submit. |
+
+The HTTP `method` is **read server-side** from the persisted action entry —
+the client never picks the verb. The write fires only if the owner
+allow-listed the `(method, path)`.
+
+Response `200` (success):
+
+```json
+{
+  "ok": true,
+  "action": "mark_renewed",
+  "status": 201,
+  "response": { "id": 42, "status": "renewed" },
+  "on_success": [{ "action": "run_source", "source": "leases" }],
+  "on_error": []
+}
+```
+
+Response `200` (rejected): `ok` is `false`, with an `error` message and a
+`code`. Codes: `action_not_found`, `bad_binding`, `instinct_required`,
+`rate_limited`, `bad_base_url`, `bad_path`, `bad_host`, `not_allowed`,
+`redirect`, `http_error`, `too_large`, `timeout`, `request_failed`,
+`error`. The result is delivered **in this response body** — there is no
+`pocket_mutation` SSE emit; the client applies the `on_success` /
+`on_error` reconcile handlers.
+
+Returns `400` when the pocket has no backend configured; `403` when the
+caller is neither the owner nor in `shared_with`.
+
+**Security.** The write executor inherits every SSRF / timeout / size /
+redirect guard from the shared `_http_guard` module (the same code the
+read executor uses), then layers the write allowlist check, the
+fail-closed instinct-reject, an `Idempotency-Key` header on every call,
+and a write-specific rate limit — 20 writes per `(pocket, user)` per
+minute, a **separate** counter from the read budget. Every run (including
+every rejection) is written to the audit log; the credential token is
+never logged.

--- a/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
@@ -962,7 +962,7 @@ class _SetActionArgs(BaseModel):
         default=None,
         description=(
             "Request body for the write — a map of fields, values may be "
-            "`{...}` expressions (e.g. {\"rent\": \"{state.form.rent}\"})."
+            '`{...}` expressions (e.g. {"rent": "{state.form.rent}"}).'
         ),
     )
     confirm: bool = Field(
@@ -1010,9 +1010,7 @@ def make_set_action_tool(
         if on_error is not None:
             binding["on_error"] = on_error
         result = await set_action_for_agent(pocket_id, action_key, binding)
-        _capture_op(
-            capture, "set_action", {"action_key": action_key, "method": method}, result
-        )
+        _capture_op(capture, "set_action", {"action_key": action_key, "method": method}, result)
         return result
 
     return StructuredTool.from_function(

--- a/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
@@ -23,6 +23,10 @@ Changes: 2026-05-22 (RFC 04 alpha follow-up) — added the ``set_source``
 / ``remove_source`` edit-tool factories so the specialist can author the
 pocket's top-level ``rippleSpec.sources`` block (read-only GET data
 bindings). Registered in ``make_edit_pocket_tools``.
+Changes: 2026-05-22 (RFC 05 M2a) — added the ``set_action`` /
+``remove_action`` edit-tool factories so the specialist can author the
+pocket's top-level ``rippleSpec.actions`` block (write bindings —
+POST/PUT/PATCH/DELETE). Registered in ``make_edit_pocket_tools``.
 """
 
 from __future__ import annotations
@@ -933,6 +937,131 @@ def make_remove_source_tool(
     )
 
 
+# ---------------------------------------------------------------------------
+# rippleSpec.actions ops — write bindings (RFC 05 M2a)
+# ---------------------------------------------------------------------------
+
+
+class _SetActionArgs(BaseModel):
+    action_key: str = Field(
+        ..., description="Short name for the action — also the `actions` map key."
+    )
+    method: str = Field(
+        ...,
+        description="The write verb: POST, PUT, PATCH, or DELETE.",
+    )
+    path: str = Field(
+        ...,
+        description=(
+            "RELATIVE path against the pocket's configured backend "
+            "(e.g. `/leases/{item.id}/renew`). Never an absolute URL. "
+            "May carry `{...}` expressions Ripple resolves at click time."
+        ),
+    )
+    params: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Request body for the write — a map of fields, values may be "
+            "`{...}` expressions (e.g. {\"rent\": \"{state.form.rent}\"})."
+        ),
+    )
+    confirm: bool = Field(
+        default=False,
+        description=(
+            "When true the widget should gate the write behind a confirm "
+            "step. Author DELETE / full-PUT actions with confirm=true."
+        ),
+    )
+    on_success: list[dict[str, Any]] | None = Field(
+        default=None,
+        description="Handlers to run after the write succeeds (e.g. run_source to refetch).",
+    )
+    on_error: list[dict[str, Any]] | None = Field(
+        default=None,
+        description="Handlers to run if the write fails (e.g. a rollback mutate_state).",
+    )
+
+
+def make_set_action_tool(
+    *, pocket_id: str, capture: dict[str, Any] | None = None
+) -> StructuredTool:
+    """Declare (or replace) a write action on the pocket."""
+
+    async def _run(
+        action_key: str,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+        confirm: bool = False,
+        on_success: list[dict[str, Any]] | None = None,
+        on_error: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        from pocketpaw_ee.cloud.pockets.agent_context import set_action_for_agent
+
+        binding: dict[str, Any] = {
+            "kind": "write_binding",
+            "method": method.upper() if isinstance(method, str) else method,
+            "path": path,
+            "params": params or {},
+            "confirm": confirm,
+        }
+        if on_success is not None:
+            binding["on_success"] = on_success
+        if on_error is not None:
+            binding["on_error"] = on_error
+        result = await set_action_for_agent(pocket_id, action_key, binding)
+        _capture_op(
+            capture, "set_action", {"action_key": action_key, "method": method}, result
+        )
+        return result
+
+    return StructuredTool.from_function(
+        coroutine=_run,
+        name="set_action",
+        description=(
+            "Declare a WRITE action in rippleSpec.actions — a binding that "
+            "POST/PUT/PATCH/DELETEs against the pocket's own configured "
+            "backend. A widget triggers it with on_click "
+            "{action: 'call_binding', binding: '<action_key>'}. The write "
+            "fires ONLY if the human owner has allow-listed that method+path "
+            "in the pocket's backend settings — authoring the action does "
+            "not authorize it. Author DELETE / full-PUT actions with "
+            "confirm=true. Use `on_success` to reconcile (run_source to "
+            "refetch a list, or set state from the response)."
+        ),
+        args_schema=_SetActionArgs,
+    )
+
+
+class _RemoveActionArgs(BaseModel):
+    action_key: str = Field(..., description="The `actions` map key to remove.")
+
+
+def make_remove_action_tool(
+    *, pocket_id: str, capture: dict[str, Any] | None = None
+) -> StructuredTool:
+    """Remove a write-action declaration from the pocket."""
+
+    async def _run(action_key: str) -> dict[str, Any]:
+        from pocketpaw_ee.cloud.pockets.agent_context import remove_action_for_agent
+
+        result = await remove_action_for_agent(pocket_id, action_key)
+        _capture_op(capture, "remove_action", {"action_key": action_key}, result)
+        return result
+
+    return StructuredTool.from_function(
+        coroutine=_run,
+        name="remove_action",
+        description=(
+            "Remove a write action from rippleSpec.actions by its key. "
+            "Idempotent — removing an action that was never declared still "
+            "succeeds. Any call_binding handler still pointing at it will "
+            "no-op after removal — drop those handlers too."
+        ),
+        args_schema=_RemoveActionArgs,
+    )
+
+
 def make_edit_pocket_tools(
     *, pocket_id: str, capture: dict[str, Any] | None = None
 ) -> list[StructuredTool]:
@@ -942,8 +1071,9 @@ def make_edit_pocket_tools(
     so the agent is prompted toward "get then mutate" rather than
     blind writes. The Tier-2 ``*_prop_array_item`` ops sit next to
     ``set_node_prop`` — they are the surgical alternative to it. The
-    ``*_source`` ops sit last — they write the top-level
-    ``rippleSpec.sources`` block, not the ui tree or state.
+    ``*_source`` and ``*_action`` ops sit last — they write the top-level
+    ``rippleSpec.sources`` / ``rippleSpec.actions`` blocks, not the ui
+    tree or state.
     """
     return [
         make_get_pocket_tool(pocket_id=pocket_id),
@@ -961,4 +1091,6 @@ def make_edit_pocket_tools(
         make_remove_node_tool(pocket_id=pocket_id, capture=capture),
         make_set_source_tool(pocket_id=pocket_id, capture=capture),
         make_remove_source_tool(pocket_id=pocket_id, capture=capture),
+        make_set_action_tool(pocket_id=pocket_id, capture=capture),
+        make_remove_action_tool(pocket_id=pocket_id, capture=capture),
     ]

--- a/ee/pocketpaw_ee/cloud/models/pocket_backend.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket_backend.py
@@ -8,12 +8,37 @@
 #   The auth token is encrypted at rest: `encrypted_token` / `nonce` / `salt`
 #   are produced by `pockets/backend_crypto.py` (AES-GCM + HKDF-SHA256).
 #   The plaintext token never touches this document.
+#
+# Updated: 2026-05-22 (RFC 05 M2a) — added the per-pocket WRITE ALLOWLIST.
+#   `AllowedWrite` is one (method, path_pattern) rule; `allowed_writes` is
+#   the list of rules a write action must match before the write executor
+#   makes the call. The list lives HERE — outside the spec, in the same
+#   human-configured store as the auth credential — so a compromised or
+#   hallucinated spec cannot widen its own blast radius. The default is an
+#   EMPTY list: fail-closed, no write can fire until a human allow-lists it.
 
 from __future__ import annotations
 
+from typing import Literal
+
 from beanie import Indexed
+from pydantic import BaseModel, Field
 
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class AllowedWrite(BaseModel):
+    """One write-allowlist rule: a method + a glob path pattern.
+
+    The write executor matches an action's `(method, path)` against every
+    `AllowedWrite` on the pocket's backend config. `method` is matched
+    exactly; `path_pattern` is a glob (`fnmatch`) — `/leases/*/renew`
+    matches `POST /leases/42/renew`. No rule for a verb → that verb can
+    never fire (e.g. omit a `DELETE` entry → no DELETE action can run).
+    """
+
+    method: Literal["POST", "PUT", "PATCH", "DELETE"]
+    path_pattern: str
 
 
 class PocketBackendCredential(TimestampedDocument):
@@ -21,7 +46,8 @@ class PocketBackendCredential(TimestampedDocument):
 
     One row per pocket. The run-sources executor decrypts the token at call
     time; every other read path returns only `base_url` / `auth_type` /
-    `configured` so the secret never leaves this collection.
+    `configured` / `allowed_writes` so the secret never leaves this
+    collection.
     """
 
     pocket_id: Indexed(str)  # type: ignore[valid-type]
@@ -35,6 +61,10 @@ class PocketBackendCredential(TimestampedDocument):
     encrypted_token: bytes | None = None
     nonce: bytes | None = None
     salt: bytes | None = None
+    # RFC 05 M2a write allowlist. EMPTY by default — fail-closed: a pocket
+    # with no policy can fire no write actions. A human widens it via
+    # `PUT /pockets/{id}/backend/write-policy`.
+    allowed_writes: list[AllowedWrite] = Field(default_factory=list)
 
     class Settings:
         name = "pocket_backend_credentials"

--- a/ee/pocketpaw_ee/cloud/pockets/_http_guard.py
+++ b/ee/pocketpaw_ee/cloud/pockets/_http_guard.py
@@ -1,0 +1,134 @@
+# _http_guard.py — The canonical SSRF-guard module for pocket HTTP executors.
+# Created: 2026-05-22 (RFC 05 M2a) — EXTRACTED verbatim from
+#   `source_executor.py` (RFC 04 alpha). It is the ONE shared module both the
+#   read executor (`source_executor.py`) and the write executor
+#   (`action_executor.py`) import for outbound-HTTP safety. Pure extraction —
+#   no behavior change from the alpha; the read-executor regression tests are
+#   the proof gate.
+#
+# SSRF BOUNDARY. Every defense from the locked RFC 04 security review lives
+# here: strict path-traversal rejection, absolute-URL rejection, same-host
+# assertion after URL join, DNS rebinding check, no redirect following,
+# tight timeouts, a 512 KB response cap, error-message sanitization, and the
+# auth-header builder. The executors layer their own policy (rate limits,
+# allowlist, instinct gating) ON TOP of these primitives.
+#
+# IMPORT-LINTER: must NOT import `pocketpaw_ee.cloud.models.*`. This module
+# only sees base_url / auth / path strings passed by parameter.
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import ipaddress
+import socket
+import urllib.parse
+
+import httpx
+
+from pocketpaw.security.url_validators import host_is_internal
+
+# --- limits / policy --------------------------------------------------------
+_MAX_RESPONSE_BYTES = 524_288  # 512 KB (D11)
+_HTTP_TIMEOUT = httpx.Timeout(connect=5.0, read=10.0, write=5.0, pool=5.0)  # D10
+
+
+class _GuardError(Exception):
+    """An HTTP-guard failure with an already-sanitized message.
+
+    Both executors catch this and fold ``message`` / ``code`` into their
+    own ``{ok: false}`` / per-source error shapes — the raw exception text
+    is never propagated to a client.
+    """
+
+    def __init__(self, message: str, code: str = "error") -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+
+
+def _strip_query(url: str) -> str:
+    """Return ``url`` with query string and fragment removed — safe to log."""
+    return urllib.parse.urlsplit(url)._replace(query="", fragment="").geturl()
+
+
+def _resolve_url(base_url: str, path: str) -> str:
+    """Join ``path`` onto ``base_url`` and reject anything that escapes it.
+
+    Implements D7: reject absolute URLs, ``..`` segments, null bytes /
+    non-printable chars, and any join whose resulting netloc differs from
+    the base. Returns the safe absolute URL.
+    """
+    if "\x00" in path or any(not ch.isprintable() for ch in path):
+        raise _GuardError("path contains illegal characters", code="bad_path")
+
+    split_path = urllib.parse.urlsplit(path)
+    if split_path.scheme or split_path.netloc:
+        raise _GuardError("path must be relative, not an absolute URL", code="bad_path")
+
+    # Percent-decode and reject traversal segments.
+    decoded = urllib.parse.unquote(split_path.path)
+    if any(seg == ".." for seg in decoded.split("/")):
+        raise _GuardError("path may not contain '..' segments", code="bad_path")
+
+    joined = urllib.parse.urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
+    if urllib.parse.urlsplit(joined).netloc != urllib.parse.urlsplit(base_url).netloc:
+        raise _GuardError("path resolves to a different host", code="bad_path")
+    return joined
+
+
+async def _assert_host_external(hostname: str) -> None:
+    """D8 — resolve ``hostname`` and reject if any IP is internal.
+
+    Guards against DNS rebinding: the base URL may be a public name that
+    resolves to a private address. ``getaddrinfo`` runs in a worker thread
+    so the event loop is not blocked.
+    """
+    try:
+        infos = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
+    except socket.gaierror as exc:
+        raise _GuardError("backend host could not be resolved", code="dns_error") from exc
+
+    for info in infos:
+        # info[4] is the sockaddr — (host, port[, flowinfo, scope_id]).
+        ip = str(info[4][0])
+        # strip a zone id (fe80::1%eth0) before parsing
+        ip = ip.split("%", 1)[0]
+        if host_is_internal(ip):
+            raise _GuardError("backend host resolves to an internal address", code="bad_host")
+        try:
+            addr = ipaddress.ip_address(ip)
+        except ValueError:
+            continue
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+            raise _GuardError("backend host resolves to an internal address", code="bad_host")
+
+
+def _auth_headers(auth_type: str, auth_header: str | None, token: str) -> dict[str, str]:
+    """Build the request auth header for the configured auth type.
+
+    ``none`` adds no header. Unknown types are treated as ``none`` —
+    the DTO Literal already constrains the wire input.
+
+    For ``basic`` the stored token is the raw ``user:pass`` credential; it
+    is base64-encoded here to form a valid ``Authorization: Basic`` header.
+    """
+    if auth_type == "bearer":
+        return {"Authorization": f"Bearer {token}"}
+    if auth_type == "api_key":
+        return {(auth_header or "X-Api-Key"): token}
+    if auth_type == "basic":
+        encoded = base64.b64encode(token.encode()).decode()
+        return {"Authorization": f"Basic {encoded}"}
+    return {}
+
+
+__all__ = [
+    "_HTTP_TIMEOUT",
+    "_MAX_RESPONSE_BYTES",
+    "_GuardError",
+    "_assert_host_external",
+    "_auth_headers",
+    "_resolve_url",
+    "_strip_query",
+]

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -1,0 +1,488 @@
+# action_executor.py — Server-side executor for pocket WRITE actions.
+# Created: 2026-05-22 (RFC 05 M2a) — the write half of the pocket data
+#   layer. RFC 04's `source_executor.py` runs GET read bindings; this
+#   module runs POST/PUT/PATCH/DELETE write bindings declared in a pocket's
+#   `rippleSpec.actions` block against the pocket's single configured
+#   backend.
+#
+# A write has blast radius a read does not, so this executor adds three
+# concerns on TOP of the shared SSRF guards:
+#   1. The per-pocket WRITE ALLOWLIST (`allowed_writes`) — set by a human in
+#      the backend config, OUTSIDE the spec. A method+path that does not
+#      match an allowlist entry is rejected before any call leaves the
+#      server. Authorship (the agent writes bindings) and authorization
+#      (the human allow-lists the *class* of writes) are split.
+#   2. INSTINCT-REJECT (fail-closed). M2b will route `requires_instinct`
+#      actions through the Instinct approval surface. M2a must NOT silently
+#      honor-then-ignore the flag: any action whose RAW dict carries a
+#      truthy `requires_instinct` is rejected with `code: instinct_required`
+#      and makes NO call.
+#   3. An `Idempotency-Key` header (client-supplied or server `uuid4().hex`)
+#      so a write retried after a network timeout cannot double-submit.
+#
+# Every SSRF/timeout/size/redirect guard from the read executor is INHERITED
+# verbatim via the shared `_http_guard.py` module — strict base-URL
+# re-validation, path-traversal rejection, same-host assertion, DNS
+# rebinding check, no redirect following, tight timeouts, 512 KB response
+# cap, error-message sanitization.
+#
+# A write-specific rate limit (`_action_log`, 20 writes / 60s /
+# (pocket, user)) is a SEPARATE counter from the read executor's `_run_log`.
+#
+# IMPORT-LINTER: must NOT import `pocketpaw_ee.cloud.models.*`. The executor
+# receives base_url / auth / the action binding / the allowlist by
+# parameter only — `pockets/service.py` owns all Beanie access.
+
+from __future__ import annotations
+
+import asyncio
+import fnmatch
+import logging
+import time
+import urllib.parse
+import uuid
+from typing import Any, Literal
+
+import httpx
+from pydantic import BaseModel, Field, ValidationError
+
+from pocketpaw.security.url_validators import validate_external_url_strict
+from pocketpaw_ee.cloud.pockets._http_guard import (
+    _HTTP_TIMEOUT,
+    _MAX_RESPONSE_BYTES,
+    _GuardError,
+    _assert_host_external,
+    _auth_headers,
+    _resolve_url,
+    _strip_query,
+)
+
+logger = logging.getLogger(__name__)
+
+# --- limits / policy --------------------------------------------------------
+_PER_ACTION_TIMEOUT_S = 10.0
+# Write budget per (pocket, user) per window. Separate from the read
+# executor's _RATE_LIMIT_MAX (10) — a write is heavier, but the read budget
+# must not be drained by writes nor vice versa, so the counters are split.
+_ACTION_RATE_LIMIT_MAX = 20
+_ACTION_RATE_LIMIT_WINDOW_S = 60.0
+
+# Per-(pocket, user) write timestamps. SEPARATE dict from
+# source_executor._run_log so reads and writes never share a budget.
+_action_log: dict[tuple[str, str], list[float]] = {}
+
+# Guards the check-and-record on ``_action_log``. The read-filter-write is a
+# TOCTOU race under ``asyncio.gather``; the lock makes it atomic — the same
+# pattern source_executor uses for its read counter.
+_action_log_lock = asyncio.Lock()
+
+
+class ActionBinding(BaseModel):
+    """One write binding parsed from `rippleSpec.actions`.
+
+    ``model_config`` ignores unknown keys — the spec entry carries M2b
+    governance/metering fields (`requires_instinct`, `instinct_policy`,
+    `outcome`) and possibly RFC-03 template fields that this M2a executor
+    does not act on. Ignoring them keeps an M2b-authored spec parseable by
+    an M2a runtime instead of crashing on an unknown field.
+
+    NOTE: `requires_instinct` is deliberately NOT a declared field — the
+    instinct-reject check reads it off the RAW action dict (see
+    `_instinct_rejected`). Declaring it here would let `extra:ignore` drop
+    it and the fail-closed gate would silently pass.
+    """
+
+    model_config = {"extra": "ignore"}
+
+    kind: Literal["write_binding"] = "write_binding"
+    method: Literal["POST", "PUT", "PATCH", "DELETE"]
+    path: str
+    params: dict = Field(default_factory=dict)
+    confirm: bool = False
+    on_success: list[dict] = Field(default_factory=list)
+    on_error: list[dict] = Field(default_factory=list)
+
+
+def _instinct_rejected(raw_action: dict[str, Any]) -> bool:
+    """Return ``True`` when the RAW action dict requests Instinct gating.
+
+    Fail-closed: M2a has no Instinct wiring, so any truthy
+    ``requires_instinct`` means the action must NOT fire. Reads the raw
+    dict — never the parsed ``ActionBinding`` — because ``extra: ignore``
+    drops the field off the model.
+    """
+    return bool(raw_action.get("requires_instinct"))
+
+
+def _allowlist_match(
+    method: str, path_no_query: str, allowed_writes: list[dict[str, Any]]
+) -> bool:
+    """Return ``True`` when ``(method, path)`` matches an allowlist entry.
+
+    ``method`` is matched exactly (case-sensitive — both sides are upper
+    verbs). ``path_no_query`` is matched against each entry's
+    ``path_pattern`` via ``fnmatch.fnmatchcase`` — a glob, so ``*`` spans
+    any run of characters including ``/``. The query string is stripped by
+    the caller before this check so a pattern like ``/leases/*`` is not
+    defeated by ``?x=y``.
+
+    An empty ``allowed_writes`` matches nothing — fail-closed: a pocket
+    with no write policy can fire no writes.
+    """
+    for entry in allowed_writes:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("method") != method:
+            continue
+        pattern = entry.get("path_pattern")
+        if not isinstance(pattern, str):
+            continue
+        if fnmatch.fnmatchcase(path_no_query, pattern):
+            return True
+    return False
+
+
+async def _action_rate_limited(pocket_id: str, user_id: str) -> bool:
+    """Return True when ``(pocket_id, user_id)`` has used its write budget.
+
+    Records the call timestamp when it returns False (call permitted). The
+    check-and-record runs under ``_action_log_lock`` so concurrent writes
+    cannot race past the limit (TOCTOU under ``asyncio.gather``). Mirrors
+    ``source_executor._rate_limited`` but against the separate write
+    counter.
+    """
+    key = (pocket_id, user_id)
+    now = time.monotonic()
+    window_start = now - _ACTION_RATE_LIMIT_WINDOW_S
+    async with _action_log_lock:
+        stamps = [t for t in _action_log.get(key, []) if t >= window_start]
+        if len(stamps) >= _ACTION_RATE_LIMIT_MAX:
+            _action_log[key] = stamps
+            return True
+        stamps.append(now)
+        _action_log[key] = stamps
+        return False
+
+
+def _audit_action_run(
+    *, actor: str, pocket_id: str, action: str, status: str, base_url: str
+) -> None:
+    """Write an audit-log entry for a write-action run.
+
+    Mirrors ``source_executor._audit_source_run`` — category
+    ``pocket_backend_config``, severity WARNING. The token is NEVER passed;
+    ``base_url`` is query-stripped before it is logged. A rejected write
+    (allowlist miss, instinct gate, bad path) is audited with the matching
+    ``status`` so the rejection is visible. Audit failures must not break
+    the run, so the call is wrapped.
+    """
+    try:
+        from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+
+        get_audit_logger().log(
+            AuditEvent.create(
+                severity=AuditSeverity.WARNING,
+                actor=actor,
+                action="pocket.actions.run",
+                target=pocket_id,
+                status=status,
+                category="pocket_backend_config",
+                pocket_id=pocket_id,
+                pocket_action=action,
+                base_url=_strip_query(base_url),
+            )
+        )
+    except Exception:  # noqa: BLE001 — audit must never break the run
+        logger.warning("pocket action-run audit-log write failed", exc_info=True)
+
+
+def _error(action: str, message: str, code: str, on_error: list[dict]) -> dict:
+    """Build the standard failure response for a write action."""
+    return {
+        "ok": False,
+        "action": action,
+        "error": message,
+        "code": code,
+        "on_error": on_error,
+    }
+
+
+async def run_action(
+    *,
+    pocket_id: str,
+    user_id: str,
+    action: str,
+    raw_action: dict[str, Any],
+    path: str,
+    params: dict[str, Any],
+    base_url: str,
+    auth_type: str,
+    auth_header: str | None,
+    token: str,
+    allowed_writes: list[dict[str, Any]],
+    idempotency_key: str | None = None,
+) -> dict:
+    """Run ONE pocket write action against its configured backend.
+
+    ``raw_action`` is the action's entry from the persisted
+    ``rippleSpec.actions`` block — the server reads ``method`` /
+    ``confirm`` / ``on_success`` / ``on_error`` from it (a compromised
+    client cannot pick the verb). ``path`` and ``params`` arrive from the
+    client already resolved by Ripple's ``{...}`` expression resolver.
+
+    The result shape on success::
+
+        {"ok": true, "action", "status", "response",
+         "on_success": [...], "on_error": [...]}
+
+    On failure::
+
+        {"ok": false, "action", "error", "code", "on_error": [...]}
+
+    The executor is pure: it makes the one HTTP call and returns. It does
+    NOT persist to the Pocket document and does NOT emit ``pocket_mutation``
+    — the response is delivered in the calling route's HTTP body.
+
+    Gate order (each gate makes NO call when it rejects):
+      1. Parse the binding (``ActionBinding``); a malformed entry is a
+         ``bad_binding`` rejection.
+      2. INSTINCT-REJECT — fail-closed on a truthy raw ``requires_instinct``.
+      3. Write rate limit — 20 writes / 60s / (pocket, user).
+      4. Strict base-URL re-validation (defense in depth).
+      5. ``_resolve_url`` — path-traversal / absolute-URL / cross-host
+         rejection (shared SSRF guard).
+      6. ALLOWLIST — ``(method, query-stripped path)`` must match an
+         ``allowed_writes`` entry; a miss is audited WARNING ``rejected``.
+      7. DNS pre-resolve — reject a host that resolves internal.
+      8. The HTTP call: redirects disabled, 3xx is an error, tight
+         timeouts, 512 KB response cap, sanitized errors.
+    """
+    # ── 1. parse the binding ────────────────────────────────────────────
+    try:
+        binding = ActionBinding.model_validate(raw_action)
+    except ValidationError as exc:
+        msg = exc.errors()[0].get("msg", "malformed action binding") if exc.errors() else (
+            "malformed action binding"
+        )
+        return _error(action, f"action binding is malformed: {msg}", "bad_binding", [])
+
+    on_error = binding.on_error
+    method = binding.method
+
+    # ── 2. instinct-reject (fail-closed) ────────────────────────────────
+    # M2a has no Instinct wiring. Honoring-then-ignoring the flag would
+    # silently fire a write the spec said needs approval — reject instead.
+    if _instinct_rejected(raw_action):
+        _audit_action_run(
+            actor=user_id,
+            pocket_id=pocket_id,
+            action=action,
+            status="instinct-required",
+            base_url=base_url,
+        )
+        return _error(
+            action,
+            "action requires approval — Instinct gating is not in this build",
+            "instinct_required",
+            on_error,
+        )
+
+    # ── 3. write rate limit ─────────────────────────────────────────────
+    if await _action_rate_limited(pocket_id, user_id):
+        _audit_action_run(
+            actor=user_id,
+            pocket_id=pocket_id,
+            action=action,
+            status="rate-limited",
+            base_url=base_url,
+        )
+        return _error(action, "write rate limit exceeded", "rate_limited", on_error)
+
+    # ── 4. strict base-URL re-validation ────────────────────────────────
+    # D6/D15 — re-validate even though config-time validation already ran.
+    try:
+        validate_external_url_strict(base_url)
+    except ValueError as exc:
+        _audit_action_run(
+            actor=user_id,
+            pocket_id=pocket_id,
+            action=action,
+            status="rejected",
+            base_url=base_url,
+        )
+        return _error(action, str(exc), "bad_base_url", on_error)
+
+    # ── 5. resolve + SSRF-guard the path ────────────────────────────────
+    try:
+        url = _resolve_url(base_url, path)
+    except _GuardError as exc:
+        _audit_action_run(
+            actor=user_id,
+            pocket_id=pocket_id,
+            action=action,
+            status="rejected",
+            base_url=base_url,
+        )
+        return _error(action, exc.message, exc.code, on_error)
+
+    # ── 6. allowlist check ──────────────────────────────────────────────
+    # Match (method, path-with-query-stripped) against the human-set
+    # allowlist. The query is stripped so `/leases/*` is not bypassed by a
+    # trailing `?x=y`. A miss makes NO call and is audited as `rejected`.
+    path_no_query = _strip_query(url)
+    # _strip_query keeps the scheme+host; match the entry against the path
+    # portion only, the same shape the human authors in `path_pattern`.
+    path_only = urllib.parse.urlsplit(path_no_query).path or "/"
+    if not _allowlist_match(method, path_only, allowed_writes):
+        logger.warning(
+            "pocket %s action %s: %s %s not in write allowlist",
+            pocket_id,
+            action,
+            method,
+            path_only,
+        )
+        _audit_action_run(
+            actor=user_id,
+            pocket_id=pocket_id,
+            action=action,
+            status="rejected",
+            base_url=base_url,
+        )
+        return _error(
+            action,
+            f"{method} {path_only} is not in this pocket's write allowlist",
+            "not_allowed",
+            on_error,
+        )
+
+    # ── 7. DNS pre-resolve ──────────────────────────────────────────────
+    try:
+        await _assert_host_external(urllib.parse.urlsplit(url).hostname or "")
+    except _GuardError as exc:
+        _audit_action_run(
+            actor=user_id,
+            pocket_id=pocket_id,
+            action=action,
+            status="rejected",
+            base_url=base_url,
+        )
+        return _error(action, exc.message, exc.code, on_error)
+
+    # ── 8. the HTTP call ────────────────────────────────────────────────
+    headers = _auth_headers(auth_type, auth_header, token)
+    # Idempotency-Key — client-supplied wins, else a server-generated hex.
+    # A write retried after a network timeout carries the SAME key so a
+    # well-behaved backend can dedupe it.
+    headers["Idempotency-Key"] = idempotency_key or uuid.uuid4().hex
+
+    try:
+        result = await asyncio.wait_for(
+            _do_request(
+                method=method,
+                url=url,
+                headers=headers,
+                params=params,
+            ),
+            timeout=_PER_ACTION_TIMEOUT_S,
+        )
+    except TimeoutError:
+        _audit_action_run(
+            actor=user_id,
+            pocket_id=pocket_id,
+            action=action,
+            status="error",
+            base_url=base_url,
+        )
+        return _error(action, "action timed out", "timeout", on_error)
+    except _GuardError as exc:
+        _audit_action_run(
+            actor=user_id,
+            pocket_id=pocket_id,
+            action=action,
+            status="error",
+            base_url=base_url,
+        )
+        return _error(action, exc.message, exc.code, on_error)
+    except Exception:  # noqa: BLE001 — never let a raw exception escape
+        logger.warning("pocket %s action %s: unexpected failure", pocket_id, action, exc_info=True)
+        _audit_action_run(
+            actor=user_id,
+            pocket_id=pocket_id,
+            action=action,
+            status="error",
+            base_url=base_url,
+        )
+        return _error(action, "action failed", "error", on_error)
+
+    _audit_action_run(
+        actor=user_id,
+        pocket_id=pocket_id,
+        action=action,
+        status="success",
+        base_url=base_url,
+    )
+    return {
+        "ok": True,
+        "action": action,
+        "status": result["status"],
+        "response": result["response"],
+        "on_success": binding.on_success,
+        "on_error": on_error,
+    }
+
+
+async def _do_request(
+    *,
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    params: dict[str, Any],
+) -> dict:
+    """Make the one write request. Returns ``{status, response}``; raises
+    ``_GuardError`` on a transport failure, a 3xx redirect, a >=400 status,
+    or an oversized body.
+
+    ``params`` is sent as the JSON request body for POST/PUT/PATCH; DELETE
+    sends it too (some APIs accept a DELETE body) — an empty dict is
+    harmless. Redirects are disabled on the client; a 3xx is an error,
+    exactly as the read executor treats one.
+    """
+    async with httpx.AsyncClient(
+        follow_redirects=False,
+        timeout=_HTTP_TIMEOUT,
+    ) as client:
+        try:
+            resp = await client.request(method, url, headers=headers, json=params)
+        except httpx.HTTPError as exc:
+            # D12 — never propagate raw exception text; log a stripped URL.
+            logger.warning(
+                "action request to %s failed: %s",
+                _strip_query(url),
+                type(exc).__name__,
+            )
+            raise _GuardError("request to backend failed", code="request_failed") from exc
+
+    # D9 — redirects are disabled on the client; treat any 3xx as an error.
+    if 300 <= resp.status_code < 400:
+        raise _GuardError("backend returned a redirect (not followed)", code="redirect")
+    if resp.status_code >= 400:
+        raise _GuardError(f"backend returned status {resp.status_code}", code="http_error")
+
+    # D11 — reject oversized bodies; never surface partial data.
+    body = resp.content
+    if len(body) > _MAX_RESPONSE_BYTES:
+        raise _GuardError("backend response exceeds the 512 KB limit", code="too_large")
+
+    # A successful write often returns the mutated record; sometimes an
+    # empty 204. Parse JSON when present, else fall back to None — a
+    # non-JSON 2xx is still a success.
+    response: Any = None
+    if body:
+        try:
+            response = resp.json()
+        except ValueError:
+            response = None
+    return {"status": resp.status_code, "response": response}
+
+
+__all__ = ["ActionBinding", "run_action"]

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -4,6 +4,14 @@
 #   module runs POST/PUT/PATCH/DELETE write bindings declared in a pocket's
 #   `rippleSpec.actions` block against the pocket's single configured
 #   backend.
+# Updated: 2026-05-22 (security review hardening) — (S1) the write
+#   allowlist now globs the human `path_pattern` against the percent-
+#   DECODED request path so encoding cannot defeat the match; (S2) a
+#   backend >=400 status is no longer echoed to the client — the exact
+#   number goes only to the audit log via `_BackendHTTPError`, the client
+#   sees a generic message; (N1) an empty-params DELETE sends no JSON
+#   body; (N3) `workspace_id` is now on every write-action audit entry so
+#   the entries are tenant-filterable.
 #
 # A write has blast radius a read does not, so this executor adds three
 # concerns on TOP of the shared SSRF guards:
@@ -77,6 +85,20 @@ _action_log: dict[tuple[str, str], list[float]] = {}
 _action_log_lock = asyncio.Lock()
 
 
+class _BackendHTTPError(Exception):
+    """Raised by ``_do_request`` when the backend returns a >=400 status.
+
+    Carries the exact numeric ``status_code`` so the caller can record it
+    in the audit log — but the caller never echoes it to the client. A
+    separate type (not ``_GuardError``) keeps the status-bearing failure
+    from leaking the number through a shared ``message`` field.
+    """
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"backend returned status {status_code}")
+        self.status_code = status_code
+
+
 class ActionBinding(BaseModel):
     """One write binding parsed from `rippleSpec.actions`.
 
@@ -124,6 +146,12 @@ def _allowlist_match(method: str, path_no_query: str, allowed_writes: list[dict[
     the caller before this check so a pattern like ``/leases/*`` is not
     defeated by ``?x=y``.
 
+    The caller passes the percent-DECODED path — the human-authored
+    ``path_pattern`` is globbed against the decoded request path so the
+    match is consistent regardless of client encoding (a ``%2e%2e`` cannot
+    slip past as something the pattern does not recognise). The
+    ``path_pattern`` itself is matched as-is and is NOT decoded.
+
     An empty ``allowed_writes`` matches nothing — fail-closed: a pocket
     with no write policy can fire no writes.
     """
@@ -163,19 +191,39 @@ async def _action_rate_limited(pocket_id: str, user_id: str) -> bool:
 
 
 def _audit_action_run(
-    *, actor: str, pocket_id: str, action: str, status: str, base_url: str
+    *,
+    actor: str,
+    workspace_id: str,
+    pocket_id: str,
+    action: str,
+    status: str,
+    base_url: str,
+    backend_status: int | None = None,
 ) -> None:
     """Write an audit-log entry for a write-action run.
 
     Mirrors ``source_executor._audit_source_run`` — category
     ``pocket_backend_config``, severity WARNING. The token is NEVER passed;
-    ``base_url`` is query-stripped before it is logged. A rejected write
-    (allowlist miss, instinct gate, bad path) is audited with the matching
-    ``status`` so the rejection is visible. Audit failures must not break
-    the run, so the call is wrapped.
+    ``base_url`` is query-stripped before it is logged. ``workspace_id`` is
+    logged so write-action entries are tenant-filterable, the same way the
+    backend-config audit entries already are. A rejected write (allowlist
+    miss, instinct gate, bad path) is audited with the matching ``status``
+    so the rejection is visible. ``backend_status`` carries the exact
+    numeric HTTP status from the backend on an ``http_error`` — it goes
+    ONLY into the audit log, never the client response, so the endpoint is
+    not a path-probing oracle. Audit failures must not break the run, so
+    the call is wrapped.
     """
     try:
         from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+
+        fields: dict[str, Any] = {
+            "pocket_id": pocket_id,
+            "pocket_action": action,
+            "base_url": _strip_query(base_url),
+        }
+        if backend_status is not None:
+            fields["backend_status"] = backend_status
 
         get_audit_logger().log(
             AuditEvent.create(
@@ -185,9 +233,8 @@ def _audit_action_run(
                 target=pocket_id,
                 status=status,
                 category="pocket_backend_config",
-                pocket_id=pocket_id,
-                pocket_action=action,
-                base_url=_strip_query(base_url),
+                workspace_id=workspace_id,
+                **fields,
             )
         )
     except Exception:  # noqa: BLE001 — audit must never break the run
@@ -207,6 +254,7 @@ def _error(action: str, message: str, code: str, on_error: list[dict]) -> dict:
 
 async def run_action(
     *,
+    workspace_id: str,
     pocket_id: str,
     user_id: str,
     action: str,
@@ -249,8 +297,9 @@ async def run_action(
       4. Strict base-URL re-validation (defense in depth).
       5. ``_resolve_url`` — path-traversal / absolute-URL / cross-host
          rejection (shared SSRF guard).
-      6. ALLOWLIST — ``(method, query-stripped path)`` must match an
-         ``allowed_writes`` entry; a miss is audited WARNING ``rejected``.
+      6. ALLOWLIST — ``(method, query-stripped, percent-decoded path)``
+         must match an ``allowed_writes`` entry; a miss is audited WARNING
+         ``rejected``.
       7. DNS pre-resolve — reject a host that resolves internal.
       8. The HTTP call: redirects disabled, 3xx is an error, tight
          timeouts, 512 KB response cap, sanitized errors.
@@ -275,6 +324,7 @@ async def run_action(
     if _instinct_rejected(raw_action):
         _audit_action_run(
             actor=user_id,
+            workspace_id=workspace_id,
             pocket_id=pocket_id,
             action=action,
             status="instinct-required",
@@ -291,6 +341,7 @@ async def run_action(
     if await _action_rate_limited(pocket_id, user_id):
         _audit_action_run(
             actor=user_id,
+            workspace_id=workspace_id,
             pocket_id=pocket_id,
             action=action,
             status="rate-limited",
@@ -305,6 +356,7 @@ async def run_action(
     except ValueError as exc:
         _audit_action_run(
             actor=user_id,
+            workspace_id=workspace_id,
             pocket_id=pocket_id,
             action=action,
             status="rejected",
@@ -318,6 +370,7 @@ async def run_action(
     except _GuardError as exc:
         _audit_action_run(
             actor=user_id,
+            workspace_id=workspace_id,
             pocket_id=pocket_id,
             action=action,
             status="rejected",
@@ -333,16 +386,25 @@ async def run_action(
     # _strip_query keeps the scheme+host; match the entry against the path
     # portion only, the same shape the human authors in `path_pattern`.
     path_only = urllib.parse.urlsplit(path_no_query).path or "/"
-    if not _allowlist_match(method, path_only, allowed_writes):
+    # Decode percent-encoding ONCE before the match — `_allowlist_match`
+    # globs the human-authored `path_pattern` against the DECODED path, so
+    # an entry like `/leases/*/renew` matches consistently regardless of
+    # how the client encoded the path. A `%2e%2e` cannot slip past the
+    # allowlist as something the human pattern does not recognise. The
+    # `path_pattern` itself is human-authored and matched as-is — only the
+    # request path is decoded.
+    path_decoded = urllib.parse.unquote(path_only)
+    if not _allowlist_match(method, path_decoded, allowed_writes):
         logger.warning(
             "pocket %s action %s: %s %s not in write allowlist",
             pocket_id,
             action,
             method,
-            path_only,
+            path_decoded,
         )
         _audit_action_run(
             actor=user_id,
+            workspace_id=workspace_id,
             pocket_id=pocket_id,
             action=action,
             status="rejected",
@@ -350,7 +412,7 @@ async def run_action(
         )
         return _error(
             action,
-            f"{method} {path_only} is not in this pocket's write allowlist",
+            f"{method} {path_decoded} is not in this pocket's write allowlist",
             "not_allowed",
             on_error,
         )
@@ -361,6 +423,7 @@ async def run_action(
     except _GuardError as exc:
         _audit_action_run(
             actor=user_id,
+            workspace_id=workspace_id,
             pocket_id=pocket_id,
             action=action,
             status="rejected",
@@ -388,15 +451,32 @@ async def run_action(
     except TimeoutError:
         _audit_action_run(
             actor=user_id,
+            workspace_id=workspace_id,
             pocket_id=pocket_id,
             action=action,
             status="error",
             base_url=base_url,
         )
         return _error(action, "action timed out", "timeout", on_error)
+    except _BackendHTTPError as exc:
+        # S2 — the exact backend HTTP status goes ONLY to the audit log,
+        # never the client. Echoing `resp.status_code` to the caller turns
+        # this endpoint into a path-probing oracle on the configured
+        # backend. The client sees a generic `http_error` category.
+        _audit_action_run(
+            actor=user_id,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            action=action,
+            status="error",
+            base_url=base_url,
+            backend_status=exc.status_code,
+        )
+        return _error(action, "the backend rejected the request", "http_error", on_error)
     except _GuardError as exc:
         _audit_action_run(
             actor=user_id,
+            workspace_id=workspace_id,
             pocket_id=pocket_id,
             action=action,
             status="error",
@@ -407,6 +487,7 @@ async def run_action(
         logger.warning("pocket %s action %s: unexpected failure", pocket_id, action, exc_info=True)
         _audit_action_run(
             actor=user_id,
+            workspace_id=workspace_id,
             pocket_id=pocket_id,
             action=action,
             status="error",
@@ -416,6 +497,7 @@ async def run_action(
 
     _audit_action_run(
         actor=user_id,
+        workspace_id=workspace_id,
         pocket_id=pocket_id,
         action=action,
         status="success",
@@ -439,20 +521,29 @@ async def _do_request(
     params: dict[str, Any],
 ) -> dict:
     """Make the one write request. Returns ``{status, response}``; raises
-    ``_GuardError`` on a transport failure, a 3xx redirect, a >=400 status,
-    or an oversized body.
+    ``_GuardError`` on a transport failure, a 3xx redirect, or an oversized
+    body, and ``_BackendHTTPError`` on a >=400 status.
 
-    ``params`` is sent as the JSON request body for POST/PUT/PATCH; DELETE
-    sends it too (some APIs accept a DELETE body) — an empty dict is
-    harmless. Redirects are disabled on the client; a 3xx is an error,
-    exactly as the read executor treats one.
+    ``params`` is sent as the JSON request body for POST/PUT/PATCH. For a
+    DELETE the body is sent ONLY when ``params`` is non-empty — a DELETE
+    with no params sends no JSON body at all, because some backends and
+    WAFs reject a DELETE that carries a body. Redirects are disabled on
+    the client; a 3xx is an error, exactly as the read executor treats one.
     """
+    # N1 — omit the JSON body on an empty-params DELETE; some backends/WAFs
+    # reject a DELETE with a body. Any verb with non-empty params still
+    # sends the body.
+    send_body = bool(params) or method != "DELETE"
+
     async with httpx.AsyncClient(
         follow_redirects=False,
         timeout=_HTTP_TIMEOUT,
     ) as client:
         try:
-            resp = await client.request(method, url, headers=headers, json=params)
+            if send_body:
+                resp = await client.request(method, url, headers=headers, json=params)
+            else:
+                resp = await client.request(method, url, headers=headers)
         except httpx.HTTPError as exc:
             # D12 — never propagate raw exception text; log a stripped URL.
             logger.warning(
@@ -465,8 +556,11 @@ async def _do_request(
     # D9 — redirects are disabled on the client; treat any 3xx as an error.
     if 300 <= resp.status_code < 400:
         raise _GuardError("backend returned a redirect (not followed)", code="redirect")
+    # S2 — a >=400 status raises a status-bearing error; the caller logs
+    # the exact number to the audit log and returns a generic message to
+    # the client so the endpoint is not a backend path-probing oracle.
     if resp.status_code >= 400:
-        raise _GuardError(f"backend returned status {resp.status_code}", code="http_error")
+        raise _BackendHTTPError(resp.status_code)
 
     # D11 — reject oversized bodies; never surface partial data.
     body = resp.content

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -50,9 +50,9 @@ from pocketpaw.security.url_validators import validate_external_url_strict
 from pocketpaw_ee.cloud.pockets._http_guard import (
     _HTTP_TIMEOUT,
     _MAX_RESPONSE_BYTES,
-    _GuardError,
     _assert_host_external,
     _auth_headers,
+    _GuardError,
     _resolve_url,
     _strip_query,
 )
@@ -114,9 +114,7 @@ def _instinct_rejected(raw_action: dict[str, Any]) -> bool:
     return bool(raw_action.get("requires_instinct"))
 
 
-def _allowlist_match(
-    method: str, path_no_query: str, allowed_writes: list[dict[str, Any]]
-) -> bool:
+def _allowlist_match(method: str, path_no_query: str, allowed_writes: list[dict[str, Any]]) -> bool:
     """Return ``True`` when ``(method, path)`` matches an allowlist entry.
 
     ``method`` is matched exactly (case-sensitive — both sides are upper
@@ -261,8 +259,10 @@ async def run_action(
     try:
         binding = ActionBinding.model_validate(raw_action)
     except ValidationError as exc:
-        msg = exc.errors()[0].get("msg", "malformed action binding") if exc.errors() else (
-            "malformed action binding"
+        msg = (
+            exc.errors()[0].get("msg", "malformed action binding")
+            if exc.errors()
+            else ("malformed action binding")
         )
         return _error(action, f"action binding is malformed: {msg}", "bad_binding", [])
 

--- a/ee/pocketpaw_ee/cloud/pockets/actions_ops.py
+++ b/ee/pocketpaw_ee/cloud/pockets/actions_ops.py
@@ -1,0 +1,62 @@
+# actions_ops.py — Pure mutate helpers for ``rippleSpec.actions``.
+# Created: 2026-05-22 (RFC 05 M2a) — the write-action sibling of
+#   ``sources_ops.py``. RFC 05 adds a top-level ``rippleSpec.actions`` block
+#   of write bindings (POST/PUT/PATCH/DELETE) alongside the RFC 04
+#   ``rippleSpec.sources`` block of read bindings. This module owns the
+#   ``actions`` key the way ``sources_ops.py`` owns ``sources``,
+#   ``state_ops.py`` owns ``state``, and ``spec_ops.py`` owns ``ui``.
+#
+# These helpers are side-effect-free: they take and return plain ``dict``
+# structures, never touch Beanie or the SSE bus, and never log. The
+# service layer (``service.py``) wraps them with binding validation,
+# persistence, and event emission. Keeping this module Beanie-free is an
+# import-linter contract (``ee/pyproject.toml``).
+#
+# An action entry is keyed by a single flat name — ``actions["mark_done"]``
+# — so these helpers take a bare ``key`` rather than a path. The binding
+# *value* is validated upstream by the ``ActionBinding`` Pydantic model in
+# ``action_executor.py``; this module stores whatever dict it is handed.
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def set_action(spec: dict[str, Any], key: str, binding: dict[str, Any]) -> dict[str, Any]:
+    """Write ``binding`` at ``spec["actions"][key]``, creating the
+    ``actions`` dict if it is absent. Overwrites an existing entry.
+
+    Returns ``spec`` (mutated in place) so callers can chain.
+
+    Raises ``ValueError`` if ``key`` is empty or if ``spec["actions"]``
+    exists but is not a dict (a malformed spec the agent should not be
+    appending to).
+    """
+    if not key:
+        raise ValueError("action key is required")
+    actions = spec.get("actions")
+    if actions is None:
+        actions = {}
+        spec["actions"] = actions
+    if not isinstance(actions, dict):
+        raise ValueError(
+            f"rippleSpec.actions is a {type(actions).__name__}, expected an object"
+        )
+    actions[key] = binding
+    return spec
+
+
+def remove_action(spec: dict[str, Any], key: str) -> dict[str, Any]:
+    """Remove ``spec["actions"][key]``. No-op when the ``actions`` block
+    or the key is absent — removal is idempotent so the agent can call it
+    without first checking existence.
+
+    Returns ``spec`` (mutated in place).
+    """
+    actions = spec.get("actions")
+    if isinstance(actions, dict):
+        actions.pop(key, None)
+    return spec
+
+
+__all__ = ["remove_action", "set_action"]

--- a/ee/pocketpaw_ee/cloud/pockets/actions_ops.py
+++ b/ee/pocketpaw_ee/cloud/pockets/actions_ops.py
@@ -39,9 +39,7 @@ def set_action(spec: dict[str, Any], key: str, binding: dict[str, Any]) -> dict[
         actions = {}
         spec["actions"] = actions
     if not isinstance(actions, dict):
-        raise ValueError(
-            f"rippleSpec.actions is a {type(actions).__name__}, expected an object"
-        )
+        raise ValueError(f"rippleSpec.actions is a {type(actions).__name__}, expected an object")
     actions[key] = binding
     return spec
 

--- a/ee/pocketpaw_ee/cloud/pockets/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/pockets/agent_context.py
@@ -777,6 +777,39 @@ async def remove_source_for_agent(pocket_id: str, source_key: str) -> dict[str, 
     return {"ok": True, "source_key": source_key}
 
 
+# ---------------------------------------------------------------------------
+# rippleSpec.actions mutations — the write-action surface (RFC 05 M2a)
+# ---------------------------------------------------------------------------
+#
+# Sibling of the ``sources`` wrappers above. An ``actions`` declaration is
+# part of the persisted pocket document, so these wrappers push a
+# full-document ``replace`` ``pocket_mutation`` via ``_push_replace``.
+
+
+async def set_action_for_agent(
+    pocket_id: str, action_key: str, binding: dict[str, Any]
+) -> dict[str, Any]:
+    """Declare (or replace) a write action on the pocket."""
+    result, err = await pockets_service.agent_set_action(
+        pocket_id, action_key=action_key, binding=binding
+    )
+    if err is not None or result is None:
+        return {"ok": False, "error": err or "set_action failed"}
+    pocket_view: dict[str, Any] = result.get("pocket") or {}
+    await _push_replace(pocket_view)
+    return {"ok": True, "action_key": action_key, "binding": result.get("binding")}
+
+
+async def remove_action_for_agent(pocket_id: str, action_key: str) -> dict[str, Any]:
+    """Remove a write-action declaration from the pocket."""
+    result, err = await pockets_service.agent_remove_action(pocket_id, action_key=action_key)
+    if err is not None or result is None:
+        return {"ok": False, "error": err or "remove_action failed"}
+    pocket_view: dict[str, Any] = result.get("pocket") or {}
+    await _push_replace(pocket_view)
+    return {"ok": True, "action_key": action_key}
+
+
 __all__ = [
     "add_node_for_agent",
     "add_widget_for_agent",
@@ -787,12 +820,14 @@ __all__ = [
     "list_pockets_for_agent",
     "move_node_for_agent",
     "patch_state_for_agent",
+    "remove_action_for_agent",
     "remove_node_for_agent",
     "remove_prop_array_item_for_agent",
     "remove_source_for_agent",
     "remove_state_for_agent",
     "remove_widget_for_agent",
     "replace_node_for_agent",
+    "set_action_for_agent",
     "set_node_prop_for_agent",
     "set_prop_array_item_for_agent",
     "set_source_for_agent",

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -14,6 +14,9 @@ Updated: 2026-05-21 (PR #1177 security pass) — PocketBackendConfigRequest
 .base_url now requires min_length=1; RunSourcesRequest.source coerces an
 empty string to None; documented that `auth_token` for `basic` is the
 `user:pass` credential (base64-encoded server-side).
+Updated: 2026-05-22 (RFC 05 M2a) — added RunActionRequest /
+RunActionResponse for the write-action run endpoint, plus AllowedWriteDTO
+and SetWritePolicyRequest for the per-pocket write-allowlist endpoint.
 """
 
 from __future__ import annotations
@@ -115,6 +118,17 @@ class PocketResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class AllowedWriteDTO(BaseModel):
+    """One write-allowlist rule on the wire — a (method, path_pattern) pair.
+
+    Mirrors ``models.pocket_backend.AllowedWrite``. ``path_pattern`` is a
+    glob: ``/leases/*/renew`` allows ``POST /leases/42/renew``. RFC 05 M2a.
+    """
+
+    method: Literal["POST", "PUT", "PATCH", "DELETE"]
+    path_pattern: str = Field(min_length=1)
+
+
 class PocketBackendConfigRequest(BaseModel):
     """Body for ``PUT /pockets/{id}/backend`` — bind a pocket to one backend.
 
@@ -138,11 +152,17 @@ class PocketBackendConfigRequest(BaseModel):
 
 
 class PocketBackendConfigResponse(BaseModel):
-    """Backend binding as returned to clients — never carries the token."""
+    """Backend binding as returned to clients — never carries the token.
+
+    ``allowed_writes`` is the per-pocket write allowlist (RFC 05 M2a) —
+    an owner/editor-facing non-secret. Empty by default (fail-closed: no
+    write fires until a human allow-lists it).
+    """
 
     base_url: str
     auth_type: str
     configured: bool
+    allowed_writes: list[AllowedWriteDTO] = Field(default_factory=list)
 
 
 class RunSourcesRequest(BaseModel):
@@ -164,6 +184,60 @@ class RunSourcesRequest(BaseModel):
     @classmethod
     def _empty_source_is_none(cls, v: str | None) -> str | None:
         return v or None
+
+
+# ---------------------------------------------------------------------------
+# Pocket write actions + write policy (RFC 05 M2a)
+# ---------------------------------------------------------------------------
+
+
+class RunActionRequest(BaseModel):
+    """Body for ``POST /pockets/{id}/actions/run``.
+
+    The client sends the action's NAME (``action``) plus the *resolved*
+    ``path`` and ``params`` — Ripple's ``{...}`` expression resolver runs
+    client-side at click time. The server loads the named action from the
+    persisted ``rippleSpec.actions`` block to read the HTTP ``method`` —
+    the client never picks the verb.
+
+    ``idempotency_key`` is optional: when omitted the server generates one
+    so a write retried after a timeout cannot double-submit.
+    """
+
+    action: str = Field(min_length=1)
+    path: str = Field(min_length=1)
+    params: dict[str, Any] = Field(default_factory=dict)
+    idempotency_key: str | None = None
+
+
+class RunActionResponse(BaseModel):
+    """Result of a write-action run.
+
+    On success ``ok`` is true and ``status`` / ``response`` carry the
+    backend's HTTP status + parsed JSON body. On failure ``ok`` is false
+    and ``error`` / ``code`` describe the rejection. ``on_success`` /
+    ``on_error`` are the reconcile handler lists the client runs after.
+    All optional fields keep one model usable for both outcomes.
+    """
+
+    ok: bool
+    action: str
+    status: int | None = None
+    response: Any = None
+    error: str | None = None
+    code: str | None = None
+    on_success: list[dict] = Field(default_factory=list)
+    on_error: list[dict] = Field(default_factory=list)
+
+
+class SetWritePolicyRequest(BaseModel):
+    """Body for ``PUT /pockets/{id}/backend/write-policy``.
+
+    Replaces the pocket's whole write allowlist. An empty list is valid
+    and meaningful — it revokes every write (fail-closed).
+    """
+
+    allowed_writes: list[AllowedWriteDTO] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -451,6 +451,7 @@ async def run_pocket_action(
 
     # no-event: the write result is response-body delivery, not persisted.
     result = await action_executor.run_action(
+        workspace_id=workspace_id,
         pocket_id=pocket_id,
         user_id=user_id,
         action=body.action,

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -23,6 +23,15 @@ DELETE /pockets/{id}/backend route so a configured credential can be
 revoked; the GET route now requires pocket edit access (owner/editor),
 matching the PUT route; the source-run route threads user_id into the
 executor for per-user rate limiting + audit logging.
+
+Updated: 2026-05-22 (RFC 05 M2a) — added the write-action routes:
+
+    POST /pockets/{id}/actions/run        — run a declared write action
+    PUT  /pockets/{id}/backend/write-policy — set the write allowlist
+
+The action-run route is gated OWNER or explicit shared_with ONLY
+(``require_pocket_action_run``) — narrower than source-run, because a
+write has blast radius. The write-policy route is owner-only.
 """
 
 from __future__ import annotations
@@ -43,7 +52,10 @@ from pocketpaw_ee.cloud.pockets.dto import (
     PocketBackendConfigRequest,
     PocketBackendConfigResponse,
     ReorderWidgetsRequest,
+    RunActionRequest,
+    RunActionResponse,
     RunSourcesRequest,
+    SetWritePolicyRequest,
     ShareLinkRequest,
     UpdatePocketRequest,
     UpdateWidgetRequest,
@@ -59,6 +71,7 @@ from pocketpaw_ee.cloud.sessions.dto import CreateSessionRequest
 from pocketpaw_ee.cloud.shared.deps import (
     current_user_id,
     current_workspace_id,
+    require_pocket_action_run,
     require_pocket_edit,
     require_pocket_owner,
 )
@@ -336,7 +349,7 @@ async def run_pocket_sources(
             "pocket_backend.not_configured",
             "This pocket has no backend configured — set one via PUT /pockets/{id}/backend",
         )
-    base_url, auth_type, auth_header, token = creds
+    base_url, auth_type, auth_header, token, _allowed_writes = creds
 
     from pocketpaw_ee.cloud.pockets import source_executor
 
@@ -352,6 +365,106 @@ async def run_pocket_sources(
         trigger=body.trigger,
         only_source=body.source,
     )
+
+
+@router.put(
+    "/{pocket_id}/backend/write-policy",
+    dependencies=[Depends(require_pocket_owner)],
+)
+async def set_pocket_write_policy(
+    pocket_id: str,
+    body: SetWritePolicyRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> PocketBackendConfigResponse:
+    """Set this pocket's write allowlist (RFC 05 M2a). Owner-only.
+
+    Replaces the whole ``allowed_writes`` list — an empty list revokes
+    every write (fail-closed). The policy lives on the backend-credential
+    row, OUTSIDE the spec, so the agent that authors the spec cannot widen
+    its own write blast radius. Returns ``400`` when the pocket has no
+    backend configured — a write policy with no backend to apply to is
+    meaningless.
+    """
+    result = await pockets_service.set_pocket_write_policy(
+        workspace_id,
+        user_id,
+        pocket_id,
+        [rule.model_dump() for rule in body.allowed_writes],
+    )
+    return PocketBackendConfigResponse(**result)
+
+
+@router.post(
+    "/{pocket_id}/actions/run",
+    dependencies=[Depends(require_pocket_action_run)],
+)
+async def run_pocket_action(
+    pocket_id: str,
+    body: RunActionRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> RunActionResponse:
+    """Run one declared ``rippleSpec.actions`` write action against the
+    pocket's backend.
+
+    Access is OWNER or explicit ``shared_with`` ONLY — a write has blast
+    radius, so a workspace-visible pocket does NOT grant run access. The
+    HTTP ``method`` is read server-side from the persisted action entry;
+    the client only sends the resolved ``path`` / ``params``. The write
+    fires only if the human owner allow-listed the method+path.
+
+    The backend's response is delivered in THIS response body — there is
+    no ``pocket_mutation`` SSE emit, because the run endpoint is a
+    standalone REST call outside any SSE stream. The client applies the
+    ``on_success`` / ``on_error`` reconcile handlers.
+    """
+    pocket = await pockets_service.get(pocket_id, user_id)
+    ripple_spec = pocket.get("rippleSpec") or {}
+    actions = ripple_spec.get("actions")
+    if not isinstance(actions, dict) or body.action not in actions:
+        return RunActionResponse(
+            ok=False,
+            action=body.action,
+            error=f"no action named '{body.action}' on this pocket",
+            code="action_not_found",
+        )
+    raw_action = actions[body.action]
+    if not isinstance(raw_action, dict):
+        return RunActionResponse(
+            ok=False,
+            action=body.action,
+            error=f"action '{body.action}' is malformed",
+            code="bad_binding",
+        )
+
+    creds = await pockets_service.get_pocket_backend_for_executor(workspace_id, pocket_id)
+    if creds is None:
+        raise CloudError(
+            400,
+            "pocket_backend.not_configured",
+            "This pocket has no backend configured — set one via PUT /pockets/{id}/backend",
+        )
+    base_url, auth_type, auth_header, token, allowed_writes = creds
+
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    # no-event: the write result is response-body delivery, not persisted.
+    result = await action_executor.run_action(
+        pocket_id=pocket_id,
+        user_id=user_id,
+        action=body.action,
+        raw_action=raw_action,
+        path=body.path,
+        params=body.params,
+        base_url=base_url,
+        auth_type=auth_type,
+        auth_header=auth_header,
+        token=token,
+        allowed_writes=allowed_writes,
+        idempotency_key=body.idempotency_key,
+    )
+    return RunActionResponse(**result)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -2427,10 +2427,11 @@ async def set_pocket_write_policy(
             "This pocket has no backend configured — set one before a write policy",
         )
 
-    doc.allowed_writes = [
-        _AllowedWriteDoc(method=rule["method"], path_pattern=rule["path_pattern"])
-        for rule in allowed_writes
-    ]
+    # `model_validate` re-checks the method Literal at runtime — the router
+    # already validated each rule through `AllowedWriteDTO`, but internal
+    # callers (bus handlers, jobs) re-parse here, matching the entry-point
+    # validation rule.
+    doc.allowed_writes = [_AllowedWriteDoc.model_validate(rule) for rule in allowed_writes]
     await doc.save()
 
     _audit_backend_config(

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -42,6 +42,17 @@ attaches a non-secret ``backend`` summary (``{base_url, auth_type,
 configured}``) so the edit specialist knows whether a backend is already
 configured before it authors a ``sources`` block. The token is NEVER
 included — the summary comes from ``get_pocket_backend``.
+Changes: 2026-05-22 (RFC 05 M2a) — added the write-action half:
+``agent_set_action`` / ``agent_remove_action`` author the top-level
+``rippleSpec.actions`` block (twins of the ``sources`` ops, validated
+through ``ActionBinding``); ``set_pocket_write_policy`` sets the
+per-pocket write allowlist (owner-only, audit-logged, rejects when no
+backend is configured); ``has_action_run_access`` gates the action-run
+route (owner OR explicit shared_with ONLY — a write is NOT
+workspace-visible). ``get_pocket_backend`` /
+``get_pocket_backend_for_executor`` / ``_agent_backend_summary`` now
+carry ``allowed_writes`` so the executor and the edit specialist can see
+the write policy.
 """
 
 from __future__ import annotations
@@ -64,10 +75,12 @@ from pocketpaw_ee.cloud._core.realtime.events import (
 )
 from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
 from pocketpaw_ee.cloud.models.pocket import Widget as _WidgetDoc
+from pocketpaw_ee.cloud.models.pocket_backend import AllowedWrite as _AllowedWriteDoc
 from pocketpaw_ee.cloud.models.pocket_backend import (
     PocketBackendCredential as _BackendCredentialDoc,
 )
 from pocketpaw_ee.cloud.pockets import (
+    actions_ops,
     backend_crypto,
     prop_arrays,
     sources_ops,
@@ -868,6 +881,31 @@ async def is_owner(pocket_id: str, user_id: str) -> bool:
     return doc.owner == user_id
 
 
+async def has_action_run_access(pocket_id: str, user_id: str) -> bool:
+    """Return ``True`` if ``user_id`` may RUN a write action on the pocket.
+
+    The gate is OWNER or explicit ``shared_with`` ONLY — deliberately
+    NARROWER than ``has_edit_access`` (which also allows any caller on a
+    workspace-visible pocket). A write has blast radius: it hits a real
+    backend with a real ``DELETE``. M2a keeps the run surface to people
+    the owner explicitly invited; M2b widens this once Instinct gating is
+    wired. Raises ``NotFound`` if the pocket doesn't exist — the
+    ``require_pocket_action_run`` guard converts that to a 404.
+    """
+    try:
+        pocket_oid = PydanticObjectId(pocket_id)
+    except Exception as exc:  # noqa: BLE001
+        raise NotFound("pocket", pocket_id) from exc
+
+    doc = await _PocketDoc.get(pocket_oid)
+    if doc is None:
+        raise NotFound("pocket", pocket_id)
+
+    if doc.owner == user_id:
+        return True
+    return user_id in (doc.shared_with or [])
+
+
 async def is_member(pocket_id: str, user_id: str) -> bool:
     """Return ``True`` if ``user_id`` may read the pocket — owner, team
     member, explicit shared_with, or any caller when visibility is
@@ -956,11 +994,14 @@ async def _agent_backend_summary(doc: _PocketDoc) -> dict[str, Any]:
     if summary is None:
         return {"configured": False}
     # get_pocket_backend already excludes the token — assert the shape
-    # and never pass anything else through.
+    # and never pass anything else through. ``allowed_writes`` is carried
+    # so the edit specialist can see which write methods+paths the owner
+    # has authorized before it authors a write action.
     return {
         "base_url": summary.get("base_url"),
         "auth_type": summary.get("auth_type"),
         "configured": True,
+        "allowed_writes": summary.get("allowed_writes") or [],
     }
 
 
@@ -1939,6 +1980,108 @@ async def agent_remove_source(
         )
 
 
+# ---------------------------------------------------------------------------
+# Granular rippleSpec.actions mutations — agent-facing (RFC 05 M2a)
+# ---------------------------------------------------------------------------
+#
+# The write-action sibling of the ``sources`` ops above. ``actions`` is a
+# fourth top-level rippleSpec key declaring write bindings (POST/PUT/PATCH/
+# DELETE). Like ``sources`` it is part of the persisted pocket document, so
+# these ops call ``doc.save()``. Each binding is validated through
+# ``ActionBinding`` (action_executor.py) before it is written — an invalid
+# binding is rejected, never stored. Authoring a binding does NOT authorize
+# the write: the human-set ``allowed_writes`` allowlist on the backend
+# config decides whether the write may actually fire.
+
+
+async def agent_set_action(
+    pocket_id: str,
+    *,
+    action_key: str,
+    binding: dict[str, Any],
+) -> tuple[dict | None, str | None]:
+    """Declare (or replace) a write action on the pocket.
+
+    ``binding`` is validated through the ``ActionBinding`` model — an
+    entry missing ``method`` / ``path``, or carrying a non-write verb, is
+    rejected before any write. M2b governance/metering fields
+    (``requires_instinct``, ``outcome``, …) are CARRIED THROUGH unchanged:
+    ``ActionBinding`` ignores them on parse, so they are taken from the
+    raw ``binding`` dict and re-merged onto the validated core. The write
+    only fires at run time if the human owner has allow-listed the
+    method+path in backend settings.
+
+    Returns ``({"action_key": ..., "binding": ..., "pocket": <view>},
+    None)`` on success.
+    """
+    from pocketpaw_ee.cloud.pockets.action_executor import ActionBinding
+
+    if not action_key:
+        return None, "action_key is required"
+    if not isinstance(binding, dict):
+        return None, "binding must be an object"
+    try:
+        validated = ActionBinding.model_validate(binding)
+    except PydanticValidationError as exc:
+        return None, f"invalid action binding: {exc.errors()[0].get('msg', exc)}"
+
+    # The validated model drops M2b governance fields (extra: ignore). Carry
+    # them through verbatim so an M2b-aware client can author them now and
+    # they survive a round-trip through an M2a runtime.
+    normalized = {**binding, **validated.model_dump(mode="json")}
+    async with _pocket_lock(pocket_id):
+        doc, err = await _agent_load_doc(pocket_id)
+        if err or doc is None:
+            return None, err
+        spec = _sources_root(doc)
+        try:
+            actions_ops.set_action(spec, action_key, normalized)
+        except ValueError as exc:
+            return None, str(exc)
+        try:
+            await doc.save()
+        except Exception as exc:  # noqa: BLE001
+            return None, f"save failed: {exc}"
+        await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+        return (
+            {
+                "action_key": action_key,
+                "binding": normalized,
+                "pocket": _agent_view_dict(doc),
+            },
+            None,
+        )
+
+
+async def agent_remove_action(
+    pocket_id: str,
+    *,
+    action_key: str,
+) -> tuple[dict | None, str | None]:
+    """Remove a write-action declaration from the pocket.
+
+    Idempotent — removing an action that was never declared still
+    succeeds. Returns ``({"action_key": ..., "pocket": <view>}, None)``.
+    """
+    if not action_key:
+        return None, "action_key is required"
+    async with _pocket_lock(pocket_id):
+        doc, err = await _agent_load_doc(pocket_id)
+        if err or doc is None:
+            return None, err
+        spec = _sources_root(doc)
+        actions_ops.remove_action(spec, action_key)
+        try:
+            await doc.save()
+        except Exception as exc:  # noqa: BLE001
+            return None, f"save failed: {exc}"
+        await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+        return (
+            {"action_key": action_key, "pocket": _agent_view_dict(doc)},
+            None,
+        )
+
+
 async def agent_create(
     *,
     workspace_id: str,
@@ -2196,11 +2339,26 @@ async def set_pocket_backend(
     return {"base_url": base_url, "auth_type": auth_type, "configured": True}
 
 
+def _allowed_writes_wire(doc: _BackendCredentialDoc) -> list[dict[str, str]]:
+    """Render a backend doc's ``allowed_writes`` as plain wire dicts.
+
+    Each rule is ``{method, path_pattern}``. An older row written before
+    RFC 05 has no ``allowed_writes`` attribute — ``getattr`` defaults it
+    to an empty list (fail-closed: no write fires).
+    """
+    rules = getattr(doc, "allowed_writes", None) or []
+    out: list[dict[str, str]] = []
+    for rule in rules:
+        out.append({"method": rule.method, "path_pattern": rule.path_pattern})
+    return out
+
+
 async def get_pocket_backend(workspace_id: str, pocket_id: str) -> dict | None:
     """Return the pocket's backend binding summary, or ``None`` if unset.
 
     NEVER returns the token — only ``base_url`` / ``auth_type`` /
-    ``configured``.
+    ``configured`` / ``allowed_writes`` (the write allowlist; an
+    owner/editor-facing non-secret).
     """
     doc = await _BackendCredentialDoc.find_one(
         _BackendCredentialDoc.pocket_id == pocket_id,
@@ -2208,18 +2366,25 @@ async def get_pocket_backend(workspace_id: str, pocket_id: str) -> dict | None:
     )
     if doc is None:
         return None
-    return {"base_url": doc.base_url, "auth_type": doc.auth_type, "configured": True}
+    return {
+        "base_url": doc.base_url,
+        "auth_type": doc.auth_type,
+        "configured": True,
+        "allowed_writes": _allowed_writes_wire(doc),
+    }
 
 
 async def get_pocket_backend_for_executor(
     workspace_id: str, pocket_id: str
-) -> tuple[str, str, str | None, str] | None:
-    """Internal — return ``(base_url, auth_type, auth_header, token)``.
+) -> tuple[str, str, str | None, str, list[dict[str, str]]] | None:
+    """Internal — return ``(base_url, auth_type, auth_header, token,
+    allowed_writes)``.
 
-    Decrypts the stored token. Used ONLY by the run-sources route handler
-    to pass credentials to the source executor. Returns ``None`` when the
-    pocket has no backend configured. The plaintext token returned here
-    must never be logged or returned to a client.
+    Decrypts the stored token. Used by the run-sources route handler (it
+    ignores ``allowed_writes``) and the run-action route handler (it needs
+    it). Returns ``None`` when the pocket has no backend configured. The
+    plaintext token returned here must never be logged or returned to a
+    client.
     """
     doc = await _BackendCredentialDoc.find_one(
         _BackendCredentialDoc.pocket_id == pocket_id,
@@ -2231,7 +2396,60 @@ async def get_pocket_backend_for_executor(
     token = ""
     if doc.auth_type != "none" and doc.encrypted_token and doc.nonce and doc.salt:
         token = backend_crypto.decrypt_token(doc.encrypted_token, doc.nonce, doc.salt)
-    return doc.base_url, doc.auth_type, doc.auth_header, token
+    return doc.base_url, doc.auth_type, doc.auth_header, token, _allowed_writes_wire(doc)
+
+
+async def set_pocket_write_policy(
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    allowed_writes: list[dict[str, str]],
+) -> dict:
+    """Replace the pocket's write allowlist. Owner-only.
+
+    ``allowed_writes`` is a list of ``{method, path_pattern}`` rules. The
+    list lives on the backend-credential row — OUTSIDE the spec — so the
+    agent (which authors the spec) cannot widen its own write blast
+    radius. An empty list is valid and revokes every write.
+
+    Rejects with ``pocket_backend.not_configured`` if the pocket has no
+    backend configured: a write policy with no backend to apply it to is
+    meaningless, and silently storing one would mask the misconfiguration.
+    The mutation is audit-logged via the ``_audit_backend_config`` path.
+    """
+    doc = await _BackendCredentialDoc.find_one(
+        _BackendCredentialDoc.pocket_id == pocket_id,
+        _BackendCredentialDoc.workspace_id == workspace_id,
+    )
+    if doc is None:
+        raise ValidationError(
+            "pocket_backend.not_configured",
+            "This pocket has no backend configured — set one before a write policy",
+        )
+
+    doc.allowed_writes = [
+        _AllowedWriteDoc(method=rule["method"], path_pattern=rule["path_pattern"])
+        for rule in allowed_writes
+    ]
+    await doc.save()
+
+    _audit_backend_config(
+        actor=user_id,
+        action="pocket.backend.write_policy",
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        base_url=doc.base_url,
+        auth_type=doc.auth_type,
+    )
+    # no-event: backend credentials (and the write policy on them) are a
+    # separate collection, not pocket state — no downstream handler keys
+    # off a PocketUpdated for them.
+    return {
+        "base_url": doc.base_url,
+        "auth_type": doc.auth_type,
+        "configured": True,
+        "allowed_writes": _allowed_writes_wire(doc),
+    }
 
 
 async def remove_pocket_backend(workspace_id: str, user_id: str, pocket_id: str) -> None:
@@ -2272,11 +2490,13 @@ __all__ = [
     "agent_list",
     "agent_move_node",
     "agent_patch_state",
+    "agent_remove_action",
     "agent_remove_node",
     "agent_remove_source",
     "agent_remove_state",
     "agent_remove_widget",
     "agent_replace_node",
+    "agent_set_action",
     "agent_set_node_prop",
     "agent_set_source",
     "agent_set_state",
@@ -2291,6 +2511,7 @@ __all__ = [
     "get",
     "get_pocket_backend",
     "get_pocket_backend_for_executor",
+    "has_action_run_access",
     "has_edit_access",
     "is_member",
     "is_owner",
@@ -2303,6 +2524,7 @@ __all__ = [
     "reorder_widgets",
     "revoke_share_link",
     "set_pocket_backend",
+    "set_pocket_write_policy",
     "unassign_project_on_pockets",
     "update",
     "update_share_link",

--- a/ee/pocketpaw_ee/cloud/pockets/source_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/source_executor.py
@@ -43,9 +43,9 @@ from pocketpaw.security.url_validators import validate_external_url_strict
 from pocketpaw_ee.cloud.pockets._http_guard import (
     _HTTP_TIMEOUT,
     _MAX_RESPONSE_BYTES,
-    _GuardError,
     _assert_host_external,
     _auth_headers,
+    _GuardError,
     _resolve_url,
     _strip_query,
 )

--- a/ee/pocketpaw_ee/cloud/pockets/source_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/source_executor.py
@@ -2,18 +2,27 @@
 # Created: 2026-05-21 (RFC 04 alpha) — runs the GET "bindings" declared in a
 #   pocket's `rippleSpec.sources` against the pocket's single configured
 #   backend and returns the JSON results. Read-only (GET) only — write
-#   bindings land in RFC 04 Milestone 2.
+#   bindings land in RFC 05 (write actions).
 # Updated: 2026-05-21 (PR #1177 security pass) — basic auth now base64-encodes
 #   the `user:pass` credential; the rate limiter is keyed per (pocket, user)
 #   and guarded by an asyncio.Lock; imports the public `host_is_internal`;
 #   `run_sources` writes an audit-log entry for every run.
+# Updated: 2026-05-22 (RFC 05 M2a) — the SSRF/timeout/size guards extracted
+#   to the shared `_http_guard.py` module: `_resolve_url`,
+#   `_assert_host_external`, `_auth_headers`, `_strip_query`, the
+#   `_HTTP_TIMEOUT` / `_MAX_RESPONSE_BYTES` constants, and the error class
+#   (renamed `_SourceError` -> `_GuardError`). This executor now imports
+#   them; `_SourceError` is kept as a `_GuardError` subclass for the read
+#   executor's own per-source errors (timeouts, http_error, bad_json, …).
+#   Behavior-identical — pure refactor; the read-executor tests are the
+#   regression gate.
 #
-# SSRF BOUNDARY. This module is the ONLY pocket-domain module that makes
-# outbound HTTP. Every defense from the locked security review is enforced
-# here: strict base-URL re-validation, path-traversal rejection, same-host
-# assertion after URL join, DNS rebinding check, no redirect following,
-# tight timeouts, a 512 KB response cap, error-message sanitization, and a
-# per-(pocket, user) rate limit.
+# SSRF BOUNDARY. The outbound-HTTP defenses now live in `_http_guard.py` —
+# the ONE canonical guard module both executors import. Every defense from
+# the locked security review still applies: strict base-URL re-validation,
+# path-traversal rejection, same-host assertion after URL join, DNS
+# rebinding check, no redirect following, tight timeouts, a 512 KB response
+# cap, error-message sanitization, and a per-(pocket, user) rate limit.
 #
 # IMPORT-LINTER: must NOT import `pocketpaw_ee.cloud.models.*`. The executor
 # receives base_url / auth / spec by parameter only — `pockets/service.py`
@@ -22,10 +31,7 @@
 from __future__ import annotations
 
 import asyncio
-import base64
-import ipaddress
 import logging
-import socket
 import time
 import urllib.parse
 from typing import Literal
@@ -33,16 +39,23 @@ from typing import Literal
 import httpx
 from pydantic import BaseModel, Field, ValidationError
 
-from pocketpaw.security.url_validators import host_is_internal, validate_external_url_strict
+from pocketpaw.security.url_validators import validate_external_url_strict
+from pocketpaw_ee.cloud.pockets._http_guard import (
+    _HTTP_TIMEOUT,
+    _MAX_RESPONSE_BYTES,
+    _GuardError,
+    _assert_host_external,
+    _auth_headers,
+    _resolve_url,
+    _strip_query,
+)
 
 logger = logging.getLogger(__name__)
 
 # --- limits / policy --------------------------------------------------------
 _PER_SOURCE_TIMEOUT_S = 10.0
-_MAX_RESPONSE_BYTES = 524_288  # 512 KB (D11)
 _RATE_LIMIT_MAX = 10  # runs per window per (pocket, user) (D16)
 _RATE_LIMIT_WINDOW_S = 60.0
-_HTTP_TIMEOUT = httpx.Timeout(connect=5.0, read=10.0, write=5.0, pool=5.0)  # D10
 
 # Per-(pocket, user) run timestamps for the rate limiter. Keyed on both so a
 # single member cannot exhaust another member's budget on a shared pocket.
@@ -102,11 +115,6 @@ async def _rate_limited(pocket_id: str, user_id: str) -> bool:
         return False
 
 
-def _strip_query(url: str) -> str:
-    """Return ``url`` with query string and fragment removed — safe to log."""
-    return urllib.parse.urlsplit(url)._replace(query="", fragment="").geturl()
-
-
 def _audit_source_run(
     *, actor: str, pocket_id: str, status: str, base_url: str, ran: int, errors: int
 ) -> None:
@@ -138,84 +146,16 @@ def _audit_source_run(
         logger.warning("pocket source-run audit-log write failed", exc_info=True)
 
 
-class _SourceError(Exception):
-    """Internal: a per-source failure with an already-sanitized message."""
+class _SourceError(_GuardError):
+    """Internal: a per-source failure with an already-sanitized message.
 
-    def __init__(self, message: str, code: str = "error") -> None:
-        super().__init__(message)
-        self.message = message
-        self.code = code
-
-
-def _resolve_url(base_url: str, path: str) -> str:
-    """Join ``path`` onto ``base_url`` and reject anything that escapes it.
-
-    Implements D7: reject absolute URLs, ``..`` segments, null bytes /
-    non-printable chars, and any join whose resulting netloc differs from
-    the base. Returns the safe absolute URL.
+    Subclasses the shared ``_GuardError`` so a single ``except _GuardError``
+    catch covers both the guard primitives' rejections (extracted to
+    ``_http_guard.py``) and the read executor's own per-source errors
+    (timeout, http_error, bad_json, …). The guard messages say "path …";
+    this read-executor subclass keeps the "source …" wording for its own
+    rejections so the read-executor tests pass unchanged.
     """
-    if "\x00" in path or any(not ch.isprintable() for ch in path):
-        raise _SourceError("source path contains illegal characters", code="bad_path")
-
-    split_path = urllib.parse.urlsplit(path)
-    if split_path.scheme or split_path.netloc:
-        raise _SourceError("source path must be relative, not an absolute URL", code="bad_path")
-
-    # Percent-decode and reject traversal segments.
-    decoded = urllib.parse.unquote(split_path.path)
-    if any(seg == ".." for seg in decoded.split("/")):
-        raise _SourceError("source path may not contain '..' segments", code="bad_path")
-
-    joined = urllib.parse.urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
-    if urllib.parse.urlsplit(joined).netloc != urllib.parse.urlsplit(base_url).netloc:
-        raise _SourceError("source path resolves to a different host", code="bad_path")
-    return joined
-
-
-async def _assert_host_external(hostname: str) -> None:
-    """D8 — resolve ``hostname`` and reject if any IP is internal.
-
-    Guards against DNS rebinding: the base URL may be a public name that
-    resolves to a private address. ``getaddrinfo`` runs in a worker thread
-    so the event loop is not blocked.
-    """
-    try:
-        infos = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
-    except socket.gaierror as exc:
-        raise _SourceError("backend host could not be resolved", code="dns_error") from exc
-
-    for info in infos:
-        # info[4] is the sockaddr — (host, port[, flowinfo, scope_id]).
-        ip = str(info[4][0])
-        # strip a zone id (fe80::1%eth0) before parsing
-        ip = ip.split("%", 1)[0]
-        if host_is_internal(ip):
-            raise _SourceError("backend host resolves to an internal address", code="bad_host")
-        try:
-            addr = ipaddress.ip_address(ip)
-        except ValueError:
-            continue
-        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
-            raise _SourceError("backend host resolves to an internal address", code="bad_host")
-
-
-def _auth_headers(auth_type: str, auth_header: str | None, token: str) -> dict[str, str]:
-    """Build the request auth header for the configured auth type.
-
-    ``none`` adds no header. Unknown types are treated as ``none`` —
-    the DTO Literal already constrains the wire input.
-
-    For ``basic`` the stored token is the raw ``user:pass`` credential; it
-    is base64-encoded here to form a valid ``Authorization: Basic`` header.
-    """
-    if auth_type == "bearer":
-        return {"Authorization": f"Bearer {token}"}
-    if auth_type == "api_key":
-        return {(auth_header or "X-Api-Key"): token}
-    if auth_type == "basic":
-        encoded = base64.b64encode(token.encode()).decode()
-        return {"Authorization": f"Basic {encoded}"}
-    return {}
 
 
 def _select_sources(
@@ -268,7 +208,9 @@ async def _run_one(
     base_url: str,
     headers: dict[str, str],
 ) -> dict:
-    """Fetch a single source. Returns a ``ran`` row; raises ``_SourceError``."""
+    """Fetch a single source. Returns a ``ran`` row; raises ``_GuardError``
+    (the shared guard rejections) or its ``_SourceError`` subclass (the
+    read executor's own per-source failures)."""
     url = _resolve_url(base_url, binding.path)
     await _assert_host_external(urllib.parse.urlsplit(url).hostname or "")
 
@@ -410,7 +352,9 @@ async def run_sources(
                         "code": "timeout",
                     }
                 }
-            except _SourceError as exc:
+            except _GuardError as exc:
+                # Covers both the shared-guard rejections and this
+                # executor's own ``_SourceError`` subclass.
                 return {"__error__": {"source": key, "error": exc.message, "code": exc.code}}
             except Exception:
                 # Catch-all: never let a raw exception escape into the body.

--- a/ee/pocketpaw_ee/cloud/ripple_normalizer.py
+++ b/ee/pocketpaw_ee/cloud/ripple_normalizer.py
@@ -271,13 +271,14 @@ _WRITE_VERBS = ("POST", "PUT", "PATCH", "DELETE")
 _CALL_BINDING_NAME_ALIASES = ("binding", "action_id", "name")
 
 
-def _is_relative_url(raw: str) -> bool:
+def _is_relative_url(raw: Any) -> bool:
     """Return ``True`` when ``raw`` is a relative path (no scheme, no
     netloc) — the only shape we lift onto the pocket's own backend.
 
     An absolute URL (``https://third-party.example/x``) or a
     protocol-relative URL (``//host/x``, which carries a netloc) is a
-    different intent and returns ``False``.
+    different intent and returns ``False``. A non-string (the agent's
+    ``url`` field may be missing or malformed) also returns ``False``.
     """
     if not isinstance(raw, str) or not raw:
         return False

--- a/ee/pocketpaw_ee/cloud/ripple_normalizer.py
+++ b/ee/pocketpaw_ee/cloud/ripple_normalizer.py
@@ -18,6 +18,19 @@ field instead of ``source``. The runtime reads only ``sources`` and only
 ``handler.source``, so that output is inert. Prompt guidance has not
 beaten the model's prior, so we translate the output deterministically:
 lift the REST entries into ``sources`` and repair the button handlers.
+
+Changes: 2026-05-22 (RFC 05 M2a) — ``normalize_ripple_spec`` now runs
+``_lift_write_actions`` right after ``_lift_rest_sources``. The authoring
+agent emits a write the same hallucinated way it emits a read: an inline
+``{action: "api", method: "POST", url: "/x", body: {...}}`` handler
+instead of a ``rippleSpec.actions`` write binding triggered by
+``call_binding``. We lift any such handler whose ``url`` is a RELATIVE
+path into the ``actions`` block and rewrite the handler to
+``call_binding``. An ABSOLUTE-URL ``api`` call is a DIFFERENT intent (a
+third-party endpoint) and is left as ``api`` — never redirected onto the
+pocket's credentialed backend. ``call_binding`` handlers wired with the
+wrong binding-name field (``action_id`` / ``name``) are repaired to
+``binding``.
 """
 
 from __future__ import annotations
@@ -238,6 +251,206 @@ def _lift_rest_sources(spec: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+# ---------------------------------------------------------------------------
+# RFC 05 M2a — lift inline write `api` handlers into rippleSpec.actions.
+#
+# The runtime fires a write through the `actions` block + a `call_binding`
+# handler. The authoring agent emits writes inline instead — a handler
+# `{action: "api", method: "POST", url: "/x", body: {...}}`. We translate
+# that deterministically. CRITICAL: only a RELATIVE-url `api` call is lifted
+# — an absolute-URL `api` call targets a different (third-party) host and is
+# left untouched, never redirected onto the pocket's credentialed backend.
+# ---------------------------------------------------------------------------
+
+_WRITE_VERBS = ("POST", "PUT", "PATCH", "DELETE")
+
+# Keys an inline `api` write handler may carry that we map onto a write
+# binding. Everything else on the handler is dropped from the binding (it
+# was never a write-binding field) but `on_success` / `on_error` are
+# preserved on BOTH the binding and the rewritten call_binding handler.
+_CALL_BINDING_NAME_ALIASES = ("binding", "action_id", "name")
+
+
+def _is_relative_url(raw: str) -> bool:
+    """Return ``True`` when ``raw`` is a relative path (no scheme, no
+    netloc) — the only shape we lift onto the pocket's own backend.
+
+    An absolute URL (``https://third-party.example/x``) or a
+    protocol-relative URL (``//host/x``, which carries a netloc) is a
+    different intent and returns ``False``.
+    """
+    if not isinstance(raw, str) or not raw:
+        return False
+    split = urllib.parse.urlsplit(raw)
+    return not split.scheme and not split.netloc
+
+
+def _is_inline_write_api(handler: Any) -> bool:
+    """Heuristic: is ``handler`` an inline write ``api`` call we should lift?
+
+    True only when it is an ``api`` action with a write ``method`` and a
+    RELATIVE ``url``. A GET ``api`` call, an absolute-URL ``api`` call, and
+    a non-``api`` handler all return False.
+    """
+    if not isinstance(handler, dict) or handler.get("action") != "api":
+        return False
+    method = str(handler.get("method") or "").upper()
+    if method not in _WRITE_VERBS:
+        return False
+    return _is_relative_url(handler.get("url"))
+
+
+def _lifted_action_entry(handler: dict[str, Any]) -> dict[str, Any]:
+    """Translate one inline write ``api`` handler into a canonical
+    ``rippleSpec.actions`` entry.
+
+    ``params`` is taken from the handler's ``body`` (the agent's usual
+    field for a request payload), falling back to ``params``.
+    ``on_success`` / ``on_error`` are carried through.
+    """
+    method = str(handler["method"]).upper()
+    body = handler.get("body")
+    if not isinstance(body, dict):
+        body = handler.get("params") if isinstance(handler.get("params"), dict) else {}
+    entry: dict[str, Any] = {
+        "kind": "write_binding",
+        "method": method,
+        "path": handler["url"],
+        "params": body,
+        "confirm": bool(handler.get("confirm", False)),
+    }
+    on_success = handler.get("on_success")
+    if isinstance(on_success, list):
+        entry["on_success"] = on_success
+    on_error = handler.get("on_error")
+    if isinstance(on_error, list):
+        entry["on_error"] = on_error
+    return entry
+
+
+def _repair_call_binding_handler(handler: Any) -> Any:
+    """Repair a ``call_binding`` handler that names its target with the
+    wrong field — the agent uses ``action_id`` / ``name`` where the
+    runtime reads ``binding``. Non-``call_binding`` handlers pass through.
+    """
+    if not isinstance(handler, dict) or handler.get("action") != "call_binding":
+        return handler
+    if handler.get("binding"):
+        # Already correct — drop any stray alias.
+        if "action_id" in handler or "name" in handler:
+            return {k: v for k, v in handler.items() if k not in ("action_id", "name")}
+        return handler
+    for alias in ("action_id", "name"):
+        candidate = handler.get(alias)
+        if isinstance(candidate, str) and candidate:
+            repaired = {k: v for k, v in handler.items() if k not in ("action_id", "name")}
+            repaired["binding"] = candidate
+            return repaired
+    return handler
+
+
+class _ActionLifter:
+    """Stateful walk that lifts inline write ``api`` handlers into a single
+    ``actions`` dict, generating ``act_1`` / ``act_2`` / … names.
+
+    Pure with respect to its input: every visited dict/list is rebuilt, the
+    input structure is never mutated. ``actions`` accumulates the lifted
+    entries; ``_counter`` mints unique names that do not collide with a
+    binding name already present in ``actions``.
+    """
+
+    def __init__(self, actions: dict[str, Any]) -> None:
+        self.actions = actions
+        self._counter = 0
+
+    def _next_name(self) -> str:
+        while True:
+            self._counter += 1
+            name = f"act_{self._counter}"
+            if name not in self.actions:
+                return name
+
+    def _transform_handler(self, handler: Any) -> Any:
+        """Lift an inline write ``api`` handler; else repair a
+        ``call_binding`` handler; else pass through."""
+        if _is_inline_write_api(handler):
+            name = self._next_name()
+            self.actions[name] = _lifted_action_entry(handler)
+            rewritten: dict[str, Any] = {"action": "call_binding", "binding": name}
+            # Keep the reconcile handlers on the call site too — Ripple
+            # runs per-action on_success/on_error from the handler.
+            on_success = handler.get("on_success")
+            if isinstance(on_success, list):
+                rewritten["on_success"] = on_success
+            on_error = handler.get("on_error")
+            if isinstance(on_error, list):
+                rewritten["on_error"] = on_error
+            return rewritten
+        return _repair_call_binding_handler(handler)
+
+    def walk(self, node: Any) -> Any:
+        """Recursively rebuild a UI structure, transforming every handler
+        in an event slot. Returns a new structure; input is not mutated."""
+        if isinstance(node, dict):
+            rebuilt = dict(node)
+            for slot in _HANDLER_SLOTS:
+                if slot not in rebuilt:
+                    continue
+                value = rebuilt[slot]
+                if isinstance(value, list):
+                    rebuilt[slot] = [self._transform_handler(h) for h in value]
+                else:
+                    rebuilt[slot] = self._transform_handler(value)
+            for key in ("children", "else_children"):
+                kids = rebuilt.get(key)
+                if isinstance(kids, list):
+                    rebuilt[key] = [self.walk(c) for c in kids]
+            return rebuilt
+        if isinstance(node, list):
+            return [self.walk(c) for c in node]
+        return node
+
+
+def _lift_write_actions(spec: dict[str, Any]) -> dict[str, Any]:
+    """Translate inline write ``api`` handlers into the canonical RFC 05
+    ``rippleSpec.actions`` shape.
+
+    Two repairs, both pure (the input ``spec`` is not mutated):
+
+    1. Lift every event handler shaped ``{action: "api", method:
+       POST|PUT|PATCH|DELETE, url: <RELATIVE path>, body: {...}}`` into a
+       ``rippleSpec.actions`` entry (``kind: write_binding``, the method,
+       ``path`` from ``url``, ``params`` from ``body``, carrying
+       ``on_success`` / ``on_error``). The handler is rewritten to
+       ``{action: "call_binding", binding: "<generated name>"}``. An
+       absolute-URL ``api`` handler is a third-party call — left as ``api``.
+    2. Repair ``call_binding`` handlers that name the target with the wrong
+       field (``action_id`` / ``name`` → ``binding``).
+
+    A correctly-authored ``actions`` block is never clobbered — lifted
+    entries get fresh ``act_N`` names that skip any existing key. A spec
+    with no inline write handlers and no ``call_binding`` mis-wires passes
+    through structurally unchanged.
+    """
+    actions: dict[str, Any] = (
+        dict(spec.get("actions") or {}) if isinstance(spec.get("actions"), dict) else {}
+    )
+    lifter = _ActionLifter(actions)
+
+    result = spec
+    if isinstance(result.get("ui"), (dict, list)):
+        result = {**result, "ui": lifter.walk(result["ui"])}
+    if isinstance(result.get("panes"), dict):
+        result = {
+            **result,
+            "panes": {k: lifter.walk(v) for k, v in result["panes"].items()},
+        }
+
+    if actions:
+        result = {**result, "actions": actions}
+    return result
+
+
 def _stamp_node_ids(ui: Any) -> Any:
     """Assign a stable ``n_xxxxxxxx`` id to every node in a UISpec
     tree that lacks one. Idempotent and collision-safe — nodes that
@@ -382,6 +595,11 @@ def normalize_ripple_spec(spec: dict[str, Any] | None) -> dict[str, Any] | None:
     # canonical RFC 04 shape before any other normalization. Pure: returns
     # a new dict, leaves a correctly-authored spec structurally unchanged.
     spec = _lift_rest_sources(spec)
+
+    # Translate inline write ``api`` handlers into the RFC 05
+    # ``rippleSpec.actions`` block + ``call_binding`` handlers. Pure; an
+    # absolute-URL ``api`` call (third-party intent) is left untouched.
+    spec = _lift_write_actions(spec)
 
     name = spec.get("title") or spec.get("name")
     pocket_id = spec.get("id") or (spec.get("lifecycle") or {}).get("id") or f"pocket-{_short_id()}"

--- a/ee/pocketpaw_ee/cloud/shared/deps.py
+++ b/ee/pocketpaw_ee/cloud/shared/deps.py
@@ -47,6 +47,7 @@ __all__ = [
     "require_group_action",
     "require_membership",
     "require_plan_feature",
+    "require_pocket_action_run",
     "require_pocket_edit",
     "require_pocket_owner",
 ]
@@ -170,3 +171,31 @@ async def require_pocket_owner(
         resource_id=pocket_id,
     )
     raise Forbidden("pocket.not_owner", "Only the pocket owner can perform this action")
+
+
+async def require_pocket_action_run(
+    pocket_id: str,
+    user: Any = Depends(current_active_user),
+) -> Any:
+    """Allow if the caller is pocket.owner or in pocket.shared_with.
+
+    Deliberately NARROWER than ``require_pocket_edit`` — a workspace-visible
+    pocket does NOT grant write-action access. A write action hits a real
+    backend with a real ``DELETE``; M2a keeps that surface to people the
+    owner explicitly invited. M2b widens this once Instinct gating is wired.
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    user_id = str(user.id)
+    if await pockets_service.has_action_run_access(pocket_id, user_id):
+        return user
+
+    log_denial(
+        actor=user_id,
+        action="pocket.action.run",
+        code="pocket.access_denied",
+        resource_id=pocket_id,
+    )
+    raise Forbidden(
+        "pocket.access_denied", "You do not have write-action access to this pocket"
+    )

--- a/ee/pocketpaw_ee/cloud/shared/deps.py
+++ b/ee/pocketpaw_ee/cloud/shared/deps.py
@@ -196,6 +196,4 @@ async def require_pocket_action_run(
         code="pocket.access_denied",
         resource_id=pocket_id,
     )
-    raise Forbidden(
-        "pocket.access_denied", "You do not have write-action access to this pocket"
-    )
+    raise Forbidden("pocket.access_denied", "You do not have write-action access to this pocket")

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -173,6 +173,9 @@ source_modules = [
     "pocketpaw_ee.cloud.pockets.agent_context",
     "pocketpaw_ee.cloud.pockets.source_executor",
     "pocketpaw_ee.cloud.pockets.sources_ops",
+    "pocketpaw_ee.cloud.pockets._http_guard",
+    "pocketpaw_ee.cloud.pockets.action_executor",
+    "pocketpaw_ee.cloud.pockets.actions_ops",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.pocket",

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -26,6 +26,14 @@
 # to read that line instead of asking the user for a backend URL it can
 # already see.
 #
+# Changes: 2026-05-22 (RFC 05 M2a) — added `_WRITE_ACTIONS_BLOCK` (create)
+# and `_WRITE_ACTIONS_EDIT_BLOCK` (edit), spliced in after the
+# `_LIVE_DATA_SOURCES_*` blocks. They teach the agent the `rippleSpec.actions`
+# write-binding block — a sibling of `sources` — the `call_binding` action,
+# `confirm` for destructive writes, `on_success` reconcile, and that a write
+# fires only if the human owner allow-listed the method+path.
+# `_EDIT_TOOLS_MCP` now also lists `set_action` / `remove_action`.
+#
 # Canonical source for every pocket-mode system prompt the agent ever sees.
 # Four strings are exported, one per (action × backend) cell:
 #
@@ -611,6 +619,158 @@ nothing else:
 """
 
 
+# Create-specialist write-actions guidance. `sources` (reads) and `actions`
+# (writes) are two sibling rippleSpec blocks; this teaches the second.
+_WRITE_ACTIONS_BLOCK = """\
+<write-actions>
+A `sources` binding READS the backend; a `actions` binding WRITES to it.
+When the user wants a widget that DOES something to their backend — submit
+a form, mark a row done, advance a card, delete a record — declare a
+`actions` block in the rippleSpec. `actions` is a SIBLING of `sources`.
+
+  "rippleSpec": {
+    "sources": { "leases": {"method": "GET", "path": "/leases?expiring=90d",
+                            "bind": "state.leases", "refresh": ["pocket_open"]} },
+    "actions": {
+      "mark_renewed": {
+        "kind": "write_binding",
+        "method": "POST",
+        "path": "/leases/{item.id}/renew",
+        "params": { "proposed_rent": "{state.form.rent}" },
+        "confirm": false,
+        "on_success": [{ "action": "run_source", "source": "leases" }],
+        "on_error":   [{ "action": "toast", "variant": "error" }]
+      }
+    },
+    "ui": [ ... ],
+    "state": { "leases": [], "form": { "rent": "" } }
+  }
+
+An action entry has EXACTLY these fields (M2a):
+- `kind`     — always the string `"write_binding"`.
+- `method`   — `POST`, `PUT`, `PATCH`, or `DELETE`. (GET is a `source`, not
+  an action.)
+- `path`     — a RELATIVE path on the pocket's backend, never an absolute
+  URL. May carry `{...}` expressions (`{item.id}`, `{state.form.x}`) — they
+  resolve client-side at click time, the SAME resolver `sources` and binds
+  use. No new syntax.
+- `params`   — the request body, a map; values may be `{...}` expressions.
+- `confirm`  — `true` puts a confirm step in front of the write. See below.
+- `on_success` / `on_error` — handler lists run after the write resolves.
+
+A widget triggers an action BY NAME with the `call_binding` action:
+
+  {"type": "button", "props": {"label": "Renew"},
+   "on_click": {"action": "call_binding", "binding": "mark_renewed"}}
+
+DESTRUCTIVE WRITES NEED A CONFIRM. `DELETE` and a full-resource `PUT` are
+destructive. Set `confirm: true` on the action AND author the click as a
+`[confirm, call_binding]` flow so the user sees a speed bump:
+
+  "on_click": {"action": "flow", "steps": [
+    {"action": "confirm", "message": "Delete this lease? This cannot be undone."},
+    {"action": "call_binding", "binding": "delete_lease"}
+  ]}
+
+`POST` / `PATCH` are additive — no confirm needed by default.
+
+RECONCILE WITH on_success. After a write succeeds the UI must catch up:
+- Single-record write → `on_success` a `set` mutate plus the `{event}`
+  response, or just re-run the one source.
+- List-changing write (added/removed a row) → `on_success` a `run_source`
+  that re-fetches the list.
+
+OPTIMISTIC UPDATE is just a flow, not a new feature. For a snappy toggle,
+`mutate_state` first, then `call_binding`, with an `on_error` that reverses
+the mutate:
+
+  "on_click": {"action": "flow", "steps": [
+    {"action": "mutate_state", "op": "set", "path": "row.{item.id}.status",
+     "value": "renewed"},
+    {"action": "call_binding", "binding": "mark_renewed", "on_error": [
+       {"action": "mutate_state", "op": "set", "path": "row.{item.id}.status",
+        "value": "active"}]}
+  ]}
+
+THE WRITE ONLY FIRES IF THE OWNER ALLOW-LISTED IT. Authoring an action does
+NOT authorize the write. The pocket's human owner sets a write allowlist
+(method + path pattern) in the backend settings — OUTSIDE the spec. A write
+whose method+path is not allow-listed is rejected server-side and never
+leaves PocketPaw. Author the action the user asked for; if no backend or no
+allowlist entry exists, tell the user to configure it in backend settings.
+
+DO NOT GET THIS WRONG:
+- Writes go in `rippleSpec.actions` ONLY, triggered by `call_binding`.
+  NEVER inline an `{action: "api", method: "POST", url: ...}` handler — that
+  is the read-source mistake's write twin and is normalized away.
+- `path` is RELATIVE. An absolute URL is a different (third-party) intent
+  and must not be authored as a pocket action.
+</write-actions>
+"""
+
+
+# Edit-specialist variant — the EDIT specialist authors actions through the
+# `set_action` / `remove_action` granular ops, not whole-spec JSON.
+_WRITE_ACTIONS_EDIT_BLOCK = """\
+<write-actions>
+A `sources` binding READS the backend; a `actions` binding WRITES to it.
+When the user wants a widget that DOES something to their backend — submit
+a form, mark a row done, delete a record — use the `set_action` /
+`remove_action` ops. They write the pocket's top-level `rippleSpec.actions`
+block (a SIBLING of `sources`); the state/node ops cannot.
+
+  set_action(
+    action_key="mark_renewed",
+    method="POST",                 # POST | PUT | PATCH | DELETE
+    path="/leases/{item.id}/renew",  # RELATIVE path, never an absolute URL
+    params={"proposed_rent": "{state.form.rent}"},
+    confirm=False,
+    on_success=[{"action": "run_source", "source": "leases"}],
+  )
+
+  remove_action(action_key="mark_renewed")
+
+An action is EXACTLY `{kind:"write_binding", method, path, params, confirm,
+on_success?, on_error?}` (M2a). `method` is a write verb — GET is a
+`source`, not an action. `path` is RELATIVE and may carry `{...}`
+expressions (`{item.id}`, `{state.form.x}`) resolved client-side at click
+time — no new syntax.
+
+After `set_action`, wire the trigger with the normal node ops — a widget
+fires the action BY NAME via `call_binding`:
+
+  add_node(... a button whose on_click is
+           {"action": "call_binding", "binding": "mark_renewed"})
+
+DESTRUCTIVE WRITES NEED A CONFIRM. For `DELETE` / full-resource `PUT`, pass
+`confirm=true` to `set_action` AND author the on_click as a
+`[confirm, call_binding]` flow so the user sees a speed bump. `POST` /
+`PATCH` are additive — no confirm by default.
+
+RECONCILE WITH on_success. After a write succeeds the UI must catch up: for
+a single-record write `set` the changed state from the response; for a
+list-changing write `run_source` to refetch the list. For an optimistic
+toggle, author the on_click as a flow — `mutate_state` then `call_binding`
+with an `on_error` that reverses the mutate.
+
+THE WRITE ONLY FIRES IF THE OWNER ALLOW-LISTED IT. Authoring an action does
+NOT authorize the write. The pocket's human owner sets a write allowlist
+(method + path pattern) in the pocket's backend settings — OUTSIDE the
+spec. A write whose method+path is not allow-listed is rejected server-side.
+The `Backend:` line in `<current-pocket>` tells you whether a backend
+exists. If there is no backend, tell the user to configure one (and the
+write allowlist) in backend settings before the action can fire.
+
+DO NOT GET THIS WRONG:
+- Writes go in `rippleSpec.actions` ONLY, via `set_action`, triggered by a
+  `call_binding` handler. NEVER stash a write in `state` and never build a
+  chat-round-trip button for it.
+- `path` is RELATIVE. An absolute URL is a third-party intent — not a
+  pocket action.
+</write-actions>
+"""
+
+
 # ---------------------------------------------------------------------------
 # Tool surface — MCP variant (claude_agent_sdk).
 # Identity (workspace, user, session) is bound from the active SSE
@@ -733,8 +893,16 @@ DATA-SOURCE OPS — read-only live data bindings (rippleSpec.sources)
                                 pocket's configured backend into state
   remove_source(source_key)     delete a data-source declaration
 
+WRITE-ACTION OPS — write bindings (rippleSpec.actions)
+
+  set_action(action_key, method, path, params?, confirm?,
+             on_success?, on_error?)
+                                declare a POST/PUT/PATCH/DELETE binding the
+                                backend; a widget fires it via call_binding
+  remove_action(action_key)     delete a write-action declaration
+
 Use these only for the user's OWN backend (a CRM, an internal API). See
-the `<live-data-sources>` block for when and how.
+the `<live-data-sources>` and `<write-actions>` blocks for when and how.
 
 The toolset above is the WHOLE interface. Apply the smallest granular op
 that satisfies the intent.
@@ -1653,6 +1821,7 @@ def _assemble_specialist() -> str:
         _INTERACTIVE_DEFAULT_BLOCK,
         _STATE_SOURCES_BLOCK,
         _LIVE_DATA_SOURCES_BLOCK,
+        _WRITE_ACTIONS_BLOCK,
         _CREATION_EXAMPLES_MCP,
         _RESEARCH_PROTOCOL,
         _RIPPLE_DESIGN_ESSENTIALS,
@@ -1729,7 +1898,12 @@ def _assemble_interaction(*, mcp: bool) -> str:
     knows it can author a ``rippleSpec.sources`` block via the
     ``set_source`` / ``remove_source`` ops (RFC 04 alpha follow-up) —
     without it, the specialist stashed fake source descriptors in state
-    and built chat-round-trip refresh buttons."""
+    and built chat-round-trip refresh buttons.
+
+    ``_WRITE_ACTIONS_EDIT_BLOCK`` is spliced in next (RFC 05 M2a) so the
+    specialist knows it can author a ``rippleSpec.actions`` write-binding
+    block via the ``set_action`` / ``remove_action`` ops, triggered by a
+    ``call_binding`` handler."""
     parts = [
         _SCOPE_BLOCK,
         _CANVAS_BLOCK,
@@ -1738,6 +1912,7 @@ def _assemble_interaction(*, mcp: bool) -> str:
         _INTERACTIVE_DEFAULT_BLOCK,
         _STATE_SOURCES_BLOCK,
         _LIVE_DATA_SOURCES_EDIT_BLOCK,
+        _WRITE_ACTIONS_EDIT_BLOCK,
         RIPPLE_DESIGN_RULES,
         # MUST be last — see _CURRENT_POCKET_BLOCK_TEMPLATE rationale.
         _CURRENT_POCKET_BLOCK_TEMPLATE,

--- a/tests/cloud/test_pocket_action_executor.py
+++ b/tests/cloud/test_pocket_action_executor.py
@@ -17,6 +17,14 @@
 #   - The write rate limit is a SEPARATE counter from the read executor's
 #     (a read budget never drains the write budget and vice versa).
 #   - The Idempotency-Key header is present; a client-supplied key wins.
+#
+# Updated: 2026-05-22 (security review hardening) — adds:
+#   - S1: the allowlist matches the percent-DECODED path, so encoding
+#     cannot flip the verdict and an off-allowlist path cannot slip past.
+#   - S2: a backend >=400 status does not leak the exact number to the
+#     client — the response carries a generic message.
+#   - N1: a DELETE with empty params sends NO request body; a DELETE with
+#     params still does.
 #   - The happy path returns the backend's parsed JSON + on_success.
 
 from __future__ import annotations
@@ -136,6 +144,7 @@ async def test_instinct_required_rejects_before_any_call(monkeypatch):
 
     raw = {**_write_action(), "requires_instinct": True}
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="mark_renewed",
@@ -159,6 +168,7 @@ async def test_instinct_policy_alone_does_not_reject(monkeypatch):
     _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
     raw = {**_write_action(), "instinct_policy": "approve_per_row"}
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="mark_renewed",
@@ -182,6 +192,7 @@ async def test_instinct_policy_alone_does_not_reject(monkeypatch):
 async def test_allowlist_happy_match(monkeypatch):
     _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"renewed": True}))
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="mark_renewed",
@@ -208,6 +219,7 @@ async def test_allowlist_method_mismatch_rejected(monkeypatch):
 
     _mock_client_patch(monkeypatch, handler)
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="del",
@@ -235,6 +247,7 @@ async def test_allowlist_path_mismatch_rejected(monkeypatch):
 
     _mock_client_patch(monkeypatch, handler)
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="del",
@@ -257,6 +270,7 @@ async def test_allowlist_strips_query_before_match(monkeypatch):
     the query is stripped before the allowlist check."""
     _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="patch",
@@ -282,6 +296,7 @@ async def test_allowlist_empty_rejects_everything(monkeypatch):
 
     _mock_client_patch(monkeypatch, handler)
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="mark_renewed",
@@ -312,6 +327,7 @@ async def test_allowlist_literal_star_in_path_does_not_match_concrete_pattern(mo
 
     _mock_client_patch(monkeypatch, handler)
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="weird",
@@ -338,6 +354,7 @@ async def test_allowlist_literal_star_in_path_does_not_match_concrete_pattern(mo
 async def test_dotdot_traversal_rejected(monkeypatch):
     _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="a",
@@ -357,6 +374,7 @@ async def test_dotdot_traversal_rejected(monkeypatch):
 async def test_absolute_url_path_rejected(monkeypatch):
     _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="a",
@@ -376,6 +394,7 @@ async def test_absolute_url_path_rejected(monkeypatch):
 async def test_internal_base_url_rejected(monkeypatch):
     _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="a",
@@ -401,6 +420,7 @@ async def test_host_resolving_internal_rejected(monkeypatch):
 
     monkeypatch.setattr("socket.getaddrinfo", _internal_getaddrinfo)
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="a",
@@ -424,6 +444,7 @@ async def test_redirect_is_an_error(monkeypatch):
         lambda r: httpx.Response(302, headers={"location": "https://evil.com/x"}),
     )
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="a",
@@ -449,6 +470,7 @@ async def test_oversize_response_rejected(monkeypatch):
         lambda r: httpx.Response(200, content=big, headers={"content-type": "application/json"}),
     )
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="a",
@@ -475,6 +497,7 @@ async def test_write_rate_limit_breach(monkeypatch):
 
     async def _one():
         return await run_action(
+            workspace_id="w1",
             pocket_id="p-rl",
             user_id="u1",
             action="a",
@@ -504,6 +527,7 @@ async def test_write_rate_limit_isolated_from_read_budget(monkeypatch):
     # Drain the WRITE budget fully.
     for _ in range(action_executor._ACTION_RATE_LIMIT_MAX):
         await run_action(
+            workspace_id="w1",
             pocket_id="shared",
             user_id="u1",
             action="a",
@@ -517,6 +541,7 @@ async def test_write_rate_limit_isolated_from_read_budget(monkeypatch):
             allowed_writes=_allow(),
         )
     breach = await run_action(
+        workspace_id="w1",
         pocket_id="shared",
         user_id="u1",
         action="a",
@@ -548,6 +573,7 @@ async def test_read_budget_does_not_drain_write_budget(monkeypatch):
 
     # A write for the same key still goes through — separate counter.
     result = await run_action(
+        workspace_id="w1",
         pocket_id="shared2",
         user_id="u1",
         action="a",
@@ -578,6 +604,7 @@ async def test_idempotency_key_generated_when_omitted(monkeypatch):
 
     _mock_client_patch(monkeypatch, handler)
     await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="a",
@@ -605,6 +632,7 @@ async def test_client_supplied_idempotency_key_is_honored(monkeypatch):
 
     _mock_client_patch(monkeypatch, handler)
     await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="a",
@@ -643,6 +671,7 @@ async def test_happy_path_sends_params_and_carries_on_success(monkeypatch):
         "on_error": [{"action": "toast", "variant": "error"}],
     }
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="mark_renewed",
@@ -665,8 +694,13 @@ async def test_happy_path_sends_params_and_carries_on_success(monkeypatch):
 
 
 async def test_backend_4xx_becomes_http_error(monkeypatch):
+    """A backend >=400 maps to the `http_error` category — and the exact
+    numeric status is NOT echoed to the client (S2: the endpoint must not
+    be a backend path-probing oracle). The number lives only in the audit
+    log."""
     _mock_client_patch(monkeypatch, lambda r: httpx.Response(422, json={"err": "bad"}))
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="a",
@@ -681,12 +715,16 @@ async def test_backend_4xx_becomes_http_error(monkeypatch):
     )
     assert result["ok"] is False
     assert result["code"] == "http_error"
+    # S2 — the client-facing message is generic; the raw 422 is not leaked.
+    assert "422" not in result["error"]
+    assert result["error"] == "the backend rejected the request"
 
 
 async def test_malformed_binding_is_bad_binding(monkeypatch):
     """A raw action missing `method` is a `bad_binding` rejection."""
     _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
     result = await run_action(
+        workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
         action="a",
@@ -701,3 +739,165 @@ async def test_malformed_binding_is_bad_binding(monkeypatch):
     )
     assert result["ok"] is False
     assert result["code"] == "bad_binding"
+
+
+# ---------------------------------------------------------------------------
+# S1 — the allowlist matches the DECODED path
+# ---------------------------------------------------------------------------
+
+
+async def test_percent_encoded_path_matches_decoded_form_consistently(monkeypatch):
+    """A request path with percent-encoded segments is matched against the
+    human-authored `path_pattern` after a single decode. The match result
+    is identical to the result for the path's plain, decoded form — a
+    client cannot change the allowlist verdict by encoding the request.
+
+    Pattern `/leases/*/renew` allows lease renewals. The literal word
+    `renew` encoded as `%72%65%6e%65%77` decodes back to `renew`, so the
+    encoded request matches exactly as its decoded twin does — without the
+    decode, the trailing literal would not match the pattern and an
+    allowed request would be wrongly rejected."""
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["hit"] = True
+        return httpx.Response(200, json={"renewed": True})
+
+    _mock_client_patch(monkeypatch, handler)
+
+    # `%72%65%6e%65%77` == "renew"; the resolved path decodes to
+    # `/leases/42/renew`, matching the `/leases/*/renew` pattern.
+    encoded_result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="mark_renewed",
+        raw_action=_write_action("POST", "/leases/42/%72%65%6e%65%77"),
+        path="/leases/42/%72%65%6e%65%77",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/leases/*/renew"),
+    )
+    # The decoded twin — the SAME resource expressed plainly.
+    plain_result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="mark_renewed",
+        raw_action=_write_action("POST", "/leases/42/renew"),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/leases/*/renew"),
+    )
+    # Encoding the path must not flip the allowlist verdict.
+    assert encoded_result["ok"] == plain_result["ok"] is True
+    assert seen.get("hit") is True
+
+
+async def test_percent_encoded_path_cannot_slip_past_allowlist(monkeypatch):
+    """A request whose DECODED path is not on the allowlist stays rejected
+    even when the client percent-encodes it. `%2E%2E` decodes to `..`; the
+    SSRF guard catches the traversal, and a non-traversal encoded path that
+    decodes to an off-allowlist resource is a plain `not_allowed` miss —
+    either way the encoded form gets the same verdict as its decoded twin:
+    no call leaves the server."""
+    called = {"hit": False}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["hit"] = True
+        return httpx.Response(200, json={})
+
+    _mock_client_patch(monkeypatch, handler)
+
+    # `%75%73%65%72%73` == "users"; decoded path is `/users/9/delete`,
+    # which the `/leases/*/renew` pattern does not cover. Encoding it does
+    # not smuggle it past the allowlist.
+    result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="del",
+        raw_action=_write_action("POST", "/%75%73%65%72%73/9/delete"),
+        path="/%75%73%65%72%73/9/delete",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/leases/*/renew"),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "not_allowed"
+    # The rejection message names the DECODED path, not the encoded one.
+    assert "/users/9/delete" in result["error"]
+    assert called["hit"] is False
+
+
+# ---------------------------------------------------------------------------
+# N1 — empty-params DELETE sends no JSON body
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_with_empty_params_sends_no_body(monkeypatch):
+    """A DELETE with no params sends NO request body — some backends and
+    WAFs reject a DELETE that carries a JSON body."""
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["content"] = request.content
+        seen["content_type"] = request.headers.get("content-type")
+        return httpx.Response(200, json={"deleted": True})
+
+    _mock_client_patch(monkeypatch, handler)
+    result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="del",
+        raw_action=_write_action("DELETE", "/leases/42"),
+        path="/leases/42",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("DELETE", "/leases/*"),
+    )
+    assert result["ok"] is True
+    # No body at all — not even an empty `{}`.
+    assert seen["content"] == b""
+
+
+async def test_delete_with_params_still_sends_body(monkeypatch):
+    """A DELETE WITH params still carries the JSON body — only the empty
+    case is special-cased."""
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content) if request.content else None
+        return httpx.Response(200, json={"deleted": True})
+
+    _mock_client_patch(monkeypatch, handler)
+    result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="del",
+        raw_action={**_write_action("DELETE", "/leases/42"), "params": {"reason": "expired"}},
+        path="/leases/42",
+        params={"reason": "expired"},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("DELETE", "/leases/*"),
+    )
+    assert result["ok"] is True
+    assert seen["body"] == {"reason": "expired"}

--- a/tests/cloud/test_pocket_action_executor.py
+++ b/tests/cloud/test_pocket_action_executor.py
@@ -1,0 +1,703 @@
+# tests/cloud/test_pocket_action_executor.py — RFC 05 M2a.
+# Created: 2026-05-22 — Coverage for the pocket WRITE-action executor, the
+# write half of the pocket data layer. No real network calls — outbound
+# HTTP is faked via httpx.MockTransport and socket.getaddrinfo is
+# monkeypatched so fake hostnames "resolve" to a public IP.
+#
+# What this pins:
+#   - ActionBinding parses and IGNORES M2b governance fields
+#     (requires_instinct / instinct_policy / outcome).
+#   - INSTINCT-REJECT (fail-closed): a truthy raw `requires_instinct`
+#     yields code `instinct_required` and makes NO call.
+#   - The allowlist matrix: method mismatch, path mismatch, query string
+#     stripped before match, a literal `*` in a hallucinated path, the
+#     happy match.
+#   - SSRF guards on the WRITE path: `..` traversal, absolute-URL path,
+#     a host that resolves internal, a 3xx redirect, an oversize body.
+#   - The write rate limit is a SEPARATE counter from the read executor's
+#     (a read budget never drains the write budget and vice versa).
+#   - The Idempotency-Key header is present; a client-supplied key wins.
+#   - The happy path returns the backend's parsed JSON + on_success.
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud.pockets import action_executor, source_executor
+from pocketpaw_ee.cloud.pockets.action_executor import ActionBinding, run_action
+
+BASE = "https://api.example.com"
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limits():
+    """Clear both module-level rate-limit logs between tests."""
+    action_executor._action_log.clear()
+    source_executor._run_log.clear()
+    yield
+    action_executor._action_log.clear()
+    source_executor._run_log.clear()
+
+
+@pytest.fixture(autouse=True)
+def _public_dns(monkeypatch):
+    """Make every hostname resolve to a public IP so the DNS guard passes.
+
+    Tests that need an internal-resolving host override this.
+    """
+
+    def _fake_getaddrinfo(host, *_args, **_kwargs):
+        return [(2, 1, 6, "", ("8.8.8.8", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", _fake_getaddrinfo)
+
+
+def _mock_client_patch(monkeypatch, handler):
+    """Patch httpx.AsyncClient so the executor uses a MockTransport.
+
+    The executor builds its own AsyncClient; we wrap the constructor to
+    inject ``transport=MockTransport(handler)`` while preserving the
+    follow_redirects=False / timeout settings the executor passes.
+    """
+    real_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(action_executor.httpx, "AsyncClient", _factory)
+
+
+def _write_action(method: str = "POST", path: str = "/leases/42/renew") -> dict:
+    """A minimal, well-formed raw action dict."""
+    return {"kind": "write_binding", "method": method, "path": path, "params": {}}
+
+
+def _allow(method: str = "POST", pattern: str = "/leases/*/renew") -> list[dict]:
+    """A one-rule write allowlist."""
+    return [{"method": method, "path_pattern": pattern}]
+
+
+# ---------------------------------------------------------------------------
+# ActionBinding parsing
+# ---------------------------------------------------------------------------
+
+
+def test_action_binding_parses_minimal():
+    binding = ActionBinding.model_validate(_write_action())
+    assert binding.kind == "write_binding"
+    assert binding.method == "POST"
+    assert binding.path == "/leases/42/renew"
+    assert binding.params == {}
+    assert binding.confirm is False
+    assert binding.on_success == []
+    assert binding.on_error == []
+
+
+def test_action_binding_ignores_m2b_governance_fields():
+    """`requires_instinct` / `instinct_policy` / `outcome` are M2b fields —
+    ActionBinding ignores them on parse (extra: ignore) so an M2b-authored
+    spec stays parseable by the M2a runtime."""
+    raw = {
+        **_write_action(),
+        "requires_instinct": True,
+        "instinct_policy": "approve_per_row",
+        "outcome": "renewal_completed",
+    }
+    binding = ActionBinding.model_validate(raw)
+    # The governance fields are dropped, not declared on the model.
+    assert not hasattr(binding, "requires_instinct")
+    assert "requires_instinct" not in binding.model_dump()
+    assert "outcome" not in binding.model_dump()
+
+
+def test_action_binding_rejects_non_write_verb():
+    with pytest.raises(Exception):
+        ActionBinding.model_validate({"method": "GET", "path": "/x"})
+
+
+# ---------------------------------------------------------------------------
+# Instinct-reject (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+async def test_instinct_required_rejects_before_any_call(monkeypatch):
+    """A truthy raw `requires_instinct` is rejected with code
+    `instinct_required` and NO HTTP call is made."""
+    called = {"hit": False}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["hit"] = True
+        return httpx.Response(200, json={})
+
+    _mock_client_patch(monkeypatch, handler)
+
+    raw = {**_write_action(), "requires_instinct": True}
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="mark_renewed",
+        raw_action=raw,
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "instinct_required"
+    assert called["hit"] is False
+
+
+async def test_instinct_policy_alone_does_not_reject(monkeypatch):
+    """`instinct_policy` without a truthy `requires_instinct` does NOT
+    trigger the fail-closed gate — only `requires_instinct` does."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
+    raw = {**_write_action(), "instinct_policy": "approve_per_row"}
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="mark_renewed",
+        raw_action=raw,
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert result["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Allowlist matrix
+# ---------------------------------------------------------------------------
+
+
+async def test_allowlist_happy_match(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"renewed": True}))
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="mark_renewed",
+        raw_action=_write_action("POST", "/leases/42/renew"),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/leases/*/renew"),
+    )
+    assert result["ok"] is True
+    assert result["response"] == {"renewed": True}
+
+
+async def test_allowlist_method_mismatch_rejected(monkeypatch):
+    """A DELETE action against a POST-only allowlist is rejected — no call."""
+    called = {"hit": False}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["hit"] = True
+        return httpx.Response(200, json={})
+
+    _mock_client_patch(monkeypatch, handler)
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="del",
+        raw_action=_write_action("DELETE", "/leases/42/renew"),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/leases/*/renew"),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "not_allowed"
+    assert called["hit"] is False
+
+
+async def test_allowlist_path_mismatch_rejected(monkeypatch):
+    """A path that no pattern covers is rejected — no call."""
+    called = {"hit": False}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["hit"] = True
+        return httpx.Response(200, json={})
+
+    _mock_client_patch(monkeypatch, handler)
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="del",
+        raw_action=_write_action("POST", "/users/9/delete"),
+        path="/users/9/delete",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/leases/*/renew"),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "not_allowed"
+    assert called["hit"] is False
+
+
+async def test_allowlist_strips_query_before_match(monkeypatch):
+    """A `?x=y` on the resolved path must not defeat a `/leases/*` pattern —
+    the query is stripped before the allowlist check."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="patch",
+        raw_action=_write_action("PATCH", "/leases/42?notify=true"),
+        path="/leases/42?notify=true",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("PATCH", "/leases/*"),
+    )
+    assert result["ok"] is True
+
+
+async def test_allowlist_empty_rejects_everything(monkeypatch):
+    """Fail-closed: an empty allowlist matches nothing — no write fires."""
+    called = {"hit": False}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["hit"] = True
+        return httpx.Response(200, json={})
+
+    _mock_client_patch(monkeypatch, handler)
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="mark_renewed",
+        raw_action=_write_action(),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=[],
+    )
+    assert result["ok"] is False
+    assert result["code"] == "not_allowed"
+    assert called["hit"] is False
+
+
+async def test_allowlist_literal_star_in_path_does_not_match_concrete_pattern(monkeypatch):
+    """A hallucinated path that literally contains `*` must NOT match a
+    concrete (glob-free) allowlist pattern. fnmatchcase treats the pattern
+    as the glob and the path as a literal — a literal `*` in the path is
+    just a character that the concrete pattern cannot match."""
+    called = {"hit": False}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["hit"] = True
+        return httpx.Response(200, json={})
+
+    _mock_client_patch(monkeypatch, handler)
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="weird",
+        raw_action=_write_action("POST", "/leases/*/renew"),
+        path="/leases/*/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        # Concrete pattern, no glob — only matches the exact string.
+        allowed_writes=_allow("POST", "/leases/42/renew"),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "not_allowed"
+    assert called["hit"] is False
+
+
+# ---------------------------------------------------------------------------
+# SSRF guards on the write path
+# ---------------------------------------------------------------------------
+
+
+async def test_dotdot_traversal_rejected(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="a",
+        raw_action=_write_action("POST", "/a/../../etc/passwd"),
+        path="/a/../../etc/passwd",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/*"),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "bad_path"
+
+
+async def test_absolute_url_path_rejected(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="a",
+        raw_action=_write_action("POST", "https://evil.com/x"),
+        path="https://evil.com/x",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/*"),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "bad_path"
+
+
+async def test_internal_base_url_rejected(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="a",
+        raw_action=_write_action("POST", "/x"),
+        path="/x",
+        params={},
+        base_url="http://127.0.0.1",
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/x"),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "bad_base_url"
+
+
+async def test_host_resolving_internal_rejected(monkeypatch):
+    """DNS rebinding guard — a public name resolving to a private IP."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
+
+    def _internal_getaddrinfo(host, *_a, **_k):
+        return [(2, 1, 6, "", ("169.254.169.254", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", _internal_getaddrinfo)
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="a",
+        raw_action=_write_action("POST", "/x"),
+        path="/x",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/x"),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "bad_host"
+
+
+async def test_redirect_is_an_error(monkeypatch):
+    """A 3xx is treated as an error — redirects are never followed."""
+    _mock_client_patch(
+        monkeypatch,
+        lambda r: httpx.Response(302, headers={"location": "https://evil.com/x"}),
+    )
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="a",
+        raw_action=_write_action("POST", "/leases/42/renew"),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/leases/*/renew"),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "redirect"
+
+
+async def test_oversize_response_rejected(monkeypatch):
+    big = json.dumps([{"x": "a" * 1000}] * 600)  # > 512 KB
+    assert len(big.encode()) > action_executor._MAX_RESPONSE_BYTES
+
+    _mock_client_patch(
+        monkeypatch,
+        lambda r: httpx.Response(200, content=big, headers={"content-type": "application/json"}),
+    )
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="a",
+        raw_action=_write_action("POST", "/leases/42/renew"),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/leases/*/renew"),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "too_large"
+
+
+# ---------------------------------------------------------------------------
+# Rate limit — write counter isolated from the read counter
+# ---------------------------------------------------------------------------
+
+
+async def test_write_rate_limit_breach(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
+
+    async def _one():
+        return await run_action(
+            pocket_id="p-rl",
+            user_id="u1",
+            action="a",
+            raw_action=_write_action(),
+            path="/leases/42/renew",
+            params={},
+            base_url=BASE,
+            auth_type="none",
+            auth_header=None,
+            token="",
+            allowed_writes=_allow(),
+        )
+
+    for _ in range(action_executor._ACTION_RATE_LIMIT_MAX):
+        assert (await _one())["ok"] is True
+    breach = await _one()
+    assert breach["ok"] is False
+    assert breach["code"] == "rate_limited"
+
+
+async def test_write_rate_limit_isolated_from_read_budget(monkeypatch):
+    """Burning the READ budget for (pocket, user) must not drain the WRITE
+    budget for the same key, and vice versa — the counters are separate
+    dicts."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
+
+    # Drain the WRITE budget fully.
+    for _ in range(action_executor._ACTION_RATE_LIMIT_MAX):
+        await run_action(
+            pocket_id="shared",
+            user_id="u1",
+            action="a",
+            raw_action=_write_action(),
+            path="/leases/42/renew",
+            params={},
+            base_url=BASE,
+            auth_type="none",
+            auth_header=None,
+            token="",
+            allowed_writes=_allow(),
+        )
+    breach = await run_action(
+        pocket_id="shared",
+        user_id="u1",
+        action="a",
+        raw_action=_write_action(),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert breach["code"] == "rate_limited"
+
+    # The READ budget for the SAME (pocket, user) is untouched.
+    assert source_executor._run_log.get(("shared", "u1")) in (None, [])
+    assert not await source_executor._rate_limited("shared", "u1")
+
+
+async def test_read_budget_does_not_drain_write_budget(monkeypatch):
+    """The reverse: exhausting the read counter leaves the write counter
+    with its full budget."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
+
+    # Drain the READ counter for (pocket, user) directly.
+    for _ in range(source_executor._RATE_LIMIT_MAX):
+        await source_executor._rate_limited("shared2", "u1")
+    assert await source_executor._rate_limited("shared2", "u1")
+
+    # A write for the same key still goes through — separate counter.
+    result = await run_action(
+        pocket_id="shared2",
+        user_id="u1",
+        action="a",
+        raw_action=_write_action(),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert result["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Idempotency-Key header
+# ---------------------------------------------------------------------------
+
+
+async def test_idempotency_key_generated_when_omitted(monkeypatch):
+    """When the client omits a key the executor sends a generated one."""
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["key"] = request.headers.get("idempotency-key")
+        return httpx.Response(200, json={"ok": 1})
+
+    _mock_client_patch(monkeypatch, handler)
+    await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="a",
+        raw_action=_write_action(),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert seen["key"]
+    assert len(seen["key"]) >= 16
+
+
+async def test_client_supplied_idempotency_key_is_honored(monkeypatch):
+    """A client-supplied key is sent verbatim — a write retried after a
+    timeout carries the SAME key so the backend can dedupe it."""
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["key"] = request.headers.get("idempotency-key")
+        return httpx.Response(200, json={"ok": 1})
+
+    _mock_client_patch(monkeypatch, handler)
+    await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="a",
+        raw_action=_write_action(),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+        idempotency_key="client-key-123",
+    )
+    assert seen["key"] == "client-key-123"
+
+
+# ---------------------------------------------------------------------------
+# Happy path — body + on_success
+# ---------------------------------------------------------------------------
+
+
+async def test_happy_path_sends_params_and_carries_on_success(monkeypatch):
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        seen["body"] = json.loads(request.content) if request.content else None
+        return httpx.Response(201, json={"id": 42, "status": "renewed"})
+
+    _mock_client_patch(monkeypatch, handler)
+    raw = {
+        **_write_action("POST", "/leases/42/renew"),
+        "params": {"proposed_rent": 2000},
+        "on_success": [{"action": "run_source", "source": "leases"}],
+        "on_error": [{"action": "toast", "variant": "error"}],
+    }
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="mark_renewed",
+        raw_action=raw,
+        path="/leases/42/renew",
+        params={"proposed_rent": 2000},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/leases/*/renew"),
+    )
+    assert result["ok"] is True
+    assert result["status"] == 201
+    assert result["response"] == {"id": 42, "status": "renewed"}
+    assert result["on_success"] == [{"action": "run_source", "source": "leases"}]
+    assert result["on_error"] == [{"action": "toast", "variant": "error"}]
+    assert seen["method"] == "POST"
+    assert seen["body"] == {"proposed_rent": 2000}
+
+
+async def test_backend_4xx_becomes_http_error(monkeypatch):
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(422, json={"err": "bad"}))
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="a",
+        raw_action=_write_action(),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "http_error"
+
+
+async def test_malformed_binding_is_bad_binding(monkeypatch):
+    """A raw action missing `method` is a `bad_binding` rejection."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={}))
+    result = await run_action(
+        pocket_id="p1",
+        user_id="u1",
+        action="a",
+        raw_action={"kind": "write_binding", "path": "/x"},  # no method
+        path="/x",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/x"),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "bad_binding"

--- a/tests/cloud/test_pocket_actions_lift.py
+++ b/tests/cloud/test_pocket_actions_lift.py
@@ -1,0 +1,209 @@
+# tests/cloud/test_pocket_actions_lift.py — RFC 05 M2a.
+# Created: 2026-05-22 — pins the deterministic translation the spec
+# normalizer applies to the pocket-authoring agent's hallucinated WRITE
+# output. The agent emits a write the same way it emits a read: an inline
+# `{action: "api", method: "POST", url: "/x", body: {...}}` handler instead
+# of a `rippleSpec.actions` write binding triggered by `call_binding`.
+# `normalize_ripple_spec` lifts a RELATIVE-url inline write into the
+# `actions` block and rewrites the handler to `call_binding`.
+#
+# What this pins:
+#   - a relative-url inline `api` POST handler -> rippleSpec.actions entry
+#     + a call_binding handler.
+#   - an ABSOLUTE-url `api` handler is left as `api` (third-party intent —
+#     never redirected onto the credentialed backend).
+#   - a GET `api` handler is left alone (not a write).
+#   - a correctly-authored `actions` block passes through unchanged.
+#   - a call_binding handler wired with the wrong field name is repaired.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec
+
+
+def test_relative_inline_write_api_is_lifted_into_actions():
+    """An inline `{action:"api", method:"POST", url:<relative>}` handler is
+    lifted into `rippleSpec.actions` and the handler becomes a
+    `call_binding`."""
+    spec = {
+        "title": "Lease Tracker",
+        "version": "1.0",
+        "state": {"form": {"rent": ""}},
+        "ui": {
+            "type": "flex",
+            "children": [
+                {
+                    "type": "button",
+                    "props": {"label": "Renew"},
+                    "on_click": {
+                        "action": "api",
+                        "method": "POST",
+                        "url": "/leases/42/renew",
+                        "body": {"proposed_rent": "{state.form.rent}"},
+                    },
+                }
+            ],
+        },
+    }
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+
+    actions = normalized.get("actions")
+    assert isinstance(actions, dict)
+    assert len(actions) == 1
+    entry = next(iter(actions.values()))
+    assert entry["kind"] == "write_binding"
+    assert entry["method"] == "POST"
+    assert entry["path"] == "/leases/42/renew"
+    assert entry["params"] == {"proposed_rent": "{state.form.rent}"}
+
+    # The handler is rewritten to call_binding pointing at the lifted name.
+    handler = normalized["ui"]["children"][0]["on_click"]
+    assert handler["action"] == "call_binding"
+    assert handler["binding"] == next(iter(actions.keys()))
+
+
+def test_absolute_url_inline_api_is_left_untouched():
+    """An ABSOLUTE-url `api` call is a different (third-party) intent and
+    must NEVER be redirected onto the pocket's credentialed backend."""
+    spec = {
+        "title": "Third Party",
+        "version": "1.0",
+        "state": {},
+        "ui": {
+            "type": "flex",
+            "children": [
+                {
+                    "type": "button",
+                    "props": {"label": "Notify"},
+                    "on_click": {
+                        "action": "api",
+                        "method": "POST",
+                        "url": "https://hooks.thirdparty.example/notify",
+                        "body": {"msg": "hi"},
+                    },
+                }
+            ],
+        },
+    }
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+    # No actions block created; the handler is unchanged.
+    assert "actions" not in normalized
+    handler = normalized["ui"]["children"][0]["on_click"]
+    assert handler["action"] == "api"
+    assert handler["url"] == "https://hooks.thirdparty.example/notify"
+
+
+def test_get_inline_api_is_not_lifted_as_a_write():
+    """A GET `api` handler is a read, not a write — not lifted into
+    `actions`."""
+    spec = {
+        "title": "Reader",
+        "version": "1.0",
+        "state": {},
+        "ui": {
+            "type": "flex",
+            "children": [
+                {
+                    "type": "button",
+                    "props": {"label": "Fetch"},
+                    "on_click": {"action": "api", "method": "GET", "url": "/leases"},
+                }
+            ],
+        },
+    }
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+    assert "actions" not in normalized
+    assert normalized["ui"]["children"][0]["on_click"]["action"] == "api"
+
+
+def test_correctly_authored_actions_block_passes_through():
+    """A spec already using `rippleSpec.actions` + `call_binding` is not
+    mutated."""
+    good = {
+        "title": "Good",
+        "version": "1.0",
+        "actions": {
+            "mark_renewed": {
+                "kind": "write_binding",
+                "method": "POST",
+                "path": "/leases/{item.id}/renew",
+                "params": {},
+                "confirm": False,
+            }
+        },
+        "state": {},
+        "ui": {
+            "type": "flex",
+            "children": [
+                {
+                    "type": "button",
+                    "props": {"label": "Renew"},
+                    "on_click": {"action": "call_binding", "binding": "mark_renewed"},
+                }
+            ],
+        },
+    }
+    normalized = normalize_ripple_spec(good)
+    assert normalized is not None
+    assert normalized["actions"] == good["actions"]
+    handler = normalized["ui"]["children"][0]["on_click"]
+    assert handler == {"action": "call_binding", "binding": "mark_renewed"}
+
+
+def test_call_binding_wrong_field_name_is_repaired():
+    """A call_binding handler that names its target with `action_id` /
+    `name` is repaired to `binding`."""
+    spec = {
+        "title": "Misnamed",
+        "version": "1.0",
+        "actions": {"mark_renewed": {"kind": "write_binding", "method": "POST", "path": "/x"}},
+        "state": {},
+        "ui": {
+            "type": "flex",
+            "children": [
+                {
+                    "type": "button",
+                    "props": {"label": "Renew"},
+                    "on_click": {"action": "call_binding", "action_id": "mark_renewed"},
+                }
+            ],
+        },
+    }
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+    handler = normalized["ui"]["children"][0]["on_click"]
+    assert handler["binding"] == "mark_renewed"
+    assert "action_id" not in handler
+
+
+def test_lifted_name_skips_existing_action_keys():
+    """A lifted entry gets a fresh `act_N` name that does not clobber an
+    already-authored action."""
+    spec = {
+        "title": "Mixed",
+        "version": "1.0",
+        "actions": {"act_1": {"kind": "write_binding", "method": "POST", "path": "/existing"}},
+        "state": {},
+        "ui": {
+            "type": "flex",
+            "children": [
+                {
+                    "type": "button",
+                    "props": {"label": "Do"},
+                    "on_click": {"action": "api", "method": "DELETE", "url": "/rows/9"},
+                }
+            ],
+        },
+    }
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+    actions = normalized["actions"]
+    # The pre-existing act_1 survives; the lifted entry took a fresh name.
+    assert actions["act_1"]["path"] == "/existing"
+    assert len(actions) == 2
+    lifted_name = normalized["ui"]["children"][0]["on_click"]["binding"]
+    assert lifted_name != "act_1"
+    assert actions[lifted_name]["method"] == "DELETE"

--- a/tests/cloud/test_pocket_actions_ops.py
+++ b/tests/cloud/test_pocket_actions_ops.py
@@ -1,0 +1,463 @@
+# test_pocket_actions_ops.py — Tests for the edit-specialist `actions` ops.
+# Created: 2026-05-22 (RFC 05 M2a) — the write-action sibling of
+#   test_pocket_sources_ops.py. Covers the pure `actions_ops` helpers, the
+#   service-layer `agent_set_action` / `agent_remove_action` functions
+#   (happy path, invalid-binding rejection, governance-field carry-through,
+#   persistence, emitted mutation), the `set_action` / `remove_action`
+#   agent_context wrappers + edit-tool factories, and the owner-only
+#   `set_pocket_write_policy` service function.
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pocketpaw_ee.cloud.pockets import actions_ops, agent_context
+from pocketpaw_ee.cloud.pockets import service as pocket_service
+
+# ---------------------------------------------------------------------------
+# Fake doc + patch helper (mirrors test_pocket_sources_ops.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeDoc:
+    """Minimum surface to stand in for a ``_PocketDoc``. Mutations operate
+    on ``self.rippleSpec`` in place; ``save()`` is an async no-op counted
+    via ``saves``."""
+
+    def __init__(self, pocket_id: str, ripple_spec: dict[str, Any]):
+        self.id = pocket_id
+        self.workspace = "w1"
+        self.name = "Test"
+        self.description = ""
+        self.type = "custom"
+        self.icon = ""
+        self.color = ""
+        self.owner = "u1"
+        self.visibility = "workspace"
+        self.team: list[str] = []
+        self.agents: list[str] = []
+        self.widgets: list[Any] = []
+        self.rippleSpec = ripple_spec
+        self.share_link_token = None
+        self.share_link_access = "view"
+        self.shared_with: list[str] = []
+        self.tool_specs: list[Any] = []
+        self.saves = 0
+
+    async def save(self) -> None:
+        self.saves += 1
+
+    def model_dump(self, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "_id": self.id,
+            "workspace": self.workspace,
+            "rippleSpec": self.rippleSpec,
+            "owner": self.owner,
+        }
+
+
+@pytest.fixture
+def fake_doc() -> _FakeDoc:
+    """A persisted pocket with a UI tree + seeded state but NO actions."""
+    return _FakeDoc(
+        "507f1f77bcf86cd799439011",
+        {
+            "version": "1.0",
+            "state": {"leases": []},
+            "ui": {"id": "n_root0000", "type": "flex", "children": []},
+        },
+    )
+
+
+def _patches(doc: _FakeDoc):
+    """Patch the doc fetch + emit/push seams + identity ContextVars.
+    Returns ``(ExitStack, push_calls)``."""
+    push_calls: list[dict[str, Any]] = []
+
+    def _capture(payload: dict[str, Any]) -> None:
+        push_calls.append(payload)
+
+    stack = ExitStack()
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service._PocketDoc.get",
+            new=AsyncMock(return_value=doc),
+        )
+    )
+    stack.enter_context(patch("pocketpaw_ee.cloud.pockets.service.emit", new=AsyncMock()))
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service._pocket_event_payload",
+            new=AsyncMock(return_value={"pocket_id": doc.id}),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.push_pocket_mutation",
+            new=MagicMock(side_effect=_capture),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service.normalize_ripple_spec",
+            new=lambda s: s,
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+            new=MagicMock(return_value=doc.workspace),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+            new=MagicMock(return_value=doc.owner),
+        )
+    )
+    return stack, push_calls
+
+
+_VALID_BINDING = {
+    "kind": "write_binding",
+    "method": "POST",
+    "path": "/leases/{item.id}/renew",
+    "params": {"proposed_rent": "{state.form.rent}"},
+    "confirm": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Pure ops — actions_ops.set_action / remove_action
+# ---------------------------------------------------------------------------
+
+
+def test_set_action_creates_actions_dict_when_absent():
+    spec: dict[str, Any] = {"ui": {}, "state": {}}
+    out = actions_ops.set_action(spec, "mark_renewed", dict(_VALID_BINDING))
+    assert out is spec
+    assert spec["actions"]["mark_renewed"] == _VALID_BINDING
+
+
+def test_set_action_adds_alongside_existing_actions():
+    spec = {"actions": {"a": dict(_VALID_BINDING)}}
+    actions_ops.set_action(spec, "b", dict(_VALID_BINDING))
+    assert set(spec["actions"]) == {"a", "b"}
+
+
+def test_set_action_overwrites_existing_key():
+    spec = {"actions": {"mark_renewed": {"method": "PATCH", "path": "/old"}}}
+    actions_ops.set_action(spec, "mark_renewed", dict(_VALID_BINDING))
+    assert spec["actions"]["mark_renewed"]["path"] == "/leases/{item.id}/renew"
+
+
+def test_set_action_requires_a_key():
+    with pytest.raises(ValueError, match="action key"):
+        actions_ops.set_action({}, "", dict(_VALID_BINDING))
+
+
+def test_set_action_rejects_malformed_actions_block():
+    """An `actions` value that is not a dict is a malformed spec — refuse
+    to append rather than overwrite it."""
+    with pytest.raises(ValueError, match="expected an object"):
+        actions_ops.set_action({"actions": ["bad"]}, "x", dict(_VALID_BINDING))
+
+
+def test_remove_action_drops_the_key():
+    spec = {"actions": {"a": dict(_VALID_BINDING), "b": dict(_VALID_BINDING)}}
+    actions_ops.remove_action(spec, "a")
+    assert "a" not in spec["actions"]
+    assert "b" in spec["actions"]
+
+
+def test_remove_action_is_a_noop_when_key_absent():
+    spec = {"actions": {"a": dict(_VALID_BINDING)}}
+    out = actions_ops.remove_action(spec, "nope")
+    assert out is spec
+    assert "a" in spec["actions"]
+
+
+def test_remove_action_is_a_noop_when_actions_absent():
+    spec: dict[str, Any] = {"ui": {}}
+    out = actions_ops.remove_action(spec, "a")
+    assert out is spec
+    assert "actions" not in spec
+
+
+# ---------------------------------------------------------------------------
+# Service layer — agent_set_action
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_set_action_adds_actions_block_to_existing_pocket(fake_doc):
+    """An EXISTING persisted pocket with no ``rippleSpec.actions`` gains a
+    write binding when the edit specialist calls ``agent_set_action``."""
+    ctx, _ = _patches(fake_doc)
+    with ctx:
+        result, err = await pocket_service.agent_set_action(
+            fake_doc.id, action_key="mark_renewed", binding=dict(_VALID_BINDING)
+        )
+    assert err is None
+    assert result is not None
+    assert fake_doc.rippleSpec["actions"]["mark_renewed"]["method"] == "POST"
+    assert fake_doc.rippleSpec["actions"]["mark_renewed"]["path"] == "/leases/{item.id}/renew"
+    assert fake_doc.saves == 1
+
+
+async def test_agent_set_action_returns_view_with_binding(fake_doc):
+    ctx, _ = _patches(fake_doc)
+    with ctx:
+        result, err = await pocket_service.agent_set_action(
+            fake_doc.id, action_key="mark_renewed", binding=dict(_VALID_BINDING)
+        )
+    assert err is None
+    assert result is not None
+    assert result["action_key"] == "mark_renewed"
+    assert result["binding"]["method"] == "POST"
+    assert result["pocket"]["rippleSpec"]["actions"]["mark_renewed"]["confirm"] is False
+
+
+async def test_agent_set_action_rejects_invalid_binding(fake_doc):
+    """A binding missing ``method`` is rejected via the ``ActionBinding``
+    model before any write happens."""
+    ctx, push_calls = _patches(fake_doc)
+    with ctx:
+        result, err = await pocket_service.agent_set_action(
+            fake_doc.id, action_key="bad", binding={"kind": "write_binding", "path": "/x"}
+        )
+    assert result is None
+    assert err is not None
+    assert "binding" in err.lower()
+    assert "actions" not in fake_doc.rippleSpec
+    assert fake_doc.saves == 0
+    assert not push_calls
+
+
+async def test_agent_set_action_rejects_read_verb(fake_doc):
+    """``method`` is a write-verb Literal — a GET binding is rejected."""
+    ctx, _ = _patches(fake_doc)
+    bad = dict(_VALID_BINDING, method="GET")
+    with ctx:
+        result, err = await pocket_service.agent_set_action(
+            fake_doc.id, action_key="bad", binding=bad
+        )
+    assert result is None
+    assert err is not None
+
+
+async def test_agent_set_action_requires_a_key(fake_doc):
+    ctx, _ = _patches(fake_doc)
+    with ctx:
+        result, err = await pocket_service.agent_set_action(
+            fake_doc.id, action_key="", binding=dict(_VALID_BINDING)
+        )
+    assert result is None
+    assert err is not None
+    assert "action_key" in err
+
+
+async def test_agent_set_action_carries_governance_fields_through(fake_doc):
+    """M2b governance fields (``requires_instinct`` / ``outcome``) are
+    CARRIED THROUGH on the persisted binding even though ``ActionBinding``
+    ignores them on parse — an M2b-aware client can author them now."""
+    ctx, _ = _patches(fake_doc)
+    binding = {
+        **_VALID_BINDING,
+        "requires_instinct": True,
+        "outcome": "renewal_completed",
+    }
+    with ctx:
+        result, err = await pocket_service.agent_set_action(
+            fake_doc.id, action_key="mark_renewed", binding=binding
+        )
+    assert err is None
+    stored = fake_doc.rippleSpec["actions"]["mark_renewed"]
+    assert stored["requires_instinct"] is True
+    assert stored["outcome"] == "renewal_completed"
+    # The validated core fields are still present.
+    assert stored["method"] == "POST"
+
+
+# ---------------------------------------------------------------------------
+# Service layer — agent_remove_action
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_remove_action_drops_the_binding():
+    doc = _FakeDoc(
+        "507f1f77bcf86cd799439022",
+        {
+            "version": "1.0",
+            "actions": {"mark_renewed": dict(_VALID_BINDING)},
+            "state": {},
+            "ui": {"id": "n_root0000", "type": "flex"},
+        },
+    )
+    ctx, _ = _patches(doc)
+    with ctx:
+        result, err = await pocket_service.agent_remove_action(doc.id, action_key="mark_renewed")
+    assert err is None
+    assert result is not None
+    assert "mark_renewed" not in doc.rippleSpec.get("actions", {})
+    assert doc.saves == 1
+
+
+async def test_agent_remove_action_noop_when_absent(fake_doc):
+    """Removing an action that was never declared still succeeds."""
+    ctx, _ = _patches(fake_doc)
+    with ctx:
+        result, err = await pocket_service.agent_remove_action(fake_doc.id, action_key="ghost")
+    assert err is None
+    assert result is not None
+    assert fake_doc.saves == 1
+
+
+# ---------------------------------------------------------------------------
+# agent_context wrappers
+# ---------------------------------------------------------------------------
+
+
+async def test_set_action_for_agent_returns_ok_shape(fake_doc):
+    ctx, push_calls = _patches(fake_doc)
+    with ctx:
+        result = await agent_context.set_action_for_agent(
+            fake_doc.id, "mark_renewed", dict(_VALID_BINDING)
+        )
+    assert result["ok"] is True
+    assert fake_doc.rippleSpec["actions"]["mark_renewed"]["method"] == "POST"
+    assert push_calls[0]["action"] == "replace"
+
+
+async def test_set_action_for_agent_surfaces_error(fake_doc):
+    ctx, _ = _patches(fake_doc)
+    with ctx:
+        result = await agent_context.set_action_for_agent(
+            fake_doc.id, "bad", {"kind": "write_binding", "path": "/x"}
+        )
+    assert result["ok"] is False
+    assert "error" in result
+
+
+async def test_remove_action_for_agent_returns_ok_shape():
+    doc = _FakeDoc(
+        "507f1f77bcf86cd799439033",
+        {"version": "1.0", "actions": {"mark_renewed": dict(_VALID_BINDING)}, "ui": {}},
+    )
+    ctx, _ = _patches(doc)
+    with ctx:
+        result = await agent_context.remove_action_for_agent(doc.id, "mark_renewed")
+    assert result["ok"] is True
+    assert "mark_renewed" not in doc.rippleSpec.get("actions", {})
+
+
+# ---------------------------------------------------------------------------
+# Edit tool factories
+# ---------------------------------------------------------------------------
+
+
+async def test_action_tools_registered_in_edit_toolset():
+    from pocketpaw_ee.agent.pocket_specialist.tools import make_edit_pocket_tools
+
+    tools = make_edit_pocket_tools(pocket_id="507f1f77bcf86cd799439011")
+    names = {t.name for t in tools}
+    assert "set_action" in names
+    assert "remove_action" in names
+
+
+async def test_set_action_tool_runs_and_captures_op(fake_doc):
+    from pocketpaw_ee.agent.pocket_specialist.tools import make_set_action_tool
+
+    capture: dict[str, Any] = {}
+    tool = make_set_action_tool(pocket_id=fake_doc.id, capture=capture)
+    ctx, _ = _patches(fake_doc)
+    with ctx:
+        result = await tool.coroutine(
+            action_key="mark_renewed",
+            method="post",  # lower-case — the tool upper-cases it
+            path="/leases/{item.id}/renew",
+            params={"proposed_rent": "{state.form.rent}"},
+            confirm=False,
+            on_success=[{"action": "run_source", "source": "leases"}],
+        )
+    assert result["ok"] is True
+    stored = fake_doc.rippleSpec["actions"]["mark_renewed"]
+    assert stored["method"] == "POST"
+    assert stored["on_success"] == [{"action": "run_source", "source": "leases"}]
+    assert capture["ops"][0]["op"] == "set_action"
+
+
+async def test_remove_action_tool_runs_and_captures_op():
+    from pocketpaw_ee.agent.pocket_specialist.tools import make_remove_action_tool
+
+    doc = _FakeDoc(
+        "507f1f77bcf86cd799439044",
+        {"version": "1.0", "actions": {"mark_renewed": dict(_VALID_BINDING)}, "ui": {}},
+    )
+    capture: dict[str, Any] = {}
+    tool = make_remove_action_tool(pocket_id=doc.id, capture=capture)
+    ctx, _ = _patches(doc)
+    with ctx:
+        result = await tool.coroutine(action_key="mark_renewed")
+    assert result["ok"] is True
+    assert "mark_renewed" not in doc.rippleSpec.get("actions", {})
+    assert capture["ops"][0]["op"] == "remove_action"
+
+
+# ---------------------------------------------------------------------------
+# Service layer — set_pocket_write_policy (owner-only, needs a backend)
+# ---------------------------------------------------------------------------
+
+
+async def test_set_write_policy_persists_allowlist(mongo_db):
+    """Setting the policy on a pocket with a backend stores the allowlist
+    and the executor/summary then carry it."""
+    await pocket_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+    result = await pocket_service.set_pocket_write_policy(
+        "w1",
+        "u1",
+        "pocket-1",
+        [{"method": "POST", "path_pattern": "/leases/*/renew"}],
+    )
+    assert result["allowed_writes"] == [{"method": "POST", "path_pattern": "/leases/*/renew"}]
+    # The executor tuple now carries the same allowlist.
+    creds = await pocket_service.get_pocket_backend_for_executor("w1", "pocket-1")
+    assert creds is not None
+    assert creds[4] == [{"method": "POST", "path_pattern": "/leases/*/renew"}]
+
+
+async def test_set_write_policy_empty_list_revokes_all(mongo_db):
+    """An empty list is valid and revokes every write (fail-closed)."""
+    await pocket_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+    await pocket_service.set_pocket_write_policy(
+        "w1", "u1", "pocket-1", [{"method": "POST", "path_pattern": "/x"}]
+    )
+    result = await pocket_service.set_pocket_write_policy("w1", "u1", "pocket-1", [])
+    assert result["allowed_writes"] == []
+
+
+async def test_set_write_policy_rejects_when_no_backend(mongo_db):
+    """A write policy with no backend to apply to is meaningless — the
+    service rejects it rather than storing a dangling policy."""
+    from pocketpaw_ee.cloud.shared.errors import ValidationError
+
+    with pytest.raises(ValidationError):
+        await pocket_service.set_pocket_write_policy(
+            "w1", "u1", "no-backend-pocket", [{"method": "POST", "path_pattern": "/x"}]
+        )

--- a/tests/cloud/test_pocket_agent_backend_view.py
+++ b/tests/cloud/test_pocket_agent_backend_view.py
@@ -7,6 +7,11 @@
 #   `backend` summary ({base_url, auth_type, configured}), and that the
 #   token NEVER reaches agent context.
 #
+# Updated: 2026-05-22 (RFC 05 M2a) — the backend summary gained an
+#   `allowed_writes` key (the per-pocket write allowlist — a non-secret
+#   the edit specialist needs to author write actions). Assertions updated
+#   to the new four-key shape.
+#
 # Exercises the real Beanie path against the in-memory mongomock-motor DB
 # (mongo_db fixture) with the w1/u1 SSE-stream identity (agent_identity).
 
@@ -99,6 +104,9 @@ async def test_agent_view_includes_configured_backend_summary(mongo_db, agent_id
         "base_url": "https://jsonplaceholder.typicode.com",
         "auth_type": "none",
         "configured": True,
+        # RFC 05 M2a: the summary now carries the write allowlist —
+        # empty by default (fail-closed).
+        "allowed_writes": [],
     }
 
 
@@ -125,8 +133,9 @@ async def test_agent_view_backend_summary_never_leaks_the_token(mongo_db, agent_
     backend = view["backend"]
     assert backend["configured"] is True
     assert backend["auth_type"] == "bearer"
-    # The summary carries only the three non-secret keys.
-    assert set(backend) == {"base_url", "auth_type", "configured"}
+    # The summary carries only non-secret keys (RFC 05 M2a adds
+    # `allowed_writes` — the write allowlist, also non-secret).
+    assert set(backend) == {"base_url", "auth_type", "configured", "allowed_writes"}
     # The token must not appear anywhere in the serialized view.
     import json
 
@@ -183,6 +192,8 @@ async def test_fetch_pocket_for_agent_carries_backend_summary(mongo_db, agent_id
         "base_url": "https://jsonplaceholder.typicode.com",
         "auth_type": "none",
         "configured": True,
+        # RFC 05 M2a: the summary now carries the write allowlist.
+        "allowed_writes": [],
     }
 
 

--- a/tests/cloud/test_pocket_backend_routes.py
+++ b/tests/cloud/test_pocket_backend_routes.py
@@ -15,6 +15,13 @@
 # Updated: 2026-05-21 (PR #1177 security pass) — added coverage for the
 # DELETE route, the edit-access guard on GET, and the user_id thread-through
 # on the source-run route.
+#
+# Updated: 2026-05-22 (RFC 05 M2a) — the executor-creds tuple gained a
+# trailing `allowed_writes` element and the backend response carries the
+# write allowlist; existing assertions updated. Added coverage for the two
+# new write-action routes:
+#   POST /pockets/{id}/actions/run        — run a declared write action
+#   PUT  /pockets/{id}/backend/write-policy — set the write allowlist
 
 from __future__ import annotations
 
@@ -27,6 +34,7 @@ from pocketpaw_ee.cloud.pockets.router import router
 from pocketpaw_ee.cloud.shared.deps import (
     current_user_id,
     current_workspace_id,
+    require_pocket_action_run,
     require_pocket_edit,
     require_pocket_owner,
 )
@@ -46,6 +54,7 @@ def app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
     a.dependency_overrides[require_license] = lambda: None
     a.dependency_overrides[require_pocket_edit] = lambda: None
     a.dependency_overrides[require_pocket_owner] = lambda: None
+    a.dependency_overrides[require_pocket_action_run] = lambda: None
     a.dependency_overrides[current_user_id] = lambda: FAKE_USER
     a.dependency_overrides[current_workspace_id] = lambda: FAKE_WORKSPACE
     return a
@@ -91,6 +100,9 @@ def test_put_backend_configures(monkeypatch, client):
         "base_url": "https://api.example.com",
         "auth_type": "bearer",
         "configured": True,
+        # RFC 05 M2a: the response now carries the write allowlist —
+        # empty by default (fail-closed).
+        "allowed_writes": [],
     }
     # The route forwarded the right identity + body to the service.
     assert captured["workspace_id"] == FAKE_WORKSPACE
@@ -214,7 +226,8 @@ def test_run_sources_happy_path(monkeypatch, client):
         return {"_id": pocket_id, "rippleSpec": spec}
 
     async def _get_creds(workspace_id, pocket_id):
-        return ("https://api.example.com", "bearer", None, "tok")
+        # RFC 05 M2a: 5-tuple — the trailing element is the write allowlist.
+        return ("https://api.example.com", "bearer", None, "tok", [])
 
     monkeypatch.setattr(pockets_service, "get", _get_pocket)
     monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _get_creds)
@@ -254,3 +267,192 @@ def test_run_sources_400_when_no_backend(monkeypatch, client):
 
     res = client.post("/pockets/pocket-1/sources/run", json={})
     assert res.status_code == 400, res.text
+
+
+# ---------------------------------------------------------------------------
+# PUT /pockets/{id}/backend/write-policy — RFC 05 M2a
+# ---------------------------------------------------------------------------
+
+
+def test_put_write_policy_sets_allowlist(monkeypatch, client):
+    captured = {}
+
+    async def _set_policy(workspace_id, user_id, pocket_id, allowed_writes):
+        captured.update(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            allowed_writes=allowed_writes,
+        )
+        return {
+            "base_url": "https://api.example.com",
+            "auth_type": "bearer",
+            "configured": True,
+            "allowed_writes": allowed_writes,
+        }
+
+    monkeypatch.setattr(pockets_service, "set_pocket_write_policy", _set_policy)
+
+    res = client.put(
+        "/pockets/pocket-1/backend/write-policy",
+        json={"allowed_writes": [{"method": "POST", "path_pattern": "/leases/*/renew"}]},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["allowed_writes"] == [{"method": "POST", "path_pattern": "/leases/*/renew"}]
+    # The route forwarded the right identity + rules to the service.
+    assert captured["pocket_id"] == "pocket-1"
+    assert captured["allowed_writes"] == [{"method": "POST", "path_pattern": "/leases/*/renew"}]
+
+
+def test_put_write_policy_rejects_bad_method(client):
+    """`method` is a write-verb Literal — GET is rejected at parse time."""
+    res = client.put(
+        "/pockets/pocket-1/backend/write-policy",
+        json={"allowed_writes": [{"method": "GET", "path_pattern": "/x"}]},
+    )
+    assert res.status_code == 422
+
+
+def test_put_write_policy_empty_list_is_valid(monkeypatch, client):
+    """An empty allowlist revokes every write — a valid request."""
+
+    async def _set_policy(workspace_id, user_id, pocket_id, allowed_writes):
+        return {
+            "base_url": "https://api.example.com",
+            "auth_type": "none",
+            "configured": True,
+            "allowed_writes": [],
+        }
+
+    monkeypatch.setattr(pockets_service, "set_pocket_write_policy", _set_policy)
+    res = client.put("/pockets/pocket-1/backend/write-policy", json={"allowed_writes": []})
+    assert res.status_code == 200, res.text
+    assert res.json()["allowed_writes"] == []
+
+
+# ---------------------------------------------------------------------------
+# POST /pockets/{id}/actions/run — RFC 05 M2a
+# ---------------------------------------------------------------------------
+
+
+def test_run_action_happy_path(monkeypatch, client):
+    """The route reads `method` server-side from the persisted action,
+    threads the resolved path/params + creds + allowlist to the executor,
+    and returns its result."""
+    spec = {
+        "actions": {
+            "mark_renewed": {
+                "kind": "write_binding",
+                "method": "POST",
+                "path": "/leases/{item.id}/renew",
+            }
+        }
+    }
+
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id, "rippleSpec": spec}
+
+    async def _get_creds(workspace_id, pocket_id):
+        return (
+            "https://api.example.com",
+            "bearer",
+            None,
+            "tok",
+            [{"method": "POST", "path_pattern": "/leases/*/renew"}],
+        )
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _get_creds)
+
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    captured = {}
+
+    async def _run_action(**kwargs):
+        captured.update(kwargs)
+        return {
+            "ok": True,
+            "action": kwargs["action"],
+            "status": 200,
+            "response": {"renewed": True},
+            "on_success": [],
+            "on_error": [],
+        }
+
+    monkeypatch.setattr(action_executor, "run_action", _run_action)
+
+    res = client.post(
+        "/pockets/pocket-1/actions/run",
+        json={"action": "mark_renewed", "path": "/leases/42/renew", "params": {"rent": 2000}},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ok"] is True
+    assert body["response"] == {"renewed": True}
+    # The executor saw the raw action (the server picks the verb), the
+    # resolved path/params, the creds, and the allowlist.
+    assert captured["raw_action"]["method"] == "POST"
+    assert captured["path"] == "/leases/42/renew"
+    assert captured["params"] == {"rent": 2000}
+    assert captured["allowed_writes"] == [{"method": "POST", "path_pattern": "/leases/*/renew"}]
+    assert captured["user_id"] == FAKE_USER
+
+
+def test_run_action_404_when_action_not_declared(monkeypatch, client):
+    """An action name not in the persisted spec returns an `ok:false`
+    body with code `action_not_found` — no executor call."""
+
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id, "rippleSpec": {"actions": {}}}
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+
+    res = client.post(
+        "/pockets/pocket-1/actions/run",
+        json={"action": "ghost", "path": "/x"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ok"] is False
+    assert body["code"] == "action_not_found"
+
+
+def test_run_action_400_when_no_backend(monkeypatch, client):
+    spec = {"actions": {"a": {"kind": "write_binding", "method": "POST", "path": "/x"}}}
+
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id, "rippleSpec": spec}
+
+    async def _no_creds(workspace_id, pocket_id):
+        return None
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _no_creds)
+
+    res = client.post("/pockets/pocket-1/actions/run", json={"action": "a", "path": "/x"})
+    assert res.status_code == 400, res.text
+
+
+def test_run_action_forbidden_for_non_invited(monkeypatch):
+    """The action-run gate is owner OR explicit shared_with ONLY — a
+    workspace-visible pocket does not grant access. The guard denies."""
+    from pocketpaw_ee.cloud._core.errors import Forbidden
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+
+    a = FastAPI()
+    add_error_handler(a)
+    a.include_router(router)
+    a.dependency_overrides[require_license] = lambda: None
+    a.dependency_overrides[require_pocket_edit] = lambda: None
+    a.dependency_overrides[require_pocket_owner] = lambda: None
+    a.dependency_overrides[current_user_id] = lambda: FAKE_USER
+    a.dependency_overrides[current_workspace_id] = lambda: FAKE_WORKSPACE
+
+    def _deny():
+        raise Forbidden("pocket.access_denied", "write-action access required")
+
+    a.dependency_overrides[require_pocket_action_run] = _deny
+
+    res = TestClient(a).post("/pockets/pocket-1/actions/run", json={"action": "a", "path": "/x"})
+    assert res.status_code == 403

--- a/tests/cloud/test_pocket_backend_routes.py
+++ b/tests/cloud/test_pocket_backend_routes.py
@@ -397,6 +397,9 @@ def test_run_action_happy_path(monkeypatch, client):
     assert captured["params"] == {"rent": 2000}
     assert captured["allowed_writes"] == [{"method": "POST", "path_pattern": "/leases/*/renew"}]
     assert captured["user_id"] == FAKE_USER
+    # The route threads `workspace_id` so the executor can tenant-tag its
+    # audit-log entries.
+    assert captured["workspace_id"]
 
 
 def test_run_action_404_when_action_not_declared(monkeypatch, client):

--- a/tests/cloud/test_pocket_backend_service.py
+++ b/tests/cloud/test_pocket_backend_service.py
@@ -5,6 +5,10 @@
 #
 # Updated: 2026-05-21 (PR #1177 security pass) — added coverage that
 # remove_pocket_backend writes an audit-log entry.
+# Updated: 2026-05-22 (RFC 05 M2a) — get_pocket_backend now carries an
+# `allowed_writes` list and get_pocket_backend_for_executor returns a
+# 5-tuple (the trailing element is the write allowlist). Assertions
+# updated to the new contract.
 #
 # What this pins:
 #   - set_pocket_backend then get_pocket_backend returns configured:true
@@ -46,10 +50,13 @@ async def test_set_then_get_backend(mongo_db):
     assert "token" not in result
 
     summary = await pockets_service.get_pocket_backend("w1", "pocket-1")
+    # RFC 05 M2a: the summary now also carries the write allowlist —
+    # empty by default (fail-closed). The token is still never present.
     assert summary == {
         "base_url": "https://api.example.com",
         "auth_type": "bearer",
         "configured": True,
+        "allowed_writes": [],
     }
     assert "token" not in summary
     assert "encrypted_token" not in summary
@@ -84,11 +91,12 @@ async def test_get_for_executor_decrypts_token(mongo_db):
     )
     creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
     assert creds is not None
-    base_url, auth_type, auth_header, token = creds
+    base_url, auth_type, auth_header, token, allowed_writes = creds
     assert base_url == "https://api.example.com"
     assert auth_type == "api_key"
     assert auth_header == "X-Custom-Key"
     assert token == "my-api-key"
+    assert allowed_writes == []
 
 
 async def test_get_for_executor_none_when_unset(mongo_db):

--- a/tests/cloud/test_pocket_backend_service.py
+++ b/tests/cloud/test_pocket_backend_service.py
@@ -114,9 +114,11 @@ async def test_get_for_executor_no_token_for_none_auth(mongo_db):
     )
     creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
     assert creds is not None
-    _, auth_type, _, token = creds
+    # RFC 05 M2a: the executor tuple gained a trailing `allowed_writes`.
+    _, auth_type, _, token, allowed_writes = creds
     assert auth_type == "none"
     assert token == ""
+    assert allowed_writes == []
 
 
 async def test_set_backend_upserts(mongo_db):


### PR DESCRIPTION
## What this is

Increment 1 of RFC 05 — the write half of the pocket data layer. RFC 04's alpha made pockets live: read bindings hydrate `state`. This makes them do things — a pocket can submit a form, mark a row done, or trigger a backend operation through a declared `rippleSpec.actions` write binding.

This is 1 of 3 increment-1 PRs. The other two are ripple #41 and paw-enterprise #238.

## The write executor

A new `action_executor.py` runs `POST`/`PUT`/`PATCH`/`DELETE` bindings against a pocket's single configured backend. It is the write counterpart to RFC 04's read-only `source_executor.py`.

A write has blast radius a read does not, so the executor adds three things on top of the SSRF guards:

- **A per-pocket write allowlist.** A `(method, path)` that does not match an `allowed_writes` entry is rejected before any call leaves the server. The allowlist lives on the backend config, outside `rippleSpec`, so the agent that authors a binding cannot widen its own write blast radius. The default is empty — fail-closed, no write fires until a human owner sets a policy.
- **Fail-closed instinct-reject.** M2a has no Instinct approval surface. Rather than accept a `requires_instinct` flag and then quietly ignore it, any action whose declaration carries a truthy `requires_instinct` is rejected with `code: instinct_required` and makes no call. M2b wires the real approval routing.
- **Idempotency.** Every call carries an `Idempotency-Key` header — a client-supplied key when present, so a write retried after a timeout dedupes, otherwise a server-generated one.

The write rate limit (20 writes per `(pocket, user)` per minute) is a separate counter from the read executor's, so a read budget never drains the write budget or vice versa.

## Shared `_http_guard` extraction

The SSRF defenses RFC 04's read executor enforced — path-traversal rejection, absolute-URL rejection, same-host assertion, DNS rebinding check, no redirect following, tight timeouts, the 512 KB response cap, error sanitization — are pulled out verbatim into one canonical `_http_guard.py` module that both executors import. It is a pure refactor; the read-executor regression tests are the proof gate and pass unchanged.

## Two new endpoints

- `POST /pockets/{id}/actions/run` — runs a declared write action. The HTTP method is read server-side from the persisted spec, so a compromised client cannot pick the verb. Access is owner or explicit `shared_with` only — a workspace-visible pocket does not grant run access, because a write has blast radius.
- `PUT /pockets/{id}/backend/write-policy` — sets the write allowlist. Owner-only.

## Authoring path

The normalizer lifts the agent's hallucinated inline-write shape (`{action: "api", method: "POST", url: <relative>}`) into a proper `actions` block plus a `call_binding` handler. An absolute-URL `api` call is left alone — it targets a third party and must never be redirected onto the credentialed backend. The pocket specialist gets `set_action` / `remove_action` granular tools and prompt guidance for both the create and edit paths.

## Tests and gates

- New: `test_pocket_action_executor.py`, `test_pocket_actions_lift.py`, `test_pocket_actions_ops.py` cover the executor, the normalizer lift, and the ops + service layer. The existing backend and agent-backend-view tests are updated to the new `allowed_writes` contract.
- `ruff check` and `ruff format --check` pass.
- `mypy` is clean on every touched file — zero errors over the baseline.
- `pytest tests/cloud/` — all 60 new tests pass. The 54 pre-existing failures sit in unrelated areas (tasks, notifications, connectors, agent_router) and are untouched by this change.
- import-linter — all 15 contracts hold; the three new modules stay Beanie-free.

## Docs

`docs/api-reference.md` documents the two endpoints. RFC 05 is amended — open questions #1 (block naming), #3 (reconcile cost), and #6 (idempotency) are marked resolved.
