### PR TITLE
feat(foresight): MCP read tools (projections + aggregate + insights) + offset

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/foresight.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/foresight.py
@@ -16,8 +16,9 @@
 #   - ``build_foresight_server`` returns ``None`` when claude_agent_sdk
 #     isn't installed (same import-guard pattern the sibling servers use)
 #
-# Tools (8): list_scenarios, get_scenario, save_scenario, update_scenario,
-# delete_scenario, run_scenario, list_runs, get_run.
+# Tools (11): list_scenarios, get_scenario, save_scenario, update_scenario,
+# delete_scenario, run_scenario, list_runs, get_run, plus the 2026-05-28
+# result-side reads — list_projected_decisions, get_aggregate, get_insights.
 
 from __future__ import annotations
 
@@ -38,6 +39,11 @@ DELETE_SCENARIO_TOOL_ID = f"mcp__{SERVER_NAME}__delete_scenario"
 RUN_SCENARIO_TOOL_ID = f"mcp__{SERVER_NAME}__run_scenario"
 LIST_RUNS_TOOL_ID = f"mcp__{SERVER_NAME}__list_runs"
 GET_RUN_TOOL_ID = f"mcp__{SERVER_NAME}__get_run"
+# Result reads — added 2026-05-28 follow-up to PR #1266. Closes the same
+# "agent fell back to curl with bad env vars" gap on the read side.
+LIST_PROJECTED_DECISIONS_TOOL_ID = f"mcp__{SERVER_NAME}__list_projected_decisions"
+GET_AGGREGATE_TOOL_ID = f"mcp__{SERVER_NAME}__get_aggregate"
+GET_INSIGHTS_TOOL_ID = f"mcp__{SERVER_NAME}__get_insights"
 
 FORESIGHT_TOOL_IDS = (
     LIST_SCENARIOS_TOOL_ID,
@@ -48,6 +54,9 @@ FORESIGHT_TOOL_IDS = (
     RUN_SCENARIO_TOOL_ID,
     LIST_RUNS_TOOL_ID,
     GET_RUN_TOOL_ID,
+    LIST_PROJECTED_DECISIONS_TOOL_ID,
+    GET_AGGREGATE_TOOL_ID,
+    GET_INSIGHTS_TOOL_ID,
 )
 
 _SUB_TYPE_ENUM = ["decision_forecast", "market_sim", "org_change_rehearsal"]
@@ -204,6 +213,45 @@ async def _get_run_handler(args: dict) -> dict:
     if not run_id or not isinstance(run_id, str):
         return _error("get_run requires a `run_id` (string).")
     return _result_payload(await get_run_for_agent(run_id))
+
+
+async def _list_projected_decisions_handler(args: dict) -> dict:
+    from pocketpaw_ee.cloud.foresight.agent_context import list_projected_decisions_for_agent
+
+    run_id = args.get("run_id")
+    if not run_id or not isinstance(run_id, str):
+        return _error(
+            "list_projected_decisions requires a `run_id` (string). Find it "
+            "via list_runs or capture it from run_scenario's response."
+        )
+    anchor_id = args.get("anchor_id")
+    if anchor_id is not None and not isinstance(anchor_id, str):
+        return _error("list_projected_decisions `anchor_id` must be a string when set.")
+    limit = args.get("limit", 50)
+    offset = args.get("offset", 0)
+    return _result_payload(
+        await list_projected_decisions_for_agent(
+            run_id, anchor_id=anchor_id, limit=limit, offset=offset
+        )
+    )
+
+
+async def _get_aggregate_handler(args: dict) -> dict:
+    from pocketpaw_ee.cloud.foresight.agent_context import get_aggregate_for_agent
+
+    window_days = args.get("window_days")
+    if window_days is not None and not isinstance(window_days, int):
+        return _error("get_aggregate `window_days` must be an integer when set.")
+    return _result_payload(await get_aggregate_for_agent(window_days=window_days))
+
+
+async def _get_insights_handler(args: dict) -> dict:
+    # Intentionally ignores ``args`` — get_insights takes no parameters
+    # (the synthesizer reads the workspace's full window).
+    del args
+    from pocketpaw_ee.cloud.foresight.agent_context import get_insights_for_agent
+
+    return _result_payload(await get_insights_for_agent())
 
 
 # ---------------------------------------------------------------------------
@@ -435,9 +483,94 @@ def build_foresight_server() -> tuple[str, Any] | None:
     async def get_run(args):  # type: ignore[no-untyped-def]
         return await _get_run_handler(args)
 
+    @tool(
+        "list_projected_decisions",
+        (
+            "List projected decisions for a run — the per-anchor, per-persona "
+            "verdicts the engine emitted. Use this when the user asks 'what "
+            "did each persona decide' / 'show me the projections for run X' / "
+            "'break down the renewal sim by anchor'. ``run_id`` is required; "
+            "filter by ``anchor_id`` to drill into one decision. 404 "
+            "(``foresight_run.not_found``) for unknown or cross-tenant ids. "
+            "Returns ``{items[], total, limit, offset, has_more}``."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "run_id": {
+                    "type": "string",
+                    "description": "Run id from run_scenario / list_runs.",
+                },
+                "anchor_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional filter on a single anchor (e.g. 'rollout:training'). "
+                        "Omit to list across all anchors in the run."
+                    ),
+                },
+                "limit": {"type": "integer", "description": "Max items (default 50, cap 500)."},
+                "offset": {"type": "integer", "description": "Pagination offset (default 0)."},
+            },
+            "required": ["run_id"],
+        },
+    )
+    async def list_projected_decisions(args):  # type: ignore[no-untyped-def]
+        return await _list_projected_decisions_handler(args)
+
+    @tool(
+        "get_aggregate",
+        (
+            "Workspace-level rolling accuracy + confidence drift + modal "
+            "outcome distribution over the trailing window. Use this when the "
+            "user asks 'how accurate were we' / 'did we predict X correctly' "
+            "/ 'show me our hit rate'. Reads PredictionRecord docs across the "
+            "whole workspace — not backtests; the dashboard's Backtest panel "
+            "is a different surface. Empty workspaces return zeros + empty "
+            "arrays (never 404). ``window_days`` defaults to 30 and caps at "
+            "90 — above the cap surfaces ``foresight.invalid_window``."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "window_days": {
+                    "type": "integer",
+                    "description": (
+                        "Trailing window in days (default 30, cap 90). Omit for the default."
+                    ),
+                },
+            },
+            "required": [],
+        },
+    )
+    async def get_aggregate(args):  # type: ignore[no-untyped-def]
+        return await _get_aggregate_handler(args)
+
+    @tool(
+        "get_insights",
+        (
+            "Narrative insights synthesized over the workspace's recent "
+            "PredictionRecords + backtests — accuracy drops, persona "
+            "outliers, tier imbalances, threshold misses. Use this when the "
+            "user asks 'what mattered in the last run' / 'explain the "
+            "insights' / 'anything worth flagging'. Five-rule v0.5 "
+            "synthesizer by default; LLM v1.0 synthesizer opt-in via "
+            "workspace config (wire shape unchanged). Empty workspaces yield "
+            "``items=[]`` — the synthesizer fires no rows when no patterns "
+            "match. Surface ``severity`` (info | warning | critical) verbatim "
+            "so the user sees the same colour the dashboard does."
+        ),
+        {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    )
+    async def get_insights(args):  # type: ignore[no-untyped-def]
+        return await _get_insights_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
-        version="1.0.0",
+        version="1.1.0",
         tools=[
             list_scenarios,
             get_scenario,
@@ -447,6 +580,9 @@ def build_foresight_server() -> tuple[str, Any] | None:
             run_scenario,
             list_runs,
             get_run,
+            list_projected_decisions,
+            get_aggregate,
+            get_insights,
         ],
     )
     return SERVER_NAME, server
@@ -455,8 +591,11 @@ def build_foresight_server() -> tuple[str, Any] | None:
 __all__ = [
     "DELETE_SCENARIO_TOOL_ID",
     "FORESIGHT_TOOL_IDS",
+    "GET_AGGREGATE_TOOL_ID",
+    "GET_INSIGHTS_TOOL_ID",
     "GET_RUN_TOOL_ID",
     "GET_SCENARIO_TOOL_ID",
+    "LIST_PROJECTED_DECISIONS_TOOL_ID",
     "LIST_RUNS_TOOL_ID",
     "LIST_SCENARIOS_TOOL_ID",
     "RUN_SCENARIO_TOOL_ID",

--- a/ee/pocketpaw_ee/cloud/foresight/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/foresight/agent_context.py
@@ -379,12 +379,118 @@ async def get_run_for_agent(run_id: str) -> dict[str, Any]:
     return payload
 
 
+# ---------------------------------------------------------------------------
+# Result reads — projected decisions, aggregate rollup, insights
+# ---------------------------------------------------------------------------
+
+
+async def list_projected_decisions_for_agent(
+    run_id: str,
+    *,
+    anchor_id: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """List projected decisions for a run, optionally filtered by anchor.
+
+    The service collapses unknown / cross-tenant ``run_id`` into
+    ``foresight_run.not_found`` via ``_fetch_in_workspace`` — surface
+    that as ``{ok: False, error: 'foresight_run.not_found', ...}`` so
+    the agent retries with a valid id rather than fabricating one.
+
+    Shape on success: ``{"ok": True, "items": [...], "total": N,
+    "limit": int, "offset": int, "has_more": bool}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import service as foresight_service
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        response = await foresight_service.list_projected_decisions(
+            ctx, run_id, anchor_id=anchor_id, limit=limit, offset=offset
+        )
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    payload = response.model_dump()
+    payload["ok"] = True
+    return payload
+
+
+async def get_aggregate_for_agent(*, window_days: int | None = None) -> dict[str, Any]:
+    """Return the workspace's rolling-accuracy + confidence-drift +
+    modal-outcome rollup over the trailing ``window_days`` window.
+
+    ``window_days`` defaults to the service's 30-day window; values
+    above the 90-day cap raise ``foresight.invalid_window`` which we
+    collapse to ``{ok: False, error: 'foresight.invalid_window', ...}``.
+
+    Shape on success: ``{"ok": True, "workspace_id": ...,
+    "window_days": N, "rolling_accuracy": {...},
+    "confidence_drift": {...}, "modal_outcome_distribution": [...],
+    "generated_at": iso}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import service as foresight_service
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        response = await foresight_service.get_aggregate_rollup(ctx, window_days=window_days)
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    payload = response.model_dump()
+    payload["ok"] = True
+    return payload
+
+
+async def get_insights_for_agent() -> dict[str, Any]:
+    """Return the workspace's Insights panel — narrative rows the
+    five-rule synthesizer (or the v1.0 LLM synthesizer, depending on
+    workspace config) emits over the same window the aggregate uses.
+
+    Empty workspaces collapse to ``items=[]`` — the synthesizer yields
+    no rows when none of the patterns can fire, so the agent should
+    treat an empty list as "nothing notable yet", not a 404.
+
+    Shape on success: ``{"ok": True, "items": [...], "generated_at":
+    iso, ...}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import service as foresight_service
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        response = await foresight_service.get_insights(ctx)
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    payload = response.model_dump()
+    payload["ok"] = True
+    return payload
+
+
 __all__ = [
     "NO_WORKSPACE_ERROR",
     "NO_WORKSPACE_MESSAGE",
     "delete_scenario_for_agent",
+    "get_aggregate_for_agent",
+    "get_insights_for_agent",
     "get_run_for_agent",
     "get_scenario_for_agent",
+    "list_projected_decisions_for_agent",
     "list_runs_for_agent",
     "list_scenarios_for_agent",
     "run_scenario_for_agent",

--- a/ee/pocketpaw_ee/cloud/foresight/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/foresight/agent_context.py
@@ -23,10 +23,16 @@
 #     (``custom_scenario_id`` required). Inline-personas runs are still
 #     reachable via the REST surface; we don't expose two run shapes on
 #     the chat surface because mixing them is the bug we're fixing.
-#   - The list-runs wrapper carries ``offset`` for parity with the brief
-#     signature, then slices client-side because
-#     ``list_scenario_runs`` itself doesn't yet take an offset arg.
-#     Cheap on small workspaces; document the limitation.
+#   - The list-runs wrapper now passes ``offset`` through to the service
+#     (added 2026-05-28 alongside the read-tools follow-up) so Mongo's
+#     ``.skip()`` does the pagination at source instead of over-fetching
+#     and slicing client-side.
+#
+# 2026-05-28 update: added three read wrappers
+# (``list_projected_decisions_for_agent``, ``get_aggregate_for_agent``,
+# ``get_insights_for_agent``) for the results / accuracy / insights MCP
+# tools. Same identity-resolution + CloudError-collapse shape as the
+# existing scenarios + runs wrappers.
 
 from __future__ import annotations
 
@@ -325,11 +331,9 @@ async def run_scenario_for_agent(
 async def list_runs_for_agent(limit: int = 10, offset: int = 0) -> dict[str, Any]:
     """List recent scenario runs in the active workspace, newest first.
 
-    Note: ``ee.cloud.foresight.service.list_scenario_runs`` doesn't yet
-    accept an ``offset`` kwarg, so we fetch ``limit + offset`` and slice
-    client-side. Adequate for the chat surface (the agent rarely scrolls
-    back; sessions average single-digit runs) — a server-side offset is
-    a separate follow-up.
+    ``offset`` is passed through to the service so pagination happens at
+    Mongo's ``.skip()`` step rather than over-fetching and slicing
+    client-side.
 
     Shape on success: ``{"ok": True, "items": [...], "limit": int,
     "offset": int}``.
@@ -343,11 +347,11 @@ async def list_runs_for_agent(limit: int = 10, offset: int = 0) -> dict[str, Any
 
     ctx = _build_request_context(workspace_id, user_id)
     try:
-        runs = await foresight_service.list_scenario_runs(ctx, limit=limit + offset)
+        runs = await foresight_service.list_scenario_runs(ctx, limit=limit, offset=offset)
     except CloudError as exc:
         return _cloud_error_payload(exc)
 
-    items = [run.model_dump() for run in runs[offset : offset + limit]]
+    items = [run.model_dump() for run in runs]
     return {"ok": True, "items": items, "limit": limit, "offset": offset}
 
 

--- a/ee/pocketpaw_ee/cloud/foresight/service.py
+++ b/ee/pocketpaw_ee/cloud/foresight/service.py
@@ -812,7 +812,7 @@ async def get_scenario_run(ctx: RequestContext, run_id: str) -> ScenarioRunRespo
 
 
 async def list_scenario_runs(
-    ctx: RequestContext, *, limit: int = 50
+    ctx: RequestContext, *, limit: int = 50, offset: int = 0
 ) -> list[ScenarioRunListItemResponse]:
     """List runs in the caller's workspace, most recent first.
 
@@ -821,6 +821,13 @@ async def list_scenario_runs(
     :class:`ScenarioRunListItemResponse` shape drops the inline
     ``result`` blob so a workspace with a hundred runs still serves
     the list endpoint in tens of kilobytes rather than megabytes.
+
+    ``offset`` is the server-side cursor for pagination. Defaults to
+    ``0`` so existing single-page callers stay correct; negative values
+    raise ``foresight.invalid_offset`` (same pattern as
+    :func:`list_projected_decisions`). Mongo's ``.skip(offset)`` runs
+    inside the same sort + tenant filter so the ordering stays stable
+    across pages.
     """
     workspace_id = _require_workspace(ctx)
     if limit < 1:
@@ -829,6 +836,8 @@ async def list_scenario_runs(
         # Hard cap so a misconfigured caller can't drag the entire
         # collection into memory; the frontend never asks for more.
         limit = 200
+    if offset < 0:
+        raise ValidationError("foresight.invalid_offset", "offset must be >= 0")
 
     # Tenant filter on every read per cloud rule #7. Sort newest first
     # so the Scenarios panel renders most-recent-on-top without a
@@ -839,6 +848,7 @@ async def list_scenario_runs(
     docs = (
         await _ForesightRunDoc.find({"workspace": workspace_id})
         .sort([("createdAt", -1), ("_id", -1)])  # type: ignore[list-item]
+        .skip(offset)
         .limit(limit)
         .to_list()
     )

--- a/src/pocketpaw/bundled_skills/_bundled/foresight-create-sim/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/foresight-create-sim/SKILL.md
@@ -90,6 +90,44 @@ carrying the cloud error code + message (e.g.
 ``foresight_custom_scenario.not_found``). Surface those codes to the
 user verbatim — they name the field to fix.
 
+## Read tools (results, accuracy, insights)
+
+Three additional tools cover the *result* side — what the run produced,
+how accurate the workspace has been, and what's worth flagging. Same
+workspace-context guarantee as the write tools (closed over the chat
+stream's workspace id; no env vars, no headers).
+
+  - ``mcp__pocketpaw_foresight__list_projected_decisions({run_id,
+    anchor_id?, limit?, offset?})`` — per-anchor, per-persona verdicts
+    for a single run. Returns ``{items[], total, limit, offset,
+    has_more}``. 404 (``foresight_run.not_found``) for unknown or
+    cross-tenant ids.
+
+    **When to use:** "show me the projections for run X", "what did
+    each persona decide", "break down the renewal sim by anchor".
+
+  - ``mcp__pocketpaw_foresight__get_aggregate({window_days?})`` —
+    workspace-level rolling accuracy + confidence drift + modal outcome
+    distribution over the trailing window. Defaults to 30 days, caps at
+    90; above the cap surfaces ``foresight.invalid_window``. Empty
+    workspaces return zeros + empty arrays (never 404).
+
+    **When to use:** "how accurate were we", "did we predict X
+    correctly", "show me our hit rate". Not the same surface as the
+    Backtest panel — backtests are per-scenario; this is the
+    workspace-wide rollup.
+
+  - ``mcp__pocketpaw_foresight__get_insights({})`` — narrative insights
+    synthesized over recent PredictionRecords + backtests (accuracy
+    drops, persona outliers, tier imbalances, threshold misses). Empty
+    workspaces yield ``items=[]`` — the synthesizer fires no rows when
+    no patterns match. Each item carries ``severity`` (``info`` |
+    ``warning`` | ``critical``) — surface it verbatim so the user sees
+    the same colour the dashboard renders.
+
+    **When to use:** "what mattered in the last run", "explain the
+    insights", "anything worth flagging".
+
 ## The four-phase workflow
 
 Every interaction with Foresight from chat follows this loop:

--- a/tests/cloud/test_foresight_agent_context.py
+++ b/tests/cloud/test_foresight_agent_context.py
@@ -250,3 +250,100 @@ async def test_list_runs_returns_workspace_runs(
     assert out["ok"] is True
     assert len(out["items"]) >= 1
     assert any(item["scenario_name"] == "lr-target" for item in out["items"])
+
+
+# ---------------------------------------------------------------------------
+# Read wrappers — projected decisions, aggregate, insights
+# ---------------------------------------------------------------------------
+
+
+async def test_list_projected_decisions_without_workspace_returns_clean_error() -> None:
+    out = await agent_context.list_projected_decisions_for_agent("run-1")
+    assert out == {
+        "ok": False,
+        "error": agent_context.NO_WORKSPACE_ERROR,
+        "message": agent_context.NO_WORKSPACE_MESSAGE,
+    }
+
+
+async def test_get_aggregate_without_workspace_returns_clean_error() -> None:
+    out = await agent_context.get_aggregate_for_agent()
+    assert out["ok"] is False
+    assert out["error"] == agent_context.NO_WORKSPACE_ERROR
+
+
+async def test_get_insights_without_workspace_returns_clean_error() -> None:
+    out = await agent_context.get_insights_for_agent()
+    assert out["ok"] is False
+    assert out["error"] == agent_context.NO_WORKSPACE_ERROR
+
+
+async def test_list_projected_decisions_unknown_run_returns_not_found(
+    bound_identity: None,
+) -> None:
+    """``list_projected_decisions`` runs ``_fetch_in_workspace`` first so
+    a stale / cross-tenant run id surfaces as ``foresight_run.not_found``
+    rather than an empty list (which would hide the bug)."""
+    out = await agent_context.list_projected_decisions_for_agent("507f1f77bcf86cd799439011")
+    assert out["ok"] is False
+    assert out["error"] == "foresight_run.not_found"
+
+
+async def test_list_projected_decisions_returns_items_for_real_run(
+    bound_identity: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    save = await agent_context.save_scenario_for_agent(
+        name="lpd-target",
+        sub_type="decision_forecast",
+        yaml_body=_decision_forecast_yaml("lpd-target"),
+    )
+
+    async def _fake_engine(body: Any, *, workspace_id: str, run_id: str, route_to_instinct: bool):
+        return {"aggregates": {}, "projected_decisions": []}
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.foresight.service._run_engine_inline", _fake_engine)
+    run = await agent_context.run_scenario_for_agent(
+        name="lpd-target", custom_scenario_id=save["id"]
+    )
+
+    out = await agent_context.list_projected_decisions_for_agent(run["id"], limit=10)
+    assert out["ok"] is True
+    # Empty projections list is the legitimate empty-result shape for
+    # this minimal engine stub — what we're testing is that the wrapper
+    # threads identity correctly and surfaces the typed response.
+    assert "items" in out
+    assert "total" in out
+    assert out["limit"] == 10
+    assert out["offset"] == 0
+
+
+async def test_get_aggregate_returns_rollup_envelope(bound_identity: None) -> None:
+    """Empty workspace collapses to zeros + empty arrays per the service
+    contract — no 404, no exception, so the agent gets a usable rollup."""
+    out = await agent_context.get_aggregate_for_agent()
+    assert out["ok"] is True
+    assert out["window_days"] >= 1
+    assert "rolling_accuracy" in out
+    assert "confidence_drift" in out
+    assert "modal_outcome_distribution" in out
+    assert "generated_at" in out
+
+
+async def test_get_aggregate_surfaces_invalid_window_as_ok_false(
+    bound_identity: None,
+) -> None:
+    """``window_days`` above the 90-day cap raises
+    ``foresight.invalid_window`` from the service; the wrapper collapses
+    it into the agent envelope without raising."""
+    out = await agent_context.get_aggregate_for_agent(window_days=999)
+    assert out["ok"] is False
+    assert out["error"] == "foresight.invalid_window"
+
+
+async def test_get_insights_returns_items_envelope(bound_identity: None) -> None:
+    """Empty workspace yields ``items=[]`` — the synthesizer fires no
+    rows when no PredictionRecords / backtests exist yet."""
+    out = await agent_context.get_insights_for_agent()
+    assert out["ok"] is True
+    assert "items" in out
+    assert isinstance(out["items"], list)

--- a/tests/cloud/test_foresight_service.py
+++ b/tests/cloud/test_foresight_service.py
@@ -232,3 +232,27 @@ async def test_list_rejects_invalid_limit() -> None:
     ctx = _ctx()
     with pytest.raises(ValidationError):
         await foresight_service.list_scenario_runs(ctx, limit=0)
+
+
+async def test_list_offset_skips_initial_runs() -> None:
+    """``offset`` is the server-side cursor used by both the agent-context
+    wrapper and any future paginated UI surface. Five runs in newest-first
+    order: ``skip=2, limit=2`` returns runs 3-4 (the third and fourth
+    newest) — i.e. the second and third creates after the latest two
+    were skipped."""
+    ctx = _ctx()
+    runs = []
+    for i in range(5):
+        runs.append(await foresight_service.create_scenario_run(ctx, _body(name=f"run-{i}")))
+
+    page = await foresight_service.list_scenario_runs(ctx, limit=2, offset=2)
+    # Newest-first: runs[4], runs[3], runs[2], runs[1], runs[0].
+    # offset=2 drops the first two (runs[4], runs[3]); limit=2 returns
+    # runs[2], runs[1] in that order.
+    assert [item.id for item in page] == [runs[2].id, runs[1].id]
+
+
+async def test_list_rejects_negative_offset() -> None:
+    ctx = _ctx()
+    with pytest.raises(ValidationError):
+        await foresight_service.list_scenario_runs(ctx, offset=-1)

--- a/tests/ee/agent/test_foresight_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_foresight_mcp_server/test_mcp_tool.py
@@ -21,8 +21,11 @@ class TestForesightMcpServerRegistration:
         from pocketpaw_ee.agent.mcp_servers.foresight import (
             DELETE_SCENARIO_TOOL_ID,
             FORESIGHT_TOOL_IDS,
+            GET_AGGREGATE_TOOL_ID,
+            GET_INSIGHTS_TOOL_ID,
             GET_RUN_TOOL_ID,
             GET_SCENARIO_TOOL_ID,
+            LIST_PROJECTED_DECISIONS_TOOL_ID,
             LIST_RUNS_TOOL_ID,
             LIST_SCENARIOS_TOOL_ID,
             RUN_SCENARIO_TOOL_ID,
@@ -41,7 +44,14 @@ class TestForesightMcpServerRegistration:
         assert RUN_SCENARIO_TOOL_ID == "mcp__pocketpaw_foresight__run_scenario"
         assert LIST_RUNS_TOOL_ID == "mcp__pocketpaw_foresight__list_runs"
         assert GET_RUN_TOOL_ID == "mcp__pocketpaw_foresight__get_run"
-        assert len(FORESIGHT_TOOL_IDS) == 8
+        # Result-side reads — 2026-05-28 follow-up.
+        assert (
+            LIST_PROJECTED_DECISIONS_TOOL_ID
+            == "mcp__pocketpaw_foresight__list_projected_decisions"
+        )
+        assert GET_AGGREGATE_TOOL_ID == "mcp__pocketpaw_foresight__get_aggregate"
+        assert GET_INSIGHTS_TOOL_ID == "mcp__pocketpaw_foresight__get_insights"
+        assert len(FORESIGHT_TOOL_IDS) == 11
         # Every id is published — the claude_sdk allowlist loop reads
         # this tuple.
         for tid in (
@@ -53,6 +63,9 @@ class TestForesightMcpServerRegistration:
             RUN_SCENARIO_TOOL_ID,
             LIST_RUNS_TOOL_ID,
             GET_RUN_TOOL_ID,
+            LIST_PROJECTED_DECISIONS_TOOL_ID,
+            GET_AGGREGATE_TOOL_ID,
+            GET_INSIGHTS_TOOL_ID,
         ):
             assert tid in FORESIGHT_TOOL_IDS
 
@@ -374,3 +387,170 @@ class TestGetRunHandler:
 
         body = _decode_payload(out)
         assert body["id"] == "r1"
+
+
+# ---------------------------------------------------------------------------
+# Read-tool handlers — 2026-05-28 follow-up to PR #1266
+# ---------------------------------------------------------------------------
+
+
+class TestListProjectedDecisionsHandler:
+    @pytest.mark.asyncio
+    async def test_happy_path_delegates_with_args(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {
+            "ok": True,
+            "items": [{"id": "pd1", "anchor_id": "rollout:training"}],
+            "total": 1,
+            "limit": 50,
+            "offset": 0,
+            "has_more": False,
+        }
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.list_projected_decisions_for_agent",
+            new=AsyncMock(return_value=fake),
+        ) as mock:
+            out = await foresight_mcp._list_projected_decisions_handler(
+                {
+                    "run_id": "r1",
+                    "anchor_id": "rollout:training",
+                    "limit": 50,
+                    "offset": 0,
+                }
+            )
+
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        assert body["items"][0]["id"] == "pd1"
+        mock.assert_awaited_once_with(
+            "r1", anchor_id="rollout:training", limit=50, offset=0
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_run_id_is_rejected_locally(self) -> None:
+        """The run_id validation runs before the agent_context call so a
+        missing field never reaches the cloud — same guard pattern the
+        existing get_run handler uses."""
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        mock = AsyncMock()
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.list_projected_decisions_for_agent",
+            new=mock,
+        ):
+            out = await foresight_mcp._list_projected_decisions_handler({})
+
+        assert out.get("is_error") is True
+        assert "run_id" in out["content"][0]["text"]
+        mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace_surfaces_as_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {"ok": False, "error": "no_workspace_context", "message": "stream missing"}
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.list_projected_decisions_for_agent",
+            new=AsyncMock(return_value=fake),
+        ):
+            out = await foresight_mcp._list_projected_decisions_handler({"run_id": "r1"})
+
+        assert out.get("is_error") is True
+        assert "no_workspace_context" in out["content"][0]["text"]
+
+
+class TestGetAggregateHandler:
+    @pytest.mark.asyncio
+    async def test_happy_path_passes_window(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {
+            "ok": True,
+            "window_days": 7,
+            "generated_at": "2026-05-28T12:00:00Z",
+            "rolling_accuracy": {"points": []},
+            "confidence_drift": {"points": []},
+            "modal_outcome_distribution": {"entries": []},
+        }
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.get_aggregate_for_agent",
+            new=AsyncMock(return_value=fake),
+        ) as mock:
+            out = await foresight_mcp._get_aggregate_handler({"window_days": 7})
+
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        assert body["window_days"] == 7
+        mock.assert_awaited_once_with(window_days=7)
+
+    @pytest.mark.asyncio
+    async def test_default_window_when_omitted(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.get_aggregate_for_agent",
+            new=AsyncMock(return_value={"ok": True, "window_days": 30}),
+        ) as mock:
+            out = await foresight_mcp._get_aggregate_handler({})
+
+        assert not out.get("is_error")
+        mock.assert_awaited_once_with(window_days=None)
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace_surfaces_as_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {"ok": False, "error": "no_workspace_context", "message": "stream missing"}
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.get_aggregate_for_agent",
+            new=AsyncMock(return_value=fake),
+        ):
+            out = await foresight_mcp._get_aggregate_handler({})
+
+        assert out.get("is_error") is True
+        assert "no_workspace_context" in out["content"][0]["text"]
+
+
+class TestGetInsightsHandler:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_items(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {
+            "ok": True,
+            "items": [
+                {
+                    "id": "i1",
+                    "kind": "accuracy_drop",
+                    "title": "Accuracy dropped",
+                    "body": "...",
+                    "severity": "warning",
+                    "anchor_refs": [],
+                    "generated_at": "2026-05-28T12:00:00Z",
+                }
+            ],
+        }
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.get_insights_for_agent",
+            new=AsyncMock(return_value=fake),
+        ) as mock:
+            out = await foresight_mcp._get_insights_handler({})
+
+        body = _decode_payload(out)
+        assert body["items"][0]["severity"] == "warning"
+        mock.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace_surfaces_as_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {"ok": False, "error": "no_workspace_context", "message": "stream missing"}
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.get_insights_for_agent",
+            new=AsyncMock(return_value=fake),
+        ):
+            out = await foresight_mcp._get_insights_handler({})
+
+        assert out.get("is_error") is True
+        assert "no_workspace_context" in out["content"][0]["text"]


### PR DESCRIPTION
## Gap

PR #1266 shipped 8 typed MCP write/lookup tools so the chat agent could
save + run scenarios without falling through to the loopback REST path
(which needs ``$WORKSPACE_ID`` / ``$USER_ID`` env vars the
``claude_agent_sdk`` backend doesn't set). The result side stayed on
the broken path: ask "how accurate was the last run" or "show me the
insights" and the agent reaches for curl with the same workspace-id
bug.

Also: ``list_scenario_runs`` didn't accept ``offset``. The agent-context
wrapper sliced client-side as a workaround and left a TODO. The cloud
surface handler was already calling ``list_scenario_runs(..., offset=0)``
and silently TypeError-ing inside a broad ``except``.

## Fix

- ``service.list_scenario_runs`` takes an ``offset`` kwarg; validates
  negative values with the same ``foresight.invalid_offset`` code
  ``list_projected_decisions`` uses. Default 0 keeps every existing
  caller correct (router, surface handler, list tests).
- Three new ``agent_context`` wrappers — ``list_projected_decisions_for_agent``,
  ``get_aggregate_for_agent``, ``get_insights_for_agent`` — same
  identity-from-ContextVar + CloudError-collapse shape the write
  wrappers use.
- Three new typed MCP tools on the ``pocketpaw_foresight`` server
  delegating to those wrappers. Server version bumps to 1.1.0;
  ``FORESIGHT_TOOL_IDS`` grows to 11.
- ``list_runs_for_agent`` now passes ``offset`` straight through to the
  service. Over-fetch + slice + TODO are gone.
- Bundled skill (``foresight-create-sim``) gets a "Read tools" section
  documenting each tool's input schema, error surface, and trigger
  phrases ("how accurate were we" -> ``get_aggregate``, "what did each
  persona decide" -> ``list_projected_decisions``, "what's worth
  flagging" -> ``get_insights``).

## Files

- ``ee/pocketpaw_ee/cloud/foresight/service.py`` (offset on list_scenario_runs)
- ``ee/pocketpaw_ee/cloud/foresight/agent_context.py`` (offset passthrough + 3 new wrappers)
- ``ee/pocketpaw_ee/agent/mcp_servers/foresight.py`` (3 new tools + ids + handlers)
- ``src/pocketpaw/bundled_skills/_bundled/foresight-create-sim/SKILL.md`` (Read tools section)
- ``tests/cloud/test_foresight_service.py`` (offset + invalid-offset tests)
- ``tests/cloud/test_foresight_agent_context.py`` (3 happy + 3 missing-workspace + invalid-window)
- ``tests/ee/agent/test_foresight_mcp_server/test_mcp_tool.py`` (3 happy + 3 missing-workspace + local-validation guards)

## Test plan

- [x] ``uv run pytest tests/ee/agent/test_foresight_mcp_server/ tests/cloud/test_foresight_agent_context.py tests/cloud/test_foresight_service.py tests/cloud/test_foresight_router.py -q`` — 79 passed
- [x] ``uv run ruff check ee/pocketpaw_ee/cloud/foresight/ ee/pocketpaw_ee/agent/mcp_servers/foresight.py`` — clean
- [x] ``CloudForesightMcpProvider().tool_ids()`` advertises 11 entries
- [x] ``build_foresight_server()`` returns ``(name, server)`` under the ee group
- [ ] Manual: ask the chat agent "how accurate were we", "show projections for run X", "what's worth flagging" — confirm each routes to the new MCP tool rather than curl

## Stack

Stacked on top of #1266 in ``foresight``. No special handling — #1251
(``foresight`` -> ``dev``) carries both through.