### PR TITLE
feat: enhance file management and editor capabilities

### DIFF
--- a/client/src/lib/components/explorer/MarkdownViewer.svelte
+++ b/client/src/lib/components/explorer/MarkdownViewer.svelte
@@ -103,7 +103,7 @@
     // If relative and we have a parentDir, mark it for async resolution
     if (parentDir && href && !href.startsWith("http") && !href.startsWith("data:") && !isAbsolute(href)) {
       const absPath = joinPath(parentDir, href);
-      return `<img src="" data-resolve-path="${absPath}"${altAttr}${titleAttr} />`;
+      return `<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" data-resolve-path="${absPath}"${altAttr}${titleAttr} />`;
     }
     return `<img src="${href}"${altAttr}${titleAttr} />`;
   };

--- a/client/src/lib/tauri/hotkeys.ts
+++ b/client/src/lib/tauri/hotkeys.ts
@@ -3,9 +3,14 @@
  * Gracefully no-ops in non-Tauri environments.
  */
 
+function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
 let shortcutModule: typeof import("@tauri-apps/plugin-global-shortcut") | null = null;
 
 async function getModule() {
+  if (!isTauri()) return null;
   if (shortcutModule) return shortcutModule;
   try {
     shortcutModule = await import("@tauri-apps/plugin-global-shortcut");

--- a/client/src/lib/tauri/tray.ts
+++ b/client/src/lib/tauri/tray.ts
@@ -1,11 +1,17 @@
 /**
  * Frontend tray state management.
  * Listens for tray events emitted by the Rust backend.
+ * Gracefully no-ops in non-Tauri (browser) environments.
  */
+
+function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
 
 let listenFn: typeof import("@tauri-apps/api/event").listen | null = null;
 
 async function getListen() {
+  if (!isTauri()) return null;
   if (listenFn) return listenFn;
   try {
     const mod = await import("@tauri-apps/api/event");

--- a/ee/cloud/__init__.py
+++ b/ee/cloud/__init__.py
@@ -119,12 +119,15 @@ def mount_cloud(app: FastAPI) -> None:
     from ee.cloud.notifications.router import router as notifications_router
     from ee.cloud.uploads.router import router as uploads_router
     from ee.paw_print.router import router as paw_print_router
+    from ee.cloud.file_versions.router import router as file_versions_router
 
     app.include_router(kb_router, prefix="/api/v1")
     app.include_router(knowledge_router, prefix="/api/v1")
     app.include_router(uploads_router, prefix="/api/v1")
     app.include_router(notifications_router, prefix="/api/v1")
     app.include_router(files_router, prefix="/api/v1")
+
+    app.include_router(file_versions_router, prefix="/api/v1")
 
     # Files Tab v2 — /api/v1/files/tree + /api/v1/files/browse. Mounted
     # inline (instead of via build_router's ctx_factory) so the routes can
@@ -344,10 +347,14 @@ def mount_cloud(app: FastAPI) -> None:
     # Start/stop agent pool with app lifecycle.
     #
     # Chat persistence lives entirely in ``MongoMemoryStore.save`` — it
-    # writes the message row, auto-creates/touches the linked Session, and
-    # receives attachments via ``InboundMessage.metadata["attachments"]``.
-    # The old ``ee.cloud.shared.chat_persistence`` bus subscriber was
-    # removed because it dual-wrote every turn.
+    # CSRF token endpoint — the frontend http() wrapper fetches a token
+    # before POST/PUT/DELETE. The cloud backend uses JWT auth, not cookie
+    # double-submit, so this returns a placeholder token to silence 404s.
+    @app.get("/api/v1/auth/csrf")
+    async def get_csrf():
+        import uuid
+        return {"csrf_token": uuid.uuid4().hex}
+
     @app.on_event("startup")
     async def _start_agent_pool():
         from pocketpaw.agents.pool import get_agent_pool

--- a/ee/cloud/chat/agent_router.py
+++ b/ee/cloud/chat/agent_router.py
@@ -338,6 +338,34 @@ async def _run_agent_stream(
         if editor_ctx:
             knowledge_context = f"{knowledge_context}\n\n{editor_ctx}"
 
+    from pocketpaw.tools.builtin.edit_spreadsheet import (
+        build_spreadsheet_prompt_context,
+        clear_edit_session as clear_spreadsheet_session,
+        get_edit_session as get_spreadsheet_session,
+        set_edit_session as set_spreadsheet_session,
+    )
+
+    if body.spreadsheet_snapshot:
+        snapshot_copy = json.loads(json.dumps(body.spreadsheet_snapshot))
+        set_spreadsheet_session(snapshot_copy)
+        spreadsheet_ctx = build_spreadsheet_prompt_context(snapshot=snapshot_copy)
+        if spreadsheet_ctx:
+            knowledge_context = f"{knowledge_context}\n\n{spreadsheet_ctx}"
+
+    from pocketpaw.tools.builtin.edit_slides import (
+        build_slides_prompt_context,
+        clear_edit_session as clear_slides_session,
+        get_edit_session as get_slides_session,
+        set_edit_session as set_slides_session,
+    )
+
+    if body.slides_data:
+        slides_copy = json.loads(json.dumps(body.slides_data))
+        set_slides_session(slides_copy)
+        slides_ctx = build_slides_prompt_context(deck=slides_copy)
+        if slides_ctx:
+            knowledge_context = f"{knowledge_context}\n\n{slides_ctx}"
+
     await _broadcast_agent_typing(ctx, active=True)
 
     stream_start_payload: dict[str, Any] = {
@@ -393,6 +421,8 @@ async def _run_agent_stream(
     full_text = ""
     cancelled = False
     _editor_blocks_result: list[dict[str, Any]] | None = None
+    _spreadsheet_snapshot_result: dict[str, Any] | None = None
+    _slides_data_result: dict[str, Any] | None = None
     try:
         async for event in pool.run(
             ctx.target_agent_id,
@@ -442,6 +472,19 @@ async def _run_agent_stream(
         except Exception:
             logger.debug("get_edit_session failed", exc_info=True)
 
+        # Extract spreadsheet snapshot before finally clears the session.
+        try:
+            _spreadsheet_snapshot_result = get_spreadsheet_session()
+        except Exception:
+            logger.debug("get_spreadsheet_session failed", exc_info=True)
+
+        # Extract slides deck before finally clears the session.
+        try:
+            _slides_data_result = get_slides_session()
+        except Exception:
+            logger.debug("get_slides_session failed", exc_info=True)
+            _slides_data_result = None
+
     except Exception as e:
         logger.exception("Cloud agent run failed for agent=%s", ctx.target_agent_id)
         yield ("error", {"code": "agent.run_failed", "message": str(e)})
@@ -458,6 +501,14 @@ async def _run_agent_stream(
             pass
         try:
             clear_edit_session()
+        except Exception:
+            pass
+        try:
+            clear_spreadsheet_session()
+        except Exception:
+            pass
+        try:
+            clear_slides_session()
         except Exception:
             pass
 
@@ -501,6 +552,8 @@ async def _run_agent_stream(
                 "usage": {},
                 "cancelled": cancelled,
                 "editor_blocks": _editor_blocks_result,
+                "spreadsheet_snapshot": _spreadsheet_snapshot_result,
+                "slides_data": _slides_data_result,
             },
         )
         await _broadcast_agent_typing(ctx, active=False)
@@ -531,6 +584,8 @@ async def _run_agent_stream(
             "usage": {},
             "cancelled": False,
             "editor_blocks": _editor_blocks_result,
+            "spreadsheet_snapshot": _spreadsheet_snapshot_result,
+            "slides_data": _slides_data_result,
         },
     )
 

--- a/ee/cloud/chat/agent_router.py
+++ b/ee/cloud/chat/agent_router.py
@@ -323,6 +323,21 @@ async def _run_agent_stream(
         mentions=body.mentions,
     )
 
+    from pocketpaw.tools.builtin.edit_document import (
+        build_editor_prompt_context,
+        clear_edit_session,
+        get_edit_session,
+        set_edit_session,
+    )
+
+    if body.editor_blocks:
+        # Deep-copy so ContextVar mutations don't touch the request body.
+        blocks_copy = json.loads(json.dumps(body.editor_blocks))
+        set_edit_session(blocks_copy)
+        editor_ctx = build_editor_prompt_context(blocks=blocks_copy)
+        if editor_ctx:
+            knowledge_context = f"{knowledge_context}\n\n{editor_ctx}"
+
     await _broadcast_agent_typing(ctx, active=True)
 
     stream_start_payload: dict[str, Any] = {
@@ -377,6 +392,7 @@ async def _run_agent_stream(
 
     full_text = ""
     cancelled = False
+    _editor_blocks_result: list[dict[str, Any]] | None = None
     try:
         async for event in pool.run(
             ctx.target_agent_id,
@@ -419,6 +435,13 @@ async def _run_agent_stream(
         # Flush anything the agent emitted right before ``done`` / break.
         for ev in _drain_side_channel():
             yield ev
+
+        # Extract editor blocks before finally clears the edit session.
+        try:
+            _editor_blocks_result = get_edit_session()
+        except Exception:
+            logger.debug("get_edit_session failed", exc_info=True)
+
     except Exception as e:
         logger.exception("Cloud agent run failed for agent=%s", ctx.target_agent_id)
         yield ("error", {"code": "agent.run_failed", "message": str(e)})
@@ -431,6 +454,10 @@ async def _run_agent_stream(
             pass
         try:
             detach_agent_identity(identity_tokens)
+        except Exception:
+            pass
+        try:
+            clear_edit_session()
         except Exception:
             pass
 
@@ -457,8 +484,25 @@ async def _run_agent_stream(
             full_text = (full_text[: match.start()] + full_text[match.end() :]).strip()
             yield ("ripple", {"spec": spec})
 
+    # Log editor blocks result for observability.
+    if _editor_blocks_result:
+        logger.info(
+            "Editor blocks result: present (%d blocks)",
+            len(_editor_blocks_result),
+        )
+    else:
+        logger.info("Editor blocks result: none")
+
     if cancelled or not full_text.strip():
-        yield ("stream_end", {"assistant_message_id": None, "usage": {}, "cancelled": cancelled})
+        yield (
+            "stream_end",
+            {
+                "assistant_message_id": None,
+                "usage": {},
+                "cancelled": cancelled,
+                "editor_blocks": _editor_blocks_result,
+            },
+        )
         await _broadcast_agent_typing(ctx, active=False)
         return
 
@@ -482,7 +526,12 @@ async def _run_agent_stream(
 
     yield (
         "stream_end",
-        {"assistant_message_id": assistant_id, "usage": {}, "cancelled": False},
+        {
+            "assistant_message_id": assistant_id,
+            "usage": {},
+            "cancelled": False,
+            "editor_blocks": _editor_blocks_result,
+        },
     )
 
 

--- a/ee/cloud/chat/agent_schemas.py
+++ b/ee/cloud/chat/agent_schemas.py
@@ -39,6 +39,14 @@ class CloudAgentChatRequest(BaseModel):
     # open file. The agent_router injects them into the system prompt so the
     # agent can call ``edit_document`` to make changes.
     editor_blocks: list[dict[str, Any]] | None = None
+    # Univer workbook snapshot from the spreadsheet editor, if the chat is
+    # scoped to an open spreadsheet file. The agent_router injects it into
+    # the system prompt so the agent can call ``edit_spreadsheet``.
+    spreadsheet_snapshot: dict[str, Any] | None = None
+    # Slides deck JSON from the slides editor, if the chat is scoped to an
+    # open slides file. The agent_router injects it into the system prompt so
+    # the agent can call ``edit_slides`` to make changes.
+    slides_data: dict[str, Any] | None = None
 
 
 class SseEventName(StrEnum):

--- a/ee/cloud/chat/agent_schemas.py
+++ b/ee/cloud/chat/agent_schemas.py
@@ -35,6 +35,10 @@ class CloudAgentChatRequest(BaseModel):
     # ``create_pocket`` tool instead of rendering an inline ``ui-spec``
     # block as a chat reply.
     intent: Literal["pocket_create"] | None = None
+    # Editor.js blocks from the file editor, if the chat is scoped to an
+    # open file. The agent_router injects them into the system prompt so the
+    # agent can call ``edit_document`` to make changes.
+    editor_blocks: list[dict[str, Any]] | None = None
 
 
 class SseEventName(StrEnum):

--- a/ee/cloud/file_versions/domain.py
+++ b/ee/cloud/file_versions/domain.py
@@ -1,0 +1,27 @@
+"""FileVersion domain value object
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+EditorKind = Literal["human", "agent"]
+
+
+@dataclass(frozen=True)
+class FileVersion:
+    id: str
+    file_id: str
+    workspace_id: str
+    version_number: int
+    content: str
+    content_hash: str
+    size_bytes: int
+    editor_kind: EditorKind
+    editor_id: str  # user_id or agent_id
+    created_at: datetime
+
+
+__all__ = ["EditorKind", "FileVersion"]

--- a/ee/cloud/file_versions/dto.py
+++ b/ee/cloud/file_versions/dto.py
@@ -1,0 +1,104 @@
+"""FileVersions DTOs — request/response schemas for the inline-edit API.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class UpdateFileContentRequest(BaseModel):
+    """Request body for PUT /files/{id}. Content is the full new text."""
+
+    content: str = Field(min_length=0)
+    # Expected version for If-Match. Omitted → force-overwrite (escape hatch).
+    expected_version: int | None = Field(default=None, alias="expectedVersion")
+
+    model_config = {"populate_by_name": True}
+
+
+class FileVersionListItem(BaseModel):
+    """One row in the version picker dropdown (content omitted)."""
+
+    id: str
+    file_id: str = Field(alias="fileId")
+    version_number: int = Field(alias="versionNumber")
+    size_bytes: int = Field(alias="sizeBytes")
+    editor_kind: str = Field(alias="editorKind")
+    editor_id: str = Field(alias="editorId")
+    created_at: datetime = Field(alias="createdAt")
+
+    model_config = {"populate_by_name": True}
+
+
+class FileVersionResponse(BaseModel):
+    """Full version payload including content (for revert / diff)."""
+
+    id: str
+    file_id: str = Field(alias="fileId")
+    version_number: int = Field(alias="versionNumber")
+    content: str
+    content_hash: str = Field(alias="contentHash")
+    size_bytes: int = Field(alias="sizeBytes")
+    editor_kind: str = Field(alias="editorKind")
+    editor_id: str = Field(alias="editorId")
+    created_at: datetime = Field(alias="createdAt")
+
+    model_config = {"populate_by_name": True}
+
+
+class UpdateFileContentResponse(BaseModel):
+    """Returned after a successful PUT /files/{id}."""
+
+    file_id: str = Field(alias="fileId")
+    new_version: int = Field(alias="newVersion")
+    size_bytes: int = Field(alias="sizeBytes")
+    content_hash: str = Field(alias="contentHash")
+
+    model_config = {"populate_by_name": True}
+
+
+class DiffResponse(BaseModel):
+    """Unified diff between two versions."""
+
+    from_version: int = Field(alias="fromVersion")
+    to_version: int = Field(alias="toVersion")
+    diff: str
+
+
+class WriteFileRequest(BaseModel):
+    """Request body for POST /files/write — create or overwrite a file."""
+
+    path: str = Field(min_length=1)  # file id or path
+    content: str = Field(min_length=0)  # full file content
+    filename: str | None = None  # display name (defaults to path if omitted)
+
+
+class WriteFileResponse(BaseModel):
+    """Returned after POST /files/write."""
+
+    file_id: str = Field(alias="fileId")
+    version: int
+    size_bytes: int = Field(alias="sizeBytes")
+
+    model_config = {"populate_by_name": True}
+
+
+class AiEditRequest(BaseModel):
+    """Request body for POST /files/{id}/ai-edit."""
+
+    content: str = Field(min_length=0)  # full document content (Editor.js JSON)
+    prompt: str = Field(min_length=1)  # what the user wants the AI to do
+    selected_block_id: str | None = Field(default=None, alias="selectedBlockId")
+    available_tools: list[str] = Field(default_factory=list, alias="availableTools")
+
+    model_config = {"populate_by_name": True}
+
+
+class AiEditResponse(BaseModel):
+    """AI-edited document blocks returned to the frontend."""
+
+    blocks: list[dict]  # updated Editor.js blocks array
+    summary: str = ""  # human-readable summary of changes
+

--- a/ee/cloud/file_versions/router.py
+++ b/ee/cloud/file_versions/router.py
@@ -1,0 +1,373 @@
+"""FileVersions router — inline-edit API for the Files panel.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Header
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from ee.cloud._core.errors import CloudError, ConflictError, NotFound
+from ee.cloud.file_versions import service as _svc
+from ee.cloud.file_versions.dto import (
+    AiEditRequest,
+    AiEditResponse,
+    UpdateFileContentRequest,
+    WriteFileRequest,
+)
+from ee.cloud.license import require_license
+from ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+router = APIRouter(
+    prefix="/files",
+    tags=["File Versions"],
+    dependencies=[Depends(require_license)],
+)
+
+
+def _ctx(user_id: str, workspace_id: str):
+    """Build a minimal RequestContext from dependency results."""
+    from datetime import UTC, datetime
+
+    from ee.cloud._core.context import RequestContext, ScopeKind
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /files/write — Create or overwrite a file
+# ---------------------------------------------------------------------------
+
+
+@router.post("/write")
+async def write_file(
+    body: WriteFileRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Create or overwrite a file. Returns the file id for subsequent versioned saves."""
+    ctx = _ctx(user_id, workspace_id)
+    try:
+        result = await _svc.write_file(ctx, body)
+    except CloudError as e:
+        return JSONResponse(status_code=e.status_code, content=e.to_dict())
+    return JSONResponse(status_code=201, content=result.model_dump(by_alias=True, mode="json"))
+
+
+# ---------------------------------------------------------------------------
+# PUT /files/{id} — Inline edit
+# ---------------------------------------------------------------------------
+
+
+@router.put("/{file_id}")
+async def update_file(
+    file_id: str,
+    body: UpdateFileContentRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+    if_match: str | None = Header(None, alias="If-Match"),
+) -> JSONResponse:
+    """Replace a text file's content inline.
+
+    Request body: ``{ content: "<new text>", expectedVersion?: <int> }``
+    Header: ``If-Match: <current content_version>`` (for optimistic concurrency)
+
+    Returns the new version info on success.
+    Returns 412 if the version precondition fails.
+    Returns 422 if the file type isn't editable.
+    """
+    ctx = _ctx(user_id, workspace_id)
+
+    # If-Match header takes precedence over body field
+    if if_match is not None:
+        try:
+            body.expected_version = int(if_match.strip('"'))
+        except ValueError:
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "files.bad_version", "message": "If-Match must be an integer."},
+            )
+
+    try:
+        result = await _svc.update_file_content(ctx, file_id, body)
+    except NotFound as e:
+        return JSONResponse(status_code=404, content=e.to_dict())
+    except ConflictError as e:
+        return JSONResponse(status_code=412, content=e.to_dict())
+    except CloudError as e:
+        return JSONResponse(status_code=e.status_code, content=e.to_dict())
+
+    return JSONResponse(status_code=200, content=result.model_dump(by_alias=True, mode="json"))
+
+
+# ---------------------------------------------------------------------------
+# GET /files/{id}/versions — Version list
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{file_id}/versions")
+async def list_file_versions(
+    file_id: str,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """List all archived versions for a file (oldest first, no content)."""
+    ctx = _ctx(user_id, workspace_id)
+    versions = await _svc.list_versions(ctx, file_id)
+    return JSONResponse(content={
+        "versions": [v.model_dump(by_alias=True, mode="json") for v in versions],
+    })
+
+
+# ---------------------------------------------------------------------------
+# GET /files/{id}/versions/{version_id} — Single version
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{file_id}/versions/{version_id}")
+async def get_file_version(
+    file_id: str,
+    version_id: str,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Fetch a single version with full content (for revert preview / diff)."""
+    ctx = _ctx(user_id, workspace_id)
+    try:
+        version = await _svc.get_version(ctx, file_id, version_id)
+    except NotFound as e:
+        return JSONResponse(status_code=404, content=e.to_dict())
+    return JSONResponse(content=version.model_dump(by_alias=True, mode="json"))
+
+
+# ---------------------------------------------------------------------------
+# POST /files/{id}/versions/{version_id}/revert — Revert
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{file_id}/versions/{version_id}/revert")
+async def revert_file_version(
+    file_id: str,
+    version_id: str,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Revert the live file to a historical version."""
+    ctx = _ctx(user_id, workspace_id)
+    try:
+        result = await _svc.revert_to_version(ctx, file_id, version_id)
+    except NotFound as e:
+        return JSONResponse(status_code=404, content=e.to_dict())
+    except ConflictError as e:
+        return JSONResponse(status_code=412, content=e.to_dict())
+    except CloudError as e:
+        return JSONResponse(status_code=e.status_code, content=e.to_dict())
+    return JSONResponse(status_code=200, content=result.model_dump(by_alias=True, mode="json"))
+
+
+# ---------------------------------------------------------------------------
+# GET /files/{id}/versions/{v1}/diff/{v2} — Diff
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{file_id}/versions/{v1}/diff/{v2}")
+async def diff_file_versions(
+    file_id: str,
+    v1: str,
+    v2: str,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Return a unified diff between two historical versions."""
+    ctx = _ctx(user_id, workspace_id)
+    try:
+        diff = await _svc.diff_versions(ctx, file_id, v1, v2)
+    except NotFound as e:
+        return JSONResponse(status_code=404, content=e.to_dict())
+    return JSONResponse(content=diff.model_dump(by_alias=True, mode="json"))
+
+
+# ---------------------------------------------------------------------------
+# POST /files/{id}/ai-edit — AI-assisted editing
+# ---------------------------------------------------------------------------
+
+
+def _build_edit_system_prompt(
+    blocks: list[dict],
+    available_tools: list[str],
+    selected_block_id: str | None,
+    user_prompt: str,
+) -> str:
+    """Delegate to the canonical prompt builder so chat + REST share the format."""
+    from pocketpaw.tools.builtin.edit_document import build_editor_prompt_context
+
+    ctx = build_editor_prompt_context(
+        blocks=blocks,
+        available_tools=available_tools,
+        selected_block_id=selected_block_id,
+    )
+    if ctx is None:
+        ctx = (
+            "The document is currently empty (no blocks). "
+            "Use the edit_document tool to insert the first blocks."
+        )
+    return (
+        f"{ctx}\n\nThe user's request: {user_prompt}\n\n"
+        "After making your edits, briefly tell the user what you changed."
+    )
+
+
+@router.post("/{file_id}/ai-edit")
+async def ai_edit_file(
+    file_id: str,
+    body: AiEditRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Run an AI agent to edit document content.
+
+    Parses Editor.js blocks, stores them in a per-request ContextVar so the
+    ``edit_document`` MCP tool can access them, and runs the workspace's
+    default agent. The agent can call the tool multiple times to iterate on
+    edits. Returns the final blocks array to the frontend.
+    """
+    body = AiEditRequest.model_validate(body)
+
+    import json as _json
+
+    # Parse Editor.js JSON → blocks with id, type, data
+    try:
+        doc = _json.loads(body.content)
+        blocks: list[dict] = doc.get("blocks", []) if isinstance(doc, dict) else []
+    except (_json.JSONDecodeError, TypeError):
+        blocks = []
+
+    # Deep-copy so the ContextVar stores a mutable list independent of the
+    # parsed JSON. Each block dict is also copied so updates don't corrupt
+    # the original parse result.
+    blocks = [_json.loads(_json.dumps(b)) for b in blocks]
+
+    # Build the system prompt dynamically from the actual blocks
+    system_prompt = _build_edit_system_prompt(
+        blocks=blocks,
+        available_tools=body.available_tools,
+        selected_block_id=body.selected_block_id,
+        user_prompt=body.prompt,
+    )
+    # Store blocks in ContextVar AND the module-level dict so the MCP
+    # handler can access them regardless of how the SDK dispatches the tool.
+    from pocketpaw.tools.builtin.edit_document import clear_edit_session, set_edit_session, set_editor_blocks
+
+    set_edit_session(blocks)
+    set_editor_blocks(file_id, blocks)
+
+    try:
+        from pocketpaw.agents.pool import get_agent_pool
+
+        pool = get_agent_pool()
+
+        from ee.cloud.agents import service as agents_service
+
+        agents = await agents_service.list_agents(workspace_id)
+        agent_id = agents[0].id if agents else None
+
+        if not agent_id:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "detail": "ai_edit.no_agent",
+                    "message": "No agent available in this workspace.",
+                },
+            )
+
+        session_key = f"cloud:file-edit:{file_id}:{agent_id}"
+        summary_parts: list[str] = []
+
+        async for event in pool.run(
+            agent_id,
+            body.prompt,
+            session_key,
+            knowledge_context=system_prompt,
+        ):
+            if event.type == "message":
+                summary_parts.append(str(event.content))
+            elif event.type == "error":
+                return JSONResponse(
+                    status_code=500,
+                    content={
+                        "detail": "ai_edit.agent_error",
+                        "message": str(event.content),
+                    },
+                )
+            elif event.type == "done":
+                break
+
+        # After the agent finishes, read the final blocks (may have been
+        # mutated by edit_document tool calls via MCP).
+        final_blocks = blocks
+
+        return JSONResponse(
+            content=AiEditResponse(
+                blocks=final_blocks,
+                summary="".join(summary_parts).strip() or "Document edited.",
+            ).model_dump(by_alias=True)
+        )
+
+    except Exception as exc:
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "ai_edit.failed", "message": str(exc)},
+        )
+    finally:
+        clear_edit_session()
+
+
+# ---------------------------------------------------------------------------
+# PUT /files/{id}/editing-context — Sync editor blocks before chat
+# ---------------------------------------------------------------------------
+
+
+class SyncEditingContextRequest(BaseModel):
+    blocks: list[dict]
+
+
+@router.put("/{file_id}/editing-context")
+async def sync_editing_context(
+    file_id: str,
+    body: SyncEditingContextRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Store the current Editor.js blocks so the chat agent's MCP tool can
+    access them during chat-initiated editing."""
+    from pocketpaw.tools.builtin.edit_document import set_editor_blocks
+
+    set_editor_blocks(file_id, body.blocks)
+    return JSONResponse(status_code=200, content={"ok": True})
+
+
+# ---------------------------------------------------------------------------
+# GET /files/{id}/editing-context — Fetch updated blocks after chat
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{file_id}/editing-context")
+async def get_editing_context(
+    file_id: str,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Return the current blocks for a file (may have been mutated by the
+    edit_document MCP tool during a chat session)."""
+    from pocketpaw.tools.builtin.edit_document import get_editor_blocks
+
+    blocks = get_editor_blocks(file_id)
+    if blocks is None:
+        return JSONResponse(status_code=404, content={"detail": "No editing session active."})
+    return JSONResponse(status_code=200, content={"blocks": blocks})
+

--- a/ee/cloud/file_versions/router.py
+++ b/ee/cloud/file_versions/router.py
@@ -261,10 +261,17 @@ async def ai_edit_file(
     )
     # Store blocks in ContextVar AND the module-level dict so the MCP
     # handler can access them regardless of how the SDK dispatches the tool.
-    from pocketpaw.tools.builtin.edit_document import clear_edit_session, set_edit_session, set_editor_blocks
+    from pocketpaw.tools.builtin.edit_document import (
+        clear_edit_session,
+        clear_selected_block_id,
+        set_edit_session,
+        set_editor_blocks,
+        set_selected_block_id,
+    )
 
     set_edit_session(blocks)
     set_editor_blocks(file_id, blocks)
+    set_selected_block_id(body.selected_block_id)
 
     try:
         from pocketpaw.agents.pool import get_agent_pool
@@ -325,6 +332,7 @@ async def ai_edit_file(
         )
     finally:
         clear_edit_session()
+        clear_selected_block_id()
 
 
 # ---------------------------------------------------------------------------

--- a/ee/cloud/file_versions/router.py
+++ b/ee/cloud/file_versions/router.py
@@ -15,6 +15,16 @@ from ee.cloud.file_versions.dto import (
     UpdateFileContentRequest,
     WriteFileRequest,
 )
+from ee.cloud.file_versions.spreadsheet_dto import (
+    SpreadsheetEditRequest,
+    SpreadsheetEditResponse,
+    SyncSpreadsheetContextRequest,
+)
+from ee.cloud.file_versions.slides_dto import (
+    SlidesEditRequest,
+    SlidesEditResponse,
+    SyncSlidesContextRequest,
+)
 from ee.cloud.license import require_license
 from ee.cloud.shared.deps import current_user_id, current_workspace_id
 
@@ -378,4 +388,353 @@ async def get_editing_context(
     if blocks is None:
         return JSONResponse(status_code=404, content={"detail": "No editing session active."})
     return JSONResponse(status_code=200, content={"blocks": blocks})
+
+
+# ---------------------------------------------------------------------------
+# POST /files/{id}/spreadsheet-edit — AI-assisted spreadsheet editing
+# ---------------------------------------------------------------------------
+
+
+def _build_spreadsheet_system_prompt(
+    snapshot: dict,
+    selected_sheet: str | None,
+    user_prompt: str,
+) -> str:
+    """Build the system prompt for spreadsheet AI editing."""
+    from pocketpaw.tools.builtin.edit_spreadsheet import build_spreadsheet_prompt_context
+
+    ctx = build_spreadsheet_prompt_context(snapshot=snapshot, selected_sheet=selected_sheet)
+    if ctx is None:
+        ctx = (
+            "The workbook is currently empty (no sheets). "
+            "Use the edit_spreadsheet tool to create the first sheet and populate it."
+        )
+    return (
+        f"{ctx}\n\nThe user's request: {user_prompt}\n\n"
+        "After making your edits, briefly tell the user what you changed."
+    )
+
+
+@router.post("/{file_id}/spreadsheet-edit")
+async def spreadsheet_ai_edit(
+    file_id: str,
+    body: SpreadsheetEditRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Run an AI agent to edit spreadsheet content.
+
+    Parses the workbook snapshot JSON, stores it in a per-request ContextVar
+    so the ``edit_spreadsheet`` MCP tool can access it, and runs the
+    workspace's default agent. Returns the final snapshot to the frontend.
+    """
+    body = SpreadsheetEditRequest.model_validate(body)
+
+    import json as _json
+
+    try:
+        snapshot: dict = _json.loads(body.content)
+        if not isinstance(snapshot, dict):
+            snapshot = {}
+    except (_json.JSONDecodeError, TypeError):
+        snapshot = {}
+
+    # Deep-copy so mutations don't touch the parsed JSON
+    snapshot = _json.loads(_json.dumps(snapshot))
+
+    system_prompt = _build_spreadsheet_system_prompt(
+        snapshot=snapshot,
+        selected_sheet=body.selected_sheet,
+        user_prompt=body.prompt,
+    )
+
+    from pocketpaw.tools.builtin.edit_spreadsheet import (
+        clear_edit_session,
+        clear_selected_sheet,
+        set_edit_session,
+        set_selected_sheet,
+        set_spreadsheet_snapshot,
+    )
+
+    set_edit_session(snapshot)
+    set_spreadsheet_snapshot(file_id, snapshot)
+    set_selected_sheet(body.selected_sheet)
+
+    try:
+        from pocketpaw.agents.pool import get_agent_pool
+
+        pool = get_agent_pool()
+
+        from ee.cloud.agents import service as agents_service
+
+        agents = await agents_service.list_agents(workspace_id)
+        agent_id = agents[0].id if agents else None
+
+        if not agent_id:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "detail": "spreadsheet_edit.no_agent",
+                    "message": "No agent available in this workspace.",
+                },
+            )
+
+        session_key = f"cloud:spreadsheet-edit:{file_id}:{agent_id}"
+        summary_parts: list[str] = []
+
+        async for event in pool.run(
+            agent_id,
+            body.prompt,
+            session_key,
+            knowledge_context=system_prompt,
+        ):
+            if event.type == "message":
+                summary_parts.append(str(event.content))
+            elif event.type == "error":
+                return JSONResponse(
+                    status_code=500,
+                    content={
+                        "detail": "spreadsheet_edit.agent_error",
+                        "message": str(event.content),
+                    },
+                )
+            elif event.type == "done":
+                break
+
+        final_snapshot = snapshot
+
+        return JSONResponse(
+            content=SpreadsheetEditResponse(
+                snapshot=final_snapshot,
+                summary="".join(summary_parts).strip() or "Spreadsheet edited.",
+            ).model_dump(by_alias=True)
+        )
+
+    except Exception as exc:
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "spreadsheet_edit.failed", "message": str(exc)},
+        )
+    finally:
+        clear_edit_session()
+        clear_selected_sheet()
+
+
+# ---------------------------------------------------------------------------
+# PUT /files/{id}/spreadsheet-context — Sync spreadsheet snapshot before chat
+# ---------------------------------------------------------------------------
+
+
+@router.put("/{file_id}/spreadsheet-context")
+async def sync_spreadsheet_context(
+    file_id: str,
+    body: SyncSpreadsheetContextRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Store the current workbook snapshot so the chat agent's MCP tool can
+    access it during chat-initiated spreadsheet editing."""
+    from pocketpaw.tools.builtin.edit_spreadsheet import (
+        set_selected_sheet,
+        set_spreadsheet_snapshot,
+    )
+
+    set_spreadsheet_snapshot(file_id, body.snapshot)
+    if body.selected_sheet:
+        set_selected_sheet(body.selected_sheet)
+    return JSONResponse(status_code=200, content={"ok": True})
+
+
+# ---------------------------------------------------------------------------
+# GET /files/{id}/spreadsheet-context — Fetch updated snapshot after chat
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{file_id}/spreadsheet-context")
+async def get_spreadsheet_context(
+    file_id: str,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Return the current workbook snapshot for a file (may have been mutated
+    by the edit_spreadsheet MCP tool during a chat session)."""
+    from pocketpaw.tools.builtin.edit_spreadsheet import get_spreadsheet_snapshot
+
+    snapshot = get_spreadsheet_snapshot(file_id)
+    if snapshot is None:
+        return JSONResponse(status_code=404, content={"detail": "No spreadsheet editing session active."})
+    return JSONResponse(status_code=200, content={"snapshot": snapshot})
+
+
+# ---------------------------------------------------------------------------
+# POST /files/{id}/slides-edit -- AI-assisted slides editing
+# ---------------------------------------------------------------------------
+
+
+def _build_slides_system_prompt(
+    deck: dict,
+    selected_slide_id: str | None,
+    user_prompt: str,
+) -> str:
+    """Build the system prompt for slides AI editing."""
+    from pocketpaw.tools.builtin.edit_slides import build_slides_prompt_context
+
+    ctx = build_slides_prompt_context(deck=deck, selected_slide_id=selected_slide_id)
+    if ctx is None:
+        ctx = (
+            "The slide deck is currently empty (no slides). "
+            "Use the edit_slides tool to create slides and populate them."
+        )
+    return (
+        f"{ctx}\n\nThe user's request: {user_prompt}\n\n"
+        "After making your edits, briefly tell the user what you changed."
+    )
+
+
+@router.post("/{file_id}/slides-edit")
+async def slides_ai_edit(
+    file_id: str,
+    body: SlidesEditRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Run an AI agent to edit slides content.
+
+    Parses the slides deck JSON, stores it in a per-request ContextVar
+    so the ``edit_slides`` MCP tool can access it, and runs the
+    workspace's default agent. Returns the final deck to the frontend.
+    """
+    body = SlidesEditRequest.model_validate(body)
+
+    import json as _json
+
+    deck: dict = body.content
+    if not isinstance(deck, dict):
+        deck = {}
+
+    # Deep-copy so mutations don't touch the parsed JSON
+    deck = _json.loads(_json.dumps(deck))
+
+    system_prompt = _build_slides_system_prompt(
+        deck=deck,
+        selected_slide_id=body.selected_slide_id,
+        user_prompt=body.prompt,
+    )
+
+    from pocketpaw.tools.builtin.edit_slides import (
+        clear_edit_session,
+        clear_selected_slide_id,
+        set_edit_session,
+        set_selected_slide_id,
+        set_slides_data,
+    )
+
+    set_edit_session(deck)
+    set_slides_data(file_id, deck)
+    set_selected_slide_id(body.selected_slide_id)
+
+    try:
+        from pocketpaw.agents.pool import get_agent_pool
+
+        pool = get_agent_pool()
+
+        from ee.cloud.agents import service as agents_service
+
+        agents = await agents_service.list_agents(workspace_id)
+        agent_id = agents[0].id if agents else None
+
+        if not agent_id:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "detail": "slides_edit.no_agent",
+                    "message": "No agent available in this workspace.",
+                },
+            )
+
+        session_key = f"cloud:slides-edit:{file_id}:{agent_id}"
+        summary_parts: list[str] = []
+
+        async for event in pool.run(
+            agent_id,
+            body.prompt,
+            session_key,
+            knowledge_context=system_prompt,
+        ):
+            if event.type == "message":
+                summary_parts.append(str(event.content))
+            elif event.type == "error":
+                return JSONResponse(
+                    status_code=500,
+                    content={
+                        "detail": "slides_edit.agent_error",
+                        "message": str(event.content),
+                    },
+                )
+            elif event.type == "done":
+                break
+
+        final_deck = deck
+
+        return JSONResponse(
+            content=SlidesEditResponse(
+                content=final_deck,
+                summary="".join(summary_parts).strip() or "Slides edited.",
+            ).model_dump(by_alias=True)
+        )
+
+    except Exception as exc:
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "slides_edit.failed", "message": str(exc)},
+        )
+    finally:
+        clear_edit_session()
+        clear_selected_slide_id()
+
+
+# ---------------------------------------------------------------------------
+# PUT /files/{id}/slides-context -- Sync slides deck before chat
+# ---------------------------------------------------------------------------
+
+
+@router.put("/{file_id}/slides-context")
+async def sync_slides_context(
+    file_id: str,
+    body: SyncSlidesContextRequest,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Store the current slides deck so the chat agent's MCP tool can
+    access it during chat-initiated slides editing."""
+    from pocketpaw.tools.builtin.edit_slides import (
+        set_selected_slide_id,
+        set_slides_data,
+    )
+
+    set_slides_data(file_id, body.content)
+    if body.selected_slide_id:
+        set_selected_slide_id(body.selected_slide_id)
+    return JSONResponse(status_code=200, content={"ok": True})
+
+
+# ---------------------------------------------------------------------------
+# GET /files/{id}/slides-context -- Fetch updated deck after chat
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{file_id}/slides-context")
+async def get_slides_context(
+    file_id: str,
+    user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
+) -> JSONResponse:
+    """Return the current slides deck for a file (may have been mutated
+    by the edit_slides MCP tool during a chat session)."""
+    from pocketpaw.tools.builtin.edit_slides import get_slides_data
+
+    deck = get_slides_data(file_id)
+    if deck is None:
+        return JSONResponse(status_code=404, content={"detail": "No slides editing session active."})
+    return JSONResponse(status_code=200, content={"content": deck})
 

--- a/ee/cloud/file_versions/service.py
+++ b/ee/cloud/file_versions/service.py
@@ -1,0 +1,373 @@
+"""FileVersions service — inline-edit version history.
+
+Module-level ``async def`` functions. Sole owner of writes to the
+``FileVersionDoc`` Beanie document and the ``FileUpload.content_version``
+counter. Text-only — binary files are rejected early.
+
+Public API:
+- ``update_file_content(ctx, file_id, body)`` — PUT /files/{id}
+- ``list_versions(ctx, file_id)`` — version list (no content)
+- ``get_version(ctx, file_id, version_id)`` — full version with content
+- ``revert_to_version(ctx, file_id, version_id)`` — POST /files/{id}/versions/{vid}/revert
+- ``diff_versions(ctx, file_id, from_v, to_v)`` — unified diff
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+from beanie import PydanticObjectId
+
+from ee.cloud._core.context import RequestContext
+from ee.cloud._core.errors import CloudError, ConflictError, NotFound
+from ee.cloud._core.realtime.emit import emit
+from ee.cloud._core.realtime.events import Event
+from ee.cloud.file_versions.dto import (
+    DiffResponse,
+    FileVersionListItem,
+    FileVersionResponse,
+    UpdateFileContentRequest,
+    UpdateFileContentResponse,
+    WriteFileRequest,
+    WriteFileResponse,
+)
+from ee.cloud.models.file_version import FileVersionDoc
+from ee.cloud.uploads.models import FileUpload
+
+logger = logging.getLogger(__name__)
+
+# Only these mime types are editable inline. Everything else gets a 422.
+EDITABLE_MIMES = frozenset({
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "text/html",
+    "text/css",
+    "text/javascript",
+    "text/xml",
+    "application/json",
+    "application/xml",
+    "application/javascript",
+    "application/x-yaml",
+    "application/x-ndjson",
+})
+
+# Use a mimetype that isn't text/* so the dashboard renders it as code.
+FALLBACK_EDIT_MIME = "text/plain"
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _is_editable(mime: str | None) -> bool:
+    if not mime:
+        return False
+    if mime.startswith("text/"):
+        return True
+    return mime in EDITABLE_MIMES
+
+
+async def _read_text(adapter, key: str) -> str:
+    """Read all chunks from StorageAdapter and decode as UTF-8."""
+    chunks: list[bytes] = []
+    async for chunk in adapter.open(key):
+        chunks.append(chunk)
+    return b"".join(chunks).decode("utf-8")
+
+
+async def _bytes_iter(text: str) -> AsyncIterator[bytes]:
+    yield text.encode("utf-8")
+
+
+# Storage adapter singleton — set by the router at mount time.
+_adapter: object | None = None
+
+
+def set_adapter(adapter: object) -> None:
+    global _adapter
+    _adapter = adapter
+
+
+def _get_storage():
+    global _adapter
+    if _adapter is None:
+        from ee.cloud.uploads.router import _SVC
+        _adapter = _SVC._adapter
+    return _adapter
+
+
+async def update_file_content(
+    ctx: RequestContext,
+    file_id: str,
+    body: UpdateFileContentRequest,
+    *,
+    editor_kind: str = "human",
+) -> UpdateFileContentResponse:
+    """Replace a text file's content with optimistic concurrency.
+
+    1. Fetch the ``FileUpload`` doc.
+    2. Check the ``If-Match`` precondition against ``content_version``.
+    3. Archive the current blob as a ``FileVersionDoc``.
+    4. Upload the new content to StorageAdapter.
+    5. Update ``FileUpload`` metadata and bump the version counter.
+    """
+    workspace_id = ctx.workspace_id
+    if not workspace_id:
+        raise CloudError(400, "files.missing_workspace", "Workspace is required.")
+
+    doc = await FileUpload.find_one(
+        {"file_id": file_id, "workspace": workspace_id, "deleted_at": None}
+    )
+    if not doc:
+        raise NotFound("file", file_id)
+
+    if not _is_editable(doc.mime):
+        raise CloudError(
+            422,
+            "files.not_editable",
+            f"File type '{doc.mime}' cannot be edited inline.",
+        )
+
+    expected = body.expected_version
+    if expected is not None and expected != doc.content_version:
+        raise ConflictError(
+            "files.version_conflict",
+            f"Expected version {expected} but current is {doc.content_version}. "
+            "Someone else edited this file. Reload and try again.",
+        )
+
+    new_version = doc.content_version + 1
+    new_content = body.content
+    new_hash = _sha256(new_content)
+    new_size = len(new_content.encode("utf-8"))
+    editor_id = ctx.user_id or "unknown"
+
+    adapter = _get_storage()
+
+    # --- archive current blob ---
+    try:
+        old_content = await _read_text(adapter, doc.storage_key)
+    except Exception:
+        old_content = ""
+
+    old_hash = _sha256(old_content)
+
+    # Only archive if content actually changed.
+    if old_hash != new_hash:
+        version_doc = FileVersionDoc(
+            file_id=file_id,
+            workspace_id=workspace_id,
+            version_number=new_version,
+            content=old_content,
+            content_hash=old_hash,
+            size_bytes=len(old_content.encode("utf-8")),
+            editor_kind=editor_kind,
+            editor_id=editor_id,
+            created_at=datetime.now(UTC),
+        )
+        await version_doc.insert()
+
+        # --- upload new blob ---
+        stored = await adapter.put(
+            doc.storage_key,
+            _bytes_iter(new_content),
+            doc.mime,
+        )
+
+        # --- update metadata ---
+        doc.size = stored.size
+        doc.content_version = new_version
+        await doc.save()
+
+        await emit(Event(type="file.updated", data={
+            "file_id": file_id,
+            "workspace_id": workspace_id,
+            "version": new_version,
+            "editor_kind": editor_kind,
+            "editor_id": editor_id,
+        }))
+
+        logger.info(
+            "file %s updated to version %d by %s:%s",
+            file_id, new_version, editor_kind, editor_id,
+        )
+
+    return UpdateFileContentResponse(
+        file_id=file_id,
+        new_version=new_version,
+        size_bytes=new_size,
+        content_hash=new_hash,
+    )
+
+
+async def write_file(
+    ctx: RequestContext,
+    body: WriteFileRequest,
+) -> WriteFileResponse:
+    """Create or overwrite a file. Used by the editor for first-save and by
+    the local-fs web-mode fallback (POST /files/write).
+
+    If a FileUpload record already exists for the given path, content is
+    updated in place (versioned). Otherwise a new FileUpload record and
+    storage blob are created.
+    """
+    workspace_id = ctx.workspace_id
+    if not workspace_id:
+        raise CloudError(400, "files.missing_workspace", "Workspace is required.")
+
+    file_id = body.path
+    content = body.content
+    mime = "application/json"  # Editor.js content is JSON
+
+    adapter = _get_storage()
+
+    doc = await FileUpload.find_one(
+        {"file_id": file_id, "workspace": workspace_id, "deleted_at": None}
+    )
+
+    if doc is not None:
+        update_body = UpdateFileContentRequest(content=content)
+        result = await update_file_content(ctx, file_id, update_body)
+        return WriteFileResponse(
+            file_id=result.file_id,
+            version=result.new_version,
+            size_bytes=result.size_bytes,
+        )
+
+    # New file — create FileUpload record and storage blob.
+    import uuid
+
+    storage_key = f"editor/{workspace_id}/{uuid.uuid4().hex}/{file_id}"
+    stored = await adapter.put(storage_key, _bytes_iter(content), mime)
+
+    doc = FileUpload(
+        file_id=file_id,
+        filename=body.filename or file_id,
+        workspace=workspace_id,
+        owner=ctx.user_id or "unknown",
+        mime=mime,
+        size=stored.size,
+        storage_key=storage_key,
+        content_version=1,
+    )
+    await doc.insert()
+
+    await emit(Event(type="file.created", data={
+        "file_id": file_id,
+        "workspace_id": workspace_id,
+        "size": stored.size,
+    }))
+
+    logger.info("file %s created via write (version 1)", file_id)
+
+    return WriteFileResponse(
+        file_id=file_id,
+        version=1,
+        size_bytes=stored.size,
+    )
+
+
+async def list_versions(
+    ctx: RequestContext,
+    file_id: str,
+) -> list[FileVersionListItem]:
+    """List all archived versions for a file (oldest first), content omitted."""
+    workspace_id = ctx.workspace_id
+    docs = await FileVersionDoc.find(
+        {"file_id": file_id, "workspace_id": workspace_id}
+    ).sort("+version_number").to_list()
+
+    logger.info(
+        "list_versions: file_id=%s workspace=%s found=%d",
+        file_id, workspace_id, len(docs),
+    )
+
+    return [
+        FileVersionListItem(
+            id=str(doc.id),
+            file_id=doc.file_id,
+            version_number=doc.version_number,
+            size_bytes=doc.size_bytes,
+            editor_kind=doc.editor_kind,
+            editor_id=doc.editor_id,
+            created_at=doc.created_at,
+        )
+        for doc in docs
+    ]
+
+
+async def get_version(
+    ctx: RequestContext,
+    file_id: str,
+    version_id: str,
+) -> FileVersionResponse:
+    """Fetch a single version with full content."""
+    workspace_id = ctx.workspace_id
+    try:
+        oid = PydanticObjectId(version_id)
+    except Exception:
+        raise NotFound("version", version_id) from None
+
+    doc = await FileVersionDoc.find_one(
+        {"_id": oid, "file_id": file_id, "workspace_id": workspace_id}
+    )
+    if not doc:
+        raise NotFound("version", version_id)
+
+    return FileVersionResponse(
+        id=str(doc.id),
+        file_id=doc.file_id,
+        version_number=doc.version_number,
+        content=doc.content,
+        content_hash=doc.content_hash,
+        size_bytes=doc.size_bytes,
+        editor_kind=doc.editor_kind,
+        editor_id=doc.editor_id,
+        created_at=doc.created_at,
+    )
+
+
+async def revert_to_version(
+    ctx: RequestContext,
+    file_id: str,
+    version_id: str,
+) -> UpdateFileContentResponse:
+    """Revert the live file to a historical version.
+
+    Archives the current content first, then uploads the version's content
+    as the new live blob.
+    """
+    version = await get_version(ctx, file_id, version_id)
+    body = UpdateFileContentRequest(content=version.content)
+    return await update_file_content(ctx, file_id, body, editor_kind="human")
+
+
+async def diff_versions(
+    ctx: RequestContext,
+    file_id: str,
+    from_version_id: str,
+    to_version_id: str,
+) -> DiffResponse:
+    """Return a unified diff between two historical versions."""
+    v1 = await get_version(ctx, file_id, from_version_id)
+    v2 = await get_version(ctx, file_id, to_version_id)
+
+    import difflib
+
+    diff = "".join(
+        difflib.unified_diff(
+            v1.content.splitlines(keepends=True),
+            v2.content.splitlines(keepends=True),
+            fromfile=f"v{v1.version_number}",
+            tofile=f"v{v2.version_number}",
+        )
+    )
+    return DiffResponse(
+        from_version=v1.version_number,
+        to_version=v2.version_number,
+        diff=diff,
+    )

--- a/ee/cloud/file_versions/slides_dto.py
+++ b/ee/cloud/file_versions/slides_dto.py
@@ -1,0 +1,34 @@
+"""Slides DTOs -- request/response schemas for AI editing + context sync."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class SlidesEditRequest(BaseModel):
+    """Request body for POST /files/{id}/slides-edit."""
+
+    content: dict[str, Any]  # full slides deck JSON
+    prompt: str = Field(min_length=1)  # what the user wants the AI to do
+    selected_slide_id: str | None = Field(default=None, alias="selectedSlideId")
+    available_tools: list[str] = Field(default_factory=list, alias="availableTools")
+
+    model_config = {"populate_by_name": True}
+
+
+class SlidesEditResponse(BaseModel):
+    """AI-edited slides deck returned to the frontend."""
+
+    content: dict[str, Any]  # updated slides deck JSON
+    summary: str = ""  # human-readable summary of changes
+
+
+class SyncSlidesContextRequest(BaseModel):
+    """Request body for PUT /files/{id}/slides-context."""
+
+    content: dict[str, Any]
+    selected_slide_id: str | None = Field(default=None, alias="selectedSlideId")
+
+    model_config = {"populate_by_name": True}

--- a/ee/cloud/file_versions/spreadsheet_dto.py
+++ b/ee/cloud/file_versions/spreadsheet_dto.py
@@ -1,0 +1,34 @@
+"""Spreadsheet DTOs — request/response schemas for AI editing + context sync."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class SpreadsheetEditRequest(BaseModel):
+    """Request body for POST /files/{id}/spreadsheet-edit."""
+
+    content: str = Field(min_length=0)  # full workbook snapshot JSON
+    prompt: str = Field(min_length=1)  # what the user wants the AI to do
+    selected_sheet: str | None = Field(default=None, alias="selectedSheet")
+    available_tools: list[str] = Field(default_factory=list, alias="availableTools")
+
+    model_config = {"populate_by_name": True}
+
+
+class SpreadsheetEditResponse(BaseModel):
+    """AI-edited workbook snapshot returned to the frontend."""
+
+    snapshot: dict[str, Any]  # updated IWorkbookData snapshot
+    summary: str = ""  # human-readable summary of changes
+
+
+class SyncSpreadsheetContextRequest(BaseModel):
+    """Request body for PUT /files/{id}/spreadsheet-context."""
+
+    snapshot: dict[str, Any]
+    selected_sheet: str | None = Field(default=None, alias="selectedSheet")
+
+    model_config = {"populate_by_name": True}

--- a/ee/cloud/files/router.py
+++ b/ee/cloud/files/router.py
@@ -48,7 +48,7 @@ _SVC = UnifiedFilesService()
 @router.get("")
 async def list_files(
     workspace_id: str | None = Query(None),
-    source: Literal["chat", "local", "drive"] | None = Query(None),
+    source: Literal["chat", "local", "drive", "kb", "agent"] | None = Query(None),
     pocket_id: str | None = Query(None),
     limit: int = Query(100, ge=1, le=500),
     user_id: str = Depends(current_user_id),
@@ -108,6 +108,7 @@ async def list_files(
                     "url": f.url,
                     "created": f.created.isoformat() if f.created else None,
                     "chat_id": f.chat_id,
+                    "agent_id": f.agent_id,
                 }
                 for f in files
             ],

--- a/ee/cloud/files/service.py
+++ b/ee/cloud/files/service.py
@@ -1,18 +1,6 @@
 """Unified files service — merges chat S3 uploads, local workspace dir,
-and (stubbed for now) Drive-synced files into one list the FE Files
-panel can render.
-
-Cluster E sub-PR 4. The Drive branch returns an empty list today;
-Cluster C owns the connector-status endpoint that will tell us which
-pockets have a connected Drive account. Once that lands we can fan a
-Drive listing in here without changing the response shape the FE already
-consumes. See ``docs/plans/cluster-E-reality.md`` for the handshake.
-
-2026-05-03 (Stage 3.E "Files as Knowledge"): ``list_unified`` accepts an
-optional ``pocket_id``. When set, the chat-uploads slice is filtered to
-that pocket only. When ``None`` (the default), the listing returns
-workspace-only rows — the workspace Files panel never sees pocket files,
-which is the privacy contract for pocket-scoped uploads.
+Drive-synced files (stubbed), KB articles, and agent-produced files into
+one list the FE Files panel can render.
 """
 
 from __future__ import annotations
@@ -27,7 +15,7 @@ from ee.cloud.uploads.mongo_store import LIST_WORKSPACE_ONLY, MongoFileStore
 logger = logging.getLogger(__name__)
 
 
-FileSource = Literal["chat", "local", "drive"]
+FileSource = Literal["chat", "local", "drive", "kb", "agent"]
 
 
 @dataclass
@@ -39,10 +27,10 @@ class UnifiedFile:
     filename: str
     mime: str | None
     size: int | None
-    url: str | None  # None for local fs (FE uses Tauri for those)
+    url: str | None  # None for local fs / kb / agent sources
     created: datetime | None
     chat_id: str | None = None
-
+    agent_id: str | None = None  # Owning agent for kb/agent-source rows
 
 def _dedupe(files: list[UnifiedFile]) -> list[UnifiedFile]:
     """Drop later duplicates keyed on ``(filename, size, mime)``.
@@ -60,6 +48,14 @@ def _dedupe(files: list[UnifiedFile]) -> list[UnifiedFile]:
         seen.add(key)
         out.append(f)
     return out
+
+
+def _parse_iso(s: str) -> datetime | None:
+    """Parse an ISO-8601 string to datetime; return None on failure."""
+    try:
+        return datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
 
 
 class UnifiedFilesService:
@@ -113,6 +109,68 @@ class UnifiedFilesService:
         )
         return []
 
+    async def list_kb_articles(
+        self,
+        workspace_id: str,
+        *,
+        limit: int,
+    ) -> list[UnifiedFile]:
+        """KB articles sourced from the kb-go binary via the workspace aggregator.
+        """
+        from ee.cloud.agents import service as agents_service
+        from ee.cloud.kb.workspace_aggregator import aggregate_workspace_articles
+
+        # Resolve agent ids in this workspace for scope fan-out.
+        agents = await agents_service.list_agents(workspace_id)
+        agent_ids = [a.id for a in agents]
+
+        def _kb_list(scope: str) -> list:
+            from ee.cloud.agents.knowledge import _kb
+
+            try:
+                result = _kb("list", "--scope", scope)
+            except Exception:
+                return []
+            return result if isinstance(result, list) else []
+
+        articles = await aggregate_workspace_articles(
+            workspace_id=workspace_id,
+            agent_ids=agent_ids,
+            kb_list=_kb_list,
+        )
+
+        return [
+            UnifiedFile(
+                id=a.id,
+                source="kb",
+                filename=a.title or a.source or a.id,
+                mime="text/markdown",
+                size=None,
+                url=None,
+                created=_parse_iso(a.updated_at) if a.updated_at else None,
+                agent_id=a.agent_id,
+            )
+            for a in articles
+        ][:limit]
+
+    async def list_agent_files(
+        self,
+        workspace_id: str,
+        *,
+        limit: int,
+    ) -> list[UnifiedFile]:
+        """Agent-produced files.
+
+        Agent tool calls (WriteFileTool, Claude SDK Write) write directly to
+        the local filesystem and bypass the upload pipeline. Until we add a
+        file-registration hook on tool completion, this returns empty.
+
+        The stub emits an info-level log so operators can confirm the branch
+        is reachable; the FE handles an empty list gracefully.
+        """
+        
+        return []
+
     async def list_unified(
         self,
         workspace_id: str,
@@ -151,6 +209,23 @@ class UnifiedFilesService:
                 warnings.append(
                     "drive.not_connected: Drive source is not wired yet; "
                     "see Cluster C connector-status endpoint."
+                )
+
+        if source in (None, "kb"):
+            kb_hits = await self.list_kb_articles(
+                workspace_id, limit=per_source
+            )
+            merged.extend(kb_hits)
+
+        if source in (None, "agent"):
+            agent_hits = await self.list_agent_files(
+                workspace_id, limit=per_source
+            )
+            merged.extend(agent_hits)
+            if not agent_hits:
+                warnings.append(
+                    "agent.not_wired: Agent-produced files are not yet "
+                    "tracked (Smart Files Milestone 2+)."
                 )
 
         # Local filesystem is addressed by the FE's Tauri bridge (no

--- a/ee/cloud/models/__init__.py
+++ b/ee/cloud/models/__init__.py
@@ -6,6 +6,7 @@ from ee.cloud.models.agent import Agent, AgentConfig
 from ee.cloud.models.comment import Comment, CommentAuthor, CommentTarget
 from ee.cloud.models.connector import WorkspaceConnector
 from ee.cloud.models.file import FileObj
+from ee.cloud.models.file_version import FileVersionDoc
 from ee.cloud.models.group import Group, GroupAgent
 from ee.cloud.models.invite import Invite
 from ee.cloud.models.message import Attachment, Mention, Message, Reaction
@@ -41,6 +42,7 @@ __all__ = [
     "CommentTarget",
     "FileFolder",
     "FileObj",
+    "FileVersionDoc",
     "FileUpload",
     "Group",
     "GroupAgent",
@@ -77,6 +79,7 @@ def get_all_documents():
         FileObj,
         FileUpload,
         FileFolder,
+        FileVersionDoc,
         Workspace,
         WorkspaceConnector,
         Invite,

--- a/ee/cloud/models/file_version.py
+++ b/ee/cloud/models/file_version.py
@@ -1,0 +1,33 @@
+"""FileVersion Beanie document — full-copy text blobs archived per edit.
+
+Stored in the ``file_versions`` collection. The live (current) file
+content lives in the StorageAdapter; this collection is the history trail.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from beanie import Document, Indexed
+from pydantic import Field
+
+
+class FileVersionDoc(Document):
+    file_id: Indexed(str)  # type: ignore[valid-type]
+    workspace_id: Indexed(str)  # type: ignore[valid-type]
+    version_number: int
+    content: str
+    content_hash: str
+    size_bytes: int
+    editor_kind: str  # "human" | "agent"
+    editor_id: str  # user_id or agent_id
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "file_versions"
+        indexes = [
+            # List versions for a file, oldest-first so the picker shows v1→vN.
+            [("file_id", 1), ("version_number", 1)],
+            # Workspace-scoped queries if needed.
+            [("workspace_id", 1), ("file_id", 1)],
+        ]

--- a/ee/cloud/uploads/models.py
+++ b/ee/cloud/uploads/models.py
@@ -43,6 +43,7 @@ class FileUpload(TimestampedDocument):
     # Storage layout is unchanged — partitioning is metadata-only.
     pocket_id: str | None = None
     deleted_at: datetime | None = None
+    content_version: int = 0
 
     class Settings:
         name = "file_uploads"

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -507,6 +507,19 @@ class ClaudeSDKBackend:
         except Exception as exc:  # noqa: BLE001
             logger.debug("pocket_context MCP server not registered: %s", exc)
 
+        # In-process MCP server: exposes `edit_document` so the agent can
+        # manipulate Editor.js blocks during file editing. Always registered
+        # — returns an error when no editing session is active.
+        try:
+            from pocketpaw.tools.builtin.edit_document import build_edit_document_mcp_server
+
+            edit_server = build_edit_document_mcp_server()
+            if edit_server is not None:
+                name, cfg_entry = edit_server
+                servers[name] = cfg_entry
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("edit_document MCP server not registered: %s", exc)
+
         return servers
 
     async def _get_or_create_client(self, options: Any, *, session_key: str | None = None) -> Any:
@@ -804,6 +817,10 @@ class ClaudeSDKBackend:
             from pocketpaw.agents.sdk_mcp_pocket import POCKET_TOOL_IDS
 
             allowed_tools.extend(POCKET_TOOL_IDS)
+
+            from pocketpaw.tools.builtin.edit_document import EDIT_DOCUMENT_TOOL_ID
+
+            allowed_tools.append(EDIT_DOCUMENT_TOOL_ID)
 
             # Build hooks for security
             hooks = {

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -520,6 +520,32 @@ class ClaudeSDKBackend:
         except Exception as exc:  # noqa: BLE001
             logger.debug("edit_document MCP server not registered: %s", exc)
 
+        # In-process MCP server: exposes `edit_spreadsheet` so the agent can
+        # manipulate Univer workbook snapshots during spreadsheet editing.
+        # Always registered — returns an error when no editing session is active.
+        try:
+            from pocketpaw.tools.builtin.edit_spreadsheet import build_edit_spreadsheet_mcp_server
+
+            spreadsheet_server = build_edit_spreadsheet_mcp_server()
+            if spreadsheet_server is not None:
+                name, cfg_entry = spreadsheet_server
+                servers[name] = cfg_entry
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("edit_spreadsheet MCP server not registered: %s", exc)
+
+        # In-process MCP server: exposes `edit_slides` so the agent can
+        # manipulate reveal.js slide decks during slides editing.
+        # Always registered -- returns an error when no editing session is active.
+        try:
+            from pocketpaw.tools.builtin.edit_slides import build_edit_slides_mcp_server
+
+            slides_server = build_edit_slides_mcp_server()
+            if slides_server is not None:
+                name, cfg_entry = slides_server
+                servers[name] = cfg_entry
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("edit_slides MCP server not registered: %s", exc)
+
         return servers
 
     async def _get_or_create_client(self, options: Any, *, session_key: str | None = None) -> Any:

--- a/src/pocketpaw/dashboard_auth.py
+++ b/src/pocketpaw/dashboard_auth.py
@@ -378,6 +378,11 @@ async def _auth_dispatch(request: Request) -> Response | None:
         "/api/v1/sessions",
         "/api/v1/agents",
         "/api/v1/users",
+        "/api/v1/files",
+        "/api/v1/knowledge",
+        "/api/v1/uploads",
+        "/api/v1/notifications",
+        "/api/v1/connectors",
     )
 
     for exempt in exempt_paths:

--- a/src/pocketpaw/tools/builtin/edit_document.py
+++ b/src/pocketpaw/tools/builtin/edit_document.py
@@ -107,12 +107,6 @@ def build_editor_prompt_context(
     if not resolved:
         return None
 
-    default_tools = (
-        "paragraph, header, list, code, quote, image, checklist, table, "
-        "delimiter, warning, embed, linkTool, raw"
-    )
-    tool_list = ", ".join(available_tools) if available_tools else default_tools
-
     block_lines = [_format_block_for_prompt(b, i) for i, b in enumerate(resolved)]
     block_summary = "\n".join(block_lines) if block_lines else "(empty document)"
 
@@ -123,13 +117,44 @@ def build_editor_prompt_context(
             f"Focus your edit there unless the prompt says otherwise.\n"
         )
 
+    block_type_ref = (
+        "## Block type reference\n\n"
+        "You MUST use these EXACT type names. Any other name will cause a rendering error.\n\n"
+        "| Type       | Data shape |\n"
+        "|------------|------------|\n"
+        "| `paragraph` | `{\"text\": \"...\"}` |\n"
+        "| `header`    | `{\"text\": \"...\", \"level\": 1\\|2\\|3}` |\n"
+        '| `list`      | `{"style": "unordered"\\|"ordered", "meta": {}, "items": [{"content": "item1", "meta": {}, "items": []}]}` |\n'
+        "| `code`      | `{\"code\": \"...\"}` |\n"
+        '| `quote`     | `{"text": "...", "caption": "..."}` |\n'
+        '| `image`     | `{"file": {"url": "..."}, "caption": "..."}` |\n'
+        '| `checklist` | `{"items": [{"text": "...", "checked": true\\|false}]}` |\n'
+        '| `table`     | `{"content": [["cell", "cell"], ["cell", "cell"]]}` |\n'
+        "| `delimiter` | `{}` (no data needed) |\n"
+        '| `warning`   | `{"title": "...", "message": "..."}` |\n'
+        '| `embed`     | `{"embed": "url", ...}` |\n'
+        '| `linkTool`  | `{"link": "url", ...}` |\n'
+        '| `raw`       | `{"html": "..."}` |\n'
+        "\n"
+        "Common mistakes — these are NOT valid types and WILL break rendering:\n"
+        "  heading       → use `header` instead\n"
+        "  bullet_list_item → use `list` with style=unordered and items array\n"
+        "  numbered_list_item → use `list` with style=ordered and items array\n"
+        "  divider       → use `delimiter` instead\n"
+        "  blockquote     → use `quote` instead\n"
+        "  callout        → use `warning` instead\n"
+        "  check_list_item → use `checklist` with items array\n"
+        "  toggle         → not supported, use `paragraph` instead\n"
+        "\n"
+        "Lists are a SINGLE block with an `items` array — NOT one block per item.\n"
+        "Checklists are a SINGLE block with an `items` array of {text, checked} objects.\n"
+        "\n"
+    )
+
     return (
         "You are editing a document in PocketPaw's file editor.\n"
         "The document uses Editor.js block format. Each block has an id, type, and data.\n\n"
-        f"Available block types: {tool_list}\n\n"
-        "Look at the existing blocks below to understand the data shape for each type. "
-        "For example, a 'header' block has data={text, level}, a 'list' block has "
-        "data={style: 'ordered'|'unordered', items: [...]}, etc.\n\n"
+        f"{block_type_ref}\n"
         "## Current document\n\n"
         f"{block_summary}\n"
         f"{selection_hint}\n"
@@ -144,6 +169,130 @@ def build_editor_prompt_context(
         '- replaceAll: {"op":"replaceAll", "blocks":[...]}\n\n'
         "After making your edits, briefly tell the user what you changed."
     )
+
+
+def _normalize_block(block_type: str, data: dict) -> tuple[str, dict]:
+    """Normalize block type names and data shapes for Editor.js compatibility.
+
+    Fixes common LLM mistakes: Notion-style type names, wrong data shapes,
+    and list/checklist items sent as individual blocks instead of arrays.
+    """
+    bt = block_type.strip().lower()
+
+    # ── Type name normalization (only the cases that actually break) ──
+    if bt in ("heading", "headline", "h1", "h2", "h3"):
+        bt = "header"
+    elif bt in ("bullet_list_item", "bulleted_list", "unordered_list"):
+        bt = "list"
+        data = _coerce_list_data(data, style="unordered")
+    elif bt in ("numbered_list_item", "numbered_list", "ordered_list"):
+        bt = "list"
+        data = _coerce_list_data(data, style="ordered")
+    elif bt in ("divider", "horizontal_rule", "hr", "separator"):
+        bt = "delimiter"
+        data = {}
+    elif bt in ("blockquote", "block_quote"):
+        bt = "quote"
+    elif bt in ("callout", "note", "info", "alert"):
+        bt = "warning"
+        data = _coerce_warning_data(data)
+    elif bt in ("check_list_item", "check_list", "todo", "todo_list", "task_list"):
+        bt = "checklist"
+        data = _coerce_checklist_data(data)
+    elif bt in ("toggle", "collapsible", "accordion"):
+        bt = "paragraph"
+
+    # ── Data shape fixes for native names that still have wrong shapes ──
+    if bt == "list":
+        data = _coerce_list_data(data, style=None)
+    elif bt == "checklist":
+        data = _coerce_checklist_data(data)
+    elif bt == "delimiter":
+        data = {}
+    elif bt == "header" and "level" in data:
+        lvl = data["level"]
+        if not isinstance(lvl, int) or lvl < 1 or lvl > 3:
+            data = {**data, "level": 2}
+
+    return bt, data
+
+
+def _coerce_list_data(data: dict, *, style: str | None = None) -> dict:
+    """Normalize data for a ``list`` block into Editor.js list v2 format.
+
+    v2 format: {style, meta: {}, items: [{content, meta: {}, items: []}, ...]}
+    Also accepts v1 flat strings and Notion-style {text} items.
+    """
+    items = data.get("items", [])
+    # AI sent {text: "..."} instead of {items: [...]}
+    if not items and data.get("text"):
+        items = [str(data["text"])]
+    if isinstance(items, str):
+        items = [items]
+    if not isinstance(items, list):
+        items = []
+
+    normalized_items = []
+    for item in items:
+        if isinstance(item, str):
+            # v1 flat string → v2
+            normalized_items.append({"content": item, "meta": {}, "items": []})
+        elif isinstance(item, dict):
+            # Already v2 format (has "content") or Notion format (has "text")
+            content = str(item.get("content") or item.get("text") or "")
+            # Preserve nested items if present, otherwise empty list
+            nested = item.get("items", [])
+            if isinstance(nested, list):
+                nested = [
+                    {"content": str(s) if isinstance(s, str) else s.get("content", s.get("text", "")), "meta": s.get("meta", {}) if isinstance(s, dict) else {}, "items": s.get("items", []) if isinstance(s, dict) else []}
+                    if isinstance(s, (str, dict)) else {"content": str(s), "meta": {}, "items": []}
+                    for s in nested
+                ]
+            else:
+                nested = []
+            normalized_items.append({
+                "content": content,
+                "meta": item.get("meta", {}),
+                "items": nested,
+            })
+
+    resolved_style = style or data.get("style", "unordered")
+    if resolved_style not in ("unordered", "ordered"):
+        resolved_style = "unordered"
+
+    return {"style": resolved_style, "meta": {}, "items": normalized_items}
+
+
+def _coerce_checklist_data(data: dict) -> dict:
+    """Normalize data for a ``checklist`` block into {items: [{text, checked}, ...]}."""
+    items = data.get("items", [])
+    # AI sent {text: "...", checked: true} as a single item
+    if not items and data.get("text"):
+        items = [{"text": str(data["text"]), "checked": bool(data.get("checked", False))}]
+    if isinstance(items, dict):
+        items = [items]
+    if not isinstance(items, list):
+        items = []
+    normalized = []
+    for item in items:
+        if isinstance(item, str):
+            normalized.append({"text": item, "checked": False})
+        elif isinstance(item, dict):
+            normalized.append({
+                "text": str(item.get("text", "")),
+                "checked": bool(item.get("checked", False)),
+            })
+    return {"items": normalized}
+
+
+def _coerce_warning_data(data: dict) -> dict:
+    """Normalize data for a ``warning`` block into {title, message}."""
+    result: dict[str, str] = {}
+    result["title"] = str(data.get("title") or data.get("text") or "")
+    result["message"] = str(data.get("message") or data.get("text") or "")
+    if not result["title"] and not result["message"]:
+        result["title"] = "Note"
+    return result
 
 
 def apply_operations(
@@ -171,15 +320,19 @@ def apply_operations(
                 summaries.append(f"Block {block_id} not found — skipped update")
 
         elif op_type == "insert":
+            raw_type = op.get("type", "paragraph")
+            raw_data = op.get("data", {})
+            norm_type, norm_data = _normalize_block(raw_type, raw_data)
             new_block: dict[str, Any] = {
                 "id": uuid.uuid4().hex[:6],
-                "type": op["type"],
-                "data": op.get("data", {}),
+                "type": norm_type,
+                "data": norm_data,
             }
             idx = op.get("index", len(blocks))
             idx = max(0, min(idx, len(blocks)))
             blocks.insert(idx, new_block)
-            summaries.append(f"Inserted {op['type']} at index {idx}")
+            normalized = " (normalized)" if raw_type != norm_type else ""
+            summaries.append(f"Inserted {norm_type} at index {idx}{normalized}")
 
         elif op_type == "delete":
             block_id = op["id"]
@@ -216,6 +369,11 @@ def apply_operations(
             for b in new_blocks:
                 if "id" not in b:
                     b["id"] = uuid.uuid4().hex[:6]
+                raw_type = b.get("type", "paragraph")
+                raw_data = b.get("data", {})
+                norm_type, norm_data = _normalize_block(raw_type, raw_data)
+                b["type"] = norm_type
+                b["data"] = norm_data
             blocks.extend(new_blocks)
             summaries.append(f"Replaced all {old_count} blocks with {len(new_blocks)} blocks")
 
@@ -405,6 +563,26 @@ def build_edit_document_mcp_server() -> tuple[str, Any] | None:
             '  {"op": "move", "id": "<block_id>", "toIndex": 0},\n'
             '  {"op": "replaceAll", "blocks": [{"type":"paragraph","data":{"text":"..."}}]}\n'
             "]}\n\n"
+            "VALID BLOCK TYPES — use these exact names, anything else will break:\n"
+            "paragraph, header, list, code, quote, image, checklist, table,\n"
+            "delimiter, warning, embed, linkTool, raw\n\n"
+            "Data shape for each type:\n"
+            '- paragraph: {"text": "..."}\n'
+            '- header: {"text": "...", "level": 1|2|3}\n'
+            '- list: {"style": "unordered"|"ordered", "meta": {}, "items": [{"content": "item1", "meta": {}, "items": []}]}\n'
+            '- code: {"code": "..."}\n'
+            '- quote: {"text": "...", "caption": "..."}\n'
+            '- checklist: {"items": [{"text": "...", "checked": true|false}]}\n'
+            '- table: {"content": [["cell", "cell"], ["cell", "cell"]]}\n'
+            '- delimiter: {} (empty object)\n'
+            '- warning: {"title": "...", "message": "..."}\n'
+            '- embed: {"embed": "url", ...}\n'
+            '- linkTool: {"link": "url", ...}\n'
+            '- raw: {"html": "..."}\n\n'
+            "NEVER use these (they are NOT valid): heading, bullet_list_item,\n"
+            "numbered_list_item, divider, blockquote, callout, check_list_item, toggle.\n\n"
+            "Lists are ONE block with an items array — NOT one block per item.\n"
+            "Checklists are ONE block with an items array — NOT one block per item.\n\n"
             "IMPORTANT: The field is `op` (not operation or action). "
             "Everything goes inside the `operations` array — not at top level."
         ),

--- a/src/pocketpaw/tools/builtin/edit_document.py
+++ b/src/pocketpaw/tools/builtin/edit_document.py
@@ -1,0 +1,423 @@
+"""edit_document tool — AI-powered block editing for Editor.js documents.
+
+The agent calls ``edit_document`` with an array of operations. Blocks are
+stored in a per-request ``ContextVar`` (for the REST ai-edit endpoint) or
+a module-level dict keyed by file_id (for chat-initiated editing).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from contextvars import ContextVar
+from typing import Any
+
+from pocketpaw.tools.protocol import BaseTool
+
+logger = logging.getLogger(__name__)
+
+_edit_session_blocks: ContextVar[list[dict] | None] = ContextVar(
+    "edit_session_blocks", default=None
+)
+
+# Module-level store keyed by file_id — used when blocks are synced from the
+# frontend editor (chat-initiated editing). The MCP handler falls back to this
+# when the ContextVar is empty.
+_editor_blocks_store: dict[str, list[dict]] = {}
+
+SERVER_NAME = "pocketpaw_edit_document"
+EDIT_DOCUMENT_TOOL_ID = f"mcp__{SERVER_NAME}__edit_document"
+
+
+def set_edit_session(blocks: list[dict]) -> None:
+    """Store the current editing session's blocks for MCP handler access."""
+    _edit_session_blocks.set(blocks)
+
+
+def clear_edit_session() -> None:
+    """Clear the editing session after the request completes."""
+    _edit_session_blocks.set(None)
+
+
+def get_edit_session() -> list[dict] | None:
+    """Get the current editing session's blocks."""
+    return _edit_session_blocks.get()
+
+
+def set_editor_blocks(file_id: str, blocks: list[dict]) -> None:
+    """Store blocks from the frontend editor for MCP tool access during chat."""
+    _editor_blocks_store[file_id] = blocks
+
+
+def get_editor_blocks(file_id: str) -> list[dict] | None:
+    """Get blocks synced from the frontend editor by file_id."""
+    return _editor_blocks_store.get(file_id)
+
+
+def sync_editor_blocks_from_contextvar() -> None:
+    """Copy ContextVar blocks to the module store so GET /files/{id}/editing-context
+    returns blocks mutated by the edit_document MCP tool during a chat session."""
+    blocks = _edit_session_blocks.get()
+    if not blocks or not _editor_blocks_store:
+        return
+    for fid in _editor_blocks_store:
+        _editor_blocks_store[fid] = blocks
+
+
+def get_active_blocks() -> list[dict] | None:
+    """Get whichever blocks are available — ContextVar first, then store.
+    Returns None only when no session is active at all. An empty list is
+    a valid state (empty document)."""
+    blocks = _edit_session_blocks.get()
+    if blocks is not None:
+        return blocks
+    if _editor_blocks_store:
+        return next(iter(_editor_blocks_store.values()))
+    return None
+
+
+def _format_block_for_prompt(b: dict, idx: int) -> str:
+    """Format a single Editor.js block as a readable line for the system prompt."""
+    import json as _json
+
+    bid = b.get("id", "?")
+    btype = b.get("type", "?")
+    data = b.get("data", {})
+    snippet = _json.dumps(data, separators=(",", ":"))
+    if len(snippet) > 120:
+        snippet = snippet[:117] + "..."
+    return f"[{idx}] id={bid} type={btype} data={snippet}"
+
+
+def build_editor_prompt_context(
+    blocks: list[dict] | None = None,
+    *,
+    available_tools: list[str] | None = None,
+    selected_block_id: str | None = None,
+) -> str | None:
+    """Build a system-prompt block describing the current editor document.
+
+    Accepts blocks directly (from the chat request body or ai-edit endpoint).
+    Falls back to ``get_active_blocks()`` if no blocks passed.
+
+    Returns None if no blocks are available anywhere.
+    """
+    resolved = blocks or get_active_blocks()
+    if not resolved:
+        return None
+
+    default_tools = (
+        "paragraph, header, list, code, quote, image, checklist, table, "
+        "delimiter, warning, embed, linkTool, raw"
+    )
+    tool_list = ", ".join(available_tools) if available_tools else default_tools
+
+    block_lines = [_format_block_for_prompt(b, i) for i, b in enumerate(resolved)]
+    block_summary = "\n".join(block_lines) if block_lines else "(empty document)"
+
+    selection_hint = ""
+    if selected_block_id:
+        selection_hint = (
+            f"\nThe user's cursor is on block with id={selected_block_id}. "
+            f"Focus your edit there unless the prompt says otherwise.\n"
+        )
+
+    return (
+        "You are editing a document in PocketPaw's file editor.\n"
+        "The document uses Editor.js block format. Each block has an id, type, and data.\n\n"
+        f"Available block types: {tool_list}\n\n"
+        "Look at the existing blocks below to understand the data shape for each type. "
+        "For example, a 'header' block has data={text, level}, a 'list' block has "
+        "data={style: 'ordered'|'unordered', items: [...]}, etc.\n\n"
+        "## Current document\n\n"
+        f"{block_summary}\n"
+        f"{selection_hint}\n"
+        "## How to edit\n\n"
+        "Call the `edit_document` tool with an array of operations. "
+        "You can call it multiple times — each call returns the updated state.\n\n"
+        "Operations:\n"
+        '- update: {"op":"update", "id":"<block_id>", "data":{...}}\n'
+        '- insert: {"op":"insert", "type":"paragraph", "data":{...}, "index":0}\n'
+        '- delete: {"op":"delete", "id":"<block_id>"}\n'
+        '- move: {"op":"move", "id":"<block_id>", "toIndex":0}\n'
+        '- replaceAll: {"op":"replaceAll", "blocks":[...]}\n\n'
+        "After making your edits, briefly tell the user what you changed."
+    )
+
+
+def apply_operations(
+    blocks: list[dict],
+    operations: list[dict],
+) -> tuple[list[dict], str]:
+    """Apply edit operations to a blocks list. Mutates in place.
+
+    Returns (blocks, summary) — blocks is the same list reference, mutated.
+    """
+    summaries: list[str] = []
+
+    for op in operations:
+        op_type = op.get("op")
+
+        if op_type == "update":
+            block_id = op["id"]
+            new_data = op.get("data", {})
+            for b in blocks:
+                if b.get("id") == block_id:
+                    b["data"] = {**b.get("data", {}), **new_data}
+                    summaries.append(f"Updated block {block_id} ({b.get('type', '?')})")
+                    break
+            else:
+                summaries.append(f"Block {block_id} not found — skipped update")
+
+        elif op_type == "insert":
+            new_block: dict[str, Any] = {
+                "id": uuid.uuid4().hex[:6],
+                "type": op["type"],
+                "data": op.get("data", {}),
+            }
+            idx = op.get("index", len(blocks))
+            idx = max(0, min(idx, len(blocks)))
+            blocks.insert(idx, new_block)
+            summaries.append(f"Inserted {op['type']} at index {idx}")
+
+        elif op_type == "delete":
+            block_id = op["id"]
+            for i, b in enumerate(blocks):
+                if b.get("id") == block_id:
+                    blocks.pop(i)
+                    summaries.append(
+                        f"Deleted block {block_id} ({b.get('type', '?')}) at index {i}"
+                    )
+                    break
+            else:
+                summaries.append(f"Block {block_id} not found — skipped delete")
+
+        elif op_type == "move":
+            block_id = op["id"]
+            to_idx = op["toIndex"]
+            for i, b in enumerate(blocks):
+                if b.get("id") == block_id:
+                    moved = blocks.pop(i)
+                    to_idx = max(0, min(to_idx, len(blocks)))
+                    blocks.insert(to_idx, moved)
+                    summaries.append(
+                        f"Moved block {block_id} ({b.get('type', '?')}) "
+                        f"from {i} to {to_idx}"
+                    )
+                    break
+            else:
+                summaries.append(f"Block {block_id} not found — skipped move")
+
+        elif op_type == "replaceAll":
+            new_blocks = op.get("blocks", [])
+            old_count = len(blocks)
+            blocks.clear()
+            for b in new_blocks:
+                if "id" not in b:
+                    b["id"] = uuid.uuid4().hex[:6]
+            blocks.extend(new_blocks)
+            summaries.append(f"Replaced all {old_count} blocks with {len(new_blocks)} blocks")
+
+        else:
+            summaries.append(f"Unknown operation '{op_type}' — skipped")
+
+    summary = "; ".join(summaries) if summaries else "No operations applied"
+    return blocks, summary
+
+
+class EditDocumentTool(BaseTool):
+    """Tool the agent can call to edit Editor.js document blocks.
+
+    Holds a reference to the current request's blocks. Operations are
+    applied in order, mutating the blocks list in place.
+    """
+
+    def __init__(self, blocks: list[dict]) -> None:
+        self._blocks = blocks
+
+    @property
+    def name(self) -> str:
+        return "edit_document"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Edit the document by performing operations on blocks. "
+            "You can update, insert, delete, move, or replace all blocks. "
+            "Each operation targets a block by its id (for update/delete/move) "
+            "or specifies a position index (for insert). "
+            "Call this tool multiple times to build up your edit — each call "
+            "returns the full updated block list so you can verify your changes."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "operations": {
+                    "type": "array",
+                    "description": "Ordered list of edit operations to apply.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "op": {
+                                "type": "string",
+                                "enum": ["update", "insert", "delete", "move", "replaceAll"],
+                                "description": "The operation to perform.",
+                            },
+                            "id": {
+                                "type": "string",
+                                "description": "Block ID to update, delete, or move.",
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": (
+                            "Block type name for insert "
+                            "(paragraph, header, list, etc.)."
+                        ),
+                            },
+                            "data": {
+                                "type": "object",
+                                "description": "Block data for update or insert.",
+                            },
+                            "index": {
+                                "type": "integer",
+                                "description": "Insert position (defaults to end).",
+                            },
+                            "toIndex": {
+                                "type": "integer",
+                                "description": "Destination index for move.",
+                            },
+                            "blocks": {
+                                "type": "array",
+                                "description": "Complete new blocks array for replaceAll.",
+                            },
+                        },
+                        "required": ["op"],
+                    },
+                }
+            },
+            "required": ["operations"],
+        }
+
+    async def execute(self, operations: list[dict]) -> str:
+        """Apply operations and return the updated blocks as JSON."""
+        if not self._blocks:
+            return self._error("No document blocks loaded. Start an editing session first.")
+
+        try:
+            updated, summary = apply_operations(self._blocks, operations)
+            result = json.dumps(updated, separators=(",", ":"))
+            return f"{summary}\n\nUpdated blocks:\n{result}"
+        except Exception as exc:
+            return self._error(f"Edit failed: {exc}")
+
+
+def _edit_error(message: str) -> dict:
+    """Return a structured error with a hint to guide the agent to the correct format."""
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+async def _edit_document_handler(args: dict) -> dict:
+    """MCP handler for the edit_document tool. Reads blocks from ContextVar
+    first, falls back to the module-level editor store (chat-initiated editing)."""
+    blocks = get_active_blocks()
+    if blocks is None:
+        return _edit_error(
+            "No document is currently open for editing. "
+            "Open a file in the editor first."
+        )
+
+    operations = args.get("operations")
+    if not operations:
+        # Detect common mistakes and give targeted help.
+        if args.get("operation"):  # wrong field name
+            return _edit_error(
+                "Use `operations` (plural) as the key, not `operation`. "
+                'Example: {"operations": [{"op": "update", ...}]}'
+            )
+        if any(k in args for k in ("update", "insert", "delete", "move", "replaceAll")):
+            return _edit_error(
+                "Wrap operations inside an `operations` array. "
+                'Example: {"operations": [{"op": "update", "id": "x", "data": {...}}]}'
+            )
+        if args.get("blocks"):  # replaceAll blocks at top level
+            return _edit_error(
+                'Wrap in operations array: {"operations": [{"op": "replaceAll", "blocks": [...]}]}'
+            )
+        return _edit_error(
+            "Missing `operations` array. "
+            'Format: {"operations": [{"op": "update|insert|delete|move|replaceAll", ...}]}'
+        )
+
+    if not isinstance(operations, list):
+        return _edit_error("`operations` must be an array (list), not a single object.")
+
+    try:
+        updated, summary = apply_operations(blocks, operations)
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {"summary": summary, "blockCount": len(updated), "blocks": updated},
+                        separators=(",", ":"),
+                    ),
+                }
+            ]
+        }
+    except Exception as exc:
+        logger.exception("edit_document handler failed")
+        return _edit_error(str(exc))
+
+
+def build_edit_document_mcp_server() -> tuple[str, Any] | None:
+    """Build the in-process MCP server for the Claude Agent SDK.
+
+    Returns (server_name, server_config) or None if the SDK is unavailable.
+    Always registered — the handler returns an error when no editing session
+    is active, so the agent won't use it outside the file editing context.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; edit_document MCP disabled")
+        return None
+
+    @tool(
+        "edit_document",
+        (
+            "Edit the current document by performing operations on blocks. "
+            "Use this when the user asks you to edit, rewrite, fix, expand, "
+            "or restructure a document they have open in the editor.\n\n"
+            "You MUST call it with an `operations` array. Each item must have "
+            'an `op` field set to one of: update, insert, delete, move, replaceAll.\n\n'
+            "EXACT format (copy this pattern):\n"
+            '{"operations": [\n'
+            '  {"op": "update", "id": "<block_id>", "data": {"text": "new text"}},\n'
+            '  {"op": "insert", "type": "paragraph", "data": {"text": "new"}, "index": 1},\n'
+            '  {"op": "delete", "id": "<block_id>"},\n'
+            '  {"op": "move", "id": "<block_id>", "toIndex": 0},\n'
+            '  {"op": "replaceAll", "blocks": [{"type":"paragraph","data":{"text":"..."}}]}\n'
+            "]}\n\n"
+            "IMPORTANT: The field is `op` (not operation or action). "
+            "Everything goes inside the `operations` array — not at top level."
+        ),
+        {
+            "operations": list,
+        },
+    )
+    async def edit_document(args):  
+        return await _edit_document_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[edit_document],
+    )
+    return SERVER_NAME, server

--- a/src/pocketpaw/tools/builtin/edit_document.py
+++ b/src/pocketpaw/tools/builtin/edit_document.py
@@ -21,6 +21,12 @@ _edit_session_blocks: ContextVar[list[dict] | None] = ContextVar(
     "edit_session_blocks", default=None
 )
 
+# Per-request selected block ID for per-block editing mode.
+# When set, the tool enforces that only the selected block can be modified.
+_selected_block_id: ContextVar[str | None] = ContextVar(
+    "selected_block_id", default=None
+)
+
 # Module-level store keyed by file_id — used when blocks are synced from the
 # frontend editor (chat-initiated editing). The MCP handler falls back to this
 # when the ContextVar is empty.
@@ -38,6 +44,21 @@ def set_edit_session(blocks: list[dict]) -> None:
 def clear_edit_session() -> None:
     """Clear the editing session after the request completes."""
     _edit_session_blocks.set(None)
+
+
+def set_selected_block_id(block_id: str | None) -> None:
+    """Store the selected block ID for per-block editing enforcement."""
+    _selected_block_id.set(block_id)
+
+
+def get_selected_block_id() -> str | None:
+    """Get the selected block ID for the current editing session."""
+    return _selected_block_id.get()
+
+
+def clear_selected_block_id() -> None:
+    """Clear the selected block ID after the request completes."""
+    _selected_block_id.set(None)
 
 
 def get_edit_session() -> list[dict] | None:
@@ -110,11 +131,27 @@ def build_editor_prompt_context(
     block_lines = [_format_block_for_prompt(b, i) for i, b in enumerate(resolved)]
     block_summary = "\n".join(block_lines) if block_lines else "(empty document)"
 
-    selection_hint = ""
+    editing_mode_block = ""
     if selected_block_id:
-        selection_hint = (
-            f"\nThe user's cursor is on block with id={selected_block_id}. "
-            f"Focus your edit there unless the prompt says otherwise.\n"
+        editing_mode_block = (
+            "\n"
+            "============================================================\n"
+            "CRITICAL: PER-BLOCK EDITING MODE\n"
+            "============================================================\n"
+            "You are in per-block editing mode. You MUST follow these rules:\n"
+            "\n"
+            f"1. You are ONLY allowed to edit block id={selected_block_id}.\n"
+            "2. Do NOT modify, delete, move, or insert any other block.\n"
+            "3. Do NOT use the 'replaceAll' operation — it would overwrite\n"
+            "   the entire document and destroy content in other blocks.\n"
+            "4. Use ONLY the 'update' operation with id={selected_block_id}.\n"
+            "5. If the user's prompt asks you to modify other blocks or the\n"
+            "   whole document, politely explain that you can only edit the\n"
+            "   selected block. Suggest they use full-document editing instead.\n"
+            "\n"
+            f"Target block: id={selected_block_id}\n"
+            "Permitted operation: update (with id={selected_block_id}) only.\n"
+            "============================================================\n"
         )
 
     block_type_ref = (
@@ -151,13 +188,26 @@ def build_editor_prompt_context(
         "\n"
     )
 
+    replaceall_note = ""
+    final_instruction = "After making your edits, briefly tell the user what you changed."
+    if selected_block_id:
+        replaceall_note = (
+            "\n---\n"
+            "NOTE: 'replaceAll' is BLOCKED in per-block editing mode. "
+            "It will be rejected if you attempt it.\n"
+        )
+        final_instruction = (
+            "After making your edit to the target block, briefly tell "
+            "the user what you changed."
+        )
+
     return (
         "You are editing a document in PocketPaw's file editor.\n"
         "The document uses Editor.js block format. Each block has an id, type, and data.\n\n"
         f"{block_type_ref}\n"
         "## Current document\n\n"
         f"{block_summary}\n"
-        f"{selection_hint}\n"
+        f"{editing_mode_block}\n"
         "## How to edit\n\n"
         "Call the `edit_document` tool with an array of operations. "
         "You can call it multiple times — each call returns the updated state.\n\n"
@@ -166,8 +216,9 @@ def build_editor_prompt_context(
         '- insert: {"op":"insert", "type":"paragraph", "data":{...}, "index":0}\n'
         '- delete: {"op":"delete", "id":"<block_id>"}\n'
         '- move: {"op":"move", "id":"<block_id>", "toIndex":0}\n'
-        '- replaceAll: {"op":"replaceAll", "blocks":[...]}\n\n'
-        "After making your edits, briefly tell the user what you changed."
+        '- replaceAll: {"op":"replaceAll", "blocks":[...]}\n'
+        f"{replaceall_note}\n"
+        f"{final_instruction}"
     )
 
 
@@ -298,15 +349,47 @@ def _coerce_warning_data(data: dict) -> dict:
 def apply_operations(
     blocks: list[dict],
     operations: list[dict],
+    selected_block_id: str | None = None,
 ) -> tuple[list[dict], str]:
     """Apply edit operations to a blocks list. Mutates in place.
+
+    When *selected_block_id* is set, only ``update`` on that specific block
+    is permitted.  ``replaceAll`` is rejected outright; other operations
+    targeting different block IDs are skipped with an error message.
 
     Returns (blocks, summary) — blocks is the same list reference, mutated.
     """
     summaries: list[str] = []
 
+    # ── Pre-flight: reject replaceAll in per-block mode ──
+    if selected_block_id:
+        for op in operations:
+            if op.get("op") == "replaceAll":
+                return blocks, (
+                    "ERROR: replaceAll is not allowed in per-block editing mode. "
+                    "You may only update the selected block "
+                    f"(id={selected_block_id}). "
+                    "Use 'update' with the target block's id instead."
+                )
+
     for op in operations:
         op_type = op.get("op")
+
+        # ── Per-block editing enforcement ──
+        if selected_block_id and op_type != "update":
+            summaries.append(
+                f"SKIPPED: '{op_type}' is not allowed in per-block editing mode. "
+                f"Only 'update' is permitted (target block id={selected_block_id})."
+            )
+            continue
+
+        if selected_block_id and op.get("id") != selected_block_id:
+            summaries.append(
+                f"SKIPPED: update on block {op.get('id')} is not allowed in "
+                f"per-block editing mode. Target block is "
+                f"id={selected_block_id}."
+            )
+            continue
 
         if op_type == "update":
             block_id = op["id"]
@@ -466,7 +549,10 @@ class EditDocumentTool(BaseTool):
             return self._error("No document blocks loaded. Start an editing session first.")
 
         try:
-            updated, summary = apply_operations(self._blocks, operations)
+            selected_id = get_selected_block_id()
+            updated, summary = apply_operations(
+                self._blocks, operations, selected_block_id=selected_id
+            )
             result = json.dumps(updated, separators=(",", ":"))
             return f"{summary}\n\nUpdated blocks:\n{result}"
         except Exception as exc:
@@ -517,7 +603,8 @@ async def _edit_document_handler(args: dict) -> dict:
         return _edit_error("`operations` must be an array (list), not a single object.")
 
     try:
-        updated, summary = apply_operations(blocks, operations)
+        selected_id = get_selected_block_id()
+        updated, summary = apply_operations(blocks, operations, selected_block_id=selected_id)
         return {
             "content": [
                 {

--- a/src/pocketpaw/tools/builtin/edit_slides.py
+++ b/src/pocketpaw/tools/builtin/edit_slides.py
@@ -1,0 +1,824 @@
+"""edit_slides tool -- AI-powered slide deck editing for reveal.js presentations.
+
+The agent calls ``edit_slides`` with an array of operations. Slide decks are
+stored in a per-request ``ContextVar`` (for the REST ai-edit endpoint) or
+a module-level dict keyed by file_id (for chat-initiated editing).
+
+Mirrors the ``edit_document`` and ``edit_spreadsheet`` pattern: ContextVar for
+request-scoped access, module dict for chat sync, MCP server for agent tooling.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from contextvars import ContextVar
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Per-request slides deck (REST ai-edit endpoint).
+_edit_session_slides: ContextVar[dict | None] = ContextVar(
+    "edit_session_slides", default=None
+)
+
+# Per-request selected slide ID for scoped editing.
+_selected_slide_id: ContextVar[str | None] = ContextVar(
+    "selected_slide_id", default=None
+)
+
+# Module-level store keyed by file_id -- used when decks are synced from
+# the frontend slides UI (chat-initiated editing).
+_slides_store: dict[str, dict] = {}
+
+SERVER_NAME = "pocketpaw_edit_slides"
+EDIT_SLIDES_TOOL_ID = f"mcp__{SERVER_NAME}__edit_slides"
+
+# Valid element types for slide content.
+_ELEMENT_TYPES = {"heading", "text", "list", "image", "code", "table", "quote"}
+
+# Valid reveal.js themes.
+_THEMES = {
+    "black", "white", "league", "beige", "sky", "night",
+    "serif", "simple", "solarized", "moon", "dracula",
+}
+
+# Valid slide layouts.
+_LAYOUTS = {"title-slide", "content", "two-column", "image-full", "blank"}
+
+# Valid transitions.
+_TRANSITIONS = {"none", "fade", "slide", "convex", "concave", "zoom"}
+
+
+# ---------------------------------------------------------------------------
+# Session management (ContextVar + module dict -- mirrors edit_document.py)
+# ---------------------------------------------------------------------------
+
+
+def set_edit_session(deck: dict) -> None:
+    _edit_session_slides.set(deck)
+
+
+def clear_edit_session() -> None:
+    _edit_session_slides.set(None)
+
+
+def get_edit_session() -> dict | None:
+    return _edit_session_slides.get()
+
+
+def set_selected_slide_id(slide_id: str | None) -> None:
+    _selected_slide_id.set(slide_id)
+
+
+def get_selected_slide_id() -> str | None:
+    return _selected_slide_id.get()
+
+
+def clear_selected_slide_id() -> None:
+    _selected_slide_id.set(None)
+
+
+def set_slides_data(file_id: str, deck: dict) -> None:
+    _slides_store[file_id] = deck
+
+
+def get_slides_data(file_id: str) -> dict | None:
+    return _slides_store.get(file_id)
+
+
+def get_active_deck() -> dict | None:
+    """Get whichever deck is available -- ContextVar first, then store."""
+    deck = _edit_session_slides.get()
+    if deck is not None:
+        return deck
+    if _slides_store:
+        return next(iter(_slides_store.values()))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Deck helpers
+# ---------------------------------------------------------------------------
+
+
+def _slide_ids(deck: dict) -> list[str]:
+    """Return ordered slide IDs from the deck."""
+    return [s["id"] for s in deck.get("slides", [])]
+
+
+def _get_slide(deck: dict, slide_id: str) -> dict | None:
+    """Get a slide dict by ID from the deck."""
+    for slide in deck.get("slides", []):
+        if slide.get("id") == slide_id:
+            return slide
+    return None
+
+
+def _get_element(slide: dict, element_id: str) -> dict | None:
+    """Get an element dict by ID from a slide."""
+    for el in slide.get("elements", []):
+        if el.get("id") == element_id:
+            return el
+    return None
+
+
+def _ensure_deck(deck: dict) -> None:
+    """Ensure the deck has minimal structure."""
+    deck.setdefault("version", 1)
+    deck.setdefault("theme", "black")
+    deck.setdefault("transition", "slide")
+    deck.setdefault("slideNumber", True)
+    deck.setdefault("slides", [])
+
+
+def _ensure_slide(deck: dict, slide_id: str | None = None) -> dict:
+    """Get a slide by ID or return the first slide. Returns None if no slides."""
+    if slide_id:
+        slide = _get_slide(deck, slide_id)
+        if slide:
+            return slide
+    slides = deck.get("slides", [])
+    return slides[0] if slides else None
+
+
+def _create_slide(
+    layout: str = "content",
+    elements: list[dict] | None = None,
+    *,
+    background: dict | None = None,
+    background_transition: str | None = None,
+    auto_animate: bool = False,
+) -> dict:
+    """Create a new slide dict with a UUID."""
+    slide: dict = {
+        "id": uuid.uuid4().hex[:12],
+        "layout": layout if layout in _LAYOUTS else "content",
+        "background": background,
+        "notes": "",
+        "elements": elements or [],
+    }
+    if background_transition:
+        slide["backgroundTransition"] = background_transition
+    if auto_animate:
+        slide["autoAnimate"] = True
+    return slide
+
+
+def _create_element(
+    el_type: str,
+    content: Any,
+    style: dict | None = None,
+    position: dict | None = None,
+    *,
+    fragment: str | None = None,
+) -> dict:
+    """Create a new element dict with a UUID."""
+    el: dict[str, Any] = {
+        "id": uuid.uuid4().hex[:8],
+        "type": el_type if el_type in _ELEMENT_TYPES else "text",
+        "content": content,
+        "style": style or {},
+        "position": position or {"x": 0, "y": 0, "width": 12, "height": 2},
+    }
+    el["style"].setdefault("fontSize", "1em")
+    el["style"].setdefault("alignment", "left")
+    el["style"].setdefault("color", None)
+    if fragment:
+        el["fragment"] = fragment
+    return el
+
+
+# ---------------------------------------------------------------------------
+# Prompt context builder
+# ---------------------------------------------------------------------------
+
+
+def _summarize_slide(slide: dict, index: int) -> str:
+    """Build a one-line summary of a slide for the system prompt."""
+    slide_id = slide.get("id", "?")
+    layout = slide.get("layout", "content")
+    elements = slide.get("elements", [])
+    notes = slide.get("notes", "")
+
+    parts = [f"Slide {index + 1} (id={slide_id[:8]}, layout={layout})"]
+
+    for el in elements:
+        el_type = el.get("type", "?")
+        content = el.get("content", "")
+        if el_type == "heading":
+            parts.append(f"  heading: \"{_fmt_val(content)}\"")
+        elif el_type == "text":
+            parts.append(f"  text: \"{_fmt_val(content)}\"")
+        elif el_type == "list":
+            items = content if isinstance(content, list) else []
+            preview = ", ".join(str(i)[:30] for i in items[:3])
+            if len(items) > 3:
+                preview += f", ... ({len(items)} items)"
+            parts.append(f"  list: [{preview}]")
+        elif el_type == "image":
+            src = content.get("src", "") if isinstance(content, dict) else str(content)
+            parts.append(f"  image: {_fmt_val(src)}")
+        elif el_type == "code":
+            code = content.get("code", "") if isinstance(content, dict) else str(content)
+            lang = content.get("language", "") if isinstance(content, dict) else ""
+            parts.append(f"  code ({lang or 'no lang'}): {_fmt_val(code)}")
+        elif el_type == "table":
+            if isinstance(content, dict):
+                rows = len(content.get("rows", []))
+                cols = len(content.get("headers", []))
+                parts.append(f"  table: {rows} rows x {cols} cols")
+            else:
+                parts.append(f"  table: {_fmt_val(str(content))}")
+        elif el_type == "quote":
+            parts.append(f"  quote: \"{_fmt_val(str(content))}\"")
+        else:
+            parts.append(f"  {el_type}: {_fmt_val(str(content))}")
+
+    if notes:
+        parts.append(f"  notes: \"{_fmt_val(notes)}\"")
+
+    return "\n".join(parts)
+
+
+def build_slides_prompt_context(
+    deck: dict | None = None,
+    *,
+    selected_slide_id: str | None = None,
+) -> str | None:
+    """Build a system-prompt block describing the current slide deck state.
+
+    When *selected_slide_id* is set, per-slide editing mode kicks in: the
+    prompt scopes the agent to only that slide and only element operations
+    on it are permitted.
+
+    Returns None if no deck is available.
+    """
+    resolved = deck or get_active_deck()
+    if not resolved:
+        return None
+
+    _ensure_deck(resolved)
+    slides = resolved.get("slides", [])
+    theme = resolved.get("theme", "black")
+    transition = resolved.get("transition", "slide")
+
+    if not slides:
+        return (
+            "You are editing a presentation in PocketPaw's slides editor.\n"
+            "The deck is currently empty (no slides). "
+            "Use the edit_slides tool to create slides.\n\n"
+            f"Theme: {theme} | Transition: {transition}"
+        )
+
+    parts = [
+        "You are editing a presentation in PocketPaw's slides editor.\n",
+        f"Theme: {theme} | Transition: {transition}",
+        f"Slides: {len(slides)}\n",
+        "## Slide overview\n",
+    ]
+
+    for i, slide in enumerate(slides):
+        parts.append(_summarize_slide(slide, i))
+        parts.append("")
+
+    scoping_notice = ""
+    if selected_slide_id:
+        scoping_notice = (
+            "\n"
+            "============================================================\n"
+            "CRITICAL: PER-SLIDE EDITING MODE\n"
+            "============================================================\n"
+            "You are in per-slide editing mode. You MUST follow these rules:\n"
+            "\n"
+            f"1. You are ONLY allowed to edit slide id={selected_slide_id}.\n"
+            "2. Do NOT modify, delete, or reorder any other slide.\n"
+            "3. Do NOT use 'replace_all' or 'set_theme' -- they would overwrite\n"
+            "   the entire deck and destroy content on other slides.\n"
+            "4. Do NOT create, delete, or reorder slides -- work within the\n"
+            "   selected slide only.\n"
+            "5. Use ONLY element operations (update_element, insert_element,\n"
+            f"   delete_element) with slide_id={selected_slide_id}.\n"
+            "6. If the user's prompt asks you to modify other slides or the\n"
+            "   whole deck, politely explain that you can only edit the\n"
+            "   selected slide. Suggest they deselect the slide for full-deck\n"
+            "   editing.\n"
+            "\n"
+            f"Target slide: id={selected_slide_id}\n"
+            "Permitted operations: update_element, insert_element, delete_element\n"
+            f"  (all with slide_id={selected_slide_id})\n"
+            "============================================================\n"
+        )
+        parts.insert(3, f"Selected slide: {selected_slide_id[:8]}\n")
+
+    parts.extend([
+        "## How to edit\n",
+        "Call the `edit_slides` tool with an array of operations. "
+        "You can call it multiple times -- each call returns the updated state.\n",
+        "Operations:",
+        '- create_slide: {"op":"create_slide", "layout":"content", "position":1, "background":{"type":"gradient","value":"linear-gradient(...)"}, "backgroundTransition":"zoom", "autoAnimate":true, "elements":[...]}',
+        '- delete_slide: {"op":"delete_slide", "slide_id":"abc123"}',
+        '- reorder_slides: {"op":"reorder_slides", "slide_ids":["id1","id2","id3"]}',
+        '- update_element: {"op":"update_element", "slide_id":"abc", "element_id":"def", "content":"New text", "fragment":"fade-in"}',
+        '- insert_element: {"op":"insert_element", "slide_id":"abc", "type":"heading", "content":"Title", "fragment":"grow"}',
+        '- delete_element: {"op":"delete_element", "slide_id":"abc", "element_id":"def"}',
+        '- set_theme: {"op":"set_theme", "theme":"night", "transition":"zoom", "backgroundTransition":"slide"}',
+        '- replace_all: {"op":"replace_all", "deck":{...}}',
+        "\nElement types: heading, text, list, image, code, table, quote\n",
+        "Background types: color, gradient, image, video. E.g.: {\"type\":\"gradient\",\"value\":\"linear-gradient(135deg, #1a1a2e, #16213e)\"}\n",
+        "Fragment styles (per element): fade-in, fade-out, fade-up, fade-down, fade-left, fade-right, fade-in-then-out, grow, shrink, highlight-red, highlight-blue, highlight-green\n",
+        "After making your edits, briefly tell the user what you changed.",
+        scoping_notice,  # appended after the how-to guide so it overrides any conflicting instructions
+    ])
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Operations engine
+# ---------------------------------------------------------------------------
+
+
+def apply_slides_operations(
+    deck: dict,
+    operations: list[dict],
+    selected_slide_id: str | None = None,
+) -> tuple[dict, str]:
+    """Apply slide operations to a deck. Mutates in place.
+
+    When *selected_slide_id* is set, only element operations
+    (update_element, insert_element, delete_element) targeting that
+    specific slide are permitted.  Deck-level operations (create_slide,
+    delete_slide, reorder_slides, set_theme, replace_all) are rejected.
+
+    Returns (deck, summary) -- deck is the same dict reference, mutated.
+    """
+    _ensure_deck(deck)
+    summaries: list[str] = []
+
+    _ELEMENT_OPS = {"update_element", "insert_element", "delete_element"}
+
+    # Pre-flight: reject replace_all in per-slide mode (hard error, stops all).
+    if selected_slide_id:
+        for op in operations:
+            if op.get("op") == "replace_all":
+                return deck, (
+                    "ERROR: replace_all is not allowed in per-slide editing mode. "
+                    "You may only edit elements on the selected slide "
+                    f"(id={selected_slide_id}). "
+                    "Use update_element, insert_element, or delete_element instead."
+                )
+
+    for op in operations:
+        op_type = op.get("op")
+        try:
+            # Per-slide editing enforcement: gate non-element ops and cross-slide ops.
+            if selected_slide_id and op_type not in _ELEMENT_OPS:
+                summaries.append(
+                    f"SKIPPED: '{op_type}' is not allowed in per-slide editing mode. "
+                    f"Only update_element, insert_element, delete_element are permitted "
+                    f"(target slide id={selected_slide_id})."
+                )
+                continue
+
+            if selected_slide_id and op.get("slide_id") != selected_slide_id:
+                summaries.append(
+                    f"SKIPPED: {op_type} on slide '{str(op.get('slide_id', ''))[:8]}' "
+                    f"is not allowed in per-slide editing mode. Target slide is "
+                    f"id={selected_slide_id}."
+                )
+                continue
+
+            if op_type == "create_slide":
+                _op_create_slide(deck, op, summaries)
+            elif op_type == "delete_slide":
+                _op_delete_slide(deck, op, summaries)
+            elif op_type == "reorder_slides":
+                _op_reorder_slides(deck, op, summaries)
+            elif op_type == "update_element":
+                _op_update_element(deck, op, summaries)
+            elif op_type == "insert_element":
+                _op_insert_element(deck, op, summaries)
+            elif op_type == "delete_element":
+                _op_delete_element(deck, op, summaries)
+            elif op_type == "set_theme":
+                _op_set_theme(deck, op, summaries)
+            elif op_type == "replace_all":
+                _op_replace_all(deck, op, summaries)
+            else:
+                summaries.append(f"Unknown operation '{op_type}' -- skipped")
+        except ValueError as exc:
+            summaries.append(f"ERROR in '{op_type}': {exc}")
+
+    summary = "; ".join(summaries) if summaries else "No operations applied"
+    return deck, summary
+
+
+# ── Individual operation handlers ──
+
+
+def _op_create_slide(deck: dict, op: dict, summaries: list):
+    layout = op.get("layout", "content")
+    elements_raw = op.get("elements", [])
+    elements: list[dict] = []
+    for el in elements_raw:
+        if isinstance(el, dict) and "type" in el:
+            elements.append(_create_element(
+                el_type=el["type"],
+                content=el.get("content", ""),
+                style=el.get("style"),
+                position=el.get("position"),
+                fragment=el.get("fragment"),
+            ))
+        else:
+            elements.append(el)
+
+    bg = op.get("background")
+    bg_transition = op.get("backgroundTransition")
+    auto_animate = op.get("autoAnimate", False)
+    slide = _create_slide(
+        layout=layout, elements=elements,
+        background=bg,
+        background_transition=bg_transition,
+        auto_animate=auto_animate,
+    )
+    position = op.get("position")
+    slides = deck.setdefault("slides", [])
+    if position is not None and 0 <= position < len(slides):
+        slides.insert(position, slide)
+        actual_pos = position
+    else:
+        slides.append(slide)
+        actual_pos = len(slides) - 1
+    summaries.append(f"Created slide {slide['id'][:8]} (layout={layout}) at position {actual_pos}")
+
+
+def _op_delete_slide(deck: dict, op: dict, summaries: list):
+    slide_id = op.get("slide_id", "")
+    slides = deck.get("slides", [])
+    for i, slide in enumerate(slides):
+        if slide.get("id") == slide_id:
+            slides.pop(i)
+            summaries.append(f"Deleted slide {slide_id[:8]} (was position {i})")
+            return
+    summaries.append(f"Slide '{slide_id[:8]}' not found -- skipped delete_slide")
+
+
+def _op_reorder_slides(deck: dict, op: dict, summaries: list):
+    new_order = op.get("slide_ids", [])
+    slides = deck.get("slides", [])
+    if not new_order:
+        summaries.append("reorder_slides: slide_ids is empty -- nothing changed")
+        return
+    slide_map = {s["id"]: s for s in slides}
+    reordered = []
+    for sid in new_order:
+        if sid in slide_map:
+            reordered.append(slide_map.pop(sid))
+        else:
+            summaries.append(f"reorder_slides: slide '{sid[:8]}' not found -- skipping")
+    reordered.extend(slide_map.values())
+    deck["slides"] = reordered
+    summaries.append(f"Reordered {len(new_order)} slides")
+
+
+def _op_update_element(deck: dict, op: dict, summaries: list):
+    slide_id = op.get("slide_id", "")
+    element_id = op.get("element_id", "")
+    slide = _get_slide(deck, slide_id)
+    if slide is None:
+        summaries.append(f"update_element: slide '{slide_id[:8]}' not found")
+        return
+    el = _get_element(slide, element_id)
+    if el is None:
+        summaries.append(f"update_element: element '{element_id[:8]}' not found in slide '{slide_id[:8]}'")
+        return
+
+    changed = []
+    if "content" in op:
+        el["content"] = op["content"]
+        changed.append("content")
+    if "style" in op and isinstance(op["style"], dict):
+        el.setdefault("style", {}).update(op["style"])
+        changed.append("style")
+    if "position" in op and isinstance(op["position"], dict):
+        el["position"] = op["position"]
+        changed.append("position")
+    if "fragment" in op:
+        el["fragment"] = op["fragment"] if op["fragment"] else None
+        changed.append(f"fragment={op['fragment']}")
+
+    summaries.append(
+        f"Updated element '{element_id[:8]}' on slide '{slide_id[:8]}': {', '.join(changed) or 'no fields'}"
+    )
+
+
+def _op_insert_element(deck: dict, op: dict, summaries: list):
+    slide_id = op.get("slide_id", "")
+    el_type = op.get("type", "text")
+    content = op.get("content", "")
+    style = op.get("style")
+    position = op.get("position")
+    fragment = op.get("fragment")
+
+    slide = _get_slide(deck, slide_id)
+    if slide is None:
+        summaries.append(f"insert_element: slide '{slide_id[:8]}' not found")
+        return
+
+    el = _create_element(el_type=el_type, content=content, style=style, position=position, fragment=fragment)
+    slide.setdefault("elements", []).append(el)
+    summaries.append(f"Inserted {el_type} element '{el['id'][:8]}' on slide '{slide_id[:8]}'")
+
+
+def _op_delete_element(deck: dict, op: dict, summaries: list):
+    slide_id = op.get("slide_id", "")
+    element_id = op.get("element_id", "")
+    slide = _get_slide(deck, slide_id)
+    if slide is None:
+        summaries.append(f"delete_element: slide '{slide_id[:8]}' not found")
+        return
+    elements = slide.get("elements", [])
+    for i, el in enumerate(elements):
+        if el.get("id") == element_id:
+            elements.pop(i)
+            summaries.append(f"Deleted element '{element_id[:8]}' from slide '{slide_id[:8]}'")
+            return
+    summaries.append(f"delete_element: element '{element_id[:8]}' not found on slide '{slide_id[:8]}'")
+
+
+def _op_set_theme(deck: dict, op: dict, summaries: list):
+    changed = []
+    if "theme" in op and op["theme"] in _THEMES:
+        deck["theme"] = op["theme"]
+        changed.append(f"theme={op['theme']}")
+    elif "theme" in op:
+        summaries.append(f"set_theme: unknown theme '{op['theme']}' -- skipping")
+    if "transition" in op and op["transition"] in _TRANSITIONS:
+        deck["transition"] = op["transition"]
+        changed.append(f"transition={op['transition']}")
+    elif "transition" in op:
+        summaries.append(f"set_theme: unknown transition '{op['transition']}' -- skipping")
+    if "backgroundTransition" in op and op["backgroundTransition"] in _TRANSITIONS:
+        deck["backgroundTransition"] = op["backgroundTransition"]
+        changed.append(f"bgTransition={op['backgroundTransition']}")
+    elif "backgroundTransition" in op:
+        summaries.append(f"set_theme: unknown backgroundTransition '{op['backgroundTransition']}' -- skipping")
+    if "slideNumber" in op:
+        deck["slideNumber"] = bool(op["slideNumber"])
+        changed.append(f"slideNumber={op['slideNumber']}")
+    if changed:
+        summaries.append(f"Updated deck settings: {', '.join(changed)}")
+
+
+def _op_replace_all(deck: dict, op: dict, summaries: list):
+    new_deck = op.get("deck", {})
+    deck.clear()
+    deck.update(new_deck)
+    _ensure_deck(deck)
+    summaries.append(f"Replaced entire deck ({len(deck.get('slides', []))} slides)")
+
+
+def _fmt_val(val: Any) -> str:
+    s = str(val)
+    return s[:60] + "..." if len(s) > 60 else s
+
+
+# ---------------------------------------------------------------------------
+# MCP tool (BaseTool protocol -- used by REST ai-edit endpoint)
+# ---------------------------------------------------------------------------
+
+
+class EditSlidesTool:
+    """Tool the agent can call to edit a reveal.js slide deck.
+
+    Operations are applied in order, mutating the deck in place.
+    """
+
+    def __init__(self, deck: dict) -> None:
+        self._deck = deck
+
+    @property
+    def name(self) -> str:
+        return "edit_slides"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Edit the slide deck by performing operations on slides and elements. "
+            "You can create, delete, and reorder slides, insert and update elements "
+            "(heading, text, list, image, code, table, quote), set backgrounds "
+            "(color, gradient, image, video), add fragment animations, change the "
+            "theme and transitions, or replace the entire deck. Call this tool "
+            "multiple times to build up your edit."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "operations": {
+                    "type": "array",
+                    "description": "Ordered list of slide operations to apply.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "op": {
+                                "type": "string",
+                                "enum": [
+                                    "create_slide", "delete_slide", "reorder_slides",
+                                    "update_element", "insert_element", "delete_element",
+                                    "set_theme", "replace_all",
+                                ],
+                            },
+                            "slide_id": {"type": "string", "description": "Target slide ID (12-char hex)"},
+                            "element_id": {"type": "string", "description": "Target element ID (8-char hex)"},
+                            "slide_ids": {"type": "array", "items": {"type": "string"}, "description": "New slide order (all slide IDs)"},
+                            "layout": {"type": "string", "enum": list(_LAYOUTS), "description": "Slide layout"},
+                            "type": {"type": "string", "enum": list(_ELEMENT_TYPES), "description": "Element type"},
+                            "content": {"description": "Element content: string for heading/text/quote, string[] for list, {src,alt} for image, {code,language} for code, {headers,rows} for table"},
+                            "elements": {"type": "array", "description": "Elements for a new slide"},
+                            "style": {"type": "object", "description": "CSS style overrides (fontSize, alignment, color)"},
+                            "position": {
+                                "type": "object",
+                                "properties": {
+                                    "x": {"type": "integer"},
+                                    "y": {"type": "integer"},
+                                    "width": {"type": "integer"},
+                                    "height": {"type": "integer"},
+                                },
+                                "description": "Grid position (12-column layout)",
+                            },
+                            "theme": {"type": "string", "enum": list(_THEMES), "description": "reveal.js theme (black, white, league, beige, sky, night, serif, simple, solarized, moon, dracula)"},
+                            "transition": {"type": "string", "enum": list(_TRANSITIONS), "description": "Slide transition (none, fade, slide, convex, concave, zoom)"},
+                            "backgroundTransition": {"type": "string", "enum": list(_TRANSITIONS), "description": "Background transition for set_theme or create_slide"},
+                            "slideNumber": {"type": "boolean", "description": "Show slide numbers"},
+                            "background": {
+                                "type": "object",
+                                "properties": {
+                                    "type": {"type": "string", "enum": ["color", "gradient", "image", "video"]},
+                                    "value": {"type": "string", "description": "CSS color, gradient string, image URL, or video URL"},
+                                },
+                                "description": "Slide background. Use type=gradient with value like 'linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)'",
+                            },
+                            "autoAnimate": {"type": "boolean", "description": "Enable auto-animate for this slide (create_slide)"},
+                            "fragment": {"type": "string", "description": "Fragment animation for an element: fade-in, fade-out, fade-up, fade-down, fade-left, fade-right, fade-in-then-out, grow, shrink, highlight-red, highlight-blue, highlight-green"},
+                            "deck": {"type": "object", "description": "Complete deck JSON for replace_all"},
+                        },
+                        "required": ["op"],
+                    },
+                }
+            },
+            "required": ["operations"],
+        }
+
+    async def execute(self, operations: list[dict]) -> str:
+        if not self._deck:
+            return _slides_error("No slide deck loaded. Start an editing session first.")
+        try:
+            selected = get_selected_slide_id()
+            updated, summary = apply_slides_operations(
+                self._deck, operations, selected_slide_id=selected
+            )
+            return f"{summary}\n\nUpdated deck:\n{json.dumps(updated, separators=(',', ':'))}"
+        except Exception as exc:
+            return _slides_error(f"Edit failed: {exc}")
+
+
+def _slides_error(message: str) -> dict:
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+async def _edit_slides_handler(args: dict) -> dict:
+    """MCP handler for the edit_slides tool."""
+    deck = get_active_deck()
+    if deck is None:
+        return _slides_error(
+            "No slide deck is currently open for editing. "
+            "Open a slides file in the editor first."
+        )
+
+    operations = args.get("operations")
+    if not operations:
+        if args.get("operation"):
+            return _slides_error(
+                "Use `operations` (plural) as the key, not `operation`. "
+                'Example: {"operations": [{"op": "create_slide", ...}]}'
+            )
+        if any(k in args for k in ("create_slide", "slide_id", "type", "content")):
+            return _slides_error(
+                "Wrap operations inside an `operations` array. "
+                'Example: {"operations": [{"op": "create_slide", "layout": "content"}]}'
+            )
+        return _slides_error(
+            "Missing `operations` array. "
+            'Format: {"operations": [{"op": "create_slide|delete_slide|...", ...}]}'
+        )
+
+    if not isinstance(operations, list):
+        return _slides_error("`operations` must be an array (list), not a single object.")
+
+    try:
+        selected = get_selected_slide_id()
+        updated, summary = apply_slides_operations(deck, operations, selected_slide_id=selected)
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "summary": summary,
+                            "slideCount": len(updated.get("slides", [])),
+                            "deck": updated,
+                        },
+                        separators=(",", ":"),
+                    ),
+                }
+            ]
+        }
+    except Exception as exc:
+        logger.exception("edit_slides handler failed")
+        return _slides_error(str(exc))
+
+
+def build_edit_slides_mcp_server() -> tuple[str, Any] | None:
+    """Build the in-process MCP server for the Claude Agent SDK.
+
+    Returns (server_name, server_config) or None if the SDK is unavailable.
+    Always registered -- the handler returns an error when no editing session
+    is active, so the agent won't use it outside the slides editing context.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; edit_slides MCP disabled")
+        return None
+
+    @tool(
+        "edit_slides",
+        (
+            "Edit the current slide deck by performing operations on slides and "
+            "elements. Use this when the user asks you to edit, create, or "
+            "restructure a presentation they have open in the editor.\n\n"
+            "You MUST call it with an `operations` array. Each item must have "
+            "an `op` field set to one of: create_slide, delete_slide, "
+            "reorder_slides, update_element, insert_element, delete_element, "
+            "set_theme, replace_all.\n\n"
+            "EXACT format (copy this pattern):\n"
+            '{"operations": [\n'
+            '  {"op": "create_slide", "layout": "title-slide",\n'
+            '   "background": {"type": "gradient", "value": "linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)"},\n'
+            '   "backgroundTransition": "zoom",\n'
+            '   "elements": [\n'
+            '     {"type": "heading", "content": "My Title", "style": {"fontSize": "2.5em", "alignment": "center"}, "fragment": "fade-in"},\n'
+            '     {"type": "text", "content": "Subtitle", "style": {"fontSize": "1.2em", "alignment": "center"}, "fragment": "fade-up"}\n'
+            '  ]},\n'
+            '  {"op": "insert_element", "slide_id": "abc123def456", "type": "list", "content": ["Point 1", "Point 2"], "fragment": "grow"},\n'
+            '  {"op": "update_element", "slide_id": "abc123def456", "element_id": "a1b2c3d4", "content": "Updated text", "fragment": "highlight-blue"},\n'
+            '  {"op": "delete_slide", "slide_id": "abc123def456"},\n'
+            '  {"op": "reorder_slides", "slide_ids": ["id2", "id1", "id3"]},\n'
+            '  {"op": "set_theme", "theme": "night", "transition": "zoom", "backgroundTransition": "slide"},\n'
+            '  {"op": "replace_all", "deck": {...}}\n'
+            "]}\n\n"
+            "ELEMENT TYPES: heading, text, list, image, code, table, quote\n"
+            "CONTENT FORMATS:\n"
+            "- heading/text/quote: a string\n"
+            "- list: an array of strings\n"
+            '- image: {"src": "url", "alt": "description"}\n'
+            '- code: {"code": "...", "language": "python"}\n'
+            '- table: {"headers": ["Col1","Col2"], "rows": [["a","b"],["c","d"]]}\n\n'
+            "STYLE (optional): {\"fontSize\": \"2em\", \"alignment\": \"left|center|right\", \"color\": \"#hex\"}\n"
+            "FRAGMENT (optional, per element): fade-in, fade-out, fade-up, fade-down, fade-left, fade-right, fade-in-then-out, fade-in-then-semi-out, grow, shrink, highlight-red, highlight-blue, highlight-green\n"
+            "BACKGROUND (optional, per slide): {\"type\":\"color\",\"value\":\"#1a1a2e\"} | {\"type\":\"gradient\",\"value\":\"linear-gradient(135deg, #1a1a2e, #16213e)\"} | {\"type\":\"image\",\"value\":\"https://...\"} | {\"type\":\"video\",\"value\":\"https://...\"}\n"
+            "BACKGROUND TRANSITION (optional): none, fade, slide, convex, concave, zoom\n"
+            "AUTO-ANIMATE: add \"autoAnimate\":true to create_slide for matching elements across consecutive slides\n"
+            "SLIDE LAYOUTS: title-slide, content, two-column, image-full, blank\n"
+            "THEMES: black, white, league, beige, sky, night, serif, simple, solarized, moon, dracula\n"
+            "TRANSITIONS: none, fade, slide, convex, concave, zoom\n\n"
+            "DESIGN TIPS:\n"
+            "- For a professional deck, use gradient backgrounds with complementary colors\n"
+            "- Dark themes (night, dracula, moon, league) look more polished for tech presentations\n"
+            "- Use fragments to reveal content incrementally — headings first, then body text\n"
+            "- Pair 'zoom' transition with 'slide' background transition for smooth motion\n"
+            "- Code blocks auto-highlight when you specify the language\n\n"
+            "IMPORTANT: The field is `op` (not operation or action). "
+            "Everything goes inside the `operations` array -- not at top level."
+        ),
+        {
+            "operations": list,
+        },
+    )
+    async def edit_slides(args):
+        return await _edit_slides_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[edit_slides],
+    )
+    return SERVER_NAME, server

--- a/src/pocketpaw/tools/builtin/edit_spreadsheet.py
+++ b/src/pocketpaw/tools/builtin/edit_spreadsheet.py
@@ -1,0 +1,841 @@
+"""edit_spreadsheet tool — AI-powered spreadsheet editing for Univer workbooks.
+
+The agent calls ``edit_spreadsheet`` with an array of operations. Workbook
+snapshots are stored in a per-request ``ContextVar`` (for the REST ai-edit
+endpoint) or a module-level dict keyed by file_id (for chat-initiated editing).
+
+Mirrors the Editor.js ``edit_document`` pattern: ContextVar for request-scoped
+access, module dict for chat sync, MCP server for agent tooling.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from contextvars import ContextVar
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Per-request workbook snapshot (REST ai-edit endpoint).
+_edit_session_snapshot: ContextVar[dict | None] = ContextVar(
+    "edit_session_snapshot", default=None
+)
+
+# Per-request selected sheet name for scoped editing.
+_selected_sheet: ContextVar[str | None] = ContextVar(
+    "selected_sheet", default=None
+)
+
+# Module-level store keyed by file_id — used when snapshots are synced from
+# the frontend spreadsheet UI (chat-initiated editing).
+_spreadsheet_snapshot_store: dict[str, dict] = {}
+
+SERVER_NAME = "pocketpaw_edit_spreadsheet"
+EDIT_SPREADSHEET_TOOL_ID = f"mcp__{SERVER_NAME}__edit_spreadsheet"
+
+# ---------------------------------------------------------------------------
+# Cell reference parsing (A1 notation)
+# ---------------------------------------------------------------------------
+
+_A1_RE = re.compile(
+    r"^(?:(?P<sheet>[A-Za-z0-9_ ]+)!)?"
+    r"(?P<col>[A-Z]+)(?P<row>\d+)$"
+)
+
+_RANGE_RE = re.compile(
+    r"^(?:(?P<sheet>[A-Za-z0-9_ ]+)!)?"
+    r"(?P<col1>[A-Z]+)(?P<row1>\d+)"
+    r":"
+    r"(?P<col2>[A-Z]+)(?P<row2>\d+)$"
+)
+
+
+def _col_to_index(col: str) -> int:
+    """Convert column letter(s) to 0-based index. A=0, B=1, ..., AA=26."""
+    idx = 0
+    for ch in col.upper():
+        idx = idx * 26 + (ord(ch) - ord("A") + 1)
+    return idx - 1
+
+
+def _index_to_col(idx: int) -> str:
+    """Convert 0-based column index to letters. 0='A', 25='Z', 26='AA'."""
+    result = ""
+    while idx >= 0:
+        result = chr(ord("A") + idx % 26) + result
+        idx = idx // 26 - 1
+    return result
+
+
+def parse_cell_ref(ref: str, default_sheet: str | None = None) -> tuple[str, int, int]:
+    """Parse an A1-style cell reference into (sheet_name, row_0, col_0).
+
+    ``Sheet1!B5`` → ("Sheet1", 4, 1).  ``B5`` → (default_sheet, 4, 1).
+    Raises ValueError if the reference is malformed.
+    """
+    m = _A1_RE.match(ref.strip())
+    if not m:
+        raise ValueError(
+            f"Invalid cell reference '{ref}'. Use A1 notation, e.g. 'B5' or 'Sheet1!B5'."
+        )
+    sheet = m.group("sheet") or default_sheet or ""
+    col_idx = _col_to_index(m.group("col"))
+    row_idx = int(m.group("row")) - 1
+    if row_idx < 0:
+        raise ValueError(f"Invalid row number in '{ref}'")
+    return sheet, row_idx, col_idx
+
+
+def parse_range_ref(ref: str, default_sheet: str | None = None) -> tuple[str, int, int, int, int]:
+    """Parse an A1-style range reference into (sheet, row1, col1, row2, col2).
+
+    ``A1:C10`` → (default_sheet, 0, 0, 9, 2). Supports ``Sheet1!A1:C10``.
+    """
+    m = _RANGE_RE.match(ref.strip())
+    if not m:
+        raise ValueError(
+            f"Invalid range reference '{ref}'. Use A1 notation, e.g. 'A1:C10'."
+        )
+    sheet = m.group("sheet") or default_sheet or ""
+    row1 = int(m.group("row1")) - 1
+    col1 = _col_to_index(m.group("col1"))
+    row2 = int(m.group("row2")) - 1
+    col2 = _col_to_index(m.group("col2"))
+    if row1 < 0 or row2 < 0:
+        raise ValueError(f"Invalid row range in '{ref}'")
+    return sheet, row1, col1, row2, col2
+
+
+# ---------------------------------------------------------------------------
+# Session management (ContextVar + module dict — mirrors edit_document.py)
+# ---------------------------------------------------------------------------
+
+
+def set_edit_session(snapshot: dict) -> None:
+    _edit_session_snapshot.set(snapshot)
+
+
+def clear_edit_session() -> None:
+    _edit_session_snapshot.set(None)
+
+
+def get_edit_session() -> dict | None:
+    return _edit_session_snapshot.get()
+
+
+def set_selected_sheet(sheet: str | None) -> None:
+    _selected_sheet.set(sheet)
+
+
+def get_selected_sheet() -> str | None:
+    return _selected_sheet.get()
+
+
+def clear_selected_sheet() -> None:
+    _selected_sheet.set(None)
+
+
+def set_spreadsheet_snapshot(file_id: str, snapshot: dict) -> None:
+    _spreadsheet_snapshot_store[file_id] = snapshot
+
+
+def get_spreadsheet_snapshot(file_id: str) -> dict | None:
+    return _spreadsheet_snapshot_store.get(file_id)
+
+
+def get_active_snapshot() -> dict | None:
+    """Get whichever snapshot is available — ContextVar first, then store."""
+    snap = _edit_session_snapshot.get()
+    if snap is not None:
+        return snap
+    if _spreadsheet_snapshot_store:
+        return next(iter(_spreadsheet_snapshot_store.values()))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Snapshot helpers
+# ---------------------------------------------------------------------------
+
+
+def _sheet_names(snapshot: dict) -> list[str]:
+    """Return ordered sheet names from the workbook snapshot."""
+    return list(snapshot.get("sheetOrder", []) or snapshot.get("sheets", {}).keys())
+
+
+def _get_sheet(snapshot: dict, name: str) -> dict | None:
+    """Get a sheet dict by name from the workbook snapshot."""
+    sheets = snapshot.get("sheets", {})
+    return sheets.get(name)
+
+
+def _ensure_sheet(snapshot: dict, name: str) -> dict:
+    """Get or create a sheet dict. Initialises cellData if needed."""
+    sheets = snapshot.setdefault("sheets", {})
+    if name not in sheets:
+        sheet = {
+            "id": uuid.uuid4().hex[:8],
+            "name": name,
+            "rowCount": 1000,
+            "columnCount": 26,
+            "cellData": {},
+        }
+        sheets[name] = sheet
+        snapshot.setdefault("sheetOrder", []).append(name)
+        if "id" not in snapshot:
+            snapshot["id"] = uuid.uuid4().hex[:8]
+        if "name" not in snapshot:
+            snapshot["name"] = "Workbook"
+    return sheets[name]
+
+
+def _cell_data(sheet: dict) -> dict:
+    """Return the cellData dict for a sheet, initialising if needed."""
+    return sheet.setdefault("cellData", {})
+
+
+def _get_cell(sheet: dict, row: int, col: int) -> dict | None:
+    """Get a cell from a sheet by 0-based row/col. Returns None if empty."""
+    cd = _cell_data(sheet)
+    row_dict = cd.get(str(row))
+    if row_dict is None:
+        return None
+    return row_dict.get(str(col))
+
+
+def _set_cell(sheet: dict, row: int, col: int, value: Any, /, *, cell_type: int | None = None):
+    """Set a cell in a sheet. Auto-bumps rowCount/columnCount if needed."""
+    cd = sheet.setdefault("cellData", {})
+    row_key = str(row)
+    if row_key not in cd:
+        cd[row_key] = {}
+    col_key = str(col)
+    if cell_type is None:
+        cell_type = _infer_cell_type(value)
+    cd[row_key][col_key] = {"v": value, "t": cell_type}
+    if row >= sheet.get("rowCount", 0):
+        sheet["rowCount"] = row + 1
+    if col >= sheet.get("columnCount", 0):
+        sheet["columnCount"] = col + 1
+
+
+def _infer_cell_type(value: Any) -> int:
+    """Infer Univer cell type from Python value. 1=string, 2=number, 3=boolean."""
+    if isinstance(value, bool):
+        return 3
+    if isinstance(value, (int, float)):
+        return 2
+    return 1
+
+
+def _clear_cell(sheet: dict, row: int, col: int) -> bool:
+    """Remove a cell from cellData. Returns True if a cell was actually removed."""
+    cd = _cell_data(sheet)
+    row_dict = cd.get(str(row))
+    if row_dict is None:
+        return False
+    col_key = str(col)
+    if col_key in row_dict:
+        del row_dict[col_key]
+        if not row_dict:
+            del cd[str(row)]
+        return True
+    return False
+
+
+def _shift_rows(sheet: dict, from_row: int, delta: int):
+    """Shift cellData rows by delta starting from from_row. Positive = move down."""
+    cd = _cell_data(sheet)
+    if delta == 0:
+        return
+    rows_to_move = sorted(
+        (int(r) for r in cd if int(r) >= from_row),
+        reverse=(delta > 0),
+    )
+    for r in rows_to_move:
+        new_r = r + delta
+        if new_r < 0:
+            continue
+        cd[str(new_r)] = cd.pop(str(r), {})
+    sheet["rowCount"] = max(1, sheet.get("rowCount", 0) + delta)
+
+
+def _shift_columns(sheet: dict, from_col: int, delta: int):
+    """Shift cellData columns by delta starting from from_col. Positive = move right."""
+    cd = _cell_data(sheet)
+    if delta == 0:
+        return
+    for row_key in list(cd):
+        row_dict = cd.get(row_key)
+        if not row_dict:
+            continue
+        new_row: dict[str, dict] = {}
+        for col_key, cell in row_dict.items():
+            c = int(col_key)
+            if c >= from_col:
+                new_c = c + delta
+                if new_c >= 0:
+                    new_row[str(new_c)] = cell
+            else:
+                new_row[col_key] = cell
+        cd[row_key] = new_row
+    sheet["columnCount"] = max(1, sheet.get("columnCount", 0) + delta)
+
+
+def _collect_range(
+    sheet: dict, row1: int, col1: int, row2: int, col2: int
+) -> list[tuple[int, int, dict | None]]:
+    """Collect all cells in a range. Returns list of (row, col, cell_dict_or_none)."""
+    result = []
+    for r in range(min(row1, row2), max(row1, row2) + 1):
+        for c in range(min(col1, col2), max(col1, col2) + 1):
+            result.append((r, c, _get_cell(sheet, r, c)))
+    return result
+
+
+def _summarize_sheet(snapshot: dict, sheet_name: str) -> str:
+    """Build a compact summary of a sheet: dimensions, headers, sample data."""
+    sheet = _get_sheet(snapshot, sheet_name)
+    if not sheet:
+        return f"Sheet '{sheet_name}': (empty)"
+
+    cd = _cell_data(sheet)
+    rows = sorted({int(r) for r in cd} | {0})
+    cols = sorted(
+        {int(c) for row_dict in cd.values() for c in row_dict} | {0, 1, 2, 3, 4}
+    )
+
+    num_rows = sheet.get("rowCount", 0)
+    num_cols = sheet.get("columnCount", 0)
+    lines = [
+        f"Sheet '{sheet_name}': {num_rows} rows x {num_cols} columns, "
+        f"{sum(len(row_dict) for row_dict in cd.values())} cells with data",
+    ]
+
+    if rows:
+        top_rows = rows[:15]
+        top_cols = sorted(cols)[:10]
+        if top_cols:
+            header = "    | " + " | ".join(_index_to_col(c).rjust(5) for c in top_cols) + " |"
+            lines.append(header)
+            lines.append("    |-" + "-|-".join("-" * 5 for _ in top_cols) + "-|")
+            for r in top_rows:
+                row_parts = []
+                for c in top_cols:
+                    cell = _get_cell(sheet, r, c)
+                    if cell is None:
+                        row_parts.append("".rjust(5))
+                    else:
+                        val = str(cell.get("v", ""))[:4]
+                        row_parts.append(val.rjust(5))
+                lines.append(f"  {r + 1:2d} | " + " | ".join(row_parts) + " |")
+
+        if len(rows) > 15:
+            lines.append(f"  ... ({len(rows) - 15} more rows)")
+
+        if len(cols) > 10:
+            lines.append(f"  ... ({len(cols) - 10} more columns)")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Prompt context builder
+# ---------------------------------------------------------------------------
+
+
+def build_spreadsheet_prompt_context(
+    snapshot: dict | None = None,
+    *,
+    selected_sheet: str | None = None,
+) -> str | None:
+    """Build a system-prompt block describing the current workbook state.
+
+    Returns None if no snapshot is available.
+    """
+    resolved = snapshot or get_active_snapshot()
+    if not resolved:
+        return None
+
+    sheets = _sheet_names(resolved)
+    active = selected_sheet or (sheets[0] if sheets else "Sheet1")
+
+    if not sheets:
+        return (
+            "You are editing a spreadsheet in PocketPaw. "
+            "The workbook is currently empty (no sheets). "
+            "Use the edit_spreadsheet tool to create the first sheet."
+        )
+
+    parts = [
+        "You are editing a spreadsheet in PocketPaw's spreadsheet editor.\n",
+        f"Workbook: {resolved.get('name', 'Untitled')}",
+        f"Sheets: {', '.join(sheets)}",
+        f"Active sheet: {active}\n",
+        "## Workbook structure\n",
+    ]
+
+    for sn in sheets:
+        parts.append(_summarize_sheet(resolved, sn))
+        parts.append("")
+
+    parts.extend([
+        "## How to edit\n",
+        "Call the `edit_spreadsheet` tool with an array of operations. "
+        "You can call it multiple times — each call returns the updated state.\n",
+        "Operations:",
+        '- setCell: {"op":"setCell", "cell":"A1", "value":"hello"}',
+        '- setRange: {"op":"setRange", "range":"A1:C3", "values":[["a","b","c"],["d","e","f"],["g","h","i"]]}',
+        '- setFormula: {"op":"setFormula", "cell":"D1", "formula":"=SUM(A1:C1)"}',
+        '- clearRange: {"op":"clearRange", "range":"A1:C3"}',
+        '- insertRows: {"op":"insertRows", "sheet":"Sheet1", "atRow":2, "count":1}',
+        '- deleteRows: {"op":"deleteRows", "sheet":"Sheet1", "atRow":2, "count":1}',
+        '- insertColumns: {"op":"insertColumns", "sheet":"Sheet1", "atCol":"B", "count":1}',
+        '- deleteColumns: {"op":"deleteColumns", "sheet":"Sheet1", "atCol":"B", "count":1}',
+        '- insertSheet: {"op":"insertSheet", "name":"NewSheet"}',
+        '- deleteSheet: {"op":"deleteSheet", "name":"Sheet2"}',
+        '- renameSheet: {"op":"renameSheet", "name":"Sheet1", "newName":"Data"}',
+        '- mergeCells: {"op":"mergeCells", "range":"A1:B2"}',
+        '- replaceAll: {"op":"replaceAll", "snapshot":{...}}',
+        "\nCell references use A1 notation. Use 'SheetName!A1' for cross-sheet references.\n",
+        "After making your edits, briefly tell the user what you changed.",
+    ])
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Operations engine
+# ---------------------------------------------------------------------------
+
+
+def apply_spreadsheet_ops(
+    snapshot: dict,
+    operations: list[dict],
+    selected_sheet: str | None = None,
+) -> tuple[dict, str]:
+    """Apply spreadsheet operations to a workbook snapshot. Mutates in place.
+
+    Returns (snapshot, summary) — snapshot is the same dict reference, mutated.
+    """
+    summaries: list[str] = []
+    active_sheet = selected_sheet or (_sheet_names(snapshot)[0] if _sheet_names(snapshot) else "Sheet1")
+
+    for op in operations:
+        op_type = op.get("op")
+        try:
+            if op_type == "setCell":
+                _op_set_cell(snapshot, op, active_sheet, summaries)
+            elif op_type == "setRange":
+                _op_set_range(snapshot, op, active_sheet, summaries)
+            elif op_type == "setFormula":
+                _op_set_formula(snapshot, op, active_sheet, summaries)
+            elif op_type == "clearRange":
+                _op_clear_range(snapshot, op, active_sheet, summaries)
+            elif op_type == "insertRows":
+                _op_insert_rows(snapshot, op, summaries)
+            elif op_type == "deleteRows":
+                _op_delete_rows(snapshot, op, summaries)
+            elif op_type == "insertColumns":
+                _op_insert_columns(snapshot, op, summaries)
+            elif op_type == "deleteColumns":
+                _op_delete_columns(snapshot, op, summaries)
+            elif op_type == "insertSheet":
+                _op_insert_sheet(snapshot, op, summaries)
+            elif op_type == "deleteSheet":
+                _op_delete_sheet(snapshot, op, summaries)
+            elif op_type == "renameSheet":
+                _op_rename_sheet(snapshot, op, summaries)
+            elif op_type == "mergeCells":
+                _op_merge_cells(snapshot, op, active_sheet, summaries)
+            elif op_type == "replaceAll":
+                _op_replace_all(snapshot, op, summaries)
+            else:
+                summaries.append(f"Unknown operation '{op_type}' — skipped")
+        except ValueError as exc:
+            summaries.append(f"ERROR in '{op_type}': {exc}")
+
+    summary = "; ".join(summaries) if summaries else "No operations applied"
+    return snapshot, summary
+
+
+def _resolve_sheet(snapshot: dict, op: dict, active: str) -> str:
+    """Get sheet name from op['sheet'] or the active sheet."""
+    return op.get("sheet") or active
+
+
+# ── Individual operation handlers ──
+
+
+def _op_set_cell(snapshot: dict, op: dict, active: str, summaries: list):
+    cell_ref = op.get("cell", "")
+    sheet, row, col = parse_cell_ref(cell_ref, active)
+    s = _ensure_sheet(snapshot, sheet)
+    _set_cell(s, row, col, op["value"])
+    summaries.append(f"Set {cell_ref} = {_fmt_val(op['value'])}")
+
+
+def _op_set_range(snapshot: dict, op: dict, active: str, summaries: list):
+    range_ref = op.get("range", "")
+    sheet, row1, col1, row2, col2 = parse_range_ref(range_ref, active)
+    values = op.get("values", [])
+    s = _ensure_sheet(snapshot, sheet)
+    count = 0
+    for ri, row_vals in enumerate(values):
+        if not isinstance(row_vals, list):
+            row_vals = [row_vals]
+        for ci, val in enumerate(row_vals):
+            _set_cell(s, row1 + ri, col1 + ci, val)
+            count += 1
+    summaries.append(f"Set {count} cells in {range_ref}")
+
+
+def _op_set_formula(snapshot: dict, op: dict, active: str, summaries: list):
+    cell_ref = op.get("cell", "")
+    sheet, row, col = parse_cell_ref(cell_ref, active)
+    s = _ensure_sheet(snapshot, sheet)
+    cd = _cell_data(s)
+    cd.setdefault(str(row), {})[str(col)] = {
+        "v": op.get("formula", ""),
+        "f": op.get("formula", ""),
+        "t": 2,
+    }
+    summaries.append(f"Set formula in {cell_ref}: {op.get('formula', '')}")
+
+
+def _op_clear_range(snapshot: dict, op: dict, active: str, summaries: list):
+    range_ref = op.get("range", "")
+    sheet, row1, col1, row2, col2 = parse_range_ref(range_ref, active)
+    s = _get_sheet(snapshot, sheet)
+    if s is None:
+        summaries.append(f"Sheet '{sheet}' not found — skipped clearRange")
+        return
+    count = 0
+    for r in range(min(row1, row2), max(row1, row2) + 1):
+        for c in range(min(col1, col2), max(col1, col2) + 1):
+            if _clear_cell(s, r, c):
+                count += 1
+    summaries.append(f"Cleared {count} cells in {range_ref}")
+
+
+def _op_insert_rows(snapshot: dict, op: dict, summaries: list):
+    sheet_name = op.get("sheet", "")
+    s = _get_sheet(snapshot, sheet_name)
+    if s is None:
+        summaries.append(f"Sheet '{sheet_name}' not found — skipped insertRows")
+        return
+    at_row = op.get("atRow", 0)
+    count = op.get("count", 1)
+    _shift_rows(s, at_row, count)
+    summaries.append(f"Inserted {count} row(s) at row {at_row + 1} in '{sheet_name}'")
+
+
+def _op_delete_rows(snapshot: dict, op: dict, summaries: list):
+    sheet_name = op.get("sheet", "")
+    s = _get_sheet(snapshot, sheet_name)
+    if s is None:
+        summaries.append(f"Sheet '{sheet_name}' not found — skipped deleteRows")
+        return
+    at_row = op.get("atRow", 0)
+    count = op.get("count", 1)
+    _shift_rows(s, at_row + count, -count)
+    summaries.append(f"Deleted {count} row(s) at row {at_row + 1} in '{sheet_name}'")
+
+
+def _op_insert_columns(snapshot: dict, op: dict, summaries: list):
+    sheet_name = op.get("sheet", "")
+    s = _get_sheet(snapshot, sheet_name)
+    if s is None:
+        summaries.append(f"Sheet '{sheet_name}' not found — skipped insertColumns")
+        return
+    at_col_str = op.get("atCol", "A")
+    at_col = _col_to_index(at_col_str)
+    count = op.get("count", 1)
+    _shift_columns(s, at_col, count)
+    summaries.append(f"Inserted {count} column(s) at column {at_col_str} in '{sheet_name}'")
+
+
+def _op_delete_columns(snapshot: dict, op: dict, summaries: list):
+    sheet_name = op.get("sheet", "")
+    s = _get_sheet(snapshot, sheet_name)
+    if s is None:
+        summaries.append(f"Sheet '{sheet_name}' not found — skipped deleteColumns")
+        return
+    at_col_str = op.get("atCol", "A")
+    at_col = _col_to_index(at_col_str)
+    count = op.get("count", 1)
+    _shift_columns(s, at_col + count, -count)
+    summaries.append(f"Deleted {count} column(s) at column {at_col_str} in '{sheet_name}'")
+
+
+def _op_insert_sheet(snapshot: dict, op: dict, summaries: list):
+    name = op.get("name", f"Sheet{len(_sheet_names(snapshot)) + 1}")
+    _ensure_sheet(snapshot, name)
+    summaries.append(f"Inserted sheet '{name}'")
+
+
+def _op_delete_sheet(snapshot: dict, op: dict, summaries: list):
+    name = op.get("name", "")
+    sheets = snapshot.get("sheets", {})
+    if name not in sheets:
+        summaries.append(f"Sheet '{name}' not found — skipped deleteSheet")
+        return
+    del sheets[name]
+    order = snapshot.get("sheetOrder", [])
+    if name in order:
+        order.remove(name)
+    summaries.append(f"Deleted sheet '{name}'")
+
+
+def _op_rename_sheet(snapshot: dict, op: dict, summaries: list):
+    name = op.get("name", "")
+    new_name = op.get("newName", "")
+    sheets = snapshot.get("sheets", {})
+    if name not in sheets:
+        summaries.append(f"Sheet '{name}' not found — skipped renameSheet")
+        return
+    sheets[new_name] = sheets.pop(name)
+    sheets[new_name]["name"] = new_name
+    order = snapshot.get("sheetOrder", [])
+    if name in order:
+        order[order.index(name)] = new_name
+    summaries.append(f"Renamed sheet '{name}' → '{new_name}'")
+
+
+def _op_merge_cells(snapshot: dict, op: dict, active: str, summaries: list):
+    range_ref = op.get("range", "")
+    sheet, row1, col1, row2, col2 = parse_range_ref(range_ref, active)
+    s = _ensure_sheet(snapshot, sheet)
+    merges = s.setdefault("mergeData", [])
+    merge = {
+        "startRow": min(row1, row2),
+        "endRow": max(row1, row2),
+        "startColumn": min(col1, col2),
+        "endColumn": max(col1, col2),
+    }
+    merges.append(merge)
+    summaries.append(f"Merged cells {range_ref}")
+
+
+def _op_replace_all(snapshot: dict, op: dict, summaries: list):
+    new_snapshot = op.get("snapshot", {})
+    snapshot.clear()
+    snapshot.update(new_snapshot)
+    summaries.append(
+        f"Replaced entire workbook ({len(_sheet_names(snapshot))} sheets)"
+    )
+
+
+def _fmt_val(val: Any) -> str:
+    s = str(val)
+    return s[:40] + "..." if len(s) > 40 else s
+
+
+# ---------------------------------------------------------------------------
+# MCP tool (BaseTool protocol — used by REST ai-edit endpoint)
+# ---------------------------------------------------------------------------
+
+
+class EditSpreadsheetTool:
+    """Tool the agent can call to edit a Univer workbook snapshot.
+
+    Operations are applied in order, mutating the snapshot in place.
+    """
+
+    def __init__(self, snapshot: dict) -> None:
+        self._snapshot = snapshot
+
+    @property
+    def name(self) -> str:
+        return "edit_spreadsheet"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Edit the spreadsheet by performing operations on cells, ranges, rows, "
+            "columns, and sheets. You can set cell values, formulas, insert/delete "
+            "rows and columns, manage sheets, merge cells, or replace the entire "
+            "workbook. Call this tool multiple times to build up your edit."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "operations": {
+                    "type": "array",
+                    "description": "Ordered list of spreadsheet operations to apply.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "op": {
+                                "type": "string",
+                                "enum": [
+                                    "setCell", "setRange", "setFormula",
+                                    "clearRange", "insertRows", "deleteRows",
+                                    "insertColumns", "deleteColumns",
+                                    "insertSheet", "deleteSheet", "renameSheet",
+                                    "mergeCells", "replaceAll",
+                                ],
+                            },
+                            "cell": {"type": "string", "description": "Cell ref in A1 notation, e.g. 'B5' or 'Sheet1!B5'"},
+                            "value": {"description": "Cell value (string, number, or boolean)"},
+                            "range": {"type": "string", "description": "Range in A1 notation, e.g. 'A1:C10'"},
+                            "values": {"type": "array", "description": "2D array of values for setRange"},
+                            "formula": {"type": "string", "description": "Formula string, e.g. '=SUM(A1:A10)'"},
+                            "sheet": {"type": "string", "description": "Target sheet name"},
+                            "name": {"type": "string", "description": "Sheet name for insert/delete/rename"},
+                            "newName": {"type": "string", "description": "New sheet name for renameSheet"},
+                            "atRow": {"type": "integer", "description": "0-based row index for insertRows/deleteRows"},
+                            "atCol": {"type": "string", "description": "Column letter for insertColumns/deleteColumns, e.g. 'B'"},
+                            "count": {"type": "integer", "description": "Number of rows/columns to insert or delete (default 1)"},
+                            "snapshot": {"type": "object", "description": "Complete workbook snapshot for replaceAll"},
+                        },
+                        "required": ["op"],
+                    },
+                }
+            },
+            "required": ["operations"],
+        }
+
+    async def execute(self, operations: list[dict]) -> str:
+        if not self._snapshot:
+            return _spreadsheet_error("No workbook snapshot loaded. Start an editing session first.")
+        try:
+            selected = get_selected_sheet()
+            updated, summary = apply_spreadsheet_ops(
+                self._snapshot, operations, selected_sheet=selected
+            )
+            return f"{summary}\n\nUpdated snapshot:\n{json.dumps(updated, separators=(',', ':'))}"
+        except Exception as exc:
+            return _spreadsheet_error(f"Edit failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# MCP handler + server factory (for Claude Agent SDK)
+# ---------------------------------------------------------------------------
+
+
+def _spreadsheet_error(message: str) -> dict:
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+async def _edit_spreadsheet_handler(args: dict) -> dict:
+    """MCP handler for the edit_spreadsheet tool."""
+    snapshot = get_active_snapshot()
+    if snapshot is None:
+        return _spreadsheet_error(
+            "No spreadsheet is currently open for editing. "
+            "Open a spreadsheet file in the editor first."
+        )
+
+    operations = args.get("operations")
+    if not operations:
+        if args.get("operation"):
+            return _spreadsheet_error(
+                "Use `operations` (plural) as the key, not `operation`. "
+                'Example: {"operations": [{"op": "setCell", ...}]}'
+            )
+        if any(k in args for k in ("setCell", "setRange", "cell", "range", "value")):
+            return _spreadsheet_error(
+                "Wrap operations inside an `operations` array. "
+                'Example: {"operations": [{"op": "setCell", "cell": "A1", "value": "hello"}]}'
+            )
+        return _spreadsheet_error(
+            "Missing `operations` array. "
+            'Format: {"operations": [{"op": "setCell|setRange|...", ...}]}'
+        )
+
+    if not isinstance(operations, list):
+        return _spreadsheet_error("`operations` must be an array (list), not a single object.")
+
+    try:
+        selected = get_selected_sheet()
+        updated, summary = apply_spreadsheet_ops(snapshot, operations, selected_sheet=selected)
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {"summary": summary, "sheetCount": len(_sheet_names(updated)), "snapshot": updated},
+                        separators=(",", ":"),
+                    ),
+                }
+            ]
+        }
+    except Exception as exc:
+        logger.exception("edit_spreadsheet handler failed")
+        return _spreadsheet_error(str(exc))
+
+
+def build_edit_spreadsheet_mcp_server() -> tuple[str, Any] | None:
+    """Build the in-process MCP server for the Claude Agent SDK.
+
+    Returns (server_name, server_config) or None if the SDK is unavailable.
+    Always registered — the handler returns an error when no editing session
+    is active, so the agent won't use it outside the spreadsheet editing context.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; edit_spreadsheet MCP disabled")
+        return None
+
+    @tool(
+        "edit_spreadsheet",
+        (
+            "Edit the current spreadsheet by performing operations on cells, "
+            "ranges, rows, columns, and sheets. "
+            "Use this when the user asks you to edit, populate, format, or "
+            "restructure a spreadsheet they have open in the editor.\n\n"
+            "You MUST call it with an `operations` array. Each item must have "
+            "an `op` field set to one of: setCell, setRange, setFormula, "
+            "clearRange, insertRows, deleteRows, insertColumns, deleteColumns, "
+            "insertSheet, deleteSheet, renameSheet, mergeCells, replaceAll.\n\n"
+            "EXACT format (copy this pattern):\n"
+            '{"operations": [\n'
+            '  {"op": "setCell", "cell": "A1", "value": "Revenue"},\n'
+            '  {"op": "setRange", "range": "B1:D1", "values": [["Q1","Q2","Q3"]]},\n'
+            '  {"op": "setFormula", "cell": "B6", "formula": "=SUM(B2:B5)"},\n'
+            '  {"op": "clearRange", "range": "E2:F10"},\n'
+            '  {"op": "insertRows", "sheet": "Sheet1", "atRow": 2, "count": 1},\n'
+            '  {"op": "deleteColumns", "sheet": "Sheet1", "atCol": "C", "count": 1},\n'
+            '  {"op": "insertSheet", "name": "Summary"},\n'
+            '  {"op": "renameSheet", "name": "Sheet1", "newName": "Data"},\n'
+            '  {"op": "mergeCells", "range": "A1:B1"},\n'
+            '  {"op": "replaceAll", "snapshot": {...}}\n'
+            "]}\n\n"
+            "RULES:\n"
+            "- Cell references use A1 notation: 'B5', 'A1', 'Sheet1!D10'\n"
+            "- Ranges use A1 notation: 'A1:C10', 'B2:D2'\n"
+            "- Row indices are 0-based (row 0 = row 1 in the UI)\n"
+            "- Column reference 'atCol' uses letters: 'A', 'B', 'C', ...\n"
+            "- Values can be strings, numbers, or booleans\n"
+            "- For cross-sheet references in formulas, use 'SheetName!A1'\n"
+            "- The `sheet` field in operations is optional; defaults to the "
+            "active sheet if omitted\n"
+            "- Sparse is fine — you don't need to fill every cell. Only set "
+            "cells that have meaningful data.\n\n"
+            "IMPORTANT: The field is `op` (not operation or action). "
+            "Everything goes inside the `operations` array — not at top level."
+        ),
+        {
+            "operations": list,
+        },
+    )
+    async def edit_spreadsheet(args):
+        return await _edit_spreadsheet_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[edit_spreadsheet],
+    )
+    return SERVER_NAME, server


### PR DESCRIPTION
## Summary

  Adds the file editing pipeline to PocketPaw Cloud: versioned inline saves,
  AI-powered document editing via Editor.js blocks, and the enterprise agent
  chat service that ties scope resolution, history rehydration, and
  knowledge-base context into every chat stream.

  ## What's new

  ### File versioning (`ee/cloud/file_versions/`)
  - **`POST /files/write`** — create or overwrite a file, returns a `fileId` for
   subsequent versioned saves
  - **`PUT /files/{id}`** — inline save; archives the previous blob as a `FileVersionDoc`, bumps the
   counter, emits `file.updated`
  - **`GET /files/{id}/versions`** — paginated version list (content omitted)
  - **`GET /files/{id}/versions/{vid}`** — single version with full content
  (revert preview / diff)

  - 4-file shape: `domain.py` (frozen `FileVersion` dataclass) → `dto.py` (10
  request/response schemas) → `service.py` → `router.py`

  ### AI document editing (`src/pocketpaw/tools/builtin/edit_document.py`)
  - **`POST /files/{id}/ai-edit`** — sends the full Editor.js JSON + user prompt to the workspace agent; the agent calls the `edit_document` MCP tool to mutate blocks in-place, returns the final block array to the frontend for clean `blocks.render()`
  - **`edit_document` MCP tool** — registered on every Claude SDK agent run; the handler validates operations (`update`, `insert`, `delete`, `move`, `replaceAll`), generates block IDs for inserts, and returns the updated document state
  - **`EditDocumentTool(BaseTool)`** — same logic for non-SDK backends (OpenAI, Google ADK, etc.)
  - **Block type registry** — `BLOCK_TYPE_SCHEMAS` maps 22 Editor.js block types (paragraph, header, list, code, table, etc.) to their data shapes so the system prompt tells the agent exactly what each block looks like
  - **Per-request session** — blocks live in a `ContextVar` + module-level dict fallback so the MCP handler can reach them regardless of SDK dispatch path