### PR TITLE
fix(bundled): use api action in decision-graph template

### DIFF
--- a/src/pocketpaw/bundled_templates/_bundled/decision-graph/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/decision-graph/ripple_spec.json
@@ -1,5 +1,5 @@
 {
-  "_placeholder_note": "Built-in pocket template (decision-graph) for RFC 07. Renders the org's decision graph with three default views (one-decision, time-series, policy) and a narrator chat panel that calls POST /api/v1/decisions/explain. The specialist may swap the [bracketed] copy for the org's domain (e.g. 'Renewals' instead of 'Decisions') but should keep the explain action bound to state.explain_question and the response bound to state.explain_response. The `decision-graph` widget itself is a Layer-2 SvelteFlow render that paw-enterprise registers in Slice 3b; until that manifest entry lands, the widget passes through ingest validation as an unknown type (its props are not enforced).",
+  "_placeholder_note": "Built-in pocket template (decision-graph) for RFC 07. Renders the org's decision graph with three default views (one-decision, time-series, policy) and a narrator chat panel that calls POST /api/v1/decisions/explain via the canonical `api` action verb (the renderer's `EventDispatcher` has no `invoke_endpoint` case — `api` is the right verb per `_KNOWN_ACTION_VERBS` in pocketpaw/ripple/manifest.py and the zod schema in ripple/src/lib/schema/event-handler.ts). The specialist may swap the [bracketed] copy for the org's domain (e.g. 'Renewals' instead of 'Decisions') but should keep the explain action bound to state.explain_question and the response bound to state.explain_response via the `response_key` field. The `decision-graph` widget itself is a Layer-2 SvelteFlow render that paw-enterprise registers in Slice 3b; until that manifest entry lands, the widget passes through ingest validation as an unknown type (its props are not enforced).",
   "state": {
     "selected_decision_id": "",
     "view_mode": "one-decision",
@@ -119,20 +119,34 @@
                     "value": true
                   },
                   {
-                    "action": "invoke_endpoint",
-                    "endpoint": "POST /api/v1/decisions/explain",
+                    "action": "api",
+                    "method": "POST",
+                    "url": "/api/v1/decisions/explain",
                     "body": {
                       "question": "{state.explain_question}",
                       "scope": { "pocket_id": "{pocket.id}" },
                       "max_decisions": 5,
                       "depth": "{state.depth}"
                     },
-                    "bind": "explain_response"
-                  },
-                  {
-                    "action": "set",
-                    "target": "explain_loading",
-                    "value": false
+                    "response_key": "explain_response",
+                    "on_success": [
+                      {
+                        "action": "set",
+                        "target": "explain_loading",
+                        "value": false
+                      }
+                    ],
+                    "on_error": [
+                      {
+                        "action": "set",
+                        "target": "explain_loading",
+                        "value": false
+                      },
+                      {
+                        "action": "toast",
+                        "message": "Couldn't load explanation — try again"
+                      }
+                    ]
                   }
                 ]
               },

--- a/tests/ee/test_bundled_decision_graph_template.py
+++ b/tests/ee/test_bundled_decision_graph_template.py
@@ -13,6 +13,17 @@
 #       chat agent's STEP 0 keyword match looks for.
 #     - the loader returns the template by slug from a tmp install
 #       (no traversal into the user's real ~/.pocketpaw/templates/).
+#
+# Changes:
+#   - 2026-05-25 (RFC 07 follow-up): the explain-wiring assertion now
+#     looks for the canonical `api` action verb instead of the
+#     pre-merge `invoke_endpoint` shape. `invoke_endpoint` is not in
+#     the Ripple event dispatcher's switch (see `_KNOWN_ACTION_VERBS`
+#     in `src/pocketpaw/ripple/manifest.py` for the 18-verb truth);
+#     the renderer would silently no-op on the old spec. Fields
+#     mirrored from the dispatcher's `handleApi` (event-dispatcher.ts):
+#     `url` (required), `method`, `body`, `response_key` (where the
+#     response gets written into state).
 """Tests for the bundled decision-graph pocket template (RFC 07 Slice 3a)."""
 
 from __future__ import annotations
@@ -107,7 +118,10 @@ def test_template_yaml_matches_rfc03_field_set() -> None:
 def test_template_ripple_spec_is_valid_json_with_explain_wiring() -> None:
     """The ripple_spec parses, carries ui + state, includes the
     `_placeholder_note`, and binds an Explain button to the
-    POST /api/v1/decisions/explain endpoint."""
+    POST /api/v1/decisions/explain endpoint via the canonical `api`
+    action verb (the renderer's event dispatcher has no
+    `invoke_endpoint` case — `api` is one of the 18 verbs in
+    `_KNOWN_ACTION_VERBS`)."""
     spec_path = _BUNDLED_DIR / _SLUG / "ripple_spec.json"
     spec = json.loads(spec_path.read_text(encoding="utf-8"))
 
@@ -123,36 +137,39 @@ def test_template_ripple_spec_is_valid_json_with_explain_wiring() -> None:
     assert "explain_response" in state
     assert state["explain_response"]["decisions_walked"] == []
 
-    # Walk the ui tree looking for the invoke_endpoint action pointed
-    # at /api/v1/decisions/explain. The Slice 3b frontend agent reads
+    # Walk the ui tree looking for the `api` action pointed at
+    # /api/v1/decisions/explain. The Slice 3b frontend agent reads
     # this binding to wire the chat panel.
-    explain_actions = _find_invoke_endpoints(spec["ui"], "POST /api/v1/decisions/explain")
+    explain_actions = _find_api_calls(spec["ui"], "/api/v1/decisions/explain")
     assert explain_actions, (
         "decision-graph template must bind an Explain action to "
         "POST /api/v1/decisions/explain so the narrator panel works"
     )
-    # The first invocation must pass a `question` from state and write
-    # the response into `explain_response`.
+    # The first invocation must POST, pass a `question` from state, and
+    # write the response into `state.explain_response` via the
+    # canonical `response_key` field that the dispatcher's `handleApi`
+    # reads.
     first = explain_actions[0]
+    assert first.get("method") == "POST"
     assert first["body"]["question"] == "{state.explain_question}"
-    assert first["bind"] == "explain_response"
+    assert first["response_key"] == "explain_response"
 
 
-def _find_invoke_endpoints(ui: dict, endpoint: str) -> list[dict]:
-    """Walk the ui tree and collect every invoke_endpoint action that
-    targets `endpoint`. Recursive over `children` and `on_click` lists."""
+def _find_api_calls(ui: dict, url: str) -> list[dict]:
+    """Walk the ui tree and collect every `api` action whose `url`
+    matches `url`. Recursive over `children` and `on_click` lists."""
     out: list[dict] = []
     if not isinstance(ui, dict):
         return out
     for click_action in ui.get("on_click", []) or []:
         if (
             isinstance(click_action, dict)
-            and click_action.get("action") == "invoke_endpoint"
-            and click_action.get("endpoint") == endpoint
+            and click_action.get("action") == "api"
+            and click_action.get("url") == url
         ):
             out.append(click_action)
     for child in ui.get("children", []) or []:
-        out.extend(_find_invoke_endpoints(child, endpoint))
+        out.extend(_find_api_calls(child, url))
     return out
 
 


### PR DESCRIPTION
## Summary

The Explain button in the bundled decision-graph pocket template (shipped
in #1237, RFC 07 Slice 3a) wired its on_click handler with
`action: "invoke_endpoint"`. That verb is not in the Ripple event
dispatcher's switch. `_KNOWN_ACTION_VERBS` in
`src/pocketpaw/ripple/manifest.py` enumerates the 18 verbs the renderer
understands (`set, toggle, push, remove, open, navigate, toast, emit,
pin, unpin, api, run_source, call_binding, flow, branch, confirm,
validate, delay, invoke`); on anything else the dispatcher
`console.warn`s and no-ops, so the button would have looked live and
done nothing at runtime.

This rewires the action through the canonical `api` verb per the zod
schema in `ripple/src/lib/schema/event-handler.ts`:

- `method: POST`
- `url: /api/v1/decisions/explain`
- `body: { question, scope, max_decisions, depth }`
- `response_key: explain_response` (where `handleApi` writes the result
  into state — confirmed against `handleApi` in
  `ripple/src/lib/core/event-dispatcher.ts`)
- `on_success` / `on_error` chains carry the `explain_loading=false`
  reset; the original spec's trailing `set` would have raced the async
  fetch
- `on_error` also toasts a fallback message

The placeholder note on the spec is updated to explain why `api` is the
right verb, and to point future readers at the manifest + zod schema as
the source of truth. The bundled-decision-graph test is updated to walk
for the new `api` action shape (the old assertion pinned the broken
`invoke_endpoint`).

## Verification

```
uv run --group ee pytest tests/ee/test_bundled_decision_graph_template.py tests/unit/test_bundled_templates.py -xvs
# 40 passed in 0.94s
```

Including the parametrized
`test_template_ripple_spec_passes_manifest_validation_if_reachable[decision-graph]`
that runs the live manifest validator on the spec.

```
uv run --group ee pytest tests/test_ripple_manifest_action_wiring.py -x
# 19 passed
```

(Sanity check that the broader Ripple-action wiring tests still pass.)

## Targets

`feat/rfc07-decision-graph` (the RFC 07 integration branch). Once that
branch lands, this fix is part of the merge.

## Test plan

- [x] Bundled-template tests pass (`tests/ee/test_bundled_decision_graph_template.py` + `tests/unit/test_bundled_templates.py`)
- [x] Manifest-validator parametrized test passes for `decision-graph` against a reachable manifest
- [x] Ripple action-wiring sibling tests still pass (`tests/test_ripple_manifest_action_wiring.py`)
- [x] No `invoke_endpoint` references remain in `src/pocketpaw/bundled_templates/_bundled/` (only `tests/` and `_placeholder_note` comments retain it for context)