### PR TITLE
feat(foresight): RFC 08 §8 — Foresight → Instinct approval-loop fan-out

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -507,6 +507,19 @@ class ForesightProjectedDecisionEmitted(Event):
     EVENT_TYPE: ClassVar[str] = "foresight.projected_decision.emitted"
 
 
+# Foresight → Instinct approval loop — RFC 08 §8. Fires when a
+# ProjectedDecision opts into the Instinct queue (via the scenario's
+# ``route_to_instinct=true`` flag) and the cloud-side fan-out creates
+# one Instinct ``Action`` row. The proposal is EVIDENCE — the Instinct
+# policy that already gates the underlying real decision still owns
+# the predicate; approving the proposal acknowledges the forecast but
+# does NOT trigger any executing side-effect. Listeners use this event
+# to refresh the Tray feed without polling.
+@dataclass
+class ForesightInstinctProposalCreated(Event):
+    EVENT_TYPE: ClassVar[str] = "foresight.instinct_proposal.created"
+
+
 # Composio — per-user OAuth integrations (Gmail, Slack, GitHub, …)
 # verified via per-toolkit identity probes. ``ComposioConnectionVerified``
 # fires when a probe succeeds and the stored identity matches (or first

--- a/ee/pocketpaw_ee/cloud/foresight/dto.py
+++ b/ee/pocketpaw_ee/cloud/foresight/dto.py
@@ -62,6 +62,17 @@ class CreateScenarioRequest(BaseModel):
       - ``scenario_id``: reference a stored scenario by id
       - ``tier_mix_override``, ``budget_cap_usd``, ``activation_overlay``
         and the rest of RFC §18's grammar.
+
+    PR 8 (RFC 08 §8) adds ``route_to_instinct``: when true, every
+    ``ProjectedDecision`` the run emits also lands one row in the
+    Instinct approval queue so the operator's Tray surfaces the
+    forecast as evidence next to the matching real-world decision.
+    Defaults to ``False`` so backwards-compatible callers (smoke
+    runs, backtests, the chat-driven CLI) don't accidentally fan
+    proposals into the Tray. The flag is documented on the scenario
+    YAML files (``decision_forecast.yaml`` / ``market_sim.yaml`` /
+    ``org_change.yaml``) as a v1.0 loader hook — v0.5 reads it only
+    from the request body.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -70,6 +81,17 @@ class CreateScenarioRequest(BaseModel):
     sub_type: str = Field(default="decision_forecast", max_length=64)
     n_ticks: int = Field(default=1, ge=1, le=1000)
     personas: list[PersonaSpecRequest] = Field(..., min_length=1, max_length=1000)
+    route_to_instinct: bool = Field(
+        default=False,
+        description=(
+            "When true, every ProjectedDecision the run emits is also "
+            "fanned into the Instinct approval queue (RFC 08 §8). The "
+            "proposal is EVIDENCE-only — approving it acknowledges the "
+            "forecast but does NOT trigger an executing side-effect. "
+            "Backtests cannot opt in (the backtest endpoint reuses the "
+            "scenario runner but disables this fan-out)."
+        ),
+    )
 
 
 class ScenarioRunResponse(BaseModel):
@@ -305,11 +327,80 @@ class ProjectedDecisionListResponse(BaseModel):
     has_more: bool = False
 
 
+# ---------------------------------------------------------------------------
+# Foresight → Instinct approval-loop fan-out (RFC 08 §8 + PR 8).
+#
+# When a scenario opts in via ``route_to_instinct=True``, each
+# ProjectedDecision becomes one row in the Instinct approval queue.
+# These response shapes wrap the persisted Instinct Action rows back
+# into a Foresight-flavoured view so the Tray UI can render
+# "the proposals spawned by THIS run" without poking the generic
+# ``/instinct/actions/pending`` endpoint with a client-side filter.
+# ---------------------------------------------------------------------------
+
+
+class ForesightInstinctProposalResponse(BaseModel):
+    """One Instinct proposal spawned by a Foresight ProjectedDecision.
+
+    A subset of the full ``Action`` shape — enough for the Tray rail's
+    Foresight column to render the row without requesting the
+    Instinct detail endpoint. Operators who need the full Action
+    payload (corrections, audit) fetch it via
+    ``GET /api/v1/instinct/actions/{id}`` keyed by ``action_id``.
+
+    Fields mirror the Instinct ``Action`` model where they apply,
+    plus the ``foresight`` provenance block the bridge stamped onto
+    ``parameters._foresight`` at propose time so the consumer can
+    rehydrate the originating (run × tick × anchor) without a second
+    round trip.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    action_id: str
+    pocket_id: str
+    title: str
+    description: str
+    recommendation: str
+    status: str  # "pending" | "approved" | "rejected" | "executed" | "failed"
+    priority: str  # "low" | "medium" | "high" | "critical"
+    category: str  # "data" for foresight evidence proposals
+    assignee: str | None = None
+    created_at: str | None = None
+    # Provenance — the ``_foresight`` block the bridge stamped on
+    # ``parameters`` at propose time. Carrying it on the response lets
+    # the Tray UI render the "Why?" drawer (originating run / tick /
+    # anchor / confidence) without a second API call.
+    foresight: dict[str, Any]
+
+
+class ForesightInstinctProposalListResponse(BaseModel):
+    """Paginated wrapper for
+    ``GET /runs/{id}/instinct-proposals``.
+
+    Mirrors :class:`ProjectedDecisionListResponse`: the items array
+    plus the cursor metadata a paginating client needs. v0.8 keeps
+    the cursor offset-based for parity with the projection-list
+    endpoint; v1.0 may swap to opaque cursors once dataset sizes
+    make a count_documents call expensive.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[ForesightInstinctProposalResponse]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+    has_more: bool = False
+
+
 __all__ = [
     "BacktestRunListItemResponse",
     "BacktestRunResponse",
     "CreateBacktestRequest",
     "CreateScenarioRequest",
+    "ForesightInstinctProposalListResponse",
+    "ForesightInstinctProposalResponse",
     "HistoricalAnchorRequest",
     "OnboardingGateResponse",
     "PersonaSpecRequest",

--- a/ee/pocketpaw_ee/cloud/foresight/router.py
+++ b/ee/pocketpaw_ee/cloud/foresight/router.py
@@ -1,4 +1,12 @@
 # ee/pocketpaw_ee/cloud/foresight/router.py
+# Modified: 2026-05-25 (feat/foresight-v08-approval-loop) — PR 8 / RFC 08 §8
+#   adds the Foresight → Instinct approval-loop surface:
+#     GET /api/v1/foresight/runs/{id}/instinct-proposals
+#       → paginated list of Instinct rows spawned by this run. Tenancy:
+#         404 when the run is unknown / cross-tenant (same collapsing
+#         rule as the projection-list endpoint). Cursor: offset-based
+#         ``limit`` (default 50, capped at 500) + ``offset`` (default 0).
+#         Empty list when the run didn't opt into ``route_to_instinct``.
 # Modified: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) — PR 5
 #   adds the per-anchor projection fanout surface:
 #     GET /api/v1/foresight/runs/{id}/projected-decisions
@@ -51,6 +59,7 @@ from pocketpaw_ee.cloud.foresight.dto import (
     BacktestRunResponse,
     CreateBacktestRequest,
     CreateScenarioRequest,
+    ForesightInstinctProposalListResponse,
     OnboardingGateResponse,
     ProjectedDecisionListResponse,
     ScenarioRunListItemResponse,
@@ -154,6 +163,52 @@ async def list_projected_decisions(
         ctx,
         run_id,
         anchor_id=anchor_id,
+        limit=limit,
+        offset=offset,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Foresight → Instinct approval loop (RFC 08 §8 + PR 8)
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/runs/{run_id}/instinct-proposals",
+    response_model=ForesightInstinctProposalListResponse,
+)
+async def list_instinct_proposals(
+    run_id: str,
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    ctx: RequestContext = Depends(request_context),
+) -> ForesightInstinctProposalListResponse:
+    """List the Instinct proposals spawned by one Foresight run.
+
+    PR 8 contract (RFC 08 §8):
+      - Returns the Instinct rows whose ``parameters._foresight.run_id``
+        matches the run. Empty list when the run didn't opt into
+        ``route_to_instinct`` or when the run hasn't ticked yet.
+      - Each row is the EVIDENCE-only proposal the bridge spawned: the
+        Instinct policy that already gates the underlying real decision
+        still owns the predicate; approving a row acknowledges the
+        forecast but does NOT trigger any executing side-effect.
+      - Tenancy: an unknown / cross-tenant run id returns 404
+        (``foresight_run.not_found``) — same collapsing rule the
+        projection-list endpoint uses so existence isn't cross-tenant
+        leakable. The Instinct store itself doesn't carry a
+        ``workspace_id`` column (it's OSS-runtime SQLite), so the
+        workspace check happens at the run level here.
+      - Pagination is offset-based for parity with the projection-list
+        endpoint; ``limit`` is hard-capped at 500.
+
+    Operators who need the full Action payload (corrections, audit)
+    fetch it via ``GET /api/v1/instinct/actions/{id}`` keyed by
+    ``action_id``.
+    """
+    return await foresight_service.list_instinct_proposals_for_run(
+        ctx,
+        run_id,
         limit=limit,
         offset=offset,
     )

--- a/ee/pocketpaw_ee/cloud/foresight/service.py
+++ b/ee/pocketpaw_ee/cloud/foresight/service.py
@@ -1,4 +1,16 @@
 # ee/pocketpaw_ee/cloud/foresight/service.py
+# Updated: 2026-05-25 (feat/foresight-v08-approval-loop) — PR 8 §14.4 wire:
+#   - ``emit_projected_decision`` now accepts an optional
+#     ``forward_precedent_decision_id`` kwarg and persists it on the
+#     ``ForesightProjectedDecision`` doc instead of hardcoding ``None``.
+#     The cloud-side closure in ``_run_engine_inline`` resolves the id
+#     via ``ee.foresight.decision_graph_ref.NoOpDecisionGraphRef`` (PR
+#     #1235 §14.4) so the persisted doc matches the engine's
+#     ``RunResult.projected_decisions`` shape one-to-one. The cloud
+#     body does not yet expose ``precedent_seed`` so the ref is seeded
+#     empty by default — every lookup returns ``None`` and behaviour
+#     is unchanged until either a body extension lands or RFC 07's
+#     real Decision Graph implementation replaces the NoOp ref.
 # Updated: 2026-05-25 (feat/foresight-v08-approval-loop) — PR 8 / RFC 08 §8:
 #   - ``CreateScenarioRequest.route_to_instinct`` threads through
 #     ``_run_engine_inline`` into the per-tick callback. When the flag
@@ -251,6 +263,7 @@ async def _run_engine_inline(
     persist the run as a JSON-shaped blob without leaking dataclass
     types into the persistence layer.
     """
+    from pocketpaw_ee.foresight.decision_graph_ref import NoOpDecisionGraphRef
     from pocketpaw_ee.foresight.persona import OceanDrift
     from pocketpaw_ee.foresight.scenarios.runner import (
         PersonaSpec,
@@ -273,6 +286,19 @@ async def _run_engine_inline(
         personas=personas,
     )
 
+    # v14 (§14.4) — build a DecisionGraphRef mirroring the engine's
+    # default so the cloud closure can stamp the same
+    # ``forward_precedent_decision_id`` value the runner computes for
+    # ``RunResult.projected_decisions``. The cloud's
+    # ``CreateScenarioRequest`` body does not yet expose
+    # ``precedent_seed`` / ``precedent_seeds`` (engine YAML can carry
+    # them; cloud body extension lands later), so this ref is seeded
+    # empty by default — :class:`NoOpDecisionGraphRef` returns ``None``
+    # for every lookup in that case, preserving the v0.1 behaviour the
+    # callers expect. Real RFC 07 wiring drops in by swapping the
+    # implementation here once the Decision Graph lands in pocketpaw.
+    decision_graph_ref = NoOpDecisionGraphRef(seed="")
+
     # Per-tick emission closure — only wired when the cloud caller
     # supplies the run id. CLI smoke runs pass no run_id and the
     # callback stays None; the engine still surfaces the records on
@@ -284,6 +310,13 @@ async def _run_engine_inline(
     # projection when the scenario opted in. The engine layer itself
     # stays unaware of Instinct — it only sees the projection callback
     # signature it already supports.
+    #
+    # v14 (§14.4): the closure also resolves the forward-precedent id
+    # via the cloud-side DecisionGraphRef so the persisted
+    # ``ForesightProjectedDecision`` doc carries the same value the
+    # engine writes into ``RunResult.projected_decisions``. The lookup
+    # is pure / deterministic — same inputs always produce the same id
+    # — so the engine + cloud paths stay in sync without coordination.
     callback = None
     if workspace_id and run_id:
         scenario_name = body.name
@@ -296,6 +329,11 @@ async def _run_engine_inline(
             confidence: float,
             sub_type: str,
         ) -> None:
+            precedent_id = decision_graph_ref.lookup_precedent(
+                anchor_id=anchor_id,
+                persona_id=persona_id,
+                scenario_id=scenario_name,
+            )
             await emit_projected_decision(
                 workspace_id=workspace_id,
                 run_id=run_id,
@@ -305,6 +343,7 @@ async def _run_engine_inline(
                 decision_text=decision_text,
                 confidence=confidence,
                 sub_type=sub_type,
+                forward_precedent_decision_id=precedent_id,
                 route_to_instinct=route_to_instinct,
                 scenario_name=scenario_name,
             )
@@ -964,6 +1003,7 @@ async def emit_projected_decision(
     decision_text: str,
     confidence: float,
     sub_type: str,
+    forward_precedent_decision_id: str | None = None,
     route_to_instinct: bool = False,
     scenario_name: str = "",
 ) -> ProjectedDecisionResponse:
@@ -1016,7 +1056,11 @@ async def emit_projected_decision(
         decision_text=decision_text,
         confidence=confidence,
         sub_type=sub_type,
-        forward_precedent_decision_id=None,
+        # v14 (§14.4) — caller threads the forward-precedent id resolved
+        # by its DecisionGraphRef. ``None`` is still the default for
+        # un-seeded scenarios; PR #1235 introduces synthetic ids only
+        # when the scenario opts in via ``precedent_seed``.
+        forward_precedent_decision_id=forward_precedent_decision_id,
     )
     await doc.insert()
 

--- a/ee/pocketpaw_ee/cloud/foresight/service.py
+++ b/ee/pocketpaw_ee/cloud/foresight/service.py
@@ -1,4 +1,23 @@
 # ee/pocketpaw_ee/cloud/foresight/service.py
+# Updated: 2026-05-25 (feat/foresight-v08-approval-loop) — PR 8 / RFC 08 §8:
+#   - ``CreateScenarioRequest.route_to_instinct`` threads through
+#     ``_run_engine_inline`` into the per-tick callback. When the flag
+#     is true, ``emit_projected_decision`` also fans the projection
+#     into the Instinct approval queue via
+#     ``ee.foresight.instinct_bridge.projected_decision_to_instinct_proposal``
+#     + the global ``InstinctStore`` (lazy import — the engine layer
+#     stays clean of cloud, and the cloud module never grew a static
+#     ``pocketpaw.instinct`` dep). The fan-out is idempotent: before
+#     proposing, the service scans existing Instinct rows scoped to
+#     the run's synthetic ``pocket_id`` and skips when an Action with
+#     the same dedupe key already exists. Backtests never opt in —
+#     ``create_backtest`` builds its scenario body with
+#     ``route_to_instinct=False`` explicitly.
+#   - Added ``list_instinct_proposals_for_run(ctx, run_id, limit, offset)``
+#     — the GET endpoint reader. Returns the Instinct rows whose
+#     ``parameters._foresight.run_id`` matches the run, scoped to
+#     the caller's workspace via the same ``_fetch_in_workspace``
+#     404-collapse rule the projection-list endpoint uses.
 # Updated: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) — PR 5:
 #   - Added the RFC §7.7 per-anchor projection fanout. The engine call
 #     (``_run_engine_inline``) now accepts a ``run_id`` + an injected
@@ -77,6 +96,7 @@ from pocketpaw_ee.cloud._core.realtime.events import (
     ForesightBacktestCompleted,
     ForesightBacktestCreated,
     ForesightBacktestFailed,
+    ForesightInstinctProposalCreated,
     ForesightOnboardingUnlocked,
     ForesightProjectedDecisionEmitted,
     ForesightRunCompleted,
@@ -95,6 +115,8 @@ from pocketpaw_ee.cloud.foresight.dto import (
     BacktestRunResponse,
     CreateBacktestRequest,
     CreateScenarioRequest,
+    ForesightInstinctProposalListResponse,
+    ForesightInstinctProposalResponse,
     OnboardingGateResponse,
     ProjectedDecisionListResponse,
     ProjectedDecisionResponse,
@@ -206,6 +228,7 @@ async def _run_engine_inline(
     *,
     workspace_id: str | None = None,
     run_id: str | None = None,
+    route_to_instinct: bool = False,
 ) -> dict[str, Any]:
     """Drive the foresight engine for one scenario run.
 
@@ -254,8 +277,16 @@ async def _run_engine_inline(
     # supplies the run id. CLI smoke runs pass no run_id and the
     # callback stays None; the engine still surfaces the records on
     # ``RunResult.projected_decisions`` either way.
+    #
+    # PR 8 (RFC 08 §8): the closure forwards ``route_to_instinct`` and
+    # the originating scenario name into ``emit_projected_decision`` so
+    # the cloud-side fan-out can spawn an Instinct proposal per
+    # projection when the scenario opted in. The engine layer itself
+    # stays unaware of Instinct — it only sees the projection callback
+    # signature it already supports.
     callback = None
     if workspace_id and run_id:
+        scenario_name = body.name
 
         async def _on_projected_decision(
             anchor_id: str,
@@ -274,6 +305,8 @@ async def _run_engine_inline(
                 decision_text=decision_text,
                 confidence=confidence,
                 sub_type=sub_type,
+                route_to_instinct=route_to_instinct,
+                scenario_name=scenario_name,
             )
 
         callback = _on_projected_decision
@@ -370,6 +403,12 @@ async def create_scenario_run(
             body,
             workspace_id=workspace_id,
             run_id=str(doc.id),
+            # PR 8 (RFC 08 §8) — forward the operator's opt-in flag into the
+            # per-tick fanout closure. When false (the default), the
+            # projection-only fan-out runs and no Instinct rows are created.
+            # When true, ``emit_projected_decision`` also fans an evidence
+            # proposal into the Instinct queue.
+            route_to_instinct=body.route_to_instinct,
         )
     except Exception as exc:  # noqa: BLE001 — capture into the doc, never bubble
         error_message = f"{type(exc).__name__}: {exc}"
@@ -692,11 +731,19 @@ async def create_backtest(ctx: RequestContext, body: CreateBacktestRequest) -> B
         # configuration in v0.1 (the engine doesn't fan per-anchor
         # projections yet; PR 8 wires that). The scoring step pairs the
         # engine's modal outcome against each anchor's actual_outcome.
+        #
+        # PR 8 (RFC 08 §8): backtests NEVER route to Instinct. The
+        # explicit ``route_to_instinct=False`` belt-and-braces the
+        # default — a future edit that flips the request DTO's default
+        # to true must not silently turn the historical-replay path
+        # into a proposal-spawning surface (the backtest is the trust
+        # unlock, not an operator decision queue).
         scenario_body = CreateScenarioRequest(
             name=body.name,
             sub_type=body.sub_type,
             n_ticks=body.n_ticks,
             personas=body.personas,
+            route_to_instinct=False,
         )
         engine_result = await _run_engine_inline(scenario_body)
         summary_dict, gate_dict = await _score_backtest(
@@ -917,6 +964,8 @@ async def emit_projected_decision(
     decision_text: str,
     confidence: float,
     sub_type: str,
+    route_to_instinct: bool = False,
+    scenario_name: str = "",
 ) -> ProjectedDecisionResponse:
     """Persist one projected-decision record and emit the event.
 
@@ -943,6 +992,14 @@ async def emit_projected_decision(
     until RFC 07 lands in pocketpaw; the field is part of the persisted
     shape so the backfill pass can populate it without a wire-shape
     bump.
+
+    PR 8 (RFC 08 §8) — when ``route_to_instinct=True``, the function
+    ALSO fans the projection into the Instinct approval queue via
+    :func:`_fan_to_instinct_proposal`. The fan-out is idempotent — a
+    re-emit of the same (workspace, run, tick, anchor, persona) bucket
+    skips when a matching Instinct row already exists. The Instinct
+    write is best-effort: a store failure logs a warning and never
+    masks the projection write the engine is waiting on.
     """
     if not workspace_id:
         raise Forbidden(
@@ -963,8 +1020,30 @@ async def emit_projected_decision(
     )
     await doc.insert()
 
-    response = _to_projected_decision_response(_to_projected_decision_domain(doc))
+    domain_pd = _to_projected_decision_domain(doc)
+    response = _to_projected_decision_response(domain_pd)
     await emit(ForesightProjectedDecisionEmitted(data=response.model_dump()))
+
+    # PR 8 (RFC 08 §8) — optional Instinct fan-out. Best-effort: a store
+    # failure must never mask the projection write the engine is waiting
+    # on. The Instinct rows live in OSS-runtime SQLite (``~/.pocketpaw/``)
+    # so the lazy import here keeps the cloud module free of a static
+    # ``pocketpaw.instinct`` dep at module top.
+    if route_to_instinct:
+        try:
+            await _fan_to_instinct_proposal(
+                domain_pd=domain_pd,
+                scenario_name=scenario_name,
+            )
+        except Exception:  # noqa: BLE001 — never break the projection write
+            logger.exception(
+                "foresight.emit_projected_decision: Instinct fan-out failed "
+                "for ws=%s run=%s anchor=%s tick=%s (non-fatal)",
+                workspace_id,
+                run_id,
+                anchor_id,
+                tick_id,
+            )
     return response
 
 
@@ -1033,6 +1112,252 @@ async def list_projected_decisions(
     )
 
 
+# ---------------------------------------------------------------------------
+# Foresight → Instinct approval loop (RFC 08 §8 + PR 8)
+# ---------------------------------------------------------------------------
+#
+# The fan-out from a persisted ProjectedDecision into one Instinct
+# proposal row. The cloud service owns this orchestration so the engine
+# stays decoupled from Instinct and the import-linter's
+# "engine → cloud forbidden" contract holds. The bridge module
+# (``ee.foresight.instinct_bridge``) is pure conversion — no Beanie,
+# no store — and the heavy lifting (read-before-write idempotence,
+# event emission) lives here.
+
+
+_FORESIGHT_POCKET_PREFIX = "foresight:run:"
+
+
+def _foresight_pocket_id(run_id: str) -> str:
+    """Stable synthetic ``pocket_id`` for an Instinct row spawned by a
+    Foresight run. The Instinct store treats ``pocket_id`` as a
+    free-form string (no FK) so a prefix-scoped query recovers every
+    row a single run produced.
+    """
+    return f"{_FORESIGHT_POCKET_PREFIX}{run_id}" if run_id else f"{_FORESIGHT_POCKET_PREFIX}unknown"
+
+
+async def _existing_dedupe_keys(store: Any, pocket_id: str) -> set[str]:
+    """Read the dedupe keys already stamped on Instinct rows for one
+    Foresight run.
+
+    Returns a set so the idempotence check is O(1) per projection
+    when the fan-out replays a long run. Rows without the
+    ``_foresight.dedupe_key`` field (e.g. a hand-crafted Action that
+    happens to land in the same pocket-id namespace) are skipped —
+    we only dedupe against our own provenance block.
+    """
+    actions = await store.list_actions(pocket_id=pocket_id, limit=500)
+    keys: set[str] = set()
+    for act in actions:
+        params = getattr(act, "parameters", {}) or {}
+        block = params.get("_foresight") if isinstance(params, dict) else None
+        if isinstance(block, dict):
+            key = block.get("dedupe_key")
+            if isinstance(key, str) and key:
+                keys.add(key)
+    return keys
+
+
+async def _fan_to_instinct_proposal(
+    *,
+    domain_pd: ProjectedDecision,
+    scenario_name: str,
+) -> str | None:
+    """Spawn one Instinct ``Action`` row from a ProjectedDecision.
+
+    The conversion is delegated to
+    :func:`ee.foresight.instinct_bridge.projected_decision_to_instinct_proposal`
+    (pure conversion, no store call). This function adds the
+    cloud-side wiring:
+
+      1. Resolve the synthetic ``pocket_id`` for the run.
+      2. Read existing Instinct rows in that pocket scope and skip if
+         a row with the same dedupe key already exists (idempotence).
+      3. Build the ``ActionTrigger`` (the bridge stays string-typed so
+         the engine namespace doesn't pull ``pocketpaw.instinct``).
+      4. Call ``store.propose(...)``.
+      5. Emit ``ForesightInstinctProposalCreated``.
+
+    Returns the spawned Action id on success, or ``None`` when the
+    fan-out was skipped (duplicate) or silently no-oped (no run id).
+
+    Imports for the Instinct surface are lazy at function scope so
+    importing the cloud module stays cheap (no SQLite touch, no
+    OSS-runtime side effects) until the fan-out actually fires.
+    """
+    from pocketpaw.instinct.models import (
+        ActionCategory,
+        ActionPriority,
+        ActionTrigger,
+    )
+    from pocketpaw.stores import get_instinct_store
+    from pocketpaw_ee.foresight.instinct_bridge import (
+        projected_decision_to_instinct_proposal,
+    )
+
+    proposal = projected_decision_to_instinct_proposal(
+        domain_pd,
+        scenario_config={"name": scenario_name} if scenario_name else None,
+    )
+    dedupe_key = proposal.parameters.get("_foresight", {}).get("dedupe_key", "")
+
+    store = get_instinct_store()
+    existing = await _existing_dedupe_keys(store, proposal.pocket_id)
+    if dedupe_key in existing:
+        # Idempotent skip — a re-emit of the same (ws, run, tick,
+        # anchor, persona) bucket already has a row in The Tray.
+        logger.debug(
+            "foresight._fan_to_instinct_proposal: skipped duplicate dedupe_key=%s",
+            dedupe_key,
+        )
+        return None
+
+    trigger = ActionTrigger(
+        type=proposal.trigger_type,
+        source=proposal.trigger_source,
+        reason=proposal.trigger_reason,
+    )
+    # Pydantic enum coercion — the bridge stays string-typed so the
+    # engine namespace doesn't drag in the Instinct domain at module
+    # top; the store call needs the real enums.
+    try:
+        category = ActionCategory(proposal.category)
+    except ValueError:
+        category = ActionCategory.DATA
+    try:
+        priority = ActionPriority(proposal.priority)
+    except ValueError:
+        priority = ActionPriority.MEDIUM
+
+    action = await store.propose(
+        pocket_id=proposal.pocket_id,
+        title=proposal.title,
+        description=proposal.description,
+        recommendation=proposal.recommendation,
+        trigger=trigger,
+        category=category,
+        priority=priority,
+        parameters=proposal.parameters,
+        assignee=proposal.assignee,
+    )
+
+    await emit(
+        ForesightInstinctProposalCreated(
+            data={
+                "action_id": action.id,
+                "pocket_id": proposal.pocket_id,
+                "workspace_id": domain_pd.workspace_id,
+                "run_id": domain_pd.run_id,
+                "tick_id": domain_pd.tick_id,
+                "anchor_id": domain_pd.anchor_id,
+                "persona_id": domain_pd.persona_id,
+                "sub_type": domain_pd.sub_type,
+                "confidence": domain_pd.confidence,
+                "dedupe_key": dedupe_key,
+            }
+        )
+    )
+    return action.id
+
+
+def _instinct_action_to_response(action: Any) -> ForesightInstinctProposalResponse:
+    """Convert a ``pocketpaw.instinct.models.Action`` (or any duck-typed
+    equivalent) into the Foresight-flavoured response shape.
+
+    Duck-typed so test doubles can hand in a ``SimpleNamespace`` without
+    importing the Instinct domain module from cloud-test code.
+    """
+    params = getattr(action, "parameters", {}) or {}
+    block = params.get("_foresight") if isinstance(params, dict) else {}
+    if not isinstance(block, dict):
+        block = {}
+    created_at = getattr(action, "created_at", None)
+    return ForesightInstinctProposalResponse(
+        action_id=str(getattr(action, "id", "")),
+        pocket_id=str(getattr(action, "pocket_id", "")),
+        title=str(getattr(action, "title", "")),
+        description=str(getattr(action, "description", "")),
+        recommendation=str(getattr(action, "recommendation", "")),
+        status=getattr(getattr(action, "status", None), "value", "pending"),
+        priority=getattr(getattr(action, "priority", None), "value", "medium"),
+        category=getattr(getattr(action, "category", None), "value", "data"),
+        assignee=getattr(action, "assignee", None),
+        created_at=iso_utc(created_at) if created_at is not None else None,
+        foresight=block,
+    )
+
+
+async def list_instinct_proposals_for_run(
+    ctx: RequestContext,
+    run_id: str,
+    *,
+    limit: int = 50,
+    offset: int = 0,
+) -> ForesightInstinctProposalListResponse:
+    """List the Instinct proposals spawned by one Foresight run.
+
+    Reads the OSS-runtime Instinct store filtered to the run's
+    synthetic ``pocket_id`` (``foresight:run:<run_id>``) and returns
+    the rows whose ``parameters._foresight.run_id`` matches.
+
+    Cross-tenant safety: this function calls ``_fetch_in_workspace``
+    first so an unknown / cross-tenant run id surfaces as ``NotFound``
+    *before* the Instinct query runs. That keeps the 404-collapse rule
+    consistent with the projection-list endpoint — existence is never
+    leakable across tenants. The Instinct store itself does not carry
+    a ``workspace_id`` column (it's OSS-runtime SQLite), so the
+    workspace check has to happen at the run level here.
+
+    Pagination is offset-based for parity with the projection-list
+    endpoint. ``total`` is computed locally over the pocket-scoped
+    list because Instinct doesn't expose a count surface; this is
+    cheap until a single run accumulates thousands of projections,
+    at which point v1.0 will swap to a streaming reader.
+    """
+    workspace_id = _require_workspace(ctx)
+    # 404-collapse rule — the run must exist in this workspace before
+    # any Instinct read runs. Without this, the Instinct store (which
+    # doesn't carry workspace_id) would happily return rows even for
+    # a cross-tenant run-id probe.
+    await _fetch_in_workspace(workspace_id, run_id)
+
+    if limit < 1:
+        raise ValidationError("foresight.invalid_limit", "limit must be >= 1")
+    if limit > 500:
+        limit = 500
+    if offset < 0:
+        raise ValidationError("foresight.invalid_offset", "offset must be >= 0")
+
+    # Lazy import — the Instinct store is OSS-runtime SQLite; importing
+    # at module top would touch the disk on every cloud module load.
+    from pocketpaw.stores import get_instinct_store
+
+    store = get_instinct_store()
+    pocket_id = _foresight_pocket_id(run_id)
+    # Pull a generous slice (Instinct's max page size is 500) and
+    # filter to the rows our own provenance stamped, in case a future
+    # caller drops an Action into the same pocket-id namespace by hand.
+    raw = await store.list_actions(pocket_id=pocket_id, limit=500)
+    matching = [
+        a
+        for a in raw
+        if isinstance(getattr(a, "parameters", None), dict)
+        and isinstance(a.parameters.get("_foresight"), dict)
+        and a.parameters["_foresight"].get("run_id") == run_id
+    ]
+    total = len(matching)
+    page = matching[offset : offset + limit]
+    items = [_instinct_action_to_response(a) for a in page]
+    return ForesightInstinctProposalListResponse(
+        items=items,
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=(offset + len(items)) < total,
+    )
+
+
 __all__ = [
     "GATE_DEFAULT_THRESHOLD",
     "create_backtest",
@@ -1042,6 +1367,7 @@ __all__ = [
     "get_onboarding_gate",
     "get_scenario_run",
     "list_backtests",
+    "list_instinct_proposals_for_run",
     "list_projected_decisions",
     "list_scenario_runs",
 ]

--- a/ee/pocketpaw_ee/foresight/instinct_bridge.py
+++ b/ee/pocketpaw_ee/foresight/instinct_bridge.py
@@ -1,0 +1,313 @@
+# ee/pocketpaw_ee/foresight/instinct_bridge.py
+# Created: 2026-05-25 (feat/foresight-v08-approval-loop) — RFC 08 §8.
+#
+# Foresight → Instinct bridge. Pure conversion module that turns a
+# persisted ``ProjectedDecision`` (cloud domain value object) into an
+# ``InstinctProposal`` shape ready for ``InstinctStore.propose``. The
+# cloud-side fan-out (``ee.cloud.foresight.service.emit_projected_decision``)
+# imports this lazily and stores the resulting proposal when a scenario
+# opted into routing (``route_to_instinct=True``).
+#
+# Why a separate module:
+#   - The conversion logic is pure (no Beanie, no Instinct store call,
+#     no engine-side OASIS / CAMEL imports). Keeping it isolated lets
+#     the cloud service import it without dragging in the foresight
+#     engine's optional-extra surface.
+#   - The bridge is engine-side by file location only — it sits in
+#     ``ee.pocketpaw_ee.foresight`` so it ships with the foresight
+#     namespace, but it imports nothing from ``foresight.persona``,
+#     ``foresight.llm``, ``foresight.scenarios``, ``foresight.subtypes``,
+#     ``foresight.substrate``, ``foresight.aggregator``, or
+#     ``foresight.calibration``. The import-linter contract
+#     "Foresight cloud — must not import the engine layer" forbids
+#     those specific submodules; ``instinct_bridge`` is deliberately
+#     not on that list because it has no engine deps to leak.
+#   - RFC 08 §8 contract: Foresight feeds Instinct as EVIDENCE, not as
+#     new policy. The Instinct policy still owns "who gates this" and
+#     "what the predicate is". This bridge surfaces the projection so
+#     the approver UI's Tray can render it; the proposal itself is a
+#     non-executing notice (``category=DATA``, no ``_pocket_write`` blob).
+#
+# Dedupe contract:
+#   - The proposal carries a dedupe key under
+#     ``parameters._foresight.dedupe_key`` whose value joins
+#     ``(workspace_id, run_id, tick_id, anchor_id, persona_id)`` with
+#     a ``|`` separator. The cloud caller is responsible for skipping
+#     a propose call when an Instinct row with the same key already
+#     exists — the bridge stays pure (no store side-effects); the
+#     cloud service does the read-before-write.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Dedupe key — joined string so a single SQLite LIKE / equality scan finds
+# duplicates without a JSON-path query (instinct_actions stores parameters
+# as a JSON TEXT column).
+# ---------------------------------------------------------------------------
+
+
+def build_dedupe_key(
+    *,
+    workspace_id: str,
+    run_id: str,
+    tick_id: int,
+    anchor_id: str,
+    persona_id: str,
+) -> str:
+    """Stable dedupe key for one (workspace × run × tick × anchor × persona)
+    ProjectedDecision bucket.
+
+    Used by the cloud fan-out to skip duplicate Instinct proposals when a
+    ProjectedDecision is re-emitted (e.g. a run replay or a scenario
+    re-run with the same id). Joined with ``|`` so the key is a single
+    string the bridge / store can compare without decomposing.
+
+    Empty ``persona_id`` is preserved as an empty segment (matches the
+    engine's convention of emitting one record per anchor even when no
+    persona acted), so the key shape is deterministic for every fan-out.
+    """
+    return f"{workspace_id}|{run_id}|{tick_id}|{anchor_id}|{persona_id}"
+
+
+# ---------------------------------------------------------------------------
+# Output shape — the cloud service constructs an ``ActionTrigger`` and
+# calls ``InstinctStore.propose(**kwargs)`` with these fields. We do not
+# build the ``ActionTrigger`` here because importing it would couple the
+# bridge to ``pocketpaw.instinct.models`` at module top; the cloud
+# service threads the import lazily so the engine namespace stays clean.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InstinctProposal:
+    """Conversion output — the kwargs an Instinct ``propose`` call needs.
+
+    Fields mirror :meth:`pocketpaw.instinct.store.InstinctStore.propose`'s
+    signature one-to-one, plus ``trigger_type`` / ``trigger_source`` /
+    ``trigger_reason`` so the cloud service can build the
+    :class:`pocketpaw.instinct.models.ActionTrigger` without re-importing
+    the domain types here.
+
+    The shape is frozen so callers can't mutate the conversion result
+    between bridge and store; the dedupe key + provenance live under
+    ``parameters._foresight`` so a downstream listener can introspect
+    "which ProjectedDecision spawned this proposal" without a second
+    round trip.
+    """
+
+    pocket_id: str
+    title: str
+    description: str
+    recommendation: str
+    category: str  # ActionCategory value — bridge stays string-typed
+    priority: str  # ActionPriority value
+    parameters: dict[str, Any]
+    trigger_type: str
+    trigger_source: str
+    trigger_reason: str
+    assignee: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Sub-type-aware label rendering — the title/description text the operator
+# sees in The Tray. Each sub-type has a distinct anchor convention:
+#
+#   decision_forecast → ``decision:<name>``     ("a single decision to make")
+#   market_sim        → ``segment:<role>``      ("how a segment responds")
+#   org_change_*      → ``rollout:<event>``     ("how a rollout step lands")
+#
+# Anything unrecognized falls back to a neutral "Forecast" label so a
+# new sub-type added in a later PR doesn't blow up here.
+# ---------------------------------------------------------------------------
+
+
+def _label_for_sub_type(sub_type: str) -> str:
+    """Short verb label rendered in the proposal title (e.g. ``Forecast``,
+    ``Segment forecast``, ``Rollout forecast``).
+
+    Kept tiny so the conversion stays readable; a future sub-type just
+    drops a new branch here without touching the rest of the bridge.
+    """
+    return {
+        "decision_forecast": "Forecast",
+        "market_sim": "Segment forecast",
+        "org_change_rehearsal": "Rollout forecast",
+    }.get(sub_type, "Forecast")
+
+
+def _humanize_anchor(anchor_id: str) -> str:
+    """Strip the ``<kind>:`` prefix off an anchor id and Title-Case the
+    remainder so a label like ``decision:lease-renewal`` reads as
+    ``Lease-Renewal`` in the operator UI.
+
+    Anchors that don't carry the convention (no colon) come back
+    unchanged so the proposal still surfaces a useful string.
+    """
+    if ":" not in anchor_id:
+        return anchor_id
+    _, _, suffix = anchor_id.partition(":")
+    return suffix.replace("_", "-")
+
+
+def _priority_from_confidence(confidence: float) -> str:
+    """Map projection confidence to an :class:`ActionPriority` value.
+
+    The mapping mirrors the band convention the rest of the codebase
+    uses (low / medium / high / critical) without importing the enum.
+    Strings are validated on the receiving service when the bridge
+    output is handed to ``InstinctStore.propose``.
+
+    Bands:
+      - confidence >= 0.9 → critical
+      - confidence >= 0.7 → high
+      - confidence >= 0.4 → medium
+      - otherwise        → low
+    """
+    if confidence >= 0.9:
+        return "critical"
+    if confidence >= 0.7:
+        return "high"
+    if confidence >= 0.4:
+        return "medium"
+    return "low"
+
+
+# ---------------------------------------------------------------------------
+# Conversion entry point — the cloud service calls this once per
+# (anchor × tick) bucket after the ProjectedDecision document is written.
+# ---------------------------------------------------------------------------
+
+
+def projected_decision_to_instinct_proposal(
+    pd: Any,
+    scenario_config: dict[str, Any] | None = None,
+    *,
+    assignee: str | None = None,
+) -> InstinctProposal:
+    """Convert one ProjectedDecision into the proposal shape Instinct's
+    store expects.
+
+    Args:
+        pd: a :class:`pocketpaw_ee.cloud.foresight.domain.ProjectedDecision`
+            (or any object exposing the same attribute set: ``workspace_id``,
+            ``run_id``, ``anchor_id``, ``persona_id``, ``tick_id``,
+            ``decision_text``, ``confidence``, ``sub_type``,
+            ``forward_precedent_decision_id``). The bridge stays
+            duck-typed so test doubles don't need to import the cloud
+            domain module.
+        scenario_config: the scenario's wire dict (the
+            ``CreateScenarioRequest`` body the operator posted). The
+            bridge currently pulls ``name`` for the description and
+            forwards the rest as provenance. Pass ``None`` when the
+            caller doesn't have a body handy (e.g. a future
+            calibration-loop replay) — the bridge defaults the
+            scenario name to the projection's ``sub_type``.
+        assignee: optional human user-id who should see this proposal in
+            The Tray. Default ``None`` — the proposal becomes a
+            workspace-wide pending row picked up by the unfiltered
+            pending feed. Forwarded directly to
+            :meth:`InstinctStore.propose`.
+
+    Returns:
+        An :class:`InstinctProposal` carrying everything the cloud
+        service needs to build the ``ActionTrigger`` + call
+        ``store.propose``. The ``parameters`` dict includes the
+        ``_foresight`` provenance block so a downstream consumer (the
+        Tray UI rendering the "Why?" drawer) can rehydrate the
+        originating run / tick / anchor without a second API call.
+
+    Per RFC 08 §8: the proposal is EVIDENCE, not an executing write.
+    Category is :class:`ActionCategory.DATA`; no ``_pocket_write`` blob
+    is parked; the Instinct policy that already gates the underlying
+    real decision still owns the predicate. Approving the surfaced
+    proposal simply acknowledges the forecast — it does NOT trigger any
+    side-effect beyond the audit row.
+    """
+    workspace_id = str(getattr(pd, "workspace_id", "") or "")
+    run_id = str(getattr(pd, "run_id", "") or "")
+    anchor_id = str(getattr(pd, "anchor_id", "") or "")
+    persona_id = str(getattr(pd, "persona_id", "") or "")
+    tick_id = int(getattr(pd, "tick_id", 0) or 0)
+    decision_text = str(getattr(pd, "decision_text", "") or "noop")
+    confidence = float(getattr(pd, "confidence", 0.0) or 0.0)
+    sub_type = str(getattr(pd, "sub_type", "decision_forecast") or "decision_forecast")
+    forward_precedent = getattr(pd, "forward_precedent_decision_id", None)
+
+    scenario_name = ""
+    if scenario_config:
+        scenario_name = str(scenario_config.get("name") or "")
+
+    label = _label_for_sub_type(sub_type)
+    anchor_label = _humanize_anchor(anchor_id) or "anchor"
+    title = f"{label}: {decision_text} for {anchor_label} (tick {tick_id})"
+    description = (
+        f"Foresight projected '{decision_text}' for {anchor_label} at tick {tick_id} "
+        f"with confidence {confidence:.2f}."
+    )
+    if scenario_name:
+        description += f" Scenario: {scenario_name}."
+    recommendation = (
+        "Review this projection before the matching real-world decision "
+        "lands. Approving acknowledges the forecast; rejecting flags it "
+        "for calibration follow-up."
+    )
+
+    dedupe_key = build_dedupe_key(
+        workspace_id=workspace_id,
+        run_id=run_id,
+        tick_id=tick_id,
+        anchor_id=anchor_id,
+        persona_id=persona_id,
+    )
+
+    # ``_foresight`` is the provenance block any consumer (Tray Why?
+    # drawer, calibration loop) can read back. The ``dedupe_key`` field
+    # is what the cloud's read-before-write check compares against.
+    parameters: dict[str, Any] = {
+        "_foresight": {
+            "workspace_id": workspace_id,
+            "run_id": run_id,
+            "tick_id": tick_id,
+            "anchor_id": anchor_id,
+            "persona_id": persona_id,
+            "sub_type": sub_type,
+            "decision_text": decision_text,
+            "confidence": confidence,
+            "forward_precedent_decision_id": forward_precedent,
+            "scenario_name": scenario_name,
+            "dedupe_key": dedupe_key,
+        },
+    }
+
+    # Synthetic pocket id binds the proposal to the foresight run; the
+    # Instinct store treats ``pocket_id`` as a free-form string (no FK).
+    # Pending-feed callers can filter by this prefix to recover all
+    # foresight-spawned proposals across a single run.
+    pocket_id = f"foresight:run:{run_id}" if run_id else "foresight:run:unknown"
+
+    return InstinctProposal(
+        pocket_id=pocket_id,
+        title=title,
+        description=description,
+        recommendation=recommendation,
+        category="data",
+        priority=_priority_from_confidence(confidence),
+        parameters=parameters,
+        trigger_type="foresight",
+        trigger_source=f"run:{run_id}" if run_id else "run:unknown",
+        trigger_reason=(
+            f"Foresight projected '{decision_text}' at tick {tick_id} for "
+            f"{anchor_label}; surfaced as evidence per RFC 08 §8."
+        ),
+        assignee=assignee,
+    )
+
+
+__all__ = [
+    "InstinctProposal",
+    "build_dedupe_key",
+    "projected_decision_to_instinct_proposal",
+]

--- a/ee/pocketpaw_ee/foresight/scenarios/decision_forecast.yaml
+++ b/ee/pocketpaw_ee/foresight/scenarios/decision_forecast.yaml
@@ -20,6 +20,17 @@ name: smoke-decision-forecast
 sub_type: decision_forecast
 n_ticks: 1
 
+# PR 8 (RFC 08 §8) — when true, every ProjectedDecision this scenario
+# emits is also fanned into the Instinct approval queue so The Tray
+# surfaces the forecast as evidence next to the matching real-world
+# decision. Defaults to false here (and in the request DTO) so smoke
+# runs don't pollute the Tray. The v0.8 cloud loader only reads this
+# flag from the POST body; the YAML carries it as documentation /
+# v1.0 loader hook. Backtests can NOT opt in — the cloud service
+# always passes route_to_instinct=false through the backtest path.
+#
+# route_to_instinct: false
+
 # PR 3 — Captain-locked default tier mix (RFC 08 §10). Per-scenario
 # overrides are allowed but trigger a cost-estimator warning in
 # paw-enterprise (PR 6 work).

--- a/ee/pocketpaw_ee/foresight/scenarios/market_sim.yaml
+++ b/ee/pocketpaw_ee/foresight/scenarios/market_sim.yaml
@@ -20,6 +20,16 @@ name: smoke-market-sim
 sub_type: market_sim
 n_ticks: 2
 
+# PR 8 (RFC 08 §8) — when true, every ProjectedDecision this scenario
+# emits is also fanned into the Instinct approval queue so The Tray
+# surfaces the forecast as evidence next to the matching real-world
+# decision. Defaults to false here (and in the request DTO) so smoke
+# runs don't pollute the Tray. The v0.8 cloud loader only reads this
+# flag from the POST body; the YAML carries it as documentation /
+# v1.0 loader hook.
+#
+# route_to_instinct: false
+
 # Captain-locked 5/15/80 default per RFC §10. Declared explicitly so
 # new readers see the tier mix without chasing the loader's default.
 tier_mix:

--- a/ee/pocketpaw_ee/foresight/scenarios/org_change.yaml
+++ b/ee/pocketpaw_ee/foresight/scenarios/org_change.yaml
@@ -21,6 +21,16 @@ name: smoke-org-change
 sub_type: org_change_rehearsal
 n_ticks: 4  # one tick per rollout event (announce / training / deadline / escalation)
 
+# PR 8 (RFC 08 §8) — when true, every ProjectedDecision this scenario
+# emits is also fanned into the Instinct approval queue so The Tray
+# surfaces the rollout forecast as evidence next to the real-world
+# adoption decision. Defaults to false here (and in the request DTO)
+# so smoke runs don't pollute the Tray. The v0.8 cloud loader only
+# reads this flag from the POST body; the YAML carries it as
+# documentation / v1.0 loader hook.
+#
+# route_to_instinct: false
+
 # Captain-locked 5/15/80 default per RFC §10.
 tier_mix:
   premium: 0.05  # Claude Sonnet 4.7 — manager personas

--- a/tests/cloud/test_foresight_service_instinct.py
+++ b/tests/cloud/test_foresight_service_instinct.py
@@ -347,3 +347,64 @@ async def test_backtest_does_not_fan_to_instinct(isolated_instinct_store) -> Non
         r for r in rows if str(getattr(r, "pocket_id", "")).startswith("foresight:run:")
     ]
     assert foresight_rows == []
+
+
+# ---------------------------------------------------------------------------
+# §14.4 — forward_precedent_decision_id threads through emit_projected_decision
+# onto the persisted Beanie doc. PR #1235 introduced the engine-side
+# DecisionGraphRef; PR 8 wires the cloud closure so the persisted doc
+# carries the same id the runner writes to RunResult.projected_decisions.
+# ---------------------------------------------------------------------------
+
+
+async def test_emit_projected_decision_persists_forward_precedent_id() -> None:
+    """When the cloud-side caller passes a non-None precedent id, the
+    persisted ``ForesightProjectedDecision`` doc and the wire response
+    both surface it instead of the hardcoded ``None``.
+
+    Uses a custom anchor id that the run loop never emits so the
+    direct ``emit_projected_decision`` call lands the only record
+    under that anchor (the run itself fans ``decision:<name>``).
+    """
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(ctx, _body(name="precedent-wire"))
+
+    response = await foresight_service.emit_projected_decision(
+        workspace_id="w1",
+        run_id=run.id,
+        anchor_id="custom:precedent-test",
+        persona_id="p1",
+        tick_id=42,
+        decision_text="accept",
+        confidence=0.8,
+        sub_type="decision_forecast",
+        forward_precedent_decision_id="synthetic-precedent-abc123def456",
+    )
+    assert response.forward_precedent_decision_id == "synthetic-precedent-abc123def456"
+
+    # ...and the persisted doc round-trips through the list endpoint
+    # filtered to the custom anchor so only the direct-emit row matches.
+    listing = await foresight_service.list_projected_decisions(
+        ctx, run.id, anchor_id="custom:precedent-test"
+    )
+    assert listing.total == 1
+    assert listing.items[0].forward_precedent_decision_id == "synthetic-precedent-abc123def456"
+
+
+async def test_emit_projected_decision_defaults_precedent_to_none() -> None:
+    """Backwards-compat: callers that omit the kwarg still get the
+    v0.1 wire shape (``forward_precedent_decision_id=None``)."""
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(ctx, _body(name="precedent-default"))
+
+    response = await foresight_service.emit_projected_decision(
+        workspace_id="w1",
+        run_id=run.id,
+        anchor_id="decision:precedent-default",
+        persona_id="p1",
+        tick_id=0,
+        decision_text="accept",
+        confidence=0.5,
+        sub_type="decision_forecast",
+    )
+    assert response.forward_precedent_decision_id is None

--- a/tests/cloud/test_foresight_service_instinct.py
+++ b/tests/cloud/test_foresight_service_instinct.py
@@ -1,0 +1,349 @@
+# tests/cloud/test_foresight_service_instinct.py — RFC 08 PR 8.
+# Created: 2026-05-25 (feat/foresight-v08-approval-loop)
+# — service-level tests for the Foresight → Instinct approval-loop
+# fan-out under ``ee.cloud.foresight.service.emit_projected_decision``
+# (when ``route_to_instinct=True``) + ``list_instinct_proposals_for_run``.
+#
+# The Instinct store is OSS-runtime SQLite; the tests swap the
+# ``get_instinct_store`` singleton for a fresh ``InstinctStore`` rooted
+# at a per-test temp path so the rows don't leak across tests or
+# accumulate in the developer's ``~/.pocketpaw/instinct.db``.
+"""Tests for the Foresight → Instinct approval-loop integration."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound, ValidationError
+from pocketpaw_ee.cloud._core.realtime.events import (
+    ForesightInstinctProposalCreated,
+)
+from pocketpaw_ee.cloud.foresight import service as foresight_service
+from pocketpaw_ee.cloud.foresight.dto import (
+    CreateScenarioRequest,
+    PersonaSpecRequest,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace: str | None = "w1", user: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _body(
+    *,
+    name: str = "renewal-forecast",
+    sub_type: str = "decision_forecast",
+    n_ticks: int = 1,
+    personas: list[PersonaSpecRequest] | None = None,
+    route_to_instinct: bool = False,
+) -> CreateScenarioRequest:
+    return CreateScenarioRequest(
+        name=name,
+        sub_type=sub_type,
+        n_ticks=n_ticks,
+        personas=personas
+        or [
+            PersonaSpecRequest(name="Anne", role="approver", ocean={}),
+        ],
+        route_to_instinct=route_to_instinct,
+    )
+
+
+@pytest.fixture
+def isolated_instinct_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Swap the global InstinctStore singleton for a fresh test-local one.
+
+    The default ``get_instinct_store`` returns a process-wide singleton
+    rooted at ``~/.pocketpaw/instinct.db``. For these tests we point
+    it at a per-test SQLite file under ``tmp_path`` so:
+
+      1. Rows don't leak across tests (each test gets a fresh DB).
+      2. Rows don't accumulate in the developer's real DB.
+
+    We monkey-patch BOTH ``pocketpaw.stores.get_instinct_store`` (where
+    the singleton is defined) AND the binding the cloud service imports
+    lazily, so every code path the service touches sees the test store.
+    """
+    from pocketpaw import stores as stores_mod
+    from pocketpaw.instinct.store import InstinctStore
+
+    test_store = InstinctStore(tmp_path / "instinct-test.db")
+
+    def _factory() -> InstinctStore:
+        return test_store
+
+    monkeypatch.setattr(stores_mod, "get_instinct_store", _factory)
+    return test_store
+
+
+# ---------------------------------------------------------------------------
+# Opt-in routing: a run with ``route_to_instinct=True`` spawns one
+# Instinct row per ProjectedDecision; a run with the flag false spawns
+# nothing.
+# ---------------------------------------------------------------------------
+
+
+async def test_opt_in_run_fans_one_instinct_row_per_projection(
+    isolated_instinct_store, recording_bus
+) -> None:
+    """Decision Forecast with n_ticks=2 produces 2 projections and 2
+    Instinct rows when ``route_to_instinct=True``."""
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(
+        ctx, _body(name="renewal", n_ticks=2, route_to_instinct=True)
+    )
+    assert run.status == "complete"
+
+    listing = await foresight_service.list_instinct_proposals_for_run(ctx, run.id)
+    assert listing.total == 2
+    assert len(listing.items) == 2
+    # Every proposal carries the foresight provenance block.
+    for item in listing.items:
+        assert item.foresight["run_id"] == run.id
+        assert item.foresight["sub_type"] == "decision_forecast"
+        assert item.pocket_id == f"foresight:run:{run.id}"
+        # RFC §8 contract — evidence-only proposals.
+        assert item.category == "data"
+
+
+async def test_opt_out_run_creates_no_instinct_rows(isolated_instinct_store) -> None:
+    """A scenario run with ``route_to_instinct=False`` (the default)
+    must NOT create any Instinct rows even though projections still
+    persist."""
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(
+        ctx, _body(name="silent", n_ticks=2, route_to_instinct=False)
+    )
+    # Projections still landed — the run is otherwise unchanged.
+    projections = await foresight_service.list_projected_decisions(ctx, run.id)
+    assert projections.total == 2
+
+    # ...but no Instinct rows.
+    listing = await foresight_service.list_instinct_proposals_for_run(ctx, run.id)
+    assert listing.total == 0
+    assert listing.items == []
+
+
+async def test_opt_in_emits_proposal_created_event(isolated_instinct_store, recording_bus) -> None:
+    """The Instinct fan-out emits one
+    ``ForesightInstinctProposalCreated`` event per spawned row so the
+    Tray UI can refresh without polling."""
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(
+        ctx, _body(name="event-test", n_ticks=3, route_to_instinct=True)
+    )
+    emitted = [e for e in recording_bus.events if isinstance(e, ForesightInstinctProposalCreated)]
+    # Decision Forecast = 1 anchor × 3 ticks
+    assert len(emitted) == 3
+    assert all(e.data["run_id"] == run.id for e in emitted)
+    # Every event carries the dedupe key so a downstream listener can
+    # cross-reference without an extra Instinct round trip.
+    assert {e.data["tick_id"] for e in emitted} == {0, 1, 2}
+
+
+# ---------------------------------------------------------------------------
+# Idempotence: a re-emit of the same (ws, run, tick, anchor, persona)
+# bucket must NOT create a duplicate Instinct row.
+# ---------------------------------------------------------------------------
+
+
+async def test_repeat_emit_with_same_dedupe_key_does_not_duplicate(
+    isolated_instinct_store,
+) -> None:
+    """Calling ``emit_projected_decision`` twice with identical args
+    must produce only one Instinct row — the dedupe key is the gate."""
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(ctx, _body(name="dedupe-seed"))
+
+    kwargs = {
+        "workspace_id": "w1",
+        "run_id": run.id,
+        "anchor_id": "decision:dedupe-seed",
+        "persona_id": "p1",
+        "tick_id": 0,
+        "decision_text": "accept",
+        "confidence": 0.7,
+        "sub_type": "decision_forecast",
+        "route_to_instinct": True,
+        "scenario_name": "dedupe-seed",
+    }
+
+    # First call — Instinct row created.
+    await foresight_service.emit_projected_decision(**kwargs)
+    after_first = await foresight_service.list_instinct_proposals_for_run(ctx, run.id)
+    first_total = after_first.total
+    assert first_total >= 1
+
+    # Second call with identical args — no new Instinct row.
+    await foresight_service.emit_projected_decision(**kwargs)
+    after_second = await foresight_service.list_instinct_proposals_for_run(ctx, run.id)
+    assert after_second.total == first_total
+
+
+async def test_distinct_dedupe_keys_create_separate_rows(isolated_instinct_store) -> None:
+    """Two emits that differ only on ``tick_id`` (or any other dedupe
+    axis) must each land their own Instinct row."""
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(ctx, _body(name="distinct"))
+
+    base_kwargs = {
+        "workspace_id": "w1",
+        "run_id": run.id,
+        "anchor_id": "decision:distinct",
+        "persona_id": "p1",
+        "decision_text": "accept",
+        "confidence": 0.7,
+        "sub_type": "decision_forecast",
+        "route_to_instinct": True,
+        "scenario_name": "distinct",
+    }
+
+    before = await foresight_service.list_instinct_proposals_for_run(ctx, run.id)
+    await foresight_service.emit_projected_decision(tick_id=10, **base_kwargs)
+    await foresight_service.emit_projected_decision(tick_id=11, **base_kwargs)
+    after = await foresight_service.list_instinct_proposals_for_run(ctx, run.id)
+    assert after.total == before.total + 2
+
+
+# ---------------------------------------------------------------------------
+# Tenancy: list_instinct_proposals_for_run enforces the 404-collapse
+# rule so a cross-tenant run-id probe can't leak existence even
+# though the Instinct store itself is workspace-blind.
+# ---------------------------------------------------------------------------
+
+
+async def test_list_unknown_run_returns_404(isolated_instinct_store) -> None:
+    ctx = _ctx()
+    with pytest.raises(NotFound):
+        await foresight_service.list_instinct_proposals_for_run(ctx, "5f50c31b1c9d440000000000")
+
+
+async def test_list_cross_tenant_run_returns_404(isolated_instinct_store) -> None:
+    """A run created in w1 must be invisible from w2 even on the
+    instinct-proposals list endpoint."""
+    ctx_w1 = _ctx(workspace="w1")
+    ctx_w2 = _ctx(workspace="w2")
+    run = await foresight_service.create_scenario_run(
+        ctx_w1, _body(name="tenant-iso", route_to_instinct=True)
+    )
+    with pytest.raises(NotFound):
+        await foresight_service.list_instinct_proposals_for_run(ctx_w2, run.id)
+
+
+async def test_list_requires_workspace(isolated_instinct_store) -> None:
+    ctx = _ctx(workspace=None)
+    with pytest.raises(Forbidden):
+        await foresight_service.list_instinct_proposals_for_run(ctx, "0" * 24)
+
+
+async def test_list_invalid_limit_raises(isolated_instinct_store) -> None:
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(ctx, _body())
+    with pytest.raises(ValidationError):
+        await foresight_service.list_instinct_proposals_for_run(ctx, run.id, limit=0)
+
+
+async def test_list_invalid_offset_raises(isolated_instinct_store) -> None:
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(ctx, _body())
+    with pytest.raises(ValidationError):
+        await foresight_service.list_instinct_proposals_for_run(ctx, run.id, offset=-1)
+
+
+async def test_list_caps_limit_at_500(isolated_instinct_store) -> None:
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(ctx, _body())
+    listing = await foresight_service.list_instinct_proposals_for_run(ctx, run.id, limit=10000)
+    assert listing.limit == 500
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+
+async def test_list_paginates_with_offset_and_limit(isolated_instinct_store) -> None:
+    """An Org Change run with 4 ticks × 4 anchors produces 16
+    proposals when routed; pagination behaves like the projection-list
+    endpoint."""
+    ctx = _ctx()
+    run = await foresight_service.create_scenario_run(
+        ctx,
+        _body(
+            name="paged-org",
+            sub_type="org_change_rehearsal",
+            n_ticks=4,
+            personas=[PersonaSpecRequest(name="x", role="manager")],
+            route_to_instinct=True,
+        ),
+    )
+    page1 = await foresight_service.list_instinct_proposals_for_run(ctx, run.id, limit=5)
+    assert len(page1.items) == 5
+    assert page1.has_more is True
+    assert page1.total == 16
+
+    page2 = await foresight_service.list_instinct_proposals_for_run(ctx, run.id, limit=5, offset=5)
+    assert len(page2.items) == 5
+    assert page2.offset == 5
+
+    last_page = await foresight_service.list_instinct_proposals_for_run(
+        ctx, run.id, limit=10, offset=10
+    )
+    # 6 remaining after offset 10 in a 16-record set.
+    assert len(last_page.items) == 6
+    assert last_page.has_more is False
+
+
+# ---------------------------------------------------------------------------
+# Backtests never route to Instinct, even when a future edit flips the
+# scenario default — the backtest path explicitly passes
+# ``route_to_instinct=False``.
+# ---------------------------------------------------------------------------
+
+
+async def test_backtest_does_not_fan_to_instinct(isolated_instinct_store) -> None:
+    """A backtest reuses the scenario runner but must never spawn
+    Instinct proposals — the historical-replay path is the trust
+    unlock, not an operator decision queue."""
+    from pocketpaw_ee.cloud.foresight.dto import (
+        CreateBacktestRequest,
+        HistoricalAnchorRequest,
+    )
+
+    ctx = _ctx()
+    bt = await foresight_service.create_backtest(
+        ctx,
+        CreateBacktestRequest(
+            name="bt-no-route",
+            sub_type="decision_forecast",
+            n_ticks=1,
+            personas=[PersonaSpecRequest(name="x", role="approver")],
+            anchors=[
+                HistoricalAnchorRequest(
+                    anchor_object_id="lease:LR-1",
+                    actual_outcome={"verdict": "approve"},
+                )
+            ],
+        ),
+    )
+    assert bt.status == "complete"
+
+    # No way to query the backtest's Instinct rows (there are none) —
+    # but we can confirm the SQLite store has zero rows under any
+    # foresight pocket-id namespace.
+    rows = await isolated_instinct_store.list_actions(limit=500)
+    foresight_rows = [
+        r for r in rows if str(getattr(r, "pocket_id", "")).startswith("foresight:run:")
+    ]
+    assert foresight_rows == []

--- a/tests/ee/foresight/test_instinct_bridge.py
+++ b/tests/ee/foresight/test_instinct_bridge.py
@@ -1,0 +1,200 @@
+# tests/ee/foresight/test_instinct_bridge.py — RFC 08 PR 8.
+# Created: 2026-05-25 (feat/foresight-v08-approval-loop)
+# — pure-conversion tests for the Foresight → Instinct bridge module.
+# The bridge is a pure function (no I/O, no Beanie, no Instinct store
+# call), so these tests exercise it directly with duck-typed projection
+# fixtures rather than spinning up Mongo or SQLite.
+"""Unit tests for the Foresight → Instinct bridge (RFC 08 §8 conversion)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pocketpaw_ee.foresight.instinct_bridge import (
+    InstinctProposal,
+    build_dedupe_key,
+    projected_decision_to_instinct_proposal,
+)
+
+
+def _pd(
+    *,
+    workspace_id: str = "w1",
+    run_id: str = "r1",
+    anchor_id: str = "decision:renewal",
+    persona_id: str = "p1",
+    tick_id: int = 0,
+    decision_text: str = "accept",
+    confidence: float = 0.5,
+    sub_type: str = "decision_forecast",
+    forward_precedent_decision_id: str | None = None,
+) -> SimpleNamespace:
+    """Duck-typed ProjectedDecision stand-in.
+
+    The bridge stays attribute-typed so test doubles don't have to
+    import the cloud domain value object — a ``SimpleNamespace`` with
+    the same field names is enough.
+    """
+    return SimpleNamespace(
+        workspace_id=workspace_id,
+        run_id=run_id,
+        anchor_id=anchor_id,
+        persona_id=persona_id,
+        tick_id=tick_id,
+        decision_text=decision_text,
+        confidence=confidence,
+        sub_type=sub_type,
+        forward_precedent_decision_id=forward_precedent_decision_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_dedupe_key — deterministic, joined-string key
+# ---------------------------------------------------------------------------
+
+
+def test_dedupe_key_is_stable_for_same_inputs() -> None:
+    a = build_dedupe_key(
+        workspace_id="w1", run_id="r1", tick_id=2, anchor_id="decision:lease", persona_id="p7"
+    )
+    b = build_dedupe_key(
+        workspace_id="w1", run_id="r1", tick_id=2, anchor_id="decision:lease", persona_id="p7"
+    )
+    assert a == b
+    assert a == "w1|r1|2|decision:lease|p7"
+
+
+def test_dedupe_key_includes_empty_persona_segment() -> None:
+    # Engine emits one record per anchor even when no persona acted;
+    # the empty persona_id must be preserved as an empty segment so
+    # the key shape is deterministic across that branch.
+    key = build_dedupe_key(
+        workspace_id="w1", run_id="r1", tick_id=0, anchor_id="rollout:announce", persona_id=""
+    )
+    assert key == "w1|r1|0|rollout:announce|"
+
+
+def test_dedupe_key_differs_when_any_axis_changes() -> None:
+    base = build_dedupe_key(
+        workspace_id="w1", run_id="r1", tick_id=0, anchor_id="a", persona_id="p"
+    )
+    assert base != build_dedupe_key(
+        workspace_id="w2", run_id="r1", tick_id=0, anchor_id="a", persona_id="p"
+    )
+    assert base != build_dedupe_key(
+        workspace_id="w1", run_id="r2", tick_id=0, anchor_id="a", persona_id="p"
+    )
+    assert base != build_dedupe_key(
+        workspace_id="w1", run_id="r1", tick_id=1, anchor_id="a", persona_id="p"
+    )
+    assert base != build_dedupe_key(
+        workspace_id="w1", run_id="r1", tick_id=0, anchor_id="b", persona_id="p"
+    )
+    assert base != build_dedupe_key(
+        workspace_id="w1", run_id="r1", tick_id=0, anchor_id="a", persona_id="q"
+    )
+
+
+# ---------------------------------------------------------------------------
+# projected_decision_to_instinct_proposal — shape + labels
+# ---------------------------------------------------------------------------
+
+
+def test_conversion_returns_proposal_with_expected_fields() -> None:
+    proposal = projected_decision_to_instinct_proposal(_pd())
+    assert isinstance(proposal, InstinctProposal)
+    assert proposal.pocket_id == "foresight:run:r1"
+    assert proposal.category == "data"  # RFC §8 — evidence, not executing
+    assert proposal.trigger_type == "foresight"
+    assert proposal.trigger_source == "run:r1"
+    # The dedupe key is stamped under parameters._foresight so the
+    # cloud-side idempotence check can read it back.
+    block = proposal.parameters["_foresight"]
+    assert block["dedupe_key"] == "w1|r1|0|decision:renewal|p1"
+    assert block["run_id"] == "r1"
+    assert block["sub_type"] == "decision_forecast"
+    assert block["confidence"] == 0.5
+
+
+def test_decision_forecast_label_uses_forecast_prefix() -> None:
+    proposal = projected_decision_to_instinct_proposal(
+        _pd(sub_type="decision_forecast", anchor_id="decision:lease-renewal")
+    )
+    assert proposal.title.startswith("Forecast:")
+
+
+def test_market_sim_label_uses_segment_forecast_prefix() -> None:
+    proposal = projected_decision_to_instinct_proposal(
+        _pd(sub_type="market_sim", anchor_id="segment:enterprise", decision_text="churn")
+    )
+    assert proposal.title.startswith("Segment forecast:")
+    # The anchor "kind:" prefix is stripped for the human label.
+    assert "enterprise" in proposal.title
+
+
+def test_org_change_label_uses_rollout_forecast_prefix() -> None:
+    proposal = projected_decision_to_instinct_proposal(
+        _pd(
+            sub_type="org_change_rehearsal",
+            anchor_id="rollout:training",
+            decision_text="resist",
+        )
+    )
+    assert proposal.title.startswith("Rollout forecast:")
+    assert "training" in proposal.title
+
+
+def test_unknown_sub_type_falls_back_to_neutral_label() -> None:
+    proposal = projected_decision_to_instinct_proposal(_pd(sub_type="future_sub_type_v1"))
+    assert proposal.title.startswith("Forecast:")
+
+
+def test_priority_scales_with_confidence() -> None:
+    assert projected_decision_to_instinct_proposal(_pd(confidence=0.95)).priority == "critical"
+    assert projected_decision_to_instinct_proposal(_pd(confidence=0.75)).priority == "high"
+    assert projected_decision_to_instinct_proposal(_pd(confidence=0.5)).priority == "medium"
+    assert projected_decision_to_instinct_proposal(_pd(confidence=0.1)).priority == "low"
+
+
+def test_scenario_name_appears_in_description_when_supplied() -> None:
+    proposal = projected_decision_to_instinct_proposal(
+        _pd(),
+        scenario_config={"name": "Q3-renewal-forecast"},
+    )
+    assert "Q3-renewal-forecast" in proposal.description
+
+
+def test_scenario_config_is_optional() -> None:
+    # The bridge stays happy with no scenario_config — the proposal
+    # still has a valid description that doesn't mention a scenario.
+    proposal = projected_decision_to_instinct_proposal(_pd())
+    assert proposal.description  # non-empty
+
+
+def test_assignee_threads_through() -> None:
+    proposal = projected_decision_to_instinct_proposal(_pd(), assignee="user:anne")
+    assert proposal.assignee == "user:anne"
+
+
+def test_assignee_defaults_to_none() -> None:
+    proposal = projected_decision_to_instinct_proposal(_pd())
+    assert proposal.assignee is None
+
+
+def test_unknown_run_id_falls_back_to_unknown_pocket_id() -> None:
+    proposal = projected_decision_to_instinct_proposal(_pd(run_id=""))
+    assert proposal.pocket_id == "foresight:run:unknown"
+    assert proposal.trigger_source == "run:unknown"
+
+
+def test_anchor_without_prefix_passes_through_unchanged() -> None:
+    # An anchor that doesn't carry the "kind:" convention should still
+    # produce a readable title; the bridge falls back to the raw id.
+    proposal = projected_decision_to_instinct_proposal(_pd(anchor_id="raw-anchor"))
+    assert "raw-anchor" in proposal.title
+
+
+def test_forward_precedent_is_preserved_in_provenance_block() -> None:
+    proposal = projected_decision_to_instinct_proposal(_pd(forward_precedent_decision_id="dec-123"))
+    block = proposal.parameters["_foresight"]
+    assert block["forward_precedent_decision_id"] == "dec-123"


### PR DESCRIPTION
## Summary
- ProjectedDecisions now fan into the Instinct approval queue as evidence when a scenario sets `route_to_instinct=True`. Instinct's policy still owns the predicate; the proposal is non-executing. RFC 08 §8.
- New `ee/pocketpaw_ee/foresight/instinct_bridge.py` converts a `ProjectedDecision` into the kwarg shape `InstinctStore.propose()` expects. Sub-type-aware labels for Decision Forecast, Market Sim, and Org Change. Priority comes from projection confidence. A joined dedupe key `(workspace|run|tick|anchor|persona)` rides under `parameters._foresight`.
- Cloud `emit_projected_decision` now optionally fans to Instinct. Lazy import keeps the engine namespace clean, the service scans existing rows on the run's synthetic `pocket_id` and skips duplicates, and an Instinct write failure logs but never breaks the projection write the engine is waiting on.
- `GET /api/v1/foresight/runs/{id}/instinct-proposals` returns the spawned rows paginated like the projection-list endpoint, with the same 404-collapse rule for cross-tenant access.
- Threads §14.4's `forward_precedent_decision_id` through `emit_projected_decision` so the persisted doc carries the same id the engine writes onto `RunResult.projected_decisions`. The hardcoded `None` was leftover from before PR #1235.
- Backtests explicitly pass `route_to_instinct=False` so the historical-replay path never spawns Tray rows, even if a future edit flips the body default.

## Test plan
- [x] Bridge unit tests (16): dedupe stability, axis differentiation, sub-type labels, priority bands, scenario-name pass-through, assignee threading, unknown-run fallback, anchor-without-prefix tolerance, forward_precedent preserved in provenance.
- [x] Service tests (15): opt-in / opt-out routing, event emission, idempotent re-emit, distinct-axis fan-out, cross-tenant 404, workspace required, invalid limit / offset, limit cap, pagination across a 16-record Org Change run, backtest never routes, §14.4 precedent persistence.
- [x] `uv run pytest tests/ee/foresight/ tests/cloud/ -k "instinct or foresight or decision_graph_ref"` → 515 passed.
- [x] Full collection: 5467 tests collected cleanly.
- [x] ruff check + ruff format clean on changed files.
- [x] mypy clean. The 2 missing-stub warnings on `pocketpaw.instinct.models` and `pocketpaw.stores` are pre-existing baseline; the existing `cloud/pockets/instinct_bridge.py` has the same ones.
- [x] import-linter: 18 contracts kept, 0 broken. The foresight cloud → engine boundary holds; the new bridge module is engine-side but pure so cloud can import it without breaking the forbidden list (which only names `persona`, `llm`, `scenarios`, `substrate`, `world`, `aggregator`, `calibration`, `subtypes`).