### PR TITLE
fix(foresight): assert foresight-first behavior in surface preamble

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/handlers/foresight.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/foresight.py
@@ -39,7 +39,34 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         f'<surface kind="foresight" route="/foresight"'
         f'{f" panel=\"{panel}\"" if panel else ""} />'
     )
-    parts: list[str] = [surface_tag]
+    # Directive block — assert foresight-first behavior FIRST so the
+    # agent's default "let me offer some pocket buttons" pattern doesn't
+    # leak into the greeting. Captain caught this 2026-05-27: agent
+    # responded to "hi" on /foresight with [Build a pocket / List my
+    # pockets / Rehearse a decision] because the preamble was descriptive
+    # but not directive. This block is small + assertive — the agent
+    # reads it before the rest of the chat-agent system prompt's pocket
+    # guidance.
+    guidance = (
+        "<surface-guidance>\n"
+        "The user is on the Foresight rail (population simulation for\n"
+        "decision rehearsal). PREFER Foresight affordances:\n"
+        "  - Create / edit a scenario (use the foresight-create-sim skill).\n"
+        "  - Run a scenario + summarize results.\n"
+        "  - Explain projected decisions, calibration accuracy, insights.\n"
+        "  - Branch a run, promote a decision to an anchor.\n"
+        "DO NOT offer pocket creation, pocket lists, or generic canvas\n"
+        "actions in starter buttons here — those belong on /pockets, not\n"
+        "/foresight. If the user explicitly asks for a pocket, you may\n"
+        "redirect them; otherwise stay in the Foresight context. When\n"
+        "greeting, offer Foresight-shaped starter actions only:\n"
+        '  - "Rehearse a decision"\n'
+        '  - "Run a quick scenario"\n'
+        '  - "Show me my recent runs"\n'
+        '  - "Explain the latest insights"\n'
+        "</surface-guidance>"
+    )
+    parts: list[str] = [surface_tag, guidance]
 
     # Active run block. Pulled when the sidebar stamps run_id (e.g. on
     # /foresight when the rail is watching a specific run).

--- a/tests/cloud/surface/test_foresight_handler.py
+++ b/tests/cloud/surface/test_foresight_handler.py
@@ -29,6 +29,27 @@ from pocketpaw_ee.cloud.surface.handlers import foresight as foresight_handler
 # ---------------------------------------------------------------------------
 
 
+async def test_preamble_includes_directive_surface_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The preamble carries a directive block that asserts foresight-first
+    behavior. Captain caught (2026-05-27) the agent offering pocket
+    affordances on /foresight when the preamble was descriptive but not
+    directive. The fix is locked here so the guidance can't drop silently.
+    """
+    monkeypatch.setattr(foresight_handler, "_render_active_run", _async_return(""))
+    monkeypatch.setattr(foresight_handler, "_render_active_scenario", _async_return(""))
+    monkeypatch.setattr(foresight_handler, "_render_workspace_ambient", _async_return(""))
+    monkeypatch.setattr(foresight_handler, "_render_skill_hint", lambda: "")
+
+    out = await foresight_handler.build_preamble("ws_a", "user_a", SurfaceMeta())
+    assert "<surface-guidance>" in out
+    assert "PREFER Foresight affordances" in out
+    assert "DO NOT offer pocket creation" in out
+    assert "Rehearse a decision" in out
+    assert "Run a quick scenario" in out
+
+
 async def test_surface_tag_emits_with_panel(monkeypatch: pytest.MonkeyPatch) -> None:
     """The opening tag carries panel when one of the valid values is supplied.
 


### PR DESCRIPTION
Captain caught 2026-05-27: on /foresight, greeting the agent with \"hi\" returned a ui-spec with three buttons — **[Build a pocket]** [Rehearse a decision] **[List my pockets]**. Two of the three are pocket-themed, even though the surface stamp + handler from #1261 were resolving foresight correctly.

## Root cause

The preamble was **descriptive** (here's the route, here's the active run, here's the workspace summary) but **not directive**. The chat agent's broader system prompt still includes pocket-affordance defaults from \`POCKET_DELEGATION_RULE\` etc., and the foresight preamble didn't assert primacy. The agent treated /foresight as \"yet another route that includes pockets\" rather than \"the Foresight rail, defer to that context first\".

## Fix

Add a `<surface-guidance>` directive block right after the surface tag. Short + assertive:

\`\`\`
<surface-guidance>
The user is on the Foresight rail (population simulation for
decision rehearsal). PREFER Foresight affordances:
  - Create / edit a scenario (use the foresight-create-sim skill).
  - Run a scenario + summarize results.
  - Explain projected decisions, calibration accuracy, insights.
  - Branch a run, promote a decision to an anchor.
DO NOT offer pocket creation, pocket lists, or generic canvas
actions in starter buttons here — those belong on /pockets, not
/foresight. If the user explicitly asks for a pocket, you may
redirect them; otherwise stay in the Foresight context. When
greeting, offer Foresight-shaped starter actions only:
  - \"Rehearse a decision\"
  - \"Run a quick scenario\"
  - \"Show me my recent runs\"
  - \"Explain the latest insights\"
</surface-guidance>
\`\`\`

Redirect rule (\"If the user explicitly asks for a pocket, you may redirect\") is included so the agent doesn't refuse a legitimate \"make me a pocket\" mid-chat — it just doesn't START with pocket affordances.

## Test plan

- [x] \`uv run --group ee pytest tests/cloud/surface/test_foresight_handler.py\` — 10/10 pass (incl. new regression test \`test_preamble_includes_directive_surface_guidance\`)
- [ ] Captain reload /foresight + type \"hi\" → expect Foresight-shaped starter buttons, not pocket-themed ones