### PR TITLE
fix(decisions): clear ruff baseline + unblock test collection

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/decisions.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/decisions.py
@@ -460,7 +460,7 @@ def build_decisions_context_server() -> tuple[str, Any] | None:
             "finds candidate decisions in the caller's scope, walks a "
             "depth-bounded trace upstream from the top candidate, and "
             "narrates the result with Sonnet (or a deterministic "
-            "templated narrator when `backend=\"templated\"` is set or "
+            'templated narrator when `backend="templated"` is set or '
             "the LLM call fails). Every sentence in the narrative cites "
             "a decision id; the response also surfaces "
             "`decisions_walked` (every node in the trace) and "

--- a/ee/pocketpaw_ee/cloud/decisions/dto.py
+++ b/ee/pocketpaw_ee/cloud/decisions/dto.py
@@ -30,7 +30,6 @@ from pocketpaw_ee.cloud.decisions.domain import (
     ScopeKind,
 )
 
-
 # ---------------------------------------------------------------------------
 # Approver / input / outcome wire shapes — minor flattenings of the domain
 # value objects so the wire schema doesn't leak Pydantic internals.

--- a/ee/pocketpaw_ee/cloud/decisions/explain/cache.py
+++ b/ee/pocketpaw_ee/cloud/decisions/explain/cache.py
@@ -30,7 +30,7 @@ import logging
 import re
 import threading
 from collections.abc import Iterable
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
@@ -159,7 +159,7 @@ class ExplainCache:
         """Fetch a cached explanation. Returns ``None`` on miss, expired
         entry, or shape error. Expired entries are not GC'd here — the
         sweeper does that lazily (cheap enough to skip on the hot path)."""
-        now = now or datetime.now(timezone.utc)
+        now = now or datetime.now(UTC)
         conn = self._store._conn  # noqa: SLF001
         if conn is None:
             return None
@@ -202,7 +202,7 @@ class ExplainCache:
         """Insert or replace the cache entry. ``decisions_walked`` is
         serialised as a JSON array string so the reverse-index search
         is a single LIKE-glob (good enough at expected scale)."""
-        now = now or datetime.now(timezone.utc)
+        now = now or datetime.now(UTC)
         expires = now + self._ttl
         walked_json = json.dumps([str(uid) for uid in explanation.decisions_walked])
         explanation_json = explanation.model_dump_json()
@@ -273,7 +273,7 @@ class ExplainCache:
     def sweep_expired(self, *, now: datetime | None = None) -> int:
         """Drop every expired row. Cheap to run periodically; not on
         the hot path (cache.get handles expiry inline for the hit row)."""
-        now = now or datetime.now(timezone.utc)
+        now = now or datetime.now(UTC)
         conn = self._store._conn  # noqa: SLF001
         if conn is None:
             return 0
@@ -289,9 +289,7 @@ class ExplainCache:
         conn = self._store._conn  # noqa: SLF001
         if conn is None:
             return 0
-        row = conn.execute(
-            "SELECT COUNT(*) AS n FROM decision_explain_cache"
-        ).fetchone()
+        row = conn.execute("SELECT COUNT(*) AS n FROM decision_explain_cache").fetchone()
         return int(row["n"]) if row else 0
 
     # --- internals ---------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/decisions/explain/extractor.py
+++ b/ee/pocketpaw_ee/cloud/decisions/explain/extractor.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 from uuid import UUID
 
@@ -127,8 +127,7 @@ def _build_user_message(question: str) -> str:
     """Render the per-call user message. The few-shots are baked into the
     system prefix so the cache hit rate stays high across questions."""
     shots = "\n\n".join(
-        f"Question: {q}\nOutput: {json.dumps(out, separators=(',', ':'))}"
-        for q, out in _FEWSHOTS
+        f"Question: {q}\nOutput: {json.dumps(out, separators=(',', ':'))}" for q, out in _FEWSHOTS
     )
     return (
         f"Few-shot examples (do not echo):\n{shots}\n\n"
@@ -208,7 +207,9 @@ async def extract_entities(
             ],
         )
     except Exception:  # noqa: BLE001
-        logger.warning("explain extractor LLM call failed; falling back to templated", exc_info=True)
+        logger.warning(
+            "explain extractor LLM call failed; falling back to templated", exc_info=True
+        )
         return _templated_extract(question, scope)
 
     try:
@@ -276,8 +277,18 @@ def _parse_llm_output(raw: str) -> ExtractedEntities | None:
 # ---------------------------------------------------------------------------
 
 _MONTH_NAMES = {
-    "january": 1, "february": 2, "march": 3, "april": 4, "may": 5, "june": 6,
-    "july": 7, "august": 8, "september": 9, "october": 10, "november": 11, "december": 12,
+    "january": 1,
+    "february": 2,
+    "march": 3,
+    "april": 4,
+    "may": 5,
+    "june": 6,
+    "july": 7,
+    "august": 8,
+    "september": 9,
+    "october": 10,
+    "november": 11,
+    "december": 12,
 }
 
 _FABRIC_PREFIXES = ("lease", "case", "patient", "vendor", "tenant", "deal", "ticket")
@@ -340,7 +351,7 @@ def _templated_extract(question: str, scope: dict[str, Any]) -> ExtractedEntitie
     iso_match = re.search(r"\b(\d{4})-(\d{2})-(\d{2})\b", question)
     if iso_match:
         y, mo, d = map(int, iso_match.groups())
-        start = datetime(y, mo, d, tzinfo=timezone.utc)
+        start = datetime(y, mo, d, tzinfo=UTC)
         out.time_range = (start, start + timedelta(days=1))
     else:
         mo_match = re.search(
@@ -351,8 +362,8 @@ def _templated_extract(question: str, scope: dict[str, Any]) -> ExtractedEntitie
         if mo_match:
             month = _MONTH_NAMES[mo_match.group(1).lower()]
             day = int(mo_match.group(2))
-            year = datetime.now(timezone.utc).year
-            start = datetime(year, month, day, tzinfo=timezone.utc)
+            year = datetime.now(UTC).year
+            start = datetime(year, month, day, tzinfo=UTC)
             out.time_range = (start, start + timedelta(days=1))
 
     # policy — "approve_per_row policy" or just "approve_per_row"

--- a/ee/pocketpaw_ee/cloud/decisions/explain/narrator.py
+++ b/ee/pocketpaw_ee/cloud/decisions/explain/narrator.py
@@ -181,9 +181,7 @@ def _compress_decision(decision: Decision) -> dict[str, Any]:
             {
                 "status": decision.outcome.status,
                 "landed_at": (
-                    decision.outcome.landed_at.isoformat()
-                    if decision.outcome.landed_at
-                    else None
+                    decision.outcome.landed_at.isoformat() if decision.outcome.landed_at else None
                 ),
                 "metered": decision.outcome.metered,
             }
@@ -380,9 +378,7 @@ def _render_templated(root: Decision, trace: TraceResult) -> str:
         root.inputs[0] if root.inputs else None,
     )
     target_label = (
-        primary_input.label or primary_input.id
-        if primary_input
-        else "an unspecified target"
+        primary_input.label or primary_input.id if primary_input else "an unspecified target"
     )
 
     # 1. Headline — what / who / when
@@ -432,14 +428,10 @@ def _render_templated(root: Decision, trace: TraceResult) -> str:
     # 5. Outcome
     if root.outcome and root.outcome.status == "landed":
         landed_phrase = (
-            f" at {_format_dt(root.outcome.landed_at)}"
-            if root.outcome.landed_at
-            else ""
+            f" at {_format_dt(root.outcome.landed_at)}" if root.outcome.landed_at else ""
         )
         metered_phrase = " and was metered" if root.outcome.metered else ""
-        sentences.append(
-            f"The outcome landed{landed_phrase}{metered_phrase} [{root_short}]."
-        )
+        sentences.append(f"The outcome landed{landed_phrase}{metered_phrase} [{root_short}].")
     elif root.outcome and root.outcome.status == "rejected":
         sentences.append(
             f"The decision did not produce a landed outcome — it was rejected [{root_short}]."

--- a/ee/pocketpaw_ee/cloud/decisions/explain/service.py
+++ b/ee/pocketpaw_ee/cloud/decisions/explain/service.py
@@ -25,14 +25,14 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from pocketpaw_ee.cloud.decisions.domain import Decision
 from pocketpaw_ee.cloud.decisions.explain.cache import (
-    build_cache_key,
-    get_explain_cache,
-)
-from pocketpaw_ee.cloud.decisions.explain.cache import (
     _hash_scope as hash_scope,
 )
 from pocketpaw_ee.cloud.decisions.explain.cache import (
     _normalize_question as normalize_question,
+)
+from pocketpaw_ee.cloud.decisions.explain.cache import (
+    build_cache_key,
+    get_explain_cache,
 )
 from pocketpaw_ee.cloud.decisions.explain.extractor import (
     ExtractedEntities,
@@ -44,7 +44,6 @@ from pocketpaw_ee.cloud.decisions.explain.narrator import (
 )
 from pocketpaw_ee.cloud.decisions.service import (
     DecisionGraph,
-    TraceResult,
     get_decision_graph,
 )
 

--- a/ee/pocketpaw_ee/cloud/decisions/router.py
+++ b/ee/pocketpaw_ee/cloud/decisions/router.py
@@ -122,9 +122,7 @@ def _maybe_uuid(value: str) -> UUID:
     try:
         return UUID(value)
     except (ValueError, TypeError) as exc:
-        raise CloudError(
-            400, "decisions.invalid_id", f"'{value}' is not a valid UUID"
-        ) from exc
+        raise CloudError(400, "decisions.invalid_id", f"'{value}' is not a valid UUID") from exc
 
 
 def _trace_to_response(result: TraceResult) -> DecisionTraceResponse:

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -7,7 +7,6 @@ remains registered in ``get_all_documents()`` for Beanie init.
 
 from __future__ import annotations
 
-from pocketpaw_ee.calendar.models import _CalendarDoc, _EventDoc
 from pocketpaw_ee.cloud.models.agent import Agent, AgentConfig
 from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
 from pocketpaw_ee.cloud.models.comment import Comment, CommentAuthor, CommentTarget
@@ -32,6 +31,8 @@ from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
 # Lazy import to avoid circular imports
 FileUpload: type = None  # type: ignore[assignment]
 FileFolder: type = None  # type: ignore[assignment]
+_CalendarDoc: type = None  # type: ignore[assignment]
+_EventDoc: type = None  # type: ignore[assignment]
 
 
 def _ensure_file_upload():
@@ -43,6 +44,20 @@ def _ensure_file_upload():
         FileUpload = _FileUpload
         FileFolder = _FileFolder
     return FileUpload
+
+
+def _ensure_calendar_docs():
+    # Why: calendar.__init__ eagerly imports the router which transitively
+    # imports cloud.auth.current_active_user. Deferred to break the cycle
+    # when cloud.models is loaded during cloud.auth's own init.
+    global _CalendarDoc, _EventDoc
+    if _CalendarDoc is None:
+        from pocketpaw_ee.calendar.models import _CalendarDoc as _CD
+        from pocketpaw_ee.calendar.models import _EventDoc as _ED
+
+        _CalendarDoc = _CD
+        _EventDoc = _ED
+    return _CalendarDoc, _EventDoc
 
 
 __all__ = [
@@ -90,6 +105,7 @@ __all__ = [
 def get_all_documents():
     """Get all Beanie documents, with lazy FileUpload loading."""
     _ensure_file_upload()
+    cal_doc, evt_doc = _ensure_calendar_docs()
     return [
         User,
         Agent,
@@ -113,8 +129,8 @@ def get_all_documents():
         Project,
         PlanSession,
         ChatRunDoc,
-        _CalendarDoc,
-        _EventDoc,
+        cal_doc,
+        evt_doc,
     ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,6 +393,8 @@ select = ["E", "F", "I", "UP"]
 # strings can't be wrapped without changing the rendered prompt.
 "src/pocketpaw/ripple/_pockets.py" = ["E501"]
 "src/pocketpaw/ripple/_design.py" = ["E501"]
+"ee/pocketpaw_ee/cloud/decisions/explain/extractor.py" = ["E501"]
+"ee/pocketpaw_ee/cloud/decisions/explain/narrator.py" = ["E501"]
 
 [dependency-groups]
 dev = [

--- a/tests/ee/test_bundled_decision_graph_template.py
+++ b/tests/ee/test_bundled_decision_graph_template.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 import yaml
 
 from pocketpaw.bundled_templates.installer import install_bundled_templates
@@ -63,11 +62,7 @@ _RFC03_SHAPE_ENUM = {
 }
 
 _BUNDLED_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "src"
-    / "pocketpaw"
-    / "bundled_templates"
-    / "_bundled"
+    Path(__file__).resolve().parents[2] / "src" / "pocketpaw" / "bundled_templates" / "_bundled"
 )
 _SLUG = "decision-graph"
 

--- a/tests/ee/test_decisions_explain.py
+++ b/tests/ee/test_decisions_explain.py
@@ -28,8 +28,6 @@ from uuid import UUID, uuid4
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from soul_protocol.spec.journal import Actor, EventEntry
-
 from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
 from pocketpaw_ee.cloud._core.http import add_error_handler
 from pocketpaw_ee.cloud.decisions.dto import ExplanationResponse
@@ -39,7 +37,6 @@ from pocketpaw_ee.cloud.decisions.explain import (
     narrate_decision,
 )
 from pocketpaw_ee.cloud.decisions.explain.cache import (
-    ExplainCache,
     build_cache_key,
     get_explain_cache,
     reset_explain_cache_for_tests,
@@ -56,7 +53,7 @@ from pocketpaw_ee.cloud.decisions.service import (
 )
 from pocketpaw_ee.cloud.decisions.store import DecisionStore, set_db_path
 from pocketpaw_ee.cloud.license import require_license
-
+from soul_protocol.spec.journal import Actor, EventEntry
 
 # ---------------------------------------------------------------------------
 # Fixtures — fresh projection + store + cache per test
@@ -173,7 +170,8 @@ def _seed_chain(
         "intent": intent,
         "action": action_name,
         "pocket_id": pocket_id,
-        "inputs": inputs or [{"kind": "fabric_object", "id": "lease:LR-2026-117", "label": "Lease LR-2026-117"}],
+        "inputs": inputs
+        or [{"kind": "fabric_object", "id": "lease:LR-2026-117", "label": "Lease LR-2026-117"}],
     }
     if precedents is not None:
         payload["precedents"] = precedents
@@ -362,12 +360,8 @@ async def test_llm_narrator_strips_ungrounded_sentences(projection, base_ts) -> 
     fake_client = MagicMock()
     fake_client.messages = fake_messages
 
-    with patch(
-        "anthropic.AsyncAnthropic", return_value=fake_client
-    ):
-        explanation = await narrate_decision(
-            root, trace, backend="llm", api_key="sk-fake"
-        )
+    with patch("anthropic.AsyncAnthropic", return_value=fake_client):
+        explanation = await narrate_decision(root, trace, backend="llm", api_key="sk-fake")
 
     # The grounded sentence is kept; the ungrounded one stripped.
     assert f"[{short}]" in explanation.narrative
@@ -394,9 +388,7 @@ async def test_llm_narrator_falls_back_on_sdk_error(projection, base_ts) -> None
     fake_client.messages.create = AsyncMock(side_effect=RuntimeError("api down"))
 
     with patch("anthropic.AsyncAnthropic", return_value=fake_client):
-        explanation = await narrate_decision(
-            root, trace, backend="llm", api_key="sk-fake"
-        )
+        explanation = await narrate_decision(root, trace, backend="llm", api_key="sk-fake")
 
     assert explanation.backend_used == "templated"
     assert str(root_id)[:8] in explanation.narrative
@@ -518,9 +510,7 @@ async def test_explain_cache_invalidated_by_new_event(graph, projection, base_ts
 
 
 @pytest.mark.asyncio
-async def test_explain_cache_invalidation_via_projection_hook(
-    graph, projection, base_ts
-) -> None:
+async def test_explain_cache_invalidation_via_projection_hook(graph, projection, base_ts) -> None:
     """Confirm the cache invalidation hook is registered on the projection
     and fires when a new decision lands whose id matches a cached walked
     entry. We synthesise a chain where the new decision IS the cached
@@ -552,9 +542,7 @@ async def test_explain_cache_invalidation_via_projection_hook(
 
 
 @pytest.mark.asyncio
-async def test_explain_scope_filter_hides_other_workspace(
-    graph, projection, base_ts
-) -> None:
+async def test_explain_scope_filter_hides_other_workspace(graph, projection, base_ts) -> None:
     """A workspace-B caller can't reach workspace-A decisions through
     the explain orchestrator — `requester_scopes` is the gate."""
     _seed_chain(projection, base_ts=base_ts, workspace="ws_a_test")
@@ -577,9 +565,7 @@ async def test_explain_scope_filter_hides_other_workspace(
 # ---------------------------------------------------------------------------
 
 
-def test_explain_route_returns_grounded_response(
-    client: TestClient, projection, base_ts
-) -> None:
+def test_explain_route_returns_grounded_response(client: TestClient, projection, base_ts) -> None:
     """Round-trip through the FastAPI route. Templated backend so the
     test is hermetic."""
     root_id = _seed_chain(projection, base_ts=base_ts)

--- a/tests/ee/test_decisions_explain_mcp.py
+++ b/tests/ee/test_decisions_explain_mcp.py
@@ -29,8 +29,6 @@ from typing import Any
 from uuid import UUID, uuid4
 
 import pytest
-from soul_protocol.spec.journal import Actor, EventEntry
-
 from pocketpaw_ee.agent.mcp_servers.decisions import (
     DECISIONS_EXPLAIN_TOOL_ID,
     DECISIONS_TOOL_IDS,
@@ -47,6 +45,7 @@ from pocketpaw_ee.cloud.decisions.service import (
     reset_projection_for_tests,
 )
 from pocketpaw_ee.cloud.decisions.store import DecisionStore, set_db_path
+from soul_protocol.spec.journal import Actor, EventEntry
 
 # ---------------------------------------------------------------------------
 # Fixtures — mirror test_decisions_mcp's pattern
@@ -146,7 +145,9 @@ def _seed_chain(
         "intent": f"chain-{corr.hex[:8]}",
         "action": "send_to_tenant",
         "pocket_id": pocket_id,
-        "inputs": [{"kind": "fabric_object", "id": "lease:LR-2026-117", "label": "Lease LR-2026-117"}],
+        "inputs": [
+            {"kind": "fabric_object", "id": "lease:LR-2026-117", "label": "Lease LR-2026-117"}
+        ],
     }
     events = [
         _event(
@@ -220,9 +221,7 @@ async def test_explain_handler_returns_grounded_envelope(
 async def test_explain_handler_requires_identity(graph) -> None:
     """Outside a chat stream, the workspace ContextVar is None and the
     handler returns the canonical "no active workspace" error."""
-    envelope = await _decisions_explain_handler(
-        {"question": "Why was LR-2026-117 approved?"}
-    )
+    envelope = await _decisions_explain_handler({"question": "Why was LR-2026-117 approved?"})
     assert envelope.get("is_error") is True
     assert "no active workspace" in envelope["content"][0]["text"]
 
@@ -233,18 +232,14 @@ async def test_explain_handler_requires_identity(graph) -> None:
 
 
 @pytest.mark.asyncio
-async def test_explain_handler_rejects_empty_question(
-    _identity_context, graph
-) -> None:
+async def test_explain_handler_rejects_empty_question(_identity_context, graph) -> None:
     envelope = await _decisions_explain_handler({"question": ""})
     assert envelope.get("is_error") is True
     assert "question is required" in envelope["content"][0]["text"]
 
 
 @pytest.mark.asyncio
-async def test_explain_handler_rejects_missing_question(
-    _identity_context, graph
-) -> None:
+async def test_explain_handler_rejects_missing_question(_identity_context, graph) -> None:
     envelope = await _decisions_explain_handler({})
     assert envelope.get("is_error") is True
 

--- a/tests/ee/test_decisions_mcp.py
+++ b/tests/ee/test_decisions_mcp.py
@@ -25,8 +25,6 @@ from typing import Any
 from uuid import UUID, uuid4
 
 import pytest
-from soul_protocol.spec.journal import Actor, EventEntry
-
 from pocketpaw_ee.agent.mcp_servers.decisions import (
     _decisions_find_handler,
     _decisions_get_handler,
@@ -42,6 +40,7 @@ from pocketpaw_ee.cloud.decisions.service import (
     reset_projection_for_tests,
 )
 from pocketpaw_ee.cloud.decisions.store import DecisionStore, set_db_path
+from soul_protocol.spec.journal import Actor, EventEntry
 
 # ---------------------------------------------------------------------------
 # Identity context — set the per-stream ContextVars the MCP handlers read
@@ -289,9 +288,7 @@ async def test_decisions_trace_walks_precedents(graph, projection, base_ts) -> N
         precedents=[{"decision_id": str(prec_id), "weight": 0.9}],
     )
 
-    envelope = await _decisions_trace_handler(
-        {"decision_id": str(new_id), "depth": 2}
-    )
+    envelope = await _decisions_trace_handler({"decision_id": str(new_id), "depth": 2})
     body = _read_envelope(envelope)
     assert body["root"] == str(new_id)
     assert str(prec_id) in body["nodes"]

--- a/tests/ee/test_decisions_router.py
+++ b/tests/ee/test_decisions_router.py
@@ -34,10 +34,6 @@ from uuid import UUID, uuid4
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from soul_protocol.engine.journal import open_journal
-from soul_protocol.spec.journal import Actor, EventEntry
-
-from pocketpaw.journal_dep import get_journal, reset_journal_cache
 from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
 from pocketpaw_ee.cloud._core.http import add_error_handler
 from pocketpaw_ee.cloud.decisions.projection import DecisionProjection
@@ -48,7 +44,10 @@ from pocketpaw_ee.cloud.decisions.service import (
 )
 from pocketpaw_ee.cloud.decisions.store import DecisionStore, set_db_path
 from pocketpaw_ee.cloud.license import require_license
+from soul_protocol.engine.journal import open_journal
+from soul_protocol.spec.journal import Actor, EventEntry
 
+from pocketpaw.journal_dep import get_journal, reset_journal_cache
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -293,9 +292,7 @@ def test_get_returns_404_when_scope_mismatch(
 
 def test_list_returns_decisions(client, projection, base_ts) -> None:
     _seed_chain(projection, base_ts=base_ts, actor_id="did:soul:a")
-    _seed_chain(
-        projection, base_ts=base_ts + timedelta(seconds=10), actor_id="did:soul:b"
-    )
+    _seed_chain(projection, base_ts=base_ts + timedelta(seconds=10), actor_id="did:soul:b")
     resp = client.get("/api/v1/decisions")
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -372,9 +369,7 @@ def test_list_rejects_workspace_id_query(client) -> None:
     assert resp.json()["error"]["code"] == "decisions.workspace_id_forbidden"
 
 
-def test_list_scope_filter_per_call(
-    client, app, projection, base_ts, workspace_b_id
-) -> None:
+def test_list_scope_filter_per_call(client, app, projection, base_ts, workspace_b_id) -> None:
     """Two-workspace tenant isolation — A's decisions invisible to B."""
     _seed_chain(projection, base_ts=base_ts, workspace="ws_a_test")
     _seed_chain(
@@ -576,9 +571,7 @@ def test_downstream_returns_404_for_missing_root(client) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_timeline_returns_journal_events(
-    client, projection, base_ts, journal_path: Path
-) -> None:
+def test_timeline_returns_journal_events(client, projection, base_ts, journal_path: Path) -> None:
     """The timeline endpoint reads the journal for events sharing the
     Decision's correlation_id and returns them in seq order."""
     # Seed a Decision via the projection — chain has a correlation_id.

--- a/tests/ee/test_outcomes_decision_backref.py
+++ b/tests/ee/test_outcomes_decision_backref.py
@@ -24,8 +24,6 @@ from pathlib import Path
 from uuid import UUID, uuid4
 
 import pytest
-from soul_protocol.spec.journal import Actor, EventEntry
-
 from pocketpaw_ee.cloud.decisions.projection import DecisionProjection
 from pocketpaw_ee.cloud.decisions.service import (
     DecisionGraph,
@@ -34,7 +32,7 @@ from pocketpaw_ee.cloud.decisions.service import (
 from pocketpaw_ee.cloud.decisions.store import DecisionStore, set_db_path
 from pocketpaw_ee.cloud.outcomes import service as outcomes_service
 from pocketpaw_ee.cloud.outcomes.dto import OutcomeResponse
-
+from soul_protocol.spec.journal import Actor, EventEntry
 
 # ---------------------------------------------------------------------------
 # Fixtures


### PR DESCRIPTION
## Why

CI lint on `dev` (and inherited into every PR off `dev`) is failing on 26 ruff errors that landed in the decisions module via PR #1240. None are behavioural — they're import-order misses (auto-fixable) and a handful of E501 long-line warnings in LLM-prompt strings.

Also: the calendar circular-import block on `dev` (which prevents `pytest tests/ee/` from even collecting the decisions tests) is fixed here so this PR can be verified end-to-end. Same lazy-load fix that's on the wave1 branch (b4c61e97) but independently useful on `dev`.

## Changes

- `ruff --fix` against `ee/pocketpaw_ee/cloud/decisions/*` and `tests/ee/test_decisions_*` — 17 I-rule / E-rule fixes
- Two fixture dicts in `test_decisions_explain.py` / `test_decisions_explain_mcp.py` reformatted to multi-line
- Two LLM-prompt modules added to `[tool.ruff.lint.per-file-ignores]` with `["E501"]` — same precedent as `ripple/_pockets.py` / `ripple/_design.py`: long lines inside multi-line prompt strings can't be wrapped without changing the rendered prompt
- `cloud/models/__init__.py` defers calendar doc imports the same way `FileUpload` is deferred — breaks the chain `cloud.models -> calendar -> calendar.router -> cloud.shared.deps -> cloud._core.deps -> cloud.auth` that fires while `cloud.auth.__init__` is still mid-load

## Verification

- `ruff check .` — All checks passed
- `pytest tests/ee/test_decisions_{explain,mcp,router}.py tests/ee/test_outcomes_decision_backref.py` — 58 passed

## Scope

Lint-only + a one-file circular-import fix. No behavioural changes to the decisions module.