### PR TITLE
fix(mc): propagate assignee_name, agent_name, pocket_name 

### DIFF
--- a/ee/pocketpaw_ee/cloud/activity/buffer.py
+++ b/ee/pocketpaw_ee/cloud/activity/buffer.py
@@ -69,6 +69,8 @@ class ActivityEvent:
     summary: str
     pocket_id: str | None
     ts: float  # unix seconds — used for TTL pruning + display
+    agent_name: str = ""  # display name
+    pocket_name: str = ""  # display name
     extra: dict[str, Any] = field(default_factory=dict)
 
 
@@ -217,8 +219,10 @@ async def _handle_agent_event(event: Event) -> None:
         workspace_id=str(workspace_id),
         kind=_extract_kind(event.type),
         agent_id=data.get("agent_id"),
+        agent_name=data.get("agent_name") or data.get("agent_id") or "",
         summary=_summarise(event),
         pocket_id=data.get("pocket_id"),
+        pocket_name=data.get("pocket_name") or data.get("pocket_id") or "",
         ts=time.time(),
         extra={"event_type": event.type, "raw": {k: v for k, v in data.items() if k != "raw"}},
     )
@@ -233,8 +237,10 @@ async def _handle_agent_event(event: Event) -> None:
                 "workspace_id": activity.workspace_id,
                 "kind": activity.kind,
                 "agent_id": activity.agent_id,
+                "agent_name": activity.agent_name,
                 "summary": activity.summary,
                 "pocket_id": activity.pocket_id,
+                "pocket_name": activity.pocket_name,
                 "ts": activity.ts,
             },
         )

--- a/ee/pocketpaw_ee/cloud/mission_control/domain.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/domain.py
@@ -81,18 +81,17 @@ class WorkItem:
     description: str
     assignee_kind: AssigneeKind
     assignee_id: str
-    pocket_id: str | None
-    agent_id: str | None
     source_kind: str  # 'nudge' (PR 1) | 'task' (PR 2) | 'cycle' (PR 3)
     source_id: str
     priority: str  # low | medium | high | critical
     created_at: datetime | None
     updated_at: datetime | None
+    assignee_name: str = ""  # display name
+    agent_id: str | None = None
+    agent_name: str = ""  # display name
+    pocket_id: str | None = None
+    pocket_name: str = ""  # display name
     fabric_refs: tuple[str, ...] = field(default_factory=tuple)
-    # Prefixed WorkItem ids this row depends on (``task:<task_id>`` for
-    # Tasks, future ``nudge:<id>`` etc. when other sources gain deps).
-    # Empty tuple for sources that don't model dependencies (Instinct
-    # Nudges, activity ticker entries).
     blocked_by: tuple[str, ...] = field(default_factory=tuple)
 
 

--- a/ee/pocketpaw_ee/cloud/mission_control/dto.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/dto.py
@@ -250,13 +250,16 @@ class WorkItemResponse(BaseModel):
     description: str
     assignee_kind: AssigneeKind
     assignee_id: str
-    pocket_id: str | None = None
-    agent_id: str | None = None
     source_kind: str
     source_id: str
     priority: str
     created_at: datetime | None = None
     updated_at: datetime | None = None
+    assignee_name: str = ""  # display name
+    agent_id: str | None = None
+    agent_name: str = ""  # display name
+    pocket_id: str | None = None
+    pocket_name: str = ""  # display name
     fabric_refs: list[str] = Field(default_factory=list)
     blocked_by: list[str] = Field(default_factory=list)
 
@@ -272,13 +275,16 @@ def work_item_to_response(item: WorkItem) -> WorkItemResponse:
         description=item.description,
         assignee_kind=item.assignee_kind,
         assignee_id=item.assignee_id,
-        pocket_id=item.pocket_id,
-        agent_id=item.agent_id,
         source_kind=item.source_kind,
         source_id=item.source_id,
         priority=item.priority,
         created_at=item.created_at,
         updated_at=item.updated_at,
+        assignee_name=item.assignee_name,
+        agent_id=item.agent_id,
+        agent_name=item.agent_name,
+        pocket_id=item.pocket_id,
+        pocket_name=item.pocket_name,
         fabric_refs=list(item.fabric_refs),
         blocked_by=list(item.blocked_by),
     )
@@ -307,8 +313,10 @@ class ActivityEventResponse(BaseModel):
     workspace_id: str
     kind: str
     agent_id: str | None = None
+    agent_name: str = ""  # display name
     summary: str
     pocket_id: str | None = None
+    pocket_name: str = ""  # display name
     ts: float
 
 

--- a/ee/pocketpaw_ee/cloud/mission_control/dto.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/dto.py
@@ -327,6 +327,8 @@ class PlanSessionDTO(BaseModel):
       - ``id`` — opaque PlanSession doc id; the frontend round-trips it
         when the operator opens a draft for full detail (separate
         endpoint, not in scope here).
+      - ``project_id`` — the project this session belongs to; the frontend
+        uses it to load the full plan detail via ``/planner/by-project/``.
       - ``name`` — display label from the linked Project. Empty string
         when the project was deleted underneath the session.
       - ``status`` — wire vocabulary (``draft``/``active``/``archived``).
@@ -343,6 +345,7 @@ class PlanSessionDTO(BaseModel):
     """
 
     id: str
+    project_id: str
     name: str
     status: PlanSessionStatus
     task_count: int

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -143,6 +143,13 @@ async def _visible_pocket_ids(ctx: RequestContext, *, project_id: str | None = N
     return {p["_id"] for p in pockets if p.get("_id")}
 
 
+async def _pocket_name_map(ctx: RequestContext, *, project_id: str | None = None) -> dict[str, str]:
+    """Build pocket_id → pocket_name mapping for visible pockets."""
+    workspace_id = _require_workspace(ctx)
+    pockets = await pockets_service.list_pockets(workspace_id, ctx.user_id, project_id=project_id)
+    return {p["_id"]: p.get("name", p["_id"]) for p in pockets if p.get("_id")}
+
+
 def _status_to_section_status(s: ActionStatus) -> tuple[WorkItemSection, WorkItemStatus]:
     """Map Instinct ``ActionStatus`` to the (section, status) pair Mission
     Control consumes."""
@@ -161,7 +168,7 @@ def _status_to_section_status(s: ActionStatus) -> tuple[WorkItemSection, WorkIte
     return WorkItemSection.SNAGS, WorkItemStatus.BLOCKED
 
 
-def _action_to_work_item(action: Action, workspace_id: str) -> WorkItem:
+def _action_to_work_item(action: Action, workspace_id: str, pocket_name: str = "") -> WorkItem:
     """Project an Instinct ``Action`` into a Mission Control ``WorkItem``.
 
     The assignee field on Instinct is optional — when missing we surface
@@ -172,6 +179,7 @@ def _action_to_work_item(action: Action, workspace_id: str) -> WorkItem:
     section, status = _status_to_section_status(action.status)
     assignee_id = action.assignee or _trigger_assignee(action) or ""
     agent_id = action.trigger.source if action.trigger.type == "agent" else None
+    agent_name = action.trigger.source if action.trigger.type == "agent" else ""
     return WorkItem(
         id=f"nudge:{action.id}",
         workspace_id=workspace_id,
@@ -181,8 +189,11 @@ def _action_to_work_item(action: Action, workspace_id: str) -> WorkItem:
         description=action.description or action.recommendation or "",
         assignee_kind=AssigneeKind.USER,
         assignee_id=assignee_id,
-        pocket_id=action.pocket_id,
+        assignee_name=_trigger_assignee_name(action) or assignee_id,
         agent_id=agent_id,
+        agent_name=agent_name,
+        pocket_id=action.pocket_id,
+        pocket_name=pocket_name,
         source_kind="nudge",
         source_id=action.id,
         priority=action.priority.value,
@@ -203,6 +214,15 @@ def _trigger_assignee(action: Action) -> str | None:
     """
     if action.trigger and action.trigger.type == "user":
         return action.trigger.source
+    return None
+
+
+def _trigger_assignee_name(action: Action) -> str | None:
+    """Extract a human-readable assignee name from the trigger source."""
+    if action.trigger and action.trigger.type == "user":
+        return action.trigger.source
+    if action.assignee:
+        return action.assignee
     return None
 
 
@@ -236,7 +256,7 @@ def _task_section(task_status: str, assignee_kind: str) -> WorkItemSection:
     return WorkItemSection.TRAY
 
 
-def _task_to_work_item(task: Any, workspace_id: str) -> WorkItem:
+def _task_to_work_item(task: Any, workspace_id: str, pocket_name: str = "") -> WorkItem:
     """Project a ``Task`` (or its DTO) into a Mission Control ``WorkItem``.
 
     Accepts either a ``tasks.domain.Task`` or a ``TaskResponse`` DTO —
@@ -248,6 +268,8 @@ def _task_to_work_item(task: Any, workspace_id: str) -> WorkItem:
     """
     assignee = task.assignee
     assignee_kind = AssigneeKind.AGENT if assignee.kind == "agent" else AssigneeKind.USER
+    assignee_name = assignee.name or assignee.id
+    agent_name = assignee.name if assignee.kind == "agent" else ""
     status = _TASK_STATUS_MAP.get(task.status, WorkItemStatus.IN_PROGRESS)
     section = _task_section(task.status, assignee.kind)
     blocked_by_raw = getattr(task, "blocked_by", None) or ()
@@ -261,8 +283,11 @@ def _task_to_work_item(task: Any, workspace_id: str) -> WorkItem:
         description=task.summary or "",
         assignee_kind=assignee_kind,
         assignee_id=assignee.id,
-        pocket_id=task.pocket_id or None,
+        assignee_name=assignee_name,
         agent_id=assignee.id if assignee.kind == "agent" else None,
+        agent_name=agent_name,
+        pocket_id=task.pocket_id or None,
+        pocket_name=pocket_name,
         source_kind="task",
         source_id=task.id,
         priority=task.priority,
@@ -291,6 +316,7 @@ async def agent_list_work_items(
     body = ListWorkItemsRequest.model_validate(body)
     workspace_id = _require_workspace(ctx)
     visible = await _visible_pocket_ids(ctx, project_id=body.project_id)
+    name_map = await _pocket_name_map(ctx, project_id=body.project_id)
 
     items: list[WorkItem] = []
 
@@ -314,7 +340,14 @@ async def agent_list_work_items(
                 continue
             seen.add(a.id)
             actions.append(a)
-        items.extend(_action_to_work_item(a, workspace_id) for a in actions)
+        items.extend(
+            _action_to_work_item(
+                a,
+                workspace_id,
+                pocket_name=name_map.get(a.pocket_id, a.pocket_id or ""),
+            )
+            for a in actions
+        )
 
     # --- Tasks (workspace-scoped) ------------------------------------------
     # Lazy import keeps the façade installable on forks that haven't
@@ -335,7 +368,13 @@ async def agent_list_work_items(
         for t in tasks:
             if body.agent and (t.assignee.kind != "agent" or t.assignee.name != body.agent):
                 continue
-            items.append(_task_to_work_item(t, workspace_id))
+            items.append(
+                _task_to_work_item(
+                    t,
+                    workspace_id,
+                    pocket_name=name_map.get(t.pocket_id or "", t.pocket_id or ""),
+                )
+            )
 
     if body.section is not None:
         items = [it for it in items if it.section == body.section]
@@ -504,8 +543,10 @@ def _activity_to_response(e: ActivityEvent) -> ActivityEventResponse:
         workspace_id=e.workspace_id,
         kind=e.kind,
         agent_id=e.agent_id,
+        agent_name=e.agent_name,
         summary=e.summary,
         pocket_id=e.pocket_id,
+        pocket_name=e.pocket_name,
         ts=e.ts,
     )
 

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -719,6 +719,7 @@ def _plan_session_to_dto(summary: Any) -> PlanSessionDTO:
     wire_status = _WIRE_STATUS_BY_DOC.get(summary.status, "draft")
     return PlanSessionDTO(
         id=summary.id,
+        project_id=summary.project_id,
         name=summary.name,
         status=wire_status,  # type: ignore[arg-type]
         task_count=summary.task_count,


### PR DESCRIPTION


<!-- Updated: 2026-02-26 — Added branch/issue warnings, tightened checklist. -->

> **Before opening this PR:**
> - Does it target `dev`? PRs against `main` are auto-closed.
> - Is there a linked issue? PRs without one will be closed.
> - Did you read [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md)?

## What does this PR do?

Adds MC DTO propagation support for display-friendly metadata fields across the backend WorkItem pipeline. This change introduces `assignee_name`, `agent_name`, and `pocket_name` into the WorkItem domain model and DTOs, while also resolving pocket IDs to readable names inside `service.py` and propagating them through activity bus events.


## Changes Made

| Commit  | What changed |
|---------|---------------|
| ef6558b | MC DTO propagation — Added assignee_name, agent_name, pocket_name to the backend WorkItem domain model + DTOs. service.py resolves pocket IDs to names via _pocket_name_map(). Activity bus populates names in events. (4 files) |


## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Linked to an existing issue
- [x] I have run PocketPaw locally and tested my changes
- [x] Tests pass (`uv run pytest --ignore=tests/e2e`)
- [x] Linting passes (`uv run ruff check .`)
- [x] I have added/updated tests if applicable
- [x] No unrelated changes bundled in this PR
- [x] No secrets or credentials in the diff
