### PR TITLE
feat(prompts): RIGHT/WRONG examples for run_source wiring in edit block

### DIFF
--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -736,6 +736,29 @@ nothing else:
   invent `kind`, `url`, `auto_fetch`, `into`, or `id` — they do not exist.
 - The refresh button targets the source by `source` (the source key),
   NEVER `source_id`.
+- The dispatcher only knows a fixed set of action verbs — see
+  ``pocketpaw.ripple.manifest._KNOWN_ACTION_VERBS`` for the canonical
+  list. Anything else (``fetch``, ``refresh``, ``reload``, ``load``) is
+  silently dropped on click. For loading backend data the verb is
+  ALWAYS ``run_source``.
+
+  WRONG — invented verb, the dispatcher drops it:
+    {"action": "fetch", "source": "todos"}
+
+  RIGHT:
+    {"action": "run_source", "source": "todos"}
+
+  WRONG — no on_click, the button is decorative and relies on a
+  chat round-trip that never comes:
+    add_node(parent_id="root", type="button", props={
+      "label": "Refresh",
+    })
+
+  RIGHT — whole on_click wires straight to the source:
+    add_node(parent_id="root", type="button", props={
+      "label": "Refresh",
+      "on_click": {"action": "run_source", "source": "todos"},
+    })
 
   WRONG — inert, the runtime ignores it:
     {"action": "run_source", "source_id": "todos"}


### PR DESCRIPTION
## Summary

- Adds two new RIGHT/WRONG pairs to the EDIT specialist's `<live-data-sources>` block in `_pockets.py`: one for invented action verbs (`fetch` etc.), one for the whole `add_node` shape that wires a Refresh button's `on_click` to `run_source`.
- Points the reader at `pocketpaw.ripple.manifest._KNOWN_ACTION_VERBS` as the canonical source of accepted verbs, so the model can self-check before emitting and the mechanical reject doesn't need to be the only signal.
- Pairs cluster at the end of the block, right before `</live-data-sources>`, alongside the existing `source_id`/`source` example.

## Test plan

- [x] `uv run pytest tests/unit/test_pocket_delegation_rule_gaps.py -v` — 14 passed
- [x] `uv run pytest tests/cloud/test_pocket_agent_context.py -v -k "live_data_sources or block or bind"` — 4 passed
- [x] `uv run ruff check src/pocketpaw/ripple/_pockets.py` — clean
- [x] `uv run ruff format --check src/pocketpaw/ripple/_pockets.py` — already formatted