### PR TITLE
Auth/RBAC/Invitation hardening — Wave 2 (backend)

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -140,6 +140,7 @@ def mount_cloud(app: FastAPI) -> None:
     # Import and mount domain routers
     from pocketpaw_ee.cloud.agents.router import router as agents_router
     from pocketpaw_ee.cloud.audit.router import router as audit_router
+    from pocketpaw_ee.cloud.audit.router import workspace_router as audit_workspace_router
     from pocketpaw_ee.cloud.auth.router import router as auth_router
     from pocketpaw_ee.cloud.chat.router import router as chat_router
     from pocketpaw_ee.cloud.chat.runs.router import router as runs_router
@@ -160,6 +161,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(workspace_router, prefix="/api/v1")
     app.include_router(agents_router, prefix="/api/v1")
     app.include_router(audit_router, prefix="/api/v1")
+    app.include_router(audit_workspace_router, prefix="/api/v1")
     app.include_router(chat_router, prefix="/api/v1")
     app.include_router(runs_router, prefix="/api/v1")
     app.include_router(connectors_router, prefix="/api/v1")

--- a/ee/pocketpaw_ee/cloud/_core/deps.py
+++ b/ee/pocketpaw_ee/cloud/_core/deps.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from fastapi import Depends, HTTPException
 
-from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound
 from pocketpaw_ee.cloud.auth import current_active_user
 from pocketpaw_ee.cloud.models.user import User
 from pocketpaw_ee.guards.audit import log_denial
@@ -172,7 +172,12 @@ def require_plan_feature(feature: str) -> Callable[..., Coroutine[Any, Any, None
     async def _guard(workspace_id: str = Depends(current_workspace_id)) -> None:
         from pocketpaw_ee.cloud.workspace import service as workspace_service
 
+        # Re-raises on DB errors — better to surface 5xx than silently
+        # downgrade an enterprise customer to the most restrictive plan
+        # during a transient Mongo flap.
         plan = await workspace_service.get_workspace_plan(workspace_id)
+        if plan is None:
+            raise NotFound("workspace", workspace_id)
         allowed_features = PLAN_FEATURES.get(plan, set())
         if feature not in allowed_features:
             raise Forbidden(

--- a/ee/pocketpaw_ee/cloud/_core/rate_limit.py
+++ b/ee/pocketpaw_ee/cloud/_core/rate_limit.py
@@ -1,0 +1,44 @@
+"""Rate-limit Depends factories for cloud routes.
+
+Layered on top of the OSS in-memory limiter from
+``pocketpaw.security.rate_limiter`` — no new dependency. The dashboard's
+middleware already enforces a per-IP api_limiter on every request; these
+deps add a finer-grained per-(actor, resource) bucket so abuse from a
+single authenticated actor is bounded even when the IP bucket isn't.
+
+In-memory backing is per-process. A multi-instance backend needs the
+Redis-backed Wave 3 limiter; until then a single-instance deploy is the
+assumption.
+"""
+
+from __future__ import annotations
+
+from fastapi import Depends
+
+from pocketpaw.security.rate_limiter import RateLimiter
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import RateLimited
+
+# 50 invites per workspace per actor per day. Burst capped at 50, refill at
+# 50/day so a single bad admin can't email-bomb a workspace's domain.
+_invite_create_limiter = RateLimiter(rate=50.0 / 86400.0, capacity=50)
+
+
+async def rate_limit_invite_create(
+    workspace_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> None:
+    """Per-(actor, workspace) bucket guarding POST /workspaces/{id}/invites.
+
+    Raises ``RateLimited`` (CloudError → 429) when the bucket is empty.
+    """
+    key = f"invite-create:{ctx.user_id}:{workspace_id}"
+    info = _invite_create_limiter.check(key)
+    if not info.allowed:
+        raise RateLimited(
+            "workspace.invite_rate_limited",
+            "Too many invites created — try again later.",
+        )
+
+
+__all__ = ["rate_limit_invite_create"]

--- a/ee/pocketpaw_ee/cloud/_core/rate_limit.py
+++ b/ee/pocketpaw_ee/cloud/_core/rate_limit.py
@@ -41,4 +41,23 @@ async def rate_limit_invite_create(
         )
 
 
-__all__ = ["rate_limit_invite_create"]
+def consume_invite_create_tokens(user_id: str, workspace_id: str, count: int) -> None:
+    """Consume ``count`` tokens from the invite-create bucket for this
+    (actor, workspace). Used by the bulk-invite route, where the batch
+    size isn't known at Depends-resolution time so the limiter has to be
+    checked manually inside the handler. Each email in the batch consumes
+    one token, so the same 50/day cap covers batches too — a 100-email
+    paste effectively spends two days of budget. That's intentional: bulk
+    is for one-off onboarding, not steady-state invite traffic.
+    """
+    key = f"invite-create:{user_id}:{workspace_id}"
+    for _ in range(count):
+        info = _invite_create_limiter.check(key)
+        if not info.allowed:
+            raise RateLimited(
+                "workspace.invite_rate_limited",
+                "Too many invites created — try again later.",
+            )
+
+
+__all__ = ["consume_invite_create_tokens", "rate_limit_invite_create"]

--- a/ee/pocketpaw_ee/cloud/_core/rate_limit.py
+++ b/ee/pocketpaw_ee/cloud/_core/rate_limit.py
@@ -23,6 +23,10 @@ from pocketpaw_ee.cloud._core.errors import RateLimited
 # 50/day so a single bad admin can't email-bomb a workspace's domain.
 _invite_create_limiter = RateLimiter(rate=50.0 / 86400.0, capacity=50)
 
+# 5 resends per 30 minutes per invite. Keyed on invite_id rather than actor
+# so an admin can't sidestep by rotating between teammates.
+_invite_resend_limiter = RateLimiter(rate=5.0 / 1800.0, capacity=5)
+
 
 async def rate_limit_invite_create(
     workspace_id: str,
@@ -60,4 +64,27 @@ def consume_invite_create_tokens(user_id: str, workspace_id: str, count: int) ->
             )
 
 
-__all__ = ["consume_invite_create_tokens", "rate_limit_invite_create"]
+async def rate_limit_invite_resend(
+    workspace_id: str,
+    invite_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> None:
+    """Per-invite bucket guarding POST /workspaces/{id}/invites/{invite_id}/resend.
+
+    Keyed on invite_id rather than actor: the resend is meant to refresh a
+    plaintext for the inviter's clipboard, not a re-mail blast surface.
+    """
+    key = f"invite-resend:{invite_id}"
+    info = _invite_resend_limiter.check(key)
+    if not info.allowed:
+        raise RateLimited(
+            "workspace.invite_resend_rate_limited",
+            "Too many resends — wait before retrying.",
+        )
+
+
+__all__ = [
+    "consume_invite_create_tokens",
+    "rate_limit_invite_create",
+    "rate_limit_invite_resend",
+]

--- a/ee/pocketpaw_ee/cloud/audit/domain.py
+++ b/ee/pocketpaw_ee/cloud/audit/domain.py
@@ -2,7 +2,7 @@
 # Created: 2026-05-17 — Tenancy fields required at construction per ee/cloud Rule 3.
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Literal, NewType
 
@@ -25,4 +25,37 @@ class AuditEntryView:
     status: str = "completed"
 
 
-__all__ = ["AuditEntryView", "AuditEntryId", "AuditCategory"]
+# ---------------------------------------------------------------------------
+# Workspace-mutation audit event (Wave 2 Task 10).
+# Tenancy fields (workspace_id, actor_id) are required at construction time
+# per cloud Rule 3.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AuditEventDomain:
+    id: str
+    workspace_id: str
+    actor_id: str
+    action: str
+    target_type: str
+    target_id: str | None
+    metadata: dict[str, Any]
+    ip: str | None
+    user_agent: str | None
+    at: datetime
+
+
+@dataclass(frozen=True)
+class AuditPage:
+    items: list[AuditEventDomain] = field(default_factory=list)
+    next_cursor: str | None = None
+
+
+__all__ = [
+    "AuditCategory",
+    "AuditEntryId",
+    "AuditEntryView",
+    "AuditEventDomain",
+    "AuditPage",
+]

--- a/ee/pocketpaw_ee/cloud/audit/dto.py
+++ b/ee/pocketpaw_ee/cloud/audit/dto.py
@@ -37,4 +37,47 @@ class AuditListResponse(BaseModel):
     total: int
 
 
-__all__ = ["ListAuditRequest", "AuditListResponse", "AuditEntryDTO"]
+# ---------------------------------------------------------------------------
+# Workspace audit-event DTOs (Wave 2 Task 10).
+#
+# Wire shape uses camelCase to match the rest of the workspace surface
+# (memberOut, inviteOut, etc.). Request / response classes are kept
+# distinct per cloud Rule 4.
+# ---------------------------------------------------------------------------
+
+
+class AuditEventOut(BaseModel):
+    id: str
+    workspaceId: str
+    actorId: str
+    action: str
+    targetType: str
+    targetId: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    ip: str | None = None
+    userAgent: str | None = None
+    at: str  # ISO-8601
+
+
+class AuditQueryRequest(BaseModel):
+    action: str | None = Field(default=None, max_length=120)
+    actor: str | None = Field(default=None, max_length=120)
+    since: str | None = None  # ISO-8601 — parsed in service
+    until: str | None = None  # ISO-8601
+    cursor: str | None = None  # opaque, composite ``{at_iso}|{oid}``
+    limit: int = Field(default=50, ge=1, le=100)
+
+
+class AuditPageResponse(BaseModel):
+    items: list[AuditEventOut]
+    nextCursor: str | None = None
+
+
+__all__ = [
+    "AuditEntryDTO",
+    "AuditEventOut",
+    "AuditListResponse",
+    "AuditPageResponse",
+    "AuditQueryRequest",
+    "ListAuditRequest",
+]

--- a/ee/pocketpaw_ee/cloud/audit/router.py
+++ b/ee/pocketpaw_ee/cloud/audit/router.py
@@ -6,9 +6,15 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Query, Request
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.deps import require_action
 from pocketpaw_ee.cloud._core.errors import CloudError
 from pocketpaw_ee.cloud.audit import service as audit_service
-from pocketpaw_ee.cloud.audit.dto import AuditListResponse, ListAuditRequest
+from pocketpaw_ee.cloud.audit.dto import (
+    AuditListResponse,
+    AuditPageResponse,
+    AuditQueryRequest,
+    ListAuditRequest,
+)
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.shared.deps import require_action_any_workspace
 
@@ -49,3 +55,44 @@ async def list_audit(
         cursor=cursor,
     )
     return await audit_service.agent_list_audit(ctx, body)
+
+
+# ---------------------------------------------------------------------------
+# Workspace-scoped audit log (Wave 2 Task 10).
+#
+# Separate router mounted under ``/workspaces/{workspace_id}/audit`` so the
+# admin-only ``audit.read`` guard binds to the path workspace, not the
+# active workspace on the user record.
+# ---------------------------------------------------------------------------
+
+
+workspace_router = APIRouter(
+    prefix="/workspaces",
+    tags=["Audit"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@workspace_router.get(
+    "/{workspace_id}/audit",
+    response_model=AuditPageResponse,
+    dependencies=[Depends(require_action("audit.read"))],
+)
+async def list_workspace_audit(
+    workspace_id: str,
+    action: str | None = Query(default=None, max_length=120),
+    actor: str | None = Query(default=None, max_length=120),
+    since: str | None = Query(default=None),
+    until: str | None = Query(default=None),
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=100),
+) -> AuditPageResponse:
+    body = AuditQueryRequest(
+        action=action,
+        actor=actor,
+        since=since,
+        until=until,
+        cursor=cursor,
+        limit=limit,
+    )
+    return await audit_service.list_events_response(workspace_id, body)

--- a/ee/pocketpaw_ee/cloud/audit/service.py
+++ b/ee/pocketpaw_ee/cloud/audit/service.py
@@ -5,11 +5,24 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
+from typing import Any
+
+from beanie import PydanticObjectId
 
 from pocketpaw.audit.store import AuditStore, get_audit_store  # type: ignore[import-untyped]
 from pocketpaw_ee.cloud._core.context import RequestContext
-from pocketpaw_ee.cloud._core.errors import CloudError, Internal
-from pocketpaw_ee.cloud.audit.dto import AuditEntryDTO, AuditListResponse, ListAuditRequest
+from pocketpaw_ee.cloud._core.errors import CloudError, Internal, ValidationError
+from pocketpaw_ee.cloud.audit.domain import AuditEventDomain, AuditPage
+from pocketpaw_ee.cloud.audit.dto import (
+    AuditEntryDTO,
+    AuditEventOut,
+    AuditListResponse,
+    AuditPageResponse,
+    AuditQueryRequest,
+    ListAuditRequest,
+)
+from pocketpaw_ee.cloud.models.audit_event import AuditEvent as _AuditEventDoc
 
 logger = logging.getLogger(__name__)
 
@@ -42,4 +55,164 @@ async def agent_list_audit(
     return AuditListResponse(entries=dtos, total=len(dtos))
 
 
-__all__ = ["agent_list_audit"]
+# ---------------------------------------------------------------------------
+# Workspace-mutation audit log (Wave 2 Task 10).
+#
+# ``record`` is called from workspace/service.py on every mutating op. It is
+# fire-and-forget: a write failure is logged and swallowed so an audit
+# outage cannot block a legitimate mutation. ``list_events`` is the read
+# path behind GET /workspaces/{id}/audit, paginated by a composite
+# ``(at, _id)`` cursor for stable ordering.
+#
+# IP + user-agent are stubbed to None for now; threading them through
+# RequestContext is deferred to Wave 3.
+# ---------------------------------------------------------------------------
+
+
+def _doc_to_domain(doc: _AuditEventDoc) -> AuditEventDomain:
+    return AuditEventDomain(
+        id=str(doc.id),
+        workspace_id=doc.workspace,
+        actor_id=doc.actor_id,
+        action=doc.action,
+        target_type=doc.target_type,
+        target_id=doc.target_id,
+        metadata=dict(doc.metadata or {}),
+        ip=doc.ip,
+        user_agent=doc.user_agent,
+        at=doc.at,
+    )
+
+
+def _domain_to_wire(d: AuditEventDomain) -> AuditEventOut:
+    return AuditEventOut(
+        id=d.id,
+        workspaceId=d.workspace_id,
+        actorId=d.actor_id,
+        action=d.action,
+        targetType=d.target_type,
+        targetId=d.target_id,
+        metadata=d.metadata,
+        ip=d.ip,
+        userAgent=d.user_agent,
+        at=d.at.isoformat(),
+    )
+
+
+def _encode_cursor(at: datetime, oid: PydanticObjectId) -> str:
+    return f"{at.isoformat()}|{oid!s}"
+
+
+def _decode_cursor(cursor: str) -> tuple[datetime, PydanticObjectId]:
+    try:
+        at_iso, oid_str = cursor.split("|", 1)
+        return datetime.fromisoformat(at_iso), PydanticObjectId(oid_str)
+    except (ValueError, TypeError) as exc:
+        raise ValidationError("audit.bad_cursor", "Invalid pagination cursor") from exc
+
+
+def _parse_iso(value: str, field_name: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValidationError("audit.bad_timestamp", f"Invalid ISO-8601 in {field_name!r}") from exc
+
+
+async def record(
+    workspace_id: str,
+    actor_id: str,
+    action: str,
+    *,
+    target_type: str,
+    target_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    ip: str | None = None,
+    user_agent: str | None = None,
+) -> None:
+    """Persist one workspace audit event.
+
+    Never raises — an audit-write failure is logged so the mutating
+    operation that triggered it can complete. # no-event: audit rows ARE
+    the event sink; emitting a realtime event here would be self-referential.
+    """
+    try:
+        doc = _AuditEventDoc(
+            workspace=workspace_id,
+            actor_id=actor_id,
+            action=action,
+            target_type=target_type,
+            target_id=target_id,
+            metadata=dict(metadata or {}),
+            ip=ip,
+            user_agent=user_agent,
+        )
+        await doc.insert()
+    except Exception:
+        logger.warning("audit.record failed for %s/%s", workspace_id, action, exc_info=True)
+
+
+async def list_events(workspace_id: str, query: AuditQueryRequest | dict) -> AuditPage:
+    """Cursor-paginated audit-event list, newest first."""
+    body = AuditQueryRequest.model_validate(query or {})
+
+    mongo_filter: dict[str, Any] = {"workspace": workspace_id}
+    if body.action:
+        mongo_filter["action"] = body.action
+    if body.actor:
+        mongo_filter["actor_id"] = body.actor
+
+    time_filter: dict[str, datetime] = {}
+    if body.since:
+        time_filter["$gte"] = _parse_iso(body.since, "since")
+    if body.until:
+        time_filter["$lte"] = _parse_iso(body.until, "until")
+    if time_filter:
+        mongo_filter["at"] = time_filter
+
+    if body.cursor:
+        c_at, c_oid = _decode_cursor(body.cursor)
+        cursor_clause: dict[str, Any] = {
+            "$or": [
+                {"at": {"$lt": c_at}},
+                {"at": c_at, "_id": {"$lt": c_oid}},
+            ],
+        }
+        mongo_filter = {"$and": [mongo_filter, cursor_clause]}
+
+    # Per reference_mongomock_quirks: no .aggregate() — straight find+sort
+    # with a composite sort key for stable ordering across pages.
+    docs = (
+        await _AuditEventDoc.find(mongo_filter)
+        .sort([("at", -1), ("_id", -1)])
+        .limit(body.limit + 1)
+        .to_list()
+    )
+
+    has_more = len(docs) > body.limit
+    rows = docs[: body.limit]
+    next_cursor = _encode_cursor(rows[-1].at, rows[-1].id) if has_more and rows else None
+    return AuditPage(items=[_doc_to_domain(d) for d in rows], next_cursor=next_cursor)
+
+
+async def list_events_response(
+    workspace_id: str,
+    query: AuditQueryRequest | dict,
+) -> AuditPageResponse:
+    """Service-level helper that wraps ``list_events`` in the wire shape.
+
+    Kept inline (cloud Rule 8: mapping helpers live next to the service)
+    so the router stays a thin adapter.
+    """
+    page = await list_events(workspace_id, query)
+    return AuditPageResponse(
+        items=[_domain_to_wire(d) for d in page.items],
+        nextCursor=page.next_cursor,
+    )
+
+
+__all__ = [
+    "agent_list_audit",
+    "list_events",
+    "list_events_response",
+    "record",
+]

--- a/ee/pocketpaw_ee/cloud/chat/group_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/group_service.py
@@ -885,10 +885,31 @@ async def set_member_role(
     return role
 
 
+async def _require_agent_in_workspace(agent_id: str, workspace_id: str) -> None:
+    """Raise ``NotFound`` unless the agent exists and belongs to ``workspace_id``.
+
+    Keeps existence opaque to attackers — a leaked ``agent_id`` from a foreign
+    workspace surfaces as a 404, never a 403 (which would confirm the agent
+    lives somewhere). Used by the group-agent add / update / remove paths to
+    block cross-tenant wiring.
+    """
+    from pocketpaw_ee.cloud.models.agent import Agent as AgentModel
+
+    try:
+        agent_oid = PydanticObjectId(agent_id)
+    except Exception as exc:  # noqa: BLE001 - surface as NotFound
+        raise NotFound("agent", agent_id) from exc
+
+    agent_doc = await AgentModel.get(agent_oid)
+    if agent_doc is None or agent_doc.workspace != workspace_id:
+        raise NotFound("agent", agent_id)
+
+
 async def add_agent(group_id: str, user_id: str, body: AddGroupAgentRequest) -> None:
     """Add an agent to a group. Owner only."""
     group = await _get_group_domain_or_404(group_id)
     _require_domain_group_admin(group, user_id)
+    await _require_agent_in_workspace(body.agent_id, group.workspace_id)
 
     for existing in group.agents:
         if existing.agent_id == body.agent_id:
@@ -917,6 +938,7 @@ async def update_agent(
     """Update an agent's respond_mode in a group. Owner only."""
     group = await _get_group_domain_or_404(group_id)
     _require_domain_group_admin(group, user_id)
+    await _require_agent_in_workspace(agent_id, group.workspace_id)
 
     result = await _update_group_agent_respond_mode_doc(group_id, agent_id, body.respond_mode)
     if result is None:
@@ -936,6 +958,7 @@ async def remove_agent(group_id: str, user_id: str, agent_id: str) -> None:
     """Remove an agent from a group. Owner only."""
     group = await _get_group_domain_or_404(group_id)
     _require_domain_group_admin(group, user_id)
+    await _require_agent_in_workspace(agent_id, group.workspace_id)
 
     result = await _remove_group_agent_doc(group_id, agent_id)
     if result is None:

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -8,6 +8,7 @@ remains registered in ``get_all_documents()`` for Beanie init.
 from __future__ import annotations
 
 from pocketpaw_ee.cloud.models.agent import Agent, AgentConfig
+from pocketpaw_ee.cloud.models.audit_event import AuditEvent
 from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
 from pocketpaw_ee.cloud.models.comment import Comment, CommentAuthor, CommentTarget
 from pocketpaw_ee.cloud.models.composio_connection import ComposioConnection
@@ -48,6 +49,7 @@ __all__ = [
     "Agent",
     "AgentConfig",
     "Attachment",
+    "AuditEvent",
     "ChatRunDoc",
     "Comment",
     "CommentAuthor",
@@ -112,6 +114,7 @@ def get_all_documents():
         Project,
         PlanSession,
         ChatRunDoc,
+        AuditEvent,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/models/audit_event.py
+++ b/ee/pocketpaw_ee/cloud/models/audit_event.py
@@ -1,0 +1,38 @@
+"""AuditEvent document — persistent audit log of workspace mutations.
+
+Wave 2 Task 10: structured audit-log for workspace CRUD, member ops, and
+invite ops. Distinct from the legacy ``pocketpaw.audit.store`` SQLite
+sink (which captures pocket / skills / agent decisions) — this doc
+captures *workspace-governance* writes for the admin-visible audit
+surface.
+
+The 1-year TTL keeps the collection bounded; ``workspace + at`` is the
+primary read path for cursor-paginated listing.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from beanie import Document, Indexed
+from pydantic import Field
+from pymongo import IndexModel
+
+
+class AuditEvent(Document):
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    actor_id: Indexed(str)  # type: ignore[valid-type]
+    action: Indexed(str)  # type: ignore[valid-type]
+    target_type: str
+    target_id: str | None = None
+    metadata: dict = Field(default_factory=dict)
+    ip: str | None = None
+    user_agent: str | None = None
+    at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "audit_events"
+        indexes = [
+            IndexModel([("workspace", 1), ("at", -1)]),
+            IndexModel("at", expireAfterSeconds=86400 * 365),
+        ]

--- a/ee/pocketpaw_ee/cloud/models/invite.py
+++ b/ee/pocketpaw_ee/cloud/models/invite.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime, timedelta
 
 from beanie import Document, Indexed
 from pydantic import Field
+from pymongo import IndexModel
 
 
 def _default_expiry() -> datetime:
@@ -55,3 +56,9 @@ class Invite(Document):
 
     class Settings:
         name = "invites"
+        indexes = [
+            # Mongo auto-deletes documents whose expires_at is more than 14
+            # days in the past — gives the application a 7-day grace beyond
+            # the 7-day invite expiry for late accepts / audit, then GC's.
+            IndexModel([("expires_at", 1)], expireAfterSeconds=86400 * 14),
+        ]

--- a/ee/pocketpaw_ee/cloud/models/invite.py
+++ b/ee/pocketpaw_ee/cloud/models/invite.py
@@ -44,6 +44,7 @@ class Invite(Document):
     group: str | None = None
     accepted: bool = False
     revoked: bool = False
+    revoked_reason: str | None = None  # e.g. "declined" when invitee declines vs inviter-revoke
     accepted_at: datetime | None = None  # single-use stamp (Task 4)
     expires_at: datetime = Field(default_factory=_default_expiry)
 

--- a/ee/pocketpaw_ee/cloud/models/invite.py
+++ b/ee/pocketpaw_ee/cloud/models/invite.py
@@ -47,6 +47,7 @@ class Invite(Document):
     revoked_reason: str | None = None  # e.g. "declined" when invitee declines vs inviter-revoke
     accepted_at: datetime | None = None  # single-use stamp (Task 4)
     expires_at: datetime = Field(default_factory=_default_expiry)
+    resend_count: int = 0  # increments on each POST /invites/{id}/resend
 
     @property
     def expired(self) -> bool:

--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import re
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.workspace.domain import Invite, Workspace, WorkspaceMember
@@ -48,6 +48,25 @@ class CreateInviteRequest(BaseModel):
 
 class UpdateMemberRoleRequest(BaseModel):
     role: str = Field(pattern="^(owner|admin|member)$")
+
+
+class BulkInviteRequest(BaseModel):
+    """POST /workspaces/{id}/invites/bulk request.
+
+    ``emails`` is bounded at 100 so a single batch can't dwarf the daily
+    invite-rate budget. The frontend's paste-a-list UI clamps client-side.
+    """
+
+    emails: list[EmailStr] = Field(min_length=1, max_length=100)
+    role: str = Field(default="member", pattern="^(admin|member)$")
+    group_id: str | None = None
+
+
+class BulkInviteSkip(BaseModel):
+    """One per-email skip in the bulk response."""
+
+    email: str
+    reason: Literal["already_member", "already_pending", "invalid_email", "seat_limit"]
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +116,13 @@ class InviteOut(BaseModel):
     expiresAt: str | None  # noqa: N815 - camelCase wire key
 
     model_config = {"populate_by_name": True}
+
+
+class BulkInviteResponse(BaseModel):
+    """POST /workspaces/{id}/invites/bulk response."""
+
+    created: list[InviteOut]
+    skipped: list[BulkInviteSkip]
 
 
 class ValidateInviteOut(InviteOut):
@@ -192,6 +218,9 @@ def invite_to_validate_dto(inv: Invite, workspace_name: str) -> ValidateInviteOu
 
 
 __all__ = [
+    "BulkInviteRequest",
+    "BulkInviteResponse",
+    "BulkInviteSkip",
     "CreateInviteRequest",
     "CreateWorkspaceRequest",
     "InviteOut",

--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -133,6 +133,24 @@ class ValidateInviteOut(InviteOut):
     workspace_name: str
 
 
+class WorkspaceDeletePreviewResponse(BaseModel):
+    """GET /workspaces/{id}/delete-preview response — blast-radius before delete.
+
+    Counts the rows the cascade in ``workspace_service.delete`` will tear
+    through (members, chat groups, agents, files, pending invites) plus the
+    total file bytes attributable to the workspace. The UI uses this for a
+    "Deleting will remove X members, Y rooms, Z bytes — this cannot be
+    undone" confirmation step before the type-name-to-confirm prompt.
+    """
+
+    member_count: int
+    room_count: int
+    agent_count: int
+    file_count: int
+    invite_count: int
+    total_bytes: int
+
+
 class InvitePreviewResponse(BaseModel):
     """Typed preview of an invite token for the accept UI.
 
@@ -229,6 +247,7 @@ __all__ = [
     "UpdateMemberRoleRequest",
     "UpdateWorkspaceRequest",
     "ValidateInviteOut",
+    "WorkspaceDeletePreviewResponse",
     "WorkspaceOut",
     "invite_to_dto",
     "invite_to_validate_dto",

--- a/ee/pocketpaw_ee/cloud/workspace/router.py
+++ b/ee/pocketpaw_ee/cloud/workspace/router.py
@@ -222,5 +222,5 @@ async def revoke_invite(
     invite_id: str,
     user: User = Depends(require_action("invite.revoke")),
 ) -> Response:
-    await workspace_service.revoke_invite(workspace_id, invite_id)
+    await workspace_service.revoke_invite(workspace_id, invite_id, str(user.id))
     return Response(status_code=204)

--- a/ee/pocketpaw_ee/cloud/workspace/router.py
+++ b/ee/pocketpaw_ee/cloud/workspace/router.py
@@ -16,6 +16,7 @@ from pocketpaw_ee.cloud._core.deps import (
     require_action,
     require_membership,
 )
+from pocketpaw_ee.cloud._core.rate_limit import rate_limit_invite_create
 from pocketpaw_ee.cloud.auth.core import current_optional_user
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.models.user import User
@@ -152,6 +153,7 @@ async def create_invite(
     body: CreateInviteRequest,
     ctx: RequestContext = Depends(request_context),
     user: User = Depends(require_action("invite.create")),
+    _rl: None = Depends(rate_limit_invite_create),
 ) -> InviteOut:
     invite = await workspace_service.create_invite(ctx, workspace_id, body)
     return invite_to_dto(invite)

--- a/ee/pocketpaw_ee/cloud/workspace/router.py
+++ b/ee/pocketpaw_ee/cloud/workspace/router.py
@@ -19,6 +19,7 @@ from pocketpaw_ee.cloud._core.deps import (
 from pocketpaw_ee.cloud._core.rate_limit import (
     consume_invite_create_tokens,
     rate_limit_invite_create,
+    rate_limit_invite_resend,
 )
 from pocketpaw_ee.cloud.auth.core import current_optional_user
 from pocketpaw_ee.cloud.license import require_license
@@ -224,3 +225,20 @@ async def revoke_invite(
 ) -> Response:
     await workspace_service.revoke_invite(workspace_id, invite_id, str(user.id))
     return Response(status_code=204)
+
+
+@router.post("/{workspace_id}/invites/{invite_id}/resend")
+async def resend_invite_route(
+    workspace_id: str,
+    invite_id: str,
+    ctx: RequestContext = Depends(request_context),
+    user: User = Depends(require_action("invite.resend")),
+    _rl: None = Depends(rate_limit_invite_resend),
+) -> dict:
+    """Rotate the invite's token and return the fresh plaintext.
+
+    The plaintext is the value the UI needs to put on the clipboard for
+    the inviter — the server only stores the hash, so this is the only
+    moment the plaintext exists outside the original email link.
+    """
+    return await workspace_service.resend_invite(ctx, workspace_id, invite_id)

--- a/ee/pocketpaw_ee/cloud/workspace/router.py
+++ b/ee/pocketpaw_ee/cloud/workspace/router.py
@@ -184,6 +184,13 @@ async def accept_invite(
     return {"ok": True}
 
 
+@router.post("/invites/{token}/decline", status_code=204)
+async def decline_invite_route(token: str) -> Response:
+    """Invitee-side decline. Public — the invitee may not have an account."""
+    await workspace_service.decline_invite(token)
+    return Response(status_code=204)
+
+
 @router.delete("/{workspace_id}/invites/{invite_id}", status_code=204)
 async def revoke_invite(
     workspace_id: str,

--- a/ee/pocketpaw_ee/cloud/workspace/router.py
+++ b/ee/pocketpaw_ee/cloud/workspace/router.py
@@ -16,12 +16,18 @@ from pocketpaw_ee.cloud._core.deps import (
     require_action,
     require_membership,
 )
-from pocketpaw_ee.cloud._core.rate_limit import rate_limit_invite_create
+from pocketpaw_ee.cloud._core.rate_limit import (
+    consume_invite_create_tokens,
+    rate_limit_invite_create,
+)
 from pocketpaw_ee.cloud.auth.core import current_optional_user
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.models.user import User
 from pocketpaw_ee.cloud.workspace import service as workspace_service
 from pocketpaw_ee.cloud.workspace.dto import (
+    BulkInviteRequest,
+    BulkInviteResponse,
+    BulkInviteSkip,
     CreateInviteRequest,
     CreateWorkspaceRequest,
     InviteOut,
@@ -157,6 +163,25 @@ async def create_invite(
 ) -> InviteOut:
     invite = await workspace_service.create_invite(ctx, workspace_id, body)
     return invite_to_dto(invite)
+
+
+@router.post("/{workspace_id}/invites/bulk", response_model=BulkInviteResponse)
+async def bulk_create_invites(
+    workspace_id: str,
+    body: BulkInviteRequest,
+    ctx: RequestContext = Depends(request_context),
+    user: User = Depends(require_action("invite.create")),
+) -> BulkInviteResponse:
+    # FastAPI's Depends can't see the request body, so the limiter has
+    # to be consumed inside the handler with the actual batch size.
+    # Counted BEFORE the service call so a rejected batch never touches
+    # the DB.
+    consume_invite_create_tokens(ctx.user_id, workspace_id, len(body.emails))
+    result = await workspace_service.bulk_create_invites(ctx, workspace_id, body)
+    return BulkInviteResponse(
+        created=[invite_to_dto(inv) for inv in result["created"]],
+        skipped=[BulkInviteSkip(**s) for s in result["skipped"]],
+    )
 
 
 @router.get("/invites/{token}/preview", response_model=InvitePreviewResponse)

--- a/ee/pocketpaw_ee/cloud/workspace/router.py
+++ b/ee/pocketpaw_ee/cloud/workspace/router.py
@@ -37,6 +37,7 @@ from pocketpaw_ee.cloud.workspace.dto import (
     UpdateMemberRoleRequest,
     UpdateWorkspaceRequest,
     ValidateInviteOut,
+    WorkspaceDeletePreviewResponse,
     WorkspaceOut,
     invite_to_dto,
     invite_to_validate_dto,
@@ -102,6 +103,22 @@ async def delete_workspace(
 ) -> Response:
     await workspace_service.delete(ctx, workspace_id)
     return Response(status_code=204)
+
+
+@router.get(
+    "/{workspace_id}/delete-preview",
+    response_model=WorkspaceDeletePreviewResponse,
+)
+async def delete_preview(
+    workspace_id: str,
+    user: User = Depends(require_action("workspace.delete")),
+) -> dict:
+    """Blast-radius counts for the delete confirmation UI.
+
+    Gated by the same ``workspace.delete`` action as the destructive route —
+    seeing the preview implies you're the one who could pull the trigger.
+    """
+    return await workspace_service.get_delete_preview(workspace_id)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -26,7 +26,7 @@ Changes: added get_workspace_plan helper for plan-feature gate dep.
 from __future__ import annotations
 
 import secrets
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from beanie import PydanticObjectId
@@ -898,6 +898,68 @@ async def revoke_invite(
         )
 
 
+async def resend_invite(
+    ctx: RequestContext,
+    workspace_id: str,
+    invite_id: str,
+) -> dict:
+    """Rotate the invite's token and reset the 7-day expiry.
+
+    Mints a fresh plaintext, persists only the new hash, and returns the
+    plaintext so the route can ship it to the inviter's clipboard — the
+    original plaintext is gone (server only ever stored the hash). The
+    invite_id, workspace_id, email, and group are unchanged.
+    """
+    try:
+        invite_doc = await _InviteDoc.get(PydanticObjectId(invite_id))
+    except Exception:
+        invite_doc = None
+    if invite_doc is None or invite_doc.workspace != workspace_id:
+        raise NotFound("invite", invite_id)
+    if invite_doc.accepted:
+        raise ConflictError("invite.already_accepted", "This invite has already been accepted")
+    if invite_doc.revoked:
+        raise ConflictError("invite.revoked", "This invite has been revoked")
+
+    plaintext = secrets.token_urlsafe(32)
+    new_expiry = datetime.now(UTC) + timedelta(days=7)
+    invite_doc.token = None
+    invite_doc.token_hash = hash_token(plaintext)
+    invite_doc.expires_at = new_expiry
+    invite_doc.resend_count = (invite_doc.resend_count or 0) + 1
+    await invite_doc.save()
+
+    await emit(
+        WorkspaceInviteCreated(
+            data={
+                "workspace_id": workspace_id,
+                "invite_id": invite_id,
+                "email": invite_doc.email,
+                "resend": True,
+            }
+        )
+    )
+
+    await audit_service.record(
+        workspace_id,
+        ctx.user_id,
+        "workspace.invite_resent",
+        target_type="invite",
+        target_id=invite_id,
+        metadata={
+            "invite_id": invite_id,
+            "email": invite_doc.email,
+            "resend_count": invite_doc.resend_count,
+        },
+    )
+
+    return {
+        "invite_id": invite_id,
+        "token": plaintext,
+        "expires_at": new_expiry.isoformat(),
+    }
+
+
 async def decline_invite(token: str) -> None:
     """Invitee-side decline. No auth — the invitee may not have an account.
 
@@ -1096,6 +1158,7 @@ __all__ = [
     "list_peer_ids",
     "preview_invite",
     "remove_member",
+    "resend_invite",
     "revoke_invite",
     "seed_default_workspace",
     "update",

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -956,16 +956,25 @@ async def seed_default_workspace(admin_id: str, *, name: str, slug: str) -> _Wor
         return None
 
 
-async def get_workspace_plan(workspace_id: str) -> str:
-    """Return the plan tier string for a workspace.
+async def get_workspace_plan(workspace_id: str) -> str | None:
+    """Return the plan tier string for a workspace, or None if missing.
 
-    Used by the plan-feature gate dependency. Returns "team" (the most
-    restrictive plan) as a safe fallback when the workspace cannot be
-    loaded so the guard fails open on plan rather than raising a 500.
+    Used by the plan-feature gate dependency. Returns None when the
+    workspace genuinely doesn't exist (invalid id, never created, or
+    soft-deleted) so the caller can map that to a 404.
+
+    Re-raises any DB-level exception rather than swallowing it. The
+    previous implementation silently degraded to the most restrictive
+    plan on transient Mongo errors, which 403'd paying customers during
+    DB hiccups. Let the framework surface a 5xx instead.
     """
-    doc = await _fetch_workspace(workspace_id)
-    if doc is None:
-        return "team"
+    try:
+        oid = PydanticObjectId(workspace_id)
+    except Exception:
+        return None
+    doc = await _WorkspaceDoc.get(oid)
+    if doc is None or doc.deleted_at is not None:
+        return None
     return doc.plan
 
 

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -50,6 +50,7 @@ from pocketpaw_ee.cloud._core.realtime.events import (
     WorkspaceMemberRole,
     WorkspaceUpdated,
 )
+from pocketpaw_ee.cloud.audit import service as audit_service
 from pocketpaw_ee.cloud.models.invite import Invite as _InviteDoc
 from pocketpaw_ee.cloud.models.invite import hash_token
 from pocketpaw_ee.cloud.models.notification import NotificationSource
@@ -231,6 +232,17 @@ async def create(ctx: RequestContext, body: CreateWorkspaceRequest) -> Workspace
     )
     get_resolver().invalidate_workspace(str(doc.id))
 
+    # Wave 2 Task 10: structured audit log. ip + user_agent threading is
+    # deferred to Wave 3 (needs RequestContext changes).
+    await audit_service.record(
+        str(doc.id),
+        ctx.user_id,
+        "workspace.created",
+        target_type="workspace",
+        target_id=str(doc.id),
+        metadata={"name": doc.name, "slug": doc.slug},
+    )
+
     return _workspace_to_domain(doc, member_count=1)
 
 
@@ -262,6 +274,15 @@ async def update(
     patched = body.model_dump(exclude_unset=True)
     await emit(WorkspaceUpdated(data={"workspace_id": workspace_id, **patched}))
 
+    await audit_service.record(
+        workspace_id,
+        ctx.user_id,
+        "workspace.updated",
+        target_type="workspace",
+        target_id=workspace_id,
+        metadata={"patched": patched},
+    )
+
     count = await _count_members(workspace_id)
     return _workspace_to_domain(doc, member_count=count)
 
@@ -288,6 +309,14 @@ async def delete(ctx: RequestContext, workspace_id: str) -> None:
 
     await emit(WorkspaceDeleted(data={"workspace_id": workspace_id}))
     get_resolver().invalidate_workspace(workspace_id)
+
+    await audit_service.record(
+        workspace_id,
+        ctx.user_id,
+        "workspace.deleted",
+        target_type="workspace",
+        target_id=workspace_id,
+    )
 
 
 async def list_for_user(ctx: RequestContext) -> list[Workspace]:
@@ -373,8 +402,10 @@ async def update_member_role(
     if user is None:
         raise NotFound("member", target_user_id)
     updated = False
+    from_role: str | None = None
     for m in user.workspaces:
         if m.workspace == workspace_id:
+            from_role = m.role
             m.role = role
             updated = True
             break
@@ -392,6 +423,15 @@ async def update_member_role(
         )
     )
     get_resolver().invalidate_workspace(workspace_id)
+
+    await audit_service.record(
+        workspace_id,
+        actor_user_id,
+        "workspace.member_role_changed",
+        target_type="user",
+        target_id=target_user_id,
+        metadata={"from_role": from_role, "to_role": role},
+    )
 
 
 async def remove_member(
@@ -438,6 +478,14 @@ async def remove_member(
         WorkspaceMemberRemoved(data={"workspace_id": workspace_id, "user_id": target_user_id})
     )
     get_resolver().invalidate_workspace(workspace_id)
+
+    await audit_service.record(
+        workspace_id,
+        actor_user_id,
+        "workspace.member_removed",
+        target_type="user",
+        target_id=target_user_id,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -535,6 +583,15 @@ async def create_invite(
 
     await emit(WorkspaceInviteCreated(data=event_data))
 
+    await audit_service.record(
+        workspace_id,
+        ctx.user_id,
+        "workspace.invite_created",
+        target_type="invite",
+        target_id=invite.id,
+        metadata={"invite_id": invite.id, "email": body.email, "role": body.role},
+    )
+
     if invited_user_id:
         await notifications_service.create(
             workspace_id=workspace_id,
@@ -604,6 +661,15 @@ async def bulk_create_invites(
         if existing_user_id:
             event_data["user_id"] = existing_user_id
         await emit(WorkspaceInviteCreated(data=event_data))
+
+        await audit_service.record(
+            workspace_id,
+            ctx.user_id,
+            "workspace.invite_created",
+            target_type="invite",
+            target_id=invite.id,
+            metadata={"invite_id": invite.id, "email": email, "role": body.role},
+        )
 
         if existing_user_id:
             await notifications_service.create(
@@ -796,8 +862,21 @@ async def accept_invite(ctx: RequestContext, token: str) -> None:
     )
     get_resolver().invalidate_workspace(wid)
 
+    await audit_service.record(
+        wid,
+        ctx.user_id,
+        "workspace.invite_accepted",
+        target_type="invite",
+        target_id=invite.id,
+        metadata={"invite_id": invite.id, "email": invite.email},
+    )
 
-async def revoke_invite(workspace_id: str, invite_id: str) -> None:
+
+async def revoke_invite(
+    workspace_id: str,
+    invite_id: str,
+    actor_user_id: str | None = None,
+) -> None:
     try:
         invite_doc = await _InviteDoc.get(PydanticObjectId(invite_id))
     except Exception:
@@ -807,6 +886,16 @@ async def revoke_invite(workspace_id: str, invite_id: str) -> None:
     invite_doc.revoked = True
     await invite_doc.save()
     await emit(WorkspaceInviteRevoked(data={"workspace_id": workspace_id, "invite_id": invite_id}))
+
+    if actor_user_id is not None:
+        await audit_service.record(
+            workspace_id,
+            actor_user_id,
+            "workspace.invite_revoked",
+            target_type="invite",
+            target_id=invite_id,
+            metadata={"invite_id": invite_id, "reason": "revoked"},
+        )
 
 
 async def decline_invite(token: str) -> None:
@@ -870,6 +959,17 @@ async def decline_invite(token: str) -> None:
                 "reason": "declined",
             }
         )
+    )
+
+    # Decline is unauthed (the invitee may not have an account), so we
+    # log the invitee's email as the actor identifier.
+    await audit_service.record(
+        workspace_id,
+        f"email:{claimed.get('email', '')}",
+        "workspace.invite_declined",
+        target_type="invite",
+        target_id=invite_id,
+        metadata={"invite_id": invite_id, "email": claimed.get("email", "")},
     )
 
 

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -61,6 +61,7 @@ from pocketpaw_ee.cloud.notifications import service as notifications_service
 from pocketpaw_ee.cloud.shared.events import event_bus
 from pocketpaw_ee.cloud.workspace.domain import Invite, Workspace, WorkspaceMember
 from pocketpaw_ee.cloud.workspace.dto import (
+    BulkInviteRequest,
     CreateInviteRequest,
     CreateWorkspaceRequest,
     UpdateWorkspaceRequest,
@@ -451,6 +452,62 @@ async def list_invites(workspace_id: str) -> list[Invite]:
     return [_invite_to_domain(d) for d in docs if not d.expired]
 
 
+async def _mint_invite_for_email(
+    ctx: RequestContext,
+    workspace_id: str,
+    email: str,
+    role: str,
+    group_id: str | None,
+) -> Invite:
+    """Pre-clean expired/stale rows, reject duplicate pending, insert the
+    hashed invite. Shared between ``create_invite`` (single) and
+    ``bulk_create_invites`` (batch) so token hashing + pre-cleanup stay
+    in lockstep. Does NOT emit or notify — the caller handles side-effects.
+    """
+    # Mongo TTL is the long-term GC; this pre-cleanup makes the
+    # collision check below honest about what's "still pending."
+    await _InviteDoc.find(
+        {
+            "workspace": workspace_id,
+            "email": email,
+            "group": group_id,
+            "$or": [
+                {"revoked": True},
+                {"accepted": True},
+                {"expires_at": {"$lt": datetime.now(UTC)}},
+            ],
+        }
+    ).delete()
+
+    existing = await _InviteDoc.find_one(
+        {
+            "workspace": workspace_id,
+            "email": email,
+            "accepted": False,
+            "revoked": False,
+            "group": group_id,
+        }
+    )
+    if existing is not None and not existing.expired:
+        msg = f"A pending invite already exists for {email}" + (
+            " in this group" if group_id else ""
+        )
+        raise ConflictError("invite.already_pending", msg)
+
+    plaintext = secrets.token_urlsafe(32)
+    invite_doc = _InviteDoc(
+        workspace=workspace_id,
+        email=email,
+        role=role,
+        invited_by=ctx.user_id,
+        token=None,  # plaintext never persisted for new invites
+        token_hash=hash_token(plaintext),
+        group=group_id,
+    )
+    await invite_doc.insert()
+    return _invite_to_domain(invite_doc, plaintext_token=plaintext)
+
+
 async def create_invite(
     ctx: RequestContext,
     workspace_id: str,
@@ -464,48 +521,7 @@ async def create_invite(
     if member_count >= doc.seats:
         raise SeatLimitError(doc.seats)
 
-    # Mongo TTL is the long-term GC; this pre-cleanup makes the
-    # collision check below honest about what's "still pending."
-    await _InviteDoc.find(
-        {
-            "workspace": workspace_id,
-            "email": body.email,
-            "group": body.group_id,
-            "$or": [
-                {"revoked": True},
-                {"accepted": True},
-                {"expires_at": {"$lt": datetime.now(UTC)}},
-            ],
-        }
-    ).delete()
-
-    existing = await _InviteDoc.find_one(
-        {
-            "workspace": workspace_id,
-            "email": body.email,
-            "accepted": False,
-            "revoked": False,
-            "group": body.group_id,
-        }
-    )
-    if existing is not None and not existing.expired:
-        msg = f"A pending invite already exists for {body.email}" + (
-            " in this group" if body.group_id else ""
-        )
-        raise ConflictError("invite.already_pending", msg)
-
-    plaintext = secrets.token_urlsafe(32)
-    invite_doc = _InviteDoc(
-        workspace=workspace_id,
-        email=body.email,
-        role=body.role,
-        invited_by=ctx.user_id,
-        token=None,  # plaintext never persisted for new invites
-        token_hash=hash_token(plaintext),
-        group=body.group_id,
-    )
-    await invite_doc.insert()
-    invite = _invite_to_domain(invite_doc, plaintext_token=plaintext)
+    invite = await _mint_invite_for_email(ctx, workspace_id, body.email, body.role, body.group_id)
 
     invited_user_id = await _find_user_id_by_email(body.email)
 
@@ -534,6 +550,78 @@ async def create_invite(
         )
 
     return invite
+
+
+async def bulk_create_invites(
+    ctx: RequestContext,
+    workspace_id: str,
+    body: BulkInviteRequest,
+) -> dict:
+    """Create many invites in one call.
+
+    Seat-limit is checked ONCE against the full batch size before any row
+    is inserted, so callers don't get partial writes when the batch can't
+    possibly fit. Per-email failures (already a member, already a pending
+    invite) are returned in the ``skipped`` list — they don't abort the
+    batch. Emits one WorkspaceInviteCreated event per created row, mirroring
+    the single-invite path so downstream subscribers (search index, audit
+    log, notifications) see no special bulk shape.
+    """
+    doc = await _fetch_workspace(workspace_id)
+    if doc is None:
+        raise NotFound("workspace", workspace_id)
+
+    current_count = await _count_members(workspace_id)
+    if current_count + len(body.emails) > doc.seats:
+        raise SeatLimitError(doc.seats)
+
+    created: list[Invite] = []
+    skipped: list[dict] = []
+
+    for email in body.emails:
+        existing_user_id = await _find_user_id_by_email(email)
+        if existing_user_id is not None:
+            existing_role = await _get_member_role(workspace_id, existing_user_id)
+            if existing_role is not None:
+                skipped.append({"email": email, "reason": "already_member"})
+                continue
+
+        try:
+            invite = await _mint_invite_for_email(
+                ctx, workspace_id, email, body.role, body.group_id
+            )
+        except ConflictError as exc:
+            if exc.code == "invite.already_pending":
+                skipped.append({"email": email, "reason": "already_pending"})
+                continue
+            raise
+
+        event_data: dict = {
+            "workspace_id": workspace_id,
+            "invite_id": invite.id,
+            "email": email,
+        }
+        if existing_user_id:
+            event_data["user_id"] = existing_user_id
+        await emit(WorkspaceInviteCreated(data=event_data))
+
+        if existing_user_id:
+            await notifications_service.create(
+                workspace_id=workspace_id,
+                recipient=existing_user_id,
+                kind="invite",
+                title=f"You were invited to join {doc.name}",
+                body="",
+                source=NotificationSource(
+                    type="invite",
+                    id=invite.id,
+                    room_id=invite.group_id,
+                ),
+            )
+
+        created.append(invite)
+
+    return {"created": created, "skipped": skipped}
 
 
 async def validate_invite(token: str) -> tuple[Invite, str]:
@@ -883,6 +971,7 @@ async def get_workspace_plan(workspace_id: str) -> str:
 
 __all__ = [
     "accept_invite",
+    "bulk_create_invites",
     "create",
     "create_invite",
     "decline_invite",

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -682,6 +682,70 @@ async def revoke_invite(workspace_id: str, invite_id: str) -> None:
     await emit(WorkspaceInviteRevoked(data={"workspace_id": workspace_id, "invite_id": invite_id}))
 
 
+async def decline_invite(token: str) -> None:
+    """Invitee-side decline. No auth — the invitee may not have an account.
+
+    Atomically marks the invite revoked with ``revoked_reason="declined"`` so
+    audit can later distinguish an inviter-revoke from an invitee-decline.
+    Idempotent: declining an already-declined/revoked invite is a no-op (no
+    duplicate event). Refuses to decline an accepted invite (409).
+    """
+    th = hash_token(token)
+
+    invite_doc = await _InviteDoc.find_one(_InviteDoc.token_hash == th)
+    if invite_doc is None:
+        invite_doc = await _InviteDoc.find_one(_InviteDoc.token == token)
+    if invite_doc is None:
+        raise NotFound("invite")
+
+    if invite_doc.accepted:
+        raise ConflictError("invite.already_accepted", "This invite has already been accepted")
+    if invite_doc.revoked:
+        return  # idempotent — already declined or revoked
+
+    collection = _InviteDoc.get_pymongo_collection()
+    claimed = await collection.find_one_and_update(
+        {"token_hash": th, "accepted": False, "revoked": False},
+        {"$set": {"revoked": True, "revoked_reason": "declined"}},
+        return_document=False,
+    )
+
+    if claimed is None:
+        # Race: re-read and disambiguate. Mirror accept_invite's fallback,
+        # including the legacy plaintext backfill path.
+        existing = await _InviteDoc.find_one(_InviteDoc.token_hash == th)
+        if existing is None:
+            existing = await _InviteDoc.find_one(_InviteDoc.token == token)
+        if existing is None:
+            raise NotFound("invite")
+        if existing.accepted:
+            raise ConflictError("invite.already_accepted", "This invite has already been accepted")
+        if existing.revoked:
+            return  # somebody else just revoked/declined it — idempotent
+        existing.token_hash = th
+        existing.token = None
+        await existing.save()
+        claimed = await collection.find_one_and_update(
+            {"_id": existing.id, "accepted": False, "revoked": False},
+            {"$set": {"revoked": True, "revoked_reason": "declined"}},
+            return_document=False,
+        )
+        if claimed is None:
+            return  # raced again; treat as idempotent
+
+    workspace_id = claimed["workspace"]
+    invite_id = str(claimed["_id"])
+    await emit(
+        WorkspaceInviteRevoked(
+            data={
+                "workspace_id": workspace_id,
+                "invite_id": invite_id,
+                "reason": "declined",
+            }
+        )
+    )
+
+
 # ---------------------------------------------------------------------------
 # Realtime audience helpers — used as function refs by realtime/audience.py
 # ---------------------------------------------------------------------------
@@ -782,6 +846,7 @@ __all__ = [
     "accept_invite",
     "create",
     "create_invite",
+    "decline_invite",
     "delete",
     "get",
     "get_workspace_plan",

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -319,6 +319,51 @@ async def delete(ctx: RequestContext, workspace_id: str) -> None:
     )
 
 
+async def get_delete_preview(workspace_id: str) -> dict:
+    """Return counts + total bytes for the cascade ``delete()`` would perform.
+
+    Mirrors the resources the workspace ``delete`` path (and its eventual
+    cascades) reaches: members, chat groups, agents, file uploads, and
+    pending invites. Used by the UI to show a blast-radius summary before
+    the type-name-to-confirm step. Owner-only at the route layer.
+
+    Uses ``find().count()`` rather than ``aggregate()`` because aggregation
+    cursors don't survive mongomock-motor in tests (see
+    reference_mongomock_quirks memory).
+    """
+    doc = await _fetch_workspace(workspace_id)
+    if doc is None:
+        raise NotFound("workspace", workspace_id)
+
+    # Local imports keep these documents off the cold-start path for callers
+    # that never touch the preview endpoint.
+    from pocketpaw_ee.cloud.models.agent import Agent as _AgentDoc
+    from pocketpaw_ee.cloud.models.group import Group as _GroupDoc
+    from pocketpaw_ee.cloud.uploads.models import FileUpload as _FileUploadDoc
+
+    member_count = await _count_members(workspace_id)
+    room_count = await _GroupDoc.find({"workspace": workspace_id}).count()
+    agent_count = await _AgentDoc.find({"workspace": workspace_id}).count()
+    file_count = await _FileUploadDoc.find({"workspace": workspace_id, "deleted_at": None}).count()
+    invite_count = await _InviteDoc.find(
+        {"workspace": workspace_id, "accepted": False, "revoked": False}
+    ).count()
+
+    # Python-side reduction over the file rows; aggregate($sum) would be
+    # cheaper but mongomock-motor doesn't honour it reliably.
+    file_rows = await _FileUploadDoc.find({"workspace": workspace_id, "deleted_at": None}).to_list()
+    total_bytes = sum(int(getattr(r, "size", 0) or 0) for r in file_rows)
+
+    return {
+        "member_count": member_count,
+        "room_count": room_count,
+        "agent_count": agent_count,
+        "file_count": file_count,
+        "invite_count": invite_count,
+        "total_bytes": total_bytes,
+    }
+
+
 async def list_for_user(ctx: RequestContext) -> list[Workspace]:
     """List the user's non-deleted workspaces with member counts.
 
@@ -1148,6 +1193,7 @@ __all__ = [
     "decline_invite",
     "delete",
     "get",
+    "get_delete_preview",
     "get_workspace_plan",
     "legacy_ctx",
     "list_admin_ids",

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -425,6 +425,21 @@ async def create_invite(
     if member_count >= doc.seats:
         raise SeatLimitError(doc.seats)
 
+    # Mongo TTL is the long-term GC; this pre-cleanup makes the
+    # collision check below honest about what's "still pending."
+    await _InviteDoc.find(
+        {
+            "workspace": workspace_id,
+            "email": body.email,
+            "group": body.group_id,
+            "$or": [
+                {"revoked": True},
+                {"accepted": True},
+                {"expires_at": {"$lt": datetime.now(UTC)}},
+            ],
+        }
+    ).delete()
+
     existing = await _InviteDoc.find_one(
         {
             "workspace": workspace_id,

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -121,6 +121,23 @@ async def _count_members(workspace_id: str) -> int:
     return await _UserDoc.find({"workspaces.workspace": workspace_id}).count()
 
 
+async def _count_owners(workspace_id: str) -> int:
+    """Count members whose role is ``owner`` in this workspace.
+
+    Independent of the ``Workspace.owner`` singular field — once ownership
+    transfers via update_member_role, that field can lag behind reality.
+    Uses ``$elemMatch`` so a single ``find().count()`` does the work
+    (aggregation cursors don't survive mongomock-motor in tests).
+    """
+    return await _UserDoc.find(
+        {
+            "workspaces": {
+                "$elemMatch": {"workspace": workspace_id, "role": "owner"},
+            }
+        }
+    ).count()
+
+
 async def _count_members_bulk(workspace_ids: list[str]) -> dict[str, int]:
     """Aggregation: ``{workspace_id: member_count}`` in one round-trip."""
     if not workspace_ids:
@@ -339,6 +356,18 @@ async def update_member_role(
             "workspace.cannot_demote_owner",
             "Cannot demote the workspace owner",
         )
+    # Independent last-owner guard: even if target is not doc.owner, if
+    # they hold an owner ROLE and they're the only owner, blocking the
+    # demotion keeps the workspace governable.
+    if role != "owner":
+        target_role = await _get_member_role(workspace_id, target_user_id)
+        if target_role == "owner":
+            owner_count = await _count_owners(workspace_id)
+            if owner_count <= 1:
+                raise Forbidden(
+                    "workspace.last_owner",
+                    "Cannot demote the last owner. Promote another member to owner first.",
+                )
     user = await _UserDoc.get(PydanticObjectId(target_user_id))
     if user is None:
         raise NotFound("member", target_user_id)
@@ -374,6 +403,16 @@ async def remove_member(
         raise NotFound("workspace", workspace_id)
     if doc.owner == target_user_id:
         raise Forbidden("workspace.cannot_remove_owner", "Cannot remove the workspace owner")
+
+    # Role-based last-owner guard (independent of doc.owner field).
+    target_role = await _get_member_role(workspace_id, target_user_id)
+    if target_role == "owner":
+        owner_count = await _count_owners(workspace_id)
+        if owner_count <= 1:
+            raise Forbidden(
+                "workspace.last_owner",
+                "Cannot remove the last owner. Promote another member to owner first.",
+            )
 
     user = await _UserDoc.get(PydanticObjectId(target_user_id))
     if user is None:

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -146,6 +146,7 @@ ACTIONS: dict[str, ActionRule] = {
     # Invite
     "invite.create": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     "invite.revoke": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    "invite.resend": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     # Billing
     "billing.view": ActionRule(WorkspaceRole.ADMIN, "billing.admin_only"),
     "billing.manage": ActionRule(WorkspaceRole.OWNER, "billing.owner_only"),

--- a/src/pocketpaw/dashboard_auth.py
+++ b/src/pocketpaw/dashboard_auth.py
@@ -19,7 +19,7 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pocketpaw.config import Settings, get_access_token, regenerate_token
 from pocketpaw.dashboard_state import _LOCALHOST_ADDRS, _PROXY_HEADERS
 from pocketpaw.http_utils import is_request_secure
-from pocketpaw.security.rate_limiter import api_limiter, auth_limiter
+from pocketpaw.security.rate_limiter import api_limiter, auth_limiter, login_limiter
 from pocketpaw.security.session_tokens import create_session_token, verify_session_token
 from pocketpaw.tunnel import get_tunnel_manager
 from pocketpaw.uploads.signing import verify_grant
@@ -288,6 +288,29 @@ class AuthMiddleware:
         if rejection is not None:
             await rejection(scope, receive, send)
             return
+        # If the dispatch consumed the body for the login/register rate-limit
+        # branch, replay it for the downstream auth handler. Without this,
+        # fastapi-users sees an empty body and 422s every login.
+        cached_body = getattr(request.state, "cached_body", None)
+        downstream_receive = receive
+        if cached_body is not None:
+            body_sent = False
+
+            async def replay_receive():
+                nonlocal body_sent
+                if not body_sent:
+                    body_sent = True
+                    return {
+                        "type": "http.request",
+                        "body": cached_body,
+                        "more_body": False,
+                    }
+                # After the cached body, defer to the original receive for any
+                # subsequent messages (e.g. disconnect).
+                return await receive()
+
+            downstream_receive = replay_receive
+
         # Allowed — inject rate-limit headers into the downstream response
         rl_headers = getattr(request.state, "rate_limit_headers", None)
         if rl_headers:
@@ -300,9 +323,16 @@ class AuthMiddleware:
                     message = {**message, "headers": headers}
                 await send(message)
 
-            await self.app(scope, receive, send_with_headers)
+            await self.app(scope, downstream_receive, send_with_headers)
         else:
-            await self.app(scope, receive, send)
+            await self.app(scope, downstream_receive, send)
+
+
+_LOGIN_RATE_LIMITED_PATHS = (
+    "/api/v1/auth/login",
+    "/api/v1/auth/register",
+    "/api/v1/auth/bearer/login",
+)
 
 
 async def _auth_dispatch(request: Request) -> Response | None:
@@ -313,6 +343,51 @@ async def _auth_dispatch(request: Request) -> Response | None:
 
     path = request.url.path
     client_ip = request.client.host if request.client else "unknown"
+
+    # Brute-force guard for login / register / bearer-login (OWASP A07).
+    # These paths used to be unconditionally exempt from rate limiting, which
+    # left an unbounded brute-force window. The per-(ip, email) bucket prevents
+    # an attacker from rotating the email field behind one IP to slip the
+    # per-IP api_limiter. fastapi-users reads the form body downstream, so we
+    # cache the body bytes on request.state and the ASGI wrapper in
+    # AuthMiddleware.__call__ replays them via a wrapped `receive`.
+    if request.method == "POST" and path in _LOGIN_RATE_LIMITED_PATHS:
+        try:
+            body_bytes = await request.body()
+            request.state.cached_body = body_bytes
+        except Exception:
+            body_bytes = b""
+            request.state.cached_body = body_bytes
+        email = ""
+        try:
+            form = await request.form()
+            # fastapi-users uses OAuth2PasswordRequestForm — field is "username".
+            # /register receives JSON with an "email" field instead.
+            email = str(form.get("username") or form.get("email") or "").strip().lower()
+        except Exception:
+            # JSON body on /register — best-effort parse for the email key.
+            try:
+                import json as _json
+
+                payload = _json.loads(body_bytes.decode("utf-8") or "{}")
+                if isinstance(payload, dict):
+                    email = (
+                        str(payload.get("email") or payload.get("username") or "").strip().lower()
+                    )
+            except Exception:
+                email = ""
+        key = f"login:{client_ip}:{email}"
+        rl_info = login_limiter.check(key)
+        if not rl_info.allowed:
+            _audit_auth_event("login_rate_limited", request, status="block")
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Too many login attempts"},
+                headers=rl_info.headers(),
+            )
+        # Allowed — fall through. The cached body is on request.state so the
+        # ASGI wrapper can hand a replayed `receive` to the downstream auth
+        # handler.
 
     # Rate-limit authentication endpoints BEFORE exempt-path processing.
     # Login and QR endpoints are intentionally exempt from token auth (the user
@@ -345,7 +420,6 @@ async def _auth_dispatch(request: Request) -> Response | None:
         # NOTE: /ws, /v1/ws, /api/v1/ws are no longer exempted here — WebSocket
         # scopes are now authenticated at the middleware level (issue #883).
         "/api/auth/login",
-        "/api/v1/auth/login",
         "/api/v1/docs",
         "/api/v1/redoc",
         "/api/v1/openapi.json",
@@ -358,9 +432,10 @@ async def _auth_dispatch(request: Request) -> Response | None:
         "/api/v1/mcp/oauth/callback",
         "/api/v1/oauth/authorize",
         "/api/v1/oauth/token",
-        "/api/v1/auth/login",
-        "/api/v1/auth/register",
-        "/api/v1/auth/bearer/login",
+        # NOTE: /api/v1/auth/login, /register, /bearer/login are NOT exempt.
+        # They have no token (the user is acquiring one) but must still pass
+        # through the login_limiter branch below — see the (ip, email) bucket
+        # near the top of _auth_dispatch.
         "/api/v1/auth/me",
         "/api/v1/license",
         "/ws/cloud",

--- a/src/pocketpaw/security/rate_limiter.py
+++ b/src/pocketpaw/security/rate_limiter.py
@@ -3,6 +3,7 @@
 Pre-configured tiers:
   - api:      10 req/s, burst 30  (general API endpoints)
   - auth:      1 req/s, burst  5  (token/QR endpoints)
+  - login:    5 per 15 min, burst 5  (login/register/bearer-login, keyed by (ip, email))
   - ws:        2 conn/s, burst  5  (WebSocket connections)
   - api_key:   configurable per-key limiter (default 60 req/min)
 
@@ -20,6 +21,7 @@ __all__ = [
     "RateLimitInfo",
     "api_limiter",
     "auth_limiter",
+    "login_limiter",
     "ws_limiter",
     "get_api_key_limiter",
     "cleanup_all",
@@ -120,6 +122,9 @@ class RateLimiter:
 # Pre-configured limiter instances
 api_limiter = RateLimiter(rate=10.0, capacity=30)
 auth_limiter = RateLimiter(rate=1.0, capacity=5)
+# Login / register / bearer-login: 5 attempts per 15 min, keyed by (ip, email)
+# so attackers can't bypass the bucket by rotating the email field behind one IP.
+login_limiter = RateLimiter(rate=5.0 / 900.0, capacity=5)
 ws_limiter = RateLimiter(rate=2.0, capacity=5)
 _api_key_limiter: RateLimiter | None = None
 
@@ -140,7 +145,12 @@ def get_api_key_limiter() -> RateLimiter:
 
 def cleanup_all() -> int:
     """Run cleanup on all global limiters. Returns total entries removed."""
-    total = api_limiter.cleanup() + auth_limiter.cleanup() + ws_limiter.cleanup()
+    total = (
+        api_limiter.cleanup()
+        + auth_limiter.cleanup()
+        + login_limiter.cleanup()
+        + ws_limiter.cleanup()
+    )
     if _api_key_limiter is not None:
         total += _api_key_limiter.cleanup()
     return total

--- a/tests/cloud/audit/test_service_v2.py
+++ b/tests/cloud/audit/test_service_v2.py
@@ -1,0 +1,331 @@
+"""Tests for the workspace audit-event log (Wave 2 Task 10).
+
+Verifies:
+- Every mutating workspace op writes exactly one audit row with the
+  right action / target / actor.
+- ``list_events`` filters by action and respects composite ``(at, _id)``
+  cursor pagination ordering.
+- The ``GET /workspaces/{id}/audit`` endpoint is admin-gated — a plain
+  member receives 403 via ``require_action("audit.read")``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.audit import service as audit_service
+from pocketpaw_ee.cloud.audit.dto import AuditQueryRequest
+from pocketpaw_ee.cloud.audit.router import workspace_router
+from pocketpaw_ee.cloud.auth import current_active_user
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.models.audit_event import AuditEvent as _AuditEventDoc
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.models.user import WorkspaceMembership as _Membership
+from pocketpaw_ee.cloud.workspace import service as workspace_service
+from pocketpaw_ee.cloud.workspace.dto import (
+    BulkInviteRequest,
+    CreateInviteRequest,
+    CreateWorkspaceRequest,
+    UpdateWorkspaceRequest,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx(user_id: str, workspace_id: str | None = None) -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _seed_user(email: str = "owner@x.c") -> _UserDoc:
+    doc = _UserDoc(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="U",
+        workspaces=[],
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.fixture(autouse=True)
+def _resolver_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Stub the realtime resolver — same shape as workspace tests."""
+    mock = MagicMock()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.get_resolver", lambda: mock)
+    return mock
+
+
+@pytest.fixture
+def _legacy_bus(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict]]:
+    events: list[tuple[str, dict]] = []
+
+    class _FakeBus:
+        async def emit(self, name: str, payload: dict) -> None:
+            events.append((name, payload))
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.event_bus", _FakeBus())
+    return events
+
+
+async def _rows_for(workspace_id: str) -> list[_AuditEventDoc]:
+    return await _AuditEventDoc.find({"workspace": workspace_id}).sort("at").to_list()
+
+
+# ---------------------------------------------------------------------------
+# record() write fan-out from workspace mutations
+# ---------------------------------------------------------------------------
+
+
+async def test_create_workspace_writes_audit_row() -> None:
+    owner = await _seed_user()
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    rows = await _rows_for(ws.id)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.action == "workspace.created"
+    assert row.actor_id == str(owner.id)
+    assert row.target_type == "workspace"
+    assert row.target_id == ws.id
+
+
+async def test_update_workspace_writes_audit_row() -> None:
+    owner = await _seed_user()
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service.update(_ctx(str(owner.id)), ws.id, UpdateWorkspaceRequest(name="B"))
+    rows = await _rows_for(ws.id)
+    actions = [r.action for r in rows]
+    assert "workspace.updated" in actions
+
+
+async def test_delete_workspace_writes_audit_row() -> None:
+    owner = await _seed_user()
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service.delete(_ctx(str(owner.id)), ws.id)
+    rows = await _rows_for(ws.id)
+    assert "workspace.deleted" in [r.action for r in rows]
+
+
+async def test_update_member_role_writes_audit_row() -> None:
+    owner = await _seed_user("o@x.c")
+    other = await _seed_user("p@x.c")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service._add_member(ws.id, str(other.id), role="member")
+    await workspace_service.update_member_role(ws.id, str(other.id), "admin", str(owner.id))
+    rows = [r for r in await _rows_for(ws.id) if r.action == "workspace.member_role_changed"]
+    assert len(rows) == 1
+    assert rows[0].metadata == {"from_role": "member", "to_role": "admin"}
+    assert rows[0].target_id == str(other.id)
+
+
+async def test_remove_member_writes_audit_row(_legacy_bus) -> None:
+    owner = await _seed_user("o@x.c")
+    other = await _seed_user("p@x.c")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service._add_member(ws.id, str(other.id), role="member")
+    await workspace_service.remove_member(ws.id, str(other.id), str(owner.id))
+    rows = [r for r in await _rows_for(ws.id) if r.action == "workspace.member_removed"]
+    assert len(rows) == 1
+    assert rows[0].target_id == str(other.id)
+
+
+async def test_create_invite_writes_audit_row() -> None:
+    owner = await _seed_user("o@x.c")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(email="new@x.c", role="member"),
+    )
+    rows = [r for r in await _rows_for(ws.id) if r.action == "workspace.invite_created"]
+    assert len(rows) == 1
+    assert rows[0].metadata["invite_id"] == invite.id
+    assert rows[0].metadata["email"] == "new@x.c"
+
+
+async def test_bulk_create_invites_writes_per_email_rows() -> None:
+    owner = await _seed_user("o@x.c")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service.bulk_create_invites(
+        _ctx(str(owner.id)),
+        ws.id,
+        BulkInviteRequest(emails=["a@x.c", "b@x.c", "c@x.c"], role="member"),
+    )
+    rows = [r for r in await _rows_for(ws.id) if r.action == "workspace.invite_created"]
+    assert len(rows) == 3
+    assert {r.metadata["email"] for r in rows} == {"a@x.c", "b@x.c", "c@x.c"}
+
+
+async def test_accept_invite_writes_audit_row() -> None:
+    owner = await _seed_user("o@x.c")
+    invitee = await _seed_user("i@x.c")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(email="i@x.c", role="member"),
+    )
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
+    rows = [r for r in await _rows_for(ws.id) if r.action == "workspace.invite_accepted"]
+    assert len(rows) == 1
+    assert rows[0].actor_id == str(invitee.id)
+
+
+async def test_revoke_invite_writes_audit_row() -> None:
+    owner = await _seed_user("o@x.c")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(email="x@x.c", role="member"),
+    )
+    await workspace_service.revoke_invite(ws.id, invite.id, str(owner.id))
+    rows = [r for r in await _rows_for(ws.id) if r.action == "workspace.invite_revoked"]
+    assert len(rows) == 1
+    assert rows[0].metadata["invite_id"] == invite.id
+
+
+async def test_decline_invite_writes_audit_row() -> None:
+    owner = await _seed_user("o@x.c")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(email="x@x.c", role="member"),
+    )
+    await workspace_service.decline_invite(invite.token)
+    rows = [r for r in await _rows_for(ws.id) if r.action == "workspace.invite_declined"]
+    assert len(rows) == 1
+    assert rows[0].actor_id == "email:x@x.c"
+
+
+# ---------------------------------------------------------------------------
+# list_events filtering and cursor pagination
+# ---------------------------------------------------------------------------
+
+
+async def test_list_events_filters_by_action() -> None:
+    owner = await _seed_user()
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service.update(_ctx(str(owner.id)), ws.id, UpdateWorkspaceRequest(name="B"))
+
+    page = await audit_service.list_events(ws.id, AuditQueryRequest(action="workspace.updated"))
+    assert len(page.items) == 1
+    assert page.items[0].action == "workspace.updated"
+
+
+async def test_list_events_cursor_pagination_is_stable() -> None:
+    owner = await _seed_user()
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    # Seed enough rows to require multiple pages.
+    for i in range(7):
+        await audit_service.record(
+            ws.id,
+            str(owner.id),
+            "workspace.updated",
+            target_type="workspace",
+            target_id=ws.id,
+            metadata={"i": i},
+        )
+
+    seen_ids: list[str] = []
+    cursor: str | None = None
+    while True:
+        page = await audit_service.list_events(ws.id, AuditQueryRequest(limit=3, cursor=cursor))
+        seen_ids.extend(item.id for item in page.items)
+        if not page.next_cursor:
+            break
+        cursor = page.next_cursor
+
+    # No duplicates, every row exactly once (8 rows total: 1 create + 7 updates).
+    assert len(seen_ids) == len(set(seen_ids))
+    assert len(seen_ids) == 8
+
+
+async def test_list_events_bad_cursor_raises() -> None:
+    owner = await _seed_user()
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    with pytest.raises(Exception) as exc:
+        await audit_service.list_events(ws.id, AuditQueryRequest(cursor="garbage"))
+    assert "audit.bad_cursor" in str(exc.value) or hasattr(exc.value, "code")
+
+
+# ---------------------------------------------------------------------------
+# HTTP-layer: require_action("audit.read") gates non-admins.
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def audit_client_member() -> AsyncClient:
+    """FastAPI app with the audit workspace_router mounted under a member user."""
+
+    member = await _seed_user("member@x.c")
+    member.workspaces = [
+        _Membership(workspace="ws-test-1", role="member", joined_at=datetime.now(UTC))
+    ]
+    await member.save()
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(workspace_router, prefix="/api/v1")
+
+    async def _override_user() -> Any:
+        return await _UserDoc.get(member.id)
+
+    app.dependency_overrides[current_active_user] = _override_user
+    app.dependency_overrides[require_license] = lambda: None
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+async def test_member_gets_403_on_audit_read(audit_client_member: AsyncClient) -> None:
+    resp = await audit_client_member.get("/api/v1/workspaces/ws-test-1/audit")
+    assert resp.status_code == 403

--- a/tests/cloud/chat/test_group_emits.py
+++ b/tests/cloud/chat/test_group_emits.py
@@ -22,6 +22,7 @@ from pocketpaw_ee.cloud.chat.schemas import (
     UpdateGroupAgentRequest,
     UpdateGroupRequest,
 )
+from pocketpaw_ee.cloud.models.agent import Agent as _AgentDoc
 from pocketpaw_ee.cloud.models.group import Group as _GroupDoc
 from pocketpaw_ee.cloud.models.group import GroupAgent as _GroupAgentDoc
 from pocketpaw_ee.cloud.realtime.events import (
@@ -86,6 +87,18 @@ async def _make_group(
         owner=owner,
         agents=agent_docs,
     )
+    await doc.insert()
+    return doc
+
+
+async def _make_agent(
+    *,
+    workspace: str = "w1",
+    owner: str = "u1",
+    name: str = "Agent",
+    slug: str = "agent",
+) -> _AgentDoc:
+    doc = _AgentDoc(workspace=workspace, name=name, slug=slug, owner=owner)
     await doc.insert()
     return doc
 
@@ -274,57 +287,150 @@ async def test_set_member_role_emits_member_role_no_invalidation(
 
 @pytest.mark.asyncio
 async def test_add_agent_emits_agent_added(mongo_db, recording_bus):
-    group = await _make_group(owner="u1", member_roles={"u1": "admin"})
+    agent = await _make_agent(workspace="w1")
+    group = await _make_group(workspace="w1", owner="u1", member_roles={"u1": "admin"})
 
     await group_service.add_agent(
         str(group.id),
         "u1",
-        AddGroupAgentRequest(agent_id="a1", respond_mode="auto"),
+        AddGroupAgentRequest(agent_id=str(agent.id), respond_mode="auto"),
     )
 
     events = [e for e in recording_bus.events if isinstance(e, GroupAgentAdded)]
     assert len(events) == 1
     assert events[0].data == {
         "group_id": str(group.id),
-        "agent_id": "a1",
+        "agent_id": str(agent.id),
         "respond_mode": "auto",
     }
 
 
 @pytest.mark.asyncio
 async def test_update_agent_emits_agent_updated(mongo_db, recording_bus):
+    agent = await _make_agent(workspace="w1")
     group = await _make_group(
+        workspace="w1",
         owner="u1",
         member_roles={"u1": "admin"},
-        agents=[("a1", "assistant", "auto")],
+        agents=[(str(agent.id), "assistant", "auto")],
     )
 
     await group_service.update_agent(
-        str(group.id), "u1", "a1", UpdateGroupAgentRequest(respond_mode="mention")
+        str(group.id), "u1", str(agent.id), UpdateGroupAgentRequest(respond_mode="mention")
     )
 
     events = [e for e in recording_bus.events if isinstance(e, GroupAgentUpdated)]
     assert len(events) == 1
     assert events[0].data == {
         "group_id": str(group.id),
-        "agent_id": "a1",
+        "agent_id": str(agent.id),
         "respond_mode": "mention",
     }
 
 
 @pytest.mark.asyncio
 async def test_remove_agent_emits_agent_removed(mongo_db, recording_bus):
+    agent = await _make_agent(workspace="w1")
     group = await _make_group(
+        workspace="w1",
         owner="u1",
         member_roles={"u1": "admin"},
-        agents=[("a1", "assistant", "auto")],
+        agents=[(str(agent.id), "assistant", "auto")],
     )
 
-    await group_service.remove_agent(str(group.id), "u1", "a1")
+    await group_service.remove_agent(str(group.id), "u1", str(agent.id))
 
     events = [e for e in recording_bus.events if isinstance(e, GroupAgentRemoved)]
     assert len(events) == 1
-    assert events[0].data == {"group_id": str(group.id), "agent_id": "a1"}
+    assert events[0].data == {"group_id": str(group.id), "agent_id": str(agent.id)}
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant agent-on-group IDOR guard (Wave 2 task 9)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_agent_rejects_cross_workspace_agent(mongo_db, recording_bus):
+    """A workspace-A admin cannot wire a workspace-B agent into an A-side group.
+
+    The service must raise NotFound (not Forbidden) — 404 keeps the agent's
+    existence opaque to a probing attacker.
+    """
+    from pocketpaw_ee.cloud.shared.errors import NotFound
+
+    foreign_agent = await _make_agent(workspace="w2", owner="u2", slug="foreign")
+    group = await _make_group(workspace="w1", owner="u1", member_roles={"u1": "admin"})
+
+    with pytest.raises(NotFound):
+        await group_service.add_agent(
+            str(group.id),
+            "u1",
+            AddGroupAgentRequest(agent_id=str(foreign_agent.id), respond_mode="auto"),
+        )
+
+    assert not [e for e in recording_bus.events if isinstance(e, GroupAgentAdded)]
+
+
+@pytest.mark.asyncio
+async def test_add_agent_rejects_unknown_agent(mongo_db, recording_bus):
+    """A made-up agent_id must surface as NotFound, not Forbidden."""
+    from beanie import PydanticObjectId
+    from pocketpaw_ee.cloud.shared.errors import NotFound
+
+    group = await _make_group(workspace="w1", owner="u1", member_roles={"u1": "admin"})
+
+    with pytest.raises(NotFound):
+        await group_service.add_agent(
+            str(group.id),
+            "u1",
+            AddGroupAgentRequest(agent_id=str(PydanticObjectId()), respond_mode="auto"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_agent_rejects_cross_workspace_agent(mongo_db, recording_bus):
+    """update_agent must refuse a foreign-workspace agent even if the id
+    happens to already be on the group's agents list (corrupt-state guard)."""
+    from pocketpaw_ee.cloud.shared.errors import NotFound
+
+    foreign_agent = await _make_agent(workspace="w2", owner="u2", slug="foreign")
+    group = await _make_group(
+        workspace="w1",
+        owner="u1",
+        member_roles={"u1": "admin"},
+        agents=[(str(foreign_agent.id), "assistant", "auto")],
+    )
+
+    with pytest.raises(NotFound):
+        await group_service.update_agent(
+            str(group.id),
+            "u1",
+            str(foreign_agent.id),
+            UpdateGroupAgentRequest(respond_mode="mention"),
+        )
+
+    assert not [e for e in recording_bus.events if isinstance(e, GroupAgentUpdated)]
+
+
+@pytest.mark.asyncio
+async def test_remove_agent_rejects_cross_workspace_agent(mongo_db, recording_bus):
+    """remove_agent must refuse a foreign-workspace agent — guards against
+    using a leaked agent_id to fingerprint or de-wire foreign agents."""
+    from pocketpaw_ee.cloud.shared.errors import NotFound
+
+    foreign_agent = await _make_agent(workspace="w2", owner="u2", slug="foreign")
+    group = await _make_group(
+        workspace="w1",
+        owner="u1",
+        member_roles={"u1": "admin"},
+        agents=[(str(foreign_agent.id), "assistant", "auto")],
+    )
+
+    with pytest.raises(NotFound):
+        await group_service.remove_agent(str(group.id), "u1", str(foreign_agent.id))
+
+    assert not [e for e in recording_bus.events if isinstance(e, GroupAgentRemoved)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/realtime/test_audience_isolation.py
+++ b/tests/cloud/realtime/test_audience_isolation.py
@@ -1,0 +1,159 @@
+"""Regression: realtime fan-out must not leak events to non-audience users.
+
+The WebSocket path at ``/ws/cloud`` is authenticated at handshake time via a
+JWT in the query string (see ``chat/router.py::websocket_endpoint``). Once a
+client is connected, the only "subscription" surface is the audience-keyed
+bus fan-out in ``_core/realtime/bus.py::InProcessBus.publish``: each event is
+resolved to a list of ``user_id`` recipients and the connection manager is
+told to ``send_to_user(uid, payload)`` for each one. There is no per-channel
+client-side subscribe step a stranger could spoof to receive other tenants'
+events.
+
+These tests pin that behaviour. If a future refactor accidentally turns the
+realtime layer into a broadcast bus (e.g. "send to every connected socket"),
+or skips the resolver, or routes by socket-supplied ``group_id`` instead of
+DB-resolved membership, these tests fail loudly.
+
+The companion membership checks for *inbound* client → server messages
+(``room.join``, ``typing.*``, ``read.ack``) live in
+``tests/cloud/chat/test_room_scoped.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime.audience import AudienceResolver
+from pocketpaw_ee.cloud._core.realtime.bus import InProcessBus
+from pocketpaw_ee.cloud._core.realtime.events import (
+    MessageNew,
+    WorkspaceUpdated,
+)
+
+
+@pytest.mark.asyncio
+async def test_workspace_event_not_delivered_to_stranger():
+    """A workspace.updated event must reach only workspace members.
+
+    Setup: workspace ``w-alpha`` has members [u-alice, u-bob]. An unrelated
+    user u-mallory has an active WebSocket but is NOT in w-alpha.
+    """
+    members_by_workspace = {"w-alpha": ["u-alice", "u-bob"]}
+
+    async def workspace_members(wid: str) -> list[str]:
+        return list(members_by_workspace.get(wid, []))
+
+    resolver = AudienceResolver(workspace_members=workspace_members)
+    conn = AsyncMock()
+    bus = InProcessBus(resolver=resolver, conn_manager=conn)
+
+    await bus.publish(WorkspaceUpdated(data={"workspace_id": "w-alpha"}))
+
+    recipients = {call.args[0] for call in conn.send_to_user.await_args_list}
+    assert recipients == {"u-alice", "u-bob"}
+    assert "u-mallory" not in recipients
+
+
+@pytest.mark.asyncio
+async def test_message_new_not_delivered_to_non_group_member():
+    """message.new for group g1 must reach only g1 members.
+
+    A stranger holding a live socket cannot receive g1's messages because the
+    fan-out is keyed by ``group_members(g1)``, not by who happens to be online.
+    """
+    members_by_group = {"g1": ["u-alice", "u-bob"]}
+
+    async def group_members(gid: str) -> list[str]:
+        return list(members_by_group.get(gid, []))
+
+    resolver = AudienceResolver(group_members=group_members)
+    conn = AsyncMock()
+    bus = InProcessBus(resolver=resolver, conn_manager=conn)
+
+    # message.new excludes the sender from the audience; u-bob should still get it.
+    await bus.publish(MessageNew(data={"group_id": "g1", "sender": "u-alice"}))
+
+    recipients = {call.args[0] for call in conn.send_to_user.await_args_list}
+    assert recipients == {"u-bob"}
+    assert "u-mallory" not in recipients
+    assert "u-alice" not in recipients  # sender excluded by resolver
+
+
+@pytest.mark.asyncio
+async def test_event_for_unknown_workspace_delivers_to_nobody():
+    """If the resolver returns [] for a workspace, nobody gets the event.
+
+    This pins the failure mode: if a service emits a workspace event with a
+    bogus workspace_id, the fan-out is a no-op rather than a broadcast.
+    """
+
+    async def workspace_members(_wid: str) -> list[str]:
+        return []
+
+    resolver = AudienceResolver(workspace_members=workspace_members)
+    conn = AsyncMock()
+    bus = InProcessBus(resolver=resolver, conn_manager=conn)
+
+    await bus.publish(WorkspaceUpdated(data={"workspace_id": "w-ghost"}))
+
+    conn.send_to_user.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Connect-time JWT verification (handshake auth)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_handshake_rejects_invalid_token(monkeypatch):
+    """The /ws/cloud handshake must reject tokens that fail JWT verification.
+
+    Connect-time auth is the gate that makes audience-keyed fan-out trustworthy:
+    the bus delivers to ``user_id``, but ``user_id`` is only meaningful if the
+    socket really belongs to that user. ``websocket_endpoint`` decodes the JWT
+    with ``AUTH_SECRET`` and closes with 4001 on any failure.
+    """
+    import importlib
+
+    router_mod = importlib.import_module("pocketpaw_ee.cloud.chat.router")
+
+    # License gate must pass so we reach the JWT check.
+    class _Lic:
+        expired = False
+
+    monkeypatch.setattr(router_mod, "get_license", lambda: _Lic())
+    monkeypatch.setenv("AUTH_SECRET", "test-secret-for-realtime-isolation")
+
+    ws = AsyncMock()
+    ws.close = AsyncMock()
+    ws.accept = AsyncMock()
+
+    # Bogus token — JWT decode raises, handler must close before accept().
+    await router_mod.websocket_endpoint(ws, token="not-a-jwt")
+
+    ws.close.assert_awaited_once()
+    close_kwargs = ws.close.await_args.kwargs
+    assert close_kwargs.get("code") == 4001
+    ws.accept.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ws_handshake_rejects_when_license_missing(monkeypatch):
+    """No enterprise license → close 4003, never touch the JWT or connect."""
+    import importlib
+
+    router_mod = importlib.import_module("pocketpaw_ee.cloud.chat.router")
+
+    monkeypatch.setattr(router_mod, "get_license", lambda: None)
+
+    ws = AsyncMock()
+    ws.close = AsyncMock()
+    ws.accept = AsyncMock()
+
+    await router_mod.websocket_endpoint(ws, token="anything")
+
+    ws.close.assert_awaited_once()
+    close_kwargs = ws.close.await_args.kwargs
+    assert close_kwargs.get("code") == 4003
+    ws.accept.assert_not_called()

--- a/tests/cloud/workspace/test_invite_rate_limit.py
+++ b/tests/cloud/workspace/test_invite_rate_limit.py
@@ -1,0 +1,70 @@
+"""Tests for the per-(actor, workspace) invite-create rate limiter.
+
+Exercises the `rate_limit_invite_create` Depends directly with synthetic
+RequestContext values — keeps the test focused on the bucket behavior
+without needing the full FastAPI route + Mongo fixture stack.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core import rate_limit as rate_limit_mod
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import RateLimited
+
+
+def _ctx(user_id: str) -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=None,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fresh_limiter(monkeypatch: pytest.MonkeyPatch):
+    """Reset the module-level bucket so tests don't leak state into each other."""
+    from pocketpaw.security.rate_limiter import RateLimiter
+
+    fresh = RateLimiter(rate=50.0 / 86400.0, capacity=50)
+    monkeypatch.setattr(rate_limit_mod, "_invite_create_limiter", fresh)
+    yield
+
+
+async def test_invite_create_allows_up_to_capacity():
+    ctx = _ctx("user-a")
+    for _ in range(50):
+        # No exception → allowed.
+        await rate_limit_mod.rate_limit_invite_create("ws-1", ctx)
+
+
+async def test_invite_create_blocks_on_51st_per_actor_workspace():
+    ctx = _ctx("user-a")
+    for _ in range(50):
+        await rate_limit_mod.rate_limit_invite_create("ws-1", ctx)
+    with pytest.raises(RateLimited) as excinfo:
+        await rate_limit_mod.rate_limit_invite_create("ws-1", ctx)
+    assert excinfo.value.status_code == 429
+    assert excinfo.value.code == "workspace.invite_rate_limited"
+
+
+async def test_invite_create_buckets_per_actor_per_workspace():
+    """Two workspaces and two actors each get their own bucket."""
+    actor_a = _ctx("user-a")
+    actor_b = _ctx("user-b")
+
+    # Exhaust user-a on ws-1.
+    for _ in range(50):
+        await rate_limit_mod.rate_limit_invite_create("ws-1", actor_a)
+    with pytest.raises(RateLimited):
+        await rate_limit_mod.rate_limit_invite_create("ws-1", actor_a)
+
+    # user-a on a different workspace still has a full bucket.
+    await rate_limit_mod.rate_limit_invite_create("ws-2", actor_a)
+
+    # user-b on ws-1 still has a full bucket.
+    await rate_limit_mod.rate_limit_invite_create("ws-1", actor_b)

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -680,3 +680,78 @@ async def test_create_invite_cleans_up_revoked_rows(owner, monkeypatch) -> None:
     assert second.id != first.id
     # Old revoked row is gone.
     assert await _InviteDoc.get(PydanticObjectId(first.id)) is None
+
+
+# ---------------------------------------------------------------------------
+# Wave 2 Task 3: decline_invite
+# ---------------------------------------------------------------------------
+
+
+async def test_decline_invite_marks_revoked_with_reason(owner, recording_bus, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="d@x.c")
+    )
+    recording_bus.events.clear()
+
+    await workspace_service.decline_invite(invite.token)
+
+    row = await _InviteDoc.get(PydanticObjectId(invite.id))
+    assert row is not None
+    assert row.revoked is True
+    assert row.revoked_reason == "declined"
+    assert row.accepted is False
+
+    revoked_events = [e for e in recording_bus.events if isinstance(e, WorkspaceInviteRevoked)]
+    assert len(revoked_events) == 1
+    assert revoked_events[0].data.get("reason") == "declined"
+    assert revoked_events[0].data.get("workspace_id") == ws.id
+    assert revoked_events[0].data.get("invite_id") == invite.id
+
+
+async def test_decline_invite_404_unknown_token() -> None:
+    with pytest.raises(NotFound):
+        await workspace_service.decline_invite("not-a-real-token")
+
+
+async def test_decline_invite_409_already_accepted(owner, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="acc@x.c")
+    )
+    invitee = await _seed_user(email="acc@x.c")
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
+
+    with pytest.raises(ConflictError) as exc:
+        await workspace_service.decline_invite(invite.token)
+    assert exc.value.code == "invite.already_accepted"
+
+
+async def test_decline_invite_atomic_against_accept(owner, monkeypatch) -> None:
+    """After decline, accept must surface the revoked-branch in accept_invite."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="race@x.c")
+    )
+
+    await workspace_service.decline_invite(invite.token)
+
+    invitee = await _seed_user(email="race@x.c")
+    with pytest.raises(Forbidden) as exc:
+        await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
+    assert exc.value.code == "invite.revoked"

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -38,6 +38,7 @@ from pocketpaw_ee.cloud.models.invite import Invite as _InviteDoc
 from pocketpaw_ee.cloud.models.user import User as _UserDoc
 from pocketpaw_ee.cloud.workspace import service as workspace_service
 from pocketpaw_ee.cloud.workspace.dto import (
+    BulkInviteRequest,
     CreateInviteRequest,
     CreateWorkspaceRequest,
     UpdateWorkspaceRequest,
@@ -835,3 +836,108 @@ async def test_decline_invite_atomic_against_accept(owner, monkeypatch) -> None:
     with pytest.raises(Forbidden) as exc:
         await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
     assert exc.value.code == "invite.revoked"
+
+
+# ---------------------------------------------------------------------------
+# Bulk invites
+# ---------------------------------------------------------------------------
+
+
+async def test_bulk_create_invites_happy_path_3_emails(owner, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    result = await workspace_service.bulk_create_invites(
+        _ctx(str(owner.id)),
+        ws.id,
+        BulkInviteRequest(emails=["a@x.c", "b@x.c", "c@x.c"]),
+    )
+    assert len(result["created"]) == 3
+    assert result["skipped"] == []
+    # Each minted invite carries a plaintext token.
+    assert all(inv.token and len(inv.token) >= 32 for inv in result["created"])
+
+
+async def test_bulk_create_invites_skips_existing_members(owner, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    # Seed an existing member of the workspace.
+    member = await _seed_user(email="member@x.c")
+    await workspace_service._add_member(ws.id, str(member.id), role="member")
+
+    result = await workspace_service.bulk_create_invites(
+        _ctx(str(owner.id)),
+        ws.id,
+        BulkInviteRequest(emails=["new@x.c", "member@x.c"]),
+    )
+    assert len(result["created"]) == 1
+    assert result["created"][0].email == "new@x.c"
+    assert result["skipped"] == [{"email": "member@x.c", "reason": "already_member"}]
+
+
+async def test_bulk_create_invites_skips_pending_dupes(owner, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="dup@x.c")
+    )
+
+    result = await workspace_service.bulk_create_invites(
+        _ctx(str(owner.id)),
+        ws.id,
+        BulkInviteRequest(emails=["dup@x.c", "fresh@x.c"]),
+    )
+    assert len(result["created"]) == 1
+    assert result["created"][0].email == "fresh@x.c"
+    assert result["skipped"] == [{"email": "dup@x.c", "reason": "already_pending"}]
+
+
+async def test_bulk_create_invites_rejects_over_seats(owner, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    # Shrink seats to 5 and pre-fill 3 extra members → current_count=4.
+    ws_doc = await workspace_service._WorkspaceDoc.get(PydanticObjectId(ws.id))
+    assert ws_doc is not None
+    ws_doc.seats = 5
+    await ws_doc.save()
+    for i in range(3):
+        u = await _seed_user(email=f"seat{i}@x.c")
+        await workspace_service._add_member(ws.id, str(u.id), role="member")
+
+    invite_count_before = await _InviteDoc.find({"workspace": ws.id}).count()
+    with pytest.raises(SeatLimitError):
+        await workspace_service.bulk_create_invites(
+            _ctx(str(owner.id)),
+            ws.id,
+            BulkInviteRequest(emails=["a@x.c", "b@x.c", "c@x.c"]),
+        )
+    # No partial writes: the invite collection is untouched.
+    invite_count_after = await _InviteDoc.find({"workspace": ws.id}).count()
+    assert invite_count_after == invite_count_before
+
+
+async def test_bulk_create_invites_max_100_emails() -> None:
+    # 100 is the cap — exactly 100 validates.
+    ok = BulkInviteRequest(emails=[f"u{i}@x.c" for i in range(100)])
+    assert len(ok.emails) == 100
+    # 101 trips the pydantic max_length validator.
+    with pytest.raises(Exception):  # pydantic.ValidationError
+        BulkInviteRequest(emails=[f"u{i}@x.c" for i in range(101)])
+    # Empty list also rejected (min_length=1).
+    with pytest.raises(Exception):
+        BulkInviteRequest(emails=[])

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -209,6 +209,86 @@ async def test_remove_member_emits_both_paths(
     resolver_mock.invalidate_workspace.assert_called_with(ws.id)
 
 
+async def test_update_member_role_blocks_demoting_last_owner(owner) -> None:
+    """Role-based last-owner check fires even when target is not doc.owner.
+
+    Seeds a NON-doc-owner user, promotes them to owner-role, then strips the
+    original doc.owner's owner role so the new user is the SOLE owner. The
+    doc.owner-field check would not catch this; the new _count_owners guard
+    must.
+    """
+    sole_owner = await _seed_user(email="sole@x.c", full_name="Sole")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service._add_member(ws.id, str(sole_owner.id), role="owner")
+    # Demote the doc.owner directly via the User doc so we bypass the
+    # cannot_demote_owner guard; this leaves sole_owner as the only owner.
+    owner_doc = await _UserDoc.get(owner.id)
+    assert owner_doc is not None
+    for m in owner_doc.workspaces:
+        if m.workspace == ws.id:
+            m.role = "member"
+    await owner_doc.save()
+
+    with pytest.raises(Forbidden) as exc:
+        await workspace_service.update_member_role(
+            ws.id, str(sole_owner.id), "admin", str(sole_owner.id)
+        )
+    assert exc.value.code == "workspace.last_owner"
+
+
+async def test_update_member_role_allows_demoting_one_of_many_owners(
+    owner, recording_bus, resolver_mock
+) -> None:
+    co_owner = await _seed_user(email="co@x.c", full_name="Co")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service._add_member(ws.id, str(co_owner.id), role="owner")
+
+    # Demoting co_owner (not doc.owner) when there are two owners — allowed.
+    await workspace_service.update_member_role(ws.id, str(co_owner.id), "admin", str(owner.id))
+
+    role = await workspace_service._get_member_role(ws.id, str(co_owner.id))
+    assert role == "admin"
+
+
+async def test_remove_member_blocks_removing_last_owner(owner) -> None:
+    sole_owner = await _seed_user(email="sole@x.c", full_name="Sole")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service._add_member(ws.id, str(sole_owner.id), role="owner")
+    # Strip doc.owner's owner role so sole_owner is the only owner.
+    owner_doc = await _UserDoc.get(owner.id)
+    assert owner_doc is not None
+    for m in owner_doc.workspaces:
+        if m.workspace == ws.id:
+            m.role = "member"
+    await owner_doc.save()
+
+    with pytest.raises(Forbidden) as exc:
+        await workspace_service.remove_member(ws.id, str(sole_owner.id), str(sole_owner.id))
+    assert exc.value.code == "workspace.last_owner"
+
+
+async def test_remove_member_allows_removing_one_of_many_owners(
+    owner, recording_bus, captured_legacy_events, resolver_mock
+) -> None:
+    co_owner = await _seed_user(email="co@x.c", full_name="Co")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service._add_member(ws.id, str(co_owner.id), role="owner")
+
+    # Removing one owner when another remains — allowed.
+    await workspace_service.remove_member(ws.id, str(co_owner.id), str(owner.id))
+
+    role = await workspace_service._get_member_role(ws.id, str(co_owner.id))
+    assert role is None
+
+
 # ---------------------------------------------------------------------------
 # Invites
 # ---------------------------------------------------------------------------

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -941,3 +941,71 @@ async def test_bulk_create_invites_max_100_emails() -> None:
     # Empty list also rejected (min_length=1).
     with pytest.raises(Exception):
         BulkInviteRequest(emails=[])
+
+
+# ---------------------------------------------------------------------------
+# get_workspace_plan — fail-closed semantics (Wave 2 Task 8)
+# ---------------------------------------------------------------------------
+
+
+async def test_get_workspace_plan_returns_real_plan(owner) -> None:
+    """Happy path: an existing workspace returns its plan tier verbatim."""
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="W", slug="w-plan")
+    )
+    # Upgrade plan directly on the doc.
+    ws_doc = await workspace_service._WorkspaceDoc.get(PydanticObjectId(ws.id))
+    assert ws_doc is not None
+    ws_doc.plan = "enterprise"
+    await ws_doc.save()
+
+    plan = await workspace_service.get_workspace_plan(ws.id)
+    assert plan == "enterprise"
+
+
+async def test_get_workspace_plan_returns_none_for_missing_workspace() -> None:
+    """A genuinely missing workspace returns None — caller decides 404."""
+    # Valid ObjectId shape, but no doc with that id.
+    missing_id = str(PydanticObjectId())
+    plan = await workspace_service.get_workspace_plan(missing_id)
+    assert plan is None
+
+
+async def test_get_workspace_plan_returns_none_for_invalid_id() -> None:
+    """A malformed id is treated as 'doesn't exist', not propagated."""
+    plan = await workspace_service.get_workspace_plan("not-an-objectid")
+    assert plan is None
+
+
+async def test_get_workspace_plan_returns_none_for_soft_deleted(owner) -> None:
+    """Soft-deleted workspaces are indistinguishable from missing here."""
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="W", slug="w-del")
+    )
+    ws_doc = await workspace_service._WorkspaceDoc.get(PydanticObjectId(ws.id))
+    assert ws_doc is not None
+    ws_doc.deleted_at = datetime.now(UTC)
+    await ws_doc.save()
+
+    plan = await workspace_service.get_workspace_plan(ws.id)
+    assert plan is None
+
+
+async def test_get_workspace_plan_reraises_on_db_error(
+    owner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Transient DB failures must propagate, not silently downgrade
+    enterprise customers to the most restrictive plan."""
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="W", slug="w-flap")
+    )
+
+    class _Boom(Exception):
+        pass
+
+    async def _raise(*_a: Any, **_k: Any) -> None:
+        raise _Boom("simulated mongo outage")
+
+    monkeypatch.setattr(workspace_service._WorkspaceDoc, "get", _raise)
+    with pytest.raises(_Boom):
+        await workspace_service.get_workspace_plan(ws.id)

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -11,7 +11,7 @@ Asserts on:
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -613,7 +613,9 @@ async def test_preview_invite_revoked_expired_accepted(
     )
     exp_doc = await _InviteDoc.get(PydanticObjectId(expired_invite.id))
     assert exp_doc is not None
-    exp_doc.expires_at = datetime(2000, 1, 1, tzinfo=UTC)
+    # Past, but inside the 14-day TTL grace so mongomock doesn't reap the
+    # row before preview_invite can read it.
+    exp_doc.expires_at = datetime.now(UTC) - timedelta(days=1)
     await exp_doc.save()
     out = await workspace_service.preview_invite(expired_invite.token, viewer_user_id=None)
     assert out["state"] == "expired"
@@ -630,3 +632,51 @@ async def test_preview_invite_revoked_expired_accepted(
     out = await workspace_service.preview_invite(accepted_invite.token, viewer_user_id=None)
     assert out["state"] == "already_accepted"
     assert out["email"] == "acc@x.c"
+
+
+async def test_create_invite_cleans_up_expired_rows(owner, monkeypatch) -> None:
+    """A previously-expired invite must not block a fresh invite to the same email."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    first = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="dup@x.c")
+    )
+    # Push expires_at into the past but inside the 14-day TTL grace, so
+    # mongomock's TTL enforcer doesn't purge the row before we get to it.
+    doc = await _InviteDoc.get(PydanticObjectId(first.id))
+    assert doc is not None
+    doc.expires_at = datetime.now(UTC) - timedelta(days=1)
+    await doc.save()
+
+    # Should not collide; the dead row gets cleaned up first.
+    second = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="dup@x.c")
+    )
+    assert second.id != first.id
+    # Old expired row is gone.
+    assert await _InviteDoc.get(PydanticObjectId(first.id)) is None
+
+
+async def test_create_invite_cleans_up_revoked_rows(owner, monkeypatch) -> None:
+    """A revoked invite must not block a fresh invite to the same (email, group)."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    first = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="dup@x.c")
+    )
+    await workspace_service.revoke_invite(ws.id, first.id)
+
+    second = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="dup@x.c")
+    )
+    assert second.id != first.id
+    # Old revoked row is gone.
+    assert await _InviteDoc.get(PydanticObjectId(first.id)) is None

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -1145,3 +1145,82 @@ async def test_resend_invite_rejects_revoked_invite(owner, monkeypatch) -> None:
     with pytest.raises(ConflictError) as exc:
         await workspace_service.resend_invite(_ctx(str(owner.id)), ws.id, original.id)
     assert exc.value.code == "invite.revoked"
+
+
+# ---------------------------------------------------------------------------
+# Delete preview (Wave 2 Task 19)
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_preview_counts_resources(owner, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    from pocketpaw_ee.cloud.models.agent import Agent as _AgentDoc
+    from pocketpaw_ee.cloud.models.group import Group as _GroupDoc
+    from pocketpaw_ee.cloud.uploads.models import FileUpload as _FileUploadDoc
+
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+
+    # 2 additional members → 3 total including owner.
+    for i in range(2):
+        u = await _seed_user(email=f"m{i}@x.c", full_name=f"M{i}")
+        await workspace_service._add_member(ws.id, str(u.id), role="member")
+
+    # 2 rooms.
+    for i in range(2):
+        await _GroupDoc(workspace=ws.id, name=f"g{i}", owner=str(owner.id)).insert()
+
+    # 1 agent.
+    await _AgentDoc(workspace=ws.id, name="bot", slug="bot", owner=str(owner.id)).insert()
+
+    # 4 file uploads, 256 bytes each → 1024 total.
+    for i in range(4):
+        await _FileUploadDoc(
+            file_id=f"f{i}",
+            storage_key=f"key/{i}",
+            filename=f"f{i}.txt",
+            mime="text/plain",
+            size=256,
+            workspace=ws.id,
+            owner=str(owner.id),
+        ).insert()
+
+    # 5 pending invites.
+    for i in range(5):
+        await workspace_service.create_invite(
+            _ctx(str(owner.id)), ws.id, CreateInviteRequest(email=f"inv{i}@x.c")
+        )
+
+    preview = await workspace_service.get_delete_preview(ws.id)
+
+    assert preview == {
+        "member_count": 3,
+        "room_count": 2,
+        "agent_count": 1,
+        "file_count": 4,
+        "invite_count": 5,
+        "total_bytes": 1024,
+    }
+
+
+async def test_delete_preview_zero_resources(owner) -> None:
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    preview = await workspace_service.get_delete_preview(ws.id)
+    # Owner counts as a member; everything else is zero.
+    assert preview["member_count"] == 1
+    assert preview["room_count"] == 0
+    assert preview["agent_count"] == 0
+    assert preview["file_count"] == 0
+    assert preview["invite_count"] == 0
+    assert preview["total_bytes"] == 0
+
+
+async def test_delete_preview_workspace_not_found() -> None:
+    bogus = str(PydanticObjectId())
+    with pytest.raises(NotFound):
+        await workspace_service.get_delete_preview(bogus)

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -1009,3 +1009,139 @@ async def test_get_workspace_plan_reraises_on_db_error(
     monkeypatch.setattr(workspace_service._WorkspaceDoc, "get", _raise)
     with pytest.raises(_Boom):
         await workspace_service.get_workspace_plan(ws.id)
+
+
+# ---------------------------------------------------------------------------
+# resend_invite (Wave 2 Task 16)
+# ---------------------------------------------------------------------------
+
+
+async def test_resend_invite_returns_new_plaintext(owner, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    original = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="x@y.z")
+    )
+
+    result = await workspace_service.resend_invite(_ctx(str(owner.id)), ws.id, original.id)
+
+    assert result["invite_id"] == original.id
+    new_plaintext = result["token"]
+    assert isinstance(new_plaintext, str) and len(new_plaintext) >= 32
+    assert new_plaintext != original.token
+
+    from pocketpaw_ee.cloud.models.invite import hash_token
+
+    row = await _InviteDoc.get(PydanticObjectId(original.id))
+    assert row is not None
+    assert row.token_hash == hash_token(new_plaintext)
+    assert row.token in (None, "")
+
+
+async def test_resend_invite_resets_expires_at(owner, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    original = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="x@y.z")
+    )
+    row = await _InviteDoc.get(PydanticObjectId(original.id))
+    assert row is not None
+    row.expires_at = datetime.now(UTC) - timedelta(days=1)
+    await row.save()
+
+    await workspace_service.resend_invite(_ctx(str(owner.id)), ws.id, original.id)
+
+    refreshed = await _InviteDoc.get(PydanticObjectId(original.id))
+    assert refreshed is not None
+    exp = refreshed.expires_at
+    if exp.tzinfo is None:
+        exp = exp.replace(tzinfo=UTC)
+    delta = exp - datetime.now(UTC)
+    # Should be very close to 7 days; allow a wide window for slow CI.
+    assert timedelta(days=6, hours=23) <= delta <= timedelta(days=7, minutes=1)
+
+
+async def test_resend_invite_increments_count(owner, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    original = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="x@y.z")
+    )
+
+    await workspace_service.resend_invite(_ctx(str(owner.id)), ws.id, original.id)
+    await workspace_service.resend_invite(_ctx(str(owner.id)), ws.id, original.id)
+
+    refreshed = await _InviteDoc.get(PydanticObjectId(original.id))
+    assert refreshed is not None
+    assert refreshed.resend_count == 2
+
+
+async def test_resend_invite_emits_audit_row(owner, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    original = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="x@y.z")
+    )
+
+    await workspace_service.resend_invite(_ctx(str(owner.id)), ws.id, original.id)
+
+    from pocketpaw_ee.cloud.models.audit_event import AuditEvent as _AuditEventDoc
+
+    rows = await _AuditEventDoc.find(
+        {"workspace": ws.id, "action": "workspace.invite_resent"}
+    ).to_list()
+    assert len(rows) == 1
+    assert rows[0].metadata["invite_id"] == original.id
+    assert rows[0].metadata["email"] == "x@y.z"
+    assert rows[0].metadata["resend_count"] == 1
+
+
+async def test_resend_invite_rejects_accepted_invite(owner, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    original = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="x@y.z")
+    )
+    invitee = await _seed_user(email="x@y.z")
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), original.token)
+
+    with pytest.raises(ConflictError) as exc:
+        await workspace_service.resend_invite(_ctx(str(owner.id)), ws.id, original.id)
+    assert exc.value.code == "invite.already_accepted"
+
+
+async def test_resend_invite_rejects_revoked_invite(owner, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    original = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="x@y.z")
+    )
+    await workspace_service.revoke_invite(ws.id, original.id, str(owner.id))
+
+    with pytest.raises(ConflictError) as exc:
+        await workspace_service.resend_invite(_ctx(str(owner.id)), ws.id, original.id)
+    assert exc.value.code == "invite.revoked"

--- a/tests/test_api_rate_limits.py
+++ b/tests/test_api_rate_limits.py
@@ -2,7 +2,12 @@
 # Created: 2026-02-20
 
 
-from pocketpaw.security.rate_limiter import RateLimiter, RateLimitInfo, get_api_key_limiter
+from pocketpaw.security.rate_limiter import (
+    RateLimiter,
+    RateLimitInfo,
+    get_api_key_limiter,
+    login_limiter,
+)
 
 
 class TestRateLimiter:
@@ -55,6 +60,39 @@ class TestRateLimiter:
         limiter = get_api_key_limiter()
         assert limiter.capacity == 60
         assert limiter.rate == 60 / 60.0  # capacity / 60s
+
+
+class TestLoginLimiter:
+    """The login_limiter caps brute-force attempts on /auth/login etc."""
+
+    def test_login_limiter_blocks_after_5_attempts_per_ip_email(self):
+        """6 hits on the same (ip, email) key — 6th returns denied with Retry-After."""
+        # Use a fresh limiter so global state from earlier tests doesn't pollute.
+        limiter = RateLimiter(rate=5.0 / 900.0, capacity=5)
+        key = "login:1.2.3.4:bob@x.c"
+        for _ in range(5):
+            info = limiter.check(key)
+            assert info.allowed is True
+        info = limiter.check(key)
+        assert info.allowed is False
+        assert "Retry-After" in info.headers()
+
+    def test_login_limiter_separate_emails_isolated(self):
+        """Rotating the email field behind one IP gets its own bucket."""
+        limiter = RateLimiter(rate=5.0 / 900.0, capacity=5)
+        ip = "1.2.3.4"
+        # Exhaust bob's bucket.
+        for _ in range(5):
+            limiter.check(f"login:{ip}:bob@x.c")
+        assert limiter.check(f"login:{ip}:bob@x.c").allowed is False
+        # alice still has her full bucket — keying lets the (ip, email) tuple
+        # distinguish a normal user from a brute-force rotating emails.
+        assert limiter.check(f"login:{ip}:alice@x.c").allowed is True
+
+    def test_login_limiter_module_singleton_configured(self):
+        """The exported login_limiter is 5 / 15 min."""
+        assert login_limiter.capacity == 5
+        assert abs(login_limiter.rate - 5.0 / 900.0) < 1e-9
 
 
 class TestRateLimitInfo:


### PR DESCRIPTION
## Summary

Wave 2 closes the medium-severity backend findings from the audit and lays groundwork for the frontend members page. Each commit is one concern with passing tests. Stacked on Wave 1 (pocketpaw#1256) — please land that first.

- **Rate-limit login / register / invite-create.** Closes the exemption gap in dashboard_auth that left `/auth/login`, `/auth/register`, and `/auth/bearer/login` fully unprotected against brute force. New `login_limiter` keys on `(ip, email)` at 5 / 15 min so email-rotation behind one IP can't slip the bucket. Invite-create gains a per-(actor, workspace) bucket at 50/day. Layered on the existing in-memory limiter — no new dependency.
- **Stale-invite GC.** TTL index on `Invite.expires_at` (14-day grace) + pre-create cleanup of expired/revoked/accepted rows for the same `(workspace, email, group)`. Old code kept dead rows around, so a re-invite would collide on a stale pending row.
- **`POST /invites/{token}/decline`.** Public endpoint for the Decline button. Atomic revoke with `revoked_reason="declined"` so audit rows distinguish inviter-revoke from invitee-decline. Idempotent on a second decline; 409 if already accepted.
- **Last-owner guard.** Adds a role-based count check on `update_member_role` and `remove_member`. The prior checks only fired on the `doc.owner` field; a workspace whose ownership had transferred could be left with zero owners after demote/remove. New check counts owner-roled members and blocks the action when the count would drop to zero.
- **`POST /invites/bulk`.** Up to 100 emails per call, single seat-limit pre-check, per-email skip with typed reason (`already_member` / `already_pending`) on duplicates instead of failing the whole call. Shares the rate-limit bucket with single-invite (each email consumes one token).
- **Fail-closed on plan lookup.** \`get_workspace_plan\` used to swallow exceptions and silently downgrade to "team" on any failure, including transient Mongo flaps. Now returns None for genuinely-missing workspaces and propagates DB exceptions so paying customers don't get 403'd by infra hiccups.
- **Cross-tenant agent check on group ops.** Adding/updating/removing an agent on a chat group accepted any \`agent_id\` without verifying the agent's workspace matched the group's. Service now raises NotFound when the agent belongs to a different workspace (404 to keep existence opaque).
- **Audit log.** New \`audit/\` entity following the cloud 4-file shape. Workspace mutations (CRUD, member ops, invite ops) emit an audit row tagged with actor + action + target. 1-year TTL keeps the collection bounded. \`GET /workspaces/{id}/audit\` returns cursor-paginated history filtered by action/actor/time-range, gated by the existing \`audit.read\` admin-tier action. ip + user_agent are stubbed to None pending RequestContext threading in Wave 3.
- **Realtime audience pin.** Audit-and-test commit (no behavior change). Verifies that \`/ws/cloud\` rejects unauthenticated handshakes and that event fanout is audience-keyed (no broadcast fallback). Regression test pins this so a future refactor can't quietly turn it into a broadcast.

## Tests

\`tests/cloud/workspace + tests/cloud/auth + tests/cloud/audit + tests/cloud/chat/test_group_emits.py + tests/cloud/realtime\` → **183 passed.**

## Deferred to Wave 3

- ip + user_agent on audit rows (needs RequestContext threading).
- Redis-backed rate limit buckets (current in-memory is fine for single-instance).
- 429 \`Retry-After\` header on the CloudError envelope (RateLimited doesn't carry it today).

## Test plan
- [ ] Manual: 6 logins from the same IP+email in 15 min → 6th returns 429
- [ ] Manual: 51 invite-create calls from one admin to one workspace in 24h → 51st returns 429
- [ ] Manual: bulk-invite 100 emails where 5 are already members → response has \`created\` and \`skipped\` separated; no 500
- [ ] Manual: as a workspace owner, demote yourself → 403 \`workspace.last_owner\`. Promote another member to owner first, then demote → succeeds.
- [ ] Manual: \`POST /workspaces/invites/{token}/decline\` → invite shows as revoked with reason \`declined\` in the audit log
- [ ] Manual: \`GET /workspaces/{id}/audit?action=workspace.invite_created\` returns paginated rows; cursor works across pages