### PR TITLE
feat(foresight): RFC 08 v1.0 — per-workspace onboarding-gate threshold override

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -495,6 +495,16 @@ class ForesightOnboardingUnlocked(Event):
     EVENT_TYPE: ClassVar[str] = "foresight.onboarding.unlocked"
 
 
+# Foresight per-workspace configuration — RFC 08 v1.0 PR 10. Fires when
+# an admin tightens the workspace's onboarding gate threshold via the
+# PUT /foresight/workspace/threshold endpoint, or resets it back to the
+# global default. Listeners can refresh the Aggregate / Onboarding panels
+# in the UI without polling the GET endpoint.
+@dataclass
+class ForesightThresholdUpdated(Event):
+    EVENT_TYPE: ClassVar[str] = "foresight.threshold.updated"
+
+
 # Foresight per-anchor projection fanout — RFC 08 §7.7 + PR 5. Fires
 # once per (anchor × tick) bucket as the engine ticks the run forward;
 # the UI's Live panel consumes these to render the projection timeline

--- a/ee/pocketpaw_ee/cloud/foresight/domain.py
+++ b/ee/pocketpaw_ee/cloud/foresight/domain.py
@@ -450,6 +450,46 @@ class LiveSnapshotView:
     anomalies: tuple[LiveAnomaly, ...]
 
 
+# ---------------------------------------------------------------------------
+# Per-workspace threshold-override view (RFC 08 v1.0 PR 10).
+#
+# Workspace-scoped at construction per cloud rule #3 — ``workspace_id`` is
+# required positionally with no default. The view is derived state
+# (recomputed on every GET / PUT) rather than a persisted snapshot; the
+# Mongo doc carries only the override value, the service composes this
+# view by reading the doc + the GATE_DEFAULT_THRESHOLD constant.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ThresholdOverrideView:
+    """The workspace's resolved foresight threshold view.
+
+    Composed by the service from
+    :class:`pocketpaw_ee.cloud.models.foresight_workspace_config.ForesightWorkspaceConfig`
+    plus the global default constant. Mirrors
+    :class:`pocketpaw_ee.cloud.foresight.dto.ForesightThresholdResponse`
+    field-for-field so the service maps the two via Pydantic's
+    ``model_validate(..., from_attributes=True)`` per cloud rule #8.
+
+    Fields:
+      - ``workspace_id``: tenancy key (required positional per cloud rule #3).
+      - ``current_threshold``: the effective threshold — override when
+        set, default otherwise.
+      - ``default_threshold``: echoed default so the UI doesn't hard-code
+        the constant.
+      - ``is_overridden``: True when a per-workspace override exists.
+      - ``updated_at``: when the override was last written; None when
+        no override exists.
+    """
+
+    workspace_id: str
+    current_threshold: float
+    default_threshold: float
+    is_overridden: bool
+    updated_at: datetime | None = None
+
+
 __all__ = [
     "AggregateRollup",
     "BacktestRun",
@@ -468,4 +508,5 @@ __all__ = [
     "ScenarioCatalogEntry",
     "ScenarioRun",
     "ScenarioRunStatus",
+    "ThresholdOverrideView",
 ]

--- a/ee/pocketpaw_ee/cloud/foresight/dto.py
+++ b/ee/pocketpaw_ee/cloud/foresight/dto.py
@@ -1,4 +1,16 @@
 # ee/pocketpaw_ee/cloud/foresight/dto.py
+# Modified: 2026-05-26 (feat/foresight-v10-threshold-override-cloud) —
+# RFC 08 v1.0 PR 10 adds the per-workspace threshold-override surface:
+#     - ``ForesightThresholdResponse`` — shape returned by both GET and
+#       PUT /api/v1/foresight/workspace/threshold. Carries the resolved
+#       view (current / default / is_overridden / updated_at) the
+#       paw-enterprise settings panel renders.
+#     - ``SetForesightThresholdRequest`` — PUT body. Single-field shape
+#       (``threshold: float | None``); float ∈ [0.5, 0.95] sets the
+#       override, ``None`` resets to the default. Bounds are DTO-level
+#       so a 422 fires before service code runs.
+#   Contract is locked against Team A2's settings panel; the response
+#   field names mirror the TypeScript surface that ships alongside.
 # Modified: 2026-05-26 (feat/foresight-v10-live-snapshot-and-fixes) —
 # RFC 08 v1.0 PR — three additions:
 #   1. ``LiveSnapshotResponse`` + nested ``TierMixActual`` / ``SampledTrace``
@@ -829,6 +841,76 @@ class LiveSnapshotResponse(BaseModel):
     anomalies: list[Anomaly] = Field(default_factory=list)
 
 
+# ---------------------------------------------------------------------------
+# Per-workspace onboarding-gate threshold override (RFC 08 v1.0 PR 10).
+#
+# Contract locked to paw-enterprise Team A2's settings panel — the
+# admin's "Foresight" preferences row reads the GET response to render
+# the current vs. default values, and the PUT body is the only mutation
+# surface the UI exposes (no inline edit on the Onboarding panel itself).
+# ---------------------------------------------------------------------------
+
+
+class ForesightThresholdResponse(BaseModel):
+    """Response shape for both
+    ``GET /api/v1/foresight/workspace/threshold`` and
+    ``PUT /api/v1/foresight/workspace/threshold``.
+
+    Carries the resolved view the UI renders:
+
+    - ``current_threshold``: the effective threshold the gate / backtest
+      scorer apply right now. When ``is_overridden=False`` this equals
+      ``default_threshold``; when ``is_overridden=True`` it equals the
+      admin-set override.
+    - ``default_threshold``: the global default
+      (``GATE_DEFAULT_THRESHOLD = 0.65``). Echoed back so the UI can
+      render "default 0.65" next to the override input without a second
+      round trip or a hard-coded constant on the frontend.
+    - ``is_overridden``: ``True`` when a per-workspace
+      :class:`pocketpaw_ee.cloud.models.foresight_workspace_config.ForesightWorkspaceConfig`
+      doc carries a non-null ``threshold_override``. ``False`` when no
+      doc exists or its override is ``None``.
+    - ``updated_at``: ISO-8601 UTC timestamp the override was last
+      written. ``None`` when ``is_overridden=False`` (no override → no
+      meaningful timestamp).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_id: str
+    current_threshold: float = Field(..., ge=0.5, le=0.95)
+    default_threshold: float = Field(..., ge=0.5, le=0.95)
+    is_overridden: bool
+    updated_at: str | None = None
+
+
+class SetForesightThresholdRequest(BaseModel):
+    """``PUT /api/v1/foresight/workspace/threshold`` body.
+
+    Single-field shape:
+
+    - ``threshold: float | None`` — a float in the closed range
+      ``[0.5, 0.95]`` sets the workspace override; ``None`` resets the
+      workspace to the global default (deletes the override).
+
+    Bounds chosen for the captain-approved override window:
+      - Lower bound 0.5 keeps operators from relaxing the gate to a
+        meaningless level (random guessing on binary outcomes).
+      - Upper bound 0.95 keeps operators from setting an unreachable
+        bar (the v0.1 deterministic engine + a 10-anchor backtest can
+        cap below 1.0 due to mismatch noise).
+
+    The service emits ``foresight.threshold.updated`` whenever the
+    effective override changes (a no-op write that keeps the same value
+    does NOT emit — the UI's optimistic local state shouldn't get
+    rebroadcast for free).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    threshold: float | None = Field(default=None, ge=0.5, le=0.95)
+
+
 __all__ = [
     "AggregateRollupResponse",
     "Anomaly",
@@ -839,6 +921,7 @@ __all__ = [
     "CreateScenarioRequest",
     "ForesightInstinctProposalListResponse",
     "ForesightInstinctProposalResponse",
+    "ForesightThresholdResponse",
     "GateDecision",
     "HistoricalAnchorRequest",
     "InsightResponse",
@@ -857,5 +940,6 @@ __all__ = [
     "ScenarioCatalogResponse",
     "ScenarioRunListItemResponse",
     "ScenarioRunResponse",
+    "SetForesightThresholdRequest",
     "TierMixActual",
 ]

--- a/ee/pocketpaw_ee/cloud/foresight/router.py
+++ b/ee/pocketpaw_ee/cloud/foresight/router.py
@@ -1,4 +1,22 @@
 # ee/pocketpaw_ee/cloud/foresight/router.py
+# Modified: 2026-05-26 (feat/foresight-v10-threshold-override-cloud) —
+# RFC 08 v1.0 PR 10 adds the per-workspace onboarding-gate threshold
+# override surface:
+#     GET /api/v1/foresight/workspace/threshold
+#       → ForesightThresholdResponse (current / default / is_overridden /
+#         updated_at). Workspace-scoped; no cross-tenant read possible
+#         (the view is intrinsically per-workspace, and an absent
+#         override collapses to the default).
+#     PUT /api/v1/foresight/workspace/threshold
+#       Body: { threshold: float | None } — float ∈ [0.5, 0.95] sets the
+#         workspace override; null resets to the default.
+#       → ForesightThresholdResponse (same shape, reflecting the new
+#         state). 422 on out-of-bounds (DTO-level enforcement); 400 on
+#         malformed body; emits ``foresight.threshold.updated`` on
+#         effective-value changes.
+#   Both routes delegate to ``ee.cloud.foresight.service`` per cloud
+#   rule #2. paw-enterprise Team A2 builds the settings panel against
+#   the locked field set above.
 # Modified: 2026-05-26 (feat/foresight-v10-live-snapshot-and-fixes) —
 # RFC 08 v1.0 PR adds the LivePanel backing endpoint:
 #     GET /api/v1/foresight/runs/{id}/live-snapshot
@@ -83,6 +101,7 @@ from pocketpaw_ee.cloud.foresight.dto import (
     CreateBacktestRequest,
     CreateScenarioRequest,
     ForesightInstinctProposalListResponse,
+    ForesightThresholdResponse,
     InsightsResponse,
     LiveSnapshotResponse,
     OnboardingGateResponse,
@@ -90,6 +109,7 @@ from pocketpaw_ee.cloud.foresight.dto import (
     ScenarioCatalogResponse,
     ScenarioRunListItemResponse,
     ScenarioRunResponse,
+    SetForesightThresholdRequest,
 )
 from pocketpaw_ee.cloud.license import require_license
 
@@ -446,6 +466,67 @@ async def get_insights(
     row keyed on the stable ``id``.
     """
     return await foresight_service.get_insights(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Per-workspace onboarding-gate threshold override (RFC 08 v1.0 PR 10)
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/workspace/threshold",
+    response_model=ForesightThresholdResponse,
+)
+async def get_workspace_threshold(
+    ctx: RequestContext = Depends(request_context),
+) -> ForesightThresholdResponse:
+    """Return the workspace's resolved onboarding-gate threshold view.
+
+    Workspace-scoped — the view is intrinsically per-workspace and an
+    absent override collapses to the default (``current_threshold ==
+    default_threshold == 0.65``, ``is_overridden=False``,
+    ``updated_at=null``). No cross-tenant read possible.
+
+    Tenancy: 403 when the caller has no active workspace. Never 404.
+
+    paw-enterprise Team A2's settings panel reads this on mount to
+    render the override input pre-populated with the current value plus
+    a "default 0.65" hint next to it.
+    """
+    return await foresight_service.get_threshold(ctx)
+
+
+@router.put(
+    "/workspace/threshold",
+    response_model=ForesightThresholdResponse,
+)
+async def set_workspace_threshold(
+    body: SetForesightThresholdRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> ForesightThresholdResponse:
+    """Upsert the workspace's onboarding-gate threshold override.
+
+    ``body.threshold = float`` in ``[0.5, 0.95]`` sets the workspace
+    override (validated at the DTO layer — 422 fires before the service
+    runs); ``body.threshold = null`` resets the workspace to the global
+    default.
+
+    Returns the same response shape as the GET so the UI can keep its
+    local store in sync with one round trip.
+
+    Side effects:
+      - Upserts the
+        :class:`pocketpaw_ee.cloud.models.foresight_workspace_config.ForesightWorkspaceConfig`
+        doc keyed by ``workspace_id``.
+      - Emits ``foresight.threshold.updated`` when the effective value
+        changes; a no-op write (same value) stays quiet.
+
+    Tenancy: 403 when no active workspace. The override applies to ALL
+    future ``get_onboarding_gate`` reads and ALL future ``create_backtest``
+    calls — a workspace that tightens its floor to 0.80 will reject
+    per-run threshold requests below 0.80 starting on the next call.
+    """
+    return await foresight_service.set_threshold(ctx, body)
 
 
 __all__ = ["router"]

--- a/ee/pocketpaw_ee/cloud/foresight/service.py
+++ b/ee/pocketpaw_ee/cloud/foresight/service.py
@@ -1,4 +1,35 @@
 # ee/pocketpaw_ee/cloud/foresight/service.py
+# Updated: 2026-05-26 (feat/foresight-v10-threshold-override-cloud) — RFC
+# 08 v1.0 PR 10. Per-workspace onboarding-gate threshold override:
+#   - New ``get_threshold(ctx)`` — returns the resolved
+#     :class:`ForesightThresholdResponse` (current / default /
+#     is_overridden / updated_at) for the caller's workspace. Reads the
+#     ``ForesightWorkspaceConfig`` doc (creates none); collapses absent
+#     overrides to the default. Tenancy: 403 when no workspace; 404
+#     never (the doc is per-workspace and read is intrinsically scoped).
+#   - New ``set_threshold(ctx, body)`` — upserts the workspace's
+#     override. ``body.threshold=None`` clears the override (sets the
+#     doc field to ``None``); a float ∈ [0.5, 0.95] sets it. Emits
+#     ``foresight.threshold.updated`` whenever the effective value
+#     changes; a no-op write (same value) does NOT emit.
+#   - ``get_onboarding_gate(ctx)`` now reads the workspace's effective
+#     threshold via the new ``_resolve_workspace_threshold`` helper
+#     instead of the hardcoded ``GATE_DEFAULT_THRESHOLD``. Backward
+#     compat: a workspace with no override still sees 0.65 echoed back.
+#   - ``create_backtest(ctx, body)`` now resolves the workspace floor
+#     before validating the per-run threshold — a workspace that has
+#     tightened to 0.80 cannot accept a per-run threshold of 0.70 even
+#     though the global default is 0.65. The 422 message reports the
+#     effective floor so the operator sees the right number.
+#   - The ``_score_backtest`` -> ``ThresholdDecision`` path is
+#     unchanged: the caller (``create_backtest``) already passes the
+#     resolved threshold through, so the backtest scores against the
+#     workspace-effective value automatically. Verified by the new
+#     ``test_create_backtest_uses_workspace_override`` test.
+#   - The aggregator (``ee.foresight.aggregator``) layer never sees the
+#     workspace doc; the cloud service reads + resolves the override at
+#     the entry point and threads the resulting float through. The
+#     import-linter contract (cloud → engine forbidden) is preserved.
 # Updated: 2026-05-26 (feat/foresight-v10-live-snapshot-and-fixes) —
 # RFC 08 v1.0 — three changes:
 #   1. New ``get_live_snapshot(ctx, run_id)`` — backs
@@ -202,6 +233,7 @@ from pocketpaw_ee.cloud._core.realtime.events import (
     ForesightRunCompleted,
     ForesightRunCreated,
     ForesightRunFailed,
+    ForesightThresholdUpdated,
 )
 from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.foresight.domain import (
@@ -218,6 +250,7 @@ from pocketpaw_ee.cloud.foresight.domain import (
     RollingAccuracyPoint,
     ScenarioCatalogEntry,
     ScenarioRun,
+    ThresholdOverrideView,
 )
 from pocketpaw_ee.cloud.foresight.dto import (
     AggregateRollupResponse,
@@ -229,6 +262,7 @@ from pocketpaw_ee.cloud.foresight.dto import (
     CreateScenarioRequest,
     ForesightInstinctProposalListResponse,
     ForesightInstinctProposalResponse,
+    ForesightThresholdResponse,
     GateDecision,
     InsightResponse,
     InsightsResponse,
@@ -245,6 +279,7 @@ from pocketpaw_ee.cloud.foresight.dto import (
     ScenarioCatalogResponse,
     ScenarioRunListItemResponse,
     ScenarioRunResponse,
+    SetForesightThresholdRequest,
     TierMixActual,
 )
 from pocketpaw_ee.cloud.foresight.live_snapshot import (
@@ -265,6 +300,9 @@ from pocketpaw_ee.cloud.models.foresight_projected_decision import (
     ForesightProjectedDecision as _ForesightProjectedDecisionDoc,
 )
 from pocketpaw_ee.cloud.models.foresight_run import ForesightRun as _ForesightRunDoc
+from pocketpaw_ee.cloud.models.foresight_workspace_config import (
+    ForesightWorkspaceConfig as _ForesightWorkspaceConfigDoc,
+)
 
 # Default onboarding gate threshold (RFC §13.1 gate 7 — captain locked for
 # v0.1 per PR 4 brief; v1.0 ops UI will let workspace admins tune).
@@ -865,23 +903,196 @@ async def _fetch_backtest_in_workspace(
     return doc
 
 
-def _resolve_threshold(requested: float | None) -> float:
+def _resolve_threshold(requested: float | None, *, floor: float = GATE_DEFAULT_THRESHOLD) -> float:
     """Pick the effective threshold for one backtest run.
 
-    v0.1: caller may tighten above ``GATE_DEFAULT_THRESHOLD`` but not
-    relax below it — an operator who could relax the bar could trivially
-    open the gate. v1.0's workspace-config override will let admins
-    set the floor; the per-run tightening path stays.
+    v1.0 (this PR): the floor is now the workspace's effective threshold
+    (the workspace admin's override when set, otherwise the global
+    :data:`GATE_DEFAULT_THRESHOLD`). A workspace that has tightened to
+    0.80 cannot accept a per-run threshold of 0.70 even though the
+    global default is 0.65 — the operator must tighten above the
+    workspace floor, never relax below it. The 422 message reports the
+    floor so the operator sees the right number.
+
+    v0.1 took a single argument and always compared against
+    ``GATE_DEFAULT_THRESHOLD``. The new ``floor`` kwarg defaults to that
+    constant so any unmigrated caller (none in tree) behaves identically.
     """
     if requested is None:
-        return GATE_DEFAULT_THRESHOLD
-    if requested < GATE_DEFAULT_THRESHOLD:
+        return floor
+    if requested < floor:
         raise ValidationError(
             "foresight.threshold_below_default",
-            f"per-run threshold {requested} cannot relax below the default "
-            f"{GATE_DEFAULT_THRESHOLD}; tighten above the floor only",
+            f"per-run threshold {requested} cannot relax below the workspace "
+            f"floor {floor}; tighten above the floor only",
         )
     return requested
+
+
+# ---------------------------------------------------------------------------
+# Per-workspace threshold override (RFC 08 v1.0 PR 10).
+#
+# Workspaces can persist a per-workspace override above the global
+# default (0.5–0.95 inclusive, enforced at the DTO layer). The override
+# is read by ``get_onboarding_gate`` and by ``create_backtest`` so all
+# gate-scoping reads see the same effective value.
+#
+# Two reads:
+#   - ``_resolve_workspace_threshold`` returns just the float (used in
+#     hot paths that don't need the full view, e.g. the gate read).
+#   - ``_load_threshold_view`` returns the full
+#     :class:`ThresholdOverrideView` (used by the GET / PUT response
+#     mappers).
+# ---------------------------------------------------------------------------
+
+
+async def _load_threshold_view(workspace_id: str) -> ThresholdOverrideView:
+    """Compose the workspace's threshold-override view.
+
+    A workspace with no config doc, or with a doc whose
+    ``threshold_override`` is ``None``, collapses to a "no override"
+    view — ``current_threshold`` equals the default, ``is_overridden``
+    is ``False``, ``updated_at`` is ``None``. The read never raises (an
+    absent doc is the normal case for a fresh workspace).
+    """
+    doc = await _ForesightWorkspaceConfigDoc.find_one(
+        {"workspace": workspace_id},
+    )
+    if doc is None or doc.threshold_override is None:
+        return ThresholdOverrideView(
+            workspace_id=workspace_id,
+            current_threshold=GATE_DEFAULT_THRESHOLD,
+            default_threshold=GATE_DEFAULT_THRESHOLD,
+            is_overridden=False,
+            updated_at=None,
+        )
+    return ThresholdOverrideView(
+        workspace_id=workspace_id,
+        current_threshold=float(doc.threshold_override),
+        default_threshold=GATE_DEFAULT_THRESHOLD,
+        is_overridden=True,
+        updated_at=doc.updatedAt,
+    )
+
+
+async def _resolve_workspace_threshold(workspace_id: str) -> float:
+    """Return the workspace's effective onboarding-gate threshold.
+
+    Light wrapper around :func:`_load_threshold_view` that pulls just the
+    float — used by hot paths (``get_onboarding_gate``, ``create_backtest``)
+    that don't need the full view shape.
+    """
+    view = await _load_threshold_view(workspace_id)
+    return view.current_threshold
+
+
+def _to_threshold_response(view: ThresholdOverrideView) -> ForesightThresholdResponse:
+    """Map the domain view to the wire DTO."""
+    return ForesightThresholdResponse(
+        workspace_id=view.workspace_id,
+        current_threshold=view.current_threshold,
+        default_threshold=view.default_threshold,
+        is_overridden=view.is_overridden,
+        updated_at=iso_utc(view.updated_at),
+    )
+
+
+async def get_threshold(ctx: RequestContext) -> ForesightThresholdResponse:
+    """Return the workspace's resolved onboarding-gate threshold view.
+
+    GET /api/v1/foresight/workspace/threshold backing.
+
+    Tenancy:
+      - 403 ``foresight.no_workspace`` when the caller has no active
+        workspace.
+      - No cross-tenant reads possible — the view is intrinsically
+        per-workspace; an absent override collapses to the default view
+        (never 404).
+    """
+    workspace_id = _require_workspace(ctx)
+    # no-event: read-only path; emit only on writes (cloud rule #9).
+    view = await _load_threshold_view(workspace_id)
+    return _to_threshold_response(view)
+
+
+async def set_threshold(
+    ctx: RequestContext,
+    body: SetForesightThresholdRequest,
+) -> ForesightThresholdResponse:
+    """Upsert the workspace's onboarding-gate threshold override.
+
+    PUT /api/v1/foresight/workspace/threshold backing.
+
+    ``body.threshold=None`` resets the workspace to the global default
+    (writes ``threshold_override=None`` on the doc — the doc itself
+    survives, since a "previously overridden, now reset" workspace has
+    an audit-relevant updatedAt). A float ∈ [0.5, 0.95] sets the
+    override; DTO-level bounds enforce the range so a 422 fires before
+    this function runs.
+
+    Emit semantics:
+      - When the effective value changes (override → different override,
+        override → reset, no-override → set), fire
+        ``foresight.threshold.updated`` with ``data={
+            workspace_id, threshold (new effective), is_overridden,
+            previous_threshold, previous_is_overridden,
+        }`` so listeners (UI panels, audit log) can react without a
+        round trip.
+      - A no-op write (same value as the current effective threshold)
+        does NOT emit — keeps the UI's optimistic-local-state path from
+        rebroadcasting redundant updates.
+    """
+    body = SetForesightThresholdRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+
+    previous_view = await _load_threshold_view(workspace_id)
+    new_override = body.threshold  # already validated to None or ∈ [0.5, 0.95]
+
+    # Upsert pattern — Beanie has no native upsert helper that returns
+    # the resulting doc, so split into find_one + insert / update. The
+    # workspace field is unique-indexed so a concurrent insert race
+    # would surface as a DuplicateKeyError; for v1.0's admin-only write
+    # path that race is unlikely enough to treat as a 500 (no retry
+    # loop). v1.1 can swap to Mongo's $setOnInsert if the race shows up.
+    doc = await _ForesightWorkspaceConfigDoc.find_one(
+        {"workspace": workspace_id},
+    )
+    if doc is None:
+        doc = _ForesightWorkspaceConfigDoc(
+            workspace=workspace_id,
+            threshold_override=new_override,
+        )
+        await doc.insert()
+    else:
+        doc.threshold_override = new_override
+        await doc.save()
+
+    new_view = await _load_threshold_view(workspace_id)
+    response = _to_threshold_response(new_view)
+
+    # Emit only when the effective value changed. A no-op write
+    # (e.g. PUT {"threshold": 0.7} when the override is already 0.7)
+    # stays quiet so the UI's optimistic state doesn't get echoed.
+    changed = (
+        previous_view.current_threshold != new_view.current_threshold
+        or previous_view.is_overridden != new_view.is_overridden
+    )
+    if changed:
+        await emit(
+            ForesightThresholdUpdated(
+                data={
+                    "workspace_id": workspace_id,
+                    "threshold": new_view.current_threshold,
+                    "is_overridden": new_view.is_overridden,
+                    "previous_threshold": previous_view.current_threshold,
+                    "previous_is_overridden": previous_view.is_overridden,
+                }
+            )
+        )
+    # else: no-event: idempotent write (cloud rule #9 allows this with
+    # the inline comment); the GET still returns the resolved view so
+    # the client's PUT round-trip stays useful.
+    return response
 
 
 async def _score_backtest(
@@ -1033,7 +1244,8 @@ async def create_backtest(ctx: RequestContext, body: CreateBacktestRequest) -> B
     """
     body = CreateBacktestRequest.model_validate(body)
     workspace_id = _require_workspace(ctx)
-    threshold = _resolve_threshold(body.threshold)
+    workspace_floor = await _resolve_workspace_threshold(workspace_id)
+    threshold = _resolve_threshold(body.threshold, floor=workspace_floor)
 
     # Surface engine-side scenario validation as 422 before opening a
     # doc row — the engine config carries the supported-sub-type list.
@@ -1212,12 +1424,15 @@ async def get_onboarding_gate(ctx: RequestContext) -> OnboardingGateResponse:
         quarterly recalibration shouldn't briefly close the gate
         mid-run).
 
-    The threshold echoed back is the workspace's effective floor
-    (``GATE_DEFAULT_THRESHOLD`` in v0.1; v1.0 reads a workspace-config
-    override here).
+    The threshold echoed back is the workspace's effective floor —
+    the per-workspace override when set, else the global
+    :data:`GATE_DEFAULT_THRESHOLD`. v1.0 reads the
+    :class:`pocketpaw_ee.cloud.models.foresight_workspace_config.ForesightWorkspaceConfig`
+    doc via :func:`_resolve_workspace_threshold` (which handles the
+    absent-doc and null-override cases).
     """
     workspace_id = _require_workspace(ctx)
-    threshold = GATE_DEFAULT_THRESHOLD
+    threshold = await _resolve_workspace_threshold(workspace_id)
 
     latest_complete = await (
         _ForesightBacktestDoc.find({"workspace": workspace_id, "status": "complete"})
@@ -2862,10 +3077,12 @@ __all__ = [
     "get_live_snapshot",
     "get_onboarding_gate",
     "get_scenario_run",
+    "get_threshold",
     "list_backtests",
     "list_instinct_proposals_for_run",
     "list_projected_decisions",
     "list_scenario_runs",
     "list_scenarios",
     "pair_prediction",
+    "set_threshold",
 ]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,10 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-05-26 (feat/foresight-v10-threshold-override-cloud) — added
+``ForesightWorkspaceConfig`` to the registered docs + ``__all__`` so RFC 08
+v1.0's per-workspace onboarding threshold override is wired into
+``init_beanie``. Only ``ee.cloud.foresight.service`` imports the doc class
+directly (import-linter contract).
 Updated: 2026-05-26 (feat/foresight-v10-prediction-record-persist) — added
 ``ForesightPredictionRecord`` to the registered docs + ``__all__`` so the
 RFC 08 §9 calibration buffer's Mongo persistence is wired into ``init_beanie``.
@@ -24,6 +29,9 @@ from pocketpaw_ee.cloud.models.foresight_projected_decision import (
     ForesightProjectedDecision,
 )
 from pocketpaw_ee.cloud.models.foresight_run import ForesightRun
+from pocketpaw_ee.cloud.models.foresight_workspace_config import (
+    ForesightWorkspaceConfig,
+)
 from pocketpaw_ee.cloud.models.group import Group, GroupAgent
 from pocketpaw_ee.cloud.models.invite import Invite
 from pocketpaw_ee.cloud.models.message import Attachment, Mention, Message, Reaction
@@ -71,6 +79,7 @@ __all__ = [
     "ForesightPredictionRecord",
     "ForesightProjectedDecision",
     "ForesightRun",
+    "ForesightWorkspaceConfig",
     "Group",
     "GroupAgent",
     "Invite",
@@ -128,6 +137,7 @@ def get_all_documents():
         ForesightBacktest,
         ForesightProjectedDecision,
         ForesightPredictionRecord,
+        ForesightWorkspaceConfig,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/models/foresight_workspace_config.py
+++ b/ee/pocketpaw_ee/cloud/models/foresight_workspace_config.py
@@ -1,0 +1,64 @@
+# ee/pocketpaw_ee/cloud/models/foresight_workspace_config.py
+# Created: 2026-05-26 (feat/foresight-v10-threshold-override-cloud) —
+# RFC 08 v1.0. Per-workspace Foresight configuration. v1.0 ships with one
+# overridable knob — the onboarding gate threshold — but the doc shape is
+# designed so subsequent workspace-scoped foresight settings (default
+# scenario sub_type, notification routing, default insight cap) layer on
+# without churning the workspace ``Workspace`` document (RFC 03 keeps
+# domain-specific config in domain-owned docs).
+#
+# One row per workspace; an upsert key on ``workspace`` makes the
+# read/write paths idempotent (the service's ``set_threshold`` uses
+# ``find_one_and_update`` semantics rather than insert-or-error).
+#
+# Only ``ee.cloud.foresight.service`` may import this module — enforced
+# by the import-linter contract in ``ee/pyproject.toml`` (same contract
+# that scopes ForesightRun / ForesightBacktest writes to service.py).
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class ForesightWorkspaceConfig(TimestampedDocument):
+    """Per-workspace Foresight configuration overrides.
+
+    Fields:
+      - ``workspace`` — tenancy key. Indexed unique so ``find_one``
+        / upsert remains O(1).
+      - ``threshold_override`` — when not ``None``, the workspace's
+        effective onboarding-gate threshold. Read by
+        ``get_onboarding_gate`` and by the backtest scorer
+        (``create_backtest``) so a workspace that has tightened the bar
+        sees ALL gate-scoping reads use the override. Constrained at
+        the DTO layer (0.5–0.95 inclusive); the doc stores the raw float
+        because a future bump of the floor must not retroactively
+        invalidate stored overrides — the DTO validator is the single
+        source of truth for the legal range at write time.
+      - ``createdAt`` / ``updatedAt`` — inherited from
+        :class:`TimestampedDocument`. ``updatedAt`` doubles as the
+        "when did the admin last touch this" timestamp the GET response
+        exposes to the UI.
+
+    v1.0 ships threshold-only. v1.1 candidates:
+      - ``default_sub_type: str`` — the sub_type the new-scenario wizard
+        opens on.
+      - ``notification_routing: dict[str, str]`` — channel routing for
+        backtest-completed / onboarding-unlocked.
+      - ``insight_cap: int`` — per-call cap on synthesizer insights.
+
+    The shape is therefore extension-additive; new optional fields with
+    ``None`` defaults won't break callers reading the v1.0 wire dict.
+    """
+
+    workspace: Indexed(str, unique=True)  # type: ignore[valid-type]
+    threshold_override: float | None = Field(default=None)
+
+    class Settings:
+        name = "foresight_workspace_configs"
+        # ``workspace`` already has a unique single-field index from the
+        # ``Indexed(..., unique=True)`` annotation; the upsert path uses it
+        # directly. No composite indexes needed in v1.0.

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -390,6 +390,7 @@ forbidden_modules = [
     "pocketpaw_ee.cloud.models.foresight_backtest",
     "pocketpaw_ee.cloud.models.foresight_projected_decision",
     "pocketpaw_ee.cloud.models.foresight_prediction_record",
+    "pocketpaw_ee.cloud.models.foresight_workspace_config",
 ]
 
 [[tool.importlinter.contracts]]
@@ -413,6 +414,7 @@ source_modules = [
     "pocketpaw_ee.cloud.models.foresight_backtest",
     "pocketpaw_ee.cloud.models.foresight_projected_decision",
     "pocketpaw_ee.cloud.models.foresight_prediction_record",
+    "pocketpaw_ee.cloud.models.foresight_workspace_config",
 ]
 forbidden_modules = [
     "pocketpaw_ee.foresight.persona",

--- a/tests/cloud/test_foresight_threshold.py
+++ b/tests/cloud/test_foresight_threshold.py
@@ -1,0 +1,445 @@
+# tests/cloud/test_foresight_threshold.py — RFC 08 v1.0 PR 10.
+# Created: 2026-05-26 (feat/foresight-v10-threshold-override-cloud).
+# Service- + router-level tests for the per-workspace onboarding-gate
+# threshold override surface. Exercises:
+#   - GET without override → default view collapses to 0.65 / not
+#     overridden / updated_at=null
+#   - GET with override → echoes the override value + updated_at
+#   - PUT (set valid) → upserts the doc, emits the event, GET reflects
+#   - PUT (set null) → resets the override but keeps the doc (audit
+#     trail), emits the event
+#   - PUT idempotent (same value) → no event emitted
+#   - PUT out-of-bounds (< 0.5 or > 0.95) → 422 from DTO validation
+#   - PUT bad shape → 422 from FastAPI
+#   - Cross-tenant isolation: an override in w1 must NOT bleed into w2
+#   - Tenancy 403: GET / PUT with no workspace → Forbidden
+"""Tests for ``ee.cloud.foresight.service`` threshold override API."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud._core.realtime.events import ForesightThresholdUpdated
+from pocketpaw_ee.cloud.foresight import service as foresight_service
+from pocketpaw_ee.cloud.foresight.dto import SetForesightThresholdRequest
+from pocketpaw_ee.cloud.foresight.router import router as foresight_router
+from pocketpaw_ee.cloud.license import require_license
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace: str | None = "w1", user: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Service-level: get_threshold
+# ---------------------------------------------------------------------------
+
+
+async def test_get_threshold_no_override_returns_default() -> None:
+    """Fresh workspace — no config doc — collapses to the default view."""
+    ctx = _ctx(workspace="fresh-ws")
+    out = await foresight_service.get_threshold(ctx)
+    assert out.workspace_id == "fresh-ws"
+    assert out.current_threshold == pytest.approx(0.65)
+    assert out.default_threshold == pytest.approx(0.65)
+    assert out.is_overridden is False
+    assert out.updated_at is None
+
+
+async def test_get_threshold_with_override_reports_override() -> None:
+    ctx = _ctx(workspace="tight-ws")
+    await foresight_service.set_threshold(ctx, SetForesightThresholdRequest(threshold=0.80))
+    out = await foresight_service.get_threshold(ctx)
+    assert out.workspace_id == "tight-ws"
+    assert out.current_threshold == pytest.approx(0.80)
+    assert out.default_threshold == pytest.approx(0.65)
+    assert out.is_overridden is True
+    assert out.updated_at is not None
+    # ISO-8601 surface — string with timezone info
+    assert "T" in out.updated_at
+
+
+async def test_get_threshold_requires_workspace() -> None:
+    ctx = _ctx(workspace=None)
+    with pytest.raises(Forbidden):
+        await foresight_service.get_threshold(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Service-level: set_threshold
+# ---------------------------------------------------------------------------
+
+
+async def test_set_threshold_creates_doc_and_emits(recording_bus) -> None:
+    ctx = _ctx(workspace="set-ws")
+    out = await foresight_service.set_threshold(ctx, SetForesightThresholdRequest(threshold=0.75))
+    assert out.current_threshold == pytest.approx(0.75)
+    assert out.is_overridden is True
+    assert out.updated_at is not None
+
+    # Event fires on the create transition.
+    events = [e for e in recording_bus.events if isinstance(e, ForesightThresholdUpdated)]
+    assert len(events) == 1
+    payload = events[0].data
+    assert payload["workspace_id"] == "set-ws"
+    assert payload["threshold"] == pytest.approx(0.75)
+    assert payload["is_overridden"] is True
+    assert payload["previous_threshold"] == pytest.approx(0.65)
+    assert payload["previous_is_overridden"] is False
+
+
+async def test_set_threshold_update_emits_with_previous(recording_bus) -> None:
+    ctx = _ctx(workspace="update-ws")
+    await foresight_service.set_threshold(ctx, SetForesightThresholdRequest(threshold=0.70))
+    # Drain the first event so we only assert on the second transition.
+    recording_bus.events.clear()
+    out = await foresight_service.set_threshold(ctx, SetForesightThresholdRequest(threshold=0.85))
+    assert out.current_threshold == pytest.approx(0.85)
+
+    events = [e for e in recording_bus.events if isinstance(e, ForesightThresholdUpdated)]
+    assert len(events) == 1
+    payload = events[0].data
+    assert payload["threshold"] == pytest.approx(0.85)
+    assert payload["previous_threshold"] == pytest.approx(0.70)
+    assert payload["previous_is_overridden"] is True
+
+
+async def test_set_threshold_null_resets_to_default(recording_bus) -> None:
+    ctx = _ctx(workspace="reset-ws")
+    await foresight_service.set_threshold(ctx, SetForesightThresholdRequest(threshold=0.80))
+    recording_bus.events.clear()
+
+    out = await foresight_service.set_threshold(ctx, SetForesightThresholdRequest(threshold=None))
+    assert out.current_threshold == pytest.approx(0.65)
+    assert out.is_overridden is False
+    assert out.updated_at is None  # reset → no meaningful "override updated" timestamp
+
+    # GET right after PUT reflects the reset.
+    follow_up = await foresight_service.get_threshold(ctx)
+    assert follow_up.is_overridden is False
+    assert follow_up.current_threshold == pytest.approx(0.65)
+
+    # Event fires for the reset.
+    events = [e for e in recording_bus.events if isinstance(e, ForesightThresholdUpdated)]
+    assert len(events) == 1
+    payload = events[0].data
+    assert payload["threshold"] == pytest.approx(0.65)
+    assert payload["is_overridden"] is False
+    assert payload["previous_is_overridden"] is True
+
+
+async def test_set_threshold_noop_does_not_emit(recording_bus) -> None:
+    """Writing the same value twice should not emit a second event.
+
+    Keeps the UI's optimistic local state from rebroadcasting redundant
+    updates.
+    """
+    ctx = _ctx(workspace="noop-ws")
+    await foresight_service.set_threshold(ctx, SetForesightThresholdRequest(threshold=0.72))
+    recording_bus.events.clear()
+
+    out = await foresight_service.set_threshold(ctx, SetForesightThresholdRequest(threshold=0.72))
+    assert out.current_threshold == pytest.approx(0.72)
+
+    events = [e for e in recording_bus.events if isinstance(e, ForesightThresholdUpdated)]
+    assert events == []
+
+
+async def test_set_threshold_null_when_already_default_is_noop(recording_bus) -> None:
+    """Reset on a fresh workspace (no doc) should be a no-op emit-wise."""
+    ctx = _ctx(workspace="already-default-ws")
+    out = await foresight_service.set_threshold(ctx, SetForesightThresholdRequest(threshold=None))
+    assert out.is_overridden is False
+    assert out.current_threshold == pytest.approx(0.65)
+
+    events = [e for e in recording_bus.events if isinstance(e, ForesightThresholdUpdated)]
+    assert events == []
+
+
+async def test_set_threshold_isolates_across_workspaces() -> None:
+    """An override in w1 must NOT bleed into w2."""
+    ctx_w1 = _ctx(workspace="w1")
+    ctx_w2 = _ctx(workspace="w2")
+    await foresight_service.set_threshold(ctx_w1, SetForesightThresholdRequest(threshold=0.85))
+
+    view_w1 = await foresight_service.get_threshold(ctx_w1)
+    view_w2 = await foresight_service.get_threshold(ctx_w2)
+    assert view_w1.current_threshold == pytest.approx(0.85)
+    assert view_w1.is_overridden is True
+    assert view_w2.current_threshold == pytest.approx(0.65)
+    assert view_w2.is_overridden is False
+
+
+async def test_set_threshold_requires_workspace() -> None:
+    ctx = _ctx(workspace=None)
+    with pytest.raises(Forbidden):
+        await foresight_service.set_threshold(ctx, SetForesightThresholdRequest(threshold=0.70))
+
+
+# ---------------------------------------------------------------------------
+# Service-level: gate + backtest wire-through (the load-bearing change)
+# ---------------------------------------------------------------------------
+
+
+async def test_onboarding_gate_uses_workspace_threshold() -> None:
+    """``get_onboarding_gate`` must echo the workspace's effective threshold."""
+    ctx = _ctx(workspace="gate-ws")
+    # No override yet — gate reads the default.
+    gate = await foresight_service.get_onboarding_gate(ctx)
+    assert gate.threshold == pytest.approx(0.65)
+
+    # Set override; gate now reads the override.
+    await foresight_service.set_threshold(ctx, SetForesightThresholdRequest(threshold=0.78))
+    gate = await foresight_service.get_onboarding_gate(ctx)
+    assert gate.threshold == pytest.approx(0.78)
+
+    # Reset; gate falls back to default.
+    await foresight_service.set_threshold(ctx, SetForesightThresholdRequest(threshold=None))
+    gate = await foresight_service.get_onboarding_gate(ctx)
+    assert gate.threshold == pytest.approx(0.65)
+
+
+async def test_create_backtest_uses_workspace_override(monkeypatch) -> None:
+    """The per-run threshold is resolved against the workspace floor.
+
+    A workspace that has tightened the floor to 0.80 must reject a
+    per-run request below 0.80 even though the global default is 0.65.
+    """
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+    from pocketpaw_ee.cloud.foresight.dto import (
+        CreateBacktestRequest,
+        HistoricalAnchorRequest,
+        PersonaSpecRequest,
+    )
+
+    ctx = _ctx(workspace="strict-ws")
+    await foresight_service.set_threshold(ctx, SetForesightThresholdRequest(threshold=0.80))
+
+    body = CreateBacktestRequest(
+        name="bt",
+        sub_type="decision_forecast",
+        n_ticks=1,
+        personas=[PersonaSpecRequest(name="A", role="approver", ocean={})],
+        anchors=[
+            HistoricalAnchorRequest(
+                anchor_object_id="lease:1",
+                actual_outcome={"outcome": "accept"},
+            )
+        ],
+        threshold=0.70,  # above the global default 0.65 but below the workspace 0.80
+    )
+    with pytest.raises(ValidationError) as exc:
+        await foresight_service.create_backtest(ctx, body)
+    assert "0.8" in str(exc.value.message)
+
+    # A passing request — at or above 0.80 — is accepted; we stub the
+    # scorer so the engine path stays out of the way (this PR's focus
+    # is the threshold-resolution wiring).
+    async def _passing_scorer(_body, *, engine_result, threshold, **_kwargs):
+        return (
+            {"modal_accuracy": 0.9, "n_pairs": 10},
+            {
+                "passed": True,
+                "observed": 0.9,
+                "threshold": threshold,
+                "margin": 0.1,
+                "n_pairs": 10,
+            },
+        )
+
+    monkeypatch.setattr(foresight_service, "_score_backtest", _passing_scorer)
+    body_ok = body.model_copy(update={"threshold": 0.85})
+    out = await foresight_service.create_backtest(ctx, body_ok)
+    assert out.threshold == pytest.approx(0.85)
+    # gate_decision threshold should also reflect the effective value the
+    # backtest scored against — Cloud-side wire-through.
+    assert out.gate_decision is not None
+    assert out.gate_decision.threshold == pytest.approx(0.85)
+
+
+async def test_create_backtest_defaults_to_workspace_threshold(monkeypatch) -> None:
+    """When the body omits ``threshold``, the run uses the workspace floor.
+
+    Backward compat: a workspace with no override still defaults to 0.65.
+    """
+    from pocketpaw_ee.cloud.foresight.dto import (
+        CreateBacktestRequest,
+        HistoricalAnchorRequest,
+        PersonaSpecRequest,
+    )
+
+    async def _passing_scorer(_body, *, engine_result, threshold, **_kwargs):
+        return (
+            {"modal_accuracy": 0.9, "n_pairs": 10},
+            {
+                "passed": True,
+                "observed": 0.9,
+                "threshold": threshold,
+                "margin": threshold,
+                "n_pairs": 10,
+            },
+        )
+
+    monkeypatch.setattr(foresight_service, "_score_backtest", _passing_scorer)
+
+    ctx_default = _ctx(workspace="default-ws")
+    body = CreateBacktestRequest(
+        name="bt",
+        sub_type="decision_forecast",
+        n_ticks=1,
+        personas=[PersonaSpecRequest(name="A", role="approver", ocean={})],
+        anchors=[
+            HistoricalAnchorRequest(
+                anchor_object_id="lease:1",
+                actual_outcome={"outcome": "accept"},
+            )
+        ],
+    )
+    out_default = await foresight_service.create_backtest(ctx_default, body)
+    assert out_default.threshold == pytest.approx(0.65)
+
+    ctx_override = _ctx(workspace="override-ws")
+    await foresight_service.set_threshold(
+        ctx_override, SetForesightThresholdRequest(threshold=0.75)
+    )
+    out_override = await foresight_service.create_backtest(ctx_override, body)
+    assert out_override.threshold == pytest.approx(0.75)
+
+
+# ---------------------------------------------------------------------------
+# Router-level: HTTP wiring
+# ---------------------------------------------------------------------------
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(foresight_router)
+
+    async def _ctx_dep() -> RequestContext:
+        return _ctx(workspace_id, user_id)
+
+    app.dependency_overrides[request_context] = _ctx_dep
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def http_client_w1(mongo_db: Any) -> AsyncClient:
+    app = _build_app(workspace_id="w1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+async def test_get_threshold_endpoint_returns_default(
+    http_client_w1: AsyncClient,
+) -> None:
+    resp = await http_client_w1.get("/foresight/workspace/threshold")
+    assert resp.status_code == 200
+    body = resp.json()
+    # Contract field set must match what paw-enterprise Team A2 builds against.
+    assert set(body.keys()) == {
+        "workspace_id",
+        "current_threshold",
+        "default_threshold",
+        "is_overridden",
+        "updated_at",
+    }
+    assert body["workspace_id"] == "w1"
+    assert body["current_threshold"] == pytest.approx(0.65)
+    assert body["default_threshold"] == pytest.approx(0.65)
+    assert body["is_overridden"] is False
+    assert body["updated_at"] is None
+
+
+async def test_put_threshold_endpoint_sets_and_get_reflects(
+    http_client_w1: AsyncClient,
+) -> None:
+    put_resp = await http_client_w1.put(
+        "/foresight/workspace/threshold",
+        json={"threshold": 0.82},
+    )
+    assert put_resp.status_code == 200
+    payload = put_resp.json()
+    assert payload["current_threshold"] == pytest.approx(0.82)
+    assert payload["is_overridden"] is True
+    assert payload["updated_at"] is not None
+
+    follow = await http_client_w1.get("/foresight/workspace/threshold")
+    assert follow.status_code == 200
+    assert follow.json()["current_threshold"] == pytest.approx(0.82)
+
+
+async def test_put_threshold_endpoint_reset_with_null(
+    http_client_w1: AsyncClient,
+) -> None:
+    # Seed an override first.
+    await http_client_w1.put("/foresight/workspace/threshold", json={"threshold": 0.80})
+    resp = await http_client_w1.put("/foresight/workspace/threshold", json={"threshold": None})
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["is_overridden"] is False
+    assert payload["current_threshold"] == pytest.approx(0.65)
+    assert payload["updated_at"] is None
+
+
+async def test_put_threshold_endpoint_out_of_bounds_422(
+    http_client_w1: AsyncClient,
+) -> None:
+    """DTO-level bounds validation: 422 with a clear error code."""
+    for bad in (0.49, 0.96, -1.0, 1.5):
+        resp = await http_client_w1.put("/foresight/workspace/threshold", json={"threshold": bad})
+        assert resp.status_code == 422, f"expected 422 for threshold={bad}, got {resp.status_code}"
+
+
+async def test_put_threshold_endpoint_malformed_body_400_or_422(
+    http_client_w1: AsyncClient,
+) -> None:
+    """Extra fields are forbidden by the DTO; FastAPI surfaces 422.
+
+    Different malformed shapes can surface as 400 or 422 depending on
+    the parsing stage; both are valid HTTP error codes for the contract.
+    """
+    resp = await http_client_w1.put(
+        "/foresight/workspace/threshold",
+        json={"threshold": 0.7, "unknown_field": "bad"},
+    )
+    assert resp.status_code in (400, 422)
+
+
+async def test_cross_tenant_isolation_via_http(mongo_db: Any) -> None:
+    """An override set under w1 must not leak into w2."""
+    # Set under w1.
+    app_w1 = _build_app(workspace_id="w1")
+    transport_w1 = ASGITransport(app=app_w1)
+    async with AsyncClient(transport=transport_w1, base_url="http://test") as c1:
+        resp = await c1.put("/foresight/workspace/threshold", json={"threshold": 0.88})
+        assert resp.status_code == 200
+
+    # Read under w2.
+    app_w2 = _build_app(workspace_id="w2")
+    transport_w2 = ASGITransport(app=app_w2)
+    async with AsyncClient(transport=transport_w2, base_url="http://test") as c2:
+        resp = await c2.get("/foresight/workspace/threshold")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["workspace_id"] == "w2"
+        assert body["is_overridden"] is False
+        assert body["current_threshold"] == pytest.approx(0.65)


### PR DESCRIPTION
## Summary

Lets workspace admins persist an onboarding-gate threshold override above the global 0.65 floor. Two endpoints on the foresight cloud router; the override is read by `get_onboarding_gate` and by `create_backtest` so every gate-scoping path sees the same effective value.

Locked contract (Team A2 paw-enterprise settings panel builds against this):

```
GET /api/v1/foresight/workspace/threshold
→ ForesightThresholdResponse {
    workspace_id: str,
    current_threshold: float,    // override when set, else default
    default_threshold: float,    // 0.65 (GATE_DEFAULT_THRESHOLD)
    is_overridden: bool,
    updated_at: datetime | null  // null when is_overridden=False
  }

PUT /api/v1/foresight/workspace/threshold
  Body: { threshold: float | null }   // [0.5, 0.95] sets; null resets
→ ForesightThresholdResponse (same shape, post-write)
```

## Changes

**Persistence — new Beanie doc.** `ForesightWorkspaceConfig` at `ee/pocketpaw_ee/cloud/models/foresight_workspace_config.py` with `(workspace, threshold_override, createdAt, updatedAt)`. Kept it in foresight's domain rather than extending the cross-cutting `WorkspaceSettings` model — foresight already owns four collections, and a future foresight-config knob (default sub_type, notification routing, insight cap) can layer on without touching the global workspace doc. Registered in `ALL_DOCUMENTS` and pinned to `service.py` via the import-linter contract.

**Service.** Two new public functions plus two private helpers (`_load_threshold_view`, `_resolve_workspace_threshold`). `_resolve_threshold` (the per-run backtest tightening check) now takes the workspace floor as a kwarg so a workspace tightened to 0.80 will reject a per-run 0.70 request even though the global default is 0.65. `get_onboarding_gate` reads the workspace floor via the helper.

**Router.** Two endpoints under the existing `/foresight` router. PUT body validation (`[0.5, 0.95]`) lives on the DTO so 422s fire before the service runs.

**Event.** `ForesightThresholdUpdated` (`foresight.threshold.updated`) fires whenever the effective value changes; no-op writes stay quiet so an optimistic UI store doesn't get redundant rebroadcasts.

**Backward-compat.** A workspace with no override returns `current_threshold=0.65` and `is_overridden=false`. The legacy `GATE_DEFAULT_THRESHOLD` constant is unchanged. Backtests scored under the old code path keep their persisted threshold value (the doc stores the value scored against, not the live workspace floor).

## Test plan

- [x] 19 new tests in `tests/cloud/test_foresight_threshold.py`
- [x] GET (no override / with override / no workspace → 403)
- [x] PUT (valid set / reset to null / no-op idempotent / bounds violation → 422 / extra field → 422)
- [x] Cross-tenant isolation (HTTP-level + service-level)
- [x] `get_onboarding_gate` echoes the workspace-effective threshold
- [x] `create_backtest` rejects per-run threshold below workspace floor; uses workspace floor as default; scores against the resolved value
- [x] Event payload contains `previous_threshold` + `previous_is_overridden` for audit
- [x] All 216 existing foresight cloud + 273 engine tests still pass
- [x] 18 import-linter contracts still pass
- [x] ruff check + format + targeted mypy clean (2 pre-existing untyped-import warnings on `pocketpaw.instinct.*` lazy imports, unchanged by this PR)

## Notes

- Targets the `foresight` integration branch, not `dev` or `main`.
- DO NOT merge — captain reviews the foresight v1.0 stack as a unit.
- Team A2 paw-enterprise settings panel builds against the locked DTO shape above.