### PR TITLE
feat(foresight): RFC 08 v1.0 — opt-in LLM-driven insights synthesizer

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -505,6 +505,17 @@ class ForesightThresholdUpdated(Event):
     EVENT_TYPE: ClassVar[str] = "foresight.threshold.updated"
 
 
+# Foresight insights-synthesizer config — RFC 08 v1.0 (LLM insights PR).
+# Fires when an admin flips the workspace's synthesizer choice between
+# "pattern" (the v0.5 deterministic synthesizer) and "llm" (the v1.0
+# LLM-driven synthesizer with a hard fallback). Listeners can clear
+# any per-workspace LLM insight cache and refresh the Insights panel
+# without polling.
+@dataclass
+class ForesightInsightsConfigUpdated(Event):
+    EVENT_TYPE: ClassVar[str] = "foresight.insights_config.updated"
+
+
 # Foresight per-anchor projection fanout — RFC 08 §7.7 + PR 5. Fires
 # once per (anchor × tick) bucket as the engine ticks the run forward;
 # the UI's Live panel consumes these to render the projection timeline

--- a/ee/pocketpaw_ee/cloud/foresight/domain.py
+++ b/ee/pocketpaw_ee/cloud/foresight/domain.py
@@ -1,4 +1,9 @@
 # ee/pocketpaw_ee/cloud/foresight/domain.py
+# Updated: 2026-05-26 (feat/foresight-v10-insights-llm) — RFC 08 v1.0
+# adds ``InsightsConfigView`` for the per-workspace LLM-vs-pattern
+# synthesizer toggle. Workspace-scoped at construction per cloud rule
+# #3 — ``workspace_id`` is required positionally. The view mirrors the
+# DTO field-for-field so the service maps via Pydantic per cloud rule #8.
 # Updated: 2026-05-26 (feat/foresight-v10-scenario-editor-backend) — RFC 08
 # v1.0 wave 3 — adds workspace-scoped custom-scenario domain shapes:
 #   - ``CustomScenario`` — frozen value object mirroring the persisted
@@ -504,11 +509,46 @@ class ThresholdOverrideView:
 
 
 # ---------------------------------------------------------------------------
+# Per-workspace insights-synthesizer config view (RFC 08 v1.0 — LLM
+# insights PR). Workspace-scoped at construction per cloud rule #3.
+# Mirrors :class:`pocketpaw_ee.cloud.foresight.dto.ForesightInsightsConfigResponse`
+# field-for-field so the service maps via Pydantic's
+# ``model_validate(..., from_attributes=True)`` per cloud rule #8.
+#
 # Custom scenarios (RFC 08 v1.0 wave 3) — workspace-owned scenario YAML
 # storage. Sibling shape to ``ScenarioCatalogEntry`` (which enumerates
 # the bundled engine templates); ``CustomScenario`` is the persisted
 # operator-authored record.
 # ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InsightsConfigView:
+    """The workspace's resolved insights-synthesizer configuration.
+
+    Composed by the service from
+    :class:`pocketpaw_ee.cloud.models.foresight_workspace_config.ForesightWorkspaceConfig`
+    plus the module constants from ``ee.foresight.insights_llm``. The
+    view is derived (recomputed on every GET / PUT) rather than a
+    persisted snapshot.
+
+    Fields:
+      - ``workspace_id``: tenancy key (required positional per cloud
+        rule #3).
+      - ``synthesizer``: ``"pattern"`` (the v0.5 deterministic five-rule
+        synthesizer; default) or ``"llm"`` (the v1.0 LLM-driven
+        synthesizer with a hard fallback to ``pattern`` on LLM failure).
+      - ``llm_cache_ttl_seconds``: the in-memory LRU TTL for the LLM
+        synthesizer. v1.0 echoes the module constant; v1.1 will expose
+        it as a per-workspace override.
+      - ``updated_at``: when the config row was last written; None when
+        no row exists.
+    """
+
+    workspace_id: str
+    synthesizer: Literal["pattern", "llm"]
+    llm_cache_ttl_seconds: int
+    updated_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -568,6 +608,7 @@ __all__ = [
     "CustomScenario",
     "CustomScenarioParsedMeta",
     "InsightView",
+    "InsightsConfigView",
     "LiveAnomaly",
     "LiveSampledTrace",
     "LiveSnapshotView",

--- a/ee/pocketpaw_ee/cloud/foresight/dto.py
+++ b/ee/pocketpaw_ee/cloud/foresight/dto.py
@@ -946,6 +946,74 @@ class SetForesightThresholdRequest(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Per-workspace insights-synthesizer config (RFC 08 v1.0 — LLM insights PR).
+#
+# Companion endpoint to the threshold override above. Same shape pattern
+# (separate request / response with explicit field bounds) so the
+# settings panel can read + write each knob independently. The synthesizer
+# choice defaults to "pattern" — the v0.5 deterministic synthesizer
+# stays as the default. Workspaces opt into "llm" explicitly via the
+# PUT body.
+# ---------------------------------------------------------------------------
+
+
+class ForesightInsightsConfigResponse(BaseModel):
+    """Response shape for both
+    ``GET /api/v1/foresight/workspace/insights-config`` and
+    ``PUT /api/v1/foresight/workspace/insights-config``.
+
+    Fields:
+      - ``workspace_id``: tenancy key (echoed for client-side
+        bookkeeping).
+      - ``synthesizer``: ``"pattern"`` (default — the v0.5 deterministic
+        five-rule synthesizer) or ``"llm"`` (the v1.0 LLM-driven
+        synthesizer; opt-in only). LLM failures fall back to the
+        pattern synthesizer so the wire response never 5xxs.
+      - ``llm_cache_ttl_seconds``: the in-memory LRU TTL the LLM
+        synthesizer applies to its per-workspace cache. v1.0 echoes the
+        module constant (300 seconds) so the UI can render the cost-
+        discipline note without round-tripping a separate read.
+      - ``updated_at``: ISO-8601 UTC timestamp of the last config write.
+        ``None`` when no config row exists for the workspace.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_id: str
+    synthesizer: Literal["pattern", "llm"]
+    llm_cache_ttl_seconds: int = Field(..., ge=1)
+    updated_at: str | None = None
+
+
+class SetForesightInsightsConfigRequest(BaseModel):
+    """``PUT /api/v1/foresight/workspace/insights-config`` body.
+
+    Single-field shape:
+
+    - ``synthesizer: Literal["pattern", "llm"]`` — the synthesizer the
+      workspace's ``/insights`` endpoint runs by default. ``"pattern"``
+      keeps the v0.5 deterministic five-rule synthesizer; ``"llm"`` opts
+      into the LLM-driven synthesizer.
+
+    Bounds rationale:
+      - The Literal forbids the third-state ``None`` / unknown values so
+        a typo (``"LLM"``, ``"ai"``) gets 422'd at the DTO layer rather
+        than silently coerced.
+      - The LLM path has a hard fallback to ``pattern`` on failure
+        (timeouts, malformed JSON, etc.) so a workspace stuck on "llm"
+        during an outage still gets pattern-rule insights.
+
+    The service emits ``foresight.insights_config.updated`` whenever
+    the effective synthesizer changes. A no-op write (same value)
+    stays quiet so the UI's optimistic local state doesn't echo.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    synthesizer: Literal["pattern", "llm"]
+
+
+# ---------------------------------------------------------------------------
 # Custom scenarios (Team 1 wave 3) — workspace-scoped scenario YAML
 # storage + CRUD wire shapes (RFC 08 v1.0).
 #
@@ -1098,6 +1166,7 @@ __all__ = [
     "CustomScenarioParsedMetaDto",
     "CustomScenarioResponse",
     "CustomScenarioSubType",
+    "ForesightInsightsConfigResponse",
     "ForesightInstinctProposalListResponse",
     "ForesightInstinctProposalResponse",
     "ForesightThresholdResponse",
@@ -1119,6 +1188,7 @@ __all__ = [
     "ScenarioCatalogResponse",
     "ScenarioRunListItemResponse",
     "ScenarioRunResponse",
+    "SetForesightInsightsConfigRequest",
     "SetForesightThresholdRequest",
     "TierMixActual",
 ]

--- a/ee/pocketpaw_ee/cloud/foresight/router.py
+++ b/ee/pocketpaw_ee/cloud/foresight/router.py
@@ -1,4 +1,18 @@
 # ee/pocketpaw_ee/cloud/foresight/router.py
+# Modified: 2026-05-26 (feat/foresight-v10-insights-llm) — RFC 08 v1.0.
+# LLM-driven insights synthesizer toggle:
+#     GET /api/v1/foresight/workspace/insights-config
+#       → ForesightInsightsConfigResponse (synthesizer +
+#         llm_cache_ttl_seconds + updated_at). Workspace-scoped; an
+#         absent config collapses to the default (synthesizer="pattern").
+#     PUT /api/v1/foresight/workspace/insights-config
+#       Body: { synthesizer: "pattern" | "llm" } — opts the workspace
+#         into the LLM synthesizer (default stays "pattern"). 422 on
+#         unknown synthesizer value (DTO-level enforcement); emits
+#         ``foresight.insights_config.updated`` on effective change.
+#   Both routes delegate to ``ee.cloud.foresight.service`` per cloud
+#   rule #2. The /insights endpoint signature is UNCHANGED — only the
+#   synthesizer implementation behind it swaps.
 # Modified: 2026-05-26 (feat/foresight-v10-scenario-editor-backend) —
 # RFC 08 v1.0 wave 3 adds the workspace-scoped custom-scenario CRUD:
 #     GET    /api/v1/foresight/scenarios/custom
@@ -124,6 +138,7 @@ from pocketpaw_ee.cloud.foresight.dto import (
     CreateScenarioRequest,
     CustomScenarioListResponse,
     CustomScenarioResponse,
+    ForesightInsightsConfigResponse,
     ForesightInstinctProposalListResponse,
     ForesightThresholdResponse,
     InsightsResponse,
@@ -133,6 +148,7 @@ from pocketpaw_ee.cloud.foresight.dto import (
     ScenarioCatalogResponse,
     ScenarioRunListItemResponse,
     ScenarioRunResponse,
+    SetForesightInsightsConfigRequest,
     SetForesightThresholdRequest,
 )
 from pocketpaw_ee.cloud.license import require_license
@@ -554,8 +570,76 @@ async def set_workspace_threshold(
 
 
 # ---------------------------------------------------------------------------
-# Workspace-scoped custom scenarios (RFC 08 v1.0 wave 3)
+# Per-workspace insights-synthesizer toggle (RFC 08 v1.0 — LLM insights PR)
+#
+# Sibling endpoint to the threshold pair above. Workspaces opt into the
+# LLM synthesizer here; the wire shape of /insights is unchanged either
+# way (the toggle only swaps the synthesizer implementation behind the
+# endpoint). Default stays ``"pattern"`` — cost discipline: the LLM
+# path is opt-in, deterministic pattern rules stay free.
+#
+# Workspace-scoped custom scenarios (RFC 08 v1.0 wave 3) follow below.
 # ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/workspace/insights-config",
+    response_model=ForesightInsightsConfigResponse,
+)
+async def get_workspace_insights_config(
+    ctx: RequestContext = Depends(request_context),
+) -> ForesightInsightsConfigResponse:
+    """Return the workspace's resolved insights-synthesizer config.
+
+    Workspace-scoped — the view is intrinsically per-workspace and an
+    absent config collapses to the default (``synthesizer="pattern"``,
+    ``llm_cache_ttl_seconds=300``, ``updated_at=null``). No
+    cross-tenant read possible.
+
+    Tenancy: 403 when the caller has no active workspace. Never 404.
+
+    paw-enterprise builds the Foresight admin panel against this read
+    so the settings UI can show the current toggle plus the LLM cache
+    TTL note without a hard-coded constant.
+    """
+    return await foresight_service.get_insights_config(ctx)
+
+
+@router.put(
+    "/workspace/insights-config",
+    response_model=ForesightInsightsConfigResponse,
+)
+async def set_workspace_insights_config(
+    body: SetForesightInsightsConfigRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> ForesightInsightsConfigResponse:
+    """Upsert the workspace's insights-synthesizer choice.
+
+    ``body.synthesizer = "pattern"`` keeps the v0.5 deterministic
+    five-rule synthesizer (default). ``body.synthesizer = "llm"`` opts
+    into the v1.0 LLM-driven synthesizer; LLM failures fall back to
+    pattern at runtime so the wire response never 5xxs.
+
+    Returns the same response shape as the GET so the UI can keep its
+    local store in sync with one round trip.
+
+    Side effects:
+      - Upserts the
+        :class:`pocketpaw_ee.cloud.models.foresight_workspace_config.ForesightWorkspaceConfig`
+        doc keyed by ``workspace_id``.
+      - Emits ``foresight.insights_config.updated`` when the effective
+        synthesizer changes; a no-op write (same value) stays quiet.
+
+    Tenancy: 403 when no active workspace. The toggle applies to ALL
+    future ``GET /api/v1/foresight/insights`` reads.
+
+    Cost discipline: opting into the LLM synthesizer triggers per-poll
+    LLM round-trips (cached per workspace with a 5-minute TTL). The
+    pattern synthesizer is deterministic and free; workspaces should
+    only flip to "llm" when the operator wants richer pattern
+    discovery and accepts the LLM cost.
+    """
+    return await foresight_service.set_insights_config(ctx, body)
 
 
 @router.get(

--- a/ee/pocketpaw_ee/cloud/foresight/service.py
+++ b/ee/pocketpaw_ee/cloud/foresight/service.py
@@ -1,4 +1,24 @@
 # ee/pocketpaw_ee/cloud/foresight/service.py
+# Updated: 2026-05-26 (feat/foresight-v10-insights-llm) — RFC 08 v1.0.
+# LLM-driven insights synthesizer + per-workspace synthesizer toggle:
+#   - ``get_insights(ctx)`` extended — reads the workspace's
+#     ``insights_synthesizer`` config ("pattern" | "llm", default
+#     "pattern") and either delegates to the v0.5 pattern synthesizer
+#     (unchanged) OR to the new LLM synthesizer
+#     (``ee.foresight.insights_llm.synthesize_insights_llm``). LLM
+#     failures (timeout, malformed output, rate-limit) fall back to the
+#     pattern synthesizer + log a structured warning so the wire
+#     response never 5xxs. Wire shape (``InsightsResponse``) unchanged.
+#   - New ``get_insights_config(ctx)`` / ``set_insights_config(ctx,
+#     body)`` — sibling endpoint to the threshold pair. Reads / writes
+#     the per-workspace synthesizer choice. Emits
+#     ``foresight.insights_config.updated`` on effective change; no-op
+#     write stays quiet.
+#   - Lazy engine import for ``insights_llm`` (same pattern as the v0.5
+#     synthesizer) — preserves the cloud→engine import-linter contract.
+#   - Cost discipline: LLM mode is opt-in only. Default stays "pattern"
+#     (deterministic, free). Workspaces with no config doc see the
+#     pattern path; only an explicit PUT flips the toggle.
 # Updated: 2026-05-26 (feat/foresight-v10-scenario-editor-backend) — RFC
 # 08 v1.0 wave 3. ``create_scenario_run`` now honors the optional
 # ``custom_scenario_id`` field on the POST body:
@@ -229,6 +249,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from datetime import UTC as UTC_TZ
 from datetime import datetime, timedelta
 from typing import Any, Literal
@@ -242,6 +263,7 @@ from pocketpaw_ee.cloud._core.realtime.events import (
     ForesightBacktestCompleted,
     ForesightBacktestCreated,
     ForesightBacktestFailed,
+    ForesightInsightsConfigUpdated,
     ForesightInstinctProposalCreated,
     ForesightOnboardingUnlocked,
     ForesightProjectedDecisionEmitted,
@@ -255,6 +277,7 @@ from pocketpaw_ee.cloud.foresight.domain import (
     AggregateRollup,
     BacktestRun,
     ConfidenceDrift,
+    InsightsConfigView,
     InsightView,
     LiveAnomaly,
     LiveSnapshotView,
@@ -275,6 +298,7 @@ from pocketpaw_ee.cloud.foresight.dto import (
     ConfidenceDriftDto,
     CreateBacktestRequest,
     CreateScenarioRequest,
+    ForesightInsightsConfigResponse,
     ForesightInstinctProposalListResponse,
     ForesightInstinctProposalResponse,
     ForesightThresholdResponse,
@@ -294,6 +318,7 @@ from pocketpaw_ee.cloud.foresight.dto import (
     ScenarioCatalogResponse,
     ScenarioRunListItemResponse,
     ScenarioRunResponse,
+    SetForesightInsightsConfigRequest,
     SetForesightThresholdRequest,
     TierMixActual,
 )
@@ -2874,18 +2899,33 @@ async def get_insights(ctx: RequestContext) -> InsightsResponse:
 
     Composes the synthesizer input bundle from PredictionRecord docs
     (the same source the aggregate endpoint reads), then delegates
-    rule evaluation to :func:`ee.foresight.insights.synthesize_insights`.
-    Engine import is lazy so the cloud module stays clean of the
+    rule evaluation to either:
+
+      - the v0.5 deterministic five-rule synthesizer
+        (:func:`ee.foresight.insights.synthesize_insights`), when the
+        workspace config's ``insights_synthesizer`` is ``"pattern"``
+        (default), OR
+      - the v1.0 LLM-driven synthesizer
+        (:func:`ee.foresight.insights_llm.synthesize_insights_llm`),
+        when the toggle is ``"llm"``. Failures collapse to the pattern
+        path so the wire response never 5xxs.
+
+    Engine imports are lazy so the cloud module stays clean of the
     engine layer per the import-linter contract.
 
     Empty workspaces return ``items=[]`` — the synthesizer yields no
-    rows when none of the five rules can fire.
+    rows when none of the rules / patterns can fire.
 
     PR 10 (v1.0): per-persona calibration + rolling accuracy + drift
     now read PredictionRecord docs instead of the v0.5 proxies. The
     ``tier_distribution_deltas`` + ``latest_backtest`` synthesizer
     fields still source from backtest docs (those carry the per-run
     tier mix + gate decision the prediction records don't echo).
+
+    LLM PR (v1.0): the workspace can opt into the LLM synthesizer via
+    the ``insights_synthesizer`` config; the wire shape stays the
+    same. Cost discipline: LLM mode is opt-in only — the default
+    pattern path stays free.
     """
     workspace_id = _require_workspace(ctx)
     now = datetime.now(UTC_TZ)
@@ -2925,16 +2965,121 @@ async def get_insights(ctx: RequestContext) -> InsightsResponse:
     latest_backtest_doc = backtest_docs[-1] if backtest_docs else None
     latest_gate = _compose_latest_backtest_gate(latest_backtest_doc)
 
-    # Lazy import — the synthesizer module is pure but lives in the
-    # engine namespace, so the import-linter forbids static imports
-    # from the cloud surface. Imported inside the function call
-    # path keeps the contract clean.
+    # Read the per-workspace synthesizer choice. Absent doc → "pattern".
+    config_view = await _load_insights_config_view(workspace_id)
+
+    raw_insights: list[Any]
+    if config_view.synthesizer == "llm":
+        # Try LLM. On ANY failure (timeout, malformed output, rate
+        # limit, missing backend) fall back to the pattern synthesizer
+        # so the wire response stays valid. The LLM helper itself
+        # collapses internal exceptions to ``[]``; we treat that as
+        # "fallback to pattern" so the operator never sees an empty
+        # panel when the pattern rules would have fired.
+        llm_insights = await _synthesize_insights_llm(
+            workspace_id=workspace_id,
+            now=now,
+            rolling=rolling,
+            drift=drift,
+            per_persona=per_persona,
+            tier_deltas=tier_deltas,
+            latest_gate=latest_gate,
+            all_records=all_records,
+        )
+        if llm_insights:
+            raw_insights = list(llm_insights)
+        else:
+            # Empty LLM output — likely a failure or a quiet workspace.
+            # Either way the pattern rules are the safe default; if
+            # they also produce nothing the response is correctly empty.
+            logger.warning(
+                "foresight.insights.llm_empty_falling_back_to_pattern",
+                extra={"workspace_id": workspace_id},
+            )
+            raw_insights = list(
+                _synthesize_insights_pattern(
+                    now=now,
+                    rolling=rolling,
+                    drift=drift,
+                    per_persona=per_persona,
+                    tier_deltas=tier_deltas,
+                    latest_gate=latest_gate,
+                )
+            )
+    else:
+        raw_insights = list(
+            _synthesize_insights_pattern(
+                now=now,
+                rolling=rolling,
+                drift=drift,
+                per_persona=per_persona,
+                tier_deltas=tier_deltas,
+                latest_gate=latest_gate,
+            )
+        )
+
+    items = [
+        _insight_to_response(
+            InsightView(
+                id=insight.id,
+                kind=insight.kind,
+                title=insight.title,
+                body=insight.body,
+                severity=insight.severity,
+                anchor_refs=insight.anchor_refs,
+                generated_at=insight.generated_at,
+            )
+        )
+        for insight in raw_insights
+    ]
+    return InsightsResponse(items=items)
+
+
+# ── LLM insights (Team 3 wave 3) ──────────────────────────────────────────
+# Workspace-config toggle + LLM synthesizer integration. Team 1's
+# scenario CRUD lives elsewhere in this file — do not interleave. All
+# helpers below are scoped to the LLM insights surface.
+# --------------------------------------------------------------------------
+
+# Module-level handle used by tests to inject a stub LLM backend. None
+# means "construct the default :class:`ClaudeCodeBackend`"; tests
+# monkey-patch this to a stub backend that returns canned JSON.
+_LLM_BACKEND_OVERRIDE: Any | None = None
+
+
+def _set_llm_backend_for_testing(backend: Any | None) -> None:
+    """Test-only hook to inject a stub LLM backend.
+
+    Replaces the default :class:`ClaudeCodeBackend` constructed inside
+    :func:`_synthesize_insights_llm`. Tests use this rather than
+    monkey-patching ``claude_agent_sdk`` so the cloud module stays
+    decoupled from the SDK install.
+    """
+    global _LLM_BACKEND_OVERRIDE
+    _LLM_BACKEND_OVERRIDE = backend
+
+
+def _synthesize_insights_pattern(
+    *,
+    now: datetime,
+    rolling: Sequence[Any],
+    drift: ConfidenceDrift,
+    per_persona: Sequence[Any],
+    tier_deltas: Sequence[Any],
+    latest_gate: Any | None,
+) -> list[Any]:
+    """Run the v0.5 deterministic five-rule synthesizer over the bundle.
+
+    Lazy engine imports per the cloud → engine import-linter contract.
+    Returns the list directly (already sorted + capped by the engine
+    function).
+    """
     from pocketpaw_ee.foresight.insights import (  # noqa: PLC0415
         ConfidenceDriftInput,
         SynthesizerInput,
         synthesize_insights,
     )
-    from pocketpaw_ee.foresight.insights import (
+    from pocketpaw_ee.foresight.insights import (  # noqa: PLC0415
         RollingAccuracyPoint as _RollingPoint,
     )
 
@@ -2956,23 +3101,262 @@ async def get_insights(ctx: RequestContext) -> InsightsResponse:
         tier_distribution_deltas=tuple(tier_deltas),
         latest_backtest=latest_gate,
     )
+    return list(synthesize_insights(bundle, cap=INSIGHTS_DEFAULT_CAP))
 
-    raw_insights = synthesize_insights(bundle, cap=INSIGHTS_DEFAULT_CAP)
-    items = [
-        _insight_to_response(
-            InsightView(
-                id=insight.id,
-                kind=insight.kind,
-                title=insight.title,
-                body=insight.body,
-                severity=insight.severity,
-                anchor_refs=insight.anchor_refs,
-                generated_at=insight.generated_at,
+
+async def _synthesize_insights_llm(
+    *,
+    workspace_id: str,
+    now: datetime,
+    rolling: Sequence[Any],
+    drift: ConfidenceDrift,
+    per_persona: Sequence[Any],
+    tier_deltas: Sequence[Any],
+    latest_gate: Any | None,
+    all_records: list[Any],
+) -> list[Any]:
+    """Run the v1.0 LLM-driven synthesizer over the bundle.
+
+    The helper is wrapped in a broad except so any unexpected error
+    (engine module import failure, prompt-construction edge case,
+    backend not wired) falls back to ``[]`` and the caller swaps to
+    the pattern synthesizer. The LLM module itself ALSO collapses
+    internal exceptions to ``[]``; this outer guard catches anything
+    the inner guard misses (e.g. import errors).
+    """
+    try:
+        # Lazy engine imports per the import-linter contract.
+        from pocketpaw_ee.foresight.insights import (  # noqa: PLC0415
+            ConfidenceDriftInput,
+        )
+        from pocketpaw_ee.foresight.insights import (  # noqa: PLC0415
+            RollingAccuracyPoint as _RollingPoint,
+        )
+        from pocketpaw_ee.foresight.insights_llm import (  # noqa: PLC0415
+            LLMInsightsInput,
+            RecentPredictionRecordSummary,
+            synthesize_insights_llm,
+        )
+
+        backend = _LLM_BACKEND_OVERRIDE
+        if backend is None:
+            from pocketpaw_ee.foresight.llm.adapter import (  # noqa: PLC0415
+                ClaudeCodeBackend,
+            )
+
+            backend = ClaudeCodeBackend()
+
+        period_key = _llm_period_key_for(now)
+        recent_records = [
+            RecentPredictionRecordSummary(
+                anchor_id=getattr(doc, "anchor_id", "") or "",
+                persona_id=getattr(doc, "persona_id", "") or "",
+                modal_outcome=_extract_modal_outcome(getattr(doc, "prediction", {})),
+                confidence=float(getattr(doc, "confidence", 0.0) or 0.0),
+                paired=bool(getattr(doc, "paired", False)),
+                observed_outcome=_extract_modal_outcome(
+                    getattr(doc, "observed_outcome", None) or {}
+                )
+                or None,
+                captured_at=getattr(doc, "captured_at", None),
+            )
+            for doc in all_records[-50:]
+        ]
+        bundle = LLMInsightsInput(
+            workspace_id=workspace_id,
+            period_key=period_key,
+            now=now,
+            rolling_accuracy=tuple(
+                _RollingPoint(
+                    ts=p.ts,
+                    accuracy=p.accuracy,
+                    sample_count=p.sample_count,
+                )
+                for p in rolling
+            ),
+            confidence_drift=ConfidenceDriftInput(
+                trend=drift.trend,
+                magnitude=drift.magnitude,
+            ),
+            per_persona_calibration=tuple(per_persona),
+            tier_distribution_deltas=tuple(tier_deltas),
+            latest_backtest=latest_gate,
+            recent_records=tuple(recent_records),
+        )
+        result = await synthesize_insights_llm(
+            bundle,
+            backend,
+            cap=INSIGHTS_DEFAULT_CAP,
+        )
+        return list(result)
+    except Exception as exc:  # noqa: BLE001 — defensive outer guard
+        logger.warning(
+            "foresight.insights.llm_outer_error",
+            extra={"workspace_id": workspace_id, "error": repr(exc)},
+        )
+        return []
+
+
+def _llm_period_key_for(now: datetime) -> str:
+    """Compute a stable ISO year-week key for ``now``.
+
+    Mirrors :func:`ee.foresight.insights._default_period_key`. Kept
+    local rather than imported so the cloud → engine call surface
+    stays restricted to the public synthesizer functions (the helper
+    is private to the engine module).
+    """
+    iso = now.isocalendar()
+    return f"{iso.year}_W{iso.week:02d}"
+
+
+def _extract_modal_outcome(payload: Any) -> str:
+    """Pull a short modal-outcome label out of a prediction or
+    observation payload dict. Returns ``""`` when nothing matches.
+    """
+    if not isinstance(payload, dict):
+        return ""
+    for key in ("modal_outcome", "outcome", "action", "decision"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()[:48]
+    return ""
+
+
+# --------------------------------------------------------------------------
+# Insights-synthesizer config — workspace-scoped GET / PUT.
+# --------------------------------------------------------------------------
+
+
+async def _load_insights_config_view(workspace_id: str) -> InsightsConfigView:
+    """Compose the workspace's insights-synthesizer config view.
+
+    Absent doc OR a doc missing the field (older records persisted
+    before this PR) collapses to the default ``"pattern"`` synthesizer
+    so the read path stays back-compat.
+    """
+    # Lazy import — keeps the LLM cache-TTL constant out of the cloud
+    # module's static deps. ``ee.foresight.insights_llm`` is in the
+    # engine namespace; lazy import preserves the import-linter
+    # contract.
+    from pocketpaw_ee.foresight.insights_llm import (  # noqa: PLC0415
+        DEFAULT_CACHE_TTL_SECONDS,
+    )
+
+    doc = await _ForesightWorkspaceConfigDoc.find_one(
+        {"workspace": workspace_id},
+    )
+    if doc is None:
+        return InsightsConfigView(
+            workspace_id=workspace_id,
+            synthesizer="pattern",
+            llm_cache_ttl_seconds=DEFAULT_CACHE_TTL_SECONDS,
+            updated_at=None,
+        )
+    # Older docs persisted before this PR don't carry the field; the
+    # Pydantic default makes ``doc.insights_synthesizer`` resolve to
+    # ``"pattern"``, but be defensive in case a malformed write
+    # landed.
+    synthesizer = getattr(doc, "insights_synthesizer", "pattern") or "pattern"
+    if synthesizer not in ("pattern", "llm"):
+        synthesizer = "pattern"
+    return InsightsConfigView(
+        workspace_id=workspace_id,
+        synthesizer=synthesizer,  # type: ignore[arg-type]
+        llm_cache_ttl_seconds=DEFAULT_CACHE_TTL_SECONDS,
+        updated_at=doc.updatedAt,
+    )
+
+
+def _to_insights_config_response(view: InsightsConfigView) -> ForesightInsightsConfigResponse:
+    """Map the domain view to the wire DTO."""
+    return ForesightInsightsConfigResponse(
+        workspace_id=view.workspace_id,
+        synthesizer=view.synthesizer,
+        llm_cache_ttl_seconds=view.llm_cache_ttl_seconds,
+        updated_at=iso_utc(view.updated_at),
+    )
+
+
+async def get_insights_config(ctx: RequestContext) -> ForesightInsightsConfigResponse:
+    """Return the workspace's resolved insights-synthesizer config view.
+
+    GET /api/v1/foresight/workspace/insights-config backing.
+
+    Tenancy:
+      - 403 ``foresight.no_workspace`` when the caller has no active
+        workspace.
+      - No cross-tenant reads possible — the view is intrinsically
+        per-workspace; an absent config collapses to the default view
+        (synthesizer="pattern"). Never 404.
+    """
+    workspace_id = _require_workspace(ctx)
+    # no-event: read-only path; emit only on writes (cloud rule #9).
+    view = await _load_insights_config_view(workspace_id)
+    return _to_insights_config_response(view)
+
+
+async def set_insights_config(
+    ctx: RequestContext,
+    body: SetForesightInsightsConfigRequest,
+) -> ForesightInsightsConfigResponse:
+    """Upsert the workspace's insights-synthesizer choice.
+
+    PUT /api/v1/foresight/workspace/insights-config backing.
+
+    Emit semantics:
+      - When the effective synthesizer changes (pattern → llm or
+        llm → pattern), fire ``foresight.insights_config.updated``
+        with ``data={workspace_id, synthesizer (new), previous_synthesizer}``
+        so listeners (LLM cache invalidator, UI panels) can react
+        without a round trip.
+      - A no-op write (same value as the current effective synthesizer)
+        does NOT emit — keeps the UI's optimistic-local-state path
+        from rebroadcasting redundant updates.
+    """
+    body = SetForesightInsightsConfigRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+
+    previous_view = await _load_insights_config_view(workspace_id)
+    new_choice = body.synthesizer
+
+    # Upsert pattern — Beanie has no native upsert helper that returns
+    # the resulting doc, so split into find_one + insert / update. The
+    # workspace field is unique-indexed so a concurrent insert race
+    # would surface as a DuplicateKeyError; this admin-only write path
+    # treats that race as a 500 (no retry loop).
+    doc = await _ForesightWorkspaceConfigDoc.find_one(
+        {"workspace": workspace_id},
+    )
+    if doc is None:
+        doc = _ForesightWorkspaceConfigDoc(
+            workspace=workspace_id,
+            insights_synthesizer=new_choice,
+        )
+        await doc.insert()
+    else:
+        doc.insights_synthesizer = new_choice
+        await doc.save()
+
+    new_view = await _load_insights_config_view(workspace_id)
+    response = _to_insights_config_response(new_view)
+
+    if new_view.synthesizer != previous_view.synthesizer:
+        await emit(
+            ForesightInsightsConfigUpdated(
+                data={
+                    "workspace_id": workspace_id,
+                    "synthesizer": new_view.synthesizer,
+                    "previous_synthesizer": previous_view.synthesizer,
+                }
             )
         )
-        for insight in raw_insights
-    ]
-    return InsightsResponse(items=items)
+    # else: no-event: idempotent write (cloud rule #9 allows this with
+    # the inline comment); the GET still returns the resolved view so
+    # the client's PUT round-trip stays useful.
+    return response
+
+
+# ── end LLM insights (Team 3 wave 3) ─────────────────────────────────────
 
 
 # ---------------------------------------------------------------------------
@@ -3173,6 +3557,7 @@ __all__ = [
     "get_aggregate_rollup",
     "get_backtest",
     "get_insights",
+    "get_insights_config",
     "get_live_snapshot",
     "get_onboarding_gate",
     "get_scenario_run",
@@ -3183,5 +3568,6 @@ __all__ = [
     "list_scenario_runs",
     "list_scenarios",
     "pair_prediction",
+    "set_insights_config",
     "set_threshold",
 ]

--- a/ee/pocketpaw_ee/cloud/models/foresight_workspace_config.py
+++ b/ee/pocketpaw_ee/cloud/models/foresight_workspace_config.py
@@ -1,4 +1,11 @@
 # ee/pocketpaw_ee/cloud/models/foresight_workspace_config.py
+# Updated: 2026-05-26 (feat/foresight-v10-insights-llm) — RFC 08 v1.0
+# adds the ``insights_synthesizer`` field. Workspace admins can opt
+# into the LLM-driven synthesizer alongside the v0.5 pattern rules; the
+# default stays "pattern" (deterministic, free). The shape is otherwise
+# unchanged — new field is optional with a safe default, so older docs
+# stored before this PR continue to load and ``find_one`` returns
+# ``insights_synthesizer = "pattern"`` for them.
 # Created: 2026-05-26 (feat/foresight-v10-threshold-override-cloud) —
 # RFC 08 v1.0. Per-workspace Foresight configuration. v1.0 ships with one
 # overridable knob — the onboarding gate threshold — but the doc shape is
@@ -17,10 +24,19 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from beanie import Indexed
 from pydantic import Field
 
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+# Synthesizer choice values the workspace config accepts. ``pattern`` is
+# the v0.5 deterministic rule synthesizer (default); ``llm`` opts into
+# the v1.0 LLM-driven synthesizer with a hard fallback to ``pattern`` on
+# LLM failure (so the wire response never 5xxs even when the LLM path
+# is broken).
+InsightsSynthesizerChoice = Literal["pattern", "llm"]
 
 
 class ForesightWorkspaceConfig(TimestampedDocument):
@@ -38,24 +54,35 @@ class ForesightWorkspaceConfig(TimestampedDocument):
         because a future bump of the floor must not retroactively
         invalidate stored overrides — the DTO validator is the single
         source of truth for the legal range at write time.
+      - ``insights_synthesizer`` — ``"pattern"`` (default) keeps the v0.5
+        deterministic five-rule synthesizer; ``"llm"`` opts the
+        workspace into the LLM-driven synthesizer
+        (``ee.foresight.insights_llm``) with a hard fallback to
+        ``pattern`` on LLM failure. Cost discipline note: the LLM mode
+        is opt-in only — workspaces with the default value pay zero
+        LLM cost. Constrained at the DTO layer.
       - ``createdAt`` / ``updatedAt`` — inherited from
         :class:`TimestampedDocument`. ``updatedAt`` doubles as the
         "when did the admin last touch this" timestamp the GET response
         exposes to the UI.
 
-    v1.0 ships threshold-only. v1.1 candidates:
+    v1.0 ships threshold + insights_synthesizer. v1.1 candidates:
       - ``default_sub_type: str`` — the sub_type the new-scenario wizard
         opens on.
       - ``notification_routing: dict[str, str]`` — channel routing for
         backtest-completed / onboarding-unlocked.
       - ``insight_cap: int`` — per-call cap on synthesizer insights.
+      - ``llm_cache_ttl_seconds: int`` — per-workspace LLM cache TTL
+        override (default is the module constant
+        ``ee.foresight.insights_llm.DEFAULT_CACHE_TTL_SECONDS``).
 
     The shape is therefore extension-additive; new optional fields with
-    ``None`` defaults won't break callers reading the v1.0 wire dict.
+    safe defaults won't break callers reading the v1.0 wire dict.
     """
 
     workspace: Indexed(str, unique=True)  # type: ignore[valid-type]
     threshold_override: float | None = Field(default=None)
+    insights_synthesizer: InsightsSynthesizerChoice = Field(default="pattern")
 
     class Settings:
         name = "foresight_workspace_configs"

--- a/ee/pocketpaw_ee/foresight/insights_llm.py
+++ b/ee/pocketpaw_ee/foresight/insights_llm.py
@@ -1,0 +1,735 @@
+# ee/pocketpaw_ee/foresight/insights_llm.py
+# Created: 2026-05-26 (feat/foresight-v10-insights-llm) — RFC 08 v1.0
+# Insights synthesizer alternative: LLM-driven pattern discovery on top
+# of the same SynthesizerInput-style structured summary the v0.5 pattern
+# rules consume.
+#
+# Stays inside the engine namespace (``pocketpaw_ee.foresight``) — same
+# as the v0.5 pattern synthesizer in ``insights.py``. No I/O against
+# Beanie / FastAPI / Pydantic; the cloud service composes the structured
+# summary and hands it in. The module owns:
+#
+#   - ``LLMInsightsInput`` — the structured summary shape (rolling
+#     accuracy + drift + modal outcomes + recent prediction records +
+#     last backtest decision) handed to the prompt.
+#   - ``LLMBackendProtocol`` — the minimal model-backend surface; matches
+#     ``ee.foresight.llm.adapter.ClaudeCodeBackend.complete`` so the
+#     existing CC-SDK adapter from PR #1227/#1232 plugs in unchanged.
+#   - ``synthesize_insights_llm(...)`` — async pure function: builds a
+#     prompt, calls the backend, parses + validates the JSON output into
+#     ``Insight`` records (reusing the dataclass from the v0.5
+#     synthesizer so the cloud-side InsightView mapper handles both paths
+#     uniformly).
+#   - In-memory LRU cache keyed on
+#     ``(workspace_id, aggregator_state_hash)`` with a configurable TTL
+#     (default 5 minutes). Stable-id discipline (SHA-1 of
+#     ``(workspace_id, period_key, prompt_hash, kind, salt)``) means the
+#     UI sees consistent ids across reloads while the input data is
+#     unchanged.
+#   - Hard fallback: timeouts, malformed JSON, schema validation errors,
+#     rate-limit / connection failures ALL collapse to ``[]`` so the
+#     cloud-side ``get_insights`` can fall back to the pattern rules
+#     instead of 5xx-ing the panel.
+#
+# Cost discipline: LLM mode is opt-in via the per-workspace
+# ``insights_synthesizer`` config field. The pattern path is unchanged
+# (deterministic, free) and stays the default. The LLM path runs only
+# when a workspace admin flips the toggle.
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import time
+from collections import OrderedDict
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Protocol, cast
+
+from pocketpaw_ee.foresight.insights import (
+    _SEVERITY_RANK,
+    ConfidenceDriftInput,
+    Insight,
+    InsightSeverity,
+    LatestBacktestGate,
+    PerPersonaCalibration,
+    RollingAccuracyPoint,
+    TierDistributionDelta,
+    _iso,
+    _safe_id_segment,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Severity values the LLM is allowed to emit. The cloud-side wire DTO
+# (``InsightResponse.severity``) is a plain ``str`` but the synthesizer
+# input ``Insight.severity`` is the v0.5 ``InsightSeverity`` Literal —
+# any value outside this set is silently coerced to ``"info"`` so the
+# UI's severity → colour mapping stays defined.
+_ALLOWED_SEVERITIES: frozenset[str] = frozenset({"info", "warning", "critical"})
+
+# The opaque kind values the LLM is encouraged to emit, beyond the
+# v0.5 pattern set. Documented to the model so its output stays in a
+# bounded enum the UI can later partition by; values outside this list
+# pass through (the cloud-side ``InsightView.kind`` is ``str``).
+LLM_KIND_VOCABULARY: tuple[str, ...] = (
+    "trend_explainer",
+    "outlier_cluster",
+    "persona_pattern",
+    "tier_pattern",
+    "backtest_observation",
+    "cross_signal_correlation",
+    "regression_risk",
+    "data_quality",
+)
+
+# Cap on insights the LLM is asked to produce. The cloud-side
+# ``get_insights`` already caps the wire response at
+# ``INSIGHTS_DEFAULT_CAP=20``; the per-call ceiling here is lower so
+# the prompt stays focused on the most actionable items.
+LLM_PROMPT_INSIGHT_CAP: int = 8
+
+# Default TTL for the in-memory cache. Keeps the LLM cost per workspace
+# bounded — if the UI polls /insights every minute, only the first call
+# of a 5-minute window pays the LLM round-trip; the next four hit cache.
+DEFAULT_CACHE_TTL_SECONDS: int = 300
+
+# Default cache capacity. LRU eviction is keyed by
+# ``(workspace_id, aggregator_state_hash)`` so a workspace with rapidly
+# changing data won't displace another workspace's cached entry.
+DEFAULT_CACHE_CAPACITY: int = 64
+
+
+class LLMBackendProtocol(Protocol):
+    """Minimal model-backend surface ``synthesize_insights_llm`` requires.
+
+    Matches the surface :class:`ee.foresight.llm.adapter.ClaudeCodeBackend`
+    exposes (``async def complete(prompt: str) -> str``) so the existing
+    CC-SDK adapter from PR #1227/#1232 plugs in unchanged. Tests inject
+    a stub that returns canned JSON.
+    """
+
+    async def complete(self, prompt: str) -> str:  # pragma: no cover — protocol
+        ...
+
+
+@dataclass(frozen=True)
+class RecentPredictionRecordSummary:
+    """One row of recent prediction-record data fed into the LLM prompt.
+
+    Compact shape — the LLM only needs anchor / persona / outcome /
+    confidence / paired status. Full PredictionRecord docs would blow
+    the prompt budget for any workspace with a non-trivial history.
+    """
+
+    anchor_id: str
+    persona_id: str
+    modal_outcome: str
+    confidence: float
+    paired: bool
+    observed_outcome: str | None = None
+    captured_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class LLMInsightsInput:
+    """Structured summary the LLM synthesizer reads.
+
+    Same data shape the v0.5 pattern synthesizer consumes, plus a
+    compact list of recent prediction records. Each field is optional
+    so partial data (empty workspace, no backtests yet) collapses to an
+    empty prompt section rather than raising.
+
+    ``workspace_id`` and ``period_key`` are required positionally per
+    the cloud rule #3 multi-tenancy invariant — the cache key and the
+    stable-id hash both consume these so a leak across tenants would
+    surface as a stable-id collision rather than a silent miss.
+
+    ``now`` anchors every ``generated_at`` so tests stay deterministic.
+    """
+
+    workspace_id: str
+    period_key: str
+    now: datetime
+    rolling_accuracy: Sequence[RollingAccuracyPoint] = ()
+    confidence_drift: ConfidenceDriftInput | None = None
+    per_persona_calibration: Sequence[PerPersonaCalibration] = ()
+    tier_distribution_deltas: Sequence[TierDistributionDelta] = ()
+    latest_backtest: LatestBacktestGate | None = None
+    recent_records: Sequence[RecentPredictionRecordSummary] = ()
+
+    # Tunables (kept on the input bundle so callers don't have to pass
+    # a separate config). Defaults match the cost-discipline targets
+    # documented in the module header.
+    max_insights: int = LLM_PROMPT_INSIGHT_CAP
+    recent_records_cap: int = 25
+
+
+@dataclass(frozen=True)
+class _CachedInsights:
+    """One LRU cache entry — the synthesized insight list plus the
+    Unix timestamp at insertion so TTL expiry is O(1) on lookup.
+    """
+
+    insights: tuple[Insight, ...]
+    inserted_at: float
+
+
+@dataclass
+class _LRUCache:
+    """Tiny LRU + TTL cache. Kept module-private so callers can't
+    sidestep the eviction policy.
+
+    Key: ``(workspace_id, aggregator_state_hash)``.
+    Value: ``_CachedInsights``.
+
+    Capacity bound + TTL together keep memory usage bounded even when
+    every workspace polls hot. The OrderedDict supplies the LRU
+    ordering; ``move_to_end`` on lookup keeps the touched key at the
+    "most recent" tail.
+    """
+
+    capacity: int = DEFAULT_CACHE_CAPACITY
+    ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS
+    _store: OrderedDict[tuple[str, str], _CachedInsights] = field(default_factory=OrderedDict)
+
+    def get(self, key: tuple[str, str]) -> tuple[Insight, ...] | None:
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        if (time.monotonic() - entry.inserted_at) > self.ttl_seconds:
+            # Stale — evict and miss.
+            del self._store[key]
+            return None
+        # Touch recency.
+        self._store.move_to_end(key)
+        return entry.insights
+
+    def put(self, key: tuple[str, str], insights: tuple[Insight, ...]) -> None:
+        if key in self._store:
+            self._store.move_to_end(key)
+        self._store[key] = _CachedInsights(
+            insights=insights,
+            inserted_at=time.monotonic(),
+        )
+        # Evict from the head (LRU) until under capacity.
+        while len(self._store) > self.capacity:
+            self._store.popitem(last=False)
+
+    def clear(self) -> None:
+        self._store.clear()
+
+
+# Module-level singleton — one cache per process. Tests can clear it
+# via ``reset_cache`` between cases without monkey-patching.
+_cache: _LRUCache = _LRUCache()
+
+
+def reset_cache() -> None:
+    """Clear the module-level LRU. Test-only convenience."""
+    _cache.clear()
+
+
+def configure_cache(*, ttl_seconds: int | None = None, capacity: int | None = None) -> None:
+    """Reconfigure the module-level cache. Used by the cloud-side config
+    endpoint when an admin tunes ``llm_cache_ttl_seconds`` (forward-
+    compat: v1.0 ships a fixed TTL; v1.1 will expose it). Reset is
+    implicit — clearing the store on reconfigure avoids stale-TTL races.
+    """
+    if ttl_seconds is not None:
+        if ttl_seconds < 1:
+            raise ValueError(f"ttl_seconds must be >= 1, got {ttl_seconds}")
+        _cache.ttl_seconds = ttl_seconds
+    if capacity is not None:
+        if capacity < 1:
+            raise ValueError(f"capacity must be >= 1, got {capacity}")
+        _cache.capacity = capacity
+    _cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+async def synthesize_insights_llm(
+    bundle: LLMInsightsInput,
+    backend: LLMBackendProtocol,
+    *,
+    cap: int = 20,
+    timeout_seconds: float = 30.0,
+) -> list[Insight]:
+    """Run the LLM-driven synthesizer over ``bundle`` and return a sorted
+    list of insights.
+
+    The function is failure-resilient by construction: any exception
+    (timeout, network error, malformed JSON, missing fields) is caught
+    and surfaced as an empty list so the cloud-side ``get_insights``
+    can fall back to the pattern rules instead of 5xx-ing.
+
+    Cache strategy:
+      1. Compose a stable hash of the input data.
+      2. Look up ``(workspace_id, hash)`` in the LRU.
+      3. On hit, return the cached insights (recency-touched).
+      4. On miss, call the backend, parse + validate, store and return.
+
+    Stable-id discipline:
+      - Each parsed insight's id is SHA-1 of
+        ``(workspace_id, period_key, prompt_hash, kind, salt)`` so the
+        same input always yields the same id. The salt is the insight's
+        ordinal in the LLM output to keep duplicates within a single
+        response disambiguated.
+
+    Sorting + capping matches the v0.5 pattern synthesizer exactly:
+    severity descending (critical > warning > info), then
+    ``generated_at`` descending, then id (lexicographic). Capped at
+    ``cap`` items so the wire-response cap downstream is preserved.
+    """
+    if cap < 1:
+        raise ValueError(f"cap must be >= 1, got {cap}")
+
+    if not bundle.workspace_id:
+        # Cloud rule #3 — workspace_id is required. Don't raise; just
+        # collapse to empty so the cloud-side fallback path takes over.
+        logger.warning(
+            "insights_llm.empty_workspace_id",
+            extra={"period_key": bundle.period_key},
+        )
+        return []
+
+    state_hash = _hash_bundle(bundle)
+    cache_key = (bundle.workspace_id, state_hash)
+    cached = _cache.get(cache_key)
+    if cached is not None:
+        # Return a list copy — callers may sort/modify in place.
+        return list(cached)[:cap]
+
+    prompt = _build_prompt(bundle)
+    prompt_hash = hashlib.sha1(prompt.encode("utf-8")).hexdigest()
+
+    try:
+        raw_output = await asyncio.wait_for(
+            backend.complete(prompt),
+            timeout=timeout_seconds,
+        )
+    except TimeoutError:
+        logger.warning(
+            "insights_llm.timeout",
+            extra={
+                "workspace_id": bundle.workspace_id,
+                "period_key": bundle.period_key,
+                "timeout_seconds": timeout_seconds,
+            },
+        )
+        return []
+    except Exception as exc:  # noqa: BLE001 — backend errors are opaque
+        logger.warning(
+            "insights_llm.backend_error",
+            extra={
+                "workspace_id": bundle.workspace_id,
+                "period_key": bundle.period_key,
+                "error": repr(exc),
+            },
+        )
+        return []
+
+    parsed = _parse_llm_output(
+        raw_output,
+        workspace_id=bundle.workspace_id,
+        period_key=bundle.period_key,
+        prompt_hash=prompt_hash,
+        now=bundle.now,
+    )
+
+    # Sort: severity desc, generated_at desc, then id lex — mirrors the
+    # v0.5 synthesizer exactly so the LLM and pattern paths render in
+    # consistent order on the UI.
+    parsed.sort(
+        key=lambda item: (
+            -_SEVERITY_RANK.get(item.severity, 0),
+            -item.generated_at.timestamp(),
+            item.id,
+        )
+    )
+    capped = parsed[:cap]
+    _cache.put(cache_key, tuple(capped))
+    return capped
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction
+# ---------------------------------------------------------------------------
+
+
+_PROMPT_SYSTEM = (
+    "You are a foresight analyst. Given a structured summary of one "
+    "workspace's recent prediction performance, identify up to {max_insights} "
+    "actionable patterns that an operator should know about. Focus on "
+    "explainable, evidence-based observations — name the persona, tier, "
+    "or anchor that drives each pattern.\n\n"
+    "Return a JSON object with a single top-level field 'insights' whose "
+    "value is an array of objects. Each insight object MUST have:\n"
+    "  - 'kind' (string): short snake_case label; prefer one of "
+    "{kind_vocab} but a new label is acceptable when none fit.\n"
+    "  - 'title' (string, <= 80 chars): one-line summary.\n"
+    "  - 'body' (string, <= 400 chars): why this matters and what to "
+    "look at next. Reference concrete IDs from the data.\n"
+    "  - 'severity' (string): one of 'info', 'warning', 'critical'.\n"
+    "  - 'anchor_refs' (array of strings, optional): IDs the UI can "
+    "deep-link to (e.g. 'persona:abc', 'tier:premium', "
+    "'backtest:5f5...'). Empty array when no refs.\n\n"
+    "Return ONLY the JSON object, no prose. If the data does not "
+    'support any insights, return {{"insights": []}}.'
+)
+
+
+def _build_prompt(bundle: LLMInsightsInput) -> str:
+    """Compose the prompt sent to the model backend.
+
+    The prompt has three sections:
+      1. System guidance — what to emit, severity vocabulary, kind
+         vocabulary, output schema.
+      2. Structured data summary — JSON-formatted view of the rolling
+         accuracy series, drift, per-persona calibration, tier deltas,
+         latest backtest, and a capped tail of recent prediction
+         records.
+      3. The closing instruction — emit JSON only.
+    """
+    system = _PROMPT_SYSTEM.format(
+        max_insights=bundle.max_insights,
+        kind_vocab=", ".join(LLM_KIND_VOCABULARY),
+    )
+
+    data: dict[str, Any] = {
+        "workspace_id": bundle.workspace_id,
+        "period_key": bundle.period_key,
+        "now": _iso(bundle.now),
+        "rolling_accuracy": [
+            {
+                "ts": _iso(p.ts),
+                "accuracy": round(float(p.accuracy), 4),
+                "sample_count": int(p.sample_count),
+            }
+            for p in bundle.rolling_accuracy
+        ],
+        "confidence_drift": (
+            None
+            if bundle.confidence_drift is None
+            else {
+                "trend": bundle.confidence_drift.trend,
+                "magnitude": round(float(bundle.confidence_drift.magnitude), 4),
+            }
+        ),
+        "per_persona_calibration": [
+            {
+                "persona_id": entry.persona_id,
+                "calibration": round(float(entry.calibration), 4),
+                "sample_count": int(entry.sample_count),
+            }
+            for entry in bundle.per_persona_calibration
+        ],
+        "tier_distribution_deltas": [
+            {
+                "tier": entry.tier,
+                "configured": round(float(entry.configured), 4),
+                "actual": round(float(entry.actual), 4),
+                "delta": round(float(entry.delta), 4),
+            }
+            for entry in bundle.tier_distribution_deltas
+        ],
+        "latest_backtest": (
+            None
+            if bundle.latest_backtest is None
+            else {
+                "backtest_id": bundle.latest_backtest.backtest_id,
+                "passed": bool(bundle.latest_backtest.passed),
+                "observed": round(float(bundle.latest_backtest.observed), 4),
+                "threshold": round(float(bundle.latest_backtest.threshold), 4),
+                "completed_at": _iso(bundle.latest_backtest.completed_at),
+            }
+        ),
+        "recent_records": [
+            {
+                "anchor_id": rec.anchor_id,
+                "persona_id": rec.persona_id,
+                "modal_outcome": rec.modal_outcome,
+                "confidence": round(float(rec.confidence), 4),
+                "paired": bool(rec.paired),
+                "observed_outcome": rec.observed_outcome,
+                "captured_at": _iso(rec.captured_at) if rec.captured_at else None,
+            }
+            for rec in list(bundle.recent_records)[: bundle.recent_records_cap]
+        ],
+    }
+    return f"{system}\n\nDATA:\n{json.dumps(data, sort_keys=True)}\n"
+
+
+# ---------------------------------------------------------------------------
+# Output parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_llm_output(
+    raw_output: str,
+    *,
+    workspace_id: str,
+    period_key: str,
+    prompt_hash: str,
+    now: datetime,
+) -> list[Insight]:
+    """Parse the model's JSON response into a list of ``Insight`` records.
+
+    Robustness rules:
+      - The body may be wrapped in a fenced code block; strip ``` fences
+        and any leading prose.
+      - The top-level shape MUST be an object with an ``insights`` array.
+        Anything else collapses to an empty list with a debug log.
+      - Per-item validation: required keys (kind/title/body/severity)
+        must all be present and the right type. Invalid items are
+        skipped (warn) while valid siblings are kept.
+      - Severity must be one of ``info|warning|critical``; out-of-vocab
+        values coerce to ``info`` rather than dropping the row.
+      - Each surviving item gets a stable id computed by hashing
+        ``(workspace_id, period_key, prompt_hash, kind, ordinal)``.
+    """
+    cleaned = _strip_json_fences(raw_output).strip()
+    if not cleaned:
+        return []
+    try:
+        payload = json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "insights_llm.json_decode_error",
+            extra={
+                "workspace_id": workspace_id,
+                "period_key": period_key,
+                "error": str(exc),
+                "raw_head": cleaned[:120],
+            },
+        )
+        return []
+
+    if not isinstance(payload, dict):
+        logger.warning(
+            "insights_llm.payload_not_object",
+            extra={"workspace_id": workspace_id, "period_key": period_key},
+        )
+        return []
+
+    items_raw = payload.get("insights")
+    if not isinstance(items_raw, list):
+        logger.warning(
+            "insights_llm.insights_field_missing_or_not_list",
+            extra={"workspace_id": workspace_id, "period_key": period_key},
+        )
+        return []
+
+    parsed: list[Insight] = []
+    skipped = 0
+    for ordinal, raw_item in enumerate(items_raw):
+        if not isinstance(raw_item, dict):
+            skipped += 1
+            continue
+        kind = raw_item.get("kind")
+        title = raw_item.get("title")
+        body = raw_item.get("body")
+        severity_raw = raw_item.get("severity")
+        anchor_refs_raw = raw_item.get("anchor_refs", [])
+        if not (
+            isinstance(kind, str)
+            and kind.strip()
+            and isinstance(title, str)
+            and title.strip()
+            and isinstance(body, str)
+            and body.strip()
+            and isinstance(severity_raw, str)
+        ):
+            skipped += 1
+            continue
+        # Coerce out-of-vocab severity to "info" so the UI's severity
+        # → colour mapping stays defined. cast() keeps the Literal type
+        # narrow for mypy without an opaque ignore.
+        severity_value = severity_raw if severity_raw in _ALLOWED_SEVERITIES else "info"
+        severity_norm = cast(InsightSeverity, severity_value)
+        anchor_refs: tuple[str, ...]
+        if isinstance(anchor_refs_raw, list):
+            anchor_refs = tuple(
+                str(ref) for ref in anchor_refs_raw if isinstance(ref, str) and ref.strip()
+            )
+        else:
+            anchor_refs = ()
+        # Trim oversized fields so the wire response stays bounded.
+        # The DTO doesn't enforce a length but the UI's card layout
+        # breaks past these bounds.
+        safe_title = title.strip()[:160]
+        safe_body = body.strip()[:800]
+        safe_kind = kind.strip()[:64]
+        insight_id = _stable_insight_id(
+            workspace_id=workspace_id,
+            period_key=period_key,
+            prompt_hash=prompt_hash,
+            kind=safe_kind,
+            ordinal=ordinal,
+        )
+        # The opaque kind extension means we feed strings outside the
+        # ``InsightKind`` Literal into the dataclass — Python is
+        # permissive at runtime; cast() keeps mypy quiet without an
+        # unscoped ignore.
+        parsed.append(
+            Insight(
+                id=insight_id,
+                kind=cast(Any, safe_kind),
+                title=safe_title,
+                body=safe_body,
+                severity=severity_norm,
+                generated_at=now,
+                anchor_refs=anchor_refs,
+            )
+        )
+
+    if skipped:
+        logger.warning(
+            "insights_llm.partial_parse",
+            extra={
+                "workspace_id": workspace_id,
+                "period_key": period_key,
+                "skipped": skipped,
+                "kept": len(parsed),
+            },
+        )
+    return parsed
+
+
+def _strip_json_fences(text: str) -> str:
+    """Strip ``` fences and a leading ``json`` language tag if present.
+
+    LLMs commonly wrap JSON in a fenced block even when the prompt asks
+    for raw JSON. Be tolerant rather than fail closed.
+    """
+    s = text.strip()
+    if s.startswith("```"):
+        # Strip the opening fence (with or without a language tag).
+        first_newline = s.find("\n")
+        if first_newline != -1:
+            s = s[first_newline + 1 :]
+        else:
+            s = s[3:]
+        # Strip the trailing fence if present.
+        if s.rstrip().endswith("```"):
+            last_fence = s.rfind("```")
+            s = s[:last_fence]
+    return s.strip()
+
+
+def _stable_insight_id(
+    *,
+    workspace_id: str,
+    period_key: str,
+    prompt_hash: str,
+    kind: str,
+    ordinal: int,
+) -> str:
+    """Compute a deterministic insight id from the surrounding context.
+
+    The id has the prefix ``llm_`` so debugging logs make the synthesizer
+    source obvious at a glance, and a 12-hex-char SHA-1 tail so the
+    namespace is bounded but collision-resistant for a single workspace's
+    poll cadence.
+    """
+    safe_kind = _safe_id_segment(kind) or "insight"
+    payload = "|".join(
+        [
+            workspace_id,
+            period_key or "",
+            prompt_hash,
+            safe_kind,
+            str(ordinal),
+        ]
+    )
+    digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()[:12]
+    return f"llm_{safe_kind}_{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Bundle hashing — cache key
+# ---------------------------------------------------------------------------
+
+
+def _hash_bundle(bundle: LLMInsightsInput) -> str:
+    """Compute a stable hash of the data portion of the bundle.
+
+    The hash drives the LRU cache key — two calls with the same workspace
+    + same data hash return the cached output. ``now`` and tunables are
+    EXCLUDED so a polling UI doesn't blow the cache every second; the
+    period_key + the data series implicitly drift over time as new
+    records land.
+    """
+    items: dict[str, Any] = {
+        "period_key": bundle.period_key,
+        "rolling_accuracy": [
+            (round(float(p.accuracy), 6), int(p.sample_count), _iso(p.ts))
+            for p in bundle.rolling_accuracy
+        ],
+        "drift": (
+            None
+            if bundle.confidence_drift is None
+            else (bundle.confidence_drift.trend, round(float(bundle.confidence_drift.magnitude), 6))
+        ),
+        "per_persona": sorted(
+            [
+                (e.persona_id, round(float(e.calibration), 6), int(e.sample_count))
+                for e in bundle.per_persona_calibration
+            ]
+        ),
+        "tier_deltas": sorted(
+            [
+                (
+                    e.tier,
+                    round(float(e.configured), 6),
+                    round(float(e.actual), 6),
+                )
+                for e in bundle.tier_distribution_deltas
+            ]
+        ),
+        "backtest": (
+            None
+            if bundle.latest_backtest is None
+            else (
+                bundle.latest_backtest.backtest_id,
+                bool(bundle.latest_backtest.passed),
+                round(float(bundle.latest_backtest.observed), 6),
+                round(float(bundle.latest_backtest.threshold), 6),
+            )
+        ),
+        "recent": [
+            (
+                r.anchor_id,
+                r.persona_id,
+                r.modal_outcome,
+                round(float(r.confidence), 6),
+                bool(r.paired),
+                r.observed_outcome,
+            )
+            for r in bundle.recent_records
+        ],
+    }
+    serialized = json.dumps(items, sort_keys=True, default=str)
+    return hashlib.sha1(serialized.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "DEFAULT_CACHE_CAPACITY",
+    "DEFAULT_CACHE_TTL_SECONDS",
+    "LLM_KIND_VOCABULARY",
+    "LLM_PROMPT_INSIGHT_CAP",
+    "LLMBackendProtocol",
+    "LLMInsightsInput",
+    "RecentPredictionRecordSummary",
+    "configure_cache",
+    "reset_cache",
+    "synthesize_insights_llm",
+]

--- a/tests/cloud/test_foresight_insights_config.py
+++ b/tests/cloud/test_foresight_insights_config.py
@@ -1,0 +1,293 @@
+# tests/cloud/test_foresight_insights_config.py
+# Created: 2026-05-26 (feat/foresight-v10-insights-llm) — RFC 08 v1.0.
+# Service- + router-level tests for the per-workspace insights-synthesizer
+# config surface. Exercises:
+#   - GET without config → default view collapses to synthesizer="pattern",
+#     llm_cache_ttl_seconds=300, updated_at=null.
+#   - GET with config → echoes the stored choice + updated_at.
+#   - PUT pattern → llm → upserts the doc, emits the event, GET reflects.
+#   - PUT llm → pattern → emits the reverse event.
+#   - PUT idempotent (same value) → no event emitted.
+#   - PUT unknown synthesizer value → 422 from DTO Literal validation.
+#   - PUT bad shape (extra field) → 422/400 from FastAPI / DTO.
+#   - Tenancy 403: GET / PUT with no workspace → Forbidden.
+#   - Cross-tenant isolation: an LLM toggle in w1 must NOT bleed into w2.
+"""Tests for the per-workspace insights-synthesizer config endpoint."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud._core.realtime.events import ForesightInsightsConfigUpdated
+from pocketpaw_ee.cloud.foresight import service as foresight_service
+from pocketpaw_ee.cloud.foresight.dto import SetForesightInsightsConfigRequest
+from pocketpaw_ee.cloud.foresight.router import router as foresight_router
+from pocketpaw_ee.cloud.license import require_license
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace: str | None = "w1", user: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Service-level GET
+# ---------------------------------------------------------------------------
+
+
+async def test_get_insights_config_default_returns_pattern() -> None:
+    """Fresh workspace — no config doc — collapses to the default view."""
+    ctx = _ctx(workspace="fresh-config-ws")
+    out = await foresight_service.get_insights_config(ctx)
+    assert out.workspace_id == "fresh-config-ws"
+    assert out.synthesizer == "pattern"
+    assert out.llm_cache_ttl_seconds >= 1
+    assert out.updated_at is None
+
+
+async def test_get_insights_config_with_set_value_reports_llm() -> None:
+    ctx = _ctx(workspace="llm-config-ws")
+    await foresight_service.set_insights_config(
+        ctx, SetForesightInsightsConfigRequest(synthesizer="llm")
+    )
+    out = await foresight_service.get_insights_config(ctx)
+    assert out.synthesizer == "llm"
+    assert out.updated_at is not None
+    assert "T" in out.updated_at
+
+
+async def test_get_insights_config_requires_workspace() -> None:
+    with pytest.raises(Forbidden):
+        await foresight_service.get_insights_config(_ctx(workspace=None))
+
+
+# ---------------------------------------------------------------------------
+# Service-level PUT
+# ---------------------------------------------------------------------------
+
+
+async def test_set_insights_config_pattern_to_llm_emits(recording_bus) -> None:
+    """First PUT (pattern → llm) emits the event with both values."""
+    ctx = _ctx(workspace="pattern-to-llm-ws")
+    out = await foresight_service.set_insights_config(
+        ctx, SetForesightInsightsConfigRequest(synthesizer="llm")
+    )
+    assert out.synthesizer == "llm"
+    assert out.updated_at is not None
+
+    events = [e for e in recording_bus.events if isinstance(e, ForesightInsightsConfigUpdated)]
+    assert len(events) == 1
+    payload = events[0].data
+    assert payload["workspace_id"] == "pattern-to-llm-ws"
+    assert payload["synthesizer"] == "llm"
+    assert payload["previous_synthesizer"] == "pattern"
+
+
+async def test_set_insights_config_llm_to_pattern_emits(recording_bus) -> None:
+    """Reverting from llm back to pattern emits the reverse event."""
+    ctx = _ctx(workspace="reset-config-ws")
+    await foresight_service.set_insights_config(
+        ctx, SetForesightInsightsConfigRequest(synthesizer="llm")
+    )
+    recording_bus.events.clear()
+
+    out = await foresight_service.set_insights_config(
+        ctx, SetForesightInsightsConfigRequest(synthesizer="pattern")
+    )
+    assert out.synthesizer == "pattern"
+
+    events = [e for e in recording_bus.events if isinstance(e, ForesightInsightsConfigUpdated)]
+    assert len(events) == 1
+    payload = events[0].data
+    assert payload["synthesizer"] == "pattern"
+    assert payload["previous_synthesizer"] == "llm"
+
+
+async def test_set_insights_config_noop_does_not_emit(recording_bus) -> None:
+    """Writing the same value twice does not emit a second event."""
+    ctx = _ctx(workspace="noop-config-ws")
+    await foresight_service.set_insights_config(
+        ctx, SetForesightInsightsConfigRequest(synthesizer="llm")
+    )
+    recording_bus.events.clear()
+
+    out = await foresight_service.set_insights_config(
+        ctx, SetForesightInsightsConfigRequest(synthesizer="llm")
+    )
+    assert out.synthesizer == "llm"
+    events = [e for e in recording_bus.events if isinstance(e, ForesightInsightsConfigUpdated)]
+    assert events == []
+
+
+async def test_set_insights_config_pattern_when_already_default_is_noop(
+    recording_bus,
+) -> None:
+    """Setting "pattern" on a fresh workspace (no doc) → no emit."""
+    ctx = _ctx(workspace="already-pattern-ws")
+    out = await foresight_service.set_insights_config(
+        ctx, SetForesightInsightsConfigRequest(synthesizer="pattern")
+    )
+    assert out.synthesizer == "pattern"
+    events = [e for e in recording_bus.events if isinstance(e, ForesightInsightsConfigUpdated)]
+    assert events == []
+
+
+async def test_set_insights_config_isolates_across_workspaces() -> None:
+    """A toggle in w1 must NOT bleed into w2."""
+    ctx_w1 = _ctx(workspace="cfg-w1")
+    ctx_w2 = _ctx(workspace="cfg-w2")
+    await foresight_service.set_insights_config(
+        ctx_w1, SetForesightInsightsConfigRequest(synthesizer="llm")
+    )
+
+    view_w1 = await foresight_service.get_insights_config(ctx_w1)
+    view_w2 = await foresight_service.get_insights_config(ctx_w2)
+    assert view_w1.synthesizer == "llm"
+    assert view_w2.synthesizer == "pattern"
+
+
+async def test_set_insights_config_requires_workspace() -> None:
+    with pytest.raises(Forbidden):
+        await foresight_service.set_insights_config(
+            _ctx(workspace=None),
+            SetForesightInsightsConfigRequest(synthesizer="llm"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# DTO validation
+# ---------------------------------------------------------------------------
+
+
+def test_dto_rejects_unknown_synthesizer_value() -> None:
+    """The Literal type guards against typos at the DTO layer."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        SetForesightInsightsConfigRequest(synthesizer="LLM")  # uppercase
+    with pytest.raises(pydantic.ValidationError):
+        SetForesightInsightsConfigRequest(synthesizer="ai")
+    with pytest.raises(pydantic.ValidationError):
+        SetForesightInsightsConfigRequest(synthesizer=None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Router (HTTP) level
+# ---------------------------------------------------------------------------
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(foresight_router)
+
+    async def _ctx_dep() -> RequestContext:
+        return _ctx(workspace_id, user_id)
+
+    app.dependency_overrides[request_context] = _ctx_dep
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def http_client_w1(mongo_db: Any) -> AsyncClient:
+    app = _build_app(workspace_id="w1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+async def test_get_insights_config_endpoint_returns_default(
+    http_client_w1: AsyncClient,
+) -> None:
+    resp = await http_client_w1.get("/foresight/workspace/insights-config")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {
+        "workspace_id",
+        "synthesizer",
+        "llm_cache_ttl_seconds",
+        "updated_at",
+    }
+    assert body["workspace_id"] == "w1"
+    assert body["synthesizer"] == "pattern"
+    assert body["llm_cache_ttl_seconds"] >= 1
+    assert body["updated_at"] is None
+
+
+async def test_put_insights_config_endpoint_sets_llm_and_get_reflects(
+    http_client_w1: AsyncClient,
+) -> None:
+    put_resp = await http_client_w1.put(
+        "/foresight/workspace/insights-config",
+        json={"synthesizer": "llm"},
+    )
+    assert put_resp.status_code == 200
+    payload = put_resp.json()
+    assert payload["synthesizer"] == "llm"
+    assert payload["updated_at"] is not None
+
+    follow = await http_client_w1.get("/foresight/workspace/insights-config")
+    assert follow.status_code == 200
+    assert follow.json()["synthesizer"] == "llm"
+
+
+async def test_put_insights_config_endpoint_unknown_value_422(
+    http_client_w1: AsyncClient,
+) -> None:
+    """DTO Literal validation: 422 for unknown synthesizer value."""
+    for bad in ("LLM", "ai", "gpt", "", None):
+        resp = await http_client_w1.put(
+            "/foresight/workspace/insights-config",
+            json={"synthesizer": bad},
+        )
+        assert resp.status_code == 422, f"expected 422 for synthesizer={bad!r}"
+
+
+async def test_put_insights_config_endpoint_extra_field_422_or_400(
+    http_client_w1: AsyncClient,
+) -> None:
+    """Extra fields forbidden by the DTO (model_config extra='forbid')."""
+    resp = await http_client_w1.put(
+        "/foresight/workspace/insights-config",
+        json={"synthesizer": "llm", "rogue_field": "bad"},
+    )
+    assert resp.status_code in (400, 422)
+
+
+async def test_cross_tenant_isolation_via_http(mongo_db: Any) -> None:
+    """A toggle set under w1 must not leak into w2."""
+    # Set under w1.
+    app_w1 = _build_app(workspace_id="w1")
+    transport_w1 = ASGITransport(app=app_w1)
+    async with AsyncClient(transport=transport_w1, base_url="http://test") as c1:
+        resp = await c1.put(
+            "/foresight/workspace/insights-config",
+            json={"synthesizer": "llm"},
+        )
+        assert resp.status_code == 200
+
+    # Read under w2 — should still be pattern.
+    app_w2 = _build_app(workspace_id="w2")
+    transport_w2 = ASGITransport(app=app_w2)
+    async with AsyncClient(transport=transport_w2, base_url="http://test") as c2:
+        resp = await c2.get("/foresight/workspace/insights-config")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["workspace_id"] == "w2"
+        assert body["synthesizer"] == "pattern"

--- a/tests/cloud/test_foresight_service_insights_llm.py
+++ b/tests/cloud/test_foresight_service_insights_llm.py
@@ -1,0 +1,327 @@
+# tests/cloud/test_foresight_service_insights_llm.py
+# Created: 2026-05-26 (feat/foresight-v10-insights-llm) — RFC 08 v1.0.
+# Service-level tests for the LLM toggle on ``get_insights``:
+#   - synthesizer="pattern" → existing five-rule path runs unchanged
+#     (regression guard).
+#   - synthesizer="llm" + valid backend → LLM-driven insights surface
+#     through the wire response with the right shape.
+#   - synthesizer="llm" + backend failure (rate-limit, malformed JSON,
+#     empty output) → falls back to the pattern synthesizer so the wire
+#     response never 5xxs.
+#   - Tenant filter applies: an LLM call for w1 must NOT leak into w2's
+#     insight set.
+"""Cloud-side ``get_insights`` LLM branch tests."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.foresight import service as foresight_service
+from pocketpaw_ee.cloud.foresight.dto import SetForesightInsightsConfigRequest
+from pocketpaw_ee.cloud.models.foresight_prediction_record import (
+    ForesightPredictionRecord,
+)
+from pocketpaw_ee.foresight import insights_llm
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(workspace: str | None = "w1") -> RequestContext:
+    return RequestContext(
+        user_id="u1",
+        workspace_id=workspace,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _seed_record(
+    *,
+    workspace: str = "w1",
+    persona_id: str = "alice",
+    confidence: float = 0.3,
+    captured_at: datetime | None = None,
+    paired: bool = True,
+    run_id: str = "r-1",
+    tick_id: int = 0,
+) -> None:
+    if captured_at is None:
+        captured_at = datetime.now(UTC) - timedelta(days=1)
+    doc = ForesightPredictionRecord(
+        workspace=workspace,
+        anchor_id="decision:lease",
+        persona_id=persona_id,
+        scenario_id="seed",
+        run_id=run_id,
+        tick_id=tick_id,
+        prediction={"modal_outcome": "accept"},
+        confidence=confidence,
+        captured_at=captured_at,
+        observed_at=captured_at + timedelta(seconds=1) if paired else None,
+        observed_outcome={"outcome": "reject"} if paired else None,
+        paired=paired,
+        pair_delta={"outcome": {"match": False, "projected": "accept", "actual": "reject"}}
+        if paired
+        else None,
+    )
+    await doc.insert()
+
+
+class _StubLLMBackend:
+    """Mock LLM backend for service-level tests."""
+
+    def __init__(self, *, responses: list[str], raise_on_call: Exception | None = None) -> None:
+        self._responses = list(responses)
+        self._raise = raise_on_call
+        self.calls: list[str] = []
+
+    async def complete(self, prompt: str) -> str:
+        self.calls.append(prompt)
+        if self._raise is not None:
+            raise self._raise
+        if not self._responses:
+            return ""
+        return self._responses.pop(0)
+
+
+def _valid_llm_payload() -> str:
+    return json.dumps(
+        {
+            "insights": [
+                {
+                    "kind": "trend_explainer",
+                    "title": "Persona alice underperforms",
+                    "body": "Alice's recent calibration falls below the 0.50 floor.",
+                    "severity": "warning",
+                    "anchor_refs": ["persona:alice"],
+                }
+            ]
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_llm_state() -> None:
+    """Reset the LLM cache + the test-only backend override between tests."""
+    insights_llm.reset_cache()
+    foresight_service._set_llm_backend_for_testing(None)
+    yield
+    insights_llm.reset_cache()
+    foresight_service._set_llm_backend_for_testing(None)
+
+
+# ---------------------------------------------------------------------------
+# Pattern path (default) — regression guard
+# ---------------------------------------------------------------------------
+
+
+async def test_get_insights_default_uses_pattern_synthesizer() -> None:
+    """No config doc → synthesizer="pattern" → existing five-rule path."""
+    # Seed enough prediction records that persona_outlier would fire on
+    # the pattern path.
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    for i in range(3):
+        await _seed_record(
+            persona_id="alice",
+            confidence=0.2,
+            run_id=f"r-{i}",
+            tick_id=i,
+            captured_at=captured_at,
+        )
+
+    # Backend should NEVER be called on the pattern path; install a
+    # noisy stub to prove it.
+    raising = _StubLLMBackend(responses=[], raise_on_call=RuntimeError("must not be called"))
+    foresight_service._set_llm_backend_for_testing(raising)
+
+    response = await foresight_service.get_insights(_ctx())
+    persona_outliers = [i for i in response.items if i.kind == "persona_outlier"]
+    assert len(persona_outliers) >= 1
+    assert raising.calls == []
+
+
+# ---------------------------------------------------------------------------
+# LLM path — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_get_insights_with_llm_synthesizer_uses_llm_backend() -> None:
+    """synthesizer="llm" → backend is invoked and its output reaches the wire."""
+    # Seed enough records to make the LLM call meaningful.
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    for i in range(5):
+        await _seed_record(
+            persona_id="alice",
+            confidence=0.4,
+            run_id=f"r-{i}",
+            tick_id=i,
+            captured_at=captured_at,
+        )
+
+    # Flip the workspace toggle to "llm".
+    await foresight_service.set_insights_config(
+        _ctx(),
+        SetForesightInsightsConfigRequest(synthesizer="llm"),
+    )
+    backend = _StubLLMBackend(responses=[_valid_llm_payload()])
+    foresight_service._set_llm_backend_for_testing(backend)
+
+    response = await foresight_service.get_insights(_ctx())
+    assert len(backend.calls) == 1
+    # LLM-driven insights surface with their own kinds.
+    kinds = {i.kind for i in response.items}
+    assert "trend_explainer" in kinds
+    # Stable id discipline — LLM ids carry the llm_ prefix.
+    assert any(i.id.startswith("llm_") for i in response.items)
+
+
+# ---------------------------------------------------------------------------
+# LLM failure → fallback to pattern
+# ---------------------------------------------------------------------------
+
+
+async def test_get_insights_with_llm_falls_back_to_pattern_on_failure() -> None:
+    """LLM call raises (rate-limit) → pattern rules still produce output."""
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    for i in range(3):
+        await _seed_record(
+            persona_id="alice",
+            confidence=0.2,
+            run_id=f"r-{i}",
+            tick_id=i,
+            captured_at=captured_at,
+        )
+
+    await foresight_service.set_insights_config(
+        _ctx(),
+        SetForesightInsightsConfigRequest(synthesizer="llm"),
+    )
+    # Backend raises — synthesize_insights_llm returns [] which the
+    # cloud service interprets as "fall back to pattern".
+    backend = _StubLLMBackend(responses=[], raise_on_call=RuntimeError("rate limit"))
+    foresight_service._set_llm_backend_for_testing(backend)
+
+    response = await foresight_service.get_insights(_ctx())
+    # Backend was called once.
+    assert len(backend.calls) == 1
+    # Pattern-rule output survives — persona_outlier should fire.
+    persona_outliers = [i for i in response.items if i.kind == "persona_outlier"]
+    assert len(persona_outliers) >= 1
+
+
+async def test_get_insights_with_llm_falls_back_on_malformed_json() -> None:
+    """LLM returns garbage → synthesize_insights_llm returns [] → fallback."""
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    for i in range(3):
+        await _seed_record(
+            persona_id="alice",
+            confidence=0.2,
+            run_id=f"r-{i}",
+            tick_id=i,
+            captured_at=captured_at,
+        )
+
+    await foresight_service.set_insights_config(
+        _ctx(),
+        SetForesightInsightsConfigRequest(synthesizer="llm"),
+    )
+    backend = _StubLLMBackend(responses=["not json {malformed"])
+    foresight_service._set_llm_backend_for_testing(backend)
+
+    response = await foresight_service.get_insights(_ctx())
+    assert len(backend.calls) == 1
+    persona_outliers = [i for i in response.items if i.kind == "persona_outlier"]
+    assert len(persona_outliers) >= 1
+
+
+async def test_get_insights_with_llm_empty_workspace_returns_empty_items() -> None:
+    """LLM path on an empty workspace → ``items=[]`` (both LLM AND
+    pattern produce nothing on no data)."""
+    await foresight_service.set_insights_config(
+        _ctx(),
+        SetForesightInsightsConfigRequest(synthesizer="llm"),
+    )
+    backend = _StubLLMBackend(responses=[json.dumps({"insights": []})])
+    foresight_service._set_llm_backend_for_testing(backend)
+
+    response = await foresight_service.get_insights(_ctx())
+    assert response.items == []
+
+
+# ---------------------------------------------------------------------------
+# Tenant isolation on the LLM path
+# ---------------------------------------------------------------------------
+
+
+async def test_get_insights_with_llm_isolates_across_workspaces() -> None:
+    """w1's LLM call doesn't poison w2's cache; toggle is per-workspace."""
+    # Seed both workspaces with their own data.
+    await _seed_record(workspace="w1", persona_id="alice", run_id="r-1", tick_id=0)
+    await _seed_record(workspace="w1", persona_id="alice", run_id="r-1", tick_id=1)
+    await _seed_record(workspace="w2", persona_id="bob", run_id="r-1", tick_id=0)
+    await _seed_record(workspace="w2", persona_id="bob", run_id="r-1", tick_id=1)
+
+    # Only w1 opts into LLM.
+    await foresight_service.set_insights_config(
+        _ctx(workspace="w1"),
+        SetForesightInsightsConfigRequest(synthesizer="llm"),
+    )
+
+    backend = _StubLLMBackend(responses=[_valid_llm_payload()])
+    foresight_service._set_llm_backend_for_testing(backend)
+
+    # w1 → LLM path
+    w1_response = await foresight_service.get_insights(_ctx(workspace="w1"))
+    assert any(i.id.startswith("llm_") for i in w1_response.items)
+    assert len(backend.calls) == 1
+
+    # w2 → pattern path (didn't flip toggle); backend NOT called again.
+    w2_response = await foresight_service.get_insights(_ctx(workspace="w2"))
+    assert all(not i.id.startswith("llm_") for i in w2_response.items)
+    assert len(backend.calls) == 1  # still 1 — no extra invocation
+    # w2 sees pattern insights for its OWN persona, not w1's alice.
+    assert all("alice" not in (i.body + i.title) for i in w2_response.items)
+
+
+# ---------------------------------------------------------------------------
+# Cache hit on the service path
+# ---------------------------------------------------------------------------
+
+
+async def test_get_insights_with_llm_caches_repeat_calls() -> None:
+    """Repeat GET on stable data → one backend call (cache hit second time)."""
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    for i in range(3):
+        await _seed_record(
+            persona_id="alice",
+            confidence=0.4,
+            run_id=f"r-{i}",
+            tick_id=i,
+            captured_at=captured_at,
+        )
+
+    await foresight_service.set_insights_config(
+        _ctx(),
+        SetForesightInsightsConfigRequest(synthesizer="llm"),
+    )
+    backend = _StubLLMBackend(
+        responses=[_valid_llm_payload(), _valid_llm_payload()],
+    )
+    foresight_service._set_llm_backend_for_testing(backend)
+
+    first = await foresight_service.get_insights(_ctx())
+    second = await foresight_service.get_insights(_ctx())
+    assert [i.id for i in first.items] == [i.id for i in second.items]
+    assert len(backend.calls) == 1
+
+
+async def test_get_insights_requires_workspace_under_llm_path() -> None:
+    """The tenancy guard still fires on the LLM branch."""
+    from pocketpaw_ee.cloud._core.errors import Forbidden
+
+    with pytest.raises(Forbidden):
+        await foresight_service.get_insights(_ctx(workspace=None))

--- a/tests/ee/foresight/test_insights_llm.py
+++ b/tests/ee/foresight/test_insights_llm.py
@@ -1,0 +1,529 @@
+# tests/ee/foresight/test_insights_llm.py
+# Created: 2026-05-26 (feat/foresight-v10-insights-llm) — RFC 08 v1.0.
+# Unit tests for the LLM-driven insights synthesizer in
+# ``ee/pocketpaw_ee/foresight/insights_llm.py``. Exercises:
+#   - Happy path: backend returns valid JSON → list of Insight rows.
+#   - Malformed JSON output → returns ``[]`` (the cloud-side
+#     ``get_insights`` then falls back to pattern rules).
+#   - Partial-valid output: some items pass validation, others get
+#     skipped with a warning.
+#   - Severity coercion: unknown severity values land as ``"info"`` so
+#     the UI's severity → colour mapping stays defined.
+#   - Backend exceptions (rate-limit / connection) → returns ``[]``.
+#   - Cache hit: second call with same input data returns cached output
+#     without re-calling the backend; the cache is workspace-scoped so
+#     a second workspace's call doesn't poison the first's cache.
+#   - Stable id discipline: same input always yields the same id;
+#     differently-prompted output yields different ids.
+"""Unit tests for the LLM-driven foresight insights synthesizer."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from pocketpaw_ee.foresight.insights import (
+    ConfidenceDriftInput,
+    LatestBacktestGate,
+    PerPersonaCalibration,
+    RollingAccuracyPoint,
+    TierDistributionDelta,
+)
+from pocketpaw_ee.foresight.insights_llm import (
+    LLM_KIND_VOCABULARY,
+    LLMInsightsInput,
+    RecentPredictionRecordSummary,
+    configure_cache,
+    reset_cache,
+    synthesize_insights_llm,
+)
+
+_NOW = datetime(2026, 5, 26, 12, 0, 0, tzinfo=UTC)
+_DAY = timedelta(days=1)
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache() -> None:
+    """Ensure each test sees a clean LRU + the module-default TTL."""
+    reset_cache()
+    yield
+    reset_cache()
+
+
+def _make_bundle(
+    *,
+    workspace_id: str = "w-test",
+    period_key: str = "2026_W21",
+) -> LLMInsightsInput:
+    """Build a representative bundle with one insight in every input."""
+    return LLMInsightsInput(
+        workspace_id=workspace_id,
+        period_key=period_key,
+        now=_NOW,
+        rolling_accuracy=(
+            RollingAccuracyPoint(ts=_NOW - 7 * _DAY, accuracy=0.80, sample_count=40),
+            RollingAccuracyPoint(ts=_NOW, accuracy=0.55, sample_count=42),
+        ),
+        confidence_drift=ConfidenceDriftInput(trend="falling", magnitude=0.30),
+        per_persona_calibration=(
+            PerPersonaCalibration(persona_id="alice", calibration=0.40, sample_count=8),
+            PerPersonaCalibration(persona_id="bob", calibration=0.72, sample_count=12),
+        ),
+        tier_distribution_deltas=(
+            TierDistributionDelta(tier="premium", configured=0.05, actual=0.30),
+            TierDistributionDelta(tier="tail", configured=0.80, actual=0.55),
+        ),
+        latest_backtest=LatestBacktestGate(
+            backtest_id="bt-1",
+            passed=False,
+            observed=0.55,
+            threshold=0.65,
+            completed_at=_NOW - 2 * _DAY,
+        ),
+        recent_records=(
+            RecentPredictionRecordSummary(
+                anchor_id="decision:lease",
+                persona_id="alice",
+                modal_outcome="accept",
+                confidence=0.4,
+                paired=True,
+                observed_outcome="reject",
+                captured_at=_NOW - _DAY,
+            ),
+        ),
+    )
+
+
+class _StubBackend:
+    """Mock LLM backend with scriptable responses + call counting."""
+
+    def __init__(
+        self,
+        *,
+        responses: list[str] | None = None,
+        raise_on_call: Exception | None = None,
+    ) -> None:
+        self._responses = list(responses or [])
+        self._raise = raise_on_call
+        self.calls: list[str] = []
+
+    async def complete(self, prompt: str) -> str:
+        self.calls.append(prompt)
+        if self._raise is not None:
+            raise self._raise
+        if not self._responses:
+            return ""
+        return self._responses.pop(0)
+
+
+def _valid_json_payload(*, count: int = 3) -> str:
+    """Build a representative LLM response payload."""
+    items: list[dict[str, Any]] = []
+    for i in range(count):
+        items.append(
+            {
+                "kind": "trend_explainer" if i == 0 else "outlier_cluster",
+                "title": f"Insight {i}",
+                "body": f"Reasoning for insight {i} referencing persona:alice",
+                "severity": "warning" if i % 2 == 0 else "info",
+                "anchor_refs": ["persona:alice"] if i == 0 else [],
+            }
+        )
+    return json.dumps({"insights": items})
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_synthesize_happy_path_returns_insights() -> None:
+    """Backend returns valid JSON → parsed list of Insight records."""
+    backend = _StubBackend(responses=[_valid_json_payload(count=3)])
+    bundle = _make_bundle()
+    out = await synthesize_insights_llm(bundle, backend)
+    assert len(out) == 3
+    # Sorted by severity desc (warning > info) then generated_at desc.
+    severities = [i.severity for i in out]
+    assert severities[0] == "warning"
+    # Each insight has a stable id with the ``llm_`` prefix.
+    assert all(i.id.startswith("llm_") for i in out)
+    # Backend was called once.
+    assert len(backend.calls) == 1
+    # Prompt mentions the workspace data — the rolling accuracy + drift
+    # + persona ids appear in the prompt JSON section.
+    prompt = backend.calls[0]
+    assert "alice" in prompt
+    assert "decision:lease" in prompt
+    assert "trend_explainer" in prompt  # kind vocabulary echoed
+
+
+async def test_synthesize_anchors_passed_through() -> None:
+    """``anchor_refs`` from the LLM payload survives parsing."""
+    backend = _StubBackend(
+        responses=[
+            json.dumps(
+                {
+                    "insights": [
+                        {
+                            "kind": "persona_pattern",
+                            "title": "Alice underperforms",
+                            "body": "Alice's calibration is 0.40 below the 0.50 floor.",
+                            "severity": "warning",
+                            "anchor_refs": ["persona:alice", "tier:premium"],
+                        }
+                    ]
+                }
+            )
+        ]
+    )
+    out = await synthesize_insights_llm(_make_bundle(), backend)
+    assert len(out) == 1
+    assert out[0].anchor_refs == ("persona:alice", "tier:premium")
+    assert out[0].kind == "persona_pattern"
+
+
+# ---------------------------------------------------------------------------
+# Error paths — ALL collapse to []
+# ---------------------------------------------------------------------------
+
+
+async def test_synthesize_returns_empty_on_malformed_json() -> None:
+    """Output that isn't JSON returns ``[]`` so the caller falls back."""
+    backend = _StubBackend(responses=["not actually json {{"])
+    out = await synthesize_insights_llm(_make_bundle(), backend)
+    assert out == []
+
+
+async def test_synthesize_returns_empty_on_empty_output() -> None:
+    backend = _StubBackend(responses=[""])
+    out = await synthesize_insights_llm(_make_bundle(), backend)
+    assert out == []
+
+
+async def test_synthesize_returns_empty_on_array_at_top_level() -> None:
+    """Top-level must be an object — array shape is invalid."""
+    backend = _StubBackend(responses=[json.dumps([{"kind": "x", "title": "y"}])])
+    out = await synthesize_insights_llm(_make_bundle(), backend)
+    assert out == []
+
+
+async def test_synthesize_returns_empty_when_insights_field_missing() -> None:
+    backend = _StubBackend(responses=[json.dumps({"items": []})])
+    out = await synthesize_insights_llm(_make_bundle(), backend)
+    assert out == []
+
+
+async def test_synthesize_handles_backend_exception() -> None:
+    """Backend raising → returns ``[]`` (fallback to pattern path)."""
+    backend = _StubBackend(raise_on_call=RuntimeError("rate limited"))
+    out = await synthesize_insights_llm(_make_bundle(), backend)
+    assert out == []
+
+
+async def test_synthesize_handles_backend_timeout() -> None:
+    """``backend.complete`` hangs → the asyncio.wait_for timeout fires
+    and the call returns ``[]`` so the caller can fall back."""
+
+    class _HangingBackend:
+        async def complete(self, prompt: str) -> str:  # noqa: ARG002
+            await asyncio.sleep(60)  # longer than our timeout
+            return ""
+
+    out = await synthesize_insights_llm(
+        _make_bundle(),
+        _HangingBackend(),
+        timeout_seconds=0.1,
+    )
+    assert out == []
+
+
+async def test_synthesize_returns_empty_when_workspace_id_missing() -> None:
+    """Defensive — empty workspace_id collapses to ``[]`` (cloud rule #3)."""
+    bundle = LLMInsightsInput(
+        workspace_id="",
+        period_key="2026_W21",
+        now=_NOW,
+    )
+    backend = _StubBackend(responses=[_valid_json_payload()])
+    out = await synthesize_insights_llm(bundle, backend)
+    assert out == []
+    # Backend not called when the guard fires.
+    assert backend.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Partial parse
+# ---------------------------------------------------------------------------
+
+
+async def test_synthesize_partial_valid_skips_bad_items() -> None:
+    """Invalid items are skipped; valid siblings survive."""
+    payload = {
+        "insights": [
+            {  # valid
+                "kind": "trend_explainer",
+                "title": "Good",
+                "body": "Good reasoning",
+                "severity": "warning",
+            },
+            {  # missing body
+                "kind": "outlier_cluster",
+                "title": "Bad",
+                "severity": "info",
+            },
+            "not a dict",  # not even an object
+            {  # severity coerced
+                "kind": "persona_pattern",
+                "title": "Severity-coerce",
+                "body": "Reasoning",
+                "severity": "extreme",
+            },
+            {  # empty title
+                "kind": "data_quality",
+                "title": "   ",
+                "body": "x",
+                "severity": "info",
+            },
+        ]
+    }
+    backend = _StubBackend(responses=[json.dumps(payload)])
+    out = await synthesize_insights_llm(_make_bundle(), backend)
+    # Two valid items survive (1st + 4th).
+    assert len(out) == 2
+    titles = {i.title for i in out}
+    assert "Good" in titles
+    assert "Severity-coerce" in titles
+    # Severity coerces to "info".
+    coerced = next(i for i in out if i.title == "Severity-coerce")
+    assert coerced.severity == "info"
+
+
+async def test_synthesize_handles_code_fenced_output() -> None:
+    """LLMs commonly wrap JSON in ```json fences — the parser strips them."""
+    payload = json.dumps(
+        {
+            "insights": [
+                {
+                    "kind": "trend_explainer",
+                    "title": "Fenced output",
+                    "body": "Reasoning",
+                    "severity": "info",
+                }
+            ]
+        }
+    )
+    backend = _StubBackend(responses=[f"```json\n{payload}\n```"])
+    out = await synthesize_insights_llm(_make_bundle(), backend)
+    assert len(out) == 1
+    assert out[0].title == "Fenced output"
+
+
+# ---------------------------------------------------------------------------
+# Cache behavior
+# ---------------------------------------------------------------------------
+
+
+async def test_synthesize_cache_hit_does_not_call_backend_again() -> None:
+    """Two calls with the same workspace + data hash → one backend call."""
+    backend = _StubBackend(responses=[_valid_json_payload(count=2), _valid_json_payload(count=99)])
+    bundle = _make_bundle()
+    first = await synthesize_insights_llm(bundle, backend)
+    second = await synthesize_insights_llm(bundle, backend)
+    assert [i.id for i in first] == [i.id for i in second]
+    # Only one backend call — the second hit the LRU.
+    assert len(backend.calls) == 1
+
+
+async def test_synthesize_cache_isolates_across_workspaces() -> None:
+    """Different workspace_ids → independent cache entries."""
+    backend = _StubBackend(
+        responses=[
+            _valid_json_payload(count=1),
+            _valid_json_payload(count=2),
+        ]
+    )
+    out_w1 = await synthesize_insights_llm(_make_bundle(workspace_id="w1"), backend)
+    out_w2 = await synthesize_insights_llm(_make_bundle(workspace_id="w2"), backend)
+    assert len(out_w1) == 1
+    assert len(out_w2) == 2
+    # Two distinct backend calls — workspace isolation respected.
+    assert len(backend.calls) == 2
+
+
+async def test_synthesize_cache_invalidates_when_data_changes() -> None:
+    """A change in the input data invalidates the cache key."""
+    backend = _StubBackend(
+        responses=[
+            _valid_json_payload(count=1),
+            _valid_json_payload(count=3),
+        ]
+    )
+    bundle1 = _make_bundle()
+    out1 = await synthesize_insights_llm(bundle1, backend)
+    assert len(out1) == 1
+
+    # Mutate the rolling accuracy series → new data hash.
+    bundle2 = _make_bundle()
+    bundle2_changed = LLMInsightsInput(
+        **{
+            **bundle2.__dict__,
+            "rolling_accuracy": (
+                RollingAccuracyPoint(ts=_NOW - 7 * _DAY, accuracy=0.95, sample_count=40),
+                RollingAccuracyPoint(ts=_NOW, accuracy=0.92, sample_count=42),
+            ),
+        }
+    )
+    out2 = await synthesize_insights_llm(bundle2_changed, backend)
+    assert len(out2) == 3
+    assert len(backend.calls) == 2
+
+
+async def test_cache_ttl_expiry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stale cache entries (older than TTL) are evicted on lookup."""
+    backend = _StubBackend(
+        responses=[
+            _valid_json_payload(count=1),
+            _valid_json_payload(count=2),
+        ]
+    )
+    # 1-second TTL so we can drive expiry deterministically.
+    configure_cache(ttl_seconds=1)
+
+    bundle = _make_bundle()
+    first = await synthesize_insights_llm(bundle, backend)
+    assert len(first) == 1
+    assert len(backend.calls) == 1
+
+    # Fake-advance the clock past TTL.
+    import time as _time_mod
+
+    base = _time_mod.monotonic()
+
+    def _later() -> float:
+        return base + 5.0  # > 1-second TTL
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.foresight.insights_llm.time.monotonic",
+        _later,
+    )
+
+    second = await synthesize_insights_llm(bundle, backend)
+    assert len(second) == 2  # fresh response — cache miss after TTL
+    assert len(backend.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Stable id discipline
+# ---------------------------------------------------------------------------
+
+
+async def test_stable_ids_are_deterministic_across_runs() -> None:
+    """Identical input + identical LLM output → identical ids."""
+    backend1 = _StubBackend(responses=[_valid_json_payload(count=2)])
+    backend2 = _StubBackend(responses=[_valid_json_payload(count=2)])
+    bundle = _make_bundle()
+
+    out1 = await synthesize_insights_llm(bundle, backend1)
+    reset_cache()
+    out2 = await synthesize_insights_llm(bundle, backend2)
+
+    assert [i.id for i in out1] == [i.id for i in out2]
+
+
+async def test_stable_ids_differ_when_workspace_changes() -> None:
+    """Workspace_id is part of the id hash — same data + different
+    workspace → different ids."""
+    backend1 = _StubBackend(responses=[_valid_json_payload(count=1)])
+    backend2 = _StubBackend(responses=[_valid_json_payload(count=1)])
+
+    out1 = await synthesize_insights_llm(_make_bundle(workspace_id="w1"), backend1)
+    out2 = await synthesize_insights_llm(_make_bundle(workspace_id="w2"), backend2)
+    assert out1[0].id != out2[0].id
+
+
+# ---------------------------------------------------------------------------
+# Prompt content discipline
+# ---------------------------------------------------------------------------
+
+
+async def test_prompt_includes_kind_vocabulary() -> None:
+    """The prompt advertises the bounded kind set so the model stays
+    within the documented vocabulary."""
+    backend = _StubBackend(responses=[_valid_json_payload(count=0)])
+    await synthesize_insights_llm(_make_bundle(), backend)
+    prompt = backend.calls[0]
+    for kind in LLM_KIND_VOCABULARY:
+        assert kind in prompt, f"prompt missing kind vocabulary: {kind}"
+
+
+async def test_prompt_caps_recent_records() -> None:
+    """Bundle with many recent records → prompt only carries the cap."""
+    records = tuple(
+        RecentPredictionRecordSummary(
+            anchor_id=f"decision:rec-{i}",
+            persona_id=f"persona-{i}",
+            modal_outcome="accept",
+            confidence=0.5 + i * 0.001,
+            paired=True,
+        )
+        for i in range(200)
+    )
+    bundle = LLMInsightsInput(
+        workspace_id="w-cap",
+        period_key="2026_W21",
+        now=_NOW,
+        recent_records=records,
+        recent_records_cap=10,
+    )
+    backend = _StubBackend(responses=[json.dumps({"insights": []})])
+    await synthesize_insights_llm(bundle, backend)
+    prompt = backend.calls[0]
+    # Only 10 of the 200 records should be in the prompt — the 11th is
+    # excluded by the cap.
+    assert "decision:rec-9" in prompt
+    assert "decision:rec-10" not in prompt
+    assert "decision:rec-150" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Cap respect
+# ---------------------------------------------------------------------------
+
+
+async def test_response_capped_at_caller_cap() -> None:
+    """Even if the LLM returns more items than ``cap``, the result is
+    truncated at the cap so the wire response stays bounded."""
+    payload = json.dumps(
+        {
+            "insights": [
+                {
+                    "kind": "trend_explainer",
+                    "title": f"i{i}",
+                    "body": f"reasoning {i}",
+                    "severity": "info",
+                }
+                for i in range(20)
+            ]
+        }
+    )
+    backend = _StubBackend(responses=[payload])
+    out = await synthesize_insights_llm(_make_bundle(), backend, cap=5)
+    assert len(out) == 5
+
+
+async def test_cap_below_one_raises() -> None:
+    backend = _StubBackend(responses=[_valid_json_payload()])
+    with pytest.raises(ValueError):
+        await synthesize_insights_llm(_make_bundle(), backend, cap=0)
+
+
+async def test_configure_cache_validates_bounds() -> None:
+    """``configure_cache`` rejects out-of-range tunables explicitly."""
+    with pytest.raises(ValueError):
+        configure_cache(ttl_seconds=0)
+    with pytest.raises(ValueError):
+        configure_cache(capacity=0)


### PR DESCRIPTION
## Summary

Adds an opt-in **LLM-driven synthesizer** for `GET /api/v1/foresight/insights`. The v0.5 deterministic five-rule pattern synthesizer (PR #1241) stays as the default — workspaces opt into the LLM path via a new per-workspace config flag layered on the workspace-config doc from PR #1255. The wire shape of `/insights` is unchanged across both paths.

## What's in here

- **`ee/pocketpaw_ee/foresight/insights_llm.py`** — pure module living next to the existing `insights.py`. Exposes `synthesize_insights_llm(bundle, backend, *, cap, timeout_seconds)` and a `LLMBackendProtocol` that matches the surface of the existing `ClaudeCodeBackend` adapter, so the CC-SDK plugs in unchanged. Composes a structured summary (rolling accuracy + drift + modal outcomes + per-persona calibration + tier deltas + latest backtest + recent prediction records), prompts the model for up to 8 patterns, parses + validates JSON output into the existing `Insight` dataclass, and returns a sorted, capped list.

- **In-memory LRU cache** keyed on `(workspace_id, aggregator_state_hash)` with a 5-minute TTL. Polling UIs hit the cache for the next four polls of a 5-minute window; the data hash excludes `now` so a quiet workspace doesn't blow the cache every second.

- **Stable-id discipline** — each parsed insight's id is `llm_<safe_kind>_<sha1_12hex>` of `(workspace_id, period_key, prompt_hash, kind, ordinal)`. Same input + same LLM output → same ids across reloads so the UI's dedupe stays clean.

- **Hard fallback** — any LLM failure (timeout via `asyncio.wait_for`, malformed JSON, rate-limit / backend exception, payload missing the `insights` field) collapses to `[]`. The cloud-side `get_insights` then re-runs the pattern synthesizer so the wire response never 5xxs.

- **Per-workspace toggle** — extends `ForesightWorkspaceConfig` with `insights_synthesizer: Literal["pattern", "llm"]` (default `"pattern"`) and adds a sibling `/workspace/insights-config` endpoint pair mirroring the threshold-override surface from PR #1255. Emits `foresight.insights_config.updated` on effective change; no-op writes stay quiet.

- **Tests** — three new files covering 45 cases:
  - `tests/ee/foresight/test_insights_llm.py` — 22 unit tests (happy path, malformed JSON, partial-valid output, severity coercion, backend exception, timeout, code-fenced output, cache hit, workspace isolation, TTL expiry, stable-id discipline, prompt content, cap discipline).
  - `tests/cloud/test_foresight_service_insights_llm.py` — 8 service-level tests (pattern path regression guard, LLM happy path, fallback on raise / malformed JSON, tenant isolation, cache hit, empty workspace).
  - `tests/cloud/test_foresight_insights_config.py` — 15 tests for GET/PUT + DTO validation + tenant isolation.

## Design decisions

- **Separate endpoint vs extending threshold** — added a parallel `/workspace/insights-config` rather than collapsing the two into a generic multi-key endpoint. Keeps each setting cohesive, separate event types, and lets paw-enterprise read just the config it cares about without ignoring fields. Cheap to add a third sibling endpoint later if more settings land.

- **Opaque kind extension** — extended the LLM payload's `kind` values to a documented but bounded vocabulary (`trend_explainer`, `outlier_cluster`, `persona_pattern`, …). The existing `InsightView.kind` is `str`, so the cloud-side mapper handles both pattern + LLM kinds uniformly with no DTO churn.

- **Cost discipline** — LLM mode is opt-in only. Default stays `"pattern"` (deterministic, free). Cache TTL is 5 minutes — if the UI polls `/insights` every minute, only the first call of a window pays the LLM cost. Workspace admins flip the toggle explicitly via the new PUT; nothing in PR #1241's surface changes.

- **Wire shape unchanged** — `InsightsResponse` items still carry `id` / `kind` / `title` / `body` / `severity` / `anchor_refs` / `generated_at`. LLM-driven kinds are documented as an opaque enum extension (the UI's severity → colour mapping is unchanged because severity stays locked to `info | warning | critical`).

## Coordination

Wave 3 — Team 3. Team 1's scenario CRUD lands in the same `service.py` in a different bounded section (`# ── Scenario CRUD (Team 1 wave 3) ──` vs my `# ── LLM insights (Team 3 wave 3) ──`). The two diffs touch disjoint regions of the file and disjoint helpers.

## Verification

- `uv run --group ee pytest tests/ee/foresight tests/cloud -k "insights" --ignore=tests/cloud/extraction` → **86 passed**.
- Full foresight suite: `tests/ee/foresight tests/cloud -k "foresight"` → **534 passed**, no regressions.
- `uv run ruff check` → all green on touched files.
- `uv run ruff format` → applied.
- `uv run mypy` on touched files → only 2 pre-existing errors (`pocketpaw.instinct.models` / `pocketpaw.stores` lack py.typed markers) — verified pre-existing against `origin/foresight`.
- `uv run lint-imports --config ee/pyproject.toml` → **18 contracts kept, 0 broken**.

## Test plan

- [ ] CI green on the 86-test insights subset.
- [ ] CI green on the full `tests/ee/foresight + tests/cloud` foresight slice (534 tests).
- [ ] Manual: flip the workspace toggle via the new PUT, hit `/insights`, see LLM-driven kinds in the response. Flip back, see the v0.5 pattern kinds.
- [ ] Manual: simulate an LLM failure (network down) → `/insights` still returns pattern-rule output, no 5xx.