### PR TITLE
feat(pockets): mechanical guards for action-verb allowlist + unwired-live-button

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -735,6 +735,24 @@ async def create_from_ripple_spec(
         logger.info("Auto-created pocket %s from ripple spec", pocket_id)
         await emit(PocketCreated(data=await _pocket_event_payload(doc)))
         return pocket_id
+    except CatalogViolationError as exc:
+        # Strict catalog gate blocked the auto-create; surface the field
+        # paths explicitly instead of letting them disappear into the
+        # catch-all stack trace below.
+        logger.warning(
+            "Auto-create blocked by catalog gate: %d violation(s); paths=%s",
+            len(exc.violations),
+            [v.get("path") for v in exc.violations],
+        )
+        return None
+    except ActionWiringViolationError as exc:
+        # Strict action-wiring gate blocked the auto-create (PR #1196).
+        logger.warning(
+            "Auto-create blocked by action-wiring gate: %d violation(s); paths=%s",
+            len(exc.violations),
+            [v.get("path") for v in exc.violations],
+        )
+        return None
     except Exception:
         logger.warning("Failed to auto-create pocket from ripple spec", exc_info=True)
         return None

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -107,8 +107,12 @@ from pocketpaw_ee.cloud.pockets.dto import (
 )
 from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec
 from pocketpaw_ee.cloud.ripple_validator import (
+    ActionWiringViolationError,
     CatalogViolationError,
+    format_action_violations_for_agent,
     format_violations_for_agent,
+    validate_action_wiring_logged,
+    validate_action_wiring_strict,
     validate_against_catalog_logged,
     validate_against_catalog_strict,
     validate_ripple_spec_logged,
@@ -441,11 +445,27 @@ async def _gate_catalog(
             pocket_id=pocket_id,
             workspace_id=workspace_id,
         )
+        # Action-handler wiring runs as a sibling gate — same strict
+        # posture as the catalog walk so the agent-generation path
+        # gets a single corrective signal per failed attempt rather
+        # than chained-and-shadowed errors. Manifest-driven catalog
+        # already passed; this catches the verb-level / Refresh-button
+        # failure modes the catalog can't see.
+        validate_action_wiring_strict(
+            spec,
+            pocket_id=pocket_id,
+            workspace_id=workspace_id,
+        )
     else:
         validate_against_catalog_logged(
             spec,
             allowed_types,
             embed_allowed_hosts=embed_hosts,
+            pocket_id=pocket_id,
+            workspace_id=workspace_id,
+        )
+        validate_action_wiring_logged(
+            spec,
             pocket_id=pocket_id,
             workspace_id=workspace_id,
         )
@@ -1285,6 +1305,8 @@ async def agent_update(
                 )
             except CatalogViolationError as exc:
                 return None, format_violations_for_agent(exc.violations)
+            except ActionWiringViolationError as exc:
+                return None, format_action_violations_for_agent(exc.violations)
     try:
         await doc.save()
     except Exception as exc:  # noqa: BLE001
@@ -2298,6 +2320,8 @@ async def agent_create(
             await _gate_catalog(normalized, strict=True, actor=owner_id, workspace_id=workspace_id)
         except CatalogViolationError as exc:
             return None, None, format_violations_for_agent(exc.violations)
+        except ActionWiringViolationError as exc:
+            return None, None, format_action_violations_for_agent(exc.violations)
     try:
         doc = _PocketDoc(
             workspace=workspace_id,

--- a/ee/pocketpaw_ee/cloud/ripple_validator.py
+++ b/ee/pocketpaw_ee/cloud/ripple_validator.py
@@ -582,20 +582,16 @@ def format_action_violations_for_agent(violations: list[dict[str, Any]]) -> str:
                 if v.get("suggestion")
                 else " Use one of: set, push, run_source, api, navigate, toast, emit."
             )
-            lines.append(
-                f"  • {v['path']}: action '{v['action']}' is not a recognized verb.{hint}"
-            )
+            lines.append(f"  • {v['path']}: action '{v['action']}' is not a recognized verb.{hint}")
         else:
-            lines.append(
-                f"  • {v['path']} (label={v.get('label')!r}): {v['reason']}"
-            )
+            lines.append(f"  • {v['path']} (label={v.get('label')!r}): {v['reason']}")
     if len(violations) > 10:
         lines.append(f"  • …and {len(violations) - 10} more")
     lines.append(
         "Action verbs are a closed set — see ripple/event-dispatcher.ts. A button "
         "labelled 'Refresh' / 'Sync' / 'Fetch' must call `run_source` with a "
         "declared `sources` key OR `api` with a real `url`. An invented verb "
-        "(e.g. `action: \"fetch\"`) silently no-ops at runtime, which looks "
+        '(e.g. `action: "fetch"`) silently no-ops at runtime, which looks '
         "like a working button but does nothing."
     )
     return "\n".join(lines)

--- a/ee/pocketpaw_ee/cloud/ripple_validator.py
+++ b/ee/pocketpaw_ee/cloud/ripple_validator.py
@@ -43,6 +43,8 @@ from typing import Any
 
 from pocketpaw.ripple.manifest import (
     check_embed_nodes_in_spec,
+    find_unwired_live_buttons,
+    validate_action_verbs,
     validate_against_catalog,
 )
 
@@ -499,12 +501,180 @@ def validate_against_catalog_strict(
         raise CatalogViolationError(violations)
 
 
+# ---------------------------------------------------------------------------
+# Action-verb + unwired-live-button gate (2026-05-23).
+#
+# Closes a class of LLM "loophole" failures the prompt-side rule in
+# PR #1194 couldn't catch: the specialist authoring buttons with
+# fictitious action verbs (``action: "fetch"``) or live-labelled
+# Refresh buttons whose on_click is empty / inert. The pure walkers
+# live in OSS ``pocketpaw.ripple.manifest``; this layer adds the
+# strict / logged wiring + the agent-readable error formatting.
+# ---------------------------------------------------------------------------
+
+
+class ActionWiringViolationError(Exception):
+    """Raised by :func:`validate_action_wiring_strict` when a spec
+    carries an event handler with an unknown action verb or a
+    live-labelled button whose on_click is empty / inert.
+
+    Same shape as :class:`CatalogViolationError`: ``.violations`` plus
+    a class-level formatter so the chat agent's retry loop can surface
+    a focused corrective hint.
+    """
+
+    def __init__(self, violations: list[dict[str, Any]]) -> None:
+        self.violations = violations
+        super().__init__(self._format(violations))
+
+    @staticmethod
+    def _format(violations: list[dict[str, Any]]) -> str:
+        lines = [f"{len(violations)} action-wiring violation(s) in rippleSpec:"]
+        for v in violations[:20]:
+            if "action" in v:
+                hint = f" — did you mean '{v['suggestion']}'?" if v.get("suggestion") else ""
+                lines.append(
+                    f"  - [unknown_verb] {v['path']}: action '{v['action']}' "
+                    f"is not a recognized verb{hint}"
+                )
+            else:
+                lines.append(
+                    f"  - [unwired_live_button] {v['path']} (label={v.get('label')!r}): "
+                    f"{v['reason']}"
+                )
+        if len(violations) > 20:
+            lines.append(f"  - …and {len(violations) - 20} more")
+        return "\n".join(lines)
+
+
+def _collect_action_wiring_violations(spec: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Run both action-wiring walks, return the combined list.
+
+    Unknown-verb issues first (cheaper to fix, also catch the inert
+    on_click failure mode at the same site), then unwired-button
+    issues. Deduplication by ``path`` so a verb violation on the same
+    handler that also fails the live-button check isn't reported
+    twice.
+    """
+    violations: list[dict[str, Any]] = []
+    violations.extend(validate_action_verbs(spec))
+    seen_paths = {v["path"] for v in violations}
+    for v in find_unwired_live_buttons(spec):
+        if v["path"] not in seen_paths:
+            violations.append(v)
+    return violations
+
+
+def format_action_violations_for_agent(violations: list[dict[str, Any]]) -> str:
+    """Build a compact, agent-readable summary of action-wiring violations.
+
+    Suitable as the ``error`` field on an MCP tool result so the
+    specialist sees specifically which handler / button failed and
+    can target its fix.
+    """
+    if not violations:
+        return ""
+    lines = ["The rippleSpec was rejected — event-handler wiring is broken:"]
+    for v in violations[:10]:
+        if "action" in v:
+            hint = (
+                f" Use '{v['suggestion']}' instead."
+                if v.get("suggestion")
+                else " Use one of: set, push, run_source, api, navigate, toast, emit."
+            )
+            lines.append(
+                f"  • {v['path']}: action '{v['action']}' is not a recognized verb.{hint}"
+            )
+        else:
+            lines.append(
+                f"  • {v['path']} (label={v.get('label')!r}): {v['reason']}"
+            )
+    if len(violations) > 10:
+        lines.append(f"  • …and {len(violations) - 10} more")
+    lines.append(
+        "Action verbs are a closed set — see ripple/event-dispatcher.ts. A button "
+        "labelled 'Refresh' / 'Sync' / 'Fetch' must call `run_source` with a "
+        "declared `sources` key OR `api` with a real `url`. An invented verb "
+        "(e.g. `action: \"fetch\"`) silently no-ops at runtime, which looks "
+        "like a working button but does nothing."
+    )
+    return "\n".join(lines)
+
+
+def validate_action_wiring_logged(
+    spec: dict[str, Any] | None,
+    *,
+    pocket_id: str | None = None,
+    workspace_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Validate action-handler wiring, emit one ``log.warning`` per
+    violation, and return the violations list.
+
+    Use this on the human / import path — a violation is recorded for
+    triage but does NOT block the write (an older imported spec may
+    have wiring that's since become inert).
+    """
+    violations = _collect_action_wiring_violations(spec)
+    for v in violations:
+        if "action" in v:
+            log.warning(
+                "ripple_spec.unknown_action_verb",
+                extra={
+                    "pocket_id": pocket_id,
+                    "workspace_id": workspace_id,
+                    "field_path": v["path"],
+                    "action": v["action"],
+                    "suggestion": v.get("suggestion"),
+                },
+            )
+        else:
+            log.warning(
+                "ripple_spec.unwired_live_button",
+                extra={
+                    "pocket_id": pocket_id,
+                    "workspace_id": workspace_id,
+                    "field_path": v["path"],
+                    "label": v.get("label"),
+                    "reason": v.get("reason"),
+                },
+            )
+    return violations
+
+
+def validate_action_wiring_strict(
+    spec: dict[str, Any] | None,
+    *,
+    pocket_id: str | None = None,
+    workspace_id: str | None = None,
+) -> None:
+    """Validate action-handler wiring; raise
+    :class:`ActionWiringViolationError` if any handler uses an
+    unknown verb or any live-labelled button is unwired.
+
+    Use this only on the agent-generation path where the caller can
+    handle a retry. Human / import callers should use
+    :func:`validate_action_wiring_logged` — strict mode would block a
+    legitimate import of an older spec.
+    """
+    violations = validate_action_wiring_logged(
+        spec,
+        pocket_id=pocket_id,
+        workspace_id=workspace_id,
+    )
+    if violations:
+        raise ActionWiringViolationError(violations)
+
+
 __all__ = [
+    "ActionWiringViolationError",
     "CatalogViolationError",
     "ExpressionWarning",
     "RippleSpecGrammarError",
+    "format_action_violations_for_agent",
     "format_violations_for_agent",
     "format_warnings_for_agent",
+    "validate_action_wiring_logged",
+    "validate_action_wiring_strict",
     "validate_against_catalog_logged",
     "validate_against_catalog_strict",
     "validate_ripple_spec",

--- a/src/pocketpaw/ripple/manifest.py
+++ b/src/pocketpaw/ripple/manifest.py
@@ -482,6 +482,321 @@ def _walk_embed_policy(
                 _walk_embed_policy(child, f"{path}.{key}[{i}]", allowed_hosts, issues)
 
 
+# ---------------------------------------------------------------------------
+# Action-verb allowlist + unwired-live-button detector (2026-05-23).
+#
+# Two related failure modes the prompt-side "label without source" rule
+# (PR #1194) didn't catch:
+#
+#  A. Invented action verbs. The specialist authors ``on_click:
+#     {action: "fetch", endpoint: "/pet/1", target: "pet_rows"}``. The
+#     Ripple event dispatcher has no ``fetch`` verb — its default case
+#     ``console.warn``s and returns. The button looks live but does
+#     nothing.
+#
+#  B. "Live"-labelled buttons with no real wiring. A Refresh button
+#     whose ``on_click`` is empty (or only contains the invented verb
+#     above) renders, takes user clicks, and never fetches. Coupled
+#     with pre-seeded mock data in ``state.<key>``, the canvas looks
+#     alive but is inert.
+#
+# Both walks here run as siblings to the catalog gate — strict on the
+# agent-generation path (raises so the chat agent can retry), logged on
+# the human / import path.
+# ---------------------------------------------------------------------------
+
+# Canonical action verbs the Ripple event dispatcher understands.
+# Source of truth: ``ripple/src/lib/core/event-dispatcher.ts`` — the
+# switch in ``dispatch()``. Drift between the two would let an invented
+# verb pass spec validation and silently no-op at runtime, which is the
+# exact failure we are guarding against; mirror this list whenever the
+# dispatcher gains a new case.
+_KNOWN_ACTION_VERBS: frozenset[str] = frozenset(
+    {
+        "set",
+        "toggle",
+        "push",
+        "remove",
+        "open",
+        "navigate",
+        "toast",
+        "emit",
+        "pin",
+        "unpin",
+        "api",
+        "run_source",
+        "call_binding",
+        "flow",
+        "branch",
+        "confirm",
+        "validate",
+        "delay",
+        "invoke",
+    }
+)
+
+# Button labels (case-insensitive substring match) that promise a live
+# fetch. Used by :func:`find_unwired_live_buttons` to know which buttons
+# are advertising behavior that must actually be wired.
+_LIVE_BUTTON_KEYWORDS: tuple[str, ...] = (
+    "refresh",
+    "reload",
+    "sync",
+    "pull",
+    "fetch",
+    "update from",
+    "re-fetch",
+    "refetch",
+)
+
+# Event-prop names that carry one or more action handlers. Mirrors the
+# Ripple node shape — any prop value whose key matches and whose value
+# is a handler-shaped object (or list of them) is in scope.
+_EVENT_PROP_NAMES: frozenset[str] = frozenset(
+    {
+        "on_click",
+        "onClick",
+        "on_change",
+        "onChange",
+        "on_submit",
+        "onSubmit",
+        "on_input",
+        "onInput",
+        "on_blur",
+        "onBlur",
+        "on_focus",
+        "onFocus",
+        "on_select",
+        "onSelect",
+    }
+)
+
+
+def _iter_handlers(value: Any) -> list[dict[str, Any]]:
+    """Normalise a handler prop value into the list of handler dicts.
+
+    A handler is either a single object ``{action: ..., ...}`` or a
+    list of such objects (action chains). Returns the flat list — any
+    non-dict entries are dropped (the catalog already rejected those).
+    """
+    if isinstance(value, dict):
+        return [value]
+    if isinstance(value, list):
+        return [h for h in value if isinstance(h, dict)]
+    return []
+
+
+def _walk_action_verbs(node: Any, path: str, issues: list[dict[str, Any]]) -> None:
+    """Recursive walk that collects unknown-action-verb violations.
+
+    Each issue: ``{path, prop, action, suggestion}``. ``suggestion`` is
+    the nearest known verb (difflib) so the corrective hint can be
+    specific. A handler without an ``action`` field is skipped — that
+    is the catalog's concern, not the verb gate.
+    """
+    if isinstance(node, dict):
+        # node-level prop scan
+        props = node.get("props") if isinstance(node.get("props"), dict) else node
+        if isinstance(props, dict):
+            for prop_name, prop_value in props.items():
+                if prop_name not in _EVENT_PROP_NAMES:
+                    continue
+                for handler in _iter_handlers(prop_value):
+                    verb = handler.get("action")
+                    if not isinstance(verb, str) or not verb:
+                        # No action field — the renderer treats this as
+                        # a no-op too. Flag it: a Refresh button bound
+                        # to ``{}`` is identical to ``{action: "fetch"}``
+                        # in effect.
+                        issues.append(
+                            {
+                                "path": f"{path}.props.{prop_name}",
+                                "prop": prop_name,
+                                "action": "<missing>",
+                                "suggestion": None,
+                            }
+                        )
+                        continue
+                    if verb not in _KNOWN_ACTION_VERBS:
+                        matches = difflib.get_close_matches(
+                            verb, sorted(_KNOWN_ACTION_VERBS), n=1, cutoff=0.6
+                        )
+                        issues.append(
+                            {
+                                "path": f"{path}.props.{prop_name}",
+                                "prop": prop_name,
+                                "action": verb,
+                                "suggestion": matches[0] if matches else None,
+                            }
+                        )
+
+        for key in ("children", "else_children"):
+            kids = node.get(key)
+            if isinstance(kids, list):
+                for i, child in enumerate(kids):
+                    _walk_action_verbs(child, f"{path}.{key}[{i}]", issues)
+
+
+def validate_action_verbs(spec: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Walk the spec, flag every event-handler whose ``action`` verb
+    is not in :data:`_KNOWN_ACTION_VERBS`.
+
+    Returns one issue per offending handler; ``[]`` when ``spec`` is
+    not a dict or every handler's verb is recognized. Issue shape::
+
+        {
+          "path": "ui.children[2].props.on_click",
+          "prop": "on_click",
+          "action": "fetch",
+          "suggestion": "run_source",   # nearest known verb, or None
+        }
+
+    The renderer's event dispatcher silently no-ops unknown verbs (it
+    ``console.warn``s and returns), which masks broken buttons as
+    "working." Catching this at spec ingest forces the agent to use
+    the right verb.
+    """
+    if not isinstance(spec, dict):
+        return []
+    root = spec.get("ui") if isinstance(spec.get("ui"), dict) else spec
+    issues: list[dict[str, Any]] = []
+    _walk_action_verbs(root, "ui", issues)
+    return issues
+
+
+def _node_label_text(node: dict[str, Any]) -> str:
+    """Return the user-visible text of a node — used to detect Refresh
+    / Sync / Fetch labels. Concatenates ``props.label``, ``props.text``,
+    ``props.title``, and ``props.aria_label`` if present.
+    """
+    props = node.get("props") if isinstance(node.get("props"), dict) else {}
+    parts: list[str] = []
+    for key in ("label", "text", "title", "aria_label", "ariaLabel"):
+        v = props.get(key) if isinstance(props, dict) else None
+        if isinstance(v, str):
+            parts.append(v)
+    return " ".join(parts)
+
+
+def _looks_live(label: str) -> bool:
+    """True when a button's label promises live fetching behaviour."""
+    if not label:
+        return False
+    lo = label.lower()
+    return any(kw in lo for kw in _LIVE_BUTTON_KEYWORDS)
+
+
+def _walk_live_buttons(
+    node: Any,
+    path: str,
+    sources: dict[str, Any],
+    issues: list[dict[str, Any]],
+) -> None:
+    """Recursive walk that flags Refresh-labelled buttons whose
+    ``on_click`` is empty or wired to an unrecognized verb / missing
+    source.
+    """
+    if isinstance(node, dict):
+        wtype = node.get("type")
+        if wtype == "button":
+            props = node.get("props") if isinstance(node.get("props"), dict) else {}
+            label = _node_label_text(node)
+            if _looks_live(label):
+                handlers = _iter_handlers(props.get("on_click") if isinstance(props, dict) else None)
+                if not handlers:
+                    issues.append(
+                        {
+                            "path": f"{path}.props.on_click",
+                            "label": label,
+                            "reason": "live-labelled button has no on_click handler",
+                        }
+                    )
+                else:
+                    # Pick the first handler that's plausibly the
+                    # "fetch" — verb in {api, run_source, invoke, flow}.
+                    plausible = [
+                        h
+                        for h in handlers
+                        if h.get("action") in {"api", "run_source", "invoke", "flow"}
+                    ]
+                    if not plausible:
+                        # Either all handlers use non-fetching verbs
+                        # (set/toggle/etc.) or an unknown verb. Either
+                        # way the button doesn't fetch anything.
+                        verbs = sorted({str(h.get("action") or "<missing>") for h in handlers})
+                        issues.append(
+                            {
+                                "path": f"{path}.props.on_click",
+                                "label": label,
+                                "reason": (
+                                    "live-labelled button has no fetching action — "
+                                    f"verbs present: {verbs}; expected one of "
+                                    "['api', 'run_source', 'invoke', 'flow']"
+                                ),
+                            }
+                        )
+                    else:
+                        for h in plausible:
+                            if h.get("action") == "run_source":
+                                src_key = h.get("source")
+                                if not isinstance(src_key, str) or src_key not in sources:
+                                    issues.append(
+                                        {
+                                            "path": f"{path}.props.on_click",
+                                            "label": label,
+                                            "reason": (
+                                                f"run_source references source "
+                                                f"{src_key!r} which is not declared "
+                                                "in rippleSpec.sources"
+                                            ),
+                                        }
+                                    )
+                            elif h.get("action") == "api":
+                                if not isinstance(h.get("url"), str) or not h.get("url"):
+                                    issues.append(
+                                        {
+                                            "path": f"{path}.props.on_click",
+                                            "label": label,
+                                            "reason": "api handler has no url",
+                                        }
+                                    )
+
+        for key in ("children", "else_children"):
+            kids = node.get(key)
+            if isinstance(kids, list):
+                for i, child in enumerate(kids):
+                    _walk_live_buttons(child, f"{path}.{key}[{i}]", sources, issues)
+
+
+def find_unwired_live_buttons(spec: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Walk the spec, flag every "live"-labelled button whose on_click
+    is empty, references an undeclared source, or uses an action verb
+    that doesn't actually fetch.
+
+    Returns one issue per offending button; ``[]`` when ``spec`` is
+    not a dict or every Refresh-class button is properly wired. Issue
+    shape::
+
+        {
+          "path": "ui.children[2].props.on_click",
+          "label": "Refresh",
+          "reason": "...",
+        }
+
+    Pairs with :func:`validate_action_verbs` — the verb check catches
+    the dispatcher-level failure (unknown verb), this catches the
+    semantic-level failure (verb known, but the wiring is broken for
+    the button's purpose).
+    """
+    if not isinstance(spec, dict):
+        return []
+    raw_sources = (spec.get("sources") if isinstance(spec.get("sources"), dict) else {}) or {}
+    root = spec.get("ui") if isinstance(spec.get("ui"), dict) else spec
+    issues: list[dict[str, Any]] = []
+    _walk_live_buttons(root, "ui", raw_sources, issues)
+    return issues
+
+
 def format_for_prompt(manifest: dict[str, Any]) -> str:
     """Render the manifest as a markdown block for system-prompt injection.
 

--- a/src/pocketpaw/ripple/manifest.py
+++ b/src/pocketpaw/ripple/manifest.py
@@ -702,7 +702,9 @@ def _walk_live_buttons(
             props = node.get("props") if isinstance(node.get("props"), dict) else {}
             label = _node_label_text(node)
             if _looks_live(label):
-                handlers = _iter_handlers(props.get("on_click") if isinstance(props, dict) else None)
+                handlers = _iter_handlers(
+                    props.get("on_click") if isinstance(props, dict) else None
+                )
                 if not handlers:
                     issues.append(
                         {

--- a/tests/cloud/test_ripple_validator_action_wiring.py
+++ b/tests/cloud/test_ripple_validator_action_wiring.py
@@ -1,0 +1,232 @@
+# tests/cloud/test_ripple_validator_action_wiring.py
+# 2026-05-23 — EE-side wiring tests for the action-verb +
+# unwired-live-button gate. The pure walkers are covered in
+# tests/test_ripple_manifest_action_wiring.py; this file covers the
+# strict/logged variants, the agent-readable formatter, and the
+# ActionWiringViolationError shape so the chat agent's retry loop can
+# read it.
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from pocketpaw_ee.cloud.ripple_validator import (
+    ActionWiringViolationError,
+    format_action_violations_for_agent,
+    validate_action_wiring_logged,
+    validate_action_wiring_strict,
+)
+
+
+def _spec_with_invented_verb() -> dict:
+    """The Test-D failure shape — Refresh button bound to ``action: "fetch"``."""
+    return {
+        "ui": {
+            "type": "flex",
+            "children": [
+                {
+                    "type": "button",
+                    "props": {
+                        "label": "Refresh",
+                        "on_click": {
+                            "action": "fetch",
+                            "endpoint": "/pet/1",
+                            "target": "pet_rows",
+                        },
+                    },
+                }
+            ],
+        }
+    }
+
+
+def _clean_spec() -> dict:
+    return {
+        "sources": {"pets": {"method": "GET", "path": "/pets", "bind": "state.pets"}},
+        "ui": {
+            "type": "button",
+            "props": {
+                "label": "Refresh",
+                "on_click": {"action": "run_source", "source": "pets"},
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strict mode raises ActionWiringViolationError
+# ---------------------------------------------------------------------------
+
+
+class TestStrict:
+    def test_raises_on_unknown_verb(self):
+        with pytest.raises(ActionWiringViolationError) as ei:
+            validate_action_wiring_strict(_spec_with_invented_verb())
+        # The exception carries the structured violations list AND
+        # formats a human-readable message.
+        assert len(ei.value.violations) >= 1
+        assert "fetch" in str(ei.value)
+
+    def test_clean_spec_does_not_raise(self):
+        validate_action_wiring_strict(_clean_spec())  # no raise
+
+    def test_non_dict_does_not_raise(self):
+        validate_action_wiring_strict(None)
+        validate_action_wiring_strict("not a spec")
+
+
+# ---------------------------------------------------------------------------
+# Logged mode returns the list and emits structured log warnings
+# ---------------------------------------------------------------------------
+
+
+class TestLogged:
+    def test_returns_violations_and_logs(self, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING, logger="pocketpaw_ee.cloud.ripple_validator")
+        out = validate_action_wiring_logged(
+            _spec_with_invented_verb(), pocket_id="p1", workspace_id="w1"
+        )
+        assert len(out) >= 1
+        # Structured warning is emitted at WARNING level.
+        records = [r for r in caplog.records if r.message.startswith("ripple_spec.")]
+        assert records, "no structured warning emitted"
+        codes = {r.message for r in records}
+        assert "ripple_spec.unknown_action_verb" in codes
+
+    def test_logs_unwired_live_button_separately(self, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING, logger="pocketpaw_ee.cloud.ripple_validator")
+        spec = {
+            "ui": {
+                "type": "button",
+                "props": {"label": "Refresh"},  # no on_click
+            }
+        }
+        out = validate_action_wiring_logged(spec, pocket_id="p1", workspace_id="w1")
+        assert len(out) == 1
+        codes = {r.message for r in caplog.records if r.message.startswith("ripple_spec.")}
+        assert "ripple_spec.unwired_live_button" in codes
+
+    def test_clean_spec_returns_empty(self):
+        assert validate_action_wiring_logged(_clean_spec()) == []
+
+    def test_dedups_overlap_with_verb_check(self):
+        # A Refresh button with an unknown verb produces ONE violation,
+        # not two — the verb check fires first, and the live-button
+        # walk skips paths the verb check already covered.
+        out = validate_action_wiring_logged(_spec_with_invented_verb())
+        assert len(out) == 1
+        assert out[0].get("action") == "fetch"
+
+
+# ---------------------------------------------------------------------------
+# Agent-readable formatter
+# ---------------------------------------------------------------------------
+
+
+class TestFormatForAgent:
+    def test_empty_returns_empty_string(self):
+        assert format_action_violations_for_agent([]) == ""
+
+    def test_unknown_verb_includes_path_and_suggestion(self):
+        violations = [
+            {
+                "path": "ui.children[0].props.on_click",
+                "prop": "on_click",
+                "action": "fetch",
+                "suggestion": "run_source",
+            }
+        ]
+        msg = format_action_violations_for_agent(violations)
+        assert "ui.children[0].props.on_click" in msg
+        assert "'fetch'" in msg
+        assert "run_source" in msg
+
+    def test_unwired_button_includes_label_and_reason(self):
+        violations = [
+            {
+                "path": "ui.children[2].props.on_click",
+                "label": "Refresh",
+                "reason": "live-labelled button has no on_click handler",
+            }
+        ]
+        msg = format_action_violations_for_agent(violations)
+        assert "Refresh" in msg
+        assert "no on_click handler" in msg
+
+    def test_message_carries_remediation_guidance(self):
+        """The message must teach the agent the right shape, not just
+        list what's broken — the retry loop is what closes the loop."""
+        msg = format_action_violations_for_agent(
+            [{"path": "ui", "prop": "on_click", "action": "fetch", "suggestion": None}]
+        )
+        # Should mention run_source or api as the right verbs and that
+        # invented verbs silently no-op.
+        assert "run_source" in msg or "api" in msg
+        assert "no-op" in msg.lower() or "silently" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Service integration — _gate_catalog hooks the new gate
+# ---------------------------------------------------------------------------
+
+
+class TestGateCatalogWiring:
+    """End-to-end: ``_gate_catalog`` calls the new action-wiring gate
+    alongside the existing catalog gate. Strict mode raises, logged
+    mode warns. We patch ``_catalog_allowed_types`` so the catalog
+    walk passes (a clean type list) and the action gate is the one
+    flagging."""
+
+    @pytest.mark.asyncio
+    async def test_strict_mode_raises_on_invented_verb(self, monkeypatch):
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        async def _allowed_types():
+            return ["flex", "button", "text"]
+
+        monkeypatch.setattr(pockets_service, "_catalog_allowed_types", _allowed_types)
+        with pytest.raises(ActionWiringViolationError):
+            await pockets_service._gate_catalog(
+                _spec_with_invented_verb(),
+                strict=True,
+                actor="agent",
+                workspace_id="w1",
+                pocket_id=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_logged_mode_does_not_raise(self, monkeypatch):
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        async def _allowed_types():
+            return ["flex", "button", "text"]
+
+        monkeypatch.setattr(pockets_service, "_catalog_allowed_types", _allowed_types)
+        # No raise — logged mode swallows.
+        await pockets_service._gate_catalog(
+            _spec_with_invented_verb(),
+            strict=False,
+            actor="user",
+            workspace_id="w1",
+            pocket_id="p1",
+        )
+
+    @pytest.mark.asyncio
+    async def test_manifest_unavailable_skips_gates(self, monkeypatch):
+        """If the manifest fetch fails, both gates are skipped — best-effort
+        posture matches the existing catalog gate."""
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        async def _allowed_types():
+            return None  # manifest unavailable
+
+        monkeypatch.setattr(pockets_service, "_catalog_allowed_types", _allowed_types)
+        # Even strict mode does not raise when the manifest is gone.
+        await pockets_service._gate_catalog(
+            _spec_with_invented_verb(),
+            strict=True,
+            actor="agent",
+            workspace_id="w1",
+            pocket_id=None,
+        )

--- a/tests/test_ripple_manifest_action_wiring.py
+++ b/tests/test_ripple_manifest_action_wiring.py
@@ -12,12 +12,12 @@
 from __future__ import annotations
 
 import pytest
+
 from pocketpaw.ripple.manifest import (
     _KNOWN_ACTION_VERBS,
     find_unwired_live_buttons,
     validate_action_verbs,
 )
-
 
 # ---------------------------------------------------------------------------
 # Action-verb allowlist
@@ -292,9 +292,7 @@ class TestFindUnwiredLiveButtons:
     def test_non_button_with_refresh_label_ignored(self):
         # The walk only inspects ``type: "button"`` nodes. A heading
         # that says "Refresh" is not a button and not in scope.
-        spec = {
-            "ui": {"type": "heading", "props": {"text": "Refresh history"}}
-        }
+        spec = {"ui": {"type": "heading", "props": {"text": "Refresh history"}}}
         assert find_unwired_live_buttons(spec) == []
 
     def test_non_dict_spec_returns_empty(self):

--- a/tests/test_ripple_manifest_action_wiring.py
+++ b/tests/test_ripple_manifest_action_wiring.py
@@ -1,0 +1,306 @@
+# tests/test_ripple_manifest_action_wiring.py
+# 2026-05-23 — Cover the action-verb allowlist and the unwired-live-button
+# detector. Companion to the catalog gate: catches a class of LLM
+# "loophole" failures the prompt-side rule in PR #1194 didn't catch:
+#   - ``action: "fetch"`` and other invented verbs the dispatcher
+#     ``console.warn``s and silently no-ops on.
+#   - Refresh-labelled buttons whose on_click is empty / inert /
+#     pointing at an undeclared source.
+# Pure-walker tests; the EE strict + logged wiring lives in
+# ``tests/cloud/test_ripple_validator_action_wiring.py``.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw.ripple.manifest import (
+    _KNOWN_ACTION_VERBS,
+    find_unwired_live_buttons,
+    validate_action_verbs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Action-verb allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestValidateActionVerbs:
+    def test_known_verb_passes(self):
+        spec = {
+            "ui": {
+                "type": "button",
+                "props": {"on_click": {"action": "set", "target": "x", "value": 1}},
+            }
+        }
+        assert validate_action_verbs(spec) == []
+
+    def test_unknown_verb_flagged_with_suggestion(self):
+        spec = {
+            "ui": {
+                "type": "button",
+                "props": {
+                    "on_click": {
+                        "action": "fetch",
+                        "endpoint": "/pet/1",
+                        "target": "pet_rows",
+                    }
+                },
+            }
+        }
+        issues = validate_action_verbs(spec)
+        assert len(issues) == 1
+        assert issues[0]["action"] == "fetch"
+        assert issues[0]["prop"] == "on_click"
+        assert "props.on_click" in issues[0]["path"]
+        # difflib should suggest something close-ish from the known set;
+        # we don't pin the exact suggestion (depends on close-matches
+        # cutoff) but assert it surfaces *some* valid verb when one
+        # exists.
+        if issues[0]["suggestion"] is not None:
+            assert issues[0]["suggestion"] in _KNOWN_ACTION_VERBS
+
+    def test_missing_action_field_flagged(self):
+        # A handler dict with no `action` field is functionally
+        # identical to an unknown action — the dispatcher's switch
+        # falls through to the no-op default.
+        spec = {
+            "ui": {
+                "type": "button",
+                "props": {"on_click": {"target": "x"}},
+            }
+        }
+        issues = validate_action_verbs(spec)
+        assert len(issues) == 1
+        assert issues[0]["action"] == "<missing>"
+
+    def test_action_chain_each_handler_checked(self):
+        # on_click can be a list of handlers (action chain). Every
+        # handler in the chain is independently validated.
+        spec = {
+            "ui": {
+                "type": "button",
+                "props": {
+                    "on_click": [
+                        {"action": "set", "target": "draft", "value": ""},
+                        {"action": "frobnicate", "target": "x"},
+                        {"action": "toast", "message": "ok"},
+                    ]
+                },
+            }
+        }
+        issues = validate_action_verbs(spec)
+        assert len(issues) == 1
+        assert issues[0]["action"] == "frobnicate"
+
+    def test_walks_nested_children(self):
+        spec = {
+            "ui": {
+                "type": "flex",
+                "children": [
+                    {
+                        "type": "flex",
+                        "children": [
+                            {
+                                "type": "button",
+                                "props": {"on_click": {"action": "bogus"}},
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+        issues = validate_action_verbs(spec)
+        assert len(issues) == 1
+        assert "ui.children[0].children[0]" in issues[0]["path"]
+
+    def test_else_children_walked(self):
+        spec = {
+            "ui": {
+                "type": "if",
+                "condition": "{state.x}",
+                "children": [{"type": "text", "props": {"text": "ok"}}],
+                "else_children": [
+                    {
+                        "type": "button",
+                        "props": {"on_click": {"action": "nope"}},
+                    }
+                ],
+            }
+        }
+        issues = validate_action_verbs(spec)
+        assert len(issues) == 1
+        assert "else_children" in issues[0]["path"]
+
+    def test_event_prop_aliases_handled(self):
+        # Both snake_case and camelCase event-prop names are scanned.
+        spec = {
+            "ui": {
+                "type": "input",
+                "props": {"onChange": {"action": "set", "target": "v", "value": "{$event}"}},
+            }
+        }
+        assert validate_action_verbs(spec) == []
+        spec2 = {
+            "ui": {
+                "type": "input",
+                "props": {"onChange": {"action": "bogus"}},
+            }
+        }
+        assert len(validate_action_verbs(spec2)) == 1
+
+    def test_non_dict_spec_returns_empty(self):
+        assert validate_action_verbs(None) == []
+        assert validate_action_verbs("string") == []
+        assert validate_action_verbs([1, 2, 3]) == []
+
+    def test_all_known_verbs_pass(self):
+        # Spot-check the full known set — if a verb is removed from
+        # the dispatcher without updating this list, this test catches
+        # the drift the next time someone runs it locally.
+        for verb in _KNOWN_ACTION_VERBS:
+            spec = {
+                "ui": {
+                    "type": "button",
+                    "props": {"on_click": {"action": verb}},
+                }
+            }
+            assert validate_action_verbs(spec) == [], f"verb {verb!r} flagged unexpectedly"
+
+
+# ---------------------------------------------------------------------------
+# Unwired live buttons
+# ---------------------------------------------------------------------------
+
+
+class TestFindUnwiredLiveButtons:
+    def test_refresh_button_with_run_source_passes(self):
+        spec = {
+            "sources": {"pets": {"method": "GET", "path": "/pets", "bind": "state.pets"}},
+            "ui": {
+                "type": "button",
+                "props": {
+                    "label": "Refresh",
+                    "on_click": {"action": "run_source", "source": "pets"},
+                },
+            },
+        }
+        assert find_unwired_live_buttons(spec) == []
+
+    def test_refresh_button_with_api_passes(self):
+        spec = {
+            "ui": {
+                "type": "button",
+                "props": {
+                    "label": "Refresh pets",
+                    "on_click": {"action": "api", "url": "/pets", "target": "pets"},
+                },
+            }
+        }
+        assert find_unwired_live_buttons(spec) == []
+
+    def test_refresh_button_with_empty_on_click_flagged(self):
+        spec = {
+            "ui": {
+                "type": "button",
+                "props": {"label": "Refresh"},
+            }
+        }
+        issues = find_unwired_live_buttons(spec)
+        assert len(issues) == 1
+        assert "no on_click" in issues[0]["reason"]
+
+    def test_refresh_button_with_invented_verb_flagged(self):
+        # Captain's test-D failure shape — the agent invented
+        # ``action: "fetch"``. Catch is two-layered: the verb check
+        # already flags it, but the live-button walk catches the
+        # semantic too.
+        spec = {
+            "ui": {
+                "type": "button",
+                "props": {
+                    "label": "Refresh",
+                    "on_click": {
+                        "action": "fetch",
+                        "endpoint": "/pet/1",
+                        "target": "pet_rows",
+                    },
+                },
+            }
+        }
+        issues = find_unwired_live_buttons(spec)
+        assert len(issues) == 1
+        assert "no fetching action" in issues[0]["reason"]
+
+    def test_refresh_button_run_source_with_missing_key_flagged(self):
+        spec = {
+            "sources": {},
+            "ui": {
+                "type": "button",
+                "props": {
+                    "label": "Refresh",
+                    "on_click": {"action": "run_source", "source": "ghost"},
+                },
+            },
+        }
+        issues = find_unwired_live_buttons(spec)
+        assert len(issues) == 1
+        assert "'ghost'" in issues[0]["reason"]
+
+    def test_refresh_button_api_without_url_flagged(self):
+        spec = {
+            "ui": {
+                "type": "button",
+                "props": {
+                    "label": "Refresh",
+                    "on_click": {"action": "api", "target": "x"},
+                },
+            }
+        }
+        issues = find_unwired_live_buttons(spec)
+        assert len(issues) == 1
+        assert "no url" in issues[0]["reason"]
+
+    def test_non_live_button_is_not_flagged(self):
+        # A button labelled "Save draft" doesn't promise live behaviour
+        # — its on_click can be a plain set. Don't false-positive on
+        # those.
+        spec = {
+            "ui": {
+                "type": "button",
+                "props": {
+                    "label": "Save draft",
+                    "on_click": {"action": "set", "target": "draft.saved", "value": True},
+                },
+            }
+        }
+        assert find_unwired_live_buttons(spec) == []
+
+    def test_aria_label_also_matched(self):
+        # Sometimes the visible label is an icon and the live-claim is
+        # in aria-label only.
+        spec = {
+            "ui": {
+                "type": "button",
+                "props": {
+                    "aria_label": "Refresh data",
+                    "on_click": {"action": "frobnicate"},
+                },
+            }
+        }
+        assert len(find_unwired_live_buttons(spec)) == 1
+
+    def test_non_button_with_refresh_label_ignored(self):
+        # The walk only inspects ``type: "button"`` nodes. A heading
+        # that says "Refresh" is not a button and not in scope.
+        spec = {
+            "ui": {"type": "heading", "props": {"text": "Refresh history"}}
+        }
+        assert find_unwired_live_buttons(spec) == []
+
+    def test_non_dict_spec_returns_empty(self):
+        assert find_unwired_live_buttons(None) == []
+        assert find_unwired_live_buttons("string") == []
+
+
+# Silence ruff unused-import nudge.
+_ = pytest


### PR DESCRIPTION
## What

Closes the loophole class the prompt-side rule in #1194 missed. After all three RFC 04/05 PRs landed I re-walked inc 2b end-to-end on dev tip and asked the agent for a live pets table. What came back:

- A "Refresh" button whose `on_click` was `{action: "fetch", endpoint: "/pet/1", target: "pet_rows"}`. Ripple's event dispatcher has no `fetch` verb — its `default:` case `console.warn`s and returns, so the button takes clicks and silently no-ops.
- Pre-seeded `state.pet_rows` with hallucinated mock data shaped wrong for petstore (`category: "dogs"` string vs. real `{id, name}` object, `tags: "tag0"` string vs. real array). The canvas looked alive but every "live" row was static.

The PR #1194 rule said "label without source = broken." The LLM found the loophole: move the path off labels into a made-up verb, and seed mock data so the table renders. Prompt-engineering alone won't catch this.

## Two narrow walkers

| Walker | What it catches |
|---|---|
| `validate_action_verbs` | Any event-handler `action` field outside the dispatcher's closed verb set (`set, push, remove, open, navigate, toast, emit, pin, unpin, api, run_source, call_binding, flow, branch, confirm, validate, delay, invoke, toggle`). Returns the nearest known verb as a difflib suggestion so the corrective hint is targeted. |
| `find_unwired_live_buttons` | Buttons whose label / aria-label matches a live-claim keyword (refresh / reload / sync / pull / fetch / re-fetch / update from), where `on_click` is empty, has no fetching verb, references an undeclared source, or has `api` with no url. |

Both land in OSS `pocketpaw.ripple.manifest` alongside `validate_against_catalog`. The EE layer adds the strict / logged pair and wires them into `_gate_catalog` as siblings of the existing catalog gate — so the agent-create / edit path blocks (raises `ActionWiringViolationError`), and the PATCH / human-import path warns via structured log.

The `except CatalogViolationError` catch sites in `pockets/service.py` gain a sibling `except ActionWiringViolationError` returning `format_action_violations_for_agent(violations)` — same `ok=false` + corrective-string retry shape PR #1190 established for the chat agent.

## Why two walkers, not one

The verb check is mechanical and catches the dispatcher-level failure. The live-button walk is semantic — it catches the case where the verb is real (`set`, `toggle`) but the button still doesn't fetch what its label promises. They overlap on the captain's exact Test-D case (an unknown verb on a Refresh button); the logged path de-dups by path so the agent gets ONE corrective hint per offending handler, not two.

## Test plan

- [x] `uv run pytest tests/test_ripple_manifest_action_wiring.py` — 19 pure-walker tests (verb gate + Refresh-button detector, incl. captain's Test-D failure spec verbatim).
- [x] `uv run pytest tests/cloud/test_ripple_validator_action_wiring.py` — 14 EE-side tests: strict raises, logged emits structured warnings, formatter teaches the agent the right shape, `_gate_catalog` integration, manifest-unavailable skip path.
- [x] `uv run pytest tests/ -k "ripple or pocket or catalog or specialist"` — 435 passed, 1 skipped, 0 failures (no regression in adjacent catalog / specialist tests).

## Next

Once this merges I'll re-run the inc 2b loop on dev tip — the agent's same Test-D turn should now bounce back with the corrective hint and retry, and the resulting spec should either carry a real source OR not claim "live" via a Refresh button.