### PR TITLE
feat(decisions): RFC 07 Slice 1 — DecisionProjection + Python API substrate

### DIFF
--- a/docs/c4/model.json
+++ b/docs/c4/model.json
@@ -268,6 +268,13 @@
                 "description": "JavaScript-based utilities and client-side functionality.",
                 "technology": "JavaScript",
                 "kb_article": "deps-fastapi-dependency-injection-layer-for-cloud-router-authentication-and-auth"
+              },
+              {
+                "id": "decision-graph",
+                "name": "Decision Graph",
+                "description": "Materializes decision chains from journal events into queryable Decisions. Provides Python API for audit, trace, and explainability.",
+                "technology": "Python/SQLite",
+                "kb_article": "audit-decisions-materialized-graph-over-journal-event-chains-for-trace-and-explain"
               }
             ]
           }
@@ -396,6 +403,24 @@
         "source": "daemon",
         "target": "pocketpaw",
         "description": "imports pocketpaw",
+        "style": "sync"
+      },
+      {
+        "source": "decision-graph",
+        "target": "bus",
+        "description": "subscribes to journal events to fold decisions",
+        "style": "async"
+      },
+      {
+        "source": "decision-graph",
+        "target": "audit",
+        "description": "is the queryable audit log — decisions, traces, lineage",
+        "style": "sync"
+      },
+      {
+        "source": "api",
+        "target": "decision-graph",
+        "description": "exposes decisions via REST surface (Slice 2)",
         "style": "sync"
       },
       {

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -200,6 +200,7 @@ def mount_cloud(app: FastAPI) -> None:
 
     app.include_router(pockets_journal_stream_router, prefix="/api/v1")
 
+    from pocketpaw_ee.cloud.decisions.router import router as decisions_router
     from pocketpaw_ee.cloud.kb.router import router as kb_router
     from pocketpaw_ee.cloud.livekit.router import router as livekit_router
     from pocketpaw_ee.cloud.mission_control.router import router as mission_control_router
@@ -222,6 +223,10 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(livekit_router, prefix="/api/v1")
     # Pocket outcomes — GET /api/v1/outcomes count surface (RFC 05 M2b.2).
     app.include_router(outcomes_router, prefix="/api/v1")
+    # Decision graph — Slice 1 ships only GET /api/v1/decisions/_ping;
+    # the real REST surface (get/find/trace/downstream/timeline/explain)
+    # lands in RFC 07 Slice 2.
+    app.include_router(decisions_router, prefix="/api/v1")
 
     # Files Tab v2 — /api/v1/files/tree + /api/v1/files/browse. Mounted
     # inline (instead of via build_router's ctx_factory) so the routes can
@@ -480,6 +485,15 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.outcomes import service as _outcomes_service
 
     _get_bus().subscribe("pocket.outcome", _outcomes_service.record_outcome)
+
+    # Decision graph projection (RFC 07 Slice 1). Lazy-init the
+    # singleton DecisionGraph + projection so `GET /api/v1/decisions/_ping`
+    # and the in-process Python API (`get_decision_graph()`) work from
+    # process start. Slice 1 ships the substrate only — Slice 2 wires
+    # the journal-to-projection subscription that keeps the store live.
+    from pocketpaw_ee.cloud.decisions.service import init_decisions_projection
+
+    init_decisions_projection()
 
     # Tasks → notifications fan-out. When a Task is proposed to a human
     # assignee, drop an in-app notification so they see it even without

--- a/ee/pocketpaw_ee/cloud/decisions/__init__.py
+++ b/ee/pocketpaw_ee/cloud/decisions/__init__.py
@@ -1,0 +1,9 @@
+# __init__.py — Decision-graph entity package marker.
+# Created: 2026-05-25 (RFC 07 Slice 1) — the substrate that folds an
+#   N-event subgraph of the org journal (`agent.proposed`, `human.corrected`,
+#   `policy.evaluated`, `decision.graduated`, `decision.outcome_attached`)
+#   into one queryable Decision row + edge rows. Materialized in
+#   `~/.soul/decisions.db` (SQLite, WAL); queried via the in-process
+#   `DecisionGraph` Python API. Slice 1 ships the substrate (projection +
+#   store + Python API + smoke router). REST endpoints + narrator land in
+#   Slice 2 / Slice 3. See RFC 07 for the load-bearing contract.

--- a/ee/pocketpaw_ee/cloud/decisions/domain.py
+++ b/ee/pocketpaw_ee/cloud/decisions/domain.py
@@ -1,0 +1,258 @@
+# domain.py — Frozen value objects for the decision-graph entity.
+# Created: 2026-05-25 (RFC 07 Slice 1) — the load-bearing types for the
+#   whole Decision projection / query pipeline. Every other module hangs
+#   off these.
+#
+#   The Decision is the fold of an N-event journal subgraph into one
+#   queryable record. Hash-chained within `correlation_id` so tampering
+#   with one Decision invalidates every later one in the chain. Outcome
+#   is intentionally NOT in the hash so a late-landing
+#   `decision.outcome_attached` event can mutate it without breaking the
+#   chain.
+#
+#   Amendments applied (RFC 07 prototype-derived):
+#   - A1 (gap G1): `approvers` is `list[ApproverRef]`, not `list[Actor]`.
+#     `ApproverRef` carries `approved_at` + `position` so the SQL schema's
+#     `decision_approvers.approved_at` / `.position` columns have a domain
+#     home. Without this, every implementer rediscovers it on day 1.
+#   - G6 hash composition: see `_hash_material_v1` doc-comment below.
+#     The decision id (UUID v4) is the primary collision-defeater; the
+#     remaining fields are content-bound for tampering detection.
+#     `prev_hash` is included in the material so the chain links within
+#     `correlation_id`.
+#
+#   Multi-tenancy: `scope: list[str]` is required (min_length=1) per
+#   ee/cloud Rule 3 (domain enforces multi-tenancy at construction). A
+#   Decision cannot exist without at least one scope tag — the journal
+#   already requires it on every EventEntry.
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+from soul_protocol.spec.journal import Actor
+
+# ---------------------------------------------------------------------------
+# Type aliases mirroring the RFC's `ScopeKind`, `OutcomeStatus`,
+# `EdgeRelation` enums.
+# ---------------------------------------------------------------------------
+
+ScopeKind = Literal["workspace", "org", "pocket", "team"]
+OutcomeStatus = Literal["pending", "landed", "rejected", "abandoned"]
+EdgeRelation = Literal["precedent", "input", "approval", "outcome", "downstream"]
+InputKind = Literal["fabric_object", "dataref", "decision"]
+DecisionRelation = Literal["precedent", "downstream", "input"]
+
+
+# ---------------------------------------------------------------------------
+# Value objects on the Decision (RFC 07 "The Decision Object" section)
+# ---------------------------------------------------------------------------
+
+
+class InputRef(BaseModel):
+    """A fact considered when this decision was made (RFC lines 86-103).
+
+    Three input shapes:
+      - ``fabric_object`` — a Fabric record (Lease, Case, Patient, Vendor).
+      - ``dataref`` — a Zero-Copy reference (Salesforce row, Drive doc,
+        S3 object). Carries ``point_in_time`` because mutable inputs need
+        a snapshot the trace can anchor to.
+      - ``decision`` — a prior decision that literally fed data into
+        this one. Distinct from ``precedents`` (similar-shape templates).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: InputKind
+    id: str = Field(min_length=1)
+    label: str = ""
+    point_in_time: datetime | None = None
+
+
+class DecisionRef(BaseModel):
+    """A reference to another decision (RFC lines 105-116).
+
+    Used for ``precedents`` and the inverse ``downstream`` relation. Stored
+    as a denormalized edge row so trace traversal is index-driven, not a
+    recursive SQL CTE.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    decision_id: UUID
+    relation: DecisionRelation
+    weight: float = 1.0  # bigger = stronger precedent (used by explain ranker)
+
+
+class OutcomeRef(BaseModel):
+    """The outcome a decision resolved to (RFC lines 118-130).
+
+    ``None`` on initial Decision construction; populated by a later
+    ``decision.outcome_attached`` journal event. The hash chain excludes
+    outcome precisely so this mutation is safe.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    outcome_id: UUID
+    status: OutcomeStatus
+    landed_at: datetime | None = None
+    metered: bool = False
+
+
+class ApproverRef(BaseModel):
+    """An approval recorded on the Decision (RFC 07 amendment A1, gap G1).
+
+    The RFC's draft `Decision.approvers: list[Actor]` left no place to
+    land the `approved_at` timestamp that the SQL `decision_approvers`
+    table requires. `ApproverRef` lifts that field onto the domain so
+    Pydantic catches a missing timestamp at construction.
+
+    ``position`` is the approver's order in the chain — first approver = 0.
+    Used so "who approved first" is a query, not a guess.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    actor: Actor
+    approved_at: datetime
+    position: int = 0
+
+
+# ---------------------------------------------------------------------------
+# The Decision itself
+# ---------------------------------------------------------------------------
+
+
+class Decision(BaseModel):
+    """A first-class queryable decision (RFC 07 lines 132-168).
+
+    The fold of an N-event subgraph of the journal into one record.
+    Construction happens inside ``DecisionProjection._close_chain`` when a
+    terminal event (per A2: only ``decision.graduated``) lands on a
+    correlation_id that previously received ``agent.proposed``.
+
+    Multi-tenancy: ``scope`` is required (min_length=1). The journal
+    requires a non-empty scope on every EventEntry; the Decision inherits
+    that invariant at construction time.
+
+    Mutability: ``model_config = ConfigDict(frozen=False)`` is deliberate.
+    ``outcome`` mutates after first emit when ``decision.outcome_attached``
+    lands — the *only* post-emit mutation. The hash_link is computed
+    *without* outcome so the chain stays valid across that mutation.
+    """
+
+    model_config = ConfigDict(frozen=False)
+
+    id: UUID
+    ts: datetime  # tz-aware UTC; matches EventEntry.ts semantics
+    decided_by: Actor  # agent | user | system | root — reuses journal's Actor
+    scope: list[str] = Field(min_length=1)
+    scope_kind: ScopeKind = "pocket"
+    intent: str = Field(min_length=1)
+    action: str = Field(min_length=1)
+    inputs: list[InputRef] = Field(default_factory=list)
+    approvers: list[ApproverRef] = Field(default_factory=list)  # A1 (gap G1)
+    instinct_policy: str | None = None
+    instinct_policy_passed: bool | None = None
+    precedents: list[DecisionRef] = Field(default_factory=list)
+    outcome: OutcomeRef | None = None
+    payload: dict = Field(default_factory=dict)
+    pocket_id: str | None = None
+    correlation_id: UUID | None = None
+    hash_link: str = ""
+    last_seq: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Edge records (mirror the `decision_edges` SQLite schema in RFC § The
+# materialized store).
+# ---------------------------------------------------------------------------
+
+
+class DecisionEdgeRecord(BaseModel):
+    """One row in the `decision_edges` table — five edge kinds, all explicit.
+
+    The forward edge for ``downstream`` is **never written**; the inverse
+    of a ``precedent`` edge answers downstream queries via the
+    ``(target_id, relation='precedent')`` index. This keeps writes O(1)
+    per Decision while reads stay index-driven.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    src_id: UUID
+    target_id: str  # string because targets can be UUID *or* fabric_object id
+    relation: EdgeRelation
+    weight: float = 1.0
+
+
+# ---------------------------------------------------------------------------
+# Hash chain composition (RFC 07 amendment, gap G6)
+# ---------------------------------------------------------------------------
+
+
+def compute_hash_link(decision: Decision, prev_hash: str) -> str:
+    """Compute a decision's hash link per RFC 07 (amended for gap G6).
+
+    Composition:
+      sha256(id || ts || decided_by.id || action || sorted(input_ids) || prev_hash)
+
+    Why each part:
+      - ``id`` — UUID v4, primary collision-defeater. Two decisions with
+        identical content but different ids hash to different values.
+      - ``ts`` (ISO-8601) — content-bound; tampering with the timestamp
+        invalidates the hash.
+      - ``decided_by.id`` — content-bound; rewriting the actor breaks
+        the chain.
+      - ``action`` — content-bound; renaming the action breaks the chain.
+      - ``sorted(input_ids)`` — content-bound; swapping inputs breaks
+        the chain. Sort so ordering of `inputs[]` is irrelevant to the
+        hash.
+      - ``prev_hash`` — chain link within ``correlation_id``. Tampering
+        with one Decision invalidates every later Decision in the same
+        correlation chain.
+
+    Why some fields are **excluded** from the hash:
+      - ``outcome`` — mutates after first emit (RFC 07 line 144). If
+        outcome were in the hash, the late-landing
+        ``decision.outcome_attached`` event would invalidate the chain.
+      - ``approvers`` — the RFC excludes; in practice approvers land
+        before the terminal event so they could be in the hash, but
+        keeping them out keeps the chain symmetric with the
+        outcome-late-attach case.
+      - ``payload`` — opaque to the graph; not indexed; not hashed.
+      - ``precedents`` — supplied by the proposer; A3 fallback can add
+        more after the fact (same-pocket / same-action / nearest-ts).
+        Excluding from the hash keeps the precedent-fallback path safe.
+    """
+
+    h = hashlib.sha256()
+    h.update(str(decision.id).encode())
+    h.update(decision.ts.isoformat().encode())
+    h.update(decision.decided_by.id.encode())
+    h.update(decision.action.encode())
+    for input_id in sorted(i.id for i in decision.inputs):
+        h.update(input_id.encode())
+    if prev_hash:
+        h.update(prev_hash.encode())
+    return h.hexdigest()
+
+
+__all__ = [
+    "ApproverRef",
+    "Decision",
+    "DecisionEdgeRecord",
+    "DecisionRef",
+    "DecisionRelation",
+    "EdgeRelation",
+    "InputKind",
+    "InputRef",
+    "OutcomeRef",
+    "OutcomeStatus",
+    "ScopeKind",
+    "compute_hash_link",
+]

--- a/ee/pocketpaw_ee/cloud/decisions/dto.py
+++ b/ee/pocketpaw_ee/cloud/decisions/dto.py
@@ -1,0 +1,114 @@
+# dto.py — Request / response DTOs for the decision-graph REST surface.
+# Created: 2026-05-25 (RFC 07 Slice 1) — skeletons only. Slice 1 ships the
+#   in-process Python API (`DecisionGraph` in service.py) which returns
+#   `Decision` domain objects directly. The REST router fills in shape
+#   in Slice 2 — these DTOs are the wire contract it will use.
+#
+# Why ship the DTOs now: Slice 2 work can start without re-deriving the
+# wire shape, and the import-linter contract (decisions/dto.py forbidden
+# from importing models.*) needs a real file to lint. Distinct
+# Request/Response per ee/cloud Rule 4.
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pocketpaw_ee.cloud.decisions.domain import (
+    Decision,
+    DecisionEdgeRecord,
+    OutcomeStatus,
+    ScopeKind,
+)
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/decisions  (Slice 2)
+# ---------------------------------------------------------------------------
+
+
+class DecisionsListRequest(BaseModel):
+    """Validated query for `GET /api/v1/decisions` (Slice 2).
+
+    ``workspace_id`` is taken from auth context, never the query.
+    Pagination is keyset-style (RFC perf budget — never OFFSET at scale):
+    ``before_ts`` + ``before_id`` carry the cursor from the previous page.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    actor: str | None = None
+    since: datetime | None = None
+    until: datetime | None = None
+    scope_kind: ScopeKind | None = None
+    pocket_id: str | None = None
+    policy: str | None = None
+    outcome_status: OutcomeStatus | None = None
+    input_id: str | None = None
+    limit: int = Field(default=50, ge=1, le=200)
+    # keyset pagination cursor (sort key: ts DESC, id DESC). Slice 2 wires.
+    before_ts: datetime | None = None
+    before_id: str | None = None
+
+
+class DecisionsListResponse(BaseModel):
+    """List response. ``total`` is post-scope-filter — never the
+    pre-filter count (RFC 07 § Privacy + audit; matches FabricProjection
+    invariant).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    decisions: list[Decision] = Field(default_factory=list)
+    total: int = 0
+    next_before_ts: datetime | None = None
+    next_before_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/decisions/:id/trace  (Slice 2)
+# ---------------------------------------------------------------------------
+
+
+class DecisionTraceRequest(BaseModel):
+    """Validated query for `GET /api/v1/decisions/:id/trace?depth=N`."""
+
+    model_config = ConfigDict(frozen=True)
+
+    depth: int = Field(default=3, ge=1, le=10)
+    max_fanout: int = Field(default=20, ge=1, le=100)
+
+
+class TraceNodeWire(BaseModel):
+    """One node in the trace response wire shape (Slice 2)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    kind: str  # decision | fabric_object | dataref
+    decision: Decision | None = None
+    label: str = ""
+
+
+class DecisionTraceResponse(BaseModel):
+    """BFS trace response (Slice 2). ``truncated`` is set when any node
+    exceeded the fanout cap; ``truncated_count`` reports how many edges
+    were dropped (RFC 07 amendment for gap G7).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    root: str
+    nodes: dict[str, TraceNodeWire] = Field(default_factory=dict)
+    edges: list[DecisionEdgeRecord] = Field(default_factory=list)
+    truncated: bool = False
+    truncated_count: int = 0
+    depth_reached: int = 0
+
+
+__all__ = [
+    "DecisionTraceRequest",
+    "DecisionTraceResponse",
+    "DecisionsListRequest",
+    "DecisionsListResponse",
+    "TraceNodeWire",
+]

--- a/ee/pocketpaw_ee/cloud/decisions/projection.py
+++ b/ee/pocketpaw_ee/cloud/decisions/projection.py
@@ -1,0 +1,594 @@
+# projection.py — Fold journal events into Decisions + edge rows.
+# Created: 2026-05-25 (RFC 07 Slice 1) — the read path that turns the
+#   append-only journal into queryable Decision objects. Ported from the
+#   /tmp/team-rfc07 prototype (8 green tests there) but rewritten for:
+#     - SQLite store (DecisionStore) instead of in-memory dicts
+#     - A1 — `approvers: list[ApproverRef]` carrying approved_at + position
+#     - A2 — ONLY `decision.graduated` closes a chain. Fabric writes
+#       (`fabric.object.*`) CONTRIBUTE inputs but do NOT close. This
+#       decouples the projection from Fabric's namespace.
+#     - A3 — Precedent supply order: (1) agent payload first, (2)
+#       projection fallback same-pocket / same-action / nearest-ts.
+#       Out-of-band reconciler deferred.
+#     - G6 — hash chain includes prev_hash (see domain.compute_hash_link).
+#
+#   Contract mirrors FabricProjection (src/pocketpaw/fabric/projection.py):
+#     - rebuild(journal, since_seq=0): full or incremental replay
+#     - apply(entry): incremental single-event update
+#     - cursor property for restart catch-up
+#   The instance is process-local; SQLite handles cross-process via WAL
+#   but a single writer is the only safe pattern (one projection per org).
+#
+#   Note on `decision.outcome_attached`: that event action is being added
+#   to soul-protocol's ACTION_NAMESPACES in a parallel PR (Slice 0). The
+#   projection consumes it as a STRING LITERAL here — when Slice 0
+#   merges, no code change is needed; the namespace registration is
+#   advisory, not enforced.
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from soul_protocol.spec.journal import Actor, EventEntry
+
+from pocketpaw_ee.cloud.decisions.domain import (
+    ApproverRef,
+    Decision,
+    DecisionEdgeRecord,
+    DecisionRef,
+    InputRef,
+    OutcomeRef,
+    compute_hash_link,
+)
+from pocketpaw_ee.cloud.decisions.store import DecisionStore
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Action namespace constants
+# ---------------------------------------------------------------------------
+# A2 (gap G2): ONLY `decision.graduated` closes a chain. Fabric writes
+# CONTRIBUTE inputs but do NOT close. Rejection chains end on
+# `decision.graduated` too — the payload carries `passed=false`.
+_TERMINAL_ACTIONS = frozenset({"decision.graduated"})
+
+# Fabric write actions — they don't close a chain (A2) but they do
+# contribute the target object as an InputRef so the decision row carries
+# "this is the object the write hit."
+_FABRIC_WRITE_ACTIONS = frozenset(
+    {
+        "fabric.object.created",
+        "fabric.object.updated",
+        "fabric.object.archived",
+    }
+)
+
+# The full set the projection cares about; everything else is dropped.
+_TRACKED_ACTIONS = (
+    frozenset(
+        {
+            "agent.proposed",
+            "human.corrected",
+            "policy.evaluated",
+            # String literal — namespace registration lives in Slice 0.
+            "decision.outcome_attached",
+        }
+    )
+    | _TERMINAL_ACTIONS
+    | _FABRIC_WRITE_ACTIONS
+)
+
+
+# ---------------------------------------------------------------------------
+# Pending-chain bookkeeping
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PendingChain:
+    """In-flight decision chain — accumulates events under one
+    correlation_id until a `decision.graduated` event closes it."""
+
+    correlation_id: UUID
+    intent: str = ""
+    action: str = ""
+    decided_by: Actor | None = None
+    scope: list[str] = field(default_factory=list)
+    pocket_id: str | None = None
+    inputs: list[InputRef] = field(default_factory=list)
+    approvers: list[ApproverRef] = field(default_factory=list)
+    instinct_policy: str | None = None
+    instinct_policy_passed: bool | None = None
+    precedent_hints: list[DecisionRef] = field(default_factory=list)
+    last_seq: int = 0
+    proposed_at: datetime | None = None
+    payload_acc: dict[str, Any] = field(default_factory=dict)
+    # A2: if the chain saw a `fabric.object.*` write the projection
+    # records the target object as an additional input — but the chain
+    # stays open until `decision.graduated` lands.
+    fabric_write_payload: dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Projection
+# ---------------------------------------------------------------------------
+
+
+class DecisionProjection:
+    """Replay journal events and materialize Decision rows + edge rows.
+
+    Wire contract matches FabricProjection:
+      - one instance per process (per org)
+      - `rebuild(journal, since_seq=0)` for full / incremental replay
+      - `apply(entry)` for inline per-event update inside the journal
+        write path
+      - `cursor` property surfaces the latest seen seq for restart catch-up
+    """
+
+    def __init__(self, store: DecisionStore | None = None) -> None:
+        self._store = store if store is not None else DecisionStore()
+        self._pending: dict[UUID, _PendingChain] = {}
+        self._last_hash_per_correlation: dict[UUID, str] = {}
+        self._cursor: int = self._store.get_cursor()
+
+    @property
+    def store(self) -> DecisionStore:
+        return self._store
+
+    @property
+    def cursor(self) -> int:
+        return self._cursor
+
+    # --- rebuild / apply ----------------------------------------------------
+
+    def rebuild(self, journal_iter: Iterable[EventEntry], *, since_seq: int = 0) -> int:
+        """Replay events. Returns count applied. If `since_seq == 0`, the
+        store is reset first.
+
+        Idempotence: applying the same entry twice produces the same
+        Decision rows (the chain's `correlation_id` is the dedup key
+        within the projection's pending dict; once the chain emits, the
+        store's `INSERT OR REPLACE` handles re-emission). A rebuild from
+        seq=0 yields the same final state as an incremental replay from
+        any intermediate cursor — pinned by `test_rebuild_idempotent`.
+        """
+        if since_seq == 0:
+            self._store.reset()
+            self._pending = {}
+            self._last_hash_per_correlation = {}
+            self._cursor = 0
+            # Re-hydrate the per-correlation last hash from the store on
+            # incremental replay so the chain links across restarts.
+        else:
+            self._rehydrate_correlation_state()
+
+        applied = 0
+        for entry in journal_iter:
+            entry_seq = getattr(entry, "seq", None)
+            # Skip events whose seq is at or below the cursor — but if
+            # the entry has no seq at all (older soul-protocol wheels
+            # don't expose it yet), apply unconditionally. The cursor
+            # itself only advances when seq is present.
+            if entry_seq is not None and entry_seq <= since_seq:
+                continue
+            self.apply(entry)
+            applied += 1
+        return applied
+
+    def _rehydrate_correlation_state(self) -> None:
+        """Refill the per-correlation `last_hash` map from the store after
+        an incremental restart. Without this, hash chain `prev_hash` would
+        be empty for the first new event after a restart, breaking the
+        chain. We only need the LAST hash per correlation."""
+        # Cheap scan — group by correlation_id, pick the latest by ts.
+        # The schema has an index on correlation_id; the count is bounded
+        # by the number of open + recently-closed chains.
+        for decision in self._store.iter_decisions():
+            if decision.correlation_id is None:
+                continue
+            self._last_hash_per_correlation[decision.correlation_id] = decision.hash_link
+
+    def apply(self, entry: EventEntry) -> Decision | None:
+        """Fold one event. Returns a Decision when a chain closes
+        (`decision.graduated`), or when a `decision.outcome_attached`
+        mutates an already-emitted Decision, or for a degenerate
+        single-write Decision (no correlation_id). Returns None while a
+        chain is still accumulating.
+        """
+        if entry.action not in _TRACKED_ACTIONS:
+            return None
+
+        seq = getattr(entry, "seq", None) or 0
+        if seq > self._cursor:
+            self._cursor = seq
+            # Persist so a restart skips this event without re-applying.
+            try:
+                self._store.set_cursor(seq)
+            except Exception:  # pragma: no cover — store IO errors logged but non-fatal here
+                logger.warning("failed to persist decision-projection cursor", exc_info=True)
+
+        # Special-case the late outcome attach — doesn't accumulate into a
+        # pending chain; mutates an already-emitted Decision in place.
+        if entry.action == "decision.outcome_attached":
+            return self._apply_outcome_attached(entry)
+
+        correlation_id = entry.correlation_id
+        if correlation_id is None:
+            # RFC line 274 — degenerate Decision: a one-off Fabric write
+            # with no correlation. The graph still represents it, the
+            # explain narrator still has something to say.
+            if entry.action in _FABRIC_WRITE_ACTIONS:
+                return self._emit_degenerate(entry)
+            # Other actions without a correlation aren't actionable.
+            logger.debug(
+                "decision projection: %s without correlation_id — dropped",
+                entry.action,
+            )
+            return None
+
+        chain = self._pending.get(correlation_id)
+        if chain is None:
+            chain = _PendingChain(correlation_id=correlation_id)
+            self._pending[correlation_id] = chain
+        chain.last_seq = max(chain.last_seq, seq)
+
+        if entry.action == "agent.proposed":
+            self._fold_proposed(chain, entry)
+        elif entry.action == "human.corrected":
+            self._fold_corrected(chain, entry)
+        elif entry.action == "policy.evaluated":
+            self._fold_policy(chain, entry)
+        elif entry.action in _FABRIC_WRITE_ACTIONS:
+            # A2: contribute, do not close.
+            self._fold_fabric_write(chain, entry)
+        elif entry.action in _TERMINAL_ACTIONS:
+            return self._close_chain(chain, entry)
+        return None
+
+    # --- fold helpers -------------------------------------------------------
+
+    def _fold_proposed(self, chain: _PendingChain, entry: EventEntry) -> None:
+        payload = entry.payload or {}
+        chain.intent = payload.get("intent", chain.intent) or chain.intent
+        chain.action = payload.get("action", chain.action) or chain.action or "propose"
+        chain.decided_by = entry.actor
+        chain.scope = list(entry.scope)
+        chain.pocket_id = payload.get("pocket_id", chain.pocket_id)
+        chain.proposed_at = entry.ts
+
+        # inputs in payload: list of {kind, id, label?, point_in_time?} or
+        # bare-string ids (assumed fabric_object).
+        for raw in payload.get("inputs", []) or []:
+            if isinstance(raw, dict):
+                try:
+                    chain.inputs.append(
+                        InputRef(
+                            kind=raw.get("kind", "fabric_object"),
+                            id=raw["id"],
+                            label=raw.get("label", ""),
+                            point_in_time=_parse_dt(raw.get("point_in_time")),
+                        )
+                    )
+                except (KeyError, ValueError):
+                    continue
+            elif isinstance(raw, str):
+                chain.inputs.append(InputRef(kind="fabric_object", id=raw))
+
+        # A3 path 1: agent supplies precedents in the proposed payload.
+        for raw in payload.get("precedents", []) or []:
+            if not isinstance(raw, dict):
+                continue
+            try:
+                chain.precedent_hints.append(
+                    DecisionRef(
+                        decision_id=UUID(raw["decision_id"]),
+                        relation="precedent",
+                        weight=float(raw.get("weight", 1.0)),
+                    )
+                )
+            except (KeyError, ValueError):
+                continue
+
+        # Payload bag — keep the agent's free-form data for the narrator.
+        data = payload.get("data")
+        if isinstance(data, dict):
+            chain.payload_acc.update(data)
+
+    def _fold_corrected(self, chain: _PendingChain, entry: EventEntry) -> None:
+        chain.approvers.append(
+            ApproverRef(
+                actor=entry.actor,
+                approved_at=entry.ts,
+                position=len(chain.approvers),
+            )
+        )
+        note = (entry.payload or {}).get("note")
+        if note:
+            chain.payload_acc.setdefault("approver_notes", []).append(
+                {"actor": entry.actor.id, "note": note}
+            )
+
+    def _fold_policy(self, chain: _PendingChain, entry: EventEntry) -> None:
+        """Each `policy.evaluated` event overrides the chain's current
+        policy state. The *last* policy seen before terminal close is
+        what counts (RFC line 264). A rejection only sticks if the last
+        observed state is `passed=False`. We stash the rejection reason
+        whenever a fail event lands so the narrator has it even if a
+        later pass overrides — the payload remembers "we considered
+        this, here's why instinct first balked." `has_rejection` is
+        re-derived from `instinct_policy_passed` at close time, so a
+        false→true sequence (instinct asked for human → human approved →
+        instinct re-checked → passed) ends with `has_rejection=False`.
+        """
+        payload = entry.payload or {}
+        policy_name = payload.get("policy")
+        if policy_name:
+            chain.instinct_policy = policy_name
+            passed = bool(payload.get("passed", False))
+            chain.instinct_policy_passed = passed
+            if not passed:
+                reason = payload.get("reason")
+                if reason:
+                    chain.payload_acc["rejection_reason"] = reason
+
+    def _fold_fabric_write(self, chain: _PendingChain, entry: EventEntry) -> None:
+        """A2: a fabric write contributes the target object as an input
+        AND records the canonical write payload, but does NOT close the
+        chain. The chain stays open until `decision.graduated` lands."""
+        payload = entry.payload or {}
+        chain.fabric_write_payload = dict(payload)
+        target = payload.get("object_id")
+        if target and not any(i.id == target for i in chain.inputs):
+            chain.inputs.append(InputRef(kind="fabric_object", id=target, label=str(target)))
+
+    # --- close --------------------------------------------------------------
+
+    def _close_chain(self, chain: _PendingChain, terminal: EventEntry) -> Decision | None:
+        """Emit a Decision row + its edge rows in a single transaction."""
+        if chain.decided_by is None:
+            # Chain closed without ever seeing `agent.proposed` — nothing
+            # to emit. This can happen on a malformed event stream; log
+            # and drop so the projection stays available.
+            logger.warning(
+                "decision projection: chain %s closed without proposed event — skipping",
+                chain.correlation_id,
+            )
+            self._pending.pop(chain.correlation_id, None)
+            return None
+
+        decision_id = uuid4()
+        scope_kind = _infer_scope_kind(chain.scope, chain.pocket_id)
+
+        # Derive rejection from the freshest available signal:
+        #   1. terminal `decision.graduated` payload's `passed` flag (if set)
+        #   2. fall back to the LAST observed `instinct_policy_passed`
+        # A chain that went policy(fail) → human → policy(pass) → graduated
+        # ends with `instinct_policy_passed=True` and is NOT rejected.
+        terminal_payload = terminal.payload or {}
+        terminal_passed = terminal_payload.get("passed")
+        if terminal_passed is False:
+            rejected = True
+        elif terminal_passed is True:
+            rejected = False
+        else:
+            rejected = chain.instinct_policy_passed is False
+
+        outcome: OutcomeRef | None = None
+        if rejected:
+            outcome = OutcomeRef(
+                outcome_id=uuid4(),
+                status="rejected",
+                landed_at=terminal.ts,
+                metered=False,
+            )
+
+        decision = Decision(
+            id=decision_id,
+            ts=chain.proposed_at or terminal.ts,
+            decided_by=chain.decided_by,
+            scope=chain.scope,
+            scope_kind=scope_kind,
+            intent=chain.intent or "(no intent recorded)",
+            action=chain.action or "graduated",
+            inputs=chain.inputs,
+            approvers=chain.approvers,
+            instinct_policy=chain.instinct_policy,
+            instinct_policy_passed=chain.instinct_policy_passed,
+            precedents=list(chain.precedent_hints),  # A3 path 1
+            outcome=outcome,
+            payload=chain.payload_acc,
+            pocket_id=chain.pocket_id,
+            correlation_id=chain.correlation_id,
+            last_seq=chain.last_seq,
+        )
+
+        # G6 hash chain — include prev_hash within correlation_id.
+        prev = self._last_hash_per_correlation.get(chain.correlation_id, "")
+        decision.hash_link = compute_hash_link(decision, prev)
+        self._last_hash_per_correlation[chain.correlation_id] = decision.hash_link
+
+        # A3 path 2: precedent fallback if payload empty. Only attempt
+        # when the agent didn't supply ANY precedents and the chain has
+        # a pocket_id to scope the lookup.
+        if not decision.precedents and decision.pocket_id and not rejected:
+            fallback = self._fallback_precedents(decision)
+            decision.precedents = fallback
+
+        edges = self._build_edges(decision)
+        self._store.upsert_decision(decision, edges=edges)
+
+        self._pending.pop(chain.correlation_id, None)
+        return decision
+
+    def _emit_degenerate(self, entry: EventEntry) -> Decision:
+        """A one-off fabric write with no correlation — emit a minimal
+        Decision so the graph still has a node for it (RFC line 274)."""
+        decision_id = uuid4()
+        payload = entry.payload or {}
+        obj_id = payload.get("object_id", "unknown")
+        decision = Decision(
+            id=decision_id,
+            ts=entry.ts,
+            decided_by=entry.actor,
+            scope=list(entry.scope),
+            scope_kind=_infer_scope_kind(list(entry.scope), None),
+            intent=f"Direct write to {obj_id}",
+            action=entry.action,
+            inputs=[InputRef(kind="fabric_object", id=str(obj_id), label=str(obj_id))],
+            payload=dict(payload),
+            correlation_id=None,
+            last_seq=(getattr(entry, "seq", None) or 0),
+        )
+        decision.hash_link = compute_hash_link(decision, "")
+        edges = self._build_edges(decision)
+        self._store.upsert_decision(decision, edges=edges)
+        return decision
+
+    def _apply_outcome_attached(self, entry: EventEntry) -> Decision | None:
+        """Mutate the outcome on an existing Decision. Hash chain is
+        preserved (outcome isn't in the hash material)."""
+        payload = entry.payload or {}
+        decision_id_raw = payload.get("decision_id")
+        if not decision_id_raw:
+            logger.warning("outcome_attached without decision_id — dropped")
+            return None
+        try:
+            decision_id = UUID(decision_id_raw)
+        except (ValueError, TypeError):
+            logger.warning(
+                "outcome_attached with invalid decision_id %r — dropped",
+                decision_id_raw,
+            )
+            return None
+
+        existing = self._store.get_decision(decision_id)
+        if existing is None:
+            logger.warning("outcome_attached for unknown decision %s — dropped", decision_id)
+            return None
+
+        outcome_id_raw = payload.get("outcome_id")
+        try:
+            outcome_id = UUID(outcome_id_raw) if outcome_id_raw else uuid4()
+        except (ValueError, TypeError):
+            outcome_id = uuid4()
+
+        outcome = OutcomeRef(
+            outcome_id=outcome_id,
+            status=payload.get("status", "landed"),
+            landed_at=_parse_dt(payload.get("landed_at")) or entry.ts,
+            metered=bool(payload.get("metered", False)),
+        )
+        self._store.update_outcome(decision_id, outcome)
+        # Return the refreshed Decision so callers can act on it.
+        return self._store.get_decision(decision_id)
+
+    # --- edges --------------------------------------------------------------
+
+    def _build_edges(self, decision: Decision) -> list[DecisionEdgeRecord]:
+        """Build the edge rows the Decision contributes to the graph."""
+        edges: list[DecisionEdgeRecord] = []
+        # precedent edges (forward; downstream queries read these inversely)
+        for p in decision.precedents:
+            edges.append(
+                DecisionEdgeRecord(
+                    src_id=decision.id,
+                    target_id=str(p.decision_id),
+                    relation="precedent",
+                    weight=p.weight,
+                )
+            )
+        # input edges
+        for inp in decision.inputs:
+            edges.append(
+                DecisionEdgeRecord(
+                    src_id=decision.id,
+                    target_id=inp.id,
+                    relation="input",
+                    weight=1.0,
+                )
+            )
+        # approval edges (one per approver — actor id as the target)
+        for app in decision.approvers:
+            edges.append(
+                DecisionEdgeRecord(
+                    src_id=decision.id,
+                    target_id=app.actor.id,
+                    relation="approval",
+                    weight=1.0,
+                )
+            )
+        # outcome edge — only emitted when an outcome is present at first
+        # emit (rejection). Late-attach uses store.update_outcome which
+        # writes the edge separately.
+        if decision.outcome is not None:
+            edges.append(
+                DecisionEdgeRecord(
+                    src_id=decision.id,
+                    target_id=str(decision.outcome.outcome_id),
+                    relation="outcome",
+                    weight=1.0,
+                )
+            )
+        return edges
+
+    def _fallback_precedents(self, decision: Decision) -> list[DecisionRef]:
+        """A3 path 2: same-pocket + same-action + nearest-ts (top 3).
+        Weights decay 0.95 → 0.85 → 0.75 by recency rank."""
+        if not decision.pocket_id:
+            return []
+        siblings = [
+            d
+            for d in self._store.iter_decisions(
+                pocket_id=decision.pocket_id,
+            )
+            if d.id != decision.id and d.action == decision.action and d.ts < decision.ts
+        ]
+        # iter_decisions already sorts by ts DESC — take the top 3.
+        out: list[DecisionRef] = []
+        for i, sib in enumerate(siblings[:3]):
+            weight = round(0.95 - (i * 0.1), 2)
+            out.append(
+                DecisionRef(
+                    decision_id=sib.id,
+                    relation="precedent",
+                    weight=weight,
+                )
+            )
+        return out
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_dt(v: Any) -> datetime | None:
+    if v is None or isinstance(v, datetime):
+        return v
+    if isinstance(v, str):
+        try:
+            return datetime.fromisoformat(v.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def _infer_scope_kind(scope: list[str], pocket_id: str | None) -> str:
+    if pocket_id:
+        return "pocket"
+    for s in scope:
+        if s.startswith("pocket:"):
+            return "pocket"
+        if s.startswith("team:"):
+            return "team"
+        if s.startswith("org:"):
+            return "org"
+    return "workspace"
+
+
+__all__ = ["DecisionProjection"]

--- a/ee/pocketpaw_ee/cloud/decisions/router.py
+++ b/ee/pocketpaw_ee/cloud/decisions/router.py
@@ -1,0 +1,46 @@
+# router.py — FastAPI router skeleton for the decision-graph entity.
+# Created: 2026-05-25 (RFC 07 Slice 1) — SKELETON only. Slice 1 ships the
+#   in-process Python API; Slice 2 wires the real REST endpoints:
+#
+#     GET  /api/v1/decisions/:id
+#     GET  /api/v1/decisions
+#     GET  /api/v1/decisions/:id/trace
+#     GET  /api/v1/decisions/:id/downstream
+#     GET  /api/v1/decisions/:id/timeline
+#     POST /api/v1/decisions/explain
+#
+#   Slice 1 ships ONE placeholder route — `GET /api/v1/decisions/_ping`
+#   — that returns the projection cursor + row count. It exists so
+#   operators can smoke-test that the projection bootstrap fired without
+#   waiting on Slice 2. Thin: never `raise HTTPException`; CloudError →
+#   JSON is the contract.
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud.decisions.service import get_decision_graph
+from pocketpaw_ee.cloud.license import require_license
+
+router = APIRouter(
+    prefix="/decisions",
+    tags=["Decisions"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.get("/_ping")
+async def decisions_ping() -> dict[str, Any]:
+    """Smoke endpoint — returns projection cursor + row count.
+
+    Slice 1-only. Slice 2 replaces this with the real REST surface.
+    Intentionally unauthenticated beyond the license gate so an
+    operator can curl it.
+    """
+    graph = get_decision_graph()
+    return {
+        "status": "ok",
+        "cursor": graph.projection.cursor,
+        "decisions": graph.store.count(),
+    }

--- a/ee/pocketpaw_ee/cloud/decisions/service.py
+++ b/ee/pocketpaw_ee/cloud/decisions/service.py
@@ -1,0 +1,458 @@
+# service.py — In-process Python API + projection bootstrap for the decision graph.
+# Created: 2026-05-25 (RFC 07 Slice 1) — the surface pockets, agents, and
+#   jobs call. Exposes four methods on a `DecisionGraph` class:
+#
+#     - get(decision_id, requester_scopes=...)         → Decision | None
+#     - find(actor=, since=, until=, scope_kind=,
+#            pocket_id=, policy=, outcome_status=,
+#            input_id=, limit=, before_ts=, before_id=,
+#            requester_scopes=...)                     → list[Decision]
+#     - trace(decision_id, depth=, max_fanout=,
+#             requester_scopes=...)                    → TraceResult
+#     - downstream(decision_id, depth=,
+#                  requester_scopes=...)               → TraceResult
+#
+#   `explain` (NL Q&A with narrator) lives in Slice 3 and is intentionally
+#   NOT on this surface yet.
+#
+# Scope-filter-post-count invariant
+# ---------------------------------
+# Every read filters by scope BEFORE counting. The store exposes
+# unfiltered iterators; this service is the one place that enforces the
+# scope filter. A caller cannot probe for hidden decisions by comparing
+# pre- and post-filter counts because no pre-filter count is ever
+# computed here. This mirrors `FabricProjection.query`'s contract
+# (`src/pocketpaw/fabric/projection.py`) that closed the #938 pagination
+# leak.
+#
+# Pagination
+# ----------
+# Keyset-style on (ts DESC, id DESC) per RFC 07's perf budget. The
+# `find` method takes `before_ts` + `before_id` cursors from the prior
+# page; OFFSET-based pagination is avoided because it gets pathologically
+# slow at scale. The reference implementation is small enough that we
+# load the filtered set into memory then slice — the RFC's index design
+# means the filtered set is bounded by the most-selective axis.
+#
+# Bootstrap
+# ---------
+# `init_decisions_projection()` lazily creates the singleton projection
+# + store on first call. `mount_cloud()` invokes this after
+# `init_realtime()` per the ee/cloud bootstrap convention. Tests get a
+# fresh projection per fixture by calling `reset_projection_for_tests()`.
+from __future__ import annotations
+
+import logging
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pocketpaw_ee.cloud.decisions.domain import (
+    Decision,
+    DecisionEdgeRecord,
+    OutcomeStatus,
+    ScopeKind,
+)
+from pocketpaw_ee.cloud.decisions.projection import DecisionProjection
+from pocketpaw_ee.cloud.decisions.store import DecisionStore
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Trace result shape — domain-side; the wire DTO lives in dto.py
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TraceNode:
+    """One node in a depth-bounded trace. Either a Decision (with the
+    full domain object hydrated) or an external input (no Decision)."""
+
+    id: str
+    kind: Literal["decision", "fabric_object", "dataref", "actor"]
+    decision: Decision | None = None
+    label: str = ""
+
+
+@dataclass
+class TraceResult:
+    """Depth-bounded BFS over the decision graph. `truncated` is set
+    when any node hit the fanout cap; `truncated_count` reports how many
+    edges were dropped (RFC 07 amendment for gap G7)."""
+
+    root: UUID
+    nodes: dict[str, TraceNode] = field(default_factory=dict)
+    edges: list[DecisionEdgeRecord] = field(default_factory=list)
+    truncated: bool = False
+    truncated_count: int = 0
+    depth_reached: int = 0
+
+
+# ---------------------------------------------------------------------------
+# DecisionGraph — the Python API
+# ---------------------------------------------------------------------------
+
+
+class DecisionGraph:
+    """In-process Python API over the materialized decision store.
+
+    One instance per process (per org). Wire via the module-level
+    singleton (`get_decision_graph()`); tests get a fresh instance by
+    calling `reset_projection_for_tests()` then re-fetching.
+    """
+
+    def __init__(
+        self,
+        store: DecisionStore | None = None,
+        projection: DecisionProjection | None = None,
+    ) -> None:
+        if store is None and projection is None:
+            store = DecisionStore()
+            projection = DecisionProjection(store=store)
+        elif projection is None:
+            projection = DecisionProjection(store=store)
+        elif store is None:
+            store = projection.store
+        self._store = store
+        self._projection = projection
+
+    @property
+    def projection(self) -> DecisionProjection:
+        return self._projection
+
+    @property
+    def store(self) -> DecisionStore:
+        return self._store
+
+    # --- single lookup -----------------------------------------------------
+
+    async def get(
+        self,
+        decision_id: UUID,
+        *,
+        requester_scopes: list[str] | None = None,
+    ) -> Decision | None:
+        """Return one Decision or None. Returns None outside the
+        caller's scope (no "exists but hidden" probe)."""
+        decision = self._store.get_decision(decision_id)
+        if decision is None:
+            return None
+        if not _visible(decision, requester_scopes):
+            return None
+        return decision
+
+    # --- multi-axis filter -------------------------------------------------
+
+    async def find(
+        self,
+        *,
+        actor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        scope_kind: ScopeKind | None = None,
+        pocket_id: str | None = None,
+        policy: str | None = None,
+        outcome_status: OutcomeStatus | None = None,
+        input_id: str | None = None,
+        limit: int = 50,
+        before_ts: datetime | None = None,
+        before_id: str | None = None,
+        requester_scopes: list[str] | None = None,
+    ) -> list[Decision]:
+        """Index-driven multi-axis filter. Keyset pagination on
+        (ts DESC, id DESC). The store does the row selection; this
+        method applies the scope filter post-fetch and the keyset
+        cursor pre-truncate.
+
+        Scope filter is the load-bearing invariant: it runs BEFORE the
+        limit slice, so a caller cannot infer hidden-row counts by
+        comparing the requested limit to the returned length.
+        """
+        if limit < 1:
+            limit = 1
+        elif limit > 200:
+            limit = 200
+
+        # Stream the unfiltered candidates; apply the scope filter and
+        # cursor here. The store's iter is already sorted (ts DESC, id DESC).
+        results: list[Decision] = []
+        for d in self._store.iter_decisions(
+            actor=actor,
+            pocket_id=pocket_id,
+            policy=policy,
+            outcome_status=outcome_status,
+            scope_kind=scope_kind,
+            since=since,
+            until=until,
+            input_id=input_id,
+        ):
+            if not _visible(d, requester_scopes):
+                continue
+            if before_ts is not None:
+                # Keyset: skip rows that aren't strictly before the cursor.
+                if d.ts > before_ts:
+                    continue
+                if d.ts == before_ts and before_id is not None:
+                    if str(d.id) >= before_id:
+                        continue
+            results.append(d)
+            if len(results) >= limit:
+                break
+        return results
+
+    # --- trace upstream ----------------------------------------------------
+
+    async def trace(
+        self,
+        decision_id: UUID,
+        *,
+        depth: int = 3,
+        max_fanout: int = 20,
+        requester_scopes: list[str] | None = None,
+    ) -> TraceResult:
+        """Depth-bounded BFS walking `precedent` and `input` edges
+        upstream. Approval + outcome edges are surfaced (the narrator
+        wants them) but not walked further — they're terminal labels.
+
+        Cycle defense: a `visited` set blocks revisits. Precedent edges
+        cannot cycle (older-ts requirement) but the defense is cheap.
+        """
+        if depth < 1:
+            depth = 1
+        elif depth > 10:
+            depth = 10
+
+        root = self._store.get_decision(decision_id)
+        if root is None or not _visible(root, requester_scopes):
+            return TraceResult(root=decision_id)
+
+        result = TraceResult(root=decision_id)
+        result.nodes[str(decision_id)] = TraceNode(
+            id=str(decision_id), kind="decision", decision=root
+        )
+
+        visited: set[str] = set()
+        queue: deque[tuple[str, int]] = deque([(str(decision_id), 0)])
+
+        while queue:
+            cur_id, cur_depth = queue.popleft()
+            if cur_id in visited:
+                continue
+            visited.add(cur_id)
+            result.depth_reached = max(result.depth_reached, cur_depth)
+            if cur_depth >= depth:
+                continue
+
+            try:
+                cur_uuid = UUID(cur_id)
+            except ValueError:
+                continue  # external input node, not walkable
+
+            outgoing = self._store.edges_from(cur_uuid)
+            if len(outgoing) > max_fanout:
+                # G7: deterministic order — precedents first (by weight
+                # DESC), then inputs by insertion order, then approval
+                # / outcome. We approximate by sorting precedents by
+                # weight DESC and keeping insertion order otherwise.
+                precedents = sorted(
+                    [e for e in outgoing if e.relation == "precedent"],
+                    key=lambda e: -e.weight,
+                )
+                others = [e for e in outgoing if e.relation != "precedent"]
+                ranked = precedents + others
+                kept = ranked[:max_fanout]
+                dropped = ranked[max_fanout:]
+                outgoing = kept
+                result.truncated = True
+                result.truncated_count += len(dropped)
+
+            for edge in outgoing:
+                if edge.relation in {"approval", "outcome"}:
+                    # surface as terminal nodes; don't walk further
+                    result.edges.append(edge)
+                    if edge.target_id not in result.nodes:
+                        kind: Literal["decision", "fabric_object", "dataref", "actor"] = (
+                            "actor" if edge.relation == "approval" else "dataref"
+                        )
+                        result.nodes[edge.target_id] = TraceNode(
+                            id=edge.target_id,
+                            kind=kind,
+                            label=edge.target_id,
+                        )
+                    continue
+
+                result.edges.append(edge)
+
+                if edge.relation == "precedent":
+                    try:
+                        target_uuid = UUID(edge.target_id)
+                    except ValueError:
+                        continue
+                    target = self._store.get_decision(target_uuid)
+                    if target is not None and _visible(target, requester_scopes):
+                        if edge.target_id not in result.nodes:
+                            result.nodes[edge.target_id] = TraceNode(
+                                id=edge.target_id,
+                                kind="decision",
+                                decision=target,
+                            )
+                        queue.append((edge.target_id, cur_depth + 1))
+                elif edge.relation == "input":
+                    # external input — UUID-ish input ids are rare; treat
+                    # most as fabric_object stubs.
+                    if edge.target_id not in result.nodes:
+                        result.nodes[edge.target_id] = TraceNode(
+                            id=edge.target_id,
+                            kind="fabric_object",
+                            label=edge.target_id,
+                        )
+        return result
+
+    # --- downstream --------------------------------------------------------
+
+    async def downstream(
+        self,
+        decision_id: UUID,
+        *,
+        depth: int = 3,
+        requester_scopes: list[str] | None = None,
+    ) -> TraceResult:
+        """Decisions that later cited this one as a precedent. Reads the
+        inverse of the precedent index: `(target_id, relation='precedent')`.
+        """
+        if depth < 1:
+            depth = 1
+        elif depth > 10:
+            depth = 10
+
+        root = self._store.get_decision(decision_id)
+        if root is None or not _visible(root, requester_scopes):
+            return TraceResult(root=decision_id)
+
+        result = TraceResult(root=decision_id)
+        result.nodes[str(decision_id)] = TraceNode(
+            id=str(decision_id), kind="decision", decision=root
+        )
+
+        visited: set[str] = set()
+        queue: deque[tuple[str, int]] = deque([(str(decision_id), 0)])
+
+        while queue:
+            cur_id, cur_depth = queue.popleft()
+            if cur_id in visited:
+                continue
+            visited.add(cur_id)
+            result.depth_reached = max(result.depth_reached, cur_depth)
+            if cur_depth >= depth:
+                continue
+
+            incoming = self._store.edges_to(cur_id, relation="precedent")
+            for edge in incoming:
+                src_str = str(edge.src_id)
+                # Re-stamp the edge as "downstream" so callers can render it
+                # correctly without re-deriving the inverse semantics.
+                result.edges.append(
+                    DecisionEdgeRecord(
+                        src_id=edge.src_id,
+                        target_id=cur_id,
+                        relation="downstream",
+                        weight=edge.weight,
+                    )
+                )
+                if src_str not in result.nodes:
+                    src_decision = self._store.get_decision(edge.src_id)
+                    if src_decision is not None and _visible(src_decision, requester_scopes):
+                        result.nodes[src_str] = TraceNode(
+                            id=src_str,
+                            kind="decision",
+                            decision=src_decision,
+                        )
+                        queue.append((src_str, cur_depth + 1))
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Scope filter — the load-bearing invariant
+# ---------------------------------------------------------------------------
+
+
+def _visible(decision: Decision, requester_scopes: list[str] | None) -> bool:
+    """Return True if the requester is allowed to see this decision.
+
+    None/[] is treated as "admin / unscoped" and sees everything. Any
+    non-empty list does an intersection-with-overlap on the decision's
+    scope tags — the same shape FabricProjection uses
+    (`pocketpaw.fabric.policy.visible`).
+    """
+    if not requester_scopes:
+        return True
+    return any(s in requester_scopes for s in decision.scope)
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton + bootstrap
+# ---------------------------------------------------------------------------
+
+
+_GRAPH: DecisionGraph | None = None
+
+
+def init_decisions_projection() -> DecisionGraph:
+    """Wire the singleton DecisionGraph + projection. Idempotent.
+
+    Called from `mount_cloud()` after `init_realtime()`. Subsequent
+    calls return the existing singleton — re-mounting (tests) does not
+    rebuild the store.
+
+    The projection's `rebuild()` is NOT invoked here. Slice 1 ships the
+    substrate; the rebuild + journal subscription that keeps the
+    projection live land in Slice 2 when the journal-to-projection
+    bus subscriber wires in. For now the store stays empty until a
+    caller (test or future Slice 2 wiring) feeds events via
+    `graph.projection.apply()`.
+    """
+    global _GRAPH
+    if _GRAPH is None:
+        _GRAPH = DecisionGraph()
+        logger.info(
+            "decisions projection initialized — cursor=%d count=%d",
+            _GRAPH.projection.cursor,
+            _GRAPH.store.count(),
+        )
+    return _GRAPH
+
+
+def get_decision_graph() -> DecisionGraph:
+    """Return the singleton DecisionGraph. Calls `init_decisions_projection`
+    if it hasn't run yet — safe in tests that import service.py without
+    going through `mount_cloud`."""
+    global _GRAPH
+    if _GRAPH is None:
+        return init_decisions_projection()
+    return _GRAPH
+
+
+def reset_projection_for_tests() -> None:
+    """Drop the singleton so the next call to `get_decision_graph()`
+    builds a fresh one. Tests use this in a fixture to get isolation
+    across test cases (combined with `set_db_path(tmp_path)`)."""
+    global _GRAPH
+    if _GRAPH is not None:
+        try:
+            _GRAPH.store.close()
+        except Exception:  # pragma: no cover
+            logger.warning("error closing decisions store on reset", exc_info=True)
+    _GRAPH = None
+
+
+__all__ = [
+    "DecisionGraph",
+    "TraceNode",
+    "TraceResult",
+    "get_decision_graph",
+    "init_decisions_projection",
+    "reset_projection_for_tests",
+]

--- a/ee/pocketpaw_ee/cloud/decisions/store.py
+++ b/ee/pocketpaw_ee/cloud/decisions/store.py
@@ -1,0 +1,649 @@
+# store.py — SQLite-backed materialized store for the decision graph.
+# Created: 2026-05-25 (RFC 07 Slice 1) — implements the DDL from RFC 07
+#   § "The materialized store" (lines 278-348). Four tables:
+#     - decisions          (one row per Decision)
+#     - decision_edges     (five edge kinds; the graph)
+#     - decision_inputs    (denormalized for fast input filtering)
+#     - decision_approvers (denormalized for "approved by X" queries)
+#
+#   WAL mode + 64 MB page cache per the RFC's perf budgets. The six
+#   indexes the RFC lists are created on bootstrap. JSON1 is used at
+#   read time for scope-tag overlap (`scope_tags ?| ?` — JSON array
+#   containment) so a per-request scope filter is one query.
+#
+#   The store lives at `~/.soul/decisions.db` per RFC § Architecture —
+#   sibling to the journal at `~/.soul/journal.db`. The path is
+#   overridable via `set_db_path` so tests write to a tmp file instead
+#   of the real home directory.
+#
+#   Why SQLite (not a graph engine): five edge kinds, depth-3 walks,
+#   bounded fanout. The RFC's Open Q "should we use Neo4j" answers "no"
+#   — SQLite + the right indexes wins on operator simplicity. See RFC
+#   § Performance + scale.
+#
+#   Multi-tenancy: one decisions.db per org, but the SAME db can hold
+#   decisions from multiple scope tags within the org. Every read
+#   filters by scope BEFORE counting (the scope-filter-post-count
+#   invariant from RFC § Privacy + audit). Calls in service.py guard
+#   this — store.py exposes raw reads + filtered reads, service.py
+#   always uses the filtered variant.
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+from collections.abc import Iterable
+from datetime import datetime
+from pathlib import Path
+from uuid import UUID
+
+from pocketpaw_ee.cloud.decisions.domain import (
+    ApproverRef,
+    Decision,
+    DecisionEdgeRecord,
+    DecisionRef,
+    InputRef,
+    OutcomeRef,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Module-level db path. Default is the canonical `~/.soul/decisions.db`;
+# tests call ``set_db_path(tmp_path / "decisions.db")``.
+_DB_PATH: Path = Path.home() / ".soul" / "decisions.db"
+
+
+def set_db_path(path: str | Path) -> None:
+    """Override the decisions store path (test seam)."""
+    global _DB_PATH
+    _DB_PATH = Path(path)
+
+
+def get_db_path() -> Path:
+    """Return the current decisions store path."""
+    return _DB_PATH
+
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS decisions (
+    id TEXT PRIMARY KEY,                  -- UUID v4
+    ts TEXT NOT NULL,                     -- ISO-8601 UTC
+    decided_by_kind TEXT NOT NULL,        -- agent | user | system | root
+    decided_by_id TEXT NOT NULL,
+    decided_by_scope_context TEXT NOT NULL, -- JSON array
+    scope_kind TEXT NOT NULL,             -- workspace | org | pocket | team
+    pocket_id TEXT,
+    intent TEXT NOT NULL,
+    action TEXT NOT NULL,
+    instinct_policy TEXT,
+    instinct_policy_passed INTEGER,       -- 0|1|NULL
+    outcome_id TEXT,
+    outcome_status TEXT,                  -- pending|landed|rejected|abandoned
+    outcome_landed_at TEXT,
+    outcome_metered INTEGER,              -- 0|1|NULL
+    payload TEXT NOT NULL,                -- JSON blob
+    correlation_id TEXT,
+    hash_link TEXT NOT NULL,
+    last_seq INTEGER NOT NULL,
+    scope_tags TEXT NOT NULL              -- JSON array of journal scope strings
+);
+
+CREATE INDEX IF NOT EXISTS idx_decisions_ts ON decisions(ts);
+CREATE INDEX IF NOT EXISTS idx_decisions_actor_ts ON decisions(decided_by_id, ts);
+CREATE INDEX IF NOT EXISTS idx_decisions_pocket_ts ON decisions(pocket_id, ts);
+CREATE INDEX IF NOT EXISTS idx_decisions_scope_ts ON decisions(scope_kind, ts);
+CREATE INDEX IF NOT EXISTS idx_decisions_policy_ts ON decisions(instinct_policy, ts);
+CREATE INDEX IF NOT EXISTS idx_decisions_outcome_ts ON decisions(outcome_status, ts);
+CREATE INDEX IF NOT EXISTS idx_decisions_correlation ON decisions(correlation_id);
+
+CREATE TABLE IF NOT EXISTS decision_edges (
+    src_id TEXT NOT NULL,
+    target_id TEXT NOT NULL,
+    relation TEXT NOT NULL,               -- precedent | input | approval | outcome
+    weight REAL NOT NULL DEFAULT 1.0,
+    PRIMARY KEY (src_id, target_id, relation),
+    FOREIGN KEY (src_id) REFERENCES decisions(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_edges_src_rel ON decision_edges(src_id, relation);
+CREATE INDEX IF NOT EXISTS idx_edges_tgt_rel ON decision_edges(target_id, relation);
+
+CREATE TABLE IF NOT EXISTS decision_inputs (
+    decision_id TEXT NOT NULL,
+    kind TEXT NOT NULL,                   -- fabric_object | dataref | decision
+    input_id TEXT NOT NULL,
+    label TEXT,
+    point_in_time TEXT,
+    PRIMARY KEY (decision_id, kind, input_id),
+    FOREIGN KEY (decision_id) REFERENCES decisions(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_inputs_id ON decision_inputs(input_id);
+
+CREATE TABLE IF NOT EXISTS decision_approvers (
+    decision_id TEXT NOT NULL,
+    approver_kind TEXT NOT NULL,
+    approver_id TEXT NOT NULL,
+    approver_scope_context TEXT NOT NULL, -- JSON array
+    approved_at TEXT NOT NULL,
+    position INTEGER NOT NULL,            -- order; first approver = 0
+    PRIMARY KEY (decision_id, position),
+    FOREIGN KEY (decision_id) REFERENCES decisions(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_approvers_id ON decision_approvers(approver_id);
+
+CREATE TABLE IF NOT EXISTS decision_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+"""
+
+
+class DecisionStore:
+    """SQLite-backed store for the materialized Decision graph.
+
+    One instance per process. Thread-safe for one writer + many readers
+    via SQLite's WAL mode. The projection (single-writer) calls `upsert`
+    + `add_edge` inside a transaction; the Python API (`service.py`)
+    calls the read methods.
+    """
+
+    def __init__(self, db_path: Path | str | None = None) -> None:
+        self._db_path = Path(db_path) if db_path is not None else _DB_PATH
+        self._lock = threading.Lock()  # serialize writes; SQLite WAL handles reads
+        self._conn: sqlite3.Connection | None = None
+        self._bootstrap()
+
+    # --- lifecycle -----------------------------------------------------------
+
+    def _bootstrap(self) -> None:
+        """Open the connection, set pragmas, create the schema if absent."""
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        # ``check_same_thread=False`` is needed because the projection's
+        # `apply()` may be called from the FastAPI request thread while
+        # `DecisionGraph.find()` reads from another. Writes are serialized
+        # by ``self._lock``; reads rely on SQLite WAL concurrency.
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False, isolation_level=None)
+        self._conn.row_factory = sqlite3.Row
+        # WAL mode + 64 MB page cache per RFC perf budget. ``synchronous
+        # = normal`` is the documented WAL choice — durable enough, fast
+        # for the high write rate the projection can produce on rebuild.
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.execute("PRAGMA synchronous = NORMAL")
+        self._conn.execute("PRAGMA cache_size = -64000")  # 64 MB
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        # Apply DDL — IF NOT EXISTS clauses make this idempotent.
+        self._conn.executescript(_DDL)
+
+    def close(self) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except sqlite3.Error:
+                logger.warning("error closing decisions store", exc_info=True)
+            self._conn = None
+
+    def reset(self) -> None:
+        """Drop all rows. Used by ``DecisionProjection.rebuild(since_seq=0)``
+        and by tests. Does NOT drop the schema — just truncates."""
+        with self._lock:
+            assert self._conn is not None
+            self._conn.execute("BEGIN")
+            try:
+                self._conn.execute("DELETE FROM decision_approvers")
+                self._conn.execute("DELETE FROM decision_inputs")
+                self._conn.execute("DELETE FROM decision_edges")
+                self._conn.execute("DELETE FROM decisions")
+                self._conn.execute("DELETE FROM decision_meta")
+                self._conn.execute("COMMIT")
+            except sqlite3.Error:
+                self._conn.execute("ROLLBACK")
+                raise
+
+    # --- writes --------------------------------------------------------------
+
+    def upsert_decision(
+        self,
+        decision: Decision,
+        *,
+        edges: Iterable[DecisionEdgeRecord] = (),
+    ) -> None:
+        """Insert (or update) a Decision + its edges in a single transaction.
+
+        The whole write is one transaction so a partial-failure can't leave
+        a Decision visible without its edges. On `INSERT OR REPLACE` we
+        re-stamp every row from the Decision; the older rows are dropped
+        in the same transaction.
+        """
+        with self._lock:
+            assert self._conn is not None
+            self._conn.execute("BEGIN")
+            try:
+                self._write_decision_row(decision)
+                self._write_input_rows(decision)
+                self._write_approver_rows(decision)
+                for edge in edges:
+                    self._write_edge_row(edge)
+                self._conn.execute("COMMIT")
+            except sqlite3.Error:
+                self._conn.execute("ROLLBACK")
+                raise
+
+    def update_outcome(self, decision_id: UUID, outcome: OutcomeRef) -> None:
+        """Update only the outcome columns on an existing Decision row.
+
+        Called when ``decision.outcome_attached`` lands. Outcome is the
+        ONLY post-emit mutation the projection makes; it intentionally
+        does NOT touch hash_link (the chain stays valid).
+        """
+        with self._lock:
+            assert self._conn is not None
+            self._conn.execute("BEGIN")
+            try:
+                self._conn.execute(
+                    """
+                    UPDATE decisions
+                       SET outcome_id = ?,
+                           outcome_status = ?,
+                           outcome_landed_at = ?,
+                           outcome_metered = ?
+                     WHERE id = ?
+                    """,
+                    (
+                        str(outcome.outcome_id),
+                        outcome.status,
+                        outcome.landed_at.isoformat() if outcome.landed_at else None,
+                        1 if outcome.metered else 0,
+                        str(decision_id),
+                    ),
+                )
+                # Also write an "outcome" edge so trace queries can surface
+                # the link to the Outcome object.
+                self._write_edge_row(
+                    DecisionEdgeRecord(
+                        src_id=decision_id,
+                        target_id=str(outcome.outcome_id),
+                        relation="outcome",
+                        weight=1.0,
+                    )
+                )
+                self._conn.execute("COMMIT")
+            except sqlite3.Error:
+                self._conn.execute("ROLLBACK")
+                raise
+
+    def set_cursor(self, seq: int) -> None:
+        """Persist the projection cursor so restarts can resume."""
+        with self._lock:
+            assert self._conn is not None
+            self._conn.execute(
+                "INSERT INTO decision_meta(key, value) VALUES('cursor', ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (str(seq),),
+            )
+
+    def get_cursor(self) -> int:
+        assert self._conn is not None
+        row = self._conn.execute("SELECT value FROM decision_meta WHERE key = 'cursor'").fetchone()
+        if row is None:
+            return 0
+        try:
+            return int(row["value"])
+        except (TypeError, ValueError):
+            return 0
+
+    # --- low-level write helpers --------------------------------------------
+
+    def _write_decision_row(self, d: Decision) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO decisions (
+                id, ts,
+                decided_by_kind, decided_by_id, decided_by_scope_context,
+                scope_kind, pocket_id, intent, action,
+                instinct_policy, instinct_policy_passed,
+                outcome_id, outcome_status, outcome_landed_at, outcome_metered,
+                payload, correlation_id, hash_link, last_seq, scope_tags
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(d.id),
+                d.ts.isoformat(),
+                d.decided_by.kind,
+                d.decided_by.id,
+                json.dumps(list(d.decided_by.scope_context)),
+                d.scope_kind,
+                d.pocket_id,
+                d.intent,
+                d.action,
+                d.instinct_policy,
+                None if d.instinct_policy_passed is None else int(bool(d.instinct_policy_passed)),
+                str(d.outcome.outcome_id) if d.outcome else None,
+                d.outcome.status if d.outcome else None,
+                d.outcome.landed_at.isoformat() if d.outcome and d.outcome.landed_at else None,
+                (1 if d.outcome.metered else 0) if d.outcome else None,
+                json.dumps(d.payload, default=str),
+                str(d.correlation_id) if d.correlation_id else None,
+                d.hash_link,
+                d.last_seq,
+                json.dumps(list(d.scope)),
+            ),
+        )
+        # Re-stamp input/approver rows on every upsert — drop old ones first
+        # so the row set is canonical.
+        self._conn.execute("DELETE FROM decision_inputs WHERE decision_id = ?", (str(d.id),))
+        self._conn.execute("DELETE FROM decision_approvers WHERE decision_id = ?", (str(d.id),))
+
+    def _write_input_rows(self, d: Decision) -> None:
+        assert self._conn is not None
+        for inp in d.inputs:
+            self._conn.execute(
+                """
+                INSERT OR REPLACE INTO decision_inputs (
+                    decision_id, kind, input_id, label, point_in_time
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    str(d.id),
+                    inp.kind,
+                    inp.id,
+                    inp.label,
+                    inp.point_in_time.isoformat() if inp.point_in_time else None,
+                ),
+            )
+
+    def _write_approver_rows(self, d: Decision) -> None:
+        assert self._conn is not None
+        for app in d.approvers:
+            self._conn.execute(
+                """
+                INSERT OR REPLACE INTO decision_approvers (
+                    decision_id, approver_kind, approver_id,
+                    approver_scope_context, approved_at, position
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(d.id),
+                    app.actor.kind,
+                    app.actor.id,
+                    json.dumps(list(app.actor.scope_context)),
+                    app.approved_at.isoformat(),
+                    app.position,
+                ),
+            )
+
+    def _write_edge_row(self, edge: DecisionEdgeRecord) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO decision_edges (
+                src_id, target_id, relation, weight
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (str(edge.src_id), edge.target_id, edge.relation, edge.weight),
+        )
+
+    # --- reads ---------------------------------------------------------------
+
+    def get_decision(self, decision_id: UUID) -> Decision | None:
+        """Fetch one Decision (unfiltered — caller must scope-filter)."""
+        assert self._conn is not None
+        row = self._conn.execute(
+            "SELECT * FROM decisions WHERE id = ?", (str(decision_id),)
+        ).fetchone()
+        if row is None:
+            return None
+        return self._hydrate_decision(row)
+
+    def iter_decisions(
+        self,
+        *,
+        actor: str | None = None,
+        pocket_id: str | None = None,
+        policy: str | None = None,
+        outcome_status: str | None = None,
+        scope_kind: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        input_id: str | None = None,
+        correlation_id: UUID | None = None,
+    ) -> Iterable[Decision]:
+        """Index-driven multi-axis filter. The most selective axis is
+        picked by SQLite's planner via the indexes the RFC lists. Scope
+        filter is applied by the caller (see service.py) — this method
+        returns the *unfiltered* set so the post-filter total invariant
+        can be honored in one place.
+
+        ``input_id`` narrows via a join on decision_inputs; the
+        ``idx_inputs_id`` index keeps this O(matches).
+        """
+        assert self._conn is not None
+
+        clauses: list[str] = []
+        params: list[object] = []
+
+        if input_id is not None:
+            base = (
+                "SELECT d.* FROM decisions d "
+                "JOIN decision_inputs di ON di.decision_id = d.id "
+                "WHERE di.input_id = ?"
+            )
+            params.append(input_id)
+        else:
+            base = "SELECT * FROM decisions WHERE 1=1"
+
+        if actor is not None:
+            clauses.append("decided_by_id = ?")
+            params.append(actor)
+        if pocket_id is not None:
+            clauses.append("pocket_id = ?")
+            params.append(pocket_id)
+        if policy is not None:
+            clauses.append("instinct_policy = ?")
+            params.append(policy)
+        if outcome_status is not None:
+            if outcome_status == "pending":
+                clauses.append("outcome_status IS NULL")
+            else:
+                clauses.append("outcome_status = ?")
+                params.append(outcome_status)
+        if scope_kind is not None:
+            clauses.append("scope_kind = ?")
+            params.append(scope_kind)
+        if since is not None:
+            clauses.append("ts >= ?")
+            params.append(since.isoformat())
+        if until is not None:
+            clauses.append("ts <= ?")
+            params.append(until.isoformat())
+        if correlation_id is not None:
+            clauses.append("correlation_id = ?")
+            params.append(str(correlation_id))
+
+        sql = base
+        if clauses:
+            joiner = " AND " if "WHERE" in sql else " WHERE "
+            sql = sql + joiner + " AND ".join(clauses)
+        sql = sql + " ORDER BY ts DESC, id DESC"
+
+        for row in self._conn.execute(sql, params):
+            yield self._hydrate_decision(row)
+
+    def edges_from(
+        self,
+        src_id: UUID,
+        *,
+        relation: str | None = None,
+    ) -> list[DecisionEdgeRecord]:
+        assert self._conn is not None
+        if relation is not None:
+            rows = self._conn.execute(
+                "SELECT * FROM decision_edges WHERE src_id = ? AND relation = ?",
+                (str(src_id), relation),
+            )
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM decision_edges WHERE src_id = ?", (str(src_id),)
+            )
+        return [self._hydrate_edge(r) for r in rows]
+
+    def edges_to(
+        self,
+        target_id: str,
+        *,
+        relation: str | None = None,
+    ) -> list[DecisionEdgeRecord]:
+        assert self._conn is not None
+        if relation is not None:
+            rows = self._conn.execute(
+                "SELECT * FROM decision_edges WHERE target_id = ? AND relation = ?",
+                (target_id, relation),
+            )
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM decision_edges WHERE target_id = ?", (target_id,)
+            )
+        return [self._hydrate_edge(r) for r in rows]
+
+    def count(self) -> int:
+        """Total decisions in the store (smoke / debug)."""
+        assert self._conn is not None
+        row = self._conn.execute("SELECT COUNT(*) AS n FROM decisions").fetchone()
+        return int(row["n"])
+
+    # --- hydration -----------------------------------------------------------
+
+    def _hydrate_decision(self, row: sqlite3.Row) -> Decision:
+        """Re-build a Decision domain object from a sqlite Row."""
+        # Local imports keep the module dep-free of the Actor type at
+        # write time (the row gets the kind+id columns directly).
+        from soul_protocol.spec.journal import Actor
+
+        decided_by = Actor(
+            kind=row["decided_by_kind"],
+            id=row["decided_by_id"],
+            scope_context=json.loads(row["decided_by_scope_context"]) or [],
+        )
+
+        inputs = self._read_inputs(UUID(row["id"]))
+        approvers = self._read_approvers(UUID(row["id"]))
+        precedents = self._read_precedents(UUID(row["id"]))
+
+        outcome: OutcomeRef | None = None
+        if row["outcome_id"] is not None:
+            landed_at_raw = row["outcome_landed_at"]
+            metered_raw = row["outcome_metered"]
+            outcome = OutcomeRef(
+                outcome_id=UUID(row["outcome_id"]),
+                status=row["outcome_status"],
+                landed_at=_parse_iso(landed_at_raw),
+                metered=bool(metered_raw) if metered_raw is not None else False,
+            )
+
+        policy_passed = row["instinct_policy_passed"]
+        return Decision(
+            id=UUID(row["id"]),
+            ts=_parse_iso(row["ts"]) or datetime.now(),
+            decided_by=decided_by,
+            scope=json.loads(row["scope_tags"]) or ["org:unscoped"],
+            scope_kind=row["scope_kind"],
+            intent=row["intent"],
+            action=row["action"],
+            inputs=inputs,
+            approvers=approvers,
+            instinct_policy=row["instinct_policy"],
+            instinct_policy_passed=bool(policy_passed) if policy_passed is not None else None,
+            precedents=precedents,
+            outcome=outcome,
+            payload=json.loads(row["payload"]) if row["payload"] else {},
+            pocket_id=row["pocket_id"],
+            correlation_id=UUID(row["correlation_id"]) if row["correlation_id"] else None,
+            hash_link=row["hash_link"],
+            last_seq=int(row["last_seq"]),
+        )
+
+    def _read_inputs(self, decision_id: UUID) -> list[InputRef]:
+        assert self._conn is not None
+        rows = self._conn.execute(
+            "SELECT * FROM decision_inputs WHERE decision_id = ?",
+            (str(decision_id),),
+        )
+        return [
+            InputRef(
+                kind=r["kind"],
+                id=r["input_id"],
+                label=r["label"] or "",
+                point_in_time=_parse_iso(r["point_in_time"]),
+            )
+            for r in rows
+        ]
+
+    def _read_approvers(self, decision_id: UUID) -> list[ApproverRef]:
+        from soul_protocol.spec.journal import Actor
+
+        assert self._conn is not None
+        rows = self._conn.execute(
+            "SELECT * FROM decision_approvers WHERE decision_id = ? ORDER BY position ASC",
+            (str(decision_id),),
+        )
+        return [
+            ApproverRef(
+                actor=Actor(
+                    kind=r["approver_kind"],
+                    id=r["approver_id"],
+                    scope_context=json.loads(r["approver_scope_context"]) or [],
+                ),
+                approved_at=_parse_iso(r["approved_at"]) or datetime.now(),
+                position=int(r["position"]),
+            )
+            for r in rows
+        ]
+
+    def _read_precedents(self, decision_id: UUID) -> list[DecisionRef]:
+        """Read precedent edges from `decision_edges` for this Decision."""
+        edges = self.edges_from(decision_id, relation="precedent")
+        out: list[DecisionRef] = []
+        for e in edges:
+            try:
+                out.append(
+                    DecisionRef(
+                        decision_id=UUID(e.target_id),
+                        relation="precedent",
+                        weight=e.weight,
+                    )
+                )
+            except ValueError:
+                # Target wasn't a UUID — skip (shouldn't happen for precedents).
+                continue
+        return out
+
+    def _hydrate_edge(self, row: sqlite3.Row) -> DecisionEdgeRecord:
+        return DecisionEdgeRecord(
+            src_id=UUID(row["src_id"]),
+            target_id=row["target_id"],
+            relation=row["relation"],
+            weight=float(row["weight"]),
+        )
+
+
+def _parse_iso(v: object) -> datetime | None:
+    """Parse an ISO-8601 string back to a datetime; tolerate None."""
+    if v is None:
+        return None
+    if isinstance(v, datetime):
+        return v
+    try:
+        return datetime.fromisoformat(str(v).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = [
+    "DecisionStore",
+    "get_db_path",
+    "set_db_path",
+]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -366,6 +366,34 @@ source_modules = [
 ]
 forbidden_modules = ["pocketpaw_ee.cloud.models.audit"]
 
+# Decisions — Beanie writes only from service.py (RFC 07 Slice 1).
+# The decision-graph entity has no Beanie document of its own — it
+# materializes into SQLite (`~/.soul/decisions.db`) via DecisionStore,
+# not MongoDB. The contract is included for consistency with the other
+# entities and to forbid any future Beanie creep. `domain.py`, `dto.py`,
+# `router.py`, `projection.py`, and `store.py` must never import the
+# cloud models.* tree — only `service.py` may (it doesn't yet, but the
+# contract pins the rule for future maintenance).
+[[tool.importlinter.contracts]]
+name = "Decisions — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.cloud.decisions.router",
+    "pocketpaw_ee.cloud.decisions.dto",
+    "pocketpaw_ee.cloud.decisions.domain",
+    "pocketpaw_ee.cloud.decisions.projection",
+    "pocketpaw_ee.cloud.decisions.store",
+]
+forbidden_modules = [
+    "pocketpaw_ee.cloud.models.notification",
+    "pocketpaw_ee.cloud.models.session",
+    "pocketpaw_ee.cloud.models.pocket",
+    "pocketpaw_ee.cloud.models.user",
+    "pocketpaw_ee.cloud.models.agent",
+    "pocketpaw_ee.cloud.models.workspace",
+]
+
 # Increment 3 — the pocket execution router. The classifier is PURE: a
 # rule-based ``classify(intent, ripple_spec)`` with no I/O. It must never
 # import Beanie documents, the cloud-side executors / services, or the LLM

--- a/tests/ee/test_decision_graph_api.py
+++ b/tests/ee/test_decision_graph_api.py
@@ -1,0 +1,361 @@
+# tests/ee/test_decision_graph_api.py — RFC 07 Slice 1 in-process API
+# tests. Covers the four DecisionGraph methods (get, find, trace,
+# downstream) including scope-filter enforcement on every method.
+#
+# Created: 2026-05-25 (feat/rfc07-decision-graph-slice1).
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from pocketpaw_ee.cloud.decisions.projection import DecisionProjection
+from pocketpaw_ee.cloud.decisions.service import DecisionGraph
+from pocketpaw_ee.cloud.decisions.store import DecisionStore, set_db_path
+from soul_protocol.spec.journal import Actor, EventEntry
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> DecisionStore:
+    set_db_path(tmp_path / "decisions.db")
+    s = DecisionStore()
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def projection(store: DecisionStore) -> DecisionProjection:
+    return DecisionProjection(store=store)
+
+
+@pytest.fixture
+def graph(store: DecisionStore, projection: DecisionProjection) -> DecisionGraph:
+    return DecisionGraph(store=store, projection=projection)
+
+
+@pytest.fixture
+def base_ts() -> datetime:
+    return datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — duplicated tiny bit from the projection tests to keep this
+# file self-contained
+# ---------------------------------------------------------------------------
+
+
+def _event(
+    *,
+    seq: int,
+    ts: datetime,
+    actor: Actor,
+    action: str,
+    correlation_id: UUID | None,
+    payload: dict,
+    scope: list[str] | None = None,
+) -> EventEntry:
+    return EventEntry(
+        id=uuid4(),
+        ts=ts,
+        actor=actor,
+        action=action,
+        scope=scope or ["org:nerve"],
+        correlation_id=correlation_id,
+        payload=payload,
+        seq=seq,
+    )
+
+
+def _seed_chain(
+    projection: DecisionProjection,
+    *,
+    base_ts: datetime,
+    pocket_id: str = "pa",
+    scope: list[str] | None = None,
+    action_name: str = "send_to_tenant",
+    actor_id: str = "did:soul:agent1",
+    precedents: list[dict] | None = None,
+    seq_base: int = 1000,
+) -> UUID:
+    """Seed one approval chain in the store; return the chain's
+    correlation_id. Returns the FIRST `decision.graduated` Decision's
+    id via a helper lookup post-emit."""
+    corr = uuid4()
+    scope = scope or ["org:nerve", f"pocket:{pocket_id}"]
+    actor = Actor(kind="agent", id=actor_id, scope_context=scope)
+    payload = {
+        "intent": f"chain-{seq_base}",
+        "action": action_name,
+        "pocket_id": pocket_id,
+    }
+    if precedents is not None:
+        payload["precedents"] = precedents
+    events = [
+        _event(
+            seq=seq_base,
+            ts=base_ts,
+            actor=actor,
+            action="agent.proposed",
+            correlation_id=corr,
+            payload=payload,
+            scope=scope,
+        ),
+        _event(
+            seq=seq_base + 1,
+            ts=base_ts + timedelta(seconds=1),
+            actor=actor,
+            action="decision.graduated",
+            correlation_id=corr,
+            payload={"passed": True},
+            scope=scope,
+        ),
+    ]
+    last_decision_id: UUID | None = None
+    for e in events:
+        result = projection.apply(e)
+        if result is not None:
+            last_decision_id = result.id
+    assert last_decision_id is not None
+    return last_decision_id
+
+
+# ---------------------------------------------------------------------------
+# get()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_returns_decision(graph, projection, base_ts) -> None:
+    decision_id = _seed_chain(projection, base_ts=base_ts)
+    found = await graph.get(decision_id)
+    assert found is not None
+    assert found.id == decision_id
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_when_missing(graph) -> None:
+    found = await graph.get(uuid4())
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_when_scope_mismatch(graph, projection, base_ts) -> None:
+    """Scope filter on get() — outside-scope caller gets None (not a probe)."""
+    decision_id = _seed_chain(projection, base_ts=base_ts, scope=["org:nerve", "workspace:a"])
+    found = await graph.get(decision_id, requester_scopes=["workspace:b"])
+    assert found is None
+
+
+# ---------------------------------------------------------------------------
+# find()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_find_filters_by_actor(graph, projection, base_ts) -> None:
+    _seed_chain(projection, base_ts=base_ts, actor_id="did:soul:agent_a", seq_base=2000)
+    _seed_chain(
+        projection,
+        base_ts=base_ts + timedelta(seconds=10),
+        actor_id="did:soul:agent_b",
+        seq_base=2100,
+    )
+    a_only = await graph.find(actor="did:soul:agent_a")
+    assert len(a_only) == 1
+    assert a_only[0].decided_by.id == "did:soul:agent_a"
+
+
+@pytest.mark.asyncio
+async def test_find_filters_by_pocket(graph, projection, base_ts) -> None:
+    _seed_chain(projection, base_ts=base_ts, pocket_id="pocket_alpha", seq_base=2200)
+    _seed_chain(
+        projection,
+        base_ts=base_ts + timedelta(seconds=10),
+        pocket_id="pocket_beta",
+        seq_base=2300,
+    )
+    alpha = await graph.find(pocket_id="pocket_alpha")
+    assert len(alpha) == 1
+    assert alpha[0].pocket_id == "pocket_alpha"
+
+
+@pytest.mark.asyncio
+async def test_find_filters_by_time_window(graph, projection, base_ts) -> None:
+    _seed_chain(projection, base_ts=base_ts, seq_base=2400)
+    _seed_chain(
+        projection,
+        base_ts=base_ts + timedelta(hours=2),
+        seq_base=2500,
+    )
+    only_early = await graph.find(until=base_ts + timedelta(hours=1))
+    assert len(only_early) == 1
+
+
+@pytest.mark.asyncio
+async def test_find_keyset_pagination(graph, projection, base_ts) -> None:
+    """Keyset pagination on (ts DESC, id DESC) — page 2 uses page 1's
+    last (ts, id) as the cursor."""
+    for i in range(5):
+        _seed_chain(
+            projection,
+            base_ts=base_ts + timedelta(seconds=i),
+            seq_base=2600 + i * 10,
+        )
+    page_one = await graph.find(limit=2)
+    assert len(page_one) == 2
+    last = page_one[-1]
+    page_two = await graph.find(limit=2, before_ts=last.ts, before_id=str(last.id))
+    assert len(page_two) == 2
+    # No overlap.
+    ids_one = {d.id for d in page_one}
+    ids_two = {d.id for d in page_two}
+    assert ids_one.isdisjoint(ids_two)
+
+
+@pytest.mark.asyncio
+async def test_find_scope_filter_per_call(graph, projection, base_ts) -> None:
+    """Scope filter on find() — A-scope caller sees only A-scope rows."""
+    _seed_chain(projection, base_ts=base_ts, scope=["org:nerve", "workspace:a"], seq_base=2700)
+    _seed_chain(
+        projection,
+        base_ts=base_ts + timedelta(seconds=10),
+        scope=["org:nerve", "workspace:b"],
+        seq_base=2800,
+    )
+    a_scoped = await graph.find(requester_scopes=["workspace:a"])
+    assert len(a_scoped) == 1
+    assert "workspace:a" in a_scoped[0].scope
+
+
+# ---------------------------------------------------------------------------
+# trace() — upstream walk
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trace_walks_precedents(graph, projection, base_ts) -> None:
+    """A decision with an agent-supplied precedent has an edge to the
+    precedent that the trace walks."""
+    # Seed two prior decisions; capture their ids.
+    seed_ids: list[UUID] = []
+    for i in range(2):
+        sid = _seed_chain(
+            projection,
+            base_ts=base_ts - timedelta(days=2 - i),
+            seq_base=3000 + i * 10,
+        )
+        seed_ids.append(sid)
+
+    # Now a new decision with explicit precedents pointing at the seeds.
+    new_id = _seed_chain(
+        projection,
+        base_ts=base_ts,
+        precedents=[
+            {"decision_id": str(seed_ids[0]), "weight": 0.9},
+            {"decision_id": str(seed_ids[1]), "weight": 0.7},
+        ],
+        seq_base=3100,
+    )
+    trace = await graph.trace(new_id, depth=2)
+    # The two precedent nodes are walked.
+    node_ids = set(trace.nodes.keys())
+    assert str(new_id) in node_ids
+    assert str(seed_ids[0]) in node_ids
+    assert str(seed_ids[1]) in node_ids
+    # At least the precedent edges are present.
+    precedent_edges = [e for e in trace.edges if e.relation == "precedent"]
+    assert len(precedent_edges) >= 2
+
+
+@pytest.mark.asyncio
+async def test_trace_respects_scope_filter(graph, projection, base_ts) -> None:
+    """A precedent in a different scope does NOT appear in the trace."""
+    # Seed precedent in scope B.
+    b_id = _seed_chain(
+        projection,
+        base_ts=base_ts - timedelta(days=1),
+        scope=["org:nerve", "workspace:b"],
+        seq_base=3200,
+    )
+    # A-scoped Decision points at the B-scoped precedent (synthetic; the
+    # projection doesn't normally cross-scope-link, but the edge could
+    # exist if a payload references it).
+    new_id = _seed_chain(
+        projection,
+        base_ts=base_ts,
+        scope=["org:nerve", "workspace:a"],
+        precedents=[{"decision_id": str(b_id), "weight": 0.9}],
+        seq_base=3300,
+    )
+    # Trace with A-scope only.
+    trace = await graph.trace(new_id, depth=2, requester_scopes=["workspace:a"])
+    # The B-scoped precedent must NOT appear as a node.
+    assert str(b_id) not in trace.nodes
+
+
+@pytest.mark.asyncio
+async def test_trace_returns_empty_for_missing_root(graph) -> None:
+    trace = await graph.trace(uuid4(), depth=2)
+    assert trace.nodes == {}
+    assert trace.edges == []
+
+
+# ---------------------------------------------------------------------------
+# downstream() — inverse precedent walk
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_downstream_finds_later_citers(graph, projection, base_ts) -> None:
+    """Decisions that later cite this one show up in downstream."""
+    # The root (older) decision.
+    root_id = _seed_chain(projection, base_ts=base_ts - timedelta(days=1), seq_base=4000)
+
+    # Two later decisions that cite it.
+    citer_one = _seed_chain(
+        projection,
+        base_ts=base_ts,
+        precedents=[{"decision_id": str(root_id), "weight": 0.8}],
+        seq_base=4100,
+    )
+    citer_two = _seed_chain(
+        projection,
+        base_ts=base_ts + timedelta(seconds=5),
+        precedents=[{"decision_id": str(root_id), "weight": 0.6}],
+        seq_base=4200,
+    )
+
+    down = await graph.downstream(root_id, depth=2)
+    node_ids = set(down.nodes.keys())
+    assert str(root_id) in node_ids
+    assert str(citer_one) in node_ids
+    assert str(citer_two) in node_ids
+    # Inverse edges are stamped as "downstream" in the result.
+    downstream_edges = [e for e in down.edges if e.relation == "downstream"]
+    assert len(downstream_edges) == 2
+
+
+@pytest.mark.asyncio
+async def test_downstream_respects_scope_filter(graph, projection, base_ts) -> None:
+    """A citer in a different scope does NOT appear in downstream."""
+    root_id = _seed_chain(
+        projection,
+        base_ts=base_ts - timedelta(days=1),
+        scope=["org:nerve", "workspace:a"],
+        seq_base=4300,
+    )
+    # B-scoped citer.
+    _seed_chain(
+        projection,
+        base_ts=base_ts,
+        scope=["org:nerve", "workspace:b"],
+        precedents=[{"decision_id": str(root_id), "weight": 0.9}],
+        seq_base=4400,
+    )
+    # A-scope only — the B citer must not appear.
+    down = await graph.downstream(root_id, depth=2, requester_scopes=["workspace:a"])
+    # Only root should be visible.
+    assert len(down.nodes) == 1
+    assert str(root_id) in down.nodes

--- a/tests/ee/test_decision_projection.py
+++ b/tests/ee/test_decision_projection.py
@@ -1,0 +1,694 @@
+# tests/ee/test_decision_projection.py — Coverage for the RFC 07 Slice 1
+# Decision projection. These tests pin the invariants the substrate is
+# supposed to hold; if any of them regress we've silently violated the
+# A1/A2/A3 amendments or the hash-chain G6 contract.
+#
+# Created: 2026-05-25 (RFC 07 Slice 1, feat/rfc07-decision-graph-slice1).
+#
+# Mirrors `tests/ee/test_fabric_journal.py` fixture style: a fresh store
+# per test via `tmp_path` + `set_db_path`, then run events through the
+# projection directly. We don't open a real soul-protocol Journal here —
+# the projection's contract is `apply(EventEntry)` and we test that
+# contract by handing it constructed EventEntry instances. The
+# journal-to-projection subscription that produces those entries from a
+# real journal lands in Slice 2.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from pocketpaw_ee.cloud.decisions.domain import ApproverRef, compute_hash_link
+from pocketpaw_ee.cloud.decisions.projection import DecisionProjection
+from pocketpaw_ee.cloud.decisions.store import DecisionStore, set_db_path
+from soul_protocol.spec.journal import Actor, EventEntry
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> DecisionStore:
+    """Fresh SQLite-backed store per test."""
+    set_db_path(tmp_path / "decisions.db")
+    s = DecisionStore()
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def projection(store: DecisionStore) -> DecisionProjection:
+    return DecisionProjection(store=store)
+
+
+@pytest.fixture
+def base_ts() -> datetime:
+    """Stable base timestamp for ordered event chains. tz-aware UTC per
+    EventEntry's validator."""
+    return datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build EventEntry instances for the projection
+# ---------------------------------------------------------------------------
+
+
+def _agent_actor(agent_id: str = "did:soul:lease_specialist") -> Actor:
+    return Actor(kind="agent", id=agent_id, scope_context=["org:nerve"])
+
+
+def _user_actor(user_id: str = "user:prakash") -> Actor:
+    return Actor(kind="user", id=user_id, scope_context=["org:nerve"])
+
+
+def _system_actor(system_id: str = "system:instinct") -> Actor:
+    return Actor(kind="system", id=system_id, scope_context=["org:nerve"])
+
+
+def _event(
+    *,
+    seq: int,
+    ts: datetime,
+    actor: Actor,
+    action: str,
+    correlation_id: UUID | None,
+    payload: dict,
+    scope: list[str] | None = None,
+) -> EventEntry:
+    return EventEntry(
+        id=uuid4(),
+        ts=ts,
+        actor=actor,
+        action=action,
+        scope=scope or ["org:nerve", "pocket:p_lease_renewals"],
+        correlation_id=correlation_id,
+        payload=payload,
+        seq=seq,
+    )
+
+
+def _approval_chain(
+    base_ts: datetime,
+    correlation_id: UUID | None = None,
+    *,
+    include_fabric_write: bool = True,
+    scope: list[str] | None = None,
+    pocket_id: str = "p_lease_renewals",
+) -> tuple[UUID, list[EventEntry]]:
+    """Build a 5-event approval chain ending in `decision.graduated`."""
+    corr = correlation_id or uuid4()
+    scope = scope or ["org:nerve", f"pocket:{pocket_id}"]
+    events = [
+        _event(
+            seq=100,
+            ts=base_ts,
+            actor=_agent_actor(),
+            action="agent.proposed",
+            correlation_id=corr,
+            payload={
+                "intent": "Renew LR-2026-117 at $2,850",
+                "action": "send_to_tenant",
+                "pocket_id": pocket_id,
+                "inputs": [
+                    {"kind": "fabric_object", "id": "lease:LR-2026-117"},
+                    {"kind": "fabric_object", "id": "tenant:t_42"},
+                ],
+                "data": {"rent_old": 2750, "rent_new": 2850},
+            },
+            scope=scope,
+        ),
+        _event(
+            seq=101,
+            ts=base_ts + timedelta(seconds=1),
+            actor=_system_actor(),
+            action="policy.evaluated",
+            correlation_id=corr,
+            payload={
+                "policy": "approve_per_row",
+                "passed": False,
+                "reason": "human approval required",
+            },
+            scope=scope,
+        ),
+        _event(
+            seq=102,
+            ts=base_ts + timedelta(seconds=10),
+            actor=_user_actor(),
+            action="human.corrected",
+            correlation_id=corr,
+            payload={"action": "approve", "note": "comp set checks out"},
+            scope=scope,
+        ),
+        _event(
+            seq=103,
+            ts=base_ts + timedelta(seconds=11),
+            actor=_system_actor(),
+            action="policy.evaluated",
+            correlation_id=corr,
+            payload={"policy": "approve_per_row", "passed": True},
+            scope=scope,
+        ),
+    ]
+    if include_fabric_write:
+        events.append(
+            _event(
+                seq=104,
+                ts=base_ts + timedelta(seconds=14),
+                actor=_agent_actor(),
+                action="fabric.object.updated",
+                correlation_id=corr,
+                payload={
+                    "object_id": "lease:LR-2026-117",
+                    "properties": {"status": "renewal_sent"},
+                },
+                scope=scope,
+            )
+        )
+    events.append(
+        _event(
+            seq=105,
+            ts=base_ts + timedelta(seconds=15),
+            actor=_agent_actor(),
+            action="decision.graduated",
+            correlation_id=corr,
+            payload={"passed": True},
+            scope=scope,
+        )
+    )
+    return corr, events
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy-path: 5-event chain emits one Decision on `decision.graduated`
+# ---------------------------------------------------------------------------
+
+
+def test_chain_emits_decision_on_graduated(
+    projection: DecisionProjection, base_ts: datetime
+) -> None:
+    """A canonical chain (proposed → policy → human → policy → fabric →
+    graduated) emits exactly one Decision, and the terminal event is the
+    graduated event."""
+    _, events = _approval_chain(base_ts)
+
+    emitted = [d for d in (projection.apply(e) for e in events) if d is not None]
+    assert len(emitted) == 1
+    decision = emitted[0]
+
+    # The Decision's action comes from the proposed payload, not the
+    # fabric write.
+    assert decision.action == "send_to_tenant"
+    assert decision.intent.startswith("Renew LR-2026-117")
+    # Policy ended on `passed=true` — outcome is None (not rejected).
+    assert decision.instinct_policy == "approve_per_row"
+    assert decision.instinct_policy_passed is True
+    assert decision.outcome is None
+    # Approvers landed as ApproverRef with approved_at.
+    assert len(decision.approvers) == 1
+    assert decision.approvers[0].approved_at == base_ts + timedelta(seconds=10)
+    # Fabric write contributed the target object as an input.
+    input_ids = {i.id for i in decision.inputs}
+    assert "lease:LR-2026-117" in input_ids
+    assert "tenant:t_42" in input_ids
+    # The store has exactly one row.
+    assert projection.store.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. A2 — Fabric writes contribute, do NOT close the chain
+# ---------------------------------------------------------------------------
+
+
+def test_fabric_writes_do_not_close_chain(
+    projection: DecisionProjection, base_ts: datetime
+) -> None:
+    """A2 enforcement: a fabric.object.updated event mid-flow records the
+    target object as an input but the chain stays OPEN until
+    decision.graduated lands. The store stays empty until then."""
+    corr = uuid4()
+    events_before_graduated = [
+        _event(
+            seq=200,
+            ts=base_ts,
+            actor=_agent_actor(),
+            action="agent.proposed",
+            correlation_id=corr,
+            payload={
+                "intent": "Patch the lease",
+                "action": "patch",
+                "pocket_id": "p_lease_renewals",
+            },
+        ),
+        _event(
+            seq=201,
+            ts=base_ts + timedelta(seconds=1),
+            actor=_agent_actor(),
+            action="fabric.object.updated",
+            correlation_id=corr,
+            payload={"object_id": "lease:LR-2026-117"},
+        ),
+    ]
+    for e in events_before_graduated:
+        result = projection.apply(e)
+        assert result is None, f"chain emitted prematurely on {e.action}"
+    # Still empty.
+    assert projection.store.count() == 0
+
+    # Now graduate.
+    graduated = _event(
+        seq=202,
+        ts=base_ts + timedelta(seconds=2),
+        actor=_agent_actor(),
+        action="decision.graduated",
+        correlation_id=corr,
+        payload={"passed": True},
+    )
+    decision = projection.apply(graduated)
+    assert decision is not None
+    assert decision.action == "patch"
+    # The fabric write's target object is present as an input.
+    assert any(i.id == "lease:LR-2026-117" for i in decision.inputs)
+    assert projection.store.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Rejection chain — `policy.evaluated(passed=false)` → graduated
+# ---------------------------------------------------------------------------
+
+
+def test_rejection_chain_emits_rejected_outcome(
+    projection: DecisionProjection, base_ts: datetime
+) -> None:
+    """A rejected policy followed by decision.graduated emits a Decision
+    with outcome.status == 'rejected'."""
+    corr = uuid4()
+    events = [
+        _event(
+            seq=300,
+            ts=base_ts,
+            actor=_agent_actor(),
+            action="agent.proposed",
+            correlation_id=corr,
+            payload={
+                "intent": "Send tenant a renewal",
+                "action": "send_renewal",
+                "pocket_id": "p_lease_renewals",
+            },
+        ),
+        _event(
+            seq=301,
+            ts=base_ts + timedelta(seconds=1),
+            actor=_system_actor(),
+            action="policy.evaluated",
+            correlation_id=corr,
+            payload={
+                "policy": "approve_per_row",
+                "passed": False,
+                "reason": "rent above market median",
+            },
+        ),
+        _event(
+            seq=302,
+            ts=base_ts + timedelta(seconds=2),
+            actor=_agent_actor(),
+            action="decision.graduated",
+            correlation_id=corr,
+            payload={"passed": False},
+        ),
+    ]
+    emitted = [d for d in (projection.apply(e) for e in events) if d is not None]
+    assert len(emitted) == 1
+    decision = emitted[0]
+    assert decision.outcome is not None
+    assert decision.outcome.status == "rejected"
+    assert decision.instinct_policy_passed is False
+    # Rejection reason landed in the payload (for the narrator).
+    assert decision.payload.get("rejection_reason") == "rent above market median"
+
+
+# ---------------------------------------------------------------------------
+# 4. A1 — ApproverRef carries approved_at + position
+# ---------------------------------------------------------------------------
+
+
+def test_approver_ref_carries_timestamp_and_position(
+    projection: DecisionProjection, base_ts: datetime
+) -> None:
+    """A1 enforcement: every approver lands as an ApproverRef with the
+    `human.corrected` event's ts and a position index starting at 0."""
+    corr = uuid4()
+    approver_one = _user_actor("user:prakash")
+    approver_two = _user_actor("user:robert")
+    events = [
+        _event(
+            seq=400,
+            ts=base_ts,
+            actor=_agent_actor(),
+            action="agent.proposed",
+            correlation_id=corr,
+            payload={"intent": "x", "action": "patch", "pocket_id": "p"},
+        ),
+        _event(
+            seq=401,
+            ts=base_ts + timedelta(seconds=5),
+            actor=approver_one,
+            action="human.corrected",
+            correlation_id=corr,
+            payload={"action": "approve"},
+        ),
+        _event(
+            seq=402,
+            ts=base_ts + timedelta(seconds=10),
+            actor=approver_two,
+            action="human.corrected",
+            correlation_id=corr,
+            payload={"action": "approve"},
+        ),
+        _event(
+            seq=403,
+            ts=base_ts + timedelta(seconds=12),
+            actor=_agent_actor(),
+            action="decision.graduated",
+            correlation_id=corr,
+            payload={"passed": True},
+        ),
+    ]
+    emitted = [d for d in (projection.apply(e) for e in events) if d is not None]
+    assert len(emitted) == 1
+    decision = emitted[0]
+    assert len(decision.approvers) == 2
+    first, second = decision.approvers
+    assert isinstance(first, ApproverRef)
+    assert first.actor.id == "user:prakash"
+    assert first.approved_at == base_ts + timedelta(seconds=5)
+    assert first.position == 0
+    assert second.actor.id == "user:robert"
+    assert second.position == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. G6 — hash chain includes prev_hash within correlation_id
+# ---------------------------------------------------------------------------
+
+
+def test_hash_chain_includes_prev_hash(projection: DecisionProjection, base_ts: datetime) -> None:
+    """Two decisions in the same correlation_id form a hash chain: the
+    second's hash_link depends on the first. Recomputing the second's
+    hash with the first's hash as prev produces the stored value."""
+    # First chain.
+    corr = uuid4()
+    _, events_one = _approval_chain(base_ts, correlation_id=corr)
+    emitted_one = [d for d in (projection.apply(e) for e in events_one) if d is not None]
+    assert len(emitted_one) == 1
+    first = emitted_one[0]
+
+    # Second chain — same correlation_id, later ts.
+    later = base_ts + timedelta(minutes=10)
+    _, events_two = _approval_chain(later, correlation_id=corr)
+    # Bump seq to keep the cursor monotonic.
+    for i, e in enumerate(events_two):
+        events_two[i] = e.model_copy(update={"seq": 1000 + i})
+    emitted_two = [d for d in (projection.apply(e) for e in events_two) if d is not None]
+    assert len(emitted_two) == 1
+    second = emitted_two[0]
+
+    # Sanity: distinct ids, same correlation.
+    assert first.id != second.id
+    assert first.correlation_id == second.correlation_id == corr
+    # Recompute the second hash using the first's hash as prev — must match.
+    expected = compute_hash_link(second, first.hash_link)
+    assert second.hash_link == expected
+    # And explicitly: the second hash is NOT the same as if prev were empty.
+    no_prev = compute_hash_link(second, "")
+    assert second.hash_link != no_prev
+
+
+# ---------------------------------------------------------------------------
+# 6. `decision.outcome_attached` does not affect the hash
+# ---------------------------------------------------------------------------
+
+
+def test_outcome_attached_does_not_affect_hash(
+    projection: DecisionProjection, base_ts: datetime
+) -> None:
+    """Late `decision.outcome_attached` mutates the outcome columns but
+    leaves the hash_link bit-identical (outcome is excluded from the
+    hash material — that's what makes outcomes safe to amend)."""
+    _, events = _approval_chain(base_ts)
+    emitted = [d for d in (projection.apply(e) for e in events) if d is not None]
+    assert len(emitted) == 1
+    decision = emitted[0]
+    original_hash = decision.hash_link
+
+    # Attach an outcome.
+    attach = _event(
+        seq=999,
+        ts=base_ts + timedelta(minutes=1),
+        actor=_system_actor("system:outcome"),
+        action="decision.outcome_attached",
+        correlation_id=decision.correlation_id,
+        payload={
+            "decision_id": str(decision.id),
+            "outcome_id": str(uuid4()),
+            "status": "landed",
+            "metered": True,
+            "landed_at": (base_ts + timedelta(minutes=1)).isoformat(),
+        },
+    )
+    refreshed = projection.apply(attach)
+    assert refreshed is not None
+    assert refreshed.outcome is not None
+    assert refreshed.outcome.status == "landed"
+    assert refreshed.outcome.metered is True
+    # The hash MUST be identical — the chain stays valid.
+    assert refreshed.hash_link == original_hash
+
+
+# ---------------------------------------------------------------------------
+# 7. A3 path 1 — agent-supplied precedents in proposed payload
+# ---------------------------------------------------------------------------
+
+
+def test_precedent_payload_supplied(projection: DecisionProjection, base_ts: datetime) -> None:
+    """When the proposed payload carries `precedents`, those are kept
+    as-is (no fallback). Two refs with explicit weights."""
+    corr = uuid4()
+    prec_a, prec_b = uuid4(), uuid4()
+    events = [
+        _event(
+            seq=500,
+            ts=base_ts,
+            actor=_agent_actor(),
+            action="agent.proposed",
+            correlation_id=corr,
+            payload={
+                "intent": "Renew with precedents",
+                "action": "send_to_tenant",
+                "pocket_id": "p_lease_renewals",
+                "precedents": [
+                    {"decision_id": str(prec_a), "weight": 0.92},
+                    {"decision_id": str(prec_b), "weight": 0.71},
+                ],
+            },
+        ),
+        _event(
+            seq=501,
+            ts=base_ts + timedelta(seconds=1),
+            actor=_agent_actor(),
+            action="decision.graduated",
+            correlation_id=corr,
+            payload={"passed": True},
+        ),
+    ]
+    emitted = [d for d in (projection.apply(e) for e in events) if d is not None]
+    assert len(emitted) == 1
+    decision = emitted[0]
+    assert len(decision.precedents) == 2
+    weights = {p.weight for p in decision.precedents}
+    assert weights == {0.92, 0.71}
+    decision_ids = {p.decision_id for p in decision.precedents}
+    assert decision_ids == {prec_a, prec_b}
+
+
+# ---------------------------------------------------------------------------
+# 8. A3 path 2 — fallback to same-pocket / same-action / nearest-ts
+# ---------------------------------------------------------------------------
+
+
+def test_precedent_fallback_same_pocket_action(
+    projection: DecisionProjection, base_ts: datetime
+) -> None:
+    """When the proposed payload supplies no precedents, the projection
+    falls back to same-pocket + same-action + top-3 nearest-ts. Decay
+    weights: 0.95, 0.85, 0.75."""
+    # Seed four prior decisions in the same pocket, same action.
+    for i in range(4):
+        corr_seed = uuid4()
+        ts_seed = base_ts - timedelta(days=4 - i)
+        events = [
+            _event(
+                seq=600 + i * 10,
+                ts=ts_seed,
+                actor=_agent_actor(),
+                action="agent.proposed",
+                correlation_id=corr_seed,
+                payload={
+                    "intent": f"seed-{i}",
+                    "action": "send_to_tenant",
+                    "pocket_id": "p_lease_renewals",
+                },
+            ),
+            _event(
+                seq=601 + i * 10,
+                ts=ts_seed + timedelta(seconds=1),
+                actor=_agent_actor(),
+                action="decision.graduated",
+                correlation_id=corr_seed,
+                payload={"passed": True},
+            ),
+        ]
+        for e in events:
+            projection.apply(e)
+    assert projection.store.count() == 4
+
+    # Now a new chain with NO payload precedents.
+    corr = uuid4()
+    new_events = [
+        _event(
+            seq=700,
+            ts=base_ts,
+            actor=_agent_actor(),
+            action="agent.proposed",
+            correlation_id=corr,
+            payload={
+                "intent": "new renewal",
+                "action": "send_to_tenant",
+                "pocket_id": "p_lease_renewals",
+            },
+        ),
+        _event(
+            seq=701,
+            ts=base_ts + timedelta(seconds=1),
+            actor=_agent_actor(),
+            action="decision.graduated",
+            correlation_id=corr,
+            payload={"passed": True},
+        ),
+    ]
+    emitted = [d for d in (projection.apply(e) for e in new_events) if d is not None]
+    assert len(emitted) == 1
+    decision = emitted[0]
+    # Top 3 nearest-ts siblings, decayed weights.
+    assert len(decision.precedents) == 3
+    weights = [p.weight for p in decision.precedents]
+    assert weights == [0.95, 0.85, 0.75]
+
+
+# ---------------------------------------------------------------------------
+# 9. Rebuild idempotence — replay from genesis matches incremental state
+# ---------------------------------------------------------------------------
+
+
+def test_rebuild_idempotent(projection: DecisionProjection, base_ts: datetime) -> None:
+    """Apply N events, snapshot store state, reset, apply the same N
+    events via rebuild(since_seq=0), state must match."""
+    _, events_one = _approval_chain(base_ts)
+    _, events_two = _approval_chain(base_ts + timedelta(minutes=5))
+    all_events = events_one + events_two
+    for e in all_events:
+        projection.apply(e)
+    initial_count = projection.store.count()
+    initial_decisions = sorted(
+        ((d.intent, d.action, d.correlation_id) for d in projection.store.iter_decisions()),
+        key=lambda t: str(t[2]),
+    )
+    assert initial_count == 2
+
+    # Rebuild from genesis with the same events.
+    projection.rebuild(iter(all_events), since_seq=0)
+    after_count = projection.store.count()
+    after_decisions = sorted(
+        ((d.intent, d.action, d.correlation_id) for d in projection.store.iter_decisions()),
+        key=lambda t: str(t[2]),
+    )
+    assert after_count == initial_count
+    # Ids will differ (uuid4() per emission) but intent/action/correlation match.
+    assert after_decisions == initial_decisions
+
+
+# ---------------------------------------------------------------------------
+# 10. Scope filter post-count invariant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scope_filter_post_count_invariant(
+    projection: DecisionProjection, base_ts: datetime
+) -> None:
+    """A workspace-A query returns 0 workspace-B decisions. The count
+    matches the filtered set — never the unfiltered count. Same shape
+    as FabricProjection's pagination-leak fix."""
+    from pocketpaw_ee.cloud.decisions.service import DecisionGraph
+
+    # Two chains in different workspace scopes.
+    _, events_a = _approval_chain(
+        base_ts,
+        scope=["org:nerve", "workspace:a"],
+        pocket_id="pa",
+    )
+    _, events_b = _approval_chain(
+        base_ts + timedelta(minutes=1),
+        scope=["org:nerve", "workspace:b"],
+        pocket_id="pb",
+    )
+    for e in events_a + events_b:
+        projection.apply(e)
+
+    # Store has 2 decisions total — unfiltered.
+    assert projection.store.count() == 2
+
+    graph = DecisionGraph(store=projection.store, projection=projection)
+    # Workspace-A scope sees only workspace-A decisions.
+    a_only = await graph.find(requester_scopes=["workspace:a"])
+    assert len(a_only) == 1
+    assert "workspace:a" in a_only[0].scope
+
+    # Workspace-B scope sees only workspace-B decisions.
+    b_only = await graph.find(requester_scopes=["workspace:b"])
+    assert len(b_only) == 1
+    assert "workspace:b" in b_only[0].scope
+
+    # No-scope (admin) sees both.
+    admin = await graph.find(requester_scopes=None)
+    assert len(admin) == 2
+
+
+# ---------------------------------------------------------------------------
+# 11. Degenerate decision — orphan write event with no correlation
+# ---------------------------------------------------------------------------
+
+
+def test_degenerate_decision_no_correlation(
+    projection: DecisionProjection, base_ts: datetime
+) -> None:
+    """A fabric.object.* event with no correlation_id (admin direct write)
+    still emits a Decision so the graph has a node for it."""
+    event = _event(
+        seq=800,
+        ts=base_ts,
+        actor=_user_actor("user:admin"),
+        action="fabric.object.updated",
+        correlation_id=None,
+        payload={"object_id": "lease:LR-2026-999"},
+    )
+    decision = projection.apply(event)
+    assert decision is not None
+    assert decision.correlation_id is None
+    assert len(decision.inputs) == 1
+    assert decision.inputs[0].id == "lease:LR-2026-999"
+    assert decision.action == "fabric.object.updated"
+    assert decision.intent.startswith("Direct write to")
+    assert projection.store.count() == 1


### PR DESCRIPTION
## Summary

Lands the substrate the rest of RFC 07 hangs off: a journal-event fold (`DecisionProjection`) that materializes `Decision` rows + edge rows into `~/.soul/decisions.db`, plus the in-process `DecisionGraph` Python API (`get` / `find` / `trace` / `downstream`) scoped by `requester_scopes` on every call. The REST surface and the narrator both ship later — this PR is the foundation.

The work threads three RFC amendments derived from a pressure-test prototype at `/tmp/team-rfc07/` (8 green tests there, 24 in this PR). Each amendment closed a real gap that bit the prototype on day 1; pinning them down here keeps every future implementer from rediscovering the same thing.

## RFC amendments applied

- **A1 (gap G1)** — `Decision.approvers` is now `list[ApproverRef]`. `ApproverRef = {actor: Actor, approved_at: datetime, position: int}`. The SQL schema already required `approved_at` + `position`; the domain now provides a home for them so Pydantic catches a missing timestamp at construction time.
- **A2 (gap G2)** — ONLY `decision.graduated` closes a chain. `fabric.object.*` writes contribute the target object as an `InputRef` but the chain stays open until `decision.graduated` lands. Decouples the projection from Fabric's namespace and keeps the contract uniform across action verticals.
- **A3 (gap G3)** — Precedent supply order is explicit: (1) agent payload first, (2) projection fallback to same-pocket + same-action + nearest-ts top 3 (weights 0.95 / 0.85 / 0.75). The earlier "matched via similarity search" hand-wave is replaced. Out-of-band embedding-similarity reconciler is deferred.
- **G6 hash composition** — explicitly includes `prev_hash`: `sha256(id || ts || decided_by.id || action || sorted(input_ids) || prev_hash)`. Outcome, approvers, and precedents stay out of the hash so the late-attach + A3 fallback paths don't break the chain.

The RFC prose at `temp/brain-storming/to-build/07-decision-graph-query-layer-rfc.md` (in the workspace repo, separate PR coming) is amended to match the code.

## What ships

- `ee/pocketpaw_ee/cloud/decisions/__init__.py` + `domain.py` + `dto.py` + `store.py` + `projection.py` + `service.py` + `router.py` — the 4-file shape (Rule 1 per `pocketpaw/CLAUDE.md`) with `store.py` and `projection.py` as the substrate the service sits on. No `repositories.py`.
- `~/.soul/decisions.db` SQLite store with WAL + 64 MB page cache, the four tables from RFC §  "The Materialized Store" (decisions, decision_edges, decision_inputs, decision_approvers), and the six indexes the RFC lists.
- `DecisionGraph` in-process Python API with `get` / `find` / `trace` / `downstream`. Scope filter on every method. Keyset pagination on `(ts DESC, id DESC)`.
- `init_decisions_projection()` wired into `mount_cloud()` after `init_realtime()`, mirroring the outcomes-listener bootstrap pattern.
- New `Decisions — Beanie writes only from service.py` import-linter contract in `ee/pyproject.toml`.
- C4 update — `Decision Graph` Component added to `docs/c4/model.json` related to Event Bus + Audit & Compliance + API Layer.
- One smoke route: `GET /api/v1/decisions/_ping` returns projection cursor + row count so operators can confirm the projection bootstrap fired. The real REST endpoints land in Slice 2.

## Test plan

- [x] `uv run pytest tests/ee/test_decision_projection.py tests/ee/test_decision_graph_api.py -xvs` — 24 passed.
  - 11 projection tests: chain emits on graduated, fabric writes don't close, rejection chain emits rejected outcome, A1 approver ref carries ts + position, G6 hash chain includes prev_hash, outcome_attached does not affect hash, A3 payload precedents kept, A3 fallback same-pocket nearest-ts, rebuild idempotent, scope filter post-count invariant, degenerate decision with no correlation.
  - 13 API tests: get + missing + scope mismatch; find by actor / pocket / time window + keyset pagination + scope filter; trace walks precedents + scope filter + empty for missing root; downstream finds later citers + scope filter.
- [x] `uv run pytest tests/ee/ --ignore=tests/e2e -q` — 564 passed, 1 skipped (pre-existing), 0 regressions.
- [x] `uv run lint-imports --config ee/pyproject.toml` — 17 contracts kept, 0 broken (the new Decisions contract included).
- [x] `uv run ruff check ee/pocketpaw_ee/cloud/decisions/ tests/ee/test_decision_*.py` — clean.
- [x] `uv run ruff format --check` on the touched paths — clean.

## Not in this PR

- **REST surface** — Slice 2 wires the real `GET /api/v1/decisions/:id`, `?…filters`, `/trace`, `/downstream`, `/timeline`. The router file in this PR is a skeleton with one smoke route.
- **Narrator + explain endpoint** — Slice 3 ships the LLM-grounded `POST /api/v1/decisions/explain` and the prompt-cached entity extractor.
- **Journal-to-projection subscription** — Slice 2 wires the bus subscriber that feeds the projection from live journal appends. For now `projection.apply()` is the only path in.
- **`decision.outcome_attached` namespace registration in soul-protocol** — a parallel Slice 0 PR adds it to `ACTION_NAMESPACES`. This PR uses the action as a string literal; registration is advisory, not enforced.
- **RFC prose amendment** — the RFC lives in the workspace repo, not this one; a separate PR over there carries the A1/A2/A3 prose edits. The code references those amendments by name so the link is clear.

## Why now

The append-only journal shipped in April; what hasn't existed is the query layer that turns events into decisions as queryable objects. RFC 07 closes that gap; Slice 1 ships the substrate so every downstream slice (REST, narrator, Decision Graph Pocket, marketplace track records) has something to hang off of.