### PR TITLE
Pocket execution router + structure/data split (Increment 3)

### DIFF
--- a/ee/pocketpaw_ee/agent/pocket_router/__init__.py
+++ b/ee/pocketpaw_ee/agent/pocket_router/__init__.py
@@ -1,0 +1,23 @@
+# __init__.py — Pocket execution router package.
+# Created: 2026-05-22 (Increment 3) — the classified router that front-runs
+#   ``pocket_specialist__edit`` and routes a request to the cheapest
+#   capable tier (Tier 0 declarative / Tier 1 deterministic op / Tier 2
+#   specialist) instead of always invoking the LLM specialist.
+#
+#   * classifier.py — pure, rule-based ``classify(intent, ripple_spec)``
+#   * router.py     — ``classify_and_route`` dispatch + observability
+#   * events.py     — the ``pocket_execution`` SSE frame schema
+"""Pocket execution router — classify an edit, route to the cheapest tier."""
+
+from __future__ import annotations
+
+from pocketpaw_ee.agent.pocket_router.classifier import Classification, classify
+from pocketpaw_ee.agent.pocket_router.events import PocketExecutionFrame
+from pocketpaw_ee.agent.pocket_router.router import classify_and_route
+
+__all__ = [
+    "Classification",
+    "PocketExecutionFrame",
+    "classify",
+    "classify_and_route",
+]

--- a/ee/pocketpaw_ee/agent/pocket_router/classifier.py
+++ b/ee/pocketpaw_ee/agent/pocket_router/classifier.py
@@ -1,0 +1,589 @@
+# classifier.py — Pure, rule-based tier classifier for the pocket
+#   execution router.
+# Created: 2026-05-22 (Increment 3) — front-runs ``pocket_specialist__edit``.
+#   Given a natural-language edit intent and the pocket's rippleSpec, it
+#   decides the CHEAPEST capable execution tier:
+#     * Tier 0 (declarative)  — fire a declared ``sources.X`` / ``actions.X``
+#     * Tier 1 (deterministic) — apply exactly one granular op
+#     * Tier 2 (specialist)    — escalate to the existing LLM flow
+#
+# This module is PURE: no I/O, no Beanie, no LLM, no logging side effects.
+# It only inspects the two arguments and returns a ``Classification``.
+# Purity is an import-linter contract — the router (router.py) is the
+# layer allowed to touch executors and the specialist.
+#
+# FAIL-SAFE is the governing rule: the classifier returns a cheap-tier
+# verdict ONLY when it is HIGH-confidence the cheap tier produces the
+# EXACT change the user asked for. Any doubt — partial keyword match, a
+# structural verb anywhere in the intent, a target that resolves to !=1
+# entity, an unresolved ``{state.x}`` / ``{item.id}`` action param, a
+# ``requires_instinct`` action, or a confidence below threshold —
+# escalates to Tier 2. A wrong skip produces a broken pocket; a wrong
+# escalate only costs an LLM call. The asymmetry drives every default.
+"""Pure rule-based tier classifier for the pocket execution router."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+# ---------------------------------------------------------------------------
+# Verdict
+# ---------------------------------------------------------------------------
+
+Tier = Literal[0, 1, 2]
+
+
+@dataclass(frozen=True)
+class Classification:
+    """The classifier's verdict for one edit intent.
+
+    ``tier`` — 0 declarative, 1 deterministic op, 2 specialist.
+    ``target`` — what the cheap tier acts on: a source/action key (Tier
+    0), a state path or node id (Tier 1), or ``None`` (Tier 2, nothing
+    resolved).
+    ``op`` — for Tier 0, ``run_source`` / ``run_action``; for Tier 1, the
+    granular op name (``set_state`` / ``set_node_prop``); ``None`` for
+    Tier 2.
+    ``confidence`` — the classifier's confidence in a cheap-tier verdict,
+    in ``[0.0, 1.0]``. Tier 2 verdicts carry the confidence of *not*
+    being a cheap tier, which is always 1.0 (escalation is never wrong).
+    ``reasoning`` — a short human-readable explanation, surfaced in the
+    audit entry and the ``pocket_execution`` frame.
+    ``op_args`` — for a Tier 0/1 verdict, the resolved arguments the
+    router hands to the executor / op-apply path. Empty for Tier 2.
+    """
+
+    tier: Tier
+    target: str | None
+    confidence: float
+    reasoning: str
+    op: str | None = None
+    op_args: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_escalation(self) -> bool:
+        """True when the verdict routes to the specialist (Tier 2)."""
+        return self.tier == 2
+
+
+def _escalate(reasoning: str) -> Classification:
+    """Build a Tier-2 (specialist) verdict. The fail-safe default."""
+    return Classification(tier=2, target=None, confidence=1.0, reasoning=reasoning, op=None)
+
+
+# ---------------------------------------------------------------------------
+# Keyword tables
+# ---------------------------------------------------------------------------
+#
+# These are deliberately conservative. A verb only counts when it appears
+# as a whole word (``\b`` anchored) — "remarketing" must not match
+# "remove". A *partial* signal (a verb that hints at a tier but whose
+# object the classifier cannot pin to exactly one spec entity) escalates.
+
+# Structural verbs — anything that changes the COMPONENT TREE shape.
+# Their mere presence forces Tier 2: the specialist owns structure.
+_STRUCTURAL_VERBS: frozenset[str] = frozenset(
+    {
+        "add",
+        "create",
+        "insert",
+        "build",
+        "redesign",
+        "rebuild",
+        "restructure",
+        "reorganize",
+        "reorganise",
+        "layout",
+        "move",
+        "rearrange",
+        "delete",
+        "drop",
+        "split",
+        "merge",
+        "convert",
+        "turn",
+        "wrap",
+        "group",
+        "duplicate",
+        "clone",
+        "swap",
+        "redo",
+    }
+)
+
+# Creative / ambiguous verbs — open-ended intent the classifier cannot
+# reduce to one op. Also Tier 2.
+_CREATIVE_VERBS: frozenset[str] = frozenset(
+    {
+        "improve",
+        "polish",
+        "clean",
+        "cleanup",
+        "declutter",
+        "simplify",
+        "beautify",
+        "modernize",
+        "modernise",
+        "fix",
+        "tweak",
+        "adjust",
+        "enhance",
+        "optimize",
+        "optimise",
+        "refresh",  # NB: "refresh the dashboard" is creative; "refresh <source>"
+        # is Tier 0 — handled explicitly in ``_classify_tier0`` before this
+        # table is consulted.
+    }
+)
+
+# Tier-0 declarative verbs: a data REFRESH against a declared source.
+# Deliberately NOT "update" — "update" is too generic ("update the chart
+# title" is a prop edit, not a source refresh); it would shadow Tier 1.
+_REFRESH_VERBS: frozenset[str] = frozenset({"refresh", "reload", "sync", "fetch", "pull"})
+
+# Tier-0 declarative verbs: fire a declared write action.
+_ACTION_VERBS: frozenset[str] = frozenset({"submit", "save", "send", "post"})
+
+# Tier-1 deterministic-op verbs: a status flip on one state field.
+# ``mark`` / ``toggle`` are direction-NEUTRAL — they need an explicit
+# done/todo word to pin a direction. The others carry their own
+# direction: ``check`` / ``complete`` / ``tick`` mean DONE,
+# ``uncheck`` / ``untick`` mean NOT-DONE.
+_MARK_VERBS: frozenset[str] = frozenset(
+    {"mark", "check", "uncheck", "complete", "toggle", "tick", "untick"}
+)
+_VERB_IMPLIES_DONE: frozenset[str] = frozenset({"check", "complete", "tick"})
+_VERB_IMPLIES_NOT_DONE: frozenset[str] = frozenset({"uncheck", "untick"})
+
+# Tier-1 deterministic-op verbs: a single-prop / single-field rename.
+_RENAME_VERBS: frozenset[str] = frozenset({"rename", "relabel", "retitle"})
+
+# Tier-1 deterministic-op verbs: set a filter / single state value.
+_SET_VERBS: frozenset[str] = frozenset({"set", "filter", "change"})
+
+# An unresolved Ripple expression in an action's params — a ``{...}``
+# template the classifier cannot evaluate without runtime state.
+_RIPPLE_EXPR = re.compile(r"\{[^}]+\}")
+
+
+def _words(intent: str) -> list[str]:
+    """Lowercase whole-word tokens of the intent."""
+    return re.findall(r"[a-z0-9_]+", intent.lower())
+
+
+def _has_any(words: list[str], table: frozenset[str]) -> bool:
+    return any(w in table for w in words)
+
+
+# ---------------------------------------------------------------------------
+# Spec inspection helpers (pure)
+# ---------------------------------------------------------------------------
+
+
+def _sources(ripple_spec: dict[str, Any]) -> dict[str, Any]:
+    raw = (ripple_spec or {}).get("sources")
+    return raw if isinstance(raw, dict) else {}
+
+
+def _actions(ripple_spec: dict[str, Any]) -> dict[str, Any]:
+    raw = (ripple_spec or {}).get("actions")
+    return raw if isinstance(raw, dict) else {}
+
+
+def _state(ripple_spec: dict[str, Any]) -> dict[str, Any]:
+    raw = (ripple_spec or {}).get("state")
+    return raw if isinstance(raw, dict) else {}
+
+
+def _match_keys(words: list[str], keys: list[str]) -> list[str]:
+    """Return the spec keys whose name appears in the intent.
+
+    A key matches when the key itself (lowercased) is one of the intent
+    words, OR when every underscore-split segment of the key is an intent
+    word (so ``mark_done`` matches "mark done"). Conservative: a key like
+    ``orders`` matches "refresh orders" but not "refresh order" — exact
+    whole-word only.
+    """
+    wset = set(words)
+    hits: list[str] = []
+    for key in keys:
+        low = key.lower()
+        if low in wset:
+            hits.append(key)
+            continue
+        segments = [s for s in re.split(r"[_\-]", low) if s]
+        if segments and all(seg in wset for seg in segments):
+            hits.append(key)
+    return hits
+
+
+def _action_params_resolve(action_entry: Any) -> bool:
+    """True when an action's declared ``params`` carry NO unresolved
+    Ripple expression.
+
+    A ``{state.x}`` / ``{item.id}`` in a param value means the action
+    cannot fire without runtime context the classifier does not have —
+    that escalates. An action with static params (or none) resolves.
+    """
+    if not isinstance(action_entry, dict):
+        return False
+    params = action_entry.get("params")
+    if params is None:
+        return True
+    if not isinstance(params, dict):
+        return False
+
+    def _scan(value: Any) -> bool:
+        if isinstance(value, str):
+            return _RIPPLE_EXPR.search(value) is None
+        if isinstance(value, dict):
+            return all(_scan(v) for v in value.values())
+        if isinstance(value, list):
+            return all(_scan(v) for v in value)
+        return True
+
+    return _scan(params)
+
+
+def _action_requires_instinct(action_entry: Any) -> bool:
+    """True when the raw action carries a truthy ``requires_instinct``.
+
+    Mirrors ``action_executor._instinct_rejected`` — such an action must
+    NOT be auto-fired by the router; it escalates so the specialist flow
+    (and its human-in-the-loop affordances) handles it.
+    """
+    return isinstance(action_entry, dict) and bool(action_entry.get("requires_instinct"))
+
+
+# ---------------------------------------------------------------------------
+# Tier 0 — declarative
+# ---------------------------------------------------------------------------
+
+
+def _classify_tier0(words: list[str], ripple_spec: dict[str, Any]) -> Classification | None:
+    """Try to classify as Tier 0 (declarative). Returns ``None`` when the
+    intent is not a clean declarative match — the caller falls through."""
+    sources = _sources(ripple_spec)
+    actions = _actions(ripple_spec)
+
+    # ---- refresh / reload a declared source ----
+    if _has_any(words, _REFRESH_VERBS) and sources:
+        hits = _match_keys(words, list(sources.keys()))
+        if len(hits) == 1:
+            key = hits[0]
+            return Classification(
+                tier=0,
+                target=key,
+                confidence=0.97,
+                reasoning=f"intent refreshes the declared source '{key}' 1:1",
+                op="run_source",
+                op_args={"source": key},
+            )
+        if len(hits) > 1:
+            return _escalate(
+                f"refresh intent matched {len(hits)} sources {sorted(hits)} — "
+                "ambiguous, the specialist disambiguates"
+            )
+        # A refresh verb with no named source. "refresh the dashboard"
+        # is creative, not declarative — fall through to escalation.
+        return None
+
+    # ---- submit / save -> a declared write action ----
+    if _has_any(words, _ACTION_VERBS) and actions:
+        hits = _match_keys(words, list(actions.keys()))
+        if len(hits) == 1:
+            key = hits[0]
+            entry = actions[key]
+            if _action_requires_instinct(entry):
+                return _escalate(
+                    f"action '{key}' is marked requires_instinct — escalating "
+                    "so the gated flow handles approval"
+                )
+            if not _action_params_resolve(entry):
+                return _escalate(
+                    f"action '{key}' has unresolved {{state.x}}/{{item.id}} "
+                    "params — cannot fire declaratively, escalating"
+                )
+            return Classification(
+                tier=0,
+                target=key,
+                confidence=0.95,
+                reasoning=f"intent fires the declared action '{key}' 1:1 with resolved params",
+                op="run_action",
+                op_args={"action": key},
+            )
+        if len(hits) > 1:
+            return _escalate(
+                f"action intent matched {len(hits)} actions {sorted(hits)} — ambiguous"
+            )
+        return None
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — deterministic single granular op
+# ---------------------------------------------------------------------------
+
+# Status keywords the classifier knows how to write into a task/item
+# ``status`` field for a "mark X done" intent.
+_DONE_WORDS: frozenset[str] = frozenset({"done", "complete", "completed", "finished", "closed"})
+_NOT_DONE_WORDS: frozenset[str] = frozenset({"undone", "incomplete", "open", "todo", "pending"})
+
+# A trailing integer in the intent — "mark task 3 done" -> 3.
+_INDEX_RE = re.compile(r"\b(\d{1,4})\b")
+
+
+def _classify_tier1(
+    intent: str, words: list[str], ripple_spec: dict[str, Any]
+) -> Classification | None:
+    """Try to classify as Tier 1 (one deterministic granular op).
+
+    Returns ``None`` when the intent is not an unambiguous single-op
+    match. The router only acts on a returned verdict; ``None`` means
+    fall through to escalation.
+    """
+    state = _state(ripple_spec)
+
+    # ---- "mark task N done" -> set_state on a status field ----
+    if _has_any(words, _MARK_VERBS):
+        idx_match = _INDEX_RE.search(intent)
+        wset = set(words)
+        # Direction comes from an explicit done/todo word OR from a
+        # self-directed verb (``check`` -> done, ``uncheck`` -> not-done).
+        wants_done = bool(wset & _DONE_WORDS) or bool(wset & _VERB_IMPLIES_DONE)
+        wants_not_done = bool(wset & _NOT_DONE_WORDS) or bool(wset & _VERB_IMPLIES_NOT_DONE)
+        # Exactly one direction, exactly one numeric target, and a state
+        # array the index can address — anything else escalates.
+        if idx_match and (wants_done ^ wants_not_done):
+            idx = int(idx_match.group(1))
+            collection = _single_indexable_collection(state)
+            if collection is None:
+                return _escalate(
+                    "mark-done intent but no single indexable task/item "
+                    "collection in state — the specialist disambiguates"
+                )
+            name, length = collection
+            # 1-based human counting -> 0-based index. Reject out of range.
+            zero_idx = idx - 1
+            if not (0 <= zero_idx < length):
+                return _escalate(
+                    f"mark-done index {idx} is out of range for state.{name} "
+                    f"(len {length}) — escalating"
+                )
+            status_value = "done" if wants_done else "todo"
+            path = f"{name}[{zero_idx}].status"
+            return Classification(
+                tier=1,
+                target=path,
+                confidence=0.95,
+                reasoning=(
+                    f"mark item {idx} -> set_state state.{path} = '{status_value}' "
+                    "(single deterministic op)"
+                ),
+                op="set_state",
+                op_args={"path": path, "value": status_value},
+            )
+        return _escalate(
+            "mark/toggle intent is not an unambiguous single-item status "
+            "flip — escalating to the specialist"
+        )
+
+    # ---- "set filter to X" -> set_state on a top-level scalar ----
+    if "filter" in words and _has_any(words, _SET_VERBS | {"filter"}):
+        if "filter" in state and not isinstance(state.get("filter"), (dict, list)):
+            value = _trailing_value(intent)
+            if value is not None:
+                return Classification(
+                    tier=1,
+                    target="filter",
+                    confidence=0.92,
+                    reasoning=f"set the declared scalar state.filter = '{value}' (single op)",
+                    op="set_state",
+                    op_args={"path": "filter", "value": value},
+                )
+            return _escalate("set-filter intent has no extractable target value — escalating")
+        return _escalate("set-filter intent but state has no scalar 'filter' field — escalating")
+
+    # ---- "rename X to Y" -> set_node_prop, only when X resolves to one node ----
+    if _has_any(words, _RENAME_VERBS):
+        new_label = _rename_target(intent)
+        node_hits = _nodes_matching_rename(intent, ripple_spec)
+        if new_label is None:
+            return _escalate("rename intent has no extractable new label — escalating")
+        if len(node_hits) != 1:
+            return _escalate(
+                f"rename intent resolved to {len(node_hits)} candidate nodes — "
+                "the specialist disambiguates which node to relabel"
+            )
+        node_id, prop = node_hits[0]
+        return Classification(
+            tier=1,
+            target=node_id,
+            confidence=0.91,
+            reasoning=(
+                f"rename -> set_node_prop {node_id}.{prop} = '{new_label}' "
+                "(single deterministic op)"
+            ),
+            op="set_node_prop",
+            op_args={"node_id": node_id, "prop": prop, "value": new_label},
+        )
+
+    return None
+
+
+def _single_indexable_collection(state: dict[str, Any]) -> tuple[str, int] | None:
+    """Return ``(name, length)`` when state has EXACTLY ONE list whose
+    items are objects (a task/item collection an index can address);
+    ``None`` otherwise.
+
+    Multiple candidate lists is ambiguous — escalate. Zero is escalate.
+    A list of scalars is not an addressable item collection.
+    """
+    candidates: list[tuple[str, int]] = []
+    for name, value in state.items():
+        if isinstance(value, list) and value and all(isinstance(it, dict) for it in value):
+            candidates.append((name, len(value)))
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _trailing_value(intent: str) -> str | None:
+    """Extract the value after a ``to`` / ``=`` / ``:`` in a set-style
+    intent — "set the filter to overdue" -> "overdue"."""
+    m = re.search(r"(?:\bto\b|=|:)\s*['\"]?([A-Za-z0-9_\- ]+?)['\"]?\s*$", intent.strip())
+    if m:
+        value = m.group(1).strip()
+        return value or None
+    return None
+
+
+def _rename_target(intent: str) -> str | None:
+    """Extract the new label from a rename intent.
+
+    Handles ``rename X to "Y"`` and ``rename X to Y``. The quoted form
+    matches the SAME quote char that opened (so an apostrophe inside a
+    double-quoted label — ``"Today's Work"`` — is kept verbatim).
+    Returns ``None`` when no ``to`` clause is present — without a target
+    label the op cannot run.
+    """
+    m = re.search(r"\bto\b\s+([\"'])(.+?)\1", intent)
+    if m:
+        return m.group(2).strip() or None
+    m = re.search(r"\bto\b\s+(.+?)\s*$", intent.strip())
+    if m:
+        return m.group(1).strip().strip("'\"") or None
+    return None
+
+
+def _iter_nodes(node: Any) -> list[dict[str, Any]]:
+    """Flatten a rippleSpec UI tree to a list of node dicts."""
+    out: list[dict[str, Any]] = []
+    if not isinstance(node, dict):
+        return out
+    out.append(node)
+    for child in node.get("children") or []:
+        out.extend(_iter_nodes(child))
+    return out
+
+
+def _nodes_matching_rename(intent: str, ripple_spec: dict[str, Any]) -> list[tuple[str, str]]:
+    """Return ``(node_id, prop)`` pairs for nodes a rename intent targets.
+
+    A node matches when one of its text-ish props (``text`` / ``title`` /
+    ``label`` / ``heading``) holds a value whose words all appear in the
+    intent BEFORE the ``to`` clause. The prop returned is the one that
+    matched. This is intentionally strict — a rename only goes Tier 1
+    when EXACTLY ONE node matches; the caller escalates otherwise.
+    """
+    before_to = re.split(r"\bto\b", intent, maxsplit=1)[0].lower()
+    before_words = set(re.findall(r"[a-z0-9_]+", before_to))
+    if not before_words:
+        return []
+    label_props = ("text", "title", "label", "heading")
+    hits: list[tuple[str, str]] = []
+    ui = (ripple_spec or {}).get("ui")
+    for node in _iter_nodes(ui):
+        node_id = node.get("id")
+        props = node.get("props")
+        if not isinstance(node_id, str) or not isinstance(props, dict):
+            continue
+        for prop in label_props:
+            raw = props.get(prop)
+            if not isinstance(raw, str) or not raw.strip():
+                continue
+            value_words = set(re.findall(r"[a-z0-9_]+", raw.lower()))
+            # Every word of the current prop value is named in the intent.
+            if value_words and value_words <= before_words:
+                hits.append((node_id, prop))
+                break
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def classify(intent: str, ripple_spec: dict[str, Any]) -> Classification:
+    """Classify an edit ``intent`` against a pocket's ``ripple_spec``.
+
+    Pure — no I/O, no LLM. Returns a :class:`Classification` naming the
+    cheapest capable tier. The decision order is fail-safe:
+
+    1. An empty / too-short intent escalates (nothing to classify).
+    2. A structural or creative verb ANYWHERE in the intent escalates —
+       the specialist owns structure and open-ended change.
+    3. Tier 0 — a clean 1:1 declarative match against a declared
+       ``sources.X`` (refresh) or ``actions.X`` (submit/save).
+    4. Tier 1 — a clean single-op match (``set_state`` / ``set_node_prop``).
+    5. Anything left escalates to Tier 2.
+
+    The classifier never *guesses*: a partial match, a target resolving
+    to !=1 entity, an unresolved action param, or a ``requires_instinct``
+    action all escalate. A wrong skip breaks the pocket.
+    """
+    if not intent or len(intent.strip()) < 3:
+        return _escalate("intent is empty or too short to classify — escalating")
+
+    words = _words(intent)
+
+    # --- Tier 0 is checked FIRST so a declarative "refresh <source>"
+    # wins over the "refresh" creative-verb escalation below. The Tier-0
+    # path only matches a refresh verb when it pins to exactly one named
+    # source; otherwise it returns ``None`` and the creative-verb guard
+    # catches the bare "refresh the dashboard" case. ---
+    tier0 = _classify_tier0(words, ripple_spec)
+    if tier0 is not None:
+        return tier0
+
+    # --- Structural verbs: the specialist owns the component tree. ---
+    if _has_any(words, _STRUCTURAL_VERBS):
+        struck = sorted(set(words) & _STRUCTURAL_VERBS)
+        return _escalate(
+            f"structural verb(s) {struck} present — component-tree change, "
+            "the specialist owns structure"
+        )
+
+    # --- Creative / ambiguous verbs: open-ended, no single op. ---
+    if _has_any(words, _CREATIVE_VERBS):
+        struck = sorted(set(words) & _CREATIVE_VERBS)
+        return _escalate(
+            f"creative / ambiguous verb(s) {struck} present — no single "
+            "deterministic op expresses this, escalating"
+        )
+
+    # --- Tier 1: one deterministic granular op. ---
+    tier1 = _classify_tier1(intent, words, ripple_spec)
+    if tier1 is not None:
+        return tier1
+
+    # --- Fail-safe default. ---
+    return _escalate(
+        "intent did not match a high-confidence Tier-0 or Tier-1 rule — "
+        "escalating to the specialist (fail-safe default)"
+    )
+
+
+__all__ = ["Classification", "Tier", "classify"]

--- a/ee/pocketpaw_ee/agent/pocket_router/events.py
+++ b/ee/pocketpaw_ee/agent/pocket_router/events.py
@@ -1,0 +1,107 @@
+# events.py — SSE-event payload schemas for the pocket execution router.
+# Created: 2026-05-22 (Increment 3) — defines ``PocketExecutionFrame``,
+#   the single ``pocket_execution`` observability frame the router emits
+#   per ``classify_and_route`` call. The frame is the Thesys-style "what
+#   ran / what was skipped" readout: which tier handled the request, a
+#   per-stage timeline (each stage's ``ran`` flag, latency, and
+#   skipped-reason), total latency, and token spend. Tier 0/1 (the cheap
+#   tiers) report ``tokens:{0,0}`` and mark the ``layout_build`` /
+#   ``widget_render`` stages ``ran:false`` with reason "data-only change"
+#   so a client can show the user exactly what the cheap path avoided.
+#
+# Pure Pydantic models — no I/O, no Beanie, no LLM. Mirrors the shape of
+# ``cloud/chat/agent_schemas.py`` (the sibling SSE frame definitions).
+"""SSE-event payload schemas for the pocket execution router."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# The fixed stage vocabulary of a pocket-edit execution. ``classify`` and
+# ``apply`` always run; ``layout_build`` and ``widget_render`` are the
+# expensive stages a Tier-0/1 verdict skips (a data-only change needs no
+# layout pass). Kept as a Literal so a typo in a stage name fails loudly.
+ExecutionStageName = Literal[
+    "classify",
+    "apply",
+    "layout_build",
+    "widget_render",
+]
+
+
+class ExecutionStage(BaseModel):
+    """One stage in a pocket-edit execution timeline.
+
+    ``ran`` is True when the stage actually did work; when False,
+    ``skipped_reason`` explains why (e.g. "data-only change" for the
+    layout stages on a Tier-1 state edit). ``ms`` is the wall-clock cost
+    of the stage — 0 for a skipped stage. ``detail`` carries an optional
+    free-form note (the tier verdict's reasoning, an op count, …).
+    """
+
+    stage: ExecutionStageName
+    ran: bool
+    ms: int = Field(default=0, ge=0, description="Wall-clock cost of the stage, ms.")
+    skipped_reason: str | None = Field(
+        default=None,
+        description="Why the stage did not run — set iff ``ran`` is False.",
+    )
+    detail: str | None = Field(
+        default=None,
+        description="Optional free-form note (verdict reasoning, op count, …).",
+    )
+
+
+class TokenSpend(BaseModel):
+    """Prompt + completion token spend for one execution.
+
+    Tier 0 and Tier 1 are pure / deterministic — no LLM runs — so they
+    report ``{0, 0}``. Only a Tier-2 escalation spends tokens, and the
+    specialist's own accounting is not threaded back into this frame in
+    Increment 3 (it stays ``{0, 0}`` until the specialist surfaces a
+    usage report); the frame still carries the field so the wire shape
+    is stable.
+    """
+
+    prompt: int = Field(default=0, ge=0)
+    completion: int = Field(default=0, ge=0)
+
+
+class PocketExecutionFrame(BaseModel):
+    """The ``pocket_execution`` SSE frame — one per routed request.
+
+    Emitted once by ``router.classify_and_route`` after the chosen tier
+    finishes. It is the router's observability surface: a client renders
+    it as a "this edit took Tier 1, 14 ms, 0 tokens, skipped layout +
+    render" readout.
+
+    ``tier_chosen`` is the tier that actually executed (0 declarative,
+    1 deterministic op, 2 specialist). ``stages`` is the ordered
+    timeline. ``total_ms`` is the end-to-end router cost. ``tokens`` is
+    the LLM spend — ``{0, 0}`` for the cheap tiers.
+    """
+
+    type: Literal["pocket_execution"] = "pocket_execution"
+    request_id: str = Field(description="Correlation id for this routed request.")
+    intent: str = Field(description="The natural-language edit intent that was routed.")
+    tier_chosen: Literal[0, 1, 2] = Field(description="Tier that executed the request.")
+    stages: list[ExecutionStage] = Field(
+        default_factory=list,
+        description="Ordered per-stage timeline.",
+    )
+    total_ms: int = Field(default=0, ge=0, description="End-to-end router cost, ms.")
+    tokens: TokenSpend = Field(default_factory=TokenSpend)
+
+    def to_wire(self) -> dict:
+        """Serialize to the dict pushed via ``push_pocket_execution``."""
+        return self.model_dump(mode="json")
+
+
+__all__ = [
+    "ExecutionStage",
+    "ExecutionStageName",
+    "PocketExecutionFrame",
+    "TokenSpend",
+]

--- a/ee/pocketpaw_ee/agent/pocket_router/router.py
+++ b/ee/pocketpaw_ee/agent/pocket_router/router.py
@@ -1,0 +1,536 @@
+# router.py — The pocket execution router.
+# Created: 2026-05-22 (Increment 3) — ``classify_and_route`` sits in front
+#   of ``pocket_specialist__edit``. It runs the pure classifier
+#   (classifier.py) and dispatches to the CHEAPEST capable tier:
+#
+#     Tier 0 (declarative)  — fire a declared source / action via the
+#                             existing executors (source_executor.run_sources
+#                             / action_executor.run_action). The executors
+#                             keep ALL their guards (allowlist, SSRF, rate
+#                             limit, fail-closed instinct-reject); the router
+#                             only INVOKES them — it bypasses no guard.
+#     Tier 1 (deterministic) — apply one granular op through the existing
+#                             ``EditAgentModeAdapter`` op-apply path.
+#     Tier 2 (specialist)    — escalate to ``run_edit_specialist`` UNCHANGED.
+#
+# Every call records a per-stage timeline, emits ONE ``pocket_execution``
+# SSE frame (the Thesys "what ran / what was skipped" readout) and writes a
+# ``pocket_router`` audit entry — WARNING severity on a Tier-0/1 bypass,
+# because that is a write/mutation with no agent reasoning behind it and
+# deserves a durable trail.
+#
+# The kill-switch (``settings.pocket_router_enabled``) and the confidence
+# floor (``settings.pocket_router_min_confidence``) make the router
+# fail-safe: with the switch off, or on any sub-threshold verdict, the
+# router escalates and behaves exactly like today.
+"""The pocket execution router — classify an edit, route to the cheapest tier."""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import Any
+
+from pocketpaw_ee.agent.pocket_router.classifier import Classification, classify
+from pocketpaw_ee.agent.pocket_router.events import (
+    ExecutionStage,
+    PocketExecutionFrame,
+    TokenSpend,
+)
+
+logger = logging.getLogger(__name__)
+
+# Skip-reason string for the layout / render stages on a Tier-0/1 route.
+# A declarative refresh or a single-op data edit changes no component
+# structure, so the renderer never re-runs layout — the cheap-tier win.
+_SKIP_REASON_DATA_ONLY = "data-only change"
+
+
+class _Timeline:
+    """Accumulates ``ExecutionStage`` rows for one routed request.
+
+    A tiny mutable helper — the router opens stages with ``start`` and
+    closes them with ``finish`` so the per-stage ``ms`` is real
+    wall-clock, then ``skipped`` records a stage that never ran.
+    """
+
+    def __init__(self) -> None:
+        self._stages: list[ExecutionStage] = []
+        self._open: dict[str, float] = {}
+
+    def start(self, stage: str) -> None:
+        self._open[stage] = time.monotonic()
+
+    def finish(self, stage: str, detail: str | None = None) -> None:
+        began = self._open.pop(stage, None)
+        ms = int((time.monotonic() - began) * 1000) if began is not None else 0
+        self._stages.append(ExecutionStage(stage=stage, ran=True, ms=ms, detail=detail))  # type: ignore[arg-type]
+
+    def skipped(self, stage: str, reason: str) -> None:
+        self._stages.append(
+            ExecutionStage(stage=stage, ran=False, ms=0, skipped_reason=reason)  # type: ignore[arg-type]
+        )
+
+    def rows(self) -> list[ExecutionStage]:
+        return list(self._stages)
+
+
+def _add_skipped_layout_stages(timeline: _Timeline) -> None:
+    """Mark the two expensive stages a cheap-tier route never runs.
+
+    A Tier-0 declarative refresh and a Tier-1 single-op data edit both
+    leave the component tree untouched, so ``layout_build`` and
+    ``widget_render`` are skipped — this is the readout the user sees in
+    the ``pocket_execution`` frame ("skipped: data-only change")."""
+    timeline.skipped("layout_build", _SKIP_REASON_DATA_ONLY)
+    timeline.skipped("widget_render", _SKIP_REASON_DATA_ONLY)
+
+
+def _emit_execution_frame(
+    *,
+    request_id: str,
+    intent: str,
+    tier: int,
+    timeline: _Timeline,
+    started: float,
+    tokens: TokenSpend,
+) -> None:
+    """Build and push the single ``pocket_execution`` SSE frame.
+
+    Best-effort — a missing SSE sink (CLI / test) is a no-op, and a push
+    failure must never break the edit, so the call is wrapped.
+    """
+    frame = PocketExecutionFrame(
+        request_id=request_id,
+        intent=intent,
+        tier_chosen=tier,  # type: ignore[arg-type]
+        stages=timeline.rows(),
+        total_ms=int((time.monotonic() - started) * 1000),
+        tokens=tokens,
+    )
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import push_pocket_execution
+
+        push_pocket_execution(frame.to_wire())
+    except Exception:
+        logger.debug("push_pocket_execution failed (non-fatal)", exc_info=True)
+
+
+def _audit_router_decision(
+    *,
+    actor: str,
+    workspace_id: str,
+    pocket_id: str,
+    tier: int,
+    intent: str,
+    classification: Classification,
+    status: str,
+) -> None:
+    """Write a ``pocket_router`` audit entry for one routed request.
+
+    A Tier-0/1 verdict is logged at WARNING — it is a write/mutation the
+    router performed with NO agent reasoning behind it, so the durable
+    trail matters. A Tier-2 escalation is logged at INFO (the specialist
+    keeps its own trail). Audit failures never break the edit.
+    """
+    try:
+        from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+
+        severity = AuditSeverity.WARNING if tier in (0, 1) else AuditSeverity.INFO
+        get_audit_logger().log(
+            AuditEvent.create(
+                severity=severity,
+                actor=actor,
+                action="pocket.router.route",
+                target=pocket_id,
+                status=status,
+                category="pocket_router",
+                workspace_id=workspace_id,
+                pocket_id=pocket_id,
+                tier=tier,
+                intent=intent[:200],
+                op=classification.op,
+                router_target=classification.target,
+                confidence=round(classification.confidence, 3),
+                reasoning=classification.reasoning,
+            )
+        )
+    except Exception:  # noqa: BLE001 — audit must never break the route
+        logger.warning("pocket-router audit-log write failed", exc_info=True)
+
+
+async def _resolve_ripple_spec(input: Any) -> dict[str, Any]:
+    """Resolve the pocket's rippleSpec for the classifier.
+
+    Uses the caller-supplied ``input.pocket`` view when present (the chat
+    agent already fetched it); otherwise reads it via the service's
+    ``agent_view``. Returns ``{}`` when neither is available — the
+    classifier then escalates (an empty spec matches no cheap-tier rule),
+    which is the safe outcome.
+    """
+    if isinstance(input.pocket, dict):
+        spec = input.pocket.get("rippleSpec")
+        if isinstance(spec, dict):
+            return spec
+    try:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        view, err = await pockets_service.agent_view(input.pocket_id)
+        if err is None and isinstance(view, dict):
+            spec = view.get("rippleSpec")
+            if isinstance(spec, dict):
+                return spec
+    except Exception:
+        logger.debug("router could not resolve ripple_spec — escalating", exc_info=True)
+    return {}
+
+
+async def _run_tier0(
+    classification: Classification,
+    input: Any,
+    *,
+    workspace_id: str,
+    user_id: str,
+    ripple_spec: dict[str, Any],
+) -> tuple[bool, str | None]:
+    """Execute a Tier-0 declarative verdict — fire the declared source or
+    action through the EXISTING executor.
+
+    Returns ``(ok, error)``. The executors are invoked with every guard
+    they normally enforce — the router supplies the arguments, it does
+    not reach past any gate. A pocket with no backend configured, or a
+    user without run access, is a clean failure (``ok=False``), not a
+    crash.
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    creds = await pockets_service.get_pocket_backend_for_executor(workspace_id, input.pocket_id)
+    if creds is None:
+        return False, "pocket has no backend configured — cannot run a declarative tier"
+    base_url, auth_type, auth_header, token, allowed_writes = creds
+
+    if classification.op == "run_source":
+        # A source run mirrors ``POST /pockets/{id}/sources/run`` — read
+        # access only, so no extra gate. The executor keeps its SSRF +
+        # rate-limit guards.
+        from pocketpaw_ee.cloud.pockets import source_executor
+
+        result = await source_executor.run_sources(
+            pocket_id=input.pocket_id,
+            user_id=user_id,
+            ripple_spec=ripple_spec,
+            base_url=base_url,
+            auth_type=auth_type,
+            auth_header=auth_header,
+            token=token,
+            only_source=classification.op_args.get("source"),
+        )
+        errors = result.get("errors") or []
+        if errors:
+            return False, f"source run reported {len(errors)} error(s)"
+        return True, None
+
+    if classification.op == "run_action":
+        # A write action — gate run-access exactly like the REST route
+        # (``has_action_run_access``: owner or explicit shared_with).
+        if not await pockets_service.has_action_run_access(input.pocket_id, user_id):
+            return False, "caller lacks run access for this write action"
+        action_key = classification.op_args.get("action", "")
+        actions = ripple_spec.get("actions")
+        raw_action = actions.get(action_key) if isinstance(actions, dict) else None
+        if not isinstance(raw_action, dict):
+            return False, f"action '{action_key}' is missing or malformed on the pocket"
+
+        from pocketpaw_ee.cloud.pockets import action_executor
+
+        # The executor re-reads method / instinct / allowlist server-side
+        # and fails closed on any guard — the router passes data only.
+        result = await action_executor.run_action(
+            workspace_id=workspace_id,
+            pocket_id=input.pocket_id,
+            user_id=user_id,
+            action=action_key,
+            raw_action=raw_action,
+            path=raw_action.get("path", ""),
+            params=raw_action.get("params") or {},
+            base_url=base_url,
+            auth_type=auth_type,
+            auth_header=auth_header,
+            token=token,
+            allowed_writes=allowed_writes,
+        )
+        if not result.get("ok"):
+            return False, result.get("error") or "action run failed"
+        return True, None
+
+    return False, f"unknown Tier-0 op '{classification.op}'"
+
+
+async def _run_tier1(
+    classification: Classification,
+    input: Any,
+    *,
+    workspace_id: str,
+    user_id: str,
+    settings: Any,
+) -> Any:
+    """Execute a Tier-1 deterministic verdict — apply ONE granular op.
+
+    Reuses ``EditAgentModeAdapter`` (its ``_apply_ops`` path): the router
+    builds a one-op ``PocketSpecialistEditInput`` and hands it to the
+    adapter, so the op runs through the exact same validation, SSE-emit,
+    and rejected-op handling the chat-agent edit path uses. No LLM runs.
+    Returns the adapter's ``PocketSpecialistEditOutput``.
+    """
+    from pocketpaw_ee.agent.pocket_specialist.adapters import EditAgentModeAdapter
+    from pocketpaw_ee.agent.pocket_specialist.runtime import PocketSpecialistEditInput
+
+    op_input = PocketSpecialistEditInput(
+        pocket_id=input.pocket_id,
+        intent=input.intent,
+        pocket=input.pocket,
+        target_node_ids=input.target_node_ids,
+        ops=[{"op": classification.op, "args": dict(classification.op_args)}],
+    )
+    return await EditAgentModeAdapter().edit(
+        op_input,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        settings=settings,
+    )
+
+
+def _tier0_output(classification: Classification, *, pocket_id: str, ok: bool, error: str | None):
+    """Shape a Tier-0 result as a ``PocketSpecialistEditOutput`` so the
+    MCP tool handler gets a uniform return regardless of tier."""
+    from pocketpaw_ee.agent.pocket_specialist.runtime import PocketSpecialistEditOutput
+
+    return PocketSpecialistEditOutput(
+        ok=ok,
+        action="applied" if ok else "failed",
+        pocket_id=pocket_id,
+        ops=[{"op": classification.op, "args": dict(classification.op_args)}] if ok else [],
+        duration_ms=0,
+        backend_used="pocket_router:tier0",
+        error=error,
+        warnings=[],
+    )
+
+
+async def classify_and_route(
+    input: Any,
+    *,
+    workspace_id: str,
+    user_id: str,
+    settings: Any,
+) -> tuple[bool, Any]:
+    """Classify an edit ``input`` and route it to the cheapest tier.
+
+    Returns ``(handled, output)``:
+
+    * ``handled is True`` — a cheap tier (0 or 1) ran the request. The
+      caller uses ``output`` (a ``PocketSpecialistEditOutput``) directly
+      and does NOT fall through to the specialist.
+    * ``handled is False`` — the router escalated. ``output`` is ``None``;
+      the caller invokes ``run_edit_specialist`` itself (the existing
+      flow, unchanged). The router emits its observability frame + audit
+      entry for the escalation too, so a Tier-2 route is still traced.
+
+    Fail-safe gates, in order:
+      1. ``pocket_router_enabled is False`` — escalate immediately, no
+         classification (the kill-switch restores today's behaviour).
+      2. The pure classifier returns Tier 2 — escalate.
+      3. The verdict's confidence is below ``pocket_router_min_confidence``
+         — escalate (a low-confidence cheap tier is not trustworthy).
+      4. A cheap tier ran but FAILED — escalate so the specialist can
+         still satisfy the intent (the failed cheap attempt changed
+         nothing the specialist can't redo).
+    """
+    started = time.monotonic()
+    request_id = f"pr_{uuid.uuid4().hex[:12]}"
+    timeline = _Timeline()
+    intent = getattr(input, "intent", "") or ""
+
+    # ── gate 1: kill-switch ────────────────────────────────────────────
+    if not getattr(settings, "pocket_router_enabled", True):
+        timeline.skipped("classify", "router disabled (pocket_router_enabled=false)")
+        timeline.skipped("apply", "router disabled — escalating to specialist")
+        escalation = Classification(
+            tier=2,
+            target=None,
+            confidence=1.0,
+            reasoning="pocket_router_enabled is False — kill-switch escalation",
+            op=None,
+        )
+        _emit_execution_frame(
+            request_id=request_id,
+            intent=intent,
+            tier=2,
+            timeline=timeline,
+            started=started,
+            tokens=TokenSpend(),
+        )
+        _audit_router_decision(
+            actor=user_id,
+            workspace_id=workspace_id,
+            pocket_id=getattr(input, "pocket_id", ""),
+            tier=2,
+            intent=intent,
+            classification=escalation,
+            status="escalated-kill-switch",
+        )
+        return False, None
+
+    # ── classify (pure) ────────────────────────────────────────────────
+    timeline.start("classify")
+    ripple_spec = await _resolve_ripple_spec(input)
+    classification = classify(intent, ripple_spec)
+    timeline.finish("classify", detail=classification.reasoning)
+
+    min_conf = float(getattr(settings, "pocket_router_min_confidence", 0.9))
+
+    # ── gate 2 + 3: Tier-2 verdict, or sub-threshold confidence ────────
+    if classification.is_escalation or classification.confidence < min_conf:
+        reason = (
+            classification.reasoning
+            if classification.is_escalation
+            else (
+                f"confidence {classification.confidence:.2f} below floor "
+                f"{min_conf:.2f} — escalating (fail-safe)"
+            )
+        )
+        timeline.skipped("apply", reason)
+        _emit_execution_frame(
+            request_id=request_id,
+            intent=intent,
+            tier=2,
+            timeline=timeline,
+            started=started,
+            tokens=TokenSpend(),
+        )
+        _audit_router_decision(
+            actor=user_id,
+            workspace_id=workspace_id,
+            pocket_id=getattr(input, "pocket_id", ""),
+            tier=2,
+            intent=intent,
+            classification=classification,
+            status="escalated",
+        )
+        logger.info("[pocket-router] %s escalated to Tier 2 — %s", request_id, reason)
+        return False, None
+
+    # ── Tier 0 — declarative ───────────────────────────────────────────
+    if classification.tier == 0:
+        timeline.start("apply")
+        ok, error = await _run_tier0(
+            classification,
+            input,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            ripple_spec=ripple_spec,
+        )
+        timeline.finish("apply", detail=f"{classification.op} -> {classification.target}")
+        _add_skipped_layout_stages(timeline)
+        if not ok:
+            # A failed cheap tier escalates: the specialist can still try.
+            timeline.skipped("classify", f"Tier-0 attempt failed: {error}")
+            _emit_execution_frame(
+                request_id=request_id,
+                intent=intent,
+                tier=2,
+                timeline=timeline,
+                started=started,
+                tokens=TokenSpend(),
+            )
+            _audit_router_decision(
+                actor=user_id,
+                workspace_id=workspace_id,
+                pocket_id=getattr(input, "pocket_id", ""),
+                tier=2,
+                intent=intent,
+                classification=classification,
+                status="escalated-tier0-failed",
+            )
+            logger.info("[pocket-router] %s Tier-0 failed (%s) — escalating", request_id, error)
+            return False, None
+        _emit_execution_frame(
+            request_id=request_id,
+            intent=intent,
+            tier=0,
+            timeline=timeline,
+            started=started,
+            tokens=TokenSpend(),
+        )
+        _audit_router_decision(
+            actor=user_id,
+            workspace_id=workspace_id,
+            pocket_id=getattr(input, "pocket_id", ""),
+            tier=0,
+            intent=intent,
+            classification=classification,
+            status="applied",
+        )
+        logger.info("[pocket-router] %s Tier 0 applied (%s)", request_id, classification.op)
+        return True, _tier0_output(classification, pocket_id=input.pocket_id, ok=True, error=None)
+
+    # ── Tier 1 — deterministic single granular op ──────────────────────
+    timeline.start("apply")
+    output = await _run_tier1(
+        classification,
+        input,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        settings=settings,
+    )
+    timeline.finish("apply", detail=f"{classification.op} -> {classification.target}")
+    _add_skipped_layout_stages(timeline)
+
+    if not getattr(output, "ok", False):
+        # The granular op was rejected by the service — escalate so the
+        # specialist (which can re-plan) gets a shot.
+        err = getattr(output, "error", None) or "Tier-1 op did not apply"
+        timeline.skipped("classify", f"Tier-1 op rejected: {err}")
+        _emit_execution_frame(
+            request_id=request_id,
+            intent=intent,
+            tier=2,
+            timeline=timeline,
+            started=started,
+            tokens=TokenSpend(),
+        )
+        _audit_router_decision(
+            actor=user_id,
+            workspace_id=workspace_id,
+            pocket_id=getattr(input, "pocket_id", ""),
+            tier=2,
+            intent=intent,
+            classification=classification,
+            status="escalated-tier1-rejected",
+        )
+        logger.info("[pocket-router] %s Tier-1 op rejected (%s) — escalating", request_id, err)
+        return False, None
+
+    _emit_execution_frame(
+        request_id=request_id,
+        intent=intent,
+        tier=1,
+        timeline=timeline,
+        started=started,
+        tokens=TokenSpend(),
+    )
+    _audit_router_decision(
+        actor=user_id,
+        workspace_id=workspace_id,
+        pocket_id=getattr(input, "pocket_id", ""),
+        tier=1,
+        intent=intent,
+        classification=classification,
+        status="applied",
+    )
+    logger.info("[pocket-router] %s Tier 1 applied (%s)", request_id, classification.op)
+    return True, output
+
+
+__all__ = ["classify_and_route"]

--- a/ee/pocketpaw_ee/agent/pocket_specialist/mcp_tool.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/mcp_tool.py
@@ -15,6 +15,13 @@ Changes: 2026-05-21 (#1170) — the ``edit`` tool now accepts an optional
 ``ops`` argument: the agent-mode second-call payload. In agent mode the
 first ``edit`` call returns ``action='draft_kit'`` and the chat agent
 calls back with ``ops=<granular op list>``. Subagent mode ignores it.
+Changes: 2026-05-22 (Increment 3) — ``_edit_handler`` now calls the
+execution router (``pocket_router.classify_and_route``) FIRST. The
+router routes the request to the cheapest capable tier (Tier 0
+declarative / Tier 1 deterministic op); only on an *escalate* verdict
+does the handler fall through to ``run_edit_specialist`` (the existing
+flow, unchanged). ``create`` is out of scope — a new pocket has nothing
+to classify against, so it always goes straight to ``run_specialist``.
 """
 
 from __future__ import annotations
@@ -133,13 +140,48 @@ async def _edit_handler(args: dict[str, Any]) -> dict[str, Any]:
         ops=raw_ops if isinstance(raw_ops, list) else None,
     )
 
+    settings = get_settings()
     try:
-        out = await run_edit_specialist(
-            payload,
-            workspace_id=workspace_id,
-            user_id=user_id,
-            settings=get_settings(),
-        )
+        # Increment 3 — the execution router runs FIRST. It classifies the
+        # intent and, when HIGH-confidence, routes to a cheap tier (Tier 0
+        # declarative / Tier 1 deterministic op) without ever invoking the
+        # LLM specialist. Only on an *escalate* verdict (``handled`` is
+        # False) does control fall through to ``run_edit_specialist`` — the
+        # existing flow, unchanged. The router's kill-switch
+        # (``pocket_router_enabled=false``) makes every request escalate,
+        # restoring the pre-router behaviour exactly.
+        #
+        # The router only applies to a *second-call* edit (``ops is None``):
+        # the chat agent's first call is the draft-kit handshake, which the
+        # router has nothing to classify against — let it reach the
+        # specialist's agent-mode adapter unchanged.
+        if payload.ops is None:
+            from pocketpaw_ee.agent.pocket_router.router import classify_and_route
+
+            handled, routed = await classify_and_route(
+                payload,
+                workspace_id=workspace_id,
+                user_id=user_id,
+                settings=settings,
+            )
+            if handled:
+                out = routed
+            else:
+                out = await run_edit_specialist(
+                    payload,
+                    workspace_id=workspace_id,
+                    user_id=user_id,
+                    settings=settings,
+                )
+        else:
+            # An explicit op list — the chat agent already computed the
+            # ops; route straight to the deterministic apply path.
+            out = await run_edit_specialist(
+                payload,
+                workspace_id=workspace_id,
+                user_id=user_id,
+                settings=settings,
+            )
     except Exception as exc:  # noqa: BLE001
         logger.exception("pocket specialist edit run failed")
         return {

--- a/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
@@ -1,3 +1,14 @@
+# agent_schemas.py — Request and SSE-event payload schemas for the
+#   enterprise agent chat endpoint.
+# Changes: 2026-05-22 (Increment 3) — RFC-06 structure/data split:
+#   added ``PocketMutationFrame``, the discriminated ``pocket_mutation``
+#   SSE frame the granular ``agent_*`` edit ops emit. Its ``family``
+#   discriminant ("updateComponents" for node/structure ops,
+#   "updateDataModel" for state/data ops) lets the canvas re-render only
+#   the structure layer or only the data layer instead of rebuilding the
+#   whole pocket from the coarse ``PocketUpdated`` realtime event. Also
+#   added the ``POCKET_EXECUTION`` SSE event name for the execution
+#   router's per-request observability frame.
 """Request and SSE-event payload schemas for the enterprise agent chat endpoint.
 
 The endpoint lives at ``POST /cloud/chat/{scope}/{scope_id}/agent`` and streams
@@ -9,7 +20,7 @@ for the full protocol.
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -77,6 +88,108 @@ class SseEventName(StrEnum):
     RIPPLE = "ripple"
     POCKET_CREATED = "pocket_created"
     POCKET_MUTATION = "pocket_mutation"
+    POCKET_EXECUTION = "pocket_execution"
     ASK_USER_QUESTION = "ask_user_question"
     STREAM_END = "stream_end"
     ERROR = "error"
+
+
+# Map of the granular ``agent_*`` op identifier -> mutation ``family``.
+# Structure ops touch ``rippleSpec.ui`` (the component tree); data ops
+# touch ``rippleSpec.state`` (the data model). The split is the cheap
+# RFC-06 win — a data-only change need not re-run layout.
+_STRUCTURE_OPS: frozenset[str] = frozenset(
+    {
+        "node_added",
+        "node_replaced",
+        "node_prop_set",
+        "node_moved",
+        "node_removed",
+        "node_prop_array_item_set",
+        "node_prop_array_item_appended",
+        "node_prop_array_item_removed",
+    }
+)
+_DATA_OPS: frozenset[str] = frozenset(
+    {
+        "state_set",
+        "state_appended",
+        "state_removed",
+        "state_patched",
+    }
+)
+
+
+def family_for_op(op: str) -> Literal["updateComponents", "updateDataModel"] | None:
+    """Resolve a granular op identifier to its mutation ``family``.
+
+    ``updateComponents`` for a structure (node) op, ``updateDataModel``
+    for a data (state) op, ``None`` for anything else (the caller should
+    not emit a discriminated frame — the coarse ``PocketUpdated`` event
+    still covers it).
+    """
+    if op in _STRUCTURE_OPS:
+        return "updateComponents"
+    if op in _DATA_OPS:
+        return "updateDataModel"
+    return None
+
+
+class PocketMutationFrame(BaseModel):
+    """A narrow, discriminated ``pocket_mutation`` SSE frame.
+
+    Emitted by the granular ``agent_*`` edit ops in
+    ``pockets/agent_context.py`` alongside the coarse ``PocketUpdated``
+    realtime event. The coarse event tells a client "this pocket
+    changed, refetch"; this frame tells it *what kind* of change so the
+    canvas can patch in place rather than rebuild.
+
+    The ``family`` discriminant is the RFC-06 structure/data split:
+
+    * ``updateComponents`` — a node op mutated ``rippleSpec.ui`` (the
+      component tree). The renderer re-runs layout for the touched
+      subtree.
+    * ``updateDataModel`` — a state op mutated ``rippleSpec.state`` (the
+      data model). No layout work needed — only data-bound widgets
+      re-render.
+
+    ``op`` is the granular op identifier (``state_set``, ``node_added``,
+    …); ``payload`` is that op's narrow change descriptor (subtree,
+    path, value, …) — the same fields the historical un-discriminated
+    frame carried at the top level.
+
+    Wire shape: the frame is emitted FLAT — ``family``, ``op``,
+    ``pocket_id`` and every ``payload`` key sit at the top level of the
+    SSE ``data`` object, next to the legacy ``action`` key. This keeps
+    the historical un-discriminated consumers working byte-for-byte
+    (they read ``action`` + flat payload) while new consumers branch on
+    ``family``. ``to_wire()`` produces that flat dict. Older clients
+    that ignore ``family`` still get the coarse ``PocketUpdated`` event,
+    so the frame is purely additive — no client is forced to upgrade.
+    """
+
+    family: Literal["updateComponents", "updateDataModel"]
+    op: str = Field(min_length=1, description="Granular op identifier, e.g. 'state_set'.")
+    pocket_id: str = Field(description="Id of the mutated pocket.")
+    payload: dict[str, Any] = Field(
+        default_factory=dict,
+        description="The op's narrow change descriptor (subtree, path, value, …).",
+    )
+
+    def to_wire(self) -> dict[str, Any]:
+        """Flatten to the wire dict pushed via ``push_pocket_mutation``.
+
+        ``payload`` keys are spread to the top level (next to ``family`` /
+        ``op`` / ``pocket_id``) and the legacy ``action`` alias is added
+        so un-discriminated consumers keep working. A ``payload`` key
+        never collides with ``family`` / ``op`` / ``action`` / ``pocket_id``
+        — the granular ops only put change descriptors there.
+        """
+        wire: dict[str, Any] = {
+            "action": self.op,
+            "op": self.op,
+            "family": self.family,
+            "pocket_id": self.pocket_id,
+        }
+        wire.update(self.payload)
+        return wire

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -14,6 +14,9 @@ fills the interaction prompt's current-pocket block via ``fill_current_pocket``
 (both the pocket-id and backend-summary tokens) instead of a bare
 ``POCKET_ID_TOKEN`` replace, so the new ``__BACKEND_SUMMARY__`` token never
 leaks as literal text.
+Changes: 2026-05-22 (Increment 3) — added ``push_pocket_execution``, the
+SSE-sink push for the execution router's per-request ``pocket_execution``
+observability frame.
 """
 
 from __future__ import annotations
@@ -118,6 +121,15 @@ def push_sse_event(name: str, data: dict[str, Any]) -> None:
 def push_pocket_mutation(payload: dict[str, Any]) -> None:
     """Compatibility wrapper — historic call site for pocket-mutation pushes."""
     push_sse_event("pocket_mutation", payload)
+
+
+def push_pocket_execution(payload: dict[str, Any]) -> None:
+    """Push a ``pocket_execution`` SSE frame — the execution router's
+    per-request observability readout (which tier ran, the stage
+    timeline, total latency, token spend). Sibling of
+    ``push_pocket_mutation``; emitted once per ``classify_and_route``
+    call. No-op outside an SSE stream."""
+    push_sse_event("pocket_execution", payload)
 
 
 def attach_sse_event_sink(queue: asyncio.Queue[tuple[str, dict[str, Any]]]) -> Token:

--- a/ee/pocketpaw_ee/cloud/pockets/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/pockets/agent_context.py
@@ -14,6 +14,16 @@ edit specialist can author the pocket's ``rippleSpec.sources`` block.
 They emit a full-document ``replace`` ``pocket_mutation`` (the
 frontend's ``applyMutation`` already understands ``replace``) so no
 paw-enterprise change is needed.
+Changes: 2026-05-22 (Increment 3, RFC-06 structure/data split) — the
+granular node / state op frames are now discriminated: every
+``pocket_mutation`` they push carries a ``family`` field
+("updateComponents" for node ops, "updateDataModel" for state ops) so
+the canvas can patch only the structure layer or only the data layer.
+The frame is built via ``PocketMutationFrame`` and emitted FLAT so the
+historical un-discriminated consumers keep working; the coarse
+``PocketUpdated`` realtime event the service layer emits is untouched
+(it remains the refetch fallback). Still one ``pocket_mutation`` push
+per op — purely additive enrichment, not a second event.
 """
 
 from __future__ import annotations
@@ -212,29 +222,62 @@ async def _push_replace(pocket_view: dict[str, Any]) -> None:
         logger.debug("push_pocket_mutation failed (non-fatal)", exc_info=True)
 
 
-async def _push_node_op(action: str, pocket_view: dict[str, Any], payload: dict[str, Any]) -> None:
-    """Push a granular ``pocket_mutation`` SSE event for one of the
-    five node-level ops (``node_added`` / ``node_replaced`` /
-    ``node_prop_set`` / ``node_moved`` / ``node_removed``).
+def _push_mutation_frame(op: str, pocket_view: dict[str, Any], payload: dict[str, Any]) -> None:
+    """Build a discriminated ``PocketMutationFrame`` for one granular op
+    and push it as the ``pocket_mutation`` SSE event.
 
-    Newer clients apply the op in place using ``payload`` (which carries
-    the changed subtree + position info). Older clients ignore the
-    unknown action — but they STILL get a full re-render via the
-    realtime ``pocket.updated`` event the service layer emits on every
-    write, so they stay consistent without code changes.
+    ``op`` is the granular op identifier (``node_added`` / ``state_set`` /
+    …). It resolves to a mutation ``family`` — ``updateComponents`` for a
+    node/structure op, ``updateDataModel`` for a state/data op — which is
+    the RFC-06 split letting the canvas patch only the layer that
+    changed. The frame is emitted FLAT (``to_wire``) so the historical
+    un-discriminated consumers, which read ``action`` + flat payload
+    keys, keep working byte-for-byte.
+
+    Exactly one ``pocket_mutation`` push per op — the coarse
+    ``PocketUpdated`` realtime event the service layer emits on the same
+    write is the separate refetch fallback for clients that ignore
+    ``family``. An op whose identifier has no known family falls back to
+    the legacy flat frame (no ``family`` key) rather than dropping the
+    push.
     """
-    try:
-        from pocketpaw_ee.cloud.chat.agent_service import push_pocket_mutation
+    from pocketpaw_ee.cloud.chat.agent_schemas import PocketMutationFrame, family_for_op
+    from pocketpaw_ee.cloud.chat.agent_service import push_pocket_mutation
 
-        push_pocket_mutation(
-            {
-                "action": action,
-                "pocket_id": pocket_view.get("_id", ""),
-                **payload,
-            }
+    pocket_id = pocket_view.get("_id", "")
+    family = family_for_op(op)
+    try:
+        if family is None:
+            # Unknown op — keep the legacy flat frame so the canvas still
+            # gets a signal; only the discriminant is missing.
+            logger.debug("no mutation family for op %r — emitting legacy flat frame", op)
+            push_pocket_mutation({"action": op, "pocket_id": pocket_id, **payload})
+            return
+        frame = PocketMutationFrame(
+            family=family,
+            op=op,
+            pocket_id=pocket_id,
+            payload=payload,
         )
+        push_pocket_mutation(frame.to_wire())
     except Exception:
-        logger.debug("push_pocket_mutation(%s) failed (non-fatal)", action, exc_info=True)
+        logger.debug("push_pocket_mutation(%s) failed (non-fatal)", op, exc_info=True)
+
+
+async def _push_node_op(action: str, pocket_view: dict[str, Any], payload: dict[str, Any]) -> None:
+    """Push a discriminated ``pocket_mutation`` SSE event for one of the
+    eight node-level ops (``node_added`` / ``node_replaced`` /
+    ``node_prop_set`` / ``node_moved`` / ``node_removed`` plus the three
+    ``node_prop_array_item_*`` ops).
+
+    Newer clients branch on ``family == "updateComponents"`` and apply
+    the op in place using ``payload`` (which carries the changed subtree
+    + position info). Older clients ignore the unknown ``family`` /
+    ``action`` — but they STILL get a full re-render via the realtime
+    ``pocket.updated`` event the service layer emits on every write, so
+    they stay consistent without code changes.
+    """
+    _push_mutation_frame(action, pocket_view, payload)
 
 
 def _spec_grammar_warnings(ripple_spec: dict[str, Any] | None) -> str | None:
@@ -669,21 +712,12 @@ async def remove_node_for_agent(pocket_id: str, node_id: str) -> dict[str, Any]:
 
 
 async def _push_state_op(action: str, pocket_view: dict[str, Any], payload: dict[str, Any]) -> None:
-    """Push a granular ``pocket_mutation`` SSE event for one of the four
-    state-level ops (``state_set`` / ``state_appended`` / ``state_removed`` /
-    ``state_patched``). Mirrors ``_push_node_op``."""
-    try:
-        from pocketpaw_ee.cloud.chat.agent_service import push_pocket_mutation
-
-        push_pocket_mutation(
-            {
-                "action": action,
-                "pocket_id": pocket_view.get("_id", ""),
-                **payload,
-            }
-        )
-    except Exception:
-        logger.debug("push_pocket_mutation(%s) failed (non-fatal)", action, exc_info=True)
+    """Push a discriminated ``pocket_mutation`` SSE event for one of the
+    four state-level ops (``state_set`` / ``state_appended`` /
+    ``state_removed`` / ``state_patched``). Mirrors ``_push_node_op`` —
+    state ops resolve to ``family == "updateDataModel"`` so a client can
+    re-render only the data-bound widgets and skip layout entirely."""
+    _push_mutation_frame(action, pocket_view, payload)
 
 
 async def set_state_for_agent(pocket_id: str, path: str, value: Any) -> dict[str, Any]:

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -356,3 +356,22 @@ source_modules = [
     "pocketpaw_ee.cloud.audit.domain",
 ]
 forbidden_modules = ["pocketpaw_ee.cloud.models.audit"]
+
+# Increment 3 — the pocket execution router. The classifier is PURE: a
+# rule-based ``classify(intent, ripple_spec)`` with no I/O. It must never
+# import Beanie documents, the cloud-side executors / services, or the LLM
+# specialist — those belong to the router layer (``router.py``), which is
+# the only module here allowed to invoke them.
+[[tool.importlinter.contracts]]
+name = "Pocket router — classifier stays pure"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = ["pocketpaw_ee.agent.pocket_router.classifier"]
+forbidden_modules = [
+    "pocketpaw_ee.cloud.models.pocket",
+    "pocketpaw_ee.cloud.pockets.service",
+    "pocketpaw_ee.cloud.pockets.source_executor",
+    "pocketpaw_ee.cloud.pockets.action_executor",
+    "pocketpaw_ee.agent.pocket_specialist.runtime",
+    "pocketpaw_ee.agent.pocket_specialist.adapters",
+]

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,9 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-05-22: Added ``pocket_router_enabled`` (kill-switch) and
+    ``pocket_router_min_confidence`` (cheap-tier confidence floor) for
+    the pocket execution router (Increment 3).
   - 2026-05-21: Added ``auto_install_bundled_skills`` and
     ``auto_install_bundled_kb_scopes`` — toggle the boot-time mirror of
     bundled SKILL.md files and pre-compiled kb-go scopes.
@@ -367,6 +370,33 @@ class Settings(BaseSettings):
             "with ``spec=<draft>`` for validate-and-persist. ``agent`` mode "
             "ignores ``pocket_specialist_backend`` and ``pocket_specialist_model`` "
             "entirely — the chat agent's runtime is the LLM."
+        ),
+    )
+    pocket_router_enabled: bool = Field(
+        default=True,
+        description=(
+            "Kill-switch for the pocket execution router (Increment 3). When "
+            "True (default) ``pocket_specialist__edit`` first runs a pure, "
+            "rule-based classifier that routes a request to the cheapest "
+            "capable tier — Tier 0 declarative (fire a declared source/action), "
+            "Tier 1 deterministic op (apply one granular op), or Tier 2 "
+            "specialist (the existing LLM flow). When False the router always "
+            "escalates to Tier 2, restoring pre-router behaviour exactly — "
+            "every edit invokes the specialist. Flip to False to disable the "
+            "router instantly without a deploy if a Tier-0/1 verdict ever "
+            "misfires."
+        ),
+    )
+    pocket_router_min_confidence: float = Field(
+        default=0.9,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Confidence floor for a cheap-tier (Tier 0 / Tier 1) routing "
+            "verdict. The classifier escalates to the specialist (Tier 2) "
+            "whenever its confidence in the cheap tier falls below this "
+            "threshold. High by default — a wrong skip produces a broken "
+            "pocket, so the router is deliberately conservative."
         ),
     )
     auto_install_bundled_skills: bool = Field(

--- a/tests/cloud/test_agent_chat_schemas.py
+++ b/tests/cloud/test_agent_chat_schemas.py
@@ -73,6 +73,7 @@ def test_event_names_cover_spec():
         "ripple",
         "pocket_created",
         "pocket_mutation",
+        "pocket_execution",
         "ask_user_question",
         "stream_end",
         "error",

--- a/tests/cloud/test_pocket_mutation_family.py
+++ b/tests/cloud/test_pocket_mutation_family.py
@@ -1,0 +1,243 @@
+# test_pocket_mutation_family.py — RFC-06 structure/data split (Increment 3).
+# Created: 2026-05-22 — verifies that every granular ``agent_*`` edit op
+#   emits a DISCRIMINATED ``pocket_mutation`` SSE frame: a node op carries
+#   ``family == "updateComponents"`` (structure), a state op carries
+#   ``family == "updateDataModel"`` (data). It also pins the additive
+#   guarantee — the coarse ``PocketUpdated`` realtime event the service
+#   layer emits on the same write is untouched, so older clients keep
+#   getting their refetch signal.
+"""Does each granular op emit the correctly-discriminated mutation frame?"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+
+async def _make_pocket() -> Any:
+    """A pocket with a heading node (for node ops) and a tasks array in
+    state (for state ops)."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    spec = {
+        "version": "1.0",
+        "state": {"tasks": [{"id": 1, "status": "todo"}], "filter": "all"},
+        "ui": {
+            "id": "n_root0000",
+            "type": "flex",
+            "props": {"direction": "column"},
+            "children": [
+                {"id": "n_head0000", "type": "heading", "props": {"text": "Hi"}},
+            ],
+        },
+    }
+    doc = Pocket(workspace="w1", name="Family", owner="u1", visibility="workspace", rippleSpec=spec)
+    await doc.insert()
+    return doc
+
+
+@pytest.fixture
+def agent_identity():
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_agent_identity,
+        detach_agent_identity,
+    )
+
+    tokens = attach_agent_identity(workspace_id="w1", user_id="u1")
+    try:
+        yield
+    finally:
+        detach_agent_identity(tokens)
+
+
+def _frames(sink: asyncio.Queue) -> list[tuple[str, dict]]:
+    out: list[tuple[str, dict]] = []
+    while not sink.empty():
+        out.append(sink.get_nowait())
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Node ops -> family "updateComponents"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_node_prop_set_emits_update_components_frame(mongo_db, agent_identity):
+    """A ``set_node_prop`` op mutates ``rippleSpec.ui`` — its
+    ``pocket_mutation`` frame must carry ``family == "updateComponents"``."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_sse_event_sink,
+        detach_sse_event_sink,
+    )
+    from pocketpaw_ee.cloud.pockets import agent_context
+
+    doc = await _make_pocket()
+    sink: asyncio.Queue = asyncio.Queue()
+    token = attach_sse_event_sink(sink)
+    try:
+        result = await agent_context.set_node_prop_for_agent(
+            str(doc.id), node_id="n_head0000", prop="text", value="Renamed"
+        )
+    finally:
+        detach_sse_event_sink(token)
+
+    assert result["ok"] is True
+    mutations = [d for n, d in _frames(sink) if n == "pocket_mutation"]
+    assert len(mutations) == 1, "exactly one pocket_mutation frame per op"
+    frame = mutations[0]
+    assert frame["family"] == "updateComponents"
+    assert frame["op"] == "node_prop_set"
+    # The legacy un-discriminated keys still ride along (additive).
+    assert frame["action"] == "node_prop_set"
+    assert frame["node_id"] == "n_head0000"
+
+
+@pytest.mark.asyncio
+async def test_add_node_emits_update_components_frame(mongo_db, agent_identity):
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_sse_event_sink,
+        detach_sse_event_sink,
+    )
+    from pocketpaw_ee.cloud.pockets import agent_context
+
+    doc = await _make_pocket()
+    sink: asyncio.Queue = asyncio.Queue()
+    token = attach_sse_event_sink(sink)
+    try:
+        result = await agent_context.add_node_for_agent(
+            str(doc.id),
+            parent_id="n_root0000",
+            spec={"type": "stat", "props": {"value": "42"}},
+        )
+    finally:
+        detach_sse_event_sink(token)
+
+    assert result["ok"] is True
+    mutations = [d for n, d in _frames(sink) if n == "pocket_mutation"]
+    assert len(mutations) == 1
+    assert mutations[0]["family"] == "updateComponents"
+    assert mutations[0]["op"] == "node_added"
+
+
+# ---------------------------------------------------------------------------
+# State ops -> family "updateDataModel"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_state_emits_update_data_model_frame(mongo_db, agent_identity):
+    """A ``set_state`` op mutates ``rippleSpec.state`` — its
+    ``pocket_mutation`` frame must carry ``family == "updateDataModel"``."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_sse_event_sink,
+        detach_sse_event_sink,
+    )
+    from pocketpaw_ee.cloud.pockets import agent_context
+
+    doc = await _make_pocket()
+    sink: asyncio.Queue = asyncio.Queue()
+    token = attach_sse_event_sink(sink)
+    try:
+        result = await agent_context.set_state_for_agent(str(doc.id), "filter", "done")
+    finally:
+        detach_sse_event_sink(token)
+
+    assert result["ok"] is True
+    mutations = [d for n, d in _frames(sink) if n == "pocket_mutation"]
+    assert len(mutations) == 1
+    frame = mutations[0]
+    assert frame["family"] == "updateDataModel"
+    assert frame["op"] == "state_set"
+    assert frame["action"] == "state_set"
+    assert frame["path"] == "filter"
+
+
+@pytest.mark.asyncio
+async def test_append_state_emits_update_data_model_frame(mongo_db, agent_identity):
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_sse_event_sink,
+        detach_sse_event_sink,
+    )
+    from pocketpaw_ee.cloud.pockets import agent_context
+
+    doc = await _make_pocket()
+    sink: asyncio.Queue = asyncio.Queue()
+    token = attach_sse_event_sink(sink)
+    try:
+        result = await agent_context.append_state_for_agent(
+            str(doc.id), "tasks", {"id": 2, "status": "todo"}
+        )
+    finally:
+        detach_sse_event_sink(token)
+
+    assert result["ok"] is True
+    mutations = [d for n, d in _frames(sink) if n == "pocket_mutation"]
+    assert len(mutations) == 1
+    assert mutations[0]["family"] == "updateDataModel"
+    assert mutations[0]["op"] == "state_appended"
+
+
+# ---------------------------------------------------------------------------
+# Additive guarantee — the coarse PocketUpdated event still fires.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_granular_op_still_emits_pocket_updated(mongo_db, agent_identity):
+    """The discriminated frame is ADDITIVE — the service layer still
+    emits the coarse ``PocketUpdated`` realtime event on the same write,
+    so a client that ignores ``family`` keeps its refetch signal."""
+    from unittest.mock import AsyncMock, patch
+
+    from pocketpaw_ee.cloud.pockets import agent_context
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    doc = await _make_pocket()
+
+    emitted: list[Any] = []
+
+    async def _capture(event: Any) -> None:
+        emitted.append(event)
+
+    with patch.object(pockets_service, "emit", new=AsyncMock(side_effect=_capture)):
+        result = await agent_context.set_state_for_agent(str(doc.id), "filter", "x")
+    assert result["ok"] is True
+
+    types = [getattr(e, "type", None) for e in emitted]
+    assert "pocket.updated" in types, (
+        f"granular op must still emit the coarse PocketUpdated event; saw {types}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The PocketMutationFrame model itself.
+# ---------------------------------------------------------------------------
+
+
+def test_pocket_mutation_frame_to_wire_is_flat():
+    """``PocketMutationFrame.to_wire`` flattens ``payload`` to the top
+    level and adds the legacy ``action`` alias — so un-discriminated
+    consumers keep working byte-for-byte."""
+    from pocketpaw_ee.cloud.chat.agent_schemas import PocketMutationFrame, family_for_op
+
+    frame = PocketMutationFrame(
+        family="updateDataModel",
+        op="state_set",
+        pocket_id="p1",
+        payload={"path": "filter", "value": "done"},
+    )
+    wire = frame.to_wire()
+    assert wire == {
+        "action": "state_set",
+        "op": "state_set",
+        "family": "updateDataModel",
+        "pocket_id": "p1",
+        "path": "filter",
+        "value": "done",
+    }
+    assert family_for_op("node_moved") == "updateComponents"
+    assert family_for_op("state_patched") == "updateDataModel"
+    assert family_for_op("not_an_op") is None

--- a/tests/ee/agent/test_pocket_router/__init__.py
+++ b/tests/ee/agent/test_pocket_router/__init__.py
@@ -1,0 +1,1 @@
+# __init__.py — Test package for the pocket execution router (Increment 3).

--- a/tests/ee/agent/test_pocket_router/test_classifier.py
+++ b/tests/ee/agent/test_pocket_router/test_classifier.py
@@ -1,0 +1,353 @@
+# test_classifier.py — The safety-net corpus test for the pure tier
+#   classifier (Increment 3).
+# Created: 2026-05-22 — the classifier decides whether to SKIP the LLM
+#   specialist for an edit. A wrong Tier-0/1 verdict produces a broken
+#   pocket, so this corpus is deliberately exhaustive: every labelled
+#   intent asserts its expected tier, and the fail-safe escalations
+#   (partial match, structural verb, ambiguous target, unresolved
+#   action params, requires_instinct) each get their own dedicated case.
+"""Labelled-corpus safety net for the pocket-router classifier."""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.agent.pocket_router.classifier import classify
+
+# ---------------------------------------------------------------------------
+# Fixture rippleSpecs
+# ---------------------------------------------------------------------------
+
+# A pocket with one declared GET source and one declared write action.
+_SPEC_WITH_BINDINGS = {
+    "version": "1.0",
+    "sources": {
+        "prs": {"method": "GET", "path": "/pulls", "bind": "state.prs"},
+    },
+    "actions": {
+        "publish": {
+            "kind": "write_binding",
+            "method": "POST",
+            "path": "/publish",
+            "params": {"channel": "release"},  # static — resolves
+        },
+    },
+    "state": {"prs": [], "filter": "all"},
+    "ui": {"id": "n_root0000", "type": "flex", "props": {}, "children": []},
+}
+
+# A task pocket: one indexable task collection in state, a heading node.
+_SPEC_TASKS = {
+    "version": "1.0",
+    "state": {
+        "tasks": [
+            {"id": 1, "label": "buy milk", "status": "todo"},
+            {"id": 2, "label": "walk dog", "status": "todo"},
+            {"id": 3, "label": "write tests", "status": "todo"},
+        ],
+        "filter": "all",
+    },
+    "ui": {
+        "id": "n_root0000",
+        "type": "flex",
+        "props": {},
+        "children": [
+            {"id": "n_head0000", "type": "heading", "props": {"text": "My Tasks"}},
+        ],
+    },
+}
+
+# An action whose params carry an unresolved Ripple expression.
+_SPEC_UNRESOLVED_ACTION = {
+    "version": "1.0",
+    "actions": {
+        "submit": {
+            "kind": "write_binding",
+            "method": "POST",
+            "path": "/submit",
+            "params": {"taskId": "{item.id}"},  # unresolved — must escalate
+        },
+    },
+    "state": {},
+    "ui": {"id": "n_root0000", "type": "flex", "props": {}, "children": []},
+}
+
+# An action gated by Instinct — must NOT be auto-fired by the router.
+_SPEC_INSTINCT_ACTION = {
+    "version": "1.0",
+    "actions": {
+        "publish": {
+            "kind": "write_binding",
+            "method": "POST",
+            "path": "/publish",
+            "params": {},
+            "requires_instinct": True,
+        },
+    },
+    "state": {},
+    "ui": {"id": "n_root0000", "type": "flex", "props": {}, "children": []},
+}
+
+# Two declared sources — a refresh that names neither is ambiguous.
+_SPEC_TWO_SOURCES = {
+    "version": "1.0",
+    "sources": {
+        "orders": {"method": "GET", "path": "/orders", "bind": "state.orders"},
+        "customers": {"method": "GET", "path": "/customers", "bind": "state.customers"},
+    },
+    "state": {"orders": [], "customers": []},
+    "ui": {"id": "n_root0000", "type": "flex", "props": {}, "children": []},
+}
+
+
+# ---------------------------------------------------------------------------
+# Tier 0 — declarative
+# ---------------------------------------------------------------------------
+
+
+class TestTier0Declarative:
+    """A clean 1:1 refresh/action against a declared binding -> Tier 0."""
+
+    @pytest.mark.parametrize(
+        "intent",
+        [
+            "refresh the prs source",
+            "reload prs",
+            "sync prs",
+            "fetch prs",
+            "pull prs",
+        ],
+    )
+    def test_refresh_named_source_is_tier0(self, intent):
+        c = classify(intent, _SPEC_WITH_BINDINGS)
+        assert c.tier == 0, f"{intent!r} -> {c.tier} ({c.reasoning})"
+        assert c.op == "run_source"
+        assert c.target == "prs"
+        assert c.op_args == {"source": "prs"}
+        assert c.confidence >= 0.9
+
+    @pytest.mark.parametrize("intent", ["submit the publish action", "save publish"])
+    def test_submit_named_action_is_tier0(self, intent):
+        c = classify(intent, _SPEC_WITH_BINDINGS)
+        assert c.tier == 0, f"{intent!r} -> {c.tier} ({c.reasoning})"
+        assert c.op == "run_action"
+        assert c.target == "publish"
+
+    def test_refresh_with_no_named_source_escalates(self):
+        # "refresh the dashboard" names no source — creative, not declarative.
+        c = classify("refresh the dashboard", _SPEC_WITH_BINDINGS)
+        assert c.tier == 2
+
+    def test_refresh_unknown_source_escalates(self):
+        c = classify("refresh the invoices source", _SPEC_WITH_BINDINGS)
+        assert c.tier == 2
+
+    def test_refresh_ambiguous_two_sources_escalates(self):
+        # "refresh everything" matches no key; but a refresh that could
+        # touch multiple sources must never be auto-routed.
+        c = classify("sync the data", _SPEC_TWO_SOURCES)
+        assert c.tier == 2
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — deterministic single op
+# ---------------------------------------------------------------------------
+
+
+class TestTier1Deterministic:
+    """An unambiguous single-op intent -> Tier 1."""
+
+    @pytest.mark.parametrize(
+        ("intent", "expected_status"),
+        [
+            ("mark task 1 as done", "done"),
+            ("mark task 2 done", "done"),
+            ("complete task 3", "done"),
+            ("check task 1", "done"),
+            ("mark task 1 as todo", "todo"),
+            ("mark task 2 as open", "todo"),
+        ],
+    )
+    def test_mark_task_done_is_tier1_set_state(self, intent, expected_status):
+        c = classify(intent, _SPEC_TASKS)
+        assert c.tier == 1, f"{intent!r} -> {c.tier} ({c.reasoning})"
+        assert c.op == "set_state"
+        assert c.op_args["value"] == expected_status
+        assert c.op_args["path"].startswith("tasks[")
+        assert c.op_args["path"].endswith(".status")
+
+    def test_mark_task_index_is_one_based(self):
+        # "task 1" -> tasks[0]; "task 3" -> tasks[2].
+        assert classify("mark task 1 done", _SPEC_TASKS).op_args["path"] == "tasks[0].status"
+        assert classify("mark task 3 done", _SPEC_TASKS).op_args["path"] == "tasks[2].status"
+
+    def test_set_filter_is_tier1_set_state(self):
+        c = classify("set the filter to overdue", _SPEC_TASKS)
+        assert c.tier == 1
+        assert c.op == "set_state"
+        assert c.op_args == {"path": "filter", "value": "overdue"}
+
+    def test_rename_single_node_is_tier1_set_node_prop(self):
+        c = classify('rename My Tasks to "Today\'s Work"', _SPEC_TASKS)
+        assert c.tier == 1, f"-> {c.tier} ({c.reasoning})"
+        assert c.op == "set_node_prop"
+        assert c.target == "n_head0000"
+        assert c.op_args["prop"] == "text"
+        assert c.op_args["value"] == "Today's Work"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — specialist / escalation
+# ---------------------------------------------------------------------------
+
+
+class TestTier2Escalation:
+    """Structural / creative / ambiguous intents -> Tier 2."""
+
+    @pytest.mark.parametrize(
+        "intent",
+        [
+            "add a chart widget",
+            "add a status badge to the header",
+            "create a new section for metrics",
+            "insert a divider",
+            "delete the chart",
+            "move the heading below the table",
+            "rebuild this as a kanban board",
+            "redesign the layout",
+            "restructure the dashboard",
+            "split the table into two",
+            "convert the list to a grid",
+            "wrap the cards in a flex container",
+            "group the stats together",
+            "duplicate the chart",
+        ],
+    )
+    def test_structural_verbs_escalate(self, intent):
+        c = classify(intent, _SPEC_TASKS)
+        assert c.tier == 2, f"{intent!r} -> {c.tier} ({c.reasoning})"
+        assert c.is_escalation
+
+    @pytest.mark.parametrize(
+        "intent",
+        [
+            "make this less cluttered",
+            "clean up the layout",
+            "improve the design",
+            "polish the dashboard",
+            "simplify this",
+            "modernize the look",
+            "fix the spacing",
+            "make it nicer",
+        ],
+    )
+    def test_creative_verbs_escalate(self, intent):
+        c = classify(intent, _SPEC_TASKS)
+        assert c.tier == 2, f"{intent!r} -> {c.tier} ({c.reasoning})"
+
+    def test_ambiguous_intent_escalates(self):
+        c = classify("do the thing with the stuff", _SPEC_TASKS)
+        assert c.tier == 2
+
+    def test_empty_intent_escalates(self):
+        assert classify("", _SPEC_TASKS).tier == 2
+        assert classify("  ", _SPEC_TASKS).tier == 2
+        assert classify("hi", _SPEC_TASKS).tier == 2
+
+    # ---- partial-match escalations: a tier verb is present but the
+    # object cannot be pinned to exactly one spec entity ----
+
+    def test_partial_mark_no_index_escalates(self):
+        # "mark the tasks done" — a mark verb, but no single numeric target.
+        c = classify("mark the tasks done", _SPEC_TASKS)
+        assert c.tier == 2
+
+    def test_partial_mark_index_out_of_range_escalates(self):
+        # task 9 does not exist in a 3-task collection.
+        c = classify("mark task 9 done", _SPEC_TASKS)
+        assert c.tier == 2
+
+    def test_partial_mark_ambiguous_direction_escalates(self):
+        # "done" AND "todo" both present — ambiguous direction.
+        c = classify("mark task 1 done or todo", _SPEC_TASKS)
+        assert c.tier == 2
+
+    def test_mark_with_no_indexable_collection_escalates(self):
+        # state has no list-of-objects to address.
+        spec = {"state": {"count": 5, "filter": "all"}, "ui": {"id": "n_r", "type": "flex"}}
+        c = classify("mark task 1 done", spec)
+        assert c.tier == 2
+
+    def test_mark_with_two_collections_escalates(self):
+        # two candidate lists -> the index is ambiguous.
+        spec = {
+            "state": {
+                "tasks": [{"id": 1}],
+                "bugs": [{"id": 1}],
+            },
+            "ui": {"id": "n_r", "type": "flex"},
+        }
+        c = classify("mark task 1 done", spec)
+        assert c.tier == 2
+
+    def test_rename_ambiguous_two_nodes_escalates(self):
+        # two headings both reading "Status" — rename can't pick one.
+        spec = {
+            "state": {},
+            "ui": {
+                "id": "n_root",
+                "type": "flex",
+                "props": {},
+                "children": [
+                    {"id": "n_a", "type": "heading", "props": {"text": "Status"}},
+                    {"id": "n_b", "type": "heading", "props": {"text": "Status"}},
+                ],
+            },
+        }
+        c = classify('rename Status to "State"', spec)
+        assert c.tier == 2
+
+    def test_rename_no_matching_node_escalates(self):
+        c = classify('rename Nonexistent to "X"', _SPEC_TASKS)
+        assert c.tier == 2
+
+    def test_rename_without_to_clause_escalates(self):
+        c = classify("rename the heading", _SPEC_TASKS)
+        assert c.tier == 2
+
+    def test_set_filter_without_scalar_field_escalates(self):
+        spec = {"state": {"tasks": []}, "ui": {"id": "n_r", "type": "flex"}}
+        c = classify("set the filter to overdue", spec)
+        assert c.tier == 2
+
+    # ---- action-binding escalations ----
+
+    def test_action_with_unresolved_params_escalates(self):
+        # publish/submit action whose params carry {item.id}.
+        c = classify("submit the submit action", _SPEC_UNRESOLVED_ACTION)
+        assert c.tier == 2, f"-> {c.tier} ({c.reasoning})"
+
+    def test_requires_instinct_action_escalates(self):
+        # an Instinct-gated action must never be auto-fired.
+        c = classify("submit the publish action", _SPEC_INSTINCT_ACTION)
+        assert c.tier == 2, f"-> {c.tier} ({c.reasoning})"
+
+
+# ---------------------------------------------------------------------------
+# Purity — the classifier never mutates its inputs.
+# ---------------------------------------------------------------------------
+
+
+def test_classifier_does_not_mutate_ripple_spec():
+    import copy
+
+    spec = copy.deepcopy(_SPEC_TASKS)
+    before = copy.deepcopy(spec)
+    for intent in ["mark task 1 done", "add a chart", "refresh prs", "make it nicer"]:
+        classify(intent, spec)
+    assert spec == before, "classify() mutated its ripple_spec argument"
+
+
+def test_classification_is_frozen():
+    c = classify("add a widget", _SPEC_TASKS)
+    with pytest.raises((AttributeError, TypeError)):
+        c.tier = 0  # type: ignore[misc]

--- a/tests/ee/agent/test_pocket_router/test_events.py
+++ b/tests/ee/agent/test_pocket_router/test_events.py
@@ -1,0 +1,70 @@
+# test_events.py — Tests for the pocket-router SSE event schema
+#   (Increment 3).
+# Created: 2026-05-22 — pins ``PocketExecutionFrame`` / ``ExecutionStage``:
+#   the wire shape, the ``tier_chosen`` bound, and the skipped-stage
+#   contract that the ``pocket_execution`` frame carries.
+"""Schema tests for the pocket-router ``pocket_execution`` SSE frame."""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.agent.pocket_router.events import (
+    ExecutionStage,
+    PocketExecutionFrame,
+    TokenSpend,
+)
+from pydantic import ValidationError
+
+
+def test_execution_stage_ran():
+    s = ExecutionStage(stage="classify", ran=True, ms=4, detail="Tier 1")
+    assert s.ran is True
+    assert s.skipped_reason is None
+
+
+def test_execution_stage_skipped():
+    s = ExecutionStage(stage="layout_build", ran=False, skipped_reason="data-only change")
+    assert s.ran is False
+    assert s.ms == 0
+    assert s.skipped_reason == "data-only change"
+
+
+def test_token_spend_defaults_to_zero():
+    t = TokenSpend()
+    assert t.prompt == 0
+    assert t.completion == 0
+
+
+def test_execution_frame_to_wire_round_trips():
+    frame = PocketExecutionFrame(
+        request_id="pr_abc123",
+        intent="mark task 1 done",
+        tier_chosen=1,
+        stages=[
+            ExecutionStage(stage="classify", ran=True, ms=2),
+            ExecutionStage(stage="apply", ran=True, ms=11),
+            ExecutionStage(stage="layout_build", ran=False, skipped_reason="data-only change"),
+            ExecutionStage(stage="widget_render", ran=False, skipped_reason="data-only change"),
+        ],
+        total_ms=13,
+    )
+    wire = frame.to_wire()
+    assert wire["type"] == "pocket_execution"
+    assert wire["request_id"] == "pr_abc123"
+    assert wire["tier_chosen"] == 1
+    assert wire["tokens"] == {"prompt": 0, "completion": 0}
+    assert len(wire["stages"]) == 4
+    skipped = [s for s in wire["stages"] if not s["ran"]]
+    assert {s["stage"] for s in skipped} == {"layout_build", "widget_render"}
+
+
+@pytest.mark.parametrize("bad_tier", [3, -1, 5])
+def test_tier_chosen_rejects_out_of_range(bad_tier):
+    with pytest.raises(ValidationError):
+        PocketExecutionFrame(request_id="r", intent="i", tier_chosen=bad_tier)
+
+
+@pytest.mark.parametrize("tier", [0, 1, 2])
+def test_tier_chosen_accepts_valid_tiers(tier):
+    frame = PocketExecutionFrame(request_id="r", intent="i", tier_chosen=tier)
+    assert frame.tier_chosen == tier

--- a/tests/ee/agent/test_pocket_router/test_router.py
+++ b/tests/ee/agent/test_pocket_router/test_router.py
@@ -1,0 +1,411 @@
+# test_router.py — Tests for the pocket execution router's dispatch +
+#   observability (Increment 3).
+# Created: 2026-05-22 — pins the router contract: a Tier-0 verdict invokes
+#   the EXISTING executor (it does not reimplement it) and emits a
+#   ``pocket_execution`` SSE frame with ``tokens:{0,0}`` and the layout /
+#   render stages marked skipped; a Tier-2 verdict escalates (handled is
+#   False); and the kill-switch (``pocket_router_enabled=false``) makes
+#   every request escalate. The classifier itself is covered exhaustively
+#   in test_classifier.py — here we exercise routing, not classification.
+"""Dispatch + observability tests for the pocket execution router."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pocketpaw_ee.agent.pocket_router.router import classify_and_route
+
+
+class _Settings:
+    """Minimal settings stand-in — only the two router fields matter."""
+
+    def __init__(self, enabled: bool = True, min_confidence: float = 0.9) -> None:
+        self.pocket_router_enabled = enabled
+        self.pocket_router_min_confidence = min_confidence
+        # The Tier-1 path hands settings to EditAgentModeAdapter; that
+        # adapter ignores backend/model, but keep the field present.
+        self.pocket_specialist_mode = "agent"
+
+
+class _EditInput:
+    """Stand-in for ``PocketSpecialistEditInput`` — duck-typed; the router
+    only reads ``pocket_id`` / ``intent`` / ``pocket`` / ``target_node_ids``."""
+
+    def __init__(self, intent: str, pocket: dict | None = None) -> None:
+        self.pocket_id = "507f1f77bcf86cd799439011"
+        self.intent = intent
+        self.pocket = pocket
+        self.target_node_ids = None
+        self.ops = None
+
+
+_SPEC_WITH_SOURCE = {
+    "version": "1.0",
+    "sources": {"prs": {"method": "GET", "path": "/pulls", "bind": "state.prs"}},
+    "state": {"prs": []},
+    "ui": {"id": "n_root0000", "type": "flex", "props": {}, "children": []},
+}
+
+
+def _drain(sink: asyncio.Queue) -> list[tuple[str, dict]]:
+    out: list[tuple[str, dict]] = []
+    while not sink.empty():
+        out.append(sink.get_nowait())
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Kill-switch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_makes_everything_escalate():
+    """``pocket_router_enabled=false`` -> every request escalates without
+    even classifying. The router returns ``(False, None)`` so the caller
+    falls through to the specialist — today's behaviour exactly."""
+    # An intent that WOULD be Tier 0 if the router were enabled.
+    input = _EditInput("refresh the prs source", pocket={"rippleSpec": _SPEC_WITH_SOURCE})
+    handled, output = await classify_and_route(
+        input,
+        workspace_id="w1",
+        user_id="u1",
+        settings=_Settings(enabled=False),
+    )
+    assert handled is False
+    assert output is None
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_emits_tier2_execution_frame():
+    """Even with the switch off the router still emits its observability
+    frame — a kill-switch escalation is traced as Tier 2."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_sse_event_sink,
+        detach_sse_event_sink,
+    )
+
+    sink: asyncio.Queue = asyncio.Queue()
+    token = attach_sse_event_sink(sink)
+    try:
+        await classify_and_route(
+            _EditInput("refresh the prs source", pocket={"rippleSpec": _SPEC_WITH_SOURCE}),
+            workspace_id="w1",
+            user_id="u1",
+            settings=_Settings(enabled=False),
+        )
+    finally:
+        detach_sse_event_sink(token)
+
+    events = _drain(sink)
+    names = [n for n, _ in events]
+    assert "pocket_execution" in names
+    _, frame = next(e for e in events if e[0] == "pocket_execution")
+    assert frame["tier_chosen"] == 2
+    assert frame["tokens"] == {"prompt": 0, "completion": 0}
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 escalation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_structural_intent_escalates_without_running_executor():
+    """A structural intent classifies as Tier 2 — the router escalates
+    and never touches an executor."""
+    with patch(
+        "pocketpaw_ee.cloud.pockets.source_executor.run_sources",
+        new=AsyncMock(),
+    ) as run_sources:
+        handled, output = await classify_and_route(
+            _EditInput("add a chart widget", pocket={"rippleSpec": _SPEC_WITH_SOURCE}),
+            workspace_id="w1",
+            user_id="u1",
+            settings=_Settings(),
+        )
+    assert handled is False
+    assert output is None
+    run_sources.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sub_threshold_confidence_escalates():
+    """A cheap-tier verdict whose confidence is below the configured
+    floor escalates — the fail-safe gate. Tier-0 refresh scores ~0.97;
+    a floor of 0.99 trips it."""
+    handled, output = await classify_and_route(
+        _EditInput("refresh the prs source", pocket={"rippleSpec": _SPEC_WITH_SOURCE}),
+        workspace_id="w1",
+        user_id="u1",
+        settings=_Settings(min_confidence=0.99),
+    )
+    assert handled is False
+    assert output is None
+
+
+# ---------------------------------------------------------------------------
+# Tier 0 — declarative: invokes the EXISTING executor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tier0_invokes_source_executor_and_handles():
+    """A Tier-0 refresh routes to ``source_executor.run_sources`` — the
+    router INVOKES the executor, it does not reimplement it. On success
+    the router returns ``(True, output)`` so the caller skips the
+    specialist."""
+    fake_run = AsyncMock(return_value={"ran": [{"source": "prs", "value": []}], "errors": []})
+    with (
+        patch(
+            "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
+            new=AsyncMock(return_value=("https://api.example.com", "bearer", None, "tok", [])),
+        ),
+        patch("pocketpaw_ee.cloud.pockets.source_executor.run_sources", new=fake_run),
+    ):
+        handled, output = await classify_and_route(
+            _EditInput("refresh the prs source", pocket={"rippleSpec": _SPEC_WITH_SOURCE}),
+            workspace_id="w1",
+            user_id="u1",
+            settings=_Settings(),
+        )
+    assert handled is True
+    assert output is not None
+    assert output.ok is True
+    assert output.backend_used == "pocket_router:tier0"
+    # The router passed the named source straight through to the executor.
+    fake_run.assert_awaited_once()
+    assert fake_run.await_args.kwargs["only_source"] == "prs"
+    assert fake_run.await_args.kwargs["pocket_id"] == "507f1f77bcf86cd799439011"
+
+
+@pytest.mark.asyncio
+async def test_tier0_emits_execution_frame_with_zero_tokens_and_skipped_stages():
+    """A Tier-0 route emits one ``pocket_execution`` frame: ``tokens:{0,0}``
+    and the ``layout_build`` / ``widget_render`` stages marked
+    ``ran:false`` with reason 'data-only change' — the Thesys readout."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_sse_event_sink,
+        detach_sse_event_sink,
+    )
+
+    sink: asyncio.Queue = asyncio.Queue()
+    token = attach_sse_event_sink(sink)
+    try:
+        with (
+            patch(
+                "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
+                new=AsyncMock(return_value=("https://api.example.com", "bearer", None, "tok", [])),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.pockets.source_executor.run_sources",
+                new=AsyncMock(return_value={"ran": [], "errors": []}),
+            ),
+        ):
+            handled, _ = await classify_and_route(
+                _EditInput("refresh prs", pocket={"rippleSpec": _SPEC_WITH_SOURCE}),
+                workspace_id="w1",
+                user_id="u1",
+                settings=_Settings(),
+            )
+    finally:
+        detach_sse_event_sink(token)
+
+    assert handled is True
+    events = _drain(sink)
+    exec_frames = [d for n, d in events if n == "pocket_execution"]
+    assert len(exec_frames) == 1, f"expected exactly one pocket_execution frame: {events}"
+    frame = exec_frames[0]
+    assert frame["tier_chosen"] == 0
+    assert frame["tokens"] == {"prompt": 0, "completion": 0}
+
+    stages = {s["stage"]: s for s in frame["stages"]}
+    assert stages["layout_build"]["ran"] is False
+    assert stages["layout_build"]["skipped_reason"] == "data-only change"
+    assert stages["widget_render"]["ran"] is False
+    assert stages["widget_render"]["skipped_reason"] == "data-only change"
+    # classify + apply both ran.
+    assert stages["classify"]["ran"] is True
+    assert stages["apply"]["ran"] is True
+
+
+@pytest.mark.asyncio
+async def test_tier0_source_errors_escalate():
+    """A Tier-0 attempt that the executor reports as errored escalates —
+    the specialist can still satisfy the intent."""
+    with (
+        patch(
+            "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
+            new=AsyncMock(return_value=("https://api.example.com", "bearer", None, "tok", [])),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.pockets.source_executor.run_sources",
+            new=AsyncMock(return_value={"ran": [], "errors": [{"source": "prs", "error": "boom"}]}),
+        ),
+    ):
+        handled, output = await classify_and_route(
+            _EditInput("refresh prs", pocket={"rippleSpec": _SPEC_WITH_SOURCE}),
+            workspace_id="w1",
+            user_id="u1",
+            settings=_Settings(),
+        )
+    assert handled is False
+    assert output is None
+
+
+@pytest.mark.asyncio
+async def test_tier0_no_backend_escalates():
+    """A Tier-0 verdict on a pocket with no backend configured cannot
+    run declaratively — it escalates rather than crashes."""
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
+        new=AsyncMock(return_value=None),
+    ):
+        handled, output = await classify_and_route(
+            _EditInput("refresh prs", pocket={"rippleSpec": _SPEC_WITH_SOURCE}),
+            workspace_id="w1",
+            user_id="u1",
+            settings=_Settings(),
+        )
+    assert handled is False
+    assert output is None
+
+
+# ---------------------------------------------------------------------------
+# ripple_spec resolution fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_router_resolves_spec_via_agent_view_when_pocket_absent():
+    """When the caller does not hand a pocket view, the router reads the
+    spec via ``agent_view`` — and still classifies + routes correctly."""
+    fake_run = AsyncMock(return_value={"ran": [], "errors": []})
+    with (
+        patch(
+            "pocketpaw_ee.cloud.pockets.service.agent_view",
+            new=AsyncMock(return_value=({"rippleSpec": _SPEC_WITH_SOURCE}, None)),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
+            new=AsyncMock(return_value=("https://api.example.com", "bearer", None, "tok", [])),
+        ),
+        patch("pocketpaw_ee.cloud.pockets.source_executor.run_sources", new=fake_run),
+    ):
+        handled, output = await classify_and_route(
+            _EditInput("refresh prs", pocket=None),
+            workspace_id="w1",
+            user_id="u1",
+            settings=_Settings(),
+        )
+    assert handled is True
+    assert output.ok is True
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — deterministic op: end-to-end through the op-apply path
+# ---------------------------------------------------------------------------
+
+
+_SPEC_TASKS = {
+    "version": "1.0",
+    "state": {
+        "tasks": [
+            {"id": 1, "label": "buy milk", "status": "todo"},
+            {"id": 2, "label": "walk dog", "status": "todo"},
+        ],
+        "filter": "all",
+    },
+    "ui": {"id": "n_root0000", "type": "flex", "props": {}, "children": []},
+}
+
+
+@pytest.fixture
+def recording_bus():
+    """Install an in-memory realtime bus for the duration of a test.
+
+    The granular ops the Tier-1 path drives emit ``PocketUpdated`` via
+    the realtime bus, which is only wired by ``init_realtime`` in a live
+    process. ``tests/cloud`` installs this autouse; ``tests/ee`` does
+    not, so the router's end-to-end test installs its own."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list = []
+
+        async def publish(self, event) -> None:  # noqa: ANN001
+            self.events.append(event)
+
+        def subscribe(self, event_type, handler) -> None:  # noqa: ANN001, ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    try:
+        yield rec
+    finally:
+        bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_tier1_applies_one_op_end_to_end(beanie_test_db, recording_bus):
+    """A Tier-1 'mark task done' verdict routes through the existing
+    op-apply path and persists the single ``set_state`` op against a real
+    Pocket — no LLM runs, the router returns ``(True, output)``."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_agent_identity,
+        attach_sse_event_sink,
+        detach_agent_identity,
+        detach_sse_event_sink,
+    )
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    doc = Pocket(
+        workspace="w1",
+        name="Tasks",
+        owner="u1",
+        visibility="workspace",
+        rippleSpec=dict(_SPEC_TASKS),
+    )
+    await doc.insert()
+    pocket_id = str(doc.id)
+
+    sink: asyncio.Queue = asyncio.Queue()
+    id_tokens = attach_agent_identity(workspace_id="w1", user_id="u1")
+    sink_token = attach_sse_event_sink(sink)
+    try:
+        input = _EditInput("mark task 1 as done")
+        input.pocket_id = pocket_id
+        handled, output = await classify_and_route(
+            input,
+            workspace_id="w1",
+            user_id="u1",
+            settings=_Settings(),
+        )
+    finally:
+        detach_sse_event_sink(sink_token)
+        detach_agent_identity(id_tokens)
+
+    assert handled is True, f"Tier-1 should handle 'mark task 1 done': {output}"
+    assert output.ok is True
+    assert len(output.ops) == 1
+
+    # The op persisted: task 1 (index 0) is now done.
+    refreshed = await Pocket.get(doc.id)
+    assert refreshed.rippleSpec["state"]["tasks"][0]["status"] == "done"
+    assert refreshed.rippleSpec["state"]["tasks"][1]["status"] == "todo"  # untouched
+
+    # The execution frame says Tier 1, zero tokens, layout/render skipped.
+    events = _drain(sink)
+    exec_frames = [d for n, d in events if n == "pocket_execution"]
+    assert len(exec_frames) == 1
+    frame = exec_frames[0]
+    assert frame["tier_chosen"] == 1
+    assert frame["tokens"] == {"prompt": 0, "completion": 0}
+    stages = {s["stage"]: s for s in frame["stages"]}
+    assert stages["layout_build"]["ran"] is False
+    assert stages["widget_render"]["ran"] is False


### PR DESCRIPTION
Increment 3 of the pocket-edit pipeline. Two changes ship in one PR — a small additive win and a new routing layer.

## Part A — structure/data split (RFC-06)

Every granular `agent_*` edit op already pushes a `pocket_mutation` SSE frame. That frame now carries a `family` discriminant:

- `updateComponents` — a node op changed the component tree (`rippleSpec.ui`)
- `updateDataModel` — a state op changed the data model (`rippleSpec.state`)

A client can re-render only the layer that changed instead of rebuilding the whole pocket. It is still one frame per op, emitted flat so the existing un-discriminated consumers keep working byte-for-byte, and the coarse `PocketUpdated` realtime event is untouched — so a client that ignores `family` keeps its refetch signal. The change is purely additive. The rippleSpec schema is not touched and the component model is not flattened — that stays a separate spike.

## Part B — execution router

A rule-based classifier now front-runs `pocket_specialist__edit` and routes a request to the cheapest capable tier:

- **Tier 0 — declarative.** "refresh prs" or "submit publish" maps 1:1 to a declared `sources.X` / `actions.X`. Fired through the existing `source_executor` / `action_executor` — every guard (allowlist, SSRF, rate limit, fail-closed instinct-reject, run-access) stays intact. The router invokes the executor; it bypasses nothing.
- **Tier 1 — deterministic op.** "mark task 3 done" / "rename X" / "set filter" maps to one granular op, applied through the existing op-apply path. No model call.
- **Tier 2 — specialist.** Structural, creative, or ambiguous intent escalates to `run_edit_specialist` unchanged.

The classifier is pure — no I/O, no model call — and fail-safe by design: any doubt escalates to Tier 2. It escalates on a partial keyword match, a structural verb anywhere in the intent, a target that resolves to more than one entity, an unresolved `{state.x}` / `{item.id}` action param, a `requires_instinct` action, or confidence below the floor. A wrong skip produces a broken pocket; a wrong escalate only costs an LLM call, so the asymmetry drives every default.

Each route records a stage timeline, emits one `pocket_execution` SSE frame (which tier ran, per-stage `ran`/`ms`/skip-reason, total latency, token spend), and writes a `pocket_router` audit entry — WARNING on a Tier-0/1 bypass, since that is a mutation with no agent reasoning behind it. Tier 0/1 report `tokens:{0,0}` and mark the `layout_build` / `widget_render` stages skipped with reason "data-only change".

Two config keys, `POCKETPAW_` prefix:

- `pocket_router_enabled` (default `true`) — kill-switch. `false` makes every request escalate, restoring pre-router behaviour exactly.
- `pocket_router_min_confidence` (default `0.9`) — the cheap-tier confidence floor.

`pocket_specialist__create` is out of scope — a new pocket has nothing to classify against.

## Tests

- `test_classifier.py` — 56-case labelled corpus, the safety net: refresh -> T0, mark-done/rename -> T1, structural/creative/ambiguous -> T2, plus every fail-safe escalation (partial match, out-of-range index, ambiguous target, unresolved params, requires_instinct) as a dedicated case, and a purity check.
- `test_router.py` — T0 invokes the executor and emits the frame; kill-switch makes everything escalate; T2 escalation; sub-threshold confidence escalates; T1 applies one op end-to-end against a real pocket.
- `test_events.py` — the `pocket_execution` frame schema.
- `test_pocket_mutation_family.py` — each granular op emits the correctly-discriminated frame AND still emits `PocketUpdated`.

`uv run pytest tests/cloud/ tests/ee/` passes for every suite this PR touches (280 directly-affected tests green; the 64 pre-existing `uploads/` + `test_ee_correction.py` failures reproduce on `dev` unchanged). `ruff check`, `ruff format --check`, `mypy` on touched files, and all 17 import-linter contracts pass — including the new "classifier stays pure" contract.

A ripple-side mutation-router shim follows in a separate change.