### PR TITLE
feat: resumable chat runs (Tier 2 — arq worker)

### DIFF
--- a/docs/internal/2026-05-resumable-runs-deploy.md
+++ b/docs/internal/2026-05-resumable-runs-deploy.md
@@ -1,0 +1,131 @@
+# Tier 2 deploy — resumable chat runs with `arq` worker
+
+This is the operational guide for switching cloud chat runs from the
+**Tier 1 in-process** executor to the **Tier 2 arq worker** executor.
+
+Tier 1 still works after this PR ships; the worker is opt-in via env var so
+deployments can stage the rollout. Until `POCKETPAW_CLOUD_RUN_EXECUTOR=arq`
+is set, the web process runs the agent in-process exactly as before.
+
+Design + plan: `docs/plans/2026-05-22-resumable-chat-runs-design.md` +
+`docs/plans/2026-05-22-resumable-chat-runs.md`.
+
+## What changes operationally
+
+| Tier | Where the agent runs | Survives... |
+|------|---------------------|-------------|
+| 1 (default) | inside the web process (`asyncio.Task`) | refresh / session switch / explicit Stop |
+| 2 (`arq`)  | separate worker service | + web-process restart, + worker can scale independently |
+
+Both tiers stream events through Redis (`run:{run_id}:events`), so resume on
+reconnect works identically.
+
+## Coolify topology
+
+Add a **second service** to the same Coolify project, pointing at the same
+backend image and git ref as the web service.
+
+| Setting | Web service (existing) | Worker service (new) |
+|---------|-----------------------|----------------------|
+| Image / build | unchanged | same as web |
+| Start command | `uv run pocketpaw` (unchanged) | `uv run arq pocketpaw_ee.cloud.chat.runs.worker.WorkerSettings` |
+| Replicas | unchanged | start with 1; horizontal-scale by replica count |
+| Public port | unchanged | none (worker has no HTTP) |
+| Healthcheck | unchanged | none — arq is a pull worker; healthcheck the queue depth in Redis instead |
+
+### Required env on the worker
+
+Copy from the web service:
+
+- `POCKETPAW_REDIS_URL` — **must point at the same Redis** as the web service.
+- `CLOUD_MONGODB_URI` — **must point at the same Mongo** as the web service.
+- `ANTHROPIC_API_KEY` and any other agent-backend credentials the web service has.
+- Every `POCKETPAW_*` setting the agent uses at runtime (model selection,
+  feature flags, KB scopes, etc.). When in doubt, mirror the full env.
+
+The worker does **not** need: dashboard/web-only vars (`POCKETPAW_DASHBOARD_*`),
+auth secrets unique to the HTTP layer, or any `*_PUBLIC_URL`.
+
+### Flip the web service
+
+On the **web** service add:
+
+```
+POCKETPAW_CLOUD_RUN_EXECUTOR=arq
+```
+
+Redeploy the web service. POST `/api/v1/cloud/chat/{scope}/{scope_id}/agent`
+will now enqueue an `execute_run_job` instead of spawning an `asyncio.Task`.
+
+## Manual end-to-end verification (staging)
+
+Run with worker + web both up and `POCKETPAW_CLOUD_RUN_EXECUTOR=arq` on the web:
+
+1. **Happy path** — send a message in the desktop client. The reply streams
+   token-by-token. Proves: web → arq enqueue → worker pickup → worker writes
+   to Redis Stream → web GET-stream endpoint → client.
+2. **Refresh mid-stream** — send a message, press Ctrl-R while it's streaming.
+   The chat reappears after reload and the partial response keeps streaming
+   to completion. (Same Tier 1 behaviour, re-verified.)
+3. **Session switch mid-stream** — send a message in session A, switch to B,
+   then back. A's response is there and still streaming or completed.
+4. **Worker restart mid-stream** — send a message; while the worker is
+   processing, restart the worker service in Coolify. Expected:
+   - the run flips to `interrupted` (boot sweep marks it within ~5s)
+   - the partial that already streamed stays visible to the user
+   - the SSE subscriber on the web side gets a terminal `interrupted`
+     frame and finalises (instead of waiting out the heartbeat)
+   - the message renders with the Retry affordance (frontend PR)
+5. **Two sessions concurrent** — open two sessions, send in both at once;
+   both should stream independently with no interference.
+
+## Rollback
+
+Two-step rollback, web-first:
+
+1. On the **web** service: unset `POCKETPAW_CLOUD_RUN_EXECUTOR` (or set to
+   `inprocess`). Redeploy the web service. New runs now execute in-process
+   again.
+2. Drain & stop the **worker** service. Any in-flight jobs will be marked
+   `interrupted` by the in-process heartbeat sweeper (10-minute cutoff) or by
+   the next worker boot — whichever happens first. Users see the Retry
+   affordance and can resend.
+
+Rollback is independent of any data migration: the `chat_runs` collection
+schema is identical between tiers, and the Redis Stream layout is unchanged.
+
+## Crash policy
+
+`WorkerSettings.max_tries = 1` — no auto-retry. A job that raises lands as
+`failed` (or `interrupted` if killed mid-execution). LLM token streams cannot
+be resumed mid-generation, so silently re-running would double-bill and risk
+emitting a partial duplicate. The user decides via Retry.
+
+## Operational notes
+
+- Worker boot sweep uses a **5-second cutoff** (`worker._BOOT_SWEEP_OLDER_THAN_SECONDS`).
+  A run that the web enqueued less than 5s before the worker booted is left
+  alone for the worker to pick up.
+- Heartbeat sweep on the web side still runs every 5 minutes with a 10-minute
+  cutoff — that catches in-process orphans during the Tier-1 mode and also
+  serves as a safety net under Tier 2 if both worker replicas crash without
+  rebooting.
+- Multiple worker replicas are safe: arq uses a single Redis-backed queue, so
+  each job goes to exactly one worker.
+
+## Files / env reference
+
+- Worker entry: `ee/pocketpaw_ee/cloud/chat/runs/worker.py:WorkerSettings`
+- Executor seam: `ee/pocketpaw_ee/cloud/chat/runs/executor.py:get_executor`
+- arq executor: `ee/pocketpaw_ee/cloud/chat/runs/arq_executor.py:ArqExecutor`
+- Sweep: `ee/pocketpaw_ee/cloud/chat/runs/sweeper.py:sweep_stale_runs`
+
+Env vars (all also documented in `backend/CLAUDE.md` → Key Conventions):
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `POCKETPAW_CLOUD_RUN_EXECUTOR` | `inprocess` | Set to `arq` on the web service to enable Tier 2 |
+| `POCKETPAW_REDIS_URL` | — | Required for both tiers; web + worker must share |
+| `CLOUD_MONGODB_URI` | `mongodb://localhost:27017/paw-enterprise` | Web + worker must share |
+| `POCKETPAW_CLOUD_RUN_STREAM_TTL` | `3600` | Redis Stream retention after a run terminates |
+| `POCKETPAW_CLOUD_STREAM_TRANSPORT` | `redis` | Future hook for non-Redis backends |

--- a/ee/pocketpaw_ee/cloud/_core/realtime/emit.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/emit.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 
+from pocketpaw_ee.cloud._core.realtime import xproc
 from pocketpaw_ee.cloud._core.realtime.bus import get_bus
 from pocketpaw_ee.cloud._core.realtime.events import Event
 
@@ -18,6 +19,14 @@ logger = logging.getLogger(__name__)
 
 
 async def emit(event: Event) -> None:
+    # Tier 2: when running inside the arq worker, the local InProcessBus has
+    # no subscribers (every listener lives in the web process). Ship the
+    # event over the cross-process bridge instead — the web's xproc consumer
+    # publishes it to its own local bus, where the real listeners are wired.
+    if xproc.is_worker():
+        await xproc.publish_bus_envelope(event)
+        return
+
     bus = get_bus()  # raises AssertionError if not initialized (programmer error)
     try:
         await bus.publish(event)

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import ClassVar
 
+EVENT_REGISTRY: dict[str, type[Event]] = {}
+
 
 @dataclass
 class Event:
@@ -21,6 +23,41 @@ class Event:
         cls_type = getattr(type(self), "EVENT_TYPE", "")
         if cls_type:
             self.type = cls_type
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        # Register subclasses by their EVENT_TYPE discriminator so a
+        # cross-process consumer can reconstruct the original class from a
+        # JSON envelope. Subclasses without EVENT_TYPE (intermediate bases)
+        # are skipped.
+        evt_type = getattr(cls, "EVENT_TYPE", "")
+        if evt_type:
+            EVENT_REGISTRY[evt_type] = cls
+
+
+def rebuild_event(payload: dict) -> Event:
+    """Reconstruct an ``Event`` (or matching subclass) from a JSON envelope.
+
+    Unknown ``type`` values fall back to the base ``Event`` so a newer worker
+    shipping a fresh event type doesn't crash an older web consumer. Missing
+    ``ts`` defaults to now.
+    """
+    evt_type = str(payload.get("type") or "")
+    data = payload.get("data", {})
+    if not isinstance(data, dict):
+        raise TypeError(f"event payload `data` must be a dict, got {type(data).__name__}")
+    ts_raw = payload.get("ts")
+    if ts_raw is None:
+        ts = datetime.now(UTC)
+    else:
+        ts = datetime.fromisoformat(str(ts_raw))
+    cls = EVENT_REGISTRY.get(evt_type, Event)
+    inst = cls(data=data, ts=ts)
+    # Subclasses overwrite `type` in __post_init__; the base Event needs the
+    # explicit value so listeners that match on the string still work.
+    if cls is Event:
+        inst.type = evt_type
+    return inst
 
 
 # Workspace

--- a/ee/pocketpaw_ee/cloud/_core/realtime/xproc.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/xproc.py
@@ -1,0 +1,195 @@
+"""Cross-process bridge for the realtime bus and WebSocket fan-out.
+
+Tier 2 of resumable chat runs splits the agent loop off into a separate
+worker process. The worker's ``InProcessBus`` has no subscribers — every
+listener lives in the web process — and the worker's ``WsManager`` has no
+client connections. ``xproc`` ships envelopes through a Redis Stream so the
+web process re-delivers them locally as if the emit had happened there.
+
+Tier 1 (in-process executor) is unaffected: ``set_role`` defaults to ``web``,
+``publish_*`` short-circuits, and the consumer runs but reads only events
+emitted from arq workers — typically zero, since Tier 1 doesn't run any.
+
+The stream + consumer group survives both worker and web restarts: arq
+workers keep XADD-ing; the web's consumer group XACKs each delivered entry,
+so a fresh web process resumes from the last unacked cursor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from typing import Literal
+
+from redis import exceptions as redis_exceptions
+
+from pocketpaw_ee.cloud._core.realtime.bus import get_bus
+from pocketpaw_ee.cloud._core.realtime.events import Event, rebuild_event
+from pocketpaw_ee.cloud._core.redis_client import get_redis
+
+logger = logging.getLogger(__name__)
+
+XPROC_STREAM = "cloud:xproc:events"
+XPROC_GROUP = "cloud-web"
+XPROC_BLOCK_MS = 15000
+XPROC_BATCH = 64
+# Cap the stream so a stalled consumer can't grow Redis unbounded; ~10k
+# entries is roughly an hour of busy traffic and survives short outages.
+XPROC_MAXLEN = 10000
+
+_ROLE: Literal["web", "worker"] = "web"
+
+
+def set_role(role: Literal["web", "worker"]) -> None:
+    """Pin the current process role. Call once at startup: ``worker`` from
+    the arq worker's ``_startup`` hook, ``web`` (default) everywhere else."""
+    global _ROLE
+    _ROLE = role
+
+
+def is_worker() -> bool:
+    return _ROLE == "worker"
+
+
+# --- publish (worker side) --------------------------------------------------
+
+
+async def publish_bus_envelope(event: Event) -> None:
+    """Worker → web: ship a bus event for ``bus.publish`` on the web side."""
+    if not is_worker():
+        return
+    envelope = {
+        "kind": "bus",
+        "type": event.type,
+        "data": event.data,
+        "ts": event.ts.isoformat(),
+    }
+    try:
+        await _xadd(envelope)
+    except Exception:
+        # Best-effort delivery, like the local bus. A dropped envelope means
+        # one missed downstream side-effect — bad, but not worse than today's
+        # Tier 2 behavior where the same event is silently dropped.
+        logger.exception("xproc.publish_bus_envelope failed for %s", event.type)
+
+
+async def publish_ws_envelope(
+    *,
+    scope_id: str,
+    recipients: list[str],
+    ws_type: str,
+    ws_data: dict,
+) -> None:
+    """Worker → web: ship a WS broadcast for ``manager.broadcast_to_group``."""
+    if not is_worker():
+        return
+    envelope = {
+        "kind": "ws",
+        "scope_id": scope_id,
+        "recipients": list(recipients),
+        "type": ws_type,
+        "data": ws_data,
+    }
+    try:
+        await _xadd(envelope)
+    except Exception:
+        logger.exception("xproc.publish_ws_envelope failed for %s", ws_type)
+
+
+async def _xadd(envelope: dict) -> None:
+    redis = get_redis()
+    await redis.xadd(
+        XPROC_STREAM,
+        {"envelope": json.dumps(envelope)},
+        maxlen=XPROC_MAXLEN,
+        approximate=True,
+    )
+
+
+# --- consume (web side) -----------------------------------------------------
+
+
+async def run_consumer(
+    *,
+    consumer_name: str | None = None,
+    block_ms: int = XPROC_BLOCK_MS,
+) -> None:
+    """Long-running task: read envelopes and dispatch to local bus + manager.
+
+    Idempotent re consumer-group creation (BUSYGROUP is swallowed); resilient
+    to transient Redis/dispatch errors (logged, brief backoff, loop continues).
+    Cancellation propagates out so the lifecycle hook can stop it cleanly.
+    """
+    redis = get_redis()
+    try:
+        await redis.xgroup_create(XPROC_STREAM, XPROC_GROUP, id="$", mkstream=True)
+    except redis_exceptions.ResponseError as exc:
+        if "BUSYGROUP" not in str(exc):
+            raise
+
+    name = consumer_name or f"web-{uuid.uuid4().hex[:8]}"
+    logger.info("xproc consumer %s starting on %s", name, XPROC_STREAM)
+
+    while True:
+        try:
+            resp = await redis.xreadgroup(
+                XPROC_GROUP,
+                name,
+                {XPROC_STREAM: ">"},
+                count=XPROC_BATCH,
+                block=block_ms,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("xproc consumer xreadgroup failed; backing off")
+            await asyncio.sleep(1.0)
+            continue
+
+        if not resp:
+            continue
+
+        for _key, entries in resp:
+            for entry_id, fields in entries:
+                try:
+                    envelope = json.loads(fields["envelope"])
+                    await _dispatch(envelope)
+                except Exception:
+                    logger.exception("xproc dispatch failed for entry %s", entry_id)
+                finally:
+                    # Always ack — a bad envelope must not stall the stream.
+                    # Worst case the side-effect is missed once and the user
+                    # observes a one-off glitch; better than blocking forever.
+                    try:
+                        await redis.xack(XPROC_STREAM, XPROC_GROUP, entry_id)
+                    except Exception:
+                        logger.debug("xproc xack failed for %s", entry_id, exc_info=True)
+
+
+async def _dispatch(envelope: dict) -> None:
+    kind = envelope.get("kind")
+    if kind == "bus":
+        event = rebuild_event(envelope)
+        await get_bus().publish(event)
+    elif kind == "ws":
+        # Lazy import: the chat WS module pulls FastAPI types we don't want
+        # to load when the consumer isn't actually dispatching WS frames.
+        from pocketpaw_ee.cloud.chat.schemas import WsOutbound
+        from pocketpaw_ee.cloud.chat.ws import manager
+
+        await manager.broadcast_to_group(
+            envelope["scope_id"],
+            envelope.get("recipients", []),
+            WsOutbound(type=envelope["type"], data=envelope.get("data", {})),
+        )
+    else:
+        # Forward-compatible: skip envelopes from a newer worker rather than
+        # crashing the consumer.
+        logger.warning("xproc consumer: unknown envelope kind %r", kind)
+
+
+def _reset_for_tests() -> None:
+    global _ROLE
+    _ROLE = "web"

--- a/ee/pocketpaw_ee/cloud/chat/runs/arq_executor.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/arq_executor.py
@@ -7,12 +7,15 @@ lifetime of the process.
 
 from __future__ import annotations
 
+import logging
 import os
 
 from arq import create_pool
 from arq.connections import ArqRedis, RedisSettings
 
 from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
+
+logger = logging.getLogger(__name__)
 
 _pool: ArqRedis | None = None
 
@@ -25,6 +28,23 @@ async def _get_pool() -> ArqRedis:
             raise RuntimeError("POCKETPAW_REDIS_URL is not set — the arq executor needs Redis.")
         _pool = await create_pool(RedisSettings.from_dsn(url))
     return _pool
+
+
+async def close_pool() -> None:
+    """Close the cached arq Redis pool on web-process shutdown.
+
+    No-op when the pool was never built (Tier 0 / Tier 1 deployments).
+    A failing aclose is swallowed — shutdown paths can't afford to raise.
+    """
+    global _pool
+    pool = _pool
+    _pool = None
+    if pool is None:
+        return
+    try:
+        await pool.aclose()
+    except Exception:
+        logger.debug("arq pool aclose failed during shutdown", exc_info=True)
 
 
 class ArqExecutor:

--- a/ee/pocketpaw_ee/cloud/chat/runs/arq_executor.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/arq_executor.py
@@ -1,0 +1,42 @@
+"""Tier 2 executor — enqueues the run as an arq job for a separate worker
+process to execute. Selected when ``POCKETPAW_CLOUD_RUN_EXECUTOR=arq``.
+
+The arq pool is lazily constructed on first ``submit`` and cached for the
+lifetime of the process.
+"""
+
+from __future__ import annotations
+
+import os
+
+from arq import create_pool
+from arq.connections import ArqRedis, RedisSettings
+
+from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
+
+_pool: ArqRedis | None = None
+
+
+async def _get_pool() -> ArqRedis:
+    global _pool
+    if _pool is None:
+        url = os.environ.get("POCKETPAW_REDIS_URL", "").strip()
+        if not url:
+            raise RuntimeError("POCKETPAW_REDIS_URL is not set — the arq executor needs Redis.")
+        _pool = await create_pool(RedisSettings.from_dsn(url))
+    return _pool
+
+
+class ArqExecutor:
+    """RunExecutor impl — enqueues an ``execute_run_job`` for the worker."""
+
+    async def submit(self, spec: RunSpec) -> None:
+        pool = await _get_pool()
+        # RunSpec is intentionally JSON-primitive so it survives the
+        # arq/pickle boundary without custom serialisers.
+        await pool.enqueue_job("execute_run_job", spec.model_dump())
+
+
+def _reset_for_tests() -> None:
+    global _pool
+    _pool = None

--- a/ee/pocketpaw_ee/cloud/chat/runs/executor.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/executor.py
@@ -49,9 +49,7 @@ def get_executor() -> RunExecutor:
     if _executor is None:
         mode = os.environ.get("POCKETPAW_CLOUD_RUN_EXECUTOR", "inprocess").lower()
         if mode == "arq":
-            from pocketpaw_ee.cloud.chat.runs.arq_executor import (  # type: ignore[import-not-found,import-untyped]
-                ArqExecutor,
-            )
+            from pocketpaw_ee.cloud.chat.runs.arq_executor import ArqExecutor
 
             _executor = ArqExecutor()
         else:

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -566,6 +566,38 @@ async def _iter_agent_events(
         yield ev
 
 
+async def _handle_interrupted_cleanup(
+    spec: RunSpec,
+    ctx: ScopeContext,
+    full_text: str,
+    transport: Any,
+) -> None:
+    """Best-effort finalisation when ``execute_run`` is cancelled by the host.
+
+    Each step is wrapped so a single transient failure (Mongo, Redis) can't
+    block the others — every action is independently best-effort. The
+    caller wraps THIS in ``asyncio.shield`` so a second cancel arriving
+    during the cleanup can't abort it mid-flight.
+    """
+    try:
+        await _broadcast_agent_typing(ctx, active=False)
+    except Exception:
+        logger.debug("agent.typing(active=False) broadcast failed", exc_info=True)
+    try:
+        await run_service.mark_terminal(
+            spec.run_id,
+            status="interrupted",
+            partial_text=full_text,
+        )
+    except Exception:
+        logger.exception("mark_terminal(interrupted) failed for %s", spec.run_id)
+    try:
+        await transport.append_event(spec.run_id, "interrupted", {"run_id": spec.run_id})
+        await transport.set_ttl(spec.run_id, _stream_ttl())
+    except Exception:
+        logger.debug("interrupted stream write failed", exc_info=True)
+
+
 async def execute_run(spec: RunSpec) -> None:
     """Run the agent for ``spec`` and write every event to the transport.
 
@@ -586,7 +618,6 @@ async def execute_run(spec: RunSpec) -> None:
 
     full_text = ""
     cancelled = False
-    interrupted = False
     error: Exception | None = None
     backend_error_message: str | None = None
     try:
@@ -607,11 +638,25 @@ async def execute_run(spec: RunSpec) -> None:
                 backend_error_message = str(event_data.get("message") or "")
                 break
     except asyncio.CancelledError:
-        # The task itself was cancelled (worker shutdown, host signal). Mark
-        # the doc and append a terminal stream frame so live subscribers
-        # finalise, then re-raise so arq actually exits.
-        interrupted = True
+        # The task itself was cancelled (worker shutdown, host signal). Run
+        # the interrupted-cleanup INSIDE the except clause so the bare
+        # ``raise`` below re-raises the original CancelledError instance —
+        # preserving the cancel-reason arq supplies via ``task.cancel(msg)``
+        # and the original traceback. The cleanup is shielded so a second
+        # cancel (SIGKILL grace window) can't abort mark_terminal mid-flight
+        # and strand the doc in ``running`` with no terminal stream frame.
         logger.info("execute_run %s cancelled by host", spec.run_id)
+        try:
+            await asyncio.shield(_handle_interrupted_cleanup(spec, ctx, full_text, transport))
+        except asyncio.CancelledError:
+            # The outer await is cancelled but the shielded inner task
+            # continues running to completion in the background. That's
+            # exactly what we want; just don't re-raise from this layer —
+            # let the original cancel propagate after the except clause.
+            pass
+        except Exception:
+            logger.exception("interrupted cleanup raised after shield for %s", spec.run_id)
+        raise
     except Exception as exc:
         error = exc
         logger.exception("execute_run %s crashed", spec.run_id)
@@ -622,30 +667,12 @@ async def execute_run(spec: RunSpec) -> None:
         )
 
     # Drop the typing indicator before persist so a slow Mongo write
-    # doesn't leave it stuck on.
+    # doesn't leave it stuck on. Only reached on non-cancelled paths;
+    # the cancelled path handles typing-off inside the cleanup helper.
     try:
         await _broadcast_agent_typing(ctx, active=False)
     except Exception:
         logger.debug("agent.typing(active=False) broadcast failed", exc_info=True)
-
-    if interrupted:
-        # Host-driven cancellation: persist what we have, append the terminal
-        # frame so SSE subscribers finalise without waiting on heartbeats,
-        # then re-raise CancelledError so arq exits.
-        try:
-            await run_service.mark_terminal(
-                spec.run_id,
-                status="interrupted",
-                partial_text=full_text,
-            )
-        except Exception:
-            logger.exception("mark_terminal(interrupted) failed for %s", spec.run_id)
-        try:
-            await transport.append_event(spec.run_id, "interrupted", {"run_id": spec.run_id})
-            await transport.set_ttl(spec.run_id, _stream_ttl())
-        except Exception:
-            logger.debug("interrupted stream write failed", exc_info=True)
-        raise asyncio.CancelledError()
 
     if error is not None or backend_error_message is not None:
         err_msg = str(error) if error is not None else (backend_error_message or "")

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -15,6 +15,7 @@ from typing import Any
 from pocketpaw.agents.pool import (  # type: ignore[import-untyped]
     get_agent_pool,
 )
+from pocketpaw_ee.cloud._core.realtime import xproc
 from pocketpaw_ee.cloud.chat.agent_service import (
     ScopeContext,
     ScopeKind,
@@ -68,9 +69,6 @@ async def _broadcast_message_new(
     attachments: list[dict[str, Any]],
     created_at: datetime,
 ) -> None:
-    from pocketpaw_ee.cloud.chat.schemas import WsOutbound
-    from pocketpaw_ee.cloud.chat.ws import manager
-
     # Include the caller so OS chat panels (which render off chatRoomsStore
     # via WS `message.new`) see the agent reply land without a refresh. The
     # new resumable-runs SSE writes to chatStore, which os/ChatPanel doesn't
@@ -78,43 +76,60 @@ async def _broadcast_message_new(
     recipients = list(ctx.members) if ctx.members else [ctx.user_id]
     if not recipients:
         return
+    data = {
+        "id": message_id,
+        "group": ctx.scope_id,
+        "sender_type": "agent",
+        "agent": ctx.target_agent_id,
+        "content": content,
+        "attachments": attachments,
+        "created_at": created_at.isoformat(),
+    }
+    if xproc.is_worker():
+        await xproc.publish_ws_envelope(
+            scope_id=ctx.scope_id,
+            recipients=recipients,
+            ws_type="message.new",
+            ws_data=data,
+        )
+        return
+
+    from pocketpaw_ee.cloud.chat.schemas import WsOutbound
+    from pocketpaw_ee.cloud.chat.ws import manager
+
     await manager.broadcast_to_group(
         ctx.scope_id,
         recipients,
-        WsOutbound(
-            type="message.new",
-            data={
-                "id": message_id,
-                "group": ctx.scope_id,
-                "sender_type": "agent",
-                "agent": ctx.target_agent_id,
-                "content": content,
-                "attachments": attachments,
-                "created_at": created_at.isoformat(),
-            },
-        ),
+        WsOutbound(type="message.new", data=data),
     )
 
 
 async def _broadcast_agent_typing(ctx: ScopeContext, active: bool) -> None:
-    from pocketpaw_ee.cloud.chat.schemas import WsOutbound
-    from pocketpaw_ee.cloud.chat.ws import manager
-
     others = [m for m in ctx.members if m != ctx.user_id]
     if not others:
         return
+    data = {
+        "scope": ctx.kind.value,
+        "scope_id": ctx.scope_id,
+        "agent_id": ctx.target_agent_id,
+        "active": active,
+    }
+    if xproc.is_worker():
+        await xproc.publish_ws_envelope(
+            scope_id=ctx.scope_id,
+            recipients=others,
+            ws_type="agent.typing",
+            ws_data=data,
+        )
+        return
+
+    from pocketpaw_ee.cloud.chat.schemas import WsOutbound
+    from pocketpaw_ee.cloud.chat.ws import manager
+
     await manager.broadcast_to_group(
         ctx.scope_id,
         others,
-        WsOutbound(
-            type="agent.typing",
-            data={
-                "scope": ctx.kind.value,
-                "scope_id": ctx.scope_id,
-                "agent_id": ctx.target_agent_id,
-                "active": active,
-            },
-        ),
+        WsOutbound(type="agent.typing", data=data),
     )
 
 

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -571,6 +571,7 @@ async def execute_run(spec: RunSpec) -> None:
 
     full_text = ""
     cancelled = False
+    interrupted = False
     error: Exception | None = None
     backend_error_message: str | None = None
     try:
@@ -590,6 +591,12 @@ async def execute_run(spec: RunSpec) -> None:
                 # doesn't get flipped to ``completed`` by the empty-text branch.
                 backend_error_message = str(event_data.get("message") or "")
                 break
+    except asyncio.CancelledError:
+        # The task itself was cancelled (worker shutdown, host signal). Mark
+        # the doc and append a terminal stream frame so live subscribers
+        # finalise, then re-raise so arq actually exits.
+        interrupted = True
+        logger.info("execute_run %s cancelled by host", spec.run_id)
     except Exception as exc:
         error = exc
         logger.exception("execute_run %s crashed", spec.run_id)
@@ -605,6 +612,25 @@ async def execute_run(spec: RunSpec) -> None:
         await _broadcast_agent_typing(ctx, active=False)
     except Exception:
         logger.debug("agent.typing(active=False) broadcast failed", exc_info=True)
+
+    if interrupted:
+        # Host-driven cancellation: persist what we have, append the terminal
+        # frame so SSE subscribers finalise without waiting on heartbeats,
+        # then re-raise CancelledError so arq exits.
+        try:
+            await run_service.mark_terminal(
+                spec.run_id,
+                status="interrupted",
+                partial_text=full_text,
+            )
+        except Exception:
+            logger.exception("mark_terminal(interrupted) failed for %s", spec.run_id)
+        try:
+            await transport.append_event(spec.run_id, "interrupted", {"run_id": spec.run_id})
+            await transport.set_ttl(spec.run_id, _stream_ttl())
+        except Exception:
+            logger.debug("interrupted stream write failed", exc_info=True)
+        raise asyncio.CancelledError()
 
     if error is not None or backend_error_message is not None:
         err_msg = str(error) if error is not None else (backend_error_message or "")

--- a/ee/pocketpaw_ee/cloud/chat/runs/sweeper.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/sweeper.py
@@ -14,18 +14,27 @@ Two cadences share this:
 
 When the run's Redis stream is still alive, the sweeper appends an
 ``interrupted`` terminal event so any live SSE subscriber finalises
-immediately instead of waiting for the heartbeat timeout.
+immediately instead of waiting for the heartbeat timeout. The append step
+is silently skipped when ``POCKETPAW_REDIS_URL`` is unset (Tier 0
+deployments) so no warning spam appears on every tick.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 from datetime import UTC, datetime, timedelta
 
 from pocketpaw_ee.cloud.chat.runs.transport import get_stream_transport
 from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_OLDER_THAN_MINUTES = 10
+# Bound the lifetime of any stream the sweeper might resurrect via the
+# append step (stream_exists/append_event race window) so a TTL-evicted key
+# can't be brought back from the dead to live forever.
+_STREAM_TTL_AFTER_INTERRUPT = 3600
 
 
 async def sweep_stale_runs(
@@ -35,29 +44,30 @@ async def sweep_stale_runs(
 ) -> int:
     """Mark queued/running runs older than the cutoff as ``interrupted``.
 
-    Pass either ``older_than_minutes`` or ``older_than_seconds``; if both are
-    omitted, defaults to 10 minutes. Returns the number of docs updated.
+    Pass exactly one of ``older_than_minutes`` or ``older_than_seconds`` (the
+    other must be ``None``). Both ``None`` defaults to 10 minutes; passing
+    both raises ``ValueError`` so the caller's intent stays unambiguous.
+    Returns the number of docs updated.
     """
+    if older_than_minutes is not None and older_than_seconds is not None:
+        raise ValueError(
+            "sweep_stale_runs: pass exactly one of older_than_minutes / older_than_seconds"
+        )
     if older_than_seconds is not None:
         cutoff = datetime.now(UTC) - timedelta(seconds=older_than_seconds)
+    elif older_than_minutes is not None:
+        cutoff = datetime.now(UTC) - timedelta(minutes=older_than_minutes)
     else:
-        cutoff = datetime.now(UTC) - timedelta(minutes=older_than_minutes or 10)
+        cutoff = datetime.now(UTC) - timedelta(minutes=_DEFAULT_OLDER_THAN_MINUTES)
+
     stale = await ChatRunDoc.find(
         {"status": {"$in": ["queued", "running"]}},
         ChatRunDoc.createdAt < cutoff,
     ).to_list()
     if not stale:
         return 0
-    # Resolve the transport once per sweep; if Redis is unavailable we still
-    # mark interruptions in Mongo, we just can't wake live SSE subscribers.
-    try:
-        transport = get_stream_transport()
-    except Exception:
-        logger.warning(
-            "sweep_stale_runs: stream transport unavailable, interrupt events will not be appended",
-            exc_info=True,
-        )
-        transport = None
+
+    transport = _resolve_transport()
     now = datetime.now(UTC)
     for doc in stale:
         doc.status = "interrupted"  # type: ignore[assignment]
@@ -67,6 +77,11 @@ async def sweep_stale_runs(
             try:
                 if await transport.stream_exists(doc.run_id):
                     await transport.append_event(doc.run_id, "interrupted", {"run_id": doc.run_id})
+                    # The append above will recreate the key if it was just
+                    # TTL-evicted between stream_exists and append_event, so
+                    # set a fresh TTL unconditionally to bound the stream's
+                    # lifetime in that race.
+                    await transport.set_ttl(doc.run_id, _STREAM_TTL_AFTER_INTERRUPT)
             except Exception:
                 logger.exception(
                     "sweep_stale_runs: transport append failed for run %s",
@@ -74,3 +89,25 @@ async def sweep_stale_runs(
                 )
     logger.info("sweep_stale_runs: marked %d runs as interrupted", len(stale))
     return len(stale)
+
+
+def _resolve_transport():
+    """Return the stream transport when Redis is configured, else ``None``.
+
+    A Tier 0 deployment (EE installed but ``POCKETPAW_REDIS_URL`` unset) used
+    to log a WARNING + traceback every 5 minutes from the heartbeat sweeper.
+    Short-circuiting on the env var keeps those deployments quiet — the
+    Mongo-only sweep still works.
+    """
+    if not os.environ.get("POCKETPAW_REDIS_URL", "").strip():
+        return None
+    try:
+        return get_stream_transport()
+    except Exception:
+        # Env is set but the transport refused to construct (e.g. malformed
+        # URL). One-off WARNING without traceback — operators get told once
+        # per process start, not on every tick.
+        logger.warning(
+            "sweep_stale_runs: stream transport unavailable; interrupt events will not be appended"
+        )
+        return None

--- a/ee/pocketpaw_ee/cloud/chat/runs/sweeper.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/sweeper.py
@@ -5,6 +5,16 @@ Mongo still says ``running``. The sweeper marks anything that's been sitting
 in queued/running past the threshold as ``interrupted`` so the client can
 render a retry affordance instead of subscribing to a stream nobody is
 writing to.
+
+Two cadences share this:
+- The in-process heartbeat (every 5 minutes, 10-minute cutoff) catches runs
+  abandoned by a web-process restart.
+- The Tier 2 worker's boot sweep (5-second cutoff) catches runs orphaned by
+  the previous worker that just crashed.
+
+When the run's Redis stream is still alive, the sweeper appends an
+``interrupted`` terminal event so any live SSE subscriber finalises
+immediately instead of waiting for the heartbeat timeout.
 """
 
 from __future__ import annotations
@@ -12,27 +22,55 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime, timedelta
 
+from pocketpaw_ee.cloud.chat.runs.transport import get_stream_transport
 from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
 
 logger = logging.getLogger(__name__)
 
 
-async def sweep_stale_runs(*, older_than_minutes: int = 10) -> int:
-    """Mark queued/running runs older than ``older_than_minutes`` as ``interrupted``.
+async def sweep_stale_runs(
+    *,
+    older_than_minutes: int | None = None,
+    older_than_seconds: int | None = None,
+) -> int:
+    """Mark queued/running runs older than the cutoff as ``interrupted``.
 
-    Returns the number of docs updated.
+    Pass either ``older_than_minutes`` or ``older_than_seconds``; if both are
+    omitted, defaults to 10 minutes. Returns the number of docs updated.
     """
-    cutoff = datetime.now(UTC) - timedelta(minutes=older_than_minutes)
+    if older_than_seconds is not None:
+        cutoff = datetime.now(UTC) - timedelta(seconds=older_than_seconds)
+    else:
+        cutoff = datetime.now(UTC) - timedelta(minutes=older_than_minutes or 10)
     stale = await ChatRunDoc.find(
         {"status": {"$in": ["queued", "running"]}},
         ChatRunDoc.createdAt < cutoff,
     ).to_list()
     if not stale:
         return 0
+    # Resolve the transport once per sweep; if Redis is unavailable we still
+    # mark interruptions in Mongo, we just can't wake live SSE subscribers.
+    try:
+        transport = get_stream_transport()
+    except Exception:
+        logger.warning(
+            "sweep_stale_runs: stream transport unavailable, interrupt events will not be appended",
+            exc_info=True,
+        )
+        transport = None
     now = datetime.now(UTC)
     for doc in stale:
         doc.status = "interrupted"  # type: ignore[assignment]
         doc.ended_at = now
         await doc.save()
+        if transport is not None:
+            try:
+                if await transport.stream_exists(doc.run_id):
+                    await transport.append_event(doc.run_id, "interrupted", {"run_id": doc.run_id})
+            except Exception:
+                logger.exception(
+                    "sweep_stale_runs: transport append failed for run %s",
+                    doc.run_id,
+                )
     logger.info("sweep_stale_runs: marked %d runs as interrupted", len(stale))
     return len(stale)

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -1,0 +1,76 @@
+"""arq worker entry point for Tier 2 run execution.
+
+Deploy as a separate process alongside the web service::
+
+    arq pocketpaw_ee.cloud.chat.runs.worker.WorkerSettings
+
+The worker owns the agent run; the web process just enqueues
+``execute_run_job`` via ``ArqExecutor`` and streams events back through Redis.
+
+On boot, the worker sweeps any run left in ``queued``/``running`` by the
+previous worker (it crashed, otherwise we wouldn't be starting) and marks
+them ``interrupted``. LLM token streams cannot resume mid-generation, so the
+sweep does not re-enqueue — the partial already streamed remains visible and
+the user retries manually.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from arq.connections import RedisSettings
+
+# Imported at module scope so tests can ``monkeypatch.setattr(worker, …)``.
+from pocketpaw_ee.cloud import init_realtime
+from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
+from pocketpaw_ee.cloud.chat.runs.run_core import execute_run
+from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
+from pocketpaw_ee.cloud.shared.db import close_cloud_db, init_cloud_db
+
+logger = logging.getLogger(__name__)
+
+
+# A short cutoff because worker boot implies the previous worker just died;
+# runs created seconds ago by the web process should not be swept.
+_BOOT_SWEEP_OLDER_THAN_SECONDS = 5
+
+
+async def execute_run_job(ctx: dict[str, Any], spec_dict: dict[str, Any]) -> None:
+    """arq job entrypoint — rehydrate the RunSpec and run the agent."""
+    spec = RunSpec.model_validate(spec_dict)
+    logger.info("worker: starting run %s", spec.run_id)
+    await execute_run(spec)
+
+
+async def _startup(ctx: dict[str, Any]) -> None:
+    """Boot the worker: init the DB + realtime bus, then sweep orphans."""
+    mongo_uri = os.environ.get("CLOUD_MONGODB_URI", "mongodb://localhost:27017/paw-enterprise")
+    await init_cloud_db(mongo_uri)
+    init_realtime()
+    try:
+        swept = await sweep_stale_runs(older_than_seconds=_BOOT_SWEEP_OLDER_THAN_SECONDS)
+        if swept:
+            logger.info("worker boot: marked %d orphaned runs as interrupted", swept)
+    except Exception:
+        logger.exception("worker boot: stale-run sweep failed")
+
+
+async def _shutdown(ctx: dict[str, Any]) -> None:
+    await close_cloud_db()
+
+
+class WorkerSettings:
+    """arq worker configuration. Loaded by ``arq <dotted-path>``."""
+
+    functions = [execute_run_job]
+    on_startup = _startup
+    on_shutdown = _shutdown
+    # Crash policy: no auto-retry. A failed run is left as ``failed``/``interrupted``
+    # so the user can decide whether to resend — re-running could double-bill or
+    # surface a partial duplicate.
+    max_tries = 1
+    redis_settings = RedisSettings.from_dsn(
+        os.environ.get("POCKETPAW_REDIS_URL", "redis://localhost:6379/0")
+    )

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -24,6 +24,7 @@ from arq.connections import RedisSettings
 
 # Imported at module scope so tests can ``monkeypatch.setattr(worker, …)``.
 from pocketpaw_ee.cloud import init_realtime
+from pocketpaw_ee.cloud._core.realtime import xproc
 from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
 from pocketpaw_ee.cloud.chat.runs.run_core import execute_run
 from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
@@ -45,7 +46,13 @@ async def execute_run_job(ctx: dict[str, Any], spec_dict: dict[str, Any]) -> Non
 
 
 async def _startup(ctx: dict[str, Any]) -> None:
-    """Boot the worker: init the DB + realtime bus, then sweep orphans."""
+    """Boot the worker: pin role, init the DB + realtime bus, sweep orphans.
+
+    ``xproc.set_role("worker")`` must run before any agent code emits, so
+    ``emit()`` and the run-side broadcast helpers route over the bridge
+    instead of into the worker's empty local bus / WS manager.
+    """
+    xproc.set_role("worker")
     mongo_uri = os.environ.get("CLOUD_MONGODB_URI", "mongodb://localhost:27017/paw-enterprise")
     await init_cloud_db(mongo_uri)
     init_realtime()

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -68,6 +68,27 @@ async def _shutdown(ctx: dict[str, Any]) -> None:
     await close_cloud_db()
 
 
+class _LazyRedisSettings:
+    """Descriptor that reads ``POCKETPAW_REDIS_URL`` on access, not at module
+    import. arq accesses ``WorkerSettings.redis_settings`` once at worker
+    boot, so this is effectively boot-time evaluation.
+
+    Two reasons it isn't a plain class attribute:
+    - Import-time read froze the env at first import (review finding #7),
+      which broke test ergonomics and any deploy that loads env after the
+      module is imported.
+    - Defaulting silently to ``redis://localhost:6379/0`` when the env is
+      unset (review finding #4) split-brain a typoed prod deploy — web
+      enqueued to prod-Redis, worker waited on localhost.
+    """
+
+    def __get__(self, obj: object, objtype: type | None = None) -> RedisSettings:
+        url = os.environ.get("POCKETPAW_REDIS_URL", "").strip()
+        if not url:
+            raise RuntimeError("POCKETPAW_REDIS_URL must be set to run the Tier 2 arq worker")
+        return RedisSettings.from_dsn(url)
+
+
 class WorkerSettings:
     """arq worker configuration. Loaded by ``arq <dotted-path>``."""
 
@@ -78,6 +99,4 @@ class WorkerSettings:
     # so the user can decide whether to resend — re-running could double-bill or
     # surface a partial duplicate.
     max_tries = 1
-    redis_settings = RedisSettings.from_dsn(
-        os.environ.get("POCKETPAW_REDIS_URL", "redis://localhost:6379/0")
-    )
+    redis_settings = _LazyRedisSettings()

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -237,6 +237,15 @@ class CloudLifecycleHook:
             await stop_xproc_consumer()
         except Exception as exc:  # noqa: BLE001
             logger.warning("xproc consumer stop failed: %s", exc)
+
+        # Close the arq enqueuer pool if this web process ever built one
+        # (POCKETPAW_CLOUD_RUN_EXECUTOR=arq). No-op otherwise.
+        try:
+            from pocketpaw_ee.cloud.chat.runs.arq_executor import close_pool
+
+            await close_pool()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("arq pool close failed: %s", exc)
         return None
 
 

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -27,6 +27,7 @@ from typing import Any
 
 _run_sweeper_logger = logging.getLogger(__name__)
 _sweeper_task: asyncio.Task[None] | None = None
+_xproc_consumer_task: asyncio.Task[None] | None = None
 
 
 async def _sweeper_loop() -> None:
@@ -59,6 +60,32 @@ async def stop_run_sweeper() -> None:
         with suppress(asyncio.CancelledError):
             await _sweeper_task
         _sweeper_task = None
+
+
+async def start_xproc_consumer() -> None:
+    """Start the cross-process bus/WS bridge consumer in the web process.
+
+    No-op when ``POCKETPAW_REDIS_URL`` is unset — without Redis no Tier 2
+    worker can publish to the bridge, and the existing in-process bus
+    handles every emit locally. This keeps Tier 0 deployments quiet.
+    """
+    import os
+
+    if not os.environ.get("POCKETPAW_REDIS_URL", "").strip():
+        return
+    from pocketpaw_ee.cloud._core.realtime.xproc import run_consumer
+
+    global _xproc_consumer_task
+    _xproc_consumer_task = asyncio.create_task(run_consumer())
+
+
+async def stop_xproc_consumer() -> None:
+    global _xproc_consumer_task
+    if _xproc_consumer_task is not None:
+        _xproc_consumer_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await _xproc_consumer_task
+        _xproc_consumer_task = None
 
 
 class CloudEventBusProvider:
@@ -177,6 +204,15 @@ class CloudLifecycleHook:
         except Exception as exc:  # noqa: BLE001
             logger.warning("Run sweeper start failed: %s", exc)
 
+        # Cross-process bus/WS bridge consumer. Tier 2's arq worker can't
+        # reach this process's InProcessBus or WsManager directly; it XADDs
+        # envelopes to a shared Redis stream and the consumer dispatches
+        # them locally. No-op without POCKETPAW_REDIS_URL.
+        try:
+            await start_xproc_consumer()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("xproc consumer start failed: %s", exc)
+
     async def on_shutdown(self) -> None:
         # Most cloud teardown is handled inside mount_cloud's own shutdown
         # hook. The interval-refresh scheduler is owned by this lifecycle
@@ -196,6 +232,11 @@ class CloudLifecycleHook:
             await stop_run_sweeper()
         except Exception as exc:  # noqa: BLE001
             logger.warning("Run sweeper stop failed: %s", exc)
+
+        try:
+            await stop_xproc_consumer()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("xproc consumer stop failed: %s", exc)
         return None
 
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -51,6 +51,10 @@ dependencies = [
     "python-socketio>=5.11.0",
     "slowapi>=0.1.9",
     "redis[hiredis]>=5.0.0",
+    # --- Background worker (Tier 2 resumable chat runs) ---
+    # arq is only imported by `pocketpaw_ee.cloud.chat.runs.arq_executor`
+    # and `worker.py`; both are gated behind POCKETPAW_CLOUD_RUN_EXECUTOR=arq.
+    "arq>=0.26.0",
     # --- File storage (S3 + GCS) ---
     "boto3>=1.34.0",
     "google-cloud-storage>=2.14.0",

--- a/tests/cloud/realtime/test_event_registry.py
+++ b/tests/cloud/realtime/test_event_registry.py
@@ -1,0 +1,95 @@
+"""Cross-process bus bridge needs to reconstruct Event subclasses from their
+EVENT_TYPE discriminator on the receiving side. A registry populated via
+``Event.__init_subclass__`` keeps the mapping in lockstep with the class
+hierarchy without manual maintenance."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime.events import (
+    EVENT_REGISTRY,
+    Event,
+    GroupCreated,
+    MessageNew,
+    PocketCreated,
+    rebuild_event,
+)
+
+
+def test_registry_includes_every_subclass_with_event_type():
+    # Spot-check a handful that we know exist; the full coverage is the
+    # invariant that every subclass with EVENT_TYPE is present.
+    assert EVENT_REGISTRY["group.created"] is GroupCreated
+    assert EVENT_REGISTRY["message.new"] is MessageNew
+    assert EVENT_REGISTRY["pocket.created"] is PocketCreated
+
+    for cls in _all_event_subclasses(Event):
+        evt_type = getattr(cls, "EVENT_TYPE", "")
+        if not evt_type:
+            continue
+        assert EVENT_REGISTRY.get(evt_type) is cls, (
+            f"{cls.__name__} (EVENT_TYPE={evt_type!r}) missing from EVENT_REGISTRY"
+        )
+
+
+def test_rebuild_event_round_trips_through_dict():
+    original = GroupCreated(data={"id": "g1", "name": "team"})
+    payload = {
+        "type": original.type,
+        "data": original.data,
+        "ts": original.ts.isoformat(),
+    }
+
+    rebuilt = rebuild_event(payload)
+
+    assert isinstance(rebuilt, GroupCreated)
+    assert rebuilt.type == "group.created"
+    assert rebuilt.data == {"id": "g1", "name": "team"}
+    assert rebuilt.ts == original.ts
+
+
+def test_rebuild_event_unknown_type_returns_generic_event():
+    """A future event type shipped by a newer worker shouldn't crash an older
+    web consumer — fall back to the base Event so listeners that subscribe
+    by string type can still match."""
+    now = datetime.now(UTC)
+    payload = {"type": "future.event", "data": {"x": 1}, "ts": now.isoformat()}
+
+    rebuilt = rebuild_event(payload)
+
+    assert type(rebuilt) is Event
+    assert rebuilt.type == "future.event"
+    assert rebuilt.data == {"x": 1}
+    assert rebuilt.ts == now
+
+
+def test_rebuild_event_missing_ts_uses_current_time():
+    payload = {"type": "group.created", "data": {}}
+
+    rebuilt = rebuild_event(payload)
+
+    assert isinstance(rebuilt, GroupCreated)
+    assert isinstance(rebuilt.ts, datetime)
+
+
+def test_rebuild_event_rejects_non_dict_data():
+    with pytest.raises((TypeError, ValueError)):
+        rebuild_event({"type": "group.created", "data": "not-a-dict"})
+
+
+def _all_event_subclasses(root: type) -> list[type]:
+    """All transitive subclasses, deduped."""
+    seen: set[type] = set()
+    stack = [root]
+    out: list[type] = []
+    while stack:
+        cls = stack.pop()
+        for sub in cls.__subclasses__():
+            if sub in seen:
+                continue
+            seen.add(sub)
+            out.append(sub)
+            stack.append(sub)
+    return out

--- a/tests/cloud/realtime/test_xproc.py
+++ b/tests/cloud/realtime/test_xproc.py
@@ -1,0 +1,297 @@
+"""Cross-process bus/WS bridge for Tier 2 resumable runs.
+
+The worker process can't reach the web process's InProcessBus or WS manager.
+``xproc`` ships envelopes through a Redis stream; the consumer on the web side
+rebuilds the original Event subclass via ``EVENT_REGISTRY`` and dispatches to
+``bus.publish`` / ``manager.broadcast_to_group``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+
+import fakeredis.aioredis
+import pytest
+from pocketpaw_ee.cloud._core.realtime import xproc
+from pocketpaw_ee.cloud._core.realtime.events import GroupCreated, MessageNew
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    """Swap the singleton Redis client for fakeredis so every xproc primitive
+    talks to an in-memory store."""
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(xproc, "get_redis", lambda: redis)
+    xproc._reset_for_tests()
+    yield redis
+    xproc._reset_for_tests()
+
+
+# --- role + publish primitives ----------------------------------------------
+
+
+async def test_default_role_is_web():
+    xproc._reset_for_tests()
+    assert xproc.is_worker() is False
+
+
+async def test_set_role_worker_flips_flag():
+    xproc._reset_for_tests()
+    xproc.set_role("worker")
+    assert xproc.is_worker() is True
+
+
+async def test_publish_bus_envelope_noop_when_role_is_web(fake_redis):
+    await xproc.publish_bus_envelope(GroupCreated(data={"id": "g1"}))
+    # The web side must never publish; if it did the message would loop back
+    # through its own consumer and get double-dispatched.
+    assert await fake_redis.exists(xproc.XPROC_STREAM) == 0
+
+
+async def test_publish_bus_envelope_in_worker_writes_to_stream(fake_redis):
+    xproc.set_role("worker")
+    evt = GroupCreated(data={"id": "g1", "name": "team"})
+
+    await xproc.publish_bus_envelope(evt)
+
+    entries = await fake_redis.xrange(xproc.XPROC_STREAM)
+    assert len(entries) == 1
+    _entry_id, fields = entries[0]
+    envelope = json.loads(fields["envelope"])
+    assert envelope["kind"] == "bus"
+    assert envelope["type"] == "group.created"
+    assert envelope["data"] == {"id": "g1", "name": "team"}
+    assert envelope["ts"]  # iso string present
+
+
+async def test_publish_ws_envelope_in_worker_writes_to_stream(fake_redis):
+    xproc.set_role("worker")
+
+    await xproc.publish_ws_envelope(
+        scope_id="s1",
+        recipients=["u1", "u2"],
+        ws_type="agent.typing",
+        ws_data={"scope": "session", "scope_id": "s1", "agent_id": "a1", "active": True},
+    )
+
+    entries = await fake_redis.xrange(xproc.XPROC_STREAM)
+    assert len(entries) == 1
+    _entry_id, fields = entries[0]
+    envelope = json.loads(fields["envelope"])
+    assert envelope == {
+        "kind": "ws",
+        "scope_id": "s1",
+        "recipients": ["u1", "u2"],
+        "type": "agent.typing",
+        "data": {"scope": "session", "scope_id": "s1", "agent_id": "a1", "active": True},
+    }
+
+
+async def test_publish_ws_envelope_noop_when_role_is_web(fake_redis):
+    await xproc.publish_ws_envelope(scope_id="s1", recipients=["u1"], ws_type="x", ws_data={})
+    assert await fake_redis.exists(xproc.XPROC_STREAM) == 0
+
+
+# --- consumer dispatch ------------------------------------------------------
+
+
+@pytest.fixture
+def fake_bus(monkeypatch):
+    bus = AsyncMock()
+    bus.publish = AsyncMock()
+    monkeypatch.setattr(xproc, "get_bus", lambda: bus)
+    return bus
+
+
+@pytest.fixture
+def fake_manager(monkeypatch):
+    """Replace the WS manager singleton with an AsyncMock so dispatch is
+    observable without spinning up a real WebSocket."""
+    import pocketpaw_ee.cloud.chat.ws as ws_mod
+
+    fake = AsyncMock()
+    fake.broadcast_to_group = AsyncMock()
+    monkeypatch.setattr(ws_mod, "manager", fake)
+    return fake
+
+
+async def test_dispatch_bus_envelope_publishes_to_local_bus(fake_bus):
+    envelope = {
+        "kind": "bus",
+        "type": "message.new",
+        "data": {"id": "m1", "group": "g1"},
+        "ts": "2026-05-23T19:00:00+00:00",
+    }
+
+    await xproc._dispatch(envelope)
+
+    fake_bus.publish.assert_awaited_once()
+    event = fake_bus.publish.await_args.args[0]
+    assert isinstance(event, MessageNew)
+    assert event.data == {"id": "m1", "group": "g1"}
+
+
+async def test_dispatch_ws_envelope_calls_manager(fake_manager):
+    envelope = {
+        "kind": "ws",
+        "scope_id": "s1",
+        "recipients": ["u1", "u2"],
+        "type": "agent.typing",
+        "data": {"active": True},
+    }
+
+    await xproc._dispatch(envelope)
+
+    fake_manager.broadcast_to_group.assert_awaited_once()
+    args = fake_manager.broadcast_to_group.await_args.args
+    assert args[0] == "s1"
+    assert args[1] == ["u1", "u2"]
+    ws_out = args[2]
+    assert ws_out.type == "agent.typing"
+    assert ws_out.data == {"active": True}
+
+
+async def test_dispatch_unknown_kind_does_not_raise(fake_bus, fake_manager):
+    await xproc._dispatch({"kind": "future", "x": 1})
+    # Forward-compatible: an older consumer should skip envelopes it doesn't
+    # understand, not crash and stall the whole stream.
+    fake_bus.publish.assert_not_called()
+    fake_manager.broadcast_to_group.assert_not_called()
+
+
+# --- consumer loop integration ---------------------------------------------
+
+
+async def test_run_consumer_dispatches_published_envelope(
+    fake_redis,
+    fake_bus,
+    fake_manager,
+):
+    """End-to-end through the loop: web starts the consumer first (matches
+    production order), worker publishes, consumer drains + dispatches, then
+    cancellation cleanly stops the loop."""
+    # Web side starts the consumer first so the group exists with a cursor
+    # at the current tip; subsequent worker publishes flow through.
+    task = asyncio.create_task(xproc.run_consumer(consumer_name="test", block_ms=50))
+    await _wait_until_group_exists(fake_redis)
+
+    xproc.set_role("worker")
+    await xproc.publish_bus_envelope(GroupCreated(data={"id": "g1"}))
+    await xproc.publish_ws_envelope(
+        scope_id="s1", recipients=["u1"], ws_type="agent.typing", ws_data={"active": True}
+    )
+
+    await _wait_until(
+        lambda: fake_bus.publish.await_count == 1
+        and fake_manager.broadcast_to_group.await_count == 1,
+        timeout=2.0,
+    )
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def test_run_consumer_acks_so_restart_does_not_replay(
+    fake_redis,
+    fake_bus,
+    fake_manager,
+):
+    """Consumer-group XACK semantics: after the consumer processes an entry,
+    a restart (new consumer in the same group) must not redeliver it."""
+    task1 = asyncio.create_task(xproc.run_consumer(consumer_name="c1", block_ms=50))
+    await _wait_until_group_exists(fake_redis)
+
+    xproc.set_role("worker")
+    await xproc.publish_bus_envelope(GroupCreated(data={"id": "g1"}))
+
+    await _wait_until(lambda: fake_bus.publish.await_count == 1, timeout=2.0)
+    task1.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task1
+
+    # New consumer in the same group: nothing to deliver.
+    task2 = asyncio.create_task(xproc.run_consumer(consumer_name="c2", block_ms=50))
+    await asyncio.sleep(0.2)  # give it a chance to (not) re-deliver
+    task2.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task2
+
+    assert fake_bus.publish.await_count == 1
+
+
+async def test_run_consumer_idempotent_on_group_create(fake_redis):
+    """The consumer creates the consumer group on first run with
+    mkstream=True; a second start must not crash on BUSYGROUP."""
+    task1 = asyncio.create_task(xproc.run_consumer(consumer_name="c1", block_ms=50))
+    await asyncio.sleep(0.05)
+    task1.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task1
+
+    task2 = asyncio.create_task(xproc.run_consumer(consumer_name="c2", block_ms=50))
+    await asyncio.sleep(0.05)
+    task2.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task2
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+async def _wait_until(predicate, *, timeout: float) -> None:
+    """Poll a predicate until it returns truthy or the timeout elapses."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("timed out waiting for predicate")
+
+
+async def _wait_until_group_exists(redis, *, timeout: float = 2.0) -> None:
+    """Wait until the consumer task has created the consumer group. Publishing
+    before the group exists means the entry lands at ``$`` and is missed by
+    the new group's initial cursor."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        try:
+            groups = await redis.xinfo_groups(xproc.XPROC_STREAM)
+            if any(g.get("name") == xproc.XPROC_GROUP for g in groups):
+                return
+        except Exception:
+            pass
+        await asyncio.sleep(0.02)
+    raise AssertionError("consumer group never appeared")
+
+
+async def test_bus_publish_failure_does_not_crash_consumer(fake_redis, fake_manager, monkeypatch):
+    """A misbehaving listener (rebuild_event raising, bus.publish raising)
+    must not stall the stream — the bad entry is acked and the loop continues."""
+    publish_calls: list[Any] = []
+
+    class _Bus:
+        async def publish(self, event):
+            publish_calls.append(event)
+            if len(publish_calls) == 1:
+                raise RuntimeError("listener boom")
+
+    monkeypatch.setattr(xproc, "get_bus", lambda: _Bus())
+
+    task = asyncio.create_task(xproc.run_consumer(consumer_name="c1", block_ms=50))
+    await _wait_until_group_exists(fake_redis)
+
+    xproc.set_role("worker")
+    await xproc.publish_bus_envelope(GroupCreated(data={"id": "g1"}))
+    await xproc.publish_bus_envelope(GroupCreated(data={"id": "g2"}))
+
+    await _wait_until(lambda: len(publish_calls) == 2, timeout=2.0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert len(publish_calls) == 2

--- a/tests/cloud/runs/test_arq_executor.py
+++ b/tests/cloud/runs/test_arq_executor.py
@@ -1,0 +1,88 @@
+"""Tier 2: ArqExecutor enqueues a job for the worker pool instead of
+running the agent inline."""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.chat.runs import arq_executor
+from pocketpaw_ee.cloud.chat.runs.arq_executor import ArqExecutor
+from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
+
+pytestmark = pytest.mark.asyncio
+
+
+def _spec(run_id: str = "r1") -> RunSpec:
+    return RunSpec(
+        run_id=run_id,
+        workspace_id="w1",
+        context_type="session",
+        scope_id="s1",
+        session_key="session:s1",
+        group=None,
+        user_id="u1",
+        agent_id="a1",
+        client_message_id=f"c-{run_id}",
+        user_message_id="m1",
+        content="hi",
+        history=[],
+        intent=None,
+    )
+
+
+async def test_arq_executor_enqueues_execute_run_job(monkeypatch):
+    enqueued: list[tuple[str, dict]] = []
+
+    class _FakePool:
+        async def enqueue_job(self, name: str, payload: dict) -> None:
+            enqueued.append((name, payload))
+
+    async def _fake_pool():
+        return _FakePool()
+
+    monkeypatch.setattr(arq_executor, "_get_pool", _fake_pool)
+    arq_executor._reset_for_tests()
+
+    ex = ArqExecutor()
+    await ex.submit(_spec())
+
+    assert len(enqueued) == 1
+    name, payload = enqueued[0]
+    assert name == "execute_run_job"
+    assert payload["run_id"] == "r1"
+    assert payload["workspace_id"] == "w1"
+    # Round-trips through Pydantic — proves the payload is plain JSON primitives.
+    restored = RunSpec.model_validate(payload)
+    assert restored.run_id == "r1"
+
+
+async def test_arq_executor_reuses_pool(monkeypatch):
+    calls = 0
+
+    class _FakePool:
+        async def enqueue_job(self, name: str, payload: dict) -> None:
+            pass
+
+    async def _fake_pool():
+        nonlocal calls
+        calls += 1
+        return _FakePool()
+
+    monkeypatch.setattr(arq_executor, "create_pool", _make_create_pool(_fake_pool))
+    monkeypatch.setenv("POCKETPAW_REDIS_URL", "redis://localhost:6379/0")
+    arq_executor._reset_for_tests()
+
+    ex = ArqExecutor()
+    await ex.submit(_spec("a"))
+    await ex.submit(_spec("b"))
+
+    # _get_pool is memoised — the underlying pool factory runs exactly once.
+    assert calls == 1
+
+
+def _make_create_pool(factory):
+    """Wrap a zero-arg async factory so it matches arq.create_pool(settings)."""
+
+    async def _create_pool(_settings):
+        return await factory()
+
+    return _create_pool

--- a/tests/cloud/runs/test_run_core.py
+++ b/tests/cloud/runs/test_run_core.py
@@ -296,6 +296,87 @@ async def test_execute_run_propagates_cancellation(monkeypatch):
     ]
 
 
+async def test_execute_run_cancellation_preserves_original_exception(monkeypatch):
+    """Review finding #6 — the host-cancellation re-raise must use the
+    original CancelledError instance (bare ``raise``), not a fresh one, so
+    arq sees the cancel reason it sent and the original traceback survives.
+    """
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+
+    async def long_running_events(spec, ctx):
+        yield ("chunk", {"content": "x", "type": "text"})
+        # Block long enough for the cancel to land in this await.
+        await asyncio.sleep(5)
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", long_running_events)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_persist_and_complete", _persist_stub)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr(run_core, "resolve_scope_context", fake_resolve_scope_context)
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.run_core.run_service.mark_terminal", _noop)
+
+    task = asyncio.create_task(run_core.execute_run(_spec()))
+    # Give the first chunk a moment to flow through; then cancel with a
+    # specific reason that we expect to survive the re-raise.
+    await asyncio.sleep(0.05)
+    task.cancel("worker SIGTERM, graceful shutdown")
+
+    with pytest.raises(asyncio.CancelledError) as excinfo:
+        await task
+
+    # The cancel-reason supplied via task.cancel(msg) survives the cleanup
+    # path. A fresh ``raise asyncio.CancelledError()`` would drop the args.
+    assert excinfo.value.args == ("worker SIGTERM, graceful shutdown",)
+
+
+async def test_execute_run_cancellation_cleanup_survives_second_cancel(monkeypatch):
+    """Review finding #3 — when a second cancel arrives during the
+    interrupted cleanup (SIGKILL grace window), ``asyncio.shield`` must keep
+    mark_terminal + append + set_ttl running to completion so the doc isn't
+    stranded in ``running`` with no terminal stream frame."""
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+
+    mark_started = asyncio.Event()
+    mark_finished = asyncio.Event()
+
+    async def slow_mark_terminal(run_id, **kwargs):
+        mark_started.set()
+        # The cleanup is in flight; arrange for the OUTER task to be
+        # cancelled while we're awaiting this sleep.
+        await asyncio.sleep(0.1)
+        mark_finished.set()
+
+    async def fake_events(spec, ctx):
+        yield ("chunk", {"content": "partial ", "type": "text"})
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", fake_events)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_persist_and_complete", _persist_stub)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr(run_core, "resolve_scope_context", fake_resolve_scope_context)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.run_core.run_service.mark_terminal",
+        slow_mark_terminal,
+    )
+
+    task = asyncio.create_task(run_core.execute_run(_spec()))
+    await asyncio.wait_for(mark_started.wait(), timeout=1.0)
+
+    # Second cancel arrives while mark_terminal is still running. Without
+    # shield this would abort the cleanup mid-flight; with shield, the
+    # cleanup task continues to completion in the background.
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await asyncio.wait_for(mark_finished.wait(), timeout=2.0)
+
+
 async def fake_agent_events_raising(spec, ctx):
     yield ("chunk", {"content": "partial ", "type": "text"})
     raise RuntimeError("boom")

--- a/tests/cloud/runs/test_run_core.py
+++ b/tests/cloud/runs/test_run_core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import fakeredis.aioredis
@@ -236,6 +237,61 @@ async def test_execute_run_backend_error_marks_failed(monkeypatch):
             "status": "failed",
             "partial_text": "",
             "error": "codex sdk missing",
+        }
+    ]
+
+
+async def fake_agent_events_cancelled(spec, ctx):
+    yield ("chunk", {"content": "partial ", "type": "text"})
+    raise asyncio.CancelledError()
+
+
+async def test_execute_run_propagates_cancellation(monkeypatch):
+    """When the task is cancelled mid-stream (arq worker shutdown), the
+    agent loop must (a) NOT swallow CancelledError, (b) mark the run
+    ``interrupted`` with the partial text preserved, (c) append a terminal
+    event to the stream so live SSE subscribers finalise, and (d) re-raise
+    so the arq worker actually exits."""
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+
+    persisted: list[str] = []
+    mark_calls: list[dict[str, Any]] = []
+
+    async def _track_persist(*a, **k):
+        persisted.append("called")
+        return "should-not-happen"
+
+    async def _track_terminal(run_id, *, status, partial_text="", error=None, **k):
+        mark_calls.append(
+            {"run_id": run_id, "status": status, "partial_text": partial_text, "error": error}
+        )
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", fake_agent_events_cancelled)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_persist_and_complete", _track_persist)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr(run_core, "resolve_scope_context", fake_resolve_scope_context)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.run_core.run_service.mark_terminal", _track_terminal
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_core.execute_run(_spec())
+
+    events = [e async for e in transport.read_events("r1", after="0", block_ms=10)]
+    # The chunk made it through, then a terminal `interrupted` frame.
+    assert events[0].event == "chunk"
+    assert events[-1].event == "interrupted"
+    assert events[-1].is_terminal
+    assert persisted == []
+    assert mark_calls == [
+        {
+            "run_id": "r1",
+            "status": "interrupted",
+            "partial_text": "partial ",
+            "error": None,
         }
     ]
 

--- a/tests/cloud/runs/test_run_core_xproc_routing.py
+++ b/tests/cloud/runs/test_run_core_xproc_routing.py
@@ -1,0 +1,179 @@
+"""When ``xproc.is_worker()`` is True, broadcasts from run_core must go
+through the cross-process bridge instead of the local WS manager."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime import xproc
+from pocketpaw_ee.cloud.chat.runs import run_core
+from pocketpaw_ee.cloud.chat.runs.run_core import (
+    _broadcast_agent_typing,
+    _broadcast_message_new,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Ctx:
+    """Minimal stand-in for ScopeContext — only the fields the broadcasts use."""
+
+    def __init__(self, *, members=("u1", "u2"), user_id="u1"):
+        self.scope_id = "s1"
+        self.user_id = user_id
+        self.target_agent_id = "a1"
+        self.members = list(members)
+        self.kind = type("K", (), {"value": "session"})()
+
+
+@pytest.fixture
+def fake_manager(monkeypatch):
+    """Replace the WS manager so we can assert it's NOT called in worker mode."""
+    import pocketpaw_ee.cloud.chat.ws as ws_mod
+
+    fake = AsyncMock()
+    fake.broadcast_to_group = AsyncMock()
+    monkeypatch.setattr(ws_mod, "manager", fake)
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def _reset_xproc():
+    xproc._reset_for_tests()
+    yield
+    xproc._reset_for_tests()
+
+
+# --- agent.typing ----------------------------------------------------------
+
+
+async def test_typing_in_web_mode_calls_local_manager(fake_manager):
+    await _broadcast_agent_typing(_Ctx(), active=True)
+
+    fake_manager.broadcast_to_group.assert_awaited_once()
+    args = fake_manager.broadcast_to_group.await_args.args
+    assert args[0] == "s1"
+    assert args[1] == ["u2"]  # excludes the caller
+
+
+async def test_typing_in_worker_mode_publishes_via_xproc(fake_manager, monkeypatch):
+    xproc.set_role("worker")
+    published: list[dict] = []
+
+    async def _capture(**kwargs):
+        published.append(kwargs)
+
+    monkeypatch.setattr(run_core.xproc, "publish_ws_envelope", _capture)
+
+    await _broadcast_agent_typing(_Ctx(), active=True)
+
+    fake_manager.broadcast_to_group.assert_not_called()
+    assert len(published) == 1
+    env = published[0]
+    assert env["scope_id"] == "s1"
+    assert env["recipients"] == ["u2"]
+    assert env["ws_type"] == "agent.typing"
+    assert env["ws_data"]["active"] is True
+    assert env["ws_data"]["agent_id"] == "a1"
+
+
+async def test_typing_no_others_skips_in_both_modes(fake_manager, monkeypatch):
+    """No recipients → no broadcast in either mode."""
+    published: list[dict] = []
+
+    async def _capture(**kwargs):
+        published.append(kwargs)
+
+    monkeypatch.setattr(run_core.xproc, "publish_ws_envelope", _capture)
+
+    # Web mode
+    await _broadcast_agent_typing(_Ctx(members=("u1",), user_id="u1"), active=True)
+    fake_manager.broadcast_to_group.assert_not_called()
+
+    xproc.set_role("worker")
+    await _broadcast_agent_typing(_Ctx(members=("u1",), user_id="u1"), active=True)
+    assert published == []
+
+
+# --- message.new ----------------------------------------------------------
+
+
+async def test_message_new_in_web_mode_calls_local_manager(fake_manager):
+    from datetime import UTC, datetime
+
+    await _broadcast_message_new(
+        _Ctx(),
+        "msg-1",
+        "hello",
+        [],
+        datetime.now(UTC),
+    )
+
+    fake_manager.broadcast_to_group.assert_awaited_once()
+
+
+async def test_message_new_in_worker_mode_publishes_via_xproc(fake_manager, monkeypatch):
+    from datetime import UTC, datetime
+
+    xproc.set_role("worker")
+    published: list[dict] = []
+
+    async def _capture(**kwargs):
+        published.append(kwargs)
+
+    monkeypatch.setattr(run_core.xproc, "publish_ws_envelope", _capture)
+
+    created = datetime.now(UTC)
+    await _broadcast_message_new(_Ctx(), "msg-1", "hello", [], created)
+
+    fake_manager.broadcast_to_group.assert_not_called()
+    assert len(published) == 1
+    env = published[0]
+    assert env["scope_id"] == "s1"
+    # Recipients include the caller for message.new (existing behaviour).
+    assert set(env["recipients"]) == {"u1", "u2"}
+    assert env["ws_type"] == "message.new"
+    assert env["ws_data"]["id"] == "msg-1"
+    assert env["ws_data"]["content"] == "hello"
+    assert env["ws_data"]["sender_type"] == "agent"
+    assert env["ws_data"]["created_at"] == created.isoformat()
+
+
+# --- emit() routing -------------------------------------------------------
+
+
+async def test_emit_in_web_mode_uses_local_bus(monkeypatch):
+    from pocketpaw_ee.cloud._core.realtime import emit as emit_mod
+    from pocketpaw_ee.cloud._core.realtime.events import GroupCreated
+
+    bus = AsyncMock()
+    bus.publish = AsyncMock()
+    monkeypatch.setattr(emit_mod, "get_bus", lambda: bus)
+
+    await emit_mod.emit(GroupCreated(data={"id": "g1"}))
+
+    bus.publish.assert_awaited_once()
+
+
+async def test_emit_in_worker_mode_publishes_via_xproc(monkeypatch):
+    from pocketpaw_ee.cloud._core.realtime import emit as emit_mod
+    from pocketpaw_ee.cloud._core.realtime.events import GroupCreated
+
+    xproc.set_role("worker")
+    bus = AsyncMock()
+    bus.publish = AsyncMock()
+    monkeypatch.setattr(emit_mod, "get_bus", lambda: bus)
+
+    published: list = []
+
+    async def _capture(event):
+        published.append(event)
+
+    monkeypatch.setattr(emit_mod.xproc, "publish_bus_envelope", _capture)
+
+    evt = GroupCreated(data={"id": "g1"})
+    await emit_mod.emit(evt)
+
+    bus.publish.assert_not_called()
+    assert published == [evt]

--- a/tests/cloud/runs/test_sweeper.py
+++ b/tests/cloud/runs/test_sweeper.py
@@ -147,3 +147,104 @@ async def test_sweep_skips_transport_when_no_stream(
     await sweeper.sweep_stale_runs(older_than_minutes=10)
 
     assert await fake_transport.stream_exists(stale.run_id) is False
+
+
+# --- review-finding fixes ---------------------------------------------------
+
+
+async def test_sweep_older_than_minutes_zero_is_honored(mongo_db, fake_transport):  # noqa: ARG001
+    """Regression for review finding #2 — `older_than_minutes=0` was being
+    coerced to 10 by `or 10`, silently nullifying an emergency 'sweep
+    everything queued/running right now' call."""
+    just_now = ChatRunDoc(
+        run_id="r-now",
+        workspace="w1",
+        context_type="session",
+        scope_id="s1",
+        session_key="k1",
+        user_id="u1",
+        agent_id="a1",
+        client_message_id="c-now",
+        user_message_id="um1",
+        status="running",  # type: ignore[arg-type]
+        createdAt=datetime.now(UTC) - timedelta(seconds=1),
+    )
+    await just_now.insert()
+
+    n = await sweeper.sweep_stale_runs(older_than_minutes=0)
+
+    assert n == 1
+    refreshed = await ChatRunDoc.find_one(ChatRunDoc.run_id == just_now.run_id)
+    assert refreshed is not None and refreshed.status == "interrupted"
+
+
+async def test_sweep_rejects_both_cutoff_kwargs(mongo_db):  # noqa: ARG001
+    """Review finding #9 — passing both `older_than_minutes` and
+    `older_than_seconds` used to silently ignore minutes. Now an explicit
+    error so the caller's intent is unambiguous."""
+    with pytest.raises(ValueError, match="exactly one"):
+        await sweeper.sweep_stale_runs(older_than_minutes=10, older_than_seconds=5)
+
+
+async def test_sweep_no_redis_env_does_not_call_transport(
+    mongo_db,  # noqa: ARG001
+    monkeypatch,
+    caplog,
+):
+    """Review finding #5 — Tier 0 deployments (EE installed, but Redis not
+    configured yet) used to get a WARNING+traceback every sweep tick. The
+    sweep must short-circuit cleanly when there's no Redis env: no transport
+    call, no warning, no traceback."""
+    import logging
+
+    monkeypatch.delenv("POCKETPAW_REDIS_URL", raising=False)
+    called: list[str] = []
+
+    def _spy_transport():
+        called.append("get_stream_transport")
+        raise RuntimeError("POCKETPAW_REDIS_URL is not set")
+
+    monkeypatch.setattr(sweeper, "get_stream_transport", _spy_transport)
+
+    stale = _make_run(status="running", created_minutes_ago=30)
+    await stale.insert()
+
+    with caplog.at_level(logging.WARNING, logger="pocketpaw_ee.cloud.chat.runs.sweeper"):
+        n = await sweeper.sweep_stale_runs(older_than_minutes=10)
+
+    # Mongo update still happens — the sweep core works without Redis.
+    assert n == 1
+    # Sweeper short-circuited before calling the transport.
+    assert called == []
+    # And no WARNING from the sweeper.
+    sweeper_warnings = [
+        r
+        for r in caplog.records
+        if r.name == "pocketpaw_ee.cloud.chat.runs.sweeper" and r.levelno >= logging.WARNING
+    ]
+    assert sweeper_warnings == []
+
+
+async def test_sweep_sets_ttl_on_resurrected_stream(mongo_db, fake_transport, monkeypatch):  # noqa: ARG001
+    """Review finding #8 — TOCTOU window between `stream_exists` and
+    `append_event`. The append on a TTL-evicted stream creates a brand-new
+    key, so the sweep must set a TTL so the orphan doesn't live forever."""
+    stale = _make_run(status="running", created_minutes_ago=30)
+    await stale.insert()
+
+    set_ttls: list[tuple[str, int]] = []
+    orig_set_ttl = fake_transport.set_ttl
+
+    async def _record_set_ttl(run_id: str, ttl_seconds: int) -> None:
+        set_ttls.append((run_id, ttl_seconds))
+        await orig_set_ttl(run_id, ttl_seconds)
+
+    # Simulate a stream that exists at check time (race window).
+    await fake_transport.append_event(stale.run_id, "chunk", {"content": "p"})
+    monkeypatch.setattr(fake_transport, "set_ttl", _record_set_ttl)
+
+    await sweeper.sweep_stale_runs(older_than_minutes=10)
+
+    assert any(rid == stale.run_id and ttl > 0 for rid, ttl in set_ttls), (
+        f"sweep should set a TTL on the run's stream, got {set_ttls!r}"
+    )

--- a/tests/cloud/runs/test_sweeper.py
+++ b/tests/cloud/runs/test_sweeper.py
@@ -6,11 +6,25 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+import fakeredis.aioredis
 import pytest
-from pocketpaw_ee.cloud.chat.runs import sweeper
+from pocketpaw_ee.cloud.chat.runs import sweeper, transport
+from pocketpaw_ee.cloud.chat.runs.redis_stream import RedisStreamTransport
 from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
 
 pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def fake_transport(monkeypatch):
+    """Swap the stream transport for an in-memory fakeredis-backed one so the
+    sweeper's append step is testable without a live Redis."""
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    t = RedisStreamTransport(redis)
+    monkeypatch.setattr(transport, "_transport", t)
+    monkeypatch.setattr(sweeper, "get_stream_transport", lambda: t)
+    yield t
+    transport._reset_for_tests()
 
 
 def _make_run(*, status: str, created_minutes_ago: int) -> ChatRunDoc:
@@ -59,3 +73,77 @@ async def test_sweep_with_no_stale_runs_returns_zero(mongo_db):  # noqa: ARG001
     n = await sweeper.sweep_stale_runs(older_than_minutes=10)
 
     assert n == 0
+
+
+async def test_sweep_accepts_older_than_seconds(mongo_db, fake_transport):  # noqa: ARG001
+    """Worker boot uses a short cutoff — `older_than_seconds` lets the sweep
+    pick up runs orphaned by a worker crash that happened seconds ago."""
+    just_now = ChatRunDoc(
+        run_id="r-fresh",
+        workspace="w1",
+        context_type="session",
+        scope_id="s1",
+        session_key="k1",
+        user_id="u1",
+        agent_id="a1",
+        client_message_id="c-fresh",
+        user_message_id="um1",
+        status="running",  # type: ignore[arg-type]
+        createdAt=datetime.now(UTC),
+    )
+    seconds_old = ChatRunDoc(
+        run_id="r-30s",
+        workspace="w1",
+        context_type="session",
+        scope_id="s1",
+        session_key="k1",
+        user_id="u1",
+        agent_id="a1",
+        client_message_id="c-30s",
+        user_message_id="um1",
+        status="running",  # type: ignore[arg-type]
+        createdAt=datetime.now(UTC) - timedelta(seconds=30),
+    )
+    await just_now.insert()
+    await seconds_old.insert()
+
+    n = await sweeper.sweep_stale_runs(older_than_seconds=5)
+
+    assert n == 1
+    refreshed_old = await ChatRunDoc.find_one(ChatRunDoc.run_id == seconds_old.run_id)
+    assert refreshed_old is not None and refreshed_old.status == "interrupted"
+    refreshed_fresh = await ChatRunDoc.find_one(ChatRunDoc.run_id == just_now.run_id)
+    assert refreshed_fresh is not None and refreshed_fresh.status == "running"
+
+
+async def test_sweep_appends_interrupted_event_when_stream_exists(
+    mongo_db,  # noqa: ARG001
+    fake_transport,
+):
+    """Live SSE subscribers should get a terminal `interrupted` frame instead
+    of timing out on heartbeats."""
+    stale = _make_run(status="running", created_minutes_ago=30)
+    await stale.insert()
+    # A live stream exists for this run (the previous process wrote events
+    # before crashing). After the sweep, the latest event must be `interrupted`.
+    await fake_transport.append_event(stale.run_id, "chunk", {"content": "partial"})
+
+    await sweeper.sweep_stale_runs(older_than_minutes=10)
+
+    events = [e async for e in fake_transport.read_events(stale.run_id, after="0", block_ms=10)]
+    assert events[-1].event == "interrupted"
+    assert events[-1].is_terminal
+
+
+async def test_sweep_skips_transport_when_no_stream(
+    mongo_db,  # noqa: ARG001
+    fake_transport,
+):
+    """Runs that died before writing any event have no stream — the sweep
+    must not blindly create one."""
+    stale = _make_run(status="running", created_minutes_ago=30)
+    await stale.insert()
+
+    await sweeper.sweep_stale_runs(older_than_minutes=10)
+
+    assert await fake_transport.stream_exists(stale.run_id) is False

--- a/tests/cloud/runs/test_worker.py
+++ b/tests/cloud/runs/test_worker.py
@@ -1,0 +1,104 @@
+"""Tier 2 arq worker: ``execute_run_job`` rehydrates a ``RunSpec`` and
+delegates to ``execute_run``; ``_startup`` sweeps runs orphaned by the
+previous worker."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pocketpaw_ee.cloud.chat.runs import worker
+from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
+from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+pytestmark = pytest.mark.asyncio
+
+
+def _spec(run_id: str = "r1") -> RunSpec:
+    return RunSpec(
+        run_id=run_id,
+        workspace_id="w1",
+        context_type="session",
+        scope_id="s1",
+        session_key="session:s1",
+        group=None,
+        user_id="u1",
+        agent_id="a1",
+        client_message_id=f"c-{run_id}",
+        user_message_id="m1",
+        content="hi",
+        history=[],
+        intent=None,
+    )
+
+
+async def test_execute_run_job_calls_execute_run(monkeypatch):
+    seen: list[str] = []
+
+    async def fake_execute_run(spec):
+        seen.append(spec.run_id)
+
+    monkeypatch.setattr(worker, "execute_run", fake_execute_run)
+
+    await worker.execute_run_job({}, _spec().model_dump())
+
+    assert seen == ["r1"]
+
+
+async def test_execute_run_job_rehydrates_spec_from_dict(monkeypatch):
+    received: list[RunSpec] = []
+
+    async def fake_execute_run(spec):
+        received.append(spec)
+
+    monkeypatch.setattr(worker, "execute_run", fake_execute_run)
+
+    await worker.execute_run_job({}, _spec("r2").model_dump())
+
+    assert isinstance(received[0], RunSpec)
+    assert received[0].run_id == "r2"
+    assert received[0].workspace_id == "w1"
+
+
+async def test_startup_runs_short_cutoff_sweep(mongo_db, monkeypatch):  # noqa: ARG001
+    """The boot sweep must catch a run orphaned a few seconds ago by the
+    previous worker — the 10-minute default cutoff would leave it visible
+    until the next heartbeat tick."""
+
+    # Stub the DB + realtime init since the test fixture already initialised
+    # Beanie and the realtime bus is not under test here.
+    async def _noop_db(_uri):
+        return None
+
+    def _noop_realtime():
+        return None
+
+    monkeypatch.setattr(worker, "init_cloud_db", _noop_db)
+    monkeypatch.setattr(worker, "init_realtime", _noop_realtime)
+
+    orphan = ChatRunDoc(
+        run_id="r-orphan",
+        workspace="w1",
+        context_type="session",
+        scope_id="s1",
+        session_key="k1",
+        user_id="u1",
+        agent_id="a1",
+        client_message_id="c-orphan",
+        user_message_id="um1",
+        status="running",  # type: ignore[arg-type]
+        createdAt=datetime.now(UTC) - timedelta(seconds=30),
+    )
+    await orphan.insert()
+
+    await worker._startup({})
+
+    refreshed = await ChatRunDoc.find_one(ChatRunDoc.run_id == orphan.run_id)
+    assert refreshed is not None and refreshed.status == "interrupted"
+
+
+async def test_worker_settings_exposes_execute_run_job():
+    assert worker.execute_run_job in worker.WorkerSettings.functions
+    assert worker.WorkerSettings.max_tries == 1
+    assert worker.WorkerSettings.on_startup is worker._startup
+    assert worker.WorkerSettings.on_shutdown is worker._shutdown

--- a/tests/cloud/runs/test_worker_config_and_pool.py
+++ b/tests/cloud/runs/test_worker_config_and_pool.py
@@ -1,0 +1,106 @@
+"""Review findings #4, #7, #10 — worker Redis-settings consistency + arq
+pool shutdown.
+
+#4: ``WorkerSettings.redis_settings`` used to silently default to
+    ``redis://localhost:6379/0`` if ``POCKETPAW_REDIS_URL`` was unset,
+    while ``ArqExecutor._get_pool`` raised loudly. A typoed env in prod
+    would split-brain (web → prod-Redis, worker → localhost).
+
+#7: ``WorkerSettings.redis_settings`` was read at module import time, so
+    a test that ``monkeypatch.setenv`` after import had no effect.
+
+#10: ``arq_executor._pool`` had no aclose hook — a web process that ever
+     enqueued a job leaked the connection through shutdown.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pocketpaw_ee.cloud.chat.runs import arq_executor
+from pocketpaw_ee.cloud.chat.runs import worker as worker_mod
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- #4 + #7: redis_settings is lazy + fail-loud ---------------------------
+
+
+async def test_worker_redis_settings_raises_when_env_unset(monkeypatch):
+    """Accessing WorkerSettings.redis_settings without POCKETPAW_REDIS_URL
+    set must raise — silent fallback to localhost is a deploy footgun."""
+    monkeypatch.delenv("POCKETPAW_REDIS_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="POCKETPAW_REDIS_URL"):
+        worker_mod.WorkerSettings.redis_settings  # noqa: B018  (descriptor access)
+
+
+async def test_worker_redis_settings_lazy_reads_env_after_import(monkeypatch):
+    """Regression for #7 — env is read at access time, so a test (or a
+    deployment whose env loader runs after import) can set the var and the
+    next access picks it up."""
+    monkeypatch.setenv("POCKETPAW_REDIS_URL", "redis://late-loaded:6379/3")
+
+    settings = worker_mod.WorkerSettings.redis_settings
+
+    # arq's RedisSettings exposes host/port from from_dsn.
+    assert settings.host == "late-loaded"
+    assert settings.port == 6379
+    assert settings.database == 3
+
+
+async def test_worker_redis_settings_reflects_changed_env(monkeypatch):
+    """Subsequent access reflects the current env — no cached/stale value."""
+    monkeypatch.setenv("POCKETPAW_REDIS_URL", "redis://first:6379/0")
+    s1 = worker_mod.WorkerSettings.redis_settings
+    monkeypatch.setenv("POCKETPAW_REDIS_URL", "redis://second:6379/0")
+    s2 = worker_mod.WorkerSettings.redis_settings
+
+    assert s1.host == "first"
+    assert s2.host == "second"
+
+
+# --- #10: arq pool close on shutdown ---------------------------------------
+
+
+async def test_close_pool_aclose_called_when_pool_exists(monkeypatch):
+    """close_pool must actually invoke aclose() on the cached pool, then
+    null the reference so subsequent _get_pool builds a fresh one."""
+    arq_executor._reset_for_tests()
+
+    fake_pool = AsyncMock()
+    fake_pool.aclose = AsyncMock()
+    monkeypatch.setattr(arq_executor, "_pool", fake_pool)
+
+    await arq_executor.close_pool()
+
+    fake_pool.aclose.assert_awaited_once()
+    assert arq_executor._pool is None
+
+
+async def test_close_pool_is_safe_when_no_pool_exists():
+    """Web processes that never enqueued a Tier 2 job will call close_pool
+    on shutdown — it must be a no-op, not raise AttributeError."""
+    arq_executor._reset_for_tests()
+
+    # Should not raise.
+    await arq_executor.close_pool()
+    assert arq_executor._pool is None
+
+
+async def test_close_pool_swallows_aclose_failure(monkeypatch, caplog):
+    """A failing aclose() during shutdown must not propagate — shutdown
+    paths can't afford to raise."""
+    import logging
+
+    arq_executor._reset_for_tests()
+
+    fake_pool = AsyncMock()
+    fake_pool.aclose = AsyncMock(side_effect=RuntimeError("redis lost"))
+    monkeypatch.setattr(arq_executor, "_pool", fake_pool)
+
+    with caplog.at_level(logging.DEBUG, logger="pocketpaw_ee.cloud.chat.runs.arq_executor"):
+        await arq_executor.close_pool()  # must not raise
+
+    assert arq_executor._pool is None  # ref cleared even on failure

--- a/tests/cloud/runs/test_xproc_lifecycle.py
+++ b/tests/cloud/runs/test_xproc_lifecycle.py
@@ -1,0 +1,91 @@
+"""Lifecycle wiring for the xproc bridge: worker pins its role on _startup,
+the web side starts the consumer when POCKETPAW_REDIS_URL is set and is a
+no-op when it isn't (Tier 0 deployments must not log Redis errors)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee import extensions as ext
+from pocketpaw_ee.cloud._core.realtime import xproc
+from pocketpaw_ee.cloud.chat.runs import worker
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _reset_xproc():
+    xproc._reset_for_tests()
+    yield
+    xproc._reset_for_tests()
+
+
+async def test_worker_startup_pins_worker_role(monkeypatch):
+    """``_startup`` must call ``set_role('worker')`` before init_realtime,
+    otherwise the bus singleton on this process becomes the destination for
+    emits that should cross the bridge."""
+
+    async def _noop_db(_uri):
+        return None
+
+    def _noop_realtime():
+        return None
+
+    async def _noop_sweep(**kwargs):
+        return 0
+
+    monkeypatch.setattr(worker, "init_cloud_db", _noop_db)
+    monkeypatch.setattr(worker, "init_realtime", _noop_realtime)
+    monkeypatch.setattr(worker, "sweep_stale_runs", _noop_sweep)
+
+    assert xproc.is_worker() is False
+    await worker._startup({})
+    assert xproc.is_worker() is True
+
+
+async def test_start_xproc_consumer_noop_without_redis_env(monkeypatch):
+    """A cloud deploy that hasn't enabled Tier 1/2 (no POCKETPAW_REDIS_URL)
+    must not spin up the consumer — it would just log Redis errors forever."""
+    monkeypatch.delenv("POCKETPAW_REDIS_URL", raising=False)
+
+    await ext.start_xproc_consumer()
+
+    assert ext._xproc_consumer_task is None
+
+
+async def test_start_xproc_consumer_spawns_task_when_redis_set(monkeypatch):
+    """With POCKETPAW_REDIS_URL set, the consumer task is created and stop
+    cancels it cleanly."""
+    monkeypatch.setenv("POCKETPAW_REDIS_URL", "redis://localhost:6379/0")
+
+    spawned: list = []
+
+    async def _fake_run_consumer(**kwargs):
+        spawned.append("started")
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            spawned.append("cancelled")
+            raise
+
+    monkeypatch.setattr("pocketpaw_ee.cloud._core.realtime.xproc.run_consumer", _fake_run_consumer)
+
+    await ext.start_xproc_consumer()
+    assert ext._xproc_consumer_task is not None
+    assert not ext._xproc_consumer_task.done()
+    # Let the task actually start before we cancel it.
+    await asyncio.sleep(0.01)
+    assert spawned == ["started"]
+
+    await ext.stop_xproc_consumer()
+    assert ext._xproc_consumer_task is None
+    assert spawned == ["started", "cancelled"]
+
+
+async def test_stop_xproc_consumer_safe_when_never_started():
+    """Idempotent stop — Tier 0 deploys never start the task; shutdown still
+    runs stop_xproc_consumer."""
+    ext._xproc_consumer_task = None
+    await ext.stop_xproc_consumer()
+    assert ext._xproc_consumer_task is None

--- a/uv.lock
+++ b/uv.lock
@@ -281,6 +281,19 @@ wheels = [
 ]
 
 [[package]]
+name = "arq"
+version = "0.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "redis", extra = ["hiredis"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/81/7f9db65a89c29ba374000309b9dd95509500045df5c7e22f26c3731b7380/arq-0.28.0.tar.gz", hash = "sha256:a458188aefc2d7ee17d136f80d8fa8df1d6eba4ceebdead87e9f172d027dc311", size = 416141, upload-time = "2026-04-16T10:50:23.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/32/66b616976c5058d434ca2017979bfffd784888177b16b5038abcec93954a/arq-0.28.0-py3-none-any.whl", hash = "sha256:b1696bf5614d60f4172a2c0cbdc177e23ba03a5eb9acc29bd8181f4ea71fff94", size = 26061, upload-time = "2026-04-16T10:50:22.321Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4803,6 +4816,7 @@ name = "pocketpaw-ee"
 version = "0.4.16"
 source = { editable = "ee" }
 dependencies = [
+    { name = "arq" },
     { name = "beanie" },
     { name = "boto3" },
     { name = "composio" },
@@ -4828,6 +4842,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "arq", specifier = ">=0.26.0" },
     { name = "beanie", specifier = ">=1.26.0" },
     { name = "boto3", specifier = ">=1.34.0" },
     { name = "composio", specifier = ">=0.7.0" },
@@ -5987,14 +6002,15 @@ pil = [
 
 [[package]]
 name = "redis"
-version = "7.4.0"
+version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+    { name = "pyjwt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Stacked on #1189. Adds the Tier 2 executor — a separate `arq` worker service that
runs the agent in its own process, so a web restart no longer interrupts in-flight
runs. The web process enqueues an `execute_run_job` instead of spawning an
asyncio task; everything else (Redis Stream events, resumable SSE, run lifecycle)
is unchanged from Tier 1.

Until ``POCKETPAW_CLOUD_RUN_EXECUTOR=arq`` is set on the web service, behaviour
is identical to Tier 1 — this is opt-in per deployment.

Design + plan: ``docs/plans/2026-05-22-resumable-chat-runs-design.md`` +
``docs/plans/2026-05-22-resumable-chat-runs.md``. Deploy guide:
``docs/internal/2026-05-resumable-runs-deploy.md``.

## What changes

- **`ArqExecutor`** (``ee/cloud/chat/runs/arq_executor.py``) — enqueues
  ``execute_run_job`` against an arq Redis pool. Selected by
  ``POCKETPAW_CLOUD_RUN_EXECUTOR=arq``; the executor seam in
  ``executor.py:get_executor`` lazy-imports it so OSS/Tier 1 deployments never
  load arq.
- **Worker entry** (``ee/cloud/chat/runs/worker.py``) — ``WorkerSettings`` with
  ``execute_run_job`` (rehydrates ``RunSpec``, calls ``run_core.execute_run``),
  ``_startup`` (inits cloud DB + realtime, runs boot sweep), ``max_tries=1``
  (no auto-retry; the user decides via Retry).
- **Boot sweep** — on worker startup, mark any ``queued``/``running`` run older
  than 5 seconds as ``interrupted``. The 5-second cutoff is short enough to
  catch runs the previous worker crashed mid-execution but long enough not to
  race the web process enqueueing a new job.
- **Sweeper enhancement** (benefits Tier 1 too) — ``sweep_stale_runs`` now
  appends an ``interrupted`` terminal event to live Redis Streams, so any SSE
  subscriber on the web side finalises immediately instead of waiting out
  heartbeats. Added an ``older_than_seconds`` kwarg for the boot cadence;
  existing ``older_than_minutes`` callers are unchanged.
- **arq dependency** added to ``ee/pyproject.toml``. Pulls ``redis`` to 5.x
  (arq pins ``<6``); the wire-format calls we use (``xadd``/``xread``/
  ``expire``/``set``/``exists``) are identical between 5.x and 7.x.

## Deploy

See ``docs/internal/2026-05-resumable-runs-deploy.md`` for the Coolify topology,
required env, manual verification, and rollback. TL;DR: add a second service
to the same image with start command
``uv run arq pocketpaw_ee.cloud.chat.runs.worker.WorkerSettings`` and the same
``POCKETPAW_REDIS_URL`` + ``CLOUD_MONGODB_URI`` as the web; then set
``POCKETPAW_CLOUD_RUN_EXECUTOR=arq`` on the web. Rollback is unset + redeploy.

## Scope

This is the **backend half** of Tier 2. The frontend Retry affordance for
``interrupted`` messages still lives in the companion ``paw-enterprise`` PR
that was deferred from Tier 1.

## Test plan

- [x] ``uv run pytest tests/cloud/runs/`` — 40 passed, includes new
      ``test_arq_executor.py``, ``test_worker.py``, extended ``test_sweeper.py``.
- [x] ``uv run pytest tests/cloud/chat/`` — no new failures vs. Tier 1 baseline
      (the 5 pre-existing failures are env-related ObjectId mismatches per
      ``reference_backend_test_env``).
- [x] ``uv run ruff check ee/pocketpaw_ee/cloud/chat/runs/`` — clean.
- [x] ``uv run mypy ee/pocketpaw_ee/cloud/chat/runs/`` — clean.
- [x] Staging: provision worker service in Coolify, flip
      ``POCKETPAW_CLOUD_RUN_EXECUTOR=arq``, run the 5-step manual verification
      from the deploy doc (happy path, refresh, session switch, **worker
      restart mid-stream**, two-session concurrency).