### PR TITLE
feat(pockets): Instinct routing + outcome emission (RFC 05 M2b)

### DIFF
--- a/ee/pocketpaw_ee/agent/pocket_router/classifier.py
+++ b/ee/pocketpaw_ee/agent/pocket_router/classifier.py
@@ -250,9 +250,10 @@ def _action_params_resolve(action_entry: Any) -> bool:
 def _action_requires_instinct(action_entry: Any) -> bool:
     """True when the raw action carries a truthy ``requires_instinct``.
 
-    Mirrors ``action_executor._instinct_rejected`` — such an action must
-    NOT be auto-fired by the router; it escalates so the specialist flow
-    (and its human-in-the-loop affordances) handles it.
+    Reads the same ``requires_instinct`` flag the write executor parks on
+    (see ``ActionBinding.requires_instinct``) — such an action must NOT be
+    auto-fired by the router; it escalates so the specialist flow (and its
+    human-in-the-loop affordances) handles it.
     """
     return isinstance(action_entry, dict) and bool(action_entry.get("requires_instinct"))
 

--- a/ee/pocketpaw_ee/agent/pocket_router/router.py
+++ b/ee/pocketpaw_ee/agent/pocket_router/router.py
@@ -208,7 +208,11 @@ async def _run_tier0(
     creds = await pockets_service.get_pocket_backend_for_executor(workspace_id, input.pocket_id)
     if creds is None:
         return False, "pocket has no backend configured — cannot run a declarative tier"
-    base_url, auth_type, auth_header, token, allowed_writes = creds
+    # RFC 05 M2b.1 — the executor-creds tuple is a 6-tuple; the trailing
+    # `approval_route` is unused on the Tier-0 path (the classifier
+    # escalates a `requires_instinct` action to the specialist tier, so a
+    # gated write never reaches this declarative run).
+    base_url, auth_type, auth_header, token, allowed_writes, _approval_route = creds
 
     if classification.op == "run_source":
         # A source run mirrors ``POST /pockets/{id}/sources/run`` — read

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -4,6 +4,11 @@ Updated: 2026-05-22 (feat/api-skills, Increment 2b) — mounts the Skills
     entity at ``/api/v1/skills`` (POST /skills/api-doc), the per-backend
     API-skill install endpoint that turns a pocket backend's OpenAPI
     document into a loadable SKILL.md for the authoring agent.
+Updated: 2026-05-22 (RFC 05 M2b.2) — Mounts the pocket-outcomes entity at
+    ``/api/v1/outcomes`` (the count surface over the per-workspace
+    outcome ledger) and registers its ``pocket.outcome`` bus subscriber
+    (``outcomes_service.record_outcome``) after ``init_realtime`` so a
+    successful gated/direct write appends to the ledger.
 Updated: 2026-05-17 — Mounts the workspace-scoped Audit entity at
     ``/api/v1/audit`` (B1) with tenancy from ``RequestContext.workspace_id``,
     the legacy ``/api/v1/runtime/audit`` remaining live; also mounts
@@ -192,6 +197,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.livekit.router import router as livekit_router
     from pocketpaw_ee.cloud.mission_control.router import router as mission_control_router
     from pocketpaw_ee.cloud.notifications.router import router as notifications_router
+    from pocketpaw_ee.cloud.outcomes.router import router as outcomes_router
     from pocketpaw_ee.cloud.tasks.router import router as tasks_router
     from pocketpaw_ee.cloud.uploads.router import router as uploads_router
     from pocketpaw_ee.fabric.router import router as fabric_router
@@ -207,6 +213,8 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(files_router, prefix="/api/v1")
     app.include_router(mission_control_router, prefix="/api/v1")
     app.include_router(livekit_router, prefix="/api/v1")
+    # Pocket outcomes — GET /api/v1/outcomes count surface (RFC 05 M2b.2).
+    app.include_router(outcomes_router, prefix="/api/v1")
 
     # Files Tab v2 — /api/v1/files/tree + /api/v1/files/browse. Mounted
     # inline (instead of via build_router's ctx_factory) so the routes can
@@ -443,6 +451,16 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.uploads.listeners import register_upload_listeners
 
     register_upload_listeners()
+
+    # Pocket outcomes ledger subscriber (RFC 05 M2b.2). Appends every
+    # ``pocket.outcome`` event to its workspace-scoped JSONL ledger so
+    # ``GET /api/v1/outcomes`` can count business outcomes. Same
+    # constraint as the upload listeners — subscribe AFTER init_realtime
+    # installed the singleton bus.
+    from pocketpaw_ee.cloud._core.realtime.bus import get_bus as _get_bus
+    from pocketpaw_ee.cloud.outcomes import service as _outcomes_service
+
+    _get_bus().subscribe("pocket.outcome", _outcomes_service.record_outcome)
 
     # Tasks → notifications fan-out. When a Task is proposed to a human
     # assignee, drop an in-app notification so they see it even without

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -1,3 +1,9 @@
+# events.py — Realtime Event dataclass registry for the cloud bus.
+# Each subclass pins an EVENT_TYPE literal that routes both the WebSocket
+# fan-out and any in-process bus subscribers.
+# Updated: 2026-05-22 (RFC 05 M2b.2) — added PocketOutcomeEvent
+#   (type="pocket.outcome"), emitted after a successful write action whose
+#   binding declared a named `outcome`. Feeds the outcomes JSONL ledger.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -297,6 +303,30 @@ class PocketUpdated(Event):
 @dataclass
 class PocketDeleted(Event):
     EVENT_TYPE: ClassVar[str] = "pocket.deleted"
+
+
+# Pocket outcomes — RFC 05 M2b.2. Emitted AFTER a write action's
+# `run_action` returns `ok:true` AND the binding declared a non-null
+# `outcome`. A write completing is an *output*; a named `outcome` is the
+# business event the operator cares about ("renewal_completed"). The
+# outcomes ledger subscriber appends each event to a workspace-scoped
+# JSONL file so `GET /outcomes` can count them.
+#
+# Payload (`data`):
+#   outcome             — the binding's `outcome` name (str)
+#   pocket_id           — the pocket the write ran on
+#   workspace_id        — tenancy
+#   action              — the action name from `rippleSpec.actions`
+#   actor               — the user who triggered (direct) or approved
+#                          (gated) the write
+#   via_instinct        — True when the write was routed through Instinct
+#   instinct_action_id  — the Instinct Action id, or None for a direct write
+#   occurred_at         — ISO-8601 UTC timestamp
+#   outcome_value       — reserved for Layer 4 billing; always None here
+#   outcome_unit        — reserved for Layer 4 billing; always None here
+@dataclass
+class PocketOutcomeEvent(Event):
+    EVENT_TYPE: ClassVar[str] = "pocket.outcome"
 
 
 # Tasks (Mission Control work-item primitive)

--- a/ee/pocketpaw_ee/cloud/models/pocket_backend.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket_backend.py
@@ -16,6 +16,11 @@
 #   human-configured store as the auth credential — so a compromised or
 #   hallucinated spec cannot widen its own blast radius. The default is an
 #   EMPTY list: fail-closed, no write can fire until a human allow-lists it.
+# Updated: 2026-05-22 (RFC 05 M2b.1) — added the per-pocket APPROVAL ROUTE.
+#   `ApprovalRoute` decides who approves a `requires_instinct` write:
+#   `mode="owner"` (the default when `approval_route` is None) routes to
+#   the pocket owner; `mode="user"` routes to a named workspace member.
+#   It lives HERE alongside the credential — owner-set, outside the spec.
 
 from __future__ import annotations
 
@@ -39,6 +44,19 @@ class AllowedWrite(BaseModel):
 
     method: Literal["POST", "PUT", "PATCH", "DELETE"]
     path_pattern: str
+
+
+class ApprovalRoute(BaseModel):
+    """Who approves a pocket's `requires_instinct` writes (RFC 05 M2b.1).
+
+    `mode="owner"` routes a gated write to the pocket owner — the same as
+    leaving `approval_route` unset. `mode="user"` routes to the named
+    `user_id`; the service validates that id is a current workspace
+    member when the route is set, so a stale `user_id` here is trusted.
+    """
+
+    mode: Literal["owner", "user"] = "owner"
+    user_id: str | None = None
 
 
 class PocketBackendCredential(TimestampedDocument):
@@ -65,6 +83,10 @@ class PocketBackendCredential(TimestampedDocument):
     # with no policy can fire no write actions. A human widens it via
     # `PUT /pockets/{id}/backend/write-policy`.
     allowed_writes: list[AllowedWrite] = Field(default_factory=list)
+    # RFC 05 M2b.1 approval route. None means the default — `requires_instinct`
+    # writes route to the pocket owner. An owner sets a named approver via
+    # `PUT /pockets/{id}/backend/approval-route`.
+    approval_route: ApprovalRoute | None = None
 
     class Settings:
         name = "pocket_backend_credentials"

--- a/ee/pocketpaw_ee/cloud/outcomes/__init__.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/__init__.py
@@ -1,0 +1,11 @@
+# __init__.py — Pocket outcomes entity package marker.
+# Created: 2026-05-22 (RFC 05 M2b.2) — the minimal outcome meter. A pocket
+#   write action whose binding declares a named `outcome` emits a
+#   `pocket.outcome` event after the write succeeds. This entity's bus
+#   subscriber appends each event to a workspace-scoped JSONL ledger;
+#   `GET /api/v1/outcomes` reads the ledger back as a grouped count.
+#
+#   Layer 4 (billing — assigning a monetary `outcome_value`/`outcome_unit`)
+#   is reserved: the event carries both fields as `null` and this entity
+#   never sets them. The meter exists so an operator can SEE how many
+#   business outcomes a pocket produced before any pricing is wired.

--- a/ee/pocketpaw_ee/cloud/outcomes/domain.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/domain.py
@@ -1,0 +1,33 @@
+# domain.py — Frozen value objects for the pocket-outcomes entity.
+# Created: 2026-05-22 (RFC 05 M2b.2) — `OutcomeRecord` is one row in the
+#   workspace-scoped JSONL ledger. Tenancy (`workspace_id`) is a required
+#   construction field per ee/cloud Rule 3 — a record cannot exist without
+#   a workspace to scope it to.
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class OutcomeRecord:
+    """One recorded pocket outcome — a checked business event.
+
+    Built from a ``PocketOutcomeEvent`` and appended verbatim to the
+    workspace JSONL ledger. ``outcome_value`` / ``outcome_unit`` are the
+    Layer-4 billing slots — always ``None`` in this build, kept on the
+    record so the ledger format is forward-stable when pricing lands.
+    """
+
+    outcome: str
+    pocket_id: str
+    workspace_id: str
+    action: str
+    actor: str
+    via_instinct: bool
+    instinct_action_id: str | None
+    occurred_at: str  # ISO-8601 UTC
+    outcome_value: float | None = None
+    outcome_unit: str | None = None
+
+
+__all__ = ["OutcomeRecord"]

--- a/ee/pocketpaw_ee/cloud/outcomes/dto.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/dto.py
@@ -1,0 +1,38 @@
+# dto.py — Request/response DTOs for the pocket-outcomes entity.
+# Created: 2026-05-22 (RFC 05 M2b.2) — `CountOutcomesRequest` is the
+#   validated query for `GET /api/v1/outcomes`; `OutcomeCountResponse` is
+#   the grouped-count wire shape. Request and response are distinct models
+#   per ee/cloud Rule 4.
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CountOutcomesRequest(BaseModel):
+    """Validated query for ``GET /api/v1/outcomes``.
+
+    ``workspace_id`` is taken from the auth context, never the query — the
+    router rejects a ``workspace_id`` query param. ``pocket_id`` narrows
+    to one pocket; ``since`` is an ISO-8601 lower bound (inclusive) on
+    ``occurred_at``. Both optional.
+    """
+
+    pocket_id: str | None = None
+    since: str | None = None
+
+
+class OutcomeCountResponse(BaseModel):
+    """Grouped outcome counts for a workspace.
+
+    ``total`` is the count of every matching ledger row; ``by_outcome``
+    maps each distinct ``outcome`` name to its count. ``by_pocket`` does
+    the same per pocket id — handy for a workspace-wide rollup when no
+    ``pocket_id`` filter was supplied.
+    """
+
+    total: int
+    by_outcome: dict[str, int] = Field(default_factory=dict)
+    by_pocket: dict[str, int] = Field(default_factory=dict)
+
+
+__all__ = ["CountOutcomesRequest", "OutcomeCountResponse"]

--- a/ee/pocketpaw_ee/cloud/outcomes/router.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/router.py
@@ -1,0 +1,47 @@
+# router.py — FastAPI router for the pocket-outcomes entity.
+# Created: 2026-05-22 (RFC 05 M2b.2) — exposes `GET /api/v1/outcomes`, the
+#   count surface over the workspace outcome ledger. Thin: parses the
+#   query, delegates to `outcomes_service.count_outcomes`. Never raises
+#   HTTPException — CloudError → JSON via `_core.http`.
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.outcomes import service as outcomes_service
+from pocketpaw_ee.cloud.outcomes.dto import CountOutcomesRequest, OutcomeCountResponse
+from pocketpaw_ee.cloud.shared.deps import require_action_any_workspace
+
+router = APIRouter(
+    prefix="/outcomes",
+    tags=["Outcomes"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.get(
+    "",
+    response_model=OutcomeCountResponse,
+    dependencies=[Depends(require_action_any_workspace("outcomes.read"))],
+)
+async def count_outcomes(
+    request: Request,
+    pocket_id: str | None = Query(default=None),
+    since: str | None = Query(default=None, description="ISO-8601 lower bound on occurred_at"),
+    ctx: RequestContext = Depends(request_context),
+) -> OutcomeCountResponse:
+    """Count recorded pocket outcomes for the caller's workspace.
+
+    Tenancy comes from the auth context — a ``workspace_id`` query param
+    is rejected so a caller cannot read another workspace's ledger.
+    """
+    if "workspace_id" in request.query_params:
+        raise CloudError(
+            400,
+            "outcomes.workspace_id_forbidden",
+            "workspace_id is taken from auth context, not query",
+        )
+    body = CountOutcomesRequest(pocket_id=pocket_id, since=since)
+    return await outcomes_service.count_outcomes(ctx.workspace_id or "", body)

--- a/ee/pocketpaw_ee/cloud/outcomes/service.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/service.py
@@ -1,0 +1,197 @@
+# service.py — Pocket-outcomes entity business logic.
+# Created: 2026-05-22 (RFC 05 M2b.2) — the minimal outcome meter.
+#   `emit_pocket_outcome` is the producer: it builds and emits a
+#   `pocket.outcome` event after a successful write (a no-op when the
+#   binding declared no `outcome`). `record_outcome` is the consumer —
+#   the `pocket.outcome` bus subscriber that appends one JSON line to a
+#   workspace-scoped ledger file. `count_outcomes` reads a workspace's
+#   ledger back and groups the rows. There is no Beanie here — the ledger
+#   is an append-only JSONL file, so this entity's "repository" is the
+#   filesystem. No billing: the Layer-4 `outcome_value`/`outcome_unit`
+#   slots stay null.
+#
+#   The ledger lives at `<dir>/<workspace_id>.jsonl`. `<dir>` defaults to
+#   `~/.pocketpaw/outcomes/` and is overridable via `set_ledger_dir` so
+#   tests write to a tmp path instead of the real home directory.
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import PocketOutcomeEvent
+from pocketpaw_ee.cloud.outcomes.domain import OutcomeRecord
+from pocketpaw_ee.cloud.outcomes.dto import CountOutcomesRequest, OutcomeCountResponse
+
+logger = logging.getLogger(__name__)
+
+# Module-level ledger directory. Default is the real home dir; tests call
+# ``set_ledger_dir(tmp_path)`` so they never touch `~/.pocketpaw`.
+_LEDGER_DIR: Path = Path.home() / ".pocketpaw" / "outcomes"
+
+
+def set_ledger_dir(path: str | Path) -> None:
+    """Override the outcomes ledger directory (test seam)."""
+    global _LEDGER_DIR
+    _LEDGER_DIR = Path(path)
+
+
+def _ledger_path(workspace_id: str) -> Path:
+    """Return the JSONL ledger path for a workspace.
+
+    A workspace id is an opaque token (Mongo ObjectId hex or a test
+    string); ``Path`` joins it as a single filename. An empty id would
+    collide on a bare ``.jsonl`` — callers guard against that upstream
+    (a record with no workspace is dropped in ``record_outcome``).
+    """
+    return _LEDGER_DIR / f"{workspace_id}.jsonl"
+
+
+async def emit_pocket_outcome(
+    *,
+    outcome: str | None,
+    pocket_id: str,
+    workspace_id: str,
+    action: str,
+    actor: str,
+    via_instinct: bool,
+    instinct_action_id: str | None = None,
+) -> None:
+    """Emit a ``pocket.outcome`` event for a successful write action.
+
+    Called by the pockets router (a direct, non-gated write) and by
+    ``instinct_bridge.execute_approved_write`` (a write fired after
+    Instinct approval) AFTER ``run_action`` returns ``ok:true``.
+
+    A binding that declared no ``outcome`` passes ``outcome=None`` — this
+    is a NO-OP, no event is emitted. Only a named outcome produces an
+    event. ``emit`` itself never raises, so a bus failure here can never
+    break the write that already succeeded.
+
+    ``outcome_value`` / ``outcome_unit`` are emitted as ``None`` — Layer 4
+    (billing) is reserved and this build never assigns a monetary value.
+    """
+    if not outcome:
+        # No declared outcome — nothing to meter. The write still
+        # succeeded; it just isn't a named business event.
+        return
+    await emit(
+        PocketOutcomeEvent(
+            data={
+                "outcome": outcome,
+                "pocket_id": pocket_id,
+                "workspace_id": workspace_id,
+                "action": action,
+                "actor": actor,
+                "via_instinct": via_instinct,
+                "instinct_action_id": instinct_action_id,
+                "occurred_at": datetime.now(UTC).isoformat(),
+                # Layer 4 reserved — billing is not wired in this build.
+                "outcome_value": None,
+                "outcome_unit": None,
+            }
+        )
+    )
+
+
+async def record_outcome(event) -> None:  # type: ignore[no-untyped-def]
+    """Append a ``pocket.outcome`` event to its workspace ledger.
+
+    Registered as an in-process bus subscriber in ``mount_cloud()``. The
+    bus already isolates a subscriber failure (logs + swallows), so a
+    bad write here can never break the originating pocket write — but we
+    still guard defensively and log, because a silently-dropped outcome
+    is a metering gap an operator should see in the logs.
+
+    ``event`` is a ``PocketOutcomeEvent``; its ``data`` dict is the
+    payload built by ``emit_pocket_outcome``. A payload missing
+    ``workspace_id`` or ``outcome`` is dropped — the ledger is keyed by
+    workspace and a row with no outcome name is uncountable.
+    """
+    data = getattr(event, "data", None) or {}
+    workspace_id = data.get("workspace_id")
+    outcome = data.get("outcome")
+    if not workspace_id or not outcome:
+        logger.warning("pocket.outcome event dropped — missing workspace_id or outcome")
+        return
+
+    record = OutcomeRecord(
+        outcome=str(outcome),
+        pocket_id=str(data.get("pocket_id") or ""),
+        workspace_id=str(workspace_id),
+        action=str(data.get("action") or ""),
+        actor=str(data.get("actor") or ""),
+        via_instinct=bool(data.get("via_instinct")),
+        instinct_action_id=data.get("instinct_action_id"),
+        occurred_at=str(data.get("occurred_at") or ""),
+        # Layer 4 reserved — never set here.
+        outcome_value=None,
+        outcome_unit=None,
+    )
+    path = _ledger_path(record.workspace_id)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(asdict(record), separators=(",", ":")) + "\n")
+    except OSError:
+        logger.warning("failed to append pocket.outcome to ledger %s", path, exc_info=True)
+
+
+async def count_outcomes(
+    workspace_id: str,
+    body: CountOutcomesRequest | dict | None = None,
+) -> OutcomeCountResponse:
+    """Count a workspace's recorded outcomes, grouped by name and pocket.
+
+    Reads the workspace JSONL ledger, filters by the optional
+    ``pocket_id`` / ``since`` (inclusive ISO-8601 lower bound on
+    ``occurred_at``), and returns the totals. A workspace with no ledger
+    file yet returns zero counts — not an error.
+    """
+    body = CountOutcomesRequest.model_validate(body or {})
+    path = _ledger_path(workspace_id)
+    if not workspace_id or not path.exists():
+        return OutcomeCountResponse(total=0)
+
+    total = 0
+    by_outcome: dict[str, int] = {}
+    by_pocket: dict[str, int] = {}
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    # A torn write or hand-edited line — skip it rather
+                    # than failing the whole count.
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                if body.pocket_id is not None and row.get("pocket_id") != body.pocket_id:
+                    continue
+                if body.since is not None and str(row.get("occurred_at") or "") < body.since:
+                    continue
+                total += 1
+                name = str(row.get("outcome") or "")
+                pocket = str(row.get("pocket_id") or "")
+                by_outcome[name] = by_outcome.get(name, 0) + 1
+                by_pocket[pocket] = by_pocket.get(pocket, 0) + 1
+    except OSError:
+        logger.warning("failed to read outcomes ledger %s", path, exc_info=True)
+        return OutcomeCountResponse(total=0)
+
+    return OutcomeCountResponse(total=total, by_outcome=by_outcome, by_pocket=by_pocket)
+
+
+__all__ = [
+    "emit_pocket_outcome",
+    "record_outcome",
+    "count_outcomes",
+    "set_ledger_dir",
+]

--- a/ee/pocketpaw_ee/cloud/outcomes/service.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/service.py
@@ -13,6 +13,12 @@
 #   The ledger lives at `<dir>/<workspace_id>.jsonl`. `<dir>` defaults to
 #   `~/.pocketpaw/outcomes/` and is overridable via `set_ledger_dir` so
 #   tests write to a tmp path instead of the real home directory.
+#
+# Updated: 2026-05-22 (security-review fix for PR #1183, SHOULD-FIX 3) —
+#   `count_outcomes` now skips any ledger row whose `workspace_id` does
+#   not match the caller's workspace. The ledger file is already keyed by
+#   workspace, so this is defense-in-depth: a corrupt or hand-edited line
+#   carrying a foreign tenant id is no longer counted into the totals.
 from __future__ import annotations
 
 import json
@@ -172,6 +178,13 @@ async def count_outcomes(
                     # than failing the whole count.
                     continue
                 if not isinstance(row, dict):
+                    continue
+                # SHOULD-FIX 3 (PR #1183) — defense-in-depth tenant
+                # filter. The ledger file is already keyed by workspace
+                # (`<dir>/<workspace_id>.jsonl`), but a corrupt or
+                # hand-edited line carrying a foreign `workspace_id`
+                # must NOT be counted into this workspace's totals.
+                if str(row.get("workspace_id") or "") != workspace_id:
                     continue
                 if body.pocket_id is not None and row.get("pocket_id") != body.pocket_id:
                     continue

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -12,6 +12,19 @@
 #   sees a generic message; (N1) an empty-params DELETE sends no JSON
 #   body; (N3) `workspace_id` is now on every write-action audit entry so
 #   the entries are tenant-filterable.
+# Updated: 2026-05-22 (RFC 05 M2b.1 — Instinct routing) — the M2a
+#   fail-closed `_instinct_rejected` gate is GONE. `ActionBinding` now
+#   declares the real governance fields (`requires_instinct`,
+#   `instinct_policy`, `outcome`) with a `model_validator` that rejects an
+#   `instinct_policy` set without `requires_instinct`. `run_action` takes a
+#   `from_instinct` flag: when a binding requires instinct and the call is
+#   NOT already post-approval, the executor runs every cheap validation
+#   gate (rate-limit, base-URL, SSRF/allowlist/DNS) so a write the
+#   allowlist would reject is rejected NOW, then returns an
+#   `instinct_pending` sentinel carrying the resolved write under `_park`
+#   — it makes NO HTTP call. The executor stays pure (no Beanie/Instinct
+#   imports); `instinct_bridge.py` does the proposing. A successful write
+#   result now carries the binding's `outcome` string for M2b.2 emission.
 #
 # A write has blast radius a read does not, so this executor adds three
 # concerns on TOP of the shared SSRF guards:
@@ -20,11 +33,13 @@
 #      match an allowlist entry is rejected before any call leaves the
 #      server. Authorship (the agent writes bindings) and authorization
 #      (the human allow-lists the *class* of writes) are split.
-#   2. INSTINCT-REJECT (fail-closed). M2b will route `requires_instinct`
-#      actions through the Instinct approval surface. M2a must NOT silently
-#      honor-then-ignore the flag: any action whose RAW dict carries a
-#      truthy `requires_instinct` is rejected with `code: instinct_required`
-#      and makes NO call.
+#   2. INSTINCT PARK (M2b.1). A binding with `requires_instinct` is routed
+#      through the Instinct approval surface instead of firing: a direct
+#      run validates the write (gates 2-6) then returns the
+#      `instinct_pending` sentinel with the resolved write under `_park`
+#      and makes NO call. Only `instinct_bridge.execute_approved_write`,
+#      re-entering with `from_instinct=True` after a human approval, runs
+#      the actual HTTP call.
 #   3. An `Idempotency-Key` header (client-supplied or server `uuid4().hex`)
 #      so a write retried after a network timeout cannot double-submit.
 #
@@ -52,7 +67,7 @@ import uuid
 from typing import Any, Literal
 
 import httpx
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from pocketpaw.security.url_validators import validate_external_url_strict
 from pocketpaw_ee.cloud.pockets._http_guard import (
@@ -102,16 +117,25 @@ class _BackendHTTPError(Exception):
 class ActionBinding(BaseModel):
     """One write binding parsed from `rippleSpec.actions`.
 
-    ``model_config`` ignores unknown keys — the spec entry carries M2b
-    governance/metering fields (`requires_instinct`, `instinct_policy`,
-    `outcome`) and possibly RFC-03 template fields that this M2a executor
-    does not act on. Ignoring them keeps an M2b-authored spec parseable by
-    an M2a runtime instead of crashing on an unknown field.
+    ``model_config`` still ignores unknown keys — a spec entry may carry
+    RFC-03 template fields this executor does not act on, plus M2b.3's
+    deferred ``approve_batch`` extras. Ignoring them keeps a forward-dated
+    spec parseable instead of crashing on an unknown field.
 
-    NOTE: `requires_instinct` is deliberately NOT a declared field — the
-    instinct-reject check reads it off the RAW action dict (see
-    `_instinct_rejected`). Declaring it here would let `extra:ignore` drop
-    it and the fail-closed gate would silently pass.
+    M2b.1 promotes the three governance fields to REAL declared fields:
+
+    * ``requires_instinct`` — when true the write is routed through the
+      Instinct approval surface instead of firing directly.
+    * ``instinct_policy`` — how Instinct batches the write
+      (``approve_per_row`` is the only policy this build executes;
+      ``approve_batch`` is reserved for M2b.3 and not yet implemented).
+    * ``outcome`` — the named outcome a successful run emits as a
+      ``pocket.outcome`` event (M2b.2). ``None`` means no emit.
+
+    A ``model_validator`` rejects an ``instinct_policy`` set WITHOUT
+    ``requires_instinct`` — a policy with no gate to apply to is a
+    misconfiguration, and silently ignoring it would hide the author's
+    intent.
     """
 
     model_config = {"extra": "ignore"}
@@ -123,17 +147,26 @@ class ActionBinding(BaseModel):
     confirm: bool = False
     on_success: list[dict] = Field(default_factory=list)
     on_error: list[dict] = Field(default_factory=list)
+    # --- M2b governance / metering fields (RFC 05 M2b.1) ----------------
+    requires_instinct: bool = False
+    instinct_policy: Literal["approve_per_row", "approve_batch"] | None = None
+    outcome: str | None = None
 
+    @model_validator(mode="after")
+    def _policy_needs_gate(self) -> ActionBinding:
+        """An ``instinct_policy`` is meaningless without ``requires_instinct``.
 
-def _instinct_rejected(raw_action: dict[str, Any]) -> bool:
-    """Return ``True`` when the RAW action dict requests Instinct gating.
-
-    Fail-closed: M2a has no Instinct wiring, so any truthy
-    ``requires_instinct`` means the action must NOT fire. Reads the raw
-    dict — never the parsed ``ActionBinding`` — because ``extra: ignore``
-    drops the field off the model.
-    """
-    return bool(raw_action.get("requires_instinct"))
+        Setting a policy but leaving the gate off would silently never
+        route the write — reject the binding so the misconfiguration is
+        caught at parse time (``agent_set_action`` and the executor both
+        validate through this model).
+        """
+        if self.instinct_policy is not None and not self.requires_instinct:
+            raise ValueError(
+                "instinct_policy is set but requires_instinct is false — "
+                "a policy needs the instinct gate enabled"
+            )
+        return self
 
 
 def _allowlist_match(method: str, path_no_query: str, allowed_writes: list[dict[str, Any]]) -> bool:
@@ -267,40 +300,58 @@ async def run_action(
     token: str,
     allowed_writes: list[dict[str, Any]],
     idempotency_key: str | None = None,
+    from_instinct: bool = False,
 ) -> dict:
     """Run ONE pocket write action against its configured backend.
 
     ``raw_action`` is the action's entry from the persisted
     ``rippleSpec.actions`` block — the server reads ``method`` /
-    ``confirm`` / ``on_success`` / ``on_error`` from it (a compromised
-    client cannot pick the verb). ``path`` and ``params`` arrive from the
-    client already resolved by Ripple's ``{...}`` expression resolver.
+    ``confirm`` / ``on_success`` / ``on_error`` / the M2b governance
+    fields from it (a compromised client cannot pick the verb). ``path``
+    and ``params`` arrive from the client already resolved by Ripple's
+    ``{...}`` expression resolver.
 
-    The result shape on success::
+    ``from_instinct`` is ``False`` for a direct run and ``True`` only when
+    ``instinct_bridge.execute_approved_write`` re-enters this function
+    after a human approved the parked write. When a binding has
+    ``requires_instinct`` and ``from_instinct`` is ``False`` the executor
+    runs every cheap validation gate then PARKS the write — it returns the
+    ``instinct_pending`` sentinel and makes NO HTTP call.
 
-        {"ok": true, "action", "status", "response",
+    The result shape on a fired success::
+
+        {"ok": true, "action", "status", "response", "outcome",
          "on_success": [...], "on_error": [...]}
+
+    On the parked (instinct-pending) path::
+
+        {"ok": true, "code": "instinct_pending", "_park": <write dict>,
+         "action", "on_success": [], "on_error": []}
 
     On failure::
 
         {"ok": false, "action", "error", "code", "on_error": [...]}
 
-    The executor is pure: it makes the one HTTP call and returns. It does
-    NOT persist to the Pocket document and does NOT emit ``pocket_mutation``
-    — the response is delivered in the calling route's HTTP body.
+    The executor is pure: it makes the one HTTP call (or signals a park)
+    and returns. It does NOT persist to the Pocket document, does NOT emit
+    ``pocket_mutation``, and does NOT touch Beanie or the Instinct store —
+    the calling route / ``instinct_bridge`` own that.
 
     Gate order (each gate makes NO call when it rejects):
       1. Parse the binding (``ActionBinding``); a malformed entry is a
          ``bad_binding`` rejection.
-      2. INSTINCT-REJECT — fail-closed on a truthy raw ``requires_instinct``.
-      3. Write rate limit — 20 writes / 60s / (pocket, user).
-      4. Strict base-URL re-validation (defense in depth).
-      5. ``_resolve_url`` — path-traversal / absolute-URL / cross-host
+      2. Write rate limit — 20 writes / 60s / (pocket, user).
+      3. Strict base-URL re-validation (defense in depth).
+      4. ``_resolve_url`` — path-traversal / absolute-URL / cross-host
          rejection (shared SSRF guard).
-      6. ALLOWLIST — ``(method, query-stripped, percent-decoded path)``
+      5. ALLOWLIST — ``(method, query-stripped, percent-decoded path)``
          must match an ``allowed_writes`` entry; a miss is audited WARNING
          ``rejected``.
-      7. DNS pre-resolve — reject a host that resolves internal.
+      6. DNS pre-resolve — reject a host that resolves internal.
+      7. INSTINCT PARK — when the binding requires instinct and this is
+         not a post-approval call, return the ``instinct_pending``
+         sentinel after gates 2-6 have validated the write. A write the
+         allowlist would reject is rejected here, NOT parked.
       8. The HTTP call: redirects disabled, 3xx is an error, tight
          timeouts, 512 KB response cap, sanitized errors.
     """
@@ -318,26 +369,7 @@ async def run_action(
     on_error = binding.on_error
     method = binding.method
 
-    # ── 2. instinct-reject (fail-closed) ────────────────────────────────
-    # M2a has no Instinct wiring. Honoring-then-ignoring the flag would
-    # silently fire a write the spec said needs approval — reject instead.
-    if _instinct_rejected(raw_action):
-        _audit_action_run(
-            actor=user_id,
-            workspace_id=workspace_id,
-            pocket_id=pocket_id,
-            action=action,
-            status="instinct-required",
-            base_url=base_url,
-        )
-        return _error(
-            action,
-            "action requires approval — Instinct gating is not in this build",
-            "instinct_required",
-            on_error,
-        )
-
-    # ── 3. write rate limit ─────────────────────────────────────────────
+    # ── 2. write rate limit ─────────────────────────────────────────────
     if await _action_rate_limited(pocket_id, user_id):
         _audit_action_run(
             actor=user_id,
@@ -349,7 +381,7 @@ async def run_action(
         )
         return _error(action, "write rate limit exceeded", "rate_limited", on_error)
 
-    # ── 4. strict base-URL re-validation ────────────────────────────────
+    # ── 3. strict base-URL re-validation ────────────────────────────────
     # D6/D15 — re-validate even though config-time validation already ran.
     try:
         validate_external_url_strict(base_url)
@@ -364,7 +396,7 @@ async def run_action(
         )
         return _error(action, str(exc), "bad_base_url", on_error)
 
-    # ── 5. resolve + SSRF-guard the path ────────────────────────────────
+    # ── 4. resolve + SSRF-guard the path ────────────────────────────────
     try:
         url = _resolve_url(base_url, path)
     except _GuardError as exc:
@@ -378,7 +410,7 @@ async def run_action(
         )
         return _error(action, exc.message, exc.code, on_error)
 
-    # ── 6. allowlist check ──────────────────────────────────────────────
+    # ── 5. allowlist check ──────────────────────────────────────────────
     # Match (method, path-with-query-stripped) against the human-set
     # allowlist. The query is stripped so `/leases/*` is not bypassed by a
     # trailing `?x=y`. A miss makes NO call and is audited as `rejected`.
@@ -417,7 +449,7 @@ async def run_action(
             on_error,
         )
 
-    # ── 7. DNS pre-resolve ──────────────────────────────────────────────
+    # ── 6. DNS pre-resolve ──────────────────────────────────────────────
     try:
         await _assert_host_external(urllib.parse.urlsplit(url).hostname or "")
     except _GuardError as exc:
@@ -430,6 +462,40 @@ async def run_action(
             base_url=base_url,
         )
         return _error(action, exc.message, exc.code, on_error)
+
+    # ── 7. instinct park ────────────────────────────────────────────────
+    # A binding that requires instinct, on a direct (not post-approval)
+    # run, is PARKED — not fired. Gates 2-6 already ran as VALIDATION, so a
+    # write the allowlist would reject was rejected above, NOT parked: an
+    # off-policy write must never reach the approval surface looking
+    # legitimate. The executor stays pure — it just returns the resolved
+    # write under `_park` and signals `instinct_pending`. The router hands
+    # `_park` to `instinct_bridge.propose_pocket_write`, which builds the
+    # Instinct Action. NO HTTP call is made here.
+    if binding.requires_instinct and not from_instinct:
+        _audit_action_run(
+            actor=user_id,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            action=action,
+            status="instinct-pending",
+            base_url=base_url,
+        )
+        return {
+            "ok": True,
+            "code": "instinct_pending",
+            "action": action,
+            "_park": {
+                "action": action,
+                "method": method,
+                "path": path,
+                "params": params,
+                "idempotency_key": idempotency_key,
+                "outcome": binding.outcome,
+            },
+            "on_success": [],
+            "on_error": [],
+        }
 
     # ── 8. the HTTP call ────────────────────────────────────────────────
     headers = _auth_headers(auth_type, auth_header, token)
@@ -508,6 +574,10 @@ async def run_action(
         "action": action,
         "status": result["status"],
         "response": result["response"],
+        # M2b.2 — the named outcome a successful write emits as a
+        # `pocket.outcome` event. `None` when the binding declares none;
+        # the emit helper treats `None` as a no-op.
+        "outcome": binding.outcome,
         "on_success": binding.on_success,
         "on_error": on_error,
     }

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -25,6 +25,12 @@
 #   — it makes NO HTTP call. The executor stays pure (no Beanie/Instinct
 #   imports); `instinct_bridge.py` does the proposing. A successful write
 #   result now carries the binding's `outcome` string for M2b.2 emission.
+# Updated: 2026-05-22 (security-review fix for PR #1183, SHOULD-FIX 4) —
+#   `_action_rate_limited` now bounds `_action_log`: a key whose
+#   timestamp list is empty after window pruning is evicted, and stale
+#   keys are swept opportunistically under the existing lock. Previously
+#   the map grew one permanent entry per `(pocket, user)` pair that ever
+#   ran a write — an unbounded memory leak in a long-running worker.
 #
 # A write has blast radius a read does not, so this executor adds three
 # concerns on TOP of the shared SSRF guards:
@@ -209,11 +215,29 @@ async def _action_rate_limited(pocket_id: str, user_id: str) -> bool:
     cannot race past the limit (TOCTOU under ``asyncio.gather``). Mirrors
     ``source_executor._rate_limited`` but against the separate write
     counter.
+
+    SHOULD-FIX 4 (PR #1183) — the map is bounded: a key whose timestamp
+    list is empty after pruning is evicted, and stale keys are swept
+    opportunistically. Without this every ``(pocket, user)`` pair that
+    ever ran a write would leave a permanent entry — an unbounded
+    process-lifetime memory leak in a long-running cloud worker.
     """
     key = (pocket_id, user_id)
     now = time.monotonic()
     window_start = now - _ACTION_RATE_LIMIT_WINDOW_S
     async with _action_log_lock:
+        # Opportunistic sweep — drop any OTHER key whose stamps have all
+        # aged out of the window. Bounds the dict to keys with live
+        # traffic. Cheap: the map only ever holds active (pocket, user)
+        # pairs, and the sweep runs under the same lock the check needs.
+        stale = [
+            k
+            for k, ts in _action_log.items()
+            if k != key and not any(t >= window_start for t in ts)
+        ]
+        for k in stale:
+            del _action_log[k]
+
         stamps = [t for t in _action_log.get(key, []) if t >= window_start]
         if len(stamps) >= _ACTION_RATE_LIMIT_MAX:
             _action_log[key] = stamps

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -17,6 +17,12 @@ empty string to None; documented that `auth_token` for `basic` is the
 Updated: 2026-05-22 (RFC 05 M2a) — added RunActionRequest /
 RunActionResponse for the write-action run endpoint, plus AllowedWriteDTO
 and SetWritePolicyRequest for the per-pocket write-allowlist endpoint.
+Updated: 2026-05-22 (RFC 05 M2b.1) — RunActionResponse gained
+``proposed_action_id`` (set when a ``requires_instinct`` write is parked
+into an Instinct Action instead of fired). Added ApprovalRouteDTO and
+SetApprovalRouteRequest plus an optional ``approval_route`` field on
+PocketBackendConfigResponse — the per-pocket approver routing for gated
+writes.
 """
 
 from __future__ import annotations
@@ -151,18 +157,41 @@ class PocketBackendConfigRequest(BaseModel):
     auth_header: str | None = None
 
 
+class ApprovalRouteDTO(BaseModel):
+    """Who approves a pocket's ``requires_instinct`` writes (RFC 05 M2b.1).
+
+    ``mode="owner"`` (the default) routes every gated write to the pocket
+    owner. ``mode="user"`` routes to a named workspace member —
+    ``user_id`` is then required and is validated as a current workspace
+    member when the route is set.
+    """
+
+    mode: Literal["owner", "user"] = "owner"
+    user_id: str | None = None
+
+    @field_validator("user_id")
+    @classmethod
+    def _empty_user_is_none(cls, v: str | None) -> str | None:
+        return v or None
+
+
 class PocketBackendConfigResponse(BaseModel):
     """Backend binding as returned to clients — never carries the token.
 
     ``allowed_writes`` is the per-pocket write allowlist (RFC 05 M2a) —
     an owner/editor-facing non-secret. Empty by default (fail-closed: no
     write fires until a human allow-lists it).
+
+    ``approval_route`` is the per-pocket approver routing for
+    ``requires_instinct`` writes (RFC 05 M2b.1). ``None`` means the
+    default — the pocket owner approves.
     """
 
     base_url: str
     auth_type: str
     configured: bool
     allowed_writes: list[AllowedWriteDTO] = Field(default_factory=list)
+    approval_route: ApprovalRouteDTO | None = None
 
 
 class RunSourcesRequest(BaseModel):
@@ -213,11 +242,18 @@ class RunActionRequest(BaseModel):
 class RunActionResponse(BaseModel):
     """Result of a write-action run.
 
-    On success ``ok`` is true and ``status`` / ``response`` carry the
+    On a fired write ``ok`` is true and ``status`` / ``response`` carry the
     backend's HTTP status + parsed JSON body. On failure ``ok`` is false
     and ``error`` / ``code`` describe the rejection. ``on_success`` /
     ``on_error`` are the reconcile handler lists the client runs after.
-    All optional fields keep one model usable for both outcomes.
+
+    On a PARKED write (RFC 05 M2b.1) — a ``requires_instinct`` action —
+    ``ok`` is true, ``code`` is ``"instinct_pending"``, and
+    ``proposed_action_id`` carries the id of the Instinct Action the
+    write was routed into. No backend call was made; the client shows a
+    "waiting for approval" state and does NOT run the reconcile handlers.
+
+    All optional fields keep one model usable for every outcome.
     """
 
     ok: bool
@@ -226,6 +262,7 @@ class RunActionResponse(BaseModel):
     response: Any = None
     error: str | None = None
     code: str | None = None
+    proposed_action_id: str | None = None
     on_success: list[dict] = Field(default_factory=list)
     on_error: list[dict] = Field(default_factory=list)
 
@@ -238,6 +275,18 @@ class SetWritePolicyRequest(BaseModel):
     """
 
     allowed_writes: list[AllowedWriteDTO] = Field(default_factory=list)
+
+
+class SetApprovalRouteRequest(BaseModel):
+    """Body for ``PUT /pockets/{id}/backend/approval-route`` (RFC 05 M2b.1).
+
+    Sets who approves the pocket's ``requires_instinct`` writes.
+    ``route=None`` (or an omitted body) clears the route back to the
+    default — the pocket owner. ``mode="user"`` requires a ``user_id``
+    that the service validates as a current workspace member.
+    """
+
+    route: ApprovalRouteDTO | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -23,6 +23,11 @@ into an Instinct Action instead of fired). Added ApprovalRouteDTO and
 SetApprovalRouteRequest plus an optional ``approval_route`` field on
 PocketBackendConfigResponse — the per-pocket approver routing for gated
 writes.
+Updated: 2026-05-22 (security-review fix for PR #1183, SHOULD-FIX 2) —
+RunActionResponse is now ``extra="forbid"`` so an executor-internal key
+(``_park``, ``outcome``) that the router fails to strip raises on
+construction instead of leaking the resolved write path/params onto the
+wire.
 """
 
 from __future__ import annotations
@@ -254,7 +259,16 @@ class RunActionResponse(BaseModel):
     "waiting for approval" state and does NOT run the reconcile handlers.
 
     All optional fields keep one model usable for every outcome.
+
+    ``extra="forbid"`` (security-review fix for PR #1183, SHOULD-FIX 2):
+    the executor result dict carries internal-only keys (``_park`` —
+    the resolved write path/params — and ``outcome``) that the router
+    strips before constructing this response. ``forbid`` makes that
+    strip mandatory: if the strip ever misses a key, model construction
+    raises instead of leaking the resolved write onto the wire.
     """
+
+    model_config = {"extra": "forbid"}
 
     ok: bool
     action: str

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
@@ -1,0 +1,316 @@
+# instinct_bridge.py — Routes a parked pocket write through Instinct.
+# Created: 2026-05-22 (RFC 05 M2b.1) — the impure counterpart to the pure
+#   `action_executor`. When `run_action` parks a `requires_instinct`
+#   write it returns an `instinct_pending` sentinel with the resolved
+#   write under `_park`; the pockets router hands that to
+#   `propose_pocket_write` here, which builds an Instinct `Action` and
+#   stores it via the global `InstinctStore`. After a human approves the
+#   Action, the instinct router's `approve_action` fires
+#   `execute_approved_write`, which RE-loads the backend credentials,
+#   re-enters `run_action` with `from_instinct=True` (the gate is
+#   skipped, the HTTP call is made), then records the result on the
+#   Action and emits the outcome.
+#
+# Why a separate module: `action_executor` is import-linter-pure (no
+#   Beanie, no Instinct, no models). This bridge is the layer that is
+#   ALLOWED to be impure — it calls `pockets_service` (the sole Beanie
+#   writer for the backend-credential collection) and the Instinct store.
+#   It does NOT import Beanie document classes directly, so it does not
+#   belong in the "pockets — Beanie writes only from service.py"
+#   forbidden contract.
+#
+# Security:
+#   * NO TOKEN reaches the Instinct DB. The proposed Action's
+#     `parameters._pocket_write` carries method/path/params/idempotency
+#     only — the backend credential is re-loaded fresh at execution time.
+#   * The allowlist is re-checked at execution: `execute_approved_write`
+#     re-enters `run_action`, which runs the allowlist gate again. A
+#     write the owner de-authorized between propose and approve is
+#     rejected, not fired.
+#   * The approver defaults to the pocket OWNER. An optional
+#     `approval_route` on the backend config can name a different
+#     workspace member (membership validated when the route is set).
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Schema version stamped onto the parked-write blob in
+# `Action.parameters._pocket_write`. Bump when the blob shape changes so a
+# stale pending Action approved after a deploy fails loud instead of
+# executing a misinterpreted write.
+_POCKET_WRITE_SCHEMA = 1
+
+
+def _resolve_approver(
+    pocket: dict[str, Any],
+    backend_config: dict[str, Any] | None,
+) -> str:
+    """Return the workspace-member id who should approve a parked write.
+
+    Default: the pocket ``owner``. An optional ``approval_route`` on the
+    backend config overrides it::
+
+        {"mode": "owner"}                 → the pocket owner (explicit)
+        {"mode": "user", "user_id": "u9"} → a named workspace member
+
+    Membership of a routed ``user_id`` is validated when the route is
+    SET (``pockets_service.set_pocket_approval_route``), so a stale
+    ``approval_route`` here is trusted; if it is malformed we fall back
+    to the owner rather than parking a write nobody can approve.
+
+    TODO (RFC 05): template-escalation — a template author marking an
+    action as "escalate to the template publisher" — is a deliberate
+    follow-up and not wired here.
+    """
+    owner = str(pocket.get("owner") or "")
+    route = (backend_config or {}).get("approval_route")
+    if isinstance(route, dict):
+        mode = route.get("mode")
+        if mode == "user":
+            routed = route.get("user_id")
+            if isinstance(routed, str) and routed:
+                return routed
+        # mode == "owner" (or anything malformed) → fall through to owner.
+    return owner
+
+
+def _row_hint(parked_write: dict[str, Any]) -> str:
+    """Build a short, query-stripped row hint for the Action title.
+
+    The hint is the write's path with any query string dropped — a
+    query can carry resolved values an operator does not need in a
+    title, and stripping it keeps the title stable for the same row.
+    """
+    path = str(parked_write.get("path") or "")
+    return path.split("?", 1)[0]
+
+
+async def propose_pocket_write(
+    *,
+    pocket: dict[str, Any],
+    backend_config: dict[str, Any] | None,
+    parked_write: dict[str, Any],
+    requested_by: str,
+) -> str:
+    """Build + store an Instinct ``Action`` for a parked pocket write.
+
+    ``pocket`` is the wire dict from ``pockets_service.get``. ``parked_write``
+    is the ``_park`` blob from the executor's ``instinct_pending`` sentinel
+    (action / method / path / params / idempotency_key / outcome).
+    ``backend_config`` is the non-secret backend summary (may carry an
+    ``approval_route``); it is NOT required.
+
+    Returns the proposed Action id. NO token is written — the parked-write
+    blob carries only method/path/params/idempotency/outcome plus the
+    workspace + requester context; the credential is re-loaded at
+    execution.
+    """
+    from pocketpaw.instinct.models import ActionCategory, ActionTrigger
+    from pocketpaw.stores import get_instinct_store
+
+    pocket_id = str(pocket.get("_id") or pocket.get("id") or "")
+    workspace_id = str(pocket.get("workspace") or pocket.get("workspace_id") or "")
+    action_name = str(parked_write.get("action") or "")
+    method = str(parked_write.get("method") or "")
+    hint = _row_hint(parked_write)
+
+    title = f"{action_name} — {method} {hint}".strip(" —")
+    # One-line recommendation; the path is already query-stripped via
+    # `_row_hint` so no resolved query values leak into the recommendation.
+    recommendation = (
+        f"Approve to run the '{action_name}' write ({method} {hint}) "
+        f"on pocket {pocket.get('name') or pocket_id}."
+    )
+
+    trigger = ActionTrigger(
+        type="pocket_action",
+        source=requested_by,
+        reason=f"pocket write '{action_name}' requires approval",
+    )
+
+    # The parked-write blob — everything `execute_approved_write` needs to
+    # re-run the write, MINUS the credential. `outcome` rides along so the
+    # outcome event can be emitted after the gated write succeeds.
+    pocket_write = {
+        "schema": _POCKET_WRITE_SCHEMA,
+        "action": action_name,
+        "method": method,
+        "path": parked_write.get("path"),
+        "params": parked_write.get("params") or {},
+        "idempotency_key": parked_write.get("idempotency_key"),
+        "outcome": parked_write.get("outcome"),
+        "workspace_id": workspace_id,
+        "requested_by": requested_by,
+    }
+
+    approver = _resolve_approver(pocket, backend_config)
+
+    store = get_instinct_store()
+    action = await store.propose(
+        pocket_id=pocket_id,
+        title=title or action_name or "Pocket write",
+        description=recommendation,
+        recommendation=recommendation,
+        trigger=trigger,
+        category=ActionCategory.EXTERNAL,
+        parameters={"_pocket_write": pocket_write},
+        assignee=approver or None,
+    )
+    logger.info(
+        "parked pocket write '%s' on pocket %s → Instinct action %s (approver=%s)",
+        action_name,
+        pocket_id,
+        action.id,
+        approver or "<owner-unset>",
+    )
+    return action.id
+
+
+async def execute_approved_write(action) -> None:  # type: ignore[no-untyped-def]
+    """Execute the parked write carried by a freshly-approved Instinct Action.
+
+    Called best-effort from the instinct router's ``approve_action`` after
+    ``store.approve()`` succeeds. ``action`` is the approved
+    :class:`~pocketpaw.instinct.models.Action`; this function:
+
+      1. Reads ``_pocket_write`` from ``action.parameters``. A missing or
+         schema-mismatched blob is marked failed and returns.
+      2. RE-loads the pocket's backend credentials via
+         ``pockets_service.get_pocket_backend_for_executor`` — NOT a
+         snapshot. If the backend was revoked between propose and approve
+         the Action is marked failed with ``code:backend_revoked`` and no
+         write fires.
+      3. Re-enters ``action_executor.run_action`` with
+         ``from_instinct=True`` — the instinct gate is skipped, but every
+         OTHER gate (rate-limit, base-URL, SSRF, ALLOWLIST, DNS) runs
+         again, so a write the owner de-authorized is still rejected.
+      4. Records the result: ``store.mark_executed`` on success,
+         ``store.mark_failed`` on a rejection.
+      5. Emits the ``pocket.outcome`` event on success (M2b.2).
+
+    Never raises — a failure here must not break the approve response.
+    The instinct router wraps the call too; this is belt-and-braces.
+    """
+    from pocketpaw.stores import get_instinct_store
+    from pocketpaw_ee.cloud.outcomes import service as outcomes_service
+    from pocketpaw_ee.cloud.pockets import action_executor
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    store = get_instinct_store()
+    params = getattr(action, "parameters", None) or {}
+    blob = params.get("_pocket_write")
+    if not isinstance(blob, dict):
+        logger.warning("approved action %s carries no _pocket_write blob", action.id)
+        return
+    if blob.get("schema") != _POCKET_WRITE_SCHEMA:
+        await store.mark_failed(
+            action.id,
+            "parked-write schema mismatch — the write blob is from an "
+            "incompatible build and cannot be executed",
+        )
+        return
+
+    pocket_id = str(action.pocket_id or "")
+    workspace_id = str(blob.get("workspace_id") or "")
+    action_name = str(blob.get("action") or "")
+    requested_by = str(blob.get("requested_by") or "")
+    approver = str(getattr(action, "approved_by", "") or "") or "system"
+
+    # The action's raw binding shape, rebuilt from the parked blob. The
+    # executor reads `method` off this dict and re-validates everything.
+    raw_action = {
+        "kind": "write_binding",
+        "method": blob.get("method"),
+        "path": blob.get("path"),
+        "params": blob.get("params") or {},
+    }
+
+    try:
+        creds = await pockets_service.get_pocket_backend_for_executor(workspace_id, pocket_id)
+    except Exception:  # noqa: BLE001 — a creds-load failure must not raise into approve
+        logger.warning(
+            "approved action %s: backend creds load failed for pocket %s",
+            action.id,
+            pocket_id,
+            exc_info=True,
+        )
+        await store.mark_failed(action.id, "backend credential load failed")
+        return
+
+    if creds is None:
+        # The backend was revoked between propose and approve — respect
+        # the current policy, do NOT fire a write against a deleted
+        # credential.
+        await store.mark_failed(
+            action.id,
+            "pocket backend was revoked before approval — no write was made (code:backend_revoked)",
+        )
+        return
+
+    # The executor-creds tuple is a 6-tuple (M2b.1); `approval_route` is
+    # unused at execution — the approver already approved.
+    base_url, auth_type, auth_header, token, allowed_writes, _approval_route = creds
+
+    try:
+        result = await action_executor.run_action(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=requested_by or approver,
+            action=action_name,
+            raw_action=raw_action,
+            path=str(blob.get("path") or ""),
+            params=blob.get("params") or {},
+            base_url=base_url,
+            auth_type=auth_type,
+            auth_header=auth_header,
+            token=token,
+            allowed_writes=allowed_writes,
+            idempotency_key=blob.get("idempotency_key"),
+            from_instinct=True,
+        )
+    except Exception:  # noqa: BLE001 — never let an executor crash break approve
+        logger.warning("approved action %s: write executor crashed", action.id, exc_info=True)
+        await store.mark_failed(action.id, "write executor failed")
+        return
+
+    if not result.get("ok"):
+        # The post-approval re-validation rejected the write (e.g. the
+        # allowlist no longer covers it). Record the rejection on the
+        # Action; emit nothing.
+        code = result.get("code") or "error"
+        err = result.get("error") or "write rejected"
+        await store.mark_failed(action.id, f"{err} (code:{code})")
+        return
+
+    await store.mark_executed(
+        action.id,
+        f"write '{action_name}' executed — HTTP {result.get('status')}",
+    )
+
+    # M2b.2 — emit the outcome AFTER the gated write succeeded. A binding
+    # with no `outcome` makes this a no-op. `actor` is the approver: the
+    # human who authorized the write is the actor of the resulting
+    # business outcome.
+    try:
+        await outcomes_service.emit_pocket_outcome(
+            outcome=blob.get("outcome"),
+            pocket_id=pocket_id,
+            workspace_id=workspace_id,
+            action=action_name,
+            actor=approver,
+            via_instinct=True,
+            instinct_action_id=str(action.id),
+        )
+    except Exception:  # noqa: BLE001 — emit is best-effort; the write already succeeded
+        logger.warning(
+            "approved action %s: outcome emit failed (write succeeded)",
+            action.id,
+            exc_info=True,
+        )
+
+
+__all__ = ["propose_pocket_write", "execute_approved_write"]

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
@@ -30,6 +30,17 @@
 #   * The approver defaults to the pocket OWNER. An optional
 #     `approval_route` on the backend config can name a different
 #     workspace member (membership validated when the route is set).
+#
+# Updated: 2026-05-22 (security-review fix for PR #1183 — BLOCKER 1
+#   defense-in-depth) — `execute_approved_write` now refuses a parked
+#   blob whose `workspace_id` is empty: a write with no tenant to scope
+#   it to is unexecutable. The credential re-load
+#   (`get_pocket_backend_for_executor`) is itself the tenancy gate — it
+#   finds a credential row only when `(workspace_id, pocket_id)` BOTH
+#   match, so a tampered blob carrying a foreign `workspace_id` resolves
+#   no credentials and is marked failed instead of firing a cross-tenant
+#   write. The instinct router's per-`_pocket_write` workspace assertion
+#   is the primary gate; this is belt-and-braces.
 
 from __future__ import annotations
 
@@ -219,6 +230,18 @@ async def execute_approved_write(action) -> None:  # type: ignore[no-untyped-def
     action_name = str(blob.get("action") or "")
     requested_by = str(blob.get("requested_by") or "")
     approver = str(getattr(action, "approved_by", "") or "") or "system"
+
+    # BLOCKER 1 defense-in-depth (PR #1183) — a parked write with no
+    # workspace is unexecutable. The credential re-load below is the
+    # tenancy gate (it matches `(workspace_id, pocket_id)` together), so
+    # an empty workspace_id would never resolve creds anyway — but fail
+    # loud here so a malformed blob is recorded, not silently dropped.
+    if not workspace_id:
+        await store.mark_failed(
+            action.id,
+            "parked-write blob carries no workspace_id — cannot scope the write",
+        )
+        return
 
     # The action's raw binding shape, rebuilt from the parked blob. The
     # executor reads `method` off this dict and re-validates everything.

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -32,6 +32,15 @@ Updated: 2026-05-22 (RFC 05 M2a) — added the write-action routes:
 The action-run route is gated OWNER or explicit shared_with ONLY
 (``require_pocket_action_run``) — narrower than source-run, because a
 write has blast radius. The write-policy route is owner-only.
+
+Updated: 2026-05-22 (RFC 05 M2b.1) — the action-run route now branches on
+the executor's ``instinct_pending`` sentinel: a ``requires_instinct``
+write is routed into an Instinct Action via ``instinct_bridge`` and the
+route returns ``{ok:true, code:"instinct_pending", proposed_action_id}``
+instead of firing. A fired, non-gated write emits a ``pocket.outcome``
+event (M2b.2) when its binding declares an ``outcome``. Added the
+owner-only ``PUT /pockets/{id}/backend/approval-route`` for the
+per-pocket gated-write approver routing.
 """
 
 from __future__ import annotations
@@ -55,6 +64,7 @@ from pocketpaw_ee.cloud.pockets.dto import (
     RunActionRequest,
     RunActionResponse,
     RunSourcesRequest,
+    SetApprovalRouteRequest,
     SetWritePolicyRequest,
     ShareLinkRequest,
     UpdatePocketRequest,
@@ -349,7 +359,9 @@ async def run_pocket_sources(
             "pocket_backend.not_configured",
             "This pocket has no backend configured — set one via PUT /pockets/{id}/backend",
         )
-    base_url, auth_type, auth_header, token, _allowed_writes = creds
+    # M2b.1 — the executor-creds tuple gained `allowed_writes` (M2a) and
+    # `approval_route` (M2b.1); read-only source runs need neither.
+    base_url, auth_type, auth_header, token, _allowed_writes, _approval_route = creds
 
     from pocketpaw_ee.cloud.pockets import source_executor
 
@@ -395,6 +407,35 @@ async def set_pocket_write_policy(
     return PocketBackendConfigResponse(**result)
 
 
+@router.put(
+    "/{pocket_id}/backend/approval-route",
+    dependencies=[Depends(require_pocket_owner)],
+)
+async def set_pocket_approval_route(
+    pocket_id: str,
+    body: SetApprovalRouteRequest | None = None,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> PocketBackendConfigResponse:
+    """Set who approves this pocket's ``requires_instinct`` writes
+    (RFC 05 M2b.1). Owner-only.
+
+    A ``mode="user"`` route names a workspace member as the approver —
+    the service validates that id is a current member. An omitted body
+    (or ``route=null``) clears the route back to the default: the pocket
+    owner. Returns ``400`` when the pocket has no backend configured.
+    """
+    body = body or SetApprovalRouteRequest()
+    route = body.route.model_dump() if body.route is not None else None
+    result = await pockets_service.set_pocket_approval_route(
+        workspace_id,
+        user_id,
+        pocket_id,
+        route,
+    )
+    return PocketBackendConfigResponse(**result)
+
+
 @router.post(
     "/{pocket_id}/actions/run",
     dependencies=[Depends(require_pocket_action_run)],
@@ -413,6 +454,16 @@ async def run_pocket_action(
     HTTP ``method`` is read server-side from the persisted action entry;
     the client only sends the resolved ``path`` / ``params``. The write
     fires only if the human owner allow-listed the method+path.
+
+    RFC 05 M2b.1 — a binding marked ``requires_instinct`` is NOT fired
+    here. The executor validates the write then returns an
+    ``instinct_pending`` sentinel; this route hands the parked write to
+    ``instinct_bridge.propose_pocket_write`` and returns
+    ``{ok:true, code:"instinct_pending", proposed_action_id}``. The
+    actual write fires later, from the instinct router's approve hook.
+
+    On a fired (non-pending) success the route emits a ``pocket.outcome``
+    event when the binding declares an ``outcome`` (M2b.2).
 
     The backend's response is delivered in THIS response body — there is
     no ``pocket_mutation`` SSE emit, because the run endpoint is a
@@ -445,7 +496,7 @@ async def run_pocket_action(
             "pocket_backend.not_configured",
             "This pocket has no backend configured — set one via PUT /pockets/{id}/backend",
         )
-    base_url, auth_type, auth_header, token, allowed_writes = creds
+    base_url, auth_type, auth_header, token, allowed_writes, approval_route = creds
 
     from pocketpaw_ee.cloud.pockets import action_executor
 
@@ -465,7 +516,51 @@ async def run_pocket_action(
         allowed_writes=allowed_writes,
         idempotency_key=body.idempotency_key,
     )
-    return RunActionResponse(**result)
+
+    # M2b.1 — a `requires_instinct` write was PARKED, not fired. The
+    # executor validated it (a write the allowlist rejects already came
+    # back `ok:false`); `_park` carries the resolved write. Route it into
+    # an Instinct Action and return the pending response.
+    if result.get("code") == "instinct_pending":
+        from pocketpaw_ee.cloud.pockets import instinct_bridge
+
+        proposed_id = await instinct_bridge.propose_pocket_write(
+            pocket=pocket,
+            backend_config={
+                "base_url": base_url,
+                "auth_type": auth_type,
+                "allowed_writes": allowed_writes,
+                "approval_route": approval_route,
+            },
+            parked_write=result["_park"],
+            requested_by=user_id,
+        )
+        return RunActionResponse(
+            ok=True,
+            action=body.action,
+            code="instinct_pending",
+            proposed_action_id=proposed_id,
+        )
+
+    # M2b.2 — a direct (non-gated) write succeeded. Emit its outcome when
+    # the binding declared one. A binding with no `outcome` is a no-op.
+    if result.get("ok"):
+        from pocketpaw_ee.cloud.outcomes import service as outcomes_service
+
+        await outcomes_service.emit_pocket_outcome(
+            outcome=result.get("outcome"),
+            pocket_id=pocket_id,
+            workspace_id=workspace_id,
+            action=body.action,
+            actor=user_id,
+            via_instinct=False,
+            instinct_action_id=None,
+        )
+
+    # Strip executor-internal keys (`_park`, `outcome`) the wire model
+    # does not carry before building the response.
+    wire = {k: v for k, v in result.items() if k not in ("_park", "outcome")}
+    return RunActionResponse(**wire)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -41,6 +41,12 @@ instead of firing. A fired, non-gated write emits a ``pocket.outcome``
 event (M2b.2) when its binding declares an ``outcome``. Added the
 owner-only ``PUT /pockets/{id}/backend/approval-route`` for the
 per-pocket gated-write approver routing.
+
+Updated: 2026-05-22 (security-review fix for PR #1183, SHOULD-FIX 2) —
+``run_pocket_action`` now asserts the executor-internal ``_park`` blob is
+absent from the wire dict before constructing ``RunActionResponse`` (the
+DTO is also ``extra="forbid"``), so a resolved write path/params can
+never leak onto the response if the strip drifts.
 """
 
 from __future__ import annotations
@@ -558,8 +564,14 @@ async def run_pocket_action(
         )
 
     # Strip executor-internal keys (`_park`, `outcome`) the wire model
-    # does not carry before building the response.
+    # does not carry before building the response. SHOULD-FIX 2
+    # (PR #1183) — the strip is defensive: `_park` carries the resolved
+    # write path/params and must NEVER reach the wire. The explicit
+    # assertion below catches a strip that drifts out of sync with the
+    # executor's result keys; `RunActionResponse` is also `extra="forbid"`
+    # so a missed key fails construction rather than leaking.
     wire = {k: v for k, v in result.items() if k not in ("_park", "outcome")}
+    assert "_park" not in wire, "executor `_park` blob must be stripped before the wire response"
     return RunActionResponse(**wire)
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -76,6 +76,7 @@ from pocketpaw_ee.cloud._core.realtime.events import (
 from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
 from pocketpaw_ee.cloud.models.pocket import Widget as _WidgetDoc
 from pocketpaw_ee.cloud.models.pocket_backend import AllowedWrite as _AllowedWriteDoc
+from pocketpaw_ee.cloud.models.pocket_backend import ApprovalRoute as _ApprovalRouteDoc
 from pocketpaw_ee.cloud.models.pocket_backend import (
     PocketBackendCredential as _BackendCredentialDoc,
 )
@@ -996,12 +997,14 @@ async def _agent_backend_summary(doc: _PocketDoc) -> dict[str, Any]:
     # get_pocket_backend already excludes the token — assert the shape
     # and never pass anything else through. ``allowed_writes`` is carried
     # so the edit specialist can see which write methods+paths the owner
-    # has authorized before it authors a write action.
+    # has authorized before it authors a write action; ``approval_route``
+    # so it knows who approves a `requires_instinct` write.
     return {
         "base_url": summary.get("base_url"),
         "auth_type": summary.get("auth_type"),
         "configured": True,
         "allowed_writes": summary.get("allowed_writes") or [],
+        "approval_route": summary.get("approval_route"),
     }
 
 
@@ -2353,12 +2356,27 @@ def _allowed_writes_wire(doc: _BackendCredentialDoc) -> list[dict[str, str]]:
     return out
 
 
+def _approval_route_wire(doc: _BackendCredentialDoc) -> dict[str, str | None] | None:
+    """Render a backend doc's ``approval_route`` as a plain wire dict.
+
+    Returns ``{"mode": ..., "user_id": ...}`` or ``None`` when no route is
+    set (the default — gated writes go to the pocket owner). A row written
+    before RFC 05 M2b.1 has no attribute — ``getattr`` defaults it to
+    ``None``.
+    """
+    route = getattr(doc, "approval_route", None)
+    if route is None:
+        return None
+    return {"mode": route.mode, "user_id": route.user_id}
+
+
 async def get_pocket_backend(workspace_id: str, pocket_id: str) -> dict | None:
     """Return the pocket's backend binding summary, or ``None`` if unset.
 
     NEVER returns the token — only ``base_url`` / ``auth_type`` /
-    ``configured`` / ``allowed_writes`` (the write allowlist; an
-    owner/editor-facing non-secret).
+    ``configured`` / ``allowed_writes`` (the write allowlist) /
+    ``approval_route`` (the gated-write approver routing; ``None`` when
+    unset). All owner/editor-facing non-secrets.
     """
     doc = await _BackendCredentialDoc.find_one(
         _BackendCredentialDoc.pocket_id == pocket_id,
@@ -2371,20 +2389,22 @@ async def get_pocket_backend(workspace_id: str, pocket_id: str) -> dict | None:
         "auth_type": doc.auth_type,
         "configured": True,
         "allowed_writes": _allowed_writes_wire(doc),
+        "approval_route": _approval_route_wire(doc),
     }
 
 
 async def get_pocket_backend_for_executor(
     workspace_id: str, pocket_id: str
-) -> tuple[str, str, str | None, str, list[dict[str, str]]] | None:
+) -> tuple[str, str, str | None, str, list[dict[str, str]], dict[str, str | None] | None] | None:
     """Internal — return ``(base_url, auth_type, auth_header, token,
-    allowed_writes)``.
+    allowed_writes, approval_route)``.
 
     Decrypts the stored token. Used by the run-sources route handler (it
-    ignores ``allowed_writes``) and the run-action route handler (it needs
-    it). Returns ``None`` when the pocket has no backend configured. The
+    ignores the trailing elements), the run-action route handler (it needs
+    ``allowed_writes`` and ``approval_route``), and ``instinct_bridge``.
+    Returns ``None`` when the pocket has no backend configured. The
     plaintext token returned here must never be logged or returned to a
-    client.
+    client. ``approval_route`` is ``None`` when no route is set.
     """
     doc = await _BackendCredentialDoc.find_one(
         _BackendCredentialDoc.pocket_id == pocket_id,
@@ -2396,7 +2416,14 @@ async def get_pocket_backend_for_executor(
     token = ""
     if doc.auth_type != "none" and doc.encrypted_token and doc.nonce and doc.salt:
         token = backend_crypto.decrypt_token(doc.encrypted_token, doc.nonce, doc.salt)
-    return doc.base_url, doc.auth_type, doc.auth_header, token, _allowed_writes_wire(doc)
+    return (
+        doc.base_url,
+        doc.auth_type,
+        doc.auth_header,
+        token,
+        _allowed_writes_wire(doc),
+        _approval_route_wire(doc),
+    )
 
 
 async def set_pocket_write_policy(
@@ -2450,6 +2477,79 @@ async def set_pocket_write_policy(
         "auth_type": doc.auth_type,
         "configured": True,
         "allowed_writes": _allowed_writes_wire(doc),
+        "approval_route": _approval_route_wire(doc),
+    }
+
+
+async def set_pocket_approval_route(
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    route: dict[str, str | None] | None,
+) -> dict:
+    """Set (or clear) the pocket's gated-write approval route. Owner-only.
+
+    ``route`` is ``{"mode": "owner"|"user", "user_id": ...}`` or ``None``.
+    ``None`` (or ``mode="owner"``) clears the route — ``requires_instinct``
+    writes then route to the pocket owner. ``mode="user"`` routes to the
+    named member; the ``user_id`` is validated as a CURRENT workspace
+    member here, at set-time, so the bridge can trust a stored route
+    without re-checking on every parked write.
+
+    Lives on the backend-credential row alongside the write allowlist —
+    owner-set, outside the spec. Rejects with ``pocket_backend.not_configured``
+    when the pocket has no backend (a route with no backend to gate is
+    meaningless), and ``pocket_backend.invalid_approver`` when a
+    ``mode="user"`` route names a non-member. Audit-logged.
+    """
+    doc = await _BackendCredentialDoc.find_one(
+        _BackendCredentialDoc.pocket_id == pocket_id,
+        _BackendCredentialDoc.workspace_id == workspace_id,
+    )
+    if doc is None:
+        raise ValidationError(
+            "pocket_backend.not_configured",
+            "This pocket has no backend configured — set one before an approval route",
+        )
+
+    new_route: _ApprovalRouteDoc | None = None
+    if route is not None:
+        parsed = _ApprovalRouteDoc.model_validate(route)
+        if parsed.mode == "user":
+            if not parsed.user_id:
+                raise ValidationError(
+                    "pocket_backend.invalid_approver",
+                    "approval route mode 'user' requires a user_id",
+                )
+            from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+            members = await workspace_service.list_member_ids(workspace_id)
+            if parsed.user_id not in members:
+                raise ValidationError(
+                    "pocket_backend.invalid_approver",
+                    "the routed approver is not a member of this workspace",
+                )
+            new_route = parsed
+        # mode == "owner" → store None (the explicit default).
+
+    doc.approval_route = new_route
+    await doc.save()
+
+    _audit_backend_config(
+        actor=user_id,
+        action="pocket.backend.approval_route",
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        base_url=doc.base_url,
+        auth_type=doc.auth_type,
+    )
+    # no-event: see set_pocket_write_policy — credential rows aren't pocket state.
+    return {
+        "base_url": doc.base_url,
+        "auth_type": doc.auth_type,
+        "configured": True,
+        "allowed_writes": _allowed_writes_wire(doc),
+        "approval_route": _approval_route_wire(doc),
     }
 
 
@@ -2524,6 +2624,7 @@ __all__ = [
     "remove_widget",
     "reorder_widgets",
     "revoke_share_link",
+    "set_pocket_approval_route",
     "set_pocket_backend",
     "set_pocket_write_policy",
     "unassign_project_on_pockets",

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -25,6 +25,10 @@
 # Updated: 2026-05-22 (feat/api-skills, Increment 2b) — added
 # ``skills.manage`` (ADMIN) so the new ee.cloud.skills router can guard
 # POST /skills/api-doc, the per-backend API-skill install endpoint.
+#
+# Updated: 2026-05-22 (RFC 05 M2b.2) — added ``outcomes.read`` (MEMBER) so
+# the pocket-outcomes count router (ee.cloud.outcomes) can guard
+# ``GET /api/v1/outcomes``.
 
 from __future__ import annotations
 
@@ -191,6 +195,12 @@ ACTIONS: dict[str, ActionRule] = {
     # and the install accepts an uploaded document, so it should not be
     # open to every member.
     "skills.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Outcomes — workspace-scoped pocket-outcome count surface
+    # (ee.cloud.outcomes, RFC 05 M2b.2). MEMBER: an outcome count is a
+    # non-sensitive activity metric (how many "renewal_completed" events a
+    # pocket produced), with no credentials or decision payloads — any
+    # workspace member may view it, mirroring instinct.read.
+    "outcomes.read": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
 }
 
 

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -28,6 +28,13 @@
 #   POST /instinct/actions/bulk-reject. Bulk endpoints write N audit rows with
 #   a shared ``bulk_id`` UUID so the bulk transaction is replay-able per item
 #   and query-able as a unit.
+# Updated: 2026-05-22 (RFC 05 M2b.1) — ``approve_action`` now fires a parked
+#   pocket write. When the approved Action's ``parameters`` carries a
+#   ``_pocket_write`` blob, the route lazy-imports
+#   ``ee.cloud.pockets.instinct_bridge`` and calls ``execute_approved_write``
+#   — best-effort, failures recorded on the Action, never breaking the
+#   approve response. A lazy import avoids an instinct→pockets module-top
+#   dependency.
 
 from __future__ import annotations
 
@@ -359,6 +366,21 @@ async def approve_action(action_id: str, req: ApproveRequest | None = None):
     approved = await store.approve(action_id, approver=req.approver)
     if not approved:
         raise HTTPException(404, "Action not found")
+
+    # RFC 05 M2b.1 — when the approved Action carries a parked pocket
+    # write (``parameters._pocket_write``), fire it. Best-effort: a
+    # lazy import keeps the instinct package free of a module-top
+    # dependency on ee.cloud.pockets, and any failure is recorded on the
+    # Action by the bridge itself — it must NEVER break this approve
+    # response. A non-pocket-write Action (the common case) skips this.
+    if isinstance(approved.parameters, dict) and "_pocket_write" in approved.parameters:
+        try:
+            from pocketpaw_ee.cloud.pockets import instinct_bridge
+
+            await instinct_bridge.execute_approved_write(approved)
+        except Exception:
+            logger.exception("pocket-write execution after approval failed (non-fatal)")
+
     return ApproveResponse(action=approved, correction=correction)
 
 

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -35,6 +35,23 @@
 #   — best-effort, failures recorded on the Action, never breaking the
 #   approve response. A lazy import avoids an instinct→pockets module-top
 #   dependency.
+# Updated: 2026-05-22 (security-review fixes for PR #1183) —
+#   * BLOCKER 1: ``approve_action`` and ``bulk_approve_actions`` now
+#     verify a parked ``_pocket_write`` belongs to the approver's active
+#     workspace. ``require_action_any_workspace`` only checks the caller
+#     holds the role somewhere; it does NOT bind the action to a
+#     workspace. ``_assert_pocket_write_workspace`` raises ``Forbidden``
+#     (403) when ``blob["workspace_id"]`` differs from the caller's
+#     active workspace, closing a cross-tenant approval-escalation gap.
+#   * BLOCKER 2: ``bulk_approve_actions`` now mirrors the single-approve
+#     hook — every bulk-approved Action carrying a ``_pocket_write`` blob
+#     fires ``execute_approved_write`` best-effort, so bulk-approved
+#     pocket writes actually execute instead of silently stalling at
+#     ``approved``.
+#   * SHOULD-FIX 1: the audit ``approved_by``/``actor`` and the outcome
+#     actor are now the AUTHENTICATED user id, not the free-text
+#     ``approver`` request field — a caller can no longer forge the
+#     audit actor. The request field stays for display only.
 
 from __future__ import annotations
 
@@ -59,11 +76,58 @@ from pocketpaw.instinct.models import (
     AuditEntry,
 )
 from pocketpaw.instinct.trace import FabricObjectSnapshot, ReasoningTrace
-from pocketpaw_ee.cloud._core.deps import require_plan_feature
+from pocketpaw_ee.cloud._core.deps import (
+    current_user,
+    current_workspace_id,
+    require_plan_feature,
+)
+from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.shared.deps import require_action_any_workspace
 
 logger = logging.getLogger(__name__)
+
+
+def _pocket_write_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_pocket_write`` blob on an Action, or ``None``.
+
+    The blob is the parked-write payload ``instinct_bridge`` stores under
+    ``Action.parameters._pocket_write`` (method/path/params/idempotency/
+    outcome + the originating ``workspace_id``). Anything that is not a
+    dict-of-dict shape is treated as "no parked write".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_pocket_write")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_pocket_write_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving a parked pocket write from another workspace.
+
+    ``require_action_any_workspace("instinct.approve")`` only proves the
+    caller holds ``instinct.approve`` in SOME workspace — it does not bind
+    the Action being approved to that workspace, and the
+    ``instinct_actions`` table has no ``workspace_id`` column. Without this
+    check a caller with ``instinct.approve`` in workspace A could approve
+    a workspace-B parked write and trigger a cross-tenant backend write.
+
+    When the Action carries a ``_pocket_write`` blob whose ``workspace_id``
+    differs from the caller's active workspace, raise ``Forbidden`` (403).
+    A non-pocket-write Action (no blob) is unaffected — instinct's other
+    Action kinds are not tenant-bound by this column.
+    """
+    blob = _pocket_write_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if blob_workspace and blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This action's pocket write belongs to a different workspace",
+        )
+
 
 router = APIRouter(
     tags=["Instinct"],
@@ -290,7 +354,11 @@ async def list_actions(
     response_model=BulkActionResponse,
     dependencies=[Depends(require_action_any_workspace("instinct.approve"))],
 )
-async def bulk_approve_actions(req: BulkApproveRequest) -> BulkActionResponse:
+async def bulk_approve_actions(
+    req: BulkApproveRequest,
+    user: Any = Depends(current_user),
+    workspace_id: str = Depends(current_workspace_id),
+) -> BulkActionResponse:
     """Approve N pending actions in one call.
 
     Each item is flipped individually (so per-item audit replay still
@@ -300,10 +368,52 @@ async def bulk_approve_actions(req: BulkApproveRequest) -> BulkActionResponse:
     are missing or already resolved come back in ``missing`` rather than
     raising — a partial-success surface beats a single all-or-nothing
     failure on the operator console.
+
+    Security (PR #1183):
+      * BLOCKER 1 — before flipping anything, every requested Action is
+        loaded and any parked ``_pocket_write`` is checked against the
+        caller's active workspace. A single cross-workspace item fails
+        the whole call with 403 — a partial bulk that silently dropped
+        the foreign item would hide the escalation attempt.
+      * BLOCKER 2 — after the flip, each approved Action carrying a
+        ``_pocket_write`` blob fires ``execute_approved_write`` so
+        bulk-approved pocket writes actually execute (the single-approve
+        hook is the template).
+      * SHOULD-FIX 1 — the audit actor is the authenticated user id, not
+        the free-text ``req.approver`` field.
     """
-    approved, missing, bulk_id = await _store().bulk_approve(
-        list(req.ids), approver=req.approver, note=req.note
+    store = _store()
+    approver_id = str(user.id)
+
+    # BLOCKER 1 — verify tenancy on every requested action up front. A
+    # missing id simply has no blob to check; it falls through to
+    # ``bulk_approve`` and lands in ``missing``.
+    for action_id in req.ids:
+        action = await store.get_action(action_id)
+        if action is not None:
+            _assert_pocket_write_workspace(action, workspace_id)
+
+    approved, missing, bulk_id = await store.bulk_approve(
+        list(req.ids), approver=approver_id, note=req.note
     )
+
+    # BLOCKER 2 — bulk-approved pocket writes must fire, exactly like the
+    # single-approve hook. Best-effort per item: a lazy import keeps the
+    # instinct package free of a module-top dependency on ee.cloud.pockets,
+    # and any failure is recorded on the Action by the bridge — it must
+    # never break the bulk response.
+    for action in approved:
+        if _pocket_write_blob(action) is not None:
+            try:
+                from pocketpaw_ee.cloud.pockets import instinct_bridge
+
+                await instinct_bridge.execute_approved_write(action)
+            except Exception:
+                logger.exception(
+                    "bulk-approve pocket-write execution failed for %s (non-fatal)",
+                    action.id,
+                )
+
     return BulkActionResponse(bulk_id=bulk_id, affected=approved, missing=missing)
 
 
@@ -332,19 +442,40 @@ async def bulk_reject_actions(req: BulkRejectRequest) -> BulkActionResponse:
     response_model=ApproveResponse,
     dependencies=[Depends(require_action_any_workspace("instinct.approve"))],
 )
-async def approve_action(action_id: str, req: ApproveRequest | None = None):
+async def approve_action(
+    action_id: str,
+    req: ApproveRequest | None = None,
+    user: Any = Depends(current_user),
+    workspace_id: str = Depends(current_workspace_id),
+):
     """Approve a pending action, optionally with edits.
 
     If the request body carries edits, the server diffs the stored proposal
     against the incoming shape and persists a Correction alongside the
     approval. Callers that want to approve unchanged can POST with no body.
+
+    Security (PR #1183):
+      * BLOCKER 1 — a parked ``_pocket_write`` must belong to the
+        approver's active workspace, else 403.
+      * SHOULD-FIX 1 — the audit actor + outcome actor are the
+        authenticated user id, never the free-text ``req.approver``.
     """
     store = _store()
     before = await store.get_action(action_id)
     if not before:
         raise HTTPException(404, "Action not found")
 
+    # BLOCKER 1 — reject a cross-workspace parked-write approval before
+    # any state mutation. ``require_action_any_workspace`` only proved the
+    # caller holds ``instinct.approve`` somewhere; this binds the Action
+    # to the caller's workspace.
+    _assert_pocket_write_workspace(before, workspace_id)
+
     req = req or ApproveRequest()
+    # SHOULD-FIX 1 — the audit actor is the authenticated identity, not
+    # the request body's free-text ``approver``. The body field may still
+    # carry a display label, but it can never forge the audit trail.
+    approver_id = str(user.id)
     after, edited_fields = _apply_edits(before, req)
 
     correction: Correction | None = None
@@ -354,7 +485,7 @@ async def approve_action(action_id: str, req: ApproveRequest | None = None):
             correction = Correction(
                 action_id=before.id,
                 pocket_id=before.pocket_id,
-                actor=req.approver,
+                actor=approver_id,
                 patches=patches,
                 context_summary=summarize_correction(before, patches),
                 action_title=before.title,
@@ -363,7 +494,7 @@ async def approve_action(action_id: str, req: ApproveRequest | None = None):
             await _persist_edits(store, after, edited_fields)
             await _forward_to_soul(correction, after)
 
-    approved = await store.approve(action_id, approver=req.approver)
+    approved = await store.approve(action_id, approver=approver_id)
     if not approved:
         raise HTTPException(404, "Action not found")
 
@@ -373,7 +504,7 @@ async def approve_action(action_id: str, req: ApproveRequest | None = None):
     # dependency on ee.cloud.pockets, and any failure is recorded on the
     # Action by the bridge itself — it must NEVER break this approve
     # response. A non-pocket-write Action (the common case) skips this.
-    if isinstance(approved.parameters, dict) and "_pocket_write" in approved.parameters:
+    if _pocket_write_blob(approved) is not None:
         try:
             from pocketpaw_ee.cloud.pockets import instinct_bridge
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -176,6 +176,10 @@ source_modules = [
     "pocketpaw_ee.cloud.pockets._http_guard",
     "pocketpaw_ee.cloud.pockets.action_executor",
     "pocketpaw_ee.cloud.pockets.actions_ops",
+    # RFC 05 M2b.1 — the instinct bridge proposes/executes parked writes
+    # through `pockets.service` and the Instinct store; it never touches
+    # Beanie document classes directly.
+    "pocketpaw_ee.cloud.pockets.instinct_bridge",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.pocket",

--- a/tests/cloud/test_instinct_approval_security.py
+++ b/tests/cloud/test_instinct_approval_security.py
@@ -1,0 +1,356 @@
+# tests/cloud/test_instinct_approval_security.py — PR #1183 security-review.
+# Created: 2026-05-22 — regression coverage for the security-review fixes
+# on the Instinct routing + outcome-emission PR:
+#
+#   BLOCKER 1   — a workspace-A approver gets 403 approving a workspace-B
+#                 `_pocket_write` action, on BOTH the single-approve and
+#                 the bulk-approve routes.
+#   BLOCKER 2   — bulk-approving a `_pocket_write` action actually fires
+#                 `execute_approved_write`; the action reaches `executed`.
+#   SHOULD-FIX 1— the audit `approved_by` actor is the authenticated user
+#                 id, not the free-text `approver` request field.
+#   SHOULD-FIX 3— `count_outcomes` does not count a row whose
+#                 `workspace_id` is another workspace's.
+#
+# Router tests are sync and drive the API entirely over HTTP (seed via
+# POST /instinct/actions, read back via GET /instinct/actions) so the
+# TestClient owns the only event loop. SHOULD-FIX 3 is a plain async
+# service test. `pocketpaw_ee` is import-skipped on an OSS-only install.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.cloud.outcomes import service as outcomes_service  # noqa: E402
+from pocketpaw_ee.cloud.outcomes.dto import CountOutcomesRequest  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+TRIGGER = {"type": "agent", "source": "claude", "reason": "security test"}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — a router-level TestClient with seeded auth + a CloudError handler
+# ---------------------------------------------------------------------------
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    """Duck-typed User. ``id`` is the authenticated identity; the
+    audit/outcome actor must resolve to THIS, never the request body."""
+
+    def __init__(self, user_id: str = "user-A", workspace_id: str = "ws-A") -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+def _pocket_write_params(workspace_id: str, outcome: str | None = "renewal_completed") -> dict:
+    """An Action ``parameters`` payload carrying a parked pocket write — the
+    shape ``instinct_bridge.propose_pocket_write`` stores."""
+    return {
+        "_pocket_write": {
+            "schema": 1,
+            "action": "mark_renewed",
+            "method": "POST",
+            "path": "/leases/42/renew",
+            "params": {"rent": 2000},
+            "idempotency_key": "idem-xyz",
+            "outcome": outcome,
+            "workspace_id": workspace_id,
+            "requested_by": "requester-9",
+        }
+    }
+
+
+@pytest.fixture
+def router_store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "approval_security.db")
+
+
+def _make_client(router_store: InstinctStore, user: _FakeUser, monkeypatch) -> TestClient:
+    """Build a TestClient over the instinct router with a CloudError handler
+    registered so a ``Forbidden`` maps to a 403 (not a 500)."""
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app)
+
+
+def _propose(client: TestClient, *, pocket_id: str, title: str, parameters: dict | None = None):
+    """Seed a pending action over HTTP and return its id."""
+    payload: dict = {"pocket_id": pocket_id, "title": title, "trigger": TRIGGER}
+    if parameters is not None:
+        payload["parameters"] = parameters
+    resp = client.post("/instinct/actions", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _status_of(client: TestClient, action_id: str) -> str:
+    """Read an action's current status back over HTTP."""
+    resp = client.get("/instinct/actions", params={"limit": 500})
+    assert resp.status_code == 200, resp.text
+    for action in resp.json()["actions"]:
+        if action["id"] == action_id:
+            return action["status"]
+    raise AssertionError(f"action {action_id} not found")
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER 1 — cross-tenant approval escalation
+# ---------------------------------------------------------------------------
+
+
+class TestBlocker1CrossTenantApproval:
+    def test_single_approve_of_foreign_workspace_pocket_write_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A ws-A approver POSTing /approve on an action whose parked write
+        belongs to ws-B is forbidden — the action stays pending."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-B",
+                title="ws-B write",
+                parameters=_pocket_write_params(workspace_id="ws-B"),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, action_id) == "pending"
+
+    def test_single_approve_of_own_workspace_pocket_write_succeeds(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A ws-A approver may approve a ws-A parked write — the workspace
+        check does not block a same-tenant approval."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+
+        async def _noop_execute(_action):
+            return None
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.cloud.pockets.instinct_bridge.execute_approved_write",
+            _noop_execute,
+        )
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A write",
+                parameters=_pocket_write_params(workspace_id="ws-A"),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["action"]["status"] == "approved"
+
+    def test_bulk_approve_of_foreign_workspace_pocket_write_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A ws-A approver bulk-approving a list that contains a ws-B parked
+        write is forbidden — and no action in the batch flips."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            own = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A write",
+                parameters=_pocket_write_params(workspace_id="ws-A"),
+            )
+            foreign = _propose(
+                client,
+                pocket_id="pocket-B",
+                title="ws-B write",
+                parameters=_pocket_write_params(workspace_id="ws-B"),
+            )
+            resp = client.post(
+                "/instinct/actions/bulk-approve",
+                json={"ids": [own, foreign]},
+            )
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            # The whole batch is rejected — nothing flipped.
+            assert _status_of(client, own) == "pending"
+            assert _status_of(client, foreign) == "pending"
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER 2 — bulk-approve must fire parked pocket writes
+# ---------------------------------------------------------------------------
+
+
+class TestBlocker2BulkApproveFiresWrites:
+    def test_bulk_approve_fires_pocket_write_and_action_reaches_executed(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A bulk-approved `_pocket_write` action runs through
+        `execute_approved_write`; the executor is re-entered with
+        from_instinct=True and the action lands at EXECUTED."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        captured: dict = {}
+
+        async def _get_creds(workspace_id, pocket_id):
+            return ("https://api.example.com", "bearer", None, "tok", [], None)
+
+        async def _run_action(**kwargs):
+            captured.update(kwargs)
+            return {"ok": True, "action": kwargs["action"], "status": 200, "response": {}}
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor", _get_creds
+        )
+        monkeypatch.setattr("pocketpaw_ee.cloud.pockets.action_executor.run_action", _run_action)
+        # The bridge lazy-imports get_instinct_store from pocketpaw.stores —
+        # point it at the same router_store so propose + execute share state.
+        monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A write",
+                parameters=_pocket_write_params(workspace_id="ws-A"),
+            )
+            resp = client.post("/instinct/actions/bulk-approve", json={"ids": [action_id]})
+            assert resp.status_code == 200, resp.text
+            assert len(resp.json()["affected"]) == 1
+
+            # The write actually fired — re-entered the executor.
+            assert captured.get("from_instinct") is True
+            assert captured.get("action") == "mark_renewed"
+            # The action reached EXECUTED (the bridge's mark_executed).
+            assert _status_of(client, action_id) == "executed"
+
+    def test_bulk_approve_pocket_write_failure_does_not_break_response(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A crash inside `execute_approved_write` is swallowed — the bulk
+        response still returns 200."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+
+        async def _boom(_action):
+            raise RuntimeError("bridge blew up")
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.cloud.pockets.instinct_bridge.execute_approved_write", _boom
+        )
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A write",
+                parameters=_pocket_write_params(workspace_id="ws-A"),
+            )
+            resp = client.post("/instinct/actions/bulk-approve", json={"ids": [action_id]})
+            assert resp.status_code == 200, resp.text
+            assert len(resp.json()["affected"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# SHOULD-FIX 1 — the audit actor is the authenticated user, not the body
+# ---------------------------------------------------------------------------
+
+
+class TestShouldFix1AuthenticatedActor:
+    def test_single_approve_audit_actor_is_authenticated_user(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A request body with `approver="admin"` cannot forge the audit
+        actor — the `approved_by` + audit row carry the authenticated id."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(client, pocket_id="pocket-A", title="plain action")
+            resp = client.post(
+                f"/instinct/actions/{action_id}/approve",
+                json={"approver": "admin"},  # forged actor attempt
+            )
+            assert resp.status_code == 200, resp.text
+            # The persisted Action records the authenticated id.
+            assert resp.json()["action"]["approved_by"] == "user-A"
+
+            # The audit row's actor is the authenticated id, never "admin".
+            audit = client.get("/instinct/audit", params={"pocket_id": "pocket-A"})
+            assert audit.status_code == 200, audit.text
+            approved_rows = [e for e in audit.json()["entries"] if e["event"] == "action_approved"]
+            assert len(approved_rows) == 1
+            assert approved_rows[0]["actor"] == "user-A"
+            assert approved_rows[0]["actor"] != "admin"
+
+    def test_bulk_approve_audit_actor_is_authenticated_user(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """Bulk-approve also stamps the authenticated id, ignoring a forged
+        `approver` field in the body."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(client, pocket_id="pocket-A", title="plain action")
+            resp = client.post(
+                "/instinct/actions/bulk-approve",
+                json={"ids": [action_id], "approver": "admin"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["affected"][0]["approved_by"] == "user-A"
+
+            audit = client.get("/instinct/audit", params={"pocket_id": "pocket-A"})
+            assert audit.status_code == 200, audit.text
+            approved_rows = [e for e in audit.json()["entries"] if e["event"] == "action_approved"]
+            assert len(approved_rows) == 1
+            assert approved_rows[0]["actor"] == "user-A"
+
+
+# ---------------------------------------------------------------------------
+# SHOULD-FIX 3 — count_outcomes ignores a foreign-workspace row
+# ---------------------------------------------------------------------------
+
+
+async def test_count_outcomes_skips_foreign_workspace_rows(tmp_path: Path) -> None:
+    """A ledger row carrying another workspace's id (a corrupt or
+    hand-edited line) is not counted into this workspace's totals."""
+    import json
+
+    outcomes_service.set_ledger_dir(tmp_path / "outcomes")
+    try:
+        ledger = outcomes_service._ledger_path("ws-A")
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        rows = [
+            {"outcome": "real", "pocket_id": "p1", "workspace_id": "ws-A"},
+            # A line that drifted in from another tenant — must NOT count.
+            {"outcome": "leaked", "pocket_id": "p9", "workspace_id": "ws-B"},
+            {"outcome": "real2", "pocket_id": "p2", "workspace_id": "ws-A"},
+        ]
+        with ledger.open("w", encoding="utf-8") as fh:
+            for row in rows:
+                fh.write(json.dumps(row) + "\n")
+
+        counts = await outcomes_service.count_outcomes("ws-A", CountOutcomesRequest())
+        assert counts.total == 2
+        assert counts.by_outcome == {"real": 1, "real2": 1}
+        assert "leaked" not in counts.by_outcome
+    finally:
+        outcomes_service.set_ledger_dir("~/.pocketpaw/outcomes")

--- a/tests/cloud/test_pocket_action_executor.py
+++ b/tests/cloud/test_pocket_action_executor.py
@@ -26,6 +26,15 @@
 #   - N1: a DELETE with empty params sends NO request body; a DELETE with
 #     params still does.
 #   - The happy path returns the backend's parsed JSON + on_success.
+#
+# Updated: 2026-05-22 (RFC 05 M2b.1 — Instinct routing) — the M2a
+# fail-closed `instinct_required` reject is gone. `ActionBinding` now
+# DECLARES `requires_instinct` / `instinct_policy` / `outcome`, with a
+# validator that rejects an `instinct_policy` set without
+# `requires_instinct`. A `requires_instinct` write now PARKS — `run_action`
+# returns `code:"instinct_pending"` with the resolved write under `_park`
+# and makes NO call. `from_instinct=True` skips the gate. A successful
+# write result carries the binding's `outcome`.
 
 from __future__ import annotations
 
@@ -104,10 +113,9 @@ def test_action_binding_parses_minimal():
     assert binding.on_error == []
 
 
-def test_action_binding_ignores_m2b_governance_fields():
-    """`requires_instinct` / `instinct_policy` / `outcome` are M2b fields —
-    ActionBinding ignores them on parse (extra: ignore) so an M2b-authored
-    spec stays parseable by the M2a runtime."""
+def test_action_binding_declares_m2b_governance_fields():
+    """`requires_instinct` / `instinct_policy` / `outcome` are now REAL
+    declared fields on ActionBinding (RFC 05 M2b.1) — parsed, not dropped."""
     raw = {
         **_write_action(),
         "requires_instinct": True,
@@ -115,10 +123,27 @@ def test_action_binding_ignores_m2b_governance_fields():
         "outcome": "renewal_completed",
     }
     binding = ActionBinding.model_validate(raw)
-    # The governance fields are dropped, not declared on the model.
-    assert not hasattr(binding, "requires_instinct")
-    assert "requires_instinct" not in binding.model_dump()
-    assert "outcome" not in binding.model_dump()
+    assert binding.requires_instinct is True
+    assert binding.instinct_policy == "approve_per_row"
+    assert binding.outcome == "renewal_completed"
+    dumped = binding.model_dump()
+    assert dumped["requires_instinct"] is True
+    assert dumped["outcome"] == "renewal_completed"
+
+
+def test_action_binding_defaults_governance_fields_off():
+    """A plain binding has the gate off, no policy, no outcome."""
+    binding = ActionBinding.model_validate(_write_action())
+    assert binding.requires_instinct is False
+    assert binding.instinct_policy is None
+    assert binding.outcome is None
+
+
+def test_action_binding_policy_without_gate_is_invalid():
+    """An `instinct_policy` set without `requires_instinct` is a
+    misconfiguration — the model_validator rejects the binding."""
+    with pytest.raises(Exception):
+        ActionBinding.model_validate({**_write_action(), "instinct_policy": "approve_per_row"})
 
 
 def test_action_binding_rejects_non_write_verb():
@@ -127,13 +152,14 @@ def test_action_binding_rejects_non_write_verb():
 
 
 # ---------------------------------------------------------------------------
-# Instinct-reject (fail-closed)
+# Instinct park (M2b.1)
 # ---------------------------------------------------------------------------
 
 
-async def test_instinct_required_rejects_before_any_call(monkeypatch):
-    """A truthy raw `requires_instinct` is rejected with code
-    `instinct_required` and NO HTTP call is made."""
+async def test_instinct_required_parks_before_any_call(monkeypatch):
+    """A `requires_instinct` write is PARKED — `run_action` returns
+    `code:"instinct_pending"` with the resolved write under `_park` and
+    makes NO HTTP call."""
     called = {"hit": False}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -142,6 +168,75 @@ async def test_instinct_required_rejects_before_any_call(monkeypatch):
 
     _mock_client_patch(monkeypatch, handler)
 
+    raw = {**_write_action(), "requires_instinct": True, "outcome": "renewal_completed"}
+    result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="mark_renewed",
+        raw_action=raw,
+        path="/leases/42/renew",
+        params={"rent": 2000},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert result["ok"] is True
+    assert result["code"] == "instinct_pending"
+    assert called["hit"] is False
+    # The resolved write rides on `_park` for the bridge to propose.
+    park = result["_park"]
+    assert park["action"] == "mark_renewed"
+    assert park["method"] == "POST"
+    assert park["path"] == "/leases/42/renew"
+    assert park["params"] == {"rent": 2000}
+    assert park["outcome"] == "renewal_completed"
+
+
+async def test_instinct_required_allowlist_miss_rejected_not_parked(monkeypatch):
+    """A `requires_instinct` write the allowlist would reject is REJECTED
+    at park time — an off-policy write must never reach the approval
+    surface looking legitimate."""
+    called = {"hit": False}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["hit"] = True
+        return httpx.Response(200, json={})
+
+    _mock_client_patch(monkeypatch, handler)
+    result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="del",
+        raw_action={**_write_action("POST", "/users/9/delete"), "requires_instinct": True},
+        path="/users/9/delete",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow("POST", "/leases/*/renew"),
+    )
+    # NOT parked — a plain `not_allowed` rejection.
+    assert result["ok"] is False
+    assert result["code"] == "not_allowed"
+    assert "_park" not in result
+    assert called["hit"] is False
+
+
+async def test_from_instinct_skips_the_park_gate(monkeypatch):
+    """`from_instinct=True` (a post-approval re-entry) skips the park gate
+    and fires the write — every OTHER gate still runs."""
+    called = {"hit": False}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["hit"] = True
+        return httpx.Response(200, json={"renewed": True})
+
+    _mock_client_patch(monkeypatch, handler)
     raw = {**_write_action(), "requires_instinct": True}
     result = await run_action(
         workspace_id="w1",
@@ -156,23 +251,25 @@ async def test_instinct_required_rejects_before_any_call(monkeypatch):
         auth_header=None,
         token="",
         allowed_writes=_allow(),
+        from_instinct=True,
     )
-    assert result["ok"] is False
-    assert result["code"] == "instinct_required"
-    assert called["hit"] is False
+    assert result["ok"] is True
+    # A fired write carries no `code` — the pending sentinel was skipped.
+    assert result.get("code") != "instinct_pending"
+    assert result["response"] == {"renewed": True}
+    assert called["hit"] is True
 
 
-async def test_instinct_policy_alone_does_not_reject(monkeypatch):
-    """`instinct_policy` without a truthy `requires_instinct` does NOT
-    trigger the fail-closed gate — only `requires_instinct` does."""
+async def test_successful_write_carries_outcome(monkeypatch):
+    """A fired write result carries the binding's declared `outcome` for
+    M2b.2 emission; a binding with no outcome carries None."""
     _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
-    raw = {**_write_action(), "instinct_policy": "approve_per_row"}
-    result = await run_action(
+    with_outcome = await run_action(
         workspace_id="w1",
         pocket_id="p1",
         user_id="u1",
-        action="mark_renewed",
-        raw_action=raw,
+        action="a",
+        raw_action={**_write_action(), "outcome": "renewal_completed"},
         path="/leases/42/renew",
         params={},
         base_url=BASE,
@@ -181,7 +278,22 @@ async def test_instinct_policy_alone_does_not_reject(monkeypatch):
         token="",
         allowed_writes=_allow(),
     )
-    assert result["ok"] is True
+    assert with_outcome["outcome"] == "renewal_completed"
+    no_outcome = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="a",
+        raw_action=_write_action(),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert no_outcome["outcome"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_pocket_actions_ops.py
+++ b/tests/cloud/test_pocket_actions_ops.py
@@ -260,9 +260,9 @@ async def test_agent_set_action_requires_a_key(fake_doc):
 
 
 async def test_agent_set_action_carries_governance_fields_through(fake_doc):
-    """M2b governance fields (``requires_instinct`` / ``outcome``) are
-    CARRIED THROUGH on the persisted binding even though ``ActionBinding``
-    ignores them on parse — an M2b-aware client can author them now."""
+    """M2b governance fields (``requires_instinct`` / ``outcome``) survive
+    on the persisted binding. RFC 05 M2b.1 promoted them to real declared
+    ``ActionBinding`` fields, so they round-trip through validation."""
     ctx, _ = _patches(fake_doc)
     binding = {
         **_VALID_BINDING,

--- a/tests/cloud/test_pocket_agent_backend_view.py
+++ b/tests/cloud/test_pocket_agent_backend_view.py
@@ -104,9 +104,11 @@ async def test_agent_view_includes_configured_backend_summary(mongo_db, agent_id
         "base_url": "https://jsonplaceholder.typicode.com",
         "auth_type": "none",
         "configured": True,
-        # RFC 05 M2a: the summary now carries the write allowlist —
-        # empty by default (fail-closed).
+        # RFC 05 M2a: the summary carries the write allowlist (empty by
+        # default — fail-closed). RFC 05 M2b.1: and the approval route
+        # (None by default — the owner approves).
         "allowed_writes": [],
+        "approval_route": None,
     }
 
 
@@ -134,8 +136,15 @@ async def test_agent_view_backend_summary_never_leaks_the_token(mongo_db, agent_
     assert backend["configured"] is True
     assert backend["auth_type"] == "bearer"
     # The summary carries only non-secret keys (RFC 05 M2a adds
-    # `allowed_writes` — the write allowlist, also non-secret).
-    assert set(backend) == {"base_url", "auth_type", "configured", "allowed_writes"}
+    # `allowed_writes` — the write allowlist; M2b.1 adds `approval_route`
+    # — the gated-write approver routing — both non-secret).
+    assert set(backend) == {
+        "base_url",
+        "auth_type",
+        "configured",
+        "allowed_writes",
+        "approval_route",
+    }
     # The token must not appear anywhere in the serialized view.
     import json
 
@@ -192,8 +201,10 @@ async def test_fetch_pocket_for_agent_carries_backend_summary(mongo_db, agent_id
         "base_url": "https://jsonplaceholder.typicode.com",
         "auth_type": "none",
         "configured": True,
-        # RFC 05 M2a: the summary now carries the write allowlist.
+        # RFC 05 M2a: the summary carries the write allowlist; M2b.1
+        # adds the approval route (None — the owner approves).
         "allowed_writes": [],
+        "approval_route": None,
     }
 
 

--- a/tests/cloud/test_pocket_backend_routes.py
+++ b/tests/cloud/test_pocket_backend_routes.py
@@ -103,6 +103,9 @@ def test_put_backend_configures(monkeypatch, client):
         # RFC 05 M2a: the response now carries the write allowlist —
         # empty by default (fail-closed).
         "allowed_writes": [],
+        # RFC 05 M2b.1: the response carries the gated-write approval
+        # route — None by default (the pocket owner approves).
+        "approval_route": None,
     }
     # The route forwarded the right identity + body to the service.
     assert captured["workspace_id"] == FAKE_WORKSPACE
@@ -226,8 +229,9 @@ def test_run_sources_happy_path(monkeypatch, client):
         return {"_id": pocket_id, "rippleSpec": spec}
 
     async def _get_creds(workspace_id, pocket_id):
-        # RFC 05 M2a: 5-tuple — the trailing element is the write allowlist.
-        return ("https://api.example.com", "bearer", None, "tok", [])
+        # RFC 05 M2b.1: 6-tuple — trailing elements are the write
+        # allowlist and the approval route (None = owner approves).
+        return ("https://api.example.com", "bearer", None, "tok", [], None)
 
     monkeypatch.setattr(pockets_service, "get", _get_pocket)
     monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _get_creds)
@@ -354,12 +358,14 @@ def test_run_action_happy_path(monkeypatch, client):
         return {"_id": pocket_id, "rippleSpec": spec}
 
     async def _get_creds(workspace_id, pocket_id):
+        # RFC 05 M2b.1: 6-tuple — write allowlist + approval route.
         return (
             "https://api.example.com",
             "bearer",
             None,
             "tok",
             [{"method": "POST", "path_pattern": "/leases/*/renew"}],
+            None,
         )
 
     monkeypatch.setattr(pockets_service, "get", _get_pocket)
@@ -459,3 +465,192 @@ def test_run_action_forbidden_for_non_invited(monkeypatch):
 
     res = TestClient(a).post("/pockets/pocket-1/actions/run", json={"action": "a", "path": "/x"})
     assert res.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# RFC 05 M2b.1 — instinct-pending routing on POST /actions/run
+# ---------------------------------------------------------------------------
+
+
+def _instinct_spec() -> dict:
+    return {
+        "actions": {
+            "mark_renewed": {
+                "kind": "write_binding",
+                "method": "POST",
+                "path": "/leases/{item.id}/renew",
+                "requires_instinct": True,
+                "outcome": "renewal_completed",
+            }
+        }
+    }
+
+
+def test_run_action_instinct_pending_routes_to_bridge(monkeypatch, client):
+    """A `requires_instinct` write: the executor returns the
+    `instinct_pending` sentinel, the route calls
+    `instinct_bridge.propose_pocket_write`, and the response carries
+    `code:"instinct_pending"` + `proposed_action_id`."""
+
+    async def _get_pocket(pocket_id, user_id):
+        return {
+            "_id": pocket_id,
+            "workspace": FAKE_WORKSPACE,
+            "owner": FAKE_USER,
+            "rippleSpec": _instinct_spec(),
+        }
+
+    async def _get_creds(workspace_id, pocket_id):
+        return ("https://api.example.com", "bearer", None, "tok", [], None)
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _get_creds)
+
+    from pocketpaw_ee.cloud.pockets import action_executor, instinct_bridge
+
+    park_blob = {
+        "action": "mark_renewed",
+        "method": "POST",
+        "path": "/leases/42/renew",
+        "params": {},
+        "idempotency_key": None,
+        "outcome": "renewal_completed",
+    }
+
+    async def _run_action(**kwargs):
+        # The executor parked the write — no HTTP call.
+        return {
+            "ok": True,
+            "code": "instinct_pending",
+            "action": kwargs["action"],
+            "_park": park_blob,
+            "on_success": [],
+            "on_error": [],
+        }
+
+    proposed = {}
+
+    async def _propose(**kwargs):
+        proposed.update(kwargs)
+        return "act_pending_123"
+
+    monkeypatch.setattr(action_executor, "run_action", _run_action)
+    monkeypatch.setattr(instinct_bridge, "propose_pocket_write", _propose)
+
+    res = client.post(
+        "/pockets/pocket-1/actions/run",
+        json={"action": "mark_renewed", "path": "/leases/42/renew"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ok"] is True
+    assert body["code"] == "instinct_pending"
+    assert body["proposed_action_id"] == "act_pending_123"
+    # The route handed the parked write to the bridge.
+    assert proposed["parked_write"] == park_blob
+    assert proposed["requested_by"] == FAKE_USER
+
+
+def test_run_action_direct_write_emits_outcome(monkeypatch, client):
+    """A fired (non-gated) write whose binding declares an `outcome`
+    emits a `pocket.outcome` event via the outcomes service."""
+    spec = {
+        "actions": {
+            "mark_renewed": {
+                "kind": "write_binding",
+                "method": "POST",
+                "path": "/leases/{item.id}/renew",
+                "outcome": "renewal_completed",
+            }
+        }
+    }
+
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id, "workspace": FAKE_WORKSPACE, "rippleSpec": spec}
+
+    async def _get_creds(workspace_id, pocket_id):
+        return ("https://api.example.com", "bearer", None, "tok", [], None)
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _get_creds)
+
+    from pocketpaw_ee.cloud.outcomes import service as outcomes_service
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    async def _run_action(**kwargs):
+        return {
+            "ok": True,
+            "action": kwargs["action"],
+            "status": 200,
+            "response": {},
+            "outcome": "renewal_completed",
+            "on_success": [],
+            "on_error": [],
+        }
+
+    emitted = {}
+
+    async def _emit_outcome(**kwargs):
+        emitted.update(kwargs)
+
+    monkeypatch.setattr(action_executor, "run_action", _run_action)
+    monkeypatch.setattr(outcomes_service, "emit_pocket_outcome", _emit_outcome)
+
+    res = client.post(
+        "/pockets/pocket-1/actions/run",
+        json={"action": "mark_renewed", "path": "/leases/42/renew"},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["ok"] is True
+    # The route emitted the outcome with via_instinct=False.
+    assert emitted["outcome"] == "renewal_completed"
+    assert emitted["via_instinct"] is False
+    assert emitted["actor"] == FAKE_USER
+
+
+# ---------------------------------------------------------------------------
+# PUT /pockets/{id}/backend/approval-route — RFC 05 M2b.1
+# ---------------------------------------------------------------------------
+
+
+def test_put_approval_route_sets_named_approver(monkeypatch, client):
+    captured = {}
+
+    async def _set_route(workspace_id, user_id, pocket_id, route):
+        captured.update(route=route, pocket_id=pocket_id)
+        return {
+            "base_url": "https://api.example.com",
+            "auth_type": "bearer",
+            "configured": True,
+            "allowed_writes": [],
+            "approval_route": route,
+        }
+
+    monkeypatch.setattr(pockets_service, "set_pocket_approval_route", _set_route)
+    res = client.put(
+        "/pockets/pocket-1/backend/approval-route",
+        json={"route": {"mode": "user", "user_id": "approver-7"}},
+    )
+    assert res.status_code == 200, res.text
+    assert captured["route"] == {"mode": "user", "user_id": "approver-7"}
+    assert res.json()["approval_route"] == {"mode": "user", "user_id": "approver-7"}
+
+
+def test_put_approval_route_empty_body_clears_route(monkeypatch, client):
+    """An omitted body clears the route — service receives route=None."""
+    captured = {}
+
+    async def _set_route(workspace_id, user_id, pocket_id, route):
+        captured["route"] = route
+        return {
+            "base_url": "https://api.example.com",
+            "auth_type": "none",
+            "configured": True,
+            "allowed_writes": [],
+            "approval_route": None,
+        }
+
+    monkeypatch.setattr(pockets_service, "set_pocket_approval_route", _set_route)
+    res = client.put("/pockets/pocket-1/backend/approval-route", json={})
+    assert res.status_code == 200, res.text
+    assert captured["route"] is None

--- a/tests/cloud/test_pocket_backend_service.py
+++ b/tests/cloud/test_pocket_backend_service.py
@@ -9,6 +9,11 @@
 # `allowed_writes` list and get_pocket_backend_for_executor returns a
 # 5-tuple (the trailing element is the write allowlist). Assertions
 # updated to the new contract.
+# Updated: 2026-05-22 (RFC 05 M2b.1) — the executor tuple is now a
+# 6-tuple (trailing `approval_route`), the summaries carry
+# `approval_route`, and set_pocket_approval_route is covered: it
+# validates a mode=user approver as a workspace member and rejects when
+# the pocket has no backend.
 #
 # What this pins:
 #   - set_pocket_backend then get_pocket_backend returns configured:true
@@ -50,13 +55,16 @@ async def test_set_then_get_backend(mongo_db):
     assert "token" not in result
 
     summary = await pockets_service.get_pocket_backend("w1", "pocket-1")
-    # RFC 05 M2a: the summary now also carries the write allowlist —
-    # empty by default (fail-closed). The token is still never present.
+    # RFC 05 M2a: the summary carries the write allowlist (empty by
+    # default — fail-closed). RFC 05 M2b.1: it also carries the approval
+    # route (None by default — the owner approves). The token is still
+    # never present.
     assert summary == {
         "base_url": "https://api.example.com",
         "auth_type": "bearer",
         "configured": True,
         "allowed_writes": [],
+        "approval_route": None,
     }
     assert "token" not in summary
     assert "encrypted_token" not in summary
@@ -91,12 +99,14 @@ async def test_get_for_executor_decrypts_token(mongo_db):
     )
     creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
     assert creds is not None
-    base_url, auth_type, auth_header, token, allowed_writes = creds
+    base_url, auth_type, auth_header, token, allowed_writes, approval_route = creds
     assert base_url == "https://api.example.com"
     assert auth_type == "api_key"
     assert auth_header == "X-Custom-Key"
     assert token == "my-api-key"
     assert allowed_writes == []
+    # RFC 05 M2b.1: no route set → None (the pocket owner approves).
+    assert approval_route is None
 
 
 async def test_get_for_executor_none_when_unset(mongo_db):
@@ -114,11 +124,13 @@ async def test_get_for_executor_no_token_for_none_auth(mongo_db):
     )
     creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
     assert creds is not None
-    # RFC 05 M2a: the executor tuple gained a trailing `allowed_writes`.
-    _, auth_type, _, token, allowed_writes = creds
+    # RFC 05 M2b.1: the executor tuple is a 6-tuple — trailing elements
+    # are the write allowlist and the approval route.
+    _, auth_type, _, token, allowed_writes, approval_route = creds
     assert auth_type == "none"
     assert token == ""
     assert allowed_writes == []
+    assert approval_route is None
 
 
 async def test_set_backend_upserts(mongo_db):
@@ -234,3 +246,84 @@ async def test_remove_backend_audit_logs(mongo_db, monkeypatch):
     assert event.target == "pocket-1"
     # The token is never part of the audit entry.
     assert "secret-token" not in str(event.context)
+
+
+# ---------------------------------------------------------------------------
+# set_pocket_approval_route — RFC 05 M2b.1
+# ---------------------------------------------------------------------------
+
+
+async def test_set_approval_route_user_mode_validates_membership(mongo_db, monkeypatch):
+    """A mode=user route is stored only when the user_id is a current
+    workspace member; the executor tuple then carries the route."""
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    async def _members(_ws):
+        return ["u1", "approver-7"]
+
+    monkeypatch.setattr(workspace_service, "list_member_ids", _members)
+
+    result = await pockets_service.set_pocket_approval_route(
+        "w1", "u1", "pocket-1", {"mode": "user", "user_id": "approver-7"}
+    )
+    assert result["approval_route"] == {"mode": "user", "user_id": "approver-7"}
+
+    creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
+    assert creds[5] == {"mode": "user", "user_id": "approver-7"}
+
+
+async def test_set_approval_route_rejects_non_member_approver(mongo_db, monkeypatch):
+    """A mode=user route naming a non-member is rejected."""
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    async def _members(_ws):
+        return ["u1"]  # approver-9 is NOT a member
+
+    monkeypatch.setattr(workspace_service, "list_member_ids", _members)
+
+    with pytest.raises(ValidationError):
+        await pockets_service.set_pocket_approval_route(
+            "w1", "u1", "pocket-1", {"mode": "user", "user_id": "approver-9"}
+        )
+
+
+async def test_set_approval_route_owner_mode_stores_none(mongo_db):
+    """An explicit mode=owner route stores None — the default."""
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+    result = await pockets_service.set_pocket_approval_route(
+        "w1", "u1", "pocket-1", {"mode": "owner", "user_id": None}
+    )
+    assert result["approval_route"] is None
+
+
+async def test_set_approval_route_rejects_when_no_backend(mongo_db):
+    """A route with no backend to gate is meaningless — rejected."""
+    with pytest.raises(ValidationError):
+        await pockets_service.set_pocket_approval_route(
+            "w1", "u1", "missing-pocket", {"mode": "user", "user_id": "x"}
+        )

--- a/tests/cloud/test_pocket_instinct_bridge.py
+++ b/tests/cloud/test_pocket_instinct_bridge.py
@@ -1,0 +1,306 @@
+# tests/cloud/test_pocket_instinct_bridge.py — RFC 05 M2b.1.
+# Created: 2026-05-22 — coverage for the Instinct routing bridge: the
+# impure layer that proposes a parked pocket write into an Instinct
+# Action and executes it after a human approval.
+#
+# What this pins:
+#   - propose_pocket_write builds an Instinct Action carrying the
+#     `_pocket_write` blob, with `assignee` defaulting to the pocket
+#     owner — and NO token in the stored parameters.
+#   - `approval_route` mode="user" overrides the assignee.
+#   - execute_approved_write re-loads creds, re-enters run_action with
+#     `from_instinct=True`, and marks the Action executed on success.
+#   - a revoked backend → mark_failed with a `backend_revoked` note,
+#     no write fired.
+#   - a post-approval allowlist miss → mark_failed, no executed status.
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.pockets import instinct_bridge  # noqa: E402
+
+from pocketpaw.instinct.models import ActionCategory, ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    """Isolated InstinctStore on a tmp file, wired into the bridge.
+
+    The bridge lazy-imports ``get_instinct_store`` from
+    ``pocketpaw.stores`` — patch it there so propose / execute share one
+    temp-backed store and never touch ``~/.pocketpaw/instinct.db``.
+    """
+    st = InstinctStore(tmp_path / "instinct_bridge_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+def _pocket(owner: str = "owner-1") -> dict:
+    return {"_id": "pocket-1", "workspace": "w1", "name": "Leases", "owner": owner}
+
+
+def _park(outcome: str | None = "renewal_completed") -> dict:
+    """A parked-write blob — the executor's `_park` sentinel payload."""
+    return {
+        "action": "mark_renewed",
+        "method": "POST",
+        "path": "/leases/42/renew",
+        "params": {"rent": 2000},
+        "idempotency_key": "idem-xyz",
+        "outcome": outcome,
+    }
+
+
+# ---------------------------------------------------------------------------
+# propose_pocket_write
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_builds_action_with_pocket_write_and_owner_assignee(store):
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(owner="owner-1"),
+        backend_config={"base_url": "https://api.example.com", "approval_route": None},
+        parked_write=_park(),
+        requested_by="requester-9",
+    )
+    action = await store.get_action(action_id)
+    assert action is not None
+    assert action.pocket_id == "pocket-1"
+    assert action.status == ActionStatus.PENDING
+    assert action.category == ActionCategory.EXTERNAL
+    # The default approver is the pocket owner.
+    assert action.assignee == "owner-1"
+    # The parked-write blob rode along in parameters.
+    blob = action.parameters["_pocket_write"]
+    assert blob["action"] == "mark_renewed"
+    assert blob["method"] == "POST"
+    assert blob["path"] == "/leases/42/renew"
+    assert blob["outcome"] == "renewal_completed"
+    assert blob["requested_by"] == "requester-9"
+    assert blob["workspace_id"] == "w1"
+
+
+async def test_propose_never_stores_a_token(store):
+    """No credential / token field reaches the Instinct DB — the blob
+    carries only method/path/params/idempotency/outcome + context."""
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(),
+        backend_config={"base_url": "https://api.example.com"},
+        parked_write=_park(),
+        requested_by="requester-9",
+    )
+    action = await store.get_action(action_id)
+    import json
+
+    serialized = json.dumps(action.parameters)
+    assert "token" not in serialized
+    blob = action.parameters["_pocket_write"]
+    assert "token" not in blob
+    assert "auth_token" not in blob
+
+
+async def test_propose_honors_approval_route_user_override(store):
+    """An `approval_route` of mode=user routes the assignee to the named
+    member instead of the owner."""
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(owner="owner-1"),
+        backend_config={
+            "base_url": "https://api.example.com",
+            "approval_route": {"mode": "user", "user_id": "approver-7"},
+        },
+        parked_write=_park(),
+        requested_by="requester-9",
+    )
+    action = await store.get_action(action_id)
+    assert action.assignee == "approver-7"
+
+
+async def test_propose_owner_mode_route_falls_back_to_owner(store):
+    """An explicit mode=owner route resolves to the pocket owner."""
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(owner="owner-1"),
+        backend_config={"approval_route": {"mode": "owner", "user_id": None}},
+        parked_write=_park(),
+        requested_by="requester-9",
+    )
+    action = await store.get_action(action_id)
+    assert action.assignee == "owner-1"
+
+
+# ---------------------------------------------------------------------------
+# execute_approved_write
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_approved_write_fires_and_marks_executed(store, monkeypatch):
+    """A happy-path execution: creds re-loaded, run_action re-entered with
+    from_instinct=True, the Action flipped to EXECUTED."""
+    captured = {}
+
+    async def _get_creds(workspace_id, pocket_id):
+        return ("https://api.example.com", "bearer", None, "tok", [], None)
+
+    async def _run_action(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True, "action": kwargs["action"], "status": 200, "response": {}}
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor", _get_creds
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.action_executor.run_action", _run_action)
+
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(),
+        backend_config=None,
+        parked_write=_park(),
+        requested_by="requester-9",
+    )
+    approved = await store.approve(action_id, approver="owner-1")
+    await instinct_bridge.execute_approved_write(approved)
+
+    # The executor was re-entered with from_instinct=True — the gate is
+    # skipped, the HTTP call is actually made.
+    assert captured["from_instinct"] is True
+    assert captured["action"] == "mark_renewed"
+    assert captured["path"] == "/leases/42/renew"
+    assert captured["token"] == "tok"
+    # The Action is now EXECUTED.
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED
+
+
+async def test_execute_approved_write_revoked_backend_marks_failed(store, monkeypatch):
+    """A backend revoked between propose and approve → the write is NOT
+    fired and the Action is marked failed with a backend_revoked note."""
+    fired = {"hit": False}
+
+    async def _no_creds(workspace_id, pocket_id):
+        return None
+
+    async def _run_action(**kwargs):
+        fired["hit"] = True
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor", _no_creds
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.action_executor.run_action", _run_action)
+
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(),
+        backend_config=None,
+        parked_write=_park(),
+        requested_by="requester-9",
+    )
+    approved = await store.approve(action_id)
+    await instinct_bridge.execute_approved_write(approved)
+
+    assert fired["hit"] is False
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.FAILED
+    assert "backend_revoked" in (final.error or "")
+
+
+async def test_execute_approved_write_allowlist_miss_marks_failed(store, monkeypatch):
+    """A post-approval re-validation rejection (the allowlist no longer
+    covers the write) → the Action is marked failed, never executed."""
+
+    async def _get_creds(workspace_id, pocket_id):
+        return ("https://api.example.com", "bearer", None, "tok", [], None)
+
+    async def _run_action(**kwargs):
+        # The executor rejected the write — the allowlist miss.
+        return {"ok": False, "code": "not_allowed", "error": "not in allowlist"}
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor", _get_creds
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.action_executor.run_action", _run_action)
+
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(),
+        backend_config=None,
+        parked_write=_park(),
+        requested_by="requester-9",
+    )
+    approved = await store.approve(action_id)
+    await instinct_bridge.execute_approved_write(approved)
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.FAILED
+    assert final.status != ActionStatus.EXECUTED
+    assert "not_allowed" in (final.error or "")
+
+
+async def test_execute_approved_write_emits_outcome_on_success(store, monkeypatch):
+    """A gated write that succeeds emits a `pocket.outcome` event with
+    via_instinct=True and the Instinct action id."""
+    emitted = []
+
+    async def _get_creds(workspace_id, pocket_id):
+        return ("https://api.example.com", "bearer", None, "tok", [], None)
+
+    async def _run_action(**kwargs):
+        return {"ok": True, "action": kwargs["action"], "status": 200}
+
+    async def _emit(event):
+        emitted.append(event)
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor", _get_creds
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.action_executor.run_action", _run_action)
+    monkeypatch.setattr("pocketpaw_ee.cloud.outcomes.service.emit", _emit)
+
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(),
+        backend_config=None,
+        parked_write=_park(outcome="renewal_completed"),
+        requested_by="requester-9",
+    )
+    approved = await store.approve(action_id, approver="approver-7")
+    await instinct_bridge.execute_approved_write(approved)
+
+    assert len(emitted) == 1
+    data = emitted[0].data
+    assert data["outcome"] == "renewal_completed"
+    assert data["via_instinct"] is True
+    assert data["instinct_action_id"] == action_id
+    assert data["actor"] == "approver-7"
+
+
+async def test_execute_approved_write_no_outcome_emits_nothing(store, monkeypatch):
+    """A gated write whose binding declared NO outcome emits no event."""
+    emitted = []
+
+    async def _get_creds(workspace_id, pocket_id):
+        return ("https://api.example.com", "bearer", None, "tok", [], None)
+
+    async def _run_action(**kwargs):
+        return {"ok": True, "action": kwargs["action"], "status": 200}
+
+    async def _emit(event):
+        emitted.append(event)
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor", _get_creds
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.action_executor.run_action", _run_action)
+    monkeypatch.setattr("pocketpaw_ee.cloud.outcomes.service.emit", _emit)
+
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(),
+        backend_config=None,
+        parked_write=_park(outcome=None),
+        requested_by="requester-9",
+    )
+    approved = await store.approve(action_id)
+    await instinct_bridge.execute_approved_write(approved)
+
+    assert emitted == []

--- a/tests/cloud/test_pocket_outcomes.py
+++ b/tests/cloud/test_pocket_outcomes.py
@@ -1,0 +1,343 @@
+# tests/cloud/test_pocket_outcomes.py — RFC 05 M2b.2.
+# Created: 2026-05-22 — coverage for the minimal outcome meter: the
+# `pocket.outcome` event, the JSONL ledger subscriber, the count
+# service, and the `GET /outcomes` route.
+#
+# What this pins:
+#   - emit_pocket_outcome emits a PocketOutcomeEvent for a named outcome
+#     and is a no-op when the binding declared none.
+#   - record_outcome (the bus subscriber) appends one JSON line to a
+#     workspace-scoped ledger.
+#   - count_outcomes groups the ledger rows by name and pocket and
+#     honors the pocket_id / since filters.
+#   - GET /outcomes returns the grouped count.
+#   - a broken subscriber does not fail the originating write (bus
+#     isolation) — and Layer-4 fields stay null.
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install.
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.realtime.events import Event, PocketOutcomeEvent  # noqa: E402
+from pocketpaw_ee.cloud.outcomes import service as outcomes_service  # noqa: E402
+from pocketpaw_ee.cloud.outcomes.dto import CountOutcomesRequest  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _tmp_ledger(tmp_path):
+    """Point the outcomes ledger at a tmp dir so tests never touch ~/.pocketpaw."""
+    outcomes_service.set_ledger_dir(tmp_path / "outcomes")
+    yield
+    # Restore the default so a later test in the same process isn't
+    # surprised by a stale tmp path.
+    outcomes_service.set_ledger_dir("~/.pocketpaw/outcomes")
+
+
+def _outcome_event(
+    *,
+    outcome: str = "renewal_completed",
+    workspace_id: str = "w1",
+    pocket_id: str = "p1",
+    action: str = "mark_renewed",
+) -> PocketOutcomeEvent:
+    return PocketOutcomeEvent(
+        data={
+            "outcome": outcome,
+            "pocket_id": pocket_id,
+            "workspace_id": workspace_id,
+            "action": action,
+            "actor": "u1",
+            "via_instinct": False,
+            "instinct_action_id": None,
+            "occurred_at": "2026-05-22T10:00:00+00:00",
+            "outcome_value": None,
+            "outcome_unit": None,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# emit_pocket_outcome
+# ---------------------------------------------------------------------------
+
+
+async def test_emit_pocket_outcome_emits_for_named_outcome(monkeypatch):
+    emitted = []
+
+    async def _emit(event):
+        emitted.append(event)
+
+    monkeypatch.setattr(outcomes_service, "emit", _emit)
+    await outcomes_service.emit_pocket_outcome(
+        outcome="renewal_completed",
+        pocket_id="p1",
+        workspace_id="w1",
+        action="mark_renewed",
+        actor="u1",
+        via_instinct=False,
+    )
+    assert len(emitted) == 1
+    assert emitted[0].type == "pocket.outcome"
+    assert emitted[0].data["outcome"] == "renewal_completed"
+    # Layer 4 reserved — billing fields stay null.
+    assert emitted[0].data["outcome_value"] is None
+    assert emitted[0].data["outcome_unit"] is None
+
+
+async def test_emit_pocket_outcome_no_outcome_is_noop(monkeypatch):
+    """A binding with no `outcome` → emit_pocket_outcome emits nothing."""
+    emitted = []
+
+    async def _emit(event):
+        emitted.append(event)
+
+    monkeypatch.setattr(outcomes_service, "emit", _emit)
+    await outcomes_service.emit_pocket_outcome(
+        outcome=None,
+        pocket_id="p1",
+        workspace_id="w1",
+        action="mark_renewed",
+        actor="u1",
+        via_instinct=False,
+    )
+    assert emitted == []
+
+
+# ---------------------------------------------------------------------------
+# record_outcome — the JSONL ledger subscriber
+# ---------------------------------------------------------------------------
+
+
+async def test_record_outcome_appends_to_ledger():
+    await outcomes_service.record_outcome(_outcome_event(workspace_id="w1", outcome="a"))
+    await outcomes_service.record_outcome(_outcome_event(workspace_id="w1", outcome="b"))
+    counts = await outcomes_service.count_outcomes("w1")
+    assert counts.total == 2
+    assert counts.by_outcome == {"a": 1, "b": 1}
+
+
+async def test_record_outcome_drops_event_missing_workspace():
+    """An event with no workspace_id is dropped — nothing is recorded."""
+    bad = PocketOutcomeEvent(data={"outcome": "x"})  # no workspace_id
+    await outcomes_service.record_outcome(bad)
+    # Nothing was written; a count on any workspace is zero.
+    assert (await outcomes_service.count_outcomes("w1")).total == 0
+
+
+async def test_count_outcomes_groups_by_pocket_and_filters():
+    await outcomes_service.record_outcome(
+        _outcome_event(workspace_id="w1", pocket_id="p1", outcome="x")
+    )
+    await outcomes_service.record_outcome(
+        _outcome_event(workspace_id="w1", pocket_id="p1", outcome="x")
+    )
+    await outcomes_service.record_outcome(
+        _outcome_event(workspace_id="w1", pocket_id="p2", outcome="y")
+    )
+    all_counts = await outcomes_service.count_outcomes("w1")
+    assert all_counts.total == 3
+    assert all_counts.by_pocket == {"p1": 2, "p2": 1}
+    # Filter to one pocket.
+    p1 = await outcomes_service.count_outcomes("w1", CountOutcomesRequest(pocket_id="p1"))
+    assert p1.total == 2
+    assert p1.by_outcome == {"x": 2}
+
+
+async def test_count_outcomes_since_filter():
+    """`since` is an inclusive ISO lower bound on occurred_at."""
+    early = PocketOutcomeEvent(
+        data={
+            "outcome": "old",
+            "workspace_id": "w1",
+            "pocket_id": "p1",
+            "occurred_at": "2026-05-01T00:00:00+00:00",
+        }
+    )
+    late = PocketOutcomeEvent(
+        data={
+            "outcome": "new",
+            "workspace_id": "w1",
+            "pocket_id": "p1",
+            "occurred_at": "2026-05-22T00:00:00+00:00",
+        }
+    )
+    await outcomes_service.record_outcome(early)
+    await outcomes_service.record_outcome(late)
+    recent = await outcomes_service.count_outcomes(
+        "w1", CountOutcomesRequest(since="2026-05-10T00:00:00+00:00")
+    )
+    assert recent.total == 1
+    assert recent.by_outcome == {"new": 1}
+
+
+async def test_count_outcomes_empty_ledger_is_zero():
+    assert (await outcomes_service.count_outcomes("never-seen")).total == 0
+
+
+async def test_ledger_is_workspace_isolated():
+    """One workspace's outcomes never leak into another's count."""
+    await outcomes_service.record_outcome(_outcome_event(workspace_id="w1", outcome="a"))
+    await outcomes_service.record_outcome(_outcome_event(workspace_id="w2", outcome="b"))
+    assert (await outcomes_service.count_outcomes("w1")).total == 1
+    assert (await outcomes_service.count_outcomes("w2")).total == 1
+
+
+# ---------------------------------------------------------------------------
+# Bus subscriber wiring — record_outcome on a real InProcessBus
+# ---------------------------------------------------------------------------
+
+
+async def test_subscriber_appends_when_event_published():
+    """Registering record_outcome on an InProcessBus and publishing a
+    pocket.outcome event appends a ledger row."""
+    from pocketpaw_ee.cloud._core.realtime.audience import AudienceResolver
+    from pocketpaw_ee.cloud._core.realtime.bus import InProcessBus
+
+    async def _no_members(*_a, **_k):
+        return []
+
+    class _NoConn:
+        async def send_to_user(self, *_a, **_k):
+            return None
+
+    resolver = AudienceResolver(
+        group_members=_no_members,
+        workspace_members=_no_members,
+        workspace_admins=_no_members,
+        workspace_peers=_no_members,
+    )
+    bus = InProcessBus(resolver=resolver, conn_manager=_NoConn())
+    bus.subscribe("pocket.outcome", outcomes_service.record_outcome)
+    await bus.publish(_outcome_event(workspace_id="w1", outcome="z"))
+
+    counts = await outcomes_service.count_outcomes("w1")
+    assert counts.total == 1
+    assert counts.by_outcome == {"z": 1}
+
+
+async def test_broken_subscriber_does_not_break_publish():
+    """A broken co-subscriber on the same event must not stop the ledger
+    subscriber — the bus isolates each handler's failure."""
+    from pocketpaw_ee.cloud._core.realtime.audience import AudienceResolver
+    from pocketpaw_ee.cloud._core.realtime.bus import InProcessBus
+
+    async def _no_members(*_a, **_k):
+        return []
+
+    class _NoConn:
+        async def send_to_user(self, *_a, **_k):
+            return None
+
+    async def _broken(_event):
+        raise RuntimeError("subscriber blew up")
+
+    bus = InProcessBus(
+        resolver=AudienceResolver(
+            group_members=_no_members,
+            workspace_members=_no_members,
+            workspace_admins=_no_members,
+            workspace_peers=_no_members,
+        ),
+        conn_manager=_NoConn(),
+    )
+    # Broken subscriber first, ledger subscriber second.
+    bus.subscribe("pocket.outcome", _broken)
+    bus.subscribe("pocket.outcome", outcomes_service.record_outcome)
+    # publish must not raise — the broken handler is logged + swallowed.
+    await bus.publish(_outcome_event(workspace_id="w1", outcome="survived"))
+    # The ledger subscriber still ran.
+    assert (await outcomes_service.count_outcomes("w1")).total == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /outcomes route
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def outcomes_client():
+    """A TestClient over the outcomes router with auth + RBAC bypassed.
+
+    ``current_active_user`` is overridden to a SimpleNamespace member;
+    ``check_workspace_action`` is stubbed on its consumer module
+    (``ee.cloud._core.deps`` — patching the source module is too late,
+    the import binding already points at the original) so the
+    ``outcomes.read`` guard passes. Same pattern as test_audit_router.py.
+    """
+    from types import SimpleNamespace
+
+    from pocketpaw_ee.cloud._core import deps as core_deps
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.cloud.outcomes.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[require_license] = lambda: None
+
+    user = SimpleNamespace(
+        id="u1",
+        active_workspace="w1",
+        workspaces=[SimpleNamespace(workspace="w1", role="admin")],
+    )
+
+    async def _fake_user_dep():
+        return user
+
+    app.dependency_overrides[current_active_user] = _fake_user_dep
+
+    _orig = core_deps.check_workspace_action
+    core_deps.check_workspace_action = lambda *a, **k: None
+
+    with TestClient(app) as client:
+        yield client
+
+    core_deps.check_workspace_action = _orig
+
+
+async def test_get_outcomes_counts(outcomes_client):
+    await outcomes_service.record_outcome(_outcome_event(workspace_id="w1", outcome="a"))
+    await outcomes_service.record_outcome(_outcome_event(workspace_id="w1", outcome="a"))
+    await outcomes_service.record_outcome(_outcome_event(workspace_id="w1", outcome="b"))
+    res = outcomes_client.get("/api/v1/outcomes")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["total"] == 3
+    assert body["by_outcome"] == {"a": 2, "b": 1}
+
+
+def test_get_outcomes_rejects_workspace_id_query(outcomes_client):
+    """workspace_id comes from auth context — a query param is rejected."""
+    res = outcomes_client.get("/api/v1/outcomes?workspace_id=w2")
+    assert res.status_code == 400
+    assert res.json()["error"]["code"] == "outcomes.workspace_id_forbidden"
+
+
+def test_event_type_is_pocket_outcome():
+    """The Event subclass pins the `pocket.outcome` type literal."""
+    ev = PocketOutcomeEvent(data={})
+    assert ev.type == "pocket.outcome"
+    assert isinstance(ev, Event)
+
+
+async def test_ledger_json_shape():
+    """A ledger row is one JSON object per line carrying every documented
+    field — including the null Layer-4 billing slots."""
+    await outcomes_service.record_outcome(_outcome_event(workspace_id="w1"))
+    path = outcomes_service._ledger_path("w1")
+    line = path.read_text(encoding="utf-8").strip()
+    row = json.loads(line)
+    assert row["outcome"] == "renewal_completed"
+    assert row["workspace_id"] == "w1"
+    assert row["outcome_value"] is None
+    assert row["outcome_unit"] is None

--- a/tests/ee/agent/test_pocket_router/test_router.py
+++ b/tests/ee/agent/test_pocket_router/test_router.py
@@ -161,7 +161,9 @@ async def test_tier0_invokes_source_executor_and_handles():
     with (
         patch(
             "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
-            new=AsyncMock(return_value=("https://api.example.com", "bearer", None, "tok", [])),
+            new=AsyncMock(
+                return_value=("https://api.example.com", "bearer", None, "tok", [], None)
+            ),
         ),
         patch("pocketpaw_ee.cloud.pockets.source_executor.run_sources", new=fake_run),
     ):
@@ -197,7 +199,9 @@ async def test_tier0_emits_execution_frame_with_zero_tokens_and_skipped_stages()
         with (
             patch(
                 "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
-                new=AsyncMock(return_value=("https://api.example.com", "bearer", None, "tok", [])),
+                new=AsyncMock(
+                    return_value=("https://api.example.com", "bearer", None, "tok", [], None)
+                ),
             ),
             patch(
                 "pocketpaw_ee.cloud.pockets.source_executor.run_sources",
@@ -238,7 +242,9 @@ async def test_tier0_source_errors_escalate():
     with (
         patch(
             "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
-            new=AsyncMock(return_value=("https://api.example.com", "bearer", None, "tok", [])),
+            new=AsyncMock(
+                return_value=("https://api.example.com", "bearer", None, "tok", [], None)
+            ),
         ),
         patch(
             "pocketpaw_ee.cloud.pockets.source_executor.run_sources",
@@ -290,7 +296,9 @@ async def test_router_resolves_spec_via_agent_view_when_pocket_absent():
         ),
         patch(
             "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
-            new=AsyncMock(return_value=("https://api.example.com", "bearer", None, "tok", [])),
+            new=AsyncMock(
+                return_value=("https://api.example.com", "bearer", None, "tok", [], None)
+            ),
         ),
         patch("pocketpaw_ee.cloud.pockets.source_executor.run_sources", new=fake_run),
     ):


### PR DESCRIPTION
## What this does

Increment 1 shipped pocket write actions, but its executor fail-closed
rejected any action marked `requires_instinct` — it returned
`instinct_required` and made no call, because there was no approval
surface to route through. This PR builds that surface.

Two pieces, both from RFC 05 M2b:

**M2b.1 — Instinct routing.** A `requires_instinct` write is no longer
rejected. It is parked: the executor runs every cheap validation gate
(rate-limit, base-URL, SSRF, allowlist, DNS) so a write the allowlist
would reject is still rejected up front, then returns an
`instinct_pending` sentinel instead of firing. The router routes the
parked write into an Instinct Action; once a human approves it, the
write runs. The approver defaults to the pocket owner, with an optional
per-pocket route to a named workspace member.

**M2b.2 — outcome emission + a minimal meter.** A write whose binding
declares an `outcome` emits a `pocket.outcome` event after it succeeds.
A new `outcomes` entity appends each event to a per-workspace JSONL
ledger and exposes `GET /api/v1/outcomes` for counts.

`approve_batch` is deferred. `approve_per_row` plus the null policy is
the shipped surface — batch approval is a follow-up.

## Changes

M2b.1:
- `ActionBinding` declares the real fields `requires_instinct`,
  `instinct_policy`, and `outcome`. A validator rejects an
  `instinct_policy` set without `requires_instinct`. The old
  `_instinct_rejected` raw-dict gate is gone.
- `run_action` takes a `from_instinct` flag. A direct run of a
  `requires_instinct` binding validates the write then returns
  `{ok, code: instinct_pending, _park}` and makes no HTTP call. The
  executor stays pure — no Beanie, no Instinct imports.
- New `pockets/instinct_bridge.py`: `propose_pocket_write` builds the
  Instinct Action; `execute_approved_write` re-loads the backend creds,
  re-enters `run_action` with `from_instinct=True`, records the result,
  and emits the outcome. A revoked backend fails closed.
- The action-run route branches on `instinct_pending` and returns
  `proposed_action_id`. The instinct approve hook fires
  `execute_approved_write` best-effort via a lazy import.
- Per-pocket `approval_route` on the backend config, set owner-only via
  `PUT /pockets/{id}/backend/approval-route`.

M2b.2:
- `PocketOutcomeEvent` (`pocket.outcome`), emitted only when a binding
  declares an `outcome`.
- New `outcomes` entity (4-file ee/cloud shape): JSONL ledger, a
  `pocket.outcome` bus subscriber, and the `GET /outcomes` count
  endpoint. No billing — `outcome_value`/`outcome_unit` stay null.

## Security

- The allowlist is checked twice — at propose time (a parked write runs
  the allowlist gate, so an off-policy write is rejected before it
  reaches the approval surface) and again at execution (the post-approval
  re-entry runs every gate, so a write the owner de-authorized between
  propose and approve is rejected, not fired).
- No token reaches the Instinct DB. The parked-write blob carries
  method/path/params/idempotency/outcome only; the backend credential is
  re-loaded fresh at execution.
- Approval defaults to the pocket owner. A named-member route is
  validated as a current workspace member when it is set.

## Testing

`uv run pytest tests/cloud/ tests/ee/` — the M2b suite passes
(`test_pocket_instinct_bridge.py`, `test_pocket_outcomes.py`, plus the
updated executor / backend-route / backend-service / agent-view tests).
The pre-existing failures in `tests/cloud/uploads/` and
`test_ee_correction.py` are unrelated to this change and present on dev.
`ruff check`, `ruff format --check`, and import-linter (16 contracts)
all pass.