### PR TITLE
feat(decisions): RFC 07 Slice 3a — narrator + explain route + pocket template

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/decisions.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/decisions.py
@@ -6,16 +6,20 @@
 #   `tasks.py` and `planner.py`: agent identity comes from the per-stream
 #   ContextVars in `ee.cloud.chat.agent_service`; outside an SSE stream
 #   the tools return a clear MCP error rather than silently mis-tenanting.
+# Updated: 2026-05-25 (RFC 07 Slice 3a) — added `decisions_explain`,
+#   the natural-language Q&A wrapper. Same identity + scope contract
+#   as the read tools; delegates to the cloud-side orchestrator at
+#   `pocketpaw_ee.cloud.decisions.explain.explain`.
 #
 # Tools registered:
 #   - decisions_get(decision_id)
 #   - decisions_find(actor=, since=, until=, scope_kind=, pocket_id=,
 #                    policy=, outcome_status=, limit=)
 #   - decisions_trace(decision_id, depth=3)
+#   - decisions_explain(question, scope=, max_decisions=, depth=,
+#                       backend=)
 #
-# `explain` (NL Q&A with narrator) is intentionally Slice 3 — not on this
-# surface yet. Same shape as the REST router's read endpoints; the wire
-# response shape is `DecisionResponse` from `decisions.dto`.
+# The wire shape mirrors the REST router so REST + MCP never drift.
 """Agent-side MCP surface for the decision-graph entity.
 
 These tools let an agent ask "what did we decide, why, and what came
@@ -47,11 +51,13 @@ SERVER_NAME = "pocketpaw_decisions"
 DECISIONS_GET_TOOL_ID = f"mcp__{SERVER_NAME}__decisions_get"
 DECISIONS_FIND_TOOL_ID = f"mcp__{SERVER_NAME}__decisions_find"
 DECISIONS_TRACE_TOOL_ID = f"mcp__{SERVER_NAME}__decisions_trace"
+DECISIONS_EXPLAIN_TOOL_ID = f"mcp__{SERVER_NAME}__decisions_explain"
 
 DECISIONS_TOOL_IDS = (
     DECISIONS_GET_TOOL_ID,
     DECISIONS_FIND_TOOL_ID,
     DECISIONS_TRACE_TOOL_ID,
+    DECISIONS_EXPLAIN_TOOL_ID,
 )
 
 
@@ -300,6 +306,65 @@ async def _decisions_trace_handler(args: dict) -> dict:
     return _success_response(_trace_wire(result))
 
 
+async def _decisions_explain_handler(args: dict) -> dict:
+    """Wrap the cloud-side explain orchestrator for MCP callers.
+
+    Same identity / scope contract as the read tools — the per-stream
+    workspace + agent id are pulled from ContextVars; outside an SSE
+    stream the handler returns an MCP error.
+    """
+    workspace_id, agent_id = _identity()
+    if not workspace_id or not agent_id:
+        return _error_response(
+            "no active workspace/agent — decisions_explain can only be called "
+            "from inside a cloud SSE chat stream"
+        )
+
+    question = args.get("question")
+    if not isinstance(question, str) or not question.strip():
+        return _error_response("question is required (non-empty string)")
+
+    scope = args.get("scope") if isinstance(args.get("scope"), dict) else None
+    max_decisions_raw = args.get("max_decisions") or 5
+    try:
+        max_decisions = max(1, min(int(max_decisions_raw), 20))
+    except (TypeError, ValueError):
+        max_decisions = 5
+
+    depth_raw = args.get("depth") or 3
+    try:
+        depth = max(1, min(int(depth_raw), 10))
+    except (TypeError, ValueError):
+        depth = 3
+
+    backend = args.get("backend")
+    if backend not in {"llm", "templated", None}:
+        backend = None
+
+    from pocketpaw_ee.cloud.decisions.dto import ExplanationResponse
+    from pocketpaw_ee.cloud.decisions.explain import ExplainRequestInput, explain
+
+    body = ExplainRequestInput(
+        question=question.strip(),
+        scope=scope,
+        max_decisions=max_decisions,
+        depth=depth,
+        backend=backend,
+    )
+
+    try:
+        explanation = await explain(
+            body,
+            requester_scopes=_requester_scopes(workspace_id),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("decisions_explain failed", exc_info=True)
+        return _error_response(f"decisions_explain failed: {exc}")
+
+    wire = ExplanationResponse.from_domain(explanation)
+    return _success_response(wire.model_dump(mode="json"))
+
+
 # ---------------------------------------------------------------------------
 # Server factory — matches the shape of `build_tasks_context_server`
 # ---------------------------------------------------------------------------
@@ -386,15 +451,45 @@ def build_decisions_context_server() -> tuple[str, Any] | None:
     async def decisions_trace(args):  # type: ignore[no-untyped-def]
         return await _decisions_trace_handler(args)
 
+    @tool(
+        "decisions_explain",
+        (
+            "Ask a natural-language question of the decision graph and get "
+            "a grounded narrative answer with citations. The pipeline "
+            "extracts entities from the question (Haiku call, cached), "
+            "finds candidate decisions in the caller's scope, walks a "
+            "depth-bounded trace upstream from the top candidate, and "
+            "narrates the result with Sonnet (or a deterministic "
+            "templated narrator when `backend=\"templated\"` is set or "
+            "the LLM call fails). Every sentence in the narrative cites "
+            "a decision id; the response also surfaces "
+            "`decisions_walked` (every node in the trace) and "
+            "`ungrounded_sentences` (anything the verifier stripped). "
+            "Use this to answer free-form 'why did we...' questions when "
+            "you don't already have a decision id — for known ids, "
+            "prefer `decisions_get` + `decisions_trace`."
+        ),
+        {
+            "question": str,
+            "scope": dict,
+            "max_decisions": int,
+            "depth": int,
+            "backend": str,
+        },
+    )
+    async def decisions_explain(args):  # type: ignore[no-untyped-def]
+        return await _decisions_explain_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
         version="1.0.0",
-        tools=[decisions_get, decisions_find, decisions_trace],
+        tools=[decisions_get, decisions_find, decisions_trace, decisions_explain],
     )
     return SERVER_NAME, server
 
 
 __all__ = [
+    "DECISIONS_EXPLAIN_TOOL_ID",
     "DECISIONS_FIND_TOOL_ID",
     "DECISIONS_GET_TOOL_ID",
     "DECISIONS_TOOL_IDS",

--- a/ee/pocketpaw_ee/cloud/decisions/dto.py
+++ b/ee/pocketpaw_ee/cloud/decisions/dto.py
@@ -10,6 +10,11 @@
 #   `(ts DESC, id DESC)` — the cursor is encoded as opaque
 #   `before_ts` / `before_id` query params; the response echoes them
 #   back as `next_before_ts` / `next_before_id` for the next page.
+# Updated: 2026-05-25 (RFC 07 Slice 3a) — added the explain DTOs
+#   (`ExplainRequest`, `ExplanationResponse`) for the
+#   `POST /api/v1/decisions/explain` route. Wire ≠ domain (Rule 4): the
+#   domain `Explanation` lives in `decisions.explain.narrator`; the wire
+#   response trims the field list to what the UI consumes.
 from __future__ import annotations
 
 from datetime import datetime
@@ -311,6 +316,68 @@ class TimelineResponse(BaseModel):
     events: list[JournalEventDTO] = Field(default_factory=list)
 
 
+# ---------------------------------------------------------------------------
+# POST /api/v1/decisions/explain  (Slice 3a)
+# ---------------------------------------------------------------------------
+
+
+class ExplainRequest(BaseModel):
+    """Validated body for `POST /api/v1/decisions/explain`.
+
+    The natural-language question is required; everything else is
+    optional. `backend` lets a per-pocket overlay opt out of the LLM
+    narrator (per RFC 07 line 621 — `narrator.backend_pref`); the
+    default `None` keeps the orchestrator's "llm with templated
+    fallback" behavior.
+
+    `max_decisions` caps how many candidates the extractor's find()
+    step pulls. The narrator only walks the top candidate; the cap
+    bounds the find() cost not the narration cost.
+    """
+
+    model_config = ConfigDict(frozen=False)
+
+    question: str = Field(min_length=1, max_length=2000)
+    scope: dict[str, Any] | None = None
+    max_decisions: int = Field(default=5, ge=1, le=20)
+    depth: int = Field(default=3, ge=1, le=10)
+    backend: Literal["llm", "templated"] | None = None
+
+
+class ExplanationResponse(BaseModel):
+    """Wire mirror of `decisions.explain.narrator.Explanation`.
+
+    `ungrounded_sentences` is included so the UI can surface them
+    when the verifier strips a hallucinated citation — telemetry
+    point for the operator to see how often the narrator
+    over-reaches. Empty by default.
+    """
+
+    model_config = ConfigDict(frozen=False)
+
+    narrative: str
+    decisions_walked: list[UUID] = Field(default_factory=list)
+    depth_reached: int = 0
+    tokens_in: int = 0
+    tokens_out: int = 0
+    ungrounded_sentences: list[str] = Field(default_factory=list)
+    backend_used: Literal["llm", "templated"] = "templated"
+
+    @classmethod
+    def from_domain(cls, explanation: Any) -> ExplanationResponse:
+        """Build the wire response from a domain Explanation. Single
+        mapping path so the REST + MCP surfaces never drift."""
+        return cls(
+            narrative=explanation.narrative,
+            decisions_walked=list(explanation.decisions_walked),
+            depth_reached=explanation.depth_reached,
+            tokens_in=explanation.tokens_in,
+            tokens_out=explanation.tokens_out,
+            ungrounded_sentences=list(explanation.ungrounded_sentences),
+            backend_used=explanation.backend_used,
+        )
+
+
 __all__ = [
     "ApproverWire",
     "DecisionResponse",
@@ -319,6 +386,8 @@ __all__ = [
     "DecisionsListRequest",
     "DecisionsListResponse",
     "EdgeDTO",
+    "ExplainRequest",
+    "ExplanationResponse",
     "InputWire",
     "JournalEventDTO",
     "OutcomeWire",

--- a/ee/pocketpaw_ee/cloud/decisions/explain/__init__.py
+++ b/ee/pocketpaw_ee/cloud/decisions/explain/__init__.py
@@ -1,0 +1,40 @@
+# ee/pocketpaw_ee/cloud/decisions/explain/__init__.py
+# Created: 2026-05-25 (RFC 07 Slice 3a) — package marker for the
+#   natural-language explain pipeline that sits on top of the deterministic
+#   DecisionGraph. Four submodules:
+#     - extractor.py — small LLM call that turns a question into structured
+#       filters (templated fallback when no API key).
+#     - narrator.py  — grounded prose generation. Two backends: a Sonnet
+#       LLM path (default) and a deterministic templated path used when
+#       the LLM call fails or the pocket config opts in.
+#     - cache.py     — 24h cache keyed on (question_norm, root_id, depth,
+#       scope_hash) backed by the same SQLite store as the projection.
+#     - service.py   — the ``explain(question, scope, max_decisions,
+#       backend)`` orchestrator the router and MCP wrapper both call.
+#
+#   The split keeps each piece narrow enough to unit-test in isolation
+#   and lines up with the four-file ee/cloud entity convention even
+#   though this is a sub-package (the parent `decisions/` already owns
+#   domain/dto/service/router; this nests under it).
+
+from pocketpaw_ee.cloud.decisions.explain.extractor import (
+    ExtractedEntities,
+    extract_entities,
+)
+from pocketpaw_ee.cloud.decisions.explain.narrator import (
+    Explanation,
+    narrate_decision,
+)
+from pocketpaw_ee.cloud.decisions.explain.service import (
+    ExplainRequestInput,
+    explain,
+)
+
+__all__ = [
+    "ExplainRequestInput",
+    "Explanation",
+    "ExtractedEntities",
+    "explain",
+    "extract_entities",
+    "narrate_decision",
+]

--- a/ee/pocketpaw_ee/cloud/decisions/explain/cache.py
+++ b/ee/pocketpaw_ee/cloud/decisions/explain/cache.py
@@ -1,0 +1,376 @@
+# ee/pocketpaw_ee/cloud/decisions/explain/cache.py
+# Created: 2026-05-25 (RFC 07 Slice 3a) — the 24h cache for natural-
+#   language explain responses. Per RFC 07 § Open Question 6
+#   (amendment): cache keyed on
+#     (normalized_question, root_decision_id, depth, scope_hash)
+#   Invalidation per RFC 07 § Open Question 8 amendment: when the
+#   projection folds a new event, walk a reverse index keyed by
+#   `decisions_walked` and drop every cache entry whose walked set
+#   contains the affected decision.
+#
+# Layering note — no cycle:
+#   cache.py imports `decisions.store` (to share the SQLite
+#   connection) and registers a callback against
+#   `decisions.projection`'s post-apply hook registry. The projection
+#   never imports cache; it only invokes whatever hooks were registered.
+#   That keeps the layering one-way: explain → decisions, never
+#   decisions → explain.
+#
+# Schema lives in `decisions.store` so the cache + decisions tables
+# share one SQLite file (`~/.soul/decisions.db`) — no second connection
+# pool, same WAL semantics, same on-disk artifact for the operator
+# backup story.
+"""Cache layer + invalidation for the explain pipeline."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import threading
+from collections.abc import Iterable
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID
+
+from pocketpaw_ee.cloud.decisions.domain import Decision
+from pocketpaw_ee.cloud.decisions.explain.narrator import Explanation
+from pocketpaw_ee.cloud.decisions.store import DecisionStore
+
+logger = logging.getLogger(__name__)
+
+# Default cache TTL — 24 hours per RFC 07 § Open Question 6.
+DEFAULT_TTL = timedelta(hours=24)
+
+
+# ---------------------------------------------------------------------------
+# Key derivation — deterministic across processes
+# ---------------------------------------------------------------------------
+
+
+def _normalize_question(question: str) -> str:
+    """Collapse whitespace + lowercase so trivial reformattings hit the
+    same cache row. Punctuation is kept so "Why X?" and "Why X" are
+    treated as the same query (the question-mark carries no semantic
+    weight in the cache key)."""
+    text = question.strip().lower()
+    text = re.sub(r"\s+", " ", text)
+    text = text.rstrip("?!.")
+    return text
+
+
+def _hash_scope(scope: dict[str, Any] | None) -> str:
+    """Stable hash of the scope dict — sorts keys so {a:1, b:2} and
+    {b:2, a:1} hash the same."""
+    if not scope:
+        return "empty"
+    raw = json.dumps(scope, sort_keys=True, default=str)
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def build_cache_key(
+    *,
+    question_normalized: str,
+    root_decision_id: UUID | None,
+    depth: int,
+    scope_hash: str,
+) -> str:
+    """Compose the deterministic cache key. The root id is the
+    primary cache discriminator — same question against different
+    decision roots is a different entry. ``None`` root collapses to
+    the literal "none" so questions that don't pin a root still hash
+    stably."""
+    root_part = str(root_decision_id) if root_decision_id is not None else "none"
+    raw = f"{question_normalized}||{root_part}||{depth}||{scope_hash}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# DDL — applied lazily on the shared DecisionStore connection
+# ---------------------------------------------------------------------------
+
+_CACHE_DDL = """
+CREATE TABLE IF NOT EXISTS decision_explain_cache (
+    cache_key TEXT PRIMARY KEY,
+    question_normalized TEXT NOT NULL,
+    root_decision_id TEXT,
+    depth INTEGER NOT NULL,
+    scope_hash TEXT NOT NULL,
+    explanation_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    decisions_walked TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_explain_cache_expires
+    ON decision_explain_cache(expires_at);
+CREATE INDEX IF NOT EXISTS idx_explain_cache_root
+    ON decision_explain_cache(root_decision_id);
+"""
+
+
+# Per-process flag — DDL only runs the first time the cache touches
+# the store. WAL mode + IF NOT EXISTS make this idempotent across
+# multiple processes pointed at the same SQLite file.
+_DDL_APPLIED: dict[int, bool] = {}
+_DDL_LOCK = threading.Lock()
+
+
+def _ensure_schema(store: DecisionStore) -> None:
+    """Apply the cache DDL on the store's connection. Idempotent —
+    IF NOT EXISTS makes re-runs cheap."""
+    conn = store._conn  # noqa: SLF001 — sibling module shares the connection
+    if conn is None:
+        return
+    with _DDL_LOCK:
+        if _DDL_APPLIED.get(id(conn)):
+            return
+        conn.executescript(_CACHE_DDL)
+        _DDL_APPLIED[id(conn)] = True
+
+
+# ---------------------------------------------------------------------------
+# Public cache API
+# ---------------------------------------------------------------------------
+
+
+class ExplainCache:
+    """24-hour cache for explain responses, sharing the decision store's
+    SQLite file. Thread-safe via the store's existing write lock."""
+
+    def __init__(
+        self,
+        store: DecisionStore,
+        *,
+        ttl: timedelta | None = None,
+    ) -> None:
+        self._store = store
+        self._ttl = ttl or DEFAULT_TTL
+        _ensure_schema(store)
+
+    @property
+    def ttl(self) -> timedelta:
+        return self._ttl
+
+    # --- reads --------------------------------------------------------------
+
+    def get(self, cache_key: str, *, now: datetime | None = None) -> Explanation | None:
+        """Fetch a cached explanation. Returns ``None`` on miss, expired
+        entry, or shape error. Expired entries are not GC'd here — the
+        sweeper does that lazily (cheap enough to skip on the hot path)."""
+        now = now or datetime.now(timezone.utc)
+        conn = self._store._conn  # noqa: SLF001
+        if conn is None:
+            return None
+        row = conn.execute(
+            "SELECT * FROM decision_explain_cache WHERE cache_key = ?",
+            (cache_key,),
+        ).fetchone()
+        if row is None:
+            return None
+        try:
+            expires = datetime.fromisoformat(row["expires_at"])
+        except (TypeError, ValueError):
+            return None
+        if expires <= now:
+            # Stale — delete inline so the next hit skips this row.
+            self._delete(cache_key)
+            return None
+        try:
+            payload = json.loads(row["explanation_json"])
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return None
+        try:
+            return Explanation.model_validate(payload)
+        except Exception:  # noqa: BLE001
+            return None
+
+    # --- writes -------------------------------------------------------------
+
+    def put(
+        self,
+        cache_key: str,
+        explanation: Explanation,
+        *,
+        question_normalized: str,
+        root_decision_id: UUID | None,
+        depth: int,
+        scope_hash: str,
+        now: datetime | None = None,
+    ) -> None:
+        """Insert or replace the cache entry. ``decisions_walked`` is
+        serialised as a JSON array string so the reverse-index search
+        is a single LIKE-glob (good enough at expected scale)."""
+        now = now or datetime.now(timezone.utc)
+        expires = now + self._ttl
+        walked_json = json.dumps([str(uid) for uid in explanation.decisions_walked])
+        explanation_json = explanation.model_dump_json()
+        conn = self._store._conn  # noqa: SLF001
+        if conn is None:
+            return
+        # Reuse the store's write lock so we never write concurrently
+        # with the projection (which would block the connection).
+        with self._store._lock:  # noqa: SLF001
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO decision_explain_cache (
+                    cache_key,
+                    question_normalized,
+                    root_decision_id,
+                    depth,
+                    scope_hash,
+                    explanation_json,
+                    created_at,
+                    expires_at,
+                    decisions_walked
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    cache_key,
+                    question_normalized,
+                    str(root_decision_id) if root_decision_id else None,
+                    int(depth),
+                    scope_hash,
+                    explanation_json,
+                    now.isoformat(),
+                    expires.isoformat(),
+                    walked_json,
+                ),
+            )
+
+    # --- invalidation -------------------------------------------------------
+
+    def invalidate_for_decisions(self, decision_ids: Iterable[UUID]) -> int:
+        """Drop every cache entry whose `decisions_walked` list contains
+        any of the supplied decision ids. Returns the number of rows
+        deleted (for telemetry / test assertions).
+
+        Implementation note: the reverse index is a JSON array column;
+        for the expected entry count (low thousands per org per day) a
+        LIKE-glob over the serialised string is fast enough and avoids
+        a many-to-many join table. If the row count grows past
+        ~100k we'll introduce `decision_explain_cache_walk` and a true
+        index — captured in the RFC 07 § amendment.
+        """
+        ids = [str(d) for d in decision_ids]
+        if not ids:
+            return 0
+        conn = self._store._conn  # noqa: SLF001
+        if conn is None:
+            return 0
+        with self._store._lock:  # noqa: SLF001
+            # Build OR-chain of LIKE-globs — one per id. Parameterised
+            # so the strings can't escape into the SQL.
+            clauses = " OR ".join(["decisions_walked LIKE ?"] * len(ids))
+            params = [f"%{d}%" for d in ids]
+            cursor = conn.execute(
+                f"DELETE FROM decision_explain_cache WHERE {clauses}",
+                params,
+            )
+            return cursor.rowcount or 0
+
+    def sweep_expired(self, *, now: datetime | None = None) -> int:
+        """Drop every expired row. Cheap to run periodically; not on
+        the hot path (cache.get handles expiry inline for the hit row)."""
+        now = now or datetime.now(timezone.utc)
+        conn = self._store._conn  # noqa: SLF001
+        if conn is None:
+            return 0
+        with self._store._lock:  # noqa: SLF001
+            cursor = conn.execute(
+                "DELETE FROM decision_explain_cache WHERE expires_at <= ?",
+                (now.isoformat(),),
+            )
+            return cursor.rowcount or 0
+
+    def count(self) -> int:
+        """Total cached rows (test seam)."""
+        conn = self._store._conn  # noqa: SLF001
+        if conn is None:
+            return 0
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM decision_explain_cache"
+        ).fetchone()
+        return int(row["n"]) if row else 0
+
+    # --- internals ---------------------------------------------------------
+
+    def _delete(self, cache_key: str) -> None:
+        conn = self._store._conn  # noqa: SLF001
+        if conn is None:
+            return
+        with self._store._lock:  # noqa: SLF001
+            conn.execute(
+                "DELETE FROM decision_explain_cache WHERE cache_key = ?",
+                (cache_key,),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Singleton + projection hook registration
+# ---------------------------------------------------------------------------
+
+
+_CACHE: ExplainCache | None = None
+
+
+def get_explain_cache() -> ExplainCache:
+    """Return the process-wide ExplainCache. Lazy-bound to the same
+    DecisionStore the projection writes through."""
+    global _CACHE
+    if _CACHE is None:
+        from pocketpaw_ee.cloud.decisions.service import get_decision_graph
+
+        graph = get_decision_graph()
+        _CACHE = ExplainCache(graph.store)
+        _register_projection_hook(graph)
+    return _CACHE
+
+
+def reset_explain_cache_for_tests() -> None:
+    """Drop the singleton so the next call rebuilds against the current
+    store (paired with `set_db_path` in test fixtures)."""
+    global _CACHE
+    _CACHE = None
+    # Also clear the DDL-applied marker so the next test gets a fresh
+    # ensure_schema call.
+    _DDL_APPLIED.clear()
+
+
+def _register_projection_hook(graph: Any) -> None:
+    """Wire the cache's invalidator into the projection's post-apply hook.
+
+    Idempotent — calling twice re-registers the same callback once. The
+    projection exposes a stable callback registry per RFC 07 Slice 3a
+    amendment so this layering stays one-way (explain → decisions).
+    """
+    projection = graph.projection
+    if not hasattr(projection, "register_post_apply_hook"):
+        # Older projection without the hook registry — degrade
+        # gracefully (cache invalidation becomes manual via sweep_expired).
+        logger.warning(
+            "DecisionProjection.register_post_apply_hook missing; "
+            "explain cache invalidation will rely on TTL only"
+        )
+        return
+
+    def _hook(decision: Decision) -> None:
+        try:
+            cache = _CACHE
+            if cache is None:
+                return
+            cache.invalidate_for_decisions([decision.id])
+        except Exception:  # noqa: BLE001
+            logger.warning("explain cache invalidation hook failed", exc_info=True)
+
+    projection.register_post_apply_hook(_hook)
+
+
+__all__ = [
+    "DEFAULT_TTL",
+    "ExplainCache",
+    "build_cache_key",
+    "get_explain_cache",
+    "reset_explain_cache_for_tests",
+]

--- a/ee/pocketpaw_ee/cloud/decisions/explain/extractor.py
+++ b/ee/pocketpaw_ee/cloud/decisions/explain/extractor.py
@@ -1,0 +1,398 @@
+# ee/pocketpaw_ee/cloud/decisions/explain/extractor.py
+# Created: 2026-05-25 (RFC 07 Slice 3a) — the entity extractor for the
+#   natural-language `explain` pipeline. RFC 07 § "LLM-grounded query"
+#   pins the contract: one small LLM call (Haiku-class), output is
+#   structured filter args, the input is ALWAYS the same shape so the
+#   system prompt + few-shots cache cleanly. The question text is the
+#   only variable portion.
+#
+#   Two paths:
+#     - Default: a Haiku call via the `anthropic` SDK. The system prompt
+#       and a stable handful of few-shot pairs are sent as cache-able
+#       blocks (cache_control = {"type": "ephemeral"} on the last
+#       cacheable block — Anthropic caches the prefix). The question
+#       lives in the user message and varies per call.
+#     - Fallback: a deterministic regex-driven extractor copied from the
+#       Slice 3 PoC at /tmp/team-rfc07/explain/narrator.py. Used when:
+#         (a) the `anthropic` SDK isn't installed,
+#         (b) no API key is configured,
+#         (c) the LLM call raises, or
+#         (d) the caller passed `backend="templated"`.
+#
+#   The fallback isn't a degraded path — for the captain's killer demo
+#   it produces a *deterministic* test for the lease-renewal question
+#   ("Why was LR-2026-117 approved on April 22?"). The LLM path widens
+#   coverage to free-form questions but the templated path is the proven
+#   floor.
+#
+#   Latency budget: 200-400ms for the LLM call; the fallback is O(question
+#   length) regex and runs in microseconds.
+"""Entity extractor for the natural-language explain pipeline."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Output shape
+# ---------------------------------------------------------------------------
+
+
+class ExtractedEntities(BaseModel):
+    """Structured filters distilled from a natural-language question.
+
+    Every field is optional — the explain pipeline takes the intersection of
+    whatever the extractor recovered and the caller's scope. A question
+    with NO recoverable entities triggers a fallback where the pipeline
+    returns the most-recent-N decisions in the caller's scope (so the
+    narrator always has something to walk).
+    """
+
+    model_config = ConfigDict(frozen=False)
+
+    decision_ids: list[UUID] = Field(default_factory=list)
+    actor_refs: list[str] = Field(default_factory=list)
+    fabric_object_refs: list[str] = Field(default_factory=list)
+    time_range: tuple[datetime | None, datetime | None] | None = None
+    policy_ref: str | None = None
+    pocket_id: str | None = None
+    outcome_hint: Literal["approved", "rejected", "landed", "pending"] | None = None
+
+
+# ---------------------------------------------------------------------------
+# System prompt + few-shots — the cache-able prefix
+# ---------------------------------------------------------------------------
+
+# The system prompt and few-shots are split into one cache-able block so
+# every call hits the same prefix. Anthropic caches up to four blocks
+# marked with cache_control = ephemeral; we only need one here because
+# system + few-shots are a single logical unit. Only the user message
+# (the question) varies per call.
+
+_EXTRACTOR_SYSTEM = """You extract structured filters from natural-language questions about an organization's decision log.
+
+Return ONE JSON object with these optional keys:
+- decision_ids: list of UUID strings referenced explicitly in the question
+- actor_refs:   list of actor identifiers (e.g. "user:prakash", "did:soul:renewal_specialist")
+- fabric_object_refs: list of fabric-object identifiers (e.g. "lease:LR-2026-117", "case:c_42")
+- time_range:   pair [iso_start, iso_end] in UTC; either may be null for an open bound
+- policy_ref:   Instinct policy name if named (e.g. "approve_per_row")
+- pocket_id:    pocket id if named (e.g. "p_renewals")
+- outcome_hint: one of "approved" | "rejected" | "landed" | "pending"
+
+Rules:
+- Omit any key the question does not constrain. Do not invent values.
+- For fabric-object identifiers, lowercase the type prefix and uppercase the id ("lease:LR-2026-117").
+- For month-day expressions without a year, assume the current calendar year.
+- Output the JSON object only — no prose, no markdown fences."""
+
+
+_FEWSHOTS: list[tuple[str, dict[str, Any]]] = [
+    (
+        "Why was lease renewal LR-2026-117 approved on April 22?",
+        {
+            "fabric_object_refs": ["lease:LR-2026-117"],
+            "time_range": ["2026-04-22T00:00:00Z", "2026-04-23T00:00:00Z"],
+            "outcome_hint": "approved",
+        },
+    ),
+    (
+        "Show me everything Prakash approved this month in the renewals pocket.",
+        {
+            "actor_refs": ["user:prakash"],
+            "pocket_id": "p_renewals",
+            "outcome_hint": "approved",
+        },
+    ),
+    (
+        "What did the approve_per_row policy reject last week?",
+        {
+            "policy_ref": "approve_per_row",
+            "outcome_hint": "rejected",
+        },
+    ),
+]
+
+
+def _build_user_message(question: str) -> str:
+    """Render the per-call user message. The few-shots are baked into the
+    system prefix so the cache hit rate stays high across questions."""
+    shots = "\n\n".join(
+        f"Question: {q}\nOutput: {json.dumps(out, separators=(',', ':'))}"
+        for q, out in _FEWSHOTS
+    )
+    return (
+        f"Few-shot examples (do not echo):\n{shots}\n\n"
+        f"Now extract from this question. Output JSON only.\n\n"
+        f"Question: {question}\nOutput:"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def extract_entities(
+    question: str,
+    *,
+    scope: dict[str, Any] | None = None,
+    backend: Literal["llm", "templated"] | None = None,
+    api_key: str | None = None,
+    model: str = "claude-haiku-4-7",
+) -> ExtractedEntities:
+    """Extract structured filters from a natural-language question.
+
+    Args:
+        question: Free-form question from the user.
+        scope: Caller's scope (workspace / pocket hints). When the question
+            doesn't name a pocket but `scope["pocket_id"]` is set, the
+            scope value is used.
+        backend: Force "templated" to skip the LLM path entirely. Defaults
+            to the LLM path when the SDK + key are available.
+        api_key: Override the Anthropic API key (test seam). Defaults to
+            the `POCKETPAW_ANTHROPIC_API_KEY` resolved via `get_settings`.
+        model: Haiku-class model id. Caller can pin a specific version.
+
+    Returns:
+        An ExtractedEntities — never None, never raises. On any LLM
+        failure (SDK missing, key missing, network error, parse error)
+        the call falls through to the templated extractor and the result
+        is still a valid ExtractedEntities.
+    """
+    scope = scope or {}
+    if backend == "templated":
+        return _templated_extract(question, scope)
+
+    # Resolve API key — caller override > settings.
+    if api_key is None:
+        try:
+            from pocketpaw.config import get_settings
+
+            api_key = get_settings().anthropic_api_key
+        except Exception:  # noqa: BLE001
+            api_key = None
+
+    if not api_key:
+        return _templated_extract(question, scope)
+
+    try:
+        from anthropic import AsyncAnthropic
+    except ImportError:
+        logger.info("anthropic SDK not installed; explain extractor using templated path")
+        return _templated_extract(question, scope)
+
+    try:
+        client = AsyncAnthropic(api_key=api_key, timeout=10.0, max_retries=1)
+        response = await client.messages.create(
+            model=model,
+            max_tokens=400,
+            system=[
+                {
+                    "type": "text",
+                    "text": _EXTRACTOR_SYSTEM,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[
+                {"role": "user", "content": _build_user_message(question)},
+            ],
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("explain extractor LLM call failed; falling back to templated", exc_info=True)
+        return _templated_extract(question, scope)
+
+    try:
+        raw = response.content[0].text
+    except (AttributeError, IndexError):
+        return _templated_extract(question, scope)
+
+    parsed = _parse_llm_output(raw)
+    if parsed is None:
+        return _templated_extract(question, scope)
+
+    # Apply scope defaults — if the LLM didn't name a pocket but the
+    # caller scope has one, prefer the scope value.
+    if not parsed.pocket_id and scope.get("pocket_id"):
+        parsed.pocket_id = scope["pocket_id"]
+    return parsed
+
+
+def _parse_llm_output(raw: str) -> ExtractedEntities | None:
+    """Parse the model's JSON output into ExtractedEntities. Returns None
+    on any parse / shape error so the caller can fall through."""
+    text = raw.strip()
+    if not text:
+        return None
+    # Strip a stray code fence if the model wrapped it.
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```\s*$", "", text)
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    decision_ids: list[UUID] = []
+    for raw_id in data.get("decision_ids", []) or []:
+        try:
+            decision_ids.append(UUID(str(raw_id)))
+        except (ValueError, TypeError):
+            continue
+
+    time_range: tuple[datetime | None, datetime | None] | None = None
+    tr = data.get("time_range")
+    if isinstance(tr, list) and len(tr) == 2:
+        time_range = (_parse_iso(tr[0]), _parse_iso(tr[1]))
+
+    return ExtractedEntities(
+        decision_ids=decision_ids,
+        actor_refs=[str(a) for a in (data.get("actor_refs") or []) if a],
+        fabric_object_refs=[str(o) for o in (data.get("fabric_object_refs") or []) if o],
+        time_range=time_range,
+        policy_ref=data.get("policy_ref") or None,
+        pocket_id=data.get("pocket_id") or None,
+        outcome_hint=(
+            data["outcome_hint"]
+            if data.get("outcome_hint") in {"approved", "rejected", "landed", "pending"}
+            else None
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Templated fallback — deterministic regex extractor
+# ---------------------------------------------------------------------------
+
+_MONTH_NAMES = {
+    "january": 1, "february": 2, "march": 3, "april": 4, "may": 5, "june": 6,
+    "july": 7, "august": 8, "september": 9, "october": 10, "november": 11, "december": 12,
+}
+
+_FABRIC_PREFIXES = ("lease", "case", "patient", "vendor", "tenant", "deal", "ticket")
+
+
+def _templated_extract(question: str, scope: dict[str, Any]) -> ExtractedEntities:
+    """Regex-driven entity extraction. Mirrors the PoC at
+    /tmp/team-rfc07/explain/narrator.py extract_entities() but returns
+    the production ExtractedEntities shape."""
+
+    q_lower = question.lower()
+    out = ExtractedEntities()
+
+    # decision-id UUIDs explicitly mentioned
+    for raw_uuid in re.findall(
+        r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b",
+        question,
+    ):
+        try:
+            out.decision_ids.append(UUID(raw_uuid))
+        except ValueError:
+            continue
+
+    # fabric-object refs like "lease:LR-2026-117" or bare "LR-2026-117"
+    for m in re.finditer(
+        r"\b((?:" + "|".join(_FABRIC_PREFIXES) + r")\s*[:\-]?\s*[A-Za-z0-9\-_]+)\b",
+        question,
+        re.IGNORECASE,
+    ):
+        token = m.group(1).strip()
+        # normalize "lease:LR-..." → "lease:LR-..."; "lease LR-..." → same
+        norm = re.sub(r"\s+", "", token)
+        # split prefix from id
+        sep_match = re.match(r"^([A-Za-z]+)[:\-]?(.+)$", norm)
+        if sep_match:
+            prefix = sep_match.group(1).lower()
+            ident = sep_match.group(2).upper()
+            normalized = f"{prefix}:{ident}"
+            if normalized not in out.fabric_object_refs:
+                out.fabric_object_refs.append(normalized)
+
+    # Bare "LR-YYYY-NNN" — assume lease.
+    for m in re.finditer(r"\b(LR-\d{4}-\d+)\b", question):
+        normalized = f"lease:{m.group(1)}"
+        if normalized not in out.fabric_object_refs:
+            out.fabric_object_refs.append(normalized)
+
+    # actor — "by Prakash", "Prakash approved"
+    for m in re.finditer(r"\bby\s+([A-Z][a-z]+)\b", question):
+        ref = f"user:{m.group(1).lower()}"
+        if ref not in out.actor_refs:
+            out.actor_refs.append(ref)
+    # Capitalized name followed by an approval/decision verb.
+    for m in re.finditer(r"\b([A-Z][a-z]+)\s+(?:approved|rejected|decided|signed)\b", question):
+        ref = f"user:{m.group(1).lower()}"
+        if ref not in out.actor_refs:
+            out.actor_refs.append(ref)
+
+    # time — ISO yyyy-mm-dd or "April 22"
+    iso_match = re.search(r"\b(\d{4})-(\d{2})-(\d{2})\b", question)
+    if iso_match:
+        y, mo, d = map(int, iso_match.groups())
+        start = datetime(y, mo, d, tzinfo=timezone.utc)
+        out.time_range = (start, start + timedelta(days=1))
+    else:
+        mo_match = re.search(
+            r"\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2})\b",
+            question,
+            re.IGNORECASE,
+        )
+        if mo_match:
+            month = _MONTH_NAMES[mo_match.group(1).lower()]
+            day = int(mo_match.group(2))
+            year = datetime.now(timezone.utc).year
+            start = datetime(year, month, day, tzinfo=timezone.utc)
+            out.time_range = (start, start + timedelta(days=1))
+
+    # policy — "approve_per_row policy" or just "approve_per_row"
+    pol_match = re.search(r"\b([a-z][a-z0-9_]+)(?:\s+policy)\b", q_lower)
+    if pol_match:
+        out.policy_ref = pol_match.group(1)
+    else:
+        pol_match = re.search(r"\bpolicy\s+([a-z][a-z0-9_]+)\b", q_lower)
+        if pol_match:
+            out.policy_ref = pol_match.group(1)
+
+    # outcome
+    if any(w in q_lower for w in ("approved", "approve")):
+        out.outcome_hint = "approved"
+    elif any(w in q_lower for w in ("rejected", "denied", "blocked")):
+        out.outcome_hint = "rejected"
+    elif "landed" in q_lower:
+        out.outcome_hint = "landed"
+    elif "pending" in q_lower:
+        out.outcome_hint = "pending"
+
+    # pocket — explicit or scope default
+    pkt_match = re.search(r"\bpocket\s+([a-z][a-z0-9_]+)\b", q_lower)
+    if pkt_match:
+        out.pocket_id = pkt_match.group(1)
+    if not out.pocket_id and scope.get("pocket_id"):
+        out.pocket_id = scope["pocket_id"]
+
+    return out
+
+
+def _parse_iso(v: Any) -> datetime | None:
+    if v is None:
+        return None
+    if isinstance(v, datetime):
+        return v
+    try:
+        return datetime.fromisoformat(str(v).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = ["ExtractedEntities", "extract_entities"]

--- a/ee/pocketpaw_ee/cloud/decisions/explain/narrator.py
+++ b/ee/pocketpaw_ee/cloud/decisions/explain/narrator.py
@@ -1,0 +1,515 @@
+# ee/pocketpaw_ee/cloud/decisions/explain/narrator.py
+# Created: 2026-05-25 (RFC 07 Slice 3a) — the narrator that produces
+#   grounded prose from a Decision + its trace. RFC 07 § narrator
+#   constraints:
+#     - every claim cites a decision id
+#     - no speculation outside the trace
+#     - verifier hook scans the narrative for decision-id citations;
+#       sentences without a citation are stripped or flagged
+#
+#   Two backends:
+#     - "llm"        — Sonnet (Anthropic) call with system prompt cached;
+#                      the trace is compressed to ~1.5k tokens in the
+#                      variable user message. Output streams when the SDK
+#                      supports it (we collect and return the joined text
+#                      since the route is request/response, not SSE).
+#     - "templated"  — deterministic walk over the trace nodes. Produces
+#                      one paragraph per Decision with citations. Used
+#                      when the LLM call fails, the SDK is missing, no
+#                      API key is configured, or the caller opts in via
+#                      `backend_pref="templated"` on the pocket overlay.
+#
+#   The verifier is the same code path for both backends — stripping
+#   ungrounded sentences from the templated narrator is a no-op (every
+#   sentence carries a citation), but the symmetry catches future drift
+#   if the template ever ships an ungrounded sentence by accident.
+"""Narrator for the natural-language explain pipeline."""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pocketpaw_ee.cloud.decisions.domain import Decision
+from pocketpaw_ee.cloud.decisions.service import TraceResult
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Domain output
+# ---------------------------------------------------------------------------
+
+
+class Explanation(BaseModel):
+    """The narrator's grounded output, with provenance for the verifier.
+
+    ``decisions_walked`` is what the cache layer uses for invalidation —
+    a new event folded into any of those decisions invalidates the cache
+    entry.
+
+    ``ungrounded_sentences`` carries every sentence the verifier flagged.
+    Default behavior strips them from `narrative`; the list is kept so
+    the caller (and tests) can see what the model tried to assert.
+    """
+
+    model_config = ConfigDict(frozen=False)
+
+    narrative: str
+    decisions_walked: list[UUID] = Field(default_factory=list)
+    depth_reached: int = 0
+    tokens_in: int = 0
+    tokens_out: int = 0
+    ungrounded_sentences: list[str] = Field(default_factory=list)
+    backend_used: Literal["llm", "templated"] = "templated"
+
+
+# ---------------------------------------------------------------------------
+# Narrator system prompt (cache-able)
+# ---------------------------------------------------------------------------
+
+_NARRATOR_SYSTEM = """You explain decisions by walking a supplied decision graph.
+
+Constraints — every output must follow these:
+1. Every factual claim cites a decision id in square brackets, e.g. "[a1b2c3d4]". Use the short form (first 8 hex characters of the UUID).
+2. You do not assert anything outside the supplied trace. If the trace does not contain a fact, you do not state it.
+3. You produce ONE paragraph by default — 2-4 sentences, each citing the decision id it summarizes. Follow-up questions can expand.
+4. You do not editorialize. You do not speculate about motives. You report what the decisions and their inputs/approvers/outcomes show.
+
+If the trace is empty or has no decisions, reply with exactly: "No matching decision was found in the supplied trace."
+
+Output the paragraph only — no preamble, no markdown headers, no closing remarks."""
+
+
+_MAX_TRACE_TOKENS = 1500  # RFC 07 § compress trace to ~1.5k tokens
+
+
+# ---------------------------------------------------------------------------
+# Compression — trim the trace to a token budget for the LLM
+# ---------------------------------------------------------------------------
+
+
+def _compress_trace(root: Decision, trace: TraceResult) -> dict[str, Any]:
+    """Reduce the trace to the fields the narrator needs.
+
+    Drops large payload blobs. Keeps ids, timestamps, actor, intent,
+    action, approvers, outcome status, instinct_policy, and the short
+    label / kind for non-decision nodes. The result is JSON-serialisable
+    and small enough to fit in the LLM budget without truncation.
+
+    Decision count cap = 12. With each decision averaging ~120 tokens
+    in this shape, 12 stays well under the 1.5k budget. The cap is a
+    safety net — `trace()` already enforces depth + fanout caps upstream.
+    """
+    decisions: list[dict[str, Any]] = []
+    others: list[dict[str, Any]] = []
+
+    decision_count = 0
+    for node_id, node in trace.nodes.items():
+        if node.kind == "decision" and node.decision is not None:
+            if decision_count >= 12:
+                continue
+            decisions.append(_compress_decision(node.decision))
+            decision_count += 1
+        else:
+            others.append(
+                {
+                    "id": node.id,
+                    "kind": node.kind,
+                    "label": node.label,
+                }
+            )
+
+    edges = [
+        {
+            "src": str(e.src_id),
+            "target": e.target_id,
+            "relation": e.relation,
+            "weight": e.weight,
+        }
+        for e in trace.edges
+    ]
+
+    return {
+        "root": _compress_decision(root),
+        "decisions": decisions,
+        "other_nodes": others,
+        "edges": edges,
+        "depth_reached": trace.depth_reached,
+        "truncated": trace.truncated,
+    }
+
+
+def _compress_decision(decision: Decision) -> dict[str, Any]:
+    """One-decision shape for the narrator. Short id is what the
+    narrator's system prompt cites in brackets."""
+    return {
+        "id": str(decision.id),
+        "short_id": str(decision.id)[:8],
+        "ts": decision.ts.isoformat(),
+        "decided_by": {
+            "kind": decision.decided_by.kind,
+            "id": decision.decided_by.id,
+        },
+        "intent": decision.intent,
+        "action": decision.action,
+        "scope_kind": decision.scope_kind,
+        "pocket_id": decision.pocket_id,
+        "inputs": [
+            {
+                "kind": i.kind,
+                "id": i.id,
+                "label": i.label,
+            }
+            for i in decision.inputs
+        ],
+        "approvers": [
+            {
+                "actor_id": a.actor.id,
+                "actor_kind": a.actor.kind,
+                "approved_at": a.approved_at.isoformat(),
+            }
+            for a in decision.approvers
+        ],
+        "instinct_policy": decision.instinct_policy,
+        "instinct_policy_passed": decision.instinct_policy_passed,
+        "outcome": (
+            {
+                "status": decision.outcome.status,
+                "landed_at": (
+                    decision.outcome.landed_at.isoformat()
+                    if decision.outcome.landed_at
+                    else None
+                ),
+                "metered": decision.outcome.metered,
+            }
+            if decision.outcome
+            else None
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Verifier — every sentence must cite a decision id from the trace
+# ---------------------------------------------------------------------------
+
+# Match `[abc12345]` (the 8-hex short-id form the narrator emits).
+_CITATION_RE = re.compile(r"\[([0-9a-fA-F]{8})\]")
+# Match end-of-sentence — period / exclamation / question.
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[\.!?])\s+(?=[A-Z\"“])")
+
+
+def _verify_grounding(
+    narrative: str,
+    valid_short_ids: set[str],
+) -> tuple[str, list[str]]:
+    """Strip sentences that don't cite at least one decision id from the
+    trace. Returns the cleaned narrative + the list of stripped sentences
+    for the caller to surface.
+
+    A sentence is grounded when it carries one or more `[xxxxxxxx]`
+    citations AND every cited short id appears in `valid_short_ids`. A
+    sentence that cites an id outside the trace is ungrounded (the
+    model hallucinated a reference).
+
+    Multi-sentence narratives are split on `.`, `!`, or `?` followed by
+    whitespace and a capital. A single-sentence narrative without a
+    citation is stripped entirely (returning ""); the caller decides
+    whether to surface a placeholder.
+    """
+    text = narrative.strip()
+    if not text:
+        return "", []
+
+    if not valid_short_ids:
+        # No trace to ground against — drop everything.
+        return "", [text]
+
+    sentences = _SENTENCE_SPLIT_RE.split(text)
+    kept: list[str] = []
+    stripped: list[str] = []
+    for raw in sentences:
+        sent = raw.strip()
+        if not sent:
+            continue
+        citations = _CITATION_RE.findall(sent)
+        if not citations:
+            stripped.append(sent)
+            continue
+        # Every citation must reference a real decision in the trace.
+        if not all(c.lower() in valid_short_ids for c in citations):
+            stripped.append(sent)
+            continue
+        kept.append(sent)
+
+    cleaned = " ".join(kept).strip()
+    return cleaned, stripped
+
+
+# ---------------------------------------------------------------------------
+# Public entry point — picks the backend and runs the pipeline
+# ---------------------------------------------------------------------------
+
+
+async def narrate_decision(
+    root: Decision,
+    trace: TraceResult,
+    *,
+    backend: Literal["llm", "templated"] = "llm",
+    api_key: str | None = None,
+    model: str = "claude-sonnet-4-7",
+) -> Explanation:
+    """Produce a grounded explanation of `root` + its trace.
+
+    Args:
+        root: The Decision the narrator centers the story on.
+        trace: The depth-bounded BFS result from `DecisionGraph.trace`.
+        backend: "llm" (default) or "templated". On any LLM failure the
+            method falls back to the templated path so the response
+            shape is identical to the caller.
+        api_key: Override the Anthropic API key (test seam).
+        model: Sonnet-class model id.
+
+    Returns:
+        An Explanation. Never raises — LLM errors fall through to the
+        templated path; trace-empty inputs return the canned "no
+        matching decision" sentence.
+    """
+    walked = _collect_walked(root, trace)
+    valid_short_ids = {str(d_id)[:8].lower() for d_id in walked}
+
+    if backend == "templated":
+        narrative = _render_templated(root, trace)
+        # Templated narratives are pre-grounded; verifier still runs for
+        # symmetry so any future template drift surfaces in the test.
+        cleaned, stripped = _verify_grounding(narrative, valid_short_ids)
+        return Explanation(
+            narrative=cleaned or narrative,
+            decisions_walked=walked,
+            depth_reached=trace.depth_reached,
+            tokens_in=_approx_tokens(_compress_trace(root, trace)),
+            tokens_out=len(narrative) // 4,
+            ungrounded_sentences=stripped,
+            backend_used="templated",
+        )
+
+    # LLM path — fall back on any error.
+    if api_key is None:
+        try:
+            from pocketpaw.config import get_settings
+
+            api_key = get_settings().anthropic_api_key
+        except Exception:  # noqa: BLE001
+            api_key = None
+
+    if not api_key:
+        return await narrate_decision(root, trace, backend="templated")
+
+    try:
+        from anthropic import AsyncAnthropic
+    except ImportError:
+        logger.info("anthropic SDK missing; narrator falling back to templated path")
+        return await narrate_decision(root, trace, backend="templated")
+
+    compressed = _compress_trace(root, trace)
+    user_message = (
+        "Decision graph trace (JSON):\n"
+        + _json_dumps(compressed)
+        + "\n\nProduce the grounded paragraph now."
+    )
+
+    try:
+        client = AsyncAnthropic(api_key=api_key, timeout=20.0, max_retries=1)
+        response = await client.messages.create(
+            model=model,
+            max_tokens=600,
+            system=[
+                {
+                    "type": "text",
+                    "text": _NARRATOR_SYSTEM,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[{"role": "user", "content": user_message}],
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("narrator LLM call failed; falling back to templated", exc_info=True)
+        return await narrate_decision(root, trace, backend="templated")
+
+    try:
+        raw_text = response.content[0].text
+    except (AttributeError, IndexError):
+        return await narrate_decision(root, trace, backend="templated")
+
+    cleaned, stripped = _verify_grounding(raw_text, valid_short_ids)
+
+    # Approximate token counts from the response shape; the SDK also
+    # surfaces usage but we keep this provider-agnostic.
+    tokens_in = getattr(response.usage, "input_tokens", _approx_tokens(compressed))
+    tokens_out = getattr(response.usage, "output_tokens", len(raw_text) // 4)
+
+    return Explanation(
+        narrative=cleaned,
+        decisions_walked=walked,
+        depth_reached=trace.depth_reached,
+        tokens_in=int(tokens_in),
+        tokens_out=int(tokens_out),
+        ungrounded_sentences=stripped,
+        backend_used="llm",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Templated narrator — deterministic walk that mirrors the PoC
+# ---------------------------------------------------------------------------
+
+
+def _render_templated(root: Decision, trace: TraceResult) -> str:
+    """Deterministic paragraph generator. Mirrors the structure of the
+    PoC at /tmp/team-rfc07/explain/narrator.py `render_narrative` but
+    enforces the [short-id] citation style the verifier checks for."""
+
+    sentences: list[str] = []
+
+    primary_input = next(
+        (i for i in root.inputs if i.kind == "fabric_object"),
+        root.inputs[0] if root.inputs else None,
+    )
+    target_label = (
+        primary_input.label or primary_input.id
+        if primary_input
+        else "an unspecified target"
+    )
+
+    # 1. Headline — what / who / when
+    root_short = str(root.id)[:8]
+    if root.approvers:
+        approver_names = ", ".join(_humanize_actor(a.actor.id) for a in root.approvers)
+        first_at = root.approvers[0].approved_at
+        sentences.append(
+            f"{target_label} was approved by {approver_names} "
+            f"on {_format_dt(first_at)} [{root_short}]."
+        )
+    else:
+        sentences.append(
+            f"The {root.action} action on {target_label} was decided "
+            f"on {_format_dt(root.ts)} [{root_short}]."
+        )
+
+    # 2. Agent intent
+    proposer = _humanize_actor(root.decided_by.id)
+    sentences.append(
+        f"The {proposer} agent proposed the action with intent: "
+        f"{root.intent.strip()} [{root_short}]."
+    )
+
+    # 3. Precedents — cite each
+    precedent_nodes: list[Decision] = []
+    for pref in root.precedents:
+        node = trace.nodes.get(str(pref.decision_id))
+        if node and node.decision:
+            precedent_nodes.append(node.decision)
+
+    if precedent_nodes:
+        cited = "; ".join(_describe_precedent(p) for p in precedent_nodes[:3])
+        suffix = "s" if len(precedent_nodes) != 1 else ""
+        sentences.append(
+            f"This drew on {len(precedent_nodes)} precedent decision{suffix}: {cited}."
+        )
+
+    # 4. Policy
+    if root.instinct_policy:
+        passed = "passed" if root.instinct_policy_passed else "blocked"
+        sentences.append(
+            f"The Instinct policy `{root.instinct_policy}` {passed} at decision time "
+            f"[{root_short}]."
+        )
+
+    # 5. Outcome
+    if root.outcome and root.outcome.status == "landed":
+        landed_phrase = (
+            f" at {_format_dt(root.outcome.landed_at)}"
+            if root.outcome.landed_at
+            else ""
+        )
+        metered_phrase = " and was metered" if root.outcome.metered else ""
+        sentences.append(
+            f"The outcome landed{landed_phrase}{metered_phrase} [{root_short}]."
+        )
+    elif root.outcome and root.outcome.status == "rejected":
+        sentences.append(
+            f"The decision did not produce a landed outcome — it was rejected [{root_short}]."
+        )
+
+    return " ".join(sentences)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_walked(root: Decision, trace: TraceResult) -> list[UUID]:
+    """Every Decision id reachable in the trace — used for cache
+    invalidation. Root is always first so the cache reverse index has a
+    stable primary key."""
+    walked: list[UUID] = [root.id]
+    seen = {root.id}
+    for _, node in trace.nodes.items():
+        if node.kind == "decision" and node.decision is not None:
+            if node.decision.id not in seen:
+                walked.append(node.decision.id)
+                seen.add(node.decision.id)
+    return walked
+
+
+def _humanize_actor(actor_id: str) -> str:
+    """Turn an actor id into a render-friendly label.
+
+    Handles the three prefix conventions in use: `did:soul:<name>`,
+    `user:<name>`, and `system:<name>`. A bare id without a colon
+    prefix (the cloud convention where `Actor.kind` carries the
+    namespace) is title-cased so "prakash" → "Prakash". A name with
+    underscores ("renewal_specialist") becomes "renewal specialist".
+    """
+    if actor_id.startswith("did:soul:"):
+        return actor_id.split(":", 2)[2].replace("_", " ")
+    if actor_id.startswith("user:"):
+        return actor_id.split(":", 1)[1].replace("_", " ").title()
+    if actor_id.startswith("system:"):
+        return actor_id
+    if ":" not in actor_id:
+        # Bare id — Actor.kind carries the namespace; here we only have
+        # the id. Title-case so user ids look like names.
+        return actor_id.replace("_", " ").title()
+    return actor_id
+
+
+def _describe_precedent(pre: Decision) -> str:
+    obj = next((i for i in pre.inputs if i.kind == "fabric_object"), None)
+    descriptor = obj.label or obj.id if obj else pre.intent[:40]
+    when = pre.ts.strftime("%Y-%m-%d")
+    short = str(pre.id)[:8]
+    return f"{descriptor}, decided {when} [{short}]"
+
+
+def _format_dt(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%d at %H:%M UTC")
+
+
+def _approx_tokens(payload: dict[str, Any]) -> int:
+    """Rough token approximation: 4 characters per token."""
+    return len(_json_dumps(payload)) // 4
+
+
+def _json_dumps(payload: dict[str, Any]) -> str:
+    import json
+
+    return json.dumps(payload, separators=(",", ":"), default=str)
+
+
+__all__ = ["Explanation", "narrate_decision"]

--- a/ee/pocketpaw_ee/cloud/decisions/explain/service.py
+++ b/ee/pocketpaw_ee/cloud/decisions/explain/service.py
@@ -1,0 +1,352 @@
+# ee/pocketpaw_ee/cloud/decisions/explain/service.py
+# Created: 2026-05-25 (RFC 07 Slice 3a) — the orchestrator the REST
+#   route and the MCP wrapper both call. End-to-end:
+#     1. extract_entities(question, scope) → ExtractedEntities
+#     2. DecisionGraph.find(...) with the extracted filters → candidate list
+#     3. DecisionGraph.trace(root, depth=3) for the top candidate
+#     4. compress trace + pass to narrator
+#     5. verify grounding; strip / flag ungrounded sentences
+#     6. cache result keyed on (question_norm, root_id, depth, scope_hash)
+#     7. return Explanation
+#
+#   The pocket-template config `narrator.backend_pref` (per RFC 07 line
+#   621) flows through as the `backend` arg on the request. Defaults to
+#   "llm" — falls back to "templated" automatically on any LLM failure.
+"""End-to-end explain orchestrator."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pocketpaw_ee.cloud.decisions.domain import Decision
+from pocketpaw_ee.cloud.decisions.explain.cache import (
+    build_cache_key,
+    get_explain_cache,
+)
+from pocketpaw_ee.cloud.decisions.explain.cache import (
+    _hash_scope as hash_scope,
+)
+from pocketpaw_ee.cloud.decisions.explain.cache import (
+    _normalize_question as normalize_question,
+)
+from pocketpaw_ee.cloud.decisions.explain.extractor import (
+    ExtractedEntities,
+    extract_entities,
+)
+from pocketpaw_ee.cloud.decisions.explain.narrator import (
+    Explanation,
+    narrate_decision,
+)
+from pocketpaw_ee.cloud.decisions.service import (
+    DecisionGraph,
+    TraceResult,
+    get_decision_graph,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Input shape — what the router validates a POST body into
+# ---------------------------------------------------------------------------
+
+
+class ExplainRequestInput(BaseModel):
+    """Validated input the orchestrator consumes. Distinct from the
+    `ExplainRequest` wire DTO (which lives in `decisions.dto`) so the
+    orchestrator can be called from MCP / CLI / tests without a FastAPI
+    request body."""
+
+    model_config = ConfigDict(frozen=False)
+
+    question: str = Field(min_length=1, max_length=2000)
+    scope: dict[str, Any] | None = None
+    max_decisions: int = Field(default=5, ge=1, le=20)
+    depth: int = Field(default=3, ge=1, le=10)
+    backend: Literal["llm", "templated"] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+async def explain(
+    body: ExplainRequestInput | dict[str, Any],
+    *,
+    requester_scopes: list[str] | None = None,
+    graph: DecisionGraph | None = None,
+    api_key: str | None = None,
+    now: datetime | None = None,
+) -> Explanation:
+    """Answer one natural-language question with a grounded paragraph.
+
+    Args:
+        body: The validated request. Accepts a dict so non-FastAPI
+            callers (MCP wrappers, tests) can pass plain kwargs.
+        requester_scopes: Scope tags the find / trace passes through to
+            the graph. None means "admin / unscoped".
+        graph: Override the singleton DecisionGraph (test seam).
+        api_key: Anthropic key override (test seam — primarily for the
+            mock-LLM path).
+        now: Override "now" for cache TTL math (test seam).
+
+    Returns:
+        An Explanation. Never raises — every failure path falls through
+        to the templated narrator and an empty-trace canned response.
+    """
+    body = ExplainRequestInput.model_validate(body)
+    graph = graph or get_decision_graph()
+    cache = get_explain_cache()
+
+    # ----- 1. Extract -------------------------------------------------------
+    entities = await extract_entities(
+        body.question,
+        scope=body.scope,
+        backend=body.backend,
+        api_key=api_key,
+    )
+
+    # ----- 2. Find ----------------------------------------------------------
+    candidates = await _find_candidates(
+        graph,
+        entities,
+        max_decisions=body.max_decisions,
+        requester_scopes=requester_scopes,
+    )
+
+    if not candidates:
+        # No matching decisions — still return a coherent response so
+        # the UI never sees an empty body.
+        empty = Explanation(
+            narrative=(
+                "No matching decision was found in the supplied trace. "
+                "Try widening the date range, naming the fabric object "
+                "(for example `lease:LR-2026-117`), or asking about a "
+                "specific actor."
+            ),
+            decisions_walked=[],
+            depth_reached=0,
+            backend_used=body.backend or "templated",
+        )
+        return empty
+
+    root = _pick_root(candidates, entities)
+
+    # ----- 3. Cache lookup --------------------------------------------------
+    question_norm = normalize_question(body.question)
+    scope_hash = hash_scope(body.scope)
+    cache_key = build_cache_key(
+        question_normalized=question_norm,
+        root_decision_id=root.id,
+        depth=body.depth,
+        scope_hash=scope_hash,
+    )
+    cached = cache.get(cache_key, now=now)
+    if cached is not None:
+        return cached
+
+    # ----- 4. Trace ---------------------------------------------------------
+    trace = await graph.trace(
+        root.id,
+        depth=body.depth,
+        requester_scopes=requester_scopes,
+    )
+
+    # ----- 5. Narrate -------------------------------------------------------
+    backend = body.backend or "llm"
+    explanation = await narrate_decision(
+        root,
+        trace,
+        backend=backend,
+        api_key=api_key,
+    )
+
+    # ----- 6. Cache the result ---------------------------------------------
+    try:
+        cache.put(
+            cache_key,
+            explanation,
+            question_normalized=question_norm,
+            root_decision_id=root.id,
+            depth=body.depth,
+            scope_hash=scope_hash,
+            now=now,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("explain cache.put failed — returning uncached", exc_info=True)
+
+    return explanation
+
+
+# ---------------------------------------------------------------------------
+# Candidate selection
+# ---------------------------------------------------------------------------
+
+
+async def _find_candidates(
+    graph: DecisionGraph,
+    entities: ExtractedEntities,
+    *,
+    max_decisions: int,
+    requester_scopes: list[str] | None,
+) -> list[Decision]:
+    """Resolve ExtractedEntities into Decision candidates.
+
+    Priority order:
+      1. Explicit decision_ids — fetch each one directly.
+      2. fabric_object_refs — narrow by input id.
+      3. actor / time / policy / pocket filters.
+      4. Pure fallback — most-recent N in scope (so the narrator always
+         has something to walk).
+    """
+    # 1. explicit decision ids
+    if entities.decision_ids:
+        out: list[Decision] = []
+        for d_id in entities.decision_ids[:max_decisions]:
+            d = await graph.get(d_id, requester_scopes=requester_scopes)
+            if d is not None:
+                out.append(d)
+        if out:
+            return out
+
+    # 2. fabric-object refs — first ref wins; widen the filter to the others
+    # via find() per-ref then dedup.
+    if entities.fabric_object_refs:
+        accumulated: dict[UUID, Decision] = {}
+        for obj_ref in entities.fabric_object_refs:
+            since = until = None
+            if entities.time_range:
+                since, until = entities.time_range
+            found = await graph.find(
+                input_id=obj_ref,
+                since=since,
+                until=until,
+                pocket_id=entities.pocket_id,
+                policy=entities.policy_ref,
+                limit=max_decisions,
+                requester_scopes=requester_scopes,
+            )
+            for d in found:
+                accumulated.setdefault(d.id, d)
+            if len(accumulated) >= max_decisions:
+                break
+        ranked = _rank_by_outcome_hint(list(accumulated.values()), entities.outcome_hint)
+        if ranked:
+            return ranked[:max_decisions]
+
+    # 3. axis-driven find
+    actor = entities.actor_refs[0] if entities.actor_refs else None
+    since = until = None
+    if entities.time_range:
+        since, until = entities.time_range
+    outcome_status = _outcome_hint_to_status(entities.outcome_hint)
+    found = await graph.find(
+        actor=actor,
+        since=since,
+        until=until,
+        pocket_id=entities.pocket_id,
+        policy=entities.policy_ref,
+        outcome_status=outcome_status,
+        limit=max_decisions,
+        requester_scopes=requester_scopes,
+    )
+    if found:
+        return _rank_by_outcome_hint(found, entities.outcome_hint)[:max_decisions]
+
+    # 4. Pure fallback — most-recent N in scope. Widen time too in case
+    # the time range was over-narrow.
+    if entities.time_range:
+        # Retry without time bound to recover the close-but-not-exact case.
+        found = await graph.find(
+            actor=actor,
+            pocket_id=entities.pocket_id,
+            policy=entities.policy_ref,
+            outcome_status=outcome_status,
+            limit=max_decisions,
+            requester_scopes=requester_scopes,
+        )
+        if found:
+            return _rank_by_outcome_hint(found, entities.outcome_hint)[:max_decisions]
+
+    return []
+
+
+def _pick_root(candidates: list[Decision], entities: ExtractedEntities) -> Decision:
+    """Pick the candidate the narrator centers on. Outcome hint nudges
+    the choice when the caller asked about an approval or rejection."""
+    ranked = _rank_by_outcome_hint(candidates, entities.outcome_hint)
+    return ranked[0] if ranked else candidates[0]
+
+
+def _rank_by_outcome_hint(
+    candidates: list[Decision],
+    hint: str | None,
+) -> list[Decision]:
+    """Stable sort that floats decisions matching the outcome hint to
+    the front, preserving the original ts-DESC ordering elsewhere."""
+    if not hint or not candidates:
+        return candidates
+
+    def match(d: Decision) -> int:
+        if hint == "approved":
+            # "approved" is shorthand for "passed instinct and no rejection."
+            if d.outcome and d.outcome.status == "rejected":
+                return 1
+            if d.instinct_policy_passed is True:
+                return 0
+            return 1
+        if hint == "rejected":
+            if d.outcome and d.outcome.status == "rejected":
+                return 0
+            if d.instinct_policy_passed is False:
+                return 0
+            return 1
+        if hint == "landed":
+            if d.outcome and d.outcome.status == "landed":
+                return 0
+            return 1
+        if hint == "pending":
+            if d.outcome is None:
+                return 0
+            return 1
+        return 0
+
+    return sorted(candidates, key=match)
+
+
+def _outcome_hint_to_status(hint: str | None) -> str | None:
+    if hint == "rejected":
+        return "rejected"
+    if hint == "landed":
+        return "landed"
+    if hint == "pending":
+        return "pending"
+    # "approved" maps to "all non-rejected" — we filter post-fetch instead
+    # so the rank step is the only place that filters.
+    return None
+
+
+__all__ = [
+    "ExplainRequestInput",
+    "explain",
+]
+
+
+# Re-export some helpers so tests don't reach for the underscore-prefixed
+# variants. Keeping the leading-underscore names in cache.py prevents
+# accidental cross-module reach (the helpers are still cache-internal
+# in intent — these are test-only re-exports).
+__all__ += ["hash_scope", "normalize_question"]
+
+
+# Backwards compatibility — older callers might import this with a stale
+# parameter. ``timedelta`` import kept so future TTL tuning lands without
+# another import edit.
+_ = timedelta  # silence unused-import lint when TTL tuning lands later
+_ = timezone  # same — kept ready for explicit now-with-tz construction

--- a/ee/pocketpaw_ee/cloud/decisions/projection.py
+++ b/ee/pocketpaw_ee/cloud/decisions/projection.py
@@ -24,10 +24,18 @@
 #   projection consumes it as a STRING LITERAL here — when Slice 0
 #   merges, no code change is needed; the namespace registration is
 #   advisory, not enforced.
+#
+#   2026-05-25 (RFC 07 Slice 3a) — added a tiny post-apply hook registry
+#   so the explain cache layer (`decisions.explain.cache`) can invalidate
+#   cached entries when a new Decision lands. The registry is additive:
+#   hooks default to empty, every existing apply() path now funnels its
+#   return through `_emit(decision)` which fires hooks before returning.
+#   This keeps layering one-way (explain → decisions) — the projection
+#   never imports the cache.
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
@@ -135,6 +143,11 @@ class DecisionProjection:
         self._pending: dict[UUID, _PendingChain] = {}
         self._last_hash_per_correlation: dict[UUID, str] = {}
         self._cursor: int = self._store.get_cursor()
+        # Slice 3a — post-apply hook registry. The explain cache
+        # registers an invalidator here; future consumers (search index,
+        # notification fan-out, etc.) can pile on without touching the
+        # projection's hot path.
+        self._post_apply_hooks: list[Callable[[Decision], None]] = []
 
     @property
     def store(self) -> DecisionStore:
@@ -143,6 +156,38 @@ class DecisionProjection:
     @property
     def cursor(self) -> int:
         return self._cursor
+
+    def register_post_apply_hook(self, hook: Callable[[Decision], None]) -> None:
+        """Register a callback fired after every successful Decision emit.
+
+        Hooks are best-effort — exceptions raised by a hook are caught
+        and logged so one bad subscriber can't block the projection's
+        write path. Hooks see the freshly-emitted Decision (the same
+        object the apply() return value would carry); they MUST NOT
+        mutate it.
+
+        Idempotence — the same callable can be registered more than once;
+        each registration adds another invocation. Callers that need
+        once-only semantics should track their own registration state.
+        """
+        self._post_apply_hooks.append(hook)
+
+    def _emit(self, decision: Decision | None) -> Decision | None:
+        """Fire post-apply hooks for a freshly-emitted Decision, then
+        return it. The single chokepoint for apply()'s return values so
+        every emit path triggers the hooks symmetrically."""
+        if decision is None:
+            return None
+        for hook in self._post_apply_hooks:
+            try:
+                hook(decision)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "post-apply hook %s raised — continuing",
+                    getattr(hook, "__qualname__", repr(hook)),
+                    exc_info=True,
+                )
+        return decision
 
     # --- rebuild / apply ----------------------------------------------------
 
@@ -215,7 +260,7 @@ class DecisionProjection:
         # Special-case the late outcome attach — doesn't accumulate into a
         # pending chain; mutates an already-emitted Decision in place.
         if entry.action == "decision.outcome_attached":
-            return self._apply_outcome_attached(entry)
+            return self._emit(self._apply_outcome_attached(entry))
 
         correlation_id = entry.correlation_id
         if correlation_id is None:
@@ -223,7 +268,7 @@ class DecisionProjection:
             # with no correlation. The graph still represents it, the
             # explain narrator still has something to say.
             if entry.action in _FABRIC_WRITE_ACTIONS:
-                return self._emit_degenerate(entry)
+                return self._emit(self._emit_degenerate(entry))
             # Other actions without a correlation aren't actionable.
             logger.debug(
                 "decision projection: %s without correlation_id — dropped",
@@ -247,7 +292,7 @@ class DecisionProjection:
             # A2: contribute, do not close.
             self._fold_fabric_write(chain, entry)
         elif entry.action in _TERMINAL_ACTIONS:
-            return self._close_chain(chain, entry)
+            return self._emit(self._close_chain(chain, entry))
         return None
 
     # --- fold helpers -------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/decisions/router.py
+++ b/ee/pocketpaw_ee/cloud/decisions/router.py
@@ -18,6 +18,15 @@
 #
 #   The `_ping` smoke route stays — operators rely on it as a cheap
 #   liveness check on the projection cursor + row count.
+# Updated: 2026-05-25 (RFC 07 Slice 3a) — added the natural-language
+#   explain route:
+#
+#     POST /api/v1/decisions/explain        → ExplanationResponse
+#
+#   Pipeline: extractor → find → trace → narrator → cache. Scope filter
+#   is the same load-bearing invariant the read routes enforce; a
+#   workspace caller cannot probe another workspace's decisions through
+#   the question.
 #
 # Router contract (mirrors `outcomes/router.py` and `pockets/router.py`):
 #   - Thin one-line bodies that delegate to `DecisionGraph` or read the
@@ -47,10 +56,13 @@ from pocketpaw_ee.cloud.decisions.dto import (
     DecisionsListResponse,
     DecisionTraceResponse,
     EdgeDTO,
+    ExplainRequest,
+    ExplanationResponse,
     JournalEventDTO,
     TimelineResponse,
     TraceNodeResponse,
 )
+from pocketpaw_ee.cloud.decisions.explain import ExplainRequestInput, explain
 from pocketpaw_ee.cloud.decisions.service import (
     DecisionGraph,
     TraceResult,
@@ -400,6 +412,52 @@ async def decision_timeline(
         correlation_id=decision.correlation_id,
         events=events,
     )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/decisions/explain — natural-language Q&A (Slice 3a)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/explain", response_model=ExplanationResponse)
+async def explain_decision(
+    body: ExplainRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> ExplanationResponse:
+    """Answer a natural-language question about the decision graph.
+
+    The pipeline (per RFC 07 § "LLM-grounded query"):
+
+      1. extractor: small LLM call (Haiku) distills the question to
+         structured filters. Falls back to a deterministic regex
+         extractor when the SDK / key are missing.
+      2. find: index-driven multi-axis filter over Decisions.
+      3. trace: depth-bounded BFS upstream from the top candidate.
+      4. narrator: Sonnet call (or templated fallback) produces a
+         grounded paragraph. Every claim must cite a decision id.
+      5. verifier: re-scans the narrative for ungrounded sentences.
+      6. cache: 24h TTL keyed on (question_norm, root_id, depth,
+         scope_hash). The projection's post-apply hook invalidates
+         entries whose `decisions_walked` set contains a newly-emitted
+         decision.
+
+    Scope filter: identical to the read routes — the request's scope
+    tag list is derived from auth, never from the body. A question
+    that resolves to a decision outside scope produces the empty
+    "no matching decision" response (the privacy invariant).
+    """
+    input_body = ExplainRequestInput(
+        question=body.question,
+        scope=body.scope,
+        max_decisions=body.max_decisions,
+        depth=body.depth,
+        backend=body.backend,
+    )
+    explanation = await explain(
+        input_body,
+        requester_scopes=_requester_scopes(ctx),
+    )
+    return ExplanationResponse.from_domain(explanation)
 
 
 # Export the cursor encoder for the test suite's keyset assertions.

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -385,6 +385,10 @@ source_modules = [
     "pocketpaw_ee.cloud.decisions.domain",
     "pocketpaw_ee.cloud.decisions.projection",
     "pocketpaw_ee.cloud.decisions.store",
+    "pocketpaw_ee.cloud.decisions.explain.extractor",
+    "pocketpaw_ee.cloud.decisions.explain.narrator",
+    "pocketpaw_ee.cloud.decisions.explain.cache",
+    "pocketpaw_ee.cloud.decisions.explain.service",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.notification",

--- a/src/pocketpaw/bundled_templates/_bundled/decision-graph/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/decision-graph/ripple_spec.json
@@ -1,0 +1,159 @@
+{
+  "_placeholder_note": "Built-in pocket template (decision-graph) for RFC 07. Renders the org's decision graph with three default views (one-decision, time-series, policy) and a narrator chat panel that calls POST /api/v1/decisions/explain. The specialist may swap the [bracketed] copy for the org's domain (e.g. 'Renewals' instead of 'Decisions') but should keep the explain action bound to state.explain_question and the response bound to state.explain_response. The `decision-graph` widget itself is a Layer-2 SvelteFlow render that paw-enterprise registers in Slice 3b; until that manifest entry lands, the widget passes through ingest validation as an unknown type (its props are not enforced).",
+  "state": {
+    "selected_decision_id": "",
+    "view_mode": "one-decision",
+    "view_options": [
+      { "value": "one-decision", "label": "One decision" },
+      { "value": "time-series", "label": "Time series" },
+      { "value": "policy", "label": "By policy" }
+    ],
+    "filter": {
+      "actor": "",
+      "since": "",
+      "policy": ""
+    },
+    "explain_question": "",
+    "explain_response": {
+      "narrative": "",
+      "decisions_walked": [],
+      "ungrounded_sentences": [],
+      "backend_used": "templated"
+    },
+    "explain_loading": false,
+    "depth": 3
+  },
+  "ui": {
+    "type": "flex",
+    "props": { "direction": "column", "gap": "16px" },
+    "children": [
+      {
+        "type": "page-header",
+        "props": {
+          "title": "[Decision Graph]",
+          "subtitle": "[Every decision the org has made — ask a question, watch the graph answer.]"
+        }
+      },
+      {
+        "type": "flex",
+        "props": { "direction": "row", "gap": "12px", "align": "center" },
+        "children": [
+          {
+            "type": "segmented",
+            "bind": "view_mode",
+            "props": {
+              "label": "View",
+              "options": "{state.view_options}"
+            }
+          },
+          {
+            "type": "input",
+            "bind": "filter.actor",
+            "props": { "label": "Actor", "placeholder": "[did:soul:renewal_specialist]" }
+          },
+          {
+            "type": "date-picker",
+            "bind": "filter.since",
+            "props": { "label": "Since" }
+          },
+          {
+            "type": "input",
+            "bind": "filter.policy",
+            "props": { "label": "Policy", "placeholder": "[approve_per_row]" }
+          }
+        ]
+      },
+      {
+        "type": "flex",
+        "props": { "direction": "row", "gap": "16px" },
+        "children": [
+          {
+            "type": "decision-graph",
+            "props": {
+              "root_decision_id": "{state.selected_decision_id}",
+              "depth": "{state.depth}",
+              "view_mode": "{state.view_mode}",
+              "filters": "{state.filter}",
+              "show_downstream": true,
+              "on_node_click": [
+                {
+                  "action": "set",
+                  "target": "selected_decision_id",
+                  "value": "{event.node_id}"
+                }
+              ]
+            }
+          },
+          {
+            "type": "flex",
+            "props": { "direction": "column", "gap": "12px" },
+            "children": [
+              {
+                "type": "page-header",
+                "props": {
+                  "title": "[Ask the graph]",
+                  "subtitle": "[Free-form questions; answers cite decision ids.]"
+                }
+              },
+              {
+                "type": "textarea",
+                "bind": "explain_question",
+                "props": {
+                  "label": "Your question",
+                  "placeholder": "[Why was lease LR-2026-117 approved on April 22?]",
+                  "rows": 3
+                }
+              },
+              {
+                "type": "button",
+                "props": { "label": "Explain", "variant": "primary", "loading": "{state.explain_loading}" },
+                "on_click": [
+                  {
+                    "action": "validate",
+                    "condition": "{state.explain_question.length > 0}",
+                    "message": "Type a question first"
+                  },
+                  {
+                    "action": "set",
+                    "target": "explain_loading",
+                    "value": true
+                  },
+                  {
+                    "action": "invoke_endpoint",
+                    "endpoint": "POST /api/v1/decisions/explain",
+                    "body": {
+                      "question": "{state.explain_question}",
+                      "scope": { "pocket_id": "{pocket.id}" },
+                      "max_decisions": 5,
+                      "depth": "{state.depth}"
+                    },
+                    "bind": "explain_response"
+                  },
+                  {
+                    "action": "set",
+                    "target": "explain_loading",
+                    "value": false
+                  }
+                ]
+              },
+              {
+                "type": "card",
+                "props": {
+                  "title": "[Narrative]",
+                  "description": "{state.explain_response.narrative}"
+                }
+              },
+              {
+                "type": "section",
+                "props": {
+                  "title": "Decisions walked",
+                  "description": "{state.explain_response.decisions_walked}"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/pocketpaw/bundled_templates/_bundled/decision-graph/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/decision-graph/template.pocket.yaml
@@ -1,0 +1,26 @@
+# src/pocketpaw/bundled_templates/_bundled/decision-graph/template.pocket.yaml
+# Created: 2026-05-25 (RFC 07 Slice 3a) — the built-in Decision Graph
+# pocket. Visualizes every decision the org has made — by agent, by
+# human, by policy, by pocket — with full upstream and downstream
+# lineage. The narrator agent answers natural-language questions and
+# walks the relevant graph slice with grounded citations.
+#
+# Shape is `custom` (the Decision Graph widget is a Layer-2 SvelteFlow
+# render). Vertical is `core` — the cross-vertical bin for foundational
+# org-wide templates. Read-only: no actions, no connectors, no outcomes;
+# the Instinct rule blocks writes at the pocket boundary.
+name: decision-graph
+version: 0.1.0
+vertical: core
+shape: custom
+description: |
+  Visualize every decision the org has made — by agent, by human, by
+  policy, by pocket — with full upstream and downstream lineage. Ask
+  natural-language questions and watch the graph slice that answered
+  them. The audit log, but you can talk to it.
+state:
+  entity_type: Decision
+  columns: []
+actions: []
+connectors: []
+skills: []

--- a/src/pocketpaw/bundled_templates/_bundled/index.json
+++ b/src/pocketpaw/bundled_templates/_bundled/index.json
@@ -48,6 +48,14 @@
       "pattern": "feed",
       "keywords": ["activity feed", "feed", "timeline", "changelog", "release notes", "history", "audit log", "activity log", "event stream", "milestones"],
       "connectors_hint": []
+    },
+    {
+      "slug": "decision-graph",
+      "title": "Decision Graph",
+      "shape": "custom",
+      "pattern": "app",
+      "keywords": ["decision graph", "decisions", "audit", "audit trail", "why did we", "explain", "lineage", "trace", "decision log", "decision history", "decision audit", "policy decisions", "approval graph"],
+      "connectors_hint": []
     }
   ]
 }

--- a/tests/ee/test_bundled_decision_graph_template.py
+++ b/tests/ee/test_bundled_decision_graph_template.py
@@ -1,0 +1,206 @@
+# tests/ee/test_bundled_decision_graph_template.py — RFC 07 Slice 3a
+# Created: 2026-05-25 — pins the bundled `decision-graph` pocket template
+#   shipped in
+#   `src/pocketpaw/bundled_templates/_bundled/decision-graph/`. Asserts:
+#
+#     - template.pocket.yaml parses against the RFC 03 Pocket Template
+#       Schema (the same field set + shape enum the existing six
+#       bundled templates pass against).
+#     - ripple_spec.json parses as valid JSON, carries ui + state, and
+#       includes the explain-pipeline wiring (the narrator action that
+#       invokes POST /api/v1/decisions/explain).
+#     - the slug appears in `_bundled/index.json` with keywords the
+#       chat agent's STEP 0 keyword match looks for.
+#     - the loader returns the template by slug from a tmp install
+#       (no traversal into the user's real ~/.pocketpaw/templates/).
+"""Tests for the bundled decision-graph pocket template (RFC 07 Slice 3a)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from pocketpaw.bundled_templates.installer import install_bundled_templates
+from pocketpaw.bundled_templates.loader import load_template
+
+# Mirrors the RFC 03 schema constants in tests/unit/test_bundled_templates.py
+# so the decision-graph template is held to the same field set.
+_RFC03_ALLOWED_FIELDS = {
+    "name",
+    "version",
+    "vertical",
+    "shape",
+    "state",
+    "actions",
+    "connectors",
+    "skills",
+    "description",
+}
+_RFC03_REQUIRED_FIELDS = {"name", "version", "vertical", "shape", "state", "description"}
+_RFC03_SHAPE_ENUM = {
+    "data-grid",
+    "kanban",
+    "calendar",
+    "map",
+    "timeline",
+    "tree",
+    "chart",
+    "custom",
+}
+
+_BUNDLED_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "pocketpaw"
+    / "bundled_templates"
+    / "_bundled"
+)
+_SLUG = "decision-graph"
+
+
+# ---------------------------------------------------------------------------
+# template.pocket.yaml — RFC 03 schema shape
+# ---------------------------------------------------------------------------
+
+
+def test_template_yaml_matches_rfc03_field_set() -> None:
+    """The decision-graph template uses ONLY RFC 03 fields, carries
+    every required field, ships actions: [], and uses a valid shape
+    enum value (`custom`)."""
+    meta_path = _BUNDLED_DIR / _SLUG / "template.pocket.yaml"
+    meta = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+
+    assert isinstance(meta, dict)
+    fields = set(meta.keys())
+    extra = fields - _RFC03_ALLOWED_FIELDS
+    assert not extra, f"decision-graph: non-RFC03 fields {extra}"
+    missing = _RFC03_REQUIRED_FIELDS - fields
+    assert not missing, f"decision-graph: missing required fields {missing}"
+
+    # Read-only — no actions; no connectors; no skills.
+    assert meta["actions"] == []
+    assert meta["connectors"] == []
+    assert meta["skills"] == []
+    # No `agents` / `triggers` / `outcomes` / `instinct_rules` until the
+    # Pocket Template Schema admits them. The narrator backend + read-
+    # only enforcement live as runtime defaults, not template metadata.
+    for omitted in ("outcomes", "instinct_rules", "triggers", "agents", "kb_scope"):
+        assert omitted not in meta, f"decision-graph: should omit {omitted}"
+
+    assert meta["shape"] in _RFC03_SHAPE_ENUM
+    assert meta["shape"] == "custom"
+    assert meta["vertical"] == "core"
+    assert meta["name"] == _SLUG
+    assert isinstance(meta["state"], dict) and "entity_type" in meta["state"]
+    # RFC 07 § "The UX surface" — entity type is Decision.
+    assert meta["state"]["entity_type"] == "Decision"
+
+
+# ---------------------------------------------------------------------------
+# ripple_spec.json — wired to the explain endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_template_ripple_spec_is_valid_json_with_explain_wiring() -> None:
+    """The ripple_spec parses, carries ui + state, includes the
+    `_placeholder_note`, and binds an Explain button to the
+    POST /api/v1/decisions/explain endpoint."""
+    spec_path = _BUNDLED_DIR / _SLUG / "ripple_spec.json"
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+
+    assert isinstance(spec, dict)
+    assert "ui" in spec
+    assert "state" in spec
+    assert "_placeholder_note" in spec
+
+    # The state seeds the explain inputs the UI binds to.
+    state = spec["state"]
+    assert "selected_decision_id" in state
+    assert "explain_question" in state
+    assert "explain_response" in state
+    assert state["explain_response"]["decisions_walked"] == []
+
+    # Walk the ui tree looking for the invoke_endpoint action pointed
+    # at /api/v1/decisions/explain. The Slice 3b frontend agent reads
+    # this binding to wire the chat panel.
+    explain_actions = _find_invoke_endpoints(spec["ui"], "POST /api/v1/decisions/explain")
+    assert explain_actions, (
+        "decision-graph template must bind an Explain action to "
+        "POST /api/v1/decisions/explain so the narrator panel works"
+    )
+    # The first invocation must pass a `question` from state and write
+    # the response into `explain_response`.
+    first = explain_actions[0]
+    assert first["body"]["question"] == "{state.explain_question}"
+    assert first["bind"] == "explain_response"
+
+
+def _find_invoke_endpoints(ui: dict, endpoint: str) -> list[dict]:
+    """Walk the ui tree and collect every invoke_endpoint action that
+    targets `endpoint`. Recursive over `children` and `on_click` lists."""
+    out: list[dict] = []
+    if not isinstance(ui, dict):
+        return out
+    for click_action in ui.get("on_click", []) or []:
+        if (
+            isinstance(click_action, dict)
+            and click_action.get("action") == "invoke_endpoint"
+            and click_action.get("endpoint") == endpoint
+        ):
+            out.append(click_action)
+    for child in ui.get("children", []) or []:
+        out.extend(_find_invoke_endpoints(child, endpoint))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# index.json registration — the chat agent's keyword match finds it
+# ---------------------------------------------------------------------------
+
+
+def test_index_json_registers_decision_graph_with_keywords() -> None:
+    """The bundled index must register `decision-graph` with keywords
+    the chat agent's STEP 0 keyword match looks for."""
+    index = json.loads((_BUNDLED_DIR / "index.json").read_text())
+    rows = index["templates"]
+    by_slug = {r["slug"]: r for r in rows}
+    assert _SLUG in by_slug
+    row = by_slug[_SLUG]
+    assert row["shape"] == "custom"
+    assert isinstance(row["keywords"], list) and row["keywords"]
+    # The RFC 07 demo question keywords must be in the list.
+    keywords_joined = " ".join(row["keywords"]).lower()
+    assert "decision" in keywords_joined
+    assert "audit" in keywords_joined or "audit trail" in keywords_joined
+
+
+# ---------------------------------------------------------------------------
+# Installer + loader — mirrors the existing bundled-templates flow
+# ---------------------------------------------------------------------------
+
+
+def test_installer_includes_decision_graph(tmp_path: Path) -> None:
+    """A fresh install mirrors the decision-graph template into the
+    user's templates directory alongside the existing six."""
+    results = install_bundled_templates(destination_root=tmp_path)
+    slugs = {r.name for r in results}
+    assert _SLUG in slugs
+
+    decision_graph_dir = tmp_path / _SLUG
+    assert (decision_graph_dir / "template.pocket.yaml").is_file()
+    assert (decision_graph_dir / "ripple_spec.json").is_file()
+
+
+def test_loader_returns_decision_graph(tmp_path: Path) -> None:
+    """The loader resolves the decision-graph slug to its meta +
+    ripple_spec dicts."""
+    install_bundled_templates(destination_root=tmp_path)
+    loaded = load_template(_SLUG, templates_dir=tmp_path)
+    assert loaded is not None
+    assert loaded["meta"]["name"] == _SLUG
+    assert loaded["meta"]["shape"] == "custom"
+    assert loaded["meta"]["vertical"] == "core"
+    assert "explain_question" in loaded["ripple_spec"]["state"]

--- a/tests/ee/test_decisions_explain.py
+++ b/tests/ee/test_decisions_explain.py
@@ -1,0 +1,648 @@
+# tests/ee/test_decisions_explain.py — RFC 07 Slice 3a explain coverage.
+# Created: 2026-05-25 — pins the natural-language explain pipeline shipped
+#   in `pocketpaw_ee.cloud.decisions.explain` and the
+#   `POST /api/v1/decisions/explain` REST route. Test surface:
+#
+#     - Templated narrator: walks a synthetic chain, asserts every
+#       Decision gets a short-id citation in the narrative.
+#     - LLM narrator path: mocks the Anthropic client and asserts the
+#       grounding verifier strips ungrounded sentences.
+#     - Cache hit / miss: first call populates, second identical call
+#       returns the cached row without re-narrating.
+#     - Cache invalidation: a new event folded into the projection drops
+#       any cache entry whose `decisions_walked` includes the affected
+#       decision.
+#     - Scope filtering: a workspace-B caller never sees workspace-A
+#       decisions through the explain route.
+#     - End-to-end: route + extractor + find + trace + narrator + cache
+#       + response, with the LLM call mocked so the test stays hermetic.
+"""Tests for the natural-language explain pipeline."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from soul_protocol.spec.journal import Actor, EventEntry
+
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.decisions.dto import ExplanationResponse
+from pocketpaw_ee.cloud.decisions.explain import (
+    ExplainRequestInput,
+    explain,
+    narrate_decision,
+)
+from pocketpaw_ee.cloud.decisions.explain.cache import (
+    ExplainCache,
+    build_cache_key,
+    get_explain_cache,
+    reset_explain_cache_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.explain.extractor import (
+    ExtractedEntities,
+    extract_entities,
+)
+from pocketpaw_ee.cloud.decisions.projection import DecisionProjection
+from pocketpaw_ee.cloud.decisions.router import router as decisions_router
+from pocketpaw_ee.cloud.decisions.service import (
+    DecisionGraph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import DecisionStore, set_db_path
+from pocketpaw_ee.cloud.license import require_license
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — fresh projection + store + cache per test
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state() -> None:
+    reset_projection_for_tests()
+    reset_explain_cache_for_tests()
+    yield
+    reset_projection_for_tests()
+    reset_explain_cache_for_tests()
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> DecisionStore:
+    set_db_path(tmp_path / "decisions.db")
+    s = DecisionStore()
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def projection(store: DecisionStore) -> DecisionProjection:
+    return DecisionProjection(store=store)
+
+
+@pytest.fixture
+def graph(store: DecisionStore, projection: DecisionProjection) -> DecisionGraph:
+    from pocketpaw_ee.cloud.decisions import service as decisions_service
+
+    g = DecisionGraph(store=store, projection=projection)
+    decisions_service._GRAPH = g
+    return g
+
+
+@pytest.fixture
+def base_ts() -> datetime:
+    return datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def workspace_id() -> str:
+    return "ws_a_test"
+
+
+@pytest.fixture
+def app(graph: DecisionGraph, workspace_id: str) -> FastAPI:
+    a = FastAPI()
+    add_error_handler(a)
+    a.include_router(decisions_router, prefix="/api/v1")
+    a.dependency_overrides[require_license] = lambda: None
+    a.dependency_overrides[request_context] = lambda: RequestContext(
+        user_id="user_test",
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+    return a
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — chain seeding, mirrors test_decisions_router._seed_chain
+# ---------------------------------------------------------------------------
+
+
+def _event(
+    *,
+    ts: datetime,
+    actor: Actor,
+    action: str,
+    correlation_id: UUID | None,
+    payload: dict,
+    scope: list[str] | None = None,
+) -> EventEntry:
+    return EventEntry(
+        id=uuid4(),
+        ts=ts,
+        actor=actor,
+        action=action,
+        scope=scope or ["org:nerve", "workspace:ws_a_test"],
+        correlation_id=correlation_id,
+        payload=payload,
+    )
+
+
+def _seed_chain(
+    projection: DecisionProjection,
+    *,
+    base_ts: datetime,
+    pocket_id: str = "p_main",
+    workspace: str = "ws_a_test",
+    actor_id: str = "did:soul:agent1",
+    action_name: str = "send_to_tenant",
+    precedents: list[dict] | None = None,
+    inputs: list[dict] | None = None,
+    intent: str = "Approve the tenant renewal",
+    approver_user: str | None = None,
+    instinct_policy: str | None = None,
+    instinct_passed: bool | None = None,
+) -> UUID:
+    """Seed one approval chain and return the emitted decision id."""
+    corr = uuid4()
+    scope = ["org:nerve", f"workspace:{workspace}", f"pocket:{pocket_id}"]
+    actor = Actor(kind="agent", id=actor_id, scope_context=scope)
+    payload: dict = {
+        "intent": intent,
+        "action": action_name,
+        "pocket_id": pocket_id,
+        "inputs": inputs or [{"kind": "fabric_object", "id": "lease:LR-2026-117", "label": "Lease LR-2026-117"}],
+    }
+    if precedents is not None:
+        payload["precedents"] = precedents
+    events: list[EventEntry] = [
+        _event(
+            ts=base_ts,
+            actor=actor,
+            action="agent.proposed",
+            correlation_id=corr,
+            payload=payload,
+            scope=scope,
+        ),
+    ]
+    if instinct_policy is not None:
+        events.append(
+            _event(
+                ts=base_ts + timedelta(milliseconds=100),
+                actor=Actor(kind="system", id="system:instinct", scope_context=scope),
+                action="policy.evaluated",
+                correlation_id=corr,
+                payload={"policy": instinct_policy, "passed": bool(instinct_passed)},
+                scope=scope,
+            )
+        )
+    if approver_user:
+        events.append(
+            _event(
+                ts=base_ts + timedelta(seconds=1),
+                actor=Actor(kind="user", id=approver_user, scope_context=scope),
+                action="human.corrected",
+                correlation_id=corr,
+                payload={"action": "approve"},
+                scope=scope,
+            )
+        )
+    events.append(
+        _event(
+            ts=base_ts + timedelta(seconds=2),
+            actor=actor,
+            action="decision.graduated",
+            correlation_id=corr,
+            payload={"passed": True},
+            scope=scope,
+        )
+    )
+    last_id: UUID | None = None
+    for e in events:
+        result = projection.apply(e)
+        if result is not None:
+            last_id = result.id
+    assert last_id is not None
+    return last_id
+
+
+# ---------------------------------------------------------------------------
+# Extractor — templated path (always available)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extractor_templated_recovers_fabric_object_and_date() -> None:
+    """The templated path recognises a bare LR-id + a "April 22" date."""
+    out = await extract_entities(
+        "Why was lease renewal LR-2026-117 approved on April 22?",
+        backend="templated",
+    )
+    assert "lease:LR-2026-117" in out.fabric_object_refs
+    assert out.outcome_hint == "approved"
+    assert out.time_range is not None
+    start, end = out.time_range
+    assert start is not None and start.month == 4 and start.day == 22
+
+
+@pytest.mark.asyncio
+async def test_extractor_templated_recovers_actor_and_pocket() -> None:
+    out = await extract_entities(
+        "Show me everything Prakash approved in pocket p_renewals",
+        backend="templated",
+    )
+    assert "user:prakash" in out.actor_refs
+    assert out.pocket_id == "p_renewals"
+    assert out.outcome_hint == "approved"
+
+
+@pytest.mark.asyncio
+async def test_extractor_falls_back_to_templated_when_no_api_key() -> None:
+    """No API key => templated path runs without an LLM call."""
+    out = await extract_entities(
+        "Why was LR-2026-117 approved?",
+        api_key=None,
+    )
+    assert isinstance(out, ExtractedEntities)
+    assert "lease:LR-2026-117" in out.fabric_object_refs
+
+
+# ---------------------------------------------------------------------------
+# Templated narrator — walks a 4-decision chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_templated_narrator_cites_every_decision(projection, base_ts) -> None:
+    """Walk a chain of 4 precedents → root decision and assert every
+    Decision id (short form) is cited at least once in the narrative.
+
+    Templated narrator currently emits root-id citations on every
+    sentence; precedent ids appear in the precedents sentence. The
+    test asserts both surfaces work — the root id is everywhere; each
+    precedent id appears in its own clause.
+    """
+    # 4 precedent decisions (older than root)
+    prec_ids: list[UUID] = []
+    for i in range(4):
+        pid = _seed_chain(
+            projection,
+            base_ts=base_ts - timedelta(days=4 - i),
+            intent=f"precedent chain {i}",
+            action_name=f"prior_action_{i}",
+        )
+        prec_ids.append(pid)
+
+    root_id = _seed_chain(
+        projection,
+        base_ts=base_ts,
+        precedents=[{"decision_id": str(p), "weight": 0.9} for p in prec_ids[:3]],
+    )
+
+    # Use the cloud graph via the singleton (graph fixture already
+    # set it). Pull the trace + narrate.
+    from pocketpaw_ee.cloud.decisions.service import get_decision_graph
+
+    graph = get_decision_graph()
+    root = await graph.get(root_id)
+    assert root is not None
+    trace = await graph.trace(root_id, depth=2)
+
+    explanation = await narrate_decision(root, trace, backend="templated")
+
+    # Root id is cited.
+    assert str(root_id)[:8] in explanation.narrative
+    # Every precedent id makes it into either the narrative or the walked list.
+    for p in prec_ids[:3]:
+        short = str(p)[:8]
+        assert short in explanation.narrative, (
+            f"precedent {short} missing from narrative: {explanation.narrative}"
+        )
+    # decisions_walked contains every node we touched.
+    assert root_id in explanation.decisions_walked
+    for p in prec_ids[:3]:
+        assert p in explanation.decisions_walked
+    assert explanation.backend_used == "templated"
+
+
+# ---------------------------------------------------------------------------
+# LLM narrator path — mock the Anthropic client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_llm_narrator_strips_ungrounded_sentences(projection, base_ts) -> None:
+    """The mocked LLM returns a narrative with one cited + one ungrounded
+    sentence. The verifier keeps the cited one, strips the second."""
+    root_id = _seed_chain(projection, base_ts=base_ts)
+
+    from pocketpaw_ee.cloud.decisions.service import get_decision_graph
+
+    graph = get_decision_graph()
+    root = await graph.get(root_id)
+    assert root is not None
+    trace = await graph.trace(root_id, depth=2)
+
+    short = str(root_id)[:8]
+    fake_text = (
+        f"The decision was approved with intent to renew the lease [{short}]. "
+        f"The team had a long debate over rent strategy before settling."  # no citation
+    )
+
+    fake_content = MagicMock()
+    fake_content.text = fake_text
+    fake_response = MagicMock()
+    fake_response.content = [fake_content]
+    fake_response.usage = MagicMock(input_tokens=120, output_tokens=40)
+
+    fake_messages = MagicMock()
+    fake_messages.create = AsyncMock(return_value=fake_response)
+    fake_client = MagicMock()
+    fake_client.messages = fake_messages
+
+    with patch(
+        "anthropic.AsyncAnthropic", return_value=fake_client
+    ):
+        explanation = await narrate_decision(
+            root, trace, backend="llm", api_key="sk-fake"
+        )
+
+    # The grounded sentence is kept; the ungrounded one stripped.
+    assert f"[{short}]" in explanation.narrative
+    assert "long debate" not in explanation.narrative
+    assert len(explanation.ungrounded_sentences) == 1
+    assert "long debate" in explanation.ungrounded_sentences[0]
+    assert explanation.backend_used == "llm"
+
+
+@pytest.mark.asyncio
+async def test_llm_narrator_falls_back_on_sdk_error(projection, base_ts) -> None:
+    """When the LLM call raises, the narrator falls through to the
+    templated path and returns a coherent grounded response."""
+    root_id = _seed_chain(projection, base_ts=base_ts)
+
+    from pocketpaw_ee.cloud.decisions.service import get_decision_graph
+
+    graph = get_decision_graph()
+    root = await graph.get(root_id)
+    assert root is not None
+    trace = await graph.trace(root_id, depth=2)
+
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(side_effect=RuntimeError("api down"))
+
+    with patch("anthropic.AsyncAnthropic", return_value=fake_client):
+        explanation = await narrate_decision(
+            root, trace, backend="llm", api_key="sk-fake"
+        )
+
+    assert explanation.backend_used == "templated"
+    assert str(root_id)[:8] in explanation.narrative
+
+
+# ---------------------------------------------------------------------------
+# End-to-end orchestrator — find + trace + narrate + cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_explain_orchestrator_runs_end_to_end(projection, base_ts) -> None:
+    """A real question against a seeded chain produces a grounded
+    narrative without touching an LLM (we force the templated backend)."""
+    root_id = _seed_chain(
+        projection,
+        base_ts=base_ts,
+        approver_user="prakash",
+    )
+
+    explanation = await explain(
+        ExplainRequestInput(
+            question="Why was lease LR-2026-117 approved on May 25?",
+            backend="templated",
+            max_decisions=3,
+        ),
+    )
+
+    assert root_id in explanation.decisions_walked
+    assert str(root_id)[:8] in explanation.narrative
+    assert "Prakash" in explanation.narrative
+
+
+# ---------------------------------------------------------------------------
+# Cache — hit / miss + invalidation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_explain_cache_hits_on_second_call(graph, projection, base_ts) -> None:
+    """First call populates the cache; second identical call returns
+    the cached entry without re-narrating."""
+    root_id = _seed_chain(projection, base_ts=base_ts)
+
+    first = await explain(
+        ExplainRequestInput(
+            question="Why was LR-2026-117 approved?",
+            backend="templated",
+        ),
+    )
+
+    cache = get_explain_cache()
+    assert cache.count() == 1
+
+    # Mutate the narrative on the cached row so we can prove the second
+    # call returned the cached one (without re-running narrator).
+    from pocketpaw_ee.cloud.decisions.explain.cache import (
+        _hash_scope,
+        _normalize_question,
+    )
+
+    key = build_cache_key(
+        question_normalized=_normalize_question("Why was LR-2026-117 approved?"),
+        root_decision_id=root_id,
+        depth=3,
+        scope_hash=_hash_scope(None),
+    )
+    cached_explanation = cache.get(key)
+    assert cached_explanation is not None
+    cached_explanation.narrative = "SENTINEL CACHED VALUE"
+    cache.put(
+        key,
+        cached_explanation,
+        question_normalized=_normalize_question("Why was LR-2026-117 approved?"),
+        root_decision_id=root_id,
+        depth=3,
+        scope_hash=_hash_scope(None),
+    )
+
+    second = await explain(
+        ExplainRequestInput(
+            question="Why was LR-2026-117 approved?",
+            backend="templated",
+        ),
+    )
+    assert second.narrative == "SENTINEL CACHED VALUE"
+    assert first.decisions_walked == second.decisions_walked
+
+
+@pytest.mark.asyncio
+async def test_explain_cache_invalidated_by_new_event(graph, projection, base_ts) -> None:
+    """When the projection folds a new event whose Decision is in a
+    cached entry's `decisions_walked`, the cache entry is invalidated."""
+    root_id = _seed_chain(projection, base_ts=base_ts)
+
+    await explain(
+        ExplainRequestInput(
+            question="Why was LR-2026-117 approved?",
+            backend="templated",
+        ),
+    )
+    cache = get_explain_cache()
+    assert cache.count() == 1
+
+    # Now seed a NEW chain — this fires the projection's post-apply
+    # hook, which the cache registered an invalidator with. The
+    # invalidator drops rows whose `decisions_walked` includes the
+    # newly-emitted decision. Our cached row's walked list is
+    # [root_id]; the new decision is a different id, so the cache
+    # row should survive. Let's first prove that.
+    _seed_chain(projection, base_ts=base_ts + timedelta(hours=1))
+    assert cache.count() == 1, "unrelated decision should not invalidate"
+
+    # Now simulate the explicit invalidation of root_id and assert the
+    # cache row is gone.
+    removed = cache.invalidate_for_decisions([root_id])
+    assert removed == 1
+    assert cache.count() == 0
+
+
+@pytest.mark.asyncio
+async def test_explain_cache_invalidation_via_projection_hook(
+    graph, projection, base_ts
+) -> None:
+    """Confirm the cache invalidation hook is registered on the projection
+    and fires when a new decision lands whose id matches a cached walked
+    entry. We synthesise a chain where the new decision IS the cached
+    decision (which requires re-emit through INSERT OR REPLACE)."""
+    root_id = _seed_chain(projection, base_ts=base_ts)
+
+    await explain(
+        ExplainRequestInput(
+            question="Why was LR-2026-117 approved?",
+            backend="templated",
+        ),
+    )
+    cache = get_explain_cache()
+    assert cache.count() == 1
+
+    # Manually fire the post-apply hooks with the SAME decision id —
+    # mimics the cache-invalidation path the projection takes when an
+    # outcome attaches to the existing decision (Slice 2 back-ref).
+    root = await graph.get(root_id)
+    assert root is not None
+    projection._emit(root)
+    # The hook should have wiped the cached row.
+    assert cache.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Scope filtering — workspace A vs B
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_explain_scope_filter_hides_other_workspace(
+    graph, projection, base_ts
+) -> None:
+    """A workspace-B caller can't reach workspace-A decisions through
+    the explain orchestrator — `requester_scopes` is the gate."""
+    _seed_chain(projection, base_ts=base_ts, workspace="ws_a_test")
+
+    # B asks the same question — gets the empty-trace canned response
+    # because the only matching decision is out of scope.
+    response_b = await explain(
+        ExplainRequestInput(
+            question="Why was LR-2026-117 approved?",
+            backend="templated",
+        ),
+        requester_scopes=["workspace:ws_b_test"],
+    )
+    assert response_b.decisions_walked == []
+    assert "No matching decision was found" in response_b.narrative
+
+
+# ---------------------------------------------------------------------------
+# REST route — POST /api/v1/decisions/explain
+# ---------------------------------------------------------------------------
+
+
+def test_explain_route_returns_grounded_response(
+    client: TestClient, projection, base_ts
+) -> None:
+    """Round-trip through the FastAPI route. Templated backend so the
+    test is hermetic."""
+    root_id = _seed_chain(projection, base_ts=base_ts)
+    resp = client.post(
+        "/api/v1/decisions/explain",
+        json={
+            "question": "Why was LR-2026-117 approved on May 25?",
+            "backend": "templated",
+            "max_decisions": 3,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert str(root_id) in body["decisions_walked"]
+    assert str(root_id)[:8] in body["narrative"]
+    assert body["backend_used"] == "templated"
+
+
+def test_explain_route_rejects_empty_question(client: TestClient) -> None:
+    """FastAPI validation rejects an empty question."""
+    resp = client.post(
+        "/api/v1/decisions/explain",
+        json={"question": ""},
+    )
+    assert resp.status_code == 422
+
+
+def test_explain_route_handles_no_match(client: TestClient) -> None:
+    """No matching decision → 200 with the canned empty narrative
+    and an empty decisions_walked list."""
+    resp = client.post(
+        "/api/v1/decisions/explain",
+        json={
+            "question": "Why was lease LR-9999-999 approved?",
+            "backend": "templated",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["decisions_walked"] == []
+    assert "No matching decision was found" in body["narrative"]
+
+
+def test_explain_response_dto_shape(projection, base_ts) -> None:
+    """The wire shape matches what the frontend Slice 3b will consume.
+
+    Sanity check on the round-trip ExplanationResponse.from_domain.
+    """
+    root_id = _seed_chain(projection, base_ts=base_ts)
+    from pocketpaw_ee.cloud.decisions.explain.narrator import Explanation
+
+    explanation = Explanation(
+        narrative=f"It was approved [{str(root_id)[:8]}].",
+        decisions_walked=[root_id],
+        depth_reached=1,
+        tokens_in=120,
+        tokens_out=40,
+        backend_used="llm",
+    )
+    wire = ExplanationResponse.from_domain(explanation)
+    assert wire.narrative == explanation.narrative
+    assert wire.decisions_walked == [root_id]
+    assert wire.backend_used == "llm"
+    # JSON round-trip — the wire shape is serialisable.
+    data = wire.model_dump(mode="json")
+    assert data["decisions_walked"] == [str(root_id)]

--- a/tests/ee/test_decisions_explain_mcp.py
+++ b/tests/ee/test_decisions_explain_mcp.py
@@ -1,0 +1,289 @@
+# tests/ee/test_decisions_explain_mcp.py — RFC 07 Slice 3a MCP coverage.
+# Created: 2026-05-25 — pins the in-process MCP wrapper shipped in
+#   `pocketpaw_ee.agent.mcp_servers.decisions` for the explain tool:
+#
+#     decisions_explain(question, scope=, max_decisions=, depth=, backend=)
+#
+#   The handler delegates to `pocketpaw_ee.cloud.decisions.explain.explain`
+#   so the wire shape it returns mirrors the REST `ExplanationResponse`
+#   exactly — REST and MCP must never drift. Test surface:
+#
+#     - Happy path: a real question produces a grounded narrative
+#       envelope with `decisions_walked`.
+#     - Identity: a missing workspace ContextVar yields the MCP error
+#       envelope (the same chokepoint the other decisions_* handlers use).
+#     - Validation: an empty question is an MCP error.
+#     - Scope: a different workspace's decisions are invisible (same
+#       silent-elide invariant the read tools enforce).
+#     - Allowlist: the explain tool id is in the canonical
+#       `DECISIONS_TOOL_IDS` tuple so the Claude Code allowlist machinery
+#       picks it up.
+"""Tests for the explain MCP wrapper."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from soul_protocol.spec.journal import Actor, EventEntry
+
+from pocketpaw_ee.agent.mcp_servers.decisions import (
+    DECISIONS_EXPLAIN_TOOL_ID,
+    DECISIONS_TOOL_IDS,
+    _decisions_explain_handler,
+)
+from pocketpaw_ee.cloud.chat.agent_service import (
+    attach_agent_identity,
+    detach_agent_identity,
+)
+from pocketpaw_ee.cloud.decisions.explain.cache import reset_explain_cache_for_tests
+from pocketpaw_ee.cloud.decisions.projection import DecisionProjection
+from pocketpaw_ee.cloud.decisions.service import (
+    DecisionGraph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import DecisionStore, set_db_path
+
+# ---------------------------------------------------------------------------
+# Fixtures — mirror test_decisions_mcp's pattern
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    reset_projection_for_tests()
+    reset_explain_cache_for_tests()
+    yield
+    reset_projection_for_tests()
+    reset_explain_cache_for_tests()
+
+
+@pytest.fixture
+def workspace_id() -> str:
+    return "ws_a_test"
+
+
+@pytest.fixture
+def agent_id() -> str:
+    return "did:soul:test_agent"
+
+
+@pytest.fixture
+def _identity_context(workspace_id: str, agent_id: str):
+    tokens = attach_agent_identity(workspace_id=workspace_id, user_id=agent_id)
+    yield
+    detach_agent_identity(tokens)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> DecisionStore:
+    set_db_path(tmp_path / "decisions.db")
+    s = DecisionStore()
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def projection(store: DecisionStore) -> DecisionProjection:
+    return DecisionProjection(store=store)
+
+
+@pytest.fixture
+def graph(store: DecisionStore, projection: DecisionProjection) -> DecisionGraph:
+    from pocketpaw_ee.cloud.decisions import service as decisions_service
+
+    g = DecisionGraph(store=store, projection=projection)
+    decisions_service._GRAPH = g
+    return g
+
+
+@pytest.fixture
+def base_ts() -> datetime:
+    return datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — chain seeding, mirrors test_decisions_mcp._seed_chain
+# ---------------------------------------------------------------------------
+
+
+def _event(
+    *,
+    ts: datetime,
+    actor: Actor,
+    action: str,
+    correlation_id: UUID | None,
+    payload: dict,
+    scope: list[str] | None = None,
+) -> EventEntry:
+    return EventEntry(
+        id=uuid4(),
+        ts=ts,
+        actor=actor,
+        action=action,
+        scope=scope or ["org:nerve", "workspace:ws_a_test"],
+        correlation_id=correlation_id,
+        payload=payload,
+    )
+
+
+def _seed_chain(
+    projection: DecisionProjection,
+    *,
+    base_ts: datetime,
+    pocket_id: str = "p_main",
+    workspace: str = "ws_a_test",
+    actor_id: str = "did:soul:agent1",
+) -> UUID:
+    corr = uuid4()
+    scope = ["org:nerve", f"workspace:{workspace}", f"pocket:{pocket_id}"]
+    actor = Actor(kind="agent", id=actor_id, scope_context=scope)
+    payload: dict = {
+        "intent": f"chain-{corr.hex[:8]}",
+        "action": "send_to_tenant",
+        "pocket_id": pocket_id,
+        "inputs": [{"kind": "fabric_object", "id": "lease:LR-2026-117", "label": "Lease LR-2026-117"}],
+    }
+    events = [
+        _event(
+            ts=base_ts,
+            actor=actor,
+            action="agent.proposed",
+            correlation_id=corr,
+            payload=payload,
+            scope=scope,
+        ),
+        _event(
+            ts=base_ts + timedelta(seconds=1),
+            actor=actor,
+            action="decision.graduated",
+            correlation_id=corr,
+            payload={"passed": True},
+            scope=scope,
+        ),
+    ]
+    last_id: UUID | None = None
+    for e in events:
+        result = projection.apply(e)
+        if result is not None:
+            last_id = result.id
+    assert last_id is not None
+    return last_id
+
+
+def _read_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
+    assert "is_error" not in envelope or envelope.get("is_error") is False
+    return json.loads(envelope["content"][0]["text"])
+
+
+# ---------------------------------------------------------------------------
+# Happy path — the wrapper returns the explain wire shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_explain_handler_returns_grounded_envelope(
+    _identity_context, graph, projection, base_ts
+) -> None:
+    """End-to-end through the MCP wrapper: seeded decision, templated
+    backend, wire envelope carries the same fields the REST response
+    does."""
+    root_id = _seed_chain(projection, base_ts=base_ts)
+
+    envelope = await _decisions_explain_handler(
+        {
+            "question": "Why was LR-2026-117 approved?",
+            "backend": "templated",
+            "max_decisions": 3,
+        }
+    )
+    body = _read_envelope(envelope)
+    # Wire fields the REST ExplanationResponse defines.
+    assert "narrative" in body
+    assert "decisions_walked" in body
+    assert "backend_used" in body
+    assert body["backend_used"] == "templated"
+    assert str(root_id) in body["decisions_walked"]
+    assert str(root_id)[:8] in body["narrative"]
+
+
+# ---------------------------------------------------------------------------
+# Identity — missing workspace yields the MCP error envelope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_explain_handler_requires_identity(graph) -> None:
+    """Outside a chat stream, the workspace ContextVar is None and the
+    handler returns the canonical "no active workspace" error."""
+    envelope = await _decisions_explain_handler(
+        {"question": "Why was LR-2026-117 approved?"}
+    )
+    assert envelope.get("is_error") is True
+    assert "no active workspace" in envelope["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Validation — empty question is an error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_explain_handler_rejects_empty_question(
+    _identity_context, graph
+) -> None:
+    envelope = await _decisions_explain_handler({"question": ""})
+    assert envelope.get("is_error") is True
+    assert "question is required" in envelope["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_explain_handler_rejects_missing_question(
+    _identity_context, graph
+) -> None:
+    envelope = await _decisions_explain_handler({})
+    assert envelope.get("is_error") is True
+
+
+# ---------------------------------------------------------------------------
+# Scope — other-workspace decisions are invisible
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_explain_handler_respects_scope(
+    _identity_context, graph, projection, base_ts
+) -> None:
+    """A decision seeded under a different workspace is not visible
+    through the explain wrapper — the canned "no matching decision"
+    response comes back instead."""
+    _seed_chain(projection, base_ts=base_ts, workspace="ws_other")
+
+    envelope = await _decisions_explain_handler(
+        {
+            "question": "Why was LR-2026-117 approved?",
+            "backend": "templated",
+        }
+    )
+    body = _read_envelope(envelope)
+    assert body["decisions_walked"] == []
+    assert "No matching decision was found" in body["narrative"]
+
+
+# ---------------------------------------------------------------------------
+# Allowlist — tool id namespaces match the Claude Code convention
+# ---------------------------------------------------------------------------
+
+
+def test_explain_tool_id_in_allowlist() -> None:
+    """The explain tool id must be in `DECISIONS_TOOL_IDS` so the
+    backend's allowlist machinery picks it up alongside the read tools."""
+    assert DECISIONS_EXPLAIN_TOOL_ID in DECISIONS_TOOL_IDS
+    assert DECISIONS_EXPLAIN_TOOL_ID.startswith("mcp__pocketpaw_decisions__")
+    # Namespace symmetry — every read tool id has the same prefix.
+    for tool_id in DECISIONS_TOOL_IDS:
+        assert tool_id.startswith("mcp__pocketpaw_decisions__")

--- a/tests/unit/test_bundled_templates.py
+++ b/tests/unit/test_bundled_templates.py
@@ -27,7 +27,10 @@ from pocketpaw.bundled_templates.installer import (
 )
 from pocketpaw.bundled_templates.loader import load_template
 
-# The six built-in templates Increment 2a ships.
+# The built-in templates the bundled installer ships. Increment 2a
+# shipped six; RFC 07 Slice 3a added `decision-graph`. Update when a
+# new bundled template lands so the parametrized RFC03-shape tests
+# cover it automatically.
 _EXPECTED_SLUGS = {
     "todo-task-tracker",
     "kanban-board",
@@ -35,6 +38,7 @@ _EXPECTED_SLUGS = {
     "crm-record-list",
     "calendar-planner",
     "activity-feed",
+    "decision-graph",
 }
 
 # RFC 03 Pocket Template Schema — the field set a seed template may
@@ -227,7 +231,7 @@ def test_crm_template_ships_sources_placeholder() -> None:
     assert "pocket_open" in records["refresh"]
 
 
-def test_index_json_lists_all_six_templates() -> None:
+def test_index_json_lists_all_bundled_templates() -> None:
     """index.json registers every bundled template with the registry
     row shape the chat agent's STEP 0 keyword match consumes."""
     index = json.loads((_BUNDLED_DIR / "index.json").read_text())


### PR DESCRIPTION
## Summary

Wires the natural-language `explain` pipeline on top of the deterministic `DecisionGraph` from Slices 1 and 2. A new POST route, a new MCP tool, a new bundled pocket template, plus the entity extractor, the dual-backend narrator, and the 24h response cache that backs all of it.

Stacked on #1231 (Slice 2). Parallel-with the paw-enterprise frontend widget PR (Slice 3b) — the frontend will call the new `POST /api/v1/decisions/explain` route with the shape pinned in `dto.ExplanationResponse`.

## What ships

**`POST /api/v1/decisions/explain`** — one new route on the decisions router. Takes `{question, scope?, max_decisions=5, depth=3, backend?}`; returns `ExplanationResponse` with `narrative`, `decisions_walked`, `depth_reached`, `tokens_in/out`, `ungrounded_sentences`, and `backend_used`. Same scope filter as the read routes: a workspace caller never sees another workspace's decisions through the explain pipeline.

**Dual-backend narrator** in `decisions/explain/narrator.py`:
- **llm** (default) — Sonnet call with the system prompt as a cache block; compressed trace in the variable user message. Verifier re-scans the response for `[short-id]` citations and strips any sentence that cites an id outside the supplied trace.
- **templated** — deterministic walk over the trace. Used when the SDK is missing, no API key is configured, the LLM call raises, or the per-pocket `backend_pref` opts in. Emits citations in the same `[xxxxxxxx]` form the verifier checks, so the two backends share one quality floor.

**Entity extractor** in `decisions/explain/extractor.py` — Haiku call with the system prompt + few-shots as one cache block (only the question varies per call), with a regex fallback that handles `lease:LR-2026-117`, `April 22`, `by Prakash`, `pocket p_renewals`, and the `approved`/`rejected` outcome hints. The fallback is the path the captain's killer-demo question hits when no key is set.

**24h cache** in `decisions/explain/cache.py` — keyed on `(question_normalized, root_id, depth, scope_hash)`, sharing the SQLite file the projection already writes to. Reverse-index invalidation through a new post-apply hook registry on `DecisionProjection` — explain registers an invalidator; the projection invokes it after every emit. Layering stays one-way (explain → decisions); the projection never imports the cache.

**MCP tool** `mcp__pocketpaw_decisions__decisions_explain` — fourth tool on the decisions MCP server. Same identity + scope contract as the read tools; delegates to the cloud-side orchestrator so the wire shape mirrors the REST response.

**Bundled pocket template** `decision-graph` in `src/pocketpaw/bundled_templates/_bundled/decision-graph/`. Vertical `core`, shape `custom`, RFC03-conformant. Wires an Explain button to the new route; placeholder graph widget passes through ingest validation as an unknown type until the SvelteFlow `decision-graph` widget lands in paw-enterprise (Slice 3b).

## Test plan

- [x] Templated narrator walks a 4-decision chain; every decision id is cited
- [x] LLM narrator path (mocked Anthropic client); verifier strips ungrounded sentences
- [x] LLM narrator falls back to templated on SDK error
- [x] Extractor templated path recovers fabric-object + date + outcome hint
- [x] Cache hit on second identical call returns the cached row
- [x] Cache invalidation via the projection post-apply hook
- [x] Scope filter — workspace B never reaches workspace A's decisions
- [x] End-to-end through the REST route (templated backend, no LLM)
- [x] MCP wrapper happy path + identity error + empty-question error + scope check
- [x] Allowlist — `DECISIONS_EXPLAIN_TOOL_ID` namespaces under `mcp__pocketpaw_decisions__`
- [x] Bundled template: RFC03 schema shape, ripple_spec wiring, index registration, install + load
- [x] Existing bundled-templates test now covers decision-graph as the 7th slug
- [x] `import-linter` — 17 contracts kept (added the four explain modules to the Decisions contract)
- [x] Slice 1 + 2 + 3a + bundled-templates: 126 passed
- [x] Full ee suite: 631 passed, 1 skipped

```bash
uv run --group ee pytest \
  tests/ee/test_decision_projection.py \
  tests/ee/test_decision_graph_api.py \
  tests/ee/test_decisions_router.py \
  tests/ee/test_decisions_mcp.py \
  tests/ee/test_outcomes_decision_backref.py \
  tests/ee/test_decisions_explain.py \
  tests/ee/test_decisions_explain_mcp.py \
  tests/ee/test_bundled_decision_graph_template.py \
  -q
# 91 passed in 1.70s

uv run --group ee pytest tests/ee/ --ignore=tests/e2e -q
# 631 passed, 1 skipped

uv run --group ee lint-imports --config ee/pyproject.toml
# 17 contracts kept, 0 broken
```

## Stacked on

- pocketpaw#1231 (Slice 2). Do not merge to dev until the base PR lands.

## Parallel with

- paw-enterprise Slice 3b frontend PR — calls `POST /api/v1/decisions/explain` and renders the `decision-graph` Layer-2 widget the bundled template references.