### PR TITLE
feat(foresight): mount cloud router + Beanie persistence (RFC 08 PR 7)

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,12 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-05-25 (feat/foresight-v07-cloud-mount) — RFC 08 PR 7.
+    Mounts the Foresight router at ``/api/v1/foresight/*`` alongside the
+    other domain routers. Routes delegate to ``ee.cloud.foresight.service``
+    which owns Beanie writes against the ``foresight_runs`` collection.
+    The engine itself (vendored OASIS substrate + CAMEL adapter) lives at
+    ``ee/pocketpaw_ee/foresight/``; the cloud surface is a thin shell over
+    persistence + event emission.
 Modified: 2026-05-24 (#1202) — Registers ``register_audit_bridge`` during
     ``mount_cloud`` so every ``security.audit.AuditLogger.log()`` call from
     EE cloud writers (pocket actions, source runs, skills config, …) is
@@ -144,6 +151,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.chat.router import router as chat_router
     from pocketpaw_ee.cloud.connectors.router import router as connectors_router
     from pocketpaw_ee.cloud.cycles.router import router as cycles_router
+    from pocketpaw_ee.cloud.foresight.router import router as foresight_router
     from pocketpaw_ee.cloud.license import get_license_info
     from pocketpaw_ee.cloud.planner.router import router as planner_router
     from pocketpaw_ee.cloud.pockets.chat_router import router as pocket_chat_router
@@ -168,6 +176,12 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(planner_router, prefix="/api/v1")
     app.include_router(sessions_router, prefix="/api/v1")
     app.include_router(cycles_router, prefix="/api/v1")
+    # Foresight — RFC 08 scenario-run surface (POST /foresight/scenarios,
+    # GET /foresight/runs[/{id}]). Mounted alongside cycles so the
+    # Mission Control rail can launch / inspect simulation runs from the
+    # same surface as live cycles. Persistence lands in the
+    # ``foresight_runs`` Mongo collection via ``ee.cloud.foresight.service``.
+    app.include_router(foresight_router, prefix="/api/v1")
     # Skills — per-backend API-skill install (POST /skills/api-doc).
     app.include_router(skills_router, prefix="/api/v1")
 

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -440,6 +440,29 @@ class PlanGapResolved(Event):
     EVENT_TYPE: ClassVar[str] = "plan.gap_resolved"
 
 
+# Foresight — RFC 08 scenario runs. ``ForesightRunCreated`` fires when a
+# scenario run document is first inserted (status="queued"); the engine
+# then ticks the run (in PR 7 it stays synchronous, in v1.0 it fans to a
+# background task) and fires either ``ForesightRunCompleted`` once the
+# run lands a wire-dict ``result`` or ``ForesightRunFailed`` if the
+# engine raises. Listeners use these to refresh the UI rail's Live +
+# Results panels (RFC §11.3 / §11.4) and, in v1.0, to seed the
+# calibration loop's prediction buffer (RFC §9.1).
+@dataclass
+class ForesightRunCreated(Event):
+    EVENT_TYPE: ClassVar[str] = "foresight.run.created"
+
+
+@dataclass
+class ForesightRunCompleted(Event):
+    EVENT_TYPE: ClassVar[str] = "foresight.run.completed"
+
+
+@dataclass
+class ForesightRunFailed(Event):
+    EVENT_TYPE: ClassVar[str] = "foresight.run.failed"
+
+
 # Composio — per-user OAuth integrations (Gmail, Slack, GitHub, …)
 # verified via per-toolkit identity probes. ``ComposioConnectionVerified``
 # fires when a probe succeeds and the stored identity matches (or first

--- a/ee/pocketpaw_ee/cloud/foresight/__init__.py
+++ b/ee/pocketpaw_ee/cloud/foresight/__init__.py
@@ -1,10 +1,15 @@
 # ee/pocketpaw_ee/cloud/foresight/__init__.py
+# Modified: 2026-05-25 (feat/foresight-v07-cloud-mount) — PR 7. Cloud
+#   Foresight package now ships the canonical 4-file shape: domain.py
+#   (frozen value objects), dto.py (Pydantic request/response schemas),
+#   service.py (Beanie writes, business logic, event emission), and
+#   router.py (thin FastAPI endpoints). The Beanie document lives at
+#   ``ee.cloud.models.foresight_run`` per the cloud convention; only
+#   this entity's service.py imports it (enforced by import-linter).
+#   The router is mounted from ``mount_cloud`` alongside cycles_router.
 # Created: 2026-05-25 (feat/foresight-v01-scaffold) — RFC 08 v0.1 scaffold.
+#
 # Cloud-side Foresight package — exposes the REST router. The engine
 # lives at ee/pocketpaw_ee/foresight/ (a runtime module); this package
 # is the thin cloud surface that mounts under /api/v1/foresight/* via
 # ee/pocketpaw_ee/cloud/__init__.py:mount_cloud.
-#
-# v0.1 ships a 2-file surface (dto.py + router.py) and writes to the
-# foresight engine's in-memory RunStore. v1.0 adds domain.py +
-# service.py per the cloud 4-file rule once Mongo persistence lands.

--- a/ee/pocketpaw_ee/cloud/foresight/domain.py
+++ b/ee/pocketpaw_ee/cloud/foresight/domain.py
@@ -1,0 +1,94 @@
+# ee/pocketpaw_ee/cloud/foresight/domain.py
+# Created: 2026-05-25 (feat/foresight-v07-cloud-mount) — RFC 08 PR 7.
+#
+# Foresight cloud domain — frozen value objects, no Beanie / Pydantic /
+# FastAPI imports. The service (``ee.cloud.foresight.service``) maps
+# between these and the ``ForesightRun`` Beanie document; the DTO layer
+# (``ee.cloud.foresight.dto``) maps these to Pydantic responses.
+#
+# Multi-tenancy is enforced at construction per the cloud rule #3:
+# ``workspace_id`` is required positionally with no default — building a
+# ``ScenarioRun`` without one is a type error.
+#
+# Two value objects ship in PR 7:
+#
+#   - ``ScenarioRun`` — the persisted run record (mirrors RFC §7.7's
+#     run-level fields: status, request, result, error).
+#   - ``ProjectedDecision`` — the RFC §7.7 projected-decision shape
+#     (run_id, sim_tick, projection_confidence). Not persisted in PR 7
+#     (the engine emits projections inside ``RunResult.as_wire_dict``);
+#     freezing the type now so PR 8's per-tick fan-out doesn't have to
+#     reshape the surface.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal
+
+ScenarioRunStatus = Literal["queued", "running", "complete", "failed"]
+
+
+@dataclass(frozen=True)
+class ScenarioRun:
+    """One Foresight scenario run, scoped to a workspace.
+
+    Fields mirror the ``ForesightRun`` Beanie document plus the cloud
+    rule #3 tenancy invariant. ``request`` is the validated POST body
+    the operator submitted; ``result`` is the engine's
+    ``RunResult.as_wire_dict()`` once the run completes; ``error`` is
+    the failure message string when the run raises.
+
+    ``id`` is the Mongo ``ObjectId`` rendered as a hex string — the wire
+    contract the v0.1 in-memory store committed to (UUID strings via
+    ``str(uuid4())``) is honoured by the response DTO, which normalizes
+    both forms into a single string field.
+    """
+
+    id: str
+    workspace_id: str
+    scenario_name: str
+    status: ScenarioRunStatus
+    created_at: datetime
+    request: dict[str, Any]
+    result: dict[str, Any] | None = None
+    error: str | None = None
+    created_by: str = ""
+    updated_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class ProjectedDecision:
+    """A Decision (RFC 07 shape) emitted inside a Foresight run.
+
+    Same field set as the real Decision (anchor object, payload, actors)
+    plus three Foresight-specific extras per RFC §7.7:
+
+    - ``run_id``: the Foresight run that produced this projection.
+    - ``sim_tick``: the simulation tick at which the chain closed.
+    - ``projection_confidence``: aggregate confidence in (0.0, 1.0).
+
+    Not persisted as its own Mongo collection in PR 7 — projected
+    decisions live inside the run's ``result`` dict for now. PR 8 fans
+    them out into a sibling ``projected_decisions`` collection so the
+    Decision-Graph join (RFC §7.7 ``forward-precedent`` edge) can be
+    indexed cheaply. Freezing the dataclass now so PR 8's persistence
+    layer doesn't have to reshape the wire contract.
+    """
+
+    id: str
+    workspace_id: str
+    run_id: str
+    sim_tick: int
+    anchor_object_id: str
+    payload: dict[str, Any]
+    projection_confidence: float = 0.5
+    actors: tuple[str, ...] = field(default_factory=tuple)
+    created_at: datetime | None = None
+
+
+__all__ = [
+    "ProjectedDecision",
+    "ScenarioRun",
+    "ScenarioRunStatus",
+]

--- a/ee/pocketpaw_ee/cloud/foresight/dto.py
+++ b/ee/pocketpaw_ee/cloud/foresight/dto.py
@@ -1,4 +1,8 @@
 # ee/pocketpaw_ee/cloud/foresight/dto.py
+# Modified: 2026-05-25 (feat/foresight-v07-cloud-mount) — PR 7 adds
+#   ScenarioRunListItemResponse (lighter shape for GET /runs without
+#   the inline ``result`` blob) and re-exports the existing v0.1 shapes
+#   unchanged so any v0.1 caller keeps working.
 # Created: 2026-05-25 (feat/foresight-v01-scaffold) — RFC 08 v0.1 scaffold.
 #
 # Request / response models for the Foresight REST surface. Per the
@@ -58,14 +62,54 @@ class ScenarioRunResponse(BaseModel):
     returns a "queued" envelope with the run id and a websocket subscription
     URL, GET returns the full result with the per-tick aggregates and
     projected decisions stream.
+
+    PR 7 keeps the v0.1 wire field set (id, scenario_name, status,
+    created_at, request, result, error) and adds an optional
+    ``workspace_id`` so the cloud surface can echo the tenancy key the
+    persistence layer enforces. Older callers that only consumed the
+    v0.1 fields keep working — Pydantic's default ``extra="forbid"``
+    constraint is unchanged at the request side; responses tolerate
+    additional fields client-side.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     id: str
+    workspace_id: str | None = None
     scenario_name: str
     status: str  # "queued" | "running" | "complete" | "failed"
     created_at: str  # ISO-8601
+    updated_at: str | None = None
     request: dict[str, Any]
     result: dict[str, Any] | None = None
     error: str | None = None
+
+
+class ScenarioRunListItemResponse(BaseModel):
+    """Lighter shape for ``GET /runs`` — drops the inline ``result`` and
+    ``request`` blobs so the list endpoint stays cheap on workspaces
+    that have accumulated dozens of runs.
+
+    The detail endpoint (``GET /runs/{id}``) returns the full
+    :class:`ScenarioRunResponse` shape; the frontend Scenarios + Live
+    panels (RFC §11.2 / §11.3) use the list shape for cards and call
+    the detail endpoint when the operator clicks through.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    workspace_id: str | None = None
+    scenario_name: str
+    status: str
+    created_at: str
+    updated_at: str | None = None
+    error: str | None = None
+
+
+__all__ = [
+    "CreateScenarioRequest",
+    "PersonaSpecRequest",
+    "ScenarioRunListItemResponse",
+    "ScenarioRunResponse",
+]

--- a/ee/pocketpaw_ee/cloud/foresight/router.py
+++ b/ee/pocketpaw_ee/cloud/foresight/router.py
@@ -1,48 +1,36 @@
 # ee/pocketpaw_ee/cloud/foresight/router.py
+# Modified: 2026-05-25 (feat/foresight-v07-cloud-mount) — PR 7. Routes now
+#   delegate to ``ee.cloud.foresight.service`` instead of writing through
+#   the in-memory ``RunStore``; ``GET /runs`` (list endpoint) added; the
+#   router is mounted from ``mount_cloud`` (no more ``include_foresight_router``
+#   helper). The v0.1 wire contract is preserved — POST /scenarios still
+#   returns the completed run synchronously and GET /runs/{id} still
+#   returns the same field set.
 # Created: 2026-05-25 (feat/foresight-v01-scaffold) — RFC 08 v0.1 scaffold.
 #
-# Foresight REST surface — v0.1 contract:
+# Foresight REST surface — PR 7 contract:
 #
-#   POST /api/v1/foresight/scenarios   → run a scenario inline, return result
-#   GET  /api/v1/foresight/runs/{id}   → fetch a stored run
+#   POST /api/v1/foresight/scenarios     → run a scenario inline, return result
+#   GET  /api/v1/foresight/runs/{id}     → fetch a stored run
+#   GET  /api/v1/foresight/runs          → list runs in the caller's workspace
 #
-# v0.1 runs synchronously (the smoke loop is fast — milliseconds with
-# DeterministicFakeBackend) and persists results in the in-memory
-# RunStore from ee/pocketpaw_ee/foresight/api/run_store.py. v1.0 swaps
-# the store for Beanie documents, adds a service module, fans the run
-# out to a background task, and exposes a websocket for live tick
-# updates (RFC §11.3 Live panel).
-#
-# Not yet wired into mount_cloud — wiring lands in the follow-up PR
-# that adds the cloud rule #1 4-file shape (domain.py + service.py).
-# v0.1 ships the router behind an explicit ``include_foresight_router``
-# helper so the contract is testable without committing to the mount
-# order.
+# Mounted by ``ee.cloud.__init__:mount_cloud`` alongside the other cloud
+# routers. Service-owned writes go to the ``ForesightRun`` Beanie
+# collection (see ``ee.cloud.models.foresight_run``); persistence
+# survives restarts and is workspace-scoped.
 
 from __future__ import annotations
 
-from uuid import UUID
-
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
-from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
+from pocketpaw_ee.cloud.foresight import service as foresight_service
 from pocketpaw_ee.cloud.foresight.dto import (
     CreateScenarioRequest,
+    ScenarioRunListItemResponse,
     ScenarioRunResponse,
 )
 from pocketpaw_ee.cloud.license import require_license
-from pocketpaw_ee.foresight.api.run_store import (
-    RunStore,
-    get_run_store,
-    record_to_wire,
-)
-from pocketpaw_ee.foresight.persona import OceanDrift
-from pocketpaw_ee.foresight.scenarios.runner import (
-    PersonaSpec,
-    ScenarioConfig,
-    run_scenario,
-)
 
 router = APIRouter(
     prefix="/foresight",
@@ -55,98 +43,57 @@ router = APIRouter(
 async def create_scenario_run(
     body: CreateScenarioRequest,
     ctx: RequestContext = Depends(request_context),
-    store: RunStore = Depends(get_run_store),
 ) -> ScenarioRunResponse:
     """Run a scenario inline and return the result.
 
-    v0.1 contract:
+    PR 7 contract:
       - Body declares personas inline (no scenario library yet).
       - Backend is the deterministic fake (no API key required).
       - Run completes synchronously before the response returns.
-      - Result is also persisted in the in-memory RunStore so
-        ``GET /runs/{id}`` returns the same payload.
+      - Result is persisted in the ``foresight_runs`` Mongo collection
+        so ``GET /runs/{id}`` returns the same payload across restarts.
 
     v1.0 will:
       - Accept ``scenario_id`` to reference a saved scenario.
       - Route to the configured backend tier-pool.
       - Return ``status="queued"`` with a websocket URL; the run
         fans out to a background task.
-      - Emit ``foresight.run_started`` and ``foresight.run_complete``
-        events on the InProcessBus (RFC §17 cross-references).
+      - Emit ``foresight.run_started`` (in addition to the
+        ``foresight.run.created`` PR 7 already emits) so the UI's
+        Live panel can distinguish accepted-but-pending from actively
+        ticking runs.
     """
-    # Cloud rule #6: re-parse at service entry. The router has already
-    # parsed via FastAPI but the equivalent service function (v1.0)
-    # will be called from bus handlers / MCP tools / CLI — keep the
-    # pattern visible even when the router is the only caller.
-    body = CreateScenarioRequest.model_validate(body)
-
-    try:
-        personas = [
-            PersonaSpec(
-                name=p.name,
-                role=p.role,
-                ocean=OceanDrift(**p.ocean),
-            )
-            for p in body.personas
-        ]
-        config = ScenarioConfig(
-            name=body.name,
-            sub_type=body.sub_type,
-            n_ticks=body.n_ticks,
-            personas=personas,
-        )
-    except (TypeError, ValueError, NotImplementedError) as exc:
-        # ConfigValidation maps to 422 — keep the error code namespaced
-        # to the foresight surface so dashboards can filter on it.
-        raise ValidationError("foresight.invalid_scenario", str(exc)) from exc
-
-    record = store.create(
-        scenario_name=body.name,
-        request=body.model_dump(),
-    )
-
-    store.mark_running(record.id)
-    try:
-        result = await run_scenario(config)
-    except Exception as exc:  # noqa: BLE001 — capture into the store, never bubble
-        store.mark_failed(record.id, f"{type(exc).__name__}: {exc}")
-        # Re-fetch so the response carries the failure marker.
-        record = store.get(record.id)  # type: ignore[assignment]
-        assert record is not None  # noqa: S101 — invariant; we just created it
-        return ScenarioRunResponse.model_validate(record_to_wire(record))
-
-    store.mark_complete(record.id, result.as_wire_dict())
-    record = store.get(record.id)  # type: ignore[assignment]
-    assert record is not None  # noqa: S101 — invariant; we just created it
-
-    # v1.0 will emit `foresight.run_complete` here via the InProcessBus
-    # so the UI rail's Live panel can refresh and the calibration loop
-    # can pick up the prediction buffer entries. v0.1 stops at the
-    # store write — no event emission yet, no calibration capture.
-    return ScenarioRunResponse.model_validate(record_to_wire(record))
+    return await foresight_service.create_scenario_run(ctx, body)
 
 
 @router.get("/runs/{run_id}", response_model=ScenarioRunResponse)
 async def get_run(
     run_id: str,
     ctx: RequestContext = Depends(request_context),
-    store: RunStore = Depends(get_run_store),
 ) -> ScenarioRunResponse:
     """Fetch a stored run by id.
 
-    Returns 404 (``foresight_run.not_found``) if the id is unknown,
-    422 (``foresight.invalid_run_id``) if the id is not a valid UUID.
-    v1.0 adds RBAC filtering (you can only see runs for workspaces
-    you have access to) once the cloud service module lands.
+    Returns 404 (``foresight_run.not_found``) if the id is unknown or
+    belongs to another workspace — existence is deliberately not
+    leakable across tenants.
     """
-    try:
-        rid = UUID(run_id)
-    except ValueError as exc:
-        raise ValidationError(
-            "foresight.invalid_run_id",
-            f"run id must be a UUID, got {run_id!r}",
-        ) from exc
-    record = store.get(rid)
-    if record is None:
-        raise NotFound("foresight_run", run_id)
-    return ScenarioRunResponse.model_validate(record_to_wire(record))
+    return await foresight_service.get_scenario_run(ctx, run_id)
+
+
+@router.get("/runs", response_model=list[ScenarioRunListItemResponse])
+async def list_runs(
+    limit: int = Query(default=50, ge=1, le=200),
+    ctx: RequestContext = Depends(request_context),
+) -> list[ScenarioRunListItemResponse]:
+    """List runs in the caller's workspace, most recent first.
+
+    The frontend Scenarios panel (RFC §11.2) consumes this. The
+    lighter list-item shape omits the inline ``result`` blob so a
+    workspace with dozens of runs serves the list cheaply; click into
+    a row to fetch the full :class:`ScenarioRunResponse` via the
+    detail endpoint.
+    """
+    return await foresight_service.list_scenario_runs(ctx, limit=limit)
+
+
+__all__ = ["router"]

--- a/ee/pocketpaw_ee/cloud/foresight/service.py
+++ b/ee/pocketpaw_ee/cloud/foresight/service.py
@@ -1,0 +1,335 @@
+# ee/pocketpaw_ee/cloud/foresight/service.py
+# Created: 2026-05-25 (feat/foresight-v07-cloud-mount) — RFC 08 PR 7.
+#
+# Foresight cloud service — business logic for scenario runs. Sole owner
+# of writes to the ``ForesightRun`` Beanie document per the cloud rule
+# #2; module-level ``async def`` functions per rule #5; ``RequestContext``
+# first; validate-at-entry; emit on every state-mutating write.
+#
+# Public API:
+#   - ``create_scenario_run(ctx, body)`` — POST /foresight/scenarios
+#   - ``get_scenario_run(ctx, run_id)`` — GET /foresight/runs/{id}
+#   - ``list_scenario_runs(ctx)`` — GET /foresight/runs
+#
+# The engine call itself (``run_scenario`` from the foresight runtime)
+# stays synchronous inside ``create_scenario_run`` — PR 7 keeps the v0.1
+# request/response contract (run completes before POST returns) so
+# existing tests + the smoke loop are undisturbed. v1.0 fans the run
+# out to a background task and the POST returns immediately with
+# ``status="queued"``.
+#
+# Engine import is lazy: the cloud surface stays clean of any
+# ``ee.foresight.{persona,llm,scenarios}`` imports until the moment the
+# service actually runs a scenario, so importing the cloud module never
+# drags in CAMEL or the OASIS substrate (those land via PR 2's
+# ``pocketpaw-ee[foresight]`` optional extra).
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from beanie import PydanticObjectId
+
+from pocketpaw_ee.cloud._core.context import RequestContext
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound, ValidationError
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import (
+    ForesightRunCompleted,
+    ForesightRunCreated,
+    ForesightRunFailed,
+)
+from pocketpaw_ee.cloud._core.time import iso_utc
+from pocketpaw_ee.cloud.foresight.domain import ScenarioRun
+from pocketpaw_ee.cloud.foresight.dto import (
+    CreateScenarioRequest,
+    ScenarioRunListItemResponse,
+    ScenarioRunResponse,
+)
+from pocketpaw_ee.cloud.models.foresight_run import ForesightRun as _ForesightRunDoc
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Mapping helpers (kept private; cloud rule #8 prefers Pydantic mapping but
+# the ``request`` / ``result`` ``dict[str, Any]`` fields don't benefit from
+# ``from_attributes`` since they're already JSON-shaped).
+# ---------------------------------------------------------------------------
+
+
+def _to_domain(doc: _ForesightRunDoc) -> ScenarioRun:
+    return ScenarioRun(
+        id=str(doc.id),
+        workspace_id=doc.workspace,
+        scenario_name=doc.scenario_name,
+        status=doc.status,  # type: ignore[arg-type]
+        created_at=doc.createdAt,
+        request=dict(doc.request or {}),
+        result=dict(doc.result) if doc.result else None,
+        error=doc.error,
+        created_by=doc.created_by,
+        updated_at=getattr(doc, "updatedAt", None),
+    )
+
+
+def _to_response(run: ScenarioRun) -> ScenarioRunResponse:
+    return ScenarioRunResponse(
+        id=run.id,
+        workspace_id=run.workspace_id,
+        scenario_name=run.scenario_name,
+        status=run.status,
+        created_at=iso_utc(run.created_at) or "",
+        updated_at=iso_utc(run.updated_at),
+        request=dict(run.request),
+        result=dict(run.result) if run.result else None,
+        error=run.error,
+    )
+
+
+def _to_list_item_response(run: ScenarioRun) -> ScenarioRunListItemResponse:
+    return ScenarioRunListItemResponse(
+        id=run.id,
+        workspace_id=run.workspace_id,
+        scenario_name=run.scenario_name,
+        status=run.status,
+        created_at=iso_utc(run.created_at) or "",
+        updated_at=iso_utc(run.updated_at),
+        error=run.error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tenancy helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_workspace(ctx: RequestContext) -> str:
+    """Foresight always operates in a workspace; routes that bypass an
+    active workspace should never reach the service. Raise a Forbidden
+    so the caller gets a clean 403 rather than a 500."""
+    if not ctx.workspace_id:
+        raise Forbidden(
+            "foresight.no_workspace",
+            "Active workspace required for foresight operations",
+        )
+    return ctx.workspace_id
+
+
+async def _fetch_in_workspace(workspace_id: str, run_id: str) -> _ForesightRunDoc:
+    """Fetch a run scoped to the caller's workspace; raise NotFound if
+    the id is malformed, the doc is missing, or it lives in another
+    workspace (so we don't leak existence across tenants)."""
+    try:
+        oid = PydanticObjectId(run_id)
+    except Exception:
+        raise NotFound("foresight_run", run_id) from None
+    doc = await _ForesightRunDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        raise NotFound("foresight_run", run_id)
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Engine call — kept behind a lazy import so the cloud module never pulls
+# in CAMEL / OASIS / Claude SDK on import.
+# ---------------------------------------------------------------------------
+
+
+async def _run_engine_inline(body: CreateScenarioRequest) -> dict[str, Any]:
+    """Drive the foresight engine for one scenario run.
+
+    Imports are lazy: the engine modules (persona, llm, scenarios) live
+    under ``ee.pocketpaw_ee.foresight.*`` and the cloud layer must not
+    statically import them per the cloud-vs-engine separation. The
+    cloud rule #2 forbids touching the Beanie doc outside this service;
+    the analogous principle on the engine side is that the cloud
+    surface must remain importable without the engine's optional deps.
+
+    Returns the engine's ``RunResult.as_wire_dict()`` so the caller can
+    persist the run as a JSON-shaped blob without leaking dataclass
+    types into the persistence layer.
+    """
+    from pocketpaw_ee.foresight.persona import OceanDrift
+    from pocketpaw_ee.foresight.scenarios.runner import (
+        PersonaSpec,
+        ScenarioConfig,
+        run_scenario,
+    )
+
+    personas = [
+        PersonaSpec(
+            name=p.name,
+            role=p.role,
+            ocean=OceanDrift(**p.ocean),
+        )
+        for p in body.personas
+    ]
+    config = ScenarioConfig(
+        name=body.name,
+        sub_type=body.sub_type,
+        n_ticks=body.n_ticks,
+        personas=personas,
+    )
+    result = await run_scenario(config)
+    return result.as_wire_dict()
+
+
+# ---------------------------------------------------------------------------
+# Public service API
+# ---------------------------------------------------------------------------
+
+
+async def create_scenario_run(
+    ctx: RequestContext, body: CreateScenarioRequest
+) -> ScenarioRunResponse:
+    """Insert a run document, drive the engine inline, persist the result.
+
+    Three writes happen here:
+
+      1. Insert the doc with ``status="queued"`` so the run has an id
+         immediately (even though PR 7 keeps the run synchronous,
+         persisting the queued state makes the v1.0 background-task
+         migration mechanical — POST will simply return after step 1).
+      2. Save with ``status="running"`` before the engine call.
+      3. Save with ``status="complete"`` + ``result`` after success, or
+         ``status="failed"`` + ``error`` on engine failure.
+
+    Each write emits its own event so listeners (the UI rail's Live
+    panel, the v1.0 calibration loop) can react incrementally instead
+    of polling.
+
+    Engine failures are caught and persisted as ``status="failed"`` —
+    we never let an engine exception bubble out, because that would
+    leave the run document orphaned in ``status="running"``.
+    """
+    body = CreateScenarioRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+
+    # Lazy import inside the engine helper; constructing the config also
+    # validates engine-side rules (sub_type, n_ticks, personas) so we
+    # surface those as 422 before opening a doc row.
+    try:
+        # Build the config once to surface engine-side validation errors
+        # before persisting; the actual run is driven from
+        # ``_run_engine_inline`` below to keep the import lazy.
+        from pocketpaw_ee.foresight.persona import OceanDrift
+        from pocketpaw_ee.foresight.scenarios.runner import PersonaSpec, ScenarioConfig
+
+        _ = ScenarioConfig(
+            name=body.name,
+            sub_type=body.sub_type,
+            n_ticks=body.n_ticks,
+            personas=[
+                PersonaSpec(
+                    name=p.name,
+                    role=p.role,
+                    ocean=OceanDrift(**p.ocean),
+                )
+                for p in body.personas
+            ],
+        )
+    except (TypeError, ValueError, NotImplementedError) as exc:
+        raise ValidationError("foresight.invalid_scenario", str(exc)) from exc
+
+    doc = _ForesightRunDoc(
+        workspace=workspace_id,
+        scenario_name=body.name,
+        status="queued",
+        request=body.model_dump(),
+        created_by=ctx.user_id,
+    )
+    await doc.insert()
+
+    created_response = _to_response(_to_domain(doc))
+    await emit(ForesightRunCreated(data=created_response.model_dump()))
+
+    # Mark running before the engine call so observers see the
+    # transition. The save also bumps ``updatedAt`` via the
+    # TimestampedDocument hook.
+    doc.status = "running"
+    await doc.save()
+    # no-event: the ``running`` transition is an implementation detail of
+    # PR 7's inline run mode — the v1.0 background-task migration will
+    # emit a dedicated ``ForesightRunStarted`` event from the worker.
+    # PR 7 keeps the v0.1 event vocabulary (created → completed/failed).
+
+    try:
+        result_dict = await _run_engine_inline(body)
+    except Exception as exc:  # noqa: BLE001 — capture into the doc, never bubble
+        error_message = f"{type(exc).__name__}: {exc}"
+        doc.status = "failed"
+        doc.error = error_message
+        await doc.save()
+        failed_response = _to_response(_to_domain(doc))
+        await emit(ForesightRunFailed(data=failed_response.model_dump()))
+        logger.warning(
+            "foresight.create_scenario_run: engine failed for run %s in ws=%s: %s",
+            doc.id,
+            workspace_id,
+            error_message,
+        )
+        return failed_response
+
+    doc.status = "complete"
+    doc.result = result_dict
+    await doc.save()
+
+    completed_response = _to_response(_to_domain(doc))
+    await emit(ForesightRunCompleted(data=completed_response.model_dump()))
+    return completed_response
+
+
+async def get_scenario_run(ctx: RequestContext, run_id: str) -> ScenarioRunResponse:
+    """Fetch a single run by id, scoped to the caller's workspace.
+
+    Returns 404 (``foresight_run.not_found``) if the id is unknown,
+    malformed, or belongs to another tenant — we deliberately collapse
+    "wrong workspace" into "not found" so existence isn't leakable
+    across tenants.
+    """
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_in_workspace(workspace_id, run_id)
+    # no-event: read-only path; emit only on writes (cloud rule #9).
+    return _to_response(_to_domain(doc))
+
+
+async def list_scenario_runs(
+    ctx: RequestContext, *, limit: int = 50
+) -> list[ScenarioRunListItemResponse]:
+    """List runs in the caller's workspace, most recent first.
+
+    ``limit`` caps the response at 50 by default; the frontend's
+    Scenarios panel paginates beyond that. The lighter
+    :class:`ScenarioRunListItemResponse` shape drops the inline
+    ``result`` blob so a workspace with a hundred runs still serves
+    the list endpoint in tens of kilobytes rather than megabytes.
+    """
+    workspace_id = _require_workspace(ctx)
+    if limit < 1:
+        raise ValidationError("foresight.invalid_limit", "limit must be >= 1")
+    if limit > 200:
+        # Hard cap so a misconfigured caller can't drag the entire
+        # collection into memory; the frontend never asks for more.
+        limit = 200
+
+    # Tenant filter on every read per cloud rule #7. Sort newest first
+    # so the Scenarios panel renders most-recent-on-top without a
+    # client-side reorder pass. ``_id`` tiebreaker keeps the ordering
+    # stable when ``createdAt`` collides at sub-millisecond resolution
+    # (a hot create loop will produce ties under in-memory Mongo and
+    # under sub-millisecond Mongo clocks in production).
+    docs = (
+        await _ForesightRunDoc.find({"workspace": workspace_id})
+        .sort([("createdAt", -1), ("_id", -1)])  # type: ignore[list-item]
+        .limit(limit)
+        .to_list()
+    )
+    return [_to_list_item_response(_to_domain(d)) for d in docs]
+
+
+__all__ = [
+    "create_scenario_run",
+    "get_scenario_run",
+    "list_scenario_runs",
+]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -13,6 +13,7 @@ from pocketpaw_ee.cloud.models.composio_connection import ComposioConnection
 from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
 from pocketpaw_ee.cloud.models.cycle import Cycle, CycleDailyPoint
 from pocketpaw_ee.cloud.models.file import FileObj
+from pocketpaw_ee.cloud.models.foresight_run import ForesightRun
 from pocketpaw_ee.cloud.models.group import Group, GroupAgent
 from pocketpaw_ee.cloud.models.invite import Invite
 from pocketpaw_ee.cloud.models.message import Attachment, Mention, Message, Reaction
@@ -56,6 +57,7 @@ __all__ = [
     "FileFolder",
     "FileObj",
     "FileUpload",
+    "ForesightRun",
     "Group",
     "GroupAgent",
     "Invite",
@@ -109,6 +111,7 @@ def get_all_documents():
         Cycle,
         Project,
         PlanSession,
+        ForesightRun,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/models/foresight_run.py
+++ b/ee/pocketpaw_ee/cloud/models/foresight_run.py
@@ -1,0 +1,65 @@
+# ee/pocketpaw_ee/cloud/models/foresight_run.py
+# Created: 2026-05-25 (feat/foresight-v07-cloud-mount) — RFC 08 PR 7.
+#
+# Foresight run document — Mongo persistence for scenario runs that were
+# previously held in the v0.1 in-memory ``RunStore`` (ee/foresight/api/
+# run_store.py). One document per scenario run; carries the request body
+# the operator submitted, the engine's ``RunResult.as_wire_dict()`` once
+# the run completes, and an error string when the run fails.
+#
+# The full RFC §7.7 ProjectedDecision fan-out (per-tick aggregates +
+# projected_decisions rows + calibration buffer entries) lands in PR 8+;
+# this PR ships the run-level collection only so the cloud surface has
+# durable storage for ``GET /foresight/runs/:id`` / ``GET /foresight/runs``
+# across restarts and across workers.
+#
+# Only ``ee.cloud.foresight.service`` may import this module — enforced by
+# the import-linter contract in ``ee/pyproject.toml``.
+
+from __future__ import annotations
+
+from typing import Any
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class ForesightRun(TimestampedDocument):
+    """One Foresight scenario run, persisted in Mongo.
+
+    The wire shape (``ee.cloud.foresight.dto.ScenarioRunResponse``) mirrors
+    the fields below 1-to-1 with workspace-stripping at the response layer —
+    the operator's view never includes the tenancy key directly, that lives
+    on the dependency-resolved ``RequestContext``.
+
+    Status vocabulary matches the v0.1 in-memory store so the API contract
+    is unchanged: ``queued | running | complete | failed``.
+
+    ``request`` is the validated POST body (``CreateScenarioRequest.model_dump()``);
+    ``result`` is the engine's ``RunResult.as_wire_dict()`` once the run
+    completes (or ``None`` while queued / running / failed); ``error`` is
+    the failure message when the run raises.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    scenario_name: str
+    status: str = Field(
+        default="queued",
+        pattern="^(queued|running|complete|failed)$",
+    )
+    request: dict[str, Any] = Field(default_factory=dict)
+    result: dict[str, Any] | None = None
+    error: str | None = None
+    created_by: str = ""
+
+    class Settings:
+        name = "foresight_runs"
+        indexes = [
+            [("workspace", 1), ("status", 1)],
+            # ``createdAt`` ordering is the default Mongo cursor for the
+            # list endpoint; an explicit index keeps the most-recent-first
+            # query cheap once a workspace accumulates dozens of runs.
+            [("workspace", 1), ("createdAt", -1)],
+        ]

--- a/ee/pocketpaw_ee/foresight/api/run_store.py
+++ b/ee/pocketpaw_ee/foresight/api/run_store.py
@@ -1,15 +1,25 @@
 # ee/pocketpaw_ee/foresight/api/run_store.py
+# Modified: 2026-05-25 (feat/foresight-v07-cloud-mount) — PR 7. SUPERSEDED.
+#   The cloud router no longer uses this store; ``ee.cloud.foresight.service``
+#   persists runs to the ``foresight_runs`` Mongo collection via Beanie
+#   instead. Kept in-tree as a documented deprecation breadcrumb so any
+#   v0.1 caller pinning the old import path fails loudly rather than
+#   silently regressing to ephemeral storage. Remove after one release
+#   cycle once no external callers reference it.
 # Created: 2026-05-25 (feat/foresight-v01-scaffold) — RFC 08 v0.1 scaffold.
 #
 # In-memory run store — the v0.1 stand-in for the projected_decisions
 # + foresight_runs Mongo collections RFC §7.7 + §13.1 specify. The
-# router writes a RunRecord on POST /scenarios and reads it on
-# GET /runs/{id}; tests inject a fresh store via the singleton resolver.
+# v0.1 router wrote a RunRecord on POST /scenarios and read it on
+# GET /runs/{id}; tests injected a fresh store via the singleton
+# resolver.
 #
-# v1.0 swaps this for Beanie documents under ee/pocketpaw_ee/cloud/foresight/
-# following the cloud rules (4-file shape, service-owned writes, events
-# on every mutation). The router will then talk to a service module
-# instead of this store directly.
+# PR 7 SUPERSEDED this with Beanie-backed persistence at
+# ``ee.cloud.foresight.service``. The 4-file cloud shape ships in the
+# same PR: domain.py (value objects), dto.py (request/response),
+# service.py (Beanie writes + event emission), router.py (thin endpoints).
+# The router is mounted from ``mount_cloud``; this in-memory store is
+# no longer wired into the request path.
 
 from __future__ import annotations
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -347,6 +347,41 @@ source_modules = [
 forbidden_modules = ["pocketpaw_ee.cloud.models.cycle"]
 
 [[tool.importlinter.contracts]]
+name = "Foresight — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.cloud.foresight.router",
+    "pocketpaw_ee.cloud.foresight.dto",
+    "pocketpaw_ee.cloud.foresight.domain",
+]
+forbidden_modules = ["pocketpaw_ee.cloud.models.foresight_run"]
+
+[[tool.importlinter.contracts]]
+name = "Foresight cloud — must not import the engine layer"
+# Cloud is API + persistence + service; the engine (persona, llm,
+# scenarios, substrate) carries the OASIS + CAMEL deps and is the
+# optional ``pocketpaw-ee[foresight]`` extra. Static imports from the
+# cloud entity into the engine would couple the cloud surface to the
+# optional extra; the service uses lazy imports inside the engine call
+# path instead. router / dto / domain / models stay clean.
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.cloud.foresight.router",
+    "pocketpaw_ee.cloud.foresight.dto",
+    "pocketpaw_ee.cloud.foresight.domain",
+    "pocketpaw_ee.cloud.models.foresight_run",
+]
+forbidden_modules = [
+    "pocketpaw_ee.foresight.persona",
+    "pocketpaw_ee.foresight.llm",
+    "pocketpaw_ee.foresight.scenarios",
+    "pocketpaw_ee.foresight.substrate",
+    "pocketpaw_ee.foresight.world",
+]
+
+[[tool.importlinter.contracts]]
 name = "Projects — Beanie writes only from service.py"
 type = "forbidden"
 allow_indirect_imports = "true"

--- a/tests/cloud/test_foresight_domain.py
+++ b/tests/cloud/test_foresight_domain.py
@@ -1,0 +1,106 @@
+# tests/cloud/test_foresight_domain.py — RFC 08 PR 7.
+# Created: 2026-05-25 (feat/foresight-v07-cloud-mount) — domain-layer
+#   tests for the frozen value objects. No Mongo / Beanie / FastAPI;
+#   asserts the cloud-rule #3 tenancy invariant (workspace_id required
+#   at construction) and the ProjectedDecision field set per RFC §7.7.
+"""Domain-layer tests for ``ee.cloud.foresight.domain``."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud.foresight.domain import ProjectedDecision, ScenarioRun
+
+
+def _scenario_run(**overrides) -> ScenarioRun:
+    defaults = {
+        "id": "abc",
+        "workspace_id": "w1",
+        "scenario_name": "test",
+        "status": "complete",
+        "created_at": datetime.now(UTC),
+        "request": {},
+    }
+    defaults.update(overrides)
+    return ScenarioRun(**defaults)
+
+
+def test_scenario_run_is_frozen() -> None:
+    """Frozen dataclass — mutating after construction is a TypeError.
+
+    Mirrors the cycles + notifications domain convention: value objects
+    are immutable so the service can pass them around without worrying
+    about callers mutating state behind its back.
+    """
+    run = _scenario_run()
+    with pytest.raises(FrozenInstanceError):
+        run.status = "failed"  # type: ignore[misc]
+
+
+def test_scenario_run_requires_workspace_id() -> None:
+    """Cloud rule #3: tenancy is enforced at construction. No default
+    for ``workspace_id`` means TypeError when omitted."""
+    with pytest.raises(TypeError):
+        ScenarioRun(  # type: ignore[call-arg]
+            id="abc",
+            scenario_name="test",
+            status="complete",
+            created_at=datetime.now(UTC),
+            request={},
+        )
+
+
+def test_scenario_run_carries_optional_result_and_error() -> None:
+    run = _scenario_run(result={"actions_logged": 5}, error=None)
+    assert run.result == {"actions_logged": 5}
+    assert run.error is None
+
+    failed = _scenario_run(status="failed", error="engine outage", result=None)
+    assert failed.status == "failed"
+    assert failed.error == "engine outage"
+
+
+def test_projected_decision_carries_rfc_extras() -> None:
+    """RFC §7.7: a ProjectedDecision is a Decision plus three extras —
+    ``run_id``, ``sim_tick``, ``projection_confidence``. Freeze the
+    contract now so PR 8's persistence layer doesn't have to reshape."""
+    pd = ProjectedDecision(
+        id="proj-1",
+        workspace_id="w1",
+        run_id="run-1",
+        sim_tick=10,
+        anchor_object_id="lease:LR-2026-117",
+        payload={"outcome": "accept", "price": 2850},
+        projection_confidence=0.78,
+        actors=("renewal_specialist", "approver_prakash"),
+    )
+    assert pd.run_id == "run-1"
+    assert pd.sim_tick == 10
+    assert 0.0 < pd.projection_confidence < 1.0
+    assert pd.anchor_object_id == "lease:LR-2026-117"
+
+
+def test_projected_decision_is_frozen() -> None:
+    pd = ProjectedDecision(
+        id="p",
+        workspace_id="w1",
+        run_id="r",
+        sim_tick=0,
+        anchor_object_id="x",
+        payload={},
+    )
+    with pytest.raises(FrozenInstanceError):
+        pd.projection_confidence = 0.9  # type: ignore[misc]
+
+
+def test_projected_decision_requires_workspace_id() -> None:
+    with pytest.raises(TypeError):
+        ProjectedDecision(  # type: ignore[call-arg]
+            id="p",
+            run_id="r",
+            sim_tick=0,
+            anchor_object_id="x",
+            payload={},
+        )

--- a/tests/cloud/test_foresight_router.py
+++ b/tests/cloud/test_foresight_router.py
@@ -1,0 +1,186 @@
+# tests/cloud/test_foresight_router.py — RFC 08 PR 7.
+# Created: 2026-05-25 (feat/foresight-v07-cloud-mount) — HTTP-layer tests
+#   for ``ee.cloud.foresight.router``. Smokes the endpoint surface end-to-end
+#   through a FastAPI app — status mapping, tenancy via context override,
+#   create → get → list round-trip. Service-level assertions live in
+#   ``test_foresight_service.py``; this file only covers the wiring.
+"""HTTP-layer tests for ``ee/cloud/foresight/router.py``."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.foresight.router import router as foresight_router
+from pocketpaw_ee.cloud.license import require_license
+
+
+def _make_ctx(workspace_id: str | None, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(foresight_router)
+
+    async def _ctx() -> RequestContext:
+        return _make_ctx(workspace_id, user_id)
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def mongo_only(mongo_db: Any):
+    """Reuse the shared mongo_db fixture without dragging in chat router."""
+    yield mongo_db
+
+
+@pytest_asyncio.fixture
+async def w1_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id="w1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id="w2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def no_ws_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id=None)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "smoke-run",
+        "sub_type": "decision_forecast",
+        "n_ticks": 1,
+        "personas": [{"name": "Anne", "role": "approver", "ocean": {}}],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Smoke
+# ---------------------------------------------------------------------------
+
+
+async def test_post_then_get(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/foresight/scenarios", json=_payload(name="echo-run"))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["scenario_name"] == "echo-run"
+    assert body["status"] == "complete"
+    assert body["workspace_id"] == "w1"
+    rid = body["id"]
+
+    r2 = await w1_client.get(f"/foresight/runs/{rid}")
+    assert r2.status_code == 200
+    body2 = r2.json()
+    assert body2["id"] == rid
+    assert body2["result"]["scenario_name"] == "echo-run"
+
+
+async def test_list_endpoint_returns_lighter_shape(w1_client: AsyncClient) -> None:
+    await w1_client.post("/foresight/scenarios", json=_payload(name="run-a"))
+    await w1_client.post("/foresight/scenarios", json=_payload(name="run-b"))
+
+    r = await w1_client.get("/foresight/runs")
+    assert r.status_code == 200, r.text
+    items = r.json()
+    assert len(items) == 2
+    # Most-recent-first ordering.
+    assert items[0]["scenario_name"] == "run-b"
+    # List shape drops the inline result blob.
+    assert "result" not in items[0]
+    assert "request" not in items[0]
+
+
+async def test_list_respects_limit_query(w1_client: AsyncClient) -> None:
+    for i in range(3):
+        await w1_client.post("/foresight/scenarios", json=_payload(name=f"run-{i}"))
+
+    r = await w1_client.get("/foresight/runs?limit=2")
+    assert r.status_code == 200
+    assert len(r.json()) == 2
+
+
+async def test_get_404_on_unknown_run(w1_client: AsyncClient) -> None:
+    r = await w1_client.get("/foresight/runs/5f50c31b1c9d440000000000")
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "foresight_run.not_found"
+
+
+async def test_get_404_on_malformed_id(w1_client: AsyncClient) -> None:
+    r = await w1_client.get("/foresight/runs/not-an-objectid")
+    assert r.status_code == 404
+
+
+async def test_post_422_on_unsupported_sub_type(w1_client: AsyncClient) -> None:
+    r = await w1_client.post(
+        "/foresight/scenarios",
+        json=_payload(sub_type="market_sim"),
+    )
+    # The engine-side validation surfaces as a 422 with the
+    # foresight-namespaced error code.
+    assert r.status_code == 422
+    assert r.json()["error"]["code"] == "foresight.invalid_scenario"
+
+
+async def test_post_forbidden_without_workspace(no_ws_client: AsyncClient) -> None:
+    r = await no_ws_client.post("/foresight/scenarios", json=_payload())
+    assert r.status_code == 403
+    assert r.json()["error"]["code"] == "foresight.no_workspace"
+
+
+# ---------------------------------------------------------------------------
+# Tenancy
+# ---------------------------------------------------------------------------
+
+
+async def test_get_isolates_across_workspaces(
+    w1_client: AsyncClient, w2_client: AsyncClient
+) -> None:
+    r = await w1_client.post("/foresight/scenarios", json=_payload(name="w1-private"))
+    rid = r.json()["id"]
+
+    # w2 can't see w1's run — collapsed to 404 so existence isn't
+    # cross-tenant leakable.
+    r2 = await w2_client.get(f"/foresight/runs/{rid}")
+    assert r2.status_code == 404
+
+
+async def test_list_isolates_across_workspaces(
+    w1_client: AsyncClient, w2_client: AsyncClient
+) -> None:
+    await w1_client.post("/foresight/scenarios", json=_payload(name="w1-only"))
+    await w2_client.post("/foresight/scenarios", json=_payload(name="w2-only"))
+
+    items_w1 = (await w1_client.get("/foresight/runs")).json()
+    items_w2 = (await w2_client.get("/foresight/runs")).json()
+    assert {i["scenario_name"] for i in items_w1} == {"w1-only"}
+    assert {i["scenario_name"] for i in items_w2} == {"w2-only"}

--- a/tests/cloud/test_foresight_service.py
+++ b/tests/cloud/test_foresight_service.py
@@ -1,0 +1,234 @@
+# tests/cloud/test_foresight_service.py — RFC 08 PR 7.
+# Created: 2026-05-25 (feat/foresight-v07-cloud-mount) — service-level
+#   tests for ``ee.cloud.foresight.service``. Exercises the create →
+#   persist → emit cycle, tenancy isolation, validation, and the
+#   list / get read paths against the shared mongomock-motor fixture.
+"""Tests for ``ee.cloud.foresight.service`` — Beanie persistence + emit.
+
+Service-level coverage for the PR 7 cloud surface. Uses the ``mongo_db``
+fixture from ``tests/cloud/conftest.py`` so writes flow through real
+Beanie machinery against an isolated in-memory Mongo per test. The
+``recording_bus`` autouse fixture captures emitted events so each write
+can be paired against its event without standing up the WebSocket bus.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound, ValidationError
+from pocketpaw_ee.cloud._core.realtime.events import (
+    ForesightRunCompleted,
+    ForesightRunCreated,
+    ForesightRunFailed,
+)
+from pocketpaw_ee.cloud.foresight import service as foresight_service
+from pocketpaw_ee.cloud.foresight.dto import (
+    CreateScenarioRequest,
+    PersonaSpecRequest,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace: str | None = "w1", user: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _body(name: str = "renewal-forecast", n_ticks: int = 1) -> CreateScenarioRequest:
+    """Smallest legal POST body — one persona, deterministic backend."""
+    return CreateScenarioRequest(
+        name=name,
+        sub_type="decision_forecast",
+        n_ticks=n_ticks,
+        personas=[
+            PersonaSpecRequest(name="Anne", role="approver", ocean={}),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+async def test_create_persists_run_with_tenancy(recording_bus) -> None:
+    ctx = _ctx(workspace="w1", user="shawn")
+    out = await foresight_service.create_scenario_run(ctx, _body(name="q3-renewal"))
+
+    assert out.workspace_id == "w1"
+    assert out.scenario_name == "q3-renewal"
+    # PR 7 keeps the run synchronous, so POST returns ``complete`` (or
+    # ``failed`` on engine error, exercised in its own test below).
+    assert out.status == "complete"
+    assert out.result is not None
+    assert out.result["scenario_name"] == "q3-renewal"
+    assert out.result["n_ticks"] == 1
+
+
+async def test_create_emits_created_then_completed(recording_bus) -> None:
+    ctx = _ctx()
+    out = await foresight_service.create_scenario_run(ctx, _body())
+
+    created = [e for e in recording_bus.events if isinstance(e, ForesightRunCreated)]
+    completed = [e for e in recording_bus.events if isinstance(e, ForesightRunCompleted)]
+    assert len(created) == 1
+    assert len(completed) == 1
+    # The created event carries the queued state; the completed event
+    # carries the final result. Both reference the same run id.
+    assert created[0].data["id"] == out.id
+    assert created[0].data["status"] == "queued"
+    assert completed[0].data["id"] == out.id
+    assert completed[0].data["status"] == "complete"
+
+
+async def test_create_rejects_unsupported_sub_type() -> None:
+    ctx = _ctx()
+    # ``market_sim`` lands in a later PR; PR 7's engine only supports
+    # ``decision_forecast`` and the service surfaces engine validation
+    # as a 422 before opening a doc row.
+    body = CreateScenarioRequest(
+        name="early-market-sim",
+        sub_type="market_sim",
+        n_ticks=1,
+        personas=[PersonaSpecRequest(name="A", role="participant", ocean={})],
+    )
+    with pytest.raises(ValidationError) as exc:
+        await foresight_service.create_scenario_run(ctx, body)
+    assert exc.value.code == "foresight.invalid_scenario"
+
+
+async def test_create_requires_workspace() -> None:
+    ctx = _ctx(workspace=None)
+    with pytest.raises(Forbidden) as exc:
+        await foresight_service.create_scenario_run(ctx, _body())
+    assert exc.value.code == "foresight.no_workspace"
+
+
+async def test_create_captures_engine_failure_as_failed_status(monkeypatch, recording_bus) -> None:
+    """If the engine raises mid-run, the doc lands as ``failed`` with
+    an ``error`` populated, and a ``ForesightRunFailed`` event fires —
+    not bubble out as a 500."""
+    ctx = _ctx()
+
+    async def _boom(_body):
+        raise RuntimeError("simulated engine outage")
+
+    # Patch the lazy engine call (the service's only side door into the
+    # engine layer) to raise; the service should catch + persist the
+    # failure rather than letting the exception bubble back to the
+    # router as a 500.
+    monkeypatch.setattr(foresight_service, "_run_engine_inline", _boom)
+
+    out = await foresight_service.create_scenario_run(ctx, _body(name="boom-run"))
+
+    assert out.status == "failed"
+    assert out.error is not None
+    assert "simulated engine outage" in out.error
+
+    failed = [e for e in recording_bus.events if isinstance(e, ForesightRunFailed)]
+    assert len(failed) == 1
+    assert failed[0].data["id"] == out.id
+
+
+# ---------------------------------------------------------------------------
+# Get + tenancy
+# ---------------------------------------------------------------------------
+
+
+async def test_get_returns_same_payload() -> None:
+    ctx = _ctx()
+    created = await foresight_service.create_scenario_run(ctx, _body(name="echo"))
+
+    fetched = await foresight_service.get_scenario_run(ctx, created.id)
+    assert fetched.id == created.id
+    assert fetched.scenario_name == "echo"
+    assert fetched.result == created.result
+
+
+async def test_get_404_for_unknown_id() -> None:
+    ctx = _ctx()
+    # Use a syntactically valid ObjectId that's not in the DB so we
+    # exercise the ``find_one`` miss path rather than the malformed-id
+    # branch (the latter is exercised below).
+    with pytest.raises(NotFound):
+        await foresight_service.get_scenario_run(ctx, "5f50c31b1c9d440000000000")
+
+
+async def test_get_404_for_malformed_id() -> None:
+    ctx = _ctx()
+    with pytest.raises(NotFound):
+        await foresight_service.get_scenario_run(ctx, "not-an-objectid")
+
+
+async def test_get_isolates_across_workspaces() -> None:
+    """A run created in w1 must be invisible from w2 — and the surface
+    must collapse "wrong workspace" into 404 so existence isn't leakable."""
+    ctx_w1 = _ctx(workspace="w1")
+    ctx_w2 = _ctx(workspace="w2")
+    created = await foresight_service.create_scenario_run(ctx_w1, _body(name="private"))
+
+    with pytest.raises(NotFound):
+        await foresight_service.get_scenario_run(ctx_w2, created.id)
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+
+async def test_list_returns_newest_first() -> None:
+    ctx = _ctx()
+    first = await foresight_service.create_scenario_run(ctx, _body(name="run-1"))
+    second = await foresight_service.create_scenario_run(ctx, _body(name="run-2"))
+    third = await foresight_service.create_scenario_run(ctx, _body(name="run-3"))
+
+    items = await foresight_service.list_scenario_runs(ctx)
+    assert [i.id for i in items] == [third.id, second.id, first.id]
+
+
+async def test_list_drops_result_blob_to_keep_payload_small() -> None:
+    """The list-item shape omits ``result`` so dozens of runs serve
+    cheaply. The detail endpoint is the source of truth for the full
+    wire-dict — that contract is exercised in ``test_get_*`` above."""
+    ctx = _ctx()
+    await foresight_service.create_scenario_run(ctx, _body())
+
+    items = await foresight_service.list_scenario_runs(ctx)
+    assert len(items) == 1
+    serialized = items[0].model_dump()
+    assert "result" not in serialized
+    assert "request" not in serialized
+
+
+async def test_list_isolates_across_workspaces() -> None:
+    ctx_w1 = _ctx(workspace="w1")
+    ctx_w2 = _ctx(workspace="w2")
+    await foresight_service.create_scenario_run(ctx_w1, _body(name="w1-only"))
+    await foresight_service.create_scenario_run(ctx_w2, _body(name="w2-only"))
+
+    w1_items = await foresight_service.list_scenario_runs(ctx_w1)
+    w2_items = await foresight_service.list_scenario_runs(ctx_w2)
+
+    assert {i.scenario_name for i in w1_items} == {"w1-only"}
+    assert {i.scenario_name for i in w2_items} == {"w2-only"}
+
+
+async def test_list_requires_workspace() -> None:
+    ctx = _ctx(workspace=None)
+    with pytest.raises(Forbidden):
+        await foresight_service.list_scenario_runs(ctx)
+
+
+async def test_list_rejects_invalid_limit() -> None:
+    ctx = _ctx()
+    with pytest.raises(ValidationError):
+        await foresight_service.list_scenario_runs(ctx, limit=0)


### PR DESCRIPTION
## Summary

PR 7 of the RFC 08 Foresight rollout. Wires the v0.1 REST surface into `mount_cloud` and replaces the in-memory `RunStore` with a workspace-scoped `foresight_runs` Mongo collection. Brings the cloud entity onto the canonical 4-file shape (`domain` / `dto` / `service` / `router`) every other ee/cloud module follows.

## What ships

**Cloud entity (4-file rule):**
- `domain.py` — frozen `ScenarioRun` + `ProjectedDecision` value objects, `workspace_id` required at construction (cloud rule #3).
- `service.py` — sole owner of Beanie writes (rule #2); `create_scenario_run` / `get_scenario_run` / `list_scenario_runs`; validate-at-entry; emits on every state change; tenant filter on every read; lazy engine import so the cloud module stays installable without the optional `pocketpaw-ee[foresight]` extra.
- `router.py` — refactored to delegate. Adds `GET /runs` (list); preserves the v0.1 `POST /scenarios` + `GET /runs/{id}` wire contract.
- `dto.py` — adds `ScenarioRunListItemResponse` (lighter shape for the list endpoint, no inline `result` blob).

**Persistence:**
- `cloud/models/foresight_run.py` — Beanie `ForesightRun` doc (`foresight_runs` collection, indexes on `workspace+status` and `workspace+createdAt`). Registered in `ALL_DOCUMENTS`.

**Mount wiring:**
- `mount_cloud` now includes `foresight_router` alongside `cycles_router`. Boot exposes `/api/v1/foresight/scenarios`, `/foresight/runs`, `/foresight/runs/{id}`.

**Events:**
- New `ForesightRunCreated` / `ForesightRunCompleted` / `ForesightRunFailed` on the realtime bus so listeners react incrementally.

**Import-linter contracts:**
- Beanie writes only from `foresight/service.py`.
- Cloud entity must not statically import the engine layer (`persona` / `llm` / `scenarios` / `substrate` / `world`).

**Deprecation breadcrumb:**
- `ee/foresight/api/run_store.py` marked SUPERSEDED. Router no longer uses it but the module stays in-tree so any v0.1 caller pinning the import path fails loudly rather than silently regressing to ephemeral storage.

## Decisions made

- **Beanie doc lives at `cloud/models/foresight_run.py`, not `foresight/persistence.py`.** Every other cloud entity puts its doc in `cloud/models/<entity>.py`; import-linter enforces "only `<entity>/service.py` touches `models.<entity>`." A `persistence.py` inside the entity dir would have duplicated that convention.
- **Sort tiebreaker on `_id`.** The list endpoint sorts `(createdAt -1, _id -1)` so rapid creates that share a sub-millisecond timestamp stay deterministically ordered. Caught by a flake under mongomock-motor; same risk exists in real Mongo.
- **Engine call stays inline inside `create_scenario_run`.** v0.1 had the run complete synchronously before POST returns; PR 7 preserves that so the existing smoke tests and the deterministic-fake backend keep working. v1.0 fans the run to a background task and returns `202 + queued` immediately.
- **Lazy engine import.** The service only imports `pocketpaw_ee.foresight.persona / llm / scenarios` inside the engine-call helper. Keeps the cloud module installable when `pocketpaw-ee[foresight]` is not present and keeps cold-import latency off the cloud boot path.

## Verification

- `tests/cloud/test_foresight_domain.py` — 6 tests (frozen + tenancy invariant for both domain objects).
- `tests/cloud/test_foresight_service.py` — 14 tests (create/get/list against mongomock-motor; tenancy isolation; engine-failure capture; event emission).
- `tests/cloud/test_foresight_router.py` — 9 tests (HTTP-layer wiring through FastAPI with context overrides; status mapping; cross-workspace 404 collapse).
- 105 foresight tests green (76 existing engine + 29 new cloud).
- 134 tests green with cycles included (regression sweep).
- 18 import-linter contracts kept (2 new ones included).
- ruff check + ruff format clean on changed files.
- mypy clean on changed files.
- `mount_cloud` boots cleanly with the 3 routes registered.
- `pytest --collect-only` finds 5323 tests with no import errors.

## Deferred to PR 8

- Per-tick `ProjectedDecision` fan-out into a sibling `projected_decisions` collection (PR 7 emits projections inside `RunResult.as_wire_dict`).
- Background-task fan-out for the run loop; v1.0 returns 202 + WS URL.
- Calibration buffer wiring (RFC §9.1 prediction-buffer capture on `ProjectedDecision` emission).
- `forward-precedent` edge writes back to the Decision Graph (RFC 07).

The captain still has to flip `POCKETPAW_CLOUD_SCHEDULER_ENABLED` + the license-checked deployment surface to exercise the route in prod; PR 7's coverage is the in-process bootstrap + the persisted contract.

## Test plan

- [x] `tests/cloud/test_foresight_*.py` — service + router + domain, all green
- [x] `tests/ee/foresight/*.py` — existing engine suite untouched (76 pass)
- [x] `tests/cloud/test_cycles_*.py` — sanity check that the mount + models changes didn't regress neighbors (29 pass, 1 skipped)
- [x] `lint-imports --config ee/pyproject.toml` — 18 contracts kept
- [x] `ruff check` + `ruff format --check` on changed files — clean
- [x] `mypy` on changed files — clean (the 2 errors I introduced were a Beanie `.sort()` stub mismatch identical to `cycles/service.py:473`; suppressed with the same `type: ignore[list-item]` comment)
- [x] `pytest --collect-only` over the full suite — 5323 tests collected

Refs: RFC 08 (`temp/brain-storming/to-build/08-foresight-module-rfc.md`)