### PR TITLE
feat(foresight): RFC 08 §14.4 — DecisionGraphRef protocol + NoOp default

### DIFF
--- a/ee/pocketpaw_ee/foresight/__init__.py
+++ b/ee/pocketpaw_ee/foresight/__init__.py
@@ -1,4 +1,10 @@
 # ee/pocketpaw_ee/foresight/__init__.py
+# Updated: 2026-05-25 (feat/foresight-v14-decision-graph-stub) — RFC 08
+# §14.4 wiring:
+#   - Lazy-export surface grew: DecisionGraphRef (protocol),
+#     NoOpDecisionGraphRef (v0.5 default implementation),
+#     SYNTHETIC_PRECEDENT_PREFIX (id-format constant for downstream
+#     code that distinguishes synthetic from real precedent ids).
 # Updated: 2026-05-25 (feat/foresight-v04-backtest-aggregator) — PR 4:
 #   - Bumped __version__ to 0.4.0 — aggregator primitives shipped at
 #     ``foresight/aggregator.py`` and the cloud-side backtest gate
@@ -63,14 +69,17 @@ __all__ = [
     "ClaudeCodeBackend",
     "ConfidenceDrift",
     "Correction",
+    "DecisionGraphRef",
     "DeterministicFakeBackend",
     "ForesightWorld",
     "LiteLLMFallbackBackend",
     "ModalOutcomeDistribution",
+    "NoOpDecisionGraphRef",
     "OceanDrift",
     "PredictionBuffer",
     "PredictionRecord",
     "RunResult",
+    "SYNTHETIC_PRECEDENT_PREFIX",
     "ScenarioConfig",
     "SoulSeededPersona",
     "ThresholdDecision",
@@ -108,6 +117,18 @@ def __getattr__(name: str):  # pragma: no cover — lazy import shim
         from pocketpaw_ee.foresight.world import ForesightWorld
 
         return ForesightWorld
+    if name in {"DecisionGraphRef", "NoOpDecisionGraphRef", "SYNTHETIC_PRECEDENT_PREFIX"}:
+        from pocketpaw_ee.foresight.decision_graph_ref import (
+            SYNTHETIC_PRECEDENT_PREFIX,
+            DecisionGraphRef,
+            NoOpDecisionGraphRef,
+        )
+
+        return {
+            "DecisionGraphRef": DecisionGraphRef,
+            "NoOpDecisionGraphRef": NoOpDecisionGraphRef,
+            "SYNTHETIC_PRECEDENT_PREFIX": SYNTHETIC_PRECEDENT_PREFIX,
+        }[name]
     if name in {"SoulSeededPersona", "OceanDrift", "make_paw_social_agent"}:
         from pocketpaw_ee.foresight.persona import (
             OceanDrift,

--- a/ee/pocketpaw_ee/foresight/decision_graph_ref.py
+++ b/ee/pocketpaw_ee/foresight/decision_graph_ref.py
@@ -1,0 +1,157 @@
+# ee/pocketpaw_ee/foresight/decision_graph_ref.py
+# Created: 2026-05-25 (feat/foresight-v14-decision-graph-stub) — RFC 08
+# §14.4 wiring stub. The engine layer needs a forward-precedent edge to
+# attach to every ``ProjectedDecision`` it emits, but RFC 07's Decision
+# Graph implementation is not yet in pocketpaw (the scaffold lives at
+# /tmp/team-rfc07; production-izing it is a separate stream). To keep
+# v0.5 unblocked we introduce a thin protocol the runner consumes — the
+# real RFC 07 wiring will drop in by registering an implementation that
+# returns Decision-Graph short-ids instead of synthetic ones.
+#
+# Public surface:
+#   - ``DecisionGraphRef`` (Protocol) — the lookup contract.
+#   - ``NoOpDecisionGraphRef`` — the default implementation v0.5 ships.
+#     Synthesizes deterministic precedent ids from a scenario seed +
+#     anchor + persona triple. When the scenario carries no seed at all
+#     it returns ``None``, preserving the v0.1 "field always None"
+#     wire-shape contract for un-seeded smoke runs.
+#
+# Why a protocol and not a concrete class:
+#   - The runner imports the protocol type but does not depend on the
+#     concrete NoOp. Tests can swap in a fake that returns canned ids,
+#     and the future RFC 07 wiring drops in a real implementation by
+#     constructing a different ``DecisionGraphRef``-conforming instance
+#     and passing it into ``run_scenario(decision_graph_ref=...)``.
+#   - The wire shape never changes — ``ProjectedDecision.forward_precedent_decision_id``
+#     is already ``str | None`` on the cloud domain. When RFC 07 lands,
+#     the only delta is which instance the cloud injects; persisted
+#     documents and DTOs are unaffected.
+
+from __future__ import annotations
+
+from hashlib import sha1
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "DecisionGraphRef",
+    "NoOpDecisionGraphRef",
+    "SYNTHETIC_PRECEDENT_PREFIX",
+]
+
+# Short prefix on synthesized ids so consumers can distinguish them
+# from real Decision-Graph short-ids (which carry their own scheme —
+# typically ``dec_<base32>`` per the RFC 07 scaffold). UI surfaces can
+# render synthetic ids with a "stubbed precedent" badge until real
+# Decision-Graph wiring lands; the cloud-side backfill pass that
+# replaces these with real ids is mechanical (look up the real short-id
+# by anchor/persona/scenario and update the row in place).
+SYNTHETIC_PRECEDENT_PREFIX = "synthetic-precedent-"
+
+
+@runtime_checkable
+class DecisionGraphRef(Protocol):
+    """Forward-precedent lookup contract for the Foresight runner.
+
+    The runner calls ``lookup_precedent`` once per ``ProjectedDecision``
+    it emits. The returned id (when not ``None``) populates
+    ``ProjectedDecision.forward_precedent_decision_id`` on the engine
+    wire shape (``RunResult.projected_decisions[i]``) — the same field
+    persisted on ``foresight_projected_decisions`` once the cloud-side
+    backfill lands.
+
+    Implementations:
+
+    - :class:`NoOpDecisionGraphRef` (v0.5 default) — deterministic
+      synthetic ids derived from the scenario seed. Returns ``None``
+      when no seed is configured.
+    - Future RFC 07 ``DecisionGraphProjection`` — will lookup a real
+      ``Decision`` by anchor + persona + scope in the persisted
+      decision graph and return its short-id. Lives in pocketpaw once
+      the RFC 07 productionization stream merges (currently parked at
+      ``/tmp/team-rfc07``). Drop-in replacement: no engine changes
+      required.
+    """
+
+    def lookup_precedent(
+        self,
+        anchor_id: str,
+        persona_id: str,
+        scenario_id: str,
+    ) -> str | None:
+        """Return the precedent decision id for this projection bucket,
+        or ``None`` when no precedent applies.
+
+        Implementations must be **pure** w.r.t. their inputs — the
+        runner invokes this once per (anchor × tick) bucket on every
+        scenario run, and the cloud-side replay path expects stable
+        outputs given identical inputs so backfill jobs are idempotent.
+
+        Args:
+            anchor_id: the projection's anchor id — sub-type-specific
+                (``decision:<name>`` / ``segment:<role>`` /
+                ``rollout:<event>``).
+            persona_id: the modal persona's id (str(UUID)). The runner
+                passes an empty string when no persona acted on this
+                bucket; implementations may treat the empty string as
+                "no persona context" rather than a real id.
+            scenario_id: the running scenario's stable identifier (the
+                scenario name in v0.5; future versions may switch to a
+                scenario-graph short-id once RFC 07 lands).
+        """
+        ...
+
+
+class NoOpDecisionGraphRef:
+    """Default :class:`DecisionGraphRef` for v0.5.
+
+    Synthesizes deterministic precedent ids by hashing the
+    (scenario_id, anchor_id, persona_id, seed) tuple with SHA-1 and
+    truncating to 12 hex chars. Same inputs always produce the same
+    id — UI dev and replay-style tests can rely on the projection
+    carrying a stable, non-None value as long as a seed is configured.
+
+    Algorithm:
+
+      .. code-block:: text
+
+          precedent_id = "synthetic-precedent-" + sha1(
+              scenario_id + "|" + anchor_id + "|" + persona_id + "|" + seed
+          ).hexdigest()[:12]
+
+    Returns ``None`` when ``seed`` is the empty string. This preserves
+    the v0.1 behavior for un-seeded scenarios — the field is "absent" in
+    the wire dict (carries ``None``) and the cloud-side persistence
+    keeps its current hardcoded ``None`` until the RFC 07 backfill ships.
+
+    The class accepts an optional ``per_anchor_seeds`` mapping that
+    overrides the scenario-level ``seed`` for specific anchors. This
+    matches the YAML grammar v14 introduces: a scenario can declare a
+    global ``precedent_seed`` plus a ``precedent_seeds: {anchor_id:
+    seed}`` map for anchor-level overrides.
+    """
+
+    def __init__(
+        self,
+        seed: str = "",
+        *,
+        per_anchor_seeds: dict[str, str] | None = None,
+    ) -> None:
+        self._seed = seed
+        # Copy to defend against external mutation — the runner builds
+        # one NoOp per run and reuses it across (anchor × tick) calls.
+        self._per_anchor_seeds: dict[str, str] = dict(per_anchor_seeds or {})
+
+    def lookup_precedent(
+        self,
+        anchor_id: str,
+        persona_id: str,
+        scenario_id: str,
+    ) -> str | None:
+        # Per-anchor override wins; empty-string override falls back to
+        # the scenario seed (matches "remove override" semantics).
+        seed = self._per_anchor_seeds.get(anchor_id) or self._seed
+        if not seed:
+            return None
+        payload = f"{scenario_id}|{anchor_id}|{persona_id}|{seed}".encode()
+        digest = sha1(payload).hexdigest()[:12]  # noqa: S324 — non-crypto id derivation
+        return f"{SYNTHETIC_PRECEDENT_PREFIX}{digest}"

--- a/ee/pocketpaw_ee/foresight/scenarios/decision_forecast.yaml
+++ b/ee/pocketpaw_ee/foresight/scenarios/decision_forecast.yaml
@@ -1,4 +1,17 @@
 # ee/pocketpaw_ee/foresight/scenarios/decision_forecast.yaml
+# Updated: 2026-05-25 (feat/foresight-v14-decision-graph-stub) — RFC 08
+# §14.4 wiring. Two new optional scenario-root fields:
+#   - ``precedent_seed`` (string | null): scenario-wide seed the engine's
+#     DecisionGraphRef hashes into deterministic synthetic precedent
+#     ids on every emitted ProjectedDecision. Omit (or null) to keep
+#     ``forward_precedent_decision_id`` ``None`` (v0.1 behavior).
+#   - ``precedent_seeds`` (map | null): per-anchor overrides keyed by
+#     anchor_id (``decision:<name>`` / ``segment:<role>`` /
+#     ``rollout:<event>``). Anchor-level wins when both blocks are set.
+# Both fields stay absent in this smoke scenario by default — the
+# default loop is precedent-free until RFC 07 lands real Decision-Graph
+# lookup. Operators wanting synthetic ids for UI/dev work can add
+# ``precedent_seed: "abc"`` here.
 # Updated: 2026-05-25 (feat/foresight-v03-calibration) — PR 3:
 #   - Added the optional ``tier_mix:`` block. The 5/15/80 captain-
 #     locked default is implicit when the block is omitted; declaring

--- a/ee/pocketpaw_ee/foresight/scenarios/market_sim.yaml
+++ b/ee/pocketpaw_ee/foresight/scenarios/market_sim.yaml
@@ -1,4 +1,12 @@
 # ee/pocketpaw_ee/foresight/scenarios/market_sim.yaml
+# Updated: 2026-05-25 (feat/foresight-v14-decision-graph-stub) — RFC 08
+# §14.4 wiring. Optional scenario-root fields:
+#   - ``precedent_seed`` (string | null): scenario-wide seed the engine's
+#     DecisionGraphRef hashes into synthetic forward-precedent ids for
+#     every emitted ProjectedDecision.
+#   - ``precedent_seeds`` (map | null): per-anchor overrides keyed by
+#     anchor_id (``segment:<role>``). Anchor-level wins.
+# Absent by default — synthetic ids only surface when a scenario opts in.
 # Created: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) —
 # RFC 08 PR 5. Market Sim sub-type smoke scenario — RFC §4.2.
 #

--- a/ee/pocketpaw_ee/foresight/scenarios/org_change.yaml
+++ b/ee/pocketpaw_ee/foresight/scenarios/org_change.yaml
@@ -1,4 +1,12 @@
 # ee/pocketpaw_ee/foresight/scenarios/org_change.yaml
+# Updated: 2026-05-25 (feat/foresight-v14-decision-graph-stub) — RFC 08
+# §14.4 wiring. Optional scenario-root fields:
+#   - ``precedent_seed`` (string | null): scenario-wide seed the engine's
+#     DecisionGraphRef hashes into synthetic forward-precedent ids on
+#     every emitted ProjectedDecision.
+#   - ``precedent_seeds`` (map | null): per-anchor overrides keyed by
+#     anchor_id (``rollout:<event>``). Anchor-level wins.
+# Absent by default — synthetic ids only surface when a scenario opts in.
 # Created: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) —
 # RFC 08 PR 5. Org Change Rehearsal sub-type smoke scenario — RFC §4.3.
 #

--- a/ee/pocketpaw_ee/foresight/scenarios/runner.py
+++ b/ee/pocketpaw_ee/foresight/scenarios/runner.py
@@ -1,4 +1,33 @@
 # ee/pocketpaw_ee/foresight/scenarios/runner.py
+# Updated: 2026-05-25 (feat/foresight-v14-decision-graph-stub) — RFC 08
+# §14.4 wiring:
+#   - ``ScenarioConfig`` grows two optional fields: ``precedent_seed``
+#     (scenario-level seed for synthetic precedent ids) and
+#     ``precedent_seeds`` (anchor-level override map; anchor-level wins
+#     when set). Both default to ``None`` / empty so existing scenarios
+#     are unaffected.
+#   - ``ScenarioConfig.from_yaml`` parses both blocks — scenario-root
+#     ``precedent_seed:`` and the optional ``precedent_seeds:`` map of
+#     ``{anchor_id: seed}``. Documented in market_sim.yaml /
+#     org_change.yaml / decision_forecast.yaml.
+#   - ``run_scenario`` accepts ``decision_graph_ref: DecisionGraphRef``;
+#     defaults to ``NoOpDecisionGraphRef`` seeded from the config. Each
+#     per-anchor projected record now carries a
+#     ``forward_precedent_decision_id`` field — ``None`` when no seed
+#     is configured (preserves the v0.1 behavior), a deterministic
+#     synthetic id when a seed is configured.
+#   - The ``on_projected_decision`` callback signature is **unchanged**
+#     at 6 args (anchor, persona, tick, decision, confidence, sub_type)
+#     to preserve compatibility with the cloud's existing closure in
+#     ``cloud/foresight/service.py`` and the §8 approval-bridge lane.
+#     The precedent id surfaces on ``RunResult.projected_decisions``
+#     (engine wire shape) so callers consuming the result dataclass
+#     directly get the new field immediately; the cloud-side
+#     persistence backfill is a follow-up stream that will populate
+#     the same field on the Mongo doc.
+#   - When RFC 07 actually lands in pocketpaw, the cloud injects a
+#     real DecisionGraphRef into ``run_scenario`` (the
+#     NoOpDecisionGraphRef is replaced; no wire-shape change).
 # Updated: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) — PR 5:
 #   - ``SUPPORTED_SUB_TYPES`` lifted to include ``market_sim`` and
 #     ``org_change_rehearsal`` alongside ``decision_forecast``. The
@@ -55,6 +84,10 @@ from uuid import uuid4
 
 import yaml  # type: ignore[import-untyped]
 
+from pocketpaw_ee.foresight.decision_graph_ref import (
+    DecisionGraphRef,
+    NoOpDecisionGraphRef,
+)
 from pocketpaw_ee.foresight.llm.adapter import DeterministicFakeBackend
 from pocketpaw_ee.foresight.llm.tier_pool import TierMix, tier_distribution
 from pocketpaw_ee.foresight.persona import OceanDrift, SoulSeededPersona
@@ -103,6 +136,15 @@ class ScenarioConfig:
     n_ticks: int = 1
     personas: list[PersonaSpec] = field(default_factory=list)
     tier_mix: TierMix | None = None
+    # v14 — RFC 08 §14.4 forward-precedent seed plumbing. The scenario
+    # carries an optional global seed plus an optional per-anchor
+    # override map; the runner constructs a NoOpDecisionGraphRef from
+    # both when the caller doesn't supply a real DecisionGraphRef. When
+    # both are absent the runner still attaches a NoOp, and the lookup
+    # returns ``None`` so ``forward_precedent_decision_id`` keeps its
+    # v0.1 "always None" wire-shape behavior for un-seeded scenarios.
+    precedent_seed: str | None = None
+    precedent_seeds: dict[str, str] = field(default_factory=dict)
 
     # PR 5 lifts the supported set to the three sub-types v0.5 ships
     # (decision_forecast + market_sim + org_change_rehearsal). The
@@ -155,12 +197,28 @@ class ScenarioConfig:
                 mid=float(tier_mix_block.get("mid", 0.15)),
                 tail=float(tier_mix_block.get("tail", 0.80)),
             )
+        # v14 — optional forward-precedent seeds. The scenario-root
+        # ``precedent_seed:`` is the global default; the optional
+        # ``precedent_seeds:`` map carries anchor-level overrides. Both
+        # are normalized to strings here so the NoOp lookup contract
+        # (which treats the empty string as "no seed configured")
+        # stays uniform.
+        raw_seed = data.get("precedent_seed")
+        precedent_seed: str | None = str(raw_seed) if raw_seed not in (None, "") else None
+        precedent_seeds_block = data.get("precedent_seeds") or {}
+        precedent_seeds: dict[str, str] = {
+            str(anchor_id): str(seed)
+            for anchor_id, seed in precedent_seeds_block.items()
+            if seed not in (None, "")
+        }
         return cls(
             name=data["name"],
             sub_type=data.get("sub_type", "decision_forecast"),
             n_ticks=int(data.get("n_ticks", 1)),
             personas=personas,
             tier_mix=tier_mix,
+            precedent_seed=precedent_seed,
+            precedent_seeds=precedent_seeds,
         )
 
 
@@ -276,6 +334,7 @@ async def run_scenario(
     backend_pool: list[Any] | None = None,
     on_projected_decision: ProjectedDecisionCallback | None = None,
     run_id: str | None = None,
+    decision_graph_ref: DecisionGraphRef | None = None,
 ) -> RunResult:
     """Run one scenario end-to-end.
 
@@ -303,6 +362,17 @@ async def run_scenario(
             so the per-tick records cross-reference the same id the
             ForesightRun document carries. The callback receives the
             run id implicitly via the closure the caller supplies.
+        decision_graph_ref: v14 — RFC 08 §14.4 forward-precedent lookup
+            contract. When the caller doesn't supply one (CLI smoke,
+            v0.5 cloud), the runner constructs a default
+            :class:`NoOpDecisionGraphRef` seeded from
+            ``config.precedent_seed`` + ``config.precedent_seeds``. The
+            ref is consulted once per projected-decision record; the
+            return value populates the record's
+            ``forward_precedent_decision_id`` field. When RFC 07 lands
+            in pocketpaw the cloud will inject a real ``DecisionGraphRef``
+            that returns Decision-Graph short-ids instead of synthetic
+            ones — no wire-shape change.
 
     Production callers hand in a ``backend_pool`` built from
     ``TierMix.locked_default()`` (or the scenario's
@@ -314,6 +384,16 @@ async def run_scenario(
 
     if backend_pool is None and backend is None:
         backend = DeterministicFakeBackend()
+
+    # v14 — default to the NoOp ref seeded from the scenario config. The
+    # ref is consulted once per projected-decision record below; when no
+    # seed is configured the NoOp returns ``None`` and the wire shape
+    # carries ``forward_precedent_decision_id=None`` (the v0.1 behavior).
+    if decision_graph_ref is None:
+        decision_graph_ref = NoOpDecisionGraphRef(
+            seed=config.precedent_seed or "",
+            per_anchor_seeds=dict(config.precedent_seeds),
+        )
 
     world = ForesightWorld()
     tier_dist: dict[str, int] = {}
@@ -352,6 +432,8 @@ async def run_scenario(
             snapshot=snapshot,
             tick_index=tick_index,
             sub_type=config.sub_type,
+            scenario_id=config.name,
+            decision_graph_ref=decision_graph_ref,
         )
         for record in tick_records:
             projected_records.append(record)
@@ -388,6 +470,8 @@ def _project_tick(
     snapshot: WorldSnapshot,
     tick_index: int,
     sub_type: str,
+    scenario_id: str,
+    decision_graph_ref: DecisionGraphRef,
 ) -> list[dict[str, Any]]:
     """Build one projected-decision record per anchor for this tick.
 
@@ -404,6 +488,14 @@ def _project_tick(
         else an empty string. v1.0 will fan one record per (anchor ×
         persona) pair; v0.5 stays one-per-anchor so the cloud's storage
         footprint is linear in anchor count, not anchor × persona.
+
+    v14 additions (RFC 08 §14.4):
+      - ``forward_precedent_decision_id`` is resolved per record by
+        delegating to the supplied ``DecisionGraphRef``. The NoOp
+        default returns ``None`` when no scenario seed is configured
+        (preserving v0.1 wire shape) and a stable synthetic id when a
+        seed is configured. A real Decision-Graph implementation (RFC
+        07) will return live short-ids; the field shape is unchanged.
     """
     # Count verbs across successful actions; the persona id of the
     # last-seen action for each verb so we can attribute the modal
@@ -438,6 +530,11 @@ def _project_tick(
             "decision_text": modal_verb,
             "confidence": confidence,
             "sub_type": sub_type,
+            "forward_precedent_decision_id": decision_graph_ref.lookup_precedent(
+                anchor_id=anchor_id,
+                persona_id=persona_id,
+                scenario_id=scenario_id,
+            ),
         }
         for anchor_id in anchors
     ]

--- a/tests/ee/foresight/test_decision_graph_ref.py
+++ b/tests/ee/foresight/test_decision_graph_ref.py
@@ -1,0 +1,501 @@
+# tests/ee/foresight/test_decision_graph_ref.py
+# Created: 2026-05-25 (feat/foresight-v14-decision-graph-stub) — RFC 08
+# §14.4 wiring. Covers:
+#   - DecisionGraphRef protocol contract — runtime subclass detection
+#     using ``isinstance`` against the ``@runtime_checkable`` Protocol.
+#   - NoOpDecisionGraphRef determinism — same inputs always produce the
+#     same synthetic id.
+#   - NoOpDecisionGraphRef returns ``None`` when no seed is configured
+#     (preserves v0.1 "field always None" wire shape).
+#   - NoOpDecisionGraphRef per-anchor override priority — anchor-level
+#     wins over scenario-level when both are set.
+#   - ScenarioConfig YAML parsing carries ``precedent_seed`` and
+#     ``precedent_seeds`` through to the dataclass.
+#   - End-to-end runner: ProjectedDecisions emitted with no seed carry
+#     ``forward_precedent_decision_id=None``; emitted with a seed carry
+#     a stable synthetic id of the documented shape.
+#   - run_scenario accepts a custom DecisionGraphRef and routes lookup
+#     through it (drop-in replacement when RFC 07 ships).
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.foresight.decision_graph_ref import (
+    SYNTHETIC_PRECEDENT_PREFIX,
+    DecisionGraphRef,
+    NoOpDecisionGraphRef,
+)
+from pocketpaw_ee.foresight.scenarios.runner import (
+    PersonaSpec,
+    ScenarioConfig,
+    run_scenario,
+)
+from pocketpaw_ee.foresight.subtypes import (
+    SUB_TYPE_DECISION_FORECAST,
+    SUB_TYPE_MARKET_SIM,
+)
+
+# ---------------------------------------------------------------------------
+# Protocol contract
+# ---------------------------------------------------------------------------
+
+
+def test_decision_graph_ref_is_runtime_checkable_protocol():
+    """The protocol must be ``@runtime_checkable`` so the runner can do
+    isinstance checks (and so tests can detect duck-typed conformance).
+    """
+    ref = NoOpDecisionGraphRef(seed="x")
+    assert isinstance(ref, DecisionGraphRef)
+
+
+def test_decision_graph_ref_rejects_non_conforming_object():
+    """Objects without ``lookup_precedent`` must not satisfy the
+    protocol. This is the same gate the runner relies on when callers
+    supply their own ref instead of the NoOp default."""
+
+    class _NotARef:
+        pass
+
+    assert not isinstance(_NotARef(), DecisionGraphRef)
+
+
+def test_decision_graph_ref_accepts_duck_typed_conformance():
+    """Any class with the right shape conforms — that's what makes
+    swapping in the future RFC 07 implementation a drop-in change."""
+
+    class _MyRef:
+        def lookup_precedent(
+            self,
+            anchor_id: str,  # noqa: ARG002
+            persona_id: str,  # noqa: ARG002
+            scenario_id: str,  # noqa: ARG002
+        ) -> str | None:
+            return "dec_real_short_id"
+
+    assert isinstance(_MyRef(), DecisionGraphRef)
+
+
+# ---------------------------------------------------------------------------
+# NoOpDecisionGraphRef — determinism and edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_noop_returns_none_when_no_seed_configured():
+    """No seed → no precedent. Preserves v0.1 wire-shape contract for
+    un-seeded scenarios (the field stays ``None`` on every record)."""
+    ref = NoOpDecisionGraphRef()
+    result = ref.lookup_precedent(
+        anchor_id="decision:x",
+        persona_id="persona-1",
+        scenario_id="scenario-A",
+    )
+    assert result is None
+
+
+def test_noop_returns_none_when_seed_is_empty_string():
+    """Empty string is normalized as "no seed configured"."""
+    ref = NoOpDecisionGraphRef(seed="")
+    assert ref.lookup_precedent("decision:x", "p", "s") is None
+
+
+def test_noop_deterministic_same_inputs_same_id():
+    """Same (anchor, persona, scenario, seed) → same id every call.
+    Critical for replay-style backfill jobs that re-emit projections
+    and expect to land on the same precedent id idempotently."""
+    ref = NoOpDecisionGraphRef(seed="seed-abc")
+    first = ref.lookup_precedent("decision:x", "persona-1", "scenario-A")
+    second = ref.lookup_precedent("decision:x", "persona-1", "scenario-A")
+    third = ref.lookup_precedent("decision:x", "persona-1", "scenario-A")
+    assert first == second == third
+
+
+def test_noop_id_shape_matches_synthetic_prefix_contract():
+    """The synthesized id starts with the documented prefix and ends
+    with a 12-hex-char digest. Downstream code (UI badge, backfill
+    detection) keys on the prefix to tell synthetic from real ids."""
+    ref = NoOpDecisionGraphRef(seed="seed-abc")
+    result = ref.lookup_precedent("decision:x", "persona-1", "scenario-A")
+    assert result is not None
+    assert result.startswith(SYNTHETIC_PRECEDENT_PREFIX)
+    digest = result[len(SYNTHETIC_PRECEDENT_PREFIX) :]
+    assert len(digest) == 12
+    # All chars are lowercase hex
+    assert all(c in "0123456789abcdef" for c in digest)
+
+
+def test_noop_different_anchors_yield_different_ids():
+    """Different anchor ids collide infrequently — sanity check that
+    the hash actually mixes the anchor in."""
+    ref = NoOpDecisionGraphRef(seed="seed")
+    a = ref.lookup_precedent("decision:x", "p", "s")
+    b = ref.lookup_precedent("decision:y", "p", "s")
+    assert a != b
+
+
+def test_noop_different_personas_yield_different_ids():
+    ref = NoOpDecisionGraphRef(seed="seed")
+    a = ref.lookup_precedent("decision:x", "persona-1", "s")
+    b = ref.lookup_precedent("decision:x", "persona-2", "s")
+    assert a != b
+
+
+def test_noop_different_scenarios_yield_different_ids():
+    ref = NoOpDecisionGraphRef(seed="seed")
+    a = ref.lookup_precedent("decision:x", "p", "scenario-A")
+    b = ref.lookup_precedent("decision:x", "p", "scenario-B")
+    assert a != b
+
+
+def test_noop_different_seeds_yield_different_ids():
+    """The seed is part of the hash — two scenarios with the same
+    anchor/persona/scenario_id but different seeds get different ids.
+    This is what makes the backfill stream re-keyable on seed rotation.
+    """
+    ref_a = NoOpDecisionGraphRef(seed="seed-1")
+    ref_b = NoOpDecisionGraphRef(seed="seed-2")
+    a = ref_a.lookup_precedent("decision:x", "p", "s")
+    b = ref_b.lookup_precedent("decision:x", "p", "s")
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Per-anchor override priority
+# ---------------------------------------------------------------------------
+
+
+def test_noop_per_anchor_seed_overrides_scenario_seed():
+    """Anchor-level override is the v14 grammar's "scenario seed +
+    per-anchor pin" pattern. The override seed must produce a different
+    id than the scenario-level seed would have."""
+    ref_global_only = NoOpDecisionGraphRef(seed="scenario-seed")
+    ref_with_override = NoOpDecisionGraphRef(
+        seed="scenario-seed",
+        per_anchor_seeds={"decision:critical": "anchor-seed"},
+    )
+    # The non-overridden anchor stays on the scenario seed.
+    assert ref_global_only.lookup_precedent(
+        "decision:other", "p", "s"
+    ) == ref_with_override.lookup_precedent("decision:other", "p", "s")
+    # The overridden anchor diverges.
+    assert ref_global_only.lookup_precedent(
+        "decision:critical", "p", "s"
+    ) != ref_with_override.lookup_precedent("decision:critical", "p", "s")
+
+
+def test_noop_per_anchor_override_falls_back_to_scenario_seed_when_empty():
+    """An empty-string override is treated as "remove override" — the
+    YAML loader strips empty values but defense-in-depth matters."""
+    ref = NoOpDecisionGraphRef(
+        seed="scenario-seed",
+        per_anchor_seeds={"decision:x": ""},
+    )
+    bare = NoOpDecisionGraphRef(seed="scenario-seed")
+    assert ref.lookup_precedent("decision:x", "p", "s") == bare.lookup_precedent(
+        "decision:x", "p", "s"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ScenarioConfig YAML parsing carries the precedent seeds
+# ---------------------------------------------------------------------------
+
+
+def _write_yaml(body: str) -> Path:
+    """Write a scenario YAML to a temp file for from_yaml round-trip
+    tests. Returns the path; caller is responsible for cleanup (we use
+    NamedTemporaryFile via context-managed helper inside each test)."""
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8")
+    tmp.write(body)
+    tmp.close()
+    return Path(tmp.name)
+
+
+def test_scenario_config_from_yaml_loads_precedent_seed():
+    path = _write_yaml(
+        """\
+name: yaml-seed-test
+sub_type: decision_forecast
+n_ticks: 1
+precedent_seed: "shared-2026-Q3"
+personas:
+  - name: p1
+    role: approver
+"""
+    )
+    try:
+        config = ScenarioConfig.from_yaml(path)
+    finally:
+        path.unlink()
+    assert config.precedent_seed == "shared-2026-Q3"
+    assert config.precedent_seeds == {}
+
+
+def test_scenario_config_from_yaml_loads_per_anchor_seeds():
+    path = _write_yaml(
+        """\
+name: yaml-anchor-seeds
+sub_type: decision_forecast
+n_ticks: 1
+precedent_seed: "scenario-seed"
+precedent_seeds:
+  "decision:critical": "critical-pin"
+  "decision:routine": "routine-pin"
+personas:
+  - name: p1
+    role: approver
+"""
+    )
+    try:
+        config = ScenarioConfig.from_yaml(path)
+    finally:
+        path.unlink()
+    assert config.precedent_seed == "scenario-seed"
+    assert config.precedent_seeds == {
+        "decision:critical": "critical-pin",
+        "decision:routine": "routine-pin",
+    }
+
+
+def test_scenario_config_from_yaml_strips_null_and_empty_seeds():
+    """Null / empty values in the YAML map are filtered out so the
+    NoOp ref doesn't have to handle them. The runner's behavior under
+    an explicit-empty override is already covered by
+    ``test_noop_per_anchor_override_falls_back_to_scenario_seed_when_empty``;
+    this test pins the loader's normalization contract."""
+    path = _write_yaml(
+        """\
+name: yaml-empty-seeds
+sub_type: decision_forecast
+n_ticks: 1
+precedent_seeds:
+  "decision:a": "good-seed"
+  "decision:b": ""
+  "decision:c": null
+personas:
+  - name: p1
+    role: approver
+"""
+    )
+    try:
+        config = ScenarioConfig.from_yaml(path)
+    finally:
+        path.unlink()
+    assert config.precedent_seeds == {"decision:a": "good-seed"}
+
+
+def test_scenario_config_defaults_to_no_seed_when_absent():
+    """Existing scenarios without the new fields must keep working — no
+    seed means no synthetic ids, no behavior change."""
+    path = _write_yaml(
+        """\
+name: yaml-no-seed
+sub_type: decision_forecast
+n_ticks: 1
+personas:
+  - name: p1
+    role: approver
+"""
+    )
+    try:
+        config = ScenarioConfig.from_yaml(path)
+    finally:
+        path.unlink()
+    assert config.precedent_seed is None
+    assert config.precedent_seeds == {}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: ProjectedDecision now carries forward_precedent_decision_id
+# ---------------------------------------------------------------------------
+
+
+async def test_run_scenario_without_seed_records_carry_none_precedent():
+    """Backward-compat: a scenario without a precedent seed produces
+    projected-decision records with ``forward_precedent_decision_id=None``.
+    """
+    config = ScenarioConfig(
+        name="no-seed",
+        sub_type=SUB_TYPE_DECISION_FORECAST,
+        n_ticks=1,
+        personas=[PersonaSpec(name="p", role="approver")],
+    )
+    result = await run_scenario(config)
+    assert len(result.projected_decisions) == 1
+    assert result.projected_decisions[0]["forward_precedent_decision_id"] is None
+
+
+async def test_run_scenario_with_seed_records_carry_synthetic_precedent():
+    """Smoking-gun test: with a seed configured, every projected record
+    carries a non-None synthetic precedent id with the documented prefix.
+    """
+    config = ScenarioConfig(
+        name="seeded",
+        sub_type=SUB_TYPE_DECISION_FORECAST,
+        n_ticks=2,
+        personas=[PersonaSpec(name="p", role="approver")],
+        precedent_seed="run-2026-Q3",
+    )
+    result = await run_scenario(config)
+    assert len(result.projected_decisions) == 2
+    for record in result.projected_decisions:
+        pid = record["forward_precedent_decision_id"]
+        assert pid is not None
+        assert pid.startswith(SYNTHETIC_PRECEDENT_PREFIX)
+
+
+async def test_run_scenario_with_seed_synthetic_ids_are_stable_across_ticks():
+    """Same anchor/persona/scenario, different ticks → same synthetic
+    id. The synthetic id is tick-independent because v0.5's anchor set
+    is fixed per run; this property lets backfill jobs key on
+    (run, anchor) without thinking about tick ordering."""
+    config = ScenarioConfig(
+        name="stable",
+        sub_type=SUB_TYPE_DECISION_FORECAST,
+        n_ticks=3,
+        personas=[PersonaSpec(name="p", role="approver")],
+        precedent_seed="stable-seed",
+    )
+    result = await run_scenario(config)
+    ids = {r["forward_precedent_decision_id"] for r in result.projected_decisions}
+    # Decision Forecast has one anchor; 3 ticks should all produce the
+    # same synthetic id because anchor/persona/scenario/seed are the
+    # same and tick is NOT part of the hash by design (RFC §14.4 keys
+    # forward-precedents on the projection bucket, not the tick).
+    #
+    # NOTE: persona_id may differ between ticks if the modal persona
+    # diverges; in this single-persona scenario it stays constant.
+    assert len(ids) == 1
+
+
+async def test_run_scenario_with_per_anchor_seed_overrides_yield_different_ids():
+    """Anchor-level seed plumbing through the runner: two different
+    anchors get different synthetic ids when the per-anchor seed map
+    diverges."""
+    config = ScenarioConfig(
+        name="market-anchored",
+        sub_type=SUB_TYPE_MARKET_SIM,
+        n_ticks=1,
+        personas=[
+            PersonaSpec(name="a", role="enterprise"),
+            PersonaSpec(name="b", role="smb"),
+        ],
+        precedent_seed="scenario-seed",
+        precedent_seeds={
+            "segment:enterprise": "enterprise-pin",
+            "segment:smb": "smb-pin",
+        },
+    )
+    result = await run_scenario(config)
+    by_anchor = {
+        r["anchor_id"]: r["forward_precedent_decision_id"] for r in result.projected_decisions
+    }
+    assert by_anchor["segment:enterprise"] is not None
+    assert by_anchor["segment:smb"] is not None
+    assert by_anchor["segment:enterprise"] != by_anchor["segment:smb"]
+
+
+async def test_run_scenario_callback_signature_unchanged_after_v14():
+    """The six-arg callback contract is preserved for backward-compat
+    with the cloud's existing closure in cloud/foresight/service.py
+    (which the §8 approval-bridge lane may also touch). The precedent
+    id surfaces only on ``RunResult.projected_decisions``."""
+    config = ScenarioConfig(
+        name="cb-compat",
+        sub_type=SUB_TYPE_DECISION_FORECAST,
+        n_ticks=1,
+        personas=[PersonaSpec(name="p", role="approver")],
+        precedent_seed="cb-seed",
+    )
+
+    captured: list[tuple] = []
+
+    def _capture(anchor_id, persona_id, tick_id, decision_text, confidence, sub_type):
+        # Six args — same shape as before v14. If this signature broke
+        # the §8 lead's closure would fail on merge.
+        captured.append((anchor_id, persona_id, tick_id, decision_text, confidence, sub_type))
+
+    result = await run_scenario(config, on_projected_decision=_capture)
+    assert len(captured) == 1
+    # The precedent id is NOT in the callback args — it's on the record.
+    assert result.projected_decisions[0]["forward_precedent_decision_id"] is not None
+
+
+async def test_run_scenario_accepts_custom_decision_graph_ref():
+    """Drop-in replacement contract: when RFC 07 lands its real
+    DecisionGraphRef will inject through this kwarg. v0.5 tests the
+    plumbing with a fake ref that returns a canned id."""
+
+    class _FakeRef:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, str]] = []
+
+        def lookup_precedent(
+            self,
+            anchor_id: str,
+            persona_id: str,
+            scenario_id: str,
+        ) -> str | None:
+            self.calls.append((anchor_id, persona_id, scenario_id))
+            return "dec_real_rfc07_id"
+
+    fake = _FakeRef()
+    config = ScenarioConfig(
+        name="custom-ref",
+        sub_type=SUB_TYPE_DECISION_FORECAST,
+        n_ticks=1,
+        personas=[PersonaSpec(name="p", role="approver")],
+        # Even with a seed configured, the custom ref wins — it fully
+        # replaces the NoOp default.
+        precedent_seed="ignored-seed",
+    )
+    result = await run_scenario(config, decision_graph_ref=fake)
+    assert fake.calls  # the ref was consulted
+    for record in result.projected_decisions:
+        assert record["forward_precedent_decision_id"] == "dec_real_rfc07_id"
+
+
+async def test_run_scenario_wire_dict_carries_precedent_field():
+    """``RunResult.as_wire_dict()`` is what the cloud's
+    ``_run_engine_inline`` returns to the persistence layer. The
+    forward_precedent_decision_id must survive the dict round-trip."""
+    config = ScenarioConfig(
+        name="wire-precedent",
+        sub_type=SUB_TYPE_DECISION_FORECAST,
+        n_ticks=1,
+        personas=[PersonaSpec(name="p", role="approver")],
+        precedent_seed="wire-seed",
+    )
+    result = await run_scenario(config)
+    wire = result.as_wire_dict()
+    projected = wire["projected_decisions"]
+    assert len(projected) == 1
+    assert projected[0]["forward_precedent_decision_id"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Integration sanity — the shipped scenario YAMLs still parse cleanly
+# ---------------------------------------------------------------------------
+
+SHIPPED_YAMLS = ("decision_forecast.yaml", "market_sim.yaml", "org_change.yaml")
+
+
+@pytest.mark.parametrize("yaml_name", SHIPPED_YAMLS)
+def test_shipped_scenario_yamls_parse_with_new_optional_fields(yaml_name: str):
+    """All three shipped YAMLs must keep loading cleanly. None of them
+    declare ``precedent_seed`` yet — the new fields are strictly
+    additive and absent-by-default."""
+    yaml_path = (
+        Path(__file__).resolve().parents[3]
+        / "ee"
+        / "pocketpaw_ee"
+        / "foresight"
+        / "scenarios"
+        / yaml_name
+    )
+    assert yaml_path.exists(), f"missing scenario yaml: {yaml_path}"
+    config = ScenarioConfig.from_yaml(yaml_path)
+    assert config.precedent_seed is None
+    assert config.precedent_seeds == {}


### PR DESCRIPTION
## Summary

- New engine-layer protocol `DecisionGraphRef` plus a default `NoOpDecisionGraphRef`. The runner consults the ref once per `ProjectedDecision` it emits and populates `forward_precedent_decision_id` with the result. NoOp synthesizes deterministic ids from a scenario seed; future RFC 07 wiring drops in a real implementation without a wire-shape change.
- Scenario YAML grows two optional roots: `precedent_seed` (scenario-wide) and `precedent_seeds` (per-anchor override map). Both absent in shipped scenarios by default — existing runs continue to emit `forward_precedent_decision_id=None`.
- Backward compatibility: the 6-arg `on_projected_decision` callback signature is unchanged. The precedent id surfaces on `RunResult.projected_decisions`. The cloud-side persistence backfill is a separate follow-up.

## What lands here

- `ee/pocketpaw_ee/foresight/decision_graph_ref.py` (new) — `DecisionGraphRef` Protocol + `NoOpDecisionGraphRef` + `SYNTHETIC_PRECEDENT_PREFIX` constant. The synthetic id format is `synthetic-precedent-<sha1(scenario|anchor|persona|seed)[:12]>`. Empty seed returns `None`, preserving v0.1 wire shape.
- `ee/pocketpaw_ee/foresight/scenarios/runner.py` — `ScenarioConfig` gains `precedent_seed` and `precedent_seeds`. `from_yaml` parses both and strips empty/null values. `run_scenario` accepts `decision_graph_ref: DecisionGraphRef | None = None` and defaults to a NoOp seeded from the config. `_project_tick` writes `forward_precedent_decision_id` onto every record.
- `ee/pocketpaw_ee/foresight/__init__.py` — lazy export for the three new names.
- `ee/pocketpaw_ee/foresight/scenarios/{decision_forecast,market_sim,org_change}.yaml` — header docs describing the new optional schema.
- `tests/ee/foresight/test_decision_graph_ref.py` (new, 27 tests) — protocol contract via `@runtime_checkable`, NoOp determinism, None-without-seed, prefix shape, per-anchor override priority, YAML round-trip, end-to-end runner integration, drop-in replacement via custom ref.

## What stays out of scope

- The real RFC 07 Decision Graph (the scaffold lives at `/tmp/team-rfc07`; productionizing it is a separate stream).
- Cloud-side persistence of `forward_precedent_decision_id` on the Mongo doc. The `emit_projected_decision` service still writes `None` for v0.5; the backfill that replaces synthetic ids with real Decision-Graph short-ids will land alongside RFC 07.

## Test plan

- [x] `uv run pytest tests/ee/foresight/test_decision_graph_ref.py` — 27 passed
- [x] `uv run pytest tests/ee/foresight/` — 234 passed (full foresight engine suite, regression check)
- [x] `uv run pytest tests/cloud/test_foresight_*` — 61 passed (cloud-side regression check)
- [x] `uv run pytest --collect-only --ignore=tests/e2e` — 5481 tests collect cleanly
- [x] `uv run ruff check` on changed files — clean
- [x] `uv run ruff format --check` on changed files — clean
- [x] `uv run mypy` on changed engine files — clean
- [x] `uv run lint-imports --config ee/pyproject.toml` — 18/18 contracts kept