### PR TITLE
feat(pockets): gate widget specs on add and update

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/pockets.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/pockets.py
@@ -29,6 +29,14 @@ Changes: 2026-05-22 (#1174) — added the writable ``add_widget`` tool, its
 ``ADD_WIDGET_TOOL_ID`` allowlist id, manifest validation of the widget's
 rippleSpec ``spec`` subtree (skipped for ``type="native"`` widgets), and the
 ``_get_manifest_for_validation`` seam tests patch.
+Changes: 2026-05-24 (#1208) — ``_validate_widget_spec`` now also runs the
+OSS-side ``validate_action_verbs`` walker over the widget's ``spec``
+subtree. This catches hallucinated dispatcher verbs (``action: "fetch"``,
+``action: "backend_fetch"``) earlier than the service-layer gate so the
+agent's retry loop sees a tight, focused corrective hint that names the
+exact bad verb without needing a cloud round-trip. The service-layer gate
+in ``pockets/service.py`` is still the authoritative ground truth — this
+is a cheap belt-and-suspenders that runs first.
 """
 
 from __future__ import annotations
@@ -143,23 +151,67 @@ def _format_manifest_issues(issues: list[dict[str, Any]]) -> str:
     return "; ".join(lines)
 
 
-async def _validate_widget_spec(widget: dict) -> str | None:
-    """Validate the widget's rippleSpec ``spec`` subtree against the manifest.
+def _format_action_verb_issues(issues: list[dict[str, Any]]) -> str:
+    """Render ``validate_action_verbs`` issues as an agent-readable error.
 
-    Returns an error string when the spec uses props the renderer would
-    ignore, or ``None`` when the spec is clean / has no spec to check.
-    ``type="native"`` widgets carry no rippleSpec — validation is skipped.
-    Best-effort: a manifest outage returns ``None`` (never block the agent).
+    Mirrors the corrective hint in ``ripple_validator.format_action_violations_for_agent``
+    so the agent sees the same wording whether the verb gate fires at the
+    MCP layer (this function) or the service layer (#1208). Suggestions are
+    surfaced verbatim when ``difflib`` produced a close match.
+    """
+    lines = ["The widget spec uses event-handler verbs the renderer does not dispatch:"]
+    for issue in issues[:5]:
+        verb = issue.get("action", "<missing>")
+        suggestion = issue.get("suggestion")
+        path = issue.get("path", "?")
+        hint = (
+            f" Use '{suggestion}' instead."
+            if suggestion
+            else " Use one of: set, push, run_source, api, navigate, toast, emit."
+        )
+        lines.append(f"  - {path}: action '{verb}' is not a recognized verb.{hint}")
+    if len(issues) > 5:
+        lines.append(f"  - …and {len(issues) - 5} more")
+    return " ".join(lines)
+
+
+async def _validate_widget_spec(widget: dict) -> str | None:
+    """Validate the widget's rippleSpec ``spec`` subtree against the manifest
+    and the closed action-verb allowlist.
+
+    Two layered checks:
+
+    1. ``validate_action_verbs`` (OSS, no manifest needed) — catches the
+       most common LLM failure mode: invented dispatcher verbs like
+       ``action: "fetch"`` or ``action: "backend_fetch"``. This runs first
+       because it works without a manifest and the corrective hint is
+       tighter than the manifest one.
+    2. ``validate_against_manifest`` (needs a manifest fetch) — catches
+       props the renderer would silently ignore.
+
+    Returns an error string on the first failing check, or ``None`` when
+    the spec passes both. ``type="native"`` widgets carry no rippleSpec —
+    validation is skipped. Best-effort: a manifest outage returns ``None``
+    for the manifest half (never block the agent on a transient outage);
+    the verb check runs regardless because it's a pure function.
     """
     if widget.get("type") == _NATIVE_WIDGET_TYPE:
         return None
     spec = widget.get("spec")
     if not isinstance(spec, dict):
         return None
+    # Action-verb gate (#1208) — pure walker, no manifest dependency. The
+    # service-layer gate in pockets/service.py runs this same walker (and
+    # the unwired-button walker) on the same subtree; surfacing the verb
+    # half here saves a cloud round-trip on the most common failure mode.
+    from pocketpaw.ripple.manifest import validate_action_verbs, validate_against_manifest
+
+    verb_issues = validate_action_verbs(spec)
+    if verb_issues:
+        return _format_action_verb_issues(verb_issues)
     manifest = await _get_manifest_for_validation()
     if manifest is None:
         return None
-    from pocketpaw.ripple.manifest import validate_against_manifest
 
     issues = validate_against_manifest(spec, manifest, apply_aliases=True)
     actionable = [i for i in issues if i.get("unknown_props")]

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -74,6 +74,11 @@ Changes: 2026-05-22 (#1174) — widgets carry an optional ``spec`` field (a
 per-tile rippleSpec subtree the home grid renders). ``_build_widget_doc``,
 ``_widget_to_domain``, the REST ``add_widget``, and ``agent_update_widget``
 thread it through; the home agent's ``add_widget`` MCP tool populates it.
+Changes: 2026-05-24 (#1208) — ``agent_add_widget`` and ``agent_update_widget``
+now run the catalog + action-wiring gates on ``widgets[].spec`` the same way
+``agent_replace_node`` runs them on the pocket-level rippleSpec. Closes the
+verb-hallucination / unwired-Refresh-button class of regressions on the home
+pocket's widget-add surface (sibling to #1196 at the pocket level).
 Changes: 2026-05-28 (feat/wave-3e-template-slug) — wired the RFC 03 v2
 ``template_slug`` field end-to-end: ``create`` / ``update`` load + compile
 the bundled template (via OSS ``load_template`` + ``compile_template``)
@@ -510,6 +515,57 @@ async def _gate_catalog(
             pocket_id=pocket_id,
             workspace_id=workspace_id,
         )
+
+
+# Widget ``type`` whose tiles carry no rippleSpec — the frontend renders them
+# as a built-in Svelte component keyed on ``name``. Mirrors the
+# ``_NATIVE_WIDGET_TYPE`` constant in the MCP server; duplicated here so the
+# service layer can short-circuit the gate without importing from the agent
+# package (which would invert the cloud → agent dependency direction).
+_NATIVE_WIDGET_TYPE = "native"
+
+
+async def _gate_widget_spec_for_agent(
+    spec: dict[str, Any] | None,
+    *,
+    widget_type: str | None,
+    actor: str,
+    workspace_id: str | None,
+    pocket_id: str | None,
+) -> str | None:
+    """Run the catalog + action-wiring gates over a single widget's ``spec``
+    subtree on the agent-generation path. Returns an agent-readable error
+    string on rejection, or ``None`` when the spec passes (or there's nothing
+    to gate).
+
+    Mirrors the strict half of :func:`_gate_catalog` — the same posture used
+    by the pocket-level granular ops (``agent_replace_node`` etc.) — but
+    scoped to a single ``widgets[].spec`` subtree rather than the
+    ``rippleSpec.ui`` tree. ``type="native"`` widgets and missing specs are
+    a no-op; the manifest-unavailable best-effort posture is inherited
+    from :func:`_gate_catalog`.
+
+    The catalog walker tolerates an unwrapped subtree (its first line is
+    ``root = spec.get("ui") if isinstance(spec.get("ui"), dict) else spec``)
+    so we hand the widget spec in directly, no synthetic ``ui`` wrapping.
+    """
+    if widget_type == _NATIVE_WIDGET_TYPE:
+        return None
+    if not isinstance(spec, dict):
+        return None
+    try:
+        await _gate_catalog(
+            spec,
+            strict=True,
+            actor=actor,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+        )
+    except CatalogViolationError as exc:
+        return format_violations_for_agent(exc.violations)
+    except ActionWiringViolationError as exc:
+        return format_action_violations_for_agent(exc.violations)
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -1632,6 +1688,21 @@ async def agent_add_widget(pocket_id: str, widget: dict) -> tuple[dict | None, s
     doc, err = await _agent_load_doc(pocket_id)
     if err:
         return None, err
+    # Agent-generation path — strict catalog + action-wiring gate on the
+    # widget's own ``spec`` subtree (#1208). Mirrors the pocket-level gate
+    # in ``agent_replace_node`` so the home-pocket widget-add surface gets
+    # the same protection against hallucinated dispatcher verbs and unwired
+    # "Refresh" buttons. Validate BEFORE constructing the doc so a violating
+    # spec never reaches the save path.
+    gate_error = await _gate_widget_spec_for_agent(
+        widget.get("spec") if isinstance(widget.get("spec"), dict) else None,
+        widget_type=widget.get("type") if isinstance(widget.get("type"), str) else None,
+        actor="agent",
+        workspace_id=doc.workspace,
+        pocket_id=str(doc.id),
+    )
+    if gate_error is not None:
+        return None, gate_error
     try:
         new_widget = _build_widget_doc(widget)
     except Exception as exc:  # noqa: BLE001
@@ -1656,6 +1727,27 @@ async def agent_update_widget(
     widget = next((w for w in doc.widgets if w.id == widget_id), None)
     if widget is None:
         return None, f"widget {widget_id} not found in pocket {pocket_id}"
+    # Agent-generation path — strict catalog + action-wiring gate when the
+    # update overwrites ``spec`` (#1208). Only fires when a new spec is
+    # supplied; a name-only / colour-only patch skips the gate the same way
+    # the MCP-layer manifest check does. ``type`` resolution mirrors the
+    # post-update widget state: take ``fields.type`` when provided, else
+    # fall back to the existing widget's type so a native widget that
+    # accidentally received a non-empty spec dict still short-circuits.
+    if "spec" in fields:
+        new_spec = fields["spec"] if isinstance(fields["spec"], dict) else None
+        effective_type = (
+            fields["type"] if "type" in fields and isinstance(fields["type"], str) else widget.type
+        )
+        gate_error = await _gate_widget_spec_for_agent(
+            new_spec,
+            widget_type=effective_type,
+            actor="agent",
+            workspace_id=doc.workspace,
+            pocket_id=str(doc.id),
+        )
+        if gate_error is not None:
+            return None, gate_error
     for k in ("name", "type", "icon", "color", "span", "data", "spec", "assignedAgent"):
         if k in fields:
             setattr(widget, k, fields[k])

--- a/tests/cloud/test_pocket_widget_spec_gate.py
+++ b/tests/cloud/test_pocket_widget_spec_gate.py
@@ -1,0 +1,500 @@
+# tests/cloud/test_pocket_widget_spec_gate.py
+# Created: 2026-05-24 (#1208) — service-level coverage for the catalog +
+# action-wiring gates that now run on ``widgets[].spec`` in
+# ``agent_add_widget`` and ``agent_update_widget``.
+#
+# Before #1208 these chat-driven write paths bypassed the same gates the
+# pocket-level surface (``agent_replace_node`` and friends) gets, so an
+# agent-authored widget could land in Mongo with a hallucinated
+# dispatcher verb (``action: "fetch"``) or an unwired "Refresh" button —
+# the failure modes #1194/#1196 covered at the pocket level.
+#
+# What's covered:
+#   - ``agent_add_widget`` rejects a widget whose ``spec.props.on_click``
+#     uses an invented verb; nothing is persisted.
+#   - ``agent_update_widget`` rejects the same payload on the update path.
+#   - ``agent_add_widget`` rejects a live-labelled "Refresh" button with
+#     an empty ``on_click`` — the #1196 class applied to a widget spec.
+#   - ``agent_add_widget`` accepts a canonical ``run_source`` button
+#     (positive control — sanity check the gate isn't over-eager).
+#   - Manifest-unavailable best-effort: when the catalog allow-list can't
+#     be fetched, the gate is a no-op and the widget lands as before.
+#   - Native widgets (``type="native"``) skip the gate even with a stale
+#     spec — they carry no rippleSpec by contract.
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.models.pocket import Widget as _WidgetDoc  # noqa: E402
+from pocketpaw_ee.cloud.pockets import service as pockets_service  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Test doc + patch helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeHomePocketDoc:
+    """Stand-in for a ``_PocketDoc`` whose widgets array starts empty.
+
+    Mirrors the surface ``agent_add_widget`` and ``agent_update_widget``
+    read: ``id`` / ``workspace`` / ``owner`` / a ``widgets`` list of
+    ``_WidgetDoc`` sub-models. ``save()`` is an async no-op that bumps a
+    counter so the tests can assert "nothing persisted" by checking that
+    ``saves == 0`` after a rejection.
+    """
+
+    def __init__(
+        self,
+        pocket_id: str,
+        widgets: list[_WidgetDoc] | None = None,
+    ) -> None:
+        self.id = pocket_id
+        self.workspace = "w-home"
+        self.name = "Home"
+        self.description = ""
+        self.type = "home"
+        self.icon = ""
+        self.color = ""
+        self.owner = "u-home"
+        self.visibility = "private"
+        self.team: list[str] = []
+        self.agents: list[str] = []
+        self.widgets: list[_WidgetDoc] = list(widgets or [])
+        self.rippleSpec: dict[str, Any] | None = None
+        self.share_link_token: str | None = None
+        self.share_link_access = "view"
+        self.shared_with: list[str] = []
+        self.tool_specs: list[Any] = []
+        self.saves = 0
+
+    async def save(self) -> None:
+        self.saves += 1
+
+    def model_dump(self, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "_id": self.id,
+            "workspace": self.workspace,
+            "name": self.name,
+            "description": self.description,
+            "type": self.type,
+            "icon": self.icon,
+            "color": self.color,
+            "owner": self.owner,
+            "visibility": self.visibility,
+            "team": list(self.team),
+            "agents": list(self.agents),
+            "widgets": [w.model_dump(by_alias=True) for w in self.widgets],
+            "rippleSpec": self.rippleSpec,
+            "share_link_token": self.share_link_token,
+            "share_link_access": self.share_link_access,
+            "shared_with": list(self.shared_with),
+            "tool_specs": list(self.tool_specs),
+        }
+
+
+def _patch_seams(
+    doc: _FakeHomePocketDoc,
+    allowed_types: list[str] | None = None,
+) -> ExitStack:
+    """Patch the seams ``agent_add_widget`` / ``agent_update_widget`` touch:
+    doc fetch, emit, payload builder, per-stream identity ContextVars, and
+    the manifest allow-list. ``allowed_types`` becomes the manifest stub —
+    pass ``None`` to simulate a manifest outage (gate becomes a no-op).
+    """
+    stack = ExitStack()
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service._PocketDoc.get",
+            new=AsyncMock(return_value=doc),
+        ),
+    )
+    stack.enter_context(
+        patch("pocketpaw_ee.cloud.pockets.service.emit", new=AsyncMock()),
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service._pocket_event_payload",
+            new=AsyncMock(return_value={"pocket_id": doc.id}),
+        ),
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+            new=MagicMock(return_value=doc.workspace),
+        ),
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+            new=MagicMock(return_value=doc.owner),
+        ),
+    )
+
+    # Stub the catalog allow-list so the gate has a deterministic answer
+    # without hitting the network. ``None`` means "manifest unavailable" —
+    # the gate skips, mirroring the production best-effort posture.
+    async def _allowed() -> list[str] | None:
+        return allowed_types
+
+    stack.enter_context(
+        patch.object(pockets_service, "_catalog_allowed_types", _allowed),
+    )
+    return stack
+
+
+# Default allow-list that lets a button widget through the catalog walk.
+# The action-wiring gate is what we actually want to fire in the negative
+# tests — the catalog walk is just here so we don't trip on the type name.
+_BUTTON_OK_TYPES = ["button", "chart", "flex", "stat", "heading"]
+
+
+# ---------------------------------------------------------------------------
+# agent_add_widget — verb hallucination is rejected, nothing persisted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_add_widget_rejects_hallucinated_action_verb() -> None:
+    """A button widget whose ``on_click`` uses an invented dispatcher verb
+    (``action: "fetch"``) must be rejected before the doc is saved.
+
+    Verb hallucination is the #1194 failure mode applied to a widget
+    spec — the renderer's event dispatcher silently no-ops unknown
+    verbs, so a button that looks live in the canvas does nothing at
+    runtime. The gate's corrective error names the offending verb so
+    the agent can retry with a real one (``run_source``).
+    """
+    doc = _FakeHomePocketDoc("507f1f77bcf86cd799430111")
+    widget = {
+        "name": "Refresh sales",
+        "type": "button",
+        "spec": {
+            "type": "button",
+            "props": {
+                "label": "Refresh",
+                "on_click": {"action": "fetch", "source": "sales"},
+            },
+        },
+    }
+    with _patch_seams(doc, allowed_types=_BUTTON_OK_TYPES):
+        view, err = await pockets_service.agent_add_widget(doc.id, widget)
+
+    assert view is None
+    assert err is not None
+    # Error names the bad verb so the specialist sees exactly what to fix.
+    assert "fetch" in err
+    # Nothing landed in the widget list and the doc was never saved.
+    assert doc.widgets == []
+    assert doc.saves == 0
+
+
+# ---------------------------------------------------------------------------
+# agent_update_widget — same gate on the update path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_update_widget_rejects_hallucinated_action_verb() -> None:
+    """An update that overwrites ``spec`` with a hallucinated verb is
+    rejected the same way ``add_widget`` rejects it on creation.
+
+    The pre-existing widget's spec is preserved on rejection — the
+    rejected payload never reaches the in-place setattr loop.
+    """
+    original_spec = {
+        "type": "button",
+        "props": {
+            "label": "Refresh",
+            "on_click": {"action": "run_source", "source": "sales"},
+        },
+    }
+    widget = _WidgetDoc(
+        name="Refresh sales",
+        type="button",
+        icon="refresh-cw",
+        color="#0A84FF",
+        spec=original_spec,
+    )
+    doc = _FakeHomePocketDoc("507f1f77bcf86cd799430222", widgets=[widget])
+
+    bad_spec = {
+        "type": "button",
+        "props": {
+            "label": "Refresh",
+            "on_click": {"action": "backend_fetch", "source": "sales"},
+        },
+    }
+    with _patch_seams(doc, allowed_types=_BUTTON_OK_TYPES):
+        view, err = await pockets_service.agent_update_widget(
+            doc.id,
+            widget.id,
+            {"spec": bad_spec},
+        )
+
+    assert view is None
+    assert err is not None
+    assert "backend_fetch" in err
+    # The existing widget's spec was NOT overwritten by the rejected payload.
+    assert doc.widgets[0].spec == original_spec
+    assert doc.saves == 0
+
+
+# ---------------------------------------------------------------------------
+# agent_add_widget — #1196 sibling: live-labelled, unwired Refresh button
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_add_widget_rejects_empty_on_click_on_refresh_button() -> None:
+    """A button labelled "Refresh" whose ``on_click`` is missing entirely
+    is the #1196 failure mode applied at the widget-spec layer.
+
+    A live label promises live behaviour; the renderer has no handler to
+    invoke, so the button is decorative. The gate must reject this with
+    a message that names the unwired handler so the agent re-emits with
+    a real source/api binding.
+    """
+    doc = _FakeHomePocketDoc("507f1f77bcf86cd799430333")
+    widget = {
+        "name": "Refresh sales",
+        "type": "button",
+        "spec": {
+            "type": "button",
+            "props": {
+                "label": "Refresh",
+                # No on_click at all — looks live, does nothing.
+            },
+        },
+    }
+    with _patch_seams(doc, allowed_types=_BUTTON_OK_TYPES):
+        view, err = await pockets_service.agent_add_widget(doc.id, widget)
+
+    assert view is None
+    assert err is not None
+    # The unwired-live-button gate uses "Refresh" as the label in its
+    # violation payload and "on_click" / "live" in the reason string.
+    assert "Refresh" in err or "on_click" in err
+    assert doc.widgets == []
+    assert doc.saves == 0
+
+
+# ---------------------------------------------------------------------------
+# agent_add_widget — positive control
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_add_widget_accepts_canonical_run_source_button() -> None:
+    """A button wired to ``run_source`` against a declared source key is
+    the canonical pattern the catalog wants. The gate must NOT block it.
+
+    This is the positive control: it would catch a future regression
+    where the gate became over-eager and started rejecting valid
+    payloads. The spec carries a ``sources`` block so the unwired-button
+    walker sees ``run_source`` references a real key.
+    """
+    doc = _FakeHomePocketDoc("507f1f77bcf86cd799430444")
+    widget = {
+        "name": "Refresh sales",
+        "type": "button",
+        "spec": {
+            "type": "button",
+            "props": {
+                "label": "Refresh",
+                "on_click": {"action": "run_source", "source": "sales"},
+            },
+            "sources": {"sales": {"kind": "static", "data": []}},
+        },
+    }
+    with _patch_seams(doc, allowed_types=_BUTTON_OK_TYPES):
+        view, err = await pockets_service.agent_add_widget(doc.id, widget)
+
+    assert err is None, f"gate falsely rejected a valid widget: {err!r}"
+    assert view is not None
+    # The widget landed in the array and the doc was saved exactly once.
+    assert len(doc.widgets) == 1
+    assert doc.widgets[0].name == "Refresh sales"
+    assert doc.saves == 1
+
+
+# ---------------------------------------------------------------------------
+# Manifest-unavailable best-effort — gate becomes a no-op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_add_widget_skips_gate_when_manifest_unavailable() -> None:
+    """When the widget manifest can't be fetched the catalog gate is a
+    no-op — same best-effort posture as ``_gate_catalog`` for the
+    pocket-level surface. A spec that would otherwise be rejected lands
+    so the agent isn't blocked by a transient manifest outage.
+
+    The action-wiring half (verb + unwired-button walkers) lives inside
+    the catalog gate's strict branch, so it skips alongside the catalog
+    walk when no manifest is reachable. The MCP-layer verb check (#1208)
+    still fires because it doesn't need a manifest — but this test
+    exercises the service-layer path directly, so we expect the write to
+    succeed.
+    """
+    doc = _FakeHomePocketDoc("507f1f77bcf86cd799430555")
+    widget = {
+        "name": "Refresh sales",
+        "type": "button",
+        "spec": {
+            "type": "button",
+            "props": {
+                "label": "Refresh",
+                "on_click": {"action": "fetch"},  # would normally be rejected
+            },
+        },
+    }
+    with _patch_seams(doc, allowed_types=None):
+        view, err = await pockets_service.agent_add_widget(doc.id, widget)
+
+    assert err is None
+    assert view is not None
+    assert len(doc.widgets) == 1
+    assert doc.saves == 1
+
+
+# ---------------------------------------------------------------------------
+# Native widgets skip the gate even with a stale spec
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_add_widget_native_type_skips_gate() -> None:
+    """A native widget carries no rippleSpec by contract; the gate must
+    short-circuit on ``type="native"`` so a defensive caller passing in a
+    stale spec dict doesn't get blocked. Mirrors the MCP-layer
+    ``_validate_widget_spec`` posture.
+    """
+    doc = _FakeHomePocketDoc("507f1f77bcf86cd799430666")
+    widget = {
+        "name": "AgentStatus",
+        "type": "native",
+        # Stale spec — would fail the gate if we didn't skip on native.
+        "spec": {"type": "button", "props": {"on_click": {"action": "fetch"}}},
+    }
+    with _patch_seams(doc, allowed_types=_BUTTON_OK_TYPES):
+        view, err = await pockets_service.agent_add_widget(doc.id, widget)
+
+    assert err is None, f"native widget falsely rejected: {err!r}"
+    assert view is not None
+    assert len(doc.widgets) == 1
+    assert doc.saves == 1
+
+
+# ---------------------------------------------------------------------------
+# agent_update_widget — non-spec patches skip the gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_update_widget_without_spec_skips_gate() -> None:
+    """A patch that only touches ``name`` / ``color`` / ``span`` does NOT
+    re-run the gate against the existing spec. The gate is scoped to
+    "the new spec the caller is supplying" — re-validating an
+    already-persisted spec on every name change would be a footgun.
+    """
+    widget = _WidgetDoc(
+        name="Refresh sales",
+        type="button",
+        icon="refresh-cw",
+        color="#0A84FF",
+        spec={
+            "type": "button",
+            "props": {
+                "label": "Refresh",
+                "on_click": {"action": "run_source", "source": "sales"},
+            },
+        },
+    )
+    doc = _FakeHomePocketDoc("507f1f77bcf86cd799430777", widgets=[widget])
+
+    with _patch_seams(doc, allowed_types=_BUTTON_OK_TYPES):
+        view, err = await pockets_service.agent_update_widget(
+            doc.id,
+            widget.id,
+            {"name": "Refresh sales today"},
+        )
+
+    assert err is None
+    assert view is not None
+    # Name changed, spec untouched, one save.
+    assert doc.widgets[0].name == "Refresh sales today"
+    assert doc.saves == 1
+
+
+# ---------------------------------------------------------------------------
+# MCP-layer intermediate option — verb check fires without a manifest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_validate_widget_spec_rejects_unknown_verb_without_manifest() -> None:
+    """The MCP-layer ``_validate_widget_spec`` (the lighter intermediate
+    option from #1208) now runs the OSS-side ``validate_action_verbs``
+    walker BEFORE the manifest check, so a hallucinated verb is rejected
+    even when the manifest can't be reached.
+
+    This complements the service-layer gate: it's a cheap belt-and-
+    suspenders that gives the agent a tight corrective hint at the MCP
+    boundary, saving a cloud round-trip on the most common failure mode.
+    """
+    from pocketpaw_ee.agent.mcp_servers.pockets import _validate_widget_spec
+
+    widget = {
+        "type": "button",
+        "spec": {
+            "type": "button",
+            "props": {
+                "label": "Refresh",
+                "on_click": {"action": "fetch"},
+            },
+        },
+    }
+    # Patch the manifest fetch to None — verb check still runs because
+    # it's a pure function with no manifest dependency.
+    with patch(
+        "pocketpaw_ee.agent.mcp_servers.pockets._get_manifest_for_validation",
+        new=AsyncMock(return_value=None),
+    ):
+        err = await _validate_widget_spec(widget)
+
+    assert err is not None
+    assert "fetch" in err
+
+
+@pytest.mark.asyncio
+async def test_mcp_validate_widget_spec_accepts_canonical_verb() -> None:
+    """Positive control for the MCP-layer verb check — a canonical verb
+    passes the verb walker. The manifest then has nothing to validate
+    (no manifest fetched in this test), so the function returns None.
+    """
+    from pocketpaw_ee.agent.mcp_servers.pockets import _validate_widget_spec
+
+    widget = {
+        "type": "button",
+        "spec": {
+            "type": "button",
+            "props": {
+                "label": "Refresh",
+                "on_click": {"action": "run_source", "source": "sales"},
+            },
+        },
+    }
+    with patch(
+        "pocketpaw_ee.agent.mcp_servers.pockets._get_manifest_for_validation",
+        new=AsyncMock(return_value=None),
+    ):
+        err = await _validate_widget_spec(widget)
+
+    assert err is None


### PR DESCRIPTION
## Summary

The chat-driven write paths `agent_add_widget` and `agent_update_widget` in `ee/pocketpaw_ee/cloud/pockets/service.py` skipped the catalog + action-wiring gates that the pocket-level surface (`agent_replace_node`) already runs. So an agent-authored widget with `on_click: {action: "fetch"}` or a "Refresh" button with an empty `on_click` landed in Mongo even though the same payloads would have been rejected one layer up. The failure modes #1194 and #1196 caught at the pocket level were reappearing on the home pocket's widget-add surface.

This PR applies the same strict catalog + action-wiring gates to `widgets[].spec` on both write paths, with the manifest-unavailable best-effort skip the pocket-level gate already uses. The MCP-layer `_validate_widget_spec` also runs the OSS-side verb walker first as a cheap belt-and-suspenders so the most common failure mode gets a tight corrective hint without a cloud round-trip.

## What changed

- `ee/pocketpaw_ee/cloud/pockets/service.py` — new `_gate_widget_spec_for_agent` helper that runs `_gate_catalog(strict=True)` over a single widget's `spec` subtree and formats `CatalogViolationError` / `ActionWiringViolationError` through the existing agent-readable formatters. Wired into `agent_add_widget` (always when a spec is present) and `agent_update_widget` (only when the patch supplies a new spec). Native widgets short-circuit on `type="native"`.
- `ee/pocketpaw_ee/agent/mcp_servers/pockets.py` — `_validate_widget_spec` now runs `validate_action_verbs` from the OSS `pocketpaw.ripple.manifest` before the manifest prop check. Pure function, no manifest dep, so the verb half is caught even on a manifest outage.
- `tests/cloud/test_pocket_widget_spec_gate.py` — 9 new tests covering verb rejection on both add and update, the unwired-Refresh-button case from #1196, the canonical `run_source` positive control, manifest-unavailable best-effort, native-widget skip, non-spec patches skip, and the MCP-layer verb check.

## Test plan

- [x] `uv run pytest tests/cloud/test_pocket_widget_spec_gate.py -v` (9 passed)
- [x] `uv run pytest tests/cloud/test_home_pocket.py tests/cloud/test_home_pocket_update_widget.py tests/cloud/test_pocket_catalog_gate.py tests/cloud/test_pocket_granular_ops.py tests/ee/agent/test_pocket_specialist/ tests/ee/test_pocket_specialist.py -v` (154 passed, no regressions)
- [x] `uv run ruff check` on touched files (clean)
- [x] `uv run ruff format --check` on touched files (clean)
- [x] Five pre-existing failures in `tests/cloud/test_connectors_*.py` and `tests/cloud/uploads/test_router_pocket_acl.py` exist on the base branch (unrelated to widget gates).

Closes #1208.