### PR TITLE
docs: concept pages for Decision Graph, planner, router, templates, Calendar, Composio, OSS-EE

### DIFF
--- a/docs/concepts/calendar.mdx
+++ b/docs/concepts/calendar.mdx
@@ -1,0 +1,178 @@
+---
+title: "Calendar Module: Native Events, RRULE, Free/Busy"
+description: "PocketPaw's first-party calendar primitive. Events with RFC 5545 recurrence, conflict detection, free/busy queries, and a Fabric pointer for cross-domain joins. Mounted under /api/v1/calendar on the cloud app."
+section: Core Concepts
+ogType: article
+keywords: ["calendar module", "calendar primitive", "rrule", "recurrence", "free busy", "calendar conflicts"]
+tags: ["calendar", "ee", "modules"]
+---
+
+# Calendar Module: Native Events, RRULE, Free/Busy
+
+The calendar module is a native PocketPaw primitive — events, recurring rules, free/busy queries, conflict detection — not a wrapper over Google Calendar or any external system. It lives in `ee/pocketpaw_ee/calendar/`, mounts under `/api/v1/calendar`, and pairs with the [Google Calendar integration](/integrations/calendar) which uses its own tools and remote sync. Use this module when you want PocketPaw to own the events (workspace-scoped, joined to Fabric objects); use the integration when you want PocketPaw to read/write the user's existing Google Calendar.
+
+<Callout type="info">
+**Status (2026-05-25):** IMPLEMENTED.
+
+**Implementation PRs:** #1130 (RFC), #1132 (module land — domain, service, router, RRULE, freebusy), #1139 (mount into the cloud app), #1143 (security follow-ups from the #1132 review).
+
+**What's live:** `pocketpaw_ee.calendar` module with `domain.py`, `service.py`, `router.py`, RRULE expansion (`recurrence.py`), free/busy union queries (`freebusy.py`), conflict detection (`conflicts.py`), sync stub (`sync.py`); the canonical `pocketpaw_ee.cloud.calendar` sibling for the agent's per-turn surface preamble (#1218); router mounted at `/api/v1/calendar` from `pocketpaw_ee.cloud.__init__`; security hardening from PR #1143 (EmailStr on Attendee, RRULE length cap 2048, exception cap 500, datetime-typed query params, accessible-calendar gate on free/busy, creator-equality on modify).
+
+**What's planned:** remaining security follow-ups from the PR #1132 review (issue #1142); recurrence expansion plugged into `freebusy.compute_freebusy` (today masters only — recurring instances inside the window appear as a single busy block from the master row).
+</Callout>
+
+## The Two Calendar Modules
+
+PocketPaw has two `calendar` modules. They share a name but solve different problems.
+
+| Module | Path | Role |
+|---|---|---|
+| **`pocketpaw_ee.calendar`** | `ee/pocketpaw_ee/calendar/` | The full primitive — CRUD, RRULE, free/busy, conflicts. The subject of this page. |
+| **`pocketpaw_ee.cloud.calendar`** | `ee/pocketpaw_ee/cloud/calendar/` | A surface-preamble read adapter that proxies upcoming events into the chat agent's per-turn context (#1218). Domain + dto + service only, no router. |
+
+The `pocketpaw_ee.calendar.__init__` carries a pointer to the sibling so future contributors find both modules.
+
+## Module Layout — The 4-File Shape Plus Helpers
+
+The module follows the ee/cloud canonical 4-file shape (domain / dto / service / router) with a few extra pure-Python helpers:
+
+```
+ee/pocketpaw_ee/calendar/
+├── domain.py        # Frozen Pydantic value objects (Event, Calendar, Recurrence, Attendee, FreeBusy)
+├── dto.py           # Request / response DTOs (CreateEventRequest, EventResponse, ConflictReport, ...)
+├── service.py       # Module-level async functions — the business logic
+├── router.py        # FastAPI router (thin wrappers, no logic)
+├── models.py        # Beanie documents (_EventDoc, _CalendarDoc) — private
+├── recurrence.py    # Pure RRULE expansion (dateutil.rrule wrapper)
+├── freebusy.py      # Union-of-busy-periods query
+├── conflicts.py     # Overlap detection across attendees
+├── policy.py        # check_calendar_read, check_event_modify (creator-equality, visibility)
+├── events.py        # CalendarEventCreated / Updated / Deleted bus events
+├── sync.py          # External-system sync hook (Google Calendar bridge target)
+└── _context.py      # RequestContext for the calendar entity
+```
+
+## Domain — Multi-Tenancy at Construction
+
+The value objects in `domain.py` are frozen Pydantic models with `workspace_id` required and no default. Construction without tenancy info is a type error, per ee/cloud Rule 3.
+
+```python
+class Event(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    workspace_id: str          # required — no default
+    calendar_id: str
+    title: str
+    starts_at: datetime
+    ends_at: datetime
+    timezone: str              # IANA, e.g. "America/Los_Angeles"
+    created_by_user_id: str    # H-NEW-1: required, gates creator-equality modify
+    description: str = ""
+    location: str | None = None
+    attendees: list[Attendee] = Field(default_factory=list)
+    recurrence: Recurrence | None = None
+    fabric_object_id: str | None = None       # join target into ee/fabric
+    source_connector: str | None = None       # e.g. "gcalendar"
+    source_external_id: str | None = None     # e.g. the Google event id
+    created_at: datetime
+    updated_at: datetime
+```
+
+Notable invariants on the related models:
+
+- **`Attendee.email: EmailStr`** — Pydantic's email-validator integration rejects malformed emails at the boundary (PR #1143 M3) instead of letting them propagate into the DB.
+- **`Recurrence.rrule: str = Field(min_length=1, max_length=2048)`** — caps pathological RRULE strings that could choke expansion (PR #1143 M1).
+- **`Recurrence.exceptions: list[datetime] = Field(default_factory=list, max_length=500)`** — caps unbounded growth that would slow conflict detection (PR #1143 M2).
+- **`Calendar.visibility`** — `PUBLIC_TO_WORKSPACE` / `PRIVATE` / `SHARED_WITH_USERS`. Read access is also gated by `policy.check_calendar_read`.
+
+The `fabric_object_id` field lets a Customer Fabric object have a related Meeting event without a join table — a key cross-domain primitive.
+
+## RRULE Handling
+
+`recurrence.py` is **pure** — no DB, no bus, no I/O. It takes a master `Event` with a `Recurrence` and expands to concrete instances within a window.
+
+```python
+def expand_recurrence(
+    master: Event,
+    range_start: datetime,
+    range_end: datetime,
+) -> list[Event]: ...
+```
+
+Rules:
+
+- If the master has no `recurrence`, returns `[master]` when its window overlaps the range, else `[]`.
+- `range_start` inclusive, `range_end` exclusive.
+- `recurrence.exceptions` removes matching occurrences (compared to generated start datetime, not the human-visible local date).
+- `recurrence.until` and `recurrence.count` are honoured if the underlying RRULE didn't already encode them.
+- Each expanded instance keeps the master's id; callers disambiguate via `starts_at`.
+- Hard cap: `_MAX_INSTANCES = 5000` (~13 years of daily recurrence — well beyond any legitimate use).
+- The parser wraps `dateutil.rrule.rrulestr`; it synthesizes a DTSTART from `master.starts_at` if the RRULE omits one.
+
+## Free/Busy
+
+`freebusy.py` computes the union of busy periods for a list of attendees within a window using a single Mongo `$in` query on `attendees.email` (cheaper than N queries).
+
+```python
+async def compute_freebusy(
+    workspace_id: str,
+    attendee_emails: list[str],
+    starts_at: datetime,
+    ends_at: datetime,
+    accessible_calendar_ids: set[str] | None = None,
+) -> list[FreeBusy]: ...
+```
+
+The `accessible_calendar_ids` argument (PR #1143 H2 — closes the availability-oracle gap) restricts which calendars contribute to the returned busy periods. The service layer is the chokepoint for "is this email known on a calendar I can see?" pre-validation; events on calendars outside the set are silently dropped from the result so a requester only sees busy blocks for calendars they could read directly. `None` preserves legacy behaviour for trusted internal callers.
+
+Recurrence today: this implementation queries the **master rows only**, so recurring instances inside the window appear as a single busy block (the master's window). A planned follow-up plugs `expand_recurrence` in here — documented in the module docstring so the gap is explicit, not silent.
+
+Per-attendee emails are lowercased for case-insensitive matching against stored data; the response preserves the caller's casing so it matches what they sent.
+
+## REST Routes
+
+Mounted from `ee/pocketpaw_ee/cloud/__init__.py` via:
+
+```python
+from pocketpaw_ee.calendar import router as calendar_router
+app.include_router(calendar_router)  # router declares its own /api/v1/calendar prefix
+```
+
+| Route | Returns |
+|---|---|
+| `POST /api/v1/calendar/events` | `EventResponse` (201) |
+| `GET /api/v1/calendar/events?starts_after=&starts_before=&calendar_id=&limit=` | `EventListResponse` |
+| `GET /api/v1/calendar/events/:id` | `EventResponse` |
+| `PATCH /api/v1/calendar/events/:id` | `EventResponse` |
+| `DELETE /api/v1/calendar/events/:id` | 204 |
+| `POST /api/v1/calendar/freebusy` | `FreeBusyResponse` |
+| `GET /api/v1/calendar/events/:id/conflicts` | `ConflictReport` |
+
+The router is intentionally thin — every handler delegates to `service.py`, never raises `HTTPException`, and lets `_core.http` map `CloudError` subclasses to JSON. The list endpoint declares `starts_after` and `starts_before` as `datetime` query parameters directly (PR #1143 H3) so FastAPI returns 422 on malformed input instead of bubbling a `ValueError` into the global 500 handler.
+
+## Security Hardening (PR #1143)
+
+The #1132 review surfaced a stack of gaps. PR #1143 closed the high-severity ones:
+
+| Tag | Gap | Fix |
+|---|---|---|
+| H2 | Availability oracle on `/freebusy` | `accessible_calendar_ids` set restricts which calendars contribute |
+| H3 | Unvalidated datetime query params returned 500 | Declare as `datetime` parameters; FastAPI returns 422 |
+| H-NEW-1 | A synthetic-default Calendar granted cross-user modify | `Event.created_by_user_id` required; `policy.check_event_modify` gates on creator-equality |
+| M1 | Pathological RRULE strings | `rrule` capped at 2048 chars |
+| M2 | Unbounded exceptions list | `exceptions` capped at 500 entries |
+| M3 | Malformed email addresses propagating into DB | `Attendee.email: EmailStr` |
+
+The remaining items from the review are tracked in issue #1142.
+
+## Frontend Pairing
+
+paw-enterprise wires the routes into a calendar widget that pairs with the [Pocket Templates](/concepts/pocket-templates) `calendar-planner` bundled template. The widget calls `GET /api/v1/calendar/events` for the visible window and `POST /api/v1/calendar/events` from the composer. Live-source state seeding (see `feat/pockets` work in the live recovery cascade) keeps the widget reactive after every mutation without a full pocket rebuild.
+
+## Related
+
+- [Google Calendar Integration](/integrations/calendar) — the tool-level adapter that reads/writes a user's Google Calendar (uses `calendar_list`, `calendar_create`, `calendar_search` tools and OAuth).
+- [Pocket Templates](/concepts/pocket-templates) — the `calendar-planner` bundled template instantiates a pocket against this module's routes.
+- [OSS-EE Split](/concepts/oss-ee-split) — the calendar module lives under `pocketpaw_ee` and ships only in the enterprise wheel.
+- [API Reference](/api) — full REST endpoint documentation (calendar routes coming in a follow-up sweep).

--- a/docs/concepts/decision-graph.mdx
+++ b/docs/concepts/decision-graph.mdx
@@ -1,0 +1,167 @@
+---
+title: "Decision Graph: Queryable Why-Did-We-Do-That"
+description: "RFC 07's first-class Decision objects, folded out of the soul-protocol journal: one Decision per agent proposal, chained by correlation_id, with REST + MCP + NL-explain on top. The trace you can answer 'why' against."
+section: Core Concepts
+ogType: article
+keywords: ["decision graph", "rfc 07", "decision projection", "decision trace", "decision explain", "audit trail"]
+tags: ["architecture", "decisions", "rfc-07", "ee"]
+---
+
+# Decision Graph: Queryable Why-Did-We-Do-That
+
+The Decision Graph turns the append-only journal into queryable Decision objects. Every agent proposal that resolves becomes one Decision row plus zero-or-more correction, approval, and outcome events folded onto it. The graph then exposes `get`, `find`, `trace`, `downstream`, `count`, and `explain` over those rows — so "why did the agent do that?" becomes a query, not a forensic dig through journal events.
+
+<Callout type="info">
+**Status (2026-05-25):** IN FLIGHT — Slices 1, 2, and 3a are live on `dev`.
+
+**Implementation PRs:** #1226 (Slice 1 — `DecisionProjection` + Python API substrate), #1238 (Slice 2 — REST + MCP wrappers + outcomes back-reference), #1237 (Slice 3a — narrator + explain route + bundled pocket template), all rebase-merged via #1240 (umbrella).
+
+**Workspace RFC:** [docs/rfc/07-decision-graph-query-layer.md](https://github.com/qbtrix/paw-workspace/blob/main/docs/rfc/07-decision-graph-query-layer.md) (with amendments A1/A2/A3 — paw-workspace#58)
+
+**What's live:** `DecisionProjection` rebuilds from the journal. Five REST routes + `POST /decisions/explain`. Four MCP wrappers under `mcp__pocketpaw_decisions__`. Outcomes back-reference via `decision.outcome_attached`. NL extractor → narrator → SQLite cache pipeline. Bundled `decision-graph` pocket template.
+
+**What's planned:** scope-inference widening beyond `workspace:{id}`, post-merge cleanups flagged in slice reviews (singleton state leak across tests, `_compress_trace` cap alignment, public journal `query_with_seq` to replace the `_backend._conn` access in the timeline route).
+</Callout>
+
+## What a Decision Is
+
+A Decision is the **fold of an N-event journal subgraph into one queryable record**. The shape is pinned in `pocketpaw_ee.cloud.decisions.domain.Decision`:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `id` | `UUID` | Primary collision-defeater; v4 random |
+| `ts` | `datetime` | tz-aware UTC, matches `EventEntry.ts` |
+| `decided_by` | `Actor` | `agent` / `user` / `system` / `root` — same `Actor` as the journal |
+| `scope` | `list[str]` (min_length=1) | Scope tags (`workspace:abc`, `pocket:p1`); required at construction |
+| `intent` | `str` | What the agent set out to do |
+| `action` | `str` | The canonical action name (e.g. `lease.approved`) |
+| `inputs` | `list[InputRef]` | Facts considered — `fabric_object`, `dataref`, or another `decision` |
+| `approvers` | `list[ApproverRef]` | Each carries `approved_at` + `position` (RFC amendment A1, gap G1) |
+| `instinct_policy` / `_passed` | `str` / `bool` | Which Instinct policy gated this, and whether it passed |
+| `precedents` | `list[DecisionRef]` | Decisions cited as templates (`weight` ranks them) |
+| `outcome` | `OutcomeRef \| None` | Late-attached via `decision.outcome_attached` |
+| `pocket_id` | `str \| None` | If this Decision was made inside a Pocket |
+| `correlation_id` | `UUID \| None` | Chain key — every Decision in the chain shares this |
+| `hash_link` | `str` | SHA-256 over content + `prev_hash`; tampering breaks the chain |
+| `last_seq` | `int` | Latest journal `seq` the projection folded |
+
+The Decision is **mutable in exactly one place**: when a late `decision.outcome_attached` event lands, `outcome` is filled in. Everything else is content-bound and hashed. The hash material excludes `outcome` deliberately so that late mutation never invalidates the chain (RFC 07 gap G6, `compute_hash_link` doc-comment).
+
+## Where Decisions Come From
+
+The projection at `pocketpaw_ee.cloud.decisions.projection.DecisionProjection` replays the soul-protocol journal and folds tracked actions into Decisions. The chain shape:
+
+```
+agent.proposed (opens chain)
+  → human.corrected* (zero or more)
+  → policy.evaluated* (zero or more)
+  → fabric.object.{created,updated,archived}* (contribute inputs, do NOT close)
+  → decision.graduated (closes chain → emits Decision)
+  → decision.outcome_attached (late mutates Decision.outcome)
+```
+
+The terminal-action set is pinned by `_TERMINAL_ACTIONS = frozenset({"decision.graduated"})` (RFC amendment A2, gap G2). Fabric writes never close a chain on their own — they only contribute the target object as an `InputRef`. That decoupling means the projection doesn't have to know about Fabric's namespace; Fabric just shows up as an input.
+
+Precedent supply order (A3): the agent's own payload first, then a projection fallback (same-pocket / same-action / nearest-ts) if the proposer didn't supply any. Out-of-band reconciler is deferred.
+
+## The Python API
+
+`pocketpaw_ee.cloud.decisions.service.DecisionGraph` is the in-process surface. One instance per process (per org), accessed via `get_decision_graph()`. All methods are `async`:
+
+```python
+from pocketpaw_ee.cloud.decisions.service import get_decision_graph
+
+graph = get_decision_graph()
+
+# Single lookup — returns None for both "missing" and "scope-hidden"
+decision = await graph.get(decision_id, requester_scopes=["workspace:abc"])
+
+# Index-driven multi-axis filter with keyset pagination
+results = await graph.find(
+    actor="agent:claude",
+    since=datetime(2026, 5, 1),
+    scope_kind="pocket",
+    pocket_id="p_abc123",
+    outcome_status="landed",
+    limit=50,
+    before_ts=cursor_ts,
+    before_id=cursor_id,
+    requester_scopes=["workspace:abc"],
+)
+
+# Post-scope-filter total — the same iteration path as find(), no limit/cursor
+total = await graph.count(actor="agent:claude", requester_scopes=["workspace:abc"])
+
+# Depth-bounded BFS upstream — walks `precedent` + `input` edges
+trace = await graph.trace(decision_id, depth=3, max_fanout=20, requester_scopes=...)
+
+# Inverse — decisions that later cited this one as a precedent
+downstream = await graph.downstream(decision_id, depth=3, requester_scopes=...)
+```
+
+**The scope-filter-post-count invariant.** Every read filters by scope BEFORE counting. The store exposes unfiltered iterators; the service is the one place that enforces the filter. A caller cannot probe for hidden decisions by comparing pre- and post-filter counts because no pre-filter count is ever computed. This mirrors `FabricProjection.query`'s contract (`src/pocketpaw/fabric/projection.py`) that closed the #938 pagination leak.
+
+**Pagination.** Keyset-style on `(ts DESC, id DESC)` per RFC 07's perf budget. `find()` takes `before_ts` + `before_id` cursors from the prior page. OFFSET-based pagination gets pathologically slow at scale, so the API never offers it.
+
+## REST Routes (Slice 2)
+
+Mounted at `/api/v1/decisions` from `pocketpaw_ee.cloud.decisions.router`. License-gated via `Depends(require_license)`.
+
+| Route | Returns |
+|---|---|
+| `GET /decisions/:id` | `DecisionResponse` |
+| `GET /decisions?actor=&since=&until=&...` | `DecisionsListResponse` (paginated, post-filter `total`) |
+| `GET /decisions/:id/trace?depth=&max_fanout=` | `DecisionTraceResponse` |
+| `GET /decisions/:id/downstream?depth=` | `DecisionTraceResponse` |
+| `GET /decisions/:id/timeline` | `TimelineResponse` (raw journal events for this `correlation_id`) |
+| `POST /decisions/explain` | `ExplanationResponse` (Slice 3a — NL Q&A) |
+| `GET /decisions/_ping` | Smoke endpoint — projection cursor + row count for operator liveness |
+
+The router's scope inference is conservative today: `_requester_scopes(ctx)` returns `[f"workspace:{ctx.workspace_id}"]` if the caller has an active workspace, otherwise `[]` (sees nothing). A future iteration widens this once cross-pocket / cross-team membership lands.
+
+Privacy invariant: the scope filter returns `None` for both "missing" and "scope-hidden"; the router maps both to `404` with the same code so a caller cannot distinguish them.
+
+## MCP Wrappers
+
+The same five reads plus `explain` are exposed as in-process MCP tools under `mcp__pocketpaw_decisions__` so the cloud chat agent can query the graph directly from inside an SSE stream. Identity resolves through `ee.cloud.chat.agent_service` ContextVars — the same chokepoint the pocket and tasks MCP servers use.
+
+## The Explain Pipeline (Slice 3a)
+
+`POST /decisions/explain` accepts a natural-language question and returns a grounded narration. Pipeline:
+
+```
+question
+  → extractor       (extracts decision id / filter from the question)
+  → find()/get()    (load candidate decisions)
+  → trace()         (walk precedents + inputs)
+  → narrator        (LLM stitches the trace into prose)
+  → cache           (SQLite — invalidated on new Decision emit via post-apply hook)
+  → ExplanationResponse
+```
+
+The cache invalidator hooks into `DecisionProjection.register_post_apply_hook()` — a registry added in Slice 3a. Layering stays one-way: explain → decisions, never the reverse.
+
+## Outcomes Back-Reference
+
+Slice 2 added `OutcomeRecord.decision_id` so an outcome carries its parent Decision id. When the outcome lands, the service emits a `decision.outcome_attached` event with the same `correlation_id`; the projection folds it into the existing Decision and updates `outcome`. The hash chain stays valid because outcome is excluded from the hash material.
+
+## The Bundled Pocket Template
+
+`src/pocketpaw/bundled_templates/_bundled/decision-graph/` ships an RFC 03-conformant pocket template plus a `ripple_spec.json` that wires an "Explain" button to `POST /api/v1/decisions/explain`. The chat agent's STEP 0 template-library check picks this up via keywords like `audit trail`, `decision log`, `why did we`. See [Pocket Templates](/concepts/pocket-templates) for how the registry resolves.
+
+## Hash Chain Composition
+
+Per `compute_hash_link`:
+
+```
+sha256(id || ts || decided_by.id || action || sorted(input_ids) || prev_hash)
+```
+
+Each piece is content-bound. `id` is the primary collision-defeater (v4 UUIDs hash to different values even with identical content). `prev_hash` links Decisions within a `correlation_id` so tampering with one breaks every later one. Excluded fields: `outcome` (mutates late), `approvers` (kept symmetric with outcome case), `payload` (opaque, not indexed), `precedents` (A3 fallback can add more after the fact).
+
+## Related
+
+- [Foresight](/concepts/foresight) — projected Decisions land in this graph as forward-precedents (RFC 08 § 14.4).
+- [Pocket Templates](/concepts/pocket-templates) — the bundled `decision-graph` template is created from a brief like "audit trail for the leasing agent."
+- [OSS-EE Split](/concepts/oss-ee-split) — the Decision Graph lives under `pocketpaw_ee` and is license-gated; OSS core ships no decisions code.
+- [API Reference](/api) — full REST endpoint documentation.

--- a/docs/concepts/oss-ee-split.mdx
+++ b/docs/concepts/oss-ee-split.mdx
@@ -1,0 +1,259 @@
+---
+title: "OSS-EE Split: Two Wheels, One Repo, Enforced Boundary"
+description: "PocketPaw ships as pocketpaw (MIT) + pocketpaw-ee (FSL-1.1) — two installable wheels in one repo. An import-linter contract enforces the boundary; an entry-point Protocol registry plugs the enterprise layer in at runtime. Edition-aware Docker build, per-package CI."
+section: Core Concepts
+ogType: article
+keywords: ["oss ee split", "open core", "pocketpaw-ee", "import-linter", "edition", "entry-points"]
+tags: ["architecture", "packaging", "open-core"]
+---
+
+# OSS-EE Split: Two Wheels, One Repo, Enforced Boundary
+
+PocketPaw ships as **two installable wheels** built from one repo: `pocketpaw` (MIT — single-tenant agent runtime, channels, tools, local memory) and `pocketpaw-ee` (FSL-1.1 — multi-tenant cloud, auth, billing, audit, fleet, decisions, calendar, pocket specialist). The OSS core never statically imports the enterprise package; an `import-linter` contract enforces it at CI time. The enterprise layer plugs in at runtime via Python entry-points and a small registry of `typing.Protocol` extension points.
+
+This page is the canonical reference for the split. For why we did it (open-core line, GitLab/Sentry/PostHog precedent), see the design doc.
+
+<Callout type="info">
+**Status (2026-05-25):** IMPLEMENTED (Phases 1-4).
+
+**Implementation PRs:** #1152 (Phase 1 — rename), #1153 (Phase 2 — subpackage moves), #1157 (Phase 4 — pyproject split), plus follow-ups #1141 / #1148 / #1154.
+
+**Plan docs:**
+- [docs/plans/2026-05-16-oss-ee-split-design.md](https://github.com/pocketpaw/pocketpaw/blob/main/docs/plans/2026-05-16-oss-ee-split-design.md) — overall design
+- Phase 1 rename — `docs/plans/2026-05-18-oss-ee-split-phase-1-rename.md`
+- Phase 2 subpackage moves — `docs/plans/2026-05-18-oss-ee-split-phase-2-subpackage-moves.md`
+- Phase 3 extension points — `docs/plans/2026-05-18-oss-ee-split-phase-3-extension-points.md`
+- Phase 3b agents — `docs/plans/2026-05-20-oss-ee-split-phase-3b-agents.md`
+- Phase 4 pyproject split — `docs/plans/2026-05-18-oss-ee-split-phase-4-pyproject-split.md`
+- Phase 5 publish — `docs/plans/2026-05-18-oss-ee-split-phase-5-publish.md`
+
+**What's live:** `pocketpaw` + `pocketpaw-ee` as two separate Python packages with separate `pyproject.toml` files (`/pyproject.toml` for OSS, `ee/pyproject.toml` for EE); import-linter contract enforces `pocketpaw → pocketpaw_ee` is forbidden statically; eleven extension-point Protocol groups (`pocketpaw.event_bus`, `pocketpaw.embeddings`, `pocketpaw.memory_backends`, `pocketpaw.capabilities`, `pocketpaw.auth`, `pocketpaw.routes`, `pocketpaw.lifecycle`, `pocketpaw.storage_backends`, `pocketpaw.models`, `pocketpaw.pockets`, `pocketpaw.mcp_servers`, `pocketpaw.stores`); edition-aware Dockerfile via `POCKETPAW_EDITION` build arg; CI splits tests per package.
+
+**What's planned:** tighten contracts as ee modules grow (each new entity adds itself to the import-linter contract on touch).
+</Callout>
+
+## Why Two Wheels
+
+`pocketpaw` is a self-hosted single-tenant agent — channels, tools, local memory, browser, security stack, OSS routes, dashboard. `pocketpaw-ee` is the multi-tenant cloud layer — auth, workspaces, team chat, billing, file storage, audit, fleet, pocket specialist, calendar primitive, decision graph, Composio.
+
+The line is **commercial**: single-tenant runtime is free; multi-tenant cloud is paid (the GitLab / Sentry / PostHog pattern). Repo visibility stays the same — `ee/` lives in the public repo under FSL.
+
+Before the split, the OSS core imported from `ee/` in seven places, `ee/` shipped in every wheel, and `pip install pocketpaw` (hypothetically) put FSL-licensed code on disk. The split decoupled distribution, license, and dependency graph from each other.
+
+## Repo Layout
+
+```
+backend/
+├── LICENSE                      # MIT — applies to src/pocketpaw
+├── pyproject.toml               # Defines package: pocketpaw
+├── src/
+│   └── pocketpaw/
+│       ├── extensions.py        # Protocol definitions for plugin points
+│       ├── _registry.py         # entry-point discovery
+│       ├── agents/              # 6 backends
+│       ├── bus/                 # event bus + channel adapters
+│       ├── tools/               # OSS tool registry
+│       ├── memory/              # file store + mem0
+│       ├── bundled_skills/      # auto-installed AgentSkills (incl. pocket-create / -edit)
+│       ├── bundled_templates/   # auto-installed pocket templates
+│       ├── bundled_kb/          # auto-installed knowledge-base scopes
+│       └── ...
+├── ee/
+│   ├── LICENSE                  # FSL-1.1 (Apache-2.0 future-licensed)
+│   ├── pyproject.toml           # Defines package: pocketpaw-ee
+│   └── pocketpaw_ee/
+│       ├── cloud/               # multi-tenant cloud (auth, chat, pockets, billing, ...)
+│       ├── calendar/            # native calendar primitive (#1132)
+│       ├── agent/
+│       │   ├── pocket_specialist/   # specialist + skill bridge
+│       │   ├── pocket_router/       # execution-router classifier
+│       │   └── mcp_servers/         # in-process MCP servers (tasks, planner, ...)
+│       ├── audit/               # compliance audit log
+│       ├── fleet/               # multi-agent swarms
+│       ├── instinct/            # decision pipeline
+│       ├── fabric/              # knowledge graph
+│       ├── guards/              # policy/guards
+│       └── extensions.py        # entry-point implementations
+└── tests/
+    ├── cloud/                   # EE-only — needs `uv sync --dev --group ee`
+    ├── ee/                      # EE-only
+    └── ...                      # OSS — runs on plain `uv sync --dev`
+```
+
+`pocketpaw` (the OSS wheel) ships only `src/pocketpaw/`. `pocketpaw-ee` (the EE wheel) ships only `ee/pocketpaw_ee/` and depends on `pocketpaw~=0.4.x` (a compatible-release pin within the same minor series).
+
+## The Import-Linter Contract
+
+Root `pyproject.toml`:
+
+```toml
+[tool.importlinter]
+root_packages = ["pocketpaw_ee", "pocketpaw"]
+
+[[tool.importlinter.contracts]]
+name = "OSS core may not import from EE"
+type = "forbidden"
+source_modules    = ["pocketpaw"]
+forbidden_modules = ["pocketpaw_ee"]
+ignore_imports = [
+    "pocketpaw.tools.cli -> pocketpaw_ee.cloud",
+    "pocketpaw.tools.cli -> pocketpaw_ee.cloud.shared.db",
+    "pocketpaw.tools.cli -> pocketpaw_ee.cloud.pockets.service",
+    "pocketpaw.tools.cli -> pocketpaw_ee.cloud.pockets.agent_context",
+    "pocketpaw.tools.cli -> pocketpaw_ee.agent.pocket_specialist.cli_tool",
+    "pocketpaw.dashboard_lifecycle -> pocketpaw_ee.cloud.chat.runs.executor",
+]
+```
+
+The contract is checked in CI (`uv run lint-imports`). The `ignore_imports` allowlist captures the handful of runtime-only imports the CLI shells out into — each one is wrapped in `try/except ImportError` so an OSS-only install degrades cleanly. New EE additions never go through here; they go through entry-points.
+
+## Runtime Plugging — Entry-Points + Protocols
+
+`src/pocketpaw/extensions.py` defines narrow `typing.Protocol` contracts. `src/pocketpaw/_registry.py` discovers implementations via `importlib.metadata.entry_points`. The enterprise wheel declares them in `ee/pyproject.toml`:
+
+```toml
+[project.entry-points."pocketpaw.event_bus"]
+cloud = "pocketpaw_ee.extensions:CloudEventBusProvider"
+
+[project.entry-points."pocketpaw.embeddings"]
+cloud = "pocketpaw_ee.extensions:CloudEmbeddingProvider"
+
+[project.entry-points."pocketpaw.memory_backends"]
+mongodb = "pocketpaw_ee.extensions:MongoMemoryBackendProvider"
+
+[project.entry-points."pocketpaw.capabilities"]
+cloud = "pocketpaw_ee.extensions:CloudCapabilityProvider"
+
+[project.entry-points."pocketpaw.auth"]
+cloud = "pocketpaw_ee.extensions:CloudAuthProvider"
+
+[project.entry-points."pocketpaw.routes"]
+cloud = "pocketpaw_ee.extensions:CloudRouteProvider"
+
+[project.entry-points."pocketpaw.lifecycle"]
+cloud = "pocketpaw_ee.extensions:CloudLifecycleHook"
+
+[project.entry-points."pocketpaw.storage_backends"]
+cloud = "pocketpaw_ee.extensions:CloudStorageBackend"
+
+[project.entry-points."pocketpaw.models"]
+cloud = "pocketpaw_ee.extensions:CloudModelProvider"
+
+[project.entry-points."pocketpaw.pockets"]
+cloud = "pocketpaw_ee.extensions:CloudPocketWriter"
+
+[project.entry-points."pocketpaw.mcp_servers"]
+tasks       = "pocketpaw_ee.extensions:CloudTasksMcpProvider"
+planner     = "pocketpaw_ee.extensions:CloudPlannerMcpProvider"
+pocket      = "pocketpaw_ee.extensions:CloudPocketMcpProvider"
+decisions   = "pocketpaw_ee.extensions:CloudDecisionsMcpProvider"
+pocket_specialist = "pocketpaw_ee.extensions:CloudPocketSpecialistMcpProvider"
+```
+
+Each entry-point points at a zero-arg callable (usually the class itself) that the registry instantiates once and caches. Without `pocketpaw-ee` installed, `entry_points` returns the empty set and the OSS core degrades to defaults.
+
+The Protocol contracts:
+
+| Group | Protocol | What EE supplies |
+|---|---|---|
+| `pocketpaw.event_bus` | `EventBusProvider` | Distributed (Redis-backed) bus |
+| `pocketpaw.embeddings` | `EmbeddingProvider` | Cloud embedder for the KB |
+| `pocketpaw.memory_backends` | `MemoryBackendProvider` | `mongodb` backend |
+| `pocketpaw.capabilities` | `CapabilityProvider` | Reports cloud features as available |
+| `pocketpaw.auth` | `AuthProvider` | Multi-tenant FastAPI auth deps |
+| `pocketpaw.routes` | `RouteProvider` | All `/api/v1/cloud/*` + workspace + chat routes |
+| `pocketpaw.lifecycle` | `LifecycleHook` | `mount_cloud()` on startup, drain on shutdown |
+| `pocketpaw.storage_backends` | `StorageBackend` | S3 / GCS file storage |
+| `pocketpaw.models` | `ModelProvider` | Beanie document classes |
+| `pocketpaw.pockets` | `PocketWriter` | Cloud pocket-writer |
+| `pocketpaw.mcp_servers` | (string-id list) | In-process MCP servers (tasks, planner, pocket, decisions, pocket_specialist) |
+| `pocketpaw.stores` | `StoreProvider` | Singleton factory overrides (instinct, fabric) |
+
+## Developing With Both Packages Locally
+
+```bash
+# OSS-only — fast, no MongoDB / Redis / FSL code installed
+uv sync --dev
+
+# Full dev environment — adds the editable `pocketpaw-ee` package
+uv sync --dev --group ee
+```
+
+The `ee` extra is declared in the root `pyproject.toml`:
+
+```toml
+[tool.uv.sources]
+pocketpaw-ee = { path = "ee", editable = true }
+
+[project.optional-dependencies]
+ee = ["pocketpaw-ee"]
+```
+
+Editable install means changes to `ee/pocketpaw_ee/` show up immediately without a re-sync.
+
+## Test Splits
+
+```bash
+# OSS-core scope — passes on plain `uv sync --dev`
+uv run pytest --ignore=tests/e2e --ignore=tests/cloud --ignore=tests/ee
+
+# Full suite — needs `uv sync --dev --group ee`
+uv run pytest --ignore=tests/e2e
+
+# EE-only smoke
+uv run pytest tests/ee tests/cloud
+```
+
+CI splits accordingly. The "Test (OSS-only)" job runs on a `uv sync --dev` install and asserts the OSS surface stays self-contained.
+
+## Edition-Aware Docker Build
+
+The root `Dockerfile` accepts a `POCKETPAW_EDITION` build arg:
+
+```dockerfile
+ARG POCKETPAW_EDITION=oss
+
+# ...
+
+COPY ee/ ee/
+RUN if [ "$POCKETPAW_EDITION" = "enterprise" ]; then \
+        pip install --no-cache-dir ./ee ; \
+    fi
+```
+
+Two builds, one Dockerfile:
+
+```bash
+# OSS image — `ee/` lands only in the throwaway builder stage; runtime image stays EE-free
+docker build .
+
+# Enterprise image
+docker build --build-arg POCKETPAW_EDITION=enterprise .
+```
+
+The runtime stage copies only the venv from the builder, so the OSS image is genuinely EE-free on disk.
+
+## Why Touch-Time Migration
+
+The split shipped over four phases (rename → subpackage moves → extension points → pyproject split) plus follow-ups. The four-phase rollout was deliberate: each phase was independently reviewable, independently revertable, and shippable in days rather than weeks.
+
+The same touch-time principle applies going forward. When a contributor adds a new entity to `ee/pocketpaw_ee/cloud/`, they:
+
+1. Land the entity in the 4-file shape (`domain.py`, `dto.py`, `service.py`, `router.py`).
+2. Add the entity's router to the appropriate entry-point provider (`CloudRouteProvider` in `ee/pocketpaw_ee/extensions.py`).
+3. Add `<Entity>Document` to the failing list in the import-linter contract; add the new modules to the source-modules list.
+4. Ship the entity + the contract update in the same PR.
+
+The boundary stays sound because every new addition has to think about it.
+
+## Versioning
+
+`pocketpaw-ee` tracks `pocketpaw` within the same minor series via a `~=` compatible-release pin (`pocketpaw~=0.4.16` in `ee/pyproject.toml`). Patches flow automatically; a minor bump on core (0.5+) requires an explicit floor bump on EE. This catches the case where EE depends on a feature added in a newer core patch but the core wheel hasn't been bumped yet.
+
+## Related
+
+- [Architecture](/concepts/architecture) — overall PocketPaw architecture (the OSS surface).
+- [Calendar](/concepts/calendar) — example EE entity using the 4-file shape.
+- [Decision Graph](/concepts/decision-graph) — example EE entity using entry-points to expose MCP tools.
+- [Composio](/integrations/composio) — example EE entity using lazy imports for an optional SDK.
+- [Self-Hosting](/deployment/self-hosting) — building and deploying the edition-aware Docker image.

--- a/docs/concepts/pocket-execution-router.mdx
+++ b/docs/concepts/pocket-execution-router.mdx
@@ -1,0 +1,187 @@
+---
+title: "Pocket Execution Router: Cheapest-Tier Edit Dispatch + Structure/Data Split"
+description: "A pure rule-based classifier that front-runs pocket_specialist__edit, routing every edit intent to the cheapest tier that can satisfy it — declarative source/action, deterministic op, or LLM specialist. Pairs with the SSE structure/data discriminant so clients can patch only the layer that changed."
+section: Core Concepts
+ogType: article
+keywords: ["pocket execution router", "pocket router", "tier classifier", "structure data split", "updateComponents", "updateDataModel"]
+tags: ["pockets", "router", "ee"]
+---
+
+# Pocket Execution Router: Cheapest-Tier Edit Dispatch
+
+The pocket execution router is a pure rule-based classifier that front-runs `pocket_specialist__edit`. It looks at the natural-language edit intent plus the pocket's current rippleSpec and routes the request to the **cheapest tier capable of producing the exact change**. A data-only refresh fires a declared source in a few milliseconds with zero tokens. A single-prop edit fires one granular op. Anything ambiguous — anything structural — escalates to the LLM specialist unchanged.
+
+PR #1181 shipped the router and one related-but-distinct change: a **structure/data discriminant** on the `pocket_mutation` SSE frame so a client can patch only the layer that changed instead of rebuilding the whole pocket.
+
+<Callout type="info">
+**Status (2026-05-25):** IMPLEMENTED.
+
+**Implementation PRs:** #1181 (execution router + structure/data split for pocket edits).
+
+**Workspace RFC:** RFC 06 (Ripple — structure/data discriminant); router has no dedicated RFC.
+
+**What's live:** the `classify_and_route` chokepoint in `ee/pocketpaw_ee/agent/pocket_router/router.py`; the pure `classifier.py`; per-stage `ExecutionStage` timeline; the single `pocket_execution` SSE frame; `pocket_router` audit entries (WARNING severity on cheap-tier bypass); kill-switch (`settings.pocket_router_enabled`) and confidence floor (`settings.pocket_router_min_confidence`); structure/data family discriminant on every `pocket_mutation` frame (`updateComponents` for node/structure ops, `updateDataModel` for state/data ops).
+
+**What's planned:** surface routing decisions in the audit trail UI; thread the specialist's own token spend back into the `pocket_execution` frame (today it stays `{0, 0}` on Tier-2 escalation until the specialist surfaces a usage report).
+</Callout>
+
+## The Two Changes, One PR
+
+PR #1181 ships two changes that arrive together but solve different problems:
+
+1. **Execution router** — picks the cheapest tier for each edit intent. Saves latency and tokens on data-only refreshes and single-op edits.
+2. **Structure/data split** — every `pocket_mutation` SSE frame now carries a `family` discriminant (`updateComponents` or `updateDataModel`). A client can patch only the layer that changed instead of rebuilding the whole pocket.
+
+They're related — both encode the same insight that a state-only change doesn't need a full rebuild — but they live in different layers. The router decides the cheap path; the SSE discriminant tells the client what just changed so it can apply the corresponding cheap patch.
+
+## The Three Tiers
+
+```
+   intent + rippleSpec
+        │
+        ▼
+   classify (pure, no I/O)
+        │
+   ┌────┴──────────────────────────────────────┐
+   ▼                ▼                          ▼
+ Tier 0          Tier 1                     Tier 2
+ declarative     deterministic op           specialist
+   │                │                          │
+   ▼                ▼                          ▼
+ source_executor   op-apply path             run_edit_specialist
+ .run_sources()    (EditAgentModeAdapter)    (LLM round-trip)
+   │                │                          │
+ action_executor    ▼                          ▼
+ .run_action()    one granular op            full edit
+   │              applied                    pipeline
+   ▼
+ fire declared
+ source / action
+```
+
+| Tier | What it does | Latency | Tokens | When it fires |
+|---|---|---|---|---|
+| **Tier 0 — declarative** | Fire a declared `sources.X` or `actions.X` through the existing executors (the guards — allowlist, SSRF, rate limit, fail-closed instinct-reject — all still run) | ~10 ms | 0 | "Refresh the deals" → resolves to exactly one declared source |
+| **Tier 1 — deterministic** | Apply exactly one granular op through the existing `EditAgentModeAdapter` op-apply path | ~30 ms | 0 | "Set the title to 'Open PRs'" → resolves to one `set_node_prop` |
+| **Tier 2 — specialist** | Escalate to `run_edit_specialist` UNCHANGED (the legacy LLM flow) | ~5-30 s | hundreds-thousands | Anything ambiguous, anything structural, anything with `requires_instinct` |
+
+The router only **invokes** the executors — it bypasses no guard. The Tier-0 path goes through `source_executor.run_sources` and `action_executor.run_action` which keep their allowlist + SSRF + rate-limit + fail-closed instinct-reject checks. The router cannot widen the executor's surface; it can only decide whether to call them at all.
+
+## Why Fail-Safe Is the Governing Rule
+
+The classifier returns a cheap-tier verdict ONLY when it is HIGH-confidence the cheap tier produces the EXACT change the user asked for. Any doubt — a partial keyword match, a structural verb anywhere in the intent, a target that resolves to ≠ 1 entity, an unresolved `{state.x}` / `{item.id}` action param, a `requires_instinct` action, or a confidence below `settings.pocket_router_min_confidence` — escalates to Tier 2.
+
+> A wrong skip produces a broken pocket; a wrong escalate only costs an LLM call. The asymmetry drives every default.
+
+Concretely:
+
+- The structural-verbs frozenset (`add`, `create`, `insert`, `build`, `redesign`, `rebuild`, `restructure`, `reorganize`, `layout`, `move`, `rearrange`, ...) forces Tier 2 the moment any of them appears. The specialist owns structure.
+- Verbs only count when they appear as whole words (`\b`-anchored). "remarketing" won't match "remove".
+- Tier 2 escalation always carries `confidence = 1.0` ("escalation is never wrong").
+
+The kill-switch (`settings.pocket_router_enabled`) and the confidence floor make the router fail-safe: with the switch off, or on any sub-threshold verdict, the router escalates and behaves exactly like today.
+
+## The Pure Classifier
+
+`pocketpaw_ee.agent.pocket_router.classifier` is **pure**: no I/O, no Beanie, no LLM, no logging side effects. It only inspects the two arguments (intent + rippleSpec) and returns a `Classification`. Purity is an import-linter contract — the router (`router.py`) is the layer allowed to touch executors and the specialist.
+
+```python
+@dataclass(frozen=True)
+class Classification:
+    tier: Tier                 # 0, 1, or 2
+    target: str | None         # source/action key | state path | None
+    confidence: float          # [0.0, 1.0]
+    reasoning: str             # short human-readable explanation
+    op: str | None = None      # "run_source" / "run_action" / "set_state" / ...
+    op_args: dict[str, Any] = field(default_factory=dict)
+```
+
+The router calls `classify(intent, ripple_spec)` and dispatches on `result.tier`.
+
+## Per-Stage Timeline
+
+Every routed request accumulates an `ExecutionStage` timeline. The four fixed stages:
+
+| Stage | Tier 0 | Tier 1 | Tier 2 |
+|---|---|---|---|
+| `classify` | runs | runs | runs |
+| `apply` | runs | runs | runs (specialist) |
+| `layout_build` | skipped — "data-only change" | skipped — "data-only change" | runs |
+| `widget_render` | skipped — "data-only change" | skipped — "data-only change" | runs |
+
+The cheap-tier wins land in the two skipped stages. A declarative refresh and a single-op data edit both leave the component tree untouched, so the renderer never re-runs layout.
+
+## The pocket_execution SSE Frame
+
+Once per routed request the router emits one `pocket_execution` SSE frame — the Thesys-style "what ran / what was skipped" readout:
+
+```json
+{
+  "type": "pocket_execution",
+  "request_id": "req_abc123",
+  "intent": "refresh the open PRs",
+  "tier_chosen": 0,
+  "stages": [
+    {"stage": "classify",       "ran": true,  "ms": 2, "detail": "Tier 0: run_source 'open_prs' (conf=0.92)"},
+    {"stage": "apply",          "ran": true,  "ms": 84, "detail": "source 'open_prs' refreshed"},
+    {"stage": "layout_build",   "ran": false, "ms": 0, "skipped_reason": "data-only change"},
+    {"stage": "widget_render",  "ran": false, "ms": 0, "skipped_reason": "data-only change"}
+  ],
+  "total_ms": 91,
+  "tokens": {"prompt": 0, "completion": 0}
+}
+```
+
+A client can render this as a "this edit took Tier 1, 14 ms, 0 tokens, skipped layout + render" readout.
+
+## The Audit Entry
+
+Every routed request writes a `pocket_router` audit entry — **WARNING severity on a Tier-0/1 bypass** because that is a write/mutation with no agent reasoning behind it and deserves a durable trail. Tier-2 escalations log at the normal level (the specialist's own audit is already in the trail).
+
+## Structure/Data Split — the SSE Discriminant
+
+Independent of the router but shipped in the same PR: every granular `agent_*` edit op already pushed a `pocket_mutation` SSE frame. That frame now carries a `family` discriminant:
+
+| Family | When | What changed |
+|---|---|---|
+| `updateComponents` | Node / structure op (`add_node`, `remove_node`, `move_node`, `replace_node`, `set_node_prop`) | The component tree |
+| `updateDataModel` | State / data op (`set_state`, `set_state_key`, `set_state_path`) | The reactive state, not the tree |
+
+A client can patch only the layer that changed. Still one frame per op, and the coarse `PocketUpdated` realtime event is untouched, so older clients keep their refetch signal — the change is purely additive.
+
+## Mental Model
+
+```
+                    edit intent
+                         │
+                         ▼
+              ┌────────────────────┐
+              │ classify_and_route │
+              └─────────┬──────────┘
+                        │
+        ┌───────────────┼──────────────┐
+        │               │              │
+        ▼               ▼              ▼
+   Tier 0          Tier 1         Tier 2
+  (declarative)   (one op)      (specialist)
+        │               │              │
+        ▼               ▼              ▼
+  source/action    op-apply      LLM round-trip
+  fired              │                  │
+        │            ▼                  ▼
+        └──────► pocket_mutation ◄──────┘
+                 SSE frame
+                 (family: updateComponents | updateDataModel)
+                         │
+                         ▼
+                pocket_execution
+                 SSE frame
+                 (tier_chosen, stages, total_ms, tokens)
+```
+
+## Related
+
+- [Merge Pocket Spec](/api/post-pocket-spec-merge) — the merge endpoint the Tier-2 specialist's `pocketpaw-pocket-specialist` skill drives.
+- [Pocket Planner](/concepts/pocket-planner) — the create-side sibling that plans-before-build for complex pockets.
+- [Pocket Sources](/concepts/pocket-sources) — Tier 0 fires through the same source executor described here.
+- [Pocket Write Actions](/concepts/pocket-write-actions) — Tier 0 also dispatches declared actions through the action executor.

--- a/docs/concepts/pocket-planner.mdx
+++ b/docs/concepts/pocket-planner.mdx
@@ -1,0 +1,158 @@
+---
+title: "Pocket Planner: Plan-Before-Create for Complex Pockets"
+description: "A plan-pointer gate in front of the pocket specialist. Custom multi-widget briefs get planned via the deep_work pipeline first; the chat agent renders the brief, iterates with the user, then walks the todos through the merge endpoint."
+section: Core Concepts
+ogType: article
+keywords: ["pocket planner", "plan-before-create", "pocket specialist", "plan kit", "deep work", "rfc 03"]
+tags: ["pockets", "planner", "ee"]
+---
+
+# Pocket Planner: Plan-Before-Create for Complex Pockets
+
+The pocket planner sits in front of `pocket_specialist__create`. When a brief doesn't match a built-in template and looks like a custom multi-widget app, the specialist returns a **plan-pointer kit** instead of a one-shot draft. The chat agent then walks a four-phase loop — research, render, iterate, build — driven by a bundled skill and an in-process MCP tool, reusing the existing `deep_work` planner pipeline. The build phase calls the [merge endpoint](/api/post-pocket-spec-merge) once per cohesive todo.
+
+<Callout type="info">
+**Status (2026-05-25):** IN FLIGHT — merged on `feat/pocket-planner-skill`, not yet folded into `dev`.
+
+**Implementation PRs:** #1223 (pocket-planner — plan-before-create gate reusing `deep_work` for complex pockets, merged into `feat/pocket-edit-skill-merge`).
+
+**Workspace RFC:** ties indirectly to [RFC 03 — Pocket Template Schema](https://github.com/qbtrix/paw-workspace/blob/main/docs/rfc/03-pocket-template-schema.md) v2 template work.
+
+**What's live (on the planner branch):** plan-before-create gate; reuse of `pocketpaw.deep_work.planner.PlannerAgent` (4-phase pipeline, skip team assembly); `POCKET_*` prompts in `src/pocketpaw/deep_work/prompts.py`; `mcp__pocketpaw_pocket_planner__plan_pocket` MCP tool; bundled `pocketpaw-pocket-planner` skill; flag-gated coexistence with the legacy one-shot draft via `POCKETPAW_POCKET_SPECIALIST_USE_SKILL`.
+
+**What's planned:** rebase onto `dev` after PR #1240 (RFC 07 Decision Graph umbrella) and #1240's stack settle; iterate the gate triggers (when does the planner fire vs the draft path); expand the plan-kit catalog; tighten the loopback bypass to a short-lived JWT; click-on-todo-to-edit UI in the chat panel (paw-enterprise follow-up).
+</Callout>
+
+## Why a Gate, Not a Smarter Specialist
+
+The pocket-create path historically had two shapes:
+
+1. **Template match** (fast) — the chat agent's STEP 0 keyword-matches the brief against `src/pocketpaw/bundled_templates/_bundled/index.json`. On a hit, the specialist instantiates the template and skips drafting entirely.
+2. **One-shot draft** (slow, error-prone) — on a template miss, the specialist asks the LLM to generate a full rippleSpec in one turn. Custom multi-widget briefs (a home brewing log, a podcast publisher, a school-bus router) routinely came back half-baked: missing state bindings, fabricated widget types, unwired actions. 2-3 rebuild iterations was typical.
+
+The planner gate adds a third path between them: **plan-then-build**. The specialist returns a `plan_kit` payload instead of drafting. The chat agent then runs the planner explicitly, renders the brief, iterates with the user, and walks the todos one merge endpoint call at a time.
+
+## When the Gate Fires
+
+`AgentModeAdapter.create` in `ee/pocketpaw_ee/agent/pocket_specialist/adapters.py` branches to `_plan_kit_response` when ALL of:
+
+- The `POCKETPAW_POCKET_SPECIALIST_USE_SKILL` env var is truthy.
+- Template-match returned no hit (no `hints.template_id` in the input).
+- `input.spec is None` (the caller didn't pass a pre-baked spec).
+
+Otherwise it returns the legacy `_draft_kit_response`. The template-match short-circuit still runs first; templates and recipes keep their fast path. The planner only fires on custom multi-widget briefs.
+
+## The Plan-Pointer Kit
+
+The kit is a small JSON payload pointing at the skill and tool the chat agent should drive:
+
+```json
+{
+  "ok": true,
+  "action": "plan_kit",
+  "draft_kit": {
+    "skill_name": "pocketpaw-pocket-planner",
+    "mcp_tool": "mcp__pocketpaw_pocket_planner__plan_pocket",
+    "workspace_id": "<from request>",
+    "user_id":      "<from request>",
+    "loopback_headers": {
+      "X-PocketPaw-Internal":     "true",
+      "X-PocketPaw-Workspace-Id": "<workspace_id>",
+      "X-PocketPaw-User-Id":      "<user_id>"
+    }
+  }
+}
+```
+
+The loopback headers are inherited from the [merge endpoint](/api/post-pocket-spec-merge) MVP bypass — the chat agent's Claude Code subprocess uses them when it `curl`s `POST /api/v1/pockets/<id>/spec/merge` per todo.
+
+## Deep_work Reuse — the Architectural Call
+
+The planner gate **does not build a parallel planner**. It reuses the existing `pocketpaw.deep_work.planner.PlannerAgent` and threads it through a pocket-flavoured prompt set. Concrete reuse:
+
+| Module | What's reused |
+|---|---|
+| `pocketpaw.deep_work.planner.PlannerAgent` | The 4-phase pipeline engine (research → PRD → task breakdown → team assembly), with team assembly skipped |
+| `pocketpaw.deep_work.prompts.POCKET_*` | Three new prompt strings — `POCKET_RESEARCH_PROMPT`, `POCKET_PRD_PROMPT`, `POCKET_TASK_BREAKDOWN_PROMPT` — siblings of the existing project prompts in the same file |
+| `PlannerAgent._run_prompt` / `_parse_tasks` | Reused for the LLM phases |
+| `TaskSpec` with `success_criteria` / `depends_on` | Each TaskSpec becomes one ordered todo in the brief |
+
+Skipped deliberately:
+
+- `DeepWorkSession` state machine — the chat session owns the iteration state, not a Mission Control Project lifecycle.
+- `PlanSession` Beanie doc — plan iteration is ephemeral; chat history is enough.
+- Team assembly — pockets don't need a multi-agent team.
+
+The architectural call: pockets and projects are different objects with different lifecycles, but the underlying "research → PRD → tasks" pipeline is the same. Sharing the pipeline (and the prompt file) keeps the two surfaces close and means improvements to one carry to the other for free. See [Deep Work](/advanced/deep-work) for the project-side surface.
+
+## The Plan_Pocket MCP Tool
+
+`mcp__pocketpaw_pocket_planner__plan_pocket` lives in `ee/pocketpaw_ee/agent/mcp_servers/planner.py`. Two MCP servers ship from this module:
+
+- `pocketpaw_planner` — hosts `plan_project(...)` for Mission Control projects. **Opt-in** via the per-agent `mcp_servers_allow` policy.
+- `pocketpaw_pocket_planner` — hosts `plan_pocket(intent, prior_plan=None, iteration_delta=None, deep_research=False)`. **Ambient** — the pocket-create skill needs to call it without explicit opt-in.
+
+The split is per a follow-up fix on the same branch (`e17ed3f1 fix(pocket-planner): split planner MCP server to restore opt-in gating`). Operators can keep the project planner opt-in while letting `plan_pocket` flow freely.
+
+## The Bundled Skill
+
+`pocketpaw-pocket-planner` is auto-installed to `~/.claude/skills/` by the bundled-skills installer (see [Bundled Skills](/advanced/skills)). The skill teaches the chat agent the four-phase flow:
+
+1. **Research and draft the plan** — call `plan_pocket(intent=<user's verbatim brief>)`. The tool returns `{ok: true, brief}` with `narrative`, `widgets`, `state`, `sources`, `actions`, `todos[]`, and `research_notes`.
+2. **Render the brief in chat as markdown** — narrative + bulleted widget list + state shape + source/action wiring + numbered todos with done-when criteria.
+3. **Iterate with the user** — re-invoke `plan_pocket` with `prior_plan` + `iteration_delta` text until the user says "build it."
+4. **Walk the todos** — one `POST /api/v1/pockets/<id>/spec/merge` per todo, in dependency order. The merge endpoint's strict catalog + action-wiring gate catches anything the planner missed; on a blocked merge the agent fixes the spec and retries.
+
+## How It Composes
+
+```
+  user brief
+       │
+       ▼
+  pocket_specialist__create
+       │
+       ├── template match?  ──── YES ──▶ instantiate + customize (skip planner)
+       │
+       └── NO + USE_SKILL=true + spec is None
+                │
+                ▼
+        return plan_kit
+                │
+                ▼
+        chat agent invokes pocketpaw-pocket-planner skill
+                │
+                ▼
+        mcp__pocketpaw_pocket_planner__plan_pocket(intent)
+                │
+                ▼
+        PlannerAgent.plan(POCKET_* prompts, no team assembly)
+                │
+                ▼
+        brief { narrative, widgets, state, sources, actions, todos[] }
+                │
+                ├── render as markdown in chat
+                ├── iterate with user
+                │
+                ▼
+        walk todos → POST /spec/merge per todo
+                │
+                ▼
+        finished pocket
+```
+
+## Flag and Coexistence
+
+The whole gate is behind `POCKETPAW_POCKET_SPECIALIST_USE_SKILL`. With the flag off, the specialist takes the legacy one-shot draft path and the planner branch is dead code. With the flag on:
+
+- Template matches still short-circuit FIRST (templates + recipes keep their fast path).
+- Custom multi-widget briefs land on the plan-pointer kit.
+- The legacy 17-tool LangChain edit path still ships alongside the merge endpoint (gated by the same flag).
+
+Default is `false` until the captain greenlights deletion of the legacy paths.
+
+## Related
+
+- [Merge Pocket Spec](/api/post-pocket-spec-merge) — the endpoint the build phase walks, one call per todo.
+- [Deep Work](/advanced/deep-work) — the project-side use of the same `PlannerAgent` pipeline.
+- [Pocket Templates](/concepts/pocket-templates) — STEP 0 keyword match runs before the planner even gets a chance to fire.
+- [Pocket Execution Router](/concepts/pocket-execution-router) — the router classifier sits in front of `pocket_specialist__edit` (the edit-side sibling).

--- a/docs/concepts/pocket-templates.mdx
+++ b/docs/concepts/pocket-templates.mdx
@@ -1,0 +1,151 @@
+---
+title: "Pocket Templates: Curated Starting Points for the Specialist"
+description: "Pocket templates are RFC 03-shaped recipes the chat agent matches against a brief before drafting from scratch. Built-in templates auto-install on boot; an in-flight v2 schema makes Pydantic the single validation chokepoint with a bundled v1→v2 migration."
+section: Core Concepts
+ogType: article
+keywords: ["pocket templates", "rfc 03", "bundled templates", "pocket schema", "template lint", "v1 v2 migration"]
+tags: ["pockets", "templates", "rfc-03"]
+---
+
+# Pocket Templates: Curated Starting Points for the Specialist
+
+A pocket template is a hand-authored RFC 03-shaped recipe — metadata plus a rippleSpec skeleton — that the create specialist instantiates and customizes instead of generating a pocket cold. The chat agent's STEP 0 template-library check keyword-matches the user's brief against an index, and on a hit the specialist short-circuits the draft round-trip and stamps out a usable pocket in one turn.
+
+PocketPaw ships seven built-in templates today. The v2 schema work (in flight) consolidates validation behind a single Pydantic chokepoint with a bundled v1 → v2 migration and a `pocket template` CLI for linting, migration, and diff.
+
+<Callout type="info">
+**Status (2026-05-25):** IN FLIGHT — v1 templates already shipped; v2 schema chokepoint in review.
+
+**Implementation PRs:**
+- **Shipped on dev:** #1180 (Increment 2a — built-in pocket templates).
+- **Open / not on dev yet:** #1228 (RFC 03 v2 integration umbrella, OPEN against `dev`), #1225 (v2 schema chokepoint + bundled migration, MERGED into the integration branch), #1229 (CLI `pocket template lint/migrate/diff`, MERGED into the integration branch), #1239 (template-to-runtime translation seam for `data_sources`, MERGED into the integration branch).
+
+**Workspace RFC:** [docs/rfc/03-pocket-template-schema.md](https://github.com/qbtrix/paw-workspace/blob/main/docs/rfc/03-pocket-template-schema.md) (v2; amendments tracked alongside the integration PR).
+
+**What's live on dev:** built-in pocket templates land at boot via `bundled_templates.installer`; pockets can be created from a named template via the standard create flow; the seven bundled slugs (todo-task-tracker, kanban-board, metrics-dashboard, crm-record-list, calendar-planner, activity-feed, decision-graph) are picked up by STEP 0 keyword match.
+
+**What's planned (on the integration branch, awaiting merge):** `PocketTemplate` Pydantic v2 model as the single validation chokepoint; `_promote_v1_to_v2` translation pass in `loader.py` so v1 templates on disk keep loading forever; `strict: bool = False` on `load_template` (default preserves the log-warn-return-None contract; `strict=True` raises for CLI lint); CEL expressions parsed at validation via `celpy.CELParser`; `pocket template lint/migrate/diff` CLI.
+</Callout>
+
+## What a Template Is, On Disk
+
+Every bundled template lives at `src/pocketpaw/bundled_templates/_bundled/<slug>/` and holds exactly two files:
+
+| File | Format | Purpose |
+|---|---|---|
+| `template.pocket.yaml` | YAML | RFC 03 Pocket Template Schema metadata — `name`, `version`, `vertical`, `shape`, `description`, `state`, `actions`, `connectors`, `skills` |
+| `ripple_spec.json` | JSON | The hand-authored rippleSpec skeleton the specialist instantiates and customizes |
+
+The registry at `src/pocketpaw/bundled_templates/_bundled/index.json` lists every bundled template with the keywords STEP 0 matches against:
+
+```json
+{
+  "slug": "todo-task-tracker",
+  "title": "Task Tracker",
+  "shape": "data-grid",
+  "pattern": "app",
+  "keywords": ["todo", "to-do", "task list", "checklist", ...],
+  "connectors_hint": []
+}
+```
+
+The current seven slugs:
+
+| Slug | Shape | Pattern | Triggers on briefs like |
+|---|---|---|---|
+| `todo-task-tracker` | `data-grid` | `app` | "todo list," "task tracker," "action items" |
+| `kanban-board` | `kanban` | `app` | "kanban," "sprint board," "lanes," "trello" |
+| `metrics-dashboard` | `data-grid` | `dashboard` | "dashboard," "kpis," "scorecard" |
+| `crm-record-list` | `custom` | `browser` | "crm," "contacts," "leads," "pipeline" |
+| `calendar-planner` | `calendar` | `app` | "calendar," "schedule," "agenda" |
+| `activity-feed` | `timeline` | `feed` | "activity feed," "changelog," "audit log" |
+| `decision-graph` | `custom` | `app` | "decision graph," "audit trail," "why did we" (paired with [Decision Graph](/concepts/decision-graph)) |
+
+## How Templates Get to the User
+
+`src/pocketpaw/bundled_templates/installer.py` runs on dashboard boot and mirrors every `_bundled/<slug>/` directory plus `index.json` into `~/.pocketpaw/templates/`. The install is **idempotent via SHA-256 hash comparison** — the same mirror pattern as `bundled_kb.installer` and `bundled_skills.installer`. Behavior:
+
+- **First boot** — every bundled template is copied over.
+- **Subsequent boots, same content** — no-op (hash match per file).
+- **PocketPaw upgrade with new template content** — overwrites the user's copy. Operators who hand-edit a template should opt out.
+- **I/O failures** — logged at WARNING, never raised. Pocket creation still works cold-generated when the install can't run.
+
+Opt out with `POCKETPAW_AUTO_INSTALL_BUNDLED_TEMPLATES=false`.
+
+## How a Template Becomes a Pocket
+
+```
+   user brief
+        │
+        ▼
+   STEP 0: keyword-match brief against index.json
+        │
+        ├── HIT  ──▶ chat agent sets hints.template_id = <slug>
+        │              │
+        │              ▼
+        │     pocket_specialist__create(hints={template_id: ...})
+        │              │
+        │              ▼
+        │     AgentModeAdapter.create short-circuits:
+        │       load_template(slug)
+        │       _validate_and_persist(template["ripple_spec"])
+        │       (skips the _draft_kit LLM round-trip entirely)
+        │
+        └── MISS ──▶ _draft_kit_response  (one-shot)
+                or  _plan_kit_response    (plan-then-build, see Pocket Planner)
+```
+
+`load_template(slug)` is the single read path. It guards against path-traversal slugs, returns `None` on any failure (unknown slug, missing sibling file, parse error, I/O error), and logs at WARNING. The caller treats `None` as "fall back to cold generation" — a template-load failure never blocks pocket creation.
+
+Returned shape: `{"meta": <parsed template.pocket.yaml>, "ripple_spec": <parsed ripple_spec.json>}`.
+
+## The V2 Schema Chokepoint (in flight)
+
+Today every consumer (loader, specialist, future CLI) inspects template dicts directly. RFC 03 v2 collapses validation behind one Pydantic v2 model.
+
+`src/pocketpaw/bundled_templates/schema.py` will host `PocketTemplate` — every top-level v2 field and every sub-schema modeled as a Pydantic class. Every load path (loader, CLI lint, future Registry) goes through this model.
+
+Direction:
+
+- **Single chokepoint.** No consumer parses raw YAML / JSON anymore. They either get a validated `PocketTemplate` or `None`.
+- **Bundled migration.** A `_promote_v1_to_v2` translation pass in `loader.py` runs before validation, so the model only ever sees v2-shaped dicts. v1 templates on disk keep loading forever.
+- **Strict mode.** `load_template(slug, *, strict=False)` keeps the log-warn-return-None contract every EE consumer pattern-matches on. `strict=True` raises `TemplateValidationError` — the CLI lint and tests opt into this.
+- **CEL at validation, evaluation at runtime.** Filter / when expressions on `saved_views[]`, `columns[]`, `triggers[]`, and `instinct_rules.rules[]` are parsed at validation via `celpy.CELParser`. The runtime owns evaluation against a real row / workspace context.
+
+The six existing v1 templates get migrated to v2 in the same PR (per RFC 03 Appendix B) so they double as canonical v2 fixtures.
+
+## The Planned CLI
+
+`pocket template` (in PR #1229, on the integration branch) ships three subcommands:
+
+```bash
+# Validate a template file — exits non-zero on any schema violation
+pocket template lint <path/to/template.pocket.yaml>
+
+# Promote a v1 template on disk to v2 in place
+pocket template migrate <path/to/template.pocket.yaml>
+
+# Show the diff between two template versions or between disk and bundled
+pocket template diff <a> <b>
+```
+
+The CLI opens `load_template(slug, strict=True)` so a schema violation surfaces as a `TemplateValidationError` with the field path, not a silent `None`.
+
+## Composing With the Specialist
+
+Templates compose with three other surfaces:
+
+- **The chat agent's STEP 0 keyword match** — keeps the template path fast (no LLM round-trip needed to pick a template).
+- **The [Pocket Planner](/concepts/pocket-planner) gate** — fires only when STEP 0 misses AND the brief is custom multi-widget. Templates always win when they match.
+- **The [Merge Pocket Spec](/api/post-pocket-spec-merge) endpoint** — the specialist's strict catalog + action-wiring gate runs against the instantiated template's rippleSpec just like it does on any agent-generated spec. A broken template can't slip through.
+
+## Custom Templates
+
+The on-disk format is stable. Drop a `template.pocket.yaml` + `ripple_spec.json` pair into `~/.pocketpaw/templates/<your-slug>/` and the loader will pick it up. Add an entry to `~/.pocketpaw/templates/index.json` if you want STEP 0 keyword match to surface it (the bundled `index.json` is overwritten on every PocketPaw upgrade — customize a copy and opt out of the bundled overwrite, or wait for a planned per-user merge step).
+
+## Related
+
+- [Pocket Planner](/concepts/pocket-planner) — runs only when no template matches.
+- [Merge Pocket Spec](/api/post-pocket-spec-merge) — the endpoint the specialist drives whether the spec came from a template or a fresh draft.
+- [Decision Graph](/concepts/decision-graph) — paired with the bundled `decision-graph` template.
+- [Pocket Execution Router](/concepts/pocket-execution-router) — the edit-side sibling; templates feed the create path only.

--- a/docs/docs-config.json
+++ b/docs/docs-config.json
@@ -305,6 +305,36 @@
             "icon": "lucide:video"
           },
           {
+            "label": "Decision Graph",
+            "href": "/concepts/decision-graph",
+            "icon": "lucide:git-branch"
+          },
+          {
+            "label": "Pocket Planner",
+            "href": "/concepts/pocket-planner",
+            "icon": "lucide:clipboard-list"
+          },
+          {
+            "label": "Pocket Execution Router",
+            "href": "/concepts/pocket-execution-router",
+            "icon": "lucide:route"
+          },
+          {
+            "label": "Pocket Templates",
+            "href": "/concepts/pocket-templates",
+            "icon": "lucide:layout-template"
+          },
+          {
+            "label": "Calendar",
+            "href": "/concepts/calendar",
+            "icon": "lucide:calendar"
+          },
+          {
+            "label": "OSS-EE Split",
+            "href": "/concepts/oss-ee-split",
+            "icon": "lucide:split"
+          },
+          {
             "label": "PocketPaw vs OpenClaw",
             "href": "/concepts/vs-openclaw",
             "icon": "lucide:scale"
@@ -543,6 +573,11 @@
             "label": "MCP Servers",
             "href": "/integrations/mcp-servers",
             "icon": "lucide:server"
+          },
+          {
+            "label": "Composio",
+            "href": "/integrations/composio",
+            "icon": "lucide:puzzle"
           },
           {
             "label": "A2A Protocol",

--- a/docs/integrations/composio.mdx
+++ b/docs/integrations/composio.mdx
@@ -1,0 +1,184 @@
+---
+title: "Composio: 200+ Pre-Built OAuth-Managed Toolkits"
+description: "PocketPaw's first-party Composio integration. The chat agent discovers and calls any whitelisted Composio toolkit (Gmail, Slack, GitHub, Drive, Linear, …) at runtime via in-process MCP. Multi-tenant via namespaced user_id, per-backend providers for all four supported agent SDKs."
+section: Integrations
+ogType: article
+keywords: ["composio", "composio integration", "mcp tools", "third-party tools", "oauth toolkits"]
+tags: ["integrations", "composio", "tools", "ee"]
+---
+
+# Composio: 200+ Pre-Built OAuth-Managed Toolkits
+
+[Composio](https://docs.composio.dev) ships 200+ pre-built OAuth-managed integrations (Gmail, Slack, GitHub, Drive, Calendar, Linear, …) as a single MCP-shaped surface. PocketPaw wires the Composio MCP server into the cloud chat agent so it can discover and call any whitelisted toolkit at runtime, without us building per-toolkit Python glue or owning each service's OAuth dance.
+
+The v1 integration lives in `ee/pocketpaw_ee/cloud/composio/` on the 4-file shape. The chat agent gets Composio's meta-tools (`COMPOSIO_SEARCH_TOOLS`, `COMPOSIO_GET_TOOL_SCHEMAS`, `COMPOSIO_MULTI_EXECUTE_TOOL`, `COMPOSIO_MANAGE_CONNECTIONS`); the [pocket specialist](/api/post-pocket-spec-merge) does NOT. When a pocket needs Composio data, the parent agent fetches it first and passes it into the specialist brief.
+
+<Callout type="info">
+**Status (2026-05-25):** IMPLEMENTED (v1).
+
+**Implementation PRs:** #1153 (Composio v1 tool-provider integration in OSS-EE split layout).
+
+**Plan doc:** [docs/plans/2026-05-12-composio-integration.md](https://github.com/pocketpaw/pocketpaw/blob/main/docs/plans/2026-05-12-composio-integration.md).
+
+**What's live:** first-party Composio tool-provider integration via in-process MCP; per-backend providers for `claude_agent_sdk`, `openai_agents`, `google_adk`, `deep_agents`; namespaced `user_id` (`f"{enterprise_id}:{user_id}"`) for multi-tenant isolation; env-var toolkit allow-list via `POCKETPAW_COMPOSIO_TOOLKITS`; Connect Link → inline Ripple spec for OAuth handoff; per-`(user_id, backend_kind)` tools cache (default 1h TTL); identity verification on session create (`ComposioConnectionVerified` / `ComposioConnectionMismatch` bus events).
+
+**What's planned:** per-provider auth UX (per-workspace admin UI for toolkit allow-list); tool catalog surfacing in the dashboard; `ComposioConnector` adapter implementing `ConnectorProtocol` (v2, gated on Ripple `$source` demand); self-hosted Composio runtime full validation; Composio Triggers / Webhooks.
+</Callout>
+
+## Why MCP-Direct, Not a Connector
+
+The plan doc evaluates two paths and locks the MCP-direct one for v1:
+
+| Concern | MCP-direct in parent agent (v1) | `ComposioConnector` adapter (deferred to v2) |
+|---|---|---|
+| Surface | The chat agent discovers / calls any whitelisted toolkit at runtime | Each toolkit needs a typed `ConnectorProtocol` implementation |
+| Tool count to add | 4 meta-tools (search, schema, execute, manage) | 200+ toolkit-specific tools, one per service |
+| Ripple `$source` access | No (agent must mediate) | Yes (deterministic Python callers) |
+| Per-service glue | None | One adapter per toolkit |
+| Time to ship | Days | Weeks per batch |
+
+The v2 adapter is deferred until **deterministic non-agent code** (Ripple `$source`, batch jobs) actually needs a Composio toolkit. As of v1 the chat agent is the only consumer.
+
+## Architecture
+
+```
+   Settings (api_key + enterprise_id)
+         │
+         ▼
+   composio.service.is_enabled() / composio_user_id(ctx)
+         │
+         ▼
+   composio.providers.get_tools_for(backend_kind, ctx)
+         │
+   ┌─────┴──────────────────────────────────────┐
+   │           per-(user_id, backend_kind)       │
+   │              tools cache (1h TTL)           │
+   └─────┬──────────────────────────────────────┘
+         │ (miss)
+         ▼
+   Composio(provider=<BackendProvider>()).create(user_id=…)
+         │
+         ▼
+   session.tools()  →  list[Tool]
+         │
+         ▼
+   each backend's _get_mcp_servers / tool-build path:
+     - claude_agent_sdk  →  ClaudeAgentOptions.mcp_servers
+     - openai_agents     →  Agent(tools=…)
+     - google_adk        →  …
+     - deep_agents       →  langgraph wrapper
+```
+
+## Per-Backend Providers
+
+Composio publishes a dedicated provider package per agent SDK. PocketPaw wires all four:
+
+| Backend | Provider class |
+|---|---|
+| `claude_agent_sdk` | `composio_claude_agent_sdk.ClaudeAgentSDKProvider` |
+| `openai_agents` | `composio_openai_agents.OpenAIAgentsProvider` |
+| `google_adk` | `composio_google_adk.GoogleAdkProvider` |
+| `deep_agents` | `composio_langgraph.LanggraphProvider` (deep_agents is langgraph under the hood) |
+
+The shape is identical across the four (see `ee/pocketpaw_ee/cloud/composio/providers.py`):
+
+```python
+composio = Composio(provider=XxxProvider())
+session = composio.create(user_id="enterprise_id:user_id")
+tools = session.tools()
+# → pass `tools` to whatever the backend's agent constructor expects
+```
+
+The per-stream tool-build resolves the active user from `pocketpaw_ee.cloud.chat.agent_service.current_user_id` so multi-tenancy is per-call, not per-instance.
+
+## Multi-Tenancy — Namespaced `user_id`
+
+Composio scopes everything (OAuth tokens, tool catalogs, execution context) by `user_id`. To prevent collisions when one Composio org serves multiple PocketPaw deployments (one prod tenant + one staging tenant on the same Composio account, for instance), PocketPaw namespaces every `user_id`:
+
+```
+user_id sent to Composio = f"{enterprise_id}:{user_id}"
+```
+
+The `ComposioUserId` value object in `domain.py` enforces this at construction:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ComposioUserId:
+    enterprise_id: str   # required, cannot contain ":"
+    user_id: str         # required
+
+    def __str__(self) -> str:
+        return f"{self.enterprise_id}:{self.user_id}"
+```
+
+A `ComposioUserId` cannot exist without both segments — per ee/cloud Rule 3 (domain enforces multi-tenancy at construction). Service code calls `composio_user_id(ctx)` instead of stitching the string by hand.
+
+## Configuration
+
+| Setting | Env var | Purpose |
+|---|---|---|
+| `composio_api_key` | `POCKETPAW_COMPOSIO_API_KEY` | Composio API key (required to enable) |
+| `composio_enterprise_id` | `POCKETPAW_COMPOSIO_ENTERPRISE_ID` | The namespace prefix (required when `api_key` is set; Settings validator enforces) |
+| `composio_base_url` | `POCKETPAW_COMPOSIO_BASE_URL` | Override for self-hosted Composio runtime (defaults to Composio cloud) |
+| `composio_toolkits` | `POCKETPAW_COMPOSIO_TOOLKITS` | Comma-separated allow-list (`"gmail,slack,github,googlecalendar,googledrive"`) |
+| `composio_connect_link_inline` | (flag) | When true (default), render Connect Links as inline Ripple buttons; when false, fall back to text |
+| `composio_mcp_url_ttl_seconds` | (flag) | Per-user tools cache TTL — default 3600 (1h) |
+
+The toolkit allow-list is env-var driven for v1; a per-workspace admin UI is planned. Self-host parity is one env var (`COMPOSIO_BASE_URL`); full validation of self-hosted deployments is a follow-up.
+
+## Lazy Import Boundary
+
+The upstream `composio` SDK is imported **lazily** inside `_get_client` so `pocketpaw_ee.cloud.composio.service` is importable in environments that don't have `pocketpaw[enterprise]` installed (test collection in OSS-only checkouts, doc builds, etc.). Callers should gate on `composio.service.is_enabled(settings)` before invoking anything that touches the SDK.
+
+The process-global client cache holds the api_key and is safe to share across requests — it does not carry per-user state. An `asyncio.Lock` guards against the thundering-herd on first use.
+
+## Connect Link → Inline Ripple
+
+When a Composio tool call returns a "needs authorization" response, PocketPaw extracts the Connect Link URL and emits an inline Ripple spec to the active chat stream — a single button the user clicks to authorize the integration in a new browser tab. Once authorized, the user resends the same prompt and the Composio call succeeds.
+
+Why inline Ripple, not a markdown link: the cloud chat already supports interactive Ripple via the `chat.send` round-trip. A clickable button is the consistent surface for chat-side interactions; a raw URL would mix two formats in the transcript and degrade UX.
+
+Detection heuristic (refine as real Composio responses calibrate):
+
+- dict with a `connect_url` / `connect_link` / `auth_url` / `authorization_url` key
+- dict with `needs_connection: true` / `requires_auth: true` (or sibling flags) AND a URL key nested anywhere obvious
+
+Gated by `settings.composio_connect_link_inline`.
+
+## What Composio Means for Pockets
+
+The pocket specialist sub-agent does NOT receive Composio MCP. Data flows parent → specialist brief, not specialist → Composio. So when a pocket needs to render Composio-sourced data:
+
+1. The user asks for "a pocket showing my open Linear issues."
+2. The parent chat agent calls `COMPOSIO_MULTI_EXECUTE_TOOL` to fetch the issues.
+3. The fetched data goes into the specialist brief as a `state` seed.
+4. The specialist builds the pocket against the seeded state.
+
+The seeded data lives in pocket state at create time. Live refresh (post-create) goes through the pocket's own [sources](/concepts/pocket-sources) — a follow-up PR will let pocket sources reference Composio toolkits directly once the v2 `ComposioConnector` lands.
+
+## Bus Events
+
+Service-layer Composio operations emit two bus events (per ee/cloud Rule 9 — emit on every write):
+
+- `ComposioConnectionVerified` — successful identity check on session create
+- `ComposioConnectionMismatch` — caller's `user_id` didn't match the Composio session identity (defense in depth against misrouted sessions)
+
+Downstream listeners (audit log, dashboard notification) consume these.
+
+## Out of Scope (v1)
+
+Per the plan doc, deferred to follow-ups:
+
+- `ComposioConnector` implementing `ConnectorProtocol` (per-toolkit adapter layer for Ripple `$source` consumers).
+- Migration of existing custom connectors to Composio — both stacks coexist; case-by-case migration is a separate effort.
+- Toolkit allow-listing UX in paw-enterprise — v1 uses env-var allow-list.
+- Self-hosted Composio runtime full validation (single env var hook is the only support v1 ships).
+- Replacing the OSS-side tool registry (`src/pocketpaw/tools/`).
+- Composio Triggers / Webhooks — tool-call path only for v1.
+
+## Related
+
+- [Merge Pocket Spec](/api/post-pocket-spec-merge) — pocket specialist endpoint that consumes Composio-fetched data through the brief.
+- [Pocket Sources](/concepts/pocket-sources) — live source path; v2 will let sources reference Composio toolkits.
+- [OAuth Framework](/integrations/oauth) — sibling first-party OAuth path for the Google integrations.
+- [MCP Servers](/integrations/mcp-servers) — the agent-side MCP framework Composio's tools plug into.


### PR DESCRIPTION
## Summary

Continues from PR #1246 — covers the remaining May 2026 features not in the first sweep. Seven new concept and integration pages grounded in source code.

| Page | Status | Path |
|---|---|---|
| Decision Graph | IN FLIGHT (Slices 1+2+3a on dev via #1240) | `docs/concepts/decision-graph.mdx` |
| Pocket Planner | IN FLIGHT (PR #1223 on planner branch, not yet on dev) | `docs/concepts/pocket-planner.mdx` |
| Pocket Execution Router | IMPLEMENTED (#1181) | `docs/concepts/pocket-execution-router.mdx` |
| Pocket Templates | IN FLIGHT (v1 live; v2 schema in #1228 integration branch) | `docs/concepts/pocket-templates.mdx` |
| Calendar | IMPLEMENTED (#1132 + #1143) | `docs/concepts/calendar.mdx` |
| Composio | IMPLEMENTED v1 (#1153) | `docs/integrations/composio.mdx` |
| OSS-EE Split | IMPLEMENTED Phases 1-4 (#1152, #1153, #1157, follow-ups) | `docs/concepts/oss-ee-split.mdx` |

Sidebar wiring in `docs/docs-config.json`: six new entries under Core Concepts, one under Integrations.

## Stacking

This PR branches off `docs/may-features-foresight-write-actions-livekit` (PR #1246) so it doesn't conflict on `docs-config.json`. Once PR #1246 lands, this one rebases cleanly onto `dev`.

## Test plan

- [ ] Open each new page in the rendered docs site; verify the YAML frontmatter parses (title appears, sidebar entry resolves).
- [ ] Verify each page's status `<Callout type="info">` block renders.
- [ ] Verify the sidebar shows the six new Core Concepts entries (Decision Graph, Pocket Planner, Pocket Execution Router, Pocket Templates, Calendar, OSS-EE Split) and the one new Integrations entry (Composio).
- [ ] Spot-check the cross-links between pages resolve (Decision Graph ↔ Foresight, Pocket Planner ↔ Merge Pocket Spec, Pocket Templates ↔ Decision Graph, OSS-EE Split ↔ each entity page).
- [ ] Code grounding spot-checks against `dev`:
  - [ ] `DecisionGraph` Python API matches `ee/pocketpaw_ee/cloud/decisions/service.py`.
  - [ ] Tier classifier verbs and stage names match `ee/pocketpaw_ee/agent/pocket_router/classifier.py` and `events.py`.
  - [ ] Calendar domain fields match `ee/pocketpaw_ee/calendar/domain.py`.
  - [ ] Composio entry-points and providers match `ee/pyproject.toml` and `ee/pocketpaw_ee/cloud/composio/providers.py`.
  - [ ] Import-linter contract block matches the root `pyproject.toml`.