### PR TITLE
feat(schema): RFC 03 v2 Pocket Template Schema chokepoint + bundled migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "soul-protocol[engine]>=0.3.1",
     # NOTE: livekit-agents / livekit-plugins-deepgram moved to ee/pyproject.toml
     # in the OSS-EE split (Phase 4) — only ee/pocketpaw_ee/cloud/livekit imports them.
+    "cel-python>=0.5.0",
 ]
 
 [project.optional-dependencies]

--- a/src/pocketpaw/bundled_templates/__init__.py
+++ b/src/pocketpaw/bundled_templates/__init__.py
@@ -2,13 +2,17 @@
 # Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — package
 # for the curated set of built-in pocket templates the create
 # specialist instantiates instead of generating a pocket from scratch.
+# Modified 2026-05-25 (feat/rfc-03-v2-schema-chokepoint): re-exports
+# ``PocketTemplate``, ``TemplateValidationError``, and the sub-models
+# so callers (CLI, tests, future runtime) can import them at the
+# package root without reaching into ``schema`` / ``errors`` submodules.
 """Built-in pocket templates bundled and auto-installed by PocketPaw.
 
 Third sibling to ``pocketpaw.bundled_skills`` and ``pocketpaw.bundled_kb``.
 Where ``bundled_skills`` ships on-demand workflow markdown and ``bundled_kb``
 ships pre-compiled kb-go retrieval scopes, ``bundled_templates`` ships
 **ready-to-instantiate pocket templates** — hand-authored, production-quality
-rippleSpec skeletons paired with RFC 03 schema metadata.
+rippleSpec skeletons paired with RFC 03 v2 schema metadata.
 
 Why this exists
 ---------------
@@ -20,10 +24,12 @@ customizes* a matching built-in template instead of generating one cold.
 
 Each template is a directory under ``_bundled/<slug>/`` carrying two files:
 
-- ``template.pocket.yaml`` — RFC 03 Pocket Template Schema metadata
-  (``name, version, vertical, shape, state, actions, connectors, skills,
-  description``). Seed templates ship ``actions: []`` — Instinct / Outcomes
-  are not wired yet and dead action declarations are worse than none.
+- ``template.pocket.yaml`` — RFC 03 v2 Pocket Template Schema metadata
+  (``schema_version, name, version, vertical, pattern, display_name,
+  shape, state, ...``). Seed templates ship ``actions: []`` — Instinct /
+  Outcomes are not wired yet and dead action declarations are worse than
+  none. The seed bundled templates were migrated v1 -> v2 in the same PR
+  that introduced the Pydantic chokepoint.
 - ``ripple_spec.json`` — a full, hand-authored rippleSpec skeleton: the
   quality lever. The specialist starts from a correct skeleton, not a
   pressured cold generation.
@@ -31,21 +37,54 @@ Each template is a directory under ``_bundled/<slug>/`` carrying two files:
 On dashboard boot the installer mirrors ``_bundled/`` into
 ``~/.pocketpaw/templates/`` (SHA-256 idempotent, same pattern as the two
 sibling installers). The loader reads a single template back at
-pocket-creation time.
+pocket-creation time, validating it against the ``PocketTemplate``
+Pydantic v2 model. Validation failure returns ``None`` in the default
+loader path (back-compat) or raises ``TemplateValidationError`` under
+``strict=True`` (CLI ``template lint``, tests).
 
 Adding a template: drop a new ``_bundled/<slug>/`` directory with the two
 files and register it in ``_bundled/index.json``. The installer discovers
 directories via iteration — no installer code changes needed.
 """
 
+from pocketpaw.bundled_templates.errors import TemplateValidationError
 from pocketpaw.bundled_templates.installer import (
     TemplateInstallResult,
     install_bundled_templates,
 )
 from pocketpaw.bundled_templates.loader import load_template
+from pocketpaw.bundled_templates.schema import (
+    ActionDef,
+    AgentDef,
+    ColumnDef,
+    ConfirmDef,
+    DataSourceDef,
+    InstinctRule,
+    InstinctRulesDef,
+    JoinedEntity,
+    PermissionsDef,
+    PocketTemplate,
+    SavedView,
+    StateBinding,
+    TriggerDef,
+)
 
 __all__ = [
+    "ActionDef",
+    "AgentDef",
+    "ColumnDef",
+    "ConfirmDef",
+    "DataSourceDef",
+    "InstinctRule",
+    "InstinctRulesDef",
+    "JoinedEntity",
+    "PermissionsDef",
+    "PocketTemplate",
+    "SavedView",
+    "StateBinding",
     "TemplateInstallResult",
+    "TemplateValidationError",
+    "TriggerDef",
     "install_bundled_templates",
     "load_template",
 ]

--- a/src/pocketpaw/bundled_templates/_bundled/activity-feed/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/activity-feed/template.pocket.yaml
@@ -1,9 +1,15 @@
 # src/pocketpaw/bundled_templates/_bundled/activity-feed/template.pocket.yaml
 # Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — RFC 03
 # Pocket Template Schema metadata for the built-in activity feed.
+# Modified 2026-05-25 (feat/rfc-03-v2-schema-chokepoint): migrated v1 ->
+# v2. Added schema_version, display_name, pattern. Renamed skills ->
+# skill_refs. ``pattern: feed`` per the sibling index.json row.
+schema_version: "2"
 name: activity-feed
 version: 1.0.0
 vertical: productivity
+pattern: feed
+display_name: Activity Feed
 shape: timeline
 description: |
   A reverse-chronological activity feed. Each entry is a dated event
@@ -20,4 +26,4 @@ state:
     - { field: type, widget: badge }
 actions: []
 connectors: []
-skills: []
+skill_refs: []

--- a/src/pocketpaw/bundled_templates/_bundled/calendar-planner/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/calendar-planner/template.pocket.yaml
@@ -1,9 +1,15 @@
 # src/pocketpaw/bundled_templates/_bundled/calendar-planner/template.pocket.yaml
 # Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — RFC 03
 # Pocket Template Schema metadata for the built-in calendar planner.
+# Modified 2026-05-25 (feat/rfc-03-v2-schema-chokepoint): migrated v1 ->
+# v2. Added schema_version, display_name, pattern. Renamed skills ->
+# skill_refs. No behavioural change.
+schema_version: "2"
 name: calendar-planner
 version: 1.0.0
 vertical: productivity
+pattern: app
+display_name: Calendar Planner
 shape: calendar
 description: |
   A month-view calendar planner. Each entry is a dated event with a
@@ -18,4 +24,4 @@ state:
     - { field: category, widget: badge }
 actions: []
 connectors: []
-skills: []
+skill_refs: []

--- a/src/pocketpaw/bundled_templates/_bundled/crm-record-list/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/crm-record-list/template.pocket.yaml
@@ -3,9 +3,15 @@
 # Pocket Template Schema metadata for the built-in CRM record list.
 # ``shape`` is ``custom`` because RFC 03's shape enum does not carry a
 # ``master-detail`` value; the master-detail *pattern* is in index.json.
+# Modified 2026-05-25 (feat/rfc-03-v2-schema-chokepoint): migrated v1 ->
+# v2. Added schema_version, display_name, pattern. Renamed skills ->
+# skill_refs. ``pattern: browser`` per the sibling index.json row.
+schema_version: "2"
 name: crm-record-list
 version: 1.0.0
 vertical: sales
+pattern: browser
+display_name: Crm Record List
 shape: custom
 description: |
   A CRM record browser. A searchable list of contacts on the left, the
@@ -22,4 +28,4 @@ state:
     - { field: email, widget: text }
 actions: []
 connectors: []
-skills: []
+skill_refs: []

--- a/src/pocketpaw/bundled_templates/_bundled/crm-record-list/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/crm-record-list/template.pocket.yaml
@@ -6,12 +6,15 @@
 # Modified 2026-05-25 (feat/rfc-03-v2-schema-chokepoint): migrated v1 ->
 # v2. Added schema_version, display_name, pattern. Renamed skills ->
 # skill_refs. ``pattern: browser`` per the sibling index.json row.
+# ``display_name`` matches the gallery title in index.json (preserves the
+# CRM acronym; the loader's title-case fallback only fires when
+# display_name is absent).
 schema_version: "2"
 name: crm-record-list
 version: 1.0.0
 vertical: sales
 pattern: browser
-display_name: Crm Record List
+display_name: CRM Record List
 shape: custom
 description: |
   A CRM record browser. A searchable list of contacts on the left, the

--- a/src/pocketpaw/bundled_templates/_bundled/kanban-board/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/kanban-board/template.pocket.yaml
@@ -1,9 +1,15 @@
 # src/pocketpaw/bundled_templates/_bundled/kanban-board/template.pocket.yaml
 # Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — RFC 03
 # Pocket Template Schema metadata for the built-in kanban board.
+# Modified 2026-05-25 (feat/rfc-03-v2-schema-chokepoint): migrated v1 ->
+# v2. Added schema_version, display_name, pattern. Renamed skills ->
+# skill_refs. No behavioural change.
+schema_version: "2"
 name: kanban-board
 version: 1.0.0
 vertical: productivity
+pattern: app
+display_name: Kanban Board
 shape: kanban
 description: |
   A drag-and-drop kanban board for work in flight. Cards move across
@@ -19,4 +25,4 @@ state:
     - { field: assignee, widget: text }
 actions: []
 connectors: []
-skills: []
+skill_refs: []

--- a/src/pocketpaw/bundled_templates/_bundled/metrics-dashboard/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/metrics-dashboard/template.pocket.yaml
@@ -3,9 +3,15 @@
 # Pocket Template Schema metadata for the built-in metrics dashboard.
 # ``shape`` is ``data-grid`` because RFC 03's shape enum does not carry a
 # ``dashboard`` value; the dashboard *pattern* is recorded in index.json.
+# Modified 2026-05-25 (feat/rfc-03-v2-schema-chokepoint): migrated v1 ->
+# v2. Added schema_version, display_name, pattern. Renamed skills ->
+# skill_refs. ``pattern: dashboard`` per the sibling index.json row.
+schema_version: "2"
 name: metrics-dashboard
 version: 1.0.0
 vertical: analytics
+pattern: dashboard
+display_name: Metrics Dashboard
 shape: data-grid
 description: |
   An at-a-glance metrics dashboard. A strip of headline KPI tiles over a
@@ -21,4 +27,4 @@ state:
     - { field: change_pct, widget: number }
 actions: []
 connectors: []
-skills: []
+skill_refs: []

--- a/src/pocketpaw/bundled_templates/_bundled/todo-task-tracker/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/todo-task-tracker/template.pocket.yaml
@@ -3,13 +3,15 @@
 # Pocket Template Schema metadata for the built-in todo / task tracker.
 # Modified 2026-05-25 (feat/rfc-03-v2-schema-chokepoint): migrated v1 ->
 # v2. Added schema_version, display_name, pattern. Renamed skills ->
-# skill_refs. No behavioural change.
+# skill_refs. ``display_name`` matches the gallery title in index.json
+# (avoids the redundant "Todo Task" that the slug's title-case fallback
+# would produce — index.json has shipped "Task Tracker" since launch).
 schema_version: "2"
 name: todo-task-tracker
 version: 1.0.0
 vertical: productivity
 pattern: app
-display_name: Todo Task Tracker
+display_name: Task Tracker
 shape: data-grid
 description: |
   A personal task tracker. A sortable, filterable list of tasks with a

--- a/src/pocketpaw/bundled_templates/_bundled/todo-task-tracker/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/todo-task-tracker/template.pocket.yaml
@@ -1,9 +1,15 @@
 # src/pocketpaw/bundled_templates/_bundled/todo-task-tracker/template.pocket.yaml
 # Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — RFC 03
 # Pocket Template Schema metadata for the built-in todo / task tracker.
+# Modified 2026-05-25 (feat/rfc-03-v2-schema-chokepoint): migrated v1 ->
+# v2. Added schema_version, display_name, pattern. Renamed skills ->
+# skill_refs. No behavioural change.
+schema_version: "2"
 name: todo-task-tracker
 version: 1.0.0
 vertical: productivity
+pattern: app
+display_name: Todo Task Tracker
 shape: data-grid
 description: |
   A personal task tracker. A sortable, filterable list of tasks with a
@@ -19,4 +25,4 @@ state:
     - { field: due_date, widget: date }
 actions: []
 connectors: []
-skills: []
+skill_refs: []

--- a/src/pocketpaw/bundled_templates/errors.py
+++ b/src/pocketpaw/bundled_templates/errors.py
@@ -1,0 +1,53 @@
+# src/pocketpaw/bundled_templates/errors.py
+# Created: 2026-05-25 (feat/rfc-03-v2-schema-chokepoint) — explicit
+# error type the loader raises in ``strict=True`` mode so the CLI, the
+# tests, and any future tooling can pattern-match on a typed exception
+# instead of an opaque Pydantic ValidationError.
+"""Typed error raised by the template loader's strict path.
+
+``TemplateValidationError`` subclasses ``ValueError`` so any caller that
+already handles ``ValueError`` (Pydantic's own base) keeps working. It
+carries the offending ``slug`` and the underlying
+``pydantic.ValidationError`` so a CLI ``template lint`` command can
+render slug + per-field issues without re-parsing.
+"""
+
+from __future__ import annotations
+
+from pydantic import ValidationError
+
+
+class TemplateValidationError(ValueError):
+    """Raised by :func:`pocketpaw.bundled_templates.loader.load_template`
+    in ``strict=True`` mode when a template fails Pydantic validation
+    against ``PocketTemplate``.
+
+    Attributes:
+        slug: The template slug that failed to validate.
+        pydantic_error: The underlying ``pydantic.ValidationError``.
+    """
+
+    def __init__(self, slug: str, pydantic_error: ValidationError) -> None:
+        self.slug = slug
+        self.pydantic_error = pydantic_error
+        super().__init__(self._format_message(slug, pydantic_error))
+
+    @staticmethod
+    def _format_message(slug: str, err: ValidationError) -> str:
+        # Compose a human-readable, single-line summary that names the
+        # slug + the count of issues, followed by the first issue's
+        # field path + message. The full Pydantic dump is available via
+        # ``self.pydantic_error`` for richer CLI output.
+        errors = err.errors()
+        count = len(errors)
+        plural = "" if count == 1 else "s"
+        head = f"template {slug!r} failed validation ({count} issue{plural})"
+        if errors:
+            first = errors[0]
+            loc = ".".join(str(p) for p in first.get("loc", ()))
+            msg = first.get("msg", "")
+            return f"{head}: at {loc!r}: {msg}"
+        return head
+
+
+__all__ = ["TemplateValidationError"]

--- a/src/pocketpaw/bundled_templates/expressions.py
+++ b/src/pocketpaw/bundled_templates/expressions.py
@@ -1,0 +1,89 @@
+# src/pocketpaw/bundled_templates/expressions.py
+# Created: 2026-05-25 (feat/rfc-03-v2-schema-chokepoint) — Pydantic v2
+# field type for CEL expressions. Parses with ``celpy.CELParser`` at
+# validation time; never evaluates. A malformed expression raises a
+# ValueError which Pydantic wraps into ValidationError.
+"""CEL (Common Expression Language) typed field for Pydantic models.
+
+The RFC 03 v2 schema declares that ``saved_views[].filter``,
+``columns[].filter``, ``triggers[].filter`` / ``.when``, and
+``instinct_rules.rules[].when`` are CEL expressions. The chokepoint
+treats them as **parse-at-validation, no evaluation** — the schema
+loader confirms each expression is syntactically valid CEL but never
+runs it. Evaluation happens later, in the runtime, against the row /
+event context.
+
+Why no evaluation here:
+
+* The schema model has no row / workspace context to bind identifiers
+  to. Evaluation would force a fake context that drifts.
+* Parse-failure surfaces author errors at lint time (CLI ``template
+  lint`` -> RFC 03 v2 section "Style and tooling notes").
+* Custom functions (``within(field, duration)``) and runtime helpers
+  (``now()``) are not registered in this layer; CEL accepts unknown
+  identifiers as free variables at parse time, so the syntax check
+  still works.
+
+Usage from a Pydantic v2 model::
+
+    from typing import Annotated
+    from pocketpaw.bundled_templates.expressions import CelExpression
+
+    class SavedView(BaseModel):
+        filter: CelExpression  # parses on validation; raises ValueError
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from pydantic import BeforeValidator
+
+# Local lazy import so the module imports even if celpy is absent at
+# import time. The validator function imports celpy on first call. This
+# matches the loader.py pattern of keeping optional / heavy imports off
+# the hot module-load path.
+_PARSER = None
+
+
+def _get_parser() -> Any:
+    """Return a shared ``celpy.CELParser`` instance, importing celpy
+    lazily on first call."""
+    global _PARSER
+    if _PARSER is None:
+        import celpy  # noqa: PLC0415 — lazy import by design
+
+        _PARSER = celpy.CELParser()
+    return _PARSER
+
+
+def _validate_cel(value: Any) -> str:
+    """Pydantic BeforeValidator: ensure the value is a string and parses
+    as CEL. Returns the original string so the model carries the raw
+    expression text (the runtime evaluator parses it again with a real
+    context)."""
+    if not isinstance(value, str):
+        raise ValueError(f"CEL expression must be a string, got {type(value).__name__}")
+
+    # Reject the empty string explicitly — celpy parses "" as Tree([]),
+    # which would be a silent author mistake.
+    if not value.strip():
+        raise ValueError("CEL expression must not be empty")
+
+    parser = _get_parser()
+    try:
+        parser.parse(value)
+    except Exception as exc:  # noqa: BLE001 — celpy raises a wide error hierarchy
+        # Surface as ValueError so Pydantic wraps it into ValidationError.
+        raise ValueError(f"invalid CEL expression: {exc}") from exc
+    return value
+
+
+# Pydantic v2 typed alias. Annotated[str, BeforeValidator(...)] means
+# Pydantic runs the validator on the raw input before any type coercion
+# and the model stores the original string. Re-exportable as a Pydantic
+# field annotation.
+CelExpression = Annotated[str, BeforeValidator(_validate_cel)]
+
+
+__all__ = ["CelExpression"]

--- a/src/pocketpaw/bundled_templates/loader.py
+++ b/src/pocketpaw/bundled_templates/loader.py
@@ -3,6 +3,13 @@
 # single installed pocket template back from ``~/.pocketpaw/templates/``
 # so the create specialist can instantiate-and-customize it instead of
 # generating a pocket from scratch.
+# Modified 2026-05-25 (feat/rfc-03-v2-schema-chokepoint): added
+# ``_promote_v1_to_v2`` private translation function (4 RFC rewrite
+# rules), added optional ``strict`` kwarg on ``load_template`` that
+# routes through the new ``PocketTemplate`` Pydantic model and raises
+# ``TemplateValidationError`` on failure; ``strict=False`` (the default)
+# preserves the original log-warning + return-None behaviour for
+# back-compat with current EE consumers.
 """Load an installed pocket template from the user's PocketPaw dir.
 
 The installer (``bundled_templates.installer``) mirrors the bundled
@@ -12,14 +19,21 @@ the chat agent's STEP 0 keyword match set a ``template_id`` hint.
 
 A template directory holds exactly two files:
 
-- ``template.pocket.yaml`` — RFC 03 Pocket Template Schema metadata.
+- ``template.pocket.yaml`` — RFC 03 v2 Pocket Template Schema metadata.
+  v1 templates on disk are auto-promoted by ``_promote_v1_to_v2`` at
+  read time; the runtime always sees a v2-shaped dict.
 - ``ripple_spec.json``     — the hand-authored rippleSpec skeleton.
 
 ``load_template`` returns ``{"meta": <yaml dict>, "ripple_spec": <json
 dict>}`` or ``None`` on any failure (unknown slug, missing file, parse
-error, permission error). The caller treats ``None`` as "no template —
-fall back to cold generation"; a template-load failure must never block
-pocket creation.
+error, permission error, schema validation error in ``strict=True``
+mode). The caller treats ``None`` as "no template — fall back to cold
+generation"; a template-load failure must never block pocket creation
+in the default (non-strict) path.
+
+When ``strict=True`` (CLI ``template lint``, unit tests), a schema
+validation failure raises ``TemplateValidationError`` instead of
+returning ``None`` so the exact problem can be surfaced to the author.
 """
 
 from __future__ import annotations
@@ -29,6 +43,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from pocketpaw.bundled_templates.errors import TemplateValidationError
+
 logger = logging.getLogger(__name__)
 
 # Default install location — kept in sync with
@@ -36,24 +52,135 @@ logger = logging.getLogger(__name__)
 _DEFAULT_TEMPLATES_DIR = Path.home() / ".pocketpaw" / "templates"
 
 
-def load_template(slug: str, *, templates_dir: Path | None = None) -> dict[str, Any] | None:
+def _title_case_slug(slug: str) -> str:
+    """Synthesize a display_name from a kebab-case slug by title-casing
+    each hyphen-delimited word. ``"todo-task-tracker"`` -> ``"Todo Task
+    Tracker"``."""
+    return " ".join(word.capitalize() for word in slug.split("-"))
+
+
+def _lookup_pattern_in_index(name: str, templates_dir: Path | None) -> str | None:
+    """Look up ``pattern`` for a template by ``name`` in the sibling
+    ``index.json``. Returns ``None`` if the index is missing, unreadable,
+    malformed, or the row is absent."""
+    if templates_dir is None:
+        return None
+    index_path = templates_dir / "index.json"
+    if not index_path.is_file():
+        return None
+    try:
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 — best-effort lookup
+        logger.debug(
+            "bundled_templates.loader: could not read sibling index.json: %s", exc
+        )
+        return None
+    rows = index.get("templates", []) if isinstance(index, dict) else []
+    for row in rows:
+        if isinstance(row, dict) and row.get("slug") == name:
+            pat = row.get("pattern")
+            if isinstance(pat, str):
+                return pat
+    return None
+
+
+def _promote_v1_to_v2(
+    meta: dict[str, Any], *, templates_dir: Path | None = None
+) -> dict[str, Any]:
+    """Apply the four RFC 03 v1 -> v2 translation rules in-place on a
+    COPY of the input dict, returning the promoted dict.
+
+    The translation is **non-destructive**: callers pass a freshly
+    loaded dict; this function never writes back to disk.
+
+    Rules (per RFC 03 v2, "Schema version" -> "Translation: v1 -> v2"):
+
+    1. Absent ``schema_version`` -> ``"2"``.
+    2. Absent ``display_name`` -> title-case the ``name`` slug.
+    3. ``skills`` -> ``skill_refs`` (array contents identical; if both
+       are present, ``skill_refs`` wins and ``skills`` is dropped).
+    4. Absent ``pattern`` -> look up by ``name`` in the sibling
+       ``index.json``; fall back to ``"app"`` if missing.
+
+    The function is idempotent on v2-shaped input (each rule is a
+    "fill if absent" or "rename if present" — no field is overwritten
+    when already correctly populated).
+
+    Args:
+        meta: Parsed YAML dict from ``template.pocket.yaml``.
+        templates_dir: Optional path to the templates root; used only
+            for Rule 4's ``index.json`` lookup. Pass ``None`` to skip
+            the lookup (rule 4 then falls back to ``"app"`` directly).
+
+    Returns:
+        A new dict with the four translations applied. The input dict
+        is not mutated.
+    """
+    out = dict(meta)  # shallow copy — sub-dicts share references
+
+    # Rule 1: schema_version
+    if "schema_version" not in out:
+        out["schema_version"] = "2"
+
+    # Rule 3: skills -> skill_refs (run before rule 2 just for clarity;
+    # ordering does not matter since the rules are independent).
+    if "skills" in out:
+        if "skill_refs" not in out:
+            out["skill_refs"] = out["skills"]
+        del out["skills"]
+
+    # Rule 2: display_name
+    if "display_name" not in out:
+        slug = out.get("name")
+        if isinstance(slug, str) and slug:
+            out["display_name"] = _title_case_slug(slug)
+
+    # Rule 4: pattern
+    if "pattern" not in out:
+        name = out.get("name")
+        looked_up = (
+            _lookup_pattern_in_index(name, templates_dir)
+            if isinstance(name, str)
+            else None
+        )
+        out["pattern"] = looked_up if looked_up is not None else "app"
+
+    return out
+
+
+def load_template(
+    slug: str,
+    *,
+    templates_dir: Path | None = None,
+    strict: bool = False,
+) -> dict[str, Any] | None:
     """Read one installed template by slug.
 
     Args:
         slug: The template directory name (e.g. ``"todo-task-tracker"``).
         templates_dir: Override the templates root — useful for tests.
             Defaults to ``~/.pocketpaw/templates/``.
+        strict: When ``True``, the parsed (and v1->v2-promoted) meta
+            dict is validated through the ``PocketTemplate`` Pydantic
+            model. Validation failures raise
+            ``TemplateValidationError`` instead of returning ``None``.
+            Defaults to ``False`` for back-compat with existing EE
+            consumers that pattern-match on ``None``.
 
     Returns:
-        ``{"meta": <parsed template.pocket.yaml>, "ripple_spec":
-        <parsed ripple_spec.json>}`` on success, or ``None`` on ANY
-        failure — unknown slug, a missing sibling file, a YAML/JSON
-        parse error, or an I/O error. The caller falls back to cold
+        ``{"meta": <parsed + promoted template.pocket.yaml>,
+        "ripple_spec": <parsed ripple_spec.json>}`` on success, or
+        ``None`` on ANY failure when ``strict=False`` — unknown slug, a
+        missing sibling file, a YAML/JSON parse error, an I/O error, or
+        a Pydantic validation error. The caller falls back to cold
         generation when this returns ``None``.
 
-    Never raises. A template-load failure is logged at WARNING and
-    surfaced as ``None`` — pocket creation must not break because a
-    template file is missing or corrupt.
+    Raises:
+        TemplateValidationError: Only when ``strict=True`` AND the
+            template fails Pydantic validation. All other failure modes
+            still return ``None`` (the strict flag only escalates the
+            schema-validation failure mode — it does NOT promote I/O or
+            parse errors).
     """
 
     if templates_dir is None:
@@ -79,11 +206,11 @@ def load_template(slug: str, *, templates_dir: Path | None = None) -> dict[str, 
         return None
 
     try:
-        import yaml
+        import yaml  # noqa: PLC0415 — lazy import preserves OSS install path
 
         meta = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
         ripple_spec = json.loads(spec_path.read_text(encoding="utf-8"))
-    except Exception as exc:  # noqa: BLE001 — any parse / I/O error → None
+    except Exception as exc:  # noqa: BLE001 — any parse / I/O error -> None
         logger.warning(
             "bundled_templates.loader: failed to load template %r: %s",
             slug,
@@ -100,7 +227,46 @@ def load_template(slug: str, *, templates_dir: Path | None = None) -> dict[str, 
         )
         return None
 
-    return {"meta": meta, "ripple_spec": ripple_spec}
+    # v1 -> v2 promotion. Idempotent on v2 input.
+    merged_meta = _promote_v1_to_v2(meta, templates_dir=templates_dir)
+
+    # Pydantic validation gate. Lazy import keeps the optional code path
+    # off the hot loader-import boot path (matters: dashboard boot calls
+    # the installer / loader before pydantic is necessarily live).
+    try:
+        from pydantic import ValidationError  # noqa: PLC0415 — lazy
+
+        from pocketpaw.bundled_templates.schema import (  # noqa: PLC0415 — lazy
+            PocketTemplate,
+        )
+
+        PocketTemplate.model_validate(merged_meta)
+    except ValidationError as exc:
+        if strict:
+            raise TemplateValidationError(slug, exc) from exc
+        logger.warning(
+            "bundled_templates.loader: template %r failed schema validation: %s",
+            slug,
+            exc,
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001 — unexpected import-time failures
+        # An import failure of schema.py would be a bug; surface it
+        # under strict, swallow under non-strict for safety.
+        if strict:
+            raise
+        logger.warning(
+            "bundled_templates.loader: unexpected error validating template %r: %s",
+            slug,
+            exc,
+        )
+        return None
+
+    # Preserve the historical dict return contract — return the
+    # promoted meta dict, not the Pydantic instance. EE consumers
+    # pattern-match on ``meta["name"]``, ``meta["state"]["entity_type"]``
+    # etc.; never on a Pydantic model.
+    return {"meta": merged_meta, "ripple_spec": ripple_spec}
 
 
-__all__ = ["load_template"]
+__all__ = ["_promote_v1_to_v2", "load_template"]

--- a/src/pocketpaw/bundled_templates/loader.py
+++ b/src/pocketpaw/bundled_templates/loader.py
@@ -71,9 +71,7 @@ def _lookup_pattern_in_index(name: str, templates_dir: Path | None) -> str | Non
     try:
         index = json.loads(index_path.read_text(encoding="utf-8"))
     except Exception as exc:  # noqa: BLE001 — best-effort lookup
-        logger.debug(
-            "bundled_templates.loader: could not read sibling index.json: %s", exc
-        )
+        logger.debug("bundled_templates.loader: could not read sibling index.json: %s", exc)
         return None
     rows = index.get("templates", []) if isinstance(index, dict) else []
     for row in rows:
@@ -84,9 +82,7 @@ def _lookup_pattern_in_index(name: str, templates_dir: Path | None) -> str | Non
     return None
 
 
-def _promote_v1_to_v2(
-    meta: dict[str, Any], *, templates_dir: Path | None = None
-) -> dict[str, Any]:
+def _promote_v1_to_v2(meta: dict[str, Any], *, templates_dir: Path | None = None) -> dict[str, Any]:
     """Apply the four RFC 03 v1 -> v2 translation rules in-place on a
     COPY of the input dict, returning the promoted dict.
 
@@ -138,11 +134,7 @@ def _promote_v1_to_v2(
     # Rule 4: pattern
     if "pattern" not in out:
         name = out.get("name")
-        looked_up = (
-            _lookup_pattern_in_index(name, templates_dir)
-            if isinstance(name, str)
-            else None
-        )
+        looked_up = _lookup_pattern_in_index(name, templates_dir) if isinstance(name, str) else None
         out["pattern"] = looked_up if looked_up is not None else "app"
 
     return out

--- a/src/pocketpaw/bundled_templates/schema.py
+++ b/src/pocketpaw/bundled_templates/schema.py
@@ -283,9 +283,7 @@ class TriggerDef(BaseModel):
             raise ValueError("triggers[].schedule is required when type=cron")
         if self.type in ("webhook", "signal", "calendar", "source_change"):
             if not self.source:
-                raise ValueError(
-                    f"triggers[].source is required when type={self.type!r}"
-                )
+                raise ValueError(f"triggers[].source is required when type={self.type!r}")
         if self.type == "temporal" and not self.when:
             raise ValueError("triggers[].when is required when type=temporal")
         return self

--- a/src/pocketpaw/bundled_templates/schema.py
+++ b/src/pocketpaw/bundled_templates/schema.py
@@ -1,0 +1,464 @@
+# src/pocketpaw/bundled_templates/schema.py
+# Created: 2026-05-25 (feat/rfc-03-v2-schema-chokepoint) — Pydantic v2
+# model for the RFC 03 v2 Pocket Template Schema. Implements every
+# top-level field, every sub-schema, the shape x default_view
+# compatibility matrix, the outcomes_emitted subset rule, and the
+# state.id_field-resolves rule. CEL expressions parse via the
+# expressions.py validator. Fabric tier-registered + via_link registry
+# enforcement is intentionally out of scope for this PR.
+"""Pydantic v2 model for the RFC 03 v2 Pocket Template Schema.
+
+This module is the **schema chokepoint** — every bundled template, every
+installed template, and every CLI ``template lint`` call validates
+through ``PocketTemplate`` (or a sub-model). Backwards-compatible
+behaviour for v1 templates is preserved via the loader's
+``_promote_v1_to_v2`` translation pass, which mutates a v1-shaped dict
+into a v2-shaped dict BEFORE this model sees it.
+
+Scope of this module:
+
+* Pydantic v2 ``PocketTemplate`` + sub-models (``StateBinding``,
+  ``ColumnDef``, ``SavedView``, ``JoinedEntity``, ``ActionDef``,
+  ``AgentDef``, ``TriggerDef``, ``DataSourceDef``, ``PermissionsDef``,
+  ``InstinctRulesDef``, ``InstinctRule``).
+* Cross-field validators: shape x default_view, outcomes_emitted
+  subset, state.id_field resolves.
+* CEL expression parsing (via ``CelExpression`` from
+  :mod:`pocketpaw.bundled_templates.expressions`).
+
+Out of scope (separate PRs):
+
+* Fabric ``tier:registered`` / ``via_link`` registry enforcement.
+* Runtime composition (RFC 03 runtime concern, not the schema).
+* CLI ``template lint / migrate / publish``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
+
+from pocketpaw.bundled_templates.expressions import CelExpression
+
+# ---------------------------------------------------------------------------
+# Enumerations (kept as Literal aliases so Pydantic generates clean
+# error messages and they stay greppable across the codebase)
+# ---------------------------------------------------------------------------
+
+ShapeT = Literal[
+    "data-grid",
+    "kanban",
+    "calendar",
+    "map",
+    "timeline",
+    "gantt",
+    "treemap",
+    "network",
+    "tree",
+    "chart",
+    "custom",
+]
+
+PatternT = Literal[
+    "app",
+    "dashboard",
+    "browser",
+    "feed",
+    "composer",
+    "viewer",
+    "wizard",
+]
+
+DefaultViewT = Literal["list", "grid", "kanban", "calendar", "map"]
+
+ActionKindT = Literal["single-row", "bulk", "global"]
+
+InstinctPolicyT = Literal["auto", "require_approval", "notify_only"]
+
+InstinctRuleActionT = Literal["require_approval", "notify", "block"]
+
+TriggerTypeT = Literal[
+    "cron",
+    "webhook",
+    "signal",
+    "calendar",
+    "manual",
+    "source_change",
+    "temporal",
+]
+
+PermissionsScopeT = Literal["workspace", "org", "user"]
+
+KbScopeT = Literal["pocket", "workspace", "global"]
+
+DataSourceMethodT = Literal["GET"]
+
+AgentBackendT = Literal[
+    "claude_sdk",
+    "openai",
+    "codex",
+    "gemini",
+    "opencode",
+    "goose",
+    "deep_agents",
+    "auto",
+]
+
+# ---------------------------------------------------------------------------
+# shape x default_view compatibility matrix (RFC 03 v2, "Schema reference"
+# section, "shape x default_view compatibility matrix"). None means
+# the shape declares NO default_view at all.
+# ---------------------------------------------------------------------------
+
+_SHAPE_DEFAULT_VIEW_MATRIX: dict[str, set[str] | None] = {
+    "data-grid": {"list", "grid", "kanban"},
+    "kanban": {"kanban"},
+    "calendar": {"calendar", "list"},
+    "map": {"map", "list"},
+    "tree": {"list", "grid"},
+    "timeline": {"list"},
+    "chart": None,
+    "network": None,
+    "gantt": None,
+    "treemap": None,
+    "custom": "any",  # type: ignore[dict-item] — sentinel; custom accepts anything
+}
+
+
+# ---------------------------------------------------------------------------
+# Sub-schemas
+# ---------------------------------------------------------------------------
+
+
+class JoinedEntity(BaseModel):
+    """One secondary entity reachable from the primary via FabricLink."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(
+        ...,
+        description="Namespace used in column dot-paths (e.g. 'tenant').",
+    )
+    entity_type: str = Field(
+        ...,
+        description="Fabric ObjectType of the joined entity.",
+    )
+    via_link: str = Field(
+        ...,
+        description="Registered FabricLink name between primary and join.",
+    )
+
+
+class ColumnDef(BaseModel):
+    """One column declaration on a primary entity."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field: str = Field(..., description="Flat name or 'join.property' dot-path.")
+    label: str | None = None
+    widget: str = Field(..., description="Ripple Layer 1 display widget name.")
+    options: dict[str, Any] | None = None
+    sort: Literal["asc", "desc"] | None = None
+    filter: CelExpression | None = None
+
+
+class SavedView(BaseModel):
+    """A preset filter + grouping surfaced as a view chip."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    filter: CelExpression | None = None
+    group_by: str | None = None
+    sort: str | None = None
+    default: bool = False
+
+
+class StateBinding(BaseModel):
+    """Entity binding block — the primary entity + its columns + views."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    entity_type: str = Field(..., description="Primary Fabric ObjectType.")
+    id_field: str = Field(
+        default="id",
+        description="Row identifier column. Defaults to implicit 'id'.",
+    )
+    joined_entities: list[JoinedEntity] = Field(default_factory=list)
+    columns: list[ColumnDef] = Field(..., min_length=1)
+    default_view: DefaultViewT | None = None
+    saved_views: list[SavedView] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _id_field_resolves(self) -> StateBinding:
+        """``id_field`` must be 'id' (implicit) OR match a declared
+        column's ``field`` (flat name only; dot-paths are not row
+        identifiers)."""
+        if self.id_field == "id":
+            return self
+        flat_fields = {c.field for c in self.columns if "." not in c.field}
+        if self.id_field not in flat_fields:
+            raise ValueError(
+                f"state.id_field={self.id_field!r} does not resolve to a "
+                f"declared column field; declared flat fields: "
+                f"{sorted(flat_fields)}"
+            )
+        return self
+
+
+class ConfirmDef(BaseModel):
+    """Object form of an action's ``confirm`` gate."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    message: str | None = None
+    type_to_confirm: str | None = None
+    destructive: bool = False
+
+
+class ActionDef(BaseModel):
+    """One thing users or agents can DO from the pocket."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    label: str
+    kind: ActionKindT
+    instinct_policy: InstinctPolicyT
+    connectors_required: list[str] = Field(default_factory=list)
+    agent_required: str | None = None
+    outcomes_emitted: list[str] = Field(default_factory=list)
+    # confirm: True / False / object. The validator below normalises
+    # ``confirm: true`` into ``{destructive: True}`` per RFC v2.
+    confirm: bool | ConfirmDef | None = None
+    description: str | None = None
+
+    @field_validator("confirm", mode="before")
+    @classmethod
+    def _normalise_bool_confirm(cls, v: Any) -> Any:
+        # ``confirm: true`` -> ``{destructive: True}`` per v2 backward
+        # compat. ``confirm: false`` -> None (no gate).
+        if v is True:
+            return {"destructive": True}
+        if v is False:
+            return None
+        return v
+
+
+class AgentDef(BaseModel):
+    """One named agent role the pocket can spawn."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    backend: AgentBackendT = "auto"
+    system_prompt: str | None = None
+    tools: list[str] = Field(default_factory=list)
+    skill_refs: list[str] = Field(default_factory=list)
+    soul_snippet: str | None = None
+
+
+class TriggerDef(BaseModel):
+    """One activation surface."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: TriggerTypeT
+    schedule: str | None = None
+    source: str | None = None
+    when: CelExpression | None = None
+    filter: CelExpression | None = None
+    action: str | None = None
+
+    @model_validator(mode="after")
+    def _conditionals(self) -> TriggerDef:
+        if self.type == "cron" and not self.schedule:
+            raise ValueError("triggers[].schedule is required when type=cron")
+        if self.type in ("webhook", "signal", "calendar", "source_change"):
+            if not self.source:
+                raise ValueError(
+                    f"triggers[].source is required when type={self.type!r}"
+                )
+        if self.type == "temporal" and not self.when:
+            raise ValueError("triggers[].when is required when type=temporal")
+        return self
+
+
+class DataSourceDef(BaseModel):
+    """One read-only source that hydrates state at runtime (RFC 04)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    method: DataSourceMethodT = "GET"
+    path: str = Field(
+        ...,
+        description="Relative path; never absolute (SSRF-safe by RFC 04).",
+    )
+    bind: str = Field(..., description="state path that receives the result.")
+    refresh: list[str] = Field(default_factory=lambda: ["pocket_open", "manual"])
+    transform: str | None = None
+
+    @field_validator("path")
+    @classmethod
+    def _path_is_relative(cls, v: str) -> str:
+        # SSRF safety per RFC 04: relative paths only.
+        if v.startswith(("http://", "https://", "//", "ftp://")):
+            raise ValueError("data_sources[].path must be relative, not absolute")
+        return v
+
+
+class PermissionsDef(BaseModel):
+    """RBAC scope for the pocket."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scope: PermissionsScopeT = "workspace"
+    roles_allowed: list[str] = Field(default_factory=lambda: ["admin", "member"])
+    actions_role_map: dict[str, list[str]] = Field(default_factory=dict)
+
+
+class InstinctRule(BaseModel):
+    """A workspace-scoped Instinct rule."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    when: CelExpression
+    action: InstinctRuleActionT
+
+
+class InstinctRulesDef(BaseModel):
+    """Workspace-scoped rule set plus an escalation target."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    escalation: str | None = None
+    rules: list[InstinctRule] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Top-level model
+# ---------------------------------------------------------------------------
+
+
+class PocketTemplate(BaseModel):
+    """Top-level RFC 03 v2 Pocket Template Schema model.
+
+    Validates a v2-shaped dict. v1 dicts must be promoted via
+    ``loader._promote_v1_to_v2`` BEFORE being passed in.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["2"] = Field(..., description="Schema version (v2 only).")
+    name: str = Field(
+        ...,
+        max_length=64,
+        description="kebab-case slug. Forms the Registry URL.",
+    )
+    version: str = Field(..., description="Semver MAJOR.MINOR.PATCH.")
+    pattern: PatternT
+    vertical: str = Field(..., description="Free-form lower-case slug.")
+    display_name: str | None = None
+    description: str
+    shape: ShapeT
+    state: StateBinding
+    actions: list[ActionDef] = Field(default_factory=list)
+    connectors: list[str] = Field(default_factory=list)
+    agents: list[AgentDef] = Field(default_factory=list)
+    triggers: list[TriggerDef] = Field(default_factory=list)
+    outcomes: list[str] = Field(default_factory=list)
+    data_sources: list[DataSourceDef] = Field(default_factory=list)
+    kb_scope: KbScopeT = "pocket"
+    skill_refs: list[str] = Field(default_factory=list)
+    instinct_rules: InstinctRulesDef | None = None
+    permissions: PermissionsDef | None = None
+    screenshots: list[str] = Field(default_factory=list)
+    icon: str | None = None
+    color: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def _name_is_kebab(cls, v: str) -> str:
+        # Lower-case kebab-case with optional -v<n> suffix per the RFC.
+        # Reject path separators, whitespace, uppercase.
+        if not v:
+            raise ValueError("name must not be empty")
+        if any(ch.isspace() for ch in v):
+            raise ValueError("name must not contain whitespace")
+        if v != v.lower():
+            raise ValueError("name must be lower-case")
+        if "/" in v or "\\" in v:
+            raise ValueError("name must not contain path separators")
+        return v
+
+    @field_validator("vertical")
+    @classmethod
+    def _vertical_is_lower_slug(cls, v: str) -> str:
+        if not v or v != v.lower() or any(ch.isspace() for ch in v):
+            raise ValueError("vertical must be a lower-case slug")
+        return v
+
+    @model_validator(mode="after")
+    def _shape_default_view_matrix(self) -> PocketTemplate:
+        """Enforce the RFC v2 shape x default_view compatibility matrix."""
+        allowed = _SHAPE_DEFAULT_VIEW_MATRIX.get(self.shape)
+        # ``custom`` accepts any default_view.
+        if allowed == "any":
+            return self
+        if allowed is None:
+            # Shape declares NO default_view — reject any value.
+            if self.state.default_view is not None:
+                raise ValueError(
+                    f"shape={self.shape!r} declares no default_view; got "
+                    f"{self.state.default_view!r}"
+                )
+            return self
+        if self.state.default_view is None:
+            # default_view is optional — omitting is always OK.
+            return self
+        if self.state.default_view not in allowed:
+            raise ValueError(
+                f"shape={self.shape!r} does not allow default_view="
+                f"{self.state.default_view!r}; allowed: {sorted(allowed)}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _outcomes_emitted_subset(self) -> PocketTemplate:
+        """Every ``actions[].outcomes_emitted`` entry must be declared
+        in the top-level ``outcomes[]`` catalog."""
+        catalog = set(self.outcomes)
+        for action in self.actions:
+            missing = [o for o in action.outcomes_emitted if o not in catalog]
+            if missing:
+                raise ValueError(
+                    f"actions[{action.name!r}].outcomes_emitted contains "
+                    f"undeclared outcome(s) {missing}; declare them in the "
+                    f"top-level outcomes[] catalog"
+                )
+        return self
+
+
+__all__ = [
+    "ActionDef",
+    "AgentDef",
+    "ColumnDef",
+    "ConfirmDef",
+    "DataSourceDef",
+    "InstinctRule",
+    "InstinctRulesDef",
+    "JoinedEntity",
+    "PermissionsDef",
+    "PocketTemplate",
+    "SavedView",
+    "StateBinding",
+    "TriggerDef",
+]

--- a/tests/fixtures/templates/lease-renewal-v2.yaml
+++ b/tests/fixtures/templates/lease-renewal-v2.yaml
@@ -1,0 +1,177 @@
+# lease-renewal-v2.yaml
+# RFC 03 worked example rewritten in the reconciled v2 schema.
+# Key v2 additions vs the current RFC example:
+#   - schema_version: "2" (NEW required field)
+#   - pattern: app (NEW required field — orthogonal to shape)
+#   - skill_refs (was: in some shipped templates as `skills`; v2 canonical name)
+#   - state.joined_entities (NEW — multi-entity support via Q4 pick (a))
+#   - state.id_field (NEW — explicit row-identity field per gap A11)
+#   - All filter / when expressions are valid CEL per Q2 pick
+#   - confirm widened from bool to object per gap A15
+#   - Instinct resolution order documented in the RFC (Q3 pick (c));
+#     this file's per-action instinct_policy + top-level instinct_rules
+#     COMPOSE per that order.
+
+schema_version: "2"
+name: lease-renewal-v1
+version: 1.0.0
+pattern: app
+vertical: property-management
+display_name: Lease Renewal
+description: |
+  Surfaces every lease expiring in the next 90 days. Drafts a renewal
+  packet per tenant, sends through Gmail with the property manager copied,
+  calendars the signature deadline, and marks the lease renewed in Yardi
+  when the tenant returns the signed PDF.
+icon: home
+color: "#7c9c63"
+
+shape: data-grid
+
+state:
+  entity_type: Lease                     # primary entity — row identity
+  id_field: id                           # NEW — explicit
+  joined_entities:                       # NEW — closes Q4 / gap A6
+    - { name: tenant,   entity_type: Tenant,   via_link: lease_tenant }
+    - { name: property, entity_type: Property, via_link: lease_property }
+  default_view: list
+  columns:
+    - { field: tenant.name,         label: Tenant,   widget: text }
+    - { field: property.address,    label: Property, widget: text }
+    - { field: expiry_date,         label: Expires,  widget: date,             sort: asc }
+    - { field: rent_current,        label: Rent,     widget: currency }
+    - { field: rent_proposed,       label: Proposed, widget: currency_editable }
+    - { field: renewal_stage,       label: Stage,    widget: status_dot,       options: { palette: stages } }
+    - { field: days_remaining,      label: Days,     widget: trend,            options: { invert: true } }
+    - { field: packet_status,       label: Packet,   widget: badge }
+  saved_views:
+    # All filter expressions are CEL (Q2 pick). Dot-paths resolve
+    # through joined_entities; flat names resolve against the primary
+    # entity OR a declared column.
+    - { name: "Expiring 30 days", filter: "days_remaining <= 30",                       group_by: property.address, default: true }
+    - { name: "Awaiting tenant",  filter: "renewal_stage == 'sent'" }
+    - { name: "Past due",         filter: "days_remaining < 0",                         group_by: property.address }
+    - { name: "All open",         filter: "renewal_stage != 'completed'" }
+    - { name: "Risky tenants",    filter: "tenant.late_payment_count_12mo >= 3" }       # NEW — uses joined entity
+    - { name: "Expiring soon",    filter: "within(expires_at, duration('60d'))" }       # NEW — uses CEL temporal helper
+
+connectors:
+  - yardi
+  - gmail
+  - gcalendar
+
+data_sources:
+  - name: expiring_leases
+    method: GET
+    path: /leases?expiry_within=90d
+    bind: state.leases
+    refresh: [pocket_open, manual, interval:1h]
+  - name: tenant_responses
+    method: GET
+    path: /messages?label=lease-renewal&unread=true
+    bind: state.tenant_responses
+    refresh: [pocket_open, signal:gmail.inbox.update]
+
+actions:
+  - name: draft_renewal
+    label: Draft renewal
+    kind: single-row
+    instinct_policy: auto                # author intent — auto-run unless an operator overlay escalates
+    connectors_required: [yardi]
+    agent_required: renewal-drafter
+    outcomes_emitted: [lease_drafted]
+    description: Generates a renewal packet from the lease terms.
+  - name: send_to_tenant
+    label: Send to tenant
+    kind: single-row
+    instinct_policy: require_approval    # author intent — gated; floor cannot be lowered by overlay
+    connectors_required: [gmail, gcalendar]
+    agent_required: renewal-drafter
+    outcomes_emitted: [renewal_sent]
+    confirm:                             # widened from bool per gap A15
+      message: "Send packet to {tenant.name} at {tenant.email}?"
+      destructive: false
+    description: Sends the packet, copies the property manager, calendars the deadline.
+  - name: bulk_draft
+    label: Draft all expiring
+    kind: bulk                            # fan-out: one execution per selected row; one approval blesses the batch
+    instinct_policy: require_approval
+    connectors_required: [yardi]
+    agent_required: renewal-drafter
+    outcomes_emitted: [lease_drafted]
+  - name: mark_renewed
+    label: Mark renewed
+    kind: single-row
+    instinct_policy: notify_only          # author intent — runs, pings operator
+    connectors_required: [yardi]
+    outcomes_emitted: [renewal_completed]
+    description: Writes the renewal back to Yardi and closes the row.
+  - name: refresh_data
+    label: Refresh
+    kind: global
+    instinct_policy: auto
+
+agents:
+  - name: renewal-drafter
+    backend: claude_sdk
+    system_prompt: |
+      You draft lease renewal packets in the voice of the property
+      manager. Cite the current lease terms. Never propose a rent
+      change without surfacing comp data. When the tenant has a history
+      of late payments, flag for human review and do not auto-send.
+    tools: [yardi_read, gmail_compose, gcalendar_write, kb_lookup]
+    skill_refs: [skills/lease-renewal-policy, skills/yardi-helpers]
+    soul_snippet: property-manager-baseline
+
+triggers:
+  - type: cron
+    schedule: "0 8 * * MON"
+    action: bulk_draft
+  - type: source_change
+    source: tenant_responses
+    action: mark_renewed
+  - type: temporal                        # NEW trigger type closing gap A7
+    when: "within(expires_at, duration('60d')) && renewal_stage == null"
+    action: draft_renewal
+  - type: manual
+
+outcomes:
+  - lease_drafted
+  - renewal_sent
+  - renewal_completed
+
+kb_scope: pocket
+
+skill_refs:                               # v2 canonical name (was `skills` in v1)
+  - skills/lease-renewal-policy
+  - skills/yardi-helpers
+  - skills/gmail-templates
+
+instinct_rules:
+  escalation: property-manager
+  # All `when` expressions are CEL (Q2 pick). Top-level rules COMPOSE
+  # with per-action instinct_policy per the resolution order in Q3:
+  #   1. block rules always win — no policy can override them
+  #   2. require_approval rules promote auto → approval (cannot demote)
+  #   3. per-action instinct_policy applies if no rule matched
+  #   4. notify rules fire alongside non-blocking
+  rules:
+    - when: "rent_proposed_delta_pct > 8"
+      action: require_approval
+    - when: "tenant.late_payment_count_12mo >= 3"
+      action: require_approval
+    - when: "rent_proposed < rent_current * 0.95"
+      action: block
+    - when: "within(expires_at, duration('7d')) && renewal_stage == null"
+      action: notify                       # informational — pings escalation target
+
+permissions:
+  scope: workspace
+  roles_allowed: [admin, member]
+  actions_role_map:
+    bulk_draft: [admin]
+    mark_renewed: [admin, member]
+
+screenshots:
+  - assets/lease-renewal-grid.png
+  - assets/lease-renewal-drafter.png

--- a/tests/unit/test_bundled_templates.py
+++ b/tests/unit/test_bundled_templates.py
@@ -5,6 +5,14 @@
 # template.pocket.yaml, the validity of each ripple_spec.json, and the
 # create-specialist wiring (``_build_system_prompt`` template splice +
 # ``AgentModeAdapter`` template short-circuit).
+# Modified 2026-05-25 (feat/rfc-03-v2-schema-chokepoint): widened
+# ``_RFC03_ALLOWED_FIELDS`` + required-set to the v2 shape, swapped the
+# ``skills`` field name for ``skill_refs``, dropped the ``actions: []``
+# / ``omit instinct/outcomes/triggers/agents`` assertions (the bundled
+# templates are post-migration v2 now and may carry these blocks once
+# Instinct/Outcomes wire up), and added a parametrised Pydantic
+# round-trip test that calls ``PocketTemplate.model_validate(...)`` on
+# every shipped bundled template.
 """Tests for the ``pocketpaw.bundled_templates`` package and its wiring.
 
 The installer + loader tests mirror into a ``tmp_path`` destination so
@@ -37,29 +45,48 @@ _EXPECTED_SLUGS = {
     "activity-feed",
 }
 
-# RFC 03 Pocket Template Schema — the field set a seed template may
-# carry. Seed templates ship ``actions: []`` and omit
-# ``outcomes / instinct_rules / triggers / agents`` (Instinct + Outcomes
-# are not wired yet — dead declarations are worse than none).
+# RFC 03 v2 Pocket Template Schema — the field set a seed template may
+# carry after the v1 -> v2 migration. Seed templates still ship
+# ``actions: []`` and omit ``outcomes / instinct_rules / triggers /
+# agents`` (Instinct + Outcomes are not wired yet — dead declarations
+# are worse than none). What v2 adds: ``schema_version``, ``pattern``,
+# and ``display_name`` (all required at v2 except display_name); the
+# rename ``skills`` -> ``skill_refs`` lands at the same time.
 _RFC03_ALLOWED_FIELDS = {
+    "schema_version",
     "name",
     "version",
     "vertical",
+    "pattern",
+    "display_name",
     "shape",
     "state",
     "actions",
     "connectors",
-    "skills",
+    "skill_refs",
     "description",
 }
-_RFC03_REQUIRED_FIELDS = {"name", "version", "vertical", "shape", "state", "description"}
-# RFC 03 shape enum — the fixed set of Ripple Layer 2 widget shapes.
+_RFC03_REQUIRED_FIELDS = {
+    "schema_version",
+    "name",
+    "version",
+    "vertical",
+    "pattern",
+    "shape",
+    "state",
+    "description",
+}
+# RFC 03 v2 shape enum — the fixed set of Ripple Layer 2 widget shapes.
+# v2 adds ``gantt``, ``treemap``, ``network`` to the original v1 enum.
 _RFC03_SHAPE_ENUM = {
     "data-grid",
     "kanban",
     "calendar",
     "map",
     "timeline",
+    "gantt",
+    "treemap",
+    "network",
     "tree",
     "chart",
     "custom",
@@ -400,6 +427,34 @@ async def test_agent_mode_skips_draft_kit_when_template_id_set(tmp_path: Path, m
     assert "ui" in spec and "state" in spec
     # Authoring-only keys are stripped before persist.
     assert "_placeholder_note" not in spec
+
+
+# ---------------------------------------------------------------------------
+# Pydantic v2 chokepoint — every bundled template passes the new model
+# (post-migration v2 shape). This is the defense-in-depth assertion
+# layered over the field-set check above: the field set proves the YAML
+# uses the allowed keys; the Pydantic validation proves the values pass
+# the cross-field rules (shape x default_view matrix, id_field resolves,
+# outcomes_emitted subset, CEL filters parse, etc.).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("slug", sorted(_EXPECTED_SLUGS))
+def test_bundled_template_passes_pydantic_validation(slug: str) -> None:
+    """Each migrated v2 bundled template validates against the
+    ``PocketTemplate`` Pydantic model. This is the chokepoint enforced
+    by RFC 03 v2 — any bundled YAML that drifts off-schema fails here
+    before it ever ships."""
+    import yaml
+
+    from pocketpaw.bundled_templates.schema import PocketTemplate
+
+    meta_path = _BUNDLED_DIR / slug / "template.pocket.yaml"
+    meta = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+
+    template = PocketTemplate.model_validate(meta)
+    assert template.name == slug
+    assert template.schema_version == "2"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_template_schema.py
+++ b/tests/unit/test_template_schema.py
@@ -40,11 +40,7 @@ from pocketpaw.bundled_templates.schema import PocketTemplate
 
 _FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "templates"
 _BUNDLED_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "src"
-    / "pocketpaw"
-    / "bundled_templates"
-    / "_bundled"
+    Path(__file__).resolve().parents[2] / "src" / "pocketpaw" / "bundled_templates" / "_bundled"
 )
 
 
@@ -182,9 +178,7 @@ def test_lease_renewal_v2_fixture_validates() -> None:
     assert len(template.state.joined_entities) == 2
     assert {je.name for je in template.state.joined_entities} == {"tenant", "property"}
     # CEL saved-view filter parsed
-    expiring = next(
-        sv for sv in template.state.saved_views if sv.name == "Expiring 30 days"
-    )
+    expiring = next(sv for sv in template.state.saved_views if sv.name == "Expiring 30 days")
     assert "days_remaining" in expiring.filter
     # Temporal trigger present
     temporal = next(t for t in template.triggers if t.type == "temporal")
@@ -389,9 +383,7 @@ def _write_template(tmp_path: Path, slug: str, meta: dict, spec: dict) -> Path:
 
     slug_dir = tmp_path / slug
     slug_dir.mkdir(parents=True, exist_ok=True)
-    (slug_dir / "template.pocket.yaml").write_text(
-        yaml.safe_dump(meta), encoding="utf-8"
-    )
+    (slug_dir / "template.pocket.yaml").write_text(yaml.safe_dump(meta), encoding="utf-8")
     (slug_dir / "ripple_spec.json").write_text(json.dumps(spec), encoding="utf-8")
     return slug_dir
 
@@ -446,9 +438,7 @@ def test_loader_strict_true_translates_v1_then_validates(tmp_path: Path) -> None
     v1_meta = _minimal_v1_dict()
     _write_template(tmp_path, "todo-task-tracker", v1_meta, {"ui": {}, "state": {}})
 
-    result = load_template(
-        "todo-task-tracker", templates_dir=tmp_path, strict=True
-    )
+    result = load_template("todo-task-tracker", templates_dir=tmp_path, strict=True)
     assert result is not None
     meta = result["meta"]
     assert meta["schema_version"] == "2"

--- a/tests/unit/test_template_schema.py
+++ b/tests/unit/test_template_schema.py
@@ -1,0 +1,488 @@
+# tests/unit/test_template_schema.py
+# Created: 2026-05-25 (feat/rfc-03-v2-schema-chokepoint) — covers the
+# new Pydantic v2 ``PocketTemplate`` model, the CEL expression
+# validator, the v1 -> v2 promotion path, and the loader's new strict
+# kwarg. RED-first: imports the not-yet-existing schema module so the
+# whole file fails on collection until Phase 2 lands the implementation.
+"""RED tests for RFC 03 v2 — Pocket Template Schema chokepoint.
+
+The schema module under ``pocketpaw.bundled_templates.schema`` does not
+exist yet. These tests intentionally fail (ImportError on collection)
+until the Phase 2 implementer lands ``PocketTemplate``,
+``TemplateValidationError``, and the loader rewiring.
+
+Test taxonomy
+-------------
+
+1. v1 -> v2 translation: each of the 4 RFC rules round-trips.
+2. v2 worked example (lease-renewal): loads + validates clean.
+3. Pydantic enforcement: missing required field, bad enum, etc.
+4. CEL parse-as-validation: a malformed expression raises.
+5. Cross-field validator rules:
+   * shape x default_view compatibility matrix
+   * outcomes_emitted subset of top-level outcomes
+   * state.id_field resolves to a column field or implicit ``id``
+6. Loader strict kwarg: default returns None on failure; strict raises.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+# These imports drive the RED gate — they only succeed once Phase 2
+# ships the new modules. Tests stay RED via ImportError until then.
+from pocketpaw.bundled_templates.errors import TemplateValidationError
+from pocketpaw.bundled_templates.loader import _promote_v1_to_v2, load_template
+from pocketpaw.bundled_templates.schema import PocketTemplate
+
+_FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "templates"
+_BUNDLED_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "pocketpaw"
+    / "bundled_templates"
+    / "_bundled"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_v2_dict() -> dict:
+    """A minimal v2-shaped dict that passes Pydantic validation. Tests
+    mutate copies of this dict to surface per-rule violations cleanly."""
+    return {
+        "schema_version": "2",
+        "name": "minimal-template",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "productivity",
+        "description": "A minimal template used only by tests.",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "columns": [
+                {"field": "title", "widget": "text"},
+                {"field": "status", "widget": "badge"},
+            ],
+        },
+    }
+
+
+def _minimal_v1_dict() -> dict:
+    """A v1-shaped dict that mirrors the shipped bundled templates."""
+    return {
+        "name": "todo-task-tracker",
+        "version": "1.0.0",
+        "vertical": "productivity",
+        "shape": "data-grid",
+        "description": "A personal task tracker.",
+        "state": {
+            "entity_type": "Task",
+            "columns": [{"field": "title", "widget": "text"}],
+        },
+        "actions": [],
+        "connectors": [],
+        "skills": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# v1 -> v2 promotion (each of the 4 RFC translation rules)
+# ---------------------------------------------------------------------------
+
+
+def test_promote_injects_schema_version_when_absent() -> None:
+    """Rule 1: absent ``schema_version`` -> ``"2"``."""
+    v1 = _minimal_v1_dict()
+    assert "schema_version" not in v1
+    out = _promote_v1_to_v2(v1)
+    assert out["schema_version"] == "2"
+
+
+def test_promote_synthesizes_display_name_from_slug_title_case() -> None:
+    """Rule 2: absent ``display_name`` -> title-case the ``name`` slug."""
+    v1 = _minimal_v1_dict()
+    assert "display_name" not in v1
+    out = _promote_v1_to_v2(v1)
+    assert out["display_name"] == "Todo Task Tracker"
+
+
+def test_promote_renames_skills_to_skill_refs() -> None:
+    """Rule 3: ``skills`` -> ``skill_refs`` (array contents identical)."""
+    v1 = _minimal_v1_dict()
+    v1["skills"] = ["skills/a", "skills/b"]
+    out = _promote_v1_to_v2(v1)
+    assert "skills" not in out
+    assert out["skill_refs"] == ["skills/a", "skills/b"]
+
+
+def test_promote_injects_pattern_from_sibling_index_json() -> None:
+    """Rule 4: absent ``pattern`` looked up from the sibling
+    ``index.json`` by ``name``. The bundled ``todo-task-tracker`` row is
+    ``pattern: app`` per the shipped index.json — promotion must surface
+    that value."""
+    v1 = _minimal_v1_dict()
+    out = _promote_v1_to_v2(v1, templates_dir=_BUNDLED_DIR)
+    assert out["pattern"] == "app"
+
+
+def test_promote_pattern_falls_back_to_app_when_index_missing() -> None:
+    """Rule 4 fallback: no index.json -> ``pattern: 'app'``."""
+    v1 = _minimal_v1_dict()
+    out = _promote_v1_to_v2(v1, templates_dir=Path("/nonexistent/templates/dir"))
+    assert out["pattern"] == "app"
+
+
+def test_promote_is_idempotent_on_v2_input() -> None:
+    """A v2-shaped dict passes through unchanged. Critical for
+    round-trip safety of the load -> validate path."""
+    v2 = _minimal_v2_dict()
+    out = _promote_v1_to_v2(v2)
+    assert out["schema_version"] == "2"
+    # display_name was not in the v2 input either — promotion still
+    # synthesizes it because optional defaults are computed regardless
+    # of source version.
+    assert out["display_name"] == "Minimal Template"
+
+
+def test_promote_preserves_skill_refs_when_already_named() -> None:
+    """If v1 input already uses ``skill_refs`` (mixed shape), don't
+    clobber it."""
+    v1 = _minimal_v1_dict()
+    del v1["skills"]
+    v1["skill_refs"] = ["skills/x"]
+    out = _promote_v1_to_v2(v1)
+    assert out["skill_refs"] == ["skills/x"]
+
+
+# ---------------------------------------------------------------------------
+# v2 worked example (lease-renewal) loads + validates clean
+# ---------------------------------------------------------------------------
+
+
+def test_lease_renewal_v2_fixture_validates() -> None:
+    """The canonical v2 worked example loads and Pydantic-validates
+    without any error. Drift here means the schema model and the RFC
+    example are out of sync."""
+    fixture = _FIXTURES_DIR / "lease-renewal-v2.yaml"
+    meta = yaml.safe_load(fixture.read_text(encoding="utf-8"))
+    template = PocketTemplate.model_validate(meta)
+    assert template.schema_version == "2"
+    assert template.name == "lease-renewal-v1"
+    assert template.pattern == "app"
+    assert template.vertical == "property-management"
+    assert template.shape == "data-grid"
+    # joined_entities populated
+    assert len(template.state.joined_entities) == 2
+    assert {je.name for je in template.state.joined_entities} == {"tenant", "property"}
+    # CEL saved-view filter parsed
+    expiring = next(
+        sv for sv in template.state.saved_views if sv.name == "Expiring 30 days"
+    )
+    assert "days_remaining" in expiring.filter
+    # Temporal trigger present
+    temporal = next(t for t in template.triggers if t.type == "temporal")
+    assert "within(" in temporal.when
+    # confirm widened to object form
+    send = next(a for a in template.actions if a.name == "send_to_tenant")
+    assert send.confirm is not None
+
+
+# ---------------------------------------------------------------------------
+# Pydantic enforcement — required fields, enums, extra-forbid
+# ---------------------------------------------------------------------------
+
+
+def test_missing_required_top_level_field_raises() -> None:
+    """Drop a required field; expect a Pydantic validation error wrapped
+    in ``TemplateValidationError`` when invoked through the loader."""
+    bad = _minimal_v2_dict()
+    del bad["shape"]
+    with pytest.raises(Exception):  # noqa: B017 — direct Pydantic ValidationError
+        PocketTemplate.model_validate(bad)
+
+
+def test_extra_top_level_field_rejected() -> None:
+    """``extra='forbid'`` on the top-level model means unknown fields
+    are rejected. v1 'skills' is the canonical example."""
+    bad = _minimal_v2_dict()
+    bad["skills"] = ["skills/x"]  # v1 field at v2 schema -> reject
+    with pytest.raises(Exception):  # noqa: B017
+        PocketTemplate.model_validate(bad)
+
+
+def test_bad_shape_enum_rejected() -> None:
+    """``shape`` must be one of the 11 RFC-listed values."""
+    bad = _minimal_v2_dict()
+    bad["shape"] = "not-a-real-shape"
+    with pytest.raises(Exception):  # noqa: B017
+        PocketTemplate.model_validate(bad)
+
+
+def test_bad_pattern_enum_rejected() -> None:
+    """``pattern`` must be one of the 7 RFC-listed values."""
+    bad = _minimal_v2_dict()
+    bad["pattern"] = "not-a-real-pattern"
+    with pytest.raises(Exception):  # noqa: B017
+        PocketTemplate.model_validate(bad)
+
+
+# ---------------------------------------------------------------------------
+# CEL parse-as-validation
+# ---------------------------------------------------------------------------
+
+
+def test_bad_cel_in_saved_view_filter_raises() -> None:
+    """A malformed CEL expression in ``saved_views[].filter`` raises."""
+    bad = _minimal_v2_dict()
+    bad["state"]["saved_views"] = [
+        {"name": "broken", "filter": "this is not valid CEL ((("},
+    ]
+    with pytest.raises(Exception):  # noqa: B017
+        PocketTemplate.model_validate(bad)
+
+
+def test_valid_cel_in_saved_view_filter_accepts() -> None:
+    """A well-formed CEL expression passes."""
+    good = _minimal_v2_dict()
+    good["state"]["saved_views"] = [
+        {"name": "expiring", "filter": "days_remaining <= 30"},
+    ]
+    template = PocketTemplate.model_validate(good)
+    assert template.state.saved_views[0].filter == "days_remaining <= 30"
+
+
+def test_bad_cel_in_instinct_rule_when_raises() -> None:
+    """A malformed CEL expression in ``instinct_rules.rules[].when``
+    raises at validation time."""
+    bad = _minimal_v2_dict()
+    bad["instinct_rules"] = {
+        "rules": [
+            {"when": "((( bad syntax", "action": "block"},
+        ],
+    }
+    with pytest.raises(Exception):  # noqa: B017
+        PocketTemplate.model_validate(bad)
+
+
+def test_bad_cel_in_temporal_trigger_when_raises() -> None:
+    """A malformed CEL expression in ``triggers[].when`` (temporal)
+    raises."""
+    bad = _minimal_v2_dict()
+    bad["triggers"] = [
+        {"type": "temporal", "when": "((("},
+    ]
+    with pytest.raises(Exception):  # noqa: B017
+        PocketTemplate.model_validate(bad)
+
+
+# ---------------------------------------------------------------------------
+# Cross-field validator rules
+# ---------------------------------------------------------------------------
+
+
+def test_shape_kanban_with_default_view_calendar_rejected() -> None:
+    """``shape: kanban`` only allows ``default_view: kanban`` per the
+    RFC compatibility matrix."""
+    bad = _minimal_v2_dict()
+    bad["shape"] = "kanban"
+    bad["state"]["default_view"] = "calendar"
+    with pytest.raises(Exception):  # noqa: B017
+        PocketTemplate.model_validate(bad)
+
+
+def test_shape_data_grid_with_default_view_kanban_accepted() -> None:
+    """``shape: data-grid`` accepts ``default_view: kanban`` per the
+    matrix (data-grid -> list, grid, kanban)."""
+    good = _minimal_v2_dict()
+    good["shape"] = "data-grid"
+    good["state"]["default_view"] = "kanban"
+    template = PocketTemplate.model_validate(good)
+    assert template.state.default_view == "kanban"
+
+
+def test_shape_chart_with_default_view_rejected() -> None:
+    """``shape: chart`` declares NO default_view per the matrix."""
+    bad = _minimal_v2_dict()
+    bad["shape"] = "chart"
+    bad["state"]["default_view"] = "list"
+    with pytest.raises(Exception):  # noqa: B017
+        PocketTemplate.model_validate(bad)
+
+
+def test_outcomes_emitted_subset_of_top_level_outcomes() -> None:
+    """An action's ``outcomes_emitted`` must be a subset of the
+    template-level ``outcomes[]``."""
+    bad = _minimal_v2_dict()
+    bad["outcomes"] = ["thing_done"]
+    bad["actions"] = [
+        {
+            "name": "do_thing",
+            "label": "Do thing",
+            "kind": "single-row",
+            "instinct_policy": "auto",
+            "outcomes_emitted": ["unrelated_outcome"],
+        }
+    ]
+    with pytest.raises(Exception):  # noqa: B017
+        PocketTemplate.model_validate(bad)
+
+
+def test_outcomes_emitted_subset_accepted_when_aligned() -> None:
+    """The subset check passes when outcomes_emitted is listed."""
+    good = _minimal_v2_dict()
+    good["outcomes"] = ["thing_done"]
+    good["actions"] = [
+        {
+            "name": "do_thing",
+            "label": "Do thing",
+            "kind": "single-row",
+            "instinct_policy": "auto",
+            "outcomes_emitted": ["thing_done"],
+        }
+    ]
+    template = PocketTemplate.model_validate(good)
+    assert template.actions[0].outcomes_emitted == ["thing_done"]
+
+
+def test_state_id_field_missing_column_rejected() -> None:
+    """``state.id_field`` must resolve to a column field OR be the
+    implicit ``id``. A name that matches neither is rejected."""
+    bad = _minimal_v2_dict()
+    bad["state"]["id_field"] = "no_such_column"
+    with pytest.raises(Exception):  # noqa: B017
+        PocketTemplate.model_validate(bad)
+
+
+def test_state_id_field_implicit_id_accepted() -> None:
+    """The implicit ``id`` value passes even when no column declares
+    ``id`` — every entity carries an implicit row identifier."""
+    good = _minimal_v2_dict()
+    good["state"]["id_field"] = "id"
+    template = PocketTemplate.model_validate(good)
+    assert template.state.id_field == "id"
+
+
+def test_state_id_field_matching_column_accepted() -> None:
+    """``id_field`` resolves to a declared column field."""
+    good = _minimal_v2_dict()
+    good["state"]["id_field"] = "title"  # column declared in _minimal_v2_dict
+    template = PocketTemplate.model_validate(good)
+    assert template.state.id_field == "title"
+
+
+# ---------------------------------------------------------------------------
+# Loader strict kwarg + TemplateValidationError type
+# ---------------------------------------------------------------------------
+
+
+def _write_template(tmp_path: Path, slug: str, meta: dict, spec: dict) -> Path:
+    """Write a slug-shaped template directory under tmp_path; return
+    the slug directory."""
+    import json
+
+    slug_dir = tmp_path / slug
+    slug_dir.mkdir(parents=True, exist_ok=True)
+    (slug_dir / "template.pocket.yaml").write_text(
+        yaml.safe_dump(meta), encoding="utf-8"
+    )
+    (slug_dir / "ripple_spec.json").write_text(json.dumps(spec), encoding="utf-8")
+    return slug_dir
+
+
+def test_loader_strict_false_returns_none_on_bad_template(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``strict=False`` (default) preserves back-compat: a bad template
+    yields ``None`` + a logged warning; pocket creation can fall back to
+    cold generation."""
+    bad_meta = _minimal_v2_dict()
+    bad_meta["shape"] = "not-a-real-shape"  # invalid enum
+    _write_template(tmp_path, "bad-template", bad_meta, {"ui": {}, "state": {}})
+
+    with caplog.at_level("WARNING"):
+        result = load_template("bad-template", templates_dir=tmp_path, strict=False)
+
+    assert result is None
+    # The warning chain mentions the slug and the failure.
+    assert any("bad-template" in msg for msg in caplog.messages)
+
+
+def test_loader_strict_true_raises_template_validation_error(tmp_path: Path) -> None:
+    """``strict=True`` propagates a ``TemplateValidationError`` so the
+    CLI and tests can surface the exact problem."""
+    bad_meta = _minimal_v2_dict()
+    bad_meta["shape"] = "not-a-real-shape"
+    _write_template(tmp_path, "bad-template", bad_meta, {"ui": {}, "state": {}})
+
+    with pytest.raises(TemplateValidationError) as exc_info:
+        load_template("bad-template", templates_dir=tmp_path, strict=True)
+    assert "bad-template" in str(exc_info.value)
+
+
+def test_loader_strict_true_loads_v2_template_successfully(tmp_path: Path) -> None:
+    """A valid v2 template loads through the strict path and returns a
+    dict shaped exactly like the existing API: ``{meta, ripple_spec}``."""
+    good_meta = _minimal_v2_dict()
+    _write_template(tmp_path, "good-template", good_meta, {"ui": {}, "state": {}})
+
+    result = load_template("good-template", templates_dir=tmp_path, strict=True)
+    assert result is not None
+    assert set(result.keys()) == {"meta", "ripple_spec"}
+    assert isinstance(result["meta"], dict)
+    assert result["meta"]["schema_version"] == "2"
+
+
+def test_loader_strict_true_translates_v1_then_validates(tmp_path: Path) -> None:
+    """A v1 template on disk is promoted before validation under
+    ``strict=True`` — the translation path stays exercised even after
+    the bundled migration lands."""
+    v1_meta = _minimal_v1_dict()
+    _write_template(tmp_path, "todo-task-tracker", v1_meta, {"ui": {}, "state": {}})
+
+    result = load_template(
+        "todo-task-tracker", templates_dir=tmp_path, strict=True
+    )
+    assert result is not None
+    meta = result["meta"]
+    assert meta["schema_version"] == "2"
+    assert "skills" not in meta and meta.get("skill_refs") == []
+    assert meta["display_name"] == "Todo Task Tracker"
+
+
+def test_template_validation_error_carries_slug_and_pydantic_error(
+    tmp_path: Path,
+) -> None:
+    """``TemplateValidationError`` exposes the slug and the underlying
+    Pydantic ValidationError for CLI rendering."""
+    from pydantic import ValidationError
+
+    bad_meta = _minimal_v2_dict()
+    bad_meta["shape"] = "not-a-real-shape"
+    _write_template(tmp_path, "bad-template", bad_meta, {"ui": {}, "state": {}})
+
+    with pytest.raises(TemplateValidationError) as exc_info:
+        load_template("bad-template", templates_dir=tmp_path, strict=True)
+
+    err = exc_info.value
+    assert err.slug == "bad-template"
+    assert isinstance(err.pydantic_error, ValidationError)
+    assert isinstance(err, ValueError)  # ValueError subclass per the brief
+
+
+def test_loader_strict_default_is_false_for_back_compat(tmp_path: Path) -> None:
+    """The default behaviour (no kwarg) must continue to return None on
+    failure — EE consumers pattern-match on None."""
+    bad_meta = _minimal_v2_dict()
+    bad_meta["shape"] = "not-a-real-shape"
+    _write_template(tmp_path, "bad-template", bad_meta, {"ui": {}, "state": {}})
+
+    # No ``strict`` kwarg at all — should NOT raise.
+    result = load_template("bad-template", templates_dir=tmp_path)
+    assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -708,6 +708,22 @@ wheels = [
 ]
 
 [[package]]
+name = "cel-python"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-re2" },
+    { name = "jmespath" },
+    { name = "lark" },
+    { name = "pendulum" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/4e/f821948a5bbd7a98a218720f831a62216f79a98e43b13d9ab2f98e37c5f8/cel_python-0.5.0.tar.gz", hash = "sha256:3eb0a619e8df0f338d0430cda01427a742e77e3c433a1c7c3ebd409cd804c45a", size = 13364027, upload-time = "2026-01-31T19:07:13.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/f8/38812adc3f787c2c2e8ba56f524185ed379656c10b40347a32796ba61c08/cel_python-0.5.0-py3-none-any.whl", hash = "sha256:d0f85008b89655c2bb18d797d2fa3f96f2ed80f4a3b43b0e8138c6646581e5f6", size = 84950, upload-time = "2026-01-31T19:07:11.821Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -1508,19 +1524,19 @@ wheels = [
 
 [[package]]
 name = "github-copilot-sdk"
-version = "0.2.1"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/41/76a9d50d7600bf8d26c659dc113be62e4e56e00a5cbfd544e1b5b200f45c/github_copilot_sdk-0.2.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:c0823150f3b73431f04caee43d1dbafac22ae7e8bd1fc83727ee8363089ee038", size = 61076141, upload-time = "2026-04-03T20:18:22.062Z" },
-    { url = "https://files.pythonhosted.org/packages/04/04/d2e8bf4587c4da270ccb9cbd5ab8a2c4b41217c2bf04a43904be8a27ae20/github_copilot_sdk-0.2.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ef7ff68eb8960515e1a2e199ac0ffb9a17cd3325266461e6edd7290e43dcf012", size = 57838464, upload-time = "2026-04-03T20:18:26.042Z" },
-    { url = "https://files.pythonhosted.org/packages/78/8b/cc8ee46724bd9fdfd6afe855a043c8403ed6884c5f3a55a9737780810396/github_copilot_sdk-0.2.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:890f7124e3b147532a1ac6c8d5f66421ea37757b2b9990d7967f3f147a2f533a", size = 63940155, upload-time = "2026-04-03T20:18:30.297Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/ee/facf04e22e42d4bdd4fe3d356f3a51180a6ea769ae2ac306d0897f9bf9d9/github_copilot_sdk-0.2.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:6502be0b9ececacbda671835e5f61c7aaa906c6b8657ee252cad6cc8335cac8e", size = 62130538, upload-time = "2026-04-03T20:18:34.061Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/1c/8b105f14bf61d1d304a00ac29460cb0d4e7406ceb89907d5a7b41a72fe85/github_copilot_sdk-0.2.1-py3-none-win_amd64.whl", hash = "sha256:8275ca8e387e6b29bc5155a3c02a0eb3d035c6bc7b1896253eb0d469f2385790", size = 56547331, upload-time = "2026-04-03T20:18:37.859Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/c1/0ce319d2f618e9bc89f275e60b1920f4587eb0218bba6cbb84283dc7a7f3/github_copilot_sdk-0.2.1-py3-none-win_arm64.whl", hash = "sha256:1f9b59b7c41f31be416bf20818f58e25b6adc76f6d17357653fde6fbab662606", size = 54499549, upload-time = "2026-04-03T20:18:41.77Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d7/3d71064646a24d633c9dec035ff8b5b6d72c11d3aad765e54efd71737f0f/github_copilot_sdk-0.3.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:ed8f27989158824c754d7febb473bdf25744a1e6bc07a06f114f7e7deebd2c22", size = 58566984, upload-time = "2026-04-24T16:05:37.535Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/18/439854722b951a2f213c23cc731e9a31d46c8b1e2f1b1de080745c03c798/github_copilot_sdk-0.3.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7e241d9b00ebf8bb4d10b2d6101c75fcef38de04d144d729e07fa48394270ee1", size = 55318729, upload-time = "2026-04-24T16:05:41.734Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/931a65b17ad36d3b8987d8cb9bd2835f759c79ae1799fdc34d1252c38b6f/github_copilot_sdk-0.3.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:f4d98a67b8f038885ddd38bd7033d1ac20c3010f04c72ee0fc74ba4984b69ffa", size = 61452705, upload-time = "2026-04-24T16:05:45.225Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e5/7e275fc76a7f9cc3240da393ed631d9647c346a36d6392ea4b0ed56326f6/github_copilot_sdk-0.3.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:b591546d789f9f8243fb59ca71b08cb0bb1dbec818fbef060c3830c6787de2c8", size = 59646875, upload-time = "2026-04-24T16:05:48.832Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/67/00e3bf21842b0c418aad6ce233ec8cd7e8ca91859e4f7e571fc47c682ed9/github_copilot_sdk-0.3.0-py3-none-win_amd64.whl", hash = "sha256:c5712d57a2c6291b805c79e039c55c48d858034b1a37fc8e1653925403a028e9", size = 54165496, upload-time = "2026-04-24T16:05:52.712Z" },
+    { url = "https://files.pythonhosted.org/packages/91/1c/76bb5159018a1c0d44b17ded340c91085fb48dd3dc912eb349781c54c200/github_copilot_sdk-0.3.0-py3-none-win_arm64.whl", hash = "sha256:93b07c46f60cebbbb003d5bddba22eab886849b1d052b98037b52b6434a5bc07", size = 52103138, upload-time = "2026-04-24T16:05:56.329Z" },
 ]
 
 [[package]]
@@ -1715,6 +1731,58 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9d/59/3ed61240ef20b3ae6ed54e82c6f8b6d1f194947bc6679679dd6cdb037594/google_genai-1.75.0.tar.gz", hash = "sha256:56bac3991b311c93f980c0a2abcd287b672146905df1fbd71c92ed633d5a07cf", size = 539039, upload-time = "2026-05-04T22:48:54.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/b6/552d40e96da22921eb1fead7c14b00b5b5473a20e45959488660fab35ee2/google_genai-1.75.0-py3-none-any.whl", hash = "sha256:8dc4c096e7d6288c3087f6893f582fe52468932464781edb8193bd92b9fefb2c", size = 793726, upload-time = "2026-05-04T22:48:53.033Z" },
+]
+
+[[package]]
+name = "google-re2"
+version = "1.1.20251105"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/60/805c654ba53d685513df955ee745f71920fe8e6a284faf0f9b9dc19b659c/google_re2-1.1.20251105.tar.gz", hash = "sha256:1db14a292ee8303b91e91e7c37e05ac17d3c467f29416c79ac70a78be3e65bda", size = 11676, upload-time = "2025-11-05T14:58:07.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/4d/203a08dab1bdb5c83b46dd424c01a789ecb5a37dbc80f33d016bd116a9d7/google_re2-1.1.20251105-1-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:329efa209ea7baa44f0facf0402fa34e655dc97fdeb10d0b83fc06354f5575fd", size = 483717, upload-time = "2025-11-05T14:57:04.808Z" },
+    { url = "https://files.pythonhosted.org/packages/78/88/466026b43ff5c7d740f5ede090992ec63b60d1810ab14fe35dfc00677e0a/google_re2-1.1.20251105-1-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:aa2ad5f6f48921ec137a7b7f1b1da903ddef8627a2dc30bc878a9a69d9925719", size = 515547, upload-time = "2025-11-05T14:57:06.013Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6a/c6c9fdb00c98990e4f7a6cd650e209d7b5d2754ca0404b72c69ac9909a69/google_re2-1.1.20251105-1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ac1cb2526cc88f050a0661fc7245ad009ee454bddc541b2e653f1d007585000d", size = 485396, upload-time = "2025-11-05T14:57:07.592Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/f6/529c44f607c47f96cfa29c1fe3a690fe75b2fdb48e9b0d6b54e5f0a75e59/google_re2-1.1.20251105-1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:50c7205182ad66c23c07abe8072f720ca2f7d595b61e28fd9b63623614f9afd6", size = 517150, upload-time = "2025-11-05T14:57:09.376Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/ccc07860e31ab81965c63f9ed4eb69ea0d3449a9b4e1610f71883694bbe8/google_re2-1.1.20251105-1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:4cb5acee61e35772503b8b1db3c592a46b8e6a9bc0ab54d7d6233654ea2bf93d", size = 482807, upload-time = "2025-11-05T14:57:11.057Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/43/5fb20d16664457f61670bdd95f39039d43ee8b7732511c688e2f322a4317/google_re2-1.1.20251105-1-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:1617097d63620c2d46bdfc0e48f24f66cd341664fc75718636d234f67473fe7f", size = 508839, upload-time = "2025-11-05T14:57:12.338Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f2/6e470338271e164dd3c5e508876f99aec3ed23bf419c7d54a5672fd5b05f/google_re2-1.1.20251105-1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18a5610b26742b90cb1d64ead2b16fe0e3bd7e67add03fd3779cd1b85e401661", size = 573718, upload-time = "2025-11-05T14:57:13.635Z" },
+    { url = "https://files.pythonhosted.org/packages/91/21/4566fc344c21cf3c49082d13ddab785994b5e3b8b7fd4631242538f698a2/google_re2-1.1.20251105-1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03156291269f145eccddff63118f2df02d395792f51fc039f09955818943815a", size = 590749, upload-time = "2025-11-05T14:57:14.864Z" },
+    { url = "https://files.pythonhosted.org/packages/94/19/5981fb798bb8d08933b815b1fd9e55d179c380b9d8c21a49197b9b7c5967/google_re2-1.1.20251105-1-cp311-cp311-win32.whl", hash = "sha256:54f51762b51dc238eceddf49b56cc2b64594fe72d9328c1c39d615aa990e1f87", size = 434066, upload-time = "2025-11-05T14:57:16.22Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e5/f83053a36cfc4762d843748e4f7a9c1141937dcf74cd6fc3f4598292dda3/google_re2-1.1.20251105-1-cp311-cp311-win_amd64.whl", hash = "sha256:f5f856ff5036a8f22b3bad57f376d4e3b97b59b64f311bdb1f83c8dabded2492", size = 491025, upload-time = "2025-11-05T14:57:17.746Z" },
+    { url = "https://files.pythonhosted.org/packages/56/be/4315c3b38f42f9a2888fa76260545c98547502f1c35aa63a672d39011b2e/google_re2-1.1.20251105-1-cp311-cp311-win_arm64.whl", hash = "sha256:913864f97de4151eaa8bb7746ca230fd193656501e07fb658ce2cd46d4f6efcc", size = 642194, upload-time = "2025-11-05T14:57:19.374Z" },
+    { url = "https://files.pythonhosted.org/packages/67/20/73b487538e9107c2fd96aed737e3f3890dfce3e292622e4ffb2f9c810ee5/google_re2-1.1.20251105-1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b30f09b4d63249c72e65ccae4cbf6b331b48c22fc7cb439f1d85f347b9d07ceb", size = 485591, upload-time = "2025-11-05T14:57:20.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9a/ca3a993bdb5dc6d5b2616b9657b2872a83d1827f8bd3ab50cd629eb751c7/google_re2-1.1.20251105-1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:9a77892c524b8bdf3d47d7cad1cc2ac3a0108bdd65007ef4c02888fa46baf8ee", size = 518780, upload-time = "2025-11-05T14:57:22.18Z" },
+    { url = "https://files.pythonhosted.org/packages/df/37/b2e367987371514253ec9e514637f457deaacb7acc1c900814f3a6421e0f/google_re2-1.1.20251105-1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a3ac51b28cbf25c100dfd8849212d878d7005d1d4a7e129a10789043c56b6021", size = 486966, upload-time = "2025-11-05T14:57:24.575Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/69/1db6742943c0ac254bfb7d8a37a5d3f73f016a65cfa1f84fe3a0451820f6/google_re2-1.1.20251105-1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:9f7158afc9825ac2654c6561aea94a1f7edb5b5b88e6e3639bb80bb817d102ac", size = 520225, upload-time = "2025-11-05T14:57:26.039Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/0a/0747c92dbebe2c09a26bd7386d372b5c5a9926236b4f3d69bb8f15db05cb/google_re2-1.1.20251105-1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:5320da07dc3b7ac7f407514f42ac17d67e771ac7c7562d449571185e6fb601b2", size = 482943, upload-time = "2025-11-05T14:57:27.353Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/14/6bfc6838bb6cb561824ac03deeab2bd11d5d9a93505f536c8fa2f6bd46c4/google_re2-1.1.20251105-1-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:5a4e5785bc30d52ce655d805b07ad2d8a4905429a5f690ae9c2f1caa76665709", size = 510384, upload-time = "2025-11-05T14:57:29.139Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/0a/6add090c917ee39f6f0be753037cafceb3bad904b424efc155fb38082635/google_re2-1.1.20251105-1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b7a3b90f747130310d4b3b8e19ebb845d0d97c1deb63b36f76c7242dacbd736", size = 572446, upload-time = "2025-11-05T14:57:30.495Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1c/8b1ccbeade96a21435d55b5185cd6d9b2ceab5a9af998a4d9099e0540759/google_re2-1.1.20251105-1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:809c5fa5d08279413b29c2e2c5c528e85cd94a0e0fd897db595a0c09eeee2782", size = 591348, upload-time = "2025-11-05T14:57:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/62/cf/7bdd7a1ae7828b613011da808eafec4da3132f43c3be6af5e0bd670ebe8b/google_re2-1.1.20251105-1-cp312-cp312-win32.whl", hash = "sha256:d8424e63a9ec0fe5bde03d97876b2431f8a746af33eb475fa1ae39144bd05b2a", size = 433787, upload-time = "2025-11-05T14:57:33.071Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e9/5dd951c35acaabfe87c67228b9af2cdcd7779d9167edbe6b9094b8a8e529/google_re2-1.1.20251105-1-cp312-cp312-win_amd64.whl", hash = "sha256:062313c309f93dfeb6966372f4c446580e98879133ec155522eea8aaf568a5cd", size = 491726, upload-time = "2025-11-05T14:57:34.39Z" },
+    { url = "https://files.pythonhosted.org/packages/60/8d/c1afd29fc2cb475fd4c634f3d3c8099c0efb662362c10b27a9eaf11c9357/google_re2-1.1.20251105-1-cp312-cp312-win_arm64.whl", hash = "sha256:558f144b26a9555ae4e9467cc3aa3299a8ce13217f328b21ae326ca0633be19b", size = 642673, upload-time = "2025-11-05T14:57:35.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/c441722196598fc3de0f654606ad9975a968c71dc27f516b5a4c9ebb94fd/google_re2-1.1.20251105-1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:9f3cf610e857a7d6f02916cf2b7fc159a5429b8bcb23164500d46e5e233f2924", size = 485549, upload-time = "2025-11-05T14:57:36.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/87/cf588255e5ada1dfb555cc96de35be78438bb0b6faba64df5fe91cecc224/google_re2-1.1.20251105-1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:a21c2807bf4d5d00f206a4ecb3b043aad674e28c451b697b740280f608872078", size = 518840, upload-time = "2025-11-05T14:57:38.115Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/39/da66e4ca9be0c51546efc6fb39cf1683c4be8245d8199cb54a9808e8d5fa/google_re2-1.1.20251105-1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8314144eefeee7b88b742081c2038418f677e63901039ca9dbfbc0c5bb6d2911", size = 487037, upload-time = "2025-11-05T14:57:39.467Z" },
+    { url = "https://files.pythonhosted.org/packages/75/dd/24ba65692dd58dca6ff178428551f4e9b776d1489a1251f5c8539e598baa/google_re2-1.1.20251105-1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:28a46be978e53c772139d0f5c9ba69f53563fcdd4225407e4d34d51208b828f1", size = 520285, upload-time = "2025-11-05T14:57:40.666Z" },
+    { url = "https://files.pythonhosted.org/packages/61/12/cfdbb92bed24af6474970a75a26145c424f98cfbcc633fdd185985f0efe0/google_re2-1.1.20251105-1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:83292e23963aa1b219d5f64a65365b0880448a6a060276027b55270bc5b18c7e", size = 482981, upload-time = "2025-11-05T14:57:41.928Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bf/5fc32ded9279e69a87b88d7261e7e77e2e26325d4e27ca1303a3215e430a/google_re2-1.1.20251105-1-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:1920b15dc9b1bdfeca5aa2c60900373c6f27cd1056d53cd299456ea5540a6fff", size = 510366, upload-time = "2025-11-05T14:57:43.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/71/f927ddc7aef1b8d7ccc8a649c335d311f29f3dea658209e30e37720e4891/google_re2-1.1.20251105-1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b1458d9ca588124cd61aa1bf5388a216e1247e7d474f8e5e1530498044f5c87", size = 572390, upload-time = "2025-11-05T14:57:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/8c/23075e589038284c9487f41cde531d35873f9da622fb4ac7d1d97bd9086e/google_re2-1.1.20251105-1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a52cb204e49d20cdbb66faf394d57f476e96c39c23a328442ab0194fc6bd1a2b", size = 591386, upload-time = "2025-11-05T14:57:45.713Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/7f/858453ef689f6b9895cd02b466836a9d1a6e4ba535d1a275b01bf73baa1d/google_re2-1.1.20251105-1-cp313-cp313-win32.whl", hash = "sha256:67c5c73d7ebcf3f0e0a3b528b41bd8c6c04900f1598aebf05bbdf15a06cf5f9a", size = 433807, upload-time = "2025-11-05T14:57:46.92Z" },
+    { url = "https://files.pythonhosted.org/packages/08/24/6ea87fe682e115ffd296e91eb5c5a266349d1ee8414ce8ece3f99ec1ac84/google_re2-1.1.20251105-1-cp313-cp313-win_amd64.whl", hash = "sha256:0bcba63ad3ea8926fb0c71bb5044e33d405bb9395f5b5444393cd5f28f0bf6d3", size = 491734, upload-time = "2025-11-05T14:57:48.304Z" },
+    { url = "https://files.pythonhosted.org/packages/34/85/32ba71b06f3cf5f9856ae95b3d6463b971742453631a5ae2c5be338ea377/google_re2-1.1.20251105-1-cp313-cp313-win_arm64.whl", hash = "sha256:64ee189ea857f2126c5e42073cfa9b03e9f4cbaf073edbedb575059074841aa0", size = 642654, upload-time = "2025-11-05T14:57:49.602Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7f/7eb238bdcd06182b5f427afd305cf413b7cf4ea71047308bbf35912cf923/google_re2-1.1.20251105-1-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:cc151cf6a585d9ebe711da32b23683fcff40f78db8c8587c7f4b209ef4658809", size = 484719, upload-time = "2025-11-05T14:57:51.326Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/62/eed28eab67f939f4b9383c47b1db11638ade6ac30785c15cb960de85ba43/google_re2-1.1.20251105-1-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:7e2186d2c90488c1e11895343941f35ca2f58e9ba6c6b034fd531abe22ef77cc", size = 517698, upload-time = "2025-11-05T14:57:52.597Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/16/a1e6768513f788bf9c67a1cfe379ef34a793983eee46e4b653e42b558b78/google_re2-1.1.20251105-1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:41be22359c3dceb582937739b4365dd8e279de24ad0a5b10e653503abaff2ed7", size = 486421, upload-time = "2025-11-05T14:57:53.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fc/7a97ffd36d451e5a8bfaff2f9022b14807795d588f98227ff96e8da99856/google_re2-1.1.20251105-1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:f3168d7bbac247c862ea85b2f3c011d3a04bedcb6892b37f14d488f4133b206e", size = 519037, upload-time = "2025-11-05T14:57:55.078Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ee/8b6f7d94bb689dafdf60de8dd8f8f6296ad40d4d15c933fcda4da7a3a06b/google_re2-1.1.20251105-1-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:79ce664038194a31bbcf422137f9607ae3d9946a5cff98cf0efbeb7f9411e64b", size = 483373, upload-time = "2025-11-05T14:57:56.297Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a6/16a09e03d1de128f821869e4252688c21319f5017d9209f4d0e71ea5c951/google_re2-1.1.20251105-1-cp314-cp314-macosx_15_0_x86_64.whl", hash = "sha256:0476b07421b8882b279d5ceb5b760c15c62d581ded95274697fc1227e3869ee6", size = 510167, upload-time = "2025-11-05T14:57:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/9d/213dce5de401527369fb5af11096b18c06001d9eb71f3318fe5eba1ec706/google_re2-1.1.20251105-1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85feec3161ffdc12f6b144e37a2f91f80b771c72ffadde60191e89a49f6d7e81", size = 573176, upload-time = "2025-11-05T14:57:59.211Z" },
+    { url = "https://files.pythonhosted.org/packages/03/be/a8def96aa4a80b233e105767d22e3de961dcde5a04f0a05cb4f3ddb4df78/google_re2-1.1.20251105-1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7bfaa2cf55daf0c5c650e68526bb20b61e37d7f3ae53f6893013acc1c91c116", size = 591483, upload-time = "2025-11-05T14:58:00.416Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ea/144bbc4b9359da89aec07b4c2a91a6bfe7119914885386577c665b07bb01/google_re2-1.1.20251105-1-cp314-cp314-win32.whl", hash = "sha256:214c1accdc60fff9ce1bf812b157147ca361844f496ed9e0d5f357b0e562ced8", size = 433773, upload-time = "2025-11-05T14:58:01.594Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/74e301211699f1b650ba7690a3e4e52146ac4266fcd62f3ea0a945b9eda4/google_re2-1.1.20251105-1-cp314-cp314-win_amd64.whl", hash = "sha256:6d4d5fdadd329a2ed193463899d00ef2fd126172f36a4c01c9def271f19801b6", size = 491893, upload-time = "2025-11-05T14:58:02.969Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d1/4adcfcb9c95e3d064c9f7aaf6cb3a4fc842d86115014b9d4094db4d465b5/google_re2-1.1.20251105-1-cp314-cp314-win_arm64.whl", hash = "sha256:1d27f3a2a947ec1f721d0f14f661108acfd4f4d34f357ce28db951cc036656e5", size = 643093, upload-time = "2025-11-05T14:58:05.761Z" },
 ]
 
 [[package]]
@@ -2709,6 +2777,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/8a/1e8ea5e8bab2a65fa95bd36229ef38e8723ec46e430e20ca2d953487a7f1/langsmith-0.8.3.tar.gz", hash = "sha256:767ff7a8d136ed42926bf99059ac631dc6883542d6e3104b32e71c7625e1fa05", size = 4460330, upload-time = "2026-05-07T19:56:56.18Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/a9/51e644c1f1dbc3dd7d22dfd6412eab206d538c81e024e4f287373544bdcb/langsmith-0.8.3-py3-none-any.whl", hash = "sha256:b2e40e308222fa0beb2dccee3b4b30bfee9062d7a4f20a3e3e93df3c51a08ab4", size = 399048, upload-time = "2026-05-07T19:56:53.994Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]
@@ -4151,6 +4228,66 @@ wheels = [
 ]
 
 [[package]]
+name = "pendulum"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/72/9a51afa0a822b09e286c4cb827ed7b00bc818dac7bd11a5f161e493a217d/pendulum-3.2.0.tar.gz", hash = "sha256:e80feda2d10fa3ff8b1526715f7d33dcb7e08494b3088f2c8a3ac92d4a4331ce", size = 86912, upload-time = "2026-01-30T11:22:24.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/27/a4be6ec12161b503dd036f8d7cc57f8626170ae31bb298038be9af0001ce/pendulum-3.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5d775cc608c909ad415c8e789c84a9f120bb6a794c4215b2d8d910893cf0ec6a", size = 337923, upload-time = "2026-01-30T11:20:51.61Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e1/2a214e18355ec2a6ce3f683a97eecdb6050866ff3a6cf165d411450aeb1b/pendulum-3.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8de794a7f665aebc8c1ba4dd4b05ab8fe1a36ce9c0498366adf1d1edd79b2686", size = 327379, upload-time = "2026-01-30T11:20:53.085Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/01/7392e58ebc1d9e70b987dc8bb0c89710b47ac8125067efe7aa4c420b616f/pendulum-3.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bac7df7696e1c942e17c0556b3a7bcdd1d7aa5b24faee7620cb071e754a0622", size = 340115, upload-time = "2026-01-30T11:20:54.635Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/80de84c5ca1a3e4f7f3b75090c9b61b6dbb6d095e302ee592cebbaf0bbfb/pendulum-3.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db0f6a8a04475d9cba26ce701e7d66d266fd97227f2f5f499270eba04be1c7e9", size = 373969, upload-time = "2026-01-30T11:20:56.209Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e4/f7b4c1818927ab394a2a0a9b7011f360a0a75839a22678833c5bc0a84183/pendulum-3.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c352c63c1ff05f2198409b28498d7158547a8be23e1fbd4aa2cf5402fb239b55", size = 379058, upload-time = "2026-01-30T11:20:57.618Z" },
+    { url = "https://files.pythonhosted.org/packages/36/94/9947cf710620afcc68751683f2f8de88d902505e7c13c0349d7e9d362f97/pendulum-3.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de8c1ad1d1aa7d4ceae341528bab35a0f8c88a5aa63f2f5d84e16b517d1b32c2", size = 348403, upload-time = "2026-01-30T11:20:59.56Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/12/0e6ba0bb00fa57907af2a3fca8643bded5dba1e87072d50673776a0d6ed2/pendulum-3.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1ba955511c12fec2252038b0c866c25c0c30b720bf74d3023710f121e42b1498", size = 517457, upload-time = "2026-01-30T11:21:01.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/fe/dae5fbfe67bd41d943def0ad8f1e7f6988aa8e527255e433cd7c494f9ad5/pendulum-3.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4115bf364a2ec6d5ddc476751ceaa4164a04f2c15589f0d29aa210ddb784b15d", size = 561103, upload-time = "2026-01-30T11:21:03.924Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a0/8f646160b98abfc19152505af19bd643a4279ec2bdbe0959f16b7025fc6b/pendulum-3.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:4151a903356413fdd9549de0997b708fb95a214ed97803ffb479ffd834088378", size = 260595, upload-time = "2026-01-30T11:21:05.495Z" },
+    { url = "https://files.pythonhosted.org/packages/79/01/feead7af9ded7a13f2d798fb6573e70f469113eafcd8cc8f59671584ca3e/pendulum-3.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:acfdee9ddc56053cb7c8c075afbfde0857322d09e56a56195b9cd127fae87e4c", size = 255382, upload-time = "2026-01-30T11:21:06.847Z" },
+    { url = "https://files.pythonhosted.org/packages/41/56/dd0ea9f97d25a0763cda09e2217563b45714786118d8c68b0b745395d6eb/pendulum-3.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bf0b489def51202a39a2a665dcc4162d5e46934a740fe4c4fe3068979610156c", size = 337830, upload-time = "2026-01-30T11:21:08.298Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/98/83d62899bf7226fc12396de4bc1fb2b5da27e451c7c60790043aaf8b4731/pendulum-3.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:937a529aa302efa18dcf25e53834964a87ffb2df8f80e3669ab7757a6126beaf", size = 327574, upload-time = "2026-01-30T11:21:09.715Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fa/ff2aa992b23f0543c709b1a3f3f9ed760ec71fd02c8bb01f93bf008b52e4/pendulum-3.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85c7689defc65c4dc29bf257f7cca55d210fabb455de9476e1748d2ab2ae80d7", size = 339891, upload-time = "2026-01-30T11:21:11.089Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4e/25b4fa11d19503d50d7b52d7ef943c0f20fd54422aaeb9e38f588c815c50/pendulum-3.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d5e216e5a412563ea2ecf5de467dcf3d02717947fcdabe6811d5ee360726b02b", size = 373726, upload-time = "2026-01-30T11:21:12.493Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/30/0acad6396c4e74e5c689aa4f0b0c49e2ecdcfce368e7b5bf35ca1c0fc61a/pendulum-3.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a2af22eeec438fbaac72bb7fba783e0950a514fba980d9a32db394b51afccec", size = 379827, upload-time = "2026-01-30T11:21:14.08Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f7/e6a2fdf2a23d59b4b48b8fa89e8d4bf2dd371aea2c6ba8fcecec20a4acb9/pendulum-3.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3159cceb54f5aa8b85b141c7f0ce3fac8bdd1ffdc7c79e67dca9133eac7c4d11", size = 348921, upload-time = "2026-01-30T11:21:15.816Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f2/c15fa7f9ad4e181aa469b6040b574988bd108ccdf4ae509ad224f9e4db44/pendulum-3.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c39ea5e9ffa20ea8bae986d00e0908bd537c8468b71d6b6503ab0b4c3d76e0ea", size = 517188, upload-time = "2026-01-30T11:21:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c7/5f80b12ee88ec26e930c3a5a602608a63c29cf60c81a0eb066d583772550/pendulum-3.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e5afc753e570cce1f44197676371f68953f7d4f022303d141bb09f804d5fe6d7", size = 561833, upload-time = "2026-01-30T11:21:19.232Z" },
+    { url = "https://files.pythonhosted.org/packages/90/15/1ac481626cb63db751f6281e294661947c1f0321ebe5d1c532a3b51a8006/pendulum-3.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:fd55c12560816d9122ca2142d9e428f32c0c083bf77719320b1767539c7a3a3b", size = 258725, upload-time = "2026-01-30T11:21:20.558Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/50b0398d7d027eb70a3e1e336de7b6e599c6b74431cb7d3863287e1292bb/pendulum-3.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:faef52a7ed99729f0838353b956f3fabf6c550c062db247e9e2fc2b48fcb9457", size = 253089, upload-time = "2026-01-30T11:21:22.497Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8c/400c8b8dbd7524424f3d9902ded64741e82e5e321d1aabbd68ade89e71cf/pendulum-3.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:addb0512f919fe5b70c8ee534ee71c775630d3efe567ea5763d92acff857cfc3", size = 337820, upload-time = "2026-01-30T11:21:24.305Z" },
+    { url = "https://files.pythonhosted.org/packages/59/38/7c16f26cc55d9206d71da294ce6857d0da381e26bc9e0c2a069424c2b173/pendulum-3.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3aaa50342dc174acebdc21089315012e63789353957b39ac83cac9f9fc8d1075", size = 327551, upload-time = "2026-01-30T11:21:25.747Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cd/f36ec5d56d55104232380fdbf84ff53cc05607574af3cbdc8a43991ac8a7/pendulum-3.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:927e9c9ab52ff68e71b76dd410e5f1cd78f5ea6e7f0a9f5eb549aea16a4d5354", size = 339894, upload-time = "2026-01-30T11:21:27.229Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/b9a1e546519c3a92d5bc17787cea925e06a20def2ae344fa136d2fc40338/pendulum-3.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:249d18f5543c9f43aba3bd77b34864ec8cf6f64edbead405f442e23c94fce63d", size = 373766, upload-time = "2026-01-30T11:21:28.642Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a6/6471ab87ae2260594501f071586a765fc894817043b7d2d4b04e2eff4f31/pendulum-3.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c644cc15eec5fb02291f0f193195156780fd5a0affd7a349592403826d1a35e", size = 379837, upload-time = "2026-01-30T11:21:30.637Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/79/0ba0c14e862388f7b822626e6e989163c23bebe7f96de5ec4b207cbe7c3d/pendulum-3.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:063ab61af953bb56ad5bc8e131fd0431c915ed766d90ccecd7549c8090b51004", size = 348904, upload-time = "2026-01-30T11:21:32.436Z" },
+    { url = "https://files.pythonhosted.org/packages/17/34/df922c7c0b12719589d4954bfa5bdca9e02bcde220f5c5c1838a87118960/pendulum-3.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:26a3ae26c9dd70a4256f1c2f51addc43641813574c0db6ce5664f9861cd93621", size = 517173, upload-time = "2026-01-30T11:21:34.428Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ec/3b9e061eeee97b72a47c1434ee03f6d85f0284d9285d92b12b0fff2d19ac/pendulum-3.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:2b10d91dc00f424444a42f47c69e6b3bfd79376f330179dc06bc342184b35f9a", size = 561744, upload-time = "2026-01-30T11:21:35.861Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7e/f12fdb6070b7975c1fcfa5685dbe4ab73c788878a71f4d1d7e3c87979e37/pendulum-3.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:63070ff03e30a57b16c8e793ee27da8dac4123c1d6e0cf74c460ce9ee8a64aa4", size = 258746, upload-time = "2026-01-30T11:21:37.782Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/5abd872056357f069ae34a9b24a75ac58e79092d16201d779a8dd31386bb/pendulum-3.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:c8dde63e2796b62070a49ce813ce200aba9186130307f04ec78affcf6c2e8122", size = 253028, upload-time = "2026-01-30T11:21:39.381Z" },
+    { url = "https://files.pythonhosted.org/packages/82/99/5b9cc823862450910bcb2c7cdc6884c0939b268639146d30e4a4f55eb1f1/pendulum-3.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c17ac069e88c5a1e930a5ae0ef17357a14b9cc5a28abadda74eaa8106d241c8e", size = 338281, upload-time = "2026-01-30T11:21:40.812Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/3a/64a35260f6ac36c0ad50eeb5f1a465b98b0d7603f79a5c2077c41326d639/pendulum-3.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e1fbb540edecb21f8244aebfb05a1f2333ddc6c7819378c099d4a61cc91ae93c", size = 328030, upload-time = "2026-01-30T11:21:42.778Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6b/1140e09310035a2afb05bb90a2b8fbda9d3222e03b92de9533123afe6b65/pendulum-3.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8c67fb9a1fe8fc1adae2cc01b0c292b268c12475b4609ff4aed71c9dd367b4d", size = 340206, upload-time = "2026-01-30T11:21:44.148Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4a/a493de56cbc24a64b21ac6ba98513a9ec5c67daa3dba325e39a8e53f30d8/pendulum-3.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:baa9a66c980defda6cfe1275103a94b22e90d83ebd7a84cc961cee6cbd25a244", size = 373976, upload-time = "2026-01-30T11:21:45.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4c/f083c4fd1a161d4ab218680cc906338c541497b3098373f2241f58c429cb/pendulum-3.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef8f783fa7a14973b0596d8af2a5b2d90858a55030e9b4c6885eb4284b88314f", size = 380075, upload-time = "2026-01-30T11:21:46.959Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b6/333a0fcb33bf15eb879a46a11ce6300c1698a141e689665fe430783ff8d6/pendulum-3.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7d2e9bfb065727d8676e7ada3793b47a24349500a5e9637404355e482c822be", size = 349026, upload-time = "2026-01-30T11:21:48.271Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1a/dfb526ec0cba1e7cd6a5e4f4dd64a6ada7428d1449c54b15f7b295f6e122/pendulum-3.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:55d7ba6bb74171c3ee409bf30076ee3a259a3c2bb147ac87ebb76aaa3cf5d3a2", size = 517395, upload-time = "2026-01-30T11:21:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/37/b4f2b5f1200351c4869b8b46ad5c21019e3dbe0417f5867ae969fad7b5fe/pendulum-3.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:a50d8cf42f06d3d8c3f8bb2a7ac47fa93b5145e69de6a7209be6a47afdd9cf76", size = 561926, upload-time = "2026-01-30T11:21:51.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9e/567376582da58f5fe8e4f579db2bcfbf243cf619a5825bdf1023ad1436b3/pendulum-3.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e5bbb92b155cd5018b3cf70ee49ed3b9c94398caaaa7ed97fe41e5bb5a968418", size = 258817, upload-time = "2026-01-30T11:21:53.074Z" },
+    { url = "https://files.pythonhosted.org/packages/95/67/dfffd7eb50d67fa821cd4d92cf71575ead6162930202bc40dfcedf78c38c/pendulum-3.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:d53134418e04335c3029a32e9341cccc9b085a28744fb5ee4e6a8f5039363b1a", size = 253292, upload-time = "2026-01-30T11:21:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0d/d5ac8468a1b40f09a62d6e91654088de432367907579dd161c0fb1bdf222/pendulum-3.2.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9585594d32faa71efa5a78f576f1ee4f79e9c5340d7c6f0cd6c5dfe725effaaa", size = 338760, upload-time = "2026-01-30T11:22:12.225Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e5/7fa8c8be6caac8e0be78fbe7668df571f44820ed779cb3736fab645fcba8/pendulum-3.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:26401e2de77c437e8f3b6160c08c6c5d45518d906f8f9b48fd7cb5aa0f4e2aff", size = 328333, upload-time = "2026-01-30T11:22:13.811Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/78/73a1031b7d1bf7986e8e655cea3f018164b3470aecfea25a4074e77dda73/pendulum-3.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:637e65af042f383a2764a886aa28ccc6f853bf7a142df18e41c720542934c13b", size = 340841, upload-time = "2026-01-30T11:22:15.278Z" },
+    { url = "https://files.pythonhosted.org/packages/49/40/4e36e9074e92b0164c088b9ada3c02bfea386d83e24fa98b30fe9b6e61a8/pendulum-3.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6e46c28f4d067233c4a4c42748f4ffa641d9289c09e0e81488beb6d4b3fab51", size = 348959, upload-time = "2026-01-30T11:22:16.718Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/8bf7fcb91b526e1efe17d047faa845709b88800fff915ff848ff26054293/pendulum-3.2.0-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:71d46bcc86269f97bfd8c5f1475d55e717696a0a010b1871023605ca94624031", size = 518102, upload-time = "2026-01-30T11:22:18.2Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b0/a36c468d2d0dec62ddea7c5e4177e93abb12f48ac90f09f24d0581c5189f/pendulum-3.2.0-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5cd956d4176afc7bfe8a91bf3f771b46ff8d326f6c5bf778eb5010eb742ebba6", size = 561884, upload-time = "2026-01-30T11:22:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4d/dad105261898907bf806cabca53d3878529a9fa2c0d5d7f95f2035246fc2/pendulum-3.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:39ef129d7b90aab49708645867abdd207b714ba7bff12dae549975b0aca09716", size = 261236, upload-time = "2026-01-30T11:22:21.059Z" },
+    { url = "https://files.pythonhosted.org/packages/02/fb/d65db067a67df7252f18b0cb7420dda84078b9e8bfb375215469c14a50be/pendulum-3.2.0-py3-none-any.whl", hash = "sha256:f3a9c18a89b4d9ef39c5fa6a78722aaff8d5be2597c129a3b16b9f40a561acf3", size = 114111, upload-time = "2026-01-30T11:22:22.361Z" },
+]
+
+[[package]]
 name = "phonenumbers"
 version = "9.0.27"
 source = { registry = "https://pypi.org/simple" }
@@ -4276,12 +4413,13 @@ wheels = [
 
 [[package]]
 name = "pocketpaw"
-version = "0.4.16"
+version = "0.4.18"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "anthropic" },
     { name = "apscheduler" },
+    { name = "cel-python" },
     { name = "claude-agent-sdk" },
     { name = "click" },
     { name = "cryptography" },
@@ -4596,6 +4734,7 @@ requires-dist = [
     { name = "botbuilder-integration-aiohttp", marker = "extra == 'dev'", specifier = ">=4.16.0" },
     { name = "botbuilder-integration-aiohttp", marker = "extra == 'teams'", specifier = ">=4.16.0" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.34.0" },
+    { name = "cel-python", specifier = ">=0.5.0" },
     { name = "chromadb", marker = "extra == 'vector'" },
     { name = "claude-agent-sdk", specifier = ">=0.1.72" },
     { name = "click", specifier = ">=8.0" },


### PR DESCRIPTION
Lands the Pydantic v2 PocketTemplate model as the schema chokepoint for every Pocket Template the platform loads, plus the v1 to v2 migration of the six bundled templates.

## Summary

- Introduces `PocketTemplate` (Pydantic v2) at `src/pocketpaw/bundled_templates/schema.py` as the single validation seam. Every load path (loader, future CLI lint, future Registry) goes through this model.
- Adds the `_promote_v1_to_v2` translation pass in `loader.py` so v1 templates on disk keep loading forever. Promotion runs before validation, so the model only ever sees v2-shaped dicts.
- Adds `strict: bool = False` to `load_template`. `strict=False` (default) preserves the existing log-warning + return-None contract every EE consumer pattern-matches on. `strict=True` raises `TemplateValidationError` for the CLI lint and tests.
- Treats CEL expressions on `saved_views[].filter`, `columns[].filter`, `triggers[].filter` / `.when`, and `instinct_rules.rules[].when` as parse-at-validation only, not evaluation. `celpy.CELParser` is the parse engine. The runtime owns evaluation against a real row / workspace context.
- Migrates the six bundled templates to v2 in the same PR (per RFC 03 Appendix B) so they double as canonical v2 fixtures.

## RFC compliance

Closes from RFC 03 v2:
- "Schema version" section plus the v1 to v2 translation table, implemented as `_promote_v1_to_v2`.
- "Schema reference", every top-level v2 field plus every sub-schema modeled as a Pydantic class.
- "Expression grammar", CEL parse-as-validation via the `CelExpression` typed alias.
- "Style and tooling notes", Pydantic v2 model at the named path; private translation function in the loader.
- Appendix A (`discovery-review-v1` worked example) and Appendix B (todo-task-tracker v1 to v2 worked example) covered by the test suite.

Explicitly deferred to later PRs:
- `pocketpaw template lint / publish / install / migrate / diff / upgrade` CLI.
- paw-enterprise `cel-js` evaluator (separate repo).
- Fabric `tier:registered` / `via_link` registry enforcement (needs Fabric integration).
- `ee/cloud/pockets/` runtime composition + instinct resolution order execution.

## Files changed

**NEW**
- `src/pocketpaw/bundled_templates/schema.py`. `PocketTemplate` + 11 sub-models, three cross-field validators (shape × default_view matrix, outcomes_emitted subset, state.id_field resolves).
- `src/pocketpaw/bundled_templates/expressions.py`. `CelExpression` typed field, lazy celpy import.
- `src/pocketpaw/bundled_templates/errors.py`. `TemplateValidationError(ValueError)` carrying `slug` + `pydantic_error`.
- `tests/unit/test_template_schema.py`. 30 tests covering translation rules, fixture validation, Pydantic enforcement, CEL parse failure, cross-field rules, loader strict kwarg.
- `tests/fixtures/templates/lease-renewal-v2.yaml`. Canonical v2 worked example as a test fixture.

**MODIFIED**
- `src/pocketpaw/bundled_templates/loader.py`. Added `_promote_v1_to_v2` + `strict` kwarg. Return type still `dict | None`. Public signature backwards-compatible.
- `src/pocketpaw/bundled_templates/__init__.py`. Re-exports `PocketTemplate`, sub-models, `TemplateValidationError`.
- `tests/unit/test_bundled_templates.py`. Field-set widened to v2 (shape enum widened to 11 values); added per-slug `PocketTemplate.model_validate` test for the bundled set.
- `pyproject.toml` + `uv.lock`. Added `cel-python>=0.5.0`.

**MIGRATED (v1 to v2)**
- `_bundled/todo-task-tracker/template.pocket.yaml`
- `_bundled/kanban-board/template.pocket.yaml`
- `_bundled/metrics-dashboard/template.pocket.yaml`
- `_bundled/crm-record-list/template.pocket.yaml`
- `_bundled/calendar-planner/template.pocket.yaml`
- `_bundled/activity-feed/template.pocket.yaml`

Each migrated YAML adds `schema_version: "2"`, `display_name`, and `pattern` (pulled from `_bundled/index.json`), and renames `skills` to `skill_refs`. No behavioural change: the templates stay `tier:synthetic`, no joined_entities, no CEL filters.

`display_name` is set by hand on each YAML to match the gallery title in `index.json`. Two slugs would otherwise regress under the loader's title-case fallback: `crm-record-list` would become "Crm Record List" (loses the CRM acronym) and `todo-task-tracker` would become "Todo Task Tracker" (the gallery has shipped "Task Tracker" since launch). The fallback stays for external authors who omit `display_name`; the bundled set bypasses it.

## Test plan

- [ ] Targeted tests pass: `cd pocketpaw && uv run pytest tests/unit/test_template_schema.py tests/unit/test_bundled_templates.py -xvs`. Expected: 63 passed, 5 skipped (EE-only `importorskip`).
- [ ] Ruff is clean: `uv run ruff check src/pocketpaw/bundled_templates/ tests/unit/test_template_schema.py tests/unit/test_bundled_templates.py`.
- [ ] Manual smoke. Each of the six bundled templates loads through `strict=True` without raising:
  ```python
  from pathlib import Path
  import tempfile
  from pocketpaw.bundled_templates.installer import install_bundled_templates
  from pocketpaw.bundled_templates.loader import load_template
  with tempfile.TemporaryDirectory() as td:
      install_bundled_templates(destination_root=Path(td))
      for slug in ['todo-task-tracker', 'kanban-board', 'metrics-dashboard',
                   'crm-record-list', 'calendar-planner', 'activity-feed']:
          assert load_template(slug, templates_dir=Path(td), strict=True) is not None
  ```
- [ ] v1 promotion path stays exercised. Drop a v1-shaped YAML (no `schema_version`, uses `skills`) into a templates dir, load with `strict=True`, assert the returned `meta` is v2-shaped (`schema_version == "2"`, `skill_refs` present, `display_name` synthesized, `pattern` resolved).
- [ ] Loader back-compat. Bad template + default kwargs returns `None` (no raise). EE callers using `pocketpaw.bundled_templates.load_template(slug)` keep working unchanged.

## Out-of-scope

Intentionally not in this PR. Each is a separate follow-up:

- **CLI surface** (`pocketpaw template lint / publish / install / migrate / diff / upgrade`). The Pydantic model is the chokepoint the CLI will sit on. This PR ships the chokepoint; the CLI lands next.
- **paw-enterprise `cel-js` evaluator**. JS-side parity is a different repo and a different PR. Today the schema validates CEL on the Python side only; the runtime evaluator already exists per-call site.
- **Fabric `tier:registered` / `via_link` registry enforcement**. The schema accepts arbitrary `entity_type` strings today. Once Fabric exposes the ObjectType registry, a separate PR adds the lookup. All shipped bundled templates are `tier:synthetic` regardless.
- **`ee/cloud/pockets/` runtime composition + Instinct resolution order execution** (steps 1-5 documented in the RFC). The model declares the per-action and per-rule shape; the runtime change is a separate PR sitting on top of this schema.

Tested under Python 3.12.1, Pydantic 2.12.5, cel-python 0.5.0.
