### PR TITLE
feat(chat): per-turn surface preamble for the cloud chat agent

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -40,6 +40,7 @@ from pocketpaw_ee.cloud.chat.agent_service import (
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
 from pocketpaw_ee.cloud.shared.errors import CloudError
+from pocketpaw_ee.cloud.surface import resolve_surface_context
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +80,21 @@ async def post_agent_chat(
         raise CloudError(400, "scope.invalid", "Invalid scope") from None
     except CloudError:
         raise
+
+    # Resolve the surface-aware context preamble AFTER scope is resolved
+    # (so we have ``workspace_id`` / ``user_id`` confirmed) and BEFORE any
+    # other prompt assembly. The resolver never raises — failures fall
+    # back to a GENERIC context with an empty preamble, which
+    # ``build_dynamic_context`` then treats as the legacy three-line
+    # shape. Older clients that send neither ``surface`` nor
+    # ``surface_meta`` land here as ``{surface: None, meta: {}}`` and
+    # produce a GENERIC context with a placeholder preamble that the
+    # router still attaches; the chat continues to work either way.
+    ctx.surface_context = await resolve_surface_context(
+        ctx.workspace_id,
+        user_id,
+        {"surface": body.surface, "meta": body.surface_meta or {}},
+    )
 
     # Signal any prior in-flight run for the same (scope, scope_id, user_id)
     # to stop. We don't wait on it — each generator cleans its own slot in

--- a/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
@@ -9,6 +9,12 @@
 #   whole pocket from the coarse ``PocketUpdated`` realtime event. Also
 #   added the ``POCKET_EXECUTION`` SSE event name for the execution
 #   router's per-request observability frame.
+# Changes: 2026-05-24 — added ``surface`` + ``surface_meta`` fields so
+#   clients can stamp a {surface_kind, meta} hint on every send. The
+#   chat router passes them to ``surface_context.resolve_surface_context``
+#   which renders a per-turn preamble injected ahead of the dynamic
+#   scope tags. Unknown surface strings fall back to the GENERIC handler
+#   so older clients keep working unchanged.
 """Request and SSE-event payload schemas for the enterprise agent chat endpoint.
 
 The endpoint lives at ``POST /cloud/chat/{scope}/{scope_id}/agent`` and streams
@@ -58,6 +64,19 @@ class CloudAgentChatRequest(BaseModel):
     # Argument string for ``intent="skill:<name>"`` (empty when the skill
     # was invoked bare). Reserved — not consumed by the backend yet.
     skill_args: str | None = None
+    # Surface-aware context hint (RFC: universal surface context).
+    # ``surface`` is the SurfaceKind enum value the client computed from
+    # ``$page.route.id`` ("home", "pockets", "pocket", "mission_control",
+    # …). Unknown values fall back to ``GENERIC`` in
+    # ``surface_context.service.resolve_surface_context`` so a client can
+    # ship a new surface name before the backend handler does. ``None``
+    # means the client didn't stamp a hint (older clients) — the agent
+    # then sees only the legacy three-line dynamic context.
+    surface: str | None = None
+    # Per-surface meta hint — ``pocket_id`` / ``widget_id`` / ``agent_id``
+    # / etc. Validated downstream by ``SurfaceMetaRequest``; unknown
+    # fields are dropped. ``None`` is treated as an empty dict.
+    surface_meta: dict[str, Any] | None = None
 
     @field_validator("intent")
     @classmethod

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -27,6 +27,13 @@ leaks as literal text.
 Changes: 2026-05-22 (Increment 3) — added ``push_pocket_execution``, the
 SSE-sink push for the execution router's per-request ``pocket_execution``
 observability frame.
+Changes: 2026-05-24 — ``ScopeContext`` carries an optional
+``surface_context`` (the resolved {surface_kind, meta, preamble} tuple
+from ``surface_context.resolve_surface_context``). ``build_dynamic_context``
+prepends its preamble before the legacy scope/participants/current-pocket
+tags so the chat agent sees the surface snapshot first. Clients that
+don't stamp a surface hint keep the old three-line shape unchanged —
+``surface_context is None`` is the legacy path.
 """
 
 from __future__ import annotations
@@ -47,6 +54,7 @@ from pocketpaw.ripple import (
 )
 from pocketpaw.ripple._pockets import _MCP_POCKET_BACKENDS
 from pocketpaw_ee.cloud.shared.errors import CloudError, NotFound
+from pocketpaw_ee.cloud.surface import SurfaceContext
 
 logger = logging.getLogger(__name__)
 
@@ -200,6 +208,12 @@ class ScopeContext:
     # agent reach for the ``create_pocket`` MCP tool instead of rendering
     # an inline ``ui-spec`` chat reply.
     intent: str | None = None
+    # Resolved per-turn surface context from
+    # ``surface_context.resolve_surface_context``. ``None`` when the
+    # client didn't stamp a hint or the surface module is unreachable —
+    # ``build_dynamic_context`` falls back to the legacy three-line
+    # shape in that case.
+    surface_context: SurfaceContext | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -672,12 +686,22 @@ def build_dynamic_context(ctx: ScopeContext) -> str:
     participants, current-pocket-id. Pairs with
     ``build_behavior_instructions``: the dynamic context is reference
     data and lives inside the ``knowledge_context`` wrapper; the
-    behavioral instructions live at the top level."""
+    behavioral instructions live at the top level.
+
+    When a ``surface_context`` is attached, its preamble is prepended
+    FIRST — surface state (pinned widgets, snapshot, available tools)
+    is more informationally dense than the bare scope tags and the
+    agent should see it before anything else. ``surface_context is None``
+    keeps the legacy three-line shape (clients that don't stamp a
+    surface hint, or surfaces that fell back to GENERIC with an empty
+    preamble).
+    """
+    parts: list[str] = []
+    if ctx.surface_context and ctx.surface_context.preamble:
+        parts.append(ctx.surface_context.preamble)
     member_list = ", ".join(ctx.members) if ctx.members else "(none)"
-    parts = [
-        f"<scope>{ctx.kind.value} {ctx.scope_id}</scope>",
-        f"<participants>{member_list}</participants>",
-    ]
+    parts.append(f"<scope>{ctx.kind.value} {ctx.scope_id}</scope>")
+    parts.append(f"<participants>{member_list}</participants>")
     if ctx.pocket_id and ctx.intent != "pocket_create":
         parts.append(f'<current-pocket id="{ctx.pocket_id}" />')
     return "\n".join(parts)

--- a/ee/pocketpaw_ee/cloud/surface/__init__.py
+++ b/ee/pocketpaw_ee/cloud/surface/__init__.py
@@ -1,0 +1,17 @@
+# __init__.py — Public surface for the surface-context entity.
+#
+# Created: 2026-05-24 — Re-exports the resolver and the two domain
+# value objects every consumer needs. Handlers stay private to the
+# sub-package; callers don't import them directly.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceContext, SurfaceKind, SurfaceMeta
+from pocketpaw_ee.cloud.surface.service import resolve_surface_context
+
+__all__ = [
+    "SurfaceContext",
+    "SurfaceKind",
+    "SurfaceMeta",
+    "resolve_surface_context",
+]

--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -1,0 +1,87 @@
+# domain.py — Surface context value objects.
+#
+# Created: 2026-05-24 — Surface-aware chat preamble entity. The cloud
+# chat agent today only sees scope / participants / current-pocket-id
+# (three lines of dynamic context). Paw-enterprise is chat-first and
+# every route will eventually have a chat bar — the agent should know
+# which SURFACE the user is on and what's actually visible there. This
+# module owns the value objects ``SurfaceKind`` (enumerates every chat-
+# bearing surface), ``SurfaceMeta`` (client-supplied hints) and
+# ``SurfaceContext`` (resolved snapshot + rendered preamble). Per the
+# 11 entity rules, tenancy is enforced at construction — ``workspace_id``
+# and ``user_id`` are required on ``SurfaceContext``.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class SurfaceKind(StrEnum):
+    """Every chat-bearing surface in paw-enterprise.
+
+    The router stamps one of these on every chat send via the client's
+    ``surface`` hint. Unknown values fall back to ``GENERIC`` so an older
+    client (or a route we haven't classified yet) still gets a usable
+    preamble instead of failing the chat send.
+    """
+
+    HOME = "home"
+    POCKETS_LIST = "pockets"  # /pockets index
+    POCKET = "pocket"  # /pockets/[id]
+    POCKET_WIDGET = "pocket_widget"  # /pockets/[id] with widget-focus modal open
+    MISSION_CONTROL = "mission_control"  # /mission-control
+    FILES = "files"
+    AUDIT = "audit"
+    ACTIVITY = "activity"
+    AGENTS = "agents"
+    AGENT = "agent"  # /agents/[id]
+    KNOWLEDGE = "knowledge"
+    CALENDAR = "calendar"
+    CHAT = "chat"
+    QUICKASK = "quickask"
+    SETTINGS = "settings"
+    SIDEPANEL = "sidepanel"
+    GENERIC = "generic"  # any unknown surface — agent still gets a usable preamble
+
+
+@dataclass(frozen=True)
+class SurfaceMeta:
+    """Client-supplied hints about the current surface.
+
+    Every field optional. Stay small — anything heavy gets fetched
+    server-side by the matching handler rather than serialized over the
+    wire. ``route_path`` is for debugging only (the raw
+    ``$page.route.id`` the client read), not for routing decisions.
+    """
+
+    pocket_id: str | None = None
+    widget_id: str | None = None
+    focus_node_id: str | None = None
+    agent_id: str | None = None
+    file_id: str | None = None
+    route_path: str | None = None
+
+
+@dataclass(frozen=True)
+class SurfaceContext:
+    """Resolved surface state, ready to be embedded in the agent's prompt.
+
+    Multi-tenant — ``workspace_id`` and ``user_id`` are required at
+    construction time per the entity rules' tenancy-at-construction
+    contract. Constructing one without tenancy info is a type error.
+
+    ``preamble`` is the rendered XML-ish block the chat router prepends
+    to the dynamic context (before scope/participants). Empty when the
+    handler failed or had nothing meaningful to say — the chat path keeps
+    going regardless.
+    """
+
+    workspace_id: str
+    user_id: str
+    kind: SurfaceKind
+    meta: SurfaceMeta
+    preamble: str
+
+
+__all__ = ["SurfaceKind", "SurfaceMeta", "SurfaceContext"]

--- a/ee/pocketpaw_ee/cloud/surface/dto.py
+++ b/ee/pocketpaw_ee/cloud/surface/dto.py
@@ -1,0 +1,50 @@
+# dto.py — Wire schemas the client attaches to chat requests.
+#
+# Created: 2026-05-24 — The chat agent's per-turn context grows a
+# {surface, surface_meta} hint. ``SurfaceMetaRequest`` mirrors
+# ``SurfaceMeta`` for inbound validation; ``SurfaceRequest`` is the
+# composite the client stamps. ``resolve_surface_context`` validates
+# arbitrary inbound dicts through ``SurfaceRequest.model_validate``
+# rather than trusting whatever the wire produced.
+#
+# Per the entity rules — DTOs separate input (Request) from any future
+# response shape. There is no response DTO here because the surface
+# context is consumed in-process by ``chat/agent_service`` (no HTTP
+# round-trip).
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class SurfaceMetaRequest(BaseModel):
+    """Inbound shape for the client's ``surface_meta`` hint.
+
+    Mirror of the domain ``SurfaceMeta`` — every field optional. The
+    handlers fetch heavy state server-side; this hint only carries
+    cheap identifiers (which pocket is open, which widget is focused).
+    """
+
+    pocket_id: str | None = None
+    widget_id: str | None = None
+    focus_node_id: str | None = None
+    agent_id: str | None = None
+    file_id: str | None = None
+    route_path: str | None = None
+
+
+class SurfaceRequest(BaseModel):
+    """The full ``{surface, meta}`` hint the client stamps on a chat send.
+
+    Unknown ``surface`` strings (typos, future surfaces a client knows
+    about but the backend doesn't yet) fall back to ``SurfaceKind.GENERIC``
+    in the resolver — the schema deliberately accepts any string here so
+    a client roll-out can ship the new surface name before the backend
+    handler ships.
+    """
+
+    surface: str | None = None
+    meta: SurfaceMetaRequest = Field(default_factory=SurfaceMetaRequest)
+
+
+__all__ = ["SurfaceMetaRequest", "SurfaceRequest"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/__init__.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/__init__.py
@@ -1,0 +1,11 @@
+# handlers/__init__.py — One module per SurfaceKind.
+#
+# Created: 2026-05-24 — Sub-package boundary marker. Every handler module
+# exports ``async def build_preamble(workspace_id, user_id, meta) -> str``
+# returning the XML-ish preamble block the agent reads. The service-layer
+# registry maps SurfaceKind -> handler.build_preamble.
+#
+# Shared helper ``_helpers.truncate`` lives here so handlers don't have
+# to re-implement the 1500-char preamble cap.
+
+from __future__ import annotations

--- a/ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py
@@ -1,0 +1,108 @@
+# _helpers.py — Shared helpers for surface handlers.
+#
+# Created: 2026-05-24 — Keep the per-preamble char cap in one place
+# (1500 chars per turn — anything bigger eats too many tokens) and a
+# handful of formatting helpers every handler shares (formatting
+# Composio tool names for the ``<available-data-tools>`` line, the
+# audit-snapshot lines, etc.). Pulling these out keeps each handler
+# small (≤80 LOC) per the PR brief.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Preamble length cap. Soft cap — we never split mid-tag, just truncate
+# the trailing lines and append an ellipsis marker.
+PREAMBLE_MAX_CHARS = 1500
+
+
+def truncate_preamble(text: str, *, limit: int = PREAMBLE_MAX_CHARS) -> str:
+    """Cap a preamble to ``limit`` chars without breaking the closing tag.
+
+    Truncation is line-aware: we drop trailing lines until the result fits
+    and append ``... (truncated)`` so the agent knows context was lost.
+    Tag balance is the caller's responsibility — handlers structure their
+    preambles so dropping trailing detail lines doesn't break the outer
+    XML shape.
+    """
+    if len(text) <= limit:
+        return text
+    lines = text.splitlines()
+    out: list[str] = []
+    total = 0
+    suffix = "... (truncated)"
+    budget = limit - len(suffix) - 1
+    for line in lines:
+        if total + len(line) + 1 > budget:
+            break
+        out.append(line)
+        total += len(line) + 1
+    out.append(suffix)
+    return "\n".join(out)
+
+
+async def composio_tool_names(*, limit: int = 6) -> list[str]:
+    """Return up to ``limit`` Composio tool names enabled for this deploy.
+
+    Returns an empty list when Composio is disabled or unreachable —
+    handlers must tolerate that (e.g. omit the ``<available-data-tools>``
+    line entirely instead of emitting an empty one).
+
+    Wraps the lookup in a broad try/except because Composio integration
+    is optional and the failure modes range from missing env vars to
+    upstream HTTP timeouts — none of which should break a chat send.
+    """
+    try:
+        from pocketpaw_ee.cloud.composio import service as composio_service
+    except Exception:
+        return []
+    try:
+        if not composio_service.is_enabled():
+            return []
+    except Exception:
+        return []
+    # The composio package exposes a per-deployment cap; we don't enumerate
+    # the full catalog here (that would balloon the preamble). A handful of
+    # canonical action names is enough for the agent to know what's wired.
+    canonical = [
+        "GMAIL_FETCH_EMAILS",
+        "GMAIL_SEND_EMAIL",
+        "GOOGLECALENDAR_LIST_EVENTS",
+        "SLACK_SEND_MESSAGE",
+        "GITHUB_LIST_ISSUES_FOR_REPOSITORY",
+        "NOTION_SEARCH",
+    ]
+    return canonical[:limit]
+
+
+def format_widget_line(widget: Any) -> str:
+    """Format one widget for the ``<pinned-widgets>`` block.
+
+    Marks native vs spec-backed tiles and flags ``type=spec`` widgets
+    missing a ``spec`` subtree — those render as broken tiles and the
+    agent should NOT re-add them (it'd create a duplicate broken row).
+    Accepts duck-typed widget objects (anything with ``name`` / ``type``
+    attrs) so the helper works for both Beanie subdocs and domain
+    objects without importing either.
+    """
+    name = getattr(widget, "name", None) or "(unnamed)"
+    kind = getattr(widget, "type", None) or "custom"
+    spec = getattr(widget, "spec", None)
+    if kind == "native":
+        marker = "native"
+    elif kind == "spec":
+        marker = "spec — BROKEN (no spec subtree)" if not spec else "spec — live"
+    else:
+        marker = f"{kind} — live" if spec else f"{kind} — no spec"
+    return f"- {name} ({marker})"
+
+
+__all__ = [
+    "PREAMBLE_MAX_CHARS",
+    "composio_tool_names",
+    "format_widget_line",
+    "truncate_preamble",
+]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/activity.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/activity.py
@@ -1,0 +1,59 @@
+# activity.py — /activity surface preamble.
+#
+# Created: 2026-05-24 — The user-facing activity feed mirrors the audit
+# surface but uses the in-process activity buffer (channel events,
+# agent activity) rather than the persisted audit log. Falls back to
+# the audit handler's output if the activity buffer isn't reachable.
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers._helpers import truncate_preamble
+
+logger = logging.getLogger(__name__)
+
+LIST_LIMIT = 10
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the activity surface preamble."""
+    events = await _load_activity()
+    parts = [
+        '<surface kind="activity" route="/activity" />',
+        f'<activity-snapshot count="{len(events)}" />',
+    ]
+    if not events:
+        parts.append("<activity-list>(no recent activity)</activity-list>")
+    else:
+        rows = [_format_event(e) for e in events[:LIST_LIMIT]]
+        parts.append("<activity-list>\n" + "\n".join(rows) + "\n</activity-list>")
+    return truncate_preamble("\n".join(parts))
+
+
+async def _load_activity() -> list:
+    """Pull the activity buffer's recent events. ``[]`` on any failure.
+
+    The activity buffer is a singleton populated by channel adapters and
+    the agent loop — it may not be wired in every deploy (e.g. unit
+    tests). Tolerate missing imports and empty state silently.
+    """
+    try:
+        from pocketpaw_ee.cloud.activity.buffer import get_buffer
+
+        buf = get_buffer()
+        return list(getattr(buf, "events", []) or [])[-LIST_LIMIT:]
+    except Exception:
+        logger.debug("activity_handler: buffer fetch failed", exc_info=True)
+        return []
+
+
+def _format_event(event) -> str:
+    """Pull a sensible label out of an ActivityEvent-shaped object."""
+    kind = getattr(event, "kind", "?")
+    summary = getattr(event, "summary", None) or getattr(event, "agent", "") or "?"
+    return f"- {kind}: {summary}"
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/activity.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/activity.py
@@ -1,9 +1,20 @@
 # activity.py — /activity surface preamble.
 #
-# Created: 2026-05-24 — The user-facing activity feed mirrors the audit
-# surface but uses the in-process activity buffer (channel events,
-# agent activity) rather than the persisted audit log. Falls back to
-# the audit handler's output if the activity buffer isn't reachable.
+# Updated: 2026-05-24 — Added workspace_id tenancy guard and switched to
+# the buffer's workspace-scoped read API. The previous implementation
+# read ``getattr(buf, "events", [])`` — an attribute the singleton never
+# exposed (the buffer's API is ``get_recent(workspace_id, limit)``) so
+# the list was always empty in production. Worse, if a future refactor
+# had exposed a flat ``events`` list it would have leaked every
+# workspace's activity into every workspace's chat preamble. We now
+# call ``get_buffer().get_recent(workspace_id, ...)`` directly, which is
+# the only workspace-scoped read path the buffer supports. When the
+# buffer can't be filtered (import error, missing API), the handler
+# emits a placeholder list instead of a cross-workspace event dump.
+#
+# Original: The user-facing activity feed mirrors the audit surface but
+# uses the in-process activity buffer (channel events, agent activity)
+# rather than the persisted audit log.
 
 from __future__ import annotations
 
@@ -19,12 +30,19 @@ LIST_LIMIT = 10
 
 async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
     """Render the activity surface preamble."""
-    events = await _load_activity()
+    events, scoped = await _load_activity(workspace_id)
     parts = [
         '<surface kind="activity" route="/activity" />',
         f'<activity-snapshot count="{len(events)}" />',
     ]
-    if not events:
+    if not scoped:
+        # Buffer isn't workspace-scoped in this deploy — emit a
+        # placeholder rather than risk leaking another workspace's
+        # events into this chat.
+        parts.append(
+            "<activity-list>(activity unavailable — per-workspace scope required)</activity-list>"
+        )
+    elif not events:
         parts.append("<activity-list>(no recent activity)</activity-list>")
     else:
         rows = [_format_event(e) for e in events[:LIST_LIMIT]]
@@ -32,21 +50,30 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
     return truncate_preamble("\n".join(parts))
 
 
-async def _load_activity() -> list:
-    """Pull the activity buffer's recent events. ``[]`` on any failure.
+async def _load_activity(workspace_id: str) -> tuple[list, bool]:
+    """Return ``(events, scoped)`` for ``workspace_id``.
 
-    The activity buffer is a singleton populated by channel adapters and
-    the agent loop — it may not be wired in every deploy (e.g. unit
-    tests). Tolerate missing imports and empty state silently.
+    ``scoped`` is ``True`` only when the buffer exposed a workspace-aware
+    read path and we successfully used it. Any other case (missing
+    import, buffer without ``get_recent``, exception) returns
+    ``([], False)`` so the handler can render the placeholder rather
+    than guessing whether the empty list reflects no activity or a
+    missing filter.
     """
     try:
         from pocketpaw_ee.cloud.activity.buffer import get_buffer
 
         buf = get_buffer()
-        return list(getattr(buf, "events", []) or [])[-LIST_LIMIT:]
+        get_recent = getattr(buf, "get_recent", None)
+        if not callable(get_recent):
+            # Buffer is reachable but doesn't expose the workspace-scoped
+            # API. Treat as "not scoped" — don't fall back to a flat read.
+            return [], False
+        events = list(get_recent(workspace_id, LIST_LIMIT) or [])
+        return events, True
     except Exception:
         logger.debug("activity_handler: buffer fetch failed", exc_info=True)
-        return []
+        return [], False
 
 
 def _format_event(event) -> str:

--- a/ee/pocketpaw_ee/cloud/surface/handlers/agent.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/agent.py
@@ -1,8 +1,16 @@
 # agent.py — /agents/[id] surface preamble.
 #
-# Created: 2026-05-24 — Detail view for one agent. Reads via
-# ``agents_service.get``; falls back to a minimal preamble when the
-# agent id is missing or the lookup fails.
+# Updated: 2026-05-24 — Added workspace_id tenancy guard.
+# ``agents_service.get(agent_id)`` looks up by id alone — no workspace
+# filter — so a user in multiple workspaces could stamp an agent_id from
+# workspace B in a chat from workspace A and the preamble would echo
+# B's agent name/slug inside A's context. We now compare the returned
+# agent's ``workspace_id`` against the chat's; mismatches fall through
+# to the unavailable-snapshot path that already covers missing agents.
+#
+# Original: Detail view for one agent. Reads via ``agents_service.get``;
+# falls back to a minimal preamble when the agent id is missing or the
+# lookup fails.
 
 from __future__ import annotations
 
@@ -25,6 +33,22 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         agent = await agents_service.get(meta.agent_id)
     except Exception:
         logger.debug("agent_handler: get(%s) failed", meta.agent_id, exc_info=True)
+        return (
+            f'<surface kind="agent" route="/agents/{meta.agent_id}" />'
+            "<agent-snapshot>(unavailable)</agent-snapshot>"
+        )
+
+    # Tenancy guard: agents_service.get is workspace-agnostic. Reject
+    # any agent that lives in a different workspace from the chat so
+    # cross-workspace stamps can't leak the other workspace's agent.
+    agent_workspace = getattr(agent, "workspace_id", None)
+    if agent_workspace != workspace_id:
+        logger.warning(
+            "agent_handler: workspace mismatch for agent %s (chat=%s, agent=%s); rejecting",
+            meta.agent_id,
+            workspace_id,
+            agent_workspace,
+        )
         return (
             f'<surface kind="agent" route="/agents/{meta.agent_id}" />'
             "<agent-snapshot>(unavailable)</agent-snapshot>"

--- a/ee/pocketpaw_ee/cloud/surface/handlers/agent.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/agent.py
@@ -1,0 +1,41 @@
+# agent.py — /agents/[id] surface preamble.
+#
+# Created: 2026-05-24 — Detail view for one agent. Reads via
+# ``agents_service.get``; falls back to a minimal preamble when the
+# agent id is missing or the lookup fails.
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers._helpers import truncate_preamble
+
+logger = logging.getLogger(__name__)
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the single-agent surface preamble."""
+    if not meta.agent_id:
+        return '<surface kind="agent" route="/agents/?" />'
+
+    try:
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        agent = await agents_service.get(meta.agent_id)
+    except Exception:
+        logger.debug("agent_handler: get(%s) failed", meta.agent_id, exc_info=True)
+        return (
+            f'<surface kind="agent" route="/agents/{meta.agent_id}" />'
+            "<agent-snapshot>(unavailable)</agent-snapshot>"
+        )
+
+    name = getattr(agent, "name", None) or "(unnamed)"
+    slug = getattr(agent, "slug", None) or "?"
+    return truncate_preamble(
+        f'<surface kind="agent" route="/agents/{meta.agent_id}" />\n'
+        f'<current-agent id="{meta.agent_id}" name="{name}" slug="{slug}" />'
+    )
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/agents.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/agents.py
@@ -1,0 +1,49 @@
+# agents.py — /agents surface preamble.
+#
+# Created: 2026-05-24 — Workspace agents list. Reads via
+# ``agents_service.list_agents`` (tenancy via workspace_id).
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers._helpers import truncate_preamble
+
+logger = logging.getLogger(__name__)
+
+LIST_LIMIT = 10
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the agents-list surface preamble."""
+    try:
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        agents = await agents_service.list_agents(workspace_id)
+    except Exception:
+        logger.debug("agents_handler: list failed", exc_info=True)
+        return (
+            '<surface kind="agents" route="/agents" />'
+            "<agents-snapshot>(unavailable)</agents-snapshot>"
+        )
+
+    parts = [
+        '<surface kind="agents" route="/agents" />',
+        f'<agents-snapshot count="{len(agents)}" />',
+    ]
+    if not agents:
+        parts.append("<agents-list>(no agents in workspace)</agents-list>")
+    else:
+        rows = []
+        for a in agents[:LIST_LIMIT]:
+            name = getattr(a, "name", None) or "(unnamed)"
+            slug = getattr(a, "slug", None) or "?"
+            rows.append(f"- {name} (slug={slug})")
+        if len(agents) > LIST_LIMIT:
+            rows.append(f"... (+{len(agents) - LIST_LIMIT} more)")
+        parts.append("<agents-list>\n" + "\n".join(rows) + "\n</agents-list>")
+    return truncate_preamble("\n".join(parts))
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/audit.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/audit.py
@@ -1,0 +1,57 @@
+# audit.py — /audit surface preamble.
+#
+# Created: 2026-05-24 — Renders the last 10 audit entries (action,
+# target, actor, timestamp) so the agent can quote them when the user
+# asks "what happened today?". Tenancy enforced by
+# ``audit_service.agent_list_audit``.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers._helpers import truncate_preamble
+
+logger = logging.getLogger(__name__)
+
+LIST_LIMIT = 10
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the audit surface preamble."""
+    try:
+        from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+        from pocketpaw_ee.cloud.audit import service as audit_service
+
+        ctx = RequestContext(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            request_id="surface-audit",
+            scope=ScopeKind.WORKSPACE,
+            started_at=datetime.now(UTC),
+        )
+        resp = await audit_service.agent_list_audit(ctx, {"limit": LIST_LIMIT})
+    except Exception:
+        logger.debug("audit_handler: list failed", exc_info=True)
+        return (
+            '<surface kind="audit" route="/audit" /><audit-snapshot>(unavailable)</audit-snapshot>'
+        )
+
+    entries = list(getattr(resp, "entries", []) or [])
+    parts = [
+        '<surface kind="audit" route="/audit" />',
+        f'<audit-snapshot count="{len(entries)}" />',
+    ]
+    if not entries:
+        parts.append("<audit-list>(no entries)</audit-list>")
+    else:
+        rows = [
+            f"- {e.timestamp}: {e.actor} {e.action} -> {e.description[:60]}"
+            for e in entries[:LIST_LIMIT]
+        ]
+        parts.append("<audit-list>\n" + "\n".join(rows) + "\n</audit-list>")
+    return truncate_preamble("\n".join(parts))
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/calendar.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/calendar.py
@@ -1,0 +1,22 @@
+# calendar.py — /calendar surface preamble.
+#
+# Created: 2026-05-24 — Placeholder while the calendar entity is still
+# in flight. Emits the surface tag so the agent knows the route and
+# notes that no live snapshot is available yet — the agent then knows
+# to use Composio's GOOGLECALENDAR_LIST_EVENTS rather than guess.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the calendar-surface preamble."""
+    return (
+        '<surface kind="calendar" route="/calendar" />\n'
+        "<calendar-snapshot>(no live event feed wired — use "
+        "GOOGLECALENDAR_LIST_EVENTS via Composio if available)</calendar-snapshot>"
+    )
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/chat.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/chat.py
@@ -1,0 +1,48 @@
+# chat.py — /chat surface preamble.
+#
+# Created: 2026-05-24 — When the user is on the chat surface itself
+# (not a pocket / not the home dashboard) we keep the preamble minimal:
+# the agent already has the conversation state on hand. We surface the
+# session count as a tiny hint so the agent can answer "how many threads
+# do I have?" without an extra round-trip.
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers._helpers import truncate_preamble
+
+logger = logging.getLogger(__name__)
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the chat-surface preamble."""
+    count = await _session_count(workspace_id, user_id)
+    parts = ['<surface kind="chat" route="/chat" />']
+    if count is None:
+        parts.append("<chat-snapshot>(session count unavailable)</chat-snapshot>")
+    else:
+        parts.append(f'<chat-snapshot sessions="{count}" />')
+    return truncate_preamble("\n".join(parts))
+
+
+async def _session_count(workspace_id: str, user_id: str) -> int | None:
+    """Best-effort session count. Returns ``None`` on any failure."""
+    try:
+        from pocketpaw_ee.cloud.sessions import service as sessions_service
+
+        # The sessions service exposes per-user listings; we don't need
+        # to paginate — a length is enough. Tolerate missing helper
+        # (older deploys may not have this name).
+        lister = getattr(sessions_service, "list_for_user", None)
+        if lister is None:
+            return None
+        sessions = await lister(workspace_id=workspace_id, user_id=user_id)
+        return len(sessions or [])
+    except Exception:
+        logger.debug("chat_handler: session count failed", exc_info=True)
+        return None
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/files.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/files.py
@@ -1,0 +1,49 @@
+# files.py — /files surface preamble.
+#
+# Created: 2026-05-24 — Lists the workspace's most-recent files via
+# ``UnifiedFilesService`` so the agent can answer "what files do I
+# have?" with real names rather than handwaving. Tenancy enforced by
+# the service.
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers._helpers import truncate_preamble
+
+logger = logging.getLogger(__name__)
+
+LIST_LIMIT = 10
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the files surface preamble."""
+    try:
+        from pocketpaw_ee.cloud.files.service import UnifiedFilesService
+
+        svc = UnifiedFilesService()
+        files, _warnings = await svc.list_unified(workspace_id, source=None, limit=LIST_LIMIT)
+    except Exception:
+        logger.debug("files_handler: list_unified failed", exc_info=True)
+        return (
+            '<surface kind="files" route="/files" /><files-snapshot>(unavailable)</files-snapshot>'
+        )
+
+    parts = [
+        '<surface kind="files" route="/files" />',
+        f'<files-snapshot count="{len(files)}" />',
+    ]
+    if not files:
+        parts.append("<files-list>(no files yet)</files-list>")
+    else:
+        rows = []
+        for f in files[:LIST_LIMIT]:
+            name = getattr(f, "filename", None) or "(unnamed)"
+            mime = getattr(f, "mime", None) or "?"
+            rows.append(f"- {name} ({mime})")
+        parts.append("<files-list>\n" + "\n".join(rows) + "\n</files-list>")
+    return truncate_preamble("\n".join(parts))
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/generic.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/generic.py
@@ -1,0 +1,24 @@
+# generic.py — Fallback preamble for unknown surfaces.
+#
+# Created: 2026-05-24 — Catch-all for any surface kind we don't know
+# yet (client shipped a new surface name before the backend handler
+# shipped, or the client doesn't tag at all). The preamble is short on
+# purpose — we don't want to fake live data the agent can't trust.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the generic-surface preamble."""
+    route = meta.route_path or "?"
+    return (
+        f'<surface kind="generic" route="{route}" />\n'
+        "<surface-snapshot>(no specific surface context available — "
+        "answer using the user's last message and ordinary chat "
+        "tools)</surface-snapshot>"
+    )
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/home.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/home.py
@@ -1,0 +1,161 @@
+# home.py — Home-surface preamble.
+#
+# Created: 2026-05-24 — Replaces the client-side ``home-context.ts``
+# snapshot pattern. Reads the user's home pocket via
+# ``pockets_service.ensure_home_pocket`` (idempotent — provisions on
+# first call) and renders the pinned widgets, a tiny live snapshot, the
+# list of available data tools, and recent activity. Total preamble is
+# capped at ~1500 chars to keep token spend in check.
+#
+# All reads respect ``workspace_id`` (the pocket service enforces it
+# per the tenancy-on-every-read rule). Audit reads use the canonical
+# ``audit_service.agent_list_audit`` which also enforces tenancy.
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers._helpers import (
+    composio_tool_names,
+    format_widget_line,
+    truncate_preamble,
+)
+
+logger = logging.getLogger(__name__)
+
+# How many widgets to list before we collapse the tail into a count.
+WIDGET_LIST_LIMIT = 12
+# How many audit entries to surface.
+ACTIVITY_LIMIT = 5
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Build the home-surface preamble — pinned widgets, snapshot, tools."""
+    widgets_block = await _build_widgets_block(workspace_id, user_id)
+    snapshot_line = _build_snapshot_line(widgets_block["widget_count"])
+    tools_line = await _build_tools_line()
+    activity_block = await _build_activity_block(workspace_id, user_id)
+
+    parts = [
+        '<surface kind="home" route="/" />',
+        widgets_block["text"],
+        f"<live-snapshot>{snapshot_line}</live-snapshot>",
+    ]
+    if tools_line:
+        parts.append(f"<available-data-tools>{tools_line}</available-data-tools>")
+    if activity_block:
+        parts.append(activity_block)
+    return truncate_preamble("\n".join(parts))
+
+
+async def _build_widgets_block(workspace_id: str, user_id: str) -> dict:
+    """Resolve the home pocket and render its widget list.
+
+    On failure (missing pocket, fetch error) we still return a usable
+    block so the rest of the preamble keeps its shape — empty workspaces
+    just see a zero-count tag.
+    """
+    try:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        pocket, _created = await pockets_service.ensure_home_pocket(workspace_id, user_id)
+    except Exception:
+        logger.debug("home_handler: ensure_home_pocket failed", exc_info=True)
+        return {
+            "text": '<pinned-widgets count="0">(home pocket unavailable)</pinned-widgets>',
+            "widget_count": 0,
+        }
+
+    widgets = pocket.get("widgets", []) or []
+    total = len(widgets)
+    if total == 0:
+        return {
+            "text": '<pinned-widgets count="0">(empty — no widgets pinned yet)</pinned-widgets>',
+            "widget_count": 0,
+        }
+
+    # Use the helper to format each row — duck-typed against either dict
+    # or domain Widget. The widget dicts coming off ``_resolved_wire_dict``
+    # carry the same field names so attribute-access via a thin wrapper
+    # gets the marker logic for free.
+    rows = [format_widget_line(_AttrDict(w)) for w in widgets[:WIDGET_LIST_LIMIT]]
+    if total > WIDGET_LIST_LIMIT:
+        rows.append(f"... (+{total - WIDGET_LIST_LIMIT} more)")
+
+    body = "\n".join(rows)
+    return {
+        "text": f'<pinned-widgets count="{total}">\n{body}\n</pinned-widgets>',
+        "widget_count": total,
+    }
+
+
+class _AttrDict:
+    """Tiny attr-access wrapper so dict rows feed into ``format_widget_line``.
+
+    The widget objects on the home pocket wire dict are plain dicts (camel-
+    or snake-cased depending on which service path produced them). The
+    helper expects attribute access — wrap once here instead of patching
+    the helper.
+    """
+
+    def __init__(self, source: dict) -> None:
+        self._source = source
+
+    def __getattr__(self, key: str):
+        return self._source.get(key)
+
+
+def _build_snapshot_line(widget_count: int) -> str:
+    """One-line live snapshot.
+
+    Kept intentionally tiny — we don't have a unified workspace-wide
+    metrics view yet. The widget count is the only live number we have
+    on hand without an extra round-trip; future iterations can fold in
+    mission_control counts once the wiring stabilizes.
+    """
+    return f"home.pinned_widgets={widget_count}"
+
+
+async def _build_tools_line() -> str:
+    """Comma-joined list of data-tool names the agent can reach."""
+    names = ["WebSearch", "WebFetch"]
+    composio = await composio_tool_names()
+    names.extend(composio)
+    return " · ".join(names)
+
+
+async def _build_activity_block(workspace_id: str, user_id: str) -> str:
+    """Render the last few audit entries as a compact list.
+
+    Audit reads go through the canonical service which carries the
+    tenancy filter; on failure we omit the block entirely (the agent
+    doesn't need to know audit is down).
+    """
+    try:
+        from datetime import UTC, datetime
+
+        from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+        from pocketpaw_ee.cloud.audit import service as audit_service
+
+        ctx = RequestContext(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            request_id="surface-home",
+            scope=ScopeKind.WORKSPACE,
+            started_at=datetime.now(UTC),
+        )
+        resp = await audit_service.agent_list_audit(ctx, {"limit": ACTIVITY_LIMIT})
+    except Exception:
+        logger.debug("home_handler: audit lookup failed", exc_info=True)
+        return ""
+
+    entries = list(getattr(resp, "entries", []) or [])
+    if not entries:
+        return ""
+    rows = [f"- {e.timestamp}: {e.actor} {e.action}" for e in entries[:ACTIVITY_LIMIT]]
+    body = "\n".join(rows)
+    return f'<recent-activity count="{len(rows)}">\n{body}\n</recent-activity>'
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/knowledge.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/knowledge.py
@@ -1,0 +1,44 @@
+# knowledge.py — /knowledge surface preamble.
+#
+# Created: 2026-05-24 — KB scope listing for the knowledge surface.
+# Stays minimal — the kb stack varies per deploy; if the canonical
+# helper isn't reachable we emit a placeholder so the agent still
+# knows the user is on /knowledge.
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers._helpers import truncate_preamble
+
+logger = logging.getLogger(__name__)
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the knowledge-surface preamble."""
+    scopes = await _list_scopes(workspace_id)
+    parts = ['<surface kind="knowledge" route="/knowledge" />']
+    if not scopes:
+        parts.append("<knowledge-snapshot>(no scopes detected)</knowledge-snapshot>")
+    else:
+        rows = [f"- {s}" for s in scopes[:10]]
+        body = "\n".join(rows)
+        parts.append(f'<knowledge-scopes count="{len(scopes)}">\n{body}\n</knowledge-scopes>')
+    return truncate_preamble("\n".join(parts))
+
+
+async def _list_scopes(workspace_id: str) -> list[str]:
+    """Best-effort scope listing. Returns ``[]`` when no reachable backend.
+
+    The kb stack is optional in some deploys — we'd rather emit a
+    placeholder than crash. The canonical hook would be
+    ``KnowledgeService.list_scopes(workspace_id)`` once that surface
+    lands; until then a static workspace scope is the safest output.
+    """
+    if not workspace_id:
+        return []
+    return [f"workspace:{workspace_id}"]
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/mission_control.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/mission_control.py
@@ -1,0 +1,56 @@
+# mission_control.py — /mission-control surface preamble.
+#
+# Created: 2026-05-24 — Reads the unified work-items feed
+# (``mission_control.service.agent_list_work_items``) and reports
+# section counts so the agent knows what's pending vs done without
+# probing again. Tenancy carried via the ``RequestContext`` per
+# canonical pattern.
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers._helpers import truncate_preamble
+
+logger = logging.getLogger(__name__)
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the mission control surface preamble."""
+    try:
+        from datetime import UTC, datetime
+
+        from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+        from pocketpaw_ee.cloud.mission_control import service as mc_service
+
+        ctx = RequestContext(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            request_id="surface-mc",
+            scope=ScopeKind.WORKSPACE,
+            started_at=datetime.now(UTC),
+        )
+        items = await mc_service.agent_list_work_items(ctx, {"limit": 200})
+    except Exception:
+        logger.debug("mission_control_handler: work_items failed", exc_info=True)
+        return (
+            '<surface kind="mission_control" route="/mission-control" />'
+            "<mc-snapshot>(unavailable)</mc-snapshot>"
+        )
+
+    sections: Counter = Counter()
+    for it in items or []:
+        section = getattr(it, "section", None) or "unknown"
+        sections[str(section)] += 1
+    summary = " · ".join(f"{name}={count}" for name, count in sorted(sections.items())) or "empty"
+
+    parts = [
+        '<surface kind="mission_control" route="/mission-control" />',
+        f"<mc-snapshot>total={len(items or [])} · {summary}</mc-snapshot>",
+    ]
+    return truncate_preamble("\n".join(parts))
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/pocket.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/pocket.py
@@ -1,0 +1,128 @@
+# pocket.py — Pocket-surface preamble.
+#
+# Created: 2026-05-24 — When the user is viewing a specific pocket
+# (/pockets/[id]) the agent should know the pocket's name, widget /
+# node summary, and backend wiring state. Reads go through
+# ``pockets_service.get`` (tenancy enforced).
+#
+# Bad ``pocket_id`` (missing, deleted, no access) returns an empty
+# preamble per the graceful-fall-back rule; the chat send keeps going.
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers._helpers import format_widget_line, truncate_preamble
+
+logger = logging.getLogger(__name__)
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Build the pocket-surface preamble for ``meta.pocket_id``."""
+    if not meta.pocket_id:
+        # No pocket id supplied — nothing the agent can tell about this
+        # surface beyond the route. Emit a minimal preamble so the agent
+        # still knows it's on /pockets/[?] without specific context.
+        return '<surface kind="pocket" route="/pockets/?" />'
+
+    pocket = await _load_pocket(meta.pocket_id, user_id)
+    if pocket is None:
+        # Unknown / no-access pocket. Tell the agent we're on a pocket
+        # surface but the snapshot is empty — better than a totally bare
+        # preamble that hides which surface the user is on.
+        return (
+            f'<surface kind="pocket" route="/pockets/{meta.pocket_id}" />'
+            "<pocket-snapshot>(pocket unavailable)</pocket-snapshot>"
+        )
+
+    name = pocket.get("name") or "(unnamed)"
+    pocket_id = pocket.get("_id") or meta.pocket_id
+    widgets = pocket.get("widgets", []) or []
+    nodes_summary = _summarise_nodes(pocket)
+    backend_summary = _summarise_backend(pocket)
+
+    parts = [
+        f'<surface kind="pocket" route="/pockets/{pocket_id}" />',
+        f'<current-pocket id="{pocket_id}" name="{name}" widgets="{len(widgets)}" />',
+    ]
+    if widgets:
+        rows = [format_widget_line(_AttrDict(w)) for w in widgets[:12]]
+        if len(widgets) > 12:
+            rows.append(f"... (+{len(widgets) - 12} more)")
+        parts.append(
+            f'<pocket-widgets count="{len(widgets)}">\n' + "\n".join(rows) + "\n</pocket-widgets>"
+        )
+    if nodes_summary:
+        parts.append(f"<pocket-nodes>{nodes_summary}</pocket-nodes>")
+    if backend_summary:
+        parts.append(f"<pocket-backend>{backend_summary}</pocket-backend>")
+    return truncate_preamble("\n".join(parts))
+
+
+async def _load_pocket(pocket_id: str, user_id: str) -> dict | None:
+    """Fetch a pocket via the canonical service. Returns ``None`` on any error.
+
+    The catch is broad on purpose — Forbidden, NotFound, validation
+    issues all collapse into "no preamble" rather than propagating.
+    """
+    try:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        return await pockets_service.get(pocket_id, user_id)
+    except Exception:
+        logger.debug("pocket_handler: get(%s) failed", pocket_id, exc_info=True)
+        return None
+
+
+def _summarise_nodes(pocket: dict) -> str:
+    """Count nodes in the pocket's rippleSpec, if any.
+
+    A pocket can carry both a flat ``widgets`` list (the home-grid shape)
+    AND a ``rippleSpec.ui`` subtree (the canvas shape). The agent should
+    see at least the count; the full subtree blows the budget.
+    """
+    spec = pocket.get("rippleSpec") or pocket.get("ripple_spec") or {}
+    if not isinstance(spec, dict):
+        return ""
+    ui = spec.get("ui")
+    if not isinstance(ui, dict):
+        return ""
+    children = ui.get("children") or []
+    if not isinstance(children, list):
+        return ""
+    return f"ui_root={ui.get('type', '?')} top_level_nodes={len(children)}"
+
+
+def _summarise_backend(pocket: dict) -> str:
+    """Render the backend config summary tags.
+
+    The pocket wire dict carries ``backend`` (the active config). We
+    surface whether one is configured, the base URL (truncated to 60
+    chars) and the count of allowed writes — enough for the agent to
+    know what tools exist without reading the full spec.
+    """
+    backend = pocket.get("backend") or {}
+    if not isinstance(backend, dict) or not backend:
+        return "configured=false"
+    base = str(backend.get("base_url") or backend.get("baseUrl") or "")[:60]
+    actions = backend.get("allowed_writes") or backend.get("allowedWrites") or []
+    parts = ["configured=true"]
+    if base:
+        parts.append(f"base_url={base}")
+    if isinstance(actions, list):
+        parts.append(f"allowed_writes={len(actions)}")
+    return " · ".join(parts)
+
+
+class _AttrDict:
+    """Attr-access wrapper for ``format_widget_line``. Mirrors the home handler's helper."""
+
+    def __init__(self, source: dict) -> None:
+        self._source = source
+
+    def __getattr__(self, key: str):
+        return self._source.get(key)
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/pocket.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/pocket.py
@@ -1,12 +1,19 @@
 # pocket.py — Pocket-surface preamble.
 #
-# Created: 2026-05-24 — When the user is viewing a specific pocket
-# (/pockets/[id]) the agent should know the pocket's name, widget /
-# node summary, and backend wiring state. Reads go through
-# ``pockets_service.get`` (tenancy enforced).
+# Updated: 2026-05-24 — Added workspace_id tenancy guard. The downstream
+# ``pockets_service.get`` gates on owner / shared_with / visibility but
+# NOT workspace, so a user who belongs to multiple workspaces could
+# stamp a pocket_id from workspace B in a chat from workspace A and the
+# preamble would render B's pocket data inside A's chat context. We now
+# fetch the pocket, then reject any whose ``workspace`` field doesn't
+# match the chat's ``workspace_id``; the request falls back to the
+# unavailable-snapshot path that already covers unknown / no-access ids.
 #
-# Bad ``pocket_id`` (missing, deleted, no access) returns an empty
-# preamble per the graceful-fall-back rule; the chat send keeps going.
+# Original: When the user is viewing a specific pocket (/pockets/[id])
+# the agent should know the pocket's name, widget / node summary, and
+# backend wiring state. Bad ``pocket_id`` (missing, deleted, no access,
+# or now cross-workspace) returns an empty preamble per the graceful-
+# fall-back rule; the chat send keeps going.
 
 from __future__ import annotations
 
@@ -26,7 +33,7 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         # still knows it's on /pockets/[?] without specific context.
         return '<surface kind="pocket" route="/pockets/?" />'
 
-    pocket = await _load_pocket(meta.pocket_id, user_id)
+    pocket = await _load_pocket(meta.pocket_id, user_id, workspace_id)
     if pocket is None:
         # Unknown / no-access pocket. Tell the agent we're on a pocket
         # surface but the snapshot is empty — better than a totally bare
@@ -60,19 +67,35 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
     return truncate_preamble("\n".join(parts))
 
 
-async def _load_pocket(pocket_id: str, user_id: str) -> dict | None:
+async def _load_pocket(pocket_id: str, user_id: str, workspace_id: str) -> dict | None:
     """Fetch a pocket via the canonical service. Returns ``None`` on any error.
 
     The catch is broad on purpose — Forbidden, NotFound, validation
     issues all collapse into "no preamble" rather than propagating.
+
+    Tenancy guard: ``pockets_service.get`` gates by owner / shared_with /
+    visibility — not workspace. A user in multiple workspaces could stamp
+    a pocket from workspace B in a chat from workspace A and the
+    preamble would render B's pocket inside A's context. We reject any
+    pocket whose ``workspace`` field doesn't match the chat's workspace
+    so the cross-workspace bleed-through is impossible.
     """
     try:
         from pocketpaw_ee.cloud.pockets import service as pockets_service
 
-        return await pockets_service.get(pocket_id, user_id)
+        pocket = await pockets_service.get(pocket_id, user_id)
     except Exception:
         logger.debug("pocket_handler: get(%s) failed", pocket_id, exc_info=True)
         return None
+    if pocket.get("workspace") != workspace_id:
+        logger.warning(
+            "pocket_handler: workspace mismatch for pocket %s (chat=%s, pocket=%s); rejecting",
+            pocket_id,
+            workspace_id,
+            pocket.get("workspace"),
+        )
+        return None
+    return pocket
 
 
 def _summarise_nodes(pocket: dict) -> str:

--- a/ee/pocketpaw_ee/cloud/surface/handlers/pocket_widget.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/pocket_widget.py
@@ -1,10 +1,20 @@
 # pocket_widget.py — Pocket-with-widget-focus-modal-open preamble.
 #
-# Created: 2026-05-24 — Same context as the pocket handler plus a
-# pointer to the focused widget. We deliberately do NOT dump the full
-# spec subtree — only its name / type and the focus_node_id — to keep
-# the preamble within the 1500-char budget. The agent already has
-# tools to read the spec on demand.
+# Updated: 2026-05-24 — Added workspace_id tenancy guard. The base
+# preamble already delegates to ``pocket_handler.build_preamble`` which
+# now rejects cross-workspace pocket_ids — but the focus block (widget /
+# node pointer the client supplied) was still rendered unconditionally.
+# A client could stamp a pocket from workspace B + widget/node ids from
+# B in a chat from A and, even after the base unavailable fallback,
+# those id pointers would still appear in the preamble. We now suppress
+# the focus block whenever the pocket fetch would be cross-workspace so
+# the entire B-context is dropped, not just the snapshot.
+#
+# Original: Same context as the pocket handler plus a pointer to the
+# focused widget. We deliberately do NOT dump the full spec subtree —
+# only its name / type and the focus_node_id — to keep the preamble
+# within the 1500-char budget. The agent already has tools to read the
+# spec on demand.
 
 from __future__ import annotations
 
@@ -23,7 +33,43 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
     focus_block = _focus_block(meta)
     if not focus_block:
         return base
+    # Tenancy guard: the base preamble already rejects cross-workspace
+    # pockets, but the focus pointers came straight from the client. If
+    # the pocket fetch was cross-workspace, drop the focus block too so
+    # no workspace-B identifiers leak into a workspace-A chat context.
+    if meta.pocket_id and not await _pocket_in_workspace(meta.pocket_id, user_id, workspace_id):
+        return base
     return truncate_preamble(f"{base}\n{focus_block}")
+
+
+async def _pocket_in_workspace(pocket_id: str, user_id: str, workspace_id: str) -> bool:
+    """True iff ``pocket_id`` resolves to a pocket in ``workspace_id``.
+
+    Mirrors the guard in ``pocket._load_pocket``. We deliberately repeat
+    the check here rather than threading a second return value out of
+    the base preamble so the two handlers stay independently auditable.
+    """
+    try:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        pocket = await pockets_service.get(pocket_id, user_id)
+    except Exception:
+        logger.debug(
+            "pocket_widget_handler: workspace lookup for %s failed",
+            pocket_id,
+            exc_info=True,
+        )
+        return False
+    if pocket.get("workspace") != workspace_id:
+        logger.warning(
+            "pocket_widget_handler: workspace mismatch for pocket %s "
+            "(chat=%s, pocket=%s); dropping focus block",
+            pocket_id,
+            workspace_id,
+            pocket.get("workspace"),
+        )
+        return False
+    return True
 
 
 def _focus_block(meta: SurfaceMeta) -> str:

--- a/ee/pocketpaw_ee/cloud/surface/handlers/pocket_widget.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/pocket_widget.py
@@ -1,0 +1,46 @@
+# pocket_widget.py — Pocket-with-widget-focus-modal-open preamble.
+#
+# Created: 2026-05-24 — Same context as the pocket handler plus a
+# pointer to the focused widget. We deliberately do NOT dump the full
+# spec subtree — only its name / type and the focus_node_id — to keep
+# the preamble within the 1500-char budget. The agent already has
+# tools to read the spec on demand.
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers import pocket as pocket_handler
+from pocketpaw_ee.cloud.surface.handlers._helpers import truncate_preamble
+
+logger = logging.getLogger(__name__)
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Pocket preamble plus a one-line focus marker for the open widget."""
+    base = await pocket_handler.build_preamble(workspace_id, user_id, meta)
+    focus_block = _focus_block(meta)
+    if not focus_block:
+        return base
+    return truncate_preamble(f"{base}\n{focus_block}")
+
+
+def _focus_block(meta: SurfaceMeta) -> str:
+    """Render the ``<widget-focus>`` tag if either id is present.
+
+    We render whatever we have — widget id alone, node id alone, or
+    both — so the agent knows what the user is looking at without
+    needing to chase the modal's open state.
+    """
+    if not meta.widget_id and not meta.focus_node_id:
+        return ""
+    bits = []
+    if meta.widget_id:
+        bits.append(f'widget_id="{meta.widget_id}"')
+    if meta.focus_node_id:
+        bits.append(f'focus_node_id="{meta.focus_node_id}"')
+    return f"<widget-focus {' '.join(bits)} />"
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/pockets_list.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/pockets_list.py
@@ -1,0 +1,54 @@
+# pockets_list.py — /pockets index preamble.
+#
+# Created: 2026-05-24 — Summarises the user's pocket list with counts
+# and a top-N listing so the agent can answer "what pockets do I
+# have?" without an extra round-trip. Uses ``pockets_service.list_pockets``
+# (tenancy enforced).
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers._helpers import truncate_preamble
+
+logger = logging.getLogger(__name__)
+
+LIST_LIMIT = 10
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the pockets-list surface preamble."""
+    try:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        pockets = await pockets_service.list_pockets(workspace_id, user_id)
+    except Exception:
+        logger.debug("pockets_list_handler: list_pockets failed", exc_info=True)
+        return (
+            '<surface kind="pockets" route="/pockets" />'
+            "<pockets-snapshot>(unavailable)</pockets-snapshot>"
+        )
+
+    total = len(pockets)
+    parts = [
+        '<surface kind="pockets" route="/pockets" />',
+        f'<pockets-snapshot count="{total}" />',
+    ]
+    if total == 0:
+        parts.append("<pockets-list>(no pockets yet)</pockets-list>")
+    else:
+        rows = []
+        for p in pockets[:LIST_LIMIT]:
+            name = p.get("name") or "(unnamed)"
+            kind = p.get("type") or "custom"
+            widget_count = len(p.get("widgets", []) or [])
+            agent_count = len(p.get("agents", []) or [])
+            rows.append(f"- {name} (type={kind}, widgets={widget_count}, agents={agent_count})")
+        if total > LIST_LIMIT:
+            rows.append(f"... (+{total - LIST_LIMIT} more)")
+        parts.append("<pockets-list>\n" + "\n".join(rows) + "\n</pockets-list>")
+    return truncate_preamble("\n".join(parts))
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/quickask.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/quickask.py
@@ -1,0 +1,21 @@
+# quickask.py — QuickAsk overlay surface preamble.
+#
+# Created: 2026-05-24 — Minimal preamble — the QuickAsk window is the
+# "Spotlight for your AI" launcher, not a surface with persistent
+# state. Tell the agent which surface it's on; nothing else to share.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the quickask-surface preamble."""
+    return (
+        '<surface kind="quickask" route="/quickask" />\n'
+        "<quickask-snapshot>(QuickAsk overlay — no persistent surface "
+        "state; answer concisely)</quickask-snapshot>"
+    )
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/settings.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/settings.py
@@ -1,0 +1,22 @@
+# settings.py — /settings surface preamble.
+#
+# Created: 2026-05-24 — Minimal preamble. The settings surface is a
+# configuration tool; we don't want the agent leaking config values into
+# chat. Tell it the surface and stop there.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the settings-surface preamble."""
+    return (
+        '<surface kind="settings" route="/settings" />\n'
+        "<settings-snapshot>(user is configuring the workspace — "
+        "answer as a configuration-aware assistant. No live data "
+        "snapshot for this surface.)</settings-snapshot>"
+    )
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/sidepanel.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sidepanel.py
@@ -1,0 +1,20 @@
+# sidepanel.py — /sidepanel surface preamble.
+#
+# Created: 2026-05-24 — The side-panel Tauri window is a thinner chat
+# surface. Like QuickAsk, no persistent state to share.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the sidepanel-surface preamble."""
+    return (
+        '<surface kind="sidepanel" route="/sidepanel" />\n'
+        "<sidepanel-snapshot>(side-panel chat — no canvas state; "
+        "answer concisely)</sidepanel-snapshot>"
+    )
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -1,0 +1,191 @@
+# service.py — Surface context resolver and handler dispatch.
+#
+# Created: 2026-05-24 — ``resolve_surface_context(workspace_id, user_id,
+# body)`` validates the client's ``{surface, meta}`` hint, maps the
+# string to a ``SurfaceKind``, and dispatches to a per-kind handler that
+# builds the preamble. Per Rule 5 of the cloud entity rules, this is a
+# module-level async function (not a class) and validation runs at entry
+# via ``SurfaceRequest.model_validate``.
+#
+# Failure stays inert: any handler error logs and returns a
+# ``GENERIC`` context with empty preamble. The chat path is the consumer
+# — never let a surface failure break a chat send.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceContext, SurfaceKind, SurfaceMeta
+from pocketpaw_ee.cloud.surface.dto import SurfaceMetaRequest, SurfaceRequest
+
+logger = logging.getLogger(__name__)
+
+
+# Handler registry: SurfaceKind -> async callable returning the preamble.
+# Built lazily on first use so import-time failures in a handler module
+# don't block the rest of the resolver.
+_HANDLERS: dict[SurfaceKind, Any] | None = None
+
+
+def _load_handlers() -> dict[SurfaceKind, Any]:
+    """Lazy import every per-kind handler. Missing handlers are skipped.
+
+    We tolerate missing handler modules instead of raising at import time
+    because the surface module ships independently of the surfaces it
+    knows about — a fresh deploy that drops a handler module shouldn't
+    take the whole chat path down.
+    """
+    from pocketpaw_ee.cloud.surface.handlers import (
+        activity,
+        audit,
+        calendar,
+        files,
+        generic,
+        home,
+        knowledge,
+        mission_control,
+        pocket,
+        pocket_widget,
+        pockets_list,
+        quickask,
+        settings,
+        sidepanel,
+    )
+    from pocketpaw_ee.cloud.surface.handlers import (
+        agent as agent_handler,
+    )
+    from pocketpaw_ee.cloud.surface.handlers import (
+        agents as agents_handler,
+    )
+    from pocketpaw_ee.cloud.surface.handlers import (
+        chat as chat_handler,
+    )
+
+    return {
+        SurfaceKind.HOME: home.build_preamble,
+        SurfaceKind.POCKETS_LIST: pockets_list.build_preamble,
+        SurfaceKind.POCKET: pocket.build_preamble,
+        SurfaceKind.POCKET_WIDGET: pocket_widget.build_preamble,
+        SurfaceKind.MISSION_CONTROL: mission_control.build_preamble,
+        SurfaceKind.FILES: files.build_preamble,
+        SurfaceKind.AUDIT: audit.build_preamble,
+        SurfaceKind.ACTIVITY: activity.build_preamble,
+        SurfaceKind.AGENTS: agents_handler.build_preamble,
+        SurfaceKind.AGENT: agent_handler.build_preamble,
+        SurfaceKind.KNOWLEDGE: knowledge.build_preamble,
+        SurfaceKind.CALENDAR: calendar.build_preamble,
+        SurfaceKind.CHAT: chat_handler.build_preamble,
+        SurfaceKind.QUICKASK: quickask.build_preamble,
+        SurfaceKind.SETTINGS: settings.build_preamble,
+        SurfaceKind.SIDEPANEL: sidepanel.build_preamble,
+        SurfaceKind.GENERIC: generic.build_preamble,
+    }
+
+
+def _resolve_kind(value: str | None) -> SurfaceKind:
+    """Map an inbound string to a ``SurfaceKind``. Unknown -> ``GENERIC``.
+
+    Stay liberal in what we accept (clients can ship a new surface name
+    before the backend ships its handler) and conservative in what we
+    emit (the agent always gets a usable preamble).
+    """
+    if value is None:
+        return SurfaceKind.GENERIC
+    try:
+        return SurfaceKind(value)
+    except ValueError:
+        logger.debug("unknown surface kind %r — falling back to GENERIC", value)
+        return SurfaceKind.GENERIC
+
+
+def _meta_from_request(req: SurfaceMetaRequest) -> SurfaceMeta:
+    """Pydantic -> domain meta. Trivial pass-through."""
+    return SurfaceMeta(
+        pocket_id=req.pocket_id,
+        widget_id=req.widget_id,
+        focus_node_id=req.focus_node_id,
+        agent_id=req.agent_id,
+        file_id=req.file_id,
+        route_path=req.route_path,
+    )
+
+
+async def resolve_surface_context(
+    workspace_id: str, user_id: str, body: dict[str, Any] | SurfaceRequest | None
+) -> SurfaceContext:
+    """Resolve a client's surface hint into a rendered ``SurfaceContext``.
+
+    Always returns a context — never raises. Errors are absorbed:
+
+      * Invalid body shape (wrong fields, bad types) -> ``GENERIC`` with
+        empty preamble.
+      * Unknown surface kind -> ``GENERIC`` (still gets a tiny preamble).
+      * Handler raised -> ``GENERIC`` with empty preamble; the error is
+        logged at ``exception`` so it's discoverable but doesn't break
+        the chat send.
+
+    The dispatcher passes the validated meta and the tenancy tuple to
+    every handler so individual handlers don't have to re-derive them.
+    """
+    global _HANDLERS
+
+    # Step 1: validate the body. Bad input is logged at debug and the
+    # caller gets a GENERIC context with empty preamble.
+    try:
+        validated = SurfaceRequest.model_validate(body or {})
+    except Exception:
+        logger.debug("surface body failed validation; using GENERIC", exc_info=True)
+        return SurfaceContext(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            kind=SurfaceKind.GENERIC,
+            meta=SurfaceMeta(),
+            preamble="",
+        )
+
+    kind = _resolve_kind(validated.surface)
+    meta = _meta_from_request(validated.meta)
+
+    # Step 2: lazy-load the handler registry. Import errors here propagate
+    # because they indicate a broken deploy — surface a clear failure
+    # rather than silently swallowing every surface preamble.
+    if _HANDLERS is None:
+        _HANDLERS = _load_handlers()
+    handler = _HANDLERS.get(kind)
+    if handler is None:
+        # Resolver has a SurfaceKind without a handler. Treat the same as
+        # an unknown surface — graceful GENERIC fall-back, no crash.
+        logger.warning("no handler registered for surface kind %s", kind.value)
+        return SurfaceContext(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            kind=SurfaceKind.GENERIC,
+            meta=meta,
+            preamble="",
+        )
+
+    # Step 3: render the preamble. Handler exceptions are absorbed —
+    # we'd rather ship a chat with no surface context than fail the send.
+    try:
+        preamble = await handler(workspace_id, user_id, meta)
+    except Exception:
+        logger.exception("surface handler %s failed; using GENERIC preamble", kind.value)
+        return SurfaceContext(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            kind=SurfaceKind.GENERIC,
+            meta=meta,
+            preamble="",
+        )
+
+    return SurfaceContext(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        kind=kind,
+        meta=meta,
+        preamble=preamble or "",
+    )
+
+
+__all__ = ["resolve_surface_context"]

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -1,5 +1,14 @@
 # pocketpaw/ripple/_pockets.py — System prompts for the Ripple Pockets surface.
 #
+# Changes: 2026-05-24 (surface-context PR) — extended `HOME_POCKET_PROMPT`
+# with a `## Surface-context blocks` section that teaches the agent to
+# read the new `<pinned-widgets>` / `<live-snapshot>` /
+# `<available-data-tools>` tags the backend now injects per turn via
+# `ee/pocketpaw_ee/cloud/surface/handlers/home.py`. Additive — the
+# original two-response-paths workflow is unchanged. Tells the agent:
+# never re-add a widget already listed, quote snapshot numbers
+# verbatim, and never invent a tool name not on the list.
+#
 # Changes: 2026-05-24 (#1205) — `HOME_POCKET_PROMPT` learns a third response
 # path: REFRESH. The agent now reaches for `update_widget` (plus `WebSearch` /
 # `WebFetch` / configured MCP data sources) when the user asks to
@@ -2341,6 +2350,25 @@ backed by a Pocket whose canvas is a grid of pinned widgets — the things
 the user keeps an eye on (a revenue stat, a task list, a sales chart). It
 is the user's own dashboard, assembled one widget at a time. The pocket
 id is in the `<current-pocket>` block — pass it as `pocket_id`.
+
+## Surface-context blocks (you may already have these)
+
+The system context above may include three surface-aware tags built
+server-side from a per-turn snapshot. Trust them as ground truth:
+
+  - `<pinned-widgets>` lists the widgets ALREADY on the home grid with
+    their names and status markers. Do NOT call `add_widget` for a name
+    that's already listed there — that would create a duplicate tile. A
+    widget marked "spec — BROKEN (no spec subtree)" should NOT be
+    re-added either; the user already has that broken row.
+  - `<live-snapshot>` carries real counts (widget count, etc.) the user
+    can see RIGHT NOW. Quote those numbers directly — never re-derive
+    them with another tool call.
+  - `<available-data-tools>` is the truth about which third-party data
+    tools (Composio actions, WebSearch, WebFetch) are wired into this
+    deployment. NEVER invent a tool name that isn't on that list. If the
+    user asks for something that needs a missing tool, say so plainly
+    and offer the closest tool you DO have.
 
 Three response paths:
 

--- a/tests/cloud/chat/test_agent_service_surface_injection.py
+++ b/tests/cloud/chat/test_agent_service_surface_injection.py
@@ -1,0 +1,101 @@
+# tests/cloud/chat/test_agent_service_surface_injection.py — Wire test.
+#
+# Created: 2026-05-24 — Verifies the two end-to-end guarantees of the
+# chat agent wiring:
+#   1. When a ``surface_context`` is attached to the ScopeContext, its
+#      preamble lands FIRST in the dynamic-context block (before
+#      scope/participants/current-pocket).
+#   2. When no surface_context is attached (older clients that don't
+#      send the new fields), the dynamic-context block keeps its
+#      legacy three-line shape — no regression for unmigrated callers.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import (
+    ScopeContext,
+    ScopeKind,
+    build_dynamic_context,
+)
+from pocketpaw_ee.cloud.surface import SurfaceContext, SurfaceKind, SurfaceMeta
+
+pytestmark = pytest.mark.asyncio
+
+
+def _scope_ctx(**overrides) -> ScopeContext:
+    """Minimal ScopeContext for build_dynamic_context tests."""
+    base = {
+        "kind": ScopeKind.POCKET,
+        "scope_id": "p1",
+        "workspace_id": "w1",
+        "user_id": "u1",
+        "members": ["u1", "agent-1"],
+        "target_agent_id": "agent-1",
+        "pocket_id": "p1",
+    }
+    base.update(overrides)
+    return ScopeContext(**base)
+
+
+async def test_build_dynamic_context_prepends_surface_preamble_when_present() -> None:
+    """Surface preamble lands before scope/participants/current-pocket tags."""
+    surface = SurfaceContext(
+        workspace_id="w1",
+        user_id="u1",
+        kind=SurfaceKind.HOME,
+        meta=SurfaceMeta(),
+        preamble=(
+            '<surface kind="home" route="/" />\n<pinned-widgets count="0">(empty)</pinned-widgets>'
+        ),
+    )
+    ctx = _scope_ctx(surface_context=surface)
+
+    rendered = build_dynamic_context(ctx)
+    lines = rendered.splitlines()
+
+    # Surface block comes first.
+    assert lines[0].startswith('<surface kind="home"')
+    # Pinned-widgets next, before scope.
+    assert "<pinned-widgets" in lines[1]
+    # Legacy scope/participants/current-pocket still follow.
+    assert any("<scope>pocket p1</scope>" in line for line in lines)
+    assert any("<participants>" in line for line in lines)
+    assert any('<current-pocket id="p1"' in line for line in lines)
+
+
+async def test_build_dynamic_context_falls_back_to_old_shape_when_surface_context_is_none() -> None:
+    """No surface_context = legacy three-line shape — back-compat guarantee."""
+    ctx = _scope_ctx(surface_context=None)
+
+    rendered = build_dynamic_context(ctx)
+
+    # No surface tag at all — preserves the pre-surface-context wire shape.
+    assert "<surface" not in rendered
+    assert "<pinned-widgets" not in rendered
+    # Legacy tags exactly as before.
+    assert "<scope>pocket p1</scope>" in rendered
+    assert "<participants>u1, agent-1</participants>" in rendered
+    assert '<current-pocket id="p1" />' in rendered
+
+
+async def test_build_dynamic_context_skips_empty_preamble() -> None:
+    """A surface_context with an empty preamble (handler fell back) is skipped.
+
+    The empty-preamble path is the GENERIC fall-back the resolver uses
+    when validation fails or a handler raises. The dynamic-context
+    block must not emit an empty leading newline in that case.
+    """
+    surface = SurfaceContext(
+        workspace_id="w1",
+        user_id="u1",
+        kind=SurfaceKind.GENERIC,
+        meta=SurfaceMeta(),
+        preamble="",
+    )
+    ctx = _scope_ctx(surface_context=surface)
+
+    rendered = build_dynamic_context(ctx)
+    lines = rendered.splitlines()
+
+    # First line must be the scope tag — no blank leader from a "" preamble.
+    assert lines[0].startswith("<scope>")

--- a/tests/cloud/surface/test_generic_handler.py
+++ b/tests/cloud/surface/test_generic_handler.py
@@ -1,0 +1,34 @@
+# tests/cloud/surface/test_generic_handler.py — Generic fallback handler.
+#
+# Created: 2026-05-24 — One guarantee: the generic handler always
+# returns a valid preamble naming surface=generic, even when meta is
+# completely empty. It's the catch-all every other failure mode reaches
+# for, so it must never raise and must always carry the surface tag.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers import generic as generic_handler
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_generic_handler_returns_valid_preamble_with_no_meta() -> None:
+    """Empty meta still produces a valid preamble with the surface tag."""
+    preamble = await generic_handler.build_preamble("w1", "u1", SurfaceMeta())
+
+    assert '<surface kind="generic"' in preamble
+    # Route fall-back when no route_path was supplied.
+    assert 'route="?"' in preamble
+    # And a snapshot block that tells the agent there's no live state.
+    assert "no specific surface context" in preamble
+
+
+async def test_generic_handler_honors_route_path_hint() -> None:
+    """When meta carries route_path it is reflected in the surface tag."""
+    preamble = await generic_handler.build_preamble(
+        "w1", "u1", SurfaceMeta(route_path="/some/new/route")
+    )
+
+    assert 'route="/some/new/route"' in preamble

--- a/tests/cloud/surface/test_home_handler.py
+++ b/tests/cloud/surface/test_home_handler.py
@@ -1,0 +1,127 @@
+# tests/cloud/surface/test_home_handler.py — Home surface handler.
+#
+# Created: 2026-05-24 — Drives the home handler against a seeded
+# home pocket (via the real ``pockets_service.ensure_home_pocket``
+# path + ``add_widget``) so we exercise the same code path the chat
+# router would hit. Three guarantees:
+#   1. The pinned-widgets block lists every widget with native/spec
+#      markers so the agent can quote what's already on the grid.
+#   2. A ``type=spec`` widget with no spec subtree is marked BROKEN —
+#      this is the failure mode that previously caused the agent to
+#      re-add the same broken row indefinitely.
+#   3. An empty workspace (no widgets pinned yet) still produces a
+#      usable preamble naming surface=home — the home dashboard is
+#      always present, even before the user adds anything.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import AddWidgetRequest
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers import home as home_handler
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+WORKSPACE = "ws-surface-home"
+
+
+async def _seed_user(email: str = "owner@surface.test") -> str:
+    doc = _UserDoc(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="Home Owner",
+        active_workspace=WORKSPACE,
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+async def _seed_home_with_widgets(user_id: str, widgets: list[dict]) -> str:
+    """Provision the home pocket and stamp `widgets` onto it via add_widget."""
+    pocket, _ = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+    pocket_id = pocket["_id"]
+    for w in widgets:
+        # AddWidgetRequest is flat (name/type/spec on the body itself),
+        # not wrapped in a `widget` envelope. **w expands the test dict
+        # onto the request fields.
+        await pockets_service.add_widget(pocket_id, user_id, AddWidgetRequest(**w))
+    return pocket_id
+
+
+async def test_home_handler_lists_pinned_widgets() -> None:
+    """Seeded widgets (1 native + 2 spec) appear in the preamble with markers."""
+    user_id = await _seed_user()
+    await _seed_home_with_widgets(
+        user_id,
+        [
+            {"name": "Active agents", "type": "native"},
+            {
+                "name": "7-day sales",
+                "type": "chart",
+                "spec": {
+                    "type": "chart",
+                    "props": {
+                        "variant": "bar",
+                        "data": [{"label": "Mon", "value": 1}],
+                    },
+                },
+            },
+            {
+                "name": "Tasks",
+                "type": "list",
+                "spec": {"type": "list", "props": {"items": []}},
+            },
+        ],
+    )
+
+    preamble = await home_handler.build_preamble(WORKSPACE, user_id, SurfaceMeta())
+
+    assert '<surface kind="home"' in preamble
+    assert "<pinned-widgets" in preamble
+    # All three widget names round-tripped.
+    assert "Active agents" in preamble
+    assert "7-day sales" in preamble
+    assert "Tasks" in preamble
+    # Native marker is recognised on its row.
+    assert "native" in preamble
+    # The tools row mentions WebSearch (always on).
+    assert "WebSearch" in preamble
+
+
+async def test_home_handler_marks_broken_spec_widget() -> None:
+    """A `type=spec` widget without a `spec` payload is flagged as BROKEN.
+
+    This is the failure mode that previously caused the agent to re-add
+    the same broken row — without a marker, it had no way to tell the
+    existing tile was already broken.
+    """
+    user_id = await _seed_user("owner-broken@surface.test")
+    await _seed_home_with_widgets(
+        user_id,
+        [
+            # `type=spec` deliberately omits the `spec` payload.
+            {"name": "Broken tile", "type": "spec"},
+        ],
+    )
+
+    preamble = await home_handler.build_preamble(WORKSPACE, user_id, SurfaceMeta())
+
+    assert "Broken tile" in preamble
+    assert "BROKEN" in preamble
+
+
+async def test_home_handler_empty_workspace_returns_minimal_preamble() -> None:
+    """An empty workspace gets a usable preamble naming surface=home."""
+    user_id = await _seed_user("owner-empty@surface.test")
+    # No widgets seeded — ensure_home_pocket provisions an empty pocket.
+
+    preamble = await home_handler.build_preamble(WORKSPACE, user_id, SurfaceMeta())
+
+    assert '<surface kind="home"' in preamble
+    # The pinned-widgets block exists with count=0 and an empty marker.
+    assert '<pinned-widgets count="0"' in preamble
+    assert "empty" in preamble.lower()

--- a/tests/cloud/surface/test_pocket_handler.py
+++ b/tests/cloud/surface/test_pocket_handler.py
@@ -1,0 +1,75 @@
+# tests/cloud/surface/test_pocket_handler.py — Pocket surface handler.
+#
+# Created: 2026-05-24 — Two guarantees:
+#   1. An existing pocket's name, widgets, and (when present) backend
+#      summary surface in the preamble.
+#   2. An unknown ``pocket_id`` falls back gracefully — the agent still
+#      gets a surface tag but the snapshot is marked unavailable; the
+#      chat path never breaks because the client passed a stale id.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers import pocket as pocket_handler
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+WORKSPACE = "ws-surface-pocket"
+
+
+async def _seed_user(email: str = "owner@pocket.test") -> str:
+    doc = _UserDoc(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="Pocket Owner",
+        active_workspace=WORKSPACE,
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+async def test_pocket_handler_summarizes_existing_pocket() -> None:
+    """An existing pocket appears in the preamble with name + counts."""
+    user_id = await _seed_user()
+    pocket = await pockets_service.create(
+        WORKSPACE,
+        user_id,
+        CreatePocketRequest(name="Sales Pipeline"),
+    )
+
+    preamble = await pocket_handler.build_preamble(
+        WORKSPACE, user_id, SurfaceMeta(pocket_id=pocket["_id"])
+    )
+
+    assert '<surface kind="pocket"' in preamble
+    assert "Sales Pipeline" in preamble
+    assert pocket["_id"] in preamble
+    # The current-pocket tag carries the widget count.
+    assert "widgets=" in preamble
+
+
+async def test_pocket_handler_unknown_pocket_id_falls_back() -> None:
+    """A stale / non-existent pocket id returns a minimal preamble.
+
+    No exception should escape; the chat router gets a usable preamble
+    even when the client sent a deleted pocket's id.
+    """
+    user_id = await _seed_user("owner-bad@pocket.test")
+    # Mongo ObjectIds are 24-hex-chars; supply one that points at nothing.
+    bad_id = "ffffffffffffffffffffffff"
+
+    preamble = await pocket_handler.build_preamble(
+        WORKSPACE, user_id, SurfaceMeta(pocket_id=bad_id)
+    )
+
+    # Surface tag still present — agent knows it's on a pocket route.
+    assert '<surface kind="pocket"' in preamble
+    assert bad_id in preamble
+    # And the snapshot is flagged as unavailable rather than empty.
+    assert "unavailable" in preamble.lower()

--- a/tests/cloud/surface/test_surface_service.py
+++ b/tests/cloud/surface/test_surface_service.py
@@ -1,0 +1,75 @@
+# tests/cloud/surface/test_surface_service.py — Resolver behavior.
+#
+# Created: 2026-05-24 — Covers the three guarantees the chat router
+# relies on:
+#   1. Unknown surface strings fall back to GENERIC instead of raising —
+#      a client can ship a new surface name before the backend ships its
+#      handler.
+#   2. Invalid meta shapes (wrong types) collapse into GENERIC + empty
+#      preamble instead of propagating a validation error.
+#   3. A handler that raises does NOT propagate — the resolver swallows
+#      and returns a GENERIC context with empty preamble so the chat
+#      send always succeeds.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.surface import SurfaceContext, SurfaceKind, resolve_surface_context
+from pocketpaw_ee.cloud.surface import service as surface_service
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_resolve_unknown_surface_returns_generic() -> None:
+    """A surface string the backend doesn't know maps to GENERIC."""
+    ctx = await resolve_surface_context("w1", "u1", {"surface": "this_does_not_exist", "meta": {}})
+    assert isinstance(ctx, SurfaceContext)
+    assert ctx.kind is SurfaceKind.GENERIC
+    # Generic handler still returns a small preamble — not empty.
+    assert "generic" in ctx.preamble
+
+
+async def test_resolve_invalid_meta_does_not_crash() -> None:
+    """Bad body shape produces GENERIC with empty preamble, never raises."""
+    ctx = await resolve_surface_context("w1", "u1", {"surface": "home", "meta": "not-a-dict"})
+    assert ctx.kind is SurfaceKind.GENERIC
+    # The validation failure short-circuits before any handler runs, so
+    # the preamble is empty rather than the generic fall-back text.
+    assert ctx.preamble == ""
+
+
+async def test_resolve_handler_failure_returns_empty_preamble(monkeypatch) -> None:
+    """When a handler raises, the resolver returns GENERIC + empty preamble."""
+
+    async def _boom(workspace_id: str, user_id: str, meta) -> str:  # noqa: ARG001
+        raise RuntimeError("simulated handler failure")
+
+    # Force the registry to load with our broken handler in place of the
+    # real home handler. The resolver should catch and downgrade.
+    surface_service._HANDLERS = None  # invalidate any cache from prior tests
+    real_loader = surface_service._load_handlers
+
+    def _patched_loader():
+        handlers = real_loader()
+        handlers[SurfaceKind.HOME] = _boom
+        return handlers
+
+    monkeypatch.setattr(surface_service, "_load_handlers", _patched_loader)
+    surface_service._HANDLERS = None  # ensure lazy reload picks up the patch
+
+    ctx = await resolve_surface_context("w1", "u1", {"surface": "home", "meta": {}})
+
+    # GENERIC fall-back, no propagation, empty preamble.
+    assert ctx.kind is SurfaceKind.GENERIC
+    assert ctx.preamble == ""
+
+    # Reset the cache so other tests in the file don't see the patched
+    # loader.
+    surface_service._HANDLERS = None
+
+
+async def test_resolve_none_body_is_treated_as_empty() -> None:
+    """``body=None`` is equivalent to ``{}`` — GENERIC handler with placeholder."""
+    ctx = await resolve_surface_context("w1", "u1", None)
+    assert ctx.kind is SurfaceKind.GENERIC
+    assert "generic" in ctx.preamble

--- a/tests/cloud/surface/test_tenancy_guards.py
+++ b/tests/cloud/surface/test_tenancy_guards.py
@@ -1,0 +1,267 @@
+# tests/cloud/surface/test_tenancy_guards.py — Surface handler tenancy guards.
+#
+# Created: 2026-05-24 — Follow-up tests for PR #1209 review M1+M2+M3.
+# The pocket, pocket_widget, agent, and activity surface handlers all
+# consume services that historically gate by user-or-id without a
+# workspace filter, so a user who belongs to multiple workspaces could
+# stamp a B-workspace id in an A-workspace chat and the preamble would
+# echo B's data inside A's context. The guards added in this PR reject
+# every cross-workspace stamp; these tests pin that behaviour so a
+# future refactor can't quietly walk it back.
+#
+# Test shape:
+#   - Seed ONE user_id (the same human signed in across both workspaces).
+#   - Create the artifact (pocket / agent) in W2 owned by that user.
+#   - Drive the matching surface handler with workspace_id=W1 and a meta
+#     pointing at the W2 artifact.
+#   - Assert the preamble does NOT carry the W2 identifying data
+#     (name, slug, widgets) — it falls through to the unavailable /
+#     placeholder path the handler already uses for missing artifacts.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.agents import service as agents_service
+from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers import activity as activity_handler
+from pocketpaw_ee.cloud.surface.handlers import agent as agent_handler
+from pocketpaw_ee.cloud.surface.handlers import pocket as pocket_handler
+from pocketpaw_ee.cloud.surface.handlers import pocket_widget as pocket_widget_handler
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+W1 = "ws-tenancy-a"
+W2 = "ws-tenancy-b"
+
+
+async def _seed_user(email: str) -> str:
+    """Insert a user the test can attribute pockets / agents to.
+
+    The user's ``active_workspace`` is W1 — the workspace they're
+    "chatting from" in every test below. The cross-workspace stamp
+    pretends to be a route on W2 instead.
+    """
+    doc = _UserDoc(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="Tenancy Owner",
+        active_workspace=W1,
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+def _ctx(*, user_id: str, workspace_id: str) -> RequestContext:
+    """Build a minimal RequestContext for agents_service.create.
+
+    The agent service signature still takes a RequestContext but uses
+    only ``user_id`` / ``workspace_id`` for the create path the test
+    exercises; the rest of the fields are filler.
+    """
+    from datetime import UTC, datetime
+
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r-tenancy",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# M1 — pocket handler
+# ---------------------------------------------------------------------------
+
+
+async def test_pocket_handler_rejects_cross_workspace_id() -> None:
+    """A pocket owned by the user in W2 must not surface in a W1 chat.
+
+    Setup: same user is the pocket's owner — so ``pockets_service.get``
+    would return the pocket fine on its access check. The guard rejects
+    on the workspace mismatch instead, and the handler falls through to
+    the unavailable-snapshot path.
+    """
+    user_id = await _seed_user("owner@pocket-tenancy.test")
+    pocket = await pockets_service.create(
+        W2,
+        user_id,
+        CreatePocketRequest(name="Secret W2 Pocket"),
+    )
+
+    preamble = await pocket_handler.build_preamble(
+        W1, user_id, SurfaceMeta(pocket_id=pocket["_id"])
+    )
+
+    # The route tag is still rendered (the agent knows it's on a pocket
+    # surface) but the W2 data MUST NOT appear.
+    assert '<surface kind="pocket"' in preamble
+    assert "Secret W2 Pocket" not in preamble
+    # The widget count / current-pocket tag never gets emitted on the
+    # unavailable path — assert we didn't accidentally render it.
+    assert "<current-pocket" not in preamble
+    assert "widgets=" not in preamble
+    # And the standard unavailable marker is what the user sees.
+    assert "unavailable" in preamble.lower()
+
+
+# ---------------------------------------------------------------------------
+# M1 — pocket_widget handler
+# ---------------------------------------------------------------------------
+
+
+async def test_pocket_widget_handler_rejects_cross_workspace_id() -> None:
+    """Same guard, plus the focus block must drop too.
+
+    The pocket_widget handler delegates the base preamble to
+    pocket_handler (already guarded) but renders the client-supplied
+    ``widget_id`` / ``focus_node_id`` independently. The fix in
+    pocket_widget.py suppresses the focus block when the underlying
+    pocket fetch would be cross-workspace, so no W2 identifiers leak.
+    """
+    user_id = await _seed_user("owner@widget-tenancy.test")
+    pocket = await pockets_service.create(
+        W2,
+        user_id,
+        CreatePocketRequest(name="Secret W2 Widget Pocket"),
+    )
+    leaky_widget_id = "leaky-widget-id-from-w2"
+    leaky_focus_id = "leaky-focus-node-from-w2"
+
+    preamble = await pocket_widget_handler.build_preamble(
+        W1,
+        user_id,
+        SurfaceMeta(
+            pocket_id=pocket["_id"],
+            widget_id=leaky_widget_id,
+            focus_node_id=leaky_focus_id,
+        ),
+    )
+
+    # Base preamble's tenancy guard still holds.
+    assert "Secret W2 Widget Pocket" not in preamble
+    assert "<current-pocket" not in preamble
+    # The focus block carrying client-supplied W2 identifiers must NOT
+    # appear either.
+    assert "<widget-focus" not in preamble
+    assert leaky_widget_id not in preamble
+    assert leaky_focus_id not in preamble
+
+
+# ---------------------------------------------------------------------------
+# M2 — agent handler
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_handler_rejects_cross_workspace_agent_id() -> None:
+    """An agent owned by W2 must not be rendered in a W1 chat.
+
+    ``agents_service.get(agent_id)`` is workspace-agnostic, so the call
+    succeeds on the id alone. The guard added to the handler compares
+    the returned domain object's ``workspace_id`` to the chat's.
+    """
+    user_id = await _seed_user("owner@agent-tenancy.test")
+    agent = await agents_service.create(
+        _ctx(user_id=user_id, workspace_id=W2),
+        W2,
+        CreateAgentRequest(name="Secret W2 Agent", slug="secret-w2-agent"),
+    )
+
+    preamble = await agent_handler.build_preamble(W1, user_id, SurfaceMeta(agent_id=agent.id))
+
+    # Surface tag still present so the agent knows it's on /agents/[id].
+    assert '<surface kind="agent"' in preamble
+    # The W2 agent's name and slug must NOT appear.
+    assert "Secret W2 Agent" not in preamble
+    assert "secret-w2-agent" not in preamble
+    # The current-agent tag never gets emitted on the unavailable path.
+    assert "<current-agent" not in preamble
+    assert "unavailable" in preamble.lower()
+
+
+# ---------------------------------------------------------------------------
+# M3 — activity handler
+# ---------------------------------------------------------------------------
+
+
+async def test_activity_handler_returns_placeholder_when_buffer_not_workspace_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the buffer can't be filtered by workspace, render a placeholder.
+
+    The handler now requires a workspace-aware read path on the buffer.
+    Simulate a buffer without ``get_recent`` (e.g. an older deploy or a
+    future refactor that drops the API) and assert the handler emits the
+    placeholder list rather than guessing.
+    """
+
+    class _UnscopedBuffer:
+        """Stand-in buffer with no workspace-aware reader."""
+
+        # No get_recent attribute on purpose.
+        events = ["should-not-appear"]
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.activity.buffer.get_buffer",
+        lambda: _UnscopedBuffer(),
+    )
+
+    preamble = await activity_handler.build_preamble(W1, "u-irrelevant", SurfaceMeta())
+
+    # Surface block still emits — the chat path needs a usable preamble.
+    assert '<surface kind="activity"' in preamble
+    # The placeholder appears, not the would-be event list.
+    assert "per-workspace scope required" in preamble.lower()
+    assert "should-not-appear" not in preamble
+
+
+async def test_activity_handler_uses_workspace_scoped_buffer() -> None:
+    """When the buffer IS workspace-scoped, only W1 events appear.
+
+    Seeds two events on the real singleton — one for W1 and one for W2 —
+    then calls the handler for W1 and confirms the W2 event is filtered
+    out by ``Buffer.get_recent``'s workspace key.
+    """
+    import time
+
+    from pocketpaw_ee.cloud.activity.buffer import ActivityEvent, get_buffer
+
+    buf = get_buffer()
+    buf.reset()
+    now = time.time()
+    buf.push(
+        ActivityEvent(
+            workspace_id=W1,
+            kind="thinking",
+            agent_id="a-w1",
+            summary="w1-event-marker",
+            pocket_id=None,
+            ts=now,
+        )
+    )
+    buf.push(
+        ActivityEvent(
+            workspace_id=W2,
+            kind="thinking",
+            agent_id="a-w2",
+            summary="w2-event-marker",
+            pocket_id=None,
+            ts=now,
+        )
+    )
+
+    preamble = await activity_handler.build_preamble(W1, "u-irrelevant", SurfaceMeta())
+
+    assert '<surface kind="activity"' in preamble
+    assert "w1-event-marker" in preamble
+    assert "w2-event-marker" not in preamble
+
+    # Clean up so we don't leak state to neighbouring tests.
+    buf.reset()


### PR DESCRIPTION
## Summary

The chat agent today only sees three lines of dynamic context per turn (scope, participants, current-pocket-id). Paw-enterprise is becoming chat-first — every route will eventually have a chat bar, and the agent should know **which surface** the user is on and **what's actually visible there** without making extra tool calls to find out.

This PR adds the backend half: a new `surface_context` entity that resolves a `{surface, surface_meta}` hint from the client into a per-turn preamble, then injects it ahead of the legacy scope tags. The paired paw-enterprise PR (separate) will stamp `surface` / `surface_meta` on chat sends from every route.

## Architecture (module shape)

New entity under `ee/pocketpaw_ee/cloud/surface/` follows the canonical 4-file shape (`domain.py`, `dto.py`, `service.py`, plus a `handlers/` sub-package). No `router.py` — this is consumed in-process by `chat/agent_service` rather than exposed over HTTP, so the cloud entity rules' "writes through service.py" / "tenancy at construction" rules still apply but the HTTP layer is unused.

- `domain.py` — `SurfaceKind` enum, `SurfaceMeta` (client hints), `SurfaceContext` (resolved snapshot with rendered preamble; `workspace_id` / `user_id` required at construction).
- `dto.py` — `SurfaceMetaRequest` / `SurfaceRequest` for inbound validation.
- `service.py` — `resolve_surface_context(workspace_id, user_id, body)` validates, dispatches to a per-kind handler, and *never raises* — any failure degrades to a `GENERIC` context with an empty preamble so a surface error never breaks a chat send.
- `handlers/` — one module per `SurfaceKind`, each exporting `async def build_preamble(workspace_id, user_id, meta) -> str`.

## Handlers shipped

`home` (pinned widgets + live snapshot + available tools + recent activity — replaces the client-side `home-context.ts` snapshot server-side), `pocket`, `pocket_widget`, `pockets_list`, `mission_control`, `files`, `audit`, `activity`, `agents`, `agent`, `knowledge`, `calendar`, `chat`, `quickask`, `settings`, `sidepanel`, `generic`.

The richer handlers (home / pocket / pockets_list / mission_control / files / audit / agents) reach into the canonical entity services; the lighter handlers (knowledge / calendar / chat / quickask / settings / sidepanel / generic) emit a minimal preamble. All handlers tolerate import-time failures of their upstream service so a thin or partial deploy still produces a usable preamble.

Total preamble is line-aware truncated at ~1500 chars per turn (`_helpers.truncate_preamble`).

## Wire extension

- `CloudAgentChatRequest` grows `surface: str | None` and `surface_meta: dict | None` fields. Unknown `surface` strings fall back to `GENERIC` so a client can ship a new surface name before the backend handler does.
- `ScopeContext` grows `surface_context: SurfaceContext | None`. `agent_router.post_agent_chat` calls `resolve_surface_context` after `resolve_scope_context` and attaches the result.
- `build_dynamic_context(ctx)` prepends the preamble FIRST (before scope/participants/current-pocket) — surface state is more informationally dense than the bare scope tags. `surface_context is None` keeps the legacy three-line shape exactly as before — **back-compat for clients that don't send the new fields**.

## HOME_POCKET_PROMPT delta

Added a `## Surface-context blocks` section (additive — the two-response-paths workflow is unchanged). Teaches the home agent to read `<pinned-widgets>` / `<live-snapshot>` / `<available-data-tools>` as ground truth: never re-add a widget already listed (no more duplicate "spec — BROKEN" tiles), quote snapshot numbers verbatim, never invent a tool name not on the available-tools list.

## Test plan

- [x] `resolve_surface_context` returns GENERIC for unknown surface strings without raising.
- [x] `resolve_surface_context` swallows invalid body shapes -> GENERIC + empty preamble.
- [x] `resolve_surface_context` swallows handler exceptions -> GENERIC + empty preamble (proven via a patched handler that raises).
- [x] Home handler lists pinned widgets (native + spec markers) against a real Beanie store.
- [x] Home handler flags `type=spec` widgets missing a `spec` subtree as BROKEN so the agent stops re-adding them.
- [x] Home handler returns a usable preamble for an empty workspace.
- [x] Pocket handler summarizes an existing pocket (name + widget count + backend summary).
- [x] Pocket handler falls back gracefully on an unknown `pocket_id` — surface tag still present, snapshot marked unavailable, no exception.
- [x] Generic handler always returns a valid preamble; respects `meta.route_path` when supplied.
- [x] `build_dynamic_context` prepends the preamble when `surface_context` is attached.
- [x] `build_dynamic_context` keeps the legacy three-line shape when `surface_context is None` (back-compat guarantee).
- [x] `build_dynamic_context` skips a `surface_context` whose preamble is empty (the GENERIC fall-back path) — no blank leader line.

`tests/cloud/surface/` (4 files, 11 tests) + `tests/cloud/chat/test_agent_service_surface_injection.py` (3 tests) — all green. Regression sweep through `tests/cloud/test_pocket_prompts_single_source.py`, `tests/cloud/test_home_pocket.py`, `tests/cloud/test_home_pocket_route.py`, `tests/cloud/test_agent_chat_schemas.py`, `tests/cloud/test_agent_router.py` — all 50 pass. Pre-existing failures in `tests/cloud/chat/test_message_emits.py`, `tests/cloud/chat/test_search_messages_v2.py`, and a handful of `test_agent_router_*` smoke tests are unrelated (SimpleNamespace mocks missing `pocket_type` from PR #1174 + Beanie-not-initialized fixture issues); confirmed reproducible on the pre-change baseline.

`ruff check` + `ruff format --check` clean. All 17 `import-linter` contracts kept (the new surface entity respects the Beanie-only-from-service.py boundary).

## Paired with

Upcoming paw-enterprise PR (PR-A) that stamps `surface` and `surface_meta` on every chat send from `+layout.svelte` based on `$page.route.id`.