### PR TITLE
feat(compile): template-to-runtime translation seam for data_sources

### DIFF
--- a/src/pocketpaw/__main__.py
+++ b/src/pocketpaw/__main__.py
@@ -1,6 +1,11 @@
 """PocketPaw entry point.
 
 Changes:
+  - 2026-05-25: Added `template compile <file>` subaction next to lint /
+                migrate / diff (RFC 03 v2 PR 2b). Compile prints the
+                runtime-shaped rippleSpec dict the template produces —
+                JSON by default, YAML under the new top-level `--yaml`
+                flag. Author-facing inspection only; never persists.
   - 2026-05-25: Added `template` subcommand (lint / migrate / diff) for
                 RFC 03 v2 templates. Wired into _EARLY_COMMANDS so the
                 lint / migrate / diff path never pays the agent or
@@ -193,6 +198,7 @@ def _handle_early_command(args) -> int | None:
             as_json=getattr(args, "json", False),
             yes=getattr(args, "yes", False),
             no_backup=getattr(args, "no_backup", False),
+            as_yaml=getattr(args, "yaml", False),
         )
 
     return None
@@ -351,6 +357,11 @@ Examples:
         "--no-backup",
         action="store_true",
         help="Skip backup creation (for template migrate)",
+    )
+    parser.add_argument(
+        "--yaml",
+        action="store_true",
+        help="Emit YAML instead of JSON (for template compile)",
     )
 
     return parser

--- a/src/pocketpaw/bundled_templates/__init__.py
+++ b/src/pocketpaw/bundled_templates/__init__.py
@@ -6,6 +6,10 @@
 # ``PocketTemplate``, ``TemplateValidationError``, and the sub-models
 # so callers (CLI, tests, future runtime) can import them at the
 # package root without reaching into ``schema`` / ``errors`` submodules.
+# Modified 2026-05-25 (feat/rfc-03-v2-compile): re-exports
+# ``compile_template`` — the OSS-side template-to-runtime translation
+# seam. PR 2b implements ``data_sources[]`` only; other top-level
+# fields passthrough until PRs 2c-2g land their runtime executors.
 """Built-in pocket templates bundled and auto-installed by PocketPaw.
 
 Third sibling to ``pocketpaw.bundled_skills`` and ``pocketpaw.bundled_kb``.
@@ -47,6 +51,7 @@ files and register it in ``_bundled/index.json``. The installer discovers
 directories via iteration — no installer code changes needed.
 """
 
+from pocketpaw.bundled_templates.compile import compile_template
 from pocketpaw.bundled_templates.errors import TemplateValidationError
 from pocketpaw.bundled_templates.installer import (
     TemplateInstallResult,
@@ -85,6 +90,7 @@ __all__ = [
     "TemplateInstallResult",
     "TemplateValidationError",
     "TriggerDef",
+    "compile_template",
     "install_bundled_templates",
     "load_template",
 ]

--- a/src/pocketpaw/bundled_templates/compile.py
+++ b/src/pocketpaw/bundled_templates/compile.py
@@ -1,0 +1,340 @@
+# src/pocketpaw/bundled_templates/compile.py
+# Created: 2026-05-25 (feat/rfc-03-v2-compile) — translates a validated
+# RFC 03 v2 ``PocketTemplate`` into a runtime-shaped ``rippleSpec`` dict.
+# This module is the OSS-side seam between design-time templates and
+# runtime executors. The compile output is a plain dict — the EE-side
+# runtime (``pocketpaw_ee.cloud.pockets.source_executor.SourceBinding``,
+# etc.) consumes it via ``model_validate``, so the seam keeps the OSS→EE
+# import boundary clean (import-linter enforced).
+"""Translate an RFC 03 v2 ``PocketTemplate`` into a runtime rippleSpec.
+
+The ``compile_template`` function is the OSS-core seam between the
+design-time Pydantic schema (``PocketTemplate`` and its sub-models) and
+the runtime executors (RFC 04 source executor, RFC 05 action executor,
+RFC 06 A2UI patcher, …). The output is a plain dict so it can cross
+the OSS↔EE boundary without dragging a Pydantic import into either
+side beyond the schema each owns.
+
+Scope of this PR (PR 2b — data-sources only)
+============================================
+
+The compile pass implemented here translates ONE field — ``data_sources[]`` —
+into the runtime's ``sources`` block. Every other top-level field is
+passed through verbatim so downstream PRs can read them off the same
+seam without re-loading the template:
+
+* ``actions``        — passthrough; CEL evaluation in PR 2c, Instinct in PR 2d
+* ``agents``         — passthrough; agent-backend binding in a later PR
+* ``triggers``       — passthrough; cron / temporal / source_change in PR 2f
+* ``permissions``    — passthrough; RBAC runtime in PR 2g
+* ``instinct_rules`` — passthrough; Instinct execution in PR 2d
+* ``connectors``     — passthrough; the runtime resolves them at install
+* ``outcomes``       — passthrough; the meter listens on these names
+
+The output also carries ``state``, ``name``, ``version``, ``pattern``,
+``shape``, ``display_name``, ``description``, ``vertical``, ``kb_scope``,
+``skill_refs``, ``screenshots``, ``icon``, ``color``, and
+``schema_version`` so install-time tooling has a single seam to read
+off — no need to re-parse the YAML template.
+
+Forbidden: this module MUST NOT import ``pocketpaw_ee.*``. The runtime
+``SourceBinding`` lives in EE; the compile output here is shaped to be
+consumable by it but never imports the Pydantic class. Cross-boundary
+shape compatibility is verified by tests via lazy imports gated by
+``pytest.importorskip("pocketpaw_ee")``.
+
+``data_sources[]`` translation rules
+====================================
+
+The RFC's ``data_sources[]`` sub-schema and the runtime's
+``SourceBinding`` declare overlapping but non-identical field sets:
+
+* ``name`` (kebab-case) -> dict key in ``sources``; removed from value.
+* ``method`` (GET only) -> ``method``; pass through.
+* ``path`` (relative)   -> ``path``; pass through.
+* ``bind``              -> ``bind``; pass through.
+* ``refresh`` (str list with optional ``<keyword>:<arg>`` forms) ->
+  ``refresh`` (Literal list) plus optional ``refresh_interval_seconds``:
+    - ``pocket_open`` / ``manual`` / ``webhook`` pass through bare.
+    - ``interval:<dur>`` splits into bare ``interval`` plus the parsed
+      seconds (``1h`` -> 3600, ``30s`` -> 30, ``7d`` -> 604800, …).
+    - ``signal:<event>`` is dropped — the runtime has no equivalent
+      yet; tracked for a future RFC 04 PR.
+* ``transform`` -> passthrough; RFC 04 M2 runtime feature. The runtime
+  ``SourceBinding`` ignores unknown keys so this is safe today.
+
+Duration parsing supports ``<n>s``, ``<n>m``, ``<n>h``, ``<n>d`` and
+plain ``<n>`` (seconds). Anything else is treated as ``None`` — the
+runtime then falls back to its configured minimum interval.
+
+Purity contract
+===============
+
+``compile_template`` is a pure function. It performs no I/O, no
+persistence, no side effects. The input is never mutated. Calling
+twice with the same input produces identical output.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from pocketpaw.bundled_templates.schema import (
+    DataSourceDef,
+    PocketTemplate,
+)
+
+# ---------------------------------------------------------------------------
+# Refresh-keyword normalization
+# ---------------------------------------------------------------------------
+
+# Runtime ``RefreshTrigger`` literal (kept in sync with
+# ``ee/pocketpaw_ee/cloud/pockets/source_executor.RefreshTrigger``).
+# Listed here for the OSS side so the compile pass can drop entries the
+# runtime would reject. Keep in sync; when the runtime grows a new
+# trigger (e.g. ``signal``), drop it from ``_UNSUPPORTED_REFRESH_PREFIXES``.
+_KNOWN_REFRESH_KEYWORDS: frozenset[str] = frozenset(
+    {"pocket_open", "manual", "interval", "webhook"}
+)
+
+# Colon-prefixed refresh entries the RFC permits but the runtime
+# currently has no equivalent for. They are silently dropped from the
+# compile output; downstream PRs that wire the corresponding runtime
+# support remove the prefix from this set.
+_UNSUPPORTED_REFRESH_PREFIXES: frozenset[str] = frozenset({"signal"})
+
+# Compile-time duration parser. Matches ``<integer><unit>`` with
+# ``unit`` in ``s | m | h | d``. A bare integer is interpreted as
+# seconds for ergonomic agent-authored templates. Unknown forms return
+# ``None`` and the runtime falls back to the configured floor.
+_DURATION_RE = re.compile(r"^(\d+)([smhd]?)$")
+_DURATION_MULTIPLIERS: dict[str, int] = {
+    "": 1,
+    "s": 1,
+    "m": 60,
+    "h": 3600,
+    "d": 86400,
+}
+
+
+def _parse_duration_to_seconds(value: str) -> int | None:
+    """Parse ``"1h"`` / ``"30s"`` / ``"7d"`` / ``"3600"`` -> seconds.
+
+    Returns ``None`` for any unrecognized form so the runtime's interval
+    floor takes over instead of honouring a bogus value.
+    """
+    m = _DURATION_RE.match(value.strip())
+    if not m:
+        return None
+    qty = int(m.group(1))
+    unit = m.group(2)
+    multiplier = _DURATION_MULTIPLIERS.get(unit)
+    if multiplier is None:
+        return None
+    return qty * multiplier
+
+
+def _compile_refresh(refresh: list[str]) -> tuple[list[str], int | None]:
+    """Translate the RFC-form ``refresh`` list into the runtime form.
+
+    Returns ``(refresh_list, refresh_interval_seconds | None)``.
+
+    Rules:
+      * Bare ``pocket_open`` / ``manual`` / ``interval`` / ``webhook``
+        pass through.
+      * ``interval:<dur>`` splits into bare ``interval`` plus the parsed
+        seconds. The interval value is the LAST one wins if multiple
+        ``interval:`` entries exist (callers should pass at most one).
+      * ``signal:<event>`` is silently dropped (no runtime equivalent
+        yet — tracked for a future RFC 04 PR).
+      * Anything else is dropped to keep the output shape valid.
+
+    The output ``refresh_list`` preserves declaration order and is
+    deduped (each runtime keyword appears at most once).
+    """
+    out: list[str] = []
+    interval_seconds: int | None = None
+
+    for raw in refresh:
+        if not isinstance(raw, str):
+            continue
+        # Strip optional ``<keyword>:<arg>`` suffix to get the bare form.
+        if ":" in raw:
+            keyword, _, arg = raw.partition(":")
+            keyword = keyword.strip()
+            arg = arg.strip()
+        else:
+            keyword = raw.strip()
+            arg = ""
+
+        if keyword in _UNSUPPORTED_REFRESH_PREFIXES:
+            # Deferred runtime feature (e.g. signal:gmail.inbox.update).
+            continue
+
+        if keyword not in _KNOWN_REFRESH_KEYWORDS:
+            # Drop unknown keywords rather than emit garbage the runtime
+            # would reject.
+            continue
+
+        if keyword == "interval" and arg:
+            parsed = _parse_duration_to_seconds(arg)
+            if parsed is not None:
+                interval_seconds = parsed
+
+        if keyword not in out:
+            out.append(keyword)
+
+    return out, interval_seconds
+
+
+# ---------------------------------------------------------------------------
+# data_sources[] -> sources{}
+# ---------------------------------------------------------------------------
+
+
+def _compile_data_source(src: DataSourceDef) -> dict[str, Any]:
+    """Translate one ``DataSourceDef`` into the runtime per-source dict.
+
+    The ``name`` field is NOT included in the returned dict — it
+    becomes the dict key in the parent ``sources`` block (matching the
+    runtime ``rippleSpec.sources: {name: SourceBinding}`` convention).
+
+    The optional ``transform`` field passes through verbatim. The
+    runtime ``SourceBinding`` ignores unknown keys, so this is safe;
+    when RFC 04 M2 ships the transform registry, the field is already
+    on the seam.
+    """
+    refresh_list, interval_seconds = _compile_refresh(src.refresh)
+    entry: dict[str, Any] = {
+        "method": src.method,
+        "path": src.path,
+        "bind": src.bind,
+        "refresh": refresh_list,
+    }
+    if interval_seconds is not None:
+        entry["refresh_interval_seconds"] = interval_seconds
+    if src.transform is not None:
+        entry["transform"] = src.transform
+    return entry
+
+
+def _compile_sources(template: PocketTemplate) -> dict[str, dict[str, Any]]:
+    """Translate ``template.data_sources[]`` into a ``{name: entry}``
+    dict matching the runtime's ``rippleSpec.sources`` shape."""
+    return {src.name: _compile_data_source(src) for src in template.data_sources}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def compile_template(template: PocketTemplate) -> dict[str, Any]:
+    """Compile a validated ``PocketTemplate`` into a runtime rippleSpec dict.
+
+    This is the OSS-core seam between RFC 03 v2 (the design-time schema)
+    and the runtime executors (RFC 04 source executor, etc.). The output
+    is a plain dict so it can cross the OSS↔EE boundary without dragging
+    EE's Pydantic models into OSS code (forbidden by the import-linter
+    contract) or vice versa.
+
+    In this PR (PR 2b) the compile pass implements ONE translation —
+    ``data_sources[]`` -> ``sources``. Every other top-level field is
+    passed through verbatim so the seam is incrementally useful as PRs
+    2c (CEL action evaluator), 2d (Instinct execution), 2f (triggers),
+    and 2g (permissions) land.
+
+    Args:
+        template: A validated ``PocketTemplate`` instance — typically
+            obtained via ``load_template(slug, strict=True)`` or
+            ``PocketTemplate.model_validate(yaml.safe_load(...))``.
+
+    Returns:
+        A dict of shape::
+
+            {
+                # Translated fields
+                "sources": {
+                    "<name>": {
+                        "method": "GET",
+                        "path": "/items",
+                        "bind": "state.items",
+                        "refresh": ["pocket_open", "manual", "interval"],
+                        "refresh_interval_seconds": 3600,  # optional
+                        "transform": "flatten_leases",     # optional
+                    },
+                    ...
+                },
+                # Passthrough fields — read off the same seam
+                "schema_version": "2",
+                "name": "...",
+                "version": "...",
+                "pattern": "...",
+                "shape": "...",
+                "state": {...},
+                "actions": [...],
+                "agents": [...],
+                "triggers": [...],
+                "outcomes": [...],
+                "connectors": [...],
+                "permissions": {...} | None,
+                "instinct_rules": {...} | None,
+                "kb_scope": "...",
+                "skill_refs": [...],
+                "display_name": "..." | None,
+                "description": "...",
+                "vertical": "...",
+                "screenshots": [...],
+                "icon": "..." | None,
+                "color": "..." | None,
+            }
+
+    The function is pure: no I/O, no input mutation, deterministic
+    output. Calling twice with the same input yields identical dicts.
+    """
+    # Translated field — the only field this PR semantically transforms.
+    sources = _compile_sources(template)
+
+    # Passthrough fields — JSON-mode dump preserves nested Pydantic
+    # models as plain dicts, lists, strings, ints. The fields list mirrors
+    # ``PocketTemplate``'s top-level shape; new top-level RFC fields
+    # need a corresponding entry here.
+    template_dict = template.model_dump(mode="json")
+
+    out: dict[str, Any] = {
+        "schema_version": template_dict["schema_version"],
+        "name": template_dict["name"],
+        "version": template_dict["version"],
+        "pattern": template_dict["pattern"],
+        "vertical": template_dict["vertical"],
+        "shape": template_dict["shape"],
+        "description": template_dict["description"],
+        "state": template_dict["state"],
+        "actions": template_dict.get("actions", []),
+        "connectors": template_dict.get("connectors", []),
+        "agents": template_dict.get("agents", []),
+        "triggers": template_dict.get("triggers", []),
+        "outcomes": template_dict.get("outcomes", []),
+        "kb_scope": template_dict.get("kb_scope", "pocket"),
+        "skill_refs": template_dict.get("skill_refs", []),
+        "screenshots": template_dict.get("screenshots", []),
+        "sources": sources,
+    }
+    # Optional fields — emit only if populated so the compile output
+    # stays compact for the agent-authored cases.
+    if template_dict.get("display_name") is not None:
+        out["display_name"] = template_dict["display_name"]
+    if template_dict.get("icon") is not None:
+        out["icon"] = template_dict["icon"]
+    if template_dict.get("color") is not None:
+        out["color"] = template_dict["color"]
+    if template_dict.get("permissions") is not None:
+        out["permissions"] = template_dict["permissions"]
+    if template_dict.get("instinct_rules") is not None:
+        out["instinct_rules"] = template_dict["instinct_rules"]
+
+    return out
+
+
+__all__ = ["compile_template"]

--- a/src/pocketpaw/cli/template.py
+++ b/src/pocketpaw/cli/template.py
@@ -7,14 +7,20 @@
 #                   y/N confirmation prompt (idempotent on v2 input).
 #   * ``diff``    — semantic dict-walked diff between two templates,
 #                   internally promoted to v2 so v1 / v2 compare cleanly.
+# Modified 2026-05-25 (feat/rfc-03-v2-compile): added ``compile <file>``
+# subaction. Prints the runtime-shaped rippleSpec dict that
+# ``compile_template`` produces (JSON by default, YAML under --yaml).
+# Author-facing inspection only — installation is NOT part of this
+# path (that's Bucket C / Registry).
 # Publish / install / upgrade are intentionally NOT here — they belong
 # to the registry PR (Bucket C). Fabric tier:registered + via_link
 # enforcement in lint is deferred to the Fabric integration PR (PR 2g).
 """``pocketpaw template`` — author-side template tooling.
 
-Three sub-subcommands: ``lint``, ``migrate``, ``diff``. Dispatched from
-the top-level argparse parser via ``__main__._handle_early_command`` so
-the template subcommand never pays the agent / settings boot cost.
+Four sub-subcommands: ``lint``, ``migrate``, ``diff``, ``compile``.
+Dispatched from the top-level argparse parser via
+``__main__._handle_early_command`` so the template subcommand never
+pays the agent / settings boot cost.
 
 Imports of ``pocketpaw.bundled_templates`` are lazy — invoking ``--help``
 or any of the unrelated CLI commands must not pull Pydantic, YAML, or
@@ -120,14 +126,15 @@ def run_template_cmd(
     as_json: bool = False,
     yes: bool = False,
     no_backup: bool = False,
+    as_yaml: bool = False,
 ) -> int:
     """Dispatch ``pocketpaw template <subaction>`` to the right handler.
 
     Returns an exit code: 0 on success, 1 on validation / I/O failure,
     2 on usage error (unknown subaction, missing required positional).
     """
-    if subaction not in {"lint", "migrate", "diff"}:
-        msg = f"unknown subcommand {subaction!r}. Expected one of: lint, migrate, diff."
+    if subaction not in {"lint", "migrate", "diff", "compile"}:
+        msg = f"unknown subcommand {subaction!r}. Expected one of: lint, migrate, diff, compile."
         if as_json:
             output_json({"error": msg})
         else:
@@ -150,6 +157,12 @@ def run_template_cmd(
             yes=yes,
             no_backup=no_backup,
         )
+
+    if subaction == "compile":
+        if not file1:
+            _usage_error("pocketpaw template compile <file> [--yaml]", as_json)
+            return 2
+        return _run_compile(Path(file1), as_yaml=as_yaml)
 
     # subaction == "diff"
     if not file1 or not file2:
@@ -524,6 +537,75 @@ def _short(value: Any, limit: int = 60) -> str:
     if len(s) > limit:
         return s[: limit - 3] + "..."
     return s
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: compile
+# ---------------------------------------------------------------------------
+
+
+def _run_compile(path: Path, *, as_yaml: bool) -> int:
+    """Print the runtime-shaped rippleSpec dict the compile pass produces.
+
+    Author-facing inspection only — this command does NOT install or
+    persist anything. The output is what the runtime executors would
+    consume if this template were instantiated (RFC 04 sources block,
+    plus the passthrough fields PRs 2c-2g will translate).
+
+    Steps:
+      1. Read + parse the input (YAML or JSON, by extension).
+      2. Auto-promote v1 input via the loader's ``_promote_v1_to_v2``.
+      3. Validate through the Pydantic chokepoint.
+      4. Compile via ``compile_template``.
+      5. Emit the result as JSON (default) or YAML (--yaml).
+    """
+
+    # Phase 1 — read + parse
+    try:
+        meta = _parse_file(path)
+    except ValueError as exc:
+        print_fail(str(exc))
+        return 1
+
+    # Phase 2 — v1 -> v2 promotion (idempotent on v2 input)
+    from pocketpaw.bundled_templates.loader import _promote_v1_to_v2  # noqa: PLC0415
+
+    merged = _promote_v1_to_v2(meta) if _is_v1(meta) else meta
+
+    # Phase 3 — Pydantic validation
+    try:
+        from pydantic import ValidationError  # noqa: PLC0415
+
+        from pocketpaw.bundled_templates.schema import PocketTemplate  # noqa: PLC0415
+
+        template = PocketTemplate.model_validate(merged)
+    except ValidationError as exc:
+        errors = _format_pydantic_errors(exc)
+        print_fail(f"{path} failed validation:")
+        for e in errors:
+            print(f"    - {e}")
+        return 1
+    except Exception as exc:  # noqa: BLE001 — defensive
+        print_fail(f"unexpected error validating {path}: {exc}")
+        return 1
+
+    # Phase 4 — compile
+    from pocketpaw.bundled_templates.compile import compile_template  # noqa: PLC0415
+
+    try:
+        spec = compile_template(template)
+    except Exception as exc:  # noqa: BLE001 — surface compile failures cleanly
+        print_fail(f"failed to compile {path}: {exc}")
+        return 1
+
+    # Phase 5 — emit
+    if as_yaml:
+        import yaml  # noqa: PLC0415
+
+        sys.stdout.write(yaml.safe_dump(spec, sort_keys=False, default_flow_style=False))
+    else:
+        sys.stdout.write(json.dumps(spec, indent=2, default=str) + "\n")
+    return 0
 
 
 __all__ = ["run_template_cmd"]

--- a/tests/unit/test_cli_template.py
+++ b/tests/unit/test_cli_template.py
@@ -1,6 +1,9 @@
 # tests/unit/test_cli_template.py
 # Created: 2026-05-25 (feat/rfc-03-v2-cli) — RED-first tests for the
 # new ``pocketpaw template`` CLI subcommand (lint / migrate / diff).
+# Modified 2026-05-25 (feat/rfc-03-v2-compile): added tests for the
+# new ``compile`` subaction — JSON (default) + YAML (--yaml) output,
+# end-to-end through the dispatch path, plus argparse wiring sanity.
 # These cover the six contract pillars from RFC 03 v2 "Style and tooling
 # notes":
 #   1. lint on a clean v2 fixture exits 0 and reports schema_version.
@@ -13,6 +16,8 @@
 #      .v1.bak unless --no-backup, and preserves YAML vs JSON format.
 #   6. diff returns a semantic dict-walked diff (+ / - / ~) grouped
 #      under top-level fields, empty for identical inputs.
+#   7. compile emits a runtime-shaped rippleSpec dict to stdout — JSON
+#      by default, YAML under --yaml; round-trips through argparse.
 # All commands also support --json for scripting.
 """Tests for the ``pocketpaw template`` CLI subcommand.
 
@@ -531,3 +536,117 @@ def test_argparse_template_diff_two_files(monkeypatch: pytest.MonkeyPatch) -> No
     assert args.subaction == "diff"
     assert args.file1 == str(_TODO_V2)
     assert args.file2 == str(_KANBAN_V2)
+
+
+# ===========================================================================
+# pocketpaw template compile <file>
+# ===========================================================================
+
+_LEASE_V2_FIXTURE = _FIXTURES_DIR / "lease-renewal-v2.yaml"
+
+
+def test_compile_emits_json_by_default() -> None:
+    """``compile <file>`` prints the runtime-shaped rippleSpec as JSON
+    on stdout. Exit 0 on a clean v2 fixture."""
+    rc, out = _capture(run_template_cmd, subaction="compile", file1=str(_LEASE_V2_FIXTURE))
+    assert rc == 0
+    data = json.loads(out)
+    assert isinstance(data, dict)
+    # data_sources -> sources translation must have happened
+    assert "sources" in data
+    assert set(data["sources"].keys()) == {"expiring_leases", "tenant_responses"}
+    # name passthrough at the top level
+    assert data["name"] == "lease-renewal-v1"
+
+
+def test_compile_yaml_flag_emits_yaml() -> None:
+    """``compile --yaml`` emits YAML instead of JSON. Round-trip via
+    ``yaml.safe_load`` must produce the same dict shape as the JSON
+    output."""
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="compile",
+        file1=str(_LEASE_V2_FIXTURE),
+        as_yaml=True,
+    )
+    assert rc == 0
+    # YAML output should parse cleanly
+    data = yaml.safe_load(out)
+    assert isinstance(data, dict)
+    assert "sources" in data
+    assert set(data["sources"].keys()) == {"expiring_leases", "tenant_responses"}
+
+
+def test_compile_bundled_template_produces_empty_sources() -> None:
+    """The bundled todo template carries no ``data_sources`` — compile
+    must produce ``{"sources": {}}`` and still exit 0."""
+    rc, out = _capture(run_template_cmd, subaction="compile", file1=str(_TODO_V2))
+    assert rc == 0
+    data = json.loads(out)
+    assert data["sources"] == {}
+
+
+def test_compile_invalid_template_exits_one(tmp_path: Path) -> None:
+    """A template with a missing required field cannot be compiled —
+    must fail validation and exit non-zero."""
+    bad = _minimal_v2_dict()
+    del bad["version"]
+    f = _write_yaml(tmp_path / "bad.yaml", bad)
+    rc, out = _capture(run_template_cmd, subaction="compile", file1=str(f))
+    assert rc == 1
+    assert "version" in out.lower() or "error" in out.lower()
+
+
+def test_compile_v1_input_auto_promotes(tmp_path: Path) -> None:
+    """A v1 template on disk is auto-promoted through the loader's
+    ``_promote_v1_to_v2`` translation before compile runs."""
+    v1 = _minimal_v1_dict()
+    f = _write_yaml(tmp_path / "old.yaml", v1)
+    rc, out = _capture(run_template_cmd, subaction="compile", file1=str(f))
+    assert rc == 0, f"v1 compile after promote should pass; got: {out}"
+    data = json.loads(out)
+    # promoted_from_v1 schema_version visible
+    assert data.get("schema_version") == "2"
+
+
+def test_compile_missing_file_exits_one(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.yaml"
+    rc, _out = _capture(run_template_cmd, subaction="compile", file1=str(missing))
+    assert rc != 0
+
+
+def test_compile_requires_file_arg() -> None:
+    rc, _out = _capture(run_template_cmd, subaction="compile", file1=None)
+    assert rc != 0
+
+
+def test_argparse_template_compile_subcommand() -> None:
+    """``pocketpaw template compile <file>`` resolves to the right
+    dispatch."""
+    from pocketpaw.__main__ import _build_parser, _resolve_subargs
+
+    parser = _build_parser()
+    args = parser.parse_args(["template", "compile", str(_TODO_V2)])
+    _resolve_subargs(args)
+    assert args.command == "template"
+    assert args.subaction == "compile"
+    assert getattr(args, "file1", None) == str(_TODO_V2)
+
+
+def test_argparse_template_compile_yaml_flag() -> None:
+    """The ``--yaml`` top-level flag parses and surfaces via
+    ``args.yaml``. Uses ``parse_known_args`` to mirror what the real
+    ``main()`` does — this is what allows
+    ``pocketpaw template compile --yaml <file>`` to work despite ``--yaml``
+    appearing between two positionals."""
+    from pocketpaw.__main__ import _build_parser, _resolve_subargs
+
+    parser = _build_parser()
+    args, unknown = parser.parse_known_args(["template", "compile", "--yaml", str(_TODO_V2)])
+    # Mirror the main()'s unknown-positional folding behaviour
+    if unknown:
+        args.subargs = list(args.subargs or []) + [a for a in unknown if not a.startswith("-")]
+    _resolve_subargs(args)
+    assert args.subaction == "compile"
+    assert args.file1 == str(_TODO_V2)
+    assert getattr(args, "yaml", False) is True

--- a/tests/unit/test_template_compile.py
+++ b/tests/unit/test_template_compile.py
@@ -1,0 +1,393 @@
+# tests/unit/test_template_compile.py
+# Created: 2026-05-25 (feat/rfc-03-v2-compile) — RED-first tests for the
+# new ``pocketpaw.bundled_templates.compile`` module. Covers:
+#   1. ``compile_template`` translates ``data_sources[]`` into a
+#      runtime-shaped ``{"sources": {name: {method, path, bind,
+#      refresh, refresh_interval_seconds?}}}`` dict.
+#   2. The ``name`` field becomes the dict key (matching runtime
+#      ``rippleSpec.sources`` convention) and never appears inside the
+#      per-source value.
+#   3. The compile-time ``refresh`` list translates from the RFC's
+#      colon-suffixed form (``interval:1h``, ``signal:gmail.inbox.update``)
+#      to the runtime's bare-keyword form
+#      (``interval`` + numeric ``refresh_interval_seconds``;
+#      ``signal:*`` is dropped because the runtime has no equivalent
+#      yet — deferred to a future PR).
+#   4. A template with no ``data_sources`` produces ``{"sources": {}}``.
+#   5. Cross-boundary shape compatibility — every compiled source dict
+#      must validate as a runtime ``SourceBinding``. Gated by
+#      ``pytest.importorskip("pocketpaw_ee")`` so the OSS-only install
+#      still runs the rest of the suite.
+#   6. Deferred fields (actions, agents, triggers, permissions,
+#      instinct_rules, connectors, outcomes, data_sources[].transform)
+#      passthrough verbatim into the compile output so downstream PRs
+#      can rely on the seam progressively.
+
+"""Tests for ``pocketpaw.bundled_templates.compile.compile_template``.
+
+These tests pin the OSS→EE seam:
+
+* The OSS-side ``compile_template`` is a pure function from a validated
+  ``PocketTemplate`` (or a v2-shaped dict) to a runtime-shaped
+  ``rippleSpec`` dict.
+* The runtime-side ``SourceBinding`` (which lives in EE under
+  ``pocketpaw_ee.cloud.pockets.source_executor``) MUST be able to
+  validate each compiled per-source dict.
+
+The OSS production code never imports ``pocketpaw_ee``. These tests
+do — but ONLY inside the test function bodies, guarded by
+``pytest.importorskip("pocketpaw_ee")``. This is the same pattern the
+existing ``tests/unit/test_bundled_templates.py`` uses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# RED on import until Phase 2 lands compile.py.
+from pocketpaw.bundled_templates import PocketTemplate
+from pocketpaw.bundled_templates.compile import compile_template
+
+_FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "templates"
+_LEASE_V2_FIXTURE = _FIXTURES_DIR / "lease-renewal-v2.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_fixture(path: Path) -> PocketTemplate:
+    """Parse the lease-renewal fixture into a validated ``PocketTemplate``."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return PocketTemplate.model_validate(data)
+
+
+def _minimal_v2_dict(**overrides: Any) -> dict[str, Any]:
+    """Smallest valid v2 template dict, used as a baseline for tests."""
+    base: dict[str, Any] = {
+        "schema_version": "2",
+        "name": "compile-test",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "productivity",
+        "description": "Minimal template for compile tests.",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "columns": [{"field": "title", "widget": "text"}],
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def _minimal_v2_template(**overrides: Any) -> PocketTemplate:
+    return PocketTemplate.model_validate(_minimal_v2_dict(**overrides))
+
+
+# ---------------------------------------------------------------------------
+# data_sources[] translation
+# ---------------------------------------------------------------------------
+
+
+def test_no_data_sources_yields_empty_sources_block() -> None:
+    """A template with no ``data_sources`` produces ``{"sources": {}}``."""
+    template = _minimal_v2_template()
+    out = compile_template(template)
+    assert isinstance(out, dict)
+    assert out.get("sources") == {}
+
+
+def test_single_data_source_compiles_to_runtime_shape() -> None:
+    """A single source compiles to a dict keyed by name with the four
+    runtime-shape fields (``method, path, bind, refresh``)."""
+    template = _minimal_v2_template(
+        data_sources=[
+            {
+                "name": "my_source",
+                "method": "GET",
+                "path": "/items",
+                "bind": "state.items",
+                # default refresh — exercises the "no transform applied" path
+            }
+        ]
+    )
+    out = compile_template(template)
+    sources = out["sources"]
+    assert "my_source" in sources
+    entry = sources["my_source"]
+    assert entry["method"] == "GET"
+    assert entry["path"] == "/items"
+    assert entry["bind"] == "state.items"
+    # default refresh comes from the schema's default factory
+    assert entry["refresh"] == ["pocket_open", "manual"]
+    # name MUST become the dict key — never appear inside the value
+    assert "name" not in entry
+
+
+def test_lease_renewal_fixture_data_sources_compile() -> None:
+    """The canonical RFC v2 fixture has two ``data_sources`` entries.
+    Compile must produce a sources block with both entries under their
+    declared names. ``interval:1h`` translates to ``"interval"`` plus a
+    3600 ``refresh_interval_seconds`` value. ``signal:gmail.inbox.update``
+    drops because the runtime has no equivalent — deferred to a future PR."""
+    template = _load_fixture(_LEASE_V2_FIXTURE)
+    out = compile_template(template)
+
+    sources = out["sources"]
+    assert set(sources.keys()) == {"expiring_leases", "tenant_responses"}
+
+    # expiring_leases: pocket_open, manual, interval:1h
+    expiring = sources["expiring_leases"]
+    assert expiring["method"] == "GET"
+    assert expiring["path"] == "/leases?expiry_within=90d"
+    assert expiring["bind"] == "state.leases"
+    assert "pocket_open" in expiring["refresh"]
+    assert "manual" in expiring["refresh"]
+    assert "interval" in expiring["refresh"]
+    assert expiring.get("refresh_interval_seconds") == 3600
+    # The colon-suffixed RFC form must NOT leak into the runtime dict
+    assert "interval:1h" not in expiring["refresh"]
+
+    # tenant_responses: pocket_open + signal:gmail.inbox.update -> signal
+    # drops because the runtime has no equivalent yet.
+    tenant = sources["tenant_responses"]
+    assert "pocket_open" in tenant["refresh"]
+    # signal:* dropped per documented deferred-feature behaviour
+    assert not any("signal" in r for r in tenant["refresh"])
+
+
+def test_interval_duration_parses_seconds_minutes_hours() -> None:
+    """Verify the duration parser across the three RFC-supported units."""
+    template = _minimal_v2_template(
+        data_sources=[
+            {
+                "name": "fast",
+                "method": "GET",
+                "path": "/a",
+                "bind": "state.a",
+                "refresh": ["interval:30s"],
+            },
+            {
+                "name": "med",
+                "method": "GET",
+                "path": "/b",
+                "bind": "state.b",
+                "refresh": ["interval:5m"],
+            },
+            {
+                "name": "slow",
+                "method": "GET",
+                "path": "/c",
+                "bind": "state.c",
+                "refresh": ["interval:2h"],
+            },
+        ]
+    )
+    out = compile_template(template)
+    assert out["sources"]["fast"]["refresh_interval_seconds"] == 30
+    assert out["sources"]["med"]["refresh_interval_seconds"] == 300
+    assert out["sources"]["slow"]["refresh_interval_seconds"] == 7200
+
+
+def test_explicit_refresh_pocket_open_manual_only() -> None:
+    """An explicit ``refresh: [pocket_open]`` is passed through as-is —
+    no ``refresh_interval_seconds`` should be set."""
+    template = _minimal_v2_template(
+        data_sources=[
+            {
+                "name": "only_open",
+                "method": "GET",
+                "path": "/x",
+                "bind": "state.x",
+                "refresh": ["pocket_open"],
+            }
+        ]
+    )
+    out = compile_template(template)
+    entry = out["sources"]["only_open"]
+    assert entry["refresh"] == ["pocket_open"]
+    assert "refresh_interval_seconds" not in entry
+
+
+def test_data_source_transform_passes_through() -> None:
+    """``data_sources[].transform`` is declared in the RFC but is RFC 04
+    M2 runtime — it must pass through the compile output verbatim so
+    downstream consumers see it, NOT silently dropped."""
+    template = _minimal_v2_template(
+        data_sources=[
+            {
+                "name": "with_xform",
+                "method": "GET",
+                "path": "/y",
+                "bind": "state.y",
+                "transform": "flatten_leases",
+            }
+        ]
+    )
+    out = compile_template(template)
+    entry = out["sources"]["with_xform"]
+    assert entry.get("transform") == "flatten_leases"
+
+
+# ---------------------------------------------------------------------------
+# Top-level passthrough for deferred fields
+# ---------------------------------------------------------------------------
+
+
+def test_deferred_top_level_fields_passthrough() -> None:
+    """Actions / agents / triggers / permissions / instinct_rules /
+    connectors / outcomes are documented as out-of-scope for PR 2b but
+    they must still flow through the compile output verbatim so PRs
+    2c-2g have something to consume. They're at the top level alongside
+    ``sources``."""
+    template = _load_fixture(_LEASE_V2_FIXTURE)
+    out = compile_template(template)
+    # actions: lease-renewal has 5
+    assert isinstance(out.get("actions"), list)
+    assert len(out["actions"]) == 5
+    # agents: 1 (renewal-drafter)
+    assert isinstance(out.get("agents"), list)
+    assert len(out["agents"]) == 1
+    # triggers: 4 (cron, source_change, temporal, manual)
+    assert isinstance(out.get("triggers"), list)
+    assert len(out["triggers"]) == 4
+    # outcomes: 3
+    assert out.get("outcomes") == ["lease_drafted", "renewal_sent", "renewal_completed"]
+    # connectors: 3
+    assert out.get("connectors") == ["yardi", "gmail", "gcalendar"]
+    # permissions: workspace
+    assert isinstance(out.get("permissions"), dict)
+    assert out["permissions"]["scope"] == "workspace"
+    # instinct_rules: 4 rules
+    assert isinstance(out.get("instinct_rules"), dict)
+    assert len(out["instinct_rules"]["rules"]) == 4
+
+
+def test_top_level_state_passes_through() -> None:
+    """The ``state`` block (Fabric binding) compiles into the top-level
+    of the rippleSpec — UI layer needs it for column/widget rendering."""
+    template = _load_fixture(_LEASE_V2_FIXTURE)
+    out = compile_template(template)
+    state = out.get("state")
+    assert isinstance(state, dict)
+    assert state["entity_type"] == "Lease"
+    assert state["id_field"] == "id"
+    # joined_entities preserved
+    names = [j["name"] for j in state["joined_entities"]]
+    assert "tenant" in names and "property" in names
+
+
+def test_top_level_metadata_passes_through() -> None:
+    """``name``, ``version``, ``display_name``, etc. — the create-side
+    template metadata flows through so install-time tooling can read it
+    off the compile output without re-parsing the template."""
+    template = _load_fixture(_LEASE_V2_FIXTURE)
+    out = compile_template(template)
+    assert out["name"] == "lease-renewal-v1"
+    assert out["version"] == "1.0.0"
+    assert out["pattern"] == "app"
+    assert out["shape"] == "data-grid"
+    assert out["display_name"] == "Lease Renewal"
+    assert out["schema_version"] == "2"
+
+
+# ---------------------------------------------------------------------------
+# Cross-boundary shape compatibility — the critical test.
+#
+# Lazy-imports ``SourceBinding`` from EE INSIDE the test body, guarded
+# by ``pytest.importorskip("pocketpaw_ee")`` so the test is a no-op on
+# the OSS-only install. Production code never imports EE.
+# ---------------------------------------------------------------------------
+
+
+def test_compiled_sources_validate_as_runtime_source_binding() -> None:
+    """For every compiled source dict, the runtime
+    ``SourceBinding.model_validate(dict)`` must succeed. This is the
+    cross-boundary contract test — it proves the compile output is
+    consumable by the runtime executor."""
+    pytest.importorskip("pocketpaw_ee")
+    # Lazy import — never reached on an OSS-only install.
+    from pocketpaw_ee.cloud.pockets.source_executor import SourceBinding
+
+    template = _load_fixture(_LEASE_V2_FIXTURE)
+    out = compile_template(template)
+    sources = out["sources"]
+    assert sources, "fixture has data_sources; compile must produce a non-empty sources block"
+
+    for name, entry in sources.items():
+        # SourceBinding ignores unknown keys (no extra='forbid'), so
+        # ``transform`` and other passthrough keys are tolerated.
+        binding = SourceBinding.model_validate(entry)
+        # Spot-check the round-tripped shape mirrors compile output for
+        # the fields the runtime cares about.
+        assert binding.method == entry["method"], f"method mismatch for {name}"
+        assert binding.path == entry["path"], f"path mismatch for {name}"
+        assert binding.bind == entry["bind"], f"bind mismatch for {name}"
+        # refresh list comparison — runtime preserves order
+        assert list(binding.refresh) == entry["refresh"], f"refresh mismatch for {name}"
+
+
+def test_minimal_template_compiled_source_validates_runtime() -> None:
+    """A hand-built minimal source dict also validates against the
+    runtime ``SourceBinding`` — catches drift between the compile output
+    shape and the runtime's Pydantic field set."""
+    pytest.importorskip("pocketpaw_ee")
+    from pocketpaw_ee.cloud.pockets.source_executor import SourceBinding
+
+    template = _minimal_v2_template(
+        data_sources=[
+            {
+                "name": "trivial",
+                "method": "GET",
+                "path": "/items",
+                "bind": "state.items",
+                "refresh": ["pocket_open", "manual", "interval:10m"],
+            }
+        ]
+    )
+    out = compile_template(template)
+    entry = out["sources"]["trivial"]
+    binding = SourceBinding.model_validate(entry)
+    assert "interval" in binding.refresh
+    assert binding.refresh_interval_seconds == 600
+
+
+# ---------------------------------------------------------------------------
+# Input flexibility — accept either a PocketTemplate or a dict.
+# ---------------------------------------------------------------------------
+
+
+def test_compile_accepts_pocket_template_instance() -> None:
+    """Primary contract — ``compile_template`` accepts a validated
+    ``PocketTemplate`` model instance."""
+    template = _minimal_v2_template()
+    out = compile_template(template)
+    assert isinstance(out, dict)
+
+
+# ---------------------------------------------------------------------------
+# Determinism + purity
+# ---------------------------------------------------------------------------
+
+
+def test_compile_is_pure_no_template_mutation() -> None:
+    """``compile_template`` must not mutate the input PocketTemplate."""
+    template = _load_fixture(_LEASE_V2_FIXTURE)
+    before_dump = template.model_dump(mode="json")
+    compile_template(template)
+    after_dump = template.model_dump(mode="json")
+    assert before_dump == after_dump, "compile_template mutated the input template"
+
+
+def test_compile_is_deterministic() -> None:
+    """Twice-compiled identical inputs produce identical outputs."""
+    template = _load_fixture(_LEASE_V2_FIXTURE)
+    a = compile_template(template)
+    b = compile_template(template)
+    assert a == b


### PR DESCRIPTION
RFC 03 v2 PR 2b: template-to-runtime translation seam (data_sources only).

## Summary

- Adds `pocketpaw.bundled_templates.compile.compile_template(template)`. The OSS-side seam that turns a validated `PocketTemplate` into a runtime-shaped rippleSpec dict. Plain dict output keeps the OSS→EE import boundary clean; the EE-side `SourceBinding.model_validate(...)` consumes it directly.
- Translates `data_sources[]` only. `interval:<dur>` splits into bare `interval` plus parsed `refresh_interval_seconds` (s / m / h / d units). `signal:<event>` drops silently. The runtime has no equivalent yet (tracked for a future RFC 04 PR). Every other top-level field (actions, agents, triggers, permissions, instinct_rules, connectors, outcomes) passes through verbatim so PRs 2c-2g read off the same seam.
- Wires a `template compile <file>` CLI subaction next to lint / migrate / diff. JSON by default, YAML under a new top-level `--yaml` flag. Author-facing inspection only. Never persists.

## RFC compliance

- Implements the `data_sources[]` to `sources{}` translation referenced in RFC 03 v2 §"Integration touchpoints" (line 598): "Each entry compiles into a runtime `sources` block. The executor runs them per the declared refresh policy and patches `state` over A2UI (RFC 06)."
- Honours the locked architectural decision that compile lives OSS-side (cross-boundary verification via `pytest.importorskip("pocketpaw_ee")`, never an OSS→EE production import).
- Keeps the pure-function contract: no I/O, no mutation, deterministic output. Round-tripping twice produces identical dicts.

## Files changed

NEW:
- `src/pocketpaw/bundled_templates/compile.py`, 340 LOC. The `compile_template` public function plus `_compile_refresh`, `_compile_data_source`, `_compile_sources`, `_parse_duration_to_seconds` helpers.
- `tests/unit/test_template_compile.py`, 393 LOC. 14 tests covering the four translation paths, the cross-boundary `SourceBinding` round-trip, deferred-field passthrough, and the purity / determinism contract.

MODIFIED:
- `src/pocketpaw/bundled_templates/__init__.py`. Re-exports `compile_template`.
- `src/pocketpaw/cli/template.py`. Adds the `compile` subaction plus `_run_compile` handler; widens `run_template_cmd` with an `as_yaml` parameter; usage tables updated.
- `src/pocketpaw/__main__.py`. Adds the top-level `--yaml` flag and threads `as_yaml` through the template dispatch. Comment-block changelog updated.
- `tests/unit/test_cli_template.py`. 119 LOC added. 9 new tests covering `compile` JSON output, `--yaml` YAML output, deferred-field passthrough, the v1-auto-promote path, and argparse wiring.

## Test plan

- [ ] `cd <worktree> && uv run pytest tests/unit/test_template_compile.py tests/unit/test_cli_template.py -xvs`. Expected: 52 passed (with `pocketpaw-ee` installed; 2 skipped on an OSS-only install).
- [ ] `cd <worktree> && uv run ruff check src/pocketpaw/bundled_templates/compile.py src/pocketpaw/bundled_templates/__init__.py src/pocketpaw/cli/template.py src/pocketpaw/__main__.py tests/unit/test_template_compile.py tests/unit/test_cli_template.py`. Expected: "All checks passed".
- [ ] `cd <worktree> && uv run ruff format --check src/pocketpaw/bundled_templates/compile.py src/pocketpaw/bundled_templates/__init__.py src/pocketpaw/cli/template.py src/pocketpaw/__main__.py tests/unit/test_template_compile.py tests/unit/test_cli_template.py`. Expected: "6 files already formatted".
- [ ] `cd <worktree> && uv run pocketpaw template compile tests/fixtures/templates/lease-renewal-v2.yaml`. Expected JSON. `sources.expiring_leases.refresh` MUST be `["pocket_open", "manual", "interval"]` with `refresh_interval_seconds: 3600`. `sources.tenant_responses.refresh` MUST be `["pocket_open"]` (the `signal:gmail.inbox.update` is dropped per the documented deferred-runtime behaviour).
- [ ] `cd <worktree> && uv run pocketpaw template compile tests/fixtures/templates/lease-renewal-v2.yaml --yaml`. Expected: YAML round-trip of the same shape.
- [ ] `cd <worktree> && uv run pocketpaw template compile src/pocketpaw/bundled_templates/_bundled/todo-task-tracker/template.pocket.yaml`. Expected: `"sources": {}` (the bundled template has no `data_sources`).

## Stacking

This PR sits 3 levels deep on the RFC 03 stack:

```
dev
 ↓
feat/rfc-03-v2-integration   (CI infrastructure commit + integration target)
 ↓
feat/rfc-03-v2-schema-chokepoint   PR #1225   (Pydantic chokepoint + bundled v1→v2)
 ↓
feat/rfc-03-v2-cli   PR #1229   (template lint / migrate / diff)
 ↓
feat/rfc-03-v2-compile   THIS PR   (data_sources translation + template compile subcommand)
```

PR target initially `feat/rfc-03-v2-cli`. Architect retargets to `feat/rfc-03-v2-integration` (surgical `--onto` rebase) after #1225 and #1229 merge sequentially into integration.

## Out-of-scope (later PRs)

| Field                       | Behaviour today          | Lands in |
|-----------------------------|--------------------------|----------|
| `actions[]`                 | Passthrough              | PR 2c (CEL evaluator), PR 2d (Instinct execution) |
| `agents[]`                  | Passthrough              | Agent-backend wiring PR |
| `triggers[]`                | Passthrough              | PR 2f (`temporal`, `source_change`, `cron`) |
| `permissions`               | Passthrough              | PR 2g (RBAC runtime) |
| `instinct_rules`            | Passthrough              | PR 2d (Instinct execution) |
| `connectors[]`              | Passthrough              | Connector registry resolves at install time |
| `outcomes[]`                | Passthrough              | Meter listens on declared names |
| `data_sources[].transform`  | Per-source passthrough   | RFC 04 M2 transform registry |
| `data_sources[]` `signal:*` | Silently dropped         | Future RFC 04 PR. When the runtime gains a signal trigger, remove `signal` from `_UNSUPPORTED_REFRESH_PREFIXES`. |
