### PR TITLE
feat(foresight): bundled MCP tools for chat scenario save+run

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/foresight.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/foresight.py
@@ -1,0 +1,467 @@
+# ee/pocketpaw_ee/agent/mcp_servers/foresight.py
+# Created: 2026-05-28 — in-process SDK MCP server for Foresight scenario
+# CRUD + run. Closes the bug where the bundled ``foresight-create-sim``
+# skill told the claude_agent_sdk chat agent to call the cloud REST
+# surface with ``$WORKSPACE_ID`` / ``$USER_ID`` env vars that are never
+# set in that backend. Typed MCP tools close over the chat session's
+# workspace id (read from ``ee.cloud.chat.agent_service`` ContextVars)
+# so the agent literally cannot get the workspace wrong.
+#
+# Mirrors the ``pocketpaw_pocket`` server shape exactly:
+#   - SERVER_NAME constant + per-tool ``mcp__<server>__<tool>`` ids
+#   - FORESIGHT_TOOL_IDS tuple for the claude_sdk allowlist
+#   - ``_result_payload`` / ``_error`` helpers that translate the
+#     ``{ok, ...}`` envelope from ``ee.cloud.foresight.agent_context``
+#     into MCP tool-result shape
+#   - ``build_foresight_server`` returns ``None`` when claude_agent_sdk
+#     isn't installed (same import-guard pattern the sibling servers use)
+#
+# Tools (8): list_scenarios, get_scenario, save_scenario, update_scenario,
+# delete_scenario, run_scenario, list_runs, get_run.
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_foresight"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+# Allowlist entries on the claude_sdk backend must use this exact form.
+LIST_SCENARIOS_TOOL_ID = f"mcp__{SERVER_NAME}__list_scenarios"
+GET_SCENARIO_TOOL_ID = f"mcp__{SERVER_NAME}__get_scenario"
+SAVE_SCENARIO_TOOL_ID = f"mcp__{SERVER_NAME}__save_scenario"
+UPDATE_SCENARIO_TOOL_ID = f"mcp__{SERVER_NAME}__update_scenario"
+DELETE_SCENARIO_TOOL_ID = f"mcp__{SERVER_NAME}__delete_scenario"
+RUN_SCENARIO_TOOL_ID = f"mcp__{SERVER_NAME}__run_scenario"
+LIST_RUNS_TOOL_ID = f"mcp__{SERVER_NAME}__list_runs"
+GET_RUN_TOOL_ID = f"mcp__{SERVER_NAME}__get_run"
+
+FORESIGHT_TOOL_IDS = (
+    LIST_SCENARIOS_TOOL_ID,
+    GET_SCENARIO_TOOL_ID,
+    SAVE_SCENARIO_TOOL_ID,
+    UPDATE_SCENARIO_TOOL_ID,
+    DELETE_SCENARIO_TOOL_ID,
+    RUN_SCENARIO_TOOL_ID,
+    LIST_RUNS_TOOL_ID,
+    GET_RUN_TOOL_ID,
+)
+
+_SUB_TYPE_ENUM = ["decision_forecast", "market_sim", "org_change_rehearsal"]
+
+
+def _result_payload(result: dict[str, Any]) -> dict[str, Any]:
+    """Translate an ``agent_context`` ``{ok, ...}`` envelope into the MCP
+    response shape. On error, surface the code + message verbatim so the
+    agent can decide whether to retry or surface to the user."""
+    if not result.get("ok"):
+        error_code = result.get("error", "unknown_error")
+        message = result.get("message", "")
+        text = f"Error: {error_code}" + (f" — {message}" if message else "")
+        return {"content": [{"type": "text", "text": text}], "is_error": True}
+    # Drop the ``ok`` flag from the payload the agent reads — it's a
+    # transport concern, not a wire-shape concern.
+    body = {k: v for k, v in result.items() if k != "ok"}
+    return {
+        "content": [{"type": "text", "text": json.dumps(body, separators=(",", ":"), default=str)}]
+    }
+
+
+def _error(text: str) -> dict[str, Any]:
+    """Build an MCP error response. The agent reads ``text`` and retries."""
+    return {"content": [{"type": "text", "text": f"Error: {text}"}], "is_error": True}
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers — each is a thin shim into the agent_context wrappers.
+# ---------------------------------------------------------------------------
+
+
+async def _list_scenarios_handler(args: dict) -> dict:
+    from pocketpaw_ee.cloud.foresight.agent_context import list_scenarios_for_agent
+
+    limit = args.get("limit", 20)
+    offset = args.get("offset", 0)
+    sub_type = args.get("sub_type")
+    return _result_payload(
+        await list_scenarios_for_agent(limit=limit, offset=offset, sub_type=sub_type)
+    )
+
+
+async def _get_scenario_handler(args: dict) -> dict:
+    from pocketpaw_ee.cloud.foresight.agent_context import get_scenario_for_agent
+
+    scenario_id = args.get("scenario_id")
+    if not scenario_id or not isinstance(scenario_id, str):
+        return _error("get_scenario requires a `scenario_id` (string).")
+    return _result_payload(await get_scenario_for_agent(scenario_id))
+
+
+async def _save_scenario_handler(args: dict) -> dict:
+    from pocketpaw_ee.cloud.foresight.agent_context import save_scenario_for_agent
+
+    name = args.get("name")
+    sub_type = args.get("sub_type")
+    yaml_body = args.get("yaml_body")
+    description = args.get("description")
+    if not name or not isinstance(name, str):
+        return _error("save_scenario requires a `name` (string).")
+    if not sub_type or not isinstance(sub_type, str):
+        return _error("save_scenario requires a `sub_type` (string).")
+    if not yaml_body or not isinstance(yaml_body, str):
+        return _error(
+            "save_scenario requires a `yaml_body` (string). Pass the full "
+            "scenario YAML — the inner schema (personas, n_ticks, "
+            "tier_mix, ...) is documented in the foresight-create-sim skill."
+        )
+    return _result_payload(
+        await save_scenario_for_agent(
+            name=name, sub_type=sub_type, yaml_body=yaml_body, description=description
+        )
+    )
+
+
+async def _update_scenario_handler(args: dict) -> dict:
+    from pocketpaw_ee.cloud.foresight.agent_context import update_scenario_for_agent
+
+    scenario_id = args.get("scenario_id")
+    name = args.get("name")
+    sub_type = args.get("sub_type")
+    yaml_body = args.get("yaml_body")
+    description = args.get("description")
+    if not scenario_id or not isinstance(scenario_id, str):
+        return _error("update_scenario requires a `scenario_id` (string).")
+    if not name or not isinstance(name, str):
+        return _error("update_scenario requires a `name` (string).")
+    if not sub_type or not isinstance(sub_type, str):
+        return _error("update_scenario requires a `sub_type` (string).")
+    if not yaml_body or not isinstance(yaml_body, str):
+        return _error(
+            "update_scenario requires a `yaml_body` (string) — PUT is a "
+            "full replace; GET first and pass back the FULL body with the "
+            "user's edits applied."
+        )
+    return _result_payload(
+        await update_scenario_for_agent(
+            scenario_id=scenario_id,
+            name=name,
+            sub_type=sub_type,
+            yaml_body=yaml_body,
+            description=description,
+        )
+    )
+
+
+async def _delete_scenario_handler(args: dict) -> dict:
+    from pocketpaw_ee.cloud.foresight.agent_context import delete_scenario_for_agent
+
+    scenario_id = args.get("scenario_id")
+    if not scenario_id or not isinstance(scenario_id, str):
+        return _error("delete_scenario requires a `scenario_id` (string).")
+    return _result_payload(await delete_scenario_for_agent(scenario_id))
+
+
+async def _run_scenario_handler(args: dict) -> dict:
+    from pocketpaw_ee.cloud.foresight.agent_context import run_scenario_for_agent
+
+    name = args.get("name")
+    custom_scenario_id = args.get("custom_scenario_id")
+    route_to_instinct = bool(args.get("route_to_instinct", False))
+    precedent_seed = args.get("precedent_seed")
+    if not name or not isinstance(name, str):
+        return _error("run_scenario requires a `name` (string).")
+    if not custom_scenario_id or not isinstance(custom_scenario_id, str):
+        return _error(
+            "run_scenario requires a `custom_scenario_id` (string). Save "
+            "the scenario via save_scenario first, then pass the returned "
+            "id here — the chat surface only supports saved-scenario runs."
+        )
+    return _result_payload(
+        await run_scenario_for_agent(
+            name=name,
+            custom_scenario_id=custom_scenario_id,
+            route_to_instinct=route_to_instinct,
+            precedent_seed=precedent_seed,
+        )
+    )
+
+
+async def _list_runs_handler(args: dict) -> dict:
+    from pocketpaw_ee.cloud.foresight.agent_context import list_runs_for_agent
+
+    limit = args.get("limit", 10)
+    offset = args.get("offset", 0)
+    return _result_payload(await list_runs_for_agent(limit=limit, offset=offset))
+
+
+async def _get_run_handler(args: dict) -> dict:
+    from pocketpaw_ee.cloud.foresight.agent_context import get_run_for_agent
+
+    run_id = args.get("run_id")
+    if not run_id or not isinstance(run_id, str):
+        return _error("get_run requires a `run_id` (string).")
+    return _result_payload(await get_run_for_agent(run_id))
+
+
+# ---------------------------------------------------------------------------
+# Server factory
+# ---------------------------------------------------------------------------
+
+
+def build_foresight_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for Foresight, or ``None`` if
+    the Claude Agent SDK isn't installed. Same import-guard the sibling
+    servers use — a missing SDK is non-fatal for the rest of the runtime.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_foresight MCP disabled")
+        return None
+
+    @tool(
+        "list_scenarios",
+        (
+            "List the active workspace's saved Foresight scenarios. Call this "
+            "FIRST on every create flow — discovery prevents duplicates. "
+            "Workspace context is automatic; no headers, no ids to pass in. "
+            "Returns ``items[]`` (id, name, sub_type, num_personas, num_ticks, "
+            "updated_at) plus pagination meta (total, limit, offset, has_more)."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "description": "Max items (default 20, cap 100)."},
+                "offset": {"type": "integer", "description": "Pagination offset (default 0)."},
+                "sub_type": {
+                    "type": "string",
+                    "enum": _SUB_TYPE_ENUM,
+                    "description": (
+                        "Optional filter on scenario sub-type. Omit to list across all sub-types."
+                    ),
+                },
+            },
+            "required": [],
+        },
+    )
+    async def list_scenarios(args):  # type: ignore[no-untyped-def]
+        return await _list_scenarios_handler(args)
+
+    @tool(
+        "get_scenario",
+        (
+            "Fetch one saved scenario by id. Returns the full yaml_body + "
+            "parsed_meta (num_personas, num_ticks, tier_mix, precedent_seed) "
+            "so an edit flow can read-modify-write without losing fields. "
+            "404 (``foresight_custom_scenario.not_found``) for unknown or "
+            "cross-tenant ids — the workspace is inferred from the chat stream."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "scenario_id": {"type": "string", "description": "Id from list_scenarios items."}
+            },
+            "required": ["scenario_id"],
+        },
+    )
+    async def get_scenario(args):  # type: ignore[no-untyped-def]
+        return await _get_scenario_handler(args)
+
+    @tool(
+        "save_scenario",
+        (
+            "Persist a new custom scenario in the active workspace. Returns "
+            "201 with the full scenario object including the new `id` — "
+            "CAPTURE THE ID so a follow-up run_scenario call can reference "
+            "it. ``yaml_body`` is the full scenario YAML as a string; the "
+            "schema (personas[], n_ticks, tier_mix, precedent_seed, ...) is "
+            "documented in the foresight-create-sim skill. 422 surfaces YAML "
+            "parse errors, persona/tick caps, tier-mix sum, and sub_type "
+            "mismatches with stable codes (foresight.invalid_yaml, "
+            "foresight.invalid_scenario, foresight.sub_type_mismatch)."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Human-readable scenario label."},
+                "sub_type": {
+                    "type": "string",
+                    "enum": _SUB_TYPE_ENUM,
+                    "description": (
+                        "Scenario sub-type. Must match the `sub_type:` declared "
+                        "inside the YAML body or the service returns 422 "
+                        "foresight.sub_type_mismatch."
+                    ),
+                },
+                "yaml_body": {
+                    "type": "string",
+                    "description": "Full scenario YAML (≤64 KB).",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional short description (≤500 chars).",
+                },
+            },
+            "required": ["name", "sub_type", "yaml_body"],
+        },
+    )
+    async def save_scenario(args):  # type: ignore[no-untyped-def]
+        return await _save_scenario_handler(args)
+
+    @tool(
+        "update_scenario",
+        (
+            "Full-REPLACE a saved scenario. PUT semantics — every field on "
+            "the body overwrites the saved doc. ALWAYS get_scenario first, "
+            "mutate only the fields the user named, then call this with the "
+            "complete body. Validation is identical to save_scenario."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "scenario_id": {"type": "string", "description": "Id of the scenario to update."},
+                "name": {"type": "string"},
+                "sub_type": {"type": "string", "enum": _SUB_TYPE_ENUM},
+                "yaml_body": {"type": "string"},
+                "description": {"type": "string"},
+            },
+            "required": ["scenario_id", "name", "sub_type", "yaml_body"],
+        },
+    )
+    async def update_scenario(args):  # type: ignore[no-untyped-def]
+        return await _update_scenario_handler(args)
+
+    @tool(
+        "delete_scenario",
+        (
+            "Remove a saved scenario. Idempotency: a second delete on the "
+            "same id returns 404 (``foresight_custom_scenario.not_found``). "
+            "ASK THE USER BEFORE CALLING — no undo path."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "scenario_id": {"type": "string", "description": "Id to delete."},
+            },
+            "required": ["scenario_id"],
+        },
+    )
+    async def delete_scenario(args):  # type: ignore[no-untyped-def]
+        return await _delete_scenario_handler(args)
+
+    @tool(
+        "run_scenario",
+        (
+            "Execute a saved scenario. ``custom_scenario_id`` is REQUIRED — "
+            "the chat surface ONLY supports the saved-scenario path so the "
+            "scenario stays re-runnable from the dashboard. Save first via "
+            "save_scenario, capture the id, then call this. Returns the full "
+            "run record (id, status, result.aggregates, "
+            "result.projected_decisions[]). v0.1 backend completes "
+            "synchronously; future versions return status=queued."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Run label (usually the scenario's display name).",
+                },
+                "custom_scenario_id": {
+                    "type": "string",
+                    "description": "Id from save_scenario / list_scenarios.",
+                },
+                "route_to_instinct": {
+                    "type": "boolean",
+                    "description": (
+                        "When true, every ProjectedDecision the run emits also "
+                        "lands one row in the Instinct approval queue. "
+                        "Default false."
+                    ),
+                },
+                "precedent_seed": {
+                    "type": "string",
+                    "description": (
+                        "Optional global forward-precedent seed. Omit unless the "
+                        "user explicitly asked to link projections to past decisions."
+                    ),
+                },
+            },
+            "required": ["name", "custom_scenario_id"],
+        },
+    )
+    async def run_scenario(args):  # type: ignore[no-untyped-def]
+        return await _run_scenario_handler(args)
+
+    @tool(
+        "list_runs",
+        (
+            "List recent scenario runs in the active workspace, newest first. "
+            "Use this to find a previous run the user is referring to ('show "
+            "me the renewal sim from yesterday') without scanning the full "
+            "result blob. Returns lightweight items (id, scenario_name, "
+            "status, created_at, error)."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "description": "Max items (default 10, cap 200)."},
+                "offset": {"type": "integer", "description": "Pagination offset (default 0)."},
+            },
+            "required": [],
+        },
+    )
+    async def list_runs(args):  # type: ignore[no-untyped-def]
+        return await _list_runs_handler(args)
+
+    @tool(
+        "get_run",
+        (
+            "Fetch a single scenario run by id with the full result blob "
+            "(aggregates, projected decisions, per-tick state). Returns 404 "
+            "for unknown or cross-tenant ids."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "Run id from run_scenario / list_runs."}
+            },
+            "required": ["run_id"],
+        },
+    )
+    async def get_run(args):  # type: ignore[no-untyped-def]
+        return await _get_run_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[
+            list_scenarios,
+            get_scenario,
+            save_scenario,
+            update_scenario,
+            delete_scenario,
+            run_scenario,
+            list_runs,
+            get_run,
+        ],
+    )
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "DELETE_SCENARIO_TOOL_ID",
+    "FORESIGHT_TOOL_IDS",
+    "GET_RUN_TOOL_ID",
+    "GET_SCENARIO_TOOL_ID",
+    "LIST_RUNS_TOOL_ID",
+    "LIST_SCENARIOS_TOOL_ID",
+    "RUN_SCENARIO_TOOL_ID",
+    "SAVE_SCENARIO_TOOL_ID",
+    "SERVER_NAME",
+    "UPDATE_SCENARIO_TOOL_ID",
+    "build_foresight_server",
+]

--- a/ee/pocketpaw_ee/cloud/foresight/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/foresight/agent_context.py
@@ -1,0 +1,389 @@
+# ee/pocketpaw_ee/cloud/foresight/agent_context.py
+# Created: 2026-05-28 — agent-facing Foresight wrappers for the in-process
+# MCP tools that back the ``/foresight`` chat agent. Each function looks
+# up workspace + user identity from the per-stream ``ContextVar``s in
+# ``ee.cloud.chat.agent_service``, builds a ``RequestContext`` the cloud
+# service layer expects, and translates the response into the
+# ``{ok, ...}`` envelope the MCP layer in ``ee/pocketpaw_ee/agent/
+# mcp_servers/foresight.py`` consumes. CloudError subclasses (NotFound,
+# ValidationError, Forbidden) collapse to ``{ok: False, error, message}``;
+# any unexpected exception bubbles for the SDK to surface as a tool
+# failure.
+#
+# This sits parallel to ``ee.cloud.pockets.agent_context`` and exists for
+# the same reason: the in-process MCP tool channel doesn't reach the
+# FastAPI request scope, so the agent can't go through the loopback REST
+# path the SKILL teaches today (``$WORKSPACE_ID`` / ``$USER_ID`` env vars
+# the ``claude_agent_sdk`` backend never sets). Typed MCP tools close
+# over the chat session's workspace id and remove the entire class of
+# "agent saved to the wrong workspace" bugs.
+#
+# Scope rules:
+#   - The run wrapper only supports the saved-scenario path
+#     (``custom_scenario_id`` required). Inline-personas runs are still
+#     reachable via the REST surface; we don't expose two run shapes on
+#     the chat surface because mixing them is the bug we're fixing.
+#   - The list-runs wrapper carries ``offset`` for parity with the brief
+#     signature, then slices client-side because
+#     ``list_scenario_runs`` itself doesn't yet take an offset arg.
+#     Cheap on small workspaces; document the limitation.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+NO_WORKSPACE_ERROR = "no_workspace_context"
+NO_WORKSPACE_MESSAGE = (
+    "no active workspace/user — foresight tools can only be called from "
+    "inside a cloud SSE chat stream"
+)
+
+
+def _build_request_context(workspace_id: str, user_id: str) -> Any:
+    """Synthesise a ``RequestContext`` for service calls reaching us
+    from the MCP tool channel. Mirrors the surface handler's shape
+    (``surface/handlers/foresight.py`` lines 212-218)."""
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id=f"mcp-{uuid4().hex[:8]}",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _resolve_identity() -> tuple[str | None, str | None]:
+    """Read the per-stream workspace + user from the chat ContextVars.
+    Returns ``(None, None)`` if either is unset — the caller surfaces a
+    clean error instead of fabricating a workspace."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_user_id, current_workspace_id
+
+        return current_workspace_id(), current_user_id()
+    except Exception:  # noqa: BLE001
+        logger.debug("foresight agent_context: identity resolution failed", exc_info=True)
+        return None, None
+
+
+def _no_workspace_error() -> dict[str, Any]:
+    """Common error payload when the chat ContextVars aren't set. The
+    agent reads ``error`` and ``message`` and surfaces them to the user.
+    """
+    return {
+        "ok": False,
+        "error": NO_WORKSPACE_ERROR,
+        "message": NO_WORKSPACE_MESSAGE,
+    }
+
+
+def _cloud_error_payload(exc: Any) -> dict[str, Any]:
+    """Collapse a ``CloudError`` into the agent-facing error envelope."""
+    return {
+        "ok": False,
+        "error": getattr(exc, "code", "cloud_error"),
+        "message": getattr(exc, "message", str(exc)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Custom scenario CRUD
+# ---------------------------------------------------------------------------
+
+
+async def list_scenarios_for_agent(
+    limit: int = 20, offset: int = 0, sub_type: str | None = None
+) -> dict[str, Any]:
+    """List the workspace's saved custom scenarios for the active stream.
+
+    Shape on success: ``{"ok": True, "items": [...], "total": N,
+    "limit": int, "offset": int, "has_more": bool}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import scenarios as foresight_scenarios
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        response = await foresight_scenarios.list_custom_scenarios(
+            ctx, sub_type=sub_type, limit=limit, offset=offset
+        )
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    payload = response.model_dump()
+    payload["ok"] = True
+    return payload
+
+
+async def get_scenario_for_agent(scenario_id: str) -> dict[str, Any]:
+    """Fetch one saved scenario by id (full yaml_body + parsed_meta).
+
+    Shape on success: ``{"ok": True, ...scenario fields}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import scenarios as foresight_scenarios
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        response = await foresight_scenarios.get_custom_scenario(ctx, scenario_id)
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    payload = response.model_dump()
+    payload["ok"] = True
+    return payload
+
+
+async def save_scenario_for_agent(
+    name: str,
+    sub_type: str,
+    yaml_body: str,
+    description: str | None = None,
+) -> dict[str, Any]:
+    """Persist a new custom scenario in the active workspace.
+
+    Shape on success: ``{"ok": True, "id": ..., "name": ..., ...}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import scenarios as foresight_scenarios
+    from pocketpaw_ee.cloud.foresight.dto import CreateCustomScenarioRequest
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        body = CreateCustomScenarioRequest(
+            name=name,
+            sub_type=sub_type,  # type: ignore[arg-type]
+            description=description or "",
+            yaml_body=yaml_body,
+        )
+    except Exception as exc:  # noqa: BLE001 — pydantic validation surfaces here
+        return {
+            "ok": False,
+            "error": "foresight.invalid_request",
+            "message": str(exc),
+        }
+
+    try:
+        response = await foresight_scenarios.create_custom_scenario(ctx, body)
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    payload = response.model_dump()
+    payload["ok"] = True
+    return payload
+
+
+async def update_scenario_for_agent(
+    scenario_id: str,
+    name: str,
+    sub_type: str,
+    yaml_body: str,
+    description: str | None = None,
+) -> dict[str, Any]:
+    """Full-replace a saved scenario (PUT semantics — every field
+    overwrites). The agent should GET first, mutate only what the user
+    named, then call this.
+
+    Shape on success: ``{"ok": True, "id": ..., ...}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import scenarios as foresight_scenarios
+    from pocketpaw_ee.cloud.foresight.dto import CreateCustomScenarioRequest
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        body = CreateCustomScenarioRequest(
+            name=name,
+            sub_type=sub_type,  # type: ignore[arg-type]
+            description=description or "",
+            yaml_body=yaml_body,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "ok": False,
+            "error": "foresight.invalid_request",
+            "message": str(exc),
+        }
+
+    try:
+        response = await foresight_scenarios.update_custom_scenario(ctx, scenario_id, body)
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    payload = response.model_dump()
+    payload["ok"] = True
+    return payload
+
+
+async def delete_scenario_for_agent(scenario_id: str) -> dict[str, Any]:
+    """Remove a saved scenario. Idempotency: a second delete on the same
+    id returns ``{ok: False, error: 'foresight_custom_scenario.not_found'}``.
+
+    Shape on success: ``{"ok": True, "scenario_id": "..."}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import scenarios as foresight_scenarios
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        await foresight_scenarios.delete_custom_scenario(ctx, scenario_id)
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    return {"ok": True, "scenario_id": scenario_id}
+
+
+# ---------------------------------------------------------------------------
+# Scenario runs — only the saved-scenario path is exposed on chat
+# ---------------------------------------------------------------------------
+
+
+async def run_scenario_for_agent(
+    name: str,
+    custom_scenario_id: str,
+    route_to_instinct: bool = False,
+    precedent_seed: str | None = None,
+) -> dict[str, Any]:
+    """Execute a saved scenario. ``custom_scenario_id`` is REQUIRED — the
+    chat surface only supports the saved-scenario path because the bug
+    we're fixing is "agent saved nothing, then claimed it ran something
+    that didn't exist". Inline-personas runs stay reachable via the REST
+    surface for power users.
+
+    Shape on success: ``{"ok": True, "id": run_id, "status": ...,
+    "result": ..., "scenario_name": ...}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    if not custom_scenario_id:
+        return {
+            "ok": False,
+            "error": "foresight.missing_scenario_id",
+            "message": (
+                "run_scenario requires a custom_scenario_id — save the "
+                "scenario via save_scenario first, then run it by id"
+            ),
+        }
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import service as foresight_service
+    from pocketpaw_ee.cloud.foresight.dto import CreateScenarioRequest
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        body = CreateScenarioRequest(
+            name=name,
+            custom_scenario_id=custom_scenario_id,
+            route_to_instinct=route_to_instinct,
+            precedent_seed=precedent_seed,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "ok": False,
+            "error": "foresight.invalid_request",
+            "message": str(exc),
+        }
+
+    try:
+        response = await foresight_service.create_scenario_run(ctx, body)
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    payload = response.model_dump()
+    payload["ok"] = True
+    return payload
+
+
+async def list_runs_for_agent(limit: int = 10, offset: int = 0) -> dict[str, Any]:
+    """List recent scenario runs in the active workspace, newest first.
+
+    Note: ``ee.cloud.foresight.service.list_scenario_runs`` doesn't yet
+    accept an ``offset`` kwarg, so we fetch ``limit + offset`` and slice
+    client-side. Adequate for the chat surface (the agent rarely scrolls
+    back; sessions average single-digit runs) — a server-side offset is
+    a separate follow-up.
+
+    Shape on success: ``{"ok": True, "items": [...], "limit": int,
+    "offset": int}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import service as foresight_service
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        runs = await foresight_service.list_scenario_runs(ctx, limit=limit + offset)
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    items = [run.model_dump() for run in runs[offset : offset + limit]]
+    return {"ok": True, "items": items, "limit": limit, "offset": offset}
+
+
+async def get_run_for_agent(run_id: str) -> dict[str, Any]:
+    """Fetch a single scenario run by id (full result blob).
+
+    Shape on success: ``{"ok": True, "id": ..., "status": ...,
+    "result": ..., ...}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import service as foresight_service
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        response = await foresight_service.get_scenario_run(ctx, run_id)
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    payload = response.model_dump()
+    payload["ok"] = True
+    return payload
+
+
+__all__ = [
+    "NO_WORKSPACE_ERROR",
+    "NO_WORKSPACE_MESSAGE",
+    "delete_scenario_for_agent",
+    "get_run_for_agent",
+    "get_scenario_for_agent",
+    "list_runs_for_agent",
+    "list_scenarios_for_agent",
+    "run_scenario_for_agent",
+    "save_scenario_for_agent",
+    "update_scenario_for_agent",
+]

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -259,6 +259,31 @@ class CloudPocketSpecialistMcpProvider:
         return list(POCKET_SPECIALIST_TOOL_IDS)
 
 
+class CloudForesightMcpProvider:
+    """`pocketpaw.mcp_servers` — the cloud Foresight scenario CRUD + run server.
+
+    Closes the bug where the bundled ``foresight-create-sim`` skill told
+    the chat agent to call the loopback REST surface with
+    ``$WORKSPACE_ID`` / ``$USER_ID`` env vars the ``claude_agent_sdk``
+    backend never sets. The typed MCP tools close over the chat session's
+    workspace id (read from ``ee.cloud.chat.agent_service`` ContextVars)
+    so the agent literally cannot save to the wrong workspace.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        try:
+            from pocketpaw_ee.agent.mcp_servers.foresight import build_foresight_server
+
+            return build_foresight_server()
+        except ImportError:
+            return None
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.foresight import FORESIGHT_TOOL_IDS
+
+        return list(FORESIGHT_TOOL_IDS)
+
+
 class CloudAgentExtension:
     """`pocketpaw.agent_extensions` — EE additions to the core agent runtime.
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -160,6 +160,7 @@ tasks = "pocketpaw_ee.extensions:CloudTasksMcpProvider"
 planner = "pocketpaw_ee.extensions:CloudPlannerMcpProvider"
 pocket = "pocketpaw_ee.extensions:CloudPocketMcpProvider"
 pocket_specialist = "pocketpaw_ee.extensions:CloudPocketSpecialistMcpProvider"
+foresight = "pocketpaw_ee.extensions:CloudForesightMcpProvider"
 composio = "pocketpaw_ee.extensions:CloudComposioMcpProvider"
 
 [project.entry-points."pocketpaw.agent_extensions"]

--- a/src/pocketpaw/bundled_skills/_bundled/foresight-create-sim/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/foresight-create-sim/SKILL.md
@@ -1,15 +1,17 @@
 ---
 name: foresight-create-sim
 description: |
-  Create, edit, and run Foresight scenarios via the workspace's REST API.
-  Triggered when the user asks to rehearse / simulate / project / forecast
-  / branch a decision — "rehearse the renewal", "what if we cut price
-  10%", "simulate the org change before we announce", "forecast Q3 churn",
-  "branch the launch decision". The skill teaches the chat agent how to
-  discover existing scenarios, synthesize the YAML body, save it via
-  PUT/POST, and (on explicit user confirmation) execute the run. Calls the
-  cloud's existing ``/api/v1/foresight/*`` endpoints with the internal
-  loopback headers — no engine code is touched.
+  Create, edit, and run Foresight scenarios via the workspace's typed
+  MCP tools (with a curl fallback for power users / SDKs without the
+  in-process server). Triggered when the user asks to rehearse /
+  simulate / project / forecast / branch a decision — "rehearse the
+  renewal", "what if we cut price 10%", "simulate the org change before
+  we announce", "forecast Q3 churn", "branch the launch decision". The
+  skill teaches the chat agent how to discover existing scenarios,
+  synthesize the YAML body, save it via the ``save_scenario`` MCP tool,
+  and (on explicit user confirmation) execute the run via
+  ``run_scenario``. Workspace context is automatic — no env vars, no
+  headers.
 ---
 
 # Foresight Scenario Workflow
@@ -52,15 +54,52 @@ planning.
 - The user wants a **dashboard / canvas** of metrics — that's the
   ``pocketpaw-create-pocket`` skill.
 
+## MCP tool reference (PREFER THESE)
+
+The dashboard runs an in-process MCP server (``pocketpaw_foresight``)
+that closes over the chat session's workspace id. **Always use these
+tools instead of curl** — they cannot save to the wrong workspace
+because the workspace context is read from the active chat stream, not
+from env vars or headers you have to plumb yourself.
+
+  - ``mcp__pocketpaw_foresight__list_scenarios({limit?, offset?, sub_type?})``
+    — list saved custom scenarios in the active workspace. Returns
+    ``{items[], total, limit, offset, has_more}``.
+  - ``mcp__pocketpaw_foresight__get_scenario({scenario_id})`` — full
+    detail (yaml_body + parsed_meta).
+  - ``mcp__pocketpaw_foresight__save_scenario({name, sub_type,
+    yaml_body, description?})`` — create. Returns the new scenario
+    object with its ``id``. **CAPTURE THE ID** for the run step.
+  - ``mcp__pocketpaw_foresight__update_scenario({scenario_id, name,
+    sub_type, yaml_body, description?})`` — PUT-style full replace.
+  - ``mcp__pocketpaw_foresight__delete_scenario({scenario_id})`` —
+    remove. Ask the user first; no undo.
+  - ``mcp__pocketpaw_foresight__run_scenario({name, custom_scenario_id,
+    route_to_instinct?, precedent_seed?})`` — execute a saved scenario.
+    ``custom_scenario_id`` is REQUIRED (the chat surface only supports
+    the saved-scenario path so the run stays re-runnable from the
+    dashboard).
+  - ``mcp__pocketpaw_foresight__list_runs({limit?, offset?})`` —
+    recent runs, newest first.
+  - ``mcp__pocketpaw_foresight__get_run({run_id})`` — single run with
+    full result blob.
+
+Each tool returns either a JSON body (success) or an MCP error envelope
+carrying the cloud error code + message (e.g.
+``foresight.invalid_yaml``, ``foresight.sub_type_mismatch``,
+``foresight_custom_scenario.not_found``). Surface those codes to the
+user verbatim — they name the field to fix.
+
 ## The four-phase workflow
 
 Every interaction with Foresight from chat follows this loop:
 
   1. **Discover** — does a scenario like this already exist?
   2. **Synthesize** — build (or modify) the YAML body.
-  3. **Save** — POST (new) or PUT (replace) the custom scenario.
-  4. **Run** — POST /scenarios with ``custom_scenario_id``, ONLY if the
-     user explicitly confirms.
+  3. **Save** — call ``save_scenario`` (new) or ``update_scenario``
+     (replace).
+  4. **Run** — call ``run_scenario`` with ``custom_scenario_id``, ONLY
+     if the user explicitly confirms.
 
 Skipping phases is the most common failure mode. If you jump straight to
 "run" without saving, you can't re-run the same scenario. If you skip
@@ -68,15 +107,11 @@ Skipping phases is the most common failure mode. If you jump straight to
 
 ## STEP 1 — Discover (list before you create)
 
-Always GET the workspace's saved scenarios first. The user may have
+Always list the workspace's saved scenarios first. The user may have
 already built something close to what they want.
 
-```bash
-curl -s -X GET \
-  -H "X-PocketPaw-Internal: true" \
-  -H "X-PocketPaw-Workspace-Id: $WORKSPACE_ID" \
-  -H "X-PocketPaw-User-Id: $USER_ID" \
-  "http://localhost:8000/api/v1/foresight/scenarios/custom?limit=20"
+```
+mcp__pocketpaw_foresight__list_scenarios({"limit": 20})
 ```
 
 Returns ``{items, total, limit, offset, has_more}``. Each item carries
@@ -143,105 +178,67 @@ forward-compat for v2.0 fields).
 
 ### Anchors (for backtests, not forward sims)
 
-Forward sims (POST /scenarios) don't carry inline anchors — the engine
-fans personas across the ticks and emits one ProjectedDecision per
-(tick, anchor inferred from role). **Backtests** (POST /backtests) are
-where anchors are required:
-
-  ```json
-  {
-    "anchors": [
-      {
-        "anchor_object_id": "decision:renewal_q2_2026",
-        "actual_outcome": {"renewed": true, "discount_pct": 8},
-        "scenario_template": "decision_forecast.yaml",
-        "projection_confidence": 0.5
-      }
-    ]
-  }
-  ```
+Forward sims (the ``run_scenario`` tool) don't carry inline anchors —
+the engine fans personas across the ticks and emits one
+ProjectedDecision per (tick, anchor inferred from role). **Backtests**
+are where anchors are required, and they currently ship through the
+REST surface only (``POST /api/v1/foresight/backtests``); see the
+"Endpoint reference (fallback)" section below.
 
 This skill focuses on **forward sims**. If the user asks for a backtest
-("did we predict the Q2 renewals correctly?"), redirect to the backtest
-endpoint and surface the ``gate_decision`` from the response. The chat
-agent rarely needs to build backtests by hand — the UI's Aggregate panel
-does that.
+("did we predict the Q2 renewals correctly?"), redirect to the
+Aggregate panel in the UI and surface the ``gate_decision`` from the
+response. The chat agent rarely needs to build backtests by hand.
 
 ## STEP 3 — Save the scenario
 
-### Create (POST)
+### Create
 
-```bash
-YAML_BODY=$(cat <<'EOF'
-name: rehearse-q3-renewals
-sub_type: decision_forecast
-n_ticks: 1
-tier_mix:
-  premium: 0.05
-  mid: 0.15
-  tail: 0.80
-personas:
-  - name: tenant-maria
-    role: tenant
-    ocean:
-      conscientiousness: 0.4
-      agreeableness: 0.5
-  - name: approver-prakash
-    role: approver
-    ocean:
-      conscientiousness: 1.2
-EOF
-)
+Build the YAML body as a string and call ``save_scenario``. The tool
+returns the full scenario object including the new ``id`` — **capture
+it** for the run step.
 
-# Escape the YAML for JSON
-YAML_JSON=$(jq -Rs <<<"$YAML_BODY")
-
-curl -s -X POST \
-  -H "X-PocketPaw-Internal: true" \
-  -H "X-PocketPaw-Workspace-Id: $WORKSPACE_ID" \
-  -H "X-PocketPaw-User-Id: $USER_ID" \
-  -H "Content-Type: application/json" \
-  -d "{
-    \"name\": \"Rehearse Q3 Renewals\",
-    \"sub_type\": \"decision_forecast\",
-    \"description\": \"Renewal cohort with one approver.\",
-    \"yaml_body\": $YAML_JSON
-  }" \
-  http://localhost:8000/api/v1/foresight/scenarios/custom
+```
+mcp__pocketpaw_foresight__save_scenario({
+  "name": "Rehearse Q3 Renewals",
+  "sub_type": "decision_forecast",
+  "description": "Renewal cohort with one approver.",
+  "yaml_body": "name: rehearse-q3-renewals\nsub_type: decision_forecast\nn_ticks: 1\ntier_mix:\n  premium: 0.05\n  mid: 0.15\n  tail: 0.80\npersonas:\n  - name: tenant-maria\n    role: tenant\n    ocean:\n      conscientiousness: 0.4\n      agreeableness: 0.5\n  - name: approver-prakash\n    role: approver\n    ocean:\n      conscientiousness: 1.2\n"
+})
 ```
 
-Returns 201 with the full scenario object (id, parsed_meta, yaml_body).
-**Capture the ``id``** — you need it for the run step.
+Returns the scenario object: ``{id, name, sub_type, description,
+yaml_body, parsed_meta, created_at, updated_at, ...}``. **Capture the
+``id``** — you need it for the run step. The cloud rejects bodies
+where the request ``sub_type`` doesn't match the YAML's
+``sub_type:`` (422 ``foresight.sub_type_mismatch``); keep them in sync.
 
 ### Edit (PUT — full replace)
 
-```bash
-curl -s -X PUT \
-  -H "X-PocketPaw-Internal: true" \
-  -H "X-PocketPaw-Workspace-Id: $WORKSPACE_ID" \
-  -H "X-PocketPaw-User-Id: $USER_ID" \
-  -H "Content-Type: application/json" \
-  -d "{\"name\": ..., \"sub_type\": ..., \"yaml_body\": $YAML_JSON}" \
-  "http://localhost:8000/api/v1/foresight/scenarios/custom/$SCENARIO_ID"
+```
+mcp__pocketpaw_foresight__update_scenario({
+  "scenario_id": "<id>",
+  "name": "...",
+  "sub_type": "...",
+  "yaml_body": "<full yaml>",
+  "description": "..."
+})
 ```
 
-PUT is **full replace** — every field on the body overwrites the saved
-doc. Read-modify-write: GET the current state first, modify only the
-fields the user asked to change, then PUT. NEVER blank out a field the
+``update_scenario`` is **full replace** — every field on the body
+overwrites the saved doc. Read-modify-write: ``get_scenario`` first,
+modify only the fields the user asked to change, then call
+``update_scenario`` with the complete body. NEVER blank out a field the
 user didn't mention.
 
 ### Delete
 
-```bash
-curl -s -X DELETE \
-  -H "X-PocketPaw-Internal: true" \
-  -H "X-PocketPaw-Workspace-Id: $WORKSPACE_ID" \
-  -H "X-PocketPaw-User-Id: $USER_ID" \
-  "http://localhost:8000/api/v1/foresight/scenarios/custom/$SCENARIO_ID"
+```
+mcp__pocketpaw_foresight__delete_scenario({"scenario_id": "<id>"})
 ```
 
-Returns 204. **Always confirm with the user before deleting** — the
-operation is irreversible (no audit log undo).
+**Always confirm with the user before deleting** — the operation is
+irreversible (no audit log undo).
 
 ## STEP 4 — Run (only on explicit confirm)
 
@@ -249,62 +246,34 @@ After the save lands, ask the user:
 
   > "Saved as `<name>`. Want me to run it now?"
 
-Wait for an explicit "yes" / "run it" / "go" before calling POST.
-Foresight runs cost LLM tokens — never auto-run on save.
+Wait for an explicit "yes" / "run it" / "go" before calling
+``run_scenario``. Foresight runs cost LLM tokens — never auto-run on
+save.
 
-```bash
-curl -s -X POST \
-  -H "X-PocketPaw-Internal: true" \
-  -H "X-PocketPaw-Workspace-Id: $WORKSPACE_ID" \
-  -H "X-PocketPaw-User-Id: $USER_ID" \
-  -H "Content-Type: application/json" \
-  -d "{
-    \"name\": \"$SCENARIO_NAME\",
-    \"custom_scenario_id\": \"$SCENARIO_ID\"
-  }" \
-  http://localhost:8000/api/v1/foresight/scenarios
+```
+mcp__pocketpaw_foresight__run_scenario({
+  "name": "Q3 Renewals",
+  "custom_scenario_id": "<id-from-save_scenario>",
+  "route_to_instinct": false
+})
 ```
 
-The v0.1 deterministic-fake backend completes synchronously — POST
-returns the full run record (``status: complete``) on the same response.
-Future versions return ``status: queued`` plus a websocket URL; this
-skill assumes synchronous for now.
+The v0.1 deterministic-fake backend completes synchronously — the call
+returns the full run record (``status: complete``) on the same
+response. Future versions return ``status: queued`` plus a websocket
+URL; this skill assumes synchronous for now.
 
 Response carries ``id``, ``status``, ``result.aggregates``,
 ``result.projected_decisions[]``. Surface the run id and a one-line
 verdict drawn from ``result.aggregates``.
 
-For richer details, GET the per-anchor projections:
+For richer details, look up the run via ``get_run`` (or use the
+``/api/v1/foresight/runs/{id}/projected-decisions`` REST endpoint for
+the per-anchor list).
 
-```bash
-curl -s -X GET \
-  -H "X-PocketPaw-Internal: true" \
-  -H "X-PocketPaw-Workspace-Id: $WORKSPACE_ID" \
-  -H "X-PocketPaw-User-Id: $USER_ID" \
-  "http://localhost:8000/api/v1/foresight/runs/$RUN_ID/projected-decisions"
 ```
-
-## Endpoint reference
-
-  - ``GET    /api/v1/foresight/scenarios/custom`` — list saved scenarios
-    (workspace-scoped, paginated; optional ``?sub_type=`` filter).
-  - ``GET    /api/v1/foresight/scenarios/custom/{id}`` — fetch one,
-    returns full yaml_body + parsed_meta.
-  - ``POST   /api/v1/foresight/scenarios/custom`` — create. Body:
-    ``{name, sub_type, description, yaml_body}``. Returns 201 with the id.
-  - ``PUT    /api/v1/foresight/scenarios/custom/{id}`` — full replace.
-    Returns 200.
-  - ``DELETE /api/v1/foresight/scenarios/custom/{id}`` — remove (204).
-    Idempotency: a second DELETE on the same id returns 404.
-  - ``POST   /api/v1/foresight/scenarios`` — run. Body: ``{name,
-    custom_scenario_id, route_to_instinct?, precedent_seed?}`` OR the
-    inline-personas grammar (skip custom_scenario_id and embed
-    ``sub_type``, ``personas[]``, ``n_ticks`` directly).
-  - ``GET    /api/v1/foresight/runs/{id}`` — fetch one run with full
-    result blob.
-  - ``GET    /api/v1/foresight/runs/{id}/projected-decisions`` —
-    paginated list of per-anchor projections, optional
-    ``?anchor_id=`` filter.
+mcp__pocketpaw_foresight__get_run({"run_id": "<id>"})
+```
 
 ## Three worked examples
 
@@ -354,9 +323,16 @@ personas:
 
 Save then run:
 
-```bash
-ID=$(curl -s -X POST ... /scenarios/custom | jq -r .id)
-curl -s -X POST ... /scenarios -d "{\"name\":\"Q3 Renewals\",\"custom_scenario_id\":\"$ID\"}"
+```
+saved = mcp__pocketpaw_foresight__save_scenario({
+  "name": "Q3 Enterprise Renewals",
+  "sub_type": "decision_forecast",
+  "yaml_body": "<the yaml above>"
+})
+mcp__pocketpaw_foresight__run_scenario({
+  "name": "Q3 Renewals",
+  "custom_scenario_id": saved.id
+})
 ```
 
 ### Example 2 — Market Sim (pricing stress test)
@@ -460,29 +436,24 @@ personas:
 After the run, surface ``aggregates.per_event`` (adoption / resistance /
 exit / escalation rates) and ``totals.queue_depth``.
 
-## Error handling — the 422 envelope
+## Error handling — the codes you'll see
 
-The cloud returns errors in a stable envelope:
+When an MCP tool fails, the envelope carries ``is_error: true`` and the
+text starts with ``Error: <code>``. Four codes matter:
 
-```json
-{ "error": { "code": "foresight.invalid_yaml", "message": "..." } }
-```
-
-Four error codes you'll see:
-
-  - **422 ``foresight.invalid_yaml``** — YAML failed to parse. Read the
+  - **``foresight.invalid_yaml``** — YAML failed to parse. Read the
     message, identify the field (often a colon / indentation issue),
     fix, retry. NEVER swallow the error and present a fake success.
-  - **422 ``foresight.sub_type_mismatch``** — the ``sub_type`` in the
-    request body differs from the ``sub_type:`` declared inside the
-    YAML. Pick one; they must match. The body's sub_type wins as the
+  - **``foresight.sub_type_mismatch``** — the ``sub_type`` in the
+    request differs from the ``sub_type:`` declared inside the YAML.
+    Pick one; they must match. The request's sub_type wins as the
     intent declaration; rewrite the YAML to match.
-  - **422 ``foresight.invalid_scenario``** — YAML parsed but engine
-    grammar / cap failed (persona count > 100, n_ticks > 1000, tier_mix
-    doesn't sum to 1.0, etc.). Read the message — it names the field —
-    and adjust.
-  - **404 ``foresight_custom_scenario.not_found``** — the scenario id
-    is unknown or belongs to another workspace (tenancy collapse). On a
+  - **``foresight.invalid_scenario``** — YAML parsed but engine
+    grammar / cap failed (persona count > 100, n_ticks > 1000,
+    tier_mix doesn't sum to 1.0, etc.). Read the message — it names
+    the field — and adjust.
+  - **``foresight_custom_scenario.not_found``** — the scenario id is
+    unknown or belongs to another workspace (tenancy collapse). On a
     PUT/DELETE/GET retry, this means the id is stale; refresh the list.
 
 Surface the error message to the user verbatim — do not paraphrase. The
@@ -490,27 +461,41 @@ message names the field; the user can fix it directly. If the error
 recurs after one retry, stop and ask for clarification rather than
 looping.
 
-## Auth headers
+## Endpoint reference (fallback)
 
-Calls go to ``http://localhost:8000`` (the local dashboard's loopback
-address). The agent runs on the same host as the dashboard and uses
-internal-trust headers — NO user JWT needed.
+The MCP tools above are the preferred surface. The cloud also exposes a
+REST API for power users, SDKs without the in-process MCP server, and
+backtests (which the chat surface doesn't yet expose):
 
-Required on every call:
+  - ``GET    /api/v1/foresight/scenarios/custom`` — list saved scenarios
+    (workspace-scoped, paginated; optional ``?sub_type=`` filter).
+  - ``GET    /api/v1/foresight/scenarios/custom/{id}`` — fetch one.
+  - ``POST   /api/v1/foresight/scenarios/custom`` — create.
+  - ``PUT    /api/v1/foresight/scenarios/custom/{id}`` — full replace.
+  - ``DELETE /api/v1/foresight/scenarios/custom/{id}`` — remove (204).
+  - ``POST   /api/v1/foresight/scenarios`` — run. Body: ``{name,
+    custom_scenario_id, route_to_instinct?, precedent_seed?}`` OR the
+    inline-personas grammar.
+  - ``GET    /api/v1/foresight/runs/{id}`` — fetch one run.
+  - ``GET    /api/v1/foresight/runs/{id}/projected-decisions`` —
+    paginated per-anchor projections, optional ``?anchor_id=`` filter.
+  - ``POST   /api/v1/foresight/backtests`` — retroactive run scored
+    against known historical anchors. Not exposed via MCP; ship
+    backtests through the UI's Aggregate panel.
+
+## Auth headers (REST fallback only)
+
+The MCP tools handle workspace identity automatically — no headers
+required. The REST fallback is loopback-only and uses internal-trust
+headers:
 
   - ``X-PocketPaw-Internal: true``
   - ``X-PocketPaw-Workspace-Id: <id>``
   - ``X-PocketPaw-User-Id: <id>``
 
-The workspace + user ids come from the **chat surface stamp** the
-dashboard threads into the agent's context. Look for ``$WORKSPACE_ID``
-and ``$USER_ID`` env vars or a system-prompt block named ``<surface>``
-that carries them. If neither is present, ask the user to switch to a
-specific workspace before continuing.
-
-If the loopback bypass is misconfigured (wrong host, missing headers,
-or feature flag off), the cloud returns 401 — surface the error and
-tell the user the dashboard auth path needs attention.
+Prefer the MCP tools whenever possible; the REST surface exists for
+SDK callers, the backtest path, and edge cases where the in-process
+server isn't available.
 
 ## Run pattern — ask, then go
 
@@ -527,21 +512,22 @@ After the run completes (synchronous in v0.1):
 
   - One-line verdict drawn from ``result.aggregates``.
   - The run id + a hint: "Open the Live panel for the full breakdown."
-  - For richer detail, optionally GET ``/runs/{id}/projected-decisions``
-    and surface the highest-confidence projections.
+  - For richer detail, call ``get_run`` (or hit
+    ``/runs/{id}/projected-decisions``) and surface the
+    highest-confidence projections.
 
 ## Edit pattern — read, modify, replace
 
 When the user asks to change a saved scenario:
 
-  1. GET the scenario by id to capture the current state.
+  1. Call ``get_scenario`` by id to capture the current state.
   2. Parse the ``yaml_body`` into your working copy.
   3. Modify ONLY the fields the user named. Leave everything else
      verbatim — including comments, ordering, and tier_mix.
-  4. PUT the full body back.
+  4. Call ``update_scenario`` with the full body back.
 
-NEVER PUT a body assembled from memory — you'll lose fields the user
-added through the UI. Always read first.
+NEVER call ``update_scenario`` with a body assembled from memory —
+you'll lose fields the user added through the UI. Always read first.
 
 ## Conversation conventions
 
@@ -567,12 +553,16 @@ added through the UI. Always read first.
 
 ## Hard rules
 
-  - **NEVER** call POST /scenarios without first GETing the workspace
-    scenario list. Discovery prevents duplicates.
+  - **PREFER** ``mcp__pocketpaw_foresight__*`` tools over curl — they
+    always use the correct workspace_id.
+  - **NEVER** call ``run_scenario`` without first calling
+    ``list_scenarios`` (or ``get_scenario`` on a known id). Discovery
+    prevents duplicates.
   - **NEVER** run on save — always ask first.
-  - **NEVER** PUT a partial body — full replace means full state.
-  - **NEVER** invent error codes. If the cloud returns ``422
-    foresight.invalid_scenario``, surface that exact code; don't
+  - **NEVER** call ``update_scenario`` with a partial body — PUT
+    semantics mean full replace.
+  - **NEVER** invent error codes. If a tool returns
+    ``foresight.invalid_scenario``, surface that exact code; don't
     paraphrase it as "validation failed".
   - **NEVER** call ``/api/v1/foresight/backtests`` from this skill. The
     backtest path needs ground-truth anchors and ships through the UI's

--- a/tests/cloud/test_foresight_agent_context.py
+++ b/tests/cloud/test_foresight_agent_context.py
@@ -1,0 +1,252 @@
+# tests/cloud/test_foresight_agent_context.py
+# Created: 2026-05-28 — coverage for the agent-facing Foresight wrappers
+# (``ee.cloud.foresight.agent_context``) that back the in-process MCP
+# tools. The wrappers translate ``ContextVar`` identity + CloudError
+# subclasses into the ``{ok, ...}`` envelope the MCP server consumes.
+# Tests live alongside the other foresight cloud tests so they reuse
+# the ``mongo_db`` fixture from ``tests/cloud/conftest.py``.
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import attach_agent_identity, detach_agent_identity
+from pocketpaw_ee.cloud.foresight import agent_context
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+@pytest.fixture
+def bound_identity() -> Iterator[None]:
+    """Bind a workspace/user pair into the chat ContextVars for the
+    duration of one test — mirrors what ``agent_router._run_agent_stream``
+    does for a live chat session."""
+    tokens = attach_agent_identity(workspace_id="w1", user_id="prakash")
+    try:
+        yield None
+    finally:
+        detach_agent_identity(tokens)
+
+
+def _decision_forecast_yaml(name: str = "agent-ctx-forecast") -> str:
+    return f"""name: {name}
+sub_type: decision_forecast
+n_ticks: 1
+personas:
+  - name: anne
+    role: approver
+    ocean:
+      conscientiousness: 0.5
+  - name: bob
+    role: tenant
+    ocean: {{}}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Missing workspace context — the bug we're fixing
+# ---------------------------------------------------------------------------
+
+
+async def test_save_without_workspace_context_returns_clean_error() -> None:
+    """No ContextVar set → wrappers MUST refuse rather than fabricate a
+    workspace. This is the captain-hit bug — the agent claimed success
+    while writing to nothing."""
+    out = await agent_context.save_scenario_for_agent(
+        name="anywhere",
+        sub_type="decision_forecast",
+        yaml_body=_decision_forecast_yaml(),
+    )
+    assert out == {
+        "ok": False,
+        "error": agent_context.NO_WORKSPACE_ERROR,
+        "message": agent_context.NO_WORKSPACE_MESSAGE,
+    }
+
+
+async def test_list_without_workspace_context_returns_clean_error() -> None:
+    out = await agent_context.list_scenarios_for_agent()
+    assert out["ok"] is False
+    assert out["error"] == agent_context.NO_WORKSPACE_ERROR
+
+
+async def test_run_without_workspace_context_returns_clean_error() -> None:
+    out = await agent_context.run_scenario_for_agent(name="x", custom_scenario_id="abc")
+    assert out["ok"] is False
+    assert out["error"] == agent_context.NO_WORKSPACE_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Happy path — save / list / get / update / delete
+# ---------------------------------------------------------------------------
+
+
+async def test_save_scenario_persists_and_returns_id(bound_identity: None) -> None:
+    out = await agent_context.save_scenario_for_agent(
+        name="q3-renewals",
+        sub_type="decision_forecast",
+        yaml_body=_decision_forecast_yaml("q3-renewals"),
+        description="enterprise cohort",
+    )
+    assert out["ok"] is True
+    assert out["name"] == "q3-renewals"
+    assert out["sub_type"] == "decision_forecast"
+    assert out["description"] == "enterprise cohort"
+    assert out["workspace_id"] == "w1"
+    assert out["author"] == "prakash"
+    assert out["parsed_meta"]["num_personas"] == 2
+    # The id is captured so a follow-up run knows which scenario to use.
+    assert "id" in out and out["id"]
+
+
+async def test_list_after_save_includes_the_new_scenario(bound_identity: None) -> None:
+    save = await agent_context.save_scenario_for_agent(
+        name="renewal-listing",
+        sub_type="decision_forecast",
+        yaml_body=_decision_forecast_yaml("renewal-listing"),
+    )
+    listing = await agent_context.list_scenarios_for_agent(limit=10)
+    assert listing["ok"] is True
+    assert listing["total"] >= 1
+    saved_ids = [item["id"] for item in listing["items"]]
+    assert save["id"] in saved_ids
+
+
+async def test_get_scenario_returns_full_yaml_body(bound_identity: None) -> None:
+    save = await agent_context.save_scenario_for_agent(
+        name="renewal-detail",
+        sub_type="decision_forecast",
+        yaml_body=_decision_forecast_yaml("renewal-detail"),
+    )
+    detail = await agent_context.get_scenario_for_agent(save["id"])
+    assert detail["ok"] is True
+    assert detail["id"] == save["id"]
+    assert detail["yaml_body"].startswith("name: renewal-detail")
+
+
+async def test_update_full_replaces_fields(bound_identity: None) -> None:
+    save = await agent_context.save_scenario_for_agent(
+        name="renewal-edit",
+        sub_type="decision_forecast",
+        yaml_body=_decision_forecast_yaml("renewal-edit"),
+        description="initial",
+    )
+    out = await agent_context.update_scenario_for_agent(
+        scenario_id=save["id"],
+        name="renewal-edit-v2",
+        sub_type="decision_forecast",
+        yaml_body=_decision_forecast_yaml("renewal-edit-v2"),
+        description="edited",
+    )
+    assert out["ok"] is True
+    assert out["name"] == "renewal-edit-v2"
+    assert out["description"] == "edited"
+
+
+async def test_delete_removes_the_scenario(bound_identity: None) -> None:
+    save = await agent_context.save_scenario_for_agent(
+        name="renewal-delete",
+        sub_type="decision_forecast",
+        yaml_body=_decision_forecast_yaml("renewal-delete"),
+    )
+    out = await agent_context.delete_scenario_for_agent(save["id"])
+    assert out == {"ok": True, "scenario_id": save["id"]}
+    # Second delete surfaces a clean 404 envelope.
+    again = await agent_context.delete_scenario_for_agent(save["id"])
+    assert again["ok"] is False
+    assert again["error"] == "foresight_custom_scenario.not_found"
+
+
+# ---------------------------------------------------------------------------
+# CloudError surfacing — validation paths return ok=False without raising
+# ---------------------------------------------------------------------------
+
+
+async def test_save_surfaces_invalid_yaml_as_ok_false(bound_identity: None) -> None:
+    out = await agent_context.save_scenario_for_agent(
+        name="bad",
+        sub_type="decision_forecast",
+        yaml_body="not: valid: yaml: : :: :",
+    )
+    assert out["ok"] is False
+    assert out["error"] == "foresight.invalid_yaml"
+    assert "message" in out
+
+
+async def test_save_surfaces_sub_type_mismatch_as_ok_false(bound_identity: None) -> None:
+    # YAML declares decision_forecast but request claims market_sim.
+    out = await agent_context.save_scenario_for_agent(
+        name="mismatch",
+        sub_type="market_sim",
+        yaml_body=_decision_forecast_yaml("mismatch"),
+    )
+    assert out["ok"] is False
+    assert out["error"] == "foresight.sub_type_mismatch"
+
+
+async def test_get_unknown_scenario_returns_not_found(bound_identity: None) -> None:
+    out = await agent_context.get_scenario_for_agent("507f1f77bcf86cd799439011")
+    assert out["ok"] is False
+    assert out["error"] == "foresight_custom_scenario.not_found"
+
+
+# ---------------------------------------------------------------------------
+# Run path — saved-scenario only
+# ---------------------------------------------------------------------------
+
+
+async def test_run_requires_custom_scenario_id(bound_identity: None) -> None:
+    out = await agent_context.run_scenario_for_agent(name="orphan", custom_scenario_id="")
+    assert out["ok"] is False
+    assert out["error"] == "foresight.missing_scenario_id"
+
+
+async def test_run_scenario_executes_a_saved_scenario(
+    bound_identity: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drive the run path against a real saved scenario. We stub the
+    engine call so the test stays cheap — the goal is to confirm the
+    wrapper threads workspace/user identity and the saved-id correctly
+    into ``create_scenario_run``, not to exercise the engine."""
+    save = await agent_context.save_scenario_for_agent(
+        name="run-target",
+        sub_type="decision_forecast",
+        yaml_body=_decision_forecast_yaml("run-target"),
+    )
+
+    async def _fake_engine(body: Any, *, workspace_id: str, run_id: str, route_to_instinct: bool):
+        return {"aggregates": {"verdict": "stubbed"}, "projected_decisions": []}
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.foresight.service._run_engine_inline", _fake_engine)
+
+    out = await agent_context.run_scenario_for_agent(
+        name="run-target", custom_scenario_id=save["id"]
+    )
+    assert out["ok"] is True
+    assert out["status"] == "complete"
+    assert out["scenario_name"] == "run-target"
+    assert out["workspace_id"] == "w1"
+    assert out["result"]["aggregates"]["verdict"] == "stubbed"
+
+
+async def test_list_runs_returns_workspace_runs(
+    bound_identity: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    save = await agent_context.save_scenario_for_agent(
+        name="lr-target",
+        sub_type="decision_forecast",
+        yaml_body=_decision_forecast_yaml("lr-target"),
+    )
+
+    async def _fake_engine(body: Any, *, workspace_id: str, run_id: str, route_to_instinct: bool):
+        return {"aggregates": {}, "projected_decisions": []}
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.foresight.service._run_engine_inline", _fake_engine)
+    await agent_context.run_scenario_for_agent(name="lr-target", custom_scenario_id=save["id"])
+
+    out = await agent_context.list_runs_for_agent(limit=5)
+    assert out["ok"] is True
+    assert len(out["items"]) >= 1
+    assert any(item["scenario_name"] == "lr-target" for item in out["items"])

--- a/tests/ee/agent/test_foresight_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_foresight_mcp_server/test_mcp_tool.py
@@ -1,0 +1,376 @@
+# tests/ee/agent/test_foresight_mcp_server/test_mcp_tool.py
+# Created: 2026-05-28 — coverage for the in-process ``pocketpaw_foresight``
+# MCP server. Mirrors the pocket_specialist test layout: registration
+# assertions (server name, tool ids, allowlist publication) plus
+# per-tool handler tests that mock the ``agent_context`` wrappers and
+# inspect the MCP envelope the SDK returns to the agent.
+"""MCP server registration + handler tests for foresight scenario CRUD + run."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+class TestForesightMcpServerRegistration:
+    def test_server_name_and_tool_ids(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.foresight import (
+            DELETE_SCENARIO_TOOL_ID,
+            FORESIGHT_TOOL_IDS,
+            GET_RUN_TOOL_ID,
+            GET_SCENARIO_TOOL_ID,
+            LIST_RUNS_TOOL_ID,
+            LIST_SCENARIOS_TOOL_ID,
+            RUN_SCENARIO_TOOL_ID,
+            SAVE_SCENARIO_TOOL_ID,
+            SERVER_NAME,
+            UPDATE_SCENARIO_TOOL_ID,
+        )
+
+        assert SERVER_NAME == "pocketpaw_foresight"
+        # Allowlist entries must use the exact ``mcp__<server>__<tool>`` form.
+        assert SAVE_SCENARIO_TOOL_ID == "mcp__pocketpaw_foresight__save_scenario"
+        assert LIST_SCENARIOS_TOOL_ID == "mcp__pocketpaw_foresight__list_scenarios"
+        assert GET_SCENARIO_TOOL_ID == "mcp__pocketpaw_foresight__get_scenario"
+        assert UPDATE_SCENARIO_TOOL_ID == "mcp__pocketpaw_foresight__update_scenario"
+        assert DELETE_SCENARIO_TOOL_ID == "mcp__pocketpaw_foresight__delete_scenario"
+        assert RUN_SCENARIO_TOOL_ID == "mcp__pocketpaw_foresight__run_scenario"
+        assert LIST_RUNS_TOOL_ID == "mcp__pocketpaw_foresight__list_runs"
+        assert GET_RUN_TOOL_ID == "mcp__pocketpaw_foresight__get_run"
+        assert len(FORESIGHT_TOOL_IDS) == 8
+        # Every id is published — the claude_sdk allowlist loop reads
+        # this tuple.
+        for tid in (
+            SAVE_SCENARIO_TOOL_ID,
+            LIST_SCENARIOS_TOOL_ID,
+            GET_SCENARIO_TOOL_ID,
+            UPDATE_SCENARIO_TOOL_ID,
+            DELETE_SCENARIO_TOOL_ID,
+            RUN_SCENARIO_TOOL_ID,
+            LIST_RUNS_TOOL_ID,
+            GET_RUN_TOOL_ID,
+        ):
+            assert tid in FORESIGHT_TOOL_IDS
+
+    def test_extension_provider_advertises_all_tool_ids(self) -> None:
+        """The entry-point provider's ``tool_ids()`` feeds the claude_sdk
+        allowlist loop — every tool id must come through it."""
+        from pocketpaw_ee.agent.mcp_servers.foresight import FORESIGHT_TOOL_IDS
+        from pocketpaw_ee.extensions import CloudForesightMcpProvider
+
+        advertised = CloudForesightMcpProvider().tool_ids()
+        for tid in FORESIGHT_TOOL_IDS:
+            assert tid in advertised
+
+    def test_build_server_returns_object(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.foresight import build_foresight_server
+
+        out = build_foresight_server()
+        # When claude_agent_sdk is installed (the ee group), we get back
+        # ``(name, server)``. When it isn't, ``None`` — the import-guard
+        # path. Either is a valid runtime state.
+        if out is not None:
+            name, server = out
+            assert name == "pocketpaw_foresight"
+            assert server is not None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _decode_payload(envelope: dict) -> dict:
+    """MCP responses pack the JSON body into ``content[0].text``. Decode
+    it so the tests can assert on dict fields without re-encoding."""
+    assert "content" in envelope
+    assert envelope["content"][0]["type"] == "text"
+    return json.loads(envelope["content"][0]["text"])
+
+
+# ---------------------------------------------------------------------------
+# Per-tool handler tests
+# ---------------------------------------------------------------------------
+
+
+class TestListScenariosHandler:
+    @pytest.mark.asyncio
+    async def test_delegates_to_agent_context_and_returns_items(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {
+            "ok": True,
+            "items": [{"id": "s1", "name": "renewal"}],
+            "total": 1,
+            "limit": 20,
+            "offset": 0,
+            "has_more": False,
+        }
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.list_scenarios_for_agent",
+            new=AsyncMock(return_value=fake),
+        ) as mock:
+            out = await foresight_mcp._list_scenarios_handler(
+                {"limit": 20, "offset": 0, "sub_type": "decision_forecast"}
+            )
+
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        assert body["items"][0]["id"] == "s1"
+        # ``ok`` is stripped before encoding — it's a transport concern.
+        assert "ok" not in body
+        mock.assert_awaited_once_with(limit=20, offset=0, sub_type="decision_forecast")
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace_surfaces_as_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {"ok": False, "error": "no_workspace_context", "message": "stream missing"}
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.list_scenarios_for_agent",
+            new=AsyncMock(return_value=fake),
+        ):
+            out = await foresight_mcp._list_scenarios_handler({})
+
+        assert out.get("is_error") is True
+        assert "no_workspace_context" in out["content"][0]["text"]
+
+
+class TestSaveScenarioHandler:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_id(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {
+            "ok": True,
+            "id": "abc123",
+            "workspace_id": "w1",
+            "name": "renewal",
+            "sub_type": "decision_forecast",
+        }
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.save_scenario_for_agent",
+            new=AsyncMock(return_value=fake),
+        ) as mock:
+            out = await foresight_mcp._save_scenario_handler(
+                {
+                    "name": "renewal",
+                    "sub_type": "decision_forecast",
+                    "yaml_body": "name: renewal\n",
+                    "description": "desc",
+                }
+            )
+
+        body = _decode_payload(out)
+        assert body["id"] == "abc123"
+        mock.assert_awaited_once_with(
+            name="renewal",
+            sub_type="decision_forecast",
+            yaml_body="name: renewal\n",
+            description="desc",
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_required_field_returns_local_error(self) -> None:
+        """Argument-shape validation happens at the handler before any
+        agent_context call — so a missing ``yaml_body`` never reaches
+        the cloud."""
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        mock = AsyncMock()
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.save_scenario_for_agent",
+            new=mock,
+        ):
+            out = await foresight_mcp._save_scenario_handler(
+                {"name": "x", "sub_type": "decision_forecast"}
+            )
+
+        assert out.get("is_error") is True
+        assert "yaml_body" in out["content"][0]["text"]
+        mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cloud_error_surfaces_as_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {
+            "ok": False,
+            "error": "foresight.invalid_yaml",
+            "message": "YAML parse error: ...",
+        }
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.save_scenario_for_agent",
+            new=AsyncMock(return_value=fake),
+        ):
+            out = await foresight_mcp._save_scenario_handler(
+                {
+                    "name": "x",
+                    "sub_type": "decision_forecast",
+                    "yaml_body": "junk",
+                }
+            )
+
+        assert out.get("is_error") is True
+        # The agent reads the code + message verbatim so it can retry
+        # with a corrected YAML.
+        text = out["content"][0]["text"]
+        assert "foresight.invalid_yaml" in text
+        assert "YAML parse error" in text
+
+
+class TestUpdateScenarioHandler:
+    @pytest.mark.asyncio
+    async def test_passes_all_fields(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.update_scenario_for_agent",
+            new=AsyncMock(return_value={"ok": True, "id": "s1", "name": "renamed"}),
+        ) as mock:
+            out = await foresight_mcp._update_scenario_handler(
+                {
+                    "scenario_id": "s1",
+                    "name": "renamed",
+                    "sub_type": "decision_forecast",
+                    "yaml_body": "name: renamed\n",
+                    "description": "updated",
+                }
+            )
+
+        assert not out.get("is_error")
+        mock.assert_awaited_once_with(
+            scenario_id="s1",
+            name="renamed",
+            sub_type="decision_forecast",
+            yaml_body="name: renamed\n",
+            description="updated",
+        )
+
+
+class TestGetScenarioHandler:
+    @pytest.mark.asyncio
+    async def test_requires_scenario_id(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        out = await foresight_mcp._get_scenario_handler({})
+        assert out.get("is_error") is True
+
+
+class TestDeleteScenarioHandler:
+    @pytest.mark.asyncio
+    async def test_delegates_and_returns_scenario_id(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.delete_scenario_for_agent",
+            new=AsyncMock(return_value={"ok": True, "scenario_id": "s1"}),
+        ) as mock:
+            out = await foresight_mcp._delete_scenario_handler({"scenario_id": "s1"})
+
+        body = _decode_payload(out)
+        assert body["scenario_id"] == "s1"
+        mock.assert_awaited_once_with("s1")
+
+
+class TestRunScenarioHandler:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_run_id(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {
+            "ok": True,
+            "id": "run-1",
+            "status": "complete",
+            "scenario_name": "renewal",
+            "result": {"aggregates": {"verdict": "go"}},
+        }
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.run_scenario_for_agent",
+            new=AsyncMock(return_value=fake),
+        ) as mock:
+            out = await foresight_mcp._run_scenario_handler(
+                {
+                    "name": "renewal",
+                    "custom_scenario_id": "s1",
+                    "route_to_instinct": True,
+                }
+            )
+
+        body = _decode_payload(out)
+        assert body["id"] == "run-1"
+        assert body["status"] == "complete"
+        mock.assert_awaited_once_with(
+            name="renewal",
+            custom_scenario_id="s1",
+            route_to_instinct=True,
+            precedent_seed=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_custom_scenario_id_is_rejected_locally(self) -> None:
+        """The save-first contract is enforced at the handler — the run
+        call never reaches the cloud without a saved id."""
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        mock = AsyncMock()
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.run_scenario_for_agent",
+            new=mock,
+        ):
+            out = await foresight_mcp._run_scenario_handler({"name": "renewal"})
+
+        assert out.get("is_error") is True
+        assert "custom_scenario_id" in out["content"][0]["text"]
+        mock.assert_not_awaited()
+
+
+class TestListRunsHandler:
+    @pytest.mark.asyncio
+    async def test_delegates_with_pagination(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.list_runs_for_agent",
+            new=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "items": [{"id": "r1", "status": "complete"}],
+                    "limit": 5,
+                    "offset": 0,
+                }
+            ),
+        ) as mock:
+            out = await foresight_mcp._list_runs_handler({"limit": 5})
+
+        body = _decode_payload(out)
+        assert body["items"][0]["id"] == "r1"
+        mock.assert_awaited_once_with(limit=5, offset=0)
+
+
+class TestGetRunHandler:
+    @pytest.mark.asyncio
+    async def test_requires_run_id(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        out = await foresight_mcp._get_run_handler({})
+        assert out.get("is_error") is True
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_agent_context(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.get_run_for_agent",
+            new=AsyncMock(
+                return_value={"ok": True, "id": "r1", "status": "complete", "result": {}}
+            ),
+        ):
+            out = await foresight_mcp._get_run_handler({"run_id": "r1"})
+
+        body = _decode_payload(out)
+        assert body["id"] == "r1"


### PR DESCRIPTION
## Bug

The bundled `foresight-create-sim` skill told the chat agent to call the
loopback REST surface with `$WORKSPACE_ID` / `$USER_ID` env vars. The
`claude_agent_sdk` backend never sets those — `subprocess_env` in
`CloudAgentExtension` injects them only for shell-CLI backends. Result:
the agent either guessed a workspace, refused, or claimed save+run while
nothing persisted. Captain hit this an hour after #293 merged.

## Fix

Typed in-process MCP tools mirroring the existing `pocketpaw_pocket`
server. Each tool closes over the chat session's `workspace_id` via
`cloud.chat.agent_service.current_workspace_id()` — no headers, no env
vars, no curl. The agent literally cannot save to the wrong workspace.

Eight tools on the new `pocketpaw_foresight` server:
`list_scenarios`, `get_scenario`, `save_scenario`, `update_scenario`,
`delete_scenario`, `run_scenario`, `list_runs`, `get_run`.

`run_scenario` requires `custom_scenario_id` — the chat surface only
supports the saved-scenario path so a run is always re-runnable from the
dashboard. Inline-personas runs stay reachable via the REST surface for
power users.

## Files

Added:
- `ee/pocketpaw_ee/cloud/foresight/agent_context.py` — thin wrappers
  that read ContextVars, build a `RequestContext`, and collapse
  `CloudError` into a `{ok, error, message}` envelope
- `ee/pocketpaw_ee/agent/mcp_servers/foresight.py` — the MCP server
  (mirrors `pockets.py` shape exactly)
- `tests/cloud/test_foresight_agent_context.py` (14 tests)
- `tests/ee/agent/test_foresight_mcp_server/test_mcp_tool.py` (22 tests)

Modified:
- `ee/pocketpaw_ee/extensions.py` — new `CloudForesightMcpProvider`
- `ee/pyproject.toml` — `pocketpaw.mcp_servers` entry point
- `src/pocketpaw/bundled_skills/_bundled/foresight-create-sim/SKILL.md`
  — rewritten to teach the typed tools first, REST kept as a fallback
  for the backtest path and SDK callers

## Test plan

- [x] `uv run pytest tests/ee/agent/test_foresight_mcp_server/ tests/cloud/test_foresight_agent_context.py tests/cloud/test_foresight_custom_scenarios.py tests/cloud/test_foresight_service.py tests/cloud/test_foresight_router.py tests/ee/test_mcp_pocket_add_widget.py tests/test_foresight_skill_installation.py` — 109 passed
- [x] `uv run ruff check` + `uv run ruff format --check` on the diff — clean
- [x] Manual smoke: `python -c "from pocketpaw_ee.extensions import CloudForesightMcpProvider; print(CloudForesightMcpProvider().tool_ids())"` returns all eight `mcp__pocketpaw_foresight__*` ids
- [ ] Captain to hit the live chat agent and confirm save+run actually persists this time

## Notes

- PR is based on `foresight` (not `dev`) because the foresight cloud
  module hasn't been merged to dev yet. The worktree was originally
  cut from dev; I reset it to `origin/foresight` so the new code could
  reference the existing service layer.
- `list_runs_for_agent` carries an `offset` arg for API parity but
  slices client-side because `service.list_scenario_runs` doesn't take
  one. Cheap on small workspaces; a server-side offset is a separate
  follow-up.
- Same pattern could apply to `ee/instinct` and `ee/fabric` — both
  expose similar "agent guesses workspace from env" footguns. Out of
  scope here; file as follow-ups if the captain agrees.