### PR TITLE
feat(foresight): RFC 08 PR 5 - market sim + org change sub-types + projected decisions

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -495,6 +495,18 @@ class ForesightOnboardingUnlocked(Event):
     EVENT_TYPE: ClassVar[str] = "foresight.onboarding.unlocked"
 
 
+# Foresight per-anchor projection fanout — RFC 08 §7.7 + PR 5. Fires
+# once per (anchor × tick) bucket as the engine ticks the run forward;
+# the UI's Live panel consumes these to render the projection timeline
+# without polling the GET /runs/{id}/projected-decisions endpoint.
+# v1.0's calibration loop will subscribe so each projection lands in
+# the prediction buffer (RFC §9.1) as it is minted, not at the end of
+# the run.
+@dataclass
+class ForesightProjectedDecisionEmitted(Event):
+    EVENT_TYPE: ClassVar[str] = "foresight.projected_decision.emitted"
+
+
 # Composio — per-user OAuth integrations (Gmail, Slack, GitHub, …)
 # verified via per-toolkit identity probes. ``ComposioConnectionVerified``
 # fires when a probe succeeds and the stored identity matches (or first

--- a/ee/pocketpaw_ee/cloud/foresight/domain.py
+++ b/ee/pocketpaw_ee/cloud/foresight/domain.py
@@ -1,4 +1,18 @@
 # ee/pocketpaw_ee/cloud/foresight/domain.py
+# Updated: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) —
+# PR 5:
+#   - Rebuilt ``ProjectedDecision`` to match the persisted shape of
+#     the new ``foresight_projected_decisions`` collection. Fields
+#     follow RFC §7.7 (anchor_id, persona_id, tick_id, decision_text,
+#     confidence, sub_type, run_id) plus the workspace tenancy key.
+#   - Added ``forward_precedent_decision_id`` field stubbed to None —
+#     RFC 07 Decision Graph wiring (forward-precedent edge) is out of
+#     scope per the PR brief; the field is reserved so the future
+#     backfill pass doesn't have to reshape the wire contract.
+#   - The PR 7 embedded-decision shape didn't survive any consumers
+#     beyond the docstring, so the rewrite is non-breaking. The
+#     dataclass is still frozen and workspace_id is still required
+#     positionally per cloud rule #3.
 # Updated: 2026-05-25 (feat/foresight-v04-backtest-aggregator) — PR 4:
 #   - Added ``BacktestRun`` (parallel to ``ScenarioRun`` but for
 #     retroactive runs scored against ground truth) and
@@ -9,18 +23,20 @@
 #
 # Foresight cloud domain — frozen value objects, no Beanie / Pydantic /
 # FastAPI imports. The service (``ee.cloud.foresight.service``) maps
-# between these and the ``ForesightRun`` Beanie document; the DTO layer
+# between these and the ``ForesightRun`` / ``ForesightBacktest`` /
+# ``ForesightProjectedDecision`` Beanie documents; the DTO layer
 # (``ee.cloud.foresight.dto``) maps these to Pydantic responses.
 #
 # Multi-tenancy is enforced at construction per the cloud rule #3:
 # ``workspace_id`` is required positionally with no default — building a
-# ``ScenarioRun`` (or ``BacktestRun``, or ``OnboardingGateState``)
-# without one is a type error.
+# ``ScenarioRun`` (or ``BacktestRun``, ``OnboardingGateState``,
+# ``ProjectedDecision``) without one is a type error.
 #
-# Four value objects ship as of PR 4:
+# Five value objects ship as of PR 5:
 #
 #   - ``ScenarioRun`` (PR 7) — the persisted forward-run record.
-#   - ``ProjectedDecision`` (PR 7) — RFC §7.7 projected-decision shape.
+#   - ``ProjectedDecision`` (PR 5) — per-anchor projection record
+#     persisted into ``foresight_projected_decisions``.
 #   - ``BacktestRun`` (PR 4) — persisted retroactive-run record with
 #     the aggregator's accuracy summary + threshold decision pinned
 #     to the doc so historical pass/fail labels survive default tuning.
@@ -30,7 +46,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Literal
 
@@ -67,31 +83,43 @@ class ScenarioRun:
 
 @dataclass(frozen=True)
 class ProjectedDecision:
-    """A Decision (RFC 07 shape) emitted inside a Foresight run.
+    """One projected decision emitted during a Foresight run.
 
-    Same field set as the real Decision (anchor object, payload, actors)
-    plus three Foresight-specific extras per RFC §7.7:
+    Field shape mirrors the persisted
+    :class:`pocketpaw_ee.cloud.models.foresight_projected_decision.ForesightProjectedDecision`
+    document 1-to-1 plus the cloud rule #3 tenancy invariant:
 
-    - ``run_id``: the Foresight run that produced this projection.
-    - ``sim_tick``: the simulation tick at which the chain closed.
-    - ``projection_confidence``: aggregate confidence in (0.0, 1.0).
-
-    Not persisted as its own Mongo collection in PR 7 — projected
-    decisions live inside the run's ``result`` dict for now. PR 8 fans
-    them out into a sibling ``projected_decisions`` collection so the
-    Decision-Graph join (RFC §7.7 ``forward-precedent`` edge) can be
-    indexed cheaply. Freezing the dataclass now so PR 8's persistence
-    layer doesn't have to reshape the wire contract.
+    - ``id`` — Mongo ObjectId rendered as hex string.
+    - ``workspace_id`` — tenancy key (required positionally).
+    - ``run_id`` — the ForesightRun document id this projection
+      belongs to.
+    - ``anchor_id`` — sub-type-specific anchor identifier
+      (``decision:<name>`` / ``segment:<role>`` / ``rollout:<event>``).
+    - ``persona_id`` — the persona whose modal action drove the
+      projection (empty string when no persona acted).
+    - ``tick_id`` — zero-based tick index inside the run.
+    - ``decision_text`` — short string capturing the modal action
+      verb (e.g. ``"accept"``, ``"churn"``, ``"escalate"``).
+    - ``confidence`` — aggregate confidence in (0.0, 1.0).
+    - ``sub_type`` — the scenario's sub_type.
+    - ``forward_precedent_decision_id`` — RFC §7.7 forward-precedent
+      hook. ``None`` in PR 5 because RFC 07's Decision Graph wiring
+      isn't yet in pocketpaw; the field is reserved so the future
+      backfill pass (Decision Graph → projection cross-link) doesn't
+      have to reshape the wire contract.
+    - ``created_at`` — server-side timestamp from the Mongo doc.
     """
 
     id: str
     workspace_id: str
     run_id: str
-    sim_tick: int
-    anchor_object_id: str
-    payload: dict[str, Any]
-    projection_confidence: float = 0.5
-    actors: tuple[str, ...] = field(default_factory=tuple)
+    anchor_id: str
+    tick_id: int
+    decision_text: str
+    confidence: float
+    sub_type: str
+    persona_id: str = ""
+    forward_precedent_decision_id: str | None = None
     created_at: datetime | None = None
 
 

--- a/ee/pocketpaw_ee/cloud/foresight/dto.py
+++ b/ee/pocketpaw_ee/cloud/foresight/dto.py
@@ -1,4 +1,13 @@
 # ee/pocketpaw_ee/cloud/foresight/dto.py
+# Modified: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) — PR 5
+#   adds the per-anchor projection fanout surface:
+#     - ``ProjectedDecisionResponse`` — one record on the wire.
+#     - ``ProjectedDecisionListResponse`` — paginated envelope for
+#       ``GET /api/v1/foresight/runs/{id}/projected-decisions`` with the
+#       ``total / limit / offset / has_more`` fields a paginating
+#       client needs. v0.5 keeps the cursor offset-based; v1.0 may
+#       swap to opaque cursors once the dataset grows past the point
+#       where ``count_documents`` is cheap.
 # Modified: 2026-05-25 (feat/foresight-v04-backtest-aggregator) — PR 4
 #   adds the retroactive backtest gate surface:
 #     - ``CreateBacktestRequest`` — POST /foresight/backtests body.
@@ -239,6 +248,63 @@ class OnboardingGateResponse(BaseModel):
     last_backtest_at: str | None = None
 
 
+# ---------------------------------------------------------------------------
+# ProjectedDecision (RFC §7.7) — PR 5 per-anchor projection fanout.
+# ---------------------------------------------------------------------------
+
+
+class ProjectedDecisionResponse(BaseModel):
+    """One projected-decision record on the wire.
+
+    Mirrors :class:`pocketpaw_ee.cloud.foresight.domain.ProjectedDecision`
+    plus the ISO-8601 ``created_at`` string. The list endpoint
+    (``GET /runs/{id}/projected-decisions``) returns these in
+    ``(tick_id, anchor_id)`` order — bounded by the index on the
+    persistence layer.
+
+    ``forward_precedent_decision_id`` is reserved for the RFC 07
+    Decision Graph backfill path; v0.5 always reports ``None`` because
+    RFC 07 isn't yet integrated into pocketpaw. The field is on the
+    response so frontend consumers can render the link as soon as the
+    backfill pass starts populating it without a wire-shape bump.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    workspace_id: str
+    run_id: str
+    anchor_id: str
+    persona_id: str
+    tick_id: int
+    decision_text: str
+    confidence: float
+    sub_type: str
+    forward_precedent_decision_id: str | None = None
+    created_at: str | None = None
+
+
+class ProjectedDecisionListResponse(BaseModel):
+    """Paginated wrapper for ``GET /runs/{id}/projected-decisions``.
+
+    PR 5 returns a flat envelope with the items and the cursor metadata
+    a paginating client needs: ``total`` (when cheap to compute under
+    the workspace + run filter), ``limit``, ``offset``, and a
+    ``has_more`` boolean derived from
+    ``offset + len(items) < total``. The frontend Live panel uses the
+    items array; cost-aware consumers (the v1.0 export endpoint) read
+    the totals to size their fetch.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[ProjectedDecisionResponse]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+    has_more: bool = False
+
+
 __all__ = [
     "BacktestRunListItemResponse",
     "BacktestRunResponse",
@@ -247,6 +313,8 @@ __all__ = [
     "HistoricalAnchorRequest",
     "OnboardingGateResponse",
     "PersonaSpecRequest",
+    "ProjectedDecisionListResponse",
+    "ProjectedDecisionResponse",
     "ScenarioRunListItemResponse",
     "ScenarioRunResponse",
 ]

--- a/ee/pocketpaw_ee/cloud/foresight/router.py
+++ b/ee/pocketpaw_ee/cloud/foresight/router.py
@@ -1,4 +1,12 @@
 # ee/pocketpaw_ee/cloud/foresight/router.py
+# Modified: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) — PR 5
+#   adds the per-anchor projection fanout surface:
+#     GET /api/v1/foresight/runs/{id}/projected-decisions
+#       → paginated list of projected decisions for one run, optional
+#         ``anchor_id`` query filter. Tenancy: returns 404 when the run
+#         is unknown / cross-tenant (same collapsing rule as
+#         ``GET /runs/{id}``). Cursor: offset-based ``limit`` (default
+#         50, capped at 500) + ``offset`` (default 0).
 # Modified: 2026-05-25 (feat/foresight-v04-backtest-aggregator) — PR 4
 #   adds the retroactive backtest gate surface:
 #     POST /api/v1/foresight/backtests       → run a backtest + score it
@@ -44,6 +52,7 @@ from pocketpaw_ee.cloud.foresight.dto import (
     CreateBacktestRequest,
     CreateScenarioRequest,
     OnboardingGateResponse,
+    ProjectedDecisionListResponse,
     ScenarioRunListItemResponse,
     ScenarioRunResponse,
 )
@@ -111,6 +120,43 @@ async def list_runs(
     detail endpoint.
     """
     return await foresight_service.list_scenario_runs(ctx, limit=limit)
+
+
+@router.get(
+    "/runs/{run_id}/projected-decisions",
+    response_model=ProjectedDecisionListResponse,
+)
+async def list_projected_decisions(
+    run_id: str,
+    anchor_id: str | None = Query(default=None, max_length=256),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    ctx: RequestContext = Depends(request_context),
+) -> ProjectedDecisionListResponse:
+    """List projected decisions for one run.
+
+    PR 5 contract:
+      - Items are returned in ``(tick_id ASC, anchor_id ASC)`` order
+        — the index on the persistence layer makes this a single
+        bounded scan even across hundreds of records.
+      - ``anchor_id`` query filter narrows to one anchor across all
+        ticks (e.g. ``?anchor_id=segment:enterprise`` on a Market Sim
+        run, ``?anchor_id=rollout:training`` on an Org Change run).
+      - Tenancy: an unknown / cross-tenant run id returns 404
+        (``foresight_run.not_found``) — same collapsing rule the
+        scenario-run endpoints use so existence isn't cross-tenant
+        leakable.
+      - Pagination is offset-based; ``limit`` is hard-capped at 500.
+        Cursor-based pagination lands in v1.0 once the dataset grows
+        past the point where ``count_documents`` is cheap.
+    """
+    return await foresight_service.list_projected_decisions(
+        ctx,
+        run_id,
+        anchor_id=anchor_id,
+        limit=limit,
+        offset=offset,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/foresight/service.py
+++ b/ee/pocketpaw_ee/cloud/foresight/service.py
@@ -1,4 +1,20 @@
 # ee/pocketpaw_ee/cloud/foresight/service.py
+# Updated: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) — PR 5:
+#   - Added the RFC §7.7 per-anchor projection fanout. The engine call
+#     (``_run_engine_inline``) now accepts a ``run_id`` + an injected
+#     per-tick callback. The callback (``emit_projected_decision``) is
+#     the engine → cloud direction: defined here in cloud, passed by
+#     closure into the engine's ``run_scenario`` so the import-linter's
+#     "engine never imports cloud" contract holds. Every (anchor × tick)
+#     bucket gets one ForesightProjectedDecision document plus a
+#     ``ForesightProjectedDecisionEmitted`` event so the Live panel can
+#     render the timeline without polling.
+#   - Added ``list_projected_decisions(ctx, run_id, anchor_id=None,
+#     limit=50, offset=0)`` — the GET endpoint reader. Tenancy + run
+#     scoping enforced via the ``_fetch_in_workspace`` helper that
+#     already collapses unknown runs / cross-tenant ids into 404; the
+#     ``anchor_id`` filter is the additional optional clause. v0.5
+#     keeps the cursor offset-based.
 # Updated: 2026-05-25 (feat/foresight-v04-backtest-aggregator) — PR 4:
 #   - Added retroactive backtest API (``create_backtest`` /
 #     ``get_backtest`` / ``list_backtests``) and the onboarding gate
@@ -62,6 +78,7 @@ from pocketpaw_ee.cloud._core.realtime.events import (
     ForesightBacktestCreated,
     ForesightBacktestFailed,
     ForesightOnboardingUnlocked,
+    ForesightProjectedDecisionEmitted,
     ForesightRunCompleted,
     ForesightRunCreated,
     ForesightRunFailed,
@@ -70,6 +87,7 @@ from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.foresight.domain import (
     BacktestRun,
     OnboardingGateState,
+    ProjectedDecision,
     ScenarioRun,
 )
 from pocketpaw_ee.cloud.foresight.dto import (
@@ -78,11 +96,16 @@ from pocketpaw_ee.cloud.foresight.dto import (
     CreateBacktestRequest,
     CreateScenarioRequest,
     OnboardingGateResponse,
+    ProjectedDecisionListResponse,
+    ProjectedDecisionResponse,
     ScenarioRunListItemResponse,
     ScenarioRunResponse,
 )
 from pocketpaw_ee.cloud.models.foresight_backtest import (
     ForesightBacktest as _ForesightBacktestDoc,
+)
+from pocketpaw_ee.cloud.models.foresight_projected_decision import (
+    ForesightProjectedDecision as _ForesightProjectedDecisionDoc,
 )
 from pocketpaw_ee.cloud.models.foresight_run import ForesightRun as _ForesightRunDoc
 
@@ -178,7 +201,12 @@ async def _fetch_in_workspace(workspace_id: str, run_id: str) -> _ForesightRunDo
 # ---------------------------------------------------------------------------
 
 
-async def _run_engine_inline(body: CreateScenarioRequest) -> dict[str, Any]:
+async def _run_engine_inline(
+    body: CreateScenarioRequest,
+    *,
+    workspace_id: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
     """Drive the foresight engine for one scenario run.
 
     Imports are lazy: the engine modules (persona, llm, scenarios) live
@@ -187,6 +215,14 @@ async def _run_engine_inline(body: CreateScenarioRequest) -> dict[str, Any]:
     cloud rule #2 forbids touching the Beanie doc outside this service;
     the analogous principle on the engine side is that the cloud
     surface must remain importable without the engine's optional deps.
+
+    PR 5 wires the per-tick ProjectedDecision callback. When the caller
+    supplies a ``workspace_id`` + ``run_id``, the runner emits one
+    ForesightProjectedDecision document per (anchor × tick) bucket via
+    the ``emit_projected_decision`` closure below. The closure stays
+    here (rather than in the runner) so the engine never statically
+    imports the cloud — the import-linter contract holds and the
+    engine's optional-extra story is preserved.
 
     Returns the engine's ``RunResult.as_wire_dict()`` so the caller can
     persist the run as a JSON-shaped blob without leaking dataclass
@@ -213,7 +249,40 @@ async def _run_engine_inline(body: CreateScenarioRequest) -> dict[str, Any]:
         n_ticks=body.n_ticks,
         personas=personas,
     )
-    result = await run_scenario(config)
+
+    # Per-tick emission closure — only wired when the cloud caller
+    # supplies the run id. CLI smoke runs pass no run_id and the
+    # callback stays None; the engine still surfaces the records on
+    # ``RunResult.projected_decisions`` either way.
+    callback = None
+    if workspace_id and run_id:
+
+        async def _on_projected_decision(
+            anchor_id: str,
+            persona_id: str,
+            tick_id: int,
+            decision_text: str,
+            confidence: float,
+            sub_type: str,
+        ) -> None:
+            await emit_projected_decision(
+                workspace_id=workspace_id,
+                run_id=run_id,
+                anchor_id=anchor_id,
+                persona_id=persona_id,
+                tick_id=tick_id,
+                decision_text=decision_text,
+                confidence=confidence,
+                sub_type=sub_type,
+            )
+
+        callback = _on_projected_decision
+
+    result = await run_scenario(
+        config,
+        on_projected_decision=callback,
+        run_id=run_id,
+    )
     return result.as_wire_dict()
 
 
@@ -297,7 +366,11 @@ async def create_scenario_run(
     # PR 7 keeps the v0.1 event vocabulary (created → completed/failed).
 
     try:
-        result_dict = await _run_engine_inline(body)
+        result_dict = await _run_engine_inline(
+            body,
+            workspace_id=workspace_id,
+            run_id=str(doc.id),
+        )
     except Exception as exc:  # noqa: BLE001 — capture into the doc, never bubble
         error_message = f"{type(exc).__name__}: {exc}"
         doc.status = "failed"
@@ -797,13 +870,178 @@ async def get_onboarding_gate(ctx: RequestContext) -> OnboardingGateResponse:
     return _to_gate_response(state)
 
 
+# ---------------------------------------------------------------------------
+# Projected decisions (RFC §7.7 + PR 5 per-anchor projection fanout)
+# ---------------------------------------------------------------------------
+
+
+def _to_projected_decision_domain(doc: _ForesightProjectedDecisionDoc) -> ProjectedDecision:
+    return ProjectedDecision(
+        id=str(doc.id),
+        workspace_id=doc.workspace,
+        run_id=doc.run_id,
+        anchor_id=doc.anchor_id,
+        persona_id=doc.persona_id,
+        tick_id=doc.tick_id,
+        decision_text=doc.decision_text,
+        confidence=doc.confidence,
+        sub_type=doc.sub_type,
+        forward_precedent_decision_id=doc.forward_precedent_decision_id,
+        created_at=getattr(doc, "createdAt", None),
+    )
+
+
+def _to_projected_decision_response(pd: ProjectedDecision) -> ProjectedDecisionResponse:
+    return ProjectedDecisionResponse(
+        id=pd.id,
+        workspace_id=pd.workspace_id,
+        run_id=pd.run_id,
+        anchor_id=pd.anchor_id,
+        persona_id=pd.persona_id,
+        tick_id=pd.tick_id,
+        decision_text=pd.decision_text,
+        confidence=pd.confidence,
+        sub_type=pd.sub_type,
+        forward_precedent_decision_id=pd.forward_precedent_decision_id,
+        created_at=iso_utc(pd.created_at),
+    )
+
+
+async def emit_projected_decision(
+    *,
+    workspace_id: str,
+    run_id: str,
+    anchor_id: str,
+    persona_id: str,
+    tick_id: int,
+    decision_text: str,
+    confidence: float,
+    sub_type: str,
+) -> ProjectedDecisionResponse:
+    """Persist one projected-decision record and emit the event.
+
+    Called by the engine's per-tick callback (wired in
+    ``_run_engine_inline``). The callback is injected into the runner
+    via closure so the engine module stays clean of the cloud import
+    surface — the import-linter contract pins this direction.
+
+    Tenancy:
+      - ``workspace_id`` is required (the closure inside
+        ``_run_engine_inline`` will only be wired when the cloud call
+        has already resolved a workspace), so this function asserts
+        rather than validating.
+      - The run_id is the ForesightRun document id; cross-tenant
+        protection is enforced by the run's own ``_fetch_in_workspace``
+        check on the read side (a misrouted write here is impossible
+        because the closure binds the workspace from the same
+        RequestContext that constructed the run).
+
+    Returns the persisted record as a response shape so callers can
+    surface it on the live ws fan-out without a second round trip.
+
+    Per RFC §7.7: ``forward_precedent_decision_id`` is stubbed ``None``
+    until RFC 07 lands in pocketpaw; the field is part of the persisted
+    shape so the backfill pass can populate it without a wire-shape
+    bump.
+    """
+    if not workspace_id:
+        raise Forbidden(
+            "foresight.no_workspace",
+            "workspace required to emit a projected decision",
+        )
+
+    doc = _ForesightProjectedDecisionDoc(
+        workspace=workspace_id,
+        run_id=run_id,
+        anchor_id=anchor_id,
+        persona_id=persona_id,
+        tick_id=tick_id,
+        decision_text=decision_text,
+        confidence=confidence,
+        sub_type=sub_type,
+        forward_precedent_decision_id=None,
+    )
+    await doc.insert()
+
+    response = _to_projected_decision_response(_to_projected_decision_domain(doc))
+    await emit(ForesightProjectedDecisionEmitted(data=response.model_dump()))
+    return response
+
+
+async def list_projected_decisions(
+    ctx: RequestContext,
+    run_id: str,
+    *,
+    anchor_id: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> ProjectedDecisionListResponse:
+    """List projected decisions for a run, optionally filtered by anchor.
+
+    Cross-tenant safety: this function calls ``_fetch_in_workspace``
+    first so an unknown / cross-tenant run id surfaces as ``NotFound``
+    *before* the projection query runs. That keeps the 404 collapsing
+    rule consistent with ``get_scenario_run`` — existence is never
+    leakable across tenants.
+
+    Pagination:
+      - ``limit`` defaults to 50; hard-capped at 500 so a misconfigured
+        caller can't drag the entire collection into memory.
+      - ``offset`` is the cursor; v0.5 keeps the cursor offset-based
+        and computes ``total`` via ``count_documents`` under the same
+        filter. v1.0 may swap to an opaque cursor once dataset sizes
+        make ``count_documents`` expensive.
+      - ``has_more`` is derived from ``offset + len(items) < total`` so
+        callers can detect EOF without a second round trip.
+
+    Order: ``(tick_id ASC, anchor_id ASC)`` matches the
+    ``(workspace, run_id, tick_id, anchor_id)`` index so the query is a
+    single bounded scan.
+    """
+    workspace_id = _require_workspace(ctx)
+    # 404-collapse rule — run must exist in this workspace before the
+    # projection query runs (otherwise an attacker could probe run-id
+    # existence by listing projections that always return ``items=[]``).
+    await _fetch_in_workspace(workspace_id, run_id)
+
+    if limit < 1:
+        raise ValidationError("foresight.invalid_limit", "limit must be >= 1")
+    if limit > 500:
+        limit = 500
+    if offset < 0:
+        raise ValidationError("foresight.invalid_offset", "offset must be >= 0")
+
+    query: dict[str, Any] = {"workspace": workspace_id, "run_id": run_id}
+    if anchor_id:
+        query["anchor_id"] = anchor_id
+
+    total = await _ForesightProjectedDecisionDoc.find(query).count()
+    docs = (
+        await _ForesightProjectedDecisionDoc.find(query)
+        .sort([("tick_id", 1), ("anchor_id", 1)])  # type: ignore[list-item]
+        .skip(offset)
+        .limit(limit)
+        .to_list()
+    )
+    items = [_to_projected_decision_response(_to_projected_decision_domain(d)) for d in docs]
+    return ProjectedDecisionListResponse(
+        items=items,
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=(offset + len(items)) < total,
+    )
+
+
 __all__ = [
     "GATE_DEFAULT_THRESHOLD",
     "create_backtest",
     "create_scenario_run",
+    "emit_projected_decision",
     "get_backtest",
     "get_onboarding_gate",
     "get_scenario_run",
     "list_backtests",
+    "list_projected_decisions",
     "list_scenario_runs",
 ]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -14,6 +14,9 @@ from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
 from pocketpaw_ee.cloud.models.cycle import Cycle, CycleDailyPoint
 from pocketpaw_ee.cloud.models.file import FileObj
 from pocketpaw_ee.cloud.models.foresight_backtest import ForesightBacktest
+from pocketpaw_ee.cloud.models.foresight_projected_decision import (
+    ForesightProjectedDecision,
+)
 from pocketpaw_ee.cloud.models.foresight_run import ForesightRun
 from pocketpaw_ee.cloud.models.group import Group, GroupAgent
 from pocketpaw_ee.cloud.models.invite import Invite
@@ -59,6 +62,7 @@ __all__ = [
     "FileObj",
     "FileUpload",
     "ForesightBacktest",
+    "ForesightProjectedDecision",
     "ForesightRun",
     "Group",
     "GroupAgent",
@@ -115,6 +119,7 @@ def get_all_documents():
         PlanSession,
         ForesightRun,
         ForesightBacktest,
+        ForesightProjectedDecision,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/models/foresight_projected_decision.py
+++ b/ee/pocketpaw_ee/cloud/models/foresight_projected_decision.py
@@ -1,0 +1,101 @@
+# ee/pocketpaw_ee/cloud/models/foresight_projected_decision.py
+# Created: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) —
+# RFC 08 PR 5. ProjectedDecision Beanie document — RFC §7.7 per-anchor
+# projection fanout, persisted as a sibling collection of
+# ``foresight_runs`` + ``foresight_backtests``.
+#
+# Each (anchor × tick) bucket produces one document; the cloud's
+# emit_projected_decision service function is the sole writer (per the
+# cloud rule #2 — only ``ee.cloud.foresight.service`` may import this
+# module). The import-linter contract in ``ee/pyproject.toml`` lists
+# this doc alongside ``foresight_run`` + ``foresight_backtest``.
+#
+# Indexes match the two read paths PR 5 ships:
+#   - List by run: ``(workspace, run_id, tick_id, anchor_id)`` so the
+#     ``GET /runs/{id}/projected-decisions`` query is a single bounded
+#     range scan ordered by tick then anchor.
+#   - Filter by anchor across runs: ``(workspace, anchor_id, tick_id)``
+#     so a query like "show me every projected decision against
+#     lease:LR-2026-117" stays cheap even as the workspace accumulates
+#     runs.
+#
+# The ``forward_precedent_decision_id`` field is RFC 07's Decision
+# Graph hook — when a real Decision later lands that references this
+# projection, the cloud's Decision Graph wiring (NOT in scope for PR 5)
+# will populate this field with the real-decision id. v0.5 stubs it to
+# ``None`` per the PR brief; RFC 07 lives only at /tmp/team-rfc07 per
+# the soul memory and isn't yet integrated into pocketpaw.
+
+from __future__ import annotations
+
+from typing import Any
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class ForesightProjectedDecision(TimestampedDocument):
+    """One projected decision emitted during a Foresight run.
+
+    Fields:
+      - ``workspace`` — tenancy key (Indexed for fast list queries).
+      - ``run_id`` — the ForesightRun document id (hex string) the
+        projection belongs to. Not a ``PydanticObjectId`` because the
+        engine surface stays str-typed for cross-platform JSON.
+      - ``anchor_id`` — sub-type-specific anchor identifier
+        (``decision:<name>`` / ``segment:<role>`` / ``rollout:<event>``).
+      - ``persona_id`` — the persona whose modal action drove the
+        projection. Empty string when no persona acted for this anchor
+        at this tick (the engine still emits a record so the per-anchor
+        timeline stays dense).
+      - ``tick_id`` — zero-based tick index inside the run.
+      - ``decision_text`` — short string capturing the modal action
+        verb (e.g. ``"accept"``, ``"churn"``, ``"escalate"``).
+      - ``confidence`` — aggregate confidence in (0.0, 1.0). v0.5
+        derives this from the share of personas whose action verb
+        matched the modal bucket.
+      - ``sub_type`` — the scenario's sub_type (echoed for downstream
+        consumers that index per-anchor records across runs of
+        different sub-types).
+      - ``forward_precedent_decision_id`` — RFC 07 Decision Graph hook
+        (RFC §7.7 forward-precedent edge). Stubbed to ``None`` in PR 5
+        because RFC 07's Decision Graph wiring isn't in pocketpaw yet
+        (scaffold lives at /tmp/team-rfc07 only). When the Decision
+        Graph lands, a real Decision id will populate this field via
+        a backfill pass scoped to the same workspace.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    run_id: str
+    anchor_id: str
+    persona_id: str = ""
+    tick_id: int = Field(default=0, ge=0)
+    decision_text: str = Field(default="noop", max_length=256)
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    sub_type: str = Field(default="decision_forecast", max_length=64)
+    forward_precedent_decision_id: str | None = None
+
+    class Settings:
+        name = "foresight_projected_decisions"
+        indexes = [
+            # Per-run listing — the GET /runs/{id}/projected-decisions
+            # endpoint orders by (tick_id, anchor_id) inside one
+            # workspace + run scope.
+            [("workspace", 1), ("run_id", 1), ("tick_id", 1), ("anchor_id", 1)],
+            # Anchor-across-runs lookup — the future Decision Graph
+            # join (RFC §7.7 forward-precedent) walks projections by
+            # anchor; the index keeps the query cheap when one anchor
+            # accumulates dozens of projections across quarterly runs.
+            [("workspace", 1), ("anchor_id", 1), ("tick_id", 1)],
+        ]
+
+
+__all__ = ["ForesightProjectedDecision"]
+
+
+# Type alias for the dict shape the engine callback yields. Re-exported
+# from this module so the service layer's emit function has a single
+# canonical reference for the record shape.
+ProjectedDecisionDict = dict[str, Any]

--- a/ee/pocketpaw_ee/foresight/scenarios/market_sim.yaml
+++ b/ee/pocketpaw_ee/foresight/scenarios/market_sim.yaml
@@ -1,0 +1,88 @@
+# ee/pocketpaw_ee/foresight/scenarios/market_sim.yaml
+# Created: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) —
+# RFC 08 PR 5. Market Sim sub-type smoke scenario — RFC §4.2.
+#
+# Six personas across three market segments (enterprise / smb / channel)
+# plus a competitor reactor. The deterministic-fake backend will fan
+# acceptable actions per persona; the adapter buckets them into
+# per-segment market-position outcomes.
+#
+# v0.5 keeps the persona count small (six) so the smoke runs in
+# milliseconds; v1.0 will load a 10K-100K persona pool from a Fabric
+# synthesizer per RFC §4.2. The persona ``role`` is the segment label
+# the adapter keys on for the per-anchor projection fanout.
+#
+# Fields the v0.5 loader ignores but v1.0 will read live as comments
+# below the active block so this YAML can absorb the full RFC §18
+# grammar without changing shape.
+
+name: smoke-market-sim
+sub_type: market_sim
+n_ticks: 2
+
+# Captain-locked 5/15/80 default per RFC §10. Declared explicitly so
+# new readers see the tier mix without chasing the loader's default.
+tier_mix:
+  premium: 0.05  # Claude Sonnet 4.7 — competitor reactor + segment-1
+  mid:     0.15  # Claude Haiku 4.7 — mid-tier customers
+  tail:    0.80  # Llama-3.1-8B via vLLM — synthesized tail personas
+
+personas:
+  - name: enterprise-acme
+    role: enterprise
+    ocean:
+      conscientiousness: 0.6
+      neuroticism: -0.2
+  - name: enterprise-globex
+    role: enterprise
+    ocean:
+      openness: 0.4
+      agreeableness: 0.2
+  - name: smb-quickserve
+    role: smb
+    ocean:
+      extraversion: 0.5
+      openness: 0.6
+  - name: smb-corner-coffee
+    role: smb
+    ocean:
+      agreeableness: 0.7
+      conscientiousness: -0.1
+  - name: channel-partner-east
+    role: channel
+    ocean:
+      extraversion: 0.8
+      conscientiousness: 0.3
+  - name: competitor-alpha
+    role: competitor
+    ocean:
+      openness: 0.9
+      conscientiousness: 0.4
+
+# v1.0 will read these blocks — they're parked here as documentation so
+# operators editing this file can see where the next-version grammar
+# lands. The v0.5 loader silently skips unknown top-level keys.
+#
+# world:
+#   source: fabric
+#   funnel_stages: [awareness, consideration, purchase, retention]
+#   comp_set_delta_pct: 3.6
+#
+# triggers:
+#   - kind: pricing_change
+#     at_tick: 1
+#     payload:
+#       comp_set_delta_pct: 5.0
+#   - kind: new_entrant
+#     at_tick: 2
+#     payload:
+#       competitor: "Newco"
+#
+# aggregator:
+#   per_segment:
+#     - win_rate
+#     - churn_rate
+#     - nps_delta
+#   totals:
+#     - revenue_trajectory
+#     - modal_segment

--- a/ee/pocketpaw_ee/foresight/scenarios/org_change.yaml
+++ b/ee/pocketpaw_ee/foresight/scenarios/org_change.yaml
@@ -1,0 +1,106 @@
+# ee/pocketpaw_ee/foresight/scenarios/org_change.yaml
+# Created: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) —
+# RFC 08 PR 5. Org Change Rehearsal sub-type smoke scenario — RFC §4.3.
+#
+# Eight personas across four internal roles (manager / ic / ops /
+# customer-success) ticked against the four-step rollout sequence
+# (announce / training / deadline / escalation). The deterministic-fake
+# backend will fan accept / resist / exit / escalate actions; the adapter
+# buckets them into per-event adoption rates.
+#
+# v0.5 keeps the persona count small (eight) so the smoke runs in
+# milliseconds; v1.0 will load the workspace's actual team-soul roster
+# per RFC §4.3 and apply the Instinct policy overlay so the throughput
+# / queue-depth metrics emerge from the simulation.
+#
+# Fields the v0.5 loader ignores but v1.0 will read live as comments
+# below the active block so this YAML can absorb the full RFC §18
+# grammar without changing shape.
+
+name: smoke-org-change
+sub_type: org_change_rehearsal
+n_ticks: 4  # one tick per rollout event (announce / training / deadline / escalation)
+
+# Captain-locked 5/15/80 default per RFC §10.
+tier_mix:
+  premium: 0.05  # Claude Sonnet 4.7 — manager personas
+  mid:     0.15  # Claude Haiku 4.7 — IC personas
+  tail:    0.80  # Llama-3.1-8B via vLLM — ops + customer-success
+
+personas:
+  - name: eng-manager-anne
+    role: manager
+    ocean:
+      conscientiousness: 0.8
+      agreeableness: 0.4
+  - name: eng-manager-priya
+    role: manager
+    ocean:
+      conscientiousness: 0.6
+      openness: 0.3
+  - name: ic-alex
+    role: ic
+    ocean:
+      openness: 0.7
+      neuroticism: -0.3
+  - name: ic-blake
+    role: ic
+    ocean:
+      conscientiousness: 0.5
+      agreeableness: 0.6
+  - name: ic-carmen
+    role: ic
+    ocean:
+      neuroticism: 0.4   # higher resistance tilt
+      openness: -0.2
+  - name: ops-david
+    role: ops
+    ocean:
+      conscientiousness: 0.7
+      agreeableness: 0.5
+  - name: cs-elena
+    role: customer_success
+    ocean:
+      extraversion: 0.6
+      openness: 0.4
+  - name: cs-frank
+    role: customer_success
+    ocean:
+      agreeableness: 0.7
+      conscientiousness: 0.3
+
+# v1.0 will read these blocks — parked here as documentation. The v0.5
+# loader skips unknown top-level keys.
+#
+# rollout_events:
+#   - id: announce
+#     at_tick: 0
+#     payload:
+#       channel: all-hands
+#   - id: training
+#     at_tick: 1
+#     payload:
+#       attendance_required: true
+#   - id: deadline
+#     at_tick: 2
+#     payload:
+#       deadline_days: 30
+#   - id: escalation
+#     at_tick: 3
+#     payload:
+#       trigger: missed_deadline
+#
+# instinct_policy_overlay:
+#   approve_per_row:
+#     mode: two_approver_concur
+#     min_amount_usd: 5000
+#
+# aggregator:
+#   per_event:
+#     - adoption_rate
+#     - resistance_rate
+#     - exit_rate
+#   totals:
+#     - throughput
+#     - queue_depth
+#     - escalation_count

--- a/ee/pocketpaw_ee/foresight/scenarios/runner.py
+++ b/ee/pocketpaw_ee/foresight/scenarios/runner.py
@@ -1,4 +1,24 @@
 # ee/pocketpaw_ee/foresight/scenarios/runner.py
+# Updated: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) — PR 5:
+#   - ``SUPPORTED_SUB_TYPES`` lifted to include ``market_sim`` and
+#     ``org_change_rehearsal`` alongside ``decision_forecast``. The
+#     adapter set lives in ``ee.foresight.subtypes``; dispatch routes
+#     to ``get_adapter(sub_type)`` after the tick loop so each sub-type
+#     produces its own aggregate shape inside ``RunResult.aggregate``.
+#   - ``RunResult.aggregate`` added — the sub-type-specific outcome
+#     dict (market segments, rollout adoption rates, decision modal
+#     outcome). The v0.1 ``final_state`` field stays for backward
+#     compat; the cloud's backtest path reads ``aggregate`` instead.
+#   - ``run_scenario`` accepts an optional ``on_projected_decision``
+#     callback — the cloud side passes a function that persists one
+#     ProjectedDecision record per (anchor × tick) bucket. The runner
+#     fans the callback after each tick by walking
+#     ``adapter.anchors_for(config)``; per-anchor decision text comes
+#     from the modal action verb in the tick's action log. This is the
+#     RFC §7.7 per-anchor projection fanout that PR 7 + PR 4 deferred.
+#   - ``run_scenario`` accepts an optional ``run_id`` so the cloud can
+#     pre-allocate the run document id before the engine ticks; the
+#     callback echoes it back to the cloud for cross-referencing.
 # Updated: 2026-05-25 (feat/foresight-v03-calibration) — PR 3 adds:
 #   - ``tier_mix`` parse step in ``ScenarioConfig.from_yaml`` — the
 #     scenario YAML can now declare a per-scenario override of the
@@ -26,6 +46,8 @@
 
 from __future__ import annotations
 
+from collections import Counter
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -36,6 +58,8 @@ import yaml  # type: ignore[import-untyped]
 from pocketpaw_ee.foresight.llm.adapter import DeterministicFakeBackend
 from pocketpaw_ee.foresight.llm.tier_pool import TierMix, tier_distribution
 from pocketpaw_ee.foresight.persona import OceanDrift, SoulSeededPersona
+from pocketpaw_ee.foresight.subtypes import SUPPORTED_SUB_TYPES as _SUPPORTED_SUB_TYPES
+from pocketpaw_ee.foresight.subtypes import get_adapter
 from pocketpaw_ee.foresight.world import ForesightWorld, WorldSnapshot
 
 
@@ -80,15 +104,20 @@ class ScenarioConfig:
     personas: list[PersonaSpec] = field(default_factory=list)
     tier_mix: TierMix | None = None
 
-    SUPPORTED_SUB_TYPES: tuple[str, ...] = ("decision_forecast",)
+    # PR 5 lifts the supported set to the three sub-types v0.5 ships
+    # (decision_forecast + market_sim + org_change_rehearsal). The
+    # remaining four — ops_stress_test, strategic_what_if,
+    # training_rehearsal, discovery_generative — land in PR 6+ as
+    # additional sibling adapters under ``ee.foresight.subtypes``.
+    SUPPORTED_SUB_TYPES: tuple[str, ...] = _SUPPORTED_SUB_TYPES
 
     def __post_init__(self) -> None:
         if self.sub_type not in self.SUPPORTED_SUB_TYPES:
             raise NotImplementedError(
-                f"v0.1 supports only {self.SUPPORTED_SUB_TYPES}; "
-                f"got {self.sub_type!r}. Future PRs add market_sim, "
-                "org_change_rehearsal, ops_stress_test, strategic_what_if, "
-                "training_rehearsal, discovery_generative (RFC 08 §4)."
+                f"v0.5 supports only {self.SUPPORTED_SUB_TYPES}; "
+                f"got {self.sub_type!r}. Future PRs add ops_stress_test, "
+                "strategic_what_if, training_rehearsal, and "
+                "discovery_generative (RFC 08 §4)."
             )
         if self.n_ticks < 1:
             raise ValueError(f"n_ticks must be >= 1, got {self.n_ticks}")
@@ -139,24 +168,39 @@ class ScenarioConfig:
 class RunResult:
     """What a scenario run emits.
 
-    v0.1 surfaces just enough to prove the loop closed end-to-end:
+    v0.5 surfaces enough to prove the loop closed end-to-end AND to
+    serve the sub-type aggregate the cloud's backtest gate consumes:
       - ``scenario_name``: copy of the scenario's name
+      - ``sub_type``: PR 5 — copy of the scenario's sub_type so the
+        wire dict carries the dispatch label.
       - ``tick_snapshots``: WorldSnapshot per tick (in order)
       - ``final_state``: the world's toy state dict at run end
       - ``actions_logged``: total successful actions across all ticks
       - ``tier_distribution``: PR 3 — per-tier persona count when a
         tier pool was used (empty dict for the v0.1 single-backend
         path). Drives the per-run cost report's RFC §10 table.
-
-    v1.0 adds projected decisions, aggregator metrics, calibration
-    buffer writes, cost meter readouts.
+      - ``aggregate``: PR 5 — sub-type-specific outcome dict produced
+        by the adapter in ``ee.foresight.subtypes``. Decision Forecast
+        emits ``modal_outcome``; Market Sim emits per-segment
+        win_rate/churn_rate; Org Change emits per-event adoption_rate.
+        The backtest scoring path reads ``aggregate["modal_outcome"]``
+        when present (PR 4 contract) and the future per-anchor
+        projection fanout reads the sub-type-specific keys.
+      - ``projected_decisions``: PR 5 — list of per-anchor projection
+        records emitted during the tick loop. The cloud side persists
+        these via the ``on_projected_decision`` callback; the runner
+        also surfaces them on the result for callers that drive the
+        engine outside the cloud (e.g. CLI smoke).
     """
 
     scenario_name: str
     tick_snapshots: list[WorldSnapshot]
     final_state: dict[str, Any]
     actions_logged: int
+    sub_type: str = "decision_forecast"
     tier_distribution: dict[str, int] = field(default_factory=dict)
+    aggregate: dict[str, Any] = field(default_factory=dict)
+    projected_decisions: list[dict[str, Any]] = field(default_factory=list)
 
     @property
     def n_ticks(self) -> int:
@@ -164,12 +208,22 @@ class RunResult:
 
     def as_wire_dict(self) -> dict[str, Any]:
         """Cheap JSON-serializable view for the API + tests."""
-        return {
+        # Decision Forecast's adapter emits ``modal_outcome`` inside
+        # ``aggregate`` — surface it at the wire top level so the v0.1
+        # backtest scoring path (which reads ``modal_outcome`` from the
+        # engine result dict) keeps working without a special case in
+        # the cloud service. PR 4's ``_score_backtest`` already checks
+        # both ``modal_outcome`` and ``projected_modal_outcome``.
+        modal = self.aggregate.get("modal_outcome") if isinstance(self.aggregate, dict) else None
+        wire: dict[str, Any] = {
             "scenario_name": self.scenario_name,
+            "sub_type": self.sub_type,
             "n_ticks": self.n_ticks,
             "actions_logged": self.actions_logged,
             "final_state": dict(self.final_state),
             "tier_distribution": dict(self.tier_distribution),
+            "aggregate": dict(self.aggregate),
+            "projected_decisions": list(self.projected_decisions),
             "tick_snapshots": [
                 {
                     "tick": s.tick,
@@ -180,9 +234,39 @@ class RunResult:
                 for s in self.tick_snapshots
             ],
         }
+        if modal:
+            wire["modal_outcome"] = modal
+        return wire
 
 
 # --- the runner ------------------------------------------------------
+
+# PR 5 — per-tick projected-decision callback signature. The cloud side
+# (``ee.cloud.foresight.service.emit_projected_decision``) passes a
+# function shaped like this into ``run_scenario`` so the engine can
+# emit one record per (anchor × tick) bucket without statically
+# importing the cloud layer (engine → cloud direction is forbidden by
+# the import-linter contract; the cloud injects the callback so the
+# arrow points the other way at run-time only).
+#
+# Args:
+#   anchor_id: the sub-type-specific anchor (``decision:<name>`` for
+#     Decision Forecast, ``segment:<role>`` for Market Sim,
+#     ``rollout:<event>`` for Org Change).
+#   persona_id: str(UUID) of the persona whose modal action drove the
+#     projection. An empty string when no persona action landed for
+#     this anchor at this tick (the engine still emits a record so the
+#     per-anchor timeline stays dense).
+#   tick_id: zero-based tick index inside the run.
+#   decision_text: short string capturing the modal action verb (e.g.
+#     "accept", "churn", "escalate"). Used as the wire-level decision
+#     payload until v1.0 fans the full action dict.
+#   confidence: aggregate confidence in (0.0, 1.0). v0.5 derives this
+#     from the share of personas whose action verb matched the modal
+#     bucket — high agreement → high confidence.
+#   sub_type: the scenario's sub_type (echoed for downstream consumers
+#     that index per-anchor records across runs of different sub-types).
+ProjectedDecisionCallback = Callable[[str, str, int, str, float, str], Any]
 
 
 async def run_scenario(
@@ -190,6 +274,8 @@ async def run_scenario(
     *,
     backend: Any | None = None,
     backend_pool: list[Any] | None = None,
+    on_projected_decision: ProjectedDecisionCallback | None = None,
+    run_id: str | None = None,
 ) -> RunResult:
     """Run one scenario end-to-end.
 
@@ -205,6 +291,18 @@ async def run_scenario(
             and the ``backend`` arg is ignored. The run's
             ``tier_distribution`` is populated from the pool so the
             per-run report can render the cost decomposition.
+        on_projected_decision: PR 5 — optional callback invoked once
+            per (anchor × tick) bucket after each tick lands. The
+            cloud service uses this to persist ProjectedDecision
+            records as the run unfolds; CLI callers can pass ``None``
+            to skip persistence and read the same records back from
+            ``RunResult.projected_decisions``. The callback may be
+            sync or async — ``run_scenario`` awaits it when it returns
+            a coroutine.
+        run_id: PR 5 — optional pre-allocated run id the cloud passes
+            so the per-tick records cross-reference the same id the
+            ForesightRun document carries. The callback receives the
+            run id implicitly via the closure the caller supplies.
 
     Production callers hand in a ``backend_pool`` built from
     ``TierMix.locked_default()`` (or the scenario's
@@ -212,6 +310,8 @@ async def run_scenario(
     the RFC §7.3 ``List[BaseModelBackend]`` primitive OASIS's
     SocialAgent uses natively.
     """
+    import inspect  # noqa: PLC0415 — used only when the callback is sync vs async
+
     if backend_pool is None and backend is None:
         backend = DeterministicFakeBackend()
 
@@ -235,15 +335,109 @@ async def run_scenario(
     if backend_pool:
         tier_dist = tier_distribution(backend_pool[: len(config.personas)])
 
+    adapter = get_adapter(config.sub_type)
+    anchors = adapter.anchors_for(config)
+
     snapshots: list[WorldSnapshot] = []
-    for _ in range(config.n_ticks):
+    projected_records: list[dict[str, Any]] = []
+    for tick_index in range(config.n_ticks):
         snapshot = await world.tick()
         snapshots.append(snapshot)
+        # Fan one projected-decision record per anchor for this tick.
+        # The runner stays sub-type-agnostic here — anchor selection is
+        # the adapter's responsibility; decision-text + confidence
+        # derivation is a uniform tally of the tick's modal action verb.
+        tick_records = _project_tick(
+            anchors=anchors,
+            snapshot=snapshot,
+            tick_index=tick_index,
+            sub_type=config.sub_type,
+        )
+        for record in tick_records:
+            projected_records.append(record)
+            if on_projected_decision is None:
+                continue
+            maybe_coro = on_projected_decision(
+                record["anchor_id"],
+                record["persona_id"],
+                record["tick_id"],
+                record["decision_text"],
+                record["confidence"],
+                record["sub_type"],
+            )
+            if inspect.isawaitable(maybe_coro):
+                await maybe_coro
+
+    aggregate = adapter.aggregate(snapshots, config)
 
     return RunResult(
         scenario_name=config.name,
+        sub_type=config.sub_type,
         tick_snapshots=snapshots,
         final_state=world.state,
         actions_logged=snapshots[-1].actions_applied if snapshots else 0,
         tier_distribution=tier_dist,
+        aggregate=aggregate,
+        projected_decisions=projected_records,
     )
+
+
+def _project_tick(
+    *,
+    anchors: list[str],
+    snapshot: WorldSnapshot,
+    tick_index: int,
+    sub_type: str,
+) -> list[dict[str, Any]]:
+    """Build one projected-decision record per anchor for this tick.
+
+    v0.5 contract:
+      - One record per anchor (the cloud expects every anchor to be
+        addressable on every tick, even when no persona acted there).
+      - ``decision_text`` is the modal action verb across the tick's
+        successful actions; defaults to ``"noop"`` when nothing landed.
+      - ``confidence`` is the share of successful actions that picked
+        the modal verb (1.0 when one verb dominates, lower under split
+        decisions). When the tick produced zero successful actions
+        ``confidence`` is 0.0.
+      - ``persona_id`` is the modal persona's agent id when one exists,
+        else an empty string. v1.0 will fan one record per (anchor ×
+        persona) pair; v0.5 stays one-per-anchor so the cloud's storage
+        footprint is linear in anchor count, not anchor × persona.
+    """
+    # Count verbs across successful actions; the persona id of the
+    # last-seen action for each verb so we can attribute the modal
+    # bucket to a specific persona.
+    verb_counts: Counter[str] = Counter()
+    verb_persona: dict[str, str] = {}
+    successful_total = 0
+    for action in snapshot.last_tick_actions:
+        if not action.get("ok"):
+            continue
+        successful_total += 1
+        verb = str(action.get("action", "")).strip().lower() or "noop"
+        verb_counts[verb] += 1
+        agent_id = action.get("agent_id")
+        if isinstance(agent_id, str):
+            verb_persona[verb] = agent_id
+
+    if verb_counts:
+        modal_verb, modal_count = verb_counts.most_common(1)[0]
+        confidence = (modal_count / successful_total) if successful_total else 0.0
+        persona_id = verb_persona.get(modal_verb, "")
+    else:
+        modal_verb = "noop"
+        confidence = 0.0
+        persona_id = ""
+
+    return [
+        {
+            "anchor_id": anchor_id,
+            "persona_id": persona_id,
+            "tick_id": tick_index,
+            "decision_text": modal_verb,
+            "confidence": confidence,
+            "sub_type": sub_type,
+        }
+        for anchor_id in anchors
+    ]

--- a/ee/pocketpaw_ee/foresight/subtypes/__init__.py
+++ b/ee/pocketpaw_ee/foresight/subtypes/__init__.py
@@ -1,0 +1,97 @@
+# ee/pocketpaw_ee/foresight/subtypes/__init__.py
+# Created: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) —
+# RFC 08 PR 5. Sub-type adapter dispatch package — one module per
+# RFC §4 sub-type ships a small, declarative adapter that hands the
+# runner the per-tick anchor list and the post-run aggregate shape.
+#
+# v0.5 ships three of the seven RFC §4 sub-types:
+#   - decision_forecast (PR 1) — the v0.1 baseline, anchors = the
+#     decision the operator is staring at; aggregator emits an outcome
+#     distribution. Lives in the runner as the default branch.
+#   - market_sim (PR 5) — competitor + customer-segment personas;
+#     anchors = market-position keys (e.g. ``segment:enterprise``);
+#     aggregator emits market_share / win_rate / churn.
+#   - org_change (PR 5) — internal-role personas; anchors = the rollout
+#     events (announcement / training / deadline / escalation);
+#     aggregator emits adoption_rate / exit_rate / escalation_count.
+#
+# Each adapter is a module-level set of pure functions:
+#   - ``ANCHORS: tuple[str, ...]`` — fixed anchor ids for v0.5 (v1.0
+#     pulls from the scenario YAML's ``anchors:`` block).
+#   - ``anchors_for(config) -> list[str]`` — anchor ids per scenario
+#     run (currently returns ``list(ANCHORS)``; v1.0 will read
+#     ``config.anchors`` once that field lands on ScenarioConfig).
+#   - ``aggregate(snapshots, config) -> dict[str, Any]`` — sub-type
+#     outcome dict folded into ``RunResult.aggregate``.
+#
+# The runner (``scenarios/runner.py``) imports lazily inside
+# ``run_scenario`` to keep the import surface small for v0.1/v0.2
+# callers that never touch market_sim or org_change. PR 6+ will
+# add ops_stress_test / strategic_what_if / training_rehearsal /
+# discovery_generative as siblings here.
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+# Public sub-type identifiers — match the RFC §4 catalog.
+SUB_TYPE_DECISION_FORECAST = "decision_forecast"
+SUB_TYPE_MARKET_SIM = "market_sim"
+SUB_TYPE_ORG_CHANGE = "org_change_rehearsal"
+
+# Canonical sub-types known to v0.5. The runner uses this set to gate
+# its sub-type validation; adding a new module here + a YAML loads it
+# without touching the runner.
+SUPPORTED_SUB_TYPES: tuple[str, ...] = (
+    SUB_TYPE_DECISION_FORECAST,
+    SUB_TYPE_MARKET_SIM,
+    SUB_TYPE_ORG_CHANGE,
+)
+
+
+def get_adapter(sub_type: str) -> Any:
+    """Return the adapter module for ``sub_type`` or raise
+    ``NotImplementedError`` with the RFC §4 pointer.
+
+    Imports are lazy so the engine's import surface stays small —
+    ``market_sim`` and ``org_change`` only load when a scenario
+    actually targets them.
+    """
+    if sub_type == SUB_TYPE_MARKET_SIM:
+        from pocketpaw_ee.foresight.subtypes import market_sim as _market_sim
+
+        return _market_sim
+    if sub_type == SUB_TYPE_ORG_CHANGE:
+        from pocketpaw_ee.foresight.subtypes import org_change as _org_change
+
+        return _org_change
+    if sub_type == SUB_TYPE_DECISION_FORECAST:
+        # Decision Forecast stays in the runner's default branch — the
+        # adapter here is a thin pass-through so callers that want a
+        # uniform interface still get one.
+        from pocketpaw_ee.foresight.subtypes import decision_forecast as _decision_forecast
+
+        return _decision_forecast
+    raise NotImplementedError(
+        f"sub_type {sub_type!r} is not implemented; supported v0.5 set is "
+        f"{SUPPORTED_SUB_TYPES}. See RFC 08 §4 for the seven-sub-type catalog."
+    )
+
+
+# Type alias for the per-tick projected-decision callback the cloud
+# passes into the engine. Keeps the runner's signature readable.
+#
+# Args: (anchor_id, persona_id, tick_id, decision_text, confidence, sub_type)
+# Returns: nothing — the callback persists the decision side-effect.
+ProjectedDecisionCallback = Callable[[str, str, int, str, float, str], None]
+
+
+__all__ = [
+    "ProjectedDecisionCallback",
+    "SUB_TYPE_DECISION_FORECAST",
+    "SUB_TYPE_MARKET_SIM",
+    "SUB_TYPE_ORG_CHANGE",
+    "SUPPORTED_SUB_TYPES",
+    "get_adapter",
+]

--- a/ee/pocketpaw_ee/foresight/subtypes/decision_forecast.py
+++ b/ee/pocketpaw_ee/foresight/subtypes/decision_forecast.py
@@ -1,0 +1,95 @@
+# ee/pocketpaw_ee/foresight/subtypes/decision_forecast.py
+# Created: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) —
+# RFC 08 PR 5. Adapter for the Decision Forecast sub-type — RFC §4.1.
+#
+# Decision Forecast is the narrowest, highest-fidelity sub-type the v0.1
+# loop has been carrying since PR 1. The adapter here is a thin
+# pass-through that returns the runner's default behavior so the
+# get_adapter() dispatch in ``subtypes/__init__.py`` has a uniform
+# interface across all three v0.5 sub-types.
+#
+# Anchors for Decision Forecast: the operator points at a specific
+# decision (a lease, a contract amendment, an offer). v0.5 treats the
+# scenario's *name* as the anchor id when the scenario doesn't declare
+# an explicit ``anchors:`` list — that mirrors the v0.1 contract where
+# the scenario name doubles as the decision identifier in the run report.
+#
+# Aggregator: an outcome histogram across the run's tick snapshots.
+# v0.5 emits the modal "put" key the engine's last tick recorded, plus
+# the raw count of actions logged across the run. v1.0 will fold the
+# counterfactual-branch distribution per RFC §4.1.
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pocketpaw_ee.foresight.scenarios.runner import ScenarioConfig
+    from pocketpaw_ee.foresight.world import WorldSnapshot
+
+SUB_TYPE = "decision_forecast"
+
+
+def anchors_for(config: ScenarioConfig) -> list[str]:
+    """Return the list of anchor ids this scenario forecasts against.
+
+    v0.5 defaults to a single anchor named after the scenario itself —
+    the v0.1 convention that the scenario name and the decision id
+    line up. v1.0 will read ``config.anchors`` when that field lands
+    on ScenarioConfig (RFC §18 example YAML calls for an explicit
+    ``anchors:`` block).
+    """
+    return [f"decision:{config.name}"]
+
+
+def aggregate(
+    snapshots: list[WorldSnapshot],
+    config: ScenarioConfig,
+) -> dict[str, Any]:
+    """Roll the tick snapshots into a Decision Forecast outcome dict.
+
+    v0.5 contract:
+      - ``sub_type``: echo the sub-type string for downstream consumers.
+      - ``modal_outcome``: the modal ``put`` map across all successful
+        actions in the final tick. Empty dict when no action stored a
+        ``put`` block (the deterministic-fake backend does this when
+        the persona elects ``put=none``).
+      - ``actions_total``: cumulative successful action count.
+      - ``ticks_run``: number of tick snapshots.
+
+    The aggregator and calibration loop (PR 4) read ``modal_outcome``
+    when scoring the backtest gate. Returning ``{}`` for that field is
+    the v0.1 fallback — pairs against actuals will count as mismatches
+    rather than crashing.
+    """
+    if not snapshots:
+        return {
+            "sub_type": SUB_TYPE,
+            "modal_outcome": {},
+            "actions_total": 0,
+            "ticks_run": 0,
+        }
+    final = snapshots[-1]
+    puts_in_final: Counter[frozenset[tuple[str, Any]]] = Counter()
+    for action in final.last_tick_actions:
+        if not action.get("ok"):
+            continue
+        put = action.get("put")
+        if isinstance(put, dict):
+            # Stringify so Counter keys stay hashable even when the
+            # action's put map carries nested structures.
+            puts_in_final[frozenset(put.items())] += 1
+    modal_outcome: dict[str, Any] = {}
+    if puts_in_final:
+        most_common_items, _count = puts_in_final.most_common(1)[0]
+        modal_outcome = dict(most_common_items)
+    return {
+        "sub_type": SUB_TYPE,
+        "modal_outcome": modal_outcome,
+        "actions_total": final.actions_applied,
+        "ticks_run": len(snapshots),
+    }
+
+
+__all__ = ["SUB_TYPE", "aggregate", "anchors_for"]

--- a/ee/pocketpaw_ee/foresight/subtypes/market_sim.py
+++ b/ee/pocketpaw_ee/foresight/subtypes/market_sim.py
@@ -1,0 +1,200 @@
+# ee/pocketpaw_ee/foresight/subtypes/market_sim.py
+# Created: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) —
+# RFC 08 PR 5. Market Sim sub-type adapter — RFC §4.2.
+#
+# Market Sim is the "classical population shape" — competitor agents,
+# customer segments, and channel partners react to external events
+# (pricing changes, new entrants, demand shifts). Outcomes are aggregate
+# market positions: market_share / win_rate / churn / nps swings per
+# segment, not single decisions.
+#
+# v0.5 contract (the minimum the cloud + the calibration loop need):
+#   - Anchors: one anchor per market segment the scenario tracks
+#     (``segment:<role>``). Persona ``role`` is the segment id so the
+#     YAML stays declarative and the adapter doesn't need a new
+#     ScenarioConfig field.
+#   - Aggregator: rolls personas' last-tick actions into per-segment
+#     win/loss/churn counts and produces the market_position dict the
+#     UI's Aggregate panel renders (RFC §11.5).
+#
+# v1.0 will:
+#   - Pull personas from a Fabric synthesizer at 10K-100K scale (the
+#     v0.5 path runs at whatever count the operator declares inline).
+#   - Drive external events from a tick-scheduled injector (the v0.5
+#     path treats each tick as a uniform "market beat" with no event
+#     fanout — the cloud's per-tick projected-decision emission is the
+#     trace, the injector is PR 7+).
+#   - Wire OASIS's per-tier semaphore so the 100K-agent run hits the
+#     5/15/80 cost ceiling cleanly.
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pocketpaw_ee.foresight.scenarios.runner import ScenarioConfig
+    from pocketpaw_ee.foresight.world import WorldSnapshot
+
+SUB_TYPE = "market_sim"
+
+# Action-token vocabulary the aggregator buckets into market outcomes.
+# Personas' deterministic-fake responses won't always match these —
+# anything outside the bucket lands in ``other`` so the contract stays
+# total without throwing.
+_WIN_ACTIONS: frozenset[str] = frozenset({"buy", "convert", "renew", "refer"})
+_LOSS_ACTIONS: frozenset[str] = frozenset({"churn", "decline", "lapse"})
+_NEUTRAL_ACTIONS: frozenset[str] = frozenset({"hold", "noop", "watch", "complain"})
+
+
+def anchors_for(config: ScenarioConfig) -> list[str]:
+    """Anchor ids for a Market Sim run — one per segment, dedup'd.
+
+    Each persona's ``role`` is treated as the segment label (the YAML
+    convention v0.5 ships: ``role: enterprise``, ``role: smb``, etc.).
+    The dedupe step keeps the anchor list short when the operator
+    declares a 1000-persona scenario across 5 segments — the engine
+    fans projected decisions per-anchor, not per-persona, so anchor
+    cardinality drives the cloud's storage footprint.
+    """
+    segments = []
+    seen = set()
+    for spec in config.personas:
+        seg = (spec.role or "participant").strip().lower()
+        anchor_id = f"segment:{seg}"
+        if anchor_id in seen:
+            continue
+        seen.add(anchor_id)
+        segments.append(anchor_id)
+    if not segments:
+        # Defensive default — a YAML with zero personas is rejected
+        # upstream by ScenarioConfig.__post_init__, but defaulting here
+        # keeps the adapter total.
+        return ["segment:all"]
+    return segments
+
+
+def aggregate(
+    snapshots: list[WorldSnapshot],
+    config: ScenarioConfig,
+) -> dict[str, Any]:
+    """Roll the tick snapshots into per-segment market-position dicts.
+
+    v0.5 contract:
+      - ``sub_type``: echo the sub-type string.
+      - ``segments``: dict keyed by anchor id (``segment:<role>``);
+        each value carries ``wins``, ``losses``, ``neutral``, ``other``
+        counts plus the derived ``win_rate`` and ``churn_rate``.
+      - ``totals``: cross-segment aggregates (total actions, modal
+        market position by win-rate, ticks_run).
+
+    The aggregator deliberately stays additive across all snapshots so
+    the per-run trajectory shows the modal outcome at completion. v1.0
+    will split out per-tick deltas and the funnel-stage transitions
+    OASIS's recsys layer produces natively.
+    """
+    if not snapshots:
+        return {
+            "sub_type": SUB_TYPE,
+            "segments": {},
+            "totals": {
+                "actions_total": 0,
+                "modal_segment": None,
+                "modal_win_rate": 0.0,
+                "ticks_run": 0,
+            },
+        }
+
+    # Build a name → role index so the persona id (which surfaces in
+    # ``last_tick_actions`` via the world's str(uuid)) maps back to the
+    # segment. v0.5 keys on persona name in the action log via the
+    # deterministic-fake's contract; v1.0 swaps for the agent id once
+    # the world surfaces it in the action dict.
+    name_to_segment: dict[str, str] = {}
+    for spec in config.personas:
+        seg = (spec.role or "participant").strip().lower()
+        name_to_segment[spec.name] = seg
+
+    segment_counters: dict[str, Counter[str]] = defaultdict(Counter)
+    seen_segments = set(name_to_segment.values())
+
+    for snapshot in snapshots:
+        for action in snapshot.last_tick_actions:
+            if not action.get("ok"):
+                continue
+            # The world layer's action dict carries the agent id but not
+            # the persona's role; we fall back to ``segment:all`` when
+            # the role can't be resolved (deterministic-fake backend
+            # responds with a tokenized action verb either way).
+            verb = str(action.get("action", "")).strip().lower()
+            put = action.get("put")
+            segment_for_action: str | None = None
+            # Heuristic 1 — put carries an explicit segment.
+            if isinstance(put, dict):
+                explicit = put.get("segment")
+                if isinstance(explicit, str):
+                    segment_for_action = explicit.strip().lower()
+            # Heuristic 2 — map agent_id → persona name via the world's
+            # roster. The runner stores personas keyed by UUID; the
+            # action dict surfaces ``agent_id`` as the str(UUID). We
+            # don't have a back-pointer at this layer so we degrade to
+            # the modal segment across the population.
+            if segment_for_action is None:
+                # Pick the first segment as a stable default so the
+                # aggregator stays deterministic across runs even when
+                # the population's segment mix is even.
+                segment_for_action = next(iter(seen_segments), "all")
+            anchor_id = f"segment:{segment_for_action}"
+            if verb in _WIN_ACTIONS:
+                segment_counters[anchor_id]["wins"] += 1
+            elif verb in _LOSS_ACTIONS:
+                segment_counters[anchor_id]["losses"] += 1
+            elif verb in _NEUTRAL_ACTIONS:
+                segment_counters[anchor_id]["neutral"] += 1
+            else:
+                segment_counters[anchor_id]["other"] += 1
+
+    # Make sure every declared anchor surfaces even if the run produced
+    # no actions for it — the cloud's per-anchor query expects every
+    # anchor to be addressable.
+    for anchor_id in anchors_for(config):
+        segment_counters.setdefault(anchor_id, Counter())
+
+    segments_out: dict[str, dict[str, Any]] = {}
+    modal_segment = None
+    modal_win_rate = 0.0
+    actions_total = 0
+    for anchor_id, counter in segment_counters.items():
+        wins = counter.get("wins", 0)
+        losses = counter.get("losses", 0)
+        neutral = counter.get("neutral", 0)
+        other = counter.get("other", 0)
+        sub_total = wins + losses + neutral + other
+        win_rate = (wins / sub_total) if sub_total else 0.0
+        churn_rate = (losses / sub_total) if sub_total else 0.0
+        segments_out[anchor_id] = {
+            "wins": wins,
+            "losses": losses,
+            "neutral": neutral,
+            "other": other,
+            "win_rate": win_rate,
+            "churn_rate": churn_rate,
+        }
+        actions_total += sub_total
+        if win_rate > modal_win_rate:
+            modal_win_rate = win_rate
+            modal_segment = anchor_id
+
+    return {
+        "sub_type": SUB_TYPE,
+        "segments": segments_out,
+        "totals": {
+            "actions_total": actions_total,
+            "modal_segment": modal_segment,
+            "modal_win_rate": modal_win_rate,
+            "ticks_run": len(snapshots),
+        },
+    }
+
+
+__all__ = ["SUB_TYPE", "aggregate", "anchors_for"]

--- a/ee/pocketpaw_ee/foresight/subtypes/org_change.py
+++ b/ee/pocketpaw_ee/foresight/subtypes/org_change.py
@@ -1,0 +1,185 @@
+# ee/pocketpaw_ee/foresight/subtypes/org_change.py
+# Created: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) —
+# RFC 08 PR 5. Org Change Rehearsal sub-type adapter — RFC §4.3.
+#
+# Org Change Rehearsal is the "what if we change the policy" sub-type —
+# the world is an internal Fabric snapshot, personas are the team souls
+# + agent crews that operate the affected pockets, and the intervention
+# is an Instinct policy overlay. The tick semantics here are rollout
+# events: announcement → training → deadline → escalation, each ticking
+# the rollout one beat forward. Personas respond with acceptance /
+# resistance / exit / escalation.
+#
+# v0.5 contract (the minimum the cloud + the calibration loop need):
+#   - Anchors: the rollout-event sequence (RFC §4.3 names them
+#     announce / training / deadline / escalation). v0.5 ships the
+#     fixed four; v1.0 will read ``config.rollout_events`` once that
+#     field lands on ScenarioConfig.
+#   - Aggregator: rolls personas' last-tick actions into
+#     ``adoption_rate`` / ``resistance_rate`` / ``exit_rate`` /
+#     ``escalation_count`` per anchor.
+#
+# v1.0 will:
+#   - Drive personas at calendar cadence (1 sim-day / tick is typical)
+#     via an injector — v0.5 treats every tick uniformly.
+#   - Pull personas from the workspace's actual team-soul roster + the
+#     agent crews wired to the affected pockets (v0.5 still takes the
+#     inline persona list).
+#   - Apply the Instinct policy overlay so the throughput / queue-depth
+#     metrics RFC §4.3 calls for emerge from the simulation rather than
+#     being computed from action tallies.
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pocketpaw_ee.foresight.scenarios.runner import ScenarioConfig
+    from pocketpaw_ee.foresight.world import WorldSnapshot
+
+SUB_TYPE = "org_change_rehearsal"
+
+# Fixed rollout-event sequence v0.5 fans against. Each event becomes
+# one anchor id (``rollout:<event>``); the engine fans projected
+# decisions per-anchor so the cloud's storage footprint stays linear
+# in the rollout length, not in the persona count.
+DEFAULT_ROLLOUT_EVENTS: tuple[str, ...] = (
+    "announce",
+    "training",
+    "deadline",
+    "escalation",
+)
+
+# Action-token vocabulary the aggregator buckets into adoption outcomes.
+# Personas' deterministic-fake responses pick from these via the OCEAN
+# drift; tokens outside the bucket land in ``other``.
+_ADOPT_ACTIONS: frozenset[str] = frozenset({"accept", "adopt", "comply", "engage"})
+_RESIST_ACTIONS: frozenset[str] = frozenset({"resist", "object", "delay", "complain"})
+_EXIT_ACTIONS: frozenset[str] = frozenset({"exit", "leave", "quit", "transfer"})
+_ESCALATE_ACTIONS: frozenset[str] = frozenset({"escalate", "appeal", "report"})
+
+
+def anchors_for(config: ScenarioConfig) -> list[str]:
+    """Return the rollout-event anchor ids for an Org Change run.
+
+    v0.5 emits the fixed four-step sequence. v1.0 reads
+    ``config.rollout_events`` once the YAML grammar adds it.
+    """
+    return [f"rollout:{event}" for event in DEFAULT_ROLLOUT_EVENTS]
+
+
+def aggregate(
+    snapshots: list[WorldSnapshot],
+    config: ScenarioConfig,
+) -> dict[str, Any]:
+    """Roll the tick snapshots into per-rollout-event adoption dicts.
+
+    v0.5 contract:
+      - ``sub_type``: echo the sub-type string.
+      - ``rollout``: dict keyed by anchor id (``rollout:<event>``);
+        each value carries ``adoptions``, ``resistance``, ``exits``,
+        ``escalations``, ``other`` counts plus the derived
+        ``adoption_rate``, ``resistance_rate``, ``exit_rate`` rates.
+      - ``totals``: cross-event aggregates (population, escalation
+        count, modal adoption rate, ticks_run).
+
+    The tick → anchor mapping is positional: tick 0 fans against the
+    first anchor (announce), tick 1 against the second (training), and
+    so on. When ``n_ticks`` exceeds the rollout length, extra ticks
+    fan against the last anchor (escalation) — the v0.5 simplification
+    that maps "the rollout finished but the simulation kept ticking"
+    onto continued escalation responses.
+    """
+    anchors = anchors_for(config)
+    if not snapshots:
+        return {
+            "sub_type": SUB_TYPE,
+            "rollout": {anchor_id: _empty_bucket() for anchor_id in anchors},
+            "totals": {
+                "population": len(config.personas),
+                "escalation_count": 0,
+                "modal_adoption_rate": 0.0,
+                "ticks_run": 0,
+            },
+        }
+
+    buckets: dict[str, dict[str, int]] = defaultdict(_empty_bucket)
+    for tick_index, snapshot in enumerate(snapshots):
+        anchor_id = anchors[min(tick_index, len(anchors) - 1)]
+        for action in snapshot.last_tick_actions:
+            if not action.get("ok"):
+                continue
+            verb = str(action.get("action", "")).strip().lower()
+            if verb in _ADOPT_ACTIONS:
+                buckets[anchor_id]["adoptions"] += 1
+            elif verb in _RESIST_ACTIONS:
+                buckets[anchor_id]["resistance"] += 1
+            elif verb in _EXIT_ACTIONS:
+                buckets[anchor_id]["exits"] += 1
+            elif verb in _ESCALATE_ACTIONS:
+                buckets[anchor_id]["escalations"] += 1
+            else:
+                buckets[anchor_id]["other"] += 1
+
+    # Make sure every anchor surfaces even when the run hit zero
+    # actions there — the cloud's per-anchor query expects each
+    # anchor id to round-trip.
+    for anchor_id in anchors:
+        buckets.setdefault(anchor_id, _empty_bucket())
+
+    rollout_out: dict[str, dict[str, Any]] = {}
+    modal_adoption_rate = 0.0
+    escalation_total = 0
+    for anchor_id, counts in buckets.items():
+        adoptions = counts["adoptions"]
+        resistance = counts["resistance"]
+        exits = counts["exits"]
+        escalations = counts["escalations"]
+        other = counts["other"]
+        sub_total = adoptions + resistance + exits + escalations + other
+        adoption_rate = (adoptions / sub_total) if sub_total else 0.0
+        resistance_rate = (resistance / sub_total) if sub_total else 0.0
+        exit_rate = (exits / sub_total) if sub_total else 0.0
+        rollout_out[anchor_id] = {
+            "adoptions": adoptions,
+            "resistance": resistance,
+            "exits": exits,
+            "escalations": escalations,
+            "other": other,
+            "adoption_rate": adoption_rate,
+            "resistance_rate": resistance_rate,
+            "exit_rate": exit_rate,
+        }
+        escalation_total += escalations
+        if adoption_rate > modal_adoption_rate:
+            modal_adoption_rate = adoption_rate
+
+    return {
+        "sub_type": SUB_TYPE,
+        "rollout": rollout_out,
+        "totals": {
+            "population": len(config.personas),
+            "escalation_count": escalation_total,
+            "modal_adoption_rate": modal_adoption_rate,
+            "ticks_run": len(snapshots),
+        },
+    }
+
+
+def _empty_bucket() -> dict[str, int]:
+    return {
+        "adoptions": 0,
+        "resistance": 0,
+        "exits": 0,
+        "escalations": 0,
+        "other": 0,
+    }
+
+
+__all__ = [
+    "DEFAULT_ROLLOUT_EVENTS",
+    "SUB_TYPE",
+    "aggregate",
+    "anchors_for",
+]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -388,6 +388,7 @@ source_modules = [
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.foresight_run",
     "pocketpaw_ee.cloud.models.foresight_backtest",
+    "pocketpaw_ee.cloud.models.foresight_projected_decision",
 ]
 
 [[tool.importlinter.contracts]]
@@ -409,6 +410,7 @@ source_modules = [
     "pocketpaw_ee.cloud.foresight.domain",
     "pocketpaw_ee.cloud.models.foresight_run",
     "pocketpaw_ee.cloud.models.foresight_backtest",
+    "pocketpaw_ee.cloud.models.foresight_projected_decision",
 ]
 forbidden_modules = [
     "pocketpaw_ee.foresight.persona",
@@ -418,6 +420,7 @@ forbidden_modules = [
     "pocketpaw_ee.foresight.world",
     "pocketpaw_ee.foresight.aggregator",
     "pocketpaw_ee.foresight.calibration",
+    "pocketpaw_ee.foresight.subtypes",
 ]
 
 [[tool.importlinter.contracts]]

--- a/tests/cloud/test_foresight_backtest_router.py
+++ b/tests/cloud/test_foresight_backtest_router.py
@@ -134,7 +134,7 @@ async def test_post_accepts_threshold_tightening(w1_client: AsyncClient) -> None
 async def test_post_422_unsupported_sub_type(w1_client: AsyncClient) -> None:
     r = await w1_client.post(
         "/foresight/backtests",
-        json=_payload(sub_type="market_sim"),
+        json=_payload(sub_type="ops_stress_test"),
     )
     assert r.status_code == 422
     assert r.json()["error"]["code"] == "foresight.invalid_scenario"

--- a/tests/cloud/test_foresight_backtest_service.py
+++ b/tests/cloud/test_foresight_backtest_service.py
@@ -243,8 +243,8 @@ async def test_create_captures_engine_failure_as_failed_status(monkeypatch, reco
 async def test_create_rejects_unsupported_sub_type() -> None:
     ctx = _ctx()
     body = CreateBacktestRequest(
-        name="market-backtest",
-        sub_type="market_sim",
+        name="ops-stress-backtest",
+        sub_type="ops_stress_test",
         n_ticks=1,
         personas=[PersonaSpecRequest(name="A", role="participant", ocean={})],
         anchors=[

--- a/tests/cloud/test_foresight_domain.py
+++ b/tests/cloud/test_foresight_domain.py
@@ -71,23 +71,28 @@ def test_scenario_run_carries_optional_result_and_error() -> None:
 
 
 def test_projected_decision_carries_rfc_extras() -> None:
-    """RFC §7.7: a ProjectedDecision is a Decision plus three extras —
-    ``run_id``, ``sim_tick``, ``projection_confidence``. Freeze the
-    contract now so PR 8's persistence layer doesn't have to reshape."""
+    """RFC §7.7: a ProjectedDecision carries the per-anchor projection
+    fields PR 5 added — anchor_id, persona_id, tick_id, decision_text,
+    confidence, sub_type, run_id. Tenancy (``workspace_id``) is the
+    cloud rule #3 invariant. ``forward_precedent_decision_id`` is
+    reserved for the RFC 07 Decision Graph backfill — None in v0.5."""
     pd = ProjectedDecision(
         id="proj-1",
         workspace_id="w1",
         run_id="run-1",
-        sim_tick=10,
-        anchor_object_id="lease:LR-2026-117",
-        payload={"outcome": "accept", "price": 2850},
-        projection_confidence=0.78,
-        actors=("renewal_specialist", "approver_prakash"),
+        anchor_id="decision:LR-2026-117",
+        persona_id="persona-anne",
+        tick_id=10,
+        decision_text="accept",
+        confidence=0.78,
+        sub_type="decision_forecast",
     )
     assert pd.run_id == "run-1"
-    assert pd.sim_tick == 10
-    assert 0.0 < pd.projection_confidence < 1.0
-    assert pd.anchor_object_id == "lease:LR-2026-117"
+    assert pd.anchor_id == "decision:LR-2026-117"
+    assert pd.tick_id == 10
+    assert 0.0 < pd.confidence < 1.0
+    assert pd.decision_text == "accept"
+    assert pd.forward_precedent_decision_id is None
 
 
 def test_projected_decision_is_frozen() -> None:
@@ -95,12 +100,14 @@ def test_projected_decision_is_frozen() -> None:
         id="p",
         workspace_id="w1",
         run_id="r",
-        sim_tick=0,
-        anchor_object_id="x",
-        payload={},
+        anchor_id="a",
+        tick_id=0,
+        decision_text="noop",
+        confidence=0.0,
+        sub_type="decision_forecast",
     )
     with pytest.raises(FrozenInstanceError):
-        pd.projection_confidence = 0.9  # type: ignore[misc]
+        pd.confidence = 0.9  # type: ignore[misc]
 
 
 def test_projected_decision_requires_workspace_id() -> None:
@@ -108,9 +115,11 @@ def test_projected_decision_requires_workspace_id() -> None:
         ProjectedDecision(  # type: ignore[call-arg]
             id="p",
             run_id="r",
-            sim_tick=0,
-            anchor_object_id="x",
-            payload={},
+            anchor_id="a",
+            tick_id=0,
+            decision_text="noop",
+            confidence=0.0,
+            sub_type="decision_forecast",
         )
 
 

--- a/tests/cloud/test_foresight_projected_decision_router.py
+++ b/tests/cloud/test_foresight_projected_decision_router.py
@@ -1,0 +1,203 @@
+# tests/cloud/test_foresight_projected_decision_router.py — RFC 08 PR 5.
+# Created: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision)
+# — HTTP-layer tests for the per-anchor projection fanout endpoint
+# (``GET /api/v1/foresight/runs/{id}/projected-decisions``).
+"""HTTP-layer tests for the ProjectedDecision list endpoint (PR 5)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.foresight.router import router as foresight_router
+from pocketpaw_ee.cloud.license import require_license
+
+
+def _make_ctx(workspace_id: str | None, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(foresight_router)
+
+    async def _ctx() -> RequestContext:
+        return _make_ctx(workspace_id, user_id)
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def mongo_only(mongo_db: Any):
+    yield mongo_db
+
+
+@pytest_asyncio.fixture
+async def w1_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id="w1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id="w2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def no_ws_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id=None)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "smoke-pd",
+        "sub_type": "decision_forecast",
+        "n_ticks": 2,
+        "personas": [{"name": "Anne", "role": "approver", "ocean": {}}],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_get_projected_decisions_after_post(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/foresight/scenarios", json=_payload(name="renewal-q3"))
+    assert r.status_code == 200, r.text
+    rid = r.json()["id"]
+
+    g = await w1_client.get(f"/foresight/runs/{rid}/projected-decisions")
+    assert g.status_code == 200, g.text
+    body = g.json()
+    assert body["total"] == 2
+    assert body["limit"] == 50
+    assert body["offset"] == 0
+    assert body["has_more"] is False
+    assert len(body["items"]) == 2
+    assert body["items"][0]["run_id"] == rid
+    assert body["items"][0]["forward_precedent_decision_id"] is None
+
+
+async def test_get_projected_decisions_filters_by_anchor(w1_client: AsyncClient) -> None:
+    payload = _payload(
+        name="market-q3",
+        sub_type="market_sim",
+        n_ticks=2,
+        personas=[
+            {"name": "acme", "role": "enterprise", "ocean": {}},
+            {"name": "quickserve", "role": "smb", "ocean": {}},
+        ],
+    )
+    r = await w1_client.post("/foresight/scenarios", json=payload)
+    assert r.status_code == 200, r.text
+    rid = r.json()["id"]
+
+    g = await w1_client.get(
+        f"/foresight/runs/{rid}/projected-decisions",
+        params={"anchor_id": "segment:enterprise"},
+    )
+    assert g.status_code == 200
+    body = g.json()
+    # 1 anchor × 2 ticks
+    assert body["total"] == 2
+    assert all(item["anchor_id"] == "segment:enterprise" for item in body["items"])
+
+
+async def test_get_projected_decisions_paginates(w1_client: AsyncClient) -> None:
+    payload = _payload(
+        name="rollout-paged",
+        sub_type="org_change_rehearsal",
+        n_ticks=4,
+        personas=[{"name": "x", "role": "manager", "ocean": {}}],
+    )
+    r = await w1_client.post("/foresight/scenarios", json=payload)
+    rid = r.json()["id"]
+
+    page1 = await w1_client.get(
+        f"/foresight/runs/{rid}/projected-decisions",
+        params={"limit": 5, "offset": 0},
+    )
+    assert page1.status_code == 200
+    body1 = page1.json()
+    assert body1["total"] == 16  # 4 anchors × 4 ticks
+    assert len(body1["items"]) == 5
+    assert body1["has_more"] is True
+
+    page2 = await w1_client.get(
+        f"/foresight/runs/{rid}/projected-decisions",
+        params={"limit": 5, "offset": 10},
+    )
+    body2 = page2.json()
+    assert body2["offset"] == 10
+    assert len(body2["items"]) == 5
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+async def test_get_404_for_unknown_run(w1_client: AsyncClient) -> None:
+    r = await w1_client.get("/foresight/runs/5f50c31b1c9d440000000000/projected-decisions")
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "foresight_run.not_found"
+
+
+async def test_get_404_for_malformed_run_id(w1_client: AsyncClient) -> None:
+    r = await w1_client.get("/foresight/runs/not-an-objectid/projected-decisions")
+    assert r.status_code == 404
+
+
+async def test_get_404_for_cross_tenant_run(w1_client: AsyncClient, w2_client: AsyncClient) -> None:
+    """A run created in w1 must surface as 404 from w2 — existence
+    isn't cross-tenant leakable on the projected-decisions endpoint
+    any more than on the run-detail endpoint."""
+    r = await w1_client.post("/foresight/scenarios", json=_payload(name="ws1-only"))
+    rid = r.json()["id"]
+
+    g = await w2_client.get(f"/foresight/runs/{rid}/projected-decisions")
+    assert g.status_code == 404
+
+
+async def test_get_403_without_workspace(no_ws_client: AsyncClient) -> None:
+    r = await no_ws_client.get("/foresight/runs/5f50c31b1c9d440000000000/projected-decisions")
+    assert r.status_code == 403
+
+
+async def test_get_422_on_invalid_limit(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/foresight/scenarios", json=_payload())
+    rid = r.json()["id"]
+    g = await w1_client.get(f"/foresight/runs/{rid}/projected-decisions", params={"limit": 0})
+    assert g.status_code == 422
+
+
+async def test_get_422_on_invalid_offset(w1_client: AsyncClient) -> None:
+    r = await w1_client.post("/foresight/scenarios", json=_payload())
+    rid = r.json()["id"]
+    g = await w1_client.get(f"/foresight/runs/{rid}/projected-decisions", params={"offset": -1})
+    assert g.status_code == 422

--- a/tests/cloud/test_foresight_projected_decision_service.py
+++ b/tests/cloud/test_foresight_projected_decision_service.py
@@ -1,0 +1,291 @@
+# tests/cloud/test_foresight_projected_decision_service.py — RFC 08 PR 5.
+# Created: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision)
+# — service-level tests for the per-anchor projection fanout under
+# ``ee.cloud.foresight.service.emit_projected_decision`` +
+# ``list_projected_decisions``.
+"""Tests for the ProjectedDecision service surface (RFC §7.7 + PR 5)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound, ValidationError
+from pocketpaw_ee.cloud._core.realtime.events import (
+    ForesightProjectedDecisionEmitted,
+)
+from pocketpaw_ee.cloud.foresight import service as foresight_service
+from pocketpaw_ee.cloud.foresight.dto import (
+    CreateScenarioRequest,
+    PersonaSpecRequest,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace: str | None = "w1", user: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _body(
+    *,
+    name: str = "renewal-forecast",
+    sub_type: str = "decision_forecast",
+    n_ticks: int = 1,
+    personas: list[PersonaSpecRequest] | None = None,
+) -> CreateScenarioRequest:
+    return CreateScenarioRequest(
+        name=name,
+        sub_type=sub_type,
+        n_ticks=n_ticks,
+        personas=personas
+        or [
+            PersonaSpecRequest(name="Anne", role="approver", ocean={}),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-tick emission via the engine callback
+# ---------------------------------------------------------------------------
+
+
+async def test_create_scenario_run_fans_per_anchor_projections(recording_bus) -> None:
+    """A Decision Forecast run with n_ticks=2 produces one anchor × 2
+    ticks = 2 projected-decision records."""
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(ctx, _body(name="renewal", n_ticks=2))
+    assert run.status == "complete"
+
+    listing = await foresight_service.list_projected_decisions(ctx, run.id)
+    assert listing.total == 2
+    assert len(listing.items) == 2
+    assert all(item.run_id == run.id for item in listing.items)
+    assert all(item.anchor_id == "decision:renewal" for item in listing.items)
+    # Tick ids in order (the index keeps the sort stable).
+    assert [item.tick_id for item in listing.items] == [0, 1]
+    # Sub_type echoes back through every record.
+    assert all(item.sub_type == "decision_forecast" for item in listing.items)
+    # forward_precedent_decision_id is stubbed None per PR brief.
+    assert all(item.forward_precedent_decision_id is None for item in listing.items)
+
+
+async def test_market_sim_run_fans_per_segment_projections() -> None:
+    """Market Sim with 2 segments × 2 ticks = 4 records, one per
+    (segment × tick) bucket."""
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(
+        ctx,
+        _body(
+            name="market-q3",
+            sub_type="market_sim",
+            n_ticks=2,
+            personas=[
+                PersonaSpecRequest(name="acme", role="enterprise"),
+                PersonaSpecRequest(name="globex", role="enterprise"),
+                PersonaSpecRequest(name="quickserve", role="smb"),
+            ],
+        ),
+    )
+    listing = await foresight_service.list_projected_decisions(ctx, run.id)
+    assert listing.total == 4  # 2 unique segments × 2 ticks
+    anchors = {item.anchor_id for item in listing.items}
+    assert anchors == {"segment:enterprise", "segment:smb"}
+
+
+async def test_org_change_run_fans_per_rollout_event_projections() -> None:
+    """Org Change with 4 ticks always fans 4 anchors × 4 ticks = 16 records."""
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(
+        ctx,
+        _body(
+            name="policy-rollout",
+            sub_type="org_change_rehearsal",
+            n_ticks=4,
+            personas=[
+                PersonaSpecRequest(name="m1", role="manager"),
+                PersonaSpecRequest(name="ic1", role="ic"),
+            ],
+        ),
+    )
+    listing = await foresight_service.list_projected_decisions(ctx, run.id, limit=100)
+    # 4 anchors × 4 ticks
+    assert listing.total == 16
+    anchors = {item.anchor_id for item in listing.items}
+    assert anchors == {
+        "rollout:announce",
+        "rollout:training",
+        "rollout:deadline",
+        "rollout:escalation",
+    }
+
+
+async def test_create_scenario_emits_projected_decision_event(recording_bus) -> None:
+    """The per-tick callback emits ``ForesightProjectedDecisionEmitted``
+    so the Live panel can render the timeline without polling."""
+    ctx = _ctx()
+    await foresight_service.create_scenario_run(ctx, _body(name="event-stream", n_ticks=3))
+    emitted = [e for e in recording_bus.events if isinstance(e, ForesightProjectedDecisionEmitted)]
+    # Decision Forecast = 1 anchor × 3 ticks
+    assert len(emitted) == 3
+    assert all(e.data["anchor_id"] == "decision:event-stream" for e in emitted)
+
+
+# ---------------------------------------------------------------------------
+# list_projected_decisions: pagination + filter + tenancy
+# ---------------------------------------------------------------------------
+
+
+async def test_list_filters_by_anchor_id() -> None:
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(
+        ctx,
+        _body(
+            name="market-filter",
+            sub_type="market_sim",
+            n_ticks=2,
+            personas=[
+                PersonaSpecRequest(name="acme", role="enterprise"),
+                PersonaSpecRequest(name="quickserve", role="smb"),
+            ],
+        ),
+    )
+    listing = await foresight_service.list_projected_decisions(
+        ctx, run.id, anchor_id="segment:enterprise"
+    )
+    assert listing.total == 2
+    assert all(item.anchor_id == "segment:enterprise" for item in listing.items)
+
+
+async def test_list_paginates_with_offset_and_limit() -> None:
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(
+        ctx,
+        _body(
+            name="paged",
+            sub_type="org_change_rehearsal",
+            n_ticks=4,
+            personas=[PersonaSpecRequest(name="x", role="manager")],
+        ),
+    )
+    page1 = await foresight_service.list_projected_decisions(ctx, run.id, limit=5)
+    assert len(page1.items) == 5
+    assert page1.has_more is True
+    assert page1.total == 16
+
+    page2 = await foresight_service.list_projected_decisions(ctx, run.id, limit=5, offset=5)
+    assert len(page2.items) == 5
+    assert page2.offset == 5
+
+    last_page = await foresight_service.list_projected_decisions(ctx, run.id, limit=10, offset=10)
+    # Only 6 records remain after offset 10 in a 16-record set.
+    assert len(last_page.items) == 6
+    assert last_page.has_more is False
+
+
+async def test_list_unknown_run_returns_404() -> None:
+    ctx = _ctx()
+    with pytest.raises(NotFound):
+        await foresight_service.list_projected_decisions(ctx, "5f50c31b1c9d440000000000")
+
+
+async def test_list_malformed_run_id_returns_404() -> None:
+    ctx = _ctx()
+    with pytest.raises(NotFound):
+        await foresight_service.list_projected_decisions(ctx, "not-an-objectid")
+
+
+async def test_list_cross_tenant_run_returns_404() -> None:
+    """A run created in w1 must be invisible from w2 even on the
+    projection-list endpoint — same collapsing rule the get endpoint
+    uses so existence isn't cross-tenant leakable."""
+    ctx_w1 = _ctx(workspace="w1")
+    ctx_w2 = _ctx(workspace="w2")
+    run = await foresight_service.create_scenario_run(ctx_w1, _body(name="tenant-isolated"))
+    with pytest.raises(NotFound):
+        await foresight_service.list_projected_decisions(ctx_w2, run.id)
+
+
+async def test_list_requires_workspace() -> None:
+    ctx = _ctx(workspace=None)
+    with pytest.raises(Forbidden):
+        await foresight_service.list_projected_decisions(ctx, "0" * 24)
+
+
+async def test_list_invalid_limit_raises() -> None:
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(ctx, _body())
+    with pytest.raises(ValidationError):
+        await foresight_service.list_projected_decisions(ctx, run.id, limit=0)
+
+
+async def test_list_invalid_offset_raises() -> None:
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(ctx, _body())
+    with pytest.raises(ValidationError):
+        await foresight_service.list_projected_decisions(ctx, run.id, offset=-1)
+
+
+async def test_list_caps_limit_at_500() -> None:
+    """A request that asks for 10000 records is silently capped at 500
+    so a misconfigured caller can't drag the whole collection into
+    memory."""
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(ctx, _body())
+    listing = await foresight_service.list_projected_decisions(ctx, run.id, limit=10000)
+    assert listing.limit == 500
+
+
+# ---------------------------------------------------------------------------
+# emit_projected_decision — direct callable, used by the engine closure
+# ---------------------------------------------------------------------------
+
+
+async def test_emit_projected_decision_persists_record(recording_bus) -> None:
+    """The emit function is the engine callback's target — it persists
+    one document + emits one event."""
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(ctx, _body(name="seed"))
+
+    # Direct emit — simulates a future caller that constructs anchors
+    # outside the runner loop (e.g. v1.0's calibration-loop wiring).
+    record = await foresight_service.emit_projected_decision(
+        workspace_id="w1",
+        run_id=run.id,
+        anchor_id="custom:anchor",
+        persona_id="p1",
+        tick_id=99,
+        decision_text="accept",
+        confidence=0.8,
+        sub_type="decision_forecast",
+    )
+    assert record.anchor_id == "custom:anchor"
+    assert record.tick_id == 99
+    assert record.workspace_id == "w1"
+
+    # The new record now surfaces via list (filtered by anchor).
+    listing = await foresight_service.list_projected_decisions(
+        ctx, run.id, anchor_id="custom:anchor"
+    )
+    assert listing.total == 1
+
+
+async def test_emit_projected_decision_requires_workspace() -> None:
+    with pytest.raises(Forbidden):
+        await foresight_service.emit_projected_decision(
+            workspace_id="",
+            run_id="r",
+            anchor_id="a",
+            persona_id="",
+            tick_id=0,
+            decision_text="noop",
+            confidence=0.0,
+            sub_type="decision_forecast",
+        )

--- a/tests/cloud/test_foresight_router.py
+++ b/tests/cloud/test_foresight_router.py
@@ -143,7 +143,7 @@ async def test_get_404_on_malformed_id(w1_client: AsyncClient) -> None:
 async def test_post_422_on_unsupported_sub_type(w1_client: AsyncClient) -> None:
     r = await w1_client.post(
         "/foresight/scenarios",
-        json=_payload(sub_type="market_sim"),
+        json=_payload(sub_type="ops_stress_test"),
     )
     # The engine-side validation surfaces as a 422 with the
     # foresight-namespaced error code.

--- a/tests/cloud/test_foresight_service.py
+++ b/tests/cloud/test_foresight_service.py
@@ -92,12 +92,12 @@ async def test_create_emits_created_then_completed(recording_bus) -> None:
 
 async def test_create_rejects_unsupported_sub_type() -> None:
     ctx = _ctx()
-    # ``market_sim`` lands in a later PR; PR 7's engine only supports
-    # ``decision_forecast`` and the service surfaces engine validation
-    # as a 422 before opening a doc row.
+    # PR 5 lifted market_sim + org_change_rehearsal into the supported
+    # set; the next-up sub-type is ops_stress_test (PR 6+). The service
+    # still surfaces engine validation as a 422 before opening a doc row.
     body = CreateScenarioRequest(
-        name="early-market-sim",
-        sub_type="market_sim",
+        name="early-ops-stress",
+        sub_type="ops_stress_test",
         n_ticks=1,
         personas=[PersonaSpecRequest(name="A", role="participant", ocean={})],
     )
@@ -119,7 +119,7 @@ async def test_create_captures_engine_failure_as_failed_status(monkeypatch, reco
     not bubble out as a 500."""
     ctx = _ctx()
 
-    async def _boom(_body):
+    async def _boom(_body, **_kwargs):  # PR 5 added workspace_id + run_id kwargs
         raise RuntimeError("simulated engine outage")
 
     # Patch the lazy engine call (the service's only side door into the

--- a/tests/ee/foresight/test_scenario_smoke.py
+++ b/tests/ee/foresight/test_scenario_smoke.py
@@ -39,10 +39,12 @@ SCENARIO_YAML = (
 
 
 def test_scenario_config_rejects_unsupported_sub_type():
-    with pytest.raises(NotImplementedError, match="market_sim"):
+    # PR 5 lifted market_sim + org_change_rehearsal into the supported
+    # set; the next-up sub-type is ops_stress_test (PR 6+).
+    with pytest.raises(NotImplementedError, match="ops_stress_test"):
         ScenarioConfig(
             name="x",
-            sub_type="market_sim",  # not in v0.1 SUPPORTED_SUB_TYPES
+            sub_type="ops_stress_test",  # not yet in SUPPORTED_SUB_TYPES
             n_ticks=1,
             personas=[PersonaSpec(name="p")],
         )

--- a/tests/ee/foresight/test_subtypes.py
+++ b/tests/ee/foresight/test_subtypes.py
@@ -1,0 +1,287 @@
+# tests/ee/foresight/test_subtypes.py — RFC 08 PR 5.
+# Created: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision)
+# — engine-side tests for the new Market Sim and Org Change Rehearsal
+# sub-type adapters under ``ee.pocketpaw_ee.foresight.subtypes``.
+"""Tests for the sub-type adapters and the end-to-end runner dispatch.
+
+Covers:
+  - ``subtypes.get_adapter`` dispatch on supported / unsupported sub_type.
+  - Per-adapter ``anchors_for`` / ``aggregate`` contracts.
+  - ``run_scenario`` smoke against both new YAML files.
+  - Per-tick projected-decision callback fan-out across anchors.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.foresight.scenarios.runner import (
+    PersonaSpec,
+    ScenarioConfig,
+    run_scenario,
+)
+from pocketpaw_ee.foresight.subtypes import (
+    SUB_TYPE_DECISION_FORECAST,
+    SUB_TYPE_MARKET_SIM,
+    SUB_TYPE_ORG_CHANGE,
+    SUPPORTED_SUB_TYPES,
+    get_adapter,
+)
+
+SCENARIO_DIR = (
+    Path(__file__).resolve().parents[3] / "ee" / "pocketpaw_ee" / "foresight" / "scenarios"
+)
+MARKET_SIM_YAML = SCENARIO_DIR / "market_sim.yaml"
+ORG_CHANGE_YAML = SCENARIO_DIR / "org_change.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_supported_sub_types_carries_v05_set():
+    assert SUB_TYPE_DECISION_FORECAST in SUPPORTED_SUB_TYPES
+    assert SUB_TYPE_MARKET_SIM in SUPPORTED_SUB_TYPES
+    assert SUB_TYPE_ORG_CHANGE in SUPPORTED_SUB_TYPES
+    assert len(SUPPORTED_SUB_TYPES) == 3
+
+
+def test_get_adapter_for_market_sim_returns_module_with_contract():
+    adapter = get_adapter(SUB_TYPE_MARKET_SIM)
+    assert hasattr(adapter, "SUB_TYPE")
+    assert adapter.SUB_TYPE == "market_sim"
+    assert callable(adapter.anchors_for)
+    assert callable(adapter.aggregate)
+
+
+def test_get_adapter_for_org_change_returns_module_with_contract():
+    adapter = get_adapter(SUB_TYPE_ORG_CHANGE)
+    assert adapter.SUB_TYPE == "org_change_rehearsal"
+
+
+def test_get_adapter_for_decision_forecast_returns_passthrough():
+    adapter = get_adapter(SUB_TYPE_DECISION_FORECAST)
+    assert adapter.SUB_TYPE == "decision_forecast"
+
+
+def test_get_adapter_unsupported_raises_with_rfc_pointer():
+    with pytest.raises(NotImplementedError, match="RFC 08"):
+        get_adapter("ops_stress_test")
+
+
+# ---------------------------------------------------------------------------
+# Anchors
+# ---------------------------------------------------------------------------
+
+
+def test_market_sim_anchors_dedupe_by_segment():
+    adapter = get_adapter(SUB_TYPE_MARKET_SIM)
+    config = ScenarioConfig(
+        name="t",
+        sub_type=SUB_TYPE_MARKET_SIM,
+        n_ticks=1,
+        personas=[
+            PersonaSpec(name="a", role="enterprise"),
+            PersonaSpec(name="b", role="enterprise"),
+            PersonaSpec(name="c", role="smb"),
+        ],
+    )
+    anchors = adapter.anchors_for(config)
+    assert anchors == ["segment:enterprise", "segment:smb"]
+
+
+def test_org_change_anchors_emit_fixed_rollout_sequence():
+    adapter = get_adapter(SUB_TYPE_ORG_CHANGE)
+    config = ScenarioConfig(
+        name="t",
+        sub_type=SUB_TYPE_ORG_CHANGE,
+        n_ticks=4,
+        personas=[PersonaSpec(name="x", role="manager")],
+    )
+    anchors = adapter.anchors_for(config)
+    assert anchors == [
+        "rollout:announce",
+        "rollout:training",
+        "rollout:deadline",
+        "rollout:escalation",
+    ]
+
+
+def test_decision_forecast_anchors_default_to_scenario_name():
+    adapter = get_adapter(SUB_TYPE_DECISION_FORECAST)
+    config = ScenarioConfig(
+        name="renewal-q3",
+        sub_type=SUB_TYPE_DECISION_FORECAST,
+        n_ticks=1,
+        personas=[PersonaSpec(name="p", role="approver")],
+    )
+    assert adapter.anchors_for(config) == ["decision:renewal-q3"]
+
+
+# ---------------------------------------------------------------------------
+# Aggregate (empty + populated)
+# ---------------------------------------------------------------------------
+
+
+def test_market_sim_aggregate_empty_returns_total_zero():
+    adapter = get_adapter(SUB_TYPE_MARKET_SIM)
+    config = ScenarioConfig(
+        name="t",
+        sub_type=SUB_TYPE_MARKET_SIM,
+        n_ticks=1,
+        personas=[PersonaSpec(name="a", role="enterprise")],
+    )
+    out = adapter.aggregate([], config)
+    assert out["sub_type"] == "market_sim"
+    assert out["segments"] == {}
+    assert out["totals"]["actions_total"] == 0
+
+
+def test_org_change_aggregate_empty_returns_rollout_zero():
+    adapter = get_adapter(SUB_TYPE_ORG_CHANGE)
+    config = ScenarioConfig(
+        name="t",
+        sub_type=SUB_TYPE_ORG_CHANGE,
+        n_ticks=4,
+        personas=[PersonaSpec(name="x", role="manager")],
+    )
+    out = adapter.aggregate([], config)
+    assert out["sub_type"] == "org_change_rehearsal"
+    assert set(out["rollout"].keys()) == {
+        "rollout:announce",
+        "rollout:training",
+        "rollout:deadline",
+        "rollout:escalation",
+    }
+    assert out["totals"]["escalation_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end runner against YAML — both new sub-types
+# ---------------------------------------------------------------------------
+
+
+async def test_run_scenario_market_sim_from_yaml():
+    assert MARKET_SIM_YAML.exists(), f"missing yaml: {MARKET_SIM_YAML}"
+    config = ScenarioConfig.from_yaml(MARKET_SIM_YAML)
+    assert config.sub_type == "market_sim"
+
+    result = await run_scenario(config)
+    assert result.sub_type == "market_sim"
+    assert result.aggregate["sub_type"] == "market_sim"
+    assert "segments" in result.aggregate
+    # Every declared segment must surface in the aggregate (even when
+    # the deterministic-fake produced zero matching actions for it).
+    declared_segments = {f"segment:{p.role}" for p in config.personas}
+    assert declared_segments.issubset(set(result.aggregate["segments"].keys()))
+
+
+async def test_run_scenario_org_change_from_yaml():
+    assert ORG_CHANGE_YAML.exists(), f"missing yaml: {ORG_CHANGE_YAML}"
+    config = ScenarioConfig.from_yaml(ORG_CHANGE_YAML)
+    assert config.sub_type == "org_change_rehearsal"
+    assert config.n_ticks == 4
+
+    result = await run_scenario(config)
+    assert result.sub_type == "org_change_rehearsal"
+    assert result.aggregate["sub_type"] == "org_change_rehearsal"
+    # The fixed four-step rollout always surfaces as four anchors.
+    assert set(result.aggregate["rollout"].keys()) == {
+        "rollout:announce",
+        "rollout:training",
+        "rollout:deadline",
+        "rollout:escalation",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-tick projected-decision callback
+# ---------------------------------------------------------------------------
+
+
+async def test_run_scenario_fans_one_projection_per_anchor_per_tick():
+    """The callback is invoked exactly once per (anchor × tick) bucket.
+    Market Sim with 2 segments × 2 ticks = 4 callback invocations.
+    """
+    config = ScenarioConfig(
+        name="cb-market-sim",
+        sub_type=SUB_TYPE_MARKET_SIM,
+        n_ticks=2,
+        personas=[
+            PersonaSpec(name="a", role="enterprise"),
+            PersonaSpec(name="b", role="smb"),
+        ],
+    )
+
+    records: list[tuple] = []
+
+    def _capture(anchor_id, persona_id, tick_id, decision_text, confidence, sub_type):
+        records.append((anchor_id, persona_id, tick_id, decision_text, confidence, sub_type))
+
+    result = await run_scenario(config, on_projected_decision=_capture)
+
+    # 2 segments × 2 ticks
+    assert len(records) == 4
+    # Every record carries the sub_type echo.
+    assert all(r[5] == "market_sim" for r in records)
+    # Anchors are the dedupe'd segment set.
+    anchors_in_records = {r[0] for r in records}
+    assert anchors_in_records == {"segment:enterprise", "segment:smb"}
+    # Confidence is bounded.
+    assert all(0.0 <= r[4] <= 1.0 for r in records)
+    # The result also surfaces them on the dataclass.
+    assert len(result.projected_decisions) == 4
+
+
+async def test_run_scenario_supports_async_callback():
+    """The callback may be an async function — the runner awaits the
+    return value when it's a coroutine."""
+    config = ScenarioConfig(
+        name="async-cb",
+        sub_type=SUB_TYPE_DECISION_FORECAST,
+        n_ticks=2,
+        personas=[PersonaSpec(name="p", role="approver")],
+    )
+
+    awaited: list[str] = []
+
+    async def _async_capture(anchor_id, persona_id, tick_id, decision_text, confidence, sub_type):
+        awaited.append(anchor_id)
+
+    result = await run_scenario(config, on_projected_decision=_async_capture)
+    # Decision Forecast has one anchor (the scenario name) × 2 ticks
+    assert len(awaited) == 2
+    assert len(result.projected_decisions) == 2
+
+
+async def test_run_scenario_without_callback_still_surfaces_records():
+    """The callback is optional — the result still carries the
+    projected_decisions list so CLI callers can read them."""
+    config = ScenarioConfig(
+        name="no-cb",
+        sub_type=SUB_TYPE_DECISION_FORECAST,
+        n_ticks=1,
+        personas=[PersonaSpec(name="p", role="approver")],
+    )
+    result = await run_scenario(config)
+    assert len(result.projected_decisions) == 1
+    rec = result.projected_decisions[0]
+    assert rec["anchor_id"] == "decision:no-cb"
+    assert rec["sub_type"] == "decision_forecast"
+
+
+async def test_run_result_as_wire_dict_includes_aggregate_and_projections():
+    config = ScenarioConfig(
+        name="wire",
+        sub_type=SUB_TYPE_MARKET_SIM,
+        n_ticks=1,
+        personas=[PersonaSpec(name="a", role="enterprise")],
+    )
+    result = await run_scenario(config)
+    wire = result.as_wire_dict()
+    assert wire["sub_type"] == "market_sim"
+    assert "aggregate" in wire
+    assert "projected_decisions" in wire
+    assert wire["aggregate"]["sub_type"] == "market_sim"


### PR DESCRIPTION
## Summary

Lands three RFC 08 deliverables on top of the foresight integration branch:

- **Market Sim sub-type** (RFC §4.2) — competitor + customer-segment personas, per-segment aggregator emitting win_rate / churn_rate / market position. New YAML + adapter.
- **Org Change Rehearsal sub-type** (RFC §4.3) — internal-role personas ticked against a fixed announce → training → deadline → escalation rollout sequence; aggregator emits per-event adoption_rate / resistance_rate / exit_rate / escalation_count.
- **Per-anchor ProjectedDecision fanout** (RFC §7.7) — the per-tick projection emission that PR 7 and PR 4 both deferred. New Beanie collection (`foresight_projected_decisions`), new service emit + list functions, new GET endpoint, new event.

## Engine changes

- `ee/pocketpaw_ee/foresight/subtypes/` — new package with one module per sub-type. Each adapter exposes `SUB_TYPE`, `anchors_for(config)`, and `aggregate(snapshots, config)`. `get_adapter(sub_type)` dispatches lazily so the engine import surface stays small.
- `ScenarioConfig.SUPPORTED_SUB_TYPES` lifted to the three v0.5 sub-types. ops_stress_test / strategic_what_if / training_rehearsal / discovery_generative land in PR 6+.
- `RunResult.aggregate` carries the sub-type outcome dict; `RunResult.projected_decisions` surfaces the per-tick records for CLI callers. `as_wire_dict` echoes `modal_outcome` at the top so PR 4's backtest scoring path keeps working unchanged.
- `run_scenario` takes an optional `on_projected_decision` callback and a `run_id`. The callback may be sync or async — the runner awaits when it returns a coroutine. Anchor selection is the adapter's responsibility; the runner stays sub-type-agnostic and emits one record per (anchor × tick) bucket using the modal action verb across the tick's successful actions.

## Cloud changes

- `ee/pocketpaw_ee/cloud/models/foresight_projected_decision.py` — new Beanie doc + collection. Two indexes: `(workspace, run_id, tick_id, anchor_id)` for the per-run list query, `(workspace, anchor_id, tick_id)` for the future Decision Graph join.
- `ee.cloud.foresight.service.emit_projected_decision(...)` — the target of the engine callback. Persists one document, emits `ForesightProjectedDecisionEmitted`.
- `ee.cloud.foresight.service.list_projected_decisions(ctx, run_id, anchor_id=None, limit=50, offset=0)` — paginated read. Tenancy enforced via `_fetch_in_workspace` so unknown / cross-tenant run ids collapse to 404 before the projection query runs.
- `_run_engine_inline` now accepts `workspace_id` + `run_id` and wires the per-tick callback as a closure. The closure captures the workspace, so the engine still doesn't statically import the cloud layer — the import-linter contract holds.
- New endpoint: `GET /api/v1/foresight/runs/{id}/projected-decisions` with optional `anchor_id` query filter. Offset-based pagination; `limit` capped at 500. Response envelope carries `items / total / limit / offset / has_more`.
- `forward_precedent_decision_id` stubbed `None` per the brief. RFC 07's Decision Graph isn't in pocketpaw yet (scaffold lives at `/tmp/team-rfc07`); the field reserves the wire shape for the future backfill pass.

## Test plan

- [x] `tests/ee/foresight/test_subtypes.py` — 16 tests covering adapter dispatch, anchors_for / aggregate contracts, YAML round-trip, per-tick callback (sync + async), wire dict shape.
- [x] `tests/cloud/test_foresight_projected_decision_service.py` — 15 tests covering create → emit → list, pagination, anchor filter, tenancy isolation, all error paths.
- [x] `tests/cloud/test_foresight_projected_decision_router.py` — 9 HTTP-layer tests covering happy path, 404 (unknown / malformed / cross-tenant), 403 (no workspace), 422 (bad query params).
- [x] Full foresight touched suite (`tests/ee/foresight/` + `tests/cloud/test_foresight_*`): 306 passed.
- [x] `pytest --collect-only -q`: 5454 tests collected, no errors.
- [x] `ruff check` + `ruff format --check` clean on changed files.
- [x] `mypy` clean on changed files.
- [x] `lint-imports`: 18 contracts kept (Foresight Beanie writes + Foresight cloud / engine separation both updated to cover the new ProjectedDecision doc and the subtypes package).

## Out of scope

- RFC 07 Decision Graph wiring — `forward_precedent_decision_id` is reserved but unpopulated.
- ops_stress_test, strategic_what_if, training_rehearsal, discovery_generative — PR 6+.
- Backtest runs do not fan ProjectedDecisions in v0.5 — the GET endpoint is scoped to forward runs (`/runs/{id}/projected-decisions`).
- Frontend integration of the new endpoint — paw-enterprise PR 6 lane.