### PR TITLE
fix(pocket-specialist): strict action-wiring gate at end of edit batch

### DIFF
--- a/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
@@ -835,6 +835,54 @@ async def _apply_ops(input: Any, *, started: float) -> Any:
             "No edit ops were applied — every supplied op was rejected or "
             "unsupported. See warnings for the per-op reasons."
         )
+
+    # Post-apply action-wiring gate (#1196 follow-up). Each granular
+    # op writes through ``update_pocket`` which runs ``_gate_catalog``
+    # in LOGGED mode — fine for the partial mid-batch state, but it
+    # means the assembled-end-of-batch spec can still carry inert
+    # buttons (``action: "fetch"``) or live-labelled refreshers with
+    # no real fetch. PR #1196 caught those on the create path; this
+    # closes the same loophole on the edit path. Verified against the
+    # Test-D regression: agent renamed the fictitious verb from
+    # ``fetch`` to ``backend_fetch`` after the prompt-only fix — only
+    # a strict end-of-batch gate stops that retry-the-wrong-thing
+    # behaviour by forcing the corrective hint back to the agent.
+    if success:
+        try:
+            from pocketpaw_ee.cloud.pockets import service as _pockets_service
+            from pocketpaw_ee.cloud.ripple_validator import (
+                ActionWiringViolationError,
+                format_action_violations_for_agent,
+                validate_action_wiring_strict,
+            )
+
+            doc = await _pockets_service._fetch_pocket(input.pocket_id)
+            validate_action_wiring_strict(
+                doc.rippleSpec,
+                pocket_id=str(doc.id),
+                workspace_id=doc.workspace,
+            )
+        except ActionWiringViolationError as exc:
+            # Mirrors the ``nothing_applied`` fall-through: ops landed
+            # in Mongo, but the assembled spec is broken. Report
+            # ``ok=False`` with the corrective hint so the chat agent's
+            # ``is_error`` path (#1190) retries. The intermediate
+            # broken state in Mongo is overwritten by the next batch.
+            success = False
+            error_msg = format_action_violations_for_agent(exc.violations)
+            warnings.append(
+                "Edit applied ops but the assembled spec failed action-wiring "
+                "validation — see error for which handler / button needs the "
+                "real verb. The chat agent's next turn should retry."
+            )
+        except Exception:  # noqa: BLE001 — infra failures don't block edits
+            # Manifest fetch / Mongo read / etc. The gate is best-effort
+            # like the catalog walk: a transient infra failure must not
+            # mask a successful edit.
+            logger.warning(
+                "[pocket-specialist:edit] post-apply action-wiring check failed (skipped)",
+                exc_info=True,
+            )
     logger.info(
         "[pocket-specialist:edit] agent-mode apply complete: pocket_id=%s "
         "ops=%d rejected=%d unknown=%d success=%s duration=%dms",

--- a/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
@@ -5,6 +5,15 @@
 # new two-call protocol where the calling chat agent drafts the
 # rippleSpec inline using its own LLM and the specialist only runs
 # validate-and-persist on the returned draft.
+# Modified: 2026-05-23 (#1197) — ``_apply_ops`` now re-fetches the live
+# spec after a successful op batch and runs the strict action-wiring
+# gate against it. Without this, an end-of-batch spec with a hallucinated
+# verb (e.g. ``action: "backend_fetch"`` after the prompt rename) returned
+# ``ok=True, action="applied"`` — closing #1196's loophole on the agent-
+# edit path. On violation: ``ok=False`` + corrective text → MCP
+# ``is_error: true`` → chat agent retry via #1190. The post-apply gate
+# re-raises programming errors so a stale-import regression in the
+# validator surface stays loud, not silent.
 # Modified: 2026-05-22 (feat/bundled-templates, Increment 2a) —
 # ``AgentModeAdapter.create`` short-circuits on a ``hints.template_id``:
 # it loads the built-in template, passes its ``ripple_spec`` straight to
@@ -875,6 +884,12 @@ async def _apply_ops(input: Any, *, started: float) -> Any:
                 "validation — see error for which handler / button needs the "
                 "real verb. The chat agent's next turn should retry."
             )
+        except (ImportError, AttributeError, NameError, TypeError):
+            # Programming errors (stale import after a rename, attribute
+            # typo, wrong shape) must NOT be swallowed — that's the
+            # silent-success class this PR was filed to eliminate. Let
+            # them surface.
+            raise
         except Exception:  # noqa: BLE001 — infra failures don't block edits
             # Manifest fetch / Mongo read / etc. The gate is best-effort
             # like the catalog walk: a transient infra failure must not

--- a/tests/cloud/test_pocket_edit_action_gate.py
+++ b/tests/cloud/test_pocket_edit_action_gate.py
@@ -1,0 +1,282 @@
+# tests/cloud/test_pocket_edit_action_gate.py
+# 2026-05-23 — Post-apply action-wiring gate on the agent-mode edit path.
+#
+# Why this file exists. PR #1196 added ``validate_action_wiring_strict``
+# inside ``_gate_catalog`` so an agent-create that authors a fictitious
+# action verb (``action: "fetch"``) gets bounced with a corrective hint
+# and ``is_error: true`` (the chat agent's retry signal). But the
+# edit path runs through ``EditAgentModeAdapter._apply_ops``, which
+# commits granular ops via ``update_pocket`` — and that path uses
+# ``_gate_catalog(strict=False)`` so violations only LOG, never raise.
+#
+# Captain verified this gap live: after #1196 merged, asking the
+# specialist to "fix the broken Refresh button" produced a new spec
+# where the verb was renamed from ``fetch`` to ``backend_fetch`` —
+# same loophole, fresh disguise — and the run reported success because
+# no strict gate ran at the end of the batch.
+#
+# This file covers the follow-up: after _apply_ops finishes, validate
+# the assembled spec strictly and surface ``ok=False`` + the
+# corrective hint so the chat agent's ``is_error`` path (#1190) fires
+# a retry instead of accepting the broken assembly.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+async def _insert_pocket_with_root() -> Any:
+    """Insert a minimal pocket whose UI root is a ``flex`` ready to
+    accept children. The test uses ``add_node`` ops so the service
+    controls the new child ids — no need to pre-bake ids in the
+    fixture (the existing pocket-granular tests do the same).
+    """
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    spec = {
+        "version": "1.0",
+        "lifecycle": {"type": "persistent", "id": "pocket-edit-gate"},
+        "title": "Pets Tracker",
+        "name": "Pets Tracker",
+        "color": "#0A84FF",
+        "metadata": {"category": "custom"},
+        "ui": {
+            "id": "n_rootblob",
+            "type": "flex",
+            "props": {"direction": "column", "gap": "12px"},
+            "children": [],
+        },
+    }
+    doc = Pocket(
+        workspace="w1",
+        name="Pets Tracker",
+        description="",
+        type="custom",
+        icon="",
+        color="",
+        owner="u1",
+        visibility="workspace",
+        rippleSpec=spec,
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.fixture
+def agent_identity():
+    """Attach the ``w1`` / ``u1`` per-stream identity that
+    ``_agent_load_doc`` reads for its workspace + edit-access checks.
+    """
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_agent_identity,
+        detach_agent_identity,
+    )
+
+    tokens = attach_agent_identity(workspace_id="w1", user_id="u1")
+    try:
+        yield
+    finally:
+        detach_agent_identity(tokens)
+
+
+@pytest.fixture(autouse=True)
+def _stub_catalog_so_strict_gate_can_run(monkeypatch):
+    """The post-apply gate runs inside ``_gate_catalog`` which needs a
+    manifest. Stub the manifest lookup to a list that includes every
+    type the test uses, so the catalog walk passes cleanly and any
+    failure that surfaces comes from the action-wiring gate (the
+    behaviour we're actually testing).
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    async def _stub():
+        return ["flex", "heading", "button", "text", "table", "data-grid", "if", "each"]
+
+    monkeypatch.setattr(pockets_service, "_catalog_allowed_types", _stub)
+
+
+# ---------------------------------------------------------------------------
+# The captain's Test-D loophole — invented verb post-rename
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invented_verb_in_edit_returns_ok_false(mongo_db, agent_identity):
+    """REGRESSION: an edit that adds a Refresh button whose ``on_click``
+    uses a fictitious verb (``action: "backend_fetch"`` — the exact
+    rename the captain observed after the prompt-only fix) must
+    report ``ok=False`` so the chat agent retries instead of
+    accepting the broken assembly. The granular op itself lands in
+    Mongo — the post-apply strict gate is what surfaces the failure.
+    """
+    from pocketpaw_ee.agent.pocket_specialist.adapters import EditAgentModeAdapter
+    from pocketpaw_ee.agent.pocket_specialist.runtime import PocketSpecialistEditInput
+
+    from pocketpaw.config import Settings
+
+    doc = await _insert_pocket_with_root()
+    pocket_id = str(doc.id)
+
+    edit_input = PocketSpecialistEditInput(
+        pocket_id=pocket_id,
+        intent="Add a Refresh button that fetches /pet/1 from the backend.",
+        ops=[
+            {
+                "op": "add_node",
+                "args": {
+                    "parent_id": "n_rootblob",
+                    "spec": {
+                        "type": "button",
+                        "props": {
+                            "label": "Refresh",
+                            "on_click": {
+                                "action": "backend_fetch",
+                                "endpoint": "/pet/1",
+                                "target": "pet_rows",
+                            },
+                        },
+                    },
+                },
+            }
+        ],
+    )
+
+    adapter = EditAgentModeAdapter()
+    out = await adapter.edit(
+        edit_input,
+        workspace_id="w1",
+        user_id="u1",
+        settings=Settings(),
+    )
+
+    assert out.ok is False, (
+        f"agent-mode edit must reject an invented verb but reported ok=True; "
+        f"error={out.error!r} warnings={out.warnings!r}"
+    )
+    assert out.error and "backend_fetch" in out.error, (
+        f"corrective hint must name the offending verb; got error={out.error!r}"
+    )
+    # The corrective hint must teach the agent the right shape, not
+    # just say "rejected" — that's what unblocks the next retry.
+    assert any(
+        verb in (out.error or "") for verb in ("run_source", "api")
+    ), f"hint must recommend a real verb; got error={out.error!r}"
+
+
+# ---------------------------------------------------------------------------
+# Negative — a properly-wired edit still passes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proper_run_source_edit_passes(mongo_db, agent_identity):
+    """The gate does NOT false-positive on a properly-wired edit. A
+    Refresh button added via ``add_node`` whose ``on_click`` points
+    at a declared source must succeed."""
+    from pocketpaw_ee.agent.pocket_specialist.adapters import EditAgentModeAdapter
+    from pocketpaw_ee.agent.pocket_specialist.runtime import PocketSpecialistEditInput
+
+    from pocketpaw.config import Settings
+
+    doc = await _insert_pocket_with_root()
+    # Author a source up front so the run_source reference resolves.
+    doc.rippleSpec["sources"] = {
+        "pets": {
+            "method": "GET",
+            "path": "/pet/findByStatus?status=available",
+            "bind": "state.pets",
+            "refresh": ["pocket_open", "manual"],
+        }
+    }
+    await doc.save()
+    pocket_id = str(doc.id)
+
+    edit_input = PocketSpecialistEditInput(
+        pocket_id=pocket_id,
+        intent="Add a Refresh button wired to the pets source.",
+        ops=[
+            {
+                "op": "add_node",
+                "args": {
+                    "parent_id": "n_rootblob",
+                    "spec": {
+                        "type": "button",
+                        "props": {
+                            "label": "Refresh",
+                            "on_click": {"action": "run_source", "source": "pets"},
+                        },
+                    },
+                },
+            }
+        ],
+    )
+
+    adapter = EditAgentModeAdapter()
+    out = await adapter.edit(
+        edit_input,
+        workspace_id="w1",
+        user_id="u1",
+        settings=Settings(),
+    )
+
+    assert out.ok is True, (
+        f"properly-wired edit reported failure; error={out.error!r} warnings={out.warnings!r}"
+    )
+    assert not out.error
+
+
+# ---------------------------------------------------------------------------
+# Negative — non-live edits do not invoke the gate at all
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_live_edit_unaffected(mongo_db, agent_identity):
+    """A "Save draft" button using ``action: "set"`` is properly
+    wired and not live-claiming — the gate must leave it alone.
+    """
+    from pocketpaw_ee.agent.pocket_specialist.adapters import EditAgentModeAdapter
+    from pocketpaw_ee.agent.pocket_specialist.runtime import PocketSpecialistEditInput
+
+    from pocketpaw.config import Settings
+
+    doc = await _insert_pocket_with_root()
+    pocket_id = str(doc.id)
+
+    edit_input = PocketSpecialistEditInput(
+        pocket_id=pocket_id,
+        intent="Add a save-draft button.",
+        ops=[
+            {
+                "op": "add_node",
+                "args": {
+                    "parent_id": "n_rootblob",
+                    "spec": {
+                        "type": "button",
+                        "props": {
+                            "label": "Save draft",
+                            "on_click": {
+                                "action": "set",
+                                "target": "draft.saved",
+                                "value": True,
+                            },
+                        },
+                    },
+                },
+            }
+        ],
+    )
+
+    adapter = EditAgentModeAdapter()
+    out = await adapter.edit(
+        edit_input,
+        workspace_id="w1",
+        user_id="u1",
+        settings=Settings(),
+    )
+
+    assert out.ok is True, (
+        f"non-live edit incorrectly failed; error={out.error!r} warnings={out.warnings!r}"
+    )

--- a/tests/cloud/test_pocket_edit_action_gate.py
+++ b/tests/cloud/test_pocket_edit_action_gate.py
@@ -160,9 +160,9 @@ async def test_invented_verb_in_edit_returns_ok_false(mongo_db, agent_identity):
     )
     # The corrective hint must teach the agent the right shape, not
     # just say "rejected" — that's what unblocks the next retry.
-    assert any(
-        verb in (out.error or "") for verb in ("run_source", "api")
-    ), f"hint must recommend a real verb; got error={out.error!r}"
+    assert any(verb in (out.error or "") for verb in ("run_source", "api")), (
+        f"hint must recommend a real verb; got error={out.error!r}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Follow-up to #1196 closing the gap the captain hit on live verification: the strict action-wiring gate fires on the agent-CREATE path (`create_from_ripple_spec`) but the agent-EDIT path (`_apply_ops`) commits granular ops via `update_pocket` which runs `_gate_catalog` in **logged** mode. Violations warn but never raise. The assembled-end-of-batch spec can still be broken and the run reports `ok=True, action="applied"`.

Verified live after #1196 merged. Asked the chat agent to "fix the broken Refresh button." The spec came back with the verb renamed from `fetch` → `backend_fetch` — same loophole, fresh disguise — and the run reported success because no strict gate ran. The agent retried the wrong thing and the broken assembly persisted.

## How

After `_apply_ops` finishes its op loop, re-fetch the live spec and call `validate_action_wiring_strict` against it. On `ActionWiringViolationError`:

- `success = False`
- `error_msg = format_action_violations_for_agent(violations)` (the agent-readable hint shipped in #1196)
- a warning naming the failure mode is appended

The mcp_tool already surfaces `success=False` as `is_error: true` per #1190, so the chat agent's retry loop fires automatically.

## Roll-back posture

The granular ops persisted in Mongo by the time the gate runs — that's intentional. The intermediate broken state is overwritten by the next batch. A transactional roll-back would be overkill for what is, at this layer, a "tell the agent its assembly is wrong" signal. Infra failures (Mongo read, manifest fetch) inside the post-apply block are caught and logged — same best-effort posture as the catalog walk.

## Test plan

- [x] `uv run pytest tests/cloud/test_pocket_edit_action_gate.py` — 3 new integration tests against the real `EditAgentModeAdapter` + a mongomock Pocket:
  - Captain's exact Test-D regression (`action: "backend_fetch"` on a Refresh button → `ok=False`, error names the verb, hint recommends `run_source` / `api`).
  - Properly-wired Refresh button (`action: "run_source"` pointing at a declared source key) → `ok=True`.
  - Non-live button (`Save draft` using `action: "set"`) → `ok=True` — gate doesn't false-positive.
- [x] `uv run pytest tests/ -k "pocket or specialist or ripple or catalog or action"` — 550 passed, 0 failures.

## Verification next

Once this merges I'll re-run the captain's Test D one more time. Expectation: the agent's first attempt produces the invented verb, the gate rejects with the corrective hint, the chat agent retries with `set_source` + `run_source`, and the final spec carries a real source.