### PR TITLE
fix(audit): mirror AuditLogger writes into AuditStore so GET /audit returns rows

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,12 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-05-24 (#1202) — Registers ``register_audit_bridge`` during
+    ``mount_cloud`` so every ``security.audit.AuditLogger.log()`` call from
+    EE cloud writers (pocket actions, source runs, skills config, …) is
+    mirrored into ``pocketpaw.audit.store.AuditStore`` — the SQLite sink
+    the ``GET /api/v1/audit`` reader actually queries. Without this the
+    JSONL and SQLite sinks lived in parallel and the GET surface always
+    returned 0 rows even when ``~/.pocketpaw/audit.jsonl`` was full.
 Updated: 2026-05-22 (feat/api-skills, Increment 2b) — mounts the Skills
     entity at ``/api/v1/skills`` (POST /skills/api-doc), the per-backend
     API-skill install endpoint that turns a pocket backend's OpenAPI
@@ -443,6 +450,18 @@ def mount_cloud(app: FastAPI) -> None:
     # first service that calls ``emit(...)`` fails with "EventBus not
     # initialized".
     init_realtime()
+
+    # Bridge ``AuditLogger`` (JSONL) writes into ``AuditStore`` (SQLite).
+    # Cloud writers across the EE codebase (pockets/action_executor,
+    # pockets/source_executor, pockets/service, skills/service,
+    # agent/pocket_router) all call ``get_audit_logger().log(...)``, but the
+    # ``GET /api/v1/audit`` reader (``ee.cloud.audit.service``) reads from
+    # ``get_audit_store()`` — a totally separate sink. Without this bridge
+    # the reader returned 0 rows for every query (#1202). Idempotent via a
+    # module-level flag so re-mounting (tests) does not double-mirror.
+    from pocketpaw_ee.cloud.audit.listeners import register_audit_bridge
+
+    register_audit_bridge()
 
     # Register in-process bus subscribers (Stage 1.B "Files as Knowledge").
     # The FileReady listener drives KB indexing for every workspace upload.

--- a/ee/pocketpaw_ee/cloud/audit/listeners.py
+++ b/ee/pocketpaw_ee/cloud/audit/listeners.py
@@ -1,0 +1,188 @@
+# listeners.py — Bridge AuditLogger (JSONL) writes into AuditStore (SQLite).
+# Created: 2026-05-24 (#1202) — Cloud audit writers across the EE codebase
+#   (pockets/action_executor, pockets/source_executor, pockets/service,
+#   skills/service, agent/pocket_router) all call
+#   ``pocketpaw.security.audit.get_audit_logger().log(AuditEvent.create(...))``
+#   which appends a row to ``~/.pocketpaw/audit.jsonl``. The cloud reader
+#   ``GET /api/v1/audit`` (``ee/pocketpaw_ee/cloud/audit/service.py``) reads
+#   from ``pocketpaw.audit.store.AuditStore``, a SQLite file at
+#   ``~/.pocketpaw/audit.db``. Nothing was bridging the two sinks, so every
+#   query returned 0 rows — even ``?pocket_id={id}`` against a pocket that
+#   had just been written to.
+#
+#   This module installs an ``AuditLogger.on_log`` callback at ``mount_cloud``
+#   time that mirrors each event into ``AuditStore`` so the GET surface sees
+#   the writes. The mapping preserves the original (free-form) writer
+#   category in ``metadata.source_category`` and picks a coarse
+#   ``AuditEntry.category`` (the reader DTO restricts it to a literal set)
+#   so existing rows stay queryable. ``workspace_id`` rides on
+#   ``context.workspace_id`` to match the reader's tenant rollup.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw.audit.store import get_audit_store
+from pocketpaw.security.audit import get_audit_logger
+
+logger = logging.getLogger(__name__)
+
+# Module-level guard so a second ``register_audit_bridge()`` call (e.g. a
+# test that re-runs ``mount_cloud``) does not append the same callback
+# twice. ``AuditLogger.on_log`` is a thin list append with no de-dup.
+_BRIDGE_REGISTERED = False
+
+
+# Map free-form writer categories (``pocket_backend_config``,
+# ``pocket_embed``, ``skills_config``, ``pocket_router``, …) to the strict
+# ``AuditEntry.category`` literal set
+# (``decision`` / ``data`` / ``config`` / ``security``). The original value
+# is preserved in ``metadata.source_category`` so nothing is lost.
+_CATEGORY_MAP: dict[str, str] = {
+    "pocket_backend_config": "config",
+    "pocket_embed": "config",
+    "skills_config": "config",
+    "pocket_router": "decision",
+}
+
+# Writer ``status`` values from ``AuditEvent`` are free-form
+# (``success`` / ``error`` / ``rejected`` / ``rate-limited`` /
+# ``instinct-pending`` / ``allow`` / ``block`` …). ``AuditEntry.status`` is
+# a strict literal set. Map to the closest match; preserve the original in
+# ``metadata.source_status``.
+_STATUS_MAP: dict[str, str] = {
+    "success": "completed",
+    "allow": "completed",
+    "approved": "approved",
+    "rejected": "rejected",
+    "block": "rejected",
+    "pending": "pending",
+    "instinct-pending": "pending",
+}
+
+
+def _coerce_category(raw: Any) -> str:
+    """Return a valid ``AuditEntry.category`` from a free-form writer value.
+
+    Unknown values fall back to ``"config"`` — every writer this bridge
+    sees today emits a configuration- or governance-shaped event, so that
+    is the least-surprising default. The original value is preserved by
+    the caller under ``metadata.source_category``.
+    """
+    if isinstance(raw, str) and raw in _CATEGORY_MAP:
+        return _CATEGORY_MAP[raw]
+    if isinstance(raw, str) and raw in ("decision", "data", "config", "security"):
+        return raw
+    return "config"
+
+
+def _coerce_status(raw: Any) -> str:
+    """Return a valid ``AuditEntry.status`` from a free-form writer value.
+
+    Unknown values fall back to ``"completed"`` — most writer ``status``
+    strings (``error``, ``timeout``, …) describe a finished attempt and
+    line up best with ``completed``. The original lives under
+    ``metadata.source_status`` so a downstream UI can still surface the
+    nuance.
+    """
+    if isinstance(raw, str) and raw in _STATUS_MAP:
+        return _STATUS_MAP[raw]
+    if isinstance(raw, str) and raw in ("completed", "approved", "rejected", "pending"):
+        return raw
+    return "completed"
+
+
+def _mirror_to_store(event_dict: dict) -> None:
+    """Translate one ``AuditEvent`` dict and insert it into ``AuditStore``.
+
+    Runs inside the ``AuditLogger.log()`` sync callback fan-out — must be
+    fast and must NEVER raise. ``AuditLogger`` already wraps the callback
+    in ``try / except: pass``, but a defensive ``try`` here lets us log
+    the failure for debugging instead of silently dropping it.
+    """
+    try:
+        # ``security.audit.AuditEvent`` stores everything that is not one of
+        # the named fields under ``context``. The cloud writers stash
+        # ``workspace_id`` / ``pocket_id`` / ``category`` there.
+        ctx = dict(event_dict.get("context") or {})
+
+        # Pocket id may arrive in context (cloud writers) OR via ``target``
+        # (older code paths). Prefer the explicit context value so the
+        # reader's ``pocket_id = ?`` filter lines up; fall back to target
+        # when the action is a pocket.* action.
+        pocket_id = ctx.pop("pocket_id", None)
+        target = event_dict.get("target") or ""
+        action = event_dict.get("action") or ""
+        if not pocket_id and target and action.startswith("pocket."):
+            pocket_id = target
+
+        # Workspace id: must land in context so search_entries' workspace
+        # rollup (``json_extract(context, '$.workspace_id') = ?``) matches.
+        # The pop / re-add keeps the value if the writer already put it
+        # there, and silently does nothing if the writer omitted it.
+        workspace_id = ctx.get("workspace_id")
+
+        source_category = ctx.pop("category", None)
+        category = _coerce_category(source_category)
+        status = _coerce_status(event_dict.get("status"))
+
+        description = f"{action} on {target}" if target else action
+        if not description:
+            description = "audit event"
+
+        metadata: dict[str, Any] = {
+            "severity": event_dict.get("severity"),
+            "source_id": event_dict.get("id"),
+        }
+        if source_category is not None:
+            metadata["source_category"] = source_category
+        source_status = event_dict.get("status")
+        if source_status is not None and source_status != status:
+            metadata["source_status"] = source_status
+
+        store = get_audit_store()
+        store._ensure_schema()
+        # AuditStore.log_entry is async only because the public API is
+        # async-shaped; the body is a plain sync SQLite insert. Call the
+        # same code path via a dedicated sync helper so we do not need an
+        # event loop in the on_log callback.
+        store.log_entry_sync(
+            actor=event_dict.get("actor") or "system",
+            action=action or "unknown",
+            category=category,
+            description=description,
+            pocket_id=pocket_id,
+            context={**ctx, **({"workspace_id": workspace_id} if workspace_id else {})},
+            status=status,
+            metadata=metadata,
+        )
+    except Exception:  # noqa: BLE001 — never let an audit bridge break a write
+        logger.warning("audit bridge: failed to mirror entry to AuditStore", exc_info=True)
+
+
+def register_audit_bridge() -> None:
+    """Install the JSONL-to-SQLite audit bridge.
+
+    Called once from ``mount_cloud`` so every ``AuditLogger.log()`` write
+    in the EE cloud surface (pocket action runs, source runs, skills
+    config changes, …) is mirrored into ``AuditStore``. Without this the
+    cloud ``GET /api/v1/audit`` reader sees an empty SQLite file even
+    when ``~/.pocketpaw/audit.jsonl`` is full of rows.
+
+    Idempotent on two axes: a module-level ``_BRIDGE_REGISTERED`` flag
+    short-circuits repeat calls in the same process, and a containment
+    check against the logger's callback list (which a test fixture may
+    have manipulated) prevents duplicate installs even if the flag was
+    reset externally.
+    """
+    global _BRIDGE_REGISTERED
+    if _BRIDGE_REGISTERED:
+        return
+    logger = get_audit_logger()
+    if _mirror_to_store not in logger._callbacks:
+        logger.on_log(_mirror_to_store)
+    _BRIDGE_REGISTERED = True
+
+
+__all__ = ["register_audit_bridge"]

--- a/src/pocketpaw/audit/store.py
+++ b/src/pocketpaw/audit/store.py
@@ -7,6 +7,10 @@
 #   workspace_id rollup + bound-param LIKE over action/description/context.
 #   The injection regression test (tests/test_audit_fts_security.py) proves
 #   a crafted ``q`` cannot corrupt the audit_log table.
+# Modified: 2026-05-24 (#1202) — Added ``log_entry_sync`` so the cloud
+#   ``AuditLogger`` → ``AuditStore`` bridge (``ee/pocketpaw_ee/cloud/audit/
+#   listeners.py``) can mirror events into SQLite from the sync
+#   ``AuditLogger.on_log`` fan-out callback without needing an event loop.
 
 from __future__ import annotations
 
@@ -156,6 +160,61 @@ class AuditStore:
             )
             conn.commit()
         logger.debug("audit: logged %s by %s (%s)", action, actor, entry.id)
+        return entry.id
+
+    def log_entry_sync(
+        self,
+        actor: str,
+        action: str,
+        category: str,
+        description: str,
+        pocket_id: str | None = None,
+        context: dict | None = None,
+        ai_recommendation: str | None = None,
+        outcome: str | None = None,
+        status: str = "completed",
+        metadata: dict | None = None,
+    ) -> str:
+        """Synchronous sibling of :meth:`log_entry`.
+
+        Exists for the cloud audit bridge (#1202): the
+        :class:`pocketpaw.security.audit.AuditLogger` fans events out to
+        its ``on_log`` callbacks synchronously from inside ``log()``,
+        with no event loop guaranteed to be running. The async method's
+        body is already a plain blocking sqlite call, so duplicating the
+        insert here keeps the bridge dependency-free (no
+        ``asyncio.run`` / ``run_coroutine_threadsafe`` gymnastics).
+        Returns the entry id so callers can correlate with their own
+        records.
+        """
+        self._ensure_schema()
+        entry = AuditEntry(
+            actor=actor,
+            action=action,
+            category=category,  # type: ignore[arg-type]
+            description=description,
+            pocket_id=pocket_id,
+            context=context or {},
+            ai_recommendation=ai_recommendation,
+            outcome=outcome,
+            status=status,  # type: ignore[arg-type]
+            metadata=metadata or {},
+        )
+        row = entry.to_db_row()
+        with self._get_conn() as conn:
+            conn.execute(
+                """
+                INSERT INTO audit_log
+                    (id, timestamp, pocket_id, actor, action, category,
+                     description, context, ai_recommendation, outcome, status, metadata)
+                VALUES
+                    (:id, :timestamp, :pocket_id, :actor, :action, :category,
+                     :description, :context, :ai_recommendation, :outcome, :status, :metadata)
+                """,
+                row,
+            )
+            conn.commit()
+        logger.debug("audit: logged %s by %s (%s) [sync]", action, actor, entry.id)
         return entry.id
 
     async def search_entries(

--- a/tests/cloud/test_audit_bridge.py
+++ b/tests/cloud/test_audit_bridge.py
@@ -1,0 +1,332 @@
+# test_audit_bridge.py — regression coverage for #1202.
+# Created: 2026-05-24 (#1202) — Before this PR, the EE cloud audit
+#   writers (``pockets.action_executor._audit_action_run`` and friends)
+#   appended rows to the JSONL ``AuditLogger`` sink while the
+#   ``GET /api/v1/audit`` reader queried the SQLite ``AuditStore`` sink,
+#   so every list/filter call returned 0 entries even though the writes
+#   had fired. ``ee.cloud.audit.listeners.register_audit_bridge`` now
+#   installs an ``AuditLogger.on_log`` callback that mirrors each event
+#   into the SQLite store. These tests prove:
+#     * an ``_audit_action_run`` write surfaces through both
+#       ``GET /audit`` (no filter) and ``GET /audit?pocket_id={id}``,
+#     * a different workspace cannot see the row,
+#     * the bridge is idempotent (calling ``register_audit_bridge``
+#       twice doesn't double-mirror).
+from __future__ import annotations
+
+import pytest
+
+# OSS-only safety per CLAUDE.md: this file imports pocketpaw_ee — skip
+# the whole module on an OSS-only install where the wheel is absent.
+pytest.importorskip("pocketpaw_ee")
+
+from types import SimpleNamespace  # noqa: E402
+
+import pytest_asyncio  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.audit import listeners as audit_listeners  # noqa: E402
+from pocketpaw_ee.cloud.audit import service as audit_service  # noqa: E402
+from pocketpaw_ee.cloud.audit.router import router as audit_router  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+
+from pocketpaw.audit import store as audit_store_module  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_user(user_id: str = "u1", workspace_id: str | None = "w1") -> SimpleNamespace:
+    """Lightweight stand-in for ``ee.cloud.models.user.User``.
+
+    Mirrors the helper in ``test_audit_router.py`` — only the attributes
+    the auth chain reads are filled.
+    """
+    return SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=(
+            [SimpleNamespace(workspace=workspace_id, role="admin")] if workspace_id else []
+        ),
+    )
+
+
+def _install_service_seam(audit_store) -> None:
+    """Rebind ``agent_list_audit`` so the router picks up the tmp store.
+
+    The cloud service reads from the ``get_audit_store()`` singleton by
+    default; under test we want to point at a tmp file so concurrent
+    suite runs don't see each other's writes. The wrapper is restored by
+    ``_restore_service``.
+    """
+    real = audit_service.agent_list_audit
+
+    async def _bound(ctx, body=None, *, store=None):
+        return await real(ctx, body, store=store or audit_store)
+
+    audit_service.agent_list_audit = _bound  # type: ignore[assignment]
+    audit_service._orig_agent_list_audit = real  # type: ignore[attr-defined]
+
+
+def _restore_service() -> None:
+    real = getattr(audit_service, "_orig_agent_list_audit", None)
+    if real is not None:
+        audit_service.agent_list_audit = real  # type: ignore[assignment]
+        delattr(audit_service, "_orig_agent_list_audit")
+
+
+def _build_app(audit_store, *, workspace_id: str = "w1", user_id: str = "u1") -> FastAPI:
+    """Build a FastAPI app wired to the cloud audit router + tmp store."""
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(audit_router)
+    app.dependency_overrides[require_license] = lambda: None
+
+    user = _fake_user(user_id=user_id, workspace_id=workspace_id)
+
+    async def _fake_user_dep():
+        return user
+
+    app.dependency_overrides[current_active_user] = _fake_user_dep
+
+    # RBAC denial path is exercised in test_audit_router.py — here we
+    # just need a permissive guard so the handler actually runs.
+    from pocketpaw_ee.cloud._core import deps as core_deps
+
+    core_deps.check_workspace_action = lambda *a, **k: None  # type: ignore[assignment]
+
+    _install_service_seam(audit_store)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def bridged_store(audit_store_tmp, monkeypatch):
+    """Tmp ``AuditStore`` wired in as the global singleton, with the
+    bridge installed.
+
+    The bridge listener (``_mirror_to_store``) calls ``get_audit_store()``
+    at callback time, so patching the module-level singleton is enough
+    to capture every mirrored write into the tmp DB. We pop only OUR
+    bridge callback on teardown (the way ``test_pocket_catalog_gate``
+    handles its own ``on_log`` listener) so other suites that register
+    their own callbacks are not disturbed.
+    """
+    from pocketpaw.security.audit import get_audit_logger
+
+    monkeypatch.setattr(audit_store_module, "_audit_store", audit_store_tmp)
+
+    # Force a clean install so we know our specific callback is in the
+    # list. Calls to ``register_audit_bridge`` from a previous test (or
+    # from ``mount_cloud`` already executed in-process) left the flag set
+    # and our callback installed, but we want a deterministic state for
+    # the per-test ``list.remove`` teardown below.
+    audit_listeners._BRIDGE_REGISTERED = False
+    audit_listeners.register_audit_bridge()
+    yield audit_store_tmp
+
+    # Remove only our bridge callback — leave everything else alone.
+    logger = get_audit_logger()
+    try:
+        logger._callbacks.remove(audit_listeners._mirror_to_store)
+    except ValueError:
+        pass
+    audit_listeners._BRIDGE_REGISTERED = False
+
+
+@pytest_asyncio.fixture
+async def w1_client(bridged_store) -> AsyncClient:
+    app = _build_app(bridged_store, workspace_id="w1")
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            yield client
+    finally:
+        _restore_service()
+
+
+@pytest_asyncio.fixture
+async def w2_client(bridged_store) -> AsyncClient:
+    app = _build_app(bridged_store, workspace_id="w2")
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            yield client
+    finally:
+        _restore_service()
+
+
+# ---------------------------------------------------------------------------
+# The core regression — writer → reader round trip.
+# ---------------------------------------------------------------------------
+
+
+async def test_action_run_write_visible_via_get_audit(
+    w1_client: AsyncClient, bridged_store
+) -> None:
+    """Firing ``_audit_action_run`` must leave a row that surfaces via
+    the no-filter GET /audit response.
+
+    This is the literal acceptance criterion in issue #1202.
+    """
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    action_executor._audit_action_run(
+        actor="u1",
+        workspace_id="w1",
+        pocket_id="pocket_alpha",
+        action="create_lease",
+        status="success",
+        base_url="https://api.example.com",
+    )
+
+    r = await w1_client.get("/audit", params={"limit": 20})
+    assert r.status_code == 200, r.text
+    entries = r.json()["entries"]
+    assert len(entries) == 1
+    row = entries[0]
+    assert row["pocket_id"] == "pocket_alpha"
+    assert row["action"] == "pocket.actions.run"
+    assert row["actor"] == "u1"
+
+
+async def test_pocket_id_filter_returns_action_run_row(
+    w1_client: AsyncClient, bridged_store
+) -> None:
+    """``GET /audit?pocket_id={id}`` must return the row the write left.
+
+    Filters on a different pocket_id must return zero rows — proves the
+    bridge populates the SQL ``pocket_id`` column (the search predicate
+    is ``pocket_id = ?``, not a context LIKE match).
+    """
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    action_executor._audit_action_run(
+        actor="u1",
+        workspace_id="w1",
+        pocket_id="pocket_alpha",
+        action="create_lease",
+        status="success",
+        base_url="https://api.example.com",
+    )
+    action_executor._audit_action_run(
+        actor="u1",
+        workspace_id="w1",
+        pocket_id="pocket_beta",
+        action="cancel_lease",
+        status="success",
+        base_url="https://api.example.com",
+    )
+
+    r = await w1_client.get("/audit", params={"pocket_id": "pocket_alpha"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["total"] == 1
+    assert body["entries"][0]["pocket_id"] == "pocket_alpha"
+
+    # The other pocket's row is still queryable.
+    r2 = await w1_client.get("/audit", params={"pocket_id": "pocket_beta"})
+    assert r2.status_code == 200
+    assert {e["pocket_id"] for e in r2.json()["entries"]} == {"pocket_beta"}
+
+    # And a pocket with no writes returns nothing.
+    r3 = await w1_client.get("/audit", params={"pocket_id": "ghost"})
+    assert r3.status_code == 200
+    assert r3.json() == {"entries": [], "total": 0}
+
+
+async def test_write_for_other_workspace_is_hidden(w1_client: AsyncClient, bridged_store) -> None:
+    """A write logged under workspace ``w2`` must not surface for ``w1``.
+
+    The reader's tenancy filter rolls up via ``json_extract(context,
+    '$.workspace_id')`` — proves the bridge preserves the writer's
+    ``workspace_id`` under ``context.workspace_id``.
+    """
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    action_executor._audit_action_run(
+        actor="u_other",
+        workspace_id="w2",
+        pocket_id="pocket_secret",
+        action="purge",
+        status="success",
+        base_url="https://api.example.com",
+    )
+
+    r = await w1_client.get("/audit", params={"limit": 20})
+    assert r.status_code == 200
+    assert r.json() == {"entries": [], "total": 0}
+
+
+async def test_failure_status_also_audited(w1_client: AsyncClient, bridged_store) -> None:
+    """A rejected / errored write must still be visible to the reader.
+
+    ``_audit_action_run`` fires on EVERY attempt — success, rejection,
+    timeout. The bridge maps non-standard writer ``status`` values to a
+    valid ``AuditEntry.status`` and preserves the original under
+    ``metadata.source_status`` so the UI can still surface the nuance.
+    """
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    action_executor._audit_action_run(
+        actor="u1",
+        workspace_id="w1",
+        pocket_id="pocket_alpha",
+        action="delete_thing",
+        status="rejected",  # allowlist miss
+        base_url="https://api.example.com",
+    )
+
+    r = await w1_client.get("/audit", params={"pocket_id": "pocket_alpha"})
+    assert r.status_code == 200
+    rows = r.json()["entries"]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "rejected"
+    assert rows[0]["metadata"].get("source_status") in (None, "rejected")
+
+
+# ---------------------------------------------------------------------------
+# Bridge idempotency
+# ---------------------------------------------------------------------------
+
+
+async def test_register_audit_bridge_is_idempotent(bridged_store) -> None:
+    """Calling ``register_audit_bridge`` twice must NOT double-mirror.
+
+    Tests that re-run ``mount_cloud`` should land exactly one row per
+    write — duplicates would be subtle and noisy.
+    """
+    from pocketpaw.security.audit import (
+        AuditEvent,
+        AuditSeverity,
+        get_audit_logger,
+    )
+
+    # bridged_store fixture already called register_audit_bridge() once.
+    # A second call must be a no-op.
+    audit_listeners.register_audit_bridge()
+    audit_listeners.register_audit_bridge()
+
+    get_audit_logger().log(
+        AuditEvent.create(
+            severity=AuditSeverity.WARNING,
+            actor="u1",
+            action="pocket.actions.run",
+            target="pocket_alpha",
+            status="success",
+            category="pocket_backend_config",
+            workspace_id="w1",
+            pocket_id="pocket_alpha",
+            base_url="https://api.example.com",
+        )
+    )
+
+    entries = await bridged_store.search_entries(workspace_id="w1", pocket_id="pocket_alpha")
+    assert len(entries) == 1, f"expected exactly one mirrored row, got {len(entries)}"


### PR DESCRIPTION
## Why

`GET /api/v1/audit` returned 0 entries even after pocket write actions had fired `_audit_action_run` and left rows on disk. With or without a `?pocket_id=` filter, the response was always empty. Triaging the writer + reader sides showed the two sit on completely different audit sinks:

| Side | Module | Sink |
| --- | --- | --- |
| Writer (every cloud audit call) | `pocketpaw.security.audit.AuditLogger.log()` | JSONL at `~/.pocketpaw/audit.jsonl` |
| Reader (`GET /api/v1/audit`) | `pocketpaw.audit.store.AuditStore.search_entries()` | SQLite at `~/.pocketpaw/audit.db` |

Nothing was ferrying entries between them, so the cloud reader queried an empty SQLite file. This affects every cloud write that reaches an audit call site (pocket actions, source runs, skills config, agent router, …), not just the pocket action path called out in the issue.

## What

- New module `ee/pocketpaw_ee/cloud/audit/listeners.py` registers a bridge callback on the `AuditLogger` singleton. Each `log()` fan-out mirrors the event into `AuditStore` via a new sync helper.
- `mount_cloud()` calls `register_audit_bridge()` right after `init_realtime()` so the bridge is live before any HTTP traffic.
- The bridge maps the writer's free-form `category` (`pocket_backend_config`, `pocket_embed`, `skills_config`, `pocket_router`) and `status` (`success`, `rejected`, `rate-limited`, `instinct-pending`, …) into the literal sets `AuditEntry` enforces, and preserves the originals under `metadata.source_category` / `metadata.source_status` so no detail is dropped.
- `workspace_id` keeps living on `context.workspace_id` (the JSON column the reader rolls up by). `pocket_id` lands on the SQL column the reader's `pocket_id = ?` predicate matches.

## Which side was wrong + why

The writer's contract was the de facto standard across the cloud, so I fixed the reader's side — by feeding it. Adding a bridge instead of switching every writer to `AuditStore.log_entry` keeps the existing audit logger's fan-out (websocket broadcaster, PII scrubber, JSONL on-disk trail used by `pocketpaw logs`) intact and routes the rows the cloud reader needs into the SQLite store without disturbing the audit_logger path that the OSS dashboard and a long tail of callers rely on. One bridge fixes every current and future writer that uses the audit logger.

## Tests

New file `tests/cloud/test_audit_bridge.py` (5 tests, all passing):

- `_audit_action_run` write surfaces through `GET /audit` with no filter.
- `GET /audit?pocket_id={id}` returns the matching row + zero for an unknown pocket id.
- A write logged under workspace `w2` is hidden from a `w1` viewer.
- A `rejected` write (allowlist miss) still shows up with status preserved.
- `register_audit_bridge` is idempotent — calling it twice does not double-mirror.

```
uv run pytest tests/cloud/test_audit_bridge.py tests/cloud/test_audit_service.py tests/cloud/test_audit_router.py tests/cloud/test_pocket_catalog_gate.py tests/cloud/test_pocket_action_executor.py tests/test_audit.py tests/test_audit_fts_security.py tests/test_audit_completeness.py tests/v1/test_api_v1_runtime_audit.py
.........................................................................................................................................                                  [100%]
127 passed
```

`uvx ruff@0.15.9 format --check .`, `uvx ruff@0.15.9 check .`, and `uv run lint-imports` all pass.

## Files

- `ee/pocketpaw_ee/cloud/audit/listeners.py` — new bridge module
- `ee/pocketpaw_ee/cloud/__init__.py` — wire `register_audit_bridge()` into `mount_cloud`
- `src/pocketpaw/audit/store.py` — add `log_entry_sync` sister of `log_entry` so the bridge can insert from the sync `on_log` callback without dragging in an event loop
- `tests/cloud/test_audit_bridge.py` — regression coverage

Fixes #1202