### PR TITLE
Built-in pocket templates (Increment 2a)

### DIFF
--- a/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
@@ -5,6 +5,13 @@
 # new two-call protocol where the calling chat agent drafts the
 # rippleSpec inline using its own LLM and the specialist only runs
 # validate-and-persist on the returned draft.
+# Modified: 2026-05-22 (feat/bundled-templates, Increment 2a) —
+# ``AgentModeAdapter.create`` short-circuits on a ``hints.template_id``:
+# it loads the built-in template, passes its ``ripple_spec`` straight to
+# ``_validate_and_persist``, and SKIPS the ``_draft_kit`` round-trip. An
+# unknown slug falls back to the normal draft-kit flow. Without the
+# short-circuit, agent-mode pays two LLM round-trips for a one-shot
+# template customization.
 # Modified: 2026-05-21 — added full-fledged-app chrome widgets
 # (app-shell, sidebar, breadcrumb, sheet, modal, confirm-dialog,
 # dropdown-menu, command-palette, coachmark) to the starter list and
@@ -209,20 +216,95 @@ class AgentModeAdapter:
         settings: Settings,
     ) -> Any:
         started = time.monotonic()
-        if input.spec is None:
-            return _draft_kit_response(input, started=started)
-        return await _validate_and_persist(
-            input,
-            workspace_id=workspace_id,
-            user_id=user_id,
-            settings=settings,
-            started=started,
-        )
+        if input.spec is not None:
+            # Second call — the chat agent already drafted a spec.
+            return await _validate_and_persist(
+                input,
+                workspace_id=workspace_id,
+                user_id=user_id,
+                settings=settings,
+                started=started,
+            )
+
+        # First call. When the chat agent matched a built-in template,
+        # short-circuit: load the template skeleton and persist it
+        # directly — no draft-kit round-trip. Agent-mode would otherwise
+        # pay two LLM hops for a one-shot template customization.
+        template_id = getattr(input.hints, "template_id", None) if input.hints else None
+        if template_id:
+            template_input = _input_with_template_spec(input, template_id)
+            if template_input is not None:
+                logger.info(
+                    "[pocket-specialist] agent-mode template short-circuit "
+                    "(template_id=%s) — skipping draft kit",
+                    template_id,
+                )
+                return await _validate_and_persist(
+                    template_input,
+                    workspace_id=workspace_id,
+                    user_id=user_id,
+                    settings=settings,
+                    started=started,
+                )
+            # Unknown slug / load failure — fall through to the draft kit.
+            logger.info(
+                "[pocket-specialist] agent-mode template_id=%s did not load "
+                "— falling back to draft kit",
+                template_id,
+            )
+
+        return _draft_kit_response(input, started=started)
 
 
 # ---------------------------------------------------------------------------
 # Agent-mode internals
 # ---------------------------------------------------------------------------
+
+
+def _input_with_template_spec(input: Any, template_id: str) -> Any | None:
+    """Load a built-in template and return a copy of ``input`` with the
+    template's ``ripple_spec`` set as ``spec``.
+
+    Agent mode persists ``input.spec`` directly. By loading the
+    template skeleton into ``spec`` here, the create flow takes the
+    same validate-and-persist path the second call uses — no LLM round
+    trip, no draft kit.
+
+    Returns ``None`` when the slug is unknown or the template files are
+    missing / corrupt; the caller then falls back to the draft kit.
+    The lazy import keeps ``bundled_templates`` off the hot path for the
+    common (no-template) create.
+    """
+    try:
+        from pocketpaw.bundled_templates.loader import load_template
+    except Exception:  # noqa: BLE001 — defensive: bundled_templates is OSS core
+        logger.warning("[pocket-specialist] bundled_templates.loader import failed", exc_info=True)
+        return None
+
+    template = load_template(template_id)
+    if template is None:
+        return None
+
+    ripple_spec = template.get("ripple_spec")
+    if not isinstance(ripple_spec, dict) or not ripple_spec:
+        logger.warning(
+            "[pocket-specialist] template %r loaded but ripple_spec is empty/invalid",
+            template_id,
+        )
+        return None
+
+    # Strip authoring-only keys (``_placeholder_note`` and any other
+    # ``_``-prefixed top-level key) — they are template-author notes,
+    # not rippleSpec fields, and must not land in the user's pocket.
+    clean_spec = {k: v for k, v in ripple_spec.items() if not k.startswith("_")}
+
+    try:
+        return input.model_copy(update={"spec": clean_spec})
+    except Exception:  # noqa: BLE001 — model_copy on a non-pydantic input
+        logger.warning(
+            "[pocket-specialist] could not copy input for template %r", template_id, exc_info=True
+        )
+        return None
 
 
 def _draft_kit_response(input: Any, *, started: float) -> Any:

--- a/ee/pocketpaw_ee/agent/pocket_specialist/mcp_tool.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/mcp_tool.py
@@ -15,6 +15,12 @@ Changes: 2026-05-21 (#1170) — the ``edit`` tool now accepts an optional
 ``ops`` argument: the agent-mode second-call payload. In agent mode the
 first ``edit`` call returns ``action='draft_kit'`` and the chat agent
 calls back with ``ops=<granular op list>``. Subagent mode ignores it.
+Changes: 2026-05-22 (feat/bundled-templates, Increment 2a) — the
+``create`` tool's ``hints`` object accepts ``template_id`` (a built-in
+pocket-template slug) and the tool gains a top-level optional
+``backend_summary`` (a non-secret ``{base_url, auth_type, configured}``
+summary — unused in 2a, declared now so 2b's API-skill loading does not
+re-touch the schema).
 """
 
 from __future__ import annotations
@@ -74,10 +80,12 @@ async def _create_handler(args: dict[str, Any]) -> dict[str, Any]:
     raw_hints = args.get("hints")
     hints = PocketSpecialistHints(**raw_hints) if raw_hints else None
     raw_spec = args.get("spec")
+    raw_backend_summary = args.get("backend_summary")
     payload = PocketSpecialistCreateInput(
         brief=args.get("brief", ""),
         hints=hints,
         spec=raw_spec if isinstance(raw_spec, dict) else None,
+        backend_summary=(raw_backend_summary if isinstance(raw_backend_summary, dict) else None),
     )
 
     try:
@@ -254,8 +262,34 @@ def build_pocket_specialist_server() -> Any:
                                 "done', 'filter by status']."
                             ),
                         },
+                        "template_id": {
+                            "type": "string",
+                            "description": (
+                                "Slug of a built-in pocket template to "
+                                "instantiate and customize (e.g. "
+                                "'todo-task-tracker', 'kanban-board', "
+                                "'metrics-dashboard', 'crm-record-list', "
+                                "'calendar-planner', 'activity-feed'). Set "
+                                "this when the brief matched a built-in "
+                                "template in ~/.pocketpaw/templates/index.json. "
+                                "It is the HIGHEST-AUTHORITY structural plan — "
+                                "the specialist starts from the template's "
+                                "hand-authored skeleton instead of "
+                                "cold-generating. An unknown slug is ignored."
+                            ),
+                        },
                     },
                     "additionalProperties": False,
+                },
+                "backend_summary": {
+                    "type": "object",
+                    "description": (
+                        "Optional non-secret backend summary "
+                        "{base_url, auth_type, configured} — NEVER include "
+                        "auth_token. Unused in 2a; declared for 2b's "
+                        "per-backend API-skill loading."
+                    ),
+                    "additionalProperties": True,
                 },
                 "spec": {
                     "type": "object",

--- a/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
@@ -29,6 +29,16 @@ pipeline now fetches the pocket's non-secret backend summary and fills it
 into the ``<current-pocket>`` block via ``fill_current_pocket`` so the
 specialist sees whether a backend is configured before authoring a
 ``sources`` block. The token is never surfaced.
+Changes: 2026-05-22 (feat/bundled-templates, Increment 2a) — built-in
+pocket templates. ``PocketSpecialistHints`` gains ``template_id`` (the
+highest-authority structural plan — when set, the specialist instantiates
+and customizes that template instead of cold-generating).
+``PocketSpecialistCreateInput`` gains ``backend_summary`` (a non-secret
+``{base_url, auth_type, configured}`` summary — unused in 2a, added now so
+2b's per-backend API-skill loading does not re-touch this model).
+``_build_system_prompt`` accepts ``backend_summary`` and, when a
+``template_id`` hint is set, splices the loaded template skeleton +
+customization rules in via ``_load_template_block``.
 """
 
 from __future__ import annotations
@@ -123,6 +133,21 @@ class PocketSpecialistHints(BaseModel):
         ),
     )
 
+    # ---- built-in template (highest-authority structural plan) ----
+    template_id: str | None = Field(
+        default=None,
+        description=(
+            "Slug of a built-in pocket template to instantiate and "
+            "customize (e.g. 'todo-task-tracker', 'kanban-board'). Set by "
+            "the chat agent's STEP 0 template-library keyword match. When "
+            "set, this is the HIGHEST-AUTHORITY structural plan — the "
+            "specialist starts from the template's hand-authored rippleSpec "
+            "skeleton and customizes it rather than cold-generating. An "
+            "unknown slug is ignored and the specialist falls back to cold "
+            "generation."
+        ),
+    )
+
 
 class PocketSpecialistCreateInput(BaseModel):
     brief: str = Field(..., min_length=10, max_length=4000)
@@ -133,6 +158,13 @@ class PocketSpecialistCreateInput(BaseModel):
             "Pre-drafted rippleSpec for agent-mode's second call. When set, "
             "the specialist skips its own LLM draft phase and goes straight "
             "to validate-and-persist. Ignored in subagent mode."
+        ),
+    )
+    backend_summary: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Non-secret backend summary {base_url, auth_type, configured} — "
+            "NEVER include auth_token. Used in 2b for API-skill loading."
         ),
     )
 
@@ -261,7 +293,7 @@ async def _run_subagent_pipeline(
         ]
     )
 
-    system_prompt = _build_system_prompt(input.hints)
+    system_prompt = _build_system_prompt(input.hints, backend_summary=input.backend_summary)
     user_message = _build_user_message(input)
 
     log.info(
@@ -348,7 +380,115 @@ async def _run_subagent_pipeline(
     )
 
 
-def _build_system_prompt(hints: PocketSpecialistHints | None) -> str:
+# ---------------------------------------------------------------------------
+# Built-in pocket templates (feat/bundled-templates, Increment 2a).
+#
+# When the caller sets ``hints.template_id`` the specialist starts from a
+# hand-authored, production-quality rippleSpec skeleton instead of
+# cold-generating. The template block below is spliced into the system
+# prompt and is the HIGHEST-AUTHORITY structural plan — it outranks the
+# layout / focal_widget hints because the skeleton already encodes them.
+# ---------------------------------------------------------------------------
+
+_TEMPLATE_BLOCK = """\
+
+BUILT-IN TEMPLATE — INSTANTIATE AND CUSTOMIZE, DO NOT REDESIGN:
+
+The chat agent matched this brief to PocketPaw's built-in
+``{slug}`` template. This is the HIGHEST-AUTHORITY structural plan —
+it outranks every layout / focal_widget hint above. Your job is
+INSTANTIATION + CUSTOMIZATION, not a cold draft.
+
+The template's hand-authored rippleSpec skeleton:
+
+{spec_json}
+
+CUSTOMIZATION RULES:
+- Replace every ``[bracketed]`` placeholder value with content for the
+  user's actual domain. Placeholders mark where real content goes.
+- Rename labels, headings, column headers, and option labels to the
+  user's domain. A "Task Tracker" brief about bugs becomes a "Bug
+  Tracker" with a "Bug" column, not a generic "Task" column.
+- PRESERVE the widget structure — the node tree, the state/bind/on_click
+  wiring, the composer rows. The skeleton is correct; do not strip
+  interactivity or swap the focal widget unless the brief explicitly
+  demands a different shape.
+- Keep seeded sample rows realistic and on-domain (3-5 rows) so the
+  canvas is alive on first load. Do not ship empty arrays for a
+  display-style widget.
+- Drop the ``_placeholder_note`` field and any ``_``-prefixed key from
+  the final spec — those are template authoring notes, not spec fields.
+{sources_rule}
+Then call persist_pocket exactly once with the customized spec.
+"""
+
+_TEMPLATE_SOURCES_WITH_BACKEND = """\
+- The template carries a ``sources`` block (a placeholder live-data
+  binding). The user HAS a backend configured — keep the ``sources``
+  block so the real endpoint hydrates the bound state. Adjust the
+  ``path`` to the user's actual endpoint if the brief names one.
+"""
+
+_TEMPLATE_SOURCES_NO_BACKEND = """\
+- The template carries a ``sources`` block (a placeholder live-data
+  binding). The user has NO backend configured — REMOVE the ``sources``
+  block entirely and keep the seeded sample rows as the working data.
+"""
+
+
+def _load_template_block(template_id: str, backend_summary: dict[str, Any] | None) -> str | None:
+    """Load a built-in template and format the splice-in prompt block.
+
+    Lazy-imports ``pocketpaw.bundled_templates.loader`` so the OSS-core
+    import is paid only when a ``template_id`` hint is actually set.
+
+    Returns the formatted ``_TEMPLATE_BLOCK`` (the skeleton + the
+    customization rules) on success, or ``None`` when the slug is
+    unknown / the template files are missing — in which case the
+    specialist falls back to cold generation.
+
+    ``backend_summary`` decides the sources-placeholder rule: a template
+    that ships a ``sources`` block (the CRM list) keeps it when a backend
+    is configured and drops it when not.
+    """
+    try:
+        from pocketpaw.bundled_templates.loader import load_template
+    except Exception:  # noqa: BLE001 — bundled_templates is OSS core; defensive only
+        log.warning("[pocket-specialist] bundled_templates.loader import failed", exc_info=True)
+        return None
+
+    template = load_template(template_id)
+    if template is None:
+        log.info(
+            "[pocket-specialist] template_id=%r not found — falling back to cold generation",
+            template_id,
+        )
+        return None
+
+    import json as _json
+
+    ripple_spec = template.get("ripple_spec") or {}
+    spec_json = _json.dumps(ripple_spec, indent=2)
+
+    if isinstance(ripple_spec, dict) and "sources" in ripple_spec:
+        configured = bool(backend_summary and backend_summary.get("configured"))
+        sources_rule = (
+            _TEMPLATE_SOURCES_WITH_BACKEND if configured else _TEMPLATE_SOURCES_NO_BACKEND
+        )
+    else:
+        sources_rule = ""
+
+    return _TEMPLATE_BLOCK.format(
+        slug=template_id,
+        spec_json=spec_json,
+        sources_rule=sources_rule,
+    )
+
+
+def _build_system_prompt(
+    hints: PocketSpecialistHints | None,
+    backend_summary: dict[str, Any] | None = None,
+) -> str:
     """Compose the specialist system prompt from the canonical creation
     prompt + any hints from the caller.
 
@@ -358,6 +498,11 @@ def _build_system_prompt(hints: PocketSpecialistHints | None) -> str:
     set, are AUTHORITATIVE — the specialist follows them rather than
     re-deciding. See the FOLLOW-THE-PLAN rule in the specialist
     workflow block.
+
+    When ``hints.template_id`` is set, the matching built-in template's
+    rippleSpec skeleton + customization rules are spliced in via
+    ``_load_template_block`` — the highest-authority structural plan.
+    An unknown slug is ignored (the specialist cold-generates).
     """
     base = POCKET_SPECIALIST_PROMPT.replace(POCKET_ID_TOKEN, "")
     if not hints:
@@ -389,9 +534,13 @@ def _build_system_prompt(hints: PocketSpecialistHints | None) -> str:
             "not creative reimagining."
         )
 
-    if not lines:
+    template_block: str | None = None
+    if hints.template_id:
+        template_block = _load_template_block(hints.template_id, backend_summary)
+
+    if not lines and template_block is None:
         return base
-    return base + "\n".join(lines)
+    return base + "\n".join(lines) + (template_block or "")
 
 
 def _build_user_message(input: PocketSpecialistCreateInput) -> str:

--- a/src/pocketpaw/bundled_templates/__init__.py
+++ b/src/pocketpaw/bundled_templates/__init__.py
@@ -1,0 +1,51 @@
+# src/pocketpaw/bundled_templates/__init__.py
+# Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — package
+# for the curated set of built-in pocket templates the create
+# specialist instantiates instead of generating a pocket from scratch.
+"""Built-in pocket templates bundled and auto-installed by PocketPaw.
+
+Third sibling to ``pocketpaw.bundled_skills`` and ``pocketpaw.bundled_kb``.
+Where ``bundled_skills`` ships on-demand workflow markdown and ``bundled_kb``
+ships pre-compiled kb-go retrieval scopes, ``bundled_templates`` ships
+**ready-to-instantiate pocket templates** — hand-authored, production-quality
+rippleSpec skeletons paired with RFC 03 schema metadata.
+
+Why this exists
+---------------
+
+The pocket-authoring agent generates every pocket from scratch — slow, 2-3
+iterations, half-baked. A "todo dashboard" is a solved pattern; it should be
+a template, not a fresh generation. The create specialist *instantiates and
+customizes* a matching built-in template instead of generating one cold.
+
+Each template is a directory under ``_bundled/<slug>/`` carrying two files:
+
+- ``template.pocket.yaml`` — RFC 03 Pocket Template Schema metadata
+  (``name, version, vertical, shape, state, actions, connectors, skills,
+  description``). Seed templates ship ``actions: []`` — Instinct / Outcomes
+  are not wired yet and dead action declarations are worse than none.
+- ``ripple_spec.json`` — a full, hand-authored rippleSpec skeleton: the
+  quality lever. The specialist starts from a correct skeleton, not a
+  pressured cold generation.
+
+On dashboard boot the installer mirrors ``_bundled/`` into
+``~/.pocketpaw/templates/`` (SHA-256 idempotent, same pattern as the two
+sibling installers). The loader reads a single template back at
+pocket-creation time.
+
+Adding a template: drop a new ``_bundled/<slug>/`` directory with the two
+files and register it in ``_bundled/index.json``. The installer discovers
+directories via iteration — no installer code changes needed.
+"""
+
+from pocketpaw.bundled_templates.installer import (
+    TemplateInstallResult,
+    install_bundled_templates,
+)
+from pocketpaw.bundled_templates.loader import load_template
+
+__all__ = [
+    "TemplateInstallResult",
+    "install_bundled_templates",
+    "load_template",
+]

--- a/src/pocketpaw/bundled_templates/_bundled/README.md
+++ b/src/pocketpaw/bundled_templates/_bundled/README.md
@@ -1,0 +1,52 @@
+<!--
+src/pocketpaw/bundled_templates/_bundled/README.md
+Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — explains the
+two-file sibling convention each template directory follows.
+-->
+# Bundled pocket templates
+
+Each subdirectory here is one built-in pocket template. The installer
+(`pocketpaw.bundled_templates.installer`) mirrors every directory plus
+the top-level `index.json` into `~/.pocketpaw/templates/` on dashboard
+boot, SHA-256 idempotent.
+
+## The sibling-file convention
+
+A template directory carries **exactly two files**:
+
+| File | Format | Purpose |
+|------|--------|---------|
+| `template.pocket.yaml` | RFC 03 Pocket Template Schema | The publishable metadata: `name`, `version`, `vertical`, `shape`, `state`, `actions`, `connectors`, `skills`, `description`. This is the registry-facing artifact. |
+| `ripple_spec.json` | rippleSpec JSON | A full, hand-authored, production-quality rippleSpec skeleton — the canvas the create specialist instantiates and customizes. **A local runtime artifact, not part of RFC 03.** |
+
+`ripple_spec.json` is a PocketPaw runtime sibling — it is *not* an RFC 03
+schema field. **RFC 03's registry linter must ignore `ripple_spec.json`.**
+A template is published to the registry on the strength of its
+`template.pocket.yaml` alone; `ripple_spec.json` is how *this* runtime
+turns the template into a live pocket without a cold LLM generation. A
+registry linter that walks a template directory should lint
+`template.pocket.yaml` and skip every other file, `ripple_spec.json`
+included.
+
+## index.json
+
+`index.json` is the registry: a flat list of `{slug, title, shape,
+pattern, keywords, connectors_hint}` rows, one per template. The chat
+agent's STEP 0 template-library check reads it, keyword-matches the
+brief against `keywords` (case-insensitive substring), and on a match
+sets the `template_id` hint so the create specialist instantiates the
+matched template.
+
+## Seed-template scope (Increment 2a)
+
+The six seed templates ship `actions: []` — empty. Instinct and
+Outcomes are not wired yet, and a dead action declaration is worse than
+none. `outcomes`, `instinct_rules`, `triggers`, and `agents` are omitted
+entirely for the same reason. Increment 2b adds per-backend API skills;
+later increments populate `actions` once Instinct lands.
+
+## Adding a template
+
+1. Create `_bundled/<slug>/template.pocket.yaml` + `_bundled/<slug>/ripple_spec.json`.
+2. Add a matching row to `_bundled/index.json`.
+3. The installer discovers the directory by iteration — no installer code change.

--- a/src/pocketpaw/bundled_templates/_bundled/activity-feed/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/activity-feed/ripple_spec.json
@@ -1,0 +1,92 @@
+{
+  "_placeholder_note": "Built-in pocket template (activity-feed). Event titles, dates, and details below carry [bracketed] placeholders — the create specialist rewrites them to the user's real history and domain. Keep the timeline bound to state.events; keep the add-entry composer so the feed is usable on first load. If the feed is a who-did-what stream rather than dated milestones, the specialist may swap `timeline` for `audit-log`.",
+  "state": {
+    "draft_title": "",
+    "draft_detail": "",
+    "draft_date": "",
+    "draft_type": "default",
+    "next_id": 6,
+    "type_options": [
+      { "value": "default", "label": "Update" },
+      { "value": "success", "label": "Shipped" },
+      { "value": "warning", "label": "At risk" },
+      { "value": "info", "label": "Note" }
+    ],
+    "events": [
+      { "id": "a1", "date": "2026-05-20", "title": "[Closed the Acme renewal]", "detail": "[Signed the 2-year contract — kickoff next week.]", "type": "success" },
+      { "id": "a2", "date": "2026-05-18", "title": "[Shipped the search rebuild]", "detail": "[New endpoint live; latency down ~40%.]", "type": "success" },
+      { "id": "a3", "date": "2026-05-15", "title": "[Onboarding flow flagged at risk]", "detail": "[Drop-off on step 3 — investigating this week.]", "type": "warning" },
+      { "id": "a4", "date": "2026-05-12", "title": "[Quarterly planning kicked off]", "detail": "[Roadmap draft circulated for feedback.]", "type": "default" },
+      { "id": "a5", "date": "2026-05-08", "title": "[New analytics dashboard in beta]", "detail": "[Rolled out to the design partners.]", "type": "info" }
+    ]
+  },
+  "ui": {
+    "type": "flex",
+    "props": { "direction": "column", "gap": "16px" },
+    "children": [
+      {
+        "type": "page-header",
+        "props": {
+          "title": "[Activity]",
+          "subtitle": "[What happened, newest first]"
+        }
+      },
+      {
+        "type": "flex",
+        "props": { "direction": "row", "gap": "8px", "align": "end" },
+        "children": [
+          {
+            "type": "input",
+            "bind": "draft_title",
+            "props": { "label": "Headline", "placeholder": "[What happened?]" }
+          },
+          {
+            "type": "input",
+            "bind": "draft_detail",
+            "props": { "label": "Detail", "placeholder": "[One line of context]" }
+          },
+          {
+            "type": "date-picker",
+            "bind": "draft_date",
+            "props": { "label": "Date" }
+          },
+          {
+            "type": "select",
+            "bind": "draft_type",
+            "props": { "label": "Type", "options": "{state.type_options}" }
+          },
+          {
+            "type": "button",
+            "props": { "label": "Add entry", "variant": "primary" },
+            "on_click": [
+              { "action": "validate", "condition": "{state.draft_title.length > 0}", "message": "Type a headline first" },
+              { "action": "validate", "condition": "{state.draft_date.length > 0}", "message": "Pick a date first" },
+              {
+                "action": "push",
+                "target": "events",
+                "value": {
+                  "id": "a-{state.next_id}",
+                  "date": "{state.draft_date}",
+                  "title": "{state.draft_title}",
+                  "detail": "{state.draft_detail}",
+                  "type": "{state.draft_type}"
+                }
+              },
+              { "action": "set", "target": "next_id", "value": "{state.next_id + 1}" },
+              { "action": "set", "target": "draft_title", "value": "" },
+              { "action": "set", "target": "draft_detail", "value": "" },
+              { "action": "set", "target": "draft_date", "value": "" }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeline",
+        "props": {
+          "events": "{state.events.sortBy('date', 'desc')}",
+          "density": "compact"
+        }
+      }
+    ]
+  }
+}

--- a/src/pocketpaw/bundled_templates/_bundled/activity-feed/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/activity-feed/template.pocket.yaml
@@ -1,0 +1,23 @@
+# src/pocketpaw/bundled_templates/_bundled/activity-feed/template.pocket.yaml
+# Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — RFC 03
+# Pocket Template Schema metadata for the built-in activity feed.
+name: activity-feed
+version: 1.0.0
+vertical: productivity
+shape: timeline
+description: |
+  A reverse-chronological activity feed. Each entry is a dated event
+  with a title and a short detail line — release notes, a project
+  history, a changelog, a milestone tracker. Rendered as a vertical
+  timeline; entries live in pocket state and can be appended from the
+  composer row.
+state:
+  entity_type: ActivityEntry
+  columns:
+    - { field: title, widget: text }
+    - { field: date, widget: date }
+    - { field: detail, widget: text }
+    - { field: type, widget: badge }
+actions: []
+connectors: []
+skills: []

--- a/src/pocketpaw/bundled_templates/_bundled/calendar-planner/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/calendar-planner/ripple_spec.json
@@ -1,0 +1,84 @@
+{
+  "_placeholder_note": "Built-in pocket template (calendar-planner). Event titles, dates, and category names below carry [bracketed] placeholders — the create specialist rewrites them to the user's real schedule and domain. The calendar widget reads each event as {id, title, start}; keep the calendar bound to state.events and keep the add-event composer row so the canvas is usable on first load.",
+  "state": {
+    "draft_title": "",
+    "draft_date": "",
+    "draft_category": "meeting",
+    "next_id": 6,
+    "category_options": [
+      { "value": "meeting", "label": "Meeting" },
+      { "value": "deadline", "label": "Deadline" },
+      { "value": "personal", "label": "Personal" },
+      { "value": "travel", "label": "Travel" }
+    ],
+    "events": [
+      { "id": "e1", "title": "[Sprint planning]", "start": "2026-06-01", "category": "meeting" },
+      { "id": "e2", "title": "[Design review with the client]", "start": "2026-06-03", "category": "meeting" },
+      { "id": "e3", "title": "[Q3 budget submission due]", "start": "2026-06-05", "category": "deadline" },
+      { "id": "e4", "title": "[Flight to the conference]", "start": "2026-06-09", "category": "travel" },
+      { "id": "e5", "title": "[Dentist appointment]", "start": "2026-06-12", "category": "personal" }
+    ]
+  },
+  "ui": {
+    "type": "flex",
+    "props": { "direction": "column", "gap": "16px" },
+    "children": [
+      {
+        "type": "page-header",
+        "props": {
+          "title": "[Planner]",
+          "subtitle": "[Your month, at a glance]"
+        }
+      },
+      {
+        "type": "flex",
+        "props": { "direction": "row", "gap": "8px", "align": "end" },
+        "children": [
+          {
+            "type": "input",
+            "bind": "draft_title",
+            "props": { "label": "Event", "placeholder": "[What's happening?]" }
+          },
+          {
+            "type": "date-picker",
+            "bind": "draft_date",
+            "props": { "label": "Date" }
+          },
+          {
+            "type": "select",
+            "bind": "draft_category",
+            "props": { "label": "Category", "options": "{state.category_options}" }
+          },
+          {
+            "type": "button",
+            "props": { "label": "Add event", "variant": "primary" },
+            "on_click": [
+              { "action": "validate", "condition": "{state.draft_title.length > 0}", "message": "Type an event title first" },
+              { "action": "validate", "condition": "{state.draft_date.length > 0}", "message": "Pick a date first" },
+              {
+                "action": "push",
+                "target": "events",
+                "value": {
+                  "id": "e-{state.next_id}",
+                  "title": "{state.draft_title}",
+                  "start": "{state.draft_date}",
+                  "category": "{state.draft_category}"
+                }
+              },
+              { "action": "set", "target": "next_id", "value": "{state.next_id + 1}" },
+              { "action": "set", "target": "draft_title", "value": "" },
+              { "action": "set", "target": "draft_date", "value": "" }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "calendar",
+        "bind": "events",
+        "props": {
+          "view": "month"
+        }
+      }
+    ]
+  }
+}

--- a/src/pocketpaw/bundled_templates/_bundled/calendar-planner/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/calendar-planner/template.pocket.yaml
@@ -1,0 +1,21 @@
+# src/pocketpaw/bundled_templates/_bundled/calendar-planner/template.pocket.yaml
+# Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — RFC 03
+# Pocket Template Schema metadata for the built-in calendar planner.
+name: calendar-planner
+version: 1.0.0
+vertical: productivity
+shape: calendar
+description: |
+  A month-view calendar planner. Each entry is a dated event with a
+  category. Add an event from the composer row — pick a date, a title,
+  a category — and it lands on the calendar. Events live in pocket
+  state bound to the calendar widget so the view stays reactive.
+state:
+  entity_type: Event
+  columns:
+    - { field: title, widget: text }
+    - { field: start, widget: date }
+    - { field: category, widget: badge }
+actions: []
+connectors: []
+skills: []

--- a/src/pocketpaw/bundled_templates/_bundled/crm-record-list/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/crm-record-list/ripple_spec.json
@@ -1,0 +1,66 @@
+{
+  "_placeholder_note": "Built-in pocket template (crm-record-list). The contact rows below carry [bracketed] placeholders — the create specialist rewrites them to the user's real records and domain. The `sources` block is a PLACEHOLDER live-data binding: if the user has a backend configured, keep it so /contacts hydrates state.records; if there is NO backend, REMOVE the `sources` block entirely and keep the seeded records as the working data. The master-detail widget binds selection to state.selected_id; the entity-detail in its children reads the selected record via the .where(...).first() expression.",
+  "sources": {
+    "records": {
+      "method": "GET",
+      "path": "/contacts",
+      "bind": "state.records",
+      "refresh": ["pocket_open", "manual"]
+    }
+  },
+  "state": {
+    "selected_id": "r1",
+    "records": [
+      { "id": "r1", "name": "[Amara Okafor]", "company": "[Northwind Labs]", "stage": "Negotiation", "email": "[amara@northwind.example]", "phone": "[+1 555 0142]", "notes": "[Wants the annual plan; waiting on procurement sign-off.]" },
+      { "id": "r2", "name": "[Liam Petrov]", "company": "[Brightline Co]", "stage": "Qualified", "email": "[liam@brightline.example]", "phone": "[+1 555 0188]", "notes": "[Evaluating against two competitors; demo booked for next week.]" },
+      { "id": "r3", "name": "[Sofia Marchetti]", "company": "[Harbor Freight Group]", "stage": "Closed won", "email": "[sofia@harborfg.example]", "phone": "[+1 555 0207]", "notes": "[Signed the 2-year contract; kickoff scheduled.]" },
+      { "id": "r4", "name": "[Daniel Cho]", "company": "[Vertex Analytics]", "stage": "New lead", "email": "[daniel@vertex.example]", "phone": "[+1 555 0231]", "notes": "[Inbound from the pricing page; not yet contacted.]" },
+      { "id": "r5", "name": "[Priya Nair]", "company": "[Cobalt Studio]", "stage": "Qualified", "email": "[priya@cobalt.example]", "phone": "[+1 555 0264]", "notes": "[Champion identified; needs a security review before moving forward.]" }
+    ]
+  },
+  "ui": {
+    "type": "flex",
+    "props": { "direction": "column", "gap": "16px" },
+    "children": [
+      {
+        "type": "page-header",
+        "props": {
+          "title": "[Contacts]",
+          "subtitle": "[Your pipeline, one record at a time]"
+        }
+      },
+      {
+        "type": "master-detail",
+        "bind": "selected_id",
+        "props": {
+          "items": "{state.records}",
+          "valueKey": "id",
+          "labelKey": "name",
+          "descriptionKey": "company",
+          "badgeKey": "stage"
+        },
+        "children": [
+          {
+            "type": "entity-detail",
+            "props": {
+              "title": "{state.records.where('id', state.selected_id).first().name}",
+              "subtitle": "{state.records.where('id', state.selected_id).first().company}",
+              "eyebrow": "Contact",
+              "status": { "label": "{state.records.where('id', state.selected_id).first().stage}", "variant": "info" },
+              "meta": [
+                { "label": "Email", "value": "{state.records.where('id', state.selected_id).first().email}", "icon": "mail" },
+                { "label": "Phone", "value": "{state.records.where('id', state.selected_id).first().phone}", "icon": "phone" }
+              ]
+            },
+            "children": [
+              {
+                "type": "text",
+                "props": { "text": "{state.records.where('id', state.selected_id).first().notes}" }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/pocketpaw/bundled_templates/_bundled/crm-record-list/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/crm-record-list/template.pocket.yaml
@@ -1,0 +1,25 @@
+# src/pocketpaw/bundled_templates/_bundled/crm-record-list/template.pocket.yaml
+# Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — RFC 03
+# Pocket Template Schema metadata for the built-in CRM record list.
+# ``shape`` is ``custom`` because RFC 03's shape enum does not carry a
+# ``master-detail`` value; the master-detail *pattern* is in index.json.
+name: crm-record-list
+version: 1.0.0
+vertical: sales
+shape: custom
+description: |
+  A CRM record browser. A searchable list of contacts on the left, the
+  full detail of the selected contact on the right — the classic
+  master-detail pattern. Ships a placeholder live-data source so a
+  connected backend hydrates the list from a real /contacts endpoint;
+  without a backend it renders the seeded sample records.
+state:
+  entity_type: Contact
+  columns:
+    - { field: name, widget: text }
+    - { field: company, widget: text }
+    - { field: stage, widget: badge }
+    - { field: email, widget: text }
+actions: []
+connectors: []
+skills: []

--- a/src/pocketpaw/bundled_templates/_bundled/index.json
+++ b/src/pocketpaw/bundled_templates/_bundled/index.json
@@ -1,0 +1,53 @@
+{
+  "_note": "Registry of built-in pocket templates. The chat agent's STEP 0 template-library check reads this file, keyword-matches the brief (case-insensitive substring) against each row's `keywords`, and on a match sets the `template_id` hint. RFC 03's registry linter must ignore the sibling `ripple_spec.json` files — they are local runtime artifacts, not schema fields. See _bundled/README.md.",
+  "templates": [
+    {
+      "slug": "todo-task-tracker",
+      "title": "Task Tracker",
+      "shape": "data-grid",
+      "pattern": "app",
+      "keywords": ["todo", "to-do", "to do", "task", "tasks", "task list", "checklist", "task tracker", "task manager", "things to do", "action items"],
+      "connectors_hint": []
+    },
+    {
+      "slug": "kanban-board",
+      "title": "Kanban Board",
+      "shape": "kanban",
+      "pattern": "app",
+      "keywords": ["kanban", "board", "sprint board", "task board", "workflow", "swimlane", "swimlanes", "drag and drop board", "trello", "lanes"],
+      "connectors_hint": []
+    },
+    {
+      "slug": "metrics-dashboard",
+      "title": "Metrics Dashboard",
+      "shape": "data-grid",
+      "pattern": "dashboard",
+      "keywords": ["dashboard", "metrics", "kpi", "kpis", "analytics", "overview", "scorecard", "performance", "stats dashboard", "metrics dashboard"],
+      "connectors_hint": []
+    },
+    {
+      "slug": "crm-record-list",
+      "title": "CRM Record List",
+      "shape": "custom",
+      "pattern": "browser",
+      "keywords": ["crm", "contacts", "contact list", "leads", "customers", "accounts", "pipeline", "record list", "directory", "people list"],
+      "connectors_hint": ["rest"]
+    },
+    {
+      "slug": "calendar-planner",
+      "title": "Calendar Planner",
+      "shape": "calendar",
+      "pattern": "app",
+      "keywords": ["calendar", "planner", "schedule", "month view", "events calendar", "agenda", "appointments", "bookings calendar"],
+      "connectors_hint": []
+    },
+    {
+      "slug": "activity-feed",
+      "title": "Activity Feed",
+      "shape": "timeline",
+      "pattern": "feed",
+      "keywords": ["activity feed", "feed", "timeline", "changelog", "release notes", "history", "audit log", "activity log", "event stream", "milestones"],
+      "connectors_hint": []
+    }
+  ]
+}

--- a/src/pocketpaw/bundled_templates/_bundled/kanban-board/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/kanban-board/ripple_spec.json
@@ -1,0 +1,83 @@
+{
+  "_placeholder_note": "Built-in pocket template (kanban-board). Card titles and lane names below carry [bracketed] placeholders — the create specialist renames lanes to the user's workflow and rewrites cards to their domain. Keep the kanban bind + columnKey wiring intact so drag-to-move persists; keep the add-card composer.",
+  "state": {
+    "draft": "",
+    "draft_lane": "backlog",
+    "next_id": 7,
+    "lane_options": [
+      { "value": "backlog", "label": "Backlog" },
+      { "value": "in_progress", "label": "In progress" },
+      { "value": "review", "label": "Review" },
+      { "value": "done", "label": "Done" }
+    ],
+    "cards": [
+      { "id": "c1", "title": "[Spec the new export format]", "status": "backlog", "assignee": "[Priya]" },
+      { "id": "c2", "title": "[Wire up the search endpoint]", "status": "in_progress", "assignee": "[Marco]" },
+      { "id": "c3", "title": "[Fix the timezone bug in reminders]", "status": "in_progress", "assignee": "[Dana]" },
+      { "id": "c4", "title": "[Review the billing migration PR]", "status": "review", "assignee": "[Sam]" },
+      { "id": "c5", "title": "[Ship the dark-mode toggle]", "status": "done", "assignee": "[Priya]" },
+      { "id": "c6", "title": "[Write the release notes]", "status": "backlog", "assignee": "[Marco]" }
+    ]
+  },
+  "ui": {
+    "type": "flex",
+    "props": { "direction": "column", "gap": "16px" },
+    "children": [
+      {
+        "type": "page-header",
+        "props": {
+          "title": "[Team Board]",
+          "subtitle": "[Drag a card to move it across the workflow]"
+        }
+      },
+      {
+        "type": "flex",
+        "props": { "direction": "row", "gap": "8px", "align": "end" },
+        "children": [
+          {
+            "type": "input",
+            "bind": "draft",
+            "props": { "label": "New card", "placeholder": "[What's the work?]" }
+          },
+          {
+            "type": "select",
+            "bind": "draft_lane",
+            "props": { "label": "Lane", "options": "{state.lane_options}" }
+          },
+          {
+            "type": "button",
+            "props": { "label": "Add card", "variant": "primary" },
+            "on_click": [
+              { "action": "validate", "condition": "{state.draft.length > 0}", "message": "Type a card title first" },
+              {
+                "action": "push",
+                "target": "cards",
+                "value": {
+                  "id": "c-{state.next_id}",
+                  "title": "{state.draft}",
+                  "status": "{state.draft_lane}",
+                  "assignee": ""
+                }
+              },
+              { "action": "set", "target": "next_id", "value": "{state.next_id + 1}" },
+              { "action": "set", "target": "draft", "value": "" }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "kanban",
+        "bind": "cards",
+        "props": {
+          "columns": [
+            { "id": "backlog", "title": "Backlog" },
+            { "id": "in_progress", "title": "In progress" },
+            { "id": "review", "title": "Review" },
+            { "id": "done", "title": "Done" }
+          ],
+          "columnKey": "status"
+        }
+      }
+    ]
+  }
+}

--- a/src/pocketpaw/bundled_templates/_bundled/kanban-board/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/kanban-board/template.pocket.yaml
@@ -1,0 +1,22 @@
+# src/pocketpaw/bundled_templates/_bundled/kanban-board/template.pocket.yaml
+# Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — RFC 03
+# Pocket Template Schema metadata for the built-in kanban board.
+name: kanban-board
+version: 1.0.0
+vertical: productivity
+shape: kanban
+description: |
+  A drag-and-drop kanban board for work in flight. Cards move across
+  Backlog, In progress, Review, and Done lanes; the lane a card sits in
+  is its status. Add cards from the composer row. Cards live in a flat
+  state array bound to the board, so a drag persists and every change
+  is reactive.
+state:
+  entity_type: Card
+  columns:
+    - { field: title, widget: text }
+    - { field: status, widget: badge }
+    - { field: assignee, widget: text }
+actions: []
+connectors: []
+skills: []

--- a/src/pocketpaw/bundled_templates/_bundled/metrics-dashboard/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/metrics-dashboard/ripple_spec.json
@@ -1,0 +1,83 @@
+{
+  "_placeholder_note": "Built-in pocket template (metrics-dashboard). All numbers, labels, and segment names below carry [bracketed] placeholders — the create specialist replaces them with the user's real metrics and domain. Keep the hero+grid layout: KPI strip on top, full-width trend chart, then the breakdown table. Reshape chart data to {label, value} for the user's actual series.",
+  "state": {
+    "period_label": "[This quarter]",
+    "kpis": [
+      { "id": "k1", "label": "[Revenue]", "value": "[$1.24M]", "delta": "[+12%]", "direction": "up-good" },
+      { "id": "k2", "label": "[New customers]", "value": "[318]", "delta": "[+8%]", "direction": "up-good" },
+      { "id": "k3", "label": "[Churn]", "value": "[2.1%]", "delta": "[-0.4%]", "direction": "down-good" },
+      { "id": "k4", "label": "[NPS]", "value": "[54]", "delta": "[+6]", "direction": "up-good" }
+    ],
+    "trend": [
+      { "label": "[Jan]", "value": 312000 },
+      { "label": "[Feb]", "value": 348000 },
+      { "label": "[Mar]", "value": 401000 },
+      { "label": "[Apr]", "value": 386000 },
+      { "label": "[May]", "value": 442000 },
+      { "label": "[Jun]", "value": 471000 }
+    ],
+    "segments": [
+      { "id": "s1", "segment": "[Enterprise]", "value": 624000, "change_pct": 14 },
+      { "id": "s2", "segment": "[Mid-market]", "value": 382000, "change_pct": 9 },
+      { "id": "s3", "segment": "[Self-serve]", "value": 158000, "change_pct": 21 },
+      { "id": "s4", "segment": "[Partners]", "value": 76000, "change_pct": -3 }
+    ]
+  },
+  "ui": {
+    "type": "flex",
+    "props": { "direction": "column", "gap": "20px" },
+    "children": [
+      {
+        "type": "page-header",
+        "props": {
+          "title": "[Performance Dashboard]",
+          "subtitle": "[Headline metrics for this period]"
+        }
+      },
+      {
+        "type": "grid",
+        "props": { "columns": 4, "gap": "16px" },
+        "children": [
+          {
+            "type": "each",
+            "items": "{state.kpis}",
+            "item_as": "kpi",
+            "children": [
+              {
+                "type": "stat",
+                "props": {
+                  "label": "{kpi.label}",
+                  "value": "{kpi.value}",
+                  "delta": "{kpi.delta}",
+                  "direction": "{kpi.direction}"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "chart",
+        "props": {
+          "type": "area",
+          "title": "[Revenue trend]",
+          "data": "{state.trend}",
+          "height": 300
+        }
+      },
+      {
+        "type": "data-grid",
+        "props": {
+          "columns": [
+            { "key": "segment", "label": "Segment", "sortable": true, "align": "left" },
+            { "key": "value", "label": "Value", "sortable": true, "align": "right" },
+            { "key": "change_pct", "label": "Change %", "sortable": true, "align": "right" }
+          ],
+          "rows": "{state.segments}",
+          "defaultSort": "value:desc",
+          "dense": true
+        }
+      }
+    ]
+  }
+}

--- a/src/pocketpaw/bundled_templates/_bundled/metrics-dashboard/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/metrics-dashboard/template.pocket.yaml
@@ -1,0 +1,24 @@
+# src/pocketpaw/bundled_templates/_bundled/metrics-dashboard/template.pocket.yaml
+# Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — RFC 03
+# Pocket Template Schema metadata for the built-in metrics dashboard.
+# ``shape`` is ``data-grid`` because RFC 03's shape enum does not carry a
+# ``dashboard`` value; the dashboard *pattern* is recorded in index.json.
+name: metrics-dashboard
+version: 1.0.0
+vertical: analytics
+shape: data-grid
+description: |
+  An at-a-glance metrics dashboard. A strip of headline KPI tiles over a
+  trend chart, with a per-segment breakdown table underneath. Built for
+  the "how are we doing this period" question — KPIs, a trend line, and
+  a roll-up roster. Pick this only when the brief explicitly asks for
+  metrics, KPIs, or an overview.
+state:
+  entity_type: Metric
+  columns:
+    - { field: segment, widget: text }
+    - { field: value, widget: number }
+    - { field: change_pct, widget: number }
+actions: []
+connectors: []
+skills: []

--- a/src/pocketpaw/bundled_templates/_bundled/todo-task-tracker/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/todo-task-tracker/ripple_spec.json
@@ -1,0 +1,97 @@
+{
+  "_placeholder_note": "Built-in pocket template (todo-task-tracker). The seed rows below carry [bracketed] placeholder values — the create specialist replaces them with the user's real domain, renames labels, and preserves the widget structure. Keep the state/bind/on_click triangle intact; never strip the composer row.",
+  "state": {
+    "draft": "",
+    "draft_priority": "Medium",
+    "next_id": 6,
+    "status_filter": "All",
+    "priority_options": [
+      { "value": "High", "label": "High" },
+      { "value": "Medium", "label": "Medium" },
+      { "value": "Low", "label": "Low" }
+    ],
+    "status_filter_options": [
+      { "value": "All", "label": "All tasks" },
+      { "value": "Todo", "label": "To do" },
+      { "value": "In progress", "label": "In progress" },
+      { "value": "Done", "label": "Done" }
+    ],
+    "tasks": [
+      { "id": "t1", "title": "[Draft the Q3 launch brief]", "status": "In progress", "priority": "High", "due_date": "2026-06-02" },
+      { "id": "t2", "title": "[Review pull request #482]", "status": "Todo", "priority": "Medium", "due_date": "2026-05-28" },
+      { "id": "t3", "title": "[Reply to the Acme renewal email]", "status": "Todo", "priority": "High", "due_date": "2026-05-26" },
+      { "id": "t4", "title": "[Book the team offsite venue]", "status": "Done", "priority": "Low", "due_date": "2026-05-20" },
+      { "id": "t5", "title": "[Update the onboarding checklist]", "status": "In progress", "priority": "Medium", "due_date": "2026-06-09" }
+    ]
+  },
+  "ui": {
+    "type": "flex",
+    "props": { "direction": "column", "gap": "16px" },
+    "children": [
+      {
+        "type": "page-header",
+        "props": {
+          "title": "[Task Tracker]",
+          "subtitle": "[Everything on your plate, in one sortable list]"
+        }
+      },
+      {
+        "type": "flex",
+        "props": { "direction": "row", "gap": "8px", "align": "end" },
+        "children": [
+          {
+            "type": "input",
+            "bind": "draft",
+            "props": { "label": "New task", "placeholder": "[What needs doing?]" }
+          },
+          {
+            "type": "select",
+            "bind": "draft_priority",
+            "props": { "label": "Priority", "options": "{state.priority_options}" }
+          },
+          {
+            "type": "button",
+            "props": { "label": "Add task", "variant": "primary" },
+            "on_click": [
+              { "action": "validate", "condition": "{state.draft.length > 0}", "message": "Type a task first" },
+              {
+                "action": "push",
+                "target": "tasks",
+                "value": {
+                  "id": "t-{state.next_id}",
+                  "title": "{state.draft}",
+                  "status": "Todo",
+                  "priority": "{state.draft_priority}",
+                  "due_date": ""
+                }
+              },
+              { "action": "set", "target": "next_id", "value": "{state.next_id + 1}" },
+              { "action": "set", "target": "draft", "value": "" }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "select",
+        "bind": "status_filter",
+        "props": { "label": "Filter by status", "options": "{state.status_filter_options}" }
+      },
+      {
+        "type": "data-grid",
+        "props": {
+          "columns": [
+            { "key": "title", "label": "Task", "sortable": true, "align": "left" },
+            { "key": "status", "label": "Status", "sortable": true, "align": "left", "width": "140px" },
+            { "key": "priority", "label": "Priority", "sortable": true, "align": "left", "width": "110px" },
+            { "key": "due_date", "label": "Due", "sortable": true, "align": "left", "width": "130px" }
+          ],
+          "rows": "{state.tasks.where('status', state.status_filter)}",
+          "searchable": true,
+          "defaultSort": "due_date",
+          "pageSize": 25,
+          "dense": true
+        }
+      }
+    ]
+  }
+}

--- a/src/pocketpaw/bundled_templates/_bundled/todo-task-tracker/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/todo-task-tracker/template.pocket.yaml
@@ -1,0 +1,22 @@
+# src/pocketpaw/bundled_templates/_bundled/todo-task-tracker/template.pocket.yaml
+# Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — RFC 03
+# Pocket Template Schema metadata for the built-in todo / task tracker.
+name: todo-task-tracker
+version: 1.0.0
+vertical: productivity
+shape: data-grid
+description: |
+  A personal task tracker. A sortable, filterable list of tasks with a
+  status, a priority, and a due date. Type a task into the composer
+  row, add it, mark it done, filter by status. The whole list lives in
+  pocket state so every change is reactive — no chat round-trip needed.
+state:
+  entity_type: Task
+  columns:
+    - { field: title, widget: text }
+    - { field: status, widget: badge }
+    - { field: priority, widget: badge }
+    - { field: due_date, widget: date }
+actions: []
+connectors: []
+skills: []

--- a/src/pocketpaw/bundled_templates/installer.py
+++ b/src/pocketpaw/bundled_templates/installer.py
@@ -1,0 +1,240 @@
+# src/pocketpaw/bundled_templates/installer.py
+# Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — auto-installs
+# the built-in pocket templates from
+# ``src/pocketpaw/bundled_templates/_bundled/<slug>/`` into the user's
+# ``~/.pocketpaw/templates/<slug>/`` so the create specialist can
+# instantiate-and-customize a matching template instead of generating a
+# pocket from scratch. Idempotent via SHA-256 hash comparison — the same
+# mirror pattern as ``bundled_kb.installer`` and ``bundled_skills.installer``.
+"""Auto-install bundled pocket templates into the user's PocketPaw dir.
+
+Why this exists
+---------------
+
+The pocket-authoring agent generates every pocket from scratch — slow,
+2-3 iterations, half-baked. PocketPaw ships a curated set of built-in
+templates (todo tracker, kanban board, metrics dashboard, CRM list,
+calendar planner, activity feed). On boot the installer mirrors them
+into ``~/.pocketpaw/templates/`` so the create specialist — and the
+chat agent's STEP 0 template-library check — can read a template back
+and customize it instead of cold-generating.
+
+Behavior
+--------
+
+- **First boot**: every ``_bundled/<slug>/`` directory plus the
+  top-level ``index.json`` are copied to ``~/.pocketpaw/templates/``.
+- **Subsequent boots, same content**: no-op (SHA-256 match per file).
+- **PocketPaw upgrade with new template content**: overwrites the
+  user's copy. We don't merge customizations — operators who hand-edit
+  a template should set
+  ``POCKETPAW_AUTO_INSTALL_BUNDLED_TEMPLATES=false``.
+- **Permissions / I/O failures**: logged at WARNING, never raised.
+  The template library is a non-critical enhancement — pocket creation
+  still works (the specialist cold-generates) even when the install
+  can't run.
+
+Opt-out
+-------
+
+Set ``POCKETPAW_AUTO_INSTALL_BUNDLED_TEMPLATES=false`` in the
+environment. The cold-generation path still works; users who want the
+template boost can manually copy ``_bundled/`` into
+``~/.pocketpaw/templates/``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Where the bundled template directories live inside the package.
+_BUNDLED_DIR = Path(__file__).parent / "_bundled"
+
+
+@dataclass(frozen=True)
+class TemplateInstallResult:
+    """Per-template install outcome surfaced by ``install_bundled_templates``.
+
+    ``status`` is one of:
+      - ``"installed"`` — destination didn't exist; freshly copied.
+      - ``"updated"``   — destination existed but content hash differed.
+      - ``"skipped"``   — destination existed and hash matched; no-op.
+      - ``"failed"``    — I/O error during install; details in ``error``.
+    """
+
+    name: str
+    status: str
+    destination: Path
+    error: str | None = None
+
+
+def install_bundled_templates(
+    *, destination_root: Path | None = None
+) -> list[TemplateInstallResult]:
+    """Mirror every bundled pocket template into the user's PocketPaw dir.
+
+    Both the per-slug template directories (``<slug>/template.pocket.yaml``
+    + ``<slug>/ripple_spec.json``) and the top-level ``index.json`` are
+    copied. ``index.json`` is mirrored as a synthetic result entry named
+    ``"index.json"`` so a hash-drift on the index alone is visible.
+
+    Args:
+        destination_root: Override the install target — useful for
+            tests. Defaults to ``~/.pocketpaw/templates/``.
+
+    Returns:
+        A list of ``TemplateInstallResult``s, one per bundled template
+        plus one for ``index.json``. Sorted by name for deterministic
+        ordering.
+
+    Never raises — per-entry failures are caught and surfaced via
+    ``TemplateInstallResult.status == "failed"`` so a permission error
+    on one entry doesn't block the others.
+    """
+
+    if destination_root is None:
+        destination_root = Path.home() / ".pocketpaw" / "templates"
+
+    if not _BUNDLED_DIR.is_dir():
+        logger.warning(
+            "bundled_templates.installer: bundled dir %s missing — nothing to install",
+            _BUNDLED_DIR,
+        )
+        return []
+
+    results: list[TemplateInstallResult] = []
+
+    for slug_dir in sorted(p for p in _BUNDLED_DIR.iterdir() if p.is_dir()):
+        result = _install_one(slug_dir, destination_root)
+        results.append(result)
+        logger.info(
+            "bundled_templates.installer: %s -> %s",
+            slug_dir.name,
+            result.status,
+        )
+
+    # The registry index sits beside the slug directories — copy it too
+    # so the chat agent's STEP 0 keyword match has the index to read.
+    index_src = _BUNDLED_DIR / "index.json"
+    if index_src.is_file():
+        index_result = _install_index(index_src, destination_root)
+        results.append(index_result)
+        logger.info(
+            "bundled_templates.installer: index.json -> %s",
+            index_result.status,
+        )
+
+    results.sort(key=lambda r: r.name)
+    return results
+
+
+def _install_one(slug_src: Path, destination_root: Path) -> TemplateInstallResult:
+    """Mirror one bundled template directory to the user's PocketPaw dir.
+
+    Same SHA-256-hash-compare-per-file pattern as
+    ``bundled_kb.installer._install_one`` — keep the three installers
+    symmetric so the file-mirror logic is one mental model.
+    """
+
+    name = slug_src.name
+    dest_dir = destination_root / name
+
+    try:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return TemplateInstallResult(
+            name=name,
+            status="failed",
+            destination=dest_dir,
+            error=f"mkdir failed: {exc}",
+        )
+
+    dest_existed = any(dest_dir.iterdir())
+    any_change = False
+    try:
+        for src_file in slug_src.rglob("*"):
+            if not src_file.is_file():
+                continue
+            relative = src_file.relative_to(slug_src)
+            dest_file = dest_dir / relative
+            dest_file.parent.mkdir(parents=True, exist_ok=True)
+
+            if dest_file.exists() and _sha256(dest_file) == _sha256(src_file):
+                continue
+            shutil.copy2(src_file, dest_file)
+            any_change = True
+    except OSError as exc:
+        return TemplateInstallResult(
+            name=name,
+            status="failed",
+            destination=dest_dir,
+            error=f"copy failed: {exc}",
+        )
+
+    if not any_change:
+        status = "skipped"
+    elif dest_existed:
+        status = "updated"
+    else:
+        status = "installed"
+    return TemplateInstallResult(name=name, status=status, destination=dest_dir)
+
+
+def _install_index(index_src: Path, destination_root: Path) -> TemplateInstallResult:
+    """Mirror the top-level ``index.json`` registry into the user's dir.
+
+    Single-file twin of ``_install_one`` — the index is not inside a
+    slug directory so it gets its own copy step. Same SHA-256 compare
+    decides installed / updated / skipped.
+    """
+
+    dest_file = destination_root / "index.json"
+    try:
+        destination_root.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return TemplateInstallResult(
+            name="index.json",
+            status="failed",
+            destination=dest_file,
+            error=f"mkdir failed: {exc}",
+        )
+
+    dest_existed = dest_file.exists()
+    try:
+        if dest_existed and _sha256(dest_file) == _sha256(index_src):
+            return TemplateInstallResult(name="index.json", status="skipped", destination=dest_file)
+        shutil.copy2(index_src, dest_file)
+    except OSError as exc:
+        return TemplateInstallResult(
+            name="index.json",
+            status="failed",
+            destination=dest_file,
+            error=f"copy failed: {exc}",
+        )
+
+    status = "updated" if dest_existed else "installed"
+    return TemplateInstallResult(name="index.json", status=status, destination=dest_file)
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA-256 hex digest of a file's contents.
+
+    Reads in 64 KB chunks so the function works for the rippleSpec JSON
+    files (which can grow large for rich templates) without holding the
+    whole file in memory.
+    """
+
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+__all__ = ["TemplateInstallResult", "install_bundled_templates"]

--- a/src/pocketpaw/bundled_templates/loader.py
+++ b/src/pocketpaw/bundled_templates/loader.py
@@ -1,0 +1,106 @@
+# src/pocketpaw/bundled_templates/loader.py
+# Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — reads a
+# single installed pocket template back from ``~/.pocketpaw/templates/``
+# so the create specialist can instantiate-and-customize it instead of
+# generating a pocket from scratch.
+"""Load an installed pocket template from the user's PocketPaw dir.
+
+The installer (``bundled_templates.installer``) mirrors the bundled
+templates into ``~/.pocketpaw/templates/<slug>/`` on boot. This module
+reads ONE template back by slug — the create specialist calls it when
+the chat agent's STEP 0 keyword match set a ``template_id`` hint.
+
+A template directory holds exactly two files:
+
+- ``template.pocket.yaml`` — RFC 03 Pocket Template Schema metadata.
+- ``ripple_spec.json``     — the hand-authored rippleSpec skeleton.
+
+``load_template`` returns ``{"meta": <yaml dict>, "ripple_spec": <json
+dict>}`` or ``None`` on any failure (unknown slug, missing file, parse
+error, permission error). The caller treats ``None`` as "no template —
+fall back to cold generation"; a template-load failure must never block
+pocket creation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Default install location — kept in sync with
+# ``installer.install_bundled_templates``'s destination default.
+_DEFAULT_TEMPLATES_DIR = Path.home() / ".pocketpaw" / "templates"
+
+
+def load_template(slug: str, *, templates_dir: Path | None = None) -> dict[str, Any] | None:
+    """Read one installed template by slug.
+
+    Args:
+        slug: The template directory name (e.g. ``"todo-task-tracker"``).
+        templates_dir: Override the templates root — useful for tests.
+            Defaults to ``~/.pocketpaw/templates/``.
+
+    Returns:
+        ``{"meta": <parsed template.pocket.yaml>, "ripple_spec":
+        <parsed ripple_spec.json>}`` on success, or ``None`` on ANY
+        failure — unknown slug, a missing sibling file, a YAML/JSON
+        parse error, or an I/O error. The caller falls back to cold
+        generation when this returns ``None``.
+
+    Never raises. A template-load failure is logged at WARNING and
+    surfaced as ``None`` — pocket creation must not break because a
+    template file is missing or corrupt.
+    """
+
+    if templates_dir is None:
+        templates_dir = _DEFAULT_TEMPLATES_DIR
+
+    # Guard against a slug that tries to escape the templates root via
+    # path traversal — the slug is an untrusted hint from the chat agent.
+    if not slug or "/" in slug or "\\" in slug or slug in (".", ".."):
+        logger.warning("bundled_templates.loader: rejecting unsafe slug %r", slug)
+        return None
+
+    slug_dir = templates_dir / slug
+    meta_path = slug_dir / "template.pocket.yaml"
+    spec_path = slug_dir / "ripple_spec.json"
+
+    if not meta_path.is_file() or not spec_path.is_file():
+        logger.warning(
+            "bundled_templates.loader: template %r incomplete or missing (meta=%s spec=%s)",
+            slug,
+            meta_path.is_file(),
+            spec_path.is_file(),
+        )
+        return None
+
+    try:
+        import yaml
+
+        meta = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+        ripple_spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 — any parse / I/O error → None
+        logger.warning(
+            "bundled_templates.loader: failed to load template %r: %s",
+            slug,
+            exc,
+        )
+        return None
+
+    if not isinstance(meta, dict) or not isinstance(ripple_spec, dict):
+        logger.warning(
+            "bundled_templates.loader: template %r has a non-dict file (meta=%s spec=%s)",
+            slug,
+            type(meta).__name__,
+            type(ripple_spec).__name__,
+        )
+        return None
+
+    return {"meta": meta, "ripple_spec": ripple_spec}
+
+
+__all__ = ["load_template"]

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,9 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-05-22: Added ``auto_install_bundled_templates`` — toggles the
+    boot-time mirror of built-in pocket templates into
+    ``~/.pocketpaw/templates/`` (feat/bundled-templates, Increment 2a).
   - 2026-05-21: Added ``auto_install_bundled_skills`` and
     ``auto_install_bundled_kb_scopes`` — toggle the boot-time mirror of
     bundled SKILL.md files and pre-compiled kb-go scopes.
@@ -401,6 +404,23 @@ class Settings(BaseSettings):
             "hand-customised scope or disable bundled KB entirely. KB "
             "retrieval is a non-critical enhancement: pocket creation "
             "still works via the MCP tool surface + the bundled skill."
+        ),
+    )
+    auto_install_bundled_templates: bool = Field(
+        default=True,
+        description=(
+            "On dashboard startup, mirror PocketPaw's built-in pocket "
+            "templates from ``pocketpaw/bundled_templates/_bundled/<slug>/`` "
+            "into ``~/.pocketpaw/templates/<slug>/``. Each template ships a "
+            "``template.pocket.yaml`` (RFC 03 schema metadata) and a "
+            "hand-authored ``ripple_spec.json`` skeleton. The create "
+            "specialist instantiates-and-customizes a matching template "
+            "instead of cold-generating a pocket — the fix for the 2-3 "
+            "iteration authoring pain. Idempotent — SHA-256 hash compare "
+            "per file. Set ``false`` to freeze a hand-customised template "
+            "or disable the template library entirely. Template install is "
+            "best-effort: pocket creation still works (the specialist "
+            "cold-generates) even when no template is installed."
         ),
     )
     deep_agents_skills: list[str] = Field(

--- a/src/pocketpaw/dashboard_lifecycle.py
+++ b/src/pocketpaw/dashboard_lifecycle.py
@@ -7,6 +7,11 @@ Extracted from dashboard.py — contains:
 - ``shutdown_event()`` — tears down all services
 
 Changes:
+- 2026-05-22: ``startup_event`` also mirrors the built-in pocket
+  templates into ``~/.pocketpaw/templates/`` via the
+  ``bundled_templates`` installer — same best-effort, catch-and-log
+  pattern as the skills / kb installers, gated on
+  ``auto_install_bundled_templates`` (feat/bundled-templates, 2a).
 - 2026-05-21: ``startup_event`` mirrors bundled SKILL.md files and
   pre-compiled kb-go scopes into the user's home dir at boot via the
   ``bundled_skills`` / ``bundled_kb`` installers. Best-effort, gated on
@@ -268,6 +273,34 @@ async def startup_event(
                 logger.warning("KB scope %s failed to install: %s", r.name, r.error)
         except Exception as exc:  # noqa: BLE001
             logger.warning("Bundled kb-go scopes install failed (non-fatal): %s", exc)
+
+    # Mirror PocketPaw's built-in pocket templates into
+    # ``~/.pocketpaw/templates/`` so the create specialist can
+    # instantiate-and-customize a matching template instead of
+    # cold-generating a pocket from scratch. Best-effort — a failure
+    # here just means the specialist falls back to cold generation;
+    # pocket creation still works. Opt-out:
+    # ``POCKETPAW_AUTO_INSTALL_BUNDLED_TEMPLATES=false``.
+    if settings.auto_install_bundled_templates:
+        try:
+            from pocketpaw.bundled_templates import install_bundled_templates
+
+            tpl_results = install_bundled_templates()
+            installed = sum(1 for r in tpl_results if r.status == "installed")
+            updated = sum(1 for r in tpl_results if r.status == "updated")
+            skipped = sum(1 for r in tpl_results if r.status == "skipped")
+            failed = [r for r in tpl_results if r.status == "failed"]
+            logger.info(
+                "Bundled pocket templates sync: %d installed / %d updated / %d skipped / %d failed",
+                installed,
+                updated,
+                skipped,
+                len(failed),
+            )
+            for r in failed:
+                logger.warning("Pocket template %s failed to install: %s", r.name, r.error)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Bundled pocket templates install failed (non-fatal): %s", exc)
 
     # Start StatusTracker (agent state for external integrations)
     from pocketpaw.dashboard_state import status_tracker

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -78,6 +78,12 @@
 # Modified: 2026-05-21 — the create specialist's prompt now splices in
 # the slim ``_RIPPLE_DESIGN_ESSENTIALS`` instead of the full
 # ``RIPPLE_DESIGN_RULES`` superblock. Reworked from PR #1106.
+# Modified: 2026-05-22 (feat/bundled-templates, Increment 2a) —
+# ``_CREATION_OVERVIEW_MCP`` gains a new "STEP 0 — CHECK BUILT-IN TEMPLATE
+# LIBRARY FIRST": the chat agent reads ``~/.pocketpaw/templates/index.json``,
+# keyword-matches the brief, and on a match sets ``hints.template_id`` and
+# skips the recipe search. The former recipe-library STEP 0 is renumbered
+# to STEP 1; the brief / structure / delegate steps shift to STEP 2-4.
 
 from __future__ import annotations
 
@@ -1280,13 +1286,52 @@ underlying primitive that actually persists. The skill is the
 preferred entry point when available; the tool is what the skill
 ultimately calls.
 
-### STEP 0 — CHECK THE RECIPE LIBRARY FIRST
+### STEP 0 — CHECK THE BUILT-IN TEMPLATE LIBRARY FIRST
 
-Before any design work, query PocketPaw's bundled recipe library for
-a polished example matching the user's intent. PocketPaw ships
-``ripple-recipes`` — a kb-go scope of hand-authored pattern recipes
-(sales pipeline, customer support app, recipe/how-to viewer, …) —
-auto-installed at ``~/.knowledge-base/ripple-recipes/``.
+Before anything else — before the recipe search in STEP 1 — check
+whether the brief matches one of PocketPaw's built-in pocket
+templates. A built-in template is a hand-authored, production-quality
+pocket skeleton; instantiating one is faster and higher-quality than
+generating from scratch or even anchoring on a recipe. The templates
+are auto-installed at ``~/.pocketpaw/templates/``.
+
+Run via your Bash tool:
+
+```
+cat ~/.pocketpaw/templates/index.json
+```
+
+The file is ``{"templates": [{slug, title, shape, pattern, keywords,
+connectors_hint}, ...]}``. Lower-case the brief and, for each template,
+check whether ANY of its ``keywords`` appears as a case-insensitive
+SUBSTRING of the brief.
+
+- **Match found** — set ``hints.template_id`` to the matched
+  template's ``slug`` when you call ``pocket_specialist__create``.
+  Announce it in your preface line: "Using the built-in <title>
+  template — customizing it for <the user's domain>." Then SKIP the
+  recipe search in STEP 1 (the template already encodes the polished
+  composition). Still do STEP 2 (understand the brief) so the
+  specialist gets the user's real content to customize the template
+  with.
+
+- **No match** — proceed to STEP 1 (the recipe-library search). The
+  template library covers the most common shapes; many briefs won't
+  match one.
+
+- **``index.json`` missing / cat errors** — proceed to STEP 1. Do not
+  block the user on infrastructure issues.
+
+The first match wins — do not agonize over picking the "best" of two
+candidate templates; pick the first whose keyword matched.
+
+### STEP 1 — CHECK THE RECIPE LIBRARY
+
+If STEP 0 did NOT match a built-in template, query PocketPaw's bundled
+recipe library for a polished example matching the user's intent.
+PocketPaw ships ``ripple-recipes`` — a kb-go scope of hand-authored
+pattern recipes (sales pipeline, customer support app, recipe/how-to
+viewer, …) — auto-installed at ``~/.knowledge-base/ripple-recipes/``.
 
 Run via your Bash tool:
 
@@ -1302,7 +1347,7 @@ the showcase-quality version of that pocket pattern. Adapt content
 to the user's specific domain; keep the structural skeleton.
 
 If ``kb search`` returns no matches, continue with first-principles
-drafting using STEP 1-3 below. The recipe library covers high-
+drafting using STEP 2-4 below. The recipe library covers high-
 leverage shapes but does NOT cover every brief.
 
 Why kb-go (not an MCP wrapper): kb-go ships its own SKILL.md with
@@ -1310,7 +1355,7 @@ the canonical CLI surface, and the ``--context`` flag was designed
 for exactly this prompt-injection use case. A wrapper would drift
 from the upstream contract — use the CLI directly.
 
-### STEP 1 — UNDERSTAND THE BRIEF
+### STEP 2 — UNDERSTAND THE BRIEF
 
 You need TWO things before you can plan: structure (what kind of
 pocket) and content seeds (concrete values to populate it).
@@ -1359,10 +1404,13 @@ If the user says "you decide", proceed with your best guess.
 - If the user is annoyed by questions, build with `<placeholder
   values clearly labeled>` and tell them they can edit.
 
-### STEP 2 — PICK THE STRUCTURE
+### STEP 3 — PICK THE STRUCTURE
 
 Decide these BEFORE calling the specialist. Don't make the
-specialist re-derive them from a vague brief:
+specialist re-derive them from a vague brief. (When STEP 0 matched a
+built-in template, the template already encodes layout + focal
+widget — you only need ``data_shape`` + ``key_interactions`` so the
+specialist customizes it with the user's real content.):
 
   • **layout**: one of (in rough order of frequency — hero+grid LAST
     on purpose; only pick it when the pattern is `dashboard`)
@@ -1391,7 +1439,7 @@ specialist re-derive them from a vague brief:
   • **key_interactions**: the verbs the user should be able to do.
     Example: ["add task", "mark done", "filter by status"]
 
-### STEP 3 — DELEGATE WITH A RICH PLAN
+### STEP 4 — DELEGATE WITH A RICH PLAN
 
     pocket_specialist__create({
         "brief": "<1-sentence summary of what the user wants>",
@@ -1400,6 +1448,10 @@ specialist re-derive them from a vague brief:
             "name": "Sales Command Center",
             "color": "#4f46e5",
             "icon": "BarChart3",
+
+            // built-in template — set ONLY when STEP 0 matched one.
+            // It is the highest-authority structural plan.
+            "template_id": "metrics-dashboard",
 
             // structural plan — YOU decide these
             "purpose": "Track quarterly sales pipeline at a glance",

--- a/tests/ee/agent/test_pocket_specialist/test_plan_handoff.py
+++ b/tests/ee/agent/test_pocket_specialist/test_plan_handoff.py
@@ -163,9 +163,19 @@ class TestParentPromptTeachesTwoPhase:
 
         # Pre-delegation thinking block is the marquee change.
         assert "TWO-PHASE DELEGATION" in POCKET_CREATION_PROMPT_MCP
-        assert "STEP 1 — UNDERSTAND THE BRIEF" in POCKET_CREATION_PROMPT_MCP
-        assert "STEP 2 — PICK THE STRUCTURE" in POCKET_CREATION_PROMPT_MCP
-        assert "STEP 3 — DELEGATE WITH A RICH PLAN" in POCKET_CREATION_PROMPT_MCP
+        # Assert on the step CONTENT, not the literal step number — the
+        # prompt's STEP numbering shifts whenever a new step is inserted
+        # (e.g. the built-in-template check became STEP 0). The intent
+        # we care about is that the parent is taught the understand →
+        # structure → delegate progression, in that order.
+        understand_at = POCKET_CREATION_PROMPT_MCP.find("UNDERSTAND THE BRIEF")
+        structure_at = POCKET_CREATION_PROMPT_MCP.find("PICK THE STRUCTURE")
+        delegate_at = POCKET_CREATION_PROMPT_MCP.find("DELEGATE WITH A RICH PLAN")
+        assert understand_at != -1, "prompt missing the 'understand the brief' step"
+        assert structure_at != -1, "prompt missing the 'pick the structure' step"
+        assert delegate_at != -1, "prompt missing the 'delegate with a rich plan' step"
+        # The three phases must appear in the taught order.
+        assert understand_at < structure_at < delegate_at
 
     def test_creation_prompt_lists_layout_menu(self) -> None:
         """The parent must see the layout menu so it can pick."""

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,3 @@
+# tests/unit/__init__.py
+# Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — package
+# marker for the unit-test scope.

--- a/tests/unit/test_bundled_templates.py
+++ b/tests/unit/test_bundled_templates.py
@@ -288,6 +288,7 @@ def test_build_system_prompt_includes_template_block_when_template_id_set(
 ) -> None:
     """``_build_system_prompt`` splices the template skeleton + the
     customization rules in when ``hints.template_id`` is set."""
+    pytest.importorskip("pocketpaw_ee")  # EE-only: skips on an OSS-only install
     _install_to_default(tmp_path, monkeypatch)
 
     from pocketpaw_ee.agent.pocket_specialist.runtime import (
@@ -310,6 +311,7 @@ def test_build_system_prompt_excludes_template_block_without_template_id(
 ) -> None:
     """Without a ``template_id`` hint the template block is absent —
     the specialist cold-generates as before."""
+    pytest.importorskip("pocketpaw_ee")  # EE-only: skips on an OSS-only install
     _install_to_default(tmp_path, monkeypatch)
 
     from pocketpaw_ee.agent.pocket_specialist.runtime import (
@@ -331,6 +333,7 @@ def test_build_system_prompt_excludes_template_block_without_template_id(
 def test_build_system_prompt_ignores_unknown_template_id(tmp_path: Path, monkeypatch) -> None:
     """An unknown ``template_id`` slug is ignored — no template block,
     no crash. The specialist falls back to cold generation."""
+    pytest.importorskip("pocketpaw_ee")  # EE-only: skips on an OSS-only install
     _install_to_default(tmp_path, monkeypatch)
 
     from pocketpaw_ee.agent.pocket_specialist.runtime import (
@@ -353,6 +356,7 @@ async def test_agent_mode_skips_draft_kit_when_template_id_set(tmp_path: Path, m
     """``AgentModeAdapter.create`` short-circuits a ``template_id`` hint:
     it loads the template and goes straight to validate-and-persist,
     SKIPPING the draft-kit round-trip."""
+    pytest.importorskip("pocketpaw_ee")  # EE-only: skips on an OSS-only install
     _install_to_default(tmp_path, monkeypatch)
 
     import pocketpaw_ee.agent.pocket_specialist.adapters as adapters_mod
@@ -404,6 +408,7 @@ async def test_agent_mode_falls_back_to_draft_kit_on_unknown_slug(
 ) -> None:
     """An unknown ``template_id`` slug falls back to the normal draft-kit
     flow — never persists, never crashes."""
+    pytest.importorskip("pocketpaw_ee")  # EE-only: skips on an OSS-only install
     _install_to_default(tmp_path, monkeypatch)
 
     import pocketpaw_ee.agent.pocket_specialist.adapters as adapters_mod

--- a/tests/unit/test_bundled_templates.py
+++ b/tests/unit/test_bundled_templates.py
@@ -1,0 +1,443 @@
+# tests/unit/test_bundled_templates.py
+# Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — covers the
+# built-in pocket templates: the SHA-256 mirror installer, the
+# slug-keyed loader, the RFC 03 schema shape of each bundled
+# template.pocket.yaml, the validity of each ripple_spec.json, and the
+# create-specialist wiring (``_build_system_prompt`` template splice +
+# ``AgentModeAdapter`` template short-circuit).
+"""Tests for the ``pocketpaw.bundled_templates`` package and its wiring.
+
+The installer + loader tests mirror into a ``tmp_path`` destination so
+the user's real ``~/.pocketpaw/templates/`` is never touched. The
+content tests assert each bundled template is well-formed against the
+RFC 03 field set. The specialist-wiring tests confirm a ``template_id``
+hint actually changes the create flow.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.bundled_templates.installer import (
+    TemplateInstallResult,
+    install_bundled_templates,
+)
+from pocketpaw.bundled_templates.loader import load_template
+
+# The six built-in templates Increment 2a ships.
+_EXPECTED_SLUGS = {
+    "todo-task-tracker",
+    "kanban-board",
+    "metrics-dashboard",
+    "crm-record-list",
+    "calendar-planner",
+    "activity-feed",
+}
+
+# RFC 03 Pocket Template Schema — the field set a seed template may
+# carry. Seed templates ship ``actions: []`` and omit
+# ``outcomes / instinct_rules / triggers / agents`` (Instinct + Outcomes
+# are not wired yet — dead declarations are worse than none).
+_RFC03_ALLOWED_FIELDS = {
+    "name",
+    "version",
+    "vertical",
+    "shape",
+    "state",
+    "actions",
+    "connectors",
+    "skills",
+    "description",
+}
+_RFC03_REQUIRED_FIELDS = {"name", "version", "vertical", "shape", "state", "description"}
+# RFC 03 shape enum — the fixed set of Ripple Layer 2 widget shapes.
+_RFC03_SHAPE_ENUM = {
+    "data-grid",
+    "kanban",
+    "calendar",
+    "map",
+    "timeline",
+    "tree",
+    "chart",
+    "custom",
+}
+
+_BUNDLED_DIR = (
+    Path(__file__).resolve().parents[2] / "src" / "pocketpaw" / "bundled_templates" / "_bundled"
+)
+
+
+# ---------------------------------------------------------------------------
+# Installer
+# ---------------------------------------------------------------------------
+
+
+def test_installer_copies_all_six_templates(tmp_path: Path) -> None:
+    """First run mirrors every bundled template directory plus index.json."""
+    results = install_bundled_templates(destination_root=tmp_path)
+
+    installed_slugs = {r.name for r in results if r.name in _EXPECTED_SLUGS}
+    assert installed_slugs == _EXPECTED_SLUGS
+
+    for slug in _EXPECTED_SLUGS:
+        slug_dir = tmp_path / slug
+        assert (slug_dir / "template.pocket.yaml").is_file()
+        assert (slug_dir / "ripple_spec.json").is_file()
+
+    # The registry index sits beside the slug directories.
+    assert (tmp_path / "index.json").is_file()
+    index_result = next(r for r in results if r.name == "index.json")
+    assert index_result.status == "installed"
+
+    # Every per-template result is a frozen dataclass with a clean status.
+    for r in results:
+        assert isinstance(r, TemplateInstallResult)
+        assert r.status in {"installed", "updated", "skipped", "failed"}
+        if r.name in _EXPECTED_SLUGS:
+            assert r.status == "installed"
+            assert r.error is None
+
+
+def test_installer_skips_unchanged_on_second_run(tmp_path: Path) -> None:
+    """Second install with unchanged content is a no-op (SHA-256 match)."""
+    install_bundled_templates(destination_root=tmp_path)
+    results2 = install_bundled_templates(destination_root=tmp_path)
+
+    for r in results2:
+        assert r.status == "skipped", f"{r.name} should be skipped on the 2nd run, got {r.status}"
+
+
+def test_installer_never_raises_on_oserror(tmp_path: Path, monkeypatch) -> None:
+    """An OSError during copy yields a ``failed`` result, never a raise —
+    template install is best-effort and must not block dashboard boot."""
+    import pocketpaw.bundled_templates.installer as installer_mod
+
+    def _explode(*args, **kwargs):  # noqa: ANN001 — test stub
+        raise OSError("simulated permission denied on ~/.pocketpaw/templates/")
+
+    monkeypatch.setattr(installer_mod.shutil, "copy2", _explode)
+
+    results = install_bundled_templates(destination_root=tmp_path)
+    assert results, "installer should still return per-entry results"
+    assert all(r.status == "failed" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def test_loader_returns_meta_and_ripple_spec_for_known_slug(tmp_path: Path) -> None:
+    """A known, installed slug loads to {meta, ripple_spec}, both dicts."""
+    install_bundled_templates(destination_root=tmp_path)
+
+    loaded = load_template("todo-task-tracker", templates_dir=tmp_path)
+    assert loaded is not None
+    assert set(loaded.keys()) == {"meta", "ripple_spec"}
+    assert isinstance(loaded["meta"], dict)
+    assert isinstance(loaded["ripple_spec"], dict)
+    assert loaded["meta"]["name"] == "todo-task-tracker"
+    assert "ui" in loaded["ripple_spec"]
+    assert "state" in loaded["ripple_spec"]
+
+
+def test_loader_returns_none_for_unknown_slug(tmp_path: Path) -> None:
+    """An unknown slug returns None — the caller cold-generates instead."""
+    install_bundled_templates(destination_root=tmp_path)
+    assert load_template("does-not-exist", templates_dir=tmp_path) is None
+
+
+def test_loader_honors_templates_dir_override(tmp_path: Path) -> None:
+    """The ``templates_dir`` override is respected — nothing reads the
+    default ~/.pocketpaw/templates/ when the override is supplied."""
+    other_root = tmp_path / "elsewhere"
+    install_bundled_templates(destination_root=other_root)
+
+    # The override dir has the template; a sibling empty dir does not.
+    assert load_template("kanban-board", templates_dir=other_root) is not None
+    assert load_template("kanban-board", templates_dir=tmp_path / "empty") is None
+
+
+def test_loader_rejects_path_traversal_slug(tmp_path: Path) -> None:
+    """A slug with path separators is rejected — the slug is an untrusted
+    hint and must not escape the templates root."""
+    install_bundled_templates(destination_root=tmp_path)
+    assert load_template("../etc/passwd", templates_dir=tmp_path) is None
+    assert load_template("", templates_dir=tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# Bundled-content shape — RFC 03 schema + valid rippleSpec JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("slug", sorted(_EXPECTED_SLUGS))
+def test_template_yaml_matches_rfc03_field_set(slug: str) -> None:
+    """Each bundled template.pocket.yaml uses ONLY RFC 03 fields, carries
+    every required field, ships ``actions: []``, and uses a valid shape."""
+    import yaml
+
+    meta_path = _BUNDLED_DIR / slug / "template.pocket.yaml"
+    meta = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+
+    assert isinstance(meta, dict)
+    fields = set(meta.keys())
+    extra = fields - _RFC03_ALLOWED_FIELDS
+    assert not extra, f"{slug}: non-RFC03 fields {extra}"
+    missing = _RFC03_REQUIRED_FIELDS - fields
+    assert not missing, f"{slug}: missing required fields {missing}"
+
+    # Seed templates ship empty actions; Instinct/Outcomes aren't wired.
+    assert meta["actions"] == [], f"{slug}: seed templates ship actions: []"
+    # Omit the not-yet-wired RFC 03 optional fields.
+    for omitted in ("outcomes", "instinct_rules", "triggers", "agents"):
+        assert omitted not in meta, f"{slug}: should omit {omitted}"
+
+    assert meta["shape"] in _RFC03_SHAPE_ENUM, f"{slug}: bad shape {meta['shape']!r}"
+    assert isinstance(meta["name"], str) and meta["name"] == slug
+    assert isinstance(meta["state"], dict) and "entity_type" in meta["state"]
+
+
+@pytest.mark.parametrize("slug", sorted(_EXPECTED_SLUGS))
+def test_template_ripple_spec_is_valid_json(slug: str) -> None:
+    """Each ripple_spec.json parses, carries ui + state, and includes the
+    mandated top-level ``_placeholder_note`` field."""
+    spec_path = _BUNDLED_DIR / slug / "ripple_spec.json"
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+
+    assert isinstance(spec, dict)
+    assert "ui" in spec, f"{slug}: ripple_spec must carry a ui tree"
+    assert "state" in spec, f"{slug}: ripple_spec must carry a state block"
+    assert "_placeholder_note" in spec, f"{slug}: ripple_spec must carry _placeholder_note"
+
+
+def test_crm_template_ships_sources_placeholder() -> None:
+    """The CRM template ships a placeholder live-data ``sources`` entry —
+    a GET /contacts binding into state.records."""
+    spec = json.loads((_BUNDLED_DIR / "crm-record-list" / "ripple_spec.json").read_text())
+    sources = spec.get("sources")
+    assert isinstance(sources, dict) and "records" in sources
+    records = sources["records"]
+    assert records["method"] == "GET"
+    assert records["path"] == "/contacts"
+    assert records["bind"] == "state.records"
+    assert "pocket_open" in records["refresh"]
+
+
+def test_index_json_lists_all_six_templates() -> None:
+    """index.json registers every bundled template with the registry
+    row shape the chat agent's STEP 0 keyword match consumes."""
+    index = json.loads((_BUNDLED_DIR / "index.json").read_text())
+    rows = index["templates"]
+    assert {r["slug"] for r in rows} == _EXPECTED_SLUGS
+    for r in rows:
+        assert {"slug", "title", "shape", "pattern", "keywords", "connectors_hint"} <= set(r.keys())
+        assert isinstance(r["keywords"], list) and r["keywords"]
+
+    # The slug of every index row must have a real template directory.
+    for r in rows:
+        assert (_BUNDLED_DIR / r["slug"]).is_dir()
+
+
+@pytest.mark.parametrize("slug", sorted(_EXPECTED_SLUGS))
+def test_template_ripple_spec_passes_manifest_validation_if_reachable(slug: str) -> None:
+    """Each ripple_spec.json passes the Ripple manifest validator when a
+    manifest is reachable. The validator needs a network-fetched manifest;
+    when offline (CI default) it returns no manifest and the check is
+    skipped — never a hard failure on infrastructure."""
+    import asyncio
+
+    from pocketpaw.config import get_settings
+    from pocketpaw.ripple.manifest import get_manifest, validate_against_manifest
+
+    settings = get_settings()
+    manifest = asyncio.run(
+        get_manifest(settings.ripple_manifest_url, ttl_seconds=settings.ripple_manifest_ttl_seconds)
+    )
+    if manifest is None:
+        pytest.skip("ripple manifest not reachable — skipping manifest validation")
+
+    spec = json.loads((_BUNDLED_DIR / slug / "ripple_spec.json").read_text())
+    issues = validate_against_manifest(spec, manifest, apply_aliases=True)
+    assert issues == [], f"{slug}: manifest validation issues {issues}"
+
+
+# ---------------------------------------------------------------------------
+# Create-specialist wiring — _build_system_prompt template splice
+# ---------------------------------------------------------------------------
+
+
+def _install_to_default(tmp_path: Path, monkeypatch) -> Path:
+    """Install the bundled templates into a tmp dir and point the loader's
+    default templates root at it — so code paths that call
+    ``load_template`` with no override (the runtime / adapter wiring)
+    resolve against the tmp install."""
+    import pocketpaw.bundled_templates.loader as loader_mod
+
+    root = tmp_path / "templates"
+    install_bundled_templates(destination_root=root)
+    monkeypatch.setattr(loader_mod, "_DEFAULT_TEMPLATES_DIR", root)
+    return root
+
+
+def test_build_system_prompt_includes_template_block_when_template_id_set(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """``_build_system_prompt`` splices the template skeleton + the
+    customization rules in when ``hints.template_id`` is set."""
+    _install_to_default(tmp_path, monkeypatch)
+
+    from pocketpaw_ee.agent.pocket_specialist.runtime import (
+        PocketSpecialistHints,
+        _build_system_prompt,
+    )
+
+    hints = PocketSpecialistHints(template_id="kanban-board")
+    prompt = _build_system_prompt(hints)
+
+    assert "BUILT-IN TEMPLATE — INSTANTIATE AND CUSTOMIZE" in prompt
+    assert "kanban-board" in prompt
+    assert "CUSTOMIZATION RULES" in prompt
+    # The actual skeleton JSON is spliced in.
+    assert '"columnKey": "status"' in prompt
+
+
+def test_build_system_prompt_excludes_template_block_without_template_id(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Without a ``template_id`` hint the template block is absent —
+    the specialist cold-generates as before."""
+    _install_to_default(tmp_path, monkeypatch)
+
+    from pocketpaw_ee.agent.pocket_specialist.runtime import (
+        PocketSpecialistHints,
+        _build_system_prompt,
+    )
+
+    # No hints at all.
+    assert "BUILT-IN TEMPLATE — INSTANTIATE AND CUSTOMIZE" not in _build_system_prompt(None)
+
+    # Hints with no template_id.
+    hints = PocketSpecialistHints(layout="hero+grid", focal_widget="data-grid")
+    prompt = _build_system_prompt(hints)
+    assert "BUILT-IN TEMPLATE — INSTANTIATE AND CUSTOMIZE" not in prompt
+    # The structural-plan hints still land.
+    assert "STRUCTURAL PLAN FROM PARENT AGENT" in prompt
+
+
+def test_build_system_prompt_ignores_unknown_template_id(tmp_path: Path, monkeypatch) -> None:
+    """An unknown ``template_id`` slug is ignored — no template block,
+    no crash. The specialist falls back to cold generation."""
+    _install_to_default(tmp_path, monkeypatch)
+
+    from pocketpaw_ee.agent.pocket_specialist.runtime import (
+        PocketSpecialistHints,
+        _build_system_prompt,
+    )
+
+    hints = PocketSpecialistHints(template_id="no-such-template")
+    prompt = _build_system_prompt(hints)
+    assert "BUILT-IN TEMPLATE — INSTANTIATE AND CUSTOMIZE" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Create-specialist wiring — AgentModeAdapter template short-circuit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_mode_skips_draft_kit_when_template_id_set(tmp_path: Path, monkeypatch) -> None:
+    """``AgentModeAdapter.create`` short-circuits a ``template_id`` hint:
+    it loads the template and goes straight to validate-and-persist,
+    SKIPPING the draft-kit round-trip."""
+    _install_to_default(tmp_path, monkeypatch)
+
+    import pocketpaw_ee.agent.pocket_specialist.adapters as adapters_mod
+    from pocketpaw_ee.agent.pocket_specialist.runtime import (
+        PocketSpecialistCreateInput,
+        PocketSpecialistCreateOutput,
+        PocketSpecialistHints,
+    )
+
+    persisted_specs: list[dict] = []
+    draft_kit_calls: list[object] = []
+
+    async def _fake_validate_and_persist(input, **kwargs):  # noqa: ANN001 — test stub
+        persisted_specs.append(input.spec)
+        return PocketSpecialistCreateOutput(
+            ok=True, action="created", pocket={"id": "p1"}, duration_ms=1, backend_used="agent_mode"
+        )
+
+    def _fake_draft_kit(input, *, started):  # noqa: ANN001 — test stub
+        draft_kit_calls.append(input)
+        return PocketSpecialistCreateOutput(
+            ok=False, action="draft_kit", duration_ms=1, backend_used="agent_mode"
+        )
+
+    monkeypatch.setattr(adapters_mod, "_validate_and_persist", _fake_validate_and_persist)
+    monkeypatch.setattr(adapters_mod, "_draft_kit_response", _fake_draft_kit)
+
+    adapter = adapters_mod.AgentModeAdapter()
+    payload = PocketSpecialistCreateInput(
+        brief="a kanban board for the team sprint",
+        hints=PocketSpecialistHints(template_id="kanban-board"),
+    )
+    out = await adapter.create(payload, workspace_id="w1", user_id="u1", settings=object())
+
+    assert out.ok is True
+    assert out.action == "created"
+    # Draft kit was skipped; validate-and-persist ran with the template spec.
+    assert draft_kit_calls == []
+    assert len(persisted_specs) == 1
+    spec = persisted_specs[0]
+    assert "ui" in spec and "state" in spec
+    # Authoring-only keys are stripped before persist.
+    assert "_placeholder_note" not in spec
+
+
+@pytest.mark.asyncio
+async def test_agent_mode_falls_back_to_draft_kit_on_unknown_slug(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An unknown ``template_id`` slug falls back to the normal draft-kit
+    flow — never persists, never crashes."""
+    _install_to_default(tmp_path, monkeypatch)
+
+    import pocketpaw_ee.agent.pocket_specialist.adapters as adapters_mod
+    from pocketpaw_ee.agent.pocket_specialist.runtime import (
+        PocketSpecialistCreateInput,
+        PocketSpecialistCreateOutput,
+        PocketSpecialistHints,
+    )
+
+    persisted_specs: list[dict] = []
+    draft_kit_calls: list[object] = []
+
+    async def _fake_validate_and_persist(input, **kwargs):  # noqa: ANN001 — test stub
+        persisted_specs.append(input.spec)
+        return PocketSpecialistCreateOutput(
+            ok=True, action="created", pocket={"id": "p1"}, duration_ms=1, backend_used="agent_mode"
+        )
+
+    def _fake_draft_kit(input, *, started):  # noqa: ANN001 — test stub
+        draft_kit_calls.append(input)
+        return PocketSpecialistCreateOutput(
+            ok=False, action="draft_kit", duration_ms=1, backend_used="agent_mode"
+        )
+
+    monkeypatch.setattr(adapters_mod, "_validate_and_persist", _fake_validate_and_persist)
+    monkeypatch.setattr(adapters_mod, "_draft_kit_response", _fake_draft_kit)
+
+    adapter = adapters_mod.AgentModeAdapter()
+    payload = PocketSpecialistCreateInput(
+        brief="something the templates do not cover at all",
+        hints=PocketSpecialistHints(template_id="no-such-template"),
+    )
+    out = await adapter.create(payload, workspace_id="w1", user_id="u1", settings=object())
+
+    assert out.action == "draft_kit"
+    assert len(draft_kit_calls) == 1
+    assert persisted_specs == []


### PR DESCRIPTION
## What this does

Today the pocket-authoring agent generates every pocket from scratch. That is slow, takes 2-3 iterations, and the first draft is usually half-baked. A todo dashboard is a solved pattern — it should be a template, not a fresh generation each time.

This ships six curated, hand-authored pocket templates the create specialist instantiates and customizes instead of cold-generating.

## The six templates

| Slug | Shape | Pattern |
|------|-------|---------|
| `todo-task-tracker` | data-grid | app |
| `kanban-board` | kanban | app |
| `metrics-dashboard` | data-grid | dashboard |
| `crm-record-list` | custom (master-detail) | browser |
| `calendar-planner` | calendar | app |
| `activity-feed` | timeline | feed |

Each template is a directory under `src/pocketpaw/bundled_templates/_bundled/<slug>/` carrying two files: a `template.pocket.yaml` (RFC 03 Pocket Template Schema metadata) and a production-quality `ripple_spec.json` skeleton. The skeleton is the quality lever — the specialist starts from a correct, well-designed pocket and customizes it rather than designing under time pressure. All six skeletons pass the Ripple widget manifest validator.

## How it works

- A new installer mirrors the templates into `~/.pocketpaw/templates/` on dashboard boot, SHA-256 idempotent — the same pattern as the bundled skills and bundled kb installers. Opt out with `POCKETPAW_AUTO_INSTALL_BUNDLED_TEMPLATES=false`.
- A loader reads one template back by slug.
- The chat agent's create flow gains a STEP 0 that reads the template index, keyword-matches the brief, and sets a `template_id` hint on a match (the former recipe-library check moves to STEP 1).
- The create specialist's system prompt splices in the matched template skeleton plus customization rules — `template_id` is the highest-authority structural plan.
- In agent mode, a `template_id` short-circuits straight to validate-and-persist, skipping the draft-kit round-trip — otherwise agent mode would pay two LLM hops for a one-shot customization.

## Design notes

- Seed templates ship `actions: []` — Instinct and Outcomes are not wired yet, and dead action declarations are worse than none. `outcomes`, `instinct_rules`, `triggers`, and `agents` are omitted for the same reason.
- The `crm-record-list` template ships a placeholder live-data `sources` entry (`GET /contacts` into `state.records`); the specialist keeps it when a backend is configured and drops it when not.
- `ripple_spec.json` is a local runtime sibling, not an RFC 03 field — the registry linter should ignore it. `_bundled/README.md` documents the convention.
- The templates are packaged in the wheel automatically by hatchling's `only-include`. PocketPaw itself is not built with PyInstaller — the only PyInstaller spec is the desktop launcher, which deliberately keeps pocketpaw in a venv — so no `--add-data` change applies.

## Scope

This is sub-increment 2a. Increment 2b adds per-backend API skills next; the new `backend_summary` field on the create input is declared now so 2b does not re-touch the model.

## Tests

`tests/unit/test_bundled_templates.py` — 32 tests covering the installer (copies all six, skips unchanged on the second run, never raises on I/O error), the loader (returns meta + ripple_spec for a known slug, None for unknown, honors the `templates_dir` override, rejects path traversal), each bundled template against the RFC 03 field set, each `ripple_spec.json` for valid JSON and manifest validation, and the specialist wiring (`_build_system_prompt` template splice, `AgentModeAdapter` template short-circuit + fallback). All 32 pass; ruff and format are clean.