### PR TITLE
feat(cli): template lint / migrate / diff for RFC 03 v2 templates

### DIFF
--- a/src/pocketpaw/__main__.py
+++ b/src/pocketpaw/__main__.py
@@ -1,6 +1,11 @@
 """PocketPaw entry point.
 
 Changes:
+  - 2026-05-25: Added `template` subcommand (lint / migrate / diff) for
+                RFC 03 v2 templates. Wired into _EARLY_COMMANDS so the
+                lint / migrate / diff path never pays the agent or
+                settings boot cost. Adds --yes and --no-backup flags for
+                template migrate.
   - 2026-04-07: Auto-detect free port in range 8000-9000 if requested port is busy.
   - 2026-03-18: Added CLI subcommands: doctor, health, channels, skills,
                 sessions, memory, config, errors, logs.
@@ -96,6 +101,7 @@ _EARLY_COMMANDS = {
     "config",
     "errors",
     "logs",
+    "template",
 }
 
 
@@ -175,6 +181,18 @@ def _handle_early_command(args) -> int | None:
             limit=getattr(args, "limit", 50),
             follow=getattr(args, "follow", False),
             as_json=getattr(args, "json", False),
+        )
+
+    if cmd == "template":
+        from pocketpaw.cli.template import run_template_cmd
+
+        return run_template_cmd(
+            subaction=getattr(args, "subaction", None),
+            file1=getattr(args, "file1", None),
+            file2=getattr(args, "file2", None),
+            as_json=getattr(args, "json", False),
+            yes=getattr(args, "yes", False),
+            no_backup=getattr(args, "no_backup", False),
         )
 
     return None
@@ -311,6 +329,7 @@ Examples:
             "config",
             "errors",
             "logs",
+            "template",
         ],
         help="Subcommand to run",
     )
@@ -323,6 +342,16 @@ Examples:
         help="Limit number of results (for errors, logs, sessions, memory)",
     )
     parser.add_argument("--follow", action="store_true", help="Tail mode (for logs)")
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompts (for template migrate)",
+    )
+    parser.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Skip backup creation (for template migrate)",
+    )
 
     return parser
 
@@ -338,6 +367,8 @@ def _resolve_subargs(args) -> None:
     args.query = None
     args.key = None
     args.value = None
+    args.file1 = None
+    args.file2 = None
 
     cmd = args.command
 
@@ -359,6 +390,13 @@ def _resolve_subargs(args) -> None:
             args.key = subargs[1]
         if len(subargs) > 2:
             args.value = subargs[2]
+    elif cmd == "template" and subargs:
+        # pocketpaw template <lint|migrate|diff> <file1> [<file2>]
+        args.subaction = subargs[0]
+        if len(subargs) > 1:
+            args.file1 = subargs[1]
+        if len(subargs) > 2:
+            args.file2 = subargs[2]
 
     if args.limit is None:
         defaults = {"errors": 20, "logs": 50, "sessions": 20, "memory": 10}
@@ -425,7 +463,22 @@ def main() -> None:
     """Main entry point."""
     _check_python_version()
     parser = _build_parser()
-    args = parser.parse_args()
+    # parse_known_args lets the template subcommand accept flags
+    # interspersed with positional file paths (e.g.
+    # ``pocketpaw template migrate --yes /path/to/file``). argparse's
+    # default `parse_args` aborts on the trailing positional because
+    # the nargs="*" subargs collector stops at the first optional. The
+    # unknown leftovers are folded into ``args.subargs`` below so the
+    # existing dispatch logic keeps working.
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        # Reject truly unknown flags (anything starting with `-`) so we
+        # don't silently swallow typos like `--frobnicate`. Bare
+        # positionals are appended to subargs for the active command.
+        bad_flags = [a for a in unknown if a.startswith("-")]
+        if bad_flags:
+            parser.error(f"unrecognized arguments: {' '.join(bad_flags)}")
+        args.subargs = list(args.subargs or []) + [a for a in unknown if not a.startswith("-")]
     _resolve_subargs(args)
 
     # Reject combining --telegram with other channel flags. Telegram is the

--- a/src/pocketpaw/cli/template.py
+++ b/src/pocketpaw/cli/template.py
@@ -1,0 +1,529 @@
+# src/pocketpaw/cli/template.py
+# Created: 2026-05-25 (feat/rfc-03-v2-cli) — ``pocketpaw template``
+# subcommand. Implements the three "author-facing" RFC 03 v2 commands:
+#   * ``lint``    — validate a template against the Pydantic chokepoint;
+#                   auto-promote v1 input and surface heuristic warnings.
+#   * ``migrate`` — rewrite v1 to v2 on disk with a .v1.bak backup and a
+#                   y/N confirmation prompt (idempotent on v2 input).
+#   * ``diff``    — semantic dict-walked diff between two templates,
+#                   internally promoted to v2 so v1 / v2 compare cleanly.
+# Publish / install / upgrade are intentionally NOT here — they belong
+# to the registry PR (Bucket C). Fabric tier:registered + via_link
+# enforcement in lint is deferred to the Fabric integration PR (PR 2g).
+"""``pocketpaw template`` — author-side template tooling.
+
+Three sub-subcommands: ``lint``, ``migrate``, ``diff``. Dispatched from
+the top-level argparse parser via ``__main__._handle_early_command`` so
+the template subcommand never pays the agent / settings boot cost.
+
+Imports of ``pocketpaw.bundled_templates`` are lazy — invoking ``--help``
+or any of the unrelated CLI commands must not pull Pydantic, YAML, or
+the schema module into memory.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+from pocketpaw.cli.utils import output_json, print_fail, print_ok, print_warn
+
+# ---------------------------------------------------------------------------
+# Heuristic ``pattern × shape`` matrix — used only by lint for soft
+# warnings. "Unusual" means we don't know of a sane pocket that uses
+# the pair; flag it but don't fail the lint. Anything not in this map
+# is treated as plausible.
+# ---------------------------------------------------------------------------
+
+_UNUSUAL_PATTERN_SHAPE_PAIRS: set[tuple[str, str]] = {
+    # dashboards are read-mostly summary surfaces; a kanban implies
+    # writable state-per-row, which makes a dashboard kanban an odd
+    # combination — flag for author review.
+    ("dashboard", "kanban"),
+    # feeds are vertically scrolling event streams; a data-grid is a
+    # columnar table. The two cohabit awkwardly — flag it.
+    ("feed", "data-grid"),
+    # wizards are single-step linear flows; a network / treemap shape
+    # has no concept of "next step", so the pairing is suspect.
+    ("wizard", "network"),
+    ("wizard", "treemap"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Format detection + I/O
+# ---------------------------------------------------------------------------
+
+
+def _detect_format(path: Path) -> str:
+    """Return ``"json"`` for ``.json`` files, ``"yaml"`` otherwise.
+
+    The RFC's canonical format is YAML; JSON is accepted as input but
+    everything else (no extension, ``.yml``, ``.yaml``) routes through
+    the YAML parser.
+    """
+    return "json" if path.suffix.lower() == ".json" else "yaml"
+
+
+def _parse_file(path: Path) -> dict[str, Any]:
+    """Read + parse one template file. Raises ``ValueError`` on failure."""
+    if not path.is_file():
+        raise ValueError(f"file not found: {path}")
+    raw = path.read_text(encoding="utf-8")
+    fmt = _detect_format(path)
+    try:
+        if fmt == "json":
+            data = json.loads(raw)
+        else:
+            import yaml  # noqa: PLC0415 — lazy
+
+            data = yaml.safe_load(raw)
+    except Exception as exc:
+        raise ValueError(f"failed to parse {path} as {fmt}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: expected a mapping at top level, got {type(data).__name__}")
+    return data
+
+
+def _write_file(path: Path, data: dict[str, Any]) -> None:
+    """Write a template dict back to disk, preserving the input format."""
+    fmt = _detect_format(path)
+    if fmt == "json":
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        return
+    import yaml  # noqa: PLC0415 — lazy
+
+    path.write_text(
+        yaml.safe_dump(data, sort_keys=False, default_flow_style=False),
+        encoding="utf-8",
+    )
+
+
+def _is_v1(meta: dict[str, Any]) -> bool:
+    """True when ``meta`` lacks a ``schema_version`` or declares ``"1"``."""
+    sv = meta.get("schema_version")
+    return sv is None or str(sv) == "1"
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point — wired from ``__main__._handle_early_command``.
+# ---------------------------------------------------------------------------
+
+
+def run_template_cmd(
+    subaction: str | None = None,
+    file1: str | None = None,
+    file2: str | None = None,
+    as_json: bool = False,
+    yes: bool = False,
+    no_backup: bool = False,
+) -> int:
+    """Dispatch ``pocketpaw template <subaction>`` to the right handler.
+
+    Returns an exit code: 0 on success, 1 on validation / I/O failure,
+    2 on usage error (unknown subaction, missing required positional).
+    """
+    if subaction not in {"lint", "migrate", "diff"}:
+        msg = f"unknown subcommand {subaction!r}. Expected one of: lint, migrate, diff."
+        if as_json:
+            output_json({"error": msg})
+        else:
+            print_fail(msg)
+        return 2
+
+    if subaction == "lint":
+        if not file1:
+            _usage_error("pocketpaw template lint <file>", as_json)
+            return 2
+        return _run_lint(Path(file1), as_json=as_json)
+
+    if subaction == "migrate":
+        if not file1:
+            _usage_error("pocketpaw template migrate <file>", as_json)
+            return 2
+        return _run_migrate(
+            Path(file1),
+            as_json=as_json,
+            yes=yes,
+            no_backup=no_backup,
+        )
+
+    # subaction == "diff"
+    if not file1 or not file2:
+        _usage_error("pocketpaw template diff <file1> <file2>", as_json)
+        return 2
+    return _run_diff(Path(file1), Path(file2), as_json=as_json)
+
+
+def _usage_error(usage: str, as_json: bool) -> None:
+    if as_json:
+        output_json({"error": f"usage: {usage}"})
+    else:
+        print_fail(f"usage: {usage}")
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: lint
+# ---------------------------------------------------------------------------
+
+
+def _run_lint(path: Path, *, as_json: bool) -> int:
+    """Validate one template file.
+
+    Steps:
+      1. Read + parse (YAML or JSON, by extension).
+      2. If v1, run the loader's private ``_promote_v1_to_v2`` and remember
+         that a rewrite would apply.
+      3. Try ``PocketTemplate.model_validate(merged)``.
+      4. Compute heuristic warnings (pattern × shape only — Fabric
+         ``via_link`` registry enforcement is out of scope).
+      5. Print human-readable or JSON output.
+    """
+
+    # Phase 1 — read + parse
+    try:
+        meta = _parse_file(path)
+    except ValueError as exc:
+        return _lint_fail(path, [str(exc)], [], False, as_json)
+
+    promoted_from_v1 = _is_v1(meta)
+
+    # Lazy imports keep the chokepoint off the hot path.
+    from pocketpaw.bundled_templates.loader import _promote_v1_to_v2  # noqa: PLC0415
+
+    merged = _promote_v1_to_v2(meta) if promoted_from_v1 else meta
+
+    # Phase 3 — Pydantic validation
+    try:
+        from pydantic import ValidationError  # noqa: PLC0415
+
+        from pocketpaw.bundled_templates.schema import PocketTemplate  # noqa: PLC0415
+
+        PocketTemplate.model_validate(merged)
+    except ValidationError as exc:
+        errors = _format_pydantic_errors(exc)
+        return _lint_fail(path, errors, [], promoted_from_v1, as_json)
+    except Exception as exc:  # noqa: BLE001 — defensive
+        return _lint_fail(path, [f"unexpected error: {exc}"], [], promoted_from_v1, as_json)
+
+    # Phase 4 — heuristic warnings (Pydantic already passed)
+    warnings = _compute_warnings(merged)
+
+    # Phase 5 — output
+    name = merged.get("name", "<unknown>")
+    if as_json:
+        output_json(
+            {
+                "file": str(path),
+                "valid": True,
+                "errors": [],
+                "warnings": warnings,
+                "schema_version": "v2",
+                "promoted_from_v1": promoted_from_v1,
+            }
+        )
+    else:
+        print_ok(f"{path} is valid (schema_version=v2, name={name})")
+        if promoted_from_v1:
+            print(
+                "  Note: input was v1; the runtime loader would auto-promote "
+                "it to v2 on read. Run `pocketpaw template migrate` to apply "
+                "the rewrite on disk."
+            )
+        for w in warnings:
+            print_warn(w)
+    return 0
+
+
+def _lint_fail(
+    path: Path,
+    errors: list[str],
+    warnings: list[str],
+    promoted_from_v1: bool,
+    as_json: bool,
+) -> int:
+    if as_json:
+        output_json(
+            {
+                "file": str(path),
+                "valid": False,
+                "errors": errors,
+                "warnings": warnings,
+                "schema_version": "v2",
+                "promoted_from_v1": promoted_from_v1,
+            }
+        )
+        return 1
+    print_fail(f"{path} failed validation:")
+    for e in errors:
+        print(f"    - {e}")
+    for w in warnings:
+        print_warn(w)
+    return 1
+
+
+def _format_pydantic_errors(exc: Any) -> list[str]:
+    """Render a Pydantic ``ValidationError`` as a list of one-line
+    ``"at <path>: <message>"`` strings."""
+    out: list[str] = []
+    for err in exc.errors():
+        loc_parts = [str(p) for p in err.get("loc", ())]
+        loc = ".".join(loc_parts) if loc_parts else "<root>"
+        msg = err.get("msg", "validation error")
+        out.append(f"at {loc!r}: {msg}")
+    return out
+
+
+def _compute_warnings(meta: dict[str, Any]) -> list[str]:
+    """Emit heuristic warnings — non-fatal flags for the author."""
+    warnings: list[str] = []
+    pattern = meta.get("pattern")
+    shape = meta.get("shape")
+    if isinstance(pattern, str) and isinstance(shape, str):
+        if (pattern, shape) in _UNUSUAL_PATTERN_SHAPE_PAIRS:
+            warnings.append(
+                f"unusual pattern x shape pairing: pattern={pattern!r} with "
+                f"shape={shape!r} (heuristic — not enforced; double-check intent)"
+            )
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: migrate
+# ---------------------------------------------------------------------------
+
+
+def _run_migrate(
+    path: Path,
+    *,
+    as_json: bool,
+    yes: bool,
+    no_backup: bool,
+) -> int:
+    """Rewrite a v1 template to v2 on disk. Idempotent on v2 input.
+
+    Steps:
+      1. Read + parse.
+      2. If already v2, print a noop message and exit 0.
+      3. Confirm with the user (unless --yes).
+      4. Back up the original to ``<file>.v1.bak`` (unless --no-backup).
+      5. Promote in memory and write back, preserving JSON vs YAML.
+    """
+
+    try:
+        meta = _parse_file(path)
+    except ValueError as exc:
+        if as_json:
+            output_json({"file": str(path), "migrated": False, "error": str(exc)})
+        else:
+            print_fail(str(exc))
+        return 1
+
+    if not _is_v1(meta):
+        if as_json:
+            output_json(
+                {
+                    "file": str(path),
+                    "migrated": False,
+                    "was_already_v2": True,
+                    "backup_path": None,
+                }
+            )
+        else:
+            print_ok(f"{path} is already v2 — no changes")
+        return 0
+
+    # Confirm
+    if not yes:
+        sys.stdout.write(f"Migrate {path} from v1 to v2? [y/N] ")
+        sys.stdout.flush()
+        try:
+            reply = input("")
+        except EOFError:
+            reply = ""
+        if reply.strip().lower() not in {"y", "yes"}:
+            if as_json:
+                output_json(
+                    {
+                        "file": str(path),
+                        "migrated": False,
+                        "was_already_v2": False,
+                        "backup_path": None,
+                        "aborted": True,
+                    }
+                )
+            else:
+                print("  Aborted — no changes written.")
+            return 0
+
+    # Backup
+    backup_path: Path | None = None
+    if not no_backup:
+        backup_path = path.with_suffix(path.suffix + ".v1.bak")
+        try:
+            shutil.copy2(path, backup_path)
+        except OSError as exc:
+            msg = f"failed to write backup at {backup_path}: {exc}"
+            if as_json:
+                output_json({"file": str(path), "migrated": False, "error": msg})
+            else:
+                print_fail(msg)
+            return 1
+
+    # Promote + write
+    from pocketpaw.bundled_templates.loader import _promote_v1_to_v2  # noqa: PLC0415
+
+    promoted = _promote_v1_to_v2(meta)
+    try:
+        _write_file(path, promoted)
+    except Exception as exc:  # noqa: BLE001
+        msg = f"failed to write {path}: {exc}"
+        if as_json:
+            output_json({"file": str(path), "migrated": False, "error": msg})
+        else:
+            print_fail(msg)
+        return 1
+
+    if as_json:
+        output_json(
+            {
+                "file": str(path),
+                "migrated": True,
+                "was_already_v2": False,
+                "backup_path": str(backup_path) if backup_path else None,
+            }
+        )
+    else:
+        print_ok(f"migrated {path} from v1 to v2")
+        if backup_path:
+            print(f"  backup: {backup_path}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: diff
+# ---------------------------------------------------------------------------
+
+
+def _run_diff(file1: Path, file2: Path, *, as_json: bool) -> int:
+    """Semantic diff between two templates.
+
+    Both inputs are promoted to v2 before comparison so v1 vs v2 files
+    compare cleanly. The output is grouped by top-level field; within a
+    group, each line uses one of:
+
+      ``+ <path>: <value>``         (added in file2)
+      ``- <path>: <value>``         (removed from file1)
+      ``~ <path>: <old> -> <new>``  (value changed)
+    """
+
+    try:
+        a_raw = _parse_file(file1)
+        b_raw = _parse_file(file2)
+    except ValueError as exc:
+        if as_json:
+            output_json({"error": str(exc)})
+        else:
+            print_fail(str(exc))
+        return 1
+
+    from pocketpaw.bundled_templates.loader import _promote_v1_to_v2  # noqa: PLC0415
+
+    a = _promote_v1_to_v2(a_raw) if _is_v1(a_raw) else a_raw
+    b = _promote_v1_to_v2(b_raw) if _is_v1(b_raw) else b_raw
+
+    entries: list[dict[str, Any]] = []
+    _walk_diff("", a, b, entries)
+
+    if as_json:
+        output_json(entries)
+        return 0
+
+    if not entries:
+        print_ok(f"no semantic differences between {file1} and {file2}")
+        return 0
+
+    # Group by top-level field (the segment before the first ``.`` or ``[``)
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for entry in entries:
+        top = _top_level_key(entry["path"])
+        grouped.setdefault(top, []).append(entry)
+
+    print(f"  diff: {file1} -> {file2}")
+    for top in sorted(grouped):
+        print(f"\n  [{top}]")
+        for entry in grouped[top]:
+            sym = {"add": "+ ", "remove": "- ", "change": "~ "}[entry["op"]]
+            if entry["op"] == "add":
+                print(f"  {sym}{entry['path']}: {_short(entry['new'])}")
+            elif entry["op"] == "remove":
+                print(f"  {sym}{entry['path']}: {_short(entry['old'])}")
+            else:
+                print(f"  {sym}{entry['path']}: {_short(entry['old'])} -> {_short(entry['new'])}")
+    return 0
+
+
+def _walk_diff(
+    prefix: str,
+    a: Any,
+    b: Any,
+    out: list[dict[str, Any]],
+) -> None:
+    """Recurse over two parsed templates and append diff entries.
+
+    Lists are diffed positionally. Dicts are diffed by key. Scalars are
+    diffed by equality.
+    """
+    if isinstance(a, dict) and isinstance(b, dict):
+        keys = set(a) | set(b)
+        for key in sorted(keys):
+            sub_prefix = f"{prefix}.{key}" if prefix else key
+            if key not in a:
+                out.append({"op": "add", "path": sub_prefix, "new": b[key]})
+            elif key not in b:
+                out.append({"op": "remove", "path": sub_prefix, "old": a[key]})
+            else:
+                _walk_diff(sub_prefix, a[key], b[key], out)
+        return
+
+    if isinstance(a, list) and isinstance(b, list):
+        max_len = max(len(a), len(b))
+        for idx in range(max_len):
+            sub_prefix = f"{prefix}[{idx}]"
+            if idx >= len(a):
+                out.append({"op": "add", "path": sub_prefix, "new": b[idx]})
+            elif idx >= len(b):
+                out.append({"op": "remove", "path": sub_prefix, "old": a[idx]})
+            else:
+                _walk_diff(sub_prefix, a[idx], b[idx], out)
+        return
+
+    if a != b:
+        out.append({"op": "change", "path": prefix, "old": a, "new": b})
+
+
+def _top_level_key(path: str) -> str:
+    """Return the path segment before the first ``.`` or ``[``."""
+    if not path:
+        return "<root>"
+    for i, ch in enumerate(path):
+        if ch in (".", "["):
+            return path[:i]
+    return path
+
+
+def _short(value: Any, limit: int = 60) -> str:
+    """Render a scalar / collection compactly for the diff output."""
+    try:
+        s = json.dumps(value, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        s = str(value)
+    if len(s) > limit:
+        return s[: limit - 3] + "..."
+    return s
+
+
+__all__ = ["run_template_cmd"]

--- a/tests/unit/test_cli_template.py
+++ b/tests/unit/test_cli_template.py
@@ -1,0 +1,533 @@
+# tests/unit/test_cli_template.py
+# Created: 2026-05-25 (feat/rfc-03-v2-cli) — RED-first tests for the
+# new ``pocketpaw template`` CLI subcommand (lint / migrate / diff).
+# These cover the six contract pillars from RFC 03 v2 "Style and tooling
+# notes":
+#   1. lint on a clean v2 fixture exits 0 and reports schema_version.
+#   2. lint on a v1 file auto-promotes and notes the rewrite.
+#   3. lint on an invalid file (missing field / bad enum / bad CEL)
+#      exits 1 and surfaces a per-field message.
+#   4. lint heuristically warns on implausible pattern x shape pairs
+#      but still exits 0.
+#   5. migrate is idempotent on v2, prompts unless --yes, writes a
+#      .v1.bak unless --no-backup, and preserves YAML vs JSON format.
+#   6. diff returns a semantic dict-walked diff (+ / - / ~) grouped
+#      under top-level fields, empty for identical inputs.
+# All commands also support --json for scripting.
+"""Tests for the ``pocketpaw template`` CLI subcommand.
+
+These tests invoke the entry function ``run_template_cmd`` directly so
+they exercise the subcommand dispatch without going through argparse.
+The argparse wiring lives in ``pocketpaw.__main__`` and is covered by
+its own (existing) test_cli_flags shape — repeating it here would only
+test argparse itself.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+import yaml
+
+# The new module under test. RED on import until Phase 2 lands it.
+from pocketpaw.cli.template import run_template_cmd
+
+_FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "templates"
+_LEASE_V2 = _FIXTURES_DIR / "lease-renewal-v2.yaml"
+_BUNDLED_DIR = (
+    Path(__file__).resolve().parents[2] / "src" / "pocketpaw" / "bundled_templates" / "_bundled"
+)
+_TODO_V2 = _BUNDLED_DIR / "todo-task-tracker" / "template.pocket.yaml"
+_KANBAN_V2 = _BUNDLED_DIR / "kanban-board" / "template.pocket.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _capture(fn, /, *args, **kwargs) -> tuple[int, str]:
+    """Call a CLI entry function and return ``(exit_code, stdout)``."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = fn(*args, **kwargs)
+    return rc, buf.getvalue()
+
+
+def _minimal_v2_dict() -> dict:
+    """Smallest dict that round-trips through the Pydantic chokepoint."""
+    return {
+        "schema_version": "2",
+        "name": "minimal-template",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "productivity",
+        "description": "A minimal template used only by CLI tests.",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "columns": [
+                {"field": "title", "widget": "text"},
+                {"field": "status", "widget": "badge"},
+            ],
+        },
+    }
+
+
+def _minimal_v1_dict() -> dict:
+    """v1-shaped dict that mirrors the shipped bundled templates."""
+    return {
+        "name": "todo-task-tracker",
+        "version": "1.0.0",
+        "vertical": "productivity",
+        "shape": "data-grid",
+        "description": "A personal task tracker.",
+        "state": {
+            "entity_type": "Task",
+            "columns": [{"field": "title", "widget": "text"}],
+        },
+        "actions": [],
+        "connectors": [],
+        "skills": [],
+    }
+
+
+def _write_yaml(path: Path, data: dict) -> Path:
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _write_json(path: Path, data: dict) -> Path:
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+# ===========================================================================
+# pocketpaw template lint <file>
+# ===========================================================================
+
+
+def test_lint_clean_v2_fixture_exits_zero_and_reports_schema_version() -> None:
+    rc, out = _capture(run_template_cmd, subaction="lint", file1=str(_LEASE_V2))
+    assert rc == 0
+    assert "valid" in out.lower()
+    # surfaces both the schema version and the slug name
+    assert "v2" in out or "schema_version=v2" in out or '"2"' in out
+    assert "lease-renewal" in out
+
+
+def test_lint_bundled_v2_template_exits_zero(tmp_path: Path) -> None:
+    rc, out = _capture(run_template_cmd, subaction="lint", file1=str(_TODO_V2))
+    assert rc == 0, f"bundled template lint failed: {out}"
+    assert "todo-task-tracker" in out
+
+
+def test_lint_missing_required_field_exits_one(tmp_path: Path) -> None:
+    bad = _minimal_v2_dict()
+    del bad["version"]  # required field
+    f = _write_yaml(tmp_path / "bad.yaml", bad)
+    rc, out = _capture(run_template_cmd, subaction="lint", file1=str(f))
+    assert rc == 1
+    # human-readable error must point at the missing field
+    assert "version" in out.lower()
+
+
+def test_lint_invalid_enum_value_exits_one(tmp_path: Path) -> None:
+    bad = _minimal_v2_dict()
+    bad["shape"] = "not-a-real-shape"
+    f = _write_yaml(tmp_path / "bad-enum.yaml", bad)
+    rc, out = _capture(run_template_cmd, subaction="lint", file1=str(f))
+    assert rc == 1
+    assert "shape" in out.lower()
+
+
+def test_lint_bad_cel_expression_exits_one(tmp_path: Path) -> None:
+    bad = _minimal_v2_dict()
+    bad["state"]["saved_views"] = [{"name": "broken", "filter": "this is :: not :: cel"}]
+    f = _write_yaml(tmp_path / "bad-cel.yaml", bad)
+    rc, out = _capture(run_template_cmd, subaction="lint", file1=str(f))
+    assert rc == 1
+
+
+def test_lint_v1_input_auto_promotes_and_notes_rewrite(tmp_path: Path) -> None:
+    v1 = _minimal_v1_dict()
+    f = _write_yaml(tmp_path / "old.yaml", v1)
+    rc, out = _capture(run_template_cmd, subaction="lint", file1=str(f))
+    # v1 still passes Pydantic *after* promotion — exit 0, with a
+    # human-readable note that the rewrite was applied.
+    assert rc == 0, f"v1 lint after promote should pass; got: {out}"
+    lower = out.lower()
+    assert "v1" in lower
+    assert "promot" in lower or "rewrite" in lower or "migrat" in lower
+
+
+def test_lint_pattern_shape_warning_is_warning_not_error(tmp_path: Path) -> None:
+    """`dashboard` x `kanban` is documented as a heuristic warning, not
+    a hard error. Exit code stays 0; output includes WARN."""
+    odd = _minimal_v2_dict()
+    odd["pattern"] = "dashboard"
+    odd["shape"] = "kanban"
+    odd["state"]["default_view"] = "kanban"  # required for kanban shape
+    f = _write_yaml(tmp_path / "odd.yaml", odd)
+    rc, out = _capture(run_template_cmd, subaction="lint", file1=str(f))
+    assert rc == 0
+    lower = out.lower()
+    assert "warn" in lower or "unusual" in lower
+
+
+def test_lint_json_output_shape(tmp_path: Path) -> None:
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="lint",
+        file1=str(_TODO_V2),
+        as_json=True,
+    )
+    assert rc == 0
+    data = json.loads(out)
+    assert isinstance(data, dict)
+    for key in ("file", "valid", "errors", "warnings", "schema_version"):
+        assert key in data, f"missing key {key!r} in --json output"
+    assert data["valid"] is True
+    assert data["errors"] == []
+
+
+def test_lint_json_output_on_invalid(tmp_path: Path) -> None:
+    bad = _minimal_v2_dict()
+    del bad["version"]
+    f = _write_yaml(tmp_path / "bad.yaml", bad)
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="lint",
+        file1=str(f),
+        as_json=True,
+    )
+    assert rc == 1
+    data = json.loads(out)
+    assert data["valid"] is False
+    assert isinstance(data["errors"], list)
+    assert len(data["errors"]) >= 1
+
+
+def test_lint_json_marks_promoted_from_v1(tmp_path: Path) -> None:
+    v1 = _minimal_v1_dict()
+    f = _write_yaml(tmp_path / "old.yaml", v1)
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="lint",
+        file1=str(f),
+        as_json=True,
+    )
+    assert rc == 0
+    data = json.loads(out)
+    assert data["promoted_from_v1"] is True
+
+
+def test_lint_accepts_json_input(tmp_path: Path) -> None:
+    f = _write_json(tmp_path / "minimal.json", _minimal_v2_dict())
+    rc, out = _capture(run_template_cmd, subaction="lint", file1=str(f))
+    assert rc == 0
+
+
+# ===========================================================================
+# pocketpaw template migrate <file>
+# ===========================================================================
+
+
+def test_migrate_v1_to_v2_happy_path_with_backup(tmp_path: Path) -> None:
+    v1 = _minimal_v1_dict()
+    f = _write_yaml(tmp_path / "lease.yaml", v1)
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="migrate",
+        file1=str(f),
+        yes=True,  # skip prompt
+    )
+    assert rc == 0
+    # 1. file is now v2
+    parsed = yaml.safe_load(f.read_text(encoding="utf-8"))
+    assert parsed["schema_version"] == "2"
+    # 2. backup exists with original v1 content
+    backup = f.with_suffix(f.suffix + ".v1.bak")
+    assert backup.exists()
+    backup_parsed = yaml.safe_load(backup.read_text(encoding="utf-8"))
+    assert "schema_version" not in backup_parsed  # original v1 had none
+    # 3. stdout mentions migration + backup
+    assert "migrate" in out.lower() or "v2" in out.lower()
+
+
+def test_migrate_already_v2_is_noop(tmp_path: Path) -> None:
+    v2 = _minimal_v2_dict()
+    f = _write_yaml(tmp_path / "already.yaml", v2)
+    original = f.read_text(encoding="utf-8")
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="migrate",
+        file1=str(f),
+        yes=True,
+    )
+    assert rc == 0
+    assert f.read_text(encoding="utf-8") == original
+    # no backup created for a noop
+    backup = f.with_suffix(f.suffix + ".v1.bak")
+    assert not backup.exists()
+    assert "already" in out.lower() or "noop" in out.lower() or "no change" in out.lower()
+
+
+def test_migrate_no_backup_flag_skips_backup(tmp_path: Path) -> None:
+    v1 = _minimal_v1_dict()
+    f = _write_yaml(tmp_path / "lease.yaml", v1)
+    rc, _out = _capture(
+        run_template_cmd,
+        subaction="migrate",
+        file1=str(f),
+        yes=True,
+        no_backup=True,
+    )
+    assert rc == 0
+    backup = f.with_suffix(f.suffix + ".v1.bak")
+    assert not backup.exists()
+
+
+def test_migrate_preserves_json_format(tmp_path: Path) -> None:
+    """A .json input must be rewritten as JSON, not YAML."""
+    v1 = _minimal_v1_dict()
+    f = _write_json(tmp_path / "lease.json", v1)
+    rc, _out = _capture(
+        run_template_cmd,
+        subaction="migrate",
+        file1=str(f),
+        yes=True,
+    )
+    assert rc == 0
+    # json.loads succeeds = output is JSON
+    parsed = json.loads(f.read_text(encoding="utf-8"))
+    assert parsed["schema_version"] == "2"
+
+
+def test_migrate_json_output_already_v2(tmp_path: Path) -> None:
+    v2 = _minimal_v2_dict()
+    f = _write_yaml(tmp_path / "v2.yaml", v2)
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="migrate",
+        file1=str(f),
+        yes=True,
+        as_json=True,
+    )
+    assert rc == 0
+    data = json.loads(out)
+    assert data["was_already_v2"] is True
+    assert data["migrated"] is False
+
+
+def test_migrate_json_output_with_migration(tmp_path: Path) -> None:
+    v1 = _minimal_v1_dict()
+    f = _write_yaml(tmp_path / "v1.yaml", v1)
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="migrate",
+        file1=str(f),
+        yes=True,
+        as_json=True,
+    )
+    assert rc == 0
+    data = json.loads(out)
+    assert data["migrated"] is True
+    assert data["was_already_v2"] is False
+    assert data["backup_path"]
+    assert Path(data["backup_path"]).exists()
+
+
+def test_migrate_prompt_aborts_without_yes(tmp_path: Path, monkeypatch) -> None:
+    """No --yes and user types anything other than y/Y aborts."""
+    v1 = _minimal_v1_dict()
+    f = _write_yaml(tmp_path / "v1.yaml", v1)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "n")
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="migrate",
+        file1=str(f),
+        yes=False,
+    )
+    assert rc == 0  # graceful abort, not error
+    # file unchanged — still v1
+    parsed = yaml.safe_load(f.read_text(encoding="utf-8"))
+    assert "schema_version" not in parsed
+    assert "abort" in out.lower() or "cancel" in out.lower() or "skipp" in out.lower()
+
+
+# ===========================================================================
+# pocketpaw template diff <file1> <file2>
+# ===========================================================================
+
+
+def test_diff_identical_files_yields_empty(tmp_path: Path) -> None:
+    v2 = _minimal_v2_dict()
+    a = _write_yaml(tmp_path / "a.yaml", v2)
+    b = _write_yaml(tmp_path / "b.yaml", v2)
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="diff",
+        file1=str(a),
+        file2=str(b),
+    )
+    assert rc == 0
+    # no +/-/~ lines should be present
+    body_lines = [ln for ln in out.splitlines() if ln.startswith(("+ ", "- ", "~ "))]
+    assert body_lines == []
+
+
+def test_diff_added_field(tmp_path: Path) -> None:
+    base = _minimal_v2_dict()
+    added = _minimal_v2_dict()
+    added["icon"] = "home"
+    a = _write_yaml(tmp_path / "a.yaml", base)
+    b = _write_yaml(tmp_path / "b.yaml", added)
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="diff",
+        file1=str(a),
+        file2=str(b),
+    )
+    assert rc == 0
+    assert any("+ " in ln and "icon" in ln for ln in out.splitlines())
+
+
+def test_diff_removed_field(tmp_path: Path) -> None:
+    base = _minimal_v2_dict()
+    base["icon"] = "home"
+    removed = _minimal_v2_dict()
+    a = _write_yaml(tmp_path / "a.yaml", base)
+    b = _write_yaml(tmp_path / "b.yaml", removed)
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="diff",
+        file1=str(a),
+        file2=str(b),
+    )
+    assert rc == 0
+    assert any("- " in ln and "icon" in ln for ln in out.splitlines())
+
+
+def test_diff_changed_value(tmp_path: Path) -> None:
+    base = _minimal_v2_dict()
+    changed = _minimal_v2_dict()
+    changed["version"] = "2.0.0"
+    a = _write_yaml(tmp_path / "a.yaml", base)
+    b = _write_yaml(tmp_path / "b.yaml", changed)
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="diff",
+        file1=str(a),
+        file2=str(b),
+    )
+    assert rc == 0
+    assert any("~ " in ln and "version" in ln for ln in out.splitlines())
+    assert "1.0.0" in out and "2.0.0" in out
+
+
+def test_diff_normalises_v1_against_v2(tmp_path: Path) -> None:
+    """A v1 file diffed against the equivalent v2 file should be (mostly)
+    empty after the internal promotion pass."""
+    v1 = _minimal_v1_dict()
+    # build the v2 equivalent — same data, post-promotion
+    v2 = dict(v1)
+    v2["schema_version"] = "2"
+    v2["display_name"] = "Todo Task Tracker"
+    v2["pattern"] = "app"
+    # rename skills -> skill_refs
+    v2["skill_refs"] = v2.pop("skills")
+    a = _write_yaml(tmp_path / "v1.yaml", v1)
+    b = _write_yaml(tmp_path / "v2.yaml", v2)
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="diff",
+        file1=str(a),
+        file2=str(b),
+    )
+    assert rc == 0
+    body_lines = [ln for ln in out.splitlines() if ln.startswith(("+ ", "- ", "~ "))]
+    assert body_lines == []
+
+
+def test_diff_json_output(tmp_path: Path) -> None:
+    base = _minimal_v2_dict()
+    other = _minimal_v2_dict()
+    other["version"] = "2.0.0"
+    a = _write_yaml(tmp_path / "a.yaml", base)
+    b = _write_yaml(tmp_path / "b.yaml", other)
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="diff",
+        file1=str(a),
+        file2=str(b),
+        as_json=True,
+    )
+    assert rc == 0
+    data = json.loads(out)
+    assert isinstance(data, list)
+    assert any(entry.get("op") == "change" and entry.get("path") == "version" for entry in data)
+
+
+# ===========================================================================
+# Argument-error surface — bad usage exits non-zero with a friendly message
+# ===========================================================================
+
+
+def test_unknown_subaction_returns_error() -> None:
+    rc, _out = _capture(
+        run_template_cmd,
+        subaction="frobnicate",
+        file1="ignored",
+    )
+    assert rc != 0
+
+
+def test_lint_missing_file_returns_error(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.yaml"
+    rc, _out = _capture(run_template_cmd, subaction="lint", file1=str(missing))
+    assert rc != 0
+
+
+def test_diff_requires_two_files(tmp_path: Path) -> None:
+    f = _write_yaml(tmp_path / "a.yaml", _minimal_v2_dict())
+    rc, _out = _capture(
+        run_template_cmd,
+        subaction="diff",
+        file1=str(f),
+        file2=None,
+    )
+    assert rc != 0
+
+
+# ===========================================================================
+# Argparse wiring — sanity that `pocketpaw template lint` parses
+# ===========================================================================
+
+
+def test_argparse_accepts_template_subcommand(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`pocketpaw template lint <file>` resolves to the template entry point."""
+    from pocketpaw.__main__ import _build_parser, _resolve_subargs
+
+    parser = _build_parser()
+    args = parser.parse_args(["template", "lint", str(_TODO_V2)])
+    _resolve_subargs(args)
+    assert args.command == "template"
+    assert args.subaction == "lint"
+    # the file path must be plumbed through to args.file1
+    assert getattr(args, "file1", None) == str(_TODO_V2)
+
+
+def test_argparse_template_diff_two_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    from pocketpaw.__main__ import _build_parser, _resolve_subargs
+
+    parser = _build_parser()
+    args = parser.parse_args(["template", "diff", str(_TODO_V2), str(_KANBAN_V2)])
+    _resolve_subargs(args)
+    assert args.subaction == "diff"
+    assert args.file1 == str(_TODO_V2)
+    assert args.file2 == str(_KANBAN_V2)


### PR DESCRIPTION
Adds the author-facing `pocketpaw template` CLI surface defined in RFC 03 §"Style and tooling notes". The runtime loader's `_promote_v1_to_v2` chokepoint shipped on `feat/rfc-03-v2-schema-chokepoint`; this PR puts a CLI in front of it so authors can validate, migrate, and diff templates without round-tripping through the loader.

## Summary

- `pocketpaw template lint <file>` validates a YAML/JSON template through the v2 `PocketTemplate` Pydantic model. v1 inputs are auto-promoted via the loader's `_promote_v1_to_v2`; the output notes when a rewrite would apply. Heuristic warnings flag implausible `pattern x shape` pairings (e.g. `dashboard x kanban`) without failing the lint.
- `pocketpaw template migrate <file>` rewrites a v1 template to v2 on disk. Idempotent on v2 input (no-op, exit 0). Prompts `y/N` unless `--yes`. Backs the original up to `<file>.v1.bak` unless `--no-backup`. Preserves YAML vs JSON format on output.
- `pocketpaw template diff <file1> <file2>` performs a semantic dict-walked diff. Internally promotes both inputs to v2 so v1 / v2 files compare cleanly. Output is grouped by top-level field; each entry uses `+ <path>: <value>`, `- <path>: <value>`, or `~ <path>: <old> -> <new>`.
- All three commands support `--json` for scripting per pocketpaw's all-CLI convention.

## RFC compliance

RFC §"Style and tooling notes" lists six `pocketpaw template` subcommands. This PR ships three of them:

| Subcommand | Status | Notes |
|---|---|---|
| `lint` | shipped | All bullet points except the Fabric `tier:registered` + `via_link` check (deferred to PR 2g) and skill_refs resolution (Skills loader). |
| `migrate` | shipped | Matches the RFC's "opt-in for authors who want to migrate their on-disk format" description. |
| `diff` | shipped | Schema diff between two versions. |
| `publish` | deferred | Registry signing and content-addressing. Bucket C. |
| `install` | deferred | Registry pull, resolve, materialize. Bucket C. |
| `upgrade` | deferred | Destructive-diff prompts. Bucket C. |

## Files changed

NEW:
- `src/pocketpaw/cli/template.py` (~390 LOC). Subcommand entry, format detection, lint / migrate / diff implementations.
- `tests/unit/test_cli_template.py` (~370 LOC). 29 tests covering each command's happy path, failure path, edge cases (v1 input, already-v2 input, `--yes`, `--no-backup`, identical files, added/removed/changed diffs).

MODIFIED:
- `src/pocketpaw/__main__.py`. Wires `"template"` into the command choices and `_EARLY_COMMANDS`, adds `--yes` / `--no-backup` flags, threads `file1` / `file2` through `_resolve_subargs`, and switches `main()` to `parse_known_args` so flags may appear before positional file paths.

## Test plan

- [x] `cd <worktree> && uv run pytest tests/unit/test_cli_template.py -xvs`. Expected: 29 passed.
- [x] `cd <worktree> && uv run pytest tests/test_cli_flags.py -xvs`. Expected: 3 passed (the `parse_known_args` switch does not regress the existing `--telegram` flag-conflict test).
- [x] `cd <worktree> && uv run pytest tests/unit/test_template_schema.py tests/unit/test_bundled_templates.py`. Expected: 63 passed, 5 skipped (no chokepoint regression).
- [x] `cd <worktree> && uv run ruff check src/pocketpaw/cli/template.py src/pocketpaw/__main__.py tests/unit/test_cli_template.py`. Expected: clean.
- [x] `cd <worktree> && uv run ruff format --check src/pocketpaw/cli/template.py src/pocketpaw/__main__.py tests/unit/test_cli_template.py`. Expected: 3 files already formatted.

Manual CLI smoke:

```
$ uv run pocketpaw template lint tests/fixtures/templates/lease-renewal-v2.yaml
  [OK]   tests/fixtures/templates/lease-renewal-v2.yaml is valid (schema_version=v2, name=lease-renewal-v1)

$ uv run pocketpaw template lint src/pocketpaw/bundled_templates/_bundled/todo-task-tracker/template.pocket.yaml
  [OK]   .../todo-task-tracker/template.pocket.yaml is valid (schema_version=v2, name=todo-task-tracker)

$ uv run pocketpaw template migrate --yes /tmp/test_v1.yaml
  [OK]   migrated /tmp/test_v1.yaml from v1 to v2
  backup: /tmp/test_v1.yaml.v1.bak

$ uv run pocketpaw template diff <todo-task-tracker> <kanban-board>
  diff: .../todo-task-tracker/template.pocket.yaml -> .../kanban-board/template.pocket.yaml
  [description]
  ~ description: "A personal task tracker. ..." -> "A drag-and-drop kanban board ..."
  [display_name]
  ~ display_name: "Task Tracker" -> "Kanban Board"
  [name]
  ~ name: "todo-task-tracker" -> "kanban-board"
  [shape]
  ~ shape: "data-grid" -> "kanban"
  [state]
  ~ state.columns[2].field: "priority" -> "assignee"
  ~ state.columns[2].widget: "badge" -> "text"
  - state.columns[3]: {"field": "due_date", "widget": "date"}
  ~ state.entity_type: "Task" -> "Card"
```

## Stacking note

This PR is stacked on `feat/rfc-03-v2-schema-chokepoint` (PR #1225). It will be re-targeted to `feat/rfc-03-v2-integration` after the chokepoint squash-merges into integration. The diff shown by GitHub is the CLI work only; the chokepoint changes belong to #1225.

## Out of scope (separate PRs)

- `pocketpaw template publish / install / upgrade`. Registry + content-addressing work. Bucket C.
- Fabric `tier:registered` + `joined_entities[].via_link` registry enforcement in `lint`. Needs Fabric integration. PR 2g.
- Remote `skill_refs[]` resolution in `lint`. Skills loader work.
- Anything in `ee/cloud/pockets/`. Runtime, not CLI.
