### PR TITLE
feat(knowledge): real scope list for /knowledge surface preamble

### DIFF
--- a/ee/pocketpaw_ee/cloud/kb/service.py
+++ b/ee/pocketpaw_ee/cloud/kb/service.py
@@ -1,5 +1,13 @@
 # service.py — Workspace-level KB scope listing.
 #
+# Updated: 2026-05-24 — Bounded the probe fan-out via a module-level
+# ``_PROBE_CONCURRENCY=8`` semaphore. The previous unbounded
+# ``asyncio.gather`` could spawn one kb-go subprocess per candidate
+# scope; on a workspace with 100 pockets + 50 agents that's 151
+# concurrent subprocesses, which exceeds the default-executor
+# thread-pool back-pressure (~32) and pressures FS + OS PID limits.
+# The cap matches the thread-pool default and stops the fork storm.
+#
 # Created: 2026-05-24 — Adds the canonical ``list_scopes(workspace_id,
 # user_id)`` helper so the /knowledge surface handler can render the
 # real KB scopes attached to a workspace instead of the
@@ -47,6 +55,17 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+# Cap on concurrent kb-go probes during ``list_scopes``. kb-go is sync
+# I/O wrapped via ``asyncio.to_thread``, so each probe consumes a
+# default-executor thread (~32 default). On a workspace with 100
+# pockets + 50 agents, an unbounded gather would dispatch 150+
+# subprocesses at once and pressure FS + OS PID limits even though the
+# thread pool throttles wall-clock concurrency. 8 matches what
+# typical workloads can sustain without saturating the executor and
+# leaves headroom for the rest of the event loop.
+_PROBE_CONCURRENCY = 8
+
+
 # A probe callable returns the kb-go list rows for a given scope. The
 # default uses the same kb-go subprocess wrapper the knowledge router
 # already calls; tests inject a dict-backed fake so the listing path is
@@ -90,12 +109,21 @@ async def list_scopes(
     probe = kb_list if kb_list is not None else _default_kb_list
     candidates = await _candidate_scopes(workspace_id, user_id)
 
-    # Probe in parallel — each call is a kb-go subprocess on the default
-    # path, so serialising would burn wall-clock for nothing. Async
-    # ``asyncio.gather`` handles the sync-or-async shape via
-    # ``_probe_scope``.
+    # Probe in parallel under a bounded semaphore — each call is a
+    # kb-go subprocess on the default path, so serialising would burn
+    # wall-clock for nothing, but unbounded gather would spawn one
+    # process per candidate (151 on a 100-pocket + 50-agent workspace)
+    # and pressure FS + OS PID limits. ``_PROBE_CONCURRENCY`` matches
+    # the default-executor thread-pool size, the natural back-pressure
+    # boundary for the kb-go ``asyncio.to_thread`` wrappers.
+    sem = asyncio.Semaphore(_PROBE_CONCURRENCY)
+
+    async def _gated(scope: str) -> bool:
+        async with sem:
+            return await _probe_scope(scope, probe)
+
     results = await asyncio.gather(
-        *(_probe_scope(scope, probe) for scope in candidates),
+        *(_gated(scope) for scope in candidates),
         return_exceptions=False,
     )
     return [scope for scope, has_articles in zip(candidates, results) if has_articles]

--- a/ee/pocketpaw_ee/cloud/kb/service.py
+++ b/ee/pocketpaw_ee/cloud/kb/service.py
@@ -1,0 +1,183 @@
+# service.py — Workspace-level KB scope listing.
+#
+# Created: 2026-05-24 — Adds the canonical ``list_scopes(workspace_id,
+# user_id)`` helper so the /knowledge surface handler can render the
+# real KB scopes attached to a workspace instead of the
+# ``[f"workspace:{workspace_id}"]`` placeholder it shipped with.
+#
+# Why a new file in ee/cloud/kb/ rather than a method on
+# ``agents.knowledge.KnowledgeService``: the existing class is an
+# agent-scoped utility wrapper around the kb-go binary (its methods
+# take ``agent_id``). A workspace-wide scope enumerator wants the
+# pocket + agent listings the agents/pockets services already own, and
+# parks naturally alongside ``workspace_aggregator.py`` in this
+# directory — both modules are workspace-level KB aggregations.
+"""Workspace-level KB scope listing.
+
+The kb-go binary stores articles against scope strings of the shape
+``workspace:{wid}``, ``pocket:{pid}``, ``agent:{aid}``. There's no
+native ``list-scopes`` command on the binary — scopes are implicit in
+whatever's been ingested. This module enumerates the **candidate** scopes
+for a workspace (the workspace itself, every pocket the calling user
+can see, every agent in the workspace), then probes each via the kb
+list shim and keeps only those that actually carry articles.
+
+Tenancy:
+    The caller's ``user_id`` filters the pocket candidates through
+    ``pockets_service.list_pockets``, which already gates by
+    owner / shared_with / workspace-visible. Agent candidates come from
+    ``agents_service.list_agents(workspace_id)`` and are pinned to the
+    workspace at the source. Cross-workspace stamps therefore return
+    nothing — both list functions filter on the explicit workspace_id.
+
+Failure mode:
+    The kb binary may be missing in lightweight deploys. The probe
+    callback wraps subprocess calls in try/except; any failure returns
+    an empty list for that scope, which excludes the scope from the
+    result. The handler treats an empty list as "(no scopes detected)".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# A probe callable returns the kb-go list rows for a given scope. The
+# default uses the same kb-go subprocess wrapper the knowledge router
+# already calls; tests inject a dict-backed fake so the listing path is
+# exercised without a kb binary on the test runner.
+KbListFn = Callable[[str], Awaitable[list[Any]] | list[Any]]
+
+
+async def list_scopes(
+    workspace_id: str,
+    user_id: str,
+    *,
+    kb_list: KbListFn | None = None,
+) -> list[str]:
+    """Return KB scope strings that belong to ``workspace_id``.
+
+    Parameters
+    ----------
+    workspace_id : str
+        Required tenant. Empty string returns ``[]`` — we never probe a
+        scope without a workspace pin (would leak across tenants if the
+        listing layer ever forgot to filter).
+    user_id : str
+        The viewer. Pocket visibility is enforced through
+        ``pockets_service.list_pockets``, so a user who can't see a
+        pocket gets no entry for it in the scope list.
+    kb_list : callable, optional
+        Probe used to verify a candidate scope actually has articles.
+        Async or sync; both call shapes are supported. Defaults to a
+        thin wrapper around ``kb list --scope <s>``.
+
+    Returns
+    -------
+    list[str]
+        Scope strings of the form ``workspace:{id}``, ``pocket:{id}``,
+        ``agent:{id}`` — in workspace → pocket → agent order. Scopes
+        with no articles (or unreachable kb backend) are excluded.
+    """
+    if not workspace_id:
+        return []
+
+    probe = kb_list if kb_list is not None else _default_kb_list
+    candidates = await _candidate_scopes(workspace_id, user_id)
+
+    # Probe in parallel — each call is a kb-go subprocess on the default
+    # path, so serialising would burn wall-clock for nothing. Async
+    # ``asyncio.gather`` handles the sync-or-async shape via
+    # ``_probe_scope``.
+    results = await asyncio.gather(
+        *(_probe_scope(scope, probe) for scope in candidates),
+        return_exceptions=False,
+    )
+    return [scope for scope, has_articles in zip(candidates, results) if has_articles]
+
+
+async def _candidate_scopes(workspace_id: str, user_id: str) -> list[str]:
+    """Enumerate candidate scopes for the workspace.
+
+    Order is intentional — workspace first, then pockets, then agents.
+    Preserves the natural "biggest container → smallest" reading order
+    in the surface preamble.
+    """
+    scopes: list[str] = [f"workspace:{workspace_id}"]
+
+    # Pocket scopes — gated by the calling user's visibility. The
+    # pockets service is the only legal reader of ``_PocketDoc`` per
+    # the entity rules; we never touch the doc directly here.
+    try:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        pockets = await pockets_service.list_pockets(workspace_id, user_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("pocket listing failed for workspace=%s: %s", workspace_id, exc)
+        pockets = []
+    for pocket in pockets:
+        pocket_id = pocket.get("_id") if isinstance(pocket, dict) else None
+        if pocket_id:
+            scopes.append(f"pocket:{pocket_id}")
+
+    # Agent scopes — workspace-pinned at the source. No per-user
+    # filter: a workspace member sees every agent in the workspace by
+    # convention (the agents page lists them all).
+    try:
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        agents = await agents_service.list_agents(workspace_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("agent listing failed for workspace=%s: %s", workspace_id, exc)
+        agents = []
+    for agent in agents:
+        agent_id = getattr(agent, "id", None)
+        if agent_id:
+            scopes.append(f"agent:{agent_id}")
+
+    return scopes
+
+
+async def _probe_scope(scope: str, probe: KbListFn) -> bool:
+    """Return True when ``scope`` carries at least one kb-go article.
+
+    Swallows every exception — the kb backend is optional, and a
+    probe failure must not crash the preamble path. Logs at DEBUG so
+    repeated failures (a missing kb binary in a dev box) don't spam
+    the warning log.
+    """
+    try:
+        result = probe(scope)
+        if hasattr(result, "__await__"):
+            rows = await result  # type: ignore[assignment]
+        else:
+            rows = result
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("kb list failed for scope=%s: %s", scope, exc)
+        return False
+    return isinstance(rows, list) and len(rows) > 0
+
+
+def _default_kb_list(scope: str) -> list[Any]:
+    """Default kb-go ``list`` probe. Mirrors ``knowledge_router._call_kb_list``.
+
+    Lives inline rather than imported from the router so this module
+    has no router dependency — the router can be unmounted in a
+    headless deploy and the surface preamble still resolves cleanly.
+    """
+    try:
+        from pocketpaw_ee.cloud.agents.knowledge import _kb
+
+        result = _kb("list", "--scope", scope)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("kb list raised for scope=%s: %s", scope, exc)
+        return []
+    return result if isinstance(result, list) else []
+
+
+__all__ = ["list_scopes"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/knowledge.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/knowledge.py
@@ -1,14 +1,18 @@
 # knowledge.py — /knowledge surface preamble.
 #
 # Created: 2026-05-24 — KB scope listing for the knowledge surface.
-# Stays minimal — the kb stack varies per deploy; if the canonical
-# helper isn't reachable we emit a placeholder so the agent still
-# knows the user is on /knowledge.
+# Updated: 2026-05-24 — Wired through ``ee.cloud.kb.service.list_scopes``
+# so the preamble renders the real workspace + pocket + agent scopes
+# the kb-go store actually carries, rather than the
+# ``[f"workspace:{workspace_id}"]`` synthetic fallback. The
+# kb-unreachable path still degrades to "(no scopes detected)" so a
+# missing kb binary doesn't break the chat send.
 
 from __future__ import annotations
 
 import logging
 
+from pocketpaw_ee.cloud.kb import service as kb_service
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
 from pocketpaw_ee.cloud.surface.handlers._helpers import truncate_preamble
 
@@ -17,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
     """Render the knowledge-surface preamble."""
-    scopes = await _list_scopes(workspace_id)
+    scopes = await _list_scopes(workspace_id, user_id)
     parts = ['<surface kind="knowledge" route="/knowledge" />']
     if not scopes:
         parts.append("<knowledge-snapshot>(no scopes detected)</knowledge-snapshot>")
@@ -28,17 +32,23 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
     return truncate_preamble("\n".join(parts))
 
 
-async def _list_scopes(workspace_id: str) -> list[str]:
-    """Best-effort scope listing. Returns ``[]`` when no reachable backend.
+async def _list_scopes(workspace_id: str, user_id: str) -> list[str]:
+    """Resolve the workspace's real KB scopes via the canonical service.
 
-    The kb stack is optional in some deploys — we'd rather emit a
-    placeholder than crash. The canonical hook would be
-    ``KnowledgeService.list_scopes(workspace_id)`` once that surface
-    lands; until then a static workspace scope is the safest output.
+    Failures are isolated — the kb stack is optional in some deploys and
+    a probe outage must never crash the preamble. We log and fall back
+    to ``[]`` so the handler renders ``(no scopes detected)`` instead.
     """
     if not workspace_id:
         return []
-    return [f"workspace:{workspace_id}"]
+    try:
+        return await kb_service.list_scopes(workspace_id, user_id)
+    except Exception:
+        logger.exception(
+            "kb_service.list_scopes failed for workspace=%s; emitting empty list",
+            workspace_id,
+        )
+        return []
 
 
 __all__ = ["build_preamble"]

--- a/tests/cloud/kb/test_service.py
+++ b/tests/cloud/kb/test_service.py
@@ -1,0 +1,163 @@
+# tests/cloud/kb/test_service.py — Workspace KB scope listing service.
+#
+# Created: 2026-05-24 — Covers ``kb.service.list_scopes`` with an
+# in-memory kb_list shim. Four guarantees:
+#   1. A workspace with one pocket + one agent + workspace-level
+#      articles returns all three scopes when the shim says they
+#      all have content.
+#   2. Scopes the shim reports as empty are filtered out.
+#   3. Cross-workspace stamping (calling with a workspace id the user
+#      doesn't belong to) returns no pocket scopes — the underlying
+#      ``pockets_service.list_pockets`` filter already enforces tenant
+#      isolation, and the service must not synthesize anything past it.
+#   4. A blank ``workspace_id`` short-circuits to ``[]`` — we never
+#      probe an unkeyed scope.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.agents import service as agents_service
+from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest
+from pocketpaw_ee.cloud.kb import service as kb_service
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+WORKSPACE = "ws-kb-scopes"
+OTHER_WORKSPACE = "ws-kb-other"
+
+
+async def _seed_user(email: str = "owner@kb.test", workspace: str = WORKSPACE) -> str:
+    doc = _UserDoc(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="KB Owner",
+        active_workspace=workspace,
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+def _ctx(user_id: str, workspace_id: str) -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r-kb",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _kb_list_with(populated: set[str]):
+    """Build a kb_list shim where the given scope strings carry one row.
+
+    Mirrors the kb-go subprocess contract: returns a list of rows or
+    ``[]``. One row per scope is enough — ``list_scopes`` only checks
+    "is the list non-empty" before keeping the scope.
+    """
+
+    def _shim(scope: str) -> list[dict]:
+        if scope in populated:
+            return [{"id": f"art-{scope}", "title": "x"}]
+        return []
+
+    return _shim
+
+
+async def test_list_scopes_returns_workspace_pocket_agent_scopes() -> None:
+    """Happy path — every populated scope appears, in workspace→pocket→agent order."""
+    user_id = await _seed_user()
+    pocket = await pockets_service.create(WORKSPACE, user_id, CreatePocketRequest(name="Sales"))
+    agent = await agents_service.create(
+        _ctx(user_id, WORKSPACE),
+        WORKSPACE,
+        CreateAgentRequest(name="Helper", slug="helper-kb"),
+    )
+
+    pocket_scope = f"pocket:{pocket['_id']}"
+    agent_scope = f"agent:{agent.id}"
+    workspace_scope = f"workspace:{WORKSPACE}"
+
+    scopes = await kb_service.list_scopes(
+        WORKSPACE,
+        user_id,
+        kb_list=_kb_list_with({workspace_scope, pocket_scope, agent_scope}),
+    )
+
+    assert scopes == [workspace_scope, pocket_scope, agent_scope]
+
+
+async def test_list_scopes_filters_out_empty_scopes() -> None:
+    """A candidate scope with no kb articles must not appear in the result."""
+    user_id = await _seed_user("owner-filter@kb.test")
+    pocket = await pockets_service.create(WORKSPACE, user_id, CreatePocketRequest(name="Drafts"))
+    # Create an agent but leave its scope empty — should NOT appear.
+    await agents_service.create(
+        _ctx(user_id, WORKSPACE),
+        WORKSPACE,
+        CreateAgentRequest(name="Idle", slug="idle-kb"),
+    )
+
+    pocket_scope = f"pocket:{pocket['_id']}"
+    workspace_scope = f"workspace:{WORKSPACE}"
+
+    # Only workspace + pocket populated — agent scope is silent.
+    scopes = await kb_service.list_scopes(
+        WORKSPACE,
+        user_id,
+        kb_list=_kb_list_with({workspace_scope, pocket_scope}),
+    )
+
+    assert workspace_scope in scopes
+    assert pocket_scope in scopes
+    assert all(not s.startswith("agent:") for s in scopes)
+
+
+async def test_list_scopes_blocks_cross_workspace_pocket_reads() -> None:
+    """Stamping the wrong workspace id returns no pocket/agent scopes.
+
+    The same user owns a pocket in ``OTHER_WORKSPACE``; calling
+    ``list_scopes`` with ``WORKSPACE`` must not surface that pocket's
+    scope. The pockets service's ``workspace`` filter is what enforces
+    this; the test pins that the kb service relies on it correctly.
+    """
+    user_id = await _seed_user("owner-cross@kb.test")
+    other_pocket = await pockets_service.create(
+        OTHER_WORKSPACE, user_id, CreatePocketRequest(name="Other-Workspace Pocket")
+    )
+
+    # The shim says BOTH the other pocket's scope and our workspace
+    # scope have content. If the service forgets the workspace filter
+    # it'll happily include the cross-workspace pocket.
+    other_pocket_scope = f"pocket:{other_pocket['_id']}"
+    scopes = await kb_service.list_scopes(
+        WORKSPACE,
+        user_id,
+        kb_list=_kb_list_with({f"workspace:{WORKSPACE}", other_pocket_scope}),
+    )
+
+    assert other_pocket_scope not in scopes
+    # The workspace scope itself is fine — we asked for WORKSPACE's.
+    assert f"workspace:{WORKSPACE}" in scopes
+
+
+async def test_list_scopes_blank_workspace_returns_empty() -> None:
+    """Blank ``workspace_id`` short-circuits to ``[]`` without probing."""
+
+    probed: list[str] = []
+
+    def _spy(scope: str) -> list[dict]:
+        probed.append(scope)
+        return [{"id": "x"}]
+
+    scopes = await kb_service.list_scopes("", "u-1", kb_list=_spy)
+
+    assert scopes == []
+    assert probed == []  # never reached the probe

--- a/tests/cloud/kb/test_service.py
+++ b/tests/cloud/kb/test_service.py
@@ -1,5 +1,10 @@
 # tests/cloud/kb/test_service.py — Workspace KB scope listing service.
 #
+# Updated: 2026-05-24 — Added ``test_list_scopes_caps_concurrent_probes``
+# proving the new ``_PROBE_CONCURRENCY`` semaphore actually bounds the
+# parallel kb-go probe fan-out. Seeds 50 fake candidate scopes via
+# monkeypatch and observes peak in-flight probe count under a lock.
+#
 # Created: 2026-05-24 — Covers ``kb.service.list_scopes`` with an
 # in-memory kb_list shim. Four guarantees:
 #   1. A workspace with one pocket + one agent + workspace-level
@@ -15,6 +20,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 
 import pytest
@@ -161,3 +167,53 @@ async def test_list_scopes_blank_workspace_returns_empty() -> None:
 
     assert scopes == []
     assert probed == []  # never reached the probe
+
+
+async def test_list_scopes_caps_concurrent_probes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The probe fan-out must stay bounded by ``_PROBE_CONCURRENCY``.
+
+    Reviewer-flagged P1: unbounded ``asyncio.gather`` on a 100-pocket +
+    50-agent workspace would spawn 151 concurrent kb-go subprocesses
+    even though the default-executor thread pool can only service ~32
+    at a time. The fix is a semaphore around ``_probe_scope``; this
+    test seeds 50 fake candidate scopes, has each probe announce its
+    in-flight status under a lock, and asserts the observed peak never
+    exceeds the cap.
+    """
+    candidates = [f"pocket:p-{i}" for i in range(50)]
+
+    async def _fake_candidates(_workspace_id: str, _user_id: str) -> list[str]:
+        return candidates
+
+    monkeypatch.setattr(kb_service, "_candidate_scopes", _fake_candidates)
+
+    in_flight = 0
+    peak = 0
+    lock = asyncio.Lock()
+
+    async def _probe(scope: str) -> list[dict]:
+        nonlocal in_flight, peak
+        async with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        # Yield so other gated tasks can attempt the semaphore — without
+        # an await the whole coroutine completes synchronously and the
+        # peak collapses to 1.
+        await asyncio.sleep(0.01)
+        async with lock:
+            in_flight -= 1
+        return [{"id": f"art-{scope}"}]
+
+    scopes = await kb_service.list_scopes("ws-cap", "u-cap", kb_list=_probe)
+
+    assert len(scopes) == len(candidates), "every populated probe should keep its scope"
+    assert peak <= kb_service._PROBE_CONCURRENCY, (
+        f"observed peak in-flight {peak} exceeded cap {kb_service._PROBE_CONCURRENCY}"
+    )
+    # Cap actually engaged — if peak is 1 we proved nothing about the
+    # semaphore. With 50 candidates and a 10ms sleep, the loop must
+    # have saturated the semaphore at least once.
+    assert peak == kb_service._PROBE_CONCURRENCY, (
+        f"probe fan-out never reached the cap (peak={peak}); "
+        "the test is no longer exercising the gate"
+    )

--- a/tests/cloud/surface/test_knowledge_handler.py
+++ b/tests/cloud/surface/test_knowledge_handler.py
@@ -1,0 +1,140 @@
+# tests/cloud/surface/test_knowledge_handler.py — /knowledge surface handler.
+#
+# Created: 2026-05-24 — Pins three guarantees on the knowledge surface
+# preamble once it stopped synthesizing a single ``workspace:<id>`` scope
+# and started reading the real scope list through ``kb.service``:
+#   1. Happy path — a workspace with one pocket + workspace-level KB
+#      articles surfaces both scope strings in the preamble.
+#   2. Empty — a fresh workspace with no kb-routed articles emits the
+#      ``(no scopes detected)`` snapshot, never a bare ``workspace:<id>``.
+#   3. Cross-workspace guard — stamping with another workspace's id
+#      surfaces no pocket / agent identifiers belonging to that
+#      workspace, only ever that workspace's own scope (if populated).
+#
+# The kb-go backend isn't installed on the test runner, so every test
+# monkeypatches ``kb_service.list_scopes`` with an in-memory shim. The
+# tests still exercise the handler-side branching (empty / non-empty
+# rendering) end-to-end.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers import knowledge as knowledge_handler
+
+WORKSPACE = "ws-knowledge-handler"
+OTHER_WORKSPACE = "ws-knowledge-other"
+USER = "u-knowledge"
+
+
+async def test_knowledge_handler_lists_populated_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Workspace + pocket scopes appear in the preamble when both have articles."""
+    workspace_scope = f"workspace:{WORKSPACE}"
+    pocket_scope = "pocket:p-001"
+
+    async def _fake_list_scopes(workspace_id: str, user_id: str) -> list[str]:
+        # Pin the call shape — handler must forward workspace_id + user_id.
+        assert workspace_id == WORKSPACE
+        assert user_id == USER
+        return [workspace_scope, pocket_scope]
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.surface.handlers.knowledge.kb_service.list_scopes",
+        _fake_list_scopes,
+    )
+
+    preamble = await knowledge_handler.build_preamble(WORKSPACE, USER, SurfaceMeta())
+
+    assert '<surface kind="knowledge"' in preamble
+    assert '<knowledge-scopes count="2"' in preamble
+    assert f"- {workspace_scope}" in preamble
+    assert f"- {pocket_scope}" in preamble
+    # The placeholder branch must NOT fire when real scopes are present.
+    assert "(no scopes detected)" not in preamble
+
+
+async def test_knowledge_handler_empty_workspace_renders_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A workspace with no kb-routed articles emits the empty snapshot.
+
+    The synthetic ``workspace:<id>`` fallback the handler used to ship
+    is gone — an empty scope list MUST render the ``(no scopes
+    detected)`` block instead so the agent knows the kb is empty rather
+    than thinking it has one scope to read from.
+    """
+
+    async def _empty(workspace_id: str, user_id: str) -> list[str]:  # noqa: ARG001
+        return []
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.surface.handlers.knowledge.kb_service.list_scopes",
+        _empty,
+    )
+
+    preamble = await knowledge_handler.build_preamble(WORKSPACE, USER, SurfaceMeta())
+
+    assert '<surface kind="knowledge"' in preamble
+    assert "(no scopes detected)" in preamble
+    # The synthetic fallback is gone — workspace_id must not appear in a
+    # ``workspace:<id>`` row when the service reported no real scopes.
+    assert f"workspace:{WORKSPACE}" not in preamble
+    assert "<knowledge-scopes" not in preamble
+
+
+async def test_knowledge_handler_cross_workspace_stamp_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stamping a foreign workspace id returns the empty snapshot.
+
+    The kb service filters pockets through ``list_pockets`` (workspace
+    + visibility gate), so when the caller stamps a workspace id that
+    the user isn't part of, the service returns ``[]`` — and the
+    handler renders the placeholder. The test simulates that contract
+    by having the shim return ``[]`` for the foreign workspace.
+    """
+    leaked_pocket_scope = "pocket:leaked-from-other-workspace"
+
+    async def _foreign(workspace_id: str, user_id: str) -> list[str]:  # noqa: ARG001
+        # The service would return ``[]`` because list_pockets filters
+        # on workspace; the shim mirrors that — no leakage, even though
+        # this test "knows" the other-workspace pocket exists.
+        if workspace_id == OTHER_WORKSPACE:
+            return []
+        return [f"workspace:{workspace_id}"]
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.surface.handlers.knowledge.kb_service.list_scopes",
+        _foreign,
+    )
+
+    preamble = await knowledge_handler.build_preamble(OTHER_WORKSPACE, USER, SurfaceMeta())
+
+    assert "(no scopes detected)" in preamble
+    assert leaked_pocket_scope not in preamble
+
+
+async def test_knowledge_handler_isolates_service_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the kb service raises, the handler renders the placeholder.
+
+    Defensive isolation — the surface preamble must never crash the
+    chat send. A missing kb binary or a transient subprocess timeout
+    has to degrade to the placeholder instead of bubbling up.
+    """
+
+    async def _boom(workspace_id: str, user_id: str) -> list[str]:  # noqa: ARG001
+        raise RuntimeError("kb binary not found")
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.surface.handlers.knowledge.kb_service.list_scopes",
+        _boom,
+    )
+
+    preamble = await knowledge_handler.build_preamble(WORKSPACE, USER, SurfaceMeta())
+
+    assert '<surface kind="knowledge"' in preamble
+    assert "(no scopes detected)" in preamble


### PR DESCRIPTION
## Summary

The `/knowledge` surface preamble used to render a hardcoded `workspace:{id}` row because there was no canonical helper for "what KB scopes does this workspace actually have." This adds `kb.service.list_scopes(workspace_id, user_id)` and wires the handler through it, so the agent sees the real workspace + pocket + agent scopes the kb-go store carries.

## What changed

- New `ee/pocketpaw_ee/cloud/kb/service.py` — `async def list_scopes(workspace_id, user_id, *, kb_list=None)`. Enumerates candidate scopes from the workspace itself, every pocket the caller can see (via `pockets_service.list_pockets`), and every agent in the workspace (via `agents_service.list_agents`). Probes each candidate in parallel through a `kb_list` shim that defaults to the existing kb-go `list --scope` wrapper, and keeps only the populated ones.
- Updated `ee/pocketpaw_ee/cloud/surface/handlers/knowledge.py` — drops the synthetic `workspace:{id}` fallback, calls the new service, isolates exceptions so the chat send never breaks on a missing kb binary. The `(no scopes detected)` block still fires for the empty path.

Tenant isolation falls out of the underlying service filters: `list_pockets` already gates by `workspace + owner/shared_with/visibility`, and `list_agents` is workspace-pinned at the source. A stamp pointing at a workspace the caller doesn't belong to returns `[]`, and the preamble renders `(no scopes detected)`.

## Test plan

- [x] `tests/cloud/kb/test_service.py` — happy path (workspace + pocket + agent), empty-scope filtering, cross-workspace guard, blank workspace short-circuit.
- [x] `tests/cloud/surface/test_knowledge_handler.py` — populated scopes render, empty scopes render the placeholder, cross-workspace stamp returns empty, service exception is isolated.
- [x] All 20 `tests/cloud/surface/` tests pass — no regression.
- [x] `ruff check` + `ruff format --check` clean on the touched files.
- [x] `lint-imports` on both the OSS root contract and the ee contract — 17 contracts kept, 0 broken (the new service goes through `pockets.service` and `agents.service` rather than touching Beanie docs directly).

Closes #1213