### PR TITLE
fix(chat): surface backend error events as SSE error frames

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -651,6 +651,13 @@ async def _run_agent_stream(
                     ctx.target_agent_id,
                     message[:200],
                 )
+                # Clear the typing indicator BEFORE breaking out — control
+                # never reaches the normal ``stream_end`` cleanup at the end
+                # of the function, and other group members would otherwise see
+                # the agent typing indicator spin indefinitely after the
+                # backend error. Solo users are unaffected (the broadcast
+                # early-returns when ``ctx.members == [user_id]``).
+                await _broadcast_agent_typing(ctx, active=False)
                 yield ("error", {"code": "agent.backend_error", "message": message})
                 break
             elif etype == "done":

--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -637,6 +637,22 @@ async def _run_agent_stream(
                     handled_pocket_ids=handled_pocket_ids,
                 )
                 yield ("tool_result", {"tool": name, "output": output})
+            elif etype == "error":
+                # Surface backend-yielded errors to the client instead of
+                # silently dropping them. Without this, a misconfigured
+                # backend (e.g. ``codex_cli`` when ``openai-codex-sdk`` is
+                # not installed, or ``claude_agent_sdk`` without the CLI)
+                # ends the stream with ``assistant_message_id: null`` and
+                # the UI just shows an empty reply. Same shape as the
+                # outer ``except`` handler at line ~647.
+                message = econtent if isinstance(econtent, str) else str(econtent)
+                logger.warning(
+                    "Backend yielded error for agent=%s: %s",
+                    ctx.target_agent_id,
+                    message[:200],
+                )
+                yield ("error", {"code": "agent.backend_error", "message": message})
+                break
             elif etype == "done":
                 break
         # Flush anything the agent emitted right before ``done`` / break.

--- a/tests/cloud/test_agent_router_backend_error.py
+++ b/tests/cloud/test_agent_router_backend_error.py
@@ -87,7 +87,10 @@ async def test_backend_error_event_surfaces_as_sse_error(cloud_app_client: Async
     async def fake_persist(ctx, body):
         return "user_msg_id_1"
 
+    typing_calls: list[tuple[object, bool]] = []
+
     async def fake_broadcast_typing(ctx, active):
+        typing_calls.append((ctx, active))
         return None
 
     async def fake_build_knowledge_context(_ctx, *, user_message, attachments=None, mentions=None):
@@ -123,3 +126,12 @@ async def test_backend_error_event_surfaces_as_sse_error(cloud_app_client: Async
     assert error_payload["code"] == "agent.backend_error"
     assert "openai-codex-sdk" in error_payload["message"]
     assert names[-1] == "error"
+
+    # The error branch must clear the typing indicator before breaking out —
+    # otherwise other group members see the agent typing forever (the outer
+    # ``finally``/``stream_end`` cleanup never runs on this path because
+    # ``gen()`` breaks on the error frame).
+    assert any(active is False for _, active in typing_calls), (
+        "typing indicator left ON after backend error — group members would "
+        "see the agent typing indefinitely"
+    )

--- a/tests/cloud/test_agent_router_backend_error.py
+++ b/tests/cloud/test_agent_router_backend_error.py
@@ -1,0 +1,125 @@
+# 2026-05-23 — Regression cover for the agent-router event loop:
+# a backend that yields ``AgentEvent(type="error", ...)`` must surface
+# its message to the client as an SSE ``error`` frame, not be silently
+# swallowed. The original loop only handled message / thinking /
+# tool_use / tool_result / done, which meant a misconfigured backend
+# (e.g. codex_cli without ``openai-codex-sdk`` installed) caused the
+# stream to end with ``assistant_message_id: null`` and no diagnostic
+# reaching the UI.
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from pocketpaw_ee.cloud.chat import agent_router as mod
+
+
+class _ErrorYieldingPool:
+    """Mimics AgentPool with a backend that yields a single error event."""
+
+    def __init__(self, message: str = "openai-codex-sdk is not installed"):
+        self.message = message
+        self.observed: list[tuple[str, str, str]] = []
+
+    async def get(self, agent_id):
+        return SimpleNamespace(
+            agent_id=agent_id,
+            agent_name="Agent " + agent_id,
+            config={"backend": "codex_cli"},
+        )
+
+    async def run(
+        self,
+        agent_id,
+        message,
+        session_key,
+        history=None,
+        knowledge_context="",
+        instructions="",
+    ):
+        # Mirrors the real codex_cli / claude_sdk early-return path
+        # when an optional dependency is missing.
+        yield SimpleNamespace(type="error", content=self.message, metadata={})
+
+    async def observe(self, agent_id, user_input, agent_output):
+        self.observed.append((agent_id, user_input, agent_output))
+
+
+def _parse_sse(body: str) -> list[tuple[str, dict]]:
+    out: list[tuple[str, dict]] = []
+    for block in body.strip().split("\n\n"):
+        name = None
+        data = ""
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                name = line[7:]
+            elif line.startswith("data: "):
+                data = line[6:]
+        if name:
+            out.append((name, json.loads(data) if data else {}))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_backend_error_event_surfaces_as_sse_error(cloud_app_client: AsyncClient):
+    fake_ctx = SimpleNamespace(
+        kind=SimpleNamespace(value="group"),
+        scope_id="g1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1", "u2"],
+        target_agent_id="agent_X",
+        agent_ids_in_scope=["agent_X"],
+        pocket_tool_specs=[],
+        session_id=None,
+        pocket_id=None,
+        intent=None,
+    )
+    fake_pool = _ErrorYieldingPool(message="openai-codex-sdk is not installed: ...")
+
+    async def fake_resolver(**kwargs):
+        return fake_ctx
+
+    async def fake_persist(ctx, body):
+        return "user_msg_id_1"
+
+    async def fake_broadcast_typing(ctx, active):
+        return None
+
+    async def fake_build_knowledge_context(_ctx, *, user_message, attachments=None, mentions=None):
+        return ""
+
+    with (
+        patch.object(mod, "resolve_scope_context", fake_resolver),
+        patch.object(mod, "_persist_user_message", fake_persist),
+        patch.object(mod, "_broadcast_agent_typing", fake_broadcast_typing),
+        patch.object(mod, "build_knowledge_context", fake_build_knowledge_context),
+        patch.object(mod, "get_agent_pool", lambda: fake_pool),
+    ):
+        async with cloud_app_client.stream(
+            "POST",
+            "/cloud/chat/group/g1/agent",
+            json={"content": "hi"},
+        ) as resp:
+            assert resp.status_code == 200
+            body = (await resp.aread()).decode()
+
+    events = _parse_sse(body)
+    names = [n for n, _ in events]
+
+    # The error must appear as a dedicated SSE frame, terminating the stream.
+    # The outer ``gen()`` wrapper in ``post_agent_chat`` breaks on either
+    # ``stream_end`` or ``error``, so ``error`` here is the legitimate
+    # terminator — what we're guarding against is the prior silent-drop
+    # behavior where no error frame fired at all.
+    assert "error" in names, (
+        f"backend error was swallowed — expected an `error` SSE frame, got: {names}"
+    )
+    error_payload = next(p for n, p in events if n == "error")
+    assert error_payload["code"] == "agent.backend_error"
+    assert "openai-codex-sdk" in error_payload["message"]
+    assert names[-1] == "error"


### PR DESCRIPTION
## Summary

- Agent router silently dropped backend error events. A misconfigured backend (codex_cli with `openai-codex-sdk` missing, claude_agent_sdk without the CLI, any future variant that early-returns an `AgentEvent(type="error", ...)`) ended the SSE with `assistant_message_id: null` and the UI got a blank reply.
- Now the loop has an `elif etype == "error"` branch that emits the canonical SSE `error` frame (`code=agent.backend_error`, `message=<backend text>`). The outer `gen()` wrapper already terminates on `error`, so the stream closes cleanly.

## Why it matters

Hit this today: a default agent doc had `backend: codex_cli` but the local install only had the default `uv sync --dev --group ee` (no `[codex-sdk]` extra). The chat endpoint returned `200 OK` with an SSE that looked like:

```
event: stream_start
event: stream_end
data: {"assistant_message_id": null, ...}
```

No way to diagnose from the client. After the fix the same scenario yields:

```
event: error
data: {"code": "agent.backend_error", "message": "openai-codex-sdk is not installed: ..."}
```

## Test plan

- [x] `uv run pytest tests/cloud/test_agent_router_backend_error.py` — new regression
- [x] `uv run pytest tests/cloud/test_agent_router.py tests/cloud/test_agent_router_run.py tests/cloud/test_agent_router_errors.py` — existing agent_router suite stays green
- [x] Manual: re-fire `POST /cloud/chat/session/{sid}/agent` with the seeded PocketPaw agent on `claude_agent_sdk`; got real streamed reply ("hi").