### PR TITLE
feat(sessions): list_for_user for chat surface session count

### DIFF
--- a/ee/pocketpaw_ee/cloud/sessions/service.py
+++ b/ee/pocketpaw_ee/cloud/sessions/service.py
@@ -241,6 +241,60 @@ async def list_for_pocket(ctx: RequestContext, pocket_id: str) -> list[DomainSes
     return [_to_domain(d) for d in docs]
 
 
+async def list_for_user(
+    workspace_id: str,
+    user_id: str,
+    limit: int | None = None,
+) -> list[dict]:
+    """Sessions in ``workspace_id`` owned by ``user_id``, newest first.
+
+    Wire-dict shape so callers outside the cloud entity (e.g. surface
+    preamble handlers) don't need to import the domain object. Field
+    names mirror :class:`DomainSession`. ``limit`` (when provided) caps
+    the returned slice; ``None`` returns the full set. Both the
+    workspace and owner filters are applied per the cloud entity
+    tenancy rule — no global reads.
+    """
+    query = (
+        _SessionDoc.find(
+            _SessionDoc.workspace == workspace_id,
+            _SessionDoc.owner == user_id,
+            _SessionDoc.deleted_at == None,  # noqa: E711
+        ).sort(-_SessionDoc.lastActivity)  # type: ignore[arg-type, operator]
+    )
+    if limit is not None:
+        query = query.limit(limit)
+    docs = await query.to_list()
+    return [_to_wire_dict(d) for d in docs]
+
+
+def _to_wire_dict(doc: _SessionDoc) -> dict:
+    """Project a ``Session`` doc to a wire dict for cross-entity callers.
+
+    Mirrors :func:`_to_domain` field names so the two shapes stay in
+    lockstep — wire callers (surface handlers, downstream readers) get
+    the same fields a domain consumer would. Scoped helper, intentionally
+    local to ``list_for_user`` until a broader migration introduces a
+    ``Session`` Response DTO.
+    """
+    return {
+        "id": str(doc.id),
+        "sessionId": doc.sessionId,
+        "context_type": doc.context_type or "session",
+        "workspace": doc.workspace,
+        "owner": doc.owner,
+        "title": doc.title,
+        "pocket": doc.pocket,
+        "group": doc.group,
+        "agent": doc.agent,
+        "message_count": doc.messageCount,
+        "last_activity": doc.lastActivity,
+        "created_at": getattr(doc, "createdAt", None),
+        "deleted_at": doc.deleted_at,
+        "surface": getattr(doc, "surface", None),
+    }
+
+
 async def _fetch_owned(session_id: str, user_id: str) -> _SessionDoc:
     """Internal: fetch by ObjectId or sessionId; check owner; raise
     NotFound / Forbidden as needed. Used by both ``get`` and the
@@ -759,6 +813,7 @@ __all__ = [
     "list_by_agent",
     "list_for_owner",
     "list_for_pocket",
+    "list_for_user",
     "set_title",
     "set_title_if_default",
     "touch",

--- a/ee/pocketpaw_ee/cloud/surface/handlers/chat.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/chat.py
@@ -1,10 +1,15 @@
 # chat.py — /chat surface preamble.
 #
-# Created: 2026-05-24 — When the user is on the chat surface itself
-# (not a pocket / not the home dashboard) we keep the preamble minimal:
-# the agent already has the conversation state on hand. We surface the
-# session count as a tiny hint so the agent can answer "how many threads
-# do I have?" without an extra round-trip.
+# Updated: 2026-05-24 — The sessions service now exposes a real
+# ``list_for_user`` helper, so the forward-compat getattr probe in
+# ``_session_count`` can go. Direct call, graceful try/except remains
+# for genuine runtime failures (DB down, etc.).
+#
+# Originally created: 2026-05-24 — When the user is on the chat surface
+# itself (not a pocket / not the home dashboard) we keep the preamble
+# minimal: the agent already has the conversation state on hand. We
+# surface the session count as a tiny hint so the agent can answer
+# "how many threads do I have?" without an extra round-trip.
 
 from __future__ import annotations
 
@@ -32,13 +37,7 @@ async def _session_count(workspace_id: str, user_id: str) -> int | None:
     try:
         from pocketpaw_ee.cloud.sessions import service as sessions_service
 
-        # The sessions service exposes per-user listings; we don't need
-        # to paginate — a length is enough. Tolerate missing helper
-        # (older deploys may not have this name).
-        lister = getattr(sessions_service, "list_for_user", None)
-        if lister is None:
-            return None
-        sessions = await lister(workspace_id=workspace_id, user_id=user_id)
+        sessions = await sessions_service.list_for_user(workspace_id=workspace_id, user_id=user_id)
         return len(sessions or [])
     except Exception:
         logger.debug("chat_handler: session count failed", exc_info=True)

--- a/tests/cloud/sessions/test_service.py
+++ b/tests/cloud/sessions/test_service.py
@@ -1,0 +1,71 @@
+# tests/cloud/sessions/test_service.py — list_for_user helper.
+#
+# Created: 2026-05-24 — Tests for the per-user sessions listing the
+# chat surface preamble calls (``_session_count``). Three guarantees:
+#   1. Owner filter — only the requested user's sessions come back when
+#      multiple users share a workspace.
+#   2. Workspace filter — only the requested workspace's sessions come
+#      back when the same user has sessions in multiple workspaces.
+#   3. Limit cap — when ``limit`` is set, the result honors it.
+#
+# Sibling sessions-service tests (CRUD, touch, list_for_owner, etc.)
+# live in ``test_service_v2.py`` — the v2 suffix is a transitional name
+# from the 2026-04-27 cloud rewrite. This file is the canonical home
+# going forward and the natural place to add new ``service.py`` tests.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.sessions import service as sessions_service
+from pocketpaw_ee.cloud.sessions.dto import CreateSessionRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(user_id: str = "u1", workspace_id: str | None = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def test_list_for_user_returns_only_owner_sessions() -> None:
+    """Two users in the same workspace — only the requested owner's rows."""
+    await sessions_service.create(_ctx("u1"), "w1", CreateSessionRequest(title="u1-a"))
+    await sessions_service.create(_ctx("u1"), "w1", CreateSessionRequest(title="u1-b"))
+    await sessions_service.create(_ctx("u2"), "w1", CreateSessionRequest(title="u2-only"))
+
+    rows = await sessions_service.list_for_user("w1", "u1")
+
+    assert len(rows) == 2
+    titles = {r["title"] for r in rows}
+    assert titles == {"u1-a", "u1-b"}
+    assert all(r["owner"] == "u1" for r in rows)
+
+
+async def test_list_for_user_respects_workspace_boundary() -> None:
+    """Same user with sessions in two workspaces — only the asked one."""
+    await sessions_service.create(_ctx("u1"), "w1", CreateSessionRequest(title="in-w1"))
+    await sessions_service.create(_ctx("u1"), "w2", CreateSessionRequest(title="in-w2"))
+
+    rows = await sessions_service.list_for_user("w1", "u1")
+
+    assert len(rows) == 1
+    assert rows[0]["title"] == "in-w1"
+    assert rows[0]["workspace"] == "w1"
+
+
+async def test_list_for_user_limit() -> None:
+    """``limit`` caps the result size."""
+    for i in range(5):
+        await sessions_service.create(_ctx("u1"), "w1", CreateSessionRequest(title=f"s{i}"))
+
+    rows = await sessions_service.list_for_user("w1", "u1", limit=2)
+
+    assert len(rows) == 2

--- a/tests/cloud/surface/test_chat_handler.py
+++ b/tests/cloud/surface/test_chat_handler.py
@@ -1,0 +1,47 @@
+# tests/cloud/surface/test_chat_handler.py — Chat surface handler.
+#
+# Created: 2026-05-24 — Two guarantees:
+#   1. Happy path — the preamble carries ``<chat-snapshot sessions="N" />``
+#      when the sessions service returns a real listing. This is the
+#      hint the agent reads to answer "how many threads do I have?".
+#   2. Failure path — the preamble falls back to
+#      ``(session count unavailable)`` when the sessions service raises,
+#      so a transient DB hiccup never breaks the chat send.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers import chat as chat_handler
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_chat_handler_emits_session_count() -> None:
+    """Sessions service returning N rows -> ``<chat-snapshot sessions="N" />``."""
+    fake_rows = [{"id": "1"}, {"id": "2"}, {"id": "3"}]
+    with patch(
+        "pocketpaw_ee.cloud.sessions.service.list_for_user",
+        new=AsyncMock(return_value=fake_rows),
+    ):
+        preamble = await chat_handler.build_preamble("w1", "u1", SurfaceMeta())
+
+    assert '<surface kind="chat"' in preamble
+    assert '<chat-snapshot sessions="3" />' in preamble
+    # The unavailable-fallback tag must NOT appear on the happy path —
+    # if both shipped the agent would see contradictory hints.
+    assert "session count unavailable" not in preamble
+
+
+async def test_chat_handler_falls_back_when_lister_raises() -> None:
+    """Any exception from the sessions service yields the unavailable fallback."""
+    with patch(
+        "pocketpaw_ee.cloud.sessions.service.list_for_user",
+        new=AsyncMock(side_effect=RuntimeError("db down")),
+    ):
+        preamble = await chat_handler.build_preamble("w1", "u1", SurfaceMeta())
+
+    assert '<surface kind="chat"' in preamble
+    assert "<chat-snapshot>(session count unavailable)</chat-snapshot>" in preamble


### PR DESCRIPTION
## Summary

The chat surface preamble (`/chat`) wants a session count to embed in `<chat-snapshot sessions="N" />`. Its `_session_count` helper has been probing `sessions_service.list_for_user` via `getattr` since launch and falling back to `(session count unavailable)` because the helper didn't exist. This PR adds the helper and drops the probe.

## What changed

- `ee/pocketpaw_ee/cloud/sessions/service.py` — new `list_for_user(workspace_id, user_id, limit=None) -> list[dict]`. Filters on both workspace and owner (tenancy rule), sorts by `lastActivity` desc, optional `limit` cap. Returns wire dicts via a scoped `_to_wire_dict` projector so cross-entity callers don't need to import the domain object.
- `ee/pocketpaw_ee/cloud/surface/handlers/chat.py` — `_session_count` calls the helper directly. Removed the `getattr(..., "list_for_user", None)` forward-compat probe. Surrounding `try/except` graceful-fallback stays so a transient DB hiccup still degrades to `(session count unavailable)`.
- `tests/cloud/sessions/test_service.py` — three new tests: owner filter, workspace boundary, limit cap.
- `tests/cloud/surface/test_chat_handler.py` — two new tests: happy path emits `<chat-snapshot sessions="N" />`, error path falls back.

The sibling sessions service tests live in `test_service_v2.py` (transitional name from the 2026-04-27 cloud rewrite); the new file `test_service.py` is the canonical home going forward.

## Test plan

- [x] `uv run pytest tests/cloud/sessions/test_service.py tests/cloud/surface/test_chat_handler.py -v` — 5 passed
- [x] `uv run pytest tests/cloud/sessions/ tests/cloud/surface/ -v` — 40 passed (no sibling regressions)
- [x] `uv run ruff check` on the four touched paths — clean
- [x] `uv run ruff format --check` on the four touched paths — clean

Closes #1215