### PR TITLE
feat(ripple): catalog-as-allowlist ingest gate + embed escape hatch

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -19,6 +19,10 @@ Updated: 2026-05-22 (feat/api-skills, Increment 2b) — documented
 POST /skills/api-doc, the per-backend API-skill install endpoint that
 turns a pocket backend's OpenAPI document into a loadable SKILL.md so
 the authoring agent stops hallucinating endpoints.
+
+Updated: 2026-05-22 (feat/catalog-allowlist, Increment 5) — documented
+the catalog-as-allowlist ingest gate, the two escape-hatch widgets
+(`model-viewer` + `embed`), and the `embed` URL/host policy.
 -->
 
 # Cloud REST API Reference
@@ -284,3 +288,58 @@ Returns `422` when the file extension is unsupported, the file exceeds
 the 2 MB cap, the document is unparseable, or it carries no `paths`
 object. Every install is audit-logged with the workspace, the actor, and
 the resulting slug — never the spec contents.
+
+## Pockets — Catalog-as-Allowlist Ingest Gate
+
+Increment 5. The Ripple renderer has a **closed widget registry**: a
+node whose `type` is not a known widget renders as a red "Unknown widget
+type" box. The catalog gate catches that at ingest time, before the spec
+is persisted.
+
+On every pocket write that carries a `rippleSpec`, the service walks the
+node tree and flags any node whose `type` is not in the widget manifest
+(plus the control-flow types `if` and `each`). The gate runs in one of
+two modes:
+
+- **Strict** — the agent-generation path (`create_from_ripple_spec`, the
+  pocket-specialist `agent_create` / `agent_update` ops). A violation
+  blocks the write; the specialist edit tools return the corrective
+  message so the LLM can retry with a real widget type.
+- **Logged** — the human / import path (`POST /pockets`,
+  `PUT /pockets/{id}`). A violation is recorded as a structured warning
+  for triage but does **not** block — an older imported spec may use a
+  widget that has since left the catalog.
+
+Each flagged node reports `{path, type, suggestion}`, where `suggestion`
+is the nearest catalog widget by edit distance. The gate is best-effort:
+when the widget manifest can't be fetched it is skipped.
+
+### Escape-hatch widgets
+
+Two catalog widgets cover content the rest of the catalog can't express:
+
+- `model-viewer` — an interactive 3D model (`.glb` / `.gltf`) with
+  orbit / zoom / pan controls.
+- `embed` — the **sanctioned escape hatch**: a renderer-sandboxed
+  iframe for a CodePen, a Figma frame, an Observable notebook, or a
+  self-contained visualization. `mode` is required (`url` or `srcdoc`).
+  The iframe `sandbox` attribute is renderer-controlled — it is **not**
+  author-settable.
+
+### `embed` URL / host policy
+
+An `embed` node in `mode: "url"` points an iframe at a third-party page,
+so its `url` is an SSRF / clickjacking boundary. The ingest gate
+enforces:
+
+- `url` must be **https** — plain `http` is rejected.
+- the host must be on the embed allow-list (`POCKETPAW_RIPPLE_EMBED_ALLOWED_HOSTS`,
+  a JSON array — default: `youtube-nocookie.com`, `player.vimeo.com`,
+  `codepen.io`, `codesandbox.io`, `observablehq.com`, `www.figma.com`).
+- loopback / RFC1918 / link-local / carrier-grade-NAT / cloud-metadata
+  hosts are **hard-blocked unconditionally** — this holds even if the
+  allow-list is widened to `["*"]`.
+
+Every ingested spec that contains an `embed` node is audit-logged
+(category `pocket_embed`) with the embed count and URLs — never the
+iframe contents.

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -98,7 +98,13 @@ from pocketpaw_ee.cloud.pockets.dto import (
     pocket_to_wire_dict,
 )
 from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec
-from pocketpaw_ee.cloud.ripple_validator import validate_ripple_spec_logged
+from pocketpaw_ee.cloud.ripple_validator import (
+    CatalogViolationError,
+    format_violations_for_agent,
+    validate_against_catalog_logged,
+    validate_against_catalog_strict,
+    validate_ripple_spec_logged,
+)
 from pocketpaw_ee.cloud.shared.errors import Forbidden, NotFound, ValidationError
 from pocketpaw_ee.cloud.shared.events import event_bus
 
@@ -305,6 +311,139 @@ async def _mutate_list_field(pocket_id: str, field: str, value: str, action: str
 
 
 # ---------------------------------------------------------------------------
+# Catalog-as-allowlist ingest gate (Increment 5)
+# ---------------------------------------------------------------------------
+
+
+async def _catalog_allowed_types() -> list[str] | None:
+    """Resolve the widget-catalog allow-list from the Ripple manifest.
+
+    The manifest's ``widgets`` array is the renderer's closed registry.
+    Returns the type list, or ``None`` when the manifest is unavailable
+    (network failure, dev server down) — the caller skips the catalog
+    gate in that case, best-effort like the manifest-drift validator.
+    """
+    try:
+        from pocketpaw.config import get_settings
+        from pocketpaw.ripple.manifest import allowed_types_from_manifest, get_manifest
+
+        settings = get_settings()
+        manifest = await get_manifest(
+            settings.ripple_manifest_url,
+            ttl_seconds=settings.ripple_manifest_ttl_seconds,
+        )
+        if manifest is None:
+            return None
+        types = allowed_types_from_manifest(manifest)
+        return types or None
+    except Exception:
+        logger.debug("ripple catalog allow-list lookup skipped (non-fatal)", exc_info=True)
+        return None
+
+
+def _embed_allowed_hosts() -> list[str]:
+    """Return the configured ``embed`` host allow-list."""
+    try:
+        from pocketpaw.config import get_settings
+
+        return list(get_settings().ripple_embed_allowed_hosts or [])
+    except Exception:
+        logger.debug("ripple embed allow-list lookup skipped (non-fatal)", exc_info=True)
+        return []
+
+
+def _audit_embed_ingest(
+    spec: dict[str, Any] | None,
+    *,
+    actor: str,
+    workspace_id: str | None,
+    pocket_id: str | None,
+) -> None:
+    """Write an audit-log entry when an ingested spec contains an ``embed``
+    node.
+
+    The ``embed`` widget points an iframe at third-party content; an
+    audit trail of every embed-bearing spec that is published lets a
+    security review reconstruct what external surfaces a pocket exposed.
+    Audit failures must never break the ingest flow — the call is wrapped.
+    """
+    try:
+        from pocketpaw.ripple.manifest import find_embed_nodes
+
+        embeds = find_embed_nodes(spec)
+        if not embeds:
+            return
+        from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+
+        urls: list[str] = []
+        for node in embeds:
+            props = node.get("props")
+            if isinstance(props, dict):
+                url = props.get("url")
+                if isinstance(url, str) and url:
+                    urls.append(url)
+        get_audit_logger().log(
+            AuditEvent.create(
+                severity=AuditSeverity.WARNING,
+                actor=actor,
+                action="pocket.embed_ingest",
+                target=pocket_id or "(new)",
+                status="success",
+                category="pocket_embed",
+                workspace_id=workspace_id,
+                pocket_id=pocket_id,
+                embed_count=len(embeds),
+                embed_urls=urls,
+            )
+        )
+    except Exception:  # noqa: BLE001 — audit must never break the ingest
+        logger.warning("pocket embed-ingest audit-log write failed", exc_info=True)
+
+
+async def _gate_catalog(
+    spec: dict[str, Any] | None,
+    *,
+    strict: bool,
+    actor: str,
+    workspace_id: str | None = None,
+    pocket_id: str | None = None,
+) -> None:
+    """Run the catalog-as-allowlist gate over a normalized rippleSpec.
+
+    ``strict=True`` (agent-generation path) raises ``CatalogViolationError``
+    on the first violation so the caller can retry the LLM. ``strict=False``
+    (human / import path) logs a structured warning per violation and does
+    not block. Either way, an embed-bearing spec is audit-logged.
+
+    Best-effort: when the widget manifest can't be fetched the gate is
+    skipped (same posture as the manifest-drift validator).
+    """
+    if not isinstance(spec, dict):
+        return
+    _audit_embed_ingest(spec, actor=actor, workspace_id=workspace_id, pocket_id=pocket_id)
+    allowed_types = await _catalog_allowed_types()
+    if allowed_types is None:
+        return
+    embed_hosts = _embed_allowed_hosts()
+    if strict:
+        validate_against_catalog_strict(
+            spec,
+            allowed_types,
+            embed_allowed_hosts=embed_hosts,
+            pocket_id=pocket_id,
+            workspace_id=workspace_id,
+        )
+    else:
+        validate_against_catalog_logged(
+            spec,
+            allowed_types,
+            embed_allowed_hosts=embed_hosts,
+            pocket_id=pocket_id,
+            workspace_id=workspace_id,
+        )
+
+
+# ---------------------------------------------------------------------------
 # CRUD
 # ---------------------------------------------------------------------------
 
@@ -323,6 +462,8 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
     normalized_spec = normalize_ripple_spec(body.ripple_spec) if body.ripple_spec else None
     if normalized_spec:
         validate_ripple_spec_logged(normalized_spec, workspace_id=workspace_id)
+        # Human/import path — catalog drift is logged for triage, not blocked.
+        await _gate_catalog(normalized_spec, strict=False, actor=user_id, workspace_id=workspace_id)
     widget_docs = [_build_widget_doc(w) for w in (body.widgets or [])]
 
     if body.project_id:
@@ -416,6 +557,14 @@ async def update(pocket_id: str, user_id: str, body: UpdatePocketRequest) -> dic
     if normalized_spec:
         validate_ripple_spec_logged(
             normalized_spec, pocket_id=str(doc.id), workspace_id=doc.workspace
+        )
+        # Human/import path — catalog drift is logged for triage, not blocked.
+        await _gate_catalog(
+            normalized_spec,
+            strict=False,
+            actor=user_id,
+            workspace_id=doc.workspace,
+            pocket_id=str(doc.id),
         )
 
     if body.name is not None:
@@ -517,12 +666,25 @@ async def create_from_ripple_spec(
     description: str = "",
 ) -> str | None:
     """Auto-create a pocket from an agent-generated ripple spec.
-    Returns the pocket id on success, None on failure."""
+    Returns the pocket id on success, None on failure.
+
+    This is the agent-generation path, so the catalog gate runs in
+    STRICT mode — a spec with a node outside the widget catalog (or an
+    ``embed`` URL violating the host policy) is BLOCKED: the function
+    returns ``None`` rather than persist a pocket the renderer would
+    draw as a red "Unknown widget type" box. The inline chat path has
+    no LLM-retry loop, so blocking + logging is the strict behavior here
+    (the specialist edit tools, which can retry, surface the corrective
+    message instead).
+    """
     try:
         normalized = normalize_ripple_spec(ripple_spec)
         if not normalized:
             return None
         validate_ripple_spec_logged(normalized, workspace_id=workspace_id)
+        # Strict catalog gate — CatalogViolationError is caught by the
+        # catch-all below, blocking the create and logging the reason.
+        await _gate_catalog(normalized, strict=True, actor=owner_id, workspace_id=workspace_id)
 
         name = (
             normalized.get("lifecycle", {}).get("name")
@@ -1103,6 +1265,18 @@ async def agent_update(
             validate_ripple_spec_logged(
                 doc.rippleSpec, pocket_id=str(doc.id), workspace_id=doc.workspace
             )
+            # Agent-generation path — strict catalog gate. Surface a
+            # violation as the error string so the specialist can retry.
+            try:
+                await _gate_catalog(
+                    doc.rippleSpec,
+                    strict=True,
+                    actor="agent",
+                    workspace_id=doc.workspace,
+                    pocket_id=str(doc.id),
+                )
+            except CatalogViolationError as exc:
+                return None, format_violations_for_agent(exc.violations)
     try:
         await doc.save()
     except Exception as exc:  # noqa: BLE001
@@ -2108,6 +2282,14 @@ async def agent_create(
     normalized = normalize_ripple_spec(ripple_spec) if ripple_spec else None
     if normalized:
         validate_ripple_spec_logged(normalized, workspace_id=workspace_id)
+        # Agent-generation path — strict catalog gate. A violation is
+        # returned as the error string so the specialist sees the
+        # corrective detail and can retry, instead of persisting a spec
+        # the renderer would draw as a red "Unknown widget type" box.
+        try:
+            await _gate_catalog(normalized, strict=True, actor=owner_id, workspace_id=workspace_id)
+        except CatalogViolationError as exc:
+            return None, None, format_violations_for_agent(exc.violations)
     try:
         doc = _PocketDoc(
             workspace=workspace_id,

--- a/ee/pocketpaw_ee/cloud/ripple_validator.py
+++ b/ee/pocketpaw_ee/cloud/ripple_validator.py
@@ -21,6 +21,16 @@ ordering).
 Grammar must mirror ``ripple/src/lib/core/expression-resolver.ts``. Any
 new token / method added to the resolver should be added here too — the
 two files together are the contract.
+
+Changes:
+  - 2026-05-22 (Increment 5): added the catalog-as-allowlist gate —
+    ``CatalogViolationError`` plus ``validate_against_catalog_strict``
+    (agent-generation path, RAISES) and ``..._logged`` (human/import
+    path, structured warn, does not block). Mirrors the
+    ``validate_ripple_spec_strict`` / ``..._logged`` split. The catalog
+    walk + the embed URL/host policy live in OSS ``pocketpaw.ripple.manifest``;
+    this module supplies the EE-side strict/logged wiring + the
+    agent-readable error formatting.
 """
 
 from __future__ import annotations
@@ -30,6 +40,11 @@ import re
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
+
+from pocketpaw.ripple.manifest import (
+    check_embed_nodes_in_spec,
+    validate_against_catalog,
+)
 
 log = logging.getLogger(__name__)
 
@@ -333,10 +348,165 @@ def format_warnings_for_agent(warnings: list[ExpressionWarning]) -> str:
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# Catalog-as-allowlist gate (Increment 5)
+#
+# A node whose ``type`` is not in the widget manifest renders as a red
+# "Unknown widget type" box. A node whose ``embed`` URL violates the host
+# policy is an SSRF / clickjacking boundary. Both checks are run together
+# here: strict (raises) on the agent-generation path, logged (warns) on
+# the human / import path. The pure walks live in OSS
+# ``pocketpaw.ripple.manifest``; this layer adds the EE wiring.
+# ---------------------------------------------------------------------------
+
+
+class CatalogViolationError(Exception):
+    """Raised by :func:`validate_against_catalog_strict` when a spec
+    contains a node outside the widget catalog allow-list, or an
+    ``embed`` node whose URL violates the host policy.
+
+    Carries the full violations list so a caller (e.g. an LLM-retry
+    loop) can build an actionable corrective prompt. Mirrors
+    :class:`RippleSpecGrammarError`'s shape — ``.violations`` plus a
+    ``format_violations_for_agent`` helper.
+    """
+
+    def __init__(self, violations: list[dict[str, Any]]) -> None:
+        self.violations = violations
+        super().__init__(self._format(violations))
+
+    @staticmethod
+    def _format(violations: list[dict[str, Any]]) -> str:
+        lines = [f"{len(violations)} catalog violation(s) in rippleSpec:"]
+        for v in violations[:20]:  # cap the message length
+            if "reason" in v:
+                lines.append(f"  - [embed] {v['path']}: {v['reason']}\n      url: {v.get('url')!r}")
+            else:
+                hint = f" — did you mean '{v['suggestion']}'?" if v.get("suggestion") else ""
+                lines.append(f"  - [unknown_type] {v['path']}: type '{v['type']}'{hint}")
+        if len(violations) > 20:
+            lines.append(f"  - …and {len(violations) - 20} more")
+        return "\n".join(lines)
+
+
+def _collect_catalog_violations(
+    spec: dict[str, Any] | None,
+    allowed_types: list[str] | set[str],
+    embed_allowed_hosts: list[str] | set[str],
+) -> list[dict[str, Any]]:
+    """Run both the catalog-type walk and the embed URL/host walk, return
+    the combined violations list (unknown-type issues first, then embed
+    policy issues)."""
+    violations: list[dict[str, Any]] = []
+    violations.extend(validate_against_catalog(spec, allowed_types))
+    violations.extend(check_embed_nodes_in_spec(spec, embed_allowed_hosts))
+    return violations
+
+
+def format_violations_for_agent(violations: list[dict[str, Any]]) -> str:
+    """Build a compact, agent-readable summary of catalog violations.
+
+    Suitable as the ``error`` field on an MCP tool result so the LLM
+    sees specifically *which* node type / embed URL was rejected and can
+    target its fix.
+    """
+    if not violations:
+        return ""
+    lines = ["The rippleSpec was rejected — it contains nodes outside the widget catalog:"]
+    for v in violations[:10]:
+        if "reason" in v:
+            lines.append(f"  • {v['path']}: embed url rejected — {v['reason']}")
+        else:
+            hint = f" Use '{v['suggestion']}' instead." if v.get("suggestion") else ""
+            lines.append(f"  • {v['path']}: type '{v['type']}' is not a catalog widget.{hint}")
+    if len(violations) > 10:
+        lines.append(f"  • …and {len(violations) - 10} more")
+    lines.append(
+        "Every node `type` must appear verbatim in the widget catalog. For content "
+        "the catalog can't express, use the sanctioned `embed` widget — its `url` "
+        "must be https and point at an allow-listed host."
+    )
+    return "\n".join(lines)
+
+
+def validate_against_catalog_logged(
+    spec: dict[str, Any] | None,
+    allowed_types: list[str] | set[str],
+    *,
+    embed_allowed_hosts: list[str] | set[str],
+    pocket_id: str | None = None,
+    workspace_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Validate the catalog allow-list + embed policy, emit one
+    ``log.warning`` per violation, and return the violations list.
+
+    Use this on the human / import path — a violation is recorded for
+    triage but does NOT block the write (an older imported spec may use
+    a widget that has since left the catalog).
+    """
+    violations = _collect_catalog_violations(spec, allowed_types, embed_allowed_hosts)
+    for v in violations:
+        if "reason" in v:
+            log.warning(
+                "ripple_spec.embed_policy_violation",
+                extra={
+                    "pocket_id": pocket_id,
+                    "workspace_id": workspace_id,
+                    "field_path": v["path"],
+                    "embed_url": v.get("url"),
+                    "detail": v["reason"],
+                },
+            )
+        else:
+            log.warning(
+                "ripple_spec.unknown_widget_type",
+                extra={
+                    "pocket_id": pocket_id,
+                    "workspace_id": workspace_id,
+                    "field_path": v["path"],
+                    "widget_type": v["type"],
+                    "suggestion": v.get("suggestion"),
+                },
+            )
+    return violations
+
+
+def validate_against_catalog_strict(
+    spec: dict[str, Any] | None,
+    allowed_types: list[str] | set[str],
+    *,
+    embed_allowed_hosts: list[str] | set[str],
+    pocket_id: str | None = None,
+    workspace_id: str | None = None,
+) -> None:
+    """Validate the catalog allow-list + embed policy; raise
+    :class:`CatalogViolationError` if any node is outside the catalog or
+    any ``embed`` URL violates the host policy.
+
+    Use this only on the agent-generation path where the caller can
+    handle a retry. Human / import callers should use
+    :func:`validate_against_catalog_logged` — strict mode would block a
+    legitimate import of an older spec.
+    """
+    violations = validate_against_catalog_logged(
+        spec,
+        allowed_types,
+        embed_allowed_hosts=embed_allowed_hosts,
+        pocket_id=pocket_id,
+        workspace_id=workspace_id,
+    )
+    if violations:
+        raise CatalogViolationError(violations)
+
+
 __all__ = [
+    "CatalogViolationError",
     "ExpressionWarning",
     "RippleSpecGrammarError",
+    "format_violations_for_agent",
     "format_warnings_for_agent",
+    "validate_against_catalog_logged",
+    "validate_against_catalog_strict",
     "validate_ripple_spec",
     "validate_ripple_spec_logged",
     "validate_ripple_spec_strict",

--- a/src/pocketpaw/bundled_skills/_bundled/pocketpaw-create-pocket/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/pocketpaw-create-pocket/SKILL.md
@@ -159,6 +159,8 @@ When ``feed``:
 | code editor (IDE-like) | ``code-editor`` |
 | terminal / shell output | ``terminal`` |
 | rich text editor | ``rich-text`` |
+| 3D model / product viewer / AR showcase | ``model-viewer`` |
+| CodePen / Figma / Observable / self-contained viz | ``embed`` |
 
 When the brief matches one of the rows above, **use the named widget
 directly**. Don't rebuild it from primitives. The polished widget
@@ -167,6 +169,30 @@ typography of that pattern.
 
 For widgets not listed above, call ``mcp__pocketpaw_pocket__get_widget_spec``
 to fetch the widget's allowed props before drafting.
+
+### Escape-hatch widgets — `model-viewer` and `embed`
+
+Two widgets cover content the rest of the catalog can't express:
+
+- ``model-viewer`` — an interactive 3D model (``.glb`` / ``.gltf``)
+  with orbit / zoom / pan. For product viewers, 3D asset previews,
+  AR-style showcases. NOT for charts or flat images.
+- ``embed`` — the **sanctioned escape hatch**. Use it ONLY when no
+  catalog widget fits: a live CodePen / CodeSandbox, an Observable
+  notebook, a Figma frame, a self-contained D3 / canvas viz.
+  - ``mode`` is **required** — ``"url"`` or ``"srcdoc"``.
+  - ``mode:"url"`` — the ``url`` must be **https** and its host must be
+    on the embed allow-list (youtube-nocookie.com, player.vimeo.com,
+    codepen.io, codesandbox.io, observablehq.com, www.figma.com). A
+    non-allow-listed or ``http`` URL is **rejected at ingest** — the
+    pocket fails to save.
+  - ``mode:"srcdoc"`` — self-contained inline HTML, for a self-contained
+    viz only; never to wrap catalog widgets.
+  - The iframe ``sandbox`` is **renderer-controlled** — do NOT emit a
+    ``sandbox`` prop, it is ignored.
+
+``embed`` is a last resort. If a catalog widget fits, use the catalog
+widget — it always reads better than an iframe.
 
 ## STEP 3 — Draft the rippleSpec
 

--- a/src/pocketpaw/bundled_skills/_bundled/pocketpaw-edit-pocket/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/pocketpaw-edit-pocket/SKILL.md
@@ -49,6 +49,7 @@ The user wants the canvas to change.
   ✓ "rebuild this as a kanban"
   ✓ "make this less cluttered"
   ✓ "switch the layout to tabs"
+  ✓ "embed this CodePen" / "add a 3D model viewer"
 
 → Use the **EDIT DECISION TREE** below to pick the right delegation
    shape, then call ``mcp__pocketpaw_pocket_specialist__edit``.
@@ -186,6 +187,13 @@ Three outcomes:
   user and stop. Do NOT improvise with shell, files, or HTTP.
 - **Always pass the pocket_id**. The current pocket is the one in
   the ``<current-pocket>`` block — don't ask the user.
+- **Escape-hatch widgets.** The catalog includes ``model-viewer`` (3D
+  ``.glb`` / ``.gltf`` viewer) and ``embed`` (the sanctioned escape
+  hatch for a CodePen / Figma / Observable / self-contained viz). When
+  the user asks for one, pass the intent through to the specialist —
+  but note an ``embed`` in ``mode:"url"`` form is rejected at ingest
+  unless its ``url`` is https and on the embed host allow-list. Reach
+  for ``embed`` only when no catalog widget fits.
 
 ## When NOT to use this skill
 

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,9 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-05-22: Added ``ripple_embed_allowed_hosts`` — host allow-list
+    for the Ripple ``embed`` widget's ``mode:"url"`` form (Increment 5,
+    escape-hatch node + embed URL policy).
   - 2026-05-22: Added ``pocket_router_enabled`` (kill-switch) and
     ``pocket_router_min_confidence`` (cheap-tier confidence floor) for
     the pocket execution router (Increment 3).
@@ -1192,6 +1195,25 @@ class Settings(BaseSettings):
     ripple_manifest_ttl_seconds: int = Field(
         default=86400,
         description="TTL in seconds for cached Ripple manifest (default: 24h)",
+    )
+    ripple_embed_allowed_hosts: list[str] = Field(
+        default_factory=lambda: [
+            "youtube-nocookie.com",
+            "player.vimeo.com",
+            "codepen.io",
+            "codesandbox.io",
+            "observablehq.com",
+            "www.figma.com",
+        ],
+        description=(
+            'Host allow-list for the Ripple `embed` widget\'s `mode:"url"` form. '
+            "An `embed` URL must be https and its host must match an entry here "
+            "(exact or sub-domain). Set via POCKETPAW_RIPPLE_EMBED_ALLOWED_HOSTS "
+            'as a JSON array. A literal `["*"]` widens it to every host; even '
+            "then loopback / private / link-local / cloud-metadata hosts stay "
+            "hard-blocked. Defaults to a curated set of sandbox-friendly "
+            "embed providers."
+        ),
     )
 
     # File extraction chain (Phase 1, "Files as Knowledge")

--- a/src/pocketpaw/ripple/_design.py
+++ b/src/pocketpaw/ripple/_design.py
@@ -19,6 +19,11 @@
 # WIDGET_SHAPES dict (per-widget lazy retrieval) and added
 # OPTIONAL_DESIGN_SECTIONS for the two-tier inline widget_help lookup.
 # Reworked from PR #1106.
+# Modified: 2026-05-22 (Increment 5) — added the two escape-hatch
+# widgets `model-viewer` and `embed` to WIDGET_CATALOG + WIDGET_SHAPES,
+# and amended NO_INVENTED_WIDGETS_RULE to name `embed` as the sanctioned
+# escape hatch (the renderer sandboxes the iframe; the catalog gate
+# blocks any non-catalog `type`).
 
 WIDGET_CATALOG = """\
 # WIDGET CATALOG
@@ -34,7 +39,9 @@ display     heading, text, badge, metric, stat, progress, progress-ring,
             icon, quote, highlight, definition-list, comparison-table,
             pros-cons, steps, status-dot, trend, link-preview, qr,
             diff, copy, chip, empty-state, loading, skeleton,
-            company-header, article-meta, soul-status, c4, terminal
+            company-header, article-meta, soul-status, c4, terminal,
+            model-viewer
+escape      embed
 input       button, input, textarea, select, combobox, multi-select,
             checkbox, switch, radio-group, slider, rating, date-picker,
             time-picker, number-input, segmented, color-picker,
@@ -320,8 +327,33 @@ Common rebuild antipatterns and their fixes:
                                             `type` like `flex` or
                                             `page-header`.
 
-If a shape isn't in the catalog and isn't expressible by composing
-catalog widgets, OMIT it and tell the user in prose. Do NOT invent.
+## The ONE sanctioned escape hatch — `embed`
+
+There is exactly one exception to "compose, don't extend". If a shape
+genuinely cannot be built from catalog widgets — a live CodePen, a
+Figma frame, an Observable notebook, a self-contained D3 / canvas
+visualization — use the `embed` widget. It is the sanctioned escape
+hatch and IS in the catalog:
+
+  - `embed` with `mode:"url"` points a renderer-sandboxed iframe at a
+    third-party page. The `url` must be https AND its host must be on
+    the embed allow-list — a non-allow-listed or http URL is rejected
+    at ingest.
+  - `embed` with `mode:"srcdoc"` renders self-contained inline HTML in
+    a sandboxed iframe — for a self-contained viz only, never to wrap
+    catalog widgets.
+  - The iframe `sandbox` attribute is RENDERER-CONTROLLED. Do NOT emit
+    a `sandbox` prop — it is ignored.
+
+`embed` is a last resort, not a shortcut. If a catalog widget fits the
+shape, use the catalog widget. Reaching for `embed` to dodge learning
+a widget's props is the wrong call — the catalog gate allows `embed`,
+but a real `chart` / `table` / `kanban` always reads better than an
+iframe.
+
+If a shape isn't in the catalog, isn't expressible by composing
+catalog widgets, and genuinely isn't `embed`-able either, OMIT it and
+tell the user in prose. Do NOT invent a new `type`.
 """
 
 
@@ -614,6 +646,74 @@ one child per tab by index. Do NOT use `props.tabs[i].content` — ignored:
   one screen would feel CROWDED with structurally different things,
   tabs are correct. If it would feel REPETITIVE (same widget, same
   rows, just filtered differently), use a filter — not tabs.
+""",
+    "model-viewer": """\
+`model-viewer` — renders an interactive 3D model (`.glb` / `.gltf`)
+with orbit / zoom / pan controls. Reach for it when the brief is a
+product viewer, a 3D asset preview, an AR-style showcase, or any
+"spin the object" surface — NOT for charts, NOT for images (use
+`image` for a flat picture).
+
+  { "type": "model-viewer", "props": {
+      "src": "https://cdn.example.com/models/headset.glb",
+      "alt": "Wireless headset, 3D model",
+      "poster": "https://cdn.example.com/models/headset.webp",
+      "autoRotate": true,
+      "cameraControls": true,
+      "height": 420
+  }}
+
+  - `src` *(required)* — https URL to a `.glb` / `.gltf` model.
+  - `alt` — accessibility description of the model.
+  - `poster` — image shown while the model loads.
+  - `autoRotate` — slow idle spin (default off).
+  - `cameraControls` — user orbit / zoom / pan (default on).
+  - `height` — viewport height in px.
+
+  One `model-viewer` IS the canvas — give it room; do not crowd it
+  with stat tiles.
+""",
+    "embed": """\
+`embed` — THE SANCTIONED ESCAPE HATCH. Use it ONLY when the content
+genuinely cannot be expressed with a catalog widget: a live CodePen /
+CodeSandbox, an Observable notebook cell, a Figma frame, a self-
+contained D3 / canvas visualization. If a catalog widget fits, use
+the catalog widget — `embed` is the last resort, not a shortcut.
+
+  *** `mode` IS REQUIRED — it is `"url"` or `"srcdoc"`. ***
+
+  mode "url" — point a SANDBOXED iframe at a third-party page:
+    { "type": "embed", "props": {
+        "mode": "url",
+        "url": "https://codepen.io/team/pen/abc123",
+        "height": 480,
+        "title": "Animated CSS gradient demo"
+    }}
+    - `url` MUST be https and its host MUST be on the embed
+      allow-list (configured providers: youtube-nocookie.com,
+      player.vimeo.com, codepen.io, codesandbox.io, observablehq.com,
+      www.figma.com). A non-allow-listed or http URL is REJECTED at
+      ingest — the pocket fails to save.
+    - loopback / private / internal hosts are blocked unconditionally.
+
+  mode "srcdoc" — render self-contained inline HTML in a sandboxed
+  iframe (use for a self-contained viz, never to wrap catalog widgets):
+    { "type": "embed", "props": {
+        "mode": "srcdoc",
+        "srcdoc": "<canvas id=c></canvas><script>/* self-contained */</script>",
+        "height": 360,
+        "title": "Generative art sketch"
+    }}
+
+  *** THE `sandbox` ATTRIBUTE IS RENDERER-CONTROLLED — NOT AUTHOR-
+  SETTABLE. *** Do NOT emit a `sandbox` prop. The renderer applies the
+  sandbox policy itself; an author-supplied `sandbox` is ignored.
+
+  - `mode` *(required)* — `"url"` or `"srcdoc"`.
+  - `url` — required when `mode:"url"`; https + allow-listed host only.
+  - `srcdoc` — required when `mode:"srcdoc"`; self-contained HTML only.
+  - `height` — iframe height in px.
+  - `title` — accessibility title for the iframe.
 """,
 }
 

--- a/src/pocketpaw/ripple/manifest.py
+++ b/src/pocketpaw/ripple/manifest.py
@@ -9,18 +9,46 @@ formats it as a markdown block suitable for system-prompt injection.
 On any failure (network, timeout, parse, schema), get_manifest()
 returns None — the caller is expected to fall back to a different
 source (today: kb scope search).
+
+Changes:
+  - 2026-05-22 (Increment 5): added ``validate_against_catalog`` — a
+    catalog-as-allowlist ingest gate that flags any node whose ``type``
+    is not in the widget manifest (sibling to ``validate_against_manifest``,
+    which only checks prop drift). Plus ``check_embed_node`` /
+    ``check_embed_nodes_in_spec`` — an https-only, host-allowlisted URL
+    policy for the sanctioned ``embed`` escape-hatch widget, with
+    loopback / private / link-local hosts hard-blocked unconditionally.
 """
 
 from __future__ import annotations
 
+import difflib
 import json
 import logging
 import time
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 
 logger = logging.getLogger(__name__)
+
+# Control-flow node types that are always allowed alongside catalog
+# widgets — they carry no widget ``type`` from the renderer's closed
+# registry, they're spec grammar (``each`` loops, ``if`` gates).
+_CONTROL_FLOW_TYPES: frozenset[str] = frozenset({"if", "each"})
+
+# Curated default host allow-list for the ``embed`` widget's ``url`` mode.
+# These providers ship sandbox-friendly iframe-embeddable pages. The
+# operator can widen this via ``POCKETPAW_RIPPLE_EMBED_ALLOWED_HOSTS``.
+DEFAULT_EMBED_ALLOWED_HOSTS: tuple[str, ...] = (
+    "youtube-nocookie.com",
+    "player.vimeo.com",
+    "codepen.io",
+    "codesandbox.io",
+    "observablehq.com",
+    "www.figma.com",
+)
 
 _FETCH_TIMEOUT_SECONDS = 5.0
 _SCHEMA = "ripple.manifest/v1"
@@ -203,6 +231,255 @@ def _walk_validate(
     if isinstance(children, list):
         for i, child in enumerate(children):
             _walk_validate(child, f"{path}.children[{i}]", by_type, apply_aliases, issues)
+
+
+# ---------------------------------------------------------------------------
+# Catalog-as-allowlist ingest gate (Increment 5).
+#
+# Where ``validate_against_manifest`` checks per-widget *prop* drift, this
+# gate checks the ``type`` itself: a node whose ``type`` is not a known
+# catalog widget renders as a red "Unknown widget type" box. Catching it
+# at ingest time lets the agent-generation path retry with a corrective
+# prompt instead of shipping the broken box to the user.
+# ---------------------------------------------------------------------------
+
+
+def allowed_types_from_manifest(manifest: dict[str, Any]) -> list[str]:
+    """Extract the widget ``type`` list from a parsed manifest.
+
+    The widget-manifest's ``widgets`` array is the catalog allow-list.
+    Returns a sorted list of unique string types; ``[]`` when the
+    manifest has no widgets.
+    """
+    widgets = manifest.get("widgets") or []
+    types: set[str] = set()
+    for w in widgets:
+        t = w.get("type")
+        if isinstance(t, str) and t:
+            types.add(t)
+    return sorted(types)
+
+
+def validate_against_catalog(
+    spec: dict[str, Any] | None,
+    allowed_types: list[str] | set[str],
+) -> list[dict[str, Any]]:
+    """Walk a rippleSpec tree and flag every node whose ``type`` is not in
+    the catalog allow-list.
+
+    ``allowed_types`` is the widget-manifest type list (the renderer's
+    closed widget registry). The control-flow types ``if`` and ``each``
+    are always allowed on top of it — they're spec grammar, not widgets.
+
+    Returns one issue dict per offending node; ``[]`` when ``spec`` is not
+    a dict or every node's type is known. Issue shape::
+
+        {
+          "path": "ui.children[2]",
+          "type": "revenue-card",
+          "suggestion": "card",      # nearest catalog match, or None
+        }
+
+    ``suggestion`` is the closest catalog widget by edit distance
+    (``difflib.get_close_matches``) so a corrective prompt can point the
+    agent at the right name. It is ``None`` when nothing is close.
+    """
+    if not isinstance(spec, dict):
+        return []
+    allowed: set[str] = set(allowed_types) | _CONTROL_FLOW_TYPES
+    # Suggestion pool excludes the control-flow types — suggesting `if`
+    # / `each` for a mistyped widget name is never the right fix.
+    pool = sorted(set(allowed_types))
+
+    root = spec.get("ui") if isinstance(spec.get("ui"), dict) else spec
+    issues: list[dict[str, Any]] = []
+    _walk_catalog(root, "ui", allowed, pool, issues)
+    return issues
+
+
+def _walk_catalog(
+    node: Any,
+    path: str,
+    allowed: set[str],
+    pool: list[str],
+    issues: list[dict[str, Any]],
+) -> None:
+    if not isinstance(node, dict):
+        return
+
+    wtype = node.get("type")
+    if isinstance(wtype, str) and wtype and wtype not in allowed:
+        matches = difflib.get_close_matches(wtype, pool, n=1, cutoff=0.6)
+        issues.append(
+            {
+                "path": path,
+                "type": wtype,
+                "suggestion": matches[0] if matches else None,
+            }
+        )
+
+    for key in ("children", "else_children"):
+        kids = node.get(key)
+        if isinstance(kids, list):
+            for i, child in enumerate(kids):
+                _walk_catalog(child, f"{path}.{key}[{i}]", allowed, pool, issues)
+
+
+# ---------------------------------------------------------------------------
+# Embed URL / host policy (Increment 5).
+#
+# The `embed` widget is the sanctioned escape hatch for content the widget
+# catalog can't express (a CodePen, a Figma frame, a self-contained viz).
+# Its `mode: "url"` form points an iframe at a third-party page, so the URL
+# is an SSRF / clickjacking boundary: https-only, host must be allow-listed,
+# and loopback / private / link-local / cloud-metadata hosts are blocked
+# UNCONDITIONALLY — even if the allow-list is widened to ``["*"]``.
+# ---------------------------------------------------------------------------
+
+
+def _host_allowed(host: str, allowed_hosts: list[str] | set[str]) -> bool:
+    """Return True when ``host`` is permitted by the allow-list.
+
+    A literal ``"*"`` entry widens the allow-list to every host (the
+    operator's explicit opt-in). Otherwise a host matches when it equals
+    an allow-list entry exactly, or is a sub-domain of one.
+    """
+    host = host.lower().rstrip(".")
+    for entry in allowed_hosts:
+        if not isinstance(entry, str) or not entry:
+            continue
+        if entry == "*":
+            return True
+        e = entry.lower().rstrip(".")
+        if host == e or host.endswith("." + e):
+            return True
+    return False
+
+
+def check_embed_url(url: Any, allowed_hosts: list[str] | set[str]) -> str | None:
+    """Validate one ``embed`` node ``url`` against the embed policy.
+
+    Returns ``None`` when the URL passes. Returns a human-readable reason
+    string when it fails. The policy, in order:
+
+    * ``url`` must be a non-empty string.
+    * scheme must be ``https`` — plain ``http`` is rejected.
+    * host must be present.
+    * loopback / RFC1918 / link-local / carrier-grade-NAT / cloud-metadata
+      hosts are hard-blocked **unconditionally** — this survives an
+      ``allowed_hosts`` widened to ``["*"]``.
+    * host must be in ``allowed_hosts`` (or ``allowed_hosts`` contains
+      ``"*"``).
+    """
+    # Imported here, not at module top, to keep the OSS-core import graph
+    # of this module light — the SSRF host classifier lives in security/.
+    from pocketpaw.security.url_validators import host_is_internal
+
+    if not isinstance(url, str) or not url.strip():
+        return "embed url must be a non-empty string"
+    parts = urlsplit(url.strip())
+    if parts.scheme != "https":
+        return f"embed url scheme '{parts.scheme or '(none)'}' not allowed — must be https"
+    if not parts.hostname:
+        return f"embed url has no host: {url!r}"
+    host = parts.hostname
+    # Hard block runs BEFORE the allow-list check so a `["*"]` allow-list
+    # can never re-enable an internal target.
+    if host_is_internal(host):
+        return (
+            f"embed url host '{host}' is loopback/private/link-local — "
+            f"blocked unconditionally (SSRF / metadata-endpoint protection)"
+        )
+    if not _host_allowed(host, allowed_hosts):
+        return f"embed url host '{host}' is not in the embed allow-list"
+    return None
+
+
+def check_embed_node(
+    node: dict[str, Any],
+    allowed_hosts: list[str] | set[str],
+) -> str | None:
+    """Validate a single ``embed`` node's policy.
+
+    Only ``mode: "url"`` embeds carry a URL boundary — a ``mode:
+    "srcdoc"`` embed is self-contained HTML and is not checked here.
+    Returns ``None`` when the node passes (or is not a URL-mode embed);
+    a reason string otherwise.
+    """
+    if not isinstance(node, dict) or node.get("type") != "embed":
+        return None
+    props = node.get("props")
+    if not isinstance(props, dict):
+        return None
+    if props.get("mode") != "url":
+        return None
+    return check_embed_url(props.get("url"), allowed_hosts)
+
+
+def find_embed_nodes(spec: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Walk a rippleSpec tree and return every ``embed`` node found.
+
+    Used by the ingest pipeline to decide whether a spec needs an
+    embed-policy check and an audit-log entry.
+    """
+    if not isinstance(spec, dict):
+        return []
+    root = spec.get("ui") if isinstance(spec.get("ui"), dict) else spec
+    found: list[dict[str, Any]] = []
+    _walk_collect_embeds(root, found)
+    return found
+
+
+def _walk_collect_embeds(node: Any, found: list[dict[str, Any]]) -> None:
+    if not isinstance(node, dict):
+        return
+    if node.get("type") == "embed":
+        found.append(node)
+    for key in ("children", "else_children"):
+        kids = node.get(key)
+        if isinstance(kids, list):
+            for child in kids:
+                _walk_collect_embeds(child, found)
+
+
+def check_embed_nodes_in_spec(
+    spec: dict[str, Any] | None,
+    allowed_hosts: list[str] | set[str],
+) -> list[dict[str, Any]]:
+    """Walk a rippleSpec tree and flag every ``embed`` node that violates
+    the URL/host policy.
+
+    Returns one issue dict per offending node; ``[]`` when the spec has no
+    policy-violating embeds. Issue shape::
+
+        { "path": "ui.children[1]", "url": "http://...", "reason": "..." }
+    """
+    if not isinstance(spec, dict):
+        return []
+    root = spec.get("ui") if isinstance(spec.get("ui"), dict) else spec
+    issues: list[dict[str, Any]] = []
+    _walk_embed_policy(root, "ui", allowed_hosts, issues)
+    return issues
+
+
+def _walk_embed_policy(
+    node: Any,
+    path: str,
+    allowed_hosts: list[str] | set[str],
+    issues: list[dict[str, Any]],
+) -> None:
+    if not isinstance(node, dict):
+        return
+    reason = check_embed_node(node, allowed_hosts)
+    if reason is not None:
+        props = node.get("props")
+        url = props.get("url") if isinstance(props, dict) else None
+        issues.append({"path": path, "url": url, "reason": reason})
+    for key in ("children", "else_children"):
+        kids = node.get(key)
+        if isinstance(kids, list):
+            for i, child in enumerate(kids):
+                _walk_embed_policy(child, f"{path}.{key}[{i}]", allowed_hosts, issues)
 
 
 def format_for_prompt(manifest: dict[str, Any]) -> str:

--- a/tests/cloud/test_pocket_catalog_gate.py
+++ b/tests/cloud/test_pocket_catalog_gate.py
@@ -1,0 +1,156 @@
+# tests/cloud/test_pocket_catalog_gate.py
+# Created: 2026-05-22 (Increment 5) — service-level tests for the
+# catalog-as-allowlist ingest gate wiring in pockets/service.py: the
+# embed-ingest audit-log entry and the strict/logged _gate_catalog
+# dispatch. EE-gated (tests/cloud/conftest.py + the explicit
+# importorskip below) so the OSS-only CI scope skips this file.
+"""Tests for the pockets-service catalog gate + embed-ingest audit log."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.pockets import service as pockets_service  # noqa: E402
+from pocketpaw_ee.cloud.ripple_validator import CatalogViolationError  # noqa: E402
+
+from pocketpaw.security.audit import get_audit_logger  # noqa: E402
+
+# `asyncio_mode = "auto"` (see pyproject) runs the async tests below
+# without an explicit marker; the sync tests run as-is.
+
+
+def _capture_audit() -> tuple[list[dict], callable]:
+    """Register a one-shot capture callback on the singleton audit logger.
+
+    Returns ``(captured_list, deregister)``. The audit logger has no
+    public deregister, so the returned cleanup pops the callback off the
+    private ``_callbacks`` list.
+    """
+    captured: list[dict] = []
+    logger = get_audit_logger()
+
+    def _cb(event_dict: dict) -> None:
+        captured.append(event_dict)
+
+    logger.on_log(_cb)
+
+    def _deregister() -> None:
+        try:
+            logger._callbacks.remove(_cb)
+        except ValueError:
+            pass
+
+    return captured, _deregister
+
+
+# ---------------------------------------------------------------------------
+# _audit_embed_ingest — fires only when the spec carries an embed node
+# ---------------------------------------------------------------------------
+
+
+def test_audit_embed_ingest_fires_for_embed_bearing_spec() -> None:
+    captured, deregister = _capture_audit()
+    try:
+        spec = {
+            "ui": {
+                "type": "flex",
+                "children": [
+                    {
+                        "type": "embed",
+                        "props": {"mode": "url", "url": "https://codepen.io/x"},
+                    }
+                ],
+            }
+        }
+        pockets_service._audit_embed_ingest(spec, actor="u1", workspace_id="w1", pocket_id="p1")
+    finally:
+        deregister()
+
+    embed_events = [e for e in captured if e.get("action") == "pocket.embed_ingest"]
+    assert len(embed_events) == 1
+    ctx = embed_events[0].get("context", {})
+    assert ctx.get("embed_count") == 1
+    assert ctx.get("embed_urls") == ["https://codepen.io/x"]
+    assert ctx.get("pocket_id") == "p1"
+
+
+def test_audit_embed_ingest_silent_for_embed_free_spec() -> None:
+    captured, deregister = _capture_audit()
+    try:
+        spec = {"ui": {"type": "flex", "children": [{"type": "stat", "props": {}}]}}
+        pockets_service._audit_embed_ingest(spec, actor="u1", workspace_id="w1", pocket_id="p1")
+    finally:
+        deregister()
+
+    assert [e for e in captured if e.get("action") == "pocket.embed_ingest"] == []
+
+
+# ---------------------------------------------------------------------------
+# _gate_catalog — strict raises, logged does not; embed always audited
+# ---------------------------------------------------------------------------
+
+
+async def test_gate_catalog_strict_raises_on_unknown_type(monkeypatch) -> None:
+    # Stub the manifest fetch so the gate has a deterministic allow-list
+    # without a network round-trip.
+    async def _fake_allowed() -> list[str]:
+        return ["flex", "stat"]
+
+    monkeypatch.setattr(pockets_service, "_catalog_allowed_types", _fake_allowed)
+
+    spec = {"ui": {"type": "flex", "children": [{"type": "ghost-widget", "props": {}}]}}
+    with pytest.raises(CatalogViolationError):
+        await pockets_service._gate_catalog(spec, strict=True, actor="u1", workspace_id="w1")
+
+
+async def test_gate_catalog_logged_does_not_raise(monkeypatch) -> None:
+    async def _fake_allowed() -> list[str]:
+        return ["flex", "stat"]
+
+    monkeypatch.setattr(pockets_service, "_catalog_allowed_types", _fake_allowed)
+
+    spec = {"ui": {"type": "flex", "children": [{"type": "ghost-widget", "props": {}}]}}
+    # Must not raise — logged mode records the violation only.
+    await pockets_service._gate_catalog(spec, strict=False, actor="u1", workspace_id="w1")
+
+
+async def test_gate_catalog_skipped_when_manifest_unavailable(monkeypatch) -> None:
+    """When the widget manifest can't be fetched the gate is a no-op —
+    a violating spec must NOT raise."""
+
+    async def _no_manifest() -> None:
+        return None
+
+    monkeypatch.setattr(pockets_service, "_catalog_allowed_types", _no_manifest)
+
+    spec = {"ui": {"type": "ghost-widget", "props": {}}}
+    # Best-effort: no manifest → no gate → no raise.
+    await pockets_service._gate_catalog(spec, strict=True, actor="u1", workspace_id="w1")
+
+
+async def test_gate_catalog_audits_embed_even_when_manifest_unavailable(
+    monkeypatch,
+) -> None:
+    async def _no_manifest() -> None:
+        return None
+
+    monkeypatch.setattr(pockets_service, "_catalog_allowed_types", _no_manifest)
+
+    captured, deregister = _capture_audit()
+    try:
+        spec = {
+            "ui": {
+                "type": "embed",
+                "props": {"mode": "url", "url": "https://www.figma.com/file/x"},
+            }
+        }
+        await pockets_service._gate_catalog(
+            spec, strict=True, actor="u1", workspace_id="w1", pocket_id="p9"
+        )
+    finally:
+        deregister()
+
+    # The embed audit fires regardless of whether the manifest was reachable.
+    assert any(e.get("action") == "pocket.embed_ingest" for e in captured)

--- a/tests/cloud/test_ripple_validator.py
+++ b/tests/cloud/test_ripple_validator.py
@@ -1,12 +1,27 @@
+# tests/cloud/test_ripple_validator.py
+# Updated: 2026-05-22 (Increment 5) — added the catalog-as-allowlist gate
+# tests: CatalogViolationError, validate_against_catalog_strict/_logged,
+# the embed URL/host policy via the validator, and format_violations_for_agent.
 """Tests for ripple_validator — grammar warnings on AI-generated specs."""
 
 from __future__ import annotations
 
+import logging
+
 import pytest
-from pocketpaw_ee.cloud.ripple_validator import (
+
+# EE-gated: skip cleanly in the `Test (OSS-only)` CI scope, which has no
+# pocketpaw_ee on disk. (tests/cloud/conftest.py also gates the tree.)
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.ripple_validator import (  # noqa: E402
+    CatalogViolationError,
     ExpressionWarning,
     RippleSpecGrammarError,
+    format_violations_for_agent,
     format_warnings_for_agent,
+    validate_against_catalog_logged,
+    validate_against_catalog_strict,
     validate_ripple_spec,
     validate_ripple_spec_strict,
 )
@@ -162,3 +177,107 @@ def test_whitelisted_methods_do_not_warn() -> None:
     for m in methods:
         spec = {"ui": {"props": {"x": f"{{state.collection.{m}}}"}}}
         assert validate_ripple_spec(spec) == [], f"method {m} should be allowed"
+
+
+# ---------------------------------------------------------------------------
+# Catalog-as-allowlist gate (Increment 5)
+# ---------------------------------------------------------------------------
+
+_ALLOWED = ["flex", "card", "stat", "chart", "embed"]
+_EMBED_HOSTS = ["codepen.io", "www.figma.com"]
+
+
+def test_catalog_strict_passes_a_valid_spec() -> None:
+    spec = {"ui": {"type": "flex", "children": [{"type": "stat", "props": {}}]}}
+    # Must not raise.
+    validate_against_catalog_strict(spec, _ALLOWED, embed_allowed_hosts=_EMBED_HOSTS)
+
+
+def test_catalog_strict_raises_on_unknown_type() -> None:
+    spec = {"ui": {"type": "flex", "children": [{"type": "revenue-card", "props": {}}]}}
+    with pytest.raises(CatalogViolationError) as exc:
+        validate_against_catalog_strict(spec, _ALLOWED, embed_allowed_hosts=_EMBED_HOSTS)
+    assert len(exc.value.violations) == 1
+    assert exc.value.violations[0]["type"] == "revenue-card"
+
+
+def test_catalog_strict_suggests_nearest_match() -> None:
+    """A near-miss type name gets a corrective suggestion."""
+    spec = {"ui": {"type": "carde", "children": []}}
+    with pytest.raises(CatalogViolationError) as exc:
+        validate_against_catalog_strict(spec, _ALLOWED, embed_allowed_hosts=_EMBED_HOSTS)
+    assert exc.value.violations[0]["suggestion"] == "card"
+
+
+def test_catalog_strict_raises_on_bad_embed_url() -> None:
+    spec = {
+        "ui": {
+            "type": "embed",
+            "props": {"mode": "url", "url": "http://codepen.io/x"},
+        }
+    }
+    with pytest.raises(CatalogViolationError) as exc:
+        validate_against_catalog_strict(spec, _ALLOWED, embed_allowed_hosts=_EMBED_HOSTS)
+    assert "reason" in exc.value.violations[0]
+
+
+def test_catalog_logged_does_not_raise(caplog: pytest.LogCaptureFixture) -> None:
+    spec = {"ui": {"type": "flex", "children": [{"type": "made-up", "props": {}}]}}
+    with caplog.at_level(logging.WARNING):
+        violations = validate_against_catalog_logged(
+            spec, _ALLOWED, embed_allowed_hosts=_EMBED_HOSTS
+        )
+    # Logged path returns the violations but never raises.
+    assert len(violations) == 1
+    assert violations[0]["type"] == "made-up"
+    assert any("unknown_widget_type" in r.message for r in caplog.records)
+
+
+def test_catalog_logged_warns_on_embed_violation(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    spec = {
+        "ui": {
+            "type": "embed",
+            "props": {"mode": "url", "url": "https://not-allowed.test/x"},
+        }
+    }
+    with caplog.at_level(logging.WARNING):
+        violations = validate_against_catalog_logged(
+            spec, _ALLOWED, embed_allowed_hosts=_EMBED_HOSTS
+        )
+    assert len(violations) == 1
+    assert any("embed_policy_violation" in r.message for r in caplog.records)
+
+
+def test_catalog_embed_loopback_blocked_even_with_wildcard() -> None:
+    """A `["*"]` embed allow-list must NOT re-enable an internal host."""
+    spec = {
+        "ui": {
+            "type": "embed",
+            "props": {"mode": "url", "url": "https://169.254.169.254/latest/meta-data/"},
+        }
+    }
+    with pytest.raises(CatalogViolationError):
+        validate_against_catalog_strict(spec, _ALLOWED, embed_allowed_hosts=["*"])
+
+
+def test_format_violations_for_agent_is_actionable() -> None:
+    violations = [
+        {"path": "ui.children[0]", "type": "kpi-tile", "suggestion": "stat"},
+        {"path": "ui.children[1]", "url": "http://x.test", "reason": "must be https"},
+    ]
+    text = format_violations_for_agent(violations)
+    assert "kpi-tile" in text
+    assert "stat" in text  # suggestion surfaced
+    assert "must be https" in text
+    assert format_violations_for_agent([]) == ""
+
+
+def test_catalog_violation_error_message_caps_at_20() -> None:
+    violations = [
+        {"path": f"ui.children[{i}]", "type": f"bad-{i}", "suggestion": None} for i in range(25)
+    ]
+    err = CatalogViolationError(violations)
+    assert err.violations == violations
+    assert "and 5 more" in str(err)

--- a/tests/test_ripple_catalog.py
+++ b/tests/test_ripple_catalog.py
@@ -1,0 +1,244 @@
+# tests/test_ripple_catalog.py
+# Created: 2026-05-22 (Increment 5) — OSS-core tests for the
+# catalog-as-allowlist ingest gate (`validate_against_catalog`) and the
+# `embed` URL/host policy in `pocketpaw.ripple.manifest`. No EE imports,
+# so this file runs in the `Test (OSS-only)` CI scope.
+"""Tests for the Ripple catalog allow-list gate + embed URL/host policy."""
+
+from __future__ import annotations
+
+from pocketpaw.ripple.manifest import (
+    DEFAULT_EMBED_ALLOWED_HOSTS,
+    allowed_types_from_manifest,
+    check_embed_node,
+    check_embed_nodes_in_spec,
+    check_embed_url,
+    find_embed_nodes,
+    validate_against_catalog,
+)
+
+# A representative widget allow-list (the widget-manifest type list).
+ALLOWED = ["flex", "card", "stat", "chart", "table", "embed", "model-viewer"]
+
+
+# ---------------------------------------------------------------------------
+# validate_against_catalog
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_returns_empty_for_non_dict_spec() -> None:
+    assert validate_against_catalog(None, ALLOWED) == []
+    assert validate_against_catalog("not a dict", ALLOWED) == []  # type: ignore[arg-type]
+    assert validate_against_catalog([], ALLOWED) == []  # type: ignore[arg-type]
+
+
+def test_catalog_valid_spec_passes() -> None:
+    spec = {
+        "ui": {
+            "type": "flex",
+            "children": [
+                {"type": "stat", "props": {"label": "Revenue", "value": 42}},
+                {"type": "chart", "props": {"type": "bar", "data": []}},
+            ],
+        }
+    }
+    assert validate_against_catalog(spec, ALLOWED) == []
+
+
+def test_catalog_allows_control_flow_types() -> None:
+    """`if` and `each` are spec grammar — always allowed even though they
+    are not in the widget allow-list."""
+    spec = {
+        "ui": {
+            "type": "flex",
+            "children": [
+                {"type": "each", "items": "{state.rows}", "children": []},
+                {"type": "if", "condition": "{state.ok}", "children": []},
+            ],
+        }
+    }
+    assert validate_against_catalog(spec, ALLOWED) == []
+
+
+def test_catalog_flags_unknown_type() -> None:
+    spec = {
+        "ui": {
+            "type": "flex",
+            "children": [{"type": "revenue-card", "props": {}}],
+        }
+    }
+    issues = validate_against_catalog(spec, ALLOWED)
+    assert len(issues) == 1
+    assert issues[0]["path"] == "ui.children[0]"
+    assert issues[0]["type"] == "revenue-card"
+
+
+def test_catalog_suggests_nearest_match() -> None:
+    """An unknown type close to a catalog widget gets a suggestion."""
+    spec = {"ui": {"type": "carde", "children": []}}
+    issues = validate_against_catalog(spec, ALLOWED)
+    assert len(issues) == 1
+    assert issues[0]["type"] == "carde"
+    assert issues[0]["suggestion"] == "card"
+
+
+def test_catalog_suggestion_is_none_when_nothing_close() -> None:
+    spec = {"ui": {"type": "zzzzzzzz", "children": []}}
+    issues = validate_against_catalog(spec, ALLOWED)
+    assert len(issues) == 1
+    assert issues[0]["suggestion"] is None
+
+
+def test_catalog_suggestion_never_points_at_control_flow() -> None:
+    """A mistyped widget name must not be 'corrected' to `if` / `each`."""
+    spec = {"ui": {"type": "eachh", "children": []}}
+    issues = validate_against_catalog(spec, ALLOWED)
+    assert len(issues) == 1
+    assert issues[0]["suggestion"] != "each"
+
+
+def test_catalog_walks_nested_and_else_children() -> None:
+    spec = {
+        "ui": {
+            "type": "flex",
+            "children": [
+                {
+                    "type": "if",
+                    "condition": "{state.x}",
+                    "children": [{"type": "bogus-a", "props": {}}],
+                    "else_children": [{"type": "bogus-b", "props": {}}],
+                }
+            ],
+        }
+    }
+    issues = validate_against_catalog(spec, ALLOWED)
+    types = sorted(i["type"] for i in issues)
+    assert types == ["bogus-a", "bogus-b"]
+
+
+def test_catalog_accepts_bare_node_without_ui_envelope() -> None:
+    bare = {"type": "made-up", "children": []}
+    issues = validate_against_catalog(bare, ALLOWED)
+    assert len(issues) == 1
+    assert issues[0]["type"] == "made-up"
+
+
+def test_catalog_allowed_types_from_manifest() -> None:
+    manifest = {
+        "widgets": [
+            {"type": "stat"},
+            {"type": "chart"},
+            {"type": "stat"},  # duplicate
+            {"type": ""},  # ignored
+            {"no_type": 1},  # ignored
+        ]
+    }
+    assert allowed_types_from_manifest(manifest) == ["chart", "stat"]
+
+
+# ---------------------------------------------------------------------------
+# Embed URL / host policy
+# ---------------------------------------------------------------------------
+
+
+def test_embed_url_https_allowlisted_host_passes() -> None:
+    assert check_embed_url("https://codepen.io/team/pen/abc", DEFAULT_EMBED_ALLOWED_HOSTS) is None
+
+
+def test_embed_url_subdomain_of_allowlisted_host_passes() -> None:
+    assert check_embed_url("https://cdn.codepen.io/x", DEFAULT_EMBED_ALLOWED_HOSTS) is None
+
+
+def test_embed_url_http_scheme_rejected() -> None:
+    reason = check_embed_url("http://codepen.io/x", DEFAULT_EMBED_ALLOWED_HOSTS)
+    assert reason is not None
+    assert "https" in reason
+
+
+def test_embed_url_non_allowlisted_host_rejected() -> None:
+    reason = check_embed_url("https://evil.example.com/x", DEFAULT_EMBED_ALLOWED_HOSTS)
+    assert reason is not None
+    assert "allow-list" in reason
+
+
+def test_embed_url_empty_rejected() -> None:
+    assert check_embed_url("", DEFAULT_EMBED_ALLOWED_HOSTS) is not None
+    assert check_embed_url(None, DEFAULT_EMBED_ALLOWED_HOSTS) is not None
+
+
+def test_embed_url_wildcard_allowlist_permits_any_public_host() -> None:
+    assert check_embed_url("https://anything.example.com/x", ["*"]) is None
+
+
+def test_embed_url_loopback_hard_blocked_even_with_wildcard_allowlist() -> None:
+    """The internal-host hard block must survive a `["*"]` allow-list."""
+    for url in (
+        "https://127.0.0.1/x",
+        "https://localhost/x",
+        "https://10.0.0.5/x",
+        "https://192.168.1.1/x",
+        "https://169.254.169.254/latest/meta-data/",  # cloud metadata
+    ):
+        reason = check_embed_url(url, ["*"])
+        assert reason is not None, f"{url} must be blocked even with ['*']"
+        assert "block" in reason.lower()
+
+
+def test_embed_node_url_mode_checked() -> None:
+    node = {"type": "embed", "props": {"mode": "url", "url": "http://codepen.io/x"}}
+    assert check_embed_node(node, DEFAULT_EMBED_ALLOWED_HOSTS) is not None
+
+
+def test_embed_node_srcdoc_mode_not_url_checked() -> None:
+    """A `srcdoc` embed carries no URL boundary — it is not checked."""
+    node = {"type": "embed", "props": {"mode": "srcdoc", "srcdoc": "<canvas></canvas>"}}
+    assert check_embed_node(node, DEFAULT_EMBED_ALLOWED_HOSTS) is None
+
+
+def test_embed_node_non_embed_passes() -> None:
+    assert check_embed_node({"type": "card"}, DEFAULT_EMBED_ALLOWED_HOSTS) is None
+
+
+def test_find_embed_nodes_walks_tree() -> None:
+    spec = {
+        "ui": {
+            "type": "flex",
+            "children": [
+                {"type": "embed", "props": {"mode": "url", "url": "https://codepen.io/a"}},
+                {
+                    "type": "if",
+                    "condition": "{state.x}",
+                    "else_children": [
+                        {"type": "embed", "props": {"mode": "srcdoc", "srcdoc": "<p>x</p>"}}
+                    ],
+                },
+            ],
+        }
+    }
+    assert len(find_embed_nodes(spec)) == 2
+
+
+def test_check_embed_nodes_in_spec_flags_violations() -> None:
+    spec = {
+        "ui": {
+            "type": "flex",
+            "children": [
+                {"type": "embed", "props": {"mode": "url", "url": "https://codepen.io/ok"}},
+                {"type": "embed", "props": {"mode": "url", "url": "http://evil.test/x"}},
+            ],
+        }
+    }
+    issues = check_embed_nodes_in_spec(spec, DEFAULT_EMBED_ALLOWED_HOSTS)
+    assert len(issues) == 1
+    assert issues[0]["path"] == "ui.children[1]"
+    assert issues[0]["url"] == "http://evil.test/x"
+
+
+def test_check_embed_nodes_in_spec_clean_spec_passes() -> None:
+    spec = {
+        "ui": {
+            "type": "embed",
+            "props": {"mode": "url", "url": "https://www.figma.com/file/abc"},
+        }
+    }
+    assert check_embed_nodes_in_spec(spec, DEFAULT_EMBED_ALLOWED_HOSTS) == []


### PR DESCRIPTION
Completes Increment 5 — the escape-hatch node and catalog-as-allowlist work. The ripple side already merged (`model-viewer` plus a sandboxed `embed` widget and a render-time catalog check); this is the pocketpaw side: an ingest-time gate that catches a bad spec before it is persisted, an embed URL policy, and the agent guidance for the two new widgets.

## Catalog-as-allowlist gate

The Ripple renderer has a closed widget registry — a node whose `type` is not a known widget renders as a red "Unknown widget type" box. `validate_against_catalog` (OSS, `pocketpaw.ripple.manifest`) walks the rippleSpec tree and flags any node whose `type` is not in the widget manifest. The control-flow types `if` and `each` are always allowed — they are spec grammar, not widgets. Each violation reports the nearest catalog match via `difflib` so a corrective prompt can point the agent at the right name.

`CatalogViolationError` plus two entry points mirror the existing `validate_ripple_spec_strict` / `_logged` split:

- **strict** — the agent-generation path raises so the caller can retry the LLM with the corrective message.
- **logged** — the human / import path records a structured warning per violation but does not block (an older imported spec may use a widget that has since left the catalog).

Wired into the pockets validation pipeline alongside the existing validate + normalize calls: strict on `create_from_ripple_spec` and the agent `create` / `update` ops, logged on the human REST `create` / `update` paths. The gate is best-effort — when the widget manifest can't be fetched it is skipped, same posture as the manifest-drift validator.

## Embed URL / host policy

An `embed` node in `mode:"url"` points an iframe at a third-party page, so its `url` is an SSRF / clickjacking boundary. The policy:

- `url` must be **https** — plain `http` is rejected.
- the host must be on a curated allow-list (`POCKETPAW_RIPPLE_EMBED_ALLOWED_HOSTS`, default: youtube-nocookie.com, player.vimeo.com, codepen.io, codesandbox.io, observablehq.com, www.figma.com).
- loopback / RFC1918 / link-local / carrier-grade-NAT / cloud-metadata hosts are hard-blocked **unconditionally** — the block survives an allow-list widened to `["*"]`, reusing the existing `host_is_internal` SSRF classifier.

Every ingested spec carrying an `embed` node is audit-logged (category `pocket_embed`) with the embed count and URLs — never the iframe contents.

## Agent guidance

`model-viewer` (3D `.glb` / `.gltf` viewer) and `embed` are added to the widget catalog, the canonical shapes, and the bundled create / edit skills. The no-invented-widgets rule now names `embed` as the one sanctioned escape hatch. The embed shape spells out that `mode` is required (`url` | `srcdoc`), the iframe `sandbox` is renderer-controlled and not author-settable, a `url` must be https and allow-listed, and `srcdoc` is for self-contained visualizations only.

## Tests

- `tests/test_ripple_catalog.py` — OSS-core coverage for `validate_against_catalog` (unknown type flagged, near-match suggested, control-flow allowed, nested walk) and the embed URL policy (https-only, allow-list match, loopback/private hard-block survives a `["*"]` allow-list). No EE imports, runs in the OSS-only CI scope.
- `tests/cloud/test_ripple_validator.py` — the strict path raises `CatalogViolationError`, the logged path warns without raising, `format_violations_for_agent` is actionable.
- `tests/cloud/test_pocket_catalog_gate.py` — the embed-ingest audit log fires on an embed-bearing spec and is silent otherwise; the strict/logged `_gate_catalog` dispatch.

New tests that import `pocketpaw_ee` guard with `pytest.importorskip("pocketpaw_ee")` so the OSS-only CI job is unaffected.

## Verification

- 80 catalog / ripple tests pass; 155 targeted OSS tests for the touched modules pass.
- `ruff check` and `ruff format --check` clean on every touched file.
- `mypy` clean on the changed code (the one `import-untyped` note on the EE-to-OSS import is the codebase-wide pattern, same as the existing `pocketpaw.security.url_validators` import).
- import-linter: the "OSS core may not import from EE" contract still holds.

## Docs

`docs/api-reference.md` gains a section on the catalog gate, the two escape-hatch widgets, and the embed URL/host policy.