### PR TITLE
Calendar bug fix

### DIFF
--- a/ee/pocketpaw_ee/calendar/conflicts.py
+++ b/ee/pocketpaw_ee/calendar/conflicts.py
@@ -12,8 +12,19 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from pocketpaw_ee.calendar.domain import Attendee, Event, Recurrence
 from pocketpaw_ee.calendar.models import _EventDoc
+
+
+def _utc_if_naive(dt: datetime) -> datetime:
+    """Ensure a datetime is timezone-aware (UTC). MongoDB stores datetimes
+    as UTC but Beanie returns them as naive. Without this, Pydantic
+    serializes naive datetimes without a timezone suffix in the JSON
+    response, and the frontend cannot correctly convert back to local
+    time."""
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt
 
 
 def _doc_to_event(doc: _EventDoc) -> Event:
@@ -26,8 +37,8 @@ def _doc_to_event(doc: _EventDoc) -> Event:
         calendar_id=doc.calendar_id,
         title=doc.title,
         description=doc.description or "",
-        starts_at=doc.starts_at,
-        ends_at=doc.ends_at,
+        starts_at=_utc_if_naive(doc.starts_at),
+        ends_at=_utc_if_naive(doc.ends_at),
         timezone=doc.timezone,
         # H-NEW-1: hydrate the creator field so check_event_modify works
         # on Events returned by conflict scans (and any other domain
@@ -39,8 +50,8 @@ def _doc_to_event(doc: _EventDoc) -> Event:
         fabric_object_id=doc.fabric_object_id,
         source_connector=doc.source_connector,
         source_external_id=doc.source_external_id,
-        created_at=doc.created_at,
-        updated_at=doc.updated_at,
+        created_at=_utc_if_naive(doc.created_at),
+        updated_at=_utc_if_naive(doc.updated_at),
     )
 
 

--- a/ee/pocketpaw_ee/calendar/service.py
+++ b/ee/pocketpaw_ee/calendar/service.py
@@ -72,6 +72,7 @@ from pocketpaw_ee.calendar.events import (
 )
 from pocketpaw_ee.calendar.freebusy import compute_freebusy
 from pocketpaw_ee.calendar.models import _CalendarDoc, _EventDoc
+from pocketpaw_ee.calendar.recurrence import expand_recurrence
 from pocketpaw_ee.cloud.shared.errors import NotFound, ValidationError
 from pocketpaw_ee.cloud.shared.events import event_bus
 
@@ -369,12 +370,19 @@ async def list_events(ctx: RequestContext, body: ListEventsRequest) -> EventList
     query: dict = {
         "workspace": ctx.workspace_id,
         "starts_at": {"$lt": body.starts_before},
-        "ends_at": {"$gt": body.starts_after},
+        "$or": [
+            {"ends_at": {"$gt": body.starts_after}},
+            {"recurrence": {"$ne": None}},
+        ],
     }
     if body.calendar_id is not None:
         query["calendar_id"] = body.calendar_id
 
-    docs = await _EventDoc.find(query).limit(body.limit).to_list()
+    # Use the max allowed limit on the raw query so recurring events are
+    # not silently dropped before expansion. The final result is capped
+    # to body.limit after expansion and sort below.
+    query_limit = max(body.limit, 500)
+    docs = await _EventDoc.find(query).limit(query_limit).to_list()
 
     # Resolve the set of unique calendar_ids in the result and check
     # read access in one pass. Cache per-calendar decisions so the
@@ -391,8 +399,24 @@ async def list_events(ctx: RequestContext, body: ListEventsRequest) -> EventList
         if accessible[cid]:
             visible_docs.append(d)
 
-    events = [_doc_to_response(d) for d in visible_docs]
-    return EventListResponse(events=events, total=len(events))
+    # Map to domain events and expand recurrences into the query window.
+    # The request boundaries are timezone-naive (FastAPI default). Stamp
+    # them as UTC so they compare with the timezone-aware datetimes
+    # produced by _doc_to_event.
+    range_start = body.starts_after.replace(tzinfo=UTC)
+    range_end = body.starts_before.replace(tzinfo=UTC)
+    expanded: list[Event] = []
+    for d in visible_docs:
+        event = _doc_to_event(d)
+        if event.recurrence is not None:
+            expanded.extend(expand_recurrence(event, range_start, range_end))
+        elif event.ends_at > range_start and event.starts_at < range_end:
+            expanded.append(event)
+
+    # Sort by starts_at and cap to the requested limit.
+    expanded.sort(key=lambda e: e.starts_at)
+    events = [_event_to_response(e) for e in expanded[: body.limit]]
+    return EventListResponse(events=events, total=len(expanded))
 
 
 async def get_freebusy(ctx: RequestContext, body: FreeBusyRequest) -> FreeBusyResponse:

--- a/ee/pocketpaw_ee/calendar/service.py
+++ b/ee/pocketpaw_ee/calendar/service.py
@@ -285,8 +285,8 @@ async def update_event(
     if body.attendees is not None:
         doc.attendees = [a.model_dump() for a in body.attendees]
         changed_fields.append("attendees")
-    if body.recurrence is not None:
-        doc.recurrence = body.recurrence.model_dump()
+    if "recurrence" in body.model_fields_set:
+        doc.recurrence = body.recurrence.model_dump() if body.recurrence is not None else None
         changed_fields.append("recurrence")
 
     # Cross-field validation after the partial merge — starts_at < ends_at.

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -7,6 +7,7 @@ remains registered in ``get_all_documents()`` for Beanie init.
 
 from __future__ import annotations
 
+from pocketpaw_ee.calendar.models import _CalendarDoc, _EventDoc
 from pocketpaw_ee.cloud.models.agent import Agent, AgentConfig
 from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
 from pocketpaw_ee.cloud.models.comment import Comment, CommentAuthor, CommentTarget
@@ -112,6 +113,8 @@ def get_all_documents():
         Project,
         PlanSession,
         ChatRunDoc,
+        _CalendarDoc,
+        _EventDoc,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/shared/db.py
+++ b/ee/pocketpaw_ee/cloud/shared/db.py
@@ -16,6 +16,7 @@ async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterpri
     """Initialize Beanie ODM with all document models."""
     global _client
 
+    from pocketpaw_ee.calendar.models import _CalendarDoc, _EventDoc
     from pocketpaw_ee.cloud.memory.bootstrap import register_default_backend
     from pocketpaw_ee.cloud.memory.documents import MemoryFactDoc
     from pocketpaw_ee.cloud.models import ALL_DOCUMENTS
@@ -26,7 +27,7 @@ async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterpri
 
     # Memory-facts doc lives in its own package to avoid circular imports with
     # ee.cloud.models; register it alongside the core documents here.
-    documents = [*ALL_DOCUMENTS, MemoryFactDoc]
+    documents = [*ALL_DOCUMENTS, MemoryFactDoc, _CalendarDoc, _EventDoc]
     await init_beanie(database=db, document_models=documents)
     logger.info("Cloud DB initialized: %s (%d models)", db_name, len(documents))
 

--- a/ee/pocketpaw_ee/cloud/shared/db.py
+++ b/ee/pocketpaw_ee/cloud/shared/db.py
@@ -16,7 +16,6 @@ async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterpri
     """Initialize Beanie ODM with all document models."""
     global _client
 
-    from pocketpaw_ee.calendar.models import _CalendarDoc, _EventDoc
     from pocketpaw_ee.cloud.memory.bootstrap import register_default_backend
     from pocketpaw_ee.cloud.memory.documents import MemoryFactDoc
     from pocketpaw_ee.cloud.models import ALL_DOCUMENTS
@@ -27,7 +26,7 @@ async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterpri
 
     # Memory-facts doc lives in its own package to avoid circular imports with
     # ee.cloud.models; register it alongside the core documents here.
-    documents = [*ALL_DOCUMENTS, MemoryFactDoc, _CalendarDoc, _EventDoc]
+    documents = [*ALL_DOCUMENTS, MemoryFactDoc]
     await init_beanie(database=db, document_models=documents)
     logger.info("Cloud DB initialized: %s (%d models)", db_name, len(documents))
 

--- a/tests/ee/calendar/test_service.py
+++ b/tests/ee/calendar/test_service.py
@@ -107,6 +107,12 @@ class _FakeStore:
 
 def _dict_match(doc: _FakeDoc, filt: dict[str, Any]) -> bool:
     for key, value in filt.items():
+        # Handle $or — at least one sub-condition must match.
+        if key == "$or":
+            if not any(_dict_match(doc, sub) for sub in value):
+                return False
+            continue
+
         actual = getattr(doc, key, None)
         if isinstance(value, dict):
             for op, operand in value.items():
@@ -114,6 +120,15 @@ def _dict_match(doc: _FakeDoc, filt: dict[str, Any]) -> bool:
                     return False
                 elif op == "$gt" and not (actual is not None and actual > operand):
                     return False
+                elif op == "$ne":
+                    # MongoDB $ne: null matches when the field value is not
+                    # null (field is present with a truthy value).
+                    if operand is None:
+                        if actual is None:
+                            return False
+                    else:
+                        if actual == operand:
+                            return False
                 elif op == "$in":
                     # only used for attendees.email which is nested — caller
                     # never asks for that path in service-level tests.


### PR DESCRIPTION
###  Weekly/daily recurring events don't appear in list views
   - **Root cause**: The `list_events` query didn't include recurring events in its result set. It filtered by `ends_at > range_start` which
   excludes events extended by recurrence. Also missing `$or` for recurrence expansion.
   - **Fix**: Added `$or: [{ends_at: {$gt: range_start}}, {recurrence: {$ne: null}}]` so recurring masters are always fetched. Added recurrence
   expansion loop after policy filter using `expand_recurrence()`.

   ### Events stored with timezone-naive datetimes (no UTC suffix)
   - **Root cause**: MongoDB stores datetimes as UTC but Beanie returns them as naive. Pydantic serializes naive datetimes without `Z` or
   `+00:00` suffix, so the frontend can't convert back to local time.
   - **Fix**: Added `_utc_if_naive()` helper that stamps `UTC` timezone on naive datetimes in `_doc_to_event()`.

   ### PATCH ignores `recurrence: null` — can't clear recurrence
   - **Root cause**: `service.py:288` used `if body.recurrence is not None:` to decide whether to update. When the frontend sends `recurrence:
   null` (to set "does not repeat"), Pydantic parses `null` as `None`, and the guard silently skipped the update. The old recurrence data stayed
   in the DB.
   - **Fix**: Changed to `if "recurrence" in body.model_fields_set:` which distinguishes "field not in payload" from "field explicitly set to
   null". When null is sent, `doc.recurrence` is now properly set to `None`.

   ```diff
   -    if body.recurrence is not None:
   -        doc.recurrence = body.recurrence.model_dump()
   +    if "recurrence" in body.model_fields_set:
   +        doc.recurrence = body.recurrence.model_dump() if body.recurrence is not None else None
   ```

   ### `CollectionWasNotInitialized` error on calendar API calls
   - **Root cause**: `_CalendarDoc` and `_EventDoc` were not registered in `init_beanie()`, so Beanie couldn't find the MongoDB collection.
   - **Fix**: Added calendar models to `pocketpaw_ee/cloud/models/__init__.py` and registered them via `ALL_DOCUMENTS` in the shared DB init.