### PR TITLE
test(pockets): kanban node-bind preserved through specialist rebuild ops

### DIFF
--- a/tests/cloud/test_pocket_granular_ops.py
+++ b/tests/cloud/test_pocket_granular_ops.py
@@ -989,3 +989,344 @@ class TestArrayItemCanary:
             assert table["props"]["rows"][i] == original, f"row {i} drifted"
         assert table["props"]["rows"][9]["status"] == "Shipped"
         assert table["props"]["rows"][9]["customer"] == "C9"  # untouched field
+
+
+# ---------------------------------------------------------------------------
+# Kanban node-level bind: end-to-end through the specialist rebuild ops.
+# Simulates the granular op sequence a "rebuild this as a kanban" intent
+# would emit against an existing Todo Dashboard. Verifies the kanban node
+# carries ``bind`` at the NODE level (not inside ``props``) after the full
+# replace_node → normalize_ripple_spec → save round-trip, and that a
+# subsequent "drag-drop" state mutation persists to the same path the
+# bind targets — proving the kanban writeback path is structurally wired.
+#
+# Pinned by the interactive-by-default block in src/pocketpaw/ripple/_pockets.py
+# (the WRONG vs RIGHT examples around line 506-512) and the prompt-content
+# guard in tests/unit/test_pocket_delegation_rule_gaps.py::TestInteractiveBindRule.
+# This file holds the runtime contract; that file holds the teaching surface.
+# ---------------------------------------------------------------------------
+
+
+def _patches_with_real_normalizer(doc: _FakeDoc):
+    """Variant of ``_patches`` that leaves ``normalize_ripple_spec`` live so
+    we can verify the normalizer's preservation of node-level ``bind``
+    across the service's mutation-then-normalize cycle.
+
+    Returns ``(ExitStack, push_calls)``. Use as ``with ctx: ...``.
+    """
+    push_calls: list[dict[str, Any]] = []
+
+    def _capture(payload: dict[str, Any]) -> None:
+        push_calls.append(payload)
+
+    stack = ExitStack()
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service._PocketDoc.get",
+            new=AsyncMock(return_value=doc),
+        )
+    )
+    stack.enter_context(patch("pocketpaw_ee.cloud.pockets.service.emit", new=AsyncMock()))
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service._pocket_event_payload",
+            new=AsyncMock(return_value={"pocket_id": doc.id}),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.push_pocket_mutation",
+            new=MagicMock(side_effect=_capture),
+        )
+    )
+    # Intentionally NOT patching normalize_ripple_spec — we want the real
+    # normalizer running so bind-preservation is verified end-to-end.
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+            new=MagicMock(return_value=doc.workspace),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+            new=MagicMock(return_value=doc.owner),
+        )
+    )
+    return stack, push_calls
+
+
+def _todo_dashboard_doc() -> _FakeDoc:
+    """A minimal Todo Dashboard: an input bound to draft, an each loop
+    rendering one row per task. No kanban yet — that's what the rebuild
+    op introduces."""
+    spec = {
+        "version": "1.0",
+        "state": {
+            "draft": "",
+            "tasks": [
+                {"id": "t1", "label": "Wire kanban", "status": "todo"},
+                {"id": "t2", "label": "Verify bind", "status": "in_progress"},
+                {"id": "t3", "label": "Ship test", "status": "done"},
+            ],
+        },
+        "ui": {
+            "id": "n_root0000",
+            "type": "flex",
+            "props": {"direction": "column"},
+            "children": [
+                {
+                    "id": "n_inputbox",
+                    "type": "input",
+                    "bind": "draft",
+                    "props": {"placeholder": "Add task..."},
+                },
+                {
+                    "id": "n_taskloop",
+                    "type": "each",
+                    "items": "state.tasks",
+                    "item_as": "task",
+                    "children": [
+                        {
+                            "id": "n_taskrow0",
+                            "type": "flex",
+                            "props": {"direction": "row"},
+                            "children": [
+                                {
+                                    "id": "n_taskcb00",
+                                    "type": "checkbox",
+                                    "bind": "tasks.{index}.done",
+                                    "props": {},
+                                },
+                                {
+                                    "id": "n_tasktext",
+                                    "type": "text",
+                                    "props": {"text": "{task.label}"},
+                                },
+                            ],
+                        }
+                    ],
+                },
+            ],
+        },
+    }
+    return _FakeDoc("507f1f77bcf86cd799439099", spec)
+
+
+class TestKanbanNodeBindPreservedThroughRebuild:
+    """End-to-end: simulate the granular-op sequence the edit specialist
+    emits for a 'rebuild this as a kanban' intent against a Todo Dashboard.
+    Lock down the kanban-writeback contract one layer below the prompt.
+
+    The teaching surface (src/pocketpaw/ripple/_pockets.py interactive-by-default
+    block, line ~497-518) tells the model to put ``bind`` at node level.
+    The unit guards (tests/unit/test_pocket_delegation_rule_gaps.py::
+    TestInteractiveBindRule) check the prompt's content. THIS test pins
+    that when the specialist FOLLOWS that teaching — emitting
+    ``replace_node`` with ``{"type": "kanban", "bind": "state.tasks", ...}`` —
+    the spec round-trips through ``agent_replace_node`` and the live
+    ``normalize_ripple_spec`` without ``bind`` getting demoted into
+    ``props`` or stripped. Then a 'drag-drop' state mutation persists at
+    the same path the bind targets — proving the writeback is structurally
+    wired."""
+
+    @pytest.mark.asyncio
+    async def test_kanban_bind_lives_at_node_level_after_replace_node(self) -> None:
+        """The chat agent ships one ``replace_node`` op turning the
+        ``each`` loop into a kanban. The kanban subtree it sends carries
+        ``bind`` at the NODE level (sibling of ``type`` / ``props``).
+        Post-op, the persisted spec must keep ``bind`` at node level —
+        not inside ``props`` — so the renderer's writeback resolver can
+        find it."""
+        doc = _todo_dashboard_doc()
+
+        # The kanban subtree the specialist emits for "rebuild as a
+        # kanban". Mirrors the RIGHT example from the canonical prompt:
+        #   {"type": "kanban", "bind": "state.tasks",
+        #    "props": {"columns": [...], "columnKey": "status", ...}}
+        kanban_spec = {
+            "type": "kanban",
+            "bind": "state.tasks",
+            "props": {
+                "columns": [
+                    {"key": "todo", "label": "To Do"},
+                    {"key": "in_progress", "label": "In Progress"},
+                    {"key": "done", "label": "Done"},
+                ],
+                "columnKey": "status",
+                "cardLabel": "{task.label}",
+            },
+        }
+
+        ctx, push_calls = _patches_with_real_normalizer(doc)
+        with ctx:
+            result = await agent_context.replace_node_for_agent(
+                doc.id,
+                node_id="n_taskloop",
+                spec=kanban_spec,
+            )
+
+        assert result["ok"] is True, f"replace_node failed: {result.get('error')!r}"
+
+        # The each loop is gone, replaced by a kanban at the same slot.
+        children = doc.rippleSpec["ui"]["children"]
+        kanban_node = children[1]  # same position the each loop was in
+        assert kanban_node["type"] == "kanban"
+        # The node id is preserved (replace_node policy) so the SSE
+        # diff machinery can keep its element-anchor stable.
+        assert kanban_node["id"] == "n_taskloop"
+
+        # --- THE CORE CONTRACT ---
+        # bind lives at the NODE level, not inside props.
+        assert kanban_node.get("bind") == "state.tasks", (
+            f"kanban bind must be at node level after replace_node + normalize, "
+            f"got node={kanban_node!r}"
+        )
+        assert "bind" not in kanban_node.get("props", {}), (
+            f"kanban bind must NOT be nested inside props — that would render "
+            f"read-only and silently drop drag-drop writes (the bug the "
+            f"interactive-by-default block in _pockets.py guards against). "
+            f"props={kanban_node['props']!r}"
+        )
+        # The columns array (a regular prop) DOES live inside props.
+        assert isinstance(kanban_node["props"].get("columns"), list)
+        assert kanban_node["props"]["columnKey"] == "status"
+
+        # The other interactive nodes are untouched — input still binds
+        # to draft, both at node level.
+        input_node = children[0]
+        assert input_node["type"] == "input"
+        assert input_node.get("bind") == "draft"
+        assert "bind" not in input_node.get("props", {})
+
+        # One SSE push fired for the node replacement.
+        assert len(push_calls) == 1
+        assert push_calls[0]["action"] == "node_replaced"
+        # The subtree the push carries also has node-level bind.
+        pushed_subtree = push_calls[0]["subtree"]
+        assert pushed_subtree.get("bind") == "state.tasks"
+        assert "bind" not in pushed_subtree.get("props", {})
+
+        # Save fired exactly once.
+        assert doc.saves == 1
+
+    @pytest.mark.asyncio
+    async def test_kanban_drag_drop_persists_to_state_tasks(self) -> None:
+        """Programmatic drag-drop simulation: after the rebuild, the
+        ``on_drop`` handler the kanban renderer wires writes to the
+        same state path the node-level ``bind`` targets. We model this
+        as a ``set_state`` write to ``tasks[0].status`` and verify the
+        kanban's bind path is unchanged afterwards — i.e. the writeback
+        path is still resolvable from the bound node.
+
+        This is the spec-level equivalent of "drag card 1 from To Do to
+        Done, refresh, card stays in Done": the state mutation lands at
+        the path the bind reads from, so the rerender shows the new
+        column placement."""
+        doc = _todo_dashboard_doc()
+        kanban_spec = {
+            "type": "kanban",
+            "bind": "state.tasks",
+            "props": {
+                "columns": [
+                    {"key": "todo", "label": "To Do"},
+                    {"key": "in_progress", "label": "In Progress"},
+                    {"key": "done", "label": "Done"},
+                ],
+                "columnKey": "status",
+            },
+        }
+
+        ctx, push_calls = _patches_with_real_normalizer(doc)
+        with ctx:
+            replace_result = await agent_context.replace_node_for_agent(
+                doc.id,
+                node_id="n_taskloop",
+                spec=kanban_spec,
+            )
+            assert replace_result["ok"] is True
+
+            # Sanity: bind is at node level before the drag-drop.
+            kanban_before = doc.rippleSpec["ui"]["children"][1]
+            assert kanban_before["bind"] == "state.tasks"
+            assert "bind" not in kanban_before["props"]
+
+            # The "drag-drop": user drags card 1 (status=todo) into the
+            # "Done" column. The renderer's on_drop handler writes
+            # ``state.tasks[0].status = "done"`` — the same path the
+            # kanban's node-level bind targets.
+            drop_result = await agent_context.set_state_for_agent(
+                doc.id,
+                "tasks[0].status",
+                "done",
+            )
+
+        assert drop_result["ok"] is True
+        assert drop_result["old_value"] == "todo"
+
+        # State persisted to the bind target.
+        tasks = doc.rippleSpec["state"]["tasks"]
+        assert tasks[0]["status"] == "done"
+        # The two other tasks are byte-identical — drag-drop is a
+        # surgical edit, not a wholesale rewrite.
+        assert tasks[1]["status"] == "in_progress"
+        assert tasks[2]["status"] == "done"
+
+        # Kanban bind is unchanged — same path, same node-level position.
+        # If a future normalizer regression demoted bind into props on
+        # subsequent writes, the writeback path would be silently
+        # severed; this assertion catches that.
+        kanban_after = doc.rippleSpec["ui"]["children"][1]
+        assert kanban_after["bind"] == "state.tasks", (
+            "kanban bind must survive subsequent state writes — without it "
+            "the next render reads from the wrong path"
+        )
+        assert "bind" not in kanban_after["props"], (
+            "bind must NOT migrate into props on subsequent writes"
+        )
+
+        # Two SSE pushes total: one for the rebuild, one for the drop.
+        actions = [p["action"] for p in push_calls]
+        assert actions == ["node_replaced", "state_set"]
+        # The state_set push targets the same path the bind names.
+        drop_push = push_calls[1]
+        assert drop_push["path"] == "tasks[0].status"
+        assert drop_push["value"] == "done"
+
+        # Two saves total (replace + state mutation).
+        assert doc.saves == 2
+
+    @pytest.mark.asyncio
+    async def test_normalizer_does_not_demote_kanban_bind_into_props(self) -> None:
+        """Direct normalizer guard for the kanban rebuild scenario — even
+        if the chat agent later (mistakenly) ships an update that nests
+        ``bind`` inside ``props``, the spec we persist must surface the
+        bind at node level. This is the symmetric of
+        ``test_normalizer_preserves_bind_on_value_widgets`` (line 532),
+        zoomed in on the specific path-form the kanban rebuild uses
+        (``state.tasks`` not bare ``tasks``)."""
+        from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec
+
+        spec = {
+            "state": {"tasks": []},
+            "ui": {
+                "type": "flex",
+                "props": {},
+                "children": [
+                    {
+                        "type": "kanban",
+                        "bind": "state.tasks",
+                        "props": {
+                            "columns": [],
+                            "columnKey": "status",
+                        },
+                    },
+                ],
+            },
+        }
+        out = normalize_ripple_spec(spec)
+        assert out is not None
+        kanban = out["ui"]["children"][0]
+        assert kanban["bind"] == "state.tasks"
+        # Crucial: the normalizer must not move bind into props.
+        assert "bind" not in kanban["props"]


### PR DESCRIPTION
## Summary

- Pins the runtime contract that a "rebuild as kanban" intent over an existing Todo Dashboard produces a spec where ``bind`` lives at the kanban node level (not nested inside ``props``), survives ``normalize_ripple_spec``, and resolves to the same ``state.tasks`` path that a drag-drop write targets.
- Simulates the granular-op sequence the edit specialist would emit against a hand-crafted Todo Dashboard fixture — a ``replace_node`` swapping the each loop for a kanban, then a ``set_state`` standing in for the drag-drop persist — and walks both through the live ``agent_replace_node`` / ``agent_set_state`` wrappers with the real normalizer.
- Adds three tests under ``TestKanbanNodeBindPreservedThroughRebuild`` in ``tests/cloud/test_pocket_granular_ops.py``. No production code touched.

## Test surface choice

Dropped this in ``tests/cloud/test_pocket_granular_ops.py`` rather than ``tests/ee/agent/test_pocket_specialist/test_edit.py``:

- ``test_edit.py`` mocks the wrappers (``set_state_for_agent``, etc.) and asserts on the specialist's plumbing — it doesn't exercise the spec mutation path.
- ``test_pocket_granular_ops.py`` already runs the granular ops end-to-end against an in-memory ``_FakeDoc`` via the agent-context wrappers, which is exactly the layer the bind-preservation contract lives at.
- A small ``_patches_with_real_normalizer`` helper was added inline (mirrors the existing ``_patches`` but leaves ``normalize_ripple_spec`` live) so the round-trip is verified rather than skipped.

Sister content guard (kanban teaching surface) lives in ``tests/unit/test_pocket_delegation_rule_gaps.py::TestInteractiveBindRule``; sister normalizer guard lives in ``tests/cloud/test_pocket_agent_context.py::test_normalizer_preserves_bind_on_value_widgets``. This test sits between them as the runtime contract.

## Test plan

- [x] ``uv run pytest tests/cloud/test_pocket_granular_ops.py::TestKanbanNodeBindPreservedThroughRebuild -v`` — 3 passed
- [x] ``uv run pytest tests/cloud/test_pocket_granular_ops.py tests/cloud/test_pocket_agent_context.py -v -k "bind or kanban"`` — 5 passed (no regressions on neighbours)
- [x] ``uv run pytest tests/cloud/test_pocket_granular_ops.py -v`` — 36 passed (all neighbouring granular-op tests still green)
- [x] ``uv run pytest tests/unit/test_pocket_delegation_rule_gaps.py -v`` — 14 passed
- [x] ``uv run ruff check tests/cloud/test_pocket_granular_ops.py`` — clean
- [x] ``uv run ruff format --check tests/cloud/test_pocket_granular_ops.py`` — clean