### PR TITLE
feat(ripple): invoke_tool action verb + /pockets/{id}/tools/run wire stub

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -42,6 +42,13 @@ RunActionResponse is now ``extra="forbid"`` so an executor-internal key
 (``_park``, ``outcome``) that the router fails to strip raises on
 construction instead of leaking the resolved write path/params onto the
 wire.
+Updated: 2026-05-24 (#1206 part a) — added RunToolRequest /
+RunToolResponse for the new ``POST /pockets/{id}/tools/run`` wire (the
+click-driven sibling of ``sources/run`` and ``actions/run``). The
+endpoint runs a named server-side tool with the resolved args from the
+``invoke_tool`` ripple action verb; the allowlist is intentionally empty
+in part (a) so the wire is locked down before any tool can fire (parts b
+and c add the home-grid plumbing + prompt guidance).
 Updated: 2026-05-28 (feat/wave-3b-action-pipeline) — added
 DispatchBulkRequest / BulkDispatchResponse / BulkExecutionResultDTO /
 BulkBlockedRowDTO for the new
@@ -364,6 +371,65 @@ class SetWritePolicyRequest(BaseModel):
     """
 
     allowed_writes: list[AllowedWriteDTO] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Pocket tool invocations (#1206 part a — invoke_tool wire)
+# ---------------------------------------------------------------------------
+
+
+class RunToolRequest(BaseModel):
+    """Body for ``POST /pockets/{id}/tools/run`` (#1206 part a).
+
+    The client sends the tool's NAME (``tool``) plus the *resolved*
+    ``args`` — Ripple's ``{state.x}`` / ``{item.id}`` expression resolver
+    runs client-side at click time, so the server sees plain values, not
+    expressions. Sibling to ``RunSourcesRequest`` (read-only fetch) and
+    ``RunActionRequest`` (named write binding); ``invoke_tool`` runs a
+    named server-side tool (WebFetch, Composio, etc.) and re-hydrates the
+    UI from the result.
+
+    The allowlist enforcement lives in the executor: an empty allowlist
+    fails closed with ``code="not_allowed"``. The wire-level allowlist is
+    intentionally empty in part (a) so nothing fires until the captain
+    explicitly enables tools per pocket; the home-grid plumbing that
+    actually POSTs here lands in part (b).
+    """
+
+    tool: str = Field(min_length=1)
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+class RunToolResponse(BaseModel):
+    """Result of an ``invoke_tool`` run.
+
+    Mirrors :class:`RunActionResponse` so a single client-side reconcile
+    handler shape services both write actions and tool invocations. On a
+    fired tool ``ok`` is true and ``status`` / ``response`` carry the
+    tool's HTTP-shaped result. On rejection ``ok`` is false and
+    ``error`` / ``code`` describe the reason — ``not_allowed`` when the
+    tool isn't on the pocket's allowlist, ``unknown_tool`` when no
+    registry entry matches.
+
+    ``on_success`` / ``on_error`` are the reconcile handler lists the
+    client runs after — the same shape ``call_binding`` returns, so the
+    home grid's ``onEvent`` plumbing handles both with one branch.
+
+    ``extra="forbid"`` matches :class:`RunActionResponse`: any
+    executor-internal key the route fails to strip raises on
+    construction instead of leaking onto the wire.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    ok: bool
+    tool: str
+    status: int | None = None
+    response: Any = None
+    error: str | None = None
+    code: str | None = None
+    on_success: list[dict] = Field(default_factory=list)
+    on_error: list[dict] = Field(default_factory=list)
 
 
 class SetApprovalRouteRequest(BaseModel):

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -67,6 +67,21 @@ chain — so an upstream system can trigger a refresh without a user
 session. A wrong / missing secret returns the SAME 403 whether or not the
 pocket exists, so the endpoint is not a tenant-existence oracle. The two
 secret-management routes are owner-only.
+
+Updated: 2026-05-24 (#1206 part a) — added the tool-run wire stub:
+
+    POST /pockets/{id}/tools/run — invoke a named server-side tool
+
+The endpoint is the click-driven sibling of ``/sources/run`` (read-only
+hydration) and ``/actions/run`` (named write binding). It accepts a tool
+name plus pre-resolved args from the new ``invoke_tool`` Ripple action
+verb and runs the named tool against the per-pocket allowlist. The
+allowlist is intentionally empty in part (a) so the wire is locked down
+before any tool can actually fire; the home-grid ``onEvent`` plumbing
+that POSTs to this route lands in part (b), and Composio / WebFetch
+routing through the real tool registry is a follow-up. Auth gating
+mirrors ``/actions/run`` (owner OR explicit ``shared_with``) — a tool
+invocation has the same blast radius as a write binding.
 """
 
 from __future__ import annotations
@@ -93,6 +108,8 @@ from pocketpaw_ee.cloud.pockets.dto import (
     RunActionRequest,
     RunActionResponse,
     RunSourcesRequest,
+    RunToolRequest,
+    RunToolResponse,
     SetApprovalRouteRequest,
     SetWritePolicyRequest,
     ShareLinkRequest,
@@ -816,6 +833,66 @@ async def dispatch_bulk_action_route(
         template=template,
     )
     return BulkDispatchResponse(**result_wire)
+
+
+# ---------------------------------------------------------------------------
+# Pocket tool invocation (#1206 part a — invoke_tool wire)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{pocket_id}/tools/run",
+    dependencies=[Depends(require_pocket_action_run)],
+)
+async def run_pocket_tool(
+    pocket_id: str,
+    body: RunToolRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> RunToolResponse:
+    """Invoke a named server-side tool with the resolved args from the
+    ``invoke_tool`` Ripple action verb (#1206 part a).
+
+    Click-driven sibling of ``/sources/run`` (read-only hydration) and
+    ``/actions/run`` (named write binding). The home grid's ``onEvent``
+    plumbing (part b) POSTs here when a ripple button fires
+    ``{action: "invoke_tool", tool: "X", args: {...}}``.
+
+    Access is OWNER or explicit ``shared_with`` ONLY — a tool invocation
+    has the same blast radius as a write binding, so a workspace-visible
+    pocket does NOT grant run access.
+
+    Part (a) is intentionally fail-closed: the per-pocket allowlist is
+    empty (see :func:`tool_executor.get_pocket_allowed_tools`), so every
+    tool name returns ``ok:false, code:"not_allowed"``. The wire shape +
+    DTOs land here so part (b) (the home-grid ``onEvent`` wiring) has
+    somewhere to POST to. Part (c) adds Composio / WebFetch routing
+    through the real tool registry behind the allowlist.
+
+    The result is delivered in THIS response body — there is no
+    ``pocket_mutation`` SSE emit, because the run endpoint is a
+    standalone REST call outside any SSE stream. The client applies the
+    ``on_success`` / ``on_error`` reconcile handlers.
+    """
+    # Ensure the caller can actually see this pocket — `get` raises
+    # NotFound when the pocket is missing or not in the user's scope, so
+    # we don't expose a tenant-existence oracle via the tool wire either.
+    await pockets_service.get(pocket_id, user_id)
+
+    from pocketpaw_ee.cloud.pockets import tool_executor
+
+    allowed_tools = await tool_executor.get_pocket_allowed_tools(workspace_id, pocket_id)
+
+    # no-event: the tool result is response-body delivery, not persisted.
+    result = await tool_executor.run_tool(
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        user_id=user_id,
+        tool=body.tool,
+        args=body.args,
+        allowed_tools=allowed_tools,
+    )
+    return RunToolResponse(**result)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/pockets/tool_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/tool_executor.py
@@ -1,0 +1,100 @@
+# tool_executor.py — Server-side executor for pocket tool invocations.
+# Created: 2026-05-24 (#1206 part a — invoke_tool wire).
+#
+# The click-driven sibling of ``source_executor`` (read-only fetch) and
+# ``action_executor`` (named write binding). This executor receives a tool
+# NAME plus pre-resolved args from the ``invoke_tool`` ripple action verb
+# and runs the named tool against the pocket's tool allowlist.
+#
+# In part (a) the allowlist is intentionally empty — the wire is locked
+# down before any tool can fire. The real tool registry + Composio /
+# WebFetch wiring lands in a follow-up; part (b) adds the home-grid
+# ``onEvent`` plumbing that POSTs to ``/pockets/{id}/tools/run`` and the
+# allowlist storage on the per-pocket backend config.
+#
+# IMPORT-LINTER: must NOT import ``pocketpaw_ee.cloud.models.*``. The
+# executor receives the allowlist by parameter only — the router /
+# service owns Beanie access.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def get_pocket_allowed_tools(workspace_id: str, pocket_id: str) -> list[str]:
+    """Return the list of tool names allowed for this pocket.
+
+    Part (a) intentionally returns ``[]`` for every pocket — the wire is
+    in place but no tool is enabled until the captain explicitly turns
+    one on per pocket (the allowlist storage lives on the per-pocket
+    backend config row in a follow-up). The empty default is fail-closed:
+    every ``invoke_tool`` POST is rejected with ``code="not_allowed"``
+    until that follow-up ships.
+    """
+    # `workspace_id` and `pocket_id` are accepted now so callers don't
+    # have to change shape when the real allowlist is plumbed through.
+    _ = (workspace_id, pocket_id)
+    return []
+
+
+async def run_tool(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    tool: str,
+    args: dict[str, Any],
+    allowed_tools: list[str],
+) -> dict[str, Any]:
+    """Run a named tool with the resolved args, returning a wire dict
+    shaped like :class:`RunActionResponse`.
+
+    Part (a) wires only the gate: an empty allowlist (default) rejects
+    every call with ``code="not_allowed"``; a tool name not on the
+    allowlist gets the same response. Real tool execution (Composio /
+    WebFetch routing through the existing tool registry) lands in a
+    follow-up — the response shape stays the same so the home-grid
+    reconcile handlers don't change.
+
+    ``workspace_id`` and ``user_id`` are accepted now so the future audit
+    log + per-(pocket, user) rate limit can plumb in without touching the
+    route signature.
+    """
+    # The kwargs are part of the public contract — accept and pass-through
+    # even before the real executor lands so the route signature doesn't
+    # have to change later.
+    _ = (workspace_id, user_id, args)
+
+    if tool not in allowed_tools:
+        logger.info(
+            "tool_executor.run_tool denied: tool=%r pocket=%r user=%r reason=not_allowed",
+            tool,
+            pocket_id,
+            user_id,
+        )
+        return {
+            "ok": False,
+            "tool": tool,
+            "error": f"tool {tool!r} is not on the pocket's allowlist",
+            "code": "not_allowed",
+        }
+
+    # The allowlist passed the name through, but no tool registry is
+    # wired up yet in part (a). Surface that as a structured error so
+    # the home-grid reconcile handlers can show a friendly toast; the
+    # follow-up replaces this branch with the real tool dispatch.
+    logger.info(
+        "tool_executor.run_tool unknown: tool=%r pocket=%r user=%r — registry not wired",
+        tool,
+        pocket_id,
+        user_id,
+    )
+    return {
+        "ok": False,
+        "tool": tool,
+        "error": f"tool {tool!r} is allowlisted but no registry implementation is wired yet",
+        "code": "unknown_tool",
+    }

--- a/src/pocketpaw/ripple/manifest.py
+++ b/src/pocketpaw/ripple/manifest.py
@@ -18,6 +18,10 @@ Changes:
     ``check_embed_nodes_in_spec`` — an https-only, host-allowlisted URL
     policy for the sanctioned ``embed`` escape-hatch widget, with
     loopback / private / link-local hosts hard-blocked unconditionally.
+  - 2026-05-24 (#1206 part a): added ``invoke_tool`` to
+    :data:`_KNOWN_ACTION_VERBS` — the click-driven sibling of
+    ``run_source`` / ``call_binding`` that routes a button into a
+    server-side tool via the new ``POST /pockets/{id}/tools/run`` wire.
 """
 
 from __future__ import annotations
@@ -511,6 +515,14 @@ def _walk_embed_policy(
 # verb pass spec validation and silently no-op at runtime, which is the
 # exact failure we are guarding against; mirror this list whenever the
 # dispatcher gains a new case.
+#
+# ``invoke_tool`` is the click-driven sibling of ``run_source`` /
+# ``call_binding`` (#1206 part a): a button hands the host a tool name +
+# resolved args, the host runs the named tool via the per-pocket
+# ``POST /pockets/{id}/tools/run`` wire, the result flows back into the
+# usual ``on_success`` / ``on_error`` chain. The verb is fully wired into
+# the dispatcher in part (a); the home-grid ``onEvent`` plumbing that
+# actually POSTs to the wire lands in part (b).
 _KNOWN_ACTION_VERBS: frozenset[str] = frozenset(
     {
         "set",
@@ -526,6 +538,7 @@ _KNOWN_ACTION_VERBS: frozenset[str] = frozenset(
         "api",
         "run_source",
         "call_binding",
+        "invoke_tool",
         "flow",
         "branch",
         "confirm",

--- a/tests/cloud/pockets/__init__.py
+++ b/tests/cloud/pockets/__init__.py
@@ -1,0 +1,6 @@
+# __init__.py — Pockets entity test package.
+# Created: 2026-05-24 (#1206 part a — invoke_tool wire) — hosts route- and
+# executor-level tests for the per-pocket primitives layered alongside the
+# router (sources/run, actions/run, tools/run, …). The legacy per-feature
+# test files live directly under ``tests/cloud/`` and stay there to keep
+# git history clean; new per-route test files go here.

--- a/tests/cloud/pockets/test_tools_run.py
+++ b/tests/cloud/pockets/test_tools_run.py
@@ -1,0 +1,238 @@
+# tests/cloud/pockets/test_tools_run.py — #1206 part a (invoke_tool wire).
+# Created: 2026-05-24 — Integration coverage for the new tool-run route:
+#
+#   POST /pockets/{id}/tools/run — invoke a named server-side tool with the
+#                                  resolved args from the new invoke_tool
+#                                  Ripple action verb.
+#
+# Part (a) intentionally ships an empty allowlist so every tool call is
+# rejected with `code:"not_allowed"`. These tests pin the wire-level
+# contract (auth gate, tenancy scoping, structured error shape) so part
+# (b) — the home-grid `onEvent` plumbing — can rely on a stable surface.
+#
+# The pocket service + tool executor are monkeypatched, so the tests pin
+# the route wiring (request body parsing, status codes, response shape)
+# without a Mongo connection or real outbound HTTP. Auth + license guards
+# are overridden — same pattern as test_pocket_backend_routes.py.
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets import tool_executor
+from pocketpaw_ee.cloud.pockets.router import router
+from pocketpaw_ee.cloud.shared.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_pocket_action_run,
+    require_pocket_edit,
+    require_pocket_owner,
+)
+
+FAKE_USER = "user-alice"
+FAKE_WORKSPACE = "ws-alpha"
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+
+    a = FastAPI()
+    add_error_handler(a)
+    a.include_router(router)
+
+    a.dependency_overrides[require_license] = lambda: None
+    a.dependency_overrides[require_pocket_edit] = lambda: None
+    a.dependency_overrides[require_pocket_owner] = lambda: None
+    a.dependency_overrides[require_pocket_action_run] = lambda: None
+    a.dependency_overrides[current_user_id] = lambda: FAKE_USER
+    a.dependency_overrides[current_workspace_id] = lambda: FAKE_WORKSPACE
+    return a
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Empty-allowlist default — every tool returns `code:"not_allowed"`
+# ---------------------------------------------------------------------------
+
+
+def test_run_tool_empty_allowlist_returns_not_allowed(monkeypatch, client):
+    """Part (a) ships with no tools enabled. Every POST returns ok:false
+    with code:not_allowed so the wire is locked down until the captain
+    explicitly enables a tool per pocket."""
+
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id}
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+
+    res = client.post(
+        "/pockets/pocket-1/tools/run",
+        json={"tool": "WebFetch", "args": {"url": "https://api.example.com/x"}},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ok"] is False
+    assert body["tool"] == "WebFetch"
+    assert body["code"] == "not_allowed"
+    # The wire shape mirrors RunActionResponse so the home-grid reconcile
+    # handlers don't need a separate branch — on_success/on_error are
+    # always present (empty lists by default).
+    assert body["on_success"] == []
+    assert body["on_error"] == []
+
+
+def test_run_tool_threads_workspace_user_pocket_to_executor(monkeypatch, client):
+    """The route forwards tenancy + caller identity into the executor so
+    a future audit log + per-(pocket, user) rate limit can plumb in
+    without touching the route signature."""
+
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id}
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+
+    captured: dict[str, object] = {}
+
+    async def _run_tool(**kwargs):
+        captured.update(kwargs)
+        return {"ok": False, "tool": kwargs["tool"], "code": "not_allowed"}
+
+    async def _allowlist(workspace_id, pocket_id):
+        captured.setdefault("allowlist_args", []).append((workspace_id, pocket_id))
+        return []
+
+    monkeypatch.setattr(tool_executor, "run_tool", _run_tool)
+    monkeypatch.setattr(tool_executor, "get_pocket_allowed_tools", _allowlist)
+
+    res = client.post(
+        "/pockets/pocket-1/tools/run",
+        json={"tool": "GMAIL_FETCH_EMAILS", "args": {"label": "INBOX"}},
+    )
+    assert res.status_code == 200, res.text
+    assert captured["workspace_id"] == FAKE_WORKSPACE
+    assert captured["pocket_id"] == "pocket-1"
+    assert captured["user_id"] == FAKE_USER
+    assert captured["tool"] == "GMAIL_FETCH_EMAILS"
+    assert captured["args"] == {"label": "INBOX"}
+    assert captured["allowed_tools"] == []
+    # The allowlist lookup is workspace-scoped.
+    assert captured["allowlist_args"] == [(FAKE_WORKSPACE, "pocket-1")]
+
+
+def test_run_tool_returns_unknown_tool_when_allowlisted_but_unregistered(monkeypatch, client):
+    """An allowlist with the tool name but no registry implementation
+    yet returns `code:unknown_tool` — the wire surface is in place so
+    the follow-up that adds Composio / WebFetch routing replaces this
+    branch without changing the response shape."""
+
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id}
+
+    async def _allowlist(workspace_id, pocket_id):
+        return ["GMAIL_FETCH_EMAILS"]
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(tool_executor, "get_pocket_allowed_tools", _allowlist)
+
+    res = client.post(
+        "/pockets/pocket-1/tools/run",
+        json={"tool": "GMAIL_FETCH_EMAILS", "args": {}},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ok"] is False
+    assert body["code"] == "unknown_tool"
+
+
+# ---------------------------------------------------------------------------
+# Auth / tenancy gates
+# ---------------------------------------------------------------------------
+
+
+def test_run_tool_forbidden_for_non_invited(monkeypatch):
+    """The tool-run gate is owner OR explicit ``shared_with`` ONLY — a
+    workspace-visible pocket does not grant access. The guard denies."""
+    from pocketpaw_ee.cloud._core.errors import Forbidden
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+
+    a = FastAPI()
+    add_error_handler(a)
+    a.include_router(router)
+    a.dependency_overrides[require_license] = lambda: None
+    a.dependency_overrides[require_pocket_edit] = lambda: None
+    a.dependency_overrides[require_pocket_owner] = lambda: None
+    a.dependency_overrides[current_user_id] = lambda: FAKE_USER
+    a.dependency_overrides[current_workspace_id] = lambda: FAKE_WORKSPACE
+
+    def _deny():
+        raise Forbidden("pocket.access_denied", "tool-run access required")
+
+    a.dependency_overrides[require_pocket_action_run] = _deny
+
+    res = TestClient(a).post(
+        "/pockets/pocket-1/tools/run",
+        json={"tool": "WebFetch", "args": {}},
+    )
+    assert res.status_code == 403
+
+
+def test_run_tool_404_when_pocket_missing(monkeypatch, client):
+    """The pre-flight ``pockets_service.get`` raises NotFound when the
+    pocket isn't in the caller's scope — so the tool wire isn't a
+    tenant-existence oracle either."""
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    async def _missing(pocket_id, user_id):
+        raise NotFound("pocket.not_found", "no such pocket")
+
+    monkeypatch.setattr(pockets_service, "get", _missing)
+
+    res = client.post(
+        "/pockets/pocket-1/tools/run",
+        json={"tool": "WebFetch", "args": {}},
+    )
+    assert res.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Request validation — pin the body schema
+# ---------------------------------------------------------------------------
+
+
+def test_run_tool_rejects_empty_tool_name(client):
+    """Pydantic ``min_length=1`` on the request body — an empty tool
+    name is a 422 before the executor sees anything."""
+    res = client.post(
+        "/pockets/pocket-1/tools/run",
+        json={"tool": "", "args": {}},
+    )
+    assert res.status_code == 422
+
+
+def test_run_tool_args_default_to_empty_dict(monkeypatch, client):
+    """``args`` is optional — an omitted args field is the empty dict,
+    not a 422. The executor sees a stable shape regardless."""
+
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id}
+
+    captured: dict[str, object] = {}
+
+    async def _run_tool(**kwargs):
+        captured.update(kwargs)
+        return {"ok": False, "tool": kwargs["tool"], "code": "not_allowed"}
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(tool_executor, "run_tool", _run_tool)
+
+    res = client.post("/pockets/pocket-1/tools/run", json={"tool": "WebFetch"})
+    assert res.status_code == 200, res.text
+    assert captured["args"] == {}


### PR DESCRIPTION
## Summary

Part (a) of #1206 — adds the new `invoke_tool` Ripple action verb to the OSS allowlist and lands the matching `POST /pockets/{id}/tools/run` wire endpoint. This is the click-driven sibling of `run_source` (read-only fetch) and `call_binding` (named write binding): a home-pocket Refresh button hands the host a tool name plus resolved args, the host POSTs them here, the tool result flows back through the usual `on_success` / `on_error` reconcile chain.

## Scope clarification

#1206 splits into three pieces — this PR is **part (a) only**:

- (a) ✅ The wire-level primitive: action verb in the dispatcher + new `/tools/run` endpoint (this PR).
- (b) ⏳ Wiring `HomeWidgetGrid` with `onEvent` + `pocket-ripple-adapter` so widget-level events actually POST to the new wire. **paw-enterprise change — separate PR.**
- (c) ⏳ Prompt guidance in `HOME_POCKET_PROMPT` for when the chat agent should author an `invoke_tool` button. **Separate PR.**

The dispatcher / event-handler / manifest entry changes that live in the ripple repo go in a separate PR there (the ripple sources sit in a sibling repo, not vendored into pocketpaw). Vitest already validated the dispatcher branch — 48 / 48 passing including 7 new `invoke_tool` cases.

## What this delivers

- **`_KNOWN_ACTION_VERBS` gains `invoke_tool`** in `src/pocketpaw/ripple/manifest.py`. The existing `validate_action_verbs` + unwired-live-button gates now accept a Refresh button wired with `{action: "invoke_tool", tool: "WebFetch", args: {...}}` and reject typos as before. `test_all_known_verbs_pass` already exercises every verb in the allowlist, so the new verb is regression-covered.
- **New `RunToolRequest` / `RunToolResponse` DTOs** that mirror `RunActionRequest` / `RunActionResponse` field for field — same `ok` / `status` / `response` / `error` / `code` / `on_success` / `on_error` shape, same `extra="forbid"` discipline. Part (b)'s reconcile handlers won't need a separate branch for write actions vs tool runs.
- **New `tool_executor.py`** — a thin service with `get_pocket_allowed_tools` (returns `[]` for every pocket in part (a) so the wire is fail-closed by default) and `run_tool` (returns `code:"not_allowed"` for any tool not on the allowlist, `code:"unknown_tool"` for an allowlisted tool the registry doesn't recognize yet). Composio / WebFetch routing through the real tool registry is a follow-up.
- **New route `POST /pockets/{pocket_id}/tools/run`** gated by `require_pocket_action_run` — same narrow gate `/actions/run` uses (owner or explicit `shared_with`), because a tool invocation has the same blast radius as a write. The route pre-flights `pockets_service.get` so the wire isn't a tenant-existence oracle either.
- **New tests at `tests/cloud/pockets/test_tools_run.py`** — 7 cases pinning the wire contract: empty-allowlist default returns `not_allowed`; the route threads workspace / user / pocket to the executor; an allowlisted-but-unregistered tool returns `unknown_tool`; the gate denies non-invited callers (403); a missing pocket is 404; empty tool name is 422; omitted `args` defaults to `{}`. New `tests/cloud/pockets/` subdir set up so future per-route tests have a home alongside the legacy `tests/cloud/test_pocket_*.py` files.

The new endpoint exists so part (b) is shippable — the home grid needs somewhere to POST to. Because every tool name is on the empty allowlist by default, no actual outbound side effect can happen yet; it's pure wiring.

## Not in this PR

- HomeWidgetGrid `onEvent` plumbing through `pocket-ripple-adapter` (part b — paw-enterprise).
- `HOME_POCKET_PROMPT` guidance on when to author `invoke_tool` (part c).
- Composio / WebFetch routing through the real tool registry — follow-up that replaces the executor's `unknown_tool` branch.
- Per-pocket tool-allowlist storage on the backend-config row — follow-up that gives `get_pocket_allowed_tools` real data to read.
- Ripple-side TS dispatcher + schema + manifest entry — separate PR in the ripple repo (vitest is already green on those changes locally; PR pending).

## Test plan

- [x] `uv run pytest tests/cloud/pockets/test_tools_run.py -v` — 7 / 7 pass
- [x] `uv run pytest tests/test_ripple_manifest_action_wiring.py tests/test_ripple_catalog.py` — 42 / 42 pass (every verb in the allowlist round-trips through `validate_action_verbs`, including the new `invoke_tool`)
- [x] `uv run pytest tests/cloud/test_pocket_*.py tests/cloud/pockets/` — 464 / 464 pass (no regression in the broader pockets surface)
- [x] `uv run ruff check ee/pocketpaw_ee/cloud/pockets/ src/pocketpaw/ripple/manifest.py tests/cloud/pockets/test_tools_run.py` — clean
- [x] `uv run ruff format --check` on every touched file — clean
- [x] `uv run lint-imports` — `OSS core may not import from EE` contract still kept (the new `tool_executor` lives in `ee/`; nothing in `src/pocketpaw/` reaches into it)

Partially closes #1206.