### PR TITLE
feat(pocket-planner): plan-before-create gate reusing deep_work for complex pockets

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/planner.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/planner.py
@@ -5,6 +5,15 @@
 #   comes from the per-stream ContextVars in
 #   ``ee.cloud.chat.agent_service``; outside an SSE stream the tool
 #   returns a clear MCP error rather than silently mis-tenanting.
+# Updated: 2026-05-25 (feat/pocket-planner-skill) — added the ``plan_pocket``
+#   sibling tool. Reuses ``PlannerAgent.plan()`` with the POCKET_*
+#   prompt family from ``pocketpaw.deep_work.prompts`` and skips the
+#   team-assembly phase by calling the helper ``_plan_pocket_pipeline``
+#   here rather than ``PlannerAgent.plan()`` (which always assembles a
+#   team). Output is a structured brief the chat agent renders in
+#   markdown — no project_id, no DB persistence, no DeepWorkSession
+#   state machine. Iteration is stateless: the chat agent passes
+#   ``prior_plan`` + ``iteration_delta`` back in on the next call.
 """Agent-side MCP surface for the cloud Planner entity.
 
 Tools registered:
@@ -13,11 +22,18 @@ Tools registered:
     ``ee.cloud.planner.service.agent_plan_project`` so the agent can
     drive the full deep_work planner against a workspace Project and
     receive the materialized cloud primitives back as JSON.
+  - ``plan_pocket(intent, prior_plan=None, iteration_delta=None,
+    deep_research=False)`` — runs the deep_work planner pipeline (sans
+    team assembly) against pocket-flavored prompts and returns a
+    structured brief (narrative + widgets + state + sources + actions
+    + ordered todos). The chat agent renders it as markdown, iterates
+    with the user, then walks the todos calling /spec/merge per todo.
+    Ephemeral: no Project, no PlanSession, no DB row.
 
 The agent identity is resolved through the same chokepoint the pocket
 and tasks MCP servers use — see ``sdk_mcp_tasks._identity`` for the
 contract. ``mcp__pocketpaw_planner__plan_project`` is the canonical
-allowlist id.
+allowlist id; ``mcp__pocketpaw_planner__plan_pocket`` is the sibling.
 """
 
 from __future__ import annotations
@@ -30,8 +46,9 @@ logger = logging.getLogger(__name__)
 
 SERVER_NAME = "pocketpaw_planner"
 PLAN_PROJECT_TOOL_ID = f"mcp__{SERVER_NAME}__plan_project"
+PLAN_POCKET_TOOL_ID = f"mcp__{SERVER_NAME}__plan_pocket"
 
-PLANNER_TOOL_IDS = (PLAN_PROJECT_TOOL_ID,)
+PLANNER_TOOL_IDS = (PLAN_PROJECT_TOOL_ID, PLAN_POCKET_TOOL_ID)
 
 
 def _error_response(message: str) -> dict[str, Any]:
@@ -133,6 +150,335 @@ async def _plan_project_handler(args: dict) -> dict:
     return _success_response({"ok": True, "plan": response.model_dump()})
 
 
+# ---------------------------------------------------------------------------
+# plan_pocket — pocket-flavored planner that returns an ephemeral brief.
+#
+# Reuses ``PlannerAgent._run_prompt`` + ``_parse_tasks`` for the LLM
+# orchestration and JSON-coercion. The pipeline is inlined here (rather
+# than a method on PlannerAgent) because pocket planning skips the team-
+# assembly phase, builds no Project, and the brief schema is shaped for
+# markdown rendering, not Mission Control materialization.
+# ---------------------------------------------------------------------------
+
+
+def _parse_pocket_prd_sections(prd_text: str) -> dict[str, str]:
+    """Split the PRD into its five labelled sections.
+
+    The PRD prompt instructs the LLM to use exactly these headings:
+    ``## NARRATIVE``, ``## WIDGETS``, ``## STATE``, ``## SOURCES``,
+    ``## ACTIONS``. We split on those tokens and return a dict mapping
+    each section name to its raw text (without the heading). Missing
+    sections come back as empty strings so the caller can branch on
+    that rather than KeyError-handling.
+    """
+
+    sections: dict[str, str] = {
+        "NARRATIVE": "",
+        "WIDGETS": "",
+        "STATE": "",
+        "SOURCES": "",
+        "ACTIONS": "",
+    }
+    if not prd_text:
+        return sections
+
+    # Walk the text line by line, capture lines under the most recent
+    # ``## <NAME>`` heading we recognise. Headings we don't recognise
+    # close the current section (so stray content does not leak).
+    current: str | None = None
+    buffers: dict[str, list[str]] = {k: [] for k in sections}
+    for line in prd_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            name = stripped[3:].strip().upper()
+            if name in sections:
+                current = name
+            else:
+                current = None
+            continue
+        if current is None:
+            continue
+        buffers[current].append(line)
+
+    for name, lines in buffers.items():
+        sections[name] = "\n".join(lines).strip()
+    return sections
+
+
+def _parse_bullet_pairs(section_text: str) -> list[tuple[str, str]]:
+    """Parse a ``- left: right`` bullet list into (left, right) tuples.
+
+    Used by the WIDGETS / STATE / SOURCES / ACTIONS section parsers. A
+    line missing the colon becomes ``(line, "")`` so downstream callers
+    can still surface the raw text in the brief. Empty / non-bullet
+    lines are skipped silently.
+    """
+
+    pairs: list[tuple[str, str]] = []
+    for raw_line in section_text.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("- "):
+            continue
+        body = line[2:].strip()
+        if not body:
+            continue
+        if ":" in body:
+            left, right = body.split(":", 1)
+            pairs.append((left.strip(), right.strip()))
+        else:
+            pairs.append((body, ""))
+    return pairs
+
+
+def _build_pocket_brief(
+    *,
+    prd: str,
+    tasks: list[Any],
+    research_notes: str,
+) -> dict[str, Any]:
+    """Turn the planner's raw PRD + parsed tasks into the brief schema.
+
+    Brief shape (see the design doc in P7):
+      ``{narrative, widgets, state, sources, actions, todos, research_notes}``
+    Each entry is a plain dict — the chat agent renders the brief as
+    markdown straight from this dict. We keep ``research_notes`` in the
+    brief so the iteration call can show the user why a widget was
+    chosen.
+    """
+
+    sections = _parse_pocket_prd_sections(prd)
+
+    widgets = [
+        {"type": left, "purpose": right}
+        for left, right in _parse_bullet_pairs(sections["WIDGETS"])
+    ]
+
+    state: dict[str, dict[str, str]] = {}
+    for left, right in _parse_bullet_pairs(sections["STATE"]):
+        # Right side is ``<type> — <purpose>``. Em-dash and hyphen-
+        # surrounded-by-spaces both come back from LLMs, so we split on
+        # whichever variant the model emitted.
+        purpose = ""
+        type_part = right
+        for sep in (" — ", " - ", " — "):
+            if sep in right:
+                type_part, purpose = right.split(sep, 1)
+                break
+        state[left] = {
+            "type": type_part.strip(),
+            "purpose": purpose.strip(),
+        }
+
+    sources: list[dict[str, str]] = []
+    for connector, body in _parse_bullet_pairs(sections["SOURCES"]):
+        sources.append({"connector": connector, "feeds": body})
+
+    actions: list[dict[str, str]] = []
+    for trigger, body in _parse_bullet_pairs(sections["ACTIONS"]):
+        actions.append({"trigger": trigger, "effect": body})
+
+    todos: list[dict[str, Any]] = []
+    for t in tasks:
+        # TaskSpec dataclass — use to_dict() so we don't depend on the
+        # internal field set here. We project a small subset (label,
+        # success_criteria, preconditions, depends_on, description) into
+        # the brief — that's all the build phase needs.
+        d = t.to_dict() if hasattr(t, "to_dict") else dict(t)
+        todos.append(
+            {
+                "id": d.get("key", ""),
+                "label": d.get("title", ""),
+                "description": d.get("description", ""),
+                "success_criteria": list(d.get("success_criteria", [])),
+                "preconditions": list(d.get("preconditions", [])),
+                "depends_on": list(d.get("blocked_by_keys", [])),
+                "tags": list(d.get("tags", [])),
+                "estimated_minutes": d.get("estimated_minutes", 0),
+            }
+        )
+
+    return {
+        "narrative": sections["NARRATIVE"],
+        "widgets": widgets,
+        "state": state,
+        "sources": sources,
+        "actions": actions,
+        "todos": todos,
+        "research_notes": research_notes,
+    }
+
+
+def _compose_intent_with_iteration(
+    intent: str,
+    prior_plan: dict[str, Any] | None,
+    iteration_delta: str | None,
+) -> str:
+    """Splice iteration context into the brief the LLM sees.
+
+    On the first call, ``prior_plan`` and ``iteration_delta`` are both
+    None and we pass the intent through. On a follow-up call the chat
+    agent supplies the previous brief plus the user's revision text;
+    we append both as labelled blocks so the LLM iterates instead of
+    re-planning from scratch.
+    """
+
+    if not prior_plan and not iteration_delta:
+        return intent
+
+    parts: list[str] = [f"USER BRIEF:\n{intent}"]
+    if iteration_delta:
+        parts.append(f"\nUSER REVISION REQUEST:\n{iteration_delta}")
+    if prior_plan:
+        # Serialize concisely so we don't blow the context window.
+        parts.append(
+            "\nPRIOR PLAN (the user just revised this — keep what they did "
+            "not call out, apply the revision above):\n"
+            + json.dumps(prior_plan, separators=(",", ":"), default=str)
+        )
+    return "\n".join(parts)
+
+
+async def _run_pocket_planner_pipeline(
+    intent: str,
+    *,
+    deep_research: bool,
+) -> dict[str, Any]:
+    """Run the pocket-flavored 3-phase planner (research → PRD → todos).
+
+    Returns the brief dict directly. Mirrors PlannerAgent.plan() but
+    with the POCKET_* prompt family and no team-assembly phase. We do
+    NOT broadcast SystemEvents here — the MCP tool boundary is the
+    progress surface, not the deep_work bus.
+    """
+
+    from pocketpaw.deep_work.planner import PlannerAgent
+    from pocketpaw.deep_work.prompts import (
+        POCKET_PRD_PROMPT,
+        POCKET_RESEARCH_PROMPT,
+        POCKET_TASK_BREAKDOWN_PROMPT,
+    )
+
+    # Use PlannerAgent's _run_prompt / _parse_tasks plumbing — it
+    # already handles the markdown-code-fence stripping and the
+    # one-retry JSON-coercion semantics. We pass ``manager=None``
+    # because the pipeline below never touches Mission Control.
+    planner = PlannerAgent(manager=None)  # type: ignore[arg-type]
+
+    from pocketpaw.agents.router import AgentRouter
+    from pocketpaw.config import get_settings
+
+    router = AgentRouter(get_settings())
+
+    # Phase 1 — research. ``deep_research`` only toggles a couple of
+    # paragraph-count knobs; pocket research is always opinionated.
+    research_prompt = POCKET_RESEARCH_PROMPT.format(project_description=intent)
+    if deep_research:
+        research_prompt = (
+            research_prompt + "\n\nBe THOROUGH — include 3-4 similar pockets, "
+            "not 0-3. Add an extra paragraph on tradeoffs between the focal "
+            "widget options."
+        )
+    research_notes = await planner._run_prompt(research_prompt, router=router)
+
+    # Phase 2 — PRD.
+    prd = await planner._run_prompt(
+        POCKET_PRD_PROMPT.format(
+            project_description=intent,
+            research_notes=research_notes,
+        ),
+        router=router,
+    )
+
+    # Phase 3 — todos. JSON output, reuse PlannerAgent's retry-on-
+    # malformed-JSON behaviour.
+    tasks_raw = await planner._run_prompt(
+        POCKET_TASK_BREAKDOWN_PROMPT.format(
+            project_description=intent,
+            prd_content=prd,
+            research_notes=research_notes,
+        ),
+        router=router,
+    )
+    tasks = planner._parse_tasks(tasks_raw)
+    if not tasks:
+        # One retry with the explicit-JSON hint, same logic plan() uses.
+        logger.info("plan_pocket: retrying task breakdown with explicit JSON hint")
+        tasks_raw = await planner._run_prompt(
+            "Your previous response was not valid JSON. Return ONLY a "
+            "JSON array of todo objects, no markdown, no explanation — "
+            "just the raw JSON array.\n\n"
+            + POCKET_TASK_BREAKDOWN_PROMPT.format(
+                project_description=intent,
+                prd_content=prd,
+                research_notes=research_notes,
+            ),
+            router=router,
+        )
+        tasks = planner._parse_tasks(tasks_raw)
+
+    return _build_pocket_brief(
+        prd=prd,
+        tasks=tasks,
+        research_notes=research_notes,
+    )
+
+
+async def _plan_pocket_handler(args: dict) -> dict:
+    """Resolve the args envelope, run the pipeline, return the brief.
+
+    Identity check matches ``_plan_project_handler``: outside an SSE
+    chat stream this tool must NOT silently mis-tenant. The pocket
+    planner doesn't actually write any tenant-scoped data, but the
+    identity gate is the contract every cloud MCP tool honours so the
+    tool surface stays uniform — and if we later wire bundled-KB
+    lookup off the workspace id, the gate is already in place.
+    """
+
+    workspace_id, agent_id = _identity()
+    if not workspace_id or not agent_id:
+        return _error_response(
+            "no active workspace/agent — plan_pocket can only be called "
+            "from inside a cloud SSE chat stream"
+        )
+
+    args = args or {}
+    intent = (args.get("intent") or "").strip()
+    if not intent:
+        return _error_response("intent is required")
+
+    prior_plan = args.get("prior_plan")
+    if prior_plan is not None and not isinstance(prior_plan, dict):
+        return _error_response("prior_plan must be a dict (a brief returned from a previous call)")
+
+    iteration_delta = args.get("iteration_delta")
+    if iteration_delta is not None and not isinstance(iteration_delta, str):
+        return _error_response("iteration_delta must be a string")
+
+    deep_research = bool(args.get("deep_research", False))
+
+    composed_intent = _compose_intent_with_iteration(
+        intent,
+        prior_plan if isinstance(prior_plan, dict) else None,
+        iteration_delta if isinstance(iteration_delta, str) else None,
+    )
+
+    try:
+        brief = await _run_pocket_planner_pipeline(
+            composed_intent,
+            deep_research=deep_research,
+        )
+    except RuntimeError as exc:
+        # LLM call failed (API key missing, transport error, …) —
+        # _run_prompt raises this so the failure surfaces cleanly
+        # rather than silently returning an empty brief.
+        return _error_response(f"plan_pocket failed: {exc}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("plan_pocket failed", exc_info=True)
+        return _error_response(f"plan_pocket failed: {exc}")
+
+    return _success_response({"ok": True, "brief": brief})
+
+
 def build_planner_context_server() -> tuple[str, Any] | None:
     """Build the in-process SDK MCP server for the planner, or ``None``
     when the Claude Agent SDK isn't installed.
@@ -167,16 +513,42 @@ def build_planner_context_server() -> tuple[str, Any] | None:
     async def plan_project(args):  # type: ignore[no-untyped-def]
         return await _plan_project_handler(args)
 
+    @tool(
+        "plan_pocket",
+        (
+            "Plan a complex pocket BEFORE creating it. Use when the "
+            "pocket_specialist create flow returned a ``plan_kit`` (the "
+            "template-match step did not find a starter and the brief "
+            "looks like a custom multi-widget app). Returns ``{ok: True, "
+            "brief}`` where ``brief`` carries ``{narrative, widgets, "
+            "state, sources, actions, todos}`` — render that as markdown "
+            "in the chat panel, iterate with the user, then walk the "
+            "todos calling POST /api/v1/pockets/<id>/spec/merge per todo. "
+            "Stateless: no Project, no plan-session row. Pass ``prior_plan`` "
+            "and ``iteration_delta`` on follow-up calls so the LLM "
+            "iterates the prior brief instead of replanning from scratch."
+        ),
+        {
+            "intent": str,
+            "prior_plan": dict,
+            "iteration_delta": str,
+            "deep_research": bool,
+        },
+    )
+    async def plan_pocket(args):  # type: ignore[no-untyped-def]
+        return await _plan_pocket_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
-        version="1.0.0",
-        tools=[plan_project],
+        version="1.1.0",
+        tools=[plan_project, plan_pocket],
     )
     return SERVER_NAME, server
 
 
 __all__ = [
     "PLANNER_TOOL_IDS",
+    "PLAN_POCKET_TOOL_ID",
     "PLAN_PROJECT_TOOL_ID",
     "SERVER_NAME",
     "build_planner_context_server",

--- a/ee/pocketpaw_ee/agent/mcp_servers/planner.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/planner.py
@@ -14,41 +14,69 @@
 #   markdown — no project_id, no DB persistence, no DeepWorkSession
 #   state machine. Iteration is stateless: the chat agent passes
 #   ``prior_plan`` + ``iteration_delta`` back in on the next call.
-"""Agent-side MCP surface for the cloud Planner entity.
+# Updated: 2026-05-25 (R2 fix for PR #1223) — split the planner module
+#   into TWO in-process MCP servers so the OPT_IN gate stays accurate:
+#     * ``pocketpaw_planner``         hosts ``plan_project`` only (opt-in)
+#     * ``pocketpaw_pocket_planner``  hosts ``plan_pocket`` only (ambient)
+#   The original single-server design conflated two policy regimes —
+#   the per-server OPT_IN_MCP_SERVERS frozenset could not gate one
+#   tool ambient + one opt-in on a single server. Splitting keeps
+#   plan_project under the existing opt-in regime (Mission Control
+#   only) while letting plan_pocket reach the pocket-create flow with
+#   no extra opt-in plumbing. Also hardened the PRD parser
+#   (heading-level / case / trailing-punctuation tolerance) and added
+#   a balanced-bracket JSON extractor for the task-breakdown step so
+#   LLM drift (trailing prose, ``#`` comments, trailing commas) no
+#   longer silently produces an empty todo list.
+"""Agent-side MCP surface for the cloud Planner entities.
 
-Tools registered:
+Two in-process MCP servers live in this module:
 
-  - ``plan_project(project_id, goal, deep_research=False)`` — invokes
-    ``ee.cloud.planner.service.agent_plan_project`` so the agent can
-    drive the full deep_work planner against a workspace Project and
-    receive the materialized cloud primitives back as JSON.
-  - ``plan_pocket(intent, prior_plan=None, iteration_delta=None,
-    deep_research=False)`` — runs the deep_work planner pipeline (sans
-    team assembly) against pocket-flavored prompts and returns a
-    structured brief (narrative + widgets + state + sources + actions
-    + ordered todos). The chat agent renders it as markdown, iterates
-    with the user, then walks the todos calling /spec/merge per todo.
-    Ephemeral: no Project, no PlanSession, no DB row.
+  - ``pocketpaw_planner`` — hosts ``plan_project(project_id, goal,
+    deep_research=False)``. Invokes
+    ``ee.cloud.planner.service.agent_plan_project`` to drive the full
+    deep_work planner against a workspace Project. **Opt-in** via the
+    per-agent ``mcp_servers_allow`` policy (Mission Control only).
+  - ``pocketpaw_pocket_planner`` — hosts ``plan_pocket(intent,
+    prior_plan=None, iteration_delta=None, deep_research=False)``.
+    Runs the deep_work planner pipeline (sans team assembly) against
+    pocket-flavored prompts and returns a structured brief
+    (narrative + widgets + state + sources + actions + ordered
+    todos). The chat agent renders it as markdown, iterates with the
+    user, then walks the todos calling /spec/merge per todo.
+    Ephemeral: no Project, no PlanSession, no DB row. **Ambient** —
+    the pocket-create skill needs to call it without explicit opt-in.
 
 The agent identity is resolved through the same chokepoint the pocket
 and tasks MCP servers use — see ``sdk_mcp_tasks._identity`` for the
-contract. ``mcp__pocketpaw_planner__plan_project`` is the canonical
-allowlist id; ``mcp__pocketpaw_planner__plan_pocket`` is the sibling.
+contract. ``mcp__pocketpaw_planner__plan_project`` and
+``mcp__pocketpaw_pocket_planner__plan_pocket`` are the canonical
+allowlist ids.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 SERVER_NAME = "pocketpaw_planner"
-PLAN_PROJECT_TOOL_ID = f"mcp__{SERVER_NAME}__plan_project"
-PLAN_POCKET_TOOL_ID = f"mcp__{SERVER_NAME}__plan_pocket"
+POCKET_PLANNER_SERVER_NAME = "pocketpaw_pocket_planner"
 
-PLANNER_TOOL_IDS = (PLAN_PROJECT_TOOL_ID, PLAN_POCKET_TOOL_ID)
+PLAN_PROJECT_TOOL_ID = f"mcp__{SERVER_NAME}__plan_project"
+PLAN_POCKET_TOOL_ID = f"mcp__{POCKET_PLANNER_SERVER_NAME}__plan_pocket"
+
+# ``PLANNER_TOOL_IDS`` is the allowlist tuple for the opt-in
+# ``pocketpaw_planner`` server. It used to carry both tool ids; the
+# split moved ``plan_pocket`` onto ``POCKET_PLANNER_TOOL_IDS`` (its own
+# always-on server). Callers iterating tool ids for the allowlist must
+# concatenate both tuples — done in ``extensions.py`` via two
+# providers, one per server.
+PLANNER_TOOL_IDS = (PLAN_PROJECT_TOOL_ID,)
+POCKET_PLANNER_TOOL_IDS = (PLAN_POCKET_TOOL_ID,)
 
 
 def _error_response(message: str) -> dict[str, Any]:
@@ -161,15 +189,43 @@ async def _plan_project_handler(args: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
+_HEADING_RE = re.compile(r"^(#{2,3})\s+(.+?)\s*$")
+
+
+def _normalize_heading_token(text: str) -> str:
+    """Strip Markdown/punctuation noise an LLM may add around a heading
+    name and upper-case the result. Tolerates ``**bold**`` wrappers,
+    trailing colons, lowercase, leading/trailing whitespace. Returns
+    the cleaned token (still upper-cased) so the caller can match it
+    against the canonical section names.
+    """
+
+    cleaned = text.strip()
+    # Repeatedly peel ``**...**`` / ``*...*`` wrappers so ``**Narrative**``
+    # and ``*Narrative*`` both reduce to ``Narrative``.
+    while len(cleaned) >= 4 and cleaned.startswith("**") and cleaned.endswith("**"):
+        cleaned = cleaned[2:-2].strip()
+    while len(cleaned) >= 2 and cleaned.startswith("*") and cleaned.endswith("*"):
+        cleaned = cleaned[1:-1].strip()
+    cleaned = cleaned.rstrip(":").rstrip("-").strip()
+    return cleaned.upper()
+
+
 def _parse_pocket_prd_sections(prd_text: str) -> dict[str, str]:
     """Split the PRD into its five labelled sections.
 
     The PRD prompt instructs the LLM to use exactly these headings:
     ``## NARRATIVE``, ``## WIDGETS``, ``## STATE``, ``## SOURCES``,
-    ``## ACTIONS``. We split on those tokens and return a dict mapping
-    each section name to its raw text (without the heading). Missing
-    sections come back as empty strings so the caller can branch on
-    that rather than KeyError-handling.
+    ``## ACTIONS``. In practice LLM drift produces variants the brain
+    accepts but the parser would silently drop: lowercased
+    (``## narrative``), trailing colons (``## NARRATIVE:``), one extra
+    hash level (``### NARRATIVE``), bold wrappers (``**Narrative**``).
+    We accept all of those — the contract is "the heading text equals
+    one of the canonical names, case-insensitively, after stripping
+    noise punctuation and Markdown emphasis markers".
+
+    Missing sections come back as empty strings so the caller can
+    branch on that rather than KeyError-handling.
     """
 
     sections: dict[str, str] = {
@@ -183,19 +239,32 @@ def _parse_pocket_prd_sections(prd_text: str) -> dict[str, str]:
         return sections
 
     # Walk the text line by line, capture lines under the most recent
-    # ``## <NAME>`` heading we recognise. Headings we don't recognise
-    # close the current section (so stray content does not leak).
+    # heading we recognise. Headings we don't recognise close the
+    # current section (so stray content does not leak).
     current: str | None = None
     buffers: dict[str, list[str]] = {k: [] for k in sections}
     for line in prd_text.splitlines():
         stripped = line.strip()
-        if stripped.startswith("## "):
-            name = stripped[3:].strip().upper()
+        heading_match = _HEADING_RE.match(stripped)
+        if heading_match:
+            name = _normalize_heading_token(heading_match.group(2))
             if name in sections:
                 current = name
             else:
                 current = None
             continue
+
+        # Tolerate the LLM emitting ``**Narrative**`` as its own line
+        # (no leading ``##``) — treat it as a heading too.
+        if (stripped.startswith("**") and stripped.endswith("**")) or (
+            stripped.startswith("*") and stripped.endswith("*")
+        ):
+            candidate = _normalize_heading_token(stripped)
+            if candidate in sections:
+                current = candidate
+                continue
+            # Fall through — it might be normal emphasis inside prose.
+
         if current is None:
             continue
         buffers[current].append(line)
@@ -203,6 +272,149 @@ def _parse_pocket_prd_sections(prd_text: str) -> dict[str, str]:
     for name, lines in buffers.items():
         sections[name] = "\n".join(lines).strip()
     return sections
+
+
+def _extract_first_json_array(text: str) -> str | None:
+    """Pull the first ``[...]`` block out of ``text`` via balanced-bracket
+    counting, tolerating prose / comments / multiple fenced blocks
+    around it.
+
+    The original task-breakdown parser ran ``re.search`` over a single
+    ``` ```json ... ``` `` fence and called ``json.loads`` on the result.
+    LLM drift broke that:
+      * Trailing prose after the array (``[...] -- and here's why``)
+      * Multiple separate code fences (the model emits a fenced thought
+        block, THEN the JSON in a second fence)
+      * Python-style ``#`` comments inside the array
+      * Trailing commas (JSON5-style)
+
+    This walks the text scanning for the first ``[``, then counts
+    brackets — respecting double-quoted strings (with backslash
+    escapes) — until the matching outer ``]``. Returns the inclusive
+    substring or ``None`` if no balanced array exists. Strings inside
+    the array are scanned but their content is untouched; this is just
+    extraction, not validation.
+    """
+
+    start = text.find("[")
+    if start < 0:
+        return None
+
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
+
+
+_HASH_COMMENT_RE = re.compile(r"(?<!\\)#.*?$", re.MULTILINE)
+_TRAILING_COMMA_RE = re.compile(r",(\s*[\]\}])")
+
+
+def _strip_json_noise(text: str) -> str:
+    """Remove Python-style ``# comments`` and JSON5 trailing commas.
+
+    Run this AFTER ``_extract_first_json_array`` peeled the right
+    substring; the inputs here are the bracketed array body. We do not
+    try to be exhaustive — JSON5 supports several relaxations but the
+    two that bite us in practice are ``#`` comments (the model leaves
+    inline annotations) and trailing commas after the last item.
+    Removing both is safe because real JSON disallows them; if a
+    string literal happens to contain ``#`` we leave it alone (we only
+    strip when not inside a string — same string-scanning logic as the
+    bracket extractor).
+    """
+
+    # Strip ``#`` comments only when not inside a string literal. We
+    # walk the text once, copying chars into a buffer and skipping
+    # comment runs. The regex form would also clip ``#`` inside a JSON
+    # string ("foo#bar"), which is a no-go.
+    out: list[str] = []
+    in_string = False
+    escape = False
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "#":
+            # Skip to end of line (do not consume the newline so block
+            # structure is preserved).
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        out.append(ch)
+        i += 1
+    stripped = "".join(out)
+    # Trailing commas: ``,]`` → ``]`` and ``,}`` → ``}``. Safe outside
+    # strings because we've already stripped comments; remaining
+    # commas in strings are preserved by the regex (it requires the
+    # following character to be a closing bracket).
+    return _TRAILING_COMMA_RE.sub(r"\1", stripped)
+
+
+def _parse_lenient_json_list(raw: str) -> tuple[list[dict] | None, str | None]:
+    """Lenient JSON-list parser used by the pocket task-breakdown step.
+
+    Returns ``(parsed_list, error_message)`` where ``parsed_list`` is
+    None on failure and ``error_message`` carries a short diagnostic
+    (suitable for surfacing in MCP warnings so the captain can see
+    what was attempted). On success ``error_message`` is None.
+
+    Strategy:
+      1. Pull the first balanced ``[...]`` block out of the raw text.
+      2. Strip ``#`` comments and trailing commas inside it.
+      3. ``json.loads`` the result.
+
+    Any of those steps can fail — we keep the original raw text in
+    the diagnostic so a follow-up retry can include the surface error.
+    """
+
+    if not raw:
+        return None, "empty model output"
+    extracted = _extract_first_json_array(raw)
+    if extracted is None:
+        return None, f"no balanced JSON array in model output: {raw[:200]!r}"
+    cleaned = _strip_json_noise(extracted)
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        return None, f"JSON parse failed ({exc}); attempted: {cleaned[:300]!r}"
+    if not isinstance(data, list):
+        return None, f"expected a JSON array, got {type(data).__name__}: {cleaned[:200]!r}"
+    return [item for item in data if isinstance(item, dict)], None
 
 
 def _parse_bullet_pairs(section_text: str) -> list[tuple[str, str]]:
@@ -338,17 +550,52 @@ def _compose_intent_with_iteration(
     return "\n".join(parts)
 
 
+def _lenient_parse_taskspecs(raw: str) -> tuple[list[Any], list[str]]:
+    """Parse the task-breakdown LLM output into TaskSpec instances.
+
+    Tries the lenient extractor first (balanced-bracket + comment /
+    trailing-comma scrub); on failure falls back to PlannerAgent's
+    ``_parse_tasks`` so the original behaviour is preserved.
+
+    Returns ``(tasks, warnings)``. ``warnings`` carries any diagnostic
+    messages from the parse attempts — empty on a clean pass. The
+    handler surfaces these so the captain can see what was attempted
+    when the LLM drifts.
+    """
+
+    from pocketpaw.deep_work.models import TaskSpec
+    from pocketpaw.deep_work.planner import PlannerAgent
+
+    warnings: list[str] = []
+    data, err = _parse_lenient_json_list(raw)
+    if data is None:
+        if err:
+            warnings.append(f"lenient parse: {err}")
+        # Fall back to the strict regex parser — if the model emitted a
+        # clean ``` ```json``` ``` fence this still works.
+        legacy = PlannerAgent(manager=None)  # type: ignore[arg-type]
+        fallback = legacy._parse_tasks(raw)
+        if fallback:
+            return fallback, warnings
+        return [], warnings
+    return [TaskSpec.from_dict(item) for item in data], warnings
+
+
 async def _run_pocket_planner_pipeline(
     intent: str,
     *,
     deep_research: bool,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], list[str]]:
     """Run the pocket-flavored 3-phase planner (research → PRD → todos).
 
-    Returns the brief dict directly. Mirrors PlannerAgent.plan() but
-    with the POCKET_* prompt family and no team-assembly phase. We do
-    NOT broadcast SystemEvents here — the MCP tool boundary is the
-    progress surface, not the deep_work bus.
+    Returns ``(brief, warnings)``. The brief is the dict the MCP tool
+    body wraps; warnings are diagnostic strings the handler surfaces
+    so the captain can see what the LLM emitted when a parse failed.
+
+    Mirrors PlannerAgent.plan() but with the POCKET_* prompt family
+    and no team-assembly phase. We do NOT broadcast SystemEvents here —
+    the MCP tool boundary is the progress surface, not the deep_work
+    bus.
     """
 
     from pocketpaw.deep_work.planner import PlannerAgent
@@ -358,16 +605,22 @@ async def _run_pocket_planner_pipeline(
         POCKET_TASK_BREAKDOWN_PROMPT,
     )
 
-    # Use PlannerAgent's _run_prompt / _parse_tasks plumbing — it
-    # already handles the markdown-code-fence stripping and the
-    # one-retry JSON-coercion semantics. We pass ``manager=None``
-    # because the pipeline below never touches Mission Control.
+    # ``manager=None`` is safe here even though PlannerAgent's __init__
+    # types it as required: the only PlannerAgent methods we touch
+    # (``_run_prompt`` and ``_parse_tasks``) never reach into
+    # ``self.manager`` — ``ensure_profile`` and ``_broadcast_phase``
+    # are the two that do, and we don't call them. TODO(PR #1223
+    # follow-up): refactor PlannerAgent so the prompt-runner + task
+    # parser are static helpers on a separate class and the optional-
+    # manager landmine goes away.
     planner = PlannerAgent(manager=None)  # type: ignore[arg-type]
 
     from pocketpaw.agents.router import AgentRouter
     from pocketpaw.config import get_settings
 
     router = AgentRouter(get_settings())
+
+    warnings: list[str] = []
 
     # Phase 1 — research. ``deep_research`` only toggles a couple of
     # paragraph-count knobs; pocket research is always opinionated.
@@ -389,8 +642,11 @@ async def _run_pocket_planner_pipeline(
         router=router,
     )
 
-    # Phase 3 — todos. JSON output, reuse PlannerAgent's retry-on-
-    # malformed-JSON behaviour.
+    # Phase 3 — todos. JSON output. Use the lenient parser so common
+    # LLM drift (trailing prose, ``#`` comments, trailing commas,
+    # multiple code fences) does not silently produce an empty todo
+    # list. On failure we retry with the explicit-JSON hint — same
+    # one-retry budget the upstream planner uses.
     tasks_raw = await planner._run_prompt(
         POCKET_TASK_BREAKDOWN_PROMPT.format(
             project_description=intent,
@@ -399,10 +655,16 @@ async def _run_pocket_planner_pipeline(
         ),
         router=router,
     )
-    tasks = planner._parse_tasks(tasks_raw)
+    tasks, parse_warnings = _lenient_parse_taskspecs(tasks_raw)
+    warnings.extend(parse_warnings)
     if not tasks:
         # One retry with the explicit-JSON hint, same logic plan() uses.
+        # Include the original output snippet in the warning so a
+        # debugging captain can see exactly what the model emitted.
         logger.info("plan_pocket: retrying task breakdown with explicit JSON hint")
+        warnings.append(
+            f"task-breakdown first attempt produced no todos; raw output (first 300 chars): {tasks_raw[:300]!r}"
+        )
         tasks_raw = await planner._run_prompt(
             "Your previous response was not valid JSON. Return ONLY a "
             "JSON array of todo objects, no markdown, no explanation — "
@@ -414,13 +676,19 @@ async def _run_pocket_planner_pipeline(
             ),
             router=router,
         )
-        tasks = planner._parse_tasks(tasks_raw)
+        tasks, retry_warnings = _lenient_parse_taskspecs(tasks_raw)
+        warnings.extend(retry_warnings)
+        if not tasks:
+            warnings.append(
+                f"task-breakdown retry also failed; raw output (first 300 chars): {tasks_raw[:300]!r}"
+            )
 
-    return _build_pocket_brief(
+    brief = _build_pocket_brief(
         prd=prd,
         tasks=tasks,
         research_notes=research_notes,
     )
+    return brief, warnings
 
 
 async def _plan_pocket_handler(args: dict) -> dict:
@@ -463,7 +731,7 @@ async def _plan_pocket_handler(args: dict) -> dict:
     )
 
     try:
-        brief = await _run_pocket_planner_pipeline(
+        brief, warnings = await _run_pocket_planner_pipeline(
             composed_intent,
             deep_research=deep_research,
         )
@@ -476,16 +744,30 @@ async def _plan_pocket_handler(args: dict) -> dict:
         logger.warning("plan_pocket failed", exc_info=True)
         return _error_response(f"plan_pocket failed: {exc}")
 
-    return _success_response({"ok": True, "brief": brief})
+    body: dict[str, Any] = {"ok": True, "brief": brief}
+    if warnings:
+        # Surface parser drift so the captain can see what the model
+        # emitted. The chat agent treats this as informational —
+        # ``ok: True`` still means the brief is renderable.
+        body["warnings"] = warnings
+    return _success_response(body)
 
 
 def build_planner_context_server() -> tuple[str, Any] | None:
-    """Build the in-process SDK MCP server for the planner, or ``None``
-    when the Claude Agent SDK isn't installed.
+    """Build the in-process SDK MCP server for the **opt-in** project
+    planner (Mission Control). Returns ``None`` when the Claude Agent
+    SDK isn't installed.
+
+    This server hosts ``plan_project`` only. The sibling
+    ``pocketpaw_pocket_planner`` server (built by
+    :func:`build_pocket_planner_context_server`) hosts the ambient
+    ``plan_pocket`` tool. The split is what restores the per-server
+    OPT_IN_MCP_SERVERS gate to working order — see the module
+    docstring and PR #1223 R2 review for the why.
 
     Matches the shape returned by ``build_tasks_context_server`` so the
-    backend's MCP registration loop in ``claude_sdk.py`` treats both
-    identically.
+    backend's MCP registration loop in ``claude_sdk.py`` treats this
+    identically to the other in-process servers.
     """
 
     try:
@@ -513,6 +795,34 @@ def build_planner_context_server() -> tuple[str, Any] | None:
     async def plan_project(args):  # type: ignore[no-untyped-def]
         return await _plan_project_handler(args)
 
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.1.0",
+        tools=[plan_project],
+    )
+    return SERVER_NAME, server
+
+
+def build_pocket_planner_context_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for the **ambient** pocket
+    planner. Returns ``None`` when the Claude Agent SDK isn't
+    installed.
+
+    This server hosts ``plan_pocket`` only. It is registered under a
+    DIFFERENT name (``pocketpaw_pocket_planner``) from the project
+    planner so the per-server OPT_IN_MCP_SERVERS gate can keep
+    ``plan_project`` opt-in while leaving ``plan_pocket`` reachable
+    for the pocket-create flow without explicit opt-in plumbing.
+    """
+
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug(
+            "claude_agent_sdk not installed; pocketpaw_pocket_planner MCP disabled"
+        )
+        return None
+
     @tool(
         "plan_pocket",
         (
@@ -539,17 +849,20 @@ def build_planner_context_server() -> tuple[str, Any] | None:
         return await _plan_pocket_handler(args)
 
     server = create_sdk_mcp_server(
-        name=SERVER_NAME,
-        version="1.1.0",
-        tools=[plan_project, plan_pocket],
+        name=POCKET_PLANNER_SERVER_NAME,
+        version="1.0.0",
+        tools=[plan_pocket],
     )
-    return SERVER_NAME, server
+    return POCKET_PLANNER_SERVER_NAME, server
 
 
 __all__ = [
-    "PLANNER_TOOL_IDS",
     "PLAN_POCKET_TOOL_ID",
     "PLAN_PROJECT_TOOL_ID",
+    "PLANNER_TOOL_IDS",
+    "POCKET_PLANNER_SERVER_NAME",
+    "POCKET_PLANNER_TOOL_IDS",
     "SERVER_NAME",
     "build_planner_context_server",
+    "build_pocket_planner_context_server",
 ]

--- a/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
@@ -502,7 +502,7 @@ def _plan_kit_response(
     agent:
 
       1. Loads the ``pocketpaw-pocket-planner`` skill body.
-      2. Calls ``mcp__pocketpaw_planner__plan_pocket(intent=...)`` and
+      2. Calls ``mcp__pocketpaw_pocket_planner__plan_pocket(intent=...)`` and
          renders the returned brief as markdown in the chat panel.
       3. Iterates with the user (``plan_pocket`` again with
          ``prior_plan`` + ``iteration_delta``).
@@ -525,7 +525,7 @@ def _plan_kit_response(
         "brief": input.brief,
         "structural_plan": hints_dict,
         "skill_name": "pocketpaw-pocket-planner",
-        "mcp_tool": "mcp__pocketpaw_planner__plan_pocket",
+        "mcp_tool": "mcp__pocketpaw_pocket_planner__plan_pocket",
         "auth_headers": {
             "X-PocketPaw-Internal": "true",
             "X-PocketPaw-Workspace-Id": workspace_id,
@@ -533,7 +533,7 @@ def _plan_kit_response(
         },
         "next_step": (
             "Invoke the ``pocketpaw-pocket-planner`` skill and the "
-            "``mcp__pocketpaw_planner__plan_pocket`` tool to draft a "
+            "``mcp__pocketpaw_pocket_planner__plan_pocket`` tool to draft a "
             "plan. Render the returned brief in chat as markdown "
             "(narrative + widgets + state + sources + actions + todos "
             "as a checkbox list). Iterate with the user — when they say "

--- a/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
@@ -11,6 +11,14 @@
 # spec-merge endpoint requires the token in addition to the prior
 # magic header + tenancy headers; without it the agent would hit a
 # clean 401 instead of the previous (forgeable) bypass.
+# Modified: 2026-05-25 (feat/pocket-planner-skill) — ``AgentModeAdapter
+# .create`` now branches to ``_plan_kit_response`` (a plan-pointer kit
+# pointing at the ``pocketpaw-pocket-planner`` skill + ``plan_pocket``
+# MCP tool) when ``POCKETPAW_POCKET_SPECIALIST_USE_SKILL`` is truthy,
+# template-match failed, and ``input.spec is None``. Custom multi-
+# widget briefs go through plan-then-build instead of the one-shot
+# draft kit. Widens ``PocketSpecialistCreateOutput.action`` to include
+# ``"plan_kit"``.
 # Modified: 2026-05-23 (#1197) — ``_apply_ops`` now re-fetches the live
 # spec after a successful op batch and runs the strict action-wiring
 # gate against it. Without this, an end-of-batch spec with a hallucinated
@@ -269,6 +277,26 @@ class AgentModeAdapter:
                 template_id,
             )
 
+        # Plan-pointer kit (feat/pocket-planner-skill, 2026-05-25). When
+        # USE_SKILL is on and template-match found nothing, custom multi-
+        # widget briefs go through plan-then-build instead of the one-
+        # shot draft kit. The chat agent invokes the
+        # ``pocketpaw-pocket-planner`` skill which calls the
+        # ``plan_pocket`` MCP tool, renders the brief in markdown, lets
+        # the user iterate, then walks the todos calling /spec/merge per
+        # todo. Falls back to ``_draft_kit_response`` when USE_SKILL is
+        # off so the existing one-shot path remains the default.
+        use_skill = os.environ.get(
+            "POCKETPAW_POCKET_SPECIALIST_USE_SKILL", ""
+        ).lower() in ("1", "true", "yes")
+        if use_skill:
+            return _plan_kit_response(
+                input,
+                started=started,
+                workspace_id=workspace_id,
+                user_id=user_id,
+            )
+
         return _draft_kit_response(input, started=started)
 
 
@@ -456,6 +484,98 @@ def _draft_kit_response(input: Any, *, started: float) -> Any:
         duration_ms=duration_ms,
         backend_used="agent_mode",
         draft_kit=kit,
+    )
+
+
+def _plan_kit_response(
+    input: Any,
+    *,
+    started: float,
+    workspace_id: str = "",
+    user_id: str = "",
+) -> Any:
+    """Build the plan-pointer kit (feat/pocket-planner-skill).
+
+    Mirrors the structure of the edit-side ``skill_kit`` branch in
+    ``_edit_kit_response`` but points at the planner skill + the
+    ``plan_pocket`` MCP tool instead of the merge endpoint. The chat
+    agent:
+
+      1. Loads the ``pocketpaw-pocket-planner`` skill body.
+      2. Calls ``mcp__pocketpaw_planner__plan_pocket(intent=...)`` and
+         renders the returned brief as markdown in the chat panel.
+      3. Iterates with the user (``plan_pocket`` again with
+         ``prior_plan`` + ``iteration_delta``).
+      4. On "build it" — walks the brief's ``todos`` in order, posting
+         each one's partial rippleSpec to
+         ``POST /api/v1/pockets/<id>/spec/merge`` with the auth headers
+         below. (The pocket itself is created on the first /spec/merge
+         call — there is no separate create step.)
+
+    No backend is spawned. Returns the same
+    ``PocketSpecialistCreateOutput`` shape as the draft kit so the MCP
+    tool handler treats both paths uniformly — just with
+    ``action="plan_kit"`` so the chat agent can switch on it.
+    """
+    from pocketpaw_ee.agent.pocket_specialist.runtime import PocketSpecialistCreateOutput
+
+    hints_dict: dict[str, Any] = input.hints.model_dump(exclude_none=True) if input.hints else {}
+
+    plan_kit: dict[str, Any] = {
+        "brief": input.brief,
+        "structural_plan": hints_dict,
+        "skill_name": "pocketpaw-pocket-planner",
+        "mcp_tool": "mcp__pocketpaw_planner__plan_pocket",
+        "auth_headers": {
+            "X-PocketPaw-Internal": "true",
+            "X-PocketPaw-Workspace-Id": workspace_id,
+            "X-PocketPaw-User-Id": user_id,
+        },
+        "next_step": (
+            "Invoke the ``pocketpaw-pocket-planner`` skill and the "
+            "``mcp__pocketpaw_planner__plan_pocket`` tool to draft a "
+            "plan. Render the returned brief in chat as markdown "
+            "(narrative + widgets + state + sources + actions + todos "
+            "as a checkbox list). Iterate with the user — when they say "
+            "'drop X' / 'add Y' / 'rebuild', call plan_pocket again "
+            "with prior_plan + iteration_delta. When the user says "
+            "'build it' (or 'go' / 'ship it'), walk the todos in order: "
+            "for each todo compute the smallest partial rippleSpec that "
+            "satisfies its success_criteria, then POST to "
+            "``http://localhost:8888/api/v1/pockets/<id>/spec/merge`` "
+            "with the auth_headers above and body "
+            "``{\"merge\": <partial>}``. The first /spec/merge against "
+            "a fresh pocket id creates the pocket; subsequent calls "
+            "merge into it. Tick each todo as you go. Halt on the "
+            "first failure unless the user says retry."
+        ),
+        "lookup_tool": (
+            "Use ``mcp__pocketpaw_pocket__get_widget_spec`` to look up "
+            "allowed props for any widget kind referenced in the brief "
+            "before assembling the partial rippleSpec. Use "
+            "``mcp__pocketpaw_pocket__list_pockets`` to see existing "
+            "pockets in the workspace."
+        ),
+    }
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    logger.info(
+        "[pocket-specialist] agent-mode plan-pointer kit returned "
+        "(USE_SKILL=true) (hints_keys=%s brief_len=%d duration=%dms)",
+        sorted(hints_dict.keys()),
+        len(input.brief or ""),
+        duration_ms,
+    )
+
+    return PocketSpecialistCreateOutput(
+        ok=False,
+        action="plan_kit",
+        pocket=None,
+        warnings=[],
+        error=None,
+        duration_ms=duration_ms,
+        backend_used="agent_mode_skill",
+        draft_kit=plan_kit,
     )
 
 

--- a/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/runtime.py
@@ -211,7 +211,7 @@ class PocketSpecialistCreateInput(BaseModel):
 
 class PocketSpecialistCreateOutput(BaseModel):
     ok: bool
-    action: Literal["created", "extended", "failed", "draft_kit", "redraft"]
+    action: Literal["created", "extended", "failed", "draft_kit", "redraft", "plan_kit"]
     pocket: dict[str, Any] | None = None
     warnings: list[str] = Field(default_factory=list)
     error: str | None = None
@@ -223,7 +223,11 @@ class PocketSpecialistCreateOutput(BaseModel):
             "Agent-mode first-call payload: design rules digest, structural "
             "plan echo, available widget list, and instructions for the "
             "calling chat agent to draft a rippleSpec and call back with "
-            "``spec=<draft>``. None in subagent mode."
+            "``spec=<draft>``. None in subagent mode. When ``action="
+            "'plan_kit'`` this carries the plan-pointer kit instead of the "
+            "draft kit: the chat agent should invoke the "
+            "``pocketpaw-pocket-planner`` skill and the ``plan_pocket`` MCP "
+            "tool to draft a multi-widget brief before any spec is built."
         ),
     )
 

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -210,7 +210,14 @@ class CloudTasksMcpProvider:
 
 
 class CloudPlannerMcpProvider:
-    """`pocketpaw.mcp_servers` — the cloud Planner in-process server."""
+    """`pocketpaw.mcp_servers` — the cloud Project Planner in-process
+    server (``pocketpaw_planner``). Hosts ``plan_project`` only.
+
+    Stays **opt-in** via ``OPT_IN_MCP_SERVERS`` — Mission Control's
+    project-level planner is dead weight in the context of agents that
+    never plan a project. The sibling ``CloudPocketPlannerMcpProvider``
+    handles the ambient pocket planner.
+    """
 
     def build_server(self) -> tuple[str, Any] | None:
         from pocketpaw_ee.agent.mcp_servers.planner import build_planner_context_server
@@ -221,6 +228,30 @@ class CloudPlannerMcpProvider:
         from pocketpaw_ee.agent.mcp_servers.planner import PLANNER_TOOL_IDS
 
         return list(PLANNER_TOOL_IDS)
+
+
+class CloudPocketPlannerMcpProvider:
+    """`pocketpaw.mcp_servers` — the pocket-create planner in-process
+    server (``pocketpaw_pocket_planner``). Hosts ``plan_pocket`` only.
+
+    Intentionally ambient — the bundled ``pocketpaw-pocket-planner``
+    skill must be reachable from any cloud agent that hits the
+    plan-pointer kit branch on pocket_specialist create. Splitting
+    this off from the project planner is what restores the per-server
+    OPT_IN gate for ``plan_project`` (see PR #1223 R2).
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        from pocketpaw_ee.agent.mcp_servers.planner import (
+            build_pocket_planner_context_server,
+        )
+
+        return build_pocket_planner_context_server()
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.planner import POCKET_PLANNER_TOOL_IDS
+
+        return list(POCKET_PLANNER_TOOL_IDS)
 
 
 class CloudPocketMcpProvider:

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -131,6 +131,7 @@ cloud = "pocketpaw_ee.extensions:CloudPocketWriter"
 [project.entry-points."pocketpaw.mcp_servers"]
 tasks = "pocketpaw_ee.extensions:CloudTasksMcpProvider"
 planner = "pocketpaw_ee.extensions:CloudPlannerMcpProvider"
+pocket_planner = "pocketpaw_ee.extensions:CloudPocketPlannerMcpProvider"
 pocket = "pocketpaw_ee.extensions:CloudPocketMcpProvider"
 pocket_specialist = "pocketpaw_ee.extensions:CloudPocketSpecialistMcpProvider"
 composio = "pocketpaw_ee.extensions:CloudComposioMcpProvider"

--- a/src/pocketpaw/bundled_skills/_bundled/pocketpaw-create-pocket/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/pocketpaw-create-pocket/SKILL.md
@@ -278,9 +278,45 @@ caller-supplied hints, and (in agent mode) the drafted ``spec``:
 ```
 
 In **agent mode** (``POCKETPAW_POCKET_SPECIALIST_MODE=agent``), the first
-call returns a draft kit with the structural plan echoed, widget hints,
-and instructions. Draft the spec inline, then call the tool AGAIN with
-``spec=<your draft>`` for validate-and-persist.
+call's response depends on what the brief contains:
+
+- **Template or recipe matched** → response is a regular draft kit with
+  the structural plan echoed, widget hints, and instructions. Draft the
+  spec inline, then call the tool AGAIN with ``spec=<your draft>`` for
+  validate-and-persist.
+
+- **No template, no recipe, custom multi-widget brief** (e.g. brewing
+  log, school-bus router, podcast publisher — domains the bundled
+  recipes don't cover) → if ``POCKETPAW_POCKET_SPECIALIST_USE_SKILL``
+  is set on the server, the response is a **plan-pointer kit** pointing
+  at the ``pocketpaw-pocket-planner`` skill. Invoke that skill — it
+  drives a research → draft → iterate → build flow via the
+  ``mcp__pocketpaw_planner__plan_pocket`` MCP tool and the
+  ``POST /api/v1/pockets/<id>/spec/merge`` endpoint. Do NOT draft the
+  spec inline in this case; the planner skill handles the build.
+
+To request the plan-pointer kit shape, call the tool WITHOUT a
+``spec`` field on the first invocation:
+
+```json
+{
+  "brief": "<the user's original brief>",
+  "hints": {
+    "name": "Brewer's Log",
+    "description": "Home-brewing fermentation tracker",
+    "color": "#92400e",
+    "icon": "beaker",
+    "purpose": "...",
+    "key_interactions": ["log gravity reading", "compute hop bill"]
+  }
+}
+```
+
+The adapter returns either a draft kit (template/recipe match) or a
+plan kit (no match + USE_SKILL on). Branch based on the ``action``
+field in the response: ``draft_kit`` → draft inline → call again with
+``spec``; ``plan_kit`` → invoke ``Skill('pocketpaw-pocket-planner')``
+and follow its instructions.
 
 In **subagent mode** (default), the tool spawns its own specialist
 backend and returns the created pocket — you only call once with the

--- a/src/pocketpaw/bundled_skills/_bundled/pocketpaw-create-pocket/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/pocketpaw-create-pocket/SKILL.md
@@ -291,7 +291,7 @@ call's response depends on what the brief contains:
   is set on the server, the response is a **plan-pointer kit** pointing
   at the ``pocketpaw-pocket-planner`` skill. Invoke that skill — it
   drives a research → draft → iterate → build flow via the
-  ``mcp__pocketpaw_planner__plan_pocket`` MCP tool and the
+  ``mcp__pocketpaw_pocket_planner__plan_pocket`` MCP tool and the
   ``POST /api/v1/pockets/<id>/spec/merge`` endpoint. Do NOT draft the
   spec inline in this case; the planner skill handles the build.
 

--- a/src/pocketpaw/bundled_skills/_bundled/pocketpaw-pocket-planner/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/pocketpaw-pocket-planner/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: pocketpaw-pocket-planner
+description: |
+  Plan a complex PocketPaw pocket before building it. Invoke when the
+  pocket_specialist create path returns a ``plan_kit`` (template-match
+  failed and the request looks like a custom multi-widget app).
+  The skill teaches the agent to call
+  ``mcp__pocketpaw_planner__plan_pocket``, render the brief in chat
+  as markdown, iterate with the user, then walk the todos to build via
+  ``POST /api/v1/pockets/<id>/spec/merge``. Sibling to
+  ``pocketpaw-pocket-specialist`` — that skill applies edits; this one
+  plans the initial build.
+---
+
+# Pocket Planner Workflow
+
+You're invoked because ``pocket_specialist__create`` returned a
+``plan_kit`` payload. The user asked for something the bundled
+templates do not cover — a custom multi-widget pocket — so we plan
+the build before we touch any rippleSpec. The plan is ephemeral: no
+DB row, no project. The chat session owns the iteration state.
+
+## When to use this skill
+
+Use it when ALL of these hold:
+
+- The user asked to create a NEW pocket (not edit an existing one).
+- The ``pocket_specialist__create`` response carried
+  ``action: "plan_kit"`` with a ``draft_kit`` whose ``skill_name``
+  field is ``pocketpaw-pocket-planner``.
+- The brief is custom and multi-widget — not a one-liner that fits a
+  built-in template.
+
+DO NOT use this skill when:
+
+- The brief matches a built-in template (kanban, todo, etc.). Those
+  short-circuit to the one-shot create path and never produce a
+  plan_kit.
+- The user is asking to EDIT a pocket they're already looking at. Use
+  the ``pocketpaw-edit-pocket`` skill for edits.
+- The brief is trivial ("a single chart of X"). Plan-then-build is
+  overhead for one-widget pockets — let the agent compose it directly.
+
+## The four-phase flow
+
+### Phase 1 — Research and draft the plan
+
+Call the planner tool with the user's verbatim brief:
+
+```
+mcp__pocketpaw_planner__plan_pocket({
+  intent: "<the user's original ask>",
+  deep_research: false
+})
+```
+
+The tool returns ``{ok: true, brief}`` where ``brief`` is the schema:
+
+```
+{
+  "narrative":   "<2-3 paragraph design rationale>",
+  "widgets":     [ {"type": "kanban", "purpose": "deal stages"}, ... ],
+  "state":       { "<key>": {"type": "<py-ish>", "purpose": "..."} },
+  "sources":     [ {"connector": "crm", "feeds": "<METHOD path>"} ],
+  "actions":     [ {"trigger": "<UI element>", "effect": "<op on state>"} ],
+  "todos":       [
+    { "id": "t1",
+      "label": "<imperative one-line action>",
+      "description": "...",
+      "success_criteria": ["concrete verifiable statement", ...],
+      "preconditions": ["..."],
+      "depends_on": ["..."] },
+    ...
+  ],
+  "research_notes": "<the planner's research output>"
+}
+```
+
+### Phase 2 — Render the brief in chat as markdown
+
+Lay the brief out so the user can read it at a glance. Use this exact
+shape (the desktop client renders standard markdown — no special
+widgets needed):
+
+```markdown
+## Plan: <one-line summary of the pocket>
+
+<narrative>
+
+### Widgets
+- **kanban** — deal stages
+- **stat** — total pipeline value
+- ...
+
+### State
+- **cards** *(list[dict])* — pipeline cards, each carrying id, title, status, value
+- **draft** *(str)* — text input buffer for the add-deal composer
+- ...
+
+### Sources
+- **crm** → feeds `state.cards` via `GET /leads`
+- ...
+
+### Actions
+- **Add Deal button** → push on `state.cards`
+- ...
+
+### Build steps
+- [ ] **t1** — Seed state.cards with pipeline data
+  - depends on: none
+  - done when: state.cards has 8+ entries
+- [ ] **t2** — Add kanban widget bound to state.cards
+  - depends on: t1
+  - done when: a kanban node exists at the ui root with columns [lead, qualified, proposal, won]
+- ...
+
+**Look right? Say "build it" to ship, or tell me what to change.**
+```
+
+Use ``- [ ]`` for unticked todos and ``- [x]`` after a todo's
+``/spec/merge`` lands. The two-space-indented sub-bullets carry
+``depends on`` and ``done when`` so the user can sanity-check the
+order and the criteria.
+
+### Phase 3 — Iterate with the user
+
+The user replies in one of three shapes:
+
+- **Build trigger** — "build it" / "go" / "ship it" / "make it" /
+  "looks good" / a thumbs-up emoji. Jump to Phase 4.
+- **Revision** — "drop the chart" / "add a forecast widget" / "use
+  a feed pattern instead of dashboard" / "rebuild this from scratch
+  as a wizard". Call the planner again with the prior plan + the
+  delta:
+
+  ```
+  mcp__pocketpaw_planner__plan_pocket({
+    intent: "<the original brief>",
+    prior_plan: <the brief object from the previous call>,
+    iteration_delta: "<the user's verbatim revision request>"
+  })
+  ```
+
+  Re-render the new brief and ask again. Iterate up to ~3 rounds
+  before suggesting the user accept the current shape (each round
+  is real LLM time).
+
+- **Pivot / cancel** — "actually, never mind" / "I want something
+  different entirely". Stop. Ask what they'd like instead and route
+  the new ask back through ``pocket_specialist__create``.
+
+### Phase 4 — Build by walking the todos
+
+The chat agent walks ``brief.todos`` in dependency order. The build
+endpoint is the same merge endpoint the
+``pocketpaw-pocket-specialist`` skill uses — see that sibling skill
+for the rippleSpec shape, action verbs, and the four interactivity
+conventions. The differences here are:
+
+1. **First todo creates the pocket.** The first ``POST /spec/merge``
+   against an id that does not exist yet creates the pocket; every
+   later todo merges into that same id. Generate a fresh pocket id
+   for the first call (the response carries the id back; reuse it).
+
+2. **One todo per merge.** Do not bundle two todos into a single
+   request — the brief's todo boundaries are tested units. Each
+   merge body should satisfy the todo's ``success_criteria`` and no
+   more.
+
+3. **Auth headers from the plan_kit.** Use the exact headers the
+   ``plan_kit.auth_headers`` block carried — ``X-PocketPaw-Internal:
+   true`` plus the workspace and user id. The endpoint runs at
+   ``http://localhost:8888/api/v1/pockets/<id>/spec/merge``.
+
+4. **Tick as you go.** After each successful merge, update the
+   markdown plan in chat — change ``- [ ]`` to ``- [x]`` for the
+   completed todo. The user wants to see progress.
+
+5. **Halt on failure.** If a merge returns ``{ok: false}`` with
+   warnings, surface the warnings to the user and STOP. Do NOT
+   retry the todo more than once on your own. Ask the user whether
+   to fix-and-retry, skip, or abandon the build.
+
+## Conventions (carry over from pocketpaw-pocket-specialist)
+
+The merge bodies you build in Phase 4 must follow the same four
+conventions the ``pocketpaw-pocket-specialist`` skill documents in
+full:
+
+1. **Client-side actions, not chat round-trips.** Use ``push`` /
+   ``set`` / ``validate`` in ``on_click`` sequences, never
+   ``{action: "emit", target: "chat.send"}``.
+2. **Selects: value/label split.** Bound state holds the ``value``
+   (machine id); the ``label`` is display-only.
+3. **Lowercase column ids.** A kanban column ``{id: "lead"}`` matches
+   cards whose ``status: "lead"`` — case-sensitive.
+4. **Validate → push → clear → increment.** The canonical add-item
+   action sequence is validate the input is non-empty, push to the
+   collection, clear the draft field, then increment the id counter.
+
+If a todo's ``success_criteria`` is satisfied by a different
+rippleSpec than what you'd naturally compose, prefer the one the
+``pocketpaw-pocket-specialist`` skill would build — it's been
+hardened. Load that skill if you need to refresh on the shape.
+
+## Hard rules
+
+- **NEVER call ``pocket_specialist__create`` again** for a brief
+  this skill is already planning. The plan_kit is the handoff; from
+  here you own the build. Calling create back would loop.
+- **NEVER skip the brief render.** Even if you think the brief is
+  obviously correct, render it so the user sees what they're
+  approving.
+- **NEVER walk the todos before the user says "build it".** A
+  rendered plan is not consent — the user has to confirm.
+- **NEVER write a todo's success_criteria yourself.** They come from
+  the planner. If the criteria are vague, that's a planner bug to
+  file, not something to paper over by gold-plating the build.
+- **NEVER post to /spec/merge without the auth headers** from
+  ``plan_kit.auth_headers``. They are how the loopback-internal
+  endpoint trusts the workspace and user.
+
+## When done
+
+Report back in chat with:
+
+- The pocket id you built (link to it in the desktop client).
+- The number of todos completed vs. total.
+- Any ``ok: true`` warnings from the merge calls (verbatim).
+- A one-line summary of what the user can now do in the pocket.
+
+Example:
+
+> Built **Sales Command Center** (pocket id `p_abc123`). 8/8 todos
+> complete. The pipeline kanban is on the canvas with seeded deals,
+> the add-deal composer pushes new cards, and the forecast chart
+> updates as you change the period. Open it from the sidebar.

--- a/src/pocketpaw/bundled_skills/_bundled/pocketpaw-pocket-planner/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/pocketpaw-pocket-planner/SKILL.md
@@ -5,7 +5,7 @@ description: |
   pocket_specialist create path returns a ``plan_kit`` (template-match
   failed and the request looks like a custom multi-widget app).
   The skill teaches the agent to call
-  ``mcp__pocketpaw_planner__plan_pocket``, render the brief in chat
+  ``mcp__pocketpaw_pocket_planner__plan_pocket``, render the brief in chat
   as markdown, iterate with the user, then walk the todos to build via
   ``POST /api/v1/pockets/<id>/spec/merge``. Sibling to
   ``pocketpaw-pocket-specialist`` — that skill applies edits; this one
@@ -48,7 +48,7 @@ DO NOT use this skill when:
 Call the planner tool with the user's verbatim brief:
 
 ```
-mcp__pocketpaw_planner__plan_pocket({
+mcp__pocketpaw_pocket_planner__plan_pocket({
   intent: "<the user's original ask>",
   deep_research: false
 })
@@ -134,7 +134,7 @@ The user replies in one of three shapes:
   delta:
 
   ```
-  mcp__pocketpaw_planner__plan_pocket({
+  mcp__pocketpaw_pocket_planner__plan_pocket({
     intent: "<the original brief>",
     prior_plan: <the brief object from the previous call>,
     iteration_delta: "<the user's verbatim revision request>"
@@ -219,6 +219,24 @@ hardened. Load that skill if you need to refresh on the shape.
 - **NEVER post to /spec/merge without the auth headers** from
   ``plan_kit.auth_headers``. They are how the loopback-internal
   endpoint trusts the workspace and user.
+
+## Known MVP limitations
+
+These are real friction points that the MVP cuts; if you bump into
+them often in real use, surface that to the captain so we know to
+prioritise the follow-up.
+
+- **Widget / state / source / action IDs are NOT stable across
+  iteration calls.** Each ``plan_pocket`` call re-derives the brief
+  from scratch, so a revision that adds one widget can renumber every
+  existing widget (``w_3`` → ``w_4``, etc.). When you walk the todos
+  in Phase 4 you key off ``brief.todos[i].id`` for tracking, but the
+  underlying widget refs inside the merge bodies may not line up with
+  what the user thinks they approved on a prior round. Surface
+  changed IDs in the rendered diff so the user is not surprised.
+- **No end-to-end test of the handler with a mocked LLM yet.** The
+  parser layer is unit-tested but the full ``_plan_pocket_handler``
+  → pipeline → brief path is exercised only against a live model.
 
 ## When done
 

--- a/src/pocketpaw/deep_work/prompts.py
+++ b/src/pocketpaw/deep_work/prompts.py
@@ -12,6 +12,13 @@
 # Updated: 2026-05-21 (PR #1164 review) — TASK_BREAKDOWN_PROMPT JSON
 #   example no longer says the description holds "acceptance criteria";
 #   criteria belong in the dedicated success_criteria array.
+# Updated: 2026-05-25 (feat/pocket-planner-skill) — added the POCKET_*
+#   prompt family for the plan-before-create gate. The three prompts
+#   parallel the project planner family but emit pocket-flavored
+#   sections (NARRATIVE / WIDGETS / STATE / SOURCES / ACTIONS) and
+#   ordered todos where each todo is one /spec/merge call. Consumed by
+#   the ``plan_pocket`` MCP tool — no project_id, no DB persistence,
+#   no team-assembly phase.
 #
 # Prompt templates:
 #   GOAL_PARSE_PROMPT — structured goal analysis (domain, complexity, roles)
@@ -21,6 +28,13 @@
 #   PRD_PROMPT — PRD generation
 #   TASK_BREAKDOWN_PROMPT — task decomposition to JSON
 #   TEAM_ASSEMBLY_PROMPT — team recommendation to JSON
+#   POCKET_RESEARCH_PROMPT — pocket research (canonical patterns +
+#     fabrics + connectors + similar pockets)
+#   POCKET_PRD_PROMPT — pocket PRD with the 5 structured sections
+#     (NARRATIVE / WIDGETS / STATE / SOURCES / ACTIONS) the brief
+#     parser consumes
+#   POCKET_TASK_BREAKDOWN_PROMPT — ordered todos where each is one
+#     /spec/merge call
 
 GOAL_PARSE_PROMPT = """\
 You are an expert project analyst. Analyze the user's goal and produce a \
@@ -241,6 +255,224 @@ Just the raw JSON array:
     "description": "...",
     "specialties": ["..."],
     "backend": "{agent_backend}"
+  }}
+]
+"""
+
+
+# ============================================================================
+# Pocket planner prompt family (feat/pocket-planner-skill).
+#
+# Mirrors the project planner family above but emits pocket-flavored
+# structure. The output of POCKET_PRD_PROMPT is parsed by the brief
+# extractor in ``pocketpaw_ee.agent.mcp_servers.planner`` — the section
+# delimiters below are part of the contract (changing them will break
+# the parser). The output of POCKET_TASK_BREAKDOWN_PROMPT is JSON the
+# same ``PlannerAgent._parse_tasks`` consumes.
+# ============================================================================
+
+POCKET_RESEARCH_PROMPT = """\
+You are a PocketPaw design researcher. A pocket is a workspace canvas — \
+a JSON ``rippleSpec`` tree of typed widget nodes (``{{type, props, \
+children}}``) that renders into a polished UI on the PocketPaw \
+dashboard. Pockets carry both UI structure and a state layer; widgets \
+read state via ``bind`` and write state via ``on_click`` action \
+sequences.
+
+Your job is NOT to design the pocket. Your job is to surface what \
+already exists that the designer downstream should reach for.
+
+USER BRIEF:
+{project_description}
+
+Look at four buckets:
+
+1. CANONICAL POCKET PATTERNS. Pockets fit into one of seven shapes — \
+``dashboard`` (overview KPIs + charts), ``app`` (interactive tool the \
+user operates: todo, kanban, planner), ``viewer`` (read-only \
+inspection of one thing), ``composer`` (focused authoring), \
+``browser`` (list + drill-in master-detail), ``wizard`` (multi-step \
+linear flow), ``feed`` (reverse-chronological stream). Name the ONE \
+pattern this brief fits. Do NOT default to ``dashboard`` — most briefs \
+are not dashboards.
+
+2. RICH FOCAL WIDGETS. PocketPaw ships 150 widgets including composed \
+domain layouts (``pipeline-dashboard``, ``invoice-layout``, \
+``entity-detail``, ``ops-dashboard``, ``project-dashboard``, \
+``master-detail``, ``kanban``, ``calendar``, ``gantt``, \
+``form-layout``, ``wizard-layout``). For this brief, name 2-4 of the \
+RICHEST widgets that map directly to the user's intent — prefer \
+composed layouts over assembling the same shape from primitives.
+
+3. STATE & LIVE DATA. List the state keys the user will visibly read \
+or write (cards, deals, tasks, filters, drafts). Tag each with whether \
+it's seed data (one-time mock content) or live (needs a connector / \
+backend source).
+
+4. EXISTING PATTERNS TO MIRROR. If PocketPaw's bundled-recipes KB \
+likely has a pattern that matches (sales-pipeline-dashboard, \
+customer-support-app, recipe-viewer), name it so the designer can \
+reach for it as a starter.
+
+OUTPUT FORMAT — plain text with EXACTLY these sections, in order:
+
+## Pattern
+(one line: the canonical pattern name and a one-sentence justification)
+
+## Focal Widgets
+(2-4 bullet lines, ``- <widget-kind>: <why this one>``)
+
+## State Shape
+(bullet lines, ``- <key>: <type> — <seed | live: <source-hint>>``)
+
+## Similar Pockets
+(0-3 bullet lines naming canonical patterns or recipes the brief \
+resembles; empty bullet list is fine when nothing obvious matches)
+
+Keep the entire output under 300 words. No code blocks, no commentary \
+outside the sections.
+"""
+
+
+POCKET_PRD_PROMPT = """\
+You are a PocketPaw pocket designer. The researcher above named the \
+pattern, the focal widgets, the state shape, and any prior art. Your \
+job is to turn that into a structured pocket PRD the downstream \
+planner can decompose into ``/spec/merge`` build steps.
+
+USER BRIEF:
+{project_description}
+
+RESEARCH NOTES:
+{research_notes}
+
+OUTPUT FORMAT — markdown with EXACTLY these five sections, in this \
+order, using EXACTLY these ``##`` headings. The brief parser splits \
+on them, so do not rename, reorder, or skip any.
+
+## NARRATIVE
+2-3 paragraphs describing what the pocket is, who uses it, and the \
+design approach. Reference the pattern from research. End with one \
+sentence on the "happy path" — the single action the user does most \
+often inside this pocket.
+
+## WIDGETS
+A bullet list, one widget per line, format ``- <kind>: <purpose>``. \
+Use the focal widgets from research as the spine; add layout primitives \
+(``flex``, ``grid``, ``app-shell``, ``sidebar``) only as needed for \
+chrome. Aim for 4-10 widgets total — pockets do one thing well. \
+EXAMPLES:
+- kanban: deal stages, cards represent deals
+- stat: total pipeline value, top-left
+- form-layout: add-deal composer below the kanban
+- chart: revenue forecast, bottom
+
+## STATE
+A bullet list, one state key per line, format \
+``- <key>: <py-ish type> — <purpose>``. Use lowercase snake_case for \
+keys. Include seed-data keys AND any draft/filter/counter keys the \
+actions need. EXAMPLES:
+- cards: list[dict] — pipeline cards each carrying id, title, status, value
+- draft: str — text input buffer for the add-deal composer
+- next_id: int — monotonic id counter for new cards
+- filter: str — current pipeline stage filter
+
+## SOURCES
+A bullet list of live data sources, one per line, format \
+``- <connector>: <feeds state.X via METHOD path>``. Use \
+``<connector> = none`` for purely seeded pockets — but ALWAYS include \
+this section even if the only entry is ``- none: pocket runs on \
+seeded state``. EXAMPLES:
+- crm: feeds state.cards via GET /leads
+- analytics: feeds state.revenue_series via GET /metrics/revenue?period=q
+
+## ACTIONS
+A bullet list of user-triggered state changes, one per line, format \
+``- <trigger>: <op> on state.<target> (<value or note>)``. The op is \
+one of: ``push`` (append item), ``set`` (overwrite), ``remove`` \
+(delete item), ``patch`` (merge). EXAMPLES:
+- Add Deal button: push on state.cards (new card from state.draft fields)
+- Stage filter select: set on state.filter (the chosen value)
+- Mark Won kanban menu: patch on state.cards[id] (status -> "won")
+
+Hard rules:
+- Use the exact section headings above (``## NARRATIVE``, \
+``## WIDGETS``, ``## STATE``, ``## SOURCES``, ``## ACTIONS``). \
+Anything else breaks the parser.
+- Bullet lines start with ``- `` (dash + space). Don't use ``*`` or \
+numbered lists.
+- Keep the whole PRD under 500 words.
+- No introduction, no closing remarks — just the five sections.
+"""
+
+
+POCKET_TASK_BREAKDOWN_PROMPT = """\
+You are a PocketPaw build planner. The PRD above describes a pocket. \
+Your job is to turn it into an ordered list of build todos, where \
+each todo is ONE cohesive ``POST /api/v1/pockets/<id>/spec/merge`` \
+call that the chat agent will walk in order.
+
+USER BRIEF:
+{project_description}
+
+PRD:
+{prd_content}
+
+RESEARCH NOTES:
+{research_notes}
+
+RULES:
+- One todo per merge call. Don't bundle "add widget X and seed state Y \
+and wire action Z" into a single todo unless they're literally one \
+merge body.
+- ORDER MATTERS. Seed state before the widgets that read it. Add the \
+parent layout before its children. Wire on_click actions only after \
+both the widget and the state key exist.
+- Aim for 4-10 todos. Fewer is better — each merge call is a tested \
+unit, not a click-by-click.
+- Each todo is "agent" task_type (the chat agent walks the list — no \
+human action between todos). Don't emit "human" or "review" todos.
+- Use short keys: ``t1``, ``t2``, ``t3``, ...
+- ``blocked_by_keys`` carries the inter-todo dependency graph and must \
+NEVER have cycles.
+
+SUCCESS CRITERIA — every todo MUST have a "success_criteria" array:
+- Each entry is ONE concrete, objectively-verifiable statement about \
+the pocket AFTER this merge runs. The chat agent will read these to \
+decide whether to advance to the next todo.
+- BANNED — never write "works", "looks good", "is correct", or any \
+other vague predicate.
+- GOOD examples: \
+"state.cards is a list with at least 4 seed entries", \
+"the kanban widget at the root has columns [lead, qualified, proposal, won]", \
+"the add-deal button's on_click sequence pushes to state.cards then clears state.draft".
+- Give 1-3 criteria per todo.
+
+PRECONDITIONS — every todo MUST have a "preconditions" array:
+- Each entry is ONE state condition that must already hold BEFORE \
+this todo runs. These are conditions about the pocket's current \
+shape, NOT inter-todo dependencies (those go in blocked_by_keys).
+- Use empty array ``[]`` when the todo has no preconditions (typical \
+for the very first seed todo).
+- GOOD examples: "state.cards exists and is a list", \
+"a node of type 'kanban' exists at the ui root".
+
+Output ONLY a valid JSON array. No markdown code fences. No commentary. \
+Just the raw JSON array:
+
+[
+  {{
+    "key": "t1",
+    "title": "<imperative one-line action, e.g. 'Seed state.cards with pipeline data'>",
+    "description": "<one-paragraph note: which merge body to assemble, why this slice was chosen>",
+    "task_type": "agent",
+    "priority": "medium",
+    "tags": ["state-seed" | "widget-add" | "action-wire" | ...],
+    "estimated_minutes": 5,
+    "required_specialties": ["pocket-spec"],
+    "blocked_by_keys": [],
+    "success_criteria": ["concrete verifiable statement about post-merge state", "..."],
+    "preconditions": ["concrete pre-merge condition", "..."]
   }}
 ]
 """

--- a/src/pocketpaw/tools/policy.py
+++ b/src/pocketpaw/tools/policy.py
@@ -93,13 +93,22 @@ TOOL_PROFILES: dict[str, dict] = {
 # turn a cloud agent's ``tools`` entries into ``mcp_servers_allow``, and
 # ``ClaudeSDKBackend`` reads it to gate both server registration and the tool
 # allowlist. A new opt-in server is added here once.
-# 2026-05-25: ``pocketpaw_planner`` was previously opt-in (Mission Control
-# only). It now also hosts ``plan_pocket`` which the pocket-specialist
-# plan-pointer kit directs the chat agent to invoke for complex pocket
-# creation. Making the server ambient is the simpler shape for the MVP
-# (the MCP tools are inert until called). Re-gate per-tool later if
-# selective exposure becomes important.
-OPT_IN_MCP_SERVERS: frozenset[str] = frozenset()
+#
+# ``pocketpaw_planner`` hosts Mission Control's ``plan_project`` and stays
+# opt-in — most cloud agents never plan a project and the schema is dead
+# weight in their context. Cloud agents opt in by listing the bare token
+# ``pocketpaw_planner`` in their ``config.tools`` field; ``AgentPool._build``
+# turns that into a ``ToolPolicy.mcp_servers_allow`` entry.
+#
+# The sibling ``pocketpaw_pocket_planner`` server (hosting ``plan_pocket``,
+# the pocket-create planning tool) is intentionally NOT in this set — it
+# must be ambient so the bundled ``pocketpaw-pocket-planner`` skill can
+# call it on a cloud agent that has never explicitly opted into anything.
+# The two were briefly hosted on a single server during the
+# feat/pocket-planner-skill MVP; PR #1223 R2 split them back apart so each
+# tool gets the policy regime it actually needs. See
+# ``ee/pocketpaw_ee/agent/mcp_servers/planner.py`` for the split.
+OPT_IN_MCP_SERVERS: frozenset[str] = frozenset({"pocketpaw_planner"})
 
 
 class ToolPolicy:

--- a/src/pocketpaw/tools/policy.py
+++ b/src/pocketpaw/tools/policy.py
@@ -93,7 +93,13 @@ TOOL_PROFILES: dict[str, dict] = {
 # turn a cloud agent's ``tools`` entries into ``mcp_servers_allow``, and
 # ``ClaudeSDKBackend`` reads it to gate both server registration and the tool
 # allowlist. A new opt-in server is added here once.
-OPT_IN_MCP_SERVERS: frozenset[str] = frozenset({"pocketpaw_planner"})
+# 2026-05-25: ``pocketpaw_planner`` was previously opt-in (Mission Control
+# only). It now also hosts ``plan_pocket`` which the pocket-specialist
+# plan-pointer kit directs the chat agent to invoke for complex pocket
+# creation. Making the server ambient is the simpler shape for the MVP
+# (the MCP tools are inert until called). Re-gate per-tool later if
+# selective exposure becomes important.
+OPT_IN_MCP_SERVERS: frozenset[str] = frozenset()
 
 
 class ToolPolicy:

--- a/tests/cloud/test_agent_pool_planner_opt_in.py
+++ b/tests/cloud/test_agent_pool_planner_opt_in.py
@@ -156,3 +156,35 @@ def test_claude_sdk_backend_is_the_real_class():
     branch in ``_build`` would silently skip the policy plumbing.
     """
     assert ClaudeSDKBackend.__name__ == "ClaudeSDKBackend"
+
+
+@pytest.mark.asyncio
+async def test_pocket_planner_ambient_does_not_need_opt_in_token():
+    """Sibling pin of ``test_no_tools_planner_off`` for the pocket-create
+    planner. ``pocketpaw_pocket_planner`` is NOT in ``OPT_IN_MCP_SERVERS``
+    — the bundled pocket-create skill calls it without the agent ever
+    naming it in ``config.tools``. The pool builder must therefore NOT
+    add it to ``mcp_servers_allow`` even if the agent does name it (an
+    unknown token is dropped silently — same as any other non-opt-in
+    server name).
+    """
+    # Agent with no tools — the ambient pocket planner must still be
+    # reachable (the allow-by-default path), so ``is_mcp_server_allowed``
+    # returns True. We assert by ABSENCE from ``mcp_servers_allow``: the
+    # ambient server is intentionally not in OPT_IN_MCP_SERVERS so the
+    # opt-in path doesn't even see it.
+    doc = _make_agent_doc(tools=[])
+    policy = await _build_with(doc, Settings(anthropic_api_key="k"))
+    # Not opted in (because not in OPT_IN_MCP_SERVERS), but still reachable
+    # via the allow-by-default channel.
+    assert policy.is_mcp_server_explicitly_allowed("pocketpaw_pocket_planner") is False
+    assert policy.is_mcp_server_allowed("pocketpaw_pocket_planner") is True
+
+    # Even an agent that explicitly names the ambient server in `tools`
+    # does not flip it into the opt-in set — only servers in
+    # OPT_IN_MCP_SERVERS get translated.
+    doc_with_token = _make_agent_doc(tools=["pocketpaw_pocket_planner"])
+    policy_with_token = await _build_with(doc_with_token, Settings(anthropic_api_key="k"))
+    assert (
+        policy_with_token.is_mcp_server_explicitly_allowed("pocketpaw_pocket_planner") is False
+    )

--- a/tests/cloud/test_plan_pocket_brief.py
+++ b/tests/cloud/test_plan_pocket_brief.py
@@ -1,0 +1,472 @@
+# Created: 2026-05-25 (feat/pocket-planner-skill) — unit tests for the
+#   plan_pocket brief schema parser. Two modules in scope:
+#
+#     * ``_parse_pocket_prd_sections`` — splits the PRD output into the
+#       five labelled sections (NARRATIVE / WIDGETS / STATE / SOURCES /
+#       ACTIONS).
+#     * ``_build_pocket_brief`` — turns the raw PRD + parsed TaskSpec
+#       list into the brief dict the MCP tool returns and the chat
+#       agent renders as markdown.
+#     * ``_compose_intent_with_iteration`` — splices prior_plan +
+#       iteration_delta into the brief on follow-up calls.
+#
+# The brief parser is the contract between the planner LLM output and
+# the markdown render. These tests pin the section delimiters, the
+# bullet-line format, and the TaskSpec → todo projection so a planner
+# prompt tweak that changes the output shape fails loudly here instead
+# of silently shipping a busted brief to the chat agent.
+"""Tests for the ``plan_pocket`` brief schema parser.
+
+The MCP tool itself wraps an LLM call so it isn't unit-tested here —
+``tests/test_deep_work_planner.py`` already covers PlannerAgent.
+These tests exercise the pure-Python brief construction so we can
+catch parser regressions without burning LLM time.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.agent.mcp_servers.planner import (
+    _build_pocket_brief,
+    _compose_intent_with_iteration,
+    _parse_bullet_pairs,
+    _parse_pocket_prd_sections,
+)
+
+from pocketpaw.deep_work.models import TaskSpec
+
+
+class TestParsePocketPrdSections:
+    """Pin the section-splitting contract for the PRD prompt output."""
+
+    def test_well_formed_prd_splits_into_five_sections(self) -> None:
+        prd = """\
+## NARRATIVE
+A sales command center for tracking the quarterly pipeline.
+
+It uses a kanban as the focal widget.
+
+## WIDGETS
+- kanban: deal stages
+- stat: total pipeline value
+- form-layout: add-deal composer
+
+## STATE
+- cards: list[dict] — pipeline cards
+- draft: str — text input buffer
+- next_id: int — monotonic id counter
+
+## SOURCES
+- crm: feeds state.cards via GET /leads
+
+## ACTIONS
+- Add Deal button: push on state.cards (new card)
+- Stage filter: set on state.filter (the chosen value)
+"""
+        sections = _parse_pocket_prd_sections(prd)
+
+        assert "A sales command center" in sections["NARRATIVE"]
+        assert "kanban: deal stages" in sections["WIDGETS"]
+        assert "cards: list[dict]" in sections["STATE"]
+        assert "crm: feeds state.cards" in sections["SOURCES"]
+        assert "Add Deal button" in sections["ACTIONS"]
+
+    def test_missing_section_returns_empty_string(self) -> None:
+        """A malformed PRD without all five sections degrades gracefully.
+
+        The brief parser is the boundary between LLM stochasticity and
+        the chat agent's markdown render. If the LLM forgets a section
+        the brief shows it as empty, not KeyError.
+        """
+        prd = """\
+## NARRATIVE
+Just a narrative — the model forgot the other sections.
+
+## WIDGETS
+- stat: a count
+"""
+        sections = _parse_pocket_prd_sections(prd)
+
+        assert "narrative" in sections["NARRATIVE"].lower()
+        assert "stat: a count" in sections["WIDGETS"]
+        assert sections["STATE"] == ""
+        assert sections["SOURCES"] == ""
+        assert sections["ACTIONS"] == ""
+
+    def test_unknown_section_does_not_leak_into_others(self) -> None:
+        """A heading we don't recognise closes the current section.
+
+        Without that, an LLM that emits ``## EXTRA NOTES`` between
+        STATE and SOURCES would dump that prose into the STATE
+        section, producing garbage bullet pairs.
+        """
+        prd = """\
+## NARRATIVE
+A pocket.
+
+## STATE
+- items: list[dict] — the items
+
+## EXTRA NOTES
+This should not land in STATE.
+
+## SOURCES
+- none: pocket runs on seeded state
+"""
+        sections = _parse_pocket_prd_sections(prd)
+
+        assert "items: list[dict]" in sections["STATE"]
+        # The "## EXTRA NOTES" block must not leak into STATE.
+        assert "should not land in STATE" not in sections["STATE"]
+        # And SOURCES is still found after the unknown heading.
+        assert "none: pocket runs on seeded state" in sections["SOURCES"]
+
+    def test_empty_prd(self) -> None:
+        sections = _parse_pocket_prd_sections("")
+        assert all(v == "" for v in sections.values())
+
+
+class TestParseBulletPairs:
+    """The ``- left: right`` bullet primitive used by every section parser."""
+
+    def test_basic_pairs(self) -> None:
+        text = "- kanban: deal stages\n- stat: total pipeline value\n"
+        pairs = _parse_bullet_pairs(text)
+        assert pairs == [
+            ("kanban", "deal stages"),
+            ("stat", "total pipeline value"),
+        ]
+
+    def test_skips_non_bullet_lines(self) -> None:
+        """Prose lines mixed into a bullet list must not become pairs."""
+        text = (
+            "Here is a list of widgets:\n"
+            "- kanban: deal stages\n"
+            "\n"
+            "More notes.\n"
+            "- stat: total pipeline value\n"
+        )
+        pairs = _parse_bullet_pairs(text)
+        assert pairs == [
+            ("kanban", "deal stages"),
+            ("stat", "total pipeline value"),
+        ]
+
+    def test_bullet_without_colon_keeps_raw_text(self) -> None:
+        """A bullet line missing the colon comes back as (line, '').
+
+        We'd rather surface the user-visible text than drop the line.
+        """
+        text = "- kanban with deal stages\n- stat: total\n"
+        pairs = _parse_bullet_pairs(text)
+        assert pairs == [
+            ("kanban with deal stages", ""),
+            ("stat", "total"),
+        ]
+
+
+class TestBuildPocketBrief:
+    """End-to-end: PRD + TaskSpec list → brief dict."""
+
+    def _well_formed_prd(self) -> str:
+        return """\
+## NARRATIVE
+A sales pipeline tracker. Users drag deals across stages.
+
+The happy path is "add a deal, then drag it forward".
+
+## WIDGETS
+- kanban: deal stages
+- stat: total pipeline value
+
+## STATE
+- cards: list[dict] — pipeline cards
+- draft: str — text input buffer
+
+## SOURCES
+- crm: feeds state.cards via GET /leads
+
+## ACTIONS
+- Add Deal button: push on state.cards (new card from draft)
+"""
+
+    def test_brief_carries_all_sections(self) -> None:
+        tasks = [
+            TaskSpec(
+                key="t1",
+                title="Seed state.cards with pipeline data",
+                description="Initial seed of 8 deals across stages",
+                success_criteria=["state.cards has 8+ entries"],
+                preconditions=[],
+                blocked_by_keys=[],
+                tags=["state-seed"],
+                estimated_minutes=5,
+            ),
+            TaskSpec(
+                key="t2",
+                title="Add kanban widget bound to state.cards",
+                description="Place at ui root with four columns",
+                success_criteria=[
+                    "a kanban node exists at the ui root",
+                    "columns are [lead, qualified, proposal, won]",
+                ],
+                preconditions=["state.cards exists and is a list"],
+                blocked_by_keys=["t1"],
+                tags=["widget-add"],
+                estimated_minutes=8,
+            ),
+        ]
+
+        brief = _build_pocket_brief(
+            prd=self._well_formed_prd(),
+            tasks=tasks,
+            research_notes="Pattern: dashboard. Focal: kanban.",
+        )
+
+        assert brief["narrative"].startswith("A sales pipeline tracker")
+        assert brief["widgets"] == [
+            {"type": "kanban", "purpose": "deal stages"},
+            {"type": "stat", "purpose": "total pipeline value"},
+        ]
+        assert brief["state"] == {
+            "cards": {"type": "list[dict]", "purpose": "pipeline cards"},
+            "draft": {"type": "str", "purpose": "text input buffer"},
+        }
+        assert brief["sources"] == [
+            {"connector": "crm", "feeds": "feeds state.cards via GET /leads"},
+        ]
+        assert brief["actions"] == [
+            {
+                "trigger": "Add Deal button",
+                "effect": "push on state.cards (new card from draft)",
+            },
+        ]
+        assert brief["research_notes"] == "Pattern: dashboard. Focal: kanban."
+
+    def test_brief_projects_taskspec_into_todos(self) -> None:
+        tasks = [
+            TaskSpec(
+                key="t1",
+                title="Seed state.cards",
+                description="...",
+                success_criteria=["state.cards has 8+ entries"],
+                preconditions=[],
+                blocked_by_keys=[],
+                tags=["state-seed"],
+                estimated_minutes=5,
+            ),
+            TaskSpec(
+                key="t2",
+                title="Add kanban",
+                description="...",
+                success_criteria=["a kanban node exists at the ui root"],
+                preconditions=["state.cards exists and is a list"],
+                blocked_by_keys=["t1"],
+                tags=["widget-add"],
+                estimated_minutes=8,
+            ),
+        ]
+
+        brief = _build_pocket_brief(
+            prd=self._well_formed_prd(),
+            tasks=tasks,
+            research_notes="",
+        )
+
+        assert brief["todos"] == [
+            {
+                "id": "t1",
+                "label": "Seed state.cards",
+                "description": "...",
+                "success_criteria": ["state.cards has 8+ entries"],
+                "preconditions": [],
+                "depends_on": [],
+                "tags": ["state-seed"],
+                "estimated_minutes": 5,
+            },
+            {
+                "id": "t2",
+                "label": "Add kanban",
+                "description": "...",
+                "success_criteria": ["a kanban node exists at the ui root"],
+                "preconditions": ["state.cards exists and is a list"],
+                "depends_on": ["t1"],
+                "tags": ["widget-add"],
+                "estimated_minutes": 8,
+            },
+        ]
+
+    def test_brief_handles_missing_prd_sections_gracefully(self) -> None:
+        """An LLM that drops sections still produces a usable brief.
+
+        The chat agent's markdown render branches on emptiness — it can
+        say "the planner did not propose any actions" rather than
+        crash.
+        """
+        prd = """\
+## NARRATIVE
+Minimal brief.
+
+## WIDGETS
+- text: a one-line greeting
+"""
+        brief = _build_pocket_brief(prd=prd, tasks=[], research_notes="")
+
+        assert brief["narrative"] == "Minimal brief."
+        assert brief["widgets"] == [{"type": "text", "purpose": "a one-line greeting"}]
+        assert brief["state"] == {}
+        assert brief["sources"] == []
+        assert brief["actions"] == []
+        assert brief["todos"] == []
+
+    def test_brief_treats_em_dash_and_hyphen_as_state_separator(self) -> None:
+        """LLMs emit ``—`` or `` - `` interchangeably between type and purpose.
+
+        Both must parse — if we only handle one variant, half the
+        briefs lose their state purpose strings.
+        """
+        prd = """\
+## NARRATIVE
+P.
+
+## STATE
+- a: int — counter
+- b: str - draft
+- c: list - items
+
+## SOURCES
+- none: seeded
+
+## ACTIONS
+- click: set on state.a
+"""
+        brief = _build_pocket_brief(prd=prd, tasks=[], research_notes="")
+        # All three rows must surface a non-empty purpose.
+        assert brief["state"]["a"]["purpose"] == "counter"
+        assert brief["state"]["b"]["purpose"] == "draft"
+        assert brief["state"]["c"]["purpose"] == "items"
+
+
+class TestComposeIntentWithIteration:
+    """The first call passes intent through. Follow-up calls splice
+    in prior_plan + iteration_delta so the LLM iterates instead of
+    re-planning from scratch."""
+
+    def test_first_call_passes_intent_through(self) -> None:
+        composed = _compose_intent_with_iteration("Build a CRM", None, None)
+        assert composed == "Build a CRM"
+
+    def test_iteration_appends_prior_plan_and_delta(self) -> None:
+        prior = {"widgets": [{"type": "kanban", "purpose": "stages"}]}
+        composed = _compose_intent_with_iteration(
+            "Build a CRM",
+            prior,
+            "drop the kanban, use a feed instead",
+        )
+        # The original brief must still appear so the LLM does not lose
+        # the user's original intent.
+        assert "Build a CRM" in composed
+        # The revision request must be present.
+        assert "drop the kanban" in composed
+        # The prior plan must be serialised so the LLM can diff.
+        assert "kanban" in composed
+        # And the order matters: USER REVISION REQUEST should appear
+        # BEFORE PRIOR PLAN so the LLM reads the change before the
+        # baseline.
+        assert composed.index("USER REVISION REQUEST") < composed.index("PRIOR PLAN")
+
+    def test_iteration_delta_without_prior_plan(self) -> None:
+        """Edge case: agent forgot to pass prior_plan but supplied a delta.
+
+        We still want the delta surfaced — the LLM gets a partial
+        iteration signal rather than a silent no-op.
+        """
+        composed = _compose_intent_with_iteration(
+            "Build a CRM",
+            None,
+            "actually make it green",
+        )
+        assert "Build a CRM" in composed
+        assert "actually make it green" in composed
+        assert "PRIOR PLAN" not in composed
+
+
+class TestPlanPocketHandlerArgs:
+    """Lightweight arg validation tests for the MCP handler.
+
+    The handler itself wraps an LLM, but its arg-coercion / identity-
+    check / error-envelope paths are deterministic and worth pinning.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_intent_returns_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import planner as planner_mod
+
+        # Patch the identity check so it appears we ARE in an SSE stream.
+        original = planner_mod._identity
+        planner_mod._identity = lambda: ("ws_1", "user_1")
+        try:
+            result = await planner_mod._plan_pocket_handler({"intent": ""})
+        finally:
+            planner_mod._identity = original
+
+        assert result.get("is_error") is True
+        assert "intent is required" in result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_no_active_workspace_returns_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import planner as planner_mod
+
+        # _identity returns (None, None) when called outside an SSE stream.
+        original = planner_mod._identity
+        planner_mod._identity = lambda: (None, None)
+        try:
+            result = await planner_mod._plan_pocket_handler({"intent": "Build a CRM"})
+        finally:
+            planner_mod._identity = original
+
+        assert result.get("is_error") is True
+        assert "no active workspace" in result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_prior_plan_must_be_dict(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import planner as planner_mod
+
+        original = planner_mod._identity
+        planner_mod._identity = lambda: ("ws_1", "user_1")
+        try:
+            result = await planner_mod._plan_pocket_handler(
+                {"intent": "Build a CRM", "prior_plan": "not a dict"}
+            )
+        finally:
+            planner_mod._identity = original
+
+        assert result.get("is_error") is True
+        assert "prior_plan must be a dict" in result["content"][0]["text"]
+
+
+class TestPlanPocketToolSurface:
+    """Pin the public surface of the planner MCP module — the IDs and
+    the tuple that drives the allowlist."""
+
+    def test_plan_pocket_tool_id_constant(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.planner import (
+            PLAN_POCKET_TOOL_ID,
+            PLANNER_TOOL_IDS,
+            SERVER_NAME,
+        )
+
+        assert PLAN_POCKET_TOOL_ID == f"mcp__{SERVER_NAME}__plan_pocket"
+        assert PLAN_POCKET_TOOL_ID in PLANNER_TOOL_IDS
+
+    def test_plan_project_still_in_tool_ids(self) -> None:
+        """Adding plan_pocket must not drop plan_project."""
+        from pocketpaw_ee.agent.mcp_servers.planner import (
+            PLAN_POCKET_TOOL_ID,
+            PLAN_PROJECT_TOOL_ID,
+            PLANNER_TOOL_IDS,
+        )
+
+        assert PLAN_PROJECT_TOOL_ID in PLANNER_TOOL_IDS
+        assert PLAN_POCKET_TOOL_ID in PLANNER_TOOL_IDS
+        assert len(PLANNER_TOOL_IDS) == 2

--- a/tests/cloud/test_plan_pocket_brief.py
+++ b/tests/cloud/test_plan_pocket_brief.py
@@ -125,6 +125,44 @@ This should not land in STATE.
         sections = _parse_pocket_prd_sections("")
         assert all(v == "" for v in sections.values())
 
+    def test_prd_parser_tolerates_heading_drift(self) -> None:
+        """Heading-level / case / trailing-punctuation / bold-wrapper
+        drift must not silently drop a section.
+
+        The PRD prompt asks for ``## NARRATIVE``, ``## WIDGETS`` etc.
+        but LLMs produce variants the brain accepts:
+          * ``### Widgets`` — one extra hash level
+          * ``**Narrative**`` — bold wrapper, no hash heading at all
+          * ``## Sources:`` — trailing colon
+          * ``## actions`` — lowercase
+        Each variant has been observed in real model output. The
+        parser tolerates all four; otherwise the brief silently loses
+        the section and the chat agent renders an empty list.
+        """
+        prd = """\
+## Narrative
+Drift case: lowercase + h2.
+
+### Widgets
+- stat: a metric
+
+**State**
+- count: int — the tally
+
+## Sources:
+- crm: feeds count via GET /total
+
+## actions
+- click: set on count
+"""
+        sections = _parse_pocket_prd_sections(prd)
+        # All five sections must surface non-empty content.
+        assert "Drift case" in sections["NARRATIVE"]
+        assert "stat: a metric" in sections["WIDGETS"], "h3 heading must be accepted"
+        assert "count: int" in sections["STATE"], "bold-wrapper heading must be accepted"
+        assert "crm: feeds count" in sections["SOURCES"], "trailing colon must be stripped"
+        assert "click: set on count" in sections["ACTIONS"], "lowercase heading must match"
+
 
 class TestParseBulletPairs:
     """The ``- left: right`` bullet primitive used by every section parser."""
@@ -447,26 +485,150 @@ class TestPlanPocketHandlerArgs:
 
 class TestPlanPocketToolSurface:
     """Pin the public surface of the planner MCP module — the IDs and
-    the tuple that drives the allowlist."""
+    the per-server tuples that drive the allowlist.
+
+    PR #1223 R2 split the original single-server hosting both tools
+    into two servers. ``PLANNER_TOOL_IDS`` now belongs to the
+    opt-in ``pocketpaw_planner`` server and carries ``plan_project``
+    only; ``POCKET_PLANNER_TOOL_IDS`` belongs to the ambient
+    ``pocketpaw_pocket_planner`` server and carries ``plan_pocket``.
+    """
 
     def test_plan_pocket_tool_id_constant(self) -> None:
         from pocketpaw_ee.agent.mcp_servers.planner import (
             PLAN_POCKET_TOOL_ID,
+            POCKET_PLANNER_SERVER_NAME,
+            POCKET_PLANNER_TOOL_IDS,
+        )
+
+        assert PLAN_POCKET_TOOL_ID == f"mcp__{POCKET_PLANNER_SERVER_NAME}__plan_pocket"
+        assert PLAN_POCKET_TOOL_ID in POCKET_PLANNER_TOOL_IDS
+        assert len(POCKET_PLANNER_TOOL_IDS) == 1
+
+    def test_plan_project_tool_id_constant(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.planner import (
+            PLAN_PROJECT_TOOL_ID,
             PLANNER_TOOL_IDS,
             SERVER_NAME,
         )
 
-        assert PLAN_POCKET_TOOL_ID == f"mcp__{SERVER_NAME}__plan_pocket"
-        assert PLAN_POCKET_TOOL_ID in PLANNER_TOOL_IDS
+        assert PLAN_PROJECT_TOOL_ID == f"mcp__{SERVER_NAME}__plan_project"
+        assert PLAN_PROJECT_TOOL_ID in PLANNER_TOOL_IDS
+        assert len(PLANNER_TOOL_IDS) == 1
 
-    def test_plan_project_still_in_tool_ids(self) -> None:
-        """Adding plan_pocket must not drop plan_project."""
+    def test_tool_ids_live_on_separate_servers(self) -> None:
+        """The split is what restores the per-server OPT_IN gate. The
+        two tool IDs must NOT be hosted on the same server name."""
         from pocketpaw_ee.agent.mcp_servers.planner import (
             PLAN_POCKET_TOOL_ID,
             PLAN_PROJECT_TOOL_ID,
-            PLANNER_TOOL_IDS,
+            POCKET_PLANNER_SERVER_NAME,
+            SERVER_NAME,
         )
 
-        assert PLAN_PROJECT_TOOL_ID in PLANNER_TOOL_IDS
-        assert PLAN_POCKET_TOOL_ID in PLANNER_TOOL_IDS
-        assert len(PLANNER_TOOL_IDS) == 2
+        assert SERVER_NAME != POCKET_PLANNER_SERVER_NAME
+        # Tool IDs follow ``mcp__<server>__<tool>``.
+        assert f"__{SERVER_NAME}__" in PLAN_PROJECT_TOOL_ID
+        assert f"__{POCKET_PLANNER_SERVER_NAME}__" in PLAN_POCKET_TOOL_ID
+
+
+class TestTaskBreakdownParserDrift:
+    """The task-breakdown step is JSON output. LLM drift produces
+    patterns the original strict regex parser silently dropped — see
+    PR #1223 R2 high-priority #2. The lenient parser must extract a
+    balanced array from those shapes; ``_lenient_parse_taskspecs``
+    wraps it for the pipeline.
+    """
+
+    def test_task_breakdown_parser_handles_drift(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.planner import _parse_lenient_json_list
+
+        # Case 1: trailing prose after the array.
+        case_trailing_prose = (
+            '[{"key": "t1", "title": "Seed state.cards"}]\n\n'
+            "-- and here's why I chose those tasks..."
+        )
+        data, err = _parse_lenient_json_list(case_trailing_prose)
+        assert err is None, f"trailing-prose case errored: {err}"
+        assert data == [{"key": "t1", "title": "Seed state.cards"}]
+
+        # Case 2: ``#`` comments inside the JSON.
+        case_comments = """\
+[
+  # the seed task — runs first
+  {"key": "t1", "title": "Seed state.cards"},
+  # the widget task
+  {"key": "t2", "title": "Add kanban"}
+]
+"""
+        data, err = _parse_lenient_json_list(case_comments)
+        assert err is None, f"comments case errored: {err}"
+        assert data == [
+            {"key": "t1", "title": "Seed state.cards"},
+            {"key": "t2", "title": "Add kanban"},
+        ]
+
+        # Case 3: trailing commas (JSON5-style).
+        case_trailing_commas = """\
+[
+  {"key": "t1", "title": "Seed state.cards",},
+  {"key": "t2", "title": "Add kanban",},
+]
+"""
+        data, err = _parse_lenient_json_list(case_trailing_commas)
+        assert err is None, f"trailing-comma case errored: {err}"
+        assert data == [
+            {"key": "t1", "title": "Seed state.cards"},
+            {"key": "t2", "title": "Add kanban"},
+        ]
+
+    def test_multiple_fenced_blocks_picks_first_array(self) -> None:
+        """Some models emit a fenced 'thinking' block, then the JSON in
+        a separate fence. The lenient parser walks the text and grabs
+        the first balanced ``[...]`` — which is the JSON, not the prose.
+        """
+        from pocketpaw_ee.agent.mcp_servers.planner import _parse_lenient_json_list
+
+        raw = """\
+Here is my thinking:
+
+```
+This pocket needs three tasks. The first seeds state...
+```
+
+And here is the JSON:
+
+```json
+[
+  {"key": "t1", "title": "Seed state.cards"}
+]
+```
+"""
+        data, err = _parse_lenient_json_list(raw)
+        assert err is None, f"multi-fence case errored: {err}"
+        assert data == [{"key": "t1", "title": "Seed state.cards"}]
+
+    def test_unparseable_output_surfaces_diagnostic(self) -> None:
+        """When the model emits nothing parseable, the parser returns
+        ``(None, err)`` with a short snippet so the captain can see
+        what was attempted. The handler propagates this into
+        ``warnings`` on the MCP response.
+        """
+        from pocketpaw_ee.agent.mcp_servers.planner import _parse_lenient_json_list
+
+        raw = "Sorry, I cannot help with that today."
+        data, err = _parse_lenient_json_list(raw)
+        assert data is None
+        assert err is not None
+        assert "no balanced JSON array" in err
+
+    def test_strings_with_brackets_do_not_break_extractor(self) -> None:
+        """A ``[`` inside a string literal must not be counted as a
+        bracket — the balanced-bracket walker respects double-quoted
+        strings."""
+        from pocketpaw_ee.agent.mcp_servers.planner import _parse_lenient_json_list
+
+        raw = '[{"key": "t1", "title": "Render [Project] dashboard"}]'
+        data, err = _parse_lenient_json_list(raw)
+        assert err is None
+        assert data == [{"key": "t1", "title": "Render [Project] dashboard"}]

--- a/tests/ee/agent/test_pocket_specialist/test_plan_kit_adapter.py
+++ b/tests/ee/agent/test_pocket_specialist/test_plan_kit_adapter.py
@@ -95,7 +95,7 @@ class TestPlanKitGate:
         kit = result.draft_kit
         assert kit is not None
         assert kit["skill_name"] == "pocketpaw-pocket-planner"
-        assert kit["mcp_tool"] == "mcp__pocketpaw_planner__plan_pocket"
+        assert kit["mcp_tool"] == "mcp__pocketpaw_pocket_planner__plan_pocket"
         # Auth headers carry the tenant identity for loopback /spec/merge.
         assert kit["auth_headers"]["X-PocketPaw-Workspace-Id"] == "ws_1"
         assert kit["auth_headers"]["X-PocketPaw-User-Id"] == "user_1"

--- a/tests/ee/agent/test_pocket_specialist/test_plan_kit_adapter.py
+++ b/tests/ee/agent/test_pocket_specialist/test_plan_kit_adapter.py
@@ -1,0 +1,205 @@
+# Created: 2026-05-25 (feat/pocket-planner-skill) — tests for the
+#   plan-pointer kit path on the create adapter. When
+#   POCKETPAW_POCKET_SPECIALIST_USE_SKILL is on and the brief did not
+#   match a template, the adapter must return a plan_kit response
+#   pointing at the pocketpaw-pocket-planner skill + plan_pocket MCP
+#   tool instead of the one-shot draft kit.
+#
+#   These tests sit alongside the existing draft-kit tests in
+#   test_adapters.py — kept separate so the plan-kit MVP's wiring can
+#   evolve without touching the green draft-kit test set.
+"""Tests for AgentModeAdapter.create's plan-pointer kit branch."""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.agent.pocket_specialist.adapters import AgentModeAdapter
+from pocketpaw_ee.agent.pocket_specialist.runtime import (
+    PocketSpecialistCreateInput,
+    PocketSpecialistHints,
+)
+
+from pocketpaw.config import Settings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Strip every env var that might smuggle a real operator override
+    into these tests. Mirrors test_adapters.py's fixture."""
+    for key in (
+        "POCKETPAW_POCKET_SPECIALIST_BACKEND",
+        "POCKETPAW_POCKET_SPECIALIST_MODEL",
+        "POCKETPAW_POCKET_SPECIALIST_MAX_VALIDATION_RETRIES",
+        "POCKETPAW_POCKET_SPECIALIST_MODE",
+        "POCKETPAW_POCKET_SPECIALIST_USE_SKILL",
+        "POCKETPAW_DEEP_AGENTS_MODEL",
+        "POCKETPAW_CLAUDE_SDK_MODEL",
+        "POCKETPAW_LANGCHAIN_REACT_MODEL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def agent_settings() -> Settings:
+    return Settings(_env_file=None, pocket_specialist_mode="agent")
+
+
+class TestPlanKitGate:
+    """USE_SKILL + no template + no spec → plan_kit. All other shapes
+    take the prior path."""
+
+    @pytest.mark.asyncio
+    async def test_use_skill_off_returns_draft_kit(
+        self, agent_settings: Settings, monkeypatch
+    ) -> None:
+        """Without USE_SKILL the adapter must keep the original
+        draft-kit behaviour — the plan-pointer kit is opt-in."""
+        monkeypatch.delenv("POCKETPAW_POCKET_SPECIALIST_USE_SKILL", raising=False)
+
+        adapter = AgentModeAdapter()
+        result = await adapter.create(
+            PocketSpecialistCreateInput(brief="Build me a custom multi-widget app for X."),
+            workspace_id="ws_1",
+            user_id="user_1",
+            settings=agent_settings,
+        )
+
+        assert result.action == "draft_kit"
+        # The draft_kit body for one-shot drafting carries the starter
+        # widget kinds, not the planner pointer.
+        assert "starter_widget_kinds" in result.draft_kit
+        assert "skill_name" not in result.draft_kit
+
+    @pytest.mark.asyncio
+    async def test_use_skill_on_returns_plan_kit(
+        self, agent_settings: Settings, monkeypatch
+    ) -> None:
+        """USE_SKILL toggles the plan-pointer kit path."""
+        monkeypatch.setenv("POCKETPAW_POCKET_SPECIALIST_USE_SKILL", "true")
+
+        adapter = AgentModeAdapter()
+        result = await adapter.create(
+            PocketSpecialistCreateInput(
+                brief="Build me a sales CRM with leads, pipeline, activity, forecast.",
+            ),
+            workspace_id="ws_1",
+            user_id="user_1",
+            settings=agent_settings,
+        )
+
+        assert result.action == "plan_kit"
+        assert result.ok is False  # plan_kit is a handoff, not a success
+        assert result.pocket is None
+        assert result.backend_used == "agent_mode_skill"
+
+        kit = result.draft_kit
+        assert kit is not None
+        assert kit["skill_name"] == "pocketpaw-pocket-planner"
+        assert kit["mcp_tool"] == "mcp__pocketpaw_planner__plan_pocket"
+        # Auth headers carry the tenant identity for loopback /spec/merge.
+        assert kit["auth_headers"]["X-PocketPaw-Workspace-Id"] == "ws_1"
+        assert kit["auth_headers"]["X-PocketPaw-User-Id"] == "user_1"
+        assert kit["auth_headers"]["X-PocketPaw-Internal"] == "true"
+        # The brief is carried over so the chat agent can pass it to
+        # plan_pocket without re-deriving from chat history.
+        assert "sales CRM" in kit["brief"]
+        # next_step must teach the four-phase flow.
+        assert "plan_pocket" in kit["next_step"]
+        assert "/spec/merge" in kit["next_step"]
+
+    @pytest.mark.asyncio
+    async def test_spec_supplied_skips_plan_kit(
+        self, agent_settings: Settings, monkeypatch
+    ) -> None:
+        """When the chat agent walked the todos and is calling back with
+        a built spec (the legacy create flow's second call), the
+        adapter must NOT bounce them into the planner. ``input.spec``
+        is the second-call shape — the plan_kit gate only fires on the
+        first call."""
+        monkeypatch.setenv("POCKETPAW_POCKET_SPECIALIST_USE_SKILL", "true")
+
+        adapter = AgentModeAdapter()
+        # An input with spec set goes straight to _validate_and_persist.
+        # We don't actually want to run that path here — we just verify
+        # the adapter does NOT return plan_kit when spec is non-None.
+        # The persist call will error out because we don't have a mongo,
+        # but that's the point: the test passes if action is not
+        # "plan_kit". An exception is fine — pytest just shouldn't see a
+        # "plan_kit" action.
+        from unittest.mock import patch
+
+        with patch(
+            "pocketpaw_ee.agent.pocket_specialist.adapters._validate_and_persist"
+        ) as mock_validate:
+            mock_validate.return_value = type(
+                "FakeOutput",
+                (),
+                {
+                    "action": "created",
+                    "ok": True,
+                    "draft_kit": None,
+                },
+            )()
+            result = await adapter.create(
+                PocketSpecialistCreateInput(
+                    brief="Build me something custom.",
+                    spec={"version": "1.0", "state": {}, "ui": {"id": "n_a", "type": "flex"}},
+                ),
+                workspace_id="ws_1",
+                user_id="user_1",
+                settings=agent_settings,
+            )
+
+        # validate_and_persist was called; plan_kit was NOT returned.
+        mock_validate.assert_called_once()
+        assert result.action != "plan_kit"
+
+    @pytest.mark.asyncio
+    async def test_template_id_short_circuit_skips_plan_kit(
+        self, agent_settings: Settings, monkeypatch
+    ) -> None:
+        """A template-match short-circuit must beat the plan_kit gate.
+
+        Built-in templates are the FAST path — even with USE_SKILL on,
+        if the chat agent already matched a template we should not
+        bounce the user through the planner."""
+        monkeypatch.setenv("POCKETPAW_POCKET_SPECIALIST_USE_SKILL", "true")
+
+        # Patch _input_with_template_spec to behave as though the
+        # template loaded — returns an input clone with spec populated.
+        from unittest.mock import patch
+
+        original_input = PocketSpecialistCreateInput(
+            brief="Build me a kanban for tasks.",
+            hints=PocketSpecialistHints(template_id="kanban-board"),
+        )
+        templated_input = original_input.model_copy(
+            update={"spec": {"version": "1.0", "state": {}, "ui": {"id": "n_a", "type": "flex"}}}
+        )
+
+        with patch(
+            "pocketpaw_ee.agent.pocket_specialist.adapters._input_with_template_spec",
+            return_value=templated_input,
+        ), patch(
+            "pocketpaw_ee.agent.pocket_specialist.adapters._validate_and_persist"
+        ) as mock_validate:
+            mock_validate.return_value = type(
+                "FakeOutput",
+                (),
+                {
+                    "action": "created",
+                    "ok": True,
+                    "draft_kit": None,
+                },
+            )()
+            adapter = AgentModeAdapter()
+            result = await adapter.create(
+                original_input,
+                workspace_id="ws_1",
+                user_id="user_1",
+                settings=agent_settings,
+            )
+
+        mock_validate.assert_called_once()
+        # Template path won — no plan_kit handoff.
+        assert result.action != "plan_kit"

--- a/tests/ee/test_mcp_claude_sdk.py
+++ b/tests/ee/test_mcp_claude_sdk.py
@@ -15,6 +15,9 @@ All SDK imports are mocked.
 
 from unittest.mock import patch
 
+from pocketpaw_ee.agent.mcp_servers.planner import (
+    POCKET_PLANNER_SERVER_NAME as _POCKET_PLANNER_MCP_SERVER_NAME,
+)
 from pocketpaw_ee.agent.mcp_servers.planner import SERVER_NAME as _PLANNER_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.pockets import SERVER_NAME as _POCKET_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.tasks import SERVER_NAME as _TASKS_MCP_SERVER_NAME
@@ -35,7 +38,9 @@ def _strip_builtin_servers(result: dict) -> dict:
     Note: ``pocketpaw_planner`` is a built-in but is *not* always-on — it is
     gated behind an explicit policy opt-in. It is stripped here so the
     external-config assertions remain correct regardless of whether a given
-    test happens to opt the planner in.
+    test happens to opt the planner in. ``pocketpaw_pocket_planner`` IS
+    always-on (the bundled pocket-create skill calls it without opt-in)
+    so it is stripped unconditionally.
     """
     out = dict(result)
     out.pop(_WIDGETS_MCP_SERVER_NAME, None)
@@ -43,6 +48,7 @@ def _strip_builtin_servers(result: dict) -> dict:
     out.pop(_POCKET_SPECIALIST_MCP_SERVER_NAME, None)
     out.pop(_TASKS_MCP_SERVER_NAME, None)
     out.pop(_PLANNER_MCP_SERVER_NAME, None)
+    out.pop(_POCKET_PLANNER_MCP_SERVER_NAME, None)
     return out
 
 
@@ -301,3 +307,73 @@ class TestMcpToolAllowlist:
         sdk = self._make_sdk()
         ids = sdk._collect_mcp_tool_ids()
         assert not any(f"__{_PLANNER_MCP_SERVER_NAME}__" in t for t in ids)
+
+
+class TestPocketPlannerMcpAmbient:
+    """The sibling ``pocketpaw_pocket_planner`` server (hosting
+    ``plan_pocket``) must be **ambient** — reachable to any agent
+    without explicit opt-in.
+
+    The pocket-create flow's plan-pointer kit directs the chat agent
+    to call ``plan_pocket`` straight away; if that server were opt-in
+    the kit's first call would 404 and the pocket-create UX would
+    break. The split from ``pocketpaw_planner`` (which IS opt-in) is
+    what restores both policy regimes — see PR #1223 R2.
+    """
+
+    def _make_sdk(self, policy: ToolPolicy | None = None, **overrides) -> ClaudeAgentSDK:
+        settings = Settings(
+            anthropic_api_key="test-key",
+            tool_profile="full",
+            **overrides,
+        )
+        with patch.object(ClaudeAgentSDK, "_initialize"):
+            sdk = ClaudeAgentSDK(settings, policy=policy)
+            sdk._sdk_available = False
+        return sdk
+
+    def test_pocket_planner_ambient(self):
+        """No injected policy → the pocket planner still loads.
+
+        This is the mirror image of ``test_planner_absent_by_default``
+        — that one pins the opt-in gate on ``pocketpaw_planner``;
+        this one pins the ambient default on
+        ``pocketpaw_pocket_planner``.
+        """
+        sdk = self._make_sdk()
+        with patch("pocketpaw.mcp.config.load_mcp_config", return_value=[]):
+            result = sdk._get_mcp_servers()
+        assert _POCKET_PLANNER_MCP_SERVER_NAME in result
+        assert result[_POCKET_PLANNER_MCP_SERVER_NAME]["type"] == "sdk"
+
+    def test_pocket_planner_still_loads_when_planner_not_opted_in(self):
+        """The ambient pocket planner does not depend on the opt-in
+        project planner being on. Opting one out must not leak into
+        the other."""
+        sdk = self._make_sdk(policy=ToolPolicy())  # explicit, no opt-ins
+        with patch("pocketpaw.mcp.config.load_mcp_config", return_value=[]):
+            result = sdk._get_mcp_servers()
+        assert _POCKET_PLANNER_MCP_SERVER_NAME in result
+        assert _PLANNER_MCP_SERVER_NAME not in result
+
+    def test_pocket_planner_absent_when_denied(self):
+        """Even an ambient server must respect a deny entry — defense
+        in depth for the rare deployment that wants to block the
+        planner entirely."""
+        sdk = self._make_sdk(
+            policy=ToolPolicy(deny=[f"mcp:{_POCKET_PLANNER_MCP_SERVER_NAME}:*"])
+        )
+        with patch("pocketpaw.mcp.config.load_mcp_config", return_value=[]):
+            result = sdk._get_mcp_servers()
+        assert _POCKET_PLANNER_MCP_SERVER_NAME not in result
+
+    def test_pocket_planner_tool_on_allowlist_by_default(self):
+        """The ambient pocket-planner tool id must appear on the
+        in-process allowlist with no policy opt-in — the chat agent
+        calls it via ``mcp__pocketpaw_pocket_planner__plan_pocket``
+        and that id has to be reachable."""
+        from pocketpaw_ee.agent.mcp_servers.planner import PLAN_POCKET_TOOL_ID
+
+        sdk = self._make_sdk()
+        ids = sdk._collect_mcp_tool_ids()
+        assert PLAN_POCKET_TOOL_ID in ids


### PR DESCRIPTION
## Summary
- New `plan_pocket` MCP tool wraps `PlannerAgent.plan()` with three new `POCKET_*` prompts (`POCKET_RESEARCH_PROMPT`, `POCKET_PRD_PROMPT`, `POCKET_TASK_BREAKDOWN_PROMPT`) in `src/pocketpaw/deep_work/prompts.py`. Skips the team-assembly phase. Returns a structured brief (narrative, widgets, state, sources, actions, todos) for markdown rendering in the chat panel.
- `_plan_kit_response` branch in `AgentModeAdapter.create` returns a plan-pointer kit when (a) `USE_SKILL` is on, (b) no template/recipe match, (c) `input.spec is None`. The kit names the new `pocketpaw-pocket-planner` skill, the MCP tool, and the loopback-internal auth headers.
- `pocketpaw-pocket-planner` bundled skill (~80 lines) teaches the chat agent the research, draft, iterate, build flow.
- `pocketpaw-create-pocket` routing skill patched so the chat agent calls `pocket_specialist__create` WITHOUT `spec` on no-template-no-recipe-match, triggering the plan-pointer kit instead of drafting inline.
- `OPT_IN_MCP_SERVERS` no longer includes `pocketpaw_planner` so the MCP server is ambient (its tools are inert until called).

## Deep_work reuse, the architectural call
This PR reuses pocketpaw's existing `deep_work` planner module rather than building a parallel scaffolding. Concrete reuse:
- `pocketpaw.deep_work.planner.PlannerAgent`, the 4-phase pipeline engine (skip team-assembly)
- `pocketpaw.deep_work.prompts.POCKET_*`, three new prompt strings in the same file as the existing `RESEARCH_PROMPT` / `PRD_PROMPT` / `TASK_BREAKDOWN_PROMPT`
- `PlannerAgent._run_prompt` and `PlannerAgent._parse_tasks`, reused for the LLM phases
- `TaskSpec` with `success_criteria` / `depends_on`, each TaskSpec becomes one todo

Skipped deliberately:
- `DeepWorkSession` state machine. Chat session owns the state, not the MC Project lifecycle.
- `PlanSession` Beanie doc. Plan is ephemeral; chat history is enough.
- Team assembly. Pockets don't need a multi-agent team.

## Live evidence
Drove the brewing-log scenario (`"Build me a home brewing log: fermentation timer, gravity readings table, hop-bill calculator, tasting-notes journal, batch summary card..."`) end-to-end through the paw-enterprise UI. Server log timeline:
- `[08:28:25] agent-mode plan-pointer kit returned (USE_SKILL=true) brief_len=3302`
- `mcp__pocketpaw_planner__plan_pocket` invoked
- `PlannerAgent.plan()` ran research, PRD, and task-breakdown with the POCKET_* prompts
- Full 5-section brief rendered in the chat panel as markdown (narrative, 8 widgets, 9 state keys, sources, 6 actions, 7 ordered todos with depends-on and done-when)
- Agent prompted: "Look right? Say 'build it' to ship, or tell me what to change."

Zero `kind_for_op` errors. Zero per-op pydantic mismatches. Zero subagent backend spawn (no API key needed). The chat agent used Claude Code's native Bash + Skill + the planner MCP, which is the captain pattern.

## Tests
- 23 new unit tests on the brief parser and plan-kit adapter (`tests/cloud/test_plan_pocket_brief.py`, `tests/ee/agent/test_pocket_specialist/test_plan_kit_adapter.py`), all green.
- 246 existing tests pass (pocket-specialist + planner regression).
- Smoke boot: `bundled_skills.installer: pocketpaw-pocket-planner -> installed` confirmed on every restart.

## Coexists with the existing path
- Gated behind `POCKETPAW_POCKET_SPECIALIST_USE_SKILL=true` (same env var as the edit MVP from #1222). Default off, so no behaviour change when the flag is unset.
- Template-match short-circuit still runs FIRST. Templates and recipes keep their fast path; the planner only fires on custom multi-widget briefs.

## Known follow-ups (NOT in this PR)
1. **Build-it trigger live test.** The build phase reuses the `/spec/merge` endpoint shipped in #1222. That endpoint was verified end-to-end on edit traffic in P6 (5 scenarios across all 17-tool layers). On create-via-planner the brief includes 7 ordered todos; the per-todo `/spec/merge` walk is straightforward but hasn't been exercised live yet. Captain can drive it after the PR lands, or it can be queued as PR-3.
2. **Auth bypass tightening.** Still loopback-internal `X-PocketPaw-Internal: true` header (inherited from #1222). Short-lived JWT comes in a future PR.
3. **pocket_router Tier 0/1 short-circuit.** Same coexistence note as #1222, set `POCKETPAW_POCKET_ROUTER_ENABLED=false` to exercise the new path. PR-2 fixes the router properly.
4. **Iteration UI.** Today the chat agent re-invokes `plan_pocket` with `prior_plan` + `iteration_delta` text. A click-on-todo-to-edit UI in the chat panel is a paw-enterprise follow-up.
5. **Selective MCP gating.** Removing `pocketpaw_planner` from `OPT_IN_MCP_SERVERS` is the simpler MVP shape. Per-tool gating (exposing `plan_pocket` but keeping `plan_project` opt-in) is a future tuning step.

## Trying it locally
```bash
POCKETPAW_POCKET_SPECIALIST_USE_SKILL=true \
POCKETPAW_POCKET_ROUTER_ENABLED=false \
uv run pocketpaw serve --port 8888
```
Then in paw-enterprise: type a complex custom-domain pocket request (something the bundled templates and recipes don't cover, e.g. home brewing log, podcast publisher, school-bus router). Watch the chat panel for the 5-section markdown brief and the build-trigger prompt.
