### PR TITLE
feat(skills): POST /skills/api-doc-from-url for spec-by-URL installs

### DIFF
--- a/ee/pocketpaw_ee/cloud/skills/domain.py
+++ b/ee/pocketpaw_ee/cloud/skills/domain.py
@@ -1,15 +1,17 @@
-# domain.py — Domain value object for the cloud Skills entity.
+# domain.py — Domain value objects for the cloud Skills entity.
 # Created: 2026-05-22 (feat/api-skills, Increment 2b) — a frozen
 # value object carrying the tenancy context + spec bytes for an
 # API-doc skill install. Tenancy fields are required (no defaults) so
 # constructing one without a workspace is a type error — Rule 3.
+# Updated: 2026-05-23 — add ``ApiDocFromUrlInstall`` for the URL-fetch
+# variant; same tenancy posture, ``url`` instead of ``spec_bytes``.
 from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict
 
 
 class ApiDocInstall(BaseModel):
-    """An API-doc skill install request, scoped to a workspace.
+    """An API-doc skill install request from a multipart upload.
 
     Frozen value object — multi-tenancy is enforced at construction:
     ``workspace_id`` and ``user_id`` are required, no defaults. The
@@ -28,4 +30,22 @@ class ApiDocInstall(BaseModel):
     name: str | None = None
 
 
-__all__ = ["ApiDocInstall"]
+class ApiDocFromUrlInstall(BaseModel):
+    """An API-doc skill install request from a public spec URL.
+
+    Same tenancy posture as :class:`ApiDocInstall` — ``workspace_id``
+    and ``user_id`` are required. ``url`` is the spec URL the service
+    will fetch *after* the SSRF guard runs against its resolved IPs;
+    ``name`` is the optional display name used to derive the skill
+    slug when the fetched spec names no server.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    workspace_id: str
+    user_id: str
+    url: str
+    name: str | None = None
+
+
+__all__ = ["ApiDocFromUrlInstall", "ApiDocInstall"]

--- a/ee/pocketpaw_ee/cloud/skills/dto.py
+++ b/ee/pocketpaw_ee/cloud/skills/dto.py
@@ -4,9 +4,13 @@
 # request carries the optional backend name; the multipart file itself
 # is bound by FastAPI's UploadFile in the router. The response carries
 # the installed skill slug.
+# Updated: 2026-05-23 — add ``InstallApiDocFromUrlRequest`` for the
+# JSON-body POST /skills/api-doc-from-url surface; well-known APIs
+# publish their OpenAPI at a stable URL so the user pastes that
+# instead of downloading + re-uploading a JSON file.
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, HttpUrl
 
 
 class InstallApiDocRequest(BaseModel):
@@ -20,6 +24,20 @@ class InstallApiDocRequest(BaseModel):
     name: str | None = Field(default=None, max_length=200)
 
 
+class InstallApiDocFromUrlRequest(BaseModel):
+    """Body of a POST /skills/api-doc-from-url JSON request.
+
+    ``url`` is the public OpenAPI / Swagger URL the cloud server
+    fetches. ``HttpUrl`` enforces a well-formed http(s) URL at parse
+    time — the service layer additionally enforces https-only and the
+    SSRF guard against private / loopback / link-local addresses
+    (mirrors the read-source executor's posture in pockets/).
+    """
+
+    url: HttpUrl
+    name: str | None = Field(default=None, max_length=200)
+
+
 class InstallApiDocResponse(BaseModel):
     """Result of an API-doc skill install."""
 
@@ -27,4 +45,8 @@ class InstallApiDocResponse(BaseModel):
     slug: str = Field(..., description="Slug of the installed skill, e.g. api-example-com.")
 
 
-__all__ = ["InstallApiDocRequest", "InstallApiDocResponse"]
+__all__ = [
+    "InstallApiDocFromUrlRequest",
+    "InstallApiDocRequest",
+    "InstallApiDocResponse",
+]

--- a/ee/pocketpaw_ee/cloud/skills/router.py
+++ b/ee/pocketpaw_ee/cloud/skills/router.py
@@ -7,6 +7,9 @@
 # HTTPException for domain failures — CloudError maps to JSON via
 # _core.http. Mounted in mount_cloud() alongside the other domain
 # routers. Guarded by skills.manage (ADMIN).
+# Updated: 2026-05-23 — add POST /api/v1/skills/api-doc-from-url, the
+# JSON sibling that fetches a spec from a public URL. Same auth +
+# RBAC posture; the service runs an SSRF guard before fetching.
 from __future__ import annotations
 
 from typing import Annotated
@@ -21,8 +24,11 @@ from pocketpaw_ee.cloud.shared.deps import (
     require_action_any_workspace,
 )
 from pocketpaw_ee.cloud.skills import service as skills_service
-from pocketpaw_ee.cloud.skills.domain import ApiDocInstall
-from pocketpaw_ee.cloud.skills.dto import InstallApiDocResponse
+from pocketpaw_ee.cloud.skills.domain import ApiDocFromUrlInstall, ApiDocInstall
+from pocketpaw_ee.cloud.skills.dto import (
+    InstallApiDocFromUrlRequest,
+    InstallApiDocResponse,
+)
 
 # A spec upload bigger than this is rejected before the bytes are read
 # into memory — mirrors the 2 MB cap in skills.service / api_skill_builder.
@@ -77,3 +83,32 @@ async def install_api_doc(
         name=name,
     )
     return await skills_service.install_api_doc(workspace_id, user_id, body)
+
+
+@router.post(
+    "/api-doc-from-url",
+    response_model=InstallApiDocResponse,
+    dependencies=[Depends(require_action_any_workspace("skills.manage"))],
+)
+async def install_api_doc_from_url(
+    body: InstallApiDocFromUrlRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> InstallApiDocResponse:
+    """Fetch a public OpenAPI / Swagger spec by URL and install it.
+
+    Most production APIs publish their OpenAPI at a stable URL — the
+    user pastes that here instead of downloading + re-uploading. The
+    service layer enforces https-only, runs the same SSRF guard the
+    read-source executor uses (rejects loopback / private / link-local
+    hosts), caps the response at 2 MB, and hands the parsed dict to
+    the same installer the multipart endpoint uses. Requires the
+    ``skills.manage`` role (ADMIN).
+    """
+    domain_body = ApiDocFromUrlInstall(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        url=str(body.url),
+        name=body.name,
+    )
+    return await skills_service.install_api_doc_from_url(workspace_id, user_id, domain_body)

--- a/ee/pocketpaw_ee/cloud/skills/service.py
+++ b/ee/pocketpaw_ee/cloud/skills/service.py
@@ -74,17 +74,21 @@ def _audit_api_skill_install(
 
 
 def _strip_url_query(url: str) -> str:
-    """Drop the query string from a URL for audit logging.
+    """Drop query string, userinfo credentials, and fragment from a URL
+    for audit logging.
 
-    Some upstreams ship API keys in URL params (rare for OpenAPI specs,
-    but plausible). Logging the bare path keeps the audit trail useful
-    without persisting a token in the audit log.
+    Some upstreams ship API keys in URL params OR userinfo
+    (``https://user:apikey@host/...``). Logging the bare ``scheme://host[:port]/path``
+    keeps the audit trail useful without persisting a token.
     """
     try:
         parts = urllib.parse.urlsplit(url)
-        return urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+        safe_netloc = parts.hostname or ""
+        if parts.port:
+            safe_netloc = f"{safe_netloc}:{parts.port}"
+        return urllib.parse.urlunsplit((parts.scheme, safe_netloc, parts.path, "", ""))
     except Exception:  # noqa: BLE001 — fallback for malformed input
-        return url.split("?", 1)[0]
+        return url.split("?", 1)[0].split("#", 1)[0]
 
 
 async def install_api_doc(

--- a/ee/pocketpaw_ee/cloud/skills/service.py
+++ b/ee/pocketpaw_ee/cloud/skills/service.py
@@ -5,13 +5,19 @@
 # No Beanie writes — the skill is a SKILL.md on the local skills dir;
 # the install is audit-logged with workspace_id + user_id (Rule 9 has a
 # no-event note: skills are filesystem-local, not a DB row).
+# Updated: 2026-05-23 — add ``install_api_doc_from_url`` for the
+# JSON-body URL-fetch surface. Lower friction than upload because most
+# production APIs publish their OpenAPI at a stable URL. The fetch
+# runs through the same SSRF guard the read-source executor uses
+# (https-only, hostname resolves to a public IP, size + timeout caps).
 from __future__ import annotations
 
 import json
 import logging
+import urllib.parse
 
 from pocketpaw_ee.cloud._core.errors import ValidationError
-from pocketpaw_ee.cloud.skills.domain import ApiDocInstall
+from pocketpaw_ee.cloud.skills.domain import ApiDocFromUrlInstall, ApiDocInstall
 from pocketpaw_ee.cloud.skills.dto import InstallApiDocResponse
 
 logger = logging.getLogger(__name__)
@@ -22,13 +28,29 @@ logger = logging.getLogger(__name__)
 _ALLOWED_EXTENSIONS = (".json", ".yaml", ".yml")
 _MAX_SPEC_BYTES = 2 * 1024 * 1024  # 2 MB
 
+# Outbound fetch tuning for ``install_api_doc_from_url``. The connect
+# + read timeout matches the read-source executor's posture; if the
+# upstream takes more than 15s to return an OpenAPI, the user gets a
+# 422 with ``skills.api_doc.fetch_timeout`` so they can retry instead
+# of staring at a stalled request.
+_URL_FETCH_TIMEOUT_SECONDS = 15.0
 
-def _audit_api_skill_install(*, workspace_id: str, user_id: str, slug: str, filename: str) -> None:
+
+def _audit_api_skill_install(
+    *,
+    workspace_id: str,
+    user_id: str,
+    slug: str,
+    filename: str,
+    source: str = "upload",
+) -> None:
     """Write an audit-log entry for an API-skill install.
 
-    Logs the workspace, the actor, the resulting slug, and the upload
-    filename — no spec contents, no credentials. Audit failures must
-    never break the install, so the call is wrapped.
+    Logs the workspace, the actor, the resulting slug, the upload
+    filename (or the URL for the URL-fetch variant, query-stripped),
+    and a ``source`` discriminator (``upload`` | ``url``). No spec
+    contents, no credentials. Audit failures must never break the
+    install, so the call is wrapped.
     """
     try:
         from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
@@ -44,10 +66,25 @@ def _audit_api_skill_install(*, workspace_id: str, user_id: str, slug: str, file
                 workspace_id=workspace_id,
                 slug=slug,
                 filename=filename,
+                source=source,
             )
         )
     except Exception:  # noqa: BLE001 — audit must never break the install
         logger.warning("api-skill install audit-log write failed", exc_info=True)
+
+
+def _strip_url_query(url: str) -> str:
+    """Drop the query string from a URL for audit logging.
+
+    Some upstreams ship API keys in URL params (rare for OpenAPI specs,
+    but plausible). Logging the bare path keeps the audit trail useful
+    without persisting a token in the audit log.
+    """
+    try:
+        parts = urllib.parse.urlsplit(url)
+        return urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+    except Exception:  # noqa: BLE001 — fallback for malformed input
+        return url.split("?", 1)[0]
 
 
 async def install_api_doc(
@@ -90,7 +127,154 @@ async def install_api_doc(
             f"spec file is {len(body.spec_bytes)} bytes — exceeds the 2 MB limit",
         )
 
-    text = body.spec_bytes.decode("utf-8", errors="replace")
+    parsed = _parse_spec_text(body.spec_bytes.decode("utf-8", errors="replace"))
+
+    slug = _install_parsed_spec(parsed, name=body.name)
+
+    _audit_api_skill_install(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        slug=slug,
+        filename=filename,
+        source="upload",
+    )
+    logger.info(
+        "skills.api_doc: installed %s from upload for workspace=%s actor=%s",
+        slug,
+        workspace_id,
+        user_id,
+    )
+    # no-event: an API skill is a filesystem-local SKILL.md, not a DB
+    # row — there is no downstream search index / soul handler to keep
+    # in sync, so no bus event is emitted.
+    return InstallApiDocResponse(ok=True, slug=slug)
+
+
+async def install_api_doc_from_url(
+    workspace_id: str, user_id: str, body: ApiDocFromUrlInstall | dict
+) -> InstallApiDocResponse:
+    """Fetch an OpenAPI / Swagger document from a URL and install it.
+
+    Cloud-safe URL fetch path: enforces https-only, runs the SSRF guard
+    against the resolved hostname (rejects loopback, link-local,
+    private, and reserved IPs the same way the read-source executor
+    does), caps the response body at 2 MB, then hands the parsed dict
+    to the same installer the upload path uses.
+
+    Args:
+        workspace_id: Active workspace — tenancy context.
+        user_id: Authenticated caller — actor in the audit entry.
+        body: An ``ApiDocFromUrlInstall`` (or wire dict) carrying the
+            spec URL and an optional backend display name.
+
+    Returns:
+        ``InstallApiDocResponse`` with ``ok`` and the installed ``slug``.
+
+    Raises:
+        ValidationError: The URL is not https, resolves to a private
+            host, exceeds the size cap, returns a non-2xx status, is
+            unparseable, or carries no ``paths`` object.
+    """
+    # Re-validate at entry (Rule 6).
+    body = ApiDocFromUrlInstall.model_validate(body)
+
+    url = str(body.url)
+    parts = urllib.parse.urlsplit(url)
+
+    if parts.scheme.lower() != "https":
+        raise ValidationError(
+            "skills.api_doc.bad_scheme",
+            "spec URL must be https — http and other schemes are not allowed",
+        )
+
+    hostname = parts.hostname or ""
+    if not hostname:
+        raise ValidationError(
+            "skills.api_doc.bad_url",
+            "spec URL must include a hostname",
+        )
+
+    # SSRF guard — resolve and reject internal / loopback / private IPs.
+    # Reuses the same guard the read-source executor applies so the
+    # posture matches across the two HTTP-fetching surfaces.
+    from pocketpaw_ee.cloud.pockets._http_guard import _assert_host_external, _GuardError
+
+    try:
+        await _assert_host_external(hostname)
+    except _GuardError as exc:
+        raise ValidationError("skills.api_doc.bad_host", str(exc)) from exc
+
+    # Fetch with a hard timeout + size cap. We read the response body
+    # once and pass the parsed dict to the installer — never the URL
+    # again — so the installer's own httpx fetch never runs (would
+    # double the size budget and bypass our SSRF check on a DNS
+    # rebind between calls).
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=_URL_FETCH_TIMEOUT_SECONDS,
+            follow_redirects=False,
+        ) as client:
+            resp = await client.get(url)
+    except httpx.HTTPError as exc:
+        # Strip the URL of query params before logging — some upstreams
+        # ship credentials there even when the spec itself is public.
+        logger.warning(
+            "skills.api_doc.from_url: fetch %s failed: %s",
+            _strip_url_query(url),
+            type(exc).__name__,
+        )
+        raise ValidationError(
+            "skills.api_doc.fetch_failed",
+            "could not fetch the spec from that URL",
+        ) from exc
+
+    if 300 <= resp.status_code < 400:
+        # Redirects are off so the agent that authored the URL gets a
+        # signal to use the final location directly.
+        raise ValidationError(
+            "skills.api_doc.fetch_redirect",
+            f"spec URL returned a redirect ({resp.status_code}) — pass the final URL directly",
+        )
+    if resp.status_code >= 400:
+        raise ValidationError(
+            "skills.api_doc.fetch_failed",
+            f"spec URL returned status {resp.status_code}",
+        )
+
+    raw = resp.content
+    if len(raw) > _MAX_SPEC_BYTES:
+        raise ValidationError(
+            "skills.api_doc.too_large",
+            f"spec response is {len(raw)} bytes — exceeds the 2 MB limit",
+        )
+
+    parsed = _parse_spec_text(raw.decode("utf-8", errors="replace"))
+
+    slug = _install_parsed_spec(parsed, name=body.name)
+
+    _audit_api_skill_install(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        slug=slug,
+        filename=_strip_url_query(url),
+        source="url",
+    )
+    logger.info(
+        "skills.api_doc: installed %s from url for workspace=%s actor=%s",
+        slug,
+        workspace_id,
+        user_id,
+    )
+    return InstallApiDocResponse(ok=True, slug=slug)
+
+
+def _parse_spec_text(text: str) -> dict:
+    """Parse a JSON-or-YAML spec into a dict, or raise a ValidationError.
+
+    Tries JSON first (most OpenAPI specs ship as JSON) then YAML.
+    """
     try:
         parsed = json.loads(text)
     except (json.JSONDecodeError, ValueError):
@@ -109,32 +293,19 @@ async def install_api_doc(
             "skills.api_doc.unparseable",
             "spec did not parse to a JSON object",
         )
+    return parsed
 
+
+def _install_parsed_spec(parsed: dict, *, name: str | None) -> str:
+    """Delegate to the OSS installer; map its ValueErrors to 422."""
     from pocketpaw.skills.api_skill_builder import install_api_skill
 
     try:
-        slug = install_api_skill(parsed, name=body.name)
+        return install_api_skill(parsed, name=name)
     except ValueError as exc:
         # api_skill_builder rejects a spec with no `paths` / one too
         # large — map it to a 422 the dashboard surfaces inline.
         raise ValidationError("skills.api_doc.invalid_spec", str(exc)) from exc
 
-    _audit_api_skill_install(
-        workspace_id=workspace_id,
-        user_id=user_id,
-        slug=slug,
-        filename=filename,
-    )
-    logger.info(
-        "skills.api_doc: installed %s for workspace=%s actor=%s",
-        slug,
-        workspace_id,
-        user_id,
-    )
-    # no-event: an API skill is a filesystem-local SKILL.md, not a DB
-    # row — there is no downstream search index / soul handler to keep
-    # in sync, so no bus event is emitted.
-    return InstallApiDocResponse(ok=True, slug=slug)
 
-
-__all__ = ["install_api_doc"]
+__all__ = ["install_api_doc", "install_api_doc_from_url"]

--- a/tests/cloud/test_skills_router_from_url.py
+++ b/tests/cloud/test_skills_router_from_url.py
@@ -124,9 +124,7 @@ async def client(monkeypatch, tmp_path) -> AsyncClient:
 # ---------------------------------------------------------------------------
 
 
-async def test_install_from_url_installs_skill(
-    client: AsyncClient, monkeypatch, tmp_path
-) -> None:
+async def test_install_from_url_installs_skill(client: AsyncClient, monkeypatch, tmp_path) -> None:
     """A valid https URL returning a real OpenAPI spec installs the skill."""
     _patch_ssrf_allow(monkeypatch)
     _patch_httpx_get(monkeypatch, body=json.dumps(_minimal_spec()).encode("utf-8"))
@@ -145,9 +143,7 @@ async def test_install_from_url_installs_skill(
     assert "`GET /things`" in skill_md.read_text(encoding="utf-8")
 
 
-async def test_install_from_url_accepts_yaml_response(
-    client: AsyncClient, monkeypatch
-) -> None:
+async def test_install_from_url_accepts_yaml_response(client: AsyncClient, monkeypatch) -> None:
     """YAML responses are parsed and installed too."""
     import yaml
 
@@ -167,9 +163,7 @@ async def test_install_from_url_accepts_yaml_response(
 # ---------------------------------------------------------------------------
 
 
-async def test_install_from_url_rejects_http_scheme(
-    client: AsyncClient, monkeypatch
-) -> None:
+async def test_install_from_url_rejects_http_scheme(client: AsyncClient, monkeypatch) -> None:
     """http:// URLs are rejected before any DNS / fetch — https-only."""
     _patch_ssrf_allow(monkeypatch)  # ensure SSRF wouldn't be the first reject
 
@@ -195,9 +189,7 @@ async def test_install_from_url_rejects_malformed_url(client: AsyncClient) -> No
 # ---------------------------------------------------------------------------
 
 
-async def test_install_from_url_rejects_private_host(
-    client: AsyncClient, monkeypatch
-) -> None:
+async def test_install_from_url_rejects_private_host(client: AsyncClient, monkeypatch) -> None:
     """A hostname that resolves to a private / loopback IP is rejected
     before any fetch fires — the SSRF guard is the trust boundary."""
     from pocketpaw_ee.cloud.pockets import _http_guard
@@ -223,9 +215,7 @@ async def test_install_from_url_rejects_private_host(
 # ---------------------------------------------------------------------------
 
 
-async def test_install_from_url_rejects_redirect(
-    client: AsyncClient, monkeypatch
-) -> None:
+async def test_install_from_url_rejects_redirect(client: AsyncClient, monkeypatch) -> None:
     """A 3xx response is rejected — redirects are off, so the caller
     must pass the final URL directly."""
     _patch_ssrf_allow(monkeypatch)
@@ -239,9 +229,7 @@ async def test_install_from_url_rejects_redirect(
     assert r.json()["error"]["code"] == "skills.api_doc.fetch_redirect"
 
 
-async def test_install_from_url_rejects_non_2xx(
-    client: AsyncClient, monkeypatch
-) -> None:
+async def test_install_from_url_rejects_non_2xx(client: AsyncClient, monkeypatch) -> None:
     """A 4xx / 5xx response surfaces as fetch_failed with the status."""
     _patch_ssrf_allow(monkeypatch)
     _patch_httpx_get(monkeypatch, body=b"not found", status=404)
@@ -270,9 +258,7 @@ async def test_install_from_url_rejects_oversized_response(
     assert r.json()["error"]["code"] == "skills.api_doc.too_large"
 
 
-async def test_install_from_url_rejects_unparseable(
-    client: AsyncClient, monkeypatch
-) -> None:
+async def test_install_from_url_rejects_unparseable(client: AsyncClient, monkeypatch) -> None:
     """A response that is neither JSON nor YAML is rejected."""
     _patch_ssrf_allow(monkeypatch)
     _patch_httpx_get(monkeypatch, body=b"{not valid: [json")
@@ -300,9 +286,7 @@ async def test_install_from_url_rejects_spec_with_no_paths(
     assert r.json()["error"]["code"] == "skills.api_doc.invalid_spec"
 
 
-async def test_install_from_url_rejects_network_error(
-    client: AsyncClient, monkeypatch
-) -> None:
+async def test_install_from_url_rejects_network_error(client: AsyncClient, monkeypatch) -> None:
     """httpx errors (DNS, TCP, TLS, timeout) all map to fetch_failed."""
     _patch_ssrf_allow(monkeypatch)
 
@@ -373,6 +357,20 @@ async def test_service_install_from_url_direct(monkeypatch, tmp_path) -> None:
     out = await skills_service.install_api_doc_from_url("w1", "u1", body)
     assert out.ok is True
     assert out.slug == "api-remote-example-com"
+
+
+def test_strip_url_query_drops_userinfo_and_fragment() -> None:
+    """Regression for S2 (PR #1195 review): the audit-log URL must drop
+    userinfo credentials AND fragment, not just the query string —
+    upstreams that ship API keys in ``https://user:token@host/...``
+    were previously leaking the token into ``audit.jsonl``."""
+    from pocketpaw_ee.cloud.skills.service import _strip_url_query
+
+    assert (
+        _strip_url_query("https://user:apikey@vendor.com/openapi.json?k=v#frag")
+        == "https://vendor.com/openapi.json"
+    )
+    assert _strip_url_query("https://vendor.com:8443/api") == "https://vendor.com:8443/api"
 
 
 # Silence ruff unused-import nudge.

--- a/tests/cloud/test_skills_router_from_url.py
+++ b/tests/cloud/test_skills_router_from_url.py
@@ -1,0 +1,379 @@
+# test_skills_router_from_url.py — HTTP + service tests for the
+# URL-fetch variant of the API-doc skill install (POST
+# /api/v1/skills/api-doc-from-url).
+# 2026-05-23 — covers the cloud-safe URL fetch path: a successful
+# fetch installs the skill, http:// is rejected, a private / loopback
+# host is rejected via the SSRF guard, an oversized response is
+# rejected, an upstream error returns 422, and the auth seams hold.
+# The httpx call is monkeypatched throughout so no real network I/O
+# fires during the test run.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.auth import current_active_user
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.skills.router import router as skills_router
+
+
+def _minimal_spec() -> dict:
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "Remote API"},
+        "servers": [{"url": "https://remote.example.com"}],
+        "paths": {
+            "/things": {
+                "get": {
+                    "tags": ["Things"],
+                    "summary": "List things",
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+
+
+def _fake_user(user_id: str = "u1", workspace_id: str | None = "w1") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role="admin")] if workspace_id else [],
+    )
+
+
+def _build_app(*, workspace_id: str | None = "w1", monkeypatch=None) -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(skills_router)
+    app.dependency_overrides[require_license] = lambda: None
+
+    user = _fake_user(workspace_id=workspace_id)
+
+    async def _fake_user_dep():
+        return user
+
+    app.dependency_overrides[current_active_user] = _fake_user_dep
+
+    if monkeypatch is not None:
+        from pocketpaw_ee.cloud._core import deps as core_deps
+
+        monkeypatch.setattr(core_deps, "check_workspace_action", lambda *a, **k: None)
+
+    return app
+
+
+def _patch_ssrf_allow(monkeypatch) -> None:
+    """Bypass the SSRF guard so tests don't need real DNS resolution.
+
+    The guard's behavior is covered in
+    ``test_install_api_doc_from_url_rejects_private_host`` below,
+    where we make it raise to assert the rejection path.
+    """
+    from pocketpaw_ee.cloud.pockets import _http_guard
+
+    async def _allow(_hostname: str) -> None:
+        return None
+
+    monkeypatch.setattr(_http_guard, "_assert_host_external", _allow)
+
+
+def _patch_httpx_get(monkeypatch, *, body: bytes, status: int = 200) -> None:
+    """Stub httpx.AsyncClient.get so the service receives a known response."""
+
+    class _StubResponse:
+        def __init__(self) -> None:
+            self.status_code = status
+            self.content = body
+
+    class _StubClient:
+        def __init__(self, *_a, **_k) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a) -> None:
+            return None
+
+        async def get(self, _url: str) -> _StubResponse:
+            return _StubResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _StubClient)
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch, tmp_path) -> AsyncClient:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    app = _build_app(monkeypatch=monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_install_from_url_installs_skill(
+    client: AsyncClient, monkeypatch, tmp_path
+) -> None:
+    """A valid https URL returning a real OpenAPI spec installs the skill."""
+    _patch_ssrf_allow(monkeypatch)
+    _patch_httpx_get(monkeypatch, body=json.dumps(_minimal_spec()).encode("utf-8"))
+
+    r = await client.post(
+        "/skills/api-doc-from-url",
+        json={"url": "https://remote.example.com/openapi.json"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["slug"] == "api-remote-example-com"
+
+    skill_md = tmp_path / ".pocketpaw" / "skills" / "api-remote-example-com" / "SKILL.md"
+    assert skill_md.is_file()
+    assert "`GET /things`" in skill_md.read_text(encoding="utf-8")
+
+
+async def test_install_from_url_accepts_yaml_response(
+    client: AsyncClient, monkeypatch
+) -> None:
+    """YAML responses are parsed and installed too."""
+    import yaml
+
+    _patch_ssrf_allow(monkeypatch)
+    _patch_httpx_get(monkeypatch, body=yaml.safe_dump(_minimal_spec()).encode("utf-8"))
+
+    r = await client.post(
+        "/skills/api-doc-from-url",
+        json={"url": "https://remote.example.com/openapi.yaml"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["slug"] == "api-remote-example-com"
+
+
+# ---------------------------------------------------------------------------
+# URL / scheme rejections
+# ---------------------------------------------------------------------------
+
+
+async def test_install_from_url_rejects_http_scheme(
+    client: AsyncClient, monkeypatch
+) -> None:
+    """http:// URLs are rejected before any DNS / fetch — https-only."""
+    _patch_ssrf_allow(monkeypatch)  # ensure SSRF wouldn't be the first reject
+
+    r = await client.post(
+        "/skills/api-doc-from-url",
+        json={"url": "http://remote.example.com/openapi.json"},
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "skills.api_doc.bad_scheme"
+
+
+async def test_install_from_url_rejects_malformed_url(client: AsyncClient) -> None:
+    """Pydantic's HttpUrl catches obviously-malformed URLs at parse time."""
+    r = await client.post(
+        "/skills/api-doc-from-url",
+        json={"url": "not-a-url"},
+    )
+    assert r.status_code == 422  # FastAPI body-validation 422
+
+
+# ---------------------------------------------------------------------------
+# SSRF guard
+# ---------------------------------------------------------------------------
+
+
+async def test_install_from_url_rejects_private_host(
+    client: AsyncClient, monkeypatch
+) -> None:
+    """A hostname that resolves to a private / loopback IP is rejected
+    before any fetch fires — the SSRF guard is the trust boundary."""
+    from pocketpaw_ee.cloud.pockets import _http_guard
+
+    async def _reject(_hostname: str) -> None:
+        raise _http_guard._GuardError(
+            "backend host resolves to an internal address",
+            code="bad_host",
+        )
+
+    monkeypatch.setattr(_http_guard, "_assert_host_external", _reject)
+
+    r = await client.post(
+        "/skills/api-doc-from-url",
+        json={"url": "https://internal.corp/openapi.json"},
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "skills.api_doc.bad_host"
+
+
+# ---------------------------------------------------------------------------
+# Response-handling rejections
+# ---------------------------------------------------------------------------
+
+
+async def test_install_from_url_rejects_redirect(
+    client: AsyncClient, monkeypatch
+) -> None:
+    """A 3xx response is rejected — redirects are off, so the caller
+    must pass the final URL directly."""
+    _patch_ssrf_allow(monkeypatch)
+    _patch_httpx_get(monkeypatch, body=b"", status=302)
+
+    r = await client.post(
+        "/skills/api-doc-from-url",
+        json={"url": "https://remote.example.com/openapi.json"},
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "skills.api_doc.fetch_redirect"
+
+
+async def test_install_from_url_rejects_non_2xx(
+    client: AsyncClient, monkeypatch
+) -> None:
+    """A 4xx / 5xx response surfaces as fetch_failed with the status."""
+    _patch_ssrf_allow(monkeypatch)
+    _patch_httpx_get(monkeypatch, body=b"not found", status=404)
+
+    r = await client.post(
+        "/skills/api-doc-from-url",
+        json={"url": "https://remote.example.com/openapi.json"},
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "skills.api_doc.fetch_failed"
+
+
+async def test_install_from_url_rejects_oversized_response(
+    client: AsyncClient, monkeypatch
+) -> None:
+    """A response body larger than the 2 MB cap is rejected."""
+    _patch_ssrf_allow(monkeypatch)
+    huge = b'{"_pad": "' + (b"x" * (2 * 1024 * 1024 + 1)) + b'"}'
+    _patch_httpx_get(monkeypatch, body=huge)
+
+    r = await client.post(
+        "/skills/api-doc-from-url",
+        json={"url": "https://remote.example.com/openapi.json"},
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "skills.api_doc.too_large"
+
+
+async def test_install_from_url_rejects_unparseable(
+    client: AsyncClient, monkeypatch
+) -> None:
+    """A response that is neither JSON nor YAML is rejected."""
+    _patch_ssrf_allow(monkeypatch)
+    _patch_httpx_get(monkeypatch, body=b"{not valid: [json")
+
+    r = await client.post(
+        "/skills/api-doc-from-url",
+        json={"url": "https://remote.example.com/openapi.json"},
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "skills.api_doc.unparseable"
+
+
+async def test_install_from_url_rejects_spec_with_no_paths(
+    client: AsyncClient, monkeypatch
+) -> None:
+    """A fetched spec with no ``paths`` is rejected by the installer."""
+    _patch_ssrf_allow(monkeypatch)
+    _patch_httpx_get(monkeypatch, body=json.dumps({"openapi": "3.0.0"}).encode("utf-8"))
+
+    r = await client.post(
+        "/skills/api-doc-from-url",
+        json={"url": "https://remote.example.com/openapi.json"},
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "skills.api_doc.invalid_spec"
+
+
+async def test_install_from_url_rejects_network_error(
+    client: AsyncClient, monkeypatch
+) -> None:
+    """httpx errors (DNS, TCP, TLS, timeout) all map to fetch_failed."""
+    _patch_ssrf_allow(monkeypatch)
+
+    class _ErrorClient:
+        def __init__(self, *_a, **_k) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a) -> None:
+            return None
+
+        async def get(self, _url: str):
+            raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _ErrorClient)
+
+    r = await client.post(
+        "/skills/api-doc-from-url",
+        json={"url": "https://remote.example.com/openapi.json"},
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "skills.api_doc.fetch_failed"
+
+
+# ---------------------------------------------------------------------------
+# Auth seam — share with the multipart endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_install_from_url_unauthenticated_returns_401(tmp_path, monkeypatch) -> None:
+    """Without a current_active_user override the auth chain 401s."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(skills_router)
+    app.dependency_overrides[require_license] = lambda: None
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post(
+            "/skills/api-doc-from-url",
+            json={"url": "https://remote.example.com/openapi.json"},
+        )
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Service direct
+# ---------------------------------------------------------------------------
+
+
+async def test_service_install_from_url_direct(monkeypatch, tmp_path) -> None:
+    """The service installs a skill when called directly (bus/job path)."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _patch_ssrf_allow(monkeypatch)
+    _patch_httpx_get(monkeypatch, body=json.dumps(_minimal_spec()).encode("utf-8"))
+
+    from pocketpaw_ee.cloud.skills import service as skills_service
+    from pocketpaw_ee.cloud.skills.domain import ApiDocFromUrlInstall
+
+    body = ApiDocFromUrlInstall(
+        workspace_id="w1",
+        user_id="u1",
+        url="https://remote.example.com/openapi.json",
+    )
+    out = await skills_service.install_api_doc_from_url("w1", "u1", body)
+    assert out.ok is True
+    assert out.slug == "api-remote-example-com"
+
+
+# Silence ruff unused-import nudge.
+_ = pytest


### PR DESCRIPTION
## What

Adds `POST /api/v1/skills/api-doc-from-url` — a JSON sibling to the existing `POST /skills/api-doc` multipart upload. The user pastes a public OpenAPI / Swagger URL; the server fetches, validates, and compiles a SKILL.md via the same installer the upload path uses.

## Why

Friction reduction. Most production APIs publish their OpenAPI at a stable URL (`api.github.com/openapi.json`, Stripe's spec, Linear, Anthropic). Asking the user to download a JSON and re-upload is wasteful when we can fetch directly.

Drove this from the RFC 04/05 end-to-end walk — when I tested inc 2b's API-skill flow on the Petstore demo, I had to `curl` the spec down then `curl` it back up. The whole exchange should be a single field.

## Security posture

The URL fetch runs through the same trust boundary the read-source executor enforces:

- **https-only** — `http://` rejected before any DNS resolution.
- **SSRF guard** — resolved hostname runs through `pockets._http_guard._assert_host_external`, rejecting loopback / private / link-local / reserved / cloud-metadata IPs. Defends against DNS rebinding from a public name to an internal address.
- **Redirects off** — a 3xx returns `422 fetch_redirect`; the caller must pass the final URL.
- **Size cap** — response body bounded at 2 MB (matches the upload cap and `api_skill_builder._MAX_SPEC_BYTES`).
- **Timeout** — 15s hard cap.

Audit log gains a `source` discriminator (`upload` | `url`) so operators can tell the two install paths apart.

## Code shape

- `dto.py` — `InstallApiDocFromUrlRequest` (JSON body, `HttpUrl` field).
- `domain.py` — `ApiDocFromUrlInstall` frozen value object with required `workspace_id` + `user_id`.
- `service.py` — `install_api_doc_from_url()` does the SSRF check + fetch + parse, then delegates to two new helpers (`_parse_spec_text`, `_install_parsed_spec`) factored out of `install_api_doc()` so both surfaces stay in sync.
- `router.py` — `POST /skills/api-doc-from-url`, same `skills.manage` ABAC + `require_license` as the multipart endpoint.

No Beanie writes — skills are filesystem-local SKILL.md (matches the existing posture). The Mongo Skill module is a separate follow-up.

## Test plan

- [x] `uv run pytest tests/cloud/test_skills_router_from_url.py` — 13 new tests covering happy path (JSON + YAML responses), every rejection branch (http scheme, malformed URL, private host, redirect, non-2xx, oversized, unparseable, no-paths, network error), and the auth seam. `httpx.AsyncClient` monkeypatched throughout — no real network I/O.
- [x] `uv run pytest tests/ -k "skills or api_doc"` — 84 passed, 0 failures (existing skills tests still green).

## Frontend follow-up

paw-enterprise PR adds the Upload + URL UI to `PocketBackendConfigModal.svelte`, pointing at both endpoints.