### PR TITLE
feat(decisions): RFC 07 Slice 2 — REST + MCP wrappers + outcomes back-reference (reopened)

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/decisions.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/decisions.py
@@ -1,0 +1,404 @@
+# decisions.py — In-process MCP server exposing the cloud decision graph.
+# Created: 2026-05-25 (RFC 07 Slice 2) — wraps the in-process
+#   `DecisionGraph` Python API so MCP-capable agent backends (currently
+#   `claude_agent_sdk`) can pull audit / trace / explainability context
+#   without going through the HTTP surface. Mirrors the pattern in
+#   `tasks.py` and `planner.py`: agent identity comes from the per-stream
+#   ContextVars in `ee.cloud.chat.agent_service`; outside an SSE stream
+#   the tools return a clear MCP error rather than silently mis-tenanting.
+#
+# Tools registered:
+#   - decisions_get(decision_id)
+#   - decisions_find(actor=, since=, until=, scope_kind=, pocket_id=,
+#                    policy=, outcome_status=, limit=)
+#   - decisions_trace(decision_id, depth=3)
+#
+# `explain` (NL Q&A with narrator) is intentionally Slice 3 — not on this
+# surface yet. Same shape as the REST router's read endpoints; the wire
+# response shape is `DecisionResponse` from `decisions.dto`.
+"""Agent-side MCP surface for the decision-graph entity.
+
+These tools let an agent ask "what did we decide, why, and what came
+of it" without leaving its loop. The wrappers thin-shim the in-process
+`DecisionGraph` Python API so the SDK never owns a copy of the wire
+contract — change the DTO once and both REST + MCP track it.
+
+The scope filter is the load-bearing audit invariant: every call passes
+`requester_scopes=[f"workspace:{workspace_id}"]` (resolved from the
+chat stream's per-request ContextVars). A Decision outside that scope
+returns the same "not found" envelope as a Decision that truly doesn't
+exist — agents cannot probe for hidden rows via the MCP surface, just
+as they can't via REST.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_decisions"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+# Allowlist entries must use this exact form.
+DECISIONS_GET_TOOL_ID = f"mcp__{SERVER_NAME}__decisions_get"
+DECISIONS_FIND_TOOL_ID = f"mcp__{SERVER_NAME}__decisions_find"
+DECISIONS_TRACE_TOOL_ID = f"mcp__{SERVER_NAME}__decisions_trace"
+
+DECISIONS_TOOL_IDS = (
+    DECISIONS_GET_TOOL_ID,
+    DECISIONS_FIND_TOOL_ID,
+    DECISIONS_TRACE_TOOL_ID,
+)
+
+
+# ---------------------------------------------------------------------------
+# MCP response envelopes — same shape as the tasks / planner servers
+# ---------------------------------------------------------------------------
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    """Build an MCP error response in the shape Claude's SDK expects."""
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    """Build an MCP success response carrying `body` as JSON text."""
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(body, separators=(",", ":"), default=str),
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Identity resolution — same chokepoint the tasks / planner servers use
+# ---------------------------------------------------------------------------
+
+
+def _identity() -> tuple[str | None, str | None]:
+    """Resolve workspace + agent-user-id from per-stream ContextVars.
+
+    Returns `(workspace_id, user_id)` — the agent's runtime authenticates
+    as itself when calling into the cloud, so `user_id` IS the agent
+    identity from the auth layer's perspective. Both values come back
+    `None` when the tool is invoked outside an SSE chat stream; the
+    handler returns a clear MCP error rather than silently mis-tenanting.
+    """
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_user_id, current_workspace_id
+
+        return current_workspace_id(), current_user_id()
+    except Exception:
+        return None, None
+
+
+def _requester_scopes(workspace_id: str) -> list[str]:
+    """Build the scope-tag list for a workspace-scoped requester.
+
+    Same contract the REST router enforces — Decisions are visible to a
+    requester whose scope list intersects with the Decision's scope
+    tags. A workspace caller can see decisions tagged
+    `workspace:<id>` (and anything that shares one of those tags).
+    """
+    return [f"workspace:{workspace_id}"]
+
+
+# ---------------------------------------------------------------------------
+# Wire helpers — share the REST router's wire shape via dto.DecisionResponse
+# ---------------------------------------------------------------------------
+
+
+def _decision_wire(decision: Any) -> dict[str, Any]:
+    """Map a domain `Decision` to the wire dict the REST surface returns."""
+    from pocketpaw_ee.cloud.decisions.dto import DecisionResponse
+
+    return DecisionResponse.from_domain(decision).model_dump(mode="json")
+
+
+def _trace_wire(result: Any) -> dict[str, Any]:
+    """Map a service-layer `TraceResult` to the wire dict."""
+    from pocketpaw_ee.cloud.decisions.dto import (
+        DecisionResponse,
+        DecisionTraceResponse,
+        EdgeDTO,
+        TraceNodeResponse,
+    )
+
+    wire = DecisionTraceResponse(
+        root=result.root,
+        nodes={
+            node_id: TraceNodeResponse(
+                id=node.id,
+                kind=node.kind,
+                decision=DecisionResponse.from_domain(node.decision) if node.decision else None,
+                label=node.label,
+            )
+            for node_id, node in result.nodes.items()
+        },
+        edges=[
+            EdgeDTO(
+                src=str(e.src_id),
+                target=e.target_id,
+                relation=e.relation,
+                weight=e.weight,
+            )
+            for e in result.edges
+        ],
+        truncated=result.truncated,
+        truncated_count=result.truncated_count,
+        depth_reached=result.depth_reached,
+    )
+    return wire.model_dump(mode="json")
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    """Parse an ISO-8601 string into a datetime; tolerate None / bad input."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers
+# ---------------------------------------------------------------------------
+
+
+async def _decisions_get_handler(args: dict) -> dict:
+    workspace_id, agent_id = _identity()
+    if not workspace_id or not agent_id:
+        return _error_response(
+            "no active workspace/agent — decisions_get can only be called "
+            "from inside a cloud SSE chat stream"
+        )
+
+    decision_id_raw = args.get("decision_id")
+    if not isinstance(decision_id_raw, str) or not decision_id_raw:
+        return _error_response("decision_id is required (string UUID)")
+    try:
+        decision_id = UUID(decision_id_raw)
+    except (ValueError, TypeError):
+        return _error_response(f"'{decision_id_raw}' is not a valid UUID")
+
+    from pocketpaw_ee.cloud.decisions.service import get_decision_graph
+
+    try:
+        graph = get_decision_graph()
+        decision = await graph.get(
+            decision_id,
+            requester_scopes=_requester_scopes(workspace_id),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("decisions_get failed", exc_info=True)
+        return _error_response(f"decisions_get failed: {exc}")
+
+    if decision is None:
+        # Same envelope as a real miss — agents cannot probe for hidden rows.
+        return _success_response({"decision": None, "found": False})
+    return _success_response({"decision": _decision_wire(decision), "found": True})
+
+
+async def _decisions_find_handler(args: dict) -> dict:
+    workspace_id, agent_id = _identity()
+    if not workspace_id or not agent_id:
+        return _error_response(
+            "no active workspace/agent — decisions_find can only be called "
+            "from inside a cloud SSE chat stream"
+        )
+
+    actor = args.get("actor") or None
+    pocket_id = args.get("pocket_id") or None
+    policy = args.get("policy") or None
+    outcome_status = args.get("outcome_status") or None
+    scope_kind = args.get("scope_kind") or None
+    input_id = args.get("input_id") or None
+    since = _parse_iso(args.get("since"))
+    until = _parse_iso(args.get("until"))
+    limit_raw = args.get("limit") or 50
+    try:
+        limit = max(1, min(int(limit_raw), 200))
+    except (TypeError, ValueError):
+        limit = 50
+
+    from pocketpaw_ee.cloud.decisions.service import get_decision_graph
+
+    try:
+        graph = get_decision_graph()
+        decisions = await graph.find(
+            actor=actor,
+            since=since,
+            until=until,
+            scope_kind=scope_kind,
+            pocket_id=pocket_id,
+            policy=policy,
+            outcome_status=outcome_status,
+            input_id=input_id,
+            limit=limit,
+            requester_scopes=_requester_scopes(workspace_id),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("decisions_find failed", exc_info=True)
+        return _error_response(f"decisions_find failed: {exc}")
+
+    return _success_response(
+        {
+            "decisions": [_decision_wire(d) for d in decisions],
+            "count": len(decisions),
+        }
+    )
+
+
+async def _decisions_trace_handler(args: dict) -> dict:
+    workspace_id, agent_id = _identity()
+    if not workspace_id or not agent_id:
+        return _error_response(
+            "no active workspace/agent — decisions_trace can only be called "
+            "from inside a cloud SSE chat stream"
+        )
+
+    decision_id_raw = args.get("decision_id")
+    if not isinstance(decision_id_raw, str) or not decision_id_raw:
+        return _error_response("decision_id is required (string UUID)")
+    try:
+        decision_id = UUID(decision_id_raw)
+    except (ValueError, TypeError):
+        return _error_response(f"'{decision_id_raw}' is not a valid UUID")
+
+    depth_raw = args.get("depth") or 3
+    try:
+        depth = max(1, min(int(depth_raw), 10))
+    except (TypeError, ValueError):
+        depth = 3
+
+    from pocketpaw_ee.cloud.decisions.service import get_decision_graph
+
+    try:
+        graph = get_decision_graph()
+        result = await graph.trace(
+            decision_id,
+            depth=depth,
+            requester_scopes=_requester_scopes(workspace_id),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("decisions_trace failed", exc_info=True)
+        return _error_response(f"decisions_trace failed: {exc}")
+
+    return _success_response(_trace_wire(result))
+
+
+# ---------------------------------------------------------------------------
+# Server factory — matches the shape of `build_tasks_context_server`
+# ---------------------------------------------------------------------------
+
+
+def build_decisions_context_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for the decision graph, or
+    return `None` if the Claude Agent SDK isn't installed.
+
+    Returned shape matches the other in-process servers (tasks, planner,
+    pockets) so the backend's MCP registration loop in `claude_sdk.py`
+    treats every server identically.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_decisions MCP disabled")
+        return None
+
+    @tool(
+        "decisions_get",
+        (
+            "Look up one Decision from the decision graph by its UUID. "
+            "Returns the full Decision record — actor, intent, action, "
+            "inputs, approvers, outcome, precedents, hash_link — when the "
+            "Decision exists AND is visible in the caller's workspace "
+            "scope. Returns `{found: false, decision: null}` when the "
+            "Decision is unknown OR outside the caller's scope (the two "
+            "states are deliberately indistinguishable — agents cannot "
+            "probe for hidden rows). Use this when the user asks 'why did "
+            "we decide X?' and you already have the decision id from a "
+            "trace, downstream walk, or list result."
+        ),
+        {"decision_id": str},
+    )
+    async def decisions_get(args):  # type: ignore[no-untyped-def]
+        return await _decisions_get_handler(args)
+
+    @tool(
+        "decisions_find",
+        (
+            "Multi-axis filter over recent decisions. Every filter is "
+            "optional; combine to narrow. Common shapes: "
+            "`{actor: 'did:soul:agent1'}` (everything one agent decided), "
+            "`{pocket_id: 'p_renewals', since: '2026-05-01T00:00:00Z'}` "
+            "(everything one pocket decided this month), "
+            "`{outcome_status: 'rejected'}` (every refused decision in the "
+            "workspace). Returns up to `limit` Decisions (default 50, max "
+            "200) sorted newest-first. Scope-filtered — only Decisions in "
+            "the caller's workspace scope are returned. Use this to build "
+            "the audit + 'similar past calls' surface."
+        ),
+        {
+            "actor": str,
+            "since": str,
+            "until": str,
+            "scope_kind": str,
+            "pocket_id": str,
+            "policy": str,
+            "outcome_status": str,
+            "input_id": str,
+            "limit": int,
+        },
+    )
+    async def decisions_find(args):  # type: ignore[no-untyped-def]
+        return await _decisions_find_handler(args)
+
+    @tool(
+        "decisions_trace",
+        (
+            "Walk the decision graph upstream from one Decision. Returns "
+            "a depth-bounded BFS over `precedent` and `input` edges — the "
+            "facts and prior calls that fed this Decision. `approval` and "
+            "`outcome` edges are surfaced as terminal labels (not walked "
+            "further) so the trace stays narratable. Defaults: depth=3, "
+            "max_fanout=20 per node. Use this to answer 'what did we "
+            "consider when we made this call?' — the response carries "
+            "every Decision + InputRef in the upstream subgraph plus the "
+            "edges that link them. Scope-filtered: nodes outside the "
+            "caller's workspace scope are silently elided."
+        ),
+        {"decision_id": str, "depth": int},
+    )
+    async def decisions_trace(args):  # type: ignore[no-untyped-def]
+        return await _decisions_trace_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[decisions_get, decisions_find, decisions_trace],
+    )
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "DECISIONS_FIND_TOOL_ID",
+    "DECISIONS_GET_TOOL_ID",
+    "DECISIONS_TOOL_IDS",
+    "DECISIONS_TRACE_TOOL_ID",
+    "SERVER_NAME",
+    "build_decisions_context_server",
+]

--- a/ee/pocketpaw_ee/cloud/decisions/dto.py
+++ b/ee/pocketpaw_ee/cloud/decisions/dto.py
@@ -1,25 +1,165 @@
 # dto.py — Request / response DTOs for the decision-graph REST surface.
-# Created: 2026-05-25 (RFC 07 Slice 1) — skeletons only. Slice 1 ships the
-#   in-process Python API (`DecisionGraph` in service.py) which returns
-#   `Decision` domain objects directly. The REST router fills in shape
-#   in Slice 2 — these DTOs are the wire contract it will use.
-#
-# Why ship the DTOs now: Slice 2 work can start without re-deriving the
-# wire shape, and the import-linter contract (decisions/dto.py forbidden
-# from importing models.*) needs a real file to lint. Distinct
-# Request/Response per ee/cloud Rule 4.
+# Created: 2026-05-25 (RFC 07 Slice 1) — skeletons only.
+# Updated: 2026-05-25 (RFC 07 Slice 2) — wired the real wire shapes the
+#   five REST routes return (get / list / trace / downstream / timeline).
+#   Adds `DecisionResponse` (the wire mirror of the domain Decision so
+#   wire ≠ domain per ee/cloud Rule 4), `EdgeDTO` (relation-tagged trace
+#   edge), `JournalEventDTO` + `TimelineResponse` (the flattened journal
+#   chain for one correlation_id), and keeps the original request DTOs
+#   the router parses query strings into. Pagination is keyset on
+#   `(ts DESC, id DESC)` — the cursor is encoded as opaque
+#   `before_ts` / `before_id` query params; the response echoes them
+#   back as `next_before_ts` / `next_before_id` for the next page.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from pocketpaw_ee.cloud.decisions.domain import (
     Decision,
-    DecisionEdgeRecord,
+    EdgeRelation,
     OutcomeStatus,
     ScopeKind,
 )
+
+
+# ---------------------------------------------------------------------------
+# Approver / input / outcome wire shapes — minor flattenings of the domain
+# value objects so the wire schema doesn't leak Pydantic internals.
+# ---------------------------------------------------------------------------
+
+
+class ApproverWire(BaseModel):
+    """Wire shape for one approver — flattens the embedded Actor so the
+    JSON consumer can read `actor_id` / `actor_kind` without unpacking.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    actor_kind: str
+    actor_id: str
+    approved_at: datetime
+    position: int = 0
+
+
+class InputWire(BaseModel):
+    """Wire shape for one input — same fields as `InputRef`, no nesting."""
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: str
+    id: str
+    label: str = ""
+    point_in_time: datetime | None = None
+
+
+class OutcomeWire(BaseModel):
+    """Wire shape for the outcome attached to a Decision."""
+
+    model_config = ConfigDict(frozen=True)
+
+    outcome_id: UUID
+    status: OutcomeStatus
+    landed_at: datetime | None = None
+    metered: bool = False
+
+
+class PrecedentWire(BaseModel):
+    """Wire shape for a precedent reference — just the target id + weight."""
+
+    model_config = ConfigDict(frozen=True)
+
+    decision_id: UUID
+    weight: float = 1.0
+
+
+class DecisionResponse(BaseModel):
+    """Wire mirror of `decisions.domain.Decision` (ee/cloud Rule 4).
+
+    Renames `decided_by` to `actor_kind` / `actor_id` for symmetry with
+    `ApproverWire`. `correlation_id` and `hash_link` are surfaced as
+    strings so the client never has to know the SQLite or hash encoding.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: UUID
+    ts: datetime
+    actor_kind: str
+    actor_id: str
+    scope: list[str]
+    scope_kind: ScopeKind
+    intent: str
+    action: str
+    inputs: list[InputWire] = Field(default_factory=list)
+    approvers: list[ApproverWire] = Field(default_factory=list)
+    instinct_policy: str | None = None
+    instinct_policy_passed: bool | None = None
+    precedents: list[PrecedentWire] = Field(default_factory=list)
+    outcome: OutcomeWire | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+    pocket_id: str | None = None
+    correlation_id: UUID | None = None
+    hash_link: str = ""
+    last_seq: int = 0
+
+    @classmethod
+    def from_domain(cls, decision: Decision) -> DecisionResponse:
+        """Build the wire response from a domain Decision. Centralised so
+        the five routes share one mapping path (no drift)."""
+        return cls(
+            id=decision.id,
+            ts=decision.ts,
+            actor_kind=decision.decided_by.kind,
+            actor_id=decision.decided_by.id,
+            scope=list(decision.scope),
+            scope_kind=decision.scope_kind,
+            intent=decision.intent,
+            action=decision.action,
+            inputs=[
+                InputWire(
+                    kind=i.kind,
+                    id=i.id,
+                    label=i.label,
+                    point_in_time=i.point_in_time,
+                )
+                for i in decision.inputs
+            ],
+            approvers=[
+                ApproverWire(
+                    actor_kind=a.actor.kind,
+                    actor_id=a.actor.id,
+                    approved_at=a.approved_at,
+                    position=a.position,
+                )
+                for a in decision.approvers
+            ],
+            instinct_policy=decision.instinct_policy,
+            instinct_policy_passed=decision.instinct_policy_passed,
+            precedents=[
+                PrecedentWire(decision_id=p.decision_id, weight=p.weight)
+                for p in decision.precedents
+            ],
+            outcome=(
+                OutcomeWire(
+                    outcome_id=decision.outcome.outcome_id,
+                    status=decision.outcome.status,
+                    landed_at=decision.outcome.landed_at,
+                    metered=decision.outcome.metered,
+                )
+                if decision.outcome
+                else None
+            ),
+            payload=dict(decision.payload),
+            pocket_id=decision.pocket_id,
+            correlation_id=decision.correlation_id,
+            hash_link=decision.hash_link,
+            last_seq=decision.last_seq,
+        )
+
 
 # ---------------------------------------------------------------------------
 # GET /api/v1/decisions  (Slice 2)
@@ -27,11 +167,11 @@ from pocketpaw_ee.cloud.decisions.domain import (
 
 
 class DecisionsListRequest(BaseModel):
-    """Validated query for `GET /api/v1/decisions` (Slice 2).
+    """Validated query for `GET /api/v1/decisions`.
 
-    ``workspace_id`` is taken from auth context, never the query.
+    `workspace_id` is taken from auth context, never the query.
     Pagination is keyset-style (RFC perf budget — never OFFSET at scale):
-    ``before_ts`` + ``before_id`` carry the cursor from the previous page.
+    `before_ts` + `before_id` carry the cursor from the previous page.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -45,7 +185,7 @@ class DecisionsListRequest(BaseModel):
     outcome_status: OutcomeStatus | None = None
     input_id: str | None = None
     limit: int = Field(default=50, ge=1, le=200)
-    # keyset pagination cursor (sort key: ts DESC, id DESC). Slice 2 wires.
+    # keyset pagination cursor (sort key: ts DESC, id DESC).
     before_ts: datetime | None = None
     before_id: str | None = None
 
@@ -53,12 +193,13 @@ class DecisionsListRequest(BaseModel):
 class DecisionsListResponse(BaseModel):
     """List response. ``total`` is post-scope-filter — never the
     pre-filter count (RFC 07 § Privacy + audit; matches FabricProjection
-    invariant).
+    invariant). Pagination cursor echoes the last (ts, id) so the
+    client can request the next page without recomputing position.
     """
 
     model_config = ConfigDict(frozen=True)
 
-    decisions: list[Decision] = Field(default_factory=list)
+    decisions: list[DecisionResponse] = Field(default_factory=list)
     total: int = 0
     next_before_ts: datetime | None = None
     next_before_id: str | None = None
@@ -78,37 +219,110 @@ class DecisionTraceRequest(BaseModel):
     max_fanout: int = Field(default=20, ge=1, le=100)
 
 
-class TraceNodeWire(BaseModel):
-    """One node in the trace response wire shape (Slice 2)."""
+class EdgeDTO(BaseModel):
+    """One edge in the trace / downstream response. Mirrors
+    `DecisionEdgeRecord` but renames `src_id` → `src` / `target_id` →
+    `target` for wire brevity. The five edge relations cover everything
+    the narrator + UI need to render (RFC 07 § Edge kinds).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    src: str
+    target: str
+    relation: EdgeRelation
+    weight: float = 1.0
+
+
+class TraceNodeResponse(BaseModel):
+    """One node in the trace response.
+
+    ``decision`` is populated when the node IS a Decision (the upstream /
+    downstream walk hydrated it from the store). For external inputs and
+    actor terminals, ``decision`` is None and ``label`` is the only
+    identifier the renderer has.
+    """
 
     model_config = ConfigDict(frozen=True)
 
     id: str
-    kind: str  # decision | fabric_object | dataref
-    decision: Decision | None = None
+    kind: Literal["decision", "fabric_object", "dataref", "actor"]
+    decision: DecisionResponse | None = None
     label: str = ""
 
 
 class DecisionTraceResponse(BaseModel):
     """BFS trace response (Slice 2). ``truncated`` is set when any node
     exceeded the fanout cap; ``truncated_count`` reports how many edges
-    were dropped (RFC 07 amendment for gap G7).
+    were dropped (RFC 07 amendment for gap G7). Shape is `{root, nodes,
+    edges, truncated, truncated_count}` per the RFC spec.
     """
 
     model_config = ConfigDict(frozen=True)
 
-    root: str
-    nodes: dict[str, TraceNodeWire] = Field(default_factory=dict)
-    edges: list[DecisionEdgeRecord] = Field(default_factory=list)
+    root: UUID
+    nodes: dict[str, TraceNodeResponse] = Field(default_factory=dict)
+    edges: list[EdgeDTO] = Field(default_factory=list)
     truncated: bool = False
     truncated_count: int = 0
     depth_reached: int = 0
 
 
+# ---------------------------------------------------------------------------
+# GET /api/v1/decisions/:id/timeline  (Slice 2)
+# ---------------------------------------------------------------------------
+
+
+class JournalEventDTO(BaseModel):
+    """One event from the journal in the timeline wire shape.
+
+    Slim mirror of `EventEntry` — only the fields the narrator + UI
+    timeline view need. `seq` is the journal's monotonic per-org sequence,
+    surfaced so the client can sort even when timestamps tie.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    seq: int
+    id: UUID
+    ts: datetime
+    actor_kind: str
+    actor_id: str
+    action: str
+    scope: list[str] = Field(default_factory=list)
+    correlation_id: UUID | None = None
+    causation_id: UUID | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class TimelineResponse(BaseModel):
+    """Wire shape for `GET /api/v1/decisions/:id/timeline`.
+
+    Bypasses the projection — reads the journal directly for events
+    sharing the Decision's `correlation_id`, returning them in seq
+    order. A Decision with no correlation_id (degenerate write) gets
+    an empty events list and the response's `correlation_id` is None.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    decision_id: UUID
+    correlation_id: UUID | None = None
+    events: list[JournalEventDTO] = Field(default_factory=list)
+
+
 __all__ = [
+    "ApproverWire",
+    "DecisionResponse",
     "DecisionTraceRequest",
     "DecisionTraceResponse",
     "DecisionsListRequest",
     "DecisionsListResponse",
-    "TraceNodeWire",
+    "EdgeDTO",
+    "InputWire",
+    "JournalEventDTO",
+    "OutcomeWire",
+    "PrecedentWire",
+    "TimelineResponse",
+    "TraceNodeResponse",
 ]

--- a/ee/pocketpaw_ee/cloud/decisions/router.py
+++ b/ee/pocketpaw_ee/cloud/decisions/router.py
@@ -1,5 +1,12 @@
 # router.py — FastAPI router for the decision-graph entity (RFC 07).
 # Created: 2026-05-25 (RFC 07 Slice 1) — skeleton ping route only.
+# Updated: 2026-05-25 (RFC 07 Slice 2 — post-filter total) — list endpoint
+#   now sources ``total`` from ``DecisionGraph.count`` (post-scope-filter)
+#   instead of ``len(decisions)`` (page size), and only echoes the
+#   keyset cursor when the returned page is full. Page-size totals
+#   defeat the anti-probe property RFC 07 § Privacy requires; partial-
+#   page cursor echoes give clients a phantom "next page" that always
+#   returns empty.
 # Updated: 2026-05-25 (RFC 07 Slice 2) — wires the five real read routes
 #   that the RFC pins:
 #
@@ -195,6 +202,7 @@ async def list_decisions(
         )
 
     graph: DecisionGraph = get_decision_graph()
+    scopes = _requester_scopes(ctx)
     decisions = await graph.find(
         actor=actor,
         since=since,
@@ -207,19 +215,33 @@ async def list_decisions(
         limit=limit,
         before_ts=before_ts,
         before_id=before_id,
-        requester_scopes=_requester_scopes(ctx),
+        requester_scopes=scopes,
+    )
+    total = await graph.count(
+        actor=actor,
+        since=since,
+        until=until,
+        scope_kind=scope_kind,  # type: ignore[arg-type]
+        pocket_id=pocket_id,
+        policy=policy,
+        outcome_status=outcome_status,  # type: ignore[arg-type]
+        input_id=input_id,
+        requester_scopes=scopes,
     )
 
+    # Only echo the cursor when the page was full. A short page is the
+    # last page — echoing a cursor here would give the client a phantom
+    # next page that always returns empty.
     next_ts: datetime | None = None
     next_id: str | None = None
-    if decisions:
+    if decisions and len(decisions) == limit:
         last = decisions[-1]
         next_ts = last.ts
         next_id = str(last.id)
 
     return DecisionsListResponse(
         decisions=[DecisionResponse.from_domain(d) for d in decisions],
-        total=len(decisions),
+        total=total,
         next_before_ts=next_ts,
         next_before_id=next_id,
     )

--- a/ee/pocketpaw_ee/cloud/decisions/router.py
+++ b/ee/pocketpaw_ee/cloud/decisions/router.py
@@ -1,26 +1,54 @@
-# router.py — FastAPI router skeleton for the decision-graph entity.
-# Created: 2026-05-25 (RFC 07 Slice 1) — SKELETON only. Slice 1 ships the
-#   in-process Python API; Slice 2 wires the real REST endpoints:
+# router.py — FastAPI router for the decision-graph entity (RFC 07).
+# Created: 2026-05-25 (RFC 07 Slice 1) — skeleton ping route only.
+# Updated: 2026-05-25 (RFC 07 Slice 2) — wires the five real read routes
+#   that the RFC pins:
 #
-#     GET  /api/v1/decisions/:id
-#     GET  /api/v1/decisions
-#     GET  /api/v1/decisions/:id/trace
-#     GET  /api/v1/decisions/:id/downstream
-#     GET  /api/v1/decisions/:id/timeline
-#     POST /api/v1/decisions/explain
+#     GET  /api/v1/decisions/:id            → DecisionResponse
+#     GET  /api/v1/decisions                 → DecisionsListResponse
+#     GET  /api/v1/decisions/:id/trace      → DecisionTraceResponse
+#     GET  /api/v1/decisions/:id/downstream → DecisionTraceResponse
+#     GET  /api/v1/decisions/:id/timeline   → TimelineResponse
 #
-#   Slice 1 ships ONE placeholder route — `GET /api/v1/decisions/_ping`
-#   — that returns the projection cursor + row count. It exists so
-#   operators can smoke-test that the projection bootstrap fired without
-#   waiting on Slice 2. Thin: never `raise HTTPException`; CloudError →
-#   JSON is the contract.
+#   The `_ping` smoke route stays — operators rely on it as a cheap
+#   liveness check on the projection cursor + row count.
+#
+# Router contract (mirrors `outcomes/router.py` and `pockets/router.py`):
+#   - Thin one-line bodies that delegate to `DecisionGraph` or read the
+#     journal directly (timeline only).
+#   - `Depends(request_context)` for `RequestContext` — `workspace_id`
+#     becomes the scope tag the service filters on.
+#   - Never `raise HTTPException`; `_core.http` maps `CloudError` to
+#     JSON. The Decision graph's scope filter returns None for both
+#     "missing" and "scope-hidden" — the router maps None to 404 with
+#     the same code so a caller cannot distinguish the two states (RFC
+#     07 § Privacy + audit).
 from __future__ import annotations
 
+import base64
+from datetime import datetime
 from typing import Any
+from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query, Request
+from soul_protocol.engine.journal import Journal
 
-from pocketpaw_ee.cloud.decisions.service import get_decision_graph
+from pocketpaw.journal_dep import get_journal
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import CloudError, NotFound
+from pocketpaw_ee.cloud.decisions.dto import (
+    DecisionResponse,
+    DecisionsListResponse,
+    DecisionTraceResponse,
+    EdgeDTO,
+    JournalEventDTO,
+    TimelineResponse,
+    TraceNodeResponse,
+)
+from pocketpaw_ee.cloud.decisions.service import (
+    DecisionGraph,
+    TraceResult,
+    get_decision_graph,
+)
 from pocketpaw_ee.cloud.license import require_license
 
 router = APIRouter(
@@ -30,13 +58,95 @@ router = APIRouter(
 )
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _requester_scopes(ctx: RequestContext) -> list[str] | None:
+    """Build the scope-tag list from the request context.
+
+    The decision graph stores `scope` tags on every Decision (e.g.
+    `workspace:abc`, `pocket:p1`, `org:nerve`). A caller with
+    `active_workspace == "abc"` is allowed to see decisions tagged
+    `workspace:abc` — that's the only tag the auth context can
+    contribute today.
+
+    A caller with no active workspace gets an empty list (treated as
+    "no scope" by the service — sees nothing) rather than `None`
+    (admin / unscoped). This is the conservative default; future
+    work will widen scope inference once cross-pocket / cross-team
+    membership lands.
+    """
+    if ctx.workspace_id:
+        return [f"workspace:{ctx.workspace_id}"]
+    return []
+
+
+def _encode_cursor(ts: datetime, decision_id: UUID) -> str:
+    """Encode `(ts, id)` as an opaque base64 cursor for the next-page link.
+
+    The cursor format is `<iso_ts>|<uuid>` base64-encoded so the wire
+    string is URL-safe and the client doesn't need to know the shape.
+    Decoding lives in `_decode_cursor`.
+    """
+    raw = f"{ts.isoformat()}|{decision_id}".encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _maybe_uuid(value: str) -> UUID:
+    """Parse a UUID query / path param or raise a CloudError (400).
+
+    Routers must never raise HTTPException; this helper keeps the path
+    handlers thin while giving a clean error envelope on bad input.
+    """
+    try:
+        return UUID(value)
+    except (ValueError, TypeError) as exc:
+        raise CloudError(
+            400, "decisions.invalid_id", f"'{value}' is not a valid UUID"
+        ) from exc
+
+
+def _trace_to_response(result: TraceResult) -> DecisionTraceResponse:
+    """Map the service-layer TraceResult into the wire trace DTO."""
+    return DecisionTraceResponse(
+        root=result.root,
+        nodes={
+            node_id: TraceNodeResponse(
+                id=node.id,
+                kind=node.kind,
+                decision=DecisionResponse.from_domain(node.decision) if node.decision else None,
+                label=node.label,
+            )
+            for node_id, node in result.nodes.items()
+        },
+        edges=[
+            EdgeDTO(
+                src=str(e.src_id),
+                target=e.target_id,
+                relation=e.relation,
+                weight=e.weight,
+            )
+            for e in result.edges
+        ],
+        truncated=result.truncated,
+        truncated_count=result.truncated_count,
+        depth_reached=result.depth_reached,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Smoke / liveness — kept from Slice 1
+# ---------------------------------------------------------------------------
+
+
 @router.get("/_ping")
 async def decisions_ping() -> dict[str, Any]:
-    """Smoke endpoint — returns projection cursor + row count.
+    """Smoke endpoint — projection cursor + total row count.
 
-    Slice 1-only. Slice 2 replaces this with the real REST surface.
-    Intentionally unauthenticated beyond the license gate so an
-    operator can curl it.
+    Kept from Slice 1 for operator liveness checks. Unauthenticated
+    beyond the license gate so an operator can curl it.
     """
     graph = get_decision_graph()
     return {
@@ -44,3 +154,231 @@ async def decisions_ping() -> dict[str, Any]:
         "cursor": graph.projection.cursor,
         "decisions": graph.store.count(),
     }
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/decisions — list (filtered, keyset-paginated)
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=DecisionsListResponse)
+async def list_decisions(
+    request: Request,
+    actor: str | None = Query(default=None, description="Decided-by actor id"),
+    since: datetime | None = Query(default=None, description="ISO-8601 lower bound on ts"),
+    until: datetime | None = Query(default=None, description="ISO-8601 upper bound on ts"),
+    scope_kind: str | None = Query(default=None, description="workspace|org|pocket|team"),
+    pocket_id: str | None = Query(default=None),
+    policy: str | None = Query(default=None, description="Instinct policy name"),
+    outcome_status: str | None = Query(
+        default=None, description="pending|landed|rejected|abandoned"
+    ),
+    input_id: str | None = Query(default=None, description="Filter to decisions citing this input"),
+    limit: int = Query(default=50, ge=1, le=200),
+    before_ts: datetime | None = Query(default=None, description="Keyset cursor (ts)"),
+    before_id: str | None = Query(default=None, description="Keyset cursor (id)"),
+    ctx: RequestContext = Depends(request_context),
+) -> DecisionsListResponse:
+    """List recent decisions for the caller's scope.
+
+    Workspace tenancy is derived from the auth context — the route
+    rejects a `workspace_id` query param so a caller cannot read another
+    workspace's decisions. Pagination is keyset on `(ts DESC, id DESC)`
+    — `next_before_ts` / `next_before_id` echo the last row's sort
+    key so the client can request the next page without OFFSET.
+    """
+    if "workspace_id" in request.query_params:
+        raise CloudError(
+            400,
+            "decisions.workspace_id_forbidden",
+            "workspace_id is taken from auth context, not query",
+        )
+
+    graph: DecisionGraph = get_decision_graph()
+    decisions = await graph.find(
+        actor=actor,
+        since=since,
+        until=until,
+        scope_kind=scope_kind,  # type: ignore[arg-type]
+        pocket_id=pocket_id,
+        policy=policy,
+        outcome_status=outcome_status,  # type: ignore[arg-type]
+        input_id=input_id,
+        limit=limit,
+        before_ts=before_ts,
+        before_id=before_id,
+        requester_scopes=_requester_scopes(ctx),
+    )
+
+    next_ts: datetime | None = None
+    next_id: str | None = None
+    if decisions:
+        last = decisions[-1]
+        next_ts = last.ts
+        next_id = str(last.id)
+
+    return DecisionsListResponse(
+        decisions=[DecisionResponse.from_domain(d) for d in decisions],
+        total=len(decisions),
+        next_before_ts=next_ts,
+        next_before_id=next_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/decisions/:id — single lookup
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{decision_id}", response_model=DecisionResponse)
+async def get_decision(
+    decision_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> DecisionResponse:
+    """Return one Decision.
+
+    Returns 404 with `decisions.not_found` for both genuinely missing
+    Decisions and Decisions outside the caller's scope — the two states
+    are deliberately indistinguishable so a caller cannot probe for
+    hidden rows (RFC 07 § Privacy + audit).
+    """
+    decision_uuid = _maybe_uuid(decision_id)
+    graph: DecisionGraph = get_decision_graph()
+    decision = await graph.get(decision_uuid, requester_scopes=_requester_scopes(ctx))
+    if decision is None:
+        raise NotFound("decisions", decision_id)
+    return DecisionResponse.from_domain(decision)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/decisions/:id/trace — upstream walk (precedents + inputs)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{decision_id}/trace", response_model=DecisionTraceResponse)
+async def trace_decision(
+    decision_id: str,
+    depth: int = Query(default=3, ge=1, le=10),
+    max_fanout: int = Query(default=20, ge=1, le=100),
+    ctx: RequestContext = Depends(request_context),
+) -> DecisionTraceResponse:
+    """Depth-bounded BFS upstream from this Decision.
+
+    Walks `precedent` and `input` edges; `approval` and `outcome` edges
+    are surfaced as terminal labels (not walked further) so the narrator
+    can render them without exploding the trace. `truncated` /
+    `truncated_count` are set when a node's outgoing edges exceeded
+    `max_fanout`.
+    """
+    decision_uuid = _maybe_uuid(decision_id)
+    graph: DecisionGraph = get_decision_graph()
+    result = await graph.trace(
+        decision_uuid,
+        depth=depth,
+        max_fanout=max_fanout,
+        requester_scopes=_requester_scopes(ctx),
+    )
+    if not result.nodes:
+        # Root either missing or scope-hidden — collapse to 404 so the
+        # caller cannot probe.
+        raise NotFound("decisions", decision_id)
+    return _trace_to_response(result)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/decisions/:id/downstream — inverse precedent walk
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{decision_id}/downstream", response_model=DecisionTraceResponse)
+async def downstream_decision(
+    decision_id: str,
+    depth: int = Query(default=3, ge=1, le=10),
+    ctx: RequestContext = Depends(request_context),
+) -> DecisionTraceResponse:
+    """Decisions that later cited this one as a precedent.
+
+    Reads the inverse of the precedent index — the result's edges are
+    stamped with `relation='downstream'` so the renderer reads the
+    arrow direction correctly without re-deriving inverse semantics.
+    """
+    decision_uuid = _maybe_uuid(decision_id)
+    graph: DecisionGraph = get_decision_graph()
+    result = await graph.downstream(
+        decision_uuid,
+        depth=depth,
+        requester_scopes=_requester_scopes(ctx),
+    )
+    if not result.nodes:
+        raise NotFound("decisions", decision_id)
+    return _trace_to_response(result)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/decisions/:id/timeline — flattened journal events
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{decision_id}/timeline", response_model=TimelineResponse)
+async def decision_timeline(
+    decision_id: str,
+    limit: int = Query(default=200, ge=1, le=1000),
+    ctx: RequestContext = Depends(request_context),
+    journal: Journal = Depends(get_journal),
+) -> TimelineResponse:
+    """Return the journal events that produced this Decision, in seq order.
+
+    Bypasses the projection — reads the journal directly for events
+    sharing the Decision's `correlation_id`. The projection folds the
+    same events into one row; the timeline view is what the narrator
+    and the audit UI use to render the per-event history with the
+    real ts / actor / payload.
+
+    Scope filter: the Decision is looked up through the graph first
+    so a caller outside scope sees a 404 just like the other routes
+    (no "decision is hidden but its events are visible" probe).
+    """
+    decision_uuid = _maybe_uuid(decision_id)
+    graph: DecisionGraph = get_decision_graph()
+    decision = await graph.get(decision_uuid, requester_scopes=_requester_scopes(ctx))
+    if decision is None:
+        raise NotFound("decisions", decision_id)
+
+    events: list[JournalEventDTO] = []
+
+    if decision.correlation_id is not None:
+        # Reach into the backend so we can capture the seq alongside the
+        # entry — the public ``Journal.query`` API flattens seq away.
+        # Same pattern the pocket journal stream router uses.
+        backend = journal._backend  # type: ignore[attr-defined]
+        rows = backend._conn.execute(  # type: ignore[attr-defined]
+            "SELECT * FROM events WHERE correlation_id = ? ORDER BY seq ASC LIMIT ?",
+            (str(decision.correlation_id), limit),
+        )
+        for row in rows:
+            entry, seq = backend._row_to_entry(row)  # type: ignore[attr-defined]
+            payload = entry.payload if isinstance(entry.payload, dict) else {}
+            events.append(
+                JournalEventDTO(
+                    seq=seq,
+                    id=entry.id,
+                    ts=entry.ts,
+                    actor_kind=entry.actor.kind,
+                    actor_id=entry.actor.id,
+                    action=entry.action,
+                    scope=list(entry.scope),
+                    correlation_id=entry.correlation_id,
+                    causation_id=entry.causation_id,
+                    payload=dict(payload),
+                )
+            )
+
+    return TimelineResponse(
+        decision_id=decision_uuid,
+        correlation_id=decision.correlation_id,
+        events=events,
+    )
+
+
+# Export the cursor encoder for the test suite's keyset assertions.
+__all__ = ["_encode_cursor", "router"]

--- a/ee/pocketpaw_ee/cloud/decisions/service.py
+++ b/ee/pocketpaw_ee/cloud/decisions/service.py
@@ -14,6 +14,15 @@
 #
 #   `explain` (NL Q&A with narrator) lives in Slice 3 and is intentionally
 #   NOT on this surface yet.
+# Updated: 2026-05-25 (RFC 07 Slice 2 — post-filter total) — added
+#   `count(filters, requester_scopes=...) → int` so the list router can
+#   return the true post-scope-filter total instead of the page size.
+#   This protects the anti-probe property from RFC 07 § Privacy + audit:
+#   a caller varying `limit` cannot observe a changing `total`, so
+#   pre- vs post-filter counts can never be compared to infer hidden
+#   rows. The new method shares the iteration path with `find()`; the
+#   only divergence is that `count()` does not slice by `limit` or
+#   `before_*` cursors (those reshape the page, not the filter set).
 #
 # Scope-filter-post-count invariant
 # ---------------------------------
@@ -202,6 +211,43 @@ class DecisionGraph:
             if len(results) >= limit:
                 break
         return results
+
+    # --- post-scope-filter total ------------------------------------------
+
+    async def count(
+        self,
+        *,
+        actor: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        scope_kind: ScopeKind | None = None,
+        pocket_id: str | None = None,
+        policy: str | None = None,
+        outcome_status: OutcomeStatus | None = None,
+        input_id: str | None = None,
+        requester_scopes: list[str] | None = None,
+    ) -> int:
+        """Count decisions matching the same filter set as ``find()``,
+        post-scope-filter. ``limit`` / ``before_ts`` / ``before_id`` are
+        NOT accepted — those reshape a page, not the filter set, and
+        including them would make the total drift across pages and let
+        a caller probe for hidden rows by comparing counts.
+        """
+        n = 0
+        for d in self._store.iter_decisions(
+            actor=actor,
+            pocket_id=pocket_id,
+            policy=policy,
+            outcome_status=outcome_status,
+            scope_kind=scope_kind,
+            since=since,
+            until=until,
+            input_id=input_id,
+        ):
+            if not _visible(d, requester_scopes):
+                continue
+            n += 1
+        return n
 
     # --- trace upstream ----------------------------------------------------
 

--- a/ee/pocketpaw_ee/cloud/outcomes/domain.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/domain.py
@@ -3,6 +3,16 @@
 #   workspace-scoped JSONL ledger. Tenancy (`workspace_id`) is a required
 #   construction field per ee/cloud Rule 3 — a record cannot exist without
 #   a workspace to scope it to.
+# Updated: 2026-05-25 (RFC 07 Slice 2) — added the `decision_id` back-
+#   reference. The decision-graph projection folds journal events into
+#   queryable Decisions; when an Outcome lands, the Decision needs to
+#   know which Outcome resolved it. A producer (instinct bridge, pocket
+#   write executor) that has a Decision in hand can pass `decision_id`
+#   on `emit_pocket_outcome`; the listener then synthesises a
+#   `decision.outcome_attached` journal event so the projection's
+#   `_apply_outcome_attached` handler mutates the Decision in place.
+#   Optional — pre-Slice-2 writers pass None and the back-reference is
+#   simply absent from the ledger row.
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -16,6 +26,9 @@ class OutcomeRecord:
     workspace JSONL ledger. ``outcome_value`` / ``outcome_unit`` are the
     Layer-4 billing slots — always ``None`` in this build, kept on the
     record so the ledger format is forward-stable when pricing lands.
+    ``decision_id`` is the optional back-reference to the Decision in
+    the RFC 07 decision graph that this outcome resolved — None for
+    outcomes emitted by writers that don't know their Decision.
     """
 
     outcome: str
@@ -28,6 +41,7 @@ class OutcomeRecord:
     occurred_at: str  # ISO-8601 UTC
     outcome_value: float | None = None
     outcome_unit: str | None = None
+    decision_id: str | None = None  # RFC 07 Slice 2 back-reference
 
 
 __all__ = ["OutcomeRecord"]

--- a/ee/pocketpaw_ee/cloud/outcomes/dto.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/dto.py
@@ -3,6 +3,13 @@
 #   validated query for `GET /api/v1/outcomes`; `OutcomeCountResponse` is
 #   the grouped-count wire shape. Request and response are distinct models
 #   per ee/cloud Rule 4.
+# Updated: 2026-05-25 (RFC 07 Slice 2) — added `OutcomeResponse`, the
+#   per-row wire shape mirroring `OutcomeRecord`. Carries the new
+#   `decision_id` back-reference so the decision-graph trace can be
+#   reached from the outcome and vice versa. No existing endpoint
+#   returns a list of rows yet; the DTO is shipped now so future
+#   `GET /api/v1/outcomes?detail=rows` lookups have a stable wire
+#   contract and the back-reference is visible on the lint surface.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -35,4 +42,27 @@ class OutcomeCountResponse(BaseModel):
     by_pocket: dict[str, int] = Field(default_factory=dict)
 
 
-__all__ = ["CountOutcomesRequest", "OutcomeCountResponse"]
+class OutcomeResponse(BaseModel):
+    """Wire shape for one recorded outcome (RFC 07 Slice 2).
+
+    Mirrors `outcomes.domain.OutcomeRecord`. The `decision_id` field is
+    the optional back-reference to the Decision in the RFC 07 decision
+    graph that this outcome resolved — set when the producer
+    (instinct bridge, pocket write executor) had a Decision in hand;
+    `None` otherwise.
+    """
+
+    outcome: str
+    pocket_id: str
+    workspace_id: str
+    action: str
+    actor: str
+    via_instinct: bool
+    instinct_action_id: str | None = None
+    occurred_at: str
+    outcome_value: float | None = None
+    outcome_unit: str | None = None
+    decision_id: str | None = None
+
+
+__all__ = ["CountOutcomesRequest", "OutcomeCountResponse", "OutcomeResponse"]

--- a/ee/pocketpaw_ee/cloud/outcomes/service.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/service.py
@@ -19,6 +19,17 @@
 #   not match the caller's workspace. The ledger file is already keyed by
 #   workspace, so this is defense-in-depth: a corrupt or hand-edited line
 #   carrying a foreign tenant id is no longer counted into the totals.
+# Updated: 2026-05-25 (RFC 07 Slice 2 — outcomes back-reference) —
+#   `emit_pocket_outcome` now accepts an optional `decision_id` and the
+#   bus listener (`record_outcome`) threads it onto the ledger row AND
+#   feeds a synthetic `decision.outcome_attached` event into the
+#   in-process DecisionProjection so the Decision row in the decision
+#   graph mutates its outcome field in place. The journal subscription
+#   that would do the same end-to-end is deferred to a follow-up; in
+#   this PR the back-reference flows synchronously from the outcome
+#   listener so the test suite can pin the contract.
+#   `"decision.outcome_attached"` is used as a STRING LITERAL (the
+#   namespace registration in soul-protocol is parallel work — Slice 0).
 from __future__ import annotations
 
 import json
@@ -26,6 +37,7 @@ import logging
 from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
+from uuid import UUID, uuid4
 
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import PocketOutcomeEvent
@@ -65,6 +77,7 @@ async def emit_pocket_outcome(
     actor: str,
     via_instinct: bool,
     instinct_action_id: str | None = None,
+    decision_id: str | None = None,
 ) -> None:
     """Emit a ``pocket.outcome`` event for a successful write action.
 
@@ -79,6 +92,12 @@ async def emit_pocket_outcome(
 
     ``outcome_value`` / ``outcome_unit`` are emitted as ``None`` — Layer 4
     (billing) is reserved and this build never assigns a monetary value.
+
+    ``decision_id`` is the RFC 07 Slice 2 back-reference — pass the id
+    of the Decision in the decision graph that this outcome resolved,
+    when the caller has one in hand. ``None`` is fine for writers that
+    don't yet know their Decision (legacy producers); the listener
+    only fires the back-reference path when the id is present.
     """
     if not outcome:
         # No declared outcome — nothing to meter. The write still
@@ -98,6 +117,8 @@ async def emit_pocket_outcome(
                 # Layer 4 reserved — billing is not wired in this build.
                 "outcome_value": None,
                 "outcome_unit": None,
+                # RFC 07 Slice 2 — back-reference to the decision graph.
+                "decision_id": decision_id,
             }
         )
     )
@@ -124,6 +145,9 @@ async def record_outcome(event) -> None:  # type: ignore[no-untyped-def]
         logger.warning("pocket.outcome event dropped — missing workspace_id or outcome")
         return
 
+    decision_id_raw = data.get("decision_id")
+    decision_id = str(decision_id_raw) if decision_id_raw else None
+
     record = OutcomeRecord(
         outcome=str(outcome),
         pocket_id=str(data.get("pocket_id") or ""),
@@ -136,6 +160,8 @@ async def record_outcome(event) -> None:  # type: ignore[no-untyped-def]
         # Layer 4 reserved — never set here.
         outcome_value=None,
         outcome_unit=None,
+        # RFC 07 Slice 2 — back-reference into the decision graph.
+        decision_id=decision_id,
     )
     path = _ledger_path(record.workspace_id)
     try:
@@ -144,6 +170,97 @@ async def record_outcome(event) -> None:  # type: ignore[no-untyped-def]
             fh.write(json.dumps(asdict(record), separators=(",", ":")) + "\n")
     except OSError:
         logger.warning("failed to append pocket.outcome to ledger %s", path, exc_info=True)
+
+    # RFC 07 Slice 2 — back-reference flow. When the producer passed a
+    # decision_id, fold a synthetic `decision.outcome_attached` event
+    # into the in-process DecisionProjection so the Decision row mutates
+    # its outcome field. The journal subscription that would do the same
+    # end-to-end is deferred to a follow-up; for now the back-reference
+    # rides on the outcome listener itself.
+    if decision_id:
+        await _attach_outcome_to_decision(record=record)
+
+
+async def _attach_outcome_to_decision(*, record: OutcomeRecord) -> None:
+    """Fold a synthetic `decision.outcome_attached` event into the
+    decision projection so the Decision row's outcome field mutates
+    in place.
+
+    The projection's `_apply_outcome_attached` handler (see
+    `decisions/projection.py`) looks up the Decision by the
+    `decision_id` carried in the event payload, then writes the
+    outcome via `store.update_outcome`. The hash chain stays valid —
+    outcome is intentionally excluded from the hash material.
+
+    Imports are local so the outcomes service stays importable in
+    environments where the decisions module isn't wired (e.g. unit
+    tests that mock the cloud bootstrap). Failures here are logged
+    and swallowed — a bad back-reference can never break the write
+    that already succeeded.
+    """
+    if not record.decision_id or not record.outcome:
+        return
+
+    try:
+        decision_uuid = UUID(record.decision_id)
+    except (TypeError, ValueError):
+        logger.warning(
+            "outcomes back-reference: decision_id %r is not a UUID — dropped",
+            record.decision_id,
+        )
+        return
+
+    try:
+        from soul_protocol.spec.journal import Actor, EventEntry
+
+        from pocketpaw_ee.cloud.decisions.service import get_decision_graph
+    except Exception:  # noqa: BLE001
+        logger.debug("decisions module unavailable — skipping outcome back-reference")
+        return
+
+    occurred_at: datetime
+    try:
+        occurred_at = datetime.fromisoformat(record.occurred_at.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        occurred_at = datetime.now(UTC)
+
+    # The projection treats `decision.outcome_attached` as the late-
+    # attach signal. Only the payload's `decision_id` is load-bearing;
+    # the rest of the payload feeds the OutcomeRef the projection
+    # writes (status, landed_at, metered).
+    event = EventEntry(
+        id=uuid4(),
+        ts=occurred_at,
+        actor=Actor(
+            kind="system",
+            id="system:outcomes",
+            scope_context=[f"workspace:{record.workspace_id}"],
+        ),
+        action="decision.outcome_attached",  # string literal — namespace in Slice 0
+        scope=[f"workspace:{record.workspace_id}"],
+        payload={
+            "decision_id": record.decision_id,
+            # Stable id from the decision_id so re-emits are idempotent.
+            # `_apply_outcome_attached` uses this if present, else mints
+            # its own uuid — either way the Decision row converges to
+            # the same outcome state.
+            "outcome_id": str(decision_uuid),
+            "status": "landed",
+            "landed_at": record.occurred_at,
+            "metered": record.outcome_value is not None,
+        },
+    )
+
+    try:
+        graph = get_decision_graph()
+        graph.projection.apply(event)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "outcomes back-reference: failed to fold decision.outcome_attached "
+            "for decision %s — outcome ledger row still written",
+            record.decision_id,
+            exc_info=True,
+        )
 
 
 async def count_outcomes(

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -237,6 +237,27 @@ class CloudPocketMcpProvider:
         return list(POCKET_TOOL_IDS)
 
 
+class CloudDecisionsMcpProvider:
+    """`pocketpaw.mcp_servers` — the decision-graph in-process server.
+
+    Wires the three read tools (decisions_get / decisions_find /
+    decisions_trace) shipped in RFC 07 Slice 2. The narrator
+    `decisions_explain` tool is intentionally Slice 3 — not registered
+    here yet so the SDK surface tracks what the substrate actually
+    supports.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        from pocketpaw_ee.agent.mcp_servers.decisions import build_decisions_context_server
+
+        return build_decisions_context_server()
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.decisions import DECISIONS_TOOL_IDS
+
+        return list(DECISIONS_TOOL_IDS)
+
+
 class CloudPocketSpecialistMcpProvider:
     """`pocketpaw.mcp_servers` — the pocket specialist (create/edit) server."""
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -132,6 +132,7 @@ cloud = "pocketpaw_ee.extensions:CloudPocketWriter"
 tasks = "pocketpaw_ee.extensions:CloudTasksMcpProvider"
 planner = "pocketpaw_ee.extensions:CloudPlannerMcpProvider"
 pocket = "pocketpaw_ee.extensions:CloudPocketMcpProvider"
+decisions = "pocketpaw_ee.extensions:CloudDecisionsMcpProvider"
 pocket_specialist = "pocketpaw_ee.extensions:CloudPocketSpecialistMcpProvider"
 composio = "pocketpaw_ee.extensions:CloudComposioMcpProvider"
 

--- a/tests/ee/test_decisions_mcp.py
+++ b/tests/ee/test_decisions_mcp.py
@@ -1,0 +1,323 @@
+# tests/ee/test_decisions_mcp.py — RFC 07 Slice 2 MCP wrapper coverage.
+# Created: 2026-05-25 — pins the three in-process MCP tool handlers
+#   shipped in `pocketpaw_ee.agent.mcp_servers.decisions`:
+#
+#     decisions_get(decision_id)
+#     decisions_find(...)
+#     decisions_trace(decision_id, depth=3)
+#
+#   The handlers resolve identity via per-stream ContextVars from
+#   `ee.cloud.chat.agent_service`. Tests set those ContextVars directly
+#   so the handlers receive a workspace + agent id without spinning up
+#   a real SSE chat stream.
+#
+#   The wrappers wire onto the same `DecisionGraph` Python API the REST
+#   router uses, so we assert that the JSON envelope each handler
+#   produces carries the wire shape `DecisionResponse` defines — REST
+#   and MCP must never drift.
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from soul_protocol.spec.journal import Actor, EventEntry
+
+from pocketpaw_ee.agent.mcp_servers.decisions import (
+    _decisions_find_handler,
+    _decisions_get_handler,
+    _decisions_trace_handler,
+)
+from pocketpaw_ee.cloud.chat.agent_service import (
+    attach_agent_identity,
+    detach_agent_identity,
+)
+from pocketpaw_ee.cloud.decisions.projection import DecisionProjection
+from pocketpaw_ee.cloud.decisions.service import (
+    DecisionGraph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import DecisionStore, set_db_path
+
+# ---------------------------------------------------------------------------
+# Identity context — set the per-stream ContextVars the MCP handlers read
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_projection():
+    reset_projection_for_tests()
+    yield
+    reset_projection_for_tests()
+
+
+@pytest.fixture
+def workspace_id() -> str:
+    return "ws_a_test"
+
+
+@pytest.fixture
+def agent_id() -> str:
+    return "did:soul:test_agent"
+
+
+@pytest.fixture(autouse=True)
+def _identity_context(workspace_id: str, agent_id: str):
+    """Install workspace + agent ContextVars via the canonical helper
+    so the MCP identity resolver returns real values instead of
+    (None, None)."""
+    tokens = attach_agent_identity(workspace_id=workspace_id, user_id=agent_id)
+    yield
+    detach_agent_identity(tokens)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> DecisionStore:
+    set_db_path(tmp_path / "decisions.db")
+    s = DecisionStore()
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def projection(store: DecisionStore) -> DecisionProjection:
+    return DecisionProjection(store=store)
+
+
+@pytest.fixture
+def graph(store: DecisionStore, projection: DecisionProjection) -> DecisionGraph:
+    """Install a DecisionGraph singleton so the MCP wrappers resolve to it."""
+    from pocketpaw_ee.cloud.decisions import service as decisions_service
+
+    g = DecisionGraph(store=store, projection=projection)
+    decisions_service._GRAPH = g
+    return g
+
+
+@pytest.fixture
+def base_ts() -> datetime:
+    return datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — same chain-seeding helper as the router test, scoped here so
+# the two files stay independent
+# ---------------------------------------------------------------------------
+
+
+def _event(
+    *,
+    ts: datetime,
+    actor: Actor,
+    action: str,
+    correlation_id: UUID | None,
+    payload: dict,
+    scope: list[str] | None = None,
+) -> EventEntry:
+    return EventEntry(
+        id=uuid4(),
+        ts=ts,
+        actor=actor,
+        action=action,
+        scope=scope or ["org:nerve", "workspace:ws_a_test"],
+        correlation_id=correlation_id,
+        payload=payload,
+    )
+
+
+def _seed_chain(
+    projection: DecisionProjection,
+    *,
+    base_ts: datetime,
+    pocket_id: str = "p_main",
+    workspace: str = "ws_a_test",
+    actor_id: str = "did:soul:agent1",
+    precedents: list[dict] | None = None,
+) -> UUID:
+    corr = uuid4()
+    scope = ["org:nerve", f"workspace:{workspace}", f"pocket:{pocket_id}"]
+    actor = Actor(kind="agent", id=actor_id, scope_context=scope)
+    payload: dict = {
+        "intent": f"chain-{corr.hex[:8]}",
+        "action": "send_to_tenant",
+        "pocket_id": pocket_id,
+    }
+    if precedents is not None:
+        payload["precedents"] = precedents
+    events = [
+        _event(
+            ts=base_ts,
+            actor=actor,
+            action="agent.proposed",
+            correlation_id=corr,
+            payload=payload,
+            scope=scope,
+        ),
+        _event(
+            ts=base_ts + timedelta(seconds=1),
+            actor=actor,
+            action="decision.graduated",
+            correlation_id=corr,
+            payload={"passed": True},
+            scope=scope,
+        ),
+    ]
+    last_decision_id: UUID | None = None
+    for e in events:
+        result = projection.apply(e)
+        if result is not None:
+            last_decision_id = result.id
+    assert last_decision_id is not None
+    return last_decision_id
+
+
+def _read_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Decode the MCP success envelope's JSON-encoded text content."""
+    assert "is_error" not in envelope or envelope.get("is_error") is False
+    text = envelope["content"][0]["text"]
+    return json.loads(text)
+
+
+# ---------------------------------------------------------------------------
+# decisions_get
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_decisions_get_returns_decision(graph, projection, base_ts) -> None:
+    decision_id = _seed_chain(projection, base_ts=base_ts)
+
+    envelope = await _decisions_get_handler({"decision_id": str(decision_id)})
+    body = _read_envelope(envelope)
+    assert body["found"] is True
+    assert body["decision"]["id"] == str(decision_id)
+    # Wire shape — same fields as the REST DecisionResponse.
+    assert body["decision"]["actor_kind"] == "agent"
+    assert body["decision"]["actor_id"] == "did:soul:agent1"
+
+
+@pytest.mark.asyncio
+async def test_decisions_get_returns_not_found_envelope(graph) -> None:
+    envelope = await _decisions_get_handler({"decision_id": str(uuid4())})
+    body = _read_envelope(envelope)
+    assert body["found"] is False
+    assert body["decision"] is None
+
+
+@pytest.mark.asyncio
+async def test_decisions_get_returns_error_on_missing_id(graph) -> None:
+    envelope = await _decisions_get_handler({})
+    assert envelope.get("is_error") is True
+    assert "decision_id is required" in envelope["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_decisions_get_returns_error_on_bad_uuid(graph) -> None:
+    envelope = await _decisions_get_handler({"decision_id": "not-a-uuid"})
+    assert envelope.get("is_error") is True
+    assert "not a valid UUID" in envelope["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_decisions_get_respects_scope(graph, projection, base_ts) -> None:
+    """A decision in another workspace's scope returns the not-found envelope."""
+    decision_id = _seed_chain(projection, base_ts=base_ts, workspace="ws_other")
+    envelope = await _decisions_get_handler({"decision_id": str(decision_id)})
+    body = _read_envelope(envelope)
+    assert body["found"] is False
+
+
+# ---------------------------------------------------------------------------
+# decisions_find
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_decisions_find_returns_list(graph, projection, base_ts) -> None:
+    _seed_chain(projection, base_ts=base_ts, actor_id="did:soul:a")
+    _seed_chain(
+        projection,
+        base_ts=base_ts + timedelta(seconds=10),
+        actor_id="did:soul:b",
+    )
+
+    envelope = await _decisions_find_handler({})
+    body = _read_envelope(envelope)
+    assert body["count"] == 2
+    assert len(body["decisions"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_decisions_find_filters_by_actor(graph, projection, base_ts) -> None:
+    _seed_chain(projection, base_ts=base_ts, actor_id="did:soul:alpha")
+    _seed_chain(
+        projection,
+        base_ts=base_ts + timedelta(seconds=10),
+        actor_id="did:soul:beta",
+    )
+
+    envelope = await _decisions_find_handler({"actor": "did:soul:alpha"})
+    body = _read_envelope(envelope)
+    assert body["count"] == 1
+    assert body["decisions"][0]["actor_id"] == "did:soul:alpha"
+
+
+@pytest.mark.asyncio
+async def test_decisions_find_respects_scope(graph, projection, base_ts) -> None:
+    """Find returns no results when every decision is out of scope."""
+    _seed_chain(projection, base_ts=base_ts, workspace="ws_other")
+    envelope = await _decisions_find_handler({})
+    body = _read_envelope(envelope)
+    assert body["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# decisions_trace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_decisions_trace_walks_precedents(graph, projection, base_ts) -> None:
+    prec_id = _seed_chain(projection, base_ts=base_ts - timedelta(days=1))
+    new_id = _seed_chain(
+        projection,
+        base_ts=base_ts,
+        precedents=[{"decision_id": str(prec_id), "weight": 0.9}],
+    )
+
+    envelope = await _decisions_trace_handler(
+        {"decision_id": str(new_id), "depth": 2}
+    )
+    body = _read_envelope(envelope)
+    assert body["root"] == str(new_id)
+    assert str(prec_id) in body["nodes"]
+
+
+@pytest.mark.asyncio
+async def test_decisions_trace_returns_error_on_missing_id(graph) -> None:
+    envelope = await _decisions_trace_handler({})
+    assert envelope.get("is_error") is True
+
+
+@pytest.mark.asyncio
+async def test_decisions_trace_returns_error_on_bad_uuid(graph) -> None:
+    envelope = await _decisions_trace_handler({"decision_id": "not-a-uuid"})
+    assert envelope.get("is_error") is True
+
+
+# ---------------------------------------------------------------------------
+# Identity / surface contract
+# ---------------------------------------------------------------------------
+
+
+def test_tool_ids_namespace_consistently() -> None:
+    """Tool ids must namespace to `mcp__pocketpaw_decisions__<verb>` so
+    the Claude Code allowlist machinery matches them."""
+    from pocketpaw_ee.agent.mcp_servers.decisions import DECISIONS_TOOL_IDS
+
+    for tool_id in DECISIONS_TOOL_IDS:
+        assert tool_id.startswith("mcp__pocketpaw_decisions__")

--- a/tests/ee/test_decisions_router.py
+++ b/tests/ee/test_decisions_router.py
@@ -1,0 +1,574 @@
+# tests/ee/test_decisions_router.py — RFC 07 Slice 2 router coverage.
+# Created: 2026-05-25 — pins the five real REST routes shipped in
+#   `pocketpaw_ee.cloud.decisions.router` (the Slice 1 ping route stays;
+#   the rest replaces the stub):
+#
+#     GET  /api/v1/decisions/_ping       — Slice 1 liveness; smoke test
+#     GET  /api/v1/decisions/:id          — single lookup, 404 + scope hide
+#     GET  /api/v1/decisions              — list w/ filters, keyset paging
+#     GET  /api/v1/decisions/:id/trace    — upstream BFS, depth + truncation
+#     GET  /api/v1/decisions/:id/downstream — inverse precedent walk
+#     GET  /api/v1/decisions/:id/timeline — flattened journal events
+#
+#   Tests mount the router on a bare FastAPI app and override the auth
+#   chain (request_context) + license gate so the contract is exercised
+#   without a real Mongo. Each test gets its own SQLite store via
+#   `tmp_path` + `set_db_path` so projection state can't leak across
+#   tests. The journal is overridden to a tmp file as well.
+#
+#   Tenant-isolation check: workspace A's decisions are invisible to
+#   workspace B — pins the load-bearing scope filter the RFC's audit
+#   contract requires.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.spec.journal import Actor, EventEntry
+
+from pocketpaw.journal_dep import get_journal, reset_journal_cache
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.decisions.projection import DecisionProjection
+from pocketpaw_ee.cloud.decisions.router import router as decisions_router
+from pocketpaw_ee.cloud.decisions.service import (
+    DecisionGraph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import DecisionStore, set_db_path
+from pocketpaw_ee.cloud.license import require_license
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_projection_and_journal() -> None:
+    """Clear module-level singletons between tests so the projection
+    + journal don't bleed state across cases.
+    """
+    reset_projection_for_tests()
+    reset_journal_cache()
+    yield
+    reset_projection_for_tests()
+    reset_journal_cache()
+
+
+@pytest.fixture
+def journal_path(tmp_path: Path) -> Path:
+    """A disposable SQLite journal file for the timeline test path."""
+    return tmp_path / "journal.db"
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> DecisionStore:
+    """Fresh SQLite-backed decision store per test.
+
+    The `service.get_decision_graph()` singleton resolves through
+    `set_db_path`, so this fixture is the seam tests use to install a
+    disposable store.
+    """
+    set_db_path(tmp_path / "decisions.db")
+    s = DecisionStore()
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def projection(store: DecisionStore) -> DecisionProjection:
+    return DecisionProjection(store=store)
+
+
+@pytest.fixture
+def graph(store: DecisionStore, projection: DecisionProjection) -> DecisionGraph:
+    """Install a DecisionGraph singleton that wraps the per-test store."""
+    from pocketpaw_ee.cloud.decisions import service as decisions_service
+
+    g = DecisionGraph(store=store, projection=projection)
+    decisions_service._GRAPH = g
+    return g
+
+
+@pytest.fixture
+def workspace_id() -> str:
+    return "ws_a_test"
+
+
+@pytest.fixture
+def workspace_b_id() -> str:
+    return "ws_b_test"
+
+
+def _make_request_context(workspace_id: str | None) -> RequestContext:
+    return RequestContext(
+        user_id="user_test",
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def app(graph: DecisionGraph, journal_path: Path, workspace_id: str) -> FastAPI:
+    """FastAPI app with the decisions router + auth + license overridden.
+
+    The default ctx pins the workspace to `workspace_id` (workspace A);
+    individual tests that want workspace B reach into
+    `app.dependency_overrides[request_context]` and swap.
+    """
+    a = FastAPI()
+    add_error_handler(a)  # CloudError → JSON envelope
+    a.include_router(decisions_router, prefix="/api/v1")
+    a.dependency_overrides[get_journal] = lambda: open_journal(journal_path)
+    a.dependency_overrides[require_license] = lambda: None
+    a.dependency_overrides[request_context] = lambda: _make_request_context(workspace_id)
+    return a
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+def base_ts() -> datetime:
+    return datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Event-building helpers — modeled on tests/ee/test_decision_projection.py
+# ---------------------------------------------------------------------------
+
+
+def _event(
+    *,
+    ts: datetime,
+    actor: Actor,
+    action: str,
+    correlation_id: UUID | None,
+    payload: dict,
+    scope: list[str] | None = None,
+) -> EventEntry:
+    return EventEntry(
+        id=uuid4(),
+        ts=ts,
+        actor=actor,
+        action=action,
+        scope=scope or ["org:nerve", "workspace:ws_a_test"],
+        correlation_id=correlation_id,
+        payload=payload,
+    )
+
+
+def _seed_chain(
+    projection: DecisionProjection,
+    *,
+    base_ts: datetime,
+    pocket_id: str = "p_main",
+    workspace: str = "ws_a_test",
+    actor_id: str = "did:soul:agent1",
+    action_name: str = "send_to_tenant",
+    precedents: list[dict] | None = None,
+    corr: UUID | None = None,
+) -> tuple[UUID, UUID]:
+    """Seed one approval chain in the store and return (correlation_id,
+    decision_id) so tests can address both axes."""
+    corr = corr or uuid4()
+    scope = ["org:nerve", f"workspace:{workspace}", f"pocket:{pocket_id}"]
+    actor = Actor(kind="agent", id=actor_id, scope_context=scope)
+    payload: dict = {
+        "intent": f"chain-{corr.hex[:8]}",
+        "action": action_name,
+        "pocket_id": pocket_id,
+    }
+    if precedents is not None:
+        payload["precedents"] = precedents
+    events = [
+        _event(
+            ts=base_ts,
+            actor=actor,
+            action="agent.proposed",
+            correlation_id=corr,
+            payload=payload,
+            scope=scope,
+        ),
+        _event(
+            ts=base_ts + timedelta(seconds=1),
+            actor=actor,
+            action="decision.graduated",
+            correlation_id=corr,
+            payload={"passed": True},
+            scope=scope,
+        ),
+    ]
+    last_decision_id: UUID | None = None
+    for e in events:
+        result = projection.apply(e)
+        if result is not None:
+            last_decision_id = result.id
+    assert last_decision_id is not None
+    return corr, last_decision_id
+
+
+# ---------------------------------------------------------------------------
+# _ping — Slice 1 holdover; sanity test it didn't regress
+# ---------------------------------------------------------------------------
+
+
+def test_ping_returns_cursor_and_count(client: TestClient, graph: DecisionGraph) -> None:
+    resp = client.get("/api/v1/decisions/_ping")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["decisions"] == 0  # nothing seeded
+    assert "cursor" in body
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/decisions/:id
+# ---------------------------------------------------------------------------
+
+
+def test_get_returns_decision(client, projection, base_ts) -> None:
+    _, decision_id = _seed_chain(projection, base_ts=base_ts)
+    resp = client.get(f"/api/v1/decisions/{decision_id}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == str(decision_id)
+    assert body["action"] == "send_to_tenant"
+    assert body["pocket_id"] == "p_main"
+    # Wire shape — flattened actor fields, no nesting.
+    assert body["actor_kind"] == "agent"
+    assert body["actor_id"] == "did:soul:agent1"
+
+
+def test_get_returns_404_when_missing(client) -> None:
+    resp = client.get(f"/api/v1/decisions/{uuid4()}")
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "decisions.not_found"
+
+
+def test_get_returns_400_when_id_is_not_uuid(client) -> None:
+    resp = client.get("/api/v1/decisions/not-a-uuid")
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "decisions.invalid_id"
+
+
+def test_get_returns_404_when_scope_mismatch(
+    client, app, projection, base_ts, workspace_b_id
+) -> None:
+    """A workspace B caller cannot see workspace A's decisions.
+
+    The route returns the same 404 envelope as a real miss — the two
+    states are deliberately indistinguishable so a caller cannot probe
+    for hidden rows (RFC 07 § Privacy + audit).
+    """
+    _, decision_id = _seed_chain(projection, base_ts=base_ts, workspace="ws_a_test")
+
+    # Flip the ctx to workspace B.
+    app.dependency_overrides[request_context] = lambda: _make_request_context(workspace_b_id)
+    resp = client.get(f"/api/v1/decisions/{decision_id}")
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "decisions.not_found"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/decisions — list + filters
+# ---------------------------------------------------------------------------
+
+
+def test_list_returns_decisions(client, projection, base_ts) -> None:
+    _seed_chain(projection, base_ts=base_ts, actor_id="did:soul:a")
+    _seed_chain(
+        projection, base_ts=base_ts + timedelta(seconds=10), actor_id="did:soul:b"
+    )
+    resp = client.get("/api/v1/decisions")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] == 2
+    assert len(body["decisions"]) == 2
+
+
+def test_list_filters_by_actor(client, projection, base_ts) -> None:
+    _seed_chain(projection, base_ts=base_ts, actor_id="did:soul:alpha")
+    _seed_chain(
+        projection,
+        base_ts=base_ts + timedelta(seconds=10),
+        actor_id="did:soul:beta",
+    )
+    resp = client.get("/api/v1/decisions", params={"actor": "did:soul:alpha"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["decisions"][0]["actor_id"] == "did:soul:alpha"
+
+
+def test_list_filters_by_pocket(client, projection, base_ts) -> None:
+    _seed_chain(projection, base_ts=base_ts, pocket_id="pocket_alpha")
+    _seed_chain(
+        projection,
+        base_ts=base_ts + timedelta(seconds=10),
+        pocket_id="pocket_beta",
+    )
+    resp = client.get("/api/v1/decisions", params={"pocket_id": "pocket_alpha"})
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["decisions"][0]["pocket_id"] == "pocket_alpha"
+
+
+def test_list_filters_by_time_window(client, projection, base_ts) -> None:
+    _seed_chain(projection, base_ts=base_ts)
+    _seed_chain(projection, base_ts=base_ts + timedelta(hours=2))
+    resp = client.get(
+        "/api/v1/decisions",
+        params={"until": (base_ts + timedelta(hours=1)).isoformat()},
+    )
+    body = resp.json()
+    assert body["total"] == 1
+
+
+def test_list_keyset_pagination(client, projection, base_ts) -> None:
+    """Two-page walk returns disjoint id sets — keyset cursor is correct."""
+    for i in range(5):
+        _seed_chain(projection, base_ts=base_ts + timedelta(seconds=i))
+
+    page_one = client.get("/api/v1/decisions", params={"limit": 2}).json()
+    assert len(page_one["decisions"]) == 2
+    assert page_one["next_before_ts"] is not None
+    assert page_one["next_before_id"] is not None
+
+    page_two = client.get(
+        "/api/v1/decisions",
+        params={
+            "limit": 2,
+            "before_ts": page_one["next_before_ts"],
+            "before_id": page_one["next_before_id"],
+        },
+    ).json()
+    assert len(page_two["decisions"]) == 2
+    ids_one = {d["id"] for d in page_one["decisions"]}
+    ids_two = {d["id"] for d in page_two["decisions"]}
+    assert ids_one.isdisjoint(ids_two)
+
+
+def test_list_rejects_workspace_id_query(client) -> None:
+    """The route refuses to take a `workspace_id` query — tenancy is auth-derived."""
+    resp = client.get("/api/v1/decisions", params={"workspace_id": "other_workspace"})
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "decisions.workspace_id_forbidden"
+
+
+def test_list_scope_filter_per_call(
+    client, app, projection, base_ts, workspace_b_id
+) -> None:
+    """Two-workspace tenant isolation — A's decisions invisible to B."""
+    _seed_chain(projection, base_ts=base_ts, workspace="ws_a_test")
+    _seed_chain(
+        projection,
+        base_ts=base_ts + timedelta(seconds=10),
+        workspace="ws_b_test",
+    )
+
+    # Workspace A sees only ws_a_test's decisions.
+    a_body = client.get("/api/v1/decisions").json()
+    assert a_body["total"] == 1
+    assert "workspace:ws_a_test" in a_body["decisions"][0]["scope"]
+
+    # Workspace B sees only ws_b_test's decisions.
+    app.dependency_overrides[request_context] = lambda: _make_request_context(workspace_b_id)
+    b_body = client.get("/api/v1/decisions").json()
+    assert b_body["total"] == 1
+    assert "workspace:ws_b_test" in b_body["decisions"][0]["scope"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/decisions/:id/trace
+# ---------------------------------------------------------------------------
+
+
+def test_trace_walks_precedents_at_default_depth(client, projection, base_ts) -> None:
+    # Seed a precedent.
+    _, prec_id = _seed_chain(projection, base_ts=base_ts - timedelta(days=1))
+    _, new_id = _seed_chain(
+        projection,
+        base_ts=base_ts,
+        precedents=[{"decision_id": str(prec_id), "weight": 0.9}],
+    )
+
+    resp = client.get(f"/api/v1/decisions/{new_id}/trace")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["root"] == str(new_id)
+    assert str(new_id) in body["nodes"]
+    assert str(prec_id) in body["nodes"]
+
+
+def test_trace_depth_1(client, projection, base_ts) -> None:
+    """depth=1 shows the root but doesn't walk further."""
+    _, prec_id = _seed_chain(projection, base_ts=base_ts - timedelta(days=2))
+    _, new_id = _seed_chain(
+        projection,
+        base_ts=base_ts,
+        precedents=[{"decision_id": str(prec_id), "weight": 0.9}],
+    )
+
+    resp = client.get(f"/api/v1/decisions/{new_id}/trace", params={"depth": 1})
+    body = resp.json()
+    assert body["root"] == str(new_id)
+    assert body["depth_reached"] <= 1
+
+
+def test_trace_depth_10_is_max(client, projection, base_ts) -> None:
+    """depth=10 is the cap (RFC 07 perf budget)."""
+    _, root_id = _seed_chain(projection, base_ts=base_ts)
+    resp = client.get(f"/api/v1/decisions/{root_id}/trace", params={"depth": 10})
+    assert resp.status_code == 200
+
+
+def test_trace_depth_above_max_rejected(client, projection, base_ts) -> None:
+    """depth=11 is rejected at the validation layer."""
+    _, root_id = _seed_chain(projection, base_ts=base_ts)
+    resp = client.get(f"/api/v1/decisions/{root_id}/trace", params={"depth": 11})
+    # FastAPI's ge/le validation returns 422 for query-param violations.
+    assert resp.status_code == 422
+
+
+def test_trace_truncates_high_fanout(client, projection, base_ts) -> None:
+    """A node with more outgoing edges than `max_fanout` is truncated and
+    the response reports it."""
+    # Seed many precedents; cite all from one new decision.
+    prec_ids: list[UUID] = []
+    for i in range(15):
+        _, p = _seed_chain(projection, base_ts=base_ts - timedelta(days=10, seconds=i))
+        prec_ids.append(p)
+
+    _, new_id = _seed_chain(
+        projection,
+        base_ts=base_ts,
+        precedents=[{"decision_id": str(p), "weight": 1.0} for p in prec_ids],
+    )
+
+    resp = client.get(
+        f"/api/v1/decisions/{new_id}/trace",
+        params={"depth": 2, "max_fanout": 3},
+    )
+    body = resp.json()
+    assert body["truncated"] is True
+    assert body["truncated_count"] > 0
+
+
+def test_trace_returns_404_for_missing_root(client) -> None:
+    resp = client.get(f"/api/v1/decisions/{uuid4()}/trace")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/decisions/:id/downstream
+# ---------------------------------------------------------------------------
+
+
+def test_downstream_finds_later_citers(client, projection, base_ts) -> None:
+    _, root_id = _seed_chain(projection, base_ts=base_ts - timedelta(days=1))
+    _, citer_id = _seed_chain(
+        projection,
+        base_ts=base_ts,
+        precedents=[{"decision_id": str(root_id), "weight": 0.8}],
+    )
+
+    resp = client.get(f"/api/v1/decisions/{root_id}/downstream")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert str(root_id) in body["nodes"]
+    assert str(citer_id) in body["nodes"]
+    # Inverse edges are stamped as "downstream" on the wire.
+    downstream_edges = [e for e in body["edges"] if e["relation"] == "downstream"]
+    assert len(downstream_edges) == 1
+
+
+def test_downstream_returns_404_for_missing_root(client) -> None:
+    resp = client.get(f"/api/v1/decisions/{uuid4()}/downstream")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/decisions/:id/timeline
+# ---------------------------------------------------------------------------
+
+
+def test_timeline_returns_journal_events(
+    client, projection, base_ts, journal_path: Path
+) -> None:
+    """The timeline endpoint reads the journal for events sharing the
+    Decision's correlation_id and returns them in seq order."""
+    # Seed a Decision via the projection — chain has a correlation_id.
+    corr = uuid4()
+    _, decision_id = _seed_chain(projection, base_ts=base_ts, corr=corr)
+
+    # Append the same events to the real journal so the timeline endpoint
+    # can read them back. Each entry shares the `corr` correlation_id.
+    journal = open_journal(journal_path)
+    actor = Actor(
+        kind="agent",
+        id="did:soul:agent1",
+        scope_context=["org:nerve", "workspace:ws_a_test", "pocket:p_main"],
+    )
+    journal.append(
+        EventEntry(
+            id=uuid4(),
+            ts=base_ts,
+            actor=actor,
+            action="agent.proposed",
+            scope=["org:nerve", "workspace:ws_a_test", "pocket:p_main"],
+            correlation_id=corr,
+            payload={"intent": "test"},
+        )
+    )
+    journal.append(
+        EventEntry(
+            id=uuid4(),
+            ts=base_ts + timedelta(seconds=1),
+            actor=actor,
+            action="decision.graduated",
+            scope=["org:nerve", "workspace:ws_a_test", "pocket:p_main"],
+            correlation_id=corr,
+            payload={"passed": True},
+        )
+    )
+
+    resp = client.get(f"/api/v1/decisions/{decision_id}/timeline")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["decision_id"] == str(decision_id)
+    assert body["correlation_id"] == str(corr)
+    assert len(body["events"]) == 2
+    # Events are seq-ordered.
+    assert body["events"][0]["seq"] < body["events"][1]["seq"]
+    assert body["events"][0]["action"] == "agent.proposed"
+    assert body["events"][1]["action"] == "decision.graduated"
+
+
+def test_timeline_returns_404_when_decision_missing(client) -> None:
+    resp = client.get(f"/api/v1/decisions/{uuid4()}/timeline")
+    assert resp.status_code == 404
+
+
+def test_timeline_returns_404_when_scope_mismatch(
+    client, app, projection, base_ts, workspace_b_id
+) -> None:
+    """Timeline is gated by the same scope check as the get endpoint —
+    workspace B caller cannot read workspace A's events."""
+    _, decision_id = _seed_chain(projection, base_ts=base_ts, workspace="ws_a_test")
+
+    app.dependency_overrides[request_context] = lambda: _make_request_context(workspace_b_id)
+    resp = client.get(f"/api/v1/decisions/{decision_id}/timeline")
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "decisions.not_found"

--- a/tests/ee/test_decisions_router.py
+++ b/tests/ee/test_decisions_router.py
@@ -2,6 +2,11 @@
 # Created: 2026-05-25 — pins the five real REST routes shipped in
 #   `pocketpaw_ee.cloud.decisions.router` (the Slice 1 ping route stays;
 #   the rest replaces the stub):
+# Updated: 2026-05-25 (RFC 07 Slice 2 — post-filter total) — added two
+#   regression tests for the list endpoint: `test_total_is_post_scope_
+#   filter_not_page_size` (the load-bearing anti-probe assertion) and
+#   `test_partial_page_returns_null_cursor` (a short page must NOT echo
+#   a phantom `next_before_*` cursor).
 #
 #     GET  /api/v1/decisions/_ping       — Slice 1 liveness; smoke test
 #     GET  /api/v1/decisions/:id          — single lookup, 404 + scope hide
@@ -388,6 +393,73 @@ def test_list_scope_filter_per_call(
     b_body = client.get("/api/v1/decisions").json()
     assert b_body["total"] == 1
     assert "workspace:ws_b_test" in b_body["decisions"][0]["scope"]
+
+
+def test_total_is_post_scope_filter_not_page_size(
+    client, app, projection, base_ts, workspace_b_id
+) -> None:
+    """``total`` reports the post-scope-filter count, not the page size.
+
+    Load-bearing test for the RFC 07 § Privacy anti-probe property: a
+    caller varying ``limit`` MUST NOT observe a changing ``total``. If
+    ``total`` echoed the page size, a caller could compare
+    ``total(limit=N)`` to a workspace-wide count to infer hidden rows
+    in their own scope; if ``total`` echoed the pre-scope-filter count,
+    the leak would be even worse — a caller would see how many rows
+    sit in OTHER workspaces.
+    """
+    # 5 in workspace A, 3 in workspace B. The route's caller (this
+    # client) is workspace A by default.
+    for i in range(5):
+        _seed_chain(
+            projection,
+            base_ts=base_ts + timedelta(seconds=i),
+            workspace="ws_a_test",
+        )
+    for i in range(3):
+        _seed_chain(
+            projection,
+            base_ts=base_ts + timedelta(seconds=100 + i),
+            workspace="ws_b_test",
+        )
+
+    # Page-sized request: limit=2 (well under the 5 we seeded for A).
+    body = client.get("/api/v1/decisions", params={"limit": 2}).json()
+
+    # The page is the requested 2 rows.
+    assert len(body["decisions"]) == 2
+    # `total` is workspace A's full scoped count, NOT the page size...
+    assert body["total"] == 5
+    # ...and NOT the unscoped total (which would leak workspace B).
+    assert body["total"] != 8
+    # ...and NOT the requested page size.
+    assert body["total"] != 2
+
+    # Sanity: varying `limit` does not move `total`. This is the
+    # invariant a probe would try to violate.
+    body_full = client.get("/api/v1/decisions", params={"limit": 50}).json()
+    assert body_full["total"] == 5
+
+    # Workspace B sees its own 3 — same scope-aware shape.
+    app.dependency_overrides[request_context] = lambda: _make_request_context(workspace_b_id)
+    body_b = client.get("/api/v1/decisions", params={"limit": 1}).json()
+    assert len(body_b["decisions"]) == 1
+    assert body_b["total"] == 3
+
+
+def test_partial_page_returns_null_cursor(client, projection, base_ts) -> None:
+    """A partial page (fewer rows returned than the limit) MUST NOT echo
+    a ``next_before_*`` cursor — the client would otherwise follow a
+    phantom next page that always returns empty.
+    """
+    # Seed 3 decisions; request limit=10 so the response is partial.
+    for i in range(3):
+        _seed_chain(projection, base_ts=base_ts + timedelta(seconds=i))
+
+    body = client.get("/api/v1/decisions", params={"limit": 10}).json()
+    assert len(body["decisions"]) == 3
+    assert body["next_before_ts"] is None
+    assert body["next_before_id"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ee/test_mcp_claude_sdk.py
+++ b/tests/ee/test_mcp_claude_sdk.py
@@ -15,6 +15,7 @@ All SDK imports are mocked.
 
 from unittest.mock import patch
 
+from pocketpaw_ee.agent.mcp_servers.decisions import SERVER_NAME as _DECISIONS_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.planner import SERVER_NAME as _PLANNER_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.pockets import SERVER_NAME as _POCKET_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.tasks import SERVER_NAME as _TASKS_MCP_SERVER_NAME
@@ -43,6 +44,7 @@ def _strip_builtin_servers(result: dict) -> dict:
     out.pop(_POCKET_SPECIALIST_MCP_SERVER_NAME, None)
     out.pop(_TASKS_MCP_SERVER_NAME, None)
     out.pop(_PLANNER_MCP_SERVER_NAME, None)
+    out.pop(_DECISIONS_MCP_SERVER_NAME, None)
     return out
 
 

--- a/tests/ee/test_outcomes_decision_backref.py
+++ b/tests/ee/test_outcomes_decision_backref.py
@@ -1,0 +1,324 @@
+# tests/ee/test_outcomes_decision_backref.py — RFC 07 Slice 2 outcomes
+# back-reference. Pins the decision-graph back-reference flow:
+#
+#   1. Seed a Decision via the projection (its row lands with no outcome).
+#   2. Call `outcomes.service.record_outcome` with a `pocket.outcome`
+#      event whose payload carries the `decision_id`.
+#   3. Assert the decision row's `outcome` field is now populated AND
+#      the ledger row carries the back-reference.
+#
+# The DecisionProjection's `_apply_outcome_attached` handler is the load-
+# bearing piece — `record_outcome` synthesises a `decision.outcome_attached`
+# journal-shaped EventEntry and feeds it through `projection.apply()`.
+# That keeps the back-reference flow strictly in-process; the
+# journal-to-projection subscription that would do the same end-to-end
+# is deferred to a follow-up.
+#
+# Created: 2026-05-25 (RFC 07 Slice 2).
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from soul_protocol.spec.journal import Actor, EventEntry
+
+from pocketpaw_ee.cloud.decisions.projection import DecisionProjection
+from pocketpaw_ee.cloud.decisions.service import (
+    DecisionGraph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import DecisionStore, set_db_path
+from pocketpaw_ee.cloud.outcomes import service as outcomes_service
+from pocketpaw_ee.cloud.outcomes.dto import OutcomeResponse
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_projection():
+    reset_projection_for_tests()
+    yield
+    reset_projection_for_tests()
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> DecisionStore:
+    set_db_path(tmp_path / "decisions.db")
+    s = DecisionStore()
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def projection(store: DecisionStore) -> DecisionProjection:
+    return DecisionProjection(store=store)
+
+
+@pytest.fixture
+def graph(store: DecisionStore, projection: DecisionProjection) -> DecisionGraph:
+    """Install the DecisionGraph singleton — outcomes service resolves
+    through `get_decision_graph()` so this is the test seam."""
+    from pocketpaw_ee.cloud.decisions import service as decisions_service
+
+    g = DecisionGraph(store=store, projection=projection)
+    decisions_service._GRAPH = g
+    return g
+
+
+@pytest.fixture
+def ledger_dir(tmp_path: Path) -> Path:
+    """Point the outcomes ledger at a tmp directory so tests never
+    touch the real ~/.pocketpaw/outcomes/ tree."""
+    d = tmp_path / "outcomes"
+    outcomes_service.set_ledger_dir(d)
+    yield d
+    # Restore the default after each test so other tests on the same
+    # process aren't redirected.
+    outcomes_service.set_ledger_dir(Path.home() / ".pocketpaw" / "outcomes")
+
+
+@pytest.fixture
+def base_ts() -> datetime:
+    return datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_decision(
+    projection: DecisionProjection,
+    *,
+    base_ts: datetime,
+    workspace: str = "ws_a_test",
+    pocket_id: str = "p_main",
+) -> UUID:
+    """Seed one approval chain and return the Decision's id."""
+    corr = uuid4()
+    scope = ["org:nerve", f"workspace:{workspace}", f"pocket:{pocket_id}"]
+    actor = Actor(kind="agent", id="did:soul:agent_decisions", scope_context=scope)
+    events = [
+        EventEntry(
+            id=uuid4(),
+            ts=base_ts,
+            actor=actor,
+            action="agent.proposed",
+            scope=scope,
+            correlation_id=corr,
+            payload={
+                "intent": "test back-reference",
+                "action": "send_to_tenant",
+                "pocket_id": pocket_id,
+            },
+        ),
+        EventEntry(
+            id=uuid4(),
+            ts=base_ts + timedelta(seconds=1),
+            actor=actor,
+            action="decision.graduated",
+            scope=scope,
+            correlation_id=corr,
+            payload={"passed": True},
+        ),
+    ]
+    last_decision_id: UUID | None = None
+    for e in events:
+        result = projection.apply(e)
+        if result is not None:
+            last_decision_id = result.id
+    assert last_decision_id is not None
+    return last_decision_id
+
+
+class _FakeEvent:
+    """Tiny stand-in for `PocketOutcomeEvent` — the listener reads
+    `.data` only, so a duck type is sufficient and keeps the test free
+    of bus wiring concerns."""
+
+    def __init__(self, data: dict) -> None:
+        self.data = data
+
+
+# ---------------------------------------------------------------------------
+# Outcome → Decision back-reference
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_attaches_outcome_to_decision(
+    graph, projection, ledger_dir: Path, base_ts: datetime
+) -> None:
+    """A `pocket.outcome` event carrying a `decision_id` mutates the
+    Decision row's outcome field in place."""
+    decision_id = _seed_decision(projection, base_ts=base_ts)
+
+    # Sanity — Decision starts with no outcome.
+    pre = graph.store.get_decision(decision_id)
+    assert pre is not None
+    assert pre.outcome is None
+
+    event = _FakeEvent(
+        data={
+            "outcome": "lease_renewed",
+            "pocket_id": "p_main",
+            "workspace_id": "ws_a_test",
+            "action": "send_to_tenant",
+            "actor": "did:soul:agent_decisions",
+            "via_instinct": False,
+            "instinct_action_id": None,
+            "occurred_at": (base_ts + timedelta(seconds=5)).isoformat(),
+            "outcome_value": None,
+            "outcome_unit": None,
+            "decision_id": str(decision_id),
+        }
+    )
+
+    await outcomes_service.record_outcome(event)
+
+    # The Decision row now carries the outcome (status=landed) — projection
+    # folded the synthetic `decision.outcome_attached` event.
+    post = graph.store.get_decision(decision_id)
+    assert post is not None
+    assert post.outcome is not None
+    assert post.outcome.status == "landed"
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_writes_decision_id_to_ledger(
+    graph, projection, ledger_dir: Path, base_ts: datetime
+) -> None:
+    """The ledger JSONL row mirrors the back-reference."""
+    decision_id = _seed_decision(projection, base_ts=base_ts)
+
+    event = _FakeEvent(
+        data={
+            "outcome": "lease_renewed",
+            "pocket_id": "p_main",
+            "workspace_id": "ws_a_test",
+            "action": "send_to_tenant",
+            "actor": "did:soul:agent_decisions",
+            "via_instinct": False,
+            "instinct_action_id": None,
+            "occurred_at": (base_ts + timedelta(seconds=5)).isoformat(),
+            "outcome_value": None,
+            "outcome_unit": None,
+            "decision_id": str(decision_id),
+        }
+    )
+
+    await outcomes_service.record_outcome(event)
+
+    ledger_path = ledger_dir / "ws_a_test.jsonl"
+    assert ledger_path.exists()
+    rows = [json.loads(line) for line in ledger_path.read_text().splitlines() if line]
+    assert len(rows) == 1
+    assert rows[0]["decision_id"] == str(decision_id)
+    assert rows[0]["outcome"] == "lease_renewed"
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_without_decision_id_is_legacy_safe(
+    graph, projection, ledger_dir: Path, base_ts: datetime
+) -> None:
+    """A producer that doesn't pass `decision_id` still meters the
+    outcome — the back-reference is just absent. Legacy writers keep
+    working."""
+    event = _FakeEvent(
+        data={
+            "outcome": "tenant_replied",
+            "pocket_id": "p_main",
+            "workspace_id": "ws_a_test",
+            "action": "send_to_tenant",
+            "actor": "did:soul:agent_decisions",
+            "via_instinct": False,
+            "instinct_action_id": None,
+            "occurred_at": (base_ts + timedelta(seconds=5)).isoformat(),
+            "outcome_value": None,
+            "outcome_unit": None,
+            # decision_id omitted on purpose.
+        }
+    )
+
+    await outcomes_service.record_outcome(event)
+
+    ledger_path = ledger_dir / "ws_a_test.jsonl"
+    rows = [json.loads(line) for line in ledger_path.read_text().splitlines() if line]
+    assert len(rows) == 1
+    assert rows[0].get("decision_id") is None
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_with_bad_decision_id_skips_attach(
+    graph, projection, ledger_dir: Path, base_ts: datetime
+) -> None:
+    """An invalid `decision_id` is logged + ignored — the ledger row
+    still lands so the outcome meter doesn't regress."""
+    event = _FakeEvent(
+        data={
+            "outcome": "lease_renewed",
+            "pocket_id": "p_main",
+            "workspace_id": "ws_a_test",
+            "action": "send_to_tenant",
+            "actor": "did:soul:agent_decisions",
+            "via_instinct": False,
+            "instinct_action_id": None,
+            "occurred_at": (base_ts + timedelta(seconds=5)).isoformat(),
+            "decision_id": "not-a-uuid",
+        }
+    )
+
+    # No exception even with a bad id.
+    await outcomes_service.record_outcome(event)
+
+    ledger_path = ledger_dir / "ws_a_test.jsonl"
+    rows = [json.loads(line) for line in ledger_path.read_text().splitlines() if line]
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_emit_pocket_outcome_threads_decision_id(monkeypatch) -> None:
+    """`emit_pocket_outcome` forwards the new `decision_id` parameter
+    onto the `pocket.outcome` bus event."""
+    captured: dict = {}
+
+    async def fake_emit(event):  # noqa: ANN001
+        captured["data"] = dict(event.data)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.outcomes.service.emit", fake_emit)
+
+    await outcomes_service.emit_pocket_outcome(
+        outcome="lease_renewed",
+        pocket_id="p_main",
+        workspace_id="ws_a_test",
+        action="send_to_tenant",
+        actor="did:soul:agent_decisions",
+        via_instinct=False,
+        decision_id="abc-decision-id",
+    )
+
+    assert captured["data"]["decision_id"] == "abc-decision-id"
+    assert captured["data"]["outcome"] == "lease_renewed"
+
+
+def test_outcome_response_carries_decision_id() -> None:
+    """Wire shape exposes the back-reference."""
+    resp = OutcomeResponse(
+        outcome="lease_renewed",
+        pocket_id="p_main",
+        workspace_id="ws_a_test",
+        action="send_to_tenant",
+        actor="did:soul:agent_decisions",
+        via_instinct=False,
+        occurred_at="2026-05-25T12:00:00+00:00",
+        decision_id="abc-decision-id",
+    )
+    body = resp.model_dump()
+    assert body["decision_id"] == "abc-decision-id"


### PR DESCRIPTION
Re-opens #1231 after the base branch (`feat/rfc07-decision-graph-slice1`) was deleted on Slice 1 merge — GitHub auto-closes PRs whose base no longer exists and refuses to reopen them. Content is identical to the closed PR plus the post-filter `total` fix from review.

## What ships

- 5 REST routes: `GET /api/v1/decisions/{id}`, `GET /api/v1/decisions` (keyset pagination), `/:id/trace`, `/:id/downstream`, `/:id/timeline`
- 3 MCP wrappers in `mcp__pocketpaw_decisions__` namespace (`get`, `find`, `trace`)
- Outcomes back-reference: `OutcomeRecord.decision_id` field + `decision.outcome_attached` emission from `record_outcome` (hash chain unaffected)
- Wire DTOs separate from domain (`ApproverWire`, `InputWire`, `OutcomeWire`, `PrecedentWire`)
- Post-filter `total` count via new `DecisionGraph.count()` (review fix — RFC § Privacy anti-probe property)
- Partial pages return `next_before_ts: null` (review fix — no extra empty round-trip)

## Test plan

- [x] `tests/ee/test_decisions_router.py` — 23 tests including tenant isolation, post-filter total assertion, partial-page cursor
- [x] `tests/ee/test_decisions_mcp.py` — 12 tests
- [x] `tests/ee/test_outcomes_decision_backref.py` — 6 tests including legacy-safe path
- [x] Full ee suite: 607 pass, 0 regressions, 17/17 lint contracts kept

## Stacked on

Slice 1 (#1226, now merged into `feat/rfc07-decision-graph`). Slice 3a (#1237) stacks on this; will retarget after this merges.

## Not in this PR

- `/explain` route → Slice 3a (#1237)
- DecisionGraph widget → Slice 3b (paw-enterprise#253)