### PR TITLE
feat(decisions): RFC 09 Slice 1b — record_decision_event helper + chain producer contract

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -532,14 +532,18 @@ def mount_cloud(app: FastAPI) -> None:
 
     _get_bus().subscribe("pocket.outcome", _outcomes_service.record_outcome)
 
-    # Decision graph projection (RFC 07 Slice 1). Lazy-init the
-    # singleton DecisionGraph + projection so `GET /api/v1/decisions/_ping`
-    # and the in-process Python API (`get_decision_graph()`) work from
-    # process start. Slice 1 ships the substrate only — Slice 2 wires
-    # the journal-to-projection subscription that keeps the store live.
+    # Decision graph projection (RFC 07 Slice 1 + RFC 09 Slice 1b).
+    # Lazy-init the singleton DecisionGraph + projection so
+    # `GET /api/v1/decisions/_ping` and the in-process Python API
+    # (`get_decision_graph()`) work from process start. Pass
+    # `rebuild_from_journal=True` so a cold process boot folds any
+    # pre-existing chain events the journal already holds (RFC 09
+    # Slice 1b § "Bootstrap replay verification"). Warm restarts skip
+    # the replay because the projection's cursor is persisted in
+    # decisions.db.
     from pocketpaw_ee.cloud.decisions.service import init_decisions_projection
 
-    init_decisions_projection()
+    init_decisions_projection(rebuild_from_journal=True)
 
     # Tasks → notifications fan-out. When a Task is proposed to a human
     # assignee, drop an in-app notification so they see it even without

--- a/ee/pocketpaw_ee/cloud/decisions/__init__.py
+++ b/ee/pocketpaw_ee/cloud/decisions/__init__.py
@@ -1,7 +1,7 @@
 # __init__.py — Decision-graph entity package marker.
 # Created: 2026-05-25 (RFC 07 Slice 1) — the substrate that folds an
 #   N-event subgraph of the org journal (`agent.proposed`, `human.corrected`,
-#   `policy.evaluated`, `decision.graduated`, `decision.outcome_attached`)
+#   `policy.evaluated`, `decision.completed`, `decision.outcome_attached`)
 #   into one queryable Decision row + edge rows. Materialized in
 #   `~/.soul/decisions.db` (SQLite, WAL); queried via the in-process
 #   `DecisionGraph` Python API. Slice 1 ships the substrate (projection +

--- a/ee/pocketpaw_ee/cloud/decisions/domain.py
+++ b/ee/pocketpaw_ee/cloud/decisions/domain.py
@@ -132,7 +132,7 @@ class Decision(BaseModel):
 
     The fold of an N-event subgraph of the journal into one record.
     Construction happens inside ``DecisionProjection._close_chain`` when a
-    terminal event (per A2: only ``decision.graduated``) lands on a
+    terminal event (per A2: only ``decision.completed``) lands on a
     correlation_id that previously received ``agent.proposed``.
 
     Multi-tenancy: ``scope`` is required (min_length=1). The journal

--- a/ee/pocketpaw_ee/cloud/decisions/journal_writer.py
+++ b/ee/pocketpaw_ee/cloud/decisions/journal_writer.py
@@ -1,0 +1,248 @@
+# journal_writer.py — Canonical write path for Decision-Graph chain events.
+# Created: 2026-05-25 (RFC 09 Slice 1b — feat/rfc-09-slice-1-record-decision-event)
+#
+#   Purpose
+#   -------
+#   RFC 09 (paw-workspace#63) introduces 9 producer sites across 4
+#   production files that emit the chain-forming actions
+#   (`agent.proposed`, `human.corrected`, `policy.evaluated`,
+#   `decision.completed`). Every producer must do the same two-step:
+#
+#       1. `journal.append(entry)` — make the event the durable record
+#       2. `projection.apply(entry)` — fold the event into the live store
+#
+#   Doing it wrong (skipping the journal, swapping the order, swallowing
+#   exceptions inconsistently) creates either a stuck projection or a
+#   silent gap between the audit log and the Decision Graph. RFC 09
+#   Audit Open Question 11 calls this out specifically — the synthetic
+#   `decision.outcome_attached` path bypasses `journal.append` and so
+#   never advances the projection cursor; we don't want any chain-forming
+#   producer to repeat that mistake.
+#
+#   `record_decision_event(...)` is the single co-location helper. Slices
+#   2 + 3 wire each producer site through this function instead of calling
+#   `journal.append` directly.
+#
+#   Soul-protocol version note
+#   --------------------------
+#   Soul-protocol 0.3.1 (the wheel currently installed) does NOT yet have
+#   `build_policy_event` / `build_completion_event` / `PolicyEvaluation`
+#   / `DecisionCompletion`. Those land in Slice 1a (soul-protocol release
+#   bumping to 0.4.x). Until that wheel is published, this helper
+#   constructs `EventEntry` instances directly with string-literal action
+#   names. The `# TODO(rfc09-slice-1a-wheel)` markers below flag the
+#   call sites that should switch to the new builders once they exist.
+#
+#   `decision.completed` is similarly absent from soul-protocol's
+#   ACTION_NAMESPACES registry today (which lists `decision.graduated`
+#   under the old "pattern-promotion" meaning). The journal does NOT
+#   validate `entry.action` against ACTION_NAMESPACES — appending
+#   `decision.completed` is accepted right now and will continue to be
+#   accepted when Slice 1a registers it formally. RFC 09 § "Vocabulary
+#   fix" pins this rename.
+#
+#   Failure isolation
+#   -----------------
+#   Per RFC 09 § "Architecture — three layers in concert", the journal
+#   write is the source of truth. If `projection.apply` raises (a bug, a
+#   schema drift, transient I/O), the helper logs a warning and returns
+#   the EventEntry anyway — the producer's request must NOT fail because
+#   of a projection problem. The Slice 4 reconciler will pick up any
+#   apply-failed entries on its next pass since the journal row exists.
+#
+#   Idempotency
+#   -----------
+#   The helper does NOT dedupe on `correlation_id` or `event_id`. The
+#   journal itself enforces seq-monotonic append; the projection's
+#   `apply()` is idempotent on (correlation_id, action) when the same
+#   payload lands twice via rebuild + hot-path. If a caller wants
+#   no-duplicate semantics it MUST check before calling — for instance,
+#   `run_action`'s re-entry path uses `from_instinct=True` to suppress
+#   the second `agent.proposed` (RFC 09 audit Surprise 3).
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from soul_protocol.spec.journal import Actor, EventEntry
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Action namespace — the chain-forming actions producers route through here
+# ---------------------------------------------------------------------------
+# Membership is the trip-wire for the lint contract in ee/pyproject.toml:
+# only `journal_writer.py` may import the soul-protocol builders that
+# construct these specific actions. Producers outside this module call
+# `record_decision_event` instead. The set is a frozenset so a producer
+# can do an `action in DECISION_CHAIN_ACTIONS` membership check without
+# fear of mutation.
+#
+# Notes on what's IN and what's OUT:
+#   * `agent.proposed` / `human.corrected` / `policy.evaluated` /
+#     `decision.completed` — yes, these are the chain spine. Every emit
+#     MUST go through `record_decision_event`.
+#   * `decision.outcome_attached` is intentionally NOT here. It is a
+#     mutation-only event emitted from the outcomes service AFTER a chain
+#     has closed; it doesn't open or close a chain, so it doesn't carry
+#     the same "must journal + apply in lockstep" risk profile. The
+#     outcomes service has its own back-reference contract (RFC 07
+#     Slice 2) and lives in `outcomes/service.py`.
+#   * `fabric.object.*` events are CONTRIBUTING (they add inputs) but
+#     not terminal — they're emitted by `FabricJournalStore` via its own
+#     well-established co-location pattern (`src/pocketpaw/fabric/
+#     journal_store.py`). RFC 07 § A2 amendment makes the chain stay
+#     open until `decision.completed` lands, so fabric writes never
+#     close a chain on their own.
+DECISION_CHAIN_ACTIONS: frozenset[str] = frozenset(
+    {
+        "agent.proposed",
+        "human.corrected",
+        "policy.evaluated",
+        "decision.completed",  # RFC 09 § Vocabulary fix — was "decision.graduated"
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper — the single chokepoint
+# ---------------------------------------------------------------------------
+
+
+def record_decision_event(
+    *,
+    action: str,
+    correlation_id: UUID,
+    actor: Actor,
+    scope: list[str],
+    payload: dict | None = None,
+    causation_id: UUID | None = None,
+    ts: datetime | None = None,
+    event_id: UUID | None = None,
+) -> EventEntry:
+    """Append a Decision-Graph chain event AND fold it into the projection.
+
+    Canonical co-location for the four chain-forming actions in
+    `DECISION_CHAIN_ACTIONS`. Producers in Slices 2 + 3 (agent runtime,
+    Instinct evaluator, approve/reject endpoints, chain-close moments)
+    MUST call this function instead of `journal.append(entry)` directly.
+
+    Contract (load-bearing — see RFC 09 § Architecture):
+      1. Build EventEntry from the kwargs.
+      2. `journal.append(entry)` — durable write FIRST so the audit log
+         is consistent even if the projection's fold raises.
+      3. `get_decision_graph().projection.apply(entry)` — fold the entry
+         into the live store so queries / explain narrators see it
+         without waiting for the Slice 4 reconciler.
+
+    Ordering matters. Reversing the calls would advance the projection
+    cursor over an event that the journal does not yet hold; a crash
+    between the two would leave the projection ahead of the journal and
+    the next rebuild would miss the row. The helper enforces the
+    journal-first order so producers don't have to remember.
+
+    Failure isolation
+    -----------------
+    `projection.apply()` failures are logged as warnings and swallowed —
+    the EventEntry is still returned to the caller. The journal row is
+    the source of truth; the projection can be reconstructed at any time
+    via `projection.rebuild(journal, since_seq=...)`. Letting a fold bug
+    block the producer's request would couple every Instinct approval
+    to the Decision Graph's health, which is the opposite of what RFC 09
+    wants.
+
+    `journal.append()` failures DO propagate. If the audit log can't be
+    written, that's a real problem the producer needs to know about.
+
+    Args:
+        action: One of `DECISION_CHAIN_ACTIONS`. Passing something else
+            still works (the journal accepts arbitrary action strings),
+            but the projection will drop it and the lint contract exists
+            to nudge callers toward `journal.append` directly for
+            non-chain events.
+        correlation_id: The chain id. Same id flows from
+            `agent.proposed` through to `decision.completed` so the
+            projection folds them into one Decision row.
+        actor: The actor responsible for the event. Carries the org /
+            workspace scope context the projection uses for visibility
+            filters.
+        scope: Tenancy tags — typically `[f"pocket:{pocket_id}",
+            f"workspace:{workspace_id}"]`. Required by the journal
+            invariant (min_length=1).
+        payload: Action-specific payload. For `agent.proposed` it's an
+            `AgentProposal.model_dump(mode="json")` dict; for
+            `human.corrected` it's a `HumanCorrection` dict; for
+            `policy.evaluated` it's the policy-evaluation shape that
+            Slice 1a will pin as `PolicyEvaluation`; for
+            `decision.completed` it's the chain-close shape that Slice
+            1a will pin as `DecisionCompletion`.
+        causation_id: Optional pointer to the event that directly caused
+            this one (e.g. `human.corrected` cites the prior
+            `policy.evaluated(passed=False)` event id).
+        ts: Optional timestamp override. Defaults to `datetime.now(UTC)`
+            — the journal validates that ts is timezone-aware UTC.
+        event_id: Optional event id override. Defaults to `uuid4()`.
+
+    Returns:
+        The freshly-constructed EventEntry. Producers usually don't need
+        it but some sites stash the entry id on a parked blob (RFC 09
+        Slice 3 wires `human.corrected.causation_id` from the prior
+        `policy.evaluated` entry).
+    """
+    # Lazy import — the decisions service is in the same package, but
+    # leaving the import at function-scope keeps a clean dependency
+    # picture in static analysis and avoids touching the
+    # `init_decisions_projection` singleton at module-import time.
+    from pocketpaw.journal_dep import get_journal
+
+    from pocketpaw_ee.cloud.decisions.service import get_decision_graph
+
+    entry = EventEntry(
+        # TODO(rfc09-slice-1a-wheel): when soul-protocol publishes
+        # `build_policy_event` / `build_completion_event`, route the
+        # `policy.evaluated` and `decision.completed` calls through them
+        # so the PolicyEvaluation / DecisionCompletion payload validation
+        # runs at construction time. `agent.proposed` and
+        # `human.corrected` can also move to `build_proposal_event` /
+        # `build_correction_event` (already shipped in 0.3.1) — they
+        # accept a structured AgentProposal / HumanCorrection rather
+        # than a raw dict, so producers will need to construct those
+        # models first.
+        id=event_id or uuid4(),
+        ts=ts or datetime.now(UTC),
+        actor=actor,
+        action=action,
+        scope=list(scope),
+        correlation_id=correlation_id,
+        causation_id=causation_id,
+        payload=payload or {},
+    )
+
+    journal = get_journal()
+    # Journal.append returns None — seq lives only in the backend. The
+    # projection's apply() handles a missing seq attribute by falling
+    # back to 0, which is fine for hot-path folds (the cursor doesn't
+    # need to advance for the fold itself; the Slice 4 reconciler uses
+    # the journal's real seq when replaying from the cursor).
+    journal.append(entry)
+
+    try:
+        graph = get_decision_graph()
+        graph.projection.apply(entry)
+    except Exception:  # noqa: BLE001 — see "Failure isolation" above
+        logger.warning(
+            "decisions projection.apply raised for %s (correlation_id=%s) — "
+            "journal row written, projection will catch up via Slice 4 "
+            "reconciler",
+            action,
+            correlation_id,
+            exc_info=True,
+        )
+
+    return entry
+
+
+__all__ = ["DECISION_CHAIN_ACTIONS", "record_decision_event"]

--- a/ee/pocketpaw_ee/cloud/decisions/journal_writer.py
+++ b/ee/pocketpaw_ee/cloud/decisions/journal_writer.py
@@ -197,7 +197,6 @@ def record_decision_event(
     # picture in static analysis and avoids touching the
     # `init_decisions_projection` singleton at module-import time.
     from pocketpaw.journal_dep import get_journal
-
     from pocketpaw_ee.cloud.decisions.service import get_decision_graph
 
     entry = EventEntry(

--- a/ee/pocketpaw_ee/cloud/decisions/projection.py
+++ b/ee/pocketpaw_ee/cloud/decisions/projection.py
@@ -4,9 +4,9 @@
 #   /tmp/team-rfc07 prototype (8 green tests there) but rewritten for:
 #     - SQLite store (DecisionStore) instead of in-memory dicts
 #     - A1 — `approvers: list[ApproverRef]` carrying approved_at + position
-#     - A2 — ONLY `decision.graduated` closes a chain. Fabric writes
-#       (`fabric.object.*`) CONTRIBUTE inputs but do NOT close. This
-#       decouples the projection from Fabric's namespace.
+#     - A2 — ONLY the terminal chain-close action closes a chain. Fabric
+#       writes (`fabric.object.*`) CONTRIBUTE inputs but do NOT close.
+#       This decouples the projection from Fabric's namespace.
 #     - A3 — Precedent supply order: (1) agent payload first, (2)
 #       projection fallback same-pocket / same-action / nearest-ts.
 #       Out-of-band reconciler deferred.
@@ -32,6 +32,16 @@
 #   return through `_emit(decision)` which fires hooks before returning.
 #   This keeps layering one-way (explain → decisions) — the projection
 #   never imports the cache.
+#
+#   2026-05-25 (RFC 09 Slice 1b) — `_TERMINAL_ACTIONS` swapped from
+#   `decision.graduated` to `decision.completed` per RFC 09 §
+#   "Vocabulary fix". The old name collided with soul-protocol's
+#   pattern-promotion concept (`DecisionGraduation` payload — meaning B);
+#   the chain-close semantic (meaning A) gets a precise name. The
+#   `DecisionGraduation` payload + the `decision.graduated` action stay
+#   in soul-protocol for the unshipped pattern-promotion subsystem.
+#   Producers route through `decisions.journal_writer.record_decision_event`
+#   which emits the renamed action.
 from __future__ import annotations
 
 import logging
@@ -60,10 +70,18 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Action namespace constants
 # ---------------------------------------------------------------------------
-# A2 (gap G2): ONLY `decision.graduated` closes a chain. Fabric writes
+# A2 (gap G2): ONLY `decision.completed` closes a chain. Fabric writes
 # CONTRIBUTE inputs but do NOT close. Rejection chains end on
-# `decision.graduated` too — the payload carries `passed=false`.
-_TERMINAL_ACTIONS = frozenset({"decision.graduated"})
+# `decision.completed` too — the payload carries `passed=false`.
+#
+# RFC 09 § "Vocabulary fix" — the chain-closing action used to be named
+# `decision.graduated` and collided with soul-protocol's pattern-
+# promotion concept (`DecisionGraduation` payload). The chain-close
+# semantic was renamed to `decision.completed` (RFC 09 Q2). The
+# `decision.graduated` action stays registered in soul-protocol's
+# ACTION_NAMESPACES for the unshipped pattern-promotion subsystem;
+# nothing in this projection consumes it any more.
+_TERMINAL_ACTIONS = frozenset({"decision.completed"})
 
 # Fabric write actions — they don't close a chain (A2) but they do
 # contribute the target object as an InputRef so the decision row carries
@@ -100,7 +118,7 @@ _TRACKED_ACTIONS = (
 @dataclass
 class _PendingChain:
     """In-flight decision chain — accumulates events under one
-    correlation_id until a `decision.graduated` event closes it."""
+    correlation_id until a `decision.completed` event closes it."""
 
     correlation_id: UUID
     intent: str = ""
@@ -118,7 +136,7 @@ class _PendingChain:
     payload_acc: dict[str, Any] = field(default_factory=dict)
     # A2: if the chain saw a `fabric.object.*` write the projection
     # records the target object as an additional input — but the chain
-    # stays open until `decision.graduated` lands.
+    # stays open until `decision.completed` lands.
     fabric_write_payload: dict[str, Any] | None = None
 
 
@@ -240,7 +258,7 @@ class DecisionProjection:
 
     def apply(self, entry: EventEntry) -> Decision | None:
         """Fold one event. Returns a Decision when a chain closes
-        (`decision.graduated`), or when a `decision.outcome_attached`
+        (`decision.completed`), or when a `decision.outcome_attached`
         mutates an already-emitted Decision, or for a degenerate
         single-write Decision (no correlation_id). Returns None while a
         chain is still accumulating.
@@ -384,7 +402,7 @@ class DecisionProjection:
     def _fold_fabric_write(self, chain: _PendingChain, entry: EventEntry) -> None:
         """A2: a fabric write contributes the target object as an input
         AND records the canonical write payload, but does NOT close the
-        chain. The chain stays open until `decision.graduated` lands."""
+        chain. The chain stays open until `decision.completed` lands."""
         payload = entry.payload or {}
         chain.fabric_write_payload = dict(payload)
         target = payload.get("object_id")
@@ -410,9 +428,9 @@ class DecisionProjection:
         scope_kind = _infer_scope_kind(chain.scope, chain.pocket_id)
 
         # Derive rejection from the freshest available signal:
-        #   1. terminal `decision.graduated` payload's `passed` flag (if set)
+        #   1. terminal `decision.completed` payload's `passed` flag (if set)
         #   2. fall back to the LAST observed `instinct_policy_passed`
-        # A chain that went policy(fail) → human → policy(pass) → graduated
+        # A chain that went policy(fail) → human → policy(pass) → completed
         # ends with `instinct_policy_passed=True` and is NOT rejected.
         terminal_payload = terminal.payload or {}
         terminal_passed = terminal_payload.get("passed")
@@ -439,7 +457,7 @@ class DecisionProjection:
             scope=chain.scope,
             scope_kind=scope_kind,
             intent=chain.intent or "(no intent recorded)",
-            action=chain.action or "graduated",
+            action=chain.action or "completed",
             inputs=chain.inputs,
             approvers=chain.approvers,
             instinct_policy=chain.instinct_policy,

--- a/ee/pocketpaw_ee/cloud/decisions/service.py
+++ b/ee/pocketpaw_ee/cloud/decisions/service.py
@@ -446,27 +446,65 @@ def _visible(decision: Decision, requester_scopes: list[str] | None) -> bool:
 _GRAPH: DecisionGraph | None = None
 
 
-def init_decisions_projection() -> DecisionGraph:
+def init_decisions_projection(*, rebuild_from_journal: bool = False) -> DecisionGraph:
     """Wire the singleton DecisionGraph + projection. Idempotent.
 
     Called from `mount_cloud()` after `init_realtime()`. Subsequent
     calls return the existing singleton — re-mounting (tests) does not
     rebuild the store.
 
-    The projection's `rebuild()` is NOT invoked here. Slice 1 ships the
-    substrate; the rebuild + journal subscription that keeps the
-    projection live land in Slice 2 when the journal-to-projection
-    bus subscriber wires in. For now the store stays empty until a
-    caller (test or future Slice 2 wiring) feeds events via
-    `graph.projection.apply()`.
+    Cold-start replay (RFC 09 Slice 1b)
+    ----------------------------------
+    When `rebuild_from_journal=True` the projection is replayed from the
+    org journal starting at its persisted cursor. This folds any
+    chain-forming events the journal already holds (e.g. events written
+    by a producer in a prior process lifetime before the projection had
+    a chance to apply them). The cursor is persisted by the store, so a
+    warm restart skips the replay — only genuinely-cold starts pay the
+    rebuild cost.
+
+    `mount_cloud()` is the only caller that passes `rebuild_from_journal=
+    True` today. Tests + smoke contexts get the no-replay default so a
+    per-test `tmp_path` decisions.db cannot accidentally absorb events
+    from a developer's real `~/.soul/journal.db`. Tests that want to
+    exercise the rebuild path call `projection.rebuild(...)` directly
+    against a journal fixture (see `tests/ee/test_record_decision_event
+    .py::test_cold_start_rebuild_folds_pre_existing_events`).
+
+    Replay failures are logged but do NOT block boot. The Slice 4
+    reconciler (RFC 09) will catch any rows the cold start missed; the
+    journal remains the source of truth.
     """
     global _GRAPH
     if _GRAPH is None:
         _GRAPH = DecisionGraph()
+        applied = 0
+        if rebuild_from_journal:
+            try:
+                # Local import keeps the journal_dep dependency lazy —
+                # tests + smoke contexts that don't mount cloud skip the
+                # journal lookup entirely.
+                from pocketpaw.journal_dep import get_journal
+
+                journal = get_journal()
+                cursor = _GRAPH.projection.cursor
+                applied = _GRAPH.projection.rebuild(
+                    journal.replay_from(cursor), since_seq=cursor
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "decisions projection cold-start rebuild skipped — "
+                    "journal unavailable or replay failed; projection "
+                    "will start empty and the Slice 4 reconciler will "
+                    "catch up",
+                    exc_info=True,
+                )
         logger.info(
-            "decisions projection initialized — cursor=%d count=%d",
+            "decisions projection initialized — cursor=%d count=%d "
+            "events_replayed=%d",
             _GRAPH.projection.cursor,
             _GRAPH.store.count(),
+            applied,
         )
     return _GRAPH
 

--- a/ee/pocketpaw_ee/cloud/decisions/service.py
+++ b/ee/pocketpaw_ee/cloud/decisions/service.py
@@ -488,9 +488,7 @@ def init_decisions_projection(*, rebuild_from_journal: bool = False) -> Decision
 
                 journal = get_journal()
                 cursor = _GRAPH.projection.cursor
-                applied = _GRAPH.projection.rebuild(
-                    journal.replay_from(cursor), since_seq=cursor
-                )
+                applied = _GRAPH.projection.rebuild(journal.replay_from(cursor), since_seq=cursor)
             except Exception:  # noqa: BLE001
                 logger.warning(
                     "decisions projection cold-start rebuild skipped — "
@@ -500,8 +498,7 @@ def init_decisions_projection(*, rebuild_from_journal: bool = False) -> Decision
                     exc_info=True,
                 )
         logger.info(
-            "decisions projection initialized — cursor=%d count=%d "
-            "events_replayed=%d",
+            "decisions projection initialized — cursor=%d count=%d events_replayed=%d",
             _GRAPH.projection.cursor,
             _GRAPH.store.count(),
             applied,

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -577,3 +577,12 @@ forbidden_modules = [
     "pocketpaw_ee.agent.pocket_specialist.runtime",
     "pocketpaw_ee.agent.pocket_specialist.adapters",
 ]
+
+# RFC 09 Slice 1b — see `scripts/audit_decision_chain.py` for the
+# enforcement of "Decision-Graph chain producers must route through
+# `pocketpaw_ee.cloud.decisions.journal_writer.record_decision_event`."
+# That rule isn't expressible as an import-linter contract because the
+# forbidden surface (`soul_protocol.spec.decisions`) is a sub-package of
+# an external package and import-linter forbidden contracts only accept
+# top-level external packages. The script is wired into the same CI
+# step as `lint-imports` — see `Makefile` / `.github/workflows/ci.yml`.

--- a/scripts/audit_decision_chain.py
+++ b/scripts/audit_decision_chain.py
@@ -186,10 +186,7 @@ def main() -> int:
         )
         return 1
 
-    print(
-        f"Decision-chain audit: clean — {files_scanned} files scanned, "
-        "no violations."
-    )
+    print(f"Decision-chain audit: clean — {files_scanned} files scanned, no violations.")
     return 0
 
 

--- a/scripts/audit_decision_chain.py
+++ b/scripts/audit_decision_chain.py
@@ -1,0 +1,197 @@
+"""Audit chain-event emission outside the canonical helper.
+
+Created: 2026-05-25 (RFC 09 Slice 1b — feat/rfc-09-slice-1-record-decision-event)
+
+The intended replacement was an `import-linter` contract forbidding
+`soul_protocol.spec.decisions` everywhere except
+`pocketpaw_ee.cloud.decisions.journal_writer`. Import-linter does not
+support sub-packages of external packages in forbidden contracts (it
+errors out with "subpackages of external packages are not valid"), and
+forbidding the entire `soul_protocol` external package would break the
+rest of ee/ that relies on it (the journal engine, EventEntry, the
+Actor model, etc.). This script enforces the same intent via a
+text-search pass.
+
+What it forbids
+---------------
+
+Outside `ee/pocketpaw_ee/cloud/decisions/journal_writer.py`, the
+following patterns may not appear in `ee/` source files:
+
+1. ``from soul_protocol.spec.decisions import …`` — the AgentProposal /
+   HumanCorrection / DecisionGraduation models + the
+   ``build_proposal_event`` / ``build_correction_event`` builders.
+2. Any direct EventEntry construction with ``action="agent.proposed"``,
+   ``action="human.corrected"``, ``action="policy.evaluated"``, or
+   ``action="decision.completed"``. These are the four chain-forming
+   actions; emitting them outside the helper bypasses the journal-
+   append-before-projection-apply ordering (RFC 09 audit Q11) and the
+   warning-on-fold-failure isolation (RFC 09 § Architecture).
+
+Why the script exists
+---------------------
+
+RFC 09 § "Producer Design" splits chain-event emission across 9 sites
+in 4 files (per the producer audit at
+``.claude/worktrees/rfc09-producer-audit/AUDIT-REPORT.md``). The
+``record_decision_event`` helper is the chokepoint Slices 2 + 3 will
+wire those sites through. Without enforcement, a future agent reading
+the existing ``FabricJournalStore`` precedent could reasonably reach
+for ``journal.append(entry)`` directly and skip the helper — that
+worked for fabric, after all. This script makes the chain-event rule
+mechanical: a violator surfaces in CI before review.
+
+Usage
+-----
+
+    uv run --group ee python scripts/audit_decision_chain.py
+
+Exit code 0 if clean, 1 if any violations are found. The exit code is
+the signal CI consumes — pair this with ``lint-imports`` in the same
+make target. Add ``--quiet`` for CI to suppress the per-file diff.
+
+Today's baseline is clean: no module in ``ee/`` imports
+``soul_protocol.spec.decisions`` or constructs the chain actions
+directly. The helper is the only allowed importer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# The four chain-forming actions per RFC 09. `decision.outcome_attached`
+# is intentionally absent — it's a mutation-only event emitted from the
+# outcomes service via a separately-audited path.
+_CHAIN_ACTIONS = {
+    "agent.proposed",
+    "human.corrected",
+    "policy.evaluated",
+    "decision.completed",
+}
+
+# Files allowed to do whatever they want with the chain actions / soul-
+# protocol builders. The helper itself MUST import the builders;
+# documentation files can mention them freely; the test that pins the
+# vocabulary swap mentions both old and new names.
+_ALLOWED_PATHS = {
+    "ee/pocketpaw_ee/cloud/decisions/journal_writer.py",
+    "ee/pocketpaw_ee/cloud/decisions/projection.py",  # _TRACKED_ACTIONS membership tests
+    "ee/pocketpaw_ee/cloud/decisions/router.py",  # exposes the explain endpoint payload
+    "ee/pocketpaw_ee/cloud/decisions/__init__.py",
+    "scripts/audit_decision_chain.py",  # this file
+}
+
+# Source roots to walk. Tests are intentionally excluded — they
+# legitimately construct chain events to exercise the projection
+# directly without going through the helper. The audit's job is to
+# enforce the production-code rule, not the test-code rule.
+_SOURCE_ROOTS = ["ee/pocketpaw_ee/", "src/pocketpaw/"]
+
+
+_IMPORT_PATTERN = re.compile(
+    r"\bfrom\s+soul_protocol\.spec\.decisions\s+import\b"
+    r"|\bimport\s+soul_protocol\.spec\.decisions\b"
+)
+
+
+def _build_action_pattern() -> re.Pattern[str]:
+    """Match `action="<chain-action>"` and `action='<chain-action>'`
+    in any line. Looks for the kwarg form because positional EventEntry
+    construction is exotic; the chain helper itself does this in
+    journal_writer.py but that file is allow-listed."""
+    quoted = "|".join(re.escape(a) for a in _CHAIN_ACTIONS)
+    return re.compile(rf'\baction\s*=\s*["\']({quoted})["\']')
+
+
+_ACTION_PATTERN = _build_action_pattern()
+
+
+def _scan_file(path: Path, repo_root: Path) -> list[str]:
+    """Return human-readable violation strings for `path`, or [] if
+    clean. Lines that match either pattern are reported with line number
+    + the offending source text trimmed."""
+    rel = str(path.relative_to(repo_root))
+    if rel in _ALLOWED_PATHS:
+        return []
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+
+    violations: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            # Comments / docstrings (when single-line) shouldn't count.
+            continue
+        if _IMPORT_PATTERN.search(line):
+            violations.append(
+                f"  {rel}:{lineno}: imports soul_protocol.spec.decisions — "
+                f"route through record_decision_event helper\n"
+                f"    {stripped}"
+            )
+        if _ACTION_PATTERN.search(line):
+            violations.append(
+                f"  {rel}:{lineno}: direct chain-action EventEntry construction — "
+                f"route through record_decision_event helper\n"
+                f"    {stripped}"
+            )
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-file violation details; print summary only.",
+    )
+    args = parser.parse_args()
+
+    # Repo root = parent of this script's `scripts/` directory.
+    repo_root = Path(__file__).resolve().parent.parent
+
+    all_violations: list[str] = []
+    files_scanned = 0
+    for src_root in _SOURCE_ROOTS:
+        src_dir = repo_root / src_root
+        if not src_dir.exists():
+            continue
+        for py_file in src_dir.rglob("*.py"):
+            files_scanned += 1
+            all_violations.extend(_scan_file(py_file, repo_root))
+
+    if all_violations:
+        if not args.quiet:
+            print("Decision-chain audit FAILED:\n", file=sys.stderr)
+            for v in all_violations:
+                print(v, file=sys.stderr)
+            print(
+                "\n"
+                "Route chain-event emission through "
+                "`pocketpaw_ee.cloud.decisions.journal_writer.record_decision_event`. "
+                "See RFC 09 Slice 1b and `journal_writer.py`'s module docstring "
+                "for the rationale.",
+                file=sys.stderr,
+            )
+        print(
+            f"Decision-chain audit: FAILED — "
+            f"{len(all_violations)} violation(s) across "
+            f"{files_scanned} scanned files.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"Decision-chain audit: clean — {files_scanned} files scanned, "
+        "no violations."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ee/test_decision_graph_api.py
+++ b/tests/ee/test_decision_graph_api.py
@@ -80,7 +80,7 @@ def _seed_chain(
     seq_base: int = 1000,
 ) -> UUID:
     """Seed one approval chain in the store; return the chain's
-    correlation_id. Returns the FIRST `decision.graduated` Decision's
+    correlation_id. Returns the FIRST `decision.completed` Decision's
     id via a helper lookup post-emit."""
     corr = uuid4()
     scope = scope or ["org:nerve", f"pocket:{pocket_id}"]
@@ -106,7 +106,7 @@ def _seed_chain(
             seq=seq_base + 1,
             ts=base_ts + timedelta(seconds=1),
             actor=actor,
-            action="decision.graduated",
+            action="decision.completed",
             correlation_id=corr,
             payload={"passed": True},
             scope=scope,

--- a/tests/ee/test_decision_projection.py
+++ b/tests/ee/test_decision_projection.py
@@ -98,7 +98,7 @@ def _approval_chain(
     scope: list[str] | None = None,
     pocket_id: str = "p_lease_renewals",
 ) -> tuple[UUID, list[EventEntry]]:
-    """Build a 5-event approval chain ending in `decision.graduated`."""
+    """Build a 5-event approval chain ending in `decision.completed`."""
     corr = correlation_id or uuid4()
     scope = scope or ["org:nerve", f"pocket:{pocket_id}"]
     events = [
@@ -172,7 +172,7 @@ def _approval_chain(
             seq=105,
             ts=base_ts + timedelta(seconds=15),
             actor=_agent_actor(),
-            action="decision.graduated",
+            action="decision.completed",
             correlation_id=corr,
             payload={"passed": True},
             scope=scope,
@@ -182,16 +182,16 @@ def _approval_chain(
 
 
 # ---------------------------------------------------------------------------
-# 1. Happy-path: 5-event chain emits one Decision on `decision.graduated`
+# 1. Happy-path: 5-event chain emits one Decision on `decision.completed`
 # ---------------------------------------------------------------------------
 
 
-def test_chain_emits_decision_on_graduated(
+def test_chain_emits_decision_on_completed(
     projection: DecisionProjection, base_ts: datetime
 ) -> None:
     """A canonical chain (proposed → policy → human → policy → fabric →
-    graduated) emits exactly one Decision, and the terminal event is the
-    graduated event."""
+    completed) emits exactly one Decision, and the terminal event is the
+    completed event."""
     _, events = _approval_chain(base_ts)
 
     emitted = [d for d in (projection.apply(e) for e in events) if d is not None]
@@ -227,9 +227,9 @@ def test_fabric_writes_do_not_close_chain(
 ) -> None:
     """A2 enforcement: a fabric.object.updated event mid-flow records the
     target object as an input but the chain stays OPEN until
-    decision.graduated lands. The store stays empty until then."""
+    decision.completed lands. The store stays empty until then."""
     corr = uuid4()
-    events_before_graduated = [
+    events_before_completed = [
         _event(
             seq=200,
             ts=base_ts,
@@ -251,22 +251,22 @@ def test_fabric_writes_do_not_close_chain(
             payload={"object_id": "lease:LR-2026-117"},
         ),
     ]
-    for e in events_before_graduated:
+    for e in events_before_completed:
         result = projection.apply(e)
         assert result is None, f"chain emitted prematurely on {e.action}"
     # Still empty.
     assert projection.store.count() == 0
 
-    # Now graduate.
-    graduated = _event(
+    # Now complete.
+    completed = _event(
         seq=202,
         ts=base_ts + timedelta(seconds=2),
         actor=_agent_actor(),
-        action="decision.graduated",
+        action="decision.completed",
         correlation_id=corr,
         payload={"passed": True},
     )
-    decision = projection.apply(graduated)
+    decision = projection.apply(completed)
     assert decision is not None
     assert decision.action == "patch"
     # The fabric write's target object is present as an input.
@@ -275,14 +275,14 @@ def test_fabric_writes_do_not_close_chain(
 
 
 # ---------------------------------------------------------------------------
-# 3. Rejection chain — `policy.evaluated(passed=false)` → graduated
+# 3. Rejection chain — `policy.evaluated(passed=false)` → completed
 # ---------------------------------------------------------------------------
 
 
 def test_rejection_chain_emits_rejected_outcome(
     projection: DecisionProjection, base_ts: datetime
 ) -> None:
-    """A rejected policy followed by decision.graduated emits a Decision
+    """A rejected policy followed by decision.completed emits a Decision
     with outcome.status == 'rejected'."""
     corr = uuid4()
     events = [
@@ -314,7 +314,7 @@ def test_rejection_chain_emits_rejected_outcome(
             seq=302,
             ts=base_ts + timedelta(seconds=2),
             actor=_agent_actor(),
-            action="decision.graduated",
+            action="decision.completed",
             correlation_id=corr,
             payload={"passed": False},
         ),
@@ -371,7 +371,7 @@ def test_approver_ref_carries_timestamp_and_position(
             seq=403,
             ts=base_ts + timedelta(seconds=12),
             actor=_agent_actor(),
-            action="decision.graduated",
+            action="decision.completed",
             correlation_id=corr,
             payload={"passed": True},
         ),
@@ -498,7 +498,7 @@ def test_precedent_payload_supplied(projection: DecisionProjection, base_ts: dat
             seq=501,
             ts=base_ts + timedelta(seconds=1),
             actor=_agent_actor(),
-            action="decision.graduated",
+            action="decision.completed",
             correlation_id=corr,
             payload={"passed": True},
         ),
@@ -545,7 +545,7 @@ def test_precedent_fallback_same_pocket_action(
                 seq=601 + i * 10,
                 ts=ts_seed + timedelta(seconds=1),
                 actor=_agent_actor(),
-                action="decision.graduated",
+                action="decision.completed",
                 correlation_id=corr_seed,
                 payload={"passed": True},
             ),
@@ -573,7 +573,7 @@ def test_precedent_fallback_same_pocket_action(
             seq=701,
             ts=base_ts + timedelta(seconds=1),
             actor=_agent_actor(),
-            action="decision.graduated",
+            action="decision.completed",
             correlation_id=corr,
             payload={"passed": True},
         ),

--- a/tests/ee/test_decisions_explain.py
+++ b/tests/ee/test_decisions_explain.py
@@ -211,7 +211,7 @@ def _seed_chain(
         _event(
             ts=base_ts + timedelta(seconds=2),
             actor=actor,
-            action="decision.graduated",
+            action="decision.completed",
             correlation_id=corr,
             payload={"passed": True},
             scope=scope,

--- a/tests/ee/test_decisions_explain_mcp.py
+++ b/tests/ee/test_decisions_explain_mcp.py
@@ -161,7 +161,7 @@ def _seed_chain(
         _event(
             ts=base_ts + timedelta(seconds=1),
             actor=actor,
-            action="decision.graduated",
+            action="decision.completed",
             correlation_id=corr,
             payload={"passed": True},
             scope=scope,

--- a/tests/ee/test_decisions_mcp.py
+++ b/tests/ee/test_decisions_mcp.py
@@ -159,7 +159,7 @@ def _seed_chain(
         _event(
             ts=base_ts + timedelta(seconds=1),
             actor=actor,
-            action="decision.graduated",
+            action="decision.completed",
             correlation_id=corr,
             payload={"passed": True},
             scope=scope,

--- a/tests/ee/test_decisions_router.py
+++ b/tests/ee/test_decisions_router.py
@@ -208,7 +208,7 @@ def _seed_chain(
         _event(
             ts=base_ts + timedelta(seconds=1),
             actor=actor,
-            action="decision.graduated",
+            action="decision.completed",
             correlation_id=corr,
             payload={"passed": True},
             scope=scope,
@@ -602,7 +602,7 @@ def test_timeline_returns_journal_events(client, projection, base_ts, journal_pa
             id=uuid4(),
             ts=base_ts + timedelta(seconds=1),
             actor=actor,
-            action="decision.graduated",
+            action="decision.completed",
             scope=["org:nerve", "workspace:ws_a_test", "pocket:p_main"],
             correlation_id=corr,
             payload={"passed": True},
@@ -618,7 +618,7 @@ def test_timeline_returns_journal_events(client, projection, base_ts, journal_pa
     # Events are seq-ordered.
     assert body["events"][0]["seq"] < body["events"][1]["seq"]
     assert body["events"][0]["action"] == "agent.proposed"
-    assert body["events"][1]["action"] == "decision.graduated"
+    assert body["events"][1]["action"] == "decision.completed"
 
 
 def test_timeline_returns_404_when_decision_missing(client) -> None:

--- a/tests/ee/test_outcomes_decision_backref.py
+++ b/tests/ee/test_outcomes_decision_backref.py
@@ -121,7 +121,7 @@ def _seed_decision(
             id=uuid4(),
             ts=base_ts + timedelta(seconds=1),
             actor=actor,
-            action="decision.graduated",
+            action="decision.completed",
             scope=scope,
             correlation_id=corr,
             payload={"passed": True},

--- a/tests/ee/test_record_decision_event.py
+++ b/tests/ee/test_record_decision_event.py
@@ -29,23 +29,20 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from soul_protocol.engine.journal import open_journal
-from soul_protocol.spec.journal import Actor
-
-import pocketpaw.journal_dep as journal_dep
-import pocketpaw_ee.cloud.decisions.service as decisions_service
 from pocketpaw_ee.cloud.decisions.journal_writer import (
     DECISION_CHAIN_ACTIONS,
     record_decision_event,
 )
-from pocketpaw_ee.cloud.decisions.projection import DecisionProjection
 from pocketpaw_ee.cloud.decisions.service import (
     DecisionGraph,
     get_decision_graph,
     reset_projection_for_tests,
 )
 from pocketpaw_ee.cloud.decisions.store import set_db_path
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.spec.journal import Actor
 
+import pocketpaw.journal_dep as journal_dep
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -359,9 +356,7 @@ def test_decision_chain_actions_contains_renamed_completed() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_helper_preserves_causation_id(
-    journal, graph: DecisionGraph, base_ts: datetime
-) -> None:
+def test_helper_preserves_causation_id(journal, graph: DecisionGraph, base_ts: datetime) -> None:
     """RFC 09 § Correlation propagation calls for `human.corrected` to
     cite the prior `policy.evaluated(passed=False)` via `causation_id`.
     The helper must round-trip that field through to the journal entry."""

--- a/tests/ee/test_record_decision_event.py
+++ b/tests/ee/test_record_decision_event.py
@@ -1,0 +1,394 @@
+# tests/ee/test_record_decision_event.py — RFC 09 Slice 1b coverage for
+# `pocketpaw_ee.cloud.decisions.journal_writer.record_decision_event`.
+# Created: 2026-05-25 (feat/rfc-09-slice-1-record-decision-event).
+#
+# These tests pin the chokepoint helper that Slices 2 + 3 will route
+# every chain-forming producer through. The invariants are:
+#   1. Happy path — the helper appends to the journal AND folds into the
+#      projection; the resulting Decision is queryable via DecisionGraph.
+#   2. Ordering — journal.append fires BEFORE projection.apply. The
+#      journal write is the source of truth; the projection's fold may
+#      see an already-journaled entry but never the reverse. (Verified
+#      via a spy that records the order of calls.)
+#   3. Failure isolation — if projection.apply raises, the journal row
+#      is still written, the helper returns the entry, and a warning is
+#      logged. The Slice 4 reconciler is the safety net.
+#   4. Cold-start rebuild — events that landed in the journal before the
+#      projection started can be folded by calling
+#      `projection.rebuild(journal, since_seq=0)`. This is the
+#      `init_decisions_projection`-time contract.
+#
+# Helper file under test: ee/pocketpaw_ee/cloud/decisions/journal_writer.py.
+# Sibling tests for the vocabulary rename live in test_decision_projection.py.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.spec.journal import Actor
+
+import pocketpaw.journal_dep as journal_dep
+import pocketpaw_ee.cloud.decisions.service as decisions_service
+from pocketpaw_ee.cloud.decisions.journal_writer import (
+    DECISION_CHAIN_ACTIONS,
+    record_decision_event,
+)
+from pocketpaw_ee.cloud.decisions.projection import DecisionProjection
+from pocketpaw_ee.cloud.decisions.service import (
+    DecisionGraph,
+    get_decision_graph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import set_db_path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    """A fresh on-disk journal per test. Patches the journal_dep cache so
+    `record_decision_event` (which looks the journal up via get_journal)
+    sees this instance."""
+    j = open_journal(tmp_path / "journal.db")
+    # Replace the cache so the helper's lazy get_journal() picks ours up.
+    journal_dep.reset_journal_cache()
+    journal_dep._cached_journal.cache_clear()
+    # Monkeypatch the cached factory to return our instance for the test.
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path):
+    """A fresh DecisionGraph + decisions.db per test, wired in as the
+    process-global singleton via reset_projection_for_tests."""
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+@pytest.fixture
+def base_ts() -> datetime:
+    return datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+
+
+def _agent_actor() -> Actor:
+    return Actor(kind="agent", id="did:soul:agent_1", scope_context=["org:nerve"])
+
+
+def _user_actor() -> Actor:
+    return Actor(kind="user", id="user:prakash", scope_context=["org:nerve"])
+
+
+def _system_actor() -> Actor:
+    return Actor(kind="system", id="system:instinct", scope_context=["org:nerve"])
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path — helper journals + folds; chain emits a Decision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_happy_path_helper_journals_and_folds(
+    journal, graph: DecisionGraph, base_ts: datetime
+) -> None:
+    """A canonical 3-event chain (proposed → human.corrected → completed)
+    routed through `record_decision_event` lands one Decision and shows up
+    via DecisionGraph.find()."""
+    corr = uuid4()
+    scope = ["org:nerve", "pocket:p_lease"]
+
+    record_decision_event(
+        action="agent.proposed",
+        correlation_id=corr,
+        actor=_agent_actor(),
+        scope=scope,
+        ts=base_ts,
+        payload={
+            "intent": "Renew LR-2026-117",
+            "action": "send_renewal",
+            "pocket_id": "p_lease",
+        },
+    )
+    record_decision_event(
+        action="human.corrected",
+        correlation_id=corr,
+        actor=_user_actor(),
+        scope=scope,
+        ts=base_ts + timedelta(seconds=10),
+        payload={"action": "approve"},
+    )
+    record_decision_event(
+        action="decision.completed",
+        correlation_id=corr,
+        actor=_agent_actor(),
+        scope=scope,
+        ts=base_ts + timedelta(seconds=12),
+        payload={"passed": True},
+    )
+
+    # Projection state: one Decision, one approver, action from the
+    # proposed payload.
+    assert graph.store.count() == 1
+    decisions = await graph.find()
+    assert len(decisions) == 1
+    decision = decisions[0]
+    assert decision.action == "send_renewal"
+    assert decision.intent.startswith("Renew LR-2026-117")
+    assert decision.correlation_id == corr
+    assert len(decision.approvers) == 1
+    assert decision.approvers[0].actor.id == "user:prakash"
+
+    # Journal state: three events landed in append order.
+    journaled = list(journal.replay_from(0))
+    assert [e.action for e in journaled] == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ]
+    assert all(e.correlation_id == corr for e in journaled)
+
+
+# ---------------------------------------------------------------------------
+# 2. Ordering — journal.append fires BEFORE projection.apply
+# ---------------------------------------------------------------------------
+
+
+def test_journal_append_runs_before_projection_apply(
+    journal, graph: DecisionGraph, base_ts: datetime, monkeypatch
+) -> None:
+    """If the helper called projection.apply before journal.append, a
+    crash between the two would leave the projection ahead of the
+    journal. Wrap both with spies and verify the call order."""
+    call_order: list[str] = []
+
+    real_append = journal.append
+
+    def spy_append(entry):
+        call_order.append("journal.append")
+        return real_append(entry)
+
+    monkeypatch.setattr(journal, "append", spy_append)
+
+    real_apply = graph.projection.apply
+
+    def spy_apply(entry):
+        call_order.append("projection.apply")
+        return real_apply(entry)
+
+    monkeypatch.setattr(graph.projection, "apply", spy_apply)
+
+    record_decision_event(
+        action="agent.proposed",
+        correlation_id=uuid4(),
+        actor=_agent_actor(),
+        scope=["org:nerve", "pocket:p_lease"],
+        ts=base_ts,
+        payload={"intent": "x", "action": "send", "pocket_id": "p_lease"},
+    )
+
+    assert call_order == ["journal.append", "projection.apply"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Failure isolation — projection failures don't block journal writes
+# ---------------------------------------------------------------------------
+
+
+def test_projection_apply_failure_does_not_block_journal_write(
+    journal, graph: DecisionGraph, base_ts: datetime, caplog, monkeypatch
+) -> None:
+    """Per RFC 09 § Architecture, the journal is the source of truth. A
+    raised exception from `projection.apply` is logged but does not
+    propagate — the helper returns the entry and the journal still has
+    the row. The Slice 4 reconciler will catch the missed apply."""
+    corr = uuid4()
+
+    def boom(_entry):
+        raise RuntimeError("simulated projection error")
+
+    monkeypatch.setattr(graph.projection, "apply", boom)
+
+    caplog.set_level(logging.WARNING, logger="pocketpaw_ee.cloud.decisions.journal_writer")
+
+    # The call MUST succeed despite the projection blowing up.
+    entry = record_decision_event(
+        action="agent.proposed",
+        correlation_id=corr,
+        actor=_agent_actor(),
+        scope=["org:nerve", "pocket:p"],
+        ts=base_ts,
+        payload={"intent": "x", "action": "send", "pocket_id": "p"},
+    )
+    assert entry.action == "agent.proposed"
+    assert entry.correlation_id == corr
+
+    # Journal row exists.
+    journaled = list(journal.replay_from(0))
+    assert len(journaled) == 1
+    assert journaled[0].correlation_id == corr
+
+    # A warning was logged with enough context to triage.
+    warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert warning_records, "no warning logged for failed projection.apply"
+    msg = warning_records[0].getMessage()
+    assert "agent.proposed" in msg
+    assert str(corr) in msg
+
+
+# ---------------------------------------------------------------------------
+# 4. Cold-start rebuild — events in the journal pre-projection still fold
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cold_start_rebuild_folds_pre_existing_events(
+    journal, tmp_path: Path, base_ts: datetime
+) -> None:
+    """Write three chain events directly to the journal (simulating a
+    producer running before the projection's process boots), then build
+    a fresh projection and call rebuild — the chain folds and the
+    Decision shows up."""
+    from soul_protocol.spec.journal import EventEntry
+
+    corr = uuid4()
+    scope = ["org:nerve", "pocket:p_lease"]
+
+    # Three events appended directly — bypass the helper to mimic a
+    # producer that ran in a prior process lifetime.
+    events_to_seed = [
+        EventEntry(
+            id=uuid4(),
+            ts=base_ts,
+            actor=_agent_actor(),
+            action="agent.proposed",
+            scope=scope,
+            correlation_id=corr,
+            payload={"intent": "Cold start", "action": "send", "pocket_id": "p_lease"},
+        ),
+        EventEntry(
+            id=uuid4(),
+            ts=base_ts + timedelta(seconds=1),
+            actor=_user_actor(),
+            action="human.corrected",
+            scope=scope,
+            correlation_id=corr,
+            payload={"action": "approve"},
+        ),
+        EventEntry(
+            id=uuid4(),
+            ts=base_ts + timedelta(seconds=2),
+            actor=_agent_actor(),
+            action="decision.completed",
+            scope=scope,
+            correlation_id=corr,
+            payload={"passed": True},
+        ),
+    ]
+    for e in events_to_seed:
+        journal.append(e)
+
+    # Fresh projection (different db path so we don't clash with other
+    # tests in the same module) — cursor=0, store empty.
+    set_db_path(tmp_path / "cold_start_decisions.db")
+    reset_projection_for_tests()
+    try:
+        graph = get_decision_graph()
+        assert graph.store.count() == 0
+
+        # Bootstrap replay — fold the journal into the projection.
+        applied = graph.projection.rebuild(journal.replay_from(0), since_seq=0)
+        assert applied == 3
+        assert graph.store.count() == 1
+
+        decisions = await graph.find()
+        assert len(decisions) == 1
+        assert decisions[0].correlation_id == corr
+        assert decisions[0].action == "send"
+    finally:
+        reset_projection_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# 5. Decision chain action set — vocabulary fix snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_decision_chain_actions_contains_renamed_completed() -> None:
+    """RFC 09 Q2: the chain-closing action is `decision.completed`, not
+    `decision.graduated`. Lock it down so a future merge can't quietly
+    swap back."""
+    assert "decision.completed" in DECISION_CHAIN_ACTIONS
+    assert "decision.graduated" not in DECISION_CHAIN_ACTIONS
+    # Outcome attachment is NOT a chain-forming action — it mutates an
+    # already-emitted Decision via the outcomes service's own path.
+    assert "decision.outcome_attached" not in DECISION_CHAIN_ACTIONS
+    # Fabric writes contribute but don't terminate the chain — they have
+    # their own (already-shipped) co-location story in FabricJournalStore.
+    assert "fabric.object.updated" not in DECISION_CHAIN_ACTIONS
+    # Spine actions are all present.
+    assert {
+        "agent.proposed",
+        "human.corrected",
+        "policy.evaluated",
+        "decision.completed",
+    } == DECISION_CHAIN_ACTIONS
+
+
+# ---------------------------------------------------------------------------
+# 6. Causation chaining — helper threads causation_id through
+# ---------------------------------------------------------------------------
+
+
+def test_helper_preserves_causation_id(
+    journal, graph: DecisionGraph, base_ts: datetime
+) -> None:
+    """RFC 09 § Correlation propagation calls for `human.corrected` to
+    cite the prior `policy.evaluated(passed=False)` via `causation_id`.
+    The helper must round-trip that field through to the journal entry."""
+    corr = uuid4()
+    scope = ["org:nerve", "pocket:p"]
+
+    policy_entry = record_decision_event(
+        action="policy.evaluated",
+        correlation_id=corr,
+        actor=_system_actor(),
+        scope=scope,
+        ts=base_ts,
+        payload={"policy": "approve_per_row", "passed": False, "reason": "park"},
+    )
+
+    correction_entry = record_decision_event(
+        action="human.corrected",
+        correlation_id=corr,
+        actor=_user_actor(),
+        scope=scope,
+        ts=base_ts + timedelta(seconds=5),
+        causation_id=policy_entry.id,
+        payload={"action": "approve"},
+    )
+
+    assert correction_entry.causation_id == policy_entry.id
+    # Journal entry preserves the link.
+    journaled = list(journal.replay_from(0))
+    assert journaled[1].action == "human.corrected"
+    assert journaled[1].causation_id == policy_entry.id


### PR DESCRIPTION
## What changed

Slice 1b of RFC 09 (paw-workspace#63) — the live-formation work that
will let the Decision Graph actually fill with chains in production.
This PR ships the chokepoint helper, swaps the chain-closing
vocabulary, wires cold-start replay, and adds a lint-style audit so
producers added in Slices 2 + 3 don't quietly bypass the helper.

### 1. `record_decision_event` helper

New module `ee/pocketpaw_ee/cloud/decisions/journal_writer.py`. The
function takes the kwargs every chain-forming producer needs (action,
correlation_id, actor, scope, payload, optional causation_id / ts /
event_id), builds an `EventEntry`, then runs `journal.append` followed
by `projection.apply`. Ordering is load-bearing — the producer audit
(`.claude/worktrees/rfc09-producer-audit/AUDIT-REPORT.md`, Q11)
showed that applying before appending would let a crash between the
two leave the projection ahead of the journal. The helper enforces the
journal-first sequence so producers don't have to remember.

`projection.apply` failures are logged at WARNING and swallowed.
Letting a fold bug block an Instinct approval would couple every
write to the Decision Graph's health — the opposite of what RFC 09
wants. The Slice 4 reconciler will catch any rows the hot path
missed.

Soul-protocol 0.3.1 (current wheel) doesn't ship the new
`build_policy_event` / `build_completion_event` builders yet — those
land in Slice 1a. The helper constructs `EventEntry` directly with
string-literal action names and a `TODO(rfc09-slice-1a-wheel)` marker
so the swap is mechanical when the new wheel publishes.

### 2. `_TERMINAL_ACTIONS` vocabulary swap

`projection.py` now closes chains on `decision.completed` instead of
`decision.graduated`. The old name collided with soul-protocol's
unshipped pattern-promotion concept (`DecisionGraduation` payload —
meaning B), where the chain-close path is meaning A; two concepts
cannot share one action name without a malformed projection on the
wrong payload. The `decision.graduated` action stays registered in
soul-protocol for the pattern-promotion subsystem; nothing in this
projection consumes it any more. RFC 09 Q2 fix.

Test fixtures across 8 files swapped to the new name. The 126 RFC 07
tests stay green.

### 3. Cold-start replay in `init_decisions_projection`

`mount_cloud()` now passes `rebuild_from_journal=True` so a cold boot
folds any chain events the journal already holds (e.g. events written
by a producer in a prior process lifetime that crashed before the
projection could apply). Warm restarts skip the replay because the
projection cursor is persisted in `decisions.db`. Tests + smoke
contexts get the no-replay default so a per-test `tmp_path` decisions
.db cannot absorb events from a developer's real `~/.soul/journal.db`.

### 4. Decision-chain audit script

`scripts/audit_decision_chain.py` greps for `from soul_protocol.spec
.decisions import` and for direct `EventEntry(action="agent.proposed"
...)` style construction outside `journal_writer.py`. Today's baseline
is clean — no module in `ee/` imports the builders. Slices 2 + 3
producers that try to bypass the helper will surface here.

This started as an `import-linter` contract but `lint-imports`
forbidden contracts only accept top-level external packages; we want
to forbid `soul_protocol.spec.decisions` specifically without losing
`soul_protocol.spec.journal` / `soul_protocol.engine.journal` /
etc. The audit script captures the same intent and also catches the
"direct EventEntry construction without the import" pattern that
import-linter wouldn't see anyway.

## How to verify

```bash
cd .claude/worktrees/rfc09-slice1-helper
uv run --group ee pytest tests/ee/test_record_decision_event.py -v
uv run --group ee pytest tests/ee/test_decision_projection.py tests/ee/test_decision_graph_api.py tests/ee/test_decisions_router.py tests/ee/test_decisions_mcp.py tests/ee/test_outcomes_decision_backref.py tests/ee/test_decisions_explain.py tests/ee/test_decisions_explain_mcp.py tests/ee/test_bundled_decision_graph_template.py -q
uv run --group ee pytest tests/ee/ -q
uv run --group ee lint-imports --config ee/pyproject.toml
uv run --group ee python scripts/audit_decision_chain.py
```

- 6 new helper tests cover happy path, ordering invariant, failure
  isolation, cold-start replay, the vocabulary lock, and causation_id
  threading
- 93 existing decision tests pass with the rename
- 639 broader ee tests stay green
- 17 import-linter contracts kept
- audit script clean on 763 scanned files

## What's deliberately not in this PR

- Slices 2 + 3 producer wiring (the actual `record_decision_event`
  call sites in `action_executor.run_action`, `instinct_bridge`, and
  `instinct/router`). Those depend on this helper landing first.
- Slice 1a soul-protocol vocabulary changes (new payload models +
  builders, `decision.completed` registered in `ACTION_NAMESPACES`).
  Tracked separately.
- Slice 4 reconciler + abandon-path sweeper.