### PR TITLE
feat(livekit): composite room recording with S3 output + owner-only c…

### DIFF
--- a/ee/pocketpaw_ee/cloud/livekit/router.py
+++ b/ee/pocketpaw_ee/cloud/livekit/router.py
@@ -5,10 +5,13 @@ Endpoints:
 - ``POST /api/v1/livekit/token`` — generate participant access token
 - ``DELETE /api/v1/livekit/rooms/{group_id}`` — end a call
 - ``GET /api/v1/livekit/rooms/{group_id}`` — get room status
+- ``POST /api/v1/livekit/rooms/{group_id}/recording/start`` — start recording (owner only)
+- ``POST /api/v1/livekit/rooms/{group_id}/recording/stop`` — stop recording (owner only)
+- ``GET /api/v1/livekit/rooms/{group_id}/recording`` — get recording status
 
 All routes require an active enterprise license, user authentication,
-and group membership.
-"""
+and group membership. Recording endpoints additionally require workspace
+ownership."""
 
 from __future__ import annotations
 
@@ -17,6 +20,7 @@ import logging
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
+from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud.chat.group_service import (
     _get_group_domain_or_404,
     _require_domain_group_member,
@@ -78,6 +82,34 @@ class EndCallResponse(BaseModel):
     ended_at: str
 
 
+class StartRecordingResponse(BaseModel):
+    egress_id: str
+    room_name: str
+    group_id: str
+    output_path: str
+    status: int = 0
+    started_at: int = 0
+
+
+class StopRecordingResponse(BaseModel):
+    egress_id: str
+    room_name: str
+    group_id: str
+    status: int = 0
+    output_files: list[dict] = []
+    ended_at: int = 0
+
+
+class RecordingInfoResponse(BaseModel):
+    egress_id: str | None = None
+    room_name: str = ""
+    group_id: str
+    status: str = "inactive"
+    is_active: bool = False
+    started_at: int = 0
+    ended_at: int = 0
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -92,6 +124,33 @@ def _group_id_from_room_name(room_name: str) -> str | None:
     if room_name.startswith(prefix):
         return room_name[len(prefix) :]
     return None
+
+
+# ---------------------------------------------------------------------------
+# Workspace owner guard for recording
+# ---------------------------------------------------------------------------
+
+
+async def _require_workspace_owner(
+    user=Depends(current_user),
+    workspace_id: str = Depends(current_workspace_id),
+) -> None:
+    """Ensure the current user is the workspace owner.
+
+    Only workspace owners can start/stop call recordings.
+    """
+    from beanie import PydanticObjectId
+
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
+
+    doc = await _WorkspaceDoc.get(PydanticObjectId(workspace_id))
+    if doc is None or doc.deleted_at is not None:
+        raise Forbidden("workspace.not_found", "Workspace not found")
+    if doc.owner != str(user.id):
+        raise Forbidden(
+            "workspace.not_owner",
+            "Only the workspace owner can manage recordings",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -241,3 +300,164 @@ async def end_call(
         logger.warning("Failed to emit CallEnded event for group %s", group_id)
 
     return EndCallResponse(**result)
+
+
+# ---------------------------------------------------------------------------
+# Recording endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/rooms/{group_id}/recording/start", response_model=StartRecordingResponse)
+async def start_recording(
+    group_id: str,
+    user=Depends(current_user),
+    workspace_id: str = Depends(current_workspace_id),
+):
+    """Start recording the call for a group.
+
+    Only the workspace owner can start recordings. The recording is saved
+    as an MP4 composite video to the workspace's S3 bucket.
+    """
+    await require_license()
+
+    # Verify the caller is a member of the target group.
+    group = await _get_group_domain_or_404(group_id)
+    _require_domain_group_member(group, str(user.id))
+
+    # Only workspace owner can record
+    await _require_workspace_owner(user=user, workspace_id=workspace_id)
+
+    try:
+        result = await livekit_service.start_room_recording(group_id)
+        return StartRecordingResponse(**result)
+    except RuntimeError as exc:
+        raise Forbidden("recording.already_active", str(exc))
+
+
+@router.post("/rooms/{group_id}/recording/stop", response_model=StopRecordingResponse)
+async def stop_recording(
+    group_id: str,
+    user=Depends(current_user),
+    workspace_id: str = Depends(current_workspace_id),
+):
+    """Stop an active call recording.
+
+    Only the workspace owner can stop recordings. The final MP4 will be
+    saved to S3 and linked in the /files page.
+    """
+    await require_license()
+
+    # Verify the caller is a member of the target group.
+    group = await _get_group_domain_or_404(group_id)
+    _require_domain_group_member(group, str(user.id))
+
+    # Only workspace owner can stop recording
+    await _require_workspace_owner(user=user, workspace_id=workspace_id)
+
+    try:
+        result = await livekit_service.stop_room_recording(group_id)
+    except RuntimeError as exc:
+        raise Forbidden("recording.not_active", str(exc))
+
+    # Create a file record so the recording appears in the /files page
+    try:
+        room_name = livekit_service.room_name_for_group(group_id)
+        output_path = result.get("output_files", [{}])[0].get("filename", "")
+        if not output_path:
+            output_path = livekit_service._recording_output_path(group_id)
+
+        from datetime import UTC, datetime
+
+        from pocketpaw.uploads.file_store import FileRecord
+        from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+        file_record = FileRecord(
+            id=result.get("egress_id", group_id),
+            storage_key=output_path,
+            filename=f"call-recording-{room_name}.mp4",
+            mime="video/mp4",
+            size=0,  # Size unknown until file is fully written by LiveKit
+            owner_id=str(user.id),
+            chat_id=group_id,
+            created=datetime.now(UTC),
+        )
+        store = MongoFileStore()
+        await store.save_scoped(
+            record=file_record,
+            workspace=workspace_id,
+            folder_path="/recordings",
+        )
+        logger.info(
+            "Created file record for recording %s in workspace %s",
+            file_record.id,
+            workspace_id,
+        )
+    except Exception as exc:
+        logger.warning("Failed to create file record for recording: %s", exc)
+
+    return StopRecordingResponse(**result)
+
+
+@router.get("/rooms/{group_id}/recording", response_model=RecordingInfoResponse)
+async def get_recording_status(
+    group_id: str,
+    user=Depends(current_user),
+    workspace_id: str = Depends(current_workspace_id),
+):
+    """Get the status of a call recording.
+
+    Returns whether a recording is active and its current state.
+    """
+    await require_license()
+
+    # Verify the caller is a member of the target group.
+    group = await _get_group_domain_or_404(group_id)
+    _require_domain_group_member(group, str(user.id))
+
+    info = await livekit_service.get_recording_info(group_id)
+
+    # Check if it's really the owner (for UI purposes we show status to
+    # all members, but only owner can start/stop)
+    is_owner = False
+    try:
+        await _require_workspace_owner(user=user, workspace_id=workspace_id)
+        is_owner = True
+    except Forbidden:
+        pass
+
+    if info is None:
+        return RecordingInfoResponse(
+            group_id=group_id,
+            status="inactive",
+            is_active=is_owner and False,
+        )
+
+    # Map protobuf status int to readable string
+    # EgressStatus values:
+    #   EGRESS_STARTING = 0
+    #   EGRESS_ACTIVE = 1
+    #   EGRESS_ENDING = 2
+    #   EGRESS_COMPLETE = 3
+    #   EGRESS_FAILED = 4
+    #   EGRESS_ABORTED = 5
+    status_map = {
+        0: "starting",
+        1: "active",
+        2: "ending",
+        3: "complete",
+        4: "failed",
+        5: "aborted",
+    }
+    status_code = info.get("status", 0)
+    status_str = status_map.get(status_code, "unknown")
+    is_active = status_code in (0, 1, 2)  # starting, active, ending
+
+    return RecordingInfoResponse(
+        egress_id=info.get("egress_id"),
+        room_name=info.get("room_name", ""),
+        group_id=group_id,
+        status=status_str,
+        is_active=is_active,
+        started_at=info.get("started_at", 0),
+        ended_at=info.get("ended_at", 0),
+    )

--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -32,6 +32,12 @@ from pocketpaw_ee.cloud.livekit.types import MeetingAgentProtocol  # noqa: E402
 
 _active_agents: dict[str, MeetingAgentProtocol] = {}
 
+# ---------------------------------------------------------------------------
+# Active recordings registry  (group_id → egress_id)
+# ---------------------------------------------------------------------------
+
+_active_recordings: dict[str, str] = {}
+
 
 def _get_agent(group_id: str) -> MeetingAgentProtocol | None:
     """Get the active meeting agent for a group, if any."""
@@ -173,6 +179,216 @@ async def _reap_agent_process(
             group_id,
             proc.returncode,
         )
+
+
+# ---------------------------------------------------------------------------
+# S3 configuration for LiveKit recording output
+# ---------------------------------------------------------------------------
+
+
+def _get_s3_config() -> dict[str, str] | None:
+    """Read S3 config from environment for LiveKit Egress output.
+
+    Returns a dict with keys used by ``livekit.protocol.egress.S3Upload``
+    or ``None`` if S3 is not configured (falls back to temp local storage).
+    """
+    bucket = os.environ.get("S3_PRIVATE_BUCKET") or os.environ.get("S3_BUCKET")
+    if not bucket:
+        logger.warning("S3 not configured — recordings will use LiveKit's built-in storage")
+        return None
+    return {
+        "bucket": bucket,
+        "region": os.environ.get("S3_REGION", ""),
+        "endpoint": os.environ.get("S3_ENDPOINT", ""),
+        "access_key": os.environ.get("S3_ACCESS_KEY_ID", ""),
+        "secret": os.environ.get("S3_SECRET_ACCESS_KEY", ""),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Recording management
+# ---------------------------------------------------------------------------
+
+RECORDING_DIR = "recordings"
+
+
+def _recording_output_path(group_id: str) -> str:
+    """Build a deterministic S3 key for a recording."""
+    from datetime import UTC, datetime
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+    return f"{RECORDING_DIR}/{group_id}/{timestamp}_{room_name_for_group(group_id)}.mp4"
+
+
+async def start_room_recording(group_id: str) -> dict[str, Any]:
+    """Start a composite room recording via LiveKit Egress, outputting to S3.
+
+    Returns the egress metadata including the egress ID and output path.
+
+    Raises ``RuntimeError`` if a recording is already active for this group.
+    """
+    _ensure_configured()
+
+    if group_id in _active_recordings:
+        raise RuntimeError(f"Recording already active for group {group_id}")
+
+    room_name = room_name_for_group(group_id)
+
+    from livekit.api import LiveKitAPI
+    from livekit.protocol.egress import (
+        EncodedFileOutput,
+        EncodedFileType,
+        EncodingOptionsPreset,
+        RoomCompositeEgressRequest,
+        S3Upload,
+    )
+
+    output_path = _recording_output_path(group_id)
+    s3_cfg = _get_s3_config()
+
+    file_output = EncodedFileOutput(
+        file_type=EncodedFileType.MP4,
+        filepath=output_path,
+        disable_manifest=False,
+    )
+
+    # Configure S3 upload destination
+    if s3_cfg:
+        file_output.s3.CopyFrom(
+            S3Upload(
+                bucket=s3_cfg["bucket"],
+                region=s3_cfg["region"],
+                endpoint=s3_cfg["endpoint"],
+                access_key=s3_cfg["access_key"],
+                secret=s3_cfg["secret"],
+            )
+        )
+    # If no S3 config, LiveKit uses its built-in storage (if configured)
+    # or the recording will fail — log a warning.
+
+    req = RoomCompositeEgressRequest(
+        room_name=room_name,
+        preset=EncodingOptionsPreset.H264_720P_30,
+        audio_only=False,
+        file_outputs=[file_output],
+    )
+
+    async with LiveKitAPI(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET) as lk:
+        try:
+            info = await lk.egress.start_room_composite_egress(req)
+            egress_id = info.egress_id
+            _active_recordings[group_id] = egress_id
+            logger.info(
+                "Started recording for room %s (egress_id=%s, output=%s)",
+                room_name,
+                egress_id,
+                output_path,
+            )
+            return {
+                "egress_id": egress_id,
+                "room_name": room_name,
+                "group_id": group_id,
+                "output_path": output_path,
+                "status": info.status,
+                "started_at": info.started_at,
+            }
+        except Exception as exc:
+            logger.error("Failed to start recording for room %s: %s", room_name, exc)
+            raise
+
+
+async def stop_room_recording(group_id: str) -> dict[str, Any]:
+    """Stop an active room recording.
+
+    Returns the final egress info including the S3 output path so the
+    caller can create a file record in the uploads system.
+
+    Raises ``RuntimeError`` if no recording is active for this group.
+    """
+    _ensure_configured()
+
+    egress_id = _active_recordings.pop(group_id, None)
+    if not egress_id:
+        raise RuntimeError(f"No active recording for group {group_id}")
+
+    from livekit.api import LiveKitAPI
+    from livekit.protocol.egress import StopEgressRequest
+
+    async with LiveKitAPI(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET) as lk:
+        try:
+            stop_req = StopEgressRequest(egress_id=egress_id)
+            info = await lk.egress.stop_egress(stop_req)
+            logger.info(
+                "Stopped recording for group %s (egress_id=%s, status=%s)",
+                group_id,
+                egress_id,
+                info.status,
+            )
+
+            # Collect output file info
+            output_files = []
+            for f in info.file_results or []:
+                output_files.append(
+                    {
+                        "filename": f.filename,
+                        "size": f.size,
+                        "duration": f.duration,
+                    }
+                )
+
+            return {
+                "egress_id": egress_id,
+                "room_name": info.room_name or room_name_for_group(group_id),
+                "group_id": group_id,
+                "status": info.status,
+                "output_files": output_files,
+                "ended_at": info.ended_at,
+            }
+        except Exception as exc:
+            logger.error("Failed to stop recording for group %s: %s", group_id, exc)
+            raise
+
+
+async def get_recording_info(group_id: str) -> dict[str, Any] | None:
+    """Get the current status of a recording for a group.
+
+    Returns ``None`` if no recording was ever started.
+    """
+    egress_id = _active_recordings.get(group_id)
+    if not egress_id:
+        return None
+
+    _ensure_configured()
+
+    from livekit.api import LiveKitAPI
+    from livekit.protocol.egress import ListEgressRequest
+
+    async with LiveKitAPI(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET) as lk:
+        try:
+            list_req = ListEgressRequest(room_name=room_name_for_group(group_id))
+            resp = await lk.egress.list_egress(list_req)
+            for item in resp.items or []:
+                if item.egress_id == egress_id:
+                    return {
+                        "egress_id": item.egress_id,
+                        "room_name": item.room_name,
+                        "group_id": group_id,
+                        "status": item.status,
+                        "started_at": item.started_at,
+                        "ended_at": item.ended_at,
+                    }
+            return {
+                "egress_id": egress_id,
+                "group_id": group_id,
+                "status": "unknown",
+            }
+        except Exception as exc:
+            logger.warning("Failed to get recording info for group %s: %s", group_id, exc)
+            return {
+                "egress_id": egress_id,
+                "group_id": group_id,
+                "status": "unknown",
+            }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add LiveKit composite room recording to the call system. Workspace owners can start/stop recordings during active calls. The recording is rendered as a single MP4 (all participant audio/video composited) and saved to the workspace S3 bucket, appearing in the /files page.

### Backend

- **POST /rooms/{group_id}/recording/start** — starts a RoomCompositeEgress via LiveKit Egress API. Requires workspace ownership. Returns egress_id, room_name, output_path, and started_at.
- **POST /rooms/{group_id}/recording/stop** — stops the active egress and creates a FileUpload MongoDB document so the recording shows up in /files. Only the workspace owner can stop.
- **GET /rooms/{group_id}/recording** — returns current recording status (is_active, status string, started_at, ended_at). All group members can read.
- **S3 output**: Recordings written directly by LiveKit Egress to workspace private S3 bucket under recordings/{group_id}/{timestamp}_group-call-{group_id}.mp4.
- **Recording registry**: In-memory _active_recordings dict tracks group_id → egress_id to prevent double-recording.
- **Workspace owner guard**: _require_workspace_owner() verifies Workspace.owner == user.id before allowing recording toggle.

### Frontend (qbtrix/paw-enterprise#240)

- Record button in the call controls bar (3 states: start/stop/loading)
- REC indicator in the top bar with blinking red dot + duration timer
- Recording state synced from the session (isRecording, recordingStartedAt, canRecord)

### Related Issues
- Closes recording backend requirements from qbtrix/paw-enterprise#239
- Closes #1184
