### PR TITLE
feat(foresight): /foresight surface handler + flip use-skill default ON

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -42,6 +42,7 @@ class SurfaceKind(StrEnum):
     QUICKASK = "quickask"
     SETTINGS = "settings"
     SIDEPANEL = "sidepanel"
+    FORESIGHT = "foresight"  # /foresight + /foresight/scenarios/* routes
     GENERIC = "generic"  # any unknown surface — agent still gets a usable preamble
 
 
@@ -61,6 +62,15 @@ class SurfaceMeta:
     agent_id: str | None = None
     file_id: str | None = None
     route_path: str | None = None
+    # Foresight surface hints — set by the paw-enterprise sidebar's
+    # surface stamp on /foresight routes. ``run_id`` is the active
+    # ScenarioRun being viewed; ``scenario_id`` is the custom scenario
+    # being edited; ``panel`` is the active rail tab ("scenarios" |
+    # "live" | "results" | "aggregate" | "insights" | "editor"). All
+    # optional — the handler degrades gracefully when absent.
+    run_id: str | None = None
+    scenario_id: str | None = None
+    panel: str | None = None
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/surface/dto.py
+++ b/ee/pocketpaw_ee/cloud/surface/dto.py
@@ -31,6 +31,11 @@ class SurfaceMetaRequest(BaseModel):
     agent_id: str | None = None
     file_id: str | None = None
     route_path: str | None = None
+    # Foresight hints — mirror SurfaceMeta. Set by the paw-enterprise
+    # sidebar's surface stamp on /foresight routes. All optional.
+    run_id: str | None = None
+    scenario_id: str | None = None
+    panel: str | None = None
 
 
 class SurfaceRequest(BaseModel):

--- a/ee/pocketpaw_ee/cloud/surface/handlers/foresight.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/foresight.py
@@ -1,0 +1,240 @@
+# foresight.py — /foresight surface preamble.
+#
+# Created: 2026-05-27 — Builds the chat agent's context preamble when the
+# user is on a /foresight or /foresight/scenarios/* route. Surfaces:
+#   - active scenario run (if ``meta.run_id`` is set) — status, sub_type,
+#     ticks, projected-decision count
+#   - active custom scenario (if ``meta.scenario_id`` is set) — name,
+#     sub_type, persona + tick counts
+#   - workspace ambient state — recent run count + latest backtest gate
+#   - the foresight-create-sim skill activation hint, when
+#     ``settings.foresight_use_skill`` is True (default ON as of 2026-05-27).
+#
+# Failure modes degrade — any query exception logs at ``debug`` and gets
+# omitted from the preamble. The chat path receives a minimal surface
+# tag even when every query fails (better than no preamble + a 5xx).
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers._helpers import truncate_preamble
+
+logger = logging.getLogger(__name__)
+
+
+_VALID_PANELS = {"scenarios", "live", "results", "aggregate", "insights", "editor"}
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the /foresight surface preamble.
+
+    Always returns a string. Individual data fetches are wrapped in
+    isolated try/except so a single missing collection (e.g. backtests
+    not yet seeded) doesn't drop the whole preamble.
+    """
+    panel = meta.panel if meta.panel in _VALID_PANELS else None
+    surface_tag = (
+        f'<surface kind="foresight" route="/foresight"'
+        f'{f" panel=\"{panel}\"" if panel else ""} />'
+    )
+    parts: list[str] = [surface_tag]
+
+    # Active run block. Pulled when the sidebar stamps run_id (e.g. on
+    # /foresight when the rail is watching a specific run).
+    if meta.run_id:
+        run_block = await _render_active_run(workspace_id, meta.run_id)
+        if run_block:
+            parts.append(run_block)
+
+    # Active scenario block. Pulled when the user is in the editor
+    # (/foresight/scenarios/[id]) so the agent knows what they're editing.
+    if meta.scenario_id:
+        scenario_block = await _render_active_scenario(workspace_id, meta.scenario_id)
+        if scenario_block:
+            parts.append(scenario_block)
+
+    # Workspace ambient — recent run count + latest gate decision. Cheap
+    # signal that helps the agent gauge "is this a new workspace or one
+    # with a history?".
+    ambient = await _render_workspace_ambient(workspace_id)
+    if ambient:
+        parts.append(ambient)
+
+    # Skill activation hint. The bundled ``foresight-create-sim`` skill
+    # auto-installs to ``~/.claude/skills/`` regardless of this flag;
+    # surfacing the hint here tells the agent to prefer the skill path
+    # for scenario create / edit / run.
+    skill_block = _render_skill_hint()
+    if skill_block:
+        parts.append(skill_block)
+
+    return truncate_preamble("\n".join(parts))
+
+
+async def _render_active_run(workspace_id: str, run_id: str) -> str:
+    """Snapshot of the run the user is currently viewing.
+
+    Looks up the ForesightRun doc + counts ForesightProjectedDecisions
+    landed so far. Both queries tenant-filtered on workspace_id (cloud
+    rule #7).
+    """
+    try:
+        from datetime import UTC, datetime
+
+        from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+        from pocketpaw_ee.cloud.foresight import service as foresight_service
+    except Exception:
+        logger.debug("foresight handler: service import failed", exc_info=True)
+        return ""
+
+    try:
+        ctx = RequestContext(
+            user_id="surface-foresight",
+            workspace_id=workspace_id,
+            request_id="surface-foresight-run",
+            scope=ScopeKind.WORKSPACE,
+            started_at=datetime.now(UTC),
+        )
+        run = await foresight_service.get_scenario_run(ctx, run_id)
+    except Exception:
+        logger.debug("foresight handler: get_scenario_run failed for %s", run_id, exc_info=True)
+        return ""
+
+    if run is None:
+        return ""
+
+    status = getattr(run, "status", "unknown")
+    sub_type = getattr(run, "sub_type", "unknown")
+    ticks_completed = getattr(run, "ticks_completed", None)
+    total_ticks = getattr(run, "total_ticks", None)
+    tick_progress = (
+        f"{ticks_completed}/{total_ticks}" if (ticks_completed is not None and total_ticks) else "—"
+    )
+
+    # Projected-decision count — small surface signal so the agent can
+    # answer "how many decisions has this run produced so far?" without
+    # round-tripping a separate query.
+    try:
+        decisions = await foresight_service.list_projected_decisions(
+            ctx, run_id, limit=1, offset=0
+        )
+        decision_count = getattr(decisions, "total", 0) if decisions else 0
+    except Exception:
+        decision_count = 0
+
+    return (
+        f'<active-run id="{run_id}" status="{status}" sub_type="{sub_type}" '
+        f'ticks="{tick_progress}" projected_decisions="{decision_count}" />'
+    )
+
+
+async def _render_active_scenario(workspace_id: str, scenario_id: str) -> str:
+    """Snapshot of the custom scenario the user is editing."""
+    try:
+        from datetime import UTC, datetime
+
+        from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+        from pocketpaw_ee.cloud.foresight import scenarios as foresight_scenarios
+    except Exception:
+        logger.debug("foresight handler: scenarios import failed", exc_info=True)
+        return ""
+
+    try:
+        ctx = RequestContext(
+            user_id="surface-foresight",
+            workspace_id=workspace_id,
+            request_id="surface-foresight-scenario",
+            scope=ScopeKind.WORKSPACE,
+            started_at=datetime.now(UTC),
+        )
+        scenario = await foresight_scenarios.get_custom_scenario(ctx, scenario_id)
+    except Exception:
+        logger.debug(
+            "foresight handler: get_custom_scenario failed for %s", scenario_id, exc_info=True
+        )
+        return ""
+
+    if scenario is None:
+        return ""
+
+    name = getattr(scenario, "name", "(unnamed)")
+    sub_type = getattr(scenario, "sub_type", "unknown")
+    parsed = getattr(scenario, "parsed_meta", None)
+    personas = getattr(parsed, "num_personas", 0) if parsed else 0
+    ticks = getattr(parsed, "num_ticks", 0) if parsed else 0
+
+    return (
+        f'<active-scenario id="{scenario_id}" name="{name}" sub_type="{sub_type}" '
+        f'personas="{personas}" ticks="{ticks}" />'
+    )
+
+
+async def _render_workspace_ambient(workspace_id: str) -> str:
+    """Lightweight workspace context — recent run count + gate state."""
+    try:
+        from datetime import UTC, datetime
+
+        from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+        from pocketpaw_ee.cloud.foresight import service as foresight_service
+    except Exception:
+        return ""
+
+    try:
+        ctx = RequestContext(
+            user_id="surface-foresight",
+            workspace_id=workspace_id,
+            request_id="surface-foresight-ambient",
+            scope=ScopeKind.WORKSPACE,
+            started_at=datetime.now(UTC),
+        )
+        runs = await foresight_service.list_scenario_runs(ctx, limit=5, offset=0)
+        run_count = getattr(runs, "total", 0) if runs else 0
+    except Exception:
+        run_count = 0
+
+    try:
+        gate = await foresight_service.get_onboarding_gate(ctx)
+        gate_state = getattr(gate, "reason", "unknown") if gate else "unknown"
+    except Exception:
+        gate_state = "unknown"
+
+    return (
+        f'<workspace-summary recent_runs="{run_count}" '
+        f'onboarding_gate="{gate_state}" />'
+    )
+
+
+def _render_skill_hint() -> str:
+    """Skill activation hint — opt-in via ``settings.foresight_use_skill``.
+
+    The bundled ``foresight-create-sim`` skill auto-installs to
+    ``~/.claude/skills/`` regardless of this flag. Surfacing the hint
+    here tells the agent to PREFER the skill path when the user asks
+    to create / edit / run a scenario from chat, instead of describing
+    the steps in prose.
+    """
+    try:
+        from pocketpaw.config import get_settings
+
+        settings = get_settings()
+    except Exception:
+        return ""
+
+    if not getattr(settings, "foresight_use_skill", False):
+        return ""
+
+    return (
+        '<skill-active name="foresight-create-sim">\n'
+        "When the user asks to rehearse / simulate / forecast / branch a\n"
+        "decision, use the foresight-create-sim skill from\n"
+        "~/.claude/skills/foresight-create-sim/. Drive the cloud CRUD via\n"
+        "Bash + curl with the X-PocketPaw-Internal header trio. The skill\n"
+        "covers the YAML schema, the 422 envelope shape, and three worked\n"
+        "examples (Decision Forecast, Market Sim, Org Change).\n"
+        "</skill-active>"
+    )
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -41,6 +41,7 @@ def _load_handlers() -> dict[SurfaceKind, Any]:
         audit,
         calendar,
         files,
+        foresight as foresight_handler,
         generic,
         home,
         knowledge,
@@ -79,6 +80,7 @@ def _load_handlers() -> dict[SurfaceKind, Any]:
         SurfaceKind.QUICKASK: quickask.build_preamble,
         SurfaceKind.SETTINGS: settings.build_preamble,
         SurfaceKind.SIDEPANEL: sidepanel.build_preamble,
+        SurfaceKind.FORESIGHT: foresight_handler.build_preamble,
         SurfaceKind.GENERIC: generic.build_preamble,
     }
 
@@ -108,6 +110,9 @@ def _meta_from_request(req: SurfaceMetaRequest) -> SurfaceMeta:
         agent_id=req.agent_id,
         file_id=req.file_id,
         route_path=req.route_path,
+        run_id=req.run_id,
+        scenario_id=req.scenario_id,
+        panel=req.panel,
     )
 
 

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -466,19 +466,19 @@ class Settings(BaseSettings):
         ),
     )
     foresight_use_skill: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Activate the ``foresight-create-sim`` bundled skill in chat. "
-            "Default OFF — the SKILL.md still auto-installs to "
-            "``~/.claude/skills/`` (idempotent, harmless) but the chat "
-            "agent's prompt context builder and the cloud's chat surface "
-            "only surface the skill when this flag is True. Read by the "
-            "agent prompt assembler (``pocketpaw.bootstrap.context_builder`` "
-            "and the cloud's paw-enterprise feature-flag echo endpoint at "
+            "Default ON as of 2026-05-27 — the SKILL.md auto-installs to "
+            "``~/.claude/skills/`` (idempotent) and the chat agent's "
+            "prompt context builder + the cloud's foresight surface "
+            "handler include the skill-activation hint in the preamble. "
+            "Read by the agent prompt assembler "
+            "(``pocketpaw.bootstrap.context_builder``) and the cloud's "
+            "paw-enterprise feature-flag echo endpoint at "
             "``/api/v1/config/features``); the foresight CRUD endpoints "
             "themselves stay reachable regardless of this flag — the gate "
-            "is purely a chat-surface affordance toggle. Flip to True per "
-            "workspace once Foresight rollout completes; the flag is dev-"
+            "is purely a chat-surface affordance toggle. The flag is dev-"
             "grade today and tightens to a per-workspace database setting "
             "in a follow-up RFC."
         ),

--- a/tests/cloud/surface/test_foresight_handler.py
+++ b/tests/cloud/surface/test_foresight_handler.py
@@ -1,0 +1,228 @@
+# tests/cloud/surface/test_foresight_handler.py — /foresight surface preamble.
+#
+# Created: 2026-05-27 (feat/foresight-v12-config-and-surface-handler) —
+# Locks five guarantees for the foresight surface handler:
+#   1. Surface tag emits with panel attribute when one is supplied.
+#   2. Active-run block fetches via foresight_service.get_scenario_run
+#      when ``meta.run_id`` is set; missing data degrades to absent
+#      block (not an exception).
+#   3. Active-scenario block fetches via foresight_scenarios.get_custom_
+#      scenario when ``meta.scenario_id`` is set.
+#   4. Skill activation hint appears iff ``settings.foresight_use_skill``
+#      is True (default ON as of 2026-05-27).
+#   5. Failure mode: the handler never raises — every data fetch is
+#      isolated, and the chat router still gets a usable preamble even
+#      when every backing service errors.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.surface.domain import SurfaceKind, SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers import foresight as foresight_handler
+
+
+# ---------------------------------------------------------------------------
+# Surface tag + panel rendering
+# ---------------------------------------------------------------------------
+
+
+async def test_surface_tag_emits_with_panel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The opening tag carries panel when one of the valid values is supplied.
+
+    Invalid panel strings are dropped silently (the agent should never
+    see a typoed panel attribute leak into its prompt context).
+    """
+    # Stub every downstream so the test isolates rendering logic.
+    monkeypatch.setattr(foresight_handler, "_render_active_run", _async_return(""))
+    monkeypatch.setattr(foresight_handler, "_render_active_scenario", _async_return(""))
+    monkeypatch.setattr(foresight_handler, "_render_workspace_ambient", _async_return(""))
+    monkeypatch.setattr(foresight_handler, "_render_skill_hint", lambda: "")
+
+    meta = SurfaceMeta(panel="live")
+    out = await foresight_handler.build_preamble("ws_a", "user_a", meta)
+    assert '<surface kind="foresight" route="/foresight" panel="live" />' in out
+
+
+async def test_surface_tag_drops_unknown_panel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An out-of-vocab panel value (typo, future panel) is silently dropped.
+
+    Keeps the agent from seeing ``panel="lvie"`` and reasoning about a
+    panel that doesn't exist.
+    """
+    monkeypatch.setattr(foresight_handler, "_render_active_run", _async_return(""))
+    monkeypatch.setattr(foresight_handler, "_render_active_scenario", _async_return(""))
+    monkeypatch.setattr(foresight_handler, "_render_workspace_ambient", _async_return(""))
+    monkeypatch.setattr(foresight_handler, "_render_skill_hint", lambda: "")
+
+    meta = SurfaceMeta(panel="lvie")
+    out = await foresight_handler.build_preamble("ws_a", "user_a", meta)
+    assert '<surface kind="foresight" route="/foresight" />' in out
+    assert "panel=" not in out
+
+
+# ---------------------------------------------------------------------------
+# Active-run + active-scenario blocks
+# ---------------------------------------------------------------------------
+
+
+async def test_active_run_block_uses_run_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """run_id present → calls _render_active_run with the same id."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_render_run(workspace_id: str, run_id: str) -> str:
+        captured["run_id"] = run_id
+        captured["workspace_id"] = workspace_id
+        return f'<active-run id="{run_id}" status="complete" />'
+
+    monkeypatch.setattr(foresight_handler, "_render_active_run", _fake_render_run)
+    monkeypatch.setattr(foresight_handler, "_render_active_scenario", _async_return(""))
+    monkeypatch.setattr(foresight_handler, "_render_workspace_ambient", _async_return(""))
+    monkeypatch.setattr(foresight_handler, "_render_skill_hint", lambda: "")
+
+    meta = SurfaceMeta(run_id="run:abc", panel="results")
+    out = await foresight_handler.build_preamble("ws_a", "user_a", meta)
+    assert captured == {"run_id": "run:abc", "workspace_id": "ws_a"}
+    assert '<active-run id="run:abc"' in out
+
+
+async def test_active_scenario_block_uses_scenario_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """scenario_id present → calls _render_active_scenario with the same id."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_render_scenario(workspace_id: str, scenario_id: str) -> str:
+        captured["scenario_id"] = scenario_id
+        return f'<active-scenario id="{scenario_id}" name="renewal" />'
+
+    monkeypatch.setattr(foresight_handler, "_render_active_run", _async_return(""))
+    monkeypatch.setattr(foresight_handler, "_render_active_scenario", _fake_render_scenario)
+    monkeypatch.setattr(foresight_handler, "_render_workspace_ambient", _async_return(""))
+    monkeypatch.setattr(foresight_handler, "_render_skill_hint", lambda: "")
+
+    meta = SurfaceMeta(scenario_id="cs_xyz", panel="editor")
+    out = await foresight_handler.build_preamble("ws_a", "user_a", meta)
+    assert captured == {"scenario_id": "cs_xyz"}
+    assert '<active-scenario id="cs_xyz"' in out
+
+
+# ---------------------------------------------------------------------------
+# Skill activation hint
+# ---------------------------------------------------------------------------
+
+
+def test_skill_hint_appears_when_flag_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """foresight_use_skill = True → the hint block is emitted."""
+    from pocketpaw import config
+
+    fake = SimpleNamespace(foresight_use_skill=True)
+    monkeypatch.setattr(config, "get_settings", lambda: fake)
+    out = foresight_handler._render_skill_hint()
+    assert '<skill-active name="foresight-create-sim">' in out
+    assert "foresight-create-sim" in out
+
+
+def test_skill_hint_omitted_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """foresight_use_skill = False → no hint block."""
+    from pocketpaw import config
+
+    fake = SimpleNamespace(foresight_use_skill=False)
+    monkeypatch.setattr(config, "get_settings", lambda: fake)
+    out = foresight_handler._render_skill_hint()
+    assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# Service registry dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_service_dispatches_foresight_kind_to_handler() -> None:
+    """resolve_surface_context maps surface='foresight' onto the new handler.
+
+    The full dispatch path: SurfaceRequest validation → SurfaceKind
+    resolution → handler registry lookup. This is the lock against
+    accidental registry omissions.
+    """
+    from pocketpaw_ee.cloud.surface.service import resolve_surface_context
+
+    body = {
+        "surface": "foresight",
+        "meta": {
+            "panel": "scenarios",
+            "route_path": "/foresight",
+        },
+    }
+    ctx = await resolve_surface_context("ws_a", "user_a", body)
+    assert ctx.kind == SurfaceKind.FORESIGHT
+    assert '<surface kind="foresight"' in ctx.preamble
+    assert 'panel="scenarios"' in ctx.preamble
+
+
+# ---------------------------------------------------------------------------
+# Failure modes — handler never raises
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_degrades_when_every_subrender_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All sub-renderers raise → still returns the surface tag + skill hint.
+
+    The chat router must always receive SOME preamble; a crash here
+    would break the entire chat send for users on /foresight.
+    """
+
+    async def _boom_async(*_a: Any, **_kw: Any) -> str:
+        raise RuntimeError("intentional surface-handler failure")
+
+    monkeypatch.setattr(foresight_handler, "_render_active_run", _boom_async)
+    monkeypatch.setattr(foresight_handler, "_render_active_scenario", _boom_async)
+    monkeypatch.setattr(foresight_handler, "_render_workspace_ambient", _boom_async)
+
+    meta = SurfaceMeta(run_id="run:x", scenario_id="cs_x", panel="live")
+    # We expect this to propagate (build_preamble doesn't catch sub-renderer
+    # exceptions; the service.py wrapper does — verified by the next test).
+    with pytest.raises(RuntimeError):
+        await foresight_handler.build_preamble("ws_a", "user_a", meta)
+
+
+async def test_service_wrapper_absorbs_handler_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the handler itself raises, the service falls back to GENERIC."""
+    from pocketpaw_ee.cloud.surface import service as surface_service
+
+    async def _boom(*_a: Any, **_kw: Any) -> str:
+        raise RuntimeError("handler exploded")
+
+    # Force the registry to load with our boom-handler patched in. We
+    # reach into the lazy load + override after.
+    surface_service._HANDLERS = None  # type: ignore[attr-defined]
+    handlers = surface_service._load_handlers()
+    handlers[SurfaceKind.FORESIGHT] = _boom
+    surface_service._HANDLERS = handlers  # type: ignore[attr-defined]
+
+    ctx = await surface_service.resolve_surface_context(
+        "ws_a", "user_a", {"surface": "foresight"}
+    )
+    # GENERIC fallback per service.py contract — chat send still works.
+    assert ctx.kind == SurfaceKind.GENERIC
+    assert ctx.preamble == ""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _async_return(value: Any) -> Any:
+    """Wrap a value in an async callable. Mirrors test_calendar_handler pattern."""
+
+    async def _runner(*_a: Any, **_kw: Any) -> Any:
+        return value
+
+    return _runner


### PR DESCRIPTION
Two ships in one PR, aligned with the captain's 2026-05-27 directive:

## 1. `foresight_use_skill` default flips False → True

The bundled `foresight-create-sim` skill (#1260) was already auto-installing to `~/.claude/skills/`; the env gate was just keeping the chat agent from surfacing the activation hint. Foresight beta is ready, so the flag flips ON by default. Operators wanting the legacy in-prose path can still set `POCKETPAW_FORESIGHT_USE_SKILL=false`.

## 2. NEW `SurfaceKind.FORESIGHT` handler

The per-route surface-context module the captain shipped 2026-05-24 (pocketpaw#1209) had 17 SurfaceKind handlers; `/foresight` fell through to `GENERIC`. This PR adds the missing handler so when the paw-enterprise AI sidebar stamps `surface="foresight"`, the resolver dispatches to a Foresight-aware preamble builder.

### Preamble structure

```xml
<surface kind="foresight" route="/foresight" panel="live" />
<active-run id="run:abc" status="complete" sub_type="decision_forecast"
  ticks="3/3" projected_decisions="14" />
<active-scenario id="cs_xyz" name="Q4 renewal" sub_type="decision_forecast"
  personas="5" ticks="3" />
<workspace-summary recent_runs="12" onboarding_gate="unlocked" />
<skill-active name="foresight-create-sim">
When the user asks to rehearse / simulate / forecast / branch a
decision, use the foresight-create-sim skill from
~/.claude/skills/foresight-create-sim/. ...
</skill-active>
```

### SurfaceMeta extension

`SurfaceMeta` + `SurfaceMetaRequest` gain three optional fields — `run_id`, `scenario_id`, `panel` — already client-stamped by Lead 2 of the v1.1 wave (paw-enterprise PR #284 / #286).

### Failure modes

Each sub-render isolated in its own try/except so a single missing collection (e.g. backtests not yet seeded) doesn't drop the whole preamble. The service.py wrapper already absorbs handler exceptions into a `GENERIC` fallback per its 2026-05-24 contract; the new handler relies on that for the outer safety net.

## Tests

9 new vitest cases in `tests/cloud/surface/test_foresight_handler.py`:
- Surface tag emits with panel attribute
- Unknown panel drops silently
- `run_id` dispatches `_render_active_run`
- `scenario_id` dispatches `_render_active_scenario`
- Skill hint appears when `foresight_use_skill = True`
- Skill hint omitted when False
- Service registry dispatches `surface="foresight"` to the new handler
- Sub-renderer raising propagates up (locks the wrapper contract)
- Service wrapper absorbs handler exceptions into GENERIC fallback

44/44 surface + skill-installation tests pass.

## Test plan

- [x] `uv run --group ee pytest tests/cloud/surface tests/test_foresight_skill_installation.py` — 44/44 pass
- [ ] Captain enables flag locally + types in the AI sidebar on /foresight: agent now uses the bundled skill (POSTs scenario via curl) instead of describing the steps in prose