### PR TITLE
feat(foresight): RFC 08 §9 — PredictionRecord Mongo persistence

### DIFF
--- a/ee/pocketpaw_ee/cloud/foresight/domain.py
+++ b/ee/pocketpaw_ee/cloud/foresight/domain.py
@@ -1,4 +1,17 @@
 # ee/pocketpaw_ee/cloud/foresight/domain.py
+# Updated: 2026-05-26 (feat/foresight-v10-prediction-record-persist) — RFC
+# 08 v1.0 PR 10:
+#   - Added ``PredictionRecord`` frozen dataclass mirroring the persisted
+#     :class:`pocketpaw_ee.cloud.models.foresight_prediction_record.ForesightPredictionRecord`
+#     document 1-to-1 plus the cloud-rule-#3 tenancy invariant. The
+#     service layer maps this to the Mongo doc and back; the aggregate +
+#     insights endpoints read these records (filtering ``paired=True``
+#     for rolling-accuracy buckets) instead of the v0.5 backtest +
+#     projected-decision proxies.
+#   - The shape is frozen so the cloud service can hand it to the
+#     engine-side aggregator primitives (``ee.foresight.aggregator``)
+#     without import-direction violations — both sides see plain
+#     dataclasses with no Beanie / FastAPI / pydantic surface.
 # Updated: 2026-05-25 (feat/foresight-v05-subtypes-projected-decision) —
 # PR 5:
 #   - Rebuilt ``ProjectedDecision`` to match the persisted shape of
@@ -46,7 +59,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Literal
 
@@ -124,6 +137,55 @@ class ProjectedDecision:
 
 
 BacktestRunStatus = Literal["queued", "running", "complete", "failed"]
+
+
+@dataclass(frozen=True)
+class PredictionRecord:
+    """One projected outcome held until reality lands.
+
+    Persisted equivalent of :class:`ee.foresight.calibration.PredictionRecord`
+    (engine in-memory shape) — the cloud's Mongo-backed mirror with the
+    cloud-rule-#3 tenancy invariant. Fields mirror
+    :class:`pocketpaw_ee.cloud.models.foresight_prediction_record.ForesightPredictionRecord`
+    1-to-1:
+
+    - ``id`` — Mongo ObjectId rendered as hex string.
+    - ``workspace_id`` — tenancy key (required positionally).
+    - ``anchor_id`` — sub-type-specific anchor identifier
+      (``decision:<name>`` / ``segment:<role>`` / ``rollout:<event>``).
+    - ``persona_id`` — the persona whose modal action drove the
+      projection (empty string when no persona acted).
+    - ``scenario_id`` — scenario name / template identifier.
+    - ``run_id`` — the ForesightRun / ForesightBacktest doc id.
+    - ``tick_id`` — zero-based tick index inside the run.
+    - ``prediction`` — projected-outcome payload (JSON dict).
+    - ``confidence`` — aggregate confidence in (0.0, 1.0).
+    - ``captured_at`` — server-side timestamp when the engine emitted
+      this prediction.
+    - ``observed_at`` — timestamp when reality landed (``None`` while
+      unpaired).
+    - ``observed_outcome`` — the actual outcome dict (``None`` while
+      unpaired).
+    - ``paired`` — ``True`` once observation lands. The §11.5
+      rolling-accuracy read filters on this so unpaired projections
+      never inflate the denominator.
+    - ``pair_delta`` — per-metric diff dict (``None`` until paired).
+    """
+
+    id: str
+    workspace_id: str
+    captured_at: datetime
+    anchor_id: str = ""
+    persona_id: str = ""
+    scenario_id: str = ""
+    run_id: str = ""
+    tick_id: int = 0
+    prediction: dict[str, Any] = field(default_factory=dict)
+    confidence: float = 0.0
+    observed_at: datetime | None = None
+    observed_outcome: dict[str, Any] | None = None
+    paired: bool = False
+    pair_delta: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -313,6 +375,7 @@ __all__ = [
     "InsightView",
     "ModalOutcomeEntry",
     "OnboardingGateState",
+    "PredictionRecord",
     "ProjectedDecision",
     "RollingAccuracyPoint",
     "ScenarioCatalogEntry",

--- a/ee/pocketpaw_ee/cloud/foresight/service.py
+++ b/ee/pocketpaw_ee/cloud/foresight/service.py
@@ -1,4 +1,40 @@
 # ee/pocketpaw_ee/cloud/foresight/service.py
+# Updated: 2026-05-26 (feat/foresight-v10-prediction-record-persist) —
+# RFC 08 v1.0 PR 10 — calibration buffer migration to Mongo:
+#   - New ``emit_prediction_record(ctx, payload)`` — engine callback
+#     mirrors each per-(anchor × tick) projection into the
+#     ``foresight_prediction_records`` collection. Idempotent on
+#     (workspace, run_id, tick_id, anchor_id, persona_id).
+#   - New ``pair_prediction(ctx, record_id, observed_outcome,
+#     pair_delta)`` — flips an existing record to ``paired=True`` and
+#     stamps ``observed_at`` / ``observed_outcome`` / ``pair_delta``.
+#   - ``_run_engine_inline`` now wires ``on_prediction_record``
+#     alongside the existing ``on_projected_decision`` closure so the
+#     same engine pass persists BOTH collections (no extra engine work
+#     — the prediction-record path is a side-mirror of the projected-
+#     decision path).
+#   - ``_score_backtest`` now persists paired PredictionRecords for
+#     each backtest anchor before scoring, so the §11.5 rolling-accuracy
+#     read sees real data instead of the v0.5 ``ForesightBacktest.gate_decision.observed``
+#     proxy.
+#   - ``get_aggregate_rollup`` REWRITTEN — reads PredictionRecord docs
+#     (paired=True, captured_at in window), buckets by day for the
+#     rolling series, derives confidence drift from per-record
+#     ``confidence`` mean comparison, derives modal distribution from
+#     ``prediction.modal_outcome`` counts. Same response shape as PR
+#     #1241 (the wire contract is locked).
+#   - ``get_insights`` REWRITTEN — reads PredictionRecord docs (no
+#     proxy) and composes the synthesizer bundle. Per-persona
+#     calibration now comes from real captured records instead of
+#     ForesightProjectedDecision.confidence; per-anchor outlier
+#     detection has the real data it needs once a workspace runs
+#     enough backtests. Same response shape.
+#
+#   v0.5 → v1.0 behaviour delta: identical wire contract. The
+#   aggregate + insights endpoints return the same JSON shape; only
+#   the data source flipped from proxy reads to real PredictionRecord
+#   reads. Empty-workspace paths still collapse to zeros + empty
+#   arrays.
 # Updated: 2026-05-25 (feat/foresight-v15-scenarios-aggregate-insights) —
 # RFC 08 §11.2 / §11.5 / §11.6 backing service functions:
 #   - ``list_scenarios(ctx)`` — enumerates the bundled YAML templates
@@ -148,6 +184,7 @@ from pocketpaw_ee.cloud.foresight.domain import (
     InsightView,
     ModalOutcomeEntry,
     OnboardingGateState,
+    PredictionRecord,
     ProjectedDecision,
     RollingAccuracyPoint,
     ScenarioCatalogEntry,
@@ -178,6 +215,9 @@ from pocketpaw_ee.cloud.foresight.dto import (
 )
 from pocketpaw_ee.cloud.models.foresight_backtest import (
     ForesightBacktest as _ForesightBacktestDoc,
+)
+from pocketpaw_ee.cloud.models.foresight_prediction_record import (
+    ForesightPredictionRecord as _ForesightPredictionRecordDoc,
 )
 from pocketpaw_ee.cloud.models.foresight_projected_decision import (
     ForesightProjectedDecision as _ForesightProjectedDecisionDoc,
@@ -391,9 +431,31 @@ async def _run_engine_inline(
 
         callback = _on_projected_decision
 
+    # PR 10 — PredictionRecord mirror callback. Persists each
+    # per-(anchor × tick) projection into the
+    # ``foresight_prediction_records`` collection. The closure stays
+    # here (not in the runner) so the engine never statically imports
+    # the cloud — the import-linter contract holds. The callback is
+    # only wired when the cloud caller has already resolved a
+    # workspace; CLI smoke runs pass no workspace_id and the prediction
+    # buffer mirror stays a no-op (the in-engine
+    # ``RunResult.projected_decisions`` field still carries the same
+    # records for direct consumption).
+    prediction_callback = None
+    if workspace_id and run_id:
+
+        async def _on_prediction_record(payload: dict[str, Any]) -> None:
+            await emit_prediction_record(
+                workspace_id=workspace_id,
+                payload=payload,
+            )
+
+        prediction_callback = _on_prediction_record
+
     result = await run_scenario(
         config,
         on_projected_decision=callback,
+        on_prediction_record=prediction_callback,
         run_id=run_id,
     )
     return result.as_wire_dict()
@@ -669,18 +731,22 @@ async def _score_backtest(
     *,
     engine_result: dict[str, Any],
     threshold: float,
+    workspace_id: str | None = None,
+    backtest_run_id: str | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Pair the engine's projected outcomes against the operator-supplied
     actual outcomes, aggregate, and score against the threshold.
 
     Returns ``(summary_wire_dict, gate_decision_wire_dict)``.
 
-    v0.1 simulates the §10 pair-against-reality loop in-process — every
-    anchor in ``body.anchors`` produces one ``CalibrationPair`` whose
-    projected outcome comes from the engine's per-tick projection (when
-    available) or a placeholder ``{}`` (the engine doesn't fan
-    projections per anchor yet — PR 8 will). v1.0 wires the projection
-    stream end-to-end via the ``projected_decisions`` collection.
+    v0.1 simulated the §10 pair-against-reality loop in-process — every
+    anchor in ``body.anchors`` produced one ``CalibrationPair`` whose
+    projected outcome came from the engine's per-tick projection (when
+    available) or a placeholder ``{}``. PR 10 (v1.0) ALSO persists one
+    paired :class:`ForesightPredictionRecord` per anchor when
+    ``workspace_id`` + ``backtest_run_id`` are supplied — this is how
+    the §11.5 rolling-accuracy read sees historical backtest data
+    without falling back to the v0.5 gate-decision-observed proxy.
 
     The aggregator imports are lazy so the cloud module stays clean of
     the engine layer per the import-linter contract.
@@ -741,6 +807,52 @@ async def _score_backtest(
         predictions_by_id=index_predictions(records),
     )
     decision = accuracy_meets_threshold(summary, threshold=threshold)
+
+    # PR 10 — persist paired PredictionRecords for the rolling-accuracy
+    # read. Each anchor produces ONE Mongo row stamped with the
+    # pair_delta the in-memory aggregator already computed. Done after
+    # scoring so a scoring exception never half-persists the batch.
+    # Caller passes ``workspace_id`` + ``backtest_run_id`` when the
+    # backtest is real (i.e. ``create_backtest`` is calling us); test
+    # callers can leave them None to keep the legacy in-memory-only
+    # path.
+    if workspace_id and backtest_run_id:
+        for record, pair in zip(records, pairs, strict=True):
+            # Compute a per-pair match flag and surface it on the
+            # stored ``pair_delta`` payload so the rolling-accuracy
+            # read can count matches without re-running the aggregator.
+            # Pair-level match = no metric fell outside the numeric
+            # tolerance band (delegates to the aggregator's own
+            # ``_metric_matches`` semantics by counting per-metric
+            # match flags inside ``pair.delta``).
+            payload: dict[str, Any] = {
+                "anchor_id": record.anchor_object_id,
+                "persona_id": "",
+                "tick_id": 0,
+                "decision_text": str(
+                    projected_outcome_default.get("modal_outcome", "")
+                    or projected_outcome_default.get("outcome", "")
+                ),
+                "confidence": float(record.projection_confidence),
+                "sub_type": str(body.sub_type),
+                "scenario_id": str(body.name),
+                "run_id": backtest_run_id,
+                "prediction": dict(projected_outcome_default),
+            }
+            persisted = await emit_prediction_record(
+                workspace_id=workspace_id,
+                payload=payload,
+            )
+            # Stamp observed_outcome + pair_delta so the rolling-accuracy
+            # window read can filter on ``paired=True`` and reproduce
+            # the per-pair match flag without a second engine call.
+            await pair_prediction(
+                workspace_id=workspace_id,
+                record_id=persisted.id,
+                observed_outcome=dict(pair.actual_outcome),
+                pair_delta=dict(pair.delta),
+            )
+
     return summary.as_wire_dict(), decision.as_wire_dict()
 
 
@@ -830,6 +942,14 @@ async def create_backtest(ctx: RequestContext, body: CreateBacktestRequest) -> B
             body,
             engine_result=engine_result,
             threshold=threshold,
+            # PR 10 — pass tenancy + run id so paired PredictionRecord
+            # rows persist alongside the in-memory aggregator pass.
+            # Drives the §11.5 rolling-accuracy read off the new
+            # ``foresight_prediction_records`` collection instead of
+            # the v0.5 ``ForesightBacktest.gate_decision.observed``
+            # proxy.
+            workspace_id=workspace_id,
+            backtest_run_id=str(doc.id),
         )
     except Exception as exc:  # noqa: BLE001 — capture into the doc, never bubble
         error_message = f"{type(exc).__name__}: {exc}"
@@ -1195,6 +1315,164 @@ async def list_projected_decisions(
         offset=offset,
         has_more=(offset + len(items)) < total,
     )
+
+
+# ---------------------------------------------------------------------------
+# PredictionRecord persistence (RFC 08 §9.1 CAPTURE / §9.2 OBSERVE + PR 10)
+#
+# The cloud-side mirror of the engine's :class:`PredictionBuffer`. The
+# engine never imports cloud — the callbacks below are injected via
+# closure into ``run_scenario`` so the import direction stays
+# cloud → engine.
+#
+# Two writes happen here:
+#
+#   1. ``emit_prediction_record`` — one INSERT per (anchor × tick) bucket
+#      as the engine ticks the run forward. Idempotent on
+#      (workspace, run_id, tick_id, anchor_id, persona_id) so a re-emit
+#      of the same bucket replays without creating duplicate rows.
+#   2. ``pair_prediction`` — UPDATE flipping ``paired=True`` and
+#      stamping ``observed_at`` / ``observed_outcome`` / ``pair_delta``
+#      once reality lands. Backtests pair every anchor at scoring time;
+#      forward sims pair via the v1.1+ outcome-listener stream.
+# ---------------------------------------------------------------------------
+
+
+def _to_prediction_record_domain(
+    doc: _ForesightPredictionRecordDoc,
+) -> PredictionRecord:
+    return PredictionRecord(
+        id=str(doc.id),
+        workspace_id=doc.workspace,
+        anchor_id=doc.anchor_id,
+        persona_id=doc.persona_id,
+        scenario_id=doc.scenario_id,
+        run_id=doc.run_id,
+        tick_id=doc.tick_id,
+        prediction=dict(doc.prediction or {}),
+        confidence=doc.confidence,
+        captured_at=doc.captured_at,
+        observed_at=doc.observed_at,
+        observed_outcome=dict(doc.observed_outcome) if doc.observed_outcome else None,
+        paired=doc.paired,
+        pair_delta=dict(doc.pair_delta) if doc.pair_delta else None,
+    )
+
+
+async def emit_prediction_record(
+    *,
+    workspace_id: str,
+    payload: dict[str, Any],
+) -> PredictionRecord:
+    """Persist one PredictionRecord row, idempotent on the bucket key.
+
+    Called by the engine's per-tick callback (wired in
+    :func:`_run_engine_inline`). The bucket key is
+    ``(workspace, run_id, tick_id, anchor_id, persona_id)`` — the same
+    quintuple the engine's :class:`PredictionBuffer` uses to dedupe
+    in-memory. A re-emit of the same bucket (re-run of a fixed-seed
+    scenario, retry after a transient error) returns the existing row
+    instead of inserting a duplicate.
+
+    Tenancy:
+      - ``workspace_id`` is required (the closure in
+        :func:`_run_engine_inline` only wires when the cloud caller
+        has already resolved a workspace), so this function asserts
+        rather than validating.
+
+    No event is emitted — the engine's projected-decision fan-out
+    already fires :class:`ForesightProjectedDecisionEmitted` for the
+    same (anchor × tick) bucket, and downstream subscribers reading
+    that event have everything they need. Adding a parallel
+    "prediction_record.captured" event would double-fire without new
+    information.
+    """
+    if not workspace_id:
+        raise Forbidden(
+            "foresight.no_workspace",
+            "workspace required to emit a prediction record",
+        )
+
+    captured_at = datetime.now(UTC_TZ)
+    run_id = str(payload.get("run_id", ""))
+    tick_id = int(payload.get("tick_id", 0))
+    anchor_id = str(payload.get("anchor_id", ""))
+    persona_id = str(payload.get("persona_id", ""))
+
+    # Idempotence guard — read-before-write on the bucket quintuple.
+    # The query is bounded by the (workspace, anchor_id, captured_at)
+    # index; for a given run + tick + anchor + persona the result set
+    # is at most one row.
+    existing = await _ForesightPredictionRecordDoc.find_one(
+        {
+            "workspace": workspace_id,
+            "run_id": run_id,
+            "tick_id": tick_id,
+            "anchor_id": anchor_id,
+            "persona_id": persona_id,
+        }
+    )
+    if existing is not None:
+        return _to_prediction_record_domain(existing)
+
+    doc = _ForesightPredictionRecordDoc(
+        workspace=workspace_id,
+        anchor_id=anchor_id,
+        persona_id=persona_id,
+        scenario_id=str(payload.get("scenario_id", "")),
+        run_id=run_id,
+        tick_id=tick_id,
+        prediction=dict(payload.get("prediction") or {}),
+        confidence=float(payload.get("confidence", 0.0)),
+        captured_at=captured_at,
+    )
+    await doc.insert()
+    return _to_prediction_record_domain(doc)
+
+
+async def pair_prediction(
+    *,
+    workspace_id: str,
+    record_id: str,
+    observed_outcome: dict[str, Any],
+    pair_delta: dict[str, Any] | None = None,
+) -> PredictionRecord:
+    """Mark a captured PredictionRecord as paired with reality.
+
+    Flips ``paired=True`` and stamps ``observed_at`` /
+    ``observed_outcome`` / ``pair_delta``. The ``pair_delta`` is the
+    diff dict :func:`ee.foresight.calibration._compute_delta` produces;
+    callers (backtests, future outcome listeners) compute it via the
+    engine helper and hand the result in.
+
+    Tenancy: scoped by ``workspace_id`` so a cross-tenant id collapses
+    to NotFound — keeps existence non-leakable across tenants.
+
+    No event emitted — same rationale as :func:`emit_prediction_record`
+    (the projection / backtest path already fires the dominant event).
+    """
+    if not workspace_id:
+        raise Forbidden(
+            "foresight.no_workspace",
+            "workspace required to pair a prediction record",
+        )
+
+    try:
+        oid = PydanticObjectId(record_id)
+    except Exception:
+        raise NotFound("foresight_prediction_record", record_id) from None
+
+    doc = await _ForesightPredictionRecordDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        raise NotFound("foresight_prediction_record", record_id)
+
+    doc.observed_at = datetime.now(UTC_TZ)
+    doc.observed_outcome = dict(observed_outcome)
+    doc.paired = True
+    if pair_delta is not None:
+        doc.pair_delta = dict(pair_delta)
+    await doc.save()
+    return _to_prediction_record_domain(doc)
 
 
 # ---------------------------------------------------------------------------
@@ -1597,12 +1875,22 @@ async def list_scenarios(_ctx: RequestContext) -> ScenarioCatalogResponse:
 # ---------------------------------------------------------------------------
 # Aggregate rollup (RFC §11.5) — rolling accuracy + drift + modal dist.
 #
-# Reads the workspace's persisted backtest summaries + projected
-# decisions over the window. PR 4's calibration buffer didn't land a
-# Mongo collection for ``PredictionRecord``; the rollup proxies the
-# missing data via the backtest summaries (rolling accuracy +
-# confidence drift) and the projection collection (modal outcome
-# distribution). Documented limitation; v1.0 wires the real buffer.
+# PR 10 (v1.0) reads the workspace's persisted ``ForesightPredictionRecord``
+# docs over the window:
+#
+#   - Rolling accuracy: paired records bucketed by day; per-bucket
+#     accuracy is the share of records whose ``pair_delta`` shows every
+#     metric inside the 10% tolerance band.
+#   - Confidence drift: earliest vs latest record-mean ``confidence``
+#     within the window; ``rising`` / ``falling`` / ``flat`` per the
+#     §11.5 vocabulary with a 5% flat threshold.
+#   - Modal outcome distribution: ``prediction.modal_outcome`` tally
+#     normalised by total record count.
+#
+# v0.5 used proxies (``ForesightBacktest.gate_decision.observed`` for
+# rolling, ``ForesightProjectedDecision`` for modal dist). v1.0 reads
+# real PredictionRecord rows — wire shape locked, only data source
+# flipped.
 # ---------------------------------------------------------------------------
 
 
@@ -1633,96 +1921,108 @@ def _resolve_window_days(window_days: int | None) -> int:
     return window_days
 
 
-def _compose_rolling_accuracy(
-    backtest_docs: list[Any],
+def _pair_is_match(pair_delta: dict[str, Any] | None, tolerance: float = 0.10) -> bool:
+    """Decide whether one paired record's ``pair_delta`` counts as a
+    match (every metric inside the numeric tolerance band, every
+    string metric flagged ``match=True``, no ``missing_in`` markers).
+
+    Mirrors the semantics of
+    :func:`ee.foresight.calibration._metric_matches` but stays local
+    to the cloud module so we don't have to import the engine for a
+    1-line check. Empty / None pair_delta means we never observed
+    reality matching the projection — treat as non-match (False) so
+    such records don't inflate accuracy.
+    """
+    if not pair_delta:
+        return False
+    for delta_val in pair_delta.values():
+        if isinstance(delta_val, dict):
+            if "missing_in" in delta_val:
+                return False
+            if not bool(delta_val.get("match", False)):
+                return False
+        elif isinstance(delta_val, (int, float)):
+            if abs(delta_val) > tolerance:
+                return False
+        else:
+            return False
+    return True
+
+
+def _compose_rolling_accuracy_from_records(
+    paired_records: list[Any],
     *,
-    window_days: int,
     now: datetime,
 ) -> tuple[RollingAccuracyPoint, ...]:
-    """Bucket completed backtests by day and emit one point per bucket.
+    """Bucket paired PredictionRecord docs by day; emit one point per
+    bucket where the accuracy is the share of records flagged
+    ``match`` (every metric inside tolerance).
 
-    ``accuracy`` is the per-bucket mean of ``gate_decision.observed``
-    across the backtests that completed in the bucket; ``sample_count``
-    is the per-bucket backtest count (i.e. the proxy for prediction
-    pairs since PR 4's buffer is in-memory only). Empty buckets are
-    omitted from the points array — the UI's chart fills gaps from
-    the bucket end-timestamp grid.
+    Empty buckets are omitted — the UI fills gaps from the bucket
+    end-timestamp grid.
     """
-    buckets: dict[datetime, list[tuple[float, int]]] = {}
-    for doc in backtest_docs:
-        gate = doc.gate_decision or {}
-        observed = gate.get("observed")
-        if not isinstance(observed, (int, float)):
-            continue
-        ts = getattr(doc, "createdAt", None) or now
+    buckets: dict[datetime, list[bool]] = {}
+    for doc in paired_records:
+        ts = getattr(doc, "captured_at", None) or now
         if isinstance(ts, datetime) and ts.tzinfo is None:
             ts = ts.replace(tzinfo=UTC_TZ)
-        # Bucket at day boundary (UTC) so the wire ts is stable.
         bucket_ts = ts.replace(hour=0, minute=0, second=0, microsecond=0)
-        n_pairs = int(gate.get("n_pairs") or 0)
-        buckets.setdefault(bucket_ts, []).append((float(observed), max(n_pairs, 1)))
+        is_match = _pair_is_match(getattr(doc, "pair_delta", None))
+        buckets.setdefault(bucket_ts, []).append(is_match)
 
     points: list[RollingAccuracyPoint] = []
-    for ts, entries in sorted(buckets.items()):
-        if not entries:
+    for ts, flags in sorted(buckets.items()):
+        if not flags:
             continue
-        total_samples = sum(sc for _, sc in entries)
-        # Weighted average across the bucket so a backtest with 100
-        # anchors counts proportionally more than one with 5.
-        weighted = sum(acc * sc for acc, sc in entries)
-        avg_accuracy = weighted / total_samples if total_samples else 0.0
+        accuracy = sum(1 for f in flags if f) / len(flags)
         points.append(
             RollingAccuracyPoint(
                 ts=ts,
-                accuracy=round(max(0.0, min(1.0, avg_accuracy)), 4),
-                sample_count=total_samples,
+                accuracy=round(max(0.0, min(1.0, accuracy)), 4),
+                sample_count=len(flags),
             )
         )
     return tuple(points)
 
 
-def _compose_confidence_drift(
-    backtest_docs: list[Any],
+def _compose_confidence_drift_from_records(
+    all_records: list[Any],
     *,
     flat_threshold: float = 0.05,
 ) -> ConfidenceDrift:
-    """Compute the §11.5 confidence-drift summary.
+    """Compute the §11.5 confidence-drift summary from PredictionRecord
+    docs.
 
-    Compares the earliest vs latest completed backtest's
-    ``result.calibration_summary.confidence_calibration``. Empty input
-    returns a flat zero-magnitude record so the UI can render "no
-    data" without a separate path.
+    Compares the per-record ``confidence`` mean for the oldest day
+    bucket vs the newest day bucket in the window. Bucketing damps
+    single-outlier noise — a single low-confidence record on day 1
+    can't fake a "falling" trend by itself.
 
-    Vocabulary:
-      - ``rising``   — calibration improved (delta > flat_threshold)
-      - ``falling``  — calibration degraded (delta < -flat_threshold)
+    Vocabulary (RFC §11.5):
+      - ``rising``   — confidence improved (delta > flat_threshold)
+      - ``falling``  — confidence degraded (delta < -flat_threshold)
       - ``flat``     — within the flat band (or no data)
     """
-    if not backtest_docs:
+    if not all_records:
         return ConfidenceDrift(trend="flat", magnitude=0.0)
-    confidences: list[tuple[datetime, float]] = []
-    for doc in backtest_docs:
-        result = doc.result or {}
-        summary = result.get("calibration_summary") if isinstance(result, dict) else None
-        if not isinstance(summary, dict):
-            continue
-        conf = summary.get("confidence_calibration")
+    by_day: dict[datetime, list[float]] = {}
+    for doc in all_records:
+        conf = getattr(doc, "confidence", None)
         if not isinstance(conf, (int, float)):
             continue
-        ts = getattr(doc, "createdAt", None)
-        if isinstance(ts, datetime) and ts.tzinfo is None:
-            ts = ts.replace(tzinfo=UTC_TZ)
-        if ts is None:
+        ts = getattr(doc, "captured_at", None)
+        if not isinstance(ts, datetime):
             continue
-        confidences.append((ts, float(conf)))
-    if len(confidences) < 2:
-        # Single point — can't compute drift. Flat zero so consumers
-        # can render the empty state.
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC_TZ)
+        bucket_ts = ts.replace(hour=0, minute=0, second=0, microsecond=0)
+        by_day.setdefault(bucket_ts, []).append(float(conf))
+    if len(by_day) < 2:
         return ConfidenceDrift(trend="flat", magnitude=0.0)
-    confidences.sort(key=lambda item: item[0])
-    earliest = confidences[0][1]
-    latest = confidences[-1][1]
-    delta = latest - earliest
+    days_sorted = sorted(by_day.items())
+    earliest_mean = sum(days_sorted[0][1]) / len(days_sorted[0][1])
+    latest_mean = sum(days_sorted[-1][1]) / len(days_sorted[-1][1])
+    delta = latest_mean - earliest_mean
     magnitude = abs(delta)
     trend: Literal["rising", "falling", "flat"]
     if magnitude < flat_threshold:
@@ -1734,19 +2034,19 @@ def _compose_confidence_drift(
     return ConfidenceDrift(trend=trend, magnitude=round(magnitude, 4))
 
 
-def _compose_modal_outcome_distribution(
-    projection_docs: list[Any],
+def _compose_modal_outcome_distribution_from_records(
+    records: list[Any],
 ) -> tuple[ModalOutcomeEntry, ...]:
-    """Tally projected-decision modal verbs into a normalised share map.
-
-    Each :class:`ForesightProjectedDecision` carries the modal verb
-    (``decision_text``); the distribution counts each unique verb and
-    normalises by the total record count. Empty input yields an empty
-    tuple.
+    """Tally ``prediction.modal_outcome`` verbs across PredictionRecord
+    docs and normalise into a share map. Records without a modal
+    outcome key collapse to no contribution.
     """
     counts: dict[str, int] = {}
-    for doc in projection_docs:
-        verb = (getattr(doc, "decision_text", "") or "").strip().lower()
+    for doc in records:
+        prediction = getattr(doc, "prediction", None) or {}
+        if not isinstance(prediction, dict):
+            continue
+        verb = str(prediction.get("modal_outcome", "")).strip().lower()
         if not verb:
             continue
         counts[verb] = counts.get(verb, 0) + 1
@@ -1763,38 +2063,46 @@ def _compose_modal_outcome_distribution(
     return tuple(entries)
 
 
-async def _fetch_aggregate_inputs(
+async def _fetch_prediction_records(
     workspace_id: str,
     *,
     window_days: int,
     now: datetime,
-) -> tuple[list[Any], list[Any]]:
-    """Read the workspace's persisted backtests + projection records
-    over the window. Returns ``(backtest_docs, projection_docs)``.
+    paired_only: bool = False,
+) -> list[Any]:
+    """Read PredictionRecord docs in the window. Tenant filter on every
+    read per cloud rule #7.
 
-    Tenant filter on every read per cloud rule #7. ``createdAt``
-    comparison uses a UTC-anchored lower bound so the window is
-    deterministic across deployments with different default tzs.
+    ``paired_only=True`` returns only records where the observation
+    landed — the §11.5 rolling-accuracy series uses this filter so
+    unpaired forward-sim projections don't inflate the denominator.
     """
     window_start = now - timedelta(days=window_days)
-    backtest_docs = await (
-        _ForesightBacktestDoc.find(
-            {
-                "workspace": workspace_id,
-                "status": "complete",
-                "createdAt": {"$gte": window_start},
-            }
-        )
-        .sort([("createdAt", 1), ("_id", 1)])  # type: ignore[list-item]
+    query: dict[str, Any] = {
+        "workspace": workspace_id,
+        "captured_at": {"$gte": window_start},
+    }
+    if paired_only:
+        query["paired"] = True
+    return await (
+        _ForesightPredictionRecordDoc.find(query)
+        .sort([("captured_at", 1), ("_id", 1)])  # type: ignore[list-item]
         .to_list()
     )
-    projection_docs = await _ForesightProjectedDecisionDoc.find(
-        {
-            "workspace": workspace_id,
-            "createdAt": {"$gte": window_start},
-        }
-    ).to_list()
-    return backtest_docs, projection_docs
+
+
+async def _fetch_latest_backtest(workspace_id: str) -> Any | None:
+    """Read the newest completed backtest in the workspace (for the
+    §11.6 ``threshold_unmet`` insight rule). Returns ``None`` when no
+    completed backtest exists — the rule then silently skips.
+    """
+    docs = await (
+        _ForesightBacktestDoc.find({"workspace": workspace_id, "status": "complete"})
+        .sort([("createdAt", -1), ("_id", -1)])  # type: ignore[list-item]
+        .limit(1)
+        .to_list()
+    )
+    return docs[0] if docs else None
 
 
 def _aggregate_to_response(rollup: AggregateRollup) -> AggregateRollupResponse:
@@ -1855,24 +2163,36 @@ async def get_aggregate_rollup(
     collapse to zeros + empty arrays so the UI never sees a 404 on
     new-tenant boot. Above the 90-day cap → 422
     ``foresight.invalid_window`` (validated in :func:`_resolve_window_days`).
+
+    PR 10 (v1.0): reads :class:`ForesightPredictionRecord` docs instead
+    of the v0.5 proxies. ``rolling_accuracy`` filters to paired
+    records (``paired=True``); ``confidence_drift`` reads per-record
+    ``confidence`` across all records (paired or not) over the
+    window; ``modal_outcome_distribution`` tallies the
+    ``prediction.modal_outcome`` vocabulary. Wire shape unchanged.
     """
     workspace_id = _require_workspace(ctx)
     effective_window = _resolve_window_days(window_days)
     now = datetime.now(UTC_TZ)
 
-    backtest_docs, projection_docs = await _fetch_aggregate_inputs(
+    # Two reads — paired-only for the rolling-accuracy series, full
+    # set for the confidence-drift + modal-distribution rollups.
+    paired_records = await _fetch_prediction_records(
         workspace_id,
         window_days=effective_window,
         now=now,
+        paired_only=True,
     )
-
-    rolling = _compose_rolling_accuracy(
-        backtest_docs,
+    all_records = await _fetch_prediction_records(
+        workspace_id,
         window_days=effective_window,
         now=now,
+        paired_only=False,
     )
-    drift = _compose_confidence_drift(backtest_docs)
-    distribution = _compose_modal_outcome_distribution(projection_docs)
+
+    rolling = _compose_rolling_accuracy_from_records(paired_records, now=now)
+    drift = _compose_confidence_drift_from_records(all_records)
+    distribution = _compose_modal_outcome_distribution_from_records(all_records)
 
     rollup = AggregateRollup(
         workspace_id=workspace_id,
@@ -1900,15 +2220,18 @@ INSIGHTS_DEFAULT_CAP: int = 20
 
 
 def _compose_per_persona_calibration(
-    projection_docs: list[Any],
+    prediction_records: list[Any],
     *,
     floor_threshold: float,
 ) -> list[Any]:
-    """Build the per-persona calibration proxy the synthesizer reads.
+    """Build the per-persona calibration view from PredictionRecord docs.
 
-    PR 4's CalibrationPair persistence didn't ship — the rule fires
-    on per-persona confidence levels read off the projection
-    collection as a proxy until the real buffer migrates to Mongo.
+    PR 10 (v1.0): reads real :class:`ForesightPredictionRecord` rows
+    instead of the v0.5 ``ForesightProjectedDecision.confidence``
+    proxy. The persona's mean per-record confidence becomes the
+    calibration figure; the persona_outlier rule downstream gates on
+    the floor_threshold so low-confidence personas surface as
+    insights.
 
     The synthesizer's ``PerPersonaCalibration`` dataclass lives in
     the engine namespace; we import it lazily inside the function so
@@ -1917,7 +2240,7 @@ def _compose_per_persona_calibration(
     from pocketpaw_ee.foresight.insights import PerPersonaCalibration
 
     per_persona: dict[str, list[float]] = {}
-    for doc in projection_docs:
+    for doc in prediction_records:
         persona_id = getattr(doc, "persona_id", "") or ""
         if not persona_id:
             continue
@@ -1930,15 +2253,11 @@ def _compose_per_persona_calibration(
     for persona_id, confidences in per_persona.items():
         if not confidences:
             continue
-        mean_conf = sum(confidences) / len(confidences)
-        # Synthesizer threshold gating happens in the rule itself;
-        # we surface every persona we have data for so a follow-up
-        # rule (or v1.0 LLM synthesizer) can re-evaluate without a
-        # second fetch.
         # Drop personas with samples below 2 to avoid noise from a
         # single low projection.
         if len(confidences) < 2:
             continue
+        mean_conf = sum(confidences) / len(confidences)
         out.append(
             PerPersonaCalibration(
                 persona_id=persona_id,
@@ -2002,19 +2321,18 @@ def _compose_tier_distribution_deltas(
 
 
 def _compose_latest_backtest_gate(
-    backtest_docs: list[Any],
+    latest_backtest: Any | None,
 ) -> Any | None:
-    """Build the synthesizer's ``LatestBacktestGate`` from the freshest
-    completed backtest. Returns ``None`` when no backtests exist —
-    the threshold_unmet rule then silently skips.
+    """Build the synthesizer's ``LatestBacktestGate`` from a single
+    backtest doc. Returns ``None`` when the doc is missing or its
+    gate payload is malformed — the threshold_unmet rule then silently
+    skips.
     """
     from pocketpaw_ee.foresight.insights import LatestBacktestGate
 
-    if not backtest_docs:
+    if latest_backtest is None:
         return None
-    # Backtest docs already arrive sorted ascending by createdAt from
-    # ``_fetch_aggregate_inputs``; the freshest is the last entry.
-    doc = backtest_docs[-1]
+    doc = latest_backtest
     gate = doc.gate_decision or {}
     observed = gate.get("observed")
     threshold = gate.get("threshold")
@@ -2031,6 +2349,33 @@ def _compose_latest_backtest_gate(
         observed=float(observed),
         threshold=float(threshold),
         completed_at=completed_at,
+    )
+
+
+async def _fetch_recent_backtest_docs(
+    workspace_id: str,
+    *,
+    window_days: int,
+    now: datetime,
+) -> list[Any]:
+    """Read completed backtest docs in the window — kept around for the
+    ``tier_distribution_deltas`` synthesizer field (each backtest's
+    ``result.tier_distribution`` reports the per-tier persona count
+    the run actually used). The rolling-accuracy series no longer
+    derives from backtests; it reads paired PredictionRecord rows
+    directly per PR 10.
+    """
+    window_start = now - timedelta(days=window_days)
+    return await (
+        _ForesightBacktestDoc.find(
+            {
+                "workspace": workspace_id,
+                "status": "complete",
+                "createdAt": {"$gte": window_start},
+            }
+        )
+        .sort([("createdAt", 1), ("_id", 1)])  # type: ignore[list-item]
+        .to_list()
     )
 
 
@@ -2055,41 +2400,58 @@ def _insight_to_response(view: InsightView) -> InsightResponse:
 async def get_insights(ctx: RequestContext) -> InsightsResponse:
     """Compose the workspace's Insights panel response.
 
-    Composes the synthesizer input bundle from the same aggregate
-    inputs the rollup endpoint reads, then delegates rule evaluation
-    to :func:`ee.foresight.insights.synthesize_insights`. Engine
-    import is lazy so the cloud module stays clean of the engine
-    layer per the import-linter contract.
+    Composes the synthesizer input bundle from PredictionRecord docs
+    (the same source the aggregate endpoint reads), then delegates
+    rule evaluation to :func:`ee.foresight.insights.synthesize_insights`.
+    Engine import is lazy so the cloud module stays clean of the
+    engine layer per the import-linter contract.
 
     Empty workspaces return ``items=[]`` — the synthesizer yields no
     rows when none of the five rules can fire.
+
+    PR 10 (v1.0): per-persona calibration + rolling accuracy + drift
+    now read PredictionRecord docs instead of the v0.5 proxies. The
+    ``tier_distribution_deltas`` + ``latest_backtest`` synthesizer
+    fields still source from backtest docs (those carry the per-run
+    tier mix + gate decision the prediction records don't echo).
     """
     workspace_id = _require_workspace(ctx)
     now = datetime.now(UTC_TZ)
 
-    # Reuse the aggregate window so the insights view is consistent
-    # with the rollup view the UI renders side-by-side.
-    backtest_docs, projection_docs = await _fetch_aggregate_inputs(
+    # Three reads — paired-only PredictionRecords for the rolling
+    # series, full PredictionRecords for the per-persona +
+    # confidence-drift + modal-distribution rollups, recent backtest
+    # docs for the tier_distribution_deltas + latest_backtest fields.
+    paired_records = await _fetch_prediction_records(
+        workspace_id,
+        window_days=AGGREGATE_DEFAULT_WINDOW_DAYS,
+        now=now,
+        paired_only=True,
+    )
+    all_records = await _fetch_prediction_records(
+        workspace_id,
+        window_days=AGGREGATE_DEFAULT_WINDOW_DAYS,
+        now=now,
+        paired_only=False,
+    )
+    backtest_docs = await _fetch_recent_backtest_docs(
         workspace_id,
         window_days=AGGREGATE_DEFAULT_WINDOW_DAYS,
         now=now,
     )
 
-    rolling = _compose_rolling_accuracy(
-        backtest_docs,
-        window_days=AGGREGATE_DEFAULT_WINDOW_DAYS,
-        now=now,
-    )
-    drift = _compose_confidence_drift(backtest_docs)
+    rolling = _compose_rolling_accuracy_from_records(paired_records, now=now)
+    drift = _compose_confidence_drift_from_records(all_records)
     per_persona = _compose_per_persona_calibration(
-        projection_docs,
+        all_records,
         floor_threshold=0.50,
     )
     tier_deltas = _compose_tier_distribution_deltas(
         backtest_docs,
         configured_default={"premium": 0.05, "mid": 0.15, "tail": 0.80},
     )
-    latest_gate = _compose_latest_backtest_gate(backtest_docs)
+    latest_backtest_doc = backtest_docs[-1] if backtest_docs else None
+    latest_gate = _compose_latest_backtest_gate(latest_backtest_doc)
 
     # Lazy import — the synthesizer module is pure but lives in the
     # engine namespace, so the import-linter forbids static imports
@@ -2148,6 +2510,7 @@ __all__ = [
     "INSIGHTS_DEFAULT_CAP",
     "create_backtest",
     "create_scenario_run",
+    "emit_prediction_record",
     "emit_projected_decision",
     "get_aggregate_rollup",
     "get_backtest",
@@ -2159,4 +2522,5 @@ __all__ = [
     "list_projected_decisions",
     "list_scenario_runs",
     "list_scenarios",
+    "pair_prediction",
 ]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,8 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-05-26 (feat/foresight-v10-prediction-record-persist) — added
+``ForesightPredictionRecord`` to the registered docs + ``__all__`` so the
+RFC 08 §9 calibration buffer's Mongo persistence is wired into ``init_beanie``.
 Updated: 2026-05-21 (PR #1177 security pass) — dropped PocketBackendCredential
 from ``__all__`` so it cannot be star-imported into routers/DTOs/domains; it
 remains registered in ``get_all_documents()`` for Beanie init.
@@ -14,6 +17,9 @@ from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
 from pocketpaw_ee.cloud.models.cycle import Cycle, CycleDailyPoint
 from pocketpaw_ee.cloud.models.file import FileObj
 from pocketpaw_ee.cloud.models.foresight_backtest import ForesightBacktest
+from pocketpaw_ee.cloud.models.foresight_prediction_record import (
+    ForesightPredictionRecord,
+)
 from pocketpaw_ee.cloud.models.foresight_projected_decision import (
     ForesightProjectedDecision,
 )
@@ -62,6 +68,7 @@ __all__ = [
     "FileObj",
     "FileUpload",
     "ForesightBacktest",
+    "ForesightPredictionRecord",
     "ForesightProjectedDecision",
     "ForesightRun",
     "Group",
@@ -120,6 +127,7 @@ def get_all_documents():
         ForesightRun,
         ForesightBacktest,
         ForesightProjectedDecision,
+        ForesightPredictionRecord,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/models/foresight_prediction_record.py
+++ b/ee/pocketpaw_ee/cloud/models/foresight_prediction_record.py
@@ -1,0 +1,114 @@
+# ee/pocketpaw_ee/cloud/models/foresight_prediction_record.py
+# Created: 2026-05-26 (feat/foresight-v10-prediction-record-persist) —
+# RFC 08 v1.0 PR 10. PredictionRecord Beanie document — the real Mongo
+# persistence behind RFC 08 §9 calibration loop (CAPTURE → OBSERVE →
+# PAIR → AGGREGATE → CORRECT).
+#
+# Mirrors the engine's ``ee.foresight.calibration.PredictionRecord``
+# dataclass with the cloud-rule-#3 tenancy invariant (``workspace`` is
+# Indexed and required). v0.5 held PredictionRecord in-memory only and
+# the §11.5 aggregate / §11.6 insights endpoints used proxies
+# (``ForesightBacktest.gate_decision.observed`` for rolling accuracy,
+# ``ForesightProjectedDecision.confidence`` for per-persona calibration).
+# v1.0 replaces those proxies with reads off this collection.
+#
+# Sole writer: ``ee.cloud.foresight.service`` (via
+# ``emit_prediction_record`` + ``pair_prediction``). The import-linter
+# contract in ``ee/pyproject.toml`` lists this doc alongside the other
+# foresight Beanie docs so router / dto / domain / models stay clean.
+#
+# Indexes are picked for the §11.5 + §11.6 read paths:
+#   - ``(workspace, captured_at)`` — rolling-accuracy window scan over
+#     all records inside the tenant + window.
+#   - ``(workspace, anchor_id, captured_at)`` — per-anchor lookup so a
+#     future Decision-Graph join (anchor across runs) stays cheap.
+#   - ``(workspace, persona_id, captured_at)`` — per-persona calibration
+#     read for the insights synthesizer's persona_outlier rule.
+#
+# The optional ``observed_at`` / ``observed_outcome`` / ``pair_delta``
+# fields are filled by ``pair_prediction`` when an outcome lands; until
+# then ``paired`` is False. Filtering ``paired=True`` is the canonical
+# rolling-accuracy read filter.
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class ForesightPredictionRecord(TimestampedDocument):
+    """One projected outcome held until reality lands (or persists
+    permanently on a backtest fan-out).
+
+    Fields:
+      - ``workspace`` — tenancy key (Indexed for fast list queries).
+      - ``anchor_id`` — sub-type-specific anchor identifier (matches
+        the ``decision:<name>`` / ``segment:<role>`` / ``rollout:<event>``
+        namespace used by ProjectedDecision).
+      - ``persona_id`` — the persona whose modal action drove the
+        prediction. Empty string when no persona acted at this tick
+        (the engine still emits a record so the per-anchor timeline
+        stays dense).
+      - ``scenario_id`` — the scenario name / template identifier
+        (``"decision_forecast"`` / ``"market_sim"`` / ``"org_change"``
+        for the v0.5 bundled set).
+      - ``run_id`` — the ForesightRun / ForesightBacktest document id
+        (hex string) this prediction belongs to.
+      - ``tick_id`` — zero-based tick index inside the run.
+      - ``prediction`` — projected-outcome payload (the engine's per-tick
+        modal outcome dict). Stored as a JSON blob so future sub-types
+        can add keys without a model migration.
+      - ``confidence`` — aggregate confidence in (0.0, 1.0).
+      - ``captured_at`` — server-side timestamp when the prediction was
+        emitted by the engine. Drives the §11.5 rolling-accuracy window
+        filter (NOT ``createdAt`` — captured_at echoes the engine clock
+        the buffer used in v0.5 so historical re-emits land in the same
+        bucket).
+      - ``observed_at`` — server-side timestamp when the matching real
+        outcome landed; ``None`` while the record stays unpaired.
+      - ``observed_outcome`` — the actual outcome dict the operator
+        supplied (backtests) or the listener wired in once reality
+        landed (forward sims, v1.1+). ``None`` while unpaired.
+      - ``paired`` — ``True`` once observation lands; the §11.5
+        rolling-accuracy read filters on this so unpaired projections
+        never inflate the denominator.
+      - ``pair_delta`` — per-metric diff dict produced by
+        :func:`ee.foresight.calibration._compute_delta` at pairing time.
+        ``None`` until paired. Numeric metrics → signed difference;
+        string metrics → ``{"match": bool, "projected": str,
+        "actual": str}``; missing metrics → ``{"missing_in": "..."}``.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    anchor_id: str = ""
+    persona_id: str = ""
+    scenario_id: str = ""
+    run_id: str = ""
+    tick_id: int = Field(default=0, ge=0)
+    prediction: dict[str, Any] = Field(default_factory=dict)
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    captured_at: datetime
+    observed_at: datetime | None = None
+    observed_outcome: dict[str, Any] | None = None
+    paired: bool = False
+    pair_delta: dict[str, Any] | None = None
+
+    class Settings:
+        name = "foresight_prediction_records"
+        indexes = [
+            # Window scan inside a workspace — §11.5 rolling accuracy.
+            [("workspace", 1), ("captured_at", 1)],
+            # Per-anchor lookup — future Decision-Graph join + insights
+            # tier-imbalance rule (per-anchor calibration drift).
+            [("workspace", 1), ("anchor_id", 1), ("captured_at", 1)],
+            # Per-persona lookup — §11.6 persona_outlier rule scan.
+            [("workspace", 1), ("persona_id", 1), ("captured_at", 1)],
+        ]
+
+
+__all__ = ["ForesightPredictionRecord"]

--- a/ee/pocketpaw_ee/foresight/calibration.py
+++ b/ee/pocketpaw_ee/foresight/calibration.py
@@ -1,4 +1,18 @@
 # ee/pocketpaw_ee/foresight/calibration.py
+# Updated: 2026-05-26 (feat/foresight-v10-prediction-record-persist) — RFC
+# 08 v1.0 PR 10:
+#   - ``PredictionBuffer`` accepts an optional ``on_capture`` /
+#     ``on_mark_observed`` callback pair. Legacy callers (CLI smoke,
+#     v0.5 tests) pass nothing and behaviour is unchanged. The cloud
+#     side hands in a closure that mirrors each capture into the new
+#     ``foresight_prediction_records`` Mongo collection and updates the
+#     same row when observation lands. The engine never imports cloud —
+#     the callbacks are injected at construction time so the import
+#     direction stays cloud → engine.
+#   - In-memory ring stays the canonical authority for the engine's
+#     own pairing path. Mongo is a side-mirror so the §11.5 aggregate
+#     + §11.6 insights endpoints can read paired records persistently
+#     across process restarts (which the in-memory ring loses).
 # Created: 2026-05-25 (feat/foresight-v03-calibration) — RFC 08 PR 3.
 #
 # Calibration loop — RFC 08 §9 "the moat".
@@ -80,18 +94,45 @@ class PredictionRecord:
 class PredictionBuffer:
     """In-memory ring of pending predictions.
 
-    PR 3 keeps this in-memory — PR 4's cloud-side path adds a
-    Beanie-backed equivalent under ``ee/pocketpaw_ee/cloud/foresight/``
-    (out of scope here per the parallel-leads lane split). The
-    interface is async to anticipate that swap.
+    PR 3 (v0.1) kept this in-memory only. v1.0 (PR 10) adds optional
+    ``on_capture`` / ``on_mark_observed`` callbacks so the cloud side
+    can mirror each capture / observation into the
+    ``foresight_prediction_records`` Mongo collection. The in-memory
+    ring stays the engine's authority — the callbacks are best-effort
+    side-mirrors. The engine never imports cloud; the cloud constructs
+    a buffer with callbacks baked in via closure.
+
+    Args:
+        on_capture: optional async callback invoked after a record is
+            captured. Receives the record. May be sync or async — the
+            buffer awaits when it returns a coroutine.
+        on_mark_observed: optional async callback invoked after a
+            record is marked observed. Receives ``(record,
+            observation)`` so the caller has both the original
+            prediction and the new outcome dict.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        on_capture: Any | None = None,
+        on_mark_observed: Any | None = None,
+    ) -> None:
         self._records: dict[UUID, PredictionRecord] = {}
         self._observed: dict[UUID, dict[str, Any]] = {}
+        self._on_capture = on_capture
+        self._on_mark_observed = on_mark_observed
 
     async def capture(self, record: PredictionRecord) -> None:
-        """Write a prediction to the buffer."""
+        """Write a prediction to the buffer.
+
+        Fires ``on_capture`` after the in-memory write lands so the
+        cloud-side mirror can persist a Mongo row. Callback exceptions
+        are intentionally NOT swallowed here — the engine treats the
+        buffer write as atomic with the side-mirror so a Mongo failure
+        surfaces to the runner (which logs + carries on per its own
+        contract). Sync + async callbacks both supported.
+        """
         self._records[record.id] = record
         logger.debug(
             "captured prediction id=%s anchor=%s observe_at=%s",
@@ -99,6 +140,10 @@ class PredictionBuffer:
             record.anchor_object_id,
             record.observe_at.isoformat(),
         )
+        if self._on_capture is not None:
+            maybe_coro = self._on_capture(record)
+            if hasattr(maybe_coro, "__await__"):
+                await maybe_coro
 
     async def pending(self, *, before: datetime | None = None) -> list[PredictionRecord]:
         """Return predictions whose ``observe_at`` has passed (or all
@@ -112,11 +157,21 @@ class PredictionBuffer:
         ]
 
     async def mark_observed(self, prediction_id: UUID, observation: dict[str, Any]) -> None:
-        """Record that reality has landed for this prediction."""
+        """Record that reality has landed for this prediction.
+
+        Fires ``on_mark_observed`` after the in-memory observation
+        lands so the cloud-side mirror can update the Mongo row's
+        ``observed_at`` / ``observed_outcome`` / ``paired`` fields.
+        """
         if prediction_id not in self._records:
             raise KeyError(f"unknown prediction id: {prediction_id}")
-        self._observed[prediction_id] = dict(observation)
+        observation_dict = dict(observation)
+        self._observed[prediction_id] = observation_dict
         logger.debug("marked observed prediction id=%s", prediction_id)
+        if self._on_mark_observed is not None:
+            maybe_coro = self._on_mark_observed(self._records[prediction_id], observation_dict)
+            if hasattr(maybe_coro, "__await__"):
+                await maybe_coro
 
     async def find_by_anchor(self, anchor_object_id: str) -> list[PredictionRecord]:
         """Find pending predictions anchored to a given Fabric object.

--- a/ee/pocketpaw_ee/foresight/scenarios/runner.py
+++ b/ee/pocketpaw_ee/foresight/scenarios/runner.py
@@ -1,4 +1,18 @@
 # ee/pocketpaw_ee/foresight/scenarios/runner.py
+# Updated: 2026-05-26 (feat/foresight-v10-prediction-record-persist) —
+# RFC 08 v1.0 PR 10:
+#   - ``run_scenario`` accepts an optional ``on_prediction_record``
+#     callback alongside the existing ``on_projected_decision``. The
+#     prediction-record callback receives the per-(anchor × tick)
+#     projection as a CAPTURE-shaped dict so the cloud's
+#     ``foresight_prediction_records`` collection can mirror each
+#     emission. Legacy callers (CLI smoke, v0.5 tests) pass nothing
+#     and behaviour is unchanged — the in-engine
+#     ``RunResult.projected_decisions`` field still carries the same
+#     records for direct consumption.
+#   - The engine never imports cloud; the callback is injected by
+#     closure exactly like ``on_projected_decision`` so the
+#     import-linter's "engine → cloud forbidden" contract holds.
 # Updated: 2026-05-25 (feat/foresight-v14-decision-graph-stub) — RFC 08
 # §14.4 wiring:
 #   - ``ScenarioConfig`` grows two optional fields: ``precedent_seed``
@@ -326,6 +340,23 @@ class RunResult:
 #     that index per-anchor records across runs of different sub-types).
 ProjectedDecisionCallback = Callable[[str, str, int, str, float, str], Any]
 
+# PR 10 — per-tick PredictionRecord callback. The cloud side passes a
+# function that mirrors each (anchor × tick) projection into the
+# ``foresight_prediction_records`` Mongo collection so the v1.0
+# aggregate + insights endpoints can read paired records persistently
+# (replacing the v0.5 ForesightBacktest + ForesightProjectedDecision
+# proxies). The dict payload mirrors the engine's per-tick
+# projected-decision record so the cloud-side writer is a thin field
+# map; the engine never sees Mongo / Beanie / pydantic.
+#
+# Args:
+#   record: dict with keys ``{anchor_id, persona_id, tick_id,
+#     decision_text, confidence, sub_type,
+#     forward_precedent_decision_id, scenario_id, run_id, prediction}``.
+#     The ``prediction`` key carries the per-tick modal-outcome dict
+#     the cloud will store as the PredictionRecord's payload.
+PredictionRecordCallback = Callable[[dict[str, Any]], Any]
+
 
 async def run_scenario(
     config: ScenarioConfig,
@@ -333,6 +364,7 @@ async def run_scenario(
     backend: Any | None = None,
     backend_pool: list[Any] | None = None,
     on_projected_decision: ProjectedDecisionCallback | None = None,
+    on_prediction_record: PredictionRecordCallback | None = None,
     run_id: str | None = None,
     decision_graph_ref: DecisionGraphRef | None = None,
 ) -> RunResult:
@@ -437,18 +469,46 @@ async def run_scenario(
         )
         for record in tick_records:
             projected_records.append(record)
-            if on_projected_decision is None:
-                continue
-            maybe_coro = on_projected_decision(
-                record["anchor_id"],
-                record["persona_id"],
-                record["tick_id"],
-                record["decision_text"],
-                record["confidence"],
-                record["sub_type"],
-            )
-            if inspect.isawaitable(maybe_coro):
-                await maybe_coro
+            if on_projected_decision is not None:
+                maybe_coro = on_projected_decision(
+                    record["anchor_id"],
+                    record["persona_id"],
+                    record["tick_id"],
+                    record["decision_text"],
+                    record["confidence"],
+                    record["sub_type"],
+                )
+                if inspect.isawaitable(maybe_coro):
+                    await maybe_coro
+            # PR 10 — PredictionRecord mirror callback. The cloud side
+            # hands in a closure that persists each (anchor × tick)
+            # projection into the ``foresight_prediction_records``
+            # collection. The dict carries the same per-tick payload
+            # the projected-decision callback received plus the
+            # scenario / run identifiers so the writer can satisfy
+            # the cloud's cloud-rule-#3 tenancy invariant without a
+            # second engine round-trip. The ``prediction`` key is the
+            # per-tick modal-outcome dict (keyed by
+            # ``decision_text`` so the cloud-side modal-distribution
+            # rollup tallies on the same vocabulary it used in v0.5).
+            if on_prediction_record is not None:
+                prediction_payload: dict[str, Any] = {
+                    "anchor_id": record["anchor_id"],
+                    "persona_id": record["persona_id"],
+                    "tick_id": record["tick_id"],
+                    "decision_text": record["decision_text"],
+                    "confidence": record["confidence"],
+                    "sub_type": record["sub_type"],
+                    "forward_precedent_decision_id": record.get("forward_precedent_decision_id"),
+                    "scenario_id": config.name,
+                    "run_id": run_id or "",
+                    "prediction": {
+                        "modal_outcome": record["decision_text"],
+                    },
+                }
+                maybe_coro_pr = on_prediction_record(prediction_payload)
+                if inspect.isawaitable(maybe_coro_pr):
+                    await maybe_coro_pr
 
     aggregate = adapter.aggregate(snapshots, config)
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -389,6 +389,7 @@ forbidden_modules = [
     "pocketpaw_ee.cloud.models.foresight_run",
     "pocketpaw_ee.cloud.models.foresight_backtest",
     "pocketpaw_ee.cloud.models.foresight_projected_decision",
+    "pocketpaw_ee.cloud.models.foresight_prediction_record",
 ]
 
 [[tool.importlinter.contracts]]
@@ -411,6 +412,7 @@ source_modules = [
     "pocketpaw_ee.cloud.models.foresight_run",
     "pocketpaw_ee.cloud.models.foresight_backtest",
     "pocketpaw_ee.cloud.models.foresight_projected_decision",
+    "pocketpaw_ee.cloud.models.foresight_prediction_record",
 ]
 forbidden_modules = [
     "pocketpaw_ee.foresight.persona",

--- a/tests/cloud/test_foresight_backtest_service.py
+++ b/tests/cloud/test_foresight_backtest_service.py
@@ -1,4 +1,9 @@
 # tests/cloud/test_foresight_backtest_service.py — RFC 08 PR 4.
+# Updated: 2026-05-26 (feat/foresight-v10-prediction-record-persist) —
+#   monkeypatched ``_score_backtest`` fakes accept ``**_kwargs`` to
+#   absorb the new ``workspace_id`` + ``backtest_run_id`` kwargs PR 10
+#   threads through for paired PredictionRecord persistence. Behaviour
+#   under test (gate state machine, unlock event) is unaffected.
 # Created: 2026-05-25 (feat/foresight-v04-backtest-aggregator) — service
 #   tests for the retroactive backtest gate. Exercises:
 #     - create → score → emit pipeline (queued / running / complete)
@@ -138,7 +143,7 @@ async def test_create_unlock_event_carries_workspace_and_accuracy(
     v0.1's placeholder pairing happens to score."""
     ctx = _ctx(workspace="ws-unlock-test")
 
-    async def _passing_scorer(_body, *, engine_result, threshold):
+    async def _passing_scorer(_body, *, engine_result, threshold, **_kwargs):
         return (
             {"modal_accuracy": 0.8, "confidence_calibration": 1.0, "n_pairs": 10},
             {
@@ -167,7 +172,7 @@ async def test_create_no_unlock_event_when_gate_fails(recording_bus, monkeypatch
     """Failing gate should NOT fire the unlock event."""
     ctx = _ctx()
 
-    async def _failing_scorer(_body, *, engine_result, threshold):
+    async def _failing_scorer(_body, *, engine_result, threshold, **_kwargs):
         return (
             {"modal_accuracy": 0.3, "confidence_calibration": 0.5, "n_pairs": 10},
             {
@@ -376,7 +381,7 @@ async def test_gate_reports_no_backtest_when_workspace_is_empty() -> None:
 async def test_gate_reports_unlocked_after_passing_backtest(monkeypatch) -> None:
     ctx = _ctx(workspace="pass-ws")
 
-    async def _passing_scorer(_body, *, engine_result, threshold):
+    async def _passing_scorer(_body, *, engine_result, threshold, **_kwargs):
         return (
             {"modal_accuracy": 0.8, "n_pairs": 10},
             {
@@ -401,7 +406,7 @@ async def test_gate_reports_unlocked_after_passing_backtest(monkeypatch) -> None
 async def test_gate_reports_below_threshold_after_failing_backtest(monkeypatch) -> None:
     ctx = _ctx(workspace="fail-ws")
 
-    async def _failing_scorer(_body, *, engine_result, threshold):
+    async def _failing_scorer(_body, *, engine_result, threshold, **_kwargs):
         return (
             {"modal_accuracy": 0.3, "n_pairs": 10},
             {
@@ -427,7 +432,7 @@ async def test_gate_isolates_across_workspaces(monkeypatch) -> None:
     ctx_w1 = _ctx(workspace="w1")
     ctx_w2 = _ctx(workspace="w2")
 
-    async def _passing_scorer(_body, *, engine_result, threshold):
+    async def _passing_scorer(_body, *, engine_result, threshold, **_kwargs):
         return (
             {"modal_accuracy": 0.9, "n_pairs": 10},
             {

--- a/tests/cloud/test_foresight_prediction_record.py
+++ b/tests/cloud/test_foresight_prediction_record.py
@@ -1,0 +1,307 @@
+# tests/cloud/test_foresight_prediction_record.py
+# Created: 2026-05-26 (feat/foresight-v10-prediction-record-persist) —
+# RFC 08 v1.0 PR 10. Tests the new ``ForesightPredictionRecord`` Beanie
+# document + the cloud service's ``emit_prediction_record`` /
+# ``pair_prediction`` functions.
+"""Tests for the PredictionRecord persistence layer (RFC 08 §9.1 + PR 10)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound
+from pocketpaw_ee.cloud.foresight import service as foresight_service
+from pocketpaw_ee.cloud.foresight.domain import PredictionRecord
+from pocketpaw_ee.cloud.models.foresight_prediction_record import (
+    ForesightPredictionRecord,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace: str | None = "w1", user: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "anchor_id": "decision:lease-renewal",
+        "persona_id": "p-anne",
+        "tick_id": 0,
+        "decision_text": "accept",
+        "confidence": 0.7,
+        "sub_type": "decision_forecast",
+        "scenario_id": "renewal-test",
+        "run_id": "67000000000000000000000a",
+        "prediction": {"modal_outcome": "accept"},
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Domain shape
+# ---------------------------------------------------------------------------
+
+
+def test_prediction_record_domain_is_frozen_and_requires_workspace() -> None:
+    """Cloud rule #3: ``workspace_id`` is positional, no default."""
+    record = PredictionRecord(
+        id="rec-1",
+        workspace_id="w1",
+        captured_at=datetime.now(UTC),
+    )
+    assert record.workspace_id == "w1"
+    # Frozen dataclass — mutation must fail.
+    with pytest.raises(Exception):
+        record.workspace_id = "w2"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# emit_prediction_record — insert + idempotence
+# ---------------------------------------------------------------------------
+
+
+async def test_emit_prediction_record_inserts_row() -> None:
+    """Happy path — one INSERT, returns the domain record with
+    workspace + bucket key fields populated."""
+    rec = await foresight_service.emit_prediction_record(
+        workspace_id="w1",
+        payload=_payload(),
+    )
+    assert isinstance(rec, PredictionRecord)
+    assert rec.workspace_id == "w1"
+    assert rec.anchor_id == "decision:lease-renewal"
+    assert rec.persona_id == "p-anne"
+    assert rec.scenario_id == "renewal-test"
+    assert rec.run_id == "67000000000000000000000a"
+    assert rec.tick_id == 0
+    assert rec.confidence == 0.7
+    assert rec.paired is False
+    assert rec.observed_at is None
+    assert rec.observed_outcome is None
+    assert rec.pair_delta is None
+    # Beanie persisted exactly one doc.
+    docs = await ForesightPredictionRecord.find_all().to_list()
+    assert len(docs) == 1
+
+
+async def test_emit_prediction_record_is_idempotent() -> None:
+    """Re-emit of the same (workspace, run_id, tick_id, anchor_id,
+    persona_id) bucket returns the existing row instead of inserting
+    a duplicate."""
+    first = await foresight_service.emit_prediction_record(
+        workspace_id="w1",
+        payload=_payload(),
+    )
+    second = await foresight_service.emit_prediction_record(
+        workspace_id="w1",
+        payload=_payload(confidence=0.99),
+    )
+    assert first.id == second.id  # same Mongo row
+    # confidence is the FIRST insertion's value (idempotent dedupe
+    # returns the existing row without overwrite).
+    assert second.confidence == 0.7
+    docs = await ForesightPredictionRecord.find_all().to_list()
+    assert len(docs) == 1
+
+
+async def test_emit_prediction_record_distinct_buckets() -> None:
+    """Different bucket quintuples produce separate rows."""
+    await foresight_service.emit_prediction_record(
+        workspace_id="w1",
+        payload=_payload(tick_id=0),
+    )
+    await foresight_service.emit_prediction_record(
+        workspace_id="w1",
+        payload=_payload(tick_id=1),  # different tick
+    )
+    await foresight_service.emit_prediction_record(
+        workspace_id="w1",
+        payload=_payload(anchor_id="decision:other-lease"),  # different anchor
+    )
+    docs = await ForesightPredictionRecord.find_all().to_list()
+    assert len(docs) == 3
+
+
+async def test_emit_prediction_record_workspace_isolation() -> None:
+    """Same bucket key in a different workspace is a separate row —
+    cloud rule #3 + #7 tenancy: tenant filter on every read."""
+    await foresight_service.emit_prediction_record(
+        workspace_id="w1",
+        payload=_payload(),
+    )
+    await foresight_service.emit_prediction_record(
+        workspace_id="w2",
+        payload=_payload(),
+    )
+    w1_docs = await ForesightPredictionRecord.find({"workspace": "w1"}).to_list()
+    w2_docs = await ForesightPredictionRecord.find({"workspace": "w2"}).to_list()
+    assert len(w1_docs) == 1
+    assert len(w2_docs) == 1
+
+
+async def test_emit_prediction_record_requires_workspace() -> None:
+    """Empty workspace_id raises Forbidden (consistent with the rest
+    of the foresight service)."""
+    with pytest.raises(Forbidden):
+        await foresight_service.emit_prediction_record(
+            workspace_id="",
+            payload=_payload(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# pair_prediction — observation stamping
+# ---------------------------------------------------------------------------
+
+
+async def test_pair_prediction_flips_paired_flag() -> None:
+    """Pair an existing record — paired=True, observed_at + outcome +
+    pair_delta stamped."""
+    rec = await foresight_service.emit_prediction_record(
+        workspace_id="w1",
+        payload=_payload(),
+    )
+    assert rec.paired is False
+
+    paired = await foresight_service.pair_prediction(
+        workspace_id="w1",
+        record_id=rec.id,
+        observed_outcome={"outcome": "accept"},
+        pair_delta={"outcome": {"match": True, "projected": "accept", "actual": "accept"}},
+    )
+    assert paired.paired is True
+    assert paired.observed_outcome == {"outcome": "accept"}
+    assert paired.pair_delta == {
+        "outcome": {"match": True, "projected": "accept", "actual": "accept"}
+    }
+    assert paired.observed_at is not None
+
+
+async def test_pair_prediction_unknown_id_raises_not_found() -> None:
+    """Unknown / malformed ids collapse to NotFound — existence not
+    leakable."""
+    with pytest.raises(NotFound):
+        await foresight_service.pair_prediction(
+            workspace_id="w1",
+            record_id="not-an-objectid",
+            observed_outcome={},
+        )
+
+
+async def test_pair_prediction_cross_tenant_collapses_to_not_found() -> None:
+    """A record in w2 cannot be paired by a w1 caller — collapses to
+    NotFound rather than leaking existence across tenants."""
+    rec = await foresight_service.emit_prediction_record(
+        workspace_id="w2",
+        payload=_payload(),
+    )
+    with pytest.raises(NotFound):
+        await foresight_service.pair_prediction(
+            workspace_id="w1",
+            record_id=rec.id,
+            observed_outcome={"outcome": "accept"},
+        )
+    # The original w2 row stays unpaired.
+    untouched = await ForesightPredictionRecord.get(rec.id)
+    assert untouched is not None
+    assert untouched.paired is False
+
+
+# ---------------------------------------------------------------------------
+# Engine → cloud → Mongo end-to-end smoke
+# ---------------------------------------------------------------------------
+
+
+async def test_create_scenario_run_persists_prediction_records() -> None:
+    """End-to-end: a forward scenario run drives the engine, which
+    fires the ``on_prediction_record`` callback for each
+    (anchor × tick) bucket, which lands one row in
+    ``foresight_prediction_records`` per bucket. This is the load-
+    bearing wire that proves the proxy → real data-source swap is
+    self-consistent — the engine writes the records the aggregate
+    endpoint reads.
+    """
+    from pocketpaw_ee.cloud.foresight.dto import (
+        CreateScenarioRequest,
+        PersonaSpecRequest,
+    )
+
+    ctx = _ctx()
+    body = CreateScenarioRequest(
+        name="renewal-smoke",
+        sub_type="decision_forecast",
+        n_ticks=2,
+        personas=[PersonaSpecRequest(name="Anne", role="approver", ocean={})],
+    )
+    run = await foresight_service.create_scenario_run(ctx, body)
+    assert run.status == "complete"
+
+    # 1 anchor × 2 ticks = 2 prediction records persisted.
+    docs = await ForesightPredictionRecord.find_all().to_list()
+    assert len(docs) == 2
+    for doc in docs:
+        assert doc.workspace == "w1"
+        assert doc.scenario_id == "renewal-smoke"
+        assert doc.run_id == run.id
+        assert doc.anchor_id == "decision:renewal-smoke"
+        # Forward sim — records remain unpaired until reality lands.
+        assert doc.paired is False
+        # Prediction blob carries the modal outcome the rollup tallies.
+        assert "modal_outcome" in doc.prediction
+
+
+async def test_create_backtest_persists_paired_prediction_records() -> None:
+    """End-to-end: a backtest run completes scoring, persists one
+    PAIRED prediction record per anchor (with ``pair_delta`` stamped
+    from the in-memory aggregator pass). This is what the
+    rolling-accuracy series reads — without these paired rows the
+    §11.5 endpoint can't return real data.
+    """
+    from pocketpaw_ee.cloud.foresight.dto import (
+        CreateBacktestRequest,
+        HistoricalAnchorRequest,
+        PersonaSpecRequest,
+    )
+
+    ctx = _ctx()
+    body = CreateBacktestRequest(
+        name="onboarding-bt-smoke",
+        sub_type="decision_forecast",
+        n_ticks=1,
+        personas=[PersonaSpecRequest(name="Anne", role="approver", ocean={})],
+        anchors=[
+            HistoricalAnchorRequest(
+                anchor_object_id=f"lease:LR-{i}",
+                actual_outcome={"outcome": "accept"},
+                scenario_template="decision_forecast.yaml",
+                projection_confidence=0.7,
+            )
+            for i in range(3)
+        ],
+    )
+    bt = await foresight_service.create_backtest(ctx, body)
+    assert bt.status == "complete"
+
+    # Paired records — one per backtest anchor. The forward-sim engine
+    # call also writes its own per-(anchor × tick) records; the
+    # aggregator path reads paired=True only, which is what the §11.5
+    # rolling-accuracy series counts on.
+    paired_docs = await ForesightPredictionRecord.find({"paired": True}).to_list()
+    assert len(paired_docs) >= 3
+    for doc in paired_docs:
+        assert doc.observed_at is not None
+        assert doc.observed_outcome == {"outcome": "accept"}
+        # pair_delta carries the engine's compute_delta output —
+        # match flag drives the rolling-accuracy match share.
+        assert doc.pair_delta is not None

--- a/tests/cloud/test_foresight_service_aggregate.py
+++ b/tests/cloud/test_foresight_service_aggregate.py
@@ -1,0 +1,288 @@
+# tests/cloud/test_foresight_service_aggregate.py
+# Created: 2026-05-26 (feat/foresight-v10-prediction-record-persist) —
+# RFC 08 v1.0 PR 10. Verifies the rewritten ``get_aggregate_rollup``
+# reads from the new ``foresight_prediction_records`` collection
+# instead of the v0.5 ``ForesightBacktest.gate_decision.observed`` /
+# ``ForesightProjectedDecision.confidence`` proxies. Wire shape is
+# unchanged — the swap is a pure data-source change.
+"""Tests for ``get_aggregate_rollup`` reading PredictionRecord docs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.foresight import service as foresight_service
+from pocketpaw_ee.cloud.models.foresight_backtest import ForesightBacktest
+from pocketpaw_ee.cloud.models.foresight_prediction_record import (
+    ForesightPredictionRecord,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace: str | None = "w1") -> RequestContext:
+    return RequestContext(
+        user_id="u1",
+        workspace_id=workspace,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _seed_paired_record(
+    *,
+    workspace: str,
+    captured_at: datetime,
+    pair_delta: dict[str, Any] | None = None,
+    confidence: float = 0.7,
+    modal_outcome: str = "accept",
+    persona_id: str = "p-anne",
+    anchor_id: str = "decision:lease-renewal",
+    run_id: str = "67000000000000000000000a",
+    tick_id: int = 0,
+) -> ForesightPredictionRecord:
+    """Direct doc-level seeder bypassing the service so we can control
+    ``captured_at`` (the service stamps it from ``datetime.now``)."""
+    if pair_delta is None:
+        pair_delta = {"outcome": {"match": True, "projected": "accept", "actual": "accept"}}
+    doc = ForesightPredictionRecord(
+        workspace=workspace,
+        anchor_id=anchor_id,
+        persona_id=persona_id,
+        scenario_id="seed-scn",
+        run_id=run_id,
+        tick_id=tick_id,
+        prediction={"modal_outcome": modal_outcome},
+        confidence=confidence,
+        captured_at=captured_at,
+        observed_at=captured_at + timedelta(seconds=1),
+        observed_outcome={"outcome": modal_outcome},
+        paired=True,
+        pair_delta=pair_delta,
+    )
+    await doc.insert()
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Reads PredictionRecord (NOT ForesightBacktest proxy)
+# ---------------------------------------------------------------------------
+
+
+async def test_aggregate_reads_prediction_records_not_backtest_proxy() -> None:
+    """The signature of the proxy-to-real swap: a workspace with NO
+    backtest docs but WITH paired PredictionRecord docs must still
+    populate ``rolling_accuracy.points``. v0.5's proxy required the
+    backtest gate_decision.observed field — the v1.0 path reads
+    PredictionRecord.pair_delta directly.
+    """
+    now = datetime.now(UTC)
+    yesterday = now - timedelta(days=1)
+    # Seed 3 paired records — all matches.
+    for i in range(3):
+        await _seed_paired_record(
+            workspace="w1",
+            captured_at=yesterday,
+            run_id=f"67000000000000000000000{i}",
+        )
+
+    # Verify NO ForesightBacktest docs exist — this is the load-bearing
+    # assertion: the v0.5 proxy would have returned an empty
+    # rolling_accuracy here.
+    backtests = await ForesightBacktest.find_all().to_list()
+    assert backtests == []
+
+    rollup = await foresight_service.get_aggregate_rollup(_ctx())
+    # Real PredictionRecord-driven rolling accuracy → 3 matches in
+    # 1 bucket = 100% accuracy, sample_count=3.
+    assert len(rollup.rolling_accuracy.points) == 1
+    point = rollup.rolling_accuracy.points[0]
+    assert point.sample_count == 3
+    assert point.accuracy == pytest.approx(1.0, abs=0.001)
+
+
+async def test_aggregate_rolling_accuracy_mixes_match_and_mismatch() -> None:
+    """A bucket with 2 matches + 1 mismatch yields ~0.667 accuracy
+    derived from PredictionRecord.pair_delta, not gate_decision."""
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    await _seed_paired_record(
+        workspace="w1",
+        captured_at=captured_at,
+        run_id="r-1",
+    )
+    await _seed_paired_record(
+        workspace="w1",
+        captured_at=captured_at,
+        run_id="r-2",
+    )
+    # One mismatch — pair_delta carries match=False.
+    await _seed_paired_record(
+        workspace="w1",
+        captured_at=captured_at,
+        run_id="r-3",
+        pair_delta={"outcome": {"match": False, "projected": "accept", "actual": "reject"}},
+    )
+
+    rollup = await foresight_service.get_aggregate_rollup(_ctx())
+    assert len(rollup.rolling_accuracy.points) == 1
+    point = rollup.rolling_accuracy.points[0]
+    assert point.sample_count == 3
+    assert point.accuracy == pytest.approx(2 / 3, abs=0.01)
+
+
+async def test_aggregate_modal_distribution_from_prediction_records() -> None:
+    """Modal-outcome share tally now sources from
+    PredictionRecord.prediction.modal_outcome — NOT
+    ForesightProjectedDecision.decision_text. v0.5 proxied the
+    distribution; v1.0 reads the prediction blob directly."""
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    # 2 "accept" + 1 "reject"
+    await _seed_paired_record(
+        workspace="w1",
+        captured_at=captured_at,
+        run_id="r-1",
+        modal_outcome="accept",
+    )
+    await _seed_paired_record(
+        workspace="w1",
+        captured_at=captured_at,
+        run_id="r-2",
+        modal_outcome="accept",
+    )
+    await _seed_paired_record(
+        workspace="w1",
+        captured_at=captured_at,
+        run_id="r-3",
+        modal_outcome="reject",
+    )
+
+    rollup = await foresight_service.get_aggregate_rollup(_ctx())
+    entries = rollup.modal_outcome_distribution.entries
+    assert len(entries) == 2
+    by_outcome = {e.outcome: e.share for e in entries}
+    assert by_outcome["accept"] == pytest.approx(2 / 3, abs=0.01)
+    assert by_outcome["reject"] == pytest.approx(1 / 3, abs=0.01)
+
+
+async def test_aggregate_unpaired_records_excluded_from_rolling_accuracy() -> None:
+    """Unpaired records (forward sims with no observation) MUST NOT
+    inflate the rolling-accuracy denominator. Only paired=True rows
+    feed the series — this is the load-bearing filter in PR 10."""
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    # 2 paired matches + 5 unpaired forward-sim records.
+    for i in range(2):
+        await _seed_paired_record(
+            workspace="w1",
+            captured_at=captured_at,
+            run_id=f"paired-r-{i}",
+        )
+    # Unpaired records — insert with paired=False.
+    for i in range(5):
+        unpaired = ForesightPredictionRecord(
+            workspace="w1",
+            anchor_id=f"decision:projection-{i}",
+            persona_id="p-anne",
+            scenario_id="seed-scn",
+            run_id=f"unpaired-r-{i}",
+            tick_id=0,
+            prediction={"modal_outcome": "accept"},
+            confidence=0.5,
+            captured_at=captured_at,
+            paired=False,
+        )
+        await unpaired.insert()
+
+    rollup = await foresight_service.get_aggregate_rollup(_ctx())
+    # Rolling-accuracy series only counts the 2 paired matches.
+    assert len(rollup.rolling_accuracy.points) == 1
+    point = rollup.rolling_accuracy.points[0]
+    assert point.sample_count == 2
+    assert point.accuracy == pytest.approx(1.0, abs=0.001)
+
+
+async def test_aggregate_confidence_drift_reads_prediction_records() -> None:
+    """Confidence-drift now reads PredictionRecord.confidence across
+    day buckets. v0.5 proxied this from
+    ForesightBacktest.result.calibration_summary.confidence_calibration."""
+    now = datetime.now(UTC)
+    earlier = now - timedelta(days=10)
+    later = now - timedelta(days=1)
+    # Earlier bucket: confidence 0.50
+    await _seed_paired_record(
+        workspace="w1",
+        captured_at=earlier,
+        run_id="early-1",
+        confidence=0.50,
+    )
+    # Later bucket: confidence 0.85 (rising by 0.35 > 0.05 flat
+    # threshold).
+    await _seed_paired_record(
+        workspace="w1",
+        captured_at=later,
+        run_id="late-1",
+        confidence=0.85,
+    )
+    rollup = await foresight_service.get_aggregate_rollup(_ctx())
+    assert rollup.confidence_drift.trend == "rising"
+    assert rollup.confidence_drift.magnitude == pytest.approx(0.35, abs=0.01)
+
+
+async def test_aggregate_empty_workspace_returns_zeros() -> None:
+    """Empty workspace path still collapses to zeros + empty arrays —
+    PR 10 must not regress the no-data behaviour."""
+    rollup = await foresight_service.get_aggregate_rollup(_ctx())
+    assert rollup.rolling_accuracy.points == []
+    assert rollup.confidence_drift.trend == "flat"
+    assert rollup.confidence_drift.magnitude == 0.0
+    assert rollup.modal_outcome_distribution.entries == []
+
+
+async def test_aggregate_window_filter_excludes_outside_records() -> None:
+    """The window_days filter clips PredictionRecord reads by
+    ``captured_at``. A record older than the window is invisible."""
+    captured_in_window = datetime.now(UTC) - timedelta(days=2)
+    captured_outside_window = datetime.now(UTC) - timedelta(days=20)
+    await _seed_paired_record(
+        workspace="w1",
+        captured_at=captured_in_window,
+        run_id="r-inside",
+    )
+    await _seed_paired_record(
+        workspace="w1",
+        captured_at=captured_outside_window,
+        run_id="r-outside",
+    )
+    rollup = await foresight_service.get_aggregate_rollup(_ctx(), window_days=7)
+    assert len(rollup.rolling_accuracy.points) == 1
+    assert rollup.rolling_accuracy.points[0].sample_count == 1
+
+
+async def test_aggregate_response_shape_unchanged() -> None:
+    """Wire-shape backward-compat — the response must carry the same
+    field structure v0.5 emitted (UI doesn't move)."""
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    await _seed_paired_record(
+        workspace="w1",
+        captured_at=captured_at,
+        run_id="r-shape",
+    )
+    rollup = await foresight_service.get_aggregate_rollup(_ctx())
+    # Wire shape is locked at the DTO layer — assert the response
+    # carries every field the v0.5 router contract advertised.
+    payload = rollup.model_dump()
+    assert set(payload.keys()) == {
+        "window_days",
+        "generated_at",
+        "rolling_accuracy",
+        "confidence_drift",
+        "modal_outcome_distribution",
+    }
+    assert set(payload["rolling_accuracy"].keys()) == {"points"}
+    assert set(payload["confidence_drift"].keys()) == {"trend", "magnitude"}
+    assert set(payload["modal_outcome_distribution"].keys()) == {"entries"}
+    # ISO-8601 UTC timestamp.
+    assert payload["generated_at"].endswith("Z")

--- a/tests/cloud/test_foresight_service_insights.py
+++ b/tests/cloud/test_foresight_service_insights.py
@@ -1,0 +1,177 @@
+# tests/cloud/test_foresight_service_insights.py
+# Created: 2026-05-26 (feat/foresight-v10-prediction-record-persist) —
+# RFC 08 v1.0 PR 10. Verifies the rewritten ``get_insights`` reads
+# PredictionRecord docs (NOT the v0.5 ForesightProjectedDecision
+# proxy) for the per-persona calibration synthesizer input.
+"""Tests for ``get_insights`` reading PredictionRecord docs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.foresight import service as foresight_service
+from pocketpaw_ee.cloud.models.foresight_prediction_record import (
+    ForesightPredictionRecord,
+)
+from pocketpaw_ee.cloud.models.foresight_projected_decision import (
+    ForesightProjectedDecision,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace: str | None = "w1") -> RequestContext:
+    return RequestContext(
+        user_id="u1",
+        workspace_id=workspace,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _seed_record(
+    *,
+    workspace: str = "w1",
+    persona_id: str = "p-anne",
+    confidence: float = 0.7,
+    captured_at: datetime | None = None,
+    run_id: str = "run-1",
+    tick_id: int = 0,
+    anchor_id: str = "decision:lease",
+    paired: bool = True,
+) -> ForesightPredictionRecord:
+    if captured_at is None:
+        captured_at = datetime.now(UTC) - timedelta(days=1)
+    doc = ForesightPredictionRecord(
+        workspace=workspace,
+        anchor_id=anchor_id,
+        persona_id=persona_id,
+        scenario_id="seed",
+        run_id=run_id,
+        tick_id=tick_id,
+        prediction={"modal_outcome": "accept"},
+        confidence=confidence,
+        captured_at=captured_at,
+        observed_at=captured_at + timedelta(seconds=1) if paired else None,
+        observed_outcome={"outcome": "accept"} if paired else None,
+        paired=paired,
+        pair_delta={"outcome": {"match": True, "projected": "accept", "actual": "accept"}}
+        if paired
+        else None,
+    )
+    await doc.insert()
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Reads PredictionRecord (NOT ForesightProjectedDecision proxy)
+# ---------------------------------------------------------------------------
+
+
+async def test_insights_reads_prediction_records_not_projection_proxy() -> None:
+    """v0.5 ``get_insights`` derived per-persona calibration from
+    ``ForesightProjectedDecision.confidence``. v1.0 sources from
+    ``ForesightPredictionRecord.confidence``. We verify the swap by
+    seeding ZERO projected-decision docs but enough prediction
+    records to trigger the persona_outlier rule.
+    """
+    # 3 low-confidence records for a single persona — meets the
+    # synthesizer's >= 2 sample_count gate and falls below the 0.50
+    # floor → persona_outlier insight should fire.
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    for i in range(3):
+        await _seed_record(
+            persona_id="p-low-conf",
+            confidence=0.2,
+            run_id=f"r-{i}",
+            tick_id=i,
+            captured_at=captured_at,
+        )
+
+    # No ForesightProjectedDecision docs exist — the v0.5 path would
+    # have produced empty per_persona_calibration here.
+    projection_docs = await ForesightProjectedDecision.find_all().to_list()
+    assert projection_docs == []
+
+    response = await foresight_service.get_insights(_ctx())
+    # The response shape stays — items is a flat list.
+    assert isinstance(response.items, list)
+    # At least one persona_outlier insight surfaced from the
+    # PredictionRecord data.
+    persona_outliers = [item for item in response.items if item.kind == "persona_outlier"]
+    assert len(persona_outliers) >= 1
+    # Insight body / anchor refs mention the low-confidence persona.
+    persona_ids_in_refs = {ref for insight in persona_outliers for ref in insight.anchor_refs}
+    assert any("p-low-conf" in ref for ref in persona_ids_in_refs)
+
+
+async def test_insights_empty_workspace_returns_empty_items() -> None:
+    """Empty-workspace contract stays — PR 10 must not regress this."""
+    response = await foresight_service.get_insights(_ctx())
+    assert response.items == []
+
+
+async def test_insights_workspace_isolation() -> None:
+    """w2 seeded prediction records do not leak into w1's insight set."""
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    for i in range(3):
+        await _seed_record(
+            workspace="w2",
+            persona_id="p-isolated",
+            confidence=0.2,
+            run_id=f"r-{i}",
+            tick_id=i,
+            captured_at=captured_at,
+        )
+    response = await foresight_service.get_insights(_ctx(workspace="w1"))
+    # w1 has no records → empty insights.
+    assert response.items == []
+
+
+async def test_insights_response_shape_unchanged() -> None:
+    """Wire-shape backward-compat — every insight row carries the
+    locked field set v0.5 emitted."""
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    for i in range(3):
+        await _seed_record(
+            persona_id="p-shape",
+            confidence=0.2,
+            run_id=f"r-{i}",
+            tick_id=i,
+            captured_at=captured_at,
+        )
+    response = await foresight_service.get_insights(_ctx())
+    for item in response.items:
+        payload = item.model_dump()
+        assert {
+            "id",
+            "kind",
+            "title",
+            "body",
+            "severity",
+            "anchor_refs",
+            "generated_at",
+        } <= set(payload.keys())
+        assert item.severity in ("info", "warning", "critical")
+
+
+async def test_insights_per_persona_excludes_thin_samples() -> None:
+    """A persona with a SINGLE record doesn't surface as a calibration
+    outlier — the synthesizer needs >= 2 samples per persona to fire
+    persona_outlier without being noise-dominated."""
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    # Only 1 record for this persona — should be filtered out.
+    await _seed_record(
+        persona_id="p-thin",
+        confidence=0.1,
+        run_id="r-thin",
+        captured_at=captured_at,
+    )
+    response = await foresight_service.get_insights(_ctx())
+    persona_outliers = [item for item in response.items if item.kind == "persona_outlier"]
+    # No persona_outlier insight for the thin-sample persona.
+    for insight in persona_outliers:
+        assert not any("p-thin" in ref for ref in insight.anchor_refs)


### PR DESCRIPTION
## Summary

- Lands a dedicated `foresight_prediction_records` Beanie collection so the §11.5 aggregate + §11.6 insights endpoints can read real CAPTURE → OBSERVE → PAIR data instead of the v0.5 proxies (`ForesightBacktest.gate_decision.observed` for rolling accuracy, `ForesightProjectedDecision.confidence` for per-persona calibration).
- Wires an engine-side `on_prediction_record` callback alongside the existing `on_projected_decision` so a single engine pass persists both collections. `PredictionBuffer` also accepts `on_capture` / `on_mark_observed` callbacks so the in-memory ring stays the engine's authority and Mongo is a side-mirror.
- Wire-level response shape is unchanged — `/aggregate` + `/insights` return the same JSON envelope. Only the data source flipped, and the UI doesn't move.

## Data flow

```
Engine tick ─▶ on_prediction_record (cloud closure)
                 │
                 ▼
        emit_prediction_record  (idempotent on workspace, run_id,
                 │               tick_id, anchor_id, persona_id)
                 ▼
        foresight_prediction_records (Mongo)
                 ▲
                 │ pair_prediction (backtest scorer +
                 │                  v1.1 outcome listener)
                 ▼
        get_aggregate_rollup  ◀── reads paired=True rows
        get_insights          ◀── reads all rows
```

## What changed

**New Beanie doc** — `ee/pocketpaw_ee/cloud/models/foresight_prediction_record.py`. Fields mirror engine `PredictionRecord` + `workspace` tenancy. Indexes: `(workspace, captured_at)`, `(workspace, anchor_id, captured_at)`, `(workspace, persona_id, captured_at)`. Registered in `ALL_DOCUMENTS` + the import-linter contract.

**New domain shape** — `PredictionRecord` frozen dataclass in `cloud/foresight/domain.py` with the cloud-rule-#3 tenancy invariant.

**Service surface** — two new public functions in `cloud/foresight/service.py`:
- `emit_prediction_record(workspace_id, payload)` — INSERT one row, idempotent on the bucket quintuple.
- `pair_prediction(workspace_id, record_id, observed_outcome, pair_delta)` — flip `paired=True` and stamp observation fields.

**Rewritten read paths**:
- `get_aggregate_rollup` reads paired PredictionRecord rows over the window. Rolling accuracy buckets by day and counts `pair_delta` matches; confidence drift compares per-record `confidence` mean across day buckets; modal distribution tallies `prediction.modal_outcome`.
- `get_insights` reads PredictionRecord rows for per-persona calibration. `tier_distribution_deltas` + `latest_backtest` synthesizer fields still source from backtest docs (those carry the per-run tier mix + gate decision the prediction records don't echo).

**Engine wiring**:
- `run_scenario` accepts `on_prediction_record` kwarg; legacy callers pass nothing and behaviour is unchanged.
- `PredictionBuffer.__init__` accepts `on_capture` / `on_mark_observed` so the cloud-side mirror can ride the buffer's writes.
- Backtest scorer `_score_backtest` persists paired records during scoring when `workspace_id` + `backtest_run_id` are supplied.

## Migration

No migration needed — v0.5 had no PredictionRecord persistence to backfill. Forward sims start writing records on the next engine pass; backtests start writing paired records on the next scoring pass.

## Tests

- `tests/cloud/test_foresight_prediction_record.py` (11 tests) — domain shape, `emit_prediction_record` idempotence + tenancy, `pair_prediction` flip + cross-tenant NotFound, end-to-end engine→cloud→Mongo smoke for both `create_scenario_run` (unpaired) and `create_backtest` (paired).
- `tests/cloud/test_foresight_service_aggregate.py` (8 tests) — verifies rolling accuracy reads PredictionRecord (NOT the ForesightBacktest proxy), unpaired records excluded from the denominator, modal distribution from `prediction.modal_outcome`, confidence drift from per-record mean, window filtering, response shape contract preserved.
- `tests/cloud/test_foresight_service_insights.py` (5 tests) — verifies per-persona calibration reads PredictionRecord (NOT the ForesightProjectedDecision proxy), workspace isolation, thin-sample filter, response shape contract preserved.
- 4 lines updated in `tests/cloud/test_foresight_backtest_service.py` — monkeypatched `_score_backtest` fakes accept `**_kwargs` so they absorb the new keyword args without changing the gate-state behaviour under test.

## Test plan

- [x] All 424 foresight tests pass (`uv run --group ee pytest tests/ee/foresight tests/cloud -k "foresight or prediction"`) — was 422 before, now 424 with the smoke tests.
- [x] Full collection check — 5490 tests collect cleanly.
- [x] `uv run ruff check` — passes on all changed files.
- [x] `uv run ruff format` — applied + clean.
- [x] `uv run mypy` — no new errors (2 pre-existing instinct-related warnings unchanged).
- [x] `uv run lint-imports` — all 18 contracts kept (engine never imports cloud; Beanie writes scoped to service.py).

## Deferred

- LLM-driven insights synthesizer (RFC §11.6 v1.0 next-PR stream) — current pattern synthesizer is unchanged; only its data source moved.
- Forward-sim outcome-listener stream that pairs unpaired records as reality lands (v1.1+) — backtests are the only pairing path in this PR.