### PR TITLE
feat(decisions): RFC 09 Slice 3 — Instinct emits + cross-workspace reject security fix

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
@@ -55,6 +55,21 @@
 #   ``execute_approved_write`` reads the correlation_id off the schema-2
 #   blob and passes it back into ``run_action(..., correlation_id=...)``
 #   so the chain folds under one id end-to-end.
+#
+# Updated: 2026-05-26 (RFC 09 Slice 3 — Instinct emits) —
+#   ``propose_pocket_write`` now emits the parked-side
+#   ``policy.evaluated(passed=False, reason="parked_for_human_approval")``
+#   chain event after ``store.propose`` succeeds, and persists the
+#   emitted event's id back onto the parked blob's
+#   ``parked_policy_event_id`` field. The instinct router's approve /
+#   reject paths read that id off the blob and use it as the
+#   ``causation_id`` on the subsequent ``human.corrected`` event so the
+#   chain has a clean cause-arrow from policy → human → close. The
+#   emit + the SQL write-back run best-effort: a Decision-Graph wiring
+#   failure must NEVER fail the propose response (the parked Action is
+#   already persisted; the worst case is a chain without a policy →
+#   human causation, which the Slice 4 reconciler / abandon-sweeper
+#   will eventually surface).
 
 from __future__ import annotations
 
@@ -220,7 +235,162 @@ async def propose_pocket_write(
         action.id,
         approver or "<owner-unset>",
     )
+
+    # RFC 09 Slice 3 — emit the parked-side ``policy.evaluated`` chain
+    # event AFTER the Action is durably stored. The semantic: parking
+    # ALWAYS means "this kind of write needs a human"; the implicit
+    # policy gate evaluated as ``passed=False`` and the chain stays open
+    # waiting for ``human.corrected``. The auto-approve ``passed=True``
+    # case lives in the action_executor's direct-path success branch
+    # (Slice 2) — Instinct never auto-approves today, so we don't emit
+    # ``passed=True`` from the router on approve (Slice 3 brief
+    # explicitly scopes that out).
+    #
+    # Best-effort: failure here must not break the propose response —
+    # the parked Action exists, the worst case is a chain without a
+    # policy→human causation_id which the Slice 4 abandon-sweeper /
+    # reconciler will eventually close.
+    raw_corr = pocket_write.get("correlation_id")
+    if isinstance(raw_corr, str) and raw_corr:
+        try:
+            correlation_id = UUID(raw_corr)
+        except ValueError:
+            logger.warning(
+                "parked pocket write %s carries malformed correlation_id %r — "
+                "policy.evaluated emit skipped; the bridge already swallows "
+                "a missing chain id",
+                action.id,
+                raw_corr,
+            )
+            correlation_id = None
+    else:
+        correlation_id = None
+
+    if correlation_id is not None:
+        event_id = _emit_parked_policy_evaluated(
+            correlation_id=correlation_id,
+            action_id=str(action.id),
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            instinct_policy=str(parked_write.get("instinct_policy") or "human_approval"),
+        )
+        if event_id is not None:
+            # Persist the emitted event's id back onto the parked blob so
+            # the eventual ``human.corrected`` event (Slice 3 — instinct
+            # router approve / reject) can chain its ``causation_id``
+            # back to this policy event. The write is best-effort: a
+            # transient SQLite lock would leave the field None and the
+            # human.corrected would emit without causation_id (the chain
+            # still folds — causation_id is optional).
+            await _persist_parked_policy_event_id(
+                store=store,
+                action_id=str(action.id),
+                event_id=str(event_id),
+            )
+
     return action.id
+
+
+def _emit_parked_policy_evaluated(
+    *,
+    correlation_id: UUID,
+    action_id: str,
+    workspace_id: str,
+    pocket_id: str,
+    instinct_policy: str,
+) -> UUID | None:
+    """Emit ``policy.evaluated(passed=False)`` for the parked write.
+
+    Returns the emitted event's id so the caller can persist it onto
+    the parked blob's ``parked_policy_event_id`` field for the
+    eventual ``human.corrected`` causation chain. Returns ``None`` if
+    the emit raised — best-effort per RFC 09 § Architecture; the Slice
+    4 reconciler picks up any orphans.
+    """
+    # Late imports — same pattern as ``_emit_bridge_chain_close``.
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_policy_evaluated
+
+    actor = Actor(
+        kind="system",
+        id="system:instinct",
+        scope_context=[f"workspace:{workspace_id}", f"pocket:{pocket_id}"],
+    )
+    payload: dict[str, Any] = {
+        "policy": instinct_policy,
+        "passed": False,
+        "reason": "parked_for_human_approval",
+        "action_id": action_id,
+        "evaluator": "instinct",
+    }
+    try:
+        entry = record_policy_evaluated(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}", f"pocket:{pocket_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "bridge policy.evaluated emit failed for correlation_id=%s "
+            "(action_id=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _persist_parked_policy_event_id(
+    *,
+    store: Any,
+    action_id: str,
+    event_id: str,
+) -> None:
+    """Write ``parked_policy_event_id`` onto the persisted Action's
+    ``parameters._pocket_write`` blob.
+
+    The Instinct store has no field-level mutator for ``parameters``
+    (it's a JSON TEXT column); ``_update_status`` flips status too, which
+    we don't want here (the action must stay ``pending``). Direct SQL
+    update — same pattern as ``router._persist_edits``. Best-effort:
+    failure leaves the field None and the eventual ``human.corrected``
+    emits without a causation_id (the chain still folds; causation_id
+    is optional on EventEntry).
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get("_pocket_write")
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["parked_policy_event_id"] = event_id
+        params["_pocket_write"] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "failed to persist parked_policy_event_id=%s onto action %s — "
+            "the chain's human.corrected will emit without causation_id",
+            event_id,
+            action_id,
+            exc_info=True,
+        )
 
 
 async def execute_approved_write(action) -> None:  # type: ignore[no-untyped-def]
@@ -307,11 +477,25 @@ async def execute_approved_write(action) -> None:  # type: ignore[no-untyped-def
 
     # The action's raw binding shape, rebuilt from the parked blob. The
     # executor reads `method` off this dict and re-validates everything.
+    #
+    # RFC 09 Slice 3 — ``requires_instinct=True`` is now stamped onto
+    # the reconstructed binding. Without it, ``action_executor.
+    # run_action``'s gate-8 success branch sees ``binding.requires_
+    # instinct=False`` and fires its auto-approve ``policy.evaluated +
+    # decision.completed`` emits — but THIS path is the Instinct
+    # re-entry, where the bridge below (``_emit_bridge_chain_close``)
+    # owns the chain close. Without the flag, every Instinct-approved
+    # write produces a doubled chain close (one from action_executor
+    # gate-8, one from the bridge). The Slice 2 tests missed this
+    # because they passed ``requires_instinct=True`` directly into
+    # ``raw_action`` rather than driving through the bridge's
+    # reconstruct step.
     raw_action = {
         "kind": "write_binding",
         "method": blob.get("method"),
         "path": blob.get("path"),
         "params": blob.get("params") or {},
+        "requires_instinct": True,
     }
 
     try:

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -52,6 +52,41 @@
 #     actor are now the AUTHENTICATED user id, not the free-text
 #     ``approver`` request field — a caller can no longer forge the
 #     audit actor. The request field stays for display only.
+#
+# Updated: 2026-05-26 (RFC 09 Slice 3 — Instinct emits + reject security fix) —
+#   * Decision-Graph chain emits — ``approve_action`` /
+#     ``bulk_approve_actions`` now emit ``human.corrected(disposition=
+#     accepted|edited)`` per item, chained off the parked
+#     ``policy.evaluated`` (the bridge populated the parked blob's
+#     ``parked_policy_event_id`` in Slice 3). ``reject_action`` /
+#     ``bulk_reject_actions`` emit ``human.corrected(disposition=
+#     rejected)`` followed by ``decision.completed(passed=False,
+#     action_outcome="rejected")`` to close the chain — the bridge is
+#     never invoked on the reject paths, so the router owns the close.
+#     The approve paths DO NOT emit ``decision.completed`` — the
+#     bridge's ``execute_approved_write`` owns the chain close after
+#     the post-approval HTTP call lands (success / re-validation
+#     rejection / executor crash all close via
+#     ``instinct_bridge._emit_bridge_chain_close``). All emits are
+#     best-effort (``record_*`` helpers swallow projection failures
+#     internally + the local try/except guards the journal-side
+#     failure path so a Decision-Graph wire never breaks an approval /
+#     rejection).
+#   * Touch-time security fix on reject endpoints —
+#     ``reject_action`` and ``bulk_reject_actions`` previously lacked
+#     ``current_user`` / ``current_workspace_id`` deps, which meant
+#     ``_assert_pocket_write_workspace`` could not run on reject paths.
+#     A workspace-A approver could therefore reject a workspace-B
+#     ``_pocket_write`` Action — a cross-tenant rejection escalation
+#     mirror of the BLOCKER 1 gap closed for approvals in PR #1183. The
+#     two deps are added and the assertion runs before any state
+#     mutation. Same partial-failure-fails-whole-batch semantics as
+#     ``bulk_approve_actions``.
+#   * ``bulk_reject_actions`` per-item emit loop — the underlying
+#     ``store.bulk_reject`` already iterates per item internally; the
+#     router now also loops over the returned ``rejected`` list to fire
+#     the per-item chain emits. No semantic change to the bulk-reject
+#     response shape (``BulkActionResponse`` with shared ``bulk_id``).
 
 from __future__ import annotations
 
@@ -117,6 +152,10 @@ def _assert_pocket_write_workspace(action: Any, current_workspace: str) -> None:
     differs from the caller's active workspace, raise ``Forbidden`` (403).
     A non-pocket-write Action (no blob) is unaffected — instinct's other
     Action kinds are not tenant-bound by this column.
+
+    Slice 3 (RFC 09) — the reject paths now invoke this check too
+    (previously only approve paths did). Same error code so the
+    frontend's existing 403 handler covers both.
     """
     blob = _pocket_write_blob(action)
     if blob is None:
@@ -126,6 +165,175 @@ def _assert_pocket_write_workspace(action: Any, current_workspace: str) -> None:
         raise Forbidden(
             "instinct.cross_workspace_approval",
             "This action's pocket write belongs to a different workspace",
+        )
+
+
+# ---------------------------------------------------------------------------
+# RFC 09 Slice 3 — Decision-Graph chain emit helpers
+# ---------------------------------------------------------------------------
+# The approve / reject endpoints emit ``human.corrected`` per item; the
+# reject endpoints additionally emit ``decision.completed(rejected)`` to
+# close the chain. The bridge owns the chain close on the approve path
+# (``instinct_bridge._emit_bridge_chain_close`` fires from
+# ``execute_approved_write`` after the post-approval HTTP call). Both
+# helpers below are best-effort — a Decision-Graph wiring failure must
+# never break an approval or rejection (the journal write is the source
+# of truth; the Slice 4 reconciler is the safety net).
+#
+# ``_chain_actor_human`` shape: ``kind="user"`` (this is the human
+# approver acting, not the agent that proposed). ``id`` is the
+# authenticated user id with a ``user:`` prefix so the projection's
+# ``_fold_corrected`` can attribute the ApproverRef to the human.
+# ``scope_context`` carries the approver's active workspace + the
+# action's pocket so visibility filters narrow correctly.
+
+
+def _chain_actor_human(*, user_id: str, workspace_id: str, pocket_id: str) -> Any:
+    """Build the Actor recorded on a ``human.corrected`` / reject-path
+    ``decision.completed`` chain event."""
+    from soul_protocol.spec.journal import Actor
+
+    return Actor(
+        kind="user",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}", f"pocket:{pocket_id}"],
+    )
+
+
+def _parked_policy_event_id(blob: dict[str, Any]) -> Any:
+    """Pull the ``parked_policy_event_id`` UUID off a schema-2 blob, or
+    ``None`` if missing / malformed. The Slice 3 bridge writes this back
+    onto the Action after ``store.propose`` succeeds; using it as the
+    ``causation_id`` on the next ``human.corrected`` event gives the
+    chain a clean policy → human cause-arrow."""
+    from uuid import UUID
+
+    raw = blob.get("parked_policy_event_id")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return UUID(raw)
+    except ValueError:
+        return None
+
+
+def _parked_correlation_id(blob: dict[str, Any]) -> Any:
+    """Pull the chain ``correlation_id`` off a schema-2 blob, or
+    ``None`` if missing / malformed. Without a correlation_id the emit
+    is skipped — there's no chain to fold into."""
+    from uuid import UUID
+
+    raw = blob.get("correlation_id")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return UUID(raw)
+    except ValueError:
+        return None
+
+
+def _emit_human_corrected(
+    *,
+    blob: dict[str, Any],
+    action: Any,
+    user_id: str,
+    workspace_id: str,
+    disposition: str,
+    note: str | None,
+) -> None:
+    """Best-effort ``human.corrected`` emit for an approve / reject /
+    bulk-approve / bulk-reject item.
+
+    ``disposition`` is one of ``accepted`` / ``edited`` / ``rejected``.
+    ``note`` is the operator-supplied reason text (reject path) or
+    correction note (edit path); ``None`` for a plain approve.
+
+    Skipped silently when the blob carries no ``correlation_id`` — a
+    blob-without-chain-id is a defensive guard (Slice 2 always populates
+    it from the executor's mint; a None means a future code path parked
+    a write without minting one). The Slice 4 reconciler / abandon
+    sweeper will deal with the orphan.
+    """
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_human_corrected
+
+    correlation_id = _parked_correlation_id(blob)
+    if correlation_id is None:
+        return
+
+    pocket_id = str(getattr(action, "pocket_id", "") or "")
+    causation = _parked_policy_event_id(blob)
+    payload: dict[str, Any] = {
+        "disposition": disposition,
+        "action_id": str(getattr(action, "id", "") or ""),
+    }
+    if note:
+        payload["note"] = note
+
+    try:
+        record_human_corrected(
+            correlation_id=correlation_id,
+            actor=_chain_actor_human(
+                user_id=user_id, workspace_id=workspace_id, pocket_id=pocket_id
+            ),
+            scope=[f"workspace:{workspace_id}", f"pocket:{pocket_id}"],
+            payload=payload,
+            causation_id=causation,
+        )
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "instinct human.corrected emit failed for correlation_id=%s "
+            "(disposition=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            disposition,
+            exc_info=True,
+        )
+
+
+def _emit_decision_completed_rejected(
+    *,
+    blob: dict[str, Any],
+    action: Any,
+    user_id: str,
+    workspace_id: str,
+    reason: str,
+) -> None:
+    """Best-effort ``decision.completed(passed=False, action_outcome=
+    "rejected")`` chain-close for a reject / bulk-reject item.
+
+    Same skip-on-missing-correlation-id semantics as
+    ``_emit_human_corrected``. The reject path owns the close because
+    the bridge is never invoked on rejection — for the approve path the
+    bridge's ``_emit_bridge_chain_close`` owns the close instead.
+    """
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    correlation_id = _parked_correlation_id(blob)
+    if correlation_id is None:
+        return
+
+    pocket_id = str(getattr(action, "pocket_id", "") or "")
+    payload: dict[str, Any] = {
+        "passed": False,
+        "action_outcome": "rejected",
+    }
+    if reason:
+        payload["reason"] = reason
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=_chain_actor_human(
+                user_id=user_id, workspace_id=workspace_id, pocket_id=pocket_id
+            ),
+            scope=[f"workspace:{workspace_id}", f"pocket:{pocket_id}"],
+            payload=payload,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "instinct decision.completed(rejected) emit failed for "
+            "correlation_id=%s — Slice 4 reconciler will catch up",
+            correlation_id,
+            exc_info=True,
         )
 
 
@@ -402,17 +610,33 @@ async def bulk_approve_actions(
     # instinct package free of a module-top dependency on ee.cloud.pockets,
     # and any failure is recorded on the Action by the bridge — it must
     # never break the bulk response.
+    #
+    # RFC 09 Slice 3 — per-item ``human.corrected`` emit slots into the
+    # same loop. Disposition is always ``accepted`` for bulk-approve —
+    # the endpoint doesn't support edits (the UI doesn't expose them on
+    # the bulk bar). The bridge owns the chain close on the approve
+    # path so we do NOT emit ``decision.completed`` here.
     for action in approved:
-        if _pocket_write_blob(action) is not None:
-            try:
-                from pocketpaw_ee.cloud.pockets import instinct_bridge
+        action_blob = _pocket_write_blob(action)
+        if action_blob is None:
+            continue
+        _emit_human_corrected(
+            blob=action_blob,
+            action=action,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition="accepted",
+            note=req.note,
+        )
+        try:
+            from pocketpaw_ee.cloud.pockets import instinct_bridge
 
-                await instinct_bridge.execute_approved_write(action)
-            except Exception:
-                logger.exception(
-                    "bulk-approve pocket-write execution failed for %s (non-fatal)",
-                    action.id,
-                )
+            await instinct_bridge.execute_approved_write(action)
+        except Exception:
+            logger.exception(
+                "bulk-approve pocket-write execution failed for %s (non-fatal)",
+                action.id,
+            )
 
     return BulkActionResponse(bulk_id=bulk_id, affected=approved, missing=missing)
 
@@ -422,7 +646,11 @@ async def bulk_approve_actions(
     response_model=BulkActionResponse,
     dependencies=[Depends(require_action_any_workspace("instinct.approve"))],
 )
-async def bulk_reject_actions(req: BulkRejectRequest) -> BulkActionResponse:
+async def bulk_reject_actions(
+    req: BulkRejectRequest,
+    user: Any = Depends(current_user),
+    workspace_id: str = Depends(current_workspace_id),
+) -> BulkActionResponse:
     """Reject N pending actions in one call. ``reason`` is required.
 
     Mirrors ``bulk_approve_actions``: shared ``bulk_id``, per-item audit
@@ -430,10 +658,57 @@ async def bulk_reject_actions(req: BulkRejectRequest) -> BulkActionResponse:
     on every audit row's ``context.reason`` and on each Action's
     ``rejected_reason`` so the soul-bridge correction pipeline still
     sees the same shape it sees on single-item rejects.
+
+    Slice 3 (RFC 09) — endpoint signature grew ``current_user`` and
+    ``current_workspace_id`` deps for the same two reasons as
+    ``reject_action``: (a) the touch-time cross-workspace security fix,
+    and (b) per-item ``human.corrected`` + ``decision.completed
+    (rejected)`` chain emits. Cross-workspace check fails the whole
+    batch with 403 — a partial bulk that silently dropped a foreign
+    item would hide a cross-tenant rejection-escalation attempt
+    (mirror of bulk-approve's BLOCKER 1 behaviour).
     """
-    rejected, missing, bulk_id = await _store().bulk_reject(
-        list(req.ids), reason=req.reason, rejector=req.rejector
+    store = _store()
+    rejector_id = str(user.id)
+
+    # Touch-time security fix — verify tenancy on every requested
+    # action up front, same shape as ``bulk_approve_actions``. A
+    # missing id has no blob to check; it falls through to
+    # ``bulk_reject`` and lands in ``missing``.
+    for action_id in req.ids:
+        action = await store.get_action(action_id)
+        if action is not None:
+            _assert_pocket_write_workspace(action, workspace_id)
+
+    rejected, missing, bulk_id = await store.bulk_reject(
+        list(req.ids), reason=req.reason, rejector=rejector_id
     )
+
+    # RFC 09 Slice 3 — per-item ``human.corrected`` + ``decision.
+    # completed(rejected)`` emit loop. The store's bulk_reject already
+    # iterates per item internally for the audit log; this loop adds
+    # the chain emits. Non-pocket-write Actions (no blob) skip both
+    # emits — there's no chain to close.
+    for action in rejected:
+        action_blob = _pocket_write_blob(action)
+        if action_blob is None:
+            continue
+        _emit_human_corrected(
+            blob=action_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=req.reason or None,
+        )
+        _emit_decision_completed_rejected(
+            blob=action_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=req.reason,
+        )
+
     return BulkActionResponse(bulk_id=bulk_id, affected=rejected, missing=missing)
 
 
@@ -498,13 +773,35 @@ async def approve_action(
     if not approved:
         raise HTTPException(404, "Action not found")
 
+    # RFC 09 Slice 3 — emit the ``human.corrected`` chain event BEFORE
+    # the bridge fires. Disposition is ``edited`` when the approver
+    # adjusted fields (``edited_fields`` is non-empty), ``accepted``
+    # otherwise. The bridge owns the chain close on the approve path
+    # (``_emit_bridge_chain_close`` from ``execute_approved_write``),
+    # so we do NOT emit ``decision.completed`` here — emitting it would
+    # double-fire the chain terminal.
+    approved_blob = _pocket_write_blob(approved)
+    if approved_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        # ``note`` is the correction's free-text summary when the
+        # approver edited; None on a plain approve.
+        note = correction.context_summary if correction is not None else None
+        _emit_human_corrected(
+            blob=approved_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+        )
+
     # RFC 05 M2b.1 — when the approved Action carries a parked pocket
     # write (``parameters._pocket_write``), fire it. Best-effort: a
     # lazy import keeps the instinct package free of a module-top
     # dependency on ee.cloud.pockets, and any failure is recorded on the
     # Action by the bridge itself — it must NEVER break this approve
     # response. A non-pocket-write Action (the common case) skips this.
-    if _pocket_write_blob(approved) is not None:
+    if approved_blob is not None:
         try:
             from pocketpaw_ee.cloud.pockets import instinct_bridge
 
@@ -535,12 +832,71 @@ async def _forward_to_soul(correction: Correction, action: Action) -> None:
     response_model=Action,
     dependencies=[Depends(require_action_any_workspace("instinct.approve"))],
 )
-async def reject_action(action_id: str, req: RejectRequest | None = None):
-    """Reject a pending action with an optional reason."""
+async def reject_action(
+    action_id: str,
+    req: RejectRequest | None = None,
+    user: Any = Depends(current_user),
+    workspace_id: str = Depends(current_workspace_id),
+):
+    """Reject a pending action with an optional reason.
+
+    Slice 3 (RFC 09) — endpoint signature grew ``current_user`` and
+    ``current_workspace_id`` deps for two reasons:
+
+      1. **Touch-time security fix** — ``require_action_any_workspace``
+         only proves the caller holds ``instinct.approve`` SOMEWHERE; it
+         does not bind the rejected Action to the caller's workspace.
+         Without the workspace dep, ``_assert_pocket_write_workspace``
+         could not run on the reject path — a workspace-A approver
+         could reject a workspace-B parked write, the mirror of the
+         BLOCKER 1 approval-escalation gap closed for approvals in PR
+         #1183. Now the same 403 + ``instinct.cross_workspace_approval``
+         error code fires on cross-tenant rejections.
+      2. **Decision-Graph chain emits** — the rejection emits
+         ``human.corrected(disposition=rejected)`` then closes the
+         chain with ``decision.completed(passed=False, action_outcome=
+         "rejected")``. The actor on both events is the authenticated
+         user id (same forge-resistance as ``approve_action``'s
+         SHOULD-FIX 1); the workspace + action's pocket form the
+         scope. The bridge is NOT invoked on reject so the router owns
+         the chain close.
+    """
+    store = _store()
+    before = await store.get_action(action_id)
+    if not before:
+        raise HTTPException(404, "Action not found")
+
+    # Touch-time security fix — same gate the approve path runs.
+    _assert_pocket_write_workspace(before, workspace_id)
+
     reason = req.reason if req else ""
-    action = await _store().reject(action_id, reason=reason)
+    rejector_id = str(user.id)
+    action = await store.reject(action_id, reason=reason, rejector=rejector_id)
     if not action:
         raise HTTPException(404, "Action not found")
+
+    # RFC 09 Slice 3 — emit ``human.corrected`` then ``decision.completed``
+    # to close the chain. Order matters for the narrator: the human
+    # action lands before the chain terminal, mirroring the approve
+    # path's "human.corrected → execute → decision.completed" ordering.
+    rejected_blob = _pocket_write_blob(action)
+    if rejected_blob is not None:
+        _emit_human_corrected(
+            blob=rejected_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+        )
+        _emit_decision_completed_rejected(
+            blob=rejected_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+        )
+
     return action
 
 

--- a/tests/cloud/test_instinct_approval_security.py
+++ b/tests/cloud/test_instinct_approval_security.py
@@ -16,6 +16,18 @@
 # POST /instinct/actions, read back via GET /instinct/actions) so the
 # TestClient owns the only event loop. SHOULD-FIX 3 is a plain async
 # service test. `pocketpaw_ee` is import-skipped on an OSS-only install.
+#
+# Updated: 2026-05-26 (RFC 09 Slice 3 — Instinct emits + reject security fix) —
+#   Added ``TestRejectCrossWorkspaceSecurity`` covering the
+#   touch-time fix that closed the BLOCKER-1-mirror gap on
+#   ``reject_action`` / ``bulk_reject_actions``. Until Slice 3 the
+#   reject endpoints lacked ``current_user`` / ``current_workspace_id``
+#   deps, which meant ``_assert_pocket_write_workspace`` could not run
+#   on rejection — a workspace-A approver could reject a workspace-B
+#   parked write. The new tests pin: (a) single + bulk reject return
+#   403 with the same ``instinct.cross_workspace_approval`` code, and
+#   (b) same-workspace reject still succeeds + the rejected Action
+#   transitions to ``rejected``.
 
 from __future__ import annotations
 
@@ -216,6 +228,121 @@ class TestBlocker1CrossTenantApproval:
             # The whole batch is rejected — nothing flipped.
             assert _status_of(client, own) == "pending"
             assert _status_of(client, foreign) == "pending"
+
+
+# ---------------------------------------------------------------------------
+# RFC 09 Slice 3 — cross-workspace REJECT escalation (BLOCKER 1 mirror)
+# ---------------------------------------------------------------------------
+
+
+class TestRejectCrossWorkspaceSecurity:
+    """Slice 3 closes the cross-workspace rejection-escalation gap that
+    mirrored BLOCKER 1 on the approve side. Until this slice, the
+    reject endpoints lacked ``current_user`` / ``current_workspace_id``
+    deps so ``_assert_pocket_write_workspace`` could not run on
+    rejection paths — a workspace-A approver could reject a
+    workspace-B parked write. Adding the deps + the assertion closes
+    the gap with the same 403 + ``instinct.cross_workspace_approval``
+    error code the approve path uses."""
+
+    def test_single_reject_of_foreign_workspace_pocket_write_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A ws-A approver POSTing /reject on an action whose parked
+        write belongs to ws-B is forbidden — the action stays pending."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-B",
+                title="ws-B write",
+                parameters=_pocket_write_params(workspace_id="ws-B"),
+            )
+            resp = client.post(
+                f"/instinct/actions/{action_id}/reject",
+                json={"reason": "nope"},
+            )
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, action_id) == "pending"
+
+    def test_single_reject_of_own_workspace_pocket_write_succeeds(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A ws-A approver may reject a ws-A parked write — the
+        workspace check does not block a same-tenant rejection."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A write",
+                parameters=_pocket_write_params(workspace_id="ws-A"),
+            )
+            resp = client.post(
+                f"/instinct/actions/{action_id}/reject",
+                json={"reason": "ok"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["status"] == "rejected"
+
+    def test_bulk_reject_of_foreign_workspace_pocket_write_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """Bulk-reject mirrors bulk-approve's BLOCKER 1: a list with
+        even one foreign-workspace item fails the whole batch with
+        403 and nothing flips. A partial bulk that silently dropped
+        the foreign item would hide the escalation attempt."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            own = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A write",
+                parameters=_pocket_write_params(workspace_id="ws-A"),
+            )
+            foreign = _propose(
+                client,
+                pocket_id="pocket-B",
+                title="ws-B write",
+                parameters=_pocket_write_params(workspace_id="ws-B"),
+            )
+            resp = client.post(
+                "/instinct/actions/bulk-reject",
+                json={"ids": [own, foreign], "reason": "batch nope"},
+            )
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, own) == "pending"
+            assert _status_of(client, foreign) == "pending"
+
+    def test_bulk_reject_of_own_workspace_pocket_writes_succeeds(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """Bulk-reject of N same-tenant items flips all of them and
+        returns the bulk_id + affected list."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            a = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A first",
+                parameters=_pocket_write_params(workspace_id="ws-A"),
+            )
+            b = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A second",
+                parameters=_pocket_write_params(workspace_id="ws-A"),
+            )
+            resp = client.post(
+                "/instinct/actions/bulk-reject",
+                json={"ids": [a, b], "reason": "ship it"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert len(resp.json()["affected"]) == 2
+            assert _status_of(client, a) == "rejected"
+            assert _status_of(client, b) == "rejected"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ee/test_instinct_decision_events.py
+++ b/tests/ee/test_instinct_decision_events.py
@@ -1,0 +1,914 @@
+# tests/ee/test_instinct_decision_events.py
+# Created: 2026-05-26 (RFC 09 Slice 3 — feat/rfc-09-slice-3-instinct-emits)
+#
+# Pins the chain-forming event emits Instinct adds in Slice 3 plus the
+# touch-time cross-workspace reject security fix on
+# ``reject_action`` / ``bulk_reject_actions``. Covers:
+#
+#   1. ``policy.evaluated(passed=False, reason="parked_for_human_approval")``
+#      fires from ``instinct_bridge.propose_pocket_write`` after
+#      ``store.propose`` succeeds; the persisted blob's
+#      ``parked_policy_event_id`` field is populated with the emitted
+#      event id so the eventual ``human.corrected`` can chain its
+#      ``causation_id`` back to the policy event.
+#   2. ``approve_action`` emits ``human.corrected(disposition=accepted)``
+#      with the right actor + causation; the bridge owns the chain
+#      close so no second ``decision.completed`` fires from the router.
+#   3. ``reject_action`` emits ``human.corrected(disposition=rejected)``
+#      + ``decision.completed(passed=False, action_outcome="rejected")``.
+#   4. ``bulk_approve_actions`` fires per-item ``human.corrected``
+#      emits matching the loop the bridge runs.
+#   5. ``bulk_reject_actions`` fires per-item ``human.corrected`` +
+#      ``decision.completed(rejected)`` emits AND closes the cross-
+#      workspace reject security gap (mirror of bulk-approve BLOCKER 1).
+#   6. Causation chain wired end-to-end —
+#      ``policy.evaluated.id == human.corrected.causation_id`` for an
+#      approve flow rooted at ``agent.proposed``.
+#   7. ``reject_action`` cross-workspace 403 — Forbidden + no chain
+#      events emitted.
+#   8. ``reject_action`` same-workspace happy path under tenant
+#      isolation.
+#   9. End-to-end happy path via ``DecisionGraph.find`` —
+#      parked → approved chain folds into a Decision row with
+#      approvers populated, ``instinct_policy_passed=False`` (last-seen
+#      policy event; the approve path does NOT emit a follow-up
+#      ``policy.evaluated(passed=True)`` per the Slice 3 brief), and
+#      ``outcome`` either None or non-rejected.
+#
+# Fixture strategy mirrors ``test_pocket_runtime_decision_events.py``
+# (journal + DecisionGraph wired into the lazy global lookup, fresh
+# tmp_path per test) AND ``test_instinct_approval_security.py``
+# (router-level TestClient with stubbed auth deps + a
+# ``CloudError``-aware app so a ``Forbidden`` maps to 403). The two
+# pieces compose: the router writes via the journal+projection set up
+# in the autouse fixture; the assertions read events out of the
+# journal and Decisions out of the graph store.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.decisions.service import (  # noqa: E402
+    DecisionGraph,
+    get_decision_graph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import set_db_path  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.cloud.pockets import instinct_bridge as instinct_bridge_module  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+from soul_protocol.engine.journal import open_journal  # noqa: E402
+
+import pocketpaw.journal_dep as journal_dep  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+TRIGGER = {"type": "agent", "source": "claude", "reason": "slice 3 test"}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — journal + projection wiring (same shape as Slice 2 tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    """Fresh on-disk journal wired into the lazy
+    ``pocketpaw.journal_dep.get_journal`` lookup. The
+    ``journal_writer.record_decision_event`` helper resolves the journal
+    through that dep so the same singleton drives both production code
+    and tests."""
+    j = open_journal(tmp_path / "journal.db")
+    journal_dep.reset_journal_cache()
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path) -> DecisionGraph:
+    """Fresh DecisionGraph + decisions.db plumbed in as the process-
+    global singleton. ``reset_projection_for_tests`` clears the prior
+    singleton so this test's set_db_path takes effect."""
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+@pytest.fixture
+def router_store(tmp_path: Path) -> InstinctStore:
+    """Fresh Instinct SQLite store per test. The router lazy-imports
+    ``_store`` through ``get_instinct_store``; tests patch the indirection
+    so propose and approve / reject share state."""
+    return InstinctStore(tmp_path / "instinct.db")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — router-level TestClient with seeded auth + CloudError handler
+# ---------------------------------------------------------------------------
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    """Duck-typed user. ``id`` is the authenticated identity; the audit
+    actor + chain-event actor resolve to THIS, not request-body fields."""
+
+    def __init__(self, user_id: str = "user-A", workspace_id: str = "ws-A") -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+def _make_client(
+    router_store: InstinctStore,
+    user: _FakeUser,
+    monkeypatch,
+) -> TestClient:
+    """Build a TestClient over the Instinct router with auth deps
+    stubbed and a ``CloudError`` handler registered so a ``Forbidden``
+    maps to 403 (not a 500). Same pattern as the security test file."""
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app)
+
+
+def _pocket_write_params(
+    *,
+    workspace_id: str,
+    correlation_id: UUID | None = None,
+    parked_policy_event_id: str | None = None,
+    outcome: str | None = "renewal_completed",
+) -> dict[str, Any]:
+    """Build a schema-2 parked pocket-write blob.
+
+    Tests that need a stable ``correlation_id`` to query the journal /
+    graph by chain id pass one; ``None`` lets the bridge / propose path
+    leave it None (those tests usually drive ``propose_pocket_write``
+    directly and supply the id via the ``_park`` shape instead).
+    """
+    return {
+        "_pocket_write": {
+            "schema": 2,
+            "action": "mark_renewed",
+            "method": "POST",
+            "path": "/leases/42/renew",
+            "params": {"rent": 2000},
+            "idempotency_key": "idem-xyz",
+            "outcome": outcome,
+            "workspace_id": workspace_id,
+            "requested_by": "requester-9",
+            "correlation_id": str(correlation_id) if correlation_id else None,
+            "parked_policy_event_id": parked_policy_event_id,
+        }
+    }
+
+
+def _propose(
+    client: TestClient,
+    *,
+    pocket_id: str,
+    title: str,
+    parameters: dict[str, Any] | None = None,
+) -> str:
+    """Seed a pending Action over HTTP and return its id."""
+    payload: dict[str, Any] = {"pocket_id": pocket_id, "title": title, "trigger": TRIGGER}
+    if parameters is not None:
+        payload["parameters"] = parameters
+    resp = client.post("/instinct/actions", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _events(journal, action: str) -> list:
+    return [e for e in journal.replay_from(0) if e.action == action]
+
+
+def _events_by_correlation(journal, correlation_id: UUID) -> list:
+    return [e for e in journal.replay_from(0) if e.correlation_id == correlation_id]
+
+
+def _seed_pocket(workspace_id: str = "ws-A", pocket_id: str = "pocket-A") -> dict[str, Any]:
+    return {
+        "_id": pocket_id,
+        "workspace": workspace_id,
+        "owner": "user-A",
+        "name": f"Pocket {pocket_id}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. propose_pocket_write — policy.evaluated emit + parked_policy_event_id wire
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_emits_policy_evaluated_and_persists_event_id(
+    monkeypatch, journal, graph: DecisionGraph, router_store: InstinctStore
+):
+    """RFC 09 Slice 3 Producer 2 (a) — after ``store.propose`` succeeds,
+    the bridge emits ``policy.evaluated(passed=False, reason=
+    "parked_for_human_approval")`` and writes the emitted event id back
+    onto the parked blob's ``parked_policy_event_id`` field so the
+    eventual ``human.corrected`` can chain its ``causation_id`` back."""
+    corr = uuid4()
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+
+    park_blob = {
+        "action": "mark_renewed",
+        "method": "POST",
+        "path": "/leases/42/renew",
+        "params": {"rent": 2000},
+        "idempotency_key": "idem-xyz",
+        "outcome": "renewal_completed",
+        "correlation_id": str(corr),
+    }
+    action_id = await instinct_bridge_module.propose_pocket_write(
+        pocket=_seed_pocket("w1", "p1"),
+        backend_config=None,
+        parked_write=park_blob,
+        requested_by="u_alice",
+    )
+
+    # Exactly one policy.evaluated event landed under this correlation
+    # with the right payload shape.
+    policy_events = _events(journal, "policy.evaluated")
+    assert len(policy_events) == 1
+    pe = policy_events[0]
+    assert pe.correlation_id == corr
+    payload = pe.payload or {}
+    assert payload["passed"] is False
+    assert payload["reason"] == "parked_for_human_approval"
+    assert payload["action_id"] == action_id
+    # System-side emit — actor is the Instinct subsystem, not the agent.
+    assert pe.actor.kind == "system"
+    assert "workspace:w1" in pe.scope
+    assert "pocket:p1" in pe.scope
+
+    # The parked blob persisted back to the Instinct store carries the
+    # event id under parked_policy_event_id (Slice 3 wire).
+    stored = await router_store.get_action(action_id)
+    assert stored is not None
+    blob = stored.parameters.get("_pocket_write")
+    assert isinstance(blob, dict)
+    assert blob["parked_policy_event_id"] == str(pe.id)
+    # The correlation_id round-trips intact.
+    assert blob["correlation_id"] == str(corr)
+
+
+async def test_propose_without_correlation_id_skips_policy_emit(
+    monkeypatch, journal, graph: DecisionGraph, router_store: InstinctStore
+):
+    """A parked blob with no correlation_id (a future code path that
+    parks without minting one) skips the policy.evaluated emit — the
+    Slice 4 abandon sweeper will eventually close the chain. The
+    propose call still succeeds."""
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+
+    park_blob = {
+        "action": "mark_renewed",
+        "method": "POST",
+        "path": "/leases/42/renew",
+        "params": {},
+        "idempotency_key": None,
+        "outcome": None,
+        # Slice 2 always populates this; defensive coverage for the
+        # missing-id case.
+        "correlation_id": None,
+    }
+    action_id = await instinct_bridge_module.propose_pocket_write(
+        pocket=_seed_pocket("w1", "p1"),
+        backend_config=None,
+        parked_write=park_blob,
+        requested_by="u_alice",
+    )
+
+    # No policy.evaluated landed; the Action is still durably stored.
+    assert _events(journal, "policy.evaluated") == []
+    stored = await router_store.get_action(action_id)
+    assert stored is not None
+    blob = stored.parameters.get("_pocket_write")
+    assert isinstance(blob, dict)
+    assert blob["parked_policy_event_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# 2. approve_action — human.corrected emit, no double decision.completed
+# ---------------------------------------------------------------------------
+
+
+async def test_approve_emits_human_corrected_and_does_not_double_emit_completed(
+    monkeypatch, journal, graph: DecisionGraph, router_store: InstinctStore
+):
+    """The approve path emits exactly one ``human.corrected``. The bridge
+    owns the chain close (its ``execute_approved_write`` emits
+    ``decision.completed`` from ``_emit_bridge_chain_close``) — the
+    router MUST NOT emit a second ``decision.completed`` itself. We
+    stub the bridge so the captain's note about which emit owns the
+    close is what's exercised."""
+    user = _FakeUser("user-A", "ws-A")
+    client = _make_client(router_store, user, monkeypatch)
+
+    # Stub out the bridge execution — we only care about what the
+    # router itself emits on this test. A `_noop_execute` covers the
+    # post-approval re-entry without firing the bridge's own emit.
+    async def _noop_execute(_action):
+        return None
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.instinct_bridge.execute_approved_write",
+        _noop_execute,
+    )
+
+    corr = uuid4()
+    parked_policy_event_id = str(uuid4())
+    with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+        action_id = _propose(
+            client,
+            pocket_id="pocket-A",
+            title="ws-A approve",
+            parameters=_pocket_write_params(
+                workspace_id="ws-A",
+                correlation_id=corr,
+                parked_policy_event_id=parked_policy_event_id,
+            ),
+        )
+        resp = client.post(f"/instinct/actions/{action_id}/approve")
+        assert resp.status_code == 200, resp.text
+
+    # Exactly one human.corrected event landed on the approve, with
+    # disposition=accepted (no edits) and the user as actor.
+    hc = _events(journal, "human.corrected")
+    assert len(hc) == 1
+    assert hc[0].correlation_id == corr
+    payload = hc[0].payload or {}
+    assert payload["disposition"] == "accepted"
+    assert payload["action_id"] == action_id
+    assert hc[0].actor.kind == "user"
+    assert hc[0].actor.id == "user:user-A"
+    # causation_id chains back to the parked policy event id.
+    assert hc[0].causation_id == UUID(parked_policy_event_id)
+
+    # The router does NOT emit decision.completed (bridge would).
+    assert _events(journal, "decision.completed") == []
+
+
+async def test_approve_with_edits_emits_human_corrected_disposition_edited(
+    monkeypatch, journal, graph: DecisionGraph, router_store: InstinctStore
+):
+    """When the approver edits the proposal before approving, the
+    chain event records ``disposition=edited`` and the correction's
+    context summary lands on the ``note`` field."""
+    user = _FakeUser("user-A", "ws-A")
+    client = _make_client(router_store, user, monkeypatch)
+
+    async def _noop_execute(_action):
+        return None
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.instinct_bridge.execute_approved_write",
+        _noop_execute,
+    )
+
+    corr = uuid4()
+    with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+        action_id = _propose(
+            client,
+            pocket_id="pocket-A",
+            title="ws-A edit-approve",
+            parameters=_pocket_write_params(workspace_id="ws-A", correlation_id=corr),
+        )
+        # Edit the title on approve; the router computes a Correction.
+        resp = client.post(
+            f"/instinct/actions/{action_id}/approve",
+            json={"title": "ws-A edit-approve (revised)"},
+        )
+        assert resp.status_code == 200, resp.text
+
+    hc = _events(journal, "human.corrected")
+    assert len(hc) == 1
+    payload = hc[0].payload or {}
+    assert payload["disposition"] == "edited"
+    assert "note" in payload  # the context_summary lands here
+
+
+# ---------------------------------------------------------------------------
+# 3. reject_action — human.corrected + decision.completed(rejected)
+# ---------------------------------------------------------------------------
+
+
+async def test_reject_emits_human_corrected_then_decision_completed_rejected(
+    monkeypatch, journal, graph: DecisionGraph, router_store: InstinctStore
+):
+    """The reject path emits both the human action and the chain
+    terminal — the bridge is never invoked on reject so the router
+    owns the close. Order matters for the narrator: the
+    ``human.corrected`` event lands before the
+    ``decision.completed`` event."""
+    user = _FakeUser("user-A", "ws-A")
+    client = _make_client(router_store, user, monkeypatch)
+    corr = uuid4()
+    parked_policy_event_id = str(uuid4())
+
+    with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+        action_id = _propose(
+            client,
+            pocket_id="pocket-A",
+            title="ws-A reject",
+            parameters=_pocket_write_params(
+                workspace_id="ws-A",
+                correlation_id=corr,
+                parked_policy_event_id=parked_policy_event_id,
+            ),
+        )
+        resp = client.post(
+            f"/instinct/actions/{action_id}/reject",
+            json={"reason": "too risky"},
+        )
+        assert resp.status_code == 200, resp.text
+
+    # Both events landed under this correlation, in order.
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == ["human.corrected", "decision.completed"], actions
+
+    hc = chain[0]
+    assert (hc.payload or {})["disposition"] == "rejected"
+    assert (hc.payload or {}).get("note") == "too risky"
+    assert hc.causation_id == UUID(parked_policy_event_id)
+    assert hc.actor.kind == "user"
+    assert hc.actor.id == "user:user-A"
+
+    dc = chain[1]
+    assert (dc.payload or {})["passed"] is False
+    assert (dc.payload or {})["action_outcome"] == "rejected"
+    assert (dc.payload or {})["reason"] == "too risky"
+
+
+# ---------------------------------------------------------------------------
+# 4. bulk_approve_actions — per-item human.corrected
+# ---------------------------------------------------------------------------
+
+
+async def test_bulk_approve_emits_human_corrected_per_item(
+    monkeypatch, journal, graph: DecisionGraph, router_store: InstinctStore
+):
+    """The bulk-approve endpoint loops over the approved Actions and
+    emits ``human.corrected(disposition=accepted)`` per item with the
+    right correlation_id per item. The bridge is stubbed so this test
+    isolates the router-side emit count."""
+    user = _FakeUser("user-A", "ws-A")
+    client = _make_client(router_store, user, monkeypatch)
+
+    async def _noop_execute(_action):
+        return None
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.instinct_bridge.execute_approved_write",
+        _noop_execute,
+    )
+
+    corrs = [uuid4(), uuid4(), uuid4()]
+    parked_policy_event_ids = [str(uuid4()) for _ in corrs]
+    with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+        action_ids = []
+        for idx, corr in enumerate(corrs):
+            aid = _propose(
+                client,
+                pocket_id="pocket-A",
+                title=f"bulk approve #{idx}",
+                parameters=_pocket_write_params(
+                    workspace_id="ws-A",
+                    correlation_id=corr,
+                    parked_policy_event_id=parked_policy_event_ids[idx],
+                ),
+            )
+            action_ids.append(aid)
+
+        resp = client.post(
+            "/instinct/actions/bulk-approve",
+            json={"ids": action_ids, "note": "ship it"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert len(resp.json()["affected"]) == 3
+
+    # Exactly 3 human.corrected events, one per item, each with the
+    # matching correlation_id and causation_id.
+    hc = _events(journal, "human.corrected")
+    assert len(hc) == 3
+
+    by_corr = {e.correlation_id: e for e in hc}
+    for idx, corr in enumerate(corrs):
+        assert corr in by_corr, f"missing human.corrected for {corr}"
+        ev = by_corr[corr]
+        payload = ev.payload or {}
+        assert payload["disposition"] == "accepted"
+        assert payload.get("note") == "ship it"
+        assert ev.causation_id == UUID(parked_policy_event_ids[idx])
+
+    # Bridge owns the close — no decision.completed from the router.
+    assert _events(journal, "decision.completed") == []
+
+
+# ---------------------------------------------------------------------------
+# 5. bulk_reject_actions — per-item human.corrected + decision.completed
+# ---------------------------------------------------------------------------
+
+
+async def test_bulk_reject_emits_human_corrected_and_completed_per_item(
+    monkeypatch, journal, graph: DecisionGraph, router_store: InstinctStore
+):
+    """The bulk-reject endpoint adds a per-item emit loop in Slice 3
+    (the underlying ``store.bulk_reject`` already iterated per item
+    for audit; the router now also iterates for chain emits). Three
+    rejected items produce three human.corrected + three
+    decision.completed(rejected) events."""
+    user = _FakeUser("user-A", "ws-A")
+    client = _make_client(router_store, user, monkeypatch)
+
+    corrs = [uuid4(), uuid4(), uuid4()]
+    parked_policy_event_ids = [str(uuid4()) for _ in corrs]
+    with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+        action_ids = []
+        for idx, corr in enumerate(corrs):
+            aid = _propose(
+                client,
+                pocket_id="pocket-A",
+                title=f"bulk reject #{idx}",
+                parameters=_pocket_write_params(
+                    workspace_id="ws-A",
+                    correlation_id=corr,
+                    parked_policy_event_id=parked_policy_event_ids[idx],
+                ),
+            )
+            action_ids.append(aid)
+
+        resp = client.post(
+            "/instinct/actions/bulk-reject",
+            json={"ids": action_ids, "reason": "scope drift"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert len(resp.json()["affected"]) == 3
+
+    hc = _events(journal, "human.corrected")
+    dc = _events(journal, "decision.completed")
+    assert len(hc) == 3
+    assert len(dc) == 3
+    for ev in hc:
+        payload = ev.payload or {}
+        assert payload["disposition"] == "rejected"
+        assert payload.get("note") == "scope drift"
+    for ev in dc:
+        payload = ev.payload or {}
+        assert payload["passed"] is False
+        assert payload["action_outcome"] == "rejected"
+        assert payload["reason"] == "scope drift"
+
+
+# ---------------------------------------------------------------------------
+# 6. End-to-end causation chain — propose → approve threads cause-arrows
+# ---------------------------------------------------------------------------
+
+
+async def test_full_chain_causation_wires_policy_to_human(
+    monkeypatch, journal, graph: DecisionGraph, router_store: InstinctStore
+):
+    """Exercise propose → approve and assert: the
+    ``policy.evaluated`` event id is the ``human.corrected.causation_id``.
+    The bridge is stubbed so the chain only contains the router-side +
+    propose-side emits this test cares about."""
+    user = _FakeUser("user-A", "ws-A")
+    client = _make_client(router_store, user, monkeypatch)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+
+    async def _noop_execute(_action):
+        return None
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.instinct_bridge.execute_approved_write",
+        _noop_execute,
+    )
+
+    corr = uuid4()
+    # Drive propose through the bridge (not the router) so the
+    # policy.evaluated emit fires and parked_policy_event_id is wired
+    # onto the persisted blob — exactly the production code path the
+    # chat agent's instinct-pending flow takes.
+    park_blob = {
+        "action": "mark_renewed",
+        "method": "POST",
+        "path": "/leases/42/renew",
+        "params": {"rent": 2000},
+        "idempotency_key": "idem-xyz",
+        "outcome": "renewal_completed",
+        "correlation_id": str(corr),
+    }
+    action_id = await instinct_bridge_module.propose_pocket_write(
+        pocket=_seed_pocket("ws-A", "pocket-A"),
+        backend_config=None,
+        parked_write=park_blob,
+        requested_by="user-A",
+    )
+
+    with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+        resp = client.post(f"/instinct/actions/{action_id}/approve")
+        assert resp.status_code == 200, resp.text
+
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == ["policy.evaluated", "human.corrected"], actions
+
+    policy_event = chain[0]
+    human_event = chain[1]
+    assert human_event.causation_id == policy_event.id
+
+
+# ---------------------------------------------------------------------------
+# 7. Security — cross-workspace reject is 403 with NO events emitted
+# ---------------------------------------------------------------------------
+
+
+class TestRejectCrossWorkspaceSecurity:
+    def test_single_reject_of_foreign_workspace_pocket_write_is_403(
+        self, journal, graph: DecisionGraph, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A ws-A approver POSTing /reject on an action whose parked
+        write belongs to ws-B is forbidden — the action stays pending
+        and no chain events fire (the security check runs BEFORE the
+        emits, mirror of bulk-approve's BLOCKER 1)."""
+        user = _FakeUser("user-A", "ws-A")
+        client = _make_client(router_store, user, monkeypatch)
+
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-B",
+                title="ws-B write",
+                parameters=_pocket_write_params(workspace_id="ws-B", correlation_id=uuid4()),
+            )
+            resp = client.post(
+                f"/instinct/actions/{action_id}/reject",
+                json={"reason": "nope"},
+            )
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+
+        # No chain events fired — the security check fails BEFORE any
+        # emit attempt.
+        assert _events(journal, "human.corrected") == []
+        assert _events(journal, "decision.completed") == []
+
+    def test_single_reject_of_own_workspace_pocket_write_succeeds(
+        self, journal, graph: DecisionGraph, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """The same-tenant happy path — a ws-A approver may reject a
+        ws-A parked write; both chain events land."""
+        user = _FakeUser("user-A", "ws-A")
+        client = _make_client(router_store, user, monkeypatch)
+        corr = uuid4()
+
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A write",
+                parameters=_pocket_write_params(workspace_id="ws-A", correlation_id=corr),
+            )
+            resp = client.post(
+                f"/instinct/actions/{action_id}/reject",
+                json={"reason": "ok"},
+            )
+            assert resp.status_code == 200, resp.text
+
+        chain = _events_by_correlation(journal, corr)
+        actions = [e.action for e in chain]
+        assert actions == ["human.corrected", "decision.completed"]
+
+    def test_bulk_reject_of_foreign_workspace_pocket_write_is_403(
+        self, journal, graph: DecisionGraph, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A ws-A approver bulk-rejecting a list containing a ws-B
+        parked write is forbidden — and no action flips, no chain
+        events fire (whole-batch-fails semantics mirror bulk-approve)."""
+        user = _FakeUser("user-A", "ws-A")
+        client = _make_client(router_store, user, monkeypatch)
+
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            own = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A write",
+                parameters=_pocket_write_params(workspace_id="ws-A", correlation_id=uuid4()),
+            )
+            foreign = _propose(
+                client,
+                pocket_id="pocket-B",
+                title="ws-B write",
+                parameters=_pocket_write_params(workspace_id="ws-B", correlation_id=uuid4()),
+            )
+            resp = client.post(
+                "/instinct/actions/bulk-reject",
+                json={"ids": [own, foreign], "reason": "batch nope"},
+            )
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+
+        # No chain events for either item — the cross-workspace check
+        # raises BEFORE store.bulk_reject runs.
+        assert _events(journal, "human.corrected") == []
+        assert _events(journal, "decision.completed") == []
+
+
+# ---------------------------------------------------------------------------
+# 8. End-to-end happy path via DecisionGraph.find — full producer set
+# ---------------------------------------------------------------------------
+
+
+async def test_full_chain_via_graph_with_real_proposed_event(
+    monkeypatch, journal, graph: DecisionGraph, router_store: InstinctStore
+):
+    """End-to-end with a real ``agent.proposed`` event from
+    ``action_executor.run_action`` opening the chain. Exercises the
+    full producer set: action_executor → bridge → router approve →
+    bridge close. Asserts:
+
+      * the cause-arrow chain
+        ``agent.proposed → policy.evaluated → human.corrected → decision.completed``
+        holds,
+      * the Decision row is queryable via ``DecisionGraph.find``,
+      * the approver attribution is present + the chain is NOT marked
+        rejected (the terminal ``decision.completed(passed=True)``
+        overrides the ``policy.evaluated(passed=False)`` parked state).
+
+    The outcomes-side emit (``emit_pocket_outcome``) is no-opped by
+    swallowing the AssertionError it raises when the EventBus isn't
+    initialised — those tests have their own coverage; this test is
+    about the chain folding."""
+    import httpx
+    from pocketpaw_ee.cloud.pockets import action_executor
+    from pocketpaw_ee.cloud.pockets.action_executor import run_action
+
+    user = _FakeUser("user-A", "ws-A")
+    client = _make_client(router_store, user, monkeypatch)
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: router_store)
+
+    def _fake_getaddrinfo(host, *_args, **_kwargs):
+        return [(2, 1, 6, "", ("8.8.8.8", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", _fake_getaddrinfo)
+
+    async def _get_creds(_workspace_id, _pocket_id):
+        return (
+            "https://api.example.com",
+            "none",
+            None,
+            "",
+            [
+                {"method": "POST", "path_pattern": "/leases/*/renew"},
+            ],
+            None,
+        )
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
+        _get_creds,
+    )
+
+    real_client = httpx.AsyncClient
+
+    def _client_factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(lambda r: httpx.Response(200, json={"ok": 1}))
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(action_executor.httpx, "AsyncClient", _client_factory)
+    action_executor._action_log.clear()
+
+    # The bridge's success path calls ``outcomes_service.emit_pocket_outcome``
+    # which needs the EventBus initialised — out of scope for this
+    # test. Stub it as a no-op so the chain close itself is what's
+    # under test.
+    from pocketpaw_ee.cloud.outcomes import service as outcomes_service
+
+    async def _noop_emit(**_kwargs):
+        return None
+
+    monkeypatch.setattr(outcomes_service, "emit_pocket_outcome", _noop_emit)
+
+    corr = uuid4()
+    # First entry — the executor mints / accepts correlation_id and
+    # fires agent.proposed. Then it returns instinct_pending with
+    # _park carrying correlation_id.
+    park_result = await run_action(
+        workspace_id="ws-A",
+        pocket_id="pocket-A",
+        user_id="user-A",
+        action="mark_renewed",
+        raw_action={
+            "kind": "write_binding",
+            "method": "POST",
+            "path": "/leases/42/renew",
+            "params": {},
+            "requires_instinct": True,
+            "outcome": "renewal_completed",
+        },
+        path="/leases/42/renew",
+        params={"rent": 2000},
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=[{"method": "POST", "path_pattern": "/leases/*/renew"}],
+        correlation_id=corr,
+    )
+    assert park_result["code"] == "instinct_pending"
+
+    # Bridge stores the parked Action; this also fires the parked
+    # policy.evaluated and back-writes parked_policy_event_id.
+    action_id = await instinct_bridge_module.propose_pocket_write(
+        pocket=_seed_pocket("ws-A", "pocket-A"),
+        backend_config=None,
+        parked_write=park_result["_park"],
+        requested_by="user-A",
+    )
+
+    # Approve over HTTP — fires human.corrected then re-enters
+    # run_action via the bridge, which closes the chain with
+    # decision.completed.
+    with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+        resp = client.post(f"/instinct/actions/{action_id}/approve")
+        assert resp.status_code == 200, resp.text
+
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    # Expected order: agent.proposed (executor) → policy.evaluated
+    # (bridge propose) → human.corrected (router approve) →
+    # decision.completed (bridge close on re-entry success).
+    assert actions == [
+        "agent.proposed",
+        "policy.evaluated",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+
+    proposed, policy, human, completed = chain
+    # The full cause-arrow chain — each event's causation_id (when
+    # present) points back at the previous emit's id.
+    assert proposed.causation_id is None  # the chain origin
+    # policy.evaluated doesn't currently chain a causation_id (Slice 2
+    # bridge doesn't pass one), so we just verify the chain folds.
+    assert human.causation_id == policy.id
+    # decision.completed from the bridge does not set causation_id —
+    # the chain still folds correctly via correlation_id.
+
+    # The folded Decision row exists and is queryable via the graph.
+    assert graph.store.count() == 1
+    decisions = await graph.find()
+    assert len(decisions) == 1
+    decision = decisions[0]
+    assert decision.correlation_id == corr
+    assert decision.intent.startswith("POST /leases/42/renew")
+    assert decision.pocket_id == "pocket-A"
+    # The human approver is attached.
+    assert len(decision.approvers) == 1
+    assert decision.approvers[0].actor.kind == "user"
+    assert decision.approvers[0].actor.id == "user:user-A"
+    # The Slice 3 brief explicitly does NOT emit a follow-up
+    # ``policy.evaluated(passed=True)`` on approve — the last-seen
+    # policy state is the parked-side passed=False. The chain is NOT
+    # marked rejected because the terminal ``decision.completed`` payload's
+    # ``passed=True`` overrides the policy state (projection.py:
+    # ``_close_chain``). The outcome stays None — no rejection, no
+    # late attach happened in this test.
+    assert decision.instinct_policy_passed is False
+    assert decision.outcome is None or decision.outcome.status != "rejected"


### PR DESCRIPTION
## What this changes

The Instinct producers for the Decision Graph chain land in this slice. The chain that Slice 2 opened at `agent.proposed` and that the executor closes for direct writes now has its parked-then-approved counterpart wired end-to-end:

```
agent.proposed         (executor, Slice 2)
  → policy.evaluated   (bridge propose, this slice)
  → human.corrected    (router approve/reject, this slice)
  → decision.completed (bridge close on approve / router on reject)
```

Five emit sites added across two files:

| Site | Action | Disposition / payload |
|---|---|---|
| `instinct_bridge.propose_pocket_write` | `policy.evaluated(passed=False)` | `reason="parked_for_human_approval"`, plus a SQL write-back stashing the event id onto the parked blob's `parked_policy_event_id` field so the eventual `human.corrected` chains its `causation_id` |
| `instinct/router.approve_action` | `human.corrected` | `accepted` (plain approve) or `edited` (approver tweaked fields — context summary lands on `note`) |
| `instinct/router.bulk_approve_actions` | `human.corrected` per item in the existing loop | `accepted` |
| `instinct/router.reject_action` | `human.corrected` + `decision.completed` | `rejected` (+ chain terminal with `passed=False, action_outcome="rejected"`) |
| `instinct/router.bulk_reject_actions` | `human.corrected` + `decision.completed` per item in a new loop | `rejected` |

The approve path intentionally does NOT emit `decision.completed` — `instinct_bridge.execute_approved_write` owns the chain close on the bridge re-entry. Reject paths own the close themselves because the bridge isn't invoked on rejection.

All five emit sites route through the per-action wrappers in `decisions/journal_writer.py` (`record_policy_evaluated`, `record_human_corrected`, `record_decision_completed`) so `scripts/audit_decision_chain.py` stays clean.

## Touch-time security fix

`reject_action` and `bulk_reject_actions` previously lacked `current_user` / `current_workspace_id` deps. Without them, `_assert_pocket_write_workspace` could not run on the reject paths — the BLOCKER-1 mirror gap. A workspace-A approver could reject a workspace-B parked write and the existing guard (added for approvals in PR #1183) had no way to fire.

Two deps added on both endpoints. The same `instinct.cross_workspace_approval` error code raises a 403 before any state mutation. The bulk variant fails the whole batch (mirror of `bulk_approve_actions`).

Regression coverage lives in `tests/cloud/test_instinct_approval_security.py` under the new `TestRejectCrossWorkspaceSecurity` class.

## Touch-time Slice 2 bug fix

End-to-end testing surfaced a chain-doubling bug from Slice 2 that the existing tests missed: `instinct_bridge.execute_approved_write` rebuilds `raw_action` from the parked blob but didn't carry `requires_instinct=True` through. The action_executor's gate-8 success branch is guarded by `if not binding.requires_instinct:`, so on the Instinct re-entry it saw `False` and fired its own `policy.evaluated + decision.completed` — and THEN the bridge's `_emit_bridge_chain_close` fired a second `decision.completed`. Every Instinct-approved write was producing a doubled terminal.

Slice 2's tests didn't catch it because they passed `requires_instinct=True` directly into the test's `raw_action` rather than routing through the bridge's reconstruction step. The fix is a one-liner — add `"requires_instinct": True` to the reconstructed dict — and the new `test_full_chain_via_graph_with_real_proposed_event` covers the production code path so it can't regress.

## Bulk-reject per-item loop

`store.bulk_reject` already iterates per item internally for the audit log; the router now also iterates over the returned `rejected` list to fire per-item chain emits. The response shape (`BulkActionResponse` with shared `bulk_id`) is unchanged.

## Tests

12 new cases in `tests/ee/test_instinct_decision_events.py`:

1. propose emits `policy.evaluated` and persists event id back onto blob
2. propose without correlation_id skips emit gracefully
3. approve emits `human.corrected(accepted)` and does NOT double-emit completed
4. approve with edits emits `human.corrected(edited)` with the correction's context summary as `note`
5. reject emits `human.corrected(rejected)` followed by `decision.completed(rejected)` in order
6. bulk-approve emits per-item `human.corrected(accepted)`
7. bulk-reject emits per-item `human.corrected(rejected)` + `decision.completed(rejected)`
8. full chain causation: `policy.evaluated.id == human.corrected.causation_id`
9. `TestRejectCrossWorkspaceSecurity` — cross-workspace single + bulk reject return 403 with no chain events emitted
10. same-workspace single + bulk reject succeed under tenant isolation
11. End-to-end: propose → approve folds into a Decision row queryable via `DecisionGraph.find` with approvers populated

Plus 4 new cases in `tests/cloud/test_instinct_approval_security.py` under `TestRejectCrossWorkspaceSecurity` (single + bulk reject security regressions).

Targeted runs all clean:

```
174 passed  (RFC 07 + Slice 1b + Slice 2 + Slice 3 sweep)
665 passed, 1 skipped  (full tests/ee/)
49 passed   (tests/cloud/test_instinct_*.py)
Decision-chain audit: clean — 763 files scanned, no violations.
lint-imports: 17 contracts kept, 0 broken.
```

## Slice 4 follow-up notes

- Abandon-path sweeper still missing per RFC 09 Producer 4 (e) — parked Actions live forever; chains can stay open if a human never acts. Slice 4 wires `_action_sweeper.py` modelled after `chat/runs/sweeper.py`.
- Correlation-propagation hardening tests (mid-chain crash → reconciler resume) and observability hooks (heartbeat, metrics, admin endpoint) ship in Slice 4.
- The `instinct_policy_passed` field on approved chains currently shows `False` (last-seen policy state from the parked event). The Slice 3 brief explicitly scoped out an approve-side `policy.evaluated(passed=True)` emit; the terminal `decision.completed(passed=True)` still flips `rejected=False` via `_close_chain`. If the field needs to read `True` for approved chains, a follow-up adds the approve-side policy emit.
- A potential abandon-sub-question: should the sweeper also flip the Instinct Action to `expired`, or just close the Decision Graph chain? Audit Surprise 5 carved this out as a separate Instinct-TTL RFC.

Refs: RFC 09 (paw-workspace#63), [producer audit](.claude/worktrees/rfc09-producer-audit/AUDIT-REPORT.md), Slice 1b helper (`journal_writer.py`), Slice 2 (PR #1249).

## Stack

Stacked on `feat/rfc-09-slice-2-pocket-runtime-emits`. Retarget to `dev` once Slice 2 merges.