### PR TITLE
fix(pockets): surface ok=false edit runs as MCP tool errors so the canvas-stale bug stops being silent

### DIFF
--- a/ee/pocketpaw_ee/agent/pocket_specialist/mcp_tool.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/mcp_tool.py
@@ -136,7 +136,12 @@ async def _create_handler(args: dict[str, Any]) -> dict[str, Any]:
             }
         ]
     }
-    if getattr(out, "ok", True) is False:
+    # Only the explicit ``failed`` action means the run errored — ``draft_kit``
+    # and ``redraft`` are legitimate ``ok=False`` protocol states (the
+    # agent-mode first-call handshake, and the create-validation retry loop)
+    # that the chat agent MUST receive and act on. Flagging those as
+    # ``is_error`` would silently break the two-call flow.
+    if getattr(out, "action", None) == "failed":
         response["is_error"] = True
     return response
 
@@ -237,7 +242,12 @@ async def _edit_handler(args: dict[str, Any]) -> dict[str, Any]:
             }
         ]
     }
-    if getattr(out, "ok", True) is False:
+    # Only the explicit ``failed`` action means the run errored — ``draft_kit``
+    # and ``redraft`` are legitimate ``ok=False`` protocol states (the
+    # agent-mode first-call handshake, and the create-validation retry loop)
+    # that the chat agent MUST receive and act on. Flagging those as
+    # ``is_error`` would silently break the two-call flow.
+    if getattr(out, "action", None) == "failed":
         response["is_error"] = True
     return response
 

--- a/ee/pocketpaw_ee/agent/pocket_specialist/mcp_tool.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/mcp_tool.py
@@ -28,6 +28,19 @@ pocket-template slug) and the tool gains a top-level optional
 ``backend_summary`` (a non-secret ``{base_url, auth_type, configured}``
 summary — unused in 2a, declared now so 2b's API-skill loading does not
 re-touch the schema).
+Changes: 2026-05-23 (fix/pocket-edit-not-visible) — both handlers now
+mark the MCP response with ``is_error: True`` whenever the underlying
+``PocketSpecialist*Output.ok`` is False. Without this, a run whose
+ops were all rejected by the service (e.g. ``add_node`` with a stale
+``parent_id``) returned a *successful* tool result whose JSON body
+carried ``ok: false`` — the calling chat agent then frequently
+hallucinated a confident "applied" reply because, at the MCP layer,
+the tool had succeeded. Flipping ``is_error`` on ``ok=False`` makes
+the Claude tool-use framework treat the result as an error, so the
+chat agent surfaces the rejection reason instead of fabricating
+success while the canvas stays stale. The decline case
+(``ok=True, ops=[], warnings=[...]``) is intentionally NOT flagged —
+a planner that legitimately chose to do nothing is not a failure.
 """
 
 from __future__ import annotations
@@ -109,7 +122,13 @@ async def _create_handler(args: dict[str, Any]) -> dict[str, Any]:
             "is_error": True,
         }
 
-    return {
+    # Mark the MCP result as an error whenever the specialist itself
+    # reported ``ok=False``. The serialized output (with ``error``,
+    # ``warnings``, etc.) is still returned so the chat agent can surface
+    # the reason — flipping ``is_error`` only changes how the Claude
+    # tool-use framework presents the result to the model, which makes a
+    # silent rejection impossible to skip past.
+    response: dict[str, Any] = {
         "content": [
             {
                 "type": "text",
@@ -117,6 +136,9 @@ async def _create_handler(args: dict[str, Any]) -> dict[str, Any]:
             }
         ]
     }
+    if getattr(out, "ok", True) is False:
+        response["is_error"] = True
+    return response
 
 
 async def _edit_handler(args: dict[str, Any]) -> dict[str, Any]:
@@ -197,7 +219,17 @@ async def _edit_handler(args: dict[str, Any]) -> dict[str, Any]:
             "is_error": True,
         }
 
-    return {
+    # Mark the MCP result as an error whenever the edit run reported
+    # ``ok=False`` — typically: every supplied op was rejected by the
+    # service (e.g. ``add_node`` with a stale ``parent_id``), the
+    # specialist's backend stream errored, or no granular tool was
+    # invoked at all. Without this the chat agent saw a "successful"
+    # MCP tool call whose JSON body said ``ok: false`` and frequently
+    # fabricated a confident "applied" reply while the canvas stayed
+    # stale. A genuine decline (``ok=True, ops=[], warnings=[...]``)
+    # is intentionally NOT flagged — that is a planner choosing to do
+    # nothing, not a failure.
+    response: dict[str, Any] = {
         "content": [
             {
                 "type": "text",
@@ -205,6 +237,9 @@ async def _edit_handler(args: dict[str, Any]) -> dict[str, Any]:
             }
         ]
     }
+    if getattr(out, "ok", True) is False:
+        response["is_error"] = True
+    return response
 
 
 def build_pocket_specialist_server() -> Any:

--- a/tests/cloud/test_pocket_edit_failure_visibility.py
+++ b/tests/cloud/test_pocket_edit_failure_visibility.py
@@ -1,0 +1,196 @@
+# test_pocket_edit_failure_visibility.py — Regression for the
+#   "chat agent claims success, canvas stays stale" bug.
+# Created: 2026-05-23 (fix/pocket-edit-not-visible)
+#
+# The captain hit this on pocket 69e99a910f928e4735de9efc: the chat
+# agent fabricated a parent_id (``n_1nchlml3``) and passed it to
+# ``pocket_specialist__edit`` as the target of an ``add_node`` op.
+# The service correctly rejected with "no node with id 'n_1nchlml3'"
+# and the agent-mode adapter correctly returned
+# ``ok=False, action="failed", warnings=[<reason>]``. But the MCP
+# tool serialized that body and returned it WITHOUT setting
+# ``is_error: True`` — so at the Claude tool-use layer it looked
+# like a successful tool call, and the chat agent then frequently
+# replied "1 op applied" while the canvas stayed stale.
+#
+# The fix flips ``is_error`` on the MCP response whenever
+# ``out.ok`` is False. This test wires up a real (mongomock-motor)
+# pocket, drives the granular ops path end-to-end, and asserts the
+# is_error flag is set. Fails on origin/dev, passes after the fix.
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+@pytest.fixture
+def agent_identity():
+    """Bind workspace/user identity for ContextVar lookups inside the
+    granular agent_* helpers. Same pattern as
+    ``test_pocket_mutation_family.py::agent_identity``."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_agent_identity,
+        detach_agent_identity,
+    )
+
+    tokens = attach_agent_identity(workspace_id="w1", user_id="u1")
+    try:
+        yield
+    finally:
+        detach_agent_identity(tokens)
+
+
+async def _make_pocket() -> Any:
+    """A minimal pocket with a known root id and a chart child — same
+    shape as the captain's "Quick Test" pocket. The chat agent in the
+    bug repro fabricated ``n_1nchlml3`` as the root id even though the
+    real root was different; we reproduce that exact mismatch below."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    spec = {
+        "version": "1.0",
+        "ui": {
+            "id": "n_root0000",
+            "type": "flex",
+            "props": {"direction": "column"},
+            "children": [
+                {
+                    "id": "n_chart000",
+                    "type": "chart",
+                    "props": {"type": "bar"},
+                }
+            ],
+        },
+    }
+    doc = Pocket(
+        workspace="w1",
+        name="Quick Test",
+        owner="u1",
+        visibility="workspace",
+        rippleSpec=spec,
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.mark.asyncio
+async def test_edit_handler_marks_is_error_when_every_op_is_rejected(mongo_db, agent_identity):
+    """The captain's bug, end-to-end.
+
+    Send an ``add_node`` op whose ``parent_id`` does not exist on the
+    pocket. Expect:
+
+    * The MCP response has ``is_error: True`` so the chat agent's
+      tool-use framework treats it as a failure (and the agent cannot
+      fabricate a confident "applied" reply past it).
+    * The serialized body still carries ``ok=False`` + the rejection
+      reason in ``warnings`` so the chat agent can relay the cause.
+    * Nothing persists — the pocket spec is unchanged.
+    """
+    from pocketpaw_ee.agent.pocket_specialist.mcp_tool import _edit_handler
+
+    doc = await _make_pocket()
+    pocket_id = str(doc.id)
+
+    payload = await _edit_handler(
+        {
+            "pocket_id": pocket_id,
+            "intent": (
+                "Append a new line chart as the last child of the root "
+                "flex (n_1nchlml3), below the existing bar chart."
+            ),
+            "ops": [
+                {
+                    "op": "add_node",
+                    "args": {
+                        # The actual root is ``n_root0000``; this id is
+                        # the chat agent's hallucination — matches the
+                        # captain's repro.
+                        "parent_id": "n_1nchlml3",
+                        "spec": {
+                            "type": "chart",
+                            "props": {"type": "line", "height": 180},
+                        },
+                    },
+                }
+            ],
+        }
+    )
+
+    # The headline assertion — the bug.
+    assert payload.get("is_error") is True, (
+        "An add_node with a stale parent_id must surface as is_error so "
+        "the chat agent cannot fabricate success while the canvas stays "
+        "stale (pocket-edit-not-visible regression)."
+    )
+
+    # The body still carries the diagnostic detail.
+    body = json.loads(payload["content"][0]["text"])
+    assert body["ok"] is False
+    assert body["action"] == "failed"
+    assert body["ops"] == []
+    assert body["warnings"], "the rejection reason must ride along"
+    assert any("n_1nchlml3" in w for w in body["warnings"])
+
+    # And nothing got persisted — the pocket spec is untouched.
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    refreshed = await Pocket.get(doc.id)
+    assert refreshed is not None
+    ui = refreshed.rippleSpec["ui"]
+    # Still one child (the original chart) — no line chart appended.
+    assert len(ui["children"]) == 1
+    assert ui["children"][0]["id"] == "n_chart000"
+
+
+@pytest.mark.asyncio
+async def test_edit_handler_does_not_flag_is_error_on_real_apply(mongo_db, agent_identity):
+    """An ``add_node`` against the REAL parent_id persists the new
+    child and returns ``ok=True``. The MCP response must NOT carry
+    ``is_error`` — that would make every successful apply look like a
+    tool error and trigger spurious retries by the framework."""
+    from pocketpaw_ee.agent.pocket_specialist.mcp_tool import _edit_handler
+
+    doc = await _make_pocket()
+    pocket_id = str(doc.id)
+
+    payload = await _edit_handler(
+        {
+            "pocket_id": pocket_id,
+            "intent": "Append a line chart at the end of the root flex",
+            "ops": [
+                {
+                    "op": "add_node",
+                    "args": {
+                        "parent_id": "n_root0000",
+                        "spec": {
+                            "type": "chart",
+                            "props": {"type": "line", "height": 180},
+                        },
+                    },
+                }
+            ],
+        }
+    )
+
+    assert "is_error" not in payload, "A successful apply must not be flagged as a tool error"
+    body = json.loads(payload["content"][0]["text"])
+    assert body["ok"] is True
+    assert len(body["ops"]) == 1
+    assert body["ops"][0]["op"] == "add_node"
+
+    # Persisted — the new child landed.
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    refreshed = await Pocket.get(doc.id)
+    assert refreshed is not None
+    ui = refreshed.rippleSpec["ui"]
+    assert len(ui["children"]) == 2
+    # New chart was appended after the existing bar chart.
+    assert ui["children"][-1]["type"] == "chart"
+    assert ui["children"][-1]["props"]["type"] == "line"

--- a/tests/ee/agent/test_pocket_specialist/test_mcp_tool.py
+++ b/tests/ee/agent/test_pocket_specialist/test_mcp_tool.py
@@ -1,8 +1,22 @@
+# test_mcp_tool.py — MCP server registration + handler tests.
+# Updated: 2026-05-23 (fix/pocket-edit-not-visible) — added the
+#   ``TestEditHandler`` class covering the regression where the
+#   ``pocket_specialist__edit`` MCP tool returned a "successful"
+#   tool result (no ``is_error`` flag) even when the underlying
+#   ``PocketSpecialistEditOutput.ok`` was False — typically because
+#   every supplied granular op was rejected by the service (e.g.
+#   ``add_node`` with a stale ``parent_id``). The calling chat
+#   agent then frequently fabricated a confident "applied" reply
+#   while the canvas stayed stale. Both ``_edit_handler`` and
+#   ``_create_handler`` now flip ``is_error`` whenever ``out.ok``
+#   is False, so the tool-use framework surfaces the rejection.
 """MCP server registration + handler tests."""
 
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
+pytest.importorskip("pocketpaw_ee")
 
 
 class TestPocketSpecialistMcpServer:
@@ -104,3 +118,222 @@ class TestCreateHandler:
             payload = await _create_handler({"brief": "Test brief here"})
         assert payload.get("is_error") is True
         assert "backend exploded" in payload["content"][0]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_handler_flips_is_error_when_specialist_returns_ok_false(self):
+        """A specialist run that completes cleanly but reports ``ok=False``
+        must still come back as an MCP tool error so the chat agent can't
+        skim past the rejection. Mirror of the edit-side regression — the
+        create path has the same hallucination surface."""
+        import json
+
+        from pocketpaw_ee.agent.pocket_specialist.mcp_tool import _create_handler
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistCreateOutput,
+        )
+
+        failed_out = PocketSpecialistCreateOutput(
+            ok=False,
+            action="failed",
+            pocket=None,
+            warnings=[],
+            duration_ms=10,
+            backend_used="agent_mode",
+            error="catalog gate rejected widget type 'imaginary-card'",
+        )
+        with (
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_workspace_id",
+                return_value="ws-1",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_user_id",
+                return_value="user-A",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.run_specialist",
+                new=AsyncMock(return_value=failed_out),
+            ),
+        ):
+            payload = await _create_handler({"brief": "Build a thing"})
+
+        assert payload.get("is_error") is True, (
+            "ok=False from the specialist must surface as is_error=True so "
+            "the chat agent treats the tool call as a failure"
+        )
+        body = json.loads(payload["content"][0]["text"])
+        assert body["ok"] is False
+        assert "imaginary-card" in body["error"]
+
+
+class TestEditHandler:
+    """The bug: ``add_node`` with a stale ``parent_id`` was rejected by
+    the service (correct), the agent-mode adapter returned
+    ``ok=False, action="failed", warnings=[<reason>]`` (correct), the
+    MCP tool serialised the body and returned it WITHOUT ``is_error``
+    (incorrect — looked like a successful tool call). The chat agent
+    then routinely fabricated "1 op applied" while the canvas stayed
+    stale because nothing actually persisted. These tests pin
+    ``is_error=True`` on the MCP response whenever ``out.ok`` is False
+    so the rejection cannot slip past the tool-use framework."""
+
+    @pytest.mark.asyncio
+    async def test_handler_flips_is_error_when_edit_run_reports_ok_false(self):
+        """The captain's bug: every op rejected → ok=False → is_error=True."""
+        import json
+
+        from pocketpaw_ee.agent.pocket_specialist.mcp_tool import _edit_handler
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditOutput,
+        )
+
+        failed_out = PocketSpecialistEditOutput(
+            ok=False,
+            action="failed",
+            pocket_id="p1",
+            ops=[],
+            duration_ms=10,
+            backend_used="agent_mode",
+            error=(
+                "No edit ops were applied — every supplied op was "
+                "rejected or unsupported. See warnings for the per-op "
+                "reasons."
+            ),
+            warnings=["Edit op 'add_node' could not be applied: no node with id 'n_1nchlml3'"],
+        )
+        with (
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_workspace_id",
+                return_value="ws-1",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_user_id",
+                return_value="user-A",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.run_edit_specialist",
+                new=AsyncMock(return_value=failed_out),
+            ),
+        ):
+            payload = await _edit_handler(
+                {
+                    "pocket_id": "p1",
+                    "intent": "Add another line chart",
+                    "ops": [
+                        {
+                            "op": "add_node",
+                            "args": {
+                                "parent_id": "n_1nchlml3",
+                                "spec": {"type": "chart"},
+                            },
+                        }
+                    ],
+                }
+            )
+
+        assert payload.get("is_error") is True, (
+            "ok=False must surface as is_error=True so the chat agent "
+            "can't claim success while the canvas stays stale"
+        )
+        body = json.loads(payload["content"][0]["text"])
+        assert body["ok"] is False
+        assert body["action"] == "failed"
+        # The warnings must still ride along so the agent has the reason
+        # — flipping is_error only changes how the framework presents it.
+        assert any("n_1nchlml3" in w for w in body["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_handler_keeps_success_path_unflagged(self):
+        """An edit run that actually applied an op must NOT trip
+        ``is_error`` — that would make a real apply look like a failure
+        and trigger spurious retries by the framework."""
+        from pocketpaw_ee.agent.pocket_specialist.mcp_tool import _edit_handler
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditOutput,
+        )
+
+        applied_out = PocketSpecialistEditOutput(
+            ok=True,
+            action="applied",
+            pocket_id="p1",
+            ops=[{"op": "set_state", "args": {"path": "filter", "value": "done"}}],
+            duration_ms=5,
+            backend_used="agent_mode",
+            warnings=[],
+        )
+        with (
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_workspace_id",
+                return_value="ws-1",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_user_id",
+                return_value="user-A",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.run_edit_specialist",
+                new=AsyncMock(return_value=applied_out),
+            ),
+        ):
+            payload = await _edit_handler(
+                {
+                    "pocket_id": "p1",
+                    "intent": "Filter to done",
+                    "ops": [
+                        {
+                            "op": "set_state",
+                            "args": {"path": "filter", "value": "done"},
+                        }
+                    ],
+                }
+            )
+
+        assert "is_error" not in payload, (
+            "ok=True must not be flagged as is_error — that would make "
+            "every successful apply look like a tool error"
+        )
+
+    @pytest.mark.asyncio
+    async def test_handler_keeps_decline_path_unflagged(self):
+        """A genuine planner decline (``ok=True, ops=[], warnings=[...]``)
+        is the subagent path saying "I looked and decided to do nothing"
+        — that is a legitimate no-op, not a failure. It must keep
+        ``is_error`` off so the chat agent can relay the planner's
+        reason without the framework treating it as an error."""
+        from pocketpaw_ee.agent.pocket_specialist.mcp_tool import _edit_handler
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditOutput,
+        )
+
+        declined_out = PocketSpecialistEditOutput(
+            ok=True,
+            action="applied",
+            pocket_id="p1",
+            ops=[],
+            duration_ms=5,
+            backend_used="deep_agents",
+            warnings=["I couldn't find a chart to recolor — the pocket has no chart node."],
+        )
+        with (
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_workspace_id",
+                return_value="ws-1",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_user_id",
+                return_value="user-A",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.run_edit_specialist",
+                new=AsyncMock(return_value=declined_out),
+            ),
+        ):
+            payload = await _edit_handler({"pocket_id": "p1", "intent": "Make the chart blue"})
+
+        assert "is_error" not in payload, "A planner that legitimately did nothing is not a failure"
+
+    # NOTE: An end-to-end variant of the captain's bug — running real
+    # agent-mode ``_apply_ops`` against a real (mongomock) pocket with
+    # an ``add_node`` op naming a non-existent ``parent_id`` — lives in
+    # ``tests/cloud/test_pocket_edit_failure_visibility.py`` because the
+    # mongo_db fixture is only wired up under tests/cloud/.

--- a/tests/ee/agent/test_pocket_specialist/test_mcp_tool.py
+++ b/tests/ee/agent/test_pocket_specialist/test_mcp_tool.py
@@ -165,6 +165,82 @@ class TestCreateHandler:
         assert body["ok"] is False
         assert "imaginary-card" in body["error"]
 
+    @pytest.mark.asyncio
+    async def test_handler_does_not_flag_is_error_on_draft_kit(self):
+        """``ok=False, action="draft_kit"`` is the agent-mode first-call
+        HANDSHAKE — the adapter returns the draft kit so the chat agent
+        can compute granular ops and call back. Flagging it as is_error
+        breaks the two-call flow silently."""
+        from pocketpaw_ee.agent.pocket_specialist.mcp_tool import _create_handler
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistCreateOutput,
+        )
+
+        draft = PocketSpecialistCreateOutput(
+            ok=False,
+            action="draft_kit",
+            pocket=None,
+            duration_ms=10,
+            backend_used="agent_mode",
+        )
+        with (
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_workspace_id",
+                return_value="ws-1",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_user_id",
+                return_value="user-A",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.run_specialist",
+                new=AsyncMock(return_value=draft),
+            ),
+        ):
+            payload = await _create_handler({"brief": "Build a thing"})
+
+        assert "is_error" not in payload, (
+            "draft_kit is a protocol handshake, not a failure — flagging it "
+            "breaks the agent-mode two-call flow"
+        )
+
+    @pytest.mark.asyncio
+    async def test_handler_does_not_flag_is_error_on_redraft(self):
+        """``ok=False, action="redraft"`` is the create validation retry
+        loop — the chat agent must see the redraft signal to retry, not
+        treat it as a hard tool failure."""
+        from pocketpaw_ee.agent.pocket_specialist.mcp_tool import _create_handler
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistCreateOutput,
+        )
+
+        redraft = PocketSpecialistCreateOutput(
+            ok=False,
+            action="redraft",
+            pocket=None,
+            duration_ms=10,
+            backend_used="agent_mode",
+        )
+        with (
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_workspace_id",
+                return_value="ws-1",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_user_id",
+                return_value="user-A",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.run_specialist",
+                new=AsyncMock(return_value=redraft),
+            ),
+        ):
+            payload = await _create_handler({"brief": "Build a thing"})
+
+        assert "is_error" not in payload, (
+            "redraft is the create validation retry signal — flagging it breaks the retry loop"
+        )
+
 
 class TestEditHandler:
     """The bug: ``add_node`` with a stale ``parent_id`` was rejected by
@@ -331,6 +407,46 @@ class TestEditHandler:
             payload = await _edit_handler({"pocket_id": "p1", "intent": "Make the chart blue"})
 
         assert "is_error" not in payload, "A planner that legitimately did nothing is not a failure"
+
+    @pytest.mark.asyncio
+    async def test_handler_does_not_flag_is_error_on_draft_kit(self):
+        """``ok=False, action="draft_kit"`` is the edit agent-mode
+        first-call HANDSHAKE — the adapter returns the draft kit so
+        the chat agent can compute granular ops and call back.
+        Flagging it as is_error breaks the two-call flow silently."""
+        from pocketpaw_ee.agent.pocket_specialist.mcp_tool import _edit_handler
+        from pocketpaw_ee.agent.pocket_specialist.runtime import (
+            PocketSpecialistEditOutput,
+        )
+
+        draft = PocketSpecialistEditOutput(
+            ok=False,
+            action="draft_kit",
+            pocket_id="p1",
+            ops=[],
+            duration_ms=10,
+            backend_used="agent_mode",
+        )
+        with (
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_workspace_id",
+                return_value="ws-1",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.current_user_id",
+                return_value="user-A",
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.mcp_tool.run_edit_specialist",
+                new=AsyncMock(return_value=draft),
+            ),
+        ):
+            payload = await _edit_handler({"pocket_id": "p1", "intent": "add a chart"})
+
+        assert "is_error" not in payload, (
+            "draft_kit is a protocol handshake, not a failure — flagging it "
+            "breaks the agent-mode two-call flow"
+        )
 
     # NOTE: An end-to-end variant of the captain's bug — running real
     # agent-mode ``_apply_ops`` against a real (mongomock) pocket with


### PR DESCRIPTION
## What

When ``pocket_specialist__edit`` finishes with ``ok=false`` — typically
because every supplied granular op was rejected by the service — the
MCP tool now sets ``is_error: True`` on the response. The serialised
body (``error``, ``warnings``, ``ops``) still rides along byte-for-byte;
only the framework-level flag changes.

``_create_handler`` gets the same treatment, for symmetry.

## Why

Captain hit a regression on pocket ``69e99a910f928e4735de9efc`` (Quick
Test): the chat reply said *"1 op applied, no warnings, Line chart
added"* but the canvas still showed the original three metric cards
and the bar chart. No line chart anywhere. Mongo confirmed the pocket
spec had not been touched since April 23 — nothing actually persisted.

The audit log explained why. The chat agent fabricated a parent id
(``n_1nchlml3``) when the actual root flex was ``n_7nwerr3r``, and
sent that as the intent. The router escalated to Tier 2, the
specialist returned a draft kit, the chat agent computed an
``add_node`` op against the hallucinated parent, the granular service
correctly rejected with *"no node with id 'n_1nchlml3'"*, and the
agent-mode adapter correctly returned ``ok=false`` with the reason in
``warnings``.

The bug was the next hop. ``_edit_handler`` serialised that body and
returned it without ``is_error``, so the Claude tool-use framework saw
a successful tool call whose payload happened to read ``ok: false``.
That is exactly the shape a chat agent skims past: the tool worked,
the body has a status field, it can confidently report "applied" in
the next turn. With ``is_error: True`` the framework presents the
result as a tool error, which the model surfaces instead of glossing
over.

## Test

``tests/cloud/test_pocket_edit_failure_visibility.py`` is the
end-to-end regression. It builds a pocket with a known root id,
fires the captain's ``add_node`` with a stale parent id through
``_edit_handler`` against a real (mongomock-motor) Mongo, and asserts:

- ``payload["is_error"]`` is ``True``
- the body still carries ``ok: false`` and the rejection reason in
  ``warnings``
- the pocket spec did not change

It fails on ``origin/dev`` (``payload.get("is_error")`` is ``None``)
and passes after the fix. Three matching unit tests in
``tests/ee/agent/test_pocket_specialist/test_mcp_tool.py`` pin the
same contract on the create path, the success path (must NOT flag
``is_error``), and the genuine planner decline (``ok=true, ops=[],
warnings=[<reason>]`` — also must NOT flag, because choosing to do
nothing is a legitimate outcome, not a failure).

## Scope

One file changed in the runtime (``mcp_tool.py``, two ~10-line
guards plus header comment) and two test files. No frontend change
— this fix is on the contract the chat agent already reads. The
ripple-side mutation consumer and the SSE pipeline were verified to
already do the right thing once the agent stops fabricating
success.

## Out of scope (separate follow-ups, not in this PR)

- The chat agent should not invent node ids in the first place. The
  ``pocketpaw-edit-pocket`` skill could nudge it harder; that is a
  prompt change, not a code fix.
- The frontend could surface a toast on a ``pocket_edit_failed``
  SSE event for users who prefer ground truth on the canvas rather
  than waiting for the chat agent's reply. Worth it as a separate
  defence-in-depth.