### PR TITLE
feat(calendar): land canonical entity for upcoming-events surface block

### DIFF
--- a/ee/pocketpaw_ee/calendar/__init__.py
+++ b/ee/pocketpaw_ee/calendar/__init__.py
@@ -1,8 +1,16 @@
 # Calendar module — public surface.
 # Created: 2026-05-19 (feat/calendar-module).
+# Updated: 2026-05-24 (feat/calendar-entity-surface, #1218) — added the
+# sibling-module pointer to ``pocketpaw_ee.cloud.calendar`` so future
+# contributors looking for "the calendar code" find both modules.
 #
 # Re-exports the router and public domain types. Beanie documents
 # (_EventDoc, _CalendarDoc) stay private — never re-exported.
+#
+# For the surface-preamble read-adapter that proxies upcoming events
+# into the chat agent's per-turn context, see
+# ``pocketpaw_ee.cloud.calendar`` (separate module — different role,
+# different code).
 
 from pocketpaw_ee.calendar.domain import (
     Attendee,

--- a/ee/pocketpaw_ee/cloud/calendar/__init__.py
+++ b/ee/pocketpaw_ee/cloud/calendar/__init__.py
@@ -1,0 +1,20 @@
+# __init__.py — Public surface for the cloud calendar entity.
+#
+# Created: 2026-05-24 (feat/calendar-entity-surface, #1214) — the
+# cloud-side calendar entity is a thin read-only adapter that surfaces
+# upcoming events from external providers (today: Composio →
+# Google Calendar) into the surface preamble. Distinct from the native
+# scheduling subsystem under ``ee/pocketpaw_ee/calendar/`` — that one
+# owns events, attendees, recurrence and free/busy as first-class
+# entities; this one is a thin entity that the surface handler reads.
+#
+# Re-exports the public domain value object and the read service. No
+# router — the surface handler is the only consumer for now.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.calendar.domain import CalendarEvent
+from pocketpaw_ee.cloud.calendar.dto import CalendarEventResponse
+from pocketpaw_ee.cloud.calendar.service import list_upcoming
+
+__all__ = ["CalendarEvent", "CalendarEventResponse", "list_upcoming"]

--- a/ee/pocketpaw_ee/cloud/calendar/domain.py
+++ b/ee/pocketpaw_ee/cloud/calendar/domain.py
@@ -1,0 +1,57 @@
+# domain.py — Cloud calendar entity value objects.
+#
+# Created: 2026-05-24 (feat/calendar-entity-surface, #1214) — frozen
+# dataclass with workspace_id required at construction. Mirrors the
+# ee/cloud rule: domain enforces multi-tenancy at construction time so
+# the workspace tag is impossible to forget. Field order keeps
+# workspace_id first after id, so any positional construction lands
+# tenancy in front; missing workspace_id is a TypeError, not silent.
+#
+# ISO-string start/end (not datetime). The data flows in from Composio
+# as JSON strings (Google Calendar returns RFC 3339 timestamps) and
+# flows back out to the surface preamble as strings — there's no
+# date math in the read path, so parsing the strings would be pure
+# overhead. Domain stays as plain pass-through value objects.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class CalendarEvent:
+    """A single upcoming calendar event scoped to a workspace.
+
+    Tenancy is enforced at construction — ``workspace_id`` is required
+    positionally with no default. Constructing a ``CalendarEvent``
+    without one is a TypeError. Same rule as the rest of ``ee/cloud``.
+
+    Fields:
+      * ``id`` — the upstream provider's event id (Google Calendar
+        event id when sourced from Composio).
+      * ``workspace_id`` — owning workspace. Tagged at construction so
+        downstream code can fan out events across workspaces without
+        accidentally bleeding one tenant into another.
+      * ``title`` — event title (Google Calendar ``summary``). Defaults
+        only to a placeholder when the upstream payload omits it.
+      * ``start`` / ``end`` — ISO 8601 strings. RFC 3339 ``dateTime``
+        when the event has a time component; date-only ``YYYY-MM-DD``
+        when the event is all-day. Empty string when missing upstream.
+      * ``attendees`` — list of email strings. Optional; defaults to
+        an empty list. Each entry is the raw email — no normalization
+        is applied at this layer (downstream services may dedupe).
+      * ``source`` — upstream system slug (e.g. ``"google"``, ``"ical"``).
+        Distinct from "the connector" so future providers can ship
+        without renaming the field.
+    """
+
+    id: str
+    workspace_id: str
+    title: str
+    start: str
+    end: str
+    source: str
+    attendees: list[str] = field(default_factory=list)
+
+
+__all__ = ["CalendarEvent"]

--- a/ee/pocketpaw_ee/cloud/calendar/dto.py
+++ b/ee/pocketpaw_ee/cloud/calendar/dto.py
@@ -1,0 +1,38 @@
+# dto.py — Cloud calendar entity response schema.
+#
+# Created: 2026-05-24 (feat/calendar-entity-surface, #1214) — Pydantic
+# response model for the wire shape. Kept separate from the domain per
+# the ee/cloud rule "DTOs separate request and response" (#4) — even
+# though we have no request type yet, the response stays in its own
+# file so the surface mirrors the canonical entity layout (pockets,
+# cycles, etc.) and future read-filter DTOs land beside it.
+#
+# No request schema — ``list_upcoming`` takes scalar parameters
+# (workspace_id / user_id / limit) rather than a request body. If a
+# future caller needs a richer filter (date range, calendar id),
+# introduce ``ListUpcomingRequest`` here at that point.
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CalendarEventResponse(BaseModel):
+    """Wire shape of a single calendar event surfaced to the agent.
+
+    Mirrors the ``CalendarEvent`` domain object 1-to-1 — no field
+    renames or transforms. Kept as a distinct Pydantic model so the
+    HTTP wire contract stays stable independent of how the in-process
+    domain object evolves.
+    """
+
+    id: str
+    workspace_id: str
+    title: str
+    start: str  # ISO 8601 (RFC 3339 datetime or YYYY-MM-DD date)
+    end: str
+    source: str
+    attendees: list[str] = Field(default_factory=list)
+
+
+__all__ = ["CalendarEventResponse"]

--- a/ee/pocketpaw_ee/cloud/calendar/service.py
+++ b/ee/pocketpaw_ee/cloud/calendar/service.py
@@ -1,0 +1,254 @@
+# service.py — Cloud calendar entity service.
+#
+# Created: 2026-05-24 (feat/calendar-entity-surface, #1214) —
+# ``list_upcoming(workspace_id, user_id, limit=10)`` returns wire dicts
+# for the next N events on the user's connected calendar. Reads only;
+# no Beanie touches; no router.
+#
+# Today's data path:
+#   1. Gate on ``composio_service.is_enabled()``. If Composio isn't
+#      configured, return ``[]`` quietly so the surface handler can
+#      fall back to its hint text.
+#   2. Build the namespaced ``user_id`` via ``composio_user_id`` so
+#      cross-tenant calls collide at the Composio layer (defense in
+#      depth — the ``workspace_id`` filter at our layer is the primary
+#      guard).
+#   3. Call ``GOOGLECALENDAR_LIST_EVENTS`` through ``tools.execute``.
+#      The action wraps Google's standard ``events.list`` endpoint;
+#      we pass ``maxResults`` so the upstream limit matches ours.
+#   4. Parse Google's response shape (``items[]`` with ``start.dateTime``
+#      / ``start.date`` etc.), tag every event with the requesting
+#      ``workspace_id`` at construction time, and emit wire dicts.
+#
+# Failure modes — all degrade to ``[]`` (never raise to the handler):
+#   * Composio disabled                                 → ``[]``
+#   * SDK missing                                       → ``[]``
+#   * User hasn't connected a calendar                  → ``[]``
+#   * Upstream timeout / 5xx / parse error              → ``[]``
+#   * Cross-workspace query (workspace_id empty)        → ``ValidationError``
+#
+# The handler always sees a list — it decides whether to render the
+# events block or the Composio hint based on len(events). The only
+# raised error is the tenancy guard (the same pattern other cloud
+# services use to refuse a missing workspace).
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.calendar.domain import CalendarEvent
+from pocketpaw_ee.cloud.calendar.dto import CalendarEventResponse
+
+logger = logging.getLogger(__name__)
+
+
+# Composio action slug for Google Calendar's events.list. Pinned here so
+# the action name has a single canonical home — if the upstream slug
+# ever renames, this is the one line to update.
+_GOOGLECALENDAR_LIST_EVENTS = "GOOGLECALENDAR_LIST_EVENTS"
+
+# Source tag stamped onto every event the Composio path produces.
+# Independent of the toolkit slug so future providers (ical, outlook)
+# can be added without renaming the field.
+_SOURCE_GOOGLE = "google"
+
+
+async def list_upcoming(workspace_id: str, user_id: str, limit: int = 10) -> list[dict[str, Any]]:
+    """Return wire dicts of the user's next ``limit`` calendar events.
+
+    Read-only — no writes, no events emitted. Workspace-scoped: each
+    event domain object is tagged with ``workspace_id`` at construction
+    so the caller can fan results across workspaces without crossing
+    tenancy. Empty list is the graceful-degradation signal — the caller
+    decides what to render when nothing comes back.
+
+    Raises ``ValidationError`` only when ``workspace_id`` is empty or
+    ``limit`` is non-positive. All other failure modes (Composio
+    disabled, SDK missing, upstream error, parse failure) return ``[]``
+    so the surface handler can fall back to its hint text without
+    needing to catch.
+    """
+    # Tenancy + bounds guard — refuse to issue the call when the basic
+    # invariants aren't met. Mirrors the pattern other cloud services
+    # use (validate-at-entry per Rule 6 of the entity rules).
+    if not workspace_id:
+        raise ValidationError(
+            "calendar.workspace_required",
+            "workspace_id is required for calendar reads",
+        )
+    if not user_id:
+        raise ValidationError(
+            "calendar.user_required",
+            "user_id is required for calendar reads",
+        )
+    if limit <= 0:
+        raise ValidationError(
+            "calendar.invalid_limit",
+            "limit must be a positive integer",
+        )
+
+    # Lazy import composio service — it pulls the upstream SDK behind
+    # ``_get_client`` and we want a fast-path "disabled" return without
+    # paying the import cost on cold paths.
+    try:
+        from pocketpaw_ee.cloud.composio import service as composio_service
+    except Exception:
+        logger.debug("calendar.list_upcoming: composio service import failed", exc_info=True)
+        return []
+
+    if not composio_service.is_enabled():
+        # Composio not configured at all — the handler will render the
+        # static hint instead. No error: this is the expected state for
+        # any deploy that hasn't wired Composio yet.
+        return []
+
+    # Build a RequestContext so ``composio_user_id`` can namespace the
+    # call the same way every other Composio-using surface does. The
+    # context never leaves this function — it's a transport-layer shim.
+    ctx = RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="calendar-list-upcoming",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+    try:
+        namespaced = composio_service.composio_user_id(ctx)
+        client = await composio_service._get_client()
+    except Exception:
+        # Most likely paths: ValidationError (composio.disabled raced
+        # is_enabled), Internal (sdk_missing). Either way: graceful empty.
+        logger.debug("calendar.list_upcoming: composio init failed", exc_info=True)
+        return []
+
+    # Cap the upstream limit at our limit. Composio honors maxResults
+    # as a hint; if the upstream returns more we still trim below.
+    args = {"maxResults": int(limit)}
+
+    try:
+        result = await asyncio.to_thread(
+            _execute_list_events_sync,
+            client,
+            _GOOGLECALENDAR_LIST_EVENTS,
+            str(namespaced),
+            args,
+        )
+    except Exception:
+        # Network errors, "no connected account" errors from Composio,
+        # 5xx from Google — all degrade to empty. The handler renders
+        # its fallback hint and the chat continues.
+        logger.debug("calendar.list_upcoming: GOOGLECALENDAR_LIST_EVENTS failed", exc_info=True)
+        return []
+
+    items = _extract_items(result)
+    events: list[CalendarEvent] = []
+    for raw in items[:limit]:
+        event = _event_from_google_item(raw, workspace_id=workspace_id)
+        if event is not None:
+            events.append(event)
+
+    # Pydantic round-trip: domain → response → dict. Same shape as the
+    # canonical pockets/cycles wire path (Rule 8: mapping via Pydantic,
+    # not hand-rolled helpers).
+    return [
+        CalendarEventResponse.model_validate(ev, from_attributes=True).model_dump() for ev in events
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Composio helpers — private to this module.
+# ---------------------------------------------------------------------------
+
+
+def _execute_list_events_sync(
+    client: Any, action: str, user_id: str, arguments: dict[str, Any]
+) -> Any:
+    """Synchronous wrapper for ``client.tools.execute`` — for ``to_thread``.
+
+    Composio's ``tools.execute`` is a blocking call in every SDK
+    version we ship against; running it on the event loop would freeze
+    the chat path for the duration of the upstream round-trip. We
+    delegate to the default executor exactly like the identity probe
+    does (see ``composio/identity.py::probe_identity_sync``).
+    """
+    return client.tools.execute(action, user_id=user_id, arguments=arguments)
+
+
+def _extract_items(result: Any) -> list[dict[str, Any]]:
+    """Pull the ``items`` array out of Composio's response envelope.
+
+    Composio wraps results as either ``{"data": {...}, "successful":
+    True}`` or a pydantic model with those same attrs depending on
+    minor SDK version. We tolerate both and fall back to an empty
+    list on any unexpected shape — the caller treats that the same
+    as "no events".
+    """
+    data: Any = None
+    if isinstance(result, dict):
+        data = result.get("data")
+    else:
+        data = getattr(result, "data", None)
+        if data is None and hasattr(result, "model_dump"):
+            try:
+                dumped = result.model_dump()
+            except Exception:  # noqa: BLE001
+                return []
+            if isinstance(dumped, dict):
+                data = dumped.get("data") or dumped
+
+    if isinstance(data, dict):
+        items = data.get("items")
+        if isinstance(items, list):
+            return [item for item in items if isinstance(item, dict)]
+    return []
+
+
+def _event_from_google_item(raw: dict[str, Any], *, workspace_id: str) -> CalendarEvent | None:
+    """Build a tenant-tagged ``CalendarEvent`` from one Google API item.
+
+    Returns ``None`` when the upstream payload is missing the bare
+    minimum we need (``id``) — better to skip a single bad row than
+    surface a partial event with confusing fields. ``start`` /
+    ``end`` collapse Google's date vs dateTime variants into a single
+    string field (the date or the dateTime, whichever is present).
+    """
+    event_id = raw.get("id")
+    if not isinstance(event_id, str) or not event_id:
+        return None
+
+    start_raw = raw.get("start") or {}
+    end_raw = raw.get("end") or {}
+    start = ""
+    end = ""
+    if isinstance(start_raw, dict):
+        start = str(start_raw.get("dateTime") or start_raw.get("date") or "")
+    if isinstance(end_raw, dict):
+        end = str(end_raw.get("dateTime") or end_raw.get("date") or "")
+
+    attendees_raw = raw.get("attendees") or []
+    attendees: list[str] = []
+    if isinstance(attendees_raw, list):
+        for a in attendees_raw:
+            if isinstance(a, dict):
+                email = a.get("email")
+                if isinstance(email, str) and email:
+                    attendees.append(email)
+
+    return CalendarEvent(
+        id=event_id,
+        workspace_id=workspace_id,
+        title=str(raw.get("summary") or "(no title)"),
+        start=start,
+        end=end,
+        source=_SOURCE_GOOGLE,
+        attendees=attendees,
+    )
+
+
+__all__ = ["list_upcoming"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/calendar.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/calendar.py
@@ -1,22 +1,120 @@
 # calendar.py — /calendar surface preamble.
 #
-# Created: 2026-05-24 — Placeholder while the calendar entity is still
-# in flight. Emits the surface tag so the agent knows the route and
-# notes that no live snapshot is available yet — the agent then knows
-# to use Composio's GOOGLECALENDAR_LIST_EVENTS rather than guess.
+# Updated: 2026-05-24 (feat/calendar-entity-surface, #1214) — replaced
+# the static placeholder with a live read against
+# ``cloud.calendar.list_upcoming``. The handler now renders a
+# ``<calendar-snapshot count="N">`` block listing each upcoming event
+# compactly so the agent can quote them directly. Three rendering
+# branches:
+#
+#   1. Events present — render one line per event ("- 10:30 AM ·
+#      Sync with Sarah") inside the snapshot block.
+#   2. No events (Composio enabled, calendar connected, just empty) —
+#      render "(no upcoming events)".
+#   3. Service raised or returned empty for any reason (Composio
+#      disabled, not connected, upstream error) — render the original
+#      Composio hint so the agent still knows the available tool.
+#
+# Surface tag is always emitted so the agent always knows which route
+# the user is on, regardless of which branch above ran.
 
 from __future__ import annotations
 
+import logging
+from datetime import datetime
+from typing import Any
+
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers._helpers import truncate_preamble
+
+logger = logging.getLogger(__name__)
+
+# Cap on how many events we list inline. 10 keeps the preamble well
+# under the per-handler 1500-char soft cap even on dense calendars.
+LIST_LIMIT = 10
+
+# Static block emitted whenever no live data is available — Composio
+# disabled, calendar not connected, service errored. Mirrors the
+# pre-#1214 placeholder so the agent still discovers the action.
+_COMPOSIO_HINT = (
+    "<calendar-snapshot>(no live event feed wired — use "
+    "GOOGLECALENDAR_LIST_EVENTS via Composio if available)</calendar-snapshot>"
+)
+
+_SURFACE_TAG = '<surface kind="calendar" route="/calendar" />'
 
 
 async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
-    """Render the calendar-surface preamble."""
-    return (
-        '<surface kind="calendar" route="/calendar" />\n'
-        "<calendar-snapshot>(no live event feed wired — use "
-        "GOOGLECALENDAR_LIST_EVENTS via Composio if available)</calendar-snapshot>"
+    """Render the calendar-surface preamble.
+
+    Always returns a usable string — never raises. The chat path drops
+    surface failures silently, but we belt-and-braces it here so a
+    quick local error doesn't cost a network round-trip on every send.
+    """
+    try:
+        from pocketpaw_ee.cloud.calendar.service import list_upcoming
+
+        events = await list_upcoming(workspace_id, user_id, limit=LIST_LIMIT)
+    except Exception:
+        logger.debug("calendar_handler: list_upcoming raised", exc_info=True)
+        return truncate_preamble(f"{_SURFACE_TAG}\n{_COMPOSIO_HINT}")
+
+    if not events:
+        # No events AND no error — could be empty calendar or Composio
+        # disabled. Either way, fall back to the hint so the agent
+        # knows what tool to reach for if the user asks.
+        return truncate_preamble(f"{_SURFACE_TAG}\n{_COMPOSIO_HINT}")
+
+    rows = [_format_event_line(ev) for ev in events[:LIST_LIMIT]]
+    snapshot = (
+        f'<calendar-snapshot count="{len(events)}">\n' + "\n".join(rows) + "\n</calendar-snapshot>"
     )
+    return truncate_preamble(f"{_SURFACE_TAG}\n{snapshot}")
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers — private to this handler.
+# ---------------------------------------------------------------------------
+
+
+def _format_event_line(event: dict[str, Any]) -> str:
+    """Format one event for the snapshot block.
+
+    Target shape: ``- 10:30 AM · Sync with Sarah``. Falls back to the
+    raw ISO string when ``start`` can't be parsed — better to show
+    something than nothing. Title is collapsed to the first line if
+    the upstream stores a multi-line summary.
+    """
+    title = str(event.get("title") or "(no title)").strip().splitlines()[0]
+    start_raw = str(event.get("start") or "")
+    when = _format_start_time(start_raw)
+    if when:
+        return f"- {when} · {title}"
+    return f"- {title}"
+
+
+def _format_start_time(iso: str) -> str:
+    """Render a start timestamp into a human-friendly time-of-day.
+
+    Returns an empty string when ``iso`` is empty or can't be parsed,
+    or the date when the event is all-day (date-only ISO). Hour formatting
+    is locale-naive but stable: ``10:30 AM``, ``2:00 PM``.
+    """
+    if not iso:
+        return ""
+    # All-day events arrive as ``YYYY-MM-DD`` (no T). Surface those as the
+    # date itself — there's no time-of-day to render.
+    if "T" not in iso:
+        return iso
+    try:
+        # ``fromisoformat`` accepts both naive and aware ISO strings
+        # (the latter as of 3.11 with the ``Z`` suffix normalization
+        # below). Strip the trailing Z to keep older Pythons happy.
+        cleaned = iso.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return iso
+    return dt.strftime("%I:%M %p").lstrip("0")
 
 
 __all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/calendar.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/calendar.py
@@ -1,19 +1,24 @@
 # calendar.py — /calendar surface preamble.
 #
-# Updated: 2026-05-24 (feat/calendar-entity-surface, #1214) — replaced
-# the static placeholder with a live read against
-# ``cloud.calendar.list_upcoming``. The handler now renders a
-# ``<calendar-snapshot count="N">`` block listing each upcoming event
-# compactly so the agent can quote them directly. Three rendering
-# branches:
+# Updated: 2026-05-24 (feat/calendar-entity-surface, #1218) — restored
+# the third rendering state so "Composio off" and "Composio on but no
+# events" no longer collapse to the same hint. Three distinct branches
+# now drive the snapshot block:
 #
 #   1. Events present — render one line per event ("- 10:30 AM ·
 #      Sync with Sarah") inside the snapshot block.
-#   2. No events (Composio enabled, calendar connected, just empty) —
-#      render "(no upcoming events)".
-#   3. Service raised or returned empty for any reason (Composio
-#      disabled, not connected, upstream error) — render the original
-#      Composio hint so the agent still knows the available tool.
+#   2. Composio enabled but no upcoming events — render
+#      ``<calendar-snapshot>(no upcoming events)</calendar-snapshot>``
+#      so the agent knows the integration works and the calendar is
+#      genuinely empty.
+#   3. Composio disabled OR the service raised — render the static
+#      hint pointing at GOOGLECALENDAR_LIST_EVENTS so the agent still
+#      discovers the action and the user can be guided to connect.
+#
+# We probe ``composio_service.is_enabled()`` from the handler (lazy
+# import, same as ``list_upcoming``) to split branches 2 and 3 without
+# changing the service signature — the brief calls this out as the
+# minimum-blast-radius split.
 #
 # Surface tag is always emitted so the agent always knows which route
 # the user is on, regardless of which branch above ran.
@@ -33,13 +38,18 @@ logger = logging.getLogger(__name__)
 # under the per-handler 1500-char soft cap even on dense calendars.
 LIST_LIMIT = 10
 
-# Static block emitted whenever no live data is available — Composio
-# disabled, calendar not connected, service errored. Mirrors the
-# pre-#1214 placeholder so the agent still discovers the action.
+# Static block emitted when Composio isn't configured or the service
+# raised. The hint surfaces the action name so the agent still
+# discovers what tool to reach for when the user asks.
 _COMPOSIO_HINT = (
     "<calendar-snapshot>(no live event feed wired — use "
     "GOOGLECALENDAR_LIST_EVENTS via Composio if available)</calendar-snapshot>"
 )
+
+# Distinct block for the "Composio is on, calendar is connected,
+# nothing on the schedule" case. Keeping this separate from the hint
+# lets the agent tell "no integration" apart from "genuinely empty".
+_EMPTY_SNAPSHOT = "<calendar-snapshot>(no upcoming events)</calendar-snapshot>"
 
 _SURFACE_TAG = '<surface kind="calendar" route="/calendar" />'
 
@@ -60,9 +70,20 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         return truncate_preamble(f"{_SURFACE_TAG}\n{_COMPOSIO_HINT}")
 
     if not events:
-        # No events AND no error — could be empty calendar or Composio
-        # disabled. Either way, fall back to the hint so the agent
-        # knows what tool to reach for if the user asks.
+        # No events AND no error. Two sub-states the agent needs to tell
+        # apart: Composio is on (calendar genuinely empty) vs Composio
+        # is off (no integration at all). Probe is_enabled() to pick.
+        # Lazy import mirrors the list_upcoming pattern above — keeps
+        # the cold-path cheap and the test monkeypatch surface clean.
+        try:
+            from pocketpaw_ee.cloud.composio import service as composio_service
+
+            composio_enabled = composio_service.is_enabled()
+        except Exception:
+            logger.debug("calendar_handler: is_enabled probe failed", exc_info=True)
+            composio_enabled = False
+        if composio_enabled:
+            return truncate_preamble(f"{_SURFACE_TAG}\n{_EMPTY_SNAPSHOT}")
         return truncate_preamble(f"{_SURFACE_TAG}\n{_COMPOSIO_HINT}")
 
     rows = [_format_event_line(ev) for ev in events[:LIST_LIMIT]]

--- a/tests/cloud/calendar/__init__.py
+++ b/tests/cloud/calendar/__init__.py
@@ -1,0 +1,3 @@
+# tests/cloud/calendar — package marker for the cloud calendar entity tests.
+#
+# Created: 2026-05-24 (feat/calendar-entity-surface, #1214).

--- a/tests/cloud/calendar/test_service.py
+++ b/tests/cloud/calendar/test_service.py
@@ -1,0 +1,292 @@
+# tests/cloud/calendar/test_service.py — Cloud calendar service.
+#
+# Created: 2026-05-24 (feat/calendar-entity-surface, #1214) — four
+# guarantees:
+#   1. Composio disabled  → ``[]`` (no SDK touch, no error).
+#   2. Happy path         → events flow through with workspace tagging.
+#   3. Workspace required → empty workspace_id raises ``ValidationError``.
+#   4. Limit parameter    → caps the returned slice even when upstream
+#                            returns more rows than asked for.
+#
+# Tests monkeypatch the composio service boundary
+# (``is_enabled`` / ``_get_client`` / ``composio_user_id``) rather than
+# the upstream SDK — we're testing the calendar adapter's contract,
+# not Composio's wire format. The one place we DO exercise Composio's
+# wire shape is the happy-path test, which feeds a Google-shaped
+# payload through the real parsing helpers.
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.calendar import service as calendar_service
+from pocketpaw_ee.cloud.composio.domain import ComposioUserId
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_composio(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    enabled: bool = True,
+    execute_return: Any = None,
+    execute_side_effect: Exception | None = None,
+) -> MagicMock:
+    """Wire the composio service surface to a controllable double.
+
+    Returns the ``client.tools.execute`` mock so individual tests can
+    assert on how many times it was called and with what arguments.
+    """
+    from pocketpaw_ee.cloud.composio import service as composio_service
+
+    monkeypatch.setattr(composio_service, "is_enabled", lambda *a, **kw: enabled)
+
+    namespaced = ComposioUserId(enterprise_id="ent_test", user_id="user_test")
+    monkeypatch.setattr(
+        composio_service,
+        "composio_user_id",
+        lambda ctx, settings=None: namespaced,
+    )
+
+    execute = MagicMock(name="tools.execute")
+    if execute_side_effect is not None:
+        execute.side_effect = execute_side_effect
+    else:
+        execute.return_value = execute_return
+
+    client = MagicMock(name="composio_client")
+    client.tools.execute = execute
+
+    async def _fake_get_client(settings: Any = None) -> MagicMock:
+        return client
+
+    monkeypatch.setattr(composio_service, "_get_client", _fake_get_client)
+    return execute
+
+
+def _google_event(
+    *,
+    id: str,
+    summary: str,
+    start: str,
+    end: str | None = None,
+    attendees: list[str] | None = None,
+    all_day: bool = False,
+) -> dict[str, Any]:
+    """Build a Google-Calendar-shaped event dict (the ``items[]`` row).
+
+    Mirrors Google's wire format closely enough that the adapter's
+    parser is exercised the same way it would be in production: nested
+    ``start.dateTime`` (or ``start.date`` for all-day), ``attendees``
+    list of ``{"email": ...}`` dicts, ``summary`` for the title.
+    """
+    start_block = {"date": start} if all_day else {"dateTime": start}
+    end_block: dict[str, Any]
+    if end is None:
+        end_block = start_block
+    elif all_day:
+        end_block = {"date": end}
+    else:
+        end_block = {"dateTime": end}
+    item: dict[str, Any] = {
+        "id": id,
+        "summary": summary,
+        "start": start_block,
+        "end": end_block,
+    }
+    if attendees:
+        item["attendees"] = [{"email": e} for e in attendees]
+    return item
+
+
+# ---------------------------------------------------------------------------
+# Tenancy + bounds guards
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_workspace_id_raises_validation_error() -> None:
+    """The first cloud entity rule is "domain enforces tenancy at
+    construction". The service mirrors it: empty workspace_id is a
+    refusal, not a quiet degrade — same pattern other cloud services
+    use to refuse a missing workspace."""
+    with pytest.raises(ValidationError, match="workspace_required"):
+        await calendar_service.list_upcoming("", "user_test", limit=5)
+
+
+async def test_empty_user_id_raises_validation_error() -> None:
+    with pytest.raises(ValidationError, match="user_required"):
+        await calendar_service.list_upcoming("ws_acme", "", limit=5)
+
+
+async def test_non_positive_limit_raises_validation_error() -> None:
+    with pytest.raises(ValidationError, match="invalid_limit"):
+        await calendar_service.list_upcoming("ws_acme", "user_test", limit=0)
+
+
+# ---------------------------------------------------------------------------
+# Composio gating
+# ---------------------------------------------------------------------------
+
+
+async def test_returns_empty_when_composio_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The most common "no data" state: Composio not configured at all.
+    The handler will fall back to its hint; the service stays silent."""
+    execute = _patch_composio(monkeypatch, enabled=False)
+    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=5)
+    assert out == []
+    execute.assert_not_called()
+
+
+async def test_returns_empty_when_upstream_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Network or auth errors from Composio must degrade gracefully —
+    the handler always sees a list, never a raised exception."""
+    _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_side_effect=RuntimeError("composio: no connected account"),
+    )
+    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=5)
+    assert out == []
+
+
+async def test_returns_empty_when_upstream_returns_no_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Composio call succeeded but the user's calendar is empty — same
+    end state as disabled. The handler folds these into one fallback."""
+    _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_return={"data": {"items": []}, "successful": True},
+    )
+    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=5)
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# Happy path + tenancy tagging
+# ---------------------------------------------------------------------------
+
+
+async def test_happy_path_renders_events_with_workspace_tag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Five Google-shaped events flow through: titles, ISO timestamps,
+    attendees, and the workspace tag all land on each wire dict.
+    Implicitly verifies the domain object refuses to be built without
+    workspace_id (it would raise at construction otherwise)."""
+    items = [
+        _google_event(
+            id="ev1",
+            summary="Sync with Sarah",
+            start="2026-05-25T10:30:00-07:00",
+            end="2026-05-25T11:00:00-07:00",
+            attendees=["sarah@example.com", "me@example.com"],
+        ),
+        _google_event(
+            id="ev2",
+            summary="Q2 planning",
+            start="2026-05-26T14:00:00-07:00",
+            end="2026-05-26T15:30:00-07:00",
+        ),
+        _google_event(
+            id="ev3",
+            summary="All-hands",
+            start="2026-05-27",
+            end="2026-05-28",
+            all_day=True,
+        ),
+    ]
+    execute = _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_return={"data": {"items": items}, "successful": True},
+    )
+
+    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=10)
+
+    assert len(out) == 3
+    assert {ev["id"] for ev in out} == {"ev1", "ev2", "ev3"}
+    # Every event carries the requesting workspace_id — tenancy tag
+    # applied at domain construction time, mirrored onto the wire dict.
+    assert all(ev["workspace_id"] == "ws_acme" for ev in out)
+    # Source is the upstream system slug, not the toolkit name.
+    assert all(ev["source"] == "google" for ev in out)
+    # Title flows from Google's ``summary`` field.
+    titles = [ev["title"] for ev in out]
+    assert "Sync with Sarah" in titles
+    # Attendees collapse to plain emails.
+    sarah_event = next(ev for ev in out if ev["id"] == "ev1")
+    assert sarah_event["attendees"] == ["sarah@example.com", "me@example.com"]
+    # All-day event keeps the date-only ISO string in ``start``.
+    allhands = next(ev for ev in out if ev["id"] == "ev3")
+    assert allhands["start"] == "2026-05-27"
+    # The Composio call was made exactly once with the right action.
+    execute.assert_called_once()
+    args, kwargs = execute.call_args
+    assert args[0] == "GOOGLECALENDAR_LIST_EVENTS"
+    assert kwargs["user_id"] == "ent_test:user_test"
+
+
+async def test_skips_items_missing_required_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An upstream payload missing ``id`` is dropped silently — better
+    than fabricating a placeholder that would confuse the agent."""
+    items = [
+        {"id": "ok", "summary": "Valid", "start": {"dateTime": "2026-05-25T10:00:00Z"}},
+        {"summary": "Missing id", "start": {"dateTime": "2026-05-25T11:00:00Z"}},
+        {"id": "", "summary": "Empty id"},
+    ]
+    _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_return={"data": {"items": items}, "successful": True},
+    )
+    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=10)
+    assert [ev["id"] for ev in out] == ["ok"]
+
+
+# ---------------------------------------------------------------------------
+# Limit
+# ---------------------------------------------------------------------------
+
+
+async def test_limit_caps_results_even_if_upstream_returns_more(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Composio honors ``maxResults`` as a hint — if the upstream
+    returns more rows than asked for, the service trims to ``limit``
+    before mapping to wire dicts."""
+    items = [
+        _google_event(
+            id=f"ev{i}",
+            summary=f"Event {i}",
+            start=f"2026-05-2{i}T10:00:00-07:00",
+            end=f"2026-05-2{i}T11:00:00-07:00",
+        )
+        for i in range(1, 8)
+    ]
+    execute = _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_return={"data": {"items": items}, "successful": True},
+    )
+
+    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=3)
+
+    assert len(out) == 3
+    assert [ev["id"] for ev in out] == ["ev1", "ev2", "ev3"]
+    # Forwarded the limit as ``maxResults`` so the upstream can
+    # short-circuit when possible.
+    _, kwargs = execute.call_args
+    assert kwargs["arguments"] == {"maxResults": 3}

--- a/tests/cloud/calendar/test_service.py
+++ b/tests/cloud/calendar/test_service.py
@@ -1,12 +1,22 @@
 # tests/cloud/calendar/test_service.py — Cloud calendar service.
 #
-# Created: 2026-05-24 (feat/calendar-entity-surface, #1214) — four
-# guarantees:
+# Updated: 2026-05-24 (feat/calendar-entity-surface, #1218) — added a
+# fifth guarantee: cross-workspace calls against the same mock
+# upstream payload tag each returned event with the requesting
+# workspace_id. Protects the tenancy invariant when the same Composio
+# response (in this contrived test) is read by two workspaces in
+# sequence — the wire dicts must carry their own workspace_id, not
+# leak whichever workspace happened to run first.
+#
+# Five guarantees:
 #   1. Composio disabled  → ``[]`` (no SDK touch, no error).
 #   2. Happy path         → events flow through with workspace tagging.
 #   3. Workspace required → empty workspace_id raises ``ValidationError``.
 #   4. Limit parameter    → caps the returned slice even when upstream
 #                            returns more rows than asked for.
+#   5. Cross-workspace    → two calls with different workspace_ids
+#                            against one upstream payload return wire
+#                            dicts each tagged with their own workspace.
 #
 # Tests monkeypatch the composio service boundary
 # (``is_enabled`` / ``_get_client`` / ``composio_user_id``) rather than
@@ -290,3 +300,56 @@ async def test_limit_caps_results_even_if_upstream_returns_more(
     # short-circuit when possible.
     _, kwargs = execute.call_args
     assert kwargs["arguments"] == {"maxResults": 3}
+
+
+# ---------------------------------------------------------------------------
+# Cross-workspace tenancy tagging
+# ---------------------------------------------------------------------------
+
+
+async def test_cross_workspace_calls_tag_each_event_with_caller_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two consecutive calls — one from ``ws_a``, one from ``ws_b`` —
+    against the same mocked Composio response. Every returned event
+    must carry the requesting workspace_id, never the other's.
+
+    The shared payload is contrived — in production each workspace
+    would have its own Composio connection. The point of this test is
+    the tag-at-construction invariant: the domain object refuses to
+    be built without a workspace_id and stamps the caller's tag onto
+    every event before it crosses the service boundary."""
+    items = [
+        _google_event(
+            id="shared_ev_1",
+            summary="Shared Event 1",
+            start="2026-05-25T10:00:00-07:00",
+            end="2026-05-25T11:00:00-07:00",
+        ),
+        _google_event(
+            id="shared_ev_2",
+            summary="Shared Event 2",
+            start="2026-05-26T14:00:00-07:00",
+            end="2026-05-26T15:00:00-07:00",
+        ),
+    ]
+    _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_return={"data": {"items": items}, "successful": True},
+    )
+
+    out_a = await calendar_service.list_upcoming("ws_a", "user_test", limit=10)
+    out_b = await calendar_service.list_upcoming("ws_b", "user_test", limit=10)
+
+    # Both calls see the same upstream rows.
+    assert {ev["id"] for ev in out_a} == {"shared_ev_1", "shared_ev_2"}
+    assert {ev["id"] for ev in out_b} == {"shared_ev_1", "shared_ev_2"}
+    # But every wire dict carries the requesting workspace_id —
+    # never the other workspace's tag.
+    assert all(ev["workspace_id"] == "ws_a" for ev in out_a)
+    assert all(ev["workspace_id"] == "ws_b" for ev in out_b)
+    # Sanity: no event from out_a ended up tagged with ws_b (would
+    # signal shared-state leak between calls).
+    assert all(ev["workspace_id"] != "ws_b" for ev in out_a)
+    assert all(ev["workspace_id"] != "ws_a" for ev in out_b)

--- a/tests/cloud/surface/test_calendar_handler.py
+++ b/tests/cloud/surface/test_calendar_handler.py
@@ -1,21 +1,30 @@
 # tests/cloud/surface/test_calendar_handler.py — Calendar surface handler.
 #
-# Created: 2026-05-24 (feat/calendar-entity-surface, #1214) — three
-# guarantees:
-#   1. Happy path     — three mocked events render into a snapshot
-#                       block with one line per event; surface tag
-#                       always present.
-#   2. Empty path     — when the service returns no events, the handler
-#                       falls back to the Composio hint so the agent
-#                       still knows what tool to reach for.
-#   3. Failure path   — when the service raises, the handler still
-#                       returns a usable preamble (surface tag + hint),
-#                       never propagates the exception to the chat
-#                       router.
+# Updated: 2026-05-24 (feat/calendar-entity-surface, #1218) — split the
+# single empty test into two so the three rendering states (events
+# present / Composio on + empty / Composio off) are each pinned. Now
+# four guarantees:
+#   1. Happy path        — three mocked events render into a snapshot
+#                           block with one line per event; surface tag
+#                           always present.
+#   2. Empty + enabled   — when ``list_upcoming`` returns ``[]`` AND
+#                           Composio is enabled, the handler renders
+#                           the ``(no upcoming events)`` snapshot
+#                           rather than the hint — the agent needs to
+#                           tell "genuinely empty" apart from "no
+#                           integration".
+#   3. Empty + disabled  — when Composio is off, the hint stays —
+#                           agent learns the action name so it can
+#                           guide the user to connect.
+#   4. Failure path      — when the service raises, the handler still
+#                           returns a usable preamble (surface tag +
+#                           hint), never propagates the exception to
+#                           the chat router.
 #
-# The handler is mocked at its single dependency
-# (``calendar.service.list_upcoming``) so these tests don't need the
-# DB or any Composio plumbing. The service has its own test file.
+# The handler is mocked at its single hot dependency
+# (``calendar.service.list_upcoming``). For branches 2 and 3 we also
+# stub ``composio_service.is_enabled`` so the test doesn't depend on
+# environment Settings.
 
 from __future__ import annotations
 
@@ -111,30 +120,56 @@ async def test_handler_renders_time_of_day_for_timed_events(
 # ---------------------------------------------------------------------------
 
 
-async def test_handler_renders_hint_when_no_events(
+async def test_handler_renders_empty_snapshot_when_composio_enabled_but_no_events(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When the service returns ``[]`` (Composio disabled, calendar
-    not connected, or just an empty calendar), the handler renders
-    the Composio hint so the agent still knows what tool to reach for.
-
-    Per the brief, the empty branch shows the hint — distinct from a
-    separate "no upcoming events" string. The hint covers both empty
-    and unavailable states with one message.
-    """
+    """Service returns ``[]`` AND Composio is on — the calendar is
+    genuinely empty. Render the ``(no upcoming events)`` snapshot so
+    the agent doesn't waste a turn telling the user to connect a
+    calendar that's already connected."""
 
     async def _fake(workspace_id: str, user_id: str, limit: int = 10) -> list[dict[str, Any]]:
         return []
 
     from pocketpaw_ee.cloud.calendar import service as calendar_service
+    from pocketpaw_ee.cloud.composio import service as composio_service
 
     monkeypatch.setattr(calendar_service, "list_upcoming", _fake)
+    monkeypatch.setattr(composio_service, "is_enabled", lambda *a, **kw: True)
+
+    preamble = await calendar_handler.build_preamble("ws_acme", "user_test", SurfaceMeta())
+
+    assert '<surface kind="calendar"' in preamble
+    assert "(no upcoming events)" in preamble
+    # The hint is suppressed — Composio is wired up, no need to nudge.
+    assert "GOOGLECALENDAR_LIST_EVENTS" not in preamble
+
+
+async def test_handler_renders_hint_when_composio_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Service returns ``[]`` because Composio is off — the agent
+    needs the action-name hint so it can guide the user toward
+    connecting an integration. Distinct from the genuinely-empty
+    case above."""
+
+    async def _fake(workspace_id: str, user_id: str, limit: int = 10) -> list[dict[str, Any]]:
+        return []
+
+    from pocketpaw_ee.cloud.calendar import service as calendar_service
+    from pocketpaw_ee.cloud.composio import service as composio_service
+
+    monkeypatch.setattr(calendar_service, "list_upcoming", _fake)
+    monkeypatch.setattr(composio_service, "is_enabled", lambda *a, **kw: False)
 
     preamble = await calendar_handler.build_preamble("ws_acme", "user_test", SurfaceMeta())
 
     assert '<surface kind="calendar"' in preamble
     assert "GOOGLECALENDAR_LIST_EVENTS" in preamble
     assert "Composio" in preamble
+    # The empty-snapshot string belongs to the enabled branch — confirm
+    # we didn't accidentally fall through both messages.
+    assert "(no upcoming events)" not in preamble
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/surface/test_calendar_handler.py
+++ b/tests/cloud/surface/test_calendar_handler.py
@@ -1,0 +1,164 @@
+# tests/cloud/surface/test_calendar_handler.py — Calendar surface handler.
+#
+# Created: 2026-05-24 (feat/calendar-entity-surface, #1214) — three
+# guarantees:
+#   1. Happy path     — three mocked events render into a snapshot
+#                       block with one line per event; surface tag
+#                       always present.
+#   2. Empty path     — when the service returns no events, the handler
+#                       falls back to the Composio hint so the agent
+#                       still knows what tool to reach for.
+#   3. Failure path   — when the service raises, the handler still
+#                       returns a usable preamble (surface tag + hint),
+#                       never propagates the exception to the chat
+#                       router.
+#
+# The handler is mocked at its single dependency
+# (``calendar.service.list_upcoming``) so these tests don't need the
+# DB or any Composio plumbing. The service has its own test file.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers import calendar as calendar_handler
+
+
+def _wire_event(**overrides: Any) -> dict[str, Any]:
+    """Build a wire-shaped event dict (matches what list_upcoming returns)."""
+    base: dict[str, Any] = {
+        "id": "ev1",
+        "workspace_id": "ws_acme",
+        "title": "Sync with Sarah",
+        "start": "2026-05-25T10:30:00-07:00",
+        "end": "2026-05-25T11:00:00-07:00",
+        "source": "google",
+        "attendees": ["sarah@example.com"],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_renders_events_into_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Three events render into one line each plus a count attribute.
+    The surface tag is always emitted regardless of branch."""
+    events = [
+        _wire_event(id="ev1", title="Sync with Sarah", start="2026-05-25T10:30:00-07:00"),
+        _wire_event(id="ev2", title="Q2 planning", start="2026-05-26T14:00:00-07:00"),
+        _wire_event(id="ev3", title="All-hands", start="2026-05-27", end="2026-05-28"),
+    ]
+
+    async def _fake_list_upcoming(
+        workspace_id: str, user_id: str, limit: int = 10
+    ) -> list[dict[str, Any]]:
+        # Forward the call so we can assert the handler passes its limit.
+        assert workspace_id == "ws_acme"
+        assert user_id == "user_test"
+        return events
+
+    # Patch via the module the handler imports from. The handler imports
+    # ``list_upcoming`` lazily inside ``build_preamble``, so the patch
+    # has to land on the source module rather than on a re-export.
+    from pocketpaw_ee.cloud.calendar import service as calendar_service
+
+    monkeypatch.setattr(calendar_service, "list_upcoming", _fake_list_upcoming)
+
+    preamble = await calendar_handler.build_preamble("ws_acme", "user_test", SurfaceMeta())
+
+    # Surface tag is always present.
+    assert '<surface kind="calendar"' in preamble
+    # Count attribute matches the event list.
+    assert 'count="3"' in preamble
+    # Each event title surfaces.
+    assert "Sync with Sarah" in preamble
+    assert "Q2 planning" in preamble
+    assert "All-hands" in preamble
+    # The empty-state hint is suppressed when events render.
+    assert "no live event feed wired" not in preamble
+
+
+async def test_handler_renders_time_of_day_for_timed_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``start`` like ``2026-05-25T10:30:00-07:00`` renders as ``10:30 AM``
+    in the snapshot line so the agent quotes a human-friendly time."""
+    events = [_wire_event(start="2026-05-25T10:30:00-07:00", title="Sync")]
+
+    async def _fake(workspace_id: str, user_id: str, limit: int = 10) -> list[dict[str, Any]]:
+        return events
+
+    from pocketpaw_ee.cloud.calendar import service as calendar_service
+
+    monkeypatch.setattr(calendar_service, "list_upcoming", _fake)
+
+    preamble = await calendar_handler.build_preamble("ws_acme", "user_test", SurfaceMeta())
+
+    assert "10:30 AM" in preamble
+    assert "Sync" in preamble
+
+
+# ---------------------------------------------------------------------------
+# Empty path
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_renders_hint_when_no_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the service returns ``[]`` (Composio disabled, calendar
+    not connected, or just an empty calendar), the handler renders
+    the Composio hint so the agent still knows what tool to reach for.
+
+    Per the brief, the empty branch shows the hint — distinct from a
+    separate "no upcoming events" string. The hint covers both empty
+    and unavailable states with one message.
+    """
+
+    async def _fake(workspace_id: str, user_id: str, limit: int = 10) -> list[dict[str, Any]]:
+        return []
+
+    from pocketpaw_ee.cloud.calendar import service as calendar_service
+
+    monkeypatch.setattr(calendar_service, "list_upcoming", _fake)
+
+    preamble = await calendar_handler.build_preamble("ws_acme", "user_test", SurfaceMeta())
+
+    assert '<surface kind="calendar"' in preamble
+    assert "GOOGLECALENDAR_LIST_EVENTS" in preamble
+    assert "Composio" in preamble
+
+
+# ---------------------------------------------------------------------------
+# Failure path
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_falls_back_when_service_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``list_upcoming`` raises (e.g. an internal bug we haven't
+    caught yet), the handler must still return a usable preamble.
+    Never let a calendar surface failure break a chat send."""
+
+    async def _boom(workspace_id: str, user_id: str, limit: int = 10) -> list[dict[str, Any]]:
+        raise RuntimeError("calendar service exploded")
+
+    from pocketpaw_ee.cloud.calendar import service as calendar_service
+
+    monkeypatch.setattr(calendar_service, "list_upcoming", _boom)
+
+    preamble = await calendar_handler.build_preamble("ws_acme", "user_test", SurfaceMeta())
+
+    # Surface tag still present.
+    assert '<surface kind="calendar"' in preamble
+    # Hint emitted so the agent still has a path forward.
+    assert "GOOGLECALENDAR_LIST_EVENTS" in preamble


### PR DESCRIPTION
## Summary

- New cloud entity at `ee/pocketpaw_ee/cloud/calendar/` — frozen `CalendarEvent` domain, `CalendarEventResponse` wire shape, and a read-only `list_upcoming(workspace_id, user_id, limit=10)` service. No router, no Beanie, no events — the surface handler is the only consumer for now.
- The `/calendar` surface handler now renders a `<calendar-snapshot count="N">` block with one line per event (`- 10:30 AM · Sync with Sarah`) instead of a static placeholder. Empty / unavailable falls back to the original Composio hint so the agent always has a path forward.
- Composio is the data path today: gate on `is_enabled`, namespace the user via `composio_user_id`, call `GOOGLECALENDAR_LIST_EVENTS` through `tools.execute`. Every failure mode (disabled, SDK missing, not connected, upstream 5xx, parse error) degrades to `[]` so the handler never needs to catch.

## What changed

**New entity** (`ee/pocketpaw_ee/cloud/calendar/`)
- `domain.py` — `CalendarEvent` frozen dataclass; `workspace_id` required at construction so tenancy is impossible to forget.
- `dto.py` — `CalendarEventResponse` Pydantic model for the wire shape.
- `service.py` — `list_upcoming` returns wire dicts; validate-at-entry for `workspace_id` / `user_id` / `limit`; lazy import of the Composio service; Pydantic round-trip for domain → response → dict per the canonical pockets/cycles pattern.
- `__init__.py` — re-exports `CalendarEvent`, `CalendarEventResponse`, `list_upcoming`.

**Handler upgrade** (`ee/pocketpaw_ee/cloud/surface/handlers/calendar.py`)
- Calls `list_upcoming` with `limit=10`.
- Renders events with a time-of-day prefix (`10:30 AM`) for timed events and the raw date for all-day rows.
- Always emits `<surface kind="calendar" route="/calendar" />`; the snapshot block adapts based on whether data is available.

## Test plan

- [x] `uv run pytest tests/cloud/calendar/ tests/cloud/surface/test_calendar_handler.py -v` — 13/13 pass (service: tenancy guards, Composio gating, happy path with workspace tagging, upstream-error degrade, malformed-row skip, limit cap; handler: snapshot rendering, time-of-day formatting, empty fallback, raise fallback).
- [x] `uv run pytest tests/cloud/surface/ -v` — 20/20 pass; no regression in the surrounding surface handlers.
- [x] `uv run pytest tests/cloud/composio/` — 69/69 pass; the Composio service surface I monkey-patched in the new tests is unchanged.
- [x] `uv run ruff check` + `ruff format --check` on the new files — clean.
- [x] `uv run lint-imports --config ee/pyproject.toml` — 16/16 contracts kept. The new entity doesn't touch Beanie, so no new contract was needed.

Closes #1214.