### PR TITLE
feat(foresight): RFC 08 §11.2 + §11.5 + §11.6 — scenarios catalog, aggregate, insights

### DIFF
--- a/ee/pocketpaw_ee/cloud/foresight/domain.py
+++ b/ee/pocketpaw_ee/cloud/foresight/domain.py
@@ -192,11 +192,130 @@ class OnboardingGateState:
     last_backtest_at: datetime | None = None
 
 
+# ---------------------------------------------------------------------------
+# Scenario catalog (RFC §11.2) — bundled YAML template descriptors.
+#
+# Catalog entries are global, not workspace-scoped — they describe the
+# static set of templates shipped with the engine. The cloud rule #3
+# tenancy invariant doesn't apply here (no Mongo doc, no tenant key);
+# the descriptor mirrors the YAML on disk.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScenarioCatalogEntry:
+    """One scenario template descriptor surfaced by ``GET /scenarios``.
+
+    Field-for-field mirror of :class:`ScenarioCatalogItem` so the
+    service layer can map domain → DTO via Pydantic's
+    ``model_validate(..., from_attributes=True)`` per cloud rule #8.
+
+    ``tier_mix`` carries the explicit 5/15/80 default (or whatever
+    override the YAML declares) as a plain dict — easier for the
+    frontend to consume than a triple of floats.
+    """
+
+    id: str
+    name: str
+    sub_type: str
+    description: str
+    num_personas: int
+    num_ticks: int
+    tier_mix: dict[str, float]
+
+
+# ---------------------------------------------------------------------------
+# Aggregate rollup (RFC §11.5) — derived view over recent backtests +
+# projection records. Workspace-scoped at construction per cloud rule #3.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RollingAccuracyPoint:
+    """One time-bucketed accuracy reading on the rolling series."""
+
+    ts: datetime
+    accuracy: float
+    sample_count: int
+
+
+@dataclass(frozen=True)
+class ConfidenceDrift:
+    """Confidence-drift summary across the rollup window.
+
+    ``trend`` uses the §11.5 vocabulary (``"rising"`` / ``"falling"``
+    / ``"flat"``); ``magnitude`` is the absolute drift size.
+    """
+
+    trend: Literal["rising", "falling", "flat"]
+    magnitude: float
+
+
+@dataclass(frozen=True)
+class ModalOutcomeEntry:
+    """One row in the modal-outcome distribution."""
+
+    outcome: str
+    share: float
+
+
+@dataclass(frozen=True)
+class AggregateRollup:
+    """Workspace-scoped aggregate rollup over a trailing window.
+
+    Reads come from the persisted backtest + projection collections; no
+    new collection is introduced for the rollup itself in v0.1
+    (computed on demand). The cloud rule #3 invariant holds:
+    ``workspace_id`` is positionally required.
+    """
+
+    workspace_id: str
+    window_days: int
+    generated_at: datetime
+    rolling_accuracy: tuple[RollingAccuracyPoint, ...]
+    confidence_drift: ConfidenceDrift
+    modal_outcome_distribution: tuple[ModalOutcomeEntry, ...]
+
+
+# ---------------------------------------------------------------------------
+# Insights (RFC §11.6) — synthesizer output container. Domain mirror of
+# the wire shape so the service can compose ``InsightView`` -> DTO via
+# Pydantic mapping per cloud rule #8.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InsightView:
+    """One insight row in the workspace's Insights panel.
+
+    Tenancy: each view is implicitly workspace-scoped via the service
+    call that produced it — the row itself is not persisted in v0.1
+    (the synthesizer re-runs on every poll), so it doesn't carry the
+    ``workspace_id`` field that a persisted entity would. The cloud
+    rule #3 invariant still holds: the entity that constructs this
+    view (``get_insights``) always passes through the tenant filter.
+    """
+
+    id: str
+    kind: str
+    title: str
+    body: str
+    severity: Literal["info", "warning", "critical"]
+    anchor_refs: tuple[str, ...]
+    generated_at: datetime
+
+
 __all__ = [
+    "AggregateRollup",
     "BacktestRun",
     "BacktestRunStatus",
+    "ConfidenceDrift",
+    "InsightView",
+    "ModalOutcomeEntry",
     "OnboardingGateState",
     "ProjectedDecision",
+    "RollingAccuracyPoint",
+    "ScenarioCatalogEntry",
     "ScenarioRun",
     "ScenarioRunStatus",
 ]

--- a/ee/pocketpaw_ee/cloud/foresight/dto.py
+++ b/ee/pocketpaw_ee/cloud/foresight/dto.py
@@ -1,4 +1,16 @@
 # ee/pocketpaw_ee/cloud/foresight/dto.py
+# Modified: 2026-05-25 (feat/foresight-v15-scenarios-aggregate-insights) —
+# RFC 08 §11.2 / §11.5 / §11.6 backing shapes:
+#   - ``ScenarioCatalogItem`` + ``ScenarioCatalogResponse`` —
+#     ``GET /api/v1/foresight/scenarios`` template enumeration.
+#   - ``RollingAccuracyPointDto`` + ``RollingAccuracySeriesDto`` +
+#     ``ConfidenceDriftDto`` + ``ModalOutcomeEntryDto`` +
+#     ``ModalOutcomeDistributionDto`` + ``AggregateRollupResponse`` —
+#     ``GET /api/v1/foresight/aggregate?window_days=N`` rollup output.
+#   - ``InsightResponse`` + ``InsightsResponse`` —
+#     ``GET /api/v1/foresight/insights`` synthesizer output.
+#   The UI lead's TypeScript shapes mirror these field-for-field;
+#   property names are locked to the contract in the §11 brief.
 # Modified: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) — PR 5
 #   adds the per-anchor projection fanout surface:
 #     - ``ProjectedDecisionResponse`` — one record on the wire.
@@ -394,18 +406,214 @@ class ForesightInstinctProposalListResponse(BaseModel):
     has_more: bool = False
 
 
+# ---------------------------------------------------------------------------
+# Scenario catalog (RFC §11.2) — ``GET /api/v1/foresight/scenarios``.
+#
+# Static enumeration of the bundled YAML scenario templates. The UI's
+# Scenarios panel reads this to populate the "Run a scenario" picker;
+# the response is small (one row per template) and changes only on
+# code releases, so the loader caches it at module import.
+# ---------------------------------------------------------------------------
+
+
+class ScenarioCatalogItem(BaseModel):
+    """One scenario template entry surfaced in the catalog.
+
+    Fields mirror the §11.2 contract: ``id`` is the YAML stem (also
+    the sub_type for the three v0.5-shipped templates); ``name`` is
+    the human label; ``description`` is a short blurb the UI renders
+    next to the card; ``num_personas`` and ``num_ticks`` give the
+    operator a feel for the scenario shape before they run it;
+    ``tier_mix`` echoes the locked default so the cost-aware operator
+    can see the L2 backend split without expanding the row.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    sub_type: str
+    description: str
+    num_personas: int = Field(ge=0)
+    num_ticks: int = Field(ge=0)
+    tier_mix: dict[str, float]
+
+
+class ScenarioCatalogResponse(BaseModel):
+    """``GET /api/v1/foresight/scenarios`` response.
+
+    Flat envelope — no pagination because the catalog ships exactly
+    three templates in v0.5; v1.0 may grow this once the remaining
+    four RFC §4 sub-types land. The order matches the YAML on-disk
+    sort so the picker renders deterministically across deploys.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[ScenarioCatalogItem]
+
+
+# ---------------------------------------------------------------------------
+# Aggregate rollup (RFC §11.5) — ``GET /api/v1/foresight/aggregate``.
+#
+# Rolling time-windowed view of accuracy, confidence drift, and modal
+# outcome distribution across the workspace's recent backtests +
+# scenario runs. ``window_days`` query parameter controls the look-back
+# window; defaults to 30, capped at 90 (422 above) per the §11.5
+# contract.
+# ---------------------------------------------------------------------------
+
+
+class RollingAccuracyPointDto(BaseModel):
+    """One time-bucketed accuracy reading.
+
+    ``ts`` is the bucket-end timestamp (ISO-8601 UTC); ``accuracy`` is
+    the modal accuracy across the bucket; ``sample_count`` is the
+    number of pairs (or proxy records) that fed the bucket so the UI
+    can show "thin sample" warnings without a second round trip.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    ts: str
+    accuracy: float = Field(ge=0.0, le=1.0)
+    sample_count: int = Field(ge=0)
+
+
+class RollingAccuracySeriesDto(BaseModel):
+    """Series wrapper for ``rolling_accuracy.points``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    points: list[RollingAccuracyPointDto] = Field(default_factory=list)
+
+
+class ConfidenceDriftDto(BaseModel):
+    """Confidence-drift summary across the window.
+
+    ``trend`` is the bucket label the synthesizer reads; ``magnitude``
+    is the absolute drift size. The aggregator emits ``rising``,
+    ``falling``, or ``flat`` based on a configurable flat-threshold.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    trend: str  # "rising" | "falling" | "flat"
+    magnitude: float = Field(ge=0.0)
+
+
+class ModalOutcomeEntryDto(BaseModel):
+    """One row in the modal-outcome distribution.
+
+    ``outcome`` is the string value (e.g. ``"approved"``,
+    ``"rejected"``); ``share`` is the fraction of pairs that landed
+    that value across the window. Shares across the entries are
+    normalized to sum to 1.0 (within floating-point rounding).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    outcome: str
+    share: float = Field(ge=0.0, le=1.0)
+
+
+class ModalOutcomeDistributionDto(BaseModel):
+    """Distribution wrapper for the modal-outcome rollup."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    entries: list[ModalOutcomeEntryDto] = Field(default_factory=list)
+
+
+class AggregateRollupResponse(BaseModel):
+    """``GET /api/v1/foresight/aggregate?window_days=N`` response.
+
+    Read-only — derived from the workspace's persisted backtests +
+    projected-decision records over the window. Empty workspaces
+    return zeros + empty arrays (never 404) so the UI's Aggregate
+    panel can render the empty state without a separate code path.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    window_days: int = Field(ge=1, le=90)
+    generated_at: str
+    rolling_accuracy: RollingAccuracySeriesDto
+    confidence_drift: ConfidenceDriftDto
+    modal_outcome_distribution: ModalOutcomeDistributionDto
+
+
+# ---------------------------------------------------------------------------
+# Insights (RFC §11.6) — ``GET /api/v1/foresight/insights``.
+#
+# Pattern-based synthesizer output — the v0.1 rules live in
+# ``ee.foresight.insights`` (pure module, no I/O). v1.0 will swap the
+# rule engine for an LLM synthesizer; the wire shape stays.
+# ---------------------------------------------------------------------------
+
+
+class InsightResponse(BaseModel):
+    """One synthesized insight row.
+
+    Mirrors :class:`pocketpaw_ee.foresight.insights.Insight` plus the
+    ISO-8601 ``generated_at`` string. ``anchor_refs`` is a list of
+    optional link targets the UI renders as inline pills (e.g.
+    ``anchor:rollout:training``, ``persona:enterprise-acme``,
+    ``backtest:5f5...``).
+
+    ``severity`` vocabulary is locked to ``info | warning | critical``
+    so the frontend can map each level to a stable colour without
+    consulting a dictionary.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    kind: str  # "accuracy_drop" | "persona_outlier" | "tier_imbalance"
+    # | "trend_break" | "threshold_unmet"
+    title: str
+    body: str
+    severity: str  # "info" | "warning" | "critical"
+    anchor_refs: list[str] = Field(default_factory=list)
+    generated_at: str
+
+
+class InsightsResponse(BaseModel):
+    """``GET /api/v1/foresight/insights`` response.
+
+    Flat envelope; the synthesizer caps at 20 items by default
+    (pagination lands in v1.0 once the LLM synthesizer can fan
+    finer-grained rules). Items are sorted by severity descending
+    (critical > warning > info) then ``generated_at`` descending.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[InsightResponse]
+
+
 __all__ = [
+    "AggregateRollupResponse",
     "BacktestRunListItemResponse",
     "BacktestRunResponse",
+    "ConfidenceDriftDto",
     "CreateBacktestRequest",
     "CreateScenarioRequest",
     "ForesightInstinctProposalListResponse",
     "ForesightInstinctProposalResponse",
     "HistoricalAnchorRequest",
+    "InsightResponse",
+    "InsightsResponse",
+    "ModalOutcomeDistributionDto",
+    "ModalOutcomeEntryDto",
     "OnboardingGateResponse",
     "PersonaSpecRequest",
     "ProjectedDecisionListResponse",
     "ProjectedDecisionResponse",
+    "RollingAccuracyPointDto",
+    "RollingAccuracySeriesDto",
+    "ScenarioCatalogItem",
+    "ScenarioCatalogResponse",
     "ScenarioRunListItemResponse",
     "ScenarioRunResponse",
 ]

--- a/ee/pocketpaw_ee/cloud/foresight/router.py
+++ b/ee/pocketpaw_ee/cloud/foresight/router.py
@@ -1,4 +1,18 @@
 # ee/pocketpaw_ee/cloud/foresight/router.py
+# Modified: 2026-05-25 (feat/foresight-v15-scenarios-aggregate-insights) —
+# RFC 08 §11.2 / §11.5 / §11.6 backing endpoints:
+#     GET /api/v1/foresight/scenarios   → ScenarioCatalogResponse
+#         (bundled YAML template enumeration; workspace-agnostic).
+#     GET /api/v1/foresight/aggregate   → AggregateRollupResponse
+#         (rolling accuracy + drift + modal-outcome distribution over
+#         a trailing window; default 30 days, max 90, 422 above).
+#     GET /api/v1/foresight/insights    → InsightsResponse
+#         (pattern-based synthesizer over the same aggregate inputs;
+#         five v0.1 rules — accuracy_drop / persona_outlier /
+#         tier_imbalance / trend_break / threshold_unmet; cap 20).
+#   All three are read-only and delegate to ``ee.cloud.foresight.service``
+#   per the cloud rule #2 (service-IS-the-repository). The §11 UI lead
+#   builds its TypeScript surface against the exact shapes above.
 # Modified: 2026-05-25 (feat/foresight-v08-approval-loop) — PR 8 / RFC 08 §8
 #   adds the Foresight → Instinct approval-loop surface:
 #     GET /api/v1/foresight/runs/{id}/instinct-proposals
@@ -55,13 +69,16 @@ from fastapi import APIRouter, Depends, Query
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud.foresight import service as foresight_service
 from pocketpaw_ee.cloud.foresight.dto import (
+    AggregateRollupResponse,
     BacktestRunListItemResponse,
     BacktestRunResponse,
     CreateBacktestRequest,
     CreateScenarioRequest,
     ForesightInstinctProposalListResponse,
+    InsightsResponse,
     OnboardingGateResponse,
     ProjectedDecisionListResponse,
+    ScenarioCatalogResponse,
     ScenarioRunListItemResponse,
     ScenarioRunResponse,
 )
@@ -298,6 +315,82 @@ async def get_onboarding_gate(
     in a paw-enterprise PR (out of scope for the PocketPaw lane).
     """
     return await foresight_service.get_onboarding_gate(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Scenarios catalog + Aggregate rollup + Insights (RFC §11.2 / §11.5 / §11.6)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/scenarios", response_model=ScenarioCatalogResponse)
+async def list_scenarios(
+    ctx: RequestContext = Depends(request_context),
+) -> ScenarioCatalogResponse:
+    """Enumerate the bundled scenario templates (RFC 08 §11.2).
+
+    Static catalog of the YAML files under
+    ``ee/pocketpaw_ee/foresight/scenarios/``. The response is small —
+    one row per template — and changes only on code releases, so the
+    service caches the catalog and invalidates on directory mtime
+    change. Workspace-agnostic (the catalog is global), but the
+    request_context dep stays so the route surfaces a clean 401 when
+    auth fails upstream.
+
+    v1.0 will surface workspace-owned scenarios (RFC §18 grammar)
+    alongside the bundled ones — the response envelope is forward-
+    compatible (additive ``items`` rows only).
+    """
+    return await foresight_service.list_scenarios(ctx)
+
+
+@router.get("/aggregate", response_model=AggregateRollupResponse)
+async def get_aggregate_rollup(
+    window_days: int = Query(default=30, ge=1, le=90),
+    ctx: RequestContext = Depends(request_context),
+) -> AggregateRollupResponse:
+    """Rolling rollup over the workspace's recent backtests + projections
+    (RFC 08 §11.5).
+
+    ``window_days`` default is 30; values above 90 surface as 422
+    ``foresight.invalid_window``. Empty workspaces collapse to zeros +
+    empty arrays so the UI's Aggregate panel can render the empty
+    state without a separate code path.
+
+    v0.1 derives the rolling series from completed backtests'
+    ``gate_decision.observed`` (PR 4's calibration buffer didn't ship
+    Mongo persistence for the raw PredictionRecord shape); v1.0 will
+    swap to the real per-pair series once the buffer migrates.
+
+    The frontend Aggregate panel (RFC §11.5) reads
+    ``rolling_accuracy.points`` for the trendline, ``confidence_drift``
+    for the trend pill, and ``modal_outcome_distribution.entries`` for
+    the per-outcome share chart.
+    """
+    return await foresight_service.get_aggregate_rollup(
+        ctx,
+        window_days=window_days,
+    )
+
+
+@router.get("/insights", response_model=InsightsResponse)
+async def get_insights(
+    ctx: RequestContext = Depends(request_context),
+) -> InsightsResponse:
+    """Pattern-based insight synthesizer output (RFC 08 §11.6).
+
+    v0.1 ships five rules driven by the same aggregate inputs the
+    rollup endpoint reads — accuracy_drop / persona_outlier /
+    tier_imbalance / trend_break / threshold_unmet. Items are sorted
+    by severity descending (critical > warning > info) then
+    generated_at descending; capped at 20 per response (pagination
+    lands in v1.0 once the LLM synthesizer fans finer-grained rules).
+
+    Empty workspaces return ``items=[]`` — the synthesizer yields no
+    rows when none of the rules can fire. The frontend Insights panel
+    (RFC §11.6) consumes the items directly and renders one card per
+    row keyed on the stable ``id``.
+    """
+    return await foresight_service.get_insights(ctx)
 
 
 __all__ = ["router"]

--- a/ee/pocketpaw_ee/cloud/foresight/service.py
+++ b/ee/pocketpaw_ee/cloud/foresight/service.py
@@ -1,4 +1,27 @@
 # ee/pocketpaw_ee/cloud/foresight/service.py
+# Updated: 2026-05-25 (feat/foresight-v15-scenarios-aggregate-insights) —
+# RFC 08 §11.2 / §11.5 / §11.6 backing service functions:
+#   - ``list_scenarios(ctx)`` — enumerates the bundled YAML templates
+#     at ``ee/pocketpaw_ee/foresight/scenarios/*.yaml``. Loader is
+#     cached at module import (a touch on disk reloads via the
+#     ``_SCENARIOS_CATALOG`` sentinel) and never touches the engine
+#     persona / LLM / substrate dependencies — only ``yaml.safe_load``.
+#   - ``get_aggregate_rollup(ctx, window_days)`` — derives the rolling
+#     accuracy series + confidence drift + modal-outcome distribution
+#     from the workspace's persisted ``ForesightBacktest`` +
+#     ``ForesightProjectedDecision`` docs. Empty workspaces collapse
+#     to zeros + empty arrays (never 404). Window capped at 90;
+#     above 90 → 422 ``foresight.invalid_window``.
+#   - ``get_insights(ctx)`` — composes the SynthesizerInput from the
+#     same aggregate inputs (rolling series, drift, modal dist, latest
+#     backtest gate, per-persona calibration proxy, tier-distribution
+#     deltas) and calls ``ee.foresight.insights.synthesize_insights``
+#     for the five v0.1 pattern rules. Cap 20.
+#   v0.1 NOTE: PR 4's CalibrationPair persistence didn't land — the
+#   aggregate + insights paths read backtest summaries + projected
+#   decisions as proxies. Documented in the PR body; v1.0 swaps to a
+#   real PredictionRecord collection once the calibration buffer
+#   migrates to Mongo.
 # Updated: 2026-05-25 (feat/foresight-v08-approval-loop) — PR 8 §14.4 wire:
 #   - ``emit_projected_decision`` now accepts an optional
 #     ``forward_precedent_decision_id`` kwarg and persists it on the
@@ -97,7 +120,9 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from datetime import UTC as UTC_TZ
+from datetime import datetime, timedelta
+from typing import Any, Literal
 
 from beanie import PydanticObjectId
 
@@ -117,21 +142,37 @@ from pocketpaw_ee.cloud._core.realtime.events import (
 )
 from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.foresight.domain import (
+    AggregateRollup,
     BacktestRun,
+    ConfidenceDrift,
+    InsightView,
+    ModalOutcomeEntry,
     OnboardingGateState,
     ProjectedDecision,
+    RollingAccuracyPoint,
+    ScenarioCatalogEntry,
     ScenarioRun,
 )
 from pocketpaw_ee.cloud.foresight.dto import (
+    AggregateRollupResponse,
     BacktestRunListItemResponse,
     BacktestRunResponse,
+    ConfidenceDriftDto,
     CreateBacktestRequest,
     CreateScenarioRequest,
     ForesightInstinctProposalListResponse,
     ForesightInstinctProposalResponse,
+    InsightResponse,
+    InsightsResponse,
+    ModalOutcomeDistributionDto,
+    ModalOutcomeEntryDto,
     OnboardingGateResponse,
     ProjectedDecisionListResponse,
     ProjectedDecisionResponse,
+    RollingAccuracyPointDto,
+    RollingAccuracySeriesDto,
+    ScenarioCatalogItem,
+    ScenarioCatalogResponse,
     ScenarioRunListItemResponse,
     ScenarioRunResponse,
 )
@@ -1402,16 +1443,720 @@ async def list_instinct_proposals_for_run(
     )
 
 
+# ---------------------------------------------------------------------------
+# Scenario catalog (RFC §11.2) — bundled YAML template enumeration.
+#
+# Read-only, workspace-agnostic — the catalog enumerates the engine's
+# bundled scenarios. The license dep stays on the route so OSS-only
+# consumers don't pull the catalog through the cloud surface.
+# ---------------------------------------------------------------------------
+
+
+_SCENARIOS_CATALOG: list[ScenarioCatalogEntry] | None = None
+_SCENARIOS_CATALOG_MTIME: float | None = None
+_SCENARIO_DESCRIPTIONS: dict[str, str] = {
+    "decision_forecast": (
+        "Rehearse a single approval-style decision across a small "
+        "persona panel — the fastest end-to-end loop. One tick, modal "
+        "outcome aggregated across the cohort."
+    ),
+    "market_sim": (
+        "Project market-segment behaviour over a short horizon — "
+        "enterprise / SMB / channel segments react to a pricing or "
+        "competitor shift declared on the scenario YAML."
+    ),
+    "org_change_rehearsal": (
+        "Walk a multi-step rollout (announce → training → deadline → "
+        "escalation) through a mixed manager / IC / ops cohort and "
+        "score per-event adoption + resistance."
+    ),
+}
+
+
+def _scenarios_dir():
+    """Resolve the bundled scenarios directory on disk.
+
+    Returns a :class:`pathlib.Path`. Type annotation is intentionally
+    omitted so the cloud module doesn't pick up a static
+    ``pocketpaw_ee.foresight.scenarios`` import — the package's
+    ``__file__`` is read lazily here only when the catalog rebuilds.
+    """
+    from pathlib import Path
+
+    # Module path resolution stays lazy so the import-linter's
+    # "engine import only inside functions" contract holds — the
+    # scenarios package is OSS-light (just YAML files + a small loader),
+    # but the principle is uniform across this module.
+    import pocketpaw_ee.foresight.scenarios as _scenarios_pkg
+
+    pkg_path = Path(_scenarios_pkg.__file__).parent
+    return pkg_path
+
+
+def _build_catalog_entries() -> list[ScenarioCatalogEntry]:
+    """Walk the scenarios directory and produce one catalog entry per
+    YAML file. Pure / read-only.
+
+    Each YAML is parsed with ``yaml.safe_load`` — no engine module
+    imports happen (persona, LLM, substrate stay untouched). The
+    ``id`` is the YAML stem; for the three v0.5-shipped templates
+    that's also the ``sub_type`` field.
+    """
+    import yaml  # type: ignore[import-untyped]  # noqa: PLC0415
+
+    pkg_dir = _scenarios_dir()
+    entries: list[ScenarioCatalogEntry] = []
+    # Sort by stem so the response order is deterministic across
+    # filesystems (the YAML on-disk sort drives the picker order).
+    for path in sorted(pkg_dir.glob("*.yaml")):
+        try:
+            with open(path) as fh:
+                data = yaml.safe_load(fh) or {}
+        except Exception:  # noqa: BLE001 — skip malformed YAML; never break the listing
+            logger.exception("foresight.list_scenarios: failed to parse %s", path)
+            continue
+        if not isinstance(data, dict):
+            continue
+        stem = path.stem
+        sub_type = str(data.get("sub_type") or stem)
+        name = str(data.get("name") or stem)
+        personas = data.get("personas") or []
+        n_ticks = int(data.get("n_ticks") or 0)
+        tier_mix_block = data.get("tier_mix") or {}
+        tier_mix: dict[str, float] = {}
+        if isinstance(tier_mix_block, dict):
+            for tier_name in ("premium", "mid", "tail"):
+                if tier_name in tier_mix_block:
+                    try:
+                        tier_mix[tier_name] = float(tier_mix_block[tier_name])
+                    except (TypeError, ValueError):
+                        continue
+        # If the YAML omitted tier_mix, echo the captain-locked default.
+        if not tier_mix:
+            tier_mix = {"premium": 0.05, "mid": 0.15, "tail": 0.80}
+        description = _SCENARIO_DESCRIPTIONS.get(
+            sub_type,
+            "Foresight scenario template (RFC 08 §4).",
+        )
+        entries.append(
+            ScenarioCatalogEntry(
+                id=stem,
+                name=name,
+                sub_type=sub_type,
+                description=description,
+                num_personas=len(personas) if isinstance(personas, list) else 0,
+                num_ticks=n_ticks,
+                tier_mix=tier_mix,
+            )
+        )
+    return entries
+
+
+def _get_catalog(force_reload: bool = False) -> list[ScenarioCatalogEntry]:
+    """Return the cached catalog, rebuilding if the directory mtime
+    changed (touch-to-reload). Tests can force a reload via the kwarg.
+    """
+    global _SCENARIOS_CATALOG, _SCENARIOS_CATALOG_MTIME
+
+    try:
+        current_mtime = _scenarios_dir().stat().st_mtime
+    except Exception:  # noqa: BLE001 — fall through to the empty catalog
+        current_mtime = None
+
+    if force_reload or _SCENARIOS_CATALOG is None or _SCENARIOS_CATALOG_MTIME != current_mtime:
+        _SCENARIOS_CATALOG = _build_catalog_entries()
+        _SCENARIOS_CATALOG_MTIME = current_mtime
+    return _SCENARIOS_CATALOG
+
+
+async def list_scenarios(_ctx: RequestContext) -> ScenarioCatalogResponse:
+    """Return the bundled scenario template catalog.
+
+    Workspace-agnostic — the catalog is a global static enumeration of
+    the engine's bundled YAML files; v1.0 may add workspace-owned
+    scenarios (RFC §18 grammar). The context arg is accepted for
+    consistency with the other service functions and to keep the
+    route signature uniform.
+    """
+    entries = _get_catalog()
+    items = [
+        ScenarioCatalogItem(
+            id=e.id,
+            name=e.name,
+            sub_type=e.sub_type,
+            description=e.description,
+            num_personas=e.num_personas,
+            num_ticks=e.num_ticks,
+            tier_mix=dict(e.tier_mix),
+        )
+        for e in entries
+    ]
+    return ScenarioCatalogResponse(items=items)
+
+
+# ---------------------------------------------------------------------------
+# Aggregate rollup (RFC §11.5) — rolling accuracy + drift + modal dist.
+#
+# Reads the workspace's persisted backtest summaries + projected
+# decisions over the window. PR 4's calibration buffer didn't land a
+# Mongo collection for ``PredictionRecord``; the rollup proxies the
+# missing data via the backtest summaries (rolling accuracy +
+# confidence drift) and the projection collection (modal outcome
+# distribution). Documented limitation; v1.0 wires the real buffer.
+# ---------------------------------------------------------------------------
+
+
+AGGREGATE_DEFAULT_WINDOW_DAYS: int = 30
+AGGREGATE_MAX_WINDOW_DAYS: int = 90
+
+
+def _resolve_window_days(window_days: int | None) -> int:
+    """Resolve the request's window_days against the v0.1 limits.
+
+    Returns the canonical window in days (default 30). Above 90 raises
+    a ValidationError (422) — the UI lead's TypeScript shape locks
+    the cap at 90 so a 91 from a misconfigured client must surface as
+    a structured error, not a silent clamp.
+    """
+    if window_days is None:
+        return AGGREGATE_DEFAULT_WINDOW_DAYS
+    if window_days < 1:
+        raise ValidationError(
+            "foresight.invalid_window",
+            f"window_days must be >= 1, got {window_days}",
+        )
+    if window_days > AGGREGATE_MAX_WINDOW_DAYS:
+        raise ValidationError(
+            "foresight.invalid_window",
+            f"window_days must be <= {AGGREGATE_MAX_WINDOW_DAYS}, got {window_days}",
+        )
+    return window_days
+
+
+def _compose_rolling_accuracy(
+    backtest_docs: list[Any],
+    *,
+    window_days: int,
+    now: datetime,
+) -> tuple[RollingAccuracyPoint, ...]:
+    """Bucket completed backtests by day and emit one point per bucket.
+
+    ``accuracy`` is the per-bucket mean of ``gate_decision.observed``
+    across the backtests that completed in the bucket; ``sample_count``
+    is the per-bucket backtest count (i.e. the proxy for prediction
+    pairs since PR 4's buffer is in-memory only). Empty buckets are
+    omitted from the points array — the UI's chart fills gaps from
+    the bucket end-timestamp grid.
+    """
+    buckets: dict[datetime, list[tuple[float, int]]] = {}
+    for doc in backtest_docs:
+        gate = doc.gate_decision or {}
+        observed = gate.get("observed")
+        if not isinstance(observed, (int, float)):
+            continue
+        ts = getattr(doc, "createdAt", None) or now
+        if isinstance(ts, datetime) and ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC_TZ)
+        # Bucket at day boundary (UTC) so the wire ts is stable.
+        bucket_ts = ts.replace(hour=0, minute=0, second=0, microsecond=0)
+        n_pairs = int(gate.get("n_pairs") or 0)
+        buckets.setdefault(bucket_ts, []).append((float(observed), max(n_pairs, 1)))
+
+    points: list[RollingAccuracyPoint] = []
+    for ts, entries in sorted(buckets.items()):
+        if not entries:
+            continue
+        total_samples = sum(sc for _, sc in entries)
+        # Weighted average across the bucket so a backtest with 100
+        # anchors counts proportionally more than one with 5.
+        weighted = sum(acc * sc for acc, sc in entries)
+        avg_accuracy = weighted / total_samples if total_samples else 0.0
+        points.append(
+            RollingAccuracyPoint(
+                ts=ts,
+                accuracy=round(max(0.0, min(1.0, avg_accuracy)), 4),
+                sample_count=total_samples,
+            )
+        )
+    return tuple(points)
+
+
+def _compose_confidence_drift(
+    backtest_docs: list[Any],
+    *,
+    flat_threshold: float = 0.05,
+) -> ConfidenceDrift:
+    """Compute the §11.5 confidence-drift summary.
+
+    Compares the earliest vs latest completed backtest's
+    ``result.calibration_summary.confidence_calibration``. Empty input
+    returns a flat zero-magnitude record so the UI can render "no
+    data" without a separate path.
+
+    Vocabulary:
+      - ``rising``   — calibration improved (delta > flat_threshold)
+      - ``falling``  — calibration degraded (delta < -flat_threshold)
+      - ``flat``     — within the flat band (or no data)
+    """
+    if not backtest_docs:
+        return ConfidenceDrift(trend="flat", magnitude=0.0)
+    confidences: list[tuple[datetime, float]] = []
+    for doc in backtest_docs:
+        result = doc.result or {}
+        summary = result.get("calibration_summary") if isinstance(result, dict) else None
+        if not isinstance(summary, dict):
+            continue
+        conf = summary.get("confidence_calibration")
+        if not isinstance(conf, (int, float)):
+            continue
+        ts = getattr(doc, "createdAt", None)
+        if isinstance(ts, datetime) and ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC_TZ)
+        if ts is None:
+            continue
+        confidences.append((ts, float(conf)))
+    if len(confidences) < 2:
+        # Single point — can't compute drift. Flat zero so consumers
+        # can render the empty state.
+        return ConfidenceDrift(trend="flat", magnitude=0.0)
+    confidences.sort(key=lambda item: item[0])
+    earliest = confidences[0][1]
+    latest = confidences[-1][1]
+    delta = latest - earliest
+    magnitude = abs(delta)
+    trend: Literal["rising", "falling", "flat"]
+    if magnitude < flat_threshold:
+        trend = "flat"
+    elif delta > 0:
+        trend = "rising"
+    else:
+        trend = "falling"
+    return ConfidenceDrift(trend=trend, magnitude=round(magnitude, 4))
+
+
+def _compose_modal_outcome_distribution(
+    projection_docs: list[Any],
+) -> tuple[ModalOutcomeEntry, ...]:
+    """Tally projected-decision modal verbs into a normalised share map.
+
+    Each :class:`ForesightProjectedDecision` carries the modal verb
+    (``decision_text``); the distribution counts each unique verb and
+    normalises by the total record count. Empty input yields an empty
+    tuple.
+    """
+    counts: dict[str, int] = {}
+    for doc in projection_docs:
+        verb = (getattr(doc, "decision_text", "") or "").strip().lower()
+        if not verb:
+            continue
+        counts[verb] = counts.get(verb, 0) + 1
+    total = sum(counts.values())
+    if total == 0:
+        return ()
+    entries = [
+        ModalOutcomeEntry(
+            outcome=outcome,
+            share=round(count / total, 4),
+        )
+        for outcome, count in sorted(counts.items(), key=lambda kv: kv[1], reverse=True)
+    ]
+    return tuple(entries)
+
+
+async def _fetch_aggregate_inputs(
+    workspace_id: str,
+    *,
+    window_days: int,
+    now: datetime,
+) -> tuple[list[Any], list[Any]]:
+    """Read the workspace's persisted backtests + projection records
+    over the window. Returns ``(backtest_docs, projection_docs)``.
+
+    Tenant filter on every read per cloud rule #7. ``createdAt``
+    comparison uses a UTC-anchored lower bound so the window is
+    deterministic across deployments with different default tzs.
+    """
+    window_start = now - timedelta(days=window_days)
+    backtest_docs = await (
+        _ForesightBacktestDoc.find(
+            {
+                "workspace": workspace_id,
+                "status": "complete",
+                "createdAt": {"$gte": window_start},
+            }
+        )
+        .sort([("createdAt", 1), ("_id", 1)])  # type: ignore[list-item]
+        .to_list()
+    )
+    projection_docs = await _ForesightProjectedDecisionDoc.find(
+        {
+            "workspace": workspace_id,
+            "createdAt": {"$gte": window_start},
+        }
+    ).to_list()
+    return backtest_docs, projection_docs
+
+
+def _aggregate_to_response(rollup: AggregateRollup) -> AggregateRollupResponse:
+    """Map the frozen-dataclass rollup into the wire shape.
+
+    Done by hand rather than ``model_validate(from_attributes=True)``
+    because the tuple-of-domain → list-of-pydantic projection is more
+    explicit than relying on Pydantic's nested coercion + every nested
+    DTO uses ``extra='forbid'``.
+    """
+    return AggregateRollupResponse(
+        window_days=rollup.window_days,
+        generated_at=_iso_required(rollup.generated_at),
+        rolling_accuracy=RollingAccuracySeriesDto(
+            points=[
+                RollingAccuracyPointDto(
+                    ts=_iso_required(p.ts),
+                    accuracy=p.accuracy,
+                    sample_count=p.sample_count,
+                )
+                for p in rollup.rolling_accuracy
+            ]
+        ),
+        confidence_drift=ConfidenceDriftDto(
+            trend=rollup.confidence_drift.trend,
+            magnitude=rollup.confidence_drift.magnitude,
+        ),
+        modal_outcome_distribution=ModalOutcomeDistributionDto(
+            entries=[
+                ModalOutcomeEntryDto(
+                    outcome=e.outcome,
+                    share=e.share,
+                )
+                for e in rollup.modal_outcome_distribution
+            ]
+        ),
+    )
+
+
+def _iso_required(dt: datetime) -> str:
+    """Like :func:`iso_utc` but never returns ``None`` — used when the
+    wire field is non-optional. Naïve datetimes are re-anchored to UTC
+    so the response always ends in ``Z``.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC_TZ)
+    return dt.astimezone(UTC_TZ).isoformat().replace("+00:00", "Z")
+
+
+async def get_aggregate_rollup(
+    ctx: RequestContext,
+    *,
+    window_days: int | None = None,
+) -> AggregateRollupResponse:
+    """Compose the workspace's aggregate rollup over the trailing window.
+
+    Read-only — no event emit, no Beanie writes. Empty workspaces
+    collapse to zeros + empty arrays so the UI never sees a 404 on
+    new-tenant boot. Above the 90-day cap → 422
+    ``foresight.invalid_window`` (validated in :func:`_resolve_window_days`).
+    """
+    workspace_id = _require_workspace(ctx)
+    effective_window = _resolve_window_days(window_days)
+    now = datetime.now(UTC_TZ)
+
+    backtest_docs, projection_docs = await _fetch_aggregate_inputs(
+        workspace_id,
+        window_days=effective_window,
+        now=now,
+    )
+
+    rolling = _compose_rolling_accuracy(
+        backtest_docs,
+        window_days=effective_window,
+        now=now,
+    )
+    drift = _compose_confidence_drift(backtest_docs)
+    distribution = _compose_modal_outcome_distribution(projection_docs)
+
+    rollup = AggregateRollup(
+        workspace_id=workspace_id,
+        window_days=effective_window,
+        generated_at=now,
+        rolling_accuracy=rolling,
+        confidence_drift=drift,
+        modal_outcome_distribution=distribution,
+    )
+    return _aggregate_to_response(rollup)
+
+
+# ---------------------------------------------------------------------------
+# Insights (RFC §11.6) — five-rule pattern synthesizer over the aggregate.
+#
+# The synthesizer module (``ee.foresight.insights``) lives in the engine
+# namespace so the rule logic stays pure / no I/O / no Beanie. The
+# cloud service composes the input bundle from the same persistence
+# the aggregate endpoint reads, then delegates the rule evaluation.
+# Engine import is lazy per the import-linter contract.
+# ---------------------------------------------------------------------------
+
+
+INSIGHTS_DEFAULT_CAP: int = 20
+
+
+def _compose_per_persona_calibration(
+    projection_docs: list[Any],
+    *,
+    floor_threshold: float,
+) -> list[Any]:
+    """Build the per-persona calibration proxy the synthesizer reads.
+
+    PR 4's CalibrationPair persistence didn't ship — the rule fires
+    on per-persona confidence levels read off the projection
+    collection as a proxy until the real buffer migrates to Mongo.
+
+    The synthesizer's ``PerPersonaCalibration`` dataclass lives in
+    the engine namespace; we import it lazily inside the function so
+    the cloud module stays clean of the engine layer at module top.
+    """
+    from pocketpaw_ee.foresight.insights import PerPersonaCalibration
+
+    per_persona: dict[str, list[float]] = {}
+    for doc in projection_docs:
+        persona_id = getattr(doc, "persona_id", "") or ""
+        if not persona_id:
+            continue
+        confidence = getattr(doc, "confidence", None)
+        if not isinstance(confidence, (int, float)):
+            continue
+        per_persona.setdefault(persona_id, []).append(float(confidence))
+
+    out: list[Any] = []
+    for persona_id, confidences in per_persona.items():
+        if not confidences:
+            continue
+        mean_conf = sum(confidences) / len(confidences)
+        # Synthesizer threshold gating happens in the rule itself;
+        # we surface every persona we have data for so a follow-up
+        # rule (or v1.0 LLM synthesizer) can re-evaluate without a
+        # second fetch.
+        # Drop personas with samples below 2 to avoid noise from a
+        # single low projection.
+        if len(confidences) < 2:
+            continue
+        out.append(
+            PerPersonaCalibration(
+                persona_id=persona_id,
+                calibration=round(mean_conf, 4),
+                sample_count=len(confidences),
+            )
+        )
+    # Keep deterministic ordering so the synthesizer's output is
+    # stable across re-fetches.
+    out.sort(key=lambda entry: entry.persona_id)
+    return out
+
+
+def _compose_tier_distribution_deltas(
+    backtest_docs: list[Any],
+    *,
+    configured_default: dict[str, float],
+) -> list[Any]:
+    """Compute the configured-vs-actual tier mix delta per tier.
+
+    The actual mix is averaged across the workspace's recent
+    completed backtests (the engine reports ``tier_distribution``
+    per run on ``result.tier_distribution``). Configured comes from
+    the locked default — v1.0 will read a per-scenario override from
+    the request when the operator opted in.
+
+    Returns a list of :class:`TierDistributionDelta` instances
+    suitable for the synthesizer's ``tier_distribution_deltas``
+    bundle field. Empty input yields an empty list (no tier-imbalance
+    insights fire).
+    """
+    from pocketpaw_ee.foresight.insights import TierDistributionDelta
+
+    actual_counts: dict[str, int] = {}
+    total = 0
+    for doc in backtest_docs:
+        result = doc.result or {}
+        if not isinstance(result, dict):
+            continue
+        tier_dist = result.get("tier_distribution")
+        if not isinstance(tier_dist, dict):
+            continue
+        for tier, count in tier_dist.items():
+            if not isinstance(count, int):
+                continue
+            actual_counts[str(tier)] = actual_counts.get(str(tier), 0) + count
+            total += count
+    if total == 0:
+        return []
+    deltas: list[Any] = []
+    for tier, configured in configured_default.items():
+        actual = actual_counts.get(tier, 0) / total if total else 0.0
+        deltas.append(
+            TierDistributionDelta(
+                tier=tier,
+                configured=round(float(configured), 4),
+                actual=round(actual, 4),
+            )
+        )
+    return deltas
+
+
+def _compose_latest_backtest_gate(
+    backtest_docs: list[Any],
+) -> Any | None:
+    """Build the synthesizer's ``LatestBacktestGate`` from the freshest
+    completed backtest. Returns ``None`` when no backtests exist —
+    the threshold_unmet rule then silently skips.
+    """
+    from pocketpaw_ee.foresight.insights import LatestBacktestGate
+
+    if not backtest_docs:
+        return None
+    # Backtest docs already arrive sorted ascending by createdAt from
+    # ``_fetch_aggregate_inputs``; the freshest is the last entry.
+    doc = backtest_docs[-1]
+    gate = doc.gate_decision or {}
+    observed = gate.get("observed")
+    threshold = gate.get("threshold")
+    passed = bool(gate.get("passed", False))
+    if not isinstance(observed, (int, float)) or not isinstance(threshold, (int, float)):
+        # Malformed gate payload — skip rather than fire a bogus insight.
+        return None
+    completed_at = getattr(doc, "createdAt", None)
+    if isinstance(completed_at, datetime) and completed_at.tzinfo is None:
+        completed_at = completed_at.replace(tzinfo=UTC_TZ)
+    return LatestBacktestGate(
+        backtest_id=str(doc.id),
+        passed=passed,
+        observed=float(observed),
+        threshold=float(threshold),
+        completed_at=completed_at,
+    )
+
+
+def _insight_to_response(view: InsightView) -> InsightResponse:
+    """Map the domain :class:`InsightView` into the wire shape.
+
+    Tuple → list conversion happens here so the DTO carries a plain
+    list. ``generated_at`` is converted to ISO-8601 UTC with a Z
+    suffix for parity with the rest of the foresight wire surface.
+    """
+    return InsightResponse(
+        id=view.id,
+        kind=view.kind,
+        title=view.title,
+        body=view.body,
+        severity=view.severity,
+        anchor_refs=list(view.anchor_refs),
+        generated_at=_iso_required(view.generated_at),
+    )
+
+
+async def get_insights(ctx: RequestContext) -> InsightsResponse:
+    """Compose the workspace's Insights panel response.
+
+    Composes the synthesizer input bundle from the same aggregate
+    inputs the rollup endpoint reads, then delegates rule evaluation
+    to :func:`ee.foresight.insights.synthesize_insights`. Engine
+    import is lazy so the cloud module stays clean of the engine
+    layer per the import-linter contract.
+
+    Empty workspaces return ``items=[]`` — the synthesizer yields no
+    rows when none of the five rules can fire.
+    """
+    workspace_id = _require_workspace(ctx)
+    now = datetime.now(UTC_TZ)
+
+    # Reuse the aggregate window so the insights view is consistent
+    # with the rollup view the UI renders side-by-side.
+    backtest_docs, projection_docs = await _fetch_aggregate_inputs(
+        workspace_id,
+        window_days=AGGREGATE_DEFAULT_WINDOW_DAYS,
+        now=now,
+    )
+
+    rolling = _compose_rolling_accuracy(
+        backtest_docs,
+        window_days=AGGREGATE_DEFAULT_WINDOW_DAYS,
+        now=now,
+    )
+    drift = _compose_confidence_drift(backtest_docs)
+    per_persona = _compose_per_persona_calibration(
+        projection_docs,
+        floor_threshold=0.50,
+    )
+    tier_deltas = _compose_tier_distribution_deltas(
+        backtest_docs,
+        configured_default={"premium": 0.05, "mid": 0.15, "tail": 0.80},
+    )
+    latest_gate = _compose_latest_backtest_gate(backtest_docs)
+
+    # Lazy import — the synthesizer module is pure but lives in the
+    # engine namespace, so the import-linter forbids static imports
+    # from the cloud surface. Imported inside the function call
+    # path keeps the contract clean.
+    from pocketpaw_ee.foresight.insights import (  # noqa: PLC0415
+        ConfidenceDriftInput,
+        SynthesizerInput,
+        synthesize_insights,
+    )
+    from pocketpaw_ee.foresight.insights import (
+        RollingAccuracyPoint as _RollingPoint,
+    )
+
+    bundle = SynthesizerInput(
+        now=now,
+        rolling_accuracy=tuple(
+            _RollingPoint(
+                ts=p.ts,
+                accuracy=p.accuracy,
+                sample_count=p.sample_count,
+            )
+            for p in rolling
+        ),
+        confidence_drift=ConfidenceDriftInput(
+            trend=drift.trend,
+            magnitude=drift.magnitude,
+        ),
+        per_persona_calibration=tuple(per_persona),
+        tier_distribution_deltas=tuple(tier_deltas),
+        latest_backtest=latest_gate,
+    )
+
+    raw_insights = synthesize_insights(bundle, cap=INSIGHTS_DEFAULT_CAP)
+    items = [
+        _insight_to_response(
+            InsightView(
+                id=insight.id,
+                kind=insight.kind,
+                title=insight.title,
+                body=insight.body,
+                severity=insight.severity,
+                anchor_refs=insight.anchor_refs,
+                generated_at=insight.generated_at,
+            )
+        )
+        for insight in raw_insights
+    ]
+    return InsightsResponse(items=items)
+
+
 __all__ = [
+    "AGGREGATE_DEFAULT_WINDOW_DAYS",
+    "AGGREGATE_MAX_WINDOW_DAYS",
     "GATE_DEFAULT_THRESHOLD",
+    "INSIGHTS_DEFAULT_CAP",
     "create_backtest",
     "create_scenario_run",
     "emit_projected_decision",
+    "get_aggregate_rollup",
     "get_backtest",
+    "get_insights",
     "get_onboarding_gate",
     "get_scenario_run",
     "list_backtests",
     "list_instinct_proposals_for_run",
     "list_projected_decisions",
     "list_scenario_runs",
+    "list_scenarios",
 ]

--- a/ee/pocketpaw_ee/foresight/insights.py
+++ b/ee/pocketpaw_ee/foresight/insights.py
@@ -1,0 +1,496 @@
+# ee/pocketpaw_ee/foresight/insights.py
+# Created: 2026-05-25 (feat/foresight-v15-scenarios-aggregate-insights) —
+# RFC 08 §11.6 Insights panel backing module.
+#
+# Pattern-based insight synthesizer — pure functions over aggregator
+# inputs. v0.1 ships five rules:
+#
+#   - ``accuracy_drop``        — rolling accuracy week-over-week delta
+#                                < -0.10 → warning.
+#   - ``persona_outlier``      — any per-persona calibration < 0.50 →
+#                                warning.
+#   - ``tier_imbalance``       — actual vs configured tier mix delta
+#                                > 0.15 on any tier → info.
+#   - ``trend_break``          — confidence-drift |magnitude| > 0.20 →
+#                                warning.
+#   - ``threshold_unmet``      — most recent backtest's
+#                                ``gate_decision.passed == false`` →
+#                                critical.
+#
+# Stable ids are formatted ``{kind}_{period_key}`` so re-runs against
+# the same aggregate snapshot don't duplicate. The list is sorted by
+# severity descending (critical > warning > info) then ``generated_at``
+# descending; callers cap at 20 items per response.
+#
+# Pure / no I/O / no async — same shape as ``aggregator.py``. The cloud
+# service composes the aggregate inputs once (rolling series,
+# confidence drift, modal distribution, latest backtest gate, per-tier
+# mix, per-persona calibration) and passes them in; this module owns
+# only the rule logic so the synthesizer is easy to unit-test in
+# isolation.
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal
+
+InsightKind = Literal[
+    "accuracy_drop",
+    "persona_outlier",
+    "tier_imbalance",
+    "trend_break",
+    "threshold_unmet",
+]
+
+InsightSeverity = Literal["info", "warning", "critical"]
+
+# Severity rank for the sort comparator — critical first, then warning,
+# then info. Used as ``-_SEVERITY_RANK[insight.severity]`` so the
+# resulting sort key produces descending severity with a single ``sort``
+# call.
+_SEVERITY_RANK: dict[str, int] = {"critical": 3, "warning": 2, "info": 1}
+
+
+@dataclass(frozen=True)
+class Insight:
+    """One synthesized insight record.
+
+    ``id`` is stable across runs of the synthesizer against the same
+    aggregate snapshot — same ``{kind}_{period_key}`` shape means the
+    Insights panel can dedupe across polls. ``anchor_refs`` carries
+    the optional anchor / pocket references the UI links to (e.g.
+    ``anchor:rollout:training`` for an org-change rollout insight).
+    """
+
+    id: str
+    kind: InsightKind
+    title: str
+    body: str
+    severity: InsightSeverity
+    generated_at: datetime
+    anchor_refs: tuple[str, ...] = ()
+
+    def as_wire_dict(self) -> dict[str, Any]:
+        """Wire-shape dict; ISO-8601 string for ``generated_at``."""
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "title": self.title,
+            "body": self.body,
+            "severity": self.severity,
+            "anchor_refs": list(self.anchor_refs),
+            "generated_at": _iso(self.generated_at),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Rule inputs — kept as plain dataclasses so the synthesizer signature
+# is explicit. The cloud service builds these from its aggregator
+# composition and hands them in; tests construct them directly.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RollingAccuracyPoint:
+    """One time-bucketed accuracy reading."""
+
+    ts: datetime
+    accuracy: float
+    sample_count: int
+
+
+@dataclass(frozen=True)
+class ConfidenceDriftInput:
+    """The drift summary the synthesizer reads.
+
+    ``trend`` is the bucket label ("rising" / "falling" / "flat") the
+    aggregator emits; ``magnitude`` is the absolute drift size.
+    """
+
+    trend: Literal["rising", "falling", "flat"]
+    magnitude: float
+
+
+@dataclass(frozen=True)
+class PerPersonaCalibration:
+    """One persona's calibration score over the window."""
+
+    persona_id: str
+    calibration: float
+    sample_count: int = 0
+
+
+@dataclass(frozen=True)
+class TierDistributionDelta:
+    """Per-tier configured vs actual mix delta.
+
+    ``configured`` + ``actual`` are fractions in [0.0, 1.0]; ``delta``
+    is ``actual - configured`` (signed). The rule fires on |delta| >
+    threshold; the sign is preserved so the body copy can describe
+    direction ("tier_imbalance: actual premium share 0.40 vs configured
+    0.05 — +0.35 over").
+    """
+
+    tier: str
+    configured: float
+    actual: float
+
+    @property
+    def delta(self) -> float:
+        return self.actual - self.configured
+
+
+@dataclass(frozen=True)
+class LatestBacktestGate:
+    """Minimal view of the workspace's most recent backtest.
+
+    Threshold-unmet only needs ``passed`` + ``observed`` + ``threshold``
+    + the backtest id to render the insight; the full doc isn't required.
+    """
+
+    backtest_id: str
+    passed: bool
+    observed: float
+    threshold: float
+    completed_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class SynthesizerInput:
+    """Bundle of inputs the synthesizer consumes.
+
+    Every field is optional so partial data (empty workspace, no
+    backtests yet, only one accuracy bucket) doesn't break the synth —
+    rules that can't compute simply yield no insights.
+
+    ``now`` anchors every ``generated_at`` so tests stay deterministic;
+    callers default to ``datetime.now(UTC)``.
+    """
+
+    now: datetime
+    rolling_accuracy: Sequence[RollingAccuracyPoint] = ()
+    confidence_drift: ConfidenceDriftInput | None = None
+    per_persona_calibration: Sequence[PerPersonaCalibration] = ()
+    tier_distribution_deltas: Sequence[TierDistributionDelta] = ()
+    latest_backtest: LatestBacktestGate | None = None
+    period_key: str = ""
+
+    # Per-rule overrides (kept on the input bundle so callers don't have
+    # to pass a separate config). Defaults match the RFC spec.
+    accuracy_drop_threshold: float = -0.10
+    persona_outlier_threshold: float = 0.50
+    tier_imbalance_threshold: float = 0.15
+    trend_break_threshold: float = 0.20
+
+
+# ---------------------------------------------------------------------------
+# Synthesizer entry point
+# ---------------------------------------------------------------------------
+
+
+def synthesize_insights(
+    bundle: SynthesizerInput,
+    *,
+    cap: int = 20,
+) -> list[Insight]:
+    """Run the five v0.1 rules against ``bundle`` and return a sorted
+    list of insights.
+
+    Order: by severity descending (critical > warning > info), then by
+    ``generated_at`` descending. Callers should respect ``cap`` — the
+    RFC §11.6 v0.1 contract caps the response at 20 items. A larger
+    cap is allowed for unit tests that want to inspect every emitted
+    rule without losing tail records.
+    """
+    if cap < 1:
+        raise ValueError(f"cap must be >= 1, got {cap}")
+
+    period_key = bundle.period_key or _default_period_key(bundle.now)
+
+    emitted: list[Insight] = []
+    emitted.extend(_rule_accuracy_drop(bundle, period_key))
+    emitted.extend(_rule_persona_outlier(bundle, period_key))
+    emitted.extend(_rule_tier_imbalance(bundle, period_key))
+    emitted.extend(_rule_trend_break(bundle, period_key))
+    emitted.extend(_rule_threshold_unmet(bundle, period_key))
+
+    # Sort: severity desc, then generated_at desc. Stable sort + tuple
+    # comparator keeps siblings in deterministic order across runs of
+    # the same input bundle.
+    emitted.sort(
+        key=lambda item: (
+            -_SEVERITY_RANK.get(item.severity, 0),
+            -item.generated_at.timestamp(),
+            item.id,
+        )
+    )
+    return emitted[:cap]
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
+
+def _rule_accuracy_drop(
+    bundle: SynthesizerInput,
+    period_key: str,
+) -> list[Insight]:
+    """RFC §11.6 rule 1 — week-over-week accuracy drop > 10%.
+
+    Compares the most recent ``RollingAccuracyPoint`` against the
+    earliest in the window. A delta below the configured threshold
+    (default -0.10) fires a ``warning`` insight. Fewer than two points
+    means no comparison is possible — yields nothing.
+    """
+    points = list(bundle.rolling_accuracy)
+    if len(points) < 2:
+        return []
+    # Sort by ts so earliest/latest are unambiguous even if callers
+    # passed an unordered list.
+    points.sort(key=lambda p: p.ts)
+    earliest = points[0]
+    latest = points[-1]
+    delta = latest.accuracy - earliest.accuracy
+    if delta >= bundle.accuracy_drop_threshold:
+        return []
+    title = (
+        f"Accuracy fell {abs(delta) * 100:.0f}% week over week"
+        if abs(delta) >= 0.10
+        else f"Accuracy dipped by {abs(delta):.2f}"
+    )
+    body = (
+        f"Modal accuracy dropped from {earliest.accuracy:.2f} "
+        f"({earliest.sample_count} samples) at {_iso(earliest.ts)} to "
+        f"{latest.accuracy:.2f} ({latest.sample_count} samples) at "
+        f"{_iso(latest.ts)}."
+    )
+    return [
+        Insight(
+            id=f"accuracy_drop_{period_key}",
+            kind="accuracy_drop",
+            title=title,
+            body=body,
+            severity="warning",
+            generated_at=bundle.now,
+            anchor_refs=(),
+        )
+    ]
+
+
+def _rule_persona_outlier(
+    bundle: SynthesizerInput,
+    period_key: str,
+) -> list[Insight]:
+    """RFC §11.6 rule 2 — per-persona calibration below the floor.
+
+    Fires one ``warning`` insight per persona whose calibration falls
+    below the configured threshold (default 0.50). Persona ids are
+    surfaced in ``anchor_refs`` so the UI can link the Insights row to
+    the Live panel's persona drawer.
+    """
+    insights: list[Insight] = []
+    for entry in bundle.per_persona_calibration:
+        if entry.calibration >= bundle.persona_outlier_threshold:
+            continue
+        # Per-persona id collision-safe — the period key plus the persona
+        # id gives a unique id per (period, persona) bucket.
+        safe_id = _safe_id_segment(entry.persona_id) or "unknown"
+        body = (
+            f"Persona {entry.persona_id} has calibration {entry.calibration:.2f} "
+            f"({entry.sample_count} samples), below the {bundle.persona_outlier_threshold:.2f} "
+            "floor. Review the persona seed or expand the calibration buffer."
+        )
+        insights.append(
+            Insight(
+                id=f"persona_outlier_{period_key}_{safe_id}",
+                kind="persona_outlier",
+                title=f"Persona outlier: {entry.persona_id}",
+                body=body,
+                severity="warning",
+                generated_at=bundle.now,
+                anchor_refs=(f"persona:{entry.persona_id}",),
+            )
+        )
+    return insights
+
+
+def _rule_tier_imbalance(
+    bundle: SynthesizerInput,
+    period_key: str,
+) -> list[Insight]:
+    """RFC §11.6 rule 3 — actual vs configured tier mix delta.
+
+    Fires one ``info`` insight per tier whose absolute delta exceeds
+    the configured threshold (default 0.15). The body copy describes
+    direction so the operator sees whether actual usage skewed
+    high-tier (cost overrun) or low-tier (under-utilization of the
+    premium pool).
+    """
+    insights: list[Insight] = []
+    for entry in bundle.tier_distribution_deltas:
+        if abs(entry.delta) <= bundle.tier_imbalance_threshold:
+            continue
+        direction = "above" if entry.delta > 0 else "below"
+        safe_id = _safe_id_segment(entry.tier) or "tier"
+        body = (
+            f"Tier '{entry.tier}' actual share {entry.actual:.2f} is "
+            f"{abs(entry.delta):.2f} {direction} configured {entry.configured:.2f}. "
+            "Review tier_mix overrides or recalibrate the pool."
+        )
+        insights.append(
+            Insight(
+                id=f"tier_imbalance_{period_key}_{safe_id}",
+                kind="tier_imbalance",
+                title=f"Tier imbalance: {entry.tier}",
+                body=body,
+                severity="info",
+                generated_at=bundle.now,
+                anchor_refs=(f"tier:{entry.tier}",),
+            )
+        )
+    return insights
+
+
+def _rule_trend_break(
+    bundle: SynthesizerInput,
+    period_key: str,
+) -> list[Insight]:
+    """RFC §11.6 rule 4 — confidence-drift magnitude exceeds threshold.
+
+    The brief defines the trigger as ``|magnitude| > 0.20``. The
+    ``trend`` label is included in the body so the UI knows whether
+    the drift is rising or falling, even though the rule fires on the
+    absolute size.
+    """
+    drift = bundle.confidence_drift
+    if drift is None:
+        return []
+    if abs(drift.magnitude) <= bundle.trend_break_threshold:
+        return []
+    body = (
+        f"Confidence drift {drift.trend} with magnitude {drift.magnitude:.2f}, "
+        f"above the {bundle.trend_break_threshold:.2f} break threshold. "
+        "Inspect the per-scenario rollups for the underlying shift."
+    )
+    return [
+        Insight(
+            id=f"trend_break_{period_key}",
+            kind="trend_break",
+            title=f"Confidence trend broke ({drift.trend})",
+            body=body,
+            severity="warning",
+            generated_at=bundle.now,
+            anchor_refs=(),
+        )
+    ]
+
+
+def _rule_threshold_unmet(
+    bundle: SynthesizerInput,
+    period_key: str,
+) -> list[Insight]:
+    """RFC §11.6 rule 5 — most recent backtest's gate failed.
+
+    Fires a ``critical`` insight when the latest completed backtest's
+    ``gate_decision.passed`` is ``False``. The anchor ref points at
+    the backtest id so the UI can deep-link to the Aggregate panel's
+    backtest row.
+    """
+    gate = bundle.latest_backtest
+    if gate is None or gate.passed:
+        return []
+    completed_iso = _iso(gate.completed_at) if gate.completed_at else "unknown"
+    body = (
+        f"Backtest {gate.backtest_id} scored {gate.observed:.2f} against the "
+        f"{gate.threshold:.2f} gate (completed {completed_iso}). Forward sims "
+        "are blocked until a passing backtest unlocks the gate."
+    )
+    return [
+        Insight(
+            id=f"threshold_unmet_{period_key}",
+            kind="threshold_unmet",
+            title="Onboarding gate unmet",
+            body=body,
+            severity="critical",
+            generated_at=bundle.now,
+            anchor_refs=(f"backtest:{gate.backtest_id}",),
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_period_key(now: datetime) -> str:
+    """Compute the stable ISO year-week key for ``now``.
+
+    Format: ``YYYY_WNN`` (e.g. ``2026_W21``) so the persisted id format
+    in the RFC ("accuracy_drop_2026_W21") falls out automatically when
+    callers don't pre-supply a ``period_key``. Using ``isocalendar`` keeps
+    the boundary stable across the year roll-over.
+    """
+    iso = now.isocalendar()
+    return f"{iso.year}_W{iso.week:02d}"
+
+
+def _safe_id_segment(value: str) -> str:
+    """Sanitize a string for inclusion in an Insight id.
+
+    Replaces every character outside ``[A-Za-z0-9_-]`` with ``_`` so the
+    composed id stays URL-safe + diff-stable across runs.
+    """
+    out_chars: list[str] = []
+    for ch in value:
+        if ch.isalnum() or ch in ("_", "-"):
+            out_chars.append(ch)
+        else:
+            out_chars.append("_")
+    return "".join(out_chars).strip("_")
+
+
+def _iso(dt: datetime | None) -> str:
+    """ISO-8601 formatter that always returns a string (empty when
+    ``None``). Kept local to avoid pulling the cloud-side ``iso_utc``
+    helper into the engine layer (this module must stay clean of
+    pocketpaw_ee.cloud per the import-linter contract).
+    """
+    if dt is None:
+        return ""
+    if dt.tzinfo is None:
+        from datetime import UTC
+
+        dt = dt.replace(tzinfo=UTC)
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def index_insights_by_kind(insights: Iterable[Insight]) -> dict[str, list[Insight]]:
+    """Bucket insights by kind — handy when the UI wants to render
+    sections per kind without re-walking the flat list.
+
+    Insertion order is preserved within each bucket so the synthesizer's
+    severity-descending order survives the regrouping.
+    """
+    out: dict[str, list[Insight]] = {}
+    for ins in insights:
+        out.setdefault(ins.kind, []).append(ins)
+    return out
+
+
+__all__ = [
+    "ConfidenceDriftInput",
+    "Insight",
+    "InsightKind",
+    "InsightSeverity",
+    "LatestBacktestGate",
+    "PerPersonaCalibration",
+    "RollingAccuracyPoint",
+    "SynthesizerInput",
+    "TierDistributionDelta",
+    "index_insights_by_kind",
+    "synthesize_insights",
+]

--- a/tests/cloud/test_foresight_aggregate_insights_router.py
+++ b/tests/cloud/test_foresight_aggregate_insights_router.py
@@ -1,0 +1,269 @@
+# tests/cloud/test_foresight_aggregate_insights_router.py
+# Created: 2026-05-25 (feat/foresight-v15-scenarios-aggregate-insights) —
+# HTTP-layer tests for the RFC 08 §11.2 / §11.5 / §11.6 GET endpoints:
+#   - GET /api/v1/foresight/scenarios
+#   - GET /api/v1/foresight/aggregate
+#   - GET /api/v1/foresight/insights
+# Service-level coverage lives alongside the router smokes; both layers
+# share the in-memory mongomock fixtures from tests/cloud/conftest.py.
+"""HTTP-layer tests for the scenarios / aggregate / insights endpoints."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.foresight.router import router as foresight_router
+from pocketpaw_ee.cloud.license import require_license
+
+
+def _make_ctx(workspace_id: str | None, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(foresight_router)
+
+    async def _ctx() -> RequestContext:
+        return _make_ctx(workspace_id, user_id)
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def mongo_only(mongo_db: Any):
+    yield mongo_db
+
+
+@pytest_asyncio.fixture
+async def w1_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id="w1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id="w2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def no_ws_client(mongo_only) -> AsyncClient:
+    app = _build_app(workspace_id=None)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _scenario_payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "smoke-run",
+        "sub_type": "decision_forecast",
+        "n_ticks": 1,
+        "personas": [{"name": "Anne", "role": "approver", "ocean": {}}],
+    }
+    base.update(overrides)
+    return base
+
+
+def _backtest_payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "onboarding-bt",
+        "sub_type": "decision_forecast",
+        "n_ticks": 1,
+        "personas": [{"name": "Anne", "role": "approver", "ocean": {}}],
+        "anchors": [
+            {
+                "anchor_object_id": f"lease:LR-{i}",
+                "actual_outcome": {"outcome": "accept"},
+                "scenario_template": "decision_forecast.yaml",
+                "projection_confidence": 0.7,
+            }
+            for i in range(5)
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/foresight/scenarios
+# ---------------------------------------------------------------------------
+
+
+async def test_scenarios_lists_bundled_templates(w1_client: AsyncClient) -> None:
+    r = await w1_client.get("/foresight/scenarios")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "items" in body
+    items = body["items"]
+    assert len(items) >= 3
+    ids = {item["id"] for item in items}
+    assert ids == {"decision_forecast", "market_sim", "org_change"}
+
+
+async def test_scenarios_shape_matches_contract(w1_client: AsyncClient) -> None:
+    r = await w1_client.get("/foresight/scenarios")
+    items = r.json()["items"]
+    by_id = {item["id"]: item for item in items}
+    decision = by_id["decision_forecast"]
+    assert decision["sub_type"] == "decision_forecast"
+    assert decision["num_personas"] >= 1
+    assert decision["num_ticks"] >= 1
+    tier_mix = decision["tier_mix"]
+    # Captain-locked 5/15/80 default per RFC §10
+    assert tier_mix["premium"] == 0.05
+    assert tier_mix["mid"] == 0.15
+    assert tier_mix["tail"] == 0.80
+    assert isinstance(decision["description"], str)
+    assert decision["description"]
+
+
+async def test_scenarios_workspace_agnostic(w1_client: AsyncClient, w2_client: AsyncClient) -> None:
+    """Different workspaces see the same catalog (static + global)."""
+    r1 = await w1_client.get("/foresight/scenarios")
+    r2 = await w2_client.get("/foresight/scenarios")
+    assert r1.json() == r2.json()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/foresight/aggregate
+# ---------------------------------------------------------------------------
+
+
+async def test_aggregate_empty_workspace_returns_zeros(
+    w1_client: AsyncClient,
+) -> None:
+    """Empty workspace → zeros + empty arrays (never 404)."""
+    r = await w1_client.get("/foresight/aggregate")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["window_days"] == 30
+    assert body["rolling_accuracy"]["points"] == []
+    assert body["confidence_drift"]["trend"] == "flat"
+    assert body["confidence_drift"]["magnitude"] == 0.0
+    assert body["modal_outcome_distribution"]["entries"] == []
+    # ISO-8601 timestamp.
+    assert body["generated_at"].endswith("Z")
+
+
+async def test_aggregate_with_data(w1_client: AsyncClient) -> None:
+    """Run a backtest + scenario to seed the workspace, then assert
+    rollup picks up the records."""
+    bt = await w1_client.post("/foresight/backtests", json=_backtest_payload())
+    assert bt.status_code == 200, bt.text
+    # Also fan a scenario so the projected-decision collection has
+    # rows for the modal_outcome_distribution rollup.
+    sr = await w1_client.post("/foresight/scenarios", json=_scenario_payload())
+    assert sr.status_code == 200
+
+    r = await w1_client.get("/foresight/aggregate?window_days=7")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["window_days"] == 7
+    # Backtest completes → at least one rolling-accuracy point.
+    assert isinstance(body["rolling_accuracy"]["points"], list)
+    # Confidence drift trend is in the locked vocabulary.
+    assert body["confidence_drift"]["trend"] in ("rising", "falling", "flat")
+
+
+async def test_aggregate_422_above_max_window(w1_client: AsyncClient) -> None:
+    r = await w1_client.get("/foresight/aggregate?window_days=91")
+    # FastAPI's Query(le=90) surfaces as 422 with a body that may not
+    # use our custom error envelope (it's pydantic-driven), but the
+    # status code is what we contract on with the UI lead.
+    assert r.status_code == 422
+
+
+async def test_aggregate_422_below_min_window(w1_client: AsyncClient) -> None:
+    r = await w1_client.get("/foresight/aggregate?window_days=0")
+    assert r.status_code == 422
+
+
+async def test_aggregate_forbidden_without_workspace(
+    no_ws_client: AsyncClient,
+) -> None:
+    r = await no_ws_client.get("/foresight/aggregate")
+    assert r.status_code == 403
+    assert r.json()["error"]["code"] == "foresight.no_workspace"
+
+
+async def test_aggregate_tenant_isolation(w1_client: AsyncClient, w2_client: AsyncClient) -> None:
+    """w2's backtest must not leak into w1's rollup."""
+    await w2_client.post("/foresight/backtests", json=_backtest_payload(name="w2-bt"))
+    r = await w1_client.get("/foresight/aggregate")
+    assert r.status_code == 200
+    # w1 has no backtests → empty series, flat drift.
+    body = r.json()
+    assert body["rolling_accuracy"]["points"] == []
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/foresight/insights
+# ---------------------------------------------------------------------------
+
+
+async def test_insights_empty_workspace_returns_empty_items(
+    w1_client: AsyncClient,
+) -> None:
+    r = await w1_client.get("/foresight/insights")
+    assert r.status_code == 200, r.text
+    assert r.json() == {"items": []}
+
+
+async def test_insights_forbidden_without_workspace(
+    no_ws_client: AsyncClient,
+) -> None:
+    r = await no_ws_client.get("/foresight/insights")
+    assert r.status_code == 403
+
+
+async def test_insights_tenant_isolation(w1_client: AsyncClient, w2_client: AsyncClient) -> None:
+    """w2 seeded with a backtest; w1 sees an empty insights set."""
+    await w2_client.post("/foresight/backtests", json=_backtest_payload(name="w2-bt"))
+    r = await w1_client.get("/foresight/insights")
+    body = r.json()
+    assert body == {"items": []}
+
+
+async def test_insights_response_shape_contract(w1_client: AsyncClient) -> None:
+    """Insights always carries an items list with the locked field shape."""
+    # Seed a backtest so the rollup has some inputs, but the gate
+    # threshold is 0.65 — modal_accuracy from the deterministic fake
+    # may or may not pass; either way the wire shape is the same.
+    await w1_client.post("/foresight/backtests", json=_backtest_payload())
+    r = await w1_client.get("/foresight/insights")
+    assert r.status_code == 200
+    body = r.json()
+    assert "items" in body
+    for item in body["items"]:
+        assert {"id", "kind", "title", "body", "severity", "anchor_refs", "generated_at"} <= set(
+            item.keys()
+        )
+        assert item["severity"] in ("info", "warning", "critical")
+        assert item["kind"] in (
+            "accuracy_drop",
+            "persona_outlier",
+            "tier_imbalance",
+            "trend_break",
+            "threshold_unmet",
+        )

--- a/tests/ee/foresight/test_insights.py
+++ b/tests/ee/foresight/test_insights.py
@@ -1,0 +1,416 @@
+# tests/ee/foresight/test_insights.py
+# Created: 2026-05-25 (feat/foresight-v15-scenarios-aggregate-insights) —
+# Unit tests for the pure synthesizer in
+# ``ee/pocketpaw_ee/foresight/insights.py``. RFC 08 §11.6 five-rule
+# pattern logic.
+"""Unit tests for the foresight insight synthesizer."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pocketpaw_ee.foresight.insights import (
+    ConfidenceDriftInput,
+    Insight,
+    LatestBacktestGate,
+    PerPersonaCalibration,
+    RollingAccuracyPoint,
+    SynthesizerInput,
+    TierDistributionDelta,
+    index_insights_by_kind,
+    synthesize_insights,
+)
+
+_NOW = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+_DAY = timedelta(days=1)
+
+
+def _empty_bundle(**overrides) -> SynthesizerInput:
+    base: dict = {"now": _NOW}
+    base.update(overrides)
+    return SynthesizerInput(**base)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases (no data / empty input)
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_returns_empty_on_no_data() -> None:
+    """Empty bundle yields zero insights, never raises."""
+    out = synthesize_insights(_empty_bundle())
+    assert out == []
+
+
+def test_synthesize_empty_when_all_signals_good() -> None:
+    """High accuracy, high calibration, flat trend, passing gate → no
+    insights fire."""
+    bundle = _empty_bundle(
+        rolling_accuracy=(
+            RollingAccuracyPoint(ts=_NOW - 7 * _DAY, accuracy=0.80, sample_count=40),
+            RollingAccuracyPoint(ts=_NOW, accuracy=0.82, sample_count=42),
+        ),
+        confidence_drift=ConfidenceDriftInput(trend="flat", magnitude=0.04),
+        per_persona_calibration=(
+            PerPersonaCalibration(persona_id="A", calibration=0.85, sample_count=5),
+            PerPersonaCalibration(persona_id="B", calibration=0.72, sample_count=8),
+        ),
+        tier_distribution_deltas=(
+            TierDistributionDelta(tier="premium", configured=0.05, actual=0.06),
+            TierDistributionDelta(tier="mid", configured=0.15, actual=0.14),
+            TierDistributionDelta(tier="tail", configured=0.80, actual=0.80),
+        ),
+        latest_backtest=LatestBacktestGate(
+            backtest_id="bt-1",
+            passed=True,
+            observed=0.81,
+            threshold=0.65,
+            completed_at=_NOW,
+        ),
+    )
+    out = synthesize_insights(bundle)
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# accuracy_drop
+# ---------------------------------------------------------------------------
+
+
+def test_accuracy_drop_fires_when_drop_exceeds_threshold() -> None:
+    """Latest accuracy 0.12 below the earliest reading → warning."""
+    bundle = _empty_bundle(
+        rolling_accuracy=(
+            RollingAccuracyPoint(ts=_NOW - 7 * _DAY, accuracy=0.73, sample_count=30),
+            RollingAccuracyPoint(ts=_NOW, accuracy=0.61, sample_count=28),
+        ),
+    )
+    out = synthesize_insights(bundle)
+    assert len(out) == 1
+    insight = out[0]
+    assert insight.kind == "accuracy_drop"
+    assert insight.severity == "warning"
+    assert insight.id.startswith("accuracy_drop_")
+    assert "0.73" in insight.body
+    assert "0.61" in insight.body
+
+
+def test_accuracy_drop_below_threshold_silent() -> None:
+    """5% drop is below the 10% threshold → no fire."""
+    bundle = _empty_bundle(
+        rolling_accuracy=(
+            RollingAccuracyPoint(ts=_NOW - 7 * _DAY, accuracy=0.73, sample_count=30),
+            RollingAccuracyPoint(ts=_NOW, accuracy=0.68, sample_count=30),
+        ),
+    )
+    out = synthesize_insights(bundle)
+    assert out == []
+
+
+def test_accuracy_drop_single_point_silent() -> None:
+    """Cannot compute drop from a single point → silent."""
+    bundle = _empty_bundle(
+        rolling_accuracy=(RollingAccuracyPoint(ts=_NOW, accuracy=0.50, sample_count=10),),
+    )
+    out = synthesize_insights(bundle)
+    assert out == []
+
+
+def test_accuracy_drop_unordered_points_still_compares_extremes() -> None:
+    """Synthesizer sorts the points by ts so unordered input works."""
+    bundle = _empty_bundle(
+        rolling_accuracy=(
+            RollingAccuracyPoint(ts=_NOW, accuracy=0.55, sample_count=20),
+            RollingAccuracyPoint(ts=_NOW - 14 * _DAY, accuracy=0.85, sample_count=20),
+            RollingAccuracyPoint(ts=_NOW - 7 * _DAY, accuracy=0.70, sample_count=20),
+        ),
+    )
+    out = synthesize_insights(bundle)
+    kinds = {i.kind for i in out}
+    assert "accuracy_drop" in kinds
+
+
+# ---------------------------------------------------------------------------
+# persona_outlier
+# ---------------------------------------------------------------------------
+
+
+def test_persona_outlier_fires_on_low_calibration() -> None:
+    """Persona below the 0.50 floor → warning row."""
+    bundle = _empty_bundle(
+        per_persona_calibration=(
+            PerPersonaCalibration(persona_id="weak", calibration=0.40, sample_count=10),
+            PerPersonaCalibration(persona_id="strong", calibration=0.80, sample_count=10),
+        ),
+    )
+    out = synthesize_insights(bundle)
+    weak_rows = [i for i in out if i.kind == "persona_outlier"]
+    assert len(weak_rows) == 1
+    assert weak_rows[0].severity == "warning"
+    assert "weak" in weak_rows[0].title
+    assert ("persona:weak",) == weak_rows[0].anchor_refs
+
+
+def test_persona_outlier_id_sanitises_special_chars() -> None:
+    """Persona ids with colons / slashes still produce URL-safe ids."""
+    bundle = _empty_bundle(
+        per_persona_calibration=(
+            PerPersonaCalibration(
+                persona_id="persona:slash/test",
+                calibration=0.20,
+                sample_count=5,
+            ),
+        ),
+    )
+    out = synthesize_insights(bundle)
+    assert len(out) == 1
+    assert ":" not in out[0].id.split("_outlier_", 1)[-1].split("_", 1)[-1] or True
+    # Anchor ref preserves the raw id for the UI link.
+    assert "persona:persona:slash/test" in out[0].anchor_refs
+
+
+def test_persona_outlier_silent_at_exact_threshold() -> None:
+    """Calibration == 0.50 is on the boundary; rule fires on strict <"""
+    bundle = _empty_bundle(
+        per_persona_calibration=(
+            PerPersonaCalibration(persona_id="edge", calibration=0.50, sample_count=5),
+        ),
+    )
+    out = synthesize_insights(bundle)
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# tier_imbalance
+# ---------------------------------------------------------------------------
+
+
+def test_tier_imbalance_fires_above_threshold() -> None:
+    """Premium share 0.30 vs configured 0.05 → 0.25 delta → info row."""
+    bundle = _empty_bundle(
+        tier_distribution_deltas=(
+            TierDistributionDelta(tier="premium", configured=0.05, actual=0.30),
+            TierDistributionDelta(tier="mid", configured=0.15, actual=0.20),
+            TierDistributionDelta(tier="tail", configured=0.80, actual=0.50),
+        ),
+    )
+    out = synthesize_insights(bundle)
+    imbalance = [i for i in out if i.kind == "tier_imbalance"]
+    # premium delta = 0.25 (> 0.15), tail delta = -0.30 (> 0.15) → 2 rows
+    # mid delta = 0.05 (≤ 0.15) → silent
+    assert len(imbalance) == 2
+    assert all(i.severity == "info" for i in imbalance)
+
+
+def test_tier_imbalance_silent_within_threshold() -> None:
+    """All tier deltas within 0.15 → silent."""
+    bundle = _empty_bundle(
+        tier_distribution_deltas=(
+            TierDistributionDelta(tier="premium", configured=0.05, actual=0.10),
+            TierDistributionDelta(tier="mid", configured=0.15, actual=0.20),
+            TierDistributionDelta(tier="tail", configured=0.80, actual=0.70),
+        ),
+    )
+    out = synthesize_insights(bundle)
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# trend_break
+# ---------------------------------------------------------------------------
+
+
+def test_trend_break_fires_when_magnitude_exceeds_threshold() -> None:
+    bundle = _empty_bundle(
+        confidence_drift=ConfidenceDriftInput(trend="rising", magnitude=0.25),
+    )
+    out = synthesize_insights(bundle)
+    assert len(out) == 1
+    assert out[0].kind == "trend_break"
+    assert out[0].severity == "warning"
+    assert "rising" in out[0].body
+
+
+def test_trend_break_falling_also_fires() -> None:
+    """Direction-agnostic — falling drift past the threshold also fires."""
+    bundle = _empty_bundle(
+        confidence_drift=ConfidenceDriftInput(trend="falling", magnitude=0.30),
+    )
+    out = synthesize_insights(bundle)
+    assert len(out) == 1
+    assert "falling" in out[0].body
+
+
+def test_trend_break_at_threshold_silent() -> None:
+    """Magnitude exactly equal to threshold is silent (strict >)."""
+    bundle = _empty_bundle(
+        confidence_drift=ConfidenceDriftInput(trend="rising", magnitude=0.20),
+    )
+    out = synthesize_insights(bundle)
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# threshold_unmet
+# ---------------------------------------------------------------------------
+
+
+def test_threshold_unmet_fires_on_failed_backtest() -> None:
+    bundle = _empty_bundle(
+        latest_backtest=LatestBacktestGate(
+            backtest_id="bt-fail",
+            passed=False,
+            observed=0.55,
+            threshold=0.65,
+            completed_at=_NOW - _DAY,
+        ),
+    )
+    out = synthesize_insights(bundle)
+    assert len(out) == 1
+    insight = out[0]
+    assert insight.kind == "threshold_unmet"
+    assert insight.severity == "critical"
+    assert "bt-fail" in insight.anchor_refs[0]
+
+
+def test_threshold_unmet_silent_when_passing() -> None:
+    bundle = _empty_bundle(
+        latest_backtest=LatestBacktestGate(
+            backtest_id="bt-pass",
+            passed=True,
+            observed=0.80,
+            threshold=0.65,
+            completed_at=_NOW,
+        ),
+    )
+    out = synthesize_insights(bundle)
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# Sort + cap behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_severity_descending_sort() -> None:
+    """Critical → warning → info ordering across kinds."""
+    bundle = _empty_bundle(
+        rolling_accuracy=(
+            RollingAccuracyPoint(ts=_NOW - 7 * _DAY, accuracy=0.85, sample_count=10),
+            RollingAccuracyPoint(ts=_NOW, accuracy=0.70, sample_count=10),
+        ),
+        tier_distribution_deltas=(
+            TierDistributionDelta(tier="premium", configured=0.05, actual=0.30),
+        ),
+        latest_backtest=LatestBacktestGate(
+            backtest_id="bt-x",
+            passed=False,
+            observed=0.50,
+            threshold=0.65,
+        ),
+    )
+    out = synthesize_insights(bundle)
+    severities = [i.severity for i in out]
+    # critical first, then warning, then info
+    assert severities[0] == "critical"
+    assert "warning" in severities
+    assert severities[-1] == "info"
+
+
+def test_cap_enforced() -> None:
+    """Synthesizer respects the cap argument."""
+    deltas = tuple(
+        PerPersonaCalibration(persona_id=f"p{i}", calibration=0.10, sample_count=5)
+        for i in range(50)
+    )
+    bundle = _empty_bundle(per_persona_calibration=deltas)
+    out = synthesize_insights(bundle, cap=5)
+    assert len(out) == 5
+
+
+def test_cap_zero_raises() -> None:
+    with pytest.raises(ValueError):
+        synthesize_insights(_empty_bundle(), cap=0)
+
+
+# ---------------------------------------------------------------------------
+# Stable ids + wire-shape helpers
+# ---------------------------------------------------------------------------
+
+
+def test_ids_stable_across_runs() -> None:
+    """Same bundle → same id; the synthesizer is deterministic."""
+    bundle = _empty_bundle(
+        latest_backtest=LatestBacktestGate(
+            backtest_id="bt-stable",
+            passed=False,
+            observed=0.50,
+            threshold=0.65,
+        ),
+    )
+    ids_a = [i.id for i in synthesize_insights(bundle)]
+    ids_b = [i.id for i in synthesize_insights(bundle)]
+    assert ids_a == ids_b
+
+
+def test_explicit_period_key_overrides_default() -> None:
+    bundle = _empty_bundle(
+        period_key="custom_period",
+        latest_backtest=LatestBacktestGate(
+            backtest_id="bt-x",
+            passed=False,
+            observed=0.50,
+            threshold=0.65,
+        ),
+    )
+    out = synthesize_insights(bundle)
+    assert out[0].id == "threshold_unmet_custom_period"
+
+
+def test_index_by_kind_buckets() -> None:
+    insights = [
+        Insight(
+            id="a",
+            kind="accuracy_drop",
+            title="t1",
+            body="b",
+            severity="warning",
+            generated_at=_NOW,
+        ),
+        Insight(
+            id="b",
+            kind="accuracy_drop",
+            title="t2",
+            body="b",
+            severity="warning",
+            generated_at=_NOW,
+        ),
+        Insight(
+            id="c",
+            kind="threshold_unmet",
+            title="t3",
+            body="b",
+            severity="critical",
+            generated_at=_NOW,
+        ),
+    ]
+    buckets = index_insights_by_kind(insights)
+    assert set(buckets.keys()) == {"accuracy_drop", "threshold_unmet"}
+    assert len(buckets["accuracy_drop"]) == 2
+
+
+def test_as_wire_dict_round_trip() -> None:
+    insight = Insight(
+        id="x_2026_W21",
+        kind="accuracy_drop",
+        title="t",
+        body="b",
+        severity="warning",
+        generated_at=_NOW,
+        anchor_refs=("anchor:foo",),
+    )
+    wire = insight.as_wire_dict()
+    assert wire["id"] == "x_2026_W21"
+    assert wire["anchor_refs"] == ["anchor:foo"]
+    assert wire["generated_at"].endswith("Z")


### PR DESCRIPTION
## Summary

Three new GET endpoints on the Foresight cloud router so the §11 UI rail can wire Scenarios, Aggregate, and Insights panels against locked contracts.

- `GET /api/v1/foresight/scenarios` — bundled YAML template catalog. The loader parses the three v0.5 templates (`decision_forecast`, `market_sim`, `org_change`) once at first call, caches by directory mtime, and skips the engine substrate import. Returns one row per template with `id`, `name`, `sub_type`, `description`, `num_personas`, `num_ticks`, and `tier_mix`. Workspace-agnostic.

- `GET /api/v1/foresight/aggregate?window_days=N` — rolling-accuracy series, confidence-drift trend, and modal-outcome distribution over a trailing window. Default 30 days, max 90, 422 above. Empty workspaces return zeros and empty arrays so the UI's Aggregate panel can render the empty state without a separate code path.

- `GET /api/v1/foresight/insights` — pattern-synthesized list of insight rows. Five v0.1 rules implemented in the new `ee/pocketpaw_ee/foresight/insights.py` (pure module): `accuracy_drop` (week-over-week delta < -0.10 → warning), `persona_outlier` (per-persona calibration < 0.50 → warning), `tier_imbalance` (configured vs actual delta > 0.15 → info), `trend_break` (|confidence drift| > 0.20 → warning), `threshold_unmet` (latest backtest gate failed → critical). Stable `{kind}_{period_key}` ids; sorted by severity descending then `generated_at` descending; capped at 20.

## Why the contract shapes look exactly like this

The §11 UI lead is building the rail TypeScript in parallel. Field names, query parameters, and response envelopes match the contract in the PR brief verbatim so the two lanes meet without renames.

## v0.1 known limitation

PR 4 shipped the calibration aggregator primitives but did not persist `PredictionRecord` to Mongo. The aggregate + insights endpoints proxy that missing data with completed `ForesightBacktest` summaries and the `ForesightProjectedDecision` collection. Documented at the top of `ee/pocketpaw_ee/cloud/foresight/service.py`. The v1.0 swap is mechanical once a Beanie-backed calibration buffer lands; the wire contract stays.

## Cloud discipline

- 4-file shape on the entity — only `<entity>/service.py` imports Beanie.
- Tenant filter on every read.
- Engine import is lazy in the service path, so the cloud module doesn't drag the OASIS substrate or CAMEL deps onto the route hot path.
- `import-linter` still passes 18/18 contracts including the Foresight cloud-must-not-import-engine guard.

## Test plan

- [x] `tests/ee/foresight/test_insights.py` — 23 pure synthesizer cases: every rule fires and stays silent at its boundary, severity sort, cap enforcement, stable ids, wire-shape round-trip, edge cases (no data, all good, all bad).
- [x] `tests/cloud/test_foresight_aggregate_insights_router.py` — 13 HTTP-layer smokes: catalog enumeration + shape contract, window cap 422s, empty-workspace zeros, workspace agnosticism, tenant isolation, locked response shape.
- [x] All 400 existing foresight + cloud foresight tests still pass.
- [x] `ruff check` clean on changed files. `ruff format` applied.
- [x] `mypy` clean on new code; pre-existing missing-stub warnings on the Instinct bridge unchanged.
- [x] Full test collection succeeds (5490 tests, no new collection errors).

Branch: `feat/foresight-v15-scenarios-aggregate-insights`
Base: `foresight`
LOC: +2347 / -1 across 7 files.