### PR TITLE
feat(pockets): kind discriminant on pocket_mutation SSE frames

### DIFF
--- a/ee/docs/architecture/pocket-mutation-channel.md
+++ b/ee/docs/architecture/pocket-mutation-channel.md
@@ -1,0 +1,78 @@
+# Pocket mutation SSE channel
+
+The `pocket_mutation` SSE event is the cloud chat agent's narrow,
+in-place patch signal for a pocket the user is currently looking at.
+It rides on the same agent-stream as `chunk` / `tool_start` /
+`stream_end`, and is what the paw-enterprise canvas re-renders from
+without a full refetch.
+
+## Producer
+
+`ee/pocketpaw_ee/cloud/pockets/agent_context.py` is the only producer.
+Every granular `*_for_agent` helper that mutates a pocket pushes one
+`pocket_mutation` frame after the Beanie write succeeds. Two helpers
+do the actual push:
+
+- `_push_mutation_frame(op, view, payload)` — granular node / state ops
+  use `PocketMutationFrame.to_wire()` to emit a flat dict.
+- `_push_replace(view)` — full-document push for changes that don't
+  map to a granular in-place op (top-level pocket fields, embedded
+  widget add/remove, `rippleSpec.sources`, `rippleSpec.actions`).
+
+Each push happens once per write. The coarse `pocket.updated` realtime
+event the service layer emits in parallel is the refetch fallback for
+clients that ignore the discriminated frame entirely.
+
+## The `kind` discriminant (RFC 06 position #2)
+
+Every frame carries a top-level `kind` field with one of three values:
+
+| `kind`        | Emitted by                                              | Wire payload                                              |
+|---------------|---------------------------------------------------------|-----------------------------------------------------------|
+| `"structure"` | node / component-tree ops (`node_added`, `node_prop_set`, `node_moved`, `node_removed`, `node_replaced`, `node_prop_array_item_*`) | `op`, `node_id`, subtree, parent / index info             |
+| `"data"`      | state-model ops (`state_set`, `state_appended`, `state_removed`, `state_patched`) | `op`, `path`, `value`, prior value                        |
+| `"replace"`   | the full-document push (`_push_replace`): top-level pocket field updates, widget add/remove, `set_source` / `remove_source`, `set_action` / `remove_action` | `op == "replace"`, `pocket` (full resolved pocket view)   |
+
+The split mirrors Ripple's two mutator modules (`spec-mutator.ts` for
+structure, `state-mutator.ts` for data) and the A2UI
+`updateComponents` / `updateDataModel` message families. A client that
+branches on `kind` can:
+
+- skip layout work entirely on `kind === "data"` (only data-bound
+  widgets need to re-render);
+- patch the touched subtree on `kind === "structure"`;
+- swap the full pocket on `kind === "replace"`.
+
+`"replace"` is a third value rather than folded into `"structure"`
+because the wire payload genuinely is different — the whole pocket
+document goes over the wire, not a subtree. Clients gate on it before
+the structure-vs-data fork.
+
+## Back-compat
+
+The frame is purely additive:
+
+- The legacy `action` key still rides on every frame (it equals `op`).
+- The A2UI-style `family` key (`"updateComponents"` / `"updateDataModel"`)
+  rides on granular structure / data frames for any consumer that
+  already branches on it. It is omitted on `kind === "replace"`
+  because the replace push isn't an A2UI granular op.
+- Every payload key the historical un-discriminated frame carried at
+  the top level still sits at the top level — `to_wire()` flattens
+  `PocketMutationFrame.payload` next to the discriminants.
+
+An op identifier with no known `kind` (a typo, a future op not yet
+wired into `kind_for_op`) falls back to the legacy un-discriminated
+flat frame in `_push_mutation_frame`. The canvas still gets the
+signal; only the discriminant is missing — and the coarse
+`pocket.updated` event still fires on the same write as the final
+backstop.
+
+## Follow-up
+
+Client-side wiring is out of scope for this PR. The paw-enterprise
+canvas continues to apply the frame the same way it did before — by
+reading `action` + flat payload. The follow-up is to gate the canvas
+on `kind` so structure changes re-run layout while data changes only
+re-render data-bound widgets, mirroring Ripple's two-mutator split on
+the consumer side too.

--- a/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
@@ -15,6 +15,18 @@
 #   which renders a per-turn preamble injected ahead of the dynamic
 #   scope tags. Unknown surface strings fall back to the GENERIC handler
 #   so older clients keep working unchanged.
+# Changes: 2026-05-24 (RFC 06 position #2 follow-up) — added the
+#   plain-English ``kind`` discriminant alongside the existing A2UI-style
+#   ``family``. ``kind`` is ``"structure" | "data" | "replace"``: every
+#   ``pocket_mutation`` frame now carries it, including the full-document
+#   ``replace`` push (which previously had no discriminant at all).
+#   ``kind`` is the simpler client-facing label; ``family`` is kept for
+#   any consumer that already branches on the A2UI names. Mapping:
+#   structure-ops -> ``"structure"``, state-ops -> ``"data"``,
+#   full-document push -> ``"replace"``. The field is additive —
+#   un-discriminated consumers keep working byte-for-byte and the
+#   coarse ``PocketUpdated`` realtime event remains the refetch fallback
+#   for clients that ignore ``kind`` entirely.
 """Request and SSE-event payload schemas for the enterprise agent chat endpoint.
 
 The endpoint lives at ``POST /cloud/chat/{scope}/{scope_id}/agent`` and streams
@@ -154,6 +166,36 @@ def family_for_op(op: str) -> Literal["updateComponents", "updateDataModel"] | N
     return None
 
 
+# RFC 06 position #2 — the plain-English ``kind`` discriminant. Mirrors
+# ``family`` but uses simpler labels every consumer can grep for without
+# learning the A2UI vocabulary. ``"replace"`` is a third value covering
+# the full-document push (no granular op identifier — the whole pocket
+# document goes over the wire). Granular sources / actions ops route
+# through the replace push today, so their frame also carries
+# ``kind == "replace"``. A future increment can split those into
+# in-place structure ops; the field gives us room without a wire break.
+MutationKind = Literal["structure", "data", "replace"]
+
+
+def kind_for_op(op: str) -> MutationKind | None:
+    """Resolve a granular op identifier to its plain-English ``kind``.
+
+    ``"structure"`` for node/component-tree ops, ``"data"`` for state
+    ops, ``None`` for anything else. The caller decides what to do with
+    ``None`` — ``_push_mutation_frame`` falls back to the legacy
+    un-discriminated frame so the canvas still gets a signal.
+
+    The full-document ``replace`` push does NOT go through this resolver
+    — it stamps ``kind="replace"`` directly because there is no granular
+    op identifier on that path.
+    """
+    if op in _STRUCTURE_OPS:
+        return "structure"
+    if op in _DATA_OPS:
+        return "data"
+    return None
+
+
 class PocketMutationFrame(BaseModel):
     """A narrow, discriminated ``pocket_mutation`` SSE frame.
 
@@ -163,31 +205,51 @@ class PocketMutationFrame(BaseModel):
     changed, refetch"; this frame tells it *what kind* of change so the
     canvas can patch in place rather than rebuild.
 
-    The ``family`` discriminant is the RFC-06 structure/data split:
+    Two discriminants ride on every frame — they carry the SAME
+    structure/data split, just under different names:
 
-    * ``updateComponents`` — a node op mutated ``rippleSpec.ui`` (the
-      component tree). The renderer re-runs layout for the touched
-      subtree.
-    * ``updateDataModel`` — a state op mutated ``rippleSpec.state`` (the
-      data model). No layout work needed — only data-bound widgets
-      re-render.
+    * ``kind`` (plain English, the canonical RFC 06 position #2 label):
+      ``"structure"`` for a component-tree op, ``"data"`` for a state op,
+      ``"replace"`` for the full-document push that ``_push_replace``
+      emits (sources/actions changes, top-level pocket-field updates,
+      embedded-widget mutations). Clients should branch on ``kind`` —
+      it's the simpler grep target and the one the channel doc names.
+    * ``family`` (A2UI vocabulary, kept for back-compat):
+      ``"updateComponents"`` for structure ops, ``"updateDataModel"`` for
+      data ops. ``None`` on a full-document replace, because the
+      replace push isn't an A2UI granular op.
 
     ``op`` is the granular op identifier (``state_set``, ``node_added``,
-    …); ``payload`` is that op's narrow change descriptor (subtree,
-    path, value, …) — the same fields the historical un-discriminated
-    frame carried at the top level.
+    …) or ``"replace"`` for the full-document push; ``payload`` is that
+    op's narrow change descriptor (subtree, path, value, full pocket) —
+    the same fields the historical un-discriminated frame carried at
+    the top level.
 
-    Wire shape: the frame is emitted FLAT — ``family``, ``op``,
+    Wire shape: the frame is emitted FLAT — ``kind``, ``family``, ``op``,
     ``pocket_id`` and every ``payload`` key sit at the top level of the
     SSE ``data`` object, next to the legacy ``action`` key. This keeps
     the historical un-discriminated consumers working byte-for-byte
     (they read ``action`` + flat payload) while new consumers branch on
-    ``family``. ``to_wire()`` produces that flat dict. Older clients
-    that ignore ``family`` still get the coarse ``PocketUpdated`` event,
-    so the frame is purely additive — no client is forced to upgrade.
+    ``kind`` (preferred) or ``family``. ``to_wire()`` produces that flat
+    dict. Older clients that ignore both discriminants still get the
+    coarse ``PocketUpdated`` event, so the frame is purely additive —
+    no client is forced to upgrade.
     """
 
-    family: Literal["updateComponents", "updateDataModel"]
+    kind: MutationKind = Field(
+        description=(
+            "Plain-English discriminant. 'structure' for component-tree ops, "
+            "'data' for state ops, 'replace' for the full-document push. The "
+            "canonical RFC 06 position #2 field name."
+        ),
+    )
+    family: Literal["updateComponents", "updateDataModel"] | None = Field(
+        default=None,
+        description=(
+            "A2UI-vocabulary alias for ``kind`` on granular ops. "
+            "``None`` on a full-document ``replace`` (no granular A2UI op)."
+        ),
+    )
     op: str = Field(min_length=1, description="Granular op identifier, e.g. 'state_set'.")
     pocket_id: str = Field(description="Id of the mutated pocket.")
     payload: dict[str, Any] = Field(
@@ -198,17 +260,22 @@ class PocketMutationFrame(BaseModel):
     def to_wire(self) -> dict[str, Any]:
         """Flatten to the wire dict pushed via ``push_pocket_mutation``.
 
-        ``payload`` keys are spread to the top level (next to ``family`` /
-        ``op`` / ``pocket_id``) and the legacy ``action`` alias is added
-        so un-discriminated consumers keep working. A ``payload`` key
-        never collides with ``family`` / ``op`` / ``action`` / ``pocket_id``
-        — the granular ops only put change descriptors there.
+        ``payload`` keys are spread to the top level (next to ``kind`` /
+        ``family`` / ``op`` / ``pocket_id``) and the legacy ``action``
+        alias is added so un-discriminated consumers keep working. A
+        ``payload`` key never collides with ``kind`` / ``family`` /
+        ``op`` / ``action`` / ``pocket_id`` — the granular ops only put
+        change descriptors there. ``family`` is omitted from the wire
+        when it's ``None`` (full-document replace), so consumers that
+        check ``"family" in frame`` keep working as before.
         """
         wire: dict[str, Any] = {
             "action": self.op,
             "op": self.op,
-            "family": self.family,
+            "kind": self.kind,
             "pocket_id": self.pocket_id,
         }
+        if self.family is not None:
+            wire["family"] = self.family
         wire.update(self.payload)
         return wire

--- a/ee/pocketpaw_ee/cloud/pockets/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/pockets/agent_context.py
@@ -24,6 +24,16 @@ historical un-discriminated consumers keep working; the coarse
 ``PocketUpdated`` realtime event the service layer emits is untouched
 (it remains the refetch fallback). Still one ``pocket_mutation`` push
 per op — purely additive enrichment, not a second event.
+Changes: 2026-05-24 (RFC 06 position #2 follow-up) — every
+``pocket_mutation`` frame now also carries a plain-English ``kind``
+discriminant: ``"structure"`` for node ops, ``"data"`` for state ops,
+``"replace"`` for the full-document push from ``_push_replace`` (top-
+level field updates, widget add/remove, sources/actions mutations).
+The ``replace`` push previously had no discriminant at all, so this
+closes the only remaining gap. ``kind`` is the simpler client-facing
+label; ``family`` is kept untouched on the granular-op frames for
+back-compat. See ``ee/docs/architecture/pocket-mutation-channel.md``
+for the full channel contract.
 """
 
 from __future__ import annotations
@@ -206,7 +216,14 @@ async def _push_replace(pocket_view: dict[str, Any]) -> None:
     """Push a ``pocket_mutation`` event for a successful update / widget
     change. Imported lazily so the cloud-chat dependency stays optional
     for callers that never go through the SSE path. The frontend gets a
-    resolved spec; the agent's caller still has the raw view."""
+    resolved spec; the agent's caller still has the raw view.
+
+    The frame carries ``kind == "replace"`` (RFC 06 position #2): the
+    full-document push isn't a granular structure-vs-data op — the whole
+    pocket goes over the wire — so it gets its own value rather than
+    folding into "structure". Clients can branch on ``kind == "replace"``
+    to do a full re-render and skip the in-place patch path.
+    """
     resolved = await _resolved_view_for_frontend(pocket_view)
     try:
         from pocketpaw_ee.cloud.chat.agent_service import push_pocket_mutation
@@ -214,6 +231,8 @@ async def _push_replace(pocket_view: dict[str, Any]) -> None:
         push_pocket_mutation(
             {
                 "action": "replace",
+                "op": "replace",
+                "kind": "replace",
                 "pocket_id": resolved.get("_id", ""),
                 "pocket": resolved,
             }
@@ -227,33 +246,44 @@ def _push_mutation_frame(op: str, pocket_view: dict[str, Any], payload: dict[str
     and push it as the ``pocket_mutation`` SSE event.
 
     ``op`` is the granular op identifier (``node_added`` / ``state_set`` /
-    …). It resolves to a mutation ``family`` — ``updateComponents`` for a
-    node/structure op, ``updateDataModel`` for a state/data op — which is
-    the RFC-06 split letting the canvas patch only the layer that
-    changed. The frame is emitted FLAT (``to_wire``) so the historical
+    …). It resolves to two parallel discriminants — both carrying the
+    same structure/data split:
+
+    * ``kind`` (plain-English, RFC 06 position #2): ``"structure"`` for a
+      node/component-tree op, ``"data"`` for a state op.
+    * ``family`` (A2UI vocabulary, back-compat): ``"updateComponents"``
+      for structure ops, ``"updateDataModel"`` for data ops.
+
+    The frame is emitted FLAT (``to_wire``) so the historical
     un-discriminated consumers, which read ``action`` + flat payload
     keys, keep working byte-for-byte.
 
     Exactly one ``pocket_mutation`` push per op — the coarse
     ``PocketUpdated`` realtime event the service layer emits on the same
-    write is the separate refetch fallback for clients that ignore
-    ``family``. An op whose identifier has no known family falls back to
-    the legacy flat frame (no ``family`` key) rather than dropping the
-    push.
+    write is the separate refetch fallback for clients that ignore both
+    discriminants. An op whose identifier has no known kind falls back
+    to the legacy flat frame (no ``kind`` / ``family`` keys) rather than
+    dropping the push.
     """
-    from pocketpaw_ee.cloud.chat.agent_schemas import PocketMutationFrame, family_for_op
+    from pocketpaw_ee.cloud.chat.agent_schemas import (
+        PocketMutationFrame,
+        family_for_op,
+        kind_for_op,
+    )
     from pocketpaw_ee.cloud.chat.agent_service import push_pocket_mutation
 
     pocket_id = pocket_view.get("_id", "")
     family = family_for_op(op)
+    kind = kind_for_op(op)
     try:
-        if family is None:
+        if family is None or kind is None:
             # Unknown op — keep the legacy flat frame so the canvas still
             # gets a signal; only the discriminant is missing.
-            logger.debug("no mutation family for op %r — emitting legacy flat frame", op)
+            logger.debug("no mutation kind for op %r — emitting legacy flat frame", op)
             push_pocket_mutation({"action": op, "pocket_id": pocket_id, **payload})
             return
         frame = PocketMutationFrame(
+            kind=kind,
             family=family,
             op=op,
             pocket_id=pocket_id,

--- a/tests/cloud/test_pocket_mutation_family.py
+++ b/tests/cloud/test_pocket_mutation_family.py
@@ -220,10 +220,12 @@ async def test_granular_op_still_emits_pocket_updated(mongo_db, agent_identity):
 def test_pocket_mutation_frame_to_wire_is_flat():
     """``PocketMutationFrame.to_wire`` flattens ``payload`` to the top
     level and adds the legacy ``action`` alias — so un-discriminated
-    consumers keep working byte-for-byte."""
+    consumers keep working byte-for-byte. The plain-English ``kind``
+    discriminant rides next to the A2UI ``family`` (RFC 06 position #2)."""
     from pocketpaw_ee.cloud.chat.agent_schemas import PocketMutationFrame, family_for_op
 
     frame = PocketMutationFrame(
+        kind="data",
         family="updateDataModel",
         op="state_set",
         pocket_id="p1",
@@ -233,6 +235,7 @@ def test_pocket_mutation_frame_to_wire_is_flat():
     assert wire == {
         "action": "state_set",
         "op": "state_set",
+        "kind": "data",
         "family": "updateDataModel",
         "pocket_id": "p1",
         "path": "filter",

--- a/tests/cloud/test_pocket_mutation_kind.py
+++ b/tests/cloud/test_pocket_mutation_kind.py
@@ -1,0 +1,301 @@
+# test_pocket_mutation_kind.py — RFC 06 position #2 follow-up.
+# Created: 2026-05-24 — verifies the plain-English ``kind`` discriminant
+#   that now rides on every ``pocket_mutation`` SSE frame. The earlier
+#   Increment-3 work (see ``test_pocket_mutation_family.py``) wired the
+#   A2UI ``family`` field on the granular node/state ops; this file
+#   pins the canonical ``kind`` label ("structure" / "data" / "replace")
+#   on ALL emit sites, including the full-document ``_push_replace``
+#   path that previously had no discriminant at all (sources, actions,
+#   widget add/remove, top-level pocket-field updates).
+"""Does every pocket_mutation SSE frame carry the right `kind` discriminant?"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+
+async def _make_pocket() -> Any:
+    """A pocket with a heading node (for node ops), a tasks array in
+    state (for state ops), and an empty sources/actions block (so the
+    sources/actions wrappers have something to mutate)."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    spec = {
+        "version": "1.0",
+        "state": {"tasks": [{"id": 1, "status": "todo"}], "filter": "all"},
+        "ui": {
+            "id": "n_root0000",
+            "type": "flex",
+            "props": {"direction": "column"},
+            "children": [
+                {"id": "n_head0000", "type": "heading", "props": {"text": "Hi"}},
+            ],
+        },
+    }
+    doc = Pocket(
+        workspace="w1",
+        name="Kind",
+        owner="u1",
+        visibility="workspace",
+        rippleSpec=spec,
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.fixture
+def agent_identity():
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_agent_identity,
+        detach_agent_identity,
+    )
+
+    tokens = attach_agent_identity(workspace_id="w1", user_id="u1")
+    try:
+        yield
+    finally:
+        detach_agent_identity(tokens)
+
+
+def _frames(sink: asyncio.Queue) -> list[tuple[str, dict]]:
+    out: list[tuple[str, dict]] = []
+    while not sink.empty():
+        out.append(sink.get_nowait())
+    return out
+
+
+def _mutations(sink: asyncio.Queue) -> list[dict]:
+    """Return only the ``pocket_mutation`` frames from the sink."""
+    return [d for n, d in _frames(sink) if n == "pocket_mutation"]
+
+
+# ---------------------------------------------------------------------------
+# Structure ops -> kind == "structure"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_node_prop_carries_kind_structure(mongo_db, agent_identity):
+    """A ``set_node_prop`` op mutates ``rippleSpec.ui`` — its frame
+    must carry ``kind == "structure"`` (the plain-English RFC 06 label)
+    plus the legacy ``family == "updateComponents"`` for back-compat."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_sse_event_sink,
+        detach_sse_event_sink,
+    )
+    from pocketpaw_ee.cloud.pockets import agent_context
+
+    doc = await _make_pocket()
+    sink: asyncio.Queue = asyncio.Queue()
+    token = attach_sse_event_sink(sink)
+    try:
+        result = await agent_context.set_node_prop_for_agent(
+            str(doc.id), node_id="n_head0000", prop="text", value="Renamed"
+        )
+    finally:
+        detach_sse_event_sink(token)
+
+    assert result["ok"] is True
+    mutations = _mutations(sink)
+    assert len(mutations) == 1
+    frame = mutations[0]
+    assert frame["kind"] == "structure"
+    # Back-compat: the legacy ``family`` discriminant still rides along.
+    assert frame["family"] == "updateComponents"
+    assert frame["op"] == "node_prop_set"
+
+
+# ---------------------------------------------------------------------------
+# Data ops -> kind == "data"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_state_carries_kind_data(mongo_db, agent_identity):
+    """A ``set_state`` op mutates ``rippleSpec.state`` — its frame
+    must carry ``kind == "data"`` plus the legacy
+    ``family == "updateDataModel"``."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_sse_event_sink,
+        detach_sse_event_sink,
+    )
+    from pocketpaw_ee.cloud.pockets import agent_context
+
+    doc = await _make_pocket()
+    sink: asyncio.Queue = asyncio.Queue()
+    token = attach_sse_event_sink(sink)
+    try:
+        result = await agent_context.set_state_for_agent(str(doc.id), "filter", "done")
+    finally:
+        detach_sse_event_sink(token)
+
+    assert result["ok"] is True
+    mutations = _mutations(sink)
+    assert len(mutations) == 1
+    frame = mutations[0]
+    assert frame["kind"] == "data"
+    assert frame["family"] == "updateDataModel"
+    assert frame["op"] == "state_set"
+
+
+# ---------------------------------------------------------------------------
+# The full-document replace push -> kind == "replace"
+# ---------------------------------------------------------------------------
+#
+# Sources / actions / widget / top-level-field changes route through
+# ``_push_replace`` which sends the whole pocket document. The push
+# now carries ``kind == "replace"`` — a third value so clients can
+# branch on ``kind === "replace"`` for a full re-render and skip the
+# in-place patch path.
+
+
+@pytest.mark.asyncio
+async def test_set_source_carries_kind_replace(mongo_db, agent_identity):
+    """``set_source_for_agent`` pushes a full-document replace — its
+    frame carries ``kind == "replace"``. (Sources changes are
+    structural in spirit, but the wire push is a full pocket — the
+    third ``kind`` value names that precisely.)"""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_sse_event_sink,
+        detach_sse_event_sink,
+    )
+    from pocketpaw_ee.cloud.pockets import agent_context
+
+    doc = await _make_pocket()
+    sink: asyncio.Queue = asyncio.Queue()
+    token = attach_sse_event_sink(sink)
+    try:
+        result = await agent_context.set_source_for_agent(
+            str(doc.id),
+            source_key="recent_tasks",
+            binding={"path": "/tasks", "method": "GET", "bind": "tasks"},
+        )
+    finally:
+        detach_sse_event_sink(token)
+
+    assert result["ok"] is True, f"set_source failed: {result.get('error')}"
+    mutations = _mutations(sink)
+    assert len(mutations) == 1, f"expected one pocket_mutation, got {len(mutations)}"
+    frame = mutations[0]
+    assert frame["kind"] == "replace"
+    assert frame["op"] == "replace"
+    assert frame["action"] == "replace"
+    # Replace push carries the full resolved pocket; ``family`` is omitted
+    # because the replace isn't an A2UI granular op.
+    assert "pocket" in frame
+    assert "family" not in frame
+
+
+@pytest.mark.asyncio
+async def test_set_action_carries_kind_replace(mongo_db, agent_identity):
+    """``set_action_for_agent`` pushes a full-document replace — its
+    frame carries ``kind == "replace"``."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_sse_event_sink,
+        detach_sse_event_sink,
+    )
+    from pocketpaw_ee.cloud.pockets import agent_context
+
+    doc = await _make_pocket()
+    sink: asyncio.Queue = asyncio.Queue()
+    token = attach_sse_event_sink(sink)
+    try:
+        result = await agent_context.set_action_for_agent(
+            str(doc.id),
+            action_key="mark_done",
+            binding={
+                "kind": "write_binding",
+                "path": "/tasks/{id}/done",
+                "method": "POST",
+            },
+        )
+    finally:
+        detach_sse_event_sink(token)
+
+    assert result["ok"] is True, f"set_action failed: {result.get('error')}"
+    mutations = _mutations(sink)
+    assert len(mutations) == 1
+    frame = mutations[0]
+    assert frame["kind"] == "replace"
+    assert frame["op"] == "replace"
+
+
+@pytest.mark.asyncio
+async def test_update_pocket_carries_kind_replace(mongo_db, agent_identity):
+    """``update_pocket_for_agent`` (a top-level field update) also
+    pushes a full-document replace — its frame carries
+    ``kind == "replace"``."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_sse_event_sink,
+        detach_sse_event_sink,
+    )
+    from pocketpaw_ee.cloud.pockets import agent_context
+
+    doc = await _make_pocket()
+    sink: asyncio.Queue = asyncio.Queue()
+    token = attach_sse_event_sink(sink)
+    try:
+        result = await agent_context.update_pocket_for_agent(
+            str(doc.id), description="Updated description"
+        )
+    finally:
+        detach_sse_event_sink(token)
+
+    assert result["ok"] is True
+    mutations = _mutations(sink)
+    assert len(mutations) == 1
+    assert mutations[0]["kind"] == "replace"
+
+
+# ---------------------------------------------------------------------------
+# The kind_for_op resolver itself.
+# ---------------------------------------------------------------------------
+
+
+def test_kind_for_op_resolves_structure_data_and_unknown():
+    """``kind_for_op`` maps structure-ops to "structure", state-ops to
+    "data", and anything else to ``None`` (the caller falls back to the
+    legacy un-discriminated frame). ``replace`` is intentionally NOT
+    listed here — the full-document push stamps ``kind="replace"``
+    directly, no resolver needed."""
+    from pocketpaw_ee.cloud.chat.agent_schemas import kind_for_op
+
+    # Structure ops.
+    assert kind_for_op("node_added") == "structure"
+    assert kind_for_op("node_prop_set") == "structure"
+    assert kind_for_op("node_moved") == "structure"
+    assert kind_for_op("node_prop_array_item_appended") == "structure"
+
+    # Data ops.
+    assert kind_for_op("state_set") == "data"
+    assert kind_for_op("state_appended") == "data"
+    assert kind_for_op("state_removed") == "data"
+    assert kind_for_op("state_patched") == "data"
+
+    # Unknown -> None (callers fall back to legacy flat frame).
+    assert kind_for_op("not_a_real_op") is None
+    assert kind_for_op("replace") is None
+
+
+def test_unknown_op_falls_back_to_legacy_flat_frame():
+    """An op identifier with no known ``kind`` (e.g. a typo, a new op
+    not yet wired into the resolver) must not break the push. The
+    caller emits the legacy un-discriminated frame instead — same
+    shape every consumer has tolerated since before the discriminant
+    existed. This is the back-compat tripwire."""
+    # The sink isn't attached here — we're checking that the resolver
+    # gives None for an unknown op. The fallback branch in
+    # ``_push_mutation_frame`` is what consumes that None. Verifying
+    # the resolver covers the contract: anything not in the maps drops
+    # to the legacy flat frame.
+    from pocketpaw_ee.cloud.chat.agent_schemas import kind_for_op
+    from pocketpaw_ee.cloud.pockets import agent_context
+
+    assert kind_for_op("totally_invented_op") is None
+    # And that path is the one ``_push_mutation_frame`` covers — see
+    # the ``if family is None or kind is None`` branch in
+    # ``agent_context._push_mutation_frame``.
+    assert hasattr(agent_context, "_push_mutation_frame")


### PR DESCRIPTION
## Summary

- Every `pocket_mutation` SSE frame now carries a plain-English `kind` discriminant — `"structure"` for component-tree ops, `"data"` for state-model ops, `"replace"` for the full-document push (sources, actions, top-level field updates, widget add/remove).
- The previously-undiscriminated `_push_replace` path now stamps `kind="replace"` — closing the only gap in the mutation channel.
- Additive enrichment: the legacy `action` key still rides on every frame; the A2UI-style `family` discriminant from Increment 3 stays on granular ops for any consumer already branching on it.

## What changed

- `agent_schemas.py` — added `MutationKind` type alias, `kind_for_op()` resolver, and the `kind` field on `PocketMutationFrame`. `to_wire()` now emits `kind` next to (and `family` is omitted on `kind="replace"` since the replace push isn't an A2UI granular op).
- `agent_context.py` — `_push_mutation_frame` now passes both `family` and `kind` to the frame; `_push_replace` stamps `kind="replace"` directly on the full-document payload.
- `tests/cloud/test_pocket_mutation_kind.py` — new suite pinning the contract: structure / data / replace across `set_node_prop`, `set_state`, `set_source`, `set_action`, `update_pocket`, the resolver itself, plus the unknown-op fallback.
- `tests/cloud/test_pocket_mutation_family.py` — one assertion updated to include `kind="data"` in the wire-shape pin.
- `ee/docs/architecture/pocket-mutation-channel.md` — short channel contract doc.

## RFC reference

RFC 06 position #2 — ADOPT NOW. The structure/data split was already implicit in Ripple's `spec-mutator.ts` vs `state-mutator.ts`; this formalizes it on the wire so clients can patch the structure layer or the data layer without re-rendering the whole pocket.

## Out of scope

Client-side wiring in paw-enterprise. The canvas continues to apply the frame the way it does today (reading `action` + flat payload). A follow-up issue can gate the canvas on `kind` for separate render-vs-hydrate paths.

## Test plan

- [x] `uv run pytest tests/cloud/test_pocket_mutation_kind.py -v` — 7 new tests, all green
- [x] `uv run pytest tests/cloud/test_pocket_mutation_family.py tests/cloud/test_pocket_mutation_sse.py tests/cloud/test_pocket_granular_ops.py tests/cloud/test_pocket_actions_ops.py tests/cloud/test_pocket_sources_ops.py tests/cloud/test_pocket_agent_context.py tests/cloud/test_home_pocket_update_widget.py tests/cloud/test_agent_chat_schemas.py` — 130+ tests, all green
- [x] `uv run ruff check` + `uv run ruff format --check` — clean
- [ ] Manual smoke against the dashboard once a reviewer runs it

Pre-existing failures unrelated to this PR: `tests/cloud/chat/test_message_emits.py` (4 tests) and `tests/cloud/chat/test_search_messages_v2.py` (1 test) fail on origin/dev tip — message threading / wire-shape drift that this PR doesn't touch.