### PR TITLE
feat(foresight): RFC 08 PR 3 — substrate wiring + calibration + tier pool + LiteLLM fallback

### DIFF
--- a/ee/pocketpaw_ee/foresight/__init__.py
+++ b/ee/pocketpaw_ee/foresight/__init__.py
@@ -1,4 +1,15 @@
 # ee/pocketpaw_ee/foresight/__init__.py
+# Updated: 2026-05-25 (feat/foresight-v03-calibration) — PR 3:
+#   - Bumped __version__ to 0.3.0 — CAMEL hard-dep promotion, OASIS
+#     substrate wiring (AgentGraph + PawSocialAgent), real LiteLLM
+#     fallback, tier_pool builder, calibration loop, CAMEL
+#     FunctionTool → SDK Permissions translator.
+#   - Lazy-export surface grew: TierMix, build_tier_pool,
+#     tier_distribution, make_paw_social_agent, PredictionRecord,
+#     PredictionBuffer, CalibrationPair, CalibrationSummary,
+#     pair_against_reality, aggregate_pairs, apply_correction,
+#     build_prediction_record, Correction, CORRECTION_CAP,
+#     translate_camel_tools_to_sdk_overrides.
 # Updated: 2026-05-25 (feat/foresight-v02-oasis-camel-paw) — PR 2:
 #   - Bumped __version__ to 0.2.0 to reflect the OASIS substrate
 #     vendoring + adapter expansion + PawAgent wrapping.
@@ -7,40 +18,59 @@
 # Created: 2026-05-25 (feat/foresight-v01-scaffold) — RFC 08 v0.1 scaffold.
 # Foresight module — the "rehearse the future" engine for the Paw IS.
 #
-# PR 1 (v0.1) shipped the module skeleton + minimal end-to-end loop
-# (Decision Forecast sub-type, 5 personas, 1 tick).
-# PR 2 (v0.2 — this commit) lands:
-#   - The vendored OASIS fork at substrate/oasis/ (upstream SHA 46cdc8d).
-#   - ClaudeCodeBackend.run(messages, ...) — CAMEL BaseModelBackend surface.
-#   - SoulSeededPersona(paw_agent=...) — RFC §7.2 fidelity floor.
-#   - LiteLLMFallbackBackend stub.
-# See docs/internal/2026-05-foresight.md for the full cut.
-#
-# Public surface (v0.2):
-#   - ForesightWorld   — Fabric-backed world stub (world.py)
-#   - SoulSeededPersona — soul-seeded persona (now PawAgent-aware) (persona.py)
-#   - ClaudeCodeBackend — CC SDK ↔ CAMEL BaseModelBackend adapter (llm/adapter.py)
-#   - LiteLLMFallbackBackend — fallback proxy stub (llm/adapter.py)
-#   - run_scenario     — single-scenario smoke entrypoint (scenarios/runner.py)
-#
-# The engine surfaces remain protocol-shaped at v0.2 — the OASIS
-# substrate is vendored but PR 3 is the one that wires it into the
-# tick loop. v1.0 fully wires the vendored substrate; v2.0 scales to
-# 100K personas.
+# Public surface (v0.3, RFC 08 PR 3):
+#   - ForesightWorld   — Fabric-backed world stub with optional
+#                        OASIS AgentGraph (world.py)
+#   - SoulSeededPersona — soul-seeded persona w/ PawAgent fidelity
+#                          (persona.py)
+#   - make_paw_social_agent — OASIS SocialAgent subclass factory
+#                              (persona.py · PR 3)
+#   - ClaudeCodeBackend — CC SDK ↔ CAMEL BaseModelBackend adapter
+#                          (llm/adapter.py)
+#   - LiteLLMFallbackBackend — real litellm.acompletion proxy
+#                                (llm/adapter.py · PR 3)
+#   - translate_camel_tools_to_sdk_overrides — FunctionTool → SDK
+#       Permissions translator (llm/adapter.py · PR 3)
+#   - TierMix, build_tier_pool, tier_distribution — tier-pool
+#       primitives (llm/tier_pool.py · PR 3)
+#   - PredictionRecord, PredictionBuffer, CalibrationPair,
+#     CalibrationSummary, pair_against_reality, aggregate_pairs,
+#     apply_correction, Correction, CORRECTION_CAP,
+#     build_prediction_record — calibration loop primitives
+#       (calibration.py · PR 3)
+#   - run_scenario     — single-scenario smoke entrypoint
+#                          (scenarios/runner.py)
 
 from __future__ import annotations
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
-    "ForesightWorld",
-    "SoulSeededPersona",
+    "CORRECTION_CAP",
+    "CalibrationPair",
+    "CalibrationSummary",
     "ClaudeCodeBackend",
+    "Correction",
+    "DeterministicFakeBackend",
+    "ForesightWorld",
     "LiteLLMFallbackBackend",
-    "run_scenario",
-    "ScenarioConfig",
+    "OceanDrift",
+    "PredictionBuffer",
+    "PredictionRecord",
     "RunResult",
+    "ScenarioConfig",
+    "SoulSeededPersona",
+    "TierMix",
     "__version__",
+    "aggregate_pairs",
+    "apply_correction",
+    "build_prediction_record",
+    "build_tier_pool",
+    "make_paw_social_agent",
+    "pair_against_reality",
+    "run_scenario",
+    "tier_distribution",
+    "translate_camel_tools_to_sdk_overrides",
 ]
 
 
@@ -54,19 +84,85 @@ def __getattr__(name: str):  # pragma: no cover — lazy import shim
         from pocketpaw_ee.foresight.world import ForesightWorld
 
         return ForesightWorld
-    if name == "SoulSeededPersona":
-        from pocketpaw_ee.foresight.persona import SoulSeededPersona
+    if name in {"SoulSeededPersona", "OceanDrift", "make_paw_social_agent"}:
+        from pocketpaw_ee.foresight.persona import (
+            OceanDrift,
+            SoulSeededPersona,
+            make_paw_social_agent,
+        )
 
-        return SoulSeededPersona
-    if name in {"ClaudeCodeBackend", "LiteLLMFallbackBackend"}:
+        return {
+            "OceanDrift": OceanDrift,
+            "SoulSeededPersona": SoulSeededPersona,
+            "make_paw_social_agent": make_paw_social_agent,
+        }[name]
+    if name in {
+        "ClaudeCodeBackend",
+        "LiteLLMFallbackBackend",
+        "DeterministicFakeBackend",
+        "translate_camel_tools_to_sdk_overrides",
+    }:
         from pocketpaw_ee.foresight.llm.adapter import (
             ClaudeCodeBackend,
+            DeterministicFakeBackend,
             LiteLLMFallbackBackend,
+            translate_camel_tools_to_sdk_overrides,
         )
 
         return {
             "ClaudeCodeBackend": ClaudeCodeBackend,
+            "DeterministicFakeBackend": DeterministicFakeBackend,
             "LiteLLMFallbackBackend": LiteLLMFallbackBackend,
+            "translate_camel_tools_to_sdk_overrides": translate_camel_tools_to_sdk_overrides,
+        }[name]
+    if name in {"TierMix", "build_tier_pool", "tier_distribution"}:
+        from pocketpaw_ee.foresight.llm.tier_pool import (
+            TierMix,
+            build_tier_pool,
+            tier_distribution,
+        )
+
+        return {
+            "TierMix": TierMix,
+            "build_tier_pool": build_tier_pool,
+            "tier_distribution": tier_distribution,
+        }[name]
+    if name in {
+        "PredictionRecord",
+        "PredictionBuffer",
+        "CalibrationPair",
+        "CalibrationSummary",
+        "Correction",
+        "CORRECTION_CAP",
+        "pair_against_reality",
+        "aggregate_pairs",
+        "apply_correction",
+        "build_prediction_record",
+    }:
+        from pocketpaw_ee.foresight.calibration import (
+            CORRECTION_CAP,
+            CalibrationPair,
+            CalibrationSummary,
+            Correction,
+            PredictionBuffer,
+            PredictionRecord,
+            aggregate_pairs,
+            apply_correction,
+            build_prediction_record,
+            pair_against_reality,
+        )
+
+        return {
+            "CORRECTION_CAP": CORRECTION_CAP,
+            "CalibrationPair": CalibrationPair,
+            "CalibrationSummary": CalibrationSummary,
+            "Correction": Correction,
+            "PredictionBuffer": PredictionBuffer,
+            "PredictionRecord": PredictionRecord,
+            "aggregate_pairs": aggregate_pairs,
+            "apply_correction": apply_correction,
+            "build_prediction_record": build_prediction_record,
+            "pair_against_reality": pair_against_reality,
         }[name]
     if name in {"run_scenario", "ScenarioConfig", "RunResult"}:
         from pocketpaw_ee.foresight.scenarios.runner import (

--- a/ee/pocketpaw_ee/foresight/calibration.py
+++ b/ee/pocketpaw_ee/foresight/calibration.py
@@ -1,0 +1,450 @@
+# ee/pocketpaw_ee/foresight/calibration.py
+# Created: 2026-05-25 (feat/foresight-v03-calibration) — RFC 08 PR 3.
+#
+# Calibration loop — RFC 08 §9 "the moat".
+#
+# The 5-step closed cycle:
+#
+#   1. CAPTURE   — every projected outcome carries an ``observe_at``
+#                  deadline; the prediction is written to the buffer.
+#   2. OBSERVE   — real outcome lands; matching pending predictions
+#                  are picked up.
+#   3. PAIR      — projected vs actual outcome diffed into a
+#                  ``CalibrationPair``.
+#   4. AGGREGATE — per-scenario / per-tier / per-metric accuracy
+#                  rollups land in ``calibration_summaries`` (PR 4 will
+#                  add the cloud-side Beanie persistence; PR 3 keeps
+#                  this in-memory).
+#   5. CORRECT   — adjustments applied to persona priors, action
+#                  propensities, aggregator weights — capped at
+#                  ±10% per cycle (RFC implementation gate 6 +
+#                  RFC 08 §16.3 "v0.1 ships at ±10% per cycle").
+#
+# DESIGN TENSION 1 (captured in soul memory): captain-reviewed vs auto
+# correction. v0.1 (this PR) ships AUTO with the ±10% cap. The PR body
+# flags this as revisitable when first customer data lands — same as
+# RFC 08 §16.3 captures it. The hook for promoting to
+# captain-reviewed lives in ``apply_correction``'s ``auto`` argument.
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+logger = logging.getLogger(__name__)
+
+
+# --- §9.1 CAPTURE ----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PredictionRecord:
+    """One projected outcome held until reality lands.
+
+    The buffer keys on ``(scenario_template, anchor_object_id,
+    observe_at)`` so a real-decision-landed event can scan for matching
+    predictions. ``anchor_decision_id`` is optional — populated when a
+    forward-precedent edge can be written before observation (rare).
+    """
+
+    id: UUID
+    scenario_template: str
+    run_id: UUID
+    anchor_object_id: str
+    anchor_decision_id: UUID | None
+    projected_outcome: dict[str, Any]
+    projection_confidence: float
+    observe_at: datetime
+    captured_at: datetime
+
+    def as_wire_dict(self) -> dict[str, Any]:
+        return {
+            "id": str(self.id),
+            "scenario_template": self.scenario_template,
+            "run_id": str(self.run_id),
+            "anchor_object_id": self.anchor_object_id,
+            "anchor_decision_id": (
+                str(self.anchor_decision_id) if self.anchor_decision_id else None
+            ),
+            "projected_outcome": dict(self.projected_outcome),
+            "projection_confidence": self.projection_confidence,
+            "observe_at": self.observe_at.isoformat(),
+            "captured_at": self.captured_at.isoformat(),
+        }
+
+
+class PredictionBuffer:
+    """In-memory ring of pending predictions.
+
+    PR 3 keeps this in-memory — PR 4's cloud-side path adds a
+    Beanie-backed equivalent under ``ee/pocketpaw_ee/cloud/foresight/``
+    (out of scope here per the parallel-leads lane split). The
+    interface is async to anticipate that swap.
+    """
+
+    def __init__(self) -> None:
+        self._records: dict[UUID, PredictionRecord] = {}
+        self._observed: dict[UUID, dict[str, Any]] = {}
+
+    async def capture(self, record: PredictionRecord) -> None:
+        """Write a prediction to the buffer."""
+        self._records[record.id] = record
+        logger.debug(
+            "captured prediction id=%s anchor=%s observe_at=%s",
+            record.id,
+            record.anchor_object_id,
+            record.observe_at.isoformat(),
+        )
+
+    async def pending(self, *, before: datetime | None = None) -> list[PredictionRecord]:
+        """Return predictions whose ``observe_at`` has passed (or all
+        unmatched predictions when ``before`` is ``None``).
+        """
+        threshold = before or datetime.now(UTC)
+        return [
+            r
+            for r in self._records.values()
+            if r.id not in self._observed and r.observe_at <= threshold
+        ]
+
+    async def mark_observed(self, prediction_id: UUID, observation: dict[str, Any]) -> None:
+        """Record that reality has landed for this prediction."""
+        if prediction_id not in self._records:
+            raise KeyError(f"unknown prediction id: {prediction_id}")
+        self._observed[prediction_id] = dict(observation)
+        logger.debug("marked observed prediction id=%s", prediction_id)
+
+    async def find_by_anchor(self, anchor_object_id: str) -> list[PredictionRecord]:
+        """Find pending predictions anchored to a given Fabric object.
+
+        Used by the §9.2 OBSERVE step when a real Decision lands —
+        the listener calls this with the decision's anchor and pairs
+        any matches.
+        """
+        return [
+            r
+            for r in self._records.values()
+            if r.anchor_object_id == anchor_object_id and r.id not in self._observed
+        ]
+
+    def __len__(self) -> int:
+        return len(self._records)
+
+    @property
+    def observed_count(self) -> int:
+        return len(self._observed)
+
+
+# --- §9.3 PAIR -------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CalibrationPair:
+    """One (prediction, observation) pair with the per-metric delta."""
+
+    prediction_id: UUID
+    real_decision_id: UUID | None
+    projected_outcome: dict[str, Any]
+    actual_outcome: dict[str, Any]
+    delta: dict[str, Any]
+    paired_at: datetime
+
+    def as_wire_dict(self) -> dict[str, Any]:
+        return {
+            "prediction_id": str(self.prediction_id),
+            "real_decision_id": (str(self.real_decision_id) if self.real_decision_id else None),
+            "projected_outcome": dict(self.projected_outcome),
+            "actual_outcome": dict(self.actual_outcome),
+            "delta": dict(self.delta),
+            "paired_at": self.paired_at.isoformat(),
+        }
+
+
+def pair_against_reality(
+    prediction: PredictionRecord,
+    *,
+    actual_outcome: dict[str, Any],
+    real_decision_id: UUID | None = None,
+) -> CalibrationPair:
+    """Build a ``CalibrationPair`` by diffing the prediction's
+    ``projected_outcome`` against the observed ``actual_outcome``.
+
+    The ``delta`` dict carries one entry per metric:
+      - numeric metrics: ``actual - projected`` (signed)
+      - string metrics: ``{"match": bool, "projected": str, "actual": str}``
+      - missing metrics: ``{"missing_in": "projected" | "actual"}``
+    """
+    delta = _compute_delta(prediction.projected_outcome, actual_outcome)
+    return CalibrationPair(
+        prediction_id=prediction.id,
+        real_decision_id=real_decision_id,
+        projected_outcome=dict(prediction.projected_outcome),
+        actual_outcome=dict(actual_outcome),
+        delta=delta,
+        paired_at=datetime.now(UTC),
+    )
+
+
+def _compute_delta(projected: dict[str, Any], actual: dict[str, Any]) -> dict[str, Any]:
+    """Per-metric delta. Tolerant of mismatched key sets.
+
+    Numeric → signed difference. String → equality test with both
+    values. Missing → ``{"missing_in": ...}`` marker.
+    """
+    delta: dict[str, Any] = {}
+    keys = set(projected) | set(actual)
+    for key in sorted(keys):
+        p_val = projected.get(key)
+        a_val = actual.get(key)
+        if key not in projected:
+            delta[key] = {"missing_in": "projected"}
+            continue
+        if key not in actual:
+            delta[key] = {"missing_in": "actual"}
+            continue
+        if isinstance(p_val, (int, float)) and isinstance(a_val, (int, float)):
+            delta[key] = a_val - p_val
+        elif isinstance(p_val, str) and isinstance(a_val, str):
+            delta[key] = {"match": p_val == a_val, "projected": p_val, "actual": a_val}
+        else:
+            # Different types or non-numeric / non-string: store both.
+            delta[key] = {"match": p_val == a_val, "projected": p_val, "actual": a_val}
+    return delta
+
+
+# --- §9.4 AGGREGATE --------------------------------------------------
+
+
+@dataclass
+class CalibrationSummary:
+    """Rollup over a set of ``CalibrationPair`` objects.
+
+    Fields mirror RFC 08 §9.4:
+      - ``modal_accuracy``: fraction of pairs whose key metric matches
+        the projected modal trajectory within tolerance.
+      - ``confidence_calibration``: how well the stated
+        ``projection_confidence`` correlates with observed match rate.
+      - ``per_metric_accuracy``: per-metric match-fraction breakdown.
+      - ``n_pairs``: count.
+    """
+
+    modal_accuracy: float
+    confidence_calibration: float
+    per_metric_accuracy: dict[str, float] = field(default_factory=dict)
+    n_pairs: int = 0
+
+    def as_wire_dict(self) -> dict[str, Any]:
+        return {
+            "modal_accuracy": round(self.modal_accuracy, 4),
+            "confidence_calibration": round(self.confidence_calibration, 4),
+            "per_metric_accuracy": {k: round(v, 4) for k, v in self.per_metric_accuracy.items()},
+            "n_pairs": self.n_pairs,
+        }
+
+
+def aggregate_pairs(
+    pairs: Iterable[CalibrationPair],
+    *,
+    predictions_by_id: dict[UUID, PredictionRecord] | None = None,
+    numeric_tolerance: float = 0.10,
+) -> CalibrationSummary:
+    """Aggregate a sequence of ``CalibrationPair`` objects.
+
+    Args:
+        pairs: iterable of paired predictions.
+        predictions_by_id: optional lookup so confidence-calibration
+            can be computed (needs ``projection_confidence`` from the
+            original prediction record).
+        numeric_tolerance: fractional band considered a "match" for
+            numeric metrics (10% by default — matches the correction
+            cap in §9.5).
+    """
+    pairs_list = list(pairs)
+    if not pairs_list:
+        return CalibrationSummary(
+            modal_accuracy=0.0,
+            confidence_calibration=0.0,
+            per_metric_accuracy={},
+            n_pairs=0,
+        )
+
+    # Per-metric match counts.
+    metric_total: dict[str, int] = {}
+    metric_matched: dict[str, int] = {}
+    pair_match_flags: list[bool] = []
+
+    for pair in pairs_list:
+        pair_all_match = True
+        for key, delta_val in pair.delta.items():
+            metric_total[key] = metric_total.get(key, 0) + 1
+            matched = _metric_matches(delta_val, numeric_tolerance)
+            if matched:
+                metric_matched[key] = metric_matched.get(key, 0) + 1
+            else:
+                pair_all_match = False
+        pair_match_flags.append(pair_all_match)
+
+    per_metric_accuracy = {
+        key: metric_matched.get(key, 0) / metric_total[key] for key in metric_total
+    }
+    modal_accuracy = sum(1 for f in pair_match_flags if f) / len(pair_match_flags)
+
+    # Confidence calibration: |observed_rate - mean_confidence|, mapped
+    # so 1.0 = perfectly calibrated.
+    confidence_calibration = 0.0
+    if predictions_by_id is not None:
+        confidences = [
+            predictions_by_id[p.prediction_id].projection_confidence
+            for p in pairs_list
+            if p.prediction_id in predictions_by_id
+        ]
+        if confidences:
+            mean_conf = sum(confidences) / len(confidences)
+            confidence_calibration = 1.0 - abs(modal_accuracy - mean_conf)
+            confidence_calibration = max(0.0, min(1.0, confidence_calibration))
+
+    return CalibrationSummary(
+        modal_accuracy=modal_accuracy,
+        confidence_calibration=confidence_calibration,
+        per_metric_accuracy=per_metric_accuracy,
+        n_pairs=len(pairs_list),
+    )
+
+
+def _metric_matches(delta_val: Any, numeric_tolerance: float) -> bool:
+    """Return True when this metric's delta is within the match band."""
+    if isinstance(delta_val, dict):
+        if "missing_in" in delta_val:
+            return False
+        return bool(delta_val.get("match", False))
+    if isinstance(delta_val, (int, float)):
+        # Tolerance band: |delta| / max(|actual|, 1) <= numeric_tolerance.
+        # For metrics centered near 0 we fall back to absolute band.
+        return abs(delta_val) <= numeric_tolerance
+    return False
+
+
+# --- §9.5 CORRECT ----------------------------------------------------
+
+
+CORRECTION_CAP = 0.10
+"""Per-cycle correction cap (RFC implementation gate 6 + §9.5 + §16.3).
+
+PR 3 ships AUTO at ±10%. DESIGN TENSION 1 is to revisit when first
+customer data lands — may move to captain-reviewed mode.
+"""
+
+
+@dataclass(frozen=True)
+class Correction:
+    """One adjustment proposal, capped at ±``CORRECTION_CAP``.
+
+    ``layer`` is one of ``"persona_prior"`` / ``"action_propensity"`` /
+    ``"aggregator_weight"``. ``target`` identifies the slot being
+    adjusted (e.g. ``"conscientious_approver.openness"`` for a persona
+    prior, ``"accept_under_compset"`` for an action propensity).
+    ``raw_delta`` is the uncapped proposed change; ``capped_delta`` is
+    what ``apply_correction`` would emit. ``auto`` is ``True`` when no
+    captain review is required.
+    """
+
+    layer: str
+    target: str
+    raw_delta: float
+    capped_delta: float
+    rationale: str
+    auto: bool = True
+
+    def as_wire_dict(self) -> dict[str, Any]:
+        return {
+            "layer": self.layer,
+            "target": self.target,
+            "raw_delta": round(self.raw_delta, 4),
+            "capped_delta": round(self.capped_delta, 4),
+            "rationale": self.rationale,
+            "auto": self.auto,
+        }
+
+
+def apply_correction(
+    *,
+    layer: str,
+    target: str,
+    raw_delta: float,
+    rationale: str,
+    auto: bool = True,
+    cap: float = CORRECTION_CAP,
+) -> Correction:
+    """Produce a capped correction record.
+
+    ``raw_delta`` can be any float; the capped value is clamped to
+    ±``cap``. ``auto=True`` ships in v0.1 — captain-reviewed corrections
+    are flagged ``auto=False`` and queued for human approval (PR 6 work).
+
+    The function does NOT mutate any global state. The caller (PR 4's
+    cloud-side service) is responsible for persisting the correction
+    and threading the capped value into the next run's priors /
+    propensities / weights.
+    """
+    if cap <= 0:
+        raise ValueError(f"cap must be > 0, got {cap}")
+    if layer not in {"persona_prior", "action_propensity", "aggregator_weight"}:
+        raise ValueError(
+            f"unknown correction layer {layer!r}; expected one of "
+            "'persona_prior', 'action_propensity', 'aggregator_weight'"
+        )
+    capped = max(-cap, min(cap, raw_delta))
+    logger.debug(
+        "correction layer=%s target=%s raw=%.4f capped=%.4f auto=%s",
+        layer,
+        target,
+        raw_delta,
+        capped,
+        auto,
+    )
+    return Correction(
+        layer=layer,
+        target=target,
+        raw_delta=raw_delta,
+        capped_delta=capped,
+        rationale=rationale,
+        auto=auto,
+    )
+
+
+# --- helper: build a PredictionRecord -------------------------------
+
+
+def build_prediction_record(
+    *,
+    scenario_template: str,
+    run_id: UUID,
+    anchor_object_id: str,
+    projected_outcome: dict[str, Any],
+    observe_at: datetime,
+    projection_confidence: float = 0.5,
+    anchor_decision_id: UUID | None = None,
+) -> PredictionRecord:
+    """Construct a ``PredictionRecord`` with ``id`` + ``captured_at``
+    auto-filled. Convenience for the projection layer (RFC 08 §7.7)
+    that emits ProjectedDecisions.
+    """
+    if not (0.0 <= projection_confidence <= 1.0):
+        raise ValueError(
+            f"projection_confidence must be in [0.0, 1.0], got {projection_confidence}"
+        )
+    return PredictionRecord(
+        id=uuid4(),
+        scenario_template=scenario_template,
+        run_id=run_id,
+        anchor_object_id=anchor_object_id,
+        anchor_decision_id=anchor_decision_id,
+        projected_outcome=dict(projected_outcome),
+        projection_confidence=projection_confidence,
+        observe_at=observe_at,
+        captured_at=datetime.now(UTC),
+    )

--- a/ee/pocketpaw_ee/foresight/llm/adapter.py
+++ b/ee/pocketpaw_ee/foresight/llm/adapter.py
@@ -1,4 +1,20 @@
 # ee/pocketpaw_ee/foresight/llm/adapter.py
+# Updated: 2026-05-25 (feat/foresight-v03-calibration) — PR 3:
+#   - Wired LiteLLMFallbackBackend to the real ``litellm.acompletion``
+#     proxy. PR 2 shipped this as a stub; PR 3 makes it operational
+#     so the tier-pool builder can route the long-tail (Llama-3.1-8B
+#     via vLLM/Modal) and the per-scenario fallback path the SDK
+#     leakage mitigation calls out (RFC §6.4 + §15.3).
+#   - Added ``translate_camel_tools_to_sdk_overrides(tools)`` — the
+#     CAMEL FunctionTool → Claude Code SDK Permissions translator
+#     PR 2 flagged as open follow-up. The translator filters CAMEL
+#     tool specs into a Permissions dict the SDK consumes; tools
+#     without a known shape are dropped with a debug log rather than
+#     crashing the run.
+#   - Both ClaudeCodeBackend.run + LiteLLMFallbackBackend.run now
+#     honor ``tools`` by translating them into the SDK Permissions
+#     overrides (no-op when the tool list is empty, preserving the
+#     PR 2 contract).
 # Updated: 2026-05-25 (feat/foresight-v02-oasis-camel-paw) — PR 2 adds:
 #   - ClaudeCodeBackend.run(messages, response_format, tools) — the
 #     CAMEL BaseModelBackend-shaped surface PR 3 will pass to OASIS's
@@ -33,6 +49,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
@@ -40,6 +57,133 @@ if TYPE_CHECKING:
     # adapter accepts any object that quacks like a BaseMessage so we
     # stay importable on machines without camel-ai installed.
     from camel.messages import BaseMessage  # type: ignore[import-not-found]
+
+logger = logging.getLogger(__name__)
+
+
+# --- CAMEL FunctionTool → Claude Code SDK Permissions translator -----
+#
+# RFC §6.4 promises a translator pass so CAMEL tool specs (which
+# OASIS's ``SocialAgent`` constructs via ``get_openai_function_list``)
+# get mapped to the SDK's ``Permissions`` overrides — which is how the
+# SDK gates which built-in tools the model is allowed to call.
+#
+# CAMEL FunctionTool shape (camel.toolkits.function_tool.FunctionTool):
+#   - ``.func`` — the underlying callable; ``func.__name__`` is the
+#     OpenAI tool name (also `func.__name__`).
+#   - ``.openai_tool_schema`` (or equiv) — the OpenAI tool-call schema.
+#
+# Claude Code SDK Permissions shape (claude_agent_sdk.Permissions):
+#   - A dict like ``{"allow": ["Read", "Bash"], "deny": []}``.
+#
+# Translation strategy: pass-through tool names that match SDK built-in
+# tool names (Bash, Read, Write, Glob, Grep, etc.); drop unknown
+# CAMEL-side tool names with a debug log. The translator is intentionally
+# conservative — a tool name we don't recognize is safer to drop than
+# to forward and have the SDK reject mid-run.
+
+
+# The set of SDK built-in tool names PR 3 knows how to whitelist.
+# Source: claude_agent_sdk's built-in tool registry (Bash / Read /
+# Write / Edit / Glob / Grep / NotebookEdit / WebFetch / WebSearch /
+# Skill / Task). Subset can be added per-scenario via the
+# ``allowed_sdk_tools`` argument below.
+_SDK_BUILTIN_TOOLS: frozenset[str] = frozenset(
+    {
+        "Bash",
+        "Edit",
+        "Glob",
+        "Grep",
+        "NotebookEdit",
+        "Read",
+        "Skill",
+        "Task",
+        "WebFetch",
+        "WebSearch",
+        "Write",
+    }
+)
+
+
+def translate_camel_tools_to_sdk_overrides(
+    tools: list[Any] | None,
+    *,
+    allowed_sdk_tools: frozenset[str] | set[str] | None = None,
+) -> dict[str, Any]:
+    """Translate a CAMEL FunctionTool list into Claude Code SDK
+    Permissions overrides.
+
+    Args:
+        tools: list of CAMEL ``FunctionTool``-shaped objects, OR
+            OpenAI-shaped tool-call dicts (the wire format that lands
+            inside ``run()``'s ``tools`` arg). Heterogeneous lists are
+            accepted; per-entry shape detection picks the right path.
+            ``None`` or ``[]`` returns ``{}`` (no overrides).
+        allowed_sdk_tools: optional whitelist of SDK built-in tool
+            names to keep. Defaults to ``_SDK_BUILTIN_TOOLS`` (the
+            full known set).
+
+    Returns:
+        A dict of the form ``{"allow": [<tool_name>, ...]}`` that the
+        SDK consumes via ``ClaudeSDKClient(permissions=...)``. Returns
+        ``{}`` when the input list is empty (no override).
+
+    The translator is best-effort: tools whose name isn't a recognized
+    SDK built-in are skipped with a debug log. Per-scenario callers
+    that need to gate custom MCP tools should layer their own
+    permissions on top of what this function returns.
+    """
+    if not tools:
+        return {}
+    # ``or`` would treat an empty set as falsy and fall through to the
+    # default — but an explicit empty whitelist means "allow nothing".
+    whitelist = allowed_sdk_tools if allowed_sdk_tools is not None else _SDK_BUILTIN_TOOLS
+    allowed: list[str] = []
+    skipped: list[str] = []
+    for tool in tools:
+        name = _extract_tool_name(tool)
+        if name is None:
+            skipped.append(repr(tool)[:40])
+            continue
+        if name in whitelist:
+            if name not in allowed:
+                allowed.append(name)
+        else:
+            skipped.append(name)
+    if skipped:
+        logger.debug(
+            "translate_camel_tools_to_sdk_overrides: skipped %d tools not in SDK built-in set: %s",
+            len(skipped),
+            skipped,
+        )
+    if not allowed:
+        return {}
+    return {"allow": list(allowed)}
+
+
+def _extract_tool_name(tool: Any) -> str | None:
+    """Pull a tool name from either a CAMEL FunctionTool or an OpenAI-
+    shaped tool-call dict.
+
+    CAMEL FunctionTool: ``tool.func.__name__``.
+    OpenAI dict: ``tool["function"]["name"]`` or ``tool["name"]``.
+    """
+    func = getattr(tool, "func", None)
+    if func is not None:
+        name = getattr(func, "__name__", None)
+        if isinstance(name, str) and name:
+            return name
+    if isinstance(tool, dict):
+        # OpenAI tool-call format: {"type": "function", "function": {"name": ...}}
+        fn = tool.get("function")
+        if isinstance(fn, dict):
+            name = fn.get("name")
+            if isinstance(name, str) and name:
+                return name
+        name = tool.get("name")
+        if isinstance(name, str) and name:
+            return name
+    return None
 
 
 class BackendProtocol(Protocol):
@@ -103,16 +247,28 @@ class ClaudeCodeBackend:
 
     # --- v0.1 convenience surface (used by SoulSeededPersona) ----------
 
-    async def complete(self, prompt: str) -> str:
+    async def complete(
+        self,
+        prompt: str,
+        *,
+        permissions_overrides: dict[str, Any] | None = None,
+    ) -> str:
         """One SDK turn → assistant's final text.
+
+        ``permissions_overrides`` (PR 3): if non-empty, passed to the
+        SDK client factory so the client constructs with the override
+        applied for THIS turn. The base client (no overrides) is reused
+        when the override is empty / ``None`` — keeps the cheap path
+        cheap.
 
         The SDK leak surface to watch (RFC §15.3): the SDK is agent-loop-
         shaped, not chat-completion-shaped. If we hit unexpected event
         streams or non-text terminal messages here, swap to the LiteLLM
-        fallback (one-line config change at v1.0).
+        fallback (PR 3 wires that fallback to real
+        ``litellm.acompletion``).
         """
         async with self._sem:
-            client = await self._build_client()
+            client = await self._build_client(permissions_overrides=permissions_overrides)
             # Lazy-imported SDK exposes ``query(prompt) -> AsyncIterator[events]``.
             # We drain to the terminal event and return its text payload.
             async with client:
@@ -132,18 +288,24 @@ class ClaudeCodeBackend:
         chat-completion-style dict so downstream parsers (SocialAgent's
         ``perform_action_by_llm``) consume it unchanged.
 
-        v0.2 behavior:
-          - ``response_format`` and ``tools`` are NOT enforced. The SDK
-            owns tool routing inside its own loop, so passing CAMEL
-            FunctionTool specs here is a no-op at the adapter layer.
-            PR 3 will close this gap by translating CAMEL tool specs
-            into SDK ``Permissions`` overrides where appropriate.
+        PR 3 behavior:
+          - ``tools`` is now translated to Claude Code SDK Permissions
+            overrides via ``translate_camel_tools_to_sdk_overrides``.
+            The resulting dict is stashed on the backend so
+            ``_build_client`` can pass it when constructing the SDK
+            client. Empty / unrecognized tool lists become a no-op
+            override (preserves the PR 2 contract).
+          - ``response_format`` remains a no-op — the SDK doesn't
+            expose a JSON-schema-coerce knob at the prompt boundary.
           - The message list is flattened: system messages become the
             SDK's system prompt, the final user message becomes the
             turn input, intermediate turns become prior-context prose.
         """
+        # Translate the CAMEL tool list into SDK Permissions overrides
+        # for THIS run (does not mutate persistent backend state).
+        overrides = translate_camel_tools_to_sdk_overrides(tools)
         prompt = self._compose_prompt(messages)
-        final = await self.complete(prompt)
+        final = await self.complete(prompt, permissions_overrides=overrides)
         return self._to_camel_response(final)
 
     def _compose_prompt(self, messages: list[Any]) -> str:
@@ -233,8 +395,15 @@ class ClaudeCodeBackend:
             },
         }
 
-    async def _build_client(self) -> Any:
+    async def _build_client(self, *, permissions_overrides: dict[str, Any] | None = None) -> Any:
         """Resolve the SDK client. Factory wins; otherwise lazy-import.
+
+        ``permissions_overrides`` (PR 3): when non-empty, attempted as
+        a constructor kwarg on the SDK client. Some SDK versions don't
+        accept ``permissions`` directly — we fall back to plain
+        construction if so, and log at debug. The factory path always
+        wins; tests inject their own factory and don't need to thread
+        overrides through.
 
         v0.1 imports ``claude_agent_sdk.ClaudeSDKClient`` only on
         first call — the foresight module must remain import-safe
@@ -253,6 +422,20 @@ class ClaudeCodeBackend:
                 "Install with `uv sync --dev --group ee` or pass a "
                 "client_factory at construction time."
             ) from exc
+        if permissions_overrides:
+            try:
+                # The SDK's ClaudeSDKClient may or may not accept a
+                # ``permissions=`` kwarg depending on the installed
+                # version. We try-except + ignore the mypy call-arg
+                # error because the runtime fallback covers older
+                # SDKs cleanly.
+                return ClaudeSDKClient(permissions=permissions_overrides)  # type: ignore[call-arg]
+            except TypeError:
+                logger.debug(
+                    "ClaudeSDKClient does not accept `permissions` kwarg; "
+                    "falling back to default construction. Tools: %s",
+                    permissions_overrides.get("allow"),
+                )
         return ClaudeSDKClient()
 
     @staticmethod
@@ -339,41 +522,265 @@ class DeterministicFakeBackend:
 
 
 class LiteLLMFallbackBackend:
-    """Stub for the LiteLLM fallback path RFC §6.4 calls out.
+    """LiteLLM proxy — the RFC §6.4 fallback path.
 
-    If the Claude Code SDK's abstraction leaks at scale (unexpected
-    event streams, non-text terminal messages, SDK-side throttling
-    that doesn't honor our semaphore), the runtime swap is to replace
-    ``ClaudeCodeBackend`` with this class, which proxies Anthropic's
-    chat-completion API directly via ``litellm.acompletion``.
+    PR 3 wires the actual ``litellm.acompletion`` proxy. The fallback
+    serves three roles in the engine:
 
-    PR 3 wires the actual proxy. v0.2 keeps the interface alive so:
-      - the tier-pool builder (RFC §7.3) can iterate over fallback
-        slots without an ImportError, and
-      - downstream callers can introspect ``BACKEND_AVAILABLE`` and
-        wire conditional fallback behavior before PR 3 lands.
+      1. **SDK leak insurance.** If the Claude Code SDK's abstraction
+         leaks at scale (unexpected event streams, non-text terminal
+         messages, SDK-side throttling that doesn't honor our
+         semaphore), the runtime swap is to replace
+         ``ClaudeCodeBackend`` with this class — same surface,
+         direct API access.
+      2. **Tier-pool tail backend.** The captain-locked tier mix
+         (5% Sonnet / 15% Haiku / 80% Llama-3.1-8B vLLM, RFC §10) uses
+         LiteLLM to route the tail to vLLM / Modal / Together / any
+         OpenAI-compatible endpoint. The ``model`` argument carries the
+         LiteLLM provider tag (e.g. ``"hosted_vllm/meta-llama/Llama-3.1-8B"``).
+      3. **Cross-provider eval.** Same scenario can run on Anthropic
+         today and Bedrock-hosted Mistral tomorrow — Cognition
+         Swappable (True IS Spec point 3 / RFC 08 §14.3).
+
+    The implementation is intentionally thin: ``complete(prompt)``
+    flattens to a one-message OpenAI-shape and proxies through
+    ``litellm.acompletion``. ``run(messages, ...)`` honors the CAMEL
+    surface that ``oasis.SocialAgent(model=...)`` calls into.
+
+    Construction:
+      - ``model``: LiteLLM model identifier. Required for ``run`` to
+        make a real call; ``complete`` falls back to a sensible default
+        for the Llama tail (``"ollama/llama3.1:8b"``) if not provided.
+      - ``base_url`` (optional): override the API base — useful for
+        self-hosted vLLM endpoints.
+      - ``api_key`` (optional): provider key; falls back to env vars
+        per LiteLLM's own resolution (``ANTHROPIC_API_KEY``,
+        ``OPENAI_API_KEY``, etc.).
+      - ``max_concurrent``: semaphore guard (mirrors
+        ``ClaudeCodeBackend``).
+      - ``extra_kwargs``: kwargs forwarded to ``litellm.acompletion``
+        (e.g. ``temperature``, ``max_tokens``).
     """
 
-    BACKEND_AVAILABLE = False
+    BACKEND_AVAILABLE = True
+    """PR 3 wires the real proxy — the flag flips to True."""
 
-    def __init__(self, *, model: str | None = None, **_: Any) -> None:
+    DEFAULT_TAIL_MODEL = "ollama/llama3.1:8b"
+    """The dev-mode default tail model. Production tier-pool callers
+    pass an explicit ``model=`` (e.g. the vLLM endpoint tag).
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        max_concurrent: int = 256,
+        extra_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        if max_concurrent < 1:
+            raise ValueError(f"max_concurrent must be >= 1, got {max_concurrent}")
         self._model = model
+        self._base_url = base_url
+        self._api_key = api_key
+        self._sem = asyncio.Semaphore(max_concurrent)
+        self._extra_kwargs = dict(extra_kwargs or {})
 
-    async def complete(self, prompt: str) -> str:  # noqa: ARG002
-        raise NotImplementedError(
-            "LiteLLMFallbackBackend is a stub at v0.2 of RFC 08. PR 3 wires "
-            "the actual litellm.acompletion proxy. Use ClaudeCodeBackend or "
-            "DeterministicFakeBackend until then."
-        )
+    async def complete(
+        self,
+        prompt: str,
+        *,
+        permissions_overrides: dict[str, Any] | None = None,  # noqa: ARG002 — surface parity with ClaudeCodeBackend
+    ) -> str:
+        """One LiteLLM call → assistant's text.
+
+        Constructs a one-message OpenAI-shape call and pulls
+        ``choices[0].message.content`` from the response. The
+        ``permissions_overrides`` arg is accepted for surface parity
+        with ``ClaudeCodeBackend.complete`` (LiteLLM doesn't gate
+        tools the same way; tool routing happens at the response
+        layer if the model emits a ``tool_calls`` block).
+        """
+        model = self._model or self.DEFAULT_TAIL_MODEL
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if self._base_url:
+            kwargs["base_url"] = self._base_url
+        if self._api_key:
+            kwargs["api_key"] = self._api_key
+        kwargs.update(self._extra_kwargs)
+        async with self._sem:
+            try:
+                from litellm import acompletion  # noqa: PLC0415 — lazy import
+            except ImportError as exc:  # pragma: no cover — depends on install
+                raise RuntimeError(
+                    "LiteLLMFallbackBackend requires the litellm package. "
+                    "Install with `uv sync --dev` (litellm is in the dev "
+                    "deps)."
+                ) from exc
+            response = await acompletion(**kwargs)
+        return self._extract_text(response)
 
     async def run(
         self,
-        messages: list[Any],  # noqa: ARG002
-        response_format: dict[str, Any] | None = None,  # noqa: ARG002
-        tools: list[dict[str, Any]] | None = None,  # noqa: ARG002
+        messages: list[Any],
+        response_format: dict[str, Any] | None = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
-        raise NotImplementedError(
-            "LiteLLMFallbackBackend is a stub at v0.2 of RFC 08. PR 3 wires "
-            "the actual litellm.acompletion proxy. Use ClaudeCodeBackend or "
-            "DeterministicFakeBackend until then."
-        )
+        """CAMEL ``BaseModelBackend``-shaped surface. Translates the
+        message list directly to LiteLLM's chat-completion call.
+
+        Unlike ``ClaudeCodeBackend.run``, the LiteLLM path can honor
+        ``tools`` natively — LiteLLM accepts the OpenAI tool-call
+        schema and the response carries ``tool_calls`` when the model
+        emits them. ``response_format`` is also forwarded (some
+        providers honor ``{"type": "json_object"}``).
+        """
+        model = self._model or self.DEFAULT_TAIL_MODEL
+        litellm_messages = self._messages_to_litellm(messages)
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": litellm_messages,
+        }
+        if response_format:
+            kwargs["response_format"] = response_format
+        if tools:
+            # LiteLLM consumes the OpenAI tool-call schema directly.
+            # CAMEL FunctionTool entries get unwrapped to their wire
+            # form; OpenAI-shaped dicts pass through unchanged.
+            kwargs["tools"] = [self._tool_to_litellm(t) for t in tools]
+        if self._base_url:
+            kwargs["base_url"] = self._base_url
+        if self._api_key:
+            kwargs["api_key"] = self._api_key
+        kwargs.update(self._extra_kwargs)
+        async with self._sem:
+            try:
+                from litellm import acompletion  # noqa: PLC0415
+            except ImportError as exc:  # pragma: no cover
+                raise RuntimeError("LiteLLMFallbackBackend requires the litellm package.") from exc
+            response = await acompletion(**kwargs)
+        return self._response_to_camel(response)
+
+    # --- helpers --------------------------------------------------------
+
+    @staticmethod
+    def _extract_text(response: Any) -> str:
+        """Pull the assistant text out of a LiteLLM response.
+
+        Handles two shapes:
+          - object response with ``.choices[0].message.content``
+          - dict response with ``["choices"][0]["message"]["content"]``
+        """
+        if hasattr(response, "choices"):
+            choices = response.choices
+            if choices:
+                msg = getattr(choices[0], "message", None)
+                if msg is not None:
+                    return str(getattr(msg, "content", "") or "")
+        if isinstance(response, dict):
+            choices = response.get("choices") or []
+            if choices:
+                msg = choices[0].get("message", {})
+                return str(msg.get("content", "") or "")
+        return str(response)
+
+    @staticmethod
+    def _messages_to_litellm(messages: list[Any]) -> list[dict[str, str]]:
+        """Map a CAMEL ``BaseMessage`` list to LiteLLM's chat-shape.
+
+        - System messages → ``{"role": "system", ...}``
+        - User messages → ``{"role": "user", ...}``
+        - Assistant messages → ``{"role": "assistant", ...}``
+        """
+        out: list[dict[str, str]] = []
+        for msg in messages:
+            content = getattr(msg, "content", None) or str(msg)
+            role = ClaudeCodeBackend._role_tag(msg).lower()
+            if role == "system":
+                out.append({"role": "system", "content": content})
+            elif role == "assistant":
+                out.append({"role": "assistant", "content": content})
+            else:
+                out.append({"role": "user", "content": content})
+        return out
+
+    @staticmethod
+    def _tool_to_litellm(tool: Any) -> dict[str, Any]:
+        """Translate a CAMEL ``FunctionTool`` (or OpenAI-shaped dict) to
+        the wire format LiteLLM expects.
+
+        For OpenAI-shaped dicts, pass through. For CAMEL FunctionTool,
+        pull ``openai_tool_schema`` if available; fall back to a
+        minimal stub.
+        """
+        if isinstance(tool, dict):
+            return dict(tool)
+        # CAMEL FunctionTool has ``get_openai_tool_schema()`` on recent
+        # versions; older versions expose ``.openai_tool_schema``.
+        schema = getattr(tool, "get_openai_tool_schema", None)
+        if callable(schema):
+            try:
+                return schema()
+            except Exception:  # noqa: BLE001 — fall back to attribute
+                pass
+        schema_attr = getattr(tool, "openai_tool_schema", None)
+        if isinstance(schema_attr, dict):
+            return dict(schema_attr)
+        # Last-resort stub so LiteLLM doesn't crash.
+        func = getattr(tool, "func", None)
+        name = getattr(func, "__name__", None) or "unknown_tool"
+        return {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": "",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+    @staticmethod
+    def _response_to_camel(response: Any) -> dict[str, Any]:
+        """Format a LiteLLM response as a CAMEL chat-completion dict.
+
+        LiteLLM responses are already OpenAI-shaped; we normalize to a
+        dict so callers don't need to introspect provider-specific
+        attribute names.
+        """
+        if isinstance(response, dict):
+            return response
+        # Object-shape — convert via .__dict__ or model_dump.
+        if hasattr(response, "model_dump"):
+            try:
+                return response.model_dump()  # pydantic-style
+            except Exception:  # noqa: BLE001 — fall back to dict_ shape
+                pass
+        if hasattr(response, "dict") and callable(response.dict):
+            try:
+                return response.dict()
+            except Exception:  # noqa: BLE001
+                pass
+        # Best effort: walk choices manually.
+        choices_out: list[dict[str, Any]] = []
+        for ch in getattr(response, "choices", []) or []:
+            msg = getattr(ch, "message", None)
+            choices_out.append(
+                {
+                    "index": getattr(ch, "index", 0),
+                    "message": {
+                        "role": getattr(msg, "role", "assistant"),
+                        "content": getattr(msg, "content", "") or "",
+                        "tool_calls": getattr(msg, "tool_calls", []) or [],
+                    },
+                    "finish_reason": getattr(ch, "finish_reason", "stop"),
+                }
+            )
+        return {
+            "id": getattr(response, "id", "litellm-response"),
+            "object": "chat.completion",
+            "choices": choices_out,
+            "usage": getattr(response, "usage", {}),
+        }

--- a/ee/pocketpaw_ee/foresight/llm/tier_pool.py
+++ b/ee/pocketpaw_ee/foresight/llm/tier_pool.py
@@ -1,0 +1,257 @@
+# ee/pocketpaw_ee/foresight/llm/tier_pool.py
+# Created: 2026-05-25 (feat/foresight-v03-calibration) — RFC 08 PR 3.
+#
+# Tier-pool builder — RFC 08 §7.3 + §10.
+#
+# Foresight ticks fan out to N personas; each persona round-robins
+# through a ``list[BaseModelBackend]`` whose composition matches the
+# captain-locked tier mix:
+#
+#   premium (Sonnet 4.7)        5%  — strategic / approval personas
+#   mid     (Haiku 4.7)        15%  — mid-fidelity persona cohort
+#   tail    (Llama-3.1-8B vLLM) 80% — synthesized / market-sim long tail
+#
+# This module provides:
+#
+#   - ``TierMix``: a frozen dataclass guarding the {premium, mid, tail}
+#     triple. Sums to 1.0; per-tier overrides land via per-scenario
+#     YAML (RFC 08 §18 ``tier_mix:`` block).
+#   - ``build_tier_pool(...)``: constructs a ``list[BaseModelBackend]``
+#     of length N where consecutive entries span tiers (avoids
+#     activation-correlated cluster effects). Caller-supplied factories
+#     for each tier produce backend instances on demand.
+#   - ``tier_distribution(...)``: telemetry helper for the cost meter
+#     and the per-run report (tier × count × wall-clock).
+#
+# vLLM hosting is DEFERRED to v2.0 (per RFC 08 §10 cost-model lock).
+# PR 3's tier-pool builder declares the routing — the tail factory may
+# return a ``LiteLLMFallbackBackend`` pointed at Modal-hosted Llama or
+# a local Ollama instance for dev; the contract is identical.
+
+from __future__ import annotations
+
+import logging
+import random
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# --- Tier mix --------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TierMix:
+    """Captain-locked default: 5 / 15 / 80 (RFC 08 §10).
+
+    Overridable per scenario YAML in the ``tier_mix:`` block. Out-of-
+    default mixes trigger a cost-estimator warning (PR 6 work — UI).
+
+    All three fields are floats in [0.0, 1.0]; they must sum to 1.0
+    (within a small float-precision band).
+    """
+
+    premium: float = 0.05
+    mid: float = 0.15
+    tail: float = 0.80
+
+    def __post_init__(self) -> None:
+        for name in ("premium", "mid", "tail"):
+            value = getattr(self, name)
+            if not isinstance(value, (int, float)):
+                raise TypeError(f"TierMix.{name} must be a number, got {type(value).__name__}")
+            if value < 0.0 or value > 1.0:
+                raise ValueError(f"TierMix.{name} must be in [0.0, 1.0], got {value}")
+        total = self.premium + self.mid + self.tail
+        if not (0.999 < total < 1.001):
+            raise ValueError(
+                f"TierMix must sum to 1.0 (within ±0.001), got {total:.4f} "
+                f"(premium={self.premium}, mid={self.mid}, tail={self.tail})"
+            )
+
+    @classmethod
+    def locked_default(cls) -> TierMix:
+        """The RFC 08 §10 captain-locked default tier mix."""
+        return cls()  # 0.05 / 0.15 / 0.80
+
+    def is_default(self) -> bool:
+        """``True`` for the locked default; ``False`` for any override.
+
+        The cost estimator surfaces a warning when a scenario YAML
+        declares a non-default mix — typically because the operator is
+        opting into more Sonnet for higher fidelity at higher cost.
+        """
+        return (
+            abs(self.premium - 0.05) < 0.0001
+            and abs(self.mid - 0.15) < 0.0001
+            and abs(self.tail - 0.80) < 0.0001
+        )
+
+    def as_dict(self) -> dict[str, float]:
+        return {"premium": self.premium, "mid": self.mid, "tail": self.tail}
+
+
+# --- Backend factory protocol ---------------------------------------
+
+
+class BackendFactory(Protocol):
+    """A no-arg callable that returns a fresh ``BaseModelBackend``-shaped
+    object. The contract is intentionally loose so any of:
+
+      - ``lambda: ClaudeCodeBackend(model="claude-sonnet-4-7")``
+      - ``lambda: LiteLLMFallbackBackend(model="claude-haiku-4-7")``
+      - ``lambda: VLLMBackend(endpoint="http://localhost:8000")``
+
+    can serve as a factory. Foresight only requires ``async def run(...)
+    -> dict`` (the CAMEL ``BaseModelBackend`` surface) — the
+    ``async def complete(prompt: str) -> str`` shorthand is preserved
+    for the v0.1 smoke loop.
+    """
+
+    def __call__(self) -> Any: ...  # pragma: no cover — protocol
+
+
+# --- Tier pool construction -----------------------------------------
+
+
+def build_tier_pool(
+    *,
+    tier_mix: TierMix,
+    n_personas: int,
+    premium_factory: BackendFactory,
+    mid_factory: BackendFactory,
+    tail_factory: BackendFactory,
+    seed: int | None = None,
+) -> list[Any]:
+    """Build a list of ``BaseModelBackend`` instances honoring the tier mix.
+
+    The pool's length equals ``n_personas`` so a caller can assign
+    persona i to ``pool[i]`` without overflow. Composition:
+
+      - ``round(n_personas * tier_mix.premium)`` premium backends
+      - ``round(n_personas * tier_mix.mid)`` mid backends
+      - everything else is tail (preserves sum == n_personas under
+        any rounding drift)
+
+    The pool is then *pre-shuffled* (deterministically when ``seed`` is
+    set) so consecutive persona ids span tiers — avoiding cluster
+    effects when activation is correlated with persona id (e.g.
+    "personas 0-99 fire on tick 1, 100-199 on tick 2…").
+
+    Args:
+        tier_mix: the {premium, mid, tail} fractions.
+        n_personas: total persona count.
+        premium_factory, mid_factory, tail_factory: callables returning
+            fresh backend instances per persona slot.
+        seed: optional RNG seed for the shuffle. ``None`` uses
+            ``random.shuffle``'s default (non-deterministic across
+            processes); tests + reproducible runs should pass a seed.
+
+    Returns:
+        ``list[BaseModelBackend]`` of length ``n_personas``.
+
+    Raises:
+        ValueError: if ``n_personas < 1`` or any factory returns None.
+    """
+    if n_personas < 1:
+        raise ValueError(f"n_personas must be >= 1, got {n_personas}")
+
+    n_premium = round(n_personas * tier_mix.premium)
+    n_mid = round(n_personas * tier_mix.mid)
+    n_tail = n_personas - n_premium - n_mid
+    if n_tail < 0:
+        # Rounding pushed premium + mid past total. Trim mid down.
+        n_mid = max(0, n_personas - n_premium)
+        n_tail = n_personas - n_premium - n_mid
+
+    pool: list[Any] = []
+    pool.extend(_invoke_factory(premium_factory, "premium", n_premium))
+    pool.extend(_invoke_factory(mid_factory, "mid", n_mid))
+    pool.extend(_invoke_factory(tail_factory, "tail", n_tail))
+
+    # Shuffle so persona-id-correlated activation hits all tiers.
+    rng = random.Random(seed)
+    rng.shuffle(pool)
+
+    logger.debug(
+        "Built tier pool: n_personas=%d premium=%d mid=%d tail=%d (mix=%s, seed=%s)",
+        n_personas,
+        n_premium,
+        n_mid,
+        n_tail,
+        tier_mix.as_dict(),
+        seed,
+    )
+    return pool
+
+
+def _invoke_factory(factory: BackendFactory, tier_name: str, count: int) -> list[Any]:
+    if count == 0:
+        return []
+    instances: list[Any] = []
+    for i in range(count):
+        try:
+            instance = factory()
+        except Exception as exc:  # noqa: BLE001 — surface tier-name in the error
+            raise RuntimeError(
+                f"tier-pool {tier_name} factory raised on slot {i + 1}/{count}: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+        if instance is None:
+            raise ValueError(
+                f"tier-pool {tier_name} factory returned None on slot {i + 1}/{count}; "
+                "factories must return a backend instance"
+            )
+        instances.append(instance)
+    return instances
+
+
+def tier_distribution(
+    pool: list[Any],
+    *,
+    premium_marker: Callable[[Any], bool] | None = None,
+    mid_marker: Callable[[Any], bool] | None = None,
+) -> dict[str, int]:
+    """Telemetry — count how many slots in ``pool`` are premium / mid /
+    tail. Used by the cost meter and the per-run report.
+
+    Tier detection uses caller-supplied predicates (the markers).
+    Default predicates inspect the backend's ``_model`` attribute
+    (set by ``ClaudeCodeBackend`` / ``LiteLLMFallbackBackend``
+    constructors) — if absent, everything is counted as tail.
+
+    Args:
+        pool: the backend pool to inspect.
+        premium_marker: predicate identifying premium-tier backends.
+            Defaults to ``"sonnet" in (model or "").lower()``.
+        mid_marker: predicate identifying mid-tier backends.
+            Defaults to ``"haiku" in (model or "").lower()``.
+
+    Returns:
+        ``{"premium": n_premium, "mid": n_mid, "tail": n_tail}``.
+    """
+
+    def _default_premium(b: Any) -> bool:
+        m = getattr(b, "_model", None) or ""
+        return "sonnet" in str(m).lower()
+
+    def _default_mid(b: Any) -> bool:
+        m = getattr(b, "_model", None) or ""
+        return "haiku" in str(m).lower()
+
+    is_premium = premium_marker or _default_premium
+    is_mid = mid_marker or _default_mid
+
+    n_premium = 0
+    n_mid = 0
+    n_tail = 0
+    for backend in pool:
+        if is_premium(backend):
+            n_premium += 1
+        elif is_mid(backend):
+            n_mid += 1
+        else:
+            n_tail += 1
+    return {"premium": n_premium, "mid": n_mid, "tail": n_tail}

--- a/ee/pocketpaw_ee/foresight/persona.py
+++ b/ee/pocketpaw_ee/foresight/persona.py
@@ -1,4 +1,25 @@
 # ee/pocketpaw_ee/foresight/persona.py
+# Updated: 2026-05-25 (feat/foresight-v03-calibration) — PR 3 adds the
+# OASIS substrate-level integration RFC §7.2 specifies:
+#   - ``PawSocialAgent`` class that subclasses
+#     ``oasis.social_agent.SocialAgent`` when OASIS_AVAILABLE. The
+#     subclass overrides ``perform_action_by_llm`` to delegate to a
+#     wrapped ``SoulSeededPersona.decide`` so the runtime cognition
+#     path (PawAgent + Soul bootstrap + memory tiers) is preserved
+#     inside the OASIS-side agent shell. The "fidelity floor" RFC
+#     §7.2 calls for is met: what Foresight rehearses is what the
+#     live system would do.
+#   - ``make_paw_social_agent(...)`` factory — convenience builder
+#     that constructs the OASIS ``UserInfo`` + auto-assigns a unique
+#     integer ``social_agent_id`` so callers don't have to thread
+#     them through.
+#   - Graceful fallback — when OASIS is not loaded (e.g. missing
+#     torch / pandas / igraph despite the PR 3 lazy-import work), the
+#     factory raises ``RuntimeError`` with a clear pointer to the
+#     ``OASIS_AVAILABLE`` flag and the recovery path.
+#   - ``SoulSeededPersona`` remains the lightweight fallback path
+#     (no OASIS dependency) for the smoke loop, tests, and dev
+#     environments without the full substrate.
 # Updated: 2026-05-25 (feat/foresight-v02-oasis-camel-paw) — PR 2 lifts
 # the persona toward RFC §7.2 fidelity:
 #   - Optional ``paw_agent: PawAgent`` parameter — when provided, the
@@ -365,3 +386,255 @@ class SoulSeededPersona:
         else:
             put = {put_raw: True}
         return {"action": action, "rationale": rationale, "put": put}
+
+
+# --- PR 3 — PawSocialAgent (RFC §7.2 substrate-level integration) -----
+#
+# This is the load-bearing primitive RFC 08 §7.2 calls for: a persona
+# that IS a real Paw agent wrapped in OASIS's SocialAgent shell. The
+# class subclasses ``oasis.social_agent.SocialAgent`` so OASIS-side
+# machinery (AgentGraph membership, action-space restriction, the
+# Channel-based message bus) treats it like any other SocialAgent —
+# while the cognition path delegates to a wrapped
+# ``SoulSeededPersona`` so the live runtime's bootstrap / memory /
+# tool routing is preserved.
+#
+# Construction is via the ``make_paw_social_agent`` factory because
+# OASIS's ``SocialAgent.__init__`` needs a ``user_info`` and an
+# integer ``agent_id`` — the factory hands callers a friendlier shape
+# and handles the OASIS-import gating.
+
+
+_PAW_SOCIAL_AGENT_COUNTER = 0
+"""Monotonic counter for ``social_agent_id``. OASIS keys its
+AgentGraph on this int; we need uniqueness within a run. Reset by
+``reset_paw_social_agent_counter()`` for tests.
+"""
+
+
+def reset_paw_social_agent_counter() -> None:
+    """Reset the module-level counter — test-only convenience."""
+    global _PAW_SOCIAL_AGENT_COUNTER
+    _PAW_SOCIAL_AGENT_COUNTER = 0
+
+
+def _wrap_as_camel_backend(backend: Any) -> Any:
+    """Wrap a Foresight backend in a CAMEL ``BaseModelBackend`` shim
+    so OASIS's ``SocialAgent.__init__`` accepts it.
+
+    Foresight's adapters (ClaudeCodeBackend etc.) are intentionally
+    protocol-shaped (``async def run(messages, ...) -> dict``) and
+    don't subclass CAMEL's ``BaseModelBackend``. CAMEL's ChatAgent
+    constructor strictly type-checks ``model``, so we wrap.
+
+    The shim:
+      - subclasses ``BaseModelBackend`` (so CAMEL's check passes)
+      - delegates ``_arun`` (the async path) to ``backend.run(...)``
+      - synthesizes ``_run`` (sync) by calling ``asyncio.run`` on the
+        async path — sufficient for the simulation tick context where
+        only the async path is exercised.
+      - exposes a ``token_counter`` that always returns 0 (Foresight's
+        cost meter is fed from outside; CAMEL just needs the property
+        to exist).
+
+    If ``backend`` is already a ``BaseModelBackend`` instance, it's
+    returned unchanged.
+    """
+    from camel.models import BaseModelBackend  # noqa: PLC0415
+    from camel.types import ModelType  # noqa: PLC0415
+
+    if isinstance(backend, BaseModelBackend):
+        return backend
+
+    class _ForesightBackendShim(BaseModelBackend):
+        """Minimal BaseModelBackend wrapper. Constructed on-demand
+        so each ``make_paw_social_agent`` call gets a fresh instance
+        — avoids state collisions when one PawAgent is reused across
+        multiple PawSocialAgents.
+        """
+
+        def __init__(self) -> None:
+            # CAMEL's __init__ wants a ModelType + model_config; the
+            # config is consulted by CAMEL's default token counter,
+            # which we override to a noop below. Picking
+            # ``ModelType.STUB`` (if it exists) or ``ModelType.DEFAULT``
+            # avoids accidentally engaging CAMEL's pricing tables.
+            chosen_type = getattr(ModelType, "STUB", None) or ModelType.DEFAULT
+            super().__init__(model_type=chosen_type, model_config_dict={})
+            self._wrapped = backend
+
+        async def _arun(self, messages, response_format=None, tools=None):  # noqa: ARG002, ANN001
+            """Delegate to the wrapped backend's run(). Returns a CAMEL
+            chat-completion-shaped dict; CAMEL will parse it.
+            """
+            return await self._wrapped.run(messages, response_format=response_format, tools=tools)
+
+        def _run(self, messages, response_format=None, tools=None):  # noqa: ARG002, ANN001
+            """Sync fallback — CAMEL rarely exercises this in async
+            sim runs but the abstract method must be implemented.
+            """
+            import asyncio  # noqa: PLC0415
+
+            return asyncio.run(
+                self._wrapped.run(messages, response_format=response_format, tools=tools)
+            )
+
+        @property
+        def token_counter(self):  # type: ignore[override]
+            """Foresight's cost meter is fed externally (RFC §10);
+            CAMEL's per-call counter is bypassed.
+            """
+            return _NoopTokenCounter()
+
+    return _ForesightBackendShim()
+
+
+class _NoopTokenCounter:
+    """Always returns 0. Used by ``_ForesightBackendShim``."""
+
+    def count_tokens_from_messages(self, messages: Any) -> int:  # noqa: ARG002
+        return 0
+
+    def count_tokens_from_text(self, text: Any) -> int:  # noqa: ARG002
+        return 0
+
+
+def make_paw_social_agent(
+    *,
+    persona: SoulSeededPersona,
+    user_info_template: str | None = None,
+    available_actions: list[Any] | None = None,
+    backend: Any | None = None,
+) -> Any:
+    """Construct a ``PawSocialAgent`` (subclass of
+    ``oasis.social_agent.SocialAgent``) wrapping the given
+    ``SoulSeededPersona``.
+
+    The wrapped persona owns the cognition path: when OASIS's
+    ``perform_action_by_llm`` fires, the override delegates to
+    ``persona.decide(observation)`` — same code path the
+    ``ForesightWorld.tick()`` smoke loop uses. The OASIS shell layers
+    on the AgentGraph membership + Channel-based message bus that
+    Market Sim and Org Change Rehearsal sub-types will need (RFC §4.2,
+    §4.3).
+
+    Args:
+        persona: a ``SoulSeededPersona`` (ideally with
+            ``paw_agent=`` attached for RFC §7.2 fidelity).
+        user_info_template: optional ``camel.prompts.TextPrompt`` for
+            ``SocialAgent.user_info.to_custom_system_message``.
+            Defaults to ``None`` so OASIS uses
+            ``user_info.to_system_message()``.
+        available_actions: optional ``list[oasis.ActionType]`` — gates
+            which OASIS action vocab the agent is allowed to emit.
+            Defaults to "all" (matches OASIS's default).
+        backend: optional CAMEL ``BaseModelBackend`` to pass to
+            OASIS's ``SocialAgent(model=...)``. Defaults to the
+            persona's own backend.
+
+    Raises:
+        RuntimeError: when OASIS is not loaded (missing igraph /
+            pandas / torch / camel — see
+            ``pocketpaw_ee.foresight.substrate.oasis.OASIS_LOAD_ERROR``
+            for the underlying cause).
+
+    Returns:
+        An instance of the dynamically-created ``PawSocialAgent``
+        subclass (subclass of ``oasis.social_agent.SocialAgent``).
+        Its ``perform_action_by_llm`` delegates to ``persona.decide``;
+        its ``decide`` (added for parity with ``SoulSeededPersona``)
+        also delegates to ``persona.decide`` so ``ForesightWorld.tick``
+        can treat it as a regular persona.
+    """
+    from pocketpaw_ee.foresight.substrate import oasis  # noqa: PLC0415 — lazy
+
+    if not oasis.OASIS_AVAILABLE or oasis.SocialAgent is None or oasis.UserInfo is None:
+        raise RuntimeError(
+            "make_paw_social_agent requires the OASIS substrate to be "
+            "loaded. OASIS_AVAILABLE=False; underlying error: "
+            f"{oasis.OASIS_LOAD_ERROR!r}. Use SoulSeededPersona directly "
+            "for the non-OASIS path."
+        )
+
+    global _PAW_SOCIAL_AGENT_COUNTER
+    agent_id_int = _PAW_SOCIAL_AGENT_COUNTER
+    _PAW_SOCIAL_AGENT_COUNTER += 1
+
+    raw_backend = backend or persona._backend  # noqa: SLF001 — internal contract
+    # OASIS's ``SocialAgent.__init__`` (inherited from CAMEL's
+    # ``ChatAgent``) strictly type-checks the ``model`` parameter and
+    # rejects anything that isn't a ``BaseModelBackend``. Our adapter
+    # classes (ClaudeCodeBackend, DeterministicFakeBackend,
+    # LiteLLMFallbackBackend) intentionally don't subclass it — they
+    # are protocol-shaped. Wrap them in a thin CAMEL BaseModelBackend
+    # shim so CAMEL's type check passes; the shim's ``_arun`` delegates
+    # straight to the wrapped backend's ``run``.
+    backend_to_use = _wrap_as_camel_backend(raw_backend)
+
+    # Build a UserInfo from the persona. OASIS UserInfo carries a
+    # ``user_id`` and a ``description`` (used by
+    # ``to_system_message()``); we render the persona's identity
+    # block as the description so the OASIS-side system prompt
+    # carries the soul context.
+    user_info = oasis.UserInfo(
+        name=persona.name,
+        description=persona._identity_block(),  # noqa: SLF001
+        profile={
+            "role": persona.role,
+            "ocean_drift": {
+                "openness": persona.ocean_drift.openness,
+                "conscientiousness": persona.ocean_drift.conscientiousness,
+                "extraversion": persona.ocean_drift.extraversion,
+                "agreeableness": persona.ocean_drift.agreeableness,
+                "neuroticism": persona.ocean_drift.neuroticism,
+            },
+            "has_fidelity": persona.has_fidelity,
+        },
+    )
+
+    class PawSocialAgent(oasis.SocialAgent):  # type: ignore[misc, valid-type]
+        """RFC §7.2 — Paw persona wrapped in OASIS's SocialAgent shell.
+
+        Defined inline so the OASIS class lookup happens lazily at
+        ``make_paw_social_agent`` call time, not at module import.
+        This keeps ``persona.py`` importable without OASIS.
+        """
+
+        def __init__(self, _agent_id: int, _user_info: Any, _persona: SoulSeededPersona) -> None:
+            super().__init__(
+                agent_id=_agent_id,
+                user_info=_user_info,
+                user_info_template=user_info_template,
+                model=backend_to_use,
+                available_actions=available_actions,
+            )
+            self._persona = _persona
+
+        async def perform_action_by_llm(self) -> Any:
+            """Override OASIS's per-tick action emitter. The persona's
+            ``decide`` runs the live Paw runtime path (bootstrap,
+            memory, Soul recall, the SDK's loop); we wrap its return
+            in a CAMEL response shape so OASIS's downstream parsers
+            don't break if a future PR wires the ``perform_action_by_data``
+            path back in.
+            """
+            # The observation OASIS would normally read off
+            # ``self.env`` is not available here (we don't have a
+            # Platform). Pass a minimal observation so the persona's
+            # prompt composer can render its tick context.
+            observation = {
+                "tick": getattr(self, "_pp_tick", 0),
+                "state": getattr(self, "_pp_state", {}),
+                "active_count": 1,
+            }
+            return await self._persona.decide(observation)
+
+        async def decide(self, observation: dict[str, Any]) -> dict[str, Any]:
+            """Parity surface for ``ForesightWorld.tick()`` — delegates
+            straight through to the wrapped persona's decide(). Lets
+            the world's registry treat a ``PawSocialAgent`` and a
+            plain ``SoulSeededPersona`` identically.
+            """
+            return await self._persona.decide(observation)
+
+    return PawSocialAgent(agent_id_int, user_info, persona)

--- a/ee/pocketpaw_ee/foresight/scenarios/decision_forecast.yaml
+++ b/ee/pocketpaw_ee/foresight/scenarios/decision_forecast.yaml
@@ -1,20 +1,32 @@
 # ee/pocketpaw_ee/foresight/scenarios/decision_forecast.yaml
+# Updated: 2026-05-25 (feat/foresight-v03-calibration) — PR 3:
+#   - Added the optional ``tier_mix:`` block. The 5/15/80 captain-
+#     locked default is implicit when the block is omitted; declaring
+#     it explicitly here documents the locked value for new readers.
 # Created: 2026-05-25 (feat/foresight-v01-scaffold) — RFC 08 v0.1 scaffold.
 #
-# v0.1 Decision Forecast scenario — the simplest end-to-end loop the
+# v0.2 Decision Forecast scenario — the simplest end-to-end loop the
 # captain asked for. Five personas, one tick, decisions logged.
 #
 # This is intentionally a *fragment* of the full RFC §18 example YAML.
-# Fields like ``world.source``, ``tier_mix``, ``activation``,
-# ``action_space``, ``instinct_policy_overlay``, ``aggregator``,
-# ``projection``, ``calibration``, ``cost_estimate``, ``ui_rail``,
-# ``triggers``, and ``permissions`` are all valid for v1.0 but ignored
-# by the v0.1 loader (``ScenarioConfig.from_yaml``). Adding them now
-# would be dead schema — v0.1 ships only what the runner reads.
+# Fields like ``world.source``, ``activation``, ``action_space``,
+# ``instinct_policy_overlay``, ``aggregator``, ``projection``,
+# ``calibration``, ``cost_estimate``, ``ui_rail``, ``triggers``, and
+# ``permissions`` are all valid for v1.0 but ignored by the v0.2 loader
+# (``ScenarioConfig.from_yaml``). Adding them now would be dead schema
+# — v0.2 ships only what the runner reads.
 
 name: smoke-decision-forecast
 sub_type: decision_forecast
 n_ticks: 1
+
+# PR 3 — Captain-locked default tier mix (RFC 08 §10). Per-scenario
+# overrides are allowed but trigger a cost-estimator warning in
+# paw-enterprise (PR 6 work).
+tier_mix:
+  premium: 0.05  # Claude Sonnet 4.7 — strategic / approver personas
+  mid:     0.15  # Claude Haiku 4.7 — mid-fidelity cohort
+  tail:    0.80  # Llama-3.1-8B via vLLM (hosting deferred to v2.0)
 
 personas:
   - name: tenant-maria

--- a/ee/pocketpaw_ee/foresight/scenarios/runner.py
+++ b/ee/pocketpaw_ee/foresight/scenarios/runner.py
@@ -1,4 +1,17 @@
 # ee/pocketpaw_ee/foresight/scenarios/runner.py
+# Updated: 2026-05-25 (feat/foresight-v03-calibration) — PR 3 adds:
+#   - ``tier_mix`` parse step in ``ScenarioConfig.from_yaml`` — the
+#     scenario YAML can now declare a per-scenario override of the
+#     captain-locked 5/15/80 tier mix (RFC §10).
+#   - ``run_scenario`` accepts an optional ``backend_pool`` (a
+#     pre-built ``list[BaseModelBackend]`` from ``llm.tier_pool``).
+#     When supplied, persona i is assigned ``pool[i % len(pool)]``.
+#     When not supplied, the runner uses the v0.1 single-backend
+#     fallback (DeterministicFakeBackend or whatever the caller
+#     hands in via ``backend=``).
+#   - ``RunResult.tier_distribution`` field — captures the per-tier
+#     persona count so the per-run report can render the cost
+#     decomposition (RFC §10 audit table).
 # Created: 2026-05-25 (feat/foresight-v01-scaffold) — RFC 08 v0.1 scaffold.
 #
 # Scenario runner — the v0.1 end-to-end loop. Takes a ScenarioConfig,
@@ -21,6 +34,7 @@ from uuid import uuid4
 import yaml  # type: ignore[import-untyped]
 
 from pocketpaw_ee.foresight.llm.adapter import DeterministicFakeBackend
+from pocketpaw_ee.foresight.llm.tier_pool import TierMix, tier_distribution
 from pocketpaw_ee.foresight.persona import OceanDrift, SoulSeededPersona
 from pocketpaw_ee.foresight.world import ForesightWorld, WorldSnapshot
 
@@ -49,8 +63,12 @@ class ScenarioConfig:
         ``decision_forecast`` only; others raise NotImplementedError)
       - ``n_ticks``: ticks to run (default 1, matching the minimum loop)
       - ``personas``: list of PersonaSpec entries
+      - ``tier_mix``: PR 3 — optional override of the captain-locked
+        5/15/80 tier mix (RFC §10). ``None`` means "use the locked
+        default". Loaders coerce the YAML ``tier_mix:`` block to a
+        ``TierMix`` instance.
 
-    v1.0 adds tick_cadence, tier_mix, activation policy, action_space,
+    v1.0 adds tick_cadence, activation policy, action_space,
     instinct_policy_overlay, aggregator, projection, calibration,
     cost_estimate, ui_rail, triggers, permissions — i.e. the full
     RFC §18 example YAML.
@@ -60,6 +78,7 @@ class ScenarioConfig:
     sub_type: str = "decision_forecast"
     n_ticks: int = 1
     personas: list[PersonaSpec] = field(default_factory=list)
+    tier_mix: TierMix | None = None
 
     SUPPORTED_SUB_TYPES: tuple[str, ...] = ("decision_forecast",)
 
@@ -82,9 +101,10 @@ class ScenarioConfig:
     def from_yaml(cls, path: str | Path) -> ScenarioConfig:
         """Load a scenario from a YAML file.
 
-        v0.1 accepts the flat shape declared by
-        ``scenarios/decision_forecast.yaml``; v1.0 will accept the
-        full RFC §18 grammar.
+        v0.2 accepts the flat shape declared by
+        ``scenarios/decision_forecast.yaml`` plus the optional
+        ``tier_mix:`` block PR 3 introduces. v1.0 will accept the
+        full RFC §18 grammar (activation, action_space, etc.).
         """
         with open(path) as fp:
             data = yaml.safe_load(fp) or {}
@@ -96,11 +116,22 @@ class ScenarioConfig:
             )
             for p in data.get("personas", [])
         ]
+        tier_mix_block = data.get("tier_mix")
+        tier_mix: TierMix | None = None
+        if tier_mix_block:
+            # Coerce the YAML dict to a TierMix; raises if the triple
+            # doesn't sum to 1.0.
+            tier_mix = TierMix(
+                premium=float(tier_mix_block.get("premium", 0.05)),
+                mid=float(tier_mix_block.get("mid", 0.15)),
+                tail=float(tier_mix_block.get("tail", 0.80)),
+            )
         return cls(
             name=data["name"],
             sub_type=data.get("sub_type", "decision_forecast"),
             n_ticks=int(data.get("n_ticks", 1)),
             personas=personas,
+            tier_mix=tier_mix,
         )
 
 
@@ -113,6 +144,9 @@ class RunResult:
       - ``tick_snapshots``: WorldSnapshot per tick (in order)
       - ``final_state``: the world's toy state dict at run end
       - ``actions_logged``: total successful actions across all ticks
+      - ``tier_distribution``: PR 3 — per-tier persona count when a
+        tier pool was used (empty dict for the v0.1 single-backend
+        path). Drives the per-run cost report's RFC §10 table.
 
     v1.0 adds projected decisions, aggregator metrics, calibration
     buffer writes, cost meter readouts.
@@ -122,6 +156,7 @@ class RunResult:
     tick_snapshots: list[WorldSnapshot]
     final_state: dict[str, Any]
     actions_logged: int
+    tier_distribution: dict[str, int] = field(default_factory=dict)
 
     @property
     def n_ticks(self) -> int:
@@ -134,6 +169,7 @@ class RunResult:
             "n_ticks": self.n_ticks,
             "actions_logged": self.actions_logged,
             "final_state": dict(self.final_state),
+            "tier_distribution": dict(self.tier_distribution),
             "tick_snapshots": [
                 {
                     "tick": s.tick,
@@ -153,27 +189,51 @@ async def run_scenario(
     config: ScenarioConfig,
     *,
     backend: Any | None = None,
+    backend_pool: list[Any] | None = None,
 ) -> RunResult:
     """Run one scenario end-to-end.
 
-    ``backend`` defaults to ``DeterministicFakeBackend()`` so calling
-    ``run_scenario(config)`` works in tests + smoke runs without an
-    API key. Production callers hand in a ``ClaudeCodeBackend()`` (or,
-    at v1.0, a tier-pool round-robin of three).
+    Args:
+        config: the scenario configuration (sub-type, n_ticks,
+            persona specs, optional tier_mix override).
+        backend: single backend to share across all personas. The
+            v0.1 path. Defaults to ``DeterministicFakeBackend()`` so
+            tests + smoke runs work without an API key.
+        backend_pool: PR 3 — pre-built ``list[BaseModelBackend]``
+            (e.g. from ``llm.tier_pool.build_tier_pool``). When
+            supplied, persona i is assigned ``pool[i % len(pool)]``
+            and the ``backend`` arg is ignored. The run's
+            ``tier_distribution`` is populated from the pool so the
+            per-run report can render the cost decomposition.
+
+    Production callers hand in a ``backend_pool`` built from
+    ``TierMix.locked_default()`` (or the scenario's
+    ``tier_mix`` override). The pool round-robin assignment matches
+    the RFC §7.3 ``List[BaseModelBackend]`` primitive OASIS's
+    SocialAgent uses natively.
     """
-    if backend is None:
+    if backend_pool is None and backend is None:
         backend = DeterministicFakeBackend()
 
     world = ForesightWorld()
-    for spec in config.personas:
+    tier_dist: dict[str, int] = {}
+
+    for idx, spec in enumerate(config.personas):
+        if backend_pool:
+            persona_backend = backend_pool[idx % len(backend_pool)]
+        else:
+            persona_backend = backend
         persona = SoulSeededPersona(
             name=spec.name,
             role=spec.role,
             ocean_drift=spec.ocean,
-            backend=backend,
+            backend=persona_backend,
             agent_id=uuid4(),
         )
         world.add_agent(persona)
+
+    if backend_pool:
+        tier_dist = tier_distribution(backend_pool[: len(config.personas)])
 
     snapshots: list[WorldSnapshot] = []
     for _ in range(config.n_ticks):
@@ -185,4 +245,5 @@ async def run_scenario(
         tick_snapshots=snapshots,
         final_state=world.state,
         actions_logged=snapshots[-1].actions_applied if snapshots else 0,
+        tier_distribution=tier_dist,
     )

--- a/ee/pocketpaw_ee/foresight/substrate/oasis/README-FORK.md
+++ b/ee/pocketpaw_ee/foresight/substrate/oasis/README-FORK.md
@@ -1,5 +1,6 @@
 # OASIS vendored fork
 
+Updated: 2026-05-25 (feat/foresight-v03-calibration) — RFC 08 PR 3.
 Updated: 2026-05-25 (feat/foresight-v02-oasis-camel-paw) — RFC 08 v0.2 PR.
 Created: 2026-05-25 (feat/foresight-v01-scaffold) — RFC 08 v0.1 first PR.
 
@@ -28,14 +29,18 @@ automatically — see "Drift policy" below.
 | File / region | Change | Why |
 |---|---|---|
 | All `*.py` files | `from oasis.X` → `from pocketpaw_ee.foresight.substrate.oasis.X` (mechanical rewrite) | Upstream uses absolute imports rooted at top-level `oasis`. Vendoring inside our namespace package requires the rewrite. No semantic change. |
-| `__init__.py` | Replaced with a safe wrapper that lazy-imports upstream re-exports | Lets the package be importable on machines without `camel-ai` installed (OSS-only install path). Upstream's verbatim re-exports moved to `_upstream_init.py`. |
-| `_upstream_init.py` | New file — verbatim copy of upstream's `__init__.py` with the import-path rewrite above | Preserves provenance; PR 3 wires the re-exports into the engine via the `OASIS_AVAILABLE` flag the new `__init__.py` exposes. |
+| `__init__.py` | Replaced with a tiered import wrapper (`OASIS_AVAILABLE` for the core / `OASIS_RECSYS_AVAILABLE` for the recsys+torch tier) | Lets the package be importable without torch / pandas / neo4j. Upstream's verbatim re-exports moved to `_upstream_init.py`. |
+| `_upstream_init.py` | New file — verbatim copy of upstream's `__init__.py` with the import-path rewrite above | Preserves provenance; the recsys tier loads from here via `oasis.__init__.py`'s second try block. |
+| `social_platform/__init__.py` | **(PR 3)** Made `Platform` re-export lazy via module-level `__getattr__` | Upstream eagerly imports `.platform` → `.recsys` → `torch`. Foresight per RFC 08 §6.2 drops Platform entirely (replaced with `ForesightWorld`). Lazy import keeps `Channel` cheap. |
+| `social_agent/__init__.py` | **(PR 3)** Made `generate_*_agent_graph` / `generate_agents_100w` re-exports lazy via module-level `__getattr__` | Upstream eagerly imports `agents_generator` → `pandas`. Foresight v0.1 uses `.soul`-file persona pools, not CSV imports. |
+| `social_agent/agent.py` | **(PR 3)** Guarded the eager `FileHandler` setup with try/except + `makedirs(exist_ok=True)` | Upstream unconditionally writes to `./log/social.agent-<ts>.log` at import; fails in read-only sandboxes (CI, /tmp). Guard preserves stream-handler logging when file logging fails. |
+| `social_agent/agent_graph.py` | **(PR 3)** Lazy-imported `neo4j.GraphDatabase` inside `Neo4jHandler.__init__` | Upstream eagerly imports it; AgentGraph defaults to `igraph` (the v0.1 backend), so the neo4j driver stays optional. |
+| `environment/env.py` | **(PR 3)** Same log-dir guard as `social_agent/agent.py` | Same rationale. |
 
-No upstream functional code was modified. Every algorithm, schema, and
-control-flow path comes from upstream as-is. The Apache-2.0 §4(b)
-modified-file marker is reserved for *future* per-file behavioural
-edits; the import-path rewrite is a packaging-only adaptation and is
-documented here at the module level rather than per-file.
+The Apache-2.0 §4(b) modified-file markers are at the top of each PR-3
+file listed above, with a "Modified by PocketPaw, 2026-05-25" notice
+plus the per-change justification. PR 2's mechanical import-path
+rewrite is documented at the module level (no behavioural change).
 
 ### What was NOT copied (intentional)
 

--- a/ee/pocketpaw_ee/foresight/substrate/oasis/__init__.py
+++ b/ee/pocketpaw_ee/foresight/substrate/oasis/__init__.py
@@ -1,4 +1,16 @@
 # ee/pocketpaw_ee/foresight/substrate/oasis/__init__.py
+# Updated: 2026-05-25 (feat/foresight-v03-calibration) — PR 3:
+#   - Switched to a tiered import strategy so OASIS's torch-dependent
+#     recsys (Twitter Platform / TWHIN-BERT / process_recsys_posts)
+#     stays lazy. The bits PR 3+ actually uses — SocialAgent, AgentGraph,
+#     UserInfo, ActionType, Channel — DO NOT need torch and load
+#     cleanly. RFC 08 §6.2 explicitly drops the SQLite/recsys-backed
+#     Platform; setting up the OASIS_AVAILABLE branch on the lightweight
+#     core lets ForesightWorld wire through SocialAgent without
+#     dragging torch into every dev shell. The heavy upstream surface
+#     (Platform, make, print_db_contents, generate_*_agent_graph,
+#     LLMAction, ManualAction) is still importable on machines that
+#     happen to have torch — guarded by OASIS_RECSYS_AVAILABLE.
 # Updated: 2026-05-25 (feat/foresight-v02-oasis-camel-paw) — vendored fork
 # of camel-ai/oasis at upstream SHA 46cdc8d.
 #
@@ -6,13 +18,14 @@
 # init so ``import pocketpaw_ee.foresight.substrate.oasis`` always
 # succeeds — even on machines without camel-ai installed. The upstream
 # top-level re-exports live in ``_upstream_init.py`` (preserved verbatim
-# except for absolute-import path rewrites from ``oasis.*`` to
-# ``pocketpaw_ee.foresight.substrate.oasis.*``); we attempt them on
-# import and fall through to a namespace-only package when CAMEL is
-# missing. PR 3 wires the substrate into ForesightWorld; until then,
-# v0.1's engine surfaces (World, Persona, Backend) are protocol-shaped
-# and do NOT import from this package, so missing-CAMEL machines remain
-# fully operational.
+# except for absolute-import path rewrites). PR 3 splits the surface
+# in two:
+#   - the *core* (SocialAgent / AgentGraph / UserInfo / ActionType /
+#     Channel) — needs CAMEL but NOT torch; this is what the Foresight
+#     engine actually wires through.
+#   - the *recsys* tier (Platform / make / generate_*_agent_graph /
+#     LLMAction / ManualAction / print_db_contents) — needs torch
+#     because oasis.social_platform.platform pulls recsys.py.
 
 from __future__ import annotations
 
@@ -30,53 +43,101 @@ __version__ = "0.2.5"
 # at every call site.
 OASIS_AVAILABLE: bool = False
 OASIS_LOAD_ERROR: Exception | None = None
+OASIS_RECSYS_AVAILABLE: bool = False
+OASIS_RECSYS_LOAD_ERROR: Exception | None = None
+
+# Names that get bound at module level when their tier loads cleanly.
+# Declared up-front for type checkers; reassigned in the try blocks.
+ActionType = None  # type: ignore[assignment]
+AgentGraph = None  # type: ignore[assignment]
+Channel = None  # type: ignore[assignment]
+SocialAgent = None  # type: ignore[assignment]
+UserInfo = None  # type: ignore[assignment]
+
+# Recsys-tier symbols (only bound when torch is installed).
+DefaultPlatformType = None  # type: ignore[assignment]
+LLMAction = None  # type: ignore[assignment]
+ManualAction = None  # type: ignore[assignment]
+Platform = None  # type: ignore[assignment]
+generate_reddit_agent_graph = None  # type: ignore[assignment]
+generate_twitter_agent_graph = None  # type: ignore[assignment]
+make = None  # type: ignore[assignment]
+print_db_contents = None  # type: ignore[assignment]
 
 try:
-    # The upstream init pulls in oasis.environment, oasis.social_agent,
-    # oasis.social_platform — each of which transitively imports CAMEL.
-    # On an OSS-only install (``uv sync --dev`` without ``--group ee``),
-    # camel-ai is not installed and this import will fail. That is OK —
-    # the foresight engine's v0.1 protocol surfaces don't depend on
-    # this package being loaded.
-    from pocketpaw_ee.foresight.substrate.oasis._upstream_init import (  # noqa: F401
-        ActionType,
+    # The CORE OASIS surface — SocialAgent / AgentGraph / Channel /
+    # UserInfo / ActionType. These do NOT touch torch; they only
+    # require camel-ai (the BaseModelBackend protocol + Channel
+    # primitives). This is the surface RFC 08 §6.2 says we KEEP.
+    from pocketpaw_ee.foresight.substrate.oasis.social_agent.agent import SocialAgent  # noqa: F811
+    from pocketpaw_ee.foresight.substrate.oasis.social_agent.agent_graph import (  # noqa: F811
         AgentGraph,
+    )
+    from pocketpaw_ee.foresight.substrate.oasis.social_platform.channel import Channel  # noqa: F811
+    from pocketpaw_ee.foresight.substrate.oasis.social_platform.config import UserInfo  # noqa: F811
+    from pocketpaw_ee.foresight.substrate.oasis.social_platform.typing import (  # noqa: F811
+        ActionType,
+    )
+
+    OASIS_AVAILABLE = True
+except Exception as exc:  # noqa: BLE001 — broad on purpose
+    OASIS_LOAD_ERROR = exc
+    logger.debug(
+        "OASIS core substrate not loaded (likely missing camel-ai dep). "
+        "Module is importable as a namespace package; symbols unavailable. "
+        "Underlying error: %s: %s",
+        type(exc).__name__,
+        exc,
+    )
+
+# The RECSYS-tier OASIS surface — Platform / make / generate_*_agent_graph
+# / LLMAction / ManualAction / print_db_contents. These all transitively
+# import ``oasis.social_platform.recsys`` which depends on torch. Per
+# RFC 08 §6.2 we explicitly DROP Platform (replace with Fabric-backed
+# ForesightWorld), so the recsys tier is only useful for upstream-
+# compat smoke tests and the v2.0 Market Sim sub-type (which may
+# revisit recsys). On machines without torch this branch is skipped.
+try:
+    from pocketpaw_ee.foresight.substrate.oasis._upstream_init import (  # noqa: F401, F811
         DefaultPlatformType,
         LLMAction,
         ManualAction,
         Platform,
-        SocialAgent,
-        UserInfo,
         generate_reddit_agent_graph,
         generate_twitter_agent_graph,
         make,
         print_db_contents,
     )
 
-    OASIS_AVAILABLE = True
-    __all__ = [
-        "ActionType",
-        "AgentGraph",
-        "DefaultPlatformType",
-        "LLMAction",
-        "ManualAction",
-        "OASIS_AVAILABLE",
-        "Platform",
-        "SocialAgent",
-        "UserInfo",
-        "__version__",
-        "generate_reddit_agent_graph",
-        "generate_twitter_agent_graph",
-        "make",
-        "print_db_contents",
-    ]
-except Exception as exc:  # noqa: BLE001 — broad on purpose; any import failure means no symbols
-    OASIS_LOAD_ERROR = exc
+    OASIS_RECSYS_AVAILABLE = True
+except Exception as exc:  # noqa: BLE001 — broad on purpose
+    OASIS_RECSYS_LOAD_ERROR = exc
     logger.debug(
-        "OASIS substrate is vendored but not loaded (likely missing camel-ai dep). "
-        "Module is importable as a namespace package; symbols unavailable. "
-        "Underlying error: %s: %s",
+        "OASIS recsys tier not loaded (likely missing torch). "
+        "Foresight only needs the recsys tier for Market Sim sub-type "
+        "(v2.0). Core OASIS symbols (SocialAgent, AgentGraph, Channel) "
+        "remain available. Underlying error: %s: %s",
         type(exc).__name__,
         exc,
     )
-    __all__ = ["OASIS_AVAILABLE", "OASIS_LOAD_ERROR", "__version__"]
+
+__all__ = [
+    "ActionType",
+    "AgentGraph",
+    "Channel",
+    "DefaultPlatformType",
+    "LLMAction",
+    "ManualAction",
+    "OASIS_AVAILABLE",
+    "OASIS_LOAD_ERROR",
+    "OASIS_RECSYS_AVAILABLE",
+    "OASIS_RECSYS_LOAD_ERROR",
+    "Platform",
+    "SocialAgent",
+    "UserInfo",
+    "__version__",
+    "generate_reddit_agent_graph",
+    "generate_twitter_agent_graph",
+    "make",
+    "print_db_contents",
+]

--- a/ee/pocketpaw_ee/foresight/substrate/oasis/environment/env.py
+++ b/ee/pocketpaw_ee/foresight/substrate/oasis/environment/env.py
@@ -26,23 +26,35 @@ from pocketpaw_ee.foresight.substrate.oasis.social_platform.platform import Plat
 from pocketpaw_ee.foresight.substrate.oasis.social_platform.typing import (ActionType, DefaultPlatformType,
                                           RecsysType)
 
-# Create log directory if it doesn't exist
+# Modified by PocketPaw, 2026-05-25 — RFC 08 PR 3: same eager-log-dir
+# guard as social_agent/agent.py — see that file for rationale. Logs
+# fall back to stream-only when ``./log/`` is not writable.
 log_dir = "./log"
-if not os.path.exists(log_dir):
-    os.makedirs(log_dir)
+_pp_file_logging_enabled = True
+try:
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir)
+except OSError:
+    _pp_file_logging_enabled = False
 
 # Configure logger
 env_log = logging.getLogger("oasis.env")
 env_log.setLevel("INFO")
 
-# Add file handler to save logs to file
-current_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-file_handler = logging.FileHandler(f"{log_dir}/oasis-{current_time}.log",
-                                   encoding="utf-8")
-file_handler.setLevel("INFO")
-file_handler.setFormatter(
-    logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
-env_log.addHandler(file_handler)
+# Add file handler to save logs to file (only if log dir is writable).
+if _pp_file_logging_enabled:
+    try:
+        current_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        file_handler = logging.FileHandler(
+            f"{log_dir}/oasis-{current_time}.log", encoding="utf-8")
+        file_handler.setLevel("INFO")
+        file_handler.setFormatter(
+            logging.Formatter(
+                "%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+        env_log.addHandler(file_handler)
+    except OSError:
+        # File logging not possible; stream handler still receives logs.
+        pass
 
 
 class OasisEnv:

--- a/ee/pocketpaw_ee/foresight/substrate/oasis/social_agent/__init__.py
+++ b/ee/pocketpaw_ee/foresight/substrate/oasis/social_agent/__init__.py
@@ -11,13 +11,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+#
+# Modified by PocketPaw, 2026-05-25 — RFC 08 PR 3:
+#   - Made the ``agents_generator`` re-exports LAZY. Upstream eagerly
+#     imports them here, which transitively pulls in ``pandas`` (used
+#     to read OASIS's CSV/JSON profile-import format). Foresight v0.1
+#     doesn't use the CSV bulk-import path — personas come from
+#     ``.soul`` files via ``SoulSeededPersona.from_paw_agent``. Making
+#     the generators lazy lets ``pandas`` stay an optional dep.
+#   - ``SocialAgent`` and ``AgentGraph`` (the load-bearing primitives
+#     for PR 3's wiring) remain eagerly imported.
+#   - Documented in ``substrate/oasis/README-FORK.md``.
 from .agent import SocialAgent
 from .agent_graph import AgentGraph
-from .agents_generator import (generate_agents_100w,
-                               generate_reddit_agent_graph,
-                               generate_twitter_agent_graph)
 
 __all__ = [
-    "SocialAgent", "AgentGraph", "generate_agents_100w",
-    "generate_reddit_agent_graph", "generate_twitter_agent_graph"
+    "SocialAgent",
+    "AgentGraph",
+    "generate_agents_100w",
+    "generate_reddit_agent_graph",
+    "generate_twitter_agent_graph",
 ]
+
+
+def __getattr__(name: str):
+    """Lazy re-export so OASIS's CSV/JSON bulk-import functions still
+    resolve on machines that have pandas installed, without forcing
+    the pandas import on every Foresight startup.
+    """
+    if name in {
+        "generate_agents_100w",
+        "generate_reddit_agent_graph",
+        "generate_twitter_agent_graph",
+    }:
+        from . import agents_generator  # noqa: PLC0415
+
+        return getattr(agents_generator, name)
+    raise AttributeError(f"module 'oasis.social_agent' has no attribute {name!r}")

--- a/ee/pocketpaw_ee/foresight/substrate/oasis/social_agent/agent.py
+++ b/ee/pocketpaw_ee/foresight/substrate/oasis/social_agent/agent.py
@@ -35,19 +35,40 @@ from pocketpaw_ee.foresight.substrate.oasis.social_platform.typing import Action
 if TYPE_CHECKING:
     from pocketpaw_ee.foresight.substrate.oasis.social_agent import AgentGraph
 
+# Modified by PocketPaw, 2026-05-25 — RFC 08 PR 3:
+#   - Made the eager FileHandler attachment GUARDED. Upstream
+#     unconditionally writes to ``./log/social.agent-<timestamp>.log``
+#     at module import, which fails on read-only sandboxes (CI, tests
+#     run from /tmp, packaged wheels) and on any cwd where ``./log/``
+#     hasn't been pre-created. The guard skips the file handler when
+#     the directory isn't writable; the StreamHandler (default Python
+#     logger) still receives every log line, so observability is
+#     preserved without crashing imports.
+#   - The change is documented in
+#     ``ee/pocketpaw_ee/foresight/substrate/oasis/README-FORK.md``
+#     under "What we modified".
 if "sphinx" not in sys.modules:
     agent_log = logging.getLogger(name="social.agent")
     agent_log.setLevel("DEBUG")
 
     if not agent_log.handlers:
-        now = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        file_handler = logging.FileHandler(
-            f"./log/social.agent-{str(now)}.log")
-        file_handler.setLevel("DEBUG")
-        file_handler.setFormatter(
-            logging.Formatter(
-                "%(levelname)s - %(asctime)s - %(name)s - %(message)s"))
-        agent_log.addHandler(file_handler)
+        import os as _pp_os  # noqa: PLC0415
+
+        _pp_log_dir = "./log"
+        try:
+            _pp_os.makedirs(_pp_log_dir, exist_ok=True)
+            now = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            file_handler = logging.FileHandler(
+                f"{_pp_log_dir}/social.agent-{str(now)}.log")
+            file_handler.setLevel("DEBUG")
+            file_handler.setFormatter(
+                logging.Formatter(
+                    "%(levelname)s - %(asctime)s - %(name)s - %(message)s"))
+            agent_log.addHandler(file_handler)
+        except OSError:
+            # ./log/ not writable (sandbox, packaged wheel, read-only fs).
+            # Skip the file handler; stream handler still receives logs.
+            pass
 
 ALL_SOCIAL_ACTIONS = [action.value for action in ActionType]
 

--- a/ee/pocketpaw_ee/foresight/substrate/oasis/social_agent/agent_graph.py
+++ b/ee/pocketpaw_ee/foresight/substrate/oasis/social_agent/agent_graph.py
@@ -11,12 +11,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+# Modified by PocketPaw, 2026-05-25 — RFC 08 PR 3:
+#   - Lazy-imported ``neo4j.GraphDatabase``. Upstream eagerly imports
+#     it at module level, which is unhelpful: AgentGraph defaults to
+#     the ``igraph`` backend, and the neo4j backend is only used when
+#     a caller explicitly passes ``backend="neo4j"``. Foresight v0.1
+#     uses igraph exclusively (RFC 08 §6.3). Gating the import behind
+#     ``Neo4jHandler.__init__`` lets neo4j stay an optional dep.
+#   - Documented in ``substrate/oasis/README-FORK.md``.
 from __future__ import annotations
 
 from typing import Any, Literal
 
 import igraph as ig
-from neo4j import GraphDatabase
 
 from pocketpaw_ee.foresight.substrate.oasis.social_agent.agent import SocialAgent
 from pocketpaw_ee.foresight.substrate.oasis.social_platform.config import Neo4jConfig
@@ -25,6 +32,9 @@ from pocketpaw_ee.foresight.substrate.oasis.social_platform.config import Neo4jC
 class Neo4jHandler:
 
     def __init__(self, nei4j_config: Neo4jConfig):
+        # Lazy import — see modification note at the top of this file.
+        from neo4j import GraphDatabase  # noqa: PLC0415
+
         self.driver = GraphDatabase.driver(
             nei4j_config.uri,
             auth=(nei4j_config.username, nei4j_config.password),

--- a/ee/pocketpaw_ee/foresight/substrate/oasis/social_platform/__init__.py
+++ b/ee/pocketpaw_ee/foresight/substrate/oasis/social_platform/__init__.py
@@ -11,10 +11,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+#
+# Modified by PocketPaw, 2026-05-25 — RFC 08 PR 3:
+#   - Made the ``Platform`` re-export LAZY. Upstream eagerly imports
+#     ``.platform`` here, which transitively pulls
+#     ``social_platform.recsys`` → ``import torch``. Foresight per
+#     RFC 08 §6.2 explicitly DROPS the Platform (replaced with the
+#     Fabric-backed ``ForesightWorld``), so dragging torch into every
+#     `import oasis.social_platform.channel` path is a regression.
+#   - ``Channel`` (the lightweight async-queue primitive ``SocialAgent``
+#     needs) remains eagerly imported because it has no heavy
+#     transitive deps.
+#   - ``Platform`` is still reachable via attribute access
+#     (``oasis.social_platform.Platform``) — the ``__getattr__`` shim
+#     below imports it on first access and raises a helpful
+#     ImportError if torch isn't installed.
+#   - This change is documented in
+#     ``ee/pocketpaw_ee/foresight/substrate/oasis/README-FORK.md`` under
+#     "What we modified".
 from .channel import Channel
-from .platform import Platform
 
 __all__ = [
     "Channel",
     "Platform",
 ]
+
+
+def __getattr__(name: str):
+    """Lazy re-export so ``oasis.social_platform.Platform`` still
+    resolves on machines that have torch installed, without forcing
+    the import path on every consumer of ``Channel`` / ``SocialAgent``.
+    """
+    if name == "Platform":
+        from .platform import Platform  # noqa: PLC0415
+
+        return Platform
+    raise AttributeError(f"module 'oasis.social_platform' has no attribute {name!r}")

--- a/ee/pocketpaw_ee/foresight/world.py
+++ b/ee/pocketpaw_ee/foresight/world.py
@@ -1,4 +1,22 @@
 # ee/pocketpaw_ee/foresight/world.py
+# Updated: 2026-05-25 (feat/foresight-v03-calibration) — PR 3:
+#   - Added optional ``oasis.AgentGraph`` integration for the
+#     relationship layer (RFC 08 §6.3). When OASIS_AVAILABLE,
+#     ``ForesightWorld`` can be constructed with
+#     ``use_oasis_graph=True`` (or pass an explicit ``agent_graph=``)
+#     to register personas in the OASIS in-memory graph, getting
+#     follower-of / colleague-of / approves-for relationships for
+#     free. The smoke loop's old behavior (graph-free) is preserved
+#     as the default so the PR 1/2 tests keep passing.
+#   - The OASIS substrate's ``OasisEnv.step`` is NOT wired into
+#     ``tick()`` because OasisEnv requires a Platform (Twitter/Reddit
+#     SQLite-backed), and per RFC 08 §6.2 we EXPLICITLY drop
+#     Platform in favor of this Fabric-backed world. Instead, we
+#     adopt OASIS's per-backend-semaphore pattern (the load-bearing
+#     primitive from ``oasis.environment.env._perform_llm_action``)
+#     directly in ``tick()`` so the same concurrency-cap semantics
+#     hold without dragging Platform in. PR 4+ may revisit
+#     ``OasisEnv`` if a Market Sim scenario wants the recsys.
 # Created: 2026-05-25 (feat/foresight-v01-scaffold) — RFC 08 v0.1 scaffold.
 #
 # ForesightWorld — Fabric-backed stub world for the v0.1 simulation
@@ -15,9 +33,12 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID, uuid4
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -57,7 +78,32 @@ class ForesightWorld:
     cognition in the middle.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        use_oasis_graph: bool = False,
+        agent_graph: Any | None = None,
+        max_concurrent: int = 128,
+    ) -> None:
+        """Construct the world.
+
+        Args:
+            use_oasis_graph: when ``True`` (and ``OASIS_AVAILABLE`` per
+                the substrate's tiered import), construct an
+                ``oasis.AgentGraph(backend="igraph")`` and register
+                every persona in it. Personas can then read
+                relationship neighborhoods via the graph; the
+                conflict resolver uses persona priorities the graph
+                exposes. Default ``False`` preserves the PR 1/2
+                graph-free smoke loop.
+            agent_graph: pre-constructed ``oasis.AgentGraph`` instance
+                (caller-owned). Overrides ``use_oasis_graph`` when
+                supplied.
+            max_concurrent: per-tick concurrency cap (mirrors OASIS's
+                ``OasisEnv.llm_semaphore``; default 128 matches the
+                RFC §6.4 Sonnet tier). PR 4+ will swap this for
+                per-tier semaphores from ``llm.tier_pool``.
+        """
         self._personas: dict[UUID, Any] = {}
         # _state is the toy "world state" v0.1 mutates; v1.0 replaces it
         # with FabricSnapshot. The contract callers see is opaque-dict.
@@ -65,6 +111,50 @@ class ForesightWorld:
         self._tick: int = 0
         self._actions_applied: int = 0
         self._last_tick_actions: list[dict[str, Any]] = []
+        self._sem = asyncio.Semaphore(max_concurrent)
+        self._agent_graph: Any | None = agent_graph
+        # Tracks how persona ids map to OASIS-side integer agent ids
+        # (OASIS's AgentGraph keys on ``int``; we key on ``UUID``).
+        self._oasis_id_for: dict[UUID, int] = {}
+        self._next_oasis_id: int = 0
+
+        if self._agent_graph is None and use_oasis_graph:
+            self._agent_graph = self._try_construct_oasis_graph()
+
+    @staticmethod
+    def _try_construct_oasis_graph() -> Any | None:
+        """Lazy-construct an ``oasis.AgentGraph(backend='igraph')``.
+
+        Returns ``None`` (with a debug log) when OASIS_AVAILABLE is
+        False — e.g. missing igraph or one of the lazy-import wars
+        flagged in PR 3's substrate __init__. Callers can re-attempt
+        later or pass an explicit ``agent_graph=``.
+        """
+        from pocketpaw_ee.foresight.substrate import oasis  # noqa: PLC0415 — lazy
+
+        if not oasis.OASIS_AVAILABLE or oasis.AgentGraph is None:
+            logger.debug(
+                "use_oasis_graph=True but OASIS core not loaded "
+                "(OASIS_AVAILABLE=%s, error=%s). Falling back to "
+                "graph-free registry.",
+                oasis.OASIS_AVAILABLE,
+                oasis.OASIS_LOAD_ERROR,
+            )
+            return None
+        try:
+            return oasis.AgentGraph(backend="igraph")
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "Failed to construct oasis.AgentGraph: %s: %s",
+                type(exc).__name__,
+                exc,
+            )
+            return None
+
+    @property
+    def agent_graph(self) -> Any | None:
+        """The OASIS AgentGraph instance, or ``None`` when not used."""
+        return self._agent_graph
 
     # --- registry ------------------------------------------------------
 
@@ -86,6 +176,36 @@ class ForesightWorld:
         if aid in self._personas:
             raise ValueError(f"persona id {aid} already registered")
         self._personas[aid] = persona
+
+        # PR 3 — register in the OASIS AgentGraph when available.
+        # Only personas that are actual ``SocialAgent`` subclasses
+        # (i.e. ``PawSocialAgent`` from persona.py) can be added to the
+        # AgentGraph since it indexes by ``SocialAgent.social_agent_id``;
+        # ``SoulSeededPersona`` (no SocialAgent inheritance) is skipped
+        # cleanly. The integer id mapping is tracked in
+        # ``_oasis_id_for`` so future edges (follower-of /
+        # approves-for) can resolve UUID → int.
+        if self._agent_graph is not None:
+            oasis_id = self._next_oasis_id
+            self._next_oasis_id += 1
+            social_agent_id = getattr(persona, "social_agent_id", None)
+            if social_agent_id is not None:
+                try:
+                    self._agent_graph.add_agent(persona)
+                    self._oasis_id_for[aid] = int(social_agent_id)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "OASIS graph add_agent failed for persona %s: %s: %s",
+                        aid,
+                        type(exc).__name__,
+                        exc,
+                    )
+            else:
+                # Plain SoulSeededPersona; we still track an oasis_id
+                # for it so cross-persona edges can be wired by the
+                # caller, but skip the AgentGraph itself (it would
+                # crash without a real SocialAgent).
+                self._oasis_id_for[aid] = oasis_id
         return aid
 
     @property
@@ -112,9 +232,17 @@ class ForesightWorld:
             active_ids = list(self._personas.keys())
 
         observation = self._observation_for_active(active_ids)
-        coros = [
-            self._personas[aid].decide(observation) for aid in active_ids if aid in self._personas
-        ]
+
+        # PR 3 — wrap each decide() in the semaphore so the OASIS-style
+        # per-tier concurrency cap holds. The wrapper preserves
+        # ``return_exceptions=True`` semantics by letting the original
+        # exception propagate inside the semaphore and catching it on
+        # the gather side.
+        async def _capped_decide(persona: Any) -> Any:
+            async with self._sem:
+                return await persona.decide(observation)
+
+        coros = [_capped_decide(self._personas[aid]) for aid in active_ids if aid in self._personas]
         results = await asyncio.gather(*coros, return_exceptions=True)
 
         # v0.1 conflict policy: append-only, last-writer-wins on

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -76,6 +76,33 @@ dependencies = [
     "composio_openai_agents>=0.7.0",
     "composio_google_adk>=0.7.0",
     "composio_langgraph>=0.7.0",
+    # Foresight module (RFC 08) — promoted to hard dep in PR 3 (was the
+    # pocketpaw-ee[foresight] optional extra in PR 2). CAMEL provides the
+    # LLM-backend abstraction (ChatAgent, BaseModelBackend, MemoryRecord,
+    # ModelFactory, FunctionTool, TextPrompt, OpenAIEmbedding) consumed
+    # by the vendored OASIS fork at
+    # ee/pocketpaw_ee/foresight/substrate/oasis/.
+    #
+    # We pin a QBTRIX fork (relax-caps branch) because CAMEL 0.2.90 caps
+    # ``psutil<6`` which collides with livekit-agents (already an ee/ dep
+    # at psutil>=5.9.0 with no upper bound) and the root pocketpaw
+    # dependency group. The fork removes ONLY the psutil cap — the
+    # openai cap was already lifted upstream so no extra patches needed.
+    # See ee/pocketpaw_ee/foresight/substrate/oasis/README-FORK.md for
+    # vendoring rationale; the fork-pin is verified by ``uv lock``
+    # alongside langchain-openai + livekit-agents (the colliding deps).
+    "camel-ai",
+    # igraph is the default backend for ``oasis.AgentGraph`` (Foresight
+    # uses it for the in-memory follower / approver / reports-to
+    # relationship graph). The neo4j backend stays optional — we made
+    # it lazy-imported in
+    # ``substrate/oasis/social_agent/agent_graph.py`` so the neo4j
+    # driver doesn't have to be installed. ``torch`` (needed by the
+    # recsys tier we don't use) and ``sentence-transformers`` /
+    # ``cairocffi`` (also recsys-only) remain unlisted; see
+    # ``OASIS_RECSYS_AVAILABLE`` in
+    # ``ee/pocketpaw_ee/foresight/substrate/oasis/__init__.py``.
+    "igraph>=0.11",
 ]
 
 [project.optional-dependencies]
@@ -86,19 +113,6 @@ extraction = [
     "trafilatura",
     "python-docx>=1.1.0",
     "pytesseract>=0.3.10",
-]
-# Foresight module (RFC 08). CAMEL provides the LLM-backend abstraction
-# (ChatAgent, BaseModelBackend, MemoryRecord, ModelFactory, FunctionTool,
-# TextPrompt, OpenAIEmbedding) consumed by the vendored OASIS fork at
-# ee/pocketpaw_ee/foresight/substrate/oasis/. Kept optional at v0.2
-# because CAMEL 0.2.78-0.2.90 cap openai<2 and psutil<6, which collide
-# with langchain-openai (in the OSS dev group) and livekit-agents
-# (already an ee/ dep). Install with `pocketpaw-ee[foresight]` once the
-# v0.2 PR lands; PR 3 wires the substrate into the engine and revisits
-# the pin (likely needs a CAMEL fork or a constrained alt-pip resolve).
-# Released 2026-03-22, well past the 7-day supply-chain min-age gate.
-foresight = [
-    "camel-ai==0.2.90",
 ]
 
 [project.urls]
@@ -154,8 +168,24 @@ cloud = "pocketpaw_ee.extensions:CloudAgentExtension"
 [project.entry-points."pocketpaw.composio_tools"]
 cloud = "pocketpaw_ee.extensions:CloudComposioToolProvider"
 
+[tool.hatch.metadata]
+# Allow git+ direct references in dependencies (PEP 440 disallows them
+# in published metadata by default; hatchling honors this flag locally).
+# Needed for the qbtrix CAMEL fork pinned via [tool.uv.sources] below.
+allow-direct-references = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["pocketpaw_ee"]
+
+# RFC 08 PR 3 — Foresight CAMEL hard-dep promotion. The QBTRIX fork's
+# only change vs upstream camel-ai==0.2.90 is removing the psutil<6 cap
+# (which collides with livekit-agents at psutil>=7). uv resolves the
+# CAMEL dep via this source override when `uv lock` runs against
+# ee/pyproject.toml (workspace-local source). See
+# ee/pocketpaw_ee/foresight/substrate/oasis/README-FORK.md for the
+# vendoring rationale and the openai/psutil cap audit.
+[tool.uv.sources]
+camel-ai = { git = "https://github.com/qbtrix/camel-ai.git", rev = "76ff78e8c78d0a38277e421ea9aca34904b4dc37" }
 
 # ---------------------------------------------------------------------------
 # import-linter: chokepoint contracts for ee/pocketpaw_ee/cloud/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -466,6 +466,20 @@ ee = ["pocketpaw-ee"]
 
 [tool.uv.sources]
 pocketpaw-ee = { path = "ee", editable = true }
+# RFC 08 PR 3 — Foresight CAMEL hard-dep promotion.
+#
+# camel-ai is required by pocketpaw-ee (the vendored OASIS fork at
+# ee/pocketpaw_ee/foresight/substrate/oasis/ imports from camel.agents,
+# camel.messages, camel.models, etc.). The QBTRIX fork at
+# pocketpaw/v01-relax-caps removes the psutil<6 cap that collides with
+# livekit-agents (an ee/ dep at psutil>=7). The source override is
+# duplicated in ee/pyproject.toml (which is the one uv reads when
+# resolving pocketpaw-ee's deps); keeping this entry here too means a
+# root-level `uv sync` honors the same pin if anyone ever depends on
+# camel-ai directly from the OSS side. See
+# ee/pocketpaw_ee/foresight/substrate/oasis/README-FORK.md for full
+# vendoring rationale and the psutil/openai cap audit.
+camel-ai = { git = "https://github.com/qbtrix/camel-ai.git", rev = "76ff78e8c78d0a38277e421ea9aca34904b4dc37" }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/ee/foresight/test_adapter.py
+++ b/tests/ee/foresight/test_adapter.py
@@ -350,28 +350,37 @@ async def test_fake_backend_run_advances_call_count_like_complete():
     assert backend.call_count == 2
 
 
-# --- PR 2: LiteLLMFallbackBackend stub -------------------------------
+# --- PR 3: LiteLLMFallbackBackend is no longer a stub ----------------
+#
+# The deep contract — complete() / run() actually talk to LiteLLM —
+# lives in tests/ee/foresight/test_litellm_fallback.py (which uses
+# monkeypatch on ``litellm.acompletion`` so no network is needed).
+# Here we only assert the constructor still works and the availability
+# flag has flipped.
 
 
-def test_litellm_backend_marked_unavailable_at_v02():
-    """The fallback ships as a stub at PR 2; PR 3 wires the real proxy."""
-    assert LiteLLMFallbackBackend.BACKEND_AVAILABLE is False
-
-
-async def test_litellm_backend_complete_raises_with_pr3_pointer():
-    backend = LiteLLMFallbackBackend()
-    with pytest.raises(NotImplementedError, match="PR 3"):
-        await backend.complete("anything")
-
-
-async def test_litellm_backend_run_raises_with_pr3_pointer():
-    backend = LiteLLMFallbackBackend()
-    with pytest.raises(NotImplementedError, match="PR 3"):
-        await backend.run([])
+def test_litellm_backend_marked_available_at_v03():
+    """PR 2 shipped False (stub); PR 3 flips the flag to True since the
+    real ``litellm.acompletion`` proxy is now wired up.
+    """
+    assert LiteLLMFallbackBackend.BACKEND_AVAILABLE is True
 
 
 def test_litellm_backend_constructor_accepts_kwargs_without_crashing():
-    """PR 3 will accept model, base_url, api_key — for now we just ensure
-    construction doesn't blow up so the tier-pool builder can iterate."""
-    backend = LiteLLMFallbackBackend(model="anthropic/claude-sonnet-4-7")
+    """The tier-pool builder iterates over fallback slots; the
+    constructor must accept the full PR 3 kwarg surface.
+    """
+    backend = LiteLLMFallbackBackend(
+        model="anthropic/claude-sonnet-4-7",
+        base_url="https://api.example.com",
+        api_key="sk-test",
+        max_concurrent=64,
+        extra_kwargs={"temperature": 0.7},
+    )
     assert backend is not None
+    assert backend._model == "anthropic/claude-sonnet-4-7"
+
+
+def test_litellm_backend_rejects_zero_concurrency():
+    with pytest.raises(ValueError, match="max_concurrent"):
+        LiteLLMFallbackBackend(max_concurrent=0)

--- a/tests/ee/foresight/test_calibration.py
+++ b/tests/ee/foresight/test_calibration.py
@@ -1,0 +1,339 @@
+# tests/ee/foresight/test_calibration.py
+# Created: 2026-05-25 (feat/foresight-v03-calibration) — RFC 08 PR 3.
+#
+# Pin the calibration loop contract (RFC §9):
+#   - PredictionRecord round-trips through as_wire_dict.
+#   - PredictionBuffer captures + retrieves pending predictions.
+#   - find_by_anchor returns only unmatched predictions.
+#   - mark_observed gates a prediction out of pending.
+#   - pair_against_reality computes numeric / string / missing deltas.
+#   - aggregate_pairs computes modal_accuracy, per_metric_accuracy,
+#     confidence_calibration.
+#   - apply_correction caps raw deltas to ±10% per cycle (RFC gate 6).
+#   - apply_correction rejects unknown layers + non-positive caps.
+#   - build_prediction_record validates confidence range.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from pocketpaw_ee.foresight.calibration import (
+    CORRECTION_CAP,
+    PredictionBuffer,
+    PredictionRecord,
+    aggregate_pairs,
+    apply_correction,
+    build_prediction_record,
+    pair_against_reality,
+)
+
+# --- PredictionRecord -----------------------------------------------
+
+
+def _sample_prediction(
+    *,
+    anchor: str = "lease:LR-2026-117",
+    projected: dict | None = None,
+    confidence: float = 0.78,
+    observe_offset_seconds: int = 0,
+) -> PredictionRecord:
+    return build_prediction_record(
+        scenario_template="decision_forecast.yaml",
+        run_id=uuid4(),
+        anchor_object_id=anchor,
+        projected_outcome=projected or {"outcome": "accept", "amount": 2850.0},
+        observe_at=datetime.now(UTC) + timedelta(seconds=observe_offset_seconds),
+        projection_confidence=confidence,
+    )
+
+
+def test_prediction_record_round_trips_through_wire_dict():
+    record = _sample_prediction()
+    wire = record.as_wire_dict()
+    assert wire["scenario_template"] == "decision_forecast.yaml"
+    assert wire["anchor_object_id"] == "lease:LR-2026-117"
+    assert wire["projected_outcome"] == {"outcome": "accept", "amount": 2850.0}
+    assert wire["projection_confidence"] == 0.78
+
+
+def test_build_prediction_record_rejects_out_of_band_confidence():
+    with pytest.raises(ValueError, match="must be in"):
+        build_prediction_record(
+            scenario_template="x.yaml",
+            run_id=uuid4(),
+            anchor_object_id="x",
+            projected_outcome={},
+            observe_at=datetime.now(UTC),
+            projection_confidence=1.5,  # out of [0.0, 1.0]
+        )
+
+
+# --- PredictionBuffer -----------------------------------------------
+
+
+async def test_buffer_capture_and_pending_round_trip():
+    buf = PredictionBuffer()
+    record = _sample_prediction(observe_offset_seconds=-1)  # already due
+    await buf.capture(record)
+    pending = await buf.pending()
+    assert len(pending) == 1
+    assert pending[0].id == record.id
+
+
+async def test_buffer_pending_filters_by_observe_at():
+    buf = PredictionBuffer()
+    past = _sample_prediction(observe_offset_seconds=-3600)
+    future = _sample_prediction(observe_offset_seconds=3600)
+    await buf.capture(past)
+    await buf.capture(future)
+    pending = await buf.pending()
+    # Only the past prediction is due.
+    assert {p.id for p in pending} == {past.id}
+
+
+async def test_buffer_find_by_anchor_filters_unmatched():
+    buf = PredictionBuffer()
+    a = _sample_prediction(anchor="lease:A")
+    b = _sample_prediction(anchor="lease:B")
+    c = _sample_prediction(anchor="lease:A")
+    await buf.capture(a)
+    await buf.capture(b)
+    await buf.capture(c)
+    hits = await buf.find_by_anchor("lease:A")
+    assert {h.id for h in hits} == {a.id, c.id}
+
+
+async def test_buffer_mark_observed_removes_from_pending():
+    buf = PredictionBuffer()
+    record = _sample_prediction(observe_offset_seconds=-1)
+    await buf.capture(record)
+    await buf.mark_observed(record.id, {"outcome": "accept", "amount": 2880.0})
+    pending = await buf.pending()
+    assert pending == []
+    assert buf.observed_count == 1
+
+
+async def test_buffer_mark_observed_raises_on_unknown_id():
+    buf = PredictionBuffer()
+    with pytest.raises(KeyError):
+        await buf.mark_observed(uuid4(), {})
+
+
+# --- pair_against_reality -------------------------------------------
+
+
+def test_pair_computes_numeric_delta():
+    prediction = _sample_prediction(projected={"amount": 2850.0, "rent": 1200.0})
+    pair = pair_against_reality(
+        prediction,
+        actual_outcome={"amount": 2880.0, "rent": 1180.0},
+    )
+    assert pair.delta["amount"] == pytest.approx(30.0)
+    assert pair.delta["rent"] == pytest.approx(-20.0)
+
+
+def test_pair_computes_string_match():
+    prediction = _sample_prediction(projected={"outcome": "accept"})
+    pair = pair_against_reality(prediction, actual_outcome={"outcome": "accept"})
+    assert pair.delta["outcome"]["match"] is True
+
+
+def test_pair_computes_string_mismatch():
+    prediction = _sample_prediction(projected={"outcome": "accept"})
+    pair = pair_against_reality(prediction, actual_outcome={"outcome": "reject"})
+    assert pair.delta["outcome"]["match"] is False
+    assert pair.delta["outcome"]["projected"] == "accept"
+    assert pair.delta["outcome"]["actual"] == "reject"
+
+
+def test_pair_marks_missing_keys_in_either_side():
+    prediction = _sample_prediction(projected={"a": 1, "b": 2})
+    pair = pair_against_reality(prediction, actual_outcome={"b": 2, "c": 3})
+    assert pair.delta["a"] == {"missing_in": "actual"}
+    assert pair.delta["c"] == {"missing_in": "projected"}
+
+
+def test_pair_wire_dict_serializes_uuids_and_datetime():
+    prediction = _sample_prediction()
+    pair = pair_against_reality(prediction, actual_outcome={"outcome": "accept"})
+    wire = pair.as_wire_dict()
+    assert isinstance(wire["prediction_id"], str)
+    assert "paired_at" in wire and isinstance(wire["paired_at"], str)
+
+
+# --- aggregate_pairs ------------------------------------------------
+
+
+def test_aggregate_empty_returns_zero_stats():
+    summary = aggregate_pairs([])
+    assert summary.n_pairs == 0
+    assert summary.modal_accuracy == 0.0
+
+
+def test_aggregate_modal_accuracy_with_matches():
+    """3 pairs, all matching → modal_accuracy 1.0."""
+    pairs = []
+    for _ in range(3):
+        record = _sample_prediction(projected={"outcome": "accept"})
+        pairs.append(pair_against_reality(record, actual_outcome={"outcome": "accept"}))
+    summary = aggregate_pairs(pairs)
+    assert summary.modal_accuracy == pytest.approx(1.0)
+    assert summary.n_pairs == 3
+
+
+def test_aggregate_modal_accuracy_with_mismatches():
+    """2 matching + 1 mismatch → modal_accuracy 2/3."""
+    pairs = []
+    for outcome_actual in ["accept", "accept", "reject"]:
+        record = _sample_prediction(projected={"outcome": "accept"})
+        pairs.append(pair_against_reality(record, actual_outcome={"outcome": outcome_actual}))
+    summary = aggregate_pairs(pairs)
+    assert summary.modal_accuracy == pytest.approx(2 / 3)
+
+
+def test_aggregate_per_metric_breakdown():
+    """Outcome matches 2/3, amount matches 1/3 → per-metric split."""
+    pairs = []
+    rows = [
+        ("accept", 2850.0),  # matches
+        ("accept", 3200.0),  # outcome match, amount mismatch
+        ("reject", 2900.0),  # outcome mismatch, amount mismatch
+    ]
+    for outcome, amount in rows:
+        record = _sample_prediction(projected={"outcome": "accept", "amount": 2850.0})
+        pairs.append(
+            pair_against_reality(record, actual_outcome={"outcome": outcome, "amount": amount})
+        )
+    summary = aggregate_pairs(pairs, numeric_tolerance=0.05)  # tighter band
+    assert summary.per_metric_accuracy["outcome"] == pytest.approx(2 / 3)
+    # amount deltas: [0 (match), 350 (mismatch), 50 (mismatch)].
+    # Tolerance is absolute (|delta| <= numeric_tolerance), so both 350
+    # and 50 exceed 0.05. Only amount[0] matches → 1/3.
+    assert summary.per_metric_accuracy["amount"] == pytest.approx(1 / 3)
+
+
+def test_aggregate_confidence_calibration_with_perfect_calibration():
+    """All predictions at confidence=0.7 and 70% land → calibration ~1.0."""
+    pairs = []
+    predictions_by_id = {}
+    for i in range(10):
+        record = _sample_prediction(projected={"outcome": "accept"}, confidence=0.7)
+        predictions_by_id[record.id] = record
+        # 7 of 10 match
+        actual = "accept" if i < 7 else "reject"
+        pairs.append(pair_against_reality(record, actual_outcome={"outcome": actual}))
+    summary = aggregate_pairs(pairs, predictions_by_id=predictions_by_id)
+    # modal_accuracy = 7/10 = 0.7; mean_conf = 0.7 → diff 0 → calibration 1.0
+    assert summary.confidence_calibration == pytest.approx(1.0)
+
+
+# --- apply_correction (the ±10% cap, RFC gate 6) --------------------
+
+
+def test_correction_caps_positive_delta_at_default():
+    correction = apply_correction(
+        layer="persona_prior",
+        target="conscientious_approver.openness",
+        raw_delta=0.50,  # way over 0.10
+        rationale="forecast over-rejected",
+    )
+    assert correction.capped_delta == pytest.approx(CORRECTION_CAP)
+    assert correction.capped_delta == 0.10
+    assert correction.raw_delta == 0.50  # raw preserved
+
+
+def test_correction_caps_negative_delta_at_default():
+    correction = apply_correction(
+        layer="action_propensity",
+        target="accept_under_compset",
+        raw_delta=-0.30,
+        rationale="over-accepted",
+    )
+    assert correction.capped_delta == pytest.approx(-CORRECTION_CAP)
+
+
+def test_correction_passes_through_small_delta():
+    correction = apply_correction(
+        layer="aggregator_weight",
+        target="throughput_vs_queue",
+        raw_delta=0.03,
+        rationale="minor nudge",
+    )
+    assert correction.capped_delta == pytest.approx(0.03)
+
+
+def test_correction_default_is_auto():
+    correction = apply_correction(
+        layer="persona_prior",
+        target="x",
+        raw_delta=0.01,
+        rationale="",
+    )
+    assert correction.auto is True
+
+
+def test_correction_can_be_marked_for_captain_review():
+    """DESIGN TENSION 1 — flag for captain review when needed."""
+    correction = apply_correction(
+        layer="persona_prior",
+        target="x",
+        raw_delta=0.20,
+        rationale="material shift; needs human review",
+        auto=False,
+    )
+    assert correction.auto is False
+    assert correction.capped_delta == pytest.approx(CORRECTION_CAP)
+
+
+def test_correction_rejects_unknown_layer():
+    with pytest.raises(ValueError, match="unknown correction layer"):
+        apply_correction(
+            layer="not_a_real_layer",
+            target="x",
+            raw_delta=0.01,
+            rationale="",
+        )
+
+
+def test_correction_rejects_zero_or_negative_cap():
+    with pytest.raises(ValueError, match="cap must be > 0"):
+        apply_correction(
+            layer="persona_prior",
+            target="x",
+            raw_delta=0.01,
+            rationale="",
+            cap=0,
+        )
+
+
+def test_correction_honors_custom_cap():
+    correction = apply_correction(
+        layer="persona_prior",
+        target="x",
+        raw_delta=0.30,
+        rationale="",
+        cap=0.05,
+    )
+    assert correction.capped_delta == pytest.approx(0.05)
+
+
+def test_correction_wire_dict_serializes():
+    correction = apply_correction(
+        layer="persona_prior",
+        target="x",
+        raw_delta=0.30,
+        rationale="why",
+    )
+    wire = correction.as_wire_dict()
+    assert wire["layer"] == "persona_prior"
+    assert wire["target"] == "x"
+    assert wire["capped_delta"] == 0.10
+    assert wire["raw_delta"] == 0.30
+    assert wire["auto"] is True
+
+
+def test_correction_cap_constant_is_exposed():
+    """Tests should be able to introspect the locked cap."""
+    assert CORRECTION_CAP == 0.10

--- a/tests/ee/foresight/test_litellm_fallback.py
+++ b/tests/ee/foresight/test_litellm_fallback.py
@@ -1,0 +1,314 @@
+# tests/ee/foresight/test_litellm_fallback.py
+# Created: 2026-05-25 (feat/foresight-v03-calibration) — RFC 08 PR 3.
+#
+# Pin the LiteLLMFallbackBackend contract (RFC §6.4):
+#   - BACKEND_AVAILABLE is True at v0.3 (PR 3 wires the real proxy).
+#   - Constructor rejects zero / negative concurrency.
+#   - complete(prompt) proxies through litellm.acompletion.
+#   - run(messages, ...) builds an OpenAI-shaped messages list,
+#     forwards tools + response_format.
+#   - _response_to_camel normalizes provider response shapes to dict.
+#   - Semaphore caps concurrency.
+#
+# Tests use monkeypatched ``litellm.acompletion`` so they run without
+# network or API keys.
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+from pocketpaw_ee.foresight.llm.adapter import LiteLLMFallbackBackend
+
+# --- Fake response shapes --------------------------------------------
+
+
+@dataclass
+class _FakeMessage:
+    role: str
+    content: str
+    tool_calls: list | None = None
+
+
+@dataclass
+class _FakeChoice:
+    message: _FakeMessage
+    index: int = 0
+    finish_reason: str = "stop"
+
+
+@dataclass
+class _FakeUsage:
+    prompt_tokens: int = 10
+    completion_tokens: int = 5
+    total_tokens: int = 15
+
+
+@dataclass
+class _FakeLiteLLMResponse:
+    id: str = "test-response"
+    choices: list = None
+    usage: _FakeUsage = None
+
+    def __post_init__(self):
+        if self.choices is None:
+            self.choices = [_FakeChoice(_FakeMessage(role="assistant", content="ok"))]
+        if self.usage is None:
+            self.usage = _FakeUsage()
+
+
+# --- Surface-level tests ---------------------------------------------
+
+
+def test_backend_available_flag_is_true_at_pr3():
+    """PR 2 shipped False (stub); PR 3 flips to True."""
+    assert LiteLLMFallbackBackend.BACKEND_AVAILABLE is True
+
+
+def test_constructor_rejects_zero_concurrency():
+    with pytest.raises(ValueError, match="max_concurrent"):
+        LiteLLMFallbackBackend(max_concurrent=0)
+
+
+def test_constructor_rejects_negative_concurrency():
+    with pytest.raises(ValueError, match="max_concurrent"):
+        LiteLLMFallbackBackend(max_concurrent=-1)
+
+
+def test_constructor_accepts_optional_kwargs():
+    backend = LiteLLMFallbackBackend(
+        model="anthropic/claude-haiku-4-7",
+        base_url="https://api.example.com",
+        api_key="sk-test-123",
+        max_concurrent=64,
+        extra_kwargs={"temperature": 0.5},
+    )
+    assert backend._model == "anthropic/claude-haiku-4-7"
+    assert backend._base_url == "https://api.example.com"
+    assert backend._api_key == "sk-test-123"
+    assert backend._extra_kwargs == {"temperature": 0.5}
+
+
+# --- complete(prompt) ------------------------------------------------
+
+
+async def test_complete_calls_litellm_acompletion(monkeypatch):
+    """complete() should call litellm.acompletion with the right shape."""
+    captured: dict = {}
+
+    async def _fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return _FakeLiteLLMResponse(
+            choices=[_FakeChoice(_FakeMessage(role="assistant", content="hello"))]
+        )
+
+    monkeypatch.setattr("litellm.acompletion", _fake_acompletion)
+
+    backend = LiteLLMFallbackBackend(model="anthropic/claude-haiku-4-7")
+    result = await backend.complete("test prompt")
+
+    assert result == "hello"
+    assert captured["model"] == "anthropic/claude-haiku-4-7"
+    assert captured["messages"] == [{"role": "user", "content": "test prompt"}]
+
+
+async def test_complete_falls_back_to_default_tail_model(monkeypatch):
+    """No model in constructor → DEFAULT_TAIL_MODEL."""
+    captured: dict = {}
+
+    async def _fake(**kwargs):
+        captured.update(kwargs)
+        return _FakeLiteLLMResponse()
+
+    monkeypatch.setattr("litellm.acompletion", _fake)
+
+    backend = LiteLLMFallbackBackend()
+    await backend.complete("x")
+    assert captured["model"] == LiteLLMFallbackBackend.DEFAULT_TAIL_MODEL
+
+
+async def test_complete_forwards_base_url_and_api_key(monkeypatch):
+    captured: dict = {}
+
+    async def _fake(**kwargs):
+        captured.update(kwargs)
+        return _FakeLiteLLMResponse()
+
+    monkeypatch.setattr("litellm.acompletion", _fake)
+
+    backend = LiteLLMFallbackBackend(
+        model="custom-model",
+        base_url="http://localhost:8000",
+        api_key="key-xyz",
+    )
+    await backend.complete("x")
+    assert captured["base_url"] == "http://localhost:8000"
+    assert captured["api_key"] == "key-xyz"
+
+
+async def test_complete_forwards_extra_kwargs(monkeypatch):
+    captured: dict = {}
+
+    async def _fake(**kwargs):
+        captured.update(kwargs)
+        return _FakeLiteLLMResponse()
+
+    monkeypatch.setattr("litellm.acompletion", _fake)
+
+    backend = LiteLLMFallbackBackend(
+        model="custom-model",
+        extra_kwargs={"temperature": 0.0, "max_tokens": 100},
+    )
+    await backend.complete("x")
+    assert captured["temperature"] == 0.0
+    assert captured["max_tokens"] == 100
+
+
+async def test_complete_handles_dict_shaped_response(monkeypatch):
+    """LiteLLM sometimes returns plain dicts (older versions)."""
+
+    async def _fake(**kwargs):  # noqa: ARG001
+        return {
+            "choices": [{"message": {"role": "assistant", "content": "from dict"}}],
+            "usage": {},
+        }
+
+    monkeypatch.setattr("litellm.acompletion", _fake)
+
+    backend = LiteLLMFallbackBackend(model="x")
+    result = await backend.complete("y")
+    assert result == "from dict"
+
+
+# --- run(messages, ...) ---------------------------------------------
+
+
+@dataclass
+class _FakeMsg:
+    content: str
+    role_name: str = "User"
+
+
+async def test_run_builds_openai_messages_from_camel_shape(monkeypatch):
+    captured: dict = {}
+
+    async def _fake(**kwargs):
+        captured.update(kwargs)
+        return _FakeLiteLLMResponse(
+            choices=[_FakeChoice(_FakeMessage(role="assistant", content="ok"))]
+        )
+
+    monkeypatch.setattr("litellm.acompletion", _fake)
+
+    backend = LiteLLMFallbackBackend(model="anthropic/claude-haiku-4-7")
+    msgs = [
+        _FakeMsg(content="be helpful", role_name="System"),
+        _FakeMsg(content="hi", role_name="User"),
+        _FakeMsg(content="hello there", role_name="Assistant"),
+        _FakeMsg(content="what is 2+2?", role_name="User"),
+    ]
+    result = await backend.run(msgs)
+
+    assert isinstance(result, dict)
+    assert "choices" in result
+
+    sent_msgs = captured["messages"]
+    assert sent_msgs[0] == {"role": "system", "content": "be helpful"}
+    assert sent_msgs[1] == {"role": "user", "content": "hi"}
+    assert sent_msgs[2] == {"role": "assistant", "content": "hello there"}
+    assert sent_msgs[3] == {"role": "user", "content": "what is 2+2?"}
+
+
+async def test_run_forwards_response_format(monkeypatch):
+    captured: dict = {}
+
+    async def _fake(**kwargs):
+        captured.update(kwargs)
+        return _FakeLiteLLMResponse()
+
+    monkeypatch.setattr("litellm.acompletion", _fake)
+
+    backend = LiteLLMFallbackBackend(model="x")
+    await backend.run([_FakeMsg(content="hi")], response_format={"type": "json_object"})
+    assert captured["response_format"] == {"type": "json_object"}
+
+
+async def test_run_forwards_openai_tools_unchanged(monkeypatch):
+    captured: dict = {}
+
+    async def _fake(**kwargs):
+        captured.update(kwargs)
+        return _FakeLiteLLMResponse()
+
+    monkeypatch.setattr("litellm.acompletion", _fake)
+
+    tool_schema = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+    backend = LiteLLMFallbackBackend(model="x")
+    await backend.run([_FakeMsg(content="hi")], tools=[tool_schema])
+    assert captured["tools"] == [tool_schema]
+
+
+async def test_run_unwraps_camel_function_tool(monkeypatch):
+    """CAMEL FunctionTool with openai_tool_schema attr should unwrap."""
+    captured: dict = {}
+
+    async def _fake(**kwargs):
+        captured.update(kwargs)
+        return _FakeLiteLLMResponse()
+
+    monkeypatch.setattr("litellm.acompletion", _fake)
+
+    class _FakeFunctionTool:
+        openai_tool_schema = {
+            "type": "function",
+            "function": {"name": "my_tool", "description": "", "parameters": {}},
+        }
+
+    backend = LiteLLMFallbackBackend(model="x")
+    await backend.run([_FakeMsg(content="hi")], tools=[_FakeFunctionTool()])
+    assert captured["tools"][0]["function"]["name"] == "my_tool"
+
+
+async def test_run_returns_camel_chat_completion_shape(monkeypatch):
+    async def _fake(**kwargs):  # noqa: ARG001
+        return _FakeLiteLLMResponse(
+            choices=[_FakeChoice(_FakeMessage(role="assistant", content="answer"))]
+        )
+
+    monkeypatch.setattr("litellm.acompletion", _fake)
+
+    backend = LiteLLMFallbackBackend(model="x")
+    result = await backend.run([_FakeMsg(content="q")])
+    assert isinstance(result, dict)
+    assert result["choices"][0]["message"]["content"] == "answer"
+
+
+# --- Semaphore ------------------------------------------------------
+
+
+async def test_semaphore_caps_concurrent_calls(monkeypatch):
+    """6 calls @ max_concurrent=2 → at least 3 batches of 0.05s wall-clock."""
+    import time
+
+    async def _slow(**kwargs):  # noqa: ARG001
+        await asyncio.sleep(0.05)
+        return _FakeLiteLLMResponse()
+
+    monkeypatch.setattr("litellm.acompletion", _slow)
+
+    backend = LiteLLMFallbackBackend(model="x", max_concurrent=2)
+    start = time.perf_counter()
+    await asyncio.gather(*(backend.complete("p") for _ in range(6)))
+    elapsed = time.perf_counter() - start
+
+    assert elapsed >= 0.13, f"semaphore not serializing: {elapsed:.3f}s"
+    assert elapsed < 0.30, f"semaphore over-serializing: {elapsed:.3f}s"

--- a/tests/ee/foresight/test_paw_social_agent.py
+++ b/tests/ee/foresight/test_paw_social_agent.py
@@ -1,0 +1,120 @@
+# tests/ee/foresight/test_paw_social_agent.py
+# Created: 2026-05-25 (feat/foresight-v03-calibration) — RFC 08 PR 3.
+#
+# Pin the PawSocialAgent contract (RFC §7.2):
+#   - make_paw_social_agent constructs an oasis.SocialAgent subclass
+#     when OASIS_AVAILABLE.
+#   - The subclass's ``perform_action_by_llm`` delegates to the
+#     wrapped persona's decide().
+#   - The subclass's ``decide`` mirrors ``perform_action_by_llm``.
+#   - The OASIS UserInfo carries the persona's identity block +
+#     OCEAN drift + has_fidelity.
+#   - Each call to the factory gets a unique integer agent id.
+#   - The factory raises RuntimeError when OASIS is not loaded
+#     (clear pointer to OASIS_AVAILABLE).
+#
+# Tests skip themselves when OASIS_AVAILABLE is False so they can
+# run in environments without the full substrate (CI matrix that
+# doesn't install ee[foresight]).
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.foresight.llm.adapter import DeterministicFakeBackend
+from pocketpaw_ee.foresight.persona import (
+    OceanDrift,
+    SoulSeededPersona,
+    make_paw_social_agent,
+    reset_paw_social_agent_counter,
+)
+from pocketpaw_ee.foresight.substrate import oasis
+
+# Skip the entire module when OASIS isn't loaded.
+pytestmark = pytest.mark.skipif(
+    not oasis.OASIS_AVAILABLE,
+    reason=f"OASIS substrate not loaded; OASIS_LOAD_ERROR={oasis.OASIS_LOAD_ERROR!r}",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_counter():
+    """Reset the integer agent-id counter between tests."""
+    reset_paw_social_agent_counter()
+
+
+# --- Construction ---------------------------------------------------
+
+
+def test_make_paw_social_agent_returns_oasis_subclass():
+    persona = SoulSeededPersona(name="alice", backend=DeterministicFakeBackend())
+    agent = make_paw_social_agent(persona=persona)
+    assert isinstance(agent, oasis.SocialAgent)
+
+
+def test_make_paw_social_agent_assigns_unique_ids():
+    p1 = SoulSeededPersona(name="a", backend=DeterministicFakeBackend())
+    p2 = SoulSeededPersona(name="b", backend=DeterministicFakeBackend())
+    a1 = make_paw_social_agent(persona=p1)
+    a2 = make_paw_social_agent(persona=p2)
+    assert a1.social_agent_id != a2.social_agent_id
+
+
+def test_make_paw_social_agent_user_info_carries_persona_identity():
+    persona = SoulSeededPersona(
+        name="alice",
+        backend=DeterministicFakeBackend(),
+        role="approver",
+        ocean_drift=OceanDrift(conscientiousness=1.5),
+    )
+    agent = make_paw_social_agent(persona=persona)
+
+    # Inspect the OASIS-side user_info to confirm the persona's
+    # identity + OCEAN drift made it through.
+    ui = agent.user_info
+    assert ui.name == "alice"
+    # The description is the persona's identity block — should contain
+    # the role and the OCEAN drift narration.
+    assert "approver" in ui.description
+    assert "conscientious" in ui.description
+    profile = ui.profile or {}
+    assert profile["role"] == "approver"
+    assert profile["ocean_drift"]["conscientiousness"] == 1.5
+    assert profile["has_fidelity"] is False  # no paw_agent attached
+
+
+# --- Delegation -----------------------------------------------------
+
+
+async def test_decide_delegates_to_wrapped_persona():
+    backend = DeterministicFakeBackend(
+        responses=["action=approve; rationale=looks good; put=status:approved"]
+    )
+    persona = SoulSeededPersona(name="alice", backend=backend, role="approver")
+    agent = make_paw_social_agent(persona=persona)
+
+    result = await agent.decide({"tick": 0, "state": {}, "active_count": 1})
+    assert result["action"] == "approve"
+    assert result["put"] == {"status": "approved"}
+
+
+async def test_perform_action_by_llm_delegates_to_wrapped_persona():
+    backend = DeterministicFakeBackend(responses=["action=ack; rationale=done; put=k:v"])
+    persona = SoulSeededPersona(name="alice", backend=backend)
+    agent = make_paw_social_agent(persona=persona)
+
+    result = await agent.perform_action_by_llm()
+    assert result["action"] == "ack"
+    assert result["put"] == {"k": "v"}
+
+
+# --- Failure mode ----------------------------------------------------
+
+
+def test_make_paw_social_agent_raises_when_oasis_unavailable(monkeypatch):
+    """When OASIS_AVAILABLE is patched False, the factory raises
+    RuntimeError pointing the caller at the SoulSeededPersona path.
+    """
+    monkeypatch.setattr("pocketpaw_ee.foresight.substrate.oasis.OASIS_AVAILABLE", False)
+    persona = SoulSeededPersona(name="x", backend=DeterministicFakeBackend())
+    with pytest.raises(RuntimeError, match="OASIS_AVAILABLE=False"):
+        make_paw_social_agent(persona=persona)

--- a/tests/ee/foresight/test_substrate.py
+++ b/tests/ee/foresight/test_substrate.py
@@ -1,7 +1,15 @@
 # tests/ee/foresight/test_substrate.py
+# Updated: 2026-05-25 (feat/foresight-v03-calibration) — PR 3:
+#   - Added OASIS_RECSYS_AVAILABLE assertions to mirror the tiered
+#     import model introduced in this PR. The CORE tier
+#     (SocialAgent / AgentGraph / Channel / UserInfo / ActionType)
+#     loads with just camel-ai + igraph; the RECSYS tier (Platform /
+#     make / generate_*_agent_graph / LLMAction / ManualAction)
+#     needs torch + sentence-transformers and is deferred to v2.0
+#     Market Sim work.
 # Created: 2026-05-25 (feat/foresight-v02-oasis-camel-paw) — PR 2.
 #
-# Pin the v0.2 OASIS substrate vendoring contract:
+# Pin the v0.2/v0.3 OASIS substrate vendoring contract:
 #   - The vendored package at ee/pocketpaw_ee/foresight/substrate/oasis/
 #     is importable as a namespace package (no camel-ai dep needed).
 #   - When camel-ai is missing, OASIS_AVAILABLE=False and the package
@@ -10,11 +18,6 @@
 #   - The LICENSE / NOTICE / README-FORK.md files survive vendoring.
 #   - The upstream init lives at _upstream_init.py with rewritten
 #     absolute imports (oasis.X -> pocketpaw_ee.foresight.substrate.oasis.X).
-#
-# This file does NOT try to instantiate any OASIS class — PR 3 wires
-# the substrate into the engine and adds the integration tests that
-# exercise OasisEnv.step / SocialAgent / AgentGraph. PR 2's smoke
-# contract is just "the package is importable and well-formed."
 
 from __future__ import annotations
 
@@ -47,6 +50,32 @@ def test_substrate_records_load_error_when_unavailable():
     if not oasis.OASIS_AVAILABLE:
         assert oasis.OASIS_LOAD_ERROR is not None
         assert isinstance(oasis.OASIS_LOAD_ERROR, Exception)
+
+
+def test_substrate_exposes_recsys_tier_availability_flag():
+    """PR 3 — tiered import model. ``OASIS_RECSYS_AVAILABLE`` is True
+    only when torch + sentence-transformers + cairocffi are around;
+    PR 3's smoke install does NOT include them, so the flag is False
+    by default. The CORE tier loads regardless.
+    """
+    assert hasattr(oasis, "OASIS_RECSYS_AVAILABLE")
+    assert isinstance(oasis.OASIS_RECSYS_AVAILABLE, bool)
+    if not oasis.OASIS_RECSYS_AVAILABLE:
+        assert oasis.OASIS_RECSYS_LOAD_ERROR is not None
+        assert isinstance(oasis.OASIS_RECSYS_LOAD_ERROR, Exception)
+
+
+def test_substrate_core_tier_loads_when_camel_installed():
+    """When OASIS_AVAILABLE is True (PR 3 — camel-ai is a hard dep),
+    the core symbols must all be bound. This is the contract
+    PR 3 wiring relies on for ``make_paw_social_agent``.
+    """
+    if oasis.OASIS_AVAILABLE:
+        assert oasis.SocialAgent is not None
+        assert oasis.AgentGraph is not None
+        assert oasis.Channel is not None
+        assert oasis.UserInfo is not None
+        assert oasis.ActionType is not None
 
 
 def test_substrate_directory_contains_license_and_notice():

--- a/tests/ee/foresight/test_tier_pool.py
+++ b/tests/ee/foresight/test_tier_pool.py
@@ -1,0 +1,275 @@
+# tests/ee/foresight/test_tier_pool.py
+# Created: 2026-05-25 (feat/foresight-v03-calibration) — RFC 08 PR 3.
+#
+# Pin the tier-pool contract (RFC §7.3 + §10):
+#   - TierMix rejects out-of-band fractions.
+#   - TierMix rejects triples that don't sum to 1.0.
+#   - locked_default() == (0.05, 0.15, 0.80).
+#   - is_default() detects the locked mix.
+#   - build_tier_pool produces a list of length n_personas.
+#   - The mix composition matches the requested fractions (within
+#     rounding).
+#   - The shuffle is deterministic when seeded.
+#   - tier_distribution counts a pool correctly.
+#   - Factory failures surface with the tier name in the error.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from pocketpaw_ee.foresight.llm.tier_pool import (
+    TierMix,
+    build_tier_pool,
+    tier_distribution,
+)
+
+# --- TierMix ---------------------------------------------------------
+
+
+def test_tier_mix_default_is_5_15_80():
+    mix = TierMix()
+    assert mix.premium == 0.05
+    assert mix.mid == 0.15
+    assert mix.tail == 0.80
+
+
+def test_tier_mix_locked_default_matches_constructor():
+    assert TierMix.locked_default() == TierMix()
+
+
+def test_tier_mix_is_default_recognizes_locked():
+    assert TierMix.locked_default().is_default()
+
+
+def test_tier_mix_is_default_recognizes_override():
+    assert not TierMix(premium=0.10, mid=0.20, tail=0.70).is_default()
+
+
+def test_tier_mix_rejects_negative_fraction():
+    with pytest.raises(ValueError, match="must be in"):
+        TierMix(premium=-0.1, mid=0.3, tail=0.8)
+
+
+def test_tier_mix_rejects_fraction_over_one():
+    with pytest.raises(ValueError, match="must be in"):
+        TierMix(premium=1.5, mid=0.0, tail=-0.5)
+
+
+def test_tier_mix_rejects_non_unit_sum():
+    with pytest.raises(ValueError, match="must sum to 1.0"):
+        TierMix(premium=0.1, mid=0.2, tail=0.5)
+
+
+def test_tier_mix_accepts_small_float_drift():
+    """0.1 + 0.2 = 0.30000000000000004 in floats — must not crash."""
+    mix = TierMix(premium=0.1, mid=0.2, tail=0.7)
+    assert abs((mix.premium + mix.mid + mix.tail) - 1.0) < 0.001
+
+
+def test_tier_mix_as_dict_round_trips():
+    mix = TierMix(premium=0.10, mid=0.20, tail=0.70)
+    assert mix.as_dict() == {"premium": 0.10, "mid": 0.20, "tail": 0.70}
+
+
+# --- build_tier_pool -------------------------------------------------
+
+
+@dataclass
+class _FakeBackend:
+    """Stand-in for a CAMEL BaseModelBackend — carries a tier tag so
+    tier_distribution's default markers can detect it.
+    """
+
+    _model: str
+
+
+def _premium_factory():
+    return _FakeBackend(_model="claude-sonnet-4-7")
+
+
+def _mid_factory():
+    return _FakeBackend(_model="claude-haiku-4-7")
+
+
+def _tail_factory():
+    return _FakeBackend(_model="llama-3.1-8b-vllm")
+
+
+def test_build_tier_pool_returns_list_of_correct_length():
+    pool = build_tier_pool(
+        tier_mix=TierMix.locked_default(),
+        n_personas=100,
+        premium_factory=_premium_factory,
+        mid_factory=_mid_factory,
+        tail_factory=_tail_factory,
+        seed=42,
+    )
+    assert isinstance(pool, list)
+    assert len(pool) == 100
+
+
+def test_build_tier_pool_honors_default_5_15_80():
+    pool = build_tier_pool(
+        tier_mix=TierMix.locked_default(),
+        n_personas=100,
+        premium_factory=_premium_factory,
+        mid_factory=_mid_factory,
+        tail_factory=_tail_factory,
+        seed=42,
+    )
+    counts = tier_distribution(pool)
+    # 100 personas at 5/15/80: 5 premium / 15 mid / 80 tail
+    assert counts["premium"] == 5
+    assert counts["mid"] == 15
+    assert counts["tail"] == 80
+
+
+def test_build_tier_pool_honors_override_mix():
+    pool = build_tier_pool(
+        tier_mix=TierMix(premium=0.10, mid=0.20, tail=0.70),
+        n_personas=100,
+        premium_factory=_premium_factory,
+        mid_factory=_mid_factory,
+        tail_factory=_tail_factory,
+        seed=42,
+    )
+    counts = tier_distribution(pool)
+    assert counts["premium"] == 10
+    assert counts["mid"] == 20
+    assert counts["tail"] == 70
+
+
+def test_build_tier_pool_seeded_shuffle_is_deterministic():
+    """Same seed → same persona-id-to-tier assignment."""
+    pool_a = build_tier_pool(
+        tier_mix=TierMix.locked_default(),
+        n_personas=50,
+        premium_factory=_premium_factory,
+        mid_factory=_mid_factory,
+        tail_factory=_tail_factory,
+        seed=1234,
+    )
+    pool_b = build_tier_pool(
+        tier_mix=TierMix.locked_default(),
+        n_personas=50,
+        premium_factory=_premium_factory,
+        mid_factory=_mid_factory,
+        tail_factory=_tail_factory,
+        seed=1234,
+    )
+    assert [b._model for b in pool_a] == [b._model for b in pool_b]
+
+
+def test_build_tier_pool_shuffles_so_consecutive_ids_span_tiers():
+    """With the locked 5/15/80, the first 10 entries should NOT all be
+    tail (which they would be if no shuffle happened).
+    """
+    pool = build_tier_pool(
+        tier_mix=TierMix.locked_default(),
+        n_personas=100,
+        premium_factory=_premium_factory,
+        mid_factory=_mid_factory,
+        tail_factory=_tail_factory,
+        seed=42,
+    )
+    first_10 = [b._model for b in pool[:10]]
+    # At least one non-tail backend in the first 10.
+    assert any("sonnet" in m or "haiku" in m for m in first_10)
+
+
+def test_build_tier_pool_rejects_zero_personas():
+    with pytest.raises(ValueError, match="n_personas must be >= 1"):
+        build_tier_pool(
+            tier_mix=TierMix.locked_default(),
+            n_personas=0,
+            premium_factory=_premium_factory,
+            mid_factory=_mid_factory,
+            tail_factory=_tail_factory,
+        )
+
+
+def test_build_tier_pool_propagates_factory_errors_with_tier_name():
+    def _broken():
+        raise RuntimeError("oops")
+
+    with pytest.raises(RuntimeError, match="premium"):
+        build_tier_pool(
+            tier_mix=TierMix.locked_default(),
+            n_personas=20,
+            premium_factory=_broken,
+            mid_factory=_mid_factory,
+            tail_factory=_tail_factory,
+        )
+
+
+def test_build_tier_pool_rejects_none_returning_factory():
+    def _none_factory():
+        return None
+
+    with pytest.raises(ValueError, match="returned None"):
+        build_tier_pool(
+            tier_mix=TierMix.locked_default(),
+            n_personas=20,
+            premium_factory=_none_factory,
+            mid_factory=_mid_factory,
+            tail_factory=_tail_factory,
+        )
+
+
+def test_build_tier_pool_handles_small_population():
+    """5 personas at 5/15/80 should land 0 premium / 1 mid / 4 tail."""
+    pool = build_tier_pool(
+        tier_mix=TierMix.locked_default(),
+        n_personas=5,
+        premium_factory=_premium_factory,
+        mid_factory=_mid_factory,
+        tail_factory=_tail_factory,
+        seed=0,
+    )
+    assert len(pool) == 5
+    counts = tier_distribution(pool)
+    # Rounding: 0.25 → 0 premium; 0.75 → 1 mid; remainder → 4 tail.
+    assert counts["premium"] == 0
+    assert counts["mid"] == 1
+    assert counts["tail"] == 4
+
+
+# --- tier_distribution ----------------------------------------------
+
+
+def test_tier_distribution_default_markers_detect_model_name():
+    pool = [
+        _FakeBackend(_model="claude-sonnet-4-7"),
+        _FakeBackend(_model="claude-haiku-4-7"),
+        _FakeBackend(_model="llama-3.1-8b"),
+    ]
+    counts = tier_distribution(pool)
+    assert counts == {"premium": 1, "mid": 1, "tail": 1}
+
+
+def test_tier_distribution_unknown_backends_default_to_tail():
+    pool = [_FakeBackend(_model="gpt-4o")]
+    counts = tier_distribution(pool)
+    assert counts == {"premium": 0, "mid": 0, "tail": 1}
+
+
+def test_tier_distribution_handles_backends_without_model_attr():
+    """A backend without a ``_model`` attr lands in tail."""
+
+    class _NoModel:
+        pass
+
+    pool = [_NoModel()]
+    counts = tier_distribution(pool)
+    assert counts == {"premium": 0, "mid": 0, "tail": 1}
+
+
+def test_tier_distribution_honors_custom_markers():
+    pool = [{"flavor": "premium"}, {"flavor": "tail"}]
+
+    def _is_premium(b):
+        return isinstance(b, dict) and b.get("flavor") == "premium"
+
+    counts = tier_distribution(pool, premium_marker=_is_premium)
+    assert counts == {"premium": 1, "mid": 0, "tail": 1}

--- a/tests/ee/foresight/test_translator.py
+++ b/tests/ee/foresight/test_translator.py
@@ -1,0 +1,158 @@
+# tests/ee/foresight/test_translator.py
+# Created: 2026-05-25 (feat/foresight-v03-calibration) — RFC 08 PR 3.
+#
+# Pin the CAMEL FunctionTool → Claude Code SDK Permissions translator
+# (RFC §6.4 follow-up flagged in PR 2).
+#
+# Tests cover:
+#   - Empty / None tool lists return {} (no override).
+#   - CAMEL FunctionTool with func.__name__ ∈ SDK built-ins is allowed.
+#   - OpenAI-shaped dict with {"function": {"name": ...}} is allowed.
+#   - OpenAI-shaped dict with {"name": ...} is allowed (alternate shape).
+#   - Unknown tool names are dropped (not in SDK built-in set).
+#   - Mixed lists (knowns + unknowns) emit a clean allow-list.
+#   - Custom allowed_sdk_tools narrows the whitelist.
+#   - Tools without an extractable name are dropped.
+#   - Duplicates in the input list are deduplicated in the output.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pocketpaw_ee.foresight.llm.adapter import (
+    _SDK_BUILTIN_TOOLS,
+    translate_camel_tools_to_sdk_overrides,
+)
+
+# --- Fakes ----------------------------------------------------------
+
+
+@dataclass
+class _FakeFunctionTool:
+    """Quacks like ``camel.toolkits.FunctionTool`` — has ``.func`` with a
+    ``__name__`` attribute.
+    """
+
+    func: object
+
+    @staticmethod
+    def with_name(name: str) -> _FakeFunctionTool:
+        func = type("Fn", (), {"__name__": name})()
+        return _FakeFunctionTool(func=func)
+
+
+# --- Empty / None inputs --------------------------------------------
+
+
+def test_empty_list_returns_empty_dict():
+    assert translate_camel_tools_to_sdk_overrides([]) == {}
+
+
+def test_none_returns_empty_dict():
+    assert translate_camel_tools_to_sdk_overrides(None) == {}
+
+
+# --- CAMEL FunctionTool path ----------------------------------------
+
+
+def test_camel_function_tool_with_known_name_is_allowed():
+    tool = _FakeFunctionTool.with_name("Read")
+    result = translate_camel_tools_to_sdk_overrides([tool])
+    assert result == {"allow": ["Read"]}
+
+
+def test_camel_function_tool_with_unknown_name_is_dropped():
+    tool = _FakeFunctionTool.with_name("twitter_post")
+    result = translate_camel_tools_to_sdk_overrides([tool])
+    assert result == {}
+
+
+# --- OpenAI-shaped dict path ----------------------------------------
+
+
+def test_openai_function_dict_with_function_block():
+    tool = {"type": "function", "function": {"name": "Bash"}}
+    result = translate_camel_tools_to_sdk_overrides([tool])
+    assert result == {"allow": ["Bash"]}
+
+
+def test_openai_dict_with_top_level_name_key():
+    tool = {"name": "Write"}
+    result = translate_camel_tools_to_sdk_overrides([tool])
+    assert result == {"allow": ["Write"]}
+
+
+# --- Mixed lists ----------------------------------------------------
+
+
+def test_mixed_known_and_unknown_emits_known_only():
+    tools = [
+        _FakeFunctionTool.with_name("Read"),
+        _FakeFunctionTool.with_name("twitter_post"),  # unknown
+        {"function": {"name": "Glob"}},
+        {"function": {"name": "make_post"}},  # unknown
+    ]
+    result = translate_camel_tools_to_sdk_overrides(tools)
+    assert set(result["allow"]) == {"Read", "Glob"}
+
+
+def test_duplicates_in_input_are_deduplicated_in_output():
+    tools = [
+        _FakeFunctionTool.with_name("Read"),
+        _FakeFunctionTool.with_name("Read"),
+        _FakeFunctionTool.with_name("Read"),
+    ]
+    result = translate_camel_tools_to_sdk_overrides(tools)
+    assert result == {"allow": ["Read"]}
+
+
+# --- Custom whitelist -----------------------------------------------
+
+
+def test_custom_allowed_sdk_tools_narrows_whitelist():
+    """Caller can restrict the SDK-side allow-list further."""
+    tools = [
+        _FakeFunctionTool.with_name("Bash"),
+        _FakeFunctionTool.with_name("Read"),
+    ]
+    # Only allow Read (Bash is too dangerous for this scenario).
+    result = translate_camel_tools_to_sdk_overrides(tools, allowed_sdk_tools={"Read"})
+    assert result == {"allow": ["Read"]}
+
+
+def test_empty_whitelist_returns_empty_dict():
+    tools = [_FakeFunctionTool.with_name("Bash"), _FakeFunctionTool.with_name("Read")]
+    result = translate_camel_tools_to_sdk_overrides(tools, allowed_sdk_tools=set())
+    assert result == {}
+
+
+# --- Pathological inputs --------------------------------------------
+
+
+def test_tool_without_extractable_name_is_dropped():
+    """A tool that has neither .func.__name__ nor a name key is dropped."""
+
+    class _NoName:
+        pass
+
+    result = translate_camel_tools_to_sdk_overrides([_NoName()])
+    assert result == {}
+
+
+def test_dict_with_non_string_name_is_dropped():
+    tools = [{"function": {"name": 123}}, {"function": {"name": None}}]
+    assert translate_camel_tools_to_sdk_overrides(tools) == {}
+
+
+def test_empty_name_string_is_dropped():
+    tools = [_FakeFunctionTool.with_name("")]
+    assert translate_camel_tools_to_sdk_overrides(tools) == {}
+
+
+# --- Lock the SDK built-in set --------------------------------------
+
+
+def test_sdk_builtin_tools_includes_core_set():
+    """Sanity check — the constant has not silently been emptied."""
+    must_have = {"Bash", "Read", "Write", "Edit", "Glob", "Grep"}
+    assert must_have.issubset(_SDK_BUILTIN_TOOLS)

--- a/uv.lock
+++ b/uv.lock
@@ -281,6 +281,15 @@ wheels = [
 ]
 
 [[package]]
+name = "astor"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/21/75b771132fee241dfe601d39ade629548a9626d1d39f333fde31bc46febe/astor-0.8.1.tar.gz", hash = "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e", size = 35090, upload-time = "2019-12-10T01:50:35.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/88/97eef84f48fa04fbd6750e62dcceafba6c63c81b7ac1420856c8dcc0a3f9/astor-0.8.1-py2.py3-none-any.whl", hash = "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5", size = 27488, upload-time = "2019-12-10T01:50:33.628Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -705,6 +714,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6c/1d/ab15c8ac57f4ee8778d7633bc6685f808ab414437b8644f555389cdc875e/build-1.4.2.tar.gz", hash = "sha256:35b14e1ee329c186d3f08466003521ed7685ec15ecffc07e68d706090bf161d1", size = 83433, upload-time = "2026-03-25T14:20:27.659Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/57/3b7d4dd193ade4641c865bc2b93aeeb71162e81fc348b8dad020215601ed/build-1.4.2-py3-none-any.whl", hash = "sha256:7a4d8651ea877cb2a89458b1b198f2e69f536c95e89129dbf5d448045d60db88", size = 24643, upload-time = "2026-03-25T14:20:26.568Z" },
+]
+
+[[package]]
+name = "camel-ai"
+version = "0.2.91a4"
+source = { git = "https://github.com/qbtrix/camel-ai.git?rev=76ff78e8c78d0a38277e421ea9aca34904b4dc37#76ff78e8c78d0a38277e421ea9aca34904b4dc37" }
+dependencies = [
+    { name = "astor" },
+    { name = "colorama" },
+    { name = "docstring-parser" },
+    { name = "google-search-results" },
+    { name = "httpx" },
+    { name = "jsonschema" },
+    { name = "mcp" },
+    { name = "openai" },
+    { name = "pillow" },
+    { name = "psutil" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tiktoken" },
+    { name = "websockets" },
 ]
 
 [[package]]
@@ -1730,6 +1760,15 @@ wheels = [
 ]
 
 [[package]]
+name = "google-search-results"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/30/b3a6f6a2e00f8153549c2fa345c58ae1ce8e5f3153c2fe0484d444c3abcb/google_search_results-2.4.2.tar.gz", hash = "sha256:603a30ecae2af8e600b22635757a6df275dad4b934f975e67878ccd640b78245", size = 18818, upload-time = "2023-03-10T11:13:09.953Z" }
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1803,12 +1842,15 @@ wheels = [
 ]
 
 [[package]]
-name = "griffelib"
-version = "2.0.2"
+name = "griffe"
+version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
 ]
 
 [[package]]
@@ -2254,6 +2296,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "igraph"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "texttable" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/be/56bef1919005b4caf1f71522b300d359f7faeb7ae93a3b0baa9b4f146a87/igraph-1.0.0.tar.gz", hash = "sha256:2414d0be2e4d77ee5357807d100974b40f6082bb1bb71988ec46cfb6728651ee", size = 5077105, upload-time = "2025-10-23T12:22:50.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/03/3278ad0ceb3ea0e84d8ae3a85bdded4d0e57853aeb802a200feb43847b93/igraph-1.0.0-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:c2cbc415e02523e5a241eecee82319080bf928a70b1ba299f3b3e25bf029b6d4", size = 2257415, upload-time = "2025-10-23T12:22:27.246Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bc/6281ec7f9baaf71ee57c3b1748da2d3148d15d253e1a03006f204aa68ca5/igraph-1.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a27753cd80680a8f676c2d5a467aaa4a95e510b30748398ec4e4aeb982130e8", size = 2048555, upload-time = "2025-10-23T12:22:29.49Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/38/3cd6428a4ed4c09a56df05998438e7774fd1d799ee4fb8fc481674f5f7fc/igraph-1.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a55dc3a2a4e3fc3eba42479910c1511bfc3ecb33cdf5f0406891fd85f14b5aee", size = 5314141, upload-time = "2025-10-23T12:22:31.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/da/dd2867c25adbb41563720f14b5fc895c98bf88be682a3faff4f7b3118d2a/igraph-1.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2d04c2c76f686fb1f554ee35dfd3085f5e73b7965ba6b4cf06d53e66b1955522", size = 5683134, upload-time = "2025-10-23T12:22:32.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/40/243c118d34ab80382d7009c4dcb99b887384c3d2ce84d29eeac19e2a007a/igraph-1.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2b52dc1757fff0fed29a9f7a276d971a11db4211569ed78b9eab36288dfcc9d", size = 6211583, upload-time = "2025-10-23T12:22:34.238Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b7/88f433819c54b496cb0315fce28e658970cb20ff5dbd52a5a605ce2888de/igraph-1.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:05c79a2a8fca695b2f217a6fa7f2549f896f757d4db41be32a055400cb19cc30", size = 6594509, upload-time = "2025-10-23T12:22:35.831Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5d/8f7f6f619d374e959aa3664ebc4b24c10abc90c2e8efbed97f2623fadaf5/igraph-1.0.0-cp39-abi3-win32.whl", hash = "sha256:c2bce3cd472fec3dd9c4d8a3ea5b6b9be65fb30edf760beb4850760dd4f2d479", size = 2725406, upload-time = "2025-10-23T12:22:37.588Z" },
+    { url = "https://files.pythonhosted.org/packages/af/77/a85b3745cf40a0572bae2de8cd9c2a2a8af78e5cf3e880fc0a249114e609/igraph-1.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:faeff8ede0cf15eb4ded44b0fcea6e1886740146e60504c24ad2da14e0939563", size = 3221663, upload-time = "2025-10-23T12:22:39.404Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/7e/5df541c37bdf6493035e89c22bd53f30d99b291bcda6c78e9a8afeecec2b/igraph-1.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:b607cafc24b10a615e713ee96e58208ef27e0764af80140c7cc45d4724a3f2df", size = 2785701, upload-time = "2025-10-23T12:22:41.03Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/bf1d4dbbc9123435b3ca14bb608b243a50a4f158ecea564bf196715248d9/igraph-1.0.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3189c1a8e8a8f58009f3f729040eb3701254d074ed37245691d529869ec940c5", size = 2246636, upload-time = "2025-10-23T12:22:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ac/28482f2af45cc0a0ca88a69d17a6ea694f58bdbd22cc876e7273a0379282/igraph-1.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ebe9502689b946301584b3cfacdbc70c58c4d664d804e39b6daa31be5c20bf46", size = 2036101, upload-time = "2025-10-23T12:22:43.957Z" },
+    { url = "https://files.pythonhosted.org/packages/56/80/806a093df1d1ddc3b30d0418b1ee56388ae7018f8ae288677ee2b3a1abaf/igraph-1.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:f117683108c54330d6dc67a708e3724c13c9989885122a29781296872989a222", size = 3053403, upload-time = "2025-10-23T12:22:45.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/bf/cf7aeff230a4368c0b8bc6b02f3ea27db41db33714b51e1e8a7c1458f31b/igraph-1.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:077dbff0edb8b4ce0f9fefdf325200346d9d5db02de31872b41743de08e67a16", size = 3262472, upload-time = "2025-10-23T12:22:47.248Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ca/dbc06072d5eea402a6dc81f387afb1b7e0c415f1d8a75232943fc4d1bfdb/igraph-1.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fe7c693b2a84a4e03ca31e65aa05a2ecd8728137fa9909ccbf6453b4200b856d", size = 3218861, upload-time = "2025-10-23T12:22:48.46Z" },
 ]
 
 [[package]]
@@ -3865,10 +3932,10 @@ wheels = [
 
 [[package]]
 name = "openai-agents"
-version = "0.13.5"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "griffelib" },
+    { name = "griffe" },
     { name = "mcp" },
     { name = "openai" },
     { name = "pydantic" },
@@ -3876,9 +3943,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/27/e3e60cc77abf588fd95e27b15b1a6806fd7107bb9fc4b2f36acfaaeff64c/openai_agents-0.13.5.tar.gz", hash = "sha256:ebe5bfb3d7d702d133ff9fb335718d61b741300de25b409ab4a6c8212ee945c0", size = 2699666, upload-time = "2026-04-06T04:11:47.575Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/8e/71fd262046587a5b2b097aec6ce677f7bb23c81b3129da31942b7a0d0b26/openai_agents-0.4.2.tar.gz", hash = "sha256:281caff839b3ab2cf3bc52110abe93caca004985c41bf07de8e60d03c4a7528e", size = 1925615, upload-time = "2025-10-24T21:46:34.119Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/54/5f85e18235f5bf7947c84323e3214757c6a22531529914f44077eb5a1198/openai_agents-0.13.5-py3-none-any.whl", hash = "sha256:672c76830d25b7eb3d85580539ba7caca975288df4395fe80c84cb4edfe4665f", size = 470837, upload-time = "2026-04-06T04:11:45.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/2e/23dbd9099555a9c7081c2819d00b7e1ee6ddbbd2fba8032f0ca4ddff778f/openai_agents-0.4.2-py3-none-any.whl", hash = "sha256:89fda02002dc0ac90ae177bb2f381a78b73aae329753bffb9276cfbdbfd20dc3", size = 216402, upload-time = "2025-10-24T21:46:32.065Z" },
 ]
 
 [[package]]
@@ -4790,6 +4857,7 @@ source = { editable = "ee" }
 dependencies = [
     { name = "beanie" },
     { name = "boto3" },
+    { name = "camel-ai" },
     { name = "composio" },
     { name = "composio-claude-agent-sdk" },
     { name = "composio-google-adk" },
@@ -4800,6 +4868,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
     { name = "google-cloud-storage" },
+    { name = "igraph" },
     { name = "livekit-agents", extra = ["codecs"] },
     { name = "livekit-api" },
     { name = "livekit-plugins-deepgram" },
@@ -4815,7 +4884,7 @@ dependencies = [
 requires-dist = [
     { name = "beanie", specifier = ">=1.26.0" },
     { name = "boto3", specifier = ">=1.34.0" },
-    { name = "camel-ai", marker = "extra == 'foresight'", specifier = "==0.2.90" },
+    { name = "camel-ai", git = "https://github.com/qbtrix/camel-ai.git?rev=76ff78e8c78d0a38277e421ea9aca34904b4dc37" },
     { name = "composio", specifier = ">=0.7.0" },
     { name = "composio-claude-agent-sdk", specifier = ">=0.7.0" },
     { name = "composio-google-adk", specifier = ">=0.7.0" },
@@ -4826,6 +4895,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2.25.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.0" },
     { name = "google-cloud-storage", specifier = ">=2.14.0" },
+    { name = "igraph", specifier = ">=0.11" },
     { name = "livekit-agents", extras = ["codecs"], specifier = ">=1.5.9" },
     { name = "livekit-api", specifier = ">=0.6.0" },
     { name = "livekit-plugins-deepgram", specifier = ">=1.5.9" },
@@ -4840,7 +4910,7 @@ requires-dist = [
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "trafilatura", marker = "extra == 'extraction'" },
 ]
-provides-extras = ["extraction", "foresight"]
+provides-extras = ["extraction"]
 
 [[package]]
 name = "portalocker"
@@ -5286,7 +5356,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.12.5"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -5294,106 +5364,98 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/da/b8a7ee04378a53f6fefefc0c5e05570a3ebfdfa0523a878bcd3b475683ee/pydantic-2.12.0.tar.gz", hash = "sha256:c1a077e6270dbfb37bfd8b498b3981e2bb18f68103720e51fa6c306a5a9af563", size = 814760, upload-time = "2025-10-07T15:58:03.467Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/9d/d5c855424e2e5b6b626fbc6ec514d8e655a600377ce283008b115abb7445/pydantic-2.12.0-py3-none-any.whl", hash = "sha256:f6a1da352d42790537e95e83a8bdfb91c7efbae63ffd0b86fa823899e807116f", size = 459730, upload-time = "2025-10-07T15:58:01.576Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.41.5"
+version = "2.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/14/12b4a0d2b0b10d8e1d9a24ad94e7bbb43335eaf29c0c4e57860e8a30734a/pydantic_core-2.41.1.tar.gz", hash = "sha256:1ad375859a6d8c356b7704ec0f547a58e82ee80bb41baa811ad710e124bc8f2f", size = 454870, upload-time = "2025-10-07T10:50:45.974Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
-    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
-    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
-    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
-    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
-    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
-    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
-    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
-    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
-    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
-    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
-    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
-    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
-    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
-    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
-    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
-    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
-    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
-    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
-    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
-    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
-    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
-    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
-    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
-    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
-    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
-    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
-    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
-    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
-    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
-    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
-    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
-    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
-    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
-    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
-    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a9/ec440f02e57beabdfd804725ef1e38ac1ba00c49854d298447562e119513/pydantic_core-2.41.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4f276a6134fe1fc1daa692642a3eaa2b7b858599c49a7610816388f5e37566a1", size = 2111456, upload-time = "2025-10-06T21:10:09.824Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f9/6bc15bacfd8dcfc073a1820a564516d9c12a435a9a332d4cbbfd48828ddd/pydantic_core-2.41.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:07588570a805296ece009c59d9a679dc08fab72fb337365afb4f3a14cfbfc176", size = 1915012, upload-time = "2025-10-06T21:10:11.599Z" },
+    { url = "https://files.pythonhosted.org/packages/38/8a/d9edcdcdfe80bade17bed424284427c08bea892aaec11438fa52eaeaf79c/pydantic_core-2.41.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28527e4b53400cd60ffbd9812ccb2b5135d042129716d71afd7e45bf42b855c0", size = 1973762, upload-time = "2025-10-06T21:10:13.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b3/ff225c6d49fba4279de04677c1c876fc3dc6562fd0c53e9bfd66f58c51a8/pydantic_core-2.41.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:46a1c935c9228bad738c8a41de06478770927baedf581d172494ab36a6b96575", size = 2065386, upload-time = "2025-10-06T21:10:14.436Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ba/183e8c0be4321314af3fd1ae6bfc7eafdd7a49bdea5da81c56044a207316/pydantic_core-2.41.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:447ddf56e2b7d28d200d3e9eafa936fe40485744b5a824b67039937580b3cb20", size = 2252317, upload-time = "2025-10-06T21:10:15.719Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c5/aab61e94fd02f45c65f1f8c9ec38bb3b33fbf001a1837c74870e97462572/pydantic_core-2.41.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63892ead40c1160ac860b5debcc95c95c5a0035e543a8b5a4eac70dd22e995f4", size = 2373405, upload-time = "2025-10-06T21:10:17.017Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4f/3aaa3bd1ea420a15acc42d7d3ccb3b0bbc5444ae2f9dbc1959f8173e16b8/pydantic_core-2.41.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4a9543ca355e6df8fbe9c83e9faab707701e9103ae857ecb40f1c0cf8b0e94d", size = 2073794, upload-time = "2025-10-06T21:10:18.383Z" },
+    { url = "https://files.pythonhosted.org/packages/58/bd/e3975cdebe03ec080ef881648de316c73f2a6be95c14fc4efb2f7bdd0d41/pydantic_core-2.41.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f2611bdb694116c31e551ed82e20e39a90bea9b7ad9e54aaf2d045ad621aa7a1", size = 2194430, upload-time = "2025-10-06T21:10:19.638Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/6b7e7217f147d3b3105b57fb1caec3c4f667581affdfaab6d1d277e1f749/pydantic_core-2.41.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fecc130893a9b5f7bfe230be1bb8c61fe66a19db8ab704f808cb25a82aad0bc9", size = 2154611, upload-time = "2025-10-06T21:10:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/7b/239c2fe76bd8b7eef9ae2140d737368a3c6fea4fd27f8f6b4cde6baa3ce9/pydantic_core-2.41.1-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:1e2df5f8344c99b6ea5219f00fdc8950b8e6f2c422fbc1cc122ec8641fac85a1", size = 2329809, upload-time = "2025-10-06T21:10:22.678Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2e/77a821a67ff0786f2f14856d6bd1348992f695ee90136a145d7a445c1ff6/pydantic_core-2.41.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:35291331e9d8ed94c257bab6be1cb3a380b5eee570a2784bffc055e18040a2ea", size = 2327907, upload-time = "2025-10-06T21:10:24.447Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/9a/b54512bb9df7f64c586b369328c30481229b70ca6a5fcbb90b715e15facf/pydantic_core-2.41.1-cp311-cp311-win32.whl", hash = "sha256:2876a095292668d753f1a868c4a57c4ac9f6acbd8edda8debe4218d5848cf42f", size = 1989964, upload-time = "2025-10-06T21:10:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/72/63c9a4f1a5c950e65dd522d7dd67f167681f9d4f6ece3b80085a0329f08f/pydantic_core-2.41.1-cp311-cp311-win_amd64.whl", hash = "sha256:b92d6c628e9a338846a28dfe3fcdc1a3279388624597898b105e078cdfc59298", size = 2025158, upload-time = "2025-10-06T21:10:27.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/16/4e2706184209f61b50c231529257c12eb6bd9eb36e99ea1272e4815d2200/pydantic_core-2.41.1-cp311-cp311-win_arm64.whl", hash = "sha256:7d82ae99409eb69d507a89835488fb657faa03ff9968a9379567b0d2e2e56bc5", size = 1972297, upload-time = "2025-10-06T21:10:28.814Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/bc/5f520319ee1c9e25010412fac4154a72e0a40d0a19eb00281b1f200c0947/pydantic_core-2.41.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:db2f82c0ccbce8f021ad304ce35cbe02aa2f95f215cac388eed542b03b4d5eb4", size = 2099300, upload-time = "2025-10-06T21:10:30.463Z" },
+    { url = "https://files.pythonhosted.org/packages/31/14/010cd64c5c3814fb6064786837ec12604be0dd46df3327cf8474e38abbbd/pydantic_core-2.41.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47694a31c710ced9205d5f1e7e8af3ca57cbb8a503d98cb9e33e27c97a501601", size = 1910179, upload-time = "2025-10-06T21:10:31.782Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/2e/23fc2a8a93efad52df302fdade0a60f471ecc0c7aac889801ac24b4c07d6/pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e9decce94daf47baf9e9d392f5f2557e783085f7c5e522011545d9d6858e00", size = 1957225, upload-time = "2025-10-06T21:10:33.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b6/6db08b2725b2432b9390844852e11d320281e5cea8a859c52c68001975fa/pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ab0adafdf2b89c8b84f847780a119437a0931eca469f7b44d356f2b426dd9741", size = 2053315, upload-time = "2025-10-06T21:10:34.87Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d9/4de44600f2d4514b44f3f3aeeda2e14931214b6b5bf52479339e801ce748/pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5da98cc81873f39fd56882e1569c4677940fbc12bce6213fad1ead784192d7c8", size = 2224298, upload-time = "2025-10-06T21:10:36.233Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ae/dbe51187a7f35fc21b283c5250571a94e36373eb557c1cba9f29a9806dcf/pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:209910e88afb01fd0fd403947b809ba8dba0e08a095e1f703294fda0a8fdca51", size = 2351797, upload-time = "2025-10-06T21:10:37.601Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a7/975585147457c2e9fb951c7c8dab56deeb6aa313f3aa72c2fc0df3f74a49/pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365109d1165d78d98e33c5bfd815a9b5d7d070f578caefaabcc5771825b4ecb5", size = 2074921, upload-time = "2025-10-06T21:10:38.927Z" },
+    { url = "https://files.pythonhosted.org/packages/62/37/ea94d1d0c01dec1b7d236c7cec9103baab0021f42500975de3d42522104b/pydantic_core-2.41.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:706abf21e60a2857acdb09502bc853ee5bce732955e7b723b10311114f033115", size = 2187767, upload-time = "2025-10-06T21:10:40.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/fe/694cf9fdd3a777a618c3afd210dba7b414cb8a72b1bd29b199c2e5765fee/pydantic_core-2.41.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bf0bd5417acf7f6a7ec3b53f2109f587be176cb35f9cf016da87e6017437a72d", size = 2136062, upload-time = "2025-10-06T21:10:42.09Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/174aeabd89916fbd2988cc37b81a59e1186e952afd2a7ed92018c22f31ca/pydantic_core-2.41.1-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:2e71b1c6ceb9c78424ae9f63a07292fb769fb890a4e7efca5554c47f33a60ea5", size = 2317819, upload-time = "2025-10-06T21:10:43.974Z" },
+    { url = "https://files.pythonhosted.org/packages/65/e8/e9aecafaebf53fc456314f72886068725d6fba66f11b013532dc21259343/pydantic_core-2.41.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:80745b9770b4a38c25015b517451c817799bfb9d6499b0d13d8227ec941cb513", size = 2312267, upload-time = "2025-10-06T21:10:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/35/2f/1c2e71d2a052f9bb2f2df5a6a05464a0eb800f9e8d9dd800202fe31219e1/pydantic_core-2.41.1-cp312-cp312-win32.whl", hash = "sha256:83b64d70520e7890453f1aa21d66fda44e7b35f1cfea95adf7b4289a51e2b479", size = 1990927, upload-time = "2025-10-06T21:10:46.738Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/78/562998301ff2588b9c6dcc5cb21f52fa919d6e1decc75a35055feb973594/pydantic_core-2.41.1-cp312-cp312-win_amd64.whl", hash = "sha256:377defd66ee2003748ee93c52bcef2d14fde48fe28a0b156f88c3dbf9bc49a50", size = 2034703, upload-time = "2025-10-06T21:10:48.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/53/d95699ce5a5cdb44bb470bd818b848b9beadf51459fd4ea06667e8ede862/pydantic_core-2.41.1-cp312-cp312-win_arm64.whl", hash = "sha256:c95caff279d49c1d6cdfe2996e6c2ad712571d3b9caaa209a404426c326c4bde", size = 1972719, upload-time = "2025-10-06T21:10:50.256Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8a/6d54198536a90a37807d31a156642aae7a8e1263ed9fe6fc6245defe9332/pydantic_core-2.41.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:70e790fce5f05204ef4403159857bfcd587779da78627b0babb3654f75361ebf", size = 2105825, upload-time = "2025-10-06T21:10:51.719Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2e/4784fd7b22ac9c8439db25bf98ffed6853d01e7e560a346e8af821776ccc/pydantic_core-2.41.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9cebf1ca35f10930612d60bd0f78adfacee824c30a880e3534ba02c207cceceb", size = 1910126, upload-time = "2025-10-06T21:10:53.145Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/92/31eb0748059ba5bd0aa708fb4bab9fcb211461ddcf9e90702a6542f22d0d/pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:170406a37a5bc82c22c3274616bf6f17cc7df9c4a0a0a50449e559cb755db669", size = 1961472, upload-time = "2025-10-06T21:10:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/91/946527792275b5c4c7dde4cfa3e81241bf6900e9fee74fb1ba43e0c0f1ab/pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12d4257fc9187a0ccd41b8b327d6a4e57281ab75e11dda66a9148ef2e1fb712f", size = 2063230, upload-time = "2025-10-06T21:10:57.179Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5d/a35c5d7b414e5c0749f1d9f0d159ee2ef4bab313f499692896b918014ee3/pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a75a33b4db105dd1c8d57839e17ee12db8d5ad18209e792fa325dbb4baeb00f4", size = 2229469, upload-time = "2025-10-06T21:10:59.409Z" },
+    { url = "https://files.pythonhosted.org/packages/21/4d/8713737c689afa57ecfefe38db78259d4484c97aa494979e6a9d19662584/pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08a589f850803a74e0fcb16a72081cafb0d72a3cdda500106942b07e76b7bf62", size = 2347986, upload-time = "2025-10-06T21:11:00.847Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ec/929f9a3a5ed5cda767081494bacd32f783e707a690ce6eeb5e0730ec4986/pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a97939d6ea44763c456bd8a617ceada2c9b96bb5b8ab3dfa0d0827df7619014", size = 2072216, upload-time = "2025-10-06T21:11:02.43Z" },
+    { url = "https://files.pythonhosted.org/packages/26/55/a33f459d4f9cc8786d9db42795dbecc84fa724b290d7d71ddc3d7155d46a/pydantic_core-2.41.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d2ae423c65c556f09569524b80ffd11babff61f33055ef9773d7c9fabc11ed8d", size = 2193047, upload-time = "2025-10-06T21:11:03.787Z" },
+    { url = "https://files.pythonhosted.org/packages/77/af/d5c6959f8b089f2185760a2779079e3c2c411bfc70ea6111f58367851629/pydantic_core-2.41.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:4dc703015fbf8764d6a8001c327a87f1823b7328d40b47ce6000c65918ad2b4f", size = 2140613, upload-time = "2025-10-06T21:11:05.607Z" },
+    { url = "https://files.pythonhosted.org/packages/58/e5/2c19bd2a14bffe7fabcf00efbfbd3ac430aaec5271b504a938ff019ac7be/pydantic_core-2.41.1-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:968e4ffdfd35698a5fe659e5e44c508b53664870a8e61c8f9d24d3d145d30257", size = 2327641, upload-time = "2025-10-06T21:11:07.143Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ef/e0870ccda798c54e6b100aff3c4d49df5458fd64217e860cb9c3b0a403f4/pydantic_core-2.41.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:fff2b76c8e172d34771cd4d4f0ade08072385310f214f823b5a6ad4006890d32", size = 2318229, upload-time = "2025-10-06T21:11:08.73Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/4b/c3b991d95f5deb24d0bd52e47bcf716098fa1afe0ce2d4bd3125b38566ba/pydantic_core-2.41.1-cp313-cp313-win32.whl", hash = "sha256:a38a5263185407ceb599f2f035faf4589d57e73c7146d64f10577f6449e8171d", size = 1997911, upload-time = "2025-10-06T21:11:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/5c316fd62e01f8d6be1b7ee6b54273214e871772997dc2c95e204997a055/pydantic_core-2.41.1-cp313-cp313-win_amd64.whl", hash = "sha256:b42ae7fd6760782c975897e1fdc810f483b021b32245b0105d40f6e7a3803e4b", size = 2034301, upload-time = "2025-10-06T21:11:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/29/41/902640cfd6a6523194123e2c3373c60f19006447f2fb06f76de4e8466c5b/pydantic_core-2.41.1-cp313-cp313-win_arm64.whl", hash = "sha256:ad4111acc63b7384e205c27a2f15e23ac0ee21a9d77ad6f2e9cb516ec90965fb", size = 1977238, upload-time = "2025-10-06T21:11:14.1Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/28b040e88c1b89d851278478842f0bdf39c7a05da9e850333c6c8cbe7dfa/pydantic_core-2.41.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:440d0df7415b50084a4ba9d870480c16c5f67c0d1d4d5119e3f70925533a0edc", size = 1875626, upload-time = "2025-10-06T21:11:15.69Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/58/b41dd3087505220bb58bc81be8c3e8cbc037f5710cd3c838f44f90bdd704/pydantic_core-2.41.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:71eaa38d342099405dae6484216dcf1e8e4b0bebd9b44a4e08c9b43db6a2ab67", size = 2045708, upload-time = "2025-10-06T21:11:17.258Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b8/760f23754e40bf6c65b94a69b22c394c24058a0ef7e2aa471d2e39219c1a/pydantic_core-2.41.1-cp313-cp313t-win_amd64.whl", hash = "sha256:555ecf7e50f1161d3f693bc49f23c82cf6cdeafc71fa37a06120772a09a38795", size = 1997171, upload-time = "2025-10-06T21:11:18.822Z" },
+    { url = "https://files.pythonhosted.org/packages/41/12/cec246429ddfa2778d2d6301eca5362194dc8749ecb19e621f2f65b5090f/pydantic_core-2.41.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:05226894a26f6f27e1deb735d7308f74ef5fa3a6de3e0135bb66cdcaee88f64b", size = 2107836, upload-time = "2025-10-06T21:11:20.432Z" },
+    { url = "https://files.pythonhosted.org/packages/20/39/baba47f8d8b87081302498e610aefc37142ce6a1cc98b2ab6b931a162562/pydantic_core-2.41.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:85ff7911c6c3e2fd8d3779c50925f6406d770ea58ea6dde9c230d35b52b16b4a", size = 1904449, upload-time = "2025-10-06T21:11:22.185Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/9a3d87cae2c75a5178334b10358d631bd094b916a00a5993382222dbfd92/pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47f1f642a205687d59b52dc1a9a607f45e588f5a2e9eeae05edd80c7a8c47674", size = 1961750, upload-time = "2025-10-06T21:11:24.348Z" },
+    { url = "https://files.pythonhosted.org/packages/27/42/a96c9d793a04cf2a9773bff98003bb154087b94f5530a2ce6063ecfec583/pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:df11c24e138876ace5ec6043e5cae925e34cf38af1a1b3d63589e8f7b5f5cdc4", size = 2063305, upload-time = "2025-10-06T21:11:26.556Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/8d/028c4b7d157a005b1f52c086e2d4b0067886b213c86220c1153398dbdf8f/pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7f0bf7f5c8f7bf345c527e8a0d72d6b26eda99c1227b0c34e7e59e181260de31", size = 2228959, upload-time = "2025-10-06T21:11:28.426Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f7/ee64cda8fcc9ca3f4716e6357144f9ee71166775df582a1b6b738bf6da57/pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82b887a711d341c2c47352375d73b029418f55b20bd7815446d175a70effa706", size = 2345421, upload-time = "2025-10-06T21:11:30.226Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c0/e8ec05f0f5ee7a3656973ad9cd3bc73204af99f6512c1a4562f6fb4b3f7d/pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5f1d5d6bbba484bdf220c72d8ecd0be460f4bd4c5e534a541bb2cd57589fb8b", size = 2065288, upload-time = "2025-10-06T21:11:32.019Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/25/d77a73ff24e2e4fcea64472f5e39b0402d836da9b08b5361a734d0153023/pydantic_core-2.41.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2bf1917385ebe0f968dc5c6ab1375886d56992b93ddfe6bf52bff575d03662be", size = 2189759, upload-time = "2025-10-06T21:11:33.753Z" },
+    { url = "https://files.pythonhosted.org/packages/66/45/4a4ebaaae12a740552278d06fe71418c0f2869537a369a89c0e6723b341d/pydantic_core-2.41.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:4f94f3ab188f44b9a73f7295663f3ecb8f2e2dd03a69c8f2ead50d37785ecb04", size = 2140747, upload-time = "2025-10-06T21:11:35.781Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6d/b727ce1022f143194a36593243ff244ed5a1eb3c9122296bf7e716aa37ba/pydantic_core-2.41.1-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:3925446673641d37c30bd84a9d597e49f72eacee8b43322c8999fa17d5ae5bc4", size = 2327416, upload-time = "2025-10-06T21:11:37.75Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/8c/02df9d8506c427787059f87c6c7253435c6895e12472a652d9616ee0fc95/pydantic_core-2.41.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:49bd51cc27adb980c7b97357ae036ce9b3c4d0bb406e84fbe16fb2d368b602a8", size = 2318138, upload-time = "2025-10-06T21:11:39.463Z" },
+    { url = "https://files.pythonhosted.org/packages/98/67/0cf429a7d6802536941f430e6e3243f6d4b68f41eeea4b242372f1901794/pydantic_core-2.41.1-cp314-cp314-win32.whl", hash = "sha256:a31ca0cd0e4d12ea0df0077df2d487fc3eb9d7f96bbb13c3c5b88dcc21d05159", size = 1998429, upload-time = "2025-10-06T21:11:41.989Z" },
+    { url = "https://files.pythonhosted.org/packages/38/60/742fef93de5d085022d2302a6317a2b34dbfe15258e9396a535c8a100ae7/pydantic_core-2.41.1-cp314-cp314-win_amd64.whl", hash = "sha256:1b5c4374a152e10a22175d7790e644fbd8ff58418890e07e2073ff9d4414efae", size = 2028870, upload-time = "2025-10-06T21:11:43.66Z" },
+    { url = "https://files.pythonhosted.org/packages/31/38/cdd8ccb8555ef7720bd7715899bd6cfbe3c29198332710e1b61b8f5dd8b8/pydantic_core-2.41.1-cp314-cp314-win_arm64.whl", hash = "sha256:4fee76d757639b493eb600fba668f1e17475af34c17dd61db7a47e824d464ca9", size = 1974275, upload-time = "2025-10-06T21:11:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/7e/8ac10ccb047dc0221aa2530ec3c7c05ab4656d4d4bd984ee85da7f3d5525/pydantic_core-2.41.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f9b9c968cfe5cd576fdd7361f47f27adeb120517e637d1b189eea1c3ece573f4", size = 1875124, upload-time = "2025-10-06T21:11:47.591Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e4/7d9791efeb9c7d97e7268f8d20e0da24d03438a7fa7163ab58f1073ba968/pydantic_core-2.41.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1ebc7ab67b856384aba09ed74e3e977dded40e693de18a4f197c67d0d4e6d8e", size = 2043075, upload-time = "2025-10-06T21:11:49.542Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c3/3f6e6b2342ac11ac8cd5cb56e24c7b14afa27c010e82a765ffa5f771884a/pydantic_core-2.41.1-cp314-cp314t-win_amd64.whl", hash = "sha256:8ae0dc57b62a762985bc7fbf636be3412394acc0ddb4ade07fe104230f1b9762", size = 1995341, upload-time = "2025-10-06T21:11:51.497Z" },
+    { url = "https://files.pythonhosted.org/packages/16/89/d0afad37ba25f5801735af1472e650b86baad9fe807a42076508e4824a2a/pydantic_core-2.41.1-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:68f2251559b8efa99041bb63571ec7cdd2d715ba74cc82b3bc9eff824ebc8bf0", size = 2124001, upload-time = "2025-10-07T10:49:54.369Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/c4/08609134b34520568ddebb084d9ed0a2a3f5f52b45739e6e22cb3a7112eb/pydantic_core-2.41.1-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:c7bc140c596097cb53b30546ca257dbe3f19282283190b1b5142928e5d5d3a20", size = 1941841, upload-time = "2025-10-07T10:49:56.248Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/94a4877094e5fe19a3f37e7e817772263e2c573c94f1e3fa2b1eee56ef3b/pydantic_core-2.41.1-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2896510fce8f4725ec518f8b9d7f015a00db249d2fd40788f442af303480063d", size = 1961129, upload-time = "2025-10-07T10:49:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/30/23a224d7e25260eb5f69783a63667453037e07eb91ff0e62dabaadd47128/pydantic_core-2.41.1-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ced20e62cfa0f496ba68fa5d6c7ee71114ea67e2a5da3114d6450d7f4683572a", size = 2148770, upload-time = "2025-10-07T10:49:59.959Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/3e/a51c5f5d37b9288ba30683d6e96f10fa8f1defad1623ff09f1020973b577/pydantic_core-2.41.1-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b04fa9ed049461a7398138c604b00550bc89e3e1151d84b81ad6dc93e39c4c06", size = 2115344, upload-time = "2025-10-07T10:50:02.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/bd/389504c9e0600ef4502cd5238396b527afe6ef8981a6a15cd1814fc7b434/pydantic_core-2.41.1-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b3b7d9cfbfdc43c80a16638c6dc2768e3956e73031fca64e8e1a3ae744d1faeb", size = 1927994, upload-time = "2025-10-07T10:50:04.379Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/9c/5111c6b128861cb792a4c082677e90dac4f2e090bb2e2fe06aa5b2d39027/pydantic_core-2.41.1-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eec83fc6abef04c7f9bec616e2d76ee9a6a4ae2a359b10c21d0f680e24a247ca", size = 1959394, upload-time = "2025-10-07T10:50:06.335Z" },
+    { url = "https://files.pythonhosted.org/packages/14/3f/cfec8b9a0c48ce5d64409ec5e1903cb0b7363da38f14b41de2fcb3712700/pydantic_core-2.41.1-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6771a2d9f83c4038dfad5970a3eef215940682b2175e32bcc817bdc639019b28", size = 2147365, upload-time = "2025-10-07T10:50:07.978Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/6c/fa3e45c2b054a1e627a89a364917f12cbe3abc3e91b9004edaae16e7b3c5/pydantic_core-2.41.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:af2385d3f98243fb733862f806c5bb9122e5fba05b373e3af40e3c82d711cef1", size = 2112094, upload-time = "2025-10-07T10:50:25.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/17/7eebc38b4658cc8e6902d0befc26388e4c2a5f2e179c561eeb43e1922c7b/pydantic_core-2.41.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:6550617a0c2115be56f90c31a5370261d8ce9dbf051c3ed53b51172dd34da696", size = 1935300, upload-time = "2025-10-07T10:50:27.715Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/00/9fe640194a1717a464ab861d43595c268830f98cb1e2705aa134b3544b70/pydantic_core-2.41.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc17b6ecf4983d298686014c92ebc955a9f9baf9f57dad4065e7906e7bee6222", size = 1970417, upload-time = "2025-10-07T10:50:29.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ad/f4cdfaf483b78ee65362363e73b6b40c48e067078d7b146e8816d5945ad6/pydantic_core-2.41.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:42ae9352cf211f08b04ea110563d6b1e415878eea5b4c70f6bdb17dca3b932d2", size = 2190745, upload-time = "2025-10-07T10:50:31.48Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c1/18f416d40a10f44e9387497ba449f40fdb1478c61ba05c4b6bdb82300362/pydantic_core-2.41.1-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:e82947de92068b0a21681a13dd2102387197092fbe7defcfb8453e0913866506", size = 2150888, upload-time = "2025-10-07T10:50:33.477Z" },
+    { url = "https://files.pythonhosted.org/packages/42/30/134c8a921630d8a88d6f905a562495a6421e959a23c19b0f49b660801d67/pydantic_core-2.41.1-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:e244c37d5471c9acdcd282890c6c4c83747b77238bfa19429b8473586c907656", size = 2324489, upload-time = "2025-10-07T10:50:36.48Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/48/a9263aeaebdec81e941198525b43edb3b44f27cfa4cb8005b8d3eb8dec72/pydantic_core-2.41.1-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:1e798b4b304a995110d41ec93653e57975620ccb2842ba9420037985e7d7284e", size = 2322763, upload-time = "2025-10-07T10:50:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/62/755d2bd2593f701c5839fc084e9c2c5e2418f460383ad04e3b5d0befc3ca/pydantic_core-2.41.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f1fc716c0eb1663c59699b024428ad5ec2bcc6b928527b8fe28de6cb89f47efb", size = 2144046, upload-time = "2025-10-07T10:50:40.686Z" },
 ]
 
 [[package]]
@@ -6583,6 +6645,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "texttable"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/dc/0aff23d6036a4d3bf4f1d8c8204c5c79c4437e25e0ae94ffe4bbb55ee3c2/texttable-1.7.0.tar.gz", hash = "sha256:2d2068fb55115807d3ac77a4ca68fa48803e84ebb0ee2340f858107a36522638", size = 12831, upload-time = "2023-10-03T09:48:12.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/99/4772b8e00a136f3e01236de33b0efda31ee7077203ba5967fcc76da94d65/texttable-1.7.0-py2.py3-none-any.whl", hash = "sha256:72227d592c82b3d7f672731ae73e4d1f88cd8e2ef5b075a7a7f01a23a3743917", size = 10768, upload-time = "2023-10-03T09:48:10.434Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

PR 3 picks up what PR 2 deferred: substrate-level integration, the calibration loop, a tier-pool builder, the real LiteLLM fallback, and the CAMEL FunctionTool → SDK Permissions translator.

CAMEL moves from the `pocketpaw-ee[foresight]` optional extra to a hard dep, pinned at the qbtrix relax-caps fork (`76ff78e8`) so `psutil<6` no longer collides with `livekit-agents`. The OASIS substrate's core surface (`SocialAgent`, `AgentGraph`, `Channel`, `UserInfo`, `ActionType`) now loads via a tiered import so torch, pandas, and neo4j stay optional. The recsys tier is deferred to v2.0 Market Sim work; `OASIS_RECSYS_AVAILABLE` is the branch predicate.

Five upstream files carry per-file Apache-2.0 §4(b) "Modified by PocketPaw" notices for the lazy-import and log-dir guards: `social_agent/__init__.py`, `social_agent/agent.py`, `social_agent/agent_graph.py`, `social_platform/__init__.py`, and `environment/env.py`. Rationale lives in `substrate/oasis/README-FORK.md`.

## What's in this PR

`ee/pyproject.toml` + the ee `[tool.uv.sources]` override do the CAMEL hard-dep promotion. `uv lock` resolves alongside `langchain-openai` and `livekit-agents`:

```
[[package]]
name = "camel-ai"
version = "0.2.91a4"
source = { git = "https://github.com/qbtrix/camel-ai.git?rev=76ff78e8c78d0a38277e421ea9aca34904b4dc37#76ff78e8c78d0a38277e421ea9aca34904b4dc37" }
```

`igraph>=0.11` also lands as a hard dep — it's OASIS `AgentGraph`'s default backend. Neo4j stays optional because of the lazy import added in `social_agent/agent_graph.py`.

`ee/pocketpaw_ee/foresight/calibration.py` is new (~330 LOC): `PredictionRecord`, `PredictionBuffer`, `CalibrationPair`, `CalibrationSummary`, `pair_against_reality`, `aggregate_pairs`, `apply_correction`, `Correction`, `build_prediction_record`. Locked at AUTO ±10% per cycle (RFC implementation gate 6).

`ee/pocketpaw_ee/foresight/llm/tier_pool.py` is new (~190 LOC): `TierMix(premium=0.05, mid=0.15, tail=0.80)`, `build_tier_pool`, `tier_distribution`. Round-robin assignment plus a pre-shuffle so consecutive persona ids don't all land in one tier.

`ee/pocketpaw_ee/foresight/persona.py` gains `make_paw_social_agent(persona, ...)`, a factory that builds a `oasis.social_agent.SocialAgent` subclass on the fly. The `_wrap_as_camel_backend` shim satisfies CAMEL's strict `BaseModelBackend` type check so Foresight's own adapters don't have to inherit from it. RFC §7.2 fidelity floor is met: `perform_action_by_llm` delegates to the wrapped `SoulSeededPersona.decide`.

`ee/pocketpaw_ee/foresight/llm/adapter.py` finally hooks `litellm.acompletion` into `LiteLLMFallbackBackend` (was `NotImplementedError`), adds `translate_camel_tools_to_sdk_overrides` for CAMEL FunctionTool → Claude Code SDK Permissions, and puts a semaphore on every backend.

`ee/pocketpaw_ee/foresight/world.py` adds an optional `use_oasis_graph=True` that registers personas in `oasis.AgentGraph(backend="igraph")` and runs `tick()` under an OASIS-style per-tick semaphore.

`ee/pocketpaw_ee/foresight/scenarios/runner.py` — `run_scenario(backend_pool=...)` honors tier-pool round-robin; `ScenarioConfig.from_yaml` parses the `tier_mix:` block.

`scenarios/decision_forecast.yaml` declares the captain-locked `tier_mix:` block (the 5/15/80 default) explicitly.

## Quality gates

- 161 foresight tests pass (was 65; 96 new).
- `ruff check` + `ruff format` clean on `ee/pocketpaw_ee/foresight/` and `tests/ee/foresight/`.
- `mypy` clean on changed `ee/pocketpaw_ee/foresight/*.py`.
- `lint-imports` clean: 16 ee contracts + 1 root contract kept.
- `pytest --collect-only` on the full suite collects 5378 tests; no errors.

## Open design call

AUTO vs captain-reviewed correction (RFC §16.3, DESIGN TENSION 1 in soul memory). v0.1 ships AUTO with the ±10% cap per cycle. The `apply_correction(..., auto=False)` arm is wired and tested; the gating UI for captain review is PR 6 work. Worth revisiting once first customer data lands.

## Out of this PR's lane

- UI surfacing of calibration health and per-tier accuracy is PR 6 (paw-enterprise).
- Retroactive backtest harness is PR 4.
- Beanie-backed persistence of `PredictionBuffer` and `CalibrationSummary` is PR 7 (cloud).
- vLLM tail hosting decision is v2.0 economics work (per RFC §10 cost-model lock).

## Test plan

- [x] `uv run pytest tests/ee/foresight/` — 161 passed
- [x] `uv run pytest --collect-only -q` — 5378 collected, no errors
- [x] `uv run ruff check ee/pocketpaw_ee/foresight/ tests/ee/foresight/`
- [x] `uv run ruff format --check ee/pocketpaw_ee/foresight/ tests/ee/foresight/`
- [x] `uv run mypy ee/pocketpaw_ee/foresight/{__init__,world,persona,calibration}.py ee/pocketpaw_ee/foresight/llm/{adapter,tier_pool}.py ee/pocketpaw_ee/foresight/scenarios/runner.py`
- [x] `uv run lint-imports --config ee/pyproject.toml` — 16 kept, 0 broken
- [x] `uv run lint-imports` — OSS-EE boundary kept
- [x] `uv lock` resolves alongside langchain-openai + livekit-agents