### PR TITLE
fix(pockets): close three system-prompt gaps RFC 04/05 testing surfaced

### DIFF
--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -269,15 +269,52 @@ Concrete shape of the assistant turn for a create:
   3. (After tool returns) one-to-two-sentence confirmation or failure
      message — see rules below.
 
+## HARD RULE — TEMPLATE PREFLIGHT before every create
+
+Before EVERY `pocket_specialist__create` call — BEFORE the recipe
+preflight below — check whether the brief matches one of PocketPaw's
+built-in pocket templates. A template is a hand-authored,
+production-quality skeleton; instantiating one is faster and
+higher-quality than cold generation OR a recipe anchor. Templates
+auto-install to ``~/.pocketpaw/templates/``.
+
+Run via your Bash tool:
+
+```
+cat ~/.pocketpaw/templates/index.json
+```
+
+The file is ``{"templates": [{slug, title, shape, pattern, keywords,
+connectors_hint}, ...]}``. Lower-case the brief and check whether ANY
+of each template's ``keywords`` appears as a case-insensitive SUBSTRING
+of the brief.
+
+- **Match found** — set ``hints.template_id`` to the matched template's
+  ``slug``. Announce it in your preface line: "Using the built-in
+  <title> template — customizing it for <user's domain>." Then SKIP
+  the recipe preflight below (the template already encodes a polished
+  composition). Pass the brief through anyway so the specialist
+  customizes the template with the user's real content.
+
+- **No match** — proceed to the recipe preflight below. The template
+  library covers the most common shapes; many briefs won't match one.
+
+- **``index.json`` missing / cat errors** — proceed to the recipe
+  preflight. Do not block the user on infrastructure issues.
+
+The first match wins — don't agonize over picking the "best" of two
+candidates; pick the first whose keyword matched.
+
 ## HARD RULE — RECIPE PREFLIGHT before every create
 
-Before EVERY `pocket_specialist__create` call, run a recipe-library
-search via your Bash tool. PocketPaw ships pre-compiled pattern
-recipes (sales-pipeline dashboard, customer-support app, recipe/how-to
-viewer, etc.) in the ``ripple-recipes`` kb-go scope. Each recipe has
-the showcase-quality composition for that pattern + adjacent-domain
-variations. Anchoring the brief on a matching recipe is the single
-biggest quality lever for the resulting pocket.
+If the TEMPLATE PREFLIGHT above did NOT match a built-in template,
+run a recipe-library search via your Bash tool. PocketPaw ships
+pre-compiled pattern recipes (sales-pipeline dashboard,
+customer-support app, recipe/how-to viewer, etc.) in the
+``ripple-recipes`` kb-go scope. Each recipe has the showcase-quality
+composition for that pattern + adjacent-domain variations. Anchoring
+the brief on a matching recipe is the single biggest quality lever
+for the resulting pocket.
 
 The exact preflight (run this verbatim, substitute the user's intent):
 
@@ -330,7 +367,12 @@ Pass to `pocket_specialist__create`:
            conversation context. The specialist will list existing
            pockets and decide whether to create new or extend.
   hints  — optional. Only set fields the user named explicitly:
-           {name?, description?, color?, icon?, target_pocket_id?}
+           {name?, description?, color?, icon?, target_pocket_id?,
+            template_id?}
+           ``template_id`` — set ONLY when the TEMPLATE PREFLIGHT
+                             above matched a built-in template. Carry
+                             the matched template's ``slug``. Omit
+                             otherwise.
 
 The tool returns {ok, action, pocket, warnings, error, duration_ms,
 backend_used}.
@@ -451,6 +493,33 @@ asked for a frozen snapshot. If you're not sure: put it in state.
 Never ship a stranded user: if the only widget is empty and there is
 no way to populate it from the canvas, you have shipped a broken
 pocket.
+
+INTERACTIVE WIDGETS NEED `bind` AT THE NODE LEVEL — not inside `props`.
+For widgets that must write back to state when the user interacts with
+them (kanban moves cards between columns, calendar drags events,
+checkbox/switch toggles, input/textarea typing, multi-select picking),
+the ``bind`` field sits at the SAME level as ``type`` / ``props`` /
+``id`` — NOT nested inside ``props``. The renderer reads
+``node.bind`` to wire the writeback path. Without it, the widget
+renders but every interaction is a no-op.
+
+  WRONG — read-only render, drag-drop changes evaporate:
+    {"type": "kanban", "props": {"value": "{state.tasks}",
+                                 "columnKey": "status", ...}}
+
+  RIGHT — drag-drop persists to state.tasks:
+    {"type": "kanban", "bind": "state.tasks",
+     "props": {"columns": [...], "columnKey": "status", ...}}
+
+Widgets that REQUIRE a node-level ``bind`` to be functional:
+``kanban``, ``board``, ``calendar``, ``checkbox``, ``switch``,
+``input``, ``textarea``, ``select``, ``combobox``, ``autocomplete``,
+``multi-select``, ``radio-group``, ``slider``, ``rating``,
+``date-picker``, ``time-picker``, ``otp-input``.
+
+A read-only display widget (``text``, ``heading``, ``badge``, ``chart``,
+``table`` when not editable) does NOT need a node-level ``bind`` —
+expressions like ``{state.foo}`` inside ``props`` are fine for those.
 </interactive-by-default>
 """
 
@@ -491,6 +560,15 @@ When the user wants live data from THEIR OWN backend (a CRM, an internal
 API, a service with a base URL + token) — not the workspace `$source`
 markers above — declare a `sources` block in the rippleSpec. Alpha is
 READ-ONLY: GET bindings only.
+
+HARD RULE — label without source = broken. If a widget label or
+subtitle names a backend path ("Live from /pulls", "Pulled from
+/contacts"), the spec MUST also carry the matching ``sources`` entry
+that actually fetches it AND a seeded ``state`` key for the ``bind``
+target. A widget bound to ``{state.pulls}`` with NO source authoring
+``state.pulls`` is a dead widget — it renders empty forever. Always
+pair the three: ``sources["x"] = {path, bind: "state.x", refresh}``
++ ``state.x = []`` + the widget that reads ``{state.x}``.
 
   "rippleSpec": {
     "sources": {
@@ -584,6 +662,16 @@ internal API, a service with a base URL + token) — not the workspace
 `$source` markers — use the `set_source` / `remove_source` ops. Alpha is
 READ-ONLY: GET bindings only. These write the pocket's top-level
 `rippleSpec.sources` block; the state/node ops cannot.
+
+HARD RULE — label without `set_source` = broken. If you add a widget
+whose label or subtitle names a backend path ("Live from /pulls",
+"Pulled from /contacts"), you MUST call ``set_source`` in the SAME op
+batch to author the matching binding AND ``set_state`` to seed the
+``bind`` target. A widget bound to ``{state.pulls}`` with no
+``set_source`` for that path is a dead widget — it renders empty
+forever. The three calls always travel together: ``set_source(key, path,
+bind="state.x", refresh=[...])`` + ``set_state("x", [])`` + the
+``add_node`` for the widget that reads ``{state.x}``.
 
   set_source(
     source_key="prs",            # the sources map key

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -512,8 +512,8 @@ renders but every interaction is a no-op.
      "props": {"columns": [...], "columnKey": "status", ...}}
 
 Widgets that REQUIRE a node-level ``bind`` to be functional:
-``kanban``, ``board``, ``calendar``, ``checkbox``, ``switch``,
-``input``, ``textarea``, ``select``, ``combobox``, ``autocomplete``,
+``kanban`` (alias ``board``), ``calendar``, ``checkbox``, ``switch``,
+``input``, ``textarea``, ``select``, ``combobox``,
 ``multi-select``, ``radio-group``, ``slider``, ``rating``,
 ``date-picker``, ``time-picker``, ``otp-input``.
 

--- a/tests/unit/test_pocket_delegation_rule_gaps.py
+++ b/tests/unit/test_pocket_delegation_rule_gaps.py
@@ -26,10 +26,10 @@ from __future__ import annotations
 # the new author sees the content rules need to move too — that is the
 # whole point of pinning them at the source.
 from pocketpaw.ripple._pockets import (
-    POCKET_DELEGATION_RULE,
     _INTERACTIVE_DEFAULT_BLOCK,
     _LIVE_DATA_SOURCES_BLOCK,
     _LIVE_DATA_SOURCES_EDIT_BLOCK,
+    POCKET_DELEGATION_RULE,
 )
 
 

--- a/tests/unit/test_pocket_delegation_rule_gaps.py
+++ b/tests/unit/test_pocket_delegation_rule_gaps.py
@@ -19,6 +19,12 @@
 
 from __future__ import annotations
 
+# Intentional private-attribute import: this file is a CONTENT regression
+# guard for prompt blocks that are deliberately not part of
+# ``pocketpaw.ripple``'s public surface. If a future refactor renames or
+# relocates these constants, the test should fail loud (ImportError) so
+# the new author sees the content rules need to move too — that is the
+# whole point of pinning them at the source.
 from pocketpaw.ripple._pockets import (
     POCKET_DELEGATION_RULE,
     _INTERACTIVE_DEFAULT_BLOCK,

--- a/tests/unit/test_pocket_delegation_rule_gaps.py
+++ b/tests/unit/test_pocket_delegation_rule_gaps.py
@@ -1,0 +1,133 @@
+# tests/unit/test_pocket_delegation_rule_gaps.py
+# 2026-05-23 — Cover three system-prompt gaps surfaced by RFC 04/05
+# end-to-end testing:
+#   - inc 2a: STEP 0 template-library check was only in the heavy
+#     creation_prompt, missing from POCKET_DELEGATION_RULE → MCP
+#     backends never read the built-in templates.
+#   - inc 2b follow-up: the live-data-sources guidance didn't make
+#     "label-without-source = broken" explicit, so the specialist
+#     wrote endpoint paths into widget labels but skipped the
+#     ``set_source`` op that actually fetches.
+#   - kanban-bind: the interactive-by-default block documented
+#     ``bind:`` but didn't make node-level placement loud enough,
+#     so kanban widgets rendered without a writeback path.
+#
+# These are content assertions, not behavior tests — the model still
+# has to read and follow the rules. But each gap has a concrete
+# regression case behind it, and a content drift is the easiest way
+# to lose them again.
+
+from __future__ import annotations
+
+from pocketpaw.ripple._pockets import (
+    POCKET_DELEGATION_RULE,
+    _INTERACTIVE_DEFAULT_BLOCK,
+    _LIVE_DATA_SOURCES_BLOCK,
+    _LIVE_DATA_SOURCES_EDIT_BLOCK,
+)
+
+
+class TestTemplatePreflight:
+    """STEP 0 must be wired into the delegation rule, not only the heavy
+    creation prompt — MCP backends always read the delegation rule."""
+
+    def test_template_preflight_section_present(self):
+        assert "TEMPLATE PREFLIGHT" in POCKET_DELEGATION_RULE
+
+    def test_template_preflight_runs_before_recipe(self):
+        idx_template = POCKET_DELEGATION_RULE.find("TEMPLATE PREFLIGHT")
+        idx_recipe = POCKET_DELEGATION_RULE.find("RECIPE PREFLIGHT")
+        assert idx_template != -1 and idx_recipe != -1
+        assert idx_template < idx_recipe, (
+            "template preflight must precede recipe preflight in the rule"
+        )
+
+    def test_index_json_path_present(self):
+        # The agent reads this file via Bash; the path must appear verbatim.
+        assert "~/.pocketpaw/templates/index.json" in POCKET_DELEGATION_RULE
+
+    def test_keyword_substring_match_rule(self):
+        assert "case-insensitive SUBSTRING" in POCKET_DELEGATION_RULE
+
+    def test_hints_doc_lists_template_id(self):
+        # The hints schema doc must teach the chat agent that template_id
+        # is a legitimate hint to pass — without it the agent would never
+        # forward the preflight match to the specialist.
+        assert "template_id" in POCKET_DELEGATION_RULE
+        # And explicitly anchor it to the matched slug, not arbitrary text.
+        assert "matched template" in POCKET_DELEGATION_RULE.lower() or (
+            "the matched template" in POCKET_DELEGATION_RULE
+            or "the matched" in POCKET_DELEGATION_RULE
+        )
+
+    def test_match_skips_recipe_preflight(self):
+        # The rule must tell the agent to SKIP the recipe preflight on a
+        # template match — otherwise both fire on every create, doubling
+        # bash work and confusing the brief.
+        # Whitespace-normalised so line-wrapping doesn't break the assert.
+        flat = " ".join(POCKET_DELEGATION_RULE.split())
+        assert "SKIP the recipe preflight" in flat
+
+
+class TestLabelWithoutSourceRule:
+    """The specialist authored ``state.pets``-bound widgets and labels
+    like "Live from /pet/findByStatus" but skipped ``set_source``. The
+    label/source pairing rule must be loud in both the create-variant
+    block (whole-spec authoring) and the edit-variant block (granular
+    ops via set_source)."""
+
+    def test_create_block_pairs_label_with_source(self):
+        assert "label without source" in _LIVE_DATA_SOURCES_BLOCK.lower()
+
+    def test_edit_block_pairs_label_with_set_source(self):
+        assert "label without `set_source`" in _LIVE_DATA_SOURCES_EDIT_BLOCK or (
+            "label without ``set_source``" in _LIVE_DATA_SOURCES_EDIT_BLOCK
+        )
+
+    def test_create_block_names_the_three_required_pieces(self):
+        # source entry + state seed + widget — all three must be named
+        # as the unit so the LLM doesn't ship two-of-three.
+        assert "bind" in _LIVE_DATA_SOURCES_BLOCK
+        assert "state" in _LIVE_DATA_SOURCES_BLOCK
+        assert "refresh" in _LIVE_DATA_SOURCES_BLOCK
+
+    def test_edit_block_names_set_source_set_state_add_node(self):
+        # The edit specialist uses granular ops; all three op names must
+        # appear in the pairing rule.
+        assert "set_source" in _LIVE_DATA_SOURCES_EDIT_BLOCK
+        assert "set_state" in _LIVE_DATA_SOURCES_EDIT_BLOCK
+        assert "add_node" in _LIVE_DATA_SOURCES_EDIT_BLOCK
+
+
+class TestInteractiveBindRule:
+    """Kanban (and other stateful interactive widgets) rendered without
+    writeback because the spec carried ``props.value: "{state.tasks}"``
+    instead of ``node.bind: "state.tasks"``. The interactive-by-default
+    block must call this out explicitly."""
+
+    def test_block_calls_out_node_level_bind(self):
+        assert "node level" in _INTERACTIVE_DEFAULT_BLOCK.lower() or (
+            "NODE LEVEL" in _INTERACTIVE_DEFAULT_BLOCK
+        )
+
+    def test_block_carries_wrong_and_right_examples(self):
+        # The contrasting examples are what stop the model from nesting
+        # bind inside props — a rule without the visual diff doesn't
+        # land.
+        assert "WRONG" in _INTERACTIVE_DEFAULT_BLOCK
+        assert "RIGHT" in _INTERACTIVE_DEFAULT_BLOCK
+
+    def test_block_enumerates_widgets_that_need_node_bind(self):
+        # The list anchors the rule to the actual catalog — if the model
+        # doesn't recognize the widget, it won't apply the rule.
+        for widget_type in ("kanban", "calendar", "checkbox", "input", "select"):
+            assert widget_type in _INTERACTIVE_DEFAULT_BLOCK, (
+                f"{widget_type} missing from the interactive-bind enumeration"
+            )
+
+    def test_block_says_read_only_widgets_dont_need_bind(self):
+        # Without this caveat the model over-applies ``bind:`` to
+        # display-only widgets, which the renderer warns about and
+        # which clutters specs.
+        block_lower = _INTERACTIVE_DEFAULT_BLOCK.lower()
+        assert "read-only" in block_lower or "does not need" in block_lower


### PR DESCRIPTION
## What

Three holes in the chat / specialist system prompts that the RFC 04/05 end-to-end walk surfaced. All three live in `src/pocketpaw/ripple/_pockets.py` and ride one PR because they share the same audience and assertion style.

### 1. STEP 0 template preflight was only in the heavy creation_prompt

`POCKET_DELEGATION_RULE` — the slim prompt MCP backends (`claude_agent_sdk`, etc.) always read — never got the template-library check. A "create a todo dashboard" brief skipped the built-in `~/.pocketpaw/templates/` lookup and went straight to cold LLM generation. The chat said _"Building a todo dashboard now — I'll fetch the widget specs..."_ instead of _"Using the built-in to-do template..."_.

Fix: port the STEP 0 block in before the existing RECIPE PREFLIGHT, add `template_id` to the documented `hints` schema so the chat agent has somewhere to forward the match.

### 2. Live-data-sources blocks didn't make "label without source = broken" loud

The specialist routinely wrote endpoint paths into widget subtitles (_"Live from PetStore backend · /pet/findByStatus..."_) and skipped the `set_source` op that actually fetches. The bound `state.pets` stayed `[]` forever — table rendered "No results" even though the chat described "12 preloaded pets."

Fix: add an explicit HARD RULE to both `_LIVE_DATA_SOURCES_BLOCK` (create) and `_LIVE_DATA_SOURCES_EDIT_BLOCK` (edit) requiring the source + state seed + widget triple to travel together.

### 3. `_INTERACTIVE_DEFAULT_BLOCK` documented `bind:` but not its placement

The block said kanban / calendar etc. need `"bind": "<key>"`, but the wording let the model put it inside `props`. Specialist authored `{"type": "kanban", "props": {"value": "{state.tasks}", ...}}` — readable but no writeback path, so drag-drop moves between columns evaporated.

Fix: add a contrasted WRONG/RIGHT pair plus an enumerated list of widgets that need node-level `bind` to function (`kanban`, `board`, `calendar`, `checkbox`, `switch`, `input`, …). Includes the "read-only widgets don't need it" caveat so the rule doesn't over-fire.

## Tests

`tests/unit/test_pocket_delegation_rule_gaps.py` — 14 content assertions covering each gap. Content-level, not behavior-level — the model still has to read and follow the rules. But each gap has a concrete regression case behind it and content drift is the easy way to lose them.

## Test plan

- [x] `uv run pytest tests/unit/test_pocket_delegation_rule_gaps.py` — 14/14 pass
- [x] `uv run pytest tests/ -k "ripple or pocket or delegat or template" --ignore=tests/e2e` — 470 passed, 0 failures (no regression in adjacent prompt assertions, including the cache-prefix test)

## Sibling PRs

- #1190 (pocket edit visibility) and #1191 (agent SSE empty-stream fix) — same RFC 04/05 testing pass. Independent of this one; merge order doesn't matter.