### PR TITLE
Per-backend API skills for pocket authoring (Increment 2b)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14,6 +14,11 @@ GET /pockets/{id}/backend.
 Updated: 2026-05-22 (RFC 05 M2a) — documented the write-action endpoints
 (POST /pockets/{id}/actions/run, PUT /pockets/{id}/backend/write-policy)
 and the per-pocket write allowlist now carried on the backend summary.
+
+Updated: 2026-05-22 (feat/api-skills, Increment 2b) — documented
+POST /skills/api-doc, the per-backend API-skill install endpoint that
+turns a pocket backend's OpenAPI document into a loadable SKILL.md so
+the authoring agent stops hallucinating endpoints.
 -->
 
 # Cloud REST API Reference
@@ -233,3 +238,49 @@ and a write-specific rate limit — 20 writes per `(pocket, user)` per
 minute, a **separate** counter from the read budget. Every run (including
 every rejection) is written to the audit log; the credential token is
 never logged.
+
+## Skills — Per-Backend API Skills
+
+Increment 2b (the second half of pocket Increment 2, after the built-in
+templates of 2a). When a pocket is bound to a backend, the
+pocket-authoring agent does better work if it can see the backend's
+**real** API instead of guessing endpoints. This endpoint installs a
+backend's OpenAPI / Swagger document as a loadable skill: the agent then
+authors `rippleSpec.sources` / `rippleSpec.actions` against real relative
+paths and real response shapes rather than hallucinating them.
+
+The skill is a `SKILL.md` file written under `~/.pocketpaw/skills/api-<domain-slug>/`
+— one of the three roots PocketPaw's `SkillLoader` scans. The
+pocket-specialist runtime loads it (keyed by the pocket's backend
+hostname) and splices a `<backend-api>` endpoint reference into the
+authoring prompt.
+
+### `POST /skills/api-doc`
+
+Install a backend's OpenAPI / Swagger spec as a per-backend API skill.
+Requires the `skills.manage` role (**ADMIN**) — installing a skill
+changes workspace-wide pocket-authoring behaviour.
+
+Multipart form upload:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `file` | file | Required. The OpenAPI 3.x or Swagger 2.x document — `.json`, `.yaml`, or `.yml`, max 2 MB. |
+| `name` | string | Optional. The backend display name — used to derive the skill slug when the spec itself names no server. |
+
+The slug is derived from the spec's server hostname (`servers[0].url`
+for OpenAPI 3.x, `host` for Swagger 2.x), falling back to `name`. The
+generated reference groups operations by tag (or first path segment),
+caps at 200 endpoints, and records each operation's method, path,
+summary, key request params, and key 200-response fields.
+
+Response `200`:
+
+```json
+{ "ok": true, "slug": "api-example-com" }
+```
+
+Returns `422` when the file extension is unsupported, the file exceeds
+the 2 MB cap, the document is unparseable, or it carries no `paths`
+object. Every install is audit-logged with the workspace, the actor, and
+the resulting slug — never the spec contents.

--- a/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
@@ -39,6 +39,16 @@ and customizes that template instead of cold-generating).
 ``_build_system_prompt`` accepts ``backend_summary`` and, when a
 ``template_id`` hint is set, splices the loaded template skeleton +
 customization rules in via ``_load_template_block``.
+Changes: 2026-05-22 (feat/api-skills, Increment 2b) — per-backend API
+skills. When a pocket has a backend configured, the specialist now loads
+that backend's installed API skill (a SKILL.md under
+``~/.pocketpaw/skills/api-<domain-slug>/``) and splices an endpoint
+reference into the prompt via ``_load_api_skill_for_backend`` +
+``_format_api_skill_block``, so the agent authors ``sources`` / ``actions``
+against real relative paths instead of hallucinating endpoints. Wired into
+``_build_system_prompt`` for the create path and into
+``_run_edit_subagent_pipeline`` for the edit path (the edit path already
+fetches ``backend_summary`` from ``get_pocket_backend``).
 """
 
 from __future__ import annotations
@@ -485,6 +495,94 @@ def _load_template_block(template_id: str, backend_summary: dict[str, Any] | Non
     )
 
 
+# ---------------------------------------------------------------------------
+# Per-backend API skills (feat/api-skills, Increment 2b).
+#
+# When a pocket has a backend configured, its OpenAPI spec may have been
+# installed as a skill (a SKILL.md under ``~/.pocketpaw/skills/api-<slug>/``,
+# written by ``pocketpaw.skills.api_skill_builder.install_api_skill``).
+# Loading that skill into the authoring prompt gives the specialist the
+# backend's REAL endpoints — so it authors ``sources`` / ``actions`` with
+# correct relative paths and response shapes instead of guessing.
+# ---------------------------------------------------------------------------
+
+
+def _load_api_skill_for_backend(backend_summary: dict[str, Any] | None) -> str | None:
+    """Load the installed API-skill content for a pocket's backend.
+
+    Derives the domain slug from ``backend_summary["base_url"]``'s
+    hostname (e.g. ``https://api.example.com`` → ``api-example-com``),
+    then loads ``~/.pocketpaw/skills/api-<slug>/SKILL.md`` via the
+    runtime ``parse_skill_md`` and returns its body ``.content``.
+
+    Returns ``None`` when ``backend_summary`` is missing, carries no
+    ``base_url``, or the skill file does not exist / fails to parse — a
+    missing API skill must never block pocket authoring. All imports are
+    lazy so the cost is paid only when a backend is actually configured.
+    """
+    if not backend_summary:
+        return None
+    try:
+        from urllib.parse import urlparse
+
+        from pocketpaw.skills.api_skill_builder import _slugify_domain
+        from pocketpaw.skills.loader import parse_skill_md
+
+        base_url = backend_summary.get("base_url")
+        if not isinstance(base_url, str) or not base_url.strip():
+            return None
+        parsed = urlparse(base_url if "://" in base_url else f"//{base_url}")
+        host = parsed.hostname or base_url.strip()
+        slug = _slugify_domain(host)
+
+        from pathlib import Path
+
+        skill_md = Path.home() / ".pocketpaw" / "skills" / f"api-{slug}" / "SKILL.md"
+        if not skill_md.is_file():
+            log.debug("[pocket-specialist] no API skill installed for backend slug=%s", slug)
+            return None
+
+        skill = parse_skill_md(skill_md)
+        if skill is None or not skill.content.strip():
+            return None
+        log.info("[pocket-specialist] loaded API skill api-%s into authoring prompt", slug)
+        return skill.content
+    except Exception:  # noqa: BLE001 — a missing/broken API skill must not block authoring
+        log.debug("[pocket-specialist] API-skill load failed (non-fatal)", exc_info=True)
+        return None
+
+
+def _format_api_skill_block(content: str, backend_summary: dict[str, Any] | None) -> str:
+    """Wrap loaded API-skill content in a ``<backend-api>`` prompt block.
+
+    The block tells the specialist this is the backend's REAL API and to
+    author ``sources`` / ``actions`` ``path`` values from it — never an
+    invented endpoint, always a relative path.
+    """
+    base_url = ""
+    if backend_summary and isinstance(backend_summary.get("base_url"), str):
+        base_url = backend_summary["base_url"]
+    header = (
+        "\n\n<backend-api>\n"
+        "This pocket's backend has a published API. The endpoint "
+        "reference below is the REAL API"
+    )
+    if base_url:
+        header += f" of `{base_url}`"
+    header += (
+        ".\n"
+        "- Use these endpoint references to author every `sources` and "
+        "`actions` `path` — they are the authoritative list of what the "
+        "backend exposes.\n"
+        "- NEVER invent an endpoint that is not in this reference. If the "
+        "data the user wants has no matching endpoint, say so rather than "
+        "guessing a path.\n"
+        "- ALWAYS use the RELATIVE path shown (e.g. `/contacts`), never an "
+        "absolute URL — the runtime joins it to the backend base URL.\n\n"
+    )
+    return header + content.strip() + "\n</backend-api>\n"
+
+
 def _build_system_prompt(
     hints: PocketSpecialistHints | None,
     backend_summary: dict[str, Any] | None = None,
@@ -503,10 +601,25 @@ def _build_system_prompt(
     rippleSpec skeleton + customization rules are spliced in via
     ``_load_template_block`` — the highest-authority structural plan.
     An unknown slug is ignored (the specialist cold-generates).
+
+    When ``backend_summary`` names a configured backend whose API has
+    been installed as a skill, that endpoint reference is spliced in via
+    ``_load_api_skill_for_backend`` + ``_format_api_skill_block`` so the
+    specialist authors ``sources`` / ``actions`` against real paths. The
+    API block is appended even on a bare (no-``hints``) call.
     """
     base = POCKET_SPECIALIST_PROMPT.replace(POCKET_ID_TOKEN, "")
+
+    # The backend API skill is independent of hints — load it once up
+    # front so a bare ``_build_system_prompt(None, backend_summary)``
+    # call still gets the endpoint reference.
+    api_skill_content = _load_api_skill_for_backend(backend_summary)
+    api_block = (
+        _format_api_skill_block(api_skill_content, backend_summary) if api_skill_content else ""
+    )
+
     if not hints:
-        return base
+        return base + api_block
 
     surface = ("name", "description", "color", "icon", "target_pocket_id")
     plan = ("purpose", "layout", "focal_widget", "data_shape", "key_interactions")
@@ -539,8 +652,8 @@ def _build_system_prompt(
         template_block = _load_template_block(hints.template_id, backend_summary)
 
     if not lines and template_block is None:
-        return base
-    return base + "\n".join(lines) + (template_block or "")
+        return base + api_block
+    return base + "\n".join(lines) + (template_block or "") + api_block
 
 
 def _build_user_message(input: PocketSpecialistCreateInput) -> str:
@@ -827,6 +940,12 @@ async def _run_edit_subagent_pipeline(
     system_prompt = fill_current_pocket(
         POCKET_EDIT_SPECIALIST_PROMPT_MCP, input.pocket_id, backend_summary
     )
+    # When the pocket's backend has an installed API skill, splice its
+    # endpoint reference in so the edit specialist authors set_source /
+    # set_action ``path`` values against real endpoints (Increment 2b).
+    api_skill_content = _load_api_skill_for_backend(backend_summary)
+    if api_skill_content:
+        system_prompt += _format_api_skill_block(api_skill_content, backend_summary)
     user_message = _build_edit_user_message(input)
 
     log.info(

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,9 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Updated: 2026-05-22 (feat/api-skills, Increment 2b) — mounts the Skills
+    entity at ``/api/v1/skills`` (POST /skills/api-doc), the per-backend
+    API-skill install endpoint that turns a pocket backend's OpenAPI
+    document into a loadable SKILL.md for the authoring agent.
 Updated: 2026-05-17 — Mounts the workspace-scoped Audit entity at
     ``/api/v1/audit`` (B1) with tenancy from ``RequestContext.workspace_id``,
     the legacy ``/api/v1/runtime/audit`` remaining live; also mounts
@@ -134,6 +138,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.pockets.router import router as pockets_router
     from pocketpaw_ee.cloud.projects.router import router as projects_router
     from pocketpaw_ee.cloud.sessions.router import router as sessions_router
+    from pocketpaw_ee.cloud.skills.router import router as skills_router
     from pocketpaw_ee.cloud.workspace.router import router as workspace_router
 
     app.include_router(auth_router, prefix="/api/v1")
@@ -151,6 +156,8 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(planner_router, prefix="/api/v1")
     app.include_router(sessions_router, prefix="/api/v1")
     app.include_router(cycles_router, prefix="/api/v1")
+    # Skills — per-backend API-skill install (POST /skills/api-doc).
+    app.include_router(skills_router, prefix="/api/v1")
 
     # Phase 1 PR-8: register the connector bus listener so local-mode
     # CLI actions (firebase, gcp, …) get picked up by the in-process

--- a/ee/pocketpaw_ee/cloud/skills/__init__.py
+++ b/ee/pocketpaw_ee/cloud/skills/__init__.py
@@ -1,0 +1,6 @@
+# __init__.py — Cloud Skills entity package.
+# Created: 2026-05-22 (feat/api-skills, Increment 2b) — the dashboard
+# endpoint for installing a backend's OpenAPI spec as a per-backend API
+# skill. Follows the ee/cloud 4-file shape: domain / dto / service /
+# router. No Beanie models — the skill is written to the local skills
+# directory by the OSS ``pocketpaw.skills.api_skill_builder``.

--- a/ee/pocketpaw_ee/cloud/skills/domain.py
+++ b/ee/pocketpaw_ee/cloud/skills/domain.py
@@ -1,0 +1,31 @@
+# domain.py — Domain value object for the cloud Skills entity.
+# Created: 2026-05-22 (feat/api-skills, Increment 2b) — a frozen
+# value object carrying the tenancy context + spec bytes for an
+# API-doc skill install. Tenancy fields are required (no defaults) so
+# constructing one without a workspace is a type error — Rule 3.
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ApiDocInstall(BaseModel):
+    """An API-doc skill install request, scoped to a workspace.
+
+    Frozen value object — multi-tenancy is enforced at construction:
+    ``workspace_id`` and ``user_id`` are required, no defaults. The
+    ``spec_bytes`` carry the uploaded OpenAPI / Swagger document; the
+    service parses and installs it. ``name`` is the optional backend
+    display name used to derive the skill slug when the spec itself
+    names no server.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    workspace_id: str
+    user_id: str
+    filename: str
+    spec_bytes: bytes
+    name: str | None = None
+
+
+__all__ = ["ApiDocInstall"]

--- a/ee/pocketpaw_ee/cloud/skills/dto.py
+++ b/ee/pocketpaw_ee/cloud/skills/dto.py
@@ -1,0 +1,30 @@
+# dto.py — Request/response DTOs for the cloud Skills entity.
+# Created: 2026-05-22 (feat/api-skills, Increment 2b) — distinct
+# request and response models for POST /skills/api-doc (Rule 4). The
+# request carries the optional backend name; the multipart file itself
+# is bound by FastAPI's UploadFile in the router. The response carries
+# the installed skill slug.
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class InstallApiDocRequest(BaseModel):
+    """Non-file fields of a POST /skills/api-doc multipart request.
+
+    The ``file`` part is bound separately by the router as an
+    ``UploadFile``; this DTO carries only the optional backend display
+    ``name`` so the service can re-validate at entry (Rule 6).
+    """
+
+    name: str | None = Field(default=None, max_length=200)
+
+
+class InstallApiDocResponse(BaseModel):
+    """Result of an API-doc skill install."""
+
+    ok: bool = True
+    slug: str = Field(..., description="Slug of the installed skill, e.g. api-example-com.")
+
+
+__all__ = ["InstallApiDocRequest", "InstallApiDocResponse"]

--- a/ee/pocketpaw_ee/cloud/skills/router.py
+++ b/ee/pocketpaw_ee/cloud/skills/router.py
@@ -1,0 +1,79 @@
+# router.py — FastAPI router for the cloud Skills entity.
+# Created: 2026-05-22 (feat/api-skills, Increment 2b) — exposes
+# POST /api/v1/skills/api-doc, a multipart upload that installs a
+# backend's OpenAPI / Swagger document as a per-backend API skill.
+# Thin router: validates the upload extension + size, reads the bytes,
+# and delegates to skills.service.install_api_doc. Never raises
+# HTTPException for domain failures — CloudError maps to JSON via
+# _core.http. Mounted in mount_cloud() alongside the other domain
+# routers. Guarded by skills.manage (ADMIN).
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, File, Form, UploadFile
+
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.shared.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_action_any_workspace,
+)
+from pocketpaw_ee.cloud.skills import service as skills_service
+from pocketpaw_ee.cloud.skills.domain import ApiDocInstall
+from pocketpaw_ee.cloud.skills.dto import InstallApiDocResponse
+
+# A spec upload bigger than this is rejected before the bytes are read
+# into memory — mirrors the 2 MB cap in skills.service / api_skill_builder.
+_MAX_SPEC_BYTES = 2 * 1024 * 1024
+_ALLOWED_EXTENSIONS = (".json", ".yaml", ".yml")
+
+router = APIRouter(
+    prefix="/skills",
+    tags=["Skills"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.post(
+    "/api-doc",
+    response_model=InstallApiDocResponse,
+    dependencies=[Depends(require_action_any_workspace("skills.manage"))],
+)
+async def install_api_doc(
+    file: Annotated[UploadFile, File(...)],
+    name: Annotated[str | None, Form()] = None,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> InstallApiDocResponse:
+    """Install an uploaded OpenAPI / Swagger document as an API skill.
+
+    Accepts a multipart upload — ``file`` (the spec, ``.json`` /
+    ``.yaml`` / ``.yml``) and an optional ``name`` (the backend display
+    name). The resulting skill lives under ``~/.pocketpaw/skills/`` so
+    the pocket-authoring agent can load the backend's real endpoints.
+    Requires the ``skills.manage`` role (ADMIN).
+    """
+    filename = file.filename or ""
+    if not filename.lower().endswith(_ALLOWED_EXTENSIONS):
+        raise ValidationError(
+            "skills.api_doc.bad_extension",
+            f"spec file must be one of {', '.join(_ALLOWED_EXTENSIONS)}",
+        )
+
+    spec_bytes = await file.read()
+    if len(spec_bytes) > _MAX_SPEC_BYTES:
+        raise ValidationError(
+            "skills.api_doc.too_large",
+            f"spec file is {len(spec_bytes)} bytes — exceeds the 2 MB limit",
+        )
+
+    body = ApiDocInstall(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        filename=filename,
+        spec_bytes=spec_bytes,
+        name=name,
+    )
+    return await skills_service.install_api_doc(workspace_id, user_id, body)

--- a/ee/pocketpaw_ee/cloud/skills/service.py
+++ b/ee/pocketpaw_ee/cloud/skills/service.py
@@ -1,0 +1,140 @@
+# service.py — Cloud Skills entity business logic.
+# Created: 2026-05-22 (feat/api-skills, Increment 2b) — validates an
+# uploaded OpenAPI / Swagger document and installs it as a per-backend
+# API skill by delegating to the OSS pocketpaw.skills.api_skill_builder.
+# No Beanie writes — the skill is a SKILL.md on the local skills dir;
+# the install is audit-logged with workspace_id + user_id (Rule 9 has a
+# no-event note: skills are filesystem-local, not a DB row).
+from __future__ import annotations
+
+import json
+import logging
+
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.skills.domain import ApiDocInstall
+from pocketpaw_ee.cloud.skills.dto import InstallApiDocResponse
+
+logger = logging.getLogger(__name__)
+
+# Accepted spec file extensions and the hard size cap. The cap mirrors
+# ``api_skill_builder._MAX_SPEC_BYTES`` — checked here too so an
+# oversized upload is rejected before the builder touches it.
+_ALLOWED_EXTENSIONS = (".json", ".yaml", ".yml")
+_MAX_SPEC_BYTES = 2 * 1024 * 1024  # 2 MB
+
+
+def _audit_api_skill_install(*, workspace_id: str, user_id: str, slug: str, filename: str) -> None:
+    """Write an audit-log entry for an API-skill install.
+
+    Logs the workspace, the actor, the resulting slug, and the upload
+    filename — no spec contents, no credentials. Audit failures must
+    never break the install, so the call is wrapped.
+    """
+    try:
+        from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+
+        get_audit_logger().log(
+            AuditEvent.create(
+                severity=AuditSeverity.INFO,
+                actor=user_id,
+                action="skills.api_doc.install",
+                target=slug,
+                status="success",
+                category="skills_config",
+                workspace_id=workspace_id,
+                slug=slug,
+                filename=filename,
+            )
+        )
+    except Exception:  # noqa: BLE001 — audit must never break the install
+        logger.warning("api-skill install audit-log write failed", exc_info=True)
+
+
+async def install_api_doc(
+    workspace_id: str, user_id: str, body: ApiDocInstall | dict
+) -> InstallApiDocResponse:
+    """Install an uploaded OpenAPI / Swagger document as an API skill.
+
+    Validates the file extension and size, parses the spec, delegates
+    to ``pocketpaw.skills.api_skill_builder.install_api_skill`` to write
+    the SKILL.md, audit-logs the install, and returns the skill slug.
+
+    Args:
+        workspace_id: Active workspace — tenancy context.
+        user_id: Authenticated caller — actor in the audit entry.
+        body: An ``ApiDocInstall`` (or wire dict) carrying the spec
+            bytes, the upload filename, and the optional backend name.
+
+    Returns:
+        ``InstallApiDocResponse`` with ``ok`` and the installed ``slug``.
+
+    Raises:
+        ValidationError: The file extension is unsupported, the file
+            exceeds the 2 MB cap, the spec is unparseable, or it carries
+            no ``paths`` object.
+    """
+    # Re-validate at entry (Rule 6) — FastAPI parsed the multipart body,
+    # but internal callers (jobs, tests) re-parse here.
+    body = ApiDocInstall.model_validate(body)
+
+    filename = body.filename or ""
+    if not filename.lower().endswith(_ALLOWED_EXTENSIONS):
+        raise ValidationError(
+            "skills.api_doc.bad_extension",
+            f"spec file must be one of {', '.join(_ALLOWED_EXTENSIONS)}",
+        )
+
+    if len(body.spec_bytes) > _MAX_SPEC_BYTES:
+        raise ValidationError(
+            "skills.api_doc.too_large",
+            f"spec file is {len(body.spec_bytes)} bytes — exceeds the 2 MB limit",
+        )
+
+    text = body.spec_bytes.decode("utf-8", errors="replace")
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        try:
+            import yaml  # type: ignore[import-untyped]
+
+            parsed = yaml.safe_load(text)
+        except Exception as exc:  # noqa: BLE001 — surfaced as a ValidationError
+            raise ValidationError(
+                "skills.api_doc.unparseable",
+                "spec is neither valid JSON nor YAML",
+            ) from exc
+
+    if not isinstance(parsed, dict):
+        raise ValidationError(
+            "skills.api_doc.unparseable",
+            "spec did not parse to a JSON object",
+        )
+
+    from pocketpaw.skills.api_skill_builder import install_api_skill
+
+    try:
+        slug = install_api_skill(parsed, name=body.name)
+    except ValueError as exc:
+        # api_skill_builder rejects a spec with no `paths` / one too
+        # large — map it to a 422 the dashboard surfaces inline.
+        raise ValidationError("skills.api_doc.invalid_spec", str(exc)) from exc
+
+    _audit_api_skill_install(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        slug=slug,
+        filename=filename,
+    )
+    logger.info(
+        "skills.api_doc: installed %s for workspace=%s actor=%s",
+        slug,
+        workspace_id,
+        user_id,
+    )
+    # no-event: an API skill is a filesystem-local SKILL.md, not a DB
+    # row — there is no downstream search index / soul handler to keep
+    # in sync, so no bus event is emitted.
+    return InstallApiDocResponse(ok=True, slug=slug)
+
+
+__all__ = ["install_api_doc"]

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -21,6 +21,10 @@
 # ``instinct.propose``, ``instinct.approve``, ``instinct.audit`` so the
 # Fabric and Instinct routers (previously fully unguarded) can use
 # ``require_action_any_workspace``.
+#
+# Updated: 2026-05-22 (feat/api-skills, Increment 2b) — added
+# ``skills.manage`` (ADMIN) so the new ee.cloud.skills router can guard
+# POST /skills/api-doc, the per-backend API-skill install endpoint.
 
 from __future__ import annotations
 
@@ -181,6 +185,12 @@ ACTIONS: dict[str, ActionRule] = {
     # every workspace member. The role choice mirrors the existing
     # abac.ACTION_ROLES["audit.read"] entry.
     "audit.read": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Skills — installing a backend's OpenAPI spec as a per-backend API
+    # skill (ee.cloud.skills). ADMIN, mirroring connector.manage: the
+    # installed skill changes workspace-wide pocket-authoring behaviour
+    # and the install accepts an uploaded document, so it should not be
+    # open to every member.
+    "skills.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
 }
 
 

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -34,6 +34,13 @@
 # fires only if the human owner allow-listed the method+path.
 # `_EDIT_TOOLS_MCP` now also lists `set_action` / `remove_action`.
 #
+# Changes: 2026-05-22 (feat/api-skills, Increment 2b) — both
+# `_LIVE_DATA_SOURCES_BLOCK` (create) and `_LIVE_DATA_SOURCES_EDIT_BLOCK`
+# (edit) gain a rule pointing the specialist at the `<backend-api>` block:
+# when an installed per-backend API skill is spliced into the prompt, the
+# agent must author `path` values from its real endpoint references rather
+# than guessing.
+#
 # Canonical source for every pocket-mode system prompt the agent ever sees.
 # Four strings are exported, one per (action × backend) cell:
 #
@@ -512,6 +519,9 @@ Rules:
 - A pocket using `sources` MUST have a backend configured (base URL +
   auth, set once via the pocket's backend settings — outside the spec).
   If no backend is configured, the sources will not run.
+- If a `<backend-api>` block is present in this prompt, use its endpoint
+  references to author `path` values — never guess a path when the
+  reference is available.
 - A source `path` is ALWAYS relative to the configured backend base URL
   — never put an absolute URL in `path`. You only ever author the
   relative path. If you are extending an existing pocket, `get_pocket`
@@ -600,6 +610,9 @@ Rules:
 - A pocket using sources MUST have a backend configured (base URL + auth,
   set once in the pocket's backend settings — outside the spec). Without
   a backend the sources will not run.
+- If a `<backend-api>` block is present in this prompt, use its endpoint
+  references to author `path` values — never guess a path when the
+  reference is available.
 - Do NOT stash a fake source descriptor in `state`, and do NOT build a
   refresh button that sends a chat message — use `set_source` + the
   `run_source` action.

--- a/src/pocketpaw/skills/api_skill_builder.py
+++ b/src/pocketpaw/skills/api_skill_builder.py
@@ -1,0 +1,498 @@
+# src/pocketpaw/skills/api_skill_builder.py
+# Created: 2026-05-22 (feat/api-skills, Increment 2b) — turns an OpenAPI /
+# Swagger spec for a pocket's configured backend into a loadable SKILL.md
+# so the pocket-authoring agent writes correct `sources` / `actions`
+# (real relative paths, real response shapes) instead of hallucinating
+# endpoints. Pure OSS module — no `pocketpaw_ee` import; the SkillLoader
+# in `pocketpaw.skills.loader` reads what `install_api_skill` writes.
+"""Build a per-backend API skill from an OpenAPI / Swagger spec.
+
+A pocket can be bound to one external backend (RFC 04). When the
+backend exposes an OpenAPI document, ``install_api_skill`` converts it
+to a SKILL.md under ``~/.pocketpaw/skills/api-<domain_slug>/`` — one of
+the three roots the runtime ``SkillLoader`` scans. The pocket-specialist
+runtime then loads that SKILL.md and splices an endpoint reference into
+the authoring prompt so the agent uses real paths.
+
+Two public entry points:
+
+- ``parse_openapi_to_skill_md`` — pure transform: an OpenAPI dict in, a
+  SKILL.md string out. **Content-stable** — repeated calls on the same
+  spec produce byte-identical output (paths are ``sorted()``), so the
+  SHA-based skip logic of any mirror installer stays a no-op.
+- ``install_api_skill`` — accepts a file path / URL / parsed dict,
+  validates it, writes the SKILL.md, audit-logs the install, and
+  returns the domain slug.
+
+This module never imports the enterprise package — the import-linter
+``OSS core may not import from EE`` contract covers it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# A spec file larger than this is rejected — an OpenAPI document this big
+# is almost certainly not what the user meant to upload, and parsing it
+# would blow the authoring prompt's token budget anyway.
+_MAX_SPEC_BYTES = 2 * 1024 * 1024  # 2 MB
+
+# Hard cap on endpoints emitted into a single skill. A spec with more
+# operations than this is truncated with an explicit note — the agent
+# only ever needs a representative slice, and the prompt has a budget.
+_MAX_ENDPOINTS = 200
+
+# Per-operation field caps — keep each endpoint reference compact.
+_SUMMARY_MAX_CHARS = 120
+_MAX_RESPONSE_FIELDS = 10
+
+
+# ---------------------------------------------------------------------------
+# Spec-shape helpers — handle OpenAPI 3.x AND Swagger 2.x
+# ---------------------------------------------------------------------------
+
+
+def _slugify_domain(domain: str) -> str:
+    """Turn a hostname (or any string) into a filesystem-safe slug.
+
+    ``api.example.com`` → ``api-example-com``. Dots and any non
+    ``[a-z0-9-]`` run collapse to a single hyphen so the slug is a
+    clean directory name. An empty / unusable input falls back to
+    ``backend``.
+    """
+    lowered = (domain or "").strip().lower()
+    out: list[str] = []
+    prev_hyphen = False
+    for ch in lowered:
+        if ch.isalnum():
+            out.append(ch)
+            prev_hyphen = False
+        else:
+            # Collapse any run of separators into a single hyphen.
+            if not prev_hyphen:
+                out.append("-")
+                prev_hyphen = True
+    slug = "".join(out).strip("-")
+    return slug or "backend"
+
+
+def _backend_domain_from_spec(spec: dict[str, Any]) -> str | None:
+    """Best-effort backend hostname from an OpenAPI / Swagger spec.
+
+    OpenAPI 3.x carries ``servers[0].url`` (a full or relative URL);
+    Swagger 2.x carries ``host`` (a bare hostname, optionally with a
+    port). Returns the hostname only, or ``None`` when the spec names
+    no server.
+    """
+    # OpenAPI 3.x — servers: [{url: ...}]
+    servers = spec.get("servers")
+    if isinstance(servers, list) and servers:
+        first = servers[0]
+        if isinstance(first, dict):
+            url = first.get("url")
+            if isinstance(url, str) and url.strip():
+                parsed = urlparse(url if "://" in url else f"//{url}")
+                host = parsed.hostname or url.strip()
+                return host or None
+
+    # Swagger 2.x — host: "api.example.com[:port]"
+    swagger_host = spec.get("host")
+    if isinstance(swagger_host, str) and swagger_host.strip():
+        # Strip a :port suffix if present.
+        return swagger_host.strip().split(":", 1)[0] or None
+
+    return None
+
+
+def _resolve_ref(spec: dict[str, Any], node: Any, _depth: int = 0) -> Any:
+    """Resolve a single local ``$ref`` against the spec.
+
+    Only local refs (``#/components/...`` for 3.x, ``#/definitions/...``
+    for 2.x) are followed, one hop, with a small depth guard so a
+    self-referential schema cannot loop forever. A non-ref node is
+    returned unchanged; an unresolvable ref yields ``{}``.
+    """
+    if _depth > 5 or not isinstance(node, dict):
+        return node if isinstance(node, dict) else {}
+    ref = node.get("$ref")
+    if not isinstance(ref, str) or not ref.startswith("#/"):
+        return node
+    target: Any = spec
+    for part in ref[2:].split("/"):
+        if not isinstance(target, dict) or part not in target:
+            return {}
+        target = target[part]
+    return _resolve_ref(spec, target, _depth + 1)
+
+
+def _schema_top_level_props(spec: dict[str, Any], schema: Any) -> list[str]:
+    """Top-level property names of a (possibly $ref'd) JSON schema.
+
+    When the schema describes an array, the item schema's properties are
+    used instead — a list endpoint's "shape" is the shape of one row.
+    Capped at ``_MAX_RESPONSE_FIELDS`` and sorted for content stability.
+    """
+    schema = _resolve_ref(spec, schema)
+    if not isinstance(schema, dict):
+        return []
+    if schema.get("type") == "array" or "items" in schema:
+        schema = _resolve_ref(spec, schema.get("items") or {})
+        if not isinstance(schema, dict):
+            return []
+    props = schema.get("properties")
+    if not isinstance(props, dict):
+        return []
+    return sorted(props.keys())[:_MAX_RESPONSE_FIELDS]
+
+
+def _response_fields(spec: dict[str, Any], operation: dict[str, Any]) -> list[str]:
+    """Key fields of an operation's 200 (or 2xx) response.
+
+    Handles both response shapes:
+    - OpenAPI 3.x — ``responses.200.content.<mime>.schema``
+    - Swagger 2.x — ``responses.200.schema``
+    """
+    responses = operation.get("responses")
+    if not isinstance(responses, dict):
+        return []
+    # Prefer 200; fall back to the first 2xx key present.
+    resp = None
+    for code in ("200", 200, "201", 201):
+        if code in responses:
+            resp = responses[code]
+            break
+    if resp is None:
+        for key in sorted(str(k) for k in responses):
+            if key.startswith("2"):
+                resp = responses[key] if key in responses else responses.get(int(key))
+                break
+    resp = _resolve_ref(spec, resp)
+    if not isinstance(resp, dict):
+        return []
+
+    # Swagger 2.x — schema sits directly on the response.
+    if "schema" in resp:
+        return _schema_top_level_props(spec, resp["schema"])
+
+    # OpenAPI 3.x — schema is nested under content.<mime>.schema.
+    content = resp.get("content")
+    if isinstance(content, dict):
+        for mime in sorted(content):
+            entry = content[mime]
+            if isinstance(entry, dict) and "schema" in entry:
+                return _schema_top_level_props(spec, entry["schema"])
+    return []
+
+
+def _request_params(spec: dict[str, Any], operation: dict[str, Any]) -> list[str]:
+    """Key request inputs of an operation — query params + required body.
+
+    Query params come from the ``parameters`` list (``in: query``).
+    Required body fields come from the request body schema's
+    ``required`` list — OpenAPI 3.x ``requestBody`` or Swagger 2.x's
+    ``in: body`` parameter. Sorted for content stability.
+    """
+    params: list[str] = []
+
+    parameters = operation.get("parameters")
+    if isinstance(parameters, list):
+        for raw in parameters:
+            param = _resolve_ref(spec, raw)
+            if not isinstance(param, dict):
+                continue
+            loc = param.get("in")
+            name = param.get("name")
+            if loc == "query" and isinstance(name, str):
+                params.append(f"{name} (query)")
+            elif loc == "body":
+                # Swagger 2.x body parameter — required fields of its schema.
+                body_schema = _resolve_ref(spec, param.get("schema") or {})
+                if isinstance(body_schema, dict):
+                    for field in body_schema.get("required") or []:
+                        if isinstance(field, str):
+                            params.append(f"{field} (body, required)")
+
+    # OpenAPI 3.x requestBody — required fields of the body schema.
+    request_body = _resolve_ref(spec, operation.get("requestBody") or {})
+    if isinstance(request_body, dict):
+        content = request_body.get("content")
+        if isinstance(content, dict):
+            for mime in sorted(content):
+                entry = content[mime]
+                if isinstance(entry, dict):
+                    body_schema = _resolve_ref(spec, entry.get("schema") or {})
+                    if isinstance(body_schema, dict):
+                        for field in body_schema.get("required") or []:
+                            if isinstance(field, str):
+                                params.append(f"{field} (body, required)")
+                    break  # one representative mime is enough
+
+    # De-dup while keeping a stable order.
+    return sorted(set(params))
+
+
+def _operation_group(operation: dict[str, Any], path: str) -> str:
+    """Group key for an operation — first tag, else first path segment.
+
+    A tagged operation groups under its first tag; an untagged one
+    groups under the first non-empty path segment (``/contacts/{id}``
+    → ``contacts``). Falls back to ``general``.
+    """
+    tags = operation.get("tags")
+    if isinstance(tags, list) and tags and isinstance(tags[0], str) and tags[0].strip():
+        return tags[0].strip()
+    for segment in path.split("/"):
+        seg = segment.strip()
+        if seg and not (seg.startswith("{") and seg.endswith("}")):
+            return seg
+    return "general"
+
+
+_HTTP_METHODS = ("get", "post", "put", "patch", "delete", "head", "options")
+
+
+# ---------------------------------------------------------------------------
+# Public — pure transform
+# ---------------------------------------------------------------------------
+
+
+def parse_openapi_to_skill_md(spec: dict[str, Any], *, backend_domain: str) -> str:
+    """Render an OpenAPI / Swagger spec as a SKILL.md string.
+
+    Walks ``spec["paths"]``, groups each operation by first tag (else
+    first path segment), and emits per operation: method + path,
+    a trimmed summary, key request params, and key 200-response fields.
+
+    Handles OpenAPI 3.x and Swagger 2.x response / body shapes. Caps the
+    output at ``_MAX_ENDPOINTS`` operations with a truncation note.
+
+    **Content-stable** — ``paths`` keys are ``sorted()`` and every
+    derived list is sorted, so two calls on the same spec produce
+    byte-identical output. A mirror installer's SHA-256 skip logic
+    relies on this.
+
+    Args:
+        spec: A parsed OpenAPI / Swagger document.
+        backend_domain: The backend hostname — recorded in the
+            frontmatter ``metadata.backend_domain`` and used to derive
+            the skill ``name``.
+
+    Returns:
+        A complete SKILL.md string (YAML frontmatter + markdown body).
+    """
+    slug = _slugify_domain(backend_domain)
+    paths = spec.get("paths")
+    if not isinstance(paths, dict):
+        paths = {}
+
+    spec_version = spec.get("openapi") or spec.get("swagger") or "unknown"
+    title = "API"
+    info = spec.get("info")
+    if isinstance(info, dict) and isinstance(info.get("title"), str):
+        title = info["title"].strip() or "API"
+
+    # ---- collect operations, grouped, deterministically ordered ----
+    groups: dict[str, list[tuple[str, str, dict[str, Any]]]] = {}
+    total = 0
+    truncated = False
+    for path in sorted(paths.keys()):
+        path_item = paths[path]
+        if not isinstance(path_item, dict):
+            continue
+        for method in _HTTP_METHODS:
+            operation = path_item.get(method)
+            if not isinstance(operation, dict):
+                continue
+            if total >= _MAX_ENDPOINTS:
+                truncated = True
+                break
+            group = _operation_group(operation, path)
+            groups.setdefault(group, []).append((method.upper(), path, operation))
+            total += 1
+        if truncated:
+            break
+
+    # ---- frontmatter ----
+    frontmatter_lines = [
+        "---",
+        f"name: api-{slug}",
+        (
+            f"description: API endpoint reference for the {title} backend "
+            f"({backend_domain}). Use these paths and response shapes when "
+            "authoring pocket sources and actions."
+        ),
+        "user-invocable: false",
+        "metadata:",
+        f"  backend_domain: {backend_domain}",
+        f"  spec_version: {spec_version}",
+        f"  endpoint_count: {total}",
+        "---",
+    ]
+
+    # ---- body ----
+    body: list[str] = [
+        f"# {title} — Backend API Reference",
+        "",
+        (
+            f"Endpoint reference for the backend at `{backend_domain}`. "
+            "Every `path` below is RELATIVE to the pocket's configured "
+            "backend base URL — author `sources` / `actions` against "
+            "these paths, never invent endpoints, never use an absolute "
+            "URL."
+        ),
+        "",
+    ]
+    if total == 0:
+        body.append("_This spec declared no operations._")
+    for group in sorted(groups.keys()):
+        body.append(f"## {group}")
+        body.append("")
+        for method, path, operation in groups[group]:
+            body.append(f"### `{method} {path}`")
+            summary = operation.get("summary") or operation.get("description") or ""
+            if isinstance(summary, str) and summary.strip():
+                trimmed = summary.strip().replace("\n", " ")
+                if len(trimmed) > _SUMMARY_MAX_CHARS:
+                    trimmed = trimmed[: _SUMMARY_MAX_CHARS - 1].rstrip() + "…"
+                body.append(trimmed)
+            req = _request_params(spec, operation)
+            if req:
+                body.append(f"- Request params: {', '.join(req)}")
+            resp = _response_fields(spec, operation)
+            if resp:
+                body.append(f"- Response fields (200): {', '.join(resp)}")
+            body.append("")
+    if truncated:
+        body.append(
+            f"_Reference truncated at {_MAX_ENDPOINTS} endpoints — the "
+            "backend exposes more. Ask the user for the specific endpoint "
+            "if the one you need is not listed above._"
+        )
+        body.append("")
+
+    return "\n".join(frontmatter_lines) + "\n\n" + "\n".join(body).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Public — install
+# ---------------------------------------------------------------------------
+
+
+def _parse_spec_text(text: str) -> dict[str, Any]:
+    """Parse a spec document — JSON first, then YAML.
+
+    OpenAPI documents ship as either JSON or YAML; JSON is also valid
+    YAML, so a JSON-first attempt keeps the common case fast. Raises
+    ``ValueError`` when neither parser yields a dict.
+    """
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        try:
+            import yaml  # type: ignore[import-untyped]
+
+            parsed = yaml.safe_load(text)
+        except Exception as exc:  # noqa: BLE001 — surfaced as a clean ValueError
+            raise ValueError(f"spec is neither valid JSON nor YAML: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("spec did not parse to a JSON object")
+    return parsed
+
+
+def _load_spec(openapi_source: Path | str | dict[str, Any]) -> dict[str, Any]:
+    """Resolve an ``openapi_source`` argument to a parsed spec dict.
+
+    Accepts an already-parsed dict (passed through), a ``Path`` (read
+    from disk, size-checked), or a ``str`` that is either an
+    ``http(s)://`` URL (fetched) or a filesystem path (read).
+    """
+    if isinstance(openapi_source, dict):
+        return openapi_source
+
+    if isinstance(openapi_source, str) and openapi_source.lower().startswith(
+        ("http://", "https://")
+    ):
+        import httpx
+
+        resp = httpx.get(openapi_source, timeout=30.0, follow_redirects=True)
+        resp.raise_for_status()
+        raw = resp.content
+        if len(raw) > _MAX_SPEC_BYTES:
+            raise ValueError(f"spec is {len(raw)} bytes — exceeds the {_MAX_SPEC_BYTES}-byte limit")
+        return _parse_spec_text(raw.decode("utf-8", errors="replace"))
+
+    # A filesystem path (Path object or path-like string).
+    path = Path(openapi_source)
+    if not path.is_file():
+        raise ValueError(f"spec file not found: {path}")
+    size = path.stat().st_size
+    if size > _MAX_SPEC_BYTES:
+        raise ValueError(f"spec file is {size} bytes — exceeds the {_MAX_SPEC_BYTES}-byte limit")
+    return _parse_spec_text(path.read_text(encoding="utf-8", errors="replace"))
+
+
+def install_api_skill(
+    openapi_source: Path | str | dict[str, Any],
+    *,
+    name: str | None = None,
+    dest_dir: Path | None = None,
+) -> str:
+    """Install a backend's API as a loadable skill and return its slug.
+
+    Resolves ``openapi_source`` (a parsed dict, a file path, or a URL)
+    to a spec, validates it carries a ``paths`` key, derives the backend
+    domain, renders a SKILL.md via ``parse_openapi_to_skill_md``, and
+    writes it to ``<dest_dir>/api-<domain_slug>/SKILL.md`` (default
+    ``dest_dir`` is ``~/.pocketpaw/skills``). The install is audit-logged
+    at INFO.
+
+    Args:
+        openapi_source: A parsed OpenAPI dict, a path to a ``.json`` /
+            ``.yaml`` spec file, or an ``http(s)`` URL to fetch.
+        name: Backend display name — used to derive the domain slug
+            when the spec itself names no server.
+        dest_dir: Override the skills root — for tests. Defaults to
+            ``~/.pocketpaw/skills``.
+
+    Returns:
+        The domain slug — e.g. ``api-example-com`` — naming the skill
+        directory and the SKILL.md ``name`` field.
+
+    Raises:
+        ValueError: The spec is too large, unparseable, or carries no
+            ``paths`` key.
+    """
+    spec = _load_spec(openapi_source)
+
+    if not isinstance(spec.get("paths"), dict):
+        raise ValueError("spec has no `paths` object — not a usable OpenAPI / Swagger document")
+
+    # Derive the backend domain: prefer the spec's own server, fall back
+    # to the caller-supplied name.
+    domain = _backend_domain_from_spec(spec) or (name or "").strip() or "backend"
+    domain_slug = _slugify_domain(domain)
+
+    skill_md = parse_openapi_to_skill_md(spec, backend_domain=domain)
+
+    root = dest_dir if dest_dir is not None else (Path.home() / ".pocketpaw" / "skills")
+    skill_dir = root / f"api-{domain_slug}"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+
+    logger.info(
+        "api_skill_builder: installed API skill api-%s (backend_domain=%s) at %s",
+        domain_slug,
+        domain,
+        skill_dir,
+    )
+
+    return f"api-{domain_slug}"
+
+
+__all__ = ["parse_openapi_to_skill_md", "install_api_skill"]

--- a/tests/cloud/test_skills_router.py
+++ b/tests/cloud/test_skills_router.py
@@ -1,0 +1,239 @@
+# test_skills_router.py — HTTP + service tests for ee/cloud/skills.
+# Created: 2026-05-22 (feat/api-skills, Increment 2b) — smokes the new
+# POST /api/v1/skills/api-doc surface: a valid OpenAPI upload installs a
+# per-backend API skill, an oversized upload is rejected (422), a
+# bad-extension upload is rejected (422), a spec with no `paths` is
+# rejected (422), and the auth/RBAC seams (401 unauthenticated, 403
+# without skills.manage). The service is exercised directly too.
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.auth import current_active_user
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.skills.router import router as skills_router
+
+
+def _minimal_spec() -> dict:
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "Demo API"},
+        "servers": [{"url": "https://demo.example.com"}],
+        "paths": {
+            "/things": {
+                "get": {
+                    "tags": ["Things"],
+                    "summary": "List things",
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+
+
+def _fake_user(user_id: str = "u1", workspace_id: str | None = "w1") -> SimpleNamespace:
+    """A User stand-in shaped like ``ee.cloud.models.user.User`` — only the
+    attributes the skills-router auth chain reads are filled in."""
+    return SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role="admin")] if workspace_id else [],
+    )
+
+
+def _build_app(
+    *,
+    workspace_id: str | None = "w1",
+    user_id: str = "u1",
+    skip_auth_override: bool = False,
+    permission_denier: bool = False,
+    monkeypatch=None,
+) -> FastAPI:
+    """Build a FastAPI app wired to the skills router. Auth and RBAC are
+    patched the same way ``test_audit_router.py`` does."""
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(skills_router)
+    app.dependency_overrides[require_license] = lambda: None
+
+    if not skip_auth_override:
+        user = _fake_user(user_id=user_id, workspace_id=workspace_id)
+
+        async def _fake_user_dep():
+            return user
+
+        app.dependency_overrides[current_active_user] = _fake_user_dep
+
+        if monkeypatch is not None:
+            from pocketpaw_ee.cloud._core import deps as core_deps
+            from pocketpaw_ee.guards.rbac import Forbidden as GuardForbidden
+
+            if permission_denier:
+
+                def _deny(*_a, **_k):
+                    raise GuardForbidden(
+                        code="workspace.insufficient_role",
+                        detail="no skills.manage",
+                    )
+
+                monkeypatch.setattr(core_deps, "check_workspace_action", _deny)
+            else:
+                monkeypatch.setattr(core_deps, "check_workspace_action", lambda *a, **k: None)
+    return app
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch, tmp_path) -> AsyncClient:
+    # Point the skills install dir at a tmp ~/.pocketpaw so the real
+    # user dir is never touched.
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    app = _build_app(monkeypatch=monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_install_api_doc_installs_skill(client: AsyncClient, tmp_path) -> None:
+    """A valid OpenAPI upload installs a per-backend API skill and the
+    SKILL.md lands under ~/.pocketpaw/skills/."""
+    files = {"file": ("spec.json", json.dumps(_minimal_spec()), "application/json")}
+    r = await client.post("/skills/api-doc", files=files)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["slug"] == "api-demo-example-com"
+
+    skill_md = tmp_path / ".pocketpaw" / "skills" / "api-demo-example-com" / "SKILL.md"
+    assert skill_md.is_file()
+    assert "`GET /things`" in skill_md.read_text(encoding="utf-8")
+
+
+async def test_install_api_doc_accepts_yaml(client: AsyncClient) -> None:
+    """A ``.yaml`` upload installs correctly."""
+    import yaml
+
+    files = {"file": ("spec.yaml", yaml.safe_dump(_minimal_spec()), "application/x-yaml")}
+    r = await client.post("/skills/api-doc", files=files)
+    assert r.status_code == 200, r.text
+    assert r.json()["slug"] == "api-demo-example-com"
+
+
+async def test_install_api_doc_uses_name_form_field(client: AsyncClient) -> None:
+    """The optional ``name`` form field drives the slug when the spec
+    names no server."""
+    spec = {"openapi": "3.0.0", "paths": {"/x": {"get": {"responses": {}}}}}
+    files = {"file": ("spec.json", json.dumps(spec), "application/json")}
+    r = await client.post("/skills/api-doc", files=files, data={"name": "named-backend.io"})
+    assert r.status_code == 200, r.text
+    assert r.json()["slug"] == "api-named-backend-io"
+
+
+# ---------------------------------------------------------------------------
+# Rejections
+# ---------------------------------------------------------------------------
+
+
+async def test_install_api_doc_rejects_bad_extension(client: AsyncClient) -> None:
+    """An upload that is not .json/.yaml/.yml is rejected."""
+    files = {"file": ("spec.txt", json.dumps(_minimal_spec()), "text/plain")}
+    r = await client.post("/skills/api-doc", files=files)
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "skills.api_doc.bad_extension"
+
+
+async def test_install_api_doc_rejects_oversized_file(client: AsyncClient) -> None:
+    """An upload larger than 2 MB is rejected."""
+    huge = '{"_pad": "' + ("x" * (2 * 1024 * 1024 + 1)) + '"}'
+    files = {"file": ("spec.json", huge, "application/json")}
+    r = await client.post("/skills/api-doc", files=files)
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "skills.api_doc.too_large"
+
+
+async def test_install_api_doc_rejects_spec_with_no_paths(client: AsyncClient) -> None:
+    """A spec that carries no ``paths`` object is rejected."""
+    files = {"file": ("spec.json", json.dumps({"openapi": "3.0.0"}), "application/json")}
+    r = await client.post("/skills/api-doc", files=files)
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "skills.api_doc.invalid_spec"
+
+
+async def test_install_api_doc_rejects_unparseable(client: AsyncClient) -> None:
+    """A file that is neither valid JSON nor YAML is rejected."""
+    files = {"file": ("spec.json", "{not valid: [json", "application/json")}
+    r = await client.post("/skills/api-doc", files=files)
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "skills.api_doc.unparseable"
+
+
+# ---------------------------------------------------------------------------
+# Auth / RBAC seams
+# ---------------------------------------------------------------------------
+
+
+async def test_unauthenticated_returns_401(tmp_path, monkeypatch) -> None:
+    """Without a ``current_active_user`` override the auth chain 401s."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    app = _build_app(skip_auth_override=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        files = {"file": ("spec.json", json.dumps(_minimal_spec()), "application/json")}
+        r = await c.post("/skills/api-doc", files=files)
+        assert r.status_code == 401
+
+
+async def test_without_skills_manage_returns_403(tmp_path, monkeypatch) -> None:
+    """A caller without the ``skills.manage`` role gets a 403."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    app = _build_app(permission_denier=True, monkeypatch=monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        files = {"file": ("spec.json", json.dumps(_minimal_spec()), "application/json")}
+        r = await c.post("/skills/api-doc", files=files)
+        assert r.status_code == 403, r.text
+
+
+# ---------------------------------------------------------------------------
+# Service direct — re-validation + RBAC action is registered
+# ---------------------------------------------------------------------------
+
+
+async def test_service_install_api_doc_direct(tmp_path, monkeypatch) -> None:
+    """The service installs a skill when called directly (bus/job path)."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from pocketpaw_ee.cloud.skills import service as skills_service
+    from pocketpaw_ee.cloud.skills.domain import ApiDocInstall
+
+    body = ApiDocInstall(
+        workspace_id="w1",
+        user_id="u1",
+        filename="spec.json",
+        spec_bytes=json.dumps(_minimal_spec()).encode("utf-8"),
+    )
+    out = await skills_service.install_api_doc("w1", "u1", body)
+    assert out.ok is True
+    assert out.slug == "api-demo-example-com"
+
+
+def test_skills_manage_action_is_registered() -> None:
+    """``skills.manage`` is in the RBAC action registry — an unknown
+    action would make ``require_action_any_workspace`` fail loud."""
+    from pocketpaw_ee.guards.actions import ACTIONS
+
+    assert "skills.manage" in ACTIONS
+
+
+# Silence ruff unused-import nudge for the pytest import (used implicitly).
+_ = pytest

--- a/tests/unit/test_api_skill_builder.py
+++ b/tests/unit/test_api_skill_builder.py
@@ -1,0 +1,457 @@
+# tests/unit/test_api_skill_builder.py
+# Created: 2026-05-22 (feat/api-skills, Increment 2b) — covers the
+# per-backend API skill builder: parse_openapi_to_skill_md (OpenAPI 3.x
+# + Swagger 2.x, tag grouping, endpoint truncation, byte-identical
+# stability) and install_api_skill (writes to the right path, rejects an
+# oversized file, rejects a spec with no `paths`). Also covers the EE
+# pocket-specialist wiring (_load_api_skill_for_backend, _build_system_prompt
+# block splice, and the backend_summary token-safety guarantee) — those
+# tests are guarded with pytest.importorskip("pocketpaw_ee") so the
+# OSS-only CI job (EE absent) stays green.
+"""Tests for ``pocketpaw.skills.api_skill_builder`` and its EE wiring.
+
+The builder tests are pure OSS — no enterprise import — and need no
+guard. The runtime-wiring tests import ``pocketpaw_ee`` and so begin
+with ``pytest.importorskip("pocketpaw_ee")``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.skills.api_skill_builder import (
+    install_api_skill,
+    parse_openapi_to_skill_md,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — minimal specs
+# ---------------------------------------------------------------------------
+
+
+def _minimal_openapi_3() -> dict:
+    """A small but representative OpenAPI 3.x spec — two tagged groups,
+    a query param, a required body field, and a 200 response schema."""
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "Example CRM"},
+        "servers": [{"url": "https://api.example.com/v1"}],
+        "paths": {
+            "/contacts": {
+                "get": {
+                    "tags": ["Contacts"],
+                    "summary": "List all contacts",
+                    "parameters": [
+                        {"name": "limit", "in": "query", "schema": {"type": "integer"}},
+                    ],
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {"type": "string"},
+                                                "name": {"type": "string"},
+                                                "email": {"type": "string"},
+                                            },
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                },
+                "post": {
+                    "tags": ["Contacts"],
+                    "summary": "Create a contact",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["name"],
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "email": {"type": "string"},
+                                    },
+                                }
+                            }
+                        }
+                    },
+                    "responses": {"201": {"description": "created"}},
+                },
+            },
+            "/deals": {
+                "get": {
+                    "tags": ["Deals"],
+                    "summary": "List deals",
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {"deals": {"type": "array"}},
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            },
+        },
+    }
+
+
+def _minimal_swagger_2() -> dict:
+    """A small Swagger 2.x spec — uses ``host`` and a response-level
+    ``schema`` instead of OpenAPI 3.x ``servers`` / ``content``."""
+    return {
+        "swagger": "2.0",
+        "info": {"title": "Legacy API"},
+        "host": "legacy.example.org",
+        "paths": {
+            "/users": {
+                "get": {
+                    "summary": "List users",
+                    "responses": {
+                        "200": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "uid": {"type": "string"},
+                                        "handle": {"type": "string"},
+                                    },
+                                },
+                            }
+                        }
+                    },
+                }
+            }
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# parse_openapi_to_skill_md
+# ---------------------------------------------------------------------------
+
+
+def test_parse_minimal_spec_produces_valid_skill_md() -> None:
+    """A minimal spec renders a SKILL.md with valid frontmatter + body."""
+    md = parse_openapi_to_skill_md(_minimal_openapi_3(), backend_domain="api.example.com")
+
+    # YAML frontmatter delimited by --- markers.
+    assert md.startswith("---\n")
+    assert "name: api-api-example-com" in md
+    assert "user-invocable: false" in md
+    assert "backend_domain: api.example.com" in md
+    # The endpoint reference body.
+    assert "Backend API Reference" in md
+    assert "`GET /contacts`" in md
+    assert "`POST /contacts`" in md
+    assert "List all contacts" in md
+
+
+def test_parse_groups_operations_by_tag() -> None:
+    """Operations group under their first tag — Contacts and Deals are
+    separate `##` sections."""
+    md = parse_openapi_to_skill_md(_minimal_openapi_3(), backend_domain="api.example.com")
+    assert "## Contacts" in md
+    assert "## Deals" in md
+
+
+def test_parse_groups_by_path_segment_when_untagged() -> None:
+    """An untagged operation groups under its first path segment."""
+    spec = {
+        "openapi": "3.0.0",
+        "paths": {
+            "/widgets/{id}": {"get": {"summary": "Get widget", "responses": {}}},
+        },
+    }
+    md = parse_openapi_to_skill_md(spec, backend_domain="x.test")
+    assert "## widgets" in md
+
+
+def test_parse_extracts_request_params_and_response_fields() -> None:
+    """Query params, required body fields, and 200-response top-level
+    props all surface in the per-operation reference."""
+    md = parse_openapi_to_skill_md(_minimal_openapi_3(), backend_domain="api.example.com")
+    # GET /contacts — query param + array-item response fields.
+    assert "limit (query)" in md
+    assert "email, id, name" in md  # sorted response fields
+    # POST /contacts — required body field.
+    assert "name (body, required)" in md
+
+
+def test_parse_handles_swagger_2x() -> None:
+    """Swagger 2.x ``host`` + response-level ``schema`` are handled — the
+    backend domain comes from ``host`` and the response fields parse."""
+    md = parse_openapi_to_skill_md(_minimal_swagger_2(), backend_domain="legacy.example.org")
+    assert "name: api-legacy-example-org" in md
+    assert "`GET /users`" in md
+    assert "handle, uid" in md  # sorted response fields from the item schema
+
+
+def test_parse_truncates_at_200_endpoints() -> None:
+    """A spec with more than 200 operations is truncated with a note."""
+    paths = {f"/ep{i}": {"get": {"summary": f"op {i}", "responses": {}}} for i in range(250)}
+    spec = {"openapi": "3.0.0", "paths": paths}
+    md = parse_openapi_to_skill_md(spec, backend_domain="big.test")
+
+    assert "endpoint_count: 200" in md
+    assert "truncated at 200 endpoints" in md
+    # 250 paths defined, only 200 rendered.
+    assert md.count("### `GET ") == 200
+
+
+def test_parse_is_byte_identical_on_repeated_calls() -> None:
+    """CRITICAL — repeated calls on the same spec produce byte-identical
+    output. The mirror installer's SHA skip logic depends on this."""
+    spec = _minimal_openapi_3()
+    first = parse_openapi_to_skill_md(spec, backend_domain="api.example.com")
+    second = parse_openapi_to_skill_md(spec, backend_domain="api.example.com")
+    third = parse_openapi_to_skill_md(spec, backend_domain="api.example.com")
+    assert first == second == third
+
+
+def test_parse_byte_identical_with_unordered_paths() -> None:
+    """Stability holds even when the spec's paths arrive in a different
+    insertion order — output is sorted, so order in does not matter."""
+    spec_a = {
+        "openapi": "3.0.0",
+        "paths": {
+            "/zebra": {"get": {"summary": "z", "responses": {}}},
+            "/alpha": {"get": {"summary": "a", "responses": {}}},
+        },
+    }
+    spec_b = {
+        "openapi": "3.0.0",
+        "paths": {
+            "/alpha": {"get": {"summary": "a", "responses": {}}},
+            "/zebra": {"get": {"summary": "z", "responses": {}}},
+        },
+    }
+    assert parse_openapi_to_skill_md(spec_a, backend_domain="x.test") == parse_openapi_to_skill_md(
+        spec_b, backend_domain="x.test"
+    )
+
+
+def test_parse_empty_paths_does_not_crash() -> None:
+    """A spec with no operations renders cleanly with a note, no crash."""
+    md = parse_openapi_to_skill_md({"openapi": "3.0.0", "paths": {}}, backend_domain="x.test")
+    assert "endpoint_count: 0" in md
+    assert "declared no operations" in md
+
+
+# ---------------------------------------------------------------------------
+# install_api_skill
+# ---------------------------------------------------------------------------
+
+
+def test_install_writes_to_expected_path(tmp_path: Path) -> None:
+    """install_api_skill writes ``api-<slug>/SKILL.md`` under dest_dir and
+    returns the slug."""
+    slug = install_api_skill(_minimal_openapi_3(), dest_dir=tmp_path)
+
+    assert slug == "api-api-example-com"
+    skill_md = tmp_path / "api-api-example-com" / "SKILL.md"
+    assert skill_md.is_file()
+    content = skill_md.read_text(encoding="utf-8")
+    assert "name: api-api-example-com" in content
+    assert "`GET /contacts`" in content
+
+
+def test_install_derives_domain_from_name_when_no_server(tmp_path: Path) -> None:
+    """When the spec names no server, the ``name`` arg drives the slug."""
+    spec = {"openapi": "3.0.0", "paths": {"/x": {"get": {"responses": {}}}}}
+    slug = install_api_skill(spec, name="my-backend.io", dest_dir=tmp_path)
+    assert slug == "api-my-backend-io"
+    assert (tmp_path / "api-my-backend-io" / "SKILL.md").is_file()
+
+
+def test_install_from_json_file(tmp_path: Path) -> None:
+    """A ``.json`` spec file on disk installs correctly."""
+    import json
+
+    spec_file = tmp_path / "spec.json"
+    spec_file.write_text(json.dumps(_minimal_openapi_3()), encoding="utf-8")
+    dest = tmp_path / "skills"
+    slug = install_api_skill(spec_file, dest_dir=dest)
+    assert (dest / slug / "SKILL.md").is_file()
+
+
+def test_install_from_yaml_file(tmp_path: Path) -> None:
+    """A ``.yaml`` spec file on disk installs correctly."""
+    import yaml
+
+    spec_file = tmp_path / "spec.yaml"
+    spec_file.write_text(yaml.safe_dump(_minimal_swagger_2()), encoding="utf-8")
+    dest = tmp_path / "skills"
+    slug = install_api_skill(spec_file, dest_dir=dest)
+    assert slug == "api-legacy-example-org"
+    assert (dest / slug / "SKILL.md").is_file()
+
+
+def test_install_rejects_oversized_file(tmp_path: Path) -> None:
+    """A spec file larger than 2 MB is rejected with a ValueError."""
+    big_file = tmp_path / "huge.json"
+    # 2 MB + 1 byte of filler — valid JSON, just too big.
+    big_file.write_text('{"_pad": "' + ("x" * (2 * 1024 * 1024 + 1)) + '"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="exceeds the .* limit"):
+        install_api_skill(big_file, dest_dir=tmp_path)
+
+
+def test_install_rejects_spec_with_no_paths(tmp_path: Path) -> None:
+    """A spec with no ``paths`` object is rejected — not a usable doc."""
+    with pytest.raises(ValueError, match="no `paths`"):
+        install_api_skill({"openapi": "3.0.0", "info": {"title": "X"}}, dest_dir=tmp_path)
+
+
+def test_install_rejects_missing_file(tmp_path: Path) -> None:
+    """A path to a non-existent file is rejected."""
+    with pytest.raises(ValueError, match="not found"):
+        install_api_skill(tmp_path / "nope.json", dest_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# EE wiring — _load_api_skill_for_backend  (guarded — EE-only)
+# ---------------------------------------------------------------------------
+
+
+def test_load_api_skill_for_backend_returns_content_when_present(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """``_load_api_skill_for_backend`` returns the SKILL.md body when the
+    skill file exists for the backend's domain."""
+    pytest.importorskip("pocketpaw_ee")
+    # Install the skill into the tmp ~/.pocketpaw/skills root the loader
+    # resolves once Path.home() is patched.
+    skills_root = tmp_path / ".pocketpaw" / "skills"
+    install_api_skill(_minimal_openapi_3(), dest_dir=skills_root)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from pocketpaw_ee.agent.pocket_specialist.runtime import _load_api_skill_for_backend
+
+    content = _load_api_skill_for_backend(
+        {"base_url": "https://api.example.com/v1", "auth_type": "bearer", "configured": True}
+    )
+    assert content is not None
+    assert "`GET /contacts`" in content
+
+
+def test_load_api_skill_for_backend_returns_none_when_missing(tmp_path: Path, monkeypatch) -> None:
+    """Returns ``None`` when no skill is installed for the backend."""
+    pytest.importorskip("pocketpaw_ee")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from pocketpaw_ee.agent.pocket_specialist.runtime import _load_api_skill_for_backend
+
+    assert (
+        _load_api_skill_for_backend(
+            {"base_url": "https://nothing-installed.test", "configured": True}
+        )
+        is None
+    )
+
+
+def test_load_api_skill_for_backend_returns_none_when_summary_none() -> None:
+    """Returns ``None`` when ``backend_summary`` itself is ``None``."""
+    pytest.importorskip("pocketpaw_ee")
+    from pocketpaw_ee.agent.pocket_specialist.runtime import _load_api_skill_for_backend
+
+    assert _load_api_skill_for_backend(None) is None
+
+
+# ---------------------------------------------------------------------------
+# EE wiring — _build_system_prompt block splice  (guarded — EE-only)
+# ---------------------------------------------------------------------------
+
+
+def test_build_system_prompt_includes_backend_api_block_when_skill_loaded(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """``_build_system_prompt`` splices a ``<backend-api>`` block in when
+    the pocket's backend has an installed API skill."""
+    pytest.importorskip("pocketpaw_ee")
+    skills_root = tmp_path / ".pocketpaw" / "skills"
+    install_api_skill(_minimal_openapi_3(), dest_dir=skills_root)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from pocketpaw_ee.agent.pocket_specialist.runtime import _build_system_prompt
+
+    summary = {"base_url": "https://api.example.com/v1", "configured": True}
+    prompt = _build_system_prompt(None, backend_summary=summary)
+    # The block proper opens on its own line — distinct from the literal
+    # `<backend-api>` mention inside the live-data-sources guidance.
+    assert "\n<backend-api>\n" in prompt
+    assert "`GET /contacts`" in prompt
+    assert "NEVER invent an endpoint" in prompt
+
+
+def test_build_system_prompt_excludes_backend_api_block_without_skill(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Without an installed skill the ``<backend-api>`` block is absent —
+    whether the backend summary is missing or names an unknown backend."""
+    pytest.importorskip("pocketpaw_ee")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from pocketpaw_ee.agent.pocket_specialist.runtime import _build_system_prompt
+
+    # The block proper opens on its own line — the bare `<backend-api>`
+    # token also appears as a literal mention in the live-data-sources
+    # guidance, so match the line-anchored block opener instead.
+    # No backend summary at all.
+    assert "\n<backend-api>\n" not in _build_system_prompt(None)
+    # A backend with no installed skill.
+    prompt = _build_system_prompt(
+        None, backend_summary={"base_url": "https://unknown.test", "configured": True}
+    )
+    assert "\n<backend-api>\n" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# backend_summary token-safety — the non-secret contract  (guarded — EE-only)
+# ---------------------------------------------------------------------------
+
+
+def test_backend_summary_field_never_carries_a_token() -> None:
+    """The ``PocketSpecialistCreateInput.backend_summary`` field is a
+    free-form dict, but the documented contract — and every producer
+    (``get_pocket_backend``) — keeps it to {base_url, auth_type,
+    configured, allowed_writes}. This test pins that no auth-token key
+    leaks through the model's declared description and that a token-
+    bearing summary is not what the helpers expect.
+
+    The structural guarantee lives in ``get_pocket_backend`` (which
+    never reads the encrypted token); here we assert the field's intent
+    is documented as non-secret and that the API-skill loader ignores
+    any stray token key entirely."""
+    pytest.importorskip("pocketpaw_ee")
+    from pocketpaw_ee.agent.pocket_specialist.runtime import (
+        PocketSpecialistCreateInput,
+        _load_api_skill_for_backend,
+    )
+
+    field = PocketSpecialistCreateInput.model_fields["backend_summary"]
+    description = (field.description or "").lower()
+    # The field's own documentation forbids the token.
+    assert "never include auth_token" in description
+    assert "token" not in description.replace("auth_token", "")
+
+    # Even if a caller stuffed a token in, the loader only reads base_url
+    # — the token is never touched, never logged, never spliced.
+    summary_with_stray_token = {
+        "base_url": "https://nothing.test",
+        "auth_token": "SECRET-SHOULD-BE-IGNORED",
+    }
+    # No skill installed for this domain → None, and the token was inert.
+    assert _load_api_skill_for_backend(summary_with_stray_token) is None


### PR DESCRIPTION
## What this does

When a pocket is bound to a backend, the authoring agent now gets that backend's real API as a loadable skill. Before this change the agent guessed endpoints — it would invent `/api/contacts` when the backend actually exposes `/v2/people`, or assume a response field named `title` that does not exist. Authored `sources` and `actions` were often wrong on the first pass.

This change feeds the agent the backend's actual OpenAPI document so it authors against real relative paths and real response shapes. It completes pocket Increment 2 — Increment 2a shipped the built-in templates, 2b adds the per-backend API knowledge.

## How it works

1. An admin uploads a backend's OpenAPI / Swagger spec via `POST /api/v1/skills/api-doc`.
2. The spec is converted to a `SKILL.md` under `~/.pocketpaw/skills/api-<domain-slug>/` — one of the three roots the runtime `SkillLoader` already scans.
3. When the pocket-specialist authors or edits a pocket whose backend matches that domain, it loads the skill and splices a `<backend-api>` endpoint reference into the prompt.
4. The live-data-sources prompt guidance now tells the agent to author `path` values from that reference rather than guessing.

## Changes

**New**
- `src/pocketpaw/skills/api_skill_builder.py` — pure OSS module. `parse_openapi_to_skill_md` turns an OpenAPI 3.x or Swagger 2.x dict into a SKILL.md string: groups operations by tag (or first path segment), records method, path, summary, key request params and key 200-response fields, caps at 200 endpoints, and is content-stable (sorted keys → byte-identical output on repeated calls). `install_api_skill` accepts a file path, URL, or parsed dict, validates size and shape, and writes the skill.
- `ee/pocketpaw_ee/cloud/skills/` — the cloud Skills entity (domain / dto / service / router) for `POST /api/v1/skills/api-doc`. ADMIN-gated via the new `skills.manage` action, audit-logged, 2 MB upload cap.
- Tests: `tests/unit/test_api_skill_builder.py`, `tests/cloud/test_skills_router.py`.

**Modified**
- `ee/pocketpaw_ee/agent/pocket_specialist/runtime.py` — adds `_load_api_skill_for_backend` and `_format_api_skill_block`; wires the `<backend-api>` block into both the create and edit subagent paths.
- `src/pocketpaw/ripple/_pockets.py` — the create and edit live-data-sources prompt blocks point the agent at the `<backend-api>` block.
- `ee/pocketpaw_ee/guards/actions.py` — registers `skills.manage` (ADMIN).
- `ee/pocketpaw_ee/cloud/__init__.py` — mounts the skills router.
- `docs/api-reference.md` — documents the new endpoint.

## Safety

- `api_skill_builder.py` is OSS core and imports no enterprise code — the import-linter contract holds.
- EE-dependent tests are guarded with `pytest.importorskip("pocketpaw_ee")` so the OSS-only CI job stays green.
- The backend summary the agent sees never carries the auth token — a test pins that contract.

## Checks

- `tests/unit/test_api_skill_builder.py` (22) and `tests/cloud/test_skills_router.py` (11) pass; the touched pocket-specialist suites pass (170 total).
- OSS-only scope (`uv sync --dev`, no EE) passes — EE-guarded tests skip cleanly.
- `ruff check` and `ruff format --check` clean. `mypy` clean on every touched file. import-linter: root contract and all 15 EE contracts kept.

Pre-existing `tests/cloud` / `tests/ee` failures (uploads, corrections, decision-traces auth wiring) reproduce on a pristine `origin/dev` checkout — they are not introduced here.