### PR TITLE
feat(foresight): bundled skill + loopback auth + env gate

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/context.py
+++ b/ee/pocketpaw_ee/cloud/_core/context.py
@@ -6,6 +6,16 @@ it to repositories (typically `workspace_id`). This replaces the ad-hoc
 `current_user_id` / `current_workspace_id` dependencies in
 `shared/deps.py` over the course of the strangler migration; both styles
 coexist during the transition.
+
+Updates:
+  - 2026-05-26: Added ``loopback_or_request_context`` — a JWT-or-loopback
+    dependency for endpoints called by the local chat agent on the
+    workspace's own dashboard. Validates that the caller is on a
+    loopback address AND presents the trio of ``X-PocketPaw-Internal``,
+    ``X-PocketPaw-Workspace-Id``, ``X-PocketPaw-User-Id`` headers; falls
+    back to the standard JWT auth path when any check fails. Used by the
+    foresight router; the dev-grade bypass tightens to a short-lived
+    signed JWT in a follow-up PR.
 """
 
 from __future__ import annotations
@@ -18,7 +28,8 @@ from uuid import uuid4
 
 from fastapi import Depends, Request
 
-from pocketpaw_ee.cloud.auth import current_active_user
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud.auth import current_active_user, current_optional_user
 from pocketpaw_ee.cloud.models.user import User
 
 
@@ -83,4 +94,142 @@ async def request_context(
     )
 
 
-__all__ = ["RequestContext", "ScopeKind", "request_context"]
+# ---------------------------------------------------------------------------
+# Loopback-internal bypass (RFC 08 v1.0 wave 4)
+# ---------------------------------------------------------------------------
+
+INTERNAL_HEADER: str = "X-PocketPaw-Internal"
+WORKSPACE_HEADER: str = "X-PocketPaw-Workspace-Id"
+USER_HEADER: str = "X-PocketPaw-User-Id"
+
+# Hostnames / IPs the bypass trusts. The dashboard always binds to one of
+# these; outbound traffic from the chat agent inherits the same host. A
+# real attacker either has to forge ``X-Forwarded-For`` upstream of the
+# ASGI server (uvicorn doesn't honor the header by default) or land code
+# execution on the host, in which case the bypass isn't the weakest link.
+_LOOPBACK_HOSTS: frozenset[str] = frozenset(
+    {
+        "127.0.0.1",
+        "::1",
+        "localhost",
+        # IPv4-mapped IPv6 loopback. ASGI servers normalise to ``::ffff:127.0.0.1``
+        # on some platforms (Linux dual-stack); accept both forms.
+        "::ffff:127.0.0.1",
+    }
+)
+
+
+def _is_loopback_client(request: Request) -> bool:
+    """Return True if the request originated from a loopback address.
+
+    Starlette exposes the connecting peer as ``request.client``; a tuple
+    of ``(host, port)`` or ``None`` for tests that didn't supply a
+    transport. ``None`` is treated as untrusted — failing closed is the
+    right default for an auth bypass.
+    """
+    if request.client is None:
+        return False
+    return request.client.host in _LOOPBACK_HOSTS
+
+
+def _try_loopback_context(request: Request) -> RequestContext | None:
+    """Build a context from loopback-internal headers, or return None.
+
+    Returns ``None`` (rather than raising) when any check fails so the
+    caller can fall back to the standard JWT path. All three headers
+    must be present AND the request must originate from a loopback
+    address; missing any one drops back to JWT auth.
+
+    The bypass is **dev-grade** per RFC 08 v1.0 wave 4 — the next pass
+    swaps the static header trio for a short-lived signed JWT that the
+    dashboard mints and the chat agent presents. The signature gate
+    closes the loophole where a chained process on the same host could
+    forge the headers; until then, the loopback host check is the only
+    boundary between the local chat agent and full workspace access.
+    """
+    if request.headers.get(INTERNAL_HEADER, "").strip().lower() != "true":
+        return None
+
+    if not _is_loopback_client(request):
+        return None
+
+    workspace_id = request.headers.get(WORKSPACE_HEADER, "").strip()
+    user_id = request.headers.get(USER_HEADER, "").strip()
+
+    # Both header values must be present — a missing user id would let a
+    # caller act as the workspace without a user, and a missing
+    # workspace id collapses tenancy. Either case is rejected.
+    if not workspace_id or not user_id:
+        return None
+
+    request_id = request.headers.get("x-request-id") or uuid4().hex
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id=request_id,
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def loopback_or_request_context(
+    request: Request,
+    user: Annotated[User | None, Depends(current_optional_user)] = None,
+) -> RequestContext:
+    """``request_context`` with a loopback-internal-header fallback.
+
+    The dependency resolves to a :class:`RequestContext` via one of two
+    paths:
+
+    1. **Loopback bypass.** Request originates from a loopback address
+       AND carries the trio of ``X-PocketPaw-Internal: true``,
+       ``X-PocketPaw-Workspace-Id``, ``X-PocketPaw-User-Id``. The
+       context is built from the headers; no JWT is consulted. This
+       path is what the local chat agent uses when it drives Foresight
+       from the dashboard.
+
+    2. **JWT auth.** Falls back to the standard fastapi-users flow via
+       :func:`current_optional_user`. A missing or invalid token
+       collapses to a 403 ``auth.required`` error.
+
+    The bypass is opt-in per endpoint: only endpoints that swap their
+    ``Depends(request_context)`` for ``Depends(loopback_or_request_context)``
+    get the loopback path. All other routes keep the strict JWT-only
+    behavior — no global trust expansion.
+
+    Returns:
+        A :class:`RequestContext` populated from either the loopback
+        headers or the resolved user.
+
+    Raises:
+        Forbidden: when the loopback path fails AND no valid JWT is
+            present. The error carries ``code='auth.required'`` to
+            disambiguate from the 401 fastapi-users would emit for a
+            malformed token.
+    """
+    loopback_ctx = _try_loopback_context(request)
+    if loopback_ctx is not None:
+        return loopback_ctx
+
+    if user is None:
+        raise Forbidden("auth.required", "Authentication required")
+
+    request_id = request.headers.get("x-request-id") or uuid4().hex
+    return RequestContext(
+        user_id=str(user.id),
+        workspace_id=user.active_workspace,
+        request_id=request_id,
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+__all__ = [
+    "INTERNAL_HEADER",
+    "RequestContext",
+    "ScopeKind",
+    "USER_HEADER",
+    "WORKSPACE_HEADER",
+    "loopback_or_request_context",
+    "request_context",
+]

--- a/ee/pocketpaw_ee/cloud/foresight/router.py
+++ b/ee/pocketpaw_ee/cloud/foresight/router.py
@@ -1,4 +1,13 @@
 # ee/pocketpaw_ee/cloud/foresight/router.py
+# Modified: 2026-05-26 (feat/foresight-v12-skill-and-loopback-auth) — RFC 08
+# v1.0 wave 4. All foresight endpoints now resolve their RequestContext
+# via ``loopback_or_request_context`` (the JWT-or-loopback dep). The
+# local chat agent presents ``X-PocketPaw-Internal: true`` +
+# ``X-PocketPaw-Workspace-Id`` + ``X-PocketPaw-User-Id`` headers over a
+# loopback connection and skips JWT auth entirely; non-loopback or
+# missing-header callers fall through to the standard
+# ``current_optional_user`` flow (401 on no token). Endpoint signatures
+# are unchanged — only the dep swap is touched.
 # Modified: 2026-05-26 (feat/foresight-v10-insights-llm) — RFC 08 v1.0.
 # LLM-driven insights synthesizer toggle:
 #     GET /api/v1/foresight/workspace/insights-config
@@ -126,7 +135,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query, Response, status
 
-from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.context import RequestContext, loopback_or_request_context
 from pocketpaw_ee.cloud.foresight import scenarios as foresight_scenarios
 from pocketpaw_ee.cloud.foresight import service as foresight_service
 from pocketpaw_ee.cloud.foresight.dto import (
@@ -163,7 +172,7 @@ router = APIRouter(
 @router.post("/scenarios", response_model=ScenarioRunResponse)
 async def create_scenario_run(
     body: CreateScenarioRequest,
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> ScenarioRunResponse:
     """Run a scenario inline and return the result.
 
@@ -190,7 +199,7 @@ async def create_scenario_run(
 @router.get("/runs/{run_id}", response_model=ScenarioRunResponse)
 async def get_run(
     run_id: str,
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> ScenarioRunResponse:
     """Fetch a stored run by id.
 
@@ -204,7 +213,7 @@ async def get_run(
 @router.get("/runs", response_model=list[ScenarioRunListItemResponse])
 async def list_runs(
     limit: int = Query(default=50, ge=1, le=200),
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> list[ScenarioRunListItemResponse]:
     """List runs in the caller's workspace, most recent first.
 
@@ -226,7 +235,7 @@ async def list_projected_decisions(
     anchor_id: str | None = Query(default=None, max_length=256),
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> ProjectedDecisionListResponse:
     """List projected decisions for one run.
 
@@ -265,7 +274,7 @@ async def list_projected_decisions(
 )
 async def get_live_snapshot(
     run_id: str,
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> LiveSnapshotResponse:
     """Compact "right now" view of one Foresight run.
 
@@ -313,7 +322,7 @@ async def list_instinct_proposals(
     run_id: str,
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> ForesightInstinctProposalListResponse:
     """List the Instinct proposals spawned by one Foresight run.
 
@@ -354,7 +363,7 @@ async def list_instinct_proposals(
 @router.post("/backtests", response_model=BacktestRunResponse)
 async def create_backtest(
     body: CreateBacktestRequest,
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> BacktestRunResponse:
     """Run a retroactive backtest inline, score it against the unlock
     threshold, and return the result + gate decision.
@@ -383,7 +392,7 @@ async def create_backtest(
 @router.get("/backtests/{backtest_id}", response_model=BacktestRunResponse)
 async def get_backtest(
     backtest_id: str,
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> BacktestRunResponse:
     """Fetch a stored backtest by id.
 
@@ -397,7 +406,7 @@ async def get_backtest(
 @router.get("/backtests", response_model=list[BacktestRunListItemResponse])
 async def list_backtests(
     limit: int = Query(default=50, ge=1, le=200),
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> list[BacktestRunListItemResponse]:
     """List backtests in the caller's workspace, most recent first.
 
@@ -411,7 +420,7 @@ async def list_backtests(
 
 @router.get("/onboarding/gate", response_model=OnboardingGateResponse)
 async def get_onboarding_gate(
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> OnboardingGateResponse:
     """Return the workspace's onboarding unlock posture.
 
@@ -439,7 +448,7 @@ async def get_onboarding_gate(
 
 @router.get("/scenarios", response_model=ScenarioCatalogResponse)
 async def list_scenarios(
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> ScenarioCatalogResponse:
     """Enumerate the bundled scenario templates (RFC 08 §11.2).
 
@@ -461,7 +470,7 @@ async def list_scenarios(
 @router.get("/aggregate", response_model=AggregateRollupResponse)
 async def get_aggregate_rollup(
     window_days: int = Query(default=30, ge=1, le=90),
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> AggregateRollupResponse:
     """Rolling rollup over the workspace's recent backtests + projections
     (RFC 08 §11.5).
@@ -489,7 +498,7 @@ async def get_aggregate_rollup(
 
 @router.get("/insights", response_model=InsightsResponse)
 async def get_insights(
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> InsightsResponse:
     """Pattern-based insight synthesizer output (RFC 08 §11.6).
 
@@ -518,7 +527,7 @@ async def get_insights(
     response_model=ForesightThresholdResponse,
 )
 async def get_workspace_threshold(
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> ForesightThresholdResponse:
     """Return the workspace's resolved onboarding-gate threshold view.
 
@@ -542,7 +551,7 @@ async def get_workspace_threshold(
 )
 async def set_workspace_threshold(
     body: SetForesightThresholdRequest,
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> ForesightThresholdResponse:
     """Upsert the workspace's onboarding-gate threshold override.
 
@@ -587,7 +596,7 @@ async def set_workspace_threshold(
     response_model=ForesightInsightsConfigResponse,
 )
 async def get_workspace_insights_config(
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> ForesightInsightsConfigResponse:
     """Return the workspace's resolved insights-synthesizer config.
 
@@ -611,7 +620,7 @@ async def get_workspace_insights_config(
 )
 async def set_workspace_insights_config(
     body: SetForesightInsightsConfigRequest,
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> ForesightInsightsConfigResponse:
     """Upsert the workspace's insights-synthesizer choice.
 
@@ -650,7 +659,7 @@ async def list_custom_scenarios(
     sub_type: str | None = Query(default=None, max_length=64),
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> CustomScenarioListResponse:
     """List workspace-scoped custom scenarios, most-recently-edited first.
 
@@ -677,7 +686,7 @@ async def list_custom_scenarios(
 )
 async def get_custom_scenario(
     scenario_id: str,
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> CustomScenarioResponse:
     """Fetch one custom scenario by id.
 
@@ -695,7 +704,7 @@ async def get_custom_scenario(
 )
 async def create_custom_scenario(
     body: CreateCustomScenarioRequest,
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> CustomScenarioResponse:
     """Save a new custom scenario YAML against the workspace.
 
@@ -724,7 +733,7 @@ async def create_custom_scenario(
 async def update_custom_scenario(
     scenario_id: str,
     body: CreateCustomScenarioRequest,
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> CustomScenarioResponse:
     """Full-replace the custom scenario fields.
 
@@ -747,7 +756,7 @@ async def update_custom_scenario(
 )
 async def delete_custom_scenario(
     scenario_id: str,
-    ctx: RequestContext = Depends(request_context),
+    ctx: RequestContext = Depends(loopback_or_request_context),
 ) -> Response:
     """Remove the custom scenario row.
 

--- a/src/pocketpaw/bundled_skills/_bundled/foresight-create-sim/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/foresight-create-sim/SKILL.md
@@ -1,0 +1,589 @@
+---
+name: foresight-create-sim
+description: |
+  Create, edit, and run Foresight scenarios via the workspace's REST API.
+  Triggered when the user asks to rehearse / simulate / project / forecast
+  / branch a decision — "rehearse the renewal", "what if we cut price
+  10%", "simulate the org change before we announce", "forecast Q3 churn",
+  "branch the launch decision". The skill teaches the chat agent how to
+  discover existing scenarios, synthesize the YAML body, save it via
+  PUT/POST, and (on explicit user confirmation) execute the run. Calls the
+  cloud's existing ``/api/v1/foresight/*`` endpoints with the internal
+  loopback headers — no engine code is touched.
+---
+
+# Foresight Scenario Workflow
+
+You're being asked to drive PocketPaw's **Foresight** module — the
+population-scale decision rehearsal engine (RFC 08). The user wants to
+**rehearse a decision before they make it**: model the personas, run
+synthetic ticks, surface a forecast plus per-anchor projected outcomes,
+and (optionally) compare against a known historical anchor.
+
+This skill teaches you the 4-phase workflow and the YAML schema. It does
+NOT replace the YAML editor in the UI — power users still edit there
+directly. Reach for this skill only when the user is having the
+conversation **in chat**.
+
+## When to use
+
+**Trigger phrases:** "rehearse", "simulate", "project", "forecast",
+"branch", "what if", "model the impact of", "play forward", "stress test"
+— combined with a decision the user is about to make or a change they're
+planning.
+
+  Examples that DO match:
+  - "rehearse the price increase to enterprise customers"
+  - "what if we push the renewal deadline back two weeks?"
+  - "simulate the org change before we announce it"
+  - "forecast how the founding team will react to the rebrand"
+  - "branch the Q3 hiring plan — three personas accept, two resist"
+
+**When NOT to use:**
+- The user is editing an existing pocket on the canvas — that's the
+  ``pocketpaw-edit-pocket`` skill, not this one.
+- The user opens the **YAML editor panel** directly (paw-enterprise
+  Foresight admin → New Scenario). The UI's Monaco buffer is the
+  power-user path; the chat surface is the natural-language path. They
+  cooperate via the same REST endpoints.
+- The user asks for **historical accuracy** ("how accurate were our
+  forecasts last quarter?") — that's the Aggregate / Insights panel
+  read path, not the scenario create path.
+- The user wants a **dashboard / canvas** of metrics — that's the
+  ``pocketpaw-create-pocket`` skill.
+
+## The four-phase workflow
+
+Every interaction with Foresight from chat follows this loop:
+
+  1. **Discover** — does a scenario like this already exist?
+  2. **Synthesize** — build (or modify) the YAML body.
+  3. **Save** — POST (new) or PUT (replace) the custom scenario.
+  4. **Run** — POST /scenarios with ``custom_scenario_id``, ONLY if the
+     user explicitly confirms.
+
+Skipping phases is the most common failure mode. If you jump straight to
+"run" without saving, you can't re-run the same scenario. If you skip
+"discover" and create a duplicate, the workspace fills with near-copies.
+
+## STEP 1 — Discover (list before you create)
+
+Always GET the workspace's saved scenarios first. The user may have
+already built something close to what they want.
+
+```bash
+curl -s -X GET \
+  -H "X-PocketPaw-Internal: true" \
+  -H "X-PocketPaw-Workspace-Id: $WORKSPACE_ID" \
+  -H "X-PocketPaw-User-Id: $USER_ID" \
+  "http://localhost:8000/api/v1/foresight/scenarios/custom?limit=20"
+```
+
+Returns ``{items, total, limit, offset, has_more}``. Each item carries
+``id, name, sub_type, num_personas, num_ticks, updated_at``.
+
+**Decision branch:**
+- A close match exists → ask the user "I found `<name>` from `<date>`.
+  Edit that, or start fresh?" Don't silently overwrite.
+- Nothing close → proceed to STEP 2 with a new scenario.
+
+## STEP 2 — Synthesize the YAML
+
+Foresight scenarios are YAML documents the engine parses into a
+``ScenarioConfig``. The schema below is the v1.0 wire grammar. Anything
+NOT in this list is silently ignored by the loader (intentional —
+forward-compat for v2.0 fields).
+
+### Required fields
+
+  - ``name`` (string, ≤120 chars) — human label for the scenario.
+  - ``sub_type`` (enum) — one of:
+      - ``decision_forecast`` — single-decision projection (renewals,
+        approvals, go/no-go gates).
+      - ``market_sim`` — competitive market dynamics across segments
+        (pricing, launches, churn).
+      - ``org_change_rehearsal`` — internal rollouts staged across
+        ticks (re-org, tooling, policy).
+  - ``n_ticks`` (int, 1-1000) — number of simulation steps. Decision
+    forecasts usually want 1; market sims 2-5; org change rehearsals
+    match the rollout event count (often 4).
+  - ``personas`` (list, 1-100 items) — each persona is:
+      - ``name`` (string) — identifier inside the scenario.
+      - ``role`` (string) — bucket the adapter aggregates against.
+        Common roles: ``approver``, ``tenant``, ``manager``, ``ic``,
+        ``ops``, ``customer_success``, ``enterprise``, ``smb``,
+        ``channel``, ``competitor``, ``property_manager``, ``agent``.
+      - ``ocean`` (map, optional) — OCEAN trait deltas in [-2, 2]:
+        ``openness``, ``conscientiousness``, ``extraversion``,
+        ``agreeableness``, ``neuroticism``. Values are deltas off the
+        baseline 0 — positive = stronger trait. Omit traits the user
+        didn't specify; the engine defaults them to 0.
+
+### Optional fields
+
+  - ``tier_mix`` (map) — share of personas routed to each LLM tier.
+    Must sum to 1.0 ± 0.001. Captain-locked default 5/15/80:
+
+    ```yaml
+    tier_mix:
+      premium: 0.05  # Claude Sonnet 4.7 — strategic / approver personas
+      mid:     0.15  # Claude Haiku 4.7 — mid-fidelity cohort
+      tail:    0.80  # Llama-3.1-8B via vLLM — bulk synthesized personas
+    ```
+
+    Overriding the mix triggers a cost-estimator warning in the UI —
+    only deviate when the user explicitly asked.
+
+  - ``precedent_seed`` (string) — global forward-precedent seed. When
+    set, every projected decision gets a synthetic, deterministic
+    ``forward_precedent_decision_id``. Omit unless the user mentions
+    "link to past decision".
+
+  - ``precedent_seeds`` (map) — per-anchor overrides keyed by anchor id.
+
+### Anchors (for backtests, not forward sims)
+
+Forward sims (POST /scenarios) don't carry inline anchors — the engine
+fans personas across the ticks and emits one ProjectedDecision per
+(tick, anchor inferred from role). **Backtests** (POST /backtests) are
+where anchors are required:
+
+  ```json
+  {
+    "anchors": [
+      {
+        "anchor_object_id": "decision:renewal_q2_2026",
+        "actual_outcome": {"renewed": true, "discount_pct": 8},
+        "scenario_template": "decision_forecast.yaml",
+        "projection_confidence": 0.5
+      }
+    ]
+  }
+  ```
+
+This skill focuses on **forward sims**. If the user asks for a backtest
+("did we predict the Q2 renewals correctly?"), redirect to the backtest
+endpoint and surface the ``gate_decision`` from the response. The chat
+agent rarely needs to build backtests by hand — the UI's Aggregate panel
+does that.
+
+## STEP 3 — Save the scenario
+
+### Create (POST)
+
+```bash
+YAML_BODY=$(cat <<'EOF'
+name: rehearse-q3-renewals
+sub_type: decision_forecast
+n_ticks: 1
+tier_mix:
+  premium: 0.05
+  mid: 0.15
+  tail: 0.80
+personas:
+  - name: tenant-maria
+    role: tenant
+    ocean:
+      conscientiousness: 0.4
+      agreeableness: 0.5
+  - name: approver-prakash
+    role: approver
+    ocean:
+      conscientiousness: 1.2
+EOF
+)
+
+# Escape the YAML for JSON
+YAML_JSON=$(jq -Rs <<<"$YAML_BODY")
+
+curl -s -X POST \
+  -H "X-PocketPaw-Internal: true" \
+  -H "X-PocketPaw-Workspace-Id: $WORKSPACE_ID" \
+  -H "X-PocketPaw-User-Id: $USER_ID" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"name\": \"Rehearse Q3 Renewals\",
+    \"sub_type\": \"decision_forecast\",
+    \"description\": \"Renewal cohort with one approver.\",
+    \"yaml_body\": $YAML_JSON
+  }" \
+  http://localhost:8000/api/v1/foresight/scenarios/custom
+```
+
+Returns 201 with the full scenario object (id, parsed_meta, yaml_body).
+**Capture the ``id``** — you need it for the run step.
+
+### Edit (PUT — full replace)
+
+```bash
+curl -s -X PUT \
+  -H "X-PocketPaw-Internal: true" \
+  -H "X-PocketPaw-Workspace-Id: $WORKSPACE_ID" \
+  -H "X-PocketPaw-User-Id: $USER_ID" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\": ..., \"sub_type\": ..., \"yaml_body\": $YAML_JSON}" \
+  "http://localhost:8000/api/v1/foresight/scenarios/custom/$SCENARIO_ID"
+```
+
+PUT is **full replace** — every field on the body overwrites the saved
+doc. Read-modify-write: GET the current state first, modify only the
+fields the user asked to change, then PUT. NEVER blank out a field the
+user didn't mention.
+
+### Delete
+
+```bash
+curl -s -X DELETE \
+  -H "X-PocketPaw-Internal: true" \
+  -H "X-PocketPaw-Workspace-Id: $WORKSPACE_ID" \
+  -H "X-PocketPaw-User-Id: $USER_ID" \
+  "http://localhost:8000/api/v1/foresight/scenarios/custom/$SCENARIO_ID"
+```
+
+Returns 204. **Always confirm with the user before deleting** — the
+operation is irreversible (no audit log undo).
+
+## STEP 4 — Run (only on explicit confirm)
+
+After the save lands, ask the user:
+
+  > "Saved as `<name>`. Want me to run it now?"
+
+Wait for an explicit "yes" / "run it" / "go" before calling POST.
+Foresight runs cost LLM tokens — never auto-run on save.
+
+```bash
+curl -s -X POST \
+  -H "X-PocketPaw-Internal: true" \
+  -H "X-PocketPaw-Workspace-Id: $WORKSPACE_ID" \
+  -H "X-PocketPaw-User-Id: $USER_ID" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"name\": \"$SCENARIO_NAME\",
+    \"custom_scenario_id\": \"$SCENARIO_ID\"
+  }" \
+  http://localhost:8000/api/v1/foresight/scenarios
+```
+
+The v0.1 deterministic-fake backend completes synchronously — POST
+returns the full run record (``status: complete``) on the same response.
+Future versions return ``status: queued`` plus a websocket URL; this
+skill assumes synchronous for now.
+
+Response carries ``id``, ``status``, ``result.aggregates``,
+``result.projected_decisions[]``. Surface the run id and a one-line
+verdict drawn from ``result.aggregates``.
+
+For richer details, GET the per-anchor projections:
+
+```bash
+curl -s -X GET \
+  -H "X-PocketPaw-Internal: true" \
+  -H "X-PocketPaw-Workspace-Id: $WORKSPACE_ID" \
+  -H "X-PocketPaw-User-Id: $USER_ID" \
+  "http://localhost:8000/api/v1/foresight/runs/$RUN_ID/projected-decisions"
+```
+
+## Endpoint reference
+
+  - ``GET    /api/v1/foresight/scenarios/custom`` — list saved scenarios
+    (workspace-scoped, paginated; optional ``?sub_type=`` filter).
+  - ``GET    /api/v1/foresight/scenarios/custom/{id}`` — fetch one,
+    returns full yaml_body + parsed_meta.
+  - ``POST   /api/v1/foresight/scenarios/custom`` — create. Body:
+    ``{name, sub_type, description, yaml_body}``. Returns 201 with the id.
+  - ``PUT    /api/v1/foresight/scenarios/custom/{id}`` — full replace.
+    Returns 200.
+  - ``DELETE /api/v1/foresight/scenarios/custom/{id}`` — remove (204).
+    Idempotency: a second DELETE on the same id returns 404.
+  - ``POST   /api/v1/foresight/scenarios`` — run. Body: ``{name,
+    custom_scenario_id, route_to_instinct?, precedent_seed?}`` OR the
+    inline-personas grammar (skip custom_scenario_id and embed
+    ``sub_type``, ``personas[]``, ``n_ticks`` directly).
+  - ``GET    /api/v1/foresight/runs/{id}`` — fetch one run with full
+    result blob.
+  - ``GET    /api/v1/foresight/runs/{id}/projected-decisions`` —
+    paginated list of per-anchor projections, optional
+    ``?anchor_id=`` filter.
+
+## Three worked examples
+
+### Example 1 — Decision Forecast
+
+User: "Rehearse the Q3 enterprise renewal — 5 customers, one approver,
+single decision."
+
+```yaml
+name: q3-enterprise-renewals
+sub_type: decision_forecast
+n_ticks: 1
+tier_mix:
+  premium: 0.05
+  mid: 0.15
+  tail: 0.80
+personas:
+  - name: customer-acme
+    role: tenant
+    ocean:
+      conscientiousness: 0.3
+      agreeableness: 0.5
+  - name: customer-globex
+    role: tenant
+    ocean:
+      openness: 0.4
+      neuroticism: -0.2
+  - name: customer-initech
+    role: tenant
+    ocean:
+      conscientiousness: 0.6
+  - name: customer-umbrella
+    role: tenant
+    ocean:
+      agreeableness: 0.7
+      neuroticism: 0.3
+  - name: customer-tyrell
+    role: tenant
+    ocean:
+      openness: 0.5
+      extraversion: 0.4
+  - name: approver-prakash
+    role: approver
+    ocean:
+      conscientiousness: 1.2
+```
+
+Save then run:
+
+```bash
+ID=$(curl -s -X POST ... /scenarios/custom | jq -r .id)
+curl -s -X POST ... /scenarios -d "{\"name\":\"Q3 Renewals\",\"custom_scenario_id\":\"$ID\"}"
+```
+
+### Example 2 — Market Sim (pricing stress test)
+
+User: "What happens if we raise enterprise pricing 12% and SMB stays
+flat? Two ticks — announce, then observe the competitive reaction."
+
+```yaml
+name: pricing-stress-2026q3
+sub_type: market_sim
+n_ticks: 2
+tier_mix:
+  premium: 0.05
+  mid: 0.15
+  tail: 0.80
+personas:
+  - name: enterprise-acme
+    role: enterprise
+    ocean:
+      conscientiousness: 0.6
+      neuroticism: -0.2
+  - name: enterprise-globex
+    role: enterprise
+    ocean:
+      openness: 0.4
+  - name: smb-quickserve
+    role: smb
+    ocean:
+      extraversion: 0.5
+      openness: 0.6
+  - name: smb-corner-coffee
+    role: smb
+    ocean:
+      agreeableness: 0.7
+  - name: channel-partner-east
+    role: channel
+    ocean:
+      extraversion: 0.8
+  - name: competitor-alpha
+    role: competitor
+    ocean:
+      openness: 0.9
+      conscientiousness: 0.4
+```
+
+After save + run, surface ``aggregates.per_segment`` per role bucket.
+
+### Example 3 — Org Change Rehearsal
+
+User: "Model the engineering re-org — 2 managers, 3 ICs, ops + CS. Four
+rollout events: announce, training, deadline, escalation."
+
+```yaml
+name: eng-reorg-2026q3
+sub_type: org_change_rehearsal
+n_ticks: 4  # one tick per rollout event
+tier_mix:
+  premium: 0.05
+  mid: 0.15
+  tail: 0.80
+personas:
+  - name: eng-manager-anne
+    role: manager
+    ocean:
+      conscientiousness: 0.8
+      agreeableness: 0.4
+  - name: eng-manager-priya
+    role: manager
+    ocean:
+      conscientiousness: 0.6
+      openness: 0.3
+  - name: ic-alex
+    role: ic
+    ocean:
+      openness: 0.7
+      neuroticism: -0.3
+  - name: ic-blake
+    role: ic
+    ocean:
+      conscientiousness: 0.5
+      agreeableness: 0.6
+  - name: ic-carmen
+    role: ic
+    ocean:
+      neuroticism: 0.4   # higher resistance tilt
+      openness: -0.2
+  - name: ops-david
+    role: ops
+    ocean:
+      conscientiousness: 0.7
+  - name: cs-elena
+    role: customer_success
+    ocean:
+      extraversion: 0.6
+  - name: cs-frank
+    role: customer_success
+    ocean:
+      agreeableness: 0.7
+```
+
+After the run, surface ``aggregates.per_event`` (adoption / resistance /
+exit / escalation rates) and ``totals.queue_depth``.
+
+## Error handling — the 422 envelope
+
+The cloud returns errors in a stable envelope:
+
+```json
+{ "error": { "code": "foresight.invalid_yaml", "message": "..." } }
+```
+
+Four error codes you'll see:
+
+  - **422 ``foresight.invalid_yaml``** — YAML failed to parse. Read the
+    message, identify the field (often a colon / indentation issue),
+    fix, retry. NEVER swallow the error and present a fake success.
+  - **422 ``foresight.sub_type_mismatch``** — the ``sub_type`` in the
+    request body differs from the ``sub_type:`` declared inside the
+    YAML. Pick one; they must match. The body's sub_type wins as the
+    intent declaration; rewrite the YAML to match.
+  - **422 ``foresight.invalid_scenario``** — YAML parsed but engine
+    grammar / cap failed (persona count > 100, n_ticks > 1000, tier_mix
+    doesn't sum to 1.0, etc.). Read the message — it names the field —
+    and adjust.
+  - **404 ``foresight_custom_scenario.not_found``** — the scenario id
+    is unknown or belongs to another workspace (tenancy collapse). On a
+    PUT/DELETE/GET retry, this means the id is stale; refresh the list.
+
+Surface the error message to the user verbatim — do not paraphrase. The
+message names the field; the user can fix it directly. If the error
+recurs after one retry, stop and ask for clarification rather than
+looping.
+
+## Auth headers
+
+Calls go to ``http://localhost:8000`` (the local dashboard's loopback
+address). The agent runs on the same host as the dashboard and uses
+internal-trust headers — NO user JWT needed.
+
+Required on every call:
+
+  - ``X-PocketPaw-Internal: true``
+  - ``X-PocketPaw-Workspace-Id: <id>``
+  - ``X-PocketPaw-User-Id: <id>``
+
+The workspace + user ids come from the **chat surface stamp** the
+dashboard threads into the agent's context. Look for ``$WORKSPACE_ID``
+and ``$USER_ID`` env vars or a system-prompt block named ``<surface>``
+that carries them. If neither is present, ask the user to switch to a
+specific workspace before continuing.
+
+If the loopback bypass is misconfigured (wrong host, missing headers,
+or feature flag off), the cloud returns 401 — surface the error and
+tell the user the dashboard auth path needs attention.
+
+## Run pattern — ask, then go
+
+After every save, ALWAYS ask before running:
+
+  > "Saved as `<name>`. Want me to run it now? Forward sims cost LLM
+  > tokens; the run takes ~5s on the deterministic backend, 30-120s on
+  > the live LLM tier pool."
+
+Wait for explicit confirmation. Acceptable confirms: "yes", "run it",
+"go ahead", "ship it", "send it". Anything else → wait.
+
+After the run completes (synchronous in v0.1):
+
+  - One-line verdict drawn from ``result.aggregates``.
+  - The run id + a hint: "Open the Live panel for the full breakdown."
+  - For richer detail, optionally GET ``/runs/{id}/projected-decisions``
+    and surface the highest-confidence projections.
+
+## Edit pattern — read, modify, replace
+
+When the user asks to change a saved scenario:
+
+  1. GET the scenario by id to capture the current state.
+  2. Parse the ``yaml_body`` into your working copy.
+  3. Modify ONLY the fields the user named. Leave everything else
+     verbatim — including comments, ordering, and tier_mix.
+  4. PUT the full body back.
+
+NEVER PUT a body assembled from memory — you'll lose fields the user
+added through the UI. Always read first.
+
+## Conversation conventions
+
+  - **Concise + active voice.** "Saved as q3-renewals. Run it?" beats
+    "I have successfully created the scenario for you. Would you like me
+    to execute it?"
+  - **Surface YAML in code-fence blocks** so the user can copy / edit it
+    in their own editor if they want.
+  - **Ask before deleting.** "Want me to delete the old `q2-renewals`
+    scenario?" — never silently overwrite or remove.
+  - **Admit when the request doesn't fit.** Four sub_types are deferred
+    to future RFC waves (``cycle_planner``, ``portfolio_sim``,
+    ``crisis_branch``, ``calibration_drift``). If the user asks for one
+    of those, say so and offer to map to the closest v1.0 shape:
+      - "cycle planner" → ``decision_forecast`` with n_ticks matched to
+        the cycle length
+      - "portfolio sim" → ``market_sim`` with persona segments per
+        portfolio bucket
+      - "crisis branch" → ``decision_forecast`` with one anchor per
+        crisis scenario
+      - "calibration drift" → not supported; redirect to the
+        ``/aggregate`` and ``/insights`` read endpoints
+
+## Hard rules
+
+  - **NEVER** call POST /scenarios without first GETing the workspace
+    scenario list. Discovery prevents duplicates.
+  - **NEVER** run on save — always ask first.
+  - **NEVER** PUT a partial body — full replace means full state.
+  - **NEVER** invent error codes. If the cloud returns ``422
+    foresight.invalid_scenario``, surface that exact code; don't
+    paraphrase it as "validation failed".
+  - **NEVER** call ``/api/v1/foresight/backtests`` from this skill. The
+    backtest path needs ground-truth anchors and ships through the UI's
+    Aggregate panel. If the user asks for a backtest, redirect them
+    there.
+  - **ALWAYS** echo the response shape verbatim when surfacing a run
+    result — the operator's Live panel binds to the same field names.
+
+## Related skills
+
+  - ``pocketpaw-create-pocket`` — when the user wants a **dashboard** of
+    foresight history (Aggregate / Insights), not a new sim.
+  - ``pocketpaw-edit-pocket`` — when the user is on an existing canvas
+    and wants to add a Foresight widget to it.

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,11 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-05-26: Added ``foresight_use_skill`` — env gate for the
+    ``foresight-create-sim`` bundled skill (default OFF). The SKILL.md
+    still auto-installs; this flag toggles the chat-surface affordance
+    only. Read by the agent prompt assembler and the paw-enterprise
+    feature-flag echo. RFC 08 v1.0 wave 4.
   - 2026-05-22: Added ``source_refresh_min_interval_seconds`` (interval
     floor) and ``source_refresh_max_per_hour`` (per-pocket auto-refresh
     budget) — cost controls for pocket data-source interval / webhook
@@ -458,6 +463,24 @@ class Settings(BaseSettings):
             "or disable the template library entirely. Template install is "
             "best-effort: pocket creation still works (the specialist "
             "cold-generates) even when no template is installed."
+        ),
+    )
+    foresight_use_skill: bool = Field(
+        default=False,
+        description=(
+            "Activate the ``foresight-create-sim`` bundled skill in chat. "
+            "Default OFF — the SKILL.md still auto-installs to "
+            "``~/.claude/skills/`` (idempotent, harmless) but the chat "
+            "agent's prompt context builder and the cloud's chat surface "
+            "only surface the skill when this flag is True. Read by the "
+            "agent prompt assembler (``pocketpaw.bootstrap.context_builder`` "
+            "and the cloud's paw-enterprise feature-flag echo endpoint at "
+            "``/api/v1/config/features``); the foresight CRUD endpoints "
+            "themselves stay reachable regardless of this flag — the gate "
+            "is purely a chat-surface affordance toggle. Flip to True per "
+            "workspace once Foresight rollout completes; the flag is dev-"
+            "grade today and tightens to a per-workspace database setting "
+            "in a follow-up RFC."
         ),
     )
     deep_agents_skills: list[str] = Field(

--- a/tests/cloud/test_foresight_aggregate_insights_router.py
+++ b/tests/cloud/test_foresight_aggregate_insights_router.py
@@ -16,7 +16,11 @@ from typing import Any
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.context import (
+    RequestContext,
+    ScopeKind,
+    loopback_or_request_context,
+)
 from pocketpaw_ee.cloud._core.http import add_error_handler
 from pocketpaw_ee.cloud.foresight.router import router as foresight_router
 from pocketpaw_ee.cloud.license import require_license
@@ -40,7 +44,7 @@ def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
     async def _ctx() -> RequestContext:
         return _make_ctx(workspace_id, user_id)
 
-    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[loopback_or_request_context] = _ctx
     app.dependency_overrides[require_license] = lambda: None
     return app
 

--- a/tests/cloud/test_foresight_backtest_router.py
+++ b/tests/cloud/test_foresight_backtest_router.py
@@ -13,7 +13,11 @@ from typing import Any
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.context import (
+    RequestContext,
+    ScopeKind,
+    loopback_or_request_context,
+)
 from pocketpaw_ee.cloud._core.http import add_error_handler
 from pocketpaw_ee.cloud.foresight.router import router as foresight_router
 from pocketpaw_ee.cloud.license import require_license
@@ -37,7 +41,7 @@ def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
     async def _ctx() -> RequestContext:
         return _make_ctx(workspace_id, user_id)
 
-    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[loopback_or_request_context] = _ctx
     app.dependency_overrides[require_license] = lambda: None
     return app
 

--- a/tests/cloud/test_foresight_insights_config.py
+++ b/tests/cloud/test_foresight_insights_config.py
@@ -23,7 +23,11 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.context import (
+    RequestContext,
+    ScopeKind,
+    loopback_or_request_context,
+)
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud._core.http import add_error_handler
 from pocketpaw_ee.cloud._core.realtime.events import ForesightInsightsConfigUpdated
@@ -199,7 +203,7 @@ def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
     async def _ctx_dep() -> RequestContext:
         return _ctx(workspace_id, user_id)
 
-    app.dependency_overrides[request_context] = _ctx_dep
+    app.dependency_overrides[loopback_or_request_context] = _ctx_dep
     app.dependency_overrides[require_license] = lambda: None
     return app
 

--- a/tests/cloud/test_foresight_live_snapshot_router.py
+++ b/tests/cloud/test_foresight_live_snapshot_router.py
@@ -12,7 +12,11 @@ from typing import Any
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.context import (
+    RequestContext,
+    ScopeKind,
+    loopback_or_request_context,
+)
 from pocketpaw_ee.cloud._core.http import add_error_handler
 from pocketpaw_ee.cloud.foresight.router import router as foresight_router
 from pocketpaw_ee.cloud.license import require_license
@@ -36,7 +40,7 @@ def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
     async def _ctx() -> RequestContext:
         return _make_ctx(workspace_id, user_id)
 
-    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[loopback_or_request_context] = _ctx
     app.dependency_overrides[require_license] = lambda: None
     return app
 

--- a/tests/cloud/test_foresight_loopback_auth.py
+++ b/tests/cloud/test_foresight_loopback_auth.py
@@ -1,0 +1,423 @@
+# tests/cloud/test_foresight_loopback_auth.py
+# Created: 2026-05-26 (feat/foresight-v12-skill-and-loopback-auth) — RFC 08
+# v1.0 wave 4. Tests for ``loopback_or_request_context`` — the JWT-or-
+# loopback dependency the foresight router now resolves through. Verifies:
+#   - Loopback + full header trio → context built from headers, no JWT.
+#   - Loopback but missing any header → fall through to JWT path (Forbidden
+#     when no token).
+#   - Non-loopback origin + header trio → fall through to JWT path.
+#   - Internal header set to "false" → fall through.
+#   - Loopback origin + JWT user (no internal header) → JWT path picks up.
+#   - Cross-tenant attempt (workspace header doesn't match real user) →
+#     loopback bypass trusts the header verbatim (dev-grade); the follow-up
+#     PR tightens this to a signed JWT.
+"""HTTP-layer tests for the foresight router's loopback auth bypass."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import (
+    INTERNAL_HEADER,
+    USER_HEADER,
+    WORKSPACE_HEADER,
+    RequestContext,
+)
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.foresight.router import router as foresight_router
+from pocketpaw_ee.cloud.license import require_license
+
+# ---------------------------------------------------------------------------
+# App harness — uses the REAL ``loopback_or_request_context`` dep (no
+# override). The license dep stays overridden because licensing isn't the
+# subject under test here.
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    """Build a foresight app with REAL auth dep — only license is stubbed."""
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(foresight_router)
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def loopback_client(mongo_db: Any) -> AsyncClient:
+    """Client whose transport stamps a loopback client address.
+
+    httpx's ``ASGITransport`` defaults the client scope's ``client`` to
+    ``("127.0.0.1", 123)`` which is what ``request.client.host`` reads;
+    that's the same address the local chat agent presents in production.
+    """
+    app = _build_app()
+    transport = ASGITransport(app=app, client=("127.0.0.1", 1234))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def non_loopback_client(mongo_db: Any) -> AsyncClient:
+    """Client whose transport stamps a non-loopback address — simulates a
+    public-internet caller. The bypass must refuse this even if the
+    internal headers are present."""
+    app = _build_app()
+    transport = ASGITransport(app=app, client=("203.0.113.1", 1234))  # TEST-NET-3
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Loopback + full header trio → bypass succeeds
+# ---------------------------------------------------------------------------
+
+
+async def test_loopback_with_full_headers_grants_workspace_access(
+    loopback_client: AsyncClient,
+) -> None:
+    """The chat-agent happy path: loopback + ``X-PocketPaw-Internal: true``
+    + workspace/user ids → the foresight CRUD endpoints return real data
+    (an empty list, here, since no scenarios exist)."""
+
+    response = await loopback_client.get(
+        "/foresight/scenarios/custom",
+        headers={
+            INTERNAL_HEADER: "true",
+            WORKSPACE_HEADER: "w-loopback",
+            USER_HEADER: "u-agent",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    # Empty workspace → empty items list, deterministic envelope.
+    assert body == {
+        "items": [],
+        "total": 0,
+        "limit": 20,
+        "offset": 0,
+        "has_more": False,
+    }
+
+
+async def test_loopback_bypass_threads_workspace_to_create(
+    loopback_client: AsyncClient,
+) -> None:
+    """The workspace id from the header MUST propagate into the create
+    flow — otherwise the loopback bypass would silently leak across
+    tenants. We round-trip a create + list to confirm the doc lands in
+    the same workspace the header named."""
+
+    yaml_body = (
+        "name: loopback-test\n"
+        "sub_type: decision_forecast\n"
+        "n_ticks: 1\n"
+        "personas:\n"
+        "  - name: anne\n"
+        "    role: approver\n"
+        "    ocean:\n"
+        "      conscientiousness: 0.5\n"
+    )
+
+    create_resp = await loopback_client.post(
+        "/foresight/scenarios/custom",
+        json={
+            "name": "Loopback Test",
+            "sub_type": "decision_forecast",
+            "yaml_body": yaml_body,
+        },
+        headers={
+            INTERNAL_HEADER: "true",
+            WORKSPACE_HEADER: "w-loopback",
+            USER_HEADER: "u-agent",
+        },
+    )
+
+    assert create_resp.status_code == 201, create_resp.text
+    created = create_resp.json()
+    assert created["workspace_id"] == "w-loopback"
+    assert created["name"] == "Loopback Test"
+
+    # Cross-tenant check: a list call from a DIFFERENT workspace must NOT
+    # see this scenario. The bypass trusts whatever workspace id it's
+    # handed — tenant isolation rides on the service-level filter.
+    list_resp_other = await loopback_client.get(
+        "/foresight/scenarios/custom",
+        headers={
+            INTERNAL_HEADER: "true",
+            WORKSPACE_HEADER: "w-other",
+            USER_HEADER: "u-agent",
+        },
+    )
+    assert list_resp_other.status_code == 200
+    assert list_resp_other.json()["total"] == 0
+
+    # Same workspace sees the doc.
+    list_resp_same = await loopback_client.get(
+        "/foresight/scenarios/custom",
+        headers={
+            INTERNAL_HEADER: "true",
+            WORKSPACE_HEADER: "w-loopback",
+            USER_HEADER: "u-agent",
+        },
+    )
+    assert list_resp_same.status_code == 200
+    assert list_resp_same.json()["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Loopback but missing / wrong headers → fall through to JWT path
+# ---------------------------------------------------------------------------
+
+
+async def test_loopback_without_internal_header_falls_through(
+    loopback_client: AsyncClient,
+) -> None:
+    """Loopback origin but ``X-PocketPaw-Internal`` absent — the bypass
+    declines and the JWT path fires; with no token present, that returns
+    a 403 ``auth.required``."""
+
+    response = await loopback_client.get(
+        "/foresight/scenarios/custom",
+        headers={
+            WORKSPACE_HEADER: "w-loopback",
+            USER_HEADER: "u-agent",
+            # Crucially no INTERNAL_HEADER.
+        },
+    )
+
+    assert response.status_code == 403
+    body = response.json()
+    assert body == {"error": {"code": "auth.required", "message": "Authentication required"}}
+
+
+async def test_loopback_with_internal_false_falls_through(
+    loopback_client: AsyncClient,
+) -> None:
+    """``X-PocketPaw-Internal: false`` (or any non-``true`` value) MUST
+    NOT activate the bypass. A literal string match against
+    ``"true"`` (case-insensitive) is the only accepted form."""
+
+    response = await loopback_client.get(
+        "/foresight/scenarios/custom",
+        headers={
+            INTERNAL_HEADER: "false",
+            WORKSPACE_HEADER: "w-loopback",
+            USER_HEADER: "u-agent",
+        },
+    )
+
+    assert response.status_code == 403
+
+
+async def test_loopback_missing_workspace_header_falls_through(
+    loopback_client: AsyncClient,
+) -> None:
+    """Internal header + user id but no workspace id → bypass declines.
+    A missing workspace would collapse the tenancy filter to ``None``
+    and let the service read across tenants; reject early."""
+
+    response = await loopback_client.get(
+        "/foresight/scenarios/custom",
+        headers={
+            INTERNAL_HEADER: "true",
+            USER_HEADER: "u-agent",
+        },
+    )
+
+    assert response.status_code == 403
+
+
+async def test_loopback_missing_user_header_falls_through(
+    loopback_client: AsyncClient,
+) -> None:
+    """Internal header + workspace id but no user id → bypass declines.
+    A missing user collapses authorship and per-user audit, so reject."""
+
+    response = await loopback_client.get(
+        "/foresight/scenarios/custom",
+        headers={
+            INTERNAL_HEADER: "true",
+            WORKSPACE_HEADER: "w-loopback",
+        },
+    )
+
+    assert response.status_code == 403
+
+
+async def test_loopback_blank_workspace_header_falls_through(
+    loopback_client: AsyncClient,
+) -> None:
+    """Empty string workspace id is rejected by the same code path as
+    missing — explicit guard against a header-injection that strips the
+    value but keeps the name."""
+
+    response = await loopback_client.get(
+        "/foresight/scenarios/custom",
+        headers={
+            INTERNAL_HEADER: "true",
+            WORKSPACE_HEADER: "   ",
+            USER_HEADER: "u-agent",
+        },
+    )
+
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Non-loopback origin → bypass refuses even with full header trio
+# ---------------------------------------------------------------------------
+
+
+async def test_non_loopback_with_full_headers_falls_through(
+    non_loopback_client: AsyncClient,
+) -> None:
+    """A public-internet caller can forge the headers but ``request.client.host``
+    won't be a loopback address. The bypass MUST refuse — otherwise any
+    external caller could mint workspace access by setting three headers."""
+
+    response = await non_loopback_client.get(
+        "/foresight/scenarios/custom",
+        headers={
+            INTERNAL_HEADER: "true",
+            WORKSPACE_HEADER: "w-loopback",
+            USER_HEADER: "u-agent",
+        },
+    )
+
+    assert response.status_code == 403
+    body = response.json()
+    assert body == {"error": {"code": "auth.required", "message": "Authentication required"}}
+
+
+# ---------------------------------------------------------------------------
+# RequestContext helper smokes — pure-Python checks on the
+# ``_try_loopback_context`` decision logic without the FastAPI harness.
+# ---------------------------------------------------------------------------
+
+
+def _stub_request(
+    *,
+    host: str | None = "127.0.0.1",
+    headers: dict[str, str] | None = None,
+) -> Any:
+    """Build a stand-in object compatible with the ``Request`` shape the
+    helper inspects — ``request.client.host`` + ``request.headers.get``."""
+
+    class _Client:
+        def __init__(self, h: str | None) -> None:
+            self.host = h
+
+    class _Stub:
+        def __init__(self) -> None:
+            self.client = _Client(host) if host is not None else None
+            self.headers = headers or {}
+
+    return _Stub()
+
+
+def test_try_loopback_context_returns_context_on_full_trio() -> None:
+    from pocketpaw_ee.cloud._core.context import _try_loopback_context
+
+    req = _stub_request(
+        host="127.0.0.1",
+        headers={
+            INTERNAL_HEADER: "true",
+            WORKSPACE_HEADER: "w1",
+            USER_HEADER: "u1",
+        },
+    )
+
+    ctx = _try_loopback_context(req)
+    assert isinstance(ctx, RequestContext)
+    assert ctx.workspace_id == "w1"
+    assert ctx.user_id == "u1"
+    assert isinstance(ctx.started_at, datetime)
+    assert ctx.started_at.tzinfo is UTC
+
+
+def test_try_loopback_context_returns_none_on_non_loopback_host() -> None:
+    from pocketpaw_ee.cloud._core.context import _try_loopback_context
+
+    req = _stub_request(
+        host="10.0.0.1",  # private but not loopback
+        headers={
+            INTERNAL_HEADER: "true",
+            WORKSPACE_HEADER: "w1",
+            USER_HEADER: "u1",
+        },
+    )
+
+    assert _try_loopback_context(req) is None
+
+
+def test_try_loopback_context_returns_none_on_no_client() -> None:
+    """Test apps without an explicit client transport collapse
+    ``request.client`` to ``None``. The helper must fail closed."""
+
+    from pocketpaw_ee.cloud._core.context import _try_loopback_context
+
+    req = _stub_request(
+        host=None,
+        headers={
+            INTERNAL_HEADER: "true",
+            WORKSPACE_HEADER: "w1",
+            USER_HEADER: "u1",
+        },
+    )
+
+    assert _try_loopback_context(req) is None
+
+
+def test_try_loopback_context_accepts_ipv6_loopback() -> None:
+    """``::1`` is the IPv6 loopback — dual-stack ASGI servers report it
+    when the client connects via ``localhost`` on a v6-enabled host."""
+
+    from pocketpaw_ee.cloud._core.context import _try_loopback_context
+
+    req = _stub_request(
+        host="::1",
+        headers={
+            INTERNAL_HEADER: "true",
+            WORKSPACE_HEADER: "w1",
+            USER_HEADER: "u1",
+        },
+    )
+
+    ctx = _try_loopback_context(req)
+    assert ctx is not None
+    assert ctx.workspace_id == "w1"
+
+
+def test_try_loopback_context_case_insensitive_internal_flag() -> None:
+    """``true``, ``TRUE``, and ``True`` all activate the bypass; anything
+    else (``yes``, ``1``, ``on``) does NOT."""
+
+    from pocketpaw_ee.cloud._core.context import _try_loopback_context
+
+    for value in ("true", "TRUE", "True", " true "):
+        req = _stub_request(
+            host="127.0.0.1",
+            headers={
+                INTERNAL_HEADER: value,
+                WORKSPACE_HEADER: "w1",
+                USER_HEADER: "u1",
+            },
+        )
+        assert _try_loopback_context(req) is not None, f"expected accept for {value!r}"
+
+    for value in ("yes", "1", "on", "true ish", ""):
+        req = _stub_request(
+            host="127.0.0.1",
+            headers={
+                INTERNAL_HEADER: value,
+                WORKSPACE_HEADER: "w1",
+                USER_HEADER: "u1",
+            },
+        )
+        assert _try_loopback_context(req) is None, f"expected refuse for {value!r}"

--- a/tests/cloud/test_foresight_projected_decision_router.py
+++ b/tests/cloud/test_foresight_projected_decision_router.py
@@ -12,7 +12,11 @@ from typing import Any
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.context import (
+    RequestContext,
+    ScopeKind,
+    loopback_or_request_context,
+)
 from pocketpaw_ee.cloud._core.http import add_error_handler
 from pocketpaw_ee.cloud.foresight.router import router as foresight_router
 from pocketpaw_ee.cloud.license import require_license
@@ -36,7 +40,7 @@ def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
     async def _ctx() -> RequestContext:
         return _make_ctx(workspace_id, user_id)
 
-    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[loopback_or_request_context] = _ctx
     app.dependency_overrides[require_license] = lambda: None
     return app
 

--- a/tests/cloud/test_foresight_router.py
+++ b/tests/cloud/test_foresight_router.py
@@ -14,7 +14,11 @@ from typing import Any
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.context import (
+    RequestContext,
+    ScopeKind,
+    loopback_or_request_context,
+)
 from pocketpaw_ee.cloud._core.http import add_error_handler
 from pocketpaw_ee.cloud.foresight.router import router as foresight_router
 from pocketpaw_ee.cloud.license import require_license
@@ -38,7 +42,7 @@ def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
     async def _ctx() -> RequestContext:
         return _make_ctx(workspace_id, user_id)
 
-    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[loopback_or_request_context] = _ctx
     app.dependency_overrides[require_license] = lambda: None
     return app
 

--- a/tests/cloud/test_foresight_threshold.py
+++ b/tests/cloud/test_foresight_threshold.py
@@ -24,7 +24,11 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.context import (
+    RequestContext,
+    ScopeKind,
+    loopback_or_request_context,
+)
 from pocketpaw_ee.cloud._core.errors import Forbidden
 from pocketpaw_ee.cloud._core.http import add_error_handler
 from pocketpaw_ee.cloud._core.realtime.events import ForesightThresholdUpdated
@@ -335,7 +339,7 @@ def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
     async def _ctx_dep() -> RequestContext:
         return _ctx(workspace_id, user_id)
 
-    app.dependency_overrides[request_context] = _ctx_dep
+    app.dependency_overrides[loopback_or_request_context] = _ctx_dep
     app.dependency_overrides[require_license] = lambda: None
     return app
 

--- a/tests/test_foresight_skill_installation.py
+++ b/tests/test_foresight_skill_installation.py
@@ -1,0 +1,180 @@
+# tests/test_foresight_skill_installation.py
+# Created: 2026-05-26 (feat/foresight-v12-skill-and-loopback-auth) — RFC 08
+# v1.0 wave 4. Verifies the ``foresight-create-sim`` bundled skill ships
+# with the right frontmatter shape, lands at the expected mirror path on
+# install, and survives the idempotent re-install loop. The installer
+# itself is covered by ``test_bundled_skills_installer.py``; this file
+# adds the skill-specific assertions so a frontmatter regression (missing
+# ``name``, wrong filename, etc.) trips a targeted test.
+"""Tests for the ``foresight-create-sim`` bundled skill.
+
+The skill is auto-discovered by the installer's directory iteration —
+no code wiring is needed. These tests check the SKILL.md content shape
+and the install behavior end-to-end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pocketpaw.bundled_skills.installer import install_bundled_skills
+
+# ---------------------------------------------------------------------------
+# Discovery — the installer's directory iteration must pick up the new skill
+# ---------------------------------------------------------------------------
+
+
+def test_foresight_skill_installs_to_destination(tmp_path: Path) -> None:
+    """The installer's directory iteration MUST pick up the new
+    ``foresight-create-sim`` subdir without any code change. A failed
+    discovery here means the SKILL.md is mis-located or the
+    ``_bundled/`` parent was renamed."""
+
+    results = install_bundled_skills(destination_root=tmp_path)
+
+    assert any(r.name == "foresight-create-sim" for r in results)
+
+    skill_path = tmp_path / "foresight-create-sim" / "SKILL.md"
+    assert skill_path.is_file()
+
+
+def test_foresight_skill_frontmatter_shape(tmp_path: Path) -> None:
+    """The SDK auto-discovery reads YAML frontmatter at the top of
+    SKILL.md. ``name`` MUST match the directory; ``description`` MUST
+    name the trigger phrases ("rehearse", "simulate", "forecast") so the
+    SDK's intent matcher picks the skill up on natural-language
+    invocation. A regression that drops one of those triggers would
+    silently make the skill non-discoverable in chat."""
+
+    install_bundled_skills(destination_root=tmp_path)
+
+    body = (tmp_path / "foresight-create-sim" / "SKILL.md").read_text()
+
+    # Frontmatter delimiters must be at the very top.
+    assert body.startswith("---\n"), "SKILL.md missing leading frontmatter fence"
+
+    # The ``name`` field MUST match the directory name — that's how the
+    # SDK keys the skill into its registry.
+    assert "\nname: foresight-create-sim\n" in body
+
+    # Description must mention each trigger phrase so the SDK's natural-
+    # language matcher fires on the expected user intents.
+    for trigger in ("rehearse", "simulate", "forecast"):
+        assert trigger in body.lower(), f"missing trigger phrase: {trigger!r}"
+
+
+# ---------------------------------------------------------------------------
+# Content — load-bearing sections that downstream reviewers depend on
+# ---------------------------------------------------------------------------
+
+
+def test_foresight_skill_documents_endpoint_surface(tmp_path: Path) -> None:
+    """The skill is the agent's primary doc for the foresight CRUD
+    endpoints; if these route stubs drift out of the SKILL.md, the
+    agent will guess wrong URLs. Catch that here."""
+
+    install_bundled_skills(destination_root=tmp_path)
+    body = (tmp_path / "foresight-create-sim" / "SKILL.md").read_text()
+
+    for endpoint in (
+        "/api/v1/foresight/scenarios/custom",
+        "/api/v1/foresight/scenarios",
+        "/api/v1/foresight/runs",
+    ):
+        assert endpoint in body, f"SKILL.md missing endpoint doc for {endpoint}"
+
+
+def test_foresight_skill_lists_three_subtypes(tmp_path: Path) -> None:
+    """v1.0 ships three sub_types — ``decision_forecast``, ``market_sim``,
+    ``org_change_rehearsal``. The skill MUST enumerate all three so the
+    agent can pick the right one from the user's intent. If the engine
+    adds a fourth sub_type in a later RFC wave, this test fires and the
+    skill body gets an explicit update — drift on the schema is a
+    silent failure mode otherwise."""
+
+    install_bundled_skills(destination_root=tmp_path)
+    body = (tmp_path / "foresight-create-sim" / "SKILL.md").read_text()
+
+    for sub_type in (
+        "decision_forecast",
+        "market_sim",
+        "org_change_rehearsal",
+    ):
+        assert sub_type in body, f"SKILL.md missing sub_type: {sub_type}"
+
+
+def test_foresight_skill_documents_loopback_auth_headers(tmp_path: Path) -> None:
+    """The agent uses the loopback header trio to authenticate. If the
+    skill body forgets to document any of the three header names, the
+    agent will call with the wrong auth shape and get 403s. Pin all
+    three header names here."""
+
+    install_bundled_skills(destination_root=tmp_path)
+    body = (tmp_path / "foresight-create-sim" / "SKILL.md").read_text()
+
+    for header in (
+        "X-PocketPaw-Internal",
+        "X-PocketPaw-Workspace-Id",
+        "X-PocketPaw-User-Id",
+    ):
+        assert header in body, f"SKILL.md missing header doc for {header}"
+
+
+def test_foresight_skill_documents_422_error_envelope(tmp_path: Path) -> None:
+    """The cloud's 422 errors carry a ``foresight.invalid_yaml`` /
+    ``foresight.sub_type_mismatch`` / ``foresight.invalid_scenario``
+    code. The skill MUST teach the agent to surface these verbatim
+    rather than swallow them — PR #276 lesson."""
+
+    install_bundled_skills(destination_root=tmp_path)
+    body = (tmp_path / "foresight-create-sim" / "SKILL.md").read_text()
+
+    for code in (
+        "foresight.invalid_yaml",
+        "foresight.sub_type_mismatch",
+        "foresight.invalid_scenario",
+    ):
+        assert code in body, f"SKILL.md missing error code: {code}"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — re-installing the same skill must be a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_foresight_skill_install_is_idempotent(tmp_path: Path) -> None:
+    """First install lands the file with status ``installed``; second
+    install with no content drift collapses to ``skipped``. This is the
+    steady-state boot — every dashboard restart re-runs the installer."""
+
+    first = install_bundled_skills(destination_root=tmp_path)
+    second = install_bundled_skills(destination_root=tmp_path)
+
+    first_result = next(r for r in first if r.name == "foresight-create-sim")
+    second_result = next(r for r in second if r.name == "foresight-create-sim")
+
+    assert first_result.status == "installed"
+    assert second_result.status == "skipped"
+
+
+def test_foresight_skill_updates_on_content_drift(tmp_path: Path) -> None:
+    """If the user's mirror of the SKILL.md ever drifts from the bundled
+    source (older PocketPaw version, hand-edit), the installer
+    overwrites it with the canonical bundled body. Status flips to
+    ``updated``."""
+
+    skill_dir = tmp_path / "foresight-create-sim"
+    skill_dir.mkdir(parents=True)
+    skill_file = skill_dir / "SKILL.md"
+    stale_marker = "DRIFT_SENTINEL_42"
+    skill_file.write_text(f"--- {stale_marker} content from a prior version ---")
+
+    results = install_bundled_skills(destination_root=tmp_path)
+    result = next(r for r in results if r.name == "foresight-create-sim")
+
+    assert result.status == "updated"
+    body = skill_file.read_text()
+    # The drift sentinel was a literal string the installer could not
+    # generate on its own — confirms the overwrite happened.
+    assert stale_marker not in body
+    assert "name: foresight-create-sim" in body


### PR DESCRIPTION
## Summary

Three changes wired together so the local chat agent can drive the
Foresight scenario API by talking to the user, without managing a user
JWT.

- **New bundled skill** ``foresight-create-sim`` teaches the chat agent
  the 4-phase Foresight workflow (discover, synthesize, save, run),
  documents all eight endpoints, and pins the YAML schema, the three
  v1.0 sub_types, and the 422 error vocabulary.
- **Loopback-internal auth** lets requests from ``127.0.0.1`` / ``::1``
  carrying the ``X-PocketPaw-Internal``, ``X-PocketPaw-Workspace-Id``,
  ``X-PocketPaw-User-Id`` headers skip JWT auth on the foresight routes.
- **Env gate** ``POCKETPAW_FORESIGHT_USE_SKILL`` (default OFF) toggles
  whether the chat surface advertises the skill. The skill file always
  installs; the flag controls the chat-surface affordance.

## Why

paw-enterprise's AI sidebar lead needs the chat agent to read and write
foresight scenarios on behalf of the operator without prompting for a
JWT each turn. The same conversational pattern that worked for
``pocketpaw-create-pocket`` and ``pocketpaw-edit-pocket`` ports to
foresight: a markdown SKILL.md the SDK auto-discovers, a thin REST
chokepoint the existing CRUD endpoints already provide, and a dev-grade
loopback bypass so the agent's curl calls work without intermediate
auth ceremony.

## What's in the PR

| File | Change | Notes |
|---|---|---|
| ``src/pocketpaw/bundled_skills/_bundled/foresight-create-sim/SKILL.md`` | New (589 lines) | 4-phase workflow, 8 endpoints, 3 worked examples (one per sub_type), 422 error envelope, header trio, edit pattern (GET → modify → PUT), run pattern (ask → confirm → POST). |
| ``ee/pocketpaw_ee/cloud/_core/context.py`` | Add ``loopback_or_request_context`` | Checks loopback host + header trio first; falls through to ``current_optional_user`` JWT on any miss. Returns ``Forbidden('auth.required')`` instead of fastapi-users' 401 when no auth is present. |
| ``ee/pocketpaw_ee/cloud/foresight/router.py`` | Swap dep | All 22 routes now resolve via ``loopback_or_request_context``; signatures unchanged. |
| ``src/pocketpaw/config.py`` | Add ``foresight_use_skill: bool`` | Default False; read by the agent prompt assembler / paw-enterprise feature-flag echo. |
| 7 existing foresight test files | Re-key dep override | Now override ``loopback_or_request_context`` instead of ``request_context``. |
| ``tests/cloud/test_foresight_loopback_auth.py`` | New (13 cases) | HTTP-layer happy path + every drop-through + pure-Python helper checks. |
| ``tests/test_foresight_skill_installation.py`` | New (8 cases) | Discovery, frontmatter, endpoint coverage, sub_type enum, header docs, 422 vocab, idempotent install loop. |

## Auth bypass — what existed, what I extended

There was **no pre-existing loopback bypass middleware** in the codebase
— the CSRF middleware skips cookie-less requests, and Bearer-auth
callers route around CSRF, but neither short-circuits the user-auth
dep. I introduced a NEW dep ``loopback_or_request_context`` (kept
``request_context`` intact for every other route) and limited the
trust expansion to the foresight router by swapping ONLY those 22
endpoints. The bypass requires three conditions in lockstep:

1. ``request.client.host`` is in ``{127.0.0.1, ::1, ::ffff:127.0.0.1, localhost}``.
2. ``X-PocketPaw-Internal: true`` (case-insensitive, trimmed).
3. Both ``X-PocketPaw-Workspace-Id`` and ``X-PocketPaw-User-Id`` are non-empty.

Any miss falls through to the JWT path. The dep returns
``Forbidden('auth.required')`` when neither path produces a context —
that's the 403 the chat agent will see on any boundary error.

The bypass is **dev-grade**. PR-2 follow-up tightens the loopback host
+ headers to a short-lived signed JWT minted by the dashboard; the
agent fetches it once per session and presents it as a Bearer token.
That closes the residual risk where any process on the local host can
forge the headers.

## Env-gate placement

``POCKETPAW_FORESIGHT_USE_SKILL`` is read in **two** places downstream:

- The agent prompt context builder (when the chat surface assembles the
  system prompt, it includes the skill list — the flag gates whether
  ``foresight-create-sim`` appears there).
- The paw-enterprise feature-flag echo endpoint (Lead 2's lane — the
  flag will surface there so the AI sidebar can decide whether to show
  the Foresight skill chip).

The flag is intentionally NOT read at the cloud router layer — the
foresight CRUD endpoints stay reachable regardless. The gate is purely
a chat-surface affordance toggle.

## Deferred to follow-up PRs

- **PR-2: signed-JWT loopback auth.** Replace the static header trio
  with a short-lived JWT the dashboard mints. Closes the residual risk
  where a chained process on the host can forge the headers.
- **PR-3: per-workspace skill flag.** Move ``foresight_use_skill`` from
  a global env var to a per-workspace database setting once the
  workspace-level feature-flag store ships.

## Test plan

- [x] ``uv run pytest tests/cloud --ignore=tests/cloud/extraction -k 'foresight'`` — 302 pass
- [x] ``uv run pytest tests/test_bundled_skills_installer.py tests/test_foresight_skill_installation.py`` — 15 pass
- [x] ``uv run pytest tests/cloud/_core/test_context.py`` — 7 pass (existing ``request_context`` tests unaffected)
- [x] ``uv run pytest tests/cloud/test_foresight_loopback_auth.py`` — 13 pass
- [x] ``uv run ruff check`` on touched files — clean
- [x] ``uv run mypy`` on touched files — clean
- [x] ``uv run lint-imports --config ee/pyproject.toml`` — 18 contracts kept, 0 broken
- [ ] Captain spot-check of the SKILL.md prose for the chat-agent's mental model