### PR TITLE
Pocket data sources: interval + webhook refresh, refresh-cost controls (RFC 04 M3)

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/pocket_backend.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket_backend.py
@@ -21,6 +21,12 @@
 #   `mode="owner"` (the default when `approval_route` is None) routes to
 #   the pocket owner; `mode="user"` routes to a named workspace member.
 #   It lives HERE alongside the credential — owner-set, outside the spec.
+# Updated: 2026-05-22 (RFC 04 M3) — added `webhook_secret`. A pocket source
+#   binding may declare a `"webhook"` refresh trigger; the inbound endpoint
+#   `POST /pockets/{id}/sources/{source}/refresh` authenticates the caller
+#   against this secret. It lives HERE — generated server-side, on the
+#   credential row, NEVER in the agent-authored spec — so the spec stays
+#   shareable and secret-free. `None` until an owner generates / rotates it.
 
 from __future__ import annotations
 
@@ -87,6 +93,13 @@ class PocketBackendCredential(TimestampedDocument):
     # writes route to the pocket owner. An owner sets a named approver via
     # `PUT /pockets/{id}/backend/approval-route`.
     approval_route: ApprovalRoute | None = None
+    # RFC 04 M3 webhook secret. The shared secret an inbound
+    # `POST /pockets/{id}/sources/{source}/refresh` must present to trigger
+    # a `"webhook"`-refresh source. None until an owner generates one via
+    # `POST /pockets/{id}/backend/webhook/rotate`. Stored in plaintext
+    # (it IS the credential the caller echoes back, like an API key) — a
+    # rotate replaces it, invalidating the previous value.
+    webhook_secret: str | None = None
 
     class Settings:
         name = "pocket_backend_credentials"

--- a/ee/pocketpaw_ee/cloud/pockets/_refresh_budget.py
+++ b/ee/pocketpaw_ee/cloud/pockets/_refresh_budget.py
@@ -1,0 +1,140 @@
+# _refresh_budget.py — cost controls for pocket data-source AUTO-refresh.
+# Created: 2026-05-22 (RFC 04 M3) — RFC 04 alpha shipped read-only pocket
+#   data sources refreshed on `pocket_open` / `manual`. M3 adds two
+#   AUTO-refresh triggers — `interval` (a timer) and `webhook` (an inbound
+#   POST). Both re-run a source with NO human in the loop, so each one is a
+#   real backend call that costs money. This module is the cost gate:
+#
+#   1. `min_interval_seconds()` — the floor an interval is clamped UP to.
+#      A binding's `refresh_interval_seconds: 1` is never honored; the
+#      interval scheduler reads this and clamps.
+#   2. `consume_auto_refresh(pocket_id)` — a PER-POCKET rolling-hour rate
+#      limiter for interval + webhook refreshes. It is DELIBERATELY a
+#      separate counter from the manual `run_source` per-(pocket, user)
+#      limiter in `source_executor._run_log`: a manual click and an
+#      interval/webhook storm must not share a budget, or a flood of one
+#      would starve the other. When the budget is spent the refresh is
+#      SKIPPED (and logged) — never queued — so cost stays bounded.
+#
+# Both settings are env-driven (`POCKETPAW_SOURCE_REFRESH_*`), read through
+# `pocketpaw.config.Settings` so they live in the one documented config
+# home. Reading them per-call (not at import) keeps the values
+# monkeypatchable in tests and live-reconfigurable.
+#
+# IMPORT-LINTER: pure — no Beanie, no models. Only `Settings` + stdlib.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+# Hard lower bound on the configurable floor. Even an operator who sets
+# POCKETPAW_SOURCE_REFRESH_MIN_INTERVAL_SECONDS=0 cannot drive the interval
+# scheduler below this — a 5s floor still bounds the worst case.
+_ABSOLUTE_MIN_INTERVAL_S = 5
+
+_RATE_WINDOW_S = 3600.0  # the per-pocket budget is a rolling hour
+
+
+def _settings():
+    """Load PocketPaw settings. Isolated so a load failure degrades to
+    defaults rather than breaking a refresh."""
+    from pocketpaw.config import Settings
+
+    return Settings.load()
+
+
+def min_interval_seconds() -> int:
+    """Return the interval floor — the smallest gap the interval scheduler
+    will ever leave between two automatic refreshes of one source.
+
+    A source binding's ``refresh_interval_seconds`` is clamped UP to this.
+    Reads ``POCKETPAW_SOURCE_REFRESH_MIN_INTERVAL_SECONDS`` (default 60),
+    itself floored by ``_ABSOLUTE_MIN_INTERVAL_S`` so a misconfigured 0
+    cannot spin the loop.
+    """
+    try:
+        configured = int(_settings().source_refresh_min_interval_seconds)
+    except Exception:  # noqa: BLE001 — a bad config must not break refresh
+        logger.warning("refresh-budget: min-interval config read failed", exc_info=True)
+        configured = 60
+    return max(_ABSOLUTE_MIN_INTERVAL_S, configured)
+
+
+def clamp_interval(requested: int | None) -> int:
+    """Clamp a source's requested interval to the configured floor.
+
+    ``None`` (no interval authored) → the floor itself. A value below the
+    floor → the floor. A value at or above the floor → unchanged. This is
+    the ONE place a sub-floor interval is corrected — the scheduler calls
+    it for every interval source on every pass.
+    """
+    floor = min_interval_seconds()
+    if requested is None:
+        return floor
+    return max(floor, int(requested))
+
+
+def max_per_hour() -> int:
+    """Return the per-pocket auto-refresh budget — the cap on interval +
+    webhook refreshes for one pocket in a rolling hour.
+
+    Reads ``POCKETPAW_SOURCE_REFRESH_MAX_PER_HOUR`` (default 60). A value
+    of 0 disables auto-refresh entirely (every interval/webhook refresh is
+    skipped) — a valid, explicit "turn it off" setting.
+    """
+    try:
+        return max(0, int(_settings().source_refresh_max_per_hour))
+    except Exception:  # noqa: BLE001
+        logger.warning("refresh-budget: max-per-hour config read failed", exc_info=True)
+        return 60
+
+
+# Per-pocket auto-refresh timestamps (rolling hour). Keyed on pocket id
+# ONLY — interval and webhook refreshes share this budget so neither can
+# run up unbounded cost, but it is fully separate from the manual
+# `source_executor._run_log` per-(pocket, user) limiter.
+_auto_refresh_log: dict[str, list[float]] = {}
+
+# Guards the check-and-record on ``_auto_refresh_log`` — the read-filter-
+# write is a TOCTOU race when an interval pass and a webhook hit overlap.
+_auto_refresh_lock = asyncio.Lock()
+
+
+async def consume_auto_refresh(pocket_id: str) -> bool:
+    """Try to spend one unit of ``pocket_id``'s auto-refresh budget.
+
+    Returns ``True`` when the refresh is PERMITTED (and records the spend),
+    ``False`` when the budget is exhausted (caller skips the refresh and
+    logs it — never queues). The check-and-record runs under a lock so an
+    interval pass and a concurrent webhook hit cannot both race past the
+    cap.
+    """
+    budget = max_per_hour()
+    now = time.monotonic()
+    window_start = now - _RATE_WINDOW_S
+    async with _auto_refresh_lock:
+        stamps = [t for t in _auto_refresh_log.get(pocket_id, []) if t >= window_start]
+        if len(stamps) >= budget:
+            _auto_refresh_log[pocket_id] = stamps
+            return False
+        stamps.append(now)
+        _auto_refresh_log[pocket_id] = stamps
+        return True
+
+
+def reset_budget() -> None:
+    """Clear the auto-refresh log. Test-only — production never calls it."""
+    _auto_refresh_log.clear()
+
+
+__all__ = [
+    "clamp_interval",
+    "consume_auto_refresh",
+    "max_per_hour",
+    "min_interval_seconds",
+    "reset_budget",
+]

--- a/ee/pocketpaw_ee/cloud/pockets/refresh_scheduler.py
+++ b/ee/pocketpaw_ee/cloud/pockets/refresh_scheduler.py
@@ -1,0 +1,268 @@
+# refresh_scheduler.py — in-process interval-refresh loop for pocket sources.
+# Created: 2026-05-22 (RFC 04 M3) — RFC 04 alpha refreshed pocket data
+#   sources on `pocket_open` / `manual` only. M3 adds `"interval"` refresh:
+#   a source binding may declare it should re-run on a timer. This module
+#   is that timer — a single asyncio.Task, started from the cloud
+#   lifecycle hook and cancelled cleanly on shutdown.
+#
+# Design:
+#   - One loop, one task. Every `_TICK_SECONDS` it scans the pockets that
+#     carry interval sources (`pockets.service.list_interval_source_pockets`)
+#     and re-runs each source that is DUE.
+#   - "Due" is per (pocket, source): `now - last_run >= clamp_interval(
+#     binding.refresh_interval_seconds)`. The interval is FLOORED — a
+#     hallucinated `refresh_interval_seconds: 1` is clamped up to the
+#     configured minimum (`_refresh_budget.clamp_interval`), never honored.
+#   - Each due source is re-run via `source_executor.run_sources` with
+#     `only_source=<key>` — the SAME executor the manual run endpoint uses,
+#     so the SSRF guards, timeouts and response cap all apply unchanged.
+#   - Before each pocket's refresh the loop spends one unit of that
+#     pocket's auto-refresh budget (`_refresh_budget.consume_auto_refresh`).
+#     A pocket out of budget is SKIPPED (logged) — never queued — so an
+#     interval storm cannot run up unbounded backend cost.
+#   - One pocket erroring NEVER kills the loop: every per-pocket step is
+#     wrapped, the exception logged and swallowed.
+#   - Cancel-safe: the loop re-raises `CancelledError`; `stop_scheduler`
+#     cancels and awaits it so cloud teardown is clean.
+#
+# Opt-in via `POCKETPAW_POCKET_REFRESH_SCHEDULER_ENABLED=true` — default OFF
+# so a pytest run (or a multi-replica deploy that wants exactly one
+# scheduler) does not spawn a background loop. Mirrors the cycles
+# snapshot-scheduler gate.
+#
+# IMPORT-LINTER: never imports Beanie documents — the pocket scan goes
+# through `pockets.service`, the refresh through `source_executor`.
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import time
+
+from pocketpaw_ee.cloud.pockets import _refresh_budget, source_executor
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+logger = logging.getLogger(__name__)
+
+# How often the loop wakes to look for due sources. The actual refresh
+# cadence of any one source is governed by its (floored) interval, not by
+# this tick — the tick only needs to be at least as frequent as the floor.
+_TICK_SECONDS = 30.0
+
+# The synthetic actor recorded on interval-refresh audit entries + used as
+# the `user_id` for the executor's per-(pocket, user) limiter. A reserved
+# id no real user can hold, so an interval pass never eats a member's
+# manual run budget. The PRIMARY auto-refresh cap is the per-pocket budget
+# in `_refresh_budget`; the executor's per-user `_run_log` is a secondary
+# floor that this synthetic id keeps off real users.
+_SCHEDULER_ACTOR = "system:interval-refresh"
+
+_ENV_FLAG = "POCKETPAW_POCKET_REFRESH_SCHEDULER_ENABLED"
+
+# Module-level handle on the running task. The cloud lifecycle hook has no
+# FastAPI `app` to stash it on (LifecycleHook takes no args), so the task
+# lives here. `start`/`stop` are idempotent against this single slot.
+_task: asyncio.Task | None = None
+
+# Last-run timestamps, keyed (pocket_id, source_key). `time.monotonic`
+# values — immune to wall-clock jumps. Bounded by pocket churn; a pocket
+# that drops its interval sources simply stops being scanned and its
+# stale entries are harmless (a few dict slots).
+_last_run: dict[tuple[str, str], float] = {}
+
+
+def is_enabled() -> bool:
+    """True when the interval scheduler is switched on for this process."""
+    return os.environ.get(_ENV_FLAG, "").lower() == "true"
+
+
+def _interval_sources(sources: dict) -> dict[str, dict]:
+    """Pick the interval-refresh sources out of a pocket's ``sources`` dict.
+
+    A source qualifies when it is a dict and ``"interval"`` is in its
+    ``refresh`` list. Malformed entries are skipped — the executor's own
+    parse layer reports them; the scheduler just ignores them.
+    """
+    out: dict[str, dict] = {}
+    for key, binding in (sources or {}).items():
+        if not isinstance(binding, dict):
+            continue
+        if "interval" in (binding.get("refresh") or []):
+            out[key] = binding
+    return out
+
+
+def _due_now(pocket_id: str, source_key: str, binding: dict, now: float) -> bool:
+    """Return True when ``(pocket_id, source_key)`` is due for a refresh.
+
+    Due when it has never run, or when ``now - last_run`` has reached the
+    source's CLAMPED interval. ``clamp_interval`` floors a sub-minimum (or
+    absent) ``refresh_interval_seconds`` to the configured minimum, so a
+    hallucinated tiny interval cannot make a source due every tick.
+    """
+    interval = _refresh_budget.clamp_interval(binding.get("refresh_interval_seconds"))
+    last = _last_run.get((pocket_id, source_key))
+    if last is None:
+        return True
+    return (now - last) >= interval
+
+
+async def _refresh_one_pocket(pocket: dict) -> None:
+    """Re-run every DUE interval source on one pocket.
+
+    Spends one unit of the pocket's auto-refresh budget per due source
+    before the call — an out-of-budget pocket is skipped and logged, never
+    queued. Each refresh goes through the shared ``source_executor`` so the
+    SSRF guards apply. A failure here is caught by the caller and never
+    propagates into the loop.
+    """
+    pocket_id = pocket["pocket_id"]
+    workspace_id = pocket["workspace_id"]
+    sources = _interval_sources(pocket.get("sources") or {})
+    if not sources:
+        return
+
+    now = time.monotonic()
+    due = {k: b for k, b in sources.items() if _due_now(pocket_id, k, b, now)}
+    if not due:
+        return
+
+    creds = await pockets_service.get_pocket_backend_for_executor(workspace_id, pocket_id)
+    if creds is None:
+        # No backend configured — the source cannot run. Stamp last_run so
+        # the loop does not re-evaluate this pocket every single tick.
+        for key in due:
+            _last_run[(pocket_id, key)] = now
+        logger.debug("refresh-scheduler: pocket %s has interval sources but no backend", pocket_id)
+        return
+    base_url, auth_type, auth_header, token, _allowed, _route = creds
+    ripple_spec = await pockets_service.get_pocket_ripple_spec(workspace_id, pocket_id)
+    if ripple_spec is None:
+        return
+
+    for key in due:
+        # Always advance last_run so a persistently failing / budget-blocked
+        # source backs off to its interval rather than retrying every tick.
+        _last_run[(pocket_id, key)] = now
+        if not await _refresh_budget.consume_auto_refresh(pocket_id):
+            logger.info(
+                "refresh-scheduler: pocket %s over auto-refresh budget — skipping source %s",
+                pocket_id,
+                key,
+            )
+            continue
+        try:
+            result = await source_executor.run_sources(
+                pocket_id=pocket_id,
+                user_id=_SCHEDULER_ACTOR,
+                ripple_spec=ripple_spec,
+                base_url=base_url,
+                auth_type=auth_type,
+                auth_header=auth_header,
+                token=token,
+                only_source=key,
+            )
+            if result.get("errors"):
+                logger.debug(
+                    "refresh-scheduler: pocket %s source %s ran with errors: %s",
+                    pocket_id,
+                    key,
+                    result["errors"],
+                )
+        except Exception:
+            # Per-source failure is contained — the loop and the other
+            # sources/pockets continue.
+            logger.warning(
+                "refresh-scheduler: pocket %s source %s refresh failed",
+                pocket_id,
+                key,
+                exc_info=True,
+            )
+
+
+async def run_one_pass() -> int:
+    """Run a single scan-and-refresh pass across every interval pocket.
+
+    Returns the number of pockets visited. Extracted from the loop so a
+    test can exercise one pass without the 30s sleep. Per-pocket failures
+    are caught here so one bad tenant cannot abort the pass.
+    """
+    try:
+        pockets = await pockets_service.list_interval_source_pockets()
+    except Exception:
+        logger.exception("refresh-scheduler: failed to list interval-source pockets")
+        return 0
+
+    for pocket in pockets:
+        try:
+            await _refresh_one_pocket(pocket)
+        except Exception:
+            logger.exception(
+                "refresh-scheduler: pass failed for pocket %s",
+                pocket.get("pocket_id"),
+            )
+    return len(pockets)
+
+
+async def _loop() -> None:
+    """The scheduler loop body — forever, one pass per tick."""
+    logger.info("refresh-scheduler: interval-refresh loop started (tick=%.0fs)", _TICK_SECONDS)
+    while True:
+        try:
+            await asyncio.sleep(_TICK_SECONDS)
+        except asyncio.CancelledError:
+            logger.info("refresh-scheduler: loop cancelled — exiting")
+            raise
+        # run_one_pass already swallows per-pocket errors; the extra guard
+        # here defends against an unexpected failure in the scan helper
+        # itself so the loop never dies.
+        try:
+            await run_one_pass()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("refresh-scheduler: unexpected pass failure")
+
+
+async def start_scheduler() -> None:
+    """Start the interval-refresh loop. Idempotent and gated.
+
+    A no-op when ``POCKETPAW_POCKET_REFRESH_SCHEDULER_ENABLED`` is not
+    ``true`` or when a loop is already running. Called from the cloud
+    lifecycle ``on_startup`` hook.
+    """
+    global _task
+    if not is_enabled():
+        logger.debug("refresh-scheduler: disabled (%s not 'true')", _ENV_FLAG)
+        return
+    if _task is not None and not _task.done():
+        return
+    _task = asyncio.create_task(_loop(), name="pocket-interval-refresh")
+
+
+async def stop_scheduler() -> None:
+    """Cancel + await the interval-refresh loop. Safe to call repeatedly."""
+    global _task
+    task = _task
+    if task is None or task.done():
+        _task = None
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await task
+    _task = None
+
+
+def _reset_for_tests() -> None:
+    """Clear the last-run map. Test-only."""
+    _last_run.clear()
+
+
+__all__ = [
+    "is_enabled",
+    "run_one_pass",
+    "start_scheduler",
+    "stop_scheduler",
+]

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -47,13 +47,26 @@ Updated: 2026-05-22 (security-review fix for PR #1183, SHOULD-FIX 2) —
 absent from the wire dict before constructing ``RunActionResponse`` (the
 DTO is also ``extra="forbid"``), so a resolved write path/params can
 never leak onto the response if the strip drifts.
+
+Updated: 2026-05-22 (RFC 04 M3) — added the webhook-refresh routes:
+
+    POST /pockets/{id}/sources/{source}/refresh — inbound webhook trigger
+    GET  /pockets/{id}/backend/webhook          — read the webhook secret
+    POST /pockets/{id}/backend/webhook/rotate   — rotate the webhook secret
+
+The inbound refresh route is authenticated by a per-pocket SECRET carried
+in the ``X-Pocket-Webhook-Secret`` header — NOT by the cookie/Bearer auth
+chain — so an upstream system can trigger a refresh without a user
+session. A wrong / missing secret returns the SAME 403 whether or not the
+pocket exists, so the endpoint is not a tenant-existence oracle. The two
+secret-management routes are owner-only.
 """
 
 from __future__ import annotations
 
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Header, Query
 from pydantic import BaseModel, Field
 from starlette.responses import Response
 
@@ -382,6 +395,138 @@ async def run_pocket_sources(
         token=token,
         trigger=body.trigger,
         only_source=body.source,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Webhook refresh (RFC 04 M3)
+# ---------------------------------------------------------------------------
+
+
+class WebhookSecretResponse(BaseModel):
+    """The pocket's webhook secret + the inbound URL to call with it.
+
+    Owner-facing. ``secret`` is the value an upstream system echoes back in
+    the ``X-Pocket-Webhook-Secret`` header on the refresh call. ``secret``
+    is ``None`` until an owner runs a rotate.
+    """
+
+    pocket_id: str
+    secret: str | None
+    refresh_path: str
+
+
+@router.post("/{pocket_id}/sources/{source}/refresh")
+async def webhook_refresh_source(
+    pocket_id: str,
+    source: str,
+    x_pocket_webhook_secret: str | None = Header(default=None),
+) -> dict:
+    """Re-run one ``"webhook"``-refresh source — triggered by an upstream
+    system, authenticated by the per-pocket webhook secret.
+
+    This route is DELIBERATELY outside the cookie/Bearer auth chain: an
+    upstream backend has no PocketPaw user session. Authentication is the
+    secret carried in ``X-Pocket-Webhook-Secret`` — generated server-side,
+    stored on the backend-credential row, never in the spec.
+
+    Security:
+    * A wrong / missing / unset secret, a pocket with no backend, and a
+      genuinely-missing pocket ALL return the SAME ``403`` — the endpoint
+      reveals nothing about whether a pocket id exists.
+    * The secret compare is constant-time (``secrets.compare_digest`` in
+      the service).
+    * The refresh is metered by the per-pocket auto-refresh budget — a
+      webhook flood cannot run up unbounded backend cost; over-budget
+      hits are skipped (HTTP 200 with a ``skipped`` marker), not queued.
+    * The named source must actually carry ``"webhook"`` in its refresh
+      policy — a webhook hit cannot run an arbitrary source.
+    """
+    from pocketpaw_ee.cloud.pockets import _refresh_budget, source_executor
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    creds = await pockets_service.resolve_webhook_pocket(pocket_id, x_pocket_webhook_secret or "")
+    if creds is None:
+        # Identical error for every failure mode — not a pocket oracle.
+        raise CloudError(403, "pocket_webhook.unauthorized", "Invalid or missing webhook secret")
+    base_url, auth_type, auth_header, token, _allowed, _route, workspace_id = creds
+
+    ripple_spec = await pockets_service.get_pocket_ripple_spec(workspace_id, pocket_id)
+    if ripple_spec is None:
+        raise CloudError(403, "pocket_webhook.unauthorized", "Invalid or missing webhook secret")
+
+    # The named source must exist AND opt into webhook refresh — a valid
+    # secret does not grant the right to run a non-webhook source.
+    sources = ripple_spec.get("sources")
+    binding = sources.get(source) if isinstance(sources, dict) else None
+    if not isinstance(binding, dict) or "webhook" not in (binding.get("refresh") or []):
+        raise CloudError(
+            404,
+            "pocket_webhook.source_not_found",
+            f"no webhook-refresh source named '{source}' on this pocket",
+        )
+
+    # Per-pocket auto-refresh budget — separate from the manual limiter.
+    if not await _refresh_budget.consume_auto_refresh(pocket_id):
+        return {"ran": [], "errors": [], "skipped": "rate_limited"}
+
+    # no-event: webhook refresh is response-body delivery, not persisted.
+    return await source_executor.run_sources(
+        pocket_id=pocket_id,
+        user_id="system:webhook-refresh",
+        ripple_spec=ripple_spec,
+        base_url=base_url,
+        auth_type=auth_type,
+        auth_header=auth_header,
+        token=token,
+        only_source=source,
+    )
+
+
+@router.get(
+    "/{pocket_id}/backend/webhook",
+    dependencies=[Depends(require_pocket_owner)],
+)
+async def get_pocket_webhook_secret(
+    pocket_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> WebhookSecretResponse:
+    """Read this pocket's webhook secret. Owner-only.
+
+    The secret IS the credential an upstream caller echoes back, so the
+    owner can read it to configure the upstream. ``secret`` is ``None``
+    until a rotate generates one. Returns ``400`` when the pocket has no
+    backend configured.
+    """
+    secret = await pockets_service.get_webhook_secret(workspace_id, pocket_id)
+    return WebhookSecretResponse(
+        pocket_id=pocket_id,
+        secret=secret,
+        refresh_path=f"/api/v1/pockets/{pocket_id}/sources/{{source}}/refresh",
+    )
+
+
+@router.post(
+    "/{pocket_id}/backend/webhook/rotate",
+    dependencies=[Depends(require_pocket_owner)],
+)
+async def rotate_pocket_webhook_secret(
+    pocket_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> WebhookSecretResponse:
+    """Generate a fresh webhook secret for this pocket. Owner-only.
+
+    Rotating invalidates the previous secret immediately — any upstream
+    still sending the old value gets a 403 until reconfigured. Returns
+    ``400`` when the pocket has no backend configured.
+    """
+    secret = await pockets_service.rotate_webhook_secret(workspace_id, user_id, pocket_id)
+    return WebhookSecretResponse(
+        pocket_id=pocket_id,
+        secret=secret,
+        refresh_path=f"/api/v1/pockets/{pocket_id}/sources/{{source}}/refresh",
     )
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -53,6 +53,14 @@ workspace-visible). ``get_pocket_backend`` /
 ``get_pocket_backend_for_executor`` / ``_agent_backend_summary`` now
 carry ``allowed_writes`` so the executor and the edit specialist can see
 the write policy.
+Changes: 2026-05-22 (RFC 04 M3) — added the data-source refresh half:
+``list_interval_source_pockets`` (the scan the interval scheduler
+iterates), ``get_pocket_ripple_spec`` (raw-spec read for an internal,
+already-authenticated refresh caller), and the webhook-secret trio
+``resolve_webhook_pocket`` (constant-time secret auth — returns ``None``
+for every failure so the endpoint is not a pocket-existence oracle),
+``get_webhook_secret`` / ``rotate_webhook_secret`` (owner-only). The
+secret lives on the ``PocketBackendCredential`` row — never in the spec.
 """
 
 from __future__ import annotations
@@ -2578,6 +2586,184 @@ async def remove_pocket_backend(workspace_id: str, user_id: str, pocket_id: str)
     # no-event: see set_pocket_backend — credential rows aren't pocket state.
 
 
+# ---------------------------------------------------------------------------
+# Pocket data-source refresh — interval scan + webhook secret (RFC 04 M3)
+#
+# Interval refresh: the in-process scheduler (``pockets/refresh_scheduler.py``)
+# needs the set of pockets that carry at least one ``"interval"``-refresh
+# source. ``list_interval_source_pockets`` is the scan helper — it stays in
+# the service so the Pocket Beanie read obeys the 4-file rule.
+#
+# Webhook refresh: a ``"webhook"``-refresh source is re-run by an inbound
+# authenticated POST. The shared secret lives on the backend-credential row
+# (NEVER in the spec). The helpers below generate / rotate / resolve it.
+# ---------------------------------------------------------------------------
+
+
+async def list_interval_source_pockets() -> list[dict]:
+    """Return every pocket that declares at least one interval-refresh source.
+
+    Shape per row: ``{pocket_id, workspace_id, sources}`` where ``sources``
+    is the raw ``rippleSpec.sources`` dict. The interval scheduler iterates
+    this set, picks the ``"interval"`` sources, and re-runs each when due.
+
+    Global read (no workspace filter) — the scheduler is a process-wide
+    background loop with no tenant context; it serves every workspace. The
+    Mongo ``$elemMatch`` narrows to sources whose ``refresh`` array contains
+    ``"interval"`` so the loop only loads pockets it can act on.
+    """
+    # global-read: the interval scheduler is a process-wide background loop
+    # with no per-tenant request context; it scans across all workspaces.
+    query: dict[str, Any] = {
+        "rippleSpec.sources": {"$exists": True},
+    }
+    docs = await _PocketDoc.find(query).to_list()
+    out: list[dict] = []
+    for d in docs:
+        spec = d.rippleSpec
+        if not isinstance(spec, dict):
+            continue
+        sources = spec.get("sources")
+        if not isinstance(sources, dict) or not sources:
+            continue
+        has_interval = any(
+            isinstance(b, dict) and "interval" in (b.get("refresh") or []) for b in sources.values()
+        )
+        if not has_interval:
+            continue
+        out.append(
+            {
+                "pocket_id": str(d.id),
+                "workspace_id": d.workspace,
+                "sources": sources,
+            }
+        )
+    return out
+
+
+async def get_pocket_ripple_spec(workspace_id: str, pocket_id: str) -> dict | None:
+    """Return a pocket's raw ``rippleSpec`` for an internal refresh caller.
+
+    Used by the webhook-refresh route — it has already authenticated via
+    the per-pocket webhook secret, so this skips the user-facing access
+    checks in ``get``. Returns ``None`` when the pocket is missing or
+    belongs to a different workspace. ``$source`` markers are NOT resolved
+    — the source executor only reads ``rippleSpec.sources``.
+    """
+    try:
+        doc = await _PocketDoc.get(PydanticObjectId(pocket_id))
+    except Exception:  # noqa: BLE001
+        return None
+    if doc is None or doc.workspace != workspace_id:
+        return None
+    spec = doc.rippleSpec
+    return spec if isinstance(spec, dict) else {}
+
+
+async def resolve_webhook_pocket(pocket_id: str, presented_secret: str) -> tuple | None:
+    """Authenticate an inbound webhook-refresh request by its secret.
+
+    Returns the executor-creds tuple ``(base_url, auth_type, auth_header,
+    token, allowed_writes, approval_route, workspace_id)`` ONLY when the
+    pocket has a backend with a webhook secret AND ``presented_secret``
+    matches it (constant-time compare). Returns ``None`` for EVERY failure
+    — wrong secret, no secret set, no backend, missing pocket — so the
+    caller raises one identical error and the endpoint is not a
+    pocket-existence oracle.
+
+    The comparison uses ``secrets.compare_digest`` so a timing side channel
+    cannot leak the secret. An empty presented secret short-circuits to
+    ``None`` without a DB read.
+    """
+    if not pocket_id or not presented_secret:
+        return None
+    # No workspace filter: the inbound webhook carries no tenant context.
+    # The pocket_id + secret pair IS the credential; the secret compare
+    # below is the gate. The credential row carries its own workspace_id.
+    # global-read: webhook callers present no tenant context — the secret is the gate.
+    doc = await _BackendCredentialDoc.find_one(
+        _BackendCredentialDoc.pocket_id == pocket_id,
+    )
+    if doc is None:
+        return None
+    stored = getattr(doc, "webhook_secret", None)
+    if not stored:
+        return None
+    if not secrets.compare_digest(stored, presented_secret):
+        return None
+
+    token = ""
+    if doc.auth_type != "none" and doc.encrypted_token and doc.nonce and doc.salt:
+        token = backend_crypto.decrypt_token(doc.encrypted_token, doc.nonce, doc.salt)
+    return (
+        doc.base_url,
+        doc.auth_type,
+        doc.auth_header,
+        token,
+        _allowed_writes_wire(doc),
+        _approval_route_wire(doc),
+        doc.workspace_id,
+    )
+
+
+def _new_webhook_secret() -> str:
+    """Mint a fresh URL-safe webhook secret (32 bytes of entropy)."""
+    return secrets.token_urlsafe(32)
+
+
+async def get_webhook_secret(workspace_id: str, pocket_id: str) -> str | None:
+    """Return the pocket's webhook secret, or ``None`` if none is set.
+
+    Owner-only at the route layer. The secret is the credential a webhook
+    caller echoes back, so the owner must be able to read it once to
+    configure the upstream. Raises ``pocket_backend.not_configured`` when
+    the pocket has no backend — a webhook secret with no backend to refresh
+    against is meaningless.
+    """
+    doc = await _BackendCredentialDoc.find_one(
+        _BackendCredentialDoc.pocket_id == pocket_id,
+        _BackendCredentialDoc.workspace_id == workspace_id,
+    )
+    if doc is None:
+        raise ValidationError(
+            "pocket_backend.not_configured",
+            "This pocket has no backend configured — set one before a webhook secret",
+        )
+    return getattr(doc, "webhook_secret", None)
+
+
+async def rotate_webhook_secret(workspace_id: str, user_id: str, pocket_id: str) -> str:
+    """Generate a fresh webhook secret for the pocket, replacing any prior.
+
+    Owner-only. Rotating invalidates the previous secret immediately — any
+    upstream still using the old value gets a 403 until reconfigured.
+    Returns the new secret (the ONLY time it is handed back outside the
+    owner-only GET). Audit-logged. Rejects with
+    ``pocket_backend.not_configured`` when no backend is set.
+    """
+    doc = await _BackendCredentialDoc.find_one(
+        _BackendCredentialDoc.pocket_id == pocket_id,
+        _BackendCredentialDoc.workspace_id == workspace_id,
+    )
+    if doc is None:
+        raise ValidationError(
+            "pocket_backend.not_configured",
+            "This pocket has no backend configured — set one before a webhook secret",
+        )
+    doc.webhook_secret = _new_webhook_secret()
+    await doc.save()
+    _audit_backend_config(
+        actor=user_id,
+        action="pocket.backend.webhook_rotate",
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        base_url=doc.base_url,
+        auth_type=doc.auth_type,
+    )
+    # no-event: see set_pocket_backend — credential rows aren't pocket state.
+    return doc.webhook_secret
+
+
 __all__ = [
     "access_via_share_link",
     "add_agent",
@@ -2612,10 +2798,13 @@ __all__ = [
     "get",
     "get_pocket_backend",
     "get_pocket_backend_for_executor",
+    "get_pocket_ripple_spec",
+    "get_webhook_secret",
     "has_action_run_access",
     "has_edit_access",
     "is_member",
     "is_owner",
+    "list_interval_source_pockets",
     "list_pockets",
     "remove_agent",
     "remove_collaborator",
@@ -2623,7 +2812,9 @@ __all__ = [
     "remove_team_member",
     "remove_widget",
     "reorder_widgets",
+    "resolve_webhook_pocket",
     "revoke_share_link",
+    "rotate_webhook_secret",
     "set_pocket_approval_route",
     "set_pocket_backend",
     "set_pocket_write_policy",

--- a/ee/pocketpaw_ee/cloud/pockets/source_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/source_executor.py
@@ -16,6 +16,15 @@
 #   executor's own per-source errors (timeouts, http_error, bad_json, …).
 #   Behavior-identical — pure refactor; the read-executor tests are the
 #   regression gate.
+# Updated: 2026-05-22 (RFC 04 M3) — `SourceBinding.refresh` now also
+#   accepts `"interval"` (re-run on a timer) and `"webhook"` (re-run on an
+#   inbound authenticated POST). A binding may carry
+#   `refresh_interval_seconds` — the desired interval; the interval
+#   scheduler floors it by `POCKETPAW_SOURCE_REFRESH_MIN_INTERVAL_SECONDS`
+#   so a hallucinated `1` cannot spin the loop. Both new triggers are
+#   AUTO-refresh: they re-run a source with no human in the loop, so they
+#   are metered by the per-pocket budget in `_refresh_budget.py` —
+#   SEPARATE from the manual per-(pocket, user) `_run_log` limiter here.
 #
 # SSRF BOUNDARY. The outbound-HTTP defenses now live in `_http_guard.py` —
 # the ONE canonical guard module both executors import. Every defense from
@@ -67,8 +76,15 @@ _run_log: dict[tuple[str, str], list[float]] = {}
 # TOCTOU race under ``asyncio.gather``; the lock makes it atomic.
 _run_log_lock = asyncio.Lock()
 
+# A refresh trigger names WHEN a source re-runs:
+#   pocket_open — re-run when the user opens the pocket
+#   manual      — re-run from a refresh button (run_source action)
+#   interval    — re-run on a timer (RFC 04 M3 — interval scheduler)
+#   webhook     — re-run on an authenticated inbound POST (RFC 04 M3)
+RefreshTrigger = Literal["pocket_open", "manual", "interval", "webhook"]
+
 # Default refresh policy for a source that omits ``refresh``.
-_DEFAULT_REFRESH: list[Literal["pocket_open", "manual"]] = ["pocket_open"]
+_DEFAULT_REFRESH: list[RefreshTrigger] = ["pocket_open"]
 
 
 class SourceBinding(BaseModel):
@@ -77,14 +93,20 @@ class SourceBinding(BaseModel):
     Unknown keys on a source entry are ignored — the spec may carry fields
     a later milestone reads. ``method`` is a Literal so only GET is ever
     accepted (write verbs are Milestone 2).
+
+    ``refresh_interval_seconds`` is the source author's desired interval
+    when ``"interval"`` is in ``refresh``. It is a REQUEST, not a
+    guarantee: the interval scheduler floors it by the configured
+    minimum (``POCKETPAW_SOURCE_REFRESH_MIN_INTERVAL_SECONDS``), so a
+    hallucinated ``refresh_interval_seconds: 1`` is clamped, never
+    honored. ``None`` means "use the floor as the interval".
     """
 
     method: Literal["GET"] = "GET"
     path: str
     bind: str
-    refresh: list[Literal["pocket_open", "manual"]] = Field(
-        default_factory=lambda: _DEFAULT_REFRESH.copy()
-    )
+    refresh: list[RefreshTrigger] = Field(default_factory=lambda: _DEFAULT_REFRESH.copy())
+    refresh_interval_seconds: int | None = Field(default=None, ge=1)
 
 
 def _normalize_bind(bind: str) -> str:
@@ -382,4 +404,4 @@ async def run_sources(
     return {"ran": ran, "errors": errors}
 
 
-__all__ = ["run_sources", "SourceBinding"]
+__all__ = ["run_sources", "SourceBinding", "RefreshTrigger"]

--- a/ee/pocketpaw_ee/cloud/ripple_normalizer.py
+++ b/ee/pocketpaw_ee/cloud/ripple_normalizer.py
@@ -31,6 +31,14 @@ third-party endpoint) and is left as ``api`` — never redirected onto the
 pocket's credentialed backend. ``call_binding`` handlers wired with the
 wrong binding-name field (``action_id`` / ``name``) are repaired to
 ``binding``.
+
+Changes: 2026-05-22 (RFC 04 M3) — ``_lifted_source_entry`` now carries an
+interval through. The authoring agent declares "poll every N seconds"
+under any of several invented keys (``interval`` / ``interval_seconds``
+/ ``poll_seconds`` / …); ``_coerce_interval`` picks the first that parses
+to a positive int, writes it as ``refresh_interval_seconds`` on the
+lifted source, and appends ``"interval"`` to its refresh policy. The
+interval scheduler floors a sub-minimum value at run time.
 """
 
 from __future__ import annotations
@@ -122,12 +130,51 @@ def _lifted_source_entry(entry: dict[str, Any], key: str) -> dict[str, Any] | No
     else:
         resolved_refresh = ["manual"]
 
-    return {
+    lifted: dict[str, Any] = {
         "method": "GET",
         "path": _relative_path(raw_path),
         "bind": resolved_bind,
         "refresh": resolved_refresh,
     }
+
+    # RFC 04 M3 — carry an interval through. The agent emits the interval
+    # under any of several invented keys; pick the first that parses to a
+    # positive int. The interval scheduler floors a too-small value, so we
+    # only need it to be >= 1 here (a sub-floor value is corrected later).
+    interval = _coerce_interval(entry)
+    if interval is not None:
+        lifted["refresh_interval_seconds"] = interval
+        if "interval" not in resolved_refresh:
+            resolved_refresh.append("interval")
+    return lifted
+
+
+def _coerce_interval(entry: dict[str, Any]) -> int | None:
+    """Pull a refresh interval (seconds) out of a hallucinated REST entry.
+
+    The authoring agent has no single canonical key for "poll every N
+    seconds" — it invents ``refresh_interval_seconds`` / ``interval`` /
+    ``interval_seconds`` / ``poll_seconds`` / ``poll_interval``. The first
+    one that coerces to a positive int wins. Returns ``None`` when none is
+    present or usable, in which case the source has no interval trigger.
+    """
+    for key in (
+        "refresh_interval_seconds",
+        "interval_seconds",
+        "interval",
+        "poll_seconds",
+        "poll_interval",
+    ):
+        raw = entry.get(key)
+        if raw is None:
+            continue
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if value >= 1:
+            return value
+    return None
 
 
 def _repair_run_source_handler(handler: Any, sources: dict[str, Any]) -> Any:

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -9,6 +9,13 @@ point at these classes are declared in `pyproject.toml` (and will migrate to
 Each provider does its heavy `pocketpaw_ee` imports lazily inside methods so
 that merely loading this module — which the registry does on first access —
 stays cheap and free of import cycles.
+
+Updated: 2026-05-22 (RFC 04 M3) — ``CloudLifecycleHook`` now starts the
+pocket interval-refresh scheduler in ``on_startup`` and cancels it in
+``on_shutdown``. The scheduler is a single asyncio task owned at module
+scope inside ``cloud.pockets.refresh_scheduler``; it is self-gated on
+``POCKETPAW_POCKET_REFRESH_SCHEDULER_ENABLED`` so the start call is a
+no-op unless a deployment opts in.
 """
 
 from __future__ import annotations
@@ -108,8 +115,34 @@ class CloudLifecycleHook:
         except Exception as exc:  # noqa: BLE001
             logger.warning("Cloud chat-title listener registration failed: %s", exc)
 
+        # Pocket interval-refresh scheduler (RFC 04 M3). A single asyncio
+        # task that periodically re-runs pocket data sources whose refresh
+        # policy includes `"interval"`. Self-gated on
+        # POCKETPAW_POCKET_REFRESH_SCHEDULER_ENABLED (default OFF — a
+        # pytest run never spawns it; a multi-replica deploy runs it on
+        # exactly one replica). The task lives at module scope inside the
+        # scheduler so this no-`app` lifecycle hook can still own it.
+        try:
+            from pocketpaw_ee.cloud.pockets.refresh_scheduler import start_scheduler
+
+            await start_scheduler()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Pocket interval-refresh scheduler start failed: %s", exc)
+
     async def on_shutdown(self) -> None:
-        # Cloud teardown is handled inside mount_cloud's own shutdown hook.
+        # Most cloud teardown is handled inside mount_cloud's own shutdown
+        # hook. The interval-refresh scheduler is owned by this lifecycle
+        # hook (it was started in on_startup), so it is cancelled here so
+        # the background task does not outlive the process.
+        import logging
+
+        logger = logging.getLogger(__name__)
+        try:
+            from pocketpaw_ee.cloud.pockets.refresh_scheduler import stop_scheduler
+
+            await stop_scheduler()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Pocket interval-refresh scheduler stop failed: %s", exc)
         return None
 
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -176,6 +176,11 @@ source_modules = [
     "pocketpaw_ee.cloud.pockets._http_guard",
     "pocketpaw_ee.cloud.pockets.action_executor",
     "pocketpaw_ee.cloud.pockets.actions_ops",
+    # RFC 04 M3 — the interval-refresh scheduler + the auto-refresh budget
+    # helper. The scheduler scans pockets through `pockets.service` and
+    # refreshes through `source_executor`; neither touches Beanie directly.
+    "pocketpaw_ee.cloud.pockets.refresh_scheduler",
+    "pocketpaw_ee.cloud.pockets._refresh_budget",
     # RFC 05 M2b.1 — the instinct bridge proposes/executes parked writes
     # through `pockets.service` and the Instinct store; it never touches
     # Beanie document classes directly.

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,10 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-05-22: Added ``source_refresh_min_interval_seconds`` (interval
+    floor) and ``source_refresh_max_per_hour`` (per-pocket auto-refresh
+    budget) — cost controls for pocket data-source interval / webhook
+    refresh (RFC 04 M3).
   - 2026-05-22: Added ``pocket_router_enabled`` (kill-switch) and
     ``pocket_router_min_confidence`` (cheap-tier confidence floor) for
     the pocket execution router (Increment 3).
@@ -1192,6 +1196,35 @@ class Settings(BaseSettings):
     ripple_manifest_ttl_seconds: int = Field(
         default=86400,
         description="TTL in seconds for cached Ripple manifest (default: 24h)",
+    )
+
+    # Pocket data-source refresh — cost controls (RFC 04 M3).
+    # A pocket source binding may declare an `interval` or `webhook` refresh
+    # trigger. Both are AUTO-refresh: they re-run a source without a human in
+    # the loop, so they cost real backend calls. These two settings cap that
+    # cost. The interval floor clamps a too-frequent (or hallucinated)
+    # `refresh_interval_seconds` up to a sane minimum; the per-hour cap is a
+    # separate budget — counted PER POCKET, distinct from the manual
+    # `run_source` per-(pocket, user) limiter — so an interval storm or a
+    # webhook flood cannot run up unbounded backend cost.
+    source_refresh_min_interval_seconds: int = Field(
+        default=60,
+        description=(
+            "Minimum seconds between automatic interval refreshes of a pocket "
+            "data source. A source binding's `refresh_interval_seconds` is "
+            "clamped UP to this floor — a hallucinated `refresh_interval_seconds: "
+            "1` is never honored. Set via POCKETPAW_SOURCE_REFRESH_MIN_INTERVAL_SECONDS."
+        ),
+    )
+    source_refresh_max_per_hour: int = Field(
+        default=60,
+        description=(
+            "Maximum automatic (interval + webhook) source refreshes per pocket "
+            "per rolling hour. Once the budget is spent, further auto-refreshes "
+            "are skipped (and logged) rather than queued. This counter is "
+            "SEPARATE from the manual run_source rate limiter. Set via "
+            "POCKETPAW_SOURCE_REFRESH_MAX_PER_HOUR."
+        ),
     )
 
     # File extraction chain (Phase 1, "Files as Knowledge")

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -507,8 +507,21 @@ READ-ONLY: GET bindings only.
 
 Each source entry: `method` (always "GET"), `path` (a RELATIVE path
 against the pocket's backend — never an absolute URL), `bind` (a dotted
-`state.` path the result is written to), and `refresh` (when to run it —
-`pocket_open` on open, `manual` for a refresh button).
+`state.` path the result is written to), and `refresh` (when to run it).
+
+`refresh` is a list of triggers — combine any of:
+- `pocket_open` — re-fetch each time the user opens the pocket.
+- `manual` — re-fetch from a refresh button (the `run_source` action).
+- `interval` — re-fetch on a timer. Add `refresh_interval_seconds` (the
+  desired gap in seconds) alongside `refresh`; the runtime floors a
+  too-small value, so pick a real cadence (e.g. 300 for 5 minutes).
+- `webhook` — re-fetch when an upstream system calls the pocket's
+  webhook-refresh URL. The webhook secret is generated in the pocket's
+  backend settings — never authored in the spec.
+
+  "prs": {"method": "GET", "path": "/pulls", "bind": "state.prs",
+          "refresh": ["pocket_open", "interval"],
+          "refresh_interval_seconds": 300}
 
 For a manual refresh, add a button wired to the `run_source` action:
 
@@ -538,9 +551,10 @@ nothing else:
 - Data sources go in `rippleSpec.sources` ONLY. NEVER put them in
   `tool_specs` — `tool_specs` is for LLM tools, not data, and a
   `tool_specs` entry inside the rippleSpec is silently inert.
-- A source entry has EXACTLY four fields: `method`, `path`, `bind`,
-  `refresh`. Do NOT invent `kind`, `url`, `auto_fetch`, `into`, or `id` —
-  none of those exist and the source will not run.
+- A source entry has `method`, `path`, `bind`, `refresh` — plus
+  `refresh_interval_seconds` ONLY when `refresh` includes `interval`. Do
+  NOT invent `kind`, `url`, `auto_fetch`, `into`, or `id` — none of those
+  exist and the source will not run.
 - The refresh button targets the source by `source` (the sources-map
   key). NEVER use `source_id`.
 
@@ -580,6 +594,11 @@ READ-ONLY: GET bindings only. These write the pocket's top-level
   )
 
   remove_source(source_key="prs")
+
+`refresh` triggers: `pocket_open` (on open), `manual` (refresh button),
+`interval` (a timer — pass `refresh_interval_seconds` in the binding too,
+e.g. 300 for 5 minutes), `webhook` (an upstream system pings the pocket's
+webhook-refresh URL; the secret is set in backend settings, never here).
 
 After `set_source`, do the wiring with the normal ops:
 - `set_state` the `bind` target to an empty list/value so the bound
@@ -624,8 +643,9 @@ nothing else:
 - Live data sources go in `rippleSpec.sources` ONLY, written via
   `set_source`. NEVER author a `tool_specs` entry for data — `tool_specs`
   is for LLM tools, not data, and is silently inert as a data source.
-- A source is EXACTLY `{method, path, bind, refresh}`. Do NOT invent
-  `kind`, `url`, `auto_fetch`, `into`, or `id` — they do not exist.
+- A source is `{method, path, bind, refresh}` — plus
+  `refresh_interval_seconds` when `refresh` includes `interval`. Do NOT
+  invent `kind`, `url`, `auto_fetch`, `into`, or `id` — they do not exist.
 - The refresh button targets the source by `source` (the source key),
   NEVER `source_id`.
 

--- a/tests/cloud/test_pocket_refresh_scheduler.py
+++ b/tests/cloud/test_pocket_refresh_scheduler.py
@@ -1,0 +1,314 @@
+# tests/cloud/test_pocket_refresh_scheduler.py — RFC 04 M3.
+# Created: 2026-05-22 — Coverage for the pocket data-source interval-refresh
+# scheduler and the auto-refresh cost controls.
+#
+# What this pins:
+#   - An interval source is re-run when it is DUE (and not before).
+#   - A sub-floor `refresh_interval_seconds` is CLAMPED to the configured
+#     minimum — a hallucinated `1` never makes a source due every tick.
+#   - The per-pocket auto-refresh budget caps an interval/webhook flood.
+#   - One pocket erroring NEVER kills the scan pass — the loop survives it.
+#   - The scheduler is gated off by default and start/stop are idempotent.
+#
+# No real network: the source executor is monkeypatched so the scheduler's
+# scan-and-refresh logic is tested in isolation from outbound HTTP.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.pockets import (  # noqa: E402
+    _refresh_budget,
+    refresh_scheduler,
+    source_executor,  # noqa: E402
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Clear the scheduler's last-run map + the auto-refresh budget log."""
+    refresh_scheduler._reset_for_tests()
+    _refresh_budget.reset_budget()
+    yield
+    refresh_scheduler._reset_for_tests()
+    _refresh_budget.reset_budget()
+
+
+def _interval_pocket(pocket_id="p1", interval_seconds=300, refresh=None):
+    """A pocket row as `list_interval_source_pockets` would return it."""
+    return {
+        "pocket_id": pocket_id,
+        "workspace_id": "ws-1",
+        "sources": {
+            "prs": {
+                "method": "GET",
+                "path": "/pulls",
+                "bind": "state.prs",
+                "refresh": refresh or ["interval"],
+                "refresh_interval_seconds": interval_seconds,
+            }
+        },
+    }
+
+
+def _patch_executor(monkeypatch, calls: list, *, raises_for=None):
+    """Patch `source_executor.run_sources` to record calls (no HTTP)."""
+
+    async def _fake_run_sources(*, pocket_id, only_source=None, **_kw):
+        if raises_for is not None and pocket_id == raises_for:
+            raise RuntimeError(f"boom for {pocket_id}")
+        calls.append((pocket_id, only_source))
+        return {"ran": [{"source": only_source, "bind": "prs", "value": []}], "errors": []}
+
+    monkeypatch.setattr(source_executor, "run_sources", _fake_run_sources)
+
+
+def _patch_service(
+    monkeypatch, pockets: list, *, creds=("https://api.example.com", "none", None, "", [], None)
+):
+    """Patch the pockets service calls the scheduler makes."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    async def _list():
+        return pockets
+
+    async def _creds(_ws, _pid):
+        return creds
+
+    async def _spec(_ws, pid):
+        for p in pockets:
+            if p["pocket_id"] == pid:
+                return {"sources": p["sources"]}
+        return {}
+
+    monkeypatch.setattr(pockets_service, "list_interval_source_pockets", _list)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _creds)
+    monkeypatch.setattr(pockets_service, "get_pocket_ripple_spec", _spec)
+
+
+# ---------------------------------------------------------------------------
+# Interval source is re-run when due
+# ---------------------------------------------------------------------------
+
+
+async def test_interval_source_runs_on_first_pass(monkeypatch):
+    """A never-run interval source is due immediately."""
+    calls: list = []
+    pockets = [_interval_pocket()]
+    _patch_executor(monkeypatch, calls)
+    _patch_service(monkeypatch, pockets)
+
+    visited = await refresh_scheduler.run_one_pass()
+    assert visited == 1
+    assert calls == [("p1", "prs")]
+
+
+async def test_interval_source_not_rerun_before_interval_elapses(monkeypatch):
+    """A second pass right after the first does NOT re-run the source —
+    its interval has not elapsed."""
+    calls: list = []
+    pockets = [_interval_pocket(interval_seconds=300)]
+    _patch_executor(monkeypatch, calls)
+    _patch_service(monkeypatch, pockets)
+
+    await refresh_scheduler.run_one_pass()
+    await refresh_scheduler.run_one_pass()
+    # Only the first pass ran it — 300s has not passed between passes.
+    assert calls == [("p1", "prs")]
+
+
+async def test_interval_source_rerun_once_due(monkeypatch):
+    """When monotonic time advances past the interval, the source re-runs."""
+    import time as _time
+
+    calls: list = []
+    pockets = [_interval_pocket(interval_seconds=300)]
+    _patch_executor(monkeypatch, calls)
+    _patch_service(monkeypatch, pockets)
+
+    await refresh_scheduler.run_one_pass()
+    assert len(calls) == 1
+
+    # Fast-forward monotonic time by 10 minutes — the source is now due.
+    real_monotonic = _time.monotonic
+    monkeypatch.setattr(refresh_scheduler.time, "monotonic", lambda: real_monotonic() + 600)
+    await refresh_scheduler.run_one_pass()
+    assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Sub-floor interval is clamped
+# ---------------------------------------------------------------------------
+
+
+async def test_sub_floor_interval_is_clamped(monkeypatch):
+    """A hallucinated `refresh_interval_seconds: 1` is clamped to the floor
+    (default 60s) — it does NOT make the source due on every pass."""
+    import time as _time
+
+    calls: list = []
+    # interval_seconds=1 — far below the 60s floor.
+    pockets = [_interval_pocket(interval_seconds=1)]
+    _patch_executor(monkeypatch, calls)
+    _patch_service(monkeypatch, pockets)
+
+    await refresh_scheduler.run_one_pass()
+    assert len(calls) == 1
+
+    # 30s later — past the authored `1`, but the clamp floored it to 60s,
+    # so the source is NOT due yet.
+    real_monotonic = _time.monotonic
+    monkeypatch.setattr(refresh_scheduler.time, "monotonic", lambda: real_monotonic() + 30)
+    await refresh_scheduler.run_one_pass()
+    assert len(calls) == 1  # still not due — clamp held
+
+    # 90s out — now past the 60s floor; the source re-runs.
+    monkeypatch.setattr(refresh_scheduler.time, "monotonic", lambda: real_monotonic() + 90)
+    await refresh_scheduler.run_one_pass()
+    assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Per-pocket auto-refresh budget caps a flood
+# ---------------------------------------------------------------------------
+
+
+async def test_budget_caps_an_interval_flood(monkeypatch):
+    """With the per-pocket budget set to 2, only 2 interval refreshes of a
+    pocket go through — a flood of due passes beyond that is skipped."""
+    import time as _time
+
+    calls: list = []
+    pockets = [_interval_pocket(interval_seconds=60)]
+    _patch_executor(monkeypatch, calls)
+    _patch_service(monkeypatch, pockets)
+
+    # Pin the per-pocket auto-refresh budget to 2/hour.
+    monkeypatch.setattr(_refresh_budget, "max_per_hour", lambda: 2)
+
+    real_monotonic = _time.monotonic
+    offset = {"v": 0.0}
+    monkeypatch.setattr(refresh_scheduler.time, "monotonic", lambda: real_monotonic() + offset["v"])
+
+    # 5 passes, each 60s+ apart so the source is due every time. The budget
+    # only permits 2 — passes 3-5 are skipped.
+    for i in range(5):
+        offset["v"] = i * 120
+        await refresh_scheduler.run_one_pass()
+
+    assert len(calls) == 2
+
+
+async def test_budget_is_separate_from_manual_run_log(monkeypatch):
+    """The auto-refresh budget and the manual `source_executor._run_log`
+    limiter are SEPARATE counters — spending one does not touch the other."""
+    # Spend the whole auto-refresh budget for a pocket.
+    monkeypatch.setattr(_refresh_budget, "max_per_hour", lambda: 1)
+    assert await _refresh_budget.consume_auto_refresh("pocket-x") is True
+    assert await _refresh_budget.consume_auto_refresh("pocket-x") is False
+
+    # The manual run-log for the same pocket is untouched — a human can
+    # still run sources manually.
+    source_executor._run_log.clear()
+    assert await source_executor._rate_limited("pocket-x", "human-user") is False
+
+
+# ---------------------------------------------------------------------------
+# One pocket erroring never kills the loop
+# ---------------------------------------------------------------------------
+
+
+async def test_one_pocket_error_does_not_abort_the_pass(monkeypatch):
+    """A pocket whose refresh raises is logged and skipped — every OTHER
+    pocket in the pass still refreshes."""
+    calls: list = []
+    pockets = [
+        _interval_pocket(pocket_id="bad"),
+        _interval_pocket(pocket_id="good-1"),
+        _interval_pocket(pocket_id="good-2"),
+    ]
+    _patch_executor(monkeypatch, calls, raises_for="bad")
+    _patch_service(monkeypatch, pockets)
+
+    # The pass completes — it does not raise — and visits all 3 pockets.
+    visited = await refresh_scheduler.run_one_pass()
+    assert visited == 3
+    # The two healthy pockets refreshed despite the bad one erroring.
+    assert ("good-1", "prs") in calls
+    assert ("good-2", "prs") in calls
+    assert ("bad", "prs") not in calls
+
+
+async def test_scan_failure_returns_zero_not_raises(monkeypatch):
+    """If the pocket-scan helper itself fails, run_one_pass returns 0
+    rather than propagating — the loop survives."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    async def _boom():
+        raise RuntimeError("mongo down")
+
+    monkeypatch.setattr(pockets_service, "list_interval_source_pockets", _boom)
+    assert await refresh_scheduler.run_one_pass() == 0
+
+
+# ---------------------------------------------------------------------------
+# Pocket with interval sources but no backend
+# ---------------------------------------------------------------------------
+
+
+async def test_interval_pocket_without_backend_is_skipped(monkeypatch):
+    """A pocket with an interval source but no backend configured is
+    skipped cleanly — no refresh call, no error."""
+    calls: list = []
+    pockets = [_interval_pocket()]
+    _patch_executor(monkeypatch, calls)
+
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    async def _list():
+        return pockets
+
+    async def _no_creds(_ws, _pid):
+        return None
+
+    monkeypatch.setattr(pockets_service, "list_interval_source_pockets", _list)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _no_creds)
+
+    visited = await refresh_scheduler.run_one_pass()
+    assert visited == 1
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Gating + start/stop wiring
+# ---------------------------------------------------------------------------
+
+
+async def test_scheduler_disabled_by_default(monkeypatch):
+    """Without the env flag, is_enabled is False and start is a no-op."""
+    monkeypatch.delenv("POCKETPAW_POCKET_REFRESH_SCHEDULER_ENABLED", raising=False)
+    assert refresh_scheduler.is_enabled() is False
+    await refresh_scheduler.start_scheduler()
+    assert refresh_scheduler._task is None
+
+
+async def test_scheduler_start_and_stop_idempotent(monkeypatch):
+    """With the flag on, start spawns one task; double-start/stop are safe."""
+    monkeypatch.setenv("POCKETPAW_POCKET_REFRESH_SCHEDULER_ENABLED", "true")
+    try:
+        await refresh_scheduler.start_scheduler()
+        task = refresh_scheduler._task
+        assert task is not None and not task.done()
+
+        # Second start is a no-op — same task instance.
+        await refresh_scheduler.start_scheduler()
+        assert refresh_scheduler._task is task
+
+        await refresh_scheduler.stop_scheduler()
+        assert refresh_scheduler._task is None
+        # Second stop is also a no-op.
+        await refresh_scheduler.stop_scheduler()
+    finally:
+        await refresh_scheduler.stop_scheduler()

--- a/tests/cloud/test_pocket_refresh_service.py
+++ b/tests/cloud/test_pocket_refresh_service.py
@@ -1,0 +1,230 @@
+# tests/cloud/test_pocket_refresh_service.py — RFC 04 M3.
+# Created: 2026-05-22 — Service-layer coverage for the data-source refresh
+# additions: the interval-source scan helper, the webhook-secret trio
+# (resolve / get / rotate), and the raw-spec read. Exercises the real
+# Beanie path against the in-memory mongomock-motor DB (mongo_db fixture).
+#
+# What this pins:
+#   - list_interval_source_pockets returns only pockets with an `interval`
+#     source — pockets with no interval source are excluded.
+#   - rotate_webhook_secret generates a secret; get_webhook_secret reads it.
+#   - resolve_webhook_pocket authenticates a correct secret and returns the
+#     executor creds; a wrong / empty / unset secret returns None.
+#   - resolve_webhook_pocket returns None for a missing pocket — identical
+#     to a wrong secret, so the endpoint is not a pocket-existence oracle.
+#   - rotate invalidates the previous secret.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud._core.errors import ValidationError  # noqa: E402
+from pocketpaw_ee.cloud.pockets import service as pockets_service  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def auth_secret(monkeypatch):
+    monkeypatch.setenv("AUTH_SECRET", "refresh-test-auth-secret")
+
+
+async def _make_pocket(workspace="w1", owner="u1", sources=None):
+    """Insert a pocket directly via the Beanie model and return its id."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    spec = {"ui": {"type": "root", "children": []}, "state": {}}
+    if sources is not None:
+        spec["sources"] = sources
+    doc = _PocketDoc(
+        workspace=workspace,
+        name="p",
+        description="",
+        type="custom",
+        owner=owner,
+        visibility="workspace",
+        rippleSpec=spec,
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+# ---------------------------------------------------------------------------
+# list_interval_source_pockets
+# ---------------------------------------------------------------------------
+
+
+async def test_list_interval_source_pockets_filters(mongo_db):
+    """Only pockets that declare an `interval`-refresh source are returned."""
+    interval_pid = await _make_pocket(
+        sources={
+            "prs": {
+                "method": "GET",
+                "path": "/pulls",
+                "bind": "state.prs",
+                "refresh": ["pocket_open", "interval"],
+                "refresh_interval_seconds": 300,
+            }
+        }
+    )
+    # A pocket with a source but no interval trigger — must be excluded.
+    await _make_pocket(
+        sources={
+            "issues": {
+                "method": "GET",
+                "path": "/issues",
+                "bind": "state.issues",
+                "refresh": ["pocket_open", "manual"],
+            }
+        }
+    )
+    # A pocket with no sources at all — excluded.
+    await _make_pocket(sources=None)
+
+    rows = await pockets_service.list_interval_source_pockets()
+    ids = {r["pocket_id"] for r in rows}
+    assert interval_pid in ids
+    assert len(ids) == 1
+    row = next(r for r in rows if r["pocket_id"] == interval_pid)
+    assert "prs" in row["sources"]
+    assert row["workspace_id"] == "w1"
+
+
+async def test_list_interval_source_pockets_spans_workspaces(mongo_db):
+    """The scan is global — the scheduler has no tenant context."""
+    pid_a = await _make_pocket(
+        workspace="ws-a",
+        sources={"s": {"method": "GET", "path": "/x", "bind": "x", "refresh": ["interval"]}},
+    )
+    pid_b = await _make_pocket(
+        workspace="ws-b",
+        sources={"s": {"method": "GET", "path": "/y", "bind": "y", "refresh": ["interval"]}},
+    )
+    rows = await pockets_service.list_interval_source_pockets()
+    ids = {r["pocket_id"] for r in rows}
+    assert {pid_a, pid_b} <= ids
+
+
+# ---------------------------------------------------------------------------
+# Webhook secret: rotate + get
+# ---------------------------------------------------------------------------
+
+
+async def test_rotate_then_get_webhook_secret(mongo_db):
+    pid = await _make_pocket()
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pid,
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+    # No secret until a rotate.
+    assert await pockets_service.get_webhook_secret("w1", pid) is None
+
+    secret = await pockets_service.rotate_webhook_secret("w1", "u1", pid)
+    assert secret
+    assert await pockets_service.get_webhook_secret("w1", pid) == secret
+
+
+async def test_rotate_invalidates_previous_secret(mongo_db):
+    pid = await _make_pocket()
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pid,
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+    first = await pockets_service.rotate_webhook_secret("w1", "u1", pid)
+    second = await pockets_service.rotate_webhook_secret("w1", "u1", pid)
+    assert first != second
+    # The old secret no longer authenticates.
+    assert await pockets_service.resolve_webhook_pocket(pid, first) is None
+    assert await pockets_service.resolve_webhook_pocket(pid, second) is not None
+
+
+async def test_webhook_secret_requires_backend(mongo_db):
+    """A webhook secret with no backend to refresh against is rejected."""
+    pid = await _make_pocket()
+    with pytest.raises(ValidationError):
+        await pockets_service.get_webhook_secret("w1", pid)
+    with pytest.raises(ValidationError):
+        await pockets_service.rotate_webhook_secret("w1", "u1", pid)
+
+
+# ---------------------------------------------------------------------------
+# resolve_webhook_pocket — constant-time auth, not an oracle
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_webhook_pocket_valid_secret(mongo_db):
+    pid = await _make_pocket()
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pid,
+        base_url="https://api.example.com",
+        auth_type="bearer",
+        auth_token="backend-token",
+    )
+    secret = await pockets_service.rotate_webhook_secret("w1", "u1", pid)
+
+    creds = await pockets_service.resolve_webhook_pocket(pid, secret)
+    assert creds is not None
+    base_url, auth_type, _hdr, token, _allowed, _route, workspace_id = creds
+    assert base_url == "https://api.example.com"
+    assert auth_type == "bearer"
+    assert token == "backend-token"  # decrypted round-trip
+    assert workspace_id == "w1"
+
+
+async def test_resolve_webhook_pocket_wrong_secret_is_none(mongo_db):
+    pid = await _make_pocket()
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pid,
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+    await pockets_service.rotate_webhook_secret("w1", "u1", pid)
+    assert await pockets_service.resolve_webhook_pocket(pid, "wrong-secret") is None
+
+
+async def test_resolve_webhook_pocket_empty_secret_is_none(mongo_db):
+    pid = await _make_pocket()
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pid,
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+    await pockets_service.rotate_webhook_secret("w1", "u1", pid)
+    assert await pockets_service.resolve_webhook_pocket(pid, "") is None
+
+
+async def test_resolve_webhook_pocket_no_secret_set_is_none(mongo_db):
+    """A pocket with a backend but no webhook secret rejects every caller."""
+    pid = await _make_pocket()
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pid,
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+    # No rotate has run — webhook_secret is None.
+    assert await pockets_service.resolve_webhook_pocket(pid, "anything") is None
+
+
+async def test_resolve_webhook_pocket_missing_pocket_is_none(mongo_db):
+    """A genuinely-missing pocket returns None — identical to a wrong
+    secret, so the endpoint cannot be probed as a pocket-existence oracle."""
+    assert await pockets_service.resolve_webhook_pocket("000000000000000000000000", "x") is None

--- a/tests/cloud/test_pocket_sources_lift.py
+++ b/tests/cloud/test_pocket_sources_lift.py
@@ -13,6 +13,12 @@
 #   - auto_fetch:false -> refresh ["manual"].
 #   - an absolute `url` is reduced to a relative `path`.
 #   - a non-GET method entry is skipped (alpha is GET-only).
+#
+# Updated: 2026-05-22 (RFC 04 M3) — `_lifted_source_entry` now carries an
+# interval through. A hallucinated REST entry with a poll-interval key
+# (`interval` / `interval_seconds` / `poll_seconds` / …) is lifted with
+# `refresh_interval_seconds` set and `interval` appended to its refresh
+# policy. Added coverage for that lift.
 
 from __future__ import annotations
 
@@ -269,3 +275,100 @@ def test_handler_arrays_are_walked():
     handlers = normalized["ui"]["children"][0]["on_click"]
     assert handlers[0] == {"action": "run_source", "source": "src_todos"}
     assert handlers[1] == {"action": "set_state", "path": "todos", "value": []}
+
+
+# ---------------------------------------------------------------------------
+# RFC 04 M3 — interval lift
+# ---------------------------------------------------------------------------
+
+
+def test_hallucinated_interval_key_is_lifted():
+    """A REST entry with an invented `interval` key lifts to a source with
+    `refresh_interval_seconds` and `interval` appended to its refresh list."""
+    spec = {
+        "title": "Polled",
+        "version": "1.0",
+        "tool_specs": [
+            {
+                "id": "live_prs",
+                "kind": "rest",
+                "method": "GET",
+                "url": "/pulls",
+                "into": "prs",
+                "interval": 300,
+            }
+        ],
+        "state": {"prs": []},
+        "ui": {"type": "flex", "children": []},
+    }
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+    src = normalized["sources"]["live_prs"]
+    assert src["refresh_interval_seconds"] == 300
+    assert "interval" in src["refresh"]
+
+
+def test_interval_lift_accepts_poll_seconds_alias():
+    """The `poll_seconds` alias is recognised as an interval key too."""
+    spec = {
+        "title": "Polled",
+        "version": "1.0",
+        "tool_specs": [
+            {
+                "id": "feed",
+                "kind": "rest",
+                "method": "GET",
+                "url": "/feed",
+                "into": "feed",
+                "poll_seconds": 120,
+            }
+        ],
+        "state": {"feed": []},
+        "ui": {"type": "flex", "children": []},
+    }
+    normalized = normalize_ripple_spec(spec)
+    src = normalized["sources"]["feed"]
+    assert src["refresh_interval_seconds"] == 120
+    assert "interval" in src["refresh"]
+
+
+def test_no_interval_key_leaves_source_without_interval():
+    """A REST entry with no poll key lifts to a source with NO
+    `refresh_interval_seconds` and no `interval` trigger."""
+    spec = {
+        "title": "Static",
+        "version": "1.0",
+        "tool_specs": [
+            {"id": "once", "kind": "rest", "method": "GET", "url": "/once", "into": "once"}
+        ],
+        "state": {"once": []},
+        "ui": {"type": "flex", "children": []},
+    }
+    normalized = normalize_ripple_spec(spec)
+    src = normalized["sources"]["once"]
+    assert "refresh_interval_seconds" not in src
+    assert "interval" not in src["refresh"]
+
+
+def test_unusable_interval_value_is_dropped():
+    """A non-numeric / zero interval value is ignored — no interval lift."""
+    spec = {
+        "title": "Bad interval",
+        "version": "1.0",
+        "tool_specs": [
+            {
+                "id": "x",
+                "kind": "rest",
+                "method": "GET",
+                "url": "/x",
+                "into": "x",
+                "interval": "soon",
+            }
+        ],
+        "state": {"x": []},
+        "ui": {"type": "flex", "children": []},
+    }
+    normalized = normalize_ripple_spec(spec)
+    src = normalized["sources"]["x"]
+    assert "refresh_interval_seconds" not in src
+    assert "interval" not in src["refresh"]

--- a/tests/cloud/test_pocket_webhook_refresh.py
+++ b/tests/cloud/test_pocket_webhook_refresh.py
@@ -1,0 +1,280 @@
+# tests/cloud/test_pocket_webhook_refresh.py — RFC 04 M3.
+# Created: 2026-05-22 — Coverage for the pocket data-source webhook-refresh
+# routes:
+#
+#   POST /pockets/{id}/sources/{source}/refresh — inbound webhook trigger
+#   GET  /pockets/{id}/backend/webhook          — read the webhook secret
+#   POST /pockets/{id}/backend/webhook/rotate   — rotate the webhook secret
+#
+# The service functions + the source executor are monkeypatched so the
+# tests pin the route wiring (secret auth, status codes, the not-an-oracle
+# property) without a Mongo connection or real outbound HTTP.
+#
+# What this pins:
+#   - A valid webhook secret refreshes the named source.
+#   - A wrong / missing secret is rejected with 403.
+#   - The 403 is IDENTICAL whether or not the pocket exists — the endpoint
+#     is not a tenant-existence oracle.
+#   - A valid secret cannot run a source that is not webhook-refresh.
+#   - The auto-refresh budget caps a webhook flood (skipped, not queued).
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.cloud.pockets import (
+    _refresh_budget,  # noqa: E402
+    source_executor,  # noqa: E402
+)
+from pocketpaw_ee.cloud.pockets import service as pockets_service  # noqa: E402
+from pocketpaw_ee.cloud.pockets.router import router  # noqa: E402
+from pocketpaw_ee.cloud.shared.deps import (  # noqa: E402
+    current_user_id,
+    current_workspace_id,
+    require_pocket_owner,
+)
+
+FAKE_USER = "user-alice"
+FAKE_WORKSPACE = "ws-alpha"
+GOOD_SECRET = "s3cret-webhook-token"
+
+# Executor-creds tuple as resolve_webhook_pocket returns it (with the
+# trailing workspace_id).
+_CREDS = ("https://api.example.com", "none", None, "", [], None, FAKE_WORKSPACE)
+
+
+@pytest.fixture(autouse=True)
+def _reset_budget():
+    _refresh_budget.reset_budget()
+    yield
+    _refresh_budget.reset_budget()
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+
+    a = FastAPI()
+    add_error_handler(a)
+    a.include_router(router)
+    a.dependency_overrides[require_license] = lambda: None
+    a.dependency_overrides[require_pocket_owner] = lambda: None
+    a.dependency_overrides[current_user_id] = lambda: FAKE_USER
+    a.dependency_overrides[current_workspace_id] = lambda: FAKE_WORKSPACE
+    return a
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+def _patch_webhook_source(monkeypatch, *, secret=GOOD_SECRET, source_refresh=("webhook",)):
+    """Patch the service so one pocket has a webhook source + secret."""
+
+    async def _resolve(pocket_id, presented):
+        # Mirrors the real service: only a non-empty matching secret wins.
+        if presented and secret and presented == secret:
+            return _CREDS
+        return None
+
+    async def _spec(_ws, _pid):
+        return {
+            "sources": {
+                "prs": {
+                    "method": "GET",
+                    "path": "/pulls",
+                    "bind": "state.prs",
+                    "refresh": list(source_refresh),
+                }
+            }
+        }
+
+    monkeypatch.setattr(pockets_service, "resolve_webhook_pocket", _resolve)
+    monkeypatch.setattr(pockets_service, "get_pocket_ripple_spec", _spec)
+
+
+def _patch_executor(monkeypatch, calls: list):
+    async def _fake_run_sources(*, pocket_id, only_source=None, **_kw):
+        calls.append((pocket_id, only_source))
+        return {"ran": [{"source": only_source, "bind": "prs", "value": [1]}], "errors": []}
+
+    monkeypatch.setattr(source_executor, "run_sources", _fake_run_sources)
+
+
+# ---------------------------------------------------------------------------
+# POST /pockets/{id}/sources/{source}/refresh — valid secret
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_refresh_runs_source_on_valid_secret(monkeypatch, client):
+    calls: list = []
+    _patch_webhook_source(monkeypatch)
+    _patch_executor(monkeypatch, calls)
+
+    res = client.post(
+        "/pockets/pocket-1/sources/prs/refresh",
+        headers={"X-Pocket-Webhook-Secret": GOOD_SECRET},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ran"][0]["source"] == "prs"
+    assert calls == [("pocket-1", "prs")]
+
+
+# ---------------------------------------------------------------------------
+# Invalid / missing secret — rejected, and not an oracle
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_refresh_rejects_wrong_secret(monkeypatch, client):
+    _patch_webhook_source(monkeypatch)
+    _patch_executor(monkeypatch, [])
+
+    res = client.post(
+        "/pockets/pocket-1/sources/prs/refresh",
+        headers={"X-Pocket-Webhook-Secret": "wrong-secret"},
+    )
+    assert res.status_code == 403
+
+
+def test_webhook_refresh_rejects_missing_secret(monkeypatch, client):
+    _patch_webhook_source(monkeypatch)
+    _patch_executor(monkeypatch, [])
+
+    res = client.post("/pockets/pocket-1/sources/prs/refresh")
+    assert res.status_code == 403
+
+
+def test_webhook_refresh_same_error_for_missing_pocket(monkeypatch, client):
+    """The not-an-oracle property — a wrong secret on a REAL pocket and a
+    wrong secret on a NON-EXISTENT pocket return the byte-identical 403."""
+
+    async def _resolve(_pocket_id, _presented):
+        # The real service returns None for BOTH 'bad secret' and 'no such
+        # pocket' — so the route cannot tell them apart.
+        return None
+
+    monkeypatch.setattr(pockets_service, "resolve_webhook_pocket", _resolve)
+
+    real = client.post(
+        "/pockets/real-pocket/sources/prs/refresh",
+        headers={"X-Pocket-Webhook-Secret": "wrong"},
+    )
+    missing = client.post(
+        "/pockets/does-not-exist/sources/prs/refresh",
+        headers={"X-Pocket-Webhook-Secret": "wrong"},
+    )
+    assert real.status_code == missing.status_code == 403
+    # Identical body — no distinguishing detail leaks.
+    assert real.json() == missing.json()
+
+
+# ---------------------------------------------------------------------------
+# Valid secret cannot run a non-webhook source
+# ---------------------------------------------------------------------------
+
+
+def test_valid_secret_cannot_run_non_webhook_source(monkeypatch, client):
+    """A source whose refresh policy lacks `webhook` is not runnable via
+    the webhook endpoint even with a valid secret — returns 404."""
+    calls: list = []
+    # The 'prs' source is pocket_open/manual only — NOT webhook.
+    _patch_webhook_source(monkeypatch, source_refresh=("pocket_open", "manual"))
+    _patch_executor(monkeypatch, calls)
+
+    res = client.post(
+        "/pockets/pocket-1/sources/prs/refresh",
+        headers={"X-Pocket-Webhook-Secret": GOOD_SECRET},
+    )
+    assert res.status_code == 404
+    assert calls == []
+
+
+def test_valid_secret_unknown_source_is_404(monkeypatch, client):
+    _patch_webhook_source(monkeypatch)
+    _patch_executor(monkeypatch, [])
+
+    res = client.post(
+        "/pockets/pocket-1/sources/nonexistent/refresh",
+        headers={"X-Pocket-Webhook-Secret": GOOD_SECRET},
+    )
+    assert res.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Budget caps a webhook flood
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_flood_is_capped_by_budget(monkeypatch, client):
+    """Once the per-pocket auto-refresh budget is spent, further webhook
+    hits return 200 with a `skipped` marker — NOT queued, no backend call."""
+    calls: list = []
+    _patch_webhook_source(monkeypatch)
+    _patch_executor(monkeypatch, calls)
+    monkeypatch.setattr(_refresh_budget, "max_per_hour", lambda: 2)
+
+    statuses = []
+    for _ in range(5):
+        r = client.post(
+            "/pockets/pocket-1/sources/prs/refresh",
+            headers={"X-Pocket-Webhook-Secret": GOOD_SECRET},
+        )
+        statuses.append(r.json())
+
+    # First 2 hits run the source; the rest are skipped (rate-limited).
+    assert len(calls) == 2
+    skipped = [s for s in statuses if s.get("skipped") == "rate_limited"]
+    assert len(skipped) == 3
+
+
+# ---------------------------------------------------------------------------
+# GET / rotate webhook secret (owner-only)
+# ---------------------------------------------------------------------------
+
+
+def test_get_webhook_secret_returns_secret(monkeypatch, client):
+    async def _get(_ws, _pid):
+        return GOOD_SECRET
+
+    monkeypatch.setattr(pockets_service, "get_webhook_secret", _get)
+    res = client.get("/pockets/pocket-1/backend/webhook")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["secret"] == GOOD_SECRET
+    assert body["pocket_id"] == "pocket-1"
+    assert "/sources/{source}/refresh" in body["refresh_path"]
+
+
+def test_get_webhook_secret_none_before_rotate(monkeypatch, client):
+    async def _get(_ws, _pid):
+        return None
+
+    monkeypatch.setattr(pockets_service, "get_webhook_secret", _get)
+    res = client.get("/pockets/pocket-1/backend/webhook")
+    assert res.status_code == 200
+    assert res.json()["secret"] is None
+
+
+def test_rotate_webhook_secret_returns_new_secret(monkeypatch, client):
+    captured = {}
+
+    async def _rotate(workspace_id, user_id, pocket_id):
+        captured.update(workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id)
+        return "freshly-rotated-secret"
+
+    monkeypatch.setattr(pockets_service, "rotate_webhook_secret", _rotate)
+    res = client.post("/pockets/pocket-1/backend/webhook/rotate")
+    assert res.status_code == 200, res.text
+    assert res.json()["secret"] == "freshly-rotated-secret"
+    assert captured == {
+        "workspace_id": FAKE_WORKSPACE,
+        "user_id": FAKE_USER,
+        "pocket_id": "pocket-1",
+    }


### PR DESCRIPTION
## What this does

RFC 04 alpha shipped read-only pocket data sources that refresh on `pocket_open` and from a manual refresh button. This adds the two remaining refresh triggers and the cost controls that keep automatic refreshes from running up unbounded backend cost. With this, RFC 04 is complete.

## Interval refresh

A source binding can now carry `"interval"` in its `refresh` policy plus a `refresh_interval_seconds` value. A small in-process scheduler periodically scans the pockets that declare interval sources and re-runs each one when it is due.

- The scheduler reuses the existing `source_executor.run_sources`, so every SSRF guard, timeout and response cap from the alpha still applies — nothing about the outbound HTTP path is reimplemented.
- The loop is cancel-safe (clean shutdown on cloud teardown) and one pocket's failure never aborts the scan pass.
- The interval is floored by a configurable minimum, so a hallucinated `refresh_interval_seconds: 1` is clamped up to the floor rather than honored.
- Off by default — opt in with `POCKETPAW_POCKET_REFRESH_SCHEDULER_ENABLED=true`. It starts and stops on the cloud lifecycle hook, so a test run never spawns the loop.

## Webhook refresh

A source binding can carry `"webhook"` in its `refresh` policy. Each pocket gets a generated webhook secret stored on its backend-credential row — never in the agent-authored spec, so the spec stays shareable and secret-free.

- `POST /pockets/{id}/sources/{source}/refresh` re-runs one source when the caller presents a valid secret in the `X-Pocket-Webhook-Secret` header. This route is deliberately outside the cookie/Bearer auth chain — an upstream system has no user session.
- The secret compare is constant-time. A wrong, missing or unset secret, a pocket with no backend, and a genuinely-missing pocket all return the same `403`, so the endpoint cannot be probed as a pocket-existence oracle.
- A valid secret can only run a source that actually opted into webhook refresh — it does not grant the right to run an arbitrary source.
- Owner-only routes fetch and rotate the secret; rotating invalidates the previous value immediately.

## Refresh-cost controls

Two new settings in `config.py`:

- `POCKETPAW_SOURCE_REFRESH_MIN_INTERVAL_SECONDS` (default 60) — the interval floor.
- `POCKETPAW_SOURCE_REFRESH_MAX_PER_HOUR` (default 60) — the per-pocket auto-refresh budget.

Interval and webhook refreshes share a per-pocket budget per rolling hour. That counter is fully separate from the manual `run_source` per-(pocket, user) limiter, so an interval storm or a webhook flood cannot starve a manual refresh or run up cost. An over-budget refresh is skipped and logged — never queued.

The spec normalizer also lifts a hallucinated poll-interval key from the authoring agent's REST-source output into `refresh_interval_seconds`.

## Design notes

- **Interval scheduler** — a single asyncio task owned at module scope inside `cloud.pockets.refresh_scheduler`. The cloud lifecycle hook (which takes no `app` reference) starts and cancels it. Each tick scans interval pockets via a new `pockets.service` helper, computes per-(pocket, source) due time against the clamped interval, and refreshes through the shared executor.
- **Webhook auth** — the secret lives on `PocketBackendCredential`. `resolve_webhook_pocket` returns `None` for every failure mode (bad secret, no secret, no backend, missing pocket), so the route raises one identical error for all of them.
- **Budget separation** — the new `_refresh_budget` module is a per-pocket rolling-hour limiter, distinct from the executor's per-(pocket, user) `_run_log`. The scheduler and webhook route both spend the per-pocket budget before calling the executor.

## Tests

`tests/cloud/test_pocket_refresh_scheduler.py`, `test_pocket_webhook_refresh.py`, `test_pocket_refresh_service.py`, plus interval-lift coverage added to `test_pocket_sources_lift.py`. Covers: an interval source re-running when due; a sub-floor interval being clamped; the webhook endpoint refreshing on a valid secret and rejecting an invalid or missing one with the same error whether or not the pocket exists; the per-pocket budget capping a flood; and the scan pass surviving one pocket erroring.

`uv run pytest tests/cloud/ tests/ee/` passes for every new and touched module — the ~64 pre-existing uploads / corrections / decision-trace failures are unrelated and were confirmed to fail identically on `dev`. `ruff check`, `ruff format --check`, `mypy` on touched files (no new errors), and all 16 import-linter contracts are green.