### PR TITLE
feat(decisions): RFC 09 Slice 2 — pocket runtime emits agent.proposed + decision.completed

### DIFF
--- a/ee/pocketpaw_ee/cloud/decisions/journal_writer.py
+++ b/ee/pocketpaw_ee/cloud/decisions/journal_writer.py
@@ -23,6 +23,14 @@
 #   2 + 3 wire each producer site through this function instead of calling
 #   `journal.append` directly.
 #
+#   2026-05-25 (RFC 09 Slice 2) — Producers call the per-action wrappers
+#   at the bottom of this file (``record_agent_proposed``,
+#   ``record_policy_evaluated``, ``record_human_corrected``,
+#   ``record_decision_completed``) so the chain-action string literal
+#   does not appear at producer call sites — keeps the
+#   ``scripts/audit_decision_chain.py`` lint clean. Each wrapper is a
+#   one-line forwarder to ``record_decision_event``.
+#
 #   Soul-protocol version note
 #   --------------------------
 #   Soul-protocol 0.3.1 (the wheel currently installed) does NOT yet have
@@ -244,4 +252,172 @@ def record_decision_event(
     return entry
 
 
-__all__ = ["DECISION_CHAIN_ACTIONS", "record_decision_event"]
+# ---------------------------------------------------------------------------
+# Per-action convenience wrappers (RFC 09 Slice 2)
+# ---------------------------------------------------------------------------
+# Producer sites in Slices 2 + 3 call the wrappers below instead of
+# spelling the chain-action strings at the call site. Two reasons:
+#
+#   1. The ``scripts/audit_decision_chain.py`` lint script flags any
+#      occurrence of ``action="agent.proposed"`` (et al) outside this
+#      module. Hiding the literal behind a wrapper keeps producer files
+#      audit-clean without losing the no-direct-construction guarantee.
+#
+#   2. A future swap to soul-protocol's typed builders (``build_proposal_event``
+#      with a structured ``AgentProposal`` payload, etc. — currently
+#      gated on the Slice 1a wheel publishing) only touches these four
+#      wrappers. Producer call sites stay the same.
+#
+# Each wrapper has the same kwargs as ``record_decision_event`` minus
+# the ``action`` string itself. ``payload`` shape is whatever the
+# projection's ``_fold_<kind>`` reads — see the docstrings on the
+# wrappers for the expected keys.
+
+
+def record_agent_proposed(
+    *,
+    correlation_id: UUID,
+    actor: Actor,
+    scope: list[str],
+    payload: dict,
+    causation_id: UUID | None = None,
+    ts: datetime | None = None,
+    event_id: UUID | None = None,
+) -> EventEntry:
+    """Emit ``agent.proposed`` — the chain-opening event.
+
+    Fold target: ``DecisionProjection._fold_proposed`` reads
+    ``intent`` / ``action`` / ``pocket_id`` / ``inputs`` /
+    ``precedents`` / ``data`` off the payload.
+
+    Producers: pocket runtime (``action_executor.run_action`` after the
+    allowlist gate, gated by ``not from_instinct`` — RFC 09 audit
+    Surprise 3) and any future "agent proposed a tool call" site.
+    """
+    return record_decision_event(
+        action="agent.proposed",
+        correlation_id=correlation_id,
+        actor=actor,
+        scope=scope,
+        payload=payload,
+        causation_id=causation_id,
+        ts=ts,
+        event_id=event_id,
+    )
+
+
+def record_policy_evaluated(
+    *,
+    correlation_id: UUID,
+    actor: Actor,
+    scope: list[str],
+    payload: dict,
+    causation_id: UUID | None = None,
+    ts: datetime | None = None,
+    event_id: UUID | None = None,
+) -> EventEntry:
+    """Emit ``policy.evaluated`` — a policy gate observation.
+
+    Fold target: ``DecisionProjection._fold_policy`` reads
+    ``policy`` / ``passed`` / ``reason`` off the payload.
+
+    Producers:
+      * direct-path auto-approve (Slice 2 — ``action_executor`` at the
+        gate-8 success branch) — ``passed=True, policy="auto"``.
+      * Instinct park (Slice 3 — ``instinct_bridge.propose_pocket_write``
+        after the Action is stored) — ``passed=False,
+        reason="parked_for_human_approval"``.
+      * Instinct approve (Slice 3 — ``instinct/router.approve_action``
+        after ``store.approve``) — ``passed=True``.
+    """
+    return record_decision_event(
+        action="policy.evaluated",
+        correlation_id=correlation_id,
+        actor=actor,
+        scope=scope,
+        payload=payload,
+        causation_id=causation_id,
+        ts=ts,
+        event_id=event_id,
+    )
+
+
+def record_human_corrected(
+    *,
+    correlation_id: UUID,
+    actor: Actor,
+    scope: list[str],
+    payload: dict,
+    causation_id: UUID | None = None,
+    ts: datetime | None = None,
+    event_id: UUID | None = None,
+) -> EventEntry:
+    """Emit ``human.corrected`` — a human approver's disposition.
+
+    Fold target: ``DecisionProjection._fold_corrected`` appends an
+    ``ApproverRef`` and stashes any ``note`` from the payload.
+
+    Producers (Slice 3, all in ``ee/pocketpaw_ee/instinct/router.py``):
+    ``approve_action`` (disposition ``accepted``/``edited``),
+    ``reject_action`` (``rejected``), and the bulk variants of both.
+    """
+    return record_decision_event(
+        action="human.corrected",
+        correlation_id=correlation_id,
+        actor=actor,
+        scope=scope,
+        payload=payload,
+        causation_id=causation_id,
+        ts=ts,
+        event_id=event_id,
+    )
+
+
+def record_decision_completed(
+    *,
+    correlation_id: UUID,
+    actor: Actor,
+    scope: list[str],
+    payload: dict,
+    causation_id: UUID | None = None,
+    ts: datetime | None = None,
+    event_id: UUID | None = None,
+) -> EventEntry:
+    """Emit ``decision.completed`` — the chain-closing terminal event.
+
+    Fold target: ``DecisionProjection._close_chain`` reads ``passed``
+    off the payload; ``action_outcome`` / ``error_class`` / ``reason``
+    ride along for the explain narrator.
+
+    Producers:
+      * direct success / failure (Slice 2 — ``action_executor`` at
+        gate-8 success branch and the 4 except branches; gated by
+        ``not binding.requires_instinct`` so the Instinct re-entry
+        doesn't double-emit).
+      * Instinct re-entry success / failure (Slice 2 —
+        ``instinct_bridge.execute_approved_write`` after
+        ``store.mark_executed`` or on rejection / executor crash).
+      * Instinct reject (Slice 3 — ``instinct/router.reject_action``).
+      * Abandon path (Slice 4 — ``decisions._action_sweeper`` for
+        chains stuck >24h without a terminal).
+    """
+    return record_decision_event(
+        action="decision.completed",
+        correlation_id=correlation_id,
+        actor=actor,
+        scope=scope,
+        payload=payload,
+        causation_id=causation_id,
+        ts=ts,
+        event_id=event_id,
+    )
+
+
+__all__ = [
+    "DECISION_CHAIN_ACTIONS",
+    "record_agent_proposed",
+    "record_decision_completed",
+    "record_decision_event",
+    "record_human_corrected",
+    "record_policy_evaluated",
+]

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -60,6 +60,29 @@
 #   Emitter failures must never break the executor's return — the call
 #   is wrapped so a bus or audit hiccup logs a warning but the
 #   action's success result still propagates to the caller.
+# Updated: 2026-05-25 (RFC 09 Slice 2 — Decision Graph live formation) —
+#   `run_action` now MINTS a `correlation_id` at entry (Captain Decision 9
+#   — every entry path through the chokepoint gets one for free; callers
+#   can override via kwarg) and emits the chain-forming events through the
+#   ``record_decision_event`` helper in ``decisions.journal_writer``:
+#     * ``agent.proposed`` after gate-5 (allowlist) passes and before gate-7
+#       (instinct park). GATED by ``not from_instinct`` so the Instinct
+#       call-back path does NOT re-emit (audit Surprise 3 — would otherwise
+#       reset chain ``proposed_at`` / ``intent`` / ``action`` via
+#       ``_fold_proposed``).
+#     * ``policy.evaluated(passed=True, policy="auto")`` + ``decision.completed
+#       (landed)`` on the direct-path success branch (gated by
+#       ``not binding.requires_instinct`` so the Instinct re-entry doesn't
+#       double-emit with the bridge's site (b) at ``instinct_bridge.py``).
+#       The policy emit makes the chain shape symmetric with the parked-then-
+#       approved path — every chain carries a policy step.
+#     * ``decision.completed(passed=False, action_outcome="failed",
+#       error_class=...)`` on each of the 4 gate-8 failure branches (timeout,
+#       backend HTTP error, guard error, unexpected exception). Same
+#       ``not binding.requires_instinct`` guard — the Instinct re-entry
+#       failure is closed by the bridge at ``instinct_bridge.py`` site (d).
+#   correlation_id is THREADED through to ``_park`` so the bridge can stash
+#   it on the parked Instinct Action (schema-2 bump in ``instinct_bridge``).
 #
 # A write has blast radius a read does not, so this executor adds three
 # concerns on TOP of the shared SSRF guards:
@@ -100,11 +123,18 @@ import time
 import urllib.parse
 import uuid
 from typing import TYPE_CHECKING, Any, Literal
+from uuid import UUID, uuid4
 
 import httpx
 from pydantic import BaseModel, Field, ValidationError, model_validator
+from soul_protocol.spec.journal import Actor
 
 from pocketpaw.security.url_validators import validate_external_url_strict
+from pocketpaw_ee.cloud.decisions.journal_writer import (
+    record_agent_proposed,
+    record_decision_completed,
+    record_policy_evaluated,
+)
 from pocketpaw_ee.cloud.pockets._http_guard import (
     _HTTP_TIMEOUT,
     _MAX_RESPONSE_BYTES,
@@ -344,6 +374,81 @@ def _error(action: str, message: str, code: str, on_error: list[dict]) -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# RFC 09 Slice 2 — Decision-Graph chain emitters
+# ---------------------------------------------------------------------------
+# Each helper is a thin wrapper over `record_decision_event` so the call
+# sites read as one logical line and a future agent looking at gate 8
+# does not have to reconstruct the Actor / scope shape from scratch.
+#
+# Failure isolation: each helper swallows any exception raised by the
+# emit path. A Decision-Graph wiring bug or a downstream projection crash
+# must NEVER fail the producer's request — the journal-side row is the
+# source of truth, the Slice 4 reconciler is the safety net (RFC 09 §
+# Architecture). The helper in `journal_writer.py` already swallows
+# `projection.apply` failures; this outer layer guards against the journal
+# itself raising (e.g. a transient SQLite lock).
+#
+# Actor shape: the producer is the pocket runtime (a system actor on
+# behalf of the user who initiated the write). `id` is the user_id with a
+# `user:` prefix so a future reader of the chain can attribute the
+# proposal to the human who triggered it; `scope_context` carries the
+# workspace + pocket so visibility filters narrow correctly.
+
+
+def _chain_actor(*, user_id: str, workspace_id: str, pocket_id: str) -> Actor:
+    """Build the Actor recorded on each chain-forming event.
+
+    `kind="agent"` because the pocket runtime is the actor that
+    PROPOSED the write (the chat agent / Tier-0 deterministic router /
+    REST endpoint all flow through this same chokepoint — see RFC 09
+    Captain Decision 9). The user_id rides along on the Actor's `id`
+    so the projection can attribute the chain to the human who started
+    it; the workspace + pocket scopes ride on `scope_context` so the
+    `_visible()` filter on `DecisionStore.find` narrows correctly.
+    """
+    safe_user = user_id or "unknown"
+    return Actor(
+        kind="agent",
+        id=f"user:{safe_user}",
+        scope_context=[f"workspace:{workspace_id}", f"pocket:{pocket_id}"],
+    )
+
+
+def _chain_scope(*, workspace_id: str, pocket_id: str) -> list[str]:
+    """Scope tag set stamped onto every chain event for this pocket write.
+
+    Matches the producer-1 / producer-4 scope shape in RFC 09 § Privacy
+    / scope. The projection's `_visible()` check intersects these tags
+    with the requester's scopes.
+    """
+    return [f"workspace:{workspace_id}", f"pocket:{pocket_id}"]
+
+
+def _safe_record(record_fn, *, correlation_id: UUID, **kwargs):
+    """Best-effort chain emit; swallow + log failures.
+
+    Wraps any of the per-action wrappers from
+    ``pocketpaw_ee.cloud.decisions.journal_writer`` so a Decision-Graph
+    wiring bug or transient SQLite-locked exception cannot fail the
+    producer's request. Returns the event id on success so the parked
+    path can stash it as ``causation_id`` for the next event in the
+    chain. Returns ``None`` when the emit raised — the Slice 4 reconciler
+    will reconcile from the journal cursor on the next tick.
+    """
+    try:
+        entry = record_fn(correlation_id=correlation_id, **kwargs)
+        return entry.id
+    except Exception:  # noqa: BLE001 — see "Failure isolation" above
+        logger.warning(
+            "decision-chain emit failed for %s correlation_id=%s",
+            getattr(record_fn, "__name__", "record_*"),
+            correlation_id,
+            exc_info=True,
+        )
+        return None
+
+
 async def run_action(
     *,
     workspace_id: str,
@@ -364,6 +469,7 @@ async def run_action(
     row_context: dict[str, Any] | None = None,
     workspace_context: dict[str, Any] | None = None,
     row_id: str = "",
+    correlation_id: UUID | None = None,
 ) -> dict:
     """Run ONE pocket write action against its configured backend.
 
@@ -380,6 +486,16 @@ async def run_action(
     ``requires_instinct`` and ``from_instinct`` is ``False`` the executor
     runs every cheap validation gate then PARKS the write — it returns the
     ``instinct_pending`` sentinel and makes NO HTTP call.
+
+    ``correlation_id`` (RFC 09 Slice 2 — Captain Decision 9) is the
+    Decision-Graph chain id. When ``None`` (the default) the executor
+    mints a fresh UUID at entry — every chat-agent / Tier-0 router /
+    REST entry path through this chokepoint gets one for free. The
+    Instinct re-entry path passes the original id back in so the chain
+    folds correctly (``execute_approved_write`` reads it off the parked
+    Action's schema-2 ``_pocket_write`` blob). On the parked path the
+    minted / supplied id rides on the ``_park`` dict so the bridge can
+    stash it on the Instinct Action.
 
     The result shape on a fired success::
 
@@ -410,14 +526,34 @@ async def run_action(
       5. ALLOWLIST — ``(method, query-stripped, percent-decoded path)``
          must match an ``allowed_writes`` entry; a miss is audited WARNING
          ``rejected``.
+      5b. RFC 09 Slice 2 — emit ``agent.proposed`` (chain-forming).
+         Suppressed when ``from_instinct`` is True (re-entry guard —
+         audit Surprise 3). A write rejected at gate 5 never reaches the
+         proposal point in the agent's mental model and so produces no
+         chain (Captain Decision 10).
       6. DNS pre-resolve — reject a host that resolves internal.
       7. INSTINCT PARK — when the binding requires instinct and this is
          not a post-approval call, return the ``instinct_pending``
          sentinel after gates 2-6 have validated the write. A write the
-         allowlist would reject is rejected here, NOT parked.
+         allowlist would reject is rejected here, NOT parked. The
+         ``correlation_id`` rides on ``_park`` so the bridge can stash
+         it on the parked Action's ``_pocket_write`` blob.
       8. The HTTP call: redirects disabled, 3xx is an error, tight
-         timeouts, 512 KB response cap, sanitized errors.
+         timeouts, 512 KB response cap, sanitized errors. On the direct
+         (non-Instinct) path: emit ``policy.evaluated(passed=True,
+         policy="auto")`` + ``decision.completed(landed)`` on success,
+         or ``decision.completed(failed)`` on each of the 4 except
+         branches. The Instinct re-entry path (``from_instinct=True``)
+         skips both emits — the bridge owns the chain close.
     """
+    # ── 0. RFC 09 Slice 2 — mint the correlation_id (Captain Decision 9) ──
+    # Every entry path (chat agent, Tier-0 deterministic pocket-router,
+    # direct REST endpoint) flows through here, so minting at this
+    # chokepoint covers every code path uniformly. Caller may override
+    # (e.g. the Instinct re-entry from `execute_approved_write` passes the
+    # original id back in so the chain folds correctly).
+    correlation_id = correlation_id or uuid4()
+
     # ── 1. parse the binding ────────────────────────────────────────────
     try:
         binding = ActionBinding.model_validate(raw_action)
@@ -585,6 +721,52 @@ async def run_action(
             on_error,
         )
 
+    # ── 5b. RFC 09 Slice 2 — emit agent.proposed ────────────────────────
+    # The allowlist passed (gate 5), so this write is something the agent
+    # is actually going to *propose* — either fire it directly (gate 8)
+    # or park it for human approval (gate 7). Emit BEFORE the park so the
+    # chain starts at the proposal moment; the same chain will close at
+    # gate 8 (direct) or via the Instinct bridge (parked → approved).
+    #
+    # Re-entry guard (audit Surprise 3): when `from_instinct=True` we are
+    # inside the post-approval execution of an already-proposed write —
+    # the proposal was emitted on the FIRST entry. Re-emitting here would
+    # overwrite the chain's `proposed_at` / `intent` / `action` via
+    # `_fold_proposed` (projection.py:300+) on every Instinct-approved
+    # write — a subtle bug that turns a single Decision into a "double
+    # proposed" mess. Suppress the emit on re-entry.
+    if not from_instinct:
+        _safe_record(
+            record_agent_proposed,
+            correlation_id=correlation_id,
+            actor=_chain_actor(user_id=user_id, workspace_id=workspace_id, pocket_id=pocket_id),
+            scope=_chain_scope(workspace_id=workspace_id, pocket_id=pocket_id),
+            payload={
+                # Fields the projection's `_fold_proposed` consumes
+                # (`projection.py:_fold_proposed`): intent / action /
+                # pocket_id / inputs. Extra fields ride along for the
+                # explain narrator and a future swap to soul-protocol's
+                # `build_proposal_event(AgentProposal(...))` once the
+                # Slice 1a wheel publishes (TODO(rfc09-slice-1a-wheel)).
+                "intent": f"{method} {path_decoded} via pocket {pocket_id}",
+                "action": action,
+                "pocket_id": pocket_id,
+                "inputs": [],
+                # AgentProposal-shaped fields for future-builder compat.
+                "proposal_kind": "pocket_write",
+                "summary": f"{method} {path_decoded} via pocket {pocket_id}",
+                "proposal": {
+                    "method": method,
+                    "path": path_decoded,
+                    "binding": {
+                        "requires_instinct": binding.requires_instinct,
+                        "instinct_policy": binding.instinct_policy,
+                        "outcome": binding.outcome,
+                    },
+                },
+            },
+        )
+
     # ── 6. DNS pre-resolve ──────────────────────────────────────────────
     try:
         await _assert_host_external(urllib.parse.urlsplit(url).hostname or "")
@@ -628,6 +810,13 @@ async def run_action(
                 "params": params,
                 "idempotency_key": idempotency_key,
                 "outcome": binding.outcome,
+                # RFC 09 Slice 2 — correlation_id rides on _park so the
+                # bridge can stash it on the parked Action's schema-2
+                # _pocket_write blob. The Instinct router reads it back
+                # at approve/reject time to chain policy.evaluated +
+                # human.corrected + decision.completed under the same
+                # correlation as the agent.proposed we already emitted.
+                "correlation_id": str(correlation_id),
             },
             "on_success": [],
             "on_error": [],
@@ -659,6 +848,16 @@ async def run_action(
             status="error",
             base_url=base_url,
         )
+        _emit_direct_path_failure(
+            binding=binding,
+            from_instinct=from_instinct,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+            error_class="TimeoutError",
+            reason="timeout",
+        )
         return _error(action, "action timed out", "timeout", on_error)
     except _BackendHTTPError as exc:
         # S2 — the exact backend HTTP status goes ONLY to the audit log,
@@ -674,6 +873,16 @@ async def run_action(
             base_url=base_url,
             backend_status=exc.status_code,
         )
+        _emit_direct_path_failure(
+            binding=binding,
+            from_instinct=from_instinct,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+            error_class="BackendHTTPError",
+            reason="http_error",
+        )
         return _error(action, "the backend rejected the request", "http_error", on_error)
     except _GuardError as exc:
         _audit_action_run(
@@ -684,8 +893,18 @@ async def run_action(
             status="error",
             base_url=base_url,
         )
+        _emit_direct_path_failure(
+            binding=binding,
+            from_instinct=from_instinct,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+            error_class="GuardError",
+            reason=exc.code,
+        )
         return _error(action, exc.message, exc.code, on_error)
-    except Exception:  # noqa: BLE001 — never let a raw exception escape
+    except Exception as exc:  # noqa: BLE001 — never let a raw exception escape
         logger.warning("pocket %s action %s: unexpected failure", pocket_id, action, exc_info=True)
         _audit_action_run(
             actor=user_id,
@@ -694,6 +913,16 @@ async def run_action(
             action=action,
             status="error",
             base_url=base_url,
+        )
+        _emit_direct_path_failure(
+            binding=binding,
+            from_instinct=from_instinct,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+            error_class=type(exc).__name__,
+            reason="unexpected_error",
         )
         return _error(action, "action failed", "error", on_error)
 
@@ -734,6 +963,42 @@ async def run_action(
                 exc_info=True,
             )
 
+    # RFC 09 Slice 2 — direct-path (non-Instinct) close: emit the
+    # auto-approve `policy.evaluated(passed=True)` for chain symmetry
+    # with the parked-then-approved path, then the `decision.completed`
+    # terminal. Guarded by `not binding.requires_instinct` so the
+    # Instinct re-entry path (where `from_instinct=True` AND
+    # `binding.requires_instinct=True`) does NOT double-emit with the
+    # bridge at `instinct_bridge.execute_approved_write` site (b). The
+    # captain's brief: "if there's a path that doesn't go through
+    # Instinct's human approval flow, emit policy.evaluated(passed=True)
+    # AND decision.completed(landed) in sequence."
+    if not binding.requires_instinct:
+        actor = _chain_actor(user_id=user_id, workspace_id=workspace_id, pocket_id=pocket_id)
+        scope = _chain_scope(workspace_id=workspace_id, pocket_id=pocket_id)
+        policy_event_id = _safe_record(
+            record_policy_evaluated,
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=scope,
+            payload={
+                "policy": "auto",
+                "passed": True,
+                "evaluator": "auto",
+            },
+        )
+        _safe_record(
+            record_decision_completed,
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=scope,
+            payload={
+                "passed": True,
+                "action_outcome": "landed",
+            },
+            causation_id=policy_event_id,
+        )
+
     return {
         "ok": True,
         "action": action,
@@ -746,6 +1011,42 @@ async def run_action(
         "on_success": binding.on_success,
         "on_error": on_error,
     }
+
+
+def _emit_direct_path_failure(
+    *,
+    binding: ActionBinding,
+    from_instinct: bool,
+    correlation_id: UUID,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    error_class: str,
+    reason: str,
+) -> None:
+    """Emit ``decision.completed(failed)`` for the direct (non-Instinct) path.
+
+    Same guard as the success emit: only fires when the binding is NOT
+    Instinct-gated. The Instinct re-entry failure path closes the chain
+    from ``instinct_bridge.execute_approved_write`` site (d) instead, so
+    we'd double-emit if we fired here too. ``error_class`` is the Python
+    exception type name (TimeoutError / BackendHTTPError / GuardError /
+    type(exc).__name__) for the narrator's "why did this fail" story.
+    """
+    if binding.requires_instinct:
+        return
+    _safe_record(
+        record_decision_completed,
+        correlation_id=correlation_id,
+        actor=_chain_actor(user_id=user_id, workspace_id=workspace_id, pocket_id=pocket_id),
+        scope=_chain_scope(workspace_id=workspace_id, pocket_id=pocket_id),
+        payload={
+            "passed": False,
+            "action_outcome": "failed",
+            "error_class": error_class,
+            "reason": reason,
+        },
+    )
 
 
 async def _do_request(

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
@@ -41,11 +41,26 @@
 #   no credentials and is marked failed instead of firing a cross-tenant
 #   write. The instinct router's per-`_pocket_write` workspace assertion
 #   is the primary gate; this is belt-and-braces.
+#
+# Updated: 2026-05-25 (RFC 09 Slice 2 — Decision Graph live formation) —
+#   `_POCKET_WRITE_SCHEMA` bumped 1 → 2. The parked blob now carries
+#   ``correlation_id`` (set from the executor's mint point — Captain
+#   Decision 9) and ``parked_policy_event_id`` (populated by Slice 3 when
+#   Instinct emits the parked `policy.evaluated(passed=False)` event so
+#   the eventual `human.corrected` can chain its `causation_id` back to
+#   the policy event). RFC 09 Captain Decision 5: no backward-compat
+#   shim — schema-1 blobs that get approved post-deploy are marked
+#   failed by the existing schema-mismatch check at line ~220. Drain the
+#   Instinct queue before deploying Slice 2.
+#   ``execute_approved_write`` reads the correlation_id off the schema-2
+#   blob and passes it back into ``run_action(..., correlation_id=...)``
+#   so the chain folds under one id end-to-end.
 
 from __future__ import annotations
 
 import logging
 from typing import Any
+from uuid import UUID
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +68,20 @@ logger = logging.getLogger(__name__)
 # `Action.parameters._pocket_write`. Bump when the blob shape changes so a
 # stale pending Action approved after a deploy fails loud instead of
 # executing a misinterpreted write.
-_POCKET_WRITE_SCHEMA = 1
+#
+# Schema 2 (RFC 09 Slice 2) — adds:
+#   * ``correlation_id``: the Decision-Graph chain id minted by the
+#     executor at the moment ``agent.proposed`` fired. The Instinct
+#     router (Slice 3) reads it back when emitting ``policy.evaluated`` /
+#     ``human.corrected`` / ``decision.completed``.
+#   * ``parked_policy_event_id``: the id of the
+#     ``policy.evaluated(passed=False, reason="parked_for_human_approval")``
+#     event emitted by Instinct when the write was parked. Slice 3 uses
+#     it as the ``causation_id`` on the subsequent ``human.corrected``
+#     event so the chain has a clean cause-arrow from policy → human.
+#     ``None`` when not yet populated (e.g. if a future code path parks
+#     a write without firing the policy event first).
+_POCKET_WRITE_SCHEMA = 2
 
 
 def _resolve_approver(
@@ -146,6 +174,17 @@ async def propose_pocket_write(
     # The parked-write blob — everything `execute_approved_write` needs to
     # re-run the write, MINUS the credential. `outcome` rides along so the
     # outcome event can be emitted after the gated write succeeds.
+    #
+    # Schema 2 (RFC 09 Slice 2):
+    #   * ``correlation_id``: the Decision-Graph chain id minted by the
+    #     executor when ``agent.proposed`` fired. Must round-trip via the
+    #     Instinct store so the post-approval re-entry into
+    #     ``run_action`` uses the SAME id and the chain folds under one
+    #     correlation (instead of producing a second Decision row).
+    #   * ``parked_policy_event_id``: ``None`` here — Slice 3 wires the
+    #     parked-side ``policy.evaluated`` emit and populates this field
+    #     with the event id at that point. The field exists on the
+    #     schema-2 blob now so the round-trip contract is stable.
     pocket_write = {
         "schema": _POCKET_WRITE_SCHEMA,
         "action": action_name,
@@ -156,6 +195,9 @@ async def propose_pocket_write(
         "outcome": parked_write.get("outcome"),
         "workspace_id": workspace_id,
         "requested_by": requested_by,
+        # RFC 09 Slice 2 — schema-2 chain-correlation fields
+        "correlation_id": parked_write.get("correlation_id"),
+        "parked_policy_event_id": None,
     }
 
     approver = _resolve_approver(pocket, backend_config)
@@ -231,6 +273,26 @@ async def execute_approved_write(action) -> None:  # type: ignore[no-untyped-def
     requested_by = str(blob.get("requested_by") or "")
     approver = str(getattr(action, "approved_by", "") or "") or "system"
 
+    # RFC 09 Slice 2 — pull the chain correlation_id back off the blob so
+    # the post-approval ``run_action`` re-entry folds into the SAME chain
+    # the original ``agent.proposed`` opened. A malformed / missing id
+    # falls through to None and ``run_action`` will mint a fresh one —
+    # the chain still records the executed write, just under a new id.
+    # That's better than failing the approve when the only thing wrong
+    # is a Decision-Graph wire.
+    raw_corr = blob.get("correlation_id")
+    parked_correlation_id: UUID | None = None
+    if isinstance(raw_corr, str) and raw_corr:
+        try:
+            parked_correlation_id = UUID(raw_corr)
+        except ValueError:
+            logger.warning(
+                "approved action %s has malformed correlation_id on blob — "
+                "post-approval write will mint a fresh chain id",
+                action.id,
+            )
+            parked_correlation_id = None
+
     # BLOCKER 1 defense-in-depth (PR #1183) — a parked write with no
     # workspace is unexecutable. The credential re-load below is the
     # tenancy gate (it matches `(workspace_id, pocket_id)` together), so
@@ -294,10 +356,28 @@ async def execute_approved_write(action) -> None:  # type: ignore[no-untyped-def
             allowed_writes=allowed_writes,
             idempotency_key=blob.get("idempotency_key"),
             from_instinct=True,
+            # RFC 09 Slice 2 — pass the chain correlation_id back into the
+            # executor so the executor's gates run under the same id as
+            # the original ``agent.proposed``. When ``parked_correlation_id``
+            # is None (schema-2 blob with a malformed id, or a future code
+            # path that parks without one), ``run_action`` mints a fresh id.
+            correlation_id=parked_correlation_id,
         )
     except Exception:  # noqa: BLE001 — never let an executor crash break approve
         logger.warning("approved action %s: write executor crashed", action.id, exc_info=True)
         await store.mark_failed(action.id, "write executor failed")
+        # RFC 09 Slice 2 — close the Decision chain on the executor
+        # crash too (otherwise the chain stays open indefinitely until
+        # the Slice 4 abandon-sweeper picks it up after 24h).
+        _emit_bridge_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class="ExecutorCrash",
+            correlation_id=parked_correlation_id,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=requested_by or approver,
+        )
         return
 
     if not result.get("ok"):
@@ -307,11 +387,42 @@ async def execute_approved_write(action) -> None:  # type: ignore[no-untyped-def
         code = result.get("code") or "error"
         err = result.get("error") or "write rejected"
         await store.mark_failed(action.id, f"{err} (code:{code})")
+        # RFC 09 Slice 2 — close the chain on the bridge-side failure
+        # path (audit Producer 4 site (d)). The error class rides as
+        # ``error_class`` so the explain narrator can say *why* it
+        # failed (re-validation rejected, etc.). action_executor's
+        # gate-8 failure emit is suppressed on the Instinct re-entry
+        # (``binding.requires_instinct=True`` branch) so this is the
+        # only emit that closes the chain in this case.
+        _emit_bridge_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=str(code),
+            correlation_id=parked_correlation_id,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=requested_by or approver,
+        )
         return
 
     await store.mark_executed(
         action.id,
         f"write '{action_name}' executed — HTTP {result.get('status')}",
+    )
+
+    # RFC 09 Slice 2 — chain close on the bridge-side success path
+    # (audit Producer 4 site (b)). Emit BEFORE ``emit_pocket_outcome``
+    # so the outcomes-side ``decision.outcome_attached`` (RFC 07 Slice 2
+    # back-reference) finds an existing Decision row to mutate. Order
+    # matters: a swap here would lose the late outcome attach.
+    _emit_bridge_chain_close(
+        passed=True,
+        action_outcome="landed",
+        error_class=None,
+        correlation_id=parked_correlation_id,
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        user_id=requested_by or approver,
     )
 
     # M2b.2 — emit the outcome AFTER the gated write succeeded. A binding
@@ -332,6 +443,66 @@ async def execute_approved_write(action) -> None:  # type: ignore[no-untyped-def
         logger.warning(
             "approved action %s: outcome emit failed (write succeeded)",
             action.id,
+            exc_info=True,
+        )
+
+
+def _emit_bridge_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    correlation_id: UUID | None,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+) -> None:
+    """Emit the ``decision.completed`` chain close for the bridge path.
+
+    Producer 4 sites (b) and (d) in RFC 09 audit — the bridge owns the
+    chain close on the Instinct re-entry path because the action_executor
+    suppresses its own emit when ``binding.requires_instinct=True``.
+
+    Returns early when ``correlation_id`` is None (a parked blob with a
+    malformed id). The Slice 4 abandon-sweeper will close any chain that
+    accumulates without a terminal after 24h.
+    """
+    # Late imports — keep the bridge's import surface small at module
+    # load and avoid a circular import with the decisions package.
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    if correlation_id is None:
+        # Nothing to close — the original chain never threaded an id
+        # through. The next Slice 4 reconciler / abandon-sweeper tick
+        # will deal with any orphans.
+        return
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}", f"pocket:{pocket_id}"],
+    )
+    payload: dict[str, Any] = {
+        "passed": passed,
+        "action_outcome": action_outcome,
+    }
+    if error_class:
+        payload["error_class"] = error_class
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}", f"pocket:{pocket_id}"],
+            payload=payload,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "bridge decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_outcome,
             exc_info=True,
         )
 

--- a/tests/cloud/test_instinct_approval_security.py
+++ b/tests/cloud/test_instinct_approval_security.py
@@ -64,10 +64,22 @@ class _FakeUser:
 
 def _pocket_write_params(workspace_id: str, outcome: str | None = "renewal_completed") -> dict:
     """An Action ``parameters`` payload carrying a parked pocket write — the
-    shape ``instinct_bridge.propose_pocket_write`` stores."""
+    shape ``instinct_bridge.propose_pocket_write`` stores.
+
+    Schema 2 (RFC 09 Slice 2) added the chain-correlation fields
+    ``correlation_id`` (the Decision-Graph chain id minted by the
+    action_executor at the moment ``agent.proposed`` fired) and
+    ``parked_policy_event_id`` (populated by Slice 3 when Instinct emits
+    the parked ``policy.evaluated(passed=False)``). These tests don't
+    exercise the chain semantics — they pin the security / re-entry
+    guarantees of the bridge — but the schema check in
+    ``execute_approved_write`` rejects any blob whose schema doesn't
+    match the current ``_POCKET_WRITE_SCHEMA``, so the round-trip needs
+    matching shape.
+    """
     return {
         "_pocket_write": {
-            "schema": 1,
+            "schema": 2,
             "action": "mark_renewed",
             "method": "POST",
             "path": "/leases/42/renew",
@@ -76,6 +88,12 @@ def _pocket_write_params(workspace_id: str, outcome: str | None = "renewal_compl
             "outcome": outcome,
             "workspace_id": workspace_id,
             "requested_by": "requester-9",
+            # RFC 09 Slice 2 — schema-2 chain-correlation fields. The
+            # bridge accepts None for both: a malformed correlation_id
+            # falls through to ``run_action``'s own mint, and
+            # ``parked_policy_event_id`` is populated by Slice 3.
+            "correlation_id": None,
+            "parked_policy_event_id": None,
         }
     }
 

--- a/tests/ee/test_pocket_runtime_decision_events.py
+++ b/tests/ee/test_pocket_runtime_decision_events.py
@@ -1,0 +1,717 @@
+# tests/ee/test_pocket_runtime_decision_events.py
+# Created: 2026-05-25 (RFC 09 Slice 2 — feat/rfc-09-slice-2-pocket-runtime-emits)
+#
+# Pins the chain-forming event emits the pocket runtime adds in
+# Slice 2: ``agent.proposed`` from ``run_action``'s entry-after-allowlist
+# point, ``policy.evaluated(passed=True)`` + ``decision.completed(landed)``
+# on the direct-path success branch, ``decision.completed(failed)`` on
+# each of the four gate-8 except branches, plus the parked-blob schema-2
+# round-trip and the Instinct re-entry guard that prevents a double
+# ``agent.proposed`` emit. End-to-end happy path: the chain folds into a
+# real Decision row queryable via DecisionGraph.find.
+#
+# What's NOT covered here (lives in Slice 3 / Slice 4):
+#   * ``policy.evaluated(passed=False)`` from Instinct park
+#     (instinct_bridge propose path — Slice 3).
+#   * ``human.corrected`` from approve/reject (Slice 3).
+#   * decision.completed on reject_action (Slice 3).
+#   * Abandon-path sweeper (Slice 4).
+#
+# Fixture strategy: build a small async helper that wires the journal +
+# DecisionGraph + httpx mock + DNS stub, mirrors the
+# `test_pocket_action_executor.py` pattern. We do NOT exercise the full
+# Beanie / Instinct stores — instinct_bridge.execute_approved_write is
+# unit-tested here via direct ``run_action(..., from_instinct=True,
+# correlation_id=<parked>)`` calls, which is the same code path the
+# bridge takes.
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud.decisions.service import (
+    DecisionGraph,
+    get_decision_graph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import set_db_path
+from pocketpaw_ee.cloud.pockets import action_executor
+from pocketpaw_ee.cloud.pockets import instinct_bridge as instinct_bridge_module
+from pocketpaw_ee.cloud.pockets.action_executor import run_action
+from soul_protocol.engine.journal import open_journal
+
+import pocketpaw.journal_dep as journal_dep
+
+BASE = "https://api.example.com"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — wire journal + projection + httpx + DNS
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limits():
+    """Same housekeeping as `test_pocket_action_executor.py`."""
+    action_executor._action_log.clear()
+    yield
+    action_executor._action_log.clear()
+
+
+@pytest.fixture(autouse=True)
+def _public_dns(monkeypatch):
+    """Public IP for every hostname so the SSRF DNS guard passes."""
+
+    def _fake_getaddrinfo(host, *_args, **_kwargs):
+        return [(2, 1, 6, "", ("8.8.8.8", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", _fake_getaddrinfo)
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    """Fresh on-disk journal per test, wired into the lazy
+    ``pocketpaw.journal_dep.get_journal`` lookup the helper performs."""
+    j = open_journal(tmp_path / "journal.db")
+    journal_dep.reset_journal_cache()
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path) -> DecisionGraph:
+    """Fresh DecisionGraph + decisions.db per test, plumbed in as the
+    process-global singleton via reset_projection_for_tests."""
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+def _mock_client_patch(monkeypatch, handler):
+    """Inject an httpx MockTransport that handles outbound requests."""
+    real_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(action_executor.httpx, "AsyncClient", _factory)
+
+
+def _write_action(method: str = "POST", path: str = "/leases/42/renew") -> dict:
+    return {"kind": "write_binding", "method": method, "path": path, "params": {}}
+
+
+def _allow(method: str = "POST", pattern: str = "/leases/*/renew") -> list[dict]:
+    return [{"method": method, "path_pattern": pattern}]
+
+
+def _journal_actions(journal) -> list[str]:
+    """All actions in append order — useful for assertions on which
+    chain events fired in what order."""
+    return [e.action for e in journal.replay_from(0)]
+
+
+def _events_by_correlation(journal, correlation_id: UUID) -> list:
+    """All events that share the given correlation_id, in append order."""
+    return [e for e in journal.replay_from(0) if e.correlation_id == correlation_id]
+
+
+# ---------------------------------------------------------------------------
+# 1. agent.proposed — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_proposed_emitted_on_direct_path(monkeypatch, journal, graph: DecisionGraph):
+    """A direct (non-Instinct) run_action call lands `agent.proposed` in
+    the journal with the minted correlation_id and the projection sees
+    the chain start."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
+
+    result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u_alice",
+        action="mark_renewed",
+        raw_action=_write_action(),
+        path="/leases/42/renew",
+        params={"rent": 2000},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert result["ok"] is True
+
+    # Exactly one agent.proposed event landed.
+    proposed = [e for e in journal.replay_from(0) if e.action == "agent.proposed"]
+    assert len(proposed) == 1, _journal_actions(journal)
+    entry = proposed[0]
+    assert entry.actor.kind == "agent"
+    assert entry.actor.id == "user:u_alice"
+    assert "workspace:w1" in entry.scope
+    assert "pocket:p1" in entry.scope
+    payload = entry.payload or {}
+    assert payload["action"] == "mark_renewed"
+    assert payload["pocket_id"] == "p1"
+    assert payload["proposal_kind"] == "pocket_write"
+    # Correlation_id was minted (a fresh UUID); journal entries carry it.
+    assert entry.correlation_id is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. agent.proposed re-entry guard — the subtle-bug catch
+# ---------------------------------------------------------------------------
+
+
+async def test_from_instinct_reentry_does_not_re_emit_agent_proposed(
+    monkeypatch, journal, graph: DecisionGraph
+):
+    """RFC 09 audit Surprise 3 — the Instinct re-entry path (where
+    `execute_approved_write` calls `run_action(..., from_instinct=True)`
+    with the original correlation_id) MUST NOT emit a second
+    `agent.proposed`. Otherwise `_fold_proposed` overwrites the chain's
+    `proposed_at` / `intent` / `action` and the Decision record loses
+    its original provenance."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
+    corr = uuid4()
+
+    # First entry — agent.proposed fires because from_instinct=False.
+    await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u_alice",
+        action="mark_renewed",
+        raw_action={**_write_action(), "requires_instinct": True},
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+        correlation_id=corr,
+    )
+    proposed_first = [
+        e for e in _events_by_correlation(journal, corr) if e.action == "agent.proposed"
+    ]
+    assert len(proposed_first) == 1
+
+    # Second entry — the Instinct re-entry. Same correlation_id.
+    # from_instinct=True MUST suppress the proposed emit.
+    await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u_alice",
+        action="mark_renewed",
+        raw_action={**_write_action(), "requires_instinct": True},
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+        from_instinct=True,
+        correlation_id=corr,
+    )
+
+    proposed_total = [
+        e for e in _events_by_correlation(journal, corr) if e.action == "agent.proposed"
+    ]
+    assert len(proposed_total) == 1, (
+        "Instinct re-entry must NOT re-emit agent.proposed; got "
+        f"{[e.action for e in _events_by_correlation(journal, corr)]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. correlation_id minted INSIDE run_action (not module-level)
+# ---------------------------------------------------------------------------
+
+
+async def test_each_call_mints_a_fresh_correlation_id(monkeypatch, journal, graph: DecisionGraph):
+    """Two back-to-back run_action calls (no caller-supplied correlation
+    id) must get distinct correlation_ids — a module-level cache would
+    fold both writes into one chain incorrectly."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
+
+    for _ in range(2):
+        await run_action(
+            workspace_id="w1",
+            pocket_id="p1",
+            user_id="u_alice",
+            action="mark_renewed",
+            raw_action=_write_action(),
+            path="/leases/42/renew",
+            params={},
+            base_url=BASE,
+            auth_type="none",
+            auth_header=None,
+            token="",
+            allowed_writes=_allow(),
+        )
+
+    proposed = [e for e in journal.replay_from(0) if e.action == "agent.proposed"]
+    assert len(proposed) == 2
+    assert proposed[0].correlation_id != proposed[1].correlation_id, (
+        "fresh run_action calls must get distinct correlation_ids; got "
+        f"{proposed[0].correlation_id} twice"
+    )
+
+
+async def test_caller_supplied_correlation_id_overrides_mint(
+    monkeypatch, journal, graph: DecisionGraph
+):
+    """A caller (e.g. the Instinct re-entry path) can pass its own
+    correlation_id — the emit uses that, not a freshly-minted one."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
+    corr = uuid4()
+
+    await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u_alice",
+        action="mark_renewed",
+        raw_action=_write_action(),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+        correlation_id=corr,
+    )
+
+    proposed = [e for e in journal.replay_from(0) if e.action == "agent.proposed"]
+    assert len(proposed) == 1
+    assert proposed[0].correlation_id == corr
+
+
+# ---------------------------------------------------------------------------
+# 4. decision.completed — direct success path (landed)
+# ---------------------------------------------------------------------------
+
+
+async def test_direct_success_emits_policy_and_decision_completed(
+    monkeypatch, journal, graph: DecisionGraph
+):
+    """A direct (non-Instinct) success closes the chain with two events
+    in sequence: `policy.evaluated(passed=True, policy='auto')` for
+    chain symmetry, then `decision.completed(landed)` for the close."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"renewed": True}))
+
+    result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u_alice",
+        action="mark_renewed",
+        raw_action=_write_action(),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert result["ok"] is True
+
+    actions = _journal_actions(journal)
+    assert actions == ["agent.proposed", "policy.evaluated", "decision.completed"]
+    decided = [e for e in journal.replay_from(0) if e.action == "decision.completed"][0]
+    assert (decided.payload or {}).get("passed") is True
+    assert (decided.payload or {}).get("action_outcome") == "landed"
+
+
+# ---------------------------------------------------------------------------
+# 5. decision.completed — direct failure branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "scenario,handler,expected_code,expected_error_class",
+    [
+        (
+            "http_error",
+            lambda r: httpx.Response(500, json={"error": "boom"}),
+            "http_error",
+            "BackendHTTPError",
+        ),
+        (
+            "redirect_is_guard_error",
+            lambda r: httpx.Response(302, headers={"location": "/elsewhere"}),
+            "redirect",
+            "GuardError",
+        ),
+    ],
+)
+async def test_direct_failure_branches_emit_decision_completed_failed(
+    monkeypatch,
+    journal,
+    graph: DecisionGraph,
+    scenario: str,
+    handler,
+    expected_code: str,
+    expected_error_class: str,
+):
+    """Each gate-8 except branch in `run_action` (HTTP error, guard
+    error, ...) emits `decision.completed(passed=False, action_outcome=
+    "failed", error_class=<type>)`. Parameterised so a future regression
+    on any single branch surfaces individually."""
+    _mock_client_patch(monkeypatch, handler)
+
+    result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u_alice",
+        action="mark_renewed",
+        raw_action=_write_action(),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert result["ok"] is False
+    assert result["code"] == expected_code
+
+    # The chain should end with decision.completed(failed) — NO policy.
+    # evaluated for the failure paths (the auto-approve emit only fires
+    # on the success branch).
+    actions = _journal_actions(journal)
+    assert "decision.completed" in actions, actions
+    decided = [e for e in journal.replay_from(0) if e.action == "decision.completed"][0]
+    payload = decided.payload or {}
+    assert payload["passed"] is False
+    assert payload["action_outcome"] == "failed"
+    assert payload["error_class"] == expected_error_class
+
+
+async def test_timeout_branch_emits_decision_completed_failed(
+    monkeypatch, journal, graph: DecisionGraph
+):
+    """The TimeoutError branch emits decision.completed(failed,
+    error_class='TimeoutError'). Triggered by patching asyncio.wait_for
+    to raise — the underlying httpx call timing out reliably is fragile
+    in tests."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
+
+    async def _raise_timeout(*_args, **_kwargs):
+        raise TimeoutError("simulated")
+
+    monkeypatch.setattr(action_executor.asyncio, "wait_for", _raise_timeout)
+
+    result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u_alice",
+        action="mark_renewed",
+        raw_action=_write_action(),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert result["ok"] is False
+    assert result["code"] == "timeout"
+    decided = [e for e in journal.replay_from(0) if e.action == "decision.completed"][0]
+    assert (decided.payload or {})["error_class"] == "TimeoutError"
+
+
+async def test_unexpected_exception_branch_emits_decision_completed_failed(
+    monkeypatch, journal, graph: DecisionGraph
+):
+    """The bare `except Exception` branch catches anything else and
+    emits decision.completed(failed, error_class=<type>)."""
+
+    def _raise_runtime(*_args, **_kwargs):
+        raise RuntimeError("unexpected")
+
+    # Force the asyncio.wait_for path to raise a generic Exception
+    # subclass that's neither a TimeoutError, _BackendHTTPError, nor
+    # _GuardError so the bare except branch fires.
+    async def _raise_runtime_async(*_args, **_kwargs):
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(action_executor.asyncio, "wait_for", _raise_runtime_async)
+
+    result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u_alice",
+        action="mark_renewed",
+        raw_action=_write_action(),
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert result["ok"] is False
+    # Code is "error" for the generic-exception branch.
+    assert result["code"] == "error"
+    decided = [e for e in journal.replay_from(0) if e.action == "decision.completed"][0]
+    payload = decided.payload or {}
+    assert payload["error_class"] == "RuntimeError"
+    assert payload["action_outcome"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# 6. Instinct re-entry path — bridge owns the chain close
+# ---------------------------------------------------------------------------
+
+
+async def test_instinct_reentry_success_does_not_double_emit_completed(
+    monkeypatch, journal, graph: DecisionGraph
+):
+    """When `from_instinct=True` (the bridge re-entered run_action with
+    `binding.requires_instinct=True`), the action_executor's gate-8
+    success emit MUST NOT fire — the bridge will emit decision.completed
+    at site (b). Otherwise the chain ends with TWO terminal events."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
+    corr = uuid4()
+
+    result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u_alice",
+        action="mark_renewed",
+        raw_action={**_write_action(), "requires_instinct": True},
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+        from_instinct=True,
+        correlation_id=corr,
+    )
+    assert result["ok"] is True
+
+    # The action_executor should NOT have emitted policy.evaluated or
+    # decision.completed on the re-entry path — only the bridge does.
+    actions = _journal_actions(journal)
+    assert "decision.completed" not in actions, actions
+    assert "policy.evaluated" not in actions, actions
+
+
+async def test_instinct_reentry_failure_does_not_emit_completed(
+    monkeypatch, journal, graph: DecisionGraph
+):
+    """The HTTP-error branch on the re-entry path must NOT emit
+    decision.completed — the bridge handles failure close at site (d)."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(500))
+    corr = uuid4()
+
+    result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u_alice",
+        action="mark_renewed",
+        raw_action={**_write_action(), "requires_instinct": True},
+        path="/leases/42/renew",
+        params={},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+        from_instinct=True,
+        correlation_id=corr,
+    )
+    assert result["ok"] is False
+    actions = _journal_actions(journal)
+    assert "decision.completed" not in actions, actions
+
+
+# ---------------------------------------------------------------------------
+# 7. schema-2 parked blob carries correlation_id (+ parked_policy_event_id)
+# ---------------------------------------------------------------------------
+
+
+async def test_parked_blob_carries_correlation_id_and_event_id_placeholder(
+    monkeypatch, journal, graph: DecisionGraph
+):
+    """A `requires_instinct` first-entry returns the `_park` dict with
+    correlation_id on it (action_executor side). When the bridge
+    `propose_pocket_write` persists the blob into the Instinct Action's
+    parameters, the schema-2 fields land verbatim — correlation_id
+    populated, parked_policy_event_id starts as None (Slice 3 fills it)."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": 1}))
+    corr = uuid4()
+
+    park_result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u_alice",
+        action="mark_renewed",
+        raw_action={**_write_action(), "requires_instinct": True},
+        path="/leases/42/renew",
+        params={"rent": 2000},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+        correlation_id=corr,
+    )
+    assert park_result["code"] == "instinct_pending"
+    park = park_result["_park"]
+    assert park["correlation_id"] == str(corr)
+
+    # Drive the bridge directly: `propose_pocket_write` builds the blob,
+    # but we don't need the Instinct store actually backing it — we
+    # build the blob shape it would persist by replicating
+    # propose_pocket_write's blob-construction logic via a stub on
+    # `get_instinct_store`.
+    captured_blob: dict = {}
+
+    class _StubStore:
+        async def propose(self, **kwargs):
+            captured_blob.update(kwargs.get("parameters", {}).get("_pocket_write", {}))
+
+            class _A:
+                id = "stub_id"
+
+            return _A()
+
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: _StubStore())
+
+    pocket = {"_id": "p1", "workspace": "w1", "owner": "u_alice", "name": "Lease 42"}
+    await instinct_bridge_module.propose_pocket_write(
+        pocket=pocket,
+        backend_config=None,
+        parked_write=park,
+        requested_by="u_alice",
+    )
+
+    # Schema-2 invariants on the persisted blob.
+    assert captured_blob["schema"] == instinct_bridge_module._POCKET_WRITE_SCHEMA
+    assert captured_blob["schema"] == 2
+    assert captured_blob["correlation_id"] == str(corr)
+    # Slice 3 will populate this; Slice 2 leaves it as None so the
+    # round-trip contract is stable.
+    assert captured_blob["parked_policy_event_id"] is None
+    # The non-chain fields still ride along (RFC 05 M2b.1 contract).
+    assert captured_blob["workspace_id"] == "w1"
+    assert captured_blob["requested_by"] == "u_alice"
+    assert captured_blob["method"] == "POST"
+
+
+# ---------------------------------------------------------------------------
+# 8. End-to-end happy path — direct success folds into a Decision row
+# ---------------------------------------------------------------------------
+
+
+async def test_direct_success_folds_into_decision_via_graph_find(
+    monkeypatch, journal, graph: DecisionGraph
+):
+    """RFC 07 promised the projection emits a Decision row when the
+    chain closes. Slice 2 is the producer half — exercise the full
+    happy path and assert a Decision shows up via `DecisionGraph.find`."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"renewed": True}))
+
+    result = await run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u_alice",
+        action="mark_renewed",
+        raw_action={**_write_action(), "outcome": "renewal_completed"},
+        path="/leases/42/renew",
+        params={"rent": 2000},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_allow(),
+    )
+    assert result["ok"] is True
+
+    assert graph.store.count() == 1
+    decisions = await graph.find()
+    assert len(decisions) == 1
+    decision = decisions[0]
+    assert decision.action == "mark_renewed"
+    assert decision.pocket_id == "p1"
+    # The auto-approve policy emit lands as `instinct_policy="auto"`
+    # with `instinct_policy_passed=True` so the chain shape is uniform
+    # with the parked-then-approved future Slice 3 path.
+    assert decision.instinct_policy == "auto"
+    assert decision.instinct_policy_passed is True
+    # Direct success has no rejection — the OutcomeRef stays None until
+    # the outcomes service back-references (or stays None for v1 if no
+    # outcome was named).
+    assert decision.outcome is None or decision.outcome.status != "rejected"
+
+
+# ---------------------------------------------------------------------------
+# 9. Schema-2 parked blob: stale schema-1 approval fails loud (Captain Decision 5)
+# ---------------------------------------------------------------------------
+
+
+async def test_schema_1_parked_blob_marked_failed_on_post_deploy_approval(
+    monkeypatch,
+):
+    """RFC 09 Captain Decision 5 — no backwards compat. A stale schema-1
+    blob (from a build before this deploy) reaches `execute_approved_write`
+    after approval; the existing schema-mismatch check marks it failed
+    rather than executing a misinterpreted write. Drain the Instinct
+    queue before deploying Slice 2."""
+    captured_failures: list[str] = []
+
+    class _StubStore:
+        async def mark_failed(self, action_id: str, reason: str) -> None:
+            captured_failures.append(reason)
+
+        async def mark_executed(self, action_id: str, reason: str) -> None:  # noqa: ARG002
+            pytest.fail("should not have executed a schema-1 blob")
+
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: _StubStore())
+
+    # Schema-1 blob — pre-Slice-2 shape, no correlation_id field.
+    schema_1_blob = {
+        "schema": 1,
+        "action": "mark_renewed",
+        "method": "POST",
+        "path": "/leases/42/renew",
+        "params": {},
+        "idempotency_key": None,
+        "outcome": "renewal_completed",
+        "workspace_id": "w1",
+        "requested_by": "u_alice",
+    }
+
+    class _Action:
+        id = "stale_action_id"
+        pocket_id = "p1"
+        parameters = {"_pocket_write": schema_1_blob}
+        approved_by = "u_alice"
+
+    await instinct_bridge_module.execute_approved_write(_Action())
+
+    assert len(captured_failures) == 1
+    assert "schema mismatch" in captured_failures[0]


### PR DESCRIPTION
## Summary

Slice 2 of RFC 09 wires the six chain-event producers in the pocket
runtime so production writes actually form Decisions in the projection
RFC 07 shipped. Stacked on Slice 1b
(#PENDING-SLICE-1B — `feat/rfc-09-slice-1-record-decision-event`); I'll
retarget to `dev` once Slice 1b merges.

- `action_executor.run_action` mints a `correlation_id` at entry
  (Captain Decision 9 — covers all three entry paths: chat agent,
  Tier-0 router, REST endpoint) and emits `agent.proposed` after the
  allowlist gate, gated by `not from_instinct` to catch the re-entry
  double-emit (audit Surprise 3) that would otherwise overwrite the
  chain's `proposed_at` / `intent` / `action` via `_fold_proposed` on
  every Instinct-approved write.
- Direct (non-Instinct) success closes with
  `policy.evaluated(passed=True, policy="auto")` + `decision.completed
  (landed)` so the chain shape stays symmetric with the parked-then-
  approved Slice 3 path. The four gate-8 except branches each emit
  `decision.completed(failed, error_class=<TimeoutError|GuardError|
  BackendHTTPError|...>)`. Both paths guarded by
  `not binding.requires_instinct` so the Instinct re-entry doesn't
  double-emit with the bridge.
- `instinct_bridge` bumps `_POCKET_WRITE_SCHEMA` to 2, persists
  `correlation_id` and a `parked_policy_event_id` placeholder onto the
  parked blob, threads the id back into `run_action` on re-entry, and
  owns the chain close at Producer 4 sites (b) success and (d) failure
  via a new `_emit_bridge_chain_close` helper.
- Producers call new per-action wrappers in `decisions.journal_writer`
  (`record_agent_proposed`, `record_policy_evaluated`,
  `record_human_corrected`, `record_decision_completed`) so the
  chain-action strings don't appear at producer call sites — keeps
  `scripts/audit_decision_chain.py` quiet without losing the
  no-direct-construction guarantee.
- 14 new tests in `tests/ee/test_pocket_runtime_decision_events.py`
  cover the re-entry guard, fresh-correlation-per-call, every direct
  failure branch (HTTP error / redirect / timeout / unexpected
  exception), the Instinct re-entry no-emit on action_executor side,
  the schema-2 round-trip, the schema-1-drains-loud Captain Decision 5
  path, and an end-to-end chain that folds into a Decision row via
  `DecisionGraph.find`.
- One existing-fixture update in `tests/cloud/test_instinct_approval_
  security.py` — `_pocket_write_params` now writes a schema-2 blob so
  the bridge's mismatch check doesn't reject the test parking.

## Test plan

- [x] `tests/ee/test_pocket_runtime_decision_events.py` (14 new) green
- [x] 99 RFC 07 + Slice 1b decision tests green
- [x] 50 cloud `test_pocket_action_executor` / `test_pocket_instinct_
  bridge` / `test_instinct_approval_security` tests green
- [x] Full `tests/ee/` suite (653 tests) green, 1 skipped
- [x] `scripts/audit_decision_chain.py` clean — 763 files scanned, no
  violations
- [x] `lint-imports` clean — 17 contracts kept, 0 broken
- [x] `ruff check` clean on every touched file
- [x] Pre-existing failures in `tests/cloud/uploads/` and
  `tests/cloud/test_rbac_routes.py` confirmed identical before/after
  this branch (23 auth-related 401s unrelated to Slice 2)

## Stacked on

- Base: `feat/rfc-09-slice-1-record-decision-event` (Slice 1b — the
  `record_decision_event` helper this slice wires every emit through)

## Out of scope (Slice 3 / Slice 4)

- `policy.evaluated(passed=False)` emit from Instinct park, and
  `human.corrected` from approve/reject — Slice 3
- `decision.completed` on `reject_action` and bulk reject loops —
  Slice 3
- The abandon-path sweeper for chains stuck >24h without a terminal —
  Slice 4
- Cursor-reconciler safety net and observability hooks — Slice 4

References: RFC 09 (paw-workspace#63), producer audit at
`pocketpaw/.claude/worktrees/rfc09-producer-audit/AUDIT-REPORT.md`.