### PR TITLE
feat(home-pocket): update_widget MCP tool + refresh path in HOME_POCKET_PROMPT

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/pockets.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/pockets.py
@@ -20,15 +20,15 @@ Moved here from ``src/pocketpaw/agents/sdk_mcp_pocket.py`` in the OSS-EE split
 (Phase 3b). That file also carried the ripple widget-spec tools, which have no
 cloud dependency and stayed in core as ``pocketpaw.agents.sdk_mcp_widgets``.
 
+Changes: 2026-05-24 (#1205) — added ``update_widget`` MCP tool for in-place
+widget refresh. Same shape as ``add_widget`` — agent passes the widget id
+from ``get_pocket`` and the fields to overwrite (usually ``spec`` with a
+fresh data series). Validates the new spec through the same manifest path
+``add_widget`` uses; the server version bumped to ``1.2.0``.
 Changes: 2026-05-22 (#1174) — added the writable ``add_widget`` tool, its
 ``ADD_WIDGET_TOOL_ID`` allowlist id, manifest validation of the widget's
 rippleSpec ``spec`` subtree (skipped for ``type="native"`` widgets), and the
 ``_get_manifest_for_validation`` seam tests patch.
-Changes: 2026-05-24 — added ``update_widget`` MCP tool for in-place widget
-refresh. Same shape as ``add_widget`` — agent passes the widget id from
-``get_pocket`` and the fields to overwrite (usually ``spec`` with a fresh
-data series). Validates the new spec through the same manifest path
-``add_widget`` uses; the server version bumped to ``1.2.0``.
 """
 
 from __future__ import annotations

--- a/ee/pocketpaw_ee/agent/mcp_servers/pockets.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/pockets.py
@@ -24,6 +24,11 @@ Changes: 2026-05-22 (#1174) — added the writable ``add_widget`` tool, its
 ``ADD_WIDGET_TOOL_ID`` allowlist id, manifest validation of the widget's
 rippleSpec ``spec`` subtree (skipped for ``type="native"`` widgets), and the
 ``_get_manifest_for_validation`` seam tests patch.
+Changes: 2026-05-24 — added ``update_widget`` MCP tool for in-place widget
+refresh. Same shape as ``add_widget`` — agent passes the widget id from
+``get_pocket`` and the fields to overwrite (usually ``spec`` with a fresh
+data series). Validates the new spec through the same manifest path
+``add_widget`` uses; the server version bumped to ``1.2.0``.
 """
 
 from __future__ import annotations
@@ -40,11 +45,13 @@ SERVER_NAME = "pocketpaw_pocket"
 GET_POCKET_TOOL_ID = f"mcp__{SERVER_NAME}__get_pocket"
 LIST_POCKETS_TOOL_ID = f"mcp__{SERVER_NAME}__list_pockets"
 ADD_WIDGET_TOOL_ID = f"mcp__{SERVER_NAME}__add_widget"
+UPDATE_WIDGET_TOOL_ID = f"mcp__{SERVER_NAME}__update_widget"
 
 POCKET_TOOL_IDS = (
     GET_POCKET_TOOL_ID,
     LIST_POCKETS_TOOL_ID,
     ADD_WIDGET_TOOL_ID,
+    UPDATE_WIDGET_TOOL_ID,
 )
 
 # Widget ``type`` whose tiles carry no rippleSpec — the frontend renders them
@@ -191,6 +198,48 @@ async def _add_widget_handler(args: dict) -> dict:
     return _result_payload(await add_widget_for_agent(pocket_id, widget))
 
 
+async def _update_widget_handler(args: dict) -> dict:
+    """Patch fields on an existing widget tile — the in-place refresh path.
+
+    Validates a freshly-supplied ``spec`` against the renderer's manifest
+    the same way ``add_widget`` does; on failure nothing is persisted and
+    the agent gets a corrective error. ``type="native"`` skips validation.
+    """
+    pocket_id = args.get("pocket_id")
+    if not pocket_id or not isinstance(pocket_id, str):
+        return _error(
+            "update_widget requires a `pocket_id` — pass the id of the pocket "
+            "(the current home pocket) the widget belongs to."
+        )
+    widget_id = args.get("widget_id")
+    if not widget_id or not isinstance(widget_id, str):
+        return _error(
+            "update_widget requires a `widget_id` — pass the widget's id from "
+            "`get_pocket`'s widgets[] array."
+        )
+    fields = args.get("fields")
+    if not isinstance(fields, dict):
+        return _error(
+            "update_widget requires a `fields` object — the widget fields to "
+            "overwrite, usually `{spec: <new rippleSpec>}` for a refresh."
+        )
+
+    if fields.get("spec") is not None:
+        # Wrap the spec in a widget-shaped dict so the existing validator
+        # walks the same path ``add_widget`` does. ``type`` defaults to a
+        # non-native marker so validation runs; the caller can pass
+        # ``type:"native"`` to opt out.
+        validation_error = await _validate_widget_spec(
+            {"spec": fields["spec"], "type": fields.get("type", "spec")}
+        )
+        if validation_error is not None:
+            return _error(validation_error)
+
+    from pocketpaw_ee.cloud.pockets.agent_context import update_widget_for_agent
+
+    return _result_payload(await update_widget_for_agent(pocket_id, widget_id, fields))
+
+
 def build_pocket_context_server() -> tuple[str, Any] | None:
     """Build the in-process SDK MCP server, or None if the SDK is unavailable."""
     try:
@@ -262,10 +311,48 @@ def build_pocket_context_server() -> tuple[str, Any] | None:
     async def add_widget(args):  # type: ignore[no-untyped-def]
         return await _add_widget_handler(args)
 
+    @tool(
+        "update_widget",
+        (
+            "Update an existing widget tile in place — use this to REFRESH a "
+            "widget's data (e.g., fetch latest sales numbers and rewrite the "
+            "chart's spec) without removing and re-adding. Args: `pocket_id` "
+            "(current home pocket), `widget_id` (from `get_pocket` widgets[]), "
+            "`fields` — object of widget fields to overwrite, usually "
+            "`{spec: <new spec>}`. Validation runs on the new spec the same "
+            "way `add_widget` does; an invalid spec is rejected. Use this "
+            "when the user says 'refresh', 'reload', 'update', 'show latest' "
+            "on an existing tile."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "pocket_id": {
+                    "type": "string",
+                    "description": "Id of the pocket holding the widget.",
+                },
+                "widget_id": {
+                    "type": "string",
+                    "description": "Id of the widget to update (from get_pocket widgets[]).",
+                },
+                "fields": {
+                    "type": "object",
+                    "description": (
+                        "Widget fields to overwrite. Usually "
+                        "{spec: <new rippleSpec>} for a refresh."
+                    ),
+                },
+            },
+            "required": ["pocket_id", "widget_id", "fields"],
+        },
+    )
+    async def update_widget(args):  # type: ignore[no-untyped-def]
+        return await _update_widget_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
-        version="1.1.0",
-        tools=[get_pocket, list_pockets, add_widget],
+        version="1.2.0",
+        tools=[get_pocket, list_pockets, add_widget, update_widget],
     )
     return SERVER_NAME, server
 
@@ -276,5 +363,6 @@ __all__ = [
     "LIST_POCKETS_TOOL_ID",
     "POCKET_TOOL_IDS",
     "SERVER_NAME",
+    "UPDATE_WIDGET_TOOL_ID",
     "build_pocket_context_server",
 ]

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -1,12 +1,10 @@
 # pocketpaw/ripple/_pockets.py — System prompts for the Ripple Pockets surface.
 #
-<<<<<<< HEAD
-# Changes: 2026-05-24 — `HOME_POCKET_PROMPT` learns a third response path:
-# REFRESH. The agent now reaches for `update_widget` (plus `WebSearch` /
+# Changes: 2026-05-24 (#1205) — `HOME_POCKET_PROMPT` learns a third response
+# path: REFRESH. The agent now reaches for `update_widget` (plus `WebSearch` /
 # `WebFetch` / configured MCP data sources) when the user asks to
 # refresh / reload / update an existing tile, instead of calling
 # `add_widget` again and creating a duplicate.
-=======
 # Changes: 2026-05-24 (#1203) — tightened `_LIVE_DATA_SOURCES_EDIT_BLOCK`
 # so the `set_state` seed paired with every `set_source` is UNCONDITIONAL.
 # Earlier wording ("the three calls always travel together") was read as
@@ -18,7 +16,6 @@
 # the bind target part of every `set_source` regardless of whether a
 # widget already reads it, and names the wrong-reasoning failure mode
 # so the model recognizes and rejects it.
->>>>>>> origin/dev
 #
 # Changes: 2026-05-22 (#1174) — rewrote `HOME_POCKET_PROMPT` to drive the
 # now-real `add_widget` MCP tool. It teaches the spec-first workflow:

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -1,5 +1,11 @@
 # pocketpaw/ripple/_pockets.py — System prompts for the Ripple Pockets surface.
 #
+# Changes: 2026-05-24 — `HOME_POCKET_PROMPT` learns a third response path:
+# REFRESH. The agent now reaches for `update_widget` (plus `WebSearch` /
+# `WebFetch` / configured MCP data sources) when the user asks to
+# refresh / reload / update an existing tile, instead of calling
+# `add_widget` again and creating a duplicate.
+#
 # Changes: 2026-05-22 (#1174) — rewrote `HOME_POCKET_PROMPT` to drive the
 # now-real `add_widget` MCP tool. It teaches the spec-first workflow:
 # `get_widget_spec` for the widget type FIRST, then `add_widget` with a
@@ -2314,13 +2320,17 @@ the user keeps an eye on (a revenue stat, a task list, a sales chart). It
 is the user's own dashboard, assembled one widget at a time. The pocket
 id is in the `<current-pocket>` block — pass it as `pocket_id`.
 
-Two response paths:
+Three response paths:
 
   1. ADD A WIDGET. The user asks to add, show, track, or pin a specific
      widget — "show me a 7-day sales chart", "add a task list", "track
      active agents". Pin it with the `add_widget` tool.
 
-  2. CHAT. Anything else — a question, ordinary conversation ("what's on
+  2. REFRESH A WIDGET. The user asks to refresh, reload, update, or show
+     the latest on a widget that already exists. Overwrite its data with
+     the `update_widget` tool — do not call `add_widget` again.
+
+  3. CHAT. Anything else — a question, ordinary conversation ("what's on
      my home page?", "how do I do X"). Answer directly. Do NOT call
      `add_widget` unless the user actually asked for a widget.
 
@@ -2381,6 +2391,30 @@ spec to use only the allowed props, and call again.
 To see what is already on the home grid, call `get_pocket` once with the
 pocket id and read the returned widgets. Add one widget per explicit
 request — don't pre-populate the grid.
+
+## How to refresh a widget
+
+When the user asks to "refresh", "reload", "update", or "show the latest"
+on a widget that already exists on the grid, do NOT call `add_widget`
+again — that would create a duplicate tile. Instead:
+
+  STEP 1. Call `get_pocket` to read the current `widgets[]` array. Find
+  the entry whose `name` matches the widget the user means (or the most
+  recent one if ambiguous). Grab its `_id`.
+
+  STEP 2. Fetch fresh data. You have `WebSearch`, `WebFetch`, and the
+  in-process MCP tools (Composio's gmail / calendar / drive when
+  configured) available. Use whichever fits the widget — a sales chart
+  may need a Composio CRM call, a competitor-news tile a WebSearch.
+
+  STEP 3. Call `update_widget` with the same `pocket_id`, the widget's
+  `_id` as `widget_id`, and `fields: {spec: <new rippleSpec>}` carrying
+  the fresh data. The spec shape stays the same as the original; only
+  the `data` series (or rows, or text) changes. The renderer re-renders
+  the tile in place.
+
+A native widget (Mission · Tray etc.) refreshes itself from its own
+endpoint — you do not need to touch it.
 </home-pocket>
 """
 

--- a/tests/cloud/test_home_pocket_update_widget.py
+++ b/tests/cloud/test_home_pocket_update_widget.py
@@ -1,0 +1,354 @@
+# tests/cloud/test_home_pocket_update_widget.py — Home agent's refresh path.
+# Created: 2026-05-24 — coverage for the new ``update_widget`` MCP tool that
+# lets the home agent overwrite an existing tile's data instead of
+# delete-then-re-add. Mirrors the patterns in
+# ``tests/cloud/test_home_pocket.py`` (tool-id / handler validation) and
+# ``tests/cloud/test_pocket_granular_ops.py`` (``_FakeDoc`` round-trip).
+#
+# What's covered:
+#   1. ``UPDATE_WIDGET_TOOL_ID`` is published with the expected name and
+#      sits in ``POCKET_TOOL_IDS`` (allowlist regression).
+#   2. ``_update_widget_handler`` rejects missing ``pocket_id`` / ``widget_id``
+#      / ``fields`` args before reaching out to the store.
+#   3. A widget spec carrying invented props is rejected by the same
+#      manifest validator ``add_widget`` uses — nothing is persisted.
+#   4. The happy-path round trip: handler updates a chart widget's
+#      ``spec.props.data`` in place, the saved doc carries the new
+#      series, and an SSE push fires.
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pocketpaw_ee.agent.mcp_servers.pockets import (
+    ADD_WIDGET_TOOL_ID,
+    POCKET_TOOL_IDS,
+    SERVER_NAME,
+    UPDATE_WIDGET_TOOL_ID,
+    _update_widget_handler,
+)
+from pocketpaw_ee.cloud.models.pocket import Widget as _WidgetDoc
+
+# ---------------------------------------------------------------------------
+# tool id + allowlist registration
+# ---------------------------------------------------------------------------
+
+
+def test_update_widget_tool_id_is_published() -> None:
+    """``UPDATE_WIDGET_TOOL_ID`` mirrors the SDK's ``mcp__<server>__<tool>``
+    naming so a backend allowlist entry will match the tool the SDK
+    surfaces at call time. It must also sit in the ``POCKET_TOOL_IDS``
+    tuple so the EE extension that publishes the home-agent allowlist
+    picks it up automatically."""
+    assert UPDATE_WIDGET_TOOL_ID == f"mcp__{SERVER_NAME}__update_widget"
+    assert UPDATE_WIDGET_TOOL_ID == "mcp__pocketpaw_pocket__update_widget"
+    assert UPDATE_WIDGET_TOOL_ID in POCKET_TOOL_IDS
+    # Sibling ``add_widget`` id is still there — the new tool joins the
+    # allowlist, it does not replace the existing entries.
+    assert ADD_WIDGET_TOOL_ID in POCKET_TOOL_IDS
+
+
+# ---------------------------------------------------------------------------
+# arg validation — handler short-circuits before touching the store
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_widget_handler_rejects_missing_args() -> None:
+    """Each required arg is checked independently. The handler returns an
+    MCP error payload and never reaches the agent_context helper — we
+    assert that by patching the lazy import target with a sentinel that
+    raises on call.
+    """
+    sentinel = AsyncMock(
+        side_effect=AssertionError("update_widget_for_agent must NOT be called"),
+    )
+    with patch(
+        "pocketpaw_ee.cloud.pockets.agent_context.update_widget_for_agent",
+        new=sentinel,
+    ):
+        # No args at all.
+        result = await _update_widget_handler({})
+        assert result["is_error"] is True
+        assert "pocket_id" in result["content"][0]["text"]
+
+        # pocket_id only.
+        result = await _update_widget_handler({"pocket_id": "p1"})
+        assert result["is_error"] is True
+        assert "widget_id" in result["content"][0]["text"]
+
+        # pocket_id + widget_id, no fields.
+        result = await _update_widget_handler(
+            {"pocket_id": "p1", "widget_id": "w1"},
+        )
+        assert result["is_error"] is True
+        assert "fields" in result["content"][0]["text"]
+
+        # fields wrong type — must be a dict.
+        result = await _update_widget_handler(
+            {"pocket_id": "p1", "widget_id": "w1", "fields": "not-a-dict"},
+        )
+        assert result["is_error"] is True
+
+    assert sentinel.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# manifest validation — invented props are rejected before the save
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_widget_handler_validates_spec() -> None:
+    """A ``fields={"spec": ...}`` carrying a prop the renderer does not
+    know about is rejected with the same wording ``add_widget`` uses.
+    Validation runs before the agent_context helper is reached, so the
+    store is never touched on rejection.
+    """
+    # Minimal chart manifest that only declares ``variant`` + ``data`` as
+    # allowed props. ``madeUpProp`` is not in the manifest so the validator
+    # surfaces it as an unknown prop the agent must remove. Real manifest
+    # shape: ``widgets`` is a list of ``{type, props}`` entries where
+    # ``props`` is the dict of allowed prop names → schema.
+    fake_manifest: dict[str, Any] = {
+        "widgets": [
+            {
+                "type": "chart",
+                "props": {"variant": {}, "data": {}},
+            },
+        ],
+    }
+    sentinel = AsyncMock(
+        side_effect=AssertionError("update_widget_for_agent must NOT be called"),
+    )
+    with (
+        patch(
+            "pocketpaw_ee.agent.mcp_servers.pockets._get_manifest_for_validation",
+            new=AsyncMock(return_value=fake_manifest),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.pockets.agent_context.update_widget_for_agent",
+            new=sentinel,
+        ),
+    ):
+        result = await _update_widget_handler(
+            {
+                "pocket_id": "p1",
+                "widget_id": "w1",
+                "fields": {
+                    "spec": {
+                        "type": "chart",
+                        "props": {"madeUpProp": "bad"},
+                    },
+                },
+            },
+        )
+
+    assert result["is_error"] is True
+    body = result["content"][0]["text"]
+    # The validator's error names the offending prop so the agent can
+    # re-emit a fixed spec.
+    assert "madeUpProp" in body
+    # And the store helper never ran — invalid specs are caught before
+    # any write reaches the doc.
+    assert sentinel.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# round-trip — handler overwrites the widget spec end-to-end
+# ---------------------------------------------------------------------------
+
+
+class _FakeHomePocketDoc:
+    """Stand-in for a ``_PocketDoc`` whose ``widgets`` array holds a single
+    chart tile. Mirrors the surface ``agent_update_widget`` reads: an
+    ``id``/``workspace``/``owner`` plus a ``widgets`` list of ``_WidgetDoc``
+    sub-models. ``save()`` is an async no-op that bumps a counter.
+    """
+
+    def __init__(self, pocket_id: str, widget: _WidgetDoc) -> None:
+        self.id = pocket_id
+        self.workspace = "w-home"
+        self.name = "Home"
+        self.description = ""
+        self.type = "home"
+        self.icon = ""
+        self.color = ""
+        self.owner = "u-home"
+        self.visibility = "private"
+        self.team: list[str] = []
+        self.agents: list[str] = []
+        self.widgets: list[_WidgetDoc] = [widget]
+        self.rippleSpec: dict[str, Any] | None = None
+        self.share_link_token: str | None = None
+        self.share_link_access = "view"
+        self.shared_with: list[str] = []
+        self.tool_specs: list[Any] = []
+        self.saves = 0
+
+    async def save(self) -> None:
+        self.saves += 1
+
+    def model_dump(self, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "_id": self.id,
+            "workspace": self.workspace,
+            "name": self.name,
+            "description": self.description,
+            "type": self.type,
+            "icon": self.icon,
+            "color": self.color,
+            "owner": self.owner,
+            "visibility": self.visibility,
+            "team": list(self.team),
+            "agents": list(self.agents),
+            "widgets": [w.model_dump(by_alias=True) for w in self.widgets],
+            "rippleSpec": self.rippleSpec,
+            "share_link_token": self.share_link_token,
+            "share_link_access": self.share_link_access,
+            "shared_with": list(self.shared_with),
+            "tool_specs": list(self.tool_specs),
+        }
+
+
+def _patch_store(doc: _FakeHomePocketDoc):
+    """Patch the seams ``agent_update_widget`` reaches: doc fetch, emit,
+    payload builder, the SSE push, the per-stream identity ContextVars,
+    and the manifest fetch (so spec validation is hermetic).
+
+    Returns ``(ExitStack, push_calls)``. Use as ``with ctx: ...``.
+    """
+    push_calls: list[dict[str, Any]] = []
+
+    def _capture(payload: dict[str, Any]) -> None:
+        push_calls.append(payload)
+
+    stack = ExitStack()
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service._PocketDoc.get",
+            new=AsyncMock(return_value=doc),
+        ),
+    )
+    stack.enter_context(
+        patch("pocketpaw_ee.cloud.pockets.service.emit", new=AsyncMock()),
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service._pocket_event_payload",
+            new=AsyncMock(return_value={"pocket_id": doc.id}),
+        ),
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.push_pocket_mutation",
+            new=MagicMock(side_effect=_capture),
+        ),
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+            new=MagicMock(return_value=doc.workspace),
+        ),
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+            new=MagicMock(return_value=doc.owner),
+        ),
+    )
+    # Manifest fetch returns None → spec validation no-ops. A separate
+    # test pins the rejection path with a real manifest.
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.agent.mcp_servers.pockets._get_manifest_for_validation",
+            new=AsyncMock(return_value=None),
+        ),
+    )
+    return stack, push_calls
+
+
+@pytest.mark.asyncio
+async def test_update_widget_handler_round_trip() -> None:
+    """Set up a home pocket with one chart widget carrying a 1-point
+    data series. Call the handler with a 1-point-but-different series.
+    Assert the widget's ``spec.props.data`` is the new series, the doc
+    was saved once, and an SSE push fired so connected frontends
+    re-render the tile."""
+    original_spec = {
+        "type": "chart",
+        "props": {
+            "variant": "bar",
+            "data": [{"label": "M", "value": 1}],
+        },
+    }
+    widget = _WidgetDoc(
+        name="7-day sales",
+        type="chart",
+        icon="trending-up",
+        color="#0A84FF",
+        spec=original_spec,
+    )
+    doc = _FakeHomePocketDoc("507f1f77bcf86cd799430022", widget)
+    widget_id = widget.id
+
+    new_spec = {
+        "type": "chart",
+        "props": {
+            "variant": "bar",
+            "data": [{"label": "Tue", "value": 99}],
+        },
+    }
+
+    ctx, push_calls = _patch_store(doc)
+    with ctx:
+        result = await _update_widget_handler(
+            {
+                "pocket_id": doc.id,
+                "widget_id": widget_id,
+                "fields": {"spec": new_spec},
+            },
+        )
+
+    # Handler did not return an error envelope.
+    assert "is_error" not in result, f"handler errored: {result!r}"
+    # The persisted widget carries the new series, not the original.
+    assert doc.widgets[0].spec is not None
+    assert doc.widgets[0].spec["props"]["data"] == [{"label": "Tue", "value": 99}]
+    # And one save fired — no double-write.
+    assert doc.saves == 1
+    # Connected frontends got a single SSE replace-payload so they
+    # re-render the tile in place.
+    assert len(push_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_update_widget_handler_returns_unknown_widget_error() -> None:
+    """A widget id the pocket does not carry surfaces a clear error from
+    the service layer — the handler does not crash, it returns the MCP
+    error envelope so the agent can correct itself."""
+    widget = _WidgetDoc(
+        name="7-day sales",
+        type="chart",
+        icon="trending-up",
+        color="#0A84FF",
+        spec={"type": "chart", "props": {"data": [{"label": "M", "value": 1}]}},
+    )
+    doc = _FakeHomePocketDoc("507f1f77bcf86cd799430033", widget)
+
+    ctx, _ = _patch_store(doc)
+    with ctx:
+        result = await _update_widget_handler(
+            {
+                "pocket_id": doc.id,
+                "widget_id": "not-a-real-widget-id",
+                "fields": {"spec": {"type": "chart", "props": {"data": []}}},
+            },
+        )
+
+    assert result["is_error"] is True
+    # No save fired — unknown widget short-circuits before the doc is touched.
+    assert doc.saves == 0

--- a/tests/cloud/test_home_pocket_update_widget.py
+++ b/tests/cloud/test_home_pocket_update_widget.py
@@ -248,6 +248,18 @@ def _patch_store(doc: _FakeHomePocketDoc):
             new=MagicMock(side_effect=_capture),
         ),
     )
+    # Patch ``_resolved_view_for_frontend`` explicitly — otherwise the test
+    # silently relies on ``_FakeHomePocketDoc.rippleSpec`` being None (which
+    # short-circuits the helper before its ``ripple_resolver`` import). A
+    # future test variant carrying a real rippleSpec would pull in the
+    # resolver and either import-error or make a live call. See PR #1205
+    # review N1.
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.agent_context._resolved_view_for_frontend",
+            new=AsyncMock(side_effect=lambda v: v),
+        ),
+    )
     stack.enter_context(
         patch(
             "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",

--- a/tests/cloud/test_pocket_prompts_single_source.py
+++ b/tests/cloud/test_pocket_prompts_single_source.py
@@ -179,6 +179,37 @@ def test_home_pocket_prompt_teaches_the_spec_first_workflow() -> None:
     assert "spec" in HOME_POCKET_PROMPT
 
 
+def test_home_prompt_teaches_refresh_workflow() -> None:
+    """The home agent has a third response path: REFRESH. It must call
+    ``update_widget`` (with the id from ``get_pocket``) instead of
+    ``add_widget`` again. The prompt also names ``WebSearch`` and
+    ``WebFetch`` as data sources so the agent knows where to pull fresh
+    numbers from before writing the new spec."""
+    from pocketpaw.ripple import HOME_POCKET_PROMPT
+
+    body = HOME_POCKET_PROMPT.lower()
+    assert "refresh" in body
+    # The two tools the refresh workflow uses end-to-end.
+    assert "update_widget" in HOME_POCKET_PROMPT
+    assert "get_pocket" in HOME_POCKET_PROMPT
+    # The named data-source tools the agent can reach for to fetch fresh
+    # numbers before writing the new spec.
+    assert "WebSearch" in HOME_POCKET_PROMPT
+    assert "WebFetch" in HOME_POCKET_PROMPT
+    # The path-count change — the opening lists three response paths now.
+    assert "Three response paths" in HOME_POCKET_PROMPT
+
+
+def test_home_prompt_warns_against_duplicate_add() -> None:
+    """The refresh path explicitly tells the agent NOT to call
+    ``add_widget`` a second time — that would create a duplicate tile.
+    Without this guard the LLM tends to fall back to the only widget
+    mutation it has seen in earlier turns."""
+    from pocketpaw.ripple import HOME_POCKET_PROMPT
+
+    assert "do NOT call `add_widget`" in HOME_POCKET_PROMPT
+
+
 def test_pocket_id_token_substitution() -> None:
     """The interaction prompt has a literal ``__POCKET_ID__`` token the
     caller substitutes via ``str.replace``. A naive ``str.format`` would

--- a/tests/ee/test_pocket_specialist.py
+++ b/tests/ee/test_pocket_specialist.py
@@ -39,10 +39,11 @@ def test_widget_spec_mcp_server_is_read_only():
 
 def test_pocket_mcp_server_surface():
     """The cloud ``pocketpaw_pocket`` server exposes the two read tools plus
-    the writable ``add_widget`` tool — the home agent's widget-creation
-    path. rippleSpec *design* mutations still flow through the
-    ``pocket_specialist__create`` / ``__edit`` tools; ``add_widget`` only
-    appends a tile to a pocket's ``widgets[]`` array, a different surface.
+    the writable ``add_widget`` / ``update_widget`` tools — the home agent's
+    widget-creation and refresh paths. rippleSpec *design* mutations still
+    flow through the ``pocket_specialist__create`` / ``__edit`` tools;
+    ``add_widget`` / ``update_widget`` only touch a pocket's ``widgets[]``
+    array, a different surface.
     """
     # The cloud pocket-context server is EE-only — skip when absent.
     try:
@@ -53,6 +54,7 @@ def test_pocket_mcp_server_surface():
         "mcp__pocketpaw_pocket__get_pocket",
         "mcp__pocketpaw_pocket__list_pockets",
         "mcp__pocketpaw_pocket__add_widget",
+        "mcp__pocketpaw_pocket__update_widget",
     }, f"drift in pocket MCP tool surface: {set(POCKET_TOOL_IDS)}"
 
 


### PR DESCRIPTION
## Summary

- Adds an `update_widget` tool to the in-process `pocketpaw_pocket` MCP server, mirroring the existing `add_widget` shape. The cloud-side helper `update_widget_for_agent` already existed in `ee/pocketpaw_ee/cloud/pockets/agent_context.py:358` — this PR just surfaces it.
- Teaches `HOME_POCKET_PROMPT` a third response path: read the widget id with `get_pocket`, fetch fresh data via `WebSearch` / `WebFetch` / configured MCP tools, then call `update_widget` to overwrite the tile's `spec` (or any other field).
- Bumps the MCP server version 1.1.0 → 1.2.0 and extends `POCKET_TOOL_IDS` so the EE allowlist picks the new tool up automatically.

## Why

Today's home agent only knows how to ADD widgets — refreshing a tile meant deleting and re-adding, so home widgets were static snapshots baked at creation time. The captain wanted a chat-driven "refresh the sales chart" workflow.

## What this does NOT include

Button-click refresh (a refresh affordance on each tile that fires without a chat round-trip) is a separate follow-up. This PR only covers the chat path: the user asks, the agent reads → fetches → writes.

## Test plan

- [x] `tests/cloud/test_home_pocket_update_widget.py` — new file. Covers tool-id allowlist, arg validation, manifest rejection, and a `_FakeDoc` round trip proving the persisted widget carries the new series.
- [x] `tests/cloud/test_pocket_prompts_single_source.py` — two new assertions: `test_home_prompt_teaches_refresh_workflow` and `test_home_prompt_warns_against_duplicate_add`.
- [x] Full targeted suite green: `uv run pytest tests/cloud/test_home_pocket.py tests/cloud/test_home_pocket_update_widget.py tests/cloud/test_pocket_prompts_single_source.py tests/cloud/test_agent_service_tools_context.py` — 55 passed.
- [x] Adjacent suites also green: `tests/cloud/test_pocket_granular_ops.py`, `test_pocket_prompt_state_sources.py`, `test_inline_prompt_source_of_truth.py`, `test_home_pocket_route.py` — 52 passed.
- [x] `ruff check` + `ruff format --check` clean on all four changed files.