### PR TITLE
fix(ripple): make the live-source state seed unconditional in the edit prompt

### DIFF
--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -1,5 +1,17 @@
 # pocketpaw/ripple/_pockets.py — System prompts for the Ripple Pockets surface.
 #
+# Changes: 2026-05-24 (#1203) — tightened `_LIVE_DATA_SOURCES_EDIT_BLOCK`
+# so the `set_state` seed paired with every `set_source` is UNCONDITIONAL.
+# Earlier wording ("the three calls always travel together") was read as
+# conditional by the edit specialist: when a user asked for just a live
+# source with no consuming widget yet, the agent shipped `set_source`
+# alone, reasoning "no widget reads it, seed unnecessary". The next
+# `add_node` then bound to an absent state key and rendered empty until
+# the first source run. The new UNCONDITIONAL SEED RULE makes seeding
+# the bind target part of every `set_source` regardless of whether a
+# widget already reads it, and names the wrong-reasoning failure mode
+# so the model recognizes and rejects it.
+#
 # Changes: 2026-05-22 (#1174) — rewrote `HOME_POCKET_PROMPT` to drive the
 # now-real `add_widget` MCP tool. It teaches the spec-first workflow:
 # `get_widget_spec` for the widget type FIRST, then `add_widget` with a
@@ -686,6 +698,17 @@ batch to author the matching binding AND ``set_state`` to seed the
 forever. The three calls always travel together: ``set_source(key, path,
 bind="state.x", refresh=[...])`` + ``set_state("x", [])`` + the
 ``add_node`` for the widget that reads ``{state.x}``.
+
+UNCONDITIONAL SEED RULE — `set_state` the `bind` target to a typed
+empty value as part of EVERY `set_source`, even when no widget yet
+reads the path. Keep the contract uniform. Skipping the seed because
+"nothing binds it yet" is the bug — the next widget edit (yours or a
+later one) assumes the seed exists and renders empty without it, and
+the first source run also has nothing to merge into. Typed empty means
+`[]` for a list endpoint, `{}` for an object endpoint, `""` / `0` for
+a scalar — match the shape the widget will read. There is no "I'll
+seed it later when a widget is added" exception; pair them now or the
+later add_node ships a dead widget.
 
   set_source(
     source_key="prs",            # the sources map key

--- a/tests/unit/test_pocket_delegation_rule_gaps.py
+++ b/tests/unit/test_pocket_delegation_rule_gaps.py
@@ -12,6 +12,13 @@
 #     ``bind:`` but didn't make node-level placement loud enough,
 #     so kanban widgets rendered without a writeback path.
 #
+# 2026-05-24 (#1203) — add the unconditional-seed gap: even with the
+# label/source pairing rule above, the specialist still skipped the
+# ``set_state`` seed when no widget yet bound the path, reasoning
+# "nothing reads it, no need to seed". The next ``add_node`` then
+# rendered empty until the first source run. New assertion below
+# pins the UNCONDITIONAL SEED RULE language so a drift fails loud.
+#
 # These are content assertions, not behavior tests — the model still
 # has to read and follow the rules. But each gap has a concrete
 # regression case behind it, and a content drift is the easiest way
@@ -103,6 +110,22 @@ class TestLabelWithoutSourceRule:
         assert "set_source" in _LIVE_DATA_SOURCES_EDIT_BLOCK
         assert "set_state" in _LIVE_DATA_SOURCES_EDIT_BLOCK
         assert "add_node" in _LIVE_DATA_SOURCES_EDIT_BLOCK
+
+
+class TestUnconditionalSeedRule:
+    """The specialist still skipped ``set_state`` when asked for ONLY a
+    source (no consuming widget in the same ask), reasoning "nothing
+    binds it yet, no seed needed". The next ``add_node`` then rendered
+    empty. The edit block must spell out that the seed pairs with
+    EVERY ``set_source``, unconditionally — and must name the wrong
+    reasoning so the model recognizes the failure mode."""
+
+    def test_edit_block_marks_seed_as_unconditional(self):
+        # Anchor on a phrase that only the unconditional rule carries
+        # — "even when no widget yet reads the path" is the load-bearing
+        # half of the rule and the part the old wording lacked.
+        flat = " ".join(_LIVE_DATA_SOURCES_EDIT_BLOCK.split())
+        assert "even when no widget yet reads the path" in flat
 
 
 class TestInteractiveBindRule:


### PR DESCRIPTION
## What

The edit specialist was treating the `set_state` seed paired with `set_source` as conditional on a widget already binding the path. When a chat asked for only a live source (no consuming widget in the same turn), the agent shipped `set_source` alone and reasoned "no widget reads the bind path yet, the seed is unnecessary". The next `add_node` that did bind `{state.<key>}` then rendered empty until the first source run landed.

The existing wording — "The three calls always travel together" — wasn't loud enough. The agent kept reading it as a recipe for the common case, not a rule.

## Fix

Tighten `_LIVE_DATA_SOURCES_EDIT_BLOCK` in `src/pocketpaw/ripple/_pockets.py` with an UNCONDITIONAL SEED RULE:

- Pair `set_state` with EVERY `set_source`, even when no widget yet reads the path.
- Name the failure mode out loud ("nothing binds it yet" is the bug, not the reason to skip).
- Spell out the typed-empty shape — `[]` for a list, `{}` for an object, `""` / `0` for a scalar — so the seed matches the eventual widget contract.

## Test

`tests/unit/test_pocket_delegation_rule_gaps.py` gets a new `TestUnconditionalSeedRule` class anchored on the load-bearing half of the new rule ("even when no widget yet reads the path"). Mirrors the existing `TestLabelWithoutSourceRule` shape. Imports only from `pocketpaw.ripple._pockets` (OSS path); the private-attribute import is intentional and documented in the file header per the #1194 convention.

## Verification

- `uv run pytest tests/unit/test_pocket_delegation_rule_gaps.py -q` — 15 passed
- `uvx ruff@0.15.9 format --check .` — 1311 files already formatted
- `uvx ruff@0.15.9 check .` — All checks passed

Fixes #1203