### PR TITLE
docs: concept pages for Foresight + write actions + sources + LiveKit + spec/merge

### DIFF
--- a/docs/api/post-pocket-spec-merge.mdx
+++ b/docs/api/post-pocket-spec-merge.mdx
@@ -1,0 +1,257 @@
+---
+title: Merge Pocket Spec
+description: "One-shot server-side rippleSpec write. Accepts a full replace or a partial merge, runs the strict catalog + action-wiring gates, and persists. Replaces the legacy 17-tool LangChain edit path."
+api: POST /api/v1/pockets/{pocket_id}/spec/merge
+baseUrl: http://localhost:8000
+layout: '@/layouts/APIEndpointLayout.astro'
+auth: bearer
+section: API Reference
+ogType: article
+keywords: ["pocket spec merge", "rippleSpec patch", "pocket specialist", "merge endpoint"]
+tags: ["api", "pockets", "ripple"]
+---
+
+<Callout type="info">
+**Status (2026-05-25):** IMPLEMENTED.
+
+**Implementation PRs:** #1222 (MVP merge endpoint + specialist skill), #1223 (pocket-planner gate)
+
+**Workspace RFC:** ties to RFC 03 v2 work indirectly; no dedicated RFC.
+
+**What's live:** `POST /api/v1/pockets/{id}/spec/merge` accepts a rippleSpec patch and applies it server-side. The `pocketpaw-pocket-specialist` bundled skill drives this endpoint instead of the legacy 17-tool LangChain edit path.
+
+**What's planned:** deprecate the legacy 17-tool LangChain edit path once parity is verified on live traffic.
+</Callout>
+
+## Overview
+
+A single server-side write entry point for editing a pocket's rippleSpec. The endpoint accepts **exactly one of**:
+
+- `{"replace": <full rippleSpec>}` — overwrite the spec wholesale
+- `{"merge": <partial rippleSpec>}` — patch by name into the existing spec
+
+A body that carries both, or neither, returns `400`.
+
+This endpoint replaces the legacy 17-tool LangChain edit path. Where the legacy path required 17 separate `add_node` / `replace_node` / `set_node_prop` / `move_node` / `remove_node` tool calls (one per granular operation), the merge endpoint applies the whole patch in a single round trip. Lower latency, simpler traces, and the agent can author a coherent diff instead of stitching 17 micro-mutations.
+
+## Why This Replaces the 17-Tool Path
+
+| Concern | Legacy 17-tool path | `POST /spec/merge` |
+|---------|---------------------|---------------------|
+| Round trips | 17 LangChain tool calls + 17 LLM turns | 1 endpoint call |
+| Latency | ~30s on a 10-widget rebuild (tail-of-list) | <1s server-side |
+| Atomicity | Partial-apply on tool failure mid-batch | All-or-nothing |
+| Trace clarity | 17 nested tool spans per edit | One request/response pair |
+| Validation | Per-op (some ops pass, downstream ops fail on a broken tree) | One catalog + wiring gate over the resolved spec |
+
+The catalog and action-wiring gates are the **same gates** the agent-generation path runs in `create_from_ripple_spec`. A blocking violation returns `{ok: false, warnings: [...]}` and **does not persist** — the agent can fix and retry. Non-blocking expression-grammar warnings persist with `ok: true` and the warnings folded into the list.
+
+## How the Specialist Skill Calls It
+
+The bundled `pocketpaw-pocket-specialist` workspace skill drives this endpoint. The skill auto-installs on dashboard boot to `~/.claude/skills/` alongside `pocketpaw-create-pocket` and `pocketpaw-edit-pocket`. It teaches the chat agent:
+
+1. The rippleSpec shape (`{state, ui:{children, id}}` nested, not the flat-model spike).
+2. The four interactivity conventions the live recovery cascade kept regressing on: client-side push, value/label split, lowercase column ids, validate-push-clear-increment hygiene.
+3. The exact `curl` invocation for the merge endpoint (loopback bypass + tenancy headers).
+
+Behind the scenes, runtime flag `POCKETPAW_POCKET_SPECIALIST_USE_SKILL` toggles between the skill+merge path and the legacy 17-tool LangChain path. When the flag is truthy the edit-subagent pipeline swaps in the skill-pointer prompt variant, skips `make_edit_pocket_tools`, and sets `POCKETPAW_WORKSPACE_ID` / `POCKETPAW_USER_ID` env vars on the parent process so the Claude Code subprocess can `curl` the local API with the loopback bypass headers. Flag defaults `false` until the captain greenlights deletion of the legacy path.
+
+## Pocket-Planner Gate
+
+PR #1223 added the pocket-planner gate: complex multi-widget pockets get **planned first** via `deep_work` before the merge endpoint is called. The chat agent asks the planner to break the request into a structured kit (named widgets, state shape, action bindings, source bindings), then walks the todos applying the merge endpoint once per cohesive change. Simple pockets (single template match, no novel widgets) skip the planner and go straight to merge.
+
+## Validation
+
+The endpoint rejects:
+
+- **Unknown widget types** — every `ui` node's `type` must be in the widget catalog (`pocketpaw.ripple.catalog`). PR #1187's catalog-as-allowlist promotion applies here too.
+- **Unwired bindings** — an `events.click` handler referencing `binding: "close_pr"` when `actions.close_pr` does not exist; a `@state.prs` reference when `state.prs` is absent; a `run_source` verb naming an undeclared source.
+- **Invalid action verbs** — only the allowlist of ripple verbs is permitted (`call_binding`, `run_source`, `update_state`, etc.).
+- **Malformed structure** — non-dict where a dict is required, sibling id collisions (auto-reassigned with a warning rather than rejected), missing `id` on a node referenced by a handler.
+
+A blocking violation returns:
+
+```json
+{
+  "ok": false,
+  "warnings": [
+    "ui.children[2]: unknown widget type 'fancy_chart'",
+    "events.click[0]: unwired binding 'close_pr'"
+  ]
+}
+```
+
+The pocket is **not persisted** — the agent reads the warnings, fixes the spec, and retries.
+
+## Request Body
+
+<ResponseField name="replace" type="object">
+  A full rippleSpec — `{ version, state, ui, sources?, actions? }`. Overwrites the persisted spec wholesale. Mutually exclusive with `merge`.
+</ResponseField>
+
+<ResponseField name="merge" type="object">
+  A partial rippleSpec patch. Merge semantics are by-name: an `ui` node patch keyed by `id` updates that node in place; new top-level keys (`sources.foo`, `actions.bar`, `state.baz`) are added; existing ones are overwritten. Mutually exclusive with `replace`. Orphan node ids surface in the response `warnings` list (auto-orphan + warn, no block).
+</ResponseField>
+
+## Response
+
+<ResponseField name="ok" type="boolean">
+  `true` if the spec was persisted (possibly with non-blocking warnings); `false` if a blocking violation was found and nothing was persisted.
+</ResponseField>
+
+<ResponseField name="pocket" type="object">
+  The updated pocket wire dict on success. Includes the resolved `rippleSpec` and any auto-assigned node ids.
+</ResponseField>
+
+<ResponseField name="warnings" type="array">
+  Array of strings. Blocking violations on a failed request; non-blocking warnings (orphan ids, expression-grammar nits) on a successful one.
+</ResponseField>
+
+## Error Model
+
+| HTTP | Code | When |
+|------|------|------|
+| 400 | `merge.body_mutually_exclusive` | Body carries both `replace` and `merge`, or neither |
+| 400 | `merge.invalid_shape` | Top-level body is not a dict, or the patch is not a dict |
+| 401 | `auth.required` | No valid session / token and no loopback bypass headers |
+| 403 | `pocket.forbidden` | User lacks edit access on the pocket |
+| 404 | `pocket.not_found` | Pocket id is unknown or belongs to another workspace |
+| 422 | `ripple.catalog_violation` | One or more widgets reference unknown types (also surfaces in `warnings`) |
+
+## Auth
+
+Standard cookie / Bearer JWT (same as every other pocket route), **or** a loopback-only internal bypass:
+
+- Request originates from `127.0.0.1` / `::1` (`starlette` reads `request.client.host`, which is the actual peer — not the `X-Forwarded-For` header, so a reverse-proxy cannot spoof it).
+- Header `X-PocketPaw-Internal: true`.
+- Headers `X-PocketPaw-Workspace-Id` and `X-PocketPaw-User-Id` set.
+
+Service-level edit-access checks inside `merge_spec` still run on the resolved `user_id`, so a mistyped header cannot escalate privileges. The loopback bypass is the MVP path the specialist skill's Claude Code subprocess uses to `curl` the local API without an interactive session. It is flagged as MVP in the handler docstring; a follow-up PR will tighten the bypass (named local credential, short-lived token).
+
+<RequestExample>
+<Tabs items={["cURL (replace)", "cURL (merge)", "Python", "Loopback bypass"]}>
+  <Tab title="cURL (replace)">
+```bash
+curl -X POST "http://localhost:8000/api/v1/pockets/p_abc123/spec/merge" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "replace": {
+      "version": "1.0",
+      "state": { "prs": [] },
+      "ui": {
+        "id": "n_root1234",
+        "type": "table",
+        "props": { "rows": "@state.prs" },
+        "events": { "mount": [{ "verb": "run_source", "source": "prs" }] }
+      },
+      "sources": {
+        "prs": {
+          "type": "http_get",
+          "method": "GET",
+          "path": "/repos/owner/repo/pulls",
+          "refresh": ["manual"]
+        }
+      }
+    }
+  }'
+```
+  </Tab>
+  <Tab title="cURL (merge)">
+```bash
+curl -X POST "http://localhost:8000/api/v1/pockets/p_abc123/spec/merge" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "merge": {
+      "ui": {
+        "id": "n_root1234",
+        "props": { "title": "Open Pull Requests" }
+      },
+      "state": { "filter": "open" }
+    }
+  }'
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import httpx
+
+patch = {
+    "merge": {
+        "ui": {"id": "n_root1234", "props": {"title": "Open PRs"}},
+        "state": {"filter": "open"},
+    }
+}
+
+res = httpx.post(
+    "http://localhost:8000/api/v1/pockets/p_abc123/spec/merge",
+    headers={"Authorization": f"Bearer {token}"},
+    json=patch,
+    timeout=30,
+)
+result = res.json()
+if not result["ok"]:
+    for w in result["warnings"]:
+        print(f"BLOCKED: {w}")
+```
+  </Tab>
+  <Tab title="Loopback bypass">
+```bash
+# Used by the pocket-specialist skill's Claude Code subprocess
+curl -X POST "http://localhost:8000/api/v1/pockets/p_abc123/spec/merge" \
+  -H "X-PocketPaw-Internal: true" \
+  -H "X-PocketPaw-Workspace-Id: ${POCKETPAW_WORKSPACE_ID}" \
+  -H "X-PocketPaw-User-Id: ${POCKETPAW_USER_ID}" \
+  -H "Content-Type: application/json" \
+  -d '{"merge": {"state": {"refreshing": false}}}'
+```
+  </Tab>
+</Tabs>
+</RequestExample>
+
+<ResponseExample>
+<Tabs items={["200 OK", "200 Blocked", "400"]}>
+  <Tab title="200 OK">
+```json
+{
+  "ok": true,
+  "pocket": {
+    "_id": "p_abc123",
+    "rippleSpec": {
+      "version": "1.0",
+      "state": { "prs": [], "filter": "open" },
+      "ui": {
+        "id": "n_root1234",
+        "type": "table",
+        "props": { "rows": "@state.prs", "title": "Open PRs" }
+      }
+    }
+  },
+  "warnings": []
+}
+```
+  </Tab>
+  <Tab title="200 Blocked">
+```json
+{
+  "ok": false,
+  "warnings": [
+    "ui.children[2]: unknown widget type 'fancy_chart'",
+    "events.click[0]: unwired binding 'close_pr'"
+  ]
+}
+```
+  </Tab>
+  <Tab title="400">
+```json
+{
+  "detail": {
+    "code": "merge.body_mutually_exclusive",
+    "message": "Body must carry exactly one of 'replace' or 'merge'."
+  }
+}
+```
+  </Tab>
+</Tabs>
+</ResponseExample>

--- a/docs/concepts/foresight.mdx
+++ b/docs/concepts/foresight.mdx
@@ -1,0 +1,147 @@
+---
+title: "Foresight: Population-Scale Simulation"
+description: "Foresight is PocketPaw's IS-era simulation primitive — vendored OASIS substrate, soul-seeded personas, calibrated LLM tier pool, retroactive backtest gate, and projected decisions that land in the Decision Graph."
+section: Core Concepts
+ogType: article
+keywords: ["foresight", "simulation", "OASIS", "CAMEL", "projected decisions", "backtest"]
+tags: ["foresight", "simulation", "rfc-08"]
+---
+
+# Foresight: Population-Scale Simulation
+
+> Rehearse the future before living it.
+
+Foresight is the IS-era primitive for forward-simulating real Paw agents against a real org's Fabric snapshot under a real Instinct policy. One engine, seven simulation sub-types, projected Decisions that land in the Decision Graph (RFC 07) as forward-precedents.
+
+<Callout type="info">
+**Status (2026-05-25):** IMPLEMENTED through PR 7.
+
+**Implementation PRs:** #1224, #1227, #1230, #1232, #1233, #1234
+
+**Workspace RFC:** [docs/rfc/08-foresight-module-rfc.md](https://github.com/qbtrix/paw-workspace/blob/main/docs/rfc/08-foresight-module-rfc.md)
+
+**What's live:** scaffold + minimum loop, vendored OASIS + CAMEL adapter, cloud router + Beanie persistence, substrate + calibration + tier pool + LiteLLM fallback, retroactive backtest gate + aggregator primitives, market sim + org change sub-types + projected decisions.
+
+**What's planned:** decision projection back-references, richer scenario libraries, calibration tier expansion.
+</Callout>
+
+## What Foresight Is
+
+Foresight runs **populations of agents** through scenario templates. A scenario configures personas (each soul-seeded with an OCEAN drift profile), a sub-type (decision forecast, market sim, org change, etc.), a tick count, and an optional anchor list. The engine ticks the world forward, lets the personas act, scores the predicted outcomes against reality, and emits **projected Decisions** that the Decision Graph (RFC 07) treats as forward-precedents.
+
+Three things distinguish Foresight from a generic agent harness:
+
+1. **Soul-seeded personas.** A `SoulSeededPersona` wraps a real `PawAgent` — same identity, same OCEAN trait vector — so the simulation behaves like the people / agents it models, not like a generic LLM.
+2. **Calibration loop.** Predictions go into a `PredictionBuffer`; once reality lands, `pair_against_reality` scores them and `aggregate_pairs` produces a `CalibrationSummary`. A workspace cannot run forward sims until the **backtest gate** unlocks (default threshold 0.65 accuracy).
+3. **Tier pool.** Different personas / steps run on different model tiers via a `TierMix`, with a `LiteLLMFallbackBackend` proxy as the always-available floor. Token cost and latency are bounded by configuration, not by hope.
+
+## The Five Core Primitives
+
+| Primitive | Lives in | Job |
+|----------|----------|-----|
+| **Adapters** | `foresight/llm/adapter.py` | Bridge real backends to CAMEL. `ClaudeCodeBackend` exposes the Claude Code SDK as a CAMEL `BaseModelBackend`; `LiteLLMFallbackBackend` is the litellm proxy; `DeterministicFakeBackend` is the test floor. |
+| **Substrate** | `foresight/substrate/oasis/` + `foresight/llm/tier_pool.py` | Vendored OASIS fork (~6000 LOC, upstream SHA `46cdc8d`, Apache-2.0) drives the agent graph. `build_tier_pool` + `TierMix` distribute personas across model tiers. |
+| **Calibrator** | `foresight/calibration.py` | `PredictionRecord` / `PredictionBuffer` capture forecasts; `pair_against_reality` and `aggregate_pairs` score them; `apply_correction` (bounded by `CORRECTION_CAP`) feeds learnings back. |
+| **Backtest gate + aggregator** | `foresight/aggregator.py` + cloud `foresight_backtests` collection | `accuracy_meets_threshold` / `ThresholdDecision` gate forward sims on a passing retroactive run. Rollups: `rolling_accuracy`, `confidence_drift`, `modal_outcome_distribution`. |
+| **Market simulator** | `foresight/subtypes/market_sim.py` (plus `decision_forecast.py`, `org_change.py`) | Sub-type drivers that read a `ScenarioConfig`, fan out personas across anchors, and emit projected decisions in `(tick_id ASC, anchor_id ASC)` order. |
+
+## Module Layout
+
+```
+ee/pocketpaw_ee/foresight/
+├── __init__.py            # Lazy re-export surface (CAMEL is heavy)
+├── world.py               # ForesightWorld — Fabric-backed world + OASIS AgentGraph
+├── persona.py             # SoulSeededPersona, OceanDrift, make_paw_social_agent
+├── calibration.py         # PredictionBuffer, pair_against_reality, apply_correction
+├── aggregator.py          # rolling_accuracy, modal_outcome_distribution, ThresholdDecision
+├── insights.py            # 5 v0.1 synthesizer rules (accuracy_drop, persona_outlier, …)
+├── decision_graph_ref.py  # DecisionGraphRef protocol + NoOpDecisionGraphRef
+├── instinct_bridge.py     # Foresight → Instinct EVIDENCE-only proposal spawn
+├── llm/
+│   ├── adapter.py         # ClaudeCodeBackend, LiteLLMFallbackBackend, FakeBackend
+│   └── tier_pool.py       # TierMix, build_tier_pool, tier_distribution
+├── subtypes/              # decision_forecast.py, market_sim.py, org_change.py
+├── scenarios/             # runner.py + bundled YAML scenario templates
+├── api/                   # In-memory run store (v0.1 stand-in; cloud has Beanie now)
+└── substrate/oasis/       # Vendored OASIS fork — Apache-2.0, see NOTICE
+
+ee/pocketpaw_ee/cloud/foresight/
+├── router.py              # /api/v1/foresight/* surface (see Cloud Router below)
+├── service.py             # Beanie persistence + tenancy filter
+├── dto.py                 # Request/response DTOs per RFC 08 §11
+└── domain.py              # Frozen value objects with workspace_id
+```
+
+## How a Run Executes
+
+A typical `POST /api/v1/foresight/scenarios` call walks this path:
+
+<Steps>
+  <Step title="Validate + persist the request">
+    The router parses `CreateScenarioRequest` (personas inline, sub_type, n_ticks, optional anchors), service re-validates with `model_validate`, then writes a `ForesightRun` row to MongoDB scoped on `workspace_id`.
+  </Step>
+  <Step title="Pull calibration state">
+    Service looks up the workspace's most recent `CalibrationSummary`. If the backtest gate is locked (`OnboardingGateResponse.unlocked = false`), the call returns 422; forward sims require a passing retroactive backtest first.
+  </Step>
+  <Step title="Build the tier pool + substrate">
+    `build_tier_pool(TierMix)` distributes personas across model tiers; OASIS's `AgentGraph` hosts the `SoulSeededPersona` instances wrapped as `PawSocialAgent(SocialAgent)` via `make_paw_social_agent`. The `LiteLLMFallbackBackend` is the floor when a tier's primary model fails open.
+  </Step>
+  <Step title="Tick the world">
+    `ForesightWorld.tick()` drives `n_ticks` rounds. Each tick: snapshot the world, ask every persona to propose its next action, run the sub-type's driver (`subtypes/market_sim.py` etc.), record each prediction via `build_prediction_record` into the run's `PredictionBuffer`.
+  </Step>
+  <Step title="Aggregate + emit projected decisions">
+    `aggregate_pairs` collapses the buffer into a `CalibrationSummary`; the sub-type emits one `ProjectedDecision` row per anchor (or per persona) keyed for the projection-list endpoint to return in `(tick_id, anchor_id)` order.
+  </Step>
+  <Step title="Optional Instinct fan-out">
+    When the run opted into `route_to_instinct = true`, `instinct_bridge` spawns EVIDENCE-only Instinct rows whose `parameters._foresight.run_id` matches the run. Approving a row acknowledges the forecast but does NOT execute any real side-effect — the underlying Instinct policy still owns that decision.
+  </Step>
+  <Step title="Persist + fire events">
+    The run completes synchronously (v0.5 contract), emits `foresight.run.created`, and a passing backtest also fires `foresight.onboarding.unlocked`. The Beanie collection survives restarts so `GET /runs/{id}` is idempotent across deploys.
+  </Step>
+</Steps>
+
+<Callout type="info">
+**Synchronous today, queued tomorrow.** The v0.5 contract completes runs inline before returning. v1.0 will return `status="queued"` with a websocket URL and fan out to a background task, emitting `foresight.run_started` so the Live panel can distinguish accepted-but-pending from actively-ticking runs.
+</Callout>
+
+## Where the UI Lives
+
+The frontend rail ships in paw-enterprise issue #252 — five panels:
+
+| Panel | Drives off | Endpoint |
+|-------|-----------|----------|
+| **Scenarios** | Bundled YAML catalog + workspace-owned scenarios (v1.0) | `GET /api/v1/foresight/scenarios` |
+| **Live** | Per-run progress while ticking | `GET /api/v1/foresight/runs` (list) + websocket (v1.0) |
+| **Results** | One run's full payload + projected decisions | `GET /runs/{id}` + `GET /runs/{id}/projected-decisions` |
+| **Aggregate** | Rolling accuracy + drift + outcome distribution | `GET /aggregate?window_days=30` |
+| **Insights** | Five pattern rules (accuracy_drop / persona_outlier / tier_imbalance / trend_break / threshold_unmet) | `GET /insights` |
+
+## Cloud Router
+
+The Foresight cloud router is mounted from `pocketpaw_ee.cloud.__init__:mount_cloud` and lives under `/api/v1/foresight/*`. Every route is gated on `require_license` and the standard `request_context` dep so it surfaces a clean 401 when auth fails.
+
+| Endpoint | Purpose |
+|---------|---------|
+| `POST /scenarios` | Run a scenario inline; persists to `foresight_runs` |
+| `GET /runs/{id}` | Fetch a stored run (404 on cross-tenant ids — existence is not leakable) |
+| `GET /runs` | List runs in the workspace, most recent first; lighter list shape |
+| `GET /runs/{id}/projected-decisions` | Paginated projection list, optional `anchor_id` filter |
+| `GET /runs/{id}/instinct-proposals` | Instinct rows spawned by this run (EVIDENCE-only) |
+| `POST /backtests` | Run a retroactive backtest + score it against the unlock threshold |
+| `GET /backtests/{id}` / `GET /backtests` | Fetch / list backtests |
+| `GET /onboarding/gate` | Unlock posture (`no_backtest` / `in_flight` / `below_threshold` / `unlocked`) |
+| `GET /scenarios` | Bundled scenario template catalog |
+| `GET /aggregate?window_days=30` | Rolling accuracy + drift + modal outcome distribution |
+| `GET /insights` | Pattern-based insight synthesizer output |
+
+Service-owned writes go to the `ForesightRun` and `ForesightBacktest` Beanie collections — persistence is workspace-scoped and survives restarts. Per-run thresholds may tighten above the workspace default (`GATE_DEFAULT_THRESHOLD = 0.65`) but cannot relax below it; a relaxation request returns 422 `foresight.threshold_below_default`.
+
+## Open Questions and Future Work
+
+- **Decision projection back-references.** The Decision Graph (RFC 07) will surface the projected decisions a Foresight run anchored against alongside the real ones. v0.5 emits the projections but the back-edge in the Decision Graph is still stubbed via `NoOpDecisionGraphRef`.
+- **Richer scenario libraries.** v0.5 ships three bundled templates (`decision_forecast`, `market_sim`, `org_change`). v1.0 will accept workspace-owned scenarios authored against the RFC §18 grammar — the catalog response shape is already forward-compatible (additive `items` rows).
+- **Calibration tier expansion.** PR 3's tier_pool ships a stub config. v1.0 will widen the tier mix (premium / standard / floor) and surface per-tier accuracy in the Aggregate panel.
+- **Async run execution.** Synchronous-inline is fine for the v0.5 ticks budget; market sims and org-change runs at full scale need the queued + websocket-streamed path.
+- **vLLM hosting.** Long-horizon: a self-hosted vLLM tier would close the loop on cost and data residency for tenants that cannot send simulation traffic to the public LLM APIs.
+
+For the full design rationale, see [RFC 08 — Foresight Module](https://github.com/qbtrix/paw-workspace/blob/main/docs/rfc/08-foresight-module-rfc.md) in the workspace repo, and the internal handover at `pocketpaw/docs/internal/2026-05-foresight.md`.

--- a/docs/concepts/livekit.mdx
+++ b/docs/concepts/livekit.mdx
@@ -1,0 +1,110 @@
+---
+title: "LiveKit: Agentic Meetings"
+description: "PocketPaw's LiveKit integration powers voice, video, screen-sharing, and composite room recording for group calls. Agents can join calls; owners can record to S3."
+section: Core Concepts
+ogType: article
+keywords: ["livekit", "agentic meetings", "voice", "video", "composite recording", "S3"]
+tags: ["livekit", "calls", "meetings"]
+---
+
+# LiveKit: Agentic Meetings
+
+LiveKit is the real-time media layer behind PocketPaw's group calls — voice, video, screen sharing, and composite room recording. The integration ships as a cloud router (`pocketpaw_ee.cloud.livekit`) that brokers room creation, participant tokens, and recording lifecycle. Agents can join calls as participants alongside humans; recordings land in S3 with owner-gated playback.
+
+<Callout type="info">
+**Status (2026-05-25):** IMPLEMENTED.
+
+**Implementation PRs:** #1112 (LiveKit call management API + soul memory recall), #1186 (composite room recording with S3 output + owner-only controls)
+
+**Workspace RFC:** none — direct implementation.
+
+**What's live:** voice + video calls, screen sharing, camera, composite room recording to S3 with owner-only access, soul memory recall during calls.
+
+**What's planned:** transcription + AI summaries + post-call auto-processing (issue #1184).
+</Callout>
+
+## What LiveKit Gives PocketPaw
+
+The integration enables three call patterns:
+
+| Pattern | Who joins | Why |
+|---------|-----------|-----|
+| **Human-only call** | Workspace members | Replace a Zoom for in-team discussions; record for absent members |
+| **Human + agent call** | Members plus a meeting agent | The agent listens, can contribute, recalls soul memory for context |
+| **Agent-only call** | Two or more agents | Multi-agent coordination on a shared topic, recorded for the human to review |
+
+The substrate is LiveKit Cloud — `LIVEKIT_URL` / `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET` environment variables wire to a LiveKit project. The Python SDK (`livekit-api`) handles room CRUD and token minting; the meeting agent lifecycle runs in a subprocess to keep WebRTC and Deepgram out of the FastAPI event loop.
+
+## Room Model
+
+Rooms map deterministically to chat groups:
+
+| Concept | Identifier | Scope |
+|---------|-----------|-------|
+| **Chat group** | `group_id` (workspace-scoped) | The conversation that owns the call |
+| **LiveKit room** | `room_name = "group-call-" + group_id` | The active media session |
+| **Egress (recording)** | `egress_id` (in-memory registry) | The composite recording job |
+| **Participant identity** | `user_id` | The user's display name comes from `user.full_name` |
+
+A `POST /api/v1/livekit/rooms` creates the room if it does not exist, or returns the existing one. Caller is checked for group membership; only group members may create a room, generate participant tokens, get room info, or end the call. Recording is **additionally** gated on workspace ownership.
+
+## Composite Recording
+
+PR #1186 added `RoomCompositeEgress` recording — LiveKit's server-side recording mode that composites the room into a single MP4 stream rather than recording per-participant tracks. The output:
+
+- **Codec / quality:** H.264, 720p, MP4 container.
+- **Destination:** S3, configured via the existing `S3_*` env vars (shared with the uploads module — same credentials, no separate bucket).
+- **Lifecycle:** Start via `POST /api/v1/livekit/rooms/{group_id}/recording/start`; stop via `/recording/stop`; status via `GET /recording`.
+- **Registry:** Active recordings live in an in-memory `_active_recordings: dict[str, str]` mapping `group_id → egress_id`.
+- **File row:** When the recording stops, the service creates a `FileUpload` doc in MongoDB so the recording surfaces in the workspace's `/files` page alongside other uploads.
+
+Recording controls are **workspace-owner only** (`_require_workspace_owner()`). The frontend shows a red `REC` indicator in the call top bar when active; the Record button itself only renders for owners.
+
+## Frontend Pairing
+
+The Svelte frontend lives in the paw-enterprise repo and consumes this router:
+
+- **Call UI** — `paw-enterprise#206` wires `CallPanel.svelte` (Record button, REC indicator, participant grid) plus `call/service.ts` (start / stop / status / token helpers) and `call/store.svelte.ts` (CallSession state: `isRecording`, `recordingStartedAt`, `canRecord`).
+- **Records UI** — `paw-enterprise#241` surfaces past recordings in the workspace records view; the `FileUpload` MongoDB row written on stop-recording is what the records page queries.
+- **Permissions wiring** — `ChatPanel.svelte` passes `isWorkspaceOwner` as a prop to `CallPanel.svelte` so the Record button hides for non-owners.
+
+## API Surface
+
+All routes under `/api/v1/livekit/*` require an active enterprise license, user authentication, and group membership. Recording routes additionally require workspace ownership.
+
+| Method + Path | Purpose |
+|---------------|---------|
+| `POST /livekit/rooms` | Create or fetch the room for a group; returns a short-lived admin token for the call bot |
+| `POST /livekit/token` | Mint a participant access token (default TTL 3600s); display name comes from `user.full_name` |
+| `GET /livekit/rooms/{group_id}` | Room state: participant count, list, active flag |
+| `DELETE /livekit/rooms/{group_id}` | End the call; all participants are disconnected; the bot's notes post shortly after |
+| `POST /livekit/rooms/{group_id}/recording/start` | Begin composite recording to S3 (owner only) |
+| `POST /livekit/rooms/{group_id}/recording/stop` | Stop recording; writes a `FileUpload` doc; returns the file id |
+| `GET /livekit/rooms/{group_id}/recording` | Current recording status (mapped from LiveKit `EgressStatus` protobuf) |
+
+Events fire on the realtime bus:
+
+- `CallStarted` — on room create
+- `CallEnded` — on room delete
+
+The frontend's realtime channel subscribes to both so participant lists update without polling.
+
+## Soul Memory Integration
+
+PR #1112 wired soul memory recall into the meeting agent path. When an agent joins a call (via the subprocess agent lifecycle managed in `service.py`'s `_SubprocessAgentRef`), the agent's bootstrap pulls relevant soul memories into context:
+
+- **Episodic** — past calls with the same participants, decisions made, action items
+- **Semantic** — facts about projects / people / topics mentioned in the call group
+- **Procedural** — call etiquette and any group-specific conventions
+
+The result: an agent joining a recurring meeting with the same humans already knows the prior decisions, not just the last few minutes of transcript. This is the foundation the transcription + summary work (#1184) builds on — once transcripts land, they feed back into soul as episodic memories the agent recalls in the next call.
+
+## What's Next
+
+Three things land in the next cut, tracked under issue #1184:
+
+1. **Transcription** — Deepgram (already in the subprocess deps) produces a live transcript that streams to the call UI and is persisted with the recording.
+2. **AI summaries** — Post-call, a summarizer produces structured notes (decisions, action items, open questions) and posts them to the chat group thread.
+3. **Auto-processing** — Action items detected in the summary route through the existing pocket actions pipeline so a meeting can produce concrete writes (a calendar event, a tracker entry) under the same Instinct + outcome model the rest of the system uses.
+
+The recording infrastructure is the precondition: once a composite MP4 is reliably in S3, the transcript + summary jobs can run async against it without burdening the live call path.

--- a/docs/concepts/pocket-sources.mdx
+++ b/docs/concepts/pocket-sources.mdx
@@ -1,0 +1,120 @@
+---
+title: "Pocket Sources"
+description: "Pocket sources are read-only declared bindings to live external data — HTTP, connector, or internal projection — refreshed on interval, webhook, or manual trigger, with refresh-cost ceilings and a catalog allowlist."
+section: Core Concepts
+ogType: article
+keywords: ["pocket sources", "rippleSpec sources", "live data binding", "webhook refresh", "interval refresh"]
+tags: ["pockets", "ripple", "rfc-04"]
+---
+
+# Pocket Sources
+
+A pocket source is a **read-only, declared binding to live external data** that surfaces into a pocket's UI through the ripple state tree. Sources are how a dashboard pocket gets refreshed PR counts, how a tracker pocket shows current calendar events, how a status pocket polls a deploy. They are the read half of pocket data; [write actions](/concepts/pocket-write-actions) are the write half.
+
+<Callout type="info">
+**Status (2026-05-25):** IMPLEMENTED through M3.
+
+**Implementation PRs:** #1177 (alpha), #1187 (catalog-as-allowlist + embed escape hatch), #1188 (interval + webhook refresh + cost controls)
+
+**Workspace RFC:** [docs/rfc/04-pocket-interactivity-and-data-sync-rfc.md](https://github.com/qbtrix/paw-workspace/blob/main/docs/rfc/04-pocket-interactivity-and-data-sync-rfc.md)
+
+**What's live:** read-only live data sources; interval and webhook refresh; per-pocket refresh-cost ceilings; catalog-as-allowlist source-type gate.
+
+**What's planned:** M4 multi-source joins; M5 provenance graph back to Fabric.
+</Callout>
+
+## What a Source Is
+
+A source is one entry on `rippleSpec.sources` keyed by a flat name:
+
+```json
+{
+  "sources": {
+    "prs": {
+      "type": "http_get",
+      "method": "GET",
+      "path": "/repos/octocat/hello/pulls?state=open",
+      "refresh": ["interval:60s", "manual"]
+    }
+  }
+}
+```
+
+The binding is read-only — only `GET` ever leaves the server. The pocket's single configured backend supplies the `base_url`, auth, and credentials; the source supplies the path and refresh policy. Hydrated results land on `state.prs` for widgets to bind against.
+
+The pure-helper sibling of `state_ops.py` (which mutates `rippleSpec.state`) and `spec_ops.py` (which mutates `rippleSpec.ui`) is `sources_ops.py` — it owns the third top-level rippleSpec key.
+
+## Declaring a Source
+
+A source binding sits inside `rippleSpec.sources` and is referenced from widgets via the ripple state tree:
+
+```json
+{
+  "sources": {
+    "prs": {
+      "type": "http_get",
+      "method": "GET",
+      "path": "/repos/owner/repo/pulls",
+      "refresh": ["interval:60s", "manual"]
+    }
+  },
+  "state": { "prs": [] },
+  "ui": {
+    "type": "table",
+    "props": { "rows": "@state.prs" },
+    "events": {
+      "mount": [{ "verb": "run_source", "source": "prs" }]
+    }
+  }
+}
+```
+
+Three things make this work end-to-end:
+
+1. The binding is **declared on the spec** — the agent that authors the pocket writes it; a viewer cannot edit it.
+2. The widget reads from `@state.prs` — when the source hydrates, the state slice updates and ripple re-renders the bound widgets.
+3. The `run_source` ripple verb is queued on `mount` so the table loads its first batch when the pocket opens.
+
+## Refresh Modes
+
+A source may declare any combination of three refresh modes via its `refresh` array:
+
+| Mode | Trigger | How it fires |
+|------|---------|-------------|
+| `interval:<duration>` | Server-driven, periodic | The pocket's `refresh_scheduler` ticks once per interval and re-runs the source. Costs come out of the auto-refresh budget. |
+| `webhook` | Upstream-driven, push | An upstream backend calls `POST /api/v1/pockets/{id}/sources/{source}/refresh` with the per-pocket secret in `X-Pocket-Webhook-Secret`. |
+| `manual` | UI-driven, on-demand | A widget event handler queues the `run_source` verb. Calls `POST /api/v1/pockets/{id}/sources/run`. |
+
+A source whose refresh list omits `webhook` cannot be triggered via the webhook endpoint even with a valid secret — the named source must opt in.
+
+## Cost Controls
+
+PR #1188 added per-pocket refresh-cost ceilings to prevent a runaway poll loop or a webhook flood from running up unbounded backend cost. The budget is enforced separately from the manual rate limit:
+
+- **Auto-refresh budget** — interval and webhook refreshes share one per-pocket counter. Over-budget hits are **skipped** (HTTP 200 with `{"skipped": "rate_limited"}`), not queued. The pocket simply does not refresh again until the window resets.
+- **Manual rate limit** — the explicit `POST /sources/run` from the UI has its own per-`(pocket, user)` counter so a viewer mashing the refresh button cannot blow the auto-refresh budget for everyone.
+- **Per-request guards** — every source call inherits the read executor's SSRF / DNS-rebinding / 512 KB response-size / tight-timeout guards from `_http_guard.py`. Redirects are not followed; the response is parsed inline.
+
+## Catalog as Allowlist
+
+PR #1187 promoted the source-type registry from documentation to runtime gate: **only catalog-registered source types may be used**. A spec referencing an unknown `type` is rejected at ingest with a clear warning. This prevents an agent from inventing a new transport (e.g. `type: "grpc"`) that has not been hardened, and it gives the human owner a single review surface (the catalog) for what their pockets can call.
+
+There is one **embed escape hatch**: a `type: "embed"` source surfaces a trusted iframe URL. The escape hatch is review-gated like a write allowlist entry — the workspace owner accepts the iframe domain; an agent cannot embed a fresh origin without that acceptance.
+
+## How Sources Surface in the UI
+
+A hydrated source flows through three layers to the user:
+
+1. **Executor** — `source_executor.run_sources` makes the HTTP call, parses the response, and writes the result onto the pocket's state slice (e.g. `state.prs = [...]`).
+2. **Ripple** — the state mutation propagates to every widget that bound against the slice via `@state.<key>` references. Ripple handles the diff + re-render.
+3. **Reconciler** — the frontend reconciler (the same one that handles `pocket_mutation` SSE events) merges the new slice into the live model, preserving any optimistic UI state the user had in flight.
+
+The run-sources route is deliberately NOT gated on edit access — any pocket reader may run already-authored sources. That is the core shared-live-pocket UX: a viewer opens a shared dashboard and the on-mount `run_source` verbs refresh it. The viewer cannot change the backend or the source paths (both are edit-only), so the SSRF hardening plus the immutable edit-authored source list bound the risk to "fetch the same GET bindings the editors already approved."
+
+## Open Work
+
+- **M4 — Multi-source joins.** Today each source hydrates its own state slice independently. M4 will let a widget bind against a join across two sources (e.g. PRs joined with reviewer profiles) so the agent does not have to author a server-side aggregator for every cross-source view.
+- **M5 — Provenance graph.** Each source result will be tagged with its origin (which connector, which Fabric snapshot version) so the Decision Graph can trace a projected decision back through the source data that fed it. The graph is the natural extension of the outcome events write actions already emit.
+- **Source connectors beyond raw HTTP.** The catalog is the right surface to add `connector:gmail` / `connector:calendar` / `connector:slack` typed sources that wrap the connector framework so the agent does not author raw paths against external APIs.
+
+For the full design rationale, see [RFC 04 — Pocket Interactivity and Data Sync](https://github.com/qbtrix/paw-workspace/blob/main/docs/rfc/04-pocket-interactivity-and-data-sync-rfc.md).

--- a/docs/concepts/pocket-write-actions.mdx
+++ b/docs/concepts/pocket-write-actions.mdx
@@ -1,0 +1,190 @@
+---
+title: "Pocket Write Actions"
+description: "Pocket write actions are bound, agent-callable verbs that mutate live external data through a pocket's backend. Instinct routes which writes require human approval; outcomes feed the Decision Graph."
+section: Core Concepts
+ogType: article
+keywords: ["pocket write actions", "rippleSpec actions", "Instinct routing", "call_binding", "outcome events"]
+tags: ["pockets", "ripple", "rfc-05"]
+---
+
+# Pocket Write Actions
+
+A pocket write action is a **declared, agent-callable verb** that mutates external data through the pocket's single configured backend. Read sources fetch (`GET`); write actions push (`POST` / `PUT` / `PATCH` / `DELETE`). Both share the same SSRF / size / timeout guards, but writes carry blast radius and so go through three extra gates: a human-authored write allowlist, an optional Instinct approval, and an outcome event that lands in the Decision Graph.
+
+<Callout type="info">
+**Status (2026-05-25):** IMPLEMENTED through M2b.
+
+**Implementation PRs:** #1179 (M2a), #1183 (M2b), #1181 (execution router structure/data split)
+
+**Workspace RFC:** [docs/rfc/05-pocket-write-actions-rfc.md](https://github.com/qbtrix/paw-workspace/blob/main/docs/rfc/05-pocket-write-actions-rfc.md)
+
+**What's live:** write actions wired via the `call_binding` ripple verb; Instinct routing for approval-gated bindings; outcome emission; execution router splits structure edits from data writes.
+
+**What's planned:** multi-step action chains; richer outcome schemas tied to RFC 07 Decisions.
+</Callout>
+
+## What It Is
+
+A **read source** is `rippleSpec.sources["prs"] = { method: "GET", path: "/repos/.../pulls" }`. A **write action** is `rippleSpec.actions["close_pr"] = { method: "POST", path: "/repos/.../pulls/:id/close", requires_instinct: true, outcome: "pr_closed" }`. The agent that authors a pocket writes both; the human owner authorizes the *class* of writes via a separate, spec-external `allowed_writes` allowlist on the backend credential.
+
+Authorship and authorization are split on purpose: the agent cannot widen its own write blast radius, because the allowlist lives outside the spec it owns.
+
+## The Lifecycle
+
+A write action runs through six steps from agent intent to durable side-effect:
+
+<Steps>
+  <Step title="Agent proposes via call_binding">
+    Inside a widget event handler the agent emits the ripple verb `call_binding`, naming the action key (`close_pr`) and the resolved request bits (`path`, `params`, optional `idempotency_key`). The verb queues a `POST /api/v1/pockets/{id}/actions/run` on the client.
+  </Step>
+  <Step title="Server validates the binding">
+    `pockets/router.py:run_pocket_action` looks the action up in the persisted `rippleSpec.actions` dict. The HTTP `method` is read server-side from the binding — the client only sends the resolved `path` / `params`. An unknown action returns `{ok:false, code:"action_not_found"}`.
+  </Step>
+  <Step title="Allowlist + SSRF + rate-limit gates fire">
+    `action_executor.run_action` percent-decodes the request path, globs it against `allowed_writes`, re-validates the base URL, checks SSRF / DNS rebinding, and applies a per-`(pocket, user)` rate limit (20 writes / 60s). A rejected write returns `{ok:false}` and makes NO HTTP call.
+  </Step>
+  <Step title="Instinct routes approval-gated writes">
+    A binding marked `requires_instinct: true` runs every cheap validation gate, then returns the `instinct_pending` sentinel — the executor parks the resolved write under `_park` and does NOT call the backend. The router hands the parked write to `instinct_bridge.propose_pocket_write`, which spawns an Instinct Action keyed by the pocket's `approval_route` (owner by default, or a named workspace member). The response is `{ok:true, code:"instinct_pending", proposed_action_id}`.
+  </Step>
+  <Step title="Handler executes after approval (or directly)">
+    A non-gated write fires inline; the executor returns the backend response. A gated write fires later from `instinct_bridge.execute_approved_write` when the human approves the Instinct row. The backend's response body lands in this REST response — there is no SSE emit because the run endpoint is a standalone REST call outside any SSE stream.
+  </Step>
+  <Step title="Outcome event emits">
+    On a fired (non-pending) success the route emits a `pocket.outcome` event when the binding declared an `outcome` string. The outcomes service writes the row, and the Decision Graph (RFC 07) consumes it as evidence for `DecisionProjection`. A binding without `outcome` is a silent no-op.
+  </Step>
+</Steps>
+
+## Defining a Write Action
+
+A write binding lives inside `rippleSpec.actions` on the pocket. The minimum shape:
+
+```json
+{
+  "actions": {
+    "close_pr": {
+      "method": "POST",
+      "path": "/repos/:owner/:repo/pulls/:id/close",
+      "requires_instinct": false,
+      "outcome": "pr_closed"
+    }
+  }
+}
+```
+
+| Field | Purpose |
+|-------|---------|
+| `method` | One of `POST` / `PUT` / `PATCH` / `DELETE`. Validated server-side; the client cannot override. |
+| `path` | Resolved path appended to the backend `base_url`. `:placeholder` segments are filled at call time. |
+| `requires_instinct` | When `true`, runs validation gates but parks the write for human approval via the Instinct surface. |
+| `instinct_policy` | Optional reference to a named Instinct policy. Rejected by the model validator if set without `requires_instinct`. |
+| `outcome` | Optional outcome name emitted on success. Feeds RFC 07's DecisionProjection. |
+
+The matching write rule on `allowed_writes` lives on the backend credential, set via:
+
+```bash
+PUT /api/v1/pockets/{pocket_id}/backend/write-policy
+```
+
+The body is `{ "allowed_writes": [ { "method": "POST", "path_pattern": "/repos/*/pulls/*/close" } ] }`. An empty list **revokes every write** (fail-closed); the agent cannot opt the pocket back in by editing the spec.
+
+## Instinct Routing
+
+Three things decide whether a write fires inline or routes to a human:
+
+1. **The binding** — `requires_instinct` is the explicit opt-in on the spec.
+2. **The pocket's approval route** — set via `PUT /pockets/{id}/backend/approval-route`. A `mode="user"` route names a workspace member; an unset route defaults to the pocket owner.
+3. **The Instinct policy** (optional) — when `instinct_policy` is set on the binding, the Instinct service can compose policy rules on top (allow-list of approvers, expiry, batch approval, etc.).
+
+The executor's contribution is the **fail-closed default**: a binding with `requires_instinct: true` and a misconfigured approval route still parks the write; it never silently falls through to direct execution.
+
+## Outcome Emission
+
+A successful, fired (non-pending) write that declares an `outcome` calls `outcomes_service.emit_pocket_outcome` with:
+
+```python
+emit_pocket_outcome(
+    outcome="pr_closed",
+    pocket_id=...,
+    workspace_id=...,
+    action="close_pr",
+    actor=user_id,
+    via_instinct=False,           # True when the write came through approval
+    instinct_action_id=None,      # The Instinct row id when via_instinct=True
+)
+```
+
+The outcomes service persists the row and emits a bus event. Downstream:
+
+- The pocket's UI reconciles via the `on_success` handler the agent wired into the widget event.
+- The Decision Graph (RFC 07) consumes the outcome as evidence on the relevant `DecisionProjection`.
+- The audit log keeps a tenant-filterable record (`workspace_id` is on every entry).
+
+## Execution Router and the Structure/Data Split (PR #1181)
+
+PR #1181 separated two kinds of mutations that previously shared one execution path:
+
+| Mutation kind | Where it lands | Endpoint |
+|---------------|----------------|----------|
+| **Structure edit** | Changes the pocket's rippleSpec (add a widget, rename a column, re-bind a source) | `POST /api/v1/pockets/{id}/spec/merge` — the specialist surface (see [POST /pockets/{id}/spec/merge](/api/post-pocket-spec-merge)) |
+| **Data write** | Calls the pocket's external backend through a declared action | `POST /api/v1/pockets/{id}/actions/run` — the write executor |
+
+The discriminant lives on the `pocket_mutation` SSE event so the frontend reconciler can route structure edits through the spec patch path and data writes through the optimistic-with-rollback path. Without the split, every data write triggered a spec round-trip, and the canvas flickered.
+
+## Examples
+
+### A read-only source bound to a refresh button
+
+```json
+{
+  "sources": {
+    "prs": { "method": "GET", "path": "/repos/owner/repo/pulls?state=open" }
+  },
+  "ui": {
+    "type": "button",
+    "props": { "label": "Refresh" },
+    "events": {
+      "click": [
+        { "verb": "run_source", "source": "prs" }
+      ]
+    }
+  }
+}
+```
+
+Read sources are open to any pocket reader. No allowlist, no Instinct.
+
+### A write action bound to a form submit
+
+```json
+{
+  "actions": {
+    "close_pr": {
+      "method": "POST",
+      "path": "/repos/:owner/:repo/pulls/:id/close",
+      "requires_instinct": true,
+      "outcome": "pr_closed"
+    }
+  },
+  "ui": {
+    "type": "form",
+    "children": [
+      { "type": "input", "id": "n_pr_id", "props": { "name": "id" } },
+      {
+        "type": "button",
+        "props": { "label": "Close PR" },
+        "events": {
+          "click": [
+            {
+              "verb": "call_binding",
+              "binding": "close_pr",
+              "params": { "owner": "octocat", "repo": "hello", "id": "@state.pr_id" }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+`requires_instinct: true` parks the write — the user sees an "approval pending" affordance until the approver acts on the Instinct row.

--- a/docs/docs-config.json
+++ b/docs/docs-config.json
@@ -285,6 +285,26 @@
             "icon": "lucide:layout-dashboard"
           },
           {
+            "label": "Foresight",
+            "href": "/concepts/foresight",
+            "icon": "lucide:eye"
+          },
+          {
+            "label": "Pocket Sources",
+            "href": "/concepts/pocket-sources",
+            "icon": "lucide:database"
+          },
+          {
+            "label": "Pocket Write Actions",
+            "href": "/concepts/pocket-write-actions",
+            "icon": "lucide:zap"
+          },
+          {
+            "label": "LiveKit (Calls)",
+            "href": "/concepts/livekit",
+            "icon": "lucide:video"
+          },
+          {
             "label": "PocketPaw vs OpenClaw",
             "href": "/concepts/vs-openclaw",
             "icon": "lucide:scale"
@@ -766,6 +786,12 @@
               { "label": "Cancel Project", "href": "/api/post-deep-work-cancel", "method": "POST" },
               { "label": "Skip Task", "href": "/api/post-deep-work-skip-task", "method": "POST" },
               { "label": "Retry Task", "href": "/api/post-deep-work-retry-task", "method": "POST" }
+            ]
+          },
+          {
+            "label": "Pockets",
+            "items": [
+              { "label": "Merge Pocket Spec", "href": "/api/post-pocket-spec-merge", "method": "POST" }
             ]
           },
           {


### PR DESCRIPTION
## Summary

Closes the May 2026 doc gap for the five large features shipped on `dev` this month. Each page carries a status callout at the top (label, PR list, workspace RFC link, what's live vs. what's planned) so a reader can tell signal from roadmap at a glance.

## New pages

- **`docs/concepts/foresight.mdx`** — population-scale simulation. Vendored OASIS substrate, soul-seeded personas, calibration loop, retroactive backtest gate, projected decisions, cloud router. Status: IMPLEMENTED through PR 7 (RFC 08, PRs #1224, #1227, #1230, #1232, #1233, #1234).
- **`docs/concepts/pocket-write-actions.mdx`** — RFC 05 write surface. `call_binding` lifecycle, Instinct routing for approval-gated writes, outcome emission, structure/data split. Status: IMPLEMENTED through M2b (PRs #1179, #1183, #1181).
- **`docs/concepts/pocket-sources.mdx`** — RFC 04 read surface. Interval / webhook / manual refresh, cost ceilings, catalog-as-allowlist gate, embed escape hatch. Status: IMPLEMENTED through M3 (PRs #1177, #1187, #1188).
- **`docs/concepts/livekit.mdx`** — agentic meetings. Room model, composite room recording to S3, owner-only controls, soul memory recall during calls. Status: IMPLEMENTED (PRs #1112, #1186).
- **`docs/api/post-pocket-spec-merge.mdx`** — one-shot rippleSpec write endpoint that replaces the legacy 17-tool LangChain edit path. Documents the body shape (replace / merge), validation gates, loopback bypass, error model, and the pocket-planner gate. Status: IMPLEMENTED (PRs #1222, #1223).

## Sidebar wiring

- Added 4 entries to **Core Concepts** in `docs/docs-config.json`: Foresight, Pocket Sources, Pocket Write Actions, LiveKit (Calls).
- Added a new **Pockets** section to **API Reference** with the spec/merge route.

## Conventions

- Files are `.mdx` with YAML frontmatter, matching the existing concept and API pages.
- Status header uses the `<Callout type="info">` component (the codebase convention) rather than a GitHub-flavored alert block.
- API page uses the `APIEndpointLayout.astro` layout with `<ResponseField>`, `<Tabs>`, `<RequestExample>`, `<ResponseExample>` per the existing pattern.
- Technical details (file paths, class names, endpoint shapes, env vars) were verified against the actual source — foresight code in the `feat/foresight-v15-lai` worktree, LiveKit code on dev, spec/merge handler from commit `62fa6d03`.

## Test plan

- [ ] Open `/concepts/foresight` — verify status callout renders, sidebar entry resolves
- [ ] Open `/concepts/pocket-write-actions` — verify lifecycle Steps render, sidebar entry resolves
- [ ] Open `/concepts/pocket-sources` — verify refresh-modes table renders, sidebar entry resolves
- [ ] Open `/concepts/livekit` — verify recording section renders, sidebar entry resolves
- [ ] Open `/api/post-pocket-spec-merge` — verify request/response tabs render, sidebar entry resolves under Pockets
- [ ] Confirm `docs-config.json` parses (already validated locally with `python3 -c "import json; json.load(...)"`)